### PR TITLE
What if value is a unicode string?

### DIFF
--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -160,7 +160,7 @@ class CCompiler:
             self.set_executable(key, args[key])
 
     def set_executable(self, key, value):
-        if isinstance(value, str):
+        if isinstance(value, basestring):
             setattr(self, key, split_quoted(value))
         else:
             setattr(self, key, value)


### PR DESCRIPTION
If someone does os.environ['CC'] = unicode('gcc'), using str would have failed.

Could someone explain the reasoning behind not using basestring? Python 3 compatibility?
