### PR TITLE
fix http libraries

### DIFF
--- a/Lib/http/__init__.py
+++ b/Lib/http/__init__.py
@@ -87,9 +87,9 @@ class HTTPStatus(IntEnum):
         'Client must specify Content-Length')
     PRECONDITION_FAILED = (412, 'Precondition Failed',
         'Precondition in headers is false')
-    REQUEST_ENTITY_TOO_LARGE = (413, 'Request Entity Too Large',
+    PAYLOAD_TOO_LARGE = REQUEST_ENTITY_TOO_LARGE = (413, 'Request Entity Too Large',
         'Entity is too large')
-    REQUEST_URI_TOO_LONG = (414, 'Request-URI Too Long',
+    URI_TOO_LONG = REQUEST_URI_TOO_LONG = (414, 'Request-URI Too Long',
         'URI is too long')
     UNSUPPORTED_MEDIA_TYPE = (415, 'Unsupported Media Type',
         'Entity body in unsupported format')

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -259,7 +259,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
     # The default request version.  This only affects responses up until
     # the point where the request line is parsed, so it mainly decides what
     # the client gets back when sending a malformed request line.
-    # Most web servers default to HTTP 0.9, i.e. don't send a status line.
+    # Most web servers default to HTTP 0.9, i.e. don't send a status line. → When did you wrote that line? 1980?
     default_request_version = "HTTP/0.9"
 
     def parse_request(self):
@@ -456,7 +456,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
         if (self.command != 'HEAD' and
                 code >= 200 and
                 code not in (
-                    HTTPStatus.NO_CONTENT, HTTPStatus.NOT_MODIFIED)):
+                    HTTPStatus.NO_CONTENT, HTTPStatus.RESET_CONTENT, HTTPStatus.NOT_MODIFIED)):
             self.wfile.write(body)
 
     def send_response(self, code, message=None):
@@ -696,13 +696,13 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
         """
         try:
-            list = os.listdir(path)
+            list_ = os.listdir(path)
         except OSError:
             self.send_error(
                 HTTPStatus.NOT_FOUND,
                 "No permission to list directory")
             return None
-        list.sort(key=lambda a: a.lower())
+        list_.sort(key=lambda a: a.lower())
         r = []
         try:
             displaypath = urllib.parse.unquote(self.path,
@@ -720,7 +720,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         r.append('<title>%s</title>\n</head>' % title)
         r.append('<body>\n<h1>%s</h1>' % title)
         r.append('<hr>\n<ul>')
-        for name in list:
+        for name in list_:
             fullname = os.path.join(path, name)
             displayname = linkname = name
             # Append / for directories or @ for symbolic links


### PR DESCRIPTION
Hello, I have a few changes:
* The status code REQUEST_ENTITY_TOO_LARGE has been renamed into PAYLOAD_TOO_LARGE in RFC 7230
* The status code REQUEST_URI_TOO_LONG has been renamed into URI_TOO_LONG in RFC 7230
* neither http.client nor http.server did evaluate the RESET_CONTENT 205 status code which must not contain a entity body/payload.
* every 2XX status indicated success instead of only 200 OK
* I added also some comments about further broken things which I didn't have the time to fix. They should be removed before accepting the PR.

Would you like to comment on the changes?