### PR TITLE
Fixed memory leak in sre_parse.py

### DIFF
--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -13,6 +13,7 @@
 # XXX: show string offset and offending character for all errors
 
 from sre_constants import *
+import weakref
 
 SPECIAL_CHARS = ".\\[{()*+?^$|"
 REPEAT_CHARS = "*+?{"
@@ -195,7 +196,8 @@ class SubPattern:
                 lo = lo + 1
                 hi = hi + 1
             elif op is GROUPREF:
-                i, j = self.pattern.subpatterns[av].getwidth()
+                # Get the original object
+                i, j = self.pattern.subpatterns[av]().getwidth()
                 lo = lo + i
                 hi = hi + j
             elif op is GROUPREF_EXISTS:
@@ -780,7 +782,8 @@ def _parse(source, state):
                 raise source.error("missing ), unterminated subpattern",
                                    source.tell() - start)
             if group is not None:
-                state.closegroup(group, p)
+                # Parse a weakref instead of the object
+                state.closegroup(group, weakref.ref(p))
             subpatternappend((SUBPATTERN, (group, p)))
 
         elif this == "^":


### PR DESCRIPTION
When compiling a regular expression with groups (subpatterns), circular references are created.
Here is an example to illustrate the problem:
```python
import gc
import re

# disable garbage collector
gc.disable()

# make sure we collect all and start with 0
gc.collect()

# compile something with a groups (subpatterns)
re.compile('(a|b)')

# shows x objects (depending on the string compiled)
print(gc.collect())
```

To fix the issue a `weakref` object for `p` is used. This solves the memory issue. I have also used `test_re.py` to test whether no other issues are introduced by this solution. As far as I can see this is not the case. 