### PR TITLE
Prevent ftplib from hanging on wrong PASV response

### DIFF
--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -47,7 +47,7 @@ from _ctypes import FUNCFLAG_CDECL as _FUNCFLAG_CDECL, \
 def create_string_buffer(init, size=None):
     """create_string_buffer(aBytes) -> character array
     create_string_buffer(anInteger) -> character array
-    create_string_buffer(aString, anInteger) -> character array
+    create_string_buffer(aBytes, anInteger) -> character array
     """
     if isinstance(init, bytes):
         if size is None:


### PR DESCRIPTION
When `PASV` command is responsed with local ip address and the server is not in the local network with client, this usually means the server is set wrong with its firewall settings. This situation makes ftplib be hanging until timeout on next passive-needed commands and makes the user hard to recognize the problem because its non-passive commands will success.
This commit makes client not to change its target host address on `PASV` commands based on detail ip address checking results with ipaddress library.