### PR TITLE
setup.py via run_setup shall think it is __main__

### DIFF
--- a/Lib/distutils/core.py
+++ b/Lib/distutils/core.py
@@ -205,7 +205,10 @@ def run_setup (script_name, script_args=None, stop_after="run"):
     _setup_stop_after = stop_after
 
     save_argv = sys.argv.copy()
-    g = {'__file__': script_name}
+    g = {
+        '__file__': script_name,
+        '__name__': '__main__',
+    }
     try:
         try:
             sys.argv[0] = script_name

--- a/Lib/distutils/tests/test_core.py
+++ b/Lib/distutils/tests/test_core.py
@@ -20,6 +20,15 @@ from distutils.core import setup
 setup()
 """
 
+# setup script that checks __name__ == '__main__'
+setup_using___name__ = """\
+
+assert __name__ == '__main__'
+
+from distutils.core import setup
+setup()
+"""
+
 setup_prints_cwd = """\
 
 import os
@@ -81,6 +90,12 @@ class CoreTestCase(support.EnvironGuard, unittest.TestCase):
         # setup.py script will raise NameError.
         distutils.core.run_setup(
             self.write_setup(setup_using___file__))
+
+    def test_run_setup_provides_name(self):
+        # Make sure the script will see __name__ as '__main__'; if it has
+        # another value, the test setup.py script will raise AssertionError.
+        distutils.core.run_setup(
+            self.write_setup(setup_using___name__))
 
     def test_run_setup_preserves_sys_argv(self):
         # Make sure run_setup does not clobber sys.argv


### PR DESCRIPTION
I have a setup.py file which does:

```
if __name__ == '__main__':
    setup(...)
```

When I want to run this file with `distutils.core.run_setup`, `setup()` is never called because `__name__` has a different value.
I think that `run_setup` should make the script believe that it is the main script, even if conditionally run the `setup()` function may be a bad idea.