### PR TITLE
Fix invalid keyword args in signature

### DIFF
--- a/Doc/library/http.cookies.rst
+++ b/Doc/library/http.cookies.rst
@@ -173,7 +173,7 @@ Morsel Objects
       assigning to ``key``; use :meth:`~Morsel.set` instead.
 
 
-.. method:: Morsel.set(key, value, coded_value)
+.. method:: Morsel.set(key, val, coded_val)
 
    Set the *key*, *value* and *coded_value* attributes.
 


### PR DESCRIPTION
The message said this is a python mirror only and this PR will be closed automatically. The internet says that in Jan 2016 the announcement was made to move to GitHub. Anyway I have no idea if that's done yet or not. I looked at bugs.python.org and I had no idea how to submit anything. Tried logging in etc to no avail. I probably just missed it. So my choice was forget this all together or at least try. So I am opting for trying.

There is a documentation error in `Morsel`.  Currently the docs state the signature is:

```
Morsel.set(key, value, coded_value)
```

But that's not what is written in the code:

https://github.com/python/cpython/blob/master/Lib/http/cookies.py#L369

The code says:
```
def set(self, key, val, coded_val, LegalChars=_LegalChars):
```

**val** and **coded_val** specifically **not** *value* and *coded_value* as the docs currently state.

