### PR TITLE
bpo-29527: Disable broken Travis docs job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ matrix:
         - cd Doc
         - make venv PYTHON=python3
       script:
-        - make html SPHINXBUILD="./venv/bin/python3 -m sphinx" SPHINXOPTS="-nW -q -b linkcheck"
+        - make html SPHINXBUILD="./venv/bin/python3 -m sphinx" SPHINXOPTS="-n -q -b linkcheck"
     - os: linux
       language: c
       compiler: clang


### PR DESCRIPTION
Comment the job in .travis.yml until a fix is found.

See http://bugs.python.org/issue29527