### PR TITLE
bpo-29474: Improve documentation for weakref.WeakValueDictionary

### DIFF
--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -166,8 +166,8 @@ Extension types can easily be made to support weak references; see
       performed by the program during iteration may cause items in the
       dictionary to vanish "by magic" (as a side effect of garbage collection).
 
-:class:`WeakKeyDictionary` objects have the following additional methods.  These
-expose the internal references directly.  The references are not guaranteed to
+:class:`WeakKeyDictionary` objects have an additional method that
+exposes the internal references directly.  The references are not guaranteed to
 be "live" at the time they are used, so the result of calling the references
 needs to be checked before being used.  This can be used to avoid creating
 references that will cause the garbage collector to keep the keys around longer
@@ -192,9 +192,9 @@ than needed.
       by the program during iteration may cause items in the dictionary to vanish "by
       magic" (as a side effect of garbage collection).
 
-:class:`WeakValueDictionary` objects have the following additional methods.
-These method have the same issues as the and :meth:`keyrefs` method of
-:class:`WeakKeyDictionary` objects.
+:class:`WeakValueDictionary` objects have an additional method that has the
+same issues as the :meth:`keyrefs` method of :class:`WeakKeyDictionary`
+objects.
 
 
 .. method:: WeakValueDictionary.valuerefs()


### PR DESCRIPTION
There were some grammatical errors in weakref.WeakValueDictionary
documentation.

This should be applied to 3.5, 3.6, and master.

Original patch was in bpo http://bugs.python.org/file46597/issue29474py3-2.patch

