### PR TITLE
bpo-29474: Improve documentation for weakref.WeakValueDictionary

### DIFF
--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -189,8 +189,8 @@ than needed.
       magic" (as a side effect of garbage collection).
 
 :class:`WeakValueDictionary` objects have the following additional methods.
-These method have the same issues as the :meth:`iterkeyrefs` and :meth:`keyrefs`
-methods of :class:`WeakKeyDictionary` objects.
+These methods have the same issues as the :meth:`iterkeyrefs` and
+:meth:`keyrefs` methods of :class:`WeakKeyDictionary` objects.
 
 
 .. method:: WeakValueDictionary.itervaluerefs()


### PR DESCRIPTION
There were some grammatical errors in weakref.WeakValueDictionary
documentation.

This is to be applied to 2.7