### PR TITLE
Disable Travis docs job until a fix is found

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,16 +24,16 @@ matrix:
     - env:
        - TESTING=coverage
   include:
-    - os: linux
-      language: python
-      python: 3.5
-      env:
-        - TESTING=docs
-      before_script:
-        - cd Doc
-        - make venv PYTHON=python3
-      script:
-        - make html SPHINXBUILD="./venv/bin/python3 -m sphinx" SPHINXOPTS="-n -q -b linkcheck"
+#    - os: linux
+#      language: python
+#      python: 3.5
+#      env:
+#        - TESTING=docs
+#      before_script:
+#        - cd Doc
+#        - make venv PYTHON=python3
+#      script:
+#        - make html SPHINXBUILD="./venv/bin/python3 -m sphinx" SPHINXOPTS="-nW -q -b linkcheck"
     - os: linux
       language: c
       compiler: clang


### PR DESCRIPTION
bpo-29527: The Travis docs job is still broken. Revert previous
change (add again -W option), and disable the job instead until a
better fix is found and things calm down after the migration to
GitHub.

The Travis "docs" job is still broken, even after the change removing the -W option:
https://travis-ci.org/python/cpython/jobs/200552343

It's too late to find a better fix. I suggest to disable the job just to fix Travis, so other jobs will be more useful, and take time later to fix this docs job.