### PR TITLE
Use Sphinx 1.4.9 for now

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -107,7 +107,7 @@ clean:
 
 venv:
 	$(PYTHON) -m venv venv
-	./venv/bin/python3 -m pip install -U Sphinx
+	./venv/bin/python3 -m pip install -U Sphinx==1.4.9
 
 dist:
 	rm -rf dist


### PR DESCRIPTION
Sphinx 1.5 is more strict.
We should fix them before using Sphinx 1.5 on Travis.