### PR TITLE
bpo-28556: Various updates to typing

### DIFF
--- a/Lib/test/mod_generics_cache.py
+++ b/Lib/test/mod_generics_cache.py
@@ -1,0 +1,14 @@
+"""Module for testing the behavior of generics across different modules."""
+
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+
+
+class A(Generic[T]):
+    pass
+
+
+class B(Generic[T]):
+    class A(Generic[T]):
+        pass

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -225,6 +225,10 @@ Extension Modules
 Library
 -------
 
+- PR #28: Various updates to typing module: typing.Counter, typing.ChainMap,
+  improved ABC caching, etc. Original PRs by Jelle Zijlstra, Ivan Levkivskyi,
+  Manuel Krebber, and Łukasz Langa.
+
 - Issue #29100: Fix datetime.fromtimestamp() regression introduced in Python
   3.6.0: check minimum and maximum years.
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -225,7 +225,7 @@ Extension Modules
 Library
 -------
 
-- PR #28: Various updates to typing module: typing.Counter, typing.ChainMap,
+- Issue #28556: Various updates to typing module: typing.Counter, typing.ChainMap,
   improved ABC caching, etc. Original PRs by Jelle Zijlstra, Ivan Levkivskyi,
   Manuel Krebber, and Łukasz Langa.
 


### PR DESCRIPTION
This PR contains various updates from upstream ``python/typing`` repo:
* Added ``typing.Counter`` and ``typing.ChainMap`` generics
* More flexible ``typing.NamedTuple``
* Improved generic ABC caching
* More tests
* Bugfixes
* Other updates

This should be backported to 3.6 and 3.5 branches.