### PR TITLE
Allow up to a 0.01% drop in coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,8 +13,12 @@ coverage:
   round: down
   status:
     changes: false
-    patch: true
-    project: true
+    patch:
+      default:
+        threshold: 0.01
+    project:
+      default:
+        threshold: 0.01
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
I'm not sure that this is correct, but we'll see what codecov thinks.  It does pass the validator, but I couldn't get the validator to fail at all with well-formed YAML...