### PR TITLE
bpo-29576: Improve some deprecations in the importlib

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -140,6 +140,17 @@ Deprecated
   ``0x03050400`` and ``0x03060000`` (not including) or ``0x03060100`` or
   higher.  (Contributed by Serhiy Storchaka in :issue:`27867`.)
 
+- Methods
+  :meth:`MetaPathFinder.find_module() <importlib.abc.MetaPathFinder.find_module>`
+  (replaced by
+  :meth:`MetaPathFinder.find_spec() <importlib.abc.MetaPathFinder.find_spec>`
+  ) and
+  :meth:`PathEntryFinder.find_loader() <importlib.abc.PathEntryFinder.find_loader>`
+  (replaced by
+  :meth:`PathEntryFinder.find_spec() <importlib.abc.PathEntryFinder.find_spec>`)
+  both deprecated in Python 3.4 now emit :exc:`DeprecationWarning`. (Contributed
+  by Matthias Bussonnier in :issue:`29576`)
+
 
 Removed
 =======

--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -79,7 +79,8 @@ def find_loader(name, path=None):
     This function is deprecated in favor of importlib.util.find_spec().
 
     """
-    warnings.warn('Use importlib.util.find_spec() instead.',
+    warnings.warn('Deprecated since Python 3.4. '
+                  'Use importlib.util.find_spec() instead.',
                   DeprecationWarning, stacklevel=2)
     try:
         loader = sys.modules[name].__loader__

--- a/Lib/importlib/abc.py
+++ b/Lib/importlib/abc.py
@@ -13,6 +13,7 @@ try:
 except ImportError as exc:
     _frozen_importlib_external = _bootstrap_external
 import abc
+import warnings
 
 
 def _register(abstract_cls, *classes):
@@ -34,6 +35,8 @@ class Finder(metaclass=abc.ABCMeta):
     reimplementations of the import system.  Otherwise, finder
     implementations should derive from the more specific MetaPathFinder
     or PathEntryFinder ABCs.
+
+    Deprecated since Python 3.3
     """
 
     @abc.abstractmethod
@@ -57,11 +60,16 @@ class MetaPathFinder(Finder):
         If no module is found, return None.  The fullname is a str and
         the path is a list of strings or None.
 
-        This method is deprecated in favor of finder.find_spec(). If find_spec()
-        exists then backwards-compatible functionality is provided for this
-        method.
+        This method is deprecated since Python 3.4 in favor of
+        finder.find_spec(). If find_spec() exists then backwards-compatible
+        functionality is provided for this method.
 
         """
+        warnings.warn("MetaPathFinder.find_module() is deprecated since Python "
+                      "3.4 in favor of MetaPathFinder.find_spec()"
+                      "(available since 3.4)",
+                      DeprecationWarning,
+                      stacklevel=2)
         if not hasattr(self, 'find_spec'):
             return None
         found = self.find_spec(fullname, path)
@@ -94,10 +102,15 @@ class PathEntryFinder(Finder):
         The portion will be discarded if another path entry finder
         locates the module as a normal module or package.
 
-        This method is deprecated in favor of finder.find_spec(). If find_spec()
-        is provided than backwards-compatible functionality is provided.
-
+        This method is deprecated since Python 3.4 in favor of
+        finder.find_spec(). If find_spec() is provided than backwards-compatible
+        functionality is provided.
         """
+        warnings.warn("PathEntryFinder.find_loader() is deprecated since Python "
+                      "3.4 in favor of PathEntryFinder.find_spec() "
+                      "(available since 3.4)",
+                      DeprecationWarning,
+                      stacklevel=2)
         if not hasattr(self, 'find_spec'):
             return None, []
         found = self.find_spec(fullname)

--- a/Lib/test/test_importlib/test_abc.py
+++ b/Lib/test/test_importlib/test_abc.py
@@ -163,6 +163,9 @@ class MetaPathFinderDefaultsTests(ABCTestHarness):
         # Calling the method is a no-op.
         self.ins.invalidate_caches()
 
+    def test_find_module_warns(self):
+        with self.assertWarns(DeprecationWarning):
+            self.ins.find_module('something', None)
 
 (Frozen_MPFDefaultTests,
  Source_MPFDefaultTests
@@ -189,6 +192,9 @@ class PathEntryFinderDefaultsTests(ABCTestHarness):
         # Should be a no-op.
         self.ins.invalidate_caches()
 
+    def test_find_loader_warns(self):
+        with self.assertWarns(DeprecationWarning):
+            self.ins.find_loader('something')
 
 (Frozen_PEFDefaultTests,
  Source_PEFDefaultTests

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -229,6 +229,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29576: Improve some deprecations in importlib. Some deprecated methods
+  now emit DeprecationWarnings and have better descriptive messages.
+
 - bpo-29534: Fixed different behaviour of Decimal.from_float()
   for _decimal and _pydecimal. Thanks Andrew Nester.
 


### PR DESCRIPTION
Add the python version since the functionality is deprecated,
and raise a couple of deprecation warnings in a few places.

Theses functions are marked as deprecated in the documentation, but
especially in existing codebase, programmers tends to not re-check
whether functions are deprecated. So trigger the warning when possible.

It's also more probable that a developer will drop deprecated
functionality if we immediately give them information about
replacement API, and not have them to go find it in the documentation.

Include deprecation information in DocString as well, as many tools pull
documentation from there and not from docs.python.org.
