### PR TITLE
bpo-28929: Link the documentation to its source file on GitHub

### DIFF
--- a/Doc/tools/templates/customsourcelink.html
+++ b/Doc/tools/templates/customsourcelink.html
@@ -3,8 +3,14 @@
     <h3>{{ _('This Page') }}</h3>
     <ul class="this-page-menu">
       <li><a href="{{ pathto('bugs') }}">{% trans %}Report a Bug{% endtrans %}</a></li>
-      <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}"
-            rel="nofollow">{{ _('Show Source') }}</a></li>
+      <li>
+        {% if version == "3.7" %}
+          {% set version = 'master' %}
+        {% endif %}
+        <a href="https://github.com/python/cpython/blob/{{ version }}/Doc/{{ sourcename|replace('txt', 'rst') }}"
+            rel="nofollow">{{ _('Show Source') }}
+        </a>
+      </li>
     </ul>
   </div>
 {%- endif %}

--- a/Doc/tools/templates/customsourcelink.html
+++ b/Doc/tools/templates/customsourcelink.html
@@ -4,10 +4,7 @@
     <ul class="this-page-menu">
       <li><a href="{{ pathto('bugs') }}">{% trans %}Report a Bug{% endtrans %}</a></li>
       <li>
-        {% if version == "3.7" %}
-          {% set version = 'master' %}
-        {% endif %}
-        <a href="https://github.com/python/cpython/blob/{{ version }}/Doc/{{ sourcename|replace('txt', 'rst') }}"
+        <a href="https://github.com/python/cpython/blob/master/Doc/{{ sourcename|replace('txt', 'rst') }}"
             rel="nofollow">{{ _('Show Source') }}
         </a>
       </li>


### PR DESCRIPTION
Change the documentation's `Show Source` link on the left menu
to GitHub source file.