### PR TITLE
[backport to 3.6] bpo-28929: Link the documentation to its source file on GitHub

### DIFF
--- a/Doc/tools/templates/customsourcelink.html
+++ b/Doc/tools/templates/customsourcelink.html
@@ -3,8 +3,14 @@
     <h3>{{ _('This Page') }}</h3>
     <ul class="this-page-menu">
       <li><a href="{{ pathto('bugs') }}">{% trans %}Report a Bug{% endtrans %}</a></li>
-      <li><a href="{{ pathto('_sources/' + sourcename, true)|e }}"
-            rel="nofollow">{{ _('Show Source') }}</a></li>
+      <li>
+        {% if version == "3.7" %}
+          {% set version = 'master' %}
+        {% endif %}
+        <a href="https://github.com/python/cpython/blob/{{ version }}/Doc/{{ sourcename|replace('txt', 'rst') }}"
+            rel="nofollow">{{ _('Show Source') }}
+        </a>
+      </li>
     </ul>
   </div>
 {%- endif %}

--- a/Doc/tools/templates/customsourcelink.html
+++ b/Doc/tools/templates/customsourcelink.html
@@ -4,9 +4,6 @@
     <ul class="this-page-menu">
       <li><a href="{{ pathto('bugs') }}">{% trans %}Report a Bug{% endtrans %}</a></li>
       <li>
-        {% if version == "3.7" %}
-          {% set version = 'master' %}
-        {% endif %}
         <a href="https://github.com/python/cpython/blob/{{ version }}/Doc/{{ sourcename|replace('txt', 'rst') }}"
             rel="nofollow">{{ _('Show Source') }}
         </a>


### PR DESCRIPTION
Change the documentation's `Show Source` link on the left menu
to GitHub source file.

(cherry picked from commit 23bafa294c75c20cb85ae5d97d7571a3a0ad8dd3)