### PR TITLE
bpo-29521 Fix two minor documentation build warnings

### DIFF
--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -300,9 +300,10 @@ this respect, and is easily configured to use spaces: Take :menuselection:`Tools
 --> Options --> Tabs`, and for file type "Default" set "Tab size" and "Indent
 size" to 4, and select the "Insert spaces" radio button.
 
-If you suspect mixed tabs and spaces are causing problems in leading whitespace,
-run Python with the :option:`-t` switch or run ``Tools/Scripts/tabnanny.py`` to
-check a directory tree in batch mode.
+Python raises :exc:`IndentationError` or :exc:`TabError` if mixed tabs 
+and spaces are causing problems in leading whitespace.
+You may also run the :mod:`tabnanny` module to check a directory tree 
+in batch mode.
 
 
 How do I check for a keypress without blocking?

--- a/Doc/make.bat
+++ b/Doc/make.bat
@@ -86,7 +86,7 @@ goto end
 
 :build
 if NOT "%PAPER%" == "" (
-    set SPHINXOPTS=-D latex_paper_size=%PAPER% %SPHINXOPTS%
+    set SPHINXOPTS=-D latex_elements.papersize=%PAPER% %SPHINXOPTS%
 )
 cmd /C %SPHINXBUILD% %SPHINXOPTS% -b%1 -dbuild\doctrees . %BUILDDIR%\%*
 


### PR DESCRIPTION
Much of bpo-29521 was fixed in parallel with commit 
e7ffb99 .  This cleans up the rest.

Apply parallel change to Doc/make.bat to read 
"set SPHINXOPTS=-D latex_elements.papersize="
I don't have a Windows system on which to observe the warning,
but it should be necessary.

The warning:

.../workspace/cpython_github/Doc/faq/windows.rst:303: 
    WARNING: unknown option: -t

In the Windows FAQ, How do I keep editors from inserting tabs 
into my Python source?, contained a reference to a Python -t
option. In Python 2.x, this caused Python to issue warnings
about lines with mixed spaces and tabs, but as of Python 3.6
it does nothing. 
 
Per discussion at http://bugs.python.org/issue29387, take
their wording. Python [3] raises an IndentationError or 
TabError. Tabnanny is now a module.