### PR TITLE
[backport to 2.7] Change documentation's `Show Source` link to GitHub

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -58,7 +58,7 @@ LaTeXTranslator.depart_literal_block = new_depart_literal_block
 
 def issue_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     issue = utils.unescape(text)
-    text = 'bpo- ' + issue
+    text = 'bpo-'+ issue
     refnode = nodes.reference(text, text, refuri=ISSUE_URI % issue)
     return [refnode], []
 

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -10,7 +10,7 @@
 """
 
 ISSUE_URI = 'https://bugs.python.org/issue%s'
-SOURCE_URI = 'https://hg.python.org/cpython/file/2.7/%s'
+SOURCE_URI = 'https://github.com/python/cpython/tree/2.7/%s'
 
 from docutils import nodes, utils
 
@@ -58,7 +58,7 @@ LaTeXTranslator.depart_literal_block = new_depart_literal_block
 
 def issue_role(typ, rawtext, text, lineno, inliner, options={}, content=[]):
     issue = utils.unescape(text)
-    text = 'issue ' + issue
+    text = 'bpo- ' + issue
     refnode = nodes.reference(text, text, refuri=ISSUE_URI % issue)
     return [refnode], []
 


### PR DESCRIPTION
Change documentation's `Show Source` link to GitHub (2.7 branch)
Render issue role as bpo-NNNN