### PR TITLE
[backport to 3.6] bpo-27122: Fix comment to point to correct issue number (#47)

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -105,7 +105,7 @@ class _GeneratorContextManager(ContextDecorator, AbstractContextManager):
                 # raised inside the "with" statement from being suppressed.
                 return exc is not value
             except RuntimeError as exc:
-                # Don't re-raise the passed in exception. (issue27112)
+                # Don't re-raise the passed in exception. (issue27122)
                 if exc is value:
                     return False
                 # Likewise, avoid suppressing if a StopIteration exception


### PR DESCRIPTION
It took me quite a bit to figure out what this was referring to,
since the given issue number is wrong, and the original commit
message I found through git blame lists a different, also wrong
issue number... see https://bugs.python.org/issue27122#msg279449(cherry picked from commit af88e7eda4101f36e904771d3cf59a5f740b3b00)