### PR TITLE
bpo-29176: Fix name of the _curses.window class

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2077,7 +2077,7 @@ static PyGetSetDef PyCursesWindow_getsets[] = {
 
 PyTypeObject PyCursesWindow_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_curses.curses window",            /*tp_name*/
+    "_curses.window",           /*tp_name*/
     sizeof(PyCursesWindowObject),       /*tp_basicsize*/
     0,                          /*tp_itemsize*/
     /* methods */


### PR DESCRIPTION
Set name to "_curses.window" instead of "_curses.curses window" (with
a space!?).