### PR TITLE
Update Copyright dates in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,7 @@
 This is Python version 3.7.0 alpha 1
 ====================================
 
-Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
-2012, 2013, 2014, 2015, 2016, 2017 Python Software Foundation.  All rights
+Copyright (c) 2001-2017 Python Software Foundation.  All rights
 reserved.
 
 Python 3.x is a new version of the language, which is incompatible with the
@@ -206,8 +205,7 @@ See :pep:`537` for Python 3.7 release details.
 Copyright and License Information
 ---------------------------------
 
-Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
-2012, 2013, 2014, 2015, 2016 Python Software Foundation.  All rights reserved.
+Copyright (c) 2001-2017 Python Software Foundation.  All rights reserved.
 
 Copyright (c) 2000 BeOpen.com.  All rights reserved.
 


### PR DESCRIPTION
Updated the copyright dates of Python Software Foundation found in the README to be a range of years, rather than listing out each year individually.

In addition to this, I included the missing year 2017 to the 'Copyright and License Information' section of the README for the Python Software Foundation.