### PR TITLE
bpo-29481:  DOC: mark which version typing.Deque added

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -574,6 +574,8 @@ The module defines the following classes, functions and decorators:
 
    A generic version of :class:`collections.deque`.
 
+   .. versionadded:: 3.6.1
+
 .. class:: List(list, MutableSequence[T])
 
    Generic version of :class:`list`.


### PR DESCRIPTION
This is targeted at 3.6, but half of it should be backported to 3.5.