### PR TITLE
Travis CI: run rstlint.py in the docs job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
         - make venv PYTHON=python3
       script:
         - make html SPHINXBUILD="./venv/bin/python3 -m sphinx" SPHINXOPTS="-q"
+        - python3 tools/rstlint.py -i tools -i venv
     - os: linux
       language: c
       compiler: clang

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -300,9 +300,9 @@ this respect, and is easily configured to use spaces: Take :menuselection:`Tools
 --> Options --> Tabs`, and for file type "Default" set "Tab size" and "Indent
 size" to 4, and select the "Insert spaces" radio button.
 
-Python raises :exc:`IndentationError` or :exc:`TabError` if mixed tabs 
+Python raises :exc:`IndentationError` or :exc:`TabError` if mixed tabs
 and spaces are causing problems in leading whitespace.
-You may also run the :mod:`tabnanny` module to check a directory tree 
+You may also run the :mod:`tabnanny` module to check a directory tree
 in batch mode.
 
 


### PR DESCRIPTION
Currently, http://buildbot.python.org/all/buildslaves/ware-docs
buildbot is only run as post-commit. For example, bpo-29521 (PR#41)
introduced two warnings, unnotified by the Travis CI docs job.

Modify the docs job to run toosl/rstlint.py.

Fix also the two minor warnings which causes the buildbot slave to
fail.