### PR TITLE
Fix trailing whitespaces in Doc/faq/windows.rst

### DIFF
--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -300,9 +300,9 @@ this respect, and is easily configured to use spaces: Take :menuselection:`Tools
 --> Options --> Tabs`, and for file type "Default" set "Tab size" and "Indent
 size" to 4, and select the "Insert spaces" radio button.
 
-Python raises :exc:`IndentationError` or :exc:`TabError` if mixed tabs 
+Python raises :exc:`IndentationError` or :exc:`TabError` if mixed tabs
 and spaces are causing problems in leading whitespace.
-You may also run the :mod:`tabnanny` module to check a directory tree 
+You may also run the :mod:`tabnanny` module to check a directory tree
 in batch mode.
 
 


### PR DESCRIPTION
Introduced by 3d707be950b387552585451071928e7b39cdfa53.

From docs buildbot: http://buildbot.python.org/all/builders/Docs%203.x/builds/399/steps/lint/logs/stdio

```
python3 tools/rstlint.py -i tools -i venv
[1] faq/windows.rst:303: trailing whitespace
[1] faq/windows.rst:305: trailing whitespace
2 problems with severity 1 found.
```