### PR TITLE
Add Travis CI and Codecov badges to README

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -6,12 +6,6 @@ Build Status
 
 - master
 
-  + .. image:: https://travis-ci.org/python/cpython.svg?branch=master
-       :target: https://travis-ci.org/python/cpython
-  
-  + .. image:: https://codecov.io/gh/python/cpython/branch/master/graph/badge.svg
-       :target: https://codecov.io/gh/python/cpython
-
   + `Stable buildbots <http://buildbot.python.org/3.x.stable/>`_
 
 - 3.6

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,14 @@
 This is Python version 3.7.0 alpha 1
 ====================================
 
+.. image:: https://travis-ci.org/python/cpython.svg?branch=master
+   :alt: CPython build status on Travis CI
+   :target: https://travis-ci.org/python/cpython
+
+.. image:: https://codecov.io/gh/python/cpython/branch/master/graph/badge.svg
+   :alt: CPython code coverage on Codecov
+   :target: https://codecov.io/gh/python/cpython
+
 Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
 2012, 2013, 2014, 2015, 2016, 2017 Python Software Foundation.  All rights
 reserved.


### PR DESCRIPTION
Badges are small images which gives the status of the Travis CI and
the coverage percentage of Codecode. It helps to check the status of
the Travis CI and to get the link to Travis CI.

See also https://shields.io/