### PR TITLE
bpo-29863: Add json.COMPACT constant

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -43,7 +43,7 @@ Encoding basic Python object hierarchies::
 Compact encoding::
 
     >>> import json
-    >>> json.dumps([1,2,3,{'4': 5, '6': 7}], separators=(',', ':'))
+    >>> json.dumps([1,2,3,{'4': 5, '6': 7}], separators=json.COMPACT)
     '[1,2,3,{"4":5,"6":7}]'
 
 Pretty printing::
@@ -175,6 +175,9 @@ Basic Usage
    .. versionchanged:: 3.4
       Use ``(',', ': ')`` as default if *indent* is not ``None``.
 
+   .. versionchanged:: 3.7
+      Instead of ``(',', ':')`` constant :data:`json.COMPACT` can be used.
+
    If specified, *default* should be a function that gets called for objects that
    can't otherwise be serialized.  It should return a JSON encodable version of
    the object or raise a :exc:`TypeError`.  If not specified, :exc:`TypeError`
@@ -281,6 +284,16 @@ Basic Usage
    .. versionchanged:: 3.6
       *s* can now be of type :class:`bytes` or :class:`bytearray`. The
       input encoding should be UTF-8, UTF-16 or UTF-32.
+
+
+Constants
+^^^^^^^^^
+
+.. data:: compact
+
+   A constant that can be used as the *separators* argument to emit a compact serialization.
+
+   .. versionadded:: 3.7
 
 
 Encoders and Decoders

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -170,13 +170,10 @@ Basic Usage
    If specified, *separators* should be an ``(item_separator, key_separator)``
    tuple.  The default is ``(', ', ': ')`` if *indent* is ``None`` and
    ``(',', ': ')`` otherwise.  To get the most compact JSON representation,
-   you should specify ``(',', ':')`` to eliminate whitespace.
+   you should specify :attr:`json.COMPACT` to eliminate whitespace.
 
    .. versionchanged:: 3.4
       Use ``(',', ': ')`` as default if *indent* is not ``None``.
-
-   .. versionchanged:: 3.7
-      Instead of ``(',', ':')`` constant :data:`json.COMPACT` can be used.
 
    If specified, *default* should be a function that gets called for objects that
    can't otherwise be serialized.  It should return a JSON encodable version of
@@ -289,9 +286,10 @@ Basic Usage
 Constants
 ^^^^^^^^^
 
-.. data:: compact
+.. data:: COMPACT
 
-   A constant that can be used as the *separators* argument to emit a compact serialization.
+   A constant that can be used as the *separators* argument
+   to emit a compact serialization.
 
    .. versionadded:: 3.7
 
@@ -461,7 +459,7 @@ Encoders and Decoders
    If specified, *separators* should be an ``(item_separator, key_separator)``
    tuple.  The default is ``(', ', ': ')`` if *indent* is ``None`` and
    ``(',', ': ')`` otherwise.  To get the most compact JSON representation,
-   you should specify ``(',', ':')`` to eliminate whitespace.
+   you should specify :attr:`json.COMPACT` to eliminate whitespace.
 
    .. versionchanged:: 3.4
       Use ``(',', ': ')`` as default if *indent* is not ``None``.

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -30,7 +30,7 @@ Compact encoding::
     >>> import json
     >>> from collections import OrderedDict
     >>> mydict = OrderedDict([('4', 5), ('6', 7)])
-    >>> json.dumps([1,2,3,mydict], separators=(',', ':'))
+    >>> json.dumps([1,2,3,mydict], separators=json.COMPACT)
     '[1,2,3,{"4":5,"6":7}]'
 
 Pretty printing::
@@ -99,6 +99,7 @@ __version__ = '2.0.9'
 __all__ = [
     'dump', 'dumps', 'load', 'loads',
     'JSONDecoder', 'JSONDecodeError', 'JSONEncoder',
+    'COMPACT',
 ]
 
 __author__ = 'Bob Ippolito <bob@redivi.com>'
@@ -106,6 +107,8 @@ __author__ = 'Bob Ippolito <bob@redivi.com>'
 from .decoder import JSONDecoder, JSONDecodeError
 from .encoder import JSONEncoder
 import codecs
+
+COMPACT = (',', ':')
 
 _default_encoder = JSONEncoder(
     skipkeys=False,

--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -52,6 +52,11 @@ class TestDump:
         self.json.dump({'name': 'some name', 'value': 'some value'}, sio, separators=self.json.COMPACT)
         self.assertEqual(sio.getvalue(), '{"name":"some name","value":"some value"}')
 
+    def test_compact_encode(self):
+        encoder = self.json.JSONEncoder(separators=self.json.COMPACT)
+        encoded = encoder.encode({'name': 'some name', 'value': 'some value'})
+        self.assertEqual(encoded, '{"name":"some name","value":"some value"}')
+
 class TestPyDump(TestDump, PyTest): pass
 
 class TestCDump(TestDump, CTest):

--- a/Lib/test/test_json/test_dump.py
+++ b/Lib/test/test_json/test_dump.py
@@ -47,6 +47,10 @@ class TestDump:
         d[1337] = "true.dat"
         self.assertEqual(self.dumps(d, sort_keys=True), '{"1337": "true.dat"}')
 
+    def test_compact_dump(self):
+        sio = StringIO()
+        self.json.dump({'name': 'some name', 'value': 'some value'}, sio, separators=self.json.COMPACT)
+        self.assertEqual(sio.getvalue(), '{"name":"some name","value":"some value"}')
 
 class TestPyDump(TestDump, PyTest): pass
 


### PR DESCRIPTION
Fix for https://bugs.python.org/issue29540

I decided to go with Alternative version provided R.David Murray just to keep things simple