### PR TITLE
bpo-28556: Various updates to typing (#28)

### DIFF
--- a/Lib/test/mod_generics_cache.py
+++ b/Lib/test/mod_generics_cache.py
@@ -1,0 +1,14 @@
+"""Module for testing the behavior of generics across different modules."""
+
+from typing import TypeVar, Generic
+
+T = TypeVar('T')
+
+
+class A(Generic[T]):
+    pass
+
+
+class B(Generic[T]):
+    class A(Generic[T]):
+        pass

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -25,6 +25,13 @@ Extension Modules
 Library
 -------
 
+- Issue #28556: Various updates to typing module: typing.Counter, typing.ChainMap,
+  improved ABC caching, etc. Original PRs by Jelle Zijlstra, Ivan Levkivskyi,
+  Manuel Krebber, and Łukasz Langa.
+
+- Issue #29100: Fix datetime.fromtimestamp() regression introduced in Python
+  3.6.0: check minimum and maximum years.
+
 - Issue #29519: Fix weakref spewing exceptions during interpreter shutdown
   when used with a rare combination of multiprocessing and custom codecs.
 


### PR DESCRIPTION
 various updates from upstream python/typing repo:

- Added typing.Counter and typing.ChainMap generics
- More flexible typing.NamedTuple
- Improved generic ABC caching
- More tests
- Bugfixes
- Other updates

* Add Misc/NEWS entry

* Add issue number

Contributed by Ivan Levkivskyi @ilevkivskyi 
(cherry picked from commit b692dc8475a032740576129d0990ddc3edccab2b)