### PR TITLE
bpo-24241: Preferred X browser

### DIFF
--- a/Doc/library/webbrowser.rst
+++ b/Doc/library/webbrowser.rst
@@ -83,7 +83,7 @@ The following functions are defined:
    caller's environment.
 
 
-.. function:: register(name, constructor, instance=None)
+.. function:: register(name, constructor, instance=None, *, preferred=False)
 
    Register the browser type *name*.  Once a browser type is registered, the
    :func:`get` function can return a controller for that browser type.  If
@@ -91,9 +91,11 @@ The following functions are defined:
    parameters to create an instance when needed.  If *instance* is provided,
    *constructor* will never be called, and may be ``None``.
 
-   This entry point is only useful if you plan to either set the :envvar:`BROWSER`
-   variable or call :func:`get` with a nonempty argument matching the name of a
-   handler you declare.
+   Setting *preferred* to ``True`` makes this browser a preferred result for
+   a :func:`get` call with no argument. Otherwise, this entry point is only
+   useful if you plan to either set the :envvar:`BROWSER` variable or call
+   :func:`get` with a nonempty argument matching the name of a handler you
+   declare.
 
 A number of browser types are predefined.  This table gives the type names that
 may be passed to the :func:`get` function and the corresponding instantiations

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -16,13 +16,13 @@ class Error(Exception):
 _browsers = {}          # Dictionary of available browser controllers
 _tryorder = []          # Preference order of available browsers
 
-def register(name, klass, instance=None, update_tryorder=1):
-    """Register a browser connector and, optionally, connection."""
+def register(name, klass, instance=None, *, preferred=False):
+    """Register a browser connector."""
     _browsers[name.lower()] = [klass, instance]
-    if update_tryorder > 0:
-        _tryorder.append(name)
-    elif update_tryorder < 0:
+    if preferred:
         _tryorder.insert(0, name)
+    else:
+        _tryorder.append(name)
 
 def get(using=None):
     """Return a browser launcher instance appropriate for the environment."""
@@ -610,10 +610,10 @@ if sys.platform == 'darwin':
 
     # Don't clear _tryorder or _browsers since OS X can use above Unix support
     # (but we prefer using the OS X specific stuff)
-    register("safari", None, MacOSXOSAScript('safari'), -1)
-    register("firefox", None, MacOSXOSAScript('firefox'), -1)
-    register("chrome", None, MacOSXOSAScript('chrome'), -1)
-    register("MacOSX", None, MacOSXOSAScript('default'), -1)
+    register("safari", None, MacOSXOSAScript('safari'), preferred=True)
+    register("firefox", None, MacOSXOSAScript('firefox'), preferred=True)
+    register("chrome", None, MacOSXOSAScript('chrome'), preferred=True)
+    register("MacOSX", None, MacOSXOSAScript('default'), preferred=True)
 
 
 # OK, now that we know what the default preference orders for each
@@ -628,7 +628,7 @@ if "BROWSER" in os.environ:
         if cmdline != '':
             cmd = _synthesize(cmdline, -1)
             if cmd[1] is None:
-                register(cmdline, None, GenericBrowser(cmdline), -1)
+                register(cmdline, None, GenericBrowser(cmdline), preferred=True)
     cmdline = None # to make del work if _userchoices was empty
     del cmdline
     del _userchoices

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1458,6 +1458,7 @@ Quentin Stafford-Fraser
 Frank Stajano
 Joel Stanley
 Anthony Starks
+David Steele
 Oliver Steele
 Greg Stein
 Marek Stepniowski

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -433,6 +433,11 @@ Library
 - Issue #23262: The webbrowser module now supports Firefox 36+ and derived
   browsers.  Based on patch by Oleg Broytman.
 
+- Issue #24241: The webbrowser in an X environment now prefers using the
+  default browser directly. Also, the webbrowser register() function now has
+  a documented 'preferred' argument, to specify browsers to be returned by
+  get() with no arguments. Patch by David Steele
+
 - Issue #27939: Fixed bugs in tkinter.ttk.LabeledScale and tkinter.Scale caused
   by representing the scale as float value internally in Tk.  tkinter.IntVar
   now works if float value is set to underlying Tk variable.


### PR DESCRIPTION
When calling webbrowser.open*(), the module goes through a list of installed browsers, and uses the first one that succeeds, to process the request.

The first 'browsers' in the 'X' list are 'xdg-open' and others of that ilk. The problem is that they only have one 'open' behavior - the 'new' parameter is ignored ('same window', 'new window', 'new tab').

These commits move the default web browser to the front of the tryorder list, allowing get() behavior to match the documentation.

This same problem was recently fixed in Windows via Issue #8232