### PR TITLE
bpo-29684: Fix regression of PyEval_CallObjectWithKeywords

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,10 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-29684: Fix minor regression of PyEval_CallObjectWithKeywords.
+  It should raise TypeError when kwargs is not a dict.  But it might
+  cause segv when args=NULL and kwargs is not a dict.
+
 - bpo-28598: Support __rmod__ for subclasses of str being called before
   str.__mod__.  Patch by Martijn Pieters.
 

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -766,11 +766,7 @@ PyEval_CallObjectWithKeywords(PyObject *callable,
     assert(!PyErr_Occurred());
 #endif
 
-    if (args == NULL) {
-        return _PyObject_FastCallDict(callable, NULL, 0, kwargs);
-    }
-
-    if (!PyTuple_Check(args)) {
+    if (args != NULL && !PyTuple_Check(args)) {
         PyErr_SetString(PyExc_TypeError,
                         "argument list must be a tuple");
         return NULL;
@@ -782,7 +778,12 @@ PyEval_CallObjectWithKeywords(PyObject *callable,
         return NULL;
     }
 
-    return PyObject_Call(callable, args, kwargs);
+    if (args == NULL) {
+        return _PyObject_FastCallDict(callable, NULL, 0, kwargs);
+    }
+    else {
+        return PyObject_Call(callable, args, kwargs);
+    }
 }
 
 


### PR DESCRIPTION
It should raise TypeError when kwargs is not a dict.