### PR TITLE
bpo-24665: double-width CJK chars support for textwrap

### DIFF
--- a/Doc/library/textwrap.rst
+++ b/Doc/library/textwrap.rst
@@ -117,6 +117,28 @@ functions should be good enough; otherwise, you should use an instance of
    .. versionadded:: 3.3
 
 
+.. function:: cjk_wide(char)
+
+   Return ``True`` if *char* is Fullwidth or Wide, ``False`` otherwise.
+   Fullwidth and Wide CJK chars are double-width.
+
+   .. versionadded:: 3.7
+
+
+.. function:: cjk_len(text)
+
+   Return the real width of *text* (its len if not a string).
+
+   .. versionadded:: 3.7
+
+
+.. function:: cjk_slices(text, index)
+
+   Return the two slices of *text* cut to *index*.
+
+   .. versionadded:: 3.7
+
+
 :func:`wrap`, :func:`fill` and :func:`shorten` work by creating a
 :class:`TextWrapper` instance and calling a single method on it.  That
 instance is not reused, so for applications that process many text
@@ -274,6 +296,13 @@ hyphenated words; only then will long words be broken if necessary, unless
       text if it has been truncated.
 
       .. versionadded:: 3.4
+
+
+   .. attribute:: cjk
+
+      (default: ``False``) Handle double-width CJK chars.
+
+      .. versionadded:: 3.7
 
 
    :class:`TextWrapper` also provides some public methods, analogous to the

--- a/Lib/idlelib/idle_test/test_calltips.py
+++ b/Lib/idlelib/idle_test/test_calltips.py
@@ -72,7 +72,7 @@ class Get_signatureTest(unittest.TestCase):
 (width=70, initial_indent='', subsequent_indent='', expand_tabs=True,
     replace_whitespace=True, fix_sentence_endings=False, break_long_words=True,
     drop_whitespace=True, break_on_hyphens=True, tabsize=8, *, max_lines=None,
-    placeholder=' [...]')''')
+    placeholder=' [...]', cjk=False)''')
 
     def test_docline_truncation(self):
         def f(): pass

--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -567,6 +567,10 @@ class LongWordTestCase (BaseTestCase):
 Did you say "supercalifragilisticexpialidocious?"
 How *do* you spell that odd word, anyways?
 '''
+        self.text_cjk = '''\
+Did you say "いろはにほへとちりぬるをいろはにほ?"
+How りぬ るをいろはにほり ぬるは, anyways?
+'''
 
     def test_break_long(self):
         # Wrap text with long words and lots of punctuation
@@ -579,6 +583,14 @@ How *do* you spell that odd word, anyways?
         self.check_wrap(self.text, 50,
                         ['Did you say "supercalifragilisticexpialidocious?"',
                          'How *do* you spell that odd word, anyways?'])
+        self.check_wrap(self.text_cjk, 30,
+                        ['Did you say "いろはにほへとち',
+                         'りぬるをいろはにほ?" How りぬ',
+                         'るをいろはにほり ぬるは,',
+                         'anyways?'], cjk=True)
+        self.check_wrap(self.text_cjk, 50,
+                        ['Did you say "いろはにほへとちりぬるをいろはにほ?"',
+                         'How りぬ るをいろはにほり ぬるは, anyways?'], cjk=True)
 
         # SF bug 797650.  Prevent an infinite loop by making sure that at
         # least one character gets split off on every pass.

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -3,6 +3,7 @@
 
 # Copyright (C) 1999-2001 Gregory P. Ward.
 # Copyright (C) 2002, 2003 Python Software Foundation.
+# Copyright (C) 2015-2017 Florent Gallaire <fgallaire@gmail.com>
 # Written by Greg Ward <gward@python.net>
 
 import re, unicodedata
@@ -27,8 +28,6 @@ class TextWrapper:
       width (default: 70)
         the maximum width of wrapped lines (unless break_long_words
         is false)
-      cjk (default: False)
-        Handle double-width CJK chars.
       initial_indent (default: "")
         string that will be prepended to the first line of wrapped
         output.  Counts towards the line's width.
@@ -64,6 +63,8 @@ class TextWrapper:
         Truncate wrapped lines.
       placeholder (default: ' [...]')
         Append to the last line of truncated text.
+      cjk (default: false)
+        Handle double-width CJK chars.
     """
 
     unicode_whitespace_trans = {}
@@ -117,7 +118,6 @@ class TextWrapper:
 
     def __init__(self,
                  width=70,
-                 cjk=False,
                  initial_indent="",
                  subsequent_indent="",
                  expand_tabs=True,
@@ -129,9 +129,9 @@ class TextWrapper:
                  tabsize=8,
                  *,
                  max_lines=None,
-                 placeholder=' [...]'):
+                 placeholder=' [...]',
+                 cjk=False):
         self.width = width
-        self.cjk = cjk
         self.initial_indent = initial_indent
         self.subsequent_indent = subsequent_indent
         self.expand_tabs = expand_tabs
@@ -143,6 +143,7 @@ class TextWrapper:
         self.tabsize = tabsize
         self.max_lines = max_lines
         self.placeholder = placeholder
+        self.cjk = cjk
 
         self.len = cjklen if self.cjk else len
 

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -10,7 +10,7 @@ import re
 import unicodedata
 
 __all__ = ['TextWrapper', 'wrap', 'fill', 'dedent', 'indent', 'shorten',
-           'cjkwide', 'cjklen', 'cjkslices']
+           'cjk_wide', 'cjk_len', 'cjk_slices']
 
 # Hardcode the recognized whitespace characters to the US-ASCII
 # whitespace characters.  The main reason for doing this is that
@@ -146,7 +146,7 @@ class TextWrapper:
         self.placeholder = placeholder
         self.cjk = cjk
 
-        self._width = cjklen if self.cjk else len
+        self._width = cjk_len if self.cjk else len
 
     # -- Private methods -----------------------------------------------
     # (possibly useful for subclasses to override)
@@ -224,7 +224,7 @@ class TextWrapper:
         # of the next chunk onto the current line as will fit.
         if self.break_long_words:
             if self.cjk:
-                chunk_start, chunk_end = cjkslices(reversed_chunks[-1], space_left)
+                chunk_start, chunk_end = cjk_slices(reversed_chunks[-1], space_left)
                 cur_line.append(chunk_start)
                 reversed_chunks[-1] = chunk_end
             else:
@@ -424,31 +424,31 @@ def shorten(text, width, cjk=False, **kwargs):
 
 # -- CJK support ------------------------------------------------------
 
-def cjkwide(char):
+def cjk_wide(char):
     """Return True if char is Fullwidth or Wide, False otherwise.
     Fullwidth and Wide CJK chars are double-width.
     """
     return unicodedata.east_asian_width(char) in ('F', 'W')
 
 
-def cjklen(text):
+def cjk_len(text):
     """Return the real width of text (its len if not a string).
     """
     if not isinstance(text, str):
         return len(text)
-    return sum(2 if cjkwide(char) else 1 for char in text)
+    return sum(2 if cjk_wide(char) else 1 for char in text)
 
 
-def cjkslices(text, index):
+def cjk_slices(text, index):
     """Return the two slices of text cut to the index.
     """
     if not isinstance(text, str):
         return text[:index], text[index:]
-    if cjklen(text) <= index:
+    if cjk_len(text) <= index:
         return text, ''
     i = 1
     # <= and i-1 to catch the last double length char of odd line
-    while cjklen(text[:i]) <= index:
+    while cjk_len(text[:i]) <= index:
         i = i + 1
     return text[:i-1], text[i-1:]
 

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -146,7 +146,7 @@ class TextWrapper:
         self.placeholder = placeholder
         self.cjk = cjk
 
-        self.len = cjklen if self.cjk else len
+        self._width = cjklen if self.cjk else len
 
     # -- Private methods -----------------------------------------------
     # (possibly useful for subclasses to override)
@@ -259,7 +259,7 @@ class TextWrapper:
         lines = []
         if self.width <= 0:
             raise ValueError("invalid width %r (must be > 0)" % self.width)
-        elif self.width == 1 and (sum(self.len(chunk) for chunk in chunks) >
+        elif self.width == 1 and (sum(self._width(chunk) for chunk in chunks) >
                                   sum(len(chunk) for chunk in chunks)):
             raise ValueError("invalid width 1 (must be > 1 when CJK chars)")
         if self.max_lines is not None:
@@ -296,7 +296,7 @@ class TextWrapper:
                 del chunks[-1]
 
             while chunks:
-                l = self.len(chunks[-1])
+                l = self._width(chunks[-1])
 
                 # Can at least squeeze this chunk onto the current line.
                 if cur_len + l <= width:
@@ -309,7 +309,7 @@ class TextWrapper:
 
             # The current line is full, and the next chunk is too big to
             # fit on *any* line (not just this one).
-            if chunks and self.len(chunks[-1]) > width:
+            if chunks and self._width(chunks[-1]) > width:
                 self._handle_long_word(chunks, cur_line, cur_len, width)
                 cur_len = sum(map(len, cur_line))
 

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -446,11 +446,12 @@ def cjk_slices(text, index):
         return text[:index], text[index:]
     if cjk_len(text) <= index:
         return text, ''
-    i = 1
-    # <= and i-1 to catch the last double length char of odd line
-    while cjk_len(text[:i]) <= index:
-        i = i + 1
-    return text[:i-1], text[i-1:]
+    width = 0
+    for i, char in enumerate(text):
+        width = width + cjk_wide(char) + 1
+        if width > index:
+            break
+    return text[:i], text[i:]
 
 
 # -- Loosely related functionality -------------------------------------

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -440,7 +440,7 @@ def cjk_len(text):
 
 
 def cjk_slices(text, index):
-    """Return the two slices of text cut to the index.
+    """Return the two slices of text cut to index.
     """
     if not isinstance(text, str):
         return text[:index], text[index:]

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -6,7 +6,8 @@
 # Copyright (C) 2015-2017 Florent Gallaire <fgallaire@gmail.com>
 # Written by Greg Ward <gward@python.net>
 
-import re, unicodedata
+import re
+import unicodedata
 
 __all__ = ['TextWrapper', 'wrap', 'fill', 'dedent', 'indent', 'shorten',
            'cjkwide', 'cjklen', 'cjkslices']

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -7,7 +7,6 @@
 # Written by Greg Ward <gward@python.net>
 
 import re
-import unicodedata
 
 __all__ = ['TextWrapper', 'wrap', 'fill', 'dedent', 'indent', 'shorten',
            'cjk_wide', 'cjk_len', 'cjk_slices']
@@ -428,6 +427,7 @@ def cjk_wide(char):
     """Return True if char is Fullwidth or Wide, False otherwise.
     Fullwidth and Wide CJK chars are double-width.
     """
+    import unicodedata
     return unicodedata.east_asian_width(char) in ('F', 'W')
 
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -495,6 +495,7 @@ Lele Gaifax
 Santiago Gala
 Yitzchak Gale
 Matthew Gallagher
+Florent Gallaire
 Quentin Gallet-Gilles
 Riccardo Attilio Galli
 Raymund Galvin


### PR DESCRIPTION
* Add ckj option flag, default to False
* Add cjk_wide(), cjk_len() and cjk_slices() utilities