### PR TITLE
bpo-29557: Remove abiguous line in binhex docs

### DIFF
--- a/Doc/library/binhex.rst
+++ b/Doc/library/binhex.rst
@@ -55,5 +55,3 @@ the source for details.
 If you code or decode textfiles on non-Macintosh platforms they will still use
 the old Macintosh newline convention (carriage-return as end of line).
 
-As of this writing, :func:`hexbin` appears to not work in all cases.
-


### PR DESCRIPTION
"appears to not work in all cases" does not inspire confidence in this
module. I can find no context for what bug this was referencing so it
should be removed.

It appears this comment was from the original documentation for this function in 1995 but the commit also does not include any context regarding a bug: https://hg.python.org/cpython/rev/3911d4a89ab0#l4.40

