### PR TITLE
bpo-29556: Remove unused #include <langinfo.h>

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -87,10 +87,6 @@ corresponding Unix manual entries for more information on calls.");
 #include <sys/loadavg.h>
 #endif
 
-#ifdef HAVE_LANGINFO_H
-#include <langinfo.h>
-#endif
-
 #ifdef HAVE_SYS_SENDFILE_H
 #include <sys/sendfile.h>
 #endif

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -11,10 +11,6 @@
 
 #include <ctype.h>
 
-#ifdef HAVE_LANGINFO_H
-#include <langinfo.h>   /* CODESET */
-#endif
-
 /* The default encoding used by the platform file system APIs
    Can remain NULL for all platforms that don't have such a concept
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -25,10 +25,6 @@
 #include "malloc.h" /* for alloca */
 #endif
 
-#ifdef HAVE_LANGINFO_H
-#include <langinfo.h>
-#endif
-
 #ifdef MS_WINDOWS
 #undef BYTE
 #include "windows.h"

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -33,10 +33,6 @@ extern void *PyWin_DLLhModule;
 extern const char *PyWin_DLLVersionString;
 #endif
 
-#ifdef HAVE_LANGINFO_H
-#include <langinfo.h>
-#endif
-
 _Py_IDENTIFIER(_);
 _Py_IDENTIFIER(__sizeof__);
 _Py_IDENTIFIER(buffer);


### PR DESCRIPTION
This #include is added in b744ba1d14c5487576c95d0311e357b707600b47 (issue8610) and later the use of CODESET is removed in d64e8a75e5138d5e5970f0c70995ae5cc377c421 (issue9642).

Found this in investigating issue29436

This is a minor fix but my first patch on Github. Hope everything works :)