### PR TITLE
bpo-29534: move Misc/NEWS entry to correct section; add Misc/ACKS entry.

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1066,6 +1066,7 @@ Vilmos Nebehaj
 Fredrik Nehr
 Tony Nelson
 Trent Nelson
+Andrew Nester
 Chad Netzer
 Max Neunhöffer
 Anthon van der Neut

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,8 +10,6 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
-- bpo-29534: Fixed different behaviour of Decimal.from_float() for _decimal and _pydecimal.
-
 - bpo-29438: Fixed use-after-free problem in key sharing dict.
 
 - Issue #29319: Prevent RunMainFromImporter overwriting sys.path[0].
@@ -228,6 +226,9 @@ Extension Modules
 
 Library
 -------
+
+- bpo-29534: Fixed different behaviour of Decimal.from_float()
+  for _decimal and _pydecimal. Thanks Andrew Nester.
 
 - Issue #28556: Various updates to typing module: typing.Counter, typing.ChainMap,
   improved ABC caching, etc. Original PRs by Jelle Zijlstra, Ivan Levkivskyi,


### PR DESCRIPTION
python/cpython#65 included a Misc/NEWS entry in the wrong location. This PR fixes the location of that Misc/NEWS entry, and adds a Misc/ACKS entry for Andrew ~~Nestor~~ Nester.