### PR TITLE
Remove double definition of IPPROTO_IPV6

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7238,9 +7238,6 @@ PyInit__socket(void)
 #ifdef  IPPROTO_TP
     PyModule_AddIntMacro(m, IPPROTO_TP);
 #endif
-#ifdef  IPPROTO_IPV6
-    PyModule_AddIntMacro(m, IPPROTO_IPV6);
-#endif
 #ifdef  IPPROTO_ROUTING
     PyModule_AddIntMacro(m, IPPROTO_ROUTING);
 #endif


### PR DESCRIPTION
IPPROTO_IPV6 is already defined at [socketmodule.c#L7207](https://github.com/python/cpython/blob/b4c96dea9744f322cd871369999d24b9cdf85ca3/Modules/socketmodule.c#L7207) in the same way, this looks like a copy & paste oversight.