### PR TITLE
Only run travis tests on master and X.Y branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ group: beta
 # To cache doc-building dependencies.
 cache: pip
 
+branches:
+  only:
+    - master
+    - /^\d\.\d$/
+
 os:
   - linux
   # macOS builds are disabled as the machines are under-provisioned on Travis,


### PR DESCRIPTION
If someone pushes a branch to python/cpython and then creates a PR it will cause Travis to run tests needlessly, once for the PR and once for the push. This will limit the branches that Travis will run tests for to the `master` branch and branches that match the regex `^\d\.\d$`.

This will have the effect that if someone purposely makes another branch they won't get tests to run, but in that rare case they can adjust this themselves.

An example of a branch that was needlessly built is: https://travis-ci.org/python/cpython/builds/201709867.

This feature is documented at https://docs.travis-ci.com/user/customizing-the-build#Building-Specific-Branches.