### PR TITLE
bpo-29546: Improve from-import error message with location

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -83,6 +83,9 @@ Other Language Changes
   whitespace, not only spaces.
   (Contributed by Robert Xiao in :issue:`28927`.)
 
+* :exc:`ImportError` now displays module name and module ``__file__`` path when
+  ``from ... import ...`` fails. :issue:`29546`.
+
 
 New Modules
 ===========

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -85,6 +85,15 @@ class ImportTests(unittest.TestCase):
             from os import i_dont_exist
         self.assertEqual(cm.exception.name, 'os')
         self.assertEqual(cm.exception.path, os.__file__)
+        self.assertRegex(str(cm.exception), "cannot import name 'i_dont_exist' from 'os' \(.*/Lib/os.py\)")
+
+    def test_from_import_missing_attr_has_name_and_so_path(self):
+        import _opcode
+        with self.assertRaises(ImportError) as cm:
+            from _opcode import i_dont_exist
+        self.assertEqual(cm.exception.name, '_opcode')
+        self.assertEqual(cm.exception.path, _opcode.__file__)
+        self.assertRegex(str(cm.exception), "cannot import name 'i_dont_exist' from '_opcode' \(.*\.(so|dll)\)")
 
     def test_from_import_missing_attr_has_name(self):
         with self.assertRaises(ImportError) as cm:
@@ -365,8 +374,11 @@ class ImportTests(unittest.TestCase):
         module_name = 'test_from_import_AttributeError'
         self.addCleanup(unload, module_name)
         sys.modules[module_name] = AlwaysAttributeError()
-        with self.assertRaises(ImportError):
+        with self.assertRaises(ImportError) as cm:
             from test_from_import_AttributeError import does_not_exist
+
+        self.assertEqual(str(cm.exception),
+            "cannot import name 'does_not_exist' from '<unknown module name>' (unknown location)")
 
 
 @skip_if_dont_write_bytecode

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -21,6 +21,8 @@ Core and Builtins
 
 - bpo-29546: Set the 'path' and 'name' attribute on ImportError for ``from ... import ...``.
 
+- bpo-29546: Improve from-import error message with location
+
 - Issue #29319: Prevent RunMainFromImporter overwriting sys.path[0].
 
 - Issue #29337: Fixed possible BytesWarning when compare the code objects.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5024,6 +5024,10 @@ import_from(PyObject *v, PyObject *name)
     pkgpath = PyModule_GetFilenameObject(v);
     if (pkgname == NULL) {
         pkgname_or_unknown = PyUnicode_FromString("<unknown module name>");
+        if (pkgname_or_unknown == NULL) {
+            Py_XDECREF(pkgpath);
+            return NULL;
+        }
     } else {
         pkgname_or_unknown = pkgname;
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5009,7 +5009,6 @@ import_from(PyObject *v, PyObject *name)
         goto error;
     }
     fullmodname = PyUnicode_FromFormat("%U.%U", pkgname, name);
-    Py_DECREF(pkgname);
     if (fullmodname == NULL) {
         return NULL;
     }
@@ -5018,6 +5017,7 @@ import_from(PyObject *v, PyObject *name)
     if (x == NULL) {
         goto error;
     }
+    Py_DECREF(pkgname);
     Py_INCREF(x);
     return x;
  error:
@@ -5041,6 +5041,8 @@ import_from(PyObject *v, PyObject *name)
             pkgname, pkgpath);
     }
 
+    Py_XDECREF(pkgname_or_unknown);
+    Py_XDECREF(pkgpath);
     return NULL;
 }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4995,7 +4995,7 @@ import_from(PyObject *v, PyObject *name)
 {
     PyObject *x;
     _Py_IDENTIFIER(__name__);
-    PyObject *fullmodname, *pkgname, *pkgpath;
+    PyObject *fullmodname, *pkgname, *pkgpath, *pkgname_or_unknown;
 
     x = PyObject_GetAttr(v, name);
     if (x != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError))
@@ -5022,12 +5022,23 @@ import_from(PyObject *v, PyObject *name)
     return x;
  error:
     pkgpath = PyModule_GetFilenameObject(v);
+    if (pkgname == NULL) {
+        pkgname_or_unknown = PyUnicode_FromString("<unknown module name>");
+    } else {
+        pkgname_or_unknown = pkgname;
+    }
 
     if (pkgpath == NULL || !PyUnicode_Check(pkgpath)) {
         PyErr_Clear();
-        PyErr_SetImportError(PyUnicode_FromFormat("cannot import name %R", name), pkgname, NULL);
+        PyErr_SetImportError(
+            PyUnicode_FromFormat("cannot import name %R from %R (unknown location)",
+                name, pkgname_or_unknown),
+            pkgname, NULL);
     } else {
-        PyErr_SetImportError(PyUnicode_FromFormat("cannot import name %R", name), pkgname, pkgpath);
+        PyErr_SetImportError(
+            PyUnicode_FromFormat("cannot import name %R from %R (%S)",
+                name, pkgname_or_unknown, pkgpath),
+            pkgname, pkgpath);
     }
 
     return NULL;


### PR DESCRIPTION
Add location information like canonical module name where identifier
cannot be found and file location if available.

First iteration of this was gh-91

---- 

Testless for now, I can add tests once the exact format has been agreed upon. 