### PR TITLE
bpo-29481: add versionadded 3.6.1 to typing.Deque docs

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -574,6 +574,8 @@ The module defines the following classes, functions and decorators:
 
    A generic version of :class:`collections.deque`.
 
+   .. versionadded:: 3.6.1
+
 .. class:: List(list, MutableSequence[T])
 
    Generic version of :class:`list`.


### PR DESCRIPTION
http://bugs.python.org/issue29481

