### PR TITLE
More Travis docs build tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,17 +36,10 @@ matrix:
       env:
         - TESTING=docs
       before_script:
-        - |
-            if git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '^Doc/'
-            then
-              echo "Docs weren't updated, stopping build process."
-              exit
-            fi
-            cd Doc
-            make venv PYTHON=python3
+        - cd Doc
+        - make venv PYTHON=python3
       script:
-        - make html SPHINXBUILD="./venv/bin/python3 -m sphinx" SPHINXOPTS="-q"
-        - make check
+        - make check suspicious html PYTHON="./venv/bin/python" SPHINXBUILD="./venv/bin/sphinx-build" SPHINXOPTS="-q"
     - os: linux
       language: c
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ matrix:
         - cd Doc
         - make venv PYTHON=python3
       script:
-        - make check suspicious html PYTHON="./venv/bin/python" SPHINXBUILD="./venv/bin/sphinx-build" SPHINXOPTS="-q"
+        - make check suspicious html PYTHON="./venv/bin/python" SPHINXBUILD="./venv/bin/python -m sphinx" SPHINXOPTS="-q"
     - os: linux
       language: c
       compiler: clang


### PR DESCRIPTION
- Return to always building the docs, it's a relatively cheap operation, the check is currently flawed (see GH-104, where the docs build was not run on a `Doc/`-only change; the `grep` call should not have `-v`), and the docs build is affected by at least `Misc/NEWS` as well as `Doc/`.
- Add `make suspicious`
- Do all three checks as one `make check suspicious html` invocation for
  earliest possible exit in case of issues.