### PR TITLE
bpo-29553: Fixed ArgumentParses format_usage for mutually exclusive groups

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -401,13 +401,19 @@ class HelpFormatter(object):
                             inserts[start] += ' ['
                         else:
                             inserts[start] = '['
-                        inserts[end] = ']'
+                        if end in inserts:
+                            inserts[end] += ']'
+                        else:
+                            inserts[end] = ']'
                     else:
                         if start in inserts:
                             inserts[start] += ' ('
                         else:
                             inserts[start] = '('
-                        inserts[end] = ')'
+                        if end in inserts:
+                            inserts[end] += ')'
+                        else:
+                            inserts[end] = ')'
                     for i in range(start + 1, end):
                         inserts[i] = '|'
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2725,34 +2725,42 @@ class TestMutuallyExclusiveOptionalsAndPositionalsMixed(MEMixin, TestCase):
           -c          c help
         '''
 
-class TestMutuallyExclusiveNested(TestCase):
-    def test_format_usage(self):
+class TestMutuallyExclusiveNested(MEMixin, TestCase):
+    def get_parser(self, required):
         parser = ErrorRaisingArgumentParser(prog='PROG')
-        group = parser.add_mutually_exclusive_group()
+        group = parser.add_mutually_exclusive_group(required=required)
         group.add_argument('-a')
         group.add_argument('-b')
-        group2 = group.add_mutually_exclusive_group()
+        group2 = group.add_mutually_exclusive_group(required=required)
         group2.add_argument('-c')
         group2.add_argument('-d')
-        group3 = group2.add_mutually_exclusive_group()
+        group3 = group2.add_mutually_exclusive_group(required=required)
         group3.add_argument('-e')
         group3.add_argument('-f')
-        self.assertEqual(parser.format_usage(),
-                         'usage: PROG [-h] [-a A | -b B | [-c C | -d D | [-e E | -f F]]]\n')
+        return parser
 
-    def test_format_usage_required(self):
-        parser = ErrorRaisingArgumentParser(prog='PROG')
-        group = parser.add_mutually_exclusive_group(required=True)
-        group.add_argument('-a')
-        group.add_argument('-b')
-        group2 = group.add_mutually_exclusive_group(required=True)
-        group2.add_argument('-c')
-        group2.add_argument('-d')
-        group3 = group2.add_mutually_exclusive_group(required=True)
-        group3.add_argument('-e')
-        group3.add_argument('-f')
-        self.assertEqual(parser.format_usage(),
-                         'usage: PROG [-h] (-a A | -b B | (-c C | -d D | (-e E | -f F)))\n')
+    failures = []
+    successes = []
+    successes_when_not_required = []
+
+    usage_when_not_required = '''\
+        usage: PROG [-h] [-a A | -b B | [-c C | -d D | [-e E | -f F]]]
+        '''
+    usage_when_required = '''\
+        usage: PROG [-h] (-a A | -b B | (-c C | -d D | (-e E | -f F)))
+        '''
+
+    help = '''\
+
+        optional arguments:
+          -h, --help  show this help message and exit
+          -a A
+          -b B
+          -c C
+          -d D
+          -e E
+          -f F
+        '''
 
 # =================================================
 # Mutually exclusive group in parent parser tests

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2725,6 +2725,35 @@ class TestMutuallyExclusiveOptionalsAndPositionalsMixed(MEMixin, TestCase):
           -c          c help
         '''
 
+class TestMutuallyExclusiveNested(TestCase):
+    def test_format_usage(self):
+        parser = ErrorRaisingArgumentParser(prog='PROG')
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument('-a')
+        group.add_argument('-b')
+        group2 = group.add_mutually_exclusive_group()
+        group2.add_argument('-c')
+        group2.add_argument('-d')
+        group3 = group2.add_mutually_exclusive_group()
+        group3.add_argument('-e')
+        group3.add_argument('-f')
+        self.assertEqual(parser.format_usage(),
+                         'usage: PROG [-h] [-a A | -b B | [-c C | -d D | [-e E | -f F]]]\n')
+
+    def test_format_usage_required(self):
+        parser = ErrorRaisingArgumentParser(prog='PROG')
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('-a')
+        group.add_argument('-b')
+        group2 = group.add_mutually_exclusive_group(required=True)
+        group2.add_argument('-c')
+        group2.add_argument('-d')
+        group3 = group2.add_mutually_exclusive_group(required=True)
+        group3.add_argument('-e')
+        group3.add_argument('-f')
+        self.assertEqual(parser.format_usage(),
+                         'usage: PROG [-h] (-a A | -b B | (-c C | -d D | (-e E | -f F)))\n')
+
 # =================================================
 # Mutually exclusive group in parent parser tests
 # =================================================

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -228,6 +228,7 @@ Extension Modules
 
 Library
 -------
+- bpo-29553: Fixed ArgumentParses format_usage for mutually exclusive groups.
 
 - bpo-29576: Improve some deprecations in importlib. Some deprecated methods
   now emit DeprecationWarnings and have better descriptive messages.


### PR DESCRIPTION
Fix for https://bugs.python.org/issue29553