### PR TITLE
bpo-29567: Allow argparse to be used in setup.py

### DIFF
--- a/Lib/gettext.py
+++ b/Lib/gettext.py
@@ -46,7 +46,7 @@ internationalized, to the local language and cultural habits.
 #   find this format documented anywhere.
 
 
-import locale, copy, io, os, re, struct, sys
+import locale, copy, io, os, re, sys
 from errno import ENOENT
 
 
@@ -328,7 +328,7 @@ class GNUTranslations(NullTranslations):
 
     def _parse(self, fp):
         """Override this method to support alternative .mo formats."""
-        unpack = struct.unpack
+        from struct import unpack
         filename = getattr(fp, 'name', '')
         # Parse the .mo file header, which consists of 5 little endian 32
         # bit words.


### PR DESCRIPTION
https://bugs.python.org/issue29567