### PR TITLE
Alternarive for bpo-29553 - Fixed ArgumentParses format_usage for mutually exclusive groups

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -396,18 +396,19 @@ class HelpFormatter(object):
                 if actions[start:end] == group._group_actions:
                     for action in group._group_actions:
                         group_actions.add(action)
-                    if not group.required:
-                        if start in inserts:
-                            inserts[start] += ' ['
+                    if not isinstance(group._container, _MutuallyExclusiveGroup):
+                        if not group.required:
+                            if start in inserts:
+                                inserts[start] += ' ['
+                            else:
+                                inserts[start] = '['
+                            inserts[end] = ']'
                         else:
-                            inserts[start] = '['
-                        inserts[end] = ']'
-                    else:
-                        if start in inserts:
-                            inserts[start] += ' ('
-                        else:
-                            inserts[start] = '('
-                        inserts[end] = ')'
+                            if start in inserts:
+                                inserts[start] += ' ('
+                            else:
+                                inserts[start] = '('
+                            inserts[end] = ')'
                     for i in range(start + 1, end):
                         inserts[i] = '|'
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2726,34 +2726,43 @@ class TestMutuallyExclusiveOptionalsAndPositionalsMixed(MEMixin, TestCase):
         '''
 
 
-class TestMutuallyExclusiveNested(TestCase):
-    def test_format_usage(self):
+class TestMutuallyExclusiveNested(MEMixin, TestCase):
+    def get_parser(self, required):
         parser = ErrorRaisingArgumentParser(prog='PROG')
-        group = parser.add_mutually_exclusive_group()
+        group = parser.add_mutually_exclusive_group(required=required)
         group.add_argument('-a')
         group.add_argument('-b')
-        group2 = group.add_mutually_exclusive_group()
+        group2 = group.add_mutually_exclusive_group(required=required)
         group2.add_argument('-c')
         group2.add_argument('-d')
-        group3 = group2.add_mutually_exclusive_group()
+        group3 = group2.add_mutually_exclusive_group(required=required)
         group3.add_argument('-e')
         group3.add_argument('-f')
-        self.assertEqual(parser.format_usage(),
-                         'usage: PROG [-h] [-a A | -b B | -c C | -d D | -e E | -f F]\n')
+        return parser
 
-    def test_format_usage_required(self):
-        parser = ErrorRaisingArgumentParser(prog='PROG')
-        group = parser.add_mutually_exclusive_group(required=True)
-        group.add_argument('-a')
-        group.add_argument('-b')
-        group2 = group.add_mutually_exclusive_group(required=True)
-        group2.add_argument('-c')
-        group2.add_argument('-d')
-        group3 = group2.add_mutually_exclusive_group(required=True)
-        group3.add_argument('-e')
-        group3.add_argument('-f')
-        self.assertEqual(parser.format_usage(),
-                         'usage: PROG [-h] (-a A | -b B | -c C | -d D | -e E | -f F)\n')
+    failures = []
+    successes = []
+    successes_when_not_required = []
+
+    usage_when_not_required = '''\
+        usage: PROG [-h] [-a A | -b B | -c C | -d D | -e E | -f F]
+        '''
+    usage_when_required = '''\
+        usage: PROG [-h] (-a A | -b B | -c C | -d D | -e E | -f F)
+        '''
+
+    help = '''\
+
+        optional arguments:
+          -h, --help  show this help message and exit
+          -a A
+          -b B
+          -c C
+          -d D
+          -e E
+          -f F
+        '''
+
 # =================================================
 # Mutually exclusive group in parent parser tests
 # =================================================

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2362,6 +2362,26 @@ class TestMutuallyExclusiveGroupErrors(TestCase):
               '''
         self.assertEqual(parser.format_help(), textwrap.dedent(expected))
 
+    def test_help_required(self):
+        parser = ErrorRaisingArgumentParser(prog='PROG')
+        group1 = parser.add_mutually_exclusive_group(required=True)
+        group1.add_argument('--foo', action='store_true')
+        group1.add_argument('--bar', action='store_false')
+        group2 = parser.add_mutually_exclusive_group(required=True)
+        group2.add_argument('--soup', action='store_true')
+        group2.add_argument('--nuts', action='store_false')
+        expected = '''\
+            usage: PROG [-h] (--foo | --bar) (--soup | --nuts)
+
+            optional arguments:
+              -h, --help  show this help message and exit
+              --foo
+              --bar
+              --soup
+              --nuts
+              '''
+        self.assertEqual(parser.format_help(), textwrap.dedent(expected))
+
 class MEMixin(object):
 
     def test_failures_when_not_required(self):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2725,6 +2725,35 @@ class TestMutuallyExclusiveOptionalsAndPositionalsMixed(MEMixin, TestCase):
           -c          c help
         '''
 
+
+class TestMutuallyExclusiveNested(TestCase):
+    def test_format_usage(self):
+        parser = ErrorRaisingArgumentParser(prog='PROG')
+        group = parser.add_mutually_exclusive_group()
+        group.add_argument('-a')
+        group.add_argument('-b')
+        group2 = group.add_mutually_exclusive_group()
+        group2.add_argument('-c')
+        group2.add_argument('-d')
+        group3 = group2.add_mutually_exclusive_group()
+        group3.add_argument('-e')
+        group3.add_argument('-f')
+        self.assertEqual(parser.format_usage(),
+                         'usage: PROG [-h] [-a A | -b B | -c C | -d D | -e E | -f F]\n')
+
+    def test_format_usage_required(self):
+        parser = ErrorRaisingArgumentParser(prog='PROG')
+        group = parser.add_mutually_exclusive_group(required=True)
+        group.add_argument('-a')
+        group.add_argument('-b')
+        group2 = group.add_mutually_exclusive_group(required=True)
+        group2.add_argument('-c')
+        group2.add_argument('-d')
+        group3 = group2.add_mutually_exclusive_group(required=True)
+        group3.add_argument('-e')
+        group3.add_argument('-f')
+        self.assertEqual(parser.format_usage(),
+                         'usage: PROG [-h] (-a A | -b B | -c C | -d D | -e E | -f F)\n')
 # =================================================
 # Mutually exclusive group in parent parser tests
 # =================================================

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -252,6 +252,8 @@ Library
 - bpo-29576: Improve some deprecations in importlib. Some deprecated methods
   now emit DeprecationWarnings and have better descriptive messages.
 
+- bpo-29553: Fixed ArgumentParses format_usage for mutually exclusive groups.
+
 - bpo-29534: Fixed different behaviour of Decimal.from_float()
   for _decimal and _pydecimal. Thanks Andrew Nester.
 


### PR DESCRIPTION
Fix for https://bugs.python.org/issue29553
Alternative to https://github.com/python/cpython/pull/117 
This alternative advised by Christoph Stahl and Brian Curtin