### PR TITLE
bpo-29569: threading.Timer class: Continue periodical execution till action return True

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -832,9 +832,9 @@ Timer Objects
 -------------
 
 This class represents an action that should be run after a certain amount
-of time has passed --- a timer. It also can run periodically: each run happens
-after specified time that passed since previous run until the action returns True.
-:class:`Timer` is a subclass of :class:`Thread`
+of time has passed --- a timer. It also can run periodically. Each run takes
+place after a specified time after the previous run. This continues until
+the action returns TRUE. :class:`Timer` is a subclass of :class:`Thread`
 and as such also functions as an example of creating custom threads.
 
 Timers are started, as with threads, by calling their :meth:`~Timer.start`
@@ -842,7 +842,7 @@ method.  The timer can be stopped (before its action has begun) by calling the
 :meth:`~Timer.cancel` method.  If action has returned True then next run is
 scheduled after the timer interval. The interval the timer will wait before
 executing its action may not be exactly the same as the interval specified
-by the user. 
+by the user.
 
 
 For example::
@@ -858,14 +858,12 @@ For example::
    t = Timer(1.0, star)
    t.start()  # it prints five "*" with 1 sec waiting between prints
 
-   
-
 
 .. class:: Timer(interval, function, args=None, kwargs=None)
 
    Create a timer that will run *function* with arguments *args* and  keyword
    arguments *kwargs*, after *interval* seconds have passed and continues
-   periodically run *function* until *function* returns True.
+   periodically run *function* till *function* returns True.
    If *args* is ``None`` (the default) then an empty list will be used.
    If *kwargs* is ``None`` (the default) then an empty dict will be used.
 

--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -831,29 +831,41 @@ method.  The :meth:`~Event.wait` method blocks until the flag is true.
 Timer Objects
 -------------
 
-This class represents an action that should be run only after a certain amount
-of time has passed --- a timer.  :class:`Timer` is a subclass of :class:`Thread`
+This class represents an action that should be run after a certain amount
+of time has passed --- a timer. It also can run periodically: each run happens
+after specified time that passed since previous run until the action returns True.
+:class:`Timer` is a subclass of :class:`Thread`
 and as such also functions as an example of creating custom threads.
 
 Timers are started, as with threads, by calling their :meth:`~Timer.start`
 method.  The timer can be stopped (before its action has begun) by calling the
-:meth:`~Timer.cancel` method.  The interval the timer will wait before
-executing its action may not be exactly the same as the interval specified by
-the user.
+:meth:`~Timer.cancel` method.  If action has returned True then next run is
+scheduled after the timer interval. The interval the timer will wait before
+executing its action may not be exactly the same as the interval specified
+by the user. 
+
 
 For example::
 
-   def hello():
-       print("hello, world")
+   def star():
+       global cnt
+       print("*")
+       cnt -= 1
+       if cnt > 0:
+           return True
 
-   t = Timer(30.0, hello)
-   t.start()  # after 30 seconds, "hello, world" will be printed
+   cnt = 5
+   t = Timer(1.0, star)
+   t.start()  # it prints five "*" with 1 sec waiting between prints
+
+   
 
 
 .. class:: Timer(interval, function, args=None, kwargs=None)
 
    Create a timer that will run *function* with arguments *args* and  keyword
-   arguments *kwargs*, after *interval* seconds have passed.
+   arguments *kwargs*, after *interval* seconds have passed and continues
+   periodically run *function* until *function* returns True.
    If *args* is ``None`` (the default) then an empty list will be used.
    If *kwargs* is ``None`` (the default) then an empty dict will be used.
 

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1067,6 +1067,7 @@ class TimerTests(BaseTestCase):
     def setUp(self):
         BaseTestCase.setUp(self)
         self.callback_args = []
+        self.callback_cnt = 3
         self.callback_event = threading.Event()
 
     def test_init_immutable_default_args(self):
@@ -1081,12 +1082,19 @@ class TimerTests(BaseTestCase):
         timer2 = threading.Timer(0.01, self._callback_spy)
         timer2.start()
         self.callback_event.wait()
-        self.assertEqual(len(self.callback_args), 2)
-        self.assertEqual(self.callback_args, [((), {}), ((), {})])
+
+    def test_continuous_execution(self):
+        timer = threading.Timer(0.01, self._callback_cont)
+        self.callback_event.wait(0.1)
+        self.assertEqual(self.callback_cnt, 0)
 
     def _callback_spy(self, *args, **kwargs):
         self.callback_args.append((args[:], kwargs.copy()))
         self.callback_event.set()
+
+    def _callback_cont(self):
+        self.callback_cnt -= 1
+        return self.callback_cnt > 0
 
 class LockTests(lock_tests.LockTests):
     locktype = staticmethod(threading.Lock)

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1085,7 +1085,11 @@ class TimerTests(BaseTestCase):
 
     def test_continuous_execution(self):
         timer = threading.Timer(0.01, self._callback_cont)
-        self.callback_event.wait(0.1)
+        self.callback_event.clear()
+        timer.start()
+        for i in range(3):
+            self.callback_event.wait(1)
+            self.callback_event.clear()
         self.assertEqual(self.callback_cnt, 0)
 
     def _callback_spy(self, *args, **kwargs):
@@ -1094,6 +1098,7 @@ class TimerTests(BaseTestCase):
 
     def _callback_cont(self):
         self.callback_cnt -= 1
+        self.callback_event.set()
         return self.callback_cnt > 0
 
 class LockTests(lock_tests.LockTests):

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1088,6 +1088,7 @@ class TimerTests(BaseTestCase):
     def _callback_spy(self, *args, **kwargs):
         self.callback_args.append((args[:], kwargs.copy()))
         self.callback_event.set()
+        self.assertEqual(self.callback_event.is_set(), True)
 
     def test_continuous_execution(self):
         timer1 = threading.Timer(0.01, self._callback_cont)
@@ -1108,6 +1109,7 @@ class TimerTests(BaseTestCase):
     def _callback_cont(self):
         self.callback_cnt -= 1
         self.callback_event.set()
+        self.assertEqual(self.callback_event.is_set(), True)
         return self.callback_cnt > 0
 
 class LockTests(lock_tests.LockTests):

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1082,19 +1082,28 @@ class TimerTests(BaseTestCase):
         timer2 = threading.Timer(0.01, self._callback_spy)
         timer2.start()
         self.callback_event.wait()
-
-    def test_continuous_execution(self):
-        timer = threading.Timer(0.01, self._callback_cont)
-        self.callback_event.clear()
-        timer.start()
-        for i in range(3):
-            self.callback_event.wait(1)
-            self.callback_event.clear()
-        self.assertEqual(self.callback_cnt, 0)
+        self.assertEqual(len(self.callback_args), 2)
+        self.assertEqual(self.callback_args, [((), {}), ((), {})])
 
     def _callback_spy(self, *args, **kwargs):
         self.callback_args.append((args[:], kwargs.copy()))
         self.callback_event.set()
+
+    def test_continuous_execution(self):
+        timer1 = threading.Timer(0.01, self._callback_cont)
+        self.callback_event.clear()
+        timer1.start()
+        for i in range(3):
+            self.callback_event.wait(1.0)
+            self.callback_event.clear()
+        self.assertEqual(self.callback_cnt, 0)
+        self.callback_cnt = 3
+        timer2 = threading.Timer(0.5, self._callback_cont)
+        self.callback_event.clear()
+        timer2.start()
+        timer2.cancel()
+        timer2.join(2.0)
+        self.assertEqual(self.callback_cnt, 3)
 
     def _callback_cont(self):
         self.callback_cnt -= 1

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1177,7 +1177,7 @@ class Timer(Thread):
         self.finished.set()
 
     def run(self):
-        """Continue execution after wait until function returns True"""
+        """Continue execution after wait till function returns True"""
         while(not self.finished.wait(self.interval)):
             if not self.function(*self.args, **self.kwargs):
                 break

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1177,9 +1177,10 @@ class Timer(Thread):
         self.finished.set()
 
     def run(self):
-        self.finished.wait(self.interval)
-        if not self.finished.is_set():
-            self.function(*self.args, **self.kwargs)
+        """Continue execution after wait until function returns True"""
+        while(not self.finished.wait(self.interval)):
+            if not self.function(*self.args, **self.kwargs):
+                break
         self.finished.set()
 
 # Special thread class to represent the main thread


### PR DESCRIPTION
I think that functionality of threading.Timer class can be easily extended to generate the sequence of runs with specified period. The idea comes from the GLib.timeout_add function. 
 
http://bugs.python.org/issue29569

As most current CB functions that are used in Timer returns nothing (None) they will run only once as earlier. Only functions that returns True will continue their periodical execution. 

There are two ways to stop such continues execution:
- Return something that is not True from action function,
- Call cancel method of Timer class.   

It is my first contribution and I kindly ask to help me with required future actions.

Thanks