### PR TITLE
bpo-28334: fix netrc not working when $HOME is not set

### DIFF
--- a/Doc/library/netrc.rst
+++ b/Doc/library/netrc.rst
@@ -20,8 +20,9 @@ the Unix :program:`ftp` program and other FTP clients.
 
    A :class:`~netrc.netrc` instance or subclass instance encapsulates data from  a netrc
    file.  The initialization argument, if present, specifies the file to parse.  If
-   no argument is given, the file :file:`.netrc` in the user's home directory will
-   be read.  Parse errors will raise :exc:`NetrcParseError` with diagnostic
+   no argument is given, the file :file:`.netrc` in the user's home directory --
+   as determined by :func:`os.path.expanduser` -- will be read.
+   Parse errors will raise :exc:`NetrcParseError` with diagnostic
    information including the file name, line number, and terminating token.
    If no argument is specified on a POSIX system, the presence of passwords in
    the :file:`.netrc` file will raise a :exc:`NetrcParseError` if the file
@@ -31,6 +32,10 @@ the Unix :program:`ftp` program and other FTP clients.
    programs that use :file:`.netrc`.
 
    .. versionchanged:: 3.4 Added the POSIX permission check.
+
+   .. versionchanged:: 3.7
+      Now uses :func:`os.path.expanduser` to find the location of the
+      :file:`.netrc` file when *file* is not passed as argument.
 
 
 .. exception:: NetrcParseError
@@ -82,4 +87,3 @@ Instances of :class:`~netrc.netrc` have public instance variables:
    punctuation is allowed in passwords, however, note that whitespace and
    non-printable characters are not allowed in passwords.  This is a limitation
    of the way the .netrc file is parsed and may be removed in the future.
-

--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -23,10 +23,7 @@ class netrc:
     def __init__(self, file=None):
         default_netrc = file is None
         if file is None:
-            try:
-                file = os.path.join(os.environ['HOME'], ".netrc")
-            except KeyError:
-                raise OSError("Could not find .netrc: $HOME is not set") from None
+            file = os.path.join(os.path.expanduser("~"), ".netrc")
         self.hosts = {}
         self.macros = {}
         with open(file) as fp:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1031,6 +1031,7 @@ Bill van Melle
 Lucas Prado Melo
 Ezio Melotti
 Doug Mennella
+Dimitri Merejkowsky
 Brian Merrell
 Alexis Métaireau
 Luke Mewburn

--- a/Misc/NEWS.d/next/Library/2017-11-24-11-50-41.bpo-28334.3gGGlt.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-24-11-50-41.bpo-28334.3gGGlt.rst
@@ -1,0 +1,3 @@
+Use :func:`os.path.expanduser` to find the ``~/.netrc`` file in
+:class:`netrc.netrc`.  If the file does not exist, a
+:exc:`FileNotFoundError` is raised.  Patch by Dimitri Merejkowsky.


### PR DESCRIPTION


<!-- issue-number: bpo-28334 -->
https://bugs.python.org/issue28334
<!-- /issue-number -->
