### PR TITLE
Doc/Makefile: set PYTHON to python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ matrix:
         - TESTING=docs
       before_script:
         - cd Doc
-        - make venv PYTHON=python3
+        - make venv
       script:
         - make check suspicious html PYTHON="./venv/bin/python" SPHINXBUILD="./venv/bin/python -m sphinx" SPHINXOPTS="-q"
     - os: linux

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -4,7 +4,7 @@
 #
 
 # You can set these variables from the command line.
-PYTHON       = python
+PYTHON       = python3
 SPHINXBUILD  = sphinx-build
 PAPER        =
 SOURCES      =


### PR DESCRIPTION
rstlint.py run by "make check" doesn't support Python 2.

"make venv" runs "$(PYTHON) -m venv", whereas Python 2 doens't
provide the venv module: it's a module of Python 3 standard library.