### PR TITLE
 Backport35 doc fixes: PR#68 and PR#124 #125 

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -4,7 +4,7 @@
 #
 
 # You can set these variables from the command line.
-PYTHON       = python
+PYTHON       = python3
 SPHINXBUILD  = sphinx-build
 PAPER        =
 SOURCES      =

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -300,9 +300,9 @@ this respect, and is easily configured to use spaces: Take :menuselection:`Tools
 --> Options --> Tabs`, and for file type "Default" set "Tab size" and "Indent
 size" to 4, and select the "Insert spaces" radio button.
 
-Python raises :exc:`IndentationError` or :exc:`TabError` if mixed tabs 
+Python raises :exc:`IndentationError` or :exc:`TabError` if mixed tabs
 and spaces are causing problems in leading whitespace.
-You may also run the :mod:`tabnanny` module to check a directory tree 
+You may also run the :mod:`tabnanny` module to check a directory tree
 in batch mode.
 
 


### PR DESCRIPTION
Fix "make -C Doc check": backport two fixes.

PR #125 was the backport for 3.6.