### PR TITLE
reinit the TLS before anything else

### DIFF
--- a/Parser/intrcheck.c
+++ b/Parser/intrcheck.c
@@ -172,7 +172,7 @@ void
 PyOS_AfterFork(void)
 {
 #ifdef WITH_THREAD
-    PyEval_ReInitThreads();
     PyThread_ReInitTLS();
+    PyEval_ReInitThreads();
 #endif
 }


### PR DESCRIPTION
PyEval_ReInitThread can run arbitrary Python code, which really ought to have
the TLS properly initialized. This essentially backports the Python 3 ordering.