### PR TITLE
bpo-29573: Fixed unlinking already removed NamedTemporaryFile.

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -442,7 +442,7 @@ class _TemporaryFileCloser:
                 try:
                     self.file.close()
                 finally:
-                    if self.delete:
+                    if self.delete and _os.path.isfile(self.name):
                         unlink(self.name)
 
         # Need to ensure the file is deleted on __del__

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -957,6 +957,13 @@ class TestNamedTemporaryFile(BaseTestCase):
             tempfile.NamedTemporaryFile(mode=2, dir=dir)
         self.assertEqual(os.listdir(dir), [])
 
+    def test_if_temp_file_already_removed(self):
+        tmpdir = tempfile.mkdtemp()
+        self.addCleanup(support.rmtree, tmpdir)
+        with tempfile.NamedTemporaryFile(delete=True, dir=tmpdir) as fp:
+            os.system('rm {}'.format(fp.name))
+        self.assertEqual(os.listdir(tmpdir), [])
+
     # How to test the mode and bufsize parameters?
 
 class TestSpooledTemporaryFile(BaseTestCase):


### PR DESCRIPTION
Fix for http://bugs.python.org/issue29573

<!-- issue-number: bpo-29573 -->
https://bugs.python.org/issue29573
<!-- /issue-number -->
