### PR TITLE
bpo-28787: Fix out of tree --with-dtrace builds

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -872,6 +872,7 @@ Python/frozen.o: $(srcdir)/Python/importlib.h $(srcdir)/Python/importlib_externa
 # follow our naming conventions. dtrace(1) uses the output filename to generate
 # an include guard, so we can't use a pipeline to transform its output.
 Include/pydtrace_probes.h: $(srcdir)/Include/pydtrace.d
+	@$(MKDIR_P) Include
 	$(DTRACE) $(DFLAGS) -o $@ -h -s $<
 	: sed in-place edit with POSIX-only tools
 	sed 's/PYTHON_/PyDTrace_/' $@ > $@.tmp

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -872,7 +872,7 @@ Python/frozen.o: $(srcdir)/Python/importlib.h $(srcdir)/Python/importlib_externa
 # follow our naming conventions. dtrace(1) uses the output filename to generate
 # an include guard, so we can't use a pipeline to transform its output.
 Include/pydtrace_probes.h: $(srcdir)/Include/pydtrace.d
-	@$(MKDIR_P) Include
+	$(MKDIR_P) Include
 	$(DTRACE) $(DFLAGS) -o $@ -h -s $<
 	: sed in-place edit with POSIX-only tools
 	sed 's/PYTHON_/PyDTrace_/' $@ > $@.tmp

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1487,6 +1487,7 @@ Daniel Stokes
 Michael Stone
 Serhiy Storchaka
 Ken Stox
+Charalampos Stratakis
 Dan Stromberg
 Donald Stufft
 Daniel Stutzbach

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -1039,6 +1039,9 @@ Documentation
 Build
 -----
 
+- bpo-28787: Fix out-of-tree builds of Python when configured with
+  ``--with--dtrace``.
+
 - bpo-29243: Prevent unnecessary rebuilding of Python during ``make test``,
   ``make install`` and some other make targets when configured with
   ``--enable-optimizations``.


### PR DESCRIPTION
Issue reported at: https://bugs.python.org/issue28787

This was observed after DTrace and Systemtap support was introduced for Python 3.6.0: https://bugs.python.org/issue21590