### PR TITLE
bpo-29919: Remove unused imports found by pyflakes

### DIFF
--- a/Lib/gettext.py
+++ b/Lib/gettext.py
@@ -46,7 +46,12 @@ internationalized, to the local language and cultural habits.
 #   find this format documented anywhere.
 
 
-import locale, copy, io, os, re, struct, sys
+import copy
+import locale
+import os
+import re
+import struct
+import sys
 from errno import ENOENT
 
 

--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -29,7 +29,7 @@ from configparser import ConfigParser
 import os
 import sys
 
-from tkinter.font import Font, nametofont
+from tkinter.font import Font
 
 class InvalidConfigType(Exception): pass
 class InvalidConfigSet(Exception): pass

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -26,7 +26,6 @@ from idlelib import pyparse
 from idlelib import query
 from idlelib import replace
 from idlelib import search
-from idlelib import textview
 from idlelib import windows
 
 # The default tab setting for a Text widget, in average-width characters.

--- a/Lib/idlelib/idle_test/test_config.py
+++ b/Lib/idlelib/idle_test/test_config.py
@@ -3,9 +3,7 @@
 Much is tested by opening config dialog live or in test_configdialog.
 Coverage: 27%
 '''
-from sys import modules
 from test.support import captured_stderr
-from tkinter import Tk
 import unittest
 from idlelib import config
 

--- a/Lib/idlelib/idle_test/test_config_key.py
+++ b/Lib/idlelib/idle_test/test_config_key.py
@@ -6,7 +6,7 @@ from idlelib import config_key
 from test.support import requires
 requires('gui')
 import unittest
-from tkinter import Tk, Text
+from tkinter import Tk
 
 
 class GetKeysTest(unittest.TestCase):

--- a/Lib/idlelib/idle_test/test_editor.py
+++ b/Lib/idlelib/idle_test/test_editor.py
@@ -1,7 +1,5 @@
 import unittest
-from tkinter import Tk, Text
 from idlelib.editor import EditorWindow
-from test.support import requires
 
 class Editor_func_test(unittest.TestCase):
     def test_filename_to_unicode(self):

--- a/Lib/idlelib/idle_test/test_searchbase.py
+++ b/Lib/idlelib/idle_test/test_searchbase.py
@@ -5,7 +5,7 @@ testing skipping of suite when self.needwrapbutton is false.
 '''
 import unittest
 from test.support import requires
-from tkinter import Tk, Toplevel, Frame ##, BooleanVar, StringVar
+from tkinter import Tk, Frame  ##, BooleanVar, StringVar
 from idlelib import searchengine as se
 from idlelib import searchbase as sdb
 from idlelib.idle_test.mock_idle import Func

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -19,7 +19,6 @@ if TkVersion < 8.5:
 
 from code import InteractiveInterpreter
 import getopt
-import io
 import linecache
 import os
 import os.path

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -24,7 +24,7 @@ import importlib
 import os
 from sys import executable, platform  # Platform is set for one test.
 
-from tkinter import Toplevel, StringVar, W, E, N, S
+from tkinter import Toplevel, StringVar, W, E, S
 from tkinter.ttk import Frame, Button, Entry, Label
 from tkinter import filedialog
 from tkinter.font import Font

--- a/Lib/lib2to3/pgen2/grammar.py
+++ b/Lib/lib2to3/pgen2/grammar.py
@@ -17,7 +17,7 @@ import collections
 import pickle
 
 # Local imports
-from . import token, tokenize
+from . import token
 
 
 class Grammar(object):

--- a/Lib/multiprocessing/reduction.py
+++ b/Lib/multiprocessing/reduction.py
@@ -7,7 +7,7 @@
 # Licensed to PSF under a Contributor Agreement.
 #
 
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 import copyreg
 import functools
 import io

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -7,7 +7,6 @@ import posixpath
 import re
 import sys
 from collections import Sequence
-from contextlib import contextmanager
 from errno import EINVAL, ENOENT, ENOTDIR
 from operator import attrgetter
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO

--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -83,13 +83,12 @@ __all__ = [ 'StatisticsError',
           ]
 
 import collections
-import decimal
 import math
 import numbers
 
 from fractions import Fraction
 from decimal import Decimal
-from itertools import groupby, chain
+from itertools import groupby
 from bisect import bisect_left, bisect_right
 
 

--- a/Lib/test/ssl_servers.py
+++ b/Lib/test/ssl_servers.py
@@ -2,7 +2,6 @@ import os
 import sys
 import ssl
 import pprint
-import socket
 import urllib.parse
 # Rename HTTPServer to _HTTPServer so as to avoid confusion with HTTPSServer.
 from http.server import (HTTPServer as _HTTPServer,

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -4,7 +4,6 @@
 """Unit tests for abc.py."""
 
 import unittest
-from test import support
 
 import abc
 from inspect import isabstract

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -2,8 +2,6 @@ import inspect
 import types
 import unittest
 
-from unittest import mock
-
 from test.support import import_module
 asyncio = import_module("asyncio")
 

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -1,6 +1,5 @@
 """Tests support for new syntax introduced by PEP 492."""
 
-import collections.abc
 import types
 import unittest
 

--- a/Lib/test/test_binop.py
+++ b/Lib/test/test_binop.py
@@ -1,7 +1,6 @@
 """Tests for binary operators on subtypes of built-in types."""
 
 import unittest
-from test import support
 from operator import eq, le, ne
 from abc import ABCMeta
 

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -18,7 +18,7 @@ import types
 import unittest
 import warnings
 from operator import neg
-from test.support import TESTFN, unlink,  run_unittest, check_warnings
+from test.support import TESTFN, unlink, check_warnings
 from test.support.script_helper import assert_python_ok
 try:
     import pty, signal

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -3,7 +3,6 @@
 import collections
 import copy
 import doctest
-import inspect
 import keyword
 import operator
 import pickle

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -34,7 +34,7 @@ import numbers
 import locale
 from test.support import (run_unittest, run_doctest, is_resource_enabled,
                           requires_IEEE_754, requires_docstrings)
-from test.support import (check_warnings, import_fresh_module, TestFailed,
+from test.support import (import_fresh_module, TestFailed,
                           run_with_locale, cpython_only)
 import random
 import inspect
@@ -1170,7 +1170,6 @@ class FormatTest(unittest.TestCase):
     @run_with_locale('LC_ALL', 'ps_AF')
     def test_wide_char_separator_decimal_point(self):
         # locale with wide char separator and decimal point
-        import locale
         Decimal = self.decimal.Decimal
 
         decimal_point = locale.localeconv()['decimal_point']

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -5,7 +5,6 @@ import gc
 import weakref
 import copy
 import pickle
-from io import StringIO
 import random
 import struct
 

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -6,7 +6,6 @@ import unittest
 import warnings
 import weakref
 import inspect
-import types
 
 from test import support
 

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -1,11 +1,11 @@
 # Simple test suite for http/cookies.py
 
 import copy
-from test.support import run_unittest, run_doctest, check_warnings
+from test.support import run_unittest, run_doctest
 import unittest
 from http import cookies
 import pickle
-import warnings
+
 
 class CookieTests(unittest.TestCase):
 

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -10,7 +10,6 @@ import os.path
 import socketserver
 import time
 import calendar
-import inspect
 
 from test.support import (reap_threads, verbose, transient_internet,
                           run_with_tz, run_with_locale)

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -1,5 +1,5 @@
 import decimal
-from io import StringIO, BytesIO
+from io import StringIO
 from collections import OrderedDict
 from test.test_json import PyTest, CTest
 

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import builtins
 import contextlib
 import importlib.util
 import inspect

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1,5 +1,5 @@
-from test.support import verbose, run_unittest, gc_collect, bigmemtest, _2G, \
-        cpython_only, captured_stdout
+from test.support import (gc_collect, bigmemtest, _2G,
+                          cpython_only, captured_stdout)
 import locale
 import re
 import sre_compile

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -11,7 +11,6 @@ import os.path
 import errno
 import functools
 import subprocess
-from contextlib import ExitStack
 from shutil import (make_archive,
                     register_archive_format, unregister_archive_format,
                     get_archive_formats, Error, unpack_archive,
@@ -22,8 +21,7 @@ import tarfile
 import zipfile
 
 from test import support
-from test.support import (TESTFN, check_warnings, captured_stdout,
-                          android_not_root)
+from test.support import TESTFN, android_not_root
 
 TESTFN2 = TESTFN + "2"
 

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1,12 +1,11 @@
-import unittest
-from test import support
-from contextlib import closing
-import select
+import os
 import signal
 import socket
-import struct
 import subprocess
-import sys, os, time, errno
+import sys
+import time
+import unittest
+from test import support
 from test.support.script_helper import assert_python_ok, spawn_python
 try:
     import threading

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -9,7 +9,6 @@ import operator
 import codecs
 import gc
 import sysconfig
-import platform
 import locale
 
 # count the number of test runs, used to create unique

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -10,7 +10,6 @@ import codecs
 import itertools
 import operator
 import struct
-import string
 import sys
 import unittest
 import warnings

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -16,7 +16,7 @@ from random import randint, random, getrandbits
 from test.support import script_helper
 from test.support import (TESTFN, findfile, unlink, rmtree, temp_dir, temp_cwd,
                           requires_zlib, requires_bz2, requires_lzma,
-                          captured_stdout, check_warnings)
+                          captured_stdout)
 
 TESTFN2 = TESTFN + "2"
 TESTFNDIR = TESTFN + "d"

--- a/Lib/test/test_zipfile64.py
+++ b/Lib/test/test_zipfile64.py
@@ -15,7 +15,6 @@ import zipfile, os, unittest
 import time
 import sys
 
-from io import StringIO
 from tempfile import TemporaryFile
 
 from test.support import TESTFN, requires_zlib

--- a/Lib/unittest/__main__.py
+++ b/Lib/unittest/__main__.py
@@ -13,6 +13,6 @@ if sys.argv[0].endswith("__main__.py"):
 
 __unittest = True
 
-from .main import main, TestProgram
+from .main import main
 
 main(module=None)

--- a/Modules/_decimal/tests/bench.py
+++ b/Modules/_decimal/tests/bench.py
@@ -7,7 +7,6 @@
 
 
 import time
-from math import log, ceil
 try:
     from test.support import import_fresh_module
 except ImportError:

--- a/PCbuild/prepare_ssl.py
+++ b/PCbuild/prepare_ssl.py
@@ -21,7 +21,6 @@
 from __future__ import print_function
 
 import os
-import re
 import sys
 import subprocess
 from shutil import copy

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -7,7 +7,6 @@
 
 import abc
 import ast
-import atexit
 import collections
 import contextlib
 import copy
@@ -27,7 +26,6 @@ import tempfile
 import textwrap
 import traceback
 import types
-import uuid
 
 from types import *
 NoneType = type(None)

--- a/Tools/msi/make_zip.py
+++ b/Tools/msi/make_zip.py
@@ -10,7 +10,7 @@ import tempfile
 from itertools import chain
 from pathlib import Path
 from zipfile import ZipFile, ZIP_DEFLATED
-import subprocess
+
 
 TKTCL_RE = re.compile(r'^(_?tk|tcl).+\.(pyd|dll)', re.IGNORECASE)
 DEBUG_RE = re.compile(r'_d\.(pyd|dll|exe|pdb|lib)$', re.IGNORECASE)

--- a/Tools/tz/zdump.py
+++ b/Tools/tz/zdump.py
@@ -3,7 +3,7 @@ import os
 import struct
 from array import array
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime
 
 ttinfo = namedtuple('ttinfo', ['tt_gmtoff', 'tt_isdst', 'tt_abbrind'])
 


### PR DESCRIPTION
Make also minor PEP8 coding style fixes on modified imports.

http://bugs.python.org/issue29919