### PR TITLE
bpo-29442: Replace optparse with argparse in setup.py

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-09-26-23-08-27.bpo-29442.fD8YTi.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-26-23-08-27.bpo-29442.fD8YTi.rst
@@ -1,0 +1,1 @@
+Replace optparse with argparse in setup.py

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # Autodetecting setup.py script for building the Python extensions
 #
 
-import sys, os, importlib.machinery, re, optparse
+import sys, os, importlib.machinery, re, argparse
 from glob import glob
 import importlib._bootstrap
 import importlib.util
@@ -532,24 +532,9 @@ class PyBuildExt(build_ext):
                 ('CPPFLAGS', '-I', self.compiler.include_dirs)):
             env_val = sysconfig.get_config_var(env_var)
             if env_val:
-                # To prevent optparse from raising an exception about any
-                # options in env_val that it doesn't know about we strip out
-                # all double dashes and any dashes followed by a character
-                # that is not for the option we are dealing with.
-                #
-                # Please note that order of the regex is important!  We must
-                # strip out double-dashes first so that we don't end up with
-                # substituting "--Long" to "-Long" and thus lead to "ong" being
-                # used for a library directory.
-                env_val = re.sub(r'(^|\s+)-(-|(?!%s))' % arg_name[1],
-                                 ' ', env_val)
-                parser = optparse.OptionParser()
-                # Make sure that allowing args interspersed with options is
-                # allowed
-                parser.allow_interspersed_args = True
-                parser.error = lambda msg: None
-                parser.add_option(arg_name, dest="dirs", action="append")
-                options = parser.parse_args(env_val.split())[0]
+                parser = argparse.ArgumentParser()
+                parser.add_argument(arg_name, dest="dirs", action="append")
+                options, _ = parser.parse_known_args(env_val.split())
                 if options.dirs:
                     for directory in reversed(options.dirs):
                         add_dir_to_list(dir_list, directory)


### PR DESCRIPTION
https://bugs.python.org/issue29442

PS: This patch has conflicts with #1372 

Update: depends on #1269

<!-- issue-number: bpo-29442 -->
https://bugs.python.org/issue29442
<!-- /issue-number -->
