### PR TITLE
bpo-29453: Remove reference to undefined dictionary ordering in Tutorial

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -492,8 +492,7 @@ function like this::
        for arg in arguments:
            print(arg)
        print("-" * 40)
-       keys = sorted(keywords.keys())
-       for kw in keys:
+       for kw in keywords:
            print(kw, ":", keywords[kw])
 
 It could be called like this::
@@ -513,13 +512,10 @@ and of course it would print:
    It's very runny, sir.
    It's really very, VERY runny, sir.
    ----------------------------------------
-   client : John Cleese
    shopkeeper : Michael Palin
+   client : John Cleese
    sketch : Cheese Shop Sketch
 
-Note that the list of keyword argument names is created by sorting the result
-of the keywords dictionary's ``keys()`` method before printing its contents;
-if this is not done, the order in which the arguments are printed is undefined.
 
 .. _tut-arbitraryargs:
 

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -516,6 +516,9 @@ and of course it would print:
    client : John Cleese
    sketch : Cheese Shop Sketch
 
+Note that the order in which the keyword arguments are printed is guaranteed
+to match the order in which they were provided in the function call.
+
 
 .. _tut-arbitraryargs:
 


### PR DESCRIPTION
As of Python 3.6 **kwargs are ordered, thus, remove the paragraph stating that
ordering is undefined and change snippet to remove the unnecessary sorted call.

Only issue that might need addressing as raised on the tracker is, if it is worth to mention that the output corresponds to the order of passed keyword arguments.

(Though this was already present with a patch on b.p.o I decided to turn it in a pull request since, I believe, it makes it easier to check and apply now that things are on Github)