### PR TITLE
bpo-29593: Improve UnboundLocalError message.

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -70,10 +70,10 @@ static PyObject * special_lookup(PyObject *, _Py_Identifier *);
 #define NAME_ERROR_MSG \
     "name '%.200s' is not defined"
 #define UNBOUNDLOCAL_ERROR_MSG \
-    "local variable '%.200s' referenced before assignment"
+    "local variable '%.200s' referenced before assignment, or got deleted"
 #define UNBOUNDFREE_ERROR_MSG \
     "free variable '%.200s' referenced before assignment" \
-    " in enclosing scope"
+    " in enclosing scope, or got deleted"
 
 /* Dynamic execution profile */
 #ifdef DYNAMIC_EXECUTION_PROFILE


### PR DESCRIPTION
Raymond Hettinger reported during PyCon Canada 2016 Keynote (~20m30 sec)
that unbound local error message was inaccurate, it state that :

> local variable 'xxx' referenced before assignment

Though it can be assigned and deleted.

    for a toy example:

       def foo():
          x = 1
          del x
          print(x)

       foo()

Do the same for free variable.

    def multiplier(n):
	def multiply(x):
	    return x * n
	del n
	return multiply

