### PR TITLE
bpo-5945: mapping.rst: PyMapping_Check(list) returns 1

### DIFF
--- a/Doc/c-api/mapping.rst
+++ b/Doc/c-api/mapping.rst
@@ -9,10 +9,8 @@ Mapping Protocol
 .. c:function:: int PyMapping_Check(PyObject *o)
 
    **Not recommended.** Return ``1`` if the object provides the C-API mapping
-   protocol, and ``0`` otherwise.  This function always succeeds.  The C-API
-   mapping protocol is not equivalent to :class:`collections.abc.Mapping`, and
-   also returns ``1`` for sequences that support slicing.  Use
-   :c:func::`PyObject_IsInstance` instead.
+   protocol, and ``0`` otherwise.  This function always succeeds.  PyMapping_Check()
+   also returns 1 for sequences that support slicing.
 
 
 .. c:function:: Py_ssize_t PyMapping_Size(PyObject *o)

--- a/Doc/c-api/mapping.rst
+++ b/Doc/c-api/mapping.rst
@@ -9,7 +9,9 @@ Mapping Protocol
 .. c:function:: int PyMapping_Check(PyObject *o)
 
    Return ``1`` if the object provides mapping protocol, and ``0`` otherwise.  This
-   function always succeeds.
+   function always succeeds.  The C-API mapping protocol is not equivalent to
+   :class:`collections.abc.Mapping`.  In particular, ``PyMapping_Check(list)``
+   returns ``1``.
 
 
 .. c:function:: Py_ssize_t PyMapping_Size(PyObject *o)

--- a/Doc/c-api/mapping.rst
+++ b/Doc/c-api/mapping.rst
@@ -8,10 +8,11 @@ Mapping Protocol
 
 .. c:function:: int PyMapping_Check(PyObject *o)
 
-   Return ``1`` if the object provides mapping protocol, and ``0`` otherwise.  This
-   function always succeeds.  The C-API mapping protocol is not equivalent to
-   :class:`collections.abc.Mapping`.  In particular, ``PyMapping_Check(list)``
-   returns ``1``.
+   **Not recommended.** Return ``1`` if the object provides the C-API mapping
+   protocol, and ``0`` otherwise.  This function always succeeds.  The C-API
+   mapping protocol is not equivalent to :class:`collections.abc.Mapping`, and
+   also returns ``1`` for sequences that support slicing.  Use
+   :c:func::`PyObject_IsInstance` instead.
 
 
 .. c:function:: Py_ssize_t PyMapping_Size(PyObject *o)


### PR DESCRIPTION
As discussed below, in Python 3, PyMapping_Check(list) returns 1. This behavior is justified by a developer as consistent with Python 3's internals. It is however surprising to C-API users (speaking from experience) and because it deviates from collections.abc.Mapping.

I think it is better to be vague than describe the implementation details.

https://mail.python.org/pipermail/python-dev/2009-May/089445.html

<!-- issue-number: bpo-5945 -->
https://bugs.python.org/issue5945
<!-- /issue-number -->
