### PR TITLE
bpo-21056: Document return type of next method of csv reader

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -402,9 +402,9 @@ Reader objects (:class:`DictReader` instances and objects returned by the
 .. method:: csvreader.__next__()
 
    Return the next row of the reader's iterable object as a list (if the object
-   was returned from ``reader()``) or a dict (if it is a ``DictReader``), parsed
-   according to the current dialect. Usually you should call this as
-   ``next(reader)``.
+   was returned from :func:`reader`) or a dict (if it is a :class:`DictReader`
+   instance), parsed according to the current dialect.  Usually you should call
+   this as ``next(reader)``.
 
 
 Reader objects have the following public attributes:

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -401,9 +401,10 @@ Reader objects (:class:`DictReader` instances and objects returned by the
 
 .. method:: csvreader.__next__()
 
-   Return the next row of the reader's iterable object as a list (if reader) or
-   dict (if DictReader), parsed according to the current dialect. Usually you
-   should call this as ``next(reader)``.
+   Return the next row of the reader's iterable object as a list (if the object
+   was returned from ``reader()``) or a dict (if it is a ``DictReader``), parsed
+   according to the current dialect. Usually you should call this as
+   ``next(reader)``.
 
 
 Reader objects have the following public attributes:

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -401,8 +401,9 @@ Reader objects (:class:`DictReader` instances and objects returned by the
 
 .. method:: csvreader.__next__()
 
-   Return the next row of the reader's iterable object as a list, parsed according
-   to the current dialect.  Usually you should call this as ``next(reader)``.
+   Return the next row of the reader's iterable object as a list (if reader) or
+   dict (if DictReader), parsed according to the current dialect. Usually you
+   should call this as ``next(reader)``.
 
 
 Reader objects have the following public attributes:


### PR DESCRIPTION
## csv.reader

```python
>>> import csv
>>> fp = open('foo.csv')
>>> csv_reader = csv.reader(fp)
>>> next(csv_reader)
['a', 'b', 'c', 'd']
```

## csv.DictReader

```python
>>> fp = open('foo.csv')
>>> csv_dict_reader = csv.DictReader(fp)
>>> next(csv_dict_reader)
OrderedDict([('a', 'e'), ('b', 'f'), ('c', 'g'), ('d', 'h')])
```

Contents of `foo.csv`
```
a,b,c,d
e,f,g,h
i,j,k,l
```

Documentation: https://docs.python.org/3.7/library/csv.html#reader-objects