### PR TITLE
bpo-29571: Use correct locale encoding in test_re

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1399,7 +1399,7 @@ class ReTests(unittest.TestCase):
 
     def test_locale_flag(self):
         import locale
-        _, enc = locale.getlocale(locale.LC_CTYPE)
+        enc = locale.getpreferredencoding(False)
         # Search non-ASCII letter
         for i in range(128, 256):
             try:

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -801,6 +801,11 @@ Tools/Demos
 Tests
 -----
 
+- Issue #29571: to match the behaviour of the ``re.LOCALE`` flag,
+  test_re.test_locale_flag now uses ``locale.getpreferredencoding(False)`` to
+  determine the candidate encoding for the test regex (allowing it to correctly
+  skip the test when the default locale encoding is a multi-byte encoding)
+
 - Issue #24932: Use proper command line parsing in _testembed
 
 - Issue #28950: Disallow -j0 to be combined with -T/-l in regrtest


### PR DESCRIPTION
`local.getlocale(locale.LC_CTYPE)` and
`locale.getpreferredencoding(False)` may give different answers
in some cases (such as the `en_IN` locale).

`re.LOCALE` uses the latter, so update the test case to match.