### PR TITLE
bpo-27470: fix documentation for -3 commandline option not warning wh…

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -404,9 +404,11 @@ Miscellaneous options
 
    Warn about Python 3.x possible incompatibilities by emitting a
    :exc:`DeprecationWarning` for features that are removed or significantly
-   changed in Python 3.
+   changed in Python 3 and can't be detected using static code analysis.
 
    .. versionadded:: 2.6
+
+   See :doc:`/howto/pyporting` for more details.
 
 Options you shouldn't use
 ~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
fix documentation for -3 commandline option not warning when incompatibilities can't be detected using static code analysis

<!-- issue-number: bpo-27470 -->
https://bugs.python.org/issue27470
<!-- /issue-number -->
