### PR TITLE
bpo-29506: Fixes documentation for usage of deepcopy in copy module

### DIFF
--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -47,8 +47,8 @@ copy operations:
 * Recursive objects (compound objects that, directly or indirectly, contain a
   reference to themselves) may cause a recursive loop.
 
-* Because deep copy copies *everything* it may copy too much, e.g.,
-  even administrative data structures that should be shared even between copies.
+* Because deep copy copies everything it may copy too much, such as state
+  which is intended to be shared between copies.
 
 The :func:`deepcopy` function avoids these problems by:
 

--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -47,7 +47,7 @@ copy operations:
 * Recursive objects (compound objects that, directly or indirectly, contain a
   reference to themselves) may cause a recursive loop.
 
-* Because deep copy copies everything it may copy too much, such as state
+* Because deep copy copies everything it may copy too much, such as data
   which is intended to be shared between copies.
 
 The :func:`deepcopy` function avoids these problems by:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -770,6 +770,7 @@ Lawrence Kesteloot
 Vivek Khera
 Dhiru Kholia
 Akshit Khurana
+Sanyam Khurana
 Mads Kiilerich
 Jason Killen
 Jan Kim


### PR DESCRIPTION
Fixes issue: http://bugs.python.org/issue29506

Changes Steven's proposal to use word `state` instead of `data` as per suggestion from @ncoghlan 