### PR TITLE
[3.5] bpo-29571: Use correct locale encoding in test_re (#149)

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1334,7 +1334,7 @@ class ReTests(unittest.TestCase):
 
     def test_locale_flag(self):
         import locale
-        _, enc = locale.getlocale(locale.LC_CTYPE)
+        enc = locale.getpreferredencoding(False)
         # Search non-ASCII letter
         for i in range(128, 256):
             try:

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -87,6 +87,14 @@ Documentation
 
 - Issue #29349: Fix Python 2 syntax in code for building the documentation.
 
+Tests
+-----
+
+- Issue #29571: to match the behaviour of the ``re.LOCALE`` flag,
+  test_re.test_locale_flag now uses ``locale.getpreferredencoding(False)`` to
+  determine the candidate encoding for the test regex (allowing it to correctly
+  skip the test when the default locale encoding is a multi-byte encoding)
+
 
 What's New in Python 3.5.3?
 ===========================


### PR DESCRIPTION
``local.getlocale(locale.LC_CTYPE)`` and
``locale.getpreferredencoding(False)`` may give different answers
in some cases (such as the ``en_IN`` locale).

``re.LOCALE`` uses the latter, so update the test case to match.