### PR TITLE
bpo-18423: Documents limitation for -m flag

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -74,7 +74,8 @@ source.
 .. cmdoption:: -m <module-name>
 
    Search :data:`sys.path` for the named module and execute its contents as
-   the :mod:`__main__` module.
+   the :mod:`__main__` module. This option only works for `packages` and
+   `leaf-level modules`.
 
    Since the argument is a *module* name, you must not give a file extension
    (``.py``).  The module name should be a valid absolute Python module name, but


### PR DESCRIPTION
This tries to solve http://bugs.python.org/issue18423 and documents the limitation on `-m` flag that it only works with leaf-level modules and packages.