### PR TITLE
bpo-29579: Removes readme.txt from the installer.

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -156,6 +156,8 @@ Library
 Windows
 -------
 
+- bpo-29579: Removes readme.txt from the installer
+
 - Issue #29326: Ignores blank lines in ._pth files (Patch by Alexey Izbyshev)
 
 - Issue #28164: Correctly handle special console filenames (patch by Eryk Sun)

--- a/Tools/msi/exe/exe_files.wxs
+++ b/Tools/msi/exe/exe_files.wxs
@@ -8,9 +8,6 @@
             <Component Id="NEWS.txt" Directory="InstallDirectory" Guid="*">
                 <File Name="NEWS.txt" Source="!(bindpath.src)Misc\NEWS" KeyPath="yes" />
             </Component>
-            <Component Id="README.txt" Directory="InstallDirectory" Guid="*">
-                <File Name="README.txt" Source="!(bindpath.src)README" KeyPath="yes" />
-            </Component>
         </ComponentGroup>
     </Fragment>
 


### PR DESCRIPTION
Backport of #160 