### PR TITLE
Tweak PEP 519 documentation in stdlib

### DIFF
--- a/Doc/library/lzma.rst
+++ b/Doc/library/lzma.rst
@@ -39,7 +39,7 @@ Reading and writing compressed files
    object`.
 
    The *filename* argument can be either an actual file name (given as a
-   :class:`str`, :class:`bytes` or :term:`path-like object` object), in
+   :class:`str`, :class:`bytes` or :term:`path-like <path-like object>` object), in
    which case the named file is opened, or it can be an existing file object
    to read from or write to.
 
@@ -76,7 +76,7 @@ Reading and writing compressed files
    An :class:`LZMAFile` can wrap an already-open :term:`file object`, or operate
    directly on a named file. The *filename* argument specifies either the file
    object to wrap, or the name of the file to open (as a :class:`str`,
-   :class:`bytes` or :term:`path-like object` object). When wrapping an
+   :class:`bytes` or :term:`path-like <path-like object>` object). When wrapping an
    existing file object, the wrapped file will not be closed when the
    :class:`LZMAFile` is closed.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2859,7 +2859,7 @@ These functions are all available on Linux only.
    :ref:`not following symlinks <follow_symlinks>`.
 
    .. versionchanged:: 3.6
-      Accepts a :term:`path-like object` fpr *path* and *attribute*.
+      Accepts a :term:`path-like object` for *path* and *attribute*.
 
 
 .. function:: listxattr(path=None, *, follow_symlinks=True)


### PR DESCRIPTION
* Drop duplicate work 'object' in lzma docs
* Fix typo in os docs: fpr -> for