### PR TITLE
bpo-29520: Fix deprecation warning from 'defindex' template

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -33,8 +33,8 @@ today_fmt = '%B %d, %Y'
 # By default, highlight as Python 3.
 highlight_language = 'python3'
 
-# Require Sphinx 1.2 for build.
-needs_sphinx = '1.2'
+# Require Sphinx 1.3 for build.
+needs_sphinx = '1.3'
 
 # Ignore any .rst files in the venv/ directory.
 exclude_patterns = ['venv/*', 'README.rst']

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -33,8 +33,8 @@ today_fmt = '%B %d, %Y'
 # By default, highlight as Python 3.
 highlight_language = 'python3'
 
-# Require Sphinx 1.3 for build.
-needs_sphinx = '1.3'
+# Require Sphinx 1.2 for build.
+needs_sphinx = '1.2'
 
 # Ignore any .rst files in the venv/ directory.
 exclude_patterns = ['venv/*', 'README.rst']

--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -1,5 +1,12 @@
-{% extends "defindex.html" %}
-{% block tables %}
+{% extends "layout.html" %}
+{%- block htmltitle -%}
+<title>{{ shorttitle }}</title>
+{%- endblock -%}
+{% block body %}
+  <h1>{{ docstitle|e }}</h1>
+  <p>
+  {% trans %}Welcome! This is the documentation for Python {{ release }}{% endtrans %}
+  </p>
   <p><strong>{% trans %}Parts of the documentation:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>
     <td width="50%">


### PR DESCRIPTION
Confirmed with Sphinx 1.3.6 and 1.5.2
[[bpo-29520](https://bugs.python.org/issue29520)]