### PR TITLE
bpo-29592: site: skip abs_paths() when it's redundant

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -96,22 +96,6 @@ def makepath(*paths):
     return dir, os.path.normcase(dir)
 
 
-def abs_paths():
-    """Set all module __file__ and __cached__ attributes to an absolute path"""
-    for m in set(sys.modules.values()):
-        if (getattr(getattr(m, '__loader__', None), '__module__', None) not in
-                ('_frozen_importlib', '_frozen_importlib_external')):
-            continue   # don't mess with a PEP 302-supplied __file__
-        try:
-            m.__file__ = os.path.abspath(m.__file__)
-        except (AttributeError, OSError):
-            pass
-        try:
-            m.__cached__ = os.path.abspath(m.__cached__)
-        except (AttributeError, OSError):
-            pass
-
-
 def removeduppaths():
     """ Remove duplicate entries from sys.path along with making them
     absolute"""
@@ -522,7 +506,6 @@ def main():
     """
     global ENABLE_USER_SITE
 
-    abs_paths()
     known_paths = removeduppaths()
     known_paths = venv(known_paths)
     if ENABLE_USER_SITE is None:


### PR DESCRIPTION
[[bpo-29592](https://bugs.python.org/issue29592)]
`os.path.abspath()` is relatively slow function.  Let's skip it if possible.