### PR TITLE
Fixed bpo-29565: Corrected ctypes passing of large structs by value on Windows AMD64.

### DIFF
--- a/Lib/ctypes/test/test_callbacks.py
+++ b/Lib/ctypes/test/test_callbacks.py
@@ -244,6 +244,7 @@ class SampleCallbacksTestCase(unittest.TestCase):
     def test_callback_large_struct(self):
         class Check: pass
 
+        # This should mirror the structure in Modules/_ctypes/_ctypes_test.c
         class X(Structure):
             _fields_ = [
                 ('first', c_ulong),
@@ -255,6 +256,11 @@ class SampleCallbacksTestCase(unittest.TestCase):
             check.first = s.first
             check.second = s.second
             check.third = s.third
+            # See issue #29565.
+            # The structure should be passed by value, so
+            # any changes to it should not be reflected in
+            # the value passed
+            s.first = s.second = s.third = 0x0badf00d
 
         check = Check()
         s = X()
@@ -275,6 +281,11 @@ class SampleCallbacksTestCase(unittest.TestCase):
         self.assertEqual(check.first, 0xdeadbeef)
         self.assertEqual(check.second, 0xcafebabe)
         self.assertEqual(check.third, 0x0bad1dea)
+        # See issue #29565.
+        # Ensure that the original struct is unchanged.
+        self.assertEqual(s.first, check.first)
+        self.assertEqual(s.second, check.second)
+        self.assertEqual(s.third, check.third)
 
 ################################################################
 

--- a/Lib/ctypes/test/test_structures.py
+++ b/Lib/ctypes/test/test_structures.py
@@ -3,6 +3,7 @@ from ctypes import *
 from ctypes.test import need_symbol
 from struct import calcsize
 import _testcapi
+import _ctypes_test
 
 class SubclassesTest(unittest.TestCase):
     def test_subclass(self):
@@ -390,6 +391,28 @@ class StructureTestCase(unittest.TestCase):
         self.assertEqual((z.a, z.b, z.c, z.d, z.e, z.f),
                          (1, 0, 0, 0, 0, 0))
         self.assertRaises(TypeError, lambda: Z(1, 2, 3, 4, 5, 6, 7))
+
+    def test_pass_by_value(self):
+        # This should mirror the structure in Modules/_ctypes/_ctypes_test.c
+        class X(Structure):
+            _fields_ = [
+                ('first', c_ulong),
+                ('second', c_ulong),
+                ('third', c_ulong),
+            ]
+
+        s = X()
+        s.first = 0xdeadbeef
+        s.second = 0xcafebabe
+        s.third = 0x0bad1dea
+        dll = CDLL(_ctypes_test.__file__)
+        func = dll._testfunc_large_struct_update_value
+        func.argtypes = (X,)
+        func.restype = None
+        func(s)
+        self.assertEqual(s.first, 0xdeadbeef)
+        self.assertEqual(s.second, 0xcafebabe)
+        self.assertEqual(s.third, 0x0bad1dea)
 
 class PointerMemberTestCase(unittest.TestCase):
 

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -44,6 +44,19 @@ _testfunc_cbk_large_struct(Test in, void (*func)(Test))
     func(in);
 }
 
+/*
+ * See issue 29565. Update a structure passed by value;
+ * the caller should not see any change.
+ */
+
+EXPORT(void)
+_testfunc_large_struct_update_value(Test in)
+{
+    in.first = 0x0badf00d;
+    in.second = 0x0badf00d;
+    in.third = 0x0badf00d;
+}
+
 EXPORT(void)testfunc_array(int values[4])
 {
     printf("testfunc_array %d %d %d %d\n",

--- a/Modules/_ctypes/libffi_msvc/ffi.c
+++ b/Modules/_ctypes/libffi_msvc/ffi.c
@@ -3,8 +3,8 @@
            Copyright (c) 2002  Ranjit Mathew
            Copyright (c) 2002  Bo Thorsen
            Copyright (c) 2002  Roger Sayle
-
-   x86 Foreign Function Interface
+   
+   x86 Foreign Function Interface 
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -62,65 +62,65 @@ void ffi_prep_args(char *stack, extended_cif *ecif)
 
       /* Align if necessary */
       if ((sizeof(void *) - 1) & (size_t) argp)
-    argp = (char *) ALIGN(argp, sizeof(void *));
+	argp = (char *) ALIGN(argp, sizeof(void *));
 
       z = (*p_arg)->size;
       if (z < sizeof(intptr_t))
-    {
-      z = sizeof(intptr_t);
-      switch ((*p_arg)->type)
-        {
-        case FFI_TYPE_SINT8:
-          *(intptr_t *) argp = (intptr_t)*(SINT8 *)(* p_argv);
-          break;
+	{
+	  z = sizeof(intptr_t);
+	  switch ((*p_arg)->type)
+	    {
+	    case FFI_TYPE_SINT8:
+	      *(intptr_t *) argp = (intptr_t)*(SINT8 *)(* p_argv);
+	      break;
 
-        case FFI_TYPE_UINT8:
-          *(uintptr_t *) argp = (uintptr_t)*(UINT8 *)(* p_argv);
-          break;
+	    case FFI_TYPE_UINT8:
+	      *(uintptr_t *) argp = (uintptr_t)*(UINT8 *)(* p_argv);
+	      break;
 
-        case FFI_TYPE_SINT16:
-          *(intptr_t *) argp = (intptr_t)*(SINT16 *)(* p_argv);
-          break;
+	    case FFI_TYPE_SINT16:
+	      *(intptr_t *) argp = (intptr_t)*(SINT16 *)(* p_argv);
+	      break;
 
-        case FFI_TYPE_UINT16:
-          *(uintptr_t *) argp = (uintptr_t)*(UINT16 *)(* p_argv);
-          break;
+	    case FFI_TYPE_UINT16:
+	      *(uintptr_t *) argp = (uintptr_t)*(UINT16 *)(* p_argv);
+	      break;
 
-        case FFI_TYPE_SINT32:
-          *(intptr_t *) argp = (intptr_t)*(SINT32 *)(* p_argv);
-          break;
+	    case FFI_TYPE_SINT32:
+	      *(intptr_t *) argp = (intptr_t)*(SINT32 *)(* p_argv);
+	      break;
 
-        case FFI_TYPE_UINT32:
-          *(uintptr_t *) argp = (uintptr_t)*(UINT32 *)(* p_argv);
-          break;
+	    case FFI_TYPE_UINT32:
+	      *(uintptr_t *) argp = (uintptr_t)*(UINT32 *)(* p_argv);
+	      break;
 
-        case FFI_TYPE_FLOAT:
-          *(uintptr_t *) argp = 0;
-          *(float *) argp = *(float *)(* p_argv);
-          break;
+	    case FFI_TYPE_FLOAT:
+	      *(uintptr_t *) argp = 0;
+	      *(float *) argp = *(float *)(* p_argv);
+	      break;
 
-        // 64-bit value cases should never be used for x86 and AMD64 builds
-        case FFI_TYPE_SINT64:
-          *(intptr_t *) argp = (intptr_t)*(SINT64 *)(* p_argv);
-          break;
+	    // 64-bit value cases should never be used for x86 and AMD64 builds
+	    case FFI_TYPE_SINT64:
+	      *(intptr_t *) argp = (intptr_t)*(SINT64 *)(* p_argv);
+	      break;
 
-        case FFI_TYPE_UINT64:
-          *(uintptr_t *) argp = (uintptr_t)*(UINT64 *)(* p_argv);
-          break;
+	    case FFI_TYPE_UINT64:
+	      *(uintptr_t *) argp = (uintptr_t)*(UINT64 *)(* p_argv);
+	      break;
 
-        case FFI_TYPE_STRUCT:
-          *(uintptr_t *) argp = (uintptr_t)*(UINT32 *)(* p_argv);
-          break;
+	    case FFI_TYPE_STRUCT:
+	      *(uintptr_t *) argp = (uintptr_t)*(UINT32 *)(* p_argv);
+	      break;
 
-        case FFI_TYPE_DOUBLE:
-          *(uintptr_t *) argp = 0;
-          *(double *) argp = *(double *)(* p_argv);
-          break;
+	    case FFI_TYPE_DOUBLE:
+	      *(uintptr_t *) argp = 0;
+	      *(double *) argp = *(double *)(* p_argv);
+	      break;
 
-        default:
-          FFI_ASSERT(0);
-        }
-    }
+	    default:
+	      FFI_ASSERT(0);
+	    }
+	}
 #ifdef _WIN64
       else if (z > 8)
         {
@@ -131,14 +131,14 @@ void ffi_prep_args(char *stack, extended_cif *ecif)
         }
 #endif
       else
-    {
-      memcpy(argp, *p_argv, z);
-    }
+	{
+	  memcpy(argp, *p_argv, z);
+	}
       p_argv++;
       argp += z;
     }
 
-  if (argp >= stack && (unsigned)(argp - stack) > ecif->cif->bytes)
+  if (argp >= stack && (unsigned)(argp - stack) > ecif->cif->bytes) 
     {
       Py_FatalError("FFI BUG: not enough stack space for arguments");
     }
@@ -188,37 +188,37 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
 
 #ifdef _WIN32
 extern int
-ffi_call_x86(void (*)(char *, extended_cif *),
-         /*@out@*/ extended_cif *,
-         unsigned, unsigned,
-         /*@out@*/ unsigned *,
-         void (*fn)());
+ffi_call_x86(void (*)(char *, extended_cif *), 
+	     /*@out@*/ extended_cif *, 
+	     unsigned, unsigned, 
+	     /*@out@*/ unsigned *, 
+	     void (*fn)());
 #endif
 
 #ifdef _WIN64
 extern int
 ffi_call_AMD64(void (*)(char *, extended_cif *),
-         /*@out@*/ extended_cif *,
-         unsigned, unsigned,
-         /*@out@*/ unsigned *,
-         void (*fn)());
+		 /*@out@*/ extended_cif *,
+		 unsigned, unsigned,
+		 /*@out@*/ unsigned *,
+		 void (*fn)());
 #endif
 
 int
-ffi_call(/*@dependent@*/ ffi_cif *cif,
-     void (*fn)(),
-     /*@out@*/ void *rvalue,
-     /*@dependent@*/ void **avalue)
+ffi_call(/*@dependent@*/ ffi_cif *cif, 
+	 void (*fn)(), 
+	 /*@out@*/ void *rvalue, 
+	 /*@dependent@*/ void **avalue)
 {
   extended_cif ecif;
 
   ecif.cif = cif;
   ecif.avalue = avalue;
+  
+  /* If the return value is a struct and we don't have a return	*/
+  /* value address then we need to make one		        */
 
-  /* If the return value is a struct and we don't have a return */
-  /* value address then we need to make one             */
-
-  if ((rvalue == NULL) &&
+  if ((rvalue == NULL) && 
       (cif->rtype->type == FFI_TYPE_STRUCT))
     {
       /*@-sysunrecog@*/
@@ -227,15 +227,15 @@ ffi_call(/*@dependent@*/ ffi_cif *cif,
     }
   else
     ecif.rvalue = rvalue;
-
-
-  switch (cif->abi)
+    
+  
+  switch (cif->abi) 
     {
 #if !defined(_WIN64)
     case FFI_SYSV:
     case FFI_STDCALL:
-      return ffi_call_x86(ffi_prep_args, &ecif, cif->bytes,
-              cif->flags, ecif.rvalue, fn);
+      return ffi_call_x86(ffi_prep_args, &ecif, cif->bytes, 
+			  cif->flags, ecif.rvalue, fn);
       break;
 #else
     case FFI_SYSV:
@@ -251,7 +251,7 @@ ffi_call(/*@dependent@*/ ffi_cif *cif,
       }
       /*@-usedef@*/
       return ffi_call_AMD64(ffi_prep_args, &ecif, cif->bytes,
-               cif->flags, ecif.rvalue, fn);
+			   cif->flags, ecif.rvalue, fn);
       /*@=usedef@*/
       break;
 #endif
@@ -267,7 +267,7 @@ ffi_call(/*@dependent@*/ ffi_cif *cif,
 /** private members **/
 
 static void ffi_prep_incoming_args_SYSV (char *stack, void **ret,
-                      void** args, ffi_cif* cif);
+					  void** args, ffi_cif* cif);
 /* This function is jumped to by the trampoline */
 
 #ifdef _WIN64
@@ -288,16 +288,16 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
   void *args = argp + sizeof(void*);
 
   cif         = closure->cif;
-  arg_area    = (void**) alloca (cif->nargs * sizeof (void*));
+  arg_area    = (void**) alloca (cif->nargs * sizeof (void*));  
 
   /* this call will initialize ARG_AREA, such that each
-   * element in that array points to the corresponding
+   * element in that array points to the corresponding 
    * value on the stack; and if the function returns
    * a structure, it will re-set RESP to point to the
    * structure return address.  */
 
   ffi_prep_incoming_args_SYSV(args, (void**)&resp, arg_area, cif);
-
+  
   (closure->fun) (cif, resp, arg_area, closure->user_data);
 
   rtype = cif->flags;
@@ -307,19 +307,19 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
   /* now, do a generic return based on the value of rtype */
   if (rtype == FFI_TYPE_INT)
     {
-        _asm mov eax, resp ;
-        _asm mov eax, [eax] ;
+	    _asm mov eax, resp ;
+	    _asm mov eax, [eax] ;
     }
   else if (rtype == FFI_TYPE_FLOAT)
     {
-        _asm mov eax, resp ;
-        _asm fld DWORD PTR [eax] ;
+	    _asm mov eax, resp ;
+	    _asm fld DWORD PTR [eax] ;
 //      asm ("flds (%0)" : : "r" (resp) : "st" );
     }
   else if (rtype == FFI_TYPE_DOUBLE)
     {
-        _asm mov eax, resp ;
-        _asm fld QWORD PTR [eax] ;
+	    _asm mov eax, resp ;
+	    _asm fld QWORD PTR [eax] ;
 //      asm ("fldl (%0)" : : "r" (resp) : "st", "st(1)" );
     }
   else if (rtype == FFI_TYPE_LONGDOUBLE)
@@ -328,13 +328,13 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
     }
   else if (rtype == FFI_TYPE_SINT64)
     {
-        _asm mov edx, resp ;
-        _asm mov eax, [edx] ;
-        _asm mov edx, [edx + 4] ;
+	    _asm mov edx, resp ;
+	    _asm mov eax, [edx] ;
+	    _asm mov edx, [edx + 4] ;
 //      asm ("movl 0(%0),%%eax;"
-//     "movl 4(%0),%%edx"
-//     : : "r"(resp)
-//     : "eax", "edx");
+//	   "movl 4(%0),%%edx" 
+//	   : : "r"(resp)
+//	   : "eax", "edx");
     }
 #else
   /* now, do a generic return based on the value of rtype */
@@ -357,9 +357,9 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
   else if (rtype == FFI_TYPE_SINT64)
     {
       asm ("movl 0(%0),%%eax;"
-       "movl 4(%0),%%edx"
-       : : "r"(resp)
-       : "eax", "edx");
+	   "movl 4(%0),%%edx" 
+	   : : "r"(resp)
+	   : "eax", "edx");
     }
 #endif
 #endif
@@ -374,9 +374,9 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
 }
 
 /*@-exportheader@*/
-static void
+static void 
 ffi_prep_incoming_args_SYSV(char *stack, void **rvalue,
-                void **avalue, ffi_cif *cif)
+			    void **avalue, ffi_cif *cif)
 /*@=exportheader@*/
 {
   register unsigned int i;
@@ -421,7 +421,7 @@ ffi_prep_incoming_args_SYSV(char *stack, void **rvalue,
       p_argv++;
       argp += z;
     }
-
+  
   return;
 }
 
@@ -430,10 +430,10 @@ extern void ffi_closure_OUTER();
 
 ffi_status
 ffi_prep_closure_loc (ffi_closure* closure,
-                      ffi_cif* cif,
-                      void (*fun)(ffi_cif*,void*,void**,void*),
-                      void *user_data,
-                      void *codeloc)
+					  ffi_cif* cif,
+					  void (*fun)(ffi_cif*,void*,void**,void*),
+					  void *user_data,
+					  void *codeloc)
 {
   short bytes;
   char *tramp;
@@ -441,7 +441,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
   int mask = 0;
 #endif
   FFI_ASSERT (cif->abi == FFI_SYSV);
-
+  
   if (cif->abi == FFI_SYSV)
     bytes = 0;
 #if !defined(_WIN64)
@@ -479,7 +479,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
   /* 41 BB ----         mov         r11d,mask */
   BYTES("\x41\xBB"); INT(mask);
 
-  /* 48 B8 --------     mov         rax, closure            */
+  /* 48 B8 --------     mov         rax, closure			*/
   BYTES("\x48\xB8"); POINTER(closure);
 
   /* 49 BA --------     mov         r10, ffi_closure_OUTER */
@@ -502,7 +502,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
   /* ret bytes */
   BYTES("\xc2");
   SHORT(bytes);
-
+  
 #endif
 
   if (tramp - &closure->tramp[0] > FFI_TRAMPOLINE_SIZE)

--- a/Modules/_ctypes/libffi_msvc/ffi.c
+++ b/Modules/_ctypes/libffi_msvc/ffi.c
@@ -3,8 +3,8 @@
            Copyright (c) 2002  Ranjit Mathew
            Copyright (c) 2002  Bo Thorsen
            Copyright (c) 2002  Roger Sayle
-   
-   x86 Foreign Function Interface 
+
+   x86 Foreign Function Interface
 
    Permission is hereby granted, free of charge, to any person obtaining
    a copy of this software and associated documentation files (the
@@ -62,65 +62,65 @@ void ffi_prep_args(char *stack, extended_cif *ecif)
 
       /* Align if necessary */
       if ((sizeof(void *) - 1) & (size_t) argp)
-	argp = (char *) ALIGN(argp, sizeof(void *));
+    argp = (char *) ALIGN(argp, sizeof(void *));
 
       z = (*p_arg)->size;
       if (z < sizeof(intptr_t))
-	{
-	  z = sizeof(intptr_t);
-	  switch ((*p_arg)->type)
-	    {
-	    case FFI_TYPE_SINT8:
-	      *(intptr_t *) argp = (intptr_t)*(SINT8 *)(* p_argv);
-	      break;
+    {
+      z = sizeof(intptr_t);
+      switch ((*p_arg)->type)
+        {
+        case FFI_TYPE_SINT8:
+          *(intptr_t *) argp = (intptr_t)*(SINT8 *)(* p_argv);
+          break;
 
-	    case FFI_TYPE_UINT8:
-	      *(uintptr_t *) argp = (uintptr_t)*(UINT8 *)(* p_argv);
-	      break;
+        case FFI_TYPE_UINT8:
+          *(uintptr_t *) argp = (uintptr_t)*(UINT8 *)(* p_argv);
+          break;
 
-	    case FFI_TYPE_SINT16:
-	      *(intptr_t *) argp = (intptr_t)*(SINT16 *)(* p_argv);
-	      break;
+        case FFI_TYPE_SINT16:
+          *(intptr_t *) argp = (intptr_t)*(SINT16 *)(* p_argv);
+          break;
 
-	    case FFI_TYPE_UINT16:
-	      *(uintptr_t *) argp = (uintptr_t)*(UINT16 *)(* p_argv);
-	      break;
+        case FFI_TYPE_UINT16:
+          *(uintptr_t *) argp = (uintptr_t)*(UINT16 *)(* p_argv);
+          break;
 
-	    case FFI_TYPE_SINT32:
-	      *(intptr_t *) argp = (intptr_t)*(SINT32 *)(* p_argv);
-	      break;
+        case FFI_TYPE_SINT32:
+          *(intptr_t *) argp = (intptr_t)*(SINT32 *)(* p_argv);
+          break;
 
-	    case FFI_TYPE_UINT32:
-	      *(uintptr_t *) argp = (uintptr_t)*(UINT32 *)(* p_argv);
-	      break;
+        case FFI_TYPE_UINT32:
+          *(uintptr_t *) argp = (uintptr_t)*(UINT32 *)(* p_argv);
+          break;
 
-	    case FFI_TYPE_FLOAT:
-	      *(uintptr_t *) argp = 0;
-	      *(float *) argp = *(float *)(* p_argv);
-	      break;
+        case FFI_TYPE_FLOAT:
+          *(uintptr_t *) argp = 0;
+          *(float *) argp = *(float *)(* p_argv);
+          break;
 
-	    // 64-bit value cases should never be used for x86 and AMD64 builds
-	    case FFI_TYPE_SINT64:
-	      *(intptr_t *) argp = (intptr_t)*(SINT64 *)(* p_argv);
-	      break;
+        // 64-bit value cases should never be used for x86 and AMD64 builds
+        case FFI_TYPE_SINT64:
+          *(intptr_t *) argp = (intptr_t)*(SINT64 *)(* p_argv);
+          break;
 
-	    case FFI_TYPE_UINT64:
-	      *(uintptr_t *) argp = (uintptr_t)*(UINT64 *)(* p_argv);
-	      break;
+        case FFI_TYPE_UINT64:
+          *(uintptr_t *) argp = (uintptr_t)*(UINT64 *)(* p_argv);
+          break;
 
-	    case FFI_TYPE_STRUCT:
-	      *(uintptr_t *) argp = (uintptr_t)*(UINT32 *)(* p_argv);
-	      break;
+        case FFI_TYPE_STRUCT:
+          *(uintptr_t *) argp = (uintptr_t)*(UINT32 *)(* p_argv);
+          break;
 
-	    case FFI_TYPE_DOUBLE:
-	      *(uintptr_t *) argp = 0;
-	      *(double *) argp = *(double *)(* p_argv);
-	      break;
+        case FFI_TYPE_DOUBLE:
+          *(uintptr_t *) argp = 0;
+          *(double *) argp = *(double *)(* p_argv);
+          break;
 
-	    default:
-	      FFI_ASSERT(0);
-	    }
-	}
+        default:
+          FFI_ASSERT(0);
+        }
+    }
 #ifdef _WIN64
       else if (z > 8)
         {
@@ -131,14 +131,14 @@ void ffi_prep_args(char *stack, extended_cif *ecif)
         }
 #endif
       else
-	{
-	  memcpy(argp, *p_argv, z);
-	}
+    {
+      memcpy(argp, *p_argv, z);
+    }
       p_argv++;
       argp += z;
     }
 
-  if (argp >= stack && (unsigned)(argp - stack) > ecif->cif->bytes) 
+  if (argp >= stack && (unsigned)(argp - stack) > ecif->cif->bytes)
     {
       Py_FatalError("FFI BUG: not enough stack space for arguments");
     }
@@ -188,37 +188,37 @@ ffi_status ffi_prep_cif_machdep(ffi_cif *cif)
 
 #ifdef _WIN32
 extern int
-ffi_call_x86(void (*)(char *, extended_cif *), 
-	     /*@out@*/ extended_cif *, 
-	     unsigned, unsigned, 
-	     /*@out@*/ unsigned *, 
-	     void (*fn)());
+ffi_call_x86(void (*)(char *, extended_cif *),
+         /*@out@*/ extended_cif *,
+         unsigned, unsigned,
+         /*@out@*/ unsigned *,
+         void (*fn)());
 #endif
 
 #ifdef _WIN64
 extern int
 ffi_call_AMD64(void (*)(char *, extended_cif *),
-		 /*@out@*/ extended_cif *,
-		 unsigned, unsigned,
-		 /*@out@*/ unsigned *,
-		 void (*fn)());
+         /*@out@*/ extended_cif *,
+         unsigned, unsigned,
+         /*@out@*/ unsigned *,
+         void (*fn)());
 #endif
 
 int
-ffi_call(/*@dependent@*/ ffi_cif *cif, 
-	 void (*fn)(), 
-	 /*@out@*/ void *rvalue, 
-	 /*@dependent@*/ void **avalue)
+ffi_call(/*@dependent@*/ ffi_cif *cif,
+     void (*fn)(),
+     /*@out@*/ void *rvalue,
+     /*@dependent@*/ void **avalue)
 {
   extended_cif ecif;
 
   ecif.cif = cif;
   ecif.avalue = avalue;
-  
-  /* If the return value is a struct and we don't have a return	*/
-  /* value address then we need to make one		        */
 
-  if ((rvalue == NULL) && 
+  /* If the return value is a struct and we don't have a return */
+  /* value address then we need to make one             */
+
+  if ((rvalue == NULL) &&
       (cif->rtype->type == FFI_TYPE_STRUCT))
     {
       /*@-sysunrecog@*/
@@ -227,21 +227,31 @@ ffi_call(/*@dependent@*/ ffi_cif *cif,
     }
   else
     ecif.rvalue = rvalue;
-    
-  
-  switch (cif->abi) 
+
+
+  switch (cif->abi)
     {
 #if !defined(_WIN64)
     case FFI_SYSV:
     case FFI_STDCALL:
-      return ffi_call_x86(ffi_prep_args, &ecif, cif->bytes, 
-			  cif->flags, ecif.rvalue, fn);
+      return ffi_call_x86(ffi_prep_args, &ecif, cif->bytes,
+              cif->flags, ecif.rvalue, fn);
       break;
 #else
     case FFI_SYSV:
+      /* If a single argument takes more than 8 bytes,
+         then a copy is passed by reference. */
+      for (unsigned i = 0; i < cif->nargs; i++) {
+          size_t z = cif->arg_types[i]->size;
+          if (z > 8) {
+              void *temp = alloca(z);
+              memcpy(temp, avalue[i], z);
+              avalue[i] = temp;
+          }
+      }
       /*@-usedef@*/
       return ffi_call_AMD64(ffi_prep_args, &ecif, cif->bytes,
-			   cif->flags, ecif.rvalue, fn);
+               cif->flags, ecif.rvalue, fn);
       /*@=usedef@*/
       break;
 #endif
@@ -257,7 +267,7 @@ ffi_call(/*@dependent@*/ ffi_cif *cif,
 /** private members **/
 
 static void ffi_prep_incoming_args_SYSV (char *stack, void **ret,
-					  void** args, ffi_cif* cif);
+                      void** args, ffi_cif* cif);
 /* This function is jumped to by the trampoline */
 
 #ifdef _WIN64
@@ -278,16 +288,16 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
   void *args = argp + sizeof(void*);
 
   cif         = closure->cif;
-  arg_area    = (void**) alloca (cif->nargs * sizeof (void*));  
+  arg_area    = (void**) alloca (cif->nargs * sizeof (void*));
 
   /* this call will initialize ARG_AREA, such that each
-   * element in that array points to the corresponding 
+   * element in that array points to the corresponding
    * value on the stack; and if the function returns
    * a structure, it will re-set RESP to point to the
    * structure return address.  */
 
   ffi_prep_incoming_args_SYSV(args, (void**)&resp, arg_area, cif);
-  
+
   (closure->fun) (cif, resp, arg_area, closure->user_data);
 
   rtype = cif->flags;
@@ -297,19 +307,19 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
   /* now, do a generic return based on the value of rtype */
   if (rtype == FFI_TYPE_INT)
     {
-	    _asm mov eax, resp ;
-	    _asm mov eax, [eax] ;
+        _asm mov eax, resp ;
+        _asm mov eax, [eax] ;
     }
   else if (rtype == FFI_TYPE_FLOAT)
     {
-	    _asm mov eax, resp ;
-	    _asm fld DWORD PTR [eax] ;
+        _asm mov eax, resp ;
+        _asm fld DWORD PTR [eax] ;
 //      asm ("flds (%0)" : : "r" (resp) : "st" );
     }
   else if (rtype == FFI_TYPE_DOUBLE)
     {
-	    _asm mov eax, resp ;
-	    _asm fld QWORD PTR [eax] ;
+        _asm mov eax, resp ;
+        _asm fld QWORD PTR [eax] ;
 //      asm ("fldl (%0)" : : "r" (resp) : "st", "st(1)" );
     }
   else if (rtype == FFI_TYPE_LONGDOUBLE)
@@ -318,13 +328,13 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
     }
   else if (rtype == FFI_TYPE_SINT64)
     {
-	    _asm mov edx, resp ;
-	    _asm mov eax, [edx] ;
-	    _asm mov edx, [edx + 4] ;
+        _asm mov edx, resp ;
+        _asm mov eax, [edx] ;
+        _asm mov edx, [edx + 4] ;
 //      asm ("movl 0(%0),%%eax;"
-//	   "movl 4(%0),%%edx" 
-//	   : : "r"(resp)
-//	   : "eax", "edx");
+//     "movl 4(%0),%%edx"
+//     : : "r"(resp)
+//     : "eax", "edx");
     }
 #else
   /* now, do a generic return based on the value of rtype */
@@ -347,9 +357,9 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
   else if (rtype == FFI_TYPE_SINT64)
     {
       asm ("movl 0(%0),%%eax;"
-	   "movl 4(%0),%%edx" 
-	   : : "r"(resp)
-	   : "eax", "edx");
+       "movl 4(%0),%%edx"
+       : : "r"(resp)
+       : "eax", "edx");
     }
 #endif
 #endif
@@ -364,9 +374,9 @@ ffi_closure_SYSV (ffi_closure *closure, char *argp)
 }
 
 /*@-exportheader@*/
-static void 
+static void
 ffi_prep_incoming_args_SYSV(char *stack, void **rvalue,
-			    void **avalue, ffi_cif *cif)
+                void **avalue, ffi_cif *cif)
 /*@=exportheader@*/
 {
   register unsigned int i;
@@ -411,7 +421,7 @@ ffi_prep_incoming_args_SYSV(char *stack, void **rvalue,
       p_argv++;
       argp += z;
     }
-  
+
   return;
 }
 
@@ -420,10 +430,10 @@ extern void ffi_closure_OUTER();
 
 ffi_status
 ffi_prep_closure_loc (ffi_closure* closure,
-					  ffi_cif* cif,
-					  void (*fun)(ffi_cif*,void*,void**,void*),
-					  void *user_data,
-					  void *codeloc)
+                      ffi_cif* cif,
+                      void (*fun)(ffi_cif*,void*,void**,void*),
+                      void *user_data,
+                      void *codeloc)
 {
   short bytes;
   char *tramp;
@@ -431,7 +441,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
   int mask = 0;
 #endif
   FFI_ASSERT (cif->abi == FFI_SYSV);
-  
+
   if (cif->abi == FFI_SYSV)
     bytes = 0;
 #if !defined(_WIN64)
@@ -469,7 +479,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
   /* 41 BB ----         mov         r11d,mask */
   BYTES("\x41\xBB"); INT(mask);
 
-  /* 48 B8 --------     mov         rax, closure			*/
+  /* 48 B8 --------     mov         rax, closure            */
   BYTES("\x48\xB8"); POINTER(closure);
 
   /* 49 BA --------     mov         r10, ffi_closure_OUTER */
@@ -492,7 +502,7 @@ ffi_prep_closure_loc (ffi_closure* closure,
   /* ret bytes */
   BYTES("\xc2");
   SHORT(bytes);
-  
+
 #endif
 
   if (tramp - &closure->tramp[0] > FFI_TRAMPOLINE_SIZE)


### PR DESCRIPTION
Added code and test to check that when a structure passed by value
is large enough to need to be passed by reference, a copy of the
original structure is passed. The callee updates the passed-in value,
and the test verifies that the caller's copy is unchanged. A similar
change was also added to the test added for bpo-20160 (that test was
passing, but the changes should guard against regressions).

Thanks to Eryk Sun for the patch.