### PR TITLE
bpo-29520: Fixing deprecation warning while building docs

### DIFF
--- a/Doc/tools/templates/defindex.html
+++ b/Doc/tools/templates/defindex.html
@@ -1,0 +1,35 @@
+{#
+    basic/defindex.html
+    ~~~~~~~~~~~~~~~~~~~
+
+    Default template for the "index" page.
+
+    :copyright: Copyright 2007-2016 by the Sphinx team, see AUTHORS.
+    :license: BSD, see LICENSE for details.
+#}
+{%- extends "layout.html" %}
+{% set title = _('Overview') %}
+{% block body %}
+  <h1>{{ docstitle|e }}</h1>
+  <p>
+    {{ _('Welcome! This is') }}
+    {% block description %}{{ _('the documentation for') }} {{ project|e }}
+    {{ release|e }}{% if last_updated %}, {{ _('last updated') }} {{ last_updated|e }}{% endif %}{% endblock %}.
+  </p>
+  {% block tables %}
+  <p><strong>{{ _('Indices and tables:') }}</strong></p>
+  <table class="contentstable" align="center"><tr>
+    <td width="50%">
+      <p class="biglink"><a class="biglink" href="{{ pathto("contents") }}">{{ _('Complete Table of Contents') }}</a><br>
+         <span class="linkdescr">{{ _('lists all sections and subsections') }}</span></p>
+      <p class="biglink"><a class="biglink" href="{{ pathto("search") }}">{{ _('Search Page') }}</a><br>
+         <span class="linkdescr">{{ _('search this documentation') }}</span></p>
+    </td><td width="50%">
+      <p class="biglink"><a class="biglink" href="{{ pathto("modindex") }}">{{ _('Global Module Index') }}</a><br>
+         <span class="linkdescr">{{ _('quick access to all modules') }}</span></p>
+      <p class="biglink"><a class="biglink" href="{{ pathto("genindex") }}">{{ _('General Index') }}</a><br>
+         <span class="linkdescr">{{ _('all functions, classes, terms') }}</span></p>
+    </td></tr>
+  </table>
+  {% endblock %}
+{% endblock %}


### PR DESCRIPTION
* **Description:** According to [bpo-29520](http://bugs.python.org/issue29520) the [Sphinx][sphinx] library has planned to remove `defindex.html` template from its source [reference](https://github.com/sphinx-doc/sphinx/issues/2986). Mentioned template is referenced [here](https://github.com/python/cpython/blob/master/Doc/tools/templates/indexcontent.htm) in cpython codebase. Because of this reason, a deprecation warning is fired at the time of building the documentation. Proposed fix copies the `defindex.html` file to templates for avoiding broken reference at future releases of [Sphinx][sphinx] library.

* [Deprecation warning log](http://dpaste.com/17JKMZ7)


[sphinx]: http://www.sphinx-doc.org/en/stable/