### PR TITLE
Enable travis on fork branches with normalized naming scheme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ branches:
   only:
     - master
     - /^\d\.\d$/
+    - /^bpo-\d+$/
 
 os:
   - linux


### PR DESCRIPTION
Currently the travis runs on master and branches like 2.7, 3.2, (number.number), which prevents running travis on fork branches which have custom names. This PR introduces a normalized naming scheme for branches: `bpo-32368238` (bpo-some_number). So as to enable running travis on fork branches with this naming scheme.

This could help the contributors in testing on their own travis.
For example: https://travis-ci.org/aktech/cpython/builds/203125688