### PR TITLE
bpo26128: subprocess.STARTUPINFO takes keyword-only arguments

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -127,11 +127,14 @@ if _mswindows:
     import msvcrt
     import _winapi
     class STARTUPINFO:
-        dwFlags = 0
-        hStdInput = None
-        hStdOutput = None
-        hStdError = None
-        wShowWindow = 0
+
+        def __init__(self, *, dwFlags=0, hStdInput=None, hStdOutput=None,
+                     hStdError=None, wShowWindow=None):
+            self.dwFlags = dwFlags
+            self.hStdInput = hStdInput
+            self.hStdOutput = hStdOutput
+            self.hStdError = hStdError
+            self.wShowWindow = wShowWindow
 else:
     import _posixsubprocess
     import select


### PR DESCRIPTION
Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>