### PR TITLE
bpo-28886: doc: Move deprecated abc decorators to separate section

### DIFF
--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -221,9 +221,14 @@ The :mod:`abc` module also provides the following decorators:
       multiple-inheritance.
 
 
-The :mod:`abc` module also support following legacy builtin decorators:
+The :mod:`abc` module also supports the following legacy builtin decorators:
 
 .. decorator:: abstractclassmethod
+
+   .. versionadded:: 3.2
+   .. deprecated:: 3.3
+       It is now possible to use :class:`classmethod` with
+       :func:`abstractmethod`, making this decorator redundant.
 
    A subclass of the built-in :func:`classmethod`, indicating an abstract
    classmethod. Otherwise it is similar to :func:`abstractmethod`.
@@ -238,13 +243,13 @@ The :mod:`abc` module also support following legacy builtin decorators:
           def my_abstract_classmethod(cls, ...):
               ...
 
-   .. versionadded:: 3.2
-   .. deprecated:: 3.3
-       It is now possible to use :class:`classmethod` with
-       :func:`abstractmethod`, making this decorator redundant.
-
 
 .. decorator:: abstractstaticmethod
+
+   .. versionadded:: 3.2
+   .. deprecated:: 3.3
+       It is now possible to use :class:`staticmethod` with
+       :func:`abstractmethod`, making this decorator redundant.
 
    A subclass of the built-in :func:`staticmethod`, indicating an abstract
    staticmethod. Otherwise it is similar to :func:`abstractmethod`.
@@ -259,13 +264,13 @@ The :mod:`abc` module also support following legacy builtin decorators:
           def my_abstract_staticmethod(...):
               ...
 
-   .. versionadded:: 3.2
-   .. deprecated:: 3.3
-       It is now possible to use :class:`staticmethod` with
-       :func:`abstractmethod`, making this decorator redundant.
-
 
 .. decorator:: abstractproperty(fget=None, fset=None, fdel=None, doc=None)
+
+   .. deprecated:: 3.3
+       It is now possible to use :class:`property`, :meth:`property.getter`,
+       :meth:`property.setter` and :meth:`property.deleter` with
+       :func:`abstractmethod`, making this decorator redundant.
 
    A subclass of the built-in :func:`property`, indicating an abstract
    property.
@@ -307,12 +312,6 @@ The :mod:`abc` module also support following legacy builtin decorators:
           @C.x.setter
           def x(self, val):
               ...
-
-
-   .. deprecated:: 3.3
-       It is now possible to use :class:`property`, :meth:`property.getter`,
-       :meth:`property.setter` and :meth:`property.deleter` with
-       :func:`abstractmethod`, making this decorator redundant.
 
 
 The :mod:`abc` module also provides the following functions:

--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -221,6 +221,8 @@ The :mod:`abc` module also provides the following decorators:
       multiple-inheritance.
 
 
+The :mod:`abc` module also support following legacy builtin decorators:
+
 .. decorator:: abstractclassmethod
 
    A subclass of the built-in :func:`classmethod`, indicating an abstract

--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -145,7 +145,7 @@ This module provides the following classes:
    .. versionadded:: 3.4
 
 
-The :mod:`abc` module also provides the following decorators:
+The :mod:`abc` module also provides the following decorator:
 
 .. decorator:: abstractmethod
 
@@ -221,7 +221,7 @@ The :mod:`abc` module also provides the following decorators:
       multiple-inheritance.
 
 
-The :mod:`abc` module also supports the following legacy builtin decorators:
+The :mod:`abc` module also supports the following legacy decorators:
 
 .. decorator:: abstractclassmethod
 
@@ -274,12 +274,6 @@ The :mod:`abc` module also supports the following legacy builtin decorators:
 
    A subclass of the built-in :func:`property`, indicating an abstract
    property.
-
-   Using this function requires that the class's metaclass is :class:`ABCMeta`
-   or is derived from it. A class that has a metaclass derived from
-   :class:`ABCMeta` cannot be instantiated unless all of its abstract methods
-   and properties are overridden. The abstract properties can be called using
-   any of the normal 'super' call mechanisms.
 
    This special case is deprecated, as the :func:`property` decorator
    is now correctly identified as abstract when applied to an abstract


### PR DESCRIPTION
As per the message logs, it is good to add the deprecated decorators to the separate section in
https://docs.python.org/3.7/library/abc.html

<!-- issue-number: bpo-28886 -->
https://bugs.python.org/issue28886
<!-- /issue-number -->
