### PR TITLE
[3.6] bpo-29520: fix deprecation warning from 'defindex' template

### DIFF
--- a/Doc/tools/templates/indexcontent.html
+++ b/Doc/tools/templates/indexcontent.html
@@ -1,5 +1,12 @@
-{% extends "defindex.html" %}
-{% block tables %}
+{% extends "layout.html" %}
+{%- block htmltitle -%}
+<title>{{ shorttitle }}</title>
+{%- endblock -%}
+{% block body %}
+  <h1>{{ docstitle|e }}</h1>
+  <p>
+  {% trans %}Welcome! This is the documentation for Python {{ release }}.{% endtrans %}
+  </p>
   <p><strong>{% trans %}Parts of the documentation:{% endtrans %}</strong></p>
   <table class="contentstable" align="center"><tr>
     <td width="50%">


### PR DESCRIPTION
backport of #165.