### PR TITLE
bpo-29532: Altering a kwarg dictionary passed to functools.partial()

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -90,6 +90,15 @@ class TestPartial:
         p(b=7)
         self.assertEqual(d, {'a':3})
 
+    def test_kwargs_copy(self):
+        # Issue #29532: Altering a kwarg dictionary passed to a constructor
+        # should not affect a partial object after creation
+        d = {'a': 3}
+        p = self.partial(capture, **d)
+        self.assertEqual(p(), ((), {'a': 3}))
+        d['a'] = 5
+        self.assertEqual(p(), ((), {'a': 3}))
+
     def test_arg_combinations(self):
         # exercise special code paths for zero args in either partial
         # object or the caller

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -232,6 +232,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29532: Altering a kwarg dictionary passed to functools.partial()
+  no longer affects a partial object after creation.
+
 - bpo-22807: Add uuid.SafeUUID and uuid.UUID.is_safe to relay information from
   the platform about whether generated UUIDs are generated with a
   multiprocessing safe method.

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -88,9 +88,12 @@ partial_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         if (kw == NULL) {
             pto->kw = PyDict_New();
         }
-        else {
+        else if (Py_REFCNT(kw) == 1) {
             Py_INCREF(kw);
             pto->kw = kw;
+        }
+        else {
+            pto->kw = PyDict_Copy(kw);
         }
     }
     else {


### PR DESCRIPTION
no longer affects a partial object after creation.