### PR TITLE
bpo-29569: threading.Timer class: Continue periodical execution till action return True

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -831,29 +831,39 @@ method.  The :meth:`~Event.wait` method blocks until the flag is true.
 Timer Objects
 -------------
 
-This class represents an action that should be run only after a certain amount
-of time has passed --- a timer.  :class:`Timer` is a subclass of :class:`Thread`
+This class represents an action that should be run after a certain amount
+of time has passed --- a timer. It also can run periodically. Each run takes
+place after a specified time after the previous run. This continues until
+the action returns TRUE. :class:`Timer` is a subclass of :class:`Thread`
 and as such also functions as an example of creating custom threads.
 
 Timers are started, as with threads, by calling their :meth:`~Timer.start`
 method.  The timer can be stopped (before its action has begun) by calling the
-:meth:`~Timer.cancel` method.  The interval the timer will wait before
-executing its action may not be exactly the same as the interval specified by
-the user.
+:meth:`~Timer.cancel` method.  If action has returned True then next run is
+scheduled after the timer interval. The interval the timer will wait before
+executing its action may not be exactly the same as the interval specified
+by the user.
+
 
 For example::
 
-   def hello():
-       print("hello, world")
+   def star():
+       global cnt
+       print("*")
+       cnt -= 1
+       if cnt > 0:
+           return True
 
-   t = Timer(30.0, hello)
-   t.start()  # after 30 seconds, "hello, world" will be printed
+   cnt = 5
+   t = Timer(1.0, star)
+   t.start()  # it prints five "*" with 1 sec waiting between prints
 
 
 .. class:: Timer(interval, function, args=None, kwargs=None)
 
    Create a timer that will run *function* with arguments *args* and  keyword
-   arguments *kwargs*, after *interval* seconds have passed.
+   arguments *kwargs*, after *interval* seconds have passed and continues
+   periodically run *function* till *function* returns True.
    If *args* is ``None`` (the default) then an empty list will be used.
    If *kwargs* is ``None`` (the default) then an empty dict will be used.
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1177,9 +1177,10 @@ class Timer(Thread):
         self.finished.set()
 
     def run(self):
-        self.finished.wait(self.interval)
-        if not self.finished.is_set():
-            self.function(*self.args, **self.kwargs)
+        """Continue execution after wait till function returns True"""
+        while(not self.finished.wait(self.interval)):
+            if not self.function(*self.args, **self.kwargs):
+                break
         self.finished.set()
 
 # Special thread class to represent the main thread


### PR DESCRIPTION
I think that functionality of threading.Timer class can be easily extended to generate the sequence of runs with specified period. The idea comes from the GLib.timeout_add function.

http://bugs.python.org/issue29569

As most current CB functions that are used in Timer returns nothing (None) they will run only once as earlier. Only functions that returns True will continue their periodical execution.

There are two ways to stop such continues execution:
- Return something that is not True from action function,
- Call cancel method of Timer class.

Changed method run should look like:

```
    def run(self):
        """Continue execution after wait till function returns True"""
        while(not self.finished.wait(self.interval)):
            if not self.function(*self.args, **self.kwargs):
                break
        self.finished.set()

```