### PR TITLE
bpo-29603 New Queue.unfinished() method

### DIFF
--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -190,6 +190,17 @@ Example of how to wait for enqueued tasks to be completed::
     for t in threads:
         t.join()
 
+One more method provides information about progress of tasks completion.
+
+.. method:: Queue.unfinished()
+
+   Return number of unfinished tasks i.e. number of such tasks which were queued but
+   consumer threads hadn't yet indicated that task is completed (via call of
+   :meth:`task_done`).
+
+   To get the correct value from this method you have to call :meth:`task_done`
+   for each call to :meth:`get` used to fetch a task to indicate that the item was
+   retrieved and all work on it is complete.
 
 .. seealso::
 

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -82,6 +82,13 @@ class Queue:
             while self.unfinished_tasks:
                 self.all_tasks_done.wait()
 
+    def unfinished(self):
+        '''Return number of unfinished tasks i.e. number of such tasks which
+        were queued but consumer threads hadn't yet indicated that task is
+        completed (via call of method task_done()).
+        '''
+        return self.unfinished_tasks
+
     def qsize(self):
         '''Return the approximate size of the queue (not reliable!).'''
         with self.mutex:

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -99,6 +99,7 @@ class BaseQueueTestMixin(BlockingTestMixin):
         q.put(111)
         q.put(333)
         q.put(222)
+        self.assertEqual(q.unfinished(), 3)
         target_order = dict(Queue = [111, 333, 222],
                             LifoQueue = [222, 333, 111],
                             PriorityQueue = [111, 222, 333])

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -198,6 +198,7 @@ class BaseQueueTestMixin(BlockingTestMixin):
         q.put(1)
         q.put(2)
         self.assertEqual(q.unfinished(), 2)
+        q.get()
         q.task_done()
         self.assertEqual(q.unfinished(), 1)
 

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -99,7 +99,6 @@ class BaseQueueTestMixin(BlockingTestMixin):
         q.put(111)
         q.put(333)
         q.put(222)
-        self.assertEqual(q.unfinished(), 3)
         target_order = dict(Queue = [111, 333, 222],
                             LifoQueue = [222, 333, 111],
                             PriorityQueue = [111, 222, 333])
@@ -193,6 +192,14 @@ class BaseQueueTestMixin(BlockingTestMixin):
             pass
         else:
             self.fail("Did not detect task count going negative")
+
+    def test_queue_unfinished(self):
+        q = self.type2test()
+        q.put(1)
+        q.put(2)
+        self.assertEqual(q.unfinished(), 2)
+        q.task_done()
+        self.assertEqual(q.unfinished(), 1)
 
     def test_simple_queue(self):
         # Do it a couple of times on the same queue.


### PR DESCRIPTION
Class queue.Queue control the number of unfinished tasks via method task_done(). But it is only possible to get the information about all task done (via join() method). 
I'm sure that exposing the number of unfinished tasks (unfinished_tasks class variable) can be very useful in many situations when you need more control over the process.

But it is not good idea to provide write access to this internal variable (as it controls internal queue class status). Better way - provide RO access via class method like qsize or empty. It can be look like this:

```
    def unfinished(self):
        return self.unfinished_tasks

```

One example of this method usage: there is not optimal function _adjust_thread_count in concurrent.futures.ThreadPoolExecutor with following comment: 
```
    # TODO(bquinlan): Should avoid creating new threads if there are more
    # idle threads than items in the work queue.

```
It can be easily done with following condition:

```
    if self._work_queue.unfinished() <= len(self._threads):
        return

```

http://bugs.python.org/issue29603