### PR TITLE
bpo-29509: skip redundant string intern

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -785,7 +785,7 @@ PyObject_GetAttrString(PyObject *v, const char *name)
 
     if (Py_TYPE(v)->tp_getattr != NULL)
         return (*Py_TYPE(v)->tp_getattr)(v, (char*)name);
-    w = PyUnicode_InternFromString(name);
+    w = PyUnicode_FromString(name);
     if (w == NULL)
         return NULL;
     res = PyObject_GetAttr(v, w);


### PR DESCRIPTION
PyObject_GetAttrString intern temporary key string.
It's completely redundant.