### PR TITLE
[3.6] bpo-24274: fix erroneous comment in dictobject.c

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -676,7 +676,8 @@ Christian Tismer.
 lookdict() is general-purpose, and may return DKIX_ERROR if (and only if) a
 comparison raises an exception.
 lookdict_unicode() below is specialized to string keys, comparison of which can
-never raise an exception; that function can never return DKIX_ERROR.
+never raise an exception; that function can never return DKIX_ERROR when key
+is string.  Otherwise, it falls back to lookdict().
 lookdict_unicode_nodummy is further specialized for string keys that cannot be
 the <dummy> value.
 For both, when the key isn't found a DKIX_EMPTY is returned. hashpos returns


### PR DESCRIPTION
lookdict_unicode() and lookdict_unicode_nodummy() may raise exception
when key is not unicode.