### PR TITLE
bpo-27413: add --no-ensure-ascii argument to json.tool

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -37,7 +37,7 @@ def main():
                         help='a JSON file to be validated or pretty-printed')
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
                         help='write the output of infile to outfile')
-    parser.add_argument('--no_escape', action='store_true', default=False,
+    parser.add_argument('--no-ensure-ascii', action='store_true', default=False,
                         help='Do not set ensure_ascii to escape non-ASCII characters')
     parser.add_argument('--indent', default='4', type=parse_indent,
                         help='Indent level or str for pretty-printing. '
@@ -64,7 +64,7 @@ def main():
     with outfile:
         json.dump(obj, outfile,
                   indent=options.indent,
-                  ensure_ascii=not options.no_escape,
+                  ensure_ascii=not options.no_ensure_ascii,
                   sort_keys=options.sort_keys,
                   )
         outfile.write('\n')

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -16,18 +16,6 @@ import json
 import sys
 
 
-def parse_indent(indent):
-    """Parse the argparse indent argument."""
-    if indent == 'None':
-        return None
-    if indent == r'\t':
-        return '\t'
-    try:
-        return int(indent)
-    except ValueError:
-        return indent
-
-
 def main():
     prog = 'python -m json.tool'
     description = ('A simple command line interface for json module '
@@ -39,10 +27,11 @@ def main():
                         help='write the output of infile to outfile')
     parser.add_argument('--no-ensure-ascii', action='store_true', default=False,
                         help='Do not set ensure_ascii to escape non-ASCII characters')
-    parser.add_argument('--indent', default='4', type=parse_indent,
-                        help='Indent level or str for pretty-printing. '
-                             'Use None for the most compact representation. '
-                             r'Use "\t" for tab indentation.')
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument('--indent', default=4, type=int,
+                       help='Indent level for pretty-printing.')
+    group.add_argument('--no-indent', action='store_true', default=False,
+                       help='Use compact mode.')
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
     options = parser.parse_args()
@@ -63,7 +52,7 @@ def main():
     outfile = options.outfile or sys.stdout
     with outfile:
         json.dump(obj, outfile,
-                  indent=options.indent,
+                  indent=None if options.no_indent else options.indent,
                   ensure_ascii=not options.no_ensure_ascii,
                   sort_keys=options.sort_keys,
                   )

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -30,8 +30,8 @@ def main():
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--indent', default=4, type=int,
                        help='Indent level for pretty-printing.')
-    group.add_argument('--no-indent', action='store_true', default=False,
-                       help='Use compact mode.')
+    group.add_argument('--no-indent', action='store_const', dest='indent',
+                       const=None, help='Use compact mode.')
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
     options = parser.parse_args()
@@ -52,7 +52,7 @@ def main():
     outfile = options.outfile or sys.stdout
     with outfile:
         json.dump(obj, outfile,
-                  indent=None if options.no_indent else options.indent,
+                  indent=options.indent,
                   ensure_ascii=not options.no_ensure_ascii,
                   sort_keys=options.sort_keys,
                   )

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -26,10 +26,11 @@ def main():
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
                         help='write the output of infile to outfile')
     parser.add_argument('--no-ensure-ascii', action='store_true', default=False,
-                        help='Do not set ensure_ascii to escape non-ASCII characters')
+                        help='Do not escape non-ASCII characters in output.')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('--indent', default=4, type=int,
-                       help='Indent level for pretty-printing.')
+                       help='Indent level (number of spaces) for '
+                       'pretty-printing. Defaults to 4.')
     group.add_argument('--no-indent', action='store_const', dest='indent',
                        const=None, help='Use compact mode.')
     parser.add_argument('--sort-keys', action='store_true', default=False,

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -37,6 +37,8 @@ def main():
                         help='a JSON file to be validated or pretty-printed')
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
                         help='write the output of infile to outfile')
+    parser.add_argument('--no_escape', action='store_true', default=False,
+                        help='Do not set ensure_ascii to escape non-ASCII characters')
     parser.add_argument('--indent', default='4', type=parse_indent,
                         help='Indent level or str for pretty-printing. '
                              'Use None for the most compact representation. '
@@ -62,6 +64,7 @@ def main():
     with outfile:
         json.dump(obj, outfile,
                   indent=options.indent,
+                  ensure_ascii=not options.no_escape,
                   sort_keys=options.sort_keys,
                   )
         outfile.write('\n')

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -16,6 +16,18 @@ import json
 import sys
 
 
+def parse_indent(indent):
+    """Parse the argparse indent argument."""
+    if indent == 'None':
+        return None
+    if indent == r'\t':
+        return '\t'
+    try:
+        return int(indent)
+    except ValueError:
+        return indent
+
+
 def main():
     prog = 'python -m json.tool'
     description = ('A simple command line interface for json module '
@@ -25,24 +37,33 @@ def main():
                         help='a JSON file to be validated or pretty-printed')
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
                         help='write the output of infile to outfile')
+    parser.add_argument('--indent', default='4', type=parse_indent,
+                        help='Indent level or str for pretty-printing. '
+                             'Use None for the most compact representation. '
+                             r'Use "\t" for tab indentation.')
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
     options = parser.parse_args()
 
+    # Read input JSON
     infile = options.infile or sys.stdin
-    outfile = options.outfile or sys.stdout
-    sort_keys = options.sort_keys
     with infile:
         try:
-            if sort_keys:
+            if options.sort_keys:
                 obj = json.load(infile)
             else:
                 obj = json.load(infile,
                                 object_pairs_hook=collections.OrderedDict)
         except ValueError as e:
             raise SystemExit(e)
+
+    # Export JSON
+    outfile = options.outfile or sys.stdout
     with outfile:
-        json.dump(obj, outfile, sort_keys=sort_keys, indent=4)
+        json.dump(obj, outfile,
+                  indent=options.indent,
+                  sort_keys=options.sort_keys,
+                  )
         outfile.write('\n')
 
 

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -16,7 +16,7 @@ class TestTool(unittest.TestCase):
             :"yes"}  ]
            """
 
-    expect_without_sort_keys = textwrap.dedent("""\
+    expect_without_sort_keys = textwrap.dedent(r"""\
     [
         [
             "blorpie"
@@ -26,7 +26,7 @@ class TestTool(unittest.TestCase):
         ],
         [],
         "d-shtaeou",
-        "\xA7 \N{snake} \u03B4 and \U0001D037",
+        "\u00a7 \ud83d\udc0d \u03b4 and \ud834\udc3",
         "i-vhbjkhnth",
         {
             "nifty": 87
@@ -38,7 +38,7 @@ class TestTool(unittest.TestCase):
     ]
     """)
 
-    expect = textwrap.dedent("""\
+    expect = textwrap.dedent(r"""\
     [
         [
             "blorpie"
@@ -48,7 +48,7 @@ class TestTool(unittest.TestCase):
         ],
         [],
         "d-shtaeou",
-        "\xA7 \N{snake} \u03B4 and \U0001D037",
+        "\u00a7 \ud83d\udc0d \u03b4 and \ud834\udc37",
         "i-vhbjkhnth",
         {
             "nifty": 87

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -68,22 +68,22 @@ class TestTool(unittest.TestCase):
         self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
         self.assertEqual(err, None)
 
-    def _create_infile(self):
+    def _create_infile(self, text):
         infile = support.TESTFN
         with open(infile, "w") as fp:
             self.addCleanup(os.remove, infile)
-            fp.write(self.data)
+            fp.write(text)
         return infile
 
     def test_infile_stdout(self):
-        infile = self._create_infile()
+        infile = self._create_infile(self.data)
         rc, out, err = assert_python_ok('-m', 'json.tool', infile)
         self.assertEqual(rc, 0)
         self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
         self.assertEqual(err, b'')
 
     def test_infile_outfile(self):
-        infile = self._create_infile()
+        infile = self._create_infile(self.data)
         outfile = support.TESTFN + '.out'
         rc, out, err = assert_python_ok('-m', 'json.tool', infile, outfile)
         self.addCleanup(os.remove, outfile)
@@ -100,9 +100,22 @@ class TestTool(unittest.TestCase):
         self.assertEqual(err, b'')
 
     def test_sort_keys_flag(self):
-        infile = self._create_infile()
+        infile = self._create_infile(self.data)
         rc, out, err = assert_python_ok('-m', 'json.tool', '--sort-keys', infile)
         self.assertEqual(rc, 0)
         self.assertEqual(out.splitlines(),
                          self.expect_without_sort_keys.encode().splitlines())
+        self.assertEqual(err, b'')
+
+    def test_no_ascii_flag(self):
+        data = '{"json": "🐍 and δ"}'
+        expect = textwrap.dedent('''\
+        {
+            "json": "🐍 and δ"
+        }
+        ''')
+        infile = self._create_infile(data)
+        rc, out, err = assert_python_ok('-m', 'json.tool', '--no_ascii', infile)
+        self.assertEqual(rc, 0)
+        self.assertEqual(out.splitlines(), expect.splitlines())
         self.assertEqual(err, b'')

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -11,7 +11,7 @@ class TestTool(unittest.TestCase):
     data = """
 
         [["blorpie"],[ "whoops" ] , [
-                                 ],\t"d-shtaeou",\r"🐍 and δ",
+                         ],\t"d-shtaeou",\r"\N{snake} \u03B4 and \U0001D037",
         "i-vhbjkhnth", {"nifty":87}, {"morefield" :\tfalse,"field"
             :"yes"}  ]
            """
@@ -26,7 +26,7 @@ class TestTool(unittest.TestCase):
         ],
         [],
         "d-shtaeou",
-        "🐍 and δ",
+        "\N{snake} \u03B4 and \U0001D037",
         "i-vhbjkhnth",
         {
             "nifty": 87
@@ -48,7 +48,7 @@ class TestTool(unittest.TestCase):
         ],
         [],
         "d-shtaeou",
-        "🐍 and δ",
+        "\N{snake} \u03B4 and \U0001D037",
         "i-vhbjkhnth",
         {
             "nifty": 87

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -11,7 +11,7 @@ class TestTool(unittest.TestCase):
     data = """
 
         [["blorpie"],[ "whoops" ] , [
-                         ],\t"d-shtaeou",\r"\N{snake} \u03B4 and \U0001D037",
+                      ],\t"d-shtaeou",\r"\xA7 \N{snake} \u03B4 and \U0001D037",
         "i-vhbjkhnth", {"nifty":87}, {"morefield" :\tfalse,"field"
             :"yes"}  ]
            """
@@ -26,7 +26,7 @@ class TestTool(unittest.TestCase):
         ],
         [],
         "d-shtaeou",
-        "\N{snake} \u03B4 and \U0001D037",
+        "\xA7 \N{snake} \u03B4 and \U0001D037",
         "i-vhbjkhnth",
         {
             "nifty": 87
@@ -48,7 +48,7 @@ class TestTool(unittest.TestCase):
         ],
         [],
         "d-shtaeou",
-        "\N{snake} \u03B4 and \U0001D037",
+        "\xA7 \N{snake} \u03B4 and \U0001D037",
         "i-vhbjkhnth",
         {
             "nifty": 87

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -115,7 +115,7 @@ class TestTool(unittest.TestCase):
         }
         ''')
         infile = self._create_infile(data)
-        rc, out, err = assert_python_ok('-m', 'json.tool', '--no_ascii', infile)
+        rc, out, err = assert_python_ok('-m', 'json.tool', '--no-ensure-ascii', infile)
         self.assertEqual(rc, 0)
-        self.assertEqual(out.splitlines(), expect.splitlines())
+        self.assertEqual(out.splitlines(), expect.encode().splitlines())
         self.assertEqual(err, b'')

--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -11,7 +11,7 @@ class TestTool(unittest.TestCase):
     data = """
 
         [["blorpie"],[ "whoops" ] , [
-                                 ],\t"d-shtaeou",\r"d-nthiouh",
+                                 ],\t"d-shtaeou",\r"🐍 and δ",
         "i-vhbjkhnth", {"nifty":87}, {"morefield" :\tfalse,"field"
             :"yes"}  ]
            """
@@ -26,7 +26,7 @@ class TestTool(unittest.TestCase):
         ],
         [],
         "d-shtaeou",
-        "d-nthiouh",
+        "🐍 and δ",
         "i-vhbjkhnth",
         {
             "nifty": 87
@@ -48,7 +48,7 @@ class TestTool(unittest.TestCase):
         ],
         [],
         "d-shtaeou",
-        "d-nthiouh",
+        "🐍 and δ",
         "i-vhbjkhnth",
         {
             "nifty": 87
@@ -68,22 +68,22 @@ class TestTool(unittest.TestCase):
         self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
         self.assertEqual(err, None)
 
-    def _create_infile(self, text):
+    def _create_infile(self):
         infile = support.TESTFN
         with open(infile, "w") as fp:
             self.addCleanup(os.remove, infile)
-            fp.write(text)
+            fp.write(self.data)
         return infile
 
     def test_infile_stdout(self):
-        infile = self._create_infile(self.data)
+        infile = self._create_infile()
         rc, out, err = assert_python_ok('-m', 'json.tool', infile)
         self.assertEqual(rc, 0)
         self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
         self.assertEqual(err, b'')
 
     def test_infile_outfile(self):
-        infile = self._create_infile(self.data)
+        infile = self._create_infile()
         outfile = support.TESTFN + '.out'
         rc, out, err = assert_python_ok('-m', 'json.tool', infile, outfile)
         self.addCleanup(os.remove, outfile)
@@ -100,22 +100,17 @@ class TestTool(unittest.TestCase):
         self.assertEqual(err, b'')
 
     def test_sort_keys_flag(self):
-        infile = self._create_infile(self.data)
+        infile = self._create_infile()
         rc, out, err = assert_python_ok('-m', 'json.tool', '--sort-keys', infile)
         self.assertEqual(rc, 0)
         self.assertEqual(out.splitlines(),
                          self.expect_without_sort_keys.encode().splitlines())
         self.assertEqual(err, b'')
 
-    def test_no_ascii_flag(self):
-        data = '{"json": "🐍 and δ"}'
-        expect = textwrap.dedent('''\
-        {
-            "json": "🐍 and δ"
-        }
-        ''')
-        infile = self._create_infile(data)
+    def test_no_ensure_ascii_flag(self):
+        infile = self._create_infile()
         rc, out, err = assert_python_ok('-m', 'json.tool', '--no-ensure-ascii', infile)
         self.assertEqual(rc, 0)
-        self.assertEqual(out.splitlines(), expect.encode().splitlines())
+        self.assertEqual(out.splitlines(),
+                         self.expect_without_sort_keys.encode().splitlines())
         self.assertEqual(err, b'')


### PR DESCRIPTION
**Work in progress, pending consensus on whether feature should be added**

This pull request increases the utility of `python -m json.tool` by adding support for setting `ensure_ascii` and `indent` in the `json.dump` call.

Happy to also address any other arguments that need updating. Or other issues with `json.tool`.