### PR TITLE
bpo-29602: fix signed zero handling in complex constructor

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -8,6 +8,12 @@ INF = float("inf")
 NAN = float("nan")
 # These tests ensure that complex math does the right thing
 
+# decorator for skipping tests on non-IEEE 754 platforms
+requires_IEEE_754 = unittest.skipUnless(have_getformat and
+    float.__getformat__("double").startswith("IEEE"),
+    "test requires IEEE 754 doubles")
+
+
 class ComplexTest(unittest.TestCase):
 
     def assertAlmostEqual(self, a, b):
@@ -440,6 +446,29 @@ class ComplexTest(unittest.TestCase):
                     a = 'x %s y' % op
                     b = 'y %s x' % op
                     self.assertTrue(type(eval(a)) is type(eval(b)) is xcomplex)
+
+    @requires_IEEE_754
+    def test_constructor_special_numbers(self):
+        class complex2(complex):
+            pass
+        for x in 0.0, -0.0, INF, -INF, NAN:
+            for y in 0.0, -0.0, INF, -INF, NAN:
+                with self.subTest(x=x, y=y):
+                    z = complex(x, y)
+                    self.assertFloatsAreIdentical(z.real, x)
+                    self.assertFloatsAreIdentical(z.imag, y)
+                    z = complex2(x, y)
+                    self.assertIs(type(z), complex2)
+                    self.assertFloatsAreIdentical(z.real, x)
+                    self.assertFloatsAreIdentical(z.imag, y)
+                    z = complex(complex2(x, y))
+                    self.assertIs(type(z), complex)
+                    self.assertFloatsAreIdentical(z.real, x)
+                    self.assertFloatsAreIdentical(z.imag, y)
+                    z = complex2(complex(x, y))
+                    self.assertIs(type(z), complex2)
+                    self.assertFloatsAreIdentical(z.real, x)
+                    self.assertFloatsAreIdentical(z.imag, y)
 
     def test_hash(self):
         for x in xrange(-30, 30):

--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -9,6 +9,7 @@ NAN = float("nan")
 # These tests ensure that complex math does the right thing
 
 # decorator for skipping tests on non-IEEE 754 platforms
+have_getformat = hasattr(float, "__getformat__")
 requires_IEEE_754 = unittest.skipUnless(have_getformat and
     float.__getformat__("double").startswith("IEEE"),
     "test requires IEEE 754 doubles")
@@ -453,22 +454,21 @@ class ComplexTest(unittest.TestCase):
             pass
         for x in 0.0, -0.0, INF, -INF, NAN:
             for y in 0.0, -0.0, INF, -INF, NAN:
-                with self.subTest(x=x, y=y):
-                    z = complex(x, y)
-                    self.assertFloatsAreIdentical(z.real, x)
-                    self.assertFloatsAreIdentical(z.imag, y)
-                    z = complex2(x, y)
-                    self.assertIs(type(z), complex2)
-                    self.assertFloatsAreIdentical(z.real, x)
-                    self.assertFloatsAreIdentical(z.imag, y)
-                    z = complex(complex2(x, y))
-                    self.assertIs(type(z), complex)
-                    self.assertFloatsAreIdentical(z.real, x)
-                    self.assertFloatsAreIdentical(z.imag, y)
-                    z = complex2(complex(x, y))
-                    self.assertIs(type(z), complex2)
-                    self.assertFloatsAreIdentical(z.real, x)
-                    self.assertFloatsAreIdentical(z.imag, y)
+                z = complex(x, y)
+                self.assertFloatsAreIdentical(z.real, x)
+                self.assertFloatsAreIdentical(z.imag, y)
+                z = complex2(x, y)
+                self.assertIs(type(z), complex2)
+                self.assertFloatsAreIdentical(z.real, x)
+                self.assertFloatsAreIdentical(z.imag, y)
+                z = complex(complex2(x, y))
+                self.assertIs(type(z), complex)
+                self.assertFloatsAreIdentical(z.real, x)
+                self.assertFloatsAreIdentical(z.imag, y)
+                z = complex2(complex(x, y))
+                self.assertIs(type(z), complex2)
+                self.assertFloatsAreIdentical(z.real, x)
+                self.assertFloatsAreIdentical(z.imag, y)
 
     def test_hash(self):
         for x in xrange(-30, 30):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,10 @@ What's New in Python 2.7.14?
 Core and Builtins
 -----------------
 
+- bpo-29602: Fix incorrect handling of signed zeros in complex constructor for
+  complex subclasses and for inputs having a __complex__ method. Patch
+  by Serhiy Storchaka.
+
 - bpo-29347: Fixed possibly dereferencing undefined pointers
   when creating weakref objects.
 

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -1232,11 +1232,11 @@ complex_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             return NULL;
         }
         cr.real = PyFloat_AsDouble(tmp);
-        cr.imag = 0.0; /* Shut up compiler warning */
+        cr.imag = 0.0;
         Py_DECREF(tmp);
     }
     if (i == NULL) {
-        ci.real = 0.0;
+        ci.real = cr.imag;
     }
     else if (PyComplex_Check(i)) {
         ci = ((PyComplexObject*)i)->cval;
@@ -1258,7 +1258,7 @@ complex_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (ci_is_complex) {
         cr.real -= ci.imag;
     }
-    if (cr_is_complex) {
+    if (cr_is_complex && i != NULL) {
         ci.real += cr.imag;
     }
     return complex_subtype_from_doubles(type, cr.real, ci.real);


### PR DESCRIPTION
Backport of #203 to 2.7 branch (cherry-pick of 112ec38c15b388fe025ccb85369a584d218b1160).