### PR TITLE
[3.6] bpo-29453: Remove reference to undefined dictionary ordering in Tutor…

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -492,8 +492,7 @@ function like this::
        for arg in arguments:
            print(arg)
        print("-" * 40)
-       keys = sorted(keywords.keys())
-       for kw in keys:
+       for kw in keywords:
            print(kw, ":", keywords[kw])
 
 It could be called like this::
@@ -513,13 +512,13 @@ and of course it would print:
    It's very runny, sir.
    It's really very, VERY runny, sir.
    ----------------------------------------
-   client : John Cleese
    shopkeeper : Michael Palin
+   client : John Cleese
    sketch : Cheese Shop Sketch
 
-Note that the list of keyword argument names is created by sorting the result
-of the keywords dictionary's ``keys()`` method before printing its contents;
-if this is not done, the order in which the arguments are printed is undefined.
+Note that the order in which the keyword arguments are printed is guaranteed
+to match the order in which they were provided in the function call.
+
 
 .. _tut-arbitraryargs:
 


### PR DESCRIPTION
bpo-29453

As of Python 3.6 **kwargs are ordered, thus, remove the paragraph stating that
ordering is undefined and change snippet to remove the unecessary sorted call.

* Add sentence mentioning guaranteed output order of kwargs

Contributed by Jim Fasarakis-Hilliard @DimitrisJim 

(cherry picked from commit 32e8f9bdfd4324f1aa4fbbdf1ed8536f2b00cabb)