### PR TITLE
Reduce conflict on Misc/NEWS

### DIFF
--- a/.gitattribute
+++ b/.gitattribute
@@ -1,0 +1,1 @@
+Misc/NEWS   merge=union


### PR DESCRIPTION
use "union" merge strategy for Misc/NEWS.

ref: http://krlmlr.github.io/using-gitattributes-to-avoid-merge-conflicts/