### PR TITLE
[3.6] doc: fix compile error on "shoddy" example extension

### DIFF
--- a/Doc/includes/setup.py
+++ b/Doc/includes/setup.py
@@ -5,4 +5,5 @@ setup(name="noddy", version="1.0",
          Extension("noddy2", ["noddy2.c"]),
          Extension("noddy3", ["noddy3.c"]),
          Extension("noddy4", ["noddy4.c"]),
+         Extension("shoddy", ["shoddy.c"]),
          ])

--- a/Doc/includes/shoddy.c
+++ b/Doc/includes/shoddy.c
@@ -31,7 +31,7 @@ Shoddy_init(Shoddy *self, PyObject *args, PyObject *kwds)
 
 
 static PyTypeObject ShoddyType = {
-    PyObject_HEAD_INIT(NULL)
+    PyVarObject_HEAD_INIT(NULL, 0)
     "shoddy.Shoddy",         /* tp_name */
     sizeof(Shoddy),          /* tp_basicsize */
     0,                       /* tp_itemsize */


### PR DESCRIPTION
(cherry picked from commit fb8fe72fc593438f6a0b934c6ff2d9c4aa28673d)