### PR TITLE
[3.6] bpo-29607: Fix stack_effect computation for CALL_FUNCTION_EX

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 3.6.1 release candidate 1?
 Core and Builtins
 -----------------
 
+- bpo-29607: Fix stack_effect computation for CALL_FUNCTION_EX. 
+  Patch by Matthieu Dartiailh.
+
 - bpo-29602: Fix incorrect handling of signed zeros in complex constructor for
   complex subclasses and for inputs having a __complex__ method. Patch
   by Serhiy Storchaka.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1043,7 +1043,7 @@ PyCompile_OpcodeStackEffect(int opcode, int oparg)
         case CALL_FUNCTION_KW:
             return -oparg-1;
         case CALL_FUNCTION_EX:
-            return - ((oparg & 0x01) != 0) - ((oparg & 0x02) != 0);
+            return -1 - ((oparg & 0x01) != 0);
         case MAKE_FUNCTION:
             return -1 - ((oparg & 0x01) != 0) - ((oparg & 0x02) != 0) -
                 ((oparg & 0x04) != 0) - ((oparg & 0x08) != 0);


### PR DESCRIPTION
original pull request: GH-202
(cherry picked from commit 3a9ac827c7c87dffc60c4200323948551bcb6662)
