### PR TITLE
bpo-29614: Rename and reimplement csv.DictReader.

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -117,7 +117,7 @@ class TableReader:
         # values
         while row == []:
             row = next(self.reader)
-        d = tuple(zip(self.fieldnames, row))
+        d = list(zip(self.fieldnames, row))
         lf = len(self.fieldnames)
         lr = len(row)
         if lf < lr:

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -121,7 +121,7 @@ class TableReader:
         lf = len(self.fieldnames)
         lr = len(row)
         if lf < lr:
-            d.extend((self.restkey, entry) for entry in row[lf:])
+            d.append((self.restkey, row[lf:]))
         elif lf > lr:
             for key in self.fieldnames[lr:]:
                 d.append((key, self.restval))

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -18,8 +18,8 @@ __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
            "Error", "Dialect", "__doc__", "excel", "excel_tab",
            "field_size_limit", "reader", "writer",
            "register_dialect", "get_dialect", "list_dialects", "Sniffer",
-           "unregister_dialect", "__version__", "DictReader", "DictWriter",
-           "unix_dialect"]
+           "unregister_dialect", "__version__", "TableReader", "DictReader",
+           "DictWriter", "unix_dialect"]
 
 class Dialect:
     """Describe a CSV dialect.
@@ -78,7 +78,7 @@ class unix_dialect(Dialect):
 register_dialect("unix", unix_dialect)
 
 
-class DictReader:
+class TableReader:
     def __init__(self, f, fieldnames=None, restkey=None, restval=None,
                  dialect="excel", *args, **kwds):
         self._fieldnames = fieldnames   # list of keys for the dict
@@ -117,7 +117,7 @@ class DictReader:
         # values
         while row == []:
             row = next(self.reader)
-        d = OrderedDict(zip(self.fieldnames, row))
+        d = tuple(zip(self.fieldnames, row))
         lf = len(self.fieldnames)
         lr = len(row)
         if lf < lr:
@@ -126,6 +126,11 @@ class DictReader:
             for key in self.fieldnames[lr:]:
                 d[key] = self.restval
         return d
+
+
+class DictReader(TableReader):
+    def __next__(self):
+        return OrderedDict(super().__next__())
 
 
 class DictWriter:

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -121,10 +121,10 @@ class TableReader:
         lf = len(self.fieldnames)
         lr = len(row)
         if lf < lr:
-            d[self.restkey] = row[lf:]
+            d.extend((self.restkey, entry) for entry in row[lf:])
         elif lf > lr:
             for key in self.fieldnames[lr:]:
-                d[key] = self.restval
+                d.append((key, self.restval))
         return d
 
 


### PR DESCRIPTION
Rename and modify current implementation of DictReader to TableReader that offers non-destructive behavior for csv documents with duplicate fieldname values.

Create new class DictReader as a child to TableReader, allowing for backwards compatibility.