### PR TITLE
[Security][3.4] bpo-26657: Fix Windows directory traversal vulnerability with http.server

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -817,9 +817,9 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         words = filter(None, words)
         path = os.getcwd()
         for word in words:
-            drive, word = os.path.splitdrive(word)
-            head, word = os.path.split(word)
-            if word in (os.curdir, os.pardir): continue
+            if os.path.dirname(word) or word in (os.curdir, os.pardir):
+                # Ignore components that are not a simple file/directory name
+                continue
             path = os.path.join(path, word)
         if trailing_slash:
             path += '/'

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -12,6 +12,7 @@ import os
 import sys
 import re
 import base64
+import ntpath
 import shutil
 import urllib.parse
 import html
@@ -828,6 +829,24 @@ class SimpleHTTPRequestHandlerTestCase(unittest.TestCase):
         self.assertEqual(path, self.translated)
         path = self.handler.translate_path('//filename?foo=bar')
         self.assertEqual(path, self.translated)
+
+    def test_windows_colon(self):
+        with support.swap_attr(server.os, 'path', ntpath):
+            path = self.handler.translate_path('c:c:c:foo/filename')
+            path = path.replace(ntpath.sep, os.sep)
+            self.assertEqual(path, self.translated)
+
+            path = self.handler.translate_path('\\c:../filename')
+            path = path.replace(ntpath.sep, os.sep)
+            self.assertEqual(path, self.translated)
+
+            path = self.handler.translate_path('c:\\c:..\\foo/filename')
+            path = path.replace(ntpath.sep, os.sep)
+            self.assertEqual(path, self.translated)
+
+            path = self.handler.translate_path('c:c:foo\\c:c:bar/filename')
+            path = path.replace(ntpath.sep, os.sep)
+            self.assertEqual(path, self.translated)
 
 
 class MiscTestCase(unittest.TestCase):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -19,6 +19,10 @@ Documentation
 Library
 -------
 
+- Issue #26657: Fix directory traversal vulnerability with http.server on
+  Windows.  This fixes a regression that was introduced in 3.3.4rc1 and
+  3.4.0rc1.  Based on patch by Philipp Hagemeister.
+
 - Issue #27850: Remove 3DES from ssl module's default cipher list to counter
   measure sweet32 attack (CVE-2016-2183).
 


### PR DESCRIPTION
Issue #26657: Fix Windows directory traversal vulnerability with http.server
    
Based on patch by Philipp Hagemeister.  This fixes a regression caused by revision f4377699fd47.
    
(cherry picked from commit d274b3f1f1e2d8811733fb952c9f18d7da3a376a)

http://bugs.python.org/issue26657

Backport to 3.4 the fix of a security vulnerability:
http://python-security.readthedocs.io/vulnerabilities.html#issue-26657

This pull request is based on PR #224. It's the first time that I try to create a PR based on another one. Let's see how it works :-)