### PR TITLE
mark various test data binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,10 @@
 Misc/NEWS   merge=union
+
+*.pck binary
+Lib/test/cjkencodings/* binary
+Lib/test/decimaltestdata/*.decTest binary
+Lib/test/sndhdrdata/sndhdr.* binary
+Lib/test/test_email/data/msg_26.txt binary
+Lib/test/xmltestdata/* binary
+Lib/venv/scripts/nt/* binary
+Lib/test/coding20731.py binary


### PR DESCRIPTION
It seems git's automatic LF -> CRLF translation for some binary data files is breaking the Windows buildbots. (My favorite is `ModuleNotFoundError: No module named 'random\r'`.) Turn that off .