### PR TITLE
bpo-26213: Document _UNPACK bytecodes and BUILD_MAP changes

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -801,7 +801,7 @@ All of the following opcodes use their arguments.
 .. opcode:: BUILD_TUPLE_UNPACK (count)
 
    Pops ``count`` iterables from the stack, joins them in a single tuple,
-   and pushes the result. This bytecode is used for implementing iterable
+   and pushes the result.  This bytecode is used for implementing iterable
    unpacking in tuple displays ``(*x, *y, *z)``.
 
    .. versionadded:: 3.5
@@ -834,7 +834,7 @@ All of the following opcodes use their arguments.
 .. opcode:: BUILD_MAP_UNPACK_WITH_CALL (oparg)
 
    This is similar to :opcode:`BUILD_MAP_UNPACK`,
-   but is used for ``f(**x, **y, **z)`` call syntax. The lowest byte of
+   but is used for ``f(**x, **y, **z)`` call syntax.  The lowest byte of
    ``oparg`` is the count of mappings, the relative position of the
    corresponding callable ``f`` is encoded in the second byte of ``oparg``.
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -828,7 +828,7 @@ All of the following opcodes use their arguments.
 .. opcode:: BUILD_MAP_UNPACK (count)
 
    Pops *count* mappings from the stack, merges them in a single dictionary,
-   and pushes the result.  This bytecode is used for implementing iterable
+   and pushes the result.  This bytecode is used for implementing dictionary
    unpacking in dictionary displays ``{**x, **y, **z}``.
 
    .. versionadded:: 3.5

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -723,6 +723,47 @@ All of the following opcodes use their arguments.
    are put onto the stack right-to-left.
 
 
+.. opcode:: BUILD_TUPLE_UNPACK (count)
+
+   Pops ``count`` iterables from the stack, joins them in a single tuple,
+   and pushes the result.
+
+   .. versionadded:: 3.5
+
+
+.. opcode:: BUILD_LIST_UNPACK (count)
+
+   This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a list
+   instead of tuple.
+
+   .. versionadded:: 3.5
+
+
+.. opcode:: BUILD_SET_UNPACK (count)
+
+   This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a set
+   instead of tuple.
+
+   .. versionadded:: 3.5
+
+
+.. opcode:: BUILD_MAP_UNPACK (count)
+
+   Pops ``count`` mappings from the stack, joins them in a single dictionary,
+   and pushes the result.
+
+   .. versionadded:: 3.5
+
+
+.. opcode:: BUILD_MAP_UNPACK_WITH_CALL (count)
+
+   This is similar to :opcode:`BUILD_MAP_UNPACK`,
+   but is used for ``f(**x, **y, **z)`` call syntax. The stack item at position
+   ``count + 2`` should be the corresponding callable ``f``.
+
+   .. versionadded:: 3.5
+
+
 .. opcode:: STORE_ATTR (namei)
 
    Implements ``TOS.name = TOS1``, where *namei* is the index of name in
@@ -772,8 +813,11 @@ All of the following opcodes use their arguments.
 
 .. opcode:: BUILD_MAP (count)
 
-   Pushes a new dictionary object onto the stack.  The dictionary is pre-sized
-   to hold *count* entries.
+   Pushes a new dictionary object onto the stack. Pops ``2 * count`` items
+   so that the dictionary holds ``count`` entries:
+   ``{..., TOS3: TOS2, TOS1: TOS}``.
+
+   .. versionchanged:: 3.5
 
 
 .. opcode:: BUILD_CONST_KEY_MAP (count)

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -827,7 +827,7 @@ All of the following opcodes use their arguments.
 
 .. opcode:: BUILD_MAP_UNPACK (count)
 
-   Pops *count* mappings from the stack, merges them in a single dictionary,
+   Pops *count* mappings from the stack, merges them into a single dictionary,
    and pushes the result.  Implements dictionary unpacking in dictionary
    displays ``{**x, **y, **z}``.
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -772,13 +772,13 @@ All of the following opcodes use their arguments.
 
 .. opcode:: BUILD_MAP (count)
 
-   Pushes a new dictionary object onto the stack.  Pops ``2 * count`` items
-   so that the dictionary holds ``count`` entries:
+   Pushes a new dictionary object onto the stack.  Pops *2 \* count* items
+   so that the dictionary holds *count* entries:
    ``{..., TOS3: TOS2, TOS1: TOS}``.
 
    .. versionchanged:: 3.5
       The dictionary is created from stack items instead of creating an
-      empty dictionary pre-sized to hold ``count`` items.
+      empty dictionary pre-sized to hold *count* items.
 
 
 .. opcode:: BUILD_CONST_KEY_MAP (count)
@@ -800,7 +800,7 @@ All of the following opcodes use their arguments.
 
 .. opcode:: BUILD_TUPLE_UNPACK (count)
 
-   Pops ``count`` iterables from the stack, joins them in a single tuple,
+   Pops *count* iterables from the stack, joins them in a single tuple,
    and pushes the result.  This bytecode is used for implementing iterable
    unpacking in tuple displays ``(*x, *y, *z)``.
 
@@ -810,7 +810,8 @@ All of the following opcodes use their arguments.
 .. opcode:: BUILD_LIST_UNPACK (count)
 
    This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a list
-   instead of tuple.
+   instead of tuple.  This bytecode is used for implementing iterable
+   unpacking in list displays ``[*x, *y, *z]``.
 
    .. versionadded:: 3.5
 
@@ -818,15 +819,17 @@ All of the following opcodes use their arguments.
 .. opcode:: BUILD_SET_UNPACK (count)
 
    This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a set
-   instead of tuple.
+   instead of tuple.  This bytecode is used for implementing iterable
+   unpacking in set displays ``{*x, *y, *z}``.
 
    .. versionadded:: 3.5
 
 
 .. opcode:: BUILD_MAP_UNPACK (count)
 
-   Pops ``count`` mappings from the stack, joins them in a single dictionary,
-   and pushes the result.
+   Pops *count* mappings from the stack, merges them in a single dictionary,
+   and pushes the result.  This bytecode is used for implementing iterable
+   unpacking in dictionary displays ``{**x, **y, **z}``.
 
    .. versionadded:: 3.5
 
@@ -835,8 +838,8 @@ All of the following opcodes use their arguments.
 
    This is similar to :opcode:`BUILD_MAP_UNPACK`,
    but is used for ``f(**x, **y, **z)`` call syntax.  The lowest byte of
-   ``oparg`` is the count of mappings, the relative position of the
-   corresponding callable ``f`` is encoded in the second byte of ``oparg``.
+   *oparg* is the count of mappings, the relative position of the
+   corresponding callable ``f`` is encoded in the second byte of *oparg*.
 
    .. versionadded:: 3.5
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -801,8 +801,8 @@ All of the following opcodes use their arguments.
 .. opcode:: BUILD_TUPLE_UNPACK (count)
 
    Pops *count* iterables from the stack, joins them in a single tuple,
-   and pushes the result.  This bytecode is used for implementing iterable
-   unpacking in tuple displays ``(*x, *y, *z)``.
+   and pushes the result.  Implements iterable unpacking in tuple
+   displays ``(*x, *y, *z)``.
 
    .. versionadded:: 3.5
 
@@ -810,8 +810,8 @@ All of the following opcodes use their arguments.
 .. opcode:: BUILD_LIST_UNPACK (count)
 
    This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a list
-   instead of tuple.  This bytecode is used for implementing iterable
-   unpacking in list displays ``[*x, *y, *z]``.
+   instead of tuple.  Implements iterable unpacking in list
+   displays ``[*x, *y, *z]``.
 
    .. versionadded:: 3.5
 
@@ -819,8 +819,8 @@ All of the following opcodes use their arguments.
 .. opcode:: BUILD_SET_UNPACK (count)
 
    This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a set
-   instead of tuple.  This bytecode is used for implementing iterable
-   unpacking in set displays ``{*x, *y, *z}``.
+   instead of tuple.  Implements iterable unpacking in set
+   displays ``{*x, *y, *z}``.
 
    .. versionadded:: 3.5
 
@@ -828,8 +828,8 @@ All of the following opcodes use their arguments.
 .. opcode:: BUILD_MAP_UNPACK (count)
 
    Pops *count* mappings from the stack, merges them in a single dictionary,
-   and pushes the result.  This bytecode is used for implementing dictionary
-   unpacking in dictionary displays ``{**x, **y, **z}``.
+   and pushes the result.  Implements dictionary unpacking in dictionary
+   displays ``{**x, **y, **z}``.
 
    .. versionadded:: 3.5
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -723,47 +723,6 @@ All of the following opcodes use their arguments.
    are put onto the stack right-to-left.
 
 
-.. opcode:: BUILD_TUPLE_UNPACK (count)
-
-   Pops ``count`` iterables from the stack, joins them in a single tuple,
-   and pushes the result.
-
-   .. versionadded:: 3.5
-
-
-.. opcode:: BUILD_LIST_UNPACK (count)
-
-   This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a list
-   instead of tuple.
-
-   .. versionadded:: 3.5
-
-
-.. opcode:: BUILD_SET_UNPACK (count)
-
-   This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a set
-   instead of tuple.
-
-   .. versionadded:: 3.5
-
-
-.. opcode:: BUILD_MAP_UNPACK (count)
-
-   Pops ``count`` mappings from the stack, joins them in a single dictionary,
-   and pushes the result.
-
-   .. versionadded:: 3.5
-
-
-.. opcode:: BUILD_MAP_UNPACK_WITH_CALL (count)
-
-   This is similar to :opcode:`BUILD_MAP_UNPACK`,
-   but is used for ``f(**x, **y, **z)`` call syntax. The stack item at position
-   ``count + 2`` should be the corresponding callable ``f``.
-
-   .. versionadded:: 3.5
-
-
 .. opcode:: STORE_ATTR (namei)
 
    Implements ``TOS.name = TOS1``, where *namei* is the index of name in
@@ -813,11 +772,13 @@ All of the following opcodes use their arguments.
 
 .. opcode:: BUILD_MAP (count)
 
-   Pushes a new dictionary object onto the stack. Pops ``2 * count`` items
+   Pushes a new dictionary object onto the stack.  Pops ``2 * count`` items
    so that the dictionary holds ``count`` entries:
    ``{..., TOS3: TOS2, TOS1: TOS}``.
 
    .. versionchanged:: 3.5
+      The dictionary is created from stack items instead of creating an
+      empty dictionary pre-sized to hold ``count`` items.
 
 
 .. opcode:: BUILD_CONST_KEY_MAP (count)
@@ -835,6 +796,49 @@ All of the following opcodes use their arguments.
    onto the stack.
 
    .. versionadded:: 3.6
+
+
+.. opcode:: BUILD_TUPLE_UNPACK (count)
+
+   Pops ``count`` iterables from the stack, joins them in a single tuple,
+   and pushes the result. This bytecode is used for implementing iterable
+   unpacking in tuple displays ``(*x, *y, *z)``.
+
+   .. versionadded:: 3.5
+
+
+.. opcode:: BUILD_LIST_UNPACK (count)
+
+   This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a list
+   instead of tuple.
+
+   .. versionadded:: 3.5
+
+
+.. opcode:: BUILD_SET_UNPACK (count)
+
+   This is similar to :opcode:`BUILD_TUPLE_UNPACK`, but pushes a set
+   instead of tuple.
+
+   .. versionadded:: 3.5
+
+
+.. opcode:: BUILD_MAP_UNPACK (count)
+
+   Pops ``count`` mappings from the stack, joins them in a single dictionary,
+   and pushes the result.
+
+   .. versionadded:: 3.5
+
+
+.. opcode:: BUILD_MAP_UNPACK_WITH_CALL (oparg)
+
+   This is similar to :opcode:`BUILD_MAP_UNPACK`,
+   but is used for ``f(**x, **y, **z)`` call syntax. The lowest byte of
+   ``oparg`` is the count of mappings, the relative position of the
+   corresponding callable ``f`` is encoded in the second byte of ``oparg``.
+
+   .. versionadded:: 3.5
 
 
 .. opcode:: LOAD_ATTR (namei)

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -772,7 +772,7 @@ All of the following opcodes use their arguments.
 
 .. opcode:: BUILD_MAP (count)
 
-   Pushes a new dictionary object onto the stack.  Pops *2 \* count* items
+   Pushes a new dictionary object onto the stack.  Pops ``2 * count`` items
    so that the dictionary holds *count* entries:
    ``{..., TOS3: TOS2, TOS1: TOS}``.
 


### PR DESCRIPTION
This needs to be backported to 3.5 and 3.6

This fixes http://bugs.python.org/issue26213

@serhiy-storchaka Please take a look