### PR TITLE
bpo-27200: fix configparser, copyreg and ctypes doctests

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -44,7 +44,7 @@ can be customized by end users easily.
 
 .. testsetup::
 
-    import configparser
+   import configparser
 
 
 Quick Start

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -42,6 +42,11 @@ can be customized by end users easily.
       be used for this purpose.
 
 
+.. testsetup::
+
+    import configparser
+
+
 Quick Start
 -----------
 
@@ -95,7 +100,6 @@ back and explore the data it holds.
 
 .. doctest::
 
-   >>> import configparser
    >>> config = configparser.ConfigParser()
    >>> config.sections()
    []
@@ -116,8 +120,8 @@ back and explore the data it holds.
    'no'
    >>> topsecret['Port']
    '50022'
-   >>> for key in config['bitbucket.org']: print(key)
-   ...
+   >>> for key in config['bitbucket.org']:  # doctest: +SKIP
+   ...     print(key)
    user
    compressionlevel
    serveraliveinterval
@@ -469,9 +473,9 @@ the :meth:`__init__` options:
      ...                                'bar': 'y',
      ...                                'baz': 'z'}
      ... })
-     >>> parser.sections()
+     >>> parser.sections()  # doctest: +SKIP
      ['section3', 'section2', 'section1']
-     >>> [option for option in parser['section3']]
+     >>> [option for option in parser['section3']] # doctest: +SKIP
      ['baz', 'foo', 'bar']
 
   In these operations you need to use an ordered dictionary as well:
@@ -498,11 +502,11 @@ the :meth:`__init__` options:
      ...     ),
      ...   ))
      ... )
-     >>> parser.sections()
+     >>> parser.sections()  # doctest: +SKIP
      ['s1', 's2']
-     >>> [option for option in parser['s1']]
+     >>> [option for option in parser['s1']]  # doctest: +SKIP
      ['1', '3', '5']
-     >>> [option for option in parser['s2'].values()]
+     >>> [option for option in parser['s2'].values()]  # doctest: +SKIP
      ['b', 'd', 'f']
 
 * *allow_no_value*, default value: ``False``
@@ -597,11 +601,11 @@ the :meth:`__init__` options:
     ...   line #3
     ... """)
     >>> print(parser['hashes']['shebang'])
-
+    <BLANKLINE>
     #!/usr/bin/env python
     # -*- coding: utf-8 -*-
     >>> print(parser['hashes']['extensions'])
-
+    <BLANKLINE>
     enabled_extension
     another_extension
     yet_another_extension
@@ -755,6 +759,7 @@ be overridden by subclasses or by attribute assignment.
 
   .. doctest::
 
+     >>> import re
      >>> config = """
      ... [Section 1]
      ... option = value
@@ -762,11 +767,11 @@ be overridden by subclasses or by attribute assignment.
      ... [  Section 2  ]
      ... another = val
      ... """
-     >>> typical = ConfigParser()
+     >>> typical = configparser.ConfigParser()
      >>> typical.read_string(config)
      >>> typical.sections()
      ['Section 1', '  Section 2  ']
-     >>> custom = ConfigParser()
+     >>> custom = configparser.ConfigParser()
      >>> custom.SECTCRE = re.compile(r"\[ *(?P<header>[^]]+?) *\]")
      >>> custom.read_string(config)
      >>> custom.sections()

--- a/Doc/library/copyreg.rst
+++ b/Doc/library/copyreg.rst
@@ -59,7 +59,7 @@ it will be used:
    ...
    >>> copyreg.pickle(C, pickle_c)
    >>> c = C(1)
-   >>> d = copy.copy(c)
+   >>> d = copy.copy(c)  # doctest: +SKIP
    pickling a C instance...
-   >>> p = pickle.dumps(c)
+   >>> p = pickle.dumps(c)  # doctest: +SKIP
    pickling a C instance...

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1408,8 +1408,6 @@ accessing the function through an attribute caches the result and therefore
 accessing it repeatedly returns the same object each time.  On the other hand,
 accessing it through an index returns a new object each time:
 
-.. doctest::
-
    >>> from ctypes import CDLL
    >>> libc = CDLL("libc.so.6")  # On Linux
    >>> libc.time == libc.time

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1408,6 +1408,10 @@ accessing the function through an attribute caches the result and therefore
 accessing it repeatedly returns the same object each time.  On the other hand,
 accessing it through an index returns a new object each time:
 
+.. doctest::
+
+   >>> from ctypes import CDLL
+   >>> libc = CDLL("libc.so.6")  # On Linux
    >>> libc.time == libc.time
    True
    >>> libc['time'] == libc['time']

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1406,7 +1406,7 @@ Instances of these classes have no public methods.  Functions exported by the
 shared library can be accessed as attributes or by index.  Please note that
 accessing the function through an attribute caches the result and therefore
 accessing it repeatedly returns the same object each time.  On the other hand,
-accessing it through an index returns a new object each time:
+accessing it through an index returns a new object each time::
 
    >>> from ctypes import CDLL
    >>> libc = CDLL("libc.so.6")  # On Linux


### PR DESCRIPTION
This PR patially fixes bpo-27200. Partially and not completely, because I followed the suggestion of @ezio-melotti to split the patch in several patches. According to @rhettinger I applyed minimal changes, skipping some tests instead of using `sorted()`. I just want to point out that the two `<BLANKLINE>` and the `testsetup` dicrective will not appear in the output.