### PR TITLE
bpo-29623: Make pathlib objects work with ConfigParser.read.

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -988,13 +988,16 @@ ConfigParser Objects
    .. method:: read(filenames, encoding=None)
 
       Attempt to read and parse a list of filenames, returning a list of
-      filenames which were successfully parsed.  If *filenames* is a string, it
-      is treated as a single filename.  If a file named in *filenames* cannot
-      be opened, that file will be ignored.  This is designed so that you can
-      specify a list of potential configuration file locations (for example,
-      the current directory, the user's home directory, and some system-wide
-      directory), and all existing configuration files in the list will be
-      read.  If none of the named files exist, the :class:`ConfigParser`
+      filenames which were successfully parsed.
+
+      If *filenames* is a string or :term:`path-like object`, it is treated as
+      a single filename.  If a file named in *filenames* cannot be opened, that
+      file will be ignored.  This is designed so that you can specify a list of
+      potential configuration file locations (for example, the current
+      directory, the user's home directory, and some system-wide directory),
+      and all existing configuration files in the list will be read.
+
+      If none of the named files exist, the :class:`ConfigParser`
       instance will contain an empty dataset.  An application which requires
       initial values to be loaded from a file should load the required file or
       files using :meth:`read_file` before calling :meth:`read` for any
@@ -1010,6 +1013,9 @@ ConfigParser Objects
       .. versionadded:: 3.2
          The *encoding* parameter.  Previously, all files were read using the
          default encoding for :func:`open`.
+
+      .. versionadded:: 3.6.1
+         The *filenames* parameter accepts a :term:`path-like object`.
 
 
    .. method:: read_file(f, source=None)

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -688,7 +688,7 @@ class RawConfigParser(MutableMapping):
 
         Return list of successfully read files.
         """
-        if isinstance(filenames, (str, bytes, os.PathLike)):
+        if isinstance(filenames, (str, os.PathLike)):
             filenames = [filenames]
         read_ok = []
         for filename in filenames:

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -697,6 +697,8 @@ class RawConfigParser(MutableMapping):
                     self._read(fp, filename)
             except OSError:
                 continue
+            if isinstance(filename, os.PathLike):
+                filename = os.fspath(filename)
             read_ok.append(filename)
         return read_ok
 

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -143,6 +143,7 @@ from collections import OrderedDict as _default_dict, ChainMap as _ChainMap
 import functools
 import io
 import itertools
+import os
 import re
 import sys
 import warnings
@@ -687,7 +688,7 @@ class RawConfigParser(MutableMapping):
 
         Return list of successfully read files.
         """
-        if isinstance(filenames, str):
+        if isinstance(filenames, (str, bytes, os.PathLike)):
             filenames = [filenames]
         read_ok = []
         for filename in filenames:

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -724,7 +724,12 @@ boolean {0[0]} NO
         # check when we pass only a Path object:
         cf = self.newconfig()
         parsed_files = cf.read(pathlib.Path(file1))
-        self.assertEqual(parsed_files, [pathlib.Path(file1)])
+        self.assertEqual(parsed_files, [file1])
+        self.assertEqual(cf.get("Foo Bar", "foo"), "newbar")
+        # check when we passed both a filename and a Path object:
+        cf = self.newconfig()
+        parsed_files = cf.read([pathlib.Path(file1), file1])
+        self.assertEqual(parsed_files, [file1, file1])
         self.assertEqual(cf.get("Foo Bar", "foo"), "newbar")
         # check when we pass only missing files:
         cf = self.newconfig()

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -2,6 +2,7 @@ import collections
 import configparser
 import io
 import os
+import pathlib
 import textwrap
 import unittest
 import warnings
@@ -719,6 +720,11 @@ boolean {0[0]} NO
         cf = self.newconfig()
         parsed_files = cf.read(file1)
         self.assertEqual(parsed_files, [file1])
+        self.assertEqual(cf.get("Foo Bar", "foo"), "newbar")
+        # check when we pass only a Path object
+        cf = self.newconfig()
+        parsed_files = cf.read(pathlib.Path(file1))
+        self.assertEqual(parsed_files, [pathlib.Path(file1)])
         self.assertEqual(cf.get("Foo Bar", "foo"), "newbar")
         # check when we pass only missing files:
         cf = self.newconfig()

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -721,7 +721,7 @@ boolean {0[0]} NO
         parsed_files = cf.read(file1)
         self.assertEqual(parsed_files, [file1])
         self.assertEqual(cf.get("Foo Bar", "foo"), "newbar")
-        # check when we pass only a Path object
+        # check when we pass only a Path object:
         cf = self.newconfig()
         parsed_files = cf.read(pathlib.Path(file1))
         self.assertEqual(parsed_files, [pathlib.Path(file1)])

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -22,6 +22,8 @@ Core and Builtins
 
 - bpo-28598: Support __rmod__ for subclasses of str being called before
   str.__mod__.  Patch by Martijn Pieters.
+- bpo 29623: Allow use of path-like object as a single argument in
+  configparser.ConfigParser.read
 
 - bpo-29607: Fix stack_effect computation for CALL_FUNCTION_EX.
   Patch by Matthieu Dartiailh.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -22,8 +22,6 @@ Core and Builtins
 
 - bpo-28598: Support __rmod__ for subclasses of str being called before
   str.__mod__.  Patch by Martijn Pieters.
-- bpo 29623: Allow use of path-like object as a single argument in
-  configparser.ConfigParser.read
 
 - bpo-29607: Fix stack_effect computation for CALL_FUNCTION_EX.
   Patch by Matthieu Dartiailh.
@@ -261,6 +259,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29623: Allow use of path-like object as a single argument in
+  ConfigParser.read().  Patch by David Ellis.
+
 - bpo-9303: Migrate sqlite3 module to _v2 API.  Patch by Aviv Palivoda.
 
 - bpo-28963: Fix out of bound iteration in asyncio.Future.remove_done_callback 
@@ -293,8 +294,6 @@ Library
 - Issue #16285: urrlib.parse.quote is now based on RFC 3986 and hence includes
   '~' in the set of characters that is not quoted by default. Patch by
   Christian Theune and Ratnadeep Debnath.
-- bpo 29623: Allow use of path-like object as a single argument in
-  ConfigParser.read().  Patch by David Ellis.
 
 - bpo-29532: Altering a kwarg dictionary passed to functools.partial()
   no longer affects a partial object after creation.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -293,6 +293,8 @@ Library
 - Issue #16285: urrlib.parse.quote is now based on RFC 3986 and hence includes
   '~' in the set of characters that is not quoted by default. Patch by
   Christian Theune and Ratnadeep Debnath.
+- bpo 29623: Allow use of path-like object as a single argument in
+  ConfigParser.read().  Patch by David Ellis.
 
 - bpo-29532: Altering a kwarg dictionary passed to functools.partial()
   no longer affects a partial object after creation.


### PR DESCRIPTION
Checks for os.PathLike and bytes along with str before attempting to iterate.