### PR TITLE
[3.6] bpo-28814: Undeprecate inadvertently deprecated inspect functions. (#122)

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -905,10 +905,8 @@ Classes and functions
    are the names of the ``*`` and ``**`` arguments or ``None``.  *locals* is the
    locals dictionary of the given frame.
 
-   .. deprecated:: 3.5
-      Use :func:`signature` and
-      :ref:`Signature Object <inspect-signature-object>`, which provide a
-      better introspecting API for callables.
+   .. note::
+      This function was inadvertently marked as deprecated in Python 3.5.
 
 
 .. function:: formatargspec(args[, varargs, varkw, defaults, kwonlyargs, kwonlydefaults, annotations[, formatarg, formatvarargs, formatvarkw, formatvalue, formatreturns, formatannotations]])
@@ -944,10 +942,8 @@ Classes and functions
    :func:`getargvalues`.  The format\* arguments are the corresponding optional
    formatting functions that are called to turn names and values into strings.
 
-   .. deprecated:: 3.5
-      Use :func:`signature` and
-      :ref:`Signature Object <inspect-signature-object>`, which provide a
-      better introspecting API for callables.
+   .. note::
+      This function was inadvertently marked as deprecated in Python 3.5.
 
 
 .. function:: getmro(cls)

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -2327,11 +2327,12 @@ The :func:`inspect.getargspec` function is deprecated and scheduled to be
 removed in Python 3.6.  (See :issue:`20438` for details.)
 
 The :mod:`inspect` :func:`~inspect.getfullargspec`,
-:func:`~inspect.getargvalues`, :func:`~inspect.getcallargs`,
-:func:`~inspect.getargvalues`, :func:`~inspect.formatargspec`, and
-:func:`~inspect.formatargvalues` functions are deprecated in favor of
-the :func:`inspect.signature` API.
-(Contributed by Yury Selivanov in :issue:`20438`.)
+:func:`~inspect.getcallargs`, and :func:`~inspect.formatargspec` functions are
+deprecated in favor of the :func:`inspect.signature` API. (Contributed by Yury
+Selivanov in :issue:`20438`.)
+
+:func:`~inspect.getargvalues` and :func:`~inspect.formatargvalues` functions
+were inadvertently marked as deprecated with the release of Python 3.5.0.
 
 Use of :const:`re.LOCALE` flag with str patterns or :const:`re.ASCII` is now
 deprecated.  (Contributed by Serhiy Storchaka in :issue:`22407`.)


### PR DESCRIPTION
Nick Coghlan said on bpo-28814:

> inspect.getargvalues() and inspect.formatargvalues() were deprecated
> in Python 3.5 as part of implementing bpo-20438

> This is incorrect, as these are *frame* introspection related functions,
> not callable introspection ones. The documentation and implementation
> layout is confusing though, as they're interleaved with the callable
> introspection operation

This commit undeprecates these functions and adds a note to ignore
previous deprecation notices.

(cherry picked from commit 0899b9809547ec2894dcf88cf4bba732c5d47d0d)