### PR TITLE
bpo-29630: don't run code on tab-completion

### DIFF
--- a/Lib/rlcompleter.py
+++ b/Lib/rlcompleter.py
@@ -32,6 +32,7 @@ Notes:
 import atexit
 import builtins
 import __main__
+from inspect import getattr_static
 
 __all__ = ["Completer"]
 
@@ -170,7 +171,7 @@ class Completer:
                     not (noprefix and word[:n+1] == noprefix)):
                     match = "%s.%s" % (expr, word)
                     try:
-                        val = getattr(thisobject, word)
+                        val = getattr_static_prop(thisobject, word)
                     except Exception:
                         pass  # Include even if attribute not set
                     else:
@@ -191,6 +192,12 @@ def get_class_members(klass):
         for base in klass.__bases__:
             ret = ret + get_class_members(base)
     return ret
+
+def getattr_static_prop(obj, attr):
+    val = getattr_static(obj, attr)
+    if isinstance(val, property):
+        return val
+    return getattr(obj, attr)
 
 try:
     import readline

--- a/Lib/test/test_rlcompleter.py
+++ b/Lib/test/test_rlcompleter.py
@@ -80,8 +80,8 @@ class TestRlcompleter(unittest.TestCase):
                              ['egg.{}('.format(x) for x in dir(str)
                               if x.startswith('s')])
 
-    def test_excessive_getattr(self):
-        # Ensure getattr() is invoked no more than once per attribute
+    def test_no_code_execution_triggered(self):
+        # Ensure running the completer won't invoke property getters
         class Foo:
             calls = 0
             @property
@@ -91,7 +91,7 @@ class TestRlcompleter(unittest.TestCase):
         f = Foo()
         completer = rlcompleter.Completer(dict(f=f))
         self.assertEqual(completer.complete('f.b', 0), 'f.bar')
-        self.assertEqual(f.calls, 1)
+        self.assertEqual(f.calls, 0)
 
     def test_uncreated_attr(self):
         # Attributes like properties and slots should be completed even when

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -352,6 +352,7 @@ Vincent Delft
 Arnaud Delobelle
 Konrad Delong
 Erik Demaine
+Francisco Demartino
 Martin Dengler
 John Dennis
 L. Peter Deutsch


### PR DESCRIPTION
On `rlcompleter.py`, instead of using `getattr` directly, check if dealing with a `property` with `inspect.getattr_static`, so tab-completion doesn't trigger properties' getter execution.

Trivia: here's a silly [gist](https://gist.github.com/franciscod/2d44d09abc23a6fc1e87012efb0a90ab) with some links while I was tracking down this thing.