### PR TITLE
bpo-28810: Document changes to CALL_FUNCTION opcodes

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -947,21 +947,52 @@ All of the following opcodes use their arguments.
 
 .. opcode:: CALL_FUNCTION (argc)
 
-   Calls a function.  The low byte of *argc* indicates the number of positional
-   parameters, the high byte the number of keyword parameters. On the stack, the
-   opcode finds the keyword parameters first.  For each keyword argument, the
-   value is on top of the key.  Below the keyword parameters, the positional
-   parameters are on the stack, with the right-most parameter on top.  Below the
-   parameters, the function object to call is on the stack.  Pops all function
-   arguments, and the function itself off the stack, and pushes the return
-   value.
+   Calls a function.  *argc* indicates the number of positional arguments.
+   The positional arguments are on the stack, with the right-most argument
+   on top.  Below the arguments, the function object to call is on the stack.
+   Pops all function arguments, and the function itself off the stack, and
+   pushes the return value.
+
+   .. versionchanged:: 3.6
+      This opcode is used only for calls with positional arguments.
+
+
+.. opcode:: CALL_FUNCTION_KW (argc)
+
+   Calls a function.  *argc* indicates the number of arguments (positional
+   and keyword).  The top element on the stack contains a tuple of keyword
+   argument names.  Below the tuple, keyword arguments are on the stack, in
+   the order corresponding to the tuple.  Below the keyword arguments, the
+   positional arguments are on the stack, with the right-most parameter on
+   top.  Below the arguments, the function object to call is on the stack.
+   Pops all function arguments, and the function itself off the stack, and
+   pushes the return value.
+
+   .. versionchanged:: 3.6
+      Keyword arguments are packed in a tuple instead of a dictionary,
+      *argc* indicates the total number of arguments
+
+
+.. opcode:: CALL_FUNCTION_EX (flags)
+
+   Calls a function. The lowest bit of *flags* indicates whether the
+   var-keyword argument is placed at the top of the stack.  Below the
+   var-keyword argument, the var-positional argument is on the stack.
+   Below the arguments, the function object to call is placed.
+   Pops all function arguments, and the function itself off the stack, and
+   pushes the return value. Note that this opcode pops at most three items
+   from the stack. Var-positional and var-keyword arguments are packed
+   by :opcode:`BUILD_MAP_UNPACK_WITH_CALL` and
+   :opcode:`BUILD_MAP_UNPACK_WITH_CALL`.
+
+   .. versionadded:: 3.6
 
 
 .. opcode:: LOAD_METHOD (namei)
 
    Loads a method named ``co_names[namei]`` from TOS object. TOS is popped and
    method and TOS are pushed when interpreter can call unbound method directly.
-   TOS will be uesd as the first argument (``self``) by :opcode:`CALL_METHOD`.
+   TOS will be used as the first argument (``self``) by :opcode:`CALL_METHOD`.
    Otherwise, ``NULL`` and  method is pushed (method is bound method or
    something else).
 
@@ -1007,28 +1038,6 @@ All of the following opcodes use their arguments.
    bytes.  *ext* holds two additional bytes which, taken together with the
    subsequent opcode's argument, comprise a four-byte argument, *ext* being the
    two most-significant bytes.
-
-
-.. opcode:: CALL_FUNCTION_VAR (argc)
-
-   Calls a function. *argc* is interpreted as in :opcode:`CALL_FUNCTION`. The
-   top element on the stack contains the variable argument list, followed by
-   keyword and positional arguments.
-
-
-.. opcode:: CALL_FUNCTION_KW (argc)
-
-   Calls a function. *argc* is interpreted as in :opcode:`CALL_FUNCTION`. The
-   top element on the stack contains the keyword arguments dictionary, followed
-   by explicit keyword and positional arguments.
-
-
-.. opcode:: CALL_FUNCTION_VAR_KW (argc)
-
-   Calls a function. *argc* is interpreted as in :opcode:`CALL_FUNCTION`.  The
-   top element on the stack contains the keyword arguments dictionary, followed
-   by the variable-arguments tuple, followed by explicit keyword and positional
-   arguments.
 
 
 .. opcode:: FORMAT_VALUE (flags)


### PR DESCRIPTION
This needs to be backported to 3.6

@serhiy-storchaka This PR is based on your patch in http://bugs.python.org/issue28810
plus minor additions/corrections.

@brettcannon Could you please take a look?