### PR TITLE
Document why functools.partial() must copy kwargs

### DIFF
--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -163,6 +163,9 @@ partial_call(partialobject *pto, PyObject *args, PyObject *kw)
         Py_XINCREF(kwappl);
     }
     else {
+        /* bpo-27840, bpo-29318: dictionary of keyword parameters must be
+           copied, because a function using "**kwargs" can modify the
+           dictionary. */
         kwappl = PyDict_Copy(pto->kw);
         if (kwappl == NULL) {
             Py_XDECREF(argappl);

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -317,8 +317,8 @@ _PyFunction_FastCallDict(PyObject *func, PyObject **args, Py_ssize_t nargs,
     if (nk != 0) {
         Py_ssize_t pos, i;
 
-        /* Issue #29318: Caller and callee functions must not share the
-           dictionary: kwargs must be copied. */
+        /* bpo-29318, bpo-27840: Caller and callee functions must not share
+           the dictionary: kwargs must be copied. */
         kwtuple = PyTuple_New(2 * nk);
         if (kwtuple == NULL) {
             return NULL;


### PR DESCRIPTION
Add a comment to prevent further attempts to avoid a copy for optimization.

http://bugs.python.org/issue27840