### PR TITLE
bpo-24024: update str.__doc__ to show default encoding explicitly

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15120,7 +15120,7 @@ onError:
 
 PyDoc_STRVAR(unicode_doc,
 "str(object='') -> str\n\
-str(bytes_or_buffer[, encoding[, errors]]) -> str\n\
+str(object, encoding=\"utf-8\", errors=\"strict\") -> str\n\
 \n\
 Create a new string object from the given object. If encoding or\n\
 errors is specified, then the object must expose a data buffer\n\

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15119,7 +15119,7 @@ onError:
 }
 
 PyDoc_STRVAR(unicode_doc,
-"str(object, encoding='utf-8', errors='strict') -> str\n\
+"str(object='', encoding='utf-8', errors='strict') -> str\n\
 \n\
 Create a new string object from the given object. If encoding or\n\
 errors is specified, then the object must expose a data buffer\n\

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15119,8 +15119,7 @@ onError:
 }
 
 PyDoc_STRVAR(unicode_doc,
-"str(object='') -> str\n\
-str(object, encoding='utf-8', errors='strict') -> str\n\
+"str(object, encoding='utf-8', errors='strict') -> str\n\
 \n\
 Create a new string object from the given object. If encoding or\n\
 errors is specified, then the object must expose a data buffer\n\

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15120,15 +15120,13 @@ onError:
 
 PyDoc_STRVAR(unicode_doc,
 "str(object='') -> str\n\
-str(object, encoding=\"utf-8\", errors=\"strict\") -> str\n\
+str(object, encoding='utf-8', errors='strict') -> str\n\
 \n\
 Create a new string object from the given object. If encoding or\n\
 errors is specified, then the object must expose a data buffer\n\
 that will be decoded using the given encoding and error handler.\n\
 Otherwise, returns the result of object.__str__() (if defined)\n\
-or repr(object).\n\
-encoding defaults to sys.getdefaultencoding().\n\
-errors defaults to 'strict'.");
+or repr(object).");
 
 static PyObject *unicode_iter(PyObject *seq);
 


### PR DESCRIPTION
sys.getdefaultencoding() always returns 'utf-8'
Reference: Objects/unicodeobject.c line number -> 4214

Also str() accepts bytes, bytearray or buffer-like objects as input
hence changing it to object.
As str returns .\_\_str\_\_() method defined inside object or repr(obj)
otherwise.