### PR TITLE
bpo-29455: Mention coverage.py in trace module documentation

### DIFF
--- a/Doc/library/trace.rst
+++ b/Doc/library/trace.rst
@@ -13,6 +13,10 @@ annotated statement coverage listings, print caller/callee relationships and
 list functions executed during a program run.  It can be used in another program
 or from the command line.
 
+.. seealso:: `Coverage.py <https://coverage.readthedocs.io/>`_, which is one
+   of the most popular third-party coverage tools. It provides very nice HTML
+   output along with advanced features such as branch coverage.
+
 .. _trace-cli:
 
 Command-Line Usage

--- a/Doc/library/trace.rst
+++ b/Doc/library/trace.rst
@@ -13,9 +13,11 @@ annotated statement coverage listings, print caller/callee relationships and
 list functions executed during a program run.  It can be used in another program
 or from the command line.
 
-.. seealso:: `Coverage.py <https://coverage.readthedocs.io/>`_, which is one
-   of the most popular third-party coverage tools. It provides very nice HTML
-   output along with advanced features such as branch coverage.
+.. seealso::
+
+   `Coverage.py <https://coverage.readthedocs.io/>`_
+      A popular third-party coverage tools that provides very nice HTML
+      output along with advanced features such as branch coverage.
 
 .. _trace-cli:
 

--- a/Doc/library/trace.rst
+++ b/Doc/library/trace.rst
@@ -16,7 +16,7 @@ or from the command line.
 .. seealso::
 
    `Coverage.py <https://coverage.readthedocs.io/>`_
-      A popular third-party coverage tools that provides very nice HTML
+      A popular third-party coverage tool that provides HTML
       output along with advanced features such as branch coverage.
 
 .. _trace-cli:


### PR DESCRIPTION
This pull request fixes [bpo-29455](https://bugs.python.org/issue29455).