### PR TITLE
bpo-27593: Updates Windows build to use information from git

### DIFF
--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -105,9 +105,9 @@ if "%platf%"=="x64" (
     )
 )
 
-if not exist "%HG%" where hg > "%TEMP%\hg.loc" 2> nul && set /P HG= < "%TEMP%\hg.loc" & del "%TEMP%\hg.loc"
-if exist "%HG%" set HGProperty=/p:HG="%HG%"
-if not exist "%HG%" echo Cannot find Mercurial on PATH & set HGProperty=
+if not exist "%GIT%" where git > "%TEMP%\git.loc" 2> nul && set /P GIT= < "%TEMP%\git.loc" & del "%TEMP%\git.loc"
+if exist "%GIT%" set GITProperty=/p:GIT="%GIT%"
+if not exist "%GIT%" echo Cannot find Git on PATH & set GITProperty=
 
 rem Setup the environment
 call "%dir%env.bat" %vs_platf% >nul
@@ -145,7 +145,7 @@ msbuild "%dir%pcbuild.proj" /t:%target% %parallel% %verbose%^
  /p:Configuration=%conf% /p:Platform=%platf%^
  /p:IncludeExternals=%IncludeExternals%^
  /p:IncludeSSL=%IncludeSSL% /p:IncludeTkinter=%IncludeTkinter%^
- /p:UseTestMarker=%UseTestMarker% %HGProperty%^
+ /p:UseTestMarker=%UseTestMarker% %GITProperty%^
  %1 %2 %3 %4 %5 %6 %7 %8 %9
 
 @echo off

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -408,24 +408,24 @@
   </ImportGroup>
   <Target Name="_GetBuildInfo" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <HG Condition="$(HG) == ''">hg</HG>
-      <_HG>$(HG)</_HG>
-      <_HG Condition="$(HG.Contains(` `))">"$(HG)"</_HG>
+      <GIT Condition="$(GIT) == ''">git</GIT>
+      <_GIT>$(GIT)</_GIT>
+      <_GIT Condition="$(GIT.Contains(` `))">"$(GIT)"</_GIT>
     </PropertyGroup>
-    <Message Text="Getting build info from $(_HG)" Importance="high" />
+    <Message Text="Getting build info from $(_GIT)" Importance="high" />
     <MakeDir Directories="$(IntDir)" Condition="!Exists($(IntDir))" />
-    <Exec Command="$(_HG) id -b &gt; &quot;$(IntDir)hgbranch.txt&quot;" ContinueOnError="true" />
-    <Exec Command="$(_HG) id -i &gt; &quot;$(IntDir)hgversion.txt&quot;" ContinueOnError="true" />
-    <Exec Command="$(_HG) id -t &gt; &quot;$(IntDir)hgtag.txt&quot;" ContinueOnError="true" />
+    <Exec Command="$(_GIT) rev-parse --abbrev-ref HEAD &gt; &quot;$(IntDir)gitbranch.txt&quot;" ContinueOnError="true" />
+    <Exec Command="$(_GIT) rev-parse HEAD &gt; &quot;$(IntDir)gitversion.txt&quot;" ContinueOnError="true" />
+    <Exec Command="$(_GIT) name-rev --tags --name id -t &gt; &quot;$(IntDir)gittag.txt&quot;" ContinueOnError="true" />
     <PropertyGroup>
-      <HgBranch Condition="Exists('$(IntDir)hgbranch.txt')">$([System.IO.File]::ReadAllText('$(IntDir)hgbranch.txt').Trim())</HgBranch>
-      <HgVersion Condition="Exists('$(IntDir)hgversion.txt')">$([System.IO.File]::ReadAllText('$(IntDir)hgversion.txt').Trim())</HgVersion>
-      <HgTag Condition="Exists('$(IntDir)hgtag.txt')">$([System.IO.File]::ReadAllText('$(IntDir)hgtag.txt').Trim())</HgTag>
+      <GitBranch Condition="Exists('$(IntDir)gitbranch.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gitbranch.txt').Trim())</GitBranch>
+      <GitVersion Condition="Exists('$(IntDir)gitversion.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gitversion.txt').Trim())</GitVersion>
+      <GitTag Condition="Exists('$(IntDir)gittag.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gittag.txt').Trim())</GitTag>
     </PropertyGroup>
-    <Message Text="Building $(HgTag):$(HgVersion) $(HgBranch)" Importance="high" />
+    <Message Text="Building $(GitTag):$(GitVersion) $(GitBranch)" Importance="high" />
     <ItemGroup>
       <ClCompile Include="..\Modules\getbuildinfo.c">
-        <PreprocessorDefinitions>HGVERSION="$(HgVersion)";HGTAG="$(HgTag)";HGBRANCH="$(HgBranch)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions>GITVERSION="$(GitVersion)";GITTAG="$(GitTag)";GITBRANCH="$(GitBranch)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -416,14 +416,16 @@
     <MakeDir Directories="$(IntDir)" Condition="!Exists($(IntDir))" />
     <Exec Command="$(_GIT) rev-parse --abbrev-ref HEAD &gt; &quot;$(IntDir)gitbranch.txt&quot;" ContinueOnError="true" />
     <Exec Command="$(_GIT) rev-parse HEAD &gt; &quot;$(IntDir)gitversion.txt&quot;" ContinueOnError="true" />
+    <Exec Command="$(_GIT) name-rev --tags --name id -t &gt; &quot;$(IntDir)gittag.txt&quot;" ContinueOnError="true" />
     <PropertyGroup>
       <GitBranch Condition="Exists('$(IntDir)gitbranch.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gitbranch.txt').Trim())</GitBranch>
       <GitVersion Condition="Exists('$(IntDir)gitversion.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gitversion.txt').Trim())</GitVersion>
+      <GitTag Condition="Exists('$(IntDir)gittag.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gittag.txt').Trim())</GitTag>
     </PropertyGroup>
-    <Message Text="Building $(GitVersion) $(GitBranch)" Importance="high" />
+    <Message Text="Building $(GitTag):$(GitVersion) $(GitBranch)" Importance="high" />
     <ItemGroup>
       <ClCompile Include="..\Modules\getbuildinfo.c">
-        <PreprocessorDefinitions>GITVERSION="$(GitVersion)";GITBRANCH="$(GitBranch)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions>GITVERSION="$(GitVersion)";GITTAG="$(GitTag)";GITBRANCH="$(GitBranch)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -414,7 +414,7 @@
     </PropertyGroup>
     <Message Text="Getting build info from $(_GIT)" Importance="high" />
     <MakeDir Directories="$(IntDir)" Condition="!Exists($(IntDir))" />
-    <Exec Command="$(_GIT) rev-parse --abbrev-ref HEAD &gt; &quot;$(IntDir)gitbranch.txt&quot;" ContinueOnError="true" />
+    <Exec Command="$(_GIT) name-rev --name-only HEAD &gt; &quot;$(IntDir)gitbranch.txt&quot;" ContinueOnError="true" />
     <Exec Command="$(_GIT) rev-parse HEAD &gt; &quot;$(IntDir)gitversion.txt&quot;" ContinueOnError="true" />
     <Exec Command="$(_GIT) name-rev --tags --name id -t &gt; &quot;$(IntDir)gittag.txt&quot;" ContinueOnError="true" />
     <PropertyGroup>

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -416,16 +416,14 @@
     <MakeDir Directories="$(IntDir)" Condition="!Exists($(IntDir))" />
     <Exec Command="$(_GIT) rev-parse --abbrev-ref HEAD &gt; &quot;$(IntDir)gitbranch.txt&quot;" ContinueOnError="true" />
     <Exec Command="$(_GIT) rev-parse HEAD &gt; &quot;$(IntDir)gitversion.txt&quot;" ContinueOnError="true" />
-    <Exec Command="$(_GIT) name-rev --tags --name id -t &gt; &quot;$(IntDir)gittag.txt&quot;" ContinueOnError="true" />
     <PropertyGroup>
       <GitBranch Condition="Exists('$(IntDir)gitbranch.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gitbranch.txt').Trim())</GitBranch>
       <GitVersion Condition="Exists('$(IntDir)gitversion.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gitversion.txt').Trim())</GitVersion>
-      <GitTag Condition="Exists('$(IntDir)gittag.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gittag.txt').Trim())</GitTag>
     </PropertyGroup>
-    <Message Text="Building $(GitTag):$(GitVersion) $(GitBranch)" Importance="high" />
+    <Message Text="Building $(GitVersion) $(GitBranch)" Importance="high" />
     <ItemGroup>
       <ClCompile Include="..\Modules\getbuildinfo.c">
-        <PreprocessorDefinitions>GITVERSION="$(GitVersion)";GITTAG="$(GitTag)";GITBRANCH="$(GitBranch)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
+        <PreprocessorDefinitions>GITVERSION="$(GitVersion)";GITBRANCH="$(GitBranch)";%(PreprocessorDefinitions)</PreprocessorDefinitions>
       </ClCompile>
     </ItemGroup>
   </Target>

--- a/Tools/msi/buildrelease.bat
+++ b/Tools/msi/buildrelease.bat
@@ -65,8 +65,8 @@ if "%1" NEQ "" echo Invalid option: "%1" && exit /B 1
 
 if not defined BUILDX86 if not defined BUILDX64 (set BUILDX86=1) && (set BUILDX64=1)
 
-if not exist "%HG%" where hg > "%TEMP%\hg.loc" 2> nul && set /P HG= < "%TEMP%\hg.loc" & del "%TEMP%\hg.loc"
-if not exist "%HG%" echo Cannot find Mercurial on PATH && exit /B 1
+if not exist "%GIT%" where git > "%TEMP%\git.loc" 2> nul && set /P GIT= < "%TEMP%\git.loc" & del "%TEMP%\git.loc"
+if not exist "%GIT%" echo Cannot find Git on PATH && exit /B 1
 
 call "%D%get_externals.bat"
 


### PR DESCRIPTION
bpo-27593: Updates Windows build to use information from git
Note that until getbuildinfo.c has been updated, this won't make things work any better.