### PR TITLE
bpo-28556: Update to typing: treat subscripted generics as proxies

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -674,6 +674,33 @@ class GenericTests(BaseTestCase):
         c.bar = 'abc'
         self.assertEqual(c.__dict__, {'bar': 'abc'})
 
+    def test_subscripted_generics_as_proxies(self):
+        T = TypeVar('T')
+        class C(Generic[T]):
+            x = 'def'
+        self.assertEqual(C[int].x, 'def')
+        self.assertEqual(C[C[int]].x, 'def')
+        C[C[int]].x = 'changed'
+        self.assertEqual(C.x, 'changed')
+        self.assertEqual(C[str].x, 'changed')
+        C[List[str]].z = 'new'
+        self.assertEqual(C.z, 'new')
+        self.assertEqual(C[Tuple[int]].z, 'new')
+
+        self.assertEqual(C().x, 'changed')
+        self.assertEqual(C[Tuple[str]]().z, 'new')
+
+        class D(C[T]):
+            pass
+        self.assertEqual(D[int].x, 'changed')
+        self.assertEqual(D.z, 'new')
+        D.z = 'from derived z'
+        D[int].x = 'from derived x'
+        self.assertEqual(C.x, 'changed')
+        self.assertEqual(C[int].z, 'new')
+        self.assertEqual(D.x, 'from derived x')
+        self.assertEqual(D[str].z, 'from derived z')
+
     def test_false_subclasses(self):
         class MyMapping(MutableMapping[str, str]): pass
         self.assertNotIsInstance({}, MyMapping)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1158,6 +1158,13 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               self.__parameters__, self.__args__, self.__origin__,
                               self.__extra__, self.__orig_bases__)
 
+    def __setattr__(self, attr, value):
+        # We consider all the subscripted genrics as proxies for original class
+        if attr.startswith('__') and attr.endswith('__'):
+            super(GenericMeta, self).__setattr__(attr, value)
+        else:
+            super(GenericMeta, _gorg(self)).__setattr__(attr, value)
+
 
 # Prevent checks for Generic to crash when defining Generic.
 Generic = None


### PR DESCRIPTION
This a recent update from ``python/typing`` repo. See https://github.com/python/typing/pull/393 for details.

This needs to be backported to 3.5 and 3.6

@ned-deily Guido would like to get this into 3.6.1