### PR TITLE
Update contextlib.py

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -98,7 +98,6 @@ class _GeneratorContextManager(ContextDecorator, AbstractContextManager):
                 value = type()
             try:
                 self.gen.throw(type, value, traceback)
-                raise RuntimeError("generator didn't stop after throw()")
             except StopIteration as exc:
                 # Suppress StopIteration *unless* it's the same exception that
                 # was passed to throw().  This prevents a StopIteration
@@ -124,6 +123,8 @@ class _GeneratorContextManager(ContextDecorator, AbstractContextManager):
                 #
                 if sys.exc_info()[1] is not value:
                     raise
+            else:
+                raise RuntimeError("generator didn't stop after throw()")
 
 
 def contextmanager(func):


### PR DESCRIPTION
Moved raise from inside try to try..else.
The exception raised, in case the generator doesn't stop after `.raise`, should be raised in an else block. This is a) more readable, b) saves the catching, checking and reraising of this exception.