### PR TITLE
bpo-29637: clean docstring only if not None

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -194,11 +194,14 @@ def get_docstring(node, clean=True):
     Return the docstring for the given node or None if no docstring can
     be found.  If the node provided does not have docstrings a TypeError
     will be raised.
+
+    If *clean* is `True`, all tabs are expanded to spaces and any whitespace
+    that can be uniformly removed from the second line onwards is removed.
     """
     if not isinstance(node, (AsyncFunctionDef, FunctionDef, ClassDef, Module)):
         raise TypeError("%r can't have docstrings" % node.__class__.__name__)
     text = node.docstring
-    if clean:
+    if clean and text:
         import inspect
         text = inspect.cleandoc(text)
     return text

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -532,6 +532,7 @@ class ASTHelpers_Test(unittest.TestCase):
 
         node = ast.parse('async def foo():\n  """spam\n  ham"""')
         self.assertEqual(ast.get_docstring(node.body[0]), 'spam\nham')
+        self.assertIsNone(ast.get_docstring(ast.parse('')))
 
     def test_literal_eval(self):
         self.assertEqual(ast.literal_eval('[1, 2, 3]'), [1, 2, 3])


### PR DESCRIPTION
Likely introduced by the combinaison of bpo-29622 and bpo-29463

http://bugs.python.org/issue29463
http://bugs.python.org/issue29622