### PR TITLE
[3.5] bpo-28556: Update to typing: treat subscripted generics as proxies (#265)

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -701,6 +701,14 @@ class GenericTests(BaseTestCase):
         self.assertEqual(D.x, 'from derived x')
         self.assertEqual(D[str].z, 'from derived z')
 
+    def test_abc_registry_kept(self):
+        T = TypeVar('T')
+        class C(Generic[T]): ...
+        C.register(int)
+        self.assertIsInstance(1, C)
+        C[int]
+        self.assertIsInstance(1, C)
+
     def test_false_subclasses(self):
         class MyMapping(MutableMapping[str, str]): pass
         self.assertNotIsInstance({}, MyMapping)

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -674,6 +674,33 @@ class GenericTests(BaseTestCase):
         c.bar = 'abc'
         self.assertEqual(c.__dict__, {'bar': 'abc'})
 
+    def test_subscripted_generics_as_proxies(self):
+        T = TypeVar('T')
+        class C(Generic[T]):
+            x = 'def'
+        self.assertEqual(C[int].x, 'def')
+        self.assertEqual(C[C[int]].x, 'def')
+        C[C[int]].x = 'changed'
+        self.assertEqual(C.x, 'changed')
+        self.assertEqual(C[str].x, 'changed')
+        C[List[str]].z = 'new'
+        self.assertEqual(C.z, 'new')
+        self.assertEqual(C[Tuple[int]].z, 'new')
+
+        self.assertEqual(C().x, 'changed')
+        self.assertEqual(C[Tuple[str]]().z, 'new')
+
+        class D(C[T]):
+            pass
+        self.assertEqual(D[int].x, 'changed')
+        self.assertEqual(D.z, 'new')
+        D.z = 'from derived z'
+        D[int].x = 'from derived x'
+        self.assertEqual(C.x, 'changed')
+        self.assertEqual(C[int].z, 'new')
+        self.assertEqual(D.x, 'from derived x')
+        self.assertEqual(D[str].z, 'from derived z')
+
     def test_false_subclasses(self):
         class MyMapping(MutableMapping[str, str]): pass
         self.assertNotIsInstance({}, MyMapping)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1158,6 +1158,13 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
                               self.__parameters__, self.__args__, self.__origin__,
                               self.__extra__, self.__orig_bases__)
 
+    def __setattr__(self, attr, value):
+        # We consider all the subscripted genrics as proxies for original class
+        if attr.startswith('__') and attr.endswith('__'):
+            super(GenericMeta, self).__setattr__(attr, value)
+        else:
+            super(GenericMeta, _gorg(self)).__setattr__(attr, value)
+
 
 # Prevent checks for Generic to crash when defining Generic.
 Generic = None

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1160,7 +1160,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def __setattr__(self, attr, value):
         # We consider all the subscripted genrics as proxies for original class
-        if attr.startswith('__') and attr.endswith('__'):
+        if (
+            attr.startswith('__') and attr.endswith('__') or
+            attr.startswith('_abc_')
+        ):
             super(GenericMeta, self).__setattr__(attr, value)
         else:
             super(GenericMeta, _gorg(self)).__setattr__(attr, value)


### PR DESCRIPTION
(cherry picked from commit abb3b8ad94d699c8560d94ee9bac9c917b382abe)
(cherry picked from commit 365cb5bb9069273e6970c9d5d17ee2fe5003e7ac)