### PR TITLE
bpo-28556: Fix regression that sneaked into recent typing updates

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -701,6 +701,14 @@ class GenericTests(BaseTestCase):
         self.assertEqual(D.x, 'from derived x')
         self.assertEqual(D[str].z, 'from derived z')
 
+    def test_abc_registry_kept(self):
+        T = TypeVar('T')
+        class C(Generic[T]): ...
+        C.register(int)
+        self.assertIsInstance(1, C)
+        C[int]
+        self.assertIsInstance(1, C)
+
     def test_false_subclasses(self):
         class MyMapping(MutableMapping[str, str]): pass
         self.assertNotIsInstance({}, MyMapping)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -1160,7 +1160,10 @@ class GenericMeta(TypingMeta, abc.ABCMeta):
 
     def __setattr__(self, attr, value):
         # We consider all the subscripted genrics as proxies for original class
-        if attr.startswith('__') and attr.endswith('__'):
+        if (
+            attr.startswith('__') and attr.endswith('__') or
+            attr.startswith('_abc_')
+        ):
             super(GenericMeta, self).__setattr__(attr, value)
         else:
             super(GenericMeta, _gorg(self)).__setattr__(attr, value)


### PR DESCRIPTION
Unfortunately, recent update to typing module introduced a bug: ABC registry of a generic type gets completely wiped out on every subscription. This PR fixes the problem.