### PR TITLE
bpo-24905: Support BLOB incremental I/O in sqlite module

### DIFF
--- a/Doc/includes/sqlite3/blob.py
+++ b/Doc/includes/sqlite3/blob.py
@@ -1,0 +1,13 @@
+import sqlite3
+
+con = sqlite3.connect(":memory:")
+# creating the table
+con.execute("create table test(id integer primary key, blob_col blob)")
+con.execute("insert into test(blob_col) values (zeroblob(10))")
+# opening blob handle
+blob = con.open_blob("test", "blob_col", 1, 1)
+blob.write(b"a" * 5)
+blob.write(b"b" * 5)
+blob.seek(0)
+print(blob.read()) # will print b"aaaaabbbbb"
+blob.close()

--- a/Doc/includes/sqlite3/blob.py
+++ b/Doc/includes/sqlite3/blob.py
@@ -5,7 +5,7 @@ con = sqlite3.connect(":memory:")
 con.execute("create table test(id integer primary key, blob_col blob)")
 con.execute("insert into test(blob_col) values (zeroblob(10))")
 # opening blob handle
-blob = con.open_blob("test", "blob_col", 1, 1)
+blob = con.open_blob("test", "blob_col", 1)
 blob.write(b"Hello")
 blob.write(b"World")
 blob.seek(0)

--- a/Doc/includes/sqlite3/blob.py
+++ b/Doc/includes/sqlite3/blob.py
@@ -6,8 +6,8 @@ con.execute("create table test(id integer primary key, blob_col blob)")
 con.execute("insert into test(blob_col) values (zeroblob(10))")
 # opening blob handle
 blob = con.open_blob("test", "blob_col", 1, 1)
-blob.write(b"a" * 5)
-blob.write(b"b" * 5)
+blob.write(b"Hello")
+blob.write(b"World")
 blob.seek(0)
-print(blob.read()) # will print b"aaaaabbbbb"
+print(blob.read()) # will print b"HelloWorld"
 blob.close()

--- a/Doc/includes/sqlite3/blob_with.py
+++ b/Doc/includes/sqlite3/blob_with.py
@@ -1,0 +1,12 @@
+import sqlite3
+
+con = sqlite3.connect(":memory:")
+# creating the table
+con.execute("create table test(id integer primary key, blob_col blob)")
+con.execute("insert into test(blob_col) values (zeroblob(10))")
+# opening blob handle
+with con.open_blob("test", "blob_col", 1, 1) as blob:
+    blob.write(b"a" * 5)
+    blob.write(b"b" * 5)
+    blob.seek(0)
+    print(blob.read()) # will print b"aaaaabbbbb"

--- a/Doc/includes/sqlite3/blob_with.py
+++ b/Doc/includes/sqlite3/blob_with.py
@@ -6,7 +6,7 @@ con.execute("create table test(id integer primary key, blob_col blob)")
 con.execute("insert into test(blob_col) values (zeroblob(10))")
 # opening blob handle
 with con.open_blob("test", "blob_col", 1, 1) as blob:
-    blob.write(b"a" * 5)
-    blob.write(b"b" * 5)
+    blob.write(b"Hello")
+    blob.write(b"World")
     blob.seek(0)
-    print(blob.read()) # will print b"aaaaabbbbb"
+    print(blob.read()) # will print b"HelloWorld"

--- a/Doc/includes/sqlite3/blob_with.py
+++ b/Doc/includes/sqlite3/blob_with.py
@@ -5,7 +5,7 @@ con = sqlite3.connect(":memory:")
 con.execute("create table test(id integer primary key, blob_col blob)")
 con.execute("insert into test(blob_col) values (zeroblob(10))")
 # opening blob handle
-with con.open_blob("test", "blob_col", 1, 1) as blob:
+with con.open_blob("test", "blob_col", 1) as blob:
     blob.write(b"Hello")
     blob.write(b"World")
     blob.seek(0)

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -309,6 +309,11 @@ Connection Objects
       When *readonly* is :const:`True` the BLOB is opened with read
       permissions. Otherwise the BLOB has read and write permissions.
 
+      .. note::
+
+         The BLOB size cannot be changed using the :class:`Blob` class. Use
+         `zeroblob` to create the blob in the wanted size in advance.
+
       .. versionadded:: 3.7
 
    .. method:: commit()

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -314,7 +314,7 @@ Connection Objects
          The BLOB size cannot be changed using the :class:`Blob` class. Use
          ``zeroblob`` to create the blob in the wanted size in advance.
 
-      .. versionadded:: 3.7
+      .. versionadded:: 3.8
 
    .. method:: commit()
 
@@ -873,7 +873,7 @@ Exceptions
 Blob Objects
 ------------
 
-.. versionadded:: 3.7
+.. versionadded:: 3.8
 
 .. class:: Blob
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -878,7 +878,9 @@ Blob Objects
 .. class:: Blob
 
    A :class:`Blob` instance can read and write the data in the
-   :abbr:`BLOB (Binary Large OBject)`.
+   :abbr:`BLOB (Binary Large OBject)`. The :class:`Blob` object implement both
+   the file and sequence protocol. For example You can read data from the
+   :class:`Blob` by doing ``obj.read(5)`` or by doing ``obj[:5]``.
 
    .. method:: Blob.close()
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -312,7 +312,7 @@ Connection Objects
       .. note::
 
          The BLOB size cannot be changed using the :class:`Blob` class. Use
-         `zeroblob` to create the blob in the wanted size in advance.
+         ``zeroblob`` to create the blob in the wanted size in advance.
 
       .. versionadded:: 3.7
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -301,7 +301,7 @@ Connection Objects
       supplied, this must be a callable returning an instance of :class:`Cursor`
       or its subclasses.
 
-   .. method:: open_blob(table, column, row, readonly=False, dbname="main")
+   .. method:: open_blob(table, column, row, *, readonly=False, dbname="main")
 
       On success a :class:`Blob` handle to the
       :abbr:`BLOB (Binary Large OBject)` located in row *row*,

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -314,7 +314,7 @@ Connection Objects
          The BLOB size cannot be changed using the :class:`Blob` class. Use
          ``zeroblob`` to create the blob in the wanted size in advance.
 
-      .. versionadded:: 3.8
+      .. versionadded:: 3.10
 
    .. method:: commit()
 
@@ -873,7 +873,7 @@ Exceptions
 Blob Objects
 ------------
 
-.. versionadded:: 3.8
+.. versionadded:: 3.10
 
 .. class:: Blob
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -301,6 +301,16 @@ Connection Objects
       supplied, this must be a callable returning an instance of :class:`Cursor`
       or its subclasses.
 
+   .. method:: open_blob(table, column, row, readonly=False, dbname="main")
+
+      On success a :class:`Blob` handle to the
+      :abbr:`BLOB (Binary Large OBject)` located in row *row*,
+      column *column*, table *table* in database *dbname* will be returned.
+      When *readonly* is :const:`True` the BLOB is opened with read
+      permissions. Otherwise the BLOB has read and write permissions.
+
+      .. versionadded:: 3.7
+
    .. method:: commit()
 
       This method commits the current transaction. If you don't call this method,
@@ -851,6 +861,63 @@ Exceptions
    supported by the database, e.g. calling the :meth:`~Connection.rollback`
    method on a connection that does not support transaction or has
    transactions turned off.  It is a subclass of :exc:`DatabaseError`.
+
+
+.. _sqlite3-blob-objects:
+
+Blob Objects
+------------
+
+.. versionadded:: 3.7
+
+.. class:: Blob
+
+   A :class:`Blob` instance can read and write the data in the
+   :abbr:`BLOB (Binary Large OBject)`.
+
+   .. method:: Blob.close()
+
+      Close the BLOB now (rather than whenever __del__ is called).
+
+      The BLOB will be unusable from this point forward; an
+      :class:`~sqlite3.Error` (or subclass) exception will be
+      raised if any operation is attempted with the BLOB.
+
+   .. method:: Blob.__len__()
+
+      Return the BLOB size.
+
+   .. method:: Blob.read([size])
+
+      Read *size* bytes of data from the BLOB at the current offset position.
+      If the end of the BLOB is reached we will return the data up to end of
+      file. When *size* is not specified or negative we will read up to end
+      of BLOB.
+
+   .. method:: Blob.write(data)
+
+      Write *data* to the BLOB at the current offset. This function cannot
+      changed BLOB length. If data write will result in writing to more
+      then BLOB current size an error will be raised.
+
+   .. method:: Blob.tell()
+
+      Return the current offset of the BLOB.
+
+   .. method:: Blob.seek(offset, [whence])
+
+      Set the BLOB offset. The *whence* argument is optional and defaults to
+      :data:`os.SEEK_SET` or 0 (absolute BLOB positioning); other values
+      are :data:`os.SEEK_CUR` or 1 (seek relative to the current position) and
+      :data:`os.SEEK_END` or 2 (seek relative to the BLOB’s end).
+
+   :class:`Blob` example:
+
+      .. literalinclude:: ../includes/sqlite3/blob.py
+
+   A :class:`Blob` can also be used with :term:`context manager`:
+
+      .. literalinclude:: ../includes/sqlite3/blob_with.py
 
 
 .. _sqlite3-types:

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -879,8 +879,9 @@ Blob Objects
 
    A :class:`Blob` instance can read and write the data in the
    :abbr:`BLOB (Binary Large OBject)`. The :class:`Blob` object implement both
-   the file and sequence protocol. For example You can read data from the
+   the file and sequence protocol. For example, you can read data from the
    :class:`Blob` by doing ``obj.read(5)`` or by doing ``obj[:5]``.
+   You can call ``len(obj)`` to get size of the BLOB.
 
    .. method:: Blob.close()
 
@@ -911,7 +912,7 @@ Blob Objects
 
       Return the current offset of the BLOB.
 
-   .. method:: Blob.seek(offset, [whence])
+   .. method:: Blob.seek(offset, whence=os.SEEK_SET)
 
       Set the BLOB offset. The *whence* argument is optional and defaults to
       :data:`os.SEEK_SET` or 0 (absolute BLOB positioning); other values

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -546,22 +546,12 @@ class BlobTests(unittest.TestCase):
         self.assertEqual(self.blob.tell(), 90)
 
     def CheckBlobSeekOverBlobSize(self):
-        try:
+        with self.assertRaises(ValueError):
             self.blob.seek(1000)
-            self.fail("should have raised a ValueError")
-        except ValueError:
-            pass
-        except Exception:
-            self.fail("should have raised a ValueError")
 
     def CheckBlobSeekUnderBlobSize(self):
-        try:
+        with self.assertRaises(ValueError):
             self.blob.seek(-10)
-            self.fail("should have raised a ValueError")
-        except ValueError:
-            pass
-        except Exception:
-            self.fail("should have raised a ValueError")
 
     def CheckBlobRead(self):
         self.assertEqual(self.blob.read(), self.blob_data)
@@ -594,81 +584,41 @@ class BlobTests(unittest.TestCase):
         self.assertEqual(self.blob.tell(), 50)
 
     def CheckBlobWriteMoreThenBlobSize(self):
-        try:
+        with self.assertRaises(sqlite.OperationalError):
             self.blob.write(b"a" * 1000)
-            self.fail("should have raised a sqlite.OperationalError")
-        except sqlite.OperationalError:
-            pass
-        except Exception:
-            self.fail("should have raised a sqlite.OperationalError")
 
     def CheckBlobReadAfterRowChange(self):
         self.cx.execute("UPDATE test SET blob_col='aaaa' where id=1")
-        try:
+        with self.assertRaises(sqlite.OperationalError):
             self.blob.read()
-            self.fail("should have raised a sqlite.OperationalError")
-        except sqlite.OperationalError:
-            pass
-        except Exception:
-            self.fail("should have raised a sqlite.OperationalError")
 
     def CheckBlobWriteAfterRowChange(self):
         self.cx.execute("UPDATE test SET blob_col='aaaa' where id=1")
-        try:
+        with self.assertRaises(sqlite.OperationalError):
             self.blob.write(b"aaa")
-            self.fail("should have raised a sqlite.OperationalError")
-        except sqlite.OperationalError:
-            pass
-        except Exception:
-            self.fail("should have raised a sqlite.OperationalError")
 
     def CheckBlobWriteWhenReadOnly(self):
         read_only_blob = \
             self.cx.open_blob("test", "blob_col", 1, readonly=True)
-        try:
+        with self.assertRaises(sqlite.OperationalError):
             read_only_blob.write(b"aaa")
-            self.fail("should have raised a sqlite.OperationalError")
-        except sqlite.OperationalError:
-            pass
-        except Exception:
-            self.fail("should have raised a sqlite.OperationalError")
         read_only_blob.close()
 
     def CheckBlobOpenWithBadDb(self):
-        try:
+        with self.assertRaises(sqlite.OperationalError):
             self.cx.open_blob("test", "blob_col", 1, dbname="notexisintg")
-            self.fail("should have raised a sqlite.OperationalError")
-        except sqlite.OperationalError:
-            pass
-        except Exception:
-            self.fail("should have raised a sqlite.OperationalError")
 
     def CheckBlobOpenWithBadTable(self):
-        try:
+        with self.assertRaises(sqlite.OperationalError):
             self.cx.open_blob("notexisintg", "blob_col", 1)
-            self.fail("should have raised a sqlite.OperationalError")
-        except sqlite.OperationalError:
-            pass
-        except Exception:
-            self.fail("should have raised a sqlite.OperationalError")
 
     def CheckBlobOpenWithBadColumn(self):
-        try:
+        with self.assertRaises(sqlite.OperationalError):
             self.cx.open_blob("test", "notexisting", 1)
-            self.fail("should have raised a sqlite.OperationalError")
-        except sqlite.OperationalError:
-            pass
-        except Exception:
-            self.fail("should have raised a sqlite.OperationalError")
 
     def CheckBlobOpenWithBadRow(self):
-        try:
+        with self.assertRaises(sqlite.OperationalError):
             self.cx.open_blob("test", "blob_col", 2)
-            self.fail("should have raised a sqlite.OperationalError")
-        except sqlite.OperationalError:
-            pass
-        except Exception:
-            self.fail("should have raised a sqlite.OperationalError")
 
 
 @unittest.skipUnless(threading, 'This test requires threading.')
@@ -935,13 +885,8 @@ class ClosedConTests(unittest.TestCase):
         con.execute("insert into test(blob_col) values (zeroblob(100))")
         blob = con.open_blob("test", "blob_col", 1)
         con.close()
-        try:
+        with self.assertRaises(sqlite.ProgrammingError):
             blob.read()
-            self.fail("Should have raised a ProgrammingError")
-        except sqlite.ProgrammingError:
-            pass
-        except:
-            self.fail("Should have raised a ProgrammingError")
 
     def CheckClosedCreateFunction(self):
         con = sqlite.connect(":memory:")
@@ -1109,57 +1054,32 @@ class ClosedBlobTests(unittest.TestCase):
     def CheckClosedRead(self):
         self.blob = self.cx.open_blob("test", "blob_col", 1)
         self.blob.close()
-        try:
+        with self.assertRaises(sqlite.ProgrammingError):
             self.blob.read()
-            self.fail("Should have raised a ProgrammingError")
-        except sqlite.ProgrammingError:
-            pass
-        except Exception:
-            self.fail("Should have raised a ProgrammingError")
 
     def CheckClosedWrite(self):
         self.blob = self.cx.open_blob("test", "blob_col", 1)
         self.blob.close()
-        try:
+        with self.assertRaises(sqlite.ProgrammingError):
             self.blob.write(b"aaaaaaaaa")
-            self.fail("Should have raised a ProgrammingError")
-        except sqlite.ProgrammingError:
-            pass
-        except Exception:
-            self.fail("Should have raised a ProgrammingError")
 
     def CheckClosedSeek(self):
         self.blob = self.cx.open_blob("test", "blob_col", 1)
         self.blob.close()
-        try:
+        with self.assertRaises(sqlite.ProgrammingError):
             self.blob.seek(10)
-            self.fail("Should have raised a ProgrammingError")
-        except sqlite.ProgrammingError:
-            pass
-        except Exception:
-            self.fail("Should have raised a ProgrammingError")
 
     def CheckClosedTell(self):
         self.blob = self.cx.open_blob("test", "blob_col", 1)
         self.blob.close()
-        try:
+        with self.assertRaises(sqlite.ProgrammingError):
             self.blob.tell()
-            self.fail("Should have raised a ProgrammingError")
-        except sqlite.ProgrammingError:
-            pass
-        except Exception:
-            self.fail("Should have raised a ProgrammingError")
 
     def CheckClosedClose(self):
         self.blob = self.cx.open_blob("test", "blob_col", 1)
         self.blob.close()
-        try:
+        with self.assertRaises(sqlite.ProgrammingError):
             self.blob.close()
-            self.fail("Should have raised a ProgrammingError")
-        except sqlite.ProgrammingError:
-            pass
-        except Exception:
-            self.fail("Should have raised a ProgrammingError")
 
 
 class BlobContextManagerTests(unittest.TestCase):
@@ -1180,13 +1100,8 @@ class BlobContextManagerTests(unittest.TestCase):
     def CheckContextCloseBlob(self):
         with self.cx.open_blob("test", "blob_col", 1) as blob:
             blob.seek(10)
-        try:
+        with self.assertRaises(sqlite.ProgrammingError):
             blob.close()
-            self.fail("Should have raised a ProgrammingError")
-        except sqlite.ProgrammingError:
-            pass
-        except Exception:
-            self.fail("Should have raised a ProgrammingError")
 
 
 def suite():

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -511,6 +511,167 @@ class CursorTests(unittest.TestCase):
         self.assertEqual(results, expected)
 
 
+class BlobTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(id integer primary key, blob_col blob)")
+        self.blob_data = b"a" * 100
+        self.cx.execute("insert into test(blob_col) values (?)", (self.blob_data, ))
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.second_data = b"b" * 100
+
+    def tearDown(self):
+        self.blob.close()
+        self.cx.close()
+
+    def CheckLength(self):
+        self.assertEqual(len(self.blob), 100)
+
+    def CheckTell(self):
+        self.assertEqual(self.blob.tell(), 0)
+
+    def CheckSeekFromBlobStart(self):
+        self.blob.seek(10)
+        self.assertEqual(self.blob.tell(), 10)
+        self.blob.seek(10, 0)
+        self.assertEqual(self.blob.tell(), 10)
+
+    def CheckSeekFromCurrentPosition(self):
+        self.blob.seek(10, 1)
+        self.blob.seek(10, 1)
+        self.assertEqual(self.blob.tell(), 20)
+
+    def CheckSeekFromBlobEnd(self):
+        self.blob.seek(-10, 2)
+        self.assertEqual(self.blob.tell(), 90)
+
+    def CheckBlobSeekOverBlobSize(self):
+        try:
+            self.blob.seek(1000)
+            self.fail("should have raised a ValueError")
+        except ValueError:
+            pass
+        except Exception:
+            self.fail("should have raised a ValueError")
+
+    def CheckBlobSeekUnderBlobSize(self):
+        try:
+            self.blob.seek(-10)
+            self.fail("should have raised a ValueError")
+        except ValueError:
+            pass
+        except Exception:
+            self.fail("should have raised a ValueError")
+
+    def CheckBlobRead(self):
+        self.assertEqual(self.blob.read(), self.blob_data)
+
+    def CheckBlobReadSize(self):
+        self.assertEqual(len(self.blob.read(10)), 10)
+
+    def CheckBlobReadAdvanceOffset(self):
+        self.blob.read(10)
+        self.assertEqual(self.blob.tell(), 10)
+
+    def CheckBlobReadStartAtOffset(self):
+        self.blob.seek(10)
+        self.blob.write(self.second_data[:10])
+        self.blob.seek(10)
+        self.assertEqual(self.blob.read(10), self.second_data[:10])
+
+    def CheckBlobWrite(self):
+        self.blob.write(self.second_data)
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], self.second_data)
+
+    def CheckBlobWriteAtOffset(self):
+        self.blob.seek(50)
+        self.blob.write(self.second_data[:50])
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0],
+                         self.blob_data[:50] + self.second_data[:50])
+
+    def CheckBlobWriteAdvanceOffset(self):
+        self.blob.write(self.second_data[:50])
+        self.assertEqual(self.blob.tell(), 50)
+
+    def CheckBlobWriteMoreThenBlobSize(self):
+        try:
+            self.blob.write(b"a" * 1000)
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobReadAfterRowChange(self):
+        self.cx.execute("UPDATE test SET blob_col='aaaa' where id=1")
+        try:
+            self.blob.read()
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobWriteAfterRowChange(self):
+        self.cx.execute("UPDATE test SET blob_col='aaaa' where id=1")
+        try:
+            self.blob.write(b"aaa")
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobWriteWhenReadOnly(self):
+        read_only_blob = \
+            self.cx.open_blob("test", "blob_col", 1, readonly=True)
+        try:
+            read_only_blob.write(b"aaa")
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+        read_only_blob.close()
+
+    def CheckBlobOpenWithBadDb(self):
+        try:
+            self.cx.open_blob("test", "blob_col", 1, dbname="notexisintg")
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobOpenWithBadTable(self):
+        try:
+            self.cx.open_blob("notexisintg", "blob_col", 1)
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobOpenWithBadColumn(self):
+        try:
+            self.cx.open_blob("test", "notexisting", 1)
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+    def CheckBlobOpenWithBadRow(self):
+        try:
+            self.cx.open_blob("test", "blob_col", 2)
+            self.fail("should have raised a sqlite.OperationalError")
+        except sqlite.OperationalError:
+            pass
+        except Exception:
+            self.fail("should have raised a sqlite.OperationalError")
+
+
+@unittest.skipUnless(threading, 'This test requires threading.')
 class ThreadTests(unittest.TestCase):
     def setUp(self):
         self.con = sqlite.connect(":memory:")
@@ -768,6 +929,20 @@ class ClosedConTests(unittest.TestCase):
         with self.assertRaises(sqlite.ProgrammingError):
             cur.execute("select 4")
 
+    def CheckClosedBlobRead(self):
+        con = sqlite.connect(":memory:")
+        con.execute("create table test(id integer primary key, blob_col blob)")
+        con.execute("insert into test(blob_col) values (zeroblob(100))")
+        blob = con.open_blob("test", "blob_col", 1)
+        con.close()
+        try:
+            blob.read()
+            self.fail("Should have raised a ProgrammingError")
+        except sqlite.ProgrammingError:
+            pass
+        except:
+            self.fail("Should have raised a ProgrammingError")
+
     def CheckClosedCreateFunction(self):
         con = sqlite.connect(":memory:")
         con.close()
@@ -921,6 +1096,99 @@ class SqliteOnConflictTests(unittest.TestCase):
         self.assertEqual(self.cu.fetchall(), [('Very different data!', 'foo')])
 
 
+
+class ClosedBlobTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(id integer primary key, blob_col blob)")
+        self.cx.execute("insert into test(blob_col) values (zeroblob(100))")
+
+    def tearDown(self):
+        self.cx.close()
+
+    def CheckClosedRead(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        try:
+            self.blob.read()
+            self.fail("Should have raised a ProgrammingError")
+        except sqlite.ProgrammingError:
+            pass
+        except Exception:
+            self.fail("Should have raised a ProgrammingError")
+
+    def CheckClosedWrite(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        try:
+            self.blob.write(b"aaaaaaaaa")
+            self.fail("Should have raised a ProgrammingError")
+        except sqlite.ProgrammingError:
+            pass
+        except Exception:
+            self.fail("Should have raised a ProgrammingError")
+
+    def CheckClosedSeek(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        try:
+            self.blob.seek(10)
+            self.fail("Should have raised a ProgrammingError")
+        except sqlite.ProgrammingError:
+            pass
+        except Exception:
+            self.fail("Should have raised a ProgrammingError")
+
+    def CheckClosedTell(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        try:
+            self.blob.tell()
+            self.fail("Should have raised a ProgrammingError")
+        except sqlite.ProgrammingError:
+            pass
+        except Exception:
+            self.fail("Should have raised a ProgrammingError")
+
+    def CheckClosedClose(self):
+        self.blob = self.cx.open_blob("test", "blob_col", 1)
+        self.blob.close()
+        try:
+            self.blob.close()
+            self.fail("Should have raised a ProgrammingError")
+        except sqlite.ProgrammingError:
+            pass
+        except Exception:
+            self.fail("Should have raised a ProgrammingError")
+
+
+class BlobContextManagerTests(unittest.TestCase):
+    def setUp(self):
+        self.cx = sqlite.connect(":memory:")
+        self.cx.execute("create table test(id integer primary key, blob_col blob)")
+        self.cx.execute("insert into test(blob_col) values (zeroblob(100))")
+
+    def tearDown(self):
+        self.cx.close()
+
+    def CheckContextExecute(self):
+        data = b"a" * 100
+        with self.cx.open_blob("test", "blob_col", 1) as blob:
+            blob.write(data)
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], data)
+
+    def CheckContextCloseBlob(self):
+        with self.cx.open_blob("test", "blob_col", 1) as blob:
+            blob.seek(10)
+        try:
+            blob.close()
+            self.fail("Should have raised a ProgrammingError")
+        except sqlite.ProgrammingError:
+            pass
+        except Exception:
+            self.fail("Should have raised a ProgrammingError")
+
+
 def suite():
     module_suite = unittest.makeSuite(ModuleTests, "Check")
     connection_suite = unittest.makeSuite(ConnectionTests, "Check")
@@ -931,11 +1199,12 @@ def suite():
     closed_con_suite = unittest.makeSuite(ClosedConTests, "Check")
     closed_cur_suite = unittest.makeSuite(ClosedCurTests, "Check")
     on_conflict_suite = unittest.makeSuite(SqliteOnConflictTests, "Check")
-    return unittest.TestSuite((
-        module_suite, connection_suite, cursor_suite, thread_suite,
-        constructor_suite, ext_suite, closed_con_suite, closed_cur_suite,
-        on_conflict_suite,
-    ))
+    blob_suite = unittest.makeSuite(BlobTests, "Check")
+    closed_blob_suite = unittest.makeSuite(ClosedBlobTests, "Check")
+    blob_context_manager_suite = unittest.makeSuite(BlobContextManagerTests, "Check")
+    return unittest.TestSuite((module_suite, connection_suite, cursor_suite, thread_suite, constructor_suite,
+                               ext_suite, closed_con_suite, closed_cur_suite, on_conflict_suite,
+                               blob_suite, closed_blob_suite, blob_context_manager_suite))
 
 def test():
     runner = unittest.TextTestRunner()

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -620,6 +620,62 @@ class BlobTests(unittest.TestCase):
         with self.assertRaises(sqlite.OperationalError):
             self.cx.open_blob("test", "blob_col", 2)
 
+    def CheckBlobGetItem(self):
+        self.assertEqual(self.blob[5], b"a")
+
+    def CheckBlobGetItemIndexOutOfRange(self):
+        with self.assertRaises(IndexError):
+            self.blob[105]
+        with self.assertRaises(IndexError):
+            self.blob[-105]
+
+    def CheckBlobGetItemNegativeIndex(self):
+        self.assertEqual(self.blob[-5], b"a")
+
+    def CheckBlobGetItemInvalidIndex(self):
+        with self.assertRaises(TypeError):
+            self.blob[b"a"]
+
+    def CheckBlobGetSlice(self):
+        self.assertEqual(self.blob[5:10], b"aaaaa")
+
+    def CheckBlobGetSliceNegativeIndex(self):
+        self.assertEqual(self.blob[5:-5], self.blob_data[5:-5])
+
+    def CheckBlobGetSliceInvalidIndex(self):
+        with self.assertRaises(TypeError):
+            self.blob[5:b"a"]
+
+    def CheckBlobGetSliceWithSkip(self):
+        self.blob.write(b"abcdefghij")
+        self.assertEqual(self.blob[0:10:2], b"acegi")
+
+    def CheckBlobSetItem(self):
+        self.blob[0] = b"b"
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], b"b" + self.blob_data[1:])
+
+    def CheckBlobSetSlice(self):
+        self.blob[0:5] = b"bbbbb"
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], b"bbbbb" + self.blob_data[5:])
+
+    def CheckBlobSetSliceWithSkip(self):
+        self.blob[0:10:2] = b"bbbbb"
+        self.assertEqual(self.cx.execute("select blob_col from test").fetchone()[0], b"bababababa" + self.blob_data[10:])
+
+    def CheckBlobGetEmptySlice(self):
+        self.assertEqual(self.blob[5:5], b"")
+
+    def CheckBlobSetSliceWrongLength(self):
+        with self.assertRaises(IndexError):
+            self.blob[5:10] = b"a"
+
+    def CheckBlobConcatNotSupported(self):
+        with self.assertRaises(SystemError):
+            self.blob + self.blob
+
+    def CheckBlobRepeateNotSupported(self):
+        with self.assertRaises(SystemError):
+            self.blob * 5
 
 @unittest.skipUnless(threading, 'This test requires threading.')
 class ThreadTests(unittest.TestCase):

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -677,6 +677,10 @@ class BlobTests(unittest.TestCase):
         with self.assertRaises(SystemError):
             self.blob * 5
 
+    def CheckBlobContainsNotSupported(self):
+        with self.assertRaises(SystemError):
+            b"aaaaa" in self.blob
+
 @unittest.skipUnless(threading, 'This test requires threading.')
 class ThreadTests(unittest.TestCase):
     def setUp(self):

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -584,7 +584,7 @@ class BlobTests(unittest.TestCase):
         self.assertEqual(self.blob.tell(), 50)
 
     def CheckBlobWriteMoreThenBlobSize(self):
-        with self.assertRaises(sqlite.OperationalError):
+        with self.assertRaises(ValueError):
             self.blob.write(b"a" * 1000)
 
     def CheckBlobReadAfterRowChange(self):

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -1177,9 +1177,11 @@ def suite():
     blob_suite = unittest.makeSuite(BlobTests, "Check")
     closed_blob_suite = unittest.makeSuite(ClosedBlobTests, "Check")
     blob_context_manager_suite = unittest.makeSuite(BlobContextManagerTests, "Check")
-    return unittest.TestSuite((module_suite, connection_suite, cursor_suite, thread_suite, constructor_suite,
-                               ext_suite, closed_con_suite, closed_cur_suite, on_conflict_suite,
-                               blob_suite, closed_blob_suite, blob_context_manager_suite))
+    return unittest.TestSuite((
+        module_suite, connection_suite, cursor_suite, thread_suite, constructor_suite,
+        ext_suite, closed_con_suite, closed_cur_suite, on_conflict_suite,
+        blob_suite, closed_blob_suite, blob_context_manager_suite,
+        ))
 
 def test():
     runner = unittest.TextTestRunner()

--- a/Misc/NEWS.d/next/Library/2018-04-18-16-15-55.bpo-24905.jYqjYx.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-18-16-15-55.bpo-24905.jYqjYx.rst
@@ -1,0 +1,4 @@
+The :class:`sqlite3.Connection` now has the
+:meth:`sqlite3.Connection.open_blob` method. The :class:`sqlite3.Blob`
+allows incremental I/O operations to blobs. (Contributed by Aviv Palivoda in
+:issue:`24905`)

--- a/Misc/NEWS.d/next/Library/2018-04-18-16-15-55.bpo-24905.jYqjYx.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-18-16-15-55.bpo-24905.jYqjYx.rst
@@ -1,4 +1,4 @@
 The :class:`sqlite3.Connection` now has the
 :meth:`sqlite3.Connection.open_blob` method. The :class:`sqlite3.Blob`
-allows incremental I/O operations to blobs. (Contributed by Aviv Palivoda in
+allows incremental I/O operations to blobs. (Patch by Aviv Palivoda in
 :issue:`24905`)

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -327,6 +327,15 @@ static PyObject* pysqlite_blob_repeat(pysqlite_Blob *self, PyObject *args)
     return NULL;
 }
 
+static int pysqlite_blob_contains(pysqlite_Blob *self, PyObject *args)
+{
+    if (pysqlite_check_blob(self)) {
+        PyErr_SetString(PyExc_SystemError,
+                        "Blob don't support cotains operation");
+    }
+    return -1;
+}
+
 static PyObject* pysqlite_blob_item(pysqlite_Blob *self, Py_ssize_t i)
 {
     if (!pysqlite_check_blob(self)) {
@@ -606,6 +615,7 @@ static PySequenceMethods blob_sequence_methods = {
     .sq_repeat = (ssizeargfunc)pysqlite_blob_repeat,
     .sq_item = (ssizeargfunc)pysqlite_blob_item,
     .sq_ass_item = (ssizeobjargproc)pysqlite_blob_ass_item,
+    .sq_contains = (objobjproc)pysqlite_blob_contains,
 };
 
 static PyMappingMethods blob_mapping_methods = {

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -1,0 +1,342 @@
+#include "blob.h"
+#include "util.h"
+
+
+int pysqlite_blob_init(pysqlite_Blob *self, pysqlite_Connection* connection,
+                       sqlite3_blob *blob)
+{
+    Py_INCREF(connection);
+    self->connection = connection;
+    self->offset = 0;
+    self->blob = blob;
+    self->in_weakreflist = NULL;
+
+    if (!pysqlite_check_thread(self->connection)) {
+        return -1;
+    }
+    return 0;
+}
+
+static void remove_blob_from_connection_blob_list(pysqlite_Blob *self)
+{
+    Py_ssize_t i;
+    PyObject *item;
+
+    for (i = 0; i < PyList_GET_SIZE(self->connection->blobs); i++) {
+        item = PyList_GET_ITEM(self->connection->blobs, i);
+        if (PyWeakref_GetObject(item) == (PyObject *)self) {
+            PyList_SetSlice(self->connection->blobs, i, i+1, NULL);
+            break;
+        }
+    }
+}
+
+static void _close_blob_inner(pysqlite_Blob* self)
+{
+    sqlite3_blob *blob;
+
+    /* close the blob */
+    blob = self->blob;
+    self->blob = NULL;
+    if (blob) {
+        Py_BEGIN_ALLOW_THREADS
+        sqlite3_blob_close(blob);
+        Py_END_ALLOW_THREADS
+    }
+
+    /* remove from connection weaklist */
+    remove_blob_from_connection_blob_list(self);
+    if (self->in_weakreflist != NULL) {
+        PyObject_ClearWeakRefs((PyObject*)self);
+    }   
+}
+
+static void pysqlite_blob_dealloc(pysqlite_Blob* self)
+{
+    _close_blob_inner(self);
+    Py_XDECREF(self->connection);
+    Py_TYPE(self)->tp_free((PyObject*)self);
+}
+
+
+/*
+ * Checks if a blob object is usable (i. e. not closed).
+ *
+ * 0 => error; 1 => ok
+ */
+int pysqlite_check_blob(pysqlite_Blob *blob)
+{
+
+    if (!blob->blob) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Cannot operate on a closed blob.");
+        return 0;
+    } else if (!pysqlite_check_connection(blob->connection) ||
+               !pysqlite_check_thread(blob->connection)) {
+        return 0;
+    } else {
+        return 1;
+    }
+}
+
+
+PyObject* pysqlite_blob_close(pysqlite_Blob *self)
+{
+
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    _close_blob_inner(self);
+    Py_RETURN_NONE;
+};
+
+
+static Py_ssize_t pysqlite_blob_length(pysqlite_Blob *self)
+{
+    int blob_length;
+    if (!pysqlite_check_blob(self)) {
+        return -1;
+    }
+    Py_BEGIN_ALLOW_THREADS
+    blob_length = sqlite3_blob_bytes(self->blob);
+    Py_END_ALLOW_THREADS
+
+    return blob_length;
+};
+
+
+PyObject* pysqlite_blob_read(pysqlite_Blob *self, PyObject *args)
+{
+    int read_length = -1;
+    int blob_length = 0;
+    PyObject *buffer;
+    char *raw_buffer;
+    int rc;
+
+    if (!PyArg_ParseTuple(args, "|i", &read_length)) {
+        return NULL;
+    }
+
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+
+    /* TODO: make this multithreaded and safe! */
+    Py_BEGIN_ALLOW_THREADS
+    blob_length = sqlite3_blob_bytes(self->blob);
+    Py_END_ALLOW_THREADS
+
+    if (read_length < 0) {
+        /* same as file read. */
+        read_length = blob_length;
+    }
+
+    /* making sure we don't read more then blob size */
+    if (read_length > blob_length - self->offset) {
+        read_length = blob_length - self->offset;
+    }
+
+    buffer = PyBytes_FromStringAndSize(NULL, read_length);
+    if (!buffer) {
+        return NULL;
+    }
+    raw_buffer = PyBytes_AS_STRING(buffer);
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_blob_read(self->blob, raw_buffer, read_length, self->offset);
+    Py_END_ALLOW_THREADS
+
+    if (rc != SQLITE_OK){
+        Py_DECREF(buffer);
+        /* For some reason after modifying blob the
+           error is not set on the connection db. */
+        if (rc == SQLITE_ABORT) {
+            PyErr_SetString(pysqlite_OperationalError,
+                            "Cannot operate on modified blob");
+        } else {
+            _pysqlite_seterror(self->connection->db, NULL);
+        }
+        return NULL;
+    }
+
+    /* update offset. */
+    self->offset += read_length;
+
+    return buffer;
+};
+
+
+PyObject* pysqlite_blob_write(pysqlite_Blob *self, PyObject *data)
+{
+    Py_buffer data_buffer;
+    int rc;
+
+    if (PyObject_GetBuffer(data, &data_buffer, PyBUF_SIMPLE) < 0) {
+        return NULL;
+    }
+
+    if (data_buffer.len > INT_MAX) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "data longer than INT_MAX bytes");
+        PyBuffer_Release(&data_buffer);
+        return NULL;
+    }
+
+    if (!pysqlite_check_blob(self)) {
+        PyBuffer_Release(&data_buffer);
+        return NULL;
+    }
+
+    /* TODO: throw better error on data bigger then blob. */
+
+    Py_BEGIN_ALLOW_THREADS
+    rc = sqlite3_blob_write(self->blob, data_buffer.buf,
+                            data_buffer.len, self->offset);
+    Py_END_ALLOW_THREADS
+    if (rc != SQLITE_OK) {
+        /* For some reason after modifying blob the
+        error is not set on the connection db. */
+        if (rc == SQLITE_ABORT) {
+            PyErr_SetString(pysqlite_OperationalError,
+                            "Cannot operate on modified blob");
+        } else {
+            _pysqlite_seterror(self->connection->db, NULL);
+        }
+        PyBuffer_Release(&data_buffer);
+        return NULL;
+    }
+
+    self->offset += (int)data_buffer.len;
+    PyBuffer_Release(&data_buffer);
+    Py_RETURN_NONE;
+}
+
+
+PyObject* pysqlite_blob_seek(pysqlite_Blob *self, PyObject *args)
+{
+    int blob_length, offset, from_what = 0;
+
+    if (!PyArg_ParseTuple(args, "i|i", &offset, &from_what)) {
+        return NULL;
+    }
+
+
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    Py_BEGIN_ALLOW_THREADS
+    blob_length = sqlite3_blob_bytes(self->blob);
+    Py_END_ALLOW_THREADS
+
+    switch (from_what) {
+        case 0:  // relative to blob begin
+            break;
+        case 1:  // relative to current position
+            if (offset > INT_MAX - self->offset) {
+                goto overflow;
+            }
+            offset = self->offset + offset;
+            break;
+        case 2:  // relative to blob end
+            if (offset > INT_MAX - blob_length) {
+                goto overflow;
+            }
+            offset = blob_length + offset;
+            break;
+        default:
+            return PyErr_Format(PyExc_ValueError,
+                                "from_what should be 0, 1 or 2");
+    }
+
+    if (offset < 0 || offset > blob_length) {
+        return PyErr_Format(PyExc_ValueError, "offset out of blob range");
+    }
+
+    self->offset = offset;
+    Py_RETURN_NONE;
+
+overflow:
+    return PyErr_Format(PyExc_OverflowError, "seek offset result in overflow");
+}
+
+
+PyObject* pysqlite_blob_tell(pysqlite_Blob *self)
+{
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    return PyLong_FromLong(self->offset);
+}
+
+
+PyObject* pysqlite_blob_enter(pysqlite_Blob *self)
+{
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    Py_INCREF(self);
+    return (PyObject *)self;
+}
+
+
+PyObject* pysqlite_blob_exit(pysqlite_Blob *self, PyObject *args)
+{
+    PyObject *res;
+    if (!pysqlite_check_blob(self)) {
+        return NULL;
+    }
+
+    res = pysqlite_blob_close(self);
+    if (!res) {
+        return NULL;
+    }
+    Py_XDECREF(res);
+
+    Py_RETURN_FALSE;
+}
+
+
+static PyMethodDef blob_methods[] = {
+    {"read", (PyCFunction)pysqlite_blob_read, METH_VARARGS,
+        PyDoc_STR("read data from blob")},
+    {"write", (PyCFunction)pysqlite_blob_write, METH_O,
+        PyDoc_STR("write data to blob")},
+    {"close", (PyCFunction)pysqlite_blob_close, METH_NOARGS,
+        PyDoc_STR("close blob")},
+    {"seek", (PyCFunction)pysqlite_blob_seek, METH_VARARGS,
+        PyDoc_STR("change blob current offset")},
+    {"tell", (PyCFunction)pysqlite_blob_tell, METH_NOARGS,
+        PyDoc_STR("return blob current offset")},
+    {"__enter__", (PyCFunction)pysqlite_blob_enter, METH_NOARGS,
+        PyDoc_STR("blob context manager enter")},
+    {"__exit__", (PyCFunction)pysqlite_blob_exit, METH_VARARGS,
+        PyDoc_STR("blob context manager exit")},
+    {NULL, NULL}
+};
+
+static PySequenceMethods blob_sequence_methods = {
+    (lenfunc)pysqlite_blob_length,         /* sq_length */
+};
+
+
+PyTypeObject pysqlite_BlobType = {
+        PyVarObject_HEAD_INIT(NULL, 0)
+        MODULE_NAME ".Blob",
+        .tp_basicsize = sizeof(pysqlite_Blob),
+        .tp_dealloc = (destructor)pysqlite_blob_dealloc,
+        .tp_as_sequence = &blob_sequence_methods,
+        .tp_flags = Py_TPFLAGS_DEFAULT,
+        .tp_weaklistoffset = offsetof(pysqlite_Blob, in_weakreflist),
+        .tp_methods = blob_methods,
+};
+
+extern int pysqlite_blob_setup_types(void)
+{
+    pysqlite_BlobType.tp_new = PyType_GenericNew;
+    return PyType_Ready(&pysqlite_BlobType);
+}

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -257,19 +257,19 @@ PyObject* pysqlite_blob_seek(pysqlite_Blob *self, PyObject *args)
             offset = self->length + offset;
             break;
         default:
-            return PyErr_Format(PyExc_ValueError,
+            return PyErr_SetString(PyExc_ValueError,
                                 "from_what should be 0, 1 or 2");
     }
 
     if (offset < 0 || offset > self->length) {
-        return PyErr_Format(PyExc_ValueError, "offset out of blob range");
+        return PyErr_SetString(PyExc_ValueError, "offset out of blob range");
     }
 
     self->offset = offset;
     Py_RETURN_NONE;
 
 overflow:
-    return PyErr_Format(PyExc_OverflowError, "seek offset result in overflow");
+    return PyErr_SetString(PyExc_OverflowError, "seek offset result in overflow");
 }
 
 
@@ -332,7 +332,7 @@ static int pysqlite_blob_contains(pysqlite_Blob *self, PyObject *args)
 {
     if (pysqlite_check_blob(self)) {
         PyErr_SetString(PyExc_SystemError,
-                        "Blob don't support cotains operation");
+                        "Blob don't support contains operation");
     }
     return -1;
 }
@@ -407,11 +407,11 @@ static PyObject * pysqlite_blob_subscript(pysqlite_Blob *self, PyObject *item)
             return NULL;
         }
 
-        if (slicelen <= 0)
+        if (slicelen <= 0) {
             return PyBytes_FromStringAndSize("", 0);
-        else if (step == 1)
+        } else if (step == 1) {
             return inner_read(self, slicelen, start);
-        else {
+        } else {
             char *result_buf = (char *)PyMem_Malloc(slicelen);
             char *data_buff = NULL;
             Py_ssize_t cur, i;
@@ -586,7 +586,7 @@ static int pysqlite_blob_ass_subscript(pysqlite_Blob *self, PyObject *item, PyOb
     }
     else {
         PyErr_SetString(PyExc_TypeError,
-                        "mmap indices must be integer");
+                        "Blob indices must be integer");
         return -1;
     }
 }

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -208,12 +208,17 @@ PyObject* pysqlite_blob_write(pysqlite_Blob *self, PyObject *data)
         return NULL;
     }
 
-    if (!pysqlite_check_blob(self)) {
+    if (data_buffer.len > self->length - self->offset) {
+        PyErr_SetString(PyExc_ValueError,
+                        "data longer than blob length");
         PyBuffer_Release(&data_buffer);
         return NULL;
     }
 
-    /* TODO: throw better error on data bigger then blob. */
+    if (!pysqlite_check_blob(self)) {
+        PyBuffer_Release(&data_buffer);
+        return NULL;
+    }
 
     rc = write_inner(self, data_buffer.buf, data_buffer.len, self->offset);
 
@@ -257,19 +262,22 @@ PyObject* pysqlite_blob_seek(pysqlite_Blob *self, PyObject *args)
             offset = self->length + offset;
             break;
         default:
-            return PyErr_SetString(PyExc_ValueError,
+            PyErr_SetString(PyExc_ValueError,
                                 "from_what should be 0, 1 or 2");
+            return NULL;
     }
 
     if (offset < 0 || offset > self->length) {
-        return PyErr_SetString(PyExc_ValueError, "offset out of blob range");
+        PyErr_SetString(PyExc_ValueError, "offset out of blob range");
+        return NULL;
     }
 
     self->offset = offset;
     Py_RETURN_NONE;
 
 overflow:
-    return PyErr_SetString(PyExc_OverflowError, "seek offset result in overflow");
+    PyErr_SetString(PyExc_OverflowError, "seek offset result in overflow");
+    return NULL;
 }
 
 

--- a/Modules/_sqlite/blob.c
+++ b/Modules/_sqlite/blob.c
@@ -219,6 +219,7 @@ PyObject* pysqlite_blob_write(pysqlite_Blob *self, PyObject *data)
 
     if (rc == 0) {
         self->offset += (int)data_buffer.len;
+        PyBuffer_Release(&data_buffer);
         Py_RETURN_NONE;
     } else {
         PyBuffer_Release(&data_buffer);

--- a/Modules/_sqlite/blob.h
+++ b/Modules/_sqlite/blob.h
@@ -10,6 +10,7 @@ typedef struct
     pysqlite_Connection* connection;
     sqlite3_blob *blob;
     int offset;
+    int length;
 
     PyObject* in_weakreflist; /* List of weak references */
 } pysqlite_Blob;

--- a/Modules/_sqlite/blob.h
+++ b/Modules/_sqlite/blob.h
@@ -1,0 +1,25 @@
+#ifndef PYSQLITE_BLOB_H
+#define PYSQLITE_BLOB_H
+#include "Python.h"
+#include "sqlite3.h"
+#include "connection.h"
+
+typedef struct
+{
+    PyObject_HEAD
+    pysqlite_Connection* connection;
+    sqlite3_blob *blob;
+    int offset;
+
+    PyObject* in_weakreflist; /* List of weak references */
+} pysqlite_Blob;
+
+extern PyTypeObject pysqlite_BlobType;
+
+int pysqlite_blob_init(pysqlite_Blob* self, pysqlite_Connection* connection,
+                       sqlite3_blob *blob);
+PyObject* pysqlite_blob_close(pysqlite_Blob *self);
+
+int pysqlite_blob_setup_types(void);
+
+#endif

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -336,7 +336,7 @@ PyObject* pysqlite_connection_blob(pysqlite_Connection *self, PyObject *args,
                                    PyObject *kwargs)
 {
     static char *kwlist[] = {"table", "column", "row", "readonly",
-                             "dbname", NULL, NULL};
+                             "dbname", NULL};
     int rc;
     const char *dbname = "main", *table, *column;
     long long row;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -346,7 +346,7 @@ PyObject* pysqlite_connection_blob(pysqlite_Connection *self, PyObject *args,
     PyObject *weakref;
 
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ssL|ps", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "ssL|$ps", kwlist,
                                      &table, &column, &row, &readonly,
                                      &dbname)) {
         return NULL;

--- a/Modules/_sqlite/connection.h
+++ b/Modules/_sqlite/connection.h
@@ -66,9 +66,10 @@ typedef struct
 
     pysqlite_Cache* statement_cache;
 
-    /* Lists of weak references to statements and cursors used within this connection */
+    /* Lists of weak references to statements, blobs and cursors used within this connection */
     PyObject* statements;
     PyObject* cursors;
+    PyObject* blobs;
 
     /* Counters for how many statements/cursors were created in the connection. May be
      * reset to 0 at certain intervals */

--- a/Modules/_sqlite/connection.h
+++ b/Modules/_sqlite/connection.h
@@ -66,7 +66,7 @@ typedef struct
 
     pysqlite_Cache* statement_cache;
 
-    /* Lists of weak references to statements, blobs and cursors used within this connection */
+    /* Lists of weak references to statements, cursors and blobs used within this connection */
     PyObject* statements;
     PyObject* cursors;
     PyObject* blobs;

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -28,6 +28,7 @@
 #include "prepare_protocol.h"
 #include "microprotocols.h"
 #include "row.h"
+#include "blob.h"
 
 #if SQLITE_VERSION_NUMBER >= 3003003
 #define HAVE_SHARED_CACHE
@@ -368,7 +369,8 @@ PyMODINIT_FUNC PyInit__sqlite3(void)
         (pysqlite_connection_setup_types() < 0) ||
         (pysqlite_cache_setup_types() < 0) ||
         (pysqlite_statement_setup_types() < 0) ||
-        (pysqlite_prepare_protocol_setup_types() < 0)
+        (pysqlite_prepare_protocol_setup_types() < 0) ||
+        (pysqlite_blob_setup_types() < 0)
        ) {
         Py_XDECREF(module);
         return NULL;

--- a/PCbuild/_sqlite3.vcxproj
+++ b/PCbuild/_sqlite3.vcxproj
@@ -107,6 +107,7 @@
     <ClInclude Include="..\Modules\_sqlite\row.h" />
     <ClInclude Include="..\Modules\_sqlite\statement.h" />
     <ClInclude Include="..\Modules\_sqlite\util.h" />
+    <ClInclude Include="..\Modules\_sqlite\blob.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Modules\_sqlite\cache.c" />
@@ -118,6 +119,7 @@
     <ClCompile Include="..\Modules\_sqlite\row.c" />
     <ClCompile Include="..\Modules\_sqlite\statement.c" />
     <ClCompile Include="..\Modules\_sqlite\util.c" />
+    <ClCompile Include="..\Modules\_sqlite\blob.c" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\PC\python_nt.rc" />

--- a/PCbuild/_sqlite3.vcxproj.filters
+++ b/PCbuild/_sqlite3.vcxproj.filters
@@ -39,6 +39,9 @@
     <ClInclude Include="..\Modules\_sqlite\util.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\Modules\_sqlite\blob.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\Modules\_sqlite\cache.c">
@@ -66,6 +69,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\Modules\_sqlite\util.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\Modules\_sqlite\blob.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/setup.py
+++ b/setup.py
@@ -1524,7 +1524,8 @@ class PyBuildExt(build_ext):
                 '_sqlite/row.c',
                 '_sqlite/statement.c',
                 '_sqlite/util.c',
-                '_sqlite/blob.c' ]
+                '_sqlite/blob.c',
+            ]
 
             sqlite_defines = []
             if not MS_WINDOWS:

--- a/setup.py
+++ b/setup.py
@@ -1523,7 +1523,8 @@ class PyBuildExt(build_ext):
                 '_sqlite/prepare_protocol.c',
                 '_sqlite/row.c',
                 '_sqlite/statement.c',
-                '_sqlite/util.c', ]
+                '_sqlite/util.c',
+                '_sqlite/blob.c' ]
 
             sqlite_defines = []
             if not MS_WINDOWS:


### PR DESCRIPTION
This PR adds support in BLOB incremental I/O at the sqlite module. As asked by @serhiy-storchaka and @berkerpeksag I will try to get some more developers to give their input on the wanted API. I am tagging some people that are active in the ghaering/pysqlite and rogerbinns/apsw.
@ghaering, @rianhunter, @rogerbinns, @phdru. Please look at the PR and give your notes.

<!-- issue-number: bpo-24905 -->
https://bugs.python.org/issue24905
<!-- /issue-number -->
