### PR TITLE
Fix small typos in introduction and datastructures of tutorial

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -22,11 +22,11 @@ objects:
    Add an item to the end of the list.  Equivalent to ``a[len(a):] = [x]``.
 
 
-.. method:: list.extend(L)
+.. method:: list.extend(iterable)
    :noindex:
 
-   Extend the list by appending all the items from the iterable *L*.  Equivalent to
-   ``a[len(a):] = L``.
+   Extend the list by appending all the items from the iterable.  Equivalent to
+   ``a[len(a):] = iterable``.
 
 
 .. method:: list.insert(i, x)

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -25,7 +25,7 @@ objects:
 .. method:: list.extend(L)
    :noindex:
 
-   Extend the list by appending all the items in the given list.  Equivalent to
+   Extend the list by appending all the items from the iterable *L*.  Equivalent to
    ``a[len(a):] = L``.
 
 
@@ -68,7 +68,7 @@ objects:
 
    The optional arguments *start* and *end* are interpreted as in the slice
    notation and are used to limit the search to a particular subsequence of
-   *x*.  The returned index is computed relative to the beginning of the full
+   the list.  The returned index is computed relative to the beginning of the full
    sequence rather than the *start* argument.
 
 

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -359,7 +359,7 @@ The built-in function :func:`len` returns the length of a string::
       Information about string formatting with :meth:`str.format`.
 
    :ref:`old-string-formatting`
-      The old formatting operations invoked when strings and Unicode strings are
+      The old formatting operations invoked when strings are
       the left operand of the ``%`` operator are described in more detail here.
 
 


### PR DESCRIPTION
A couple of small issues:
 
- Remove reference to Unicode string in introduction.
- Fix description of list.extend to mention iterable (and not make it look like only lists are allowed)
- "subsequence of *x*" should be "subsequence of the list" 