### PR TITLE
bpo-29414: Change 'the for statement is such an iterator' in Tutorial

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -143,9 +143,7 @@ We say such an object is :term:`iterable`, that is, suitable as a target for
 functions and constructs that expect something from which they can
 obtain successive items until the supply is exhausted. We have seen that
 the :keyword:`for` statement is such a construct, while an example of function
-that takes an iterable is :func:`sum()`:
-
-.. doctest::
+that takes an iterable is :func:`sum`:
 
     >>> sum(range(4))  # 0 + 1 + 2 + 3
     6

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -139,7 +139,7 @@ but in fact it isn't. It is an object which returns the successive items of
 the desired sequence when you iterate over it, but it doesn't really make
 the list, thus saving space.
 
-We say such an object is *iterable*, that is, suitable as a target for
+We say such an object is :term:`iterable`, that is, suitable as a target for
 functions and constructs that expect something from which they can
 obtain successive items until the supply is exhausted. We have seen that
 the :keyword:`for` statement is such a construct, while an example of function

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -150,7 +150,7 @@ that takes an iterable is :func:`sum()`:
     >>> sum(range(4))  # 0 + 1 + 2 + 3
     6
 
-Later we will see more functions that return iterables and take iterables as argument.
+Later we will see more functions that return iterables and take iterables as arguments.
 
 
 .. _tut-break:

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -142,12 +142,13 @@ the list, thus saving space.
 We say such an object is *iterable*, that is, suitable as a target for
 functions and constructs that expect something from which they can
 obtain successive items until the supply is exhausted. We have seen that
-the :keyword:`for` statement is such an *iterator*. The function :func:`list`
-is another; it creates lists from iterables::
+the :keyword:`for` statement is such a construct, while an example of function
+that takes an iterable is :func:`sum()`:
 
+.. doctest::
 
-   >>> list(range(5))
-   [0, 1, 2, 3, 4]
+    >>> sum(range(4))  # 0 + 1 + 2 + 3
+    6
 
 Later we will see more functions that return iterables and take iterables as argument.
 

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -143,12 +143,13 @@ We say such an object is :term:`iterable`, that is, suitable as a target for
 functions and constructs that expect something from which they can
 obtain successive items until the supply is exhausted. We have seen that
 the :keyword:`for` statement is such a construct, while an example of function
-that takes an iterable is :func:`sum`:
+that takes an iterable is :func:`sum`::
 
     >>> sum(range(4))  # 0 + 1 + 2 + 3
     6
 
-Later we will see more functions that return iterables and take iterables as arguments.
+Later we will see more functions that return iterables and take iterables as
+arguments.
 
 
 .. _tut-break:

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -194,13 +194,8 @@ following loop, which searches for prime numbers::
 the :keyword:`for` loop, **not** the :keyword:`if` statement.)
 
 When used with a loop, the ``else`` clause has more in common with the
-<<<<<<< HEAD
-``else`` clause of a :keyword:`try` statement than it does that of
-:keyword:`if` statements: a :keyword:`!try` statement's ``else`` clause runs
-=======
 ``else`` clause of a :keyword:`try` statement than it does with that of
 :keyword:`if` statements: a :keyword:`try` statement's ``else`` clause runs
->>>>>>> bpo-29414: add range to list example.
 when no exception occurs, and a loop's ``else`` clause runs when no ``break``
 occurs. For more on the :keyword:`!try` statement and exceptions, see
 :ref:`tut-handling`.

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -141,7 +141,7 @@ the list, thus saving space.
 
 We say such an object is :term:`iterable`, that is, suitable as a target for
 functions and constructs that expect something from which they can
-obtain successive items until the supply is exhausted. We have seen that
+obtain successive items until the supply is exhausted.  We have seen that
 the :keyword:`for` statement is such a construct, while an example of function
 that takes an iterable is :func:`sum`::
 
@@ -149,8 +149,14 @@ that takes an iterable is :func:`sum`::
     6
 
 Later we will see more functions that return iterables and take iterables as
-arguments.
+arguments.  Lastly, maybe you are curious about how to get a list from a range.
+Here is the solution::
 
+   >>> list(range(4))
+   [0, 1, 2, 3]
+
+In chapter :ref:`tut-structures`, we will discuss in more detail about
+:func:`list`.
 
 .. _tut-break:
 
@@ -161,7 +167,7 @@ The :keyword:`break` statement, like in C, breaks out of the innermost enclosing
 :keyword:`for` or :keyword:`while` loop.
 
 Loop statements may have an :keyword:`!else` clause; it is executed when the loop
-terminates through exhaustion of the list (with :keyword:`for`) or when the
+terminates through exhaustion of the iterable (with :keyword:`for`) or when the
 condition becomes false (with :keyword:`while`), but not when the loop is
 terminated by a :keyword:`break` statement.  This is exemplified by the
 following loop, which searches for prime numbers::
@@ -188,8 +194,13 @@ following loop, which searches for prime numbers::
 the :keyword:`for` loop, **not** the :keyword:`if` statement.)
 
 When used with a loop, the ``else`` clause has more in common with the
+<<<<<<< HEAD
 ``else`` clause of a :keyword:`try` statement than it does that of
 :keyword:`if` statements: a :keyword:`!try` statement's ``else`` clause runs
+=======
+``else`` clause of a :keyword:`try` statement than it does with that of
+:keyword:`if` statements: a :keyword:`try` statement's ``else`` clause runs
+>>>>>>> bpo-29414: add range to list example.
 when no exception occurs, and a loop's ``else`` clause runs when no ``break``
 occurs. For more on the :keyword:`!try` statement and exceptions, see
 :ref:`tut-handling`.


### PR DESCRIPTION
The sentence "_the for statement is such an iterator_", at the end of the section [The range() function](https://docs.python.org/3/tutorial/controlflow.html#the-range-function), is misleading. This PR fixes that sentence and completes the paragraph. For the whole discussione look at [[bpo-29414](https://bugs.python.org/issue29414)](http://bugs.python.org/issue29414l).

<!-- issue-number: [bpo-29414](https://bugs.python.org/issue29414) -->
https://bugs.python.org/issue29414
<!-- /issue-number -->
