### PR TITLE
bpo-25008: Deprecate smtpd and point to aiosmtpd

### DIFF
--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -13,6 +13,13 @@
 
 This module offers several classes to implement SMTP (email) servers.
 
+.. seealso::
+
+    The `aiosmtpd <http://aiosmtpd.readthedocs.io/en/latest/>`_ package is a
+    recommended replacement for this module.  It is based on :mod:`asyncio`
+    and provides a more straightforward API.  :mod:`smtpd` should be
+    considered deprecated.
+
 Several server implementations are present; one is a generic
 do-nothing implementation, which can be overridden, while the other two offer
 specific mail-sending strategies.

--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -15,10 +15,9 @@ This module offers several classes to implement SMTP (email) servers.
 
 .. seealso::
 
-    The `aiosmtpd <http://aiosmtpd.readthedocs.io/en/latest/>`_ package is a
-    recommended replacement for this module.  It is based on :mod:`asyncio`
-    and provides a more straightforward API.  :mod:`smtpd` should be
-    considered deprecated.
+    The `aiosmtpd <http://aiosmtpd.readthedocs.io/>`_ package is a recommended
+    replacement for this module.  It is based on :mod:`asyncio` and provides a
+    more straightforward API.  :mod:`smtpd` should be considered deprecated.
 
 Several server implementations are present; one is a generic
 do-nothing implementation, which can be overridden, while the other two offer

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -735,6 +735,9 @@ C API
 Documentation
 -------------
 
+- bpo-25008: Document smtpd.py as effectively deprecated and add a pointer to
+  aiosmtpd, a third-party asyncio-based replacement.
+
 - Issue #26355: Add canonical header link on each page to corresponding major
   version of the documentation. Patch by Matthias Bussonnier.
 


### PR DESCRIPTION
We should probably also cherry pick this change into 3.4, 3.5, and 3.6 since those are the versions aiosmtpd are compatible with.