### PR TITLE
Fix another set of typos in reference manual expressions.rst

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -190,7 +190,7 @@ Since Python 3.6, in an :keyword:`async def` function, an :keyword:`async for`
 clause may be used to iterate over a :term:`asynchronous iterator`.
 A comprehension in an :keyword:`async def` function may consist of either a
 :keyword:`for` or :keyword:`async for` clause following the leading
-expression, may contan additonal :keyword:`for` or :keyword:`async for`
+expression, may contain additional :keyword:`for` or :keyword:`async for`
 clauses, and may also use :keyword:`await` expressions.
 If a comprehension contains either :keyword:`async for` clauses
 or :keyword:`await` expressions it is called an
@@ -1317,7 +1317,7 @@ built-in types.
 * Sequences (instances of :class:`tuple`, :class:`list`, or :class:`range`) can
   be compared only within each of their types, with the restriction that ranges
   do not support order comparison.  Equality comparison across these types
-  results in unequality, and ordering comparison across these types raises
+  results in inequality, and ordering comparison across these types raises
   :exc:`TypeError`.
 
   Sequences compare lexicographically using comparison of corresponding

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -22,11 +22,11 @@ objects:
    Add an item to the end of the list.  Equivalent to ``a[len(a):] = [x]``.
 
 
-.. method:: list.extend(L)
+.. method:: list.extend(iterable)
    :noindex:
 
-   Extend the list by appending all the items from the iterable *L*.  Equivalent to
-   ``a[len(a):] = L``.
+   Extend the list by appending all the items from the iterable.  Equivalent to
+   ``a[len(a):] = iterable``.
 
 
 .. method:: list.insert(i, x)

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -25,7 +25,7 @@ objects:
 .. method:: list.extend(L)
    :noindex:
 
-   Extend the list by appending all the items in the given list.  Equivalent to
+   Extend the list by appending all the items from the iterable *L*.  Equivalent to
    ``a[len(a):] = L``.
 
 
@@ -68,7 +68,7 @@ objects:
 
    The optional arguments *start* and *end* are interpreted as in the slice
    notation and are used to limit the search to a particular subsequence of
-   *x*.  The returned index is computed relative to the beginning of the full
+   the list.  The returned index is computed relative to the beginning of the full
    sequence rather than the *start* argument.
 
 

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -359,7 +359,7 @@ The built-in function :func:`len` returns the length of a string::
       Information about string formatting with :meth:`str.format`.
 
    :ref:`old-string-formatting`
-      The old formatting operations invoked when strings and Unicode strings are
+      The old formatting operations invoked when strings are
       the left operand of the ``%`` operator are described in more detail here.
 
 


### PR DESCRIPTION
Specifically:

- may contan additonal -> contain additional
- unequality doesn't exist, change to inequality.