### PR TITLE
Fix small typos in expressions.rst

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -190,7 +190,7 @@ Since Python 3.6, in an :keyword:`async def` function, an :keyword:`async for`
 clause may be used to iterate over a :term:`asynchronous iterator`.
 A comprehension in an :keyword:`async def` function may consist of either a
 :keyword:`for` or :keyword:`async for` clause following the leading
-expression, may contan additonal :keyword:`for` or :keyword:`async for`
+expression, may contain additional :keyword:`for` or :keyword:`async for`
 clauses, and may also use :keyword:`await` expressions.
 If a comprehension contains either :keyword:`async for` clauses
 or :keyword:`await` expressions it is called an
@@ -1317,7 +1317,7 @@ built-in types.
 * Sequences (instances of :class:`tuple`, :class:`list`, or :class:`range`) can
   be compared only within each of their types, with the restriction that ranges
   do not support order comparison.  Equality comparison across these types
-  results in unequality, and ordering comparison across these types raises
+  results in inequality, and ordering comparison across these types raises
   :exc:`TypeError`.
 
   Sequences compare lexicographically using comparison of corresponding


### PR DESCRIPTION
Specifically:

- may contan additonal -> contain additional
- unequality doesn't exist, change to inequality.