### PR TITLE
bpo-25008: Deprecate smtpd and point to aiosmtpd (#274)

### DIFF
--- a/Doc/library/smtpd.rst
+++ b/Doc/library/smtpd.rst
@@ -13,6 +13,12 @@
 
 This module offers several classes to implement SMTP (email) servers.
 
+.. seealso::
+
+    The `aiosmtpd <http://aiosmtpd.readthedocs.io/>`_ package is a recommended
+    replacement for this module.  It is based on :mod:`asyncio` and provides a
+    more straightforward API.  :mod:`smtpd` should be considered deprecated.
+
 Several server implementations are present; one is a generic
 do-nothing implementation, which can be overridden, while the other two offer
 specific mail-sending strategies.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,7 +10,7 @@ What's New in Python 3.6.1 release candidate 1?
 Core and Builtins
 -----------------
 
-- bpo-29607: Fix stack_effect computation for CALL_FUNCTION_EX. 
+- bpo-29607: Fix stack_effect computation for CALL_FUNCTION_EX.
   Patch by Matthieu Dartiailh.
 
 - bpo-29602: Fix incorrect handling of signed zeros in complex constructor for
@@ -216,6 +216,9 @@ C API
 
 Documentation
 -------------
+
+- bpo-25008: Document smtpd.py as effectively deprecated and add a pointer to
+  aiosmtpd, a third-party asyncio-based replacement.
 
 - Issue #26355: Add canonical header link on each page to corresponding major
   version of the documentation. Patch by Matthias Bussonnier.


### PR DESCRIPTION
Backport bpo-25008 to 3.6