### PR TITLE
[2.7] bpo-28929: Add to Misc/NEWS

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -92,6 +92,8 @@ C API
 Documentation
 -------------
 
+- bpo-28929: Link the documentation to its source file on GitHub.
+
 - Issue #26355: Add canonical header link on each page to corresponding major
   version of the documentation. Patch by Matthias Bussonnier.
 


### PR DESCRIPTION
mention bpo-28929 in the Documentation section of
What's New in Python 2.7.14

Backport for GH-112