### PR TITLE
bpo-9285: Adding profile decorator, context manager to cProfile/profile

### DIFF
--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -24,17 +24,13 @@ def runcall(func, *args, filename=None, sort=-1):
     return _pyprofile._Utils(Profile).runcall(func, *args, filename=filename,
                                               sort=sort)
 
-def runblock(filename=None, sort=-1):
-    return _pyprofile._Utils(Profile).runblock(filename, sort)
-
 run.__doc__ = _pyprofile.run.__doc__
 runctx.__doc__ = _pyprofile.runctx.__doc__
 runcall.__doc__ = _pyprofile.runcall.__doc__
-runblock.__doc__ = _pyprofile.runblock.__doc__
 
 # ____________________________________________________________
 
-class Profile(_lsprof.Profiler):
+class Profile(_lsprof.Profiler, contextlib.ContextDecorator):
     """Profile(custom_timer=None, time_unit=None, subcalls=True, builtins=True)
 
     Builds a profiler object using the specified timer function.
@@ -49,9 +45,12 @@ class Profile(_lsprof.Profiler):
 
     def __enter__(self):
         self.enable()
+        return self
 
     def __exit__(self, *args):
         self.disable()
+        self.print_stats()
+        return False
 
     def print_stats(self, sort=-1):
         import pstats
@@ -123,14 +122,6 @@ class Profile(_lsprof.Profiler):
         self.enable()
         try:
             return func(*args, **kw)
-        finally:
-            self.disable()
-
-    @contextlib.contextmanager
-    def runblock(self):
-        self.enable()
-        try:
-            yield self
         finally:
             self.disable()
 

--- a/Lib/profile.py
+++ b/Lib/profile.py
@@ -317,10 +317,7 @@ class Profile(contextlib.ContextDecorator):
 
     def trace_dispatch_return(self, frame, t):
         if frame is not self.cur[-2]:
-            if frame is not self.cur[-2].f_back:
-                if self.cur[-3] != ('profile', 0, ''):
-                    raise AssertionError("Bad return", self.cur[-3])
-                return 1
+            assert frame is self.cur[-2].f_back, ("Bad return", self.cur[-3])
             self.trace_dispatch_return(self.cur[-2], 0)
 
         # Prefix "r" means part of the Returning or exiting frame.

--- a/Lib/test/test_profile.py
+++ b/Lib/test/test_profile.py
@@ -93,6 +93,43 @@ class ProfileTest(unittest.TestCase):
                                   filename=TESTFN)
         self.assertTrue(os.path.exists(TESTFN))
 
+    def test_runcall(self):
+        flag = []
+        with silent():
+            self.profilermodule.runcall(flag.append, 1)
+        self.assertEqual(flag, [1])
+        self.profilermodule.runcall(flag.append, 2, filename=TESTFN)
+        self.assertEqual(flag, [1, 2])
+        self.assertTrue(os.path.exists(TESTFN))
+
+    def test_runblock_ctx_manager(self):
+        flag = []
+        with silent():
+            with self.profilermodule.runblock():
+                flag.append(1)
+        self.assertEqual(flag, [1])
+        with self.profilermodule.runblock(filename=TESTFN):
+            flag.append(2)
+        self.assertEqual(flag, [1, 2])
+        self.assertTrue(os.path.exists(TESTFN))
+
+    def test_runblock_decorator(self):
+        flag = []
+
+        @self.profilermodule.runblock()
+        def foo():
+            flag.append(1)
+        with silent():
+            foo()
+        self.assertEqual(flag, [1])
+
+        @self.profilermodule.runblock(filename=TESTFN)
+        def foo():
+            flag.append(1)
+        with silent():
+            foo()
+        self.assertEqual(flag, [1, 1])
+        self.assertTrue(os.path.exists(TESTFN))
 
 def regenerate_expected_output(filename, cls):
     filename = filename.rstrip('co')

--- a/Lib/test/test_profile.py
+++ b/Lib/test/test_profile.py
@@ -102,34 +102,23 @@ class ProfileTest(unittest.TestCase):
         self.assertEqual(flag, [1, 2])
         self.assertTrue(os.path.exists(TESTFN))
 
-    def test_runblock_ctx_manager(self):
+    def test_ctx_manager(self):
         flag = []
         with silent():
-            with self.profilermodule.runblock():
+            with self.profilerclass():
                 flag.append(1)
         self.assertEqual(flag, [1])
-        with self.profilermodule.runblock(filename=TESTFN):
-            flag.append(2)
-        self.assertEqual(flag, [1, 2])
-        self.assertTrue(os.path.exists(TESTFN))
 
-    def test_runblock_decorator(self):
+    def test_decorator(self):
         flag = []
 
-        @self.profilermodule.runblock()
+        @self.profilerclass()
         def foo():
             flag.append(1)
         with silent():
             foo()
         self.assertEqual(flag, [1])
 
-        @self.profilermodule.runblock(filename=TESTFN)
-        def foo():
-            flag.append(1)
-        with silent():
-            foo()
-        self.assertEqual(flag, [1, 1])
-        self.assertTrue(os.path.exists(TESTFN))
 
 def regenerate_expected_output(filename, cls):
     filename = filename.rstrip('co')


### PR DESCRIPTION
This patch is base on Giampaolo Rodola works. It is a workaround
that change the assertion of trace_dispatch_return, somehow the
context manager will make a bad return, workaround skip this
special case and let it go.