### PR TITLE
bpo-29644: suppress subprocess output from webbrowser

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -491,7 +491,8 @@ def register_X_browsers():
 if os.environ.get("DISPLAY"):
     try:
         cmd = "xdg-settings get default-web-browser".split()
-        result = subprocess.check_output(cmd).decode().strip()
+        raw_result = subprocess.check_output(cmd, stderr=subprocess.DEVNULL)
+        result = raw_result.decode().strip()
     except (FileNotFoundError, subprocess.CalledProcessError):
         pass
     else:


### PR DESCRIPTION
When checking for the default X web browser, xdg-settings
may emit messages on stderr if some components (such as
kreadconfig5) are unavailable. These messages aren't of
interest to Python, so we just ignore them.