### PR TITLE
bpo-29648: Add reference to create_module()

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -431,7 +431,7 @@ on the module object.  If the method returns ``None``, the
 import machinery will create the new module itself.
 
 .. versionadded:: 3.4
-   The create_module() method of loaders.
+   The :meth:`~importlib.abc.Loader.create_module` method of loaders.
 
 .. versionchanged:: 3.4
    The :meth:`~importlib.abc.Loader.load_module` method was replaced by


### PR DESCRIPTION
Add a reference to `create_module()`, in the first `versionadded` of section [Loaders]( https://docs.python.org/3/reference/import.html#loaders). See [bpo-29648](http://bugs.python.org/issue29648).