### PR TITLE
[3.6] Fix small typos in introduction and datastructures of tutorial (GH-272)

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -22,11 +22,11 @@ objects:
    Add an item to the end of the list.  Equivalent to ``a[len(a):] = [x]``.
 
 
-.. method:: list.extend(L)
+.. method:: list.extend(iterable)
    :noindex:
 
-   Extend the list by appending all the items in the given list.  Equivalent to
-   ``a[len(a):] = L``.
+   Extend the list by appending all the items from the iterable.  Equivalent to
+   ``a[len(a):] = iterable``.
 
 
 .. method:: list.insert(i, x)
@@ -68,7 +68,7 @@ objects:
 
    The optional arguments *start* and *end* are interpreted as in the slice
    notation and are used to limit the search to a particular subsequence of
-   *x*.  The returned index is computed relative to the beginning of the full
+   the list.  The returned index is computed relative to the beginning of the full
    sequence rather than the *start* argument.
 
 

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -359,7 +359,7 @@ The built-in function :func:`len` returns the length of a string::
       Information about string formatting with :meth:`str.format`.
 
    :ref:`old-string-formatting`
-      The old formatting operations invoked when strings and Unicode strings are
+      The old formatting operations invoked when strings are
       the left operand of the ``%`` operator are described in more detail here.
 
 


### PR DESCRIPTION
(cherry picked from commit 53c1892dc3de1de612b1cf95dc7bf09f82c1babf)