### PR TITLE
[3.5] Fix unittest.mock._Call: don't ignore name

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1945,9 +1945,8 @@ class _Call(tuple):
 
     If the _Call has no name then it will match any name.
     """
-    def __new__(cls, value=(), name=None, parent=None, two=False,
+    def __new__(cls, value=(), name='', parent=None, two=False,
                 from_kall=True):
-        name = ''
         args = ()
         kwargs = {}
         _len = len(value)

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -306,6 +306,11 @@ class CallTest(unittest.TestCase):
         other_args = _Call(((1, 2), {'a': 3}))
         self.assertEqual(args, other_args)
 
+    def test_call_with_name(self):
+        self.assertEqual(_Call((), 'foo')[0], 'foo')
+        self.assertEqual(_Call((('bar', 'barz'),),)[0], '')
+        self.assertEqual(_Call((('bar', 'barz'), {'hello': 'world'}),)[0], '')
+
 
 class SpecSignatureTest(unittest.TestCase):
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -32,6 +32,9 @@ Extension Modules
 Library
 -------
 
+- Issue #28961: Fix unittest.mock._Call helper: don't ignore the name parameter
+  anymore. Patch written by Jiajun Huang.
+
 - bpo-29532: Altering a kwarg dictionary passed to functools.partial()
   no longer affects a partial object after creation.
 


### PR DESCRIPTION
Issue #28961: Fix unittest.mock._Call helper: don't ignore the name parameter
anymore.

Patch written by Jiajun Huang.

(cherry picked from commits 84b6fb0eea29b3b28a1a11124526b01ec0c9d17a
and dea1536fd3a8424d537794cd53715df0989cbbe1)

Conflicts:

	Misc/NEWS