### PR TITLE
[3.5] bpo-22594: Add a link to the regex module in re documentation (GH-241)

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -42,6 +42,12 @@ module-level functions and methods on
 that don't require you to compile a regex object first, but miss some
 fine-tuning parameters.
 
+.. seealso::
+
+   The third-party `regex <https://pypi.python.org/pypi/regex/>`_ module,
+   which has an API compatible with the standard library :mod:`re` module,
+   but offers additional functionality and a more thorough Unicode support.
+
 
 .. _re-syntax:
 


### PR DESCRIPTION
(cherry picked from commit ed6795e46f7653e23b862efad240a93453e7df97)