### PR TITLE
[3.6] bpo-28518: Start a transaction implicitly before a DML statement (#245)

### DIFF
--- a/Lib/sqlite3/test/transactions.py
+++ b/Lib/sqlite3/test/transactions.py
@@ -179,6 +179,15 @@ class TransactionalDDL(unittest.TestCase):
         result = self.con.execute("select * from test").fetchall()
         self.assertEqual(result, [])
 
+    def CheckImmediateTransactionalDDL(self):
+        # You can achieve transactional DDL by issuing a BEGIN
+        # statement manually.
+        self.con.execute("begin immediate")
+        self.con.execute("create table test(i)")
+        self.con.rollback()
+        with self.assertRaises(sqlite.OperationalError):
+            self.con.execute("select * from test")
+
     def CheckTransactionalDDL(self):
         # You can achieve transactional DDL by issuing a BEGIN
         # statement manually.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -69,6 +69,9 @@ Extension Modules
 Library
 -------
 
+- bpo-28518: Start a transaction implicitly before a DML statement.
+  Patch by Aviv Palivoda.
+
 - bpo-29532: Altering a kwarg dictionary passed to functools.partial()
   no longer affects a partial object after creation.
 

--- a/Modules/_sqlite/statement.c
+++ b/Modules/_sqlite/statement.c
@@ -73,8 +73,9 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
     Py_INCREF(sql);
     self->sql = sql;
 
-    /* determine if the statement is a DDL statement */
-    self->is_ddl = 0;
+    /* Determine if the statement is a DML statement.
+       SELECT is the only exception. See #9924. */
+    self->is_dml = 0;
     for (p = sql_cstr; *p != 0; p++) {
         switch (*p) {
             case ' ':
@@ -84,9 +85,10 @@ int pysqlite_statement_create(pysqlite_Statement* self, pysqlite_Connection* con
                 continue;
         }
 
-        self->is_ddl = (PyOS_strnicmp(p, "create ", 7) == 0)
-                    || (PyOS_strnicmp(p, "drop ", 5) == 0)
-                    || (PyOS_strnicmp(p, "reindex ", 8) == 0);
+        self->is_dml = (PyOS_strnicmp(p, "insert ", 7) == 0)
+                    || (PyOS_strnicmp(p, "update ", 7) == 0)
+                    || (PyOS_strnicmp(p, "delete ", 7) == 0)
+                    || (PyOS_strnicmp(p, "replace ", 8) == 0);
         break;
     }
 

--- a/Modules/_sqlite/statement.h
+++ b/Modules/_sqlite/statement.h
@@ -38,7 +38,7 @@ typedef struct
     sqlite3_stmt* st;
     PyObject* sql;
     int in_use;
-    int is_ddl;
+    int is_dml;
     PyObject* in_weakreflist; /* List of weak references */
 } pysqlite_Statement;
 


### PR DESCRIPTION
Patch by Aviv Palivoda.

(cherry picked from commit 4a926caf8e5fd8af771b2c34bfb6e91c732331fe)