### PR TITLE
[3.6] bpo-28624: Add a test that checks that cwd parameter of Popen() accepts PathLike objects (#157)

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -466,9 +466,13 @@ functions.
       The *pass_fds* parameter was added.
 
    If *cwd* is not ``None``, the function changes the working directory to
-   *cwd* before executing the child.  In particular, the function looks for
-   *executable* (or for the first item in *args*) relative to *cwd* if the
-   executable path is a relative path.
+   *cwd* before executing the child.  *cwd* can be a :class:`str` and
+   :term:`path-like <path-like object>` object.  In particular, the function
+   looks for *executable* (or for the first item in *args*) relative to *cwd*
+   if the executable path is a relative path.
+
+   .. versionchanged:: 3.6
+      *cwd* parameter accepts a :term:`path-like object`.
 
    If *restore_signals* is true (the default) all signals that Python has set to
    SIG_IGN are restored to SIG_DFL in the child process before the exec.

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -347,6 +347,16 @@ class ProcessTestCase(BaseTestCase):
         temp_dir = self._normalize_cwd(temp_dir)
         self._assert_cwd(temp_dir, sys.executable, cwd=temp_dir)
 
+    def test_cwd_with_pathlike(self):
+        temp_dir = tempfile.gettempdir()
+        temp_dir = self._normalize_cwd(temp_dir)
+
+        class _PathLikeObj:
+            def __fspath__(self):
+                return temp_dir
+
+        self._assert_cwd(temp_dir, sys.executable, cwd=_PathLikeObj())
+
     @unittest.skipIf(mswindows, "pending resolution of issue #15533")
     def test_cwd_with_relative_arg(self):
         # Check that Popen looks for args[0] relative to cwd if args[0]

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -269,6 +269,7 @@ Albert Chin-A-Young
 Adal Chiriliuc
 Matt Chisholm
 Lita Cho
+Sayan Chowdhury
 Anders Chrigström
 Tom Christiansen
 Renee Chu

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -69,6 +69,9 @@ Extension Modules
 Library
 -------
 
+- bpo-28624: Add a test that checks that cwd parameter of Popen() accepts
+  PathLike objects.  Patch by Sayan Chowdhury.
+
 - bpo-28518: Start a transaction implicitly before a DML statement.
   Patch by Aviv Palivoda.
 


### PR DESCRIPTION
(cherry picked from commit d5c11f7ace48701bb950c6345deee88c35c66e26)