### PR TITLE
bpo-29376: Fix assertion error in threading._DummyThread.is_alive()

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -170,6 +170,9 @@ class ThreadTests(BaseTestCase):
         mutex.acquire()
         self.assertIn(tid, threading._active)
         self.assertIsInstance(threading._active[tid], threading._DummyThread)
+        #Issue 29376
+        self.assertTrue(threading._active[tid].is_alive())
+        self.assertRegex(repr(threading._active[tid]), '_DummyThread')
         del threading._active[tid]
 
     # PyThreadState_SetAsyncExc() is a CPython-only gimmick, not (currently)

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1215,6 +1215,10 @@ class _DummyThread(Thread):
     def _stop(self):
         pass
 
+    def is_alive(self):
+        assert not self._is_stopped and self._started.is_set()
+        return True
+
     def join(self, timeout=None):
         assert False, "cannot join a dummy thread"
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -32,6 +32,8 @@ Extension Modules
 Library
 -------
 
+- bpo-29376: Fix assertion error in threading._DummyThread.is_alive().
+
 - bpo-29110: Fix file object leak in aifc.open() when file is given as a
   filesystem path and is not in valid AIFF format. Patch by Anthony Zhang.
 


### PR DESCRIPTION
backport to 3.5 for #236 