### PR TITLE
[3.6] Asyncio documentation: remove `self` from method signatures (GH-334)

### DIFF
--- a/Doc/library/asyncio-protocol.rst
+++ b/Doc/library/asyncio-protocol.rst
@@ -36,7 +36,7 @@ BaseTransport
 
    Base class for transports.
 
-   .. method:: close(self)
+   .. method:: close()
 
       Close the transport.  If the transport has a buffer for outgoing
       data, buffered data will be flushed asynchronously.  No more data
@@ -44,7 +44,7 @@ BaseTransport
       protocol's :meth:`connection_lost` method will be called with
       :const:`None` as its argument.
 
-   .. method:: is_closing(self)
+   .. method:: is_closing()
 
       Return ``True`` if the transport is closing or is closed.
 
@@ -251,7 +251,7 @@ BaseSubprocessTransport
       if it hasn't returned, similarly to the
       :attr:`subprocess.Popen.returncode` attribute.
 
-   .. method:: kill(self)
+   .. method:: kill()
 
       Kill the subprocess, as in :meth:`subprocess.Popen.kill`.
 


### PR DESCRIPTION
(cherry picked from commit 091b84f23a2ff57e8320ebf6fdf889af39096ab9)