### PR TITLE
bpo-32888: Improve exception message in ast.literal_eval

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -46,23 +46,23 @@ def literal_eval(node_or_string):
         node_or_string = parse(node_or_string, mode='eval')
     if isinstance(node_or_string, Expression):
         node_or_string = node_or_string.body
-    def _convert_num(node):
+    def _convert_num(node, ctx):
         if isinstance(node, Constant):
             if isinstance(node.value, (int, float, complex)):
                 return node.value
         elif isinstance(node, Num):
             return node.n
         elif isinstance(node, AST):
-            raise ValueError('%s not allowed in literal' % type(node).__name__)
+            raise ValueError('%s not allowed in %s' % (type(node).__name__, ctx))
         raise ValueError('malformed node or string: ' + repr(node))
-    def _convert_signed_num(node):
+    def _convert_signed_num(node, ctx):
         if isinstance(node, UnaryOp) and isinstance(node.op, (UAdd, USub)):
-            operand = _convert_num(node.operand)
+            operand = _convert_num(node.operand, 'unary +/-')
             if isinstance(node.op, UAdd):
                 return + operand
             else:
                 return - operand
-        return _convert_num(node)
+        return _convert_num(node, ctx)
     def _convert(node):
         if isinstance(node, Constant):
             return node.value
@@ -82,14 +82,14 @@ def literal_eval(node_or_string):
         elif isinstance(node, NameConstant):
             return node.value
         elif isinstance(node, BinOp) and isinstance(node.op, (Add, Sub)):
-            left = _convert_signed_num(node.left)
-            right = _convert_num(node.right)
+            left = _convert_signed_num(node.left, 'binary +/-')
+            right = _convert_num(node.right, 'binary +/-')
             if isinstance(left, (int, float)) and isinstance(right, complex):
                 if isinstance(node.op, Add):
                     return left + right
                 else:
                     return left - right
-        return _convert_signed_num(node)
+        return _convert_signed_num(node, 'literal')
     return _convert(node_or_string)
 
 

--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -52,6 +52,8 @@ def literal_eval(node_or_string):
                 return node.value
         elif isinstance(node, Num):
             return node.n
+        elif isinstance(node, AST):
+            raise ValueError('%s not allowed in literal' % type(node).__name__)
         raise ValueError('malformed node or string: ' + repr(node))
     def _convert_signed_num(node):
         if isinstance(node, UnaryOp) and isinstance(node.op, (UAdd, USub)):

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -583,6 +583,19 @@ class ASTHelpers_Test(unittest.TestCase):
         self.assertRaises(ValueError, ast.literal_eval, '3+(0+6j)')
         self.assertRaises(ValueError, ast.literal_eval, '-(3+6j)')
 
+    def test_literal_eval_message(self):
+        # Issue #32888
+        tests = {
+            "2 * 5": "BinOp not allowed in literal",
+            "[] + []": "List not allowed in binary +/-",
+            "+''": "Str not allowed in unary +/-",
+            ast.BinOp(ast.Num(1), ast.Add(), 'oops'): "malformed node or string: 'oops'",
+        }
+        for test, message in tests.items():
+            with self.assertRaises(ValueError) as cm:
+                ast.literal_eval(test)
+            self.assertIn(message, str(cm.exception))
+
     def test_bad_integer(self):
         # issue13436: Bad error message with invalid numeric values
         body = [ast.ImportFrom(module='time',

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -327,7 +327,7 @@ non-important content
         self.assertIsNone(g.__doc__)
 
     def test_literal_eval(self):
-        with self.assertRaisesRegex(ValueError, 'malformed node or string'):
+        with self.assertRaisesRegex(ValueError, 'JoinedStr not allowed in literal'):
             ast.literal_eval("f'x'")
 
     def test_ast_compile_time_concat(self):

--- a/Misc/NEWS.d/next/Library/2018-02-21-04-39-49.bpo-32888.G5i41Q.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-21-04-39-49.bpo-32888.G5i41Q.rst
@@ -1,2 +1,3 @@
 Improve wording of error messages from ast.literal_eval, distinguishing
 valid-but-unacceptable nodes from those that are actually malformed.
+Patch by Chris Angelico.

--- a/Misc/NEWS.d/next/Library/2018-02-21-04-39-49.bpo-32888.G5i41Q.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-21-04-39-49.bpo-32888.G5i41Q.rst
@@ -1,0 +1,2 @@
+Improve wording of error messages from ast.literal_eval, distinguishing
+valid-but-unacceptable nodes from those that are actually malformed.


### PR DESCRIPTION
When a non-literal is given to literal_eval, attempt to be more
helpful with the message, rather than calling it 'malformed'.

<!-- issue-number: bpo-32888 -->
https://bugs.python.org/issue32888
<!-- /issue-number -->
