### PR TITLE
[3.6] bpo-27788 : synchronise platform.py version number (#246)

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -110,7 +110,7 @@ __copyright__ = """
 
 """
 
-__version__ = '1.0.7'
+__version__ = '1.0.8'
 
 import collections
 import sys, os, re, subprocess


### PR DESCRIPTION
Was bumped in the docstring by b9f4feab1b9c9ffa8ea29af3d82bc536f9f3005a
but not in `__version__`

(cherry picked from commit 6059ce45aa96f52fa0150e68ea655fbfdc25609a)