### PR TITLE
bpo-29660: traceback: Document that etype is ignored in some places.

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -45,15 +45,18 @@ The module defines the following functions:
    * if *tb* is not ``None``, it prints a header ``Traceback (most recent
      call last):``
    * it prints the exception *etype* and *value* after the stack trace
-   * if *etype* is :exc:`SyntaxError` and *value* has the appropriate format, it
-     prints the line where the syntax error occurred with a caret indicating the
-     approximate position of the error.
+   * if *type(value)* is :exc:`SyntaxError` and *value* has the appropriate
+     format, it prints the line where the syntax error occurred with a caret
+     indicating the approximate position of the error.
 
    The optional *limit* argument has the same meaning as for :func:`print_tb`.
    If *chain* is true (the default), then chained exceptions (the
    :attr:`__cause__` or :attr:`__context__` attributes of the exception) will be
    printed as well, like the interpreter itself does when printing an unhandled
    exception.
+
+   .. versionchanged:: 3.5
+      The *etype* argument is ignored and inferred from the type of *value*.
 
 
 .. function:: print_exc(limit=None, file=None, chain=True)
@@ -130,6 +133,9 @@ The module defines the following functions:
    return value is a list of strings, each ending in a newline and some
    containing internal newlines.  When these lines are concatenated and printed,
    exactly the same text is printed as does :func:`print_exception`.
+
+   .. versionchanged:: 3.5
+      The *etype* argument is ignored and inferred from the type of *value*.
 
 
 .. function:: format_exc(limit=None, chain=True)
@@ -372,6 +378,7 @@ exception and traceback:
        print("*** print_tb:")
        traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)
        print("*** print_exception:")
+       # exc_type below ignored on 3.5 and later
        traceback.print_exception(exc_type, exc_value, exc_traceback,
                                  limit=2, file=sys.stdout)
        print("*** print_exc:")
@@ -381,6 +388,7 @@ exception and traceback:
        print(formatted_lines[0])
        print(formatted_lines[-1])
        print("*** format_exception:")
+       # exc_type below ignored on 3.5 and later
        print(repr(traceback.format_exception(exc_type, exc_value,
                                              exc_traceback)))
        print("*** extract_tb:")

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -378,7 +378,7 @@ exception and traceback:
        print("*** print_tb:")
        traceback.print_tb(exc_traceback, limit=1, file=sys.stdout)
        print("*** print_exception:")
-       # exc_type below ignored on 3.5 and later
+       # exc_type below is ignored on 3.5 and later
        traceback.print_exception(exc_type, exc_value, exc_traceback,
                                  limit=2, file=sys.stdout)
        print("*** print_exc:")
@@ -388,7 +388,7 @@ exception and traceback:
        print(formatted_lines[0])
        print(formatted_lines[-1])
        print("*** format_exception:")
-       # exc_type below ignored on 3.5 and later
+       # exc_type below is ignored on 3.5 and later
        print(repr(traceback.format_exception(exc_type, exc_value,
                                              exc_traceback)))
        print("*** extract_tb:")


### PR DESCRIPTION
See http://bugs.python.org/issue29660 