### PR TITLE
bpo-29666: correct documentation for enum.html

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -24,8 +24,8 @@ Module Contents
 ---------------
 
 This module defines four enumeration classes that can be used to define unique
-sets of names and values: :class:`Enum`, :class:`IntEnum`, and
-:class:`IntFlags`.  It also defines one decorator, :func:`unique`, and one
+sets of names and values: :class:`Enum`, :class:`IntEnum`, :class:`Flag`, and
+:class:`IntFlag`.  It also defines one decorator, :func:`unique`, and one
 helper, :class:`auto`.
 
 .. class:: Enum


### PR DESCRIPTION
Correct documentation for `enum.html` by adding the fourth missing type `Flag` and correcting the wrongly mentioned `IntFlag`