### PR TITLE
[3.6] Fixed a handful of typos (GH-343)

### DIFF
--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -37,7 +37,7 @@ generating a serialized version of the mssage, and for recursively walking over
 the object tree.  Note that duplicate headers are supported but special methods
 must be used to access them.
 
-The :class:`Message` psuedo-dictionary is indexed by the header names, which
+The :class:`Message` pseudo-dictionary is indexed by the header names, which
 must be ASCII values.  The values of the dictionary are strings that are
 supposed to contain only ASCII characters; there is some special handling for
 non-ASCII input, but it doesn't always produce the correct results.  Headers
@@ -181,7 +181,7 @@ Here are the methods of the :class:`Message` class:
       This is a legacy method.  On the
       :class:`~email.emailmessage.EmailMessage` class its functionality is
       replaced by :meth:`~email.message.EmailMessage.set_content` and the
-      realted ``make`` and ``add`` methods.
+      related ``make`` and ``add`` methods.
 
 
    .. method:: get_payload(i=None, decode=False)

--- a/Doc/library/email.message.rst
+++ b/Doc/library/email.message.rst
@@ -364,7 +364,7 @@ message objects.
       *header* specifies an alternative header to :mailheader:`Content-Type`.
 
       If the value contains non-ASCII characters, the charset and language may
-      be explicity specified using the optional *charset* and *language*
+      be explicitly specified using the optional *charset* and *language*
       parameters.  Optional *language* specifies the :rfc:`2231` language,
       defaulting to the empty string.  Both *charset* and *language* should be
       strings.  The default is to use the ``utf8`` *charset* and ``None`` for

--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -446,7 +446,7 @@ longer or disable the extension.
 Calltips
 ^^^^^^^^
 
-A calltip is shown when one types :kbd:`(` after the name of an *acccessible*
+A calltip is shown when one types :kbd:`(` after the name of an *accessible*
 function.  A name expression may include dots and subscripts.  A calltip
 remains until it is clicked, the cursor is moved out of the argument area,
 or :kbd:`)` is typed.  When the cursor is in the argument part of a definition,

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -616,7 +616,7 @@ Constants
 
 .. data:: PROTOCOL_TLS_CLIENT
 
-   Auto-negotiate the the highest protocol version like :data:`PROTOCOL_SSLv23`,
+   Auto-negotiate the highest protocol version like :data:`PROTOCOL_SSLv23`,
    but only support client-side :class:`SSLSocket` connections. The protocol
    enables :data:`CERT_REQUIRED` and :attr:`~SSLContext.check_hostname` by
    default.
@@ -625,7 +625,7 @@ Constants
 
 .. data:: PROTOCOL_TLS_SERVER
 
-   Auto-negotiate the the highest protocol version like :data:`PROTOCOL_SSLv23`,
+   Auto-negotiate the highest protocol version like :data:`PROTOCOL_SSLv23`,
    but only support server-side :class:`SSLSocket` connections.
 
    .. versionadded:: 3.6
@@ -948,7 +948,7 @@ SSL Sockets
    :ref:`notes on non-blocking sockets <ssl-nonblocking>`.
 
    Usually, :class:`SSLSocket` are not created directly, but using the
-   the :meth:`SSLContext.wrap_socket` method.
+   :meth:`SSLContext.wrap_socket` method.
 
    .. versionchanged:: 3.5
       The :meth:`sendfile` method was added.


### PR DESCRIPTION
(cherry picked from commit 1cf2a809b1eb4f9fc8ac3ccc97424586892d1e1a)