### PR TITLE
weaken test_from_import_missing_attr_has_name_and_path regular expression

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -85,7 +85,7 @@ class ImportTests(unittest.TestCase):
             from os import i_dont_exist
         self.assertEqual(cm.exception.name, 'os')
         self.assertEqual(cm.exception.path, os.__file__)
-        self.assertRegex(str(cm.exception), "cannot import name 'i_dont_exist' from 'os' \(.*/Lib/os.py\)")
+        self.assertRegex(str(cm.exception), "cannot import name 'i_dont_exist' from 'os' \(.*os.py\)")
 
     def test_from_import_missing_attr_has_name_and_so_path(self):
         import _opcode


### PR DESCRIPTION
Windows uses backslashes for separators.