### PR TITLE
bpo-29683 - Fixes to _PyCode_SetExtra when co_extra->ce->extras is allocated

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-29683: Fixes to memory allocation in _PyCode_SetExtra.  Patch by
+  Brian Coleman.
+
 - bpo-29684: Fix minor regression of PyEval_CallObjectWithKeywords.
   It should raise TypeError when kwargs is not a dict.  But it might
   cause segv when args=NULL and kwargs is not a dict.

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -861,16 +861,15 @@ _PyCode_SetExtra(PyObject *code, Py_ssize_t index, void *extra)
     _PyCodeObjectExtra *co_extra = (_PyCodeObjectExtra *) o->co_extra;
 
     if (co_extra == NULL) {
-        o->co_extra = (_PyCodeObjectExtra*) PyMem_Malloc(
-            sizeof(_PyCodeObjectExtra));
-        if (o->co_extra == NULL) {
+        co_extra = PyMem_Malloc(sizeof(_PyCodeObjectExtra));
+        if (co_extra == NULL) {
             return -1;
         }
-        co_extra = (_PyCodeObjectExtra *) o->co_extra;
 
         co_extra->ce_extras = PyMem_Malloc(
             tstate->co_extra_user_count * sizeof(void*));
         if (co_extra->ce_extras == NULL) {
+            PyMem_Free(co_extra);
             return -1;
         }
 
@@ -879,20 +878,25 @@ _PyCode_SetExtra(PyObject *code, Py_ssize_t index, void *extra)
         for (Py_ssize_t i = 0; i < co_extra->ce_size; i++) {
             co_extra->ce_extras[i] = NULL;
         }
+
+        o->co_extra = co_extra;
     }
     else if (co_extra->ce_size <= index) {
-        co_extra->ce_extras = PyMem_Realloc(
+        void** ce_extras = PyMem_Realloc(
             co_extra->ce_extras, tstate->co_extra_user_count * sizeof(void*));
 
-        if (co_extra->ce_extras == NULL) {
+        if (ce_extras == NULL) {
             return -1;
         }
 
-        co_extra->ce_size = tstate->co_extra_user_count;
-
-        for (Py_ssize_t i = co_extra->ce_size; i < co_extra->ce_size; i++) {
-            co_extra->ce_extras[i] = NULL;
+        for (Py_ssize_t i = co_extra->ce_size;
+             i < tstate->co_extra_user_count;
+             i++) {
+            ce_extras[i] = NULL;
         }
+
+        co_extra->ce_extras = ce_extras;
+        co_extra->ce_size = tstate->co_extra_user_count;
     }
 
     co_extra->ce_extras[index] = extra;


### PR DESCRIPTION
On PyMem_Malloc failure, _PyCode_SetExtra should set co_extra->ce_size = 0.
On PyMem_Realloc failure, _PyCode_SetExtra should set co_extra->ce_size = 0.
On PyMem_Realloc success, _PyCode_SetExtra should set all unused slots in co_extra->ce_extras to NULL.