### PR TITLE
bpo-27645: Supporting native backup facility of SQLite

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -546,6 +546,7 @@ Connection Objects
          con = sqlite3.connect('existing_db.db')
          con.backup('copy_of_existing_db.db', 1, progress)
 
+      .. versionadded:: 3.7
 
 
 .. _sqlite3-cursor-objects:

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -521,7 +521,7 @@ Connection Objects
                  f.write('%s\n' % line)
 
 
-   .. method:: backup(filename[, pages, progress])
+   .. method:: backup(filename, *, pages=0, progress=None)
 
       This method exposes the `API`__ that allows to make a backup of a SQLite
       database into the mandatory argument *filename*, even while it's being accessed

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -531,9 +531,10 @@ Connection Objects
       database is copied in a single step; otherwise the method performs a loop
       copying up to the specified *pages* at a time.
 
-      If *progress* is specified, it must either ``None`` or a callable object that
-      will be executed at each iteration with two integer arguments, respectively the
-      *remaining* number of pages still to be copied and the *total* number of pages.
+      If *progress* is specified, it must either be ``None`` or a callable object that
+      will be executed at each iteration with three integer arguments, respectively
+      the *status* of the last iteration, the *remaining* number of pages still to be
+      copied and the *total* number of pages.
 
       The *name* argument specifies the database name that will be copied: it must be
       a string containing either ``"main"``, the default, to indicate the main
@@ -545,7 +546,7 @@ Connection Objects
          # Copy an existing database into another file
          import sqlite3
 
-         def progress(remaining, total):
+         def progress(status, remaining, total):
              print(f"Copied {total-remaining} of {total} pages...")
 
          con = sqlite3.connect('existing_db.db')

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -551,6 +551,9 @@ Connection Objects
          con = sqlite3.connect('existing_db.db')
          con.backup('copy_of_existing_db.db', 1, progress)
 
+      .. note:: This is available only when the underlying SQLite library is at
+                version 3.6.11 or higher.
+
       .. versionadded:: 3.7
 
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -523,9 +523,9 @@ Connection Objects
 
    .. method:: backup(filename, *, pages=0, progress=None)
 
-      This method exposes the `API`__ that allows to make a backup of a SQLite
-      database into the mandatory argument *filename*, even while it's being accessed
-      by other clients, or concurrently by the same connection.
+      This method makes a backup of a SQLite database into the mandatory argument
+      *filename*, even while it's being accessed by other clients, or concurrently by
+      the same connection.
 
       By default, or when *pages* is either ``0`` or a negative integer, the entire
       database is copied in a single step; otherwise the method performs a loop
@@ -546,7 +546,6 @@ Connection Objects
          con = sqlite3.connect('existing_db.db')
          con.backup('copy_of_existing_db.db', 1, progress)
 
-__ http://sqlite.org/backup.html
 
 
 .. _sqlite3-cursor-objects:

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -541,7 +541,7 @@ Connection Objects
          import sqlite3
 
          def progress(remaining, total):
-             print("Copied %d of %d pages..." % (total-remaining, total))
+             print(f"Copied {total-remaining} of {total} pages...")
 
          con = sqlite3.connect('existing_db.db')
          con.backup('copy_of_existing_db.db', 1, progress)

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -521,6 +521,34 @@ Connection Objects
                  f.write('%s\n' % line)
 
 
+   .. method:: backup(filename[, pages, progress])
+
+      This method exposes the `API`__ that allows to make a backup of a SQLite
+      database into the mandatory argument *filename*, even while it's being accessed
+      by other clients, or concurrently by the same connection.
+
+      By default, or when *pages* is either ``0`` or a negative integer, the entire
+      database is copied in a single step; otherwise the method performs a loop
+      copying up to the specified *pages* at a time.
+
+      If *progress* is specified, it must either ``None`` or a callable object that
+      will be executed at each iteration with two integer arguments, respectively the
+      *remaining* number of pages still to be copied and the *total* number of pages.
+
+      Example::
+
+         # Copy an existing database into another file
+         import sqlite3
+
+         def progress(remaining, total):
+             print("Copied %d of %d pages..." % (total-remaining, total))
+
+         con = sqlite3.connect('existing_db.db')
+         con.backup('copy_of_existing_db.db', 1, progress)
+
+__ http://sqlite.org/backup.html
+
+
 .. _sqlite3-cursor-objects:
 
 Cursor Objects

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -521,7 +521,7 @@ Connection Objects
                  f.write('%s\n' % line)
 
 
-   .. method:: backup(filename, *, pages=0, progress=None)
+   .. method:: backup(filename, *, pages=0, progress=None, name="main")
 
       This method makes a backup of a SQLite database into the mandatory argument
       *filename*, even while it's being accessed by other clients, or concurrently by
@@ -534,6 +534,11 @@ Connection Objects
       If *progress* is specified, it must either ``None`` or a callable object that
       will be executed at each iteration with two integer arguments, respectively the
       *remaining* number of pages still to be copied and the *total* number of pages.
+
+      The *name* argument specifies the database name that will be copied: it must be
+      a string containing either ``"main"``, the default, to indicate the main
+      database, ``"temp"`` to indicate the temporary database or the name specified
+      after the ``AS`` keyword in an ``ATTACH`` statement for an attached database.
 
       Example::
 

--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -93,6 +93,15 @@ class BackupTests(unittest.TestCase):
         self.assertEqual(journal[1], 1)
         self.assertEqual(journal[2], 0)
 
+    def CheckFailingProgress(self):
+        def progress(remaining, total):
+            raise SystemError('nearly out of space')
+
+        with NamedTemporaryFile(suffix='.sqlite') as bckfn:
+            with self.assertRaises(SystemError) as err:
+                self.cx.backup(bckfn.name, progress=progress)
+            self.assertEqual(str(err.exception), 'nearly out of space')
+
     def CheckDatabaseSourceName(self):
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
             self.cx.backup(bckfn.name, name='main')

--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -2,6 +2,7 @@ import sqlite3 as sqlite
 from tempfile import NamedTemporaryFile
 import unittest
 
+@unittest.skipIf(sqlite.sqlite_version_info < (3, 6, 11), "Backup API not supported")
 class BackupTests(unittest.TestCase):
     def setUp(self):
         cx = self.cx = sqlite.connect(":memory:")

--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -65,9 +65,9 @@ class BackupTests(unittest.TestCase):
 
     def CheckNonCallableProgress(self):
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
-            with self.assertRaises(TypeError) as cm:
+            with self.assertRaises(TypeError) as err:
                 self.cx.backup(bckfn.name, pages=1, progress='bar')
-            self.assertEqual(str(cm.exception), 'progress argument must be a callable')
+            self.assertEqual(str(err.exception), 'progress argument must be a callable')
 
     def CheckModifyingProgress(self):
         journal = []

--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -31,21 +31,21 @@ class BackupTests(unittest.TestCase):
     def CheckProgress(self):
         journal = []
 
-        def progress(remaining, total):
-            journal.append(remaining)
+        def progress(status, remaining, total):
+            journal.append(status)
 
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
             self.cx.backup(bckfn.name, pages=1, progress=progress)
             self.testBackup(bckfn.name)
 
         self.assertEqual(len(journal), 2)
-        self.assertEqual(journal[0], 1)
-        self.assertEqual(journal[1], 0)
+        self.assertEqual(journal[0], sqlite.SQLITE_OK)
+        self.assertEqual(journal[1], sqlite.SQLITE_DONE)
 
     def CheckProgressAllPagesAtOnce_0(self):
         journal = []
 
-        def progress(remaining, total):
+        def progress(status, remaining, total):
             journal.append(remaining)
 
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
@@ -58,7 +58,7 @@ class BackupTests(unittest.TestCase):
     def CheckProgressAllPagesAtOnce_1(self):
         journal = []
 
-        def progress(remaining, total):
+        def progress(status, remaining, total):
             journal.append(remaining)
 
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
@@ -77,7 +77,7 @@ class BackupTests(unittest.TestCase):
     def CheckModifyingProgress(self):
         journal = []
 
-        def progress(remaining, total):
+        def progress(status, remaining, total):
             if not journal:
                 self.cx.execute('INSERT INTO foo (key) VALUES (?)', (remaining+1000,))
                 self.cx.commit()
@@ -99,7 +99,7 @@ class BackupTests(unittest.TestCase):
         self.assertEqual(journal[2], 0)
 
     def CheckFailingProgress(self):
-        def progress(remaining, total):
+        def progress(status, remaining, total):
             raise SystemError('nearly out of space')
 
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:

--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -19,6 +19,10 @@ class BackupTests(unittest.TestCase):
         self.assertEqual(result[0][0], 3)
         self.assertEqual(result[1][0], 4)
 
+    def CheckKeywordOnlyArgs(self):
+        with self.assertRaises(TypeError):
+            self.cx.backup('foo', 1)
+
     def CheckSimple(self):
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
             self.cx.backup(bckfn.name)

--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -30,7 +30,7 @@ class BackupTests(unittest.TestCase):
             journal.append(remaining)
 
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
-            self.cx.backup(bckfn.name, 1, progress)
+            self.cx.backup(bckfn.name, pages=1, progress=progress)
             self.testBackup(bckfn.name)
 
         self.assertEqual(len(journal), 2)
@@ -44,7 +44,7 @@ class BackupTests(unittest.TestCase):
             journal.append(remaining)
 
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
-            self.cx.backup(bckfn.name, 0, progress)
+            self.cx.backup(bckfn.name, progress=progress)
             self.testBackup(bckfn.name)
 
         self.assertEqual(len(journal), 1)
@@ -57,7 +57,7 @@ class BackupTests(unittest.TestCase):
             journal.append(remaining)
 
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
-            self.cx.backup(bckfn.name, -1, progress)
+            self.cx.backup(bckfn.name, pages=-1, progress=progress)
             self.testBackup(bckfn.name)
 
         self.assertEqual(len(journal), 1)
@@ -66,7 +66,7 @@ class BackupTests(unittest.TestCase):
     def CheckNonCallableProgress(self):
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
             with self.assertRaises(TypeError) as cm:
-                self.cx.backup(bckfn.name, 1, 'bar')
+                self.cx.backup(bckfn.name, pages=1, progress='bar')
             self.assertEqual(str(cm.exception), 'progress argument must be a callable')
 
     def CheckModifyingProgress(self):
@@ -79,7 +79,7 @@ class BackupTests(unittest.TestCase):
             journal.append(remaining)
 
         with NamedTemporaryFile(suffix='.sqlite') as bckfn:
-            self.cx.backup(bckfn.name, 1, progress)
+            self.cx.backup(bckfn.name, pages=1, progress=progress)
             self.testBackup(bckfn.name)
 
             cx = sqlite.connect(bckfn.name)

--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -1,0 +1,104 @@
+import sqlite3 as sqlite
+from tempfile import NamedTemporaryFile
+import unittest
+
+class BackupTests(unittest.TestCase):
+    def setUp(self):
+        cx = self.cx = sqlite.connect(":memory:")
+        cx.execute('CREATE TABLE foo (key INTEGER)')
+        cx.executemany('INSERT INTO foo (key) VALUES (?)', [(3,), (4,)])
+        cx.commit()
+
+    def tearDown(self):
+        self.cx.close()
+
+    def testBackup(self, bckfn):
+        cx = sqlite.connect(bckfn)
+        result = cx.execute("SELECT key FROM foo ORDER BY key").fetchall()
+        self.assertEqual(result[0][0], 3)
+        self.assertEqual(result[1][0], 4)
+
+    def CheckSimple(self):
+        with NamedTemporaryFile(suffix='.sqlite') as bckfn:
+            self.cx.backup(bckfn.name)
+            self.testBackup(bckfn.name)
+
+    def CheckProgress(self):
+        journal = []
+
+        def progress(remaining, total):
+            journal.append(remaining)
+
+        with NamedTemporaryFile(suffix='.sqlite') as bckfn:
+            self.cx.backup(bckfn.name, 1, progress)
+            self.testBackup(bckfn.name)
+
+        self.assertEqual(len(journal), 2)
+        self.assertEqual(journal[0], 1)
+        self.assertEqual(journal[1], 0)
+
+    def CheckProgressAllPagesAtOnce_0(self):
+        journal = []
+
+        def progress(remaining, total):
+            journal.append(remaining)
+
+        with NamedTemporaryFile(suffix='.sqlite') as bckfn:
+            self.cx.backup(bckfn.name, 0, progress)
+            self.testBackup(bckfn.name)
+
+        self.assertEqual(len(journal), 1)
+        self.assertEqual(journal[0], 0)
+
+    def CheckProgressAllPagesAtOnce_1(self):
+        journal = []
+
+        def progress(remaining, total):
+            journal.append(remaining)
+
+        with NamedTemporaryFile(suffix='.sqlite') as bckfn:
+            self.cx.backup(bckfn.name, -1, progress)
+            self.testBackup(bckfn.name)
+
+        self.assertEqual(len(journal), 1)
+        self.assertEqual(journal[0], 0)
+
+    def CheckNonCallableProgress(self):
+        with NamedTemporaryFile(suffix='.sqlite') as bckfn:
+            with self.assertRaises(TypeError) as cm:
+                self.cx.backup(bckfn.name, 1, 'bar')
+            self.assertEqual(str(cm.exception), 'progress argument must be a callable')
+
+    def CheckModifyingProgress(self):
+        journal = []
+
+        def progress(remaining, total):
+            if not journal:
+                self.cx.execute('INSERT INTO foo (key) VALUES (?)', (remaining+1000,))
+                self.cx.commit()
+            journal.append(remaining)
+
+        with NamedTemporaryFile(suffix='.sqlite') as bckfn:
+            self.cx.backup(bckfn.name, 1, progress)
+            self.testBackup(bckfn.name)
+
+            cx = sqlite.connect(bckfn.name)
+            result = cx.execute("SELECT key FROM foo"
+                                " WHERE key >= 1000"
+                                " ORDER BY key").fetchall()
+            self.assertEqual(result[0][0], 1001)
+
+        self.assertEqual(len(journal), 3)
+        self.assertEqual(journal[0], 1)
+        self.assertEqual(journal[1], 1)
+        self.assertEqual(journal[2], 0)
+
+def suite():
+    return unittest.TestSuite(unittest.makeSuite(BackupTests, "Check"))
+
+def test():
+    runner = unittest.TextTestRunner()
+    runner.run(suite())
+
+if __name__ == "__main__":
+    test()

--- a/Lib/test/test_sqlite.py
+++ b/Lib/test/test_sqlite.py
@@ -7,7 +7,7 @@ import unittest
 import sqlite3
 from sqlite3.test import (dbapi, types, userfunctions,
                                 factory, transactions, hooks, regression,
-                                dump)
+                                dump, backup)
 
 def load_tests(*args):
     if test.support.verbose:
@@ -18,7 +18,7 @@ def load_tests(*args):
                                userfunctions.suite(),
                                factory.suite(), transactions.suite(),
                                hooks.suite(), regression.suite(),
-                               dump.suite()])
+                               dump.suite(), backup.suite()])
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_sqlite.py
+++ b/Lib/test/test_sqlite.py
@@ -18,7 +18,8 @@ def load_tests(*args):
                                userfunctions.suite(),
                                factory.suite(), transactions.suite(),
                                hooks.suite(), regression.suite(),
-                               dump.suite(), backup.suite()])
+                               dump.suite(),
+                               backup.suite()])
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,8 +10,8 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
-- bpo-27645: sqlite3.Connection now exposes a backup() method.
-  Patch by Lele Gaifax.
+- bpo-27645: sqlite3.Connection now exposes a backup() method, if the underlying SQLite
+  library is at version 3.6.11 or higher. Patch by Lele Gaifax.
 
 - bpo-28598: Support __rmod__ for subclasses of str being called before
   str.__mod__.  Patch by Martijn Pieters.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -36,9 +36,6 @@ Core and Builtins
 
 - bpo-29546: Improve from-import error message with location
 
-- Issue #7063: Remove dead code from the "array" module's slice handling.
-  Patch by Chuck.
-
 - Issue #29319: Prevent RunMainFromImporter overwriting sys.path[0].
 
 - Issue #29337: Fixed possible BytesWarning when compare the code objects.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,8 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-27645: sqlite3.Connection now exposes a backup() method.
+
 - bpo-28598: Support __rmod__ for subclasses of str being called before
   str.__mod__.  Patch by Martijn Pieters.
 
@@ -33,6 +35,9 @@ Core and Builtins
 - bpo-29546: Set the 'path' and 'name' attribute on ImportError for ``from ... import ...``.
 
 - bpo-29546: Improve from-import error message with location
+
+- Issue #7063: Remove dead code from the "array" module's slice handling.
+  Patch by Chuck.
 
 - Issue #29319: Prevent RunMainFromImporter overwriting sys.path[0].
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -11,6 +11,7 @@ Core and Builtins
 -----------------
 
 - bpo-27645: sqlite3.Connection now exposes a backup() method.
+  Patch by Lele Gaifax.
 
 - bpo-28598: Support __rmod__ for subclasses of str being called before
   str.__mod__.  Patch by Martijn Pieters.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1478,7 +1478,7 @@ finally:
 }
 
 static PyObject *
-pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args)
+pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args, PyObject* kwds)
 {
     char* filename;
     int pages = -1;
@@ -1487,9 +1487,10 @@ pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args)
     int rc;
     sqlite3 *bckconn;
     sqlite3_backup *bckhandle;
+    static char *keywords[] = {"filename", "pages", "progress", NULL};
 
-    if (!PyArg_ParseTuple(args, "s|iO:backup(filename, pages, progress)",
-                          &filename, &pages, &progress)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|$iO:backup", keywords,
+                                     &filename, &pages, &progress)) {
         goto finally;
     }
 
@@ -1734,8 +1735,8 @@ static PyMethodDef connection_methods[] = {
         PyDoc_STR("Abort any pending database operation. Non-standard.")},
     {"iterdump", (PyCFunction)pysqlite_connection_iterdump, METH_NOARGS,
         PyDoc_STR("Returns iterator to the dump of the database in an SQL text format. Non-standard.")},
-    {"backup", (PyCFunction)pysqlite_connection_backup, METH_VARARGS,
-        PyDoc_STR("Execute a backup of the database. Non-standard.")},
+    {"backup", (PyCFunction)pysqlite_connection_backup, METH_VARARGS | METH_KEYWORDS,
+        PyDoc_STR("Makes a backup of the database. Non-standard.")},
     {"__enter__", (PyCFunction)pysqlite_connection_enter, METH_NOARGS,
         PyDoc_STR("For context manager. Non-standard.")},
     {"__exit__", (PyCFunction)pysqlite_connection_exit, METH_VARARGS,

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -21,6 +21,12 @@
  * 3. This notice may not be removed or altered from any source distribution.
  */
 
+#ifdef HAVE_UNISTD_H
+#include <unistd.h>
+#else
+extern int unlink(const char *);
+#endif
+
 #include "cache.h"
 #include "module.h"
 #include "structmember.h"
@@ -1574,7 +1580,12 @@ pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args, PyObject* 
         Py_INCREF(Py_None);
         retval = Py_None;
     } else {
-        /* TODO: should the (probably incomplete/invalid) backup be removed here? */
+        /* Remove the probably incomplete/invalid backup */
+        if (unlink(filename) < 0) {
+            /* FIXME: this should probably be chained to the outstanding
+               exception */
+            return PyErr_SetFromErrno(PyExc_OSError);
+        }
     }
 
 finally:

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1483,14 +1483,15 @@ pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args, PyObject* 
     char* filename;
     int pages = -1;
     PyObject* progress = Py_None;
+    char* name = "main";
     PyObject* retval = NULL;
     int rc;
     sqlite3 *bckconn;
     sqlite3_backup *bckhandle;
-    static char *keywords[] = {"filename", "pages", "progress", NULL};
+    static char *keywords[] = {"filename", "pages", "progress", "name", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|$iO:backup", keywords,
-                                     &filename, &pages, &progress)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "s|$iOs:backup", keywords,
+                                     &filename, &pages, &progress, &name)) {
         goto finally;
     }
 
@@ -1512,7 +1513,7 @@ pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args, PyObject* 
     }
 
     Py_BEGIN_ALLOW_THREADS
-    bckhandle = sqlite3_backup_init(bckconn, "main", self->db, "main");
+    bckhandle = sqlite3_backup_init(bckconn, "main", self->db, name);
     Py_END_ALLOW_THREADS
 
     if (bckhandle) {

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1483,18 +1483,19 @@ pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args)
     char* filename;
     int pages = -1;
     PyObject* progress = Py_None;
+    PyObject* retval = NULL;
     int rc;
     sqlite3 *bckconn;
     sqlite3_backup *bckhandle;
 
     if (!PyArg_ParseTuple(args, "s|iO:backup(filename, pages, progress)",
                           &filename, &pages, &progress)) {
-        return NULL;
+        goto finally;
     }
 
     if (progress != Py_None && !PyCallable_Check(progress)) {
         PyErr_SetString(PyExc_TypeError, "progress argument must be a callable");
-        return NULL;
+        goto finally;
     }
 
     if (pages == 0) {
@@ -1502,44 +1503,49 @@ pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args)
     }
 
     rc = sqlite3_open(filename, &bckconn);
-    if (rc == SQLITE_OK) {
-        bckhandle = sqlite3_backup_init(bckconn, "main", self->db, "main");
-        if (bckhandle) {
-            do {
-                rc = sqlite3_backup_step(bckhandle, pages);
+    if (rc != SQLITE_OK) {
+        goto finally;
+    }
 
-                if (progress != Py_None) {
-                    if (!PyObject_CallFunction(progress, "ii",
-                                               sqlite3_backup_remaining(bckhandle),
-                                               sqlite3_backup_pagecount(bckhandle))) {
-                        /* User's callback raised an error: interrupt the loop and
-                           propagate it. */
-                        rc = -1;
-                    }
+    bckhandle = sqlite3_backup_init(bckconn, "main", self->db, "main");
+    if (bckhandle) {
+        do {
+            rc = sqlite3_backup_step(bckhandle, pages);
+
+            if (progress != Py_None) {
+                if (!PyObject_CallFunction(progress, "ii",
+                                           sqlite3_backup_remaining(bckhandle),
+                                           sqlite3_backup_pagecount(bckhandle))) {
+                    /* User's callback raised an error: interrupt the loop and
+                       propagate it. */
+                    rc = -1;
                 }
+            }
 
-                /* Sleep for 250ms if there are still further pages to copy */
-                if (rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED) {
-                    sqlite3_sleep(250);
-                }
-            } while (rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED);
+            /* Sleep for 250ms if there are still further pages to copy */
+            if (rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED) {
+                sqlite3_sleep(250);
+            }
+        } while (rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED);
 
-            sqlite3_backup_finish(bckhandle);
-        }
+        sqlite3_backup_finish(bckhandle);
+    }
 
-        if (rc != -1) {
-            rc = _pysqlite_seterror(bckconn, NULL);
-        }
+    if (rc != -1) {
+        rc = _pysqlite_seterror(bckconn, NULL);
     }
 
     sqlite3_close(bckconn);
 
-    if (rc != 0) {
-        /* TODO: should the (probably incomplete/invalid) backup be removed here? */
-        return NULL;
+    if (rc == SQLITE_OK) {
+        Py_INCREF(Py_None);
+        retval = Py_None;
     } else {
-        Py_RETURN_NONE;
+        /* TODO: should the (probably incomplete/invalid) backup be removed here? */
     }
+
+finally:
+    return retval;
 }
 
 static PyObject *

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -41,6 +41,10 @@
 #endif
 #endif
 
+#if SQLITE_VERSION_NUMBER >= 3006011
+#define HAVE_BACKUP_API
+#endif
+
 _Py_IDENTIFIER(cursor);
 
 static const char * const begin_statements[] = {
@@ -1477,6 +1481,7 @@ finally:
     return retval;
 }
 
+#ifdef HAVE_BACKUP_API
 static PyObject *
 pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args, PyObject* kwds)
 {
@@ -1564,6 +1569,7 @@ pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args, PyObject* 
 finally:
     return retval;
 }
+#endif
 
 static PyObject *
 pysqlite_connection_create_collation(pysqlite_Connection* self, PyObject* args)
@@ -1737,8 +1743,10 @@ static PyMethodDef connection_methods[] = {
         PyDoc_STR("Abort any pending database operation. Non-standard.")},
     {"iterdump", (PyCFunction)pysqlite_connection_iterdump, METH_NOARGS,
         PyDoc_STR("Returns iterator to the dump of the database in an SQL text format. Non-standard.")},
+    #ifdef HAVE_BACKUP_API
     {"backup", (PyCFunction)pysqlite_connection_backup, METH_VARARGS | METH_KEYWORDS,
         PyDoc_STR("Makes a backup of the database. Non-standard.")},
+    #endif
     {"__enter__", (PyCFunction)pysqlite_connection_enter, METH_NOARGS,
         PyDoc_STR("For context manager. Non-standard.")},
     {"__exit__", (PyCFunction)pysqlite_connection_exit, METH_VARARGS,

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1528,7 +1528,7 @@ pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args, PyObject* 
             Py_END_ALLOW_THREADS
 
             if (progress != Py_None) {
-                if (!PyObject_CallFunction(progress, "ii",
+                if (!PyObject_CallFunction(progress, "iii", rc,
                                            sqlite3_backup_remaining(bckhandle),
                                            sqlite3_backup_pagecount(bckhandle))) {
                     /* User's callback raised an error: interrupt the loop and

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1532,8 +1532,9 @@ pysqlite_connection_backup(pysqlite_Connection* self, PyObject* args, PyObject* 
                 }
             }
 
-            /* Sleep for 250ms if there are still further pages to copy */
-            if (rc == SQLITE_OK || rc == SQLITE_BUSY || rc == SQLITE_LOCKED) {
+            /* Sleep for 250ms if there are still further pages to copy and
+               the engine could not make any progress */
+            if (rc == SQLITE_BUSY || rc == SQLITE_LOCKED) {
                 Py_BEGIN_ALLOW_THREADS
                 sqlite3_sleep(250);
                 Py_END_ALLOW_THREADS

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -316,6 +316,9 @@ static const IntConstantPair _int_constants[] = {
 #if SQLITE_VERSION_NUMBER >= 3008003
     {"SQLITE_RECURSIVE", SQLITE_RECURSIVE},
 #endif
+#if SQLITE_VERSION_NUMBER >= 3006011
+    {"SQLITE_DONE", SQLITE_DONE},
+#endif
     {(char*)NULL, 0}
 };
 


### PR DESCRIPTION
This is a set of patches (rebased on current master) that adds a new `backup()` method on `sqlite3.Connection`.

<!-- issue-number: bpo-27645 -->
https://bugs.python.org/issue27645
<!-- /issue-number -->
