### PR TITLE
email.compat32-message.rst: Fix typo in the word `message` (GH-379)

### DIFF
--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -33,9 +33,9 @@ having a MIME type such as :mimetype:`multipart/\*` or
 The conceptual model provided by a :class:`Message` object is that of an
 ordered dictionary of headers with additional methods for accessing both
 specialized information from the headers, for accessing the payload, for
-generating a serialized version of the mssage, and for recursively walking over
-the object tree.  Note that duplicate headers are supported but special methods
-must be used to access them.
+generating a serialized version of the message, and for recursively walking
+over the object tree.  Note that duplicate headers are supported but special
+methods must be used to access them.
 
 The :class:`Message` pseudo-dictionary is indexed by the header names, which
 must be ASCII values.  The values of the dictionary are strings that are


### PR DESCRIPTION
(cherry picked from commit da62373b0d32c14a4137512ef6f13c24fbcaa2c1)