### PR TITLE
[backport to 2.7] bpo-28598: Support __rmod__ for RHS subclasses of str in % string formatting operations

### DIFF
--- a/Lib/test/test_str.py
+++ b/Lib/test/test_str.py
@@ -38,6 +38,15 @@ class StrTest(
         string_tests.MixinStrUnicodeUserStringTest.test_formatting(self)
         self.assertRaises(OverflowError, '%c'.__mod__, 0x1234)
 
+    def test_issue28598_strsubclass_rhs(self):
+        # A subclass of str with an __rmod__ method should be able to hook
+        # into the % operator
+        class SubclassedStr(str):
+            def __rmod__(self, other):
+                return 'Success, self.__rmod__({!r}) was called'.format(other)
+        self.assertEqual('lhs %% %r' % SubclassedStr('rhs'),
+                         "Success, self.__rmod__('lhs %% %r') was called")
+
     @test_support.cpython_only
     def test_formatting_huge_precision(self):
         from _testcapi import INT_MAX

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 2.7.14?
 Core and Builtins
 -----------------
 
+-  Issue #28598: Support __rmod__ for subclasses of str being called before
+   str.__mod__.  Patch by Martijn Pieters.
+
 - bpo-29602: Fix incorrect handling of signed zeros in complex constructor for
   complex subclasses and for inputs having a __complex__ method. Patch
   by Serhiy Storchaka.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1446,10 +1446,14 @@ PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
         {
             w = POP();
             v = TOP();
-            if (PyString_CheckExact(v))
+            if (PyString_CheckExact(v) &&
+                  !PyString_Check(w) || PyString_CheckExact(w)) {
+                /* fast path; string formatting, but not if the RHS is a str
+                 * subclass (see issue28598) */
                 x = PyString_Format(v, w);
-            else
+            } else {
                 x = PyNumber_Remainder(v, w);
+            }
             Py_DECREF(v);
             Py_DECREF(w);
             SET_TOP(x);


### PR DESCRIPTION
Backport of #51 