### PR TITLE
bpo-29686: Changed case.shortDescription to return empty string instead of None

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -466,7 +466,7 @@ class TestCase(object):
         the specified test method's docstring.
         """
         doc = self._testMethodDoc
-        return doc and doc.split("\n")[0].strip() or None
+        return doc and doc.split("\n")[0].strip() or ''
 
 
     def id(self):
@@ -1381,7 +1381,7 @@ class FunctionTestCase(TestCase):
         if self._description is not None:
             return self._description
         doc = self._testFunc.__doc__
-        return doc and doc.split("\n")[0].strip() or None
+        return doc and doc.split("\n")[0].strip() or ''
 
 
 class _SubTest(TestCase):

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -572,7 +572,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
 
 
     def testShortDescriptionWithoutDocstring(self):
-        self.assertIsNone(self.shortDescription())
+        self.assertFalse(self.shortDescription())
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")

--- a/Lib/unittest/test/test_functiontestcase.py
+++ b/Lib/unittest/test/test_functiontestcase.py
@@ -128,11 +128,12 @@ class Test_FunctionTestCase(unittest.TestCase):
 
     # "Returns a one-line description of the test, or None if no description
     # has been provided. The default implementation of this method returns
-    # the first line of the test method's docstring, if available, or None."
+    # the first line of the test method's docstring, if available, or empty
+    # string."
     def test_shortDescription__no_docstring(self):
         test = unittest.FunctionTestCase(lambda: None)
 
-        self.assertEqual(test.shortDescription(), None)
+        self.assertEqual(test.shortDescription(), '')
 
     # "Returns a one-line description of the test, or None if no description
     # has been provided. The default implementation of this method returns


### PR DESCRIPTION
http://bugs.python.org/issue29686