### PR TITLE
correct check for _uuid_generate_time

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -340,7 +340,7 @@ class TestUUID(unittest.TestCase):
         equal(((u.clock_seq_hi_variant & 0x3f) << 8) |
                          u.clock_seq_low, 0x3fff)
 
-    @unittest.skipUnless(uuid._uuid_generate_time.restype is not None,
+    @unittest.skipUnless(uuid._uuid_generate_time is not None,
                          'requires uuid_generate_time_safe(3)')
     @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
     def test_uuid1_safe(self):


### PR DESCRIPTION
If ctypes is not available, _uuid_generate_time will be None not its restype attribute.