### PR TITLE
allow path-like objects to be cwd on windows

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -988,7 +988,7 @@ class Popen(object):
                                          int(not close_fds),
                                          creationflags,
                                          env,
-                                         cwd,
+                                         os.fspath(cwd),
                                          startupinfo)
             finally:
                 # Child is launched. Close the parent's copy of those pipe


### PR DESCRIPTION
#157 added the test, but it's currently (correctly) broken on windows.