### PR TITLE
require uuid_generate_time_safe for all tests of it

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -340,9 +340,10 @@ class TestUUID(unittest.TestCase):
         equal(((u.clock_seq_hi_variant & 0x3f) << 8) |
                          u.clock_seq_low, 0x3fff)
 
-    @unittest.skipUnless(uuid._uuid_generate_time is not None,
-                         'requires uuid_generate_time_safe(3)')
-    @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
+    requires_ugt = unittest.skipUnless(uuid._uuid_generate_time is not None,
+                                       'requires uuid_generate_time_safe(3)')
+
+    @requires_ugt
     def test_uuid1_safe(self):
         u = uuid.uuid1()
         # uuid_generate_time_safe() may return 0 or -1 but what it returns is
@@ -350,7 +351,7 @@ class TestUUID(unittest.TestCase):
         # unknown (unless I suppose the platform is buggy).
         self.assertNotEqual(u.is_safe, uuid.SafeUUID.unknown)
 
-    @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
+    @requires_ugt
     def test_uuid1_unknown(self):
         # Even if the platform has uuid_generate_time_safe(), let's mock it to
         # be uuid_generate_time() and ensure the safety is unknown.
@@ -359,21 +360,21 @@ class TestUUID(unittest.TestCase):
             u = uuid.uuid1()
             self.assertEqual(u.is_safe, uuid.SafeUUID.unknown)
 
-    @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
+    @requires_ugt
     def test_uuid1_is_safe(self):
         with unittest.mock.patch.object(uuid._uuid_generate_time,
                                         'restype', lambda x: 0):
             u = uuid.uuid1()
             self.assertEqual(u.is_safe, uuid.SafeUUID.safe)
 
-    @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
+    @requires_ugt
     def test_uuid1_is_unsafe(self):
         with unittest.mock.patch.object(uuid._uuid_generate_time,
                                         'restype', lambda x: -1):
             u = uuid.uuid1()
             self.assertEqual(u.is_safe, uuid.SafeUUID.unsafe)
 
-    @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
+    @requires_ugt
     def test_uuid1_bogus_return_value(self):
         with unittest.mock.patch.object(uuid._uuid_generate_time,
                                         'restype', lambda x: 3):


### PR DESCRIPTION
The way mocking is written in these tests, we need to have the underlying function around.