### PR TITLE
fix an error message and a comment in _testcapimodule.c

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1167,7 +1167,7 @@ getargs_K(PyObject *self, PyObject *args)
 }
 
 /* This function not only tests the 'k' getargs code, but also the
-   PyLong_AsUnsignedLongMask() and PyLong_AsUnsignedLongMask() functions. */
+   PyLong_AsUnsignedLongMask() function. */
 static PyObject *
 test_k_code(PyObject *self)
 {
@@ -1205,7 +1205,8 @@ test_k_code(PyObject *self)
     value = PyLong_AsUnsignedLongMask(num);
     if (value != (unsigned long)-0x42)
         return raiseTestError("test_k_code",
-            "PyLong_AsUnsignedLongMask() returned wrong value for long 0xFFF...FFF");
+                              "PyLong_AsUnsignedLongMask() returned wrong "
+                              "value for long -0xFFF..000042");
 
     PyTuple_SET_ITEM(tuple, 0, num);
 


### PR DESCRIPTION
fix two mistakes in Modules/_testcapimodule.c:
- in the function comment of test_k_code
- in an error message in test_k_code

(note that I mentioned these mistakes in bpo-27298, but only as a side note.)

Just in case, I ran the test module on my Windows 10, and as expected, it seems that this minor patch doesn't break anything.