### PR TITLE
Don't require the Python org to mention someone

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -7,6 +7,5 @@
     "Misc/NEWS"
   ],
   "userBlacklist": ["gvanrossum"],
-  "userBlacklistForPR": ["benjaminp"],
-  "requiredOrgs": ["python"]
+  "userBlacklistForPR": ["benjaminp"]
 }


### PR DESCRIPTION
**NOTE:** We may want to instead deploy our own bot that is a member of the Python org and has https://github.com/facebook/mention-bot/pull/212 added.

Previously we configured the mention-bot to only mention people who are members of the Python organization. However, this doesn't currently work if members don't have their membership public. Instead we will configure mention-bot to poke anyone, even non-members.