### PR TITLE
bpo-29678: Fixed email.Message.get_params decodes only first one header value

### DIFF
--- a/Lib/email/feedparser.py
+++ b/Lib/email/feedparser.py
@@ -238,6 +238,7 @@ class FeedParser:
         # Done with the headers, so parse them and figure out what we're
         # supposed to see in the body of the message.
         self._parse_headers(headers)
+        self._cur.group_headers()
         # Headers-only parsing is a backwards compatibility hack, which was
         # necessary in the older parser, which could raise errors.  All
         # remaining lines in the input are thrown into the message body.

--- a/Lib/email/message.py
+++ b/Lib/email/message.py
@@ -483,6 +483,14 @@ class Message:
         """
         self._headers.append((name, value))
 
+    def group_headers(self):
+        """Check if there are headers with same name and groups them"""
+        headers = {}
+        for name, value in self._headers:
+            headers.setdefault(name, []).append(value.strip(';'))
+
+        self._headers = [(name, '; '.join(value)) for name, value in headers.items()]
+
     def raw_items(self):
         """Return the (name, value) header pairs without modification.
 

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -366,6 +366,10 @@ class TestMessageAPI(TestEmailBase):
             'X-Header: foo; bar="one"; baz=two\n')
         eq(msg.get_params(header='x-header'),
            [('foo', ''), ('bar', 'one'), ('baz', 'two')])
+        msg = email.message_from_string(
+            'X-Header: foo=one;\nX-Header: bar=two\nX-Header: baz=three;')
+        eq(msg.get_params(header='x-header'),
+           [('foo', 'one'), ('bar', 'two'), ('baz', 'three')])
 
     # test_headerregistry.TestContentTypeHeader.spaces_around_param_equals
     def test_get_param_liberal(self):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -255,6 +255,7 @@ Extension Modules
 
 Library
 -------
+- bpo-29678: Fixed email.Message.get_params decodes only first one header value.
 
 - bpo-29615: SimpleXMLRPCDispatcher no longer chains KeyError (or any other
   exception) to exception(s) raised in the dispatched methods.


### PR DESCRIPTION
Fix for https://bugs.python.org/issue29678