### PR TITLE
bpo-29697: Don't use OpenSSL <1.0.2 fallback on 1.1+

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2728,12 +2728,12 @@ _ssl__SSLContext_impl(PyTypeObject *type, int proto_version)
 #endif
 
 
-#ifndef OPENSSL_NO_ECDH
+#if !defined(OPENSSL_NO_ECDH) && !defined(OPENSSL_VERSION_1_1)
     /* Allow automatic ECDH curve selection (on OpenSSL 1.0.2+), or use
        prime256v1 by default.  This is Apache mod_ssl's initialization
        policy, so we should be safe. OpenSSL 1.1 has it enabled by default.
      */
-#if defined(SSL_CTX_set_ecdh_auto) && !defined(OPENSSL_VERSION_1_1)
+#if defined(SSL_CTX_set_ecdh_auto)
     SSL_CTX_set_ecdh_auto(self->ctx, 1);
 #else
     {


### PR DESCRIPTION
Woo, C code! Someone should make sure this is right.