### PR TITLE
bpo-28963: Fix out of bound iteration in asyncio.Future.remove_done_c…

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -256,6 +256,9 @@ Extension Modules
 Library
 -------
 
+- bpo-28963: Fix out of bound iteration in asyncio.Future.remove_done_callback 
+  implemented in C.
+
 - bpo-29615: SimpleXMLRPCDispatcher no longer chains KeyError (or any other
   exception) to exception(s) raised in the dispatched methods.
   Patch by Petr Motejlek.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -522,7 +522,7 @@ _asyncio_Future_remove_done_callback(FutureObj *self, PyObject *fn)
         return NULL;
     }
 
-    for (i = 0; i < len; i++) {
+    for (i = 0; i < PyList_GET_SIZE(self->fut_callbacks); i++) {
         int ret;
         PyObject *item = PyList_GET_ITEM(self->fut_callbacks, i);
 


### PR DESCRIPTION
See http://bugs.python.org/issue28963 for details. LGTMed by @methane (please approve this PR)