### PR TITLE
bpo-29649: struct.pack_into check boundary error message didn't respect offset

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -583,9 +583,23 @@ class StructTest(unittest.TestCase):
         with self.assertRaisesRegex(
                 struct.error,
                 'pack_into requires a buffer of at least 6 '
-                'bytes for packing 1 bytes at offset 5'):
+                'bytes for packing 1 bytes at offset 5 '
+                '\(actual buffer size is 1\)'):
             struct.pack_into('b', byte_list, 5, 1)
 
+    def test_boundary_error_message_with_negative_offset(self):
+        byte_list = bytearray(10)
+        with self.assertRaisesRegex(
+                struct.error,
+                'pack_into requires negative offset not higher than -4 '
+                '\(actual offset is -2\)'):
+            struct.pack_into('<I', byte_list, -2, 123)
+
+        with self.assertRaisesRegex(
+                struct.error,
+                'pack_into requires negative offset not lower than -10 '
+                '\(actual offset is -11\)'):
+            struct.pack_into('<B', byte_list, -11, 123)
 
 class UnpackIteratorTest(unittest.TestCase):
     """

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -579,24 +579,24 @@ class StructTest(unittest.TestCase):
         self.check_sizeof('0c', 0)
 
     def test_boundary_error_message(self):
-        byte_list = bytearray(1)
-        with self.assertRaisesRegex(
-                struct.error,
-                'pack_into requires a buffer of at least 6 '
-                'bytes for packing 1 bytes at offset 5 '
-                r'\(actual buffer size is 1\)'):
-            struct.pack_into('b', byte_list, 5, 1)
+        regex = (
+            r'pack_into requires a buffer of at least 6 '
+            r'bytes for packing 1 bytes at offset 5 '
+            r'\(actual buffer size is 1\)'
+        )
+        with self.assertRaisesRegex(struct.error, regex):
+            struct.pack_into('b', bytearray(1), 5, 1)
 
     def test_boundary_error_message_with_negative_offset(self):
         byte_list = bytearray(10)
         with self.assertRaisesRegex(
                 struct.error,
-                r'No space to pack 4 bytes at offset -2'):
+                r'no space to pack 4 bytes at offset -2'):
             struct.pack_into('<I', byte_list, -2, 123)
 
         with self.assertRaisesRegex(
                 struct.error,
-                'Offset -11 out of range for 10-byte buffer'):
+                'offset -11 out of range for 10-byte buffer'):
             struct.pack_into('<B', byte_list, -11, 123)
 
 class UnpackIteratorTest(unittest.TestCase):

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -578,6 +578,14 @@ class StructTest(unittest.TestCase):
         self.check_sizeof('0s', 1)
         self.check_sizeof('0c', 0)
 
+    def test_boundary_error_message(self):
+        import ctypes
+        byte_list = ctypes.create_string_buffer(1)
+        try:
+            struct.pack_into('b', byte_list, 5, 1)
+        except struct.error as e:
+            self.assertEqual('pack_into requires a buffer of at least 6 bytes', str(e))
+
 
 class UnpackIteratorTest(unittest.TestCase):
     """

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -584,21 +584,19 @@ class StructTest(unittest.TestCase):
                 struct.error,
                 'pack_into requires a buffer of at least 6 '
                 'bytes for packing 1 bytes at offset 5 '
-                '\(actual buffer size is 1\)'):
+                r'\(actual buffer size is 1\)'):
             struct.pack_into('b', byte_list, 5, 1)
 
     def test_boundary_error_message_with_negative_offset(self):
         byte_list = bytearray(10)
         with self.assertRaisesRegex(
                 struct.error,
-                'pack_into requires negative offset not higher than -4 '
-                '\(actual offset is -2\)'):
+                r'No space to pack 4 bytes at offset -2'):
             struct.pack_into('<I', byte_list, -2, 123)
 
         with self.assertRaisesRegex(
                 struct.error,
-                'pack_into requires negative offset not lower than -10 '
-                '\(actual offset is -11\)'):
+                'Offset -11 out of range for 10-byte buffer'):
             struct.pack_into('<B', byte_list, -11, 123)
 
 class UnpackIteratorTest(unittest.TestCase):

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -579,12 +579,12 @@ class StructTest(unittest.TestCase):
         self.check_sizeof('0c', 0)
 
     def test_boundary_error_message(self):
-        import ctypes
-        byte_list = ctypes.create_string_buffer(1)
-        try:
+        byte_list = bytearray(1)
+        with self.assertRaisesRegex(
+                struct.error,
+                'pack_into requires a buffer of at least 6 '
+                'bytes for packing 1 bytes at offset 5'):
             struct.pack_into('b', byte_list, 5, 1)
-        except struct.error as e:
-            self.assertEqual('pack_into requires a buffer of at least 6 bytes', str(e))
 
 
 class UnpackIteratorTest(unittest.TestCase):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -303,8 +303,8 @@ Extension Modules
 Library
 -------
 
-- bpo-29649: struct.pack_into() check boundary error message
-  didn't respect offset.  Patch by Andrew Nester.
+- bpo-29649: Improve struct.pack_into() exception messages for problems
+  with the buffer size and offset.  Patch by Andrew Nester.
 
 - bpo-29654: Support If-Modified-Since HTTP header (browser cache).  Patch
   by Pierre Quentel.
@@ -325,7 +325,7 @@ Library
   Now using them emits a deprecation warning.
 
 - bpo-27863: Fixed multiple crashes in ElementTree caused by race conditions
-  and wrong types.
+  and wrong types. 
 
 - bpo-25996: Added support of file descriptors in os.scandir() on Unix.
   os.fwalk() is sped up by 2 times by using os.scandir().

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -9,6 +9,7 @@ What's New in Python 3.7.0 alpha 1?
 
 Core and Builtins
 -----------------
+- bpo-29649: struct.pack_into check boundary error message didn't respect offset.
 
 - bpo-29949: Fix memory usage regression of set and frozenset object.
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -9,7 +9,6 @@ What's New in Python 3.7.0 alpha 1?
 
 Core and Builtins
 -----------------
-- bpo-29649: struct.pack_into check boundary error message didn't respect offset.
 
 - bpo-29949: Fix memory usage regression of set and frozenset object.
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -305,7 +305,7 @@ Library
 -------
 
 - bpo-29649: struct.pack_into() check boundary error message
-  didn't respect offset. Patch by Andrew Nester.
+  didn't respect offset.  Patch by Andrew Nester.
 
 - bpo-29654: Support If-Modified-Since HTTP header (browser cache).  Patch
   by Pierre Quentel.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -304,6 +304,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29649: struct.pack_into() check boundary error message
+  didn't respect offset. Patch by Andrew Nester.
+
 - bpo-29654: Support If-Modified-Since HTTP header (browser cache).  Patch
   by Pierre Quentel.
 
@@ -323,7 +326,7 @@ Library
   Now using them emits a deprecation warning.
 
 - bpo-27863: Fixed multiple crashes in ElementTree caused by race conditions
-  and wrong types. 
+  and wrong types.
 
 - bpo-25996: Added support of file descriptors in os.scandir() on Unix.
   os.fwalk() is sped up by 2 times by using os.scandir().

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1931,17 +1931,42 @@ s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     }
 
     /* Support negative offsets. */
-    if (offset < 0)
+    if (offset < 0) {
+         /* Check that negative offset is low enough to fit data */
+        if (offset + soself->s_size > 0) {
+            PyErr_Format(StructError,
+                         "pack_into requires negative offset not higher "
+                         "than %zd (actual offset is %zd)",
+                         -soself->s_size,
+                         offset);
+            PyBuffer_Release(&buffer);
+            return NULL;
+        }
+
+        /* Check that negative offset is not crossing buffer boundary */
+        if (offset + buffer.len < 0) {
+            PyErr_Format(StructError,
+                         "pack_into requires negative offset not lower "
+                         "than %zd (actual offset is %zd)",
+                         -buffer.len,
+                         offset);
+            PyBuffer_Release(&buffer);
+            return NULL;
+        }
+
         offset += buffer.len;
+    }
 
     /* Check boundaries */
-    if (offset < 0 || (buffer.len - offset) < soself->s_size) {
+    if ((buffer.len - offset) < soself->s_size) {
         PyErr_Format(StructError,
                      "pack_into requires a buffer of at least %zd bytes for "
-                     "packing %zd bytes at offset %zd)",
-                     soself->s_size + (offset > 0 ? offset : 0),
+                     "packing %zd bytes at offset %zd "
+                     "(actual buffer size is %zd)",
+                     soself->s_size + offset,
                      soself->s_size,
-                     offset);
+                     offset,
+                     buffer.len);
         PyBuffer_Release(&buffer);
         return NULL;
     }

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1937,8 +1937,11 @@ s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     /* Check boundaries */
     if (offset < 0 || (buffer.len - offset) < soself->s_size) {
         PyErr_Format(StructError,
-                     "pack_into requires a buffer of at least %zd bytes",
-                     soself->s_size + (offset > 0 ? offset : 0));
+                     "pack_into requires a buffer of at least %zd bytes for "
+                     "packing %zd bytes at offset %zd)",
+                     soself->s_size + (offset > 0 ? offset : 0),
+                     soself->s_size,
+                     offset);
         PyBuffer_Release(&buffer);
         return NULL;
     }

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1935,7 +1935,7 @@ s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
          /* Check that negative offset is low enough to fit data */
         if (offset + soself->s_size > 0) {
             PyErr_Format(StructError,
-                         "No space to pack %zd bytes at offset %zd",
+                         "no space to pack %zd bytes at offset %zd",
                          soself->s_size,
                          offset);
             PyBuffer_Release(&buffer);
@@ -1945,7 +1945,7 @@ s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
         /* Check that negative offset is not crossing buffer boundary */
         if (offset + buffer.len < 0) {
             PyErr_Format(StructError,
-                         "Offset %zd out of range for %zd-byte buffer",
+                         "offset %zd out of range for %zd-byte buffer",
                          offset,
                          buffer.len);
             PyBuffer_Release(&buffer);

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1938,7 +1938,7 @@ s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     if (offset < 0 || (buffer.len - offset) < soself->s_size) {
         PyErr_Format(StructError,
                      "pack_into requires a buffer of at least %zd bytes",
-                     soself->s_size);
+                     soself->s_size + (offset > 0 ? offset : 0));
         PyBuffer_Release(&buffer);
         return NULL;
     }

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1935,9 +1935,8 @@ s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
          /* Check that negative offset is low enough to fit data */
         if (offset + soself->s_size > 0) {
             PyErr_Format(StructError,
-                         "pack_into requires negative offset not higher "
-                         "than %zd (actual offset is %zd)",
-                         -soself->s_size,
+                         "No space to pack %zd bytes at offset %zd",
+                         soself->s_size,
                          offset);
             PyBuffer_Release(&buffer);
             return NULL;
@@ -1946,10 +1945,9 @@ s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
         /* Check that negative offset is not crossing buffer boundary */
         if (offset + buffer.len < 0) {
             PyErr_Format(StructError,
-                         "pack_into requires negative offset not lower "
-                         "than %zd (actual offset is %zd)",
-                         -buffer.len,
-                         offset);
+                         "Offset %zd out of range for %zd-byte buffer",
+                         offset,
+                         buffer.len);
             PyBuffer_Release(&buffer);
             return NULL;
         }


### PR DESCRIPTION
Fix for https://bugs.python.org/issue29649 