### PR TITLE
[3.5] Add Python version since deprecation in base64 methods. (#33)

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -237,13 +237,17 @@ The legacy interface:
 
 
 .. function:: decodebytes(s)
-              decodestring(s)
 
    Decode the :term:`bytes-like object` *s*, which must contain one or more
    lines of base64 encoded data, and return the decoded :class:`bytes`.
-   ``decodestring`` is a deprecated alias.
 
    .. versionadded:: 3.1
+
+.. function:: decodestring(s)
+
+   Deprecated alias of :func:`decodebytes`.
+
+   .. deprecated:: 3.1
 
 
 .. function:: encode(input, output)
@@ -257,14 +261,19 @@ The legacy interface:
 
 
 .. function:: encodebytes(s)
-              encodestring(s)
 
    Encode the :term:`bytes-like object` *s*, which can contain arbitrary binary
    data, and return :class:`bytes` containing the base64-encoded data, with newlines
    (``b'\n'``) inserted after every 76 bytes of output, and ensuring that
    there is a trailing newline, as per :rfc:`2045` (MIME).
 
-   ``encodestring`` is a deprecated alias.
+   .. versionadded:: 3.1
+
+.. function:: encodestring(s)
+
+   Deprecated alias of :func:`encodebytes`.
+
+   .. deprecated:: 3.1
 
 
 An example usage of the module:

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -542,7 +542,8 @@ def encodebytes(s):
 def encodestring(s):
     """Legacy alias of encodebytes()."""
     import warnings
-    warnings.warn("encodestring() is a deprecated alias, use encodebytes()",
+    warnings.warn("encodestring() is a deprecated alias since 3.1, "
+                  "use encodebytes()",
                   DeprecationWarning, 2)
     return encodebytes(s)
 
@@ -555,7 +556,8 @@ def decodebytes(s):
 def decodestring(s):
     """Legacy alias of decodebytes()."""
     import warnings
-    warnings.warn("decodestring() is a deprecated alias, use decodebytes()",
+    warnings.warn("decodestring() is a deprecated alias since Python 3.1, "
+                  "use decodebytes()",
                   DeprecationWarning, 2)
     return decodebytes(s)
 

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -18,6 +18,14 @@ class LegacyBase64TestCase(unittest.TestCase):
         int_data = memoryview(b"1234").cast('I')
         self.assertRaises(TypeError, f, int_data)
 
+    def test_encodestring_warns(self):
+        with self.assertWarns(DeprecationWarning):
+            base64.encodestring(b"www.python.org")
+
+    def test_decodestring_warns(self):
+        with self.assertWarns(DeprecationWarning):
+            base64.decodestring(b"d3d3LnB5dGhvbi5vcmc=\n")
+
     def test_encodebytes(self):
         eq = self.assertEqual
         eq(base64.encodebytes(b"www.python.org"), b"d3d3LnB5dGhvbi5vcmc=\n")


### PR DESCRIPTION
Allow developers to not have to either test on N Python versions or
looked through multiple versions of the docs to know whether they can
easily update.

(cherry picked from commit c643a967dd7d33ccefa5b61b38caf40b448057ce)