### PR TITLE
bpo-29711: Fix stop_serving in proactor loop kill all listening servers

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -537,6 +537,8 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         self._accept_futures.clear()
 
     def _stop_serving(self, sock):
-        self._stop_accept_futures()
+        future = self._accept_futures.pop(sock.fileno(), None)
+        if future:
+            future.cancel()
         self._proactor._stop_serving(sock)
         sock.close()

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -557,10 +557,21 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
         self.assertTrue(self.sock.close.called)
 
     def test_stop_serving(self):
-        sock = mock.Mock()
-        self.loop._stop_serving(sock)
-        self.assertTrue(sock.close.called)
-        self.proactor._stop_serving.assert_called_with(sock)
+        sock1 = mock.Mock()
+        future1 = mock.Mock()
+        sock2 = mock.Mock()
+        future2 = mock.Mock()
+        self.loop._accept_futures = {
+            sock1.fileno(): future1,
+            sock2.fileno(): future2
+        }
+
+        self.loop._stop_serving(sock1)
+        self.assertTrue(sock1.close.called)
+        self.assertTrue(future1.cancel.called)
+        self.proactor._stop_serving.assert_called_with(sock1)
+        self.assertFalse(sock2.close.called)
+        self.assertFalse(future2.cancel.called)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2017-12-13-22-10-36.bpo-29711.hJjghA.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-13-22-10-36.bpo-29711.hJjghA.rst
@@ -1,0 +1,1 @@
+Fix ``stop_serving`` in asyncio proactor loop kill all listening servers


### PR DESCRIPTION
Current implementation of the asyncio Proactor event loop has an issue, when you stop a server it's cancel the futures of all other servers.

Original discussion: https://github.com/python/asyncio/pull/496

<!-- issue-number: bpo-29711 -->
https://bugs.python.org/issue29711
<!-- /issue-number -->
