### PR TITLE
[3.6] bpo-29455: Mention coverage.py in trace module documentation (GH-261)

### DIFF
--- a/Doc/library/trace.rst
+++ b/Doc/library/trace.rst
@@ -13,6 +13,12 @@ annotated statement coverage listings, print caller/callee relationships and
 list functions executed during a program run.  It can be used in another program
 or from the command line.
 
+.. seealso::
+
+   `Coverage.py <https://coverage.readthedocs.io/>`_
+      A popular third-party coverage tool that provides HTML
+      output along with advanced features such as branch coverage.
+
 .. _trace-cli:
 
 Command-Line Usage


### PR DESCRIPTION
(cherry picked from commit 5dfccb06dc513ae67fac5fee66356ad58a4de170)