### PR TITLE
bpo-29572: Update Windows build to OpenSSL 1.0.2k

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -806,7 +806,7 @@ Documentation
 Build
 -----
 
-- Issue #29572: Update Windows build and OS X installers to use OpenSSL 1.0.2k.
+- bpo-29572: Update Windows build and OS X installers to use OpenSSL 1.0.2k.
 
 - Issue #27659: Prohibit implicit C function declarations: use
   -Werror=implicit-function-declaration when possible (GCC and Clang, but it

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -806,6 +806,8 @@ Documentation
 Build
 -----
 
+- Issue #29572: Update Windows build and OS X installers to use OpenSSL 1.0.2k.
+
 - Issue #27659: Prohibit implicit C function declarations: use
   -Werror=implicit-function-declaration when possible (GCC and Clang, but it
   depends on the compiler version). Patch written by Chi Hsuan Yen.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -54,7 +54,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                    bzip2-1.0.6
 if NOT "%IncludeSSL%"=="false" set libraries=%libraries%     nasm-2.11.06
-if NOT "%IncludeSSL%"=="false" set libraries=%libraries%     openssl-1.0.2j
+if NOT "%IncludeSSL%"=="false" set libraries=%libraries%     openssl-1.0.2k
 set libraries=%libraries%                                    sqlite-3.14.2.0
 if NOT "%IncludeTkinter%"=="false" set libraries=%libraries% tcl-core-8.6.6.0
 if NOT "%IncludeTkinter%"=="false" set libraries=%libraries% tk-8.6.6.0

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -45,7 +45,7 @@
     <sqlite3Dir>$(ExternalsDir)sqlite-3.14.2.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-    <opensslDir>$(ExternalsDir)openssl-1.0.2j\</opensslDir>
+    <opensslDir>$(ExternalsDir)openssl-1.0.2k\</opensslDir>
     <opensslIncludeDir>$(opensslDir)include32</opensslIncludeDir>
     <opensslIncludeDir Condition="'$(ArchName)' == 'amd64'">$(opensslDir)include64</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -169,7 +169,7 @@ _lzma
     Homepage:
         http://tukaani.org/xz/
 _ssl
-    Python wrapper for version 1.0.2j of the OpenSSL secure sockets
+    Python wrapper for version 1.0.2k of the OpenSSL secure sockets
     library, which is built by ssl.vcxproj
     Homepage:
         http://www.openssl.org/


### PR DESCRIPTION
`test_xmlrpc` fails, but it did before the update as well, so I'm calling it good.