### PR TITLE
remove 3 redundant casts in Objects/longobject.c

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -316,7 +316,7 @@ PyLong_FromUnsignedLong(unsigned long ival)
     if (ival < PyLong_BASE)
         return PyLong_FromLong(ival);
     /* Count the number of Python digits. */
-    t = (unsigned long)ival;
+    t = ival;
     while (t) {
         ++ndigits;
         t >>= PyLong_SHIFT;
@@ -854,7 +854,7 @@ _PyLong_FromByteArray(const unsigned char* bytes, size_t n,
             /* Because we're going LSB to MSB, thisbyte is
                more significant than what's already in accum,
                so needs to be prepended to accum. */
-            accum |= (twodigits)thisbyte << accumbits;
+            accum |= thisbyte << accumbits;
             accumbits += 8;
             if (accumbits >= PyLong_SHIFT) {
                 /* There's enough to fill a Python digit. */
@@ -1121,7 +1121,7 @@ PyLong_FromUnsignedLongLong(unsigned long long ival)
     if (ival < PyLong_BASE)
         return PyLong_FromLong((long)ival);
     /* Count the number of Python digits. */
-    t = (unsigned long long)ival;
+    t = ival;
     while (t) {
         ++ndigits;
         t >>= PyLong_SHIFT;


### PR DESCRIPTION
ISTM that it's quite obvious that the (unsigned long) and the (unsigned long long) casts are redundant.

the (twodigits) cast is also redundant, because casting has precedence over shift left (as can be seen in http://en.cppreference.com/w/c/language/operator_precedence).

Just in case, I ran the test module on my Windows 10, with and without the patch, and as expected, it seems the patch doesn't break anything.