### PR TITLE
bpo-27593: Get SCM build info from git instead of hg.

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -70,8 +70,8 @@ PyAPI_FUNC(const char *) Py_GetCopyright(void);
 PyAPI_FUNC(const char *) Py_GetCompiler(void);
 PyAPI_FUNC(const char *) Py_GetBuildInfo(void);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(const char *) _Py_hgidentifier(void);
-PyAPI_FUNC(const char *) _Py_hgversion(void);
+PyAPI_FUNC(const char *) _Py_gitidentifier(void);
+PyAPI_FUNC(const char *) _Py_gitversion(void);
 #endif
 
 /* Internal -- various one-time initializations */

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -1198,7 +1198,9 @@ def _sys_version(sys_version=None):
         elif buildtime:
             builddate = builddate + ' ' + buildtime
 
-    if hasattr(sys, '_mercurial'):
+    if hasattr(sys, '_git'):
+        _, branch, revision = sys._git
+    elif hasattr(sys, '_mercurial'):
         _, branch, revision = sys._mercurial
     elif hasattr(sys, 'subversion'):
         # sys.subversion was added in Python 2.5

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -67,12 +67,12 @@ class PlatformTest(unittest.TestCase):
 
     def setUp(self):
         self.save_version = sys.version
-        self.save_mercurial = sys._mercurial
+        self.save_git = sys._git
         self.save_platform = sys.platform
 
     def tearDown(self):
         sys.version = self.save_version
-        sys._mercurial = self.save_mercurial
+        sys._git = self.save_git
         sys.platform = self.save_platform
 
     def test_sys_version(self):
@@ -102,7 +102,7 @@ class PlatformTest(unittest.TestCase):
              ('CPython', '2.4.3', '', '', 'truncation', '', 'GCC')),
             ):
             # branch and revision are not "parsed", but fetched
-            # from sys._mercurial.  Ignore them
+            # from sys._git.  Ignore them
             (name, version, branch, revision, buildno, builddate, compiler) \
                    = platform._sys_version(input)
             self.assertEqual(
@@ -149,10 +149,10 @@ class PlatformTest(unittest.TestCase):
                 sys_versions.items():
             sys.version = version_tag
             if subversion is None:
-                if hasattr(sys, "_mercurial"):
-                    del sys._mercurial
+                if hasattr(sys, "_git"):
+                    del sys._git
             else:
-                sys._mercurial = subversion
+                sys._git = subversion
             if sys_platform is not None:
                 sys.platform = sys_platform
             self.assertEqual(platform.python_implementation(), info[0])

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -41,9 +41,9 @@ RANLIB=		@RANLIB@
 READELF=	@READELF@
 SOABI=		@SOABI@
 LDVERSION=	@LDVERSION@
-HGVERSION=	@HGVERSION@
-HGTAG=		@HGTAG@
-HGBRANCH=	@HGBRANCH@
+GITVERSION=	@GITVERSION@
+GITTAG=		@GITTAG@
+GITBRANCH=	@GITBRANCH@
 PGO_PROF_GEN_FLAG=@PGO_PROF_GEN_FLAG@
 PGO_PROF_USE_FLAG=@PGO_PROF_USE_FLAG@
 LLVM_PROF_MERGER=@LLVM_PROF_MERGER@
@@ -741,9 +741,9 @@ Modules/getbuildinfo.o: $(PARSER_OBJS) \
 		$(MODOBJS) \
 		$(srcdir)/Modules/getbuildinfo.c
 	$(CC) -c $(PY_CORE_CFLAGS) \
-	      -DHGVERSION="\"`LC_ALL=C $(HGVERSION)`\"" \
-	      -DHGTAG="\"`LC_ALL=C $(HGTAG)`\"" \
-	      -DHGBRANCH="\"`LC_ALL=C $(HGBRANCH)`\"" \
+	      -DGITVERSION="\"`LC_ALL=C $(GITVERSION)`\"" \
+	      -DGITTAG="\"`LC_ALL=C $(GITTAG)`\"" \
+	      -DGITBRANCH="\"`LC_ALL=C $(GITBRANCH)`\"" \
 	      -o $@ $(srcdir)/Modules/getbuildinfo.c
 
 Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -806,6 +806,10 @@ Documentation
 Build
 -----
 
+- bpo-27593: sys.version and the platform module python_build(),
+  python_branch(), and python_revision() functions now use
+  git information rather than hg when building from a repo.
+
 - bpo-29572: Update Windows build and OS X installers to use OpenSSL 1.0.2k.
 
 - Issue #27659: Prohibit implicit C function declarations: use

--- a/Modules/getbuildinfo.c
+++ b/Modules/getbuildinfo.c
@@ -21,47 +21,47 @@
 #endif
 
 /* XXX Only unix build process has been tested */
-#ifndef HGVERSION
-#define HGVERSION ""
+#ifndef GITVERSION
+#define GITVERSION ""
 #endif
-#ifndef HGTAG
-#define HGTAG ""
+#ifndef GITTAG
+#define GITTAG ""
 #endif
-#ifndef HGBRANCH
-#define HGBRANCH ""
+#ifndef GITBRANCH
+#define GITBRANCH ""
 #endif
 
 const char *
 Py_GetBuildInfo(void)
 {
-    static char buildinfo[50 + sizeof(HGVERSION) +
-                          ((sizeof(HGTAG) > sizeof(HGBRANCH)) ?
-                           sizeof(HGTAG) : sizeof(HGBRANCH))];
-    const char *revision = _Py_hgversion();
+    static char buildinfo[50 + sizeof(GITVERSION) +
+                          ((sizeof(GITTAG) > sizeof(GITBRANCH)) ?
+                           sizeof(GITTAG) : sizeof(GITBRANCH))];
+    const char *revision = _Py_gitversion();
     const char *sep = *revision ? ":" : "";
-    const char *hgid = _Py_hgidentifier();
-    if (!(*hgid))
-        hgid = "default";
+    const char *gitid = _Py_gitidentifier();
+    if (!(*gitid))
+        gitid = "default";
     PyOS_snprintf(buildinfo, sizeof(buildinfo),
-                  "%s%s%s, %.20s, %.9s", hgid, sep, revision,
+                  "%s%s%s, %.20s, %.9s", gitid, sep, revision,
                   DATE, TIME);
     return buildinfo;
 }
 
 const char *
-_Py_hgversion(void)
+_Py_gitversion(void)
 {
-    return HGVERSION;
+    return GITVERSION;
 }
 
 const char *
-_Py_hgidentifier(void)
+_Py_gitidentifier(void)
 {
-    const char *hgtag, *hgid;
-    hgtag = HGTAG;
-    if ((*hgtag) && strcmp(hgtag, "tip") != 0)
-        hgid = hgtag;
+    const char *gittag, *gitid;
+    gittag = GITTAG;
+    if ((*gittag) && strcmp(gittag, "undefined") != 0)
+        gitid = gittag;
     else
-        hgid = HGBRANCH;
-    return hgid;
+        gitid = GITBRANCH;
+    return gitid;
 }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1960,9 +1960,9 @@ _PySys_Init(void)
                          PyUnicode_FromString(Py_GetVersion()));
     SET_SYS_FROM_STRING("hexversion",
                          PyLong_FromLong(PY_VERSION_HEX));
-    SET_SYS_FROM_STRING("_mercurial",
-                        Py_BuildValue("(szz)", "CPython", _Py_hgidentifier(),
-                                      _Py_hgversion()));
+    SET_SYS_FROM_STRING("_git",
+                        Py_BuildValue("(szz)", "CPython", _Py_gitidentifier(),
+                                      _Py_gitversion()));
     SET_SYS_FROM_STRING("dont_write_bytecode",
                          PyBool_FromLong(Py_DontWriteBytecodeFlag));
     SET_SYS_FROM_STRING("api_version",

--- a/configure
+++ b/configure
@@ -760,10 +760,10 @@ build_os
 build_vendor
 build_cpu
 build
-HAS_HG
-HGBRANCH
-HGTAG
-HGVERSION
+HAS_GIT
+GITBRANCH
+GITTAG
+GITVERSION
 BASECPPFLAGS
 target_alias
 host_alias
@@ -2698,17 +2698,17 @@ fi
 
 
 
-if test -e $srcdir/.hg/dirstate
+if test -e $srcdir/.git/HEAD
 then
-# Extract the first word of "hg", so it can be a program name with args.
-set dummy hg; ac_word=$2
+# Extract the first word of "git", so it can be a program name with args.
+set dummy git; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_HAS_HG+:} false; then :
+if ${ac_cv_prog_HAS_GIT+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  if test -n "$HAS_HG"; then
-  ac_cv_prog_HAS_HG="$HAS_HG" # Let the user override the test.
+  if test -n "$HAS_GIT"; then
+  ac_cv_prog_HAS_GIT="$HAS_GIT" # Let the user override the test.
 else
 as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
@@ -2717,7 +2717,7 @@ do
   test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_HAS_HG="found"
+    ac_cv_prog_HAS_GIT="found"
     $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -2725,13 +2725,13 @@ done
   done
 IFS=$as_save_IFS
 
-  test -z "$ac_cv_prog_HAS_HG" && ac_cv_prog_HAS_HG="not-found"
+  test -z "$ac_cv_prog_HAS_GIT" && ac_cv_prog_HAS_GIT="not-found"
 fi
 fi
-HAS_HG=$ac_cv_prog_HAS_HG
-if test -n "$HAS_HG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $HAS_HG" >&5
-$as_echo "$HAS_HG" >&6; }
+HAS_GIT=$ac_cv_prog_HAS_GIT
+if test -n "$HAS_GIT"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $HAS_GIT" >&5
+$as_echo "$HAS_GIT" >&6; }
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
@@ -2739,17 +2739,17 @@ fi
 
 
 else
-HAS_HG=no-repository
+HAS_GIT=no-repository
 fi
-if test $HAS_HG = found
+if test $HAS_GIT = found
 then
-    HGVERSION="hg id -i \$(srcdir)"
-    HGTAG="hg id -t \$(srcdir)"
-    HGBRANCH="hg id -b \$(srcdir)"
+    GITVERSION="git -C \$(srcdir) rev-parse HEAD"
+    GITTAG="git -C \$(srcdir) name-rev --tags --name-only HEAD"
+    GITBRANCH="git -C \$(srcdir) name-rev --name-only HEAD"
 else
-    HGVERSION=""
-    HGTAG=""
-    HGBRANCH=""
+    GITVERSION=""
+    GITTAG=""
+    GITBRANCH=""
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -25,25 +25,25 @@ else
     BASECPPFLAGS=""
 fi
 
-AC_SUBST(HGVERSION)
-AC_SUBST(HGTAG)
-AC_SUBST(HGBRANCH)
+AC_SUBST(GITVERSION)
+AC_SUBST(GITTAG)
+AC_SUBST(GITBRANCH)
 
-if test -e $srcdir/.hg/dirstate
+if test -e $srcdir/.git/HEAD
 then
-AC_CHECK_PROG(HAS_HG, hg, found, not-found)
+AC_CHECK_PROG(HAS_GIT, git, found, not-found)
 else
-HAS_HG=no-repository
+HAS_GIT=no-repository
 fi
-if test $HAS_HG = found
+if test $HAS_GIT = found
 then
-    HGVERSION="hg id -i \$(srcdir)"
-    HGTAG="hg id -t \$(srcdir)"
-    HGBRANCH="hg id -b \$(srcdir)"
+    GITVERSION="git -C \$(srcdir) rev-parse HEAD"
+    GITTAG="git -C \$(srcdir) name-rev --tags --name-only HEAD"
+    GITBRANCH="git -C \$(srcdir) name-rev --name-only HEAD"
 else
-    HGVERSION=""
-    HGTAG=""
-    HGBRANCH=""
+    GITVERSION=""
+    GITTAG=""
+    GITBRANCH=""
 fi
 
 AC_CONFIG_SRCDIR([Include/object.h])


### PR DESCRIPTION
sys.version and the platform module python_build(),
python_branch(), and python_revision() functions now use
git information rather than hg when building from a repo.

Based on original patches by Brett Cannon and Steve Dower.