### PR TITLE
remove merge=union git attribute for Misc/NEWS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-Misc/NEWS   merge=union
-
 *.pck binary
 Lib/test/cjkencodings/* binary
 Lib/test/decimaltestdata/*.decTest binary


### PR DESCRIPTION
Github doesn't support it (ref. isaacs/github#487).  So it can't ease
conflict on Github.

Additionally, it can make trouble when cherry-pick. (ref. GH-212)