### PR TITLE
bpo-28087: Skip test_asyncore and test_eintr poll failures on macOS.

### DIFF
--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -437,6 +437,8 @@ class SelectEINTRTest(EINTRBaseTest):
         self.stop_alarm()
         self.assertGreaterEqual(dt, self.sleep_time)
 
+    @unittest.skipIf(sys.platform == "darwin",
+                     "poll may fail on macOS; see issue #28087")
     @unittest.skipUnless(hasattr(select, 'poll'), 'need select.poll')
     def test_poll(self):
         poller = select.poll()

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -661,6 +661,9 @@ class BaseTestAPI:
         if HAS_UNIX_SOCKETS and self.family == socket.AF_UNIX:
             self.skipTest("Not applicable to AF_UNIX sockets.")
 
+        if sys.platform == "darwin" and self.use_poll:
+            self.skipTest("poll may fail on macOS; see issue #28087")
+
         class TestClient(BaseClient):
             def handle_expt(self):
                 self.socket.recv(1024, socket.MSG_OOB)

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -895,6 +895,10 @@ Tools/Demos
 Tests
 -----
 
+- bpo-28087: Skip test_asyncore and test_eintr poll failures on macOS.
+  Skip some tests of select.poll when running on macOS due to unresolved
+  issues with the underlying system poll function on some macOS versions.
+
 - Issue #29571: to match the behaviour of the ``re.LOCALE`` flag,
   test_re.test_locale_flag now uses ``locale.getpreferredencoding(False)`` to
   determine the candidate encoding for the test regex (allowing it to correctly


### PR DESCRIPTION
Skip some tests of select.poll when running on macOS due to unresolved issues with the underlying system poll function on some macOS versions.