### PR TITLE
bpo-29638: Fix spurious refleaks after typing is imported

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -143,9 +143,14 @@ def dash_R_cleanup(fs, ps, pic, zdc, abcs):
     sys._clear_type_cache()
 
     # Clear ABC registries, restoring previously saved ABC registries.
-    for abc in [getattr(collections.abc, a) for a in collections.abc.__all__]:
-        if not isabstract(abc):
-            continue
+    abs_classes = [getattr(collections.abc, a) for a in collections.abc.__all__]
+    abs_classes = filter(isabstract, abs_classes)
+    if 'typing' in sys.modules:
+        t = sys.modules['typing']
+        # These classes require special treatment because they do not appear
+        # in direct subclasses of collections.abc classes
+        abs_classes = list(abs_classes) + [t.ChainMap, t.Counter, t.DefaultDict]
+    for abc in abs_classes:
         for obj in abc.__subclasses__() + [abc]:
             obj._abc_registry = abcs.get(obj, WeakSet()).copy()
             obj._abc_cache.clear()

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -259,9 +259,6 @@ def clear_caches():
     else:
         for f in typing._cleanups:
             f()
-        for obj in [typing.ChainMap, typing.Counter, typing.DefaultDict]:
-            obj._abc_cache.clear()
-            obj._abc_negative_cache.clear()
 
     gc.collect()
 

--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -254,6 +254,9 @@ def clear_caches():
     else:
         for f in typing._cleanups:
             f()
+        for obj in [typing.ChainMap, typing.Counter, typing.DefaultDict]:
+            obj._abc_cache.clear()
+            obj._abc_negative_cache.clear()
 
     gc.collect()
 


### PR DESCRIPTION
Fixes http://bugs.python.org/issue29638

This adds three more caches to ``refleak.py/clear_caches()``.