### PR TITLE
[3.6] bpo-29557: Remove ambiguous line in binhex docs (#90)

### DIFF
--- a/Doc/library/binhex.rst
+++ b/Doc/library/binhex.rst
@@ -55,5 +55,3 @@ the source for details.
 If you code or decode textfiles on non-Macintosh platforms they will still use
 the old Macintosh newline convention (carriage-return as end of line).
 
-As of this writing, :func:`hexbin` appears to not work in all cases.
-


### PR DESCRIPTION
"appears to not work in all cases" does not inspire confidence in this
module. I can find no context for what bug this was referencing so it
should be removed.
(cherry picked from commit 6de2b7817fa9403e81dc38f13f3690f0bbf3d064)