### PR TITLE
bpo-29726: Change assertRaises to assertRaisesRegex in test_xmlrpc

### DIFF
--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -412,7 +412,7 @@ class SimpleXMLRPCDispatcherTestCase(unittest.TestCase):
 
         dispatcher = xmlrpc.server.SimpleXMLRPCDispatcher()
         dispatcher.register_function(None, name='method')
-        with self.assertRaises(Exception, expected_regex='method'):
+        with self.assertRaisesRegex(Exception, 'method'):
             dispatcher._dispatch('method', ('param',))
 
     def test_instance_has_no_func(self):
@@ -420,14 +420,14 @@ class SimpleXMLRPCDispatcherTestCase(unittest.TestCase):
 
         dispatcher = xmlrpc.server.SimpleXMLRPCDispatcher()
         dispatcher.register_instance(object())
-        with self.assertRaises(Exception, expected_regex='method'):
+        with self.assertRaisesRegex(Exception, 'method'):
             dispatcher._dispatch('method', ('param',))
 
     def test_cannot_locate_func(self):
         """Calls a function that the dispatcher cannot locate"""
 
         dispatcher = xmlrpc.server.SimpleXMLRPCDispatcher()
-        with self.assertRaises(Exception, expected_regex='method'):
+        with self.assertRaisesRegex(Exception, 'method'):
             dispatcher._dispatch('method', ('param',))
 
 


### PR DESCRIPTION
Fixes https://bugs.python.org/issue29726.