### PR TITLE
bpo-29695: Deprecated using bad named keyword arguments in builtings:

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -169,6 +169,11 @@ Deprecated
   both deprecated in Python 3.4 now emit :exc:`DeprecationWarning`. (Contributed
   by Matthias Bussonnier in :issue:`29576`)
 
+- Using *x* as a keyword argument in :func:`int`, :func:`bool` and
+  :func:`float` and using *sequence* as a keyword argument in :func:`list`
+  and :func:`tuple` are deprecated.  Specify the value as a positional argument
+  instead.  (Contributed by Serhiy Storchaka in :issue:`29695`.)
+
 
 Removed
 =======

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -170,6 +170,10 @@ class BoolTest(unittest.TestCase):
         self.assertIs(bool(""), False)
         self.assertIs(bool(), False)
 
+    def test_keyword_args(self):
+        with self.assertWarns(DeprecationWarning):
+            self.assertIs(bool(x=10), True)
+
     def test_format(self):
         self.assertEqual("%d" % False, "0")
         self.assertEqual("%d" % True, "1")

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -208,6 +208,10 @@ class GeneralFloatCases(unittest.TestCase):
         with self.assertWarns(DeprecationWarning):
             self.assertIs(type(FloatSubclass(F())), FloatSubclass)
 
+    def test_keyword_args(self):
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(float(x='3.14'), 3.14)
+
     def test_is_integer(self):
         self.assertFalse((1.1).is_integer())
         self.assertTrue((1.).is_integer())

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -246,9 +246,11 @@ class IntTestCases(unittest.TestCase):
 
     def test_keyword_args(self):
         # Test invoking int() using keyword arguments.
-        self.assertEqual(int(x=1.2), 1)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(int(x=1.2), 1)
         self.assertEqual(int('100', base=2), 4)
-        self.assertEqual(int(x='100', base=2), 4)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(int(x='100', base=2), 4)
         self.assertRaises(TypeError, int, base=10)
         self.assertRaises(TypeError, int, base=0)
 

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -16,6 +16,8 @@ class ListTest(list_tests.CommonTest):
         self.assertEqual(list((0, 1, 2, 3)), [0, 1, 2, 3])
         self.assertEqual(list(''), [])
         self.assertEqual(list('spam'), ['s', 'p', 'a', 'm'])
+        self.assertEqual(list(x for x in range(10) if x % 2),
+                         [1, 3, 5, 7, 9])
 
         if sys.maxsize == 0x7fffffff:
             # This test can currently only work on 32-bit machines.
@@ -38,6 +40,11 @@ class ListTest(list_tests.CommonTest):
         x = []
         x.extend(-y for y in x)
         self.assertEqual(x, [])
+
+    def test_keyword_args(self):
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(list(sequence=(x for x in range(10) if x % 2)),
+                             [1, 3, 5, 7, 9])
 
     def test_truth(self):
         super().test_truth()

--- a/Lib/test/test_tuple.py
+++ b/Lib/test/test_tuple.py
@@ -23,6 +23,13 @@ class TupleTest(seq_tests.CommonTest):
         self.assertEqual(tuple([0, 1, 2, 3]), (0, 1, 2, 3))
         self.assertEqual(tuple(''), ())
         self.assertEqual(tuple('spam'), ('s', 'p', 'a', 'm'))
+        self.assertEqual(tuple(x for x in range(10) if x % 2),
+                         (1, 3, 5, 7, 9))
+
+    def test_keyword_args(self):
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(tuple(sequence=(x for x in range(10) if x % 2)),
+                             (1, 3, 5, 7, 9))
 
     def test_truth(self):
         super().test_truth()

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,10 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-29695: Using "x" as a keyword argument in int(), bool() and float() and
+  using "sequence" as a keyword argument in list() and tuple() are deprecated.
+  Specify the value as a positional argument instead.
+
 - bpo-28893: Set correct __cause__ for errors about invalid awaitables
   returned from __aiter__ and __anext__.
 

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -48,6 +48,12 @@ bool_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:bool", kwlist, &x))
         return NULL;
+    if (kwds != NULL && PyDict_GET_SIZE(kwds) != 0) {
+        if (PyErr_Warn(PyExc_DeprecationWarning,
+                "Using 'x' as a keyword argument is deprecated; "
+                "specify the value as a positional argument instead") < 0)
+            return NULL;
+    }
     ok = PyObject_IsTrue(x);
     if (ok < 0)
         return NULL;

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1569,6 +1569,12 @@ float_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return float_subtype_new(type, args, kwds); /* Wimp out */
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:float", kwlist, &x))
         return NULL;
+    if (kwds != NULL && PyDict_GET_SIZE(kwds) != 0) {
+        if (PyErr_Warn(PyExc_DeprecationWarning,
+                "Using 'x' as a keyword argument is deprecated; "
+                "specify the value as a positional argument instead") < 0)
+            return NULL;
+    }
     /* If it's a string, but not a string subclass, use
        PyFloat_FromString. */
     if (PyUnicode_CheckExact(x))

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2297,6 +2297,12 @@ list_init(PyListObject *self, PyObject *args, PyObject *kw)
 
     if (!PyArg_ParseTupleAndKeywords(args, kw, "|O:list", kwlist, &arg))
         return -1;
+    if (arg != NULL && PyTuple_GET_SIZE(args) == 0) {
+        if (PyErr_Warn(PyExc_DeprecationWarning,
+                "Using 'sequence' as a keyword argument is deprecated; "
+                "specify the value as a positional argument instead") < 0)
+            return -1;
+    }
 
     /* Verify list invariants established by PyType_GenericAlloc() */
     assert(0 <= Py_SIZE(self));

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4811,6 +4811,12 @@ long_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         }
         return PyLong_FromLong(0L);
     }
+    if (PyTuple_GET_SIZE(args) == 0) {
+        if (PyErr_Warn(PyExc_DeprecationWarning,
+                "Using 'x' as a keyword argument is deprecated; "
+                "specify the value as a positional argument instead") < 0)
+            return NULL;
+    }
     if (obase == NULL)
         return PyNumber_Long(x);
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -654,6 +654,12 @@ tuple_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return tuple_subtype_new(type, args, kwds);
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:tuple", kwlist, &arg))
         return NULL;
+    if (arg != NULL && PyTuple_GET_SIZE(args) == 0) {
+        if (PyErr_Warn(PyExc_DeprecationWarning,
+                "Using 'sequence' as a keyword argument is deprecated; "
+                "specify the value as a positional argument instead") < 0)
+            return NULL;
+    }
 
     if (arg == NULL)
         return PyTuple_New(0);


### PR DESCRIPTION
int(), bool(), float(), list() and tuple().  Specify the value as a
positional argument instead.