### PR TITLE
bpo-29719: fix Date and Release field of whatsnew/3.6

### DIFF
--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -2,8 +2,6 @@
   What's New In Python 3.6
 ****************************
 
-:Release: |release|
-:Date: |today|
 :Editors: Elvis Pranskevichus <elvis@magic.io>, Yury Selivanov <yury@magic.io>
 
 .. Rules for maintenance:


### PR DESCRIPTION
"What's New In Python 3.6" describe changes between 3.5 and 3.6.
But |release| and |today| is used at top of the page.  They can be
unrelated to Python 3.6.