### PR TITLE
bpo-29731: Allow warnings filter to print current stack.

### DIFF
--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -140,7 +140,7 @@ def filterwarnings(action, message="", category=Warning, module="", lineno=0,
     'append' -- if true, append to the list of filters
     """
     assert action in ("error", "ignore", "always", "default", "module",
-                      "once"), "invalid action: %r" % (action,)
+                      "once", "stack"), "invalid action: %r" % (action,)
     assert isinstance(message, str), "message must be a string"
     assert isinstance(category, type), "category must be a class"
     assert issubclass(category, Warning), "category must be a Warning subclass"
@@ -173,7 +173,7 @@ def simplefilter(action, category=Warning, lineno=0, append=False):
     'append' -- if true, append to the list of filters
     """
     assert action in ("error", "ignore", "always", "default", "module",
-                      "once"), "invalid action: %r" % (action,)
+                      "once", "stack"), "invalid action: %r" % (action,)
     assert isinstance(lineno, int) and lineno >= 0, \
            "lineno must be an int >= 0"
     _add_filter(action, None, category, None, lineno, append=append)
@@ -372,8 +372,13 @@ def warn_explicit(message, category, filename, lineno,
 
     if action == "error":
         raise message
+    if action == "stack":
+        import traceback
+        import sys
+        f = sys._getframe().f_back.f_back
+        traceback.print_stack(f=f)
     # Other actions
-    if action == "once":
+    elif action == "once":
         registry[key] = 1
         oncekey = (text, category)
         if onceregistry.get(oncekey):

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -241,7 +241,7 @@ def _getaction(action):
     if not action:
         return "default"
     if action == "all": return "always" # Alias
-    for a in ('default', 'always', 'ignore', 'module', 'once', 'error'):
+    for a in ('default', 'always', 'ignore', 'module', 'once', 'error', 'stack'):
         if a.startswith(action):
             return a
     raise _OptionError("invalid action: %r" % (action,))


### PR DESCRIPTION
It is similar to "always" but show the full stack of where the warning
was triggered.

Currently incomplete, does not respect the `stacklevel=` value, and
non-tested. Code may be shared with the traceback module as well, but
may need a tiny bit of refactoring, stack is printed backward.

    ~/dev/cpython stack $ cat foo.py
    import warnings
    warnings.filterwarnings('stack')

    def foo():
        warnings.warn('this', UserWarning)

    def bar():
        foo()

    bar()
    ~/dev/cpython stack $ ./python.exe foo.py
      File "foo.py", line 5, in foo
        warnings.warn('this', UserWarning)
      File "foo.py", line 8, in bar
        foo()
      File "foo.py", line 10, in <module>
        bar()
    foo.py:5: UserWarning: this
      warnings.warn('this', UserWarning)

<!-- issue-number: [bpo-29731](https://bugs.python.org/issue29731) -->
https://bugs.python.org/issue29731
<!-- /issue-number -->
