### PR TITLE
bpo-29719: Remove Date and Release field in whatsnew/3.6

### DIFF
--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -2,8 +2,6 @@
   What's New In Python 3.6
 ****************************
 
-:Release: |release|
-:Date: |today|
 :Editors: Elvis Pranskevichus <elvis@magic.io>, Yury Selivanov <yury@magic.io>
 
 .. Rules for maintenance:


### PR DESCRIPTION
(cherry picked from commit 2225ddaa9e64c086b2b6997b0c9ac50921f7aa85)
original pull request: GH-494