### PR TITLE
bpo-29735: Optimize partial_call(): avoid tuple

### DIFF
--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -209,6 +209,10 @@ PyAPI_FUNC(int) _PyStack_UnpackDict(
    40 bytes on the stack. */
 #define _PY_FASTCALL_SMALL_STACK 5
 
+/* Return 1 if callable supports FASTCALL calling convention for positional
+   arguments: see _PyObject_FastCallDict() and _PyObject_FastCallKeywords() */
+PyAPI_FUNC(int) _PyObject_HasFastCall(PyObject *callable);
+
 /* Call the callable object 'callable' with the "fast call" calling convention:
    args is a C array for positional arguments (nargs is the number of
    positional arguments), kwargs is a dictionary for keyword arguments.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -2,6 +2,22 @@
 #include "frameobject.h"
 
 
+int
+_PyObject_HasFastCall(PyObject *callable)
+{
+    if (PyFunction_Check(callable)) {
+        return 1;
+    }
+    else if (PyCFunction_Check(callable)) {
+        return !(PyCFunction_GET_FLAGS(callable) & METH_VARARGS);
+    }
+    else {
+        assert (PyCallable_Check(callable));
+        return 0;
+    }
+}
+
+
 static PyObject *
 null_error(void)
 {


### PR DESCRIPTION
Avoid temporary tuple to pass positional arguments.

* 2 args: 1.14x faster (-12%)
* 6 args: 1.15x faster (-13%)
* 10 args: 1.17x faster (-14%)