### PR TITLE
bpo-29695: Remove bad keyword parameters in int(), bool(), float(), l…

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -169,11 +169,6 @@ Deprecated
   both deprecated in Python 3.4 now emit :exc:`DeprecationWarning`. (Contributed
   by Matthias Bussonnier in :issue:`29576`)
 
-- Using *x* as a keyword argument in :func:`int`, :func:`bool` and
-  :func:`float` and using *sequence* as a keyword argument in :func:`list`
-  and :func:`tuple` are deprecated.  Specify the value as a positional argument
-  instead.  (Contributed by Serhiy Storchaka in :issue:`29695`.)
-
 
 Removed
 =======
@@ -191,6 +186,10 @@ API and Feature Removals
 * The ``splitunc()`` function in the :mod:`ntpath` module was deprecated in
   Python 3.1, and has now been removed.  Use the :func:`~os.path.splitdrive`
   function instead.
+
+* Functions :func:`bool`, :func:`float`, :func:`list` and :func:`tuple` no
+  longer take keyword arguments.  The first argument of :func:`int` can now
+  be passes only as positional argument.
 
 
 Porting to Python 3.7

--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -171,8 +171,8 @@ class BoolTest(unittest.TestCase):
         self.assertIs(bool(), False)
 
     def test_keyword_args(self):
-        with self.assertWarns(DeprecationWarning):
-            self.assertIs(bool(x=10), True)
+        with self.assertRaisesRegex(TypeError, 'keyword argument'):
+            bool(x=10)
 
     def test_format(self):
         self.assertEqual("%d" % False, "0")

--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -209,8 +209,8 @@ class GeneralFloatCases(unittest.TestCase):
             self.assertIs(type(FloatSubclass(F())), FloatSubclass)
 
     def test_keyword_args(self):
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(float(x='3.14'), 3.14)
+        with self.assertRaisesRegex(TypeError, 'keyword argument'):
+            float(x='3.14')
 
     def test_is_integer(self):
         self.assertFalse((1.1).is_integer())

--- a/Lib/test/test_int.py
+++ b/Lib/test/test_int.py
@@ -246,11 +246,11 @@ class IntTestCases(unittest.TestCase):
 
     def test_keyword_args(self):
         # Test invoking int() using keyword arguments.
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(int(x=1.2), 1)
         self.assertEqual(int('100', base=2), 4)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(int(x='100', base=2), 4)
+        with self.assertRaisesRegex(TypeError, 'keyword argument'):
+            int(x=1.2)
+        with self.assertRaisesRegex(TypeError, 'keyword argument'):
+            int(x='100', base=2)
         self.assertRaises(TypeError, int, base=10)
         self.assertRaises(TypeError, int, base=0)
 

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -42,9 +42,8 @@ class ListTest(list_tests.CommonTest):
         self.assertEqual(x, [])
 
     def test_keyword_args(self):
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(list(sequence=(x for x in range(10) if x % 2)),
-                             [1, 3, 5, 7, 9])
+        with self.assertRaisesRegex(TypeError, 'keyword argument'):
+            list(sequence=[])
 
     def test_truth(self):
         super().test_truth()

--- a/Lib/test/test_tuple.py
+++ b/Lib/test/test_tuple.py
@@ -27,9 +27,8 @@ class TupleTest(seq_tests.CommonTest):
                          (1, 3, 5, 7, 9))
 
     def test_keyword_args(self):
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(tuple(sequence=(x for x in range(10) if x % 2)),
-                             (1, 3, 5, 7, 9))
+        with self.assertRaisesRegex(TypeError, 'keyword argument'):
+            tuple(sequence=())
 
     def test_truth(self):
         super().test_truth()

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -13,9 +13,8 @@ Core and Builtins
 - bpo-29714: Fix a regression that bytes format may fail when containing zero
   bytes inside.
 
-- bpo-29695: Using "x" as a keyword argument in int(), bool() and float() and
-  using "sequence" as a keyword argument in list() and tuple() are deprecated.
-  Specify the value as a positional argument instead.
+- bpo-29695: bool(), float(), list() and tuple() no longer take keyword arguments.
+  The first argument of int() can now be passes only as positional argument.
 
 - bpo-28893: Set correct __cause__ for errors about invalid awaitables
   returned from __aiter__ and __anext__.

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -42,18 +42,13 @@ PyObject *PyBool_FromLong(long ok)
 static PyObject *
 bool_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    static char *kwlist[] = {"x", 0};
     PyObject *x = Py_False;
     long ok;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:bool", kwlist, &x))
+    if (!_PyArg_NoKeywords("bool()", kwds))
         return NULL;
-    if (kwds != NULL && PyDict_GET_SIZE(kwds) != 0) {
-        if (PyErr_Warn(PyExc_DeprecationWarning,
-                "Using 'x' as a keyword argument is deprecated; "
-                "specify the value as a positional argument instead") < 0)
-            return NULL;
-    }
+    if (!PyArg_UnpackTuple(args, "bool", 0, 1, &x))
+        return NULL;
     ok = PyObject_IsTrue(x);
     if (ok < 0)
         return NULL;

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1563,18 +1563,13 @@ static PyObject *
 float_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *x = Py_False; /* Integer zero */
-    static char *kwlist[] = {"x", 0};
 
     if (type != &PyFloat_Type)
         return float_subtype_new(type, args, kwds); /* Wimp out */
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:float", kwlist, &x))
+    if (!_PyArg_NoKeywords("float()", kwds))
         return NULL;
-    if (kwds != NULL && PyDict_GET_SIZE(kwds) != 0) {
-        if (PyErr_Warn(PyExc_DeprecationWarning,
-                "Using 'x' as a keyword argument is deprecated; "
-                "specify the value as a positional argument instead") < 0)
-            return NULL;
-    }
+    if (!PyArg_UnpackTuple(args, "float", 0, 1, &x))
+        return NULL;
     /* If it's a string, but not a string subclass, use
        PyFloat_FromString. */
     if (PyUnicode_CheckExact(x))

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2293,16 +2293,11 @@ static int
 list_init(PyListObject *self, PyObject *args, PyObject *kw)
 {
     PyObject *arg = NULL;
-    static char *kwlist[] = {"sequence", 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "|O:list", kwlist, &arg))
+    if (!_PyArg_NoKeywords("list()", kw))
         return -1;
-    if (arg != NULL && PyTuple_GET_SIZE(args) == 0) {
-        if (PyErr_Warn(PyExc_DeprecationWarning,
-                "Using 'sequence' as a keyword argument is deprecated; "
-                "specify the value as a positional argument instead") < 0)
-            return -1;
-    }
+    if (!PyArg_UnpackTuple(args, "list", 0, 1, &arg))
+        return -1;
 
     /* Verify list invariants established by PyType_GenericAlloc() */
     assert(0 <= Py_SIZE(self));

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4796,7 +4796,7 @@ long_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *obase = NULL, *x = NULL;
     Py_ssize_t base;
-    static char *kwlist[] = {"x", "base", 0};
+    static char *kwlist[] = {"", "base", 0};
 
     if (type != &PyLong_Type)
         return long_subtype_new(type, args, kwds); /* Wimp out */
@@ -4810,12 +4810,6 @@ long_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
             return NULL;
         }
         return PyLong_FromLong(0L);
-    }
-    if (PyTuple_GET_SIZE(args) == 0) {
-        if (PyErr_Warn(PyExc_DeprecationWarning,
-                "Using 'x' as a keyword argument is deprecated; "
-                "specify the value as a positional argument instead") < 0)
-            return NULL;
     }
     if (obase == NULL)
         return PyNumber_Long(x);

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -648,18 +648,13 @@ static PyObject *
 tuple_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *arg = NULL;
-    static char *kwlist[] = {"sequence", 0};
 
     if (type != &PyTuple_Type)
         return tuple_subtype_new(type, args, kwds);
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:tuple", kwlist, &arg))
+    if (!_PyArg_NoKeywords("tuple()", kwds))
         return NULL;
-    if (arg != NULL && PyTuple_GET_SIZE(args) == 0) {
-        if (PyErr_Warn(PyExc_DeprecationWarning,
-                "Using 'sequence' as a keyword argument is deprecated; "
-                "specify the value as a positional argument instead") < 0)
-            return NULL;
-    }
+    if (!PyArg_UnpackTuple(args, "tuple", 0, 1, &arg))
+        return NULL;
 
     if (arg == NULL)
         return PyTuple_New(0);


### PR DESCRIPTION
…ist() and tuple().