### PR TITLE
bpo-29736: Optimize builtin types constructor

### DIFF
--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -42,11 +42,12 @@ PyObject *PyBool_FromLong(long ok)
 static PyObject *
 bool_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    static char *kwlist[] = {"x", 0};
+    static const char * const kwlist[] = {"x", 0};
+    static _PyArg_Parser parser = {"|O:bool", kwlist, 0};
     PyObject *x = Py_False;
     long ok;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:bool", kwlist, &x))
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwds, &parser, &x))
         return NULL;
     if (kwds != NULL && PyDict_GET_SIZE(kwds) != 0) {
         if (PyErr_Warn(PyExc_DeprecationWarning,

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2523,13 +2523,14 @@ bytes_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *new = NULL;
     PyObject *func;
     Py_ssize_t size;
-    static char *kwlist[] = {"source", "encoding", "errors", 0};
+    static const char * const kwlist[] = {"source", "encoding", "errors", 0};
+    static _PyArg_Parser parser = {"|Oss:bytes", kwlist, 0};
     _Py_IDENTIFIER(__bytes__);
 
     if (type != &PyBytes_Type)
         return bytes_subtype_new(type, args, kwds);
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Oss:bytes", kwlist, &x,
-                                     &encoding, &errors))
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwds, &parser, &x,
+                                          &encoding, &errors))
         return NULL;
     if (x == NULL) {
         if (encoding != NULL || errors != NULL) {

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -921,12 +921,12 @@ complex_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     int own_r = 0;
     int cr_is_complex = 0;
     int ci_is_complex = 0;
-    static char *kwlist[] = {"real", "imag", 0};
+    static const char * const kwlist[] = {"real", "imag", 0};
+    static _PyArg_Parser parser = {"|OO:complex", kwlist, 0};
 
     r = Py_False;
     i = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO:complex", kwlist,
-                                     &r, &i))
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwds, &parser, &r, &i))
         return NULL;
 
     /* Special-case for a single argument when type(arg) is complex. */

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1563,11 +1563,12 @@ static PyObject *
 float_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *x = Py_False; /* Integer zero */
-    static char *kwlist[] = {"x", 0};
+    static const char * const kwlist[] = {"x", 0};
+    static _PyArg_Parser parser = {"|O:float", kwlist, 0};
 
     if (type != &PyFloat_Type)
         return float_subtype_new(type, args, kwds); /* Wimp out */
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:float", kwlist, &x))
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwds, &parser, &x))
         return NULL;
     if (kwds != NULL && PyDict_GET_SIZE(kwds) != 0) {
         if (PyErr_Warn(PyExc_DeprecationWarning,

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2293,9 +2293,10 @@ static int
 list_init(PyListObject *self, PyObject *args, PyObject *kw)
 {
     PyObject *arg = NULL;
-    static char *kwlist[] = {"sequence", 0};
+    static const char * const kwlist[] = {"sequence", 0};
+    static _PyArg_Parser parser = {"|O:list", kwlist, 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "|O:list", kwlist, &arg))
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kw, &parser, &arg))
         return -1;
     if (arg != NULL && PyTuple_GET_SIZE(args) == 0) {
         if (PyErr_Warn(PyExc_DeprecationWarning,

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4796,12 +4796,12 @@ long_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *obase = NULL, *x = NULL;
     Py_ssize_t base;
-    static char *kwlist[] = {"x", "base", 0};
+    static const char * const kwlist[] = {"x", "base", 0};
+    static _PyArg_Parser parser = {"|OO:int", kwlist, 0};
 
     if (type != &PyLong_Type)
         return long_subtype_new(type, args, kwds); /* Wimp out */
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO:int", kwlist,
-                                     &x, &obase))
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwds, &parser, &x, &obase))
         return NULL;
     if (x == NULL) {
         if (obase != NULL) {

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -648,11 +648,12 @@ static PyObject *
 tuple_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *arg = NULL;
-    static char *kwlist[] = {"sequence", 0};
+    static const char * const kwlist[] = {"sequence", 0};
+    static _PyArg_Parser parser = {"|O:tuple", kwlist, 0};
 
     if (type != &PyTuple_Type)
         return tuple_subtype_new(type, args, kwds);
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|O:tuple", kwlist, &arg))
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwds, &parser, &arg))
         return NULL;
     if (arg != NULL && PyTuple_GET_SIZE(args) == 0) {
         if (PyErr_Warn(PyExc_DeprecationWarning,

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15001,14 +15001,15 @@ static PyObject *
 unicode_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *x = NULL;
-    static char *kwlist[] = {"object", "encoding", "errors", 0};
+    static const char * const kwlist[] = {"object", "encoding", "errors", 0};
+    static _PyArg_Parser parser = {"|Oss:str", kwlist, 0};
     char *encoding = NULL;
     char *errors = NULL;
 
     if (type != &PyUnicode_Type)
         return unicode_subtype_new(type, args, kwds);
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|Oss:str",
-                                     kwlist, &x, &encoding, &errors))
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwds, &parser,
+                                          &x, &encoding, &errors))
         return NULL;
     if (x == NULL)
         _Py_RETURN_UNICODE_EMPTY();


### PR DESCRIPTION
Replace PyArg_ParseTupleAndKeywords() with
_PyArg_ParseTupleAndKeywordsFast() to optimize the constructor of the
builtin types:

* bool: bool_new()
* bytes: bytes_new()
* complex: complex_new()
* float: float_new()
* int: long_new()
* list: list_init()
* str: unicode_new()
* tuple: tuple_new()

http://bugs.python.org/issue29736