### PR TITLE
Ignore what's new for MentionBot

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -5,7 +5,7 @@
   "fileBlacklist": [
     "Misc/ACKS",
     "Misc/NEWS",
-    "Doc/whatsnew/*.rst",
+    "Doc/whatsnew/*.rst"
   ],
   "userBlacklist": ["gvanrossum"],
   "userBlacklistForPR": ["benjaminp", "skrah"]

--- a/.mention-bot
+++ b/.mention-bot
@@ -4,7 +4,8 @@
   "findPotentialReviewers": true,
   "fileBlacklist": [
     "Misc/ACKS",
-    "Misc/NEWS"
+    "Misc/NEWS",
+    "Doc/whatsnew/*.rst",
   ],
   "userBlacklist": ["gvanrossum"],
   "userBlacklistForPR": ["benjaminp", "skrah"]


### PR DESCRIPTION
Because everybody is editing in every PR and that's finding wrong
reviewers.