### PR TITLE
bpo-29738: Fix memory leak in _get_crl_dp

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1209,10 +1209,6 @@ _get_crl_dp(X509 *certificate) {
     int i, j;
     PyObject *lst, *res = NULL;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
-    /* Calls x509v3_cache_extensions and sets up crldp */
-    X509_check_ca(certificate);
-#endif
     dps = X509_get_ext_d2i(certificate, NID_crl_distribution_points, NULL, NULL);
 
     if (dps == NULL)
@@ -1257,9 +1253,7 @@ _get_crl_dp(X509 *certificate) {
 
   done:
     Py_XDECREF(lst);
-#if OPENSSL_VERSION_NUMBER < 0x10001000L
-    sk_DIST_POINT_free(dps);
-#endif
+    sk_DIST_POINT_pop_free(dps, DIST_POINT_free);
     return res;
 }
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1253,7 +1253,7 @@ _get_crl_dp(X509 *certificate) {
 
   done:
     Py_XDECREF(lst);
-    sk_DIST_POINT_pop_free(dps, DIST_POINT_free);
+    CRL_DIST_POINTS_free(dps);
     return res;
 }
 


### PR DESCRIPTION
* Remove conditional on free of `dps`, since `dps` is now allocated for
all versions of OpenSSL
* Use `sk_DIST_POINT_pop_free` instead of `sk_DIST_POINT_free` since
the latter doesn't free the individual elements of the stack
* Remove call to `x509_check_ca` since it was only used to cache
the `crldp` field of the certificate