### PR TITLE
bpo-29581: Make ABCMeta.__new__ pass **kwargs to type.__new__

### DIFF
--- a/Lib/abc.py
+++ b/Lib/abc.py
@@ -129,8 +129,8 @@ class ABCMeta(type):
     #       external code.
     _abc_invalidation_counter = 0
 
-    def __new__(mcls, name, bases, namespace):
-        cls = super().__new__(mcls, name, bases, namespace)
+    def __new__(mcls, name, bases, namespace, **kwargs):
+        cls = super().__new__(mcls, name, bases, namespace, **kwargs)
         # Compute set of abstract method names
         abstracts = {name
                      for name, value in namespace.items()

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -404,5 +404,17 @@ class TestABC(unittest.TestCase):
         self.assertEqual(B.counter, 1)
 
 
+class TestABCWithInitSubclass(unittest.TestCase):
+    def test_works_with_init_subclass(self):
+        saved_kwargs = {}
+        class ReceivesClassKwargs:
+            def __init_subclass__(cls, **kwargs):
+                super().__init_subclass__()
+                saved_kwargs.update(kwargs)
+        class Receiver(ReceivesClassKwargs, abc.ABC, x=1, y=2, z=3):
+            pass
+        self.assertEqual(saved_kwargs, dict(x=1, y=2, z=3))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -714,6 +714,9 @@ Library
 - Issue #24142: Reading a corrupt config file left configparser in an
   invalid state.  Original patch by Florian Höch.
 
+- Issue #29581: ABCMeta.__new__ now accepts **kwargs, allowing abstract base
+  classes to use keyword parameters in __init_subclass__. Patch by Nate Soares.
+
 Windows
 -------
 


### PR DESCRIPTION
Many metaclasses in the standard library don't play nice with `__init_subclass__`. This bug makes ABCMeta in particular work with `__init_subclass__`, though it doesn't address other metaclasses in the standard library. AFAICT, a general solution to this problem requires updating all metaclasses in the standard library to make sure they pass **kwargs to `type.__new__`, whereas this PR only fixes ABCMeta. For context, see https://bugs.python.org/issue29581.