### PR TITLE
Exclude myself from mention-bot

### DIFF
--- a/.mention-bot
+++ b/.mention-bot
@@ -7,6 +7,6 @@
     "Misc/NEWS",
     "Doc/whatsnew/*.rst"
   ],
-  "userBlacklist": ["gvanrossum", "skrah"],
+  "userBlacklist": ["gvanrossum", "skrah", "haypo"],
   "userBlacklistForPR": ["benjaminp", "skrah"]
 }


### PR DESCRIPTION
I made changes in almost all CPython files last 5 years, so
mention-bot asks me to review basically all pull requests. I simply
don't have the bandwidth to review everything, sorry! I prefer to
select myself which PR I want to follow.