### PR TITLE
[3.6] bpo-29176: Fix name of the _curses.window class (GH-52)

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2082,7 +2082,7 @@ static PyGetSetDef PyCursesWindow_getsets[] = {
 
 PyTypeObject PyCursesWindow_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "_curses.curses window",            /*tp_name*/
+    "_curses.window",           /*tp_name*/
     sizeof(PyCursesWindowObject),       /*tp_basicsize*/
     0,                          /*tp_itemsize*/
     /* methods */


### PR DESCRIPTION
Set name to "_curses.window" instead of "_curses.curses window" (with
a space!?).
(cherry picked from commit 61e2bc74dfab1ceee332d3f480dcf86c478c87c5)