### PR TITLE
[3.6] Add sockaddr_alg to sock_addr_t (GH-234)

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -288,36 +288,6 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
 #include <net/if.h>
 #endif
 
-#ifdef HAVE_SOCKADDR_ALG
-#include <linux/if_alg.h>
-#ifndef AF_ALG
-#define AF_ALG 38
-#endif
-#ifndef SOL_ALG
-#define SOL_ALG 279
-#endif
-
-/* Linux 3.19 */
-#ifndef ALG_SET_AEAD_ASSOCLEN
-#define ALG_SET_AEAD_ASSOCLEN           4
-#endif
-#ifndef ALG_SET_AEAD_AUTHSIZE
-#define ALG_SET_AEAD_AUTHSIZE           5
-#endif
-/* Linux 4.8 */
-#ifndef ALG_SET_PUBKEY
-#define ALG_SET_PUBKEY                  6
-#endif
-
-#ifndef ALG_OP_SIGN
-#define ALG_OP_SIGN                     2
-#endif
-#ifndef ALG_OP_VERIFY
-#define ALG_OP_VERIFY                   3
-#endif
-
-#endif /* HAVE_SOCKADDR_ALG */
-
 /* Generic socket object definitions and includes */
 #define PySocket_BUILDING_SOCKET
 #include "socketmodule.h"

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -98,6 +98,37 @@ typedef int socklen_t;
 #include <sys/kern_control.h>
 #endif
 
+#ifdef HAVE_SOCKADDR_ALG
+#include <linux/if_alg.h>
+#ifndef AF_ALG
+#define AF_ALG 38
+#endif
+#ifndef SOL_ALG
+#define SOL_ALG 279
+#endif
+
+/* Linux 3.19 */
+#ifndef ALG_SET_AEAD_ASSOCLEN
+#define ALG_SET_AEAD_ASSOCLEN           4
+#endif
+#ifndef ALG_SET_AEAD_AUTHSIZE
+#define ALG_SET_AEAD_AUTHSIZE           5
+#endif
+/* Linux 4.8 */
+#ifndef ALG_SET_PUBKEY
+#define ALG_SET_PUBKEY                  6
+#endif
+
+#ifndef ALG_OP_SIGN
+#define ALG_OP_SIGN                     2
+#endif
+#ifndef ALG_OP_VERIFY
+#define ALG_OP_VERIFY                   3
+#endif
+
+#endif /* HAVE_SOCKADDR_ALG */
+
+
 #ifndef Py__SOCKET_H
 #define Py__SOCKET_H
 #ifdef __cplusplus
@@ -158,6 +189,9 @@ typedef union sock_addr {
 #endif
 #ifdef HAVE_SYS_KERN_CONTROL_H
     struct sockaddr_ctl ctl;
+#endif
+#ifdef HAVE_SOCKADDR_ALG
+    struct sockaddr_alg alg;
 #endif
 } sock_addr_t;
 


### PR DESCRIPTION
sock_addr_t is used to define the minimum size of any socket address on
the stack. Let's make sure that an AF_ALG address always fits. Coverity
complains because in theory, AF_ALG might be larger than any of the other
structs. In practice it already fits.

Closes Coverity CID 1398948, 1398949, 1398950

Signed-off-by: Christian Heimes <christian@python.org>
(cherry picked from commit d37c068e695f8ec72b5c1b5a5a5ece2337fda768)