### PR TITLE
[3.6] Fixes bpo-29680: Older gdb does not have gdb.error. (#363)

### DIFF
--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -714,7 +714,7 @@ class PyDictObjectPtr(PyObjectPtr):
         try:
             # <= Python 3.5
             return keys['dk_entries'], dk_size
-        except gdb.error:
+        except RuntimeError:
             # >= Python 3.6
             pass
 


### PR DESCRIPTION
This change is required to make python-dbg.py compatible with GDB versions before 7.3.
(cherry picked from commit 661ca8843fed1183e38db06e52d59ac300bf1c2a)