### PR TITLE
Add -q option to svn export

### DIFF
--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -66,7 +66,7 @@ for %%e in (%libraries%) do (
         echo.%%e already exists, skipping.
     ) else (
         echo.Fetching %%e...
-        svn export %SVNROOT%%%e
+        svn export -q %SVNROOT%%%e
     )
 )
 


### PR DESCRIPTION
AppVeyor log is too unreadable.