### PR TITLE
allow the first call to wcsxfrm to return ERANGE

### DIFF
--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -262,7 +262,7 @@ PyLocale_strxfrm(PyObject* self, PyObject* args)
     }
     errno = 0;
     n2 = wcsxfrm(buf, s, n1);
-    if (errno) {
+    if (errno && errno != ERANGE) {
         PyErr_SetFromErrno(PyExc_OSError);
         goto exit;
     }


### PR DESCRIPTION
If the output buffer provided to wcsxfrm is too small, errno is set to ERANGE. We should not error out in that case.

This corrects be487a65f18e1be5fde03e2977fff4be53cc2fbf on Windows, which is currently failing:
```
======================================================================
ERROR: test_strxfrm (test.test_locale.TestEnUSCollation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\projects\cpython\lib\test\test_locale.py", line 344, in test_strxfrm
    self.assertLess(locale.strxfrm('a'), locale.strxfrm('b'))
OSError: [Errno 34] Result too large
======================================================================
ERROR: test_strxfrm_with_diacritic (test.test_locale.TestEnUSCollation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "C:\projects\cpython\lib\test\test_locale.py", line 365, in test_strxfrm_with_diacritic
    self.assertLess(locale.strxfrm('�'), locale.strxfrm('b'))
OSError: [Errno 34] Result too large
----------------------------------------------------------------------
```