### PR TITLE
[3.5] PCbuild: Add -q option to svn export

### DIFF
--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -66,7 +66,7 @@ for %%e in (%libraries%) do (
         echo.%%e already exists, skipping.
     ) else (
         echo.Fetching %%e...
-        svn export %SVNROOT%%%e
+        svn export -q %SVNROOT%%%e
     )
 )
 


### PR DESCRIPTION
Without this option, AppVeyor log is too unreadable.
(cherry picked from commit 8886d5f39286dffa7d9337857b151e7fb4af23fd)
(original pull request is GH-535)