### PR TITLE
Revert "bpo-29571: Use correct locale encoding in test_re (#149)"

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1399,7 +1399,7 @@ class ReTests(unittest.TestCase):
 
     def test_locale_flag(self):
         import locale
-        enc = locale.getpreferredencoding(False)
+        _, enc = locale.getlocale(locale.LC_CTYPE)
         # Search non-ASCII letter
         for i in range(128, 256):
             try:

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -911,15 +911,6 @@ Tools/Demos
 Tests
 -----
 
-- bpo-28087: Skip test_asyncore and test_eintr poll failures on macOS.
-  Skip some tests of select.poll when running on macOS due to unresolved
-  issues with the underlying system poll function on some macOS versions.
-
-- Issue #29571: to match the behaviour of the ``re.LOCALE`` flag,
-  test_re.test_locale_flag now uses ``locale.getpreferredencoding(False)`` to
-  determine the candidate encoding for the test regex (allowing it to correctly
-  skip the test when the default locale encoding is a multi-byte encoding)
-
 - Issue #24932: Use proper command line parsing in _testembed
 
 - Issue #28950: Disallow -j0 to be combined with -T/-l in regrtest


### PR DESCRIPTION
This reverts commit ace5c0fdd9b962e6e886c29dbcea72c53f051dc4. The correct fix was in 02371e0ed1ee82ec73e7d363bcf2ed40cde1397a. This change is breaking Windows.