### PR TITLE
Revert "bpo-29571: Use correct locale encoding in test_re (#149)" (#554)

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1402,7 +1402,7 @@ class ReTests(unittest.TestCase):
 
     def test_locale_flag(self):
         import locale
-        enc = locale.getpreferredencoding(False)
+        _, enc = locale.getlocale(locale.LC_CTYPE)
         # Search non-ASCII letter
         for i in range(128, 256):
             try:

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -134,6 +134,7 @@ Library
 
 - bpo-29110: Fix file object leak in aifc.open() when file is given as a
   filesystem path and is not in valid AIFF format. Patch by Anthony Zhang.
+- Issue #24932: Use proper command line parsing in _testembed
 
 - Issue #28556: Various updates to typing module: typing.Counter, typing.ChainMap,
   improved ABC caching, etc. Original PRs by Jelle Zijlstra, Ivan Levkivskyi,


### PR DESCRIPTION
This reverts commit ace5c0fdd9b962e6e886c29dbcea72c53f051dc4.