### PR TITLE
Revert "bpo-29571: Use correct locale encoding in test_re (#149)" (#554)

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1334,7 +1334,7 @@ class ReTests(unittest.TestCase):
 
     def test_locale_flag(self):
         import locale
-        enc = locale.getpreferredencoding(False)
+        _, enc = locale.getlocale(locale.LC_CTYPE)
         # Search non-ASCII letter
         for i in range(128, 256):
             try:


### PR DESCRIPTION
This reverts commit ace5c0fdd9b962e6e886c29dbcea72c53f051dc4.