### PR TITLE
bpo-29619: Convert st_ino using unsigned integer

### DIFF
--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -22,7 +22,7 @@ PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 #ifdef MS_WINDOWS
 struct _Py_stat_struct {
     unsigned long st_dev;
-    __int64 st_ino;
+    uint64_t st_ino;
     unsigned short st_mode;
     int st_nlink;
     int st_uid;

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -270,6 +270,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29619: os.stat() and os.DirEntry.inode() now convert inode (st_ino) using
+  unsigned integers.
+
 - bpo-28298: Fix a bug that prevented array 'Q', 'L' and 'I' from accepting big
   intables (objects that have __int__) as elements.
 
@@ -289,7 +292,7 @@ Library
 
 - bpo-9303: Migrate sqlite3 module to _v2 API.  Patch by Aviv Palivoda.
 
-- bpo-28963: Fix out of bound iteration in asyncio.Future.remove_done_callback 
+- bpo-28963: Fix out of bound iteration in asyncio.Future.remove_done_callback
   implemented in C.
 
 - bpo-29704: asyncio.subprocess.SubprocessStreamProtocol no longer closes before

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -583,7 +583,7 @@ _Py_attribute_data_to_stat(BY_HANDLE_FILE_INFORMATION *info, ULONG reparse_tag,
     FILE_TIME_to_time_t_nsec(&info->ftLastWriteTime, &result->st_mtime, &result->st_mtime_nsec);
     FILE_TIME_to_time_t_nsec(&info->ftLastAccessTime, &result->st_atime, &result->st_atime_nsec);
     result->st_nlink = info->nNumberOfLinks;
-    result->st_ino = (((__int64)info->nFileIndexHigh)<<32) + info->nFileIndexLow;
+    result->st_ino = (((uint64_t)info->nFileIndexHigh) << 32) + info->nFileIndexLow;
     if (reparse_tag == IO_REPARSE_TAG_SYMLINK) {
         /* first clear the S_IFMT bits */
         result->st_mode ^= (result->st_mode & S_IFMT);
@@ -653,7 +653,7 @@ _Py_fstat_noraise(int fd, struct _Py_stat_struct *status)
 
     _Py_attribute_data_to_stat(&info, 0, status);
     /* specific to fstat() */
-    status->st_ino = (((__int64)info.nFileIndexHigh)<<32) + info.nFileIndexLow;
+    status->st_ino = (((uint64_t)info.nFileIndexHigh) << 32) + info.nFileIndexLow;
     return 0;
 #else
     return fstat(fd, status);


### PR DESCRIPTION
bpo-29619: os.stat() and os.DirEntry.inodeo() now convert inode
(st_ino) using unsigned integers.