### PR TITLE
bpo-29757: don't swallows errors in the `socket.create_connection()` utility loop

### DIFF
--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -700,7 +700,7 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
     """
 
     host, port = address
-    errs = []
+    errors = []
     for res in getaddrinfo(host, port, 0, SOCK_STREAM):
         af, socktype, proto, canonname, sa = res
         sock = None
@@ -713,13 +713,15 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
             sock.connect(sa)
             return sock
 
-        except error as _:
-            errs.append(_)
+        except error as ex:
+            errors.append(ex)
             if sock is not None:
                 sock.close()
-
-    if errs:
-        raise error("connection failed", errs)
+    nerr = len(errors)
+    if nerr == 1:
+        raise errors[0]
+    elif nerr > 1:
+        raise error("no connection possible due to %d errors" % nerr, errors)
     else:
         raise error("getaddrinfo returns an empty list")
 

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -700,7 +700,7 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
     """
 
     host, port = address
-    err = None
+    errs = []
     for res in getaddrinfo(host, port, 0, SOCK_STREAM):
         af, socktype, proto, canonname, sa = res
         sock = None
@@ -714,12 +714,12 @@ def create_connection(address, timeout=_GLOBAL_DEFAULT_TIMEOUT,
             return sock
 
         except error as _:
-            err = _
+            errs.append(_)
             if sock is not None:
                 sock.close()
 
-    if err is not None:
-        raise err
+    if errs:
+        raise error("connection failed", errs)
     else:
         raise error("getaddrinfo returns an empty list")
 


### PR DESCRIPTION
## Context
The utility method `socket.create_connection()` currently works like that:
1. resolve the destination-address into one or more IP(v4 & v6) addresses;
2. loop on each IP address and stop to the 1st one to work;
3. if none works, re-raise the last error.

## The problem
So currently the loop in `socket.create_connection()` ignores all intermediate errors and reports only the last connection failure, which  might be irrelevant.  For instance, when both IPv4 & IPv6 networks are supported, usually the last address is a IPv6 address and it frequently fails with an irrelevant error - the actual cause have already been ignored.

## Possible solutions
To facilitate network debugging, there are at least 3 options:

a. log each failure [as it happens](/python/cpython/blob/6f0eb93183519024cb360162bdd81b9faec97ba6/Lib/socket.py#L717), but that would get the final failure twice: once as a (warning?) message, and once as an exception .
b. collect all failures and log them only when connection fails, but that might miss important infos to the user;
c. collect and return all failures in list attached to the raised exception, which also might miss important infos.

### open questions
Q1. A question for all cases is what logging "means" to use: the `warnings` or `logging` module?
Q2. And if `logging` is chosen, log them in `'DEBUG'` or `'WARNING'` level?
Q3. Finally, cases (b) & (c) need an answer whether to log collected errors in the case that connection passes.

The 1st part of case (c) is implemented in this PR.