### PR TITLE
Fix the only non-C90 comment to be C90 compatible.

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -37,7 +37,7 @@ Used in:  Py_SAFE_DOWNCAST
  * integral synonyms.  Only define the ones we actually need.
  */
 
-// long long is required. Ensure HAVE_LONG_LONG is defined for compatibility.
+/* long long is required. Ensure HAVE_LONG_LONG is defined for compatibility. */
 #ifndef HAVE_LONG_LONG
 #define HAVE_LONG_LONG 1
 #endif


### PR DESCRIPTION
This is a follow up to https://github.com/python/cpython/pull/566

(Python 3.6 backport)