### PR TITLE
[3.5] bpo-29768: Fixed compile-time check for expat version. (#574)

### DIFF
--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1190,7 +1190,7 @@ newxmlparseobject(const char *encoding, const char *namespace_separator, PyObjec
         Py_DECREF(self);
         return NULL;
     }
-#if ((XML_MAJOR_VERSION >= 2) && (XML_MINOR_VERSION >= 1)) || defined(XML_HAS_SET_HASH_SALT)
+#if XML_COMBINED_VERSION >= 20100 || defined(XML_HAS_SET_HASH_SALT)
     /* This feature was added upstream in libexpat 2.1.0.  Our expat copy
      * has a backport of this feature where we also define XML_HAS_SET_HASH_SALT
      * to indicate that we can still use it. */


### PR DESCRIPTION
(cherry picked from commit 22e707fa04476710ba5cc7e2206e4ac66743931b)