### PR TITLE
[3.6] bpo-29619: Convert st_ino using unsigned integer (#557)

### DIFF
--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -22,7 +22,7 @@ PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 #ifdef MS_WINDOWS
 struct _Py_stat_struct {
     unsigned long st_dev;
-    __int64 st_ino;
+    uint64_t st_ino;
     unsigned short st_mode;
     int st_nlink;
     int st_uid;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1932,11 +1932,13 @@ _pystat_fromstructstat(STRUCT_STAT *st)
         return NULL;
 
     PyStructSequence_SET_ITEM(v, 0, PyLong_FromLong((long)st->st_mode));
-#ifdef HAVE_LARGEFILE_SUPPORT
+#if defined(HAVE_LARGEFILE_SUPPORT) || defined(MS_WINDOWS)
+    Py_BUILD_ASSERT(sizeof(unsigned long long) >= sizeof(st->st_ino));
     PyStructSequence_SET_ITEM(v, 1,
-                              PyLong_FromLongLong((long long)st->st_ino));
+                              PyLong_FromUnsignedLongLong(st->st_ino));
 #else
-    PyStructSequence_SET_ITEM(v, 1, PyLong_FromLong((long)st->st_ino));
+    Py_BUILD_ASSERT(sizeof(unsigned long) >= sizeof(st->st_ino));
+    PyStructSequence_SET_ITEM(v, 1, PyLong_FromUnsignedLong(st->st_ino));
 #endif
 #ifdef MS_WINDOWS
     PyStructSequence_SET_ITEM(v, 2, PyLong_FromUnsignedLong(st->st_dev));
@@ -11156,7 +11158,7 @@ typedef struct {
     PyObject *lstat;
 #ifdef MS_WINDOWS
     struct _Py_stat_struct win32_lstat;
-    __int64 win32_file_index;
+    uint64_t win32_file_index;
     int got_file_index;
 #else /* POSIX */
 #ifdef HAVE_DIRENT_D_TYPE
@@ -11419,7 +11421,8 @@ DirEntry_inode(DirEntry *self)
         self->win32_file_index = stat.st_ino;
         self->got_file_index = 1;
     }
-    return PyLong_FromLongLong((long long)self->win32_file_index);
+    Py_BUILD_ASSERT(sizeof(unsigned long long) >= sizeof(self->win32_file_index));
+    return PyLong_FromUnsignedLongLong(self->win32_file_index);
 #else /* POSIX */
 #ifdef HAVE_LARGEFILE_SUPPORT
     return PyLong_FromLongLong((long long)self->d_ino);

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -583,7 +583,7 @@ _Py_attribute_data_to_stat(BY_HANDLE_FILE_INFORMATION *info, ULONG reparse_tag,
     FILE_TIME_to_time_t_nsec(&info->ftLastWriteTime, &result->st_mtime, &result->st_mtime_nsec);
     FILE_TIME_to_time_t_nsec(&info->ftLastAccessTime, &result->st_atime, &result->st_atime_nsec);
     result->st_nlink = info->nNumberOfLinks;
-    result->st_ino = (((__int64)info->nFileIndexHigh)<<32) + info->nFileIndexLow;
+    result->st_ino = (((uint64_t)info->nFileIndexHigh) << 32) + info->nFileIndexLow;
     if (reparse_tag == IO_REPARSE_TAG_SYMLINK) {
         /* first clear the S_IFMT bits */
         result->st_mode ^= (result->st_mode & S_IFMT);
@@ -653,7 +653,7 @@ _Py_fstat_noraise(int fd, struct _Py_stat_struct *status)
 
     _Py_attribute_data_to_stat(&info, 0, status);
     /* specific to fstat() */
-    status->st_ino = (((__int64)info.nFileIndexHigh)<<32) + info.nFileIndexLow;
+    status->st_ino = (((uint64_t)info.nFileIndexHigh) << 32) + info.nFileIndexLow;
     return 0;
 #else
     return fstat(fd, status);


### PR DESCRIPTION
bpo-29619: os.stat() and os.DirEntry.inodeo() now convert inode
(st_ino) using unsigned integers.

(cherry picked from commit 0f6d73343d342c106cda2219ebb8a6f0c4bd9b3c)
(Misc/NEWS conflict handled manually.)