### PR TITLE
[BPO-30924] [BPO-30925] doc-files separate line and additional files patches

### DIFF
--- a/Lib/distutils/command/bdist_rpm.py
+++ b/Lib/distutils/command/bdist_rpm.py
@@ -62,6 +62,8 @@ class bdist_rpm(Command):
          "[default: vendor]"),
         ('doc-files=', None,
          "list of documentation files (space or comma-separated)"),
+        ('extra-files=', None,
+         "list of extra files to be included in the rpm (space or comma-separated) (generated externally)"),
         ('changelog=', None,
          "RPM changelog"),
         ('icon=', None,
@@ -151,6 +153,7 @@ class bdist_rpm(Command):
         self.vendor = None
         self.packager = None
         self.doc_files = None
+        self.extra_files = None
         self.changelog = None
         self.icon = None
 
@@ -220,6 +223,7 @@ class bdist_rpm(Command):
             for readme in ('README', 'README.txt'):
                 if os.path.exists(readme) and readme not in self.doc_files:
                     self.doc_files.append(readme)
+        self.ensure_string_list('extra_files')
 
         self.ensure_string('release', "1")
         self.ensure_string('serial')   # should it be an int?
@@ -260,6 +264,7 @@ class bdist_rpm(Command):
             print("vendor =", self.vendor)
             print("packager =", self.packager)
             print("doc_files =", self.doc_files)
+            print("extra_files = ", self.extra_files)
             print("changelog =", self.changelog)
 
         # make directories
@@ -548,6 +553,11 @@ class bdist_rpm(Command):
             '%files -f INSTALLED_FILES',
             '%defattr(-,root,root)',
             ])
+
+        if self.extra_files:
+            extra_files_seperator = "\n"
+            spec_file.append("\n" + extra_files_seperator.join(self.extra_files))
+
 
         if self.doc_files:
             doc_files_seperator = "\n"

--- a/Lib/distutils/command/bdist_rpm.py
+++ b/Lib/distutils/command/bdist_rpm.py
@@ -550,7 +550,8 @@ class bdist_rpm(Command):
             ])
 
         if self.doc_files:
-            spec_file.append('%doc ' + ' '.join(self.doc_files))
+            doc_files_seperator = "\n"
+            spec_file.append("%doc\n" + doc_files_seperator.join(self.doc_files))
 
         if self.changelog:
             spec_file.extend([


### PR DESCRIPTION
 doc-files Breakup should break files up into multiple lines, as per RPM expectation

when using %doc section of the RPM spec, it expects multiple files
to be listed each on their own line.  Currently what gets passed in
is:

%doc file1 file2 file3

which throws:
	error: More than one file on a line: file1
	error: More than one file on a line: file2
	error: More than one file on a line: file3

This breaks the files up into seperate lines:

%doc
file1
file2
file3

which works as expected with multiple files

Signed-off-by: John 'Warthog9' Hawley <jhawley@vmware.com>
Signed-off-by: John 'Warthog9' Hawley <warthog9@eaglescrag.net>