### PR TITLE
[email] bpo-29478: Fix passing max_line_length=None from Compat32 policy

### DIFF
--- a/Lib/email/_policybase.py
+++ b/Lib/email/_policybase.py
@@ -361,8 +361,12 @@ class Compat32(Policy):
             # Assume it is a Header-like object.
             h = value
         if h is not None:
-            parts.append(h.encode(linesep=self.linesep,
-                                  maxlinelen=self.max_line_length))
+            # The Header class interprets a value of None for maxlinelen as the
+            # default value of 78, as recommended by RFC 2822.
+            maxlinelen = 0
+            if self.max_line_length is not None:
+                maxlinelen = self.max_line_length
+            parts.append(h.encode(linesep=self.linesep, maxlinelen=maxlinelen))
         parts.append(self.linesep)
         return ''.join(parts)
 

--- a/Lib/test/test_email/test_generator.py
+++ b/Lib/test/test_email/test_generator.py
@@ -162,6 +162,13 @@ class TestGeneratorBase:
                 g.flatten(msg)
                 self.assertEqual(s.getvalue(), self.typ(expected))
 
+    def test_compat32_max_line_length_does_not_fold_when_none(self):
+        msg = self.msgmaker(self.typ(self.refold_long_expected[0]))
+        s = self.ioclass()
+        g = self.genclass(s, policy=policy.compat32.clone(max_line_length=None))
+        g.flatten(msg)
+        self.assertEqual(s.getvalue(), self.typ(self.refold_long_expected[0]))
+
 
 class TestGenerator(TestGeneratorBase, TestEmailBase):
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -310,6 +310,7 @@ Garrett Cooper
 Greg Copeland
 Ian Cordasco
 Aldo Cortesi
+Mircea Cosbuc
 David Costanzo
 Scott Cotton
 Greg Couch

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -142,6 +142,9 @@ Core and Builtins
 
 - bpo-29546: Improve from-import error message with location
 
+- bpo-29478: If max_line_length=None is specified while using the Compat32 policy,
+  it is no longer ignored.  Patch by Mircea Cosbuc.
+
 - Issue #29319: Prevent RunMainFromImporter overwriting sys.path[0].
 
 - Issue #29337: Fixed possible BytesWarning when compare the code objects.


### PR DESCRIPTION
This fixes an [issue](https://bugs.python.org/issue29478) with the `Compat32` email policy where setting the `max_line_length` attribute to `None` should prevent line wrapping as specified in the [docs](https://docs.python.org/release/3.5.2/library/email.policy.html#email.policy.Policy.max_line_length).