### PR TITLE
Ignore Include/pydtrace_probes.h (3.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 .gdb_history
 Doc/build/
 Doc/venv/
+Include/pydtrace_probes.h
 Lib/distutils/command/*.pdb
 Lib/lib2to3/*.pickle
 Lib/test/data/*


### PR DESCRIPTION
This is a generated file when --with-dtrace is passed. This entry is present in
.hgignore.