### PR TITLE
[3.6] bpo-28739: Document that f-strings cannot be used as docstring (GH-592)

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -696,6 +696,17 @@ a temporary variable.
    >>> f"newline: {newline}"
    'newline: 10'
 
+Formatted string literals cannot be used as docstrings, even if they do not
+include expressions.
+
+::
+
+   >>> def foo():
+   ...     f"Not a docstring"
+   ...
+   >>> foo.__doc__ is None
+   True
+
 See also :pep:`498` for the proposal that added formatted string literals,
 and :meth:`str.format`, which uses a related format string mechanism.
 


### PR DESCRIPTION
(cherry picked from commit d4e89287b397c7382c12d3f3d9fd901fd8243b3c)