### PR TITLE
bpo-27200: fix several doctests

### DIFF
--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -660,8 +660,12 @@ Here are the methods of the :class:`Message` class:
 
       .. testsetup::
 
+         import email
          from email import message_from_binary_file
-         with open('../Lib/test/test_email/data/msg_16.txt', 'rb') as f:
+         from os.path import join, dirname
+         lib_dir = dirname(email.__file__).rstrip('/email')
+         file_path = join(lib_dir, 'test/test_email/data/msg_16.txt')
+         with open(file_path, 'rb') as f:
              msg = message_from_binary_file(f)
          from email.iterators import _structure
 

--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -660,10 +660,10 @@ Here are the methods of the :class:`Message` class:
 
       .. testsetup::
 
-         >>> from email import message_from_binary_file
-         >>> with open('Lib/test/test_email/data/msg_16.txt', 'rb') as f:
-         ...     msg = message_from_binary_file(f)
-         >>> from email.iterators import _structure
+         from email import message_from_binary_file
+         with open('../Lib/test/test_email/data/msg_16.txt', 'rb') as f:
+             msg = message_from_binary_file(f)
+         from email.iterators import _structure
 
       .. doctest::
 
@@ -686,7 +686,7 @@ Here are the methods of the :class:`Message` class:
       .. doctest::
 
          >>> for part in msg.walk():
-         ...     print(part.get_content_maintype() == 'multipart'),
+         ...     print(part.get_content_maintype() == 'multipart',
          ...           part.is_multipart())
          True True
          False False
@@ -698,11 +698,11 @@ Here are the methods of the :class:`Message` class:
          >>> _structure(msg)
          multipart/report
              text/plain
-         message/delivery-status
-             text/plain
-             text/plain
-         message/rfc822
-             text/plain
+             message/delivery-status
+                 text/plain
+                 text/plain
+             message/rfc822
+                 text/plain
 
       Here the ``message`` parts are not ``multiparts``, but they do contain
       subparts. ``is_multipart()`` returns ``True`` and ``walk`` descends

--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -663,7 +663,7 @@ Here are the methods of the :class:`Message` class:
          import email
          from email import message_from_binary_file
          from os.path import join, dirname
-         lib_dir = dirname(email.__file__).rstrip('/email')
+         lib_dir = dirname(dirname(email.__file__))
          file_path = join(lib_dir, 'test/test_email/data/msg_16.txt')
          with open(file_path, 'rb') as f:
              msg = message_from_binary_file(f)

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -328,7 +328,7 @@ are always available.  They are listed here in alphabetical order.
    The resulting list is sorted alphabetically.  For example:
 
       >>> import struct
-      >>> dir()   # show the names in the module namespace
+      >>> dir()   # show the names in the module namespace  # doctest: +SKIP
       ['__builtins__', '__name__', 'struct']
       >>> dir(struct)   # show the names in the struct module # doctest: +SKIP
       ['Struct', '__all__', '__builtins__', '__cached__', '__doc__', '__file__',

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -25,9 +25,10 @@ This is the full module API reference—for an overview and introduction, see
 .. versionadded:: 3.3
 
 .. testsetup::
-   >>> import ipaddress
-   >>> from ipaddress import (ip_network, IPv4Address, IPv4Interface,
-   ...                        IPv4Network)
+
+   import ipaddress
+   from ipaddress import (ip_network, IPv4Address, IPv4Interface,
+                          IPv4Network)
 
 Convenience factory functions
 -----------------------------

--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -27,8 +27,9 @@ This is the full module API reference—for an overview and introduction, see
 .. testsetup::
 
    import ipaddress
-   from ipaddress import (ip_network, IPv4Address, IPv4Interface,
-                          IPv4Network)
+   from ipaddress import (
+       ip_network, IPv4Address, IPv4Interface, IPv4Network,
+   )
 
 Convenience factory functions
 -----------------------------

--- a/Doc/library/reprlib.rst
+++ b/Doc/library/reprlib.rst
@@ -48,6 +48,7 @@ string instead.
    same thread.  If a recursive call is made, the *fillvalue* is returned,
    otherwise, the usual :meth:`__repr__` call is made.  For example:
 
+        >>> from reprlib import recursive_repr
         >>> class MyList(list):
         ...     @recursive_repr()
         ...     def __repr__(self):

--- a/Doc/library/shlex.rst
+++ b/Doc/library/shlex.rst
@@ -43,15 +43,16 @@ The :mod:`shlex` module defines the following functions:
    string that can safely be used as one token in a shell command line, for
    cases where you cannot use a list.
 
-   This idiom would be unsafe::
+   This idiom would be unsafe:
 
       >>> filename = 'somefile; rm -rf ~'
       >>> command = 'ls -l {}'.format(filename)
       >>> print(command)  # executed by a shell: boom!
       ls -l somefile; rm -rf ~
 
-   :func:`quote` lets you plug the security hole::
+   :func:`quote` lets you plug the security hole:
 
+      >>> from shlex import quote
       >>> command = 'ls -l {}'.format(quote(filename))
       >>> print(command)
       ls -l 'somefile; rm -rf ~'
@@ -61,6 +62,7 @@ The :mod:`shlex` module defines the following functions:
 
    The quoting is compatible with UNIX shells and with :func:`split`:
 
+      >>> from shlex import split
       >>> remote_command = split(remote_command)
       >>> remote_command
       ['ssh', 'home', "ls -l 'somefile; rm -rf ~'"]

--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -64,6 +64,9 @@ or on combining URL components into a URL string.
    input is presumed to be a relative URL and thus to start with
    a path component.
 
+   .. doctest::
+      :options: +NORMALIZE_WHITESPACE
+
        >>> from urllib.parse import urlparse
        >>> urlparse('//www.cwi.nl:80/%7Eguido/Python.html')
        ParseResult(scheme='', netloc='www.cwi.nl:80', path='/%7Eguido/Python.html',

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -1384,7 +1384,7 @@ guaranteed not to block when :func:`select.select` says a pipe is ready
 for writing.
 
 >>> import select
->>> select.PIPE_BUF
+>>> select.PIPE_BUF  # doctest: +SKIP
 512
 
 (Available on Unix systems. Patch by Sébastien Sablé in :issue:`9862`)

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -1060,15 +1060,18 @@ of nearly equal quantities:
 
 The :func:`~math.erf` function computes a probability integral or `Gaussian
 error function <https://en.wikipedia.org/wiki/Error_function>`_.  The
-complementary error function, :func:`~math.erfc`, is ``1 - erf(x)``::
+complementary error function, :func:`~math.erfc`, is ``1 - erf(x)``:
 
-    >>> from math import erf, erfc, sqrt
-    >>> erf(1.0/sqrt(2.0))   # portion of normal distribution within 1 standard deviation
-    0.682689492137086
-    >>> erfc(1.0/sqrt(2.0))  # portion of normal distribution outside 1 standard deviation
-    0.31731050786291404
-    >>> erf(1.0/sqrt(2.0)) + erfc(1.0/sqrt(2.0))
-    1.0
+.. doctest:
+   :options: +SKIP
+
+   >>> from math import erf, erfc, sqrt
+   >>> erf(1.0/sqrt(2.0))   # portion of normal distribution within 1 standard deviation
+   0.682689492137086
+   >>> erfc(1.0/sqrt(2.0))  # portion of normal distribution outside 1 standard deviation
+   0.31731050786291404
+   >>> erf(1.0/sqrt(2.0)) + erfc(1.0/sqrt(2.0))
+   1.0
 
 The :func:`~math.gamma` function is a continuous extension of the factorial
 function.  See https://en.wikipedia.org/wiki/Gamma_function for details.  Because

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -1062,7 +1062,7 @@ The :func:`~math.erf` function computes a probability integral or `Gaussian
 error function <https://en.wikipedia.org/wiki/Error_function>`_.  The
 complementary error function, :func:`~math.erfc`, is ``1 - erf(x)``:
 
-.. doctest:
+.. doctest::
    :options: +SKIP
 
    >>> from math import erf, erfc, sqrt

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -1060,15 +1060,15 @@ of nearly equal quantities:
 
 The :func:`~math.erf` function computes a probability integral or `Gaussian
 error function <https://en.wikipedia.org/wiki/Error_function>`_.  The
-complementary error function, :func:`~math.erfc`, is ``1 - erf(x)``:
+complementary error function, :func:`~math.erfc`, is ``1 - erf(x)``::
 
->>> from math import erf, erfc, sqrt
->>> erf(1.0/sqrt(2.0))   # portion of normal distribution within 1 standard deviation
-0.682689492137086
->>> erfc(1.0/sqrt(2.0))  # portion of normal distribution outside 1 standard deviation
-0.31731050786291404
->>> erf(1.0/sqrt(2.0)) + erfc(1.0/sqrt(2.0))
-1.0
+    >>> from math import erf, erfc, sqrt
+    >>> erf(1.0/sqrt(2.0))   # portion of normal distribution within 1 standard deviation
+    0.682689492137086
+    >>> erfc(1.0/sqrt(2.0))  # portion of normal distribution outside 1 standard deviation
+    0.31731050786291404
+    >>> erf(1.0/sqrt(2.0)) + erfc(1.0/sqrt(2.0))
+    1.0
 
 The :func:`~math.gamma` function is a continuous extension of the factorial
 function.  See https://en.wikipedia.org/wiki/Gamma_function for details.  Because


### PR DESCRIPTION
This PR partially fixes [bpo-27200](https://bugs.python.org/issue27200).  Partially and not completely, because I followed the suggestion of @ezio-melotti to split the patch in several patches.  This PR is the 3rd of the series.  The first one was #240 and the second one #401.

To run the doctests (from the `Doc` directory):

```
$ sphinx-build -b doctest . build/doctest \
library/urllib.parse.rst \
library/functions.rst \
library/ipaddress.rst \
library/reprlib.rst \
library/shlex.rst \
library/email.compat32-message.rst \
whatsnew/3.2.rst
```