### PR TITLE
[3.6] bpo-29770: remove outdated PYO related info

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -155,7 +155,7 @@ Glossary
    bytecode
       Python source code is compiled into bytecode, the internal representation
       of a Python program in the CPython interpreter.  The bytecode is also
-      cached in ``.pyc`` and ``.pyo`` files so that executing the same file is
+      cached in ``.pyc`` files so that executing the same file is
       faster the second time (recompilation from source to bytecode can be
       avoided).  This "intermediate language" is said to run on a
       :term:`virtual machine` that executes the machine code corresponding to

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -464,12 +464,12 @@ The :class:`PyZipFile` constructor takes the same parameters as the
       added to the archive, compiling if necessary.
 
       If *pathname* is a file, the filename must end with :file:`.py`, and
-      just the (corresponding :file:`\*.py[co]`) file is added at the top level
+      just the (corresponding :file:`\*.pyc`) file is added at the top level
       (no path information).  If *pathname* is a file that does not end with
       :file:`.py`, a :exc:`RuntimeError` will be raised.  If it is a directory,
       and the directory is not a package directory, then all the files
-      :file:`\*.py[co]` are added at the top level.  If the directory is a
-      package directory, then all :file:`\*.py[co]` are added under the package
+      :file:`\*.pyc` are added at the top level.  If the directory is a
+      package directory, then all :file:`\*.pyc` are added under the package
       name as a file path, and if any subdirectories are package directories,
       all of these are added recursively.
 

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -9,7 +9,7 @@
 --------------
 
 This module adds the ability to import Python modules (:file:`\*.py`,
-:file:`\*.py[co]`) and packages from ZIP-format archives. It is usually not
+:file:`\*.pyc`) and packages from ZIP-format archives. It is usually not
 needed to use the :mod:`zipimport` module explicitly; it is automatically used
 by the built-in :keyword:`import` mechanism for :data:`sys.path` items that are paths
 to ZIP archives.

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -532,8 +532,8 @@ conflict.
 
 .. envvar:: PYTHONDONTWRITEBYTECODE
 
-   If this is set to a non-empty string, Python won't try to write ``.pyc`` or
-   ``.pyo`` files on the import of source modules.  This is equivalent to
+   If this is set to a non-empty string, Python won't try to write ``.pyc``
+   files on the import of source modules.  This is equivalent to
    specifying the :option:`-B` option.
 
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -53,7 +53,7 @@ static const char usage_1[] = "\
 Options and arguments (and corresponding environment variables):\n\
 -b     : issue warnings about str(bytes_instance), str(bytearray_instance)\n\
          and comparing bytes/bytearray with str. (-bb: issue errors)\n\
--B     : don't write .py[co] files on import; also PYTHONDONTWRITEBYTECODE=x\n\
+-B     : don't write .pyc files on import; also PYTHONDONTWRITEBYTECODE=x\n\
 -c cmd : program passed in as string (terminates option list)\n\
 -d     : debug output from parser; also PYTHONDEBUG=x\n\
 -E     : ignore PYTHON* environment variables (such as PYTHONPATH)\n\

--- a/Modules/zipimport.c
+++ b/Modules/zipimport.c
@@ -1102,7 +1102,7 @@ get_decompress_func(void)
     _Py_IDENTIFIER(decompress);
 
     if (importing_zlib != 0)
-        /* Someone has a zlib.py[co] in their Zip file;
+        /* Someone has a zlib.pyc in their Zip file;
            let's avoid a stack overflow. */
         return NULL;
     importing_zlib = 1;
@@ -1261,7 +1261,7 @@ eq_mtime(time_t t1, time_t t2)
     return d <= 1;
 }
 
-/* Given the contents of a .py[co] file in a buffer, unmarshal the data
+/* Given the contents of a .pyc file in a buffer, unmarshal the data
    and return the code object. Return None if it the magic word doesn't
    match (we do this instead of raising an exception as we fall back
    to .py if available and we don't want to mask other errors).
@@ -1403,7 +1403,7 @@ get_mtime_of_source(ZipImporter *self, PyObject *path)
     PyObject *toc_entry, *stripped;
     time_t mtime;
 
-    /* strip 'c' or 'o' from *.py[co] */
+    /* strip 'c' from *.pyc */
     if (PyUnicode_READY(path) == -1)
         return (time_t)-1;
     stripped = PyUnicode_FromKindAndData(PyUnicode_KIND(path),

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -185,7 +185,7 @@ exists(wchar_t *filename)
    may extend 'filename' by one character.
 */
 static int
-ismodule(wchar_t *filename, int update_filename) /* Is module -- check for .pyc/.pyo too */
+ismodule(wchar_t *filename, int update_filename) /* Is module -- check for .pyc too */
 {
     size_t n;
 
@@ -196,7 +196,7 @@ ismodule(wchar_t *filename, int update_filename) /* Is module -- check for .pyc/
     n = wcsnlen_s(filename, MAXPATHLEN+1);
     if (n < MAXPATHLEN) {
         int exist = 0;
-        filename[n] = Py_OptimizeFlag ? L'o' : L'c';
+        filename[n] = L'c';
         filename[n + 1] = L'\0';
         exist = exists(filename);
         if (!update_filename)

--- a/PCbuild/rmpyc.py
+++ b/PCbuild/rmpyc.py
@@ -1,25 +1,19 @@
-# Remove all the .pyc and .pyo files under ../Lib.
+# Remove all the .pyc files under ../Lib.
 
 
 def deltree(root):
     import os
     from os.path import join
 
-    npyc = npyo = 0
+    npyc = 0
     for root, dirs, files in os.walk(root):
         for name in files:
-            delete = False
-            if name.endswith('.pyc'):
-                delete = True
+            # to be thorough
+            if name.endswith(('.pyc', '.pyo')):
                 npyc += 1
-            elif name.endswith('.pyo'):
-                delete = True
-                npyo += 1
-
-            if delete:
                 os.remove(join(root, name))
 
-    return npyc, npyo
+    return npyc
 
-npyc, npyo = deltree("../Lib")
-print(npyc, ".pyc deleted,", npyo, ".pyo deleted")
+npyc = deltree("../Lib")
+print(npyc, ".pyc deleted")

--- a/PCbuild/rt.bat
+++ b/PCbuild/rt.bat
@@ -4,8 +4,8 @@ rem Usage:  rt [-d] [-O] [-q] [-x64] regrtest_args
 rem -d   Run Debug build (python_d.exe).  Else release build.
 rem -O   Run python.exe or python_d.exe (see -d) with -O.
 rem -q   "quick" -- normally the tests are run twice, the first time
-rem      after deleting all the .py[co] files reachable from Lib/.
-rem      -q runs the tests just once, and without deleting .py[co] files.
+rem      after deleting all the .pyc files reachable from Lib/.
+rem      -q runs the tests just once, and without deleting .pyc files.
 rem -x64 Run the 64-bit build of python (or python_d if -d was specified)
 rem      from the 'amd64' dir instead of the 32-bit build in this dir.
 rem All leading instances of these switches are shifted off, and
@@ -45,7 +45,7 @@ set exe=%prefix%python%suffix%.exe
 set cmd="%exe%" %dashO% -Wd -E -bb -m test %regrtestargs%
 if defined qmode goto Qmode
 
-echo Deleting .pyc/.pyo files ...
+echo Deleting .pyc files ...
 "%exe%" "%pcbuild%rmpyc.py"
 
 echo Cleaning _pth files ...
@@ -55,7 +55,7 @@ echo on
 %cmd%
 @echo off
 
-echo About to run again without deleting .pyc/.pyo first:
+echo About to run again without deleting .pyc first:
 pause
 
 :Qmode

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -88,7 +88,7 @@ int Py_BytesWarningFlag; /* Warn on str(bytes) and str(buffer) */
 int Py_UseClassExceptionsFlag = 1; /* Needed by bltinmodule.c: deprecated */
 int Py_FrozenFlag; /* Needed by getpath.c */
 int Py_IgnoreEnvironmentFlag; /* e.g. PYTHONPATH, PYTHONHOME */
-int Py_DontWriteBytecodeFlag; /* Suppress writing bytecode files (*.py[co]) */
+int Py_DontWriteBytecodeFlag; /* Suppress writing bytecode files (*.pyc) */
 int Py_NoUserSiteDirectory = 0; /* for -s and site.py */
 int Py_UnbufferedStdioFlag = 0; /* Unbuffered binary std{in,out,err} */
 int Py_HashRandomizationFlag = 0; /* for -R and PYTHONHASHSEED */


### PR DESCRIPTION
backports to 3.6 for #590 