### PR TITLE
bpo-29793: Convert some builtin types constructors to Argument Clinic.

### DIFF
--- a/Objects/clinic/complexobject.c.h
+++ b/Objects/clinic/complexobject.c.h
@@ -1,0 +1,34 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(complex_new__doc__,
+"complex(real=0, imag=0)\n"
+"--\n"
+"\n"
+"Create a complex number from a real part and an optional imaginary part.\n"
+"\n"
+"This is equivalent to (real + imag*1j) where imag defaults to 0.");
+
+static PyObject *
+complex_new_impl(PyTypeObject *type, PyObject *r, PyObject *i);
+
+static PyObject *
+complex_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"real", "imag", NULL};
+    static _PyArg_Parser _parser = {"|OO:complex", _keywords, 0};
+    PyObject *r = Py_False;
+    PyObject *i = NULL;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &r, &i)) {
+        goto exit;
+    }
+    return_value = complex_new_impl(type, r, i);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=74035493480ab5e5 input=a9049054013a1b77]*/

--- a/Objects/clinic/descrobject.c.h
+++ b/Objects/clinic/descrobject.c.h
@@ -1,0 +1,87 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+static PyObject *
+mappingproxy_new_impl(PyTypeObject *type, PyObject *mapping);
+
+static PyObject *
+mappingproxy_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"mapping", NULL};
+    static _PyArg_Parser _parser = {"O:mappingproxy", _keywords, 0};
+    PyObject *mapping;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &mapping)) {
+        goto exit;
+    }
+    return_value = mappingproxy_new_impl(type, mapping);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(property_init__doc__,
+"property(fget=None, fset=None, fdel=None, doc=None)\n"
+"--\n"
+"\n"
+"Property attribute.\n"
+"\n"
+"  fget\n"
+"    function to be used for getting an attribute value\n"
+"  fset\n"
+"    function to be used for setting an attribute value\n"
+"  fdel\n"
+"    function to be used for del\'ing an attribute\n"
+"  doc\n"
+"    docstring\n"
+"\n"
+"Typical use is to define a managed attribute x:\n"
+"\n"
+"class C(object):\n"
+"    def getx(self): return self._x\n"
+"    def setx(self, value): self._x = value\n"
+"    def delx(self): del self._x\n"
+"    x = property(getx, setx, delx, \"I\'m the \'x\' property.\")\n"
+"\n"
+"Decorators make defining new properties or modifying existing ones easy:\n"
+"\n"
+"class C(object):\n"
+"    @property\n"
+"    def x(self):\n"
+"        \"I am the \'x\' property.\"\n"
+"        return self._x\n"
+"    @x.setter\n"
+"    def x(self, value):\n"
+"        self._x = value\n"
+"    @x.deleter\n"
+"    def x(self):\n"
+"        del self._x");
+
+static int
+property_init_impl(propertyobject *self, PyObject *fget, PyObject *fset,
+                   PyObject *fdel, PyObject *doc);
+
+static int
+property_init(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    int return_value = -1;
+    static const char * const _keywords[] = {"fget", "fset", "fdel", "doc", NULL};
+    static _PyArg_Parser _parser = {"|OOOO:property", _keywords, 0};
+    PyObject *fget = NULL;
+    PyObject *fset = NULL;
+    PyObject *fdel = NULL;
+    PyObject *doc = NULL;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &fget, &fset, &fdel, &doc)) {
+        goto exit;
+    }
+    return_value = property_init_impl((propertyobject *)self, fget, fset, fdel, doc);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=729021fa9cdc46be input=a9049054013a1b77]*/

--- a/Objects/clinic/floatobject.c.h
+++ b/Objects/clinic/floatobject.c.h
@@ -158,6 +158,36 @@ float_as_integer_ratio(PyObject *self, PyObject *Py_UNUSED(ignored))
     return float_as_integer_ratio_impl(self);
 }
 
+PyDoc_STRVAR(float_new__doc__,
+"float(x=0, /)\n"
+"--\n"
+"\n"
+"Convert a string or number to a floating point number, if possible.");
+
+static PyObject *
+float_new_impl(PyTypeObject *type, PyObject *x);
+
+static PyObject *
+float_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *x = Py_False;
+
+    if ((type == &PyFloat_Type) &&
+        !_PyArg_NoKeywords("float", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "float",
+        0, 1,
+        &x)) {
+        goto exit;
+    }
+    return_value = float_new_impl(type, x);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(float___getnewargs____doc__,
 "__getnewargs__($self, /)\n"
 "--\n"
@@ -283,4 +313,4 @@ float___format__(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9257442b321d6a8b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a3dafb0f6c6f1514 input=a9049054013a1b77]*/

--- a/Objects/clinic/funcobject.c.h
+++ b/Objects/clinic/funcobject.c.h
@@ -1,0 +1,47 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(func_new__doc__,
+"function(code, globals, name=None, argdefs=None, closure=None)\n"
+"--\n"
+"\n"
+"Create a function object.\n"
+"\n"
+"  code\n"
+"    a code object\n"
+"  globals\n"
+"    the globals dictionary\n"
+"  name\n"
+"    a string that overrides the name from the code object\n"
+"  argdefs\n"
+"    a tuple that specifies the default argument values\n"
+"  closure\n"
+"    a tuple that supplies the bindings for free variables");
+
+static PyObject *
+func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
+              PyObject *name, PyObject *defaults, PyObject *closure);
+
+static PyObject *
+func_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"code", "globals", "name", "argdefs", "closure", NULL};
+    static _PyArg_Parser _parser = {"O!O!|OOO:function", _keywords, 0};
+    PyCodeObject *code;
+    PyObject *globals;
+    PyObject *name = Py_None;
+    PyObject *defaults = Py_None;
+    PyObject *closure = Py_None;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &PyCode_Type, &code, &PyDict_Type, &globals, &name, &defaults, &closure)) {
+        goto exit;
+    }
+    return_value = func_new_impl(type, code, globals, name, defaults, closure);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=a6ab29e4dd33010a input=a9049054013a1b77]*/

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -2,6 +2,28 @@
 preserve
 [clinic start generated code]*/
 
+static PyObject *
+long_new_impl(PyTypeObject *type, PyObject *x, PyObject *obase);
+
+static PyObject *
+long_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "base", NULL};
+    static _PyArg_Parser _parser = {"|OO:int", _keywords, 0};
+    PyObject *x = NULL;
+    PyObject *obase = NULL;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &x, &obase)) {
+        goto exit;
+    }
+    return_value = long_new_impl(type, x, obase);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(int___getnewargs____doc__,
 "__getnewargs__($self, /)\n"
 "--\n"
@@ -189,4 +211,4 @@ int_from_bytes(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyObject *
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a9bae2fd016e7b85 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c1ce9c11929b0bab input=a9049054013a1b77]*/

--- a/Objects/clinic/moduleobject.c.h
+++ b/Objects/clinic/moduleobject.c.h
@@ -1,0 +1,34 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(module___init____doc__,
+"module(name, doc=None)\n"
+"--\n"
+"\n"
+"Create a module object.\n"
+"\n"
+"The name must be a string; the optional doc argument can have any type.");
+
+static int
+module___init___impl(PyModuleObject *self, PyObject *name, PyObject *doc);
+
+static int
+module___init__(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    int return_value = -1;
+    static const char * const _keywords[] = {"name", "doc", NULL};
+    static _PyArg_Parser _parser = {"U|O:module", _keywords, 0};
+    PyObject *name;
+    PyObject *doc = Py_None;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &name, &doc)) {
+        goto exit;
+    }
+    return_value = module___init___impl((PyModuleObject *)self, name, doc);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=7b1b324bf6a590d1 input=a9049054013a1b77]*/

--- a/Objects/clinic/structseq.c.h
+++ b/Objects/clinic/structseq.c.h
@@ -1,0 +1,26 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+static PyObject *
+structseq_new_impl(PyTypeObject *type, PyObject *arg, PyObject *dict);
+
+static PyObject *
+structseq_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"sequence", "dict", NULL};
+    static _PyArg_Parser _parser = {"O|O:structseq", _keywords, 0};
+    PyObject *arg;
+    PyObject *dict = NULL;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &arg, &dict)) {
+        goto exit;
+    }
+    return_value = structseq_new_impl(type, arg, dict);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=cd643eb89b5d312a input=a9049054013a1b77]*/

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -8,6 +8,13 @@
 #include "Python.h"
 #include "structmember.h"
 
+/*[clinic input]
+class complex "PyComplexObject *" "&PyComplex_Type"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=819e057d2d10f5ec]*/
+
+#include "clinic/complexobject.c.h"
+
 /* elementary operations on complex numbers */
 
 static Py_complex c_1 = {1., 0.};
@@ -912,22 +919,27 @@ complex_subtype_from_string(PyTypeObject *type, PyObject *v)
     return result;
 }
 
+/*[clinic input]
+@classmethod
+complex.__new__ as complex_new
+    real as r: object(c_default="Py_False") = 0
+    imag as i: object(c_default="NULL") = 0
+
+Create a complex number from a real part and an optional imaginary part.
+
+This is equivalent to (real + imag*1j) where imag defaults to 0.
+[clinic start generated code]*/
+
 static PyObject *
-complex_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+complex_new_impl(PyTypeObject *type, PyObject *r, PyObject *i)
+/*[clinic end generated code: output=b6c7dd577b537dc1 input=e3d6b77ddcf280da]*/
 {
-    PyObject *r, *i, *tmp;
+    PyObject *tmp;
     PyNumberMethods *nbr, *nbi = NULL;
     Py_complex cr, ci;
     int own_r = 0;
     int cr_is_complex = 0;
     int ci_is_complex = 0;
-    static char *kwlist[] = {"real", "imag", 0};
-
-    r = Py_False;
-    i = NULL;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO:complex", kwlist,
-                                     &r, &i))
-        return NULL;
 
     /* Special-case for a single argument when type(arg) is complex. */
     if (PyComplex_CheckExact(r) && i == NULL &&
@@ -1057,12 +1069,6 @@ complex_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return complex_subtype_from_doubles(type, cr.real, ci.real);
 }
 
-PyDoc_STRVAR(complex_doc,
-"complex(real[, imag]) -> complex number\n"
-"\n"
-"Create a complex number from a real part and an optional imaginary part.\n"
-"This is equivalent to (real + imag*1j) where imag defaults to 0.");
-
 static PyNumberMethods complex_as_number = {
     (binaryfunc)complex_add,                    /* nb_add */
     (binaryfunc)complex_sub,                    /* nb_subtract */
@@ -1119,8 +1125,8 @@ PyTypeObject PyComplex_Type = {
     PyObject_GenericGetAttr,                    /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE, /* tp_flags */
-    complex_doc,                                /* tp_doc */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /* tp_flags */
+    complex_new__doc__,                         /* tp_doc */
     0,                                          /* tp_traverse */
     0,                                          /* tp_clear */
     complex_richcompare,                        /* tp_richcompare */

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -3,6 +3,12 @@
 #include "Python.h"
 #include "structmember.h" /* Why is this not included in Python.h? */
 
+/*[clinic input]
+class mappingproxy "mappingproxyobject *" "&PyDictProxy_Type"
+class property "propertyobject *" "&PyProperty_Type"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=556352653fd4c02e]*/
+
 static void
 descr_dealloc(PyDescrObject *descr)
 {
@@ -942,16 +948,19 @@ mappingproxy_check_mapping(PyObject *mapping)
     return 0;
 }
 
-static PyObject*
-mappingproxy_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
-{
-    static char *kwlist[] = {"mapping", NULL};
-    PyObject *mapping;
-    mappingproxyobject *mappingproxy;
+/*[clinic input]
+@classmethod
+mappingproxy.__new__ as mappingproxy_new
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O:mappingproxy",
-                                     kwlist, &mapping))
-        return NULL;
+    mapping: object
+
+[clinic start generated code]*/
+
+static PyObject *
+mappingproxy_new_impl(PyTypeObject *type, PyObject *mapping)
+/*[clinic end generated code: output=65f27f02d5b68fa7 input=d2d620d4f598d4f8]*/
+{
+    mappingproxyobject *mappingproxy;
 
     if (mappingproxy_check_mapping(mapping) == -1)
         return NULL;
@@ -964,48 +973,6 @@ mappingproxy_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     _PyObject_GC_TRACK(mappingproxy);
     return (PyObject *)mappingproxy;
 }
-
-PyTypeObject PyDictProxy_Type = {
-    PyVarObject_HEAD_INIT(&PyType_Type, 0)
-    "mappingproxy",                             /* tp_name */
-    sizeof(mappingproxyobject),                 /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)mappingproxy_dealloc,           /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    (reprfunc)mappingproxy_repr,                /* tp_repr */
-    0,                                          /* tp_as_number */
-    &mappingproxy_as_sequence,                  /* tp_as_sequence */
-    &mappingproxy_as_mapping,                   /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    (reprfunc)mappingproxy_str,                 /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
-    0,                                          /* tp_doc */
-    mappingproxy_traverse,                      /* tp_traverse */
-    0,                                          /* tp_clear */
-    (richcmpfunc)mappingproxy_richcompare,      /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    (getiterfunc)mappingproxy_getiter,          /* tp_iter */
-    0,                                          /* tp_iternext */
-    mappingproxy_methods,                       /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    mappingproxy_new,                           /* tp_new */
-};
 
 PyObject *
 PyDictProxy_New(PyObject *mapping)
@@ -1495,54 +1462,85 @@ property_copy(PyObject *old, PyObject *get, PyObject *set, PyObject *del)
     return new;
 }
 
+/*[clinic input]
+property.__init__ as property_init
+
+    fget: object(c_default="NULL") = None
+        function to be used for getting an attribute value
+    fset: object(c_default="NULL") = None
+        function to be used for setting an attribute value
+    fdel: object(c_default="NULL") = None
+        function to be used for del'ing an attribute
+    doc: object(c_default="NULL") = None
+        docstring
+
+Property attribute.
+
+Typical use is to define a managed attribute x:
+
+class C(object):
+    def getx(self): return self._x
+    def setx(self, value): self._x = value
+    def delx(self): del self._x
+    x = property(getx, setx, delx, "I'm the 'x' property.")
+
+Decorators make defining new properties or modifying existing ones easy:
+
+class C(object):
+    @property
+    def x(self):
+        "I am the 'x' property."
+        return self._x
+    @x.setter
+    def x(self, value):
+        self._x = value
+    @x.deleter
+    def x(self):
+        del self._x
+[clinic start generated code]*/
+
 static int
-property_init(PyObject *self, PyObject *args, PyObject *kwds)
+property_init_impl(propertyobject *self, PyObject *fget, PyObject *fset,
+                   PyObject *fdel, PyObject *doc)
+/*[clinic end generated code: output=01a960742b692b57 input=dfb5dbbffc6932d5]*/
 {
-    PyObject *get = NULL, *set = NULL, *del = NULL, *doc = NULL;
-    static char *kwlist[] = {"fget", "fset", "fdel", "doc", 0};
-    propertyobject *prop = (propertyobject *)self;
+    if (fget == Py_None)
+        fget = NULL;
+    if (fset == Py_None)
+        fset = NULL;
+    if (fdel == Py_None)
+        fdel = NULL;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OOOO:property",
-                                     kwlist, &get, &set, &del, &doc))
-        return -1;
-
-    if (get == Py_None)
-        get = NULL;
-    if (set == Py_None)
-        set = NULL;
-    if (del == Py_None)
-        del = NULL;
-
-    Py_XINCREF(get);
-    Py_XINCREF(set);
-    Py_XINCREF(del);
+    Py_XINCREF(fget);
+    Py_XINCREF(fset);
+    Py_XINCREF(fdel);
     Py_XINCREF(doc);
 
-    prop->prop_get = get;
-    prop->prop_set = set;
-    prop->prop_del = del;
-    prop->prop_doc = doc;
-    prop->getter_doc = 0;
+    self->prop_get = fget;
+    self->prop_set = fset;
+    self->prop_del = fdel;
+    self->prop_doc = doc;
+    self->getter_doc = 0;
 
     /* if no docstring given and the getter has one, use that one */
-    if ((doc == NULL || doc == Py_None) && get != NULL) {
+    if ((doc == NULL || doc == Py_None) && fget != NULL) {
         _Py_IDENTIFIER(__doc__);
-        PyObject *get_doc = _PyObject_GetAttrId(get, &PyId___doc__);
+        PyObject *get_doc = _PyObject_GetAttrId(fget, &PyId___doc__);
         if (get_doc) {
             if (Py_TYPE(self) == &PyProperty_Type) {
-                Py_XSETREF(prop->prop_doc, get_doc);
+                Py_XSETREF(self->prop_doc, get_doc);
             }
             else {
                 /* If this is a property subclass, put __doc__
                 in dict of the subclass instance instead,
                 otherwise it gets shadowed by __doc__ in the
                 class's dict. */
-                int err = _PyObject_SetAttrId(self, &PyId___doc__, get_doc);
+                int err = _PyObject_SetAttrId((PyObject *)self, &PyId___doc__, get_doc);
                 Py_DECREF(get_doc);
                 if (err < 0)
                     return -1;
             }
-            prop->getter_doc = 1;
+            self->getter_doc = 1;
         }
         else if (PyErr_ExceptionMatches(PyExc_Exception)) {
             PyErr_Clear();
@@ -1592,32 +1590,6 @@ static PyGetSetDef property_getsetlist[] = {
     {NULL} /* Sentinel */
 };
 
-PyDoc_STRVAR(property_doc,
-"property(fget=None, fset=None, fdel=None, doc=None) -> property attribute\n"
-"\n"
-"fget is a function to be used for getting an attribute value, and likewise\n"
-"fset is a function for setting, and fdel a function for del'ing, an\n"
-"attribute.  Typical use is to define a managed attribute x:\n\n"
-"class C(object):\n"
-"    def getx(self): return self._x\n"
-"    def setx(self, value): self._x = value\n"
-"    def delx(self): del self._x\n"
-"    x = property(getx, setx, delx, \"I'm the 'x' property.\")\n"
-"\n"
-"Decorators make defining new properties or modifying existing ones easy:\n\n"
-"class C(object):\n"
-"    @property\n"
-"    def x(self):\n"
-"        \"I am the 'x' property.\"\n"
-"        return self._x\n"
-"    @x.setter\n"
-"    def x(self, value):\n"
-"        self._x = value\n"
-"    @x.deleter\n"
-"    def x(self):\n"
-"        del self._x\n"
-);
-
 static int
 property_traverse(PyObject *self, visitproc visit, void *arg)
 {
@@ -1636,6 +1608,50 @@ property_clear(PyObject *self)
     Py_CLEAR(pp->prop_doc);
     return 0;
 }
+
+#include "clinic/descrobject.c.h"
+
+PyTypeObject PyDictProxy_Type = {
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)
+    "mappingproxy",                             /* tp_name */
+    sizeof(mappingproxyobject),                 /* tp_basicsize */
+    0,                                          /* tp_itemsize */
+    /* methods */
+    (destructor)mappingproxy_dealloc,           /* tp_dealloc */
+    0,                                          /* tp_print */
+    0,                                          /* tp_getattr */
+    0,                                          /* tp_setattr */
+    0,                                          /* tp_reserved */
+    (reprfunc)mappingproxy_repr,                /* tp_repr */
+    0,                                          /* tp_as_number */
+    &mappingproxy_as_sequence,                  /* tp_as_sequence */
+    &mappingproxy_as_mapping,                   /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    0,                                          /* tp_call */
+    (reprfunc)mappingproxy_str,                 /* tp_str */
+    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_setattro */
+    0,                                          /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC, /* tp_flags */
+    0,                                          /* tp_doc */
+    mappingproxy_traverse,                      /* tp_traverse */
+    0,                                          /* tp_clear */
+    (richcmpfunc)mappingproxy_richcompare,      /* tp_richcompare */
+    0,                                          /* tp_weaklistoffset */
+    (getiterfunc)mappingproxy_getiter,          /* tp_iter */
+    0,                                          /* tp_iternext */
+    mappingproxy_methods,                       /* tp_methods */
+    0,                                          /* tp_members */
+    0,                                          /* tp_getset */
+    0,                                          /* tp_base */
+    0,                                          /* tp_dict */
+    0,                                          /* tp_descr_get */
+    0,                                          /* tp_descr_set */
+    0,                                          /* tp_dictoffset */
+    0,                                          /* tp_init */
+    0,                                          /* tp_alloc */
+    mappingproxy_new,                           /* tp_new */
+};
 
 PyTypeObject PyProperty_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
@@ -1660,7 +1676,7 @@ PyTypeObject PyProperty_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,                    /* tp_flags */
-    property_doc,                               /* tp_doc */
+    property_init__doc__,                       /* tp_doc */
     property_traverse,                          /* tp_traverse */
     (inquiry)property_clear,                    /* tp_clear */
     0,                                          /* tp_richcompare */

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1612,19 +1612,23 @@ error:
 }
 
 static PyObject *
-float_subtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
+float_subtype_new(PyTypeObject *type, PyObject *x);
+
+/*[clinic input]
+@classmethod
+float.__new__ as float_new
+    x: object(c_default="Py_False") = 0
+    /
+
+Convert a string or number to a floating point number, if possible.
+[clinic start generated code]*/
 
 static PyObject *
-float_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+float_new_impl(PyTypeObject *type, PyObject *x)
+/*[clinic end generated code: output=ccf1e8dc460ba6ba input=c98d8e811ad2037a]*/
 {
-    PyObject *x = Py_False; /* Integer zero */
-
     if (type != &PyFloat_Type)
-        return float_subtype_new(type, args, kwds); /* Wimp out */
-    if (!_PyArg_NoKeywords("float()", kwds))
-        return NULL;
-    if (!PyArg_UnpackTuple(args, "float", 0, 1, &x))
-        return NULL;
+        return float_subtype_new(type, x); /* Wimp out */
     /* If it's a string, but not a string subclass, use
        PyFloat_FromString. */
     if (PyUnicode_CheckExact(x))
@@ -1638,12 +1642,12 @@ float_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
    from the regular float.  The regular float is then thrown away.
 */
 static PyObject *
-float_subtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+float_subtype_new(PyTypeObject *type, PyObject *x)
 {
     PyObject *tmp, *newobj;
 
     assert(PyType_IsSubtype(type, &PyFloat_Type));
-    tmp = float_new(&PyFloat_Type, args, kwds);
+    tmp = float_new_impl(&PyFloat_Type, x);
     if (tmp == NULL)
         return NULL;
     assert(PyFloat_Check(tmp));
@@ -1874,11 +1878,6 @@ static PyGetSetDef float_getset[] = {
     {NULL}  /* Sentinel */
 };
 
-PyDoc_STRVAR(float_doc,
-"float(x) -> floating point number\n\
-\n\
-Convert a string or number to a floating point number, if possible.");
-
 
 static PyNumberMethods float_as_number = {
     float_add,          /* nb_add */
@@ -1937,7 +1936,7 @@ PyTypeObject PyFloat_Type = {
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,   /* tp_flags */
-    float_doc,                                  /* tp_doc */
+    float_new__doc__,                           /* tp_doc */
     0,                                          /* tp_traverse */
     0,                                          /* tp_clear */
     float_richcompare,                          /* tp_richcompare */

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -416,16 +416,15 @@ static PyGetSetDef func_getsetlist[] = {
     {NULL} /* Sentinel */
 };
 
-PyDoc_STRVAR(func_doc,
-"function(code, globals[, name[, argdefs[, closure]]])\n\
-\n\
-Create a function object from a code object and a dictionary.\n\
-The optional name string overrides the name from the code object.\n\
-The optional argdefs tuple specifies the default argument values.\n\
-The optional closure tuple supplies the bindings for free variables.");
+/*[clinic input]
+class function "PyFunctionObject *" "&PyFunction_Type"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=70af9c90aa2e71b0]*/
 
-/* func_new() maintains the following invariants for closures.  The
-   closure must correspond to the free variables of the code object.
+#include "clinic/funcobject.c.h"
+
+/* function.__new__() maintains the following invariants for closures.
+   The closure must correspond to the free variables of the code object.
 
    if len(code.co_freevars) == 0:
        closure = NULL
@@ -434,25 +433,31 @@ The optional closure tuple supplies the bindings for free variables.");
    for every elt in closure, type(elt) == cell
 */
 
+/*[clinic input]
+@classmethod
+function.__new__ as func_new
+    code: object(type="PyCodeObject *", subclass_of="&PyCode_Type")
+        a code object
+    globals: object(subclass_of="&PyDict_Type")
+        the globals dictionary
+    name: object = None
+        a string that overrides the name from the code object
+    argdefs as defaults: object = None
+        a tuple that specifies the default argument values
+    closure: object = None
+        a tuple that supplies the bindings for free variables
+
+Create a function object.
+[clinic start generated code]*/
+
 static PyObject *
-func_new(PyTypeObject* type, PyObject* args, PyObject* kw)
+func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
+              PyObject *name, PyObject *defaults, PyObject *closure)
+/*[clinic end generated code: output=99c6d9da3a24e3be input=93611752fc2daf11]*/
 {
-    PyCodeObject *code;
-    PyObject *globals;
-    PyObject *name = Py_None;
-    PyObject *defaults = Py_None;
-    PyObject *closure = Py_None;
     PyFunctionObject *newfunc;
     Py_ssize_t nfree, nclosure;
-    static char *kwlist[] = {"code", "globals", "name",
-                             "argdefs", "closure", 0};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kw, "O!O!|OOO:function",
-                          kwlist,
-                          &PyCode_Type, &code,
-                          &PyDict_Type, &globals,
-                          &name, &defaults, &closure))
-        return NULL;
     if (name != Py_None && !PyUnicode_Check(name)) {
         PyErr_SetString(PyExc_TypeError,
                         "arg 3 (name) must be None or string");
@@ -602,8 +607,8 @@ PyTypeObject PyFunction_Type = {
     0,                                          /* tp_getattro */
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,/* tp_flags */
-    func_doc,                                   /* tp_doc */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
+    func_new__doc__,                            /* tp_doc */
     (traverseproc)func_traverse,                /* tp_traverse */
     0,                                          /* tp_clear */
     0,                                          /* tp_richcompare */

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4789,20 +4789,24 @@ long_float(PyObject *v)
 }
 
 static PyObject *
-long_subtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
+long_subtype_new(PyTypeObject *type, PyObject *x, PyObject *obase);
+
+/*[clinic input]
+@classmethod
+int.__new__ as long_new
+    x: object(c_default="NULL") = 0
+    /
+    base as obase: object(c_default="NULL") = 10
+[clinic start generated code]*/
 
 static PyObject *
-long_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+long_new_impl(PyTypeObject *type, PyObject *x, PyObject *obase)
+/*[clinic end generated code: output=e47cfe777ab0f24c input=81c98f418af9eb6f]*/
 {
-    PyObject *obase = NULL, *x = NULL;
     Py_ssize_t base;
-    static char *kwlist[] = {"", "base", 0};
 
     if (type != &PyLong_Type)
-        return long_subtype_new(type, args, kwds); /* Wimp out */
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO:int", kwlist,
-                                     &x, &obase))
-        return NULL;
+        return long_subtype_new(type, x, obase); /* Wimp out */
     if (x == NULL) {
         if (obase != NULL) {
             PyErr_SetString(PyExc_TypeError,
@@ -4846,13 +4850,13 @@ long_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
    the regular int.  The regular int is then thrown away.
 */
 static PyObject *
-long_subtype_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+long_subtype_new(PyTypeObject *type, PyObject *x, PyObject *obase)
 {
     PyLongObject *tmp, *newobj;
     Py_ssize_t i, n;
 
     assert(PyType_IsSubtype(type, &PyLong_Type));
-    tmp = (PyLongObject *)long_new(&PyLong_Type, args, kwds);
+    tmp = (PyLongObject *)long_new_impl(&PyLong_Type, x, obase);
     if (tmp == NULL)
         return NULL;
     assert(PyLong_Check(tmp));

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -607,24 +607,37 @@ _PyModule_ClearDict(PyObject *d)
 
 }
 
+/*[clinic input]
+class module "PyModuleObject *" "&PyModule_Type"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=3e35d4f708ecb6af]*/
+
+#include "clinic/moduleobject.c.h"
+
 /* Methods */
 
+/*[clinic input]
+module.__init__
+    name: unicode
+    doc: object = None
+
+Create a module object.
+
+The name must be a string; the optional doc argument can have any type.
+[clinic start generated code]*/
+
 static int
-module_init(PyModuleObject *m, PyObject *args, PyObject *kwds)
+module___init___impl(PyModuleObject *self, PyObject *name, PyObject *doc)
+/*[clinic end generated code: output=e7e721c26ce7aad7 input=57f9e177401e5e1e]*/
 {
-    static char *kwlist[] = {"name", "doc", NULL};
-    PyObject *dict, *name = Py_None, *doc = Py_None;
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "U|O:module.__init__",
-                                     kwlist, &name, &doc))
-        return -1;
-    dict = m->md_dict;
+    PyObject *dict = self->md_dict;
     if (dict == NULL) {
         dict = PyDict_New();
         if (dict == NULL)
             return -1;
-        m->md_dict = dict;
+        self->md_dict = dict;
     }
-    if (module_init_dict(m, dict, name, doc) < 0)
+    if (module_init_dict(self, dict, name, doc) < 0)
         return -1;
     return 0;
 }
@@ -734,12 +747,6 @@ static PyMethodDef module_methods[] = {
     {0}
 };
 
-PyDoc_STRVAR(module_doc,
-"module(name[, doc])\n\
-\n\
-Create a module object.\n\
-The name must be a string; the optional doc argument can have any type.");
-
 PyTypeObject PyModule_Type = {
     PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "module",                                   /* tp_name */
@@ -762,7 +769,7 @@ PyTypeObject PyModule_Type = {
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,                    /* tp_flags */
-    module_doc,                                 /* tp_doc */
+    module___init____doc__,                     /* tp_doc */
     (traverseproc)module_traverse,              /* tp_traverse */
     (inquiry)module_clear,                      /* tp_clear */
     0,                                          /* tp_richcompare */
@@ -777,7 +784,7 @@ PyTypeObject PyModule_Type = {
     0,                                          /* tp_descr_get */
     0,                                          /* tp_descr_set */
     offsetof(PyModuleObject, md_dict),          /* tp_dictoffset */
-    (initproc)module_init,                      /* tp_init */
+    module___init__,                            /* tp_init */
     PyType_GenericAlloc,                        /* tp_alloc */
     PyType_GenericNew,                          /* tp_new */
     PyObject_GC_Del,                            /* tp_free */

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -70,19 +70,27 @@ structseq_dealloc(PyStructSequence *obj)
     PyObject_GC_Del(obj);
 }
 
+/*[clinic input]
+class structseq "PyStructSequence *" "NULL"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=9d781c6922c77752]*/
+
+#include "clinic/structseq.c.h"
+
+/*[clinic input]
+@classmethod
+structseq.__new__ as structseq_new
+    sequence as arg: object
+    dict: object = NULL
+[clinic start generated code]*/
+
 static PyObject *
-structseq_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+structseq_new_impl(PyTypeObject *type, PyObject *arg, PyObject *dict)
+/*[clinic end generated code: output=baa082e788b171da input=9b44810243907377]*/
 {
-    PyObject *arg = NULL;
-    PyObject *dict = NULL;
     PyObject *ob;
     PyStructSequence *res = NULL;
     Py_ssize_t len, min_len, max_len, i, n_unnamed_fields;
-    static char *kwlist[] = {"sequence", "dict", 0};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:structseq",
-                                     kwlist, &arg, &dict))
-        return NULL;
 
     arg = PySequence_Fast(arg, "constructor requires a sequence");
 


### PR DESCRIPTION
Converted constructors are:

- `complex.__new__`
- `float.__new__`
- `function.__new__`
- `int.__new__`
- `mappingproxy.__new__`
- `module.__init__`
- `property.__init__`
- `structseq.__new__`
