### PR TITLE
Documentation for Py_SETREF and Py_XSETREF macro in "refcounting.rst".

### DIFF
--- a/Doc/c-api/refcounting.rst
+++ b/Doc/c-api/refcounting.rst
@@ -62,6 +62,25 @@ objects.
    variable that might be traversed during garbage collection.
 
 
+.. c:function:: void Py_SETREF(PyObject *op, PyObject *op2)
+
+   Replace *op* with *op2*. This macro will decrement the reference count for
+   the original *op* after the replacement and the reference count for *op2*
+   is unchanged.
+
+   .. versionadded:: 3.5
+
+
+.. c:function:: void Py_XSETREF(PyObject *op, PyObject *op2)
+
+   Replace *op* with *op2*. This macro will decrement the reference count for
+   the original *op* after the replacement and the reference count for *op2*
+   is unchanged. *op* may be *NULL*, otherwise it is identical to
+   :c:func:`Py_SETREF`.
+
+   .. versionadded:: 3.5
+
+
 The following functions are for runtime dynamic embedding of Python:
 ``Py_IncRef(PyObject *o)``, ``Py_DecRef(PyObject *o)``. They are
 simply exported function versions of :c:func:`Py_XINCREF` and


### PR DESCRIPTION
This adds some documentation for the `Py_SETREF` and `Py_XSETREF` macros to the documentation on ["reference counting"](https://docs.python.org/3/c-api/refcounting.html).

I have scanned through the contributions-guidelines and am not sure if I need to sign the "contributor license agreement". The ["Helping with the Developer’s Guide"](https://cpython-devguide.readthedocs.io/docquality.html#helping-with-the-developer-s-guide) mentions as a _difference_ compared to normal documentation changes that the CLA needs to be signed then. So I'm a bit confused.