### PR TITLE
fix subprocess on Windows (GH-391 backport)

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -986,7 +986,7 @@ class Popen(object):
                                          int(not close_fds),
                                          creationflags,
                                          env,
-                                         cwd,
+                                         os.fspath(cwd) if cwd is not None else None,
                                          startupinfo)
             finally:
                 # Child is launched. Close the parent's copy of those pipe


### PR DESCRIPTION
This fixes a consistent failure on AppVeyor introduced by GH-323 (bpo-28624).