### PR TITLE
bpo-29763: Use support.unlink instead of os.unlink

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -501,15 +501,15 @@ class StartupImportTests(unittest.TestCase):
                     print(line, file=f)
             return exe_file
         except:
-            os.unlink(_pth_file)
-            os.unlink(exe_file)
+            test.support.unlink(_pth_file)
+            test.support.unlink(exe_file)
             raise
 
     @classmethod
     def _cleanup_underpth_exe(self, exe_file):
         _pth_file = os.path.splitext(exe_file)[0] + '._pth'
-        os.unlink(_pth_file)
-        os.unlink(exe_file)
+        test.support.unlink(_pth_file)
+        test.support.unlink(exe_file)
 
     @classmethod
     def _calc_sys_path_for_underpth_nosite(self, sys_prefix, lines):


### PR DESCRIPTION
support.unlink waits for the files to be removed before returning