### PR TITLE
[3.5] bpo-29798: Handle git worktree in `make patchcheck`

### DIFF
--- a/Tools/scripts/patchcheck.py
+++ b/Tools/scripts/patchcheck.py
@@ -98,7 +98,10 @@ def changed_files(base_branch=None):
             cmd += ' --rev qparent'
         with subprocess.Popen(cmd.split(), stdout=subprocess.PIPE) as st:
             return [x.decode().rstrip() for x in st.stdout]
-    elif os.path.isdir(os.path.join(SRCDIR, '.git')):
+    elif os.path.exists(os.path.join(SRCDIR, '.git')):
+        # We just use an existence check here as:
+        #  directory = normal git checkout/clone
+        #  file = git worktree directory
         if base_branch:
             cmd = 'git diff --name-status ' + base_branch
         else:


### PR DESCRIPTION
In git worktree directories, `.git` is a configuration
file rather than a subdirectory
(cherry picked from commit 6a6d090612dd7deaac2bc0399fad743e5e2db606)