### PR TITLE
bpo-29600: Fix wrapping into StopIteration of return values in generators

### DIFF
--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -1103,6 +1103,21 @@ class CoroutineTest(unittest.TestCase):
                                     "coroutine is being awaited already"):
             waiter(coro).send(None)
 
+    def test_await_16(self):
+        # See https://bugs.python.org/issue29600 for details.
+
+        async def f():
+            return ValueError()
+
+        async def g():
+            try:
+                raise KeyError
+            except:
+                return await f()
+
+        _, result = run_async(g())
+        self.assertIsNone(result.__context__)
+
     def test_with_1(self):
         class Manager:
             def __init__(self, name):

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -574,8 +574,7 @@ _PyGen_SetStopIterationValue(PyObject *value)
     PyObject *e;
 
     if (value == NULL ||
-        (!PyTuple_Check(value) &&
-         !PyObject_TypeCheck(value, (PyTypeObject *) PyExc_StopIteration)))
+        (!PyTuple_Check(value) && !PyExceptionInstance_Check(value)))
     {
         /* Delay exception instantiation if we can */
         PyErr_SetObject(PyExc_StopIteration, value);


### PR DESCRIPTION
See [bpo-29600](https://bugs.python.org/issue29600) for details.

/cc @njsmith 