### PR TITLE
bpo-29800: Fix crashes in partial.__repr__ if the keys of partial.keywords are not strings

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -407,13 +407,27 @@ class TestPartialC(TestPartial, unittest.TestCase):
         p = self.partial(capture)
         # Adding a non-string/unicode keyword to partial kwargs
         p.keywords[1] = 10
-        self.assertRaises(TypeError, repr, p)
+        self.assertIn('1=10', repr(p))
         try:
             p()
         except TypeError:
             pass
         else:
             self.fail('partial object allowed passing non-string keywords')
+
+        # Deleting the key-value pair during key formatting shouldn't segfault.
+        class MutatesYourDict(object):
+            def __init__(self, dct):
+                self.dct = dct
+            def __str__(self):
+                del self.dct[self]
+                return 'astr'
+            def __repr__(self):
+                return 'arepr'
+
+        p = partial(capture)
+        p.keywords[MutatesYourDict(p.keywords)] = MutatesYourDict(p.keywords)
+        self.assertIn('astr=arepr', repr(p))
 
 
 class TestPartialPy(TestPartial, unittest.TestCase):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -403,6 +403,19 @@ class TestPartialC(TestPartial, unittest.TestCase):
         else:
             self.fail('partial object allowed __dict__ to be deleted')
 
+    def test_manually_adding_non_string_keyword(self):
+        p = self.partial(capture)
+        # Adding a non-string/unicode keyword to partial kwargs
+        p.keywords[1] = 10
+        self.assertRaises(TypeError, repr, p)
+        try:
+            p()
+        except TypeError:
+            pass
+        else:
+            self.fail('partial object allowed passing non-string keywords')
+
+
 class TestPartialPy(TestPartial, unittest.TestCase):
     partial = py_functools.partial
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1374,6 +1374,7 @@ Federico Schwindt
 Barry Scott
 Steven Scott
 Nick Seidenman
+Michael Seifert
 Žiga Seilnacht
 Yury Selivanov
 Fred Sells

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -278,6 +278,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29800: Fix crashes in partial.__repr__ if the keys of partial.keywords
+  are not strings.  Patch by Michael Seifert.
+
 - bpo-8256: Fixed possible failing or crashing input() if attributes "encoding"
   or "errors" of sys.stdin or sys.stdout are not set or are not strings.
 

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -253,12 +253,10 @@ partial_repr(partialobject *pto)
     /* Pack keyword arguments */
     assert (PyDict_Check(pto->kw));
     for (i = 0; PyDict_Next(pto->kw, &i, &key, &value);) {
-        /* Prevent key.__str__ from deleting key or value during formatting. */
-        Py_INCREF(key);
+        /* Prevent key.__str__ from deleting the value. */
         Py_INCREF(value);
         Py_SETREF(arglist, PyUnicode_FromFormat("%U, %S=%R", arglist,
                                                 key, value));
-        Py_DECREF(key);
         Py_DECREF(value);
         if (arglist == NULL)
             goto done;

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -253,6 +253,11 @@ partial_repr(partialobject *pto)
     /* Pack keyword arguments */
     assert (PyDict_Check(pto->kw));
     for (i = 0; PyDict_Next(pto->kw, &i, &key, &value);) {
+        if (!PyUnicode_Check(key)) {
+            PyErr_SetString(PyExc_TypeError, "keywords must be strings");
+            Py_DECREF(arglist);
+            goto done;
+        }
         Py_SETREF(arglist, PyUnicode_FromFormat("%U, %U=%R", arglist,
                                                 key, value));
         if (arglist == NULL)

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -253,13 +253,13 @@ partial_repr(partialobject *pto)
     /* Pack keyword arguments */
     assert (PyDict_Check(pto->kw));
     for (i = 0; PyDict_Next(pto->kw, &i, &key, &value);) {
-        if (!PyUnicode_Check(key)) {
-            PyErr_SetString(PyExc_TypeError, "keywords must be strings");
-            Py_DECREF(arglist);
-            goto done;
-        }
-        Py_SETREF(arglist, PyUnicode_FromFormat("%U, %U=%R", arglist,
+        /* Prevent key.__str__ from deleting key or value during formatting. */
+        Py_INCREF(key);
+        Py_INCREF(value);
+        Py_SETREF(arglist, PyUnicode_FromFormat("%U, %S=%R", arglist,
                                                 key, value));
+        Py_DECREF(key);
+        Py_DECREF(value);
         if (arglist == NULL)
             goto done;
     }


### PR DESCRIPTION
This is my first contribution for CPython and I must admit I haven't read through all the developer guide.

I signed the CLA (probably still in review) but if you notice anything else that needs to be done please let me know.