### PR TITLE
bpo-28810: Document remaining bytecode changes in 3.6

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -21,7 +21,8 @@ interpreter.
    work across Python VMs or Python releases.
 
    .. versionchanged:: 3.6
-      Use fixed 2 bytes per instruction for all instructions.
+      Use fixed 2 bytes per instruction for all instructions.  Instructions
+      of variable length were used before.
 
 
 Example: Given the function :func:`myfunc`::
@@ -217,7 +218,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
    decode it.
 
    .. versionchanged:: 3.6
-      Added support for negative line number delta.
+      Line numbers can be not monotonically increasing.
 
 
 .. function:: findlabels(code)
@@ -1135,8 +1136,13 @@ All of the following opcodes use their arguments.
 .. opcode:: HAVE_ARGUMENT
 
    This is not really an opcode.  It identifies the dividing line between
-   opcodes which don't take arguments ``< HAVE_ARGUMENT`` and those which do
-   ``>= HAVE_ARGUMENT``.
+   opcodes which don't use their arguments ``< HAVE_ARGUMENT`` and
+   those which do ``>= HAVE_ARGUMENT``.
+
+   .. versionchanged:: 3.6
+      Now every instruction have an argument, but opcodes ``< HAVE_ARGUMENT``
+      ignore it. Before, only opcodes ``>= HAVE_ARGUMENT`` had an argument.
+
 
 .. _opcode_collections:
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -218,7 +218,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
    how to decode it.
 
    .. versionchanged:: 3.6
-      Line numbers can be not monotonically increasing.
+      Line numbers can be decreasing. Before, they were always increasing.
 
 
 .. function:: findlabels(code)

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -20,6 +20,9 @@ interpreter.
    between versions of Python.  Use of this module should not be considered to
    work across Python VMs or Python releases.
 
+   .. versionchanged:: 3.6
+      Use fixed 2 bytes per instruction for all instructions.
+
 
 Example: Given the function :func:`myfunc`::
 
@@ -210,10 +213,8 @@ operation is being performed, so the intermediate analysis object isn't useful:
    This generator function uses the ``co_firstlineno`` and ``co_lnotab``
    attributes of the code object *code* to find the offsets which are starts of
    lines in the source code.  They are generated as ``(offset, lineno)`` pairs.
-   Functions decoding directly ``co_lnotab`` should use a signed
-   8-bit integer type for the line number delta.  See
-   ``Objects/lnotab_notes.txt`` for the ``co_lnotab`` format and how to decode
-   it.
+   See ``Objects/lnotab_notes.txt`` for the ``co_lnotab`` format and how to
+   decode it.
 
    .. versionchanged:: 3.6
       Added support for negative line number delta.
@@ -287,7 +288,6 @@ details of bytecode instructions as :class:`Instruction` instances:
 
 
 The Python compiler currently generates the following bytecode instructions.
-Every instruction takes 2 bytes.
 
 
 **General instructions**

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -213,8 +213,8 @@ operation is being performed, so the intermediate analysis object isn't useful:
    This generator function uses the ``co_firstlineno`` and ``co_lnotab``
    attributes of the code object *code* to find the offsets which are starts of
    lines in the source code.  They are generated as ``(offset, lineno)`` pairs.
-   See ``Objects/lnotab_notes.txt`` for the ``co_lnotab`` format and how to
-   decode it.
+   See :source:`Objects/lnotab_notes.txt` for the ``co_lnotab`` format and
+   how to decode it.
 
    .. versionchanged:: 3.6
       Added support for negative line number delta.

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -210,6 +210,13 @@ operation is being performed, so the intermediate analysis object isn't useful:
    This generator function uses the ``co_firstlineno`` and ``co_lnotab``
    attributes of the code object *code* to find the offsets which are starts of
    lines in the source code.  They are generated as ``(offset, lineno)`` pairs.
+   Functions decoding directly ``co_lnotab`` should use a signed
+   8-bit integer type for the line number delta.  See
+   ``Objects/lnotab_notes.txt`` for the ``co_lnotab`` format and how to decode
+   it.
+
+   .. versionchanged:: 3.6
+      Added support for negative line number delta.
 
 
 .. function:: findlabels(code)
@@ -280,6 +287,7 @@ details of bytecode instructions as :class:`Instruction` instances:
 
 
 The Python compiler currently generates the following bytecode instructions.
+Every instruction takes 2 bytes.
 
 
 **General instructions**

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -21,8 +21,8 @@ interpreter.
    work across Python VMs or Python releases.
 
    .. versionchanged:: 3.6
-      Use fixed 2 bytes per instruction for all instructions.  Instructions
-      of variable length were used before.
+      Use 2 bytes for each instruction. Previously the number of bytes varied
+      by instruction.
 
 
 Example: Given the function :func:`myfunc`::
@@ -1140,7 +1140,7 @@ All of the following opcodes use their arguments.
    those which do ``>= HAVE_ARGUMENT``.
 
    .. versionchanged:: 3.6
-      Now every instruction have an argument, but opcodes ``< HAVE_ARGUMENT``
+      Now every instruction has an argument, but opcodes ``< HAVE_ARGUMENT``
       ignore it. Before, only opcodes ``>= HAVE_ARGUMENT`` had an argument.
 
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1136,8 +1136,8 @@ All of the following opcodes use their arguments.
 .. opcode:: HAVE_ARGUMENT
 
    This is not really an opcode.  It identifies the dividing line between
-   opcodes which don't use their arguments ``< HAVE_ARGUMENT`` and
-   those which do ``>= HAVE_ARGUMENT``.
+   opcodes which don't use their argument and those that do
+   (``< HAVE_ARGUMENT`` and ``>= HAVE_ARGUMENT``, respectively).
 
    .. versionchanged:: 3.6
       Now every instruction has an argument, but opcodes ``< HAVE_ARGUMENT``


### PR DESCRIPTION
@serhiy-storchaka @brettcannon 
These are two remaining changes to close http://bugs.python.org/issue28810
This needs a backport to 3.6