### PR TITLE
ftplib.FTP.retrbinary callback gets a bytes, not a str

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -235,7 +235,7 @@ followed by ``lines`` for the text version or ``binary`` for the binary version.
 
    Retrieve a file in binary transfer mode.  *cmd* should be an appropriate
    ``RETR`` command: ``'RETR filename'``. The *callback* function is called for
-   each block of data received, with a single string argument giving the data
+   each block of data received, with a single bytes argument giving the data
    block. The optional *blocksize* argument specifies the maximum chunk size to
    read on the low-level socket object created to do the actual transfer (which
    will also be the largest size of the data blocks passed to *callback*).  A


### PR DESCRIPTION
This helps clarify that the callback to retrbinary gets bytes and the callback to retrlines gets str. See the tests at https://github.com/python/cpython/blob/master/Lib/test/test_ftplib.py#L558 to confirm the types that are passed to these callbacks.