### PR TITLE
[3.6] ftplib.FTP.retrbinary callback gets a bytes, not a str

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -235,7 +235,7 @@ followed by ``lines`` for the text version or ``binary`` for the binary version.
 
    Retrieve a file in binary transfer mode.  *cmd* should be an appropriate
    ``RETR`` command: ``'RETR filename'``. The *callback* function is called for
-   each block of data received, with a single string argument giving the data
+   each block of data received, with a single bytes argument giving the data
    block. The optional *blocksize* argument specifies the maximum chunk size to
    read on the low-level socket object created to do the actual transfer (which
    will also be the largest size of the data blocks passed to *callback*).  A


### PR DESCRIPTION
backports to 3.6 for #652 