### PR TITLE
[3.6] bpo-28856: Let %b format for bytes support objects that follow the buffer protocol 

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -315,10 +315,12 @@ class FormatTest(unittest.TestCase):
         testcommon(b"%b", b"abc", b"abc")
         testcommon(b"%b", bytearray(b"def"), b"def")
         testcommon(b"%b", fb, b"123")
+        testcommon(b"%b", memoryview(b"abc"), b"abc")
         # # %s is an alias for %b -- should only be used for Py2/3 code
         testcommon(b"%s", b"abc", b"abc")
         testcommon(b"%s", bytearray(b"def"), b"def")
         testcommon(b"%s", fb, b"123")
+        testcommon(b"%s", memoryview(b"abc"), b"abc")
         # %a will give the equivalent of
         # repr(some_obj).encode('ascii', 'backslashreplace')
         testcommon(b"%a", 3.14, b"3.14")
@@ -377,9 +379,11 @@ class FormatTest(unittest.TestCase):
         test_exc(b"%c", 3.14, TypeError,
                 "%c requires an integer in range(256) or a single byte")
         test_exc(b"%b", "Xc", TypeError,
-                "%b requires bytes, or an object that implements __bytes__, not 'str'")
+                "%b requires a bytes-like object, "
+                 "or an object that implements __bytes__, not 'str'")
         test_exc(b"%s", "Wd", TypeError,
-                "%b requires bytes, or an object that implements __bytes__, not 'str'")
+                "%b requires a bytes-like object, "
+                 "or an object that implements __bytes__, not 'str'")
 
         if maxsize == 2**31-1:
             # crashes 2.2.1 and earlier:

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -11,6 +11,8 @@ Core and Builtins
 -----------------
 
 - bpo-29600: Fix wrapping coroutine return values in StopIteration.
+- bpo-28856: Fix an oversight that %b format for bytes should support objects
+  follow the buffer protocol.
 
 - bpo-29723: The ``sys.path[0]`` initialization change for bpo-29139 caused a
   regression by revealing an inconsistency in how sys.path is initialized when

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -11,6 +11,7 @@ Core and Builtins
 -----------------
 
 - bpo-29600: Fix wrapping coroutine return values in StopIteration.
+
 - bpo-28856: Fix an oversight that %b format for bytes should support objects
   follow the buffer protocol.
 


### PR DESCRIPTION
backports to 3.6 for #546 