### PR TITLE
bpo-15988: make various overflow messages more consistent and helpful

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -720,7 +720,6 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         self.assertRaises(OverflowError, timedelta, 1e9)
         self.assertRaises(OverflowError, timedelta, 1 << 1000)
 
-
     @support.requires_IEEE_754
     def _test_overflow_special(self):
         day = timedelta(1)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -711,6 +711,14 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         self.assertRaises(OverflowError, day.__truediv__, 1e-10)
         self.assertRaises(OverflowError, day.__truediv__, 9e-10)
 
+        # test overflow in timedelta constructor
+        self.assertRaises(OverflowError, timedelta, -1 << 1000)
+        self.assertRaises(OverflowError, timedelta, -999999999, 0, -1)
+        self.assertEqual(timedelta.min, timedelta(-999999999, 0, 0))
+        self.assertRaises(OverflowError, timedelta, 1e9)
+        self.assertRaises(OverflowError, timedelta, 1 << 1000)
+
+
     @support.requires_IEEE_754
     def _test_overflow_special(self):
         day = timedelta(1)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -714,7 +714,9 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         # test overflow in timedelta constructor
         self.assertRaises(OverflowError, timedelta, -1 << 1000)
         self.assertRaises(OverflowError, timedelta, -999999999, 0, -1)
-        self.assertEqual(timedelta.min, timedelta(-999999999, 0, 0))
+        # no tests here for getting timedelta.min and timedelta.max from
+        # timedelta constructor, as these are already tested in
+        # test_resolution_info.
         self.assertRaises(OverflowError, timedelta, 1e9)
         self.assertRaises(OverflowError, timedelta, 1 << 1000)
 

--- a/Lib/test/string_tests.py
+++ b/Lib/test/string_tests.py
@@ -1144,6 +1144,7 @@ class MixinStrUnicodeUserStringTest:
     def test_mul_c_limits(self):
         from _testcapi import PY_SSIZE_T_MAX, PY_SSIZE_T_MIN
 
+        # the following tests also test sequence_repeat in Objects/abstract.c
         self.checkraises(OverflowError, '', '__mul__', -1 << 1000)
         self.checkraises(OverflowError, '', '__mul__', PY_SSIZE_T_MIN - 1)
         self.checkequal('', 'a', '__mul__', PY_SSIZE_T_MIN)

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -111,7 +111,6 @@ class BaseBytesTest:
         self.assertRaises(OverflowError, self.type2test, -1 << 1000)
         self.assertRaises(OverflowError, self.type2test, PY_SSIZE_T_MIN - 1)
         self.assertRaises(ValueError, self.type2test, PY_SSIZE_T_MIN)
-        self.assertRaises(ValueError, self.type2test, -1)
         self.assertRaises(OverflowError, self.type2test, PY_SSIZE_T_MAX + 1)
         self.assertRaises(OverflowError, self.type2test, 1 << 1000)
 

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -834,6 +834,23 @@ class TestDialectValidity(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          '"quotechar" must be string, not int')
 
+    @support.cpython_only
+    def test_quoting_c_limits(self):
+        from _testcapi import INT_MIN, INT_MAX
+
+        for bad_val in [-1 << 1000, INT_MIN - 1, INT_MAX + 1, 1 << 1000]:
+            class value_error_quoting_dialect(csv.Dialect):
+                quoting = bad_val
+            self.assertRaises(ValueError, value_error_quoting_dialect)
+        # verify ValueError is not raised
+        for in_range_val in [INT_MIN, INT_MAX]:
+            class in_range_qouting_dialect(csv.Dialect):
+                quoting = in_range_val
+            try:
+                in_range_qouting_dialect()
+            except csv.Error:
+                pass
+
     def test_delimiter(self):
         class mydialect(csv.Dialect):
             delimiter = ";"

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -834,23 +834,6 @@ class TestDialectValidity(unittest.TestCase):
         self.assertEqual(str(cm.exception),
                          '"quotechar" must be string, not int')
 
-    @support.cpython_only
-    def test_quoting_c_limits(self):
-        from _testcapi import INT_MIN, INT_MAX
-
-        for bad_val in [-1 << 1000, INT_MIN - 1, INT_MAX + 1, 1 << 1000]:
-            class value_error_quoting_dialect(csv.Dialect):
-                quoting = bad_val
-            self.assertRaises(ValueError, value_error_quoting_dialect)
-        # verify ValueError is not raised
-        for in_range_val in [INT_MIN, INT_MAX]:
-            class in_range_qouting_dialect(csv.Dialect):
-                quoting = in_range_val
-            try:
-                in_range_qouting_dialect()
-            except csv.Error:
-                pass
-
     def test_delimiter(self):
         class mydialect(csv.Dialect):
             delimiter = ";"

--- a/Lib/test/test_getargs2.py
+++ b/Lib/test/test_getargs2.py
@@ -140,10 +140,12 @@ class Unsigned_TestCase(unittest.TestCase):
             self.assertEqual(1, getargs_b(BadInt2()))
         self.assertEqual(0, getargs_b(BadInt3()))
 
+        self.assertRaises(OverflowError, getargs_b, -1 << 1000)
         self.assertRaises(OverflowError, getargs_b, -1)
         self.assertEqual(0, getargs_b(0))
         self.assertEqual(UCHAR_MAX, getargs_b(UCHAR_MAX))
         self.assertRaises(OverflowError, getargs_b, UCHAR_MAX + 1)
+        self.assertRaises(OverflowError, getargs_b, 1 << 1000)
 
         self.assertEqual(42, getargs_b(42))
         self.assertRaises(OverflowError, getargs_b, VERY_LARGE)
@@ -239,10 +241,12 @@ class Signed_TestCase(unittest.TestCase):
             self.assertEqual(1, getargs_h(BadInt2()))
         self.assertEqual(0, getargs_h(BadInt3()))
 
+        self.assertRaises(OverflowError, getargs_h, -1 << 1000)
         self.assertRaises(OverflowError, getargs_h, SHRT_MIN-1)
         self.assertEqual(SHRT_MIN, getargs_h(SHRT_MIN))
         self.assertEqual(SHRT_MAX, getargs_h(SHRT_MAX))
         self.assertRaises(OverflowError, getargs_h, SHRT_MAX+1)
+        self.assertRaises(OverflowError, getargs_h, 1 << 1000)
 
         self.assertEqual(42, getargs_h(42))
         self.assertRaises(OverflowError, getargs_h, VERY_LARGE)
@@ -258,10 +262,12 @@ class Signed_TestCase(unittest.TestCase):
             self.assertEqual(1, getargs_i(BadInt2()))
         self.assertEqual(0, getargs_i(BadInt3()))
 
+        self.assertRaises(OverflowError, getargs_i, -1 << 1000)
         self.assertRaises(OverflowError, getargs_i, INT_MIN-1)
         self.assertEqual(INT_MIN, getargs_i(INT_MIN))
         self.assertEqual(INT_MAX, getargs_i(INT_MAX))
         self.assertRaises(OverflowError, getargs_i, INT_MAX+1)
+        self.assertRaises(OverflowError, getargs_i, 1 << 1000)
 
         self.assertEqual(42, getargs_i(42))
         self.assertRaises(OverflowError, getargs_i, VERY_LARGE)

--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -873,6 +873,29 @@ class KDFTests(unittest.TestCase):
     def test_pbkdf2_hmac_c(self):
         self._test_pbkdf2_hmac(c_hashlib.pbkdf2_hmac)
 
+    @unittest.skipUnless(hasattr(c_hashlib, 'pbkdf2_hmac'),
+                     '   test requires OpenSSL > 1.0')
+    @support.cpython_only
+    def test_pbkdf2_hmac_c_limits(self):
+        from _testcapi import LONG_MIN, INT_MAX
+        # test iterations limits
+        self.assertRaises(OverflowError, c_hashlib.pbkdf2_hmac,
+                          'sha1', b'pass', b'salt', -1 << 1000)
+        self.assertRaises(OverflowError, c_hashlib.pbkdf2_hmac,
+                          'sha1', b'pass', b'salt', LONG_MIN - 1)
+        self.assertRaises(ValueError, c_hashlib.pbkdf2_hmac,
+                          'sha1', b'pass', b'salt', LONG_MIN)
+        self.assertRaises(OverflowError, c_hashlib.pbkdf2_hmac,
+                          'sha1', b'pass', b'salt', INT_MAX + 1)
+        self.assertRaises(OverflowError, c_hashlib.pbkdf2_hmac,
+                          'sha1', b'pass', b'salt', 1 << 1000)
+        # test dklen limits
+        self.assertRaises(ValueError, c_hashlib.pbkdf2_hmac,
+                          'sha1', b'pass', b'salt', 1, -1 << 1000)
+        self.assertRaises(OverflowError, c_hashlib.pbkdf2_hmac,
+                          'sha1', b'pass', b'salt', 1, INT_MAX + 1)
+        self.assertRaises(OverflowError, c_hashlib.pbkdf2_hmac,
+                          'sha1', b'pass', b'salt', 1, 1 << 1000)
 
     @unittest.skipUnless(hasattr(c_hashlib, 'scrypt'),
                      '   test requires OpenSSL > 1.1')

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -712,8 +712,7 @@ class LongTest(unittest.TestCase):
                 self.assertEqual(format(value, format_spec),
                                  format(float(value), format_spec))
 
-    @support.cpython_only
-    def test__format__c_limits(self):
+        # test 'c' specifier limits
         self.assertRaises(OverflowError, format, -1 << 1000, 'c')
         self.assertRaises(OverflowError, format, -1, 'c')
         self.assertEqual(format(0, 'c'), '\x00')

--- a/Lib/test/test_lzma.py
+++ b/Lib/test/test_lzma.py
@@ -7,7 +7,7 @@ import random
 import unittest
 
 from test.support import (
-    _4G, TESTFN, import_module, bigmemtest, run_unittest, unlink
+    _4G, TESTFN, import_module, bigmemtest, run_unittest, unlink, cpython_only
 )
 
 lzma = import_module("lzma")
@@ -57,6 +57,19 @@ class CompressorDecompressorTestCase(unittest.TestCase):
         self.assertRaises(TypeError, lzd.decompress, b"foo", b"bar")
         lzd.decompress(empty)
         self.assertRaises(EOFError, lzd.decompress, b"quux")
+
+    @cpython_only
+    def test_INT_TYPE_CONVERTER_FUNC_macro(self):
+        self.assertRaises(OverflowError, LZMACompressor, preset=-1 << 1000)
+        self.assertRaises(OverflowError, LZMACompressor, preset=-1)
+        self.assertRaises(OverflowError, LZMACompressor, preset=1 << 32)
+        self.assertRaises(OverflowError, LZMACompressor, preset=1 << 1000)
+        # verify OverflowError is not raised.
+        for in_range_preset in [0, (1 << 32) - 1]:
+            try:
+                LZMACompressor(preset=in_range_preset)
+            except LZMAError:
+                pass
 
     def test_bad_filter_spec(self):
         self.assertRaises(TypeError, LZMACompressor, filters=[b"wobsite"])

--- a/Lib/test/test_lzma.py
+++ b/Lib/test/test_lzma.py
@@ -60,16 +60,15 @@ class CompressorDecompressorTestCase(unittest.TestCase):
 
     @cpython_only
     def test_INT_TYPE_CONVERTER_FUNC_macro(self):
+        # test the macro by testing uint32_converter, which is created
+        # by using the macro, and is later used to convert the preset
+        # argument of LZMACompressor.
         self.assertRaises(OverflowError, LZMACompressor, preset=-1 << 1000)
         self.assertRaises(OverflowError, LZMACompressor, preset=-1)
+        LZMACompressor(preset=0)
+        self.assertRaises(LZMAError, LZMACompressor, preset=(1 << 32) - 1)
         self.assertRaises(OverflowError, LZMACompressor, preset=1 << 32)
         self.assertRaises(OverflowError, LZMACompressor, preset=1 << 1000)
-        # verify OverflowError is not raised.
-        for in_range_preset in [0, (1 << 32) - 1]:
-            try:
-                LZMACompressor(preset=in_range_preset)
-            except LZMAError:
-                pass
 
     def test_bad_filter_spec(self):
         self.assertRaises(TypeError, LZMACompressor, filters=[b"wobsite"])

--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -778,6 +778,21 @@ class CBytesIOTest(PyBytesIOTest):
         memio = self.ioclass(ba)
         self.assertEqual(sys.getrefcount(ba), old_rc)
 
+    @support.cpython_only
+    def test_truncate_c_limits(self):
+        from _testcapi import PY_SSIZE_T_MIN, PY_SSIZE_T_MAX
+        memio = self.ioclass()
+
+        self.assertRaises(OverflowError, memio.truncate, -1 << 1000)
+        self.assertRaises(OverflowError, memio.truncate, PY_SSIZE_T_MIN - 1)
+        self.assertRaises(ValueError, memio.truncate, PY_SSIZE_T_MIN)
+        self.assertRaises(ValueError, memio.truncate, -1)
+        # verify OverflowError/ValueError is not raised
+        memio.truncate(0)
+        memio.truncate(PY_SSIZE_T_MAX)
+        self.assertRaises(OverflowError, memio.truncate, PY_SSIZE_T_MAX + 1)
+        self.assertRaises(OverflowError, memio.truncate, 1 << 1000)
+
 class CStringIOTest(PyStringIOTest):
     ioclass = io.StringIO
     UnsupportedOperation = io.UnsupportedOperation
@@ -824,6 +839,21 @@ class CStringIOTest(PyStringIOTest):
         self.assertRaises(TypeError, memio.__setstate__, 0)
         memio.close()
         self.assertRaises(ValueError, memio.__setstate__, ("closed", "", 0, None))
+
+    @support.cpython_only
+    def test_truncate_c_limits(self):
+        from _testcapi import PY_SSIZE_T_MIN, PY_SSIZE_T_MAX
+        memio = self.ioclass()
+
+        self.assertRaises(OverflowError, memio.truncate, -1 << 1000)
+        self.assertRaises(OverflowError, memio.truncate, PY_SSIZE_T_MIN - 1)
+        self.assertRaises(ValueError, memio.truncate, PY_SSIZE_T_MIN)
+        self.assertRaises(ValueError, memio.truncate, -1)
+        # verify OverflowError/ValueError is not raised
+        memio.truncate(0)
+        memio.truncate(PY_SSIZE_T_MAX)
+        self.assertRaises(OverflowError, memio.truncate, PY_SSIZE_T_MAX + 1)
+        self.assertRaises(OverflowError, memio.truncate, 1 << 1000)
 
 
 class CStringIOPickleTest(PyStringIOPickleTest):

--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -787,7 +787,6 @@ class CBytesIOTest(PyBytesIOTest):
         self.assertRaises(OverflowError, memio.truncate, PY_SSIZE_T_MIN - 1)
         self.assertRaises(ValueError, memio.truncate, PY_SSIZE_T_MIN)
         self.assertRaises(ValueError, memio.truncate, -1)
-        # verify OverflowError/ValueError is not raised
         memio.truncate(0)
         memio.truncate(PY_SSIZE_T_MAX)
         self.assertRaises(OverflowError, memio.truncate, PY_SSIZE_T_MAX + 1)
@@ -849,7 +848,6 @@ class CStringIOTest(PyStringIOTest):
         self.assertRaises(OverflowError, memio.truncate, PY_SSIZE_T_MIN - 1)
         self.assertRaises(ValueError, memio.truncate, PY_SSIZE_T_MIN)
         self.assertRaises(ValueError, memio.truncate, -1)
-        # verify OverflowError/ValueError is not raised
         memio.truncate(0)
         memio.truncate(PY_SSIZE_T_MAX)
         self.assertRaises(OverflowError, memio.truncate, PY_SSIZE_T_MAX + 1)

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -423,18 +423,19 @@ class MmapTests(unittest.TestCase):
 
     @cpython_only
     def test_constructor_c_limits(self):
-        from _testcapi import INT_MIN, INT_MAX, PY_SSIZE_T_MIN, PY_SSIZE_T_MAX
+        from _testcapi import INT_MIN, INT_MAX, PY_SSIZE_T_MAX
 
-        # bad fileno
+        # test overflow values of arguments that are stored in the
+        # same C types on unix and on Windows:
+        # fileno
         self.assertRaises(OverflowError, mmap.mmap, -1 << 1000, 16)
         self.assertRaises(OverflowError, mmap.mmap, INT_MIN - 1, 16)
         self.assertRaises(OverflowError, mmap.mmap, INT_MAX + 1, 16)
         self.assertRaises(OverflowError, mmap.mmap, 1 << 1000, 16)
-        # bad length
-        self.assertRaises(OverflowError, mmap.mmap, -1, PY_SSIZE_T_MIN - 1)
+        # length
         self.assertRaises(OverflowError, mmap.mmap, -1, PY_SSIZE_T_MAX + 1)
         self.assertRaises(OverflowError, mmap.mmap, -1, 1 << 1000)
-        # bad access
+        # access
         self.assertRaises(OverflowError, mmap.mmap, -1, 16, access=-1 << 1000)
         self.assertRaises(OverflowError, mmap.mmap, -1, 16, access=INT_MIN - 1)
         self.assertRaises(OverflowError, mmap.mmap, -1, 16, access=INT_MAX + 1)

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -417,6 +417,29 @@ class MmapTests(unittest.TestCase):
             m[x] = b
             self.assertEqual(m[x], b)
 
+    def test_bad_length(self):
+        self.assertRaises(OverflowError, mmap.mmap, -1, -1 << 1000)
+        self.assertRaises(OverflowError, mmap.mmap, -1, -1)
+
+    @cpython_only
+    def test_constructor_c_limits(self):
+        from _testcapi import INT_MIN, INT_MAX, PY_SSIZE_T_MIN, PY_SSIZE_T_MAX
+
+        # bad fileno
+        self.assertRaises(OverflowError, mmap.mmap, -1 << 1000, 16)
+        self.assertRaises(OverflowError, mmap.mmap, INT_MIN - 1, 16)
+        self.assertRaises(OverflowError, mmap.mmap, INT_MAX + 1, 16)
+        self.assertRaises(OverflowError, mmap.mmap, 1 << 1000, 16)
+        # bad length
+        self.assertRaises(OverflowError, mmap.mmap, -1, PY_SSIZE_T_MIN - 1)
+        self.assertRaises(OverflowError, mmap.mmap, -1, PY_SSIZE_T_MAX + 1)
+        self.assertRaises(OverflowError, mmap.mmap, -1, 1 << 1000)
+        # bad access
+        self.assertRaises(OverflowError, mmap.mmap, -1, 16, access=-1 << 1000)
+        self.assertRaises(OverflowError, mmap.mmap, -1, 16, access=INT_MIN - 1)
+        self.assertRaises(OverflowError, mmap.mmap, -1, 16, access=INT_MAX + 1)
+        self.assertRaises(OverflowError, mmap.mmap, -1, 16, access=1 << 1000)
+
     def test_read_all(self):
         m = mmap.mmap(-1, 16)
         self.addCleanup(m.close)
@@ -445,6 +468,20 @@ class MmapTests(unittest.TestCase):
         self.assertRaises(TypeError, m.read, 'foo')
         self.assertRaises(TypeError, m.read, 5.5)
         self.assertRaises(TypeError, m.read, [1, 2, 3])
+
+    @cpython_only
+    def test_read_c_limits(self):
+        from _testcapi import PY_SSIZE_T_MAX, PY_SSIZE_T_MIN
+        m = mmap.mmap(-1, 16)
+        self.addCleanup(m.close)
+
+        self.assertRaises(OverflowError, m.read, -1 << 1000)
+        self.assertRaises(OverflowError, m.read, PY_SSIZE_T_MIN - 1)
+        # verify OverflowError is not raised
+        m.read(PY_SSIZE_T_MIN)
+        m.read(PY_SSIZE_T_MAX)
+        self.assertRaises(OverflowError, m.read, PY_SSIZE_T_MAX + 1)
+        self.assertRaises(OverflowError, m.read, 1 << 1000)
 
     def test_extended_getslice(self):
         # Test extended slicing by comparing with list slicing.

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -478,7 +478,6 @@ class MmapTests(unittest.TestCase):
 
         self.assertRaises(OverflowError, m.read, -1 << 1000)
         self.assertRaises(OverflowError, m.read, PY_SSIZE_T_MIN - 1)
-        # verify OverflowError is not raised
         m.read(PY_SSIZE_T_MIN)
         m.read(PY_SSIZE_T_MAX)
         self.assertRaises(OverflowError, m.read, PY_SSIZE_T_MAX + 1)

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -426,7 +426,7 @@ class MmapTests(unittest.TestCase):
         from _testcapi import INT_MIN, INT_MAX, PY_SSIZE_T_MAX
 
         # test overflow values of arguments that are stored in the
-        # same C types on unix and on Windows:
+        # same C types on Unix and on Windows:
         # fileno
         self.assertRaises(OverflowError, mmap.mmap, -1 << 1000, 16)
         self.assertRaises(OverflowError, mmap.mmap, INT_MIN - 1, 16)

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1147,8 +1147,8 @@ class PosixTester(unittest.TestCase):
         posix.sched_setaffinity(0, mask)
         self.assertEqual(posix.sched_getaffinity(0), mask)
         self.assertRaises(OSError, posix.sched_setaffinity, 0, [])
+        self.assertRaises(ValueError, posix.sched_setaffinity, 0, [-10])
         self.assertRaises(ValueError, posix.sched_setaffinity, 0, [-1])
-        self.assertRaises(ValueError, posix.sched_setaffinity, 0, [-1 << 1000])
         self.assertRaises(OverflowError, posix.sched_setaffinity, 0, [1<<128])
         self.assertRaises(OSError, posix.sched_setaffinity, -1, mask)
 
@@ -1159,6 +1159,7 @@ class PosixTester(unittest.TestCase):
         orig_mask = posix.sched_getaffinity(0)
         self.addCleanup(posix.sched_setaffinity, 0, orig_mask)
 
+        self.assertRaises(ValueError, posix.sched_setaffinity, 0, [-1 << 1000])
         # verify OverflowError is not raised
         try:
             posix.sched_setaffinity(0, [INT_MAX - 1])

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1096,6 +1096,8 @@ class PosixTester(unittest.TestCase):
         self.assertRaises(OverflowError, posix.sched_setparam, 0, param)
 
     @support.cpython_only
+    @unittest.skipUnless(hasattr(posix, 'sched_setparam'),
+                         "can't change scheduler params")
     def test_convert_sched_param_c_limits(self):
         from _testcapi import INT_MIN, INT_MAX
         orig_param = posix.sched_getparam(0)

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1507,6 +1507,27 @@ class ReTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             _sre.compile({}, 0, [], 0, [], [])
 
+    @cpython_only
+    def test_sre_compile_c_limits(self):
+        import _sre
+        # Currently SRE_CODE is an alias for Py_UCS4, which is an
+        # alias for uint32_t.
+
+        with self.assertRaises(OverflowError):
+            _sre.compile("abc", 0, [-1 << 1000], 0, {}, tuple())
+        with self.assertRaises(OverflowError):
+            _sre.compile("abc", 0, [-1], 0, {}, tuple())
+        # verify OverflowError is not raised
+        for in_range_code in [0, (1 << 32) - 1]:
+            try:
+                _sre.compile("abc", 0, [in_range_code], 0, {}, tuple())
+            except RuntimeError:
+                pass
+        with self.assertRaises(OverflowError):
+            _sre.compile("abc", 0, [1 << 32], 0, {}, tuple())
+        with self.assertRaises(OverflowError):
+            _sre.compile("abc", 0, [1 << 1000], 0, {}, tuple())
+
     def test_search_dot_unicode(self):
         self.assertTrue(re.search("123.*-", '123abc-'))
         self.assertTrue(re.search("123.*-", '123\xe9-'))

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1234,11 +1234,6 @@ class GeneralModuleTests(unittest.TestCase):
     def test_getsockaddrarg(self):
         sock = socket.socket()
         self.addCleanup(sock.close)
-        port = support.find_unused_port()
-        big_port = port + 65536
-        neg_port = port - 65536
-        self.assertRaises(OverflowError, sock.bind, (HOST, big_port))
-        self.assertRaises(OverflowError, sock.bind, (HOST, neg_port))
 
         self.assertRaises(OverflowError, sock.bind, (HOST, -1 << 1000))
         self.assertRaises(OverflowError, sock.bind, (HOST, -1))
@@ -1376,26 +1371,6 @@ class GeneralModuleTests(unittest.TestCase):
         # only IP addresses are allowed
         self.assertRaises(OSError, socket.getnameinfo, ('mail.python.org',0), 0)
 
-        # test port boundaries
-        self.assertRaises(OverflowError,
-                          socket.getnameinfo, (HOST, -1 << 1000), 0)
-        self.assertRaises(OverflowError,
-                          socket.getnameinfo, (HOST, -1), 0)
-        socket.getnameinfo((HOST, 0), 0)
-        socket.getnameinfo((HOST, 0xffff), 0)
-        self.assertRaises(OverflowError,
-                          socket.getnameinfo, (HOST, 1 << 16), 0)
-        self.assertRaises(OverflowError,
-                          socket.getnameinfo, (HOST, 1 << 1000), 0)
-
-        # test flowinfo boundaries
-        self.assertRaises(OverflowError,
-                          socket.getnameinfo, (support.HOSTv6, 0, -1), 0)
-        socket.getnameinfo((support.HOSTv6, 0, 0), 0)
-        socket.getnameinfo((support.HOSTv6, 0, (1 << 20) - 1), 0)
-        self.assertRaises(OverflowError,
-                          socket.getnameinfo, (support.HOSTv6, 0, 1 << 20), 0)
-
     @unittest.skipUnless(support.is_resource_enabled('network'),
                          'network is not enabled')
     def test_idna(self):
@@ -1530,6 +1505,12 @@ class GeneralModuleTests(unittest.TestCase):
 
     @unittest.skipUnless(support.IPV6_ENABLED, 'IPv6 required for this test.')
     def test_flowinfo(self):
+        self.assertRaises(OverflowError,
+                          socket.getnameinfo, (support.HOSTv6, 0, -1), 0)
+        socket.getnameinfo((support.HOSTv6, 0, 0), 0)
+        socket.getnameinfo((support.HOSTv6, 0, (1 << 20) - 1), 0)
+        self.assertRaises(OverflowError,
+                          socket.getnameinfo, (support.HOSTv6, 0, 1 << 20), 0)
         self.assertRaises(OverflowError, socket.getnameinfo,
                           (support.HOSTv6, 0, 0xffffffff), 0)
         with socket.socket(socket.AF_INET6, socket.SOCK_STREAM) as s:

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1381,7 +1381,6 @@ class GeneralModuleTests(unittest.TestCase):
                           socket.getnameinfo, (HOST, -1 << 1000), 0)
         self.assertRaises(OverflowError,
                           socket.getnameinfo, (HOST, -1), 0)
-        # verify OverflowError is not raised
         socket.getnameinfo((HOST, 0), 0)
         socket.getnameinfo((HOST, 0xffff), 0)
         self.assertRaises(OverflowError,
@@ -1392,7 +1391,6 @@ class GeneralModuleTests(unittest.TestCase):
         # test flowinfo boundaries
         self.assertRaises(OverflowError,
                           socket.getnameinfo, (support.HOSTv6, 0, -1), 0)
-        # verify OverflowError is not raised
         socket.getnameinfo((support.HOSTv6, 0, 0), 0)
         socket.getnameinfo((support.HOSTv6, 0, (1 << 20) - 1), 0)
         self.assertRaises(OverflowError,

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -228,6 +228,8 @@ class TestFilemodeCStat(TestFilemode, unittest.TestCase):
     def test_mode_t_converter(self):
         from _testcapi import USHRT_MAX
 
+        # test _PyLong_AsMode_t by testing S_IMODE, which uses
+        # _PyLong_AsMode_t to convert the argument it receives.
         self.assertRaises(TypeError, c_stat.S_IMODE, 1.0)
         self.assertRaises(TypeError, c_stat.S_IMODE, '1')
 

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -233,7 +233,7 @@ class TestFilemodeCStat(TestFilemode, unittest.TestCase):
 
         self.assertRaises(OverflowError, c_stat.S_IMODE, -1 << 1000)
         self.assertRaises(OverflowError, c_stat.S_IMODE, -1)
-        c_stat.S_IMODE(0) # verify OverflowError is not raised
+        c_stat.S_IMODE(0)
         self.assertRaises(OverflowError, c_stat.S_IMODE, 1 << 1000)
 
         # test platform specific mode_t upper limit

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-15988: Make various overflow error messages (in various files) more
+  consistent and helpful.
+
 - bpo-29568: Escaped percent "%%" in the format string for classic string
   formatting no longer allows any characters between two percents.
 

--- a/Modules/_blake2/blake2b_impl.c
+++ b/Modules/_blake2/blake2b_impl.c
@@ -159,6 +159,10 @@ py_blake2b_new_impl(PyTypeObject *type, PyObject *data, int digest_size,
     if (leaf_size_obj != NULL) {
         leaf_size = PyLong_AsUnsignedLong(leaf_size_obj);
         if (leaf_size == (unsigned long) -1 && PyErr_Occurred()) {
+            if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+                PyErr_SetString(PyExc_OverflowError,
+                                "leaf_size does not fit in C unsigned long");
+            }
             goto error;
         }
         if (leaf_size > 0xFFFFFFFFU) {

--- a/Modules/_blake2/blake2b_impl.c
+++ b/Modules/_blake2/blake2b_impl.c
@@ -161,7 +161,7 @@ py_blake2b_new_impl(PyTypeObject *type, PyObject *data, int digest_size,
         if (leaf_size == (unsigned long) -1 && PyErr_Occurred()) {
             if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
                 PyErr_SetString(PyExc_OverflowError,
-                                "leaf_size does not fit in C unsigned long");
+                                "leaf_size must be between 0 and 2**32-1");
             }
             goto error;
         }

--- a/Modules/_blake2/blake2s_impl.c
+++ b/Modules/_blake2/blake2s_impl.c
@@ -159,6 +159,10 @@ py_blake2s_new_impl(PyTypeObject *type, PyObject *data, int digest_size,
     if (leaf_size_obj != NULL) {
         leaf_size = PyLong_AsUnsignedLong(leaf_size_obj);
         if (leaf_size == (unsigned long) -1 && PyErr_Occurred()) {
+            if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+                PyErr_SetString(PyExc_OverflowError,
+                                "leaf_size does not fit in C unsigned long");
+            }
             goto error;
         }
         if (leaf_size > 0xFFFFFFFFU) {

--- a/Modules/_blake2/blake2s_impl.c
+++ b/Modules/_blake2/blake2s_impl.c
@@ -161,7 +161,7 @@ py_blake2s_new_impl(PyTypeObject *type, PyObject *data, int digest_size,
         if (leaf_size == (unsigned long) -1 && PyErr_Occurred()) {
             if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
                 PyErr_SetString(PyExc_OverflowError,
-                                "leaf_size does not fit in C unsigned long");
+                                "leaf_size must be between 0 and 2**32-1");
             }
             goto error;
         }

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1351,7 +1351,7 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     length = PyLong_AsLongAndOverflow(length_attr, &overflow);
     if (overflow) {
         PyErr_SetString(PyExc_OverflowError,
-                        "The '_length_' attribute is too large");
+                        "The '_length_' attribute does not fit in C long");
         Py_DECREF(length_attr);
         goto error;
     }

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -650,7 +650,8 @@ static int ConvParam(PyObject *obj, Py_ssize_t index, struct argument *pa)
             pa->value.i = PyLong_AsLong(obj);
             if (pa->value.i == -1 && PyErr_Occurred()) {
                 PyErr_SetString(PyExc_OverflowError,
-                                "int too long to convert");
+                                "Python int fits neither C unsigned long nor "
+                                "C long");
                 return -1;
             }
         }

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1225,8 +1225,7 @@ PyCursesWindow_GetStr(PyCursesWindowObject *self, PyObject *args)
             return NULL;
         }
         if (n < 0) {
-            PyErr_SetString(PyExc_ValueError,
-                            "getstr: 'n' must be nonnegative");
+            PyErr_SetString(PyExc_ValueError, "'n' must be nonnegative");
             return NULL;
         }
         Py_BEGIN_ALLOW_THREADS
@@ -1250,8 +1249,7 @@ PyCursesWindow_GetStr(PyCursesWindowObject *self, PyObject *args)
             return NULL;
         }
         if (n < 0) {
-            PyErr_SetString(PyExc_ValueError,
-                            "getstr: 'n' must be nonnegative");
+            PyErr_SetString(PyExc_ValueError, "'n' must be nonnegative");
             return NULL;
         }
 #ifdef STRICT_SYSV_CURSES
@@ -1402,8 +1400,7 @@ PyCursesWindow_InStr(PyCursesWindowObject *self, PyObject *args)
             return NULL;
         }
         if (n < 0) {
-            PyErr_SetString(PyExc_ValueError,
-                            "instr: 'n' must be nonnegative");
+            PyErr_SetString(PyExc_ValueError, "'n' must be nonnegative");
             return NULL;
         }
         rtn2 = winnstr(self->win, rtn, Py_MIN(n, 1023));
@@ -1419,8 +1416,7 @@ PyCursesWindow_InStr(PyCursesWindowObject *self, PyObject *args)
             return NULL;
         }
         if (n < 0) {
-            PyErr_SetString(PyExc_ValueError,
-                            "instr: 'n' must be nonnegative");
+            PyErr_SetString(PyExc_ValueError, "'n' must be nonnegative");
             return NULL;
         }
         rtn2 = mvwinnstr(self->win, y, x, rtn, Py_MIN(n,1023));
@@ -2607,8 +2603,7 @@ PyCurses_KeyName(PyObject *self, PyObject *args)
     }
 
     if (ch < 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "keyname: key number must be nonnegative");
+        PyErr_SetString(PyExc_ValueError, "key number must be nonnegative");
         return NULL;
     }
     knp = keyname(ch);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1616,13 +1616,10 @@ microseconds_to_delta_ex(PyObject *pyus, PyTypeObject *type)
     if (num == NULL)
         goto Done;
     Py_INCREF(num);
-    temp = PyLong_AsLong(num);
-    if (temp == -1 && PyErr_Occurred())
-        goto Done;
-    d = (int)temp;
-    if ((long)d != temp) {
-        PyErr_SetString(PyExc_OverflowError, "normalized days too "
-                        "large to fit in a C int");
+    d = _PyLong_AsInt(num);
+    if (d == -1 && PyErr_Occurred()) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "normalized days does not fit in C int");
         goto Done;
     }
     result = new_delta_ex(d, s, us, 0, type);
@@ -2184,7 +2181,7 @@ delta_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         "minutes", "hours", "weeks", NULL
     };
 
-    if (PyArg_ParseTupleAndKeywords(args, kw, "|OOOOOOO:__new__",
+    if (PyArg_ParseTupleAndKeywords(args, kw, "|OOOOOOO:timedelta.__new__",
                                     keywords,
                                     &day, &second, &us,
                                     &ms, &minute, &hour, &week) == 0)
@@ -2531,7 +2528,7 @@ date_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         return (PyObject *)me;
     }
 
-    if (PyArg_ParseTupleAndKeywords(args, kw, "iii", date_kws,
+    if (PyArg_ParseTupleAndKeywords(args, kw, "iii:date.__new__", date_kws,
                                     &year, &month, &day)) {
         self = new_date_ex(year, month, day, type);
     }
@@ -3615,7 +3612,8 @@ time_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         return (PyObject *)me;
     }
 
-    if (PyArg_ParseTupleAndKeywords(args, kw, "|iiiiO$i", time_kws,
+    if (PyArg_ParseTupleAndKeywords(args, kw, "|iiiiO$i:time.__new__",
+                                    time_kws,
                                     &hour, &minute, &second, &usecond,
                                     &tzinfo, &fold)) {
         self = new_time_ex2(hour, minute, second, usecond, tzinfo, fold,
@@ -4201,7 +4199,8 @@ datetime_new(PyTypeObject *type, PyObject *args, PyObject *kw)
         return (PyObject *)me;
     }
 
-    if (PyArg_ParseTupleAndKeywords(args, kw, "iii|iiiiO$i", datetime_kws,
+    if (PyArg_ParseTupleAndKeywords(args, kw, "iii|iiiiO$i:datetime.__new__",
+                                    datetime_kws,
                                     &year, &month, &day, &hour, &minute,
                                     &second, &usecond, &tzinfo, &fold)) {
         self = new_datetime_ex2(year, month, day,

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -629,7 +629,7 @@ pbkdf2_hmac(PyObject *self, PyObject *args, PyObject *kwdict)
     long iterations, dklen;
     int retval;
     const EVP_MD *digest;
-    int overflow = 0;
+    int overflow;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwdict, "sy*y*l|O:pbkdf2_hmac",
                                      kwlist, &name, &password, &salt,

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -480,22 +480,29 @@ _io_StringIO_truncate_impl(stringio *self, PyObject *arg)
 
     if (PyNumber_Check(arg)) {
         size = PyNumber_AsSsize_t(arg, PyExc_OverflowError);
-        if (size == -1 && PyErr_Occurred())
+        if (size == -1 && PyErr_Occurred()) {
+            if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+                PyErr_SetString(PyExc_OverflowError,
+                                "truncate: size value does not fit in C "
+                                "Py_ssize_t");
+            }
             return NULL;
+        }
     }
     else if (arg == Py_None) {
         /* Truncate to current position if no argument is passed. */
         size = self->pos;
     }
     else {
-        PyErr_Format(PyExc_TypeError, "integer argument expected, got '%s'",
+        PyErr_Format(PyExc_TypeError,
+                     "truncate: integer argument expected, got '%s'",
                      Py_TYPE(arg)->tp_name);
         return NULL;
     }
 
     if (size < 0) {
         PyErr_Format(PyExc_ValueError,
-                     "Negative size value %zd", size);
+                     "truncate: negative size value %zd", size);
         return NULL;
     }
 

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -461,6 +461,10 @@ _io_StringIO_truncate_impl(stringio *self, PyObject *arg)
     if (PyIndex_Check(arg)) {
         size = PyNumber_AsSsize_t(arg, PyExc_OverflowError);
         if (size == -1 && PyErr_Occurred()) {
+            if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+                PyErr_SetString(PyExc_OverflowError,
+                                "size value does not fit in C Py_ssize_t");
+            }
             return NULL;
         }
     }
@@ -477,7 +481,7 @@ _io_StringIO_truncate_impl(stringio *self, PyObject *arg)
 
     if (size < 0) {
         PyErr_Format(PyExc_ValueError,
-                     "truncate: negative size value %zd", size);
+                     "Negative size value %zd", size);
         return NULL;
     }
 

--- a/Modules/_sqlite/util.c
+++ b/Modules/_sqlite/util.c
@@ -151,6 +151,6 @@ _pysqlite_long_as_int64(PyObject * py_val)
         }
     }
     PyErr_SetString(PyExc_OverflowError,
-                    "Python int too large to convert to SQLite INTEGER");
+                    "Python int does not fit in C sqlite_int64");
     return -1;
 }

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -1414,12 +1414,16 @@ _sre_compile_impl(PyObject *module, PyObject *pattern, int flags,
         self->code[i] = (SRE_CODE) value;
         if ((unsigned long) self->code[i] != value) {
             PyErr_SetString(PyExc_OverflowError,
-                            "regular expression code size limit exceeded");
+                            "regular expression code out of range");
             break;
         }
     }
 
     if (PyErr_Occurred()) {
+        if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "regular expression code out of range");
+        }
         Py_DECREF(self);
         return NULL;
     }

--- a/Modules/_stat.c
+++ b/Modules/_stat.c
@@ -251,12 +251,18 @@ _PyLong_AsMode_t(PyObject *op)
     mode_t mode;
 
     value = PyLong_AsUnsignedLong(op);
-    if ((value == (unsigned long)-1) && PyErr_Occurred())
+    if ((value == (unsigned long)-1) && PyErr_Occurred()) {
+        if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "Python int does not fit in C mode_t");
+        }
         return (mode_t)-1;
+    }
 
     mode = (mode_t)value;
     if ((unsigned long)mode != value) {
-        PyErr_SetString(PyExc_OverflowError, "mode out of range");
+        PyErr_SetString(PyExc_OverflowError,
+                        "Python int does not fit in C mode_t");
         return (mode_t)-1;
     }
     return mode;

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -197,20 +197,24 @@ b_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     /* PyArg_Parse's 'b' formatter is for an unsigned char, therefore
        must use the next size up that is signed ('h') and manually do
        the overflow checking */
-    if (!PyArg_Parse(v, "h;array item must be integer", &x))
+    if (!PyArg_Parse(v, "h:array('b').__setitem__", &x)) {
         return -1;
+    }
     else if (x < -128) {
         PyErr_SetString(PyExc_OverflowError,
-            "signed char is less than minimum");
+                        "array('b').__setitem__() value argument too small "
+                        "to convert to C char");
         return -1;
     }
     else if (x > 127) {
         PyErr_SetString(PyExc_OverflowError,
-            "signed char is greater than maximum");
+                        "array('b').__setitem__() value argument too large "
+                        "to convert to C char");
         return -1;
     }
-    if (i >= 0)
+    if (i >= 0) {
         ((char *)ap->ob_item)[i] = (char)x;
+    }
     return 0;
 }
 
@@ -226,10 +230,12 @@ BB_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
 {
     unsigned char x;
     /* 'B' == unsigned char, maps to PyArg_Parse's 'b' formatter */
-    if (!PyArg_Parse(v, "b;array item must be integer", &x))
+    if (!PyArg_Parse(v, "b:array('B').__setitem__", &x)) {
         return -1;
-    if (i >= 0)
+    }
+    if (i >= 0) {
         ((char *)ap->ob_item)[i] = x;
+    }
     return 0;
 }
 
@@ -270,10 +276,12 @@ h_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
 {
     short x;
     /* 'h' == signed short, maps to PyArg_Parse's 'h' formatter */
-    if (!PyArg_Parse(v, "h;array item must be integer", &x))
+    if (!PyArg_Parse(v, "h:array('h').__setitem__", &x)) {
         return -1;
-    if (i >= 0)
-                 ((short *)ap->ob_item)[i] = x;
+    }
+    if (i >= 0) {
+        ((short *)ap->ob_item)[i] = x;
+    }
     return 0;
 }
 
@@ -289,20 +297,24 @@ HH_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     int x;
     /* PyArg_Parse's 'h' formatter is for a signed short, therefore
        must use the next size up and manually do the overflow checking */
-    if (!PyArg_Parse(v, "i;array item must be integer", &x))
+    if (!PyArg_Parse(v, "i:array('H').__setitem__", &x)) {
         return -1;
+    }
     else if (x < 0) {
         PyErr_SetString(PyExc_OverflowError,
-            "unsigned short is less than minimum");
+                        "array('H').__setitem__() value argument can't be "
+                        "negative");
         return -1;
     }
     else if (x > USHRT_MAX) {
         PyErr_SetString(PyExc_OverflowError,
-            "unsigned short is greater than maximum");
+                        "array('H').__setitem__() value argument too large "
+                        "to convert to C unsigned short");
         return -1;
     }
-    if (i >= 0)
+    if (i >= 0) {
         ((short *)ap->ob_item)[i] = (short)x;
+    }
     return 0;
 }
 
@@ -317,10 +329,12 @@ i_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
 {
     int x;
     /* 'i' == signed int, maps to PyArg_Parse's 'i' formatter */
-    if (!PyArg_Parse(v, "i;array item must be integer", &x))
+    if (!PyArg_Parse(v, "i:array('i').__setitem__", &x)) {
         return -1;
-    if (i >= 0)
-                 ((int *)ap->ob_item)[i] = x;
+    }
+    if (i >= 0) {
+        ((int *)ap->ob_item)[i] = x;
+    }
     return 0;
 }
 
@@ -357,6 +371,10 @@ II_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     }
     x = PyLong_AsUnsignedLong(v);
     if (x == (unsigned long)-1 && PyErr_Occurred()) {
+        assert(PyErr_ExceptionMatches(PyExc_OverflowError));
+        PyErr_SetString(PyExc_OverflowError,
+                        "array('I').__setitem__() value argument does "
+                        "not fit in C unsigned int");
         if (do_decref) {
             Py_DECREF(v);
         }
@@ -364,14 +382,16 @@ II_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     }
     if (x > UINT_MAX) {
         PyErr_SetString(PyExc_OverflowError,
-                        "unsigned int is greater than maximum");
+                        "array('I').__setitem__() value argument too large "
+                        "to convert to C unsigned int");
         if (do_decref) {
             Py_DECREF(v);
         }
         return -1;
     }
-    if (i >= 0)
+    if (i >= 0) {
         ((unsigned int *)ap->ob_item)[i] = (unsigned int)x;
+    }
 
     if (do_decref) {
         Py_DECREF(v);
@@ -389,10 +409,12 @@ static int
 l_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
 {
     long x;
-    if (!PyArg_Parse(v, "l;array item must be integer", &x))
+    if (!PyArg_Parse(v, "l:array('l').__setitem__", &x)) {
         return -1;
-    if (i >= 0)
-                 ((long *)ap->ob_item)[i] = x;
+    }
+    if (i >= 0) {
+        ((long *)ap->ob_item)[i] = x;
+    }
     return 0;
 }
 
@@ -417,13 +439,18 @@ LL_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     }
     x = PyLong_AsUnsignedLong(v);
     if (x == (unsigned long)-1 && PyErr_Occurred()) {
+        assert(PyErr_ExceptionMatches(PyExc_OverflowError));
+        PyErr_SetString(PyExc_OverflowError,
+                        "array('L').__setitem__() value argument does "
+                        "not fit in C unsigned long");
         if (do_decref) {
             Py_DECREF(v);
         }
         return -1;
     }
-    if (i >= 0)
+    if (i >= 0) {
         ((unsigned long *)ap->ob_item)[i] = x;
+    }
 
     if (do_decref) {
         Py_DECREF(v);
@@ -441,10 +468,12 @@ static int
 q_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
 {
     long long x;
-    if (!PyArg_Parse(v, "L;array item must be integer", &x))
+    if (!PyArg_Parse(v, "L:array('q').__setitem__", &x)) {
         return -1;
-    if (i >= 0)
+    }
+    if (i >= 0) {
         ((long long *)ap->ob_item)[i] = x;
+    }
     return 0;
 }
 
@@ -470,13 +499,18 @@ QQ_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     }
     x = PyLong_AsUnsignedLongLong(v);
     if (x == (unsigned long long)-1 && PyErr_Occurred()) {
+        assert(PyErr_ExceptionMatches(PyExc_OverflowError));
+        PyErr_SetString(PyExc_OverflowError,
+                        "array('Q').__setitem__() value argument does "
+                        "not fit in C unsigned long long");
         if (do_decref) {
             Py_DECREF(v);
         }
         return -1;
     }
-    if (i >= 0)
+    if (i >= 0) {
         ((unsigned long long *)ap->ob_item)[i] = x;
+    }
 
     if (do_decref) {
         Py_DECREF(v);

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -202,14 +202,12 @@ b_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     }
     else if (x < -128) {
         PyErr_SetString(PyExc_OverflowError,
-                        "array('b').__setitem__() value argument too small "
-                        "to convert to C char");
+                        "array item too small to convert to C char");
         return -1;
     }
     else if (x > 127) {
         PyErr_SetString(PyExc_OverflowError,
-                        "array('b').__setitem__() value argument too large "
-                        "to convert to C char");
+                        "array item too large to convert to C char");
         return -1;
     }
     if (i >= 0) {
@@ -302,14 +300,12 @@ HH_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     }
     else if (x < 0) {
         PyErr_SetString(PyExc_OverflowError,
-                        "array('H').__setitem__() value argument can't be "
-                        "negative");
+                        "array item can't be negative");
         return -1;
     }
     else if (x > USHRT_MAX) {
         PyErr_SetString(PyExc_OverflowError,
-                        "array('H').__setitem__() value argument too large "
-                        "to convert to C unsigned short");
+                        "array item too large to convert to C unsigned short");
         return -1;
     }
     if (i >= 0) {
@@ -373,8 +369,7 @@ II_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     if (x == (unsigned long)-1 && PyErr_Occurred()) {
         assert(PyErr_ExceptionMatches(PyExc_OverflowError));
         PyErr_SetString(PyExc_OverflowError,
-                        "array('I').__setitem__() value argument does "
-                        "not fit in C unsigned int");
+                        "array item does not fit in C unsigned int");
         if (do_decref) {
             Py_DECREF(v);
         }
@@ -382,8 +377,7 @@ II_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     }
     if (x > UINT_MAX) {
         PyErr_SetString(PyExc_OverflowError,
-                        "array('I').__setitem__() value argument too large "
-                        "to convert to C unsigned int");
+                        "array item too large to convert to C unsigned int");
         if (do_decref) {
             Py_DECREF(v);
         }
@@ -441,8 +435,7 @@ LL_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     if (x == (unsigned long)-1 && PyErr_Occurred()) {
         assert(PyErr_ExceptionMatches(PyExc_OverflowError));
         PyErr_SetString(PyExc_OverflowError,
-                        "array('L').__setitem__() value argument does "
-                        "not fit in C unsigned long");
+                        "array item does not fit in C unsigned long");
         if (do_decref) {
             Py_DECREF(v);
         }
@@ -501,8 +494,7 @@ QQ_setitem(arrayobject *ap, Py_ssize_t i, PyObject *v)
     if (x == (unsigned long long)-1 && PyErr_Occurred()) {
         assert(PyErr_ExceptionMatches(PyExc_OverflowError));
         PyErr_SetString(PyExc_OverflowError,
-                        "array('Q').__setitem__() value argument does "
-                        "not fit in C unsigned long long");
+                        "array item does not fit in C unsigned long long");
         if (do_decref) {
             Py_DECREF(v);
         }

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -270,8 +270,15 @@ mmap_read_method(mmap_object *self,
     PyObject *result;
 
     CHECK_VALID(NULL);
-    if (!PyArg_ParseTuple(args, "|O&:read", mmap_convert_ssize_t, &num_bytes))
+    if (!PyArg_ParseTuple(args, "|O&:read",
+                          mmap_convert_ssize_t, &num_bytes)) {
+        assert(PyErr_Occurred());
+        if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "read count does not fit in C Py_ssize_t");
+        }
         return(NULL);
+    }
 
     /* silently 'adjust' out-of-range requests */
     remaining = (self->pos < self->size) ? self->size - self->pos : 0;
@@ -1083,18 +1090,20 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
                                "flags", "prot",
                                "access", "offset", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "in|iii" _Py_PARSE_OFF_T, keywords,
-                                     &fd, &map_size, &flags, &prot,
-                                     &access, &offset))
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict,
+                                     "in|iii" _Py_PARSE_OFF_T ":mmap",
+                                     keywords, &fd, &map_size, &flags, &prot,
+                                     &access, &offset)) {
         return NULL;
+    }
     if (map_size < 0) {
         PyErr_SetString(PyExc_OverflowError,
-                        "memory mapped length must be postiive");
+                        "memory mapped length must be positive");
         return NULL;
     }
     if (offset < 0) {
         PyErr_SetString(PyExc_OverflowError,
-            "memory mapped offset must be positive");
+                        "memory mapped offset must be positive");
         return NULL;
     }
 
@@ -1243,7 +1252,7 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
                                 "tagname",
                                 "access", "offset", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "in|ziL", keywords,
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "in|ziL:mmap", keywords,
                                      &fileno, &map_size,
                                      &tagname, &access, &offset)) {
         return NULL;
@@ -1269,12 +1278,12 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
 
     if (map_size < 0) {
         PyErr_SetString(PyExc_OverflowError,
-                        "memory mapped length must be postiive");
+                        "memory mapped length must be positive");
         return NULL;
     }
     if (offset < 0) {
         PyErr_SetString(PyExc_OverflowError,
-            "memory mapped offset must be positive");
+                        "memory mapped offset must be positive");
         return NULL;
     }
 

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1092,7 +1092,7 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
                                "access", "offset", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwdict,
-                                     "in|iii" _Py_PARSE_OFF_T ":mmap",
+                                     "in|iii" _Py_PARSE_OFF_T ":mmap.__new__",
                                      keywords, &fd, &map_size, &flags, &prot,
                                      &access, &offset)) {
         return NULL;
@@ -1253,8 +1253,8 @@ new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
                                 "tagname",
                                 "access", "offset", NULL };
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "in|ziL:mmap", keywords,
-                                     &fileno, &map_size,
+    if (!PyArg_ParseTupleAndKeywords(args, kwdict, "in|ziL:mmap.__new__",
+                                     keywords, &fileno, &map_size,
                                      &tagname, &access, &offset)) {
         return NULL;
     }

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -412,7 +412,7 @@ poll_register(pollObject *self, PyObject *args)
         assert(PyErr_Occurred());
         if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
             PyErr_SetString(PyExc_OverflowError,
-                            "register: eventmask value does not fit in C "
+                            "eventmask value does not fit in C "
                             "unsigned short");
         }
         return NULL;
@@ -462,7 +462,7 @@ poll_modify(pollObject *self, PyObject *args)
         assert(PyErr_Occurred());
         if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
             PyErr_SetString(PyExc_OverflowError,
-                            "modify: eventmask value does not fit in C "
+                            "eventmask value does not fit in C "
                             "unsigned short");
         }
         return NULL;
@@ -808,8 +808,8 @@ internal_devpoll_register(devpollObject *self, PyObject *args, int remove)
         assert(PyErr_Occurred());
         if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
             PyErr_SetString(PyExc_OverflowError,
-                            "register/modify: eventmask value does not fit "
-                            "in C unsigned short");
+                            "eventmask value does not fit in C "
+                            "unsigned short");
         }
         return NULL;
     }

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1783,8 +1783,7 @@ getsockaddrarg(PySocketSockObject *s, PyObject *args,
             return 0;
         }
         if (!PyArg_ParseTuple(args, "si|iiy*:getsockaddrarg", &interfaceName,
-                              &protoNumber, &pkttype, &hatype,
-                              &haddr)) {
+                              &protoNumber, &pkttype, &hatype, &haddr)) {
             return 0;
         }
         strncpy(ifr.ifr_name, interfaceName, sizeof(ifr.ifr_name));
@@ -6097,11 +6096,6 @@ socket_getnameinfo(PyObject *self, PyObject *args)
     }
     if (!PyArg_ParseTuple(sa, "si|II:getnameinfo",
                           &hostp, &port, &flowinfo, &scope_id)) {
-        return NULL;
-    }
-    if (port < 0 || port > 0xffff) {
-        PyErr_SetString(PyExc_OverflowError,
-                        "getnameinfo: port must be 0-65535.");
         return NULL;
     }
     if (flowinfo > 0xfffff) {

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -427,11 +427,12 @@ gettmarg(PyObject *args, struct tm *p)
         return 0;
     }
 
-    if (!PyArg_ParseTuple(args, "iiiiiiiii",
+    if (!PyArg_ParseTuple(args, "iiiiiiiii:mktime/asctime/strftime",
                           &y, &p->tm_mon, &p->tm_mday,
                           &p->tm_hour, &p->tm_min, &p->tm_sec,
-                          &p->tm_wday, &p->tm_yday, &p->tm_isdst))
+                          &p->tm_wday, &p->tm_yday, &p->tm_isdst)) {
         return 0;
+    }
     p->tm_year = y - 1900;
     p->tm_mon--;
     p->tm_wday = (p->tm_wday + 1) % 7;

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -936,8 +936,14 @@ sequence_repeat(ssizeargfunc repeatfunc, PyObject *seq, PyObject *n)
     Py_ssize_t count;
     if (PyIndex_Check(n)) {
         count = PyNumber_AsSsize_t(n, PyExc_OverflowError);
-        if (count == -1 && PyErr_Occurred())
+        if (count == -1 && PyErr_Occurred()) {
+            if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+                PyErr_SetString(PyExc_OverflowError,
+                                "sequence repeat count does not fit in C "
+                                "Py_ssize_t");
+            }
             return NULL;
+        }
     }
     else {
         return type_error("can't multiply sequence by "

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -798,13 +798,17 @@ bytearray_init(PyByteArrayObject *self, PyObject *args, PyObject *kwds)
     if (PyIndex_Check(arg)) {
         count = PyNumber_AsSsize_t(arg, PyExc_OverflowError);
         if (count == -1 && PyErr_Occurred()) {
-            if (PyErr_ExceptionMatches(PyExc_OverflowError))
+            if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
+                PyErr_SetString(PyExc_OverflowError,
+                                "bytearray: count does not fit in C "
+                                "Py_ssize_t");
                 return -1;
+            }
             PyErr_Clear();  /* fall through */
         }
         else {
             if (count < 0) {
-                PyErr_SetString(PyExc_ValueError, "negative count");
+                PyErr_SetString(PyExc_ValueError, "bytearray: negative count");
                 return -1;
             }
             if (count > 0) {

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -800,15 +800,14 @@ bytearray_init(PyByteArrayObject *self, PyObject *args, PyObject *kwds)
         if (count == -1 && PyErr_Occurred()) {
             if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
                 PyErr_SetString(PyExc_OverflowError,
-                                "bytearray: count does not fit in C "
-                                "Py_ssize_t");
+                                "count does not fit in C Py_ssize_t");
                 return -1;
             }
             PyErr_Clear();  /* fall through */
         }
         else {
             if (count < 0) {
-                PyErr_SetString(PyExc_ValueError, "bytearray: negative count");
+                PyErr_SetString(PyExc_ValueError, "negative count");
                 return -1;
             }
             if (count > 0) {

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2599,14 +2599,14 @@ bytes_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         if (size == -1 && PyErr_Occurred()) {
             if (PyErr_ExceptionMatches(PyExc_OverflowError)) {
                 PyErr_SetString(PyExc_OverflowError,
-                                "bytes: count does not fit in C Py_ssize_t");
+                                "count does not fit in C Py_ssize_t");
                 return NULL;
             }
             PyErr_Clear();  /* fall through */
         }
         else {
             if (size < 0) {
-                PyErr_SetString(PyExc_ValueError, "bytes: negative count");
+                PyErr_SetString(PyExc_ValueError, "negative count");
                 return NULL;
             }
             new = _PyBytes_FromSize(size, 1);

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -505,8 +505,9 @@ byte_converter(PyObject *arg, char *p)
         else {
             iobj = PyNumber_Index(arg);
             if (iobj == NULL) {
-                if (!PyErr_ExceptionMatches(PyExc_TypeError))
+                if (!PyErr_ExceptionMatches(PyExc_TypeError)) {
                     return 0;
+                }
                 PyErr_SetString(PyExc_TypeError,
                                 "%c requires an integer in range(256) or a "
                                 "single byte");

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -505,6 +505,7 @@ byte_converter(PyObject *arg, char *p)
         else {
             iobj = PyNumber_Index(arg);
             if (iobj == NULL) {
+                assert(PyErr_Occurred());
                 if (!PyErr_ExceptionMatches(PyExc_TypeError)) {
                     return 0;
                 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -499,18 +499,13 @@ _PyLong_AsInt(PyObject *obj)
 {
     int overflow;
     long result = PyLong_AsLongAndOverflow(obj, &overflow);
-    if (result == -1 && PyErr_Occurred()) {
-        return -1;
-    }
     if (overflow == 1 || result > INT_MAX) {
         PyErr_SetString(PyExc_OverflowError,
                         "Python int too large to convert to C int");
-        return -1;
     }
     else if (overflow == -1 || result < INT_MIN) {
         PyErr_SetString(PyExc_OverflowError,
                         "Python int too small to convert to C int");
-        return -1;
     }
     return (int)result;
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -502,10 +502,12 @@ _PyLong_AsInt(PyObject *obj)
     if (overflow == 1 || result > INT_MAX) {
         PyErr_SetString(PyExc_OverflowError,
                         "Python int too large to convert to C int");
+        return -1;
     }
     else if (overflow == -1 || result < INT_MIN) {
         PyErr_SetString(PyExc_OverflowError,
                         "Python int too small to convert to C int");
+        return -1;
     }
     return (int)result;
 }

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -860,6 +860,7 @@ format_long_internal(PyObject *value, const InternalFormatSpec *format,
     Py_ssize_t prefix = 0;
     NumberFieldWidths spec;
     long x;
+    int overflow;
 
     /* Locale settings, either from the actual locale or
        from a hard-code pseudo-locale */
@@ -891,10 +892,11 @@ format_long_internal(PyObject *value, const InternalFormatSpec *format,
 
         /* taken from unicodeobject.c formatchar() */
         /* Integer input truncated to a character */
-        x = PyLong_AsLong(value);
-        if (x == -1 && PyErr_Occurred())
+        x = PyLong_AsLongAndOverflow(value, &overflow);
+        if (x == -1 && PyErr_Occurred()) {
             goto done;
-        if (x < 0 || x > 0x10ffff) {
+        }
+        if (overflow || x < 0 || x > 0x10ffff) {
             PyErr_SetString(PyExc_OverflowError,
                             "%c arg not in range(0x110000)");
             goto done;

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -890,7 +890,6 @@ format_long_internal(PyObject *value, const InternalFormatSpec *format,
             goto done;
         }
 
-        /* taken from unicodeobject.c formatchar() */
         /* Integer input truncated to a character */
         x = PyLong_AsLongAndOverflow(value, &overflow);
         if (x == -1 && PyErr_Occurred()) {

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -444,7 +444,7 @@ seterror(Py_ssize_t iarg, const char *msg, int *levels, const char *fname,
 
     if (PyErr_Occurred()) {
         assert(p_format_code != NULL);
-        if (PyErr_ExceptionMatches(PyExc_OverflowError) && fname != NULL &&
+        if (fname != NULL && PyErr_ExceptionMatches(PyExc_OverflowError) &&
             strchr("bhilLn", *p_format_code)) {
             PyErr_Format(PyExc_OverflowError,
                          "%.150s() argument out of range", fname);


### PR DESCRIPTION
according to http://bugs.python.org/issue15988:
1. in Python/getargs.c, patch seterror so that it would be easier to do _2_ in various places that use PyArg_* functions.
2. make various OverflowError and ValueError messages more consistent and helpful
3. add various overflow tests

(I ran the test module, and on my Windows 10, the same tests failed with
and without my patches. However, on my Ubuntu 16.04 VM, none of the tests
failed.)