### PR TITLE
[3.6] Fix stderr bug in json.tool test (#346)

### DIFF
--- a/Lib/test/test_json/test_tool.py
+++ b/Lib/test/test_json/test_tool.py
@@ -2,7 +2,7 @@ import os
 import sys
 import textwrap
 import unittest
-import subprocess
+from subprocess import Popen, PIPE
 from test import support
 from test.support.script_helper import assert_python_ok
 
@@ -61,12 +61,11 @@ class TestTool(unittest.TestCase):
     """)
 
     def test_stdin_stdout(self):
-        with subprocess.Popen(
-                (sys.executable, '-m', 'json.tool'),
-                stdin=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
+        args = sys.executable, '-m', 'json.tool'
+        with Popen(args, stdin=PIPE, stdout=PIPE, stderr=PIPE) as proc:
             out, err = proc.communicate(self.data.encode())
         self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
-        self.assertEqual(err, None)
+        self.assertEqual(err, b'')
 
     def _create_infile(self):
         infile = support.TESTFN


### PR DESCRIPTION
See https://github.com/python/cpython/pull/201#discussion_r103229425.

(cherry picked from commit b4e9087e7b77e8f76feac76f9c1ab21b49c0c766)