### PR TITLE
bpo-29812: Improve testing of token and tokenize

### DIFF
--- a/Lib/test/test_token.py
+++ b/Lib/test/test_token.py
@@ -1,0 +1,52 @@
+import token
+import unittest
+from test import support
+import filecmp
+import os
+import sys
+import subprocess
+
+TOKEN_FILE               = support.findfile('token.py')
+TOKEN_INCLUDE_FILE       = os.path.join(os.path.split(__file__)[0],
+                                        '..', '..', 'Include', 'token.h')
+TEST_PY_FILE             = 'token_test.py'
+NONEXISTENT_FILE         = b'not_here.txt'
+
+
+class TestTokenGeneration(unittest.TestCase):
+
+    def _copy_file_without_generated_tokens(self, source_file, dest_file):
+        with open(source_file, 'rb') as fp:
+            lines = fp.readlines()
+        nl = lines[0][len(lines[0].strip()):]
+        with open(dest_file, 'wb') as fp:
+            fp.writelines(lines[:lines.index(b"#--start constants--" + nl) + 1])
+            fp.writelines(lines[lines.index(b"#--end constants--" + nl):])
+
+    def _generate_tokens(self, skeleton_file, target_token_py_file):
+        proc = subprocess.Popen([sys.executable,
+                                 TOKEN_FILE,
+                                 skeleton_file,
+                                 target_token_py_file], stderr=subprocess.PIPE)
+        stderr = proc.communicate()[1]
+        return proc.returncode, stderr
+
+    @unittest.skipIf(not os.path.exists(TOKEN_FILE),
+                     'test only works from source build directory')
+    def test_real_token_file(self):
+        self._copy_file_without_generated_tokens(TOKEN_FILE, TEST_PY_FILE)
+        self.addCleanup(support.unlink, TEST_PY_FILE)
+        self.assertFalse(filecmp.cmp(TOKEN_FILE, TEST_PY_FILE))
+        self.assertEqual((0, b''), self._generate_tokens(TOKEN_INCLUDE_FILE,
+                                                         TEST_PY_FILE))
+        self.assertTrue(filecmp.cmp(TOKEN_FILE, TEST_PY_FILE))
+
+    def test_missing_output_file_causes_Error(self):
+        rc, stderr = self._generate_tokens(os.devnull, NONEXISTENT_FILE)
+        self.assertNotEqual(rc, 0)
+        self.assertIn(b'I/O error', stderr)
+        self.assertIn(NONEXISTENT_FILE, stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1357,6 +1357,7 @@ class TestTokenize(TestCase):
             token.STRING, token.NEWLINE, token.INDENT,
             token.DEDENT, token.OP, token.ERRORTOKEN,
             token.AWAIT, token.ASYNC,
+            token.COMMENT, token.NL, token.ENCODING,
             token.N_TOKENS, token.NT_OFFSET,
         }
 

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1352,23 +1352,25 @@ class TestTokenize(TestCase):
                          tok_name[token.ENDMARKER])
 
     def test_all_literal_tokens(self):
-        NON_LITERALS = {token.ENDMARKER, token.NAME, token.NUMBER,
-                        token.STRING, token.NEWLINE, token.INDENT,
-                        token.DEDENT, token.OP, token.ERRORTOKEN,
-                        token.AWAIT, token.ASYNC,
-                        token.N_TOKENS, token.NT_OFFSET}
+        non_literals = {
+            token.ENDMARKER, token.NAME, token.NUMBER,
+            token.STRING, token.NEWLINE, token.INDENT,
+            token.DEDENT, token.OP, token.ERRORTOKEN,
+            token.AWAIT, token.ASYNC,
+            token.N_TOKENS, token.NT_OFFSET,
+        }
 
         for tok in range(token.N_TOKENS):
-            if tok in NON_LITERALS:
+            if tok in non_literals:
                 continue
             name = tok_name[tok]
-            self.assertIn(tok, EXACT_TOKEN_TYPES.values(),
-                    "Literal token " + name + " not in EXACT_TOKEN_TYPES")
+            with self.subTest(name=name):
+                self.assertIn(tok, EXACT_TOKEN_TYPES.values())
 
-        for tok in NON_LITERALS:
+        for tok in non_literals:
             name = tok_name[tok]
-            self.assertNotIn(tok, EXACT_TOKEN_TYPES.values(),
-                    "Non literal token " + name + " in EXACT_TOKEN_TYPES")
+            with self.subTest(name=name):
+                self.assertNotIn(tok, EXACT_TOKEN_TYPES.values())
 
     def test_exact_type(self):
         self.assertExactTypeEqual('()', token.LPAR, token.RPAR)

--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -1,7 +1,7 @@
 from test import support
 from tokenize import (tokenize, _tokenize, untokenize, NUMBER, NAME, OP,
                      STRING, ENDMARKER, ENCODING, tok_name, detect_encoding,
-                     open as tokenize_open, Untokenizer)
+                     open as tokenize_open, Untokenizer, EXACT_TOKEN_TYPES)
 from io import BytesIO
 from unittest import TestCase, mock
 from test.test_grammar import (VALID_UNDERSCORE_LITERALS,
@@ -1350,6 +1350,25 @@ class TestTokenize(TestCase):
                              tok_name[optypes[i]])
         self.assertEqual(tok_name[tokens[1 + num_optypes].exact_type],
                          tok_name[token.ENDMARKER])
+
+    def test_all_literal_tokens(self):
+        NON_LITERALS = {token.ENDMARKER, token.NAME, token.NUMBER,
+                        token.STRING, token.NEWLINE, token.INDENT,
+                        token.DEDENT, token.OP, token.ERRORTOKEN,
+                        token.AWAIT, token.ASYNC,
+                        token.N_TOKENS, token.NT_OFFSET}
+
+        for tok in range(token.N_TOKENS):
+            if tok in NON_LITERALS:
+                continue
+            name = tok_name[tok]
+            self.assertIn(tok, EXACT_TOKEN_TYPES.values(),
+                    "Literal token " + name + " not in EXACT_TOKEN_TYPES")
+
+        for tok in NON_LITERALS:
+            name = tok_name[tok]
+            self.assertNotIn(tok, EXACT_TOKEN_TYPES.values(),
+                    "Non literal token " + name + " in EXACT_TOKEN_TYPES")
 
     def test_exact_type(self):
         self.assertExactTypeEqual('()', token.LPAR, token.RPAR)

--- a/Lib/token.py
+++ b/Lib/token.py
@@ -129,33 +129,37 @@ def _main():
                 comment = comment_match.group(1)
                 tokens[prev_val]['comment'] = comment
     keys = sorted(tokens.keys())
-    # load the output skeleton from the target:
+    # load the output skeleton from the target, taking
+    # care to preserve its newline convention.
+    # newline detection code from keyword.py
     try:
-        fp = open(outFileName)
+        fp = open(outFileName, newline='')
     except OSError as err:
         sys.stderr.write("I/O error: %s\n" % str(err))
         sys.exit(2)
     with fp:
-        format = fp.read().split("\n")
+        format = fp.readlines()
+    nl = format[0][len(format[0].strip()):] if format else '\n'
+
     try:
-        start = format.index("#--start constants--") + 1
-        end = format.index("#--end constants--")
+        start = format.index("#--start constants--" + nl) + 1
+        end = format.index("#--end constants--" + nl)
     except ValueError:
         sys.stderr.write("target does not contain format markers")
         sys.exit(3)
     lines = []
     for key in keys:
-        lines.append("%s = %d" % (tokens[key]["token"], key))
+        lines.append("%s = %d%s" % (tokens[key]["token"], key, nl))
         if "comment" in tokens[key]:
-            lines.append("# %s" % tokens[key]["comment"])
+            lines.append("# %s%s" % (tokens[key]["comment"], nl))
     format[start:end] = lines
     try:
-        fp = open(outFileName, 'w')
+        fp = open(outFileName, 'w', newline='')
     except OSError as err:
         sys.stderr.write("I/O error: %s\n" % str(err))
         sys.exit(4)
     with fp:
-        fp.write("\n".join(format))
+        fp.writelines(format)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds a token.py generation test, and a cross-check between the token and tokenize modules.

The generation test is akin to the current automated file generator tests in test_keyword and test_symbol. The newly added check in tokenize ensures that all the literal tokens in token such as ':', '...', '@=' have a corresponding entry within the EXACT_TOKEN_TYPES dict in tokenize.