### PR TITLE
bpo-29820: remove broken link and outdate books in othergui.rst

### DIFF
--- a/Doc/library/othergui.rst
+++ b/Doc/library/othergui.rst
@@ -9,14 +9,15 @@ available for Python:
 .. seealso::
 
    `PyGObject <https://wiki.gnome.org/Projects/PyGObject>`_
-      provides introspection bindings for C libraries using
+      PyGObject provides introspection bindings for C libraries using
       `GObject <https://developer.gnome.org/gobject/stable/>`_.  One of
       these libraries is the `GTK+ 3 <http://www.gtk.org/>`_ widget set.
       GTK+ comes with many more widgets than Tkinter provides.  An online
       `Python GTK+ 3 Tutorial <https://python-gtk-3-tutorial.readthedocs.org/en/latest/>`_
       is available.
 
-      `PyGTK <http://www.pygtk.org/>`_ provides bindings for an older version
+   `PyGTK <http://www.pygtk.org/>`_
+      PyGTK provides bindings for an older version
       of the library, GTK+ 2.  It provides an object oriented interface that
       is slightly higher level than the C one.  There are also bindings to
       `GNOME <https://www.gnome.org/>`_.  An online `tutorial
@@ -27,15 +28,10 @@ available for Python:
       extensive C++ GUI application development framework that is
       available for Unix, Windows and Mac OS X. :program:`sip` is a tool
       for generating bindings for C++ libraries as Python classes, and
-      is specifically designed for Python. The *PyQt3* bindings have a
-      book, `GUI Programming with Python: QT Edition
-      <https://www.commandprompt.com/community/pyqt/>`_ by Boudewijn
-      Rempt. The *PyQt4* bindings also have a book, `Rapid GUI Programming
-      with Python and Qt <https://www.qtrac.eu/pyqtbook.html>`_, by Mark
-      Summerfield.
+      is specifically designed for Python.
 
    `PySide <https://wiki.qt.io/PySide>`_
-      is a newer binding to the Qt toolkit, provided by Nokia.
+      PySide is a newer binding to the Qt toolkit, provided by Nokia.
       Compared to PyQt, its licensing scheme is friendlier to non-open source
       applications.
 
@@ -49,9 +45,7 @@ available for Python:
       documentation and context sensitive help, printing, HTML viewing,
       low-level device context drawing, drag and drop, system clipboard access,
       an XML-based resource format and more, including an ever growing library
-      of user-contributed modules.  wxPython has a book, `wxPython in Action
-      <https://www.manning.com/books/wxpython-in-action>`_, by Noel Rappin and
-      Robin Dunn.
+      of user-contributed modules.
 
 PyGTK, PyQt, and wxPython, all have a modern look and feel and more
 widgets than Tkinter. In addition, there are many other GUI toolkits for


### PR DESCRIPTION
This PR fixes [bpo-29820](http://bugs.python.org/issue29820). @Mariatta I removed the outdated books, but I also changed the first line of the PySide and PyGObject entries, making them consistent to the PyQt and wxPython ones.