### PR TITLE
Document that TestCase.assertCountEqual() can take iterables

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1141,7 +1141,7 @@ class TestCase(object):
 
 
     def assertCountEqual(self, first, second, msg=None):
-        """An unordered sequence comparison asserting that the same elements,
+        """An unordered iterable comparison asserting the same elements,
         regardless of order.  If the same element occurs more than once,
         it verifies that the elements occur the same number of times.
 

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1141,9 +1141,8 @@ class TestCase(object):
 
 
     def assertCountEqual(self, first, second, msg=None):
-        """An unordered iterable comparison asserting the same elements,
-        regardless of order.  If the same element occurs more than once,
-        it verifies that the elements occur the same number of times.
+        """Asserts that two iterables have the same elements, the same number of
+        times, without regard to order.
 
             self.assertEqual(Counter(list(first)),
                              Counter(list(second)))


### PR DESCRIPTION
The docstring for `assertCountEqual()` says "An unordered sequence comparison," but in fact it works fine with general Iterables, since the first thing it does is make a defensive copy.  Since order does not matter, we are not indexing into the arguments, it is necessary to read all elements to make a comparison, and a defensive copy is generally a good practice, there does not seem to be a reason to forbid iterables.  That is, it is hard to imagine a situation where a list is fine but an iterable is not.  (The only potential issue is if the same iterator object is passed as both arguments, but of course that is the nature of iterators.)  This is, however, a change to the method contract and the implementation would have to remain consistent in the future.

I noticed the issue when using mypy, and typeshed has updated their stubs: https://github.com/python/typeshed/pull/1006