### PR TITLE
replace getsockaddrarg with getnameinfo in an error message in socket_getnameinfo

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -6087,7 +6087,7 @@ socket_getnameinfo(PyObject *self, PyObject *args)
         return NULL;
     if (flowinfo > 0xfffff) {
         PyErr_SetString(PyExc_OverflowError,
-                        "getsockaddrarg: flowinfo must be 0-1048575.");
+                        "getnameinfo: flowinfo must be 0-1048575.");
         return NULL;
     }
     PyOS_snprintf(pbuf, sizeof(pbuf), "%d", port);


### PR DESCRIPTION
currently an error message in `socket_getnameinfo` says the error occurred in `getsockaddrarg`, while it actually occurred in `getnameinfo`.
this patch fixes the error message.

to which versions should I backport this patch?