### PR TITLE
[2.7] Combine the C++ header CI build into the main C build (GH-697)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,15 +38,6 @@ matrix:
       script:
         - make html SPHINXOPTS="-q"
         - make check
-    - os: linux
-      language: cpp
-      compiler: clang
-      env:
-        - TESTING="C++ header compatibility"
-      before_script:
-        - ./configure
-      script:
-        - echo '#include "Python.h"' > test.cc && $CXX -c test.cc -o /dev/null -I ./Include -I .
 
 # Travis provides only 2 cores, so don't overdue the parallelism and waste memory.
 before_script:
@@ -62,6 +53,8 @@ before_script:
 script:
   # `-r -w` implicitly provided through `make buildbottest`.
   - make buildbottest TESTOPTS="-j4"
+  # Test for C++ header compatibility.
+  - echo '#include "Python.h"' > test.cc && $CXX -c test.cc -o /dev/null -I ./Include -I .
 
 notifications:
   email: false


### PR DESCRIPTION
This will eliminate one of the builds in Travis, allowing for CI overall to complete faster.
(cherry picked from commit 993d4b3440f2282976901ce66879037c4443868a)