### PR TITLE
`make tags` fixes

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1555,7 +1555,7 @@ autoconf:
 tags::
 	cd $(srcdir); \
 	ctags -w Include/*.h; \
-	for i in $(SRCDIRS); do ctags -w -a $$i/*.[ch]; \
+	for i in $(SRCDIRS); do ctags -f tags -w -a $$i/*.[ch]; \
 	done; \
 	LC_ALL=C sort -o tags tags
 

--- a/configure
+++ b/configure
@@ -16320,7 +16320,7 @@ do
 done
 
 
-SRCDIRS="Parser Grammar Objects Python Modules Mac Programs"
+SRCDIRS="Parser Objects Python Modules Programs"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for build directories" >&5
 $as_echo_n "checking for build directories... " >&6; }
 for dir in $SRCDIRS; do

--- a/configure.ac
+++ b/configure.ac
@@ -5200,7 +5200,7 @@ do
 done
 
 AC_SUBST(SRCDIRS)
-SRCDIRS="Parser Grammar Objects Python Modules Mac Programs"
+SRCDIRS="Parser Objects Python Modules Programs"
 AC_MSG_CHECKING(for build directories)
 for dir in $SRCDIRS; do
     if test ! -d $dir; then


### PR DESCRIPTION
This PR introduces 2 fixes (in corresponding commits) for `make tags`:

1. Fix warnings because of searching for C sources and headers in "Grammar" and "Mac" directories

```
ctags: Warning: cannot open source file "Grammar/*.[ch]" : No such file or directory
ctags: Warning: cannot open source file "Mac/*.[ch]" : No such file or directory
```

2. Fix failure when ctags is configured with non-default tags filename (like ".tags").

```
sort: cannot read: tags: No such file or directory
Makefile:1570: recipe for target 'tags' failed
make: *** [tags] Error 2
```