### PR TITLE
[3.5] Drop C++ header compatibility test (GH-718)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,6 @@ before_script:
 script:
   # `-r -w` implicitly provided through `make buildbottest`.
   - make buildbottest TESTOPTS="-j4"
-  # Test for C++ header compatibility.
-  - echo '#include "Python.h"' > test.cc && $CXX -c test.cc -o /dev/null -I ./Include -I .
 
 notifications:
   email: false


### PR DESCRIPTION
The $CXX environment variable is not exported under the 'c' language on Travis.
(cherry picked from commit 77ed11552da3e01dd235b7d68988076866b1f604)