### PR TITLE
bpo-29845: Mark tests that use _testcapi as CPython-only (#711)

### DIFF
--- a/Lib/ctypes/test/test_structures.py
+++ b/Lib/ctypes/test/test_structures.py
@@ -2,8 +2,8 @@ import unittest
 from ctypes import *
 from ctypes.test import need_symbol
 from struct import calcsize
-import _testcapi
 import _ctypes_test
+import test.support
 
 class SubclassesTest(unittest.TestCase):
     def test_subclass(self):
@@ -202,7 +202,10 @@ class StructureTestCase(unittest.TestCase):
              "_pack_": -1}
         self.assertRaises(ValueError, type(Structure), "X", (Structure,), d)
 
+    @test.support.cpython_only
+    def test_packed_c_limits(self):
         # Issue 15989
+        import _testcapi
         d = {"_fields_": [("a", c_byte)],
              "_pack_": _testcapi.INT_MAX + 1}
         self.assertRaises(ValueError, type(Structure), "X", (Structure,), d)

--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -143,6 +143,7 @@ class GeneralTest(unittest.TestCase):
         self.assertEqual(l, [5])
 
 
+@support.cpython_only
 class SubinterpreterTest(unittest.TestCase):
 
     def test_callbacks_leak(self):

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -1772,6 +1772,7 @@ class SysSetCoroWrapperTest(unittest.TestCase):
             sys.set_coroutine_wrapper(None)
 
 
+@support.cpython_only
 class CAPITest(unittest.TestCase):
 
     def test_tp_await_1(self):

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -876,6 +876,7 @@ class GeneralModuleTests(unittest.TestCase):
             self.assertEqual(swapped & mask, mask)
             self.assertRaises(OverflowError, func, 1<<34)
 
+    @support.cpython_only
     def testNtoHErrors(self):
         good_values = [ 1, 2, 3, 1, 2, 3 ]
         bad_values = [ -1, -2, -3, -1, -2, -3 ]

--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -809,7 +809,7 @@ class TestCommandLine(unittest.TestCase):
                                   b'number of frames',
                                   stderr)
 
-    @unittest.skipIf(_testcapi is None, 'need _testcapi')
+    @support.cpython_only
     def test_pymem_alloc0(self):
         # Issue #21639: Check that PyMem_Malloc(0) with tracemalloc enabled
         # does not crash.

--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -809,6 +809,7 @@ class TestCommandLine(unittest.TestCase):
                                   b'number of frames',
                                   stderr)
 
+    @unittest.skipIf(_testcapi is None, 'need _testcapi')
     def test_pymem_alloc0(self):
         # Issue #21639: Check that PyMem_Malloc(0) with tracemalloc enabled
         # does not crash.


### PR DESCRIPTION
(cherry picked from commit 24c738a9e91b8f46da6166663d8ce7ec18cec784)