### PR TITLE
gh-59795: distinct python-config from pkg-config python

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -102,6 +102,9 @@ LDLAST=		@LDLAST@
 SGI_ABI=	@SGI_ABI@
 CCSHARED=	@CCSHARED@
 LINKFORSHARED=	@LINKFORSHARED@
+BLINKFORSHARED=	@BLINKFORSHARED@
+LINKFORMODULE=	@LINKFORMODULE@
+BLINKFORMODULE=	@BLINKFORMODULE@
 ARFLAGS=	@ARFLAGS@
 # Extra C flags added for building the interpreter object files.
 CFLAGSFORSHARED=@CFLAGSFORSHARED@
@@ -337,6 +340,11 @@ ASDLGEN=	$(PYTHON_FOR_GEN) $(srcdir)/Parser/asdl_c.py
 ##########################################################################
 # Python
 
+PYCONFIGFILES = \
+		Misc/python.pc \
+		Misc/python-config.sh \
+		Misc/python-config
+
 OPCODETARGETS_H= \
 		Python/opcode_targets.h
 
@@ -472,7 +480,7 @@ DTRACE_DEPS = \
 
 # Default target
 all:		@DEF_MAKE_ALL_RULE@
-build_all:	$(BUILDPYTHON) oldsharedmods sharedmods gdbhooks Programs/_testembed python-config
+build_all:	$(BUILDPYTHON) oldsharedmods sharedmods gdbhooks Programs/_testembed $(PYCONFIGFILES)
 
 # Compile a binary with profile guided optimization.
 profile-opt:
@@ -566,7 +574,7 @@ clinic: $(BUILDPYTHON) $(srcdir)/Modules/_blake2/blake2s_impl.c
 
 # Build the interpreter
 $(BUILDPYTHON):	Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
-	$(LINKCC) $(PY_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST)
+	$(LINKCC) $(PY_LDFLAGS) $(BLINKFORSHARED) -o $@ Programs/python.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST)
 
 platform: $(BUILDPYTHON) pybuilddir.txt
 	$(RUNSHARED) $(PYTHON_FOR_BUILD) -c 'import sys ; from sysconfig import get_platform ; print("%s-%d.%d" % (get_platform(), *sys.version_info[:2]))' >platform
@@ -638,7 +646,7 @@ libpython$(LDVERSION).dylib: $(LIBRARY_OBJS)
 
 
 libpython$(VERSION).sl: $(LIBRARY_OBJS)
-	$(LDSHARED) -o $@ $(LIBRARY_OBJS) $(MODLIBS) $(SHLIBS) $(LIBC) $(LIBM) $(LDLAST)
+	$(BLDSHARED) -o $@ $(LIBRARY_OBJS) $(MODLIBS) $(SHLIBS) $(LIBC) $(LIBM) $(LDLAST)
 
 # Copy up the gdb python hooks into a position where they can be automatically
 # loaded by gdb during Lib/test/test_gdb.py
@@ -677,7 +685,7 @@ $(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK): \
 # for a shared core library; otherwise, this rule is a noop.
 $(DLLLIBRARY) libpython$(LDVERSION).dll.a: $(LIBRARY_OBJS)
 	if test -n "$(DLLLIBRARY)"; then \
-		$(LDSHARED) -Wl,--out-implib=$@ -o $(DLLLIBRARY) $^ \
+		$(BLDSHARED) -Wl,--out-implib=$@ -o $(DLLLIBRARY) $^ \
 			$(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST); \
 	else true; \
 	fi
@@ -712,7 +720,7 @@ Modules/Setup: $(srcdir)/Modules/Setup.dist
 	fi
 
 Programs/_testembed: Programs/_testembed.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
-	$(LINKCC) $(PY_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/_testembed.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST)
+	$(LINKCC) $(PY_LDFLAGS) $(BLINKFORSHARED) -o $@ Programs/_testembed.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST)
 
 ############################################################################
 # Importlib
@@ -1341,18 +1349,18 @@ libinstall:	build_all $(srcdir)/Modules/xxmodule.c
 	-PYTHONPATH=$(DESTDIR)$(LIBDEST) $(RUNSHARED) \
 		$(PYTHON_FOR_BUILD) -m lib2to3.pgen2.driver $(DESTDIR)$(LIBDEST)/lib2to3/PatternGrammar.txt
 
-python-config: $(srcdir)/Misc/python-config.in Misc/python-config.sh
-	@ # Substitution happens here, as the completely-expanded BINDIR
-	@ # is not available in configure
-	sed -e "s,@EXENAME@,$(BINDIR)/python$(LDVERSION)$(EXE)," < $(srcdir)/Misc/python-config.in >python-config.py
-	@ # Replace makefile compat. variable references with shell script compat. ones; $(VAR) -> ${VAR}
-	LC_ALL=C sed -e 's,\$$(\([A-Za-z0-9_]*\)),\$$\{\1\},g' < Misc/python-config.sh >python-config
-	@ # On Darwin, always use the python version of the script, the shell
-	@ # version doesn't use the compiler customizations that are provided
-	@ # in python (_osx_support.py).
-	@if test `uname -s` = Darwin; then \
-		cp python-config.py python-config; \
-	fi
+Misc/python.pc: $(srcdir)/Misc/python.pc.in
+Misc/python-config: $(srcdir)/Misc/python-config.in
+Misc/python-config.sh: $(srcdir)/Misc/python-config.sh.in
+
+# Besides a common subset, both sysconfig and config.status provide variables
+# not known to the other. While config.status provides the configured values,
+# sysconfig provides values with variable-references resolved already:
+# Substitute sysconfig values first, and remaining ones with config.status.
+$(PYCONFIGFILES): $(BUILDPYTHON) pybuilddir.txt
+	$(RUNSHARED) $(PYTHON_FOR_BUILD) -S -m sysconfig \
+	  --generate-config-file --file=-:$(srcdir)/$@.in | \
+	  $(SHELL) config.status --file=$@:-
 
 
 # Install the include files
@@ -1380,7 +1388,7 @@ LIBPL=		@LIBPL@
 # pkgconfig directory
 LIBPC=		$(LIBDIR)/pkgconfig
 
-libainstall:	all python-config
+libainstall:	all $(PYCONFIGFILES)
 	@for i in $(LIBDIR) $(LIBPL) $(LIBPC); \
 	do \
 		if test ! -d $(DESTDIR)$$i; then \
@@ -1411,8 +1419,14 @@ libainstall:	all python-config
 	$(INSTALL_DATA) Misc/python.pc $(DESTDIR)$(LIBPC)/python-$(VERSION).pc
 	$(INSTALL_SCRIPT) $(srcdir)/Modules/makesetup $(DESTDIR)$(LIBPL)/makesetup
 	$(INSTALL_SCRIPT) $(srcdir)/install-sh $(DESTDIR)$(LIBPL)/install-sh
-	$(INSTALL_SCRIPT) python-config.py $(DESTDIR)$(LIBPL)/python-config.py
-	$(INSTALL_SCRIPT) python-config $(DESTDIR)$(BINDIR)/python$(LDVERSION)-config
+	$(INSTALL_SCRIPT) Misc/python-config $(DESTDIR)$(LIBPL)/python-config.py
+	$(INSTALL_SCRIPT) Misc/python-config.sh $(DESTDIR)$(BINDIR)/python$(LDVERSION)-config
+	# On Darwin, always use the python version of the script, the shell
+	# version doesn't use the compiler customizations that are provided
+	# in python (_osx_support.py).
+	if test `uname -s` = Darwin; then \
+		$(INSTALL_SCRIPT) Misc/python-config $(DESTDIR)$(BINDIR)/python$(LDVERSION)-config; \
+	fi
 	@if [ -s Modules/python.exp -a \
 		"`echo $(MACHDEP) | sed 's/^\(...\).*/\1/'`" = "aix" ]; then \
 		echo; echo "Installing support files for building shared extension modules on AIX:"; \
@@ -1616,7 +1630,7 @@ clobber: clean profile-removal
 		config.cache config.log pyconfig.h Modules/config.c
 	-rm -rf build platform
 	-rm -rf $(PYTHONFRAMEWORKDIR)
-	-rm -f python-config.py python-config
+	-rm -f $(PYCONFIGFILES)
 
 # Make things extra clean, before making a distribution:
 # remove all generated files, even Makefile[.pre]
@@ -1627,7 +1641,7 @@ distclean: clobber
 	done
 	-rm -f core Makefile Makefile.pre config.status \
 		Modules/Setup Modules/Setup.local Modules/Setup.config \
-		Modules/ld_so_aix Modules/python.exp Misc/python.pc
+		Modules/ld_so_aix Modules/python.exp
 	-rm -f python*-gdb.py
 	# Issue #28258: set LC_ALL to avoid issues with Estonian locale.
 	# Expansion is performed here by shell (spawned by make) itself before

--- a/Misc/python-config.in
+++ b/Misc/python-config.in
@@ -1,4 +1,4 @@
-#!@EXENAME@
+#!@BINDIR@/python@LDVERSION@@EXE@
 # -*- python -*-
 
 # Keep this script in sync with python-config.sh.in
@@ -47,16 +47,9 @@ for opt in opt_flags:
         print(' '.join(flags))
 
     elif opt in ('--libs', '--ldflags'):
-        libs = ['-lpython' + pyver + sys.abiflags]
-        libs += getvar('LIBS').split()
-        libs += getvar('SYSLIBS').split()
-        # add the prefix/lib/pythonX.Y/config dir, but only if there is no
-        # shared library in prefix/lib/.
+        # no libs for modules
         if opt == '--ldflags':
-            if not getvar('Py_ENABLE_SHARED'):
-                libs.insert(0, '-L' + getvar('LIBPL'))
-            if not getvar('PYTHONFRAMEWORK'):
-                libs.extend(getvar('LINKFORSHARED').split())
+            libs.extend(getvar('LINKFORMODULE').split())
         print(' '.join(libs))
 
     elif opt == '--extension-suffix':

--- a/Misc/python-config.sh.in
+++ b/Misc/python-config.sh.in
@@ -40,10 +40,9 @@ LIBM="@LIBM@"
 LIBC="@LIBC@"
 SYSLIBS="$LIBM $LIBC"
 ABIFLAGS="@ABIFLAGS@"
-LIBS="-lpython${VERSION}${ABIFLAGS} @LIBS@ $SYSLIBS"
 BASECFLAGS="@BASECFLAGS@"
 LDLIBRARY="@LDLIBRARY@"
-LINKFORSHARED="@LINKFORSHARED@"
+LINKFORMODULE="@LINKFORMODULE@"
 OPT="@OPT@"
 PY_ENABLE_SHARED="@PY_ENABLE_SHARED@"
 LDVERSION="@LDVERSION@"
@@ -85,18 +84,10 @@ do
             echo "$INCDIR $PLATINCDIR $BASECFLAGS $CFLAGS $OPT"
         ;;
         --libs)
-            echo "$LIBS"
+            # no libs for modules
         ;;
         --ldflags)
-            LINKFORSHAREDUSED=
-            if [ -z "$PYTHONFRAMEWORK" ] ; then
-                LINKFORSHAREDUSED=$LINKFORSHARED
-            fi
-            LIBPLUSED=
-            if [ "$PY_ENABLE_SHARED" = "0" ] ; then
-                LIBPLUSED="-L$LIBPL"
-            fi
-            echo "$LIBPLUSED -L$libdir $LIBS $LINKFORSHAREDUSED"
+            echo "$LINKFORMODULE"
         ;;
         --extension-suffix)
             echo "$SO"

--- a/Misc/python.pc.in
+++ b/Misc/python.pc.in
@@ -9,5 +9,5 @@ Description: Python library
 Requires: 
 Version: @VERSION@
 Libs.private: @LIBS@
-Libs: -L${libdir} -lpython@VERSION@@ABIFLAGS@
+Libs: -L${libdir} -lpython@VERSION@@ABIFLAGS@ @LINKFORSHARED@
 Cflags: -I${includedir}/python@VERSION@@ABIFLAGS@

--- a/configure
+++ b/configure
@@ -657,6 +657,9 @@ PKG_CONFIG_PATH
 PKG_CONFIG
 SHLIBS
 CFLAGSFORSHARED
+BLINKFORMODULE
+LINKFORMODULE
+BLINKFORSHARED
 LINKFORSHARED
 CCSHARED
 BLDSHARED
@@ -9156,7 +9159,6 @@ esac
 
 
 
-
 # SHLIB_SUFFIX is the extension of shared libraries `(including the dot!)
 # -- usually .so, .sl on HP-UX, .dll on Cygwin
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking the extension of shared libraries" >&5
@@ -9186,11 +9188,11 @@ if test -z "$LDSHARED"
 then
 	case $ac_sys_system/$ac_sys_release in
 	AIX*)
-		BLDSHARED="Modules/ld_so_aix \$(CC) -bI:Modules/python.exp"
-		LDSHARED="\$(LIBPL)/ld_so_aix \$(CC) -bI:\$(LIBPL)/python.exp"
+		BLDSHARED="Modules/ld_so_aix \$(CC)"; BLINKFORMODULE="-Wl,-bI:Modules/python.exp"
+		LDSHARED="\$(LIBPL)/ld_so_aix \$(CC)"; LINKFORMODULE="-Wl,-bI:\$(LIBPL)/python.exp"
 		;;
 	IRIX/5*) LDSHARED="ld -shared";;
-	IRIX*/6*) LDSHARED="ld ${SGI_ABI} -shared -all";;
+	IRIX*/6*) LDSHARED="ld ${SGI_ABI} -shared"; LINKFORMODULE="-all";;
 	SunOS/5*)
 		if test "$GCC" = "yes" ; then
 			LDSHARED='$(CC) -shared'
@@ -9211,32 +9213,30 @@ then
 		LDCXXSHARED='$(CXX) -bundle'
 		if test "$enable_framework" ; then
 			# Link against the framework. All externals should be defined.
-			BLDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-			LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-			LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+			BLINKFORMODULE='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+			LINKFORMODULE='$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 		else
 			# No framework. Ignore undefined symbols, assuming they come from Python
-			LDSHARED="$LDSHARED -undefined suppress"
-			LDCXXSHARED="$LDCXXSHARED -undefined suppress"
+			LINKFORMODULE="-undefined suppress"
 		fi ;;
 	Darwin/1.4*|Darwin/5.*|Darwin/6.*)
 		LDSHARED='$(CC) -bundle'
 		LDCXXSHARED='$(CXX) -bundle'
 		if test "$enable_framework" ; then
 			# Link against the framework. All externals should be defined.
-			BLDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-			LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-			LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+			BLINKFORMODULE='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+			LINKFORMODULE='$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 		else
 			# No framework, use the Python app as bundle-loader
-			BLDSHARED="$LDSHARED "'-bundle_loader $(BUILDPYTHON)'
-			LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
-			LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+			BLINKFORMODULE='-bundle_loader $(BUILDPYTHON)'
+			LINKFORMODULE='-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
 		fi ;;
 	Darwin/*)
 		# Use -undefined dynamic_lookup whenever possible (10.3 and later).
 		# This allows an extension to be used in any Python
 
+		LDSHARED='$(CC) -bundle'
+		LDCXXSHARED='$(CXX) -bundle'
 		dep_target_major=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
 				sed 's/\([0-9]*\)\.\([0-9]*\).*/\1/'`
 		dep_target_minor=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
@@ -9249,20 +9249,16 @@ then
 			LDCXXSHARED='$(CXX) -bundle'
 			if test "$enable_framework" ; then
 				# Link against the framework. All externals should be defined.
-				BLDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-				LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-				LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+				BLINKFORMODULE='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+				LINKFORMODULE='$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 			else
 				# No framework, use the Python app as bundle-loader
-				BLDSHARED="$LDSHARED "'-bundle_loader $(BUILDPYTHON)'
-				LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
-				LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+				BLINKFORMODULE='-bundle_loader $(BUILDPYTHON)'
+				LINKFORMODULE='-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
 			fi
 		else
 			# building for OS X 10.3 and later
-			LDSHARED='$(CC) -bundle -undefined dynamic_lookup'
-			LDCXXSHARED='$(CXX) -bundle -undefined dynamic_lookup'
-			BLDSHARED="$LDSHARED"
+			LINKFORMODULE='-undefined dynamic_lookup'
 		fi
 		;;
 	Linux*|GNU*|QNX*)
@@ -9282,16 +9278,16 @@ then
 	OpenBSD*)
 		if [ "`$CC -dM -E - </dev/null | grep __ELF__`" != "" ]
 		then
-				LDSHARED='$(CC) -shared $(CCSHARED)'
-				LDCXXSHARED='$(CXX) -shared $(CCSHARED)'
+				LDSHARED='$(CC) -shared'; LINKFORMODULE='$(CCSHARED)'
+				LDCXXSHARED='$(CXX) -shared'
 		else
 				case `uname -r` in
 				[01].* | 2.[0-7] | 2.[0-7].*)
-				   LDSHARED="ld -Bshareable ${LDFLAGS}"
+				   LDSHARED="ld -Bshareable"; LINKFORMODULE="${LDFLAGS}"
 				   ;;
 				*)
-				   LDSHARED='$(CC) -shared $(CCSHARED)'
-				   LDCXXSHARED='$(CXX) -shared $(CCSHARED)'
+				   LDSHARED='$(CC) -shared'; LINKFORMODULE='$(CCSHARED)'
+				   LDCXXSHARED='$(CXX) -shared'
 				   ;;
 				esac
 		fi;;
@@ -9307,18 +9303,20 @@ then
 			LDCXXSHARED='$(CXX) -G'
 		fi;;
 	SCO_SV*)
-		LDSHARED='$(CC) -Wl,-G,-Bexport'
-		LDCXXSHARED='$(CXX) -Wl,-G,-Bexport';;
+		LDSHARED='$(CC) -Wl,-G'; LINKFORMODULE='-Wl,-Bexport'
+		LDCXXSHARED='$(CXX) -Wl,-G';;
 	CYGWIN*)
-		LDSHARED="gcc -shared -Wl,--enable-auto-image-base"
-		LDCXXSHARED="g++ -shared -Wl,--enable-auto-image-base";;
+		LDSHARED="gcc -shared"; LINKFORMODULE="-Wl,--enable-auto-image-base"
+		LDCXXSHARED="g++ -shared";;
 	*)	LDSHARED="ld";;
 	esac
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $LDSHARED" >&5
-$as_echo "$LDSHARED" >&6; }
-LDCXXSHARED=${LDCXXSHARED-$LDSHARED}
-BLDSHARED=${BLDSHARED-$LDSHARED}
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $LDSHARED $LINKFORMODULE" >&5
+$as_echo "$LDSHARED $LINKFORMODULE" >&6; }
+BLINKFORMODULE=${BLINKFORMODULE-$LINKFORMODULE}
+BLDSHARED="${BLDSHARED-$LDSHARED} \$(BLINKFORMODULE)"
+LDCXXSHARED="${LDCXXSHARED-$LDSHARED} \$(LINKFORMODULE)"
+LDSHARED="$LDSHARED \$(LINKFORMODULE)"
 # CCSHARED are the C *flags* used to create objects to go into a shared
 # library (module) -- this is only needed for a few systems
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking CCSHARED" >&5
@@ -9360,12 +9358,15 @@ fi
 $as_echo "$CCSHARED" >&6; }
 # LINKFORSHARED are the flags passed to the $(CC) command that links
 # the python executable -- this is only needed for a few systems
+# Make-targets using $(LINKFORSHARED) need to depend on $(EXPORTSYMS) for AIX.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking LINKFORSHARED" >&5
 $as_echo_n "checking LINKFORSHARED... " >&6; }
 if test -z "$LINKFORSHARED"
 then
 	case $ac_sys_system/$ac_sys_release in
-	AIX*)	LINKFORSHARED='-Wl,-bE:Modules/python.exp -lld';;
+	AIX*)
+	    BLINKFORSHARED='-Wl,-bE:Modules/python.exp -lld'
+	    LINKFORSHARED='-Wl,-bE:$(LIBPL)/python.exp -lld';;
 	hp*|HP*)
 	    LINKFORSHARED="-Wl,-E -Wl,+s";;
 #	    LINKFORSHARED="-Wl,-E -Wl,+s -Wl,+b\$(BINLIBDEST)/lib-dynload";;
@@ -9417,6 +9418,7 @@ then
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $LINKFORSHARED" >&5
 $as_echo "$LINKFORSHARED" >&6; }
+BLINKFORSHARED=${BLINKFORSHARED-$LINKFORSHARED}
 
 
 
@@ -16660,7 +16662,7 @@ $as_echo "#define HAVE_GETRANDOM 1" >>confdefs.h
 fi
 
 # generate output files
-ac_config_files="$ac_config_files Makefile.pre Modules/Setup.config Misc/python.pc Misc/python-config.sh"
+ac_config_files="$ac_config_files Makefile.pre Modules/Setup.config"
 
 ac_config_files="$ac_config_files Modules/ld_so_aix"
 
@@ -17363,8 +17365,6 @@ do
     "Mac/Resources/app/Info.plist") CONFIG_FILES="$CONFIG_FILES Mac/Resources/app/Info.plist" ;;
     "Makefile.pre") CONFIG_FILES="$CONFIG_FILES Makefile.pre" ;;
     "Modules/Setup.config") CONFIG_FILES="$CONFIG_FILES Modules/Setup.config" ;;
-    "Misc/python.pc") CONFIG_FILES="$CONFIG_FILES Misc/python.pc" ;;
-    "Misc/python-config.sh") CONFIG_FILES="$CONFIG_FILES Misc/python-config.sh" ;;
     "Modules/ld_so_aix") CONFIG_FILES="$CONFIG_FILES Modules/ld_so_aix" ;;
 
   *) as_fn_error $? "invalid argument: \`$ac_config_target'" "$LINENO" 5;;

--- a/configure.ac
+++ b/configure.ac
@@ -2391,7 +2391,10 @@ AC_SUBST(LDSHARED)
 AC_SUBST(LDCXXSHARED)
 AC_SUBST(BLDSHARED)
 AC_SUBST(CCSHARED)
-AC_SUBST(LINKFORSHARED)
+AC_SUBST(LINKFORSHARED)dnl  how to link Python interpreter into an executable
+AC_SUBST(BLINKFORSHARED)dnl same at Python buildtime
+AC_SUBST(LINKFORMODULE)dnl  where a module gets the Python symbols from,
+AC_SUBST(BLINKFORMODULE)dnl same at Python buildtime
 
 # SHLIB_SUFFIX is the extension of shared libraries `(including the dot!)
 # -- usually .so, .sl on HP-UX, .dll on Cygwin
@@ -2419,11 +2422,11 @@ if test -z "$LDSHARED"
 then
 	case $ac_sys_system/$ac_sys_release in
 	AIX*)
-		BLDSHARED="Modules/ld_so_aix \$(CC) -bI:Modules/python.exp"
-		LDSHARED="\$(LIBPL)/ld_so_aix \$(CC) -bI:\$(LIBPL)/python.exp"
+		BLDSHARED="Modules/ld_so_aix \$(CC)"; BLINKFORMODULE="-Wl,-bI:Modules/python.exp"
+		LDSHARED="\$(LIBPL)/ld_so_aix \$(CC)"; LINKFORMODULE="-Wl,-bI:\$(LIBPL)/python.exp"
 		;;
 	IRIX/5*) LDSHARED="ld -shared";;
-	IRIX*/6*) LDSHARED="ld ${SGI_ABI} -shared -all";;
+	IRIX*/6*) LDSHARED="ld ${SGI_ABI} -shared"; LINKFORMODULE="-all";;
 	SunOS/5*)
 		if test "$GCC" = "yes" ; then
 			LDSHARED='$(CC) -shared'
@@ -2444,32 +2447,30 @@ then
 		LDCXXSHARED='$(CXX) -bundle'
 		if test "$enable_framework" ; then
 			# Link against the framework. All externals should be defined.
-			BLDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-			LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-			LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+			BLINKFORMODULE='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+			LINKFORMODULE='$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 		else
 			# No framework. Ignore undefined symbols, assuming they come from Python
-			LDSHARED="$LDSHARED -undefined suppress"
-			LDCXXSHARED="$LDCXXSHARED -undefined suppress"
+			LINKFORMODULE="-undefined suppress"
 		fi ;;
 	Darwin/1.4*|Darwin/5.*|Darwin/6.*)
 		LDSHARED='$(CC) -bundle'
 		LDCXXSHARED='$(CXX) -bundle'
 		if test "$enable_framework" ; then
 			# Link against the framework. All externals should be defined.
-			BLDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-			LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-			LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+			BLINKFORMODULE='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+			LINKFORMODULE='$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 		else
 			# No framework, use the Python app as bundle-loader
-			BLDSHARED="$LDSHARED "'-bundle_loader $(BUILDPYTHON)'
-			LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
-			LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+			BLINKFORMODULE='-bundle_loader $(BUILDPYTHON)'
+			LINKFORMODULE='-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
 		fi ;;
 	Darwin/*)
 		# Use -undefined dynamic_lookup whenever possible (10.3 and later).
 		# This allows an extension to be used in any Python
 
+		LDSHARED='$(CC) -bundle'
+		LDCXXSHARED='$(CXX) -bundle'
 		dep_target_major=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
 				sed 's/\([[0-9]]*\)\.\([[0-9]]*\).*/\1/'`
 		dep_target_minor=`echo ${MACOSX_DEPLOYMENT_TARGET} | \
@@ -2482,20 +2483,16 @@ then
 			LDCXXSHARED='$(CXX) -bundle'
 			if test "$enable_framework" ; then
 				# Link against the framework. All externals should be defined.
-				BLDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-				LDSHARED="$LDSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
-				LDCXXSHARED="$LDCXXSHARED "'$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+				BLINKFORMODULE='$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
+				LINKFORMODULE='$(PYTHONFRAMEWORKPREFIX)/$(PYTHONFRAMEWORKDIR)/Versions/$(VERSION)/$(PYTHONFRAMEWORK)'
 			else
 				# No framework, use the Python app as bundle-loader
-				BLDSHARED="$LDSHARED "'-bundle_loader $(BUILDPYTHON)'
-				LDSHARED="$LDSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
-				LDCXXSHARED="$LDCXXSHARED "'-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
+				BLINKFORMODULE='-bundle_loader $(BUILDPYTHON)'
+				LINKFORMODULE='-bundle_loader $(BINDIR)/python$(VERSION)$(EXE)'
 			fi
 		else
 			# building for OS X 10.3 and later
-			LDSHARED='$(CC) -bundle -undefined dynamic_lookup'
-			LDCXXSHARED='$(CXX) -bundle -undefined dynamic_lookup'
-			BLDSHARED="$LDSHARED"
+			LINKFORMODULE='-undefined dynamic_lookup'
 		fi
 		;;
 	Linux*|GNU*|QNX*)
@@ -2515,16 +2512,16 @@ then
 	OpenBSD*)
 		if [[ "`$CC -dM -E - </dev/null | grep __ELF__`" != "" ]]
 		then
-				LDSHARED='$(CC) -shared $(CCSHARED)'
-				LDCXXSHARED='$(CXX) -shared $(CCSHARED)'
+				LDSHARED='$(CC) -shared'; LINKFORMODULE='$(CCSHARED)'
+				LDCXXSHARED='$(CXX) -shared'
 		else
 				case `uname -r` in
 				[[01]].* | 2.[[0-7]] | 2.[[0-7]].*)
-				   LDSHARED="ld -Bshareable ${LDFLAGS}"
+				   LDSHARED="ld -Bshareable"; LINKFORMODULE="${LDFLAGS}"
 				   ;;
 				*)
-				   LDSHARED='$(CC) -shared $(CCSHARED)'
-				   LDCXXSHARED='$(CXX) -shared $(CCSHARED)'
+				   LDSHARED='$(CC) -shared'; LINKFORMODULE='$(CCSHARED)'
+				   LDCXXSHARED='$(CXX) -shared'
 				   ;;
 				esac
 		fi;;
@@ -2540,17 +2537,19 @@ then
 			LDCXXSHARED='$(CXX) -G'
 		fi;;
 	SCO_SV*)
-		LDSHARED='$(CC) -Wl,-G,-Bexport'
-		LDCXXSHARED='$(CXX) -Wl,-G,-Bexport';;
+		LDSHARED='$(CC) -Wl,-G'; LINKFORMODULE='-Wl,-Bexport'
+		LDCXXSHARED='$(CXX) -Wl,-G';;
 	CYGWIN*)
-		LDSHARED="gcc -shared -Wl,--enable-auto-image-base"
-		LDCXXSHARED="g++ -shared -Wl,--enable-auto-image-base";;
+		LDSHARED="gcc -shared"; LINKFORMODULE="-Wl,--enable-auto-image-base"
+		LDCXXSHARED="g++ -shared";;
 	*)	LDSHARED="ld";;
 	esac
 fi
-AC_MSG_RESULT($LDSHARED)
-LDCXXSHARED=${LDCXXSHARED-$LDSHARED}
-BLDSHARED=${BLDSHARED-$LDSHARED}
+AC_MSG_RESULT($LDSHARED $LINKFORMODULE)
+BLINKFORMODULE=${BLINKFORMODULE-$LINKFORMODULE}
+BLDSHARED="${BLDSHARED-$LDSHARED} \$(BLINKFORMODULE)"
+LDCXXSHARED="${LDCXXSHARED-$LDSHARED} \$(LINKFORMODULE)"
+LDSHARED="$LDSHARED \$(LINKFORMODULE)"
 # CCSHARED are the C *flags* used to create objects to go into a shared
 # library (module) -- this is only needed for a few systems
 AC_MSG_CHECKING(CCSHARED)
@@ -2590,11 +2589,14 @@ fi
 AC_MSG_RESULT($CCSHARED)
 # LINKFORSHARED are the flags passed to the $(CC) command that links
 # the python executable -- this is only needed for a few systems
+# Make-targets using $(LINKFORSHARED) need to depend on $(EXPORTSYMS) for AIX.
 AC_MSG_CHECKING(LINKFORSHARED)
 if test -z "$LINKFORSHARED"
 then
 	case $ac_sys_system/$ac_sys_release in
-	AIX*)	LINKFORSHARED='-Wl,-bE:Modules/python.exp -lld';;
+	AIX*)
+	    BLINKFORSHARED='-Wl,-bE:Modules/python.exp -lld'
+	    LINKFORSHARED='-Wl,-bE:$(LIBPL)/python.exp -lld';;
 	hp*|HP*)
 	    LINKFORSHARED="-Wl,-E -Wl,+s";;
 #	    LINKFORSHARED="-Wl,-E -Wl,+s -Wl,+b\$(BINLIBDEST)/lib-dynload";;
@@ -2645,6 +2647,7 @@ then
 	esac
 fi
 AC_MSG_RESULT($LINKFORSHARED)
+BLINKFORSHARED=${BLINKFORSHARED-$LINKFORSHARED}
 
 
 AC_SUBST(CFLAGSFORSHARED)
@@ -5420,7 +5423,7 @@ if test "$have_getrandom" = yes; then
 fi
 
 # generate output files
-AC_CONFIG_FILES(Makefile.pre Modules/Setup.config Misc/python.pc Misc/python-config.sh)
+AC_CONFIG_FILES(Makefile.pre Modules/Setup.config)
 AC_CONFIG_FILES([Modules/ld_so_aix], [chmod +x Modules/ld_so_aix])
 AC_OUTPUT
 


### PR DESCRIPTION
Fix output of 'python-config' for creating loadable Python modules.
Fix output of 'pkg-config python' for linking against the interpreter.

<!-- gh-issue-number: gh-59795 -->
* Issue: gh-59795
<!-- /gh-issue-number -->
