### PR TITLE
Fix "NotImplentedError" typo in constants documentation (#692)

### DIFF
--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -46,7 +46,7 @@ A small number of constants live in the built-in namespace.  They are:
 
    .. note::
 
-      ``NotImplentedError`` and ``NotImplemented`` are not interchangeable,
+      ``NotImplementedError`` and ``NotImplemented`` are not interchangeable,
       even though they have similar names and purposes.
       See :exc:`NotImplementedError` for details on when to use it.
 


### PR DESCRIPTION
`NotImplentedError` --> `NotImplementedError`
(cherry picked from commit 05f53735c8912f8df1077e897f052571e13c3496)