### PR TITLE
bpo-29734: nt._getfinalpathname  handle leak

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2325,7 +2325,63 @@ class Win32JunctionTests(unittest.TestCase):
         os.unlink(self.junction)
         self.assertFalse(os.path.exists(self.junction))
 
+@unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
+class Win32NtTests(unittest.TestCase):
+    def setUp(self):
+        from test import support
+        self.nt = support.import_module('nt')
+        pass
+    
+    def tearDown(self):
+        pass
 
+    def test_getfinalpathname_handles(self):
+        try:
+            import ctypes, ctypes.wintypes
+        except ImportError:
+            raise unittest.SkipTest('ctypes module is required for this test')
+        
+        kernel = ctypes.WinDLL('Kernel32.dll', use_last_error=True)
+        kernel.GetCurrentProcess.restype = ctypes.wintypes.HANDLE
+        
+        kernel.GetProcessHandleCount.restype = ctypes.wintypes.BOOL
+        kernel.GetProcessHandleCount.argtypes = (ctypes.wintypes.HANDLE,
+                                                 ctypes.wintypes.LPDWORD)
+        
+        # This is a pseudo-handle that doesn't need to be closed
+        hproc = kernel.GetCurrentProcess()
+        
+        handle_count = ctypes.wintypes.DWORD()
+        ok = kernel.GetProcessHandleCount(hproc, ctypes.byref(handle_count))
+        self.assertEqual(1, ok)
+        
+        before_count = handle_count.value
+        
+        # The first two test the error path, __file__ tests the success path
+        filenames = [ r'\\?\C:', 
+                      r'\\?\NUL', 
+                      r'\\?\CONIN',
+                      __file__ ]
+        
+        for i in range(10):
+            for name in filenames:
+                try:
+                    tmp = self.nt._getfinalpathname(name)
+                except:
+                    # Failure is expected
+                    pass
+                try:
+                    tmp = os.stat(name)
+                except:
+                    pass
+        
+        ok = kernel.GetProcessHandleCount(hproc, ctypes.byref(handle_count))
+        self.assertEqual(1, ok)
+        
+        handle_delta = handle_count.value - before_count
+
+        self.assertEqual(0, handle_delta)        
+    
 @support.skip_unless_symlink
 class NonLocalSymlinkTests(unittest.TestCase):
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2331,7 +2331,7 @@ class Win32NtTests(unittest.TestCase):
         from test import support
         self.nt = support.import_module('nt')
         pass
-    
+
     def tearDown(self):
         pass
 
@@ -2340,29 +2340,29 @@ class Win32NtTests(unittest.TestCase):
             import ctypes, ctypes.wintypes
         except ImportError:
             raise unittest.SkipTest('ctypes module is required for this test')
-        
+
         kernel = ctypes.WinDLL('Kernel32.dll', use_last_error=True)
         kernel.GetCurrentProcess.restype = ctypes.wintypes.HANDLE
-        
+
         kernel.GetProcessHandleCount.restype = ctypes.wintypes.BOOL
         kernel.GetProcessHandleCount.argtypes = (ctypes.wintypes.HANDLE,
                                                  ctypes.wintypes.LPDWORD)
-        
+
         # This is a pseudo-handle that doesn't need to be closed
         hproc = kernel.GetCurrentProcess()
-        
+
         handle_count = ctypes.wintypes.DWORD()
         ok = kernel.GetProcessHandleCount(hproc, ctypes.byref(handle_count))
         self.assertEqual(1, ok)
-        
+
         before_count = handle_count.value
-        
+
         # The first two test the error path, __file__ tests the success path
-        filenames = [ r'\\?\C:', 
-                      r'\\?\NUL', 
+        filenames = [ r'\\?\C:',
+                      r'\\?\NUL',
                       r'\\?\CONIN',
                       __file__ ]
-        
+
         for i in range(10):
             for name in filenames:
                 try:
@@ -2374,14 +2374,14 @@ class Win32NtTests(unittest.TestCase):
                     tmp = os.stat(name)
                 except:
                     pass
-        
+
         ok = kernel.GetProcessHandleCount(hproc, ctypes.byref(handle_count))
         self.assertEqual(1, ok)
-        
+
         handle_delta = handle_count.value - before_count
 
-        self.assertEqual(0, handle_delta)        
-    
+        self.assertEqual(0, handle_delta)
+
 @support.skip_unless_symlink
 class NonLocalSymlinkTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Windows/2019-01-12-16-52-38.bpo-29734.6_OJwI.rst
+++ b/Misc/NEWS.d/next/Windows/2019-01-12-16-52-38.bpo-29734.6_OJwI.rst
@@ -1,0 +1,1 @@
+Fix handle leaks in os.stat on Windows.


### PR DESCRIPTION
- Make sure that failure paths call CloseHandle
- Fix inconsistent flags in GetFinalPathNameByHandleW calls
- Move CloseHandle call from get_target_path to its calling function.
- Add unit test to check that the fix works, and prevent regression

https://bugs.python.org/issue29734

<!-- issue-number: [bpo-29734](https://bugs.python.org/issue29734) -->
https://bugs.python.org/issue29734
<!-- /issue-number -->
