### PR TITLE
bpo-29859: Fix error messages from return codes for pthread_* calls

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-29859: Show correct error messages when any of the pthread_* calls in
+  thread_pthread.h fails.
+
 - bpo-29849: Fix a memory leak when an ImportError is raised during from import.
 
 - bpo-28856: Fix an oversight that %b format for bytes should support objects

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -143,6 +143,7 @@ typedef struct {
 } pthread_lock;
 
 #define CHECK_STATUS(name)  if (status != 0) { perror(name); error = 1; }
+#define CHECK_STATUS_PTHREAD(name)  if (status != 0) { char* strerror_msg = strerror(status);  fprintf(stderr, "%s: %s\n", name, strerror_msg); }
 
 /*
  * Initialization.
@@ -417,7 +418,7 @@ PyThread_allocate_lock(void)
 
         status = pthread_mutex_init(&lock->mut,
                                     pthread_mutexattr_default);
-        CHECK_STATUS("pthread_mutex_init");
+        CHECK_STATUS_PTHREAD("pthread_mutex_init");
         /* Mark the pthread mutex underlying a Python mutex as
            pure happens-before.  We can't simply mark the
            Python-level mutex as a mutex because it can be
@@ -427,7 +428,7 @@ PyThread_allocate_lock(void)
 
         status = pthread_cond_init(&lock->lock_released,
                                    pthread_condattr_default);
-        CHECK_STATUS("pthread_cond_init");
+        CHECK_STATUS_PTHREAD("pthread_cond_init");
 
         if (error) {
             PyMem_RawFree((void *)lock);
@@ -452,10 +453,10 @@ PyThread_free_lock(PyThread_type_lock lock)
      * and must have the cond destroyed first.
      */
     status = pthread_cond_destroy( &thelock->lock_released );
-    CHECK_STATUS("pthread_cond_destroy");
+    CHECK_STATUS_PTHREAD("pthread_cond_destroy");
 
     status = pthread_mutex_destroy( &thelock->mut );
-    CHECK_STATUS("pthread_mutex_destroy");
+    CHECK_STATUS_PTHREAD("pthread_mutex_destroy");
 
     PyMem_RawFree((void *)thelock);
 }
@@ -472,7 +473,7 @@ PyThread_acquire_lock_timed(PyThread_type_lock lock, PY_TIMEOUT_T microseconds,
              lock, microseconds, intr_flag));
 
     status = pthread_mutex_lock( &thelock->mut );
-    CHECK_STATUS("pthread_mutex_lock[1]");
+    CHECK_STATUS_PTHREAD("pthread_mutex_lock[1]");
 
     if (thelock->locked == 0) {
         success = PY_LOCK_ACQUIRED;
@@ -494,13 +495,13 @@ PyThread_acquire_lock_timed(PyThread_type_lock lock, PY_TIMEOUT_T microseconds,
                     &thelock->mut, &ts);
                 if (status == ETIMEDOUT)
                     break;
-                CHECK_STATUS("pthread_cond_timed_wait");
+                CHECK_STATUS_PTHREAD("pthread_cond_timed_wait");
             }
             else {
                 status = pthread_cond_wait(
                     &thelock->lock_released,
                     &thelock->mut);
-                CHECK_STATUS("pthread_cond_wait");
+                CHECK_STATUS_PTHREAD("pthread_cond_wait");
             }
 
             if (intr_flag && status == 0 && thelock->locked) {
@@ -518,7 +519,7 @@ PyThread_acquire_lock_timed(PyThread_type_lock lock, PY_TIMEOUT_T microseconds,
     }
     if (success == PY_LOCK_ACQUIRED) thelock->locked = 1;
     status = pthread_mutex_unlock( &thelock->mut );
-    CHECK_STATUS("pthread_mutex_unlock[1]");
+    CHECK_STATUS_PTHREAD("pthread_mutex_unlock[1]");
 
     if (error) success = PY_LOCK_FAILURE;
     dprintf(("PyThread_acquire_lock_timed(%p, %lld, %d) -> %d\n",
@@ -536,16 +537,16 @@ PyThread_release_lock(PyThread_type_lock lock)
     dprintf(("PyThread_release_lock(%p) called\n", lock));
 
     status = pthread_mutex_lock( &thelock->mut );
-    CHECK_STATUS("pthread_mutex_lock[3]");
+    CHECK_STATUS_PTHREAD("pthread_mutex_lock[3]");
 
     thelock->locked = 0;
 
     /* wake up someone (anyone, if any) waiting on the lock */
     status = pthread_cond_signal( &thelock->lock_released );
-    CHECK_STATUS("pthread_cond_signal");
+    CHECK_STATUS_PTHREAD("pthread_cond_signal");
 
     status = pthread_mutex_unlock( &thelock->mut );
-    CHECK_STATUS("pthread_mutex_unlock[3]");
+    CHECK_STATUS_PTHREAD("pthread_mutex_unlock[3]");
 }
 
 #endif /* USE_SEMAPHORES */

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -143,7 +143,8 @@ typedef struct {
 } pthread_lock;
 
 #define CHECK_STATUS(name)  if (status != 0) { perror(name); error = 1; }
-#define CHECK_STATUS_PTHREAD(name)  if (status != 0) { char* strerror_msg = strerror(status);  fprintf(stderr, "%s: %s\n", name, strerror_msg); }
+#define CHECK_STATUS_PTHREAD(name)  if (status != 0) { fprintf(stderr, \
+    "%s: %s\n", name, strerror(status)); error = 1; }
 
 /*
  * Initialization.


### PR DESCRIPTION
Fix error messages from return codes for pthread_* calls

Before (example call to `PyThread_release_lock`):
```
pthread_mutex_lock[3]: Undefined error: 0
pthread_cond_signal: Undefined error: 0
pthread_mutex_unlock[3]: Undefined error: 0
```

After (example call to `PyThread_release_lock`):
```
pthread_mutex_lock[3]: Invalid argument
pthread_cond_signal: Invalid argument
pthread_mutex_unlock[3]: Invalid argument
```