### PR TITLE
bpo-22708: Fix http protocol version in CONNECT method, support IDN

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -892,9 +892,10 @@ class HTTPConnection:
         self.debuglevel = level
 
     def _tunnel(self):
-        connect_str = "CONNECT %s:%d HTTP/1.0\r\n" % (self._tunnel_host,
-            self._tunnel_port)
-        connect_bytes = connect_str.encode("ascii")
+        connect_bytes = b'CONNECT %s:%d %s\r\n' % (
+            self._tunnel_host.encode('idna'),
+            self._tunnel_port,
+            self._http_vsn_str.encode('ascii'))
         self.send(connect_bytes)
         for header, value in self._tunnel_headers.items():
             header_str = "%s: %s\r\n" % (header, value)

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -1877,6 +1877,16 @@ class TunnelTests(TestCase):
         # This test should be removed when CONNECT gets the HTTP/1.1 blessing
         self.assertNotIn(b'Host: proxy.com', self.conn.sock.data)
 
+    def test_connect_with_tunnel_idna(self):
+        dest = '\u03b4\u03c0\u03b8.gr'
+        expected = 'CONNECT %s:%d HTTP/1.1\r\n'.encode('ascii') % (
+            dest.encode('idna'), client.HTTP_PORT)
+        self.conn.set_tunnel(dest)
+        self.conn.request('HEAD', '/', '')
+        self.assertEqual(self.conn.sock.host, self.host)
+        self.assertEqual(self.conn.sock.port, client.HTTP_PORT)
+        self.assertIn(expected, self.conn.sock.data)
+
     def test_connect_put_request(self):
         self.conn.set_tunnel('destination.com')
         self.conn.request('PUT', '/', '')


### PR DESCRIPTION
Original author of this patch demianbrecht@gmail.com

HTTP/1.0 not supported CONNECT method, fix http version.
Support for IDN.

https://bugs.python.org/issue22708