### PR TITLE
[3.5] bpo-27593: Revise git SCM build info. (#744)

### DIFF
--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -407,8 +407,8 @@
     <Message Text="Getting build info from $(_GIT)" Importance="high" />
     <MakeDir Directories="$(IntDir)" Condition="!Exists($(IntDir))" />
     <Exec Command="$(_GIT) name-rev --name-only HEAD &gt; &quot;$(IntDir)gitbranch.txt&quot;" ContinueOnError="true" />
-    <Exec Command="$(_GIT) rev-parse HEAD &gt; &quot;$(IntDir)gitversion.txt&quot;" ContinueOnError="true" />
-    <Exec Command="$(_GIT) name-rev --tags --name-only HEAD &gt; &quot;$(IntDir)gittag.txt&quot;" ContinueOnError="true" />
+    <Exec Command="$(_GIT) rev-parse --short HEAD &gt; &quot;$(IntDir)gitversion.txt&quot;" ContinueOnError="true" />
+    <Exec Command="$(_GIT) describe --all --always --dirty &gt; &quot;$(IntDir)gittag.txt&quot;" ContinueOnError="true" />
     <PropertyGroup>
       <GitBranch Condition="Exists('$(IntDir)gitbranch.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gitbranch.txt').Trim())</GitBranch>
       <GitVersion Condition="Exists('$(IntDir)gitversion.txt')">$([System.IO.File]::ReadAllText('$(IntDir)gitversion.txt').Trim())</GitVersion>

--- a/configure
+++ b/configure
@@ -2884,8 +2884,8 @@ HAS_GIT=no-repository
 fi
 if test $HAS_GIT = found
 then
-    GITVERSION="git -C \$(srcdir) rev-parse HEAD"
-    GITTAG="git -C \$(srcdir) name-rev --tags --name-only HEAD"
+    GITVERSION="git -C \$(srcdir) rev-parse --short HEAD"
+    GITTAG="git -C \$(srcdir) describe --all --always --dirty"
     GITBRANCH="git -C \$(srcdir) name-rev --name-only HEAD"
 else
     GITVERSION=""

--- a/configure.ac
+++ b/configure.ac
@@ -37,8 +37,8 @@ HAS_GIT=no-repository
 fi
 if test $HAS_GIT = found
 then
-    GITVERSION="git -C \$(srcdir) rev-parse HEAD"
-    GITTAG="git -C \$(srcdir) name-rev --tags --name-only HEAD"
+    GITVERSION="git -C \$(srcdir) rev-parse --short HEAD"
+    GITTAG="git -C \$(srcdir) describe --all --always --dirty"
     GITBRANCH="git -C \$(srcdir) name-rev --name-only HEAD"
 else
     GITVERSION=""


### PR DESCRIPTION
Use --short form of git hash.  Use output from "git describe" for tag.

Expected outputs:
1. previous hg
2. previous git
3. updated git

Release (tagged) build:
1. Python 3.7.0a0 (v3.7.0a0:4def2a2901a5, ...
2. Python 3.7.0a0 (v3.7.0a0^0:05f53735c8912f8df1077e897f052571e13c3496, ...
3. Python 3.7.0a0 (v3.7.0a0:05f53735c8, ...

Development build:
1. Python 3.7.0a0 (default:41df79263a11, ...
2. Python 3.7.0a0 (master:05f53735c8912f8df1077e897f052571e13c3496, ...
3. Python 3.7.0a0 (heads/master-dirty:05f53735c8, ...

"dirty" means the working tree has uncommitted changes.
See "git help describe" for more info.
(cherry picked from commit 554626ada769abf82a5dabe6966afa4265acb6a6)