### PR TITLE
bpo-29866: Added datetime_diff to datetime.py.

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -149,6 +149,24 @@ Subclass relationships::
            datetime
 
 
+.. method:: datetime_diff(datetime_prior, datetime_current)
+   :noindex:
+
+   Compares two different datetime objects and returns the time
+   elapsed since.
+
+   for example, a datetime object when turned into a string
+   (being 2015-12-03 03:34:57.281000) when compared with a
+   new datetime object (equivalent to the current time) one
+   can determine how many years, months, days, hours,
+   minutes, and seconds ago the prior datetime object was.
+   This returns the data as a string readable by humans denoting
+   how much time has passed since the specified prior datetime
+   object.
+
+   .. versionadded:: 3.7
+
+
 .. _datetime-timedelta:
 
 :class:`timedelta` Objects

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -332,6 +332,53 @@ def _divide_and_round(a, b):
 
     return q
 
+def datetime_diff(datetime_prior, datetime_current):
+    """
+    Compares two different datetime objects
+    and returns the time elapsed since.
+
+    for example, a datetime object when turned
+    into a string (being 2015-12-03 03:34:57.281000)
+    when compared with a new datetime object
+    (equivalent to the current time) one can determine
+    how many years, months, days, hours, minutes, and
+    seconds ago the prior datetime object was.
+    This returns the data as a string readable by humans
+    denoting how much time has passed since the specified
+    prior datetime object.
+    """
+    elyear = datetime_current.year - datetime_prior.year
+    elmonth = datetime_current.month - datetime_prior.month
+    elday = datetime_current.day - datetime_prior.day
+    elhour = datetime_current.hour - datetime_prior.hour
+    elminute = datetime_current.minute - datetime_prior.minute
+    elsecond = datetime_current.second - datetime_prior.second
+    reply = ""
+    if elyear > 0:
+        reply += "{0} years".format(elyear)
+    if elmonth > 0:
+        if elyear > 0:
+            reply += ", "
+        reply += "{0} months".format(elmonth)
+    if elday > 0:
+        if elmonth > 0:
+            reply += ", "
+        reply += "{0} days".format(elday)
+    if elhour > 0:
+        if elday > 0:
+            reply += ", "
+        reply += "{0} hours".format(elhour)
+    if elminute > 0:
+        if elhour > 0:
+            reply += ", "
+        reply += "{0} minutes".format(elminute)
+    if elsecond > 0:
+        if elminute > 0:
+            reply += ", "
+        reply += "{0} seconds".format(elsecond)
+    reply += " ago."
+    return reply
+
 
 class timedelta:
     """Represent the difference between two datetime objects.

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -97,6 +97,13 @@ class TestModule(unittest.TestCase):
         self.assertEqual(dar(6, -4), -2)
         self.assertEqual(dar(-6, -4), 2)
 
+    def test_datetime_diff(self):
+        datetime = datetime_module.datetime.new
+        oldnow = datetime()
+        _time.sleep(14)
+        newnow = datetime()
+        self.assertEqual(datetime.datetime_diff(oldnow, newnow), "15 seconds ago.")
+
 
 #############################################################################
 # tzinfo tests


### PR DESCRIPTION
The datetime_diff function compares two datetime objects and returns the
time since the prior datetime objects (based on the current datetime
object) in a what that is readable by humans.

This is useful when one might need to compare two datetime objects,
keeping ones codebase as small as possible (to ensure fast Python code),
and to reduce 'hacks' in their code to make the comparison more readable
by humans