### PR TITLE
bpo-29864: Don't use Py_SIZE for dict object. (#747)

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1929,7 +1929,7 @@ _PyDict_FromKeys(PyObject *cls, PyObject *iterable, PyObject *value)
             PyObject *key;
             Py_hash_t hash;
 
-            if (dictresize(mp, ESTIMATE_SIZE(PyDict_GET_SIZE(iterable)))) {
+            if (dictresize(mp, ESTIMATE_SIZE(((PyDictObject *)iterable)->ma_used))) {
                 Py_DECREF(d);
                 return NULL;
             }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1929,7 +1929,7 @@ _PyDict_FromKeys(PyObject *cls, PyObject *iterable, PyObject *value)
             PyObject *key;
             Py_hash_t hash;
 
-            if (dictresize(mp, ESTIMATE_SIZE(Py_SIZE(iterable)))) {
+            if (dictresize(mp, ESTIMATE_SIZE(PyDict_GET_SIZE(iterable)))) {
                 Py_DECREF(d);
                 return NULL;
             }


### PR DESCRIPTION
(cherry picked from commit c61ac1642d19f54c7b755098230967ad2e603180)