### PR TITLE
WIP (don't merge!): bpo-21895: Experiment signal handlers in any thread

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -46,18 +46,17 @@ This has consequences:
   signal handlers will be called when the calculation finishes.
 
 
-.. _signals-and-threads:
-
-
 Signals and threads
 ^^^^^^^^^^^^^^^^^^^
 
-Python signal handlers are always executed in the main Python thread,
-even if the signal was received in another thread.  This means that signals
-can't be used as a means of inter-thread communication.  You can use
-the synchronization primitives from the :mod:`threading` module instead.
+Only the main thread is allowed to set a new signal handler.
 
-Besides, only the main thread is allowed to set a new signal handler.
+You can use the synchronization primitives from the :mod:`threading` module
+instead.
+
+.. versionchanged:: 3.7
+   Python signal handlers can now be executed in threads other than the main
+   Python thread.
 
 
 Module contents
@@ -221,11 +220,7 @@ The :mod:`signal` module defines the following functions:
 
    Send the signal *signalnum* to the thread *thread_id*, another thread in the
    same process as the caller.  The target thread can be executing any code
-   (Python or not).  However, if the target thread is executing the Python
-   interpreter, the Python signal handlers will be :ref:`executed by the main
-   thread <signals-and-threads>`.  Therefore, the only point of sending a
-   signal to a particular Python thread would be to force a running system call
-   to fail with :exc:`InterruptedError`.
+   (Python or not).
 
    Use :func:`threading.get_ident()` or the :attr:`~threading.Thread.ident`
    attribute of :class:`threading.Thread` objects to get a suitable value

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1350,9 +1350,9 @@ _winapi_WaitForMultipleObjects_impl(PyObject *module, PyObject *handle_seq,
         handles[i] = h;
         Py_DECREF(v);
     }
-    /* If this is the main thread then make the wait interruptible
-       by Ctrl-C unless we are waiting for *all* handles */
-    if (!wait_flag && _PyOS_IsMainThread()) {
+    /* Make the wait interruptible by Ctrl-C unless
+       we are waiting for *all* handles */
+    if (!wait_flag) {
         sigint_event = _PyOS_SigintEvent();
         assert(sigint_event != NULL);
         handles[nhandles++] = sigint_event;

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1457,11 +1457,9 @@ pysleep(_PyTime_t secs)
             return -1;
         }
 
-        /* Allow sleep(0) to maintain win32 semantics, and as decreed
-         * by Guido, only the main thread can be interrupted.
-         */
+        /* Allow sleep(0) to maintain win32 semantics. */
         ul_millis = (unsigned long)millisecs;
-        if (ul_millis == 0 || !_PyOS_IsMainThread()) {
+        if (ul_millis == 0) {
             Py_BEGIN_ALLOW_THREADS
             Sleep(ul_millis);
             Py_END_ALLOW_THREADS

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -355,6 +355,8 @@ PyEval_RestoreThread(PyThreadState *tstate)
    callback.
  */
 
+/* FIXME: move this array into PyThreadState to avoid race conditions between
+   threads when Py_AddPendingCall() is called by signal handlers. */
 #define NPENDINGCALLS 32
 static struct {
     int (*func)(void *);


### PR DESCRIPTION
Modified functions:

* _winapi.WaitForMultipleObjects()
* signal.signal()
* signal.set_wakeup_fd()
* PyErr_CheckSignals()
* PyErr_SetInterrupt()
* time.sleep() on Windows

Update also the signal documentation.

FIXME: move pendingcalls to PyThreadState.