### PR TITLE
bpo-29881: Add new C API for static variables

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -1071,6 +1071,26 @@ PyAPI_FUNC(void)
 _PyObject_DebugTypeStats(FILE *out);
 #endif /* ifndef Py_LIMITED_API */
 
+#ifndef Py_LIMITED_API
+typedef struct _Py_StaticVar {
+    struct _Py_StaticVar *next;
+    PyObject *obj;
+} _Py_StaticVar;
+
+
+PyAPI_FUNC(int) _PyStaticVar_Set(_Py_StaticVar *var, PyObject *obj);
+
+#define _Py_STATICVAR(var) \
+    static _Py_StaticVar var = {.next = NULL, .obj = NULL}
+
+/* Initialized the static variable 'var' once with the expression 'expr'.
+   Return 0 on success, return -1 on failure. */
+#define _PY_STATICVAR_INIT(var, expr) \
+    ((var)->obj == NULL ? _PyStaticVar_Set((var), (expr)) : 0)
+
+PyAPI_DATA(_Py_StaticVar*) _Py_static_variables;
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2124,20 +2124,19 @@ array_array___reduce_ex__(arrayobject *self, PyObject *value)
     PyObject *array_str;
     int typecode = self->ob_descr->typecode;
     int mformat_code;
-    static PyObject *array_reconstructor = NULL;
+    _Py_STATICVAR(array_reconstructor);
     long protocol;
     _Py_IDENTIFIER(_array_reconstructor);
     _Py_IDENTIFIER(__dict__);
 
-    if (array_reconstructor == NULL) {
+    if (array_reconstructor.obj == NULL) {
         PyObject *array_module = PyImport_ImportModule("array");
         if (array_module == NULL)
             return NULL;
-        array_reconstructor = _PyObject_GetAttrId(
-            array_module,
-            &PyId__array_reconstructor);
+        PyObject *meth = _PyObject_GetAttrId(array_module,
+                                             &PyId__array_reconstructor);
         Py_DECREF(array_module);
-        if (array_reconstructor == NULL)
+        if (_PyStaticVar_Set(&array_reconstructor, meth))
             return NULL;
     }
 
@@ -2191,7 +2190,7 @@ array_array___reduce_ex__(arrayobject *self, PyObject *value)
         return NULL;
     }
     result = Py_BuildValue(
-        "O(OCiN)O", array_reconstructor, Py_TYPE(self), typecode,
+        "O(OCiN)O", array_reconstructor.obj, Py_TYPE(self), typecode,
         mformat_code, array_str, dict);
     Py_DECREF(dict);
     return result;

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -2129,3 +2129,36 @@ _Py_Dealloc(PyObject *op)
 #ifdef __cplusplus
 }
 #endif
+
+
+_Py_StaticVar* _Py_static_variables = NULL;
+
+int
+_PyStaticVar_Set(_Py_StaticVar *var, PyObject *obj)
+{
+    assert(var->next == NULL);
+    assert(var->obj == NULL);
+
+    if (obj == NULL) {
+        return -1;
+    }
+
+    var->obj = obj;
+    var->next = _Py_static_variables;
+    _Py_static_variables = var;
+    return 0;
+}
+
+void
+_PyStaticVar_Fini(void)
+{
+    _Py_StaticVar *next, *var;
+
+    for (var = _Py_static_variables; var != NULL; var = next) {
+        next = var->next;
+
+        Py_CLEAR(var->obj);
+        var->next = NULL;
+    }
+    _Py_static_variables = NULL;
+}

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4419,15 +4419,14 @@ static PyObject *
 object___reduce_ex___impl(PyObject *self, int protocol)
 /*[clinic end generated code: output=2e157766f6b50094 input=8dd6a9602a12749e]*/
 {
-    static PyObject *objreduce;
+    _Py_STATICVAR(objreduce);
     PyObject *reduce, *res;
     _Py_IDENTIFIER(__reduce__);
 
-    if (objreduce == NULL) {
-        objreduce = _PyDict_GetItemId(PyBaseObject_Type.tp_dict,
-                                      &PyId___reduce__);
-        if (objreduce == NULL)
-            return NULL;
+    if (_PY_STATICVAR_INIT(&objreduce,
+                           _PyDict_GetItemId(PyBaseObject_Type.tp_dict,
+                                             &PyId___reduce__))) {
+        return NULL;
     }
 
     reduce = _PyObject_GetAttrId(self, &PyId___reduce__);
@@ -4443,7 +4442,7 @@ object___reduce_ex___impl(PyObject *self, int protocol)
             Py_DECREF(reduce);
             return NULL;
         }
-        override = (clsreduce != objreduce);
+        override = (clsreduce != objreduce.obj);
         Py_DECREF(clsreduce);
         if (override) {
             res = _PyObject_CallNoArg(reduce);

--- a/Python/import.c
+++ b/Python/import.c
@@ -1721,9 +1721,9 @@ PyImport_ReloadModule(PyObject *m)
 PyObject *
 PyImport_Import(PyObject *module_name)
 {
-    static PyObject *silly_list = NULL;
-    static PyObject *builtins_str = NULL;
-    static PyObject *import_str = NULL;
+    _Py_STATICVAR(empty_list);
+    _Py_STATICVAR(builtins_str);
+    _Py_STATICVAR(import_str);
     PyObject *globals = NULL;
     PyObject *import = NULL;
     PyObject *builtins = NULL;
@@ -1731,23 +1731,23 @@ PyImport_Import(PyObject *module_name)
     PyObject *r = NULL;
 
     /* Initialize constant string objects */
-    if (silly_list == NULL) {
-        import_str = PyUnicode_InternFromString("__import__");
-        if (import_str == NULL)
-            return NULL;
-        builtins_str = PyUnicode_InternFromString("__builtins__");
-        if (builtins_str == NULL)
-            return NULL;
-        silly_list = PyList_New(0);
-        if (silly_list == NULL)
-            return NULL;
+    if (_PY_STATICVAR_INIT(&empty_list, PyList_New(0))) {
+        return NULL;
+    }
+    if (_PY_STATICVAR_INIT(&builtins_str,
+                           PyUnicode_InternFromString("__builtins__"))) {
+        return NULL;
+    }
+    if (_PY_STATICVAR_INIT(&import_str,
+                           PyUnicode_InternFromString("__import__"))) {
+        return NULL;
     }
 
     /* Get the builtins from current globals */
     globals = PyEval_GetGlobals();
     if (globals != NULL) {
         Py_INCREF(globals);
-        builtins = PyObject_GetItem(globals, builtins_str);
+        builtins = PyObject_GetItem(globals, builtins_str.obj);
         if (builtins == NULL)
             goto err;
     }
@@ -1757,19 +1757,19 @@ PyImport_Import(PyObject *module_name)
                                               NULL, NULL, NULL, 0);
         if (builtins == NULL)
             return NULL;
-        globals = Py_BuildValue("{OO}", builtins_str, builtins);
+        globals = Py_BuildValue("{OO}", builtins_str.obj, builtins);
         if (globals == NULL)
             goto err;
     }
 
     /* Get the __import__ function from the builtins */
     if (PyDict_Check(builtins)) {
-        import = PyObject_GetItem(builtins, import_str);
+        import = PyObject_GetItem(builtins, import_str.obj);
         if (import == NULL)
-            PyErr_SetObject(PyExc_KeyError, import_str);
+            PyErr_SetObject(PyExc_KeyError, import_str.obj);
     }
     else
-        import = PyObject_GetAttr(builtins, import_str);
+        import = PyObject_GetAttr(builtins, import_str.obj);
     if (import == NULL)
         goto err;
 
@@ -1777,7 +1777,7 @@ PyImport_Import(PyObject *module_name)
        Always use absolute import here.
        Calling for side-effect of import. */
     r = PyObject_CallFunction(import, "OOOOi", module_name, globals,
-                              globals, silly_list, 0, NULL);
+                              globals, empty_list.obj, 0, NULL);
     if (r == NULL)
         goto err;
     Py_DECREF(r);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -62,6 +62,7 @@ static void call_ll_exitfuncs(void);
 extern int _PyUnicode_Init(void);
 extern int _PyStructSequence_Init(void);
 extern void _PyUnicode_Fini(void);
+extern void _PyStaticVar_Fini(void);
 extern int _PyLong_Init(void);
 extern void PyLong_Fini(void);
 extern int _PyFaulthandler_Init(void);
@@ -699,6 +700,7 @@ Py_FinalizeEx(void)
 
     /* Cleanup Unicode implementation */
     _PyUnicode_Fini();
+    _PyStaticVar_Fini();
 
     /* reset file system default encoding */
     if (!Py_HasFileSystemDefaultEncoding && Py_FileSystemDefaultEncoding) {

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -162,7 +162,7 @@ sys_displayhook(PyObject *self, PyObject *o)
     PyInterpreterState *interp = PyThreadState_GET()->interp;
     PyObject *modules = interp->modules;
     PyObject *builtins;
-    static PyObject *newline = NULL;
+    _Py_STATICVAR(newline);
     int err;
 
     builtins = _PyDict_GetItemId(modules, &PyId_builtins);
@@ -197,12 +197,10 @@ sys_displayhook(PyObject *self, PyObject *o)
             return NULL;
         }
     }
-    if (newline == NULL) {
-        newline = PyUnicode_FromString("\n");
-        if (newline == NULL)
-            return NULL;
+    if (_PY_STATICVAR_INIT(&newline, PyUnicode_FromString("\n"))) {
+        return NULL;
     }
-    if (PyFile_WriteObject(newline, outf, Py_PRINT_RAW) != 0)
+    if (PyFile_WriteObject(newline.obj, outf, Py_PRINT_RAW) != 0)
         return NULL;
     if (_PyObject_SetAttrId(builtins, &PyId__, o) != 0)
         return NULL;


### PR DESCRIPTION
* New type: _Py_StaticVar
* New macro _Py_STATICVAR(var) to declare a variable
* New macro _PY_STATICVAR_INIT(var, expr) to initialize a variable
  once
* New function _PyStaticVar_Set() to explicitly set a variable once
  to initialize it
* New _PyStaticVar_Fini() function clearing all references at exit