### PR TITLE
Fix description inconsistent with its implementation

### DIFF
--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -2611,7 +2611,7 @@ changes, or look through the Subversion logs for all the details.
 
 * The XML-RPC :class:`SimpleXMLRPCServer` and :class:`DocXMLRPCServer`
   classes can now be prevented from immediately opening and binding to
-  their socket by passing True as the ``bind_and_activate``
+  their socket by passing false as the ``bind_and_activate``
   constructor parameter.  This can be used to modify the instance's
   :attr:`allow_reuse_address` attribute before calling the
   :meth:`server_bind` and :meth:`server_activate` methods to

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -2611,7 +2611,7 @@ changes, or look through the Subversion logs for all the details.
 
 * The XML-RPC :class:`SimpleXMLRPCServer` and :class:`DocXMLRPCServer`
   classes can now be prevented from immediately opening and binding to
-  their socket by passing false as the ``bind_and_activate``
+  their socket by passing ``False`` as the *bind_and_activate*
   constructor parameter.  This can be used to modify the instance's
   :attr:`allow_reuse_address` attribute before calling the
   :meth:`server_bind` and :meth:`server_activate` methods to


### PR DESCRIPTION
Fix wrong description about SimpleXMLRPCServer class constructor parameter `bind_and_activate`.
Passing True as the `bind_and_activate` *do* immediately opening and binding to thier socket.

+ [SimpleXMLRPCServer constructor](https://github.com/python/cpython/blob/2.6/Lib/SimpleXMLRPCServer.py#L542)
+ [TCPServer constructor called from SimpleXMLRPCServer constructor](https://github.com/python/cpython/blob/2.6/Lib/SocketServer.py#L401)