### PR TITLE
Use NULL rather than 0.

### DIFF
--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -365,14 +365,14 @@ dialect_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
             Py_INCREF(dialect);
         /* Can we reuse this instance? */
         if (PyObject_TypeCheck(dialect, &Dialect_Type) &&
-            delimiter == 0 &&
-            doublequote == 0 &&
-            escapechar == 0 &&
-            lineterminator == 0 &&
-            quotechar == 0 &&
-            quoting == 0 &&
-            skipinitialspace == 0 &&
-            strict == 0)
+            delimiter == NULL &&
+            doublequote == NULL &&
+            escapechar == NULL &&
+            lineterminator == NULL &&
+            quotechar == NULL &&
+            quoting == NULL &&
+            skipinitialspace == NULL &&
+            strict == NULL)
             return dialect;
     }
 

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -132,7 +132,7 @@ _ctypes_get_errobj(int **pspace)
     PyObject *dict = PyThreadState_GetDict();
     PyObject *errobj;
     static PyObject *error_object_name;
-    if (dict == 0) {
+    if (dict == NULL) {
         PyErr_SetString(PyExc_RuntimeError,
                         "cannot get thread state");
         return NULL;

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2987,7 +2987,7 @@ PyCurses_tigetstr(PyObject *self, PyObject *args)
         return NULL;
 
     capname = tigetstr( capname );
-    if (capname == 0 || capname == (char*) -1) {
+    if (capname == NULL || capname == (char*) -1) {
         Py_RETURN_NONE;
     }
     return PyBytes_FromString( capname );

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -643,7 +643,7 @@ static void _pysqlite_step_callback(sqlite3_context *context, int argc, sqlite3_
 
     aggregate_instance = (PyObject**)sqlite3_aggregate_context(context, sizeof(PyObject*));
 
-    if (*aggregate_instance == 0) {
+    if (*aggregate_instance == NULL) {
         *aggregate_instance = _PyObject_CallNoArg(aggregate_class);
 
         if (PyErr_Occurred()) {

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -434,7 +434,7 @@ PyMODINIT_FUNC PyInit__sqlite3(void)
     PyDict_SetItemString(dict, "OptimizedUnicode", (PyObject*)&PyUnicode_Type);
 
     /* Set integer constants */
-    for (i = 0; _int_constants[i].constant_name != 0; i++) {
+    for (i = 0; _int_constants[i].constant_name != NULL; i++) {
         tmp_obj = PyLong_FromLong(_int_constants[i].constant_value);
         if (!tmp_obj) {
             goto error;

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -1378,7 +1378,7 @@ Tkapp_CallArgs(PyObject *args, Tcl_Obj** objStore, int *pobjc)
 
     else if (!(PyTuple_Check(args) || PyList_Check(args))) {
         objv[0] = AsObj(args);
-        if (objv[0] == 0)
+        if (objv[0] == NULL)
             goto finally;
         objc = 1;
         Tcl_IncrRefCount(objv[0]);

--- a/PC/bdist_wininst/install.c
+++ b/PC/bdist_wininst/install.c
@@ -2179,7 +2179,7 @@ BOOL MyIsUserAnAdmin()
     // to leave the library loaded)
     if (0 == (shell32=LoadLibrary("shell32.dll")))
         return FALSE;
-    if (0 == (pfnIsUserAnAdmin=(PFNIsUserAnAdmin)GetProcAddress(shell32, "IsUserAnAdmin")))
+    if (NULL == (pfnIsUserAnAdmin=(PFNIsUserAnAdmin)GetProcAddress(shell32, "IsUserAnAdmin")))
         return FALSE;
     return (*pfnIsUserAnAdmin)();
 }

--- a/Parser/listnode.c
+++ b/Parser/listnode.c
@@ -28,7 +28,7 @@ listnode(FILE *fp, node *n)
 static void
 list1node(FILE *fp, node *n)
 {
-    if (n == 0)
+    if (n == NULL)
         return;
     if (ISNONTERMINAL(TYPE(n))) {
         int i;


### PR DESCRIPTION
There was few cases of using literal 0 instead of NULL in the context of
pointers.  While this was a legitimate C code, using NULL rather than 0 makes
the code clearer.