### PR TITLE
bpo-29640: Protect key list during fork()

### DIFF
--- a/Include/pythread.h
+++ b/Include/pythread.h
@@ -30,6 +30,8 @@ PyAPI_FUNC(void) PyThread_delete_key(int);
 PyAPI_FUNC(int) PyThread_set_key_value(int, void *);
 PyAPI_FUNC(void *) PyThread_get_key_value(int);
 PyAPI_FUNC(void) PyThread_delete_key_value(int key);
+PyAPI_FUNC(int) _PyThread_AcquireKeyLock(void);
+PyAPI_FUNC(void) _PyThread_ReleaseKeyLock(void);
 
 /* Cleanup after a fork */
 PyAPI_FUNC(void) PyThread_ReInitTLS(void);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3836,7 +3836,18 @@ posix_fork1(PyObject *self, PyObject *noargs)
     pid_t pid;
     int result = 0;
     _PyImport_AcquireLock();
+#ifdef WITH_THREAD
+    if (_PyThread_AcquireKeyLock() == 0) {
+        _PyImport_ReleaseLock();
+        PyErr_SetString(PyExc_RuntimeError,
+                        "could not acquire thread key lock");
+        return NULL;
+    }
+#endif
     pid = fork1();
+#ifdef WITH_THREAD
+    _PyThread_ReleaseKeyLock();
+#endif
     if (pid == 0) {
         /* child: this clobbers and resets the import lock. */
         PyOS_AfterFork();
@@ -3869,7 +3880,18 @@ posix_fork(PyObject *self, PyObject *noargs)
     pid_t pid;
     int result = 0;
     _PyImport_AcquireLock();
+#ifdef WITH_THREAD
+    if (_PyThread_AcquireKeyLock() == 0) {
+        _PyImport_ReleaseLock();
+        PyErr_SetString(PyExc_RuntimeError,
+                        "could not acquire thread key lock");
+        return NULL;
+    }
+#endif
     pid = fork();
+#ifdef WITH_THREAD
+    _PyThread_ReleaseKeyLock();
+#endif
     if (pid == 0) {
         /* child: this clobbers and resets the import lock. */
         PyOS_AfterFork();
@@ -3995,7 +4017,18 @@ posix_forkpty(PyObject *self, PyObject *noargs)
     pid_t pid;
 
     _PyImport_AcquireLock();
+#ifdef WITH_THREAD
+    if (_PyThread_AcquireKeyLock() == 0) {
+        _PyImport_ReleaseLock();
+        PyErr_SetString(PyExc_RuntimeError,
+                        "could not acquire thread key lock");
+        return NULL;
+    }
+#endif
     pid = forkpty(&master_fd, NULL, NULL, NULL);
+#ifdef WITH_THREAD
+    _PyThread_ReleaseKeyLock();
+#endif
     if (pid == 0) {
         /* child: this clobbers and resets the import lock. */
         PyOS_AfterFork();

--- a/Python/thread.c
+++ b/Python/thread.c
@@ -387,6 +387,24 @@ PyThread_delete_key_value(int key)
     PyThread_release_lock(keymutex);
 }
 
+int
+_PyThread_AcquireKeyLock(void)
+{
+    if (keymutex == NULL) {
+        keymutex = PyThread_allocate_lock();
+    }
+    if (keymutex == NULL) {
+        return 0;
+    }
+    return PyThread_acquire_lock(keymutex, 1);
+}
+
+void
+_PyThread_ReleaseKeyLock(void)
+{
+    PyThread_release_lock(keymutex);
+}
+
 /* Forget everything not associated with the current thread id.
  * This function is called from PyOS_AfterFork().  It is necessary
  * because other thread ids which were in use at the time of the fork


### PR DESCRIPTION
When a thread is modifying the key list and a fork() happens in another thread, the forked process can be left with an inconsistent key list. More info at: http://bugs.python.org/issue29640

This PR adds two new functions, _PyThread_AcquireKeyLock and _PyThread_ReleaseKeyLock, which are used to lock the key mutex around fork() calls.

<!-- issue-number: bpo-29640 -->
https://bugs.python.org/issue29640
<!-- /issue-number -->
