### PR TITLE
bpo-29886: Link bytes.{,to}hex from binascii docs

### DIFF
--- a/Doc/library/binascii.rst
+++ b/Doc/library/binascii.rst
@@ -149,6 +149,8 @@ The :mod:`binascii` module defines the following functions:
    *data* is converted into the corresponding 2-digit hex representation.  The
    returned bytes object is therefore twice as long as the length of *data*.
 
+   Similar functionality (but returning a text string) is also conveniently
+   accessible using the :meth:`bytes.hex` method.
 
 .. function:: a2b_hex(hexstr)
               unhexlify(hexstr)
@@ -158,6 +160,9 @@ The :mod:`binascii` module defines the following functions:
    of hexadecimal digits (which can be upper or lower case), otherwise an
    :exc:`Error` exception is raised.
 
+   Similar functionality (accepting only text string arguments, but more
+   liberal towards whitespace) is also accessible using the
+   :meth:`bytes.fromhex` class method.
 
 .. exception:: Error
 


### PR DESCRIPTION
A suggested fix for http://bugs.python.org/issue29886 which I reported earlier today

<!-- issue-number: [bpo-29886](https://bugs.python.org/issue29886) -->
https://bugs.python.org/issue29886
<!-- /issue-number -->
