### PR TITLE
bpo-28041: Inconsistent behavior: Get st_nlink from os.stat() and os.scandir()

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3241,13 +3241,11 @@ class TestScandir(unittest.TestCase):
         self.assertFalse(entry.is_symlink())
         if os.name == 'nt':
             self.assertRaises(FileNotFoundError, entry.inode)
-            # don't fail
-            entry.stat()
-            entry.stat(follow_symlinks=False)
         else:
             self.assertGreater(entry.inode(), 0)
-            self.assertRaises(FileNotFoundError, entry.stat)
-            self.assertRaises(FileNotFoundError, entry.stat, follow_symlinks=False)
+        self.assertRaises(FileNotFoundError, entry.stat)
+        self.assertRaises(FileNotFoundError, entry.stat, follow_symlinks=False)
+
 
     def test_removed_file(self):
         entry = self.create_file_entry()
@@ -3260,13 +3258,10 @@ class TestScandir(unittest.TestCase):
         self.assertFalse(entry.is_symlink())
         if os.name == 'nt':
             self.assertRaises(FileNotFoundError, entry.inode)
-            # don't fail
-            entry.stat()
-            entry.stat(follow_symlinks=False)
         else:
             self.assertGreater(entry.inode(), 0)
-            self.assertRaises(FileNotFoundError, entry.stat)
-            self.assertRaises(FileNotFoundError, entry.stat, follow_symlinks=False)
+        self.assertRaises(FileNotFoundError, entry.stat)
+        self.assertRaises(FileNotFoundError, entry.stat, follow_symlinks=False)
 
     def test_broken_symlink(self):
         if not support.can_symlink():
@@ -3369,6 +3364,14 @@ class TestScandir(unittest.TestCase):
         with self.check_no_resource_warning():
             del iterator
 
+    def test_scandir_stat_match(self):
+        stat_basic = os.stat(__file__)
+        stat_scandir = os.stat(__file__)
+        for entry in os.scandir(os.path.dirname(os.path.abspath(__file__))):
+            if entry.name == os.path.basename(__file__):
+                stat_scandir = entry.stat()
+                break
+        self.assertEqual(stat_basic, stat_scandir)
 
 class TestPEP519(unittest.TestCase):
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11234,11 +11234,7 @@ static PyObject *
 DirEntry_get_lstat(DirEntry *self)
 {
     if (!self->lstat) {
-#ifdef MS_WINDOWS
-        self->lstat = _pystat_fromstructstat(&self->win32_lstat);
-#else /* POSIX */
         self->lstat = DirEntry_fetch_stat(self, 0);
-#endif
     }
     Py_XINCREF(self->lstat);
     return self->lstat;
@@ -11569,7 +11565,7 @@ DirEntry_from_find_data(path_t *path, WIN32_FIND_DATAW *dataW)
         if (!entry->path)
             goto error;
     }
-
+    
     find_data_to_file_info(dataW, &file_info, &reparse_tag);
     _Py_attribute_data_to_stat(&file_info, reparse_tag, &entry->win32_lstat);
 


### PR DESCRIPTION
- Unify stat approach between POSIX and Windows hosts. The data that comes out of the WIN32_FIND_DATAW is not the same information that is available in BY_HANDLE_FILE_INFORMATION.
- Add unit test to verify fix
- Update deleted file/directory tests to reflect new consistent behavior.