### PR TITLE
bpo-29894: Deprecate returning an instance of complex subclass from `__complex__`

### DIFF
--- a/Lib/test/test_complex.py
+++ b/Lib/test/test_complex.py
@@ -383,8 +383,9 @@ class ComplexTest(unittest.TestCase):
             def __complex__(self):
                 return None
 
-        self.assertAlmostEqual(complex(complex0(1j)), 42j)
-        self.assertAlmostEqual(complex(complex1(1j)), 2j)
+        self.assertEqual(complex(complex0(1j)), 42j)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(complex(complex1(1j)), 2j)
         self.assertRaises(TypeError, complex, complex2(1j))
 
     @support.requires_IEEE_754

--- a/Lib/test/test_getargs2.py
+++ b/Lib/test/test_getargs2.py
@@ -408,7 +408,8 @@ class Float_TestCase(unittest.TestCase):
         self.assertEqual(getargs_D(ComplexSubclass(7.5+0.25j)), 7.5+0.25j)
         self.assertEqual(getargs_D(ComplexSubclass2(7.5+0.25j)), 7.5+0.25j)
         self.assertRaises(TypeError, getargs_D, BadComplex())
-        self.assertEqual(getargs_D(BadComplex2()), 4.25+0.5j)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(getargs_D(BadComplex2()), 4.25+0.5j)
         self.assertEqual(getargs_D(BadComplex3(7.5+0.25j)), 7.5+0.25j)
 
         for x in (DBL_MIN, -DBL_MIN, DBL_MAX, -DBL_MAX, INF, -INF):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,10 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-29894: The deprecation warning is emitted if __complex__ returns an
+  instance of a strict subclass of complex.  In a future versions of Python
+  this can be an error.
+
 - bpo-29859: Show correct error messages when any of the pthread_* calls in
   thread_pthread.h fails.
 


### PR DESCRIPTION
In a future versions of Python this can be an error.