### PR TITLE
bpo-25803: Avoid incorrect errors raised by Path.mkdir(exist_ok=True)

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1220,6 +1220,9 @@ class Path(PurePath):
         os.close(fd)
 
     def mkdir(self, mode=0o777, parents=False, exist_ok=False):
+        """
+        Create a new directory at this given path.
+        """
         if self._closed:
             self._raise_closed()
         try:

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1776,6 +1776,11 @@ class _BasePathTest(object):
         self.assertTrue(p.exists())
         self.assertEqual(p.stat().st_ctime, st_ctime_first)
 
+    def test_mkdir_exist_ok_root(self):
+        # Issue #25803: A drive root could raise PermissionError on Windows
+        self.cls('/').resolve().mkdir(exist_ok=True)
+        self.cls('/').resolve().mkdir(parents=True, exist_ok=True)
+
     @only_nt    # XXX: not sure how to test this on POSIX
     def test_mkdir_with_unknown_drive(self):
         for d in 'ZYXWVUTSRQPONMLKJIHGFEDCBA':

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -287,6 +287,9 @@ Extension Modules
 Library
 -------
 
+- bpo-25803: Avoid incorrect errors raised by Path.mkdir(exist_ok=True)
+  when the OS gives priority to errors such as EACCES over EEXIST.
+
 - bpo-29861: Release references to tasks, their arguments and their results
   as soon as they are finished in multiprocessing.Pool.
 


### PR DESCRIPTION
when the OS gives priority to errors such as EACCES over EEXIST.