### PR TITLE
bpo-29862: Fixed grammar error in TypeError exception message in reload function

### DIFF
--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -137,7 +137,7 @@ def reload(module):
 
     """
     if not module or not isinstance(module, types.ModuleType):
-        raise TypeError("reload() argument must be module")
+        raise TypeError("reload() argument must be a module")
     try:
         name = module.__spec__.name
     except AttributeError:


### PR DESCRIPTION
Fixed the grammar error found by Brett in the TypeError exception message on Line 140. All tests passed after making the change so I went ahead and created this pull request. If I need to add a test that checks the exception message, please let me know.