### PR TITLE
[3.6] bpo-29892: Fix wrong markup on doc-lib-functions (GH-802)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1072,7 +1072,7 @@ are always available.  They are listed here in alphabetical order.
          * The ``'x'`` mode was added.
          * :exc:`IOError` used to be raised, it is now an alias of :exc:`OSError`.
          * :exc:`FileExistsError` is now raised if the file opened in exclusive
-         * creation mode (``'x'``) already exists.
+           creation mode (``'x'``) already exists.
 
    .. versionchanged::
       3.4


### PR DESCRIPTION
(cherry picked from commit 29540cdf6c66df9f806375a95078c0c63192ef78)