### PR TITLE
[3.5] bpo-29862: Fix grammar in importlib.reload() exception (GH-809)

### DIFF
--- a/Lib/importlib/__init__.py
+++ b/Lib/importlib/__init__.py
@@ -136,7 +136,7 @@ def reload(module):
 
     """
     if not module or not isinstance(module, types.ModuleType):
-        raise TypeError("reload() argument must be module")
+        raise TypeError("reload() argument must be a module")
     try:
         name = module.__spec__.name
     except AttributeError:


### PR DESCRIPTION
(cherry picked from commit 9f0aa4843f8c26937d5817f27cac4aae9c0a034f)