### PR TITLE
bpo-29900: Simplify pathlib implementation.

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -384,49 +384,37 @@ class _Accessor:
 
 class _NormalAccessor(_Accessor):
 
-    def _wrap_strfunc(strfunc):
-        @functools.wraps(strfunc)
-        def wrapped(pathobj, *args):
-            return strfunc(str(pathobj), *args)
-        return staticmethod(wrapped)
+    stat = os.stat
 
-    def _wrap_binary_strfunc(strfunc):
-        @functools.wraps(strfunc)
-        def wrapped(pathobjA, pathobjB, *args):
-            return strfunc(str(pathobjA), str(pathobjB), *args)
-        return staticmethod(wrapped)
+    lstat = os.lstat
 
-    stat = _wrap_strfunc(os.stat)
+    open = os.open
 
-    lstat = _wrap_strfunc(os.lstat)
+    listdir = os.listdir
 
-    open = _wrap_strfunc(os.open)
+    scandir = os.scandir
 
-    listdir = _wrap_strfunc(os.listdir)
-
-    scandir = _wrap_strfunc(os.scandir)
-
-    chmod = _wrap_strfunc(os.chmod)
+    chmod = os.chmod
 
     if hasattr(os, "lchmod"):
-        lchmod = _wrap_strfunc(os.lchmod)
+        lchmod = os.lchmod
     else:
         def lchmod(self, pathobj, mode):
             raise NotImplementedError("lchmod() not available on this system")
 
-    mkdir = _wrap_strfunc(os.mkdir)
+    mkdir = os.mkdir
 
-    unlink = _wrap_strfunc(os.unlink)
+    unlink = os.unlink
 
-    rmdir = _wrap_strfunc(os.rmdir)
+    rmdir = os.rmdir
 
-    rename = _wrap_binary_strfunc(os.rename)
+    rename = os.rename
 
-    replace = _wrap_binary_strfunc(os.replace)
+    replace = os.replace
 
     if nt:
         if supports_symlinks:
-            symlink = _wrap_binary_strfunc(os.symlink)
+            symlink = os.symlink
         else:
             def symlink(a, b, target_is_directory):
                 raise NotImplementedError("symlink() not available on this system")
@@ -434,9 +422,9 @@ class _NormalAccessor(_Accessor):
         # Under POSIX, os.symlink() takes two args
         @staticmethod
         def symlink(a, b, target_is_directory):
-            return os.symlink(str(a), str(b))
+            return os.symlink(a, b)
 
-    utime = _wrap_strfunc(os.utime)
+    utime = os.utime
 
     # Helper for resolve()
     def readlink(self, path):
@@ -711,7 +699,7 @@ class PurePath(object):
     def __bytes__(self):
         """Return the bytes representation of the path.  This is only
         recommended to use under Unix."""
-        return os.fsencode(str(self))
+        return os.fsencode(self)
 
     def __repr__(self):
         return "{}({!r})".format(self.__class__.__name__, self.as_posix())
@@ -1160,7 +1148,7 @@ class Path(PurePath):
         """
         if self._closed:
             self._raise_closed()
-        return io.open(str(self), mode, buffering, encoding, errors, newline,
+        return io.open(self, mode, buffering, encoding, errors, newline,
                        opener=self._opener)
 
     def read_bytes(self):


### PR DESCRIPTION
Since functions in the os module support path-like objects, explicit
converting Path to str no longer needed.