### PR TITLE
[2.7] bpo-29888: Fix the link referring to "Python download page"

### DIFF
--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -75,18 +75,9 @@ files in megabytes.{% endtrans %}</p>
 <p>{% trans %}These archives contain all the content in the
 documentation.{% endtrans %}</p>
 
-{% if release == '2.7.0' %}
-  {% set path = 'download/releases/2.7' %}
-  {% set section = 'Download' %}
-{% elif release == '2.7.1' or ('2.7.1a' <= release < '2.7.8') %}
-  {% set path = 'download/releases/' + release[:5] %}
-  {% set section = 'Download' %}
-{% else %}
-  {% set path = 'downloads/release/python-' + release.replace('.', '') %}
-  {% set section = 'Files' %}
-{% endif %}
-<p>{% trans %}HTML Help (<tt>.chm</tt>) files are made available in the "{{ section }}" section
-on the <a href="https://www.python.org/{{ path }}/">Python download page</a>.{% endtrans %}</p>
+<p>{% trans download_page="https://www.python.org/downloads/release/python-" + release.replace('.', '') + "/" %}HTML Help
+(<tt>.chm</tt>) files are made available in the "Files" section
+on the <a href="{{ download_page }}">Python download page</a>.{% endtrans %}</p>
 
 
 <h2>{% trans %}Unpacking{% endtrans %}</h2>

--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -75,9 +75,18 @@ files in megabytes.{% endtrans %}</p>
 <p>{% trans %}These archives contain all the content in the
 documentation.{% endtrans %}</p>
 
-<p>{% trans download_page="https://www.python.org/download/releases/{{ release[:5] }}/" %}HTML Help
-(<tt>.chm</tt>) files are made available in the "Windows" section
-on the <a href={{ download_page }}>Python download page</a>.{% endtrans %}</p>
+{% if release == '2.7.0' %}
+  {% set path = 'download/releases/2.7' %}
+  {% set section = 'Download' %}
+{% elif release == '2.7.1' or ('2.7.1a' <= release < '2.7.8') %}
+  {% set path = 'download/releases/' + release[:5] %}
+  {% set section = 'Download' %}
+{% else %}
+  {% set path = 'downloads/release/python-' + release.replace('.', '') %}
+  {% set section = 'Files' %}
+{% endif %}
+<p>{% trans %}HTML Help (<tt>.chm</tt>) files are made available in the "{{ section }}" section
+on the <a href="https://www.python.org/{{ path }}/">Python download page</a>.{% endtrans %}</p>
 
 
 <h2>{% trans %}Unpacking{% endtrans %}</h2>


### PR DESCRIPTION
Formats of download page URLs and section names of download pages for each Python versions are vary.

see [bpo-29888](http://bugs.python.org/issue29888).