### PR TITLE
[3.5] bpo-29888: Fix the link referring to the "Python download page" (GH-824)

### DIFF
--- a/Doc/tools/templates/download.html
+++ b/Doc/tools/templates/download.html
@@ -42,7 +42,7 @@ in the table are the size of the download files in megabytes.</p>
 <p>These archives contain all the content in the documentation.</p>
 
 <p>HTML Help (<tt>.chm</tt>) files are made available in the "Windows" section
-on the <a href="https://www.python.org/download/releases/{{ release[:5] }}/">Python
+on the <a href="https://www.python.org/downloads/release/python-{{ release.replace('.', '') }}/">Python
 download page</a>.</p>
 
 


### PR DESCRIPTION
(cherry picked from commit f8beb9831acd5cf80b9c56aea5864e16118c5400)