### PR TITLE
Fix sphinx warning in "changelog" - Misc/NEWS

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -338,7 +338,7 @@ Library
 
 - bpo-29728: Add new :data:`socket.TCP_NOTSENT_LOWAT` (Linux 3.12) constant.
   Patch by Nathaniel J. Smith.
-  
+
 - bpo-29623: Allow use of path-like object as a single argument in
   ConfigParser.read().  Patch by David Ellis.
 
@@ -791,7 +791,7 @@ Library
 - Issue #24142: Reading a corrupt config file left configparser in an
   invalid state.  Original patch by Florian Höch.
 
-- Issue #29581: ABCMeta.__new__ now accepts **kwargs, allowing abstract base
+- Issue #29581: ABCMeta.__new__ now accepts ``**kwargs``, allowing abstract base
   classes to use keyword parameters in __init_subclass__. Patch by Nate Soares.
 
 Windows


### PR DESCRIPTION
When building the documentation sphinx shows an `../../Misc/NEWS:793: WARNING: Inline strong start-string without end-string.` warning. This leads to incorrect rendering (rendered as link) of the `**`.