### PR TITLE
bpo-29916: Include PyGetSetDef in C API extension documentation

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -306,9 +306,9 @@ definition with the same method name.
    +=============+==================+===================================+
    | name        | const char \*    | attribute name.                   |
    +-------------+------------------+-----------------------------------+
-   | get         | :c:type:`getter` | C Function to get the attribute   |
+   | get         | getter           | C Function to get the attribute   |
    +-------------+------------------+-----------------------------------+
-   | set         | :c:type:`setter` | optional C function to set or     |
+   | set         | setter           | optional C function to set or     |
    |             |                  | delete the attribute.  If omitted |
    |             |                  | the attribute is readonly.        |
    +-------------+------------------+-----------------------------------+
@@ -319,25 +319,16 @@ definition with the same method name.
    |             |                  | getter and setter.                |
    +-------------+------------------+-----------------------------------+
 
-
-.. c:type:: getter
-
-   Type of functions used to implement attribute get functions in C.
-   Functions of this type take one :c:type:`PyObject\*` parameter (the
+   The ``get`` function takes one :c:type:`PyObject\*` parameter (the
    instance) and a function pointer (the associated ``closure``)::
 
        typedef PyObject *(*getter)(PyObject *, void *);
 
-   Should return a new reference on success or *NULL* with a set exception on
-   failure.
+   It should return a new reference on success or *NULL* with a set exception
+   on failure.
 
-
-.. c:type:: setter
-
-   Type of functions used to implement attribute set functions in C.
-   Functions of this type take two :c:type:`PyObject\*` parameters (the
-   instance and the value to be set) and a function pointer
-   (the associated ``closure``)::
+   ``set`` functions take two :c:type:`PyObject\*` parameters (the instance and
+   the value to be set) and a function pointer (the associated ``closure``)::
 
        typedef int (*setter)(PyObject *, PyObject *, void *);
 

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -304,25 +304,25 @@ definition with the same method name.
    +-------------+------------------+-----------------------------------+
    | Field       | C Type           | Meaning                           |
    +=============+==================+===================================+
-   | name        | const char \*    | attribute name.                   |
+   | name        | const char \*    | attribute name                    |
    +-------------+------------------+-----------------------------------+
    | get         | getter           | C Function to get the attribute   |
    +-------------+------------------+-----------------------------------+
    | set         | setter           | optional C function to set or     |
-   |             |                  | delete the attribute.  If omitted |
-   |             |                  | the attribute is readonly.        |
+   |             |                  | delete the attribute, if omitted  |
+   |             |                  | the attribute is readonly         |
    +-------------+------------------+-----------------------------------+
    | doc         | const char \*    | optional docstring                |
    +-------------+------------------+-----------------------------------+
    | closure     | void \*          | optional function pointer,        |
    |             |                  | providing additional data for     |
-   |             |                  | getter and setter.                |
+   |             |                  | getter and setter                 |
    +-------------+------------------+-----------------------------------+
 
    The ``get`` function takes one :c:type:`PyObject\*` parameter (the
    instance) and a function pointer (the associated ``closure``)::
 
-       typedef PyObject *(*getter)(PyObject *, void *);
+      typedef PyObject *(*getter)(PyObject *, void *);
 
    It should return a new reference on success or *NULL* with a set exception
    on failure.
@@ -330,7 +330,7 @@ definition with the same method name.
    ``set`` functions take two :c:type:`PyObject\*` parameters (the instance and
    the value to be set) and a function pointer (the associated ``closure``)::
 
-       typedef int (*setter)(PyObject *, PyObject *, void *);
+      typedef int (*setter)(PyObject *, PyObject *, void *);
 
    In case the attribute should be deleted the second parameter is *NULL*.
    Should return ``0`` on success or ``-1`` with a set exception on failure.

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -294,3 +294,52 @@ definition with the same method name.
    read-only access.  Using :c:macro:`T_STRING` for :attr:`type` implies
    :c:macro:`READONLY`.  Only :c:macro:`T_OBJECT` and :c:macro:`T_OBJECT_EX`
    members can be deleted.  (They are set to *NULL*).
+
+
+.. c:type:: PyGetSetDef
+
+   Structure to define property-like access for a type. See also description of
+   the :c:member:`PyTypeObject.tp_getset` slot.
+
+   +-------------+------------------+-----------------------------------+
+   | Field       | C Type           | Meaning                           |
+   +=============+==================+===================================+
+   | name        | const char \*    | attribute name.                   |
+   +-------------+------------------+-----------------------------------+
+   | get         | :c:type:`getter` | C Function to get the attribute   |
+   +-------------+------------------+-----------------------------------+
+   | set         | :c:type:`setter` | optional C function to set or     |
+   |             |                  | delete the attribute.  If omitted |
+   |             |                  | the attribute is readonly.        |
+   +-------------+------------------+-----------------------------------+
+   | doc         | const char \*    | optional docstring                |
+   +-------------+------------------+-----------------------------------+
+   | closure     | void \*          | optional function pointer,        |
+   |             |                  | providing additional data for     |
+   |             |                  | getter and setter.                |
+   +-------------+------------------+-----------------------------------+
+
+
+.. c:type:: getter
+
+   Type of functions used to implement attribute get functions in C.
+   Functions of this type take one :c:type:`PyObject\*` parameter (the
+   instance) and a function pointer (the associated ``closure``)::
+
+       typedef PyObject *(*getter)(PyObject *, void *);
+
+   Should return a new reference on success or *NULL* with a set exception on
+   failure.
+
+
+.. c:type:: setter
+
+   Type of functions used to implement attribute set functions in C.
+   Functions of this type take two :c:type:`PyObject\*` parameters (the
+   instance and the value to be set) and a function pointer
+   (the associated ``closure``)::
+
+       typedef int (*setter)(PyObject *, PyObject *, void *);
+
+   In case the attribute should be deleted the second parameter is *NULL*.
+   Should return ``0`` on success or ``-1`` with a set exception on failure.

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -719,21 +719,6 @@ type objects) *must* have the :attr:`ob_size` field.
    This field is not inherited by subtypes (computed attributes are inherited
    through a different mechanism).
 
-   .. XXX belongs elsewhere
-
-   Docs for PyGetSetDef::
-
-      typedef PyObject *(*getter)(PyObject *, void *);
-      typedef int (*setter)(PyObject *, PyObject *, void *);
-
-      typedef struct PyGetSetDef {
-          const char *name; /* attribute name */
-          getter get;       /* C function to get the attribute */
-          setter set;       /* C function to set or delete the attribute */
-          const char *doc;  /* optional doc string */
-          void *closure;    /* optional additional data for getter and setter */
-      } PyGetSetDef;
-
 
 .. c:member:: PyTypeObject* PyTypeObject.tp_base
 


### PR DESCRIPTION
There is currently only indirect documentation of the `PyGetSetDef` struct in the documentation in the [`PyTypeObject.tp_getset`](https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_getset) slot. However the documentation there contains a note that it "belongs elsewhere".

The rendered documentation looks like this:

![unbenannt](https://cloud.githubusercontent.com/assets/14200878/24356883/f0ab1296-12fb-11e7-8f79-6eaf431d955d.png)

<!-- issue-number: bpo-29916 -->
https://bugs.python.org/issue29916
<!-- /issue-number -->
