### PR TITLE
[3.5][windows] bpo-27425: Add .gitattributes, fix Windows tests

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+*.pck binary
+Lib/test/cjkencodings/* binary
+Lib/test/decimaltestdata/*.decTest binary
+Lib/test/sndhdrdata/sndhdr.* binary
+Lib/test/test_email/data/msg_26.txt binary
+Lib/test/xmltestdata/* binary
+Lib/venv/scripts/nt/* binary
+Lib/test/coding20731.py binary


### PR DESCRIPTION
Mark binary files as binay in .gitattributes to not translate newline characters in Git repositories on Windows.

The git commit is not a cherry-pick, I simply copied the file from the master branch.