### PR TITLE
bpo-29912: Remove overlapping tests in list_tests and seq_tests

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -354,66 +354,9 @@ class CommonTest(seq_tests.CommonTest):
             # verify that original order and values are retained.
             self.assertIs(x, y)
 
-    def test_count(self):
-        a = self.type2test([0, 1, 2])*3
-        self.assertEqual(a.count(0), 3)
-        self.assertEqual(a.count(1), 3)
-        self.assertEqual(a.count(3), 0)
-
-        self.assertRaises(TypeError, a.count)
-
-        class BadExc(Exception):
-            pass
-
-        class BadCmp:
-            def __eq__(self, other):
-                if other == 2:
-                    raise BadExc()
-                return False
-
-        self.assertRaises(BadExc, a.count, BadCmp())
-
     def test_index(self):
-        u = self.type2test([0, 1])
-        self.assertEqual(u.index(0), 0)
-        self.assertEqual(u.index(1), 1)
-        self.assertRaises(ValueError, u.index, 2)
-
-        u = self.type2test([-2, -1, 0, 0, 1, 2])
-        self.assertEqual(u.count(0), 2)
-        self.assertEqual(u.index(0), 2)
-        self.assertEqual(u.index(0, 2), 2)
-        self.assertEqual(u.index(-2, -10), 0)
-        self.assertEqual(u.index(0, 3), 3)
-        self.assertEqual(u.index(0, 3, 4), 3)
-        self.assertRaises(ValueError, u.index, 2, 0, -10)
-
-        self.assertRaises(TypeError, u.index)
-
-        class BadExc(Exception):
-            pass
-
-        class BadCmp:
-            def __eq__(self, other):
-                if other == 2:
-                    raise BadExc()
-                return False
-
-        a = self.type2test([0, 1, 2, 3])
-        self.assertRaises(BadExc, a.index, BadCmp())
-
+        super().test_index()
         a = self.type2test([-2, -1, 0, 0, 1, 2])
-        self.assertEqual(a.index(0), 2)
-        self.assertEqual(a.index(0, 2), 2)
-        self.assertEqual(a.index(0, -4), 2)
-        self.assertEqual(a.index(-2, -10), 0)
-        self.assertEqual(a.index(0, 3), 3)
-        self.assertEqual(a.index(0, -3), 3)
-        self.assertEqual(a.index(0, 3, 4), 3)
-        self.assertEqual(a.index(0, -3, -2), 3)
-        self.assertEqual(a.index(0, -4*sys.maxsize, 4*sys.maxsize), 2)
-        self.assertRaises(ValueError, a.index, 0, 4*sys.maxsize,-4*sys.maxsize)
-        self.assertRaises(ValueError, a.index, 2, 0, -10)
         a.remove(0)
         self.assertRaises(ValueError, a.index, 2, 0, 4)
         self.assertEqual(a, self.type2test([-2, -1, 0, 1, 2]))
@@ -548,11 +491,7 @@ class CommonTest(seq_tests.CommonTest):
         self.assertRaises(TypeError, u.__iadd__, None)
 
     def test_imul(self):
-        u = self.type2test([0, 1])
-        u *= 3
-        self.assertEqual(u, self.type2test([0, 1, 0, 1, 0, 1]))
-        u *= 0
-        self.assertEqual(u, self.type2test([]))
+        super().test_imul()
         s = self.type2test([])
         oldid = id(s)
         s *= 10

--- a/Lib/test/seq_tests.py
+++ b/Lib/test/seq_tests.py
@@ -301,6 +301,8 @@ class CommonTest(unittest.TestCase):
         u = self.type2test([0, 1])
         u *= 3
         self.assertEqual(u, self.type2test([0, 1, 0, 1, 0, 1]))
+        u *= 0
+        self.assertEqual(u, self.type2test([]))
 
     def test_getitemoverwriteiter(self):
         # Verify that __getitem__ overrides are not recognized by __iter__


### PR DESCRIPTION
Specifically:

 - `test_count` in `list_tests` completely duplicates `test_count` in `seq_tests`
 - `test_index` mostly duplicates `test_index` in `seq_tests`, removed the duplicated tests and added a `super` call.
 - `test_imul` changed similarly to `test_index`.