### PR TITLE
bpo-24739: allow argparse.FileType to accept 'newline' keyword argument

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1158,13 +1158,17 @@ class FileType(object):
             builtin open() function.
         - errors -- A string indicating how encoding and decoding errors are to
             be handled. Accepts the same value as the builtin open() function.
+        - newline -- controls how universal newlines mode works (it only 
+            applies to text mode). Accepts the same value as the builtin open() 
+            function.
     """
 
-    def __init__(self, mode='r', bufsize=-1, encoding=None, errors=None):
+    def __init__(self, mode='r', bufsize=-1, encoding=None, errors=None, newline=None):
         self._mode = mode
         self._bufsize = bufsize
         self._encoding = encoding
         self._errors = errors
+        self._newline = newline
 
     def __call__(self, string):
         # the special argument "-" means sys.std{in,out}
@@ -1180,7 +1184,7 @@ class FileType(object):
         # all other arguments are used as file names
         try:
             return open(string, self._mode, self._bufsize, self._encoding,
-                        self._errors)
+                        self._errors, self._newline)
         except OSError as e:
             message = _("can't open '%s': %s")
             raise ArgumentTypeError(message % (string, e))

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1601,11 +1601,13 @@ class TestFileTypeOpenArgs(TestCase):
     def test_open_args(self):
         FT = argparse.FileType
         cases = [
-            (FT('rb'), ('rb', -1, None, None)),
-            (FT('w', 1), ('w', 1, None, None)),
-            (FT('w', errors='replace'), ('w', -1, None, 'replace')),
-            (FT('wb', encoding='big5'), ('wb', -1, 'big5', None)),
-            (FT('w', 0, 'l1', 'strict'), ('w', 0, 'l1', 'strict')),
+            (FT('rb'), ('rb', -1, None, None, None)),
+            (FT('w', 1), ('w', 1, None, None, None)),
+            (FT('w', errors='replace'), ('w', -1, None, 'replace', None)),
+            (FT('wb', encoding='big5'), ('wb', -1, 'big5', None, None)),
+            (FT('w', 0, 'l1', 'strict'), ('w', 0, 'l1', 'strict', None)),
+            (FT('w', 0, 'l1', 'strict', '\r\n'), ('w', 0, 'l1', 'strict', '\r\n')),
+            (FT('r', newline='\r'), ('r', -1, None, None, '\r')),
         ]
         with mock.patch('builtins.open') as m:
             for type, args in cases:


### PR DESCRIPTION
allow argparse.FileType to accept 'newline' keyword argument