### PR TITLE
[WIP] bpo-17870: Add support for C intmax_t type

### DIFF
--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -275,6 +275,11 @@ Numbers
 ``n`` (:class:`int`) [Py_ssize_t]
    Convert a Python integer to a C :c:type:`Py_ssize_t`.
 
+``m`` (:class:`int`) [intmax_t]
+   Convert a Python integer to a C :c:type:`intmax_t`.
+
+   .. versionadded:: 3.7
+
 ``c`` (:class:`bytes` or :class:`bytearray` of length 1) [char]
    Convert a Python byte, represented as a :class:`bytes` or
    :class:`bytearray` object of length 1, to a C :c:type:`char`.
@@ -600,6 +605,9 @@ Building values
    ``n`` (:class:`int`) [Py_ssize_t]
       Convert a C :c:type:`Py_ssize_t` to a Python integer.
 
+   ``m`` (:class:`int`) [intmax_t]
+      Convert a C :c:type:`intmax_t` to a Python integer.
+
    ``c`` (:class:`bytes` of length 1) [char]
       Convert a C :c:type:`int` representing a byte to a Python :class:`bytes` object of
       length 1.
@@ -652,6 +660,11 @@ Building values
 
    If there is an error in the format string, the :exc:`SystemError` exception is
    set and *NULL* returned.
+
+   .. versionchanged:: 3.7
+
+      Added ``m`` format for ``intmax_t``.
+
 
 .. c:function:: PyObject* Py_VaBuildValue(const char *format, va_list vargs)
 

--- a/Include/longobject.h
+++ b/Include/longobject.h
@@ -17,14 +17,19 @@ PyAPI_DATA(PyTypeObject) PyLong_Type;
 
 PyAPI_FUNC(PyObject *) PyLong_FromLong(long);
 PyAPI_FUNC(PyObject *) PyLong_FromUnsignedLong(unsigned long);
+PyAPI_FUNC(PyObject *) PyLong_FromIntMax(intmax_t);
+PyAPI_FUNC(PyObject *) PyLong_FromUIntMax(uintmax_t);
 PyAPI_FUNC(PyObject *) PyLong_FromSize_t(size_t);
 PyAPI_FUNC(PyObject *) PyLong_FromSsize_t(Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyLong_FromDouble(double);
 PyAPI_FUNC(long) PyLong_AsLong(PyObject *);
 PyAPI_FUNC(long) PyLong_AsLongAndOverflow(PyObject *, int *);
+PyAPI_FUNC(intmax_t) PyLong_AsIntMax(PyObject *);
+PyAPI_FUNC(intmax_t) PyLong_AsIntMaxAndOverflow(PyObject *, int *);
 PyAPI_FUNC(Py_ssize_t) PyLong_AsSsize_t(PyObject *);
 PyAPI_FUNC(size_t) PyLong_AsSize_t(PyObject *);
 PyAPI_FUNC(unsigned long) PyLong_AsUnsignedLong(PyObject *);
+PyAPI_FUNC(uintmax_t) PyLong_AsUIntMax(PyObject *);
 PyAPI_FUNC(unsigned long) PyLong_AsUnsignedLongMask(PyObject *);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyLong_AsInt(PyObject *);

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -1442,9 +1442,9 @@ static PyModuleDef _lzmamodule = {
 /* Some of our constants are more than 32 bits wide, so PyModule_AddIntConstant
    would not work correctly on platforms with 32-bit longs. */
 static int
-module_add_int_constant(PyObject *m, const char *name, long long value)
+module_add_int_constant(PyObject *m, const char *name, intmax_t value)
 {
-    PyObject *o = PyLong_FromLongLong(value);
+    PyObject *o = PyLong_FromIntMax(value);
     if (o == NULL)
         return -1;
     if (PyModule_AddObject(m, name, o) == 0)

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -61,6 +61,7 @@ test_config(PyObject *self)
     CHECK_SIZEOF(SIZEOF_VOID_P, void*);
     CHECK_SIZEOF(SIZEOF_TIME_T, time_t);
     CHECK_SIZEOF(SIZEOF_LONG_LONG, long long);
+    CHECK_SIZEOF(SIZEOF_INTMAX_T, intmax_t);
 
 #undef CHECK_SIZEOF
 
@@ -401,6 +402,7 @@ raise_test_long_error(const char* msg)
 
 #define TESTNAME        test_long_api_inner
 #define TYPENAME        long
+#define UTYPENAME       unsigned long
 #define F_S_TO_PY       PyLong_FromLong
 #define F_PY_TO_S       PyLong_AsLong
 #define F_U_TO_PY       PyLong_FromUnsignedLong
@@ -416,10 +418,45 @@ test_long_api(PyObject* self)
 
 #undef TESTNAME
 #undef TYPENAME
+#undef UTYPENAME
 #undef F_S_TO_PY
 #undef F_PY_TO_S
 #undef F_U_TO_PY
 #undef F_PY_TO_U
+
+/* intmax_t */
+
+static PyObject *
+raise_test_long_intmax_error(const char* msg)
+{
+    return raiseTestError("test_long_intmax_api", msg);
+}
+
+#define TESTNAME        test_long_intmax_api_inner
+#define TYPENAME        intmax_t
+#define UTYPENAME       uintmax_t
+#define F_S_TO_PY       PyLong_FromIntMax
+#define F_PY_TO_S       PyLong_AsIntMax
+#define F_U_TO_PY       PyLong_FromUIntMax
+#define F_PY_TO_U       PyLong_AsUIntMax
+
+#include "testcapi_long.h"
+
+static PyObject *
+test_long_intmax_api(PyObject* self, PyObject *args)
+{
+    return TESTNAME(raise_test_long_intmax_error);
+}
+
+#undef TESTNAME
+#undef TYPENAME
+#undef UTYPENAME
+#undef F_S_TO_PY
+#undef F_PY_TO_S
+#undef F_U_TO_PY
+#undef F_PY_TO_U
+
+/* long long */
 
 static PyObject *
 raise_test_longlong_error(const char* msg)
@@ -429,6 +466,7 @@ raise_test_longlong_error(const char* msg)
 
 #define TESTNAME        test_longlong_api_inner
 #define TYPENAME        long long
+#define UTYPENAME       unsigned long long
 #define F_S_TO_PY       PyLong_FromLongLong
 #define F_PY_TO_S       PyLong_AsLongLong
 #define F_U_TO_PY       PyLong_FromUnsignedLongLong
@@ -444,6 +482,7 @@ test_longlong_api(PyObject* self, PyObject *args)
 
 #undef TESTNAME
 #undef TYPENAME
+#undef UTYPENAME
 #undef F_S_TO_PY
 #undef F_PY_TO_S
 #undef F_U_TO_PY
@@ -1164,6 +1203,15 @@ getargs_K(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "K", &value))
         return NULL;
     return PyLong_FromUnsignedLongLong(value);
+}
+
+static PyObject *
+getargs_m(PyObject *self, PyObject *args)
+{
+    intmax_t value;
+    if (!PyArg_ParseTuple(args, "m", &value))
+        return NULL;
+    return PyLong_FromIntMax(value);
 }
 
 /* This function not only tests the 'k' getargs code, but also the
@@ -4041,6 +4089,7 @@ static PyMethodDef TestMethods[] = {
     {"dict_hassplittable",      dict_hassplittable,              METH_O},
     {"test_lazy_hash_inheritance",      (PyCFunction)test_lazy_hash_inheritance,METH_NOARGS},
     {"test_long_api",           (PyCFunction)test_long_api,      METH_NOARGS},
+    {"test_long_intmax_api",           (PyCFunction)test_long_intmax_api,      METH_NOARGS},
     {"test_xincref_doesnt_leak",(PyCFunction)test_xincref_doesnt_leak,      METH_NOARGS},
     {"test_incref_doesnt_leak", (PyCFunction)test_incref_doesnt_leak,      METH_NOARGS},
     {"test_xdecref_doesnt_leak",(PyCFunction)test_xdecref_doesnt_leak,      METH_NOARGS},
@@ -4089,6 +4138,7 @@ static PyMethodDef TestMethods[] = {
     {"getargs_p",               getargs_p,                       METH_VARARGS},
     {"getargs_L",               getargs_L,                       METH_VARARGS},
     {"getargs_K",               getargs_K,                       METH_VARARGS},
+    {"getargs_m",               getargs_m,                       METH_VARARGS},
     {"test_longlong_api",       test_longlong_api,               METH_NOARGS},
     {"test_long_long_and_overflow",
         (PyCFunction)test_long_long_and_overflow, METH_NOARGS},
@@ -4627,7 +4677,10 @@ PyInit__testcapi(void)
     PyModule_AddObject(m, "UINT_MAX",  PyLong_FromUnsignedLong(UINT_MAX));
     PyModule_AddObject(m, "LONG_MAX", PyLong_FromLong(LONG_MAX));
     PyModule_AddObject(m, "LONG_MIN", PyLong_FromLong(LONG_MIN));
+    PyModule_AddObject(m, "INTMAX_MAX", PyLong_FromIntMax(INTMAX_MAX));
+    PyModule_AddObject(m, "INTMAX_MIN", PyLong_FromIntMax(INTMAX_MIN));
     PyModule_AddObject(m, "ULONG_MAX", PyLong_FromUnsignedLong(ULONG_MAX));
+    PyModule_AddObject(m, "UINTMAX_MAX", PyLong_FromUIntMax(UINTMAX_MAX));
     PyModule_AddObject(m, "FLT_MAX", PyFloat_FromDouble(FLT_MAX));
     PyModule_AddObject(m, "FLT_MIN", PyFloat_FromDouble(FLT_MIN));
     PyModule_AddObject(m, "DBL_MAX", PyFloat_FromDouble(DBL_MAX));

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -1182,8 +1182,9 @@ fromWideIntObj(PyObject* tkapp, Tcl_Obj *value)
 {
         Tcl_WideInt wideValue;
         if (Tcl_GetWideIntFromObj(Tkapp_Interp(tkapp), value, &wideValue) == TCL_OK) {
-            if (sizeof(wideValue) <= SIZEOF_LONG_LONG)
-                return PyLong_FromLongLong(wideValue);
+            if (sizeof(wideValue) <= SIZEOF_INTMAX_T) {
+                return PyLong_FromIntMax(wideValue);
+            }
             return _PyLong_FromByteArray((unsigned char *)(void *)&wideValue,
                                          sizeof(wideValue),
                                          PY_LITTLE_ENDIAN,

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -3606,7 +3606,7 @@ os_lseek(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
-    return_value = PyLong_FromPy_off_t(_return_value);
+    return_value = PyLong_FromIntMax(_return_value);
 
 exit:
     return return_value;
@@ -6493,4 +6493,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=5a0be969e3f71660 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e3c4d69deb356f4c input=a9049054013a1b77]*/

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -432,7 +432,7 @@ mmap_size_method(mmap_object *self,
 #ifdef MS_WINDOWS
     if (self->file_handle != INVALID_HANDLE_VALUE) {
         DWORD low,high;
-        long long size;
+        intmax_t size;
         low = GetFileSize(self->file_handle, &high);
         if (low == INVALID_FILE_SIZE) {
             /* It might be that the function appears to have failed,
@@ -443,8 +443,8 @@ mmap_size_method(mmap_object *self,
         }
         if (!high && low < LONG_MAX)
             return PyLong_FromLong((long)low);
-        size = (((long long)high)<<32) + low;
-        return PyLong_FromLongLong(size);
+        size = (((intmax_t)high)<<32) + low;
+        return PyLong_FromIntMax(size);
     } else {
         return PyLong_FromSsize_t(self->size);
     }
@@ -455,11 +455,7 @@ mmap_size_method(mmap_object *self,
         struct _Py_stat_struct status;
         if (_Py_fstat(self->fd, &status) == -1)
             return NULL;
-#ifdef HAVE_LARGEFILE_SUPPORT
-        return PyLong_FromLongLong(status.st_size);
-#else
-        return PyLong_FromLong(status.st_size);
-#endif
+        return PyLong_FromIntMax(status.st_size);
     }
 #endif /* UNIX */
 }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -645,7 +645,7 @@ fail:
 #endif /* MS_WINDOWS */
 
 
-#define _PyLong_FromDev PyLong_FromLongLong
+#define _PyLong_FromDev PyLong_FromIntMax
 
 
 #if defined(HAVE_MKNOD) && defined(HAVE_MAKEDEV)
@@ -1165,16 +1165,6 @@ Py_off_t_converter(PyObject *arg, void *addr)
     if (PyErr_Occurred())
         return 0;
     return 1;
-}
-
-static PyObject *
-PyLong_FromPy_off_t(Py_off_t offset)
-{
-#ifdef HAVE_LARGEFILE_SUPPORT
-    return PyLong_FromLongLong(offset);
-#else
-    return PyLong_FromLong(offset);
-#endif
 }
 
 #ifdef MS_WINDOWS
@@ -1927,14 +1917,8 @@ _pystat_fromstructstat(STRUCT_STAT *st)
         return NULL;
 
     PyStructSequence_SET_ITEM(v, 0, PyLong_FromLong((long)st->st_mode));
-#if defined(HAVE_LARGEFILE_SUPPORT) || defined(MS_WINDOWS)
-    Py_BUILD_ASSERT(sizeof(unsigned long long) >= sizeof(st->st_ino));
     PyStructSequence_SET_ITEM(v, 1,
-                              PyLong_FromUnsignedLongLong(st->st_ino));
-#else
-    Py_BUILD_ASSERT(sizeof(unsigned long) >= sizeof(st->st_ino));
-    PyStructSequence_SET_ITEM(v, 1, PyLong_FromUnsignedLong(st->st_ino));
-#endif
+                              PyLong_FromUIntMax(st->st_ino));
 #ifdef MS_WINDOWS
     PyStructSequence_SET_ITEM(v, 2, PyLong_FromUnsignedLong(st->st_dev));
 #else
@@ -1948,12 +1932,7 @@ _pystat_fromstructstat(STRUCT_STAT *st)
     PyStructSequence_SET_ITEM(v, 4, _PyLong_FromUid(st->st_uid));
     PyStructSequence_SET_ITEM(v, 5, _PyLong_FromGid(st->st_gid));
 #endif
-#ifdef HAVE_LARGEFILE_SUPPORT
-    PyStructSequence_SET_ITEM(v, 6,
-                              PyLong_FromLongLong((long long)st->st_size));
-#else
-    PyStructSequence_SET_ITEM(v, 6, PyLong_FromLong(st->st_size));
-#endif
+    PyStructSequence_SET_ITEM(v, 6, PyLong_FromIntMax(st->st_size));
 
 #if defined(HAVE_STAT_TV_NSEC)
     ansec = st->st_atim.tv_nsec;
@@ -2358,7 +2337,7 @@ class Py_off_t_converter(CConverter):
 
 class Py_off_t_return_converter(long_return_converter):
     type = 'Py_off_t'
-    conversion_fn = 'PyLong_FromPy_off_t'
+    conversion_fn = 'PyLong_FromIntMax'
 
 class path_confname_converter(CConverter):
     type="int"
@@ -2376,7 +2355,7 @@ class sched_param_converter(CConverter):
     impl_by_reference = True;
 
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=418fce0e01144461]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=6810f54d2201a416]*/
 
 /*[clinic input]
 
@@ -9153,18 +9132,12 @@ _pystatvfs_fromstructstatvfs(struct statvfs st) {
 #else
     PyStructSequence_SET_ITEM(v, 0, PyLong_FromLong((long) st.f_bsize));
     PyStructSequence_SET_ITEM(v, 1, PyLong_FromLong((long) st.f_frsize));
-    PyStructSequence_SET_ITEM(v, 2,
-                              PyLong_FromLongLong((long long) st.f_blocks));
-    PyStructSequence_SET_ITEM(v, 3,
-                              PyLong_FromLongLong((long long) st.f_bfree));
-    PyStructSequence_SET_ITEM(v, 4,
-                              PyLong_FromLongLong((long long) st.f_bavail));
-    PyStructSequence_SET_ITEM(v, 5,
-                              PyLong_FromLongLong((long long) st.f_files));
-    PyStructSequence_SET_ITEM(v, 6,
-                              PyLong_FromLongLong((long long) st.f_ffree));
-    PyStructSequence_SET_ITEM(v, 7,
-                              PyLong_FromLongLong((long long) st.f_favail));
+    PyStructSequence_SET_ITEM(v, 2, PyLong_FromIntMax(st.f_blocks));
+    PyStructSequence_SET_ITEM(v, 3, PyLong_FromIntMax(st.f_bfree));
+    PyStructSequence_SET_ITEM(v, 4, PyLong_FromIntMax(st.f_bavail));
+    PyStructSequence_SET_ITEM(v, 5, PyLong_FromIntMax(st.f_files));
+    PyStructSequence_SET_ITEM(v, 6, PyLong_FromIntMax(st.f_ffree));
+    PyStructSequence_SET_ITEM(v, 7, PyLong_FromIntMax(st.f_favail));
     PyStructSequence_SET_ITEM(v, 8, PyLong_FromLong((long) st.f_flag));
     PyStructSequence_SET_ITEM(v, 9, PyLong_FromLong((long) st.f_namemax));
 #endif
@@ -11414,11 +11387,7 @@ os_DirEntry_inode_impl(DirEntry *self)
     Py_BUILD_ASSERT(sizeof(unsigned long long) >= sizeof(self->win32_file_index));
     return PyLong_FromUnsignedLongLong(self->win32_file_index);
 #else /* POSIX */
-#ifdef HAVE_LARGEFILE_SUPPORT
-    return PyLong_FromLongLong((long long)self->d_ino);
-#else
-    return PyLong_FromLong((long)self->d_ino);
-#endif
+    return PyLong_FromUIntMax((long)self->d_ino);
 #endif
 }
 

--- a/Modules/resource.c
+++ b/Modules/resource.c
@@ -473,12 +473,7 @@ PyInit_resource(void)
     PyModule_AddIntMacro(m, RLIMIT_NPTS);
 #endif
 
-    if (sizeof(RLIM_INFINITY) > sizeof(long)) {
-        v = PyLong_FromLongLong((long long) RLIM_INFINITY);
-    } else
-    {
-        v = PyLong_FromLong((long) RLIM_INFINITY);
-    }
+    v = PyLong_FromIntMax(RLIM_INFINITY);
     if (v) {
         PyModule_AddObject(m, "RLIM_INFINITY", v);
     }

--- a/Modules/testcapi_long.h
+++ b/Modules/testcapi_long.h
@@ -1,6 +1,7 @@
 /* Poor-man's template.  Macros used:
    TESTNAME     name of the test (like test_long_api_inner)
    TYPENAME     the signed type (like long)
+   UTYPENAME    the unsigned type (like unsigned long)
    F_S_TO_PY    convert signed to pylong; TYPENAME -> PyObject*
    F_PY_TO_S    convert pylong to signed; PyObject* -> TYPENAME
    F_U_TO_PY    convert unsigned to pylong; unsigned TYPENAME -> PyObject*
@@ -11,7 +12,7 @@ static PyObject *
 TESTNAME(PyObject *error(const char*))
 {
     const int NBITS = sizeof(TYPENAME) * 8;
-    unsigned TYPENAME base;
+    UTYPENAME base;
     PyObject *pyresult;
     int i;
 
@@ -30,7 +31,7 @@ TESTNAME(PyObject *error(const char*))
         int j;
         for (j = 0; j < 6; ++j) {
             TYPENAME in, out;
-            unsigned TYPENAME uin, uout;
+            UTYPENAME uin, uout;
 
             /* For 0, 1, 2 use base; for 3, 4, 5 use -base */
             uin = j < 3 ? base : 0U - base;
@@ -39,7 +40,7 @@ TESTNAME(PyObject *error(const char*))
              * For 1 & 4, leave alone.
              * For 2 & 5, add 1.
              */
-            uin += (unsigned TYPENAME)(TYPENAME)(j % 3 - 1);
+            uin += (UTYPENAME)(TYPENAME)(j % 3 - 1);
 
             pyresult = F_U_TO_PY(uin);
             if (pyresult == NULL)
@@ -47,7 +48,7 @@ TESTNAME(PyObject *error(const char*))
                  "unsigned unexpected null result");
 
             uout = F_PY_TO_U(pyresult);
-            if (uout == (unsigned TYPENAME)-1 && PyErr_Occurred())
+            if (uout == (UTYPENAME)-1 && PyErr_Occurred())
                 return error(
                     "unsigned unexpected -1 result");
             if (uout != uin)
@@ -79,7 +80,7 @@ TESTNAME(PyObject *error(const char*))
     {
         PyObject *one, *x, *y;
         TYPENAME out;
-        unsigned TYPENAME uout;
+        UTYPENAME uout;
 
         one = PyLong_FromLong(1);
         if (one == NULL)
@@ -93,7 +94,7 @@ TESTNAME(PyObject *error(const char*))
                 "unexpected NULL from PyNumber_Negative");
 
         uout = F_PY_TO_U(x);
-        if (uout != (unsigned TYPENAME)-1 || !PyErr_Occurred())
+        if (uout != (UTYPENAME)-1 || !PyErr_Occurred())
             return error(
                 "PyLong_AsUnsignedXXX(-1) didn't complain");
         if (!PyErr_ExceptionMatches(PyExc_OverflowError))
@@ -116,7 +117,7 @@ TESTNAME(PyObject *error(const char*))
                 "unexpected NULL from PyNumber_Lshift");
 
         uout = F_PY_TO_U(x);
-        if (uout != (unsigned TYPENAME)-1 || !PyErr_Occurred())
+        if (uout != (UTYPENAME)-1 || !PyErr_Occurred())
             return error(
                 "PyLong_AsUnsignedXXX(2**NBITS) didn't "
                 "complain");
@@ -179,7 +180,7 @@ TESTNAME(PyObject *error(const char*))
     /* Test F_PY_TO_{S,U} on non-pylong input. This should raise a TypeError. */
     {
         TYPENAME out;
-        unsigned TYPENAME uout;
+        UTYPENAME uout;
 
         Py_INCREF(Py_None);
 
@@ -192,7 +193,7 @@ TESTNAME(PyObject *error(const char*))
         PyErr_Clear();
 
         uout = F_PY_TO_U(Py_None);
-        if (uout != (unsigned TYPENAME)-1 || !PyErr_Occurred())
+        if (uout != (UTYPENAME)-1 || !PyErr_Occurred())
             return error("PyLong_AsXXX(None) didn't complain");
         if (!PyErr_ExceptionMatches(PyExc_TypeError))
             return error("PyLong_AsXXX(None) raised "

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -304,6 +304,76 @@ PyLong_FromLong(long ival)
     return (PyObject *)v;
 }
 
+/* Create a new int object from a C intmax_t */
+
+PyObject *
+PyLong_FromIntMax(intmax_t ival)
+{
+    PyLongObject *v;
+    uintmax_t abs_ival;
+    uintmax_t t;  /* unsigned so >> doesn't propagate sign bit */
+    int ndigits = 0;
+    int sign;
+
+    CHECK_SMALL_INT(ival);
+
+    if (ival < 0) {
+        /* negate: can't write this as abs_ival = -ival since that
+           invokes undefined behaviour when ival is LONG_MIN */
+        abs_ival = 0U-(uintmax_t)ival;
+        sign = -1;
+    }
+    else {
+        abs_ival = (uintmax_t)ival;
+        sign = ival == 0 ? 0 : 1;
+    }
+
+    /* Fast path for single-digit ints */
+    if (!(abs_ival >> PyLong_SHIFT)) {
+        v = _PyLong_New(1);
+        if (v) {
+            Py_SIZE(v) = sign;
+            v->ob_digit[0] = Py_SAFE_DOWNCAST(
+                abs_ival, uintmax_t, digit);
+        }
+        return (PyObject*)v;
+    }
+
+#if PyLong_SHIFT==15
+    /* 2 digits */
+    if (!(abs_ival >> 2*PyLong_SHIFT)) {
+        v = _PyLong_New(2);
+        if (v) {
+            Py_SIZE(v) = 2*sign;
+            v->ob_digit[0] = Py_SAFE_DOWNCAST(
+                abs_ival & PyLong_MASK, uintmax_t, digit);
+            v->ob_digit[1] = Py_SAFE_DOWNCAST(
+                  abs_ival >> PyLong_SHIFT, uintmax_t, digit);
+        }
+        return (PyObject*)v;
+    }
+#endif
+
+    /* Larger numbers: loop to determine number of digits */
+    t = abs_ival;
+    while (t) {
+        ++ndigits;
+        t >>= PyLong_SHIFT;
+    }
+    v = _PyLong_New(ndigits);
+    if (v != NULL) {
+        digit *p = v->ob_digit;
+        Py_SIZE(v) = ndigits*sign;
+        t = abs_ival;
+        while (t) {
+            *p++ = Py_SAFE_DOWNCAST(
+                t & PyLong_MASK, uintmax_t, digit);
+            t >>= PyLong_SHIFT;
+        }
+    }
+    return (PyObject *)v;
+}
+
 /* Create a new int object from a C unsigned long int */
 
 PyObject *
@@ -315,12 +385,44 @@ PyLong_FromUnsignedLong(unsigned long ival)
 
     if (ival < PyLong_BASE)
         return PyLong_FromLong(ival);
+
     /* Count the number of Python digits. */
     t = ival;
     while (t) {
         ++ndigits;
         t >>= PyLong_SHIFT;
     }
+
+    v = _PyLong_New(ndigits);
+    if (v != NULL) {
+        digit *p = v->ob_digit;
+        while (ival) {
+            *p++ = (digit)(ival & PyLong_MASK);
+            ival >>= PyLong_SHIFT;
+        }
+    }
+    return (PyObject *)v;
+}
+
+/* Create a new int object from a C unsigned long int */
+
+PyObject *
+PyLong_FromUIntMax(uintmax_t ival)
+{
+    PyLongObject *v;
+    uintmax_t t;
+    int ndigits = 0;
+
+    if (ival < PyLong_BASE)
+        return PyLong_FromLong(ival);
+
+    /* Count the number of Python digits. */
+    t = ival;
+    while (t) {
+        ++ndigits;
+        t >>= PyLong_SHIFT;
+    }
+
     v = _PyLong_New(ndigits);
     if (v != NULL) {
         digit *p = v->ob_digit;
@@ -472,7 +574,104 @@ PyLong_AsLongAndOverflow(PyObject *vv, int *overflow)
     return res;
 }
 
+/* Checking for overflow in PyLong_AsIntMax is a PITA since C doesn't define
+ * anything about what happens when a signed integer operation overflows,
+ * and some compilers think they're doing you a favor by being "clever"
+ * then.  The bit pattern for the largest positive signed long is
+ * (unsigned long)INTMAX_MAX, and for the smallest negative signed long
+ * it is abs(INTMAX_MIN), which we could write -(unsigned long)INTMAX_MIN.
+ * However, some other compilers warn about applying unary minus to an
+ * unsigned operand.  Hence the weird "0-".
+ */
+#define PY_ABS_INTMAX_MIN         (0-(uintmax_t)INTMAX_MIN)
+
 /* Get a C long int from an int object or any object that has an __int__
+   method.
+
+   On overflow, return -1 and set *overflow to 1 or -1 depending on the sign of
+   the result.  Otherwise *overflow is 0.
+
+   For other errors (e.g., TypeError), return -1 and set an error condition.
+   In this case *overflow will be 0.
+*/
+
+intmax_t
+PyLong_AsIntMaxAndOverflow(PyObject *vv, int *overflow)
+{
+    /* This version by Tim Peters */
+    PyLongObject *v;
+    uintmax_t x, prev;
+    intmax_t res;
+    Py_ssize_t i;
+    int sign;
+    int do_decref = 0; /* if nb_int was called */
+
+    *overflow = 0;
+    if (vv == NULL) {
+        PyErr_BadInternalCall();
+        return -1;
+    }
+
+    if (PyLong_Check(vv)) {
+        v = (PyLongObject *)vv;
+    }
+    else {
+        v = _PyLong_FromNbInt(vv);
+        if (v == NULL)
+            return -1;
+        do_decref = 1;
+    }
+
+    res = -1;
+    i = Py_SIZE(v);
+
+    switch (i) {
+    case -1:
+        res = -(sdigit)v->ob_digit[0];
+        break;
+    case 0:
+        res = 0;
+        break;
+    case 1:
+        res = v->ob_digit[0];
+        break;
+    default:
+        sign = 1;
+        x = 0;
+        if (i < 0) {
+            sign = -1;
+            i = -(i);
+        }
+        while (--i >= 0) {
+            prev = x;
+            x = (x << PyLong_SHIFT) | v->ob_digit[i];
+            if ((x >> PyLong_SHIFT) != prev) {
+                *overflow = sign;
+                goto exit;
+            }
+        }
+        /* Haven't lost any bits, but casting to intmax_t requires extra
+         * care (see comment above).
+         */
+        if (x <= (uintmax_t)INTMAX_MAX) {
+            res = (intmax_t)x * sign;
+        }
+        else if (sign < 0 && x == PY_ABS_INTMAX_MIN) {
+            res = INTMAX_MIN;
+        }
+        else {
+            *overflow = sign;
+            /* res is already set to -1 */
+        }
+    }
+  exit:
+    if (do_decref) {
+        Py_DECREF(v);
+    }
+    return res;
+}
+
+/* Get a C long int from a Python int object or any object that has an __int__
    method.  Return -1 and set an error if overflow occurs. */
 
 long
@@ -480,6 +679,23 @@ PyLong_AsLong(PyObject *obj)
 {
     int overflow;
     long result = PyLong_AsLongAndOverflow(obj, &overflow);
+    if (overflow) {
+        /* XXX: could be cute and give a different
+           message for overflow == -1 */
+        PyErr_SetString(PyExc_OverflowError,
+                        "Python int too large to convert to C long");
+    }
+    return result;
+}
+
+/* Get a C intmax_t from a Python int object or any object that has an __int__
+   method.  Return -1 and set an error if overflow occurs. */
+
+long
+PyLong_AsIntMax(PyObject *obj)
+{
+    int overflow;
+    long result = PyLong_AsIntMaxAndOverflow(obj, &overflow);
     if (overflow) {
         /* XXX: could be cute and give a different
            message for overflow == -1 */
@@ -562,7 +778,7 @@ PyLong_AsSsize_t(PyObject *vv) {
     return -1;
 }
 
-/* Get a C unsigned long int from an int object.
+/* Get a C unsigned long int from a Python int object.
    Returns -1 and sets an error condition if overflow occurs. */
 
 unsigned long
@@ -601,6 +817,50 @@ PyLong_AsUnsignedLong(PyObject *vv)
                             "Python int too large to convert "
                             "to C unsigned long");
             return (unsigned long) -1;
+        }
+    }
+    return x;
+}
+
+/* Get a C uintmax_t int from a Python int object.
+   Returns -1 and sets an error condition if overflow occurs. */
+
+uintmax_t
+PyLong_AsUIntMax(PyObject *vv)
+{
+    PyLongObject *v;
+    uintmax_t x, prev;
+    Py_ssize_t i;
+
+    if (vv == NULL) {
+        PyErr_BadInternalCall();
+        return (uintmax_t)-1;
+    }
+    if (!PyLong_Check(vv)) {
+        PyErr_SetString(PyExc_TypeError, "an integer is required");
+        return (uintmax_t)-1;
+    }
+
+    v = (PyLongObject *)vv;
+    i = Py_SIZE(v);
+    x = 0;
+    if (i < 0) {
+        PyErr_SetString(PyExc_OverflowError,
+                        "can't convert negative value to uintmax_t");
+        return (uintmax_t) -1;
+    }
+    switch (i) {
+    case 0: return 0;
+    case 1: return v->ob_digit[0];
+    }
+    while (--i >= 0) {
+        prev = x;
+        x = (x << PyLong_SHIFT) | v->ob_digit[i];
+        if ((x >> PyLong_SHIFT) != prev) {
+            PyErr_SetString(PyExc_OverflowError,
+                            "Python int too large to convert "
+                            "to C uintmax_t");
+            return (uintmax_t) -1;
         }
     }
     return x;
@@ -1016,16 +1276,7 @@ _PyLong_AsByteArray(PyLongObject* v,
 PyObject *
 PyLong_FromVoidPtr(void *p)
 {
-#if SIZEOF_VOID_P <= SIZEOF_LONG
-    return PyLong_FromUnsignedLong((unsigned long)(uintptr_t)p);
-#else
-
-#if SIZEOF_LONG_LONG < SIZEOF_VOID_P
-#   error "PyLong_FromVoidPtr: sizeof(long long) < sizeof(void*)"
-#endif
-    return PyLong_FromUnsignedLongLong((unsigned long long)(uintptr_t)p);
-#endif /* SIZEOF_VOID_P <= SIZEOF_LONG */
-
+    return PyLong_FromUIntMax((uintptr_t)p);
 }
 
 /* Get a C pointer from an int object. */
@@ -1033,30 +1284,27 @@ PyLong_FromVoidPtr(void *p)
 void *
 PyLong_AsVoidPtr(PyObject *vv)
 {
-#if SIZEOF_VOID_P <= SIZEOF_LONG
-    long x;
+    uintptr_t u;
 
-    if (PyLong_Check(vv) && _PyLong_Sign(vv) < 0)
-        x = PyLong_AsLong(vv);
-    else
-        x = PyLong_AsUnsignedLong(vv);
-#else
+    if (PyLong_Check(vv) && _PyLong_Sign(vv) < 0) {
+        intmax_t x = PyLong_AsIntMax(vv);
+        if (x == -1 && PyErr_Occurred()) {
+            return NULL;
+        }
 
-#if SIZEOF_LONG_LONG < SIZEOF_VOID_P
-#   error "PyLong_AsVoidPtr: sizeof(long long) < sizeof(void*)"
-#endif
-    long long x;
+        Py_BUILD_ASSERT(sizeof(uintptr_t) == sizeof(intmax_t));
+        u = (uintptr_t)x;
+    }
+    else {
+        uintmax_t x = PyLong_AsUIntMax(vv);
+        if (x == (uintmax_t)-1 && PyErr_Occurred()) {
+            return NULL;
+        }
 
-    if (PyLong_Check(vv) && _PyLong_Sign(vv) < 0)
-        x = PyLong_AsLongLong(vv);
-    else
-        x = PyLong_AsUnsignedLongLong(vv);
-
-#endif /* SIZEOF_VOID_P <= SIZEOF_LONG */
-
-    if (x == -1 && PyErr_Occurred())
-        return NULL;
-    return (void *)x;
+        Py_BUILD_ASSERT(sizeof(uintptr_t) == sizeof(uintmax_t));
+        u = (uintptr_t)x;
+    }
+    return (void *)u;
 }
 
 /* Initial long long support by Chris Herborth (chrish@qnx.com), later

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -346,6 +346,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 #define SIZEOF_LONG_LONG 8
 #define SIZEOF_DOUBLE 8
 #define SIZEOF_FLOAT 4
+#define SIZEOF_INTMAX_T 8
 
 /* VC 7.1 has them and VC 6.0 does not.  VC 6.0 has a version number of 1200.
    Microsoft eMbedded Visual C++ 4.0 has a version number of 1201 and doesn't

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -805,6 +805,7 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
         *p = ival;
         break;
     }
+
     case 'l': {/* long int */
         long *p = va_arg(*p_va, long *);
         long ival;
@@ -850,6 +851,22 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
         else
             return converterr("int", arg, msgbuf, bufsize);
         *p = ival;
+        break;
+    }
+
+    case 'm': { /* intmax_t */
+        intmax_t *p = va_arg(*p_va, intmax_t *);
+        intmax_t ival;
+        if (float_argument_error(arg)) {
+            RETURN_ERR_OCCURRED;
+        }
+        ival = PyLong_AsIntMax(arg);
+        if (ival == -1 && PyErr_Occurred()) {
+            RETURN_ERR_OCCURRED;
+        }
+        else {
+            *p = ival;
+        }
         break;
     }
 
@@ -2241,6 +2258,7 @@ skipitem(const char **p_format, va_list *p_va, int flags)
     case 'L': /* long long */
     case 'K': /* long long sized bitfield */
     case 'n': /* Py_ssize_t */
+    case 'm': /* intmax_t */
     case 'f': /* float */
     case 'd': /* double */
     case 'D': /* complex double */

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -295,6 +295,9 @@ do_mkvalue(const char **p_format, va_list *p_va, int flags)
         case 'l':
             return PyLong_FromLong(va_arg(*p_va, long));
 
+        case 'm':
+            return PyLong_FromIntMax(va_arg(*p_va, intmax_t));
+
         case 'k':
         {
             unsigned long n;

--- a/configure
+++ b/configure
@@ -8759,6 +8759,39 @@ cat >>confdefs.h <<_ACEOF
 _ACEOF
 
 
+# The cast to long int works around a bug in the HP C Compiler
+# version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
+# declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
+# This bug is HP SR number 8606223364.
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking size of intmax_t" >&5
+$as_echo_n "checking size of intmax_t... " >&6; }
+if ${ac_cv_sizeof_intmax_t+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if ac_fn_c_compute_int "$LINENO" "(long int) (sizeof (intmax_t))" "ac_cv_sizeof_intmax_t"        "$ac_includes_default"; then :
+
+else
+  if test "$ac_cv_type_intmax_t" = yes; then
+     { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error 77 "cannot compute sizeof (intmax_t)
+See \`config.log' for more details" "$LINENO" 5; }
+   else
+     ac_cv_sizeof_intmax_t=0
+   fi
+fi
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_sizeof_intmax_t" >&5
+$as_echo "$ac_cv_sizeof_intmax_t" >&6; }
+
+
+
+cat >>confdefs.h <<_ACEOF
+#define SIZEOF_INTMAX_T $ac_cv_sizeof_intmax_t
+_ACEOF
+
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for long double support" >&5
 $as_echo_n "checking for long double support... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -2213,6 +2213,7 @@ AC_CHECK_SIZEOF(fpos_t, 4)
 AC_CHECK_SIZEOF(size_t, 4)
 AC_CHECK_SIZEOF(pid_t, 4)
 AC_CHECK_SIZEOF(uintptr_t)
+AC_CHECK_SIZEOF(intmax_t)
 
 AC_MSG_CHECKING(for long double support)
 have_long_double=no

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1281,6 +1281,9 @@
 /* The size of `int', as computed by sizeof. */
 #undef SIZEOF_INT
 
+/* The size of `intmax_t', as computed by sizeof. */
+#undef SIZEOF_INTMAX_T
+
 /* The size of `long', as computed by sizeof. */
 #undef SIZEOF_LONG
 


### PR DESCRIPTION
* Add new conversions functions for PyLong:

  - PyLong_FromIntMax()
  - PyLong_FromUIntMax()
  - PyLong_AsIntMax()
  - PyLong_AsIntMaxAndOverflow()
  - PyLong_AsUIntMax()

* getargs: add 'm' format
* New _testcapi constants: INTMAX_MAX, INTMAX_MIN, UINTMAX_MAX, SIZEOF_INTMAX_T
* Add _testcapi.getargs_m() and _testcapi.test_long_intmax_api()
* PyLong_FromVoidPtr() uses PyLong_FromUIntMax()
* Use intmax_t in various modules

array, struct, ctypes and memoryview are not modified yet to support
intmax_t.