### PR TITLE
[3.6] Drop the standard gcc test build on Travis (GH-853)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,11 @@ os:
   - linux
   # macOS builds are disabled as the machines are under-provisioned on Travis,
   # adding up to an extra hour completing a full CI run.
-  #- osx
 
 compiler:
   - clang
-  - gcc
+  # gcc also works, but to keep the # of concurrent builds down, we use one C
+  # compiler here and the other to run the coverage build.
 
 env:
   - TESTING=cpython
@@ -32,7 +32,7 @@ matrix:
   include:
     - os: linux
       language: python
-      python: 3.5
+      python: 3.6
       env:
         - TESTING=docs
       before_script:
@@ -42,7 +42,7 @@ matrix:
         - make check suspicious html PYTHON="./venv/bin/python" SPHINXBUILD="./venv/bin/python -m sphinx" SPHINXOPTS="-q -W"
     - os: linux
       language: c
-      compiler: clang
+      compiler: gcc
       env:
         - TESTING=coverage
       before_script:


### PR DESCRIPTION
Instead have gcc be used for the coverage build so gcc is exercised in at least one place.
(cherry picked from commit ad2f9e2c8a0b44b3e6aec9d28ba59e13239236f7)