### PR TITLE
[2.7] Drop the standard gcc test build on Travis (GH-853)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,11 @@ os:
   - linux
   # macOS builds are disabled as the machines are under-provisioned on Travis,
   # adding up to an extra hour completing a full CI run.
-  #- osx
 
 compiler:
   - clang
-  - gcc
+  # gcc also works, but to keep the # of concurrent builds down, we use one C
+  # compiler here and the other to run the coverage build.
 
 env:
   - TESTING=cpython


### PR DESCRIPTION
Instead have gcc be used for the coverage build so gcc is exercised in at least one place.
(cherry picked from commit ad2f9e2c8a0b44b3e6aec9d28ba59e13239236f7)