### PR TITLE
[3.6] bpo-29677: DOC: clarify documentation for `round` (GH-357)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1262,7 +1262,8 @@ are always available.  They are listed here in alphabetical order.
    closest multiple of 10 to the power minus *ndigits*; if two multiples are
    equally close, rounding is done toward the even choice (so, for example,
    both ``round(0.5)`` and ``round(-0.5)`` are ``0``, and ``round(1.5)`` is
-   ``2``).  The return value is an integer if called with one argument,
+   ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
+   negative).  The return value is an integer if called with one argument,
    otherwise of the same type as *number*.
 
    .. note::


### PR DESCRIPTION
Clarified that `round` can take a negative value for *ndigits*.

(cherry picked from commit 6003db7db5fec545c01923c198a5fdfca5a91538)