### PR TITLE
bpo-29913: fix documentation for compare_networks()

### DIFF
--- a/Doc/library/ipaddress.rst
+++ b/Doc/library/ipaddress.rst
@@ -554,6 +554,9 @@ so to avoid duplication they are only documented for :class:`IPv4Network`.
          >>> ip_network('192.0.2.1/32').compare_networks(ip_network('192.0.2.1/32'))
          0
 
+      .. deprecated:: 3.7
+         It uses the same ordering and comparison algorithm as "<", "==", and ">"
+
 
 .. class:: IPv6Network(address, strict=True)
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1730,3 +1730,4 @@ Peter Åstrand
 evilzero
 Dhushyanth Ramasamy
 Subhendu Ghosh
+Sanjay Sundaresan


### PR DESCRIPTION
updating the doc as discussed in issue 29913