### PR TITLE
Update tutorial/controlflow.rst

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -309,7 +309,9 @@ normally suppressed by the interpreter if it would be the only value written.
 You can see it if you really want to using :func:`print`::
 
    >>> fib(0)
+   
    >>> print(fib(0))
+   
    None
 
 It is simple to write a function that returns a list of the numbers of the


### PR DESCRIPTION
This is my first contribution and I wasn't sure if I should create an issue for such a simple fix. 
Because of the print() function a empty line is printed instead of "nothing".

Function
```
>>> def fib(n):    # write Fibonacci series up to n
...     """Print a Fibonacci series up to n."""
...     a, b = 0, 1
...     while a < n:
...         print(a, end=' ')
...         a, b = b, a+b
...     print()
```


Old docu:
```
>>> fib(0)
>>> print(fib(0))
None
```

New docu:
```
>>> fib(0)

>>> print(fib(0))

None
```