### PR TITLE
bpo-29643: Fix check for --enable-optimizations (GH-129)

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -89,6 +89,13 @@ What's New in Python 3.6.1 release candidate 1
 ==============================================
 
 *Release date: 2017-03-04*
+Build
+-----
+
+- bpo-29643: Fix ``--enable-optimization`` didn't work.
+
+Tests
+-----
 
 Core and Builtins
 -----------------

--- a/configure
+++ b/configure
@@ -6521,7 +6521,7 @@ $as_echo_n "checking for --enable-optimizations... " >&6; }
 # Check whether --enable-optimizations was given.
 if test "${enable_optimizations+set}" = set; then :
   enableval=$enable_optimizations;
-if test "$withval" != no
+if test "$enableval" != no
 then
   Py_OPT='true'
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -1274,7 +1274,7 @@ Py_OPT='false'
 AC_MSG_CHECKING(for --enable-optimizations)
 AC_ARG_ENABLE(optimizations, AS_HELP_STRING([--enable-optimizations], [Enable expensive optimizations (PGO, etc).  Disabled by default.]),
 [
-if test "$withval" != no
+if test "$enableval" != no
 then
   Py_OPT='true'
   AC_MSG_RESULT(yes);


### PR DESCRIPTION
The presence of the ``--enable-optimizations`` flag is indicated by the
value of ``$enableval``, but the configure script was checking ``$withval``,
resulting in the ``--enable-optimizations`` flag being effectively ignored.
(cherry picked from commit 8cea5929f52801b0ce5928b46ef836e99a24321a)