### PR TITLE
[2.7] bpo-29643: Fix check for --enable-optimizations

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -118,6 +118,8 @@ Documentation
 Build
 -----
 
+- bpo-29643: Fix ``--enable-optimization`` configure option didn't work.
+
 - bpo-29572: Update Windows build and OS X installers to use OpenSSL 1.0.2k.
 
 - Issue #28768: Fix implicit declaration of function _setmode. Patch by
@@ -3793,6 +3795,9 @@ Library
 - Issue #15402: An issue in the struct module that caused sys.getsizeof to
   return incorrect results for struct.Struct instances has been fixed.
   Initial patch by Serhiy Storchaka.
+
+Tests
+-----
 
 - Issue #15232: when mangle_from is True, email.Generator now correctly mangles
   lines that start with 'From ' that occur in a MIME preamble or epilog.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -3796,9 +3796,6 @@ Library
   return incorrect results for struct.Struct instances has been fixed.
   Initial patch by Serhiy Storchaka.
 
-Tests
------
-
 - Issue #15232: when mangle_from is True, email.Generator now correctly mangles
   lines that start with 'From ' that occur in a MIME preamble or epilog.
 

--- a/configure
+++ b/configure
@@ -770,7 +770,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -882,7 +881,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1135,15 +1133,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1281,7 +1270,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1434,7 +1423,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -6391,7 +6379,7 @@ $as_echo_n "checking for --enable-optimizations... " >&6; }
 # Check whether --enable-optimizations was given.
 if test "${enable_optimizations+set}" = set; then :
   enableval=$enable_optimizations;
-if test "$withval" != no
+if test "$enableval" != no
 then
   Py_OPT='true'
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -1373,7 +1373,7 @@ Py_OPT='false'
 AC_MSG_CHECKING(for --enable-optimizations)
 AC_ARG_ENABLE(optimizations, AS_HELP_STRING([--enable-optimizations], [Enable expensive optimizations (PGO, maybe LTO, etc).  Disabled by default.]),
 [
-if test "$withval" != no
+if test "$enableval" != no
 then
   Py_OPT='true'
   AC_MSG_RESULT(yes);


### PR DESCRIPTION
The presence of the ``--enable-optimizations`` flag is indicated by the
value of ``$enableval``, but the configure script was checking ``$withval``,
resulting in the ``--enable-optimizations`` flag being effectively ignored.
(cherry picked from commit 8cea5929f52801b0ce5928b46ef836e99a24321a)
(original pull request is GH-129)