### PR TITLE
bpo-13349: Fix error reporting for index and remove methods

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -409,10 +409,10 @@ Simple example::
    >>> [1, 2, 3].remove(42)
    Traceback (most recent call last):
      File "<stdin>", line 1, in ?
-   ValueError: list.remove(x): x not in list
+   ValueError: "42" not in list
 
-That doctest succeeds if :exc:`ValueError` is raised, with the ``list.remove(x):
-x not in list`` detail as shown.
+That doctest succeeds if :exc:`ValueError` is raised, with the
+``"42" not in list`` detail as shown.
 
 The expected output for an exception must start with a traceback header, which
 may be either of the following two lines, indented the same as the first line of

--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -176,7 +176,7 @@ def indexOf(a, b):
         if j == b:
             return i
     else:
-        raise ValueError('sequence.index(x): x not in sequence')
+        raise ValueError("'%.100r' not in sequence" % b)
 
 def setitem(a, b, c):
     "Same as a[b] = c."

--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -317,6 +317,10 @@ class CommonTest(seq_tests.CommonTest):
         self.assertEqual(a, [0])
         a.remove(0)
         self.assertEqual(a, [])
+        # Verify that exception message contains value (issue13349)
+        with self.assertRaises(ValueError) as cm:
+            a.remove(0)
+        self.assertIn("0", str(cm.exception))
 
         self.assertRaises(ValueError, a.remove, 0)
 

--- a/Lib/test/seq_tests.py
+++ b/Lib/test/seq_tests.py
@@ -376,7 +376,10 @@ class CommonTest(unittest.TestCase):
         self.assertEqual(u.index(0, 3), 3)
         self.assertEqual(u.index(0, 3, 4), 3)
         self.assertRaises(ValueError, u.index, 2, 0, -10)
-
+        # Verify that exception message contains value (issue13349)
+        with self.assertRaises(ValueError) as cm:
+            u.index(None)
+        self.assertIn(repr(None), str(cm.exception))
         self.assertRaises(TypeError, u.index)
 
         class BadExc(Exception):

--- a/Lib/test/test_array.py
+++ b/Lib/test/test_array.py
@@ -870,6 +870,10 @@ class BaseTest:
             self.assertEqual(a.index(x), example.index(x))
         self.assertRaises(ValueError, a.index, None)
         self.assertRaises(ValueError, a.index, self.outside)
+        # Verify that exception message contains value (issue13349)
+        with self.assertRaises(ValueError) as cm:
+            a.index(self.outside)
+        self.assertIn(repr(self.outside), str(cm.exception))
 
     def test_count(self):
         example = 2*self.example
@@ -891,7 +895,10 @@ class BaseTest:
 
         a = array.array(self.typecode, self.example)
         self.assertRaises(ValueError, a.remove, self.outside)
-
+        # Verify that exception message contains value (issue13349)
+        with self.assertRaises(ValueError) as cm:
+            a.remove(self.outside)
+        self.assertIn(repr(self.outside), str(cm.exception))
         self.assertRaises(ValueError, a.remove, None)
 
     def test_pop(self):

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -504,6 +504,10 @@ class TestBasic(unittest.TestCase):
         self.assertEqual(d, deque('abdefghij'))
         self.assertRaises(ValueError, d.remove, 'c')
         self.assertEqual(d, deque('abdefghij'))
+        # Verify that exception message contains value (issue13349)
+        with self.assertRaises(ValueError) as cm:
+            d.remove(None)
+        self.assertIn(repr(None), str(cm.exception))
 
         # Handle comparison errors
         d = deque(['a', 'b', BadCmp(), 'c'])

--- a/Lib/test/test_operator.py
+++ b/Lib/test/test_operator.py
@@ -178,6 +178,10 @@ class OperatorTestCase:
         self.assertRaises(TypeError, operator.indexOf, None, None)
         self.assertEqual(operator.indexOf([4, 3, 2, 1], 3), 1)
         self.assertRaises(ValueError, operator.indexOf, [4, 3, 2, 1], 0)
+        # Verify that exception message contains value (issue13349)
+        with self.assertRaises(ValueError) as cm:
+            operator.indexOf([0, 1, 2], None)
+        self.assertIn(repr(None), str(cm.exception))
 
     def test_invert(self):
         operator = self.module

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -304,9 +304,10 @@ class ElementTreeTest(unittest.TestCase):
         self.serialize_check(element, '<tag key="value"><subtag /></tag>') # 4
         element.remove(subelement)
         self.serialize_check(element, '<tag key="value" />') # 5
+        # Verify that exception message contains value (issue13349)
         with self.assertRaises(ValueError) as cm:
             element.remove(subelement)
-        self.assertEqual(str(cm.exception), 'list.remove(x): x not in list')
+        self.assertIn(repr(subelement), str(cm.exception))
         self.serialize_check(element, '<tag key="value" />') # 6
         element[0:0] = [subelement, subelement, subelement]
         self.serialize_check(element[1], '<subtag />')

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1116,7 +1116,7 @@ deque_index(dequeobject *deque, PyObject **args, Py_ssize_t nargs,
             index = 0;
         }
     }
-    PyErr_Format(PyExc_ValueError, "%R is not in deque", v);
+    PyErr_Format(PyExc_ValueError, "\"%.100R\" not in deque", v);
     return NULL;
 }
 
@@ -1201,7 +1201,7 @@ deque_remove(dequeobject *deque, PyObject *value)
         }
         _deque_rotate(deque, -1);
     }
-    PyErr_SetString(PyExc_ValueError, "deque.remove(x): x not in deque");
+    PyErr_Format(PyExc_ValueError, "\"%.100R\" not in deque", value);
     return NULL;
 }
 

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1570,10 +1570,7 @@ _elementtree_Element_remove_impl(ElementObject *self, PyObject *subelement)
 
     if (!self->extra) {
         /* element has no children, so raise exception */
-        PyErr_SetString(
-            PyExc_ValueError,
-            "list.remove(x): x not in list"
-            );
+        PyErr_Format(PyExc_ValueError, "\"%.100R\" not in Element", subelement);
         return NULL;
     }
 
@@ -1589,10 +1586,7 @@ _elementtree_Element_remove_impl(ElementObject *self, PyObject *subelement)
 
     if (i >= self->extra->length) {
         /* subelement is not in children, so raise exception */
-        PyErr_SetString(
-            PyExc_ValueError,
-            "list.remove(x): x not in list"
-            );
+        PyErr_Format(PyExc_ValueError, "\"%.100R\" not in Element", subelement);
         return NULL;
     }
 

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1090,7 +1090,7 @@ array_array_index(arrayobject *self, PyObject *v)
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "array.index(x): x not in list");
+    PyErr_Format(PyExc_ValueError, "\"%.100R\" not in array", v);
     return NULL;
 }
 
@@ -1142,7 +1142,7 @@ array_array_remove(arrayobject *self, PyObject *v)
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "array.remove(x): x not in list");
+    PyErr_Format(PyExc_ValueError, "\"%.100R\" not in array", v);
     return NULL;
 }
 

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -1971,8 +1971,7 @@ _PySequence_IterSearch(PyObject *seq, PyObject *obj, int operation)
     if (operation != PY_ITERSEARCH_INDEX)
         goto Done;
 
-    PyErr_SetString(PyExc_ValueError,
-                    "sequence.index(x): x not in sequence");
+    PyErr_Format(PyExc_ValueError, "'%.100R' not in sequence", obj);
     /* fall into failure code */
 Fail:
     n = -1;

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2243,7 +2243,7 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_Format(PyExc_ValueError, "%R is not in list", value);
+    PyErr_Format(PyExc_ValueError, "\"%.100R\" not in list", value);
     return NULL;
 }
 
@@ -2301,7 +2301,7 @@ list_remove(PyListObject *self, PyObject *value)
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "list.remove(x): x not in list");
+    PyErr_Format(PyExc_ValueError, "\"%.100R\" not in list", value);
     return NULL;
 }
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -568,7 +568,7 @@ tuple_index_impl(PyTupleObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "tuple.index(x): x not in tuple");
+    PyErr_Format(PyExc_ValueError, "\"%.100R\" not in tuple", value);
     return NULL;
 }
 


### PR DESCRIPTION
Fixes error reporting for the `index` and `remove` methods in  `list`, `tuple`, `deque`, `operator.indexOf`, `element` and in `abstract.c`. Also fixes an occurence of this message in the `doctest` documentation.

Instead of repeating the method name as in the original patch supplied by Sean.Ochoa on b.p.o, it changes all occurences of:

    object.method(repr(x)): repr(x) not in object

to the more concice: 

    repr(x) not in object

the repr is trimmed to 100 characters as suggested on b.p.o.

Added necessary tests to check for the presence of the value in the exception. 

Specifically, for `.index`:

 - `test_index` in `seq_tests` runs for: `list.index`, `tuple.index` and `deque.index`
 - `test_index` in `test_array` for: `array.index`
 - `test_indexOf` in `test_operator` for: `operator.indexOf`

While, for `.remove`:

 - `test_remove` in `list_tests` for: `list.remove`
 - `test_remove` in `test_deque` for: `deque.remove`
 - `test_remove` in `test_array` for: `array.remove` 
 - `test_simpleops` in `test_xml_etree` for: `element.remove`

---

The only open question I currently have is:
 1. In each of these test cases, should I add an additional check that asserts that the value in the exception message is trimmed?