### PR TITLE
[2.7] bpo-11566: Extension build errors on Windows for _hypot

### DIFF
--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -226,11 +226,6 @@ typedef int pid_t;
 #define Py_IS_FINITE(X) _finite(X)
 #define copysign _copysign
 
-/* VS 2010 and above already defines hypot as _hypot */
-#if _MSC_VER < 1600
-#define hypot _hypot
-#endif
-
 #endif /* _MSC_VER */
 
 /* define some ANSI types that are not defined in earlier Win headers */
@@ -282,7 +277,6 @@ typedef int pid_t;
 #endif
 
 #define COMPILER "[gcc]"
-#define hypot _hypot
 #define PY_LONG_LONG long long
 #define PY_LLONG_MIN LLONG_MIN
 #define PY_LLONG_MAX LLONG_MAX


### PR DESCRIPTION
This addresses C extension build errors related to an undefined _hypot
symbol when building with the Microsoft Visual C++ Compiler for Python
2.7 [1] or MinGWPy [2]. It also addresses errors when building a C++
extension with MinGWPy and C++11 from cmath, 'error "::hypot' has not
been declared'

On line 71 of PC/pyconfig.h, HAVE_HYPOT is defined, indicating that
hypot is expected to be available in current Windows toolchains.

[1] https://www.microsoft.com/en-us/download/details.aspx?id=44266

[2] https://mingwpy.github.io/

<!-- issue-number: [bpo-11566](https://bugs.python.org/issue11566) -->
https://bugs.python.org/issue11566
<!-- /issue-number -->
