### PR TITLE
bpo-29935: Fix error messages in the index() method of tuple, list and deque

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -223,7 +223,7 @@ PyAPI_FUNC(Py_ssize_t) _PyEval_RequestCodeExtraIndex(freefunc);
 
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyEval_SliceIndex(PyObject *, Py_ssize_t *);
-PyAPI_FUNC(int) _PyEval_SliceIndexOrNone(PyObject *, Py_ssize_t *);
+PyAPI_FUNC(int) _PyEval_SliceIndexNotNone(PyObject *, Py_ssize_t *);
 PyAPI_FUNC(void) _PyEval_SignalAsyncExc(void);
 #endif
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-29935: Fixed error messages in the index() method of tuple, list and deque
+  when pass indices of wrong type.
+
 - bpo-29894: The deprecation warning is emitted if __complex__ returns an
   instance of a strict subclass of complex.  In a future versions of Python
   this can be an error.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1066,8 +1066,8 @@ deque_index(dequeobject *deque, PyObject **args, Py_ssize_t nargs,
         return NULL;
     }
     if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index", &v,
-                           _PyEval_SliceIndex, &start,
-                           _PyEval_SliceIndex, &stop)) {
+                           _PyEval_SliceIndexNotNone, &start,
+                           _PyEval_SliceIndexNotNone, &stop)) {
         return NULL;
     }
 

--- a/Objects/clinic/listobject.c.h
+++ b/Objects/clinic/listobject.c.h
@@ -196,7 +196,7 @@ list_index(PyListObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     Py_ssize_t stop = PY_SSIZE_T_MAX;
 
     if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index",
-        &value, _PyEval_SliceIndex, &start, _PyEval_SliceIndex, &stop)) {
+        &value, _PyEval_SliceIndexNotNone, &start, _PyEval_SliceIndexNotNone, &stop)) {
         goto exit;
     }
 
@@ -297,4 +297,4 @@ list___reversed__(PyListObject *self, PyObject *Py_UNUSED(ignored))
 {
     return list___reversed___impl(self);
 }
-/*[clinic end generated code: output=2a3b75efcf858ed5 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=71deae70ca0e6799 input=a9049054013a1b77]*/

--- a/Objects/clinic/tupleobject.c.h
+++ b/Objects/clinic/tupleobject.c.h
@@ -26,7 +26,7 @@ tuple_index(PyTupleObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kw
     Py_ssize_t stop = PY_SSIZE_T_MAX;
 
     if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index",
-        &value, _PyEval_SliceIndex, &start, _PyEval_SliceIndex, &stop)) {
+        &value, _PyEval_SliceIndexNotNone, &start, _PyEval_SliceIndexNotNone, &stop)) {
         goto exit;
     }
 
@@ -99,4 +99,4 @@ tuple___getnewargs__(PyTupleObject *self, PyObject *Py_UNUSED(ignored))
 {
     return tuple___getnewargs___impl(self);
 }
-/*[clinic end generated code: output=561a3654411d2225 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=145bcfff64e8c809 input=a9049054013a1b77]*/

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -534,8 +534,8 @@ tuplerepeat(PyTupleObject *a, Py_ssize_t n)
 tuple.index
 
     value: object
-    start: object(converter="_PyEval_SliceIndex", type="Py_ssize_t") = 0
-    stop: object(converter="_PyEval_SliceIndex", type="Py_ssize_t", c_default="PY_SSIZE_T_MAX") = sys.maxsize
+    start: slice_index(accept={int}) = 0
+    stop: slice_index(accept={int}, c_default="PY_SSIZE_T_MAX") = sys.maxsize
     /
 
 Return first index of value.
@@ -546,7 +546,7 @@ Raises ValueError if the value is not present.
 static PyObject *
 tuple_index_impl(PyTupleObject *self, PyObject *value, Py_ssize_t start,
                  Py_ssize_t stop)
-/*[clinic end generated code: output=07b6f9f3cb5c33eb input=28890d4bec234471]*/
+/*[clinic end generated code: output=07b6f9f3cb5c33eb input=fb39e9874a21fe3f]*/
 {
     Py_ssize_t i;
 

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -2662,9 +2662,9 @@ class slice_index_converter(CConverter):
 
     def converter_init(self, *, accept={int, NoneType}):
         if accept == {int}:
-            self.converter = '_PyEval_SliceIndex'
+            self.converter = '_PyEval_SliceIndexNotNone'
         elif accept == {int, NoneType}:
-            self.converter = '_PyEval_SliceIndexOrNone'
+            self.converter = '_PyEval_SliceIndex'
         else:
             fail("slice_index_converter: illegal 'accept' argument " + repr(accept))
 


### PR DESCRIPTION
when pass indices of wrong type.

_PyEval_SliceIndex() now checks for None and not check for NULL.
_PyEval_SliceIndexNotNone() is similar to _PyEval_SliceIndex(), but doesn't allow None.