### PR TITLE
bpo-29942: Fix the use of recursion in itertools.chain.from_iterable.

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1982,7 +1982,7 @@ class RegressionTests(unittest.TestCase):
         # number this would probably only fail in Py_DEBUG mode.
         it = chain.from_iterable(() for unused in range(10000000))
         with self.assertRaises(StopIteration):
-          next(it)
+            next(it)
 
 class SubclassWithKwargsTest(unittest.TestCase):
     def test_keywords_in_subclass(self):

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1976,6 +1976,14 @@ class RegressionTests(unittest.TestCase):
         self.assertRaises(AssertionError, list, cycle(gen1()))
         self.assertEqual(hist, [0,1])
 
+    def test_deep_recursion(self):
+        # Make sure itertools.chain doesn't run into recursion limits when
+        # dealing with long chains of empty iterables. Even with a high
+        # number this would probably only fail in Py_DEBUG mode.
+        it = chain.from_iterable(() for unused in range(10000000))
+        with self.assertRaises(StopIteration):
+          next(it)
+
 class SubclassWithKwargsTest(unittest.TestCase):
     def test_keywords_in_subclass(self):
         # count is not subclassable...

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1976,7 +1976,7 @@ class RegressionTests(unittest.TestCase):
         self.assertRaises(AssertionError, list, cycle(gen1()))
         self.assertEqual(hist, [0,1])
 
-    def test_deep_recursion(self):
+    def test_long_chain_of_empty_iterables(self):
         # Make sure itertools.chain doesn't run into recursion limits when
         # dealing with long chains of empty iterables. Even with a high
         # number this would probably only fail in Py_DEBUG mode.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -291,6 +291,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29942: Fix a crash in itertools.chain.from_iterable when encountering
+  long runs of empty iterables.
+
 - bpo-28699: Fixed a bug in pools in multiprocessing.pool that raising an
   exception at the very first of an iterable may swallow the exception or
   make the program hang. Patch by Davin Potts and Xiang Zhang.


### PR DESCRIPTION

Fix the use of recursion in `itertools.chain.from_iterable`. Using recursion is unnecessary, and can easily cause stack overflows, especially when building in low optimization modes or with `Py_DEBUG` enabled.
