### PR TITLE
bpo-29917: DOC: Remove link from PyMethodDef

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -241,7 +241,7 @@ definition with the same method name.
    +==================+=============+===============================+
    | :attr:`name`     | char \*     | name of the member            |
    +------------------+-------------+-------------------------------+
-   | :attr:`type`     | int         | the type of the member in the |
+   | :attr:`!type`    | int         | the type of the member in the |
    |                  |             | C struct                      |
    +------------------+-------------+-------------------------------+
    | :attr:`offset`   | Py_ssize_t  | the offset in bytes that the  |
@@ -256,7 +256,7 @@ definition with the same method name.
    |                  |             | docstring                     |
    +------------------+-------------+-------------------------------+
 
-   :attr:`type` can be one of many ``T_`` macros corresponding to various C
+   :attr:`!type` can be one of many ``T_`` macros corresponding to various C
    types.  When the member is accessed in Python, it will be converted to the
    equivalent Python type.
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1252,11 +1252,11 @@ are always available.  They are listed here in alphabetical order.
    arguments starting at ``0``).
 
 
-.. function:: round(number[, ndigits])
+.. function:: round(x[, ndigits])
 
-   Return the floating point value *number* rounded to *ndigits* digits after
-   the decimal point.  If *ndigits* is omitted or is ``None``, it returns the
-   nearest integer to its input.  Delegates to ``number.__round__(ndigits)``.
+   Return a number *x* rounded to *ndigits* precision after the
+   decimal point.  If *ndigits* is omitted or is ``None``, it returns the
+   nearest integer to its input.
 
    For the built-in types supporting :func:`round`, values are rounded to the
    closest multiple of 10 to the power minus *ndigits*; if two multiples are
@@ -1264,7 +1264,10 @@ are always available.  They are listed here in alphabetical order.
    both ``round(0.5)`` and ``round(-0.5)`` are ``0``, and ``round(1.5)`` is
    ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
    negative).  The return value is an integer if called with one argument,
-   otherwise of the same type as *number*.
+   otherwise of the same type as *x*.
+   
+   For a general Python object ``x``, ``round(x, ndigits)`` delegates to
+   ``x.__round__(ndigits)``.
 
    .. note::
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1265,7 +1265,7 @@ are always available.  They are listed here in alphabetical order.
    ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
    negative).  The return value is an integer if called with one argument,
    otherwise of the same type as *x*.
-   
+
    For a general Python object ``x``, ``round(x, ndigits)`` delegates to
    ``x.__round__(ndigits)``.
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1252,10 +1252,10 @@ are always available.  They are listed here in alphabetical order.
    arguments starting at ``0``).
 
 
-.. function:: round(x[, ndigits])
+.. function:: round(number[, ndigits])
 
-   Return a number *x* rounded to *ndigits* precision after the
-   decimal point.  If *ndigits* is omitted or is ``None``, it returns the
+   Return *number* rounded to *ndigits* precision after the decimal
+   point.  If *ndigits* is omitted or is ``None``, it returns the
    nearest integer to its input.
 
    For the built-in types supporting :func:`round`, values are rounded to the
@@ -1264,10 +1264,10 @@ are always available.  They are listed here in alphabetical order.
    both ``round(0.5)`` and ``round(-0.5)`` are ``0``, and ``round(1.5)`` is
    ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
    negative).  The return value is an integer if called with one argument,
-   otherwise of the same type as *x*.
+   otherwise of the same type as *number*.
 
-   For a general Python object ``x``, ``round(x, ndigits)`` delegates to
-   ``x.__round__(ndigits)``.
+   For a general Python object ``number``, ``round(number, ndigits)`` delegates to
+   ``number.__round__(ndigits)``.
 
    .. note::
 


### PR DESCRIPTION
In C-API, the link target of the "type" struct member is the Python built-in "type".