### PR TITLE
bpo-29917: DOC: Remove link from PyMethodDef (#890)

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -265,7 +265,7 @@ definition with the same method name.
    +==================+=============+===============================+
    | :attr:`name`     | char \*     | name of the member            |
    +------------------+-------------+-------------------------------+
-   | :attr:`type`     | int         | the type of the member in the |
+   | :attr:`!type`    | int         | the type of the member in the |
    |                  |             | C struct                      |
    +------------------+-------------+-------------------------------+
    | :attr:`offset`   | Py_ssize_t  | the offset in bytes that the  |
@@ -280,7 +280,7 @@ definition with the same method name.
    |                  |             | docstring                     |
    +------------------+-------------+-------------------------------+
 
-   :attr:`type` can be one of many ``T_`` macros corresponding to various C
+   :attr:`!type` can be one of many ``T_`` macros corresponding to various C
    types.  When the member is accessed in Python, it will be converted to the
    equivalent Python type.
 


### PR DESCRIPTION
(cherry picked from commit c3c7ef088583cc12bd218138036d1edb6de9c63f)