### PR TITLE
bpo-29939: suppress compiler warnings in _ctypes_test

### DIFF
--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -52,9 +52,9 @@ _testfunc_cbk_large_struct(Test in, void (*func)(Test))
 EXPORT(void)
 _testfunc_large_struct_update_value(Test in)
 {
-    in.first = 0x0badf00d;
-    in.second = 0x0badf00d;
-    in.third = 0x0badf00d;
+    ((volatile Test *)&in)->first = 0x0badf00d;
+    ((volatile Test *)&in)->second = 0x0badf00d;
+    ((volatile Test *)&in)->third = 0x0badf00d;
 }
 
 EXPORT(void)testfunc_array(int values[4])


### PR DESCRIPTION
e.g.: _ctypes_test.c:53:42: warning: parameter ‘in’ set but not used [-Wunused-but-set-parameter]