### PR TITLE
Remove catching OSError in filehandler test. Catch Only URLError

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -826,7 +826,6 @@ class HandlerTests(unittest.TestCase):
         for url, ftp in [
             ("file://ftp.example.com//foo.txt", False),
             ("file://ftp.example.com///foo.txt", False),
-# XXXX bug: fails with OSError, should be URLError
             ("file://ftp.example.com/foo.txt", False),
             ("file://somehost//foo/something.txt", False),
             ("file://localhost//foo/something.txt", False),
@@ -835,7 +834,7 @@ class HandlerTests(unittest.TestCase):
             try:
                 h.file_open(req)
             # XXXX remove OSError when bug fixed
-            except (urllib.error.URLError, OSError):
+            except urllib.error.URLError:
                 self.assertFalse(ftp)
             else:
                 self.assertIs(o.req, req)
@@ -1614,7 +1613,6 @@ class HandlerTests(unittest.TestCase):
         with self.assertRaises(http.client.BadStatusLine):
             handler.do_open(conn, req)
         self.assertTrue(conn.fakesock.closed, "Connection not closed")
-
 
 
 class MiscTests(unittest.TestCase):


### PR DESCRIPTION
Only URLError is raised in urllib.request module. (#918)

(cherry picked from commit ed3dd1c02af6872bd0748f7b9a5dadb89f7b830f)