### PR TITLE
[2.7] bpo-29952: Use usual terminology of dict

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1185,7 +1185,7 @@ built-in types.
     true).
 
 * Mappings (instances of :class:`dict`) compare equal if and only if they have
-  equal `(key, value)` pairs. Equality comparison of the keys and elements
+  equal `(key, value)` pairs. Equality comparison of the keys and values
   enforces reflexivity.
 
   Outcomes other than equality are resolved


### PR DESCRIPTION
s/keys and elements/keys and values/
(cherry picked from commit cdcac039fb447f2ab04efcacbe663751bb2cb4ec)
(original pull request is GH-917)