### PR TITLE
[3.5] bpo-29902: Copying and pickling staticmethod, classmethod and property

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1,4 +1,5 @@
 import builtins
+import copy
 import copyreg
 import gc
 import itertools
@@ -12,6 +13,10 @@ import weakref
 
 from copy import deepcopy
 from test import support
+
+
+def func(*args):
+    return args
 
 
 class OperatorsTest(unittest.TestCase):
@@ -1519,6 +1524,13 @@ order (MRO) for bases """
         del cm.x
         self.assertNotHasAttr(cm, "x")
 
+    def test_classmethod_copy_pickle(self):
+        cm = classmethod(func)
+        self.assertRaises(TypeError, copy.copy, cm)
+        self.assertRaises(TypeError, copy.deepcopy, cm)
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            self.assertRaises(TypeError, pickle.dumps, cm, proto)
+
     @support.impl_detail("the module 'xxsubtype' is internal")
     def test_classmethods_in_c(self):
         # Testing C-based class methods...
@@ -1573,6 +1585,13 @@ order (MRO) for bases """
         self.assertEqual(sm.__dict__, {"x" : 42})
         del sm.x
         self.assertNotHasAttr(sm, "x")
+
+    def test_staticmethod_copy_pickle(self):
+        sm = staticmethod(func)
+        self.assertRaises(TypeError, copy.copy, sm)
+        self.assertRaises(TypeError, copy.deepcopy, sm)
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            self.assertRaises(TypeError, pickle.dumps, sm, proto)
 
     @support.impl_detail("the module 'xxsubtype' is internal")
     def test_staticmethods_in_c(self):
@@ -2164,6 +2183,13 @@ order (MRO) for bases """
             pass
         else:
             self.fail("expected ZeroDivisionError from bad property")
+
+    def test_property_copy_pickle(self):
+        p = property(func)
+        self.assertRaises(TypeError, copy.copy, p)
+        self.assertRaises(TypeError, copy.deepcopy, p)
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            self.assertRaises(TypeError, pickle.dumps, p, proto)
 
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ Release date: XXXX-XX-XX
 Core and Builtins
 -----------------
 
+- bpo-29902: Copying and pickling staticmethod, classmethod and property
+  descriptors now raises an error instead of creating an uninitialized object.
+
 - bpo-29935: Fixed error messages in the index() method of tuple, list and deque
   when pass indices of wrong type.
 

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1348,10 +1348,19 @@ property_deleter(PyObject *self, PyObject *deleter)
 }
 
 
+static PyObject *
+property_getstate(PyObject *self, PyObject *args)
+{
+    PyErr_Format(PyExc_TypeError,
+                 "cannot serialize '%s' object", Py_TYPE(self)->tp_name);
+    return NULL;
+}
+
 static PyMethodDef property_methods[] = {
     {"getter", property_getter, METH_O, getter_doc},
     {"setter", property_setter, METH_O, setter_doc},
     {"deleter", property_deleter, METH_O, deleter_doc},
+    {"__getstate__", property_getstate, METH_NOARGS, NULL},
     {0}
 };
 

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -772,6 +772,19 @@ cm_init(PyObject *self, PyObject *args, PyObject *kwds)
     return 0;
 }
 
+static PyObject *
+bad_getstate(PyObject *self, PyObject *args)
+{
+    PyErr_Format(PyExc_TypeError,
+                 "cannot serialize '%s' object", Py_TYPE(self)->tp_name);
+    return NULL;
+}
+
+static PyMethodDef cm_methods[] = {
+    {"__getstate__", bad_getstate, METH_NOARGS, NULL},
+    {NULL} /* Sentinel */
+};
+
 static PyMemberDef cm_memberlist[] = {
     {"__func__", T_OBJECT, offsetof(classmethod, cm_callable), READONLY},
     {NULL}  /* Sentinel */
@@ -849,8 +862,8 @@ PyTypeObject PyClassMethod_Type = {
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */
     0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    cm_memberlist,              /* tp_members */
+    cm_methods,                                 /* tp_methods */
+    cm_memberlist,                              /* tp_members */
     cm_getsetlist,                              /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */
@@ -953,6 +966,11 @@ sm_init(PyObject *self, PyObject *args, PyObject *kwds)
     return 0;
 }
 
+static PyMethodDef sm_methods[] = {
+    {"__getstate__", bad_getstate, METH_NOARGS, NULL},
+    {NULL} /* Sentinel */
+};
+
 static PyMemberDef sm_memberlist[] = {
     {"__func__", T_OBJECT, offsetof(staticmethod, sm_callable), READONLY},
     {NULL}  /* Sentinel */
@@ -1027,8 +1045,8 @@ PyTypeObject PyStaticMethod_Type = {
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */
     0,                                          /* tp_iternext */
-    0,                                          /* tp_methods */
-    sm_memberlist,              /* tp_members */
+    sm_methods,                                 /* tp_methods */
+    sm_memberlist,                              /* tp_members */
     sm_getsetlist,                              /* tp_getset */
     0,                                          /* tp_base */
     0,                                          /* tp_dict */


### PR DESCRIPTION
descriptors now raises an error instead of creating an uninitialized object.