### PR TITLE
bpo-29950: Rename SlotWrapperType to WrapperDescriptorType

### DIFF
--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -132,7 +132,7 @@ Standard names are defined for the following types:
    C".)
 
 
-.. data:: SlotWrapperType
+.. data:: WrapperDescriptorType
 
    The type of methods of some built-in data types and base classes such as
    :meth:`object.__init__` or :meth:`object.__lt__`.

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -577,10 +577,10 @@ class TypesTests(unittest.TestCase):
         self.assertGreater(tuple.__itemsize__, 0)
 
     def test_slot_wrapper_types(self):
-        self.assertIsInstance(object.__init__, types.SlotWrapperType)
-        self.assertIsInstance(object.__str__, types.SlotWrapperType)
-        self.assertIsInstance(object.__lt__, types.SlotWrapperType)
-        self.assertIsInstance(int.__lt__, types.SlotWrapperType)
+        self.assertIsInstance(object.__init__, types.WrapperDescriptorType)
+        self.assertIsInstance(object.__str__, types.WrapperDescriptorType)
+        self.assertIsInstance(object.__lt__, types.WrapperDescriptorType)
+        self.assertIsInstance(int.__lt__, types.WrapperDescriptorType)
 
     def test_method_wrapper_types(self):
         self.assertIsInstance(object().__init__, types.MethodWrapperType)

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -36,7 +36,7 @@ MethodType = type(_C()._m)
 BuiltinFunctionType = type(len)
 BuiltinMethodType = type([].append)     # Same as BuiltinFunctionType
 
-SlotWrapperType = type(object.__init__)
+WrapperDescriptorType = type(object.__init__)
 MethodWrapperType = type(object().__str__)
 MethodDescriptorType = type(str.join)
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -406,7 +406,7 @@ Library
 - Issue #29444: Fixed out-of-bounds buffer access in the group() method of
   the match object.  Based on patch by WGH.
 
-- Issue #29377: Add SlotWrapperType, MethodWrapperType, and
+- Issue #29377: Add WrapperDescriptorType, MethodWrapperType, and
   MethodDescriptorType built-in types to types module.
   Original patch by Manuel Krebber.
 


### PR DESCRIPTION
The name `SlotWrapperType` was added in [bpo-29377](http://bugs.python.org/issue29377) but it added the type based on the repr of the object instead of it's type as `type(object.__init__)` results in. PR changes this to `WrapperDescriptorType` to avoid and any unecessary confusion down the line.