### PR TITLE
bpo-29953: Fix memory leaks in the replace() method of datetime and time

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -4313,6 +4313,11 @@ class TestLocalTimeDisambiguation(unittest.TestCase):
         dt = dt.replace(fold=1, tzinfo=Eastern)
         self.assertEqual(t.replace(tzinfo=None).fold, 1)
         self.assertEqual(dt.replace(tzinfo=None).fold, 1)
+        # Out of bounds.
+        with self.assertRaises(ValueError):
+            t.replace(fold=2)
+        with self.assertRaises(ValueError):
+            dt.replace(fold=2)
         # Check that fold is a keyword-only argument
         with self.assertRaises(TypeError):
             t.replace(1, 1, 1, None, 1)

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -301,6 +301,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29953: Fixed memory leaks in the replace() method of datetime and time
+  objects when pass out of bound fold argument.
+
 - bpo-29942: Fix a crash in itertools.chain.from_iterable when encountering
   long runs of empty iterables.
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3937,16 +3937,16 @@ time_replace(PyDateTime_Time *self, PyObject *args, PyObject *kw)
                                       time_kws,
                                       &hh, &mm, &ss, &us, &tzinfo, &fold))
         return NULL;
+    if (fold != 0 && fold != 1) {
+        PyErr_SetString(PyExc_ValueError,
+                        "fold must be either 0 or 1");
+        return NULL;
+    }
     tuple = Py_BuildValue("iiiiO", hh, mm, ss, us, tzinfo);
     if (tuple == NULL)
         return NULL;
     clone = time_new(Py_TYPE(self), tuple, NULL);
     if (clone != NULL) {
-        if (fold != 0 && fold != 1) {
-            PyErr_SetString(PyExc_ValueError,
-                            "fold must be either 0 or 1");
-            return NULL;
-        }
         TIME_SET_FOLD(clone, fold);
     }
     Py_DECREF(tuple);
@@ -5030,17 +5030,16 @@ datetime_replace(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
                                       &y, &m, &d, &hh, &mm, &ss, &us,
                                       &tzinfo, &fold))
         return NULL;
+    if (fold != 0 && fold != 1) {
+        PyErr_SetString(PyExc_ValueError,
+                        "fold must be either 0 or 1");
+        return NULL;
+    }
     tuple = Py_BuildValue("iiiiiiiO", y, m, d, hh, mm, ss, us, tzinfo);
     if (tuple == NULL)
         return NULL;
     clone = datetime_new(Py_TYPE(self), tuple, NULL);
-
     if (clone != NULL) {
-        if (fold != 0 && fold != 1) {
-            PyErr_SetString(PyExc_ValueError,
-                            "fold must be either 0 or 1");
-            return NULL;
-        }
         DATE_SET_FOLD(clone, fold);
     }
     Py_DECREF(tuple);


### PR DESCRIPTION
objects when pass out of bound fold argument.