### PR TITLE
bpo-28157: Improvements for the time module documentation

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -626,8 +626,8 @@ Functions
       ('EET', 'EEST')
 
 
-Constants
----------
+Clock ID Constants
+------------------
 
 .. data:: CLOCK_HIGHRES
 
@@ -688,6 +688,9 @@ Constants
    .. versionadded:: 3.3
 
 
+Time Zone Constants
+-------------------
+
 .. data:: altzone
 
    The offset of the local DST timezone, in seconds west of UTC, if one is defined.
@@ -711,7 +714,7 @@ Constants
 
    .. note::
 
-      For the above data items (:data:`altzone`, :data:`daylight`, :data:`timezone`,
+      For the above Time Zone constants (:data:`altzone`, :data:`daylight`, :data:`timezone`,
       and :data:`tzname`), the value is determined by the timezone rules in effect
       at module load time or the last time :func:`tzset` is called and may be incorrect
       for times in the past.  It is recommended to use the :attr:`tm_gmtoff` and

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -126,6 +126,12 @@ The module defines the following functions and data items:
    This is negative if the local DST timezone is east of UTC (as in Western Europe,
    including the UK).  Only use this if ``daylight`` is nonzero.
 
+   .. note::
+
+      This value is determined by the timezone rules in effect at module load time
+      and may be incorrect for times in the past.  It is recommended to use the
+      :attr:`tm_gmtoff` and :attr:`tm_zone` results from :func:`localtime` to
+      obtain timezone information.
 
 .. function:: asctime([t])
 
@@ -260,6 +266,13 @@ The module defines the following functions and data items:
 .. data:: daylight
 
    Nonzero if a DST timezone is defined.
+
+   .. note::
+
+      This value is determined by the timezone rules in effect at module load time
+      and may be incorrect for times in the past.  It is recommended to use the
+      :attr:`tm_gmtoff` and :attr:`tm_zone` results from :func:`localtime` to
+      obtain timezone information.
 
 
 .. function:: get_clock_info(name)
@@ -612,12 +625,26 @@ The module defines the following functions and data items:
    The offset of the local (non-DST) timezone, in seconds west of UTC (negative in
    most of Western Europe, positive in the US, zero in the UK).
 
+   .. note::
+
+      This value is determined by the timezone rules in effect at module load time
+      and may be incorrect for times in the past.  It is recommended to use the
+      :attr:`tm_gmtoff` and :attr:`tm_zone` results from :func:`localtime` to
+      obtain timezone information.
+
 
 .. data:: tzname
 
    A tuple of two strings: the first is the name of the local non-DST timezone, the
    second is the name of the local DST timezone.  If no DST timezone is defined,
    the second string should not be used.
+
+   .. note::
+
+      This value is determined by the timezone rules in effect at module load time
+      and may be incorrect for times in the past.  It is recommended to use the
+      :attr:`tm_gmtoff` and :attr:`tm_zone` results from :func:`localtime` to
+      obtain timezone information.
 
 
 .. function:: tzset()

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -120,19 +120,6 @@ An explanation of some terminology and conventions is in order.
 
 The module defines the following functions and data items:
 
-.. data:: altzone
-
-   The offset of the local DST timezone, in seconds west of UTC, if one is defined.
-   This is negative if the local DST timezone is east of UTC (as in Western Europe,
-   including the UK).  Only use this if ``daylight`` is nonzero.
-
-   .. note::
-
-      This value is determined by the timezone rules in effect at module load time
-      and may be incorrect for times in the past.  It is recommended to use the
-      :attr:`tm_gmtoff` and :attr:`tm_zone` results from :func:`localtime` to
-      obtain timezone information.
-
 .. function:: asctime([t])
 
    Convert a tuple or :class:`struct_time` representing a time as returned by
@@ -261,18 +248,6 @@ The module defines the following functions and data items:
    local time. If *secs* is not provided or :const:`None`, the current time as
    returned by :func:`.time` is used.  ``ctime(secs)`` is equivalent to
    ``asctime(localtime(secs))``. Locale information is not used by :func:`ctime`.
-
-
-.. data:: daylight
-
-   Nonzero if a DST timezone is defined.
-
-   .. note::
-
-      This value is determined by the timezone rules in effect at module load time
-      and may be incorrect for times in the past.  It is recommended to use the
-      :attr:`tm_gmtoff` and :attr:`tm_zone` results from :func:`localtime` to
-      obtain timezone information.
 
 
 .. function:: get_clock_info(name)
@@ -620,32 +595,6 @@ The module defines the following functions and data items:
    :class:`struct_time` object is returned, from which the components
    of the calendar date may be accessed as attributes.
 
-.. data:: timezone
-
-   The offset of the local (non-DST) timezone, in seconds west of UTC (negative in
-   most of Western Europe, positive in the US, zero in the UK).
-
-   .. note::
-
-      This value is determined by the timezone rules in effect at module load time
-      and may be incorrect for times in the past.  It is recommended to use the
-      :attr:`tm_gmtoff` and :attr:`tm_zone` results from :func:`localtime` to
-      obtain timezone information.
-
-
-.. data:: tzname
-
-   A tuple of two strings: the first is the name of the local non-DST timezone, the
-   second is the name of the local DST timezone.  If no DST timezone is defined,
-   the second string should not be used.
-
-   .. note::
-
-      This value is determined by the timezone rules in effect at module load time
-      and may be incorrect for times in the past.  It is recommended to use the
-      :attr:`tm_gmtoff` and :attr:`tm_zone` results from :func:`localtime` to
-      obtain timezone information.
-
 
 .. function:: tzset()
 
@@ -733,6 +682,38 @@ The module defines the following functions and data items:
       >>> time.tzset()
       >>> time.tzname
       ('EET', 'EEST')
+
+
+The module defines the following data items:
+
+.. data:: altzone
+
+   The offset of the local DST timezone, in seconds west of UTC, if one is defined.
+   This is negative if the local DST timezone is east of UTC (as in Western Europe,
+   including the UK).  Only use this if ``daylight`` is nonzero.  See note.
+
+.. data:: daylight
+
+   Nonzero if a DST timezone is defined.  See note.
+
+.. data:: timezone
+
+   The offset of the local (non-DST) timezone, in seconds west of UTC (negative in
+   most of Western Europe, positive in the US, zero in the UK).  See note.
+
+.. data:: tzname
+
+   A tuple of two strings: the first is the name of the local non-DST timezone, the
+   second is the name of the local DST timezone.  If no DST timezone is defined,
+   the second string should not be used.  See note.
+
+   .. note::
+
+      For the above data items (:data:`altzone`, :data:`daylight`, :data:`timezone`,
+      and :data:`tzname`), the value is determined by the timezone rules in effect
+      at module load time and may be incorrect for times in the past.  It is
+      recommended to use the :attr:`tm_gmtoff` and :attr:`tm_zone` results from
+      :func:`localtime` to obtain timezone information.
 
 
 .. seealso::

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -181,8 +181,8 @@ Functions
 
 .. function:: clock_settime(clk_id, time)
 
-   Set the time of the specified clock *clk_id*.  Refer to
-   :ref:`time-clock-id-constants` for a list of accepted values for *clk_id*.
+   Set the time of the specified clock *clk_id*.  Currently,
+   :data:`CLOCK_REALTIME` is the only accepted value for *clk_id*.
 
    Availability: Unix.
 
@@ -636,14 +636,14 @@ Functions
 Clock ID Constants
 ------------------
 
-These constants are used as parameters for :func:`clock_getres`, :func:`clock_gettime`,
-and :func:`clock_settime`.
+These constants are used as parameters for :func:`clock_getres` and
+:func:`clock_gettime`.
 
 .. data:: CLOCK_HIGHRES
 
-   The Solaris OS has a CLOCK_HIGHRES timer that attempts to use an optimal
-   hardware source, and may give close to nanosecond resolution.  CLOCK_HIGHRES
-   is the nonadjustable, high-resolution clock.
+   The Solaris OS has a ``CLOCK_HIGHRES`` timer that attempts to use an optimal
+   hardware source, and may give close to nanosecond resolution.
+   ``CLOCK_HIGHRES`` is the nonadjustable, high-resolution clock.
 
    Availability: Solaris.
 
@@ -681,8 +681,9 @@ and :func:`clock_settime`.
 
 .. data:: CLOCK_REALTIME
 
-   System-wide real-time clock.  Setting this clock requires appropriate
-   privileges.
+   System-wide real-time clock.  This constant is the only parameter
+   that can be sent to :func:`clock_settime`; setting this clock requires
+   appropriate privileges.
 
    Availability: Unix.
 

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -118,6 +118,8 @@ An explanation of some terminology and conventions is in order.
   +-------------------------+-------------------------+-------------------------+
 
 
+.. _time-functions:
+
 Functions
 ---------
 
@@ -159,7 +161,8 @@ Functions
 
 .. function:: clock_getres(clk_id)
 
-   Return the resolution (precision) of the specified clock *clk_id*.
+   Return the resolution (precision) of the specified clock *clk_id*.  Refer to
+   :ref:`time-clock-id-constants` for a list of accepted values for *clk_id*.
 
    Availability: Unix.
 
@@ -168,7 +171,8 @@ Functions
 
 .. function:: clock_gettime(clk_id)
 
-   Return the time of the specified clock *clk_id*.
+   Return the time of the specified clock *clk_id*.  Refer to
+   :ref:`time-clock-id-constants` for a list of accepted values for *clk_id*.
 
    Availability: Unix.
 
@@ -177,7 +181,8 @@ Functions
 
 .. function:: clock_settime(clk_id, time)
 
-   Set the time of the specified clock *clk_id*.
+   Set the time of the specified clock *clk_id*.  Refer to
+   :ref:`time-clock-id-constants` for a list of accepted values for *clk_id*.
 
    Availability: Unix.
 
@@ -209,7 +214,7 @@ Functions
    - *adjustable*: ``True`` if the clock can be changed automatically (e.g. by
      a NTP daemon) or manually by the system administrator, ``False`` otherwise
    - *implementation*: The name of the underlying C function used to get
-     the clock value
+     the clock value.  Refer to :ref:`time-clock-id-constants` for possible values.
    - *monotonic*: ``True`` if the clock cannot go backward,
      ``False`` otherwise
    - *resolution*: The resolution of the clock in seconds (:class:`float`)
@@ -626,8 +631,13 @@ Functions
       ('EET', 'EEST')
 
 
+.. _time-clock-id-constants:
+
 Clock ID Constants
 ------------------
+
+These constants are used as parameters for :func:`clock_getres`, :func:`clock_gettime`,
+and :func:`clock_settime`.
 
 .. data:: CLOCK_HIGHRES
 
@@ -688,6 +698,8 @@ Clock ID Constants
    .. versionadded:: 3.3
 
 
+.. _time-time-zone-constants:
+
 Time Zone Constants
 -------------------
 
@@ -695,30 +707,30 @@ Time Zone Constants
 
    The offset of the local DST timezone, in seconds west of UTC, if one is defined.
    This is negative if the local DST timezone is east of UTC (as in Western Europe,
-   including the UK).  Only use this if ``daylight`` is nonzero.  See note.
+   including the UK).  Only use this if ``daylight`` is nonzero.  See note below.
 
 .. data:: daylight
 
-   Nonzero if a DST timezone is defined.  See note.
+   Nonzero if a DST timezone is defined.  See note below.
 
 .. data:: timezone
 
    The offset of the local (non-DST) timezone, in seconds west of UTC (negative in
-   most of Western Europe, positive in the US, zero in the UK).  See note.
+   most of Western Europe, positive in the US, zero in the UK).  See note below.
 
 .. data:: tzname
 
    A tuple of two strings: the first is the name of the local non-DST timezone, the
    second is the name of the local DST timezone.  If no DST timezone is defined,
-   the second string should not be used.  See note.
+   the second string should not be used.  See note below.
 
-   .. note::
+.. note::
 
-      For the above Time Zone constants (:data:`altzone`, :data:`daylight`, :data:`timezone`,
-      and :data:`tzname`), the value is determined by the timezone rules in effect
-      at module load time or the last time :func:`tzset` is called and may be incorrect
-      for times in the past.  It is recommended to use the :attr:`tm_gmtoff` and
-      :attr:`tm_zone` results from :func:`localtime` to obtain timezone information.
+   For the above Time Zone constants (:data:`altzone`, :data:`daylight`, :data:`timezone`,
+   and :data:`tzname`), the value is determined by the timezone rules in effect
+   at module load time or the last time :func:`tzset` is called and may be incorrect
+   for times in the past.  It is recommended to use the :attr:`tm_gmtoff` and
+   :attr:`tm_zone` results from :func:`localtime` to obtain timezone information.
 
 
 .. seealso::

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -679,17 +679,6 @@ These constants are used as parameters for :func:`clock_getres` and
    .. versionadded:: 3.3
 
 
-.. data:: CLOCK_REALTIME
-
-   System-wide real-time clock.  This constant is the only parameter
-   that can be sent to :func:`clock_settime`; setting this clock requires
-   appropriate privileges.
-
-   Availability: Unix.
-
-   .. versionadded:: 3.3
-
-
 .. data:: CLOCK_THREAD_CPUTIME_ID
 
    Thread-specific CPU-time clock.
@@ -699,9 +688,22 @@ These constants are used as parameters for :func:`clock_getres` and
    .. versionadded:: 3.3
 
 
-.. _time-time-zone-constants:
+The following constant is the only parameter that can be sent to
+:func:`clock_settime`.
 
-Time Zone Constants
+.. data:: CLOCK_REALTIME
+
+   System-wide real-time clock.  Setting this clock requires appropriate
+   privileges.
+
+   Availability: Unix.
+
+   .. versionadded:: 3.3
+
+
+.. _time-timezone-constants:
+
+Timezone Constants
 -------------------
 
 .. data:: altzone
@@ -727,7 +729,7 @@ Time Zone Constants
 
 .. note::
 
-   For the above Time Zone constants (:data:`altzone`, :data:`daylight`, :data:`timezone`,
+   For the above Timezone constants (:data:`altzone`, :data:`daylight`, :data:`timezone`,
    and :data:`tzname`), the value is determined by the timezone rules in effect
    at module load time or the last time :func:`tzset` is called and may be incorrect
    for times in the past.  It is recommended to use the :attr:`tm_gmtoff` and

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -713,9 +713,9 @@ Constants
 
       For the above data items (:data:`altzone`, :data:`daylight`, :data:`timezone`,
       and :data:`tzname`), the value is determined by the timezone rules in effect
-      at module load time and may be incorrect for times in the past.  It is
-      recommended to use the :attr:`tm_gmtoff` and :attr:`tm_zone` results from
-      :func:`localtime` to obtain timezone information.
+      at module load time or the last time :func:`tzset` is called and may be incorrect
+      for times in the past.  It is recommended to use the :attr:`tm_gmtoff` and
+      :attr:`tm_zone` results from :func:`localtime` to obtain timezone information.
 
 
 .. seealso::

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -118,7 +118,8 @@ An explanation of some terminology and conventions is in order.
   +-------------------------+-------------------------+-------------------------+
 
 
-The module defines the following functions and data items:
+Functions
+---------
 
 .. function:: asctime([t])
 
@@ -177,65 +178,6 @@ The module defines the following functions and data items:
 .. function:: clock_settime(clk_id, time)
 
    Set the time of the specified clock *clk_id*.
-
-   Availability: Unix.
-
-   .. versionadded:: 3.3
-
-
-.. data:: CLOCK_HIGHRES
-
-   The Solaris OS has a CLOCK_HIGHRES timer that attempts to use an optimal
-   hardware source, and may give close to nanosecond resolution.  CLOCK_HIGHRES
-   is the nonadjustable, high-resolution clock.
-
-   Availability: Solaris.
-
-   .. versionadded:: 3.3
-
-
-.. data:: CLOCK_MONOTONIC
-
-   Clock that cannot be set and represents monotonic time since some unspecified
-   starting point.
-
-   Availability: Unix.
-
-   .. versionadded:: 3.3
-
-
-.. data:: CLOCK_MONOTONIC_RAW
-
-   Similar to :data:`CLOCK_MONOTONIC`, but provides access to a raw
-   hardware-based time that is not subject to NTP adjustments.
-
-   Availability: Linux 2.6.28 or later.
-
-   .. versionadded:: 3.3
-
-
-.. data:: CLOCK_PROCESS_CPUTIME_ID
-
-   High-resolution per-process timer from the CPU.
-
-   Availability: Unix.
-
-   .. versionadded:: 3.3
-
-
-.. data:: CLOCK_REALTIME
-
-   System-wide real-time clock.  Setting this clock requires appropriate
-   privileges.
-
-   Availability: Unix.
-
-   .. versionadded:: 3.3
-
-
-.. data:: CLOCK_THREAD_CPUTIME_ID
-
-   Thread-specific CPU-time clock.
 
    Availability: Unix.
 
@@ -684,7 +626,67 @@ The module defines the following functions and data items:
       ('EET', 'EEST')
 
 
-The module defines the following data items:
+Constants
+---------
+
+.. data:: CLOCK_HIGHRES
+
+   The Solaris OS has a CLOCK_HIGHRES timer that attempts to use an optimal
+   hardware source, and may give close to nanosecond resolution.  CLOCK_HIGHRES
+   is the nonadjustable, high-resolution clock.
+
+   Availability: Solaris.
+
+   .. versionadded:: 3.3
+
+
+.. data:: CLOCK_MONOTONIC
+
+   Clock that cannot be set and represents monotonic time since some unspecified
+   starting point.
+
+   Availability: Unix.
+
+   .. versionadded:: 3.3
+
+
+.. data:: CLOCK_MONOTONIC_RAW
+
+   Similar to :data:`CLOCK_MONOTONIC`, but provides access to a raw
+   hardware-based time that is not subject to NTP adjustments.
+
+   Availability: Linux 2.6.28 or later.
+
+   .. versionadded:: 3.3
+
+
+.. data:: CLOCK_PROCESS_CPUTIME_ID
+
+   High-resolution per-process timer from the CPU.
+
+   Availability: Unix.
+
+   .. versionadded:: 3.3
+
+
+.. data:: CLOCK_REALTIME
+
+   System-wide real-time clock.  Setting this clock requires appropriate
+   privileges.
+
+   Availability: Unix.
+
+   .. versionadded:: 3.3
+
+
+.. data:: CLOCK_THREAD_CPUTIME_ID
+
+   Thread-specific CPU-time clock.
+
+   Availability: Unix.
+
+   .. versionadded:: 3.3
+
 
 .. data:: altzone
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1322,28 +1322,7 @@ The tuple items are:\n\
   DST (Daylight Savings Time) flag (-1, 0 or 1)\n\
 If the DST flag is 0, the time is given in the regular time zone;\n\
 if it is 1, the time is given in the DST time zone;\n\
-if it is -1, mktime() should guess based on the date and time.\n\
-\n\
-Variables:\n\
-\n\
-timezone -- difference in seconds between UTC and local standard time\n\
-altzone -- difference in  seconds between UTC and local DST time\n\
-daylight -- whether local time should reflect DST\n\
-tzname -- tuple of (standard time zone name, DST time zone name)\n\
-\n\
-Functions:\n\
-\n\
-time() -- return current time in seconds since the Epoch as a float\n\
-clock() -- return CPU time since process start as a float\n\
-sleep() -- delay for a number of seconds given as a float\n\
-gmtime() -- convert seconds since Epoch to UTC tuple\n\
-localtime() -- convert seconds since Epoch to local time tuple\n\
-asctime() -- convert time tuple to string\n\
-ctime() -- convert time in seconds to string\n\
-mktime() -- convert local time tuple to seconds since Epoch\n\
-strftime() -- convert time tuple to string according to format specification\n\
-strptime() -- parse string to time tuple according to format specification\n\
-tzset() -- change the local timezone");
+if it is -1, mktime() should guess based on the date and time.\n\");
 
 
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1322,7 +1322,7 @@ The tuple items are:\n\
   DST (Daylight Savings Time) flag (-1, 0 or 1)\n\
 If the DST flag is 0, the time is given in the regular time zone;\n\
 if it is 1, the time is given in the DST time zone;\n\
-if it is -1, mktime() should guess based on the date and time.\n\");
+if it is -1, mktime() should guess based on the date and time.\n");
 
 
 


### PR DESCRIPTION
1. Separated functions and constants descriptions in sections.
1. Added a note about the limitations of timezone constants.
1. Removed redundant lists from the module docstring. 

<!-- issue-number: bpo-28157 -->
https://bugs.python.org/issue28157
<!-- /issue-number -->
