### PR TITLE
bpo-29941: Fix spurious MemoryError introduced by PR #886.

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1227,10 +1227,7 @@ _PyObject_Alloc(int use_calloc, void *ctx, size_t nelem, size_t elsize)
 
     _Py_AllocatedBlocks++;
 
-    if (nelem == 0 || elsize == 0)
-        goto redirect;
-
-    assert(nelem <= PY_SSIZE_T_MAX / elsize);
+    assert(elsize == 0 || nelem <= PY_SSIZE_T_MAX / elsize);
     nbytes = nelem * elsize;
 
 #ifdef WITH_VALGRIND
@@ -1239,6 +1236,9 @@ _PyObject_Alloc(int use_calloc, void *ctx, size_t nelem, size_t elsize)
     if (UNLIKELY(running_on_valgrind))
         goto redirect;
 #endif
+
+    if (nelem == 0 || elsize == 0)
+        goto redirect;
 
     if ((nbytes - 1) < SMALL_REQUEST_THRESHOLD) {
         LOCK();


### PR DESCRIPTION
Fix MemoryError caused by moving around code in PR #886; nbytes was sometimes used unitinitalized (in non-debug builds, when use_calloc was false and elsize was 0).