### PR TITLE
bpo-29957: change LBYL key lookup to dict.setdefault

### DIFF
--- a/Lib/lib2to3/btm_matcher.py
+++ b/Lib/lib2to3/btm_matcher.py
@@ -9,6 +9,7 @@ __author__ = "George Boutsioukis <gboutsioukis@gmail.com>"
 
 import logging
 import itertools
+from collections import defaultdict
 
 from . import pytree
 from .btm_utils import reduce_tree
@@ -96,7 +97,7 @@ class BottomMatcher(object):
            A dictionary of node matches with fixers as the keys
         """
         current_ac_node = self.root
-        results = {}
+        results = defaultdict(list)
         for leaf in leaves:
             current_ast_node = leaf
             while current_ast_node:
@@ -116,7 +117,7 @@ class BottomMatcher(object):
                     #token matches
                     current_ac_node = current_ac_node.transition_table[node_token]
                     for fixer in current_ac_node.fixers:
-                        results.setdefault(fixer, []).append(current_ast_node)
+                        results[fixer].append(current_ast_node)
                 else:
                     #matching failed, reset automaton
                     current_ac_node = self.root
@@ -130,7 +131,7 @@ class BottomMatcher(object):
                         #token matches
                         current_ac_node = current_ac_node.transition_table[node_token]
                         for fixer in current_ac_node.fixers:
-                            results.setdefault(fixer, []).append(current_ast_node)
+                            results[fixer].append(current_ast_node)
 
                 current_ast_node = current_ast_node.parent
         return results

--- a/Lib/lib2to3/btm_matcher.py
+++ b/Lib/lib2to3/btm_matcher.py
@@ -9,7 +9,6 @@ __author__ = "George Boutsioukis <gboutsioukis@gmail.com>"
 
 import logging
 import itertools
-from collections import defaultdict
 
 from . import pytree
 from .btm_utils import reduce_tree
@@ -97,7 +96,7 @@ class BottomMatcher(object):
            A dictionary of node matches with fixers as the keys
         """
         current_ac_node = self.root
-        results = defaultdict(list)
+        results = {}
         for leaf in leaves:
             current_ast_node = leaf
             while current_ast_node:
@@ -117,10 +116,7 @@ class BottomMatcher(object):
                     #token matches
                     current_ac_node = current_ac_node.transition_table[node_token]
                     for fixer in current_ac_node.fixers:
-                        if not fixer in results:
-                            results[fixer] = []
-                        results[fixer].append(current_ast_node)
-
+                        results.setdefault(fixer, []).append(current_ast_node)
                 else:
                     #matching failed, reset automaton
                     current_ac_node = self.root
@@ -134,9 +130,7 @@ class BottomMatcher(object):
                         #token matches
                         current_ac_node = current_ac_node.transition_table[node_token]
                         for fixer in current_ac_node.fixers:
-                            if not fixer in results.keys():
-                                results[fixer] = []
-                            results[fixer].append(current_ast_node)
+                            results.setdefault(fixer, []).append(current_ast_node)
 
                 current_ast_node = current_ast_node.parent
         return results

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1376,6 +1376,7 @@ Steven Scott
 Nick Seidenman
 Michael Seifert
 Žiga Seilnacht
+Michael Selik
 Yury Selivanov
 Fred Sells
 Jiwon Seo


### PR DESCRIPTION
The ``results`` was constructed as a defaultdict and we could simply
delete the check ``if key not in results``. However, I think it's safer
to use dict.setdefault as I'm not sure whether the caller expects a
regular dict or defaultdict.