### PR TITLE
[3.6] bpo-29949: Fix set memory usage regression

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,8 @@ What's New in Python 3.6.2 release candidate 1?
 Core and Builtins
 -----------------
 
+- bpo-29949: Fix memory usage regression of set and frozenset object.
+
 - bpo-29935: Fixed error messages in the index() method of tuple, list and deque
   when pass indices of wrong type.
 

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -236,7 +236,7 @@ set_add_entry(PySetObject *so, PyObject *key, Py_hash_t hash)
     entry->hash = hash;
     if ((size_t)so->fill*3 < mask*2)
         return 0;
-    return set_table_resize(so, so->used);
+    return set_table_resize(so, so->used>50000 ? so->used*2 : so->used*4);
 
   found_active:
     Py_DECREF(key);
@@ -304,7 +304,6 @@ set_table_resize(PySetObject *so, Py_ssize_t minused)
     setentry small_copy[PySet_MINSIZE];
 
     assert(minused >= 0);
-    minused = (minused > 50000) ? minused * 2 : minused * 4;
 
     /* Find the smallest table size > minused. */
     /* XXX speed-up with intrinsics */
@@ -646,8 +645,8 @@ set_merge(PySetObject *so, PyObject *otherset)
      * that there will be no (or few) overlapping keys.
      */
     if ((so->fill + other->used)*3 >= so->mask*2) {
-       if (set_table_resize(so, so->used + other->used) != 0)
-           return -1;
+        if (set_table_resize(so, (so->used + other->used)*2) != 0)
+            return -1;
     }
     so_entry = so->table;
     other_entry = other->table;
@@ -990,7 +989,7 @@ set_update_internal(PySetObject *so, PyObject *other)
         if (dictsize < 0)
             return -1;
         if ((so->fill + dictsize)*3 >= so->mask*2) {
-            if (set_table_resize(so, so->used + dictsize) != 0)
+            if (set_table_resize(so, (so->used + dictsize)*2) != 0)
                 return -1;
         }
         while (_PyDict_Next(other, &pos, &key, &value, &hash)) {
@@ -1511,7 +1510,7 @@ set_difference_update_internal(PySetObject *so, PyObject *other)
     /* If more than 1/4th are dummies, then resize them away. */
     if ((size_t)(so->fill - so->used) <= (size_t)so->mask / 4)
         return 0;
-    return set_table_resize(so, so->used);
+    return set_table_resize(so, so->used>50000 ? so->used*2 : so->used*4);
 }
 
 static PyObject *


### PR DESCRIPTION
Revert "Minor factoring:  move redundant resize scaling logic into the resize function."

This reverts commit 4897300276d870f99459c82b937f0ac22450f0b6.
(cherry picked from commit e82cf8675bacd7a03de508ed11865fc2701dcef5)

(original pull request is GH-943)