### PR TITLE
bpo-29692: contextlib.contextmanager may incorrectly unchain RuntimeError

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -88,7 +88,7 @@ class _GeneratorContextManager(ContextDecorator, AbstractContextManager):
             try:
                 next(self.gen)
             except StopIteration:
-                return
+                return False
             else:
                 raise RuntimeError("generator didn't stop")
         else:
@@ -110,7 +110,7 @@ class _GeneratorContextManager(ContextDecorator, AbstractContextManager):
                 # Likewise, avoid suppressing if a StopIteration exception
                 # was passed to throw() and later wrapped into a RuntimeError
                 # (see PEP 479).
-                if exc.__cause__ is value:
+                if type is StopIteration and exc.__cause__ is value:
                     return False
                 raise
             except:
@@ -121,10 +121,10 @@ class _GeneratorContextManager(ContextDecorator, AbstractContextManager):
                 # fixes the impedance mismatch between the throw() protocol
                 # and the __exit__() protocol.
                 #
-                if sys.exc_info()[1] is not value:
-                    raise
-            else:
-                raise RuntimeError("generator didn't stop after throw()")
+                if sys.exc_info()[1] is value:
+                    return False
+                raise
+            raise RuntimeError("generator didn't stop after throw()")
 
 
 def contextmanager(func):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -302,6 +302,9 @@ Extension Modules
 
 Library
 -------
+- bpo-29692: Fixed arbitrary unchaining of RuntimeError exceptions in 
+  contextlib.contextmanager.
+  Patch by Siddharth Velankar.
 
 - bpo-29962: Add math.remainder operation, implementing remainder
   as specified in IEEE 754.


### PR DESCRIPTION
@ncoghlan @serhiy-storchaka @JelleZijlstra @brettcannon 
I had to close PR 891 and open a new PR due to an incorrect rebase on my part.
All review comments made in PR 891 have been implemented and a test case added, please review, thanks. 