### PR TITLE
bpo-29956: Fix misleading documentation for math.exp.

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -199,8 +199,8 @@ Power and logarithmic functions
 
 .. function:: exp(x)
 
-   Return ``e**x``.
-
+   Return e raised to the power *x*, where e = 2.718281... is the base
+   of natural logarithms.
 
 .. function:: expm1(x)
 


### PR DESCRIPTION
As pointed out in [issue 29956](http://bugs.python.org/issue29956), `math.exp(x)` is not the same as `math.e**x`. This PR attempts to make the documentation a bit less misleading.