### PR TITLE
Fix Combinatoric examples in itertools docs

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -63,18 +63,15 @@ Iterator                        Arguments                       Results         
 
 **Combinatoric generators:**
 
-==============================================   ====================       =============================================================
-Iterator                                         Arguments                  Results
-==============================================   ====================       =============================================================
-:func:`product`                                  p, q, ... [repeat=1]       cartesian product, equivalent to a nested for-loop
-:func:`permutations`                             p[, r]                     r-length tuples, all possible orderings, no repeated elements
-:func:`combinations`                             p, r                       r-length tuples, in sorted order, no repeated elements
-:func:`combinations_with_replacement`            p, r                       r-length tuples, in sorted order, with repeated elements
-``product('ABCD', repeat=2)``                                               ``AA AB AC AD BA BB BC BD CA CB CC CD DA DB DC DD``
-``permutations('ABCD', 2)``                                                 ``AB AC AD BA BC BD CA CB CD DA DB DC``
-``combinations('ABCD', 2)``                                                 ``AB AC AD BC BD CD``
-``combinations_with_replacement('ABCD', 2)``                                ``AA AB AC AD BB BC BD CC CD DD``
-==============================================   ====================       =============================================================
+==============================================   ====================    =============================================================    =====================================================================================
+Iterator                                         Arguments               Results                                                          Example
+==============================================   ====================    =============================================================    =====================================================================================
+:func:`product`                                  p, q, ... [repeat=1]    cartesian product, equivalent to a nested for-loop               ``product('ABCD', repeat=2)`` --> ``AA AB AC AD BA BB BC BD CA CB CC CD DA DB DC DD``
+:func:`permutations`                             p[, r]                  r-length tuples, all possible orderings, no repeated elements    ``permutations('ABCD', 2)`` --> ``AB AC AD BA BC BD CA CB CD DA DB DC``
+:func:`combinations`                             p, r                    r-length tuples, in sorted order, no repeated elements           ``combinations('ABCD', 2)`` --> ``AB AC AD BC BD CD``
+:func:`combinations_with_replacement`            p, r                    r-length tuples, in sorted order, with repeated elements         ``combinations_with_replacement('ABCD', 2)`` --> ``AA AB AC AD BB BC BD CC CD DD``
+==============================================   ====================    =============================================================    =====================================================================================
+
 
 
 .. _itertools-functions:


### PR DESCRIPTION
This PR fixes what appears to be a mistake in the [itertools](https://docs.python.org/dev/library/itertools.html) docs.

The tables at the top of the doc file summarize the `itertools` module's functions. The first two, __Infinite iterators__ and __Iterators terminating on the shortest input sequence__ have four columns:
* Iterator
* Arguments
* Results
* Example

The third table, __Combinatoric generators__, only has three columns - it's missing the Example column. It does contain examples, but they're not in the row that matches their function:

![image](https://cloud.githubusercontent.com/assets/1922815/24581213/f2821666-16dc-11e7-9892-d15d853abb09.png)

The change here is to add the Example column to the table that's missing it, and to move the examples into the appropriate row:

![image](https://cloud.githubusercontent.com/assets/1922815/24581204/c84040b2-16dc-11e7-9341-8db28d1c7750.png)

This problem appears to date back to the [2.6 docs](https://docs.python.org/release/2.6.9/library/itertools.html). The fix could be applied to 2.7 and the currently supported 3.x series if needed.
