### PR TITLE
bpo-29941: Assert fixes

### DIFF
--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -2263,6 +2263,10 @@ PyAPI_FUNC(Py_UNICODE*) PyUnicode_AsUnicodeCopy(
 PyAPI_FUNC(int) _PyUnicode_CheckConsistency(
     PyObject *op,
     int check_content);
+#elif !defined(NDEBUG)
+/* For asserts that call _PyUnicode_CheckConsistency(), which would
+ * otherwise be a problem when building with asserts but without Py_DEBUG. */
+#define _PyUnicode_CheckConsistency(op, check_content) PyUnicode_Check(op)
 #endif
 
 /* Return an interned Unicode object for an Identifier; may fail if there is no memory.*/

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1176,7 +1176,7 @@ _PyObject_Alloc(int use_calloc, void *ctx, size_t nelem, size_t elsize)
 
     _Py_AllocatedBlocks++;
 
-    assert(nelem <= PY_SSIZE_T_MAX / elsize);
+    assert(elsize == 0 || nelem <= PY_SSIZE_T_MAX / elsize);
     nbytes = nelem * elsize;
 
 #ifdef WITH_VALGRIND
@@ -2233,7 +2233,9 @@ _PyObject_DebugMallocStats(FILE *out)
 
             if (p->ref.count == 0) {
                 /* currently unused */
+#ifdef Py_DEBUG
                 assert(pool_is_in_list(p, arenas[i].freepools));
+#endif
                 continue;
             }
             ++numpools[sz];


### PR DESCRIPTION
Make a non-Py_DEBUG, asserts-enabled build of CPython possible. This means
making sure helper functions are defined when NDEBUG is not defined, not
just when Py_DEBUG is defined.

Also fix a division-by-zero in obmalloc.c that went unnoticed because in
Py_DEBUG mode, elsize is never zero.

(cherry picked from commit a00c3fd12d421e41b769debd7df717d17b0deed5 and 06bb4873d6a9ac303701d08a851d6cd9a51e02a3)