### PR TITLE
bpo-26947: DOC: clarify wording on hashable in glossary (#948)

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -434,9 +434,9 @@ Glossary
       Hashability makes an object usable as a dictionary key and a set member,
       because these data structures use the hash value internally.
 
-      All of Python's immutable built-in objects are hashable, while no mutable
-      containers (such as lists or dictionaries) are.  Objects which are
-      instances of user-defined classes are hashable by default; they all
+      All of Python's immutable built-in objects are hashable; mutable
+      containers (such as lists or dictionaries) are not.  Objects which are
+      instances of user-defined classes are hashable by default.  They all
       compare unequal (except with themselves), and their hash value is derived
       from their :func:`id`.
 


### PR DESCRIPTION
(cherry picked from commit 64c887ab3a400cf91bde4f0c5ef69eacc88bc5e1)