### PR TITLE
bpo-29963: Remove obsolete declaration in tokenizer.h

### DIFF
--- a/Parser/tokenizer.h
+++ b/Parser/tokenizer.h
@@ -80,8 +80,6 @@ extern struct tok_state *PyTokenizer_FromFile(FILE *, const char*,
                                               const char *, const char *);
 extern void PyTokenizer_Free(struct tok_state *);
 extern int PyTokenizer_Get(struct tok_state *, char **, char **);
-extern char * PyTokenizer_RestoreEncoding(struct tok_state* tok,
-                                          int len, int *offset);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Couldn't trace exactly when `PyTokenizer_RestoreEncoding` was removed from tokenizer.c but the corresponding declaration in the header file survived. PR removes it.