### PR TITLE
bpo-28087: Skip test_asyncore and test_eintr poll failures on macOS. …

### DIFF
--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -606,6 +606,9 @@ class BaseTestAPI(unittest.TestCase):
         # Note: this might fail on some platforms as OOB data is
         # tenuously supported and rarely used.
 
+        if sys.platform == "darwin" and self.use_poll:
+            self.skipTest("poll may fail on macOS; see issue #28087")
+
         class TestClient(BaseClient):
             def handle_expt(self):
                 self.flag = True

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -137,6 +137,10 @@ Build
 Tests
 -----
 
+- bpo-28087: Skip test_asyncore and test_eintr poll failures on macOS.
+  Skip some tests of select.poll when running on macOS due to unresolved
+  issues with the underlying system poll function on some macOS versions.
+
 - bpo-15083: Convert ElementTree doctests to unittests.
 
 


### PR DESCRIPTION
…(#462)

* bpo-28087: Skip test_asyncore and test_eintr poll failures on macOS

Skip some tests of select.poll when running on macOS due to unresolved
issues with the underlying system poll function on some macOS versions.

(cherry picked from commit de04644627f82d9dc48b3423def7ff5b4aa1926a)