### PR TITLE
test_locale now ignores the DeprecationWarning

### DIFF
--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -245,7 +245,7 @@ def format_string(f, val, grouping=False, monetary=False):
 def format(percent, value, grouping=False, monetary=False, *additional):
     """Deprecated, use format_string instead."""
     warnings.warn(
-        "This method will be removed in a future version of Python."
+        "This method will be removed in a future version of Python. "
         "Use 'locale.format_string()' instead.",
         DeprecationWarning, stacklevel=2
     )

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -1,4 +1,4 @@
-from test.support import verbose, is_android
+from test.support import verbose, is_android, check_warnings
 import unittest
 import locale
 import sys
@@ -144,8 +144,9 @@ class BaseFormattingTest(object):
             func(format, value, **format_opts), out)
 
     def _test_format(self, format, value, out, **format_opts):
-        self._test_formatfunc(format, value, out,
-            func=locale.format, **format_opts)
+        with check_warnings(('', DeprecationWarning)):
+            self._test_formatfunc(format, value, out,
+                func=locale.format, **format_opts)
 
     def _test_format_string(self, format, value, out, **format_opts):
         self._test_formatfunc(format, value, out,
@@ -232,14 +233,15 @@ class TestFormatPatternArg(unittest.TestCase):
     # Test handling of pattern argument of format
 
     def test_onlyOnePattern(self):
-        # Issue 2522: accept exactly one % pattern, and no extra chars.
-        self.assertRaises(ValueError, locale.format, "%f\n", 'foo')
-        self.assertRaises(ValueError, locale.format, "%f\r", 'foo')
-        self.assertRaises(ValueError, locale.format, "%f\r\n", 'foo')
-        self.assertRaises(ValueError, locale.format, " %f", 'foo')
-        self.assertRaises(ValueError, locale.format, "%fg", 'foo')
-        self.assertRaises(ValueError, locale.format, "%^g", 'foo')
-        self.assertRaises(ValueError, locale.format, "%f%%", 'foo')
+        with check_warnings(('', DeprecationWarning)):
+            # Issue 2522: accept exactly one % pattern, and no extra chars.
+            self.assertRaises(ValueError, locale.format, "%f\n", 'foo')
+            self.assertRaises(ValueError, locale.format, "%f\r", 'foo')
+            self.assertRaises(ValueError, locale.format, "%f\r\n", 'foo')
+            self.assertRaises(ValueError, locale.format, " %f", 'foo')
+            self.assertRaises(ValueError, locale.format, "%fg", 'foo')
+            self.assertRaises(ValueError, locale.format, "%^g", 'foo')
+            self.assertRaises(ValueError, locale.format, "%f%%", 'foo')
 
 
 class TestLocaleFormatString(unittest.TestCase):


### PR DESCRIPTION
Don't fail anymore if test run with python3 -Werror.

Fix also deprecation message: add a space.