### PR TITLE
bpo-29870: ssl socket leak

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -683,12 +683,14 @@ class SSLProtocol(protocols.Protocol):
             self._transport._force_close(exc)
 
     def _finalize(self):
+        self._sslpipe = None
+
         if self._transport is not None:
             self._transport.close()
 
     def _abort(self):
-        if self._transport is not None:
-            try:
+        try:
+            if self._transport is not None:
                 self._transport.abort()
-            finally:
-                self._finalize()
+        finally:
+            self._finalize()


### PR DESCRIPTION
I'm using `Python 3.6` and `aiohttp 2.0.5`.
Given this server:

```python
import http.server
import ssl

addr = ('localhost', 8081)
httpd = http.server.HTTPServer(addr, http.server.SimpleHTTPRequestHandler)
httpd.socket = ssl.wrap_socket(httpd.socket,
                keyfile='server.key',
                certfile='server.cert',
                server_side=True)
httpd.serve_forever()
```

and this client (that basically sends `get` requests to the above server):

```python
import asyncio
import aiohttp
import resource

last = 0

def handler(*_):
        global last
        mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
        print('Variation:', mem - last)
        last = mem

async def get(session):
        response = await session.request('get', 'https://0.0.0.0:8081') # https (ssl)
        print(response.status)
        response.close()

async def main(loop):
        conn = aiohttp.TCPConnector(verify_ssl=False, enable_cleanup_closed=True)
        session = aiohttp.ClientSession(loop=loop, connector=conn)

        for x in range(500):
                await get(session)
                await asyncio.sleep(1, loop=loop)
                handler()

        session.close()

if __name__ == '__main__':
        loop = asyncio.get_event_loop()
        loop.run_until_complete(main(loop))
```
I have been able to reproduce the issue. In fact, every 6-7 `get` requests, I got a `Variation: 0.25` printed on my screen that indicates my client uses 0.25 more MB of memory (it just grows indefinitely, I tested it with 10000 requests).

Using ipdb and objgraph led me to this graph where you can clearly see that there are some circular references between `SSLProtocol` and `_SSLPipe` objects:

![sslprot_backrefs](https://cloud.githubusercontent.com/assets/9290766/24620798/5394f5cc-189f-11e7-8027-c61ac927d36f.png)

I know that since PEP 442 it shouldn't be a problem anymore, the python garbage collector doesn't care about the cycle and collect them anyway. But the interesting fact is that breaking this cycle (see my commit) actually fixes the memory leak in my client (no more `Variation: 0.25`, just always `Variation: 0.0`). My hypothesis is that circular references between `SSLProtocol` and `_SSLPipe` actually hide some circular references between some C objects (that define some `tp_dealloc` slots), that lead to these memory leaks.