### PR TITLE
bpo-29725: DOC: add text for arraysize in sqlite3.Cursor (#947)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -640,6 +640,11 @@ Cursor Objects
       .. versionchanged:: 3.6
          Added support for the ``REPLACE`` statement.
 
+   .. attribute:: arraysize
+
+      Read/write attribute that controls the number of rows returned by :meth:`fetchmany`.
+      The default value is 1 which means a single row would be fetched per call.
+
    .. attribute:: description
 
       This read-only attribute provides the column names of the last query. To


### PR DESCRIPTION
* bpo-29725: DOC: add text for arraysize in sqlite3.Cursor
(cherry picked from commit 02e12138000da834f23719521a011fa93763384d)