### PR TITLE
[2.7] bpo-29978: remove merge=union attribute for Misc/NEWS (GH-460)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,3 @@
-Misc/NEWS   merge=union
-
 *.pck binary
 Lib/test/cjkencodings/* binary
 Lib/test/decimaltestdata/*.decTest binary


### PR DESCRIPTION
(cherry picked from commit 060d2d776a29341c079cce37220324f9775140ba)