### PR TITLE
bpo-29984: Improve 'heapq' test coverage

### DIFF
--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -599,3 +599,9 @@ try:
     from _heapq import _heappop_max
 except ImportError:
     pass
+
+
+if __name__ == "__main__":
+
+    import doctest # pragma: no cover
+    print(doctest.testmod()) # pragma: no cover

--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -599,9 +599,3 @@ try:
     from _heapq import _heappop_max
 except ImportError:
     pass
-
-
-if __name__ == "__main__":
-
-    import doctest
-    print(doctest.testmod())

--- a/Lib/test/test_heapq.py
+++ b/Lib/test/test_heapq.py
@@ -135,6 +135,13 @@ class TestHeap:
         x = self.module.heappushpop(h, 11)
         self.assertEqual((h, x), ([11], 10))
 
+    def test_heappop_max(self):
+        # _heapop_max has an optimization for one-item lists which isn't
+        # covered in other tests, so test that case explicitly here
+        h = [3, 2]
+        self.assertEqual(self.module._heappop_max(h), 3)
+        self.assertEqual(self.module._heappop_max(h), 2)
+
     def test_heapsort(self):
         # Exercise everything with repeated heapsort checks
         for trial in range(100):
@@ -167,6 +174,12 @@ class TestHeap:
                 self.assertEqual(sorted(chain(*inputs), key=key, reverse=reverse),
                                  list(self.module.merge(*seqs, key=key, reverse=reverse)))
                 self.assertEqual(list(self.module.merge()), [])
+
+    def test_empty_merges(self):
+        # Merging two empty lists (with or without a key) should produce
+        # another empty list.
+        self.assertEqual(list(self.module.merge([], [])), [])
+        self.assertEqual(list(self.module.merge([], [], key=lambda: 6)), [])
 
     def test_merge_does_not_suppress_index_error(self):
         # Issue 19018: Heapq.merge suppresses IndexError from user generator

--- a/Lib/test/test_heapq.py
+++ b/Lib/test/test_heapq.py
@@ -2,6 +2,7 @@
 
 import random
 import unittest
+import doctest
 
 from test import support
 from unittest import TestCase, skipUnless
@@ -25,6 +26,23 @@ class TestModules(TestCase):
         for fname in func_names:
             self.assertEqual(getattr(c_heapq, fname).__module__, '_heapq')
 
+
+def load_tests(loader, tests, ignore):
+    # The 'merge' function has examples in its docstring which we should test
+    # with 'doctest'.
+    #
+    # However, doctest can't easily find all docstrings in the module (loading
+    # it through import_fresh_module seems to confuse it), so we specifically
+    # create a finder which returns the doctests from the merge method.
+
+    class HeapqMergeDocTestFinder:
+        def find(self, *args, **kwargs):
+            dtf = doctest.DocTestFinder()
+            return dtf.find(py_heapq.merge)
+
+    tests.addTests(doctest.DocTestSuite(py_heapq,
+                                        test_finder=HeapqMergeDocTestFinder()))
+    return tests
 
 class TestHeap:
 


### PR DESCRIPTION
This brings coverage of the heapq module to 100%.

The doctest change is a bit weird, so I've made that a separate commit so it can be straightforwardly backed out if it's too weird. I dug into why `tests.addTests(doctest.DocTestSuite(py_heapq))` doesn't find any tests and it's because the comparison [here](https://github.com/python/cpython/blob/f78b119364b521307237a1484ba5f43f42300898/Lib/doctest.py#L949) doesn't return True, which I suspect is because the module is loaded with `import_fresh_module`.

(This is a pretty trivial change - I'm just improving test coverage somewhere to get started with contributing to Python, per https://docs.python.org/devguide/coverage.html)

<!-- issue-number: [bpo-29984](https://bugs.python.org/issue29984) -->
https://bugs.python.org/issue29984
<!-- /issue-number -->
