### PR TITLE
bpo-29905: Fix TypeError in asyncio/proactor_events

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -232,8 +232,9 @@ class _ProactorBaseWritePipeTransport(_ProactorBasePipeTransport,
 
     def write(self, data):
         if not isinstance(data, (bytes, bytearray, memoryview)):
-            raise TypeError('data argument must be byte-ish (%r)',
-                            type(data))
+            msg = ("data argument must be a bytes-like object, not '%s'" %
+                   type(data).__name__)
+            raise TypeError(msg)
         if self._eof_written:
             raise RuntimeError('write_eof() already called')
 


### PR DESCRIPTION
A new PR for issue29905, without including the TypeError reformatting for `asynchat` which, if my interpretation of  [#issue25002](https://bugs.python.org/issue29905) and specifically [#msg250151](https://bugs.python.org/issue25002#msg250151) was correct, should probably not be included. 

If my interpretation was incorrect, I'll push a change for it too :-).