### PR TITLE
Set headersonly for parsing header data.

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -211,7 +211,7 @@ def parse_headers(fp, _class=HTTPMessage):
         if line in (b'\r\n', b'\n', b''):
             break
     hstring = b''.join(headers).decode('iso-8859-1')
-    return email.parser.Parser(_class=_class).parsestr(hstring)
+    return email.parser.Parser(_class=_class).parsestr(hstring, headersonly=True)
 
 
 class HTTPResponse(io.BufferedIOBase):


### PR DESCRIPTION
http.client's parse_headers ends up providing only header data to parsestr, but
doesn't set the headersonly option. This ends up generating warning for
StartBoundaryNotFoundDefect. This only corrects this defect.

https://github.com/shazow/urllib3/issues/800 is related.

