### PR TITLE
[3.6] correct parse_qs and parse_qsl test case descriptions. (#968)

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -6,8 +6,8 @@ RFC2396_BASE = "http://a/b/c/d;p?q"
 RFC3986_BASE = 'http://a/b/c/d;p?q'
 SIMPLE_BASE  = 'http://a/b/c/d'
 
-# A list of test cases.  Each test case is a two-tuple that contains
-# a string with the query and a dictionary with the expected result.
+# Each parse_qsl testcase is a two-tuple that contains
+# a string with the query and a list with the expected result.
 
 parse_qsl_test_cases = [
     ("", []),
@@ -41,6 +41,9 @@ parse_qsl_test_cases = [
     (b"a=a+b;b=b+c", [(b'a', b'a b'), (b'b', b'b c')]),
     (b"a=1;a=2", [(b'a', b'1'), (b'a', b'2')]),
 ]
+
+# Each parse_qs testcase is a two-tuple that contains
+# a string with the query and a dictionary with the expected result.
 
 parse_qs_test_cases = [
     ("", {}),
@@ -290,7 +293,6 @@ class UrlParseTestCase(unittest.TestCase):
     def test_RFC2396(self):
         # cases from RFC 2396
 
-
         self.checkJoin(RFC2396_BASE, 'g:h', 'g:h')
         self.checkJoin(RFC2396_BASE, 'g', 'http://a/b/c/g')
         self.checkJoin(RFC2396_BASE, './g', 'http://a/b/c/g')
@@ -333,9 +335,7 @@ class UrlParseTestCase(unittest.TestCase):
         # self.checkJoin(RFC2396_BASE, '/./g', 'http://a/./g')
         # self.checkJoin(RFC2396_BASE, '/../g', 'http://a/../g')
 
-
     def test_RFC3986(self):
-        # Test cases from RFC3986
         self.checkJoin(RFC3986_BASE, '?y','http://a/b/c/d;p?y')
         self.checkJoin(RFC3986_BASE, ';x', 'http://a/b/c/;x')
         self.checkJoin(RFC3986_BASE, 'g:h','g:h')
@@ -363,7 +363,7 @@ class UrlParseTestCase(unittest.TestCase):
         self.checkJoin(RFC3986_BASE, '../../g','http://a/g')
         self.checkJoin(RFC3986_BASE, '../../../g', 'http://a/g')
 
-        #Abnormal Examples
+        # Abnormal Examples
 
         # The 'abnormal scenarios' are incompatible with RFC2986 parsing
         # Tests are here for reference.

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -612,6 +612,7 @@ def unquote(string, encoding='utf-8', errors='replace'):
         append(bits[i + 1])
     return ''.join(res)
 
+
 def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
              encoding='utf-8', errors='replace'):
     """Parse a query given as a string argument.
@@ -633,6 +634,8 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
 
         encoding and errors: specify how to decode percent-encoded sequences
             into Unicode characters, as accepted by the bytes.decode() method.
+
+        Returns a dictionary.
     """
     parsed_result = {}
     pairs = parse_qsl(qs, keep_blank_values, strict_parsing,
@@ -644,28 +647,29 @@ def parse_qs(qs, keep_blank_values=False, strict_parsing=False,
             parsed_result[name] = [value]
     return parsed_result
 
+
 def parse_qsl(qs, keep_blank_values=False, strict_parsing=False,
               encoding='utf-8', errors='replace'):
     """Parse a query given as a string argument.
 
-    Arguments:
+        Arguments:
 
-    qs: percent-encoded query string to be parsed
+        qs: percent-encoded query string to be parsed
 
-    keep_blank_values: flag indicating whether blank values in
-        percent-encoded queries should be treated as blank strings.  A
-        true value indicates that blanks should be retained as blank
-        strings.  The default false value indicates that blank values
-        are to be ignored and treated as if they were  not included.
+        keep_blank_values: flag indicating whether blank values in
+            percent-encoded queries should be treated as blank strings.
+            A true value indicates that blanks should be retained as blank
+            strings.  The default false value indicates that blank values
+            are to be ignored and treated as if they were  not included.
 
-    strict_parsing: flag indicating what to do with parsing errors. If
-        false (the default), errors are silently ignored. If true,
-        errors raise a ValueError exception.
+        strict_parsing: flag indicating what to do with parsing errors. If
+            false (the default), errors are silently ignored. If true,
+            errors raise a ValueError exception.
 
-    encoding and errors: specify how to decode percent-encoded sequences
-        into Unicode characters, as accepted by the bytes.decode() method.
+        encoding and errors: specify how to decode percent-encoded sequences
+            into Unicode characters, as accepted by the bytes.decode() method.
 
-    Returns a list, as G-d intended.
+        Returns a list, as G-d intended.
     """
     qs, _coerce_result = _coerce_args(qs)
     pairs = [s2 for s1 in qs.split('&') for s2 in s1.split(';')]


### PR DESCRIPTION
* correct parse_qs and parse_qsl test case descriptions.
(cherry picked from commit 257b980b316a5206ecf6c23b958e2b7c4df4f3de)