### PR TITLE
bpo-30059: Py_Ellipsis in C API documentation

### DIFF
--- a/Doc/c-api/slice.rst
+++ b/Doc/c-api/slice.rst
@@ -1,9 +1,7 @@
 .. highlightlang:: c
 
-.. _slice-objects:
-
-Slice Objects
--------------
+Ellipsis Object
+---------------
 
 
 .. c:var:: PyObject *Py_Ellipsis
@@ -11,6 +9,12 @@ Slice Objects
    The Python ``Ellipsis`` object.  This object has no methods.  It needs to be
    treated just like any other object with respect to reference counts.  Like
    :c:data:`Py_None` it is a singleton object.
+
+
+.. _slice-objects:
+
+Slice Objects
+-------------
 
 
 .. c:var:: PyTypeObject PySlice_Type

--- a/Doc/c-api/slice.rst
+++ b/Doc/c-api/slice.rst
@@ -1,16 +1,5 @@
 .. highlightlang:: c
 
-Ellipsis Object
----------------
-
-
-.. c:var:: PyObject *Py_Ellipsis
-
-   The Python ``Ellipsis`` object.  This object has no methods.  It needs to be
-   treated just like any other object with respect to reference counts.  Like
-   :c:data:`Py_None` it is a singleton object.
-
-
 .. _slice-objects:
 
 Slice Objects
@@ -104,3 +93,14 @@ Slice Objects
    code.
 
    .. versionadded:: 3.6.1
+
+
+Ellipsis Object
+---------------
+
+
+.. c:var:: PyObject *Py_Ellipsis
+
+   The Python ``Ellipsis`` object.  This object has no methods.  It needs to be
+   treated just like any other object with respect to reference counts.  Like
+   :c:data:`Py_None` it is a singleton object.

--- a/Doc/c-api/slice.rst
+++ b/Doc/c-api/slice.rst
@@ -6,6 +6,13 @@ Slice Objects
 -------------
 
 
+.. c:var:: PyObject *Py_Ellipsis
+
+   The Python ``Ellipsis`` object.  This object has no methods.  It needs to be
+   treated just like any other object with respect to reference counts.  Like
+   :c:data:`Py_None` it is a singleton object.
+
+
 .. c:var:: PyTypeObject PySlice_Type
 
    The type object for slice objects.  This is the same as :class:`slice` in the


### PR DESCRIPTION
As far as I have seen there is no mention of it anywhere. And it's defined along with `sliceobject` so I included it in the documentation there. FWIW: most of the added documentation is copied from `Py_None`.