### PR TITLE
[3.5] Remove an invalid comment in test_urllib2.py (#1020)

### DIFF
--- a/Lib/test/test_urllib2.py
+++ b/Lib/test/test_urllib2.py
@@ -833,7 +833,6 @@ class HandlerTests(unittest.TestCase):
             req = Request(url)
             try:
                 h.file_open(req)
-            # XXXX remove OSError when bug fixed
             except urllib.error.URLError:
                 self.assertFalse(ftp)
             else:


### PR DESCRIPTION
(cherry picked from commit fd0cd07a5a3c964c084f4efc5bbcb89dd2193ee6)