### PR TITLE
[2.7]: Correct typo in configparser.rst (GH-1012)

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -35,8 +35,8 @@ easily.
 .. seealso::
 
    Module :mod:`shlex`
-      Support for a creating Unix shell-like mini-languages which can be used
-      as an alternate format for application configuration files.
+      Support for creating Unix shell-like mini-languages which can be used as
+      an alternate format for application configuration files.
 
    Module :mod:`json`
       The json module implements a subset of JavaScript syntax which can also


### PR DESCRIPTION
(cherry picked from commit 01fa9ae5460b00bf1ced500c797176ebd3fb060d)