### PR TITLE
[3.6] bpo-29549: Fixes docstring for str.index (GH-256)

### DIFF
--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -542,7 +542,11 @@ _Py_bytes_find(const char *str, Py_ssize_t len, PyObject *args)
 PyDoc_STRVAR_shared(_Py_index__doc__,
 "B.index(sub[, start[, end]]) -> int\n\
 \n\
-Like B.find() but raise ValueError when the subsection is not found.");
+Return the lowest index in B where subsection sub is found,\n\
+such that sub is contained within B[start,end].  Optional\n\
+arguments start and end are interpreted as in slice notation.\n\
+\n\
+Raises ValueError when the subsection is not found.");
 
 PyObject *
 _Py_bytes_index(const char *str, Py_ssize_t len, PyObject *args)
@@ -579,7 +583,11 @@ _Py_bytes_rfind(const char *str, Py_ssize_t len, PyObject *args)
 PyDoc_STRVAR_shared(_Py_rindex__doc__,
 "B.rindex(sub[, start[, end]]) -> int\n\
 \n\
-Like B.rfind() but raise ValueError when the subsection is not found.");
+Return the highest index in B where subsection sub is found,\n\
+such that sub is contained within B[start,end].  Optional\n\
+arguments start and end are interpreted as in slice notation.\n\
+\n\
+Raise ValueError when the subsection is not found.");
 
 PyObject *
 _Py_bytes_rindex(const char *str, Py_ssize_t len, PyObject *args)
@@ -811,4 +819,3 @@ PyDoc_STRVAR_shared(_Py_zfill__doc__,
 "\n"
 "Pad a numeric string B with zeros on the left, to fill a field\n"
 "of the specified width.  B is never truncated.");
-

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -11701,7 +11701,11 @@ unicode_hash(PyObject *self)
 PyDoc_STRVAR(index__doc__,
              "S.index(sub[, start[, end]]) -> int\n\
 \n\
-Like S.find() but raise ValueError when the substring is not found.");
+Return the lowest index in S where substring sub is found, \n\
+such that sub is contained within S[start:end].  Optional\n\
+arguments start and end are interpreted as in slice notation.\n\
+\n\
+Raises ValueError when the substring is not found.");
 
 static PyObject *
 unicode_index(PyObject *self, PyObject *args)
@@ -12758,7 +12762,11 @@ unicode_rfind(PyObject *self, PyObject *args)
 PyDoc_STRVAR(rindex__doc__,
              "S.rindex(sub[, start[, end]]) -> int\n\
 \n\
-Like S.rfind() but raise ValueError when the substring is not found.");
+Return the highest index in S where substring sub is found,\n\
+such that sub is contained within S[start:end].  Optional\n\
+arguments start and end are interpreted as in slice notation.\n\
+\n\
+Raises ValueError when the substring is not found.");
 
 static PyObject *
 unicode_rindex(PyObject *self, PyObject *args)


### PR DESCRIPTION
(cherry picked from commit 43ba8861e0ad044efafa46a7cc04e12ac5df640e)