### PR TITLE
[3.5] Fix a minor typo. (#1032)

### DIFF
--- a/Doc/library/asyncio-protocol.rst
+++ b/Doc/library/asyncio-protocol.rst
@@ -381,7 +381,7 @@ The following callbacks are called on :class:`Protocol` instances:
 
 .. method:: Protocol.eof_received()
 
-   Calls when the other end signals it won't send any more data
+   Called when the other end signals it won't send any more data
    (for example by calling :meth:`write_eof`, if the other end also uses
    asyncio).
 


### PR DESCRIPTION
(cherry picked from commit dd9a0a14c89d57e43898d4b866b8c161e4ff8506)