### PR TITLE
[3.5] bpo-29939: suppress compiler warnings in _ctypes_test (#902)

### DIFF
--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -52,9 +52,9 @@ _testfunc_cbk_large_struct(Test in, void (*func)(Test))
 EXPORT(void)
 _testfunc_large_struct_update_value(Test in)
 {
-    in.first = 0x0badf00d;
-    in.second = 0x0badf00d;
-    in.third = 0x0badf00d;
+    ((volatile Test *)&in)->first = 0x0badf00d;
+    ((volatile Test *)&in)->second = 0x0badf00d;
+    ((volatile Test *)&in)->third = 0x0badf00d;
 }
 
 EXPORT(void)testfunc_array(int values[4])


### PR DESCRIPTION
Changed test code to suppress a compiler warning, while taking care to avoid the code being optimized out by the compiler.
(cherry picked from commit 164d30eb1e66575dafee6af4fca4cbf52c7fbe6a)