### PR TITLE
Made - and _ interchangeable in argparse option names.

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1365,9 +1365,15 @@ class _ActionsContainer(object):
         self._actions.append(action)
         action.container = self
 
-        # index the action by any option strings it has
+        # Index the action by any option strings it has, doing some
+        # special preprocessing to ensure that dashes and underscores
+        # are equivalent for the purpose of recognizing options.
         for option_string in action.option_strings:
-            self._option_string_actions[option_string] = action
+            match = _re.match('(-*)(.*)', option_string)
+            dashes, name = match.groups()
+            for to_replace, replace_with in ['-_', '_-']:
+                new_string = dashes + name.replace(to_replace, replace_with)
+                self._option_string_actions[new_string] = action
 
         # set the flag if any option strings look like negative numbers
         for option_string in action.option_strings:

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -786,6 +786,22 @@ class TestOptionalsDisallowLongAbbreviation(ParserTestCase):
         ('--foonly 7 --foodle --foo 2', NS(foo='2', foodle=True, foonly='7')),
     ]
 
+
+class TestDashAndUnderscoreAreTheSame(ParserTestCase):
+    """Check that - and _ in option names are interchangeable"""
+
+    argument_signatures = [
+        Sig('--with-dash'),
+        Sig('--with_underscore'),
+    ]
+    failures = []
+    successes = [
+        ('--with-dash=x', NS(with_dash='x', with_underscore=None)),
+        ('--with_dash=x', NS(with_dash='x', with_underscore=None)),
+        ('--with-underscore=x', NS(with_underscore='x', with_dash=None)),
+        ('--with_underscore=x', NS(with_underscore='x', with_dash=None)),
+    ]
+
 # ================
 # Positional tests
 # ================


### PR DESCRIPTION
This has been bugging me for a while. Some authors make option names with underscores, and others use dashes. This change frees users from having to care.