### PR TITLE
[2.7] bpo-29943: Remove the PySlice_GetIndicesEx() macro.

### DIFF
--- a/Include/sliceobject.h
+++ b/Include/sliceobject.h
@@ -38,11 +38,6 @@ PyAPI_FUNC(int) PySlice_GetIndicesEx(PySliceObject *r, Py_ssize_t length,
 				    Py_ssize_t *start, Py_ssize_t *stop, 
 				    Py_ssize_t *step, Py_ssize_t *slicelength);
 
-#define PySlice_GetIndicesEx(slice, length, start, stop, step, slicelen) (  \
-    _PySlice_Unpack((PyObject *)(slice), (start), (stop), (step)) < 0 ?     \
-    ((*(slicelen) = 0), -1) :                                               \
-    ((*(slicelen) = _PySlice_AdjustIndices((length), (start), (stop), *(step))), \
-     0))
 PyAPI_FUNC(int) _PySlice_Unpack(PyObject *slice,
                                 Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step);
 PyAPI_FUNC(Py_ssize_t) _PySlice_AdjustIndices(Py_ssize_t length,

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -106,11 +106,6 @@ Library
 - Issue #28925: cPickle now correctly propagates errors when unpickle instances
   of old-style classes.
 
-C API
------
-
-- Issue #27867: Function PySlice_GetIndicesEx() is replaced with a macro.
-
 Documentation
 -------------
 

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -4434,11 +4434,10 @@ Array_subscript(PyObject *_self, PyObject *item)
         PyObject *np;
         Py_ssize_t start, stop, step, slicelen, cur, i;
 
-        if (PySlice_GetIndicesEx((PySliceObject *)item,
-                                 self->b_length, &start, &stop,
-                                 &step, &slicelen) < 0) {
+        if (PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
             return NULL;
         }
+        slicelen = PySlice_AdjustIndices(self->b_length, &start, &stop, step);
 
         stgdict = PyObject_stgdict((PyObject *)self);
         assert(stgdict); /* Cannot be NULL for array object instances */


### PR DESCRIPTION
Expand the PySlice_GetIndicesEx() function in _ctypes.c.