### PR TITLE
[3.6] bpo-29798: Handle git worktree in patchcheck

### DIFF
--- a/Tools/scripts/patchcheck.py
+++ b/Tools/scripts/patchcheck.py
@@ -70,7 +70,7 @@ def get_git_upstream_remote():
 @status("Getting base branch for PR",
         info=lambda x: x if x is not None else "not a PR branch")
 def get_base_branch():
-    if not os.path.isdir(os.path.join(SRCDIR, '.git')):
+    if not os.path.exists(os.path.join(SRCDIR, '.git')):
         # Not a git checkout, so there's no base branch
         return None
     version = sys.version_info


### PR DESCRIPTION
The original attempted fix missed an `isdir()` call in
`get_base_branch()`.
(cherry picked from commit 2abfdf5a81383d3b1ed6b7321903a9a168c373c5)