### PR TITLE
[3.5] bpo-29506: Clarify deep copy note in copy module

### DIFF
--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -47,8 +47,8 @@ copy operations:
 * Recursive objects (compound objects that, directly or indirectly, contain a
   reference to themselves) may cause a recursive loop.
 
-* Because deep copy copies *everything* it may copy too much, e.g.,
-  even administrative data structures that should be shared even between copies.
+* Because deep copy copies everything it may copy too much, such as data
+  which is intended to be shared between copies.
 
 The :func:`deepcopy` function avoids these problems by:
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -759,6 +759,7 @@ Lawrence Kesteloot
 Vivek Khera
 Dhiru Kholia
 Akshit Khurana
+Sanyam Khurana
 Mads Kiilerich
 Jason Killen
 Jan Kim


### PR DESCRIPTION
The reference to administrative data was confusing to readers,
so this simplifies the note to explain that deep copying may copy
more then you intended, such as data that you expected to be
shared between copies.

Patch by Sanyam Khurana.

(cherry picked from commit 19e04942562a980ad2519f6ff79c455a7472783b)