### PR TITLE
[2.7] bpo-29506: Clarify deep copy note in copy module

### DIFF
--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -43,8 +43,8 @@ copy operations:
 * Recursive objects (compound objects that, directly or indirectly, contain a
   reference to themselves) may cause a recursive loop.
 
-* Because deep copy copies *everything* it may copy too much, e.g.,
-  even administrative data structures that should be shared even between copies.
+* Because deep copy copies everything it may copy too much, such as data
+  which is intended to be shared between copies.
 
 The :func:`deepcopy` function avoids these problems by:
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -712,6 +712,7 @@ Magnus Kessler
 Lawrence Kesteloot
 Vivek Khera
 Dhiru Kholia
+Sanyam Khurana
 Mads Kiilerich
 Jason Killen
 Jan Kim


### PR DESCRIPTION
The reference to administrative data was confusing to readers,
so this simplifies the note to explain that deep copying may copy
more then you intended, such as data that you expected to be
shared between copies.

Patch by Sanyam Khurana.