### PR TITLE
bpo-29883: Add UDP support to Windows Proactor Event Loop

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -489,7 +489,7 @@ Opening network connections
       The *family*, *proto*, *flags*, *reuse_address*, *reuse_port,
       *allow_broadcast*, and *sock* parameters were added.
 
-   .. versionchanged:: 3.8.0
+   .. versionchanged:: 3.8
       Added support for Windows.
 
 .. coroutinemethod:: loop.create_unix_connection(protocol_factory, \

--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -482,14 +482,15 @@ Opening network connections
      transport. If specified, *local_addr* and *remote_addr* should be omitted
      (must be :const:`None`).
 
-   On Windows, with :class:`ProactorEventLoop`, this method is not supported.
-
    See :ref:`UDP echo client protocol <asyncio-udp-echo-client-protocol>` and
    :ref:`UDP echo server protocol <asyncio-udp-echo-server-protocol>` examples.
 
    .. versionchanged:: 3.4.4
       The *family*, *proto*, *flags*, *reuse_address*, *reuse_port,
       *allow_broadcast*, and *sock* parameters were added.
+
+   .. versionchanged:: 3.8.0
+      Added support for Windows.
 
 .. coroutinemethod:: loop.create_unix_connection(protocol_factory, \
                         path=None, \*, ssl=None, sock=None, \

--- a/Doc/library/asyncio-platforms.rst
+++ b/Doc/library/asyncio-platforms.rst
@@ -53,9 +53,6 @@ All event loops on Windows do not support the following methods:
 
 :class:`ProactorEventLoop` has the following limitations:
 
-* The :meth:`loop.create_datagram_endpoint` method
-  is not supported.
-
 * The :meth:`loop.add_reader` and :meth:`loop.add_writer`
   methods are not supported.
 

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -430,9 +430,7 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport):
 
     def __init__(self, loop, sock, protocol, address=None,
                  waiter=None, extra=None):
-        super(_ProactorDatagramTransport, self).__init__(loop, sock, protocol,
-                                                         waiter=waiter,
-                                                         extra=extra)
+        super().__init__(loop, sock, protocol, waiter=waiter, extra=extra)
         self._address = address
         # We don't need to call _protocol.connection_made() since our base
         # constructor does it for us.
@@ -440,7 +438,7 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport):
         self._loop.call_soon(self._loop_reading)
 
     def _set_extra(self, sock):
-        super(_ProactorDatagramTransport, self)._set_extra(sock)
+        super()._set_extra(sock)
         self._extra['socket'] = sock
 
         try:

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -11,6 +11,7 @@ import os
 import socket
 import warnings
 import signal
+import collections
 
 from . import base_events
 from . import constants
@@ -425,6 +426,102 @@ class _ProactorWritePipeTransport(_ProactorBaseWritePipeTransport):
             self.close()
 
 
+class _ProactorDatagramTransport(_ProactorBasePipeTransport):
+
+    def __init__(self, loop, sock, protocol, address=None,
+                 waiter=None, extra=None):
+        super(_ProactorDatagramTransport, self).__init__(loop, sock, protocol,
+                                                         waiter=waiter,
+                                                         extra=extra)
+        self._address = address
+        # We don't need to call _protocol.connection_made() since our base
+        # constructor does it for us.
+        self._buffer = collections.deque()
+        self._loop.call_soon(self._loop_reading)
+
+    def abort(self):
+        self._force_close(None)
+
+    def sendto(self, data, addr=None):
+        if not isinstance(data, (bytes, bytearray, memoryview)):
+            raise TypeError('data argument must be byte-ish (%r)',
+                            type(data))
+
+        if not data:
+            return
+
+        if self._conn_lost and self._address:
+            # close() or force_close() has been called on the bound endpoint
+            return
+
+        self._buffer.appendleft((data, addr))
+
+        if self._write_fut is None:
+            # No current write operations are active, kick one off
+            self._loop_writing()
+        else:
+            # A write operation is already kicked off
+            pass
+
+    def _loop_writing(self, fut=None):
+        if self._conn_lost:
+            return
+
+        assert fut is self._write_fut
+        if fut:
+            # We are in a _loop_writing() done callback, get the result
+            fut.result()
+
+        if not self._buffer or (self._conn_lost and self._address):
+            # The connection has been closed
+            self._write_fut = None
+            return
+
+        data, addr = self._buffer.pop()
+
+        self._write_fut = None
+        try:
+            if self._address:
+                self._write_fut = self._loop._proactor.send(self._sock, data)
+            else:
+                self._write_fut = self._loop._proactor.sendto(self._sock, data, addr=addr)
+        except OSError as exc:
+            self._protocol.error_received(exc)
+            self._fatal_error(exc, 'Fatal error sending UDP datagram')
+        else:
+            self._write_fut.add_done_callback(self._loop_writing)
+
+    def _loop_reading(self, fut=None):
+        if self._conn_lost:
+            return
+
+        assert self._read_fut is fut
+
+        if fut:
+            res = fut.result()
+
+            if self._address:
+                data, addr = res, self._address
+            else:
+                data, addr = res
+
+            self._protocol.datagram_received(data, addr)
+
+        if self._conn_lost:
+            return
+
+        try:
+            if self._address:
+                self._read_fut = self._loop._proactor.recv(self._sock, 4096)
+            else:
+                self._read_fut = self._loop._proactor.recvfrom(self._sock, 4096)
+        except OSError as exc:
+            self._protocol.error_received(exc)
+            self._fatal_error(exc, "Fatal error reading from UDP endpoint")
+        else:
+            self._read_fut.add_done_callback(self._loop_reading)
+
+
 class _ProactorDuplexPipeTransport(_ProactorReadPipeTransport,
                                    _ProactorBaseWritePipeTransport,
                                    transports.Transport):
@@ -506,9 +603,15 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
                 self, protocol, sslcontext, waiter,
                 server_side, server_hostname,
                 ssl_handshake_timeout=ssl_handshake_timeout)
+
         _ProactorSocketTransport(self, rawsock, ssl_protocol,
                                  extra=extra, server=server)
         return ssl_protocol._app_transport
+
+    def _make_datagram_transport(self, sock, protocol,
+                                 address=None, waiter=None, extra=None):
+        return _ProactorDatagramTransport(self, sock, protocol, address,
+                                          waiter, extra)
 
     def _make_duplex_pipe_transport(self, sock, protocol, waiter=None,
                                     extra=None):

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -23,6 +23,25 @@ from . import transports
 from .log import logger
 
 
+def _set_socket_extra(transport, sock):
+    transport._extra['socket'] = sock
+
+    try:
+        transport._extra['sockname'] = sock.getsockname()
+    except (socket.error, AttributeError):
+        if transport._loop.get_debug():
+            logger.warning(
+                "getsockname() failed on %r", sock, exc_info=True)
+
+    if 'peername' not in transport._extra:
+        try:
+            transport._extra['peername'] = sock.getpeername()
+        except (socket.error, AttributeError):
+            if transport._loop.get_debug():
+                logger.warning("getpeername() failed on %r",
+                                sock, exc_info=True)
+
+
 class _ProactorBasePipeTransport(transports._FlowControlMixin,
                                  transports.BaseTransport):
     """Base class for pipe and socket transports."""
@@ -430,32 +449,18 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport):
 
     def __init__(self, loop, sock, protocol, address=None,
                  waiter=None, extra=None):
-        super().__init__(loop, sock, protocol, waiter=waiter, extra=extra)
         self._address = address
+        self._empty_waiter = None
         # We don't need to call _protocol.connection_made() since our base
         # constructor does it for us.
+        super().__init__(loop, sock, protocol, waiter=waiter, extra=extra)
+
+        # The base constructor sets _buffer = None, so we set it here
         self._buffer = collections.deque()
         self._loop.call_soon(self._loop_reading)
 
     def _set_extra(self, sock):
-        super()._set_extra(sock)
-        self._extra['socket'] = sock
-
-        try:
-            self._extra['sockname'] = sock.getsockname()
-        except (socket.error, AttributeError):
-            if self._loop.get_debug():
-                logger.warning(
-                    "getsockname() failed on %r", sock, exc_info=True)
-
-        if 'peername' not in self._extra:
-            try:
-                self._extra['peername'] = sock.getpeername()
-            except (socket.error, AttributeError):
-                if self._loop.get_debug():
-                    logger.warning("getpeername() failed on %r",
-                                   sock, exc_info=True)
-
+        _set_socket_extra(self, sock)
 
     def abort(self):
         self._force_close(None)
@@ -468,8 +473,14 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport):
         if not data:
             return
 
+        if self._address and addr not in (None, self._address):
+            raise ValueError(
+                f'Invalid address: must be None or {self._address}')
+
         if self._conn_lost and self._address:
-            # close() or force_close() has been called on the bound endpoint
+            if self._conn_lost >= constants.LOG_THRESHOLD_FOR_CONNLOST_WRITES:
+                logger.warning('socket.sendto() raised exception.')
+            self._conn_lost += 1
             return
 
         self._buffer.appendleft((data, addr))
@@ -477,67 +488,77 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport):
         if self._write_fut is None:
             # No current write operations are active, kick one off
             self._loop_writing()
-        else:
-            # A write operation is already kicked off
-            pass
+        # else: A write operation is already kicked off
 
     def _loop_writing(self, fut=None):
-        if self._conn_lost:
-            return
-
-        assert fut is self._write_fut
-        if fut:
-            # We are in a _loop_writing() done callback, get the result
-            fut.result()
-
-        if not self._buffer or (self._conn_lost and self._address):
-            # The connection has been closed
-            self._write_fut = None
-            return
-
-        data, addr = self._buffer.pop()
-
-        self._write_fut = None
         try:
+            if self._conn_lost:
+                return
+
+            assert fut is self._write_fut
+            self._write_fut = None
+            if fut:
+                # We are in a _loop_writing() done callback, get the result
+                fut.result()
+
+            if not self._buffer or (self._conn_lost and self._address):
+                # The connection has been closed
+                if self._closing:
+                    self._loop.call_soon(self._call_connection_lost, None)
+                return
+
+            data, addr = self._buffer.pop()
             if self._address:
                 self._write_fut = self._loop._proactor.send(self._sock, data)
             else:
                 self._write_fut = self._loop._proactor.sendto(self._sock, data, addr=addr)
         except OSError as exc:
             self._protocol.error_received(exc)
-            self._fatal_error(exc, 'Fatal error sending UDP datagram')
+        except Exception as exc:
+            self._fatal_error(exc, 'Fatal write error on datagram transport')
         else:
             self._write_fut.add_done_callback(self._loop_writing)
 
     def _loop_reading(self, fut=None):
-        if self._conn_lost:
-            return
-
-        assert self._read_fut is fut
-
-        if fut:
-            res = fut.result()
-
-            if self._address:
-                data, addr = res, self._address
-            else:
-                data, addr = res
-
-            self._protocol.datagram_received(data, addr)
-
-        if self._conn_lost:
-            return
-
+        data = None
         try:
+            if self._conn_lost:
+                return
+
+            assert self._read_fut is fut or (self._read_fut is None and
+                                             self._closing)
+
+            self._read_fut = None
+            if fut is not None:
+                res = fut.result()
+
+                if self._closing:
+                    # since close() has been called we ignore any read data
+                    data = None
+                    return
+
+                if self._address:
+                    data, addr = res, self._address
+                else:
+                    data, addr = res
+
+            if self._conn_lost:
+                return
             if self._address:
                 self._read_fut = self._loop._proactor.recv(self._sock, 4096)
             else:
                 self._read_fut = self._loop._proactor.recvfrom(self._sock, 4096)
         except OSError as exc:
             self._protocol.error_received(exc)
-            self._fatal_error(exc, "Fatal error reading from UDP endpoint")
+        except exceptions.CancelledError:
+            if not self._closing:
+                raise
         else:
-            self._read_fut.add_done_callback(self._loop_reading)
+            if self._read_fut is not None:
+                self._read_fut.add_done_callback(self._loop_reading)
+        finally:
+            if data:
+                self._protocol.datagram_received(data, addr)
 
 
 class _ProactorDuplexPipeTransport(_ProactorReadPipeTransport,
@@ -565,22 +586,7 @@ class _ProactorSocketTransport(_ProactorReadPipeTransport,
         base_events._set_nodelay(sock)
 
     def _set_extra(self, sock):
-        self._extra['socket'] = sock
-
-        try:
-            self._extra['sockname'] = sock.getsockname()
-        except (socket.error, AttributeError):
-            if self._loop.get_debug():
-                logger.warning(
-                    "getsockname() failed on %r", sock, exc_info=True)
-
-        if 'peername' not in self._extra:
-            try:
-                self._extra['peername'] = sock.getpeername()
-            except (socket.error, AttributeError):
-                if self._loop.get_debug():
-                    logger.warning("getpeername() failed on %r",
-                                   sock, exc_info=True)
+        _set_socket_extra(self, sock)
 
     def can_write_eof(self):
         return True
@@ -621,7 +627,6 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
                 self, protocol, sslcontext, waiter,
                 server_side, server_hostname,
                 ssl_handshake_timeout=ssl_handshake_timeout)
-
         _ProactorSocketTransport(self, rawsock, ssl_protocol,
                                  extra=extra, server=server)
         return ssl_protocol._app_transport

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -28,7 +28,7 @@ def _set_socket_extra(transport, sock):
 
     try:
         transport._extra['sockname'] = sock.getsockname()
-    except (socket.error, AttributeError):
+    except socket.error:
         if transport._loop.get_debug():
             logger.warning(
                 "getsockname() failed on %r", sock, exc_info=True)
@@ -36,7 +36,7 @@ def _set_socket_extra(transport, sock):
     if 'peername' not in transport._extra:
         try:
             transport._extra['peername'] = sock.getpeername()
-        except (socket.error, AttributeError):
+        except socket.error:
             # UDP sockets may not have a peer name
             transport._extra['peername'] = None
 

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -439,6 +439,26 @@ class _ProactorDatagramTransport(_ProactorBasePipeTransport):
         self._buffer = collections.deque()
         self._loop.call_soon(self._loop_reading)
 
+    def _set_extra(self, sock):
+        super(_ProactorDatagramTransport, self)._set_extra(sock)
+        self._extra['socket'] = sock
+
+        try:
+            self._extra['sockname'] = sock.getsockname()
+        except (socket.error, AttributeError):
+            if self._loop.get_debug():
+                logger.warning(
+                    "getsockname() failed on %r", sock, exc_info=True)
+
+        if 'peername' not in self._extra:
+            try:
+                self._extra['peername'] = sock.getpeername()
+            except (socket.error, AttributeError):
+                if self._loop.get_debug():
+                    logger.warning("getpeername() failed on %r",
+                                   sock, exc_info=True)
+
+
     def abort(self):
         self._force_close(None)
 

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -37,9 +37,8 @@ def _set_socket_extra(transport, sock):
         try:
             transport._extra['peername'] = sock.getpeername()
         except (socket.error, AttributeError):
-            if transport._loop.get_debug():
-                logger.warning("getpeername() failed on %r",
-                                sock, exc_info=True)
+            # UDP sockets may not have a peer name
+            transport._extra['peername'] = None
 
 
 class _ProactorBasePipeTransport(transports._FlowControlMixin,

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -511,7 +511,8 @@ class IocpProactor:
             try:
                 return ov.getresult()
             except OSError as exc:
-                if exc.winerror == _overlapped.ERROR_NETNAME_DELETED:
+                if exc.winerror in (_overlapped.ERROR_NETNAME_DELETED,
+                                    _overlapped.ERROR_OPERATION_ABORTED):
                     raise ConnectionResetError(*exc.args)
                 else:
                     raise
@@ -572,7 +573,6 @@ class IocpProactor:
             # need to register any IOCP operation
             _overlapped.WSAConnect(conn.fileno(), address)
             fut = self._loop.create_future()
-
             fut.set_result(None)
             return fut
 

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1252,11 +1252,6 @@ class EventLoopTestsMixin:
         server.transport.close()
 
     def test_create_datagram_endpoint_sock(self):
-        if (sys.platform == 'win32' and
-                isinstance(self.loop, proactor_events.BaseProactorEventLoop)):
-            raise unittest.SkipTest(
-                'UDP is not supported with proactor event loops')
-
         sock = None
         local_address = ('127.0.0.1', 0)
         infos = self.loop.run_until_complete(
@@ -2008,10 +2003,6 @@ if sys.platform == 'win32':
 
         def test_writer_callback_cancel(self):
             raise unittest.SkipTest("IocpEventLoop does not have add_writer()")
-
-        def test_create_datagram_endpoint(self):
-            raise unittest.SkipTest(
-                "IocpEventLoop does not have create_datagram_endpoint()")
 
         def test_remove_fds_after_closing(self):
             raise unittest.SkipTest("IocpEventLoop does not have add_reader()")

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -926,9 +926,6 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
         tr._protocol.error_received = mock.Mock()
         tr._loop_reading()
         tr._protocol.error_received.assert_called_with(err)
-        tr._fatal_error.assert_called_with(
-                            err,
-                            'Fatal error reading from UDP endpoint')
         close_transport(tr)
 
     def test_datagram_loop_writing_aborted(self):
@@ -940,9 +937,6 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
         tr._buffer.appendleft((b'Hello', ('127.0.0.1', 12068)))
         tr._loop_writing()
         tr._protocol.error_received.assert_called_with(err)
-        tr._fatal_error.assert_called_with(
-                            err,
-                            'Fatal error sending UDP datagram')
         close_transport(tr)
 
 

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -978,7 +978,7 @@ class ProactorEventLoopUnixSockSendfileTests(test_utils.TestCase):
         self.assertEqual(self.file.tell(), 0)
 
     def datagram_transport(self):
-        self.protocol = make_test_protocol(asyncio.DatagramProtocol)
+        self.protocol = test_utils.make_test_protocol(asyncio.DatagramProtocol)
         return self.loop._make_datagram_transport(self.sock, self.protocol)
 
     def test_make_datagram_transport(self):
@@ -1023,7 +1023,7 @@ class ProactorEventLoopUnixSockSendfileTests(test_utils.TestCase):
         tr.close = mock.Mock()
         tr._read_fut = res
         tr._loop_reading(res)
-        self.assertFalse(self.loop._proactor.recvfrom.called)
+        self.assertTrue(self.loop._proactor.recvfrom.called)
         self.assertFalse(self.protocol.error_received.called)
         self.assertFalse(tr.close.called)
 
@@ -1045,9 +1045,9 @@ class ProactorEventLoopUnixSockSendfileTests(test_utils.TestCase):
         tr = self.datagram_transport()
         tr._fatal_error = mock.Mock()
         tr._protocol.error_received = mock.Mock()
-        tr._protocol.error_received.assert_called_with(err)
         tr._buffer.appendleft((b'Hello', ('127.0.0.1', 12068)))
         tr._loop_writing()
+        tr._protocol.error_received.assert_called_with(err)
         tr._fatal_error.assert_called_with(
                             err,
                             'Fatal error sending UDP datagram')

--- a/Misc/NEWS.d/next/Windows/2018-09-15-11-36-55.bpo-29883.HErerE.rst
+++ b/Misc/NEWS.d/next/Windows/2018-09-15-11-36-55.bpo-29883.HErerE.rst
@@ -1,0 +1,2 @@
+Add Windows support for UDP transports for the Proactor Event Loop. Patch by
+Adam Meily.

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -796,6 +796,7 @@ Overlapped_getresult(OverlappedObject *self, PyObject *args)
             // The result is a two item tuple: (message, (address, port))
             self->read_from.result = PyTuple_New(2);
             if (self->read_from.result == NULL) {
+                Py_CLEAR(addr);
                 return NULL;
             }
 

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -591,12 +591,10 @@ Overlapped_clear(OverlappedObject *self)
         // The result tuple of (message, (address, port)) is only
         // allocated _after_ a message has been received.
         if(self->read_from.result) {
-            // We've received a message, free the result tuple which will
-            // also free the message buffer.
+            // We've received a message, free the result tuple.
             Py_CLEAR(self->read_from.result);
-            self->read_from.buffer = NULL;
-        } else if(self->read_from.buffer) {
-            // We haven't received a message, only free the buffer.
+        }
+        if(self->read_from.buffer) {
             Py_CLEAR(self->read_from.buffer);
         }
         break;

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -792,7 +792,6 @@ Overlapped_getresult(OverlappedObject *self, PyObject *args)
             PyTuple_SetItem(self->read_from.result, 1, addr);
 
             Py_INCREF(self->read_from.result);
-            Py_INCREF(self->read_from.addr);
             Py_INCREF(self->read_from.buffer);
             return self->read_from.result;
         default:

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -1444,7 +1444,7 @@ Overlapped_traverse(OverlappedObject *self, visitproc visit, void *arg)
 // UDP functions
 
 PyDoc_STRVAR(
-    Overlapped_WSAConnect_doc,
+    overlapped_WSAConnect_doc,
     "WSAConnect(client_handle, address_as_bytes) -> Overlapped[None]\n\n"
     "Bind a remote address to a connectionless (UDP) socket");
 
@@ -1453,7 +1453,7 @@ PyDoc_STRVAR(
  * _only_ be used for connection-less sockets (UDP).
  */
 static PyObject *
-Overlapped_WSAConnect(OverlappedObject *self, PyObject *args) {
+overlapped_WSAConnect(PyObject *self, PyObject *args) {
     SOCKET ConnectSocket;
     PyObject *AddressObj;
     char AddressBuf[sizeof(struct sockaddr_in6)];
@@ -1464,18 +1464,10 @@ Overlapped_WSAConnect(OverlappedObject *self, PyObject *args) {
     if(!PyArg_ParseTuple(args, F_HANDLE "O", &ConnectSocket, &AddressObj))
         return NULL;
 
-    if(self->type != TYPE_NONE) {
-        PyErr_SetString(PyExc_ValueError, "operation already attempted");
-        return NULL;
-    }
-
     Length = sizeof(AddressBuf);
     Length = parse_address(AddressObj, Address, Length);
     if(Length < 0)
         return NULL;
-
-    //self->type = TYPE_CONNECT;
-    //self->handle = (HANDLE)ConnectSocket;
 
     Py_BEGIN_ALLOW_THREADS
         // WSAConnect does not support overlapped I/O so this call will
@@ -1485,10 +1477,6 @@ Overlapped_WSAConnect(OverlappedObject *self, PyObject *args) {
     Py_END_ALLOW_THREADS
 
     err = err == ERROR_SUCCESS ? 0 : WSAGetLastError();
-
-    // Reset the operation type since WSAConnect finishes immediately
-    //self->type = TYPE_NOT_STARTED;
-    //self->error = err = ret ? ERROR_SUCCESS : WSAGetLastError();
 
     switch(err) {
     case ERROR_SUCCESS:
@@ -1751,8 +1739,8 @@ static PyMethodDef overlapped_functions[] = {
     {"ConnectPipe",
      (PyCFunction)ConnectPipe,
      METH_VARARGS, ConnectPipe_doc},
-    {"WSAConnect", (PyCFunction) Overlapped_WSAConnect,
-     METH_VARARGS, Overlapped_WSAConnect_doc},
+    {"WSAConnect", (PyCFunction) overlapped_WSAConnect,
+     METH_VARARGS, overlapped_WSAConnect_doc},
     {NULL}
 };
 

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -1751,7 +1751,7 @@ static PyMethodDef overlapped_functions[] = {
     {"ConnectPipe",
      (PyCFunction)ConnectPipe,
      METH_VARARGS, ConnectPipe_doc},
-    {"WSAConnect", Overlapped_WSAConnect,
+    {"WSAConnect", (PyCFunction) Overlapped_WSAConnect,
      METH_VARARGS, Overlapped_WSAConnect_doc},
     {NULL}
 };

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -781,7 +781,6 @@ Overlapped_getresult(OverlappedObject *self, PyObject *args)
 
             Py_INCREF(self->read_from.result);
             return self->read_from.result;
->>>>>>> bpo-29883: Add UDP to Windows Proactor Event Loop
         default:
             return PyLong_FromUnsignedLong((unsigned long) transferred);
     }
@@ -1660,9 +1659,9 @@ static PyMethodDef Overlapped_methods[] = {
      METH_VARARGS, Overlapped_TransmitFile_doc},
     {"ConnectNamedPipe", (PyCFunction) Overlapped_ConnectNamedPipe,
      METH_VARARGS, Overlapped_ConnectNamedPipe_doc},
-     { "WSARecvFrom", Overlapped_WSARecvFrom,
+    {"WSARecvFrom", (PyCFunction) Overlapped_WSARecvFrom,
      METH_VARARGS, Overlapped_WSARecvFrom_doc },
-     { "WSASendTo", Overlapped_WSASendTo,
+    {"WSASendTo", (PyCFunction) Overlapped_WSASendTo,
      METH_VARARGS, Overlapped_WSASendTo_doc },
     {NULL}
 };

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -661,7 +661,6 @@ unparse_address(LPSOCKADDR Address, DWORD Length)
     char AddressString[40];
     unsigned int port;
     PVOID pSinAddr;
-    DWORD err;
 
     switch(Address->sa_family) {
     case AF_INET:
@@ -1653,7 +1652,6 @@ Overlapped_WSARecvFrom(OverlappedObject *self, PyObject *args)
         self->type = TYPE_NOT_STARTED;
         return SetFromWindowsErr(err);
     }
->>>>>>> bpo-29883: Add UDP to Windows Proactor Event Loop
 }
 
 

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -789,6 +789,10 @@ Overlapped_getresult(OverlappedObject *self, PyObject *args)
             addr = unparse_address((SOCKADDR*)&self->read_from.address,
                                    self->read_from.address_length);
 
+            if (addr == NULL) {
+                return NULL;
+            }
+
             // The result is a two item tuple: (message, (address, port))
             self->read_from.result = PyTuple_New(2);
             if (self->read_from.result == NULL) {


### PR DESCRIPTION
This PR adds UDP support to the Windows Proactor Event Loop. Several changes were performed:

 * Added wrappers around Winsock UDP functions:
   * `WSAConnect` - ConnectEx doesn't support binding a UDP endpoint to a socket so I had to add this. WSAConnect completes immediately for UDP sockets.
   * `WSARecvFrom`
   * `WSASendTo`
 * Implement `_make_datagram_transport()` and the corresponding UDP transport class `_ProactorDatagramTransport`.
   * Bound UDP endpoints can call `WSARecv` and `WSASend`. Unbound UDP endpoints require calls to `WSARecvFrom` and `WSASendTo`.
 * Several new unit tests exercising UDP proactor support.

I've verified that the change can be cleanly applied to master, 3.5, and 3.6. So, back porting this feature will be straightforward, which I would like personally since I require this feature on a Python 3.5 project.

One of the SSL unit tests is failing and I've verified that the same test fails with the same error in `master`. 

```
cpython\lib\asyncio\sslproto.py:335: ResourceWarning: unclosed transport
<asyncio.sslproto._SSLProtocolTransport object at 0x00000171EABA8A90>
  source=self)
```

<!-- issue-number: bpo-29883 -->
https://bugs.python.org/issue29883
<!-- /issue-number -->
