### PR TITLE
bpo-19225: Remove duplicated description for standard warning categories

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -291,10 +291,11 @@ an error value).
    is the function calling :c:func:`PyErr_WarnEx`, 2 is  the function above that,
    and so forth.
 
+   Warning categories must be subclasses of :c:data:`PyExc_Warning`;
    :c:data:`PyExc_Warning` is a subclass of :c:data:`PyExc_Exception`;
-   warning categories must be subclasses of :c:data:`Warning`; the default warning
-   category is :c:data:`RuntimeWarning`. Their names are enumerated at
-   :ref:`standarwarningcategories`.
+   the default warning category is :c:data:`PyExc_RuntimeWarning`. The standard
+   Python warning categories are available as global variables whose names are
+   enumerated at :ref:`standarwarningcategories`.
 
    For information about warning control, see the documentation for the
    :mod:`warnings` module and the :option:`-W` option in the command line

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -292,15 +292,8 @@ an error value).
    and so forth.
 
    Warning categories must be subclasses of :c:data:`Warning`; the default warning
-   category is :c:data:`RuntimeWarning`.  The standard Python warning categories are
-   available as global variables whose names are ``PyExc_`` followed by the Python
-   exception name. These have the type :c:type:`PyObject\*`; they are all class
-   objects. Their names are :c:data:`PyExc_Warning`, :c:data:`PyExc_UserWarning`,
-   :c:data:`PyExc_UnicodeWarning`, :c:data:`PyExc_DeprecationWarning`,
-   :c:data:`PyExc_SyntaxWarning`, :c:data:`PyExc_RuntimeWarning`, and
-   :c:data:`PyExc_FutureWarning`.  :c:data:`PyExc_Warning` is a subclass of
-   :c:data:`PyExc_Exception`; the other warning categories are subclasses of
-   :c:data:`PyExc_Warning`.
+   category is :c:data:`RuntimeWarning`. Their names are enumerated at
+   :ref:`standarwarningcategories`.
 
    For information about warning control, see the documentation for the
    :mod:`warnings` module and the :option:`-W` option in the command line
@@ -963,8 +956,10 @@ Notes:
    Only defined on Windows; protect code that uses this by testing that the
    preprocessor macro ``MS_WINDOWS`` is defined.
 
-Standard Warnings
-=================
+.. _standarwarningcategories:
+
+Standard Warning Categories
+===========================
 
 All standard Python warning categories are available as global variables whose
 names are ``PyExc_`` followed by the Python exception name. These have the type

--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -291,7 +291,8 @@ an error value).
    is the function calling :c:func:`PyErr_WarnEx`, 2 is  the function above that,
    and so forth.
 
-   Warning categories must be subclasses of :c:data:`Warning`; the default warning
+   :c:data:`PyExc_Warning` is a subclass of :c:data:`PyExc_Exception`;
+   warning categories must be subclasses of :c:data:`Warning`; the default warning
    category is :c:data:`RuntimeWarning`. Their names are enumerated at
    :ref:`standarwarningcategories`.
 


### PR DESCRIPTION
see [bpo-19225](http://bugs.python.org/issue19225).