### PR TITLE
bpo-30029: SyntaxError: 'await' outside function was unreachable

### DIFF
--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1581,6 +1581,10 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
                     tok->async_def = 1;
                     return ASYNC;
                 }
+            } else {
+                if (memcmp(tok->start, "await", 5) == 0) {
+                    return AWAIT;
+                }
             }
         }
 

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1581,9 +1581,21 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
                     tok->async_def = 1;
                     return ASYNC;
                 }
-            } else {
-                /* we're outside a 'async def' function */
-                if (memcmp(tok->start, "await", 5) == 0) {
+            } else if (memcmp(tok->start, "await", 5) == 0) {
+                /* The current token is 'await'.
+                   Look ahead one token.*/
+
+                struct tok_state ahead_tok;
+                char *ahead_tok_start = NULL, *ahead_tok_end = NULL;
+                int ahead_tok_kind;
+
+                memcpy(&ahead_tok, tok, sizeof(ahead_tok));
+                ahead_tok_kind = tok_get(&ahead_tok, &ahead_tok_start,
+                                         &ahead_tok_end);
+
+                if (ahead_tok_kind == NAME
+                    && ahead_tok.cur - ahead_tok.start == 3)
+                {
                     return AWAIT;
                 }
             }

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1582,6 +1582,7 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
                     return ASYNC;
                 }
             } else {
+                /* we're outside a 'async def' function */
                 if (memcmp(tok->start, "await", 5) == 0) {
                     return AWAIT;
                 }


### PR DESCRIPTION
See [bpo-30029](http://bugs.python.org/issue30029)

Before:

```
>>> await foo()
  File "<stdin>", line 1
    await foo()
            ^
SyntaxError: invalid syntax
```

After:

```
>>> await foo()
  File "<stdin>", line 1
SyntaxError: 'await' outside function
```

Behaviour now matches the yield keyword. 