### PR TITLE
bpo-30028: os.getpid() is always available

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -315,7 +315,7 @@ class LogRecord(object):
                     self.processName = mp.current_process().name
                 except Exception: #pragma: no cover
                     pass
-        if logProcesses and hasattr(os, 'getpid'):
+        if logProcesses:
             self.process = os.getpid()
         else:
             self.process = None


### PR DESCRIPTION
Remove hasattr(os, 'getpid') from logging.LogRecord constructor. The
test was added in 2003 with the commit 4c641d0ce1cc: "getpid doesn't
exist on MacOS9", but Python 3.7 doesn't support MacOS9 anymore.