### PR TITLE
Remove superfluous comment in urllib.error.

### DIFF
--- a/Lib/urllib/error.py
+++ b/Lib/urllib/error.py
@@ -16,10 +16,6 @@ import urllib.response
 __all__ = ['URLError', 'HTTPError', 'ContentTooShortError']
 
 
-# do these error classes make sense?
-# make sure all of the OSError stuff is overridden.  we just want to be
-# subtypes.
-
 class URLError(OSError):
     # URLError is a sub-type of OSError, but it doesn't share any of
     # the implementation.  need to override __init__ and __str__.


### PR DESCRIPTION
It is documented that `URLError` is the error raised by this module.