### PR TITLE
bpo-30040: New empty dict uses key-sharing dict.

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -5346,7 +5346,7 @@ class SharedKeyTests(unittest.TestCase):
 
         a, b = A(), B()
         self.assertEqual(sys.getsizeof(vars(a)), sys.getsizeof(vars(b)))
-        self.assertLess(sys.getsizeof(vars(a)), sys.getsizeof({}))
+        self.assertLess(sys.getsizeof(vars(a)), sys.getsizeof({"a":1}))
         # Initial hash table can contain at most 5 elements.
         # Set 6 attributes to cause internal resizing.
         a.x, a.y, a.z, a.w, a.v, a.u = range(6)

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -5353,9 +5353,9 @@ class SharedKeyTests(unittest.TestCase):
         self.assertNotEqual(sys.getsizeof(vars(a)), sys.getsizeof(vars(b)))
         a2 = A()
         self.assertEqual(sys.getsizeof(vars(a)), sys.getsizeof(vars(a2)))
-        self.assertLess(sys.getsizeof(vars(a)), sys.getsizeof({}))
+        self.assertLess(sys.getsizeof(vars(a)), sys.getsizeof({"a":1}))
         b.u, b.v, b.w, b.t, b.s, b.r = range(6)
-        self.assertLess(sys.getsizeof(vars(b)), sys.getsizeof({}))
+        self.assertLess(sys.getsizeof(vars(b)), sys.getsizeof({"a":1}))
 
 
 class DebugHelperMeta(type):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -982,8 +982,10 @@ class SizeofTest(unittest.TestCase):
         check(int.__add__, size('3P2P'))
         # method-wrapper (descriptor object)
         check({}.__iter__, size('2P'))
+        # empty dict
+        check({}, size('nQ2P'))
         # dict
-        check({}, size('nQ2P') + calcsize('2nP2n') + 8 + (8*2//3)*calcsize('n2P'))
+        check({"a": 1}, size('nQ2P') + calcsize('2nP2n') + 8 + (8*2//3)*calcsize('n2P'))
         longdict = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8}
         check(longdict, size('nQ2P') + calcsize('2nP2n') + 16 + (16*2//3)*calcsize('n2P'))
         # dictionary-keyview

--- a/Misc/NEWS.d/next/Core and Builtins/2019-03-11-22-30-56.bpo-30040.W9z8X7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2019-03-11-22-30-56.bpo-30040.W9z8X7.rst
@@ -1,0 +1,2 @@
+New empty dict uses fewer memory for now.  It used more memory than empty
+dict created by ``dict.clear()``.  Patch by Inada Naoki.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -691,10 +691,8 @@ clone_combined_dict(PyDictObject *orig)
 PyObject *
 PyDict_New(void)
 {
-    PyDictKeysObject *keys = new_keys_object(PyDict_MINSIZE);
-    if (keys == NULL)
-        return NULL;
-    return new_dict(keys, NULL);
+    DK_INCREF(Py_EMPTY_KEYS);
+    return new_dict(Py_EMPTY_KEYS, empty_values);
 }
 
 /* Search index of hash table from offset of entry table */
@@ -1276,6 +1274,9 @@ _PyDict_NewPresized(Py_ssize_t minused)
     Py_ssize_t newsize;
     PyDictKeysObject *new_keys;
 
+    if (minused == 0) {
+        return PyDict_New();
+    }
     /* There are no strict guarantee that returned dict can contain minused
      * items without resize.  So we create medium size dict instead of very
      * large dict or MemoryError.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -691,7 +691,7 @@ clone_combined_dict(PyDictObject *orig)
 PyObject *
 PyDict_New(void)
 {
-    DK_INCREF(Py_EMPTY_KEYS);
+    dictkeys_incref(Py_EMPTY_KEYS);
     return new_dict(Py_EMPTY_KEYS, empty_values);
 }
 


### PR DESCRIPTION
Like dict.clear().
Sizeof new empty dict becomes 72 bytes from 240 bytes (amd64).

<!-- issue-number: [bpo-30040](https://bugs.python.org/issue30040) -->
https://bugs.python.org/issue30040
<!-- /issue-number -->
