### PR TITLE
bpo-29870: Free CRL DP with CRL_DIST_POINTS_free()

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1257,9 +1257,7 @@ _get_crl_dp(X509 *certificate) {
 
   done:
     Py_XDECREF(lst);
-#if OPENSSL_VERSION_NUMBER < 0x10001000L
-    sk_DIST_POINT_free(dps);
-#endif
+    CRL_DIST_POINTS_free(dps);
     return res;
 }
 


### PR DESCRIPTION
CRL_DIST_POINTS_free() compiles and tests with OpenSSL and libressl
versions

<BuildOpenSSL for 0.9.8zc>
<BuildOpenSSL for 0.9.8zh>
<BuildOpenSSL for 1.0.1u>
<BuildOpenSSL for 1.0.2>
<BuildOpenSSL for 1.0.2k>
<BuildOpenSSL for 1.1.0e>
<BuildLibreSSL for 2.3.10>
<BuildLibreSSL for 2.4.5>
<BuildLibreSSL for 2.5.3>

I have verified that it does no longer leak on OpenSSL 1.0.2k.