### PR TITLE
bpo-30047: Fix typos in Doc/library/select.rst

### DIFF
--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -290,7 +290,7 @@ Edge and Level Trigger Polling (epoll) Objects
    | :const:`EPOLLEXCLUSIVE` | Wake only one epoll object when the           |
    |                         | associated fd has an event. The default (if   |
    |                         | this flag is not set) is to wake all epoll    |
-   |                         | objects polling on on a fd.                   |
+   |                         | objects polling on a fd.                      |
    +-------------------------+-----------------------------------------------+
    | :const:`EPOLLRDHUP`     | Stream socket peer closed connection or shut  |
    |                         | down writing half of connection.              |


### PR DESCRIPTION
In 18.3.2. Edge and Level Trigger Polling (epoll) Objects,
there is duplicated 'on' in description of `EPOLLEXCLUSIVE`.
```
   Wake only ... objects polling on on a fd.
                                 ^^^^^
```