### PR TITLE
bpo-30049: The tp_iternext slot value no longer cached for using in loops.

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,10 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-30049: The tp_iternext slot value no longer cached for using in loops.
+  This affects list, bytearray and deque constructors, ''.join, builtin
+  functions all, any, filter, and itertools functions.
+
 - bpo-29914: Fixed default implementations of __reduce__ and __reduce_ex__().
   object.__reduce__() no longer takes arguments, object.__reduce_ex__() now
   requires one argument.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -358,11 +358,9 @@ finalize_iterator(PyObject *it)
 static PyObject*
 consume_iterator(PyObject *it)
 {
-    PyObject *(*iternext)(PyObject *);
     PyObject *item;
 
-    iternext = *Py_TYPE(it)->tp_iternext;
-    while ((item = iternext(it)) != NULL) {
+    while ((item = Py_TYPE(it)->tp_iternext(it)) != NULL) {
         Py_DECREF(item);
     }
     return finalize_iterator(it);
@@ -372,7 +370,6 @@ static PyObject *
 deque_extend(dequeobject *deque, PyObject *iterable)
 {
     PyObject *it, *item;
-    PyObject *(*iternext)(PyObject *);
     Py_ssize_t maxlen = deque->maxlen;
 
     /* Handle case where id(deque) == id(iterable) */
@@ -401,8 +398,7 @@ deque_extend(dequeobject *deque, PyObject *iterable)
         deque->rightindex = 0;
     }
 
-    iternext = *Py_TYPE(it)->tp_iternext;
-    while ((item = iternext(it)) != NULL) {
+    while ((item = Py_TYPE(it)->tp_iternext(it)) != NULL) {
         if (deque->rightindex == BLOCKLEN - 1) {
             block *b = newblock();
             if (b == NULL) {
@@ -437,7 +433,6 @@ static PyObject *
 deque_extendleft(dequeobject *deque, PyObject *iterable)
 {
     PyObject *it, *item;
-    PyObject *(*iternext)(PyObject *);
     Py_ssize_t maxlen = deque->maxlen;
 
     /* Handle case where id(deque) == id(iterable) */
@@ -466,8 +461,7 @@ deque_extendleft(dequeobject *deque, PyObject *iterable)
         deque->rightindex = BLOCKLEN - 2;
     }
 
-    iternext = *Py_TYPE(it)->tp_iternext;
-    while ((item = iternext(it)) != NULL) {
+    while ((item = Py_TYPE(it)->tp_iternext(it)) != NULL) {
         if (deque->leftindex == 0) {
             block *b = newblock();
             if (b == NULL) {

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1120,11 +1120,9 @@ dropwhile_next(dropwhileobject *lz)
     PyObject *item, *good;
     PyObject *it = lz->it;
     long ok;
-    PyObject *(*iternext)(PyObject *);
 
-    iternext = *Py_TYPE(it)->tp_iternext;
     for (;;) {
-        item = iternext(it);
+        item = Py_TYPE(it)->tp_iternext(it);
         if (item == NULL)
             return NULL;
         if (lz->start == 1)
@@ -1505,14 +1503,12 @@ islice_next(isliceobject *lz)
     PyObject *it = lz->it;
     Py_ssize_t stop = lz->stop;
     Py_ssize_t oldnext;
-    PyObject *(*iternext)(PyObject *);
 
     if (it == NULL)
         return NULL;
 
-    iternext = *Py_TYPE(it)->tp_iternext;
     while (lz->cnt < lz->next) {
-        item = iternext(it);
+        item = Py_TYPE(it)->tp_iternext(it);
         if (item == NULL)
             goto empty;
         Py_DECREF(item);
@@ -1520,7 +1516,7 @@ islice_next(isliceobject *lz)
     }
     if (stop != -1 && lz->cnt >= stop)
         goto empty;
-    item = iternext(it);
+    item = Py_TYPE(it)->tp_iternext(it);
     if (item == NULL)
         goto empty;
     lz->cnt++;
@@ -3655,8 +3651,6 @@ compress_next(compressobject *lz)
 {
     PyObject *data = lz->data, *selectors = lz->selectors;
     PyObject *datum, *selector;
-    PyObject *(*datanext)(PyObject *) = *Py_TYPE(data)->tp_iternext;
-    PyObject *(*selectornext)(PyObject *) = *Py_TYPE(selectors)->tp_iternext;
     int ok;
 
     while (1) {
@@ -3666,11 +3660,11 @@ compress_next(compressobject *lz)
            exception first).
         */
 
-        datum = datanext(data);
+        datum = Py_TYPE(data)->tp_iternext(data);
         if (datum == NULL)
             return NULL;
 
-        selector = selectornext(selectors);
+        selector = Py_TYPE(selectors)->tp_iternext(selectors);
         if (selector == NULL) {
             Py_DECREF(datum);
             return NULL;
@@ -3816,11 +3810,9 @@ filterfalse_next(filterfalseobject *lz)
     PyObject *item;
     PyObject *it = lz->it;
     long ok;
-    PyObject *(*iternext)(PyObject *);
 
-    iternext = *Py_TYPE(it)->tp_iternext;
     for (;;) {
-        item = iternext(it);
+        item = Py_TYPE(it)->tp_iternext(it);
         if (item == NULL)
             return NULL;
 

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -744,7 +744,6 @@ bytearray_init(PyByteArrayObject *self, PyObject *args, PyObject *kwds)
     const char *errors = NULL;
     Py_ssize_t count;
     PyObject *it;
-    PyObject *(*iternext)(PyObject *);
 
     if (Py_SIZE(self) != 0) {
         /* Empty previous contents (yes, do this first of all!) */
@@ -840,7 +839,6 @@ bytearray_init(PyByteArrayObject *self, PyObject *args, PyObject *kwds)
     it = PyObject_GetIter(arg);
     if (it == NULL)
         return -1;
-    iternext = *Py_TYPE(it)->tp_iternext;
 
     /* Run the iterator to exhaustion */
     for (;;) {
@@ -848,7 +846,7 @@ bytearray_init(PyByteArrayObject *self, PyObject *args, PyObject *kwds)
         int rc, value;
 
         /* Get the next item */
-        item = iternext(it);
+        item = Py_TYPE(it)->tp_iternext(it);
         if (item == NULL) {
             if (PyErr_Occurred()) {
                 if (!PyErr_ExceptionMatches(PyExc_StopIteration))

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -829,7 +829,6 @@ list_extend(PyListObject *self, PyObject *iterable)
     Py_ssize_t n;                  /* guess for size of iterable */
     Py_ssize_t mn;                 /* m + n */
     Py_ssize_t i;
-    PyObject *(*iternext)(PyObject *);
 
     /* Special cases:
        1) lists and tuples which can use PySequence_Fast ops
@@ -875,7 +874,6 @@ list_extend(PyListObject *self, PyObject *iterable)
     it = PyObject_GetIter(iterable);
     if (it == NULL)
         return NULL;
-    iternext = *it->ob_type->tp_iternext;
 
     /* Guess a result list size. */
     n = PyObject_LengthHint(iterable, 8);
@@ -901,7 +899,7 @@ list_extend(PyListObject *self, PyObject *iterable)
 
     /* Run iterator to exhaustion. */
     for (;;) {
-        PyObject *item = iternext(it);
+        PyObject *item = it->ob_type->tp_iternext(it);
         if (item == NULL) {
             if (PyErr_Occurred()) {
                 if (PyErr_ExceptionMatches(PyExc_StopIteration))

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -272,16 +272,14 @@ builtin_all(PyObject *module, PyObject *iterable)
 /*[clinic end generated code: output=ca2a7127276f79b3 input=1a7c5d1bc3438a21]*/
 {
     PyObject *it, *item;
-    PyObject *(*iternext)(PyObject *);
     int cmp;
 
     it = PyObject_GetIter(iterable);
     if (it == NULL)
         return NULL;
-    iternext = *Py_TYPE(it)->tp_iternext;
 
     for (;;) {
-        item = iternext(it);
+        item = Py_TYPE(it)->tp_iternext(it);
         if (item == NULL)
             break;
         cmp = PyObject_IsTrue(item);
@@ -321,16 +319,14 @@ builtin_any(PyObject *module, PyObject *iterable)
 /*[clinic end generated code: output=fa65684748caa60e input=41d7451c23384f24]*/
 {
     PyObject *it, *item;
-    PyObject *(*iternext)(PyObject *);
     int cmp;
 
     it = PyObject_GetIter(iterable);
     if (it == NULL)
         return NULL;
-    iternext = *Py_TYPE(it)->tp_iternext;
 
     for (;;) {
-        item = iternext(it);
+        item = Py_TYPE(it)->tp_iternext(it);
         if (item == NULL)
             break;
         cmp = PyObject_IsTrue(item);
@@ -476,12 +472,10 @@ filter_next(filterobject *lz)
     PyObject *item;
     PyObject *it = lz->it;
     long ok;
-    PyObject *(*iternext)(PyObject *);
     int checktrue = lz->func == Py_None || lz->func == (PyObject *)&PyBool_Type;
 
-    iternext = *Py_TYPE(it)->tp_iternext;
     for (;;) {
-        item = iternext(it);
+        item = Py_TYPE(it)->tp_iternext(it);
         if (item == NULL)
             return NULL;
 


### PR DESCRIPTION
This affects list, bytearray and deque constructors, ''.join, builtin
functions all, any, filter, and itertools functions.