### PR TITLE
[3.6] bpo-30047: Fix a typo in Doc/library/select.rst (GH-1086)

### DIFF
--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -290,7 +290,7 @@ Edge and Level Trigger Polling (epoll) Objects
    | :const:`EPOLLEXCLUSIVE` | Wake only one epoll object when the           |
    |                         | associated fd has an event. The default (if   |
    |                         | this flag is not set) is to wake all epoll    |
-   |                         | objects polling on on a fd.                   |
+   |                         | objects polling on a fd.                      |
    +-------------------------+-----------------------------------------------+
    | :const:`EPOLLRDHUP`     | Stream socket peer closed connection or shut  |
    |                         | down writing half of connection.              |


### PR DESCRIPTION
(cherry picked from commit 3e0f1fc4e0ffcfcc706015fa3d67c262948ef171)