### PR TITLE
[3.6] Remove superfluous comment in urllib.error. (GH-1076)

### DIFF
--- a/Lib/urllib/error.py
+++ b/Lib/urllib/error.py
@@ -16,10 +16,6 @@ import urllib.response
 __all__ = ['URLError', 'HTTPError', 'ContentTooShortError']
 
 
-# do these error classes make sense?
-# make sure all of the OSError stuff is overridden.  we just want to be
-# subtypes.
-
 class URLError(OSError):
     # URLError is a sub-type of OSError, but it doesn't share any of
     # the implementation.  need to override __init__ and __str__.


### PR DESCRIPTION
(cherry picked from commit 6fab78e9027f9ebd6414995580781b480433e595)