### PR TITLE
bpo-16379: Expose sqlite error code 

### DIFF
--- a/Doc/includes/sqlite3/complete_statement.py
+++ b/Doc/includes/sqlite3/complete_statement.py
@@ -24,7 +24,10 @@ while True:
             if buffer.lstrip().upper().startswith("SELECT"):
                 print(cur.fetchall())
         except sqlite3.Error as e:
-            print("An error occurred:", e.args[0])
+            msg = str(e))
+            error_code = e.sqlite_errorcode
+            error_name = e.sqlite_name
+            print(f"Error {error_name} [Errno {error_code}]: {msg}")
         buffer = ""
 
 con.close()

--- a/Doc/includes/sqlite3/complete_statement.py
+++ b/Doc/includes/sqlite3/complete_statement.py
@@ -24,7 +24,7 @@ while True:
             if buffer.lstrip().upper().startswith("SELECT"):
                 print(cur.fetchall())
         except sqlite3.Error as e:
-            msg = str(e))
+            msg = str(e)
             error_code = e.sqlite_errorcode
             error_name = e.sqlite_name
             print(f"Error {error_name} [Errno {error_code}]: {msg}")

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -270,6 +270,26 @@ Module functions and constants
    disable the feature again.
 
 
+.. exception:: Error
+
+   Raised to signal an error from the underlying SQLite library.
+
+   .. attribute:: sqlite_errorcode
+
+      The numeric error code from the `SQLite API
+      <http://www.sqlite.org/c3ref/c_abort.html>`_.
+
+      .. versionadded:: 3.7
+
+   .. attribute:: sqlite_errorname
+
+      The symbolic name of the numeric error code
+      from the `SQLite API
+      <http://www.sqlite.org/c3ref/c_abort.html>`_.
+
+      .. versionadded:: 3.7
+
+
 .. _sqlite3-connection-objects:
 
 Connection Objects

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -279,7 +279,7 @@ Module functions and constants
       The numeric error code from the `SQLite API
       <http://www.sqlite.org/c3ref/c_abort.html>`_.
 
-      .. versionadded:: 3.7
+      .. versionadded:: 3.8
 
    .. attribute:: sqlite_errorname
 
@@ -287,7 +287,7 @@ Module functions and constants
       from the `SQLite API
       <http://www.sqlite.org/c3ref/c_abort.html>`_.
 
-      .. versionadded:: 3.7
+      .. versionadded:: 3.8
 
 
 .. _sqlite3-connection-objects:

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -85,7 +85,7 @@ class ModuleTests(unittest.TestCase):
 
     def CheckErrorCodeOnException(self):
         with self.assertRaises(sqlite.Error) as cm:
-           db = sqlite.connect('/no/such/file/exists')
+            db = sqlite.connect('/no/such/file/exists')
         e = cm.exception
         self.assertEqual(e.sqlite_errorcode, sqlite.SQLITE_CANTOPEN)
         self.assertEqual(e.sqlite_errorname, "SQLITE_CANTOPEN")

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -83,6 +83,14 @@ class ModuleTests(unittest.TestCase):
                                    sqlite.DatabaseError),
                         "NotSupportedError is not a subclass of DatabaseError")
 
+    def CheckErrorCodeOnException(self):
+        with self.assertRaises(sqlite.Error) as cm:
+           db = sqlite.connect('/no/such/file/exists')
+        e = cm.exception
+        self.assertEqual(e.sqlite_errorcode, sqlite.SQLITE_CANTOPEN)
+        self.assertEqual(e.sqlite_errorname, "SQLITE_CANTOPEN")
+        self.assertEqual(str(e), "unable to open database file")
+
 class ConnectionTests(unittest.TestCase):
 
     def setUp(self):

--- a/Misc/NEWS.d/next/Library/2019-05-08-15-14-32.bpo-16379.rN5JVe.rst
+++ b/Misc/NEWS.d/next/Library/2019-05-08-15-14-32.bpo-16379.rN5JVe.rst
@@ -1,0 +1,2 @@
+Add sqlite error code and name to the exceptions of the sqlite3 module.
+Patch by Aviv Palivoda based on work by Daniel Shahaf.

--- a/Modules/_sqlite/module.h
+++ b/Modules/_sqlite/module.h
@@ -48,6 +48,8 @@ extern PyObject* _pysqlite_converters;
 extern int _pysqlite_enable_callback_tracebacks;
 extern int pysqlite_BaseTypeAdapted;
 
+extern const char *sqlite3ErrName(int rc);
+
 #define PARSE_DECLTYPES 1
 #define PARSE_COLNAMES 2
 #endif


### PR DESCRIPTION
This PR adds the sqlite error code and name to the exceptions raised by the sqlite3 module. Once this is merged my hope is to expose the sqlite extended error code as discussed in [bpo-24139](https://bugs.python.org/issue24139)

<!-- issue-number: [bpo-16379](https://bugs.python.org/issue16379) -->
https://bugs.python.org/issue16379
<!-- /issue-number -->
