### PR TITLE
[3.6] bpo-29791: Clarify that flush is keyword-only argument (GH-1093)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1125,7 +1125,7 @@ are always available.  They are listed here in alphabetical order.
 .. function:: print(*objects, sep=' ', end='\\n', file=sys.stdout, flush=False)
 
    Print *objects* to the text stream *file*, separated by *sep* and followed
-   by *end*.  *sep*, *end* and *file*, if present, must be given as keyword
+   by *end*.  *sep*, *end*, *file* and *flush*, if present, must be given as keyword
    arguments.
 
    All non-keyword arguments are converted to strings like :func:`str` does and


### PR DESCRIPTION
Reported by Lucio Ricardo Montero Valenzuela.

(cherry picked from commit 61b9ac93712df8092a25223cd56fa6528359792b)