### PR TITLE
[3.6] Fix a typo in Doc/library/functions.rst (GH-1117)

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -610,7 +610,7 @@ are always available.  They are listed here in alphabetical order.
 
   .. note::
 
-    For object's with custom :meth:`__hash__` methods, note that :func:`hash`
+    For objects with custom :meth:`__hash__` methods, note that :func:`hash`
     truncates the return value based on the bit width of the host machine.
     See :meth:`__hash__` for details.
 


### PR DESCRIPTION
Replace `For object's ... ` with `For objects ...`
(cherry picked from commit 873ef20d0007b4b120933473e6252d2309a70102)