### PR TITLE
bpo-29651: Cover edge case of square brackets in urllib docs

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -118,6 +118,9 @@ or on combining URL components into a URL string.
    an invalid port is specified in the URL.  See section
    :ref:`urlparse-result-object` for more information on the result object.
 
+   Unmatched square brackets in the :attr:`netloc` attribute will raise a
+   :exc:`ValueError`.
+
    .. versionchanged:: 3.2
       Added IPv6 URL parsing capabilities.
 
@@ -235,6 +238,9 @@ or on combining URL components into a URL string.
    Reading the :attr:`port` attribute will raise a :exc:`ValueError` if
    an invalid port is specified in the URL.  See section
    :ref:`urlparse-result-object` for more information on the result object.
+
+   Unmatched square brackets in the :attr:`netloc` attribute will raise a
+   :exc:`ValueError`.
 
    .. versionchanged:: 3.6
       Out-of-range port numbers now raise :exc:`ValueError`, instead of


### PR DESCRIPTION
Per bpo-29651, there is an edge case in urllib.parse where a ValueError
will be returned if there are unmatched square brackets in the `netloc`
attribute of a URL. This behavior is shown [here](https://github.com/python/cpython/blob/e32ec93/Lib/urllib/parse.py#L406-L408).
This PR explicitly states this edge case in the docs.