### PR TITLE
[3.5] Relax test timing (bpo-29861) to avoid sporadic failures (#1120)

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1990,6 +1990,7 @@ class _TestPool(BaseTestCase):
         self.pool.map(identity, objs)
 
         del objs
+        time.sleep(DELTA)  # let threaded cleanup code run
         self.assertEqual(set(wr() for wr in refs), {None})
         # With a process pool, copies of the objects are returned, check
         # they were released too.


### PR DESCRIPTION
(cherry picked from commit 685cdb9acc3fca04a9897d88b89771ddfd50e772)