### PR TITLE
bpo-30067: Fix misplaced positional argument in OS X support library

### DIFF
--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -210,7 +210,7 @@ def _remove_universal_flags(_config_vars):
         # Do not alter a config var explicitly overridden by env var
         if cv in _config_vars and cv not in os.environ:
             flags = _config_vars[cv]
-            flags = re.sub(r'-arch\s+\w+\s', ' ', flags, re.ASCII)
+            flags = re.sub(r'-arch\s+\w+\s', ' ', flags, flags=re.ASCII)
             flags = re.sub('-isysroot [^ \t]*', ' ', flags)
             _save_modified_value(_config_vars, cv, flags)
 


### PR DESCRIPTION
This pull request fixes the issue reported in issue number 30067 in the CPython bug tracker.

The issue is that a positional argument to the `re.sub` function which is meant to be an integer representing the maximum number of matches for replacement is actually passed the integer flag value `re.ASCII` upon further inspection, it is clear that the intention was to pass this in as a value for the `flags` argument to `re.sub`. 