### PR TITLE
bpo-30067 [backport 3.6]: Fix misplaced positional argument in OS X support library

### DIFF
--- a/Lib/_osx_support.py
+++ b/Lib/_osx_support.py
@@ -210,7 +210,7 @@ def _remove_universal_flags(_config_vars):
         # Do not alter a config var explicitly overridden by env var
         if cv in _config_vars and cv not in os.environ:
             flags = _config_vars[cv]
-            flags = re.sub(r'-arch\s+\w+\s', ' ', flags, re.ASCII)
+            flags = re.sub(r'-arch\s+\w+\s', ' ', flags, flags=re.ASCII)
             flags = re.sub('-isysroot [^ \t]*', ' ', flags)
             _save_modified_value(_config_vars, cv, flags)
 


### PR DESCRIPTION
Backporting #1134 to 3.6.

I accidentally based this on master before in #1136.