### PR TITLE
[3.6] bpo-29738: Fix memory leak in _get_crl_dp (GH-526)

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1210,10 +1210,6 @@ _get_crl_dp(X509 *certificate) {
     int i, j;
     PyObject *lst, *res = NULL;
 
-#if OPENSSL_VERSION_NUMBER >= 0x10001000L
-    /* Calls x509v3_cache_extensions and sets up crldp */
-    X509_check_ca(certificate);
-#endif
     dps = X509_get_ext_d2i(certificate, NID_crl_distribution_points, NULL, NULL);
 
     if (dps == NULL)
@@ -1258,9 +1254,7 @@ _get_crl_dp(X509 *certificate) {
 
   done:
     Py_XDECREF(lst);
-#if OPENSSL_VERSION_NUMBER < 0x10001000L
-    sk_DIST_POINT_free(dps);
-#endif
+    CRL_DIST_POINTS_free(dps);
     return res;
 }
 


### PR DESCRIPTION
* Remove conditional on free of `dps`, since `dps` is now allocated for
all versions of OpenSSL
* Remove call to `x509_check_ca` since it was only used to cache
the `crldp` field of the certificate
CRL_DIST_POINTS_free is available in all supported versions of OpenSSL
(recent 0.9.8+) and LibreSSL.
(cherry picked from commit 2849cc34a8db93d448a62d69c462402347b50dcb)