### PR TITLE
[3.6] bpo-30068: add missing iter(self) in _io._IOBase.readlines when hint is present

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3498,6 +3498,7 @@ class MiscIOTest(unittest.TestCase):
                 self.assertRaises(ValueError, f.readinto1, bytearray(1024))
             self.assertRaises(ValueError, f.readline)
             self.assertRaises(ValueError, f.readlines)
+            self.assertRaises(ValueError, f.readlines, 1)
             self.assertRaises(ValueError, f.seek, 0)
             self.assertRaises(ValueError, f.tell)
             self.assertRaises(ValueError, f.truncate)

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -32,12 +32,14 @@ Core and Builtins
 Library
 -------
 
+- bpo-30068: _io._IOBase.readlines will check if it's closed first when
+  hint is present.
+
 - bpo-29694: Fixed race condition in pathlib mkdir with flags
   parents=True.  Patch by Armin Rigo.
 
-- bpo-29692: Fixed arbitrary unchaining of RuntimeError exceptions in 
-  contextlib.contextmanager.
-  Patch by Siddharth Velankar.
+- bpo-29692: Fixed arbitrary unchaining of RuntimeError exceptions in
+  contextlib.contextmanager.  Patch by Siddharth Velankar.
 
 - bpo-29998: Pickling and copying ImportError now preserves name and path
   attributes.

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -650,7 +650,7 @@ _io__IOBase_readlines_impl(PyObject *self, Py_ssize_t hint)
 /*[clinic end generated code: output=2f50421677fa3dea input=1961c4a95e96e661]*/
 {
     Py_ssize_t length = 0;
-    PyObject *result;
+    PyObject *result, *it = NULL;
 
     result = PyList_New(0);
     if (result == NULL)
@@ -664,19 +664,22 @@ _io__IOBase_readlines_impl(PyObject *self, Py_ssize_t hint)
         PyObject *ret = _PyObject_CallMethodId(result, &PyId_extend, "O", self);
 
         if (ret == NULL) {
-            Py_DECREF(result);
-            return NULL;
+            goto error;
         }
         Py_DECREF(ret);
         return result;
     }
 
+    it = PyObject_GetIter(self);
+    if (it == NULL) {
+        goto error;
+    }
+
     while (1) {
-        PyObject *line = PyIter_Next(self);
+        PyObject *line = PyIter_Next(it);
         if (line == NULL) {
             if (PyErr_Occurred()) {
-                Py_DECREF(result);
-                return NULL;
+                goto error;
             }
             else
                 break; /* StopIteration raised */
@@ -684,8 +687,7 @@ _io__IOBase_readlines_impl(PyObject *self, Py_ssize_t hint)
 
         if (PyList_Append(result, line) < 0) {
             Py_DECREF(line);
-            Py_DECREF(result);
-            return NULL;
+            goto error;
         }
         length += PyObject_Size(line);
         Py_DECREF(line);
@@ -693,7 +695,14 @@ _io__IOBase_readlines_impl(PyObject *self, Py_ssize_t hint)
         if (length > hint)
             break;
     }
+
+    Py_DECREF(it);
     return result;
+
+ error:
+    Py_XDECREF(it);
+    Py_DECREF(result);
+    return NULL;
 }
 
 /*[clinic input]


### PR DESCRIPTION
backports to 3.6 for #1130 