### PR TITLE
[2.7] bpo-30068: add missing iter(self) in _io._IOBase.readlines when hint is present

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2933,6 +2933,7 @@ class MiscIOTest(unittest.TestCase):
                 self.assertRaises(ValueError, f.readinto, bytearray(1024))
             self.assertRaises(ValueError, f.readline)
             self.assertRaises(ValueError, f.readlines)
+            self.assertRaises(ValueError, f.readlines, 1)
             self.assertRaises(ValueError, f.seek, 0)
             self.assertRaises(ValueError, f.tell)
             self.assertRaises(ValueError, f.truncate)

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -42,6 +42,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30068: _io._IOBase.readlines will check if it's closed first when
+  hint is present.
+
 - bpo-27863: Fixed multiple crashes in ElementTree caused by race conditions
   and wrong types.
 
@@ -12349,4 +12352,3 @@ Mac
 ----
 
 **(For information about older versions, consult the HISTORY file.)**
-

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -1,9 +1,9 @@
 /*
     An implementation of the I/O abstract base classes hierarchy
     as defined by PEP 3116 - "New I/O"
-    
+
     Classes defined here: IOBase, RawIOBase.
-    
+
     Written by Amaury Forgeot d'Arc and Antoine Pitrou
 */
 
@@ -19,7 +19,7 @@
 
 typedef struct {
     PyObject_HEAD
-    
+
     PyObject *dict;
     PyObject *weakreflist;
 } iobase;
@@ -589,13 +589,8 @@ PyDoc_STRVAR(iobase_readlines_doc,
 static PyObject *
 iobase_readlines(PyObject *self, PyObject *args)
 {
-<<<<<<< HEAD
     Py_ssize_t hint = -1, length = 0;
-    PyObject *result;
-=======
-    Py_ssize_t length = 0;
     PyObject *result, *it = NULL;
->>>>>>> 026435c... bpo-30068: add missing iter(self) in _io._IOBase.readlines when hint is present (#1130)
 
     if (!PyArg_ParseTuple(args, "|O&:readlines", &_PyIO_ConvertSsize_t, &hint)) {
         return NULL;
@@ -837,7 +832,7 @@ rawiobase_readall(PyObject *self, PyObject *args)
     int r;
     PyObject *chunks = PyList_New(0);
     PyObject *result;
-    
+
     if (chunks == NULL)
         return NULL;
 


### PR DESCRIPTION
backports to 2.7 for #1130 