### PR TITLE
bpo-30074: Fix compile warnings of _PySlice_Unpack and convert missed

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -4434,9 +4434,7 @@ Array_subscript(PyObject *_self, PyObject *item)
         PyObject *np;
         Py_ssize_t start, stop, step, slicelen, cur, i;
 
-        if (PySlice_GetIndicesEx((PySliceObject *)item,
-                                 self->b_length, &start, &stop,
-                                 &step, &slicelen) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return NULL;
         }
 
@@ -4447,6 +4445,7 @@ Array_subscript(PyObject *_self, PyObject *item)
         assert(itemdict); /* proto is the item type of the array, a
                              ctypes type, so this cannot be NULL */
 
+        slicelen = _PySlice_AdjustIndices(self->b_length, &start, &stop, step);
         if (itemdict->getfunc == _ctypes_get_fielddesc("c")->getfunc) {
             char *ptr = (char *)self->b_ptr;
             char *dest;
@@ -4613,7 +4612,7 @@ Array_ass_subscript(PyObject *_self, PyObject *item, PyObject *value)
     else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelen, otherlen, i, cur;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return -1;
         }
         slicelen = _PySlice_AdjustIndices(self->b_length, &start, &stop, step);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1334,7 +1334,7 @@ element_subscr(PyObject* self_, PyObject* item)
         if (!self->extra)
             return PyList_New(0);
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelen = _PySlice_AdjustIndices(self->extra->length, &start, &stop,
@@ -1393,7 +1393,7 @@ element_ass_subscr(PyObject* self_, PyObject* item, PyObject* value)
         if (!self->extra)
             element_new_extra(self, NULL);
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return -1;
         }
         slicelen = _PySlice_AdjustIndices(self->extra->length, &start, &stop,

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1701,7 +1701,7 @@ array_subscr(arrayobject* self, PyObject* item)
         arrayobject* ar;
         int itemsize = self->ob_descr->itemsize;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelength = _PySlice_AdjustIndices(Py_SIZE(self), &start, &stop,
@@ -1773,7 +1773,7 @@ array_ass_subscr(arrayobject* self, PyObject* item, PyObject* value)
             return (*self->ob_descr->setitem)(self, i, value);
     }
     else if (PySlice_Check(item)) {
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return -1;
         }
         slicelength = _PySlice_AdjustIndices(Py_SIZE(self), &start, &stop,

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -784,7 +784,7 @@ mmap_subscript(mmap_object *self, PyObject *item)
     else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelen;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelen = _PySlice_AdjustIndices(self->size, &start, &stop, step);
@@ -939,7 +939,7 @@ mmap_ass_subscript(mmap_object *self, PyObject *item, PyObject *value)
     else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelen;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return -1;
         }
         slicelen = _PySlice_AdjustIndices(self->size, &start, &stop, step);

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -435,7 +435,7 @@ bytearray_subscript(PyByteArrayObject *self, PyObject *index)
     }
     else if (PySlice_Check(index)) {
         Py_ssize_t start, stop, step, slicelength, cur, i;
-        if (_PySlice_Unpack((PySliceObject *)index, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(index, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelength = _PySlice_AdjustIndices(PyByteArray_GET_SIZE(self),
@@ -619,7 +619,7 @@ bytearray_ass_subscript(PyByteArrayObject *self, PyObject *index, PyObject *valu
         }
     }
     else if (PySlice_Check(index)) {
-        if (_PySlice_Unpack((PySliceObject *)index, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(index, &start, &stop, &step) < 0) {
             return -1;
         }
         slicelen = _PySlice_AdjustIndices(PyByteArray_GET_SIZE(self), &start,

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2562,7 +2562,7 @@ list_subscript(PyListObject* self, PyObject* item)
         PyObject* it;
         PyObject **src, **dest;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelength = _PySlice_AdjustIndices(Py_SIZE(self), &start, &stop,
@@ -2612,7 +2612,7 @@ list_ass_subscript(PyListObject* self, PyObject* item, PyObject* value)
     else if (PySlice_Check(item)) {
         Py_ssize_t start, stop, step, slicelength;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return -1;
         }
         slicelength = _PySlice_AdjustIndices(Py_SIZE(self), &start, &stop,

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -584,7 +584,7 @@ memory_subscript(PyMemoryViewObject *self, PyObject *key)
     else if (PySlice_Check(key)) {
         Py_ssize_t start, stop, step, slicelength;
 
-        if (_PySlice_Unpack((PySliceObject *)key, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(key, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelength = _PySlice_AdjustIndices(get_shape0(view), &start, &stop,
@@ -663,7 +663,7 @@ memory_ass_sub(PyMemoryViewObject *self, PyObject *key, PyObject *value)
     else if (PySlice_Check(key)) {
         Py_ssize_t stop, step;
 
-        if (_PySlice_Unpack((PySliceObject *)key, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(key, &start, &stop, &step) < 0) {
             return -1;
         }
         len = _PySlice_AdjustIndices(get_shape0(view), &start, &stop, step);

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -286,7 +286,7 @@ static PyMemberDef slice_members[] = {
 static PyObject*
 slice_indices(PySliceObject* self, PyObject* len)
 {
-    Py_ssize_t ilen, start, stop, step, slicelength;
+    Py_ssize_t ilen, start, stop, step;
 
     ilen = PyNumber_AsSsize_t(len, PyExc_OverflowError);
 
@@ -294,10 +294,10 @@ slice_indices(PySliceObject* self, PyObject* len)
         return NULL;
     }
 
-    if (_PySlice_Unpack(self, &start, &stop, &step) < 0) {
+    if (_PySlice_Unpack((PyObject *)self, &start, &stop, &step) < 0) {
         return NULL;
     }
-    slicelength = _PySlice_AdjustIndices(ilen, &start, &stop, step);
+    _PySlice_AdjustIndices(ilen, &start, &stop, step);
 
     return Py_BuildValue("(nnn)", start, stop, step);
 }

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -1310,7 +1310,7 @@ string_subscript(PyStringObject* self, PyObject* item)
         char* result_buf;
         PyObject* result;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelength = _PySlice_AdjustIndices(PyString_GET_SIZE(self), &start,

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -114,7 +114,7 @@ structseq_subscript(PyStructSequence *self, PyObject *item)
         Py_ssize_t start, stop, step, slicelen, cur, i;
         PyObject *result;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelen = _PySlice_AdjustIndices(VISIBLE_SIZE(self), &start, &stop,

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -715,7 +715,7 @@ tuplesubscript(PyTupleObject* self, PyObject* item)
         PyObject* it;
         PyObject **src, **dest;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelength = _PySlice_AdjustIndices(PyTuple_GET_SIZE(self), &start,

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8008,7 +8008,7 @@ unicode_subscript(PyUnicodeObject* self, PyObject* item)
         Py_UNICODE* result_buf;
         PyObject* result;
 
-        if (_PySlice_Unpack((PySliceObject *)item, &start, &stop, &step) < 0) {
+        if (_PySlice_Unpack(item, &start, &stop, &step) < 0) {
             return NULL;
         }
         slicelength = _PySlice_AdjustIndices(PyUnicode_GET_SIZE(self), &start,


### PR DESCRIPTION
PySlice_GetIndicesEx in _ctypes.c.