### PR TITLE
bpo-30077 Update aifc.py to support Apple AIFF-C "sowt"

### DIFF
--- a/Lib/aifc.py
+++ b/Lib/aifc.py
@@ -460,6 +460,10 @@ class Aifc_read:
             self._adpcmstate = None
         data, self._adpcmstate = audioop.adpcm2lin(data, 2, self._adpcmstate)
         return data
+      
+    def _sowt2lin(self, data):
+        # do nothing for Apple pseudo-compression
+        return data
 
     def _read_comm_chunk(self, chunk):
         self._nchannels = _read_short(chunk)
@@ -492,6 +496,8 @@ class Aifc_read:
                     self._convert = self._ulaw2lin
                 elif self._comptype in (b'alaw', b'ALAW'):
                     self._convert = self._alaw2lin
+                elif self._comptype in (b'sowt', b'SOWT'):
+                    self._convert = self._sowt2lin
                 else:
                     raise Error('unsupported compression type')
                 self._sampwidth = 2


### PR DESCRIPTION
Update aifc.py to support Apple AIFF-C "sowt" pseudo-compression.  This change just allows "sowt" as a comptype value, and returns the data samples as they are, so that they appear as native bytes and we avoid an "unsupported compression type" error. See discussion on WP. https://en.wikipedia.org/wiki/Audio_Interchange_File_Format#AIFF_on_Mac_OS_X

This is an Apple-specific extension to the standard, but it requires very little change or effort to support it.  