### PR TITLE
bpo-30757 pyinstaller added to docs, py2exe ref updated

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -96,11 +96,7 @@ then compiles the generated C code and links it with the rest of the Python
 interpreter to form a self-contained binary which acts exactly like your script.
 
 Obviously, freeze requires a C compiler.  There are several other utilities
-which don't. One is Thomas Heller's py2exe (Windows only) at
-
-    http://www.py2exe.org/
-
-Another tool is Anthony Tuininga's `cx_Freeze <http://cx-freeze.sourceforge.net/>`_.
+which don't. Refer to Doc/faq/windows.rst.
 
 
 Are there coding standards or a style guide for Python programs?

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -170,8 +170,9 @@ offender.
 How do I make an executable from a Python script?
 -------------------------------------------------
 
-See http://cx-freeze.sourceforge.net/ and http://www.pyinstaller.org/ for the 
-distutils extensions that allows you to create console and GUI executables 
+See http://cx-freeze.sourceforge.net/ for the distutils extension and
+http://www.pyinstaller.org/ for another package, 
+that both allow you to create console and GUI executables 
 from Python code.
 `py2exe <http://www.py2exe.org/>`_, popular extension for building
 Python 2.x-based executables, partially supports Python 3, see 

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -170,11 +170,12 @@ offender.
 How do I make an executable from a Python script?
 -------------------------------------------------
 
-See http://cx-freeze.sourceforge.net/ for a distutils extension that allows you
-to create console and GUI executables from Python code.
-`py2exe <http://www.py2exe.org/>`_, the most popular extension for building
-Python 2.x-based executables, does not yet support Python 3 but a version that
-does is in development.
+See http://cx-freeze.sourceforge.net/ and http://www.pyinstaller.org/ for the 
+distutils extensions that allows you to create console and GUI executables 
+from Python code.
+`py2exe <http://www.py2exe.org/>`_, popular extension for building
+Python 2.x-based executables, partially supports Python 3, see 
+https://pypi.python.org/pypi/py2exe/.
 
 
 Is a ``*.pyd`` file the same as a DLL?

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -170,13 +170,12 @@ offender.
 How do I make an executable from a Python script?
 -------------------------------------------------
 
-See http://cx-freeze.sourceforge.net/ for the distutils extension and
-http://www.pyinstaller.org/ for another package,
-that both allow you to create console and GUI executables
-from Python code.
-`py2exe <http://www.py2exe.org/>`_, popular extension for building
-Python 2.x-based executables, partially supports Python 3, see
-https://pypi.python.org/pypi/py2exe/.
+The following 2 packages cx_Freeze and PyInstaller allow 
+the creation of cross-platform stand-alone console and GUI executables:
+* http://cx-freeze.sourceforge.net/
+* http://www.pyinstaller.org/
+
+Additionally, http://www.py2exe.org/ exclusively supports Windows executables.
 
 
 Is a ``*.pyd`` file the same as a DLL?

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -170,7 +170,7 @@ offender.
 How do I make an executable from a Python script?
 -------------------------------------------------
 
-The following 2 packages cx_Freeze and PyInstaller allow 
+The following 2 packages cx_Freeze and PyInstaller allow
 the creation of cross-platform stand-alone console and GUI executables:
 * http://cx-freeze.sourceforge.net/
 * http://www.pyinstaller.org/

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -171,11 +171,11 @@ How do I make an executable from a Python script?
 -------------------------------------------------
 
 See http://cx-freeze.sourceforge.net/ for the distutils extension and
-http://www.pyinstaller.org/ for another package, 
-that both allow you to create console and GUI executables 
+http://www.pyinstaller.org/ for another package,
+that both allow you to create console and GUI executables
 from Python code.
 `py2exe <http://www.py2exe.org/>`_, popular extension for building
-Python 2.x-based executables, partially supports Python 3, see 
+Python 2.x-based executables, partially supports Python 3, see
 https://pypi.python.org/pypi/py2exe/.
 
 


### PR DESCRIPTION
It is not clear why this FAQ item is written in addition to this document:

https://github.com/python/cpython/blob/909a6f626ff343937cd3f06fda996870e7890724/Doc/faq/programming.rst#how-can-i-create-a-stand-alone-binary-from-a-python-script