### PR TITLE
bpo-30092: Replace sys.version to sys.version_info

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -83,9 +83,11 @@ _INSTALL_SCHEMES = {
 _SCHEME_KEYS = ('stdlib', 'platstdlib', 'purelib', 'platlib', 'include',
                 'scripts', 'data')
 
- # FIXME don't rely on sys.version here, its format is an implementation detail
- # of CPython, use sys.version_info or sys.hexversion
-_PY_VERSION = sys.version.split()[0]
+# Don't rely on sys.version here, its format is an implementation detail
+# of CPython, use sys.version_info or sys.hexversion
+_PY_VERSION = '%s%s%d' % ('.'.join(str(i) for i in sys.version_info[:3])
+              , sys.version_info.releaselevel[0]
+              , sys.version_info.serial)
 _PY_VERSION_SHORT = '%d.%d' % sys.version_info[:2]
 _PY_VERSION_SHORT_NO_DOT = '%d%d' % sys.version_info[:2]
 _PREFIX = os.path.normpath(sys.prefix)


### PR DESCRIPTION
Not to rely on sys.version here, its format is an implementation detail
of CPython, use sys.version_info or sys.hexversion