### PR TITLE
bpo-30098: Adds verbose error to asyncio.ensure_future

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -516,12 +516,9 @@ def ensure_future(coro_or_future, *, loop=None):
         return task
     elif compat.PY35 and inspect.isawaitable(coro_or_future):
         return ensure_future(_wrap_awaitable(coro_or_future), loop=loop)
-    elif hasattr(coro_or_future.__class__, 'set_running_or_notify_cancel'):
-        raise TypeError('An asyncio.Future, coroutine or an awaitable is '
-                        'required. Not compatible with '
-                        'concurrent.futures.Future')
     else:
-        raise TypeError('A Future, a coroutine or an awaitable is required')
+        raise TypeError('An asyncio.Future, a coroutine or an awaitable is '
+                        'required')
 
 
 @coroutine

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -516,6 +516,10 @@ def ensure_future(coro_or_future, *, loop=None):
         return task
     elif compat.PY35 and inspect.isawaitable(coro_or_future):
         return ensure_future(_wrap_awaitable(coro_or_future), loop=loop)
+    elif hasattr(coro_or_future.__class__, 'set_running_or_notify_cancel'):
+        raise TypeError('An asyncio.Future, coroutine or an awaitable is '
+                        'required. Not compatible with '
+                        'concurrent.futures.Future')
     else:
         raise TypeError('A Future, a coroutine or an awaitable is required')
 


### PR DESCRIPTION
Despite the [shy mention in the docs](https://docs.python.org/3/library/asyncio-task.html#asyncio.run_coroutine_threadsafe), it was not clear to me that the future returned from `asyncio.run_coroutine_threadsafe` is not compatible with `asyncio.ensure_future` (and other asyncio functions), and it took me a fair amount of frustration and source-code-digging to figure out what was going on.

To avoid this confusion for other users, I think that a verbose TypeError warning when a concurrent.futures.Future object is passed into `asyncio.ensure_future` would be very helpful.


Few questions:
 - Is there a better way to check if the obj is a concurrent.futures.Future?
 - Is the language in the TypeError ok? I tried to make it compatible with the default TypeError.

Let me know what you think! Thanks!