### PR TITLE
bpo-30085: Improve documentation for operator

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -17,9 +17,10 @@
 
 The :mod:`operator` module exports a set of efficient functions corresponding to
 the intrinsic operators of Python.  For example, ``operator.add(x, y)`` is
-equivalent to the expression ``x+y``.  The function names are those used for
-special class methods; variants without leading and trailing ``__`` are also
-provided for convenience.
+equivalent to the expression ``x+y``. Many function names are those used for
+special methods, without the double underscores.  For backward compatibility,
+many of these have a variant with the double underscores kept. The variants
+without the double underscores are preferred for clarity.
 
 The functions fall into categories that perform object comparisons, logical
 operations, mathematical operations and sequence operations.

--- a/Misc/NEWS.d/next/Documentation/2017-09-14-18-44-50.bpo-30085.0J9w-u.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-09-14-18-44-50.bpo-30085.0J9w-u.rst
@@ -1,0 +1,2 @@
+The operator functions without double underscores are preferred for clarity.
+The one with underscores are only kept for back-compatibility.


### PR DESCRIPTION
Prefer dunderless functions, and mention that the dunder
functions only exist because of the sake of backward
compatilibity.

<!-- issue-number: bpo-30085 -->
https://bugs.python.org/issue30085
<!-- /issue-number -->
