### PR TITLE
bpo-30100: Allow WeakSet.discard and WeakSet.remove to accept non referenceable values

### DIFF
--- a/Lib/_weakrefset.py
+++ b/Lib/_weakrefset.py
@@ -106,12 +106,20 @@ class WeakSet:
     def remove(self, item):
         if self._pending_removals:
             self._commit_removals()
-        self.data.remove(ref(item))
+        try:
+            wr = ref(item)
+        except TypeError:
+            raise KeyError(item) from None
+        self.data.remove(wr)
 
     def discard(self, item):
         if self._pending_removals:
             self._commit_removals()
-        self.data.discard(ref(item))
+        try:
+            wr = ref(item)
+        except TypeError:
+            return
+        self.data.discard(wr)
 
     def update(self, other):
         if self._pending_removals:


### PR DESCRIPTION
Currently `WeakSet().discard([])` will raise a `TypeError` as we cannot take a weak reference to a list.

However, that means a list can never be in a `WeakSet`, so `WeakSet().discard([])` could instead be a no-op.  Similarly `WeakSet().remove([])` could be a KeyError.