### PR TITLE
bpo-30030: Use random.SystemRandom in tempfile

### DIFF
--- a/Lib/multiprocessing/heap.py
+++ b/Lib/multiprocessing/heap.py
@@ -29,12 +29,10 @@ if sys.platform == 'win32':
 
     class Arena(object):
 
-        _rand = tempfile._RandomNameSequence()
-
         def __init__(self, size):
             self.size = size
             for i in range(100):
-                name = 'pym-%d-%s' % (os.getpid(), next(self._rand))
+                name = 'pym-%d-%s' % (os.getpid(), tempfile._random_name())
                 buf = mmap.mmap(-1, size, tagname=name)
                 if _winapi.GetLastError() == 0:
                     break

--- a/Lib/multiprocessing/synchronize.py
+++ b/Lib/multiprocessing/synchronize.py
@@ -46,8 +46,6 @@ SEM_VALUE_MAX = _multiprocessing.SemLock.SEM_VALUE_MAX
 
 class SemLock(object):
 
-    _rand = tempfile._RandomNameSequence()
-
     def __init__(self, kind, value, maxvalue, *, ctx):
         if ctx is None:
             ctx = context._default_context.get_context()
@@ -115,7 +113,7 @@ class SemLock(object):
     @staticmethod
     def _make_name():
         return '%s-%s' % (process.current_process()._config['semprefix'],
-                          next(SemLock._rand))
+                          tempfile._random_name())
 
 #
 # Semaphore


### PR DESCRIPTION
* Rewrite tempfile._RandomNameSequence as a generator, instead of an
  iterator, using random.SystemRandom instead of random.Random.
  SystemRandom is thread-safe and handle fork(), whereas Random
  requires to be reseed on fork.
* Remoe _get_candidate_names() and the global _name_sequence
  variable: create one _RandomNameSequence generator per function.
* Remove TestGetCandidateNames test case.
* Modify also gettempdir() to use "with lock:" syntax.
* Sort imports in test_tempfile.py