### PR TITLE
regrtest: always show before/after of modified env

### DIFF
--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -279,7 +279,6 @@ class saved_test_environment:
                 if not self.quiet and not self.pgo:
                     print(f"Warning -- {name} was modified by {self.testname}",
                           file=sys.stderr, flush=True)
-                    if self.verbose > 1:
-                        print(f"  Before: {original}\n  After:  {current} ",
-                              file=sys.stderr, flush=True)
+                    print(f"  Before: {original}\n  After:  {current} ",
+                          file=sys.stderr, flush=True)
         return False


### PR DESCRIPTION
Buildbots don't run tests with -vv and so only log "xxx was modified
by test_xxx" which is not enough to debug such random issue. In many
cases, I'm unable to reproduce the warning and so unable to fix it.

Always logging the value before and value after should help to debug
such warning on buildbots.