### PR TITLE
Only define get_zone() and get_gmtoff() if needed

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1160,6 +1160,7 @@ PyDoc_STRVAR(get_clock_info_doc,
 \n\
 Get information of the specified clock.");
 
+#if !defined(HAVE_TZNAME) || defined(__GLIBC__) || defined(__CYGWIN__)
 static void
 get_zone(char *zone, int n, struct tm *p)
 {
@@ -1180,6 +1181,7 @@ get_gmtoff(time_t t, struct tm *p)
     return timegm(p) - t;
 #endif
 }
+#endif /* !defined(HAVE_TZNAME) || defined(__GLIBC__) || defined(__CYGWIN__) */
 
 static void
 PyInit_timezone(PyObject *m) {


### PR DESCRIPTION
Only define the get_zone() and get_gmtoff() private functions in the
time module if these functions are needed to initialize the module.

The change fixes the following warnings on AIX:

Modules/timemodule.c:1175:1: warning: 'get_gmtoff' defined but not used [-Wunused-function]
Modules/timemodule.c:1164:1: warning: 'get_zone' defined but not used [-Wunused-function]

Warnings: http://buildbot.python.org/all/builders/PPC64%20AIX%203.x/builds/614/steps/compile/logs/warnings%20%282%29