### PR TITLE
bpo-30106: Fix tearDown() of test_asyncore

### DIFF
--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -502,7 +502,7 @@ class BaseClient(BaseTestHandler):
 class BaseTestAPI:
 
     def tearDown(self):
-        asyncore.close_all()
+        asyncore.close_all(ignore_all=True)
 
     def loop_waiting_for_flag(self, instance, timeout=5):
         timeout = float(timeout) / 100
@@ -782,7 +782,7 @@ class BaseTestAPI:
 
         server = BaseServer(self.family, self.addr)
         t = threading.Thread(target=lambda: asyncore.loop(timeout=0.1,
-                                                          count=500), name="ident")
+                                                          count=500))
         t.start()
         try:
             with socket.socket(self.family, socket.SOCK_STREAM) as s:


### PR DESCRIPTION
Call asyncore.close_all() with ignore_all=True in the tearDown()
method of the test_asyncore base test case. It should prevent keeping
alive sockets in asyncore.socket_map if close() fails with an
unexpected error.

Revert also an unwanted change of my previous commit: remove name
parameter of Thread in test_quick_connect().