### PR TITLE
test.support.threading_cleanup() now logs a warning on failure

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2019,13 +2019,20 @@ def threading_cleanup(*original_values):
     if not _thread:
         return
     _MAX_COUNT = 100
+    t0 = time.monotonic()
     for count in range(_MAX_COUNT):
         values = _thread._count(), threading._dangling
         if values == original_values:
             break
         time.sleep(0.01)
         gc_collect()
-    # XXX print a warning in case of failure?
+    else:
+        dt = time.monotonic() - t0
+        print("Warning -- threading_cleanup() failed to cleanup %s threads "
+              "after %.0f sec (count: %s, dangling: %s)"
+              % (values[0] - original_values[0], dt,
+                 values[0], len(values[1])),
+              file=sys.stderr)
 
 def reap_threads(func):
     """Use this function when threads are being used.  This will

--- a/Lib/test/test_urllib2_localnet.py
+++ b/Lib/test/test_urllib2_localnet.py
@@ -664,7 +664,7 @@ def setUpModule():
 
 def tearDownModule():
     if threads_key:
-        support.threading_cleanup(threads_key)
+        support.threading_cleanup(*threads_key)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The @reap_threads decorator and the threading_cleanup() function of
test.support now log a warning if they fail to clenaup threads.

The log may help to debug such other warning seen on the AMD64
FreeBSD CURRENT Non-Debug 3.x buildbot:

Warning -- threading._dangling was modified by test_logging