### PR TITLE
[2.7] Remove redundant comma in argparse HOWTO (GH-1141)

### DIFF
--- a/Doc/howto/argparse.rst
+++ b/Doc/howto/argparse.rst
@@ -223,7 +223,7 @@ before proceeding.
 Introducing Optional arguments
 ==============================
 
-So far we, have been playing with positional arguments. Let us
+So far we have been playing with positional arguments. Let us
 have a look on how to add optional ones::
 
    import argparse


### PR DESCRIPTION
Reported by Sean Canavan on docs@p.o.

(cherry picked from commit 8526fb74edf5ac9ca175b7cdcb0d82bb8780d2cf)