### PR TITLE
bpo-30109: Fix reindent.py

### DIFF
--- a/Lib/test/test_tools/test_reindent.py
+++ b/Lib/test/test_tools/test_reindent.py
@@ -7,6 +7,7 @@ Tools directory of a Python checkout or tarball, such as reindent.py.
 import os
 import unittest
 from test.support.script_helper import assert_python_ok
+from test.support import findfile
 
 from test.test_tools import scriptsdir, skip_if_missing
 
@@ -24,11 +25,10 @@ class ReindentTests(unittest.TestCase):
         self.assertGreater(err, b'')
 
     def test_reindent_file_with_bad_encoding(self):
-        bad_coding_path = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), '../bad_coding.py')
+        bad_coding_path = findfile('bad_coding.py')
         rc, out, err = assert_python_ok(self.script, '-r', bad_coding_path)
         self.assertEqual(out, b'')
-        self.assertGreater(err, b'')
+        self.assertNotEqual(err, b'')
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_tools/test_reindent.py
+++ b/Lib/test/test_tools/test_reindent.py
@@ -23,6 +23,13 @@ class ReindentTests(unittest.TestCase):
         self.assertEqual(out, b'')
         self.assertGreater(err, b'')
 
+    def test_reindent_file_with_bad_encoding(self):
+        bad_coding_path = os.path.join(
+            os.path.dirname(os.path.realpath(__file__)), '../bad_coding.py')
+        rc, out, err = assert_python_ok(self.script, '-r', bad_coding_path)
+        self.assertEqual(out, b'')
+        self.assertGreater(err, b'')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Tools/scripts/reindent.py
+++ b/Tools/scripts/reindent.py
@@ -118,7 +118,11 @@ def check(file):
     if verbose:
         print("checking", file, "...", end=' ')
     with open(file, 'rb') as f:
-        encoding, _ = tokenize.detect_encoding(f.readline)
+        try:
+            encoding, _ = tokenize.detect_encoding(f.readline)
+        except SyntaxError as se:
+            errprint("%s: SyntaxError: %s" % (file, str(se)))
+            return
     try:
         with open(file, encoding=encoding) as f:
             r = Reindenter(f)


### PR DESCRIPTION
Skip the file if it has bad encoding.

https://bugs.python.org/issue30109