### PR TITLE
[3.5] bpo-30109: Fix reindent.py (GH-1207)

### DIFF
--- a/Lib/test/test_tools/test_reindent.py
+++ b/Lib/test/test_tools/test_reindent.py
@@ -7,6 +7,7 @@ Tools directory of a Python checkout or tarball, such as reindent.py.
 import os
 import unittest
 from test.support.script_helper import assert_python_ok
+from test.support import findfile
 
 from test.test_tools import scriptsdir, skip_if_missing
 
@@ -22,6 +23,12 @@ class ReindentTests(unittest.TestCase):
         rc, out, err = assert_python_ok(self.script, '-h')
         self.assertEqual(out, b'')
         self.assertGreater(err, b'')
+
+    def test_reindent_file_with_bad_encoding(self):
+        bad_coding_path = findfile('bad_coding.py')
+        rc, out, err = assert_python_ok(self.script, '-r', bad_coding_path)
+        self.assertEqual(out, b'')
+        self.assertNotEqual(err, b'')
 
 
 if __name__ == '__main__':

--- a/Tools/scripts/reindent.py
+++ b/Tools/scripts/reindent.py
@@ -118,7 +118,11 @@ def check(file):
     if verbose:
         print("checking", file, "...", end=' ')
     with open(file, 'rb') as f:
-        encoding, _ = tokenize.detect_encoding(f.readline)
+        try:
+            encoding, _ = tokenize.detect_encoding(f.readline)
+        except SyntaxError as se:
+            errprint("%s: SyntaxError: %s" % (file, str(se)))
+            return
     try:
         with open(file, encoding=encoding) as f:
             r = Reindenter(f)


### PR DESCRIPTION
Skip the file if it has bad encoding.
(cherry picked from commit 58f3c9dc8f5626abe09ac9738c34f6ba99ce2972)