### PR TITLE
bpo-29840: bool() no longer raises OverflowError for objects without …

### DIFF
--- a/Lib/test/test_bool.py
+++ b/Lib/test/test_bool.py
@@ -344,6 +344,16 @@ class BoolTest(unittest.TestCase):
                 except (Exception) as e_len:
                     self.assertEqual(str(e_bool), str(e_len))
 
+    def test_len_overflow(self):
+        self.assertIs(bool(range(1 << 1000)), True)
+        class A:
+            def __len__(self):
+                return length
+        length = 1 << 1000
+        self.assertIs(bool(A()), True)
+        length = -1 << 1000
+        self.assertRaises(ValueError, bool, A())
+
     def test_blocked(self):
         class A:
             __bool__ = None

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-29840: bool() no longer raises OverflowError for objects without defined
+  __bool__ when __len__() returned large integer or raised OverflowError.
+
 - bpo-29839: len() now raises ValueError rather than OverflowError if
   __len__() returned a large negative integer.
 


### PR DESCRIPTION
…defined
`__bool__` when `__len__()` returned a large integer or raised OverflowError.