### PR TITLE
bpo-30113: profile: Add explicit test for trace_dispatch_return

### DIFF
--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -35,6 +35,10 @@ class CProfileTest(ProfileTest):
         finally:
             unlink(TESTFN)
 
+    # Issue 30113, skip when using cProfile
+    def test_regression_30113(self):
+        pass
+
 
 def test_main():
     run_unittest(CProfileTest)

--- a/Lib/test/test_profile.py
+++ b/Lib/test/test_profile.py
@@ -93,6 +93,18 @@ class ProfileTest(unittest.TestCase):
                                   filename=TESTFN)
         self.assertTrue(os.path.exists(TESTFN))
 
+    def test_regression_30113(self):
+        def foo(self):
+            pr = self.profilerclass()
+            sys.setprofile(pr.dispatcher)
+            return 0xDEADBEAF
+
+        regex = r"\('Bad return', \('profile', 0, 'profiler'\)\)"
+        with self.assertRaisesRegex(AssertionError, regex):
+            foo(self)
+
+        sys.setprofile(None)
+
 
 def regenerate_expected_output(filename, cls):
     filename = filename.rstrip('co')


### PR DESCRIPTION
When using `profile.Profile()` with `sys.setprofile()`, profiler
can't return upper then the frame which set profile, otherwise it
will trigger the assertion of bad return.

This commit add a explicit test for this behavior, related to
bpo-9285 which want to add decorator for cProfile/profile and will
trigger this behavoir.

Related to #287 