### PR TITLE
bpo-29802: Fix reference counting in module-level struct functions

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -599,6 +599,16 @@ class StructTest(unittest.TestCase):
                 'offset -11 out of range for 10-byte buffer'):
             struct.pack_into('<B', byte_list, -11, 123)
 
+    def test_issue29802(self):
+        # When the second argument of struct.unpack() was of wrong type
+        # the Struct object was decrefed twice and the reference to
+        # deallocated object was left in a cache.
+        with self.assertRaises(TypeError):
+            struct.unpack(b'b', 0)
+        # Shouldn't crash.
+        self.assertEqual(struct.unpack(b'b', b'a'), (b'a'[0],))
+
+
 class UnpackIteratorTest(unittest.TestCase):
     """
     Tests for iterative unpacking (struct.Struct.iter_unpack).

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -313,6 +313,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29802: Fixed reference counting in module-level struct functions when
+  pass argumens of wrong type.
+
 - bpo-30070: Fixed leaks and crashes in errors handling in the parser module.
 
 - bpo-22352: Column widths in the output of dis.dis() are now adjusted for

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -314,7 +314,7 @@ Library
 -------
 
 - bpo-29802: Fixed reference counting in module-level struct functions when
-  pass argumens of wrong type.
+  pass arguments of wrong type.
 
 - bpo-30070: Fixed leaks and crashes in errors handling in the parser module.
 

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -2083,6 +2083,7 @@ cache_struct_converter(PyObject *fmt, PyObject **ptr)
 
     if (fmt == NULL) {
         Py_DECREF(*ptr);
+        *ptr = NULL;
         return 1;
     }
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3907,6 +3907,7 @@ PyUnicode_FSDecoder(PyObject* arg, void* addr)
     PyObject *output = NULL;
     if (arg == NULL) {
         Py_DECREF(*(PyObject**)addr);
+        *(PyObject**)addr = NULL;
         return 1;
     }
 


### PR DESCRIPTION
when pass argumens of wrong type.