### PR TITLE
bpo-30119: Fix ftplib to handle the ftp user's commands.

### DIFF
--- a/Lib/ftplib.py
+++ b/Lib/ftplib.py
@@ -186,6 +186,8 @@ class FTP:
 
     # Internal: send one line to the server, appending CRLF
     def putline(self, line):
+        if '\r' in line or '\n' in line:
+            raise ValueError('an illegal newline character should not be contained')
         line = line + CRLF
         if self.debugging > 1:
             print('*put*', self.sanitize(line))

--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -485,6 +485,9 @@ class TestFTPClass(TestCase):
         self.assertEqual(self.client.sanitize('PASS 12345'), repr('PASS *****'))
 
     def test_exceptions(self):
+        self.assertRaises(ValueError, self.client.sendcmd, 'echo 40\r\n0')
+        self.assertRaises(ValueError, self.client.sendcmd, 'echo 40\n0')
+        self.assertRaises(ValueError, self.client.sendcmd, 'echo 40\r0')
         self.assertRaises(ftplib.error_temp, self.client.sendcmd, 'echo 400')
         self.assertRaises(ftplib.error_temp, self.client.sendcmd, 'echo 499')
         self.assertRaises(ftplib.error_perm, self.client.sendcmd, 'echo 500')
@@ -493,7 +496,8 @@ class TestFTPClass(TestCase):
 
     def test_all_errors(self):
         exceptions = (ftplib.error_reply, ftplib.error_temp, ftplib.error_perm,
-                      ftplib.error_proto, ftplib.Error, OSError, EOFError)
+                      ftplib.error_proto, ftplib.Error, OSError,
+                      EOFError)
         for x in exceptions:
             try:
                 raise x('exception not included in all_errors set')

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -376,6 +376,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30119: ftplib.FTP.putline() now throws ValueError on commands that contains
+  CR or LF. Patch by Dong-hee Na.
+
 - bpo-30879: os.listdir() and os.scandir() now emit bytes names when called
   with bytes-like argument.
 


### PR DESCRIPTION
bpo-30119: Handle ftp user command.

See https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2017-3533
and http://blog.blindspotsecurity.com/2017/02/advisory-javapython-ftp-injections.html

<!-- issue-number: bpo-30119 -->
https://bugs.python.org/issue30119
<!-- /issue-number -->
