### PR TITLE
bpo-30104: Use -fno-strict-aliasing on clang

### DIFF
--- a/configure
+++ b/configure
@@ -6865,8 +6865,15 @@ then
 
         # Clang also needs -fwrapv
         case $CC in
-            *clang*) WRAP="-fwrapv"
-            ;;
+            *clang*)
+                WRAP="-fwrapv"
+                # bpo-30104: Python/dtoa.c requires to be build with
+                # -fno-strict-aliasing to fix compiler issue on the
+                # double/ULong[2] union using clang 4.0 and optimization level
+                # -O2 or higher
+                # https://bugs.llvm.org//show_bug.cgi?id=31928
+                ALIASING="-fno-strict-aliasing"
+                ;;
         esac
 
 	case $ac_cv_prog_cc_g in
@@ -6875,18 +6882,21 @@ then
 		# Optimization messes up debuggers, so turn it off for
 		# debug builds.
                 if "$CC" -v --help 2>/dev/null |grep -- -Og > /dev/null; then
-                    OPT="-g -Og -Wall $STRICT_PROTO"
+                    OPT="-g -Og -Wall"
                 else
-                    OPT="-g -O0 -Wall $STRICT_PROTO"
+                    OPT="-g -O0 -Wall"
                 fi
 	    else
-		OPT="-g $WRAP -O3 -Wall $STRICT_PROTO"
+		OPT="-g $WRAP -O3 -Wall"
 	    fi
 	    ;;
 	*)
-	    OPT="-O3 -Wall $STRICT_PROTO"
+	    OPT="-O3 -Wall"
 	    ;;
 	esac
+
+	OPT="$OPT $STRICT_PROTO $ALIASING"
+
 	case $ac_sys_system in
 	    SCO_SV*) OPT="$OPT -m486 -DSCO5"
 	    ;;

--- a/configure.ac
+++ b/configure.ac
@@ -1461,8 +1461,15 @@ then
 
         # Clang also needs -fwrapv
         case $CC in
-            *clang*) WRAP="-fwrapv"
-            ;;
+            *clang*)
+                WRAP="-fwrapv"
+                # bpo-30104: Python/dtoa.c requires to be build with
+                # -fno-strict-aliasing to fix compiler issue on the
+                # double/ULong[2] union using clang 4.0 and optimization level
+                # -O2 or higher
+                # https://bugs.llvm.org//show_bug.cgi?id=31928
+                ALIASING="-fno-strict-aliasing"
+                ;;
         esac
 
 	case $ac_cv_prog_cc_g in
@@ -1471,18 +1478,21 @@ then
 		# Optimization messes up debuggers, so turn it off for
 		# debug builds.
                 if "$CC" -v --help 2>/dev/null |grep -- -Og > /dev/null; then
-                    OPT="-g -Og -Wall $STRICT_PROTO"
+                    OPT="-g -Og -Wall"
                 else
-                    OPT="-g -O0 -Wall $STRICT_PROTO"
+                    OPT="-g -O0 -Wall"
                 fi
 	    else
-		OPT="-g $WRAP -O3 -Wall $STRICT_PROTO"
+		OPT="-g $WRAP -O3 -Wall"
 	    fi
 	    ;;
 	*)
-	    OPT="-O3 -Wall $STRICT_PROTO"
+	    OPT="-O3 -Wall"
 	    ;;
 	esac
+
+	OPT="$OPT $STRICT_PROTO $ALIASING"
+
 	case $ac_sys_system in
 	    SCO_SV*) OPT="$OPT -m486 -DSCO5"
 	    ;;


### PR DESCRIPTION
Python/dtoa.c is not compiled correctly with clang 4.0 and
optimization level -O2 or higher, because of an aliasing issue on
the double/ULong[2] union.

LLVM bug report:
https://bugs.llvm.org//show_bug.cgi?id=31928