### PR TITLE
Add missing .gitignore entries for VS2015 IntelliSense DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,8 @@ PCbuild/*.suo
 PCbuild/*.*sdf
 PCbuild/*-pgi
 PCbuild/*-pgo
+PCbuild/*.VC.db
+PCbuild/*.VC.opendb
 PCbuild/.vs/
 PCbuild/amd64/
 PCbuild/obj/


### PR DESCRIPTION
This are created for me when using Visual Studio 2015 Update 3:
```
pcbuild.VC.db
pcbuild.VC.VC.opendb    (VC.VC ... Microsoft bug? 😝 or intentional? who knows...)
```