### PR TITLE
[3.5] Add missing .gitignore entries for VS2015 IntelliSense DB 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ PCbuild/*.suo
 PCbuild/*.*sdf
 PCbuild/*-pgi
 PCbuild/*-pgo
+PCbuild/*.VC.db
+PCbuild/*.VC.opendb
 PCbuild/.vs/
 PCbuild/amd64/
 PCbuild/obj/


### PR DESCRIPTION
(GH-1223)

(cherry picked from commit 8e675286a92f33837cfffac5914b5175dac5d573)