### PR TITLE
[2.7] Add missing .gitignore entries for VS2015 IntelliSense DB 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ PCbuild/*.ncb
 PCbuild/*.o
 PCbuild/*.pdb
 PCbuild/Win32-temp-*
+PCbuild/*.VC.db
+PCbuild/*.VC.opendb
 Parser/pgen
 Parser/pgen.stamp
 autom4te.cache


### PR DESCRIPTION
(GH-1223)

(cherry picked from commit 8e675286a92f33837cfffac5914b5175dac5d573)