### PR TITLE
bpo-30106: Fix test_asyncore.test_quick_connect()

### DIFF
--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -781,8 +781,9 @@ class BaseTestAPI:
             self.skipTest("test specific to AF_INET and AF_INET6")
 
         server = BaseServer(self.family, self.addr)
+        # run the thread 500 ms: the socket should be connected in 200 ms
         t = threading.Thread(target=lambda: asyncore.loop(timeout=0.1,
-                                                          count=500))
+                                                          count=5))
         t.start()
         try:
             with socket.socket(self.family, socket.SOCK_STREAM) as s:


### PR DESCRIPTION
test_quick_connect() runs a thread up to 50 seconds, whereas the
socket is connected in 0.2 second and then the thread is expected to
end in less than 3 second. On Linux, the thread ends quickly because
select() seems to always return quickly. On FreeBSD, sometimes
select() fails with timeout and so the thread runs much longer than
expected.

Fix the thread timeout to fix a race condition in the test.