### PR TITLE
bpo-30125: disable faulthandler in ctypes test_SEH

### DIFF
--- a/Lib/ctypes/test/test_win32.py
+++ b/Lib/ctypes/test/test_win32.py
@@ -41,14 +41,18 @@ class FunctionCallTestCase(unittest.TestCase):
     @unittest.skipIf(sys.executable.lower().endswith('_d.exe'),
                      "SEH not enabled in debug builds")
     def test_SEH(self):
-        # Call functions with invalid arguments, and make sure
-        # that access violations are trapped and raise an
-        # exception.
-        self.assertRaises(OSError, windll.kernel32.GetModuleHandleA, 32)
+        # Disable faulthandler to prevent logging the warning:
+        # "Windows fatal exception: access violation"
+        with support.disable_faulthandler():
+            # Call functions with invalid arguments, and make sure
+            # that access violations are trapped and raise an
+            # exception.
+            self.assertRaises(OSError, windll.kernel32.GetModuleHandleA, 32)
 
     def test_noargs(self):
         # This is a special case on win32 x64
         windll.user32.GetDesktopWindow()
+
 
 @unittest.skipUnless(sys.platform == "win32", 'Windows-specific test')
 class TestWintypes(unittest.TestCase):

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2595,3 +2595,19 @@ def setswitchinterval(interval):
         if _is_android_emulator:
             interval = minimum_interval
     return sys.setswitchinterval(interval)
+
+
+@contextlib.contextmanager
+def disable_faulthandler():
+    # use sys.__stderr__ instead of sys.stderr, since regrtest replaces
+    # sys.stderr with a StringIO which has no file descriptor when a test
+    # is run with -W/--verbose3.
+    fd = sys.__stderr__.fileno()
+
+    is_enabled = faulthandler.is_enabled()
+    try:
+        faulthandler.disable()
+        yield
+    finally:
+        if is_enabled:
+            faulthandler.enable(file=fd, all_threads=True)


### PR DESCRIPTION
Disable faulthandler to run test_SEH() of test_ctypes to prevent the
following log with a traceback:

    Windows fatal exception: access violation