### PR TITLE
remove unneccessary code

### DIFF
--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -204,10 +204,8 @@ class Future:
         clears the callback list.
         """
         callbacks = self._callbacks[:]
-        if not callbacks:
-            return
-
         self._callbacks[:] = []
+
         for callback in callbacks:
             self._loop.call_soon(callback, self)
 


### PR DESCRIPTION
if callbacks is an empty list, the for loop will not execute, so the if statement is unnecessary.