### PR TITLE
bpo-30107: don't dump core on expected test_io crash (#1235)

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3720,6 +3720,7 @@ class CMiscIOTest(MiscIOTest):
             import sys
             import time
             import threading
+            from test.support import SuppressCrashReport
 
             file = sys.{stream_name}
 
@@ -3727,6 +3728,10 @@ class CMiscIOTest(MiscIOTest):
                 while True:
                     file.write('.')
                     file.flush()
+
+            crash = SuppressCrashReport()
+            crash.__enter__()
+            # don't call __exit__(): the crash occurs at Python shutdown
 
             thread = threading.Thread(target=run)
             thread.daemon = True


### PR DESCRIPTION
test_io has two unit tests which trigger a deadlock:

* test_daemon_threads_shutdown_stdout_deadlock()
* test_daemon_threads_shutdown_stderr_deadlock()

These tests call Py_FatalError() if the expected bug is triggered
which calls abort(). Use test.support.SuppressCrashReport to prevent
the creation on a core dump, to fix the warning:

Warning -- files was modified by test_io
  Before: []
  After:  ['python.core']
(cherry picked from commit 2a1aed04b0943636f605543522e16cca1dc23e70)