### PR TITLE
Correct the README link in Unix install docs

### DIFF
--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -77,7 +77,7 @@ The build process consists in the usual ::
    make install
 
 invocations. Configuration options and caveats for specific Unix platforms are
-extensively documented in the :source:`README` file in the root of the Python
+extensively documented in the :source:`README.rst` file in the root of the Python
 source tree.
 
 .. warning::


### PR DESCRIPTION
The "Building Python" section for Unix contains a link to the README file in the project root. It looks like this file has been renamed to `README.rst` and therefore the link is broken. This fixes it 😎.

