### PR TITLE
[3.6] Correct the README link in Unix install docs (GH-1245)

### DIFF
--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -77,7 +77,7 @@ The build process consists in the usual ::
    make install
 
 invocations. Configuration options and caveats for specific Unix platforms are
-extensively documented in the :source:`README` file in the root of the Python
+extensively documented in the :source:`README.rst` file in the root of the Python
 source tree.
 
 .. warning::


### PR DESCRIPTION
(cherry picked from commit d1ae24e8880fe00d006eb2996af815c35fbcfb33)