### PR TITLE
bpo-30113: Add function Allow helper function to wrap sys.setprofile

### DIFF
--- a/Lib/profile.py
+++ b/Lib/profile.py
@@ -371,6 +371,13 @@ class Profile:
         frame = self.fake_frame(code, pframe)
         self.dispatch['call'](self, frame, 0)
 
+    # bpo-30113 tweak for helper funtion wrap sys.setprofile
+    def _adjust_frame(self):
+        # Get helper function frame objecct
+        frame = sys._getframe(1)
+        self.dispatch['call'](self, frame, 0)
+
+
     # collect stats from pending stack, including getting final
     # timings for self.cmd frame.
 


### PR DESCRIPTION
Relate to #287, #1212.

This helper function `_adjust_frame` tweak the frame stack inside the profiler, it will add the helper function which wraps sys.setprofile 's frame into the profiler frame stack.

The usage: 
```python
def setprofile_helper(pr):
    pr._adjust_frame()
    sys.setprofile(pr.dispatcher)

def  profile_call(call):
    pr = profile.Profile()
    setprofile_helper(pr)
    try:
        call()
     finally:
         sys.setprofile(None)
     return pr
```