### PR TITLE
[3.6] Fix trailing colon and newline in test.rst (GH-1250)

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -570,7 +570,8 @@ The :mod:`test.support` module defines the following functions:
       def load_tests(*args):
           return load_package_tests(os.path.dirname(__file__), *args)
 
-.. function:: detect_api_mismatch(ref_api, other_api, *, ignore=()):
+
+.. function:: detect_api_mismatch(ref_api, other_api, *, ignore=())
 
    Returns the set of attributes, functions or methods of *ref_api* not
    found on *other_api*, except for a defined list of items to be


### PR DESCRIPTION
(cherry picked from commit 7fae81e1672d0b4110d31ea6a765b54f63a2e54b)