### PR TITLE
Remove outdated note about the constraning of the bit shift right operand.

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1173,11 +1173,6 @@ the left or right by the number of bits given by the second argument.
 A right shift by *n* bits is defined as floor division by ``pow(2,n)``.  A left
 shift by *n* bits is defined as multiplication with ``pow(2,n)``.
 
-.. note::
-
-   In the current implementation, the right-hand operand is required
-   to be at most :attr:`sys.maxsize`.  If the right-hand operand is larger than
-   :attr:`sys.maxsize` an :exc:`OverflowError` exception is raised.
 
 .. _bitwise:
 


### PR DESCRIPTION
The constrain was removed in bpo-29816.