### PR TITLE
[2.7] bpo-15718: Document the upper bound constrain on the __len__ re…

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1891,6 +1891,14 @@ sequences, it should iterate through the values.
    :meth:`__nonzero__` method and whose :meth:`__len__` method returns zero is
    considered to be false in a Boolean context.
 
+   .. impl-detail::
+
+      In CPython, the length is required to be at most :attr:`sys.maxsize`.
+      If the length is larger than :attr:`!sys.maxsize` some features (such as
+      :func:`len`) may raise :exc:`OverflowError`.  To prevent raising
+      :exc:`!OverflowError` by truth value testing, an object must define a
+      :meth:`__nonzero__` method.
+
 
 .. method:: object.__getitem__(self, key)
 


### PR DESCRIPTION
…turn value. (GH-1256).

(cherry picked from commit 85157cd89a6edac347a5b6871fcf20c500c6fbbf)