### PR TITLE
Added grouping paranthesis around alternative definition of suite to …

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -54,7 +54,7 @@ Summarizing:
                 : | `async_with_stmt`
                 : | `async_for_stmt`
                 : | `async_funcdef`
-   suite: `stmt_list` NEWLINE | NEWLINE INDENT `statement`+ DEDENT
+   suite: `stmt_list` NEWLINE | (NEWLINE INDENT `statement`)+ DEDENT
    statement: `stmt_list` NEWLINE | `compound_stmt`
    stmt_list: `simple_stmt` (";" `simple_stmt`)* [";"]
 


### PR DESCRIPTION
…include NEWLINE INDENT. This is to show that using multiple statements in a clause requires those three items each time they repeat.

I would label this as trivial