### PR TITLE
bpo-30157: Fix csv.Sniffer.sniff() regex pattern

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -217,7 +217,7 @@ class Sniffer:
         matches = []
         for restr in (r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?P=delim)', # ,".*?",
                       r'(?:^|\n)(?P<quote>["\']).*?(?P=quote)(?P<delim>[^\w\n"\'])(?P<space> ?)',   #  ".*?",
-                      r'(?P<delim>>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?:$|\n)',  # ,".*?"
+                      r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?:$|\n)',   # ,".*?"
                       r'(?:^|\n)(?P<quote>["\']).*?(?P=quote)(?:$|\n)'):                            #  ".*?" (no delim, no space)
             regexp = re.compile(restr, re.DOTALL | re.MULTILINE)
             matches = regexp.findall(data)

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -632,7 +632,6 @@ class TestDictFields(unittest.TestCase):
                           extrasaction="raised")
 
     def test_write_field_not_in_field_names_raise(self):
-        fileobj = StringIO()
         writer = csv.DictWriter(fileobj, ['f1', 'f2'], extrasaction="raise")
         dictrow = {'f0': 0, 'f1': 1, 'f2': 2, 'f3': 3}
         self.assertRaises(ValueError, csv.DictWriter.writerow, writer, dictrow)
@@ -966,6 +965,18 @@ Stonecutters Seafood and Chop House+ Lemont+ IL+ 12/19/02+ Week Back
         self.assertEqual(sniffer.has_header(self.sample8), False)
         self.assertEqual(sniffer.has_header(self.header2 + self.sample8),
                          True)
+
+    def test_guess_quote_and_delimiter_regex(self):
+        cases = [('asd',       ('', False, None, 0)),   # No match
+                 (',"123,4",', ('"', False, ',', 0)),   # ,".*?",
+                 ('"123,4",',  ('"', False, ',', 0)),   # ".*?",
+                 (',"123,4"',  ('"', False, ',', 0)),   # ,".*?"
+                 ('"123,4"',  ('"', False, None, 0))]   # ,".*?"
+
+        sniffer = csv.Sniffer()
+        for test_input, expected in cases:
+            guess = sniffer._guess_quote_and_delimiter(test_input, ',')
+            self.assertEqual(guess, expected)
 
     def test_sniff(self):
         sniffer = csv.Sniffer()

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -632,6 +632,7 @@ class TestDictFields(unittest.TestCase):
                           extrasaction="raised")
 
     def test_write_field_not_in_field_names_raise(self):
+        fileobj = StringIO()
         writer = csv.DictWriter(fileobj, ['f1', 'f2'], extrasaction="raise")
         dictrow = {'f0': 0, 'f1': 1, 'f2': 2, 'f3': 3}
         self.assertRaises(ValueError, csv.DictWriter.writerow, writer, dictrow)
@@ -971,7 +972,7 @@ Stonecutters Seafood and Chop House+ Lemont+ IL+ 12/19/02+ Week Back
                  (',"123,4",', ('"', False, ',', 0)),   # ,".*?",
                  ('"123,4",',  ('"', False, ',', 0)),   # ".*?",
                  (',"123,4"',  ('"', False, ',', 0)),   # ,".*?"
-                 ('"123,4"',  ('"', False, None, 0))]   # ,".*?"
+                 ('"123,4"',  ('"', False, '', 0))]   # ,".*?"
 
         sniffer = csv.Sniffer()
         for test_input, expected in cases:

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -102,6 +102,8 @@ Core and Builtins
 
 - bpo-29546: Improve from-import error message with location
 
+- bpo-30157: Fix csv.Sniffer.sniff() regex pattern typo.
+
 - Issue #29319: Prevent RunMainFromImporter overwriting sys.path[0].
 
 - Issue #29337: Fixed possible BytesWarning when compare the code objects.


### PR DESCRIPTION
Looks like there is an extra > in the regex pattern for this sort of csv line: `# ,".*?"`