### PR TITLE
bpo-28851: DOC: Retrofit changes to collections.rst from 2.7

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -771,9 +771,9 @@ they add the ability to access fields by name instead of position index.
     helpful docstring (with typename and field_names) and a helpful :meth:`__repr__`
     method which lists the tuple contents in a ``name=value`` format.
 
-    The *field_names* are a single string with each fieldname separated by whitespace
-    and/or commas, for example ``'x y'`` or ``'x, y'``.  Alternatively, *field_names*
-    can be a sequence of strings such as ``['x', 'y']``.
+    The *field_names* are a sequence of strings such as ``['x', 'y']``.
+    Alternatively, *field_names* can be a single string with each fieldname
+    separated by whitespace and/or commas, for example ``'x y'`` or ``'x, y'``.
 
     Any valid Python identifier may be used for a fieldname except for names
     starting with an underscore.  Valid identifiers consist of letters, digits,


### PR DESCRIPTION
Notes from the original change in 2.7:

 Minor doc clean-up.

* Show list of fields option before showing the single string alternative.
* Remove the PS2 prompts so that the examples become cut-and-pastable.