### PR TITLE
bpo-30132: distutils test_build_ext() uses temp_cwd()

### DIFF
--- a/Lib/distutils/tests/test_build_ext.py
+++ b/Lib/distutils/tests/test_build_ext.py
@@ -41,6 +41,13 @@ class BuildExtTestCase(TempdirManager,
         return build_ext(*args, **kwargs)
 
     def test_build_ext(self):
+        # bpo-30132: On Windows, a .pdb file may be created in the current
+        # working directory. Create a temporary working directory to cleanup
+        # everything at the end of the test.
+        with support.temp_cwd():
+            self._test_build_ext()
+
+    def _test_build_ext(self):
         cmd = support.missing_compiler_executable()
         if cmd is not None:
             self.skipTest('The %r command is not found' % cmd)


### PR DESCRIPTION
test_build_ext() of test_distutils now uses support.temp_cwd() to
prevent the creation of a pdb file in the current working directory
on Windows.