### PR TITLE
bpo-30107: Make SuppressCrashReport quiet on macOS

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2447,6 +2447,7 @@ class SuppressCrashReport:
                                        (0, self.old_value[1]))
                 except (ValueError, OSError):
                     pass
+
             if sys.platform == 'darwin':
                 # Check if the 'Crash Reporter' on OSX was configured
                 # in 'Developer' mode and warn that it will get triggered
@@ -2454,10 +2455,14 @@ class SuppressCrashReport:
                 #
                 # This assumes that this context manager is used in tests
                 # that might trigger the next manager.
-                value = subprocess.Popen(['/usr/bin/defaults', 'read',
-                        'com.apple.CrashReporter', 'DialogType'],
-                        stdout=subprocess.PIPE).communicate()[0]
-                if value.strip() == b'developer':
+                cmd = ['/usr/bin/defaults', 'read',
+                       'com.apple.CrashReporter', 'DialogType']
+                proc = subprocess.Popen(cmd,
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.PIPE)
+                with proc:
+                    stdout = proc.communicate()[0]
+                if stdout.strip() == b'developer':
                     print("this test triggers the Crash Reporter, "
                           "that is intentional", end='', flush=True)
 


### PR DESCRIPTION
On macOS, SuppressCrashReport now redirects /usr/bin/defaults command
stderr into a pipe to not pollute stderr. It fixes a
test_io.test_daemon_threads_shutdown_stderr_deadlock() failure when
the CrashReporter domain doesn't exists. Message logged into stderr:

2017-04-24 16:57:21.432 defaults[41046:2462851]
The domain/default pair of (com.apple.CrashReporter, DialogType) does not exist