### PR TITLE
itemgetter add dict example

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -314,6 +314,8 @@ expect a function argument.
    method.  Dictionaries accept any hashable value.  Lists, tuples, and
    strings accept an index or a slice:
 
+      >>> itemgetter('name')({'name': 'tu', 'age': 18})
+      'tu'
       >>> itemgetter(1)('ABCDEFG')
       'B'
       >>> itemgetter(1,3,5)('ABCDEFG')


### PR DESCRIPTION
The document says that `operator.itemgetter` using the operand’s `__getitem__()` method. However, it is difficult to understand for a newbie.
One example is better than thousands of words.