### PR TITLE
[3.6] bpo-28851: Improve namedtuple documentation (GH-1274)

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -771,9 +771,9 @@ they add the ability to access fields by name instead of position index.
     helpful docstring (with typename and field_names) and a helpful :meth:`__repr__`
     method which lists the tuple contents in a ``name=value`` format.
 
-    The *field_names* are a single string with each fieldname separated by whitespace
-    and/or commas, for example ``'x y'`` or ``'x, y'``.  Alternatively, *field_names*
-    can be a sequence of strings such as ``['x', 'y']``.
+    The *field_names* are a sequence of strings such as ``['x', 'y']``.
+    Alternatively, *field_names* can be a single string with each fieldname
+    separated by whitespace and/or commas, for example ``'x y'`` or ``'x, y'``.
 
     Any valid Python identifier may be used for a fieldname except for names
     starting with an underscore.  Valid identifiers consist of letters, digits,


### PR DESCRIPTION
Clarify that a sequence of strings is the preferred value for 'field_names'.
(cherry picked from commit 97bf722fcd1de1236824377e052369dc7686b644)