### PR TITLE
trivial: PyArg_ParseTupleAndKeywords supports required keyword only arguments

### DIFF
--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -368,9 +368,7 @@ inside nested parentheses.  They are:
 ``$``
    :c:func:`PyArg_ParseTupleAndKeywords` only:
    Indicates that the remaining arguments in the Python argument list are
-   keyword-only.  Currently, all keyword-only arguments must also be optional
-   arguments, so ``|`` must always be specified before ``$`` in the format
-   string.
+   keyword-only.
 
    .. versionadded:: 3.3
 


### PR DESCRIPTION
Remove comment about $ needing to follow | in PyArg_ParseTupleAndKeywords
    
PyArg_ParseTupleAndKeywords supports required positional arguments, $ does not
need to follow |.