### PR TITLE
timemodule.c: Cast PyUnicode_AsUTF8() to char*

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -440,7 +440,7 @@ gettmarg(PyObject *args, struct tm *p)
     if (Py_TYPE(args) == &StructTimeType) {
         PyObject *item;
         item = PyTuple_GET_ITEM(args, 9);
-        p->tm_zone = item == Py_None ? NULL : PyUnicode_AsUTF8(item);
+        p->tm_zone = item == Py_None ? NULL : (char*)PyUnicode_AsUTF8(item);
         item = PyTuple_GET_ITEM(args, 10);
         p->tm_gmtoff = item == Py_None ? 0 : PyLong_AsLong(item);
         if (PyErr_Occurred())


### PR DESCRIPTION
bpo-28769 changed PyUnicode_AsUTF8() return type from const char* to char* in Python 3.7, but tm_zone field type of the tm structure is char* on FreeBSD.
    
Cast PyUnicode_AsUTF8() to char* in gettmarg() to fix the warning:

```
Modules/timemodule.c:443:20: warning: assigning to 'char *'
from 'const char *' discards qualifiers
```

See http://bugs.python.org/issue28769