### PR TITLE
[3.6] bpo-30142: Remove "callable" from the 2to3fixer documentation.

### DIFF
--- a/Doc/library/2to3.rst
+++ b/Doc/library/2to3.rst
@@ -199,13 +199,6 @@ and off individually.  They are described here in more detail.
    because the :class:`memoryview` API is similar but not exactly the same as
    that of :class:`buffer`.
 
-.. 2to3fixer:: callable
-
-   Converts ``callable(x)`` to ``isinstance(x, collections.Callable)``, adding
-   an import to :mod:`collections` if needed. Note ``callable(x)`` has returned
-   in Python 3.2, so if you do not intend to support Python 3.1, you can disable
-   this fixer.
-
 .. 2to3fixer:: dict
 
    Fixes dictionary iteration methods.  :meth:`dict.iteritems` is converted to


### PR DESCRIPTION
cherry-pick fc3811e