### PR TITLE
bpo-27618: DOC: Update threading.Lock to define it as factory function

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -371,8 +371,9 @@ All methods are executed atomically.
    lock, subsequent attempts to acquire it block, until it is released; any
    thread may release it.
 
-   .. versionchanged:: 3.3
-      Changed from a factory function to a class.
+   Note that ``Lock`` is actually a factory function which returns an instance
+   of the most efficient version of the concrete Lock class that is supported
+   by the platform.
 
 
    .. method:: acquire(blocking=True, timeout=-1)


### PR DESCRIPTION
Based on the bug tracker, threading.Lock wasn't converted to a class, but the doc inadvertently said it had been.  Changed it to match the text used in RLock.