### PR TITLE
bpo-13349: Improve the error message for tuple.index

### DIFF
--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -568,7 +568,7 @@ tuple_index_impl(PyTupleObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "tuple.index(x): x not in tuple");
+    PyErr_Format(PyExc_ValueError, "%R is not in tuple", value);
     return NULL;
 }
 


### PR DESCRIPTION
When the required value is not found, use the same template as
list.index and display the missing value instead of 'x'. The original issue with the discussion is: https://bugs.python.org/issue13349