### PR TITLE
[2.7] bpo-30182: Use the correct name for ISO in Unicode HOWTO. (GH-1312).

### DIFF
--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -43,9 +43,9 @@ hold values ranging from 0 to 255.  ASCII codes only went up to 127, so some
 machines assigned values between 128 and 255 to accented characters.  Different
 machines had different codes, however, which led to problems exchanging files.
 Eventually various commonly used sets of values for the 128--255 range emerged.
-Some were true standards, defined by the International Standards Organization,
-and some were **de facto** conventions that were invented by one company or
-another and managed to catch on.
+Some were true standards, defined by the International Organization for
+Standardization, and some were *de facto* conventions that were invented by one
+company or another and managed to catch on.
 
 255 characters aren't very many.  For example, you can't fit both the accented
 characters used in Western Europe and the Cyrillic alphabet used for Russian


### PR DESCRIPTION
(cherry picked from commit 6fde770e4e940c19cd62de0b6aeb77840690843e)