### PR TITLE
bpo-29621: telnetlib.write() raise TypeError if recv non-bytes type.

### DIFF
--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -284,6 +284,8 @@ class Telnet:
         OSError if the connection is closed.
 
         """
+        if not isinstance(buffer, (bytes, bytearray)):
+            raise TypeError('%s must be a bytes-like type.' % buffer)
         if IAC in buffer:
             buffer = buffer.replace(IAC, IAC+IAC)
         self.msg("send %r", buffer)

--- a/Lib/test/test_telnetlib.py
+++ b/Lib/test/test_telnetlib.py
@@ -304,6 +304,17 @@ class WriteTests(unittest.TestCase):
             written = b''.join(telnet.sock.writes)
             self.assertEqual(data.replace(tl.IAC,tl.IAC+tl.IAC), written)
 
+
+    def test_write_type_error(self):
+        non_bytes_data_sample = ['data sample with string',
+                                 [b'data sample without IAC'],
+                                 [b'data sample with', tl.IAC, b' one IAC'],
+                                 (b'data sample with', tl.IAC ,b' one IAC'),
+                                 '']
+        for data in non_bytes_data_sample:
+            telnet = test_telnet()
+            self.assertRaises(TypeError, telnet.write, data)
+
 class OptionTests(unittest.TestCase):
     # RFC 854 commands
     cmds = [tl.AO, tl.AYT, tl.BRK, tl.EC, tl.EL, tl.GA, tl.IP, tl.NOP]

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -317,6 +317,9 @@ Extension Modules
 Library
 -------
 
+- bpo-29621: If telnetlib.write() receive non-byte-like type 
+             then raise TypeError. Patched by Dong-hee Na.
+
 - bpo-30101: Add support for curses.A_ITALIC.
 
 - bpo-29822: inspect.isabstract() now works during __init_subclass__.  Patch


### PR DESCRIPTION
If telnetlib.write() receive non-byte-like bytes
then raise TypeError.