### PR TITLE
bpo-30188: Catch EOFError in NetworkedNNTPTests

### DIFF
--- a/Lib/test/test_nntplib.py
+++ b/Lib/test/test_nntplib.py
@@ -286,7 +286,12 @@ class NetworkedNNTPTests(NetworkedNNTPTestsMixin, unittest.TestCase):
     def setUpClass(cls):
         support.requires("network")
         with support.transient_internet(cls.NNTP_HOST):
-            cls.server = cls.NNTP_CLASS(cls.NNTP_HOST, timeout=TIMEOUT, usenetrc=False)
+            try:
+                cls.server = cls.NNTP_CLASS(cls.NNTP_HOST, timeout=TIMEOUT,
+                                            usenetrc=False)
+            except EOFError:
+                raise unittest.SkipTest(f"{cls} got EOF error on connecting "
+                                        f"to {cls.NNTP_HOST!r}")
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
test_nntplib fails randomly with EOFError in
NetworkedNNTPTests.setUpClass(). Catch EOFError to skip tests in that
case.