### PR TITLE
[3.5] bpo-30175: Skip client cert tests of test_imaplib (#1320)

### DIFF
--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -917,11 +917,17 @@ class RemoteIMAP_SSLTest(RemoteIMAPTest):
             _server = self.imap_class(self.host, self.port)
             self.check_logincapa(_server)
 
+    @unittest.skipIf(True,
+                     "bpo-30175: FIXME: cyrus.andrew.cmu.edu doesn't accept "
+                     "our randomly generated client x509 certificate anymore")
     def test_logincapa_with_client_certfile(self):
         with transient_internet(self.host):
             _server = self.imap_class(self.host, self.port, certfile=CERTFILE)
             self.check_logincapa(_server)
 
+    @unittest.skipIf(True,
+                     "bpo-30175: FIXME: cyrus.andrew.cmu.edu doesn't accept "
+                     "our randomly generated client x509 certificate anymore")
     def test_logincapa_with_client_ssl_context(self):
         with transient_internet(self.host):
             _server = self.imap_class(

--- a/Lib/test/test_nntplib.py
+++ b/Lib/test/test_nntplib.py
@@ -286,7 +286,12 @@ class NetworkedNNTPTests(NetworkedNNTPTestsMixin, unittest.TestCase):
     def setUpClass(cls):
         support.requires("network")
         with support.transient_internet(cls.NNTP_HOST):
-            cls.server = cls.NNTP_CLASS(cls.NNTP_HOST, timeout=TIMEOUT, usenetrc=False)
+            try:
+                cls.server = cls.NNTP_CLASS(cls.NNTP_HOST, timeout=TIMEOUT,
+                                            usenetrc=False)
+            except EOFError:
+                raise unittest.SkipTest("%s got EOF error on connecting "
+                                        "to %r" % (cls, cls.NNTP_HOST))
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
* bpo-30175: Skip client cert tests of test_imaplib

The IMAP server cyrus.andrew.cmu.edu doesn't accept our randomly
generated client x509 certificate anymore.

* bpo-30188: Catch EOFError in NetworkedNNTPTests

test_nntplib fails randomly with EOFError in
NetworkedNNTPTests.setUpClass(). Catch EOFError to skip tests in that
case.

(cherry picked from commit 5bccca58b9b2b3a925b16750bedbd907695ea8d7)