### PR TITLE
bpo-30140: fix binop dispatch for subclasses

### DIFF
--- a/Lib/test/test_binop.py
+++ b/Lib/test/test_binop.py
@@ -1,7 +1,7 @@
 """Tests for binary operators on subtypes of built-in types."""
 
 import unittest
-from operator import eq, le, ne
+from operator import eq, le, ne, add
 from abc import ABCMeta
 
 def gcd(a, b):
@@ -386,6 +386,38 @@ class OperationOrderTests(unittest.TestCase):
         self.assertTrue(issubclass(V, B))
         self.assertEqual(op_sequence(eq, B, V), ['B.__eq__', 'V.__eq__'])
         self.assertEqual(op_sequence(le, B, V), ['B.__le__', 'V.__ge__'])
+
+    def test_arithmetic_orders(self):
+
+        def logged_op(name):
+            def op(self, other):
+                type_name = type(self).__name__
+                self.log_operation(f'{type_name}.__{name}__')
+                return NotImplemented
+            return op
+
+        class A(OperationLogger):
+            __add__ = logged_op('add')
+            __radd__ = logged_op('radd')
+
+        class B(OperationLogger):
+            __add__ = logged_op('add')
+            __radd__ = logged_op('radd')
+
+        class C(A):
+            pass
+
+        class D(OperationLogger):
+            pass
+
+        self.assertEqual(op_sequence(add, A, A), ['A.__add__'])
+        self.assertEqual(op_sequence(add, A, D), ['A.__add__'])
+        self.assertEqual(op_sequence(add, D, A), ['A.__radd__'])
+        self.assertEqual(op_sequence(add, A, B), ['A.__add__', 'B.__radd__'])
+        self.assertEqual(op_sequence(add, B, A), ['B.__add__', 'A.__radd__'])
+        self.assertEqual(op_sequence(add, A, C), ['C.__radd__', 'A.__add__'])
+        self.assertEqual(op_sequence(add, C, A), ['C.__add__', 'A.__radd__'])
+
 
 class SupEq(object):
     """Class that can test equality"""

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -4111,18 +4111,6 @@ order (MRO) for bases """
         self.assertEqual(D() // C(), "D.__floordiv__")
         self.assertEqual(C() // D(), "D.__rfloordiv__")
 
-        # Case 4: this didn't work right in 2.2.2 and 2.3a1
-
-        class E(C):
-            pass
-
-        self.assertEqual(E.__rfloordiv__, C.__rfloordiv__)
-
-        self.assertEqual(E() // 1, "C.__floordiv__")
-        self.assertEqual(1 // E(), "C.__rfloordiv__")
-        self.assertEqual(E() // C(), "C.__floordiv__")
-        self.assertEqual(C() // E(), "C.__floordiv__") # This one would fail
-
     @support.impl_detail("testing an internal kind of method object")
     def test_meth_class_get(self):
         # Testing __get__ method of METH_CLASS C methods...

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-05-14-54-30.bpo-30140.fnPWpS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-05-14-54-30.bpo-30140.fnPWpS.rst
@@ -1,0 +1,2 @@
+Fix binary operator dispatch to try subclasses implementations first always,
+even if the subclass does not directly override the relevant special method.


### PR DESCRIPTION
~~This doesn't work yet, but I'm not quite sure why.~~ This is now working.

<!-- issue-number: bpo-30140 -->
https://bugs.python.org/issue30140
<!-- /issue-number -->
