### PR TITLE
bpo-27593: Get SCM build info from git instead of hg

### DIFF
--- a/Include/pythonrun.h
+++ b/Include/pythonrun.h
@@ -111,11 +111,10 @@ PyAPI_FUNC(const char *) Py_GetPlatform(void);
 PyAPI_FUNC(const char *) Py_GetCopyright(void);
 PyAPI_FUNC(const char *) Py_GetCompiler(void);
 PyAPI_FUNC(const char *) Py_GetBuildInfo(void);
-PyAPI_FUNC(const char *) _Py_svnversion(void);
 PyAPI_FUNC(const char *) Py_SubversionRevision(void);
 PyAPI_FUNC(const char *) Py_SubversionShortBranch(void);
-PyAPI_FUNC(const char *) _Py_hgidentifier(void);
-PyAPI_FUNC(const char *) _Py_hgversion(void);
+PyAPI_FUNC(const char *) _Py_gitidentifier(void);
+PyAPI_FUNC(const char *) _Py_gitversion(void);
 
 /* Internal -- various one-time initializations */
 PyAPI_FUNC(PyObject *) _PyBuiltin_Init(void);

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -38,10 +38,9 @@ MAINCC=		@MAINCC@
 LINKCC=		@LINKCC@
 AR=		@AR@
 RANLIB=		@RANLIB@
-SVNVERSION=	@SVNVERSION@
-HGVERSION=	@HGVERSION@
-HGTAG=		@HGTAG@
-HGBRANCH=	@HGBRANCH@
+GITVERSION=	@GITVERSION@
+GITTAG=		@GITTAG@
+GITBRANCH=	@GITBRANCH@
 PGO_PROF_GEN_FLAG=@PGO_PROF_GEN_FLAG@
 PGO_PROF_USE_FLAG=@PGO_PROF_USE_FLAG@
 LLVM_PROF_MERGER=@LLVM_PROF_MERGER@
@@ -314,7 +313,7 @@ ASDLGEN=	$(srcdir)/Parser/asdl_c.py
 
 OPCODETARGETS_H= \
 		$(srcdir)/Python/opcode_targets.h
-		
+
 OPCODETARGETGEN= \
 		$(srcdir)/Python/makeopcodetargets.py
 
@@ -656,10 +655,9 @@ Modules/getbuildinfo.o: $(PARSER_OBJS) \
 		$(MODOBJS) \
 		$(srcdir)/Modules/getbuildinfo.c
 	$(CC) -c $(PY_CFLAGS) \
-	      -DSVNVERSION="\"`LC_ALL=C $(SVNVERSION)`\"" \
-	      -DHGVERSION="\"`LC_ALL=C $(HGVERSION)`\"" \
-	      -DHGTAG="\"`LC_ALL=C $(HGTAG)`\"" \
-	      -DHGBRANCH="\"`LC_ALL=C $(HGBRANCH)`\"" \
+	      -DGITVERSION="\"`LC_ALL=C $(GITVERSION)`\"" \
+	      -DGITTAG="\"`LC_ALL=C $(GITTAG)`\"" \
+	      -DGITBRANCH="\"`LC_ALL=C $(GITBRANCH)`\"" \
 	      -o $@ $(srcdir)/Modules/getbuildinfo.c
 
 Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -134,6 +134,10 @@ Documentation
 Build
 -----
 
+- bpo-27593: sys.version and the platform module python_build(),
+  python_branch(), and python_revision() functions now use
+  git information rather than hg when building from a repo.
+
 - bpo-29643: Fix ``--enable-optimization`` configure option didn't work.
 
 - bpo-29572: Update Windows build and OS X installers to use OpenSSL 1.0.2k.

--- a/Modules/getbuildinfo.c
+++ b/Modules/getbuildinfo.c
@@ -20,66 +20,48 @@
 #endif
 #endif
 
-/* on unix, SVNVERSION is passed on the command line.
- * on Windows, the string is interpolated using
- * subwcrev.exe
- */
-#ifndef SVNVERSION
-#define SVNVERSION "$WCRANGE$$WCMODS?M:$"
-#endif
-
 /* XXX Only unix build process has been tested */
-#ifndef HGVERSION
-#define HGVERSION ""
+#ifndef GITVERSION
+#define GITVERSION ""
 #endif
-#ifndef HGTAG
-#define HGTAG ""
+#ifndef GITTAG
+#define GITTAG ""
 #endif
-#ifndef HGBRANCH
-#define HGBRANCH ""
+#ifndef GITBRANCH
+#define GITBRANCH ""
 #endif
 
 const char *
 Py_GetBuildInfo(void)
 {
-    static char buildinfo[50 + sizeof(HGVERSION) +
-                          ((sizeof(HGTAG) > sizeof(HGBRANCH)) ?
-                           sizeof(HGTAG) : sizeof(HGBRANCH))];
-    const char *revision = _Py_hgversion();
+    static char buildinfo[50 + sizeof(GITVERSION) +
+                          ((sizeof(GITTAG) > sizeof(GITBRANCH)) ?
+                           sizeof(GITTAG) : sizeof(GITBRANCH))];
+    const char *revision = _Py_gitversion();
     const char *sep = *revision ? ":" : "";
-    const char *hgid = _Py_hgidentifier();
-    if (!(*hgid))
-        hgid = "default";
+    const char *gitid = _Py_gitidentifier();
+    if (!(*gitid))
+        gitid = "default";
     PyOS_snprintf(buildinfo, sizeof(buildinfo),
-                  "%s%s%s, %.20s, %.9s", hgid, sep, revision,
+                  "%s%s%s, %.20s, %.9s", gitid, sep, revision,
                   DATE, TIME);
     return buildinfo;
 }
 
 const char *
-_Py_svnversion(void)
+_Py_gitversion(void)
 {
-    /* the following string can be modified by subwcrev.exe */
-    static const char svnversion[] = SVNVERSION;
-    if (svnversion[0] != '$')
-        return svnversion; /* it was interpolated, or passed on command line */
-    return "Unversioned directory";
+    return GITVERSION;
 }
 
 const char *
-_Py_hgversion(void)
+_Py_gitidentifier(void)
 {
-    return HGVERSION;
-}
-
-const char *
-_Py_hgidentifier(void)
-{
-    const char *hgtag, *hgid;
-    hgtag = HGTAG;
-    if ((*hgtag) && strcmp(hgtag, "tip") != 0)
-        hgid = hgtag;
+    const char *gittag, *gitid;
+    gittag = GITTAG;
+    if ((*gittag) && strcmp(gittag, "undefined") != 0)
+        gitid = gittag;
     else
-        hgid = HGBRANCH;
-    return hgid;
+        gitid = GITBRANCH;
+    return gitid;
 }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1426,9 +1426,9 @@ _PySys_Init(void)
     SET_SYS_FROM_STRING("subversion",
                          Py_BuildValue("(ssz)", "CPython", branch,
                                       svn_revision));
-    SET_SYS_FROM_STRING("_mercurial",
-                        Py_BuildValue("(szz)", "CPython", _Py_hgidentifier(),
-                                      _Py_hgversion()));
+    SET_SYS_FROM_STRING("_git",
+                        Py_BuildValue("(szz)", "CPython", _Py_gitidentifier(),
+                                      _Py_gitversion()));
     SET_SYS_FROM_STRING("dont_write_bytecode",
                          PyBool_FromLong(Py_DontWriteBytecodeFlag));
     SET_SYS_FROM_STRING("api_version",

--- a/configure
+++ b/configure
@@ -683,11 +683,10 @@ MKDIR_P
 INSTALL_DATA
 INSTALL_SCRIPT
 INSTALL_PROGRAM
-HAS_HG
-HGBRANCH
-HGTAG
-HGVERSION
-SVNVERSION
+HAS_GIT
+GITBRANCH
+GITTAG
+GITVERSION
 ARFLAGS
 ac_ct_AR
 AR
@@ -5689,15 +5688,20 @@ then
 fi
 
 
-# Extract the first word of "svnversion", so it can be a program name with args.
-set dummy svnversion; ac_word=$2
+
+
+
+if test -e $srcdir/.git/HEAD
+then
+# Extract the first word of "git", so it can be a program name with args.
+set dummy git; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_SVNVERSION+:} false; then :
+if ${ac_cv_prog_HAS_GIT+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  if test -n "$SVNVERSION"; then
-  ac_cv_prog_SVNVERSION="$SVNVERSION" # Let the user override the test.
+  if test -n "$HAS_GIT"; then
+  ac_cv_prog_HAS_GIT="$HAS_GIT" # Let the user override the test.
 else
 as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
 for as_dir in $PATH
@@ -5706,7 +5710,7 @@ do
   test -z "$as_dir" && as_dir=.
     for ac_exec_ext in '' $ac_executable_extensions; do
   if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_SVNVERSION="found"
+    ac_cv_prog_HAS_GIT="found"
     $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
     break 2
   fi
@@ -5714,76 +5718,31 @@ done
   done
 IFS=$as_save_IFS
 
-  test -z "$ac_cv_prog_SVNVERSION" && ac_cv_prog_SVNVERSION="not-found"
+  test -z "$ac_cv_prog_HAS_GIT" && ac_cv_prog_HAS_GIT="not-found"
 fi
 fi
-SVNVERSION=$ac_cv_prog_SVNVERSION
-if test -n "$SVNVERSION"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $SVNVERSION" >&5
-$as_echo "$SVNVERSION" >&6; }
+HAS_GIT=$ac_cv_prog_HAS_GIT
+if test -n "$HAS_GIT"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $HAS_GIT" >&5
+$as_echo "$HAS_GIT" >&6; }
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 fi
 
 
-if test $SVNVERSION = found
+else
+HAS_GIT=no-repository
+fi
+if test $HAS_GIT = found
 then
-	SVNVERSION="svnversion \$(srcdir)"
+    GITVERSION="git -C \$(srcdir) rev-parse --short HEAD"
+    GITTAG="git -C \$(srcdir) describe --all --always --dirty"
+    GITBRANCH="git -C \$(srcdir) name-rev --name-only HEAD"
 else
-	SVNVERSION="echo Unversioned directory"
-fi
-
-
-
-
-# Extract the first word of "hg", so it can be a program name with args.
-set dummy hg; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_HAS_HG+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$HAS_HG"; then
-  ac_cv_prog_HAS_HG="$HAS_HG" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_HAS_HG="found"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_prog_HAS_HG" && ac_cv_prog_HAS_HG="not-found"
-fi
-fi
-HAS_HG=$ac_cv_prog_HAS_HG
-if test -n "$HAS_HG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $HAS_HG" >&5
-$as_echo "$HAS_HG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-if test $HAS_HG = found
-then
-    HGVERSION="hg id -i \$(srcdir)"
-    HGTAG="hg id -t \$(srcdir)"
-    HGBRANCH="hg id -b \$(srcdir)"
-else
-    HGVERSION=""
-    HGTAG=""
-    HGBRANCH=""
+    GITVERSION=""
+    GITTAG=""
+    GITBRANCH=""
 fi
 
 case $MACHDEP in

--- a/configure.ac
+++ b/configure.ac
@@ -979,28 +979,25 @@ then
         ARFLAGS="rc"
 fi
 
-AC_SUBST(SVNVERSION)
-AC_CHECK_PROG(SVNVERSION, svnversion, found, not-found)
-if test $SVNVERSION = found
-then
-	SVNVERSION="svnversion \$(srcdir)"
-else
-	SVNVERSION="echo Unversioned directory"
-fi
+AC_SUBST(GITVERSION)
+AC_SUBST(GITTAG)
+AC_SUBST(GITBRANCH)
 
-AC_SUBST(HGVERSION)
-AC_SUBST(HGTAG)
-AC_SUBST(HGBRANCH)
-AC_CHECK_PROG(HAS_HG, hg, found, not-found)
-if test $HAS_HG = found
+if test -e $srcdir/.git/HEAD
 then
-    HGVERSION="hg id -i \$(srcdir)"
-    HGTAG="hg id -t \$(srcdir)"
-    HGBRANCH="hg id -b \$(srcdir)"
+AC_CHECK_PROG(HAS_GIT, git, found, not-found)
 else
-    HGVERSION=""
-    HGTAG=""
-    HGBRANCH=""
+HAS_GIT=no-repository
+fi
+if test $HAS_GIT = found
+then
+    GITVERSION="git -C \$(srcdir) rev-parse --short HEAD"
+    GITTAG="git -C \$(srcdir) describe --all --always --dirty"
+    GITBRANCH="git -C \$(srcdir) name-rev --name-only HEAD"
+else
+    GITVERSION=""
+    GITTAG=""
+    GITBRANCH=""
 fi
 
 case $MACHDEP in


### PR DESCRIPTION
Based on commit 5c4b0d063aba0a68c325073f5f312a2c9f40d178 by Ned
Deily, which is based on original patches by Brett Cannon and Steve
Dower.

Remove also the private _Py_svnversion() function and SVNVERSION
variable.

Note: Py_SubversionRevision() and Py_SubversionShortBranch() are
unchanged, they are part of the public API.