### PR TITLE
Small improvements to shebang on windows docs

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -550,9 +550,9 @@ Shebang Lines
 
 If the first line of a script file starts with ``#!``, it is known as a
 "shebang" line.  Linux and other Unix like operating systems have native
-support for such lines and are commonly used on such systems to indicate how
-a script should be executed.  This launcher allows the same facilities to be
-used with Python scripts on Windows and the examples above demonstrate their
+support for such lines and they are commonly used on such systems to indicate
+how a script should be executed.  This launcher allows the same facilities to
+be used with Python scripts on Windows and the examples above demonstrate their
 use.
 
 To allow shebang lines in Python scripts to be portable between Unix and

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -552,7 +552,7 @@ If the first line of a script file starts with ``#!``, it is known as a
 "shebang" line.  Linux and other Unix like operating systems have native
 support for such lines and are commonly used on such systems to indicate how
 a script should be executed.  This launcher allows the same facilities to be
-using with Python scripts on Windows and the examples above demonstrate their
+used with Python scripts on Windows and the examples above demonstrate their
 use.
 
 To allow shebang lines in Python scripts to be portable between Unix and


### PR DESCRIPTION
The first commit is pretty straightforward, the second one is actually

```diff
diff --git a/Doc/using/windows.rst b/Doc/using/windows.rst
index 68687e9f3e..c558214025 100644
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -550,9 +550,9 @@ Shebang Lines

If the first line of a script file starts with ``#!``, it is known as a
"shebang" line.  Linux and other Unix like operating systems have native
support for such lines and[-they-] are commonly used on such systems to indicate how
a script should be executed.  This launcher allows the same facilities to be
used with Python scripts on Windows and the examples above demonstrate their
use.

To allow shebang lines in Python scripts to be portable between Unix and
```

plus reindentation.