### PR TITLE
bpo-30193: Allow to load buffer objects with json.loads()

### DIFF
--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -1,3 +1,4 @@
+import array
 import decimal
 from io import StringIO
 from collections import OrderedDict
@@ -19,6 +20,15 @@ class TestDecode:
         self.assertEqual(self.loads('{}'), {})
         self.assertEqual(self.loads('[]'), [])
         self.assertEqual(self.loads('""'), "")
+
+    def test_memoryview(self):
+        data = memoryview(b'{"key": "val"}')
+        self.assertEqual(self.loads(data), {"key": "val"})
+
+    def test_buffer(self):
+        data = array.array('B')
+        data.frombytes(b'{"key": "val"}')
+        self.assertEqual(self.loads(data), {"key": "val"})
 
     def test_object_pairs_hook(self):
         s = '{"xkd":1, "kcw":2, "art":3, "hxm":4, "qrt":5, "pad":6, "hoy":7}'

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -317,6 +317,8 @@ Extension Modules
 Library
 -------
 
+- bpo-30193: Allow to load buffer objects with ``json.loads()``
+
 - bpo-30101: Add support for curses.A_ITALIC.
 
 - bpo-29822: inspect.isabstract() now works during __init_subclass__.  Patch


### PR DESCRIPTION
it is not possible to load buffer object with json.loads()