### PR TITLE
[2.7] bpo-27726: Fix "make tags" command

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1365,10 +1365,10 @@ autoconf:
 # Create a tags file for vi
 tags::
 	cd $(srcdir); \
-	ctags -w -t Include/*.h; \
-	for i in $(SRCDIRS); do ctags -w -t -a $$i/*.[ch]; \
+	ctags -w Include/*.h; \
+	for i in $(SRCDIRS); do ctags -f tags -w -a $$i/*.[ch]; \
 	done; \
-	sort -o tags tags
+	LC_ALL=C sort -o tags tags
 
 # Create a tags file for GNU Emacs
 TAGS::

--- a/configure
+++ b/configure
@@ -15028,7 +15028,7 @@ do
 done
 
 
-SRCDIRS="Parser Grammar Objects Python Modules Mac"
+SRCDIRS="Parser Objects Python Modules"
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for build directories" >&5
 $as_echo_n "checking for build directories... " >&6; }
 for dir in $SRCDIRS; do

--- a/configure.ac
+++ b/configure.ac
@@ -4729,7 +4729,7 @@ do
 done
 
 AC_SUBST(SRCDIRS)
-SRCDIRS="Parser Grammar Objects Python Modules Mac"
+SRCDIRS="Parser Objects Python Modules"
 AC_MSG_CHECKING(for build directories)
 for dir in $SRCDIRS; do
     if test ! -d $dir; then


### PR DESCRIPTION
Backport enhancements from master, commits:

* 9c4bfa6669e220efdd379b9f8e7db32bb4e25e72: "make tags": remove -t
  option of ctags. The option was kept for backward compatibility,
  but it was completly removed recently. Patch written by Stéphane
  Wirtel.
* cf0ac6a71ae51249a05521f49c1a0fabbb948488: Fix "make tags": set
  locale to C to call sort
* 8a543c0bc7347d5b333f334d157bf4a7cd33c14a: `make tags` fixes (GH-717)