### PR TITLE
bpo-30052: Always regenerate cross-references

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -159,15 +159,20 @@ serve:
 	../Tools/scripts/serve.py build/html
 
 # Targets for daily automated doc build
+# By default, Sphinx only rebuilds pages where the page content has changed.
+# This means it doesn't always pick up changes to preferred link targets, etc
+# To ensure such changes are picked up, we build the published docs with
+# `-E` (to ignore the cached environment) and `-a` (to ignore already existing
+# output files)
 
 # for development releases: always build
 autobuild-dev:
-	make dist SPHINXOPTS='$(SPHINXOPTS) -A daily=1 -A versionswitcher=1'
+	make dist SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1 -A versionswitcher=1'
 	-make suspicious
 
 # for quick rebuilds (HTML only)
 autobuild-dev-html:
-	make html SPHINXOPTS='$(SPHINXOPTS) -A daily=1 -A versionswitcher=1'
+	make html SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1 -A versionswitcher=1'
 
 # for stable releases: only build if not in pre-release stage (alpha, beta)
 # release candidate downloads are okay, since the stable tree can be in that stage

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -984,6 +984,15 @@ C API
 Documentation
 -------------
 
+- Issue #30052: the link targets for ``:func:\`bytes\``` and
+  ``:func:\`bytearray\``` are now their respective type definitions, rather
+  than the corresponding builtin function entries. Use ``:ref:\`func-bytes\```
+  and ``:ref:\`func-bytes\``` to reference the latter.
+
+  In order to ensure this and future cross-reference updates are applied
+  automatically, the daily documentation builds now disable the default
+  output caching features in Sphinx.
+
 - bpo-26985: Add missing info of code object in inspect documentation.
 
 - bpo-19824, bpo-20314, bpo-12518: Improve the documentation for, and links

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -984,10 +984,10 @@ C API
 Documentation
 -------------
 
-- Issue #30052: the link targets for ``:func:\`bytes\``` and
-  ``:func:\`bytearray\``` are now their respective type definitions, rather
-  than the corresponding builtin function entries. Use ``:ref:\`func-bytes\```
-  and ``:ref:\`func-bytes\``` to reference the latter.
+- Issue #30052: the link targets for :func:`bytes` and
+  :func:`bytearray` are now their respective type definitions, rather
+  than the corresponding builtin function entries. Use :ref:`bytes <func-bytes>`
+  and :ref:`bytearray <func-bytearray>` to reference the latter.
 
   In order to ensure this and future cross-reference updates are applied
   automatically, the daily documentation builds now disable the default


### PR DESCRIPTION
The patch for bpo-30052 changed the preferred link target
for :func:`bytes` and :func`bytearray` references to be the
respective type definitions rather than the corresponding
builtin function entries.

This patch changes the daily documentation builds to disable
the output caching in Sphinx, in order to ensure that
cross-reference changes like this one are reliably picked
up and applied automatically after merging.