### PR TITLE
bpo-30104: Compile dtoa.c without strict aliasing

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -107,6 +107,8 @@ ARFLAGS=	@ARFLAGS@
 CFLAGSFORSHARED=@CFLAGSFORSHARED@
 # C flags used for building the interpreter object files
 PY_CORE_CFLAGS=	$(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE
+# Strict or non-strict aliasing flags used to compile dtoa.c, see above
+CFLAGS_ALIASING=@CFLAGS_ALIASING@
 
 
 # Machine-dependent subdirectories
@@ -1535,6 +1537,13 @@ config.status:	$(srcdir)/configure
 # Some make's put the object file in the current directory
 .c.o:
 	$(CC) -c $(PY_CORE_CFLAGS) -o $@ $<
+
+# bpo-30104: dtoa.c uses union to cast double to unsigned long[2]. clang 4.0
+# with -O2 or higher and strict aliasing miscompiles the ratio() function
+# causing rounding issues. Compile dtoa.c using -fno-strict-aliasing on clang.
+# https://bugs.llvm.org//show_bug.cgi?id=31928
+Python/dtoa.o: Python/dtoa.c
+	$(CC) -c $(PY_CORE_CFLAGS) $(CFLAGS_ALIASING) -o $@ $<
 
 # Run reindent on the library
 reindent:

--- a/configure
+++ b/configure
@@ -668,6 +668,7 @@ OTHER_LIBTOOL_OPT
 UNIVERSAL_ARCH_FLAGS
 CFLAGS_NODIST
 BASECFLAGS
+CFLAGS_ALIASING
 OPT
 LLVM_PROF_FOUND
 target_os
@@ -6829,13 +6830,7 @@ then
         then
             # Clang also needs -fwrapv
             WRAP="-fwrapv"
-
-            # bpo-30104: Python/dtoa.c requires to be build with
-            # -fno-strict-aliasing to fix compiler issue on the
-            # double/ULong[2] union using clang 4.0 and optimization level
-            # -O2 or higher
-            # https://bugs.llvm.org//show_bug.cgi?id=31928
-            ALIASING="-fno-strict-aliasing"
+            CFLAGS_ALIASING="-fno-strict-aliasing"
         fi
 
 	case $ac_cv_prog_cc_g in
@@ -6857,7 +6852,7 @@ then
 	    ;;
 	esac
 
-	OPT="$OPT $STRICT_PROTO $ALIASING"
+	OPT="$OPT $STRICT_PROTO"
 
 	case $ac_sys_system in
 	    SCO_SV*) OPT="$OPT -m486 -DSCO5"

--- a/configure.ac
+++ b/configure.ac
@@ -1440,6 +1440,7 @@ esac
 # tweak OPT based on compiler and platform, only if the user didn't set
 # it on the command line
 AC_SUBST(OPT)
+AC_SUBST(CFLAGS_ALIASING)
 if test "${OPT-unset}" = "unset"
 then
     case $GCC in
@@ -1469,13 +1470,9 @@ then
         then
             # Clang also needs -fwrapv
             WRAP="-fwrapv"
-
-            # bpo-30104: Python/dtoa.c requires to be build with
-            # -fno-strict-aliasing to fix compiler issue on the
-            # double/ULong[2] union using clang 4.0 and optimization level
-            # -O2 or higher
-            # https://bugs.llvm.org//show_bug.cgi?id=31928
-            ALIASING="-fno-strict-aliasing"
+            # bpo-30104: disable strict aliasing to compile correctly dtoa.c,
+            # see Makefile.pre.in for more information
+            CFLAGS_ALIASING="-fno-strict-aliasing"
         fi
 
 	case $ac_cv_prog_cc_g in
@@ -1497,7 +1494,7 @@ then
 	    ;;
 	esac
 
-	OPT="$OPT $STRICT_PROTO $ALIASING"
+	OPT="$OPT $STRICT_PROTO"
 
 	case $ac_sys_system in
 	    SCO_SV*) OPT="$OPT -m486 -DSCO5"


### PR DESCRIPTION
dtoa.c uses union to cast double to unsigned long[2]. clang 4.0 with
-O2 or higher and strict aliasing miscompiles the ratio() function
causing rounding issues. Always disable strict aliasing on dtoa.c to
prevent any risk of bug caused by optimizations.