### PR TITLE
bpo-27377: Add socket.fdtype()

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -874,6 +874,24 @@ The :mod:`socket` module also offers various network-related services:
    .. versionadded:: 3.3
 
 
+.. function:: fdtype(fd)
+
+   Get socket information from a file descriptor.  The return value
+   is a 3-tuple with the following structure:
+
+   ``(family, type, proto)``
+
+   The values of *family*, *type*, *proto* are all integers and are
+   meant to be passed to the :func:`.socket` function.  If the file
+   descriptor is not a socket, :exc:`OSError` is raised.  On some
+   platforms, determining the protocol is not possible and in those
+   cases it is returned as zero.
+
+   Availability: Unix
+
+   .. versionadded:: 3.7
+
+
 .. _socket-objects:
 
 Socket Objects

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -24,6 +24,7 @@ inet_aton() -- convert IP addr string (123.45.67.89) to 32-bit packed format
 inet_ntoa() -- convert 32-bit packed format IP to string (123.45.67.89)
 socket.getdefaulttimeout() -- get the default timeout value
 socket.setdefaulttimeout() -- set the default timeout value
+fdtype() -- get (family, type, protocol) from a socket file descriptor [*]
 create_connection() -- connects to an address, with an optional timeout and
                        optional source address.
 
@@ -459,6 +460,19 @@ def fromfd(fd, family, type, proto=0):
     """
     nfd = dup(fd)
     return socket(family, type, proto, nfd)
+
+if hasattr(_socket, 'fdtype'):
+    def fdtype(fd):
+        """fdtype(fd) -> (family, type, proto)
+
+        Return (family, type, proto) for a socket given a file descriptor.
+        Raises OSError if the file descriptor is not a socket.
+        """
+        family, type, proto = _socket.fdtype(fd)
+        return (_intenum_converter(family, AddressFamily),
+                _intenum_converter(type, SocketKind),
+                proto)
+    __all__.append('fdtype')
 
 if hasattr(_socket.socket, "share"):
     def fromshare(info):

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -5470,6 +5470,61 @@ AF_UNIX if defined on the platform; otherwise, the default is AF_INET.");
 #endif /* HAVE_SOCKETPAIR */
 
 
+/* socket.fdtype() function */
+
+#if defined(SO_TYPE) && !defined(MS_WINDOWS)
+/* set if we can implement fdtype().  On Windows, getsockname() fails with
+   error 10022.  There may be other platforms that have SO_TYPE but also
+   don't provide the necessary functionality. In those cases the #if above
+   may need tweaking. */
+#define HAVE_FDTYPE
+#endif
+
+#ifdef HAVE_FDTYPE
+static PyObject *
+socket_fdtype(PyObject *self, PyObject *fdobj)
+{
+    SOCKET_T fd;
+    int sock_type;
+    struct sockaddr sa;
+    socklen_t l;
+    int protocol;
+
+    fd = PyLong_AsSocket_t(fdobj);
+    if (fd == (SOCKET_T)(-1) && PyErr_Occurred())
+        return NULL;
+
+    l = sizeof(sock_type);
+    if (getsockopt(fd, SOL_SOCKET, SO_TYPE, &sock_type, &l) < 0) {
+        return set_error();
+    }
+
+    l = sizeof(sa);
+    if (getsockname(fd, &sa, &l) < 0) {
+        return set_error();
+    }
+#ifdef SO_PROTOCOL
+    l = sizeof(protocol);
+    if (getsockopt(fd, SOL_SOCKET, SO_PROTOCOL, &protocol, &l) < 0) {
+        return set_error();
+    }
+#else
+    protocol = 0;
+#endif
+    return Py_BuildValue("iii",
+                         sa.sa_family,
+                         sock_type,
+                         protocol);
+}
+
+PyDoc_STRVAR(fdtype_doc,
+"fdtype(integer) -> (family, type, protocol)\n\
+\n\
+Return the family, type and protocol for socket given a file descriptor.\
+");
+#endif /* HAVE_FDTYPE */
+
+
 static PyObject *
 socket_ntohs(PyObject *self, PyObject *args)
 {
@@ -6381,6 +6436,10 @@ static PyMethodDef socket_methods[] = {
 #ifdef HAVE_SOCKETPAIR
     {"socketpair",              socket_socketpair,
      METH_VARARGS, socketpair_doc},
+#endif
+#ifdef HAVE_FDTYPE
+    {"fdtype",                 socket_fdtype,
+     METH_O, fdtype_doc},
 #endif
     {"ntohs",                   socket_ntohs,
      METH_VARARGS, ntohs_doc},


### PR DESCRIPTION
This is a recreation of pull request #1333 as there seems no way to move the source branch into my own repo.  I have removed the redundant definitions as pointed out by @tiran.  I could maybe be convinced that socket.socket() get this functionality as suggested.

Comment from @tiran copied here::

>   I'm -1 on fromfd2. We shouldn't introduce yet another function and bloat the API even further. Instead 
>  let's fix the underlying bug and make socket.socket(fileno=fd) detect the socket values, see 
>  https://bugs.python.org/issue28134
