### PR TITLE
bpo-30183: Fixes HP-UX cc compilation error in pytime.c

### DIFF
--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -693,6 +693,27 @@ pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
         info->adjustable = 0;
     }
 
+#elif defined(__hpux)
+    hrtime_t time;
+
+    time = gethrtime();
+    if (time == -1) {
+        if (raise) {
+            PyErr_SetFromErrno(PyExc_OSError);
+            return -1;
+        }
+        return -1;
+    }
+
+    *tp = time;
+
+    if (info) {
+        info->implementation = "gethrtime()";
+        info->resolution = 1e-9;
+        info->monotonic = 1;
+        info->adjustable = 0;
+    }
+
 #else
     struct timespec ts;
 #ifdef CLOCK_HIGHRES

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -700,7 +700,6 @@ pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
     if (time == -1) {
         if (raise) {
             PyErr_SetFromErrno(PyExc_OSError);
-            return -1;
         }
         return -1;
     }


### PR DESCRIPTION
HP-UX does not support the CLOCK_MONOTONIC identifier, and will fail to
compile:

    "Python/pytime.c", line 723: error #2020: identifier
    "CLOCK_MONOTONIC" is undefined
          const clockid_t clk_id = CLOCK_MONOTONIC;

Add a new section for __hpux that calls `gethrtime()` instead of
`clock_gettime()`.