### PR TITLE
bpo-30207: Rename test.test_support to test.support.

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -194,8 +194,9 @@ tests.
 
 .. note::
 
-   The :mod:`test.support` module has been renamed to :mod:`test.support`
-   in Python 3.x and 2.7.13.
+   The :mod:`test.test_support` module has been renamed to :mod:`test.support`
+   in Python 3.x and 2.7.13.  The name ``test.test_support`` has been retained
+   as an alias in 2.7.
 
 The :mod:`test.support` module provides support for Python's regression
 tests.

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -15,8 +15,8 @@
 
 
 The :mod:`test` package contains all regression tests for Python as well as the
-modules :mod:`test.test_support` and :mod:`test.regrtest`.
-:mod:`test.test_support` is used to enhance your tests while
+modules :mod:`test.support` and :mod:`test.regrtest`.
+:mod:`test.support` is used to enhance your tests while
 :mod:`test.regrtest` drives the testing suite.
 
 Each module in the :mod:`test` package whose name starts with ``test_`` is a
@@ -54,7 +54,7 @@ stated.
 A basic boilerplate is often used::
 
    import unittest
-   from test import test_support
+   from test import support
 
    class MyTestCase1(unittest.TestCase):
 
@@ -82,10 +82,10 @@ A basic boilerplate is often used::
    ... more test classes ...
 
    def test_main():
-       test_support.run_unittest(MyTestCase1,
-                                 MyTestCase2,
-                                 ... list other tests ...
-                                )
+       support.run_unittest(MyTestCase1,
+                            MyTestCase2,
+                            ... list other tests ...
+                            )
 
    if __name__ == '__main__':
        test_main()
@@ -186,18 +186,18 @@ top-level directory where Python was built. On Windows, executing
 tests.
 
 
-:mod:`test.test_support` --- Utility functions for tests
-========================================================
+:mod:`test.support` --- Utility functions for tests
+===================================================
 
-.. module:: test.test_support
+.. module:: test.support
    :synopsis: Support for Python regression tests.
 
 .. note::
 
-   The :mod:`test.test_support` module has been renamed to :mod:`test.support`
-   in Python 3.x.
+   The :mod:`test.support` module has been renamed to :mod:`test.support`
+   in Python 3.x and 2.7.13.
 
-The :mod:`test.test_support` module provides support for Python's regression
+The :mod:`test.support` module provides support for Python's regression
 tests.
 
 This module defines the following exceptions:
@@ -216,7 +216,7 @@ This module defines the following exceptions:
    network connection) is not available. Raised by the :func:`requires`
    function.
 
-The :mod:`test.test_support` module defines the following constants:
+The :mod:`test.support` module defines the following constants:
 
 
 .. data:: verbose
@@ -241,7 +241,7 @@ The :mod:`test.test_support` module defines the following constants:
    Set to a name that is safe to use as the name of a temporary file.  Any
    temporary file that is created should be closed and unlinked (removed).
 
-The :mod:`test.test_support` module defines the following functions:
+The :mod:`test.support` module defines the following functions:
 
 
 .. function:: forget(module_name)
@@ -284,7 +284,7 @@ The :mod:`test.test_support` module defines the following functions:
    following :func:`test_main` function::
 
       def test_main():
-          test_support.run_unittest(__name__)
+          support.run_unittest(__name__)
 
    This will run all tests defined in the named module.
 
@@ -433,7 +433,7 @@ The :mod:`test.test_support` module defines the following functions:
    .. versionadded:: 2.7
 
 
-The :mod:`test.test_support` module defines the following classes:
+The :mod:`test.support` module defines the following classes:
 
 .. class:: TransientResource(exc[, **kwargs])
 

--- a/Lib/test/script_helper.py
+++ b/Lib/test/script_helper.py
@@ -1,0 +1,1 @@
+from test.support.script_helper import *

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1,7 +1,7 @@
 """Supporting definitions for the Python regression tests."""
 
-if __name__ != 'test.test_support':
-    raise ImportError('test_support must be imported from the test package')
+if __name__ != 'test.support':
+    raise ImportError('test.support must be imported from the test package')
 
 import contextlib
 import errno
@@ -764,8 +764,15 @@ def temp_cwd(name='tempcwd', quiet=False):
         if is_temporary:
             rmtree(name)
 
+# TEST_HOME_DIR refers to the top level directory of the "test" package
+# that contains Python's regression test suite
+TEST_SUPPORT_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_HOME_DIR = os.path.dirname(TEST_SUPPORT_DIR)
 
-def findfile(file, here=__file__, subdir=None):
+# TEST_DATA_DIR is used as a target download location for remote resources
+TEST_DATA_DIR = os.path.join(TEST_HOME_DIR, "data")
+
+def findfile(file, subdir=None):
     """Try to find a file on sys.path and the working directory.  If it is not
     found the argument passed to the function is returned (this does not
     necessarily signal failure; could still be the legitimate path)."""
@@ -773,8 +780,7 @@ def findfile(file, here=__file__, subdir=None):
         return file
     if subdir is not None:
         file = os.path.join(subdir, file)
-    path = sys.path
-    path = [os.path.dirname(here)] + path
+    path = [TEST_HOME_DIR] + sys.path
     for dn in path:
         fn = os.path.join(dn, file)
         if os.path.exists(fn): return fn
@@ -809,7 +815,7 @@ def open_urlresource(url, check=None):
 
     filename = urlparse.urlparse(url)[2].split('/')[-1] # '/': it's URL!
 
-    fn = os.path.join(os.path.dirname(__file__), "data", filename)
+    fn = os.path.join(TEST_DATA_DIR, filename)
 
     def check_valid_file(fn):
         f = open(fn)
@@ -1511,7 +1517,7 @@ def run_doctest(module, verbosity=None):
     """Run doctest on the given module.  Return (#failures, #tests).
 
     If optional argument verbosity is not specified (or is None), pass
-    test_support's belief about verbosity on to doctest.  Else doctest's
+    test.support's belief about verbosity on to doctest.  Else doctest's
     usual behavior is used (it searches sys.argv for -v).
     """
 

--- a/Lib/test/support/script_helper.py
+++ b/Lib/test/support/script_helper.py
@@ -18,7 +18,7 @@ except ImportError:
     # Most of this module can then still be used.
     pass
 
-from test.test_support import strip_python_stderr
+from test.support import strip_python_stderr
 
 # Executing the interpreter in a subprocess
 def _assert_python(expected_success, *args, **env_vars):

--- a/Lib/test/test_compiler.py
+++ b/Lib/test/test_compiler.py
@@ -26,7 +26,7 @@ class CompilerTest(unittest.TestCase):
         # warning: if 'os' or 'test_support' are moved in some other dir,
         # they should be changed here.
         libdir = os.path.dirname(os.__file__)
-        testdir = os.path.dirname(test.test_support.__file__)
+        testdir = test.test_support.TEST_HOME_DIR
 
         for dir in [testdir]:
             for basename in "test_os.py",:

--- a/Lib/test/test_linecache.py
+++ b/Lib/test/test_linecache.py
@@ -3,7 +3,7 @@
 import linecache
 import unittest
 import os.path
-from test import test_support as support
+from test import support
 
 
 FILENAME = linecache.__file__
@@ -11,7 +11,7 @@ INVALID_NAME = '!@$)(!@#_1'
 EMPTY = ''
 TESTS = 'inspect_fodder inspect_fodder2 mapping_tests'
 TESTS = TESTS.split()
-TEST_PATH = os.path.dirname(support.__file__)
+TEST_PATH = support.TEST_HOME_DIR
 MODULES = "linecache abc".split()
 MODULE_PATH = os.path.dirname(FILENAME)
 

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -1,0 +1,3 @@
+import sys
+import test.support
+sys.modules['test.test_support'] = test.support

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -144,11 +144,11 @@ Build
 Tests
 -----
 
-- bpo-30207: The test.test_support module was converted into package and
-  renamed to test.support.  The test.script_helper module was moved into
-  the test.support package.  Names test.test_support and
-  test.script_helper are left as aliases to test.support and
-  test.support.script_helper.
+- bpo-30207: To simplify backports from Python 3, the test.test_support
+  module was converted into a package and renamed to test.support.  The
+  test.script_helper module was moved into the test.support package.
+  Names test.test_support and test.script_helper are left as aliases to
+  test.support and test.support.script_helper.
 
 - bpo-30197: Enhanced function swap_attr() in the test.test_support module.
   It now works when delete replaced attribute inside the with statement.  The

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -144,6 +144,12 @@ Build
 Tests
 -----
 
+- bpo-30207: The test.test_support module was converted into package and
+  renamed to test.support.  The test.script_helper module was moved into
+  the test.support package.  Names test.test_support and
+  test.script_helper are left as aliases to test.support and
+  test.support.script_helper.
+
 - bpo-30197: Enhanced function swap_attr() in the test.test_support module.
   It now works when delete replaced attribute inside the with statement.  The
   old value of the attribute (or None if it doesn't exist) now will be


### PR DESCRIPTION
The test.test_support module was converted into package and renamed
to test.support.  The test.script_helper module was moved into
the test.support package.  Names test.test_support and
test.script_helper are left as aliases to test.support and
test.support.script_helper.