### PR TITLE
bpo-26143: IDLE: Ensure IDLE's stdlib imports are from the stdlib

### DIFF
--- a/Lib/idlelib/idle_test/test_importpath.py
+++ b/Lib/idlelib/idle_test/test_importpath.py
@@ -41,7 +41,7 @@ class ImportStdlibRandomConflicTest(unittest.TestCase):
 
             # Import and check
             import random
-            self.assertNotEqual(os.path.dirname(random.__file__), tmpdir)
+            self.assertNotEqual(os.path.dirname(random.__file__), tmpdir.name)
 
     def test_import_random_should_import_locals(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -55,7 +55,7 @@ class ImportStdlibRandomConflicTest(unittest.TestCase):
 
             # Import and check
             import random
-            self.assertEqual(os.path.dirname(random.__file__), tmpdir)
+            self.assertEqual(os.path.dirname(random.__file__), tmpdir.name)
 
 
 class ImportStdlibCtypesConflicTest(unittest.TestCase):
@@ -93,7 +93,7 @@ class ImportStdlibCtypesConflicTest(unittest.TestCase):
 
             # Import and check
             import ctypes
-            self.assertNotEqual(os.path.dirname(ctypes.__file__), tmpdir)
+            self.assertNotEqual(os.path.dirname(ctypes.__file__), tmpdir.name)
 
     def test_import_ctypes_should_import_locals(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -107,7 +107,7 @@ class ImportStdlibCtypesConflicTest(unittest.TestCase):
 
             # Import and check
             import ctypes
-            self.assertEqual(os.path.dirname(ctypes.__file__), tmpdir)
+            self.assertEqual(os.path.dirname(ctypes.__file__), tmpdir.name)
 
 
 class ImportLocalsFooTest(unittest.TestCase):
@@ -142,7 +142,7 @@ class ImportLocalsFooTest(unittest.TestCase):
 
             # Import and check
             import foo
-            self.assertEqual(os.path.dirname(foo.__file__), tmpdir)
+            self.assertEqual(os.path.dirname(foo.__file__), tmpdir.name)
 
     def test_import_foo_should_failed(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/Lib/idlelib/idle_test/test_importpath.py
+++ b/Lib/idlelib/idle_test/test_importpath.py
@@ -41,7 +41,7 @@ class ImportStdlibRandomConflicTest(unittest.TestCase):
 
             # Import and check
             import random
-            self.assertNotEqual(os.path.dirname(random.__file__), tmpdir.name)
+            self.assertNotEqual(os.path.dirname(random.__file__), tmpdir)
 
     def test_import_random_should_import_locals(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -55,7 +55,7 @@ class ImportStdlibRandomConflicTest(unittest.TestCase):
 
             # Import and check
             import random
-            self.assertEqual(os.path.dirname(random.__file__), tmpdir.name)
+            self.assertEqual(os.path.dirname(random.__file__), tmpdir)
 
 
 class ImportStdlibCtypesConflicTest(unittest.TestCase):
@@ -93,7 +93,7 @@ class ImportStdlibCtypesConflicTest(unittest.TestCase):
 
             # Import and check
             import ctypes
-            self.assertNotEqual(os.path.dirname(ctypes.__file__), tmpdir.name)
+            self.assertNotEqual(os.path.dirname(ctypes.__file__), tmpdir)
 
     def test_import_ctypes_should_import_locals(self):
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -107,7 +107,7 @@ class ImportStdlibCtypesConflicTest(unittest.TestCase):
 
             # Import and check
             import ctypes
-            self.assertEqual(os.path.dirname(ctypes.__file__), tmpdir.name)
+            self.assertEqual(os.path.dirname(ctypes.__file__), tmpdir)
 
 
 class ImportLocalsFooTest(unittest.TestCase):
@@ -142,7 +142,7 @@ class ImportLocalsFooTest(unittest.TestCase):
 
             # Import and check
             import foo
-            self.assertEqual(os.path.dirname(foo.__file__), tmpdir.name)
+            self.assertEqual(os.path.dirname(foo.__file__), tmpdir)
 
     def test_import_foo_should_failed(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/Lib/idlelib/idle_test/test_importpath.py
+++ b/Lib/idlelib/idle_test/test_importpath.py
@@ -1,0 +1,166 @@
+'''Test idlelib.importpath
+'''
+import sys
+import os
+import unittest
+import tempfile
+from idlelib import importpath
+
+
+class ImportStdlibRandomConflicTest(unittest.TestCase):
+    def setUp(self):
+        # Need to restore the current work directory
+        self.cwd = os.getcwd()
+
+        # Remove random from sys.modules
+        if 'random' in sys.modules:
+            sys.modules.pop('random')
+
+        if sys.path[0] != '':
+            sys.path.insert(0, '')
+
+    def tearDown(self):
+        # Restore cwd
+        os.chdir(self.cwd)
+
+        # Restore sys.path
+        if sys.path[0] != '':
+            sys.path.insert(0, '')
+
+    def test_import_random_should_import_stdlib(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create an empty random.py
+            random_py = os.path.join(tmpdir, 'random.py')
+            with open(random_py, 'w'):
+                pass
+
+            # Change dir to tempdir
+            os.chdir(tmpdir)
+            # Patch by _fix_import_path
+            importpath._fix_import_path()
+
+            # Import and check
+            import random
+            self.assertNotEqual(os.path.dirname(random.__file__), tmpdir)
+
+    def test_import_random_should_import_locals(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create an empty random.py
+            random_py = os.path.join(tmpdir, 'random.py')
+            with open(random_py, 'w'):
+                pass
+
+            # Change dir to tempdir
+            os.chdir(tmpdir)
+
+            # Import and check
+            import random
+            self.assertEqual(os.path.dirname(random.__file__), tmpdir)
+
+
+class ImportStdlibCtypesConflicTest(unittest.TestCase):
+    def setUp(self):
+        # Need to restore the current work directory
+        self.cwd = os.getcwd()
+
+        # Remove ctypes from sys.modules
+        if 'ctypes' in sys.modules:
+            sys.modules.pop('ctypes')
+
+        if sys.path[0] != '':
+            sys.path.insert(0, '')
+
+    def tearDown(self):
+        # Restore cwd
+        os.chdir(self.cwd)
+
+        # Restore sys.path
+        if sys.path[0] != '':
+            sys.path.insert(0, '')
+
+    def test_import_ctypes_should_import_stdlib(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create an empty ctypes.py
+            ctypes_py = os.path.join(tmpdir, 'ctypes.py')
+            with open(ctypes_py, 'w'):
+                pass
+
+            # Change dir to tempdir
+            os.chdir(tmpdir)
+
+            # Patch by _fix_import_path
+            importpath._fix_import_path()
+
+            # Import and check
+            import ctypes
+            self.assertNotEqual(os.path.dirname(ctypes.__file__), tmpdir)
+
+    def test_import_ctypes_should_import_locals(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create an empty ctypes.py
+            ctypes_py = os.path.join(tmpdir, 'ctypes.py')
+            with open(ctypes_py, 'w'):
+                pass
+
+            # Change dir to tempdir
+            os.chdir(tmpdir)
+
+            # Import and check
+            import ctypes
+            self.assertEqual(os.path.dirname(ctypes.__file__), tmpdir)
+
+
+class ImportLocalsFooTest(unittest.TestCase):
+    def setUp(self):
+        # Need to restore the current work directory
+        self.cwd = os.getcwd()
+
+        # Remove foo from sys.modules
+        if 'foo' in sys.modules:
+            sys.modules.pop('foo')
+
+        if sys.path[0] != '':
+            sys.path.insert(0, '')
+
+    def tearDown(self):
+        # Restore cwd
+        os.chdir(self.cwd)
+
+        # Restore sys.path
+        if sys.path[0] != '':
+            sys.path.insert(0, '')
+
+    def test_import_foo(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create an empty foo.py
+            foo_py = os.path.join(tmpdir, 'foo.py')
+            with open(foo_py, 'w'):
+                pass
+
+            # Change dir to tempdir
+            os.chdir(tmpdir)
+
+            # Import and check
+            import foo
+            self.assertEqual(os.path.dirname(foo.__file__), tmpdir)
+
+    def test_import_foo_should_failed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create an empty foo.py
+            foo_py = os.path.join(tmpdir, 'foo.py')
+            with open(foo_py, 'w'):
+                pass
+
+            # Change dir to tempdir
+            os.chdir(tmpdir)
+
+            # Patch by _fix_import_path
+            importpath._fix_import_path()
+
+            # Import and check
+            with self.assertRaises(ModuleNotFoundError):
+                import foo
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Lib/idlelib/importpath.py
+++ b/Lib/idlelib/importpath.py
@@ -1,0 +1,13 @@
+import sys
+
+
+def _fix_import_path():
+    """This will remove the local inport path ''
+
+    This will remove the local import path '', now using at idlelib/pyshell.py
+    and idlelib/run.py. When running with pyshell.main(), it will add back the
+    local import path when dealing with args. So don't need to worry about local
+    import problem.
+    """
+    if '' in sys.path:
+        sys.path.remove('')

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -2,6 +2,9 @@
 
 import sys
 
+from idlelib.importpath import _fix_import_path
+_fix_import_path()
+
 try:
     from tkinter import *
 except ImportError:

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -1,3 +1,6 @@
+from idlelib.importpath import _fix_import_path
+_fix_import_path()
+
 import io
 import linecache
 import queue


### PR DESCRIPTION
Add idlelib.importpath._fix_import_path function to handle
local import problem. The local import path will be recover
when at the end of the argparse part.