### PR TITLE
bpo-28315: Fixing wrong documentation

### DIFF
--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -124,7 +124,7 @@ our objects and in some error messages, for example::
 
    >>> "" + noddy.new_noddy()
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    TypeError: cannot add type "noddy.Noddy" to string
 
 Note that the name is a dotted name that includes both the module name and the

--- a/Doc/howto/functional.rst
+++ b/Doc/howto/functional.rst
@@ -210,7 +210,7 @@ You can experiment with the iteration interface manually:
     3
     >>> next(it)
     Traceback (most recent call last):
-      File "<stdin>", line 1, in ?
+      File "<stdin>", line 1, in <module>
     StopIteration
     >>>
 
@@ -474,7 +474,7 @@ Here's a sample usage of the ``generate_ints()`` generator:
     2
     >>> next(gen)
     Traceback (most recent call last):
-      File "stdin", line 1, in ?
+      File "stdin", line 1, in <module>
       File "stdin", line 2, in generate_ints
     StopIteration
 
@@ -577,7 +577,7 @@ And here's an example of changing the counter:
     9
     >>> next(it)  #doctest: +SKIP
     Traceback (most recent call last):
-      File "t.py", line 15, in ?
+      File "t.py", line 15, in <module>
         it.next()
     StopIteration
 

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -97,7 +97,7 @@ Functions are accessed as attributes of dll objects::
    <_FuncPtr object at 0x...>
    >>> print(windll.kernel32.MyOwnFunction)     # doctest: +WINDOWS
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
      File "ctypes.py", line 239, in __getattr__
        func = _StdcallFuncPtr(name, self)
    AttributeError: function 'MyOwnFunction' not found
@@ -135,7 +135,7 @@ functions can be accessed by indexing the dll object with the ordinal number::
    <_FuncPtr object at 0x...>
    >>> cdll.kernel32[0]  # doctest: +WINDOWS
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
      File "ctypes.py", line 310, in __getitem__
        func = _StdcallFuncPtr(name, self)
    AttributeError: function ordinal 0 not found
@@ -168,11 +168,11 @@ although an error is raised the function *has* been called::
 
    >>> windll.kernel32.GetModuleHandleA()      # doctest: +WINDOWS
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ValueError: Procedure probably called with not enough arguments (4 bytes missing)
    >>> windll.kernel32.GetModuleHandleA(0, 0)  # doctest: +WINDOWS
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ValueError: Procedure probably called with too many arguments (4 bytes in excess)
    >>>
 
@@ -181,13 +181,13 @@ The same exception is raised when you call an ``stdcall`` function with the
 
    >>> cdll.kernel32.GetModuleHandleA(None)  # doctest: +WINDOWS
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ValueError: Procedure probably called with not enough arguments (4 bytes missing)
    >>>
 
    >>> windll.msvcrt.printf(b"spam")  # doctest: +WINDOWS
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ValueError: Procedure probably called with too many arguments (4 bytes in excess)
    >>>
 
@@ -200,7 +200,7 @@ argument values::
 
    >>> windll.kernel32.GetModuleHandleA(32)  # doctest: +WINDOWS
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    OSError: exception: access violation reading 0x00000020
    >>>
 
@@ -373,7 +373,7 @@ from within *IDLE* or *PythonWin*::
    19
    >>> printf(b"%f bottles of beer\n", 42.5)
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ArgumentError: argument 2: exceptions.TypeError: Don't know how to convert parameter 2
    >>>
 
@@ -436,7 +436,7 @@ prototype for a C function), and tries to convert the arguments to valid types::
 
    >>> printf(b"%d %d %d", 1, 2, 3)
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ArgumentError: argument 2: exceptions.TypeError: wrong type
    >>> printf(b"%s %d %f\n", b"X", 2, 3)
    X 2 3.000000
@@ -486,7 +486,7 @@ single character Python bytes object into a C char::
    'def'
    >>> strchr(b"abcdef", b"def")
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ArgumentError: argument 2: exceptions.TypeError: one character string expected
    >>> print(strchr(b"abcdef", b"x"))
    None
@@ -512,7 +512,7 @@ useful to check for error return values and automatically raise an exception::
    486539264
    >>> GetModuleHandle("something silly")  # doctest: +WINDOWS
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
      File "<stdin>", line 3, in ValidHandle
    OSError: [Errno 126] The specified module could not be found.
    >>>
@@ -583,7 +583,7 @@ Here is a simple example of a POINT structure, which contains two integers named
    0 5
    >>> POINT(1, 2, 3)
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ValueError: too many initializers
    >>>
 
@@ -786,7 +786,7 @@ new type::
    <class 'ctypes.LP_c_long'>
    >>> PI(42)
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    TypeError: expected c_long instead of int
    >>> PI(c_int(42))
    <ctypes.LP_c_long object at 0x...>
@@ -862,7 +862,7 @@ but not instances of other types::
 
    >>> bar.values = (c_byte * 4)()
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    TypeError: incompatible types, c_byte_Array_4 instance instead of LP_c_long instance
    >>>
 
@@ -913,7 +913,7 @@ work::
    ...                 ("next", POINTER(cell))]
    ...
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
      File "<stdin>", line 2, in cell
    NameError: name 'cell' is not defined
    >>>

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -408,7 +408,7 @@ Simple example::
 
    >>> [1, 2, 3].remove(42)
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ValueError: list.remove(x): x not in list
 
 That doctest succeeds if :exc:`ValueError` is raised, with the ``list.remove(x):
@@ -432,7 +432,7 @@ multi-line detail::
 
    >>> raise ValueError('multi\n    line\ndetail')
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ValueError: multi
        line
    detail
@@ -591,7 +591,7 @@ doctest decides whether actual output matches an example's expected output:
 
       >>> (1, 2)[3] = 'moo'
       Traceback (most recent call last):
-        File "<stdin>", line 1, in ?
+        File "<stdin>", line 1, in <module>
       TypeError: object doesn't support item assignment
 
    passes under Python 2.3 and later Python versions with the flag specified,

--- a/Doc/library/fpectl.rst
+++ b/Doc/library/fpectl.rst
@@ -89,7 +89,7 @@ The following example demonstrates how to start up and test operation of the
    >>> import math
    >>> math.exp(1000)
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    FloatingPointError: in math_1
 
 

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -76,7 +76,7 @@ The typical usage to inspect a crashed program is::
    >>> import mymodule
    >>> mymodule.test()
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
      File "./mymodule.py", line 4, in test
        test2()
      File "./mymodule.py", line 3, in test2

--- a/Doc/library/unicodedata.rst
+++ b/Doc/library/unicodedata.rst
@@ -158,7 +158,7 @@ Examples:
    9
    >>> unicodedata.decimal('a')
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ValueError: not a decimal
    >>> unicodedata.category('A')  # 'L'etter, 'u'ppercase
    'Lu'

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -905,7 +905,7 @@ keyword arguments (and any ``**expression`` arguments -- see below).  So::
    2 1
    >>> f(a=1, *(2,))
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    TypeError: f() got multiple values for keyword argument 'a'
    >>> f(1, *(2,))
    1 2

--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -784,7 +784,7 @@ using the :func:`next` built-in function; this example shows how it all works::
    'c'
    >>> next(it)
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
        next(it)
    StopIteration
 

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -475,7 +475,7 @@ Here's an example that fails due to this restriction::
    ...
    >>> function(0, a=0)
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    TypeError: function() got multiple values for keyword argument 'a'
 
 When a final formal parameter of the form ``**name`` is present, it receives a

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -261,7 +261,7 @@ it must be parenthesized. ::
    [(0, 0), (1, 1), (2, 4), (3, 9), (4, 16), (5, 25)]
    >>> # the tuple must be parenthesized, otherwise an error is raised
    >>> [x, x**2 for x in range(6)]
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
        [x, x**2 for x in range(6)]
                   ^
    SyntaxError: invalid syntax

--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -362,7 +362,7 @@ attempts to use the file object will automatically fail. ::
    >>> f.close()
    >>> f.read()
    Traceback (most recent call last):
-     File "<stdin>", line 1, in ?
+     File "<stdin>", line 1, in <module>
    ValueError: I/O operation on closed file
 
 It is good practice to use the :keyword:`with` keyword when dealing with file


### PR DESCRIPTION
* **Description:** Fixing wrong documentation which was mentioning 'in ?' but the actual output in master branch gives 'in <module>'.
* **Mailing list discussions:** https://mail.python.org/mailman/private/core-mentorship/2016-October/003662.html
* **BPO:** http://bugs.python.org/issue28315

@Mariatta Please review this PR.