### PR TITLE
[2.7] bpo-30223: Add Lib/test/__main__.py.

### DIFF
--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -185,6 +185,10 @@ top-level directory where Python was built. On Windows, executing
 :program:`rt.bat` from your :file:`PCBuild` directory will run all regression
 tests.
 
+.. versionchanged:: 2.7.14
+   The :mod:`test` package can be run as a script: :program:`python -m test`.
+   This works the same as running the :mod:`test.regrtest` module.
+
 
 :mod:`test.support` --- Utility functions for tests
 ===================================================
@@ -195,7 +199,7 @@ tests.
 .. note::
 
    The :mod:`test.test_support` module has been renamed to :mod:`test.support`
-   in Python 3.x and 2.7.13.  The name ``test.test_support`` has been retained
+   in Python 3.x and 2.7.14.  The name ``test.test_support`` has been retained
    as an alias in 2.7.
 
 The :mod:`test.support` module provides support for Python's regression

--- a/Lib/test/__main__.py
+++ b/Lib/test/__main__.py
@@ -1,0 +1,3 @@
+from test import regrtest
+
+regrtest.main_in_temp_cwd()

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from __future__ import absolute_import
+
 import unittest
 import pickle
 import cPickle

--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -1645,16 +1645,8 @@ class _ExpectedSkips:
         assert self.isvalid()
         return self.expected
 
-if __name__ == '__main__':
-    # findtestdir() gets the dirname out of __file__, so we have to make it
-    # absolute before changing the working directory.
-    # For example __file__ may be relative when running trace or profile.
-    # See issue #9323.
-    __file__ = os.path.abspath(__file__)
-
-    # sanity check
-    assert __file__ == os.path.abspath(sys.argv[0])
-
+def main_in_temp_cwd():
+    """Run main() in a temporary working directory."""
     # When tests are run from the Python build directory, it is best practice
     # to keep the test files in a subfolder.  It eases the cleanup of leftover
     # files using command "make distclean".
@@ -1677,3 +1669,16 @@ if __name__ == '__main__':
     # available from test_support.SAVEDCWD.
     with test_support.temp_cwd(TESTCWD, quiet=True):
         main()
+
+if __name__ == '__main__':
+    # findtestdir() gets the dirname out of __file__, so we have to make it
+    # absolute before changing the working directory.
+    # For example __file__ may be relative when running trace or profile.
+    # See issue #9323.
+    global __file__
+    __file__ = os.path.abspath(__file__)
+
+    # sanity check
+    assert __file__ == os.path.abspath(sys.argv[0])
+
+    main_in_temp_cwd()

--- a/Lib/test/test_memoryio.py
+++ b/Lib/test/test_memoryio.py
@@ -5,6 +5,7 @@ BytesIO -- for bytes
 
 from __future__ import unicode_literals
 from __future__ import print_function
+from __future__ import absolute_import
 
 import unittest
 from test import test_support as support

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -144,6 +144,10 @@ Build
 Tests
 -----
 
+- bpo-30223: To unify running tests in Python 2.7 and Python 3, the test
+  package can be run as a script.  This is equivalent to running the
+  test.regrtest module as a script.
+
 - bpo-30207: To simplify backports from Python 3, the test.test_support
   module was converted into a package and renamed to test.support.  The
   test.script_helper module was moved into the test.support package.


### PR DESCRIPTION
To unify running tests in Python 2.7 and Python 3, the test
package can be run as a script.  This is equivalent to running the
test.regrtest module as a script.