### PR TITLE
bpo-19903: IDLE: Change to inspect.signature for calltips

### DIFF
--- a/Lib/idlelib/calltips.py
+++ b/Lib/idlelib/calltips.py
@@ -136,9 +136,6 @@ def get_argspec(ob):
     argspec = ""
     try:
         ob_call = ob.__call__
-    except AttributeError:
-        argspec = "Object is not callable"
-        return argspec
     except BaseException:
         return argspec
     if isinstance(ob, type):

--- a/Lib/idlelib/calltips.py
+++ b/Lib/idlelib/calltips.py
@@ -151,10 +151,8 @@ def get_argspec(ob):
             argspec = "This function has an invalid method signature"
             return argspec
 
-        if (isinstance(ob, (type, types.MethodType)) or
-                isinstance(ob_call, types.MethodType)):
-            if argspec.startswith("(self,"):
-                argspec = _first_param.sub("", argspec)
+        if isinstance(ob, type):
+            argspec = _first_param.sub("", argspec)
 
     lines = (textwrap.wrap(argspec, _MAX_COLS, subsequent_indent=_INDENT)
             if len(argspec) > _MAX_COLS else [argspec] if argspec else [])

--- a/Lib/idlelib/calltips.py
+++ b/Lib/idlelib/calltips.py
@@ -1,4 +1,4 @@
-b"""calltips.py - An IDLE Extension to Jog Your Memory
+"""calltips.py - An IDLE Extension to Jog Your Memory
 
 Call Tips are floating windows which display function, class, and method
 parameter and docstring information when you type an opening parenthesis, and

--- a/Lib/idlelib/calltips.py
+++ b/Lib/idlelib/calltips.py
@@ -123,6 +123,7 @@ _INDENT = ' '*4  # for wrapped signatures
 _first_param = re.compile(r'(?<=\()\w*\,?\s*')
 _default_callable_argspec = "See source or doc"
 _invalid_method = "invalid method signature"
+_argument_positional = "('/' marks preceding arguments as positional-only)"
 
 
 def get_argspec(ob):
@@ -159,9 +160,8 @@ def get_argspec(ob):
             pass
 
     if '/' in argspec:
-        """Argument Clinic positional-only mark, ignore the result of signature
-        """
-        argspec = ''
+        """Using AC's positional argument should add the explain"""
+        argspec = '\n'.join([argspec, _argument_positional])
     if isinstance(fob, type) and argspec == '()':
         """fob with no argument, use default callable argspec"""
         argspec = _default_callable_argspec

--- a/Lib/idlelib/calltips.py
+++ b/Lib/idlelib/calltips.py
@@ -136,6 +136,9 @@ def get_argspec(ob):
     argspec = ""
     try:
         ob_call = ob.__call__
+    except AttributeError:
+        argspec = "Object is not callable"
+        return argspec
     except BaseException:
         return argspec
     if isinstance(ob, type):
@@ -145,10 +148,16 @@ def get_argspec(ob):
     else:
         fob = ob
     if isinstance(fob, (types.FunctionType, types.MethodType)):
-        argspec = inspect.formatargspec(*inspect.getfullargspec(fob))
+        try:
+            argspec = str(inspect.signature(fob))
+        except ValueError:
+            argspec = "This function has an invalid method signature"
+            return argspec
+
         if (isinstance(ob, (type, types.MethodType)) or
                 isinstance(ob_call, types.MethodType)):
-            argspec = _first_param.sub("", argspec)
+            if argspec.startswith("(self,"):
+                argspec = _first_param.sub("", argspec)
 
     lines = (textwrap.wrap(argspec, _MAX_COLS, subsequent_indent=_INDENT)
             if len(argspec) > _MAX_COLS else [argspec] if argspec else [])

--- a/Lib/idlelib/calltips.py
+++ b/Lib/idlelib/calltips.py
@@ -122,6 +122,7 @@ _MAX_LINES = 5  # enough for bytes
 _INDENT = ' '*4  # for wrapped signatures
 _first_param = re.compile(r'(?<=\()\w*\,?\s*')
 _default_callable_argspec = "See source or doc"
+_invalid_method = "invalid method signature"
 
 
 def get_argspec(ob):

--- a/Lib/idlelib/calltips.py
+++ b/Lib/idlelib/calltips.py
@@ -149,7 +149,7 @@ def get_argspec(ob):
         try:
             argspec = str(inspect.signature(fob))
         except ValueError:
-            argspec = "This function has an invalid method signature"
+            argspec = _invalid_method
             return argspec
 
         if isinstance(ob, type):

--- a/Lib/idlelib/idle_test/test_calltips.py
+++ b/Lib/idlelib/idle_test/test_calltips.py
@@ -54,15 +54,18 @@ class Get_signatureTest(unittest.TestCase):
             self.assertEqual(signature(obj), out)
 
         if List.__doc__ is not None:
-            gtest(List, List.__doc__)
+            gtest(List, '(iterable=(), /)\n' + ct._argument_positional + '\n' +
+                  List.__doc__)
         gtest(list.__new__,
                '(*args, **kwargs)\nCreate and return a new object.  See help(type) for accurate signature.')
         gtest(list.__init__,
+               '(self, /, *args, **kwargs)\n' + ct._argument_positional + '\n' +
                'Initialize self.  See help(type(self)) for accurate signature.')
-        append_doc =  "Append object to the end of the list."
-        gtest(list.append, append_doc)
-        gtest([].append, append_doc)
-        gtest(List.append, append_doc)
+        append_doc = ct._argument_positional + '\n' + "Append object to the end of the list."
+        gtest(list.append, '(self, object, /)\n' + append_doc)
+        gtest(List.append, '(self, object, /)\n' + append_doc)
+        gtest([].append, '(object, /)\n' + append_doc)
+
         gtest(types.MethodType, "method(function, instance)")
         gtest(SB(), default_tip)
         import re

--- a/Lib/idlelib/idle_test/test_calltips.py
+++ b/Lib/idlelib/idle_test/test_calltips.py
@@ -66,6 +66,11 @@ class Get_signatureTest(unittest.TestCase):
         gtest(types.MethodType, "method(function, instance)")
         gtest(SB(), default_tip)
 
+        import re
+        p = re.compile('')
+        gtest(re.sub, '(pattern, repl, string, count=0, flags=0')
+        gtest(p.sub, '(repl, string, count=0)')
+
     def test_signature_wrap(self):
         if textwrap.TextWrapper.__doc__ is not None:
             self.assertEqual(signature(textwrap.TextWrapper), '''\
@@ -142,7 +147,7 @@ bytes() -> empty bytes object''')
         class Test:
             def __call__(*, a): pass
 
-        mtip = "This function has an invalid method signature"
+        mtip = ct._invalid_method
         self.assertEqual(signature(C().m2), mtip)
         self.assertEqual(signature(Test()), mtip)
 

--- a/Lib/idlelib/idle_test/test_calltips.py
+++ b/Lib/idlelib/idle_test/test_calltips.py
@@ -175,6 +175,10 @@ bytes() -> empty bytes object''')
                             (CallB(), '(ci)')):
             self.assertEqual(signature(meth), mtip)
 
+    def test_non_callables(self):
+        for obj in (0, 0.0, '0', b'0', [], {}):
+            self.assertEqual(signature(obj), '')
+
 
 class Get_entityTest(unittest.TestCase):
     def test_bad_entity(self):

--- a/Lib/idlelib/idle_test/test_calltips.py
+++ b/Lib/idlelib/idle_test/test_calltips.py
@@ -171,9 +171,6 @@ bytes() -> empty bytes object''')
                             (NoCall(), ''), (Call(), '(ci)')):
             self.assertEqual(signature(meth), mtip)
 
-    def test_non_callables(self):
-        for obj in (0, 0.0, '0', b'0', [], {}):
-            self.assertEqual(signature(obj), 'Object is not callable')
 
 class Get_entityTest(unittest.TestCase):
     def test_bad_entity(self):

--- a/Lib/idlelib/idle_test/test_calltips.py
+++ b/Lib/idlelib/idle_test/test_calltips.py
@@ -164,11 +164,15 @@ bytes() -> empty bytes object''')
         class NoCall:
             def __getattr__(self, name):
                 raise BaseException
-        class Call(NoCall):
+        class CallA(NoCall):
+            def __call__(oui, a, b, c):
+                pass
+        class CallB(NoCall):
             def __call__(self, ci):
                 pass
-        for meth, mtip  in ((NoCall, default_tip), (Call, default_tip),
-                            (NoCall(), ''), (Call(), '(ci)')):
+        for meth, mtip  in ((NoCall, default_tip), (CallA, default_tip),
+                            (NoCall(), ''), (CallA(), '(a, b, c)'),
+                            (CallB(), '(ci)')):
             self.assertEqual(signature(meth), mtip)
 
 

--- a/Lib/idlelib/idle_test/test_calltips.py
+++ b/Lib/idlelib/idle_test/test_calltips.py
@@ -132,11 +132,19 @@ bytes() -> empty bytes object''')
         # test that starred first parameter is *not* removed from argspec
         class C:
             def m1(*args): pass
-            def m2(**kwds): pass
         c = C()
-        for meth, mtip  in ((C.m1, '(*args)'), (c.m1, "(*args)"),
-                                      (C.m2, "(**kwds)"), (c.m2, "(**kwds)"),):
+        for meth, mtip  in ((C.m1, '(*args)'), (c.m1, "(*args)"),):
             self.assertEqual(signature(meth), mtip)
+
+    def test_invalid_method_signature(self):
+        class C:
+            def m2(**kwargs): pass
+        class Test:
+            def __call__(*, a): pass
+
+        mtip = "This function has an invalid method signature"
+        self.assertEqual(signature(C().m2), mtip)
+        self.assertEqual(signature(Test()), mtip)
 
     def test_non_ascii_name(self):
         # test that re works to delete a first parameter name that
@@ -165,7 +173,7 @@ bytes() -> empty bytes object''')
 
     def test_non_callables(self):
         for obj in (0, 0.0, '0', b'0', [], {}):
-            self.assertEqual(signature(obj), '')
+            self.assertEqual(signature(obj), 'Object is not callable')
 
 class Get_entityTest(unittest.TestCase):
     def test_bad_entity(self):

--- a/Lib/idlelib/idle_test/test_calltips.py
+++ b/Lib/idlelib/idle_test/test_calltips.py
@@ -46,6 +46,7 @@ class Get_signatureTest(unittest.TestCase):
 
         # Python class that inherits builtin methods
         class List(list): "List() doc"
+
         # Simulate builtin with no docstring for default tip test
         class SB:  __call__ = None
 
@@ -55,26 +56,23 @@ class Get_signatureTest(unittest.TestCase):
         if List.__doc__ is not None:
             gtest(List, List.__doc__)
         gtest(list.__new__,
-               'Create and return a new object.  See help(type) for accurate signature.')
+               '(*args, **kwargs)\nCreate and return a new object.  See help(type) for accurate signature.')
         gtest(list.__init__,
                'Initialize self.  See help(type(self)) for accurate signature.')
         append_doc =  "Append object to the end of the list."
         gtest(list.append, append_doc)
         gtest([].append, append_doc)
         gtest(List.append, append_doc)
-
         gtest(types.MethodType, "method(function, instance)")
         gtest(SB(), default_tip)
-
         import re
         p = re.compile('')
-        gtest(re.sub, '''(pattern, repl, string, count=0, flags=0)
-Return the string obtained by replacing the leftmost
+        gtest(re.sub, '''(pattern, repl, string, count=0, flags=0)\nReturn the string obtained by replacing the leftmost
 non-overlapping occurrences of the pattern in string by the
 replacement repl.  repl can be either a string or a callable;
 if a string, backslash escapes in it are processed.  If it is
 a callable, it's passed the match object and must return''')
-        gtest(p.sub, '(repl, string, count=0)')
+        gtest(p.sub, '''(repl, string, count=0)\nReturn the string obtained by replacing the leftmost non-overlapping occurrences o...''')
 
     def test_signature_wrap(self):
         if textwrap.TextWrapper.__doc__ is not None:
@@ -180,6 +178,7 @@ bytes() -> empty bytes object''')
         class CallB(NoCall):
             def __call__(self, ci):
                 pass
+
         for meth, mtip  in ((NoCall, default_tip), (CallA, default_tip),
                             (NoCall(), ''), (CallA(), '(a, b, c)'),
                             (CallB(), '(ci)')):

--- a/Lib/idlelib/idle_test/test_calltips.py
+++ b/Lib/idlelib/idle_test/test_calltips.py
@@ -68,7 +68,12 @@ class Get_signatureTest(unittest.TestCase):
 
         import re
         p = re.compile('')
-        gtest(re.sub, '(pattern, repl, string, count=0, flags=0')
+        gtest(re.sub, '''(pattern, repl, string, count=0, flags=0)
+Return the string obtained by replacing the leftmost
+non-overlapping occurrences of the pattern in string by the
+replacement repl.  repl can be either a string or a callable;
+if a string, backslash escapes in it are processed.  If it is
+a callable, it's passed the match object and must return''')
         gtest(p.sub, '(repl, string, count=0)')
 
     def test_signature_wrap(self):


### PR DESCRIPTION
This commit change the get_argspec from using inspect.getfullargspec
to inspect.signature. It will improve the tip message for use.
