### PR TITLE
bpo-30228: FileIO seek() and tell() set seekable

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -317,6 +317,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30228: The seek() and tell() methods of io.FileIO now set the internal
+  seekable attribute to avoid one syscall on open() (in buffered or text mode).
+
 - bpo-30190: unittest's assertAlmostEqual and assertNotAlmostEqual provide a
   better message in case of failure which includes the difference between
   left and right arguments.  (patch by Giampaolo Rodola')


### PR DESCRIPTION
FileIO.seek() and FileIO.tell() method now set the internal seekable
attribute to avoid one syscall open() (in buffered or text mode).

The seekable property is now also more reliable since its value is
set correctly on memory allocation failure.