### PR TITLE
bpo-30228: TextIOWrapper uses abs_pos, not tell()

### DIFF
--- a/Modules/_io/_iomodule.h
+++ b/Modules/_io/_iomodule.h
@@ -1,3 +1,5 @@
+#include "pythread.h"
+
 /*
  * Declarations shared between the different parts of the io module
  */
@@ -183,3 +185,47 @@ extern PyObject *_PyIO_empty_str;
 extern PyObject *_PyIO_empty_bytes;
 
 extern PyTypeObject _PyBytesIOBuffer_Type;
+
+typedef struct {
+    PyObject_HEAD
+
+    PyObject *raw;
+    int ok;    /* Initialized? */
+    int detached;
+    int readable;
+    int writable;
+    char finalizing;
+
+    /* True if this is a vanilla Buffered object (rather than a user derived
+       class) *and* the raw stream is a vanilla FileIO object. */
+    int fast_closed_checks;
+
+    /* Absolute position inside the raw stream (-1 if unknown). */
+    Py_off_t abs_pos;
+
+    /* A static buffer of size `buffer_size` */
+    char *buffer;
+    /* Current logical position in the buffer. */
+    Py_off_t pos;
+    /* Position of the raw stream in the buffer. */
+    Py_off_t raw_pos;
+
+    /* Just after the last buffered byte in the buffer, or -1 if the buffer
+       isn't ready for reading. */
+    Py_off_t read_end;
+
+    /* Just after the last byte actually written */
+    Py_off_t write_pos;
+    /* Just after the last byte waiting to be written, or -1 if the buffer
+       isn't ready for writing. */
+    Py_off_t write_end;
+
+    PyThread_type_lock lock;
+    volatile unsigned long owner;
+
+    Py_ssize_t buffer_size;
+    Py_ssize_t buffer_mask;
+
+    PyObject *dict;
+    PyObject *weakreflist;
+} _PyIO_buffered;

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -11,7 +11,6 @@
 #include "Python.h"
 #include "internal/pystate.h"
 #include "structmember.h"
-#include "pythread.h"
 #include "_iomodule.h"
 
 /*[clinic input]
@@ -197,49 +196,7 @@ bufferediobase_write(PyObject *self, PyObject *args)
 }
 
 
-typedef struct {
-    PyObject_HEAD
-
-    PyObject *raw;
-    int ok;    /* Initialized? */
-    int detached;
-    int readable;
-    int writable;
-    char finalizing;
-
-    /* True if this is a vanilla Buffered object (rather than a user derived
-       class) *and* the raw stream is a vanilla FileIO object. */
-    int fast_closed_checks;
-
-    /* Absolute position inside the raw stream (-1 if unknown). */
-    Py_off_t abs_pos;
-
-    /* A static buffer of size `buffer_size` */
-    char *buffer;
-    /* Current logical position in the buffer. */
-    Py_off_t pos;
-    /* Position of the raw stream in the buffer. */
-    Py_off_t raw_pos;
-
-    /* Just after the last buffered byte in the buffer, or -1 if the buffer
-       isn't ready for reading. */
-    Py_off_t read_end;
-
-    /* Just after the last byte actually written */
-    Py_off_t write_pos;
-    /* Just after the last byte waiting to be written, or -1 if the buffer
-       isn't ready for writing. */
-    Py_off_t write_end;
-
-    PyThread_type_lock lock;
-    volatile unsigned long owner;
-
-    Py_ssize_t buffer_size;
-    Py_ssize_t buffer_mask;
-
-    PyObject *dict;
-    PyObject *weakreflist;
-} buffered;
+typedef _PyIO_buffered buffered;
 
 /*
     Implementation notes:


### PR DESCRIPTION
The TextIOWrapper constructor now gets directly the abs_pos attribute
of BufferedWriter and BufferedRandom instead of calling the tell()
method to avoid one lseek() syscall on open(fname, "w") and
open(fname, "w+").

Move the buffered structure to _iomodule.h and rename it to
_PyIO_buffered. Add also "pythread.h" to _iomodule.h, needed by
_PyIO_buffered lock.

<!-- issue-number: bpo-30228 -->
https://bugs.python.org/issue30228
<!-- /issue-number -->
