### PR TITLE
bpo-30232: Support Git worktree in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_SUBST(GITVERSION)
 AC_SUBST(GITTAG)
 AC_SUBST(GITBRANCH)
 
-if test -e $srcdir/.git/HEAD
+if test -e $srcdir/.git
 then
 AC_CHECK_PROG(HAS_GIT, git, found, not-found)
 else


### PR DESCRIPTION
Don't test if .git/HEAD file exists, but only if the .git file (or
directory) exists.