### PR TITLE
bpo-30234: Remove duplicate assertions in test_isinstance.py

### DIFF
--- a/Lib/test/test_isinstance.py
+++ b/Lib/test/test_isinstance.py
@@ -177,15 +177,6 @@ class Super:
 
 class Child(Super):
     pass
-
-# new-style classes
-class NewSuper(object):
-    pass
-
-class NewChild(NewSuper):
-    pass
-
-
 
 class TestIsInstanceIsSubclass(unittest.TestCase):
     # Tests to ensure that isinstance and issubclass work on abstract
@@ -247,15 +238,8 @@ class TestIsInstanceIsSubclass(unittest.TestCase):
         self.assertEqual(False, issubclass(Child, ()))
         self.assertEqual(True, issubclass(Super, (Child, (Super,))))
 
-        self.assertEqual(True, issubclass(NewChild, (NewChild,)))
-        self.assertEqual(True, issubclass(NewChild, (NewSuper,)))
-        self.assertEqual(False, issubclass(NewSuper, (NewChild,)))
-        self.assertEqual(True, issubclass(NewSuper, (NewChild, NewSuper)))
-        self.assertEqual(False, issubclass(NewChild, ()))
-        self.assertEqual(True, issubclass(NewSuper, (NewChild, (NewSuper,))))
-
         self.assertEqual(True, issubclass(int, (int, (float, int))))
-        self.assertEqual(True, issubclass(str, (str, (Child, NewChild, str))))
+        self.assertEqual(True, issubclass(str, (str, (Child, str))))
 
     def test_subclass_recursion_limit(self):
         # make sure that issubclass raises RecursionError before the C stack is


### PR DESCRIPTION
The test file duplicates some and `issubclass` checks due to the  distinction of classes in Python 2. 