### PR TITLE
[2.7] bpo-30223: Fix test_xpickle for Python 2.4.

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
-
 import unittest
 import pickle
 import cPickle
@@ -169,7 +167,7 @@ class K(object):
         # Shouldn't support the recursion itself
         return K, (self.value,)
 
-import __main__
+__main__ = sys.modules['__main__']
 __main__.C = C
 C.__module__ = "__main__"
 __main__.D = D


### PR DESCRIPTION
Python 2.4 doesn't support absolute import.