### PR TITLE
[3.5] bpo-27372: Stop test_idle from changing locale, so test passes.

### DIFF
--- a/Lib/idlelib/EditorWindow.py
+++ b/Lib/idlelib/EditorWindow.py
@@ -25,8 +25,8 @@ from idlelib import help
 
 # The default tab setting for a Text widget, in average-width characters.
 TK_TABWIDTH_DEFAULT = 8
-
 _py_version = ' (%s)' % platform.python_version()
+
 
 def _sphinx_version():
     "Format sys.version_info to produce the Sphinx version string used to install the chm docs"
@@ -92,11 +92,12 @@ class EditorWindow(object):
     from idlelib.Percolator import Percolator
     from idlelib.ColorDelegator import ColorDelegator, color_config
     from idlelib.UndoDelegator import UndoDelegator
-    from idlelib.IOBinding import IOBinding, filesystemencoding, encoding
+    from idlelib.IOBinding import IOBinding, encoding
     from idlelib import Bindings
     from tkinter import Toplevel
     from idlelib.MultiStatusBar import MultiStatusBar
 
+    filesystemencoding = sys.getfilesystemencoding()  # for file names
     help_url = None
 
     def __init__(self, flist=None, filename=None, key=None, root=None):
@@ -1686,5 +1687,8 @@ def _editor_window(parent):  # htest #
     # edit.text.bind("<<close-window>>", edit.close_event)
 
 if __name__ == '__main__':
+    import unittest
+    unittest.main('idlelib.idle_test.test_editor', verbosity=2, exit=False)
+
     from idlelib.idle_test.htest import run
     run(_editor_window)

--- a/Lib/idlelib/IOBinding.py
+++ b/Lib/idlelib/IOBinding.py
@@ -10,57 +10,60 @@ import tkinter.filedialog as tkFileDialog
 import tkinter.messagebox as tkMessageBox
 from tkinter.simpledialog import askstring
 
+import idlelib
 from idlelib.configHandler import idleConf
 
-
-# Try setting the locale, so that we can find out
-# what encoding to use
-try:
-    import locale
-    locale.setlocale(locale.LC_CTYPE, "")
-except (ImportError, locale.Error):
-    pass
-
-# Encoding for file names
-filesystemencoding = sys.getfilesystemencoding()  ### currently unused
-
-locale_encoding = 'ascii'
-if sys.platform == 'win32':
-    # On Windows, we could use "mbcs". However, to give the user
-    # a portable encoding name, we need to find the code page
-    try:
-        locale_encoding = locale.getdefaultlocale()[1]
-        codecs.lookup(locale_encoding)
-    except LookupError:
-        pass
+if idlelib.testing:  # Set True by test.test_idle to avoid setlocale.
+    encoding = 'utf-8'
 else:
+    # Try setting the locale, so that we can find out
+    # what encoding to use
     try:
-        # Different things can fail here: the locale module may not be
-        # loaded, it may not offer nl_langinfo, or CODESET, or the
-        # resulting codeset may be unknown to Python. We ignore all
-        # these problems, falling back to ASCII
-        locale_encoding = locale.nl_langinfo(locale.CODESET)
-        if locale_encoding is None or locale_encoding is '':
-            # situation occurs on Mac OS X
-            locale_encoding = 'ascii'
-        codecs.lookup(locale_encoding)
-    except (NameError, AttributeError, LookupError):
-        # Try getdefaultlocale: it parses environment variables,
-        # which may give a clue. Unfortunately, getdefaultlocale has
-        # bugs that can cause ValueError.
+        import locale
+        locale.setlocale(locale.LC_CTYPE, "")
+    except (ImportError, locale.Error):
+        pass
+
+    locale_decode = 'ascii'
+    if sys.platform == 'win32':
+        # On Windows, we could use "mbcs". However, to give the user
+        # a portable encoding name, we need to find the code page
         try:
             locale_encoding = locale.getdefaultlocale()[1]
+            codecs.lookup(locale_encoding)
+        except LookupError:
+            pass
+    else:
+        try:
+            # Different things can fail here: the locale module may not be
+            # loaded, it may not offer nl_langinfo, or CODESET, or the
+            # resulting codeset may be unknown to Python. We ignore all
+            # these problems, falling back to ASCII
+            locale_encoding = locale.nl_langinfo(locale.CODESET)
             if locale_encoding is None or locale_encoding is '':
                 # situation occurs on Mac OS X
                 locale_encoding = 'ascii'
             codecs.lookup(locale_encoding)
-        except (ValueError, LookupError):
-            pass
+        except (NameError, AttributeError, LookupError):
+            # Try getdefaultlocale: it parses environment variables,
+            # which may give a clue. Unfortunately, getdefaultlocale has
+            # bugs that can cause ValueError.
+            try:
+                locale_encoding = locale.getdefaultlocale()[1]
+                if locale_encoding is None or locale_encoding is '':
+                    # situation occurs on Mac OS X
+                    locale_encoding = 'ascii'
+                codecs.lookup(locale_encoding)
+            except (ValueError, LookupError):
+                pass
 
-locale_encoding = locale_encoding.lower()
+    locale_encoding = locale_encoding.lower()
 
-encoding = locale_encoding  ### KBK 07Sep07  This is used all over IDLE, check!
-                            ### 'encoding' is used below in encode(), check!
+    encoding = locale_encoding
+    # Encoding is used in multiple files; locale_encoding nowhere.
+    # The only use of 'encoding' below is in _decode as initial value
+    # of deprecated block asking user for encoding.
+    # Perhaps use elsewhere should be reviewed.
 
 coding_re = re.compile(r'^[ \t\f]*#.*?coding[:=][ \t]*([-\w.]+)', re.ASCII)
 blank_re = re.compile(r'^[ \t\f]*(?:[#\r\n]|$)', re.ASCII)
@@ -301,7 +304,7 @@ class IOBinding:
                 "The file's encoding is invalid for Python 3.x.\n"
                 "IDLE will convert it to UTF-8.\n"
                 "What is the current encoding of the file?",
-                initialvalue = locale_encoding,
+                initialvalue = encoding,
                 parent = self.editwin.text)
 
             if enc:
@@ -561,5 +564,8 @@ def _io_binding(parent):  # htest #
     IOBinding(editwin)
 
 if __name__ == "__main__":
+    import unittest
+    unittest.main('idlelib.idle_test.test_iomenu', verbosity=2, exit=False)
+
     from idlelib.idle_test.htest import run
     run(_io_binding)

--- a/Lib/idlelib/__init__.py
+++ b/Lib/idlelib/__init__.py
@@ -6,3 +6,4 @@ Use the files named idle.* to start Idle.
 The other files are private implementations.  Their details are subject to
 change.  See PEP 434 for more.  Import them at your own risk.
 """
+testing = False  # Set True by test.test_idle.

--- a/Lib/test/test_idle.py
+++ b/Lib/test/test_idle.py
@@ -2,15 +2,18 @@ import unittest
 from test import support
 from test.support import import_module
 
-# Skip test if _thread or _tkinter wasn't built or idlelib was deleted.
+# Skip test if _thread or _tkinter wasn't built, or idlelib is missing,
+# or if tcl/tk version before 8.5, which is needed for ttk widgets.
+
 import_module('threading')  # imported by PyShell, imports _thread
 tk = import_module('tkinter')  # imports _tkinter
-idletest = import_module('idlelib.idle_test')
+idlelib = import_module('idlelib')
+idlelib.testing = True  # Avoid locale-changed test error
 
-# Without test_main present, regrtest.runtest_inner (line1219) calls
-# unittest.TestLoader().loadTestsFromModule(this_module) which calls
-# load_tests() if it finds it. (Unittest.main does the same.)
-load_tests = idletest.load_tests
+# Without test_main present, test.libregrtest.runtest.runtest_inner
+# calls (line 173) unittest.TestLoader().loadTestsFromModule(module)
+# which calls load_tests() if it finds it. (Unittest.main does the same.)
+from idlelib.idle_test import load_tests
 
 if __name__ == '__main__':
     unittest.main(verbosity=2, exit=False)


### PR DESCRIPTION
In 3.6, the warning is now called an error, making it harder to ignore.

(cherry picked from commit 7c1534141d3a159a32db9742e1d201d5c7a9ba81)

See also: http://bugs.python.org/issue30233 (bpo-30233).