### PR TITLE
[3.5] bpo-30232: Support Git worktree in configure.ac (#1398)

### DIFF
--- a/configure
+++ b/configure
@@ -2840,7 +2840,7 @@ fi
 
 
 
-if test -e $srcdir/.git/HEAD
+if test -e $srcdir/.git
 then
 # Extract the first word of "git", so it can be a program name with args.
 set dummy git; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_SUBST(GITVERSION)
 AC_SUBST(GITTAG)
 AC_SUBST(GITBRANCH)
 
-if test -e $srcdir/.git/HEAD
+if test -e $srcdir/.git
 then
 AC_CHECK_PROG(HAS_GIT, git, found, not-found)
 else


### PR DESCRIPTION
* bpo-30232: Support Git worktree in configure.ac (#1391)

Don't test if .git/HEAD file exists, but only if the .git file (or
directory) exists.
(cherry picked from commit 5facdbb29169c2799c42f887cef4cd9d087b0167)

* bpo-30232: Regenerate configure (#1396)

Run autoconf.
(cherry picked from commit 9ed34a89532763cf89f5e11fffb91ef7dee29fed)

(cherry picked from commit 4dae0d111dd7bb34ec730eea2327a3219acff211)