### PR TITLE
bpo-30232: Support Git worktree in configure.ac

### DIFF
--- a/configure
+++ b/configure
@@ -5691,7 +5691,7 @@ fi
 
 
 
-if test -e $srcdir/.git/HEAD
+if test -e $srcdir/.git
 then
 # Extract the first word of "git", so it can be a program name with args.
 set dummy git; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -983,7 +983,7 @@ AC_SUBST(GITVERSION)
 AC_SUBST(GITTAG)
 AC_SUBST(GITBRANCH)
 
-if test -e $srcdir/.git/HEAD
+if test -e $srcdir/.git
 then
 AC_CHECK_PROG(HAS_GIT, git, found, not-found)
 else


### PR DESCRIPTION
Don't test if .git/HEAD file exists, but only if the .git file (or
directory) exists.