### PR TITLE
[3.5] regrtest: always show before/after of modified env

### DIFF
--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -1267,10 +1267,9 @@ class saved_test_environment:
                     print("Warning -- {} was modified by {}".format(
                                                  name, self.testname),
                                                  file=sys.stderr)
-                    if self.verbose > 1 and not self.pgo:
-                        print("  Before: {}\n  After:  {} ".format(
-                                                  original, current),
-                                                  file=sys.stderr)
+                    print("  Before: {}\n  After:  {} ".format(
+                                              original, current),
+                                              file=sys.stderr)
         return False
 
 


### PR DESCRIPTION
Buildbots don't run tests with -vv and so only log "xxx was modified
by test_xxx" which is not enough to debug such random issue. In many
cases, I'm unable to reproduce the warning and so unable to fix it.

Always logging the value before and value after should help to debug
such warning on buildbots.
(cherry picked from commit ec4b17239d899550be4ee6104b61751bb3c70382)