### PR TITLE
[2.7] regrtest: always show before/after of modified env

### DIFF
--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -901,10 +901,9 @@ class saved_test_environment:
                     print >>sys.stderr, (
                           "Warning -- {} was modified by {}".format(
                                                  name, self.testname))
-                    if self.verbose > 1 and not self.pgo:
-                        print >>sys.stderr, (
-                              "  Before: {}\n  After:  {} ".format(
-                                                  original, current))
+                    print >>sys.stderr, (
+                          "  Before: {}\n  After:  {} ".format(
+                                              original, current))
             # XXX (ncoghlan): for most resources (e.g. sys.path) identity
             # matters at least as much as value. For others (e.g. cwd),
             # identity is irrelevant. Should we add a mechanism to check


### PR DESCRIPTION
Buildbots don't run tests with -vv and so only log "xxx was modified
by test_xxx" which is not enough to debug such random issue. In many
cases, I'm unable to reproduce the warning and so unable to fix it.

Always logging the value before and value after should help to debug
such warning on buildbots.
(cherry picked from commit ec4b17239d899550be4ee6104b61751bb3c70382)
(cherry picked from commit 22982350235f8c5821b71661a5616423e1c7fcc0)