### PR TITLE
[3.5] Fix typo in selectors.rst (GH-1383)

### DIFF
--- a/Doc/library/selectors.rst
+++ b/Doc/library/selectors.rst
@@ -68,7 +68,7 @@ constants below:
 .. class:: SelectorKey
 
    A :class:`SelectorKey` is a :class:`~collections.namedtuple` used to
-   associate a file object to its underlying file decriptor, selected event
+   associate a file object to its underlying file descriptor, selected event
    mask and attached data. It is returned by several :class:`BaseSelector`
    methods.
 


### PR DESCRIPTION
decriptor -> descriptor
(cherry picked from commit b0d82036549074357717d130a772d1e2ebc8ea01)