### PR TITLE
[3.5] bpo-28087: Skip test_asyncore and test_eintr poll failures on macOS

### DIFF
--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -424,6 +424,8 @@ class SelectEINTRTest(EINTRBaseTest):
         self.stop_alarm()
         self.assertGreaterEqual(dt, self.sleep_time)
 
+    @unittest.skipIf(sys.platform == "darwin",
+                     "poll may fail on macOS; see issue #28087")
     @unittest.skipUnless(hasattr(select, 'poll'), 'need select.poll')
     def test_poll(self):
         poller = select.poll()

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -656,6 +656,9 @@ class BaseTestAPI:
         if HAS_UNIX_SOCKETS and self.family == socket.AF_UNIX:
             self.skipTest("Not applicable to AF_UNIX sockets.")
 
+        if sys.platform == "darwin" and self.use_poll:
+            self.skipTest("poll may fail on macOS; see issue #28087")
+
         class TestClient(BaseClient):
             def handle_expt(self):
                 self.socket.recv(1024, socket.MSG_OOB)

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -201,6 +201,10 @@ Build
 Tests
 -----
 
+- bpo-28087: Skip test_asyncore and test_eintr poll failures on macOS.
+  Skip some tests of select.poll when running on macOS due to unresolved
+  issues with the underlying system poll function on some macOS versions.
+
 - bpo-30197: Enhanced functions swap_attr() and swap_item() in the
   test.support module.  They now work when delete replaced attribute or item
   inside the with statement.  The old value of the attribute or item (or None


### PR DESCRIPTION
Skip some tests of select.poll when running on macOS due to unresolved
issues with the underlying system poll function on some macOS versions.

(cherry picked from commit de04644627f82d9dc48b3423def7ff5b4aa1926a)
(cherry picked from commit 1d391f926b37484b8d4b326003a72c0084db19ec)