### PR TITLE
bpo-28087: Detect broken poll() on macOS Sierra

### DIFF
--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -442,8 +442,6 @@ class SelectEINTRTest(EINTRBaseTest):
         self.stop_alarm()
         self.assertGreaterEqual(dt, self.sleep_time)
 
-    @unittest.skipIf(sys.platform == "darwin",
-                     "poll may fail on macOS; see issue #28087")
     @unittest.skipUnless(hasattr(select, 'poll'), 'need select.poll')
     def test_poll(self):
         poller = select.poll()

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -661,9 +661,6 @@ class BaseTestAPI:
         if HAS_UNIX_SOCKETS and self.family == socket.AF_UNIX:
             self.skipTest("Not applicable to AF_UNIX sockets.")
 
-        if sys.platform == "darwin" and self.use_poll:
-            self.skipTest("poll may fail on macOS; see issue #28087")
-
         class TestClient(BaseClient):
             def handle_expt(self):
                 self.socket.recv(1024, socket.MSG_OOB)

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -317,6 +317,10 @@ Extension Modules
 Library
 -------
 
+- bpo-28087: On macOS, check for broken poll() at runtime on macOS Sierra
+  16.0.x-16.5.x. Disable select.poll() (remove select.poll) if poll() is
+  broken.
+
 - bpo-30103: binascii.b2a_uu() and uu.encode() now support using ``'`'``
   as zero instead of space.
 


### PR DESCRIPTION
On macOS, check for broken poll() at runtime on macOS Sierra 16.0.x-16.5.x.

Disable select.poll() (remove select.poll) if poll() is broken.

cc @MicroTransactionsMatterToo.