### PR TITLE
bpo-24725: Skip the test_socket.testFDPassEmpty on OS X.

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -2844,6 +2844,7 @@ class SCMRightsTest(SendrecvmsgServerTimeoutBase):
             nbytes = self.sendmsgToServer([msg])
         self.assertEqual(nbytes, len(msg))
 
+    @unittest.skipIf(sys.platform == "darwin", "skipping, see issue #24725")
     def testFDPassEmpty(self):
         # Try to pass an empty FD array.  Can receive either no array
         # or an empty array.


### PR DESCRIPTION
In OS X 10.11, the test fails consistently due to a platform change
since 10.10. Thanks to Jeff Ramnani for the patch.

(cherry picked from commit 3c61a448f106c7cafb050ff7be5c5c421273e68f)