### PR TITLE
[2.7] bpo-30255: Clip step in _PySlice_Unpack()

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -932,6 +932,11 @@ Tools/Demos
 C API
 -----
 
+- bpo-30255: PySlice_GetIndicesEx now clips the step to
+  [-PY_SSIZE_T_MAX, PY_SSIZE_T_MAX] instead of
+  [-PY_SSIZE_T_MAX-1, PY_SSIZE_T_MAX].  This makes it safe to do "step = -step"
+  when reversing a slice.
+
 - Issue #26476: Fixed compilation error when use PyErr_BadInternalCall() in C++.
   Patch by Jeroen Demeyer.
 

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -147,6 +147,13 @@ _PySlice_Unpack(PyObject *_r,
                             "slice step cannot be zero");
             return -1;
         }
+        /* Here *step might be -PY_SSIZE_T_MAX-1; in this case we replace it
+         * with -PY_SSIZE_T_MAX.  This doesn't affect the semantics, and it
+         * guards against later undefined behaviour resulting from code that
+         * does "step = -step" as part of a slice reversal.
+         */
+        if (*step < -PY_SSIZE_T_MAX)
+            *step = -PY_SSIZE_T_MAX;
     }
 
     if (r->start == Py_None) {


### PR DESCRIPTION
In PySlice_IndicesEx, clip the step to [-PY_SSIZE_T_MAX,
PY_SSIZE_T_MAX] rather than [PY_SSIZE_T_MIN, PY_SSIZE_T_MAX].

(cherry picked from commit e6fc7401a92c7b51a80782d8095819b9909a0322)