### PR TITLE
fix dangling keyfunc examples in documentation of heapq and sorted

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1319,8 +1319,8 @@ are always available.  They are listed here in alphabetical order.
    Has two optional arguments which must be specified as keyword arguments.
 
    *key* specifies a function of one argument that is used to extract a comparison
-   key from each list element: ``key=str.lower``.  The default value is ``None``
-   (compare the elements directly).
+   key from each element in *iterable* (for example, ``key=str.lower``).  The
+   default value is ``None`` (compare the elements directly).
 
    *reverse* is a boolean value.  If set to ``True``, then the list elements are
    sorted as if each comparison were reversed.

--- a/Doc/library/heapq.rst
+++ b/Doc/library/heapq.rst
@@ -110,8 +110,8 @@ The module also offers three general purpose functions based on heaps.
 
    Return a list with the *n* largest elements from the dataset defined by
    *iterable*.  *key*, if provided, specifies a function of one argument that is
-   used to extract a comparison key from each element in the iterable:
-   ``key=str.lower`` Equivalent to:  ``sorted(iterable, key=key,
+   used to extract a comparison key from each element in the iterable (for example,
+   ``key=str.lower``).  Equivalent to:  ``sorted(iterable, key=key,
    reverse=True)[:n]``
 
 
@@ -119,8 +119,8 @@ The module also offers three general purpose functions based on heaps.
 
    Return a list with the *n* smallest elements from the dataset defined by
    *iterable*.  *key*, if provided, specifies a function of one argument that is
-   used to extract a comparison key from each element in the iterable:
-   ``key=str.lower`` Equivalent to:  ``sorted(iterable, key=key)[:n]``
+   used to extract a comparison key from each element in the iterable (for example,
+   ``key=str.lower``).  Equivalent to:  ``sorted(iterable, key=key)[:n]``
 
 
 The latter two functions perform best for smaller values of *n*.  For larger

--- a/Doc/library/heapq.rst
+++ b/Doc/library/heapq.rst
@@ -110,7 +110,7 @@ The module also offers three general purpose functions based on heaps.
 
    Return a list with the *n* largest elements from the dataset defined by
    *iterable*.  *key*, if provided, specifies a function of one argument that is
-   used to extract a comparison key from each element in the iterable (for example,
+   used to extract a comparison key from each element in *iterable* (for example,
    ``key=str.lower``).  Equivalent to:  ``sorted(iterable, key=key,
    reverse=True)[:n]``.
 
@@ -119,7 +119,7 @@ The module also offers three general purpose functions based on heaps.
 
    Return a list with the *n* smallest elements from the dataset defined by
    *iterable*.  *key*, if provided, specifies a function of one argument that is
-   used to extract a comparison key from each element in the iterable (for example,
+   used to extract a comparison key from each element in *iterable* (for example,
    ``key=str.lower``).  Equivalent to:  ``sorted(iterable, key=key)[:n]``.
 
 

--- a/Doc/library/heapq.rst
+++ b/Doc/library/heapq.rst
@@ -112,7 +112,7 @@ The module also offers three general purpose functions based on heaps.
    *iterable*.  *key*, if provided, specifies a function of one argument that is
    used to extract a comparison key from each element in the iterable (for example,
    ``key=str.lower``).  Equivalent to:  ``sorted(iterable, key=key,
-   reverse=True)[:n]``
+   reverse=True)[:n]``.
 
 
 .. function:: nsmallest(n, iterable, key=None)
@@ -120,7 +120,7 @@ The module also offers three general purpose functions based on heaps.
    Return a list with the *n* smallest elements from the dataset defined by
    *iterable*.  *key*, if provided, specifies a function of one argument that is
    used to extract a comparison key from each element in the iterable (for example,
-   ``key=str.lower``).  Equivalent to:  ``sorted(iterable, key=key)[:n]``
+   ``key=str.lower``).  Equivalent to:  ``sorted(iterable, key=key)[:n]``.
 
 
 The latter two functions perform best for smaller values of *n*.  For larger


### PR DESCRIPTION
used the same wording as in the description of list.sort