### PR TITLE
[2.7] test_distutils: use EnvironGuard

### DIFF
--- a/Lib/distutils/tests/test_install.py
+++ b/Lib/distutils/tests/test_install.py
@@ -26,6 +26,7 @@ def _make_ext_name(modname):
 
 
 class InstallTestCase(support.TempdirManager,
+                      support.EnvironGuard,
                       support.LoggingSilencer,
                       unittest.TestCase):
 

--- a/Lib/distutils/tests/test_util.py
+++ b/Lib/distutils/tests/test_util.py
@@ -4,10 +4,11 @@ import unittest
 from test.test_support import run_unittest
 
 from distutils.errors import DistutilsByteCompileError
+from distutils.tests import support
 from distutils.util import byte_compile, grok_environment_error
 
 
-class UtilTestCase(unittest.TestCase):
+class UtilTestCase(support.EnvironGuard, unittest.TestCase):
 
     def test_dont_write_bytecode(self):
         # makes sure byte_compile raise a DistutilsError


### PR DESCRIPTION
Use EnvironGuard on InstallTestCase and UtilTestCase.

Backport fixes from master to prevent the following warning:

Warning -- os.environ was modified by test_distutils