### PR TITLE
Make code coverage less strict

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,18 +12,12 @@ ignore:
   - "Grammar/*"
 coverage:
   precision: 2
-  range:
-  - 70.0
-  - 100.0
+  range: 70...90
   round: down
   status:
     changes: off
     project: off
-    patch:
-      default:
-        target: 100%
-        only_pulls: true
-        threshold: 0.05
+    patch: off
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
Set the target to be 90% -- since there is enough OS-specific code and things that require manual testing that we will never hit 100% -- and turn off the status checks since they are so inconsistent in terms of flagging a PR as passing/failing.

Closes python/core-workflow#75 and python/core-workflow#76 .