### PR TITLE
[3.6] bpo-30225: Fix is_valid_fd() on macOS Tiger (#1443)

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1044,6 +1044,14 @@ initsite(void)
 static int
 is_valid_fd(int fd)
 {
+#ifdef __APPLE__
+    /* bpo-30225: On macOS Tiger, when stdout is redirected to a pipe
+       and the other side of the pipe is closed, dup(1) succeed, whereas
+       fstat(1, &st) fails with EBADF. Prefer fstat() over dup() to detect
+       such error. */
+    struct stat st;
+    return (fstat(fd, &st) == 0);
+#else
     int fd2;
     if (fd < 0)
         return 0;
@@ -1056,6 +1064,7 @@ is_valid_fd(int fd)
         close(fd2);
     _Py_END_SUPPRESS_IPH
     return fd2 >= 0;
+#endif
 }
 
 /* returns Py_None if the fd is not valid */


### PR DESCRIPTION
is_valid_fd() now uses fstat() instead of dup() on macOS to return 0
on a pipe when the other side of the pipe is closed. fstat() fails
with EBADF in that case, whereas dup() succeed.
(cherry picked from commit 1c4670ea0cc3d208121af11b9b973e6bb268e570)