### PR TITLE
[3.5] bpo-30185: avoid KeyboardInterrupt tracebacks in forkserver (GH-1319)

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -49,6 +49,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30185: Avoid KeyboardInterrupt tracebacks in forkserver helper process
+  when Ctrl-C is received.
+
 - bpo-28556: Various updates to typing module: add typing.NoReturn type, use
   WrapperDescriptorType, minor bug-fixes.  Original PRs by
   Jim Fasarakis-Hilliard and Ivan Levkivskyi.


### PR DESCRIPTION
* bpo-30185: avoid KeyboardInterrupt tracebacks in forkserver

* Tweak comment.
(cherry picked from commit 6dd4d734ed207ba16b017e38f8909de7ef187e29)