### PR TITLE
[2.7] bpo-30265: support.unlink() don't catch any OSError

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -276,8 +276,9 @@ else:
 def unlink(filename):
     try:
         _unlink(filename)
-    except OSError:
-        pass
+    except OSError as exc:
+        if exc.errno not in (errno.ENOENT, errno.ENOTDIR):
+            raise
 
 def rmdir(dirname):
     try:


### PR DESCRIPTION
support.unlink() now only ignores ENOENT and ENOTDIR, instead of
ignoring any OSError exception.