### PR TITLE
[2.7] test_distutils: test_build_ext uses EnvironGuard

### DIFF
--- a/Lib/distutils/tests/test_build_ext.py
+++ b/Lib/distutils/tests/test_build_ext.py
@@ -20,6 +20,7 @@ ALREADY_TESTED = False
 
 class BuildExtTestCase(support.TempdirManager,
                        support.LoggingSilencer,
+                       support.EnvironGuard,
                        unittest.TestCase):
     def setUp(self):
         super(BuildExtTestCase, self).setUp()


### PR DESCRIPTION
Use EnvironGuard on BuildExtTestCase to save/restore os.environ, to fix the
following warning:

Warning -- os.environ was modified by test_distutils

MSVCCompiler.initialize() of distutils.msvc9compiler modifies
os.environ.