### PR TITLE
[2.7] bpo-30108: Fix test_site setUpModule()

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -8,6 +8,7 @@ import unittest
 from test.test_support import run_unittest, TESTFN, EnvironmentVarGuard
 from test.test_support import captured_output
 import __builtin__
+import errno
 import os
 import sys
 import re
@@ -38,9 +39,12 @@ def setUpModule():
             os.makedirs(site.USER_SITE)
             # modify sys.path: will be restored by tearDownModule()
             site.addsitedir(site.USER_SITE)
-        except PermissionError as exc:
-            raise unittest.SkipTest('unable to create user site directory (%r): %s'
-                                    % (site.USER_SITE, exc))
+        except OSError as exc:
+            if exc.errno in (errno.EACCES, errno.EPERM):
+                raise unittest.SkipTest('unable to create user site directory (%r): %s'
+                                        % (site.USER_SITE, exc))
+            else:
+                raise
 
 
 def tearDownModule():


### PR DESCRIPTION
Oops, I forgot that PermissionError was introduced in Python 3.3!
Replace PermissionError with OSError and check on errno.