### PR TITLE
bpo-30271: Make sqlite3 statement cache optional 

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -223,6 +223,9 @@ Module functions and constants
    .. versionchanged:: 3.4
       Added the *uri* parameter.
 
+   .. versionchanged:: 3.7
+      When *cached_statements* is set to 0 there is no statement cache.
+
 
 .. function:: register_converter(typename, callable)
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,8 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-30271: sqlite3 statement cache is optional.  Patch by Aviv Palivoda.
+
 - bpo-12414: sys.getsizeof() on a code object now returns the sizes
   which includes the code struct and sizes of objects which it references.
   Patch by Dong-hee Na.

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -65,9 +65,11 @@ int pysqlite_cache_init(pysqlite_Cache* self, PyObject* args, PyObject* kwargs)
         return -1;
     }
 
-    /* minimum cache size is 5 entries */
-    if (size < 5) {
-        size = 5;
+    /* minimum cache size is 1 entry */
+    if (size < 1) {
+        PyErr_SetString(PyExc_ValueError,
+                        "Minimum cache size is 1");
+        return -1;
     }
     self->size = size;
     self->first = NULL;

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -487,9 +487,16 @@ PyObject* _pysqlite_query_execute(pysqlite_Cursor* self, int multiple, PyObject*
         (void)pysqlite_statement_reset(self->statement);
     }
 
-    Py_XSETREF(self->statement,
-              (pysqlite_Statement *)pysqlite_cache_get(self->connection->statement_cache, func_args));
-    Py_DECREF(func_args);
+    if (self->connection->statement_cache) {
+        /* We look in statment cache */
+        Py_XSETREF(self->statement,
+                  (pysqlite_Statement *)pysqlite_cache_get(self->connection->statement_cache, func_args));
+        Py_DECREF(func_args);
+    } else {
+        /* We don't have statment cache */
+        Py_XSETREF(self->statement,
+                  (pysqlite_Statement *)PyObject_CallFunction((PyObject*)self->connection, "O", func_args));
+    }
 
     if (!self->statement) {
         goto error;


### PR DESCRIPTION


<!-- issue-number: [bpo-30271](https://bugs.python.org/issue30271) -->
https://bugs.python.org/issue30271
<!-- /issue-number -->
