### PR TITLE
bpo-30273: Update sysconfig

### DIFF
--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -255,7 +255,6 @@ You can use :mod:`sysconfig` as a script with Python's *-m* option:
             AIX_GENUINE_CPLUSPLUS = "0"
             AR = "ar"
             ARFLAGS = "rc"
-            ASDLGEN = "./Parser/asdl_c.py"
             ...
 
 This call will print in the standard output the information returned by

--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -97,7 +97,7 @@ def get_python_inc(plat_specific=0, prefix=None):
             if plat_specific:
                 return base
             if _sys_home:
-                incdir = os.path.join(_sys_home, get_config_var('AST_H_DIR'))
+                incdir = os.path.join(_sys_home, 'Include')
             else:
                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
             return os.path.normpath(incdir)


### PR DESCRIPTION
The AST_H_DIR variable was removed from Makefile.pre.in by the commit
a5c62a8e9f0de6c4133825a5710984a3cd5e102b (bpo-23404).

AST_H_DIR was hardcoded to "Include", so replace the removed variable
by its content.

Remove also ASDLGEN variable from sysconfig example since this
variable was also removed.