### PR TITLE
[2.7] bpo-30243: Fixed the possibility of a crash in _json. (GH-1420)

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -42,6 +42,10 @@ Extension Modules
 Library
 -------
 
+- bpo-30243: Removed the __init__ methods of _json's scanner and encoder.
+  Misusing them could cause memory leaks or crashes.  Now scanner and encoder
+  objects are completely initialized in the __new__ methods.
+
 - Revert bpo-26293 for zipfile breakage. See also bpo-29094.
 
 - bpo-30070: Fixed leaks and crashes in errors handling in the parser module.


### PR DESCRIPTION
It was possible to get a core dump by using uninitialized
_json objects. Now __new__ methods create initialized objects.
__init__ methods are removed..
(cherry picked from commit 76a3e51a403bc84ed536921866c86dd7d07aaa7e)