### PR TITLE
bpo-30258: regrtest: Fix run_tests_multiprocess()

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -116,6 +116,8 @@ class Regrtest:
         elif ok == RESOURCE_DENIED:
             self.skipped.append(test)
             self.resource_denieds.append(test)
+        elif ok != INTERRUPTED:
+            raise ValueError("invalid test result: %r" % ok)
 
     def display_progress(self, test_index, test):
         if self.ns.quiet:

--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -124,13 +124,13 @@ class MultiprocessThread(threading.Thread):
         finally:
             self.current_test = None
 
-        stdout, _, result = stdout.strip().rpartition("\n")
         if retcode != 0:
             result = (CHILD_ERROR, "Exit code %s" % retcode)
             self.output.put((test, stdout.rstrip(), stderr.rstrip(),
                              result))
             return False
 
+        stdout, _, result = stdout.strip().rpartition("\n")
         if not result:
             self.output.put((None, None, None, None))
             return True


### PR DESCRIPTION
If the child process exited with a non-zero code, don't strip the
last line of stdout anymore.

Add also a sanity check in accumulate_result().