### PR TITLE
bpo-30302 Make timedelta.__repr__ more informative.

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -283,10 +283,12 @@ Supported operations:
 | ``abs(t)``                     | equivalent to +\ *t* when ``t.days >= 0``, and|
 |                                | to -*t* when ``t.days < 0``. (2)              |
 +--------------------------------+-----------------------------------------------+
-| ``str(t)``                     | Returns a string in the form                  |
-|                                | ``[D day[s], ][H]H:MM:SS[.UUUUUU]``, where D  |
-|                                | is negative for negative ``t``. (5)           |
+| ``str(t)``                     | Returns a string in the form                  | |                                | ``[D day[s], ][H]H:MM:SS[.UUUUUU]``, where D  | |                                | is negative for negative ``t``. (5)           |
 +--------------------------------+-----------------------------------------------+
+| ``repr(t)``                    | Returns the representation of the             |
+|                                | :class:`timedelta` object as a string.        |
++--------------------------------+-----------------------------------------------+
+
 
 Notes:
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -287,10 +287,6 @@ Supported operations:
 |                                | ``[D day[s], ][H]H:MM:SS[.UUUUUU]``, where D  |
 |                                | is negative for negative ``t``. (5)           |
 +--------------------------------+-----------------------------------------------+
-| ``repr(t)``                    | Returns a string in the form                  |
-|                                | ``datetime.timedelta(D[, S[, U]])``, where D  |
-|                                | is negative for negative ``t``. (5)           |
-+--------------------------------+-----------------------------------------------+
 
 Notes:
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -288,8 +288,8 @@ Supported operations:
 |                                | is negative for negative ``t``. (5)           |
 +--------------------------------+-----------------------------------------------+
 | ``repr(t)``                    | Returns a string representation of the        |
-|                                | :class:`timedelta` object such that           |
-|                                | ``t == eval(repr(t))``.                       |
+|                                | :class:`timedelta` object as a constructor    |
+|                                | call with canonical attribute values.         |
 +--------------------------------+-----------------------------------------------+
 
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -283,7 +283,9 @@ Supported operations:
 | ``abs(t)``                     | equivalent to +\ *t* when ``t.days >= 0``, and|
 |                                | to -*t* when ``t.days < 0``. (2)              |
 +--------------------------------+-----------------------------------------------+
-| ``str(t)``                     | Returns a string in the form                  | |                                | ``[D day[s], ][H]H:MM:SS[.UUUUUU]``, where D  | |                                | is negative for negative ``t``. (5)           |
+| ``str(t)``                     | Returns a string in the form                  |
+|                                | ``[D day[s], ][H]H:MM:SS[.UUUUUU]``, where D  |
+|                                | is negative for negative ``t``. (5)           |
 +--------------------------------+-----------------------------------------------+
 | ``repr(t)``                    | Returns the representation of the             |
 |                                | :class:`timedelta` object as a string.        |

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -287,8 +287,9 @@ Supported operations:
 |                                | ``[D day[s], ][H]H:MM:SS[.UUUUUU]``, where D  |
 |                                | is negative for negative ``t``. (5)           |
 +--------------------------------+-----------------------------------------------+
-| ``repr(t)``                    | Returns the representation of the             |
-|                                | :class:`timedelta` object as a string.        |
+| ``repr(t)``                    | Returns a string representation of the        |
+|                                | :class:`timedelta` object such that           |
+|                                | ``t == eval(repr(t))``.                       |
 +--------------------------------+-----------------------------------------------+
 
 

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -454,22 +454,24 @@ class timedelta:
         return self
 
     def __repr__(self):
+        arg_str = ""
+
+        if self._days:
+            arg_str += "days=%d" % self._days
+
+        if self._seconds or (not self._days and not self._microsecond):
+            if arg_str != "":
+                arg_str += ", "
+            arg_str += "seconds=%d" % self._seconds
+
         if self._microseconds:
-            return "%s.%s(days=%d, seconds=%d, microseconds=%d)" % \
-                                         (self.__class__.__module__,
-                                          self.__class__.__qualname__,
-                                          self._days,
-                                          self._seconds,
-                                          self._microseconds)
-        if self._seconds:
-            return "%s.%s(days=%d, seconds=%d)" % \
-                                     (self.__class__.__module__,
-                                      self.__class__.__qualname__,
-                                      self._days,
-                                      self._seconds)
-        return "%s.%s(days=%d)" % (self.__class__.__module__,
-                                   self.__class__.__qualname__,
-                                   self._days)
+            if arg_str != "":
+                arg_str += ", "
+            arg_str += "microseconds=%d" % self._microseconds
+
+        return "%s.%s(%s)" % (self.__class__.__module__,
+                              self.__class__.__qualname__,
+                              arg_str)
 
     def __str__(self):
         mm, ss = divmod(self._seconds, 60)

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -455,19 +455,21 @@ class timedelta:
 
     def __repr__(self):
         if self._microseconds:
-            return "%s.%s(%d, %d, %d)" % (self.__class__.__module__,
+            return "%s.%s(days=%d, seconds=%d, microseconds=%d)" % \
+                                         (self.__class__.__module__,
                                           self.__class__.__qualname__,
                                           self._days,
                                           self._seconds,
                                           self._microseconds)
         if self._seconds:
-            return "%s.%s(%d, %d)" % (self.__class__.__module__,
+            return "%s.%s(days=%d, seconds=%d)" % \
+                                     (self.__class__.__module__,
                                       self.__class__.__qualname__,
                                       self._days,
                                       self._seconds)
-        return "%s.%s(%d)" % (self.__class__.__module__,
-                              self.__class__.__qualname__,
-                              self._days)
+        return "%s.%s(days=%d)" % (self.__class__.__module__,
+                                   self.__class__.__qualname__,
+                                   self._days)
 
     def __str__(self):
         mm, ss = divmod(self._seconds, 60)

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -454,21 +454,18 @@ class timedelta:
         return self
 
     def __repr__(self):
-        arg_str = ""
+        args = []
 
         if self._days:
-            arg_str += "days=%d" % self._days
+            args.append("days=%d" % self._days)
 
         if self._seconds or (not self._days and not self._microseconds):
-            if arg_str != "":
-                arg_str += ", "
-            arg_str += "seconds=%d" % self._seconds
+            args.append("seconds=%d" % self._seconds)
 
         if self._microseconds:
-            if arg_str != "":
-                arg_str += ", "
-            arg_str += "microseconds=%d" % self._microseconds
+            args.append("microseconds=%d" % self._microseconds)
 
+        arg_str = ', '.join(args)
         return "%s.%s(%s)" % (self.__class__.__module__,
                               self.__class__.__qualname__,
                               arg_str)

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -459,11 +459,15 @@ class timedelta:
         if self._days:
             args.append("days=%d" % self._days)
 
-        if self._seconds or (not self._days and not self._microseconds):
+        if self._seconds:
             args.append("seconds=%d" % self._seconds)
 
         if self._microseconds:
             args.append("microseconds=%d" % self._microseconds)
+
+        if len(args) == 0:
+            return "%s.%s(0)" % (self.__class__.__module__,
+                                 self.__class__.__qualname__)
 
         return "%s.%s(%s)" % (self.__class__.__module__,
                               self.__class__.__qualname__,

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -455,19 +455,14 @@ class timedelta:
 
     def __repr__(self):
         args = []
-
         if self._days:
             args.append("days=%d" % self._days)
-
         if self._seconds:
             args.append("seconds=%d" % self._seconds)
-
         if self._microseconds:
             args.append("microseconds=%d" % self._microseconds)
-
-        if len(args) == 0:
+        if not args:
             args.append('0')
-
         return "%s.%s(%s)" % (self.__class__.__module__,
                               self.__class__.__qualname__,
                               ', '.join(args))

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -465,10 +465,9 @@ class timedelta:
         if self._microseconds:
             args.append("microseconds=%d" % self._microseconds)
 
-        arg_str = ', '.join(args)
         return "%s.%s(%s)" % (self.__class__.__module__,
                               self.__class__.__qualname__,
-                              arg_str)
+                              ', '.join(args))
 
     def __str__(self):
         mm, ss = divmod(self._seconds, 60)

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -459,7 +459,7 @@ class timedelta:
         if self._days:
             arg_str += "days=%d" % self._days
 
-        if self._seconds or (not self._days and not self._microsecond):
+        if self._seconds or (not self._days and not self._microseconds):
             if arg_str != "":
                 arg_str += ", "
             arg_str += "seconds=%d" % self._seconds

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -466,8 +466,7 @@ class timedelta:
             args.append("microseconds=%d" % self._microseconds)
 
         if len(args) == 0:
-            return "%s.%s(0)" % (self.__class__.__module__,
-                                 self.__class__.__qualname__)
+            args.append('0')
 
         return "%s.%s(%s)" % (self.__class__.__module__,
                               self.__class__.__qualname__,

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -663,20 +663,10 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
                          "%s(days=10, seconds=2)" % name)
         self.assertEqual(repr(self.theclass(-10, 2, 400000)),
                          "%s(days=-10, seconds=2, microseconds=400000)" % name)
-        self.assertEqual(repr(self.theclass(1, -1)),
-                         "%s(seconds=86399)" % name)
-        self.assertEqual(repr(self.theclass(0, 1, -1)),
-                         "%s(microseconds=999999)" % name)
-        self.assertEqual(repr(self.theclass(0, 86400)),
-                         "%s(days=1)" % name)
-        self.assertEqual(repr(self.theclass(0, 2 * 86400)),
-                         "%s(days=2)" % name)
-        self.assertEqual(repr(self.theclass(days=1, seconds=0)),
-                         "%s(days=1)" % name)
         self.assertEqual(repr(self.theclass(seconds=60)),
                          "%s(seconds=60)" % name)
         self.assertEqual(repr(self.theclass()),
-                         "%s(seconds=0)" % name)
+                         "%s(0)" % name)
         self.assertEqual(repr(self.theclass(microseconds=100)),
                          "%s(microseconds=100)" % name)
         self.assertEqual(repr(self.theclass(days=1, microseconds=100)),

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -663,8 +663,14 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
                          "%s(days=10, seconds=2)" % name)
         self.assertEqual(repr(self.theclass(-10, 2, 400000)),
                          "%s(days=-10, seconds=2, microseconds=400000)" % name)
-        self.assertEqual(repr(self.theclass(-10, 2, 400000)),
-                         "%s(days=-10, seconds=2, microseconds=400000)" % name)
+        self.assertEqual(repr(self.theclass(1, -1)),
+                         "%s(seconds=86399)" % name)
+        self.assertEqual(repr(self.theclass(0, 1, -1)),
+                         "%s(microseconds=999999)" % name)
+        self.assertEqual(repr(self.theclass(0, 86400)),
+                         "%s(days=1)" % name)
+        self.assertEqual(repr(self.theclass(0, 2 * 86400)),
+                         "%s(days=2)" % name)
         self.assertEqual(repr(self.theclass(days=1, seconds=0)),
                          "%s(days=1)" % name)
         self.assertEqual(repr(self.theclass(seconds=60)),

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -658,11 +658,11 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
     def test_repr(self):
         name = 'datetime.' + self.theclass.__name__
         self.assertEqual(repr(self.theclass(1)),
-                         "%s(1)" % name)
+                         "%s(days=1)" % name)
         self.assertEqual(repr(self.theclass(10, 2)),
-                         "%s(10, 2)" % name)
+                         "%s(days=10, seconds=2)" % name)
         self.assertEqual(repr(self.theclass(-10, 2, 400000)),
-                         "%s(-10, 2, 400000)" % name)
+                         "%s(days=-10, seconds=2, microseconds=400000)" % name)
 
     def test_roundtrip(self):
         for td in (timedelta(days=999999999, hours=23, minutes=59,

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -663,6 +663,18 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
                          "%s(days=10, seconds=2)" % name)
         self.assertEqual(repr(self.theclass(-10, 2, 400000)),
                          "%s(days=-10, seconds=2, microseconds=400000)" % name)
+        self.assertEqual(repr(self.theclass(-10, 2, 400000)),
+                         "%s(days=-10, seconds=2, microseconds=400000)" % name)
+        self.assertEqual(repr(self.theclass(days=1, seconds=0)),
+                         "%s(days=1, seconds=0)" % name)
+        self.assertEqual(repr(self.theclass(seconds=60)),
+                         "%s(seconds=60)" % name)
+        self.assertEqual(repr(self.theclass(seconds=-60)),
+                         "-%s(seconds=60)" % name)
+        self.assertEqual(repr(self.theclass(minutes=-1)),
+                         "-%s(seconds=60)" % name)
+        self.assertEqual(repr(self.theclass(minutes=-1)),
+                         "-%s(seconds=60)" % name)
 
     def test_roundtrip(self):
         for td in (timedelta(days=999999999, hours=23, minutes=59,

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -677,10 +677,6 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
                          "%s(days=1, microseconds=100)" % name)
         self.assertEqual(repr(self.theclass(seconds=1, microseconds=100)),
                          "%s(seconds=1, microseconds=100)" % name)
-        # self.assertEqual(repr(self.theclass(seconds=-60)),
-        #                  "-%s(seconds=60)" % name)
-        # self.assertEqual(repr(self.theclass(minutes=-1)),
-        #                  "-%s(seconds=60)" % name)
 
     def test_roundtrip(self):
         for td in (timedelta(days=999999999, hours=23, minutes=59,

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -666,15 +666,21 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         self.assertEqual(repr(self.theclass(-10, 2, 400000)),
                          "%s(days=-10, seconds=2, microseconds=400000)" % name)
         self.assertEqual(repr(self.theclass(days=1, seconds=0)),
-                         "%s(days=1, seconds=0)" % name)
+                         "%s(days=1)" % name)
         self.assertEqual(repr(self.theclass(seconds=60)),
                          "%s(seconds=60)" % name)
-        self.assertEqual(repr(self.theclass(seconds=-60)),
-                         "-%s(seconds=60)" % name)
-        self.assertEqual(repr(self.theclass(minutes=-1)),
-                         "-%s(seconds=60)" % name)
-        self.assertEqual(repr(self.theclass(minutes=-1)),
-                         "-%s(seconds=60)" % name)
+        self.assertEqual(repr(self.theclass()),
+                         "%s(seconds=0)" % name)
+        self.assertEqual(repr(self.theclass(microseconds=100)),
+                         "%s(microseconds=100)" % name)
+        self.assertEqual(repr(self.theclass(days=1, microseconds=100)),
+                         "%s(days=1, microseconds=100)" % name)
+        self.assertEqual(repr(self.theclass(seconds=1, microseconds=100)),
+                         "%s(seconds=1, microseconds=100)" % name)
+        # self.assertEqual(repr(self.theclass(seconds=-60)),
+        #                  "-%s(seconds=60)" % name)
+        # self.assertEqual(repr(self.theclass(minutes=-1)),
+        #                  "-%s(seconds=60)" % name)
 
     def test_roundtrip(self):
         for td in (timedelta(days=999999999, hours=23, minutes=59,

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -50,6 +50,8 @@ for module, suffix in zip(test_modules, test_suffixes):
         cls.tearDownClass = tearDownClass
     all_test_classes.extend(test_classes)
 
+    all_test_classes.extend(test_classes)
+
 def test_main():
     run_unittest(*all_test_classes)
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1766,3 +1766,4 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
+Utkarsh Upadhyay

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1766,4 +1766,3 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
-Utkarsh Upadhyay

--- a/Misc/NEWS.d/next/Library/2017-06-30-23-05-47.bpo-30302.itwK_k.rst
+++ b/Misc/NEWS.d/next/Library/2017-06-30-23-05-47.bpo-30302.itwK_k.rst
@@ -1,0 +1,1 @@
+Use keywords in the ``repr`` of ``datetime.timedelta``.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2285,18 +2285,18 @@ static PyObject *
 delta_repr(PyDateTime_Delta *self)
 {
     if (GET_TD_MICROSECONDS(self) != 0)
-        return PyUnicode_FromFormat("%s(%d, %d, %d)",
+        return PyUnicode_FromFormat("%s(days=%d, seconds=%d, microseconds=%d)",
                                     Py_TYPE(self)->tp_name,
                                     GET_TD_DAYS(self),
                                     GET_TD_SECONDS(self),
                                     GET_TD_MICROSECONDS(self));
     if (GET_TD_SECONDS(self) != 0)
-        return PyUnicode_FromFormat("%s(%d, %d)",
+        return PyUnicode_FromFormat("%s(days=%d, seconds=%d)",
                                     Py_TYPE(self)->tp_name,
                                     GET_TD_DAYS(self),
                                     GET_TD_SECONDS(self));
 
-    return PyUnicode_FromFormat("%s(%d)",
+    return PyUnicode_FromFormat("%s(days=%d)",
                                 Py_TYPE(self)->tp_name,
                                 GET_TD_DAYS(self));
 }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2284,21 +2284,33 @@ delta_bool(PyDateTime_Delta *self)
 static PyObject *
 delta_repr(PyDateTime_Delta *self)
 {
-    if (GET_TD_MICROSECONDS(self) != 0)
-        return PyUnicode_FromFormat("%s(days=%d, seconds=%d, microseconds=%d)",
-                                    Py_TYPE(self)->tp_name,
-                                    GET_TD_DAYS(self),
-                                    GET_TD_SECONDS(self),
-                                    GET_TD_MICROSECONDS(self));
-    if (GET_TD_SECONDS(self) != 0)
-        return PyUnicode_FromFormat("%s(days=%d, seconds=%d)",
-                                    Py_TYPE(self)->tp_name,
-                                    GET_TD_DAYS(self),
-                                    GET_TD_SECONDS(self));
+    char days[64] = "", seconds[64] = "", microseconds[64] = "";
+    if (GET_TD_DAYS(self) != 0) {
+        sprintf(days, "days=%d", GET_TD_DAYS(self));
+    }
 
-    return PyUnicode_FromFormat("%s(days=%d)",
+    if (GET_TD_SECONDS(self) != 0 ||
+            (GET_TD_DAYS(self) == 0 && GET_TD_MICROSECONDS(self) == 0)) {
+        if (strlen(days) == 0) {
+            sprintf(seconds, "seconds=%d", GET_TD_SECONDS(self));
+        } else {
+            sprintf(seconds, ", seconds=%d", GET_TD_SECONDS(self));
+        }
+    }
+
+    if (GET_TD_MICROSECONDS(self) != 0) {
+        if (strlen(days) == 0 && strlen(seconds) == 0) {
+            sprintf(microseconds, "microseconds=%d", GET_TD_MICROSECONDS(self));
+        } else {
+            sprintf(microseconds, ", microseconds=%d", GET_TD_MICROSECONDS(self));
+        }
+    }
+
+    return PyUnicode_FromFormat("%s(%s%s%s)",
                                 Py_TYPE(self)->tp_name,
-                                GET_TD_DAYS(self));
+                                days,
+                                seconds,
+                                microseconds);
 }
 
 static PyObject *

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2293,36 +2293,35 @@ delta_repr(PyDateTime_Delta *self)
     if (GET_TD_DAYS(self) != 0) {
         PyObject *days = PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self));
         if (days == NULL || PyList_Append(args, days) < 0) {
-            Py_DECREF(args);
             Py_XDECREF(days);
-            return NULL;
+            goto error;
         }
         Py_DECREF(days);
     }
 
-
-    if (GET_TD_SECONDS(self) != 0 ||
-        (GET_TD_DAYS(self) == 0 && GET_TD_MICROSECONDS(self) == 0)) {
+    if (GET_TD_SECONDS(self) != 0) {
         PyObject *seconds = PyUnicode_FromFormat("seconds=%d",
                                                  GET_TD_SECONDS(self));
         if (seconds == NULL || PyList_Append(args, seconds) < 0) {
-            Py_DECREF(args);
             Py_XDECREF(seconds);
-            return NULL;
+            goto error;
         }
         Py_DECREF(seconds);
     }
-
 
     if (GET_TD_MICROSECONDS(self) != 0) {
         PyObject *microseconds = PyUnicode_FromFormat("microseconds=%d",
                                                       GET_TD_MICROSECONDS(self));
         if (microseconds == NULL || PyList_Append(args, microseconds) < 0) {
-            Py_DECREF(args);
             Py_XDECREF(microseconds);
-            return NULL;
+            goto error;
         }
         Py_DECREF(microseconds);
+    }
+
+    if (PyList_Size(args) == 0) {
+        Py_DECREF(args);
+        return PyUnicode_FromFormat("%s(0)", Py_TYPE(self)->tp_name);
     }
 
     PyObject *sep = PyUnicode_FromString(", ");
@@ -2344,6 +2343,10 @@ delta_repr(PyDateTime_Delta *self)
                                           args_string);
     Py_DECREF(args_string);
     return repr;
+
+error:
+    Py_DECREF(args);
+    return NULL;
 }
 
 static PyObject *

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2284,62 +2284,46 @@ delta_bool(PyDateTime_Delta *self)
 static PyObject *
 delta_repr(PyDateTime_Delta *self)
 {
-    PyObject *args = PyList_New(0), *days = NULL, *seconds = NULL, *microseconds = NULL;
+    PyObject *args = PyList_New(0);
 
     if (args == NULL) {
         return NULL;
     }
 
     if (GET_TD_DAYS(self) != 0) {
-        days = PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self));
-        if (days == NULL) {
-            Py_DECREF(args);
-            return NULL;
-        }
-
-        if (PyList_Append(args, days) < 0) {
+        PyObject *days = PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self));
+        if (days == NULL || PyList_Append(args, days) < 0) {
             Py_DECREF(args);
             Py_XDECREF(days);
             return NULL;
         }
+        Py_DECREF(days);
     }
+
 
     if (GET_TD_SECONDS(self) != 0 ||
-            (GET_TD_DAYS(self) == 0 && GET_TD_MICROSECONDS(self) == 0)) {
-        seconds = PyUnicode_FromFormat("seconds=%d", GET_TD_SECONDS(self));
-        if (seconds == NULL) {
+        (GET_TD_DAYS(self) == 0 && GET_TD_MICROSECONDS(self) == 0)) {
+        PyObject *seconds = PyUnicode_FromFormat("seconds=%d",
+                                                 GET_TD_SECONDS(self));
+        if (seconds == NULL || PyList_Append(args, seconds) < 0) {
             Py_DECREF(args);
-            Py_XDECREF(days);
-            return NULL;
-        }
-
-        if (PyList_Append(args, seconds) < 0) {
-            Py_DECREF(args);
-            Py_XDECREF(days);
             Py_XDECREF(seconds);
             return NULL;
         }
+        Py_DECREF(seconds);
     }
+
 
     if (GET_TD_MICROSECONDS(self) != 0) {
-        microseconds = PyUnicode_FromFormat("microseconds=%d", GET_TD_MICROSECONDS(self));
-        if (microseconds == NULL) {
+        PyObject *microseconds = PyUnicode_FromFormat("microseconds=%d",
+                                                      GET_TD_MICROSECONDS(self));
+        if (microseconds == NULL || PyList_Append(args, microseconds) < 0) {
             Py_DECREF(args);
-            Py_XDECREF(days);
-            Py_XDECREF(seconds);
-        }
-
-        if (PyList_Append(args, microseconds) < 0) {
-            Py_DECREF(args);
-            Py_XDECREF(days);
-            Py_XDECREF(seconds);
             Py_XDECREF(microseconds);
+            return NULL;
         }
+        Py_DECREF(microseconds);
     }
-
-    Py_XDECREF(days);
-    Py_XDECREF(seconds);
-    Py_XDECREF(microseconds);
 
     PyObject *sep = PyUnicode_FromString(", ");
     if (sep == NULL) {
@@ -2348,15 +2332,12 @@ delta_repr(PyDateTime_Delta *self)
     }
 
     PyObject *args_string = PyUnicode_Join(sep, args);
-
-    if (args_string == NULL) {
-        Py_DECREF(sep);
-        Py_DECREF(args);
-        return NULL;
-    }
-
     Py_DECREF(sep);
     Py_DECREF(args);
+
+    if (args_string == NULL) {
+        return NULL;
+    }
 
     PyObject *repr = PyUnicode_FromFormat("%s(%S)",
                                           Py_TYPE(self)->tp_name,

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2320,8 +2320,13 @@ delta_repr(PyDateTime_Delta *self)
     }
 
     if (PyList_Size(args) == 0) {
-        Py_DECREF(args);
-        return PyUnicode_FromFormat("%s(0)", Py_TYPE(self)->tp_name);
+        PyObject *zero = PyUnicode_FromString("0");
+
+        if (zero == NULL || PyList_Append(args, zero) < 0) {
+            Py_XDECREF(zero);
+            goto error;
+        }
+        Py_DECREF(zero);
     }
 
     PyObject *sep = PyUnicode_FromString(", ");

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2284,33 +2284,26 @@ delta_bool(PyDateTime_Delta *self)
 static PyObject *
 delta_repr(PyDateTime_Delta *self)
 {
-    char days[64] = "", seconds[64] = "", microseconds[64] = "";
+    PyObject *args = PyList_New(0);
+
     if (GET_TD_DAYS(self) != 0) {
-        sprintf(days, "days=%d", GET_TD_DAYS(self));
+        PyList_Append(args, PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self)));
     }
 
     if (GET_TD_SECONDS(self) != 0 ||
             (GET_TD_DAYS(self) == 0 && GET_TD_MICROSECONDS(self) == 0)) {
-        if (strlen(days) == 0) {
-            sprintf(seconds, "seconds=%d", GET_TD_SECONDS(self));
-        } else {
-            sprintf(seconds, ", seconds=%d", GET_TD_SECONDS(self));
-        }
+        PyList_Append(args, PyUnicode_FromFormat("seconds=%d", GET_TD_SECONDS(self)));
     }
 
     if (GET_TD_MICROSECONDS(self) != 0) {
-        if (strlen(days) == 0 && strlen(seconds) == 0) {
-            sprintf(microseconds, "microseconds=%d", GET_TD_MICROSECONDS(self));
-        } else {
-            sprintf(microseconds, ", microseconds=%d", GET_TD_MICROSECONDS(self));
-        }
+        PyList_Append(args, PyUnicode_FromFormat("microseconds=%d", GET_TD_MICROSECONDS(self)));
     }
 
-    return PyUnicode_FromFormat("%s(%s%s%s)",
+    PyObject *args_string = PyUnicode_Join(PyUnicode_FromString(", "), args);
+
+    return PyUnicode_FromFormat("%s(%S)",
                                 Py_TYPE(self)->tp_name,
-                                days,
-                                seconds,
-                                microseconds);
+                                args_string);
 }
 
 static PyObject *

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2284,26 +2284,40 @@ delta_bool(PyDateTime_Delta *self)
 static PyObject *
 delta_repr(PyDateTime_Delta *self)
 {
-    PyObject *args = PyList_New(0);
+    PyObject *args = PyList_New(0), *days = NULL, *seconds = NULL, *microseconds = NULL;
 
     if (GET_TD_DAYS(self) != 0) {
-        PyList_Append(args, PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self)));
+        days = PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self));
+        PyList_Append(args, days);
     }
 
     if (GET_TD_SECONDS(self) != 0 ||
             (GET_TD_DAYS(self) == 0 && GET_TD_MICROSECONDS(self) == 0)) {
-        PyList_Append(args, PyUnicode_FromFormat("seconds=%d", GET_TD_SECONDS(self)));
+        seconds = PyUnicode_FromFormat("seconds=%d", GET_TD_SECONDS(self));
+        PyList_Append(args, seconds);
     }
 
     if (GET_TD_MICROSECONDS(self) != 0) {
-        PyList_Append(args, PyUnicode_FromFormat("microseconds=%d", GET_TD_MICROSECONDS(self)));
+        microseconds = PyUnicode_FromFormat("microseconds=%d", GET_TD_MICROSECONDS(self));
+        PyList_Append(args, microseconds);
     }
 
-    PyObject *args_string = PyUnicode_Join(PyUnicode_FromString(", "), args);
+    Py_XDECREF(days);
+    Py_XDECREF(seconds);
+    Py_XDECREF(microseconds);
 
-    return PyUnicode_FromFormat("%s(%S)",
-                                Py_TYPE(self)->tp_name,
-                                args_string);
+    PyObject *sep = PyUnicode_FromString(", ");
+    PyObject *args_string = PyUnicode_Join(sep, args);
+
+    Py_DECREF(sep);
+    Py_DECREF(args);
+
+    PyObject *repr = PyUnicode_FromFormat("%s(%S)",
+                                          Py_TYPE(self)->tp_name,
+                                          args_string);
+    Py_DECREF(args_string);
+
+    return repr;
 }
 
 static PyObject *

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2284,72 +2284,55 @@ delta_bool(PyDateTime_Delta *self)
 static PyObject *
 delta_repr(PyDateTime_Delta *self)
 {
-    PyObject *args = PyList_New(0);
+    PyObject *args = PyUnicode_FromString("");
 
     if (args == NULL) {
         return NULL;
     }
 
+    char *sep = "";
+
     if (GET_TD_DAYS(self) != 0) {
-        PyObject *days = PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self));
-        if (days == NULL || PyList_Append(args, days) < 0) {
-            Py_XDECREF(days);
-            goto error;
+        Py_SETREF(args, PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self)));
+        if (args == NULL) {
+            return NULL;
         }
-        Py_DECREF(days);
+        sep = ", ";
     }
 
     if (GET_TD_SECONDS(self) != 0) {
-        PyObject *seconds = PyUnicode_FromFormat("seconds=%d",
-                                                 GET_TD_SECONDS(self));
-        if (seconds == NULL || PyList_Append(args, seconds) < 0) {
-            Py_XDECREF(seconds);
-            goto error;
+        Py_SETREF(args, PyUnicode_FromFormat("%U%sseconds=%d",
+                                             args,
+                                             sep,
+                                             GET_TD_SECONDS(self)));
+        if (args == NULL) {
+            return NULL;
         }
-        Py_DECREF(seconds);
+        sep = ", ";
     }
 
     if (GET_TD_MICROSECONDS(self) != 0) {
-        PyObject *microseconds = PyUnicode_FromFormat("microseconds=%d",
-                                                      GET_TD_MICROSECONDS(self));
-        if (microseconds == NULL || PyList_Append(args, microseconds) < 0) {
-            Py_XDECREF(microseconds);
-            goto error;
+        Py_SETREF(args, PyUnicode_FromFormat("%U%smicroseconds=%d",
+                                             args,
+                                             sep,
+                                             GET_TD_MICROSECONDS(self)));
+        if (args == NULL) {
+            return NULL;
         }
-        Py_DECREF(microseconds);
     }
 
-    if (PyList_GET_SIZE(args) == 0) {
-        PyObject *zero = PyUnicode_FromString("0");
-        if (zero == NULL || PyList_Append(args, zero) < 0) {
-            Py_XDECREF(zero);
-            goto error;
+    if (PyUnicode_GET_LENGTH(args) == 0) {
+        Py_SETREF(args, PyUnicode_FromString("0"));
+        if (args == NULL) {
+            return NULL;
         }
-        Py_DECREF(zero);
-    }
-
-    PyObject *sep = PyUnicode_FromString(", ");
-    if (sep == NULL) {
-        Py_DECREF(args);
-        return NULL;
-    }
-
-    PyObject *args_string = PyUnicode_Join(sep, args);
-    Py_DECREF(sep);
-    Py_DECREF(args);
-    if (args_string == NULL) {
-        return NULL;
     }
 
     PyObject *repr = PyUnicode_FromFormat("%s(%S)",
                                           Py_TYPE(self)->tp_name,
-                                          args_string);
-    Py_DECREF(args_string);
-    return repr;
-
-error:
+                                          args);
     Py_DECREF(args);
-    return NULL;
+    return repr;
 }
 
 static PyObject *

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2290,7 +2290,7 @@ delta_repr(PyDateTime_Delta *self)
         return NULL;
     }
 
-    char *sep = "";
+    const char *sep = "";
 
     if (GET_TD_DAYS(self) != 0) {
         Py_SETREF(args, PyUnicode_FromFormat("days=%d", GET_TD_DAYS(self)));
@@ -2301,9 +2301,7 @@ delta_repr(PyDateTime_Delta *self)
     }
 
     if (GET_TD_SECONDS(self) != 0) {
-        Py_SETREF(args, PyUnicode_FromFormat("%U%sseconds=%d",
-                                             args,
-                                             sep,
+        Py_SETREF(args, PyUnicode_FromFormat("%U%sseconds=%d", args, sep,
                                              GET_TD_SECONDS(self)));
         if (args == NULL) {
             return NULL;
@@ -2312,9 +2310,7 @@ delta_repr(PyDateTime_Delta *self)
     }
 
     if (GET_TD_MICROSECONDS(self) != 0) {
-        Py_SETREF(args, PyUnicode_FromFormat("%U%smicroseconds=%d",
-                                             args,
-                                             sep,
+        Py_SETREF(args, PyUnicode_FromFormat("%U%smicroseconds=%d", args, sep,
                                              GET_TD_MICROSECONDS(self)));
         if (args == NULL) {
             return NULL;
@@ -2328,8 +2324,7 @@ delta_repr(PyDateTime_Delta *self)
         }
     }
 
-    PyObject *repr = PyUnicode_FromFormat("%s(%S)",
-                                          Py_TYPE(self)->tp_name,
+    PyObject *repr = PyUnicode_FromFormat("%s(%S)", Py_TYPE(self)->tp_name,
                                           args);
     Py_DECREF(args);
     return repr;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2319,9 +2319,8 @@ delta_repr(PyDateTime_Delta *self)
         Py_DECREF(microseconds);
     }
 
-    if (PyList_Size(args) == 0) {
+    if (PyList_GET_SIZE(args) == 0) {
         PyObject *zero = PyUnicode_FromString("0");
-
         if (zero == NULL || PyList_Append(args, zero) < 0) {
             Py_XDECREF(zero);
             goto error;
@@ -2338,7 +2337,6 @@ delta_repr(PyDateTime_Delta *self)
     PyObject *args_string = PyUnicode_Join(sep, args);
     Py_DECREF(sep);
     Py_DECREF(args);
-
     if (args_string == NULL) {
         return NULL;
     }


### PR DESCRIPTION
Currently, the default implementation of datetime.datetime.__repr__ (the default output string produced at the console/IPython) gives a rather cryptic output:

```python
from datetime import datetime as D
D.fromtimestamp(1390953543.1) - D.fromtimestamp(1121871596)
# datetime.timedelta(3114, 28747, 100000)
```

For the uninitiated, it is not obvious that the numeric values here are `days`, `seconds` and `microsecond` respectively.

Would there be any pushback against changing this to:

```python
# datetime.timedelta(days=3114, seconds=28747, microseconds=100000)
```

?

<!-- issue-number: bpo-30302 -->
https://bugs.python.org/issue30302
<!-- /issue-number -->
