### PR TITLE
bpo-30306: release arguments of contextmanager

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -83,6 +83,9 @@ class _GeneratorContextManager(_GeneratorContextManagerBase,
         return self.__class__(self.func, self.args, self.kwds)
 
     def __enter__(self):
+        # do not keep args and kwds alive unnecessarily
+        # they are only needed for recreation, which is not possible anymore
+        del self.args, self.kwds, self.func
         try:
             return next(self.gen)
         except StopIteration:

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -7,6 +7,7 @@ import threading
 import unittest
 from contextlib import *  # Tests __all__
 from test import support
+import weakref
 
 
 class TestAbstractContextManager(unittest.TestCase):
@@ -217,6 +218,21 @@ def woohoo():
             yield (self, func, args, kwds)
         with woohoo(self=11, func=22, args=33, kwds=44) as target:
             self.assertEqual(target, (11, 22, 33, 44))
+
+    def test_nokeepref(self):
+        class A:
+            pass
+
+        @contextmanager
+        def woohoo(a, b):
+            a = weakref.ref(a)
+            b = weakref.ref(b)
+            self.assertIsNone(a())
+            self.assertIsNone(b())
+            yield
+
+        with woohoo(A(), b=A()):
+            pass
 
 
 class ClosingTestCase(unittest.TestCase):

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -246,6 +246,25 @@ def woohoo():
         with self.assertRaises(TypeError):
             woohoo(b=3)
 
+    def test_recursive(self):
+        depth = 0
+        @contextmanager
+        def woohoo():
+            nonlocal depth
+            before = depth
+            depth += 1
+            yield
+            depth -= 1
+            self.assertEqual(depth, before)
+
+        @woohoo()
+        def recursive():
+            if depth < 10:
+                recursive()
+
+        recursive()
+        self.assertEqual(depth, 0)
+
 
 class ClosingTestCase(unittest.TestCase):
 

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -234,6 +234,18 @@ def woohoo():
         with woohoo(A(), b=A()):
             pass
 
+    def test_param_errors(self):
+        @contextmanager
+        def woohoo(a, *, b):
+            yield
+
+        with self.assertRaises(TypeError):
+            woohoo()
+        with self.assertRaises(TypeError):
+            woohoo(3, 5)
+        with self.assertRaises(TypeError):
+            woohoo(b=3)
+
 
 class ClosingTestCase(unittest.TestCase):
 


### PR DESCRIPTION
The arguments of a function which was declared as a contextmanager
are stored inside the context manager, and thus are kept alive.

This is a possible unnecessary memory leak.

This fixes the problem and adds a test for it. Look at the test to see an example of the problem.

<!-- issue-number: bpo-30306 -->
https://bugs.python.org/issue30306
<!-- /issue-number -->
