### PR TITLE
bpo-30217: add the operators ~ and | to the index

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -394,10 +394,12 @@ Bitwise Operations on Integer Types
    pair: bitwise; operations
    pair: shifting; operations
    pair: masking; operations
+   operator: |
    operator: ^
    operator: &
    operator: <<
    operator: >>
+   operator: ~
 
 Bitwise operations only make sense for integers.  Negative numbers are treated
 as their 2's complement value (this assumes that there are enough bits so that


### PR DESCRIPTION
Fix [bpo-30217](http://bugs.python.org/issue30217): *Missing entry for the tilde (~) operator in the Index*.  Also the `|` operator was not indexed.