### PR TITLE
bpo-30181: parse docstring using pydoc

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -342,13 +342,11 @@ class _AssertLogsContext(_BaseTestCaseContext):
 def _get_short_description(doc):
     # Return the summary line from a docstring.
     # If there is no summary line, return None.
-    if doc:
-        (synopsis, long_description) = pydoc.splitdoc(doc)
-        synopsis = synopsis.strip()
-    else:
-        # The text is either an empty string, or some other false value.
-        synopsis = None
+    if not doc:
+        return None
 
+    (synopsis, long_description) = pydoc.splitdoc(doc)
+    synopsis = synopsis.strip()
     return synopsis
 
 

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -339,11 +339,11 @@ class _AssertLogsContext(_BaseTestCaseContext):
                 .format(logging.getLevelName(self.level), self.logger.name))
 
 
-def _get_short_description(text):
+def _get_short_description(doc):
     # Return the summary line from a docstring.
     # If there is no summary line, return None.
-    if text:
-        (synopsis, long_description) = pydoc.splitdoc(text)
+    if doc:
+        (synopsis, long_description) = pydoc.splitdoc(doc)
         synopsis = synopsis.strip()
     else:
         # The text is either an empty string, or some other false value.

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -340,8 +340,11 @@ class _AssertLogsContext(_BaseTestCaseContext):
 
 
 def _get_short_description(doc):
-    # Return the summary line from a docstring.
-    # If there is no summary line, return None.
+    """
+    Return the summary line from a docstring.
+
+    If there is no summary line, return None.
+    """
     if not doc:
         return None
 

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -477,7 +477,12 @@ class TestCase(object):
         return result.TestResult()
 
     def shortDescription(self):
-        """ Return a one-line description of the test, if any; otherwise None. """
+        """Returns a one-line description of the test, or None if no
+        description has been provided.
+
+        This method returns the summary line of
+        the specified test method's docstring, as per PEP-257.
+        """
         return _short_description_from_docstring(self._testMethodDoc)
 
     def id(self):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -340,14 +340,8 @@ class _AssertLogsContext(_BaseTestCaseContext):
 
 
 def short_description_from_docstring(text):
-    """
-    Return the test case short description from a docstring.
-
-    Ths docstring is parsed by the standard `pydoc.splitdoc` function
-    into (`synopsis`, `long_description`).
-
-    If there is no `synopsis`, return None.
-    """
+    # Return the summary line from a docstring.
+    # If there is no summary line, return None.
     if text:
         (synopsis, long_description) = pydoc.splitdoc(text)
         synopsis = synopsis.strip()

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -339,7 +339,7 @@ class _AssertLogsContext(_BaseTestCaseContext):
                 .format(logging.getLevelName(self.level), self.logger.name))
 
 
-def short_description_from_docstring(text):
+def _short_description_from_docstring(text):
     # Return the summary line from a docstring.
     # If there is no summary line, return None.
     if text:
@@ -478,7 +478,7 @@ class TestCase(object):
 
     def shortDescription(self):
         """ Return a one-line description of the test, if any; otherwise None. """
-        return short_description_from_docstring(self._testMethodDoc)
+        return _short_description_from_docstring(self._testMethodDoc)
 
     def id(self):
         return "%s.%s" % (strclass(self.__class__), self._testMethodName)
@@ -1402,7 +1402,7 @@ class FunctionTestCase(TestCase):
     def shortDescription(self):
         if self._description is not None:
             return self._description
-        return short_description_from_docstring(self._testFunc.__doc__)
+        return _short_description_from_docstring(self._testFunc.__doc__)
 
 
 class _SubTest(TestCase):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -339,7 +339,7 @@ class _AssertLogsContext(_BaseTestCaseContext):
                 .format(logging.getLevelName(self.level), self.logger.name))
 
 
-def _short_description_from_docstring(text):
+def _get_short_description(text):
     # Return the summary line from a docstring.
     # If there is no summary line, return None.
     if text:
@@ -483,7 +483,7 @@ class TestCase(object):
         This method returns the summary line of
         the specified test method's docstring, as per PEP-257.
         """
-        return _short_description_from_docstring(self._testMethodDoc)
+        return _get_short_description(self._testMethodDoc)
 
     def id(self):
         return "%s.%s" % (strclass(self.__class__), self._testMethodName)
@@ -1407,7 +1407,7 @@ class FunctionTestCase(TestCase):
     def shortDescription(self):
         if self._description is not None:
             return self._description
-        return _short_description_from_docstring(self._testFunc.__doc__)
+        return _get_short_description(self._testFunc.__doc__)
 
 
 class _SubTest(TestCase):

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -606,6 +606,38 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
             " to get the shortDescription.")
         self.assertEqual(self.shortDescription(), expected_description)
 
+    @unittest.skipIf(
+        sys.flags.optimize >= 2,
+        "Docstrings are omitted with -O2 and above")
+    def testShortDescriptionWithSurroundingNewlineOneLineDocstring(self):
+        """
+        Surrounding newlines should be stripped to get the shortDescription.
+        """
+        expected_description = (
+            "Surrounding newlines should be stripped"
+            " to get the shortDescription.")
+        self.assertEqual(self.shortDescription(), expected_description)
+
+    @unittest.skipIf(
+        sys.flags.optimize >= 2,
+        "Docstrings are omitted with -O2 and above")
+    def testShortDescriptionWithSurroundingNewlineMultiLineDocstring(self):
+        """
+        Surrounding newlines should be stripped to get the shortDescription.
+
+        The specification of how docstring space should be parsed is at
+        https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
+        which requires that “Blank lines should be removed from the
+        beginning and end of the docstring.”
+
+        The PEP 257 algorithm is implemented by `pydoc.splitdoc`.
+
+        """
+        expected_description = (
+            "Surrounding newlines should be stripped"
+            " to get the shortDescription.")
+        self.assertEqual(self.shortDescription(), expected_description)
+
     def testAddTypeEqualityFunc(self):
         class SadSnake(object):
             """Dummy class for test_addTypeEqualityFunc."""

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -596,6 +596,16 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
                  'Tests shortDescription() for a method with a longer '
                  'docstring.')
 
+    @unittest.skipIf(
+        sys.flags.optimize >= 2,
+        "Docstrings are omitted with -O2 and above")
+    def testShortDescriptionWithSurroundingSpaceOneLineDocstring(self):
+        """ Surrounding space should be stripped to get the shortDescription. """
+        expected_description = (
+            "Surrounding space should be stripped"
+            " to get the shortDescription.")
+        self.assertEqual(self.shortDescription(), expected_description)
+
     def testAddTypeEqualityFunc(self):
         class SadSnake(object):
             """Dummy class for test_addTypeEqualityFunc."""

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -577,7 +577,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
     def testShortDescriptionWithOneLineDocstring(self):
-        """Tests shortDescription() for a method with a docstring."""
+        """ Tests shortDescription() for a method with a docstring."""
         self.assertEqual(
                 self.shortDescription(),
                 'Tests shortDescription() for a method with a docstring.')
@@ -585,7 +585,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
     @unittest.skipIf(sys.flags.optimize >= 2,
                      "Docstrings are omitted with -O2 and above")
     def testShortDescriptionWithMultiLineDocstring(self):
-        """Tests shortDescription() for a method with a longer docstring.
+        """ Tests shortDescription() for a method with a longer docstring.
 
         This method ensures that only the first line of a docstring is
         returned used in the short description, no matter how long the
@@ -595,16 +595,6 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
                 self.shortDescription(),
                  'Tests shortDescription() for a method with a longer '
                  'docstring.')
-
-    @unittest.skipIf(
-        sys.flags.optimize >= 2,
-        "Docstrings are omitted with -O2 and above")
-    def testShortDescriptionWithSurroundingSpaceOneLineDocstring(self):
-        """ Surrounding space should be stripped to get the shortDescription. """
-        expected_description = (
-            "Surrounding space should be stripped"
-            " to get the shortDescription.")
-        self.assertEqual(self.shortDescription(), expected_description)
 
     @unittest.skipIf(
         sys.flags.optimize >= 2,

--- a/Lib/unittest/test/test_functiontestcase.py
+++ b/Lib/unittest/test/test_functiontestcase.py
@@ -147,6 +147,14 @@ class Test_FunctionTestCase(unittest.TestCase):
         expected_description = "Should use the function docstring."
         self.assertEqual(test.shortDescription(), expected_description)
 
+    def test_shortDescription__singleline_docstring_space_surrounded(self):
+        """ Surrounding space should be stripped to get the shortDescription. """
+        test_function = (lambda: None)
+        test_function.__doc__ = """ Surrounding space should be stripped. """
+        test = unittest.FunctionTestCase(test_function)
+        expected_description = "Surrounding space should be stripped."
+        self.assertEqual(test.shortDescription(), expected_description)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/unittest/test/test_functiontestcase.py
+++ b/Lib/unittest/test/test_functiontestcase.py
@@ -126,22 +126,26 @@ class Test_FunctionTestCase(unittest.TestCase):
 
         self.assertIsInstance(test.id(), str)
 
-    # "Returns a one-line description of the test, or None if no description
-    # has been provided. The default implementation of this method returns
-    # the first line of the test method's docstring, if available, or None."
-    def test_shortDescription__no_docstring(self):
+    def test_shortDescription__no_description_no_docstring(self):
+        """ Should return None by default for shortDescription. """
         test = unittest.FunctionTestCase(lambda: None)
 
         self.assertEqual(test.shortDescription(), None)
 
-    # "Returns a one-line description of the test, or None if no description
-    # has been provided. The default implementation of this method returns
-    # the first line of the test method's docstring, if available, or None."
-    def test_shortDescription__singleline_docstring(self):
+    def test_shortDescription__singleline_description(self):
+        """ Should use the specified description for shortDescription. """
         desc = "this tests foo"
         test = unittest.FunctionTestCase(lambda: None, description=desc)
 
         self.assertEqual(test.shortDescription(), "this tests foo")
+
+    def test_shortDescription__no_description_singleline_docstring(self):
+        """ Should use the function docstring for the shortDescription. """
+        test_function = (lambda: None)
+        test_function.__doc__ = """Should use the function docstring."""
+        test = unittest.FunctionTestCase(test_function)
+        expected_description = "Should use the function docstring."
+        self.assertEqual(test.shortDescription(), expected_description)
 
 
 if __name__ == "__main__":

--- a/Lib/unittest/test/test_functiontestcase.py
+++ b/Lib/unittest/test/test_functiontestcase.py
@@ -155,6 +155,36 @@ class Test_FunctionTestCase(unittest.TestCase):
         expected_description = "Surrounding space should be stripped."
         self.assertEqual(test.shortDescription(), expected_description)
 
+    def test_shortDescription__singleline_docstring_newline_surrounded(self):
+        """
+        Surrounding newlines should be stripped to get the shortDescription.
+        """
+        test_function = (lambda: None)
+        test_function.__doc__ = """
+            Surrounding newlines should be stripped.
+            """
+        test = unittest.FunctionTestCase(test_function)
+        expected_description = "Surrounding newlines should be stripped."
+        self.assertEqual(test.shortDescription(), expected_description)
+
+    def test_shortDescription__multiline_docstring_newline_surrounded(self):
+        """
+        Surrounding newlines should be stripped to get the shortDescription.
+        """
+        test_function = (lambda: None)
+        test_function.__doc__ = """
+            Surrounding newlines should be stripped.
+
+            The specification of how docstring space should be parsed is at
+            https://www.python.org/dev/peps/pep-0257/#handling-docstring-indentation
+            which requires that “Blank lines should be removed from the
+            beginning and end of the docstring.”
+
+            """
+        test = unittest.FunctionTestCase(test_function)
+        expected_description = "Surrounding newlines should be stripped."
+        self.assertEqual(test.shortDescription(), expected_description)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/unittest/test/test_result.py
+++ b/Lib/unittest/test/test_result.py
@@ -369,6 +369,7 @@ class Test_TestResult(unittest.TestCase):
                      "Docstrings are omitted with -O2 and above")
     def testGetDescriptionWithMultiLineDocstring(self):
         """Tests getDescription() for a method with a longer docstring.
+
         The second line of the docstring.
         """
         result = unittest.TextTestResult(None, True, 1)
@@ -383,6 +384,7 @@ class Test_TestResult(unittest.TestCase):
                      "Docstrings are omitted with -O2 and above")
     def testGetSubTestDescriptionWithMultiLineDocstring(self):
         """Tests getDescription() for a method with a longer docstring.
+
         The second line of the docstring.
         """
         result = unittest.TextTestResult(None, True, 1)


### PR DESCRIPTION
Rebased and copied Ben Finney's changes from http://bugs.python.org/issue30181

I hope master is the correct branch to merge this into.

<!-- issue-number: [bpo-30181](https://bugs.python.org/issue30181) -->
https://bugs.python.org/issue30181
<!-- /issue-number -->
