### PR TITLE
[3.6] bpo-30289: remove Misc/python-config.sh when make distclean

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1630,7 +1630,8 @@ distclean: clobber
 	done
 	-rm -f core Makefile Makefile.pre config.status \
 		Modules/Setup Modules/Setup.local Modules/Setup.config \
-		Modules/ld_so_aix Modules/python.exp Misc/python.pc
+		Modules/ld_so_aix Modules/python.exp Misc/python.pc \
+		Misc/python-config.sh
 	-rm -f python*-gdb.py
 	# Issue #28258: set LC_ALL to avoid issues with Estonian locale.
 	# Expansion is performed here by shell (spawned by make) itself before


### PR DESCRIPTION
backports to 3.6 for #1498 