### PR TITLE
[3.5] bpo-29990: Fix range checking in GB18030 decoder

### DIFF
--- a/Lib/test/test_codecencodings_cn.py
+++ b/Lib/test/test_codecencodings_cn.py
@@ -49,6 +49,12 @@ class Test_GB18030(multibytecodec_support.TestBase, unittest.TestCase):
         (b"abc\x84\x32\x80\x80def", "replace", 'abc\ufffd2\ufffd\ufffddef'),
         (b"abc\x81\x30\x81\x30def", "strict", 'abc\x80def'),
         (b"abc\x86\x30\x81\x30def", "replace", 'abc\ufffd0\ufffd0def'),
+        # issue29990
+        (b"\xff\x30\x81\x30", "strict", None),
+        (b"\x81\x30\xff\x30", "strict", None),
+        (b"abc\x81\x39\xff\x39\xc1\xc4", "replace", "abc\ufffd\x39\ufffd\x39\u804a"),
+        (b"abc\xab\x36\xff\x30def", "replace", 'abc\ufffd\x36\ufffd\x30def'),
+        (b"abc\xbf\x38\xff\x32\xc1\xc4", "ignore",  "abc\x38\x32\u804a"),
     )
     has_iso10646 = True
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -49,6 +49,8 @@ Extension Modules
 Library
 -------
 
+- bpo-29990: Fix range checking in GB18030 decoder.  Original patch by Ma Lin.
+
 - Revert bpo-26293 for zipfile breakage. See also bpo-29094.
 
 - bpo-30243: Removed the __init__ methods of _json's scanner and encoder.

--- a/Modules/cjkcodecs/_codecs_cn.c
+++ b/Modules/cjkcodecs/_codecs_cn.c
@@ -279,7 +279,9 @@ DECODER(gb18030)
             REQUIRE_INBUF(4);
             c3 = INBYTE3;
             c4 = INBYTE4;
-            if (c < 0x81 || c3 < 0x81 || c4 < 0x30 || c4 > 0x39)
+            if (c  < 0x81 || c  > 0xFE ||
+                c3 < 0x81 || c3 > 0xFE ||
+                c4 < 0x30 || c4 > 0x39)
                 return 1;
             c -= 0x81;  c2 -= 0x30;
             c3 -= 0x81; c4 -= 0x30;


### PR DESCRIPTION
When decoding a 4-byte GB18030 sequence, the first and third byte cannot exceed 0xFE.