### PR TITLE
[2.7] bpo-29243: Fix Makefile with respect to --enable-optimizations …

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -844,12 +844,12 @@ $(LIBRARY_OBJS) $(MODOBJS) Modules/python.o: $(PYTHON_HEADERS)
 TESTOPTS=	-l $(EXTRATESTOPTS)
 TESTPROG=	$(srcdir)/Lib/test/regrtest.py
 TESTPYTHON=	$(RUNSHARED) ./$(BUILDPYTHON) -Wd -3 -E -tt $(TESTPYTHONOPTS)
-test:		all platform
+test:		@DEF_MAKE_RULE@ platform
 		-find $(srcdir)/Lib -name '*.py[co]' -print | xargs rm -f
 		-$(TESTPYTHON) $(TESTPROG) $(TESTOPTS)
 		$(TESTPYTHON) $(TESTPROG) $(TESTOPTS)
 
-testall:	all platform
+testall:	@DEF_MAKE_RULE@ platform
 		-find $(srcdir)/Lib -name '*.py[co]' -print | xargs rm -f
 		$(TESTPYTHON) $(srcdir)/Lib/compileall.py
 		-find $(srcdir)/Lib -name '*.py[co]' -print | xargs rm -f
@@ -858,7 +858,7 @@ testall:	all platform
 
 #  Run the unitests for both architectures in a Universal build on OSX
 #  Must be run on an Intel box.
-testuniversal:	all platform
+testuniversal:	@DEF_MAKE_RULE@ platform
 		if [ `arch` != 'i386' ];then \
 			echo "This can only be used on OSX/i386" ;\
 			exit 1 ;\
@@ -881,14 +881,14 @@ QUICKTESTOPTS=	$(TESTOPTS) -x test_subprocess test_io test_lib2to3 \
 		test_multibytecodec test_urllib2_localnet test_itertools \
 		test_multiprocessing test_mailbox test_socket test_poll \
 		test_select test_zipfile
-quicktest:	all platform
+quicktest:	@DEF_MAKE_RULE@ platform
 		-find $(srcdir)/Lib -name '*.py[co]' -print | xargs rm -f
 		-$(TESTPYTHON) $(TESTPROG) $(QUICKTESTOPTS)
 		$(TESTPYTHON) $(TESTPROG) $(QUICKTESTOPTS)
 
 MEMTESTOPTS=    $(QUICKTESTOPTS) -x test_dl test___all__ test_fork1 \
 		test_longexp
-memtest:	all platform
+memtest:	@DEF_MAKE_RULE@ platform
 		-rm -f $(srcdir)/Lib/test/*.py[co]
 		-$(TESTPYTHON) $(TESTPROG) $(MEMTESTOPTS)
 		$(TESTPYTHON) $(TESTPROG) $(MEMTESTOPTS)
@@ -1179,7 +1179,7 @@ LIBPL=		$(LIBP)/config
 # pkgconfig directory
 LIBPC=		$(LIBDIR)/pkgconfig
 
-libainstall:	all python-config
+libainstall:	@DEF_MAKE_RULE@ python-config
 	@for i in $(LIBDIR) $(LIBP) $(LIBPL) $(LIBPC); \
 	do \
 		if test ! -d $(DESTDIR)$$i; then \
@@ -1417,7 +1417,7 @@ distclean: clobber
 				     -exec rm -f {} ';'
 
 # Check for smelly exported symbols (not starting with Py/_Py)
-smelly: all
+smelly: @DEF_MAKE_RULE@
 	nm -p $(LIBRARY) | \
 		sed -n "/ [TDB] /s/.* //p" | grep -v "^_*Py" | sort -u; \
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1026,6 +1026,7 @@ Jason Orendorff
 Douglas Orr
 William Orr
 Michele Orrù
+Tomáš Orsava
 Oleg Oshmyan
 Denis S. Otkidach
 Peter Otten

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -139,6 +139,10 @@ Documentation
 Build
 -----
 
+ bpo-29243: Prevent unnecessary rebuilding of Python during ``make test``,
+  ``make install`` and some other make targets when configured with
+  ``--enable-optimizations``.
+
 - bpo-23404: Don't regenerate generated files based on file modification time
   anymore: the action is now explicit. Replace ``make touch`` with
   ``make regen-all``.


### PR DESCRIPTION
…(GH-1478)

* bpo-29243: Fix Makefile with respect to --enable-optimizations

When using the Profile Guided Optimization (./configure --enable-optimizations)
Python is built not only during `make` but rebuilt again during `make test`,
`make install` and others. This patch fixes the issue.

Note that this fix produces no change at all in the Makefile if configure is
run witout --enable-optimizations.

* !squash.
(cherry picked from commit a1054c3b0037d4c2a5492e79fc193f36245366c7)