### PR TITLE
bpo-30335: Add deprecation alias entry for assertNotRegexpMatches

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1168,6 +1168,8 @@ Test cases
       .. versionchanged:: 3.2
          The method ``assertRegexpMatches()`` has been renamed to
          :meth:`.assertRegex`.
+      .. versionadded:: 3.2
+         :meth:`.assertNotRegex`.
       .. versionadded:: 3.5
          The name ``assertNotRegexpMatches`` as a deprecated alias
          for :meth:`.assertNotRegex`.

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1164,12 +1164,10 @@ Test cases
       expression suitable for use by :func:`re.search`.
 
       .. versionadded:: 3.1
-         under the name ``assertRegexpMatches``.
+         under the names ``assertRegexpMatches`` and ``assertNotRegexpMatches``.
       .. versionchanged:: 3.2
-         The method ``assertRegexpMatches()`` has been renamed to
-         :meth:`.assertRegex`.
-      .. versionadded:: 3.2
-         :meth:`.assertNotRegex`.
+         The methods ``assertRegexpMatches()`` and ``assertNotRegexpMatches``
+         have been renamed to :meth:`.assertRegex` and :meth:`.assertNotRegex`.
 
 
    .. method:: assertCountEqual(first, second, msg=None)
@@ -1435,9 +1433,9 @@ For historical reasons, some of the :class:`TestCase` methods had one or more
 aliases that are now deprecated.  The following table lists the correct names
 along with their deprecated aliases:
 
-   ==============================  ====================== ======================
+   ==============================  ====================== =======================
     Method Name                     Deprecated alias       Deprecated alias
-   ==============================  ====================== ======================
+   ==============================  ====================== =======================
     :meth:`.assertEqual`            failUnlessEqual        assertEquals
     :meth:`.assertNotEqual`         failIfEqual            assertNotEquals
     :meth:`.assertTrue`             failUnless             assert\_
@@ -1446,16 +1444,18 @@ along with their deprecated aliases:
     :meth:`.assertAlmostEqual`      failUnlessAlmostEqual  assertAlmostEquals
     :meth:`.assertNotAlmostEqual`   failIfAlmostEqual      assertNotAlmostEquals
     :meth:`.assertRegex`                                   assertRegexpMatches
+    :meth:`.assertNotRegex`                                assertNotRegexpMatches
     :meth:`.assertRaisesRegex`                             assertRaisesRegexp
-   ==============================  ====================== ======================
+   ==============================  ====================== =======================
 
    .. deprecated:: 3.1
          the fail* aliases listed in the second column.
    .. deprecated:: 3.2
          the assert* aliases listed in the third column.
    .. deprecated:: 3.2
-         ``assertRegexpMatches`` and ``assertRaisesRegexp`` have been renamed to
-         :meth:`.assertRegex` and :meth:`.assertRaisesRegex`
+         ``assertRegexpMatches``, ``assertNotRegexpMatches`` and
+         ``assertRaisesRegexp`` have been renamed to :meth:`.assertRegex`,
+         :meth:`.assertNotRegex` and :meth:`.assertRaisesRegex`.
 
 
 .. _testsuite-objects:

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1164,10 +1164,13 @@ Test cases
       expression suitable for use by :func:`re.search`.
 
       .. versionadded:: 3.1
-         under the names ``assertRegexpMatches`` and ``assertNotRegexpMatches``.
+         under the name ``assertRegexpMatches``.
       .. versionchanged:: 3.2
-         The methods ``assertRegexpMatches()`` and ``assertNotRegexpMatches``
-         have been renamed to :meth:`.assertRegex` and :meth:`.assertNotRegex`.
+         The method ``assertRegexpMatches()`` has been renamed to
+         :meth:`.assertRegex`.
+      .. versionadded:: 3.5
+         The name ``assertNotRegexpMatches`` as a deprecated alias
+         for :meth:`.assertNotRegex`.
 
 
    .. method:: assertCountEqual(first, second, msg=None)
@@ -1453,10 +1456,10 @@ along with their deprecated aliases:
    .. deprecated:: 3.2
          the assert* aliases listed in the third column.
    .. deprecated:: 3.2
-         ``assertRegexpMatches``, ``assertNotRegexpMatches`` and
-         ``assertRaisesRegexp`` have been renamed to :meth:`.assertRegex`,
-         :meth:`.assertNotRegex` and :meth:`.assertRaisesRegex`.
-
+         ``assertRegexpMatches`` and ``assertRaisesRegexp`` have been renamed to
+         :meth:`.assertRegex` and :meth:`.assertRaisesRegex`.
+   .. deprecated:: 3.5
+         the ``assertNotRegexpMatches`` name in favor of :meth:`.assertNotRegex`.
 
 .. _testsuite-objects:
 

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1171,7 +1171,7 @@ Test cases
       .. versionadded:: 3.2
          :meth:`.assertNotRegex`.
       .. versionadded:: 3.5
-         The name ``assertNotRegexpMatches`` as a deprecated alias
+         The name ``assertNotRegexpMatches`` is a deprecated alias
          for :meth:`.assertNotRegex`.
 
 


### PR DESCRIPTION
Adds ``assertNotRegexpMatches`` to the table of deprecated aliases and fixes some of the directives that failed to mention it.