### PR TITLE
bpo-30329: Catch Windows error 10022 on shutdown()

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -318,9 +318,12 @@ class IMAP4:
         self.file.close()
         try:
             self.sock.shutdown(socket.SHUT_RDWR)
-        except OSError as e:
-            # The server might already have closed the connection
-            if e.errno != errno.ENOTCONN:
+        except OSError as exc:
+            # The server might already have closed the connection.
+            # On Windows, this may result in WSAEINVAL (error 10022):
+            # An invalid operation was attempted.
+            if (exc.errno != errno.ENOTCONN
+               and getattr(exc, 'winerror', 0) != 10022):
                 raise
         finally:
             self.sock.close()

--- a/Lib/poplib.py
+++ b/Lib/poplib.py
@@ -288,9 +288,12 @@ class POP3:
             if sock is not None:
                 try:
                     sock.shutdown(socket.SHUT_RDWR)
-                except OSError as e:
-                    # The server might already have closed the connection
-                    if e.errno != errno.ENOTCONN:
+                except OSError as exc:
+                    # The server might already have closed the connection.
+                    # On Windows, this may result in WSAEINVAL (error 10022):
+                    # An invalid operation was attempted.
+                    if (exc.errno != errno.ENOTCONN
+                       and getattr(exc, 'winerror', 0) != 10022):
                         raise
                 finally:
                     sock.close()

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -323,6 +323,10 @@ Extension Modules
 Library
 -------
 
+- bpo-30329: imaplib and poplib now catch the Windows socket WSAEINVAL error
+  (code 10022) on shutdown(SHUT_RDWR): An invalid operation was attempted.
+  This error occurs sometimes on SSL connections.
+
 - bpo-29196: Removed previously deprecated in Python 2.4 classes Plist, Dict
   and _InternalDict in the plistlib module.  Dict values in the result of
   functions readPlist() and readPlistFromBytes() are now normal dicts.  You


### PR DESCRIPTION
Catch the Windows socket error 10022 (An invalid operation was
attempted) on shutdown(SHUT_RDWR) in imaplib and poplib. This error
occurs sometimes on SSL connections.