### PR TITLE
[3.6] bpo-28787: Fix out of tree --with-dtrace builds (GH-135)

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -875,6 +875,7 @@ Python/frozen.o: $(srcdir)/Python/importlib.h $(srcdir)/Python/importlib_externa
 # follow our naming conventions. dtrace(1) uses the output filename to generate
 # an include guard, so we can't use a pipeline to transform its output.
 Include/pydtrace_probes.h: $(srcdir)/Include/pydtrace.d
+	$(MKDIR_P) Include
 	$(DTRACE) $(DFLAGS) -o $@ -h -s $<
 	: sed in-place edit with POSIX-only tools
 	sed 's/PYTHON_/PyDTrace_/' $@ > $@.tmp

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1476,6 +1476,7 @@ Daniel Stokes
 Michael Stone
 Serhiy Storchaka
 Ken Stox
+Charalampos Stratakis
 Dan Stromberg
 Donald Stufft
 Daniel Stutzbach

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -130,6 +130,9 @@ Library
 Build
 -----
 
+- bpo-28787: Fix out-of-tree builds of Python when configured with
+  ``--with--dtrace``.
+
 - bpo-29243: Prevent unnecessary rebuilding of Python during ``make test``,
   ``make install`` and some other make targets when configured with
   ``--enable-optimizations``.


### PR DESCRIPTION
* bpo-28787: Fix out of tree --with-dtrace builds

* Unsilence directory creation

* Add Misc/NEWS and Misc/ACKS entries.
(cherry picked from commit f6eae5bf1c5d7b83e5d5bdbecfff928e478c1cfd)