### PR TITLE
[2.7] bpo-30342: Fix sysconfig.is_python_build() on VS9.0

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -112,6 +112,11 @@ if os.name == "nt" and "pcbuild" in _PROJECT_BASE[-8:].lower():
 # PC/VS7.1
 if os.name == "nt" and "\\pc\\v" in _PROJECT_BASE[-10:].lower():
     _PROJECT_BASE = _safe_realpath(os.path.join(_PROJECT_BASE, pardir, pardir))
+# PC/VS9.0/amd64
+if (os.name == "nt"
+   and os.path.basename(os.path.dirname(os.path.dirname(_PROJECT_BASE))).lower() == "pc"
+   and os.path.basename(os.path.dirname(_PROJECT_BASE)).lower() == "vs9.0"):
+    _PROJECT_BASE = _safe_realpath(os.path.join(_PROJECT_BASE, pardir, pardir, pardir))
 # PC/AMD64
 if os.name == "nt" and "\\pcbuild\\amd64" in _PROJECT_BASE[-14:].lower():
     _PROJECT_BASE = _safe_realpath(os.path.join(_PROJECT_BASE, pardir, pardir))

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -267,6 +267,8 @@ class ProgramsTestCase(BaseTestCase):
             self.skipTest("Tools/buildbot/test.bat requires PCbuild build, "
                           "found %s" % build_dir)
 
+    @unittest.skipUnless(sysconfig.is_python_build(),
+                         'test.bat script is not installed')
     @unittest.skipUnless(sys.platform == 'win32', 'Windows only')
     def test_tools_buildbot_test(self):
         self.need_pcbuild()

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -42,6 +42,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30342: Fix sysconfig.is_python_build() if Python is built with Visual
+  Studio 2008 (VS 9.0).
+
 - bpo-29990: Fix range checking in GB18030 decoder.  Original patch by Ma Lin.
 
 - bpo-30243: Removed the __init__ methods of _json's scanner and encoder.


### PR DESCRIPTION
Fix sysconfig.is_python_build() if Python is built with Visual Studio 2008 (VS 9.0).