### PR TITLE
PCbuild/build.bat: Add note about using msbuild response file.

### DIFF
--- a/PCbuild/build.bat
+++ b/PCbuild/build.bat
@@ -10,7 +10,12 @@ echo.given.
 echo.
 echo.After the flags recognized by this script, up to 9 arguments to be passed
 echo.directly to MSBuild may be passed.  If the argument contains an '=', the
-echo.entire argument must be quoted (e.g. `%~nx0 "/p:PlatformToolset=v100"`)
+echo.entire argument must be quoted (e.g. `%~nx0 "/p:PlatformToolset=v100"`).
+echo.Alternatively you can put extra flags for MSBuild in a file named 
+echo.`msbuild.rsp` in the `PCbuild` directory, one flag per line. This file
+echo.will be picked automatically by MSBuild. Flags put in this file does not
+echo.need to be quoted. You can still use environment variables inside the 
+echo.response file.
 echo.
 echo.Available flags:
 echo.  -h  Display this help message


### PR DESCRIPTION
Using a response file will eliminate the headache associated with batch argument/quote processing.

For example I unsuccessfully compiled python with visualcpptools when specifying VSInstallDir in the batch file (cannot find vcruntime.h)

```batch
build.bat -p x64 -e -M --no-tkinter "/p:VCInstallDir=%VCInstallDir%"
```

but it built successfully when specifying it in a response file

msbuild.rsp:
```
/p:VCInstallDir=%VCInstallDir%
```