### PR TITLE
[2.7] bpo-6393: Fix locale.getprerredencoding() on macOS

### DIFF
--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -617,10 +617,22 @@ else:
                 except Error:
                     pass
                 result = nl_langinfo(CODESET)
+                if not result and sys.platform == 'darwin':
+                    # nl_langinfo can return an empty string
+                    # when the setting has an invalid value.
+                    # Default to UTF-8 in that case because
+                    # UTF-8 is the default charset on OSX and
+                    # returning nothing will crash the
+                    # interpreter.
+                    result = 'UTF-8'
+
                 setlocale(LC_CTYPE, oldloc)
                 return result
             else:
-                return nl_langinfo(CODESET)
+                result = nl_langinfo(CODESET)
+                if not result and sys.platform == 'darwin':
+                    # See above for explanation
+                    result = 'UTF-8'
 
 
 ### Database


### PR DESCRIPTION
Fix for bpo-6393: Python crashes on OSX when $LANG is set to some (but
not all) invalid values due to an invalid result from nl_langinfo

(cherry picked from commit 6d77e07196bfb5dfa4de6f5d80b2619c0643a75e)