### PR TITLE
bpo-30343: New API for JSON encoder to override supported types

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -183,8 +183,8 @@ Basic Usage
    If specified, *default* should be a function that gets called for objects that
    can't otherwise be serialized.  It should return a JSON encodable version of
    the object or raise a :exc:`TypeError`.  If not specified, :exc:`TypeError`
-   is raised.  This method is deprecated; an implementation of the transform
-   method should be used, instead.
+   is raised.  This argument is deprecated; an implementation of the transform
+   argument should be used, instead.
 
    .. deprecated:: 3.7
 

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -177,7 +177,7 @@ def dump(obj, fp, *, skipkeys=False, ensure_ascii=True, check_circular=True,
     else:
         if cls is None:
             cls = JSONEncoder
-        if default:
+        if default is not None:
             warnings.warn("default is deprecated; use transform, instead", DeprecationWarning)
         iterable = cls(skipkeys=skipkeys, ensure_ascii=ensure_ascii,
             check_circular=check_circular, allow_nan=allow_nan, indent=indent,
@@ -245,7 +245,7 @@ def dumps(obj, *, skipkeys=False, ensure_ascii=True, check_circular=True,
         return _default_encoder.encode(obj)
     if cls is None:
         cls = JSONEncoder
-    if default:
+    if default is not None:
         warnings.warn("default is deprecated; use transform, instead", DeprecationWarning)
     return cls(
         skipkeys=skipkeys, ensure_ascii=ensure_ascii,

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -322,6 +322,10 @@ def _make_iterencode(markers, _transform, _default, _encoder, _indent,
                 first = False
             else:
                 buf = separator
+
+            if _transform is not None:
+                value = _transform(value)
+
             if isinstance(value, str):
                 yield buf + _encoder(value)
             elif value is None:
@@ -404,6 +408,10 @@ def _make_iterencode(markers, _transform, _default, _encoder, _indent,
                 yield item_separator
             yield _encoder(key)
             yield _key_separator
+
+            if _transform is not None:
+                value = _transform(value)
+
             if isinstance(value, str):
                 yield _encoder(value)
             elif value is None:

--- a/Lib/test/test_json/test_transform.py
+++ b/Lib/test/test_json/test_transform.py
@@ -1,0 +1,30 @@
+from test.test_json import PyTest, CTest
+
+
+class TestTransform:
+    def test_transform(self):
+        self.assertEqual(
+            self.dumps(type, transform=repr),
+            self.dumps(repr(type)))
+
+    def test_transform_intrinsics(self):
+        def _transform(o):
+            if isinstance(o, tuple):
+                return "Tuple%s" % str(o)
+
+            if isinstance(o, dict):
+                return "Dict%s" % str(o)
+
+            if isinstance(o, list):
+                return "List%s" % str(o)
+
+            return o
+
+        for t in (1, 2, 3), [1, 2, 3], {"foo": "bar"}:
+            self.assertEqual(
+                self.dumps(t, transform=_transform),
+                self.dumps(_transform(t)))
+
+
+class TestPyTransform(TestTransform, PyTest): pass
+class TestCTransform(TestTransform, CTest): pass


### PR DESCRIPTION
This deprecates `JSONEncoder.default`:
* Custom types should be transformed *before* running through the encoder; not as the last option before failing.
* Its name doesn't give a meaningful indication of what it's used for and the documentation is opaque.
* It is up to the subclass implementation to call the superclass implementation to raise a `TypeError`; while this hasn't been implemented in this PR, this responsibility should be moved to the encoder as a final backstop.

A new method is introduced, `JSONEncoder.transform`, which is also called by `json.dump` and `json.dumps`:
* The `transform` method is run on all objects *before* running through standard type encodings. This allows custom types to be transformed into a compatible type, but unlike the old `default` method, also allowing for transformations on supported types (e.g., you can override the JSON serialisation of a named tuple, or dictionary, etc.).
* Invoking this function for every call to the encoder will add an overhead -- although note that optimisations to my code are surely possible -- but when serialising to JSON we should remember two important factors that somewhat negate the "performance argument":
  * I/O will be the primary bottleneck when dealing with JSON; writing to network or disk will far outweigh the encoding time, potentially by orders of magnitude.
  * If performance is really an issue, maybe Python isn't the right tool for the job. (That's not to dismiss Python, but if super-high throughput JSON encoding is a requirement, then there are more appropriate tools available.)

It is envisaged that `JSONEncoder.default` will ultimately be removed after a suitable deprecation period.

Note that my PR includes proof-of-concept implementations of the Python and C libraries, tests for the new API and documentation. The API implementations are not necessarily optimal and the C implementation doesn't issue `DeprecationWarning` warnings.