### PR TITLE
bpo-27144: concurrent.futures as_complete and map iterators do not keep reference to returned object

### DIFF
--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -172,11 +172,15 @@ def _create_and_install_waiters(fs, return_when):
 
 
 def _yield_and_decref(fs, ref_collect):
-    """Yields a future. Before yielding, removes the future
-    from each set in collection of sets (`ref_collect`)."""
+    """
+    Iterate on the list *fs*, yielding objects one by one in reverse order.
+    Before yielding an object, it is removed from each set in
+    the collection of sets *ref_collect*.
+    """
     while fs:
         for futures_set in ref_collect:
             futures_set.remove(fs[-1])
+        # Careful not to keep a reference to the popped value
         yield fs.pop()
 
 
@@ -566,6 +570,7 @@ class Executor(object):
                 # reverse to keep finishing order
                 fs.reverse()
                 while fs:
+                    # Careful not to keep a reference to the popped future
                     if timeout is None:
                         yield fs.pop().result()
                     else:

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -357,12 +357,12 @@ def _check_system_limits():
     raise NotImplementedError(_system_limited)
 
 
-def _chain_from_iterable(iterable):
+def _chain_from_iterable_of_lists(iterable):
     """
-    Different implementation of itertools.chain.from_iterable.
-    The difference is _chain_from_iterable do not keep reference to returned objects.
+    Specialized implementation of itertools.chain.from_iterable.
+    Each item in *iterable* should be a list.  This function is
+    careful not to keep references to yielded objects.
     """
-
     for element in iterable:
         element.reverse()
         while element:
@@ -494,7 +494,7 @@ class ProcessPoolExecutor(_base.Executor):
         results = super().map(partial(_process_chunk, fn),
                               _get_chunks(*iterables, chunksize=chunksize),
                               timeout=timeout)
-        return _chain_from_iterable(results)
+        return _chain_from_iterable_of_lists(results)
 
     def shutdown(self, wait=True):
         with self._shutdown_lock:

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -357,6 +357,18 @@ def _check_system_limits():
     raise NotImplementedError(_system_limited)
 
 
+def _chain_from_iterable(iterable):
+    """
+    Different implementation of itertools.chain.from_iterable.
+    The difference is _chain_from_iterable do not keep reference to returned objects.
+    """
+
+    for element in iterable:
+        element.reverse()
+        while element:
+            yield element.pop()
+
+
 class BrokenProcessPool(RuntimeError):
     """
     Raised when a process in a ProcessPoolExecutor terminated abruptly
@@ -482,7 +494,7 @@ class ProcessPoolExecutor(_base.Executor):
         results = super().map(partial(_process_chunk, fn),
                               _get_chunks(*iterables, chunksize=chunksize),
                               timeout=timeout)
-        return itertools.chain.from_iterable(results)
+        return _chain_from_iterable(results)
 
     def shutdown(self, wait=True):
         with self._shutdown_lock:

--- a/Misc/NEWS.d/next/Library/2017-08-30-11-26-14.bpo-27144.PEDJsE.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-30-11-26-14.bpo-27144.PEDJsE.rst
@@ -1,2 +1,2 @@
-concurrent.futures as_complie and map iterators do not keep reference to
-returned object
+The ``map()`` and ``as_completed()`` iterators in ``concurrent.futures``
+now avoid keeping a reference to yielded objects.

--- a/Misc/NEWS.d/next/Library/2017-08-30-11-26-14.bpo-27144.PEDJsE.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-30-11-26-14.bpo-27144.PEDJsE.rst
@@ -1,0 +1,2 @@
+concurrent.futures as_complie and map iterators do not keep reference to
+returned object


### PR DESCRIPTION


<!-- issue-number: bpo-27144 -->
https://bugs.python.org/issue27144
<!-- /issue-number -->
