### PR TITLE
bpo-11681: Document the `-b` and `-bb` options

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -193,11 +193,16 @@ Miscellaneous options
 
 .. cmdoption:: -b
 
-   Issue a warning when comparing :class:`bytes` with :class:`bytearray`.
+   Issue a warning when comparing :class:`unicode` with :class:`bytearray`.
    Issue an error when the option is given twice (:option:`!-bb`).
 
-   .. versionchanged:: 3.5
-      Affects comparisons of :class:`bytes` with :class:`int`.
+   Note that, unlike the corresponding Python 3.x flag, this will **not** emit
+   warnings for comparisons between :class:`str` and :class:`unicode`.
+   Instead, the ``str`` instance will be implicitly decoded to ``unicode`` and
+   Unicode comparison used.
+
+   .. versionadded:: 2.6
+
 
 .. cmdoption:: -B
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -24,7 +24,7 @@ Command line
 
 When invoking Python, you may specify any of these options::
 
-    python [-BdEiOQsRStuUvVWxX3?] [-c command | -m module-name | script | - ] [args]
+    python [-bBdEiOQsRStuUvVWxX3?] [-c command | -m module-name | script | - ] [args]
 
 The most common use case is, of course, a simple invocation of a script::
 
@@ -190,6 +190,14 @@ Generic options
 
 Miscellaneous options
 ~~~~~~~~~~~~~~~~~~~~~
+
+.. cmdoption:: -b
+
+   Issue a warning when comparing :class:`bytes` with :class:`bytearray`.
+   Issue an error when the option is given twice (:option:`!-bb`).
+
+   .. versionchanged:: 3.5
+      Affects comparisons of :class:`bytes` with :class:`int`.
 
 .. cmdoption:: -B
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -62,6 +62,8 @@ static char *usage_line =
 /* Long usage message, split into parts < 512 bytes */
 static char *usage_1 = "\
 Options and arguments (and corresponding environment variables):\n\
+-b     : issue warnings about comparing bytearray with unicode\n\
+         (-bb: issue errors)\n\
 -B     : don't write .py[co] files on import; also PYTHONDONTWRITEBYTECODE=x\n\
 -c cmd : program passed in as string (terminates option list)\n\
 -d     : debug output from parser; also PYTHONDEBUG=x\n\


### PR DESCRIPTION
@gbengeult's patch from [bpo-11681](https://bugs.python.org/issue11681) with @ncoghlan's review suggestions applied.