### PR TITLE
Update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       env:
         - TESTING=docs
       install:
-        - Sphinx
+        - pip install -U Sphinx
       script:
         - make check suspicious html SPHINXOPTS="-q -W"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,11 @@ matrix:
       python: 2.7
       env:
         - TESTING=docs
-      install:
+      before_script:
+        - cd Doc
         - pip install -U Sphinx
       script:
-        - make -C Doc check suspicious html SPHINXOPTS="-q -W"
+        - make check suspicious html SPHINXOPTS="-q -W"
 
 # Travis provides only 2 cores, so don't overdue the parallelism and waste memory.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,8 @@ matrix:
       python: 2.7
       env:
         - TESTING=docs
-      before_script:
-        - pip install -U Sphinx
+      install:
+        - Sphinx
       script:
         - make check suspicious html SPHINXOPTS="-q -W"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       install:
         - pip install -U Sphinx
       script:
-        - make check suspicious html SPHINXOPTS="-q -W"
+        - make -C Doc check suspicious html SPHINXOPTS="-q -W"
 
 # Travis provides only 2 cores, so don't overdue the parallelism and waste memory.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,17 +27,9 @@ matrix:
       env:
         - TESTING=docs
       before_script:
-        - |
-            if git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '^Doc/'
-            then
-              echo "Docs weren't updated, stopping build process."
-              exit
-            fi
-            cd Doc
         - pip install -U Sphinx
       script:
-        - make html SPHINXOPTS="-q"
-        - make check
+        - make check suspicious html SPHINXOPTS="-q -W"
 
 # Travis provides only 2 cores, so don't overdue the parallelism and waste memory.
 before_script:


### PR DESCRIPTION
Build the 'suspicious' doc target, turn on warnings-as-errors on the
docs, and always build the docs.  This better matches master's doc build
setup.

This will probably have to wait until GH-1562, GH-1563, and GH-1564 are merged.