### PR TITLE
bpo-29898: Fix incorrect env variable name

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -571,7 +571,7 @@ conflict.
 
    .. versionchanged:: 3.6
       On Windows, the encoding specified by this variable is ignored for interactive
-      console buffers unless :envvar:`PYTHONLEGACYWINDOWSIOENCODING` is also specified.
+      console buffers unless :envvar:`PYTHONLEGACYWINDOWSSTDIO` is also specified.
       Files and pipes redirected through the standard streams are not affected.
 
 .. envvar:: PYTHONNOUSERSITE
@@ -700,7 +700,7 @@ conflict.
    .. versionadded:: 3.6
       See :pep:`529` for more details.
 
-.. envvar:: PYTHONLEGACYWINDOWSIOENCODING
+.. envvar:: PYTHONLEGACYWINDOWSSTDIO
 
    If set to a non-empty string, does not use the new console reader and
    writer. This means that Unicode characters will be encoded according to

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -534,7 +534,7 @@ provide correctly read str objects to Python code. ``sys.stdin``,
 
 This change only applies when using an interactive console, and not when
 redirecting files or pipes. To revert to the previous behaviour for interactive
-console use, set :envvar:`PYTHONLEGACYWINDOWSIOENCODING`.
+console use, set :envvar:`PYTHONLEGACYWINDOWSSTDIO`.
 
 .. seealso::
 


### PR DESCRIPTION
It should read PYTHONLEGACYWINDOWSSTDIO as stated
in section "Add legacy mode" in PEP 528.