### PR TITLE
[3.5] bpo-30358: Document sort argument of profile.runctx() (GH-1566)

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -215,11 +215,11 @@ functions:
 
    and gathers profiling statistics from the execution. If no file name is
    present, then this function automatically creates a :class:`~pstats.Stats`
-   instance and prints a simple profiling report. If the sort value is specified
+   instance and prints a simple profiling report. If the sort value is specified,
    it is passed to this :class:`~pstats.Stats` instance to control how the
    results are sorted.
 
-.. function:: runctx(command, globals, locals, filename=None)
+.. function:: runctx(command, globals, locals, filename=None, sort=-1)
 
    This function is similar to :func:`run`, with added arguments to supply the
    globals and locals dictionaries for the *command* string. This routine


### PR DESCRIPTION
(cherry picked from commit 99776296230ddd8429ebad2d07854b8c27ea10ab)