### PR TITLE
[2.7] bpo-30365: Backport warnings and fix bugs in ElementTree.

### DIFF
--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -1450,6 +1450,8 @@ class TreeBuilder(object):
         self._tail = 1
         return self._last
 
+_sentinel = ['sentinel']
+
 ##
 # Element structure builder for XML source data, based on the
 # <b>expat</b> parser.
@@ -1465,7 +1467,11 @@ class TreeBuilder(object):
 
 class XMLParser(object):
 
-    def __init__(self, html=0, target=None, encoding=None):
+    def __init__(self, html=_sentinel, target=None, encoding=None):
+        if html is not _sentinel:
+            warnings.warnpy3k(
+                "The html argument of XMLParser() is deprecated",
+                DeprecationWarning, stacklevel=2)
         try:
             from xml.parsers import expat
         except ImportError:
@@ -1617,7 +1623,7 @@ class XMLParser(object):
                     pubid = pubid[1:-1]
                 if hasattr(self.target, "doctype"):
                     self.target.doctype(name, pubid, system[1:-1])
-                elif self.doctype is not self._XMLParser__doctype:
+                elif self.doctype != self._XMLParser__doctype:
                     # warn about deprecated call
                     self._XMLParser__doctype(name, pubid, system[1:-1])
                     self.doctype(name, pubid, system[1:-1])

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -42,6 +42,15 @@ Extension Modules
 Library
 -------
 
+- bpo-30365: Running Python with the -3 option now emits deprecation warnings
+  for getchildren() and getiterator() methods of the Element class in the
+  xml.etree.cElementTree module and when pass the html argument to
+  xml.etree.ElementTree.XMLParser().
+
+- bpo-30365: Fixed a deprecation warning about the doctype() method of the
+  xml.etree.ElementTree.XMLParser class.  Now it is emitted only when define
+  the doctype() method in the subclass of XMLParser.
+
 - bpo-30342: Fix sysconfig.is_python_build() if Python is built with Visual
   Studio 2008 (VS 9.0).
 


### PR DESCRIPTION
Running Python with the -3 option now emits deprecation warnings for
getchildren() and getiterator() methods of the Element class in the
xml.etree.cElementTree module and when pass the html argument to
xml.etree.ElementTree.XMLParser().

Fixed a deprecation warning about the doctype() method of the
xml.etree.ElementTree.XMLParser class.  Now it is emitted only when
define the doctype() method in the subclass of XMLParser.

Fixed a bug in the test_bug_200708_close test method.  An EchoTarget
instance was incorrectly passed to XMLParser() as the html argument and
silently ignored.

Tests no longer failed when use the -m option for running only selected
test methods. Checking warnings now is more specific, warnings are
expected only when use deprecated features.