### PR TITLE
[2.7] bpo-11790: Fix sporadic failures in test_multiprocessing.WithProcessesTestCondition

### DIFF
--- a/Lib/test/test_multiprocessing.py
+++ b/Lib/test/test_multiprocessing.py
@@ -840,7 +840,13 @@ class _TestCondition(BaseTestCase):
         cond.release()
 
         # check they have all woken
-        time.sleep(DELTA)
+        for i in range(10):
+            try:
+                if get_value(woken) == 6:
+                    break
+            except NotImplementedError:
+                break
+            time.sleep(DELTA)
         self.assertReturnsIfImplemented(6, get_value, woken)
 
         # check state is not mucked up

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -164,6 +164,9 @@ Build
 Tests
 -----
 
+- bpo-11790: Fix sporadic failures in
+  test_multiprocessing.WithProcessesTestCondition.
+
 - bpo-30236: Backported test.regrtest options -m/--match and -G/--failfast
   from Python 3.
 


### PR DESCRIPTION
(cherry picked from commit f25a8de845d20349a265442eb0f3dcd71d0d7ac5)