### PR TITLE
bpo-30339: test_multiprocessing_main_handling timeout

### DIFF
--- a/Lib/test/test_multiprocessing_main_handling.py
+++ b/Lib/test/test_multiprocessing_main_handling.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
     p = Pool(5)
     results = []
     p.map_async(f, [1, 2, 3], callback=results.extend)
-    deadline = time.time() + 10 # up to 10 s to report the results
+    deadline = time.time() + 60 # up to 60 s to report the results
     while not results:
         time.sleep(0.05)
         if time.time() > deadline:


### PR DESCRIPTION
test_multiprocessing_main_handling: increase the test_source timeout
from 10 seconds to 60 seconds, since the test fails randomly on busy
buildbots.