### PR TITLE
 bpo-29651 - Cover edge case of square brackets in urllib docs (#1128)

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -117,6 +117,9 @@ or on combining URL components into a URL string.
    See section :ref:`urlparse-result-object` for more information on the result
    object.
 
+   Unmatched square brackets in the :attr:`netloc` attribute will raise a
+   :exc:`ValueError`.
+
    .. versionchanged:: 3.2
       Added IPv6 URL parsing capabilities.
 
@@ -229,6 +232,9 @@ or on combining URL components into a URL string.
 
    See section :ref:`urlparse-result-object` for more information on the result
    object.
+
+   Unmatched square brackets in the :attr:`netloc` attribute will raise a
+   :exc:`ValueError`.
 
 
 .. function:: urlunsplit(parts)


### PR DESCRIPTION
(cherry picked from commit f6e863d868a621594df2a8abe072b5d4766e7137)