### PR TITLE
bpo-23667: IDLE: Add trim trailing whitespace and blankline on save extension

### DIFF
--- a/Lib/idlelib/config-extensions.def
+++ b/Lib/idlelib/config-extensions.def
@@ -85,6 +85,10 @@ enable=True
 enable_shell=False
 enable_editor=True
 
+[TrimExtension]
+enable=True
+enable_trim_on_save=True
+
 [ScriptBinding]
 enable=True
 enable_shell=False

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -976,6 +976,7 @@ class EditorWindow(object):
         'ParenMatch': 'parenmatch',
         'RstripExtension': 'rstrip',
         'ScriptBinding': 'runscript',
+        'TrimExtension': 'trim',
         'ZoomHeight': 'zoomheight',
         }
 

--- a/Lib/idlelib/idle_test/mock_tk.py
+++ b/Lib/idlelib/idle_test/mock_tk.py
@@ -140,6 +140,10 @@ class Text:
             return lastline, len(self.data[lastline]) - 1
         elif index == 'end':
             return self._endex(endflag)
+        elif index.startswith('end-'):
+            a, b = index.split()
+            a = int(a[4: -1])
+            index = '%d.0' % (a + 1)
 
         line, char = index.split('.')
         line = int(line)

--- a/Lib/idlelib/idle_test/test_trim.py
+++ b/Lib/idlelib/idle_test/test_trim.py
@@ -1,0 +1,51 @@
+import unittest
+import idlelib.trim as trim
+from idlelib.editor import EditorWindow as Editor
+from tkinter import Tk
+
+
+class trimTest(unittest.TestCase):
+
+    def test_trim_line(self):
+        editor = Editor(root=Tk())
+        text = editor.text
+        do_trim = trim.TrimExtension(editor).do_trim
+
+        do_trim()
+        self.assertEqual(text.get('1.0', 'insert'), '')
+        text.insert('1.0', '     ')
+        do_trim()
+        self.assertEqual(text.get('1.0', 'insert'), '')
+        text.insert('1.0', '     \n')
+        do_trim()
+        self.assertEqual(text.get('1.0', 'insert'), '')
+
+    def test_trim_multiple(self):
+        editor = Editor(root=Tk())
+        text = editor.text
+        do_trim = trim.TrimExtension(editor).do_trim
+
+        original = (
+            "Line with an ending tab\t\n"
+            "Line ending in 5 spaces     \n"
+            "Linewithnospaces\n"
+            "    indented line\n"
+            "    indented line with trailing space \n"
+            "    \n"
+            "\n"
+            "       \n"
+            "\n")
+        stripped = (
+            "Line with an ending tab\n"
+            "Line ending in 5 spaces\n"
+            "Linewithnospaces\n"
+            "    indented line\n"
+            "    indented line with trailing space\n")
+
+        text.insert('1.0', original)
+        do_trim()
+        self.assertEqual(text.get('1.0', 'insert'), stripped)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2, exit=False)

--- a/Lib/idlelib/idle_test/test_trim.py
+++ b/Lib/idlelib/idle_test/test_trim.py
@@ -1,12 +1,15 @@
 import unittest
 import idlelib.trim as trim
-from idlelib.idle_test.mock_idle import Editor
+from test.support import requires
+requires('gui')
+from idlelib.editor import EditorWindow as Editor
+from tkinter import Tk
 
 
 class trimTest(unittest.TestCase):
 
     def test_trim_line(self):
-        editor = Editor()
+        editor = Editor(root=Tk())
         text = editor.text
         do_trim = trim.TrimExtension(editor).do_trim
 
@@ -17,14 +20,10 @@ class trimTest(unittest.TestCase):
         self.assertEqual(text.get('1.0', 'insert'), '')
         text.insert('1.0', '     \n')
         do_trim()
-        self.assertEqual(text.get('1.0', 'insert'), '\n')
+        self.assertEqual(text.get('1.0', 'insert'), '')
 
     def test_trim_multiple(self):
-        editor = Editor()
-        #  Uncomment following to verify that test passes with real widgets.
-##        from idlelib.editor import EditorWindow as Editor
-##        from tkinter import Tk
-##        editor = Editor(root=Tk())
+        editor = Editor(root=Tk())
         text = editor.text
         do_trim = trim.TrimExtension(editor).do_trim
 

--- a/Lib/idlelib/idle_test/test_trim.py
+++ b/Lib/idlelib/idle_test/test_trim.py
@@ -1,13 +1,12 @@
 import unittest
 import idlelib.trim as trim
-from idlelib.editor import EditorWindow as Editor
-from tkinter import Tk
+from idlelib.idle_test.mock_idle import Editor
 
 
 class trimTest(unittest.TestCase):
 
     def test_trim_line(self):
-        editor = Editor(root=Tk())
+        editor = Editor()
         text = editor.text
         do_trim = trim.TrimExtension(editor).do_trim
 
@@ -18,10 +17,14 @@ class trimTest(unittest.TestCase):
         self.assertEqual(text.get('1.0', 'insert'), '')
         text.insert('1.0', '     \n')
         do_trim()
-        self.assertEqual(text.get('1.0', 'insert'), '')
+        self.assertEqual(text.get('1.0', 'insert'), '\n')
 
     def test_trim_multiple(self):
-        editor = Editor(root=Tk())
+        editor = Editor()
+        #  Uncomment following to verify that test passes with real widgets.
+##        from idlelib.editor import EditorWindow as Editor
+##        from tkinter import Tk
+##        editor = Editor(root=Tk())
         text = editor.text
         do_trim = trim.TrimExtension(editor).do_trim
 

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -109,6 +109,16 @@ def coding_spec(data):
     return name
 
 
+def strip_trailing_whitespace_and_blankline(f):
+    def _strip(self, event, *args, **kwargs):
+        if idleConf.GetOption('extensions', 'TrimExtension',
+                              'enable_trim_on_save',
+                              type='bool', default=False):
+            self.editwin.text.event_generate('<<do-trim>>')
+        return f(self, event, *args, **kwargs)
+    return _strip
+
+
 class IOBinding:
 # One instance per editor Window so methods know which to save, close.
 # Open returns focus to self.editwin if aborted.
@@ -340,6 +350,7 @@ class IOBinding:
         self.text.focus_set()
         return reply
 
+    @strip_trailing_whitespace_and_blankline
     def save(self, event):
         if not self.filename:
             self.save_as(event)
@@ -353,6 +364,7 @@ class IOBinding:
         self.text.focus_set()
         return "break"
 
+    @strip_trailing_whitespace_and_blankline
     def save_as(self, event):
         filename = self.asksavefile()
         if filename:
@@ -367,6 +379,7 @@ class IOBinding:
         self.updaterecentfileslist(filename)
         return "break"
 
+    @strip_trailing_whitespace_and_blankline
     def save_a_copy(self, event):
         filename = self.asksavefile()
         if filename:

--- a/Lib/idlelib/trim.py
+++ b/Lib/idlelib/trim.py
@@ -1,0 +1,40 @@
+'Provides "Trim trailing whitespace and blank line" option'
+
+
+class TrimExtension:
+
+    def __init__(self, editwin):
+        self.editwin = editwin
+        self.editwin.text.bind('<<do-trim>>', self.do_trim)
+
+    def do_trim(self, event=None):
+        text = self.editwin.text
+        undo = self.editwin.undo
+
+        undo.undo_block_start()
+
+        last = 0
+        end_line = int(float(text.index('end')))
+        for cur in range(1, end_line):
+            txt = text.get('%i.0' % cur, '%i.end' % cur)
+            raw = len(txt)
+            cut = len(txt.rstrip())
+
+            # Get the last non-blank line of code
+            if cut:
+                last = cur
+
+            # Since text.delete() marks file as changed, even if not,
+            # only call it when needed to actually delete something.
+            if cut < raw:
+                text.delete('%i.%i' % (cur, cut), '%i.end' % cur)
+
+        # Trim trailing blank line
+        text.delete('end-%ic linestart' % (end_line - last - 1), 'end')
+
+        undo.undo_block_stop()
+
+
+if __name__ == "__main__":
+    import unittest
+    unittest.main('idlelib.idle_test.test_trim', verbosity=2, exit=False)


### PR DESCRIPTION
This extension will trim the trailing whitespace and blank line in `editwin.text` when saving from editor.