### PR TITLE
[3.5] bpo-30375: Correct the stacklevel of regex compiling warnings. (GH-1595)

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -638,14 +638,18 @@ class ReTests(unittest.TestCase):
         re.purge()  # for warnings
         for c in 'ceghijklmopqyzCEFGHIJKLMNOPQRTVXY':
             with self.subTest(c):
-                with self.assertWarns(DeprecationWarning):
+                with self.assertWarns(DeprecationWarning) as warns:
                     self.assertEqual(re.fullmatch('\\%c' % c, c).group(), c)
                     self.assertIsNone(re.match('\\%c' % c, 'a'))
+                self.assertRegex(str(warns.warnings[0].message), 'bad escape')
+                self.assertEqual(warns.warnings[0].filename, __file__)
         for c in 'ceghijklmopqyzABCEFGHIJKLMNOPQRTVXYZ':
             with self.subTest(c):
-                with self.assertWarns(DeprecationWarning):
+                with self.assertWarns(DeprecationWarning) as warns:
                     self.assertEqual(re.fullmatch('[\\%c]' % c, c).group(), c)
                     self.assertIsNone(re.match('[\\%c]' % c, 'a'))
+                self.assertRegex(str(warns.warnings[0].message), 'bad escape')
+                self.assertEqual(warns.warnings[0].filename, __file__)
 
     def test_string_boundaries(self):
         # See http://bugs.python.org/issue10713

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -49,6 +49,10 @@ Extension Modules
 Library
 -------
 
+- bpo-30375: Warnings emitted when compile a regular expression now always
+  point to the line in the user code.  Previously they could point into inners
+  of the re module if emitted from inside of groups or conditionals.
+
 - bpo-30048: Fixed ``Task.cancel()`` can be ignored when the task is
   running coroutine and the coroutine returned without any more ``await``.
 


### PR DESCRIPTION
Warnings emitted when compile a regular expression now always point
to the line in the user code.  Previously they could point into inners
of the re module if emitted from inside of groups or conditionals..
(cherry picked from commit c7ac7280c321b3c1679fe5f657a6be0f86adf173)