### PR TITLE
Fix ModuleNotFoundError typo in import reference

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -890,7 +890,7 @@ import statements within that module.
 
 To selectively prevent import of some modules from a hook early on the
 meta path (rather than disabling the standard import system entirely),
-it is sufficient to raise :exc:`ModuleNoFoundError` directly from
+it is sufficient to raise :exc:`ModuleNotFoundError` directly from
 :meth:`~importlib.abc.MetaPathFinder.find_spec` instead of returning
 ``None``. The latter indicates that the meta path search should continue,
 while raising an exception terminates it immediately.


### PR DESCRIPTION
Rename `ModuleNoFoundError` to `ModuleNotFoundError` (`t` was missing).