### PR TITLE
[3.6] bpo-30357: test_thread now uses threading_cleanup() (#1592)

### DIFF
--- a/Lib/test/test_thread.py
+++ b/Lib/test/test_thread.py
@@ -20,6 +20,7 @@ def verbose_print(arg):
         with _print_mutex:
             print(arg)
 
+
 class BasicThreadTest(unittest.TestCase):
 
     def setUp(self):
@@ -30,6 +31,9 @@ class BasicThreadTest(unittest.TestCase):
         self.created = 0
         self.running = 0
         self.next_ident = 0
+
+        key = support.threading_setup()
+        self.addCleanup(support.threading_cleanup, *key)
 
 
 class ThreadRunningTests(BasicThreadTest):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -551,6 +551,7 @@ Eric Groo
 Daniel Andrade Groppe
 Dag Gruneau
 Filip Gruszczyński
+Grzegorz Grzywacz
 Thomas Guettler
 Yuyang Guo
 Anuj Gupta

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -168,6 +168,11 @@ Tools/Demos
 Tests
 -----
 
+* bpo-30357: test_thread: setUp() now uses support.threading_setup() and
+  support.threading_cleanup() to wait until threads complete to avoid
+  random side effects on following tests. Initial patch written by Grzegorz
+  Grzywacz.
+
 - bpo-30197: Enhanced functions swap_attr() and swap_item() in the
   test.support module.  They now work when delete replaced attribute or item
   inside the with statement.  The old value of the attribute or item (or None


### PR DESCRIPTION
test_thread: setUp() now uses support.threading_setup() and
support.threading_cleanup() to wait until threads complete to avoid
random side effects on following tests.

Co-Authored-By:  Grzegorz Grzywacz <grzegorz.grzywacz@nazwa.pl>
(cherry picked from commit 79ef7f8e88a4972c4aecf95cfc5cd934f1861e08)