### PR TITLE
[3.5] bpo-30357: test_thread now uses threading_cleanup() (#1592)

### DIFF
--- a/Lib/test/test_thread.py
+++ b/Lib/test/test_thread.py
@@ -20,6 +20,7 @@ def verbose_print(arg):
         with _print_mutex:
             print(arg)
 
+
 class BasicThreadTest(unittest.TestCase):
 
     def setUp(self):
@@ -30,6 +31,9 @@ class BasicThreadTest(unittest.TestCase):
         self.created = 0
         self.running = 0
         self.next_ident = 0
+
+        key = support.threading_setup()
+        self.addCleanup(support.threading_cleanup, *key)
 
 
 class ThreadRunningTests(BasicThreadTest):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -543,6 +543,7 @@ Eric Groo
 Daniel Andrade Groppe
 Dag Gruneau
 Filip Gruszczyński
+Grzegorz Grzywacz
 Thomas Guettler
 Yuyang Guo
 Anuj Gupta

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -235,6 +235,11 @@ Build
 Tests
 -----
 
+- bpo-30357: test_thread: setUp() now uses support.threading_setup() and
+  support.threading_cleanup() to wait until threads complete to avoid
+  random side effects on following tests. Initial patch written by Grzegorz
+  Grzywacz.
+
 - bpo-28087: Skip test_asyncore and test_eintr poll failures on macOS.
   Skip some tests of select.poll when running on macOS due to unresolved
   issues with the underlying system poll function on some macOS versions.


### PR DESCRIPTION
test_thread: setUp() now uses support.threading_setup() and
support.threading_cleanup() to wait until threads complete to avoid
random side effects on following tests.

Co-Authored-By:  Grzegorz Grzywacz <grzegorz.grzywacz@nazwa.pl>
(cherry picked from commit 79ef7f8e88a4972c4aecf95cfc5cd934f1861e08)