### PR TITLE
[2.7] bpo-30329: Catch Windows error 10022 on shutdown() (#1538)

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -264,8 +264,10 @@ class IMAP4:
         try:
             self.sock.shutdown(socket.SHUT_RDWR)
         except socket.error as e:
-            # The server might already have closed the connection
-            if e.errno != errno.ENOTCONN:
+            # The server might already have closed the connection.
+            # On Windows, this may result in WSAEINVAL (error 10022):
+            # An invalid operation was attempted.
+            if e.errno not in (errno.ENOTCONN, 10022):
                 raise
         finally:
             self.sock.close()

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -42,6 +42,10 @@ Extension Modules
 Library
 -------
 
+- bpo-30329: imaplib now catchs the Windows socket WSAEINVAL error
+  (code 10022) on shutdown(SHUT_RDWR): An invalid operation was attempted.
+  This error occurs sometimes on SSL connections.
+
 - bpo-30342: Fix sysconfig.is_python_build() if Python is built with Visual
   Studio 2008 (VS 9.0).
 


### PR DESCRIPTION
Catch the Windows socket WSAEINVAL error (code 10022) in imaplib
on shutdown(SHUT_RDWR): An invalid operation was attempted

This error occurs sometimes on SSL connections.
(cherry picked from commit 83a2c2879839da2e10037f5e4af1bd1dafbf1a52)