### PR TITLE
[3.5] bpo-30273: update distutils.sysconfig for venv's created from Python (#1515)

### DIFF
--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -93,14 +93,11 @@ def get_python_inc(plat_specific=0, prefix=None):
             # the build directory may not be the source directory, we
             # must use "srcdir" from the makefile to find the "Include"
             # directory.
-            base = _sys_home or project_base
             if plat_specific:
-                return base
-            if _sys_home:
-                incdir = os.path.join(_sys_home, 'Include')
+                return _sys_home or project_base
             else:
                 incdir = os.path.join(get_config_var('srcdir'), 'Include')
-            return os.path.normpath(incdir)
+                return os.path.normpath(incdir)
         python_dir = 'python' + get_python_version() + build_flags
         return os.path.join(prefix, "include", python_dir)
     elif os.name == "nt":


### PR DESCRIPTION
compiled out-of-tree (builddir != srcdir). (see also bpo-15366)
(cherry picked from commit dbdea629e2e0e4bd8845aa55041e0a0ca4172cf3)