### PR TITLE
[3.6] bpo-29063: tmtotuple(): use time_t for gmtoff (#1276)

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -279,7 +279,7 @@ static PyTypeObject StructTimeType;
 static PyObject *
 tmtotuple(struct tm *p
 #ifndef HAVE_STRUCT_TM_TM_ZONE
-        , const char *zone, int gmtoff
+        , const char *zone, time_t gmtoff
 #endif
 )
 {
@@ -305,7 +305,7 @@ tmtotuple(struct tm *p
 #else
     PyStructSequence_SET_ITEM(v, 9,
         PyUnicode_DecodeLocale(zone, "surrogateescape"));
-    SET(10, gmtoff);
+    PyStructSequence_SET_ITEM(v, 10, _PyLong_FromTime_t(gmtoff));
 #endif /* HAVE_STRUCT_TM_TM_ZONE */
 #undef SET
     if (PyErr_Occurred()) {
@@ -397,7 +397,7 @@ time_localtime(PyObject *self, PyObject *args)
     {
         struct tm local = buf;
         char zone[100];
-        int gmtoff;
+        time_t gmtoff;
         strftime(zone, sizeof(zone), "%Z", &buf);
         gmtoff = timegm(&buf) - when;
         return tmtotuple(&local, zone, gmtoff);


### PR DESCRIPTION
timegm() return type is time_t, not int. Use time_t to prevent the
following compiler warning on Windows:

timemodule.c: warning C4244: '=': conversion from 'time_t' to 'int',
              possible loss of data
(cherry picked from commit 0d659e5614cad512a1940125135b443b3eecb5d7)