### PR TITLE
[3.5] bpo-30387: Fix warning in test_threading (#1634)

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -470,13 +470,15 @@ class ThreadTests(BaseTestCase):
         for i in range(20):
             t = threading.Thread(target=lambda: None)
             t.start()
-            self.addCleanup(t.join)
             pid = os.fork()
             if pid == 0:
-                os._exit(1 if t.is_alive() else 0)
+                os._exit(11 if t.is_alive() else 10)
             else:
+                t.join()
+
                 pid, status = os.waitpid(pid, 0)
-                self.assertEqual(0, status)
+                self.assertTrue(os.WIFEXITED(status))
+                self.assertEqual(10, os.WEXITSTATUS(status))
 
     def test_main_thread(self):
         main = threading.main_thread()


### PR DESCRIPTION
test_is_alive_after_fork() now joins directly the thread to avoid the
following warning added by bpo-30357:

Warning -- threading_cleanup() failed to cleanup 0 threads
after 2 sec (count: 0, dangling: 21)

Use also a different exit code to catch generic exit code 1.
(cherry picked from commit f8d05b3a24e745ab4a974b891ac1389e2f11ce4d)