### PR TITLE
bpo-28411: Remove "modules" field from Py_InterpreterState.

### DIFF
--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -204,6 +204,11 @@ Importing Modules
    Return the dictionary used for the module administration (a.k.a.
    ``sys.modules``).  Note that this is a per-interpreter variable.
 
+.. c:function:: PyObject* PyImport_GetModule(PyObject *name)
+
+   Return the already imported module with the given name.
+
+   .. versionadded:: 3.7
 
 .. c:function:: PyObject* PyImport_GetImporter(PyObject *path)
 

--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -206,7 +206,9 @@ Importing Modules
 
 .. c:function:: PyObject* PyImport_GetModule(PyObject *name)
 
-   Return the already imported module with the given name.
+   Return the already imported module with the given name.  If the
+   module has not been imported yet then returns NULL but does not set
+   an error.  Returns NULL and sets an error if the lookup failed.
 
    .. versionadded:: 3.7
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -449,6 +449,9 @@ Changes in the Python API
   and module are affected by this change. (Contributed by INADA Naoki and
   Eugene Toder in :issue:`29463`.)
 
+* ``PyInterpreterState`` no longer has a ``modules`` field.  Instead use
+  ``sys.modules``.
+
 * The *mode* argument of :func:`os.makedirs` no longer affects the file
   permission bits of newly-created intermediate-level directories.
   To set their file permission bits you can set the umask before invoking

--- a/Include/import.h
+++ b/Include/import.h
@@ -40,6 +40,7 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyThreadState *tstate);
+PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *interp);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Include/import.h
+++ b/Include/import.h
@@ -38,6 +38,9 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
     );
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyThreadState *tstate);
+#endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(
     PyObject *name

--- a/Include/import.h
+++ b/Include/import.h
@@ -40,6 +40,9 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
+PyAPI_FUNC(PyObject *) _PyImport_GetModule(PyObject *name);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleString(const char *name);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Include/import.h
+++ b/Include/import.h
@@ -39,7 +39,6 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyInterpreterState *);
 PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000

--- a/Include/import.h
+++ b/Include/import.h
@@ -39,7 +39,7 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *);
+PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Include/import.h
+++ b/Include/import.h
@@ -39,8 +39,8 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyThreadState *tstate);
-PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *interp);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyInterpreterState *);
+PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Include/import.h
+++ b/Include/import.h
@@ -112,9 +112,12 @@ PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObjectEx(PyObject *, PyObject *,
                                                        PyObject *);
 PyAPI_FUNC(int) _PyImport_FixupBuiltin(
     PyObject *mod,
-    const char *name            /* UTF-8 encoded string */
+    const char *name,            /* UTF-8 encoded string */
+    PyObject *modules
     );
 PyAPI_FUNC(int) _PyImport_FixupExtensionObject(PyObject*, PyObject *, PyObject *);
+PyAPI_FUNC(int) _PyImport_FixupExtensionObjectEx(PyObject*, PyObject *,
+                                                 PyObject *, PyObject *);
 
 struct _inittab {
     const char *name;           /* ASCII encoded string */

--- a/Include/import.h
+++ b/Include/import.h
@@ -46,6 +46,9 @@ PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(
     PyObject *name
     );
 #endif
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *, PyObject *);
+#endif
 PyAPI_FUNC(PyObject *) PyImport_AddModule(
     const char *name            /* UTF-8 encoded string */
     );
@@ -100,9 +103,12 @@ PyAPI_FUNC(int) _PyImport_ReleaseLock(void);
 PyAPI_FUNC(void) _PyImport_ReInitLock(void);
 
 PyAPI_FUNC(PyObject *) _PyImport_FindBuiltin(
-    const char *name            /* UTF-8 encoded string */
+    const char *name,            /* UTF-8 encoded string */
+    PyObject *modules
     );
 PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObject(PyObject *, PyObject *);
+PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObjectEx(PyObject *, PyObject *,
+                                                       PyObject *);
 PyAPI_FUNC(int) _PyImport_FixupBuiltin(
     PyObject *mod,
     const char *name            /* UTF-8 encoded string */

--- a/Include/import.h
+++ b/Include/import.h
@@ -45,7 +45,6 @@ PyAPI_FUNC(PyObject *) PyImport_GetModule(PyObject *name);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _PyImport_GetModule(PyObject *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleWithError(PyObject *name);
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleString(const char *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
 PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);
 PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);

--- a/Include/import.h
+++ b/Include/import.h
@@ -122,9 +122,8 @@ PyAPI_FUNC(int) _PyImport_FixupBuiltin(
     const char *name,            /* UTF-8 encoded string */
     PyObject *modules
     );
-PyAPI_FUNC(int) _PyImport_FixupExtensionObject(PyObject*, PyObject *, PyObject *);
-PyAPI_FUNC(int) _PyImport_FixupExtensionObjectEx(PyObject*, PyObject *,
-                                                 PyObject *, PyObject *);
+PyAPI_FUNC(int) _PyImport_FixupExtensionObject(PyObject*, PyObject *,
+                                               PyObject *, PyObject *);
 
 struct _inittab {
     const char *name;           /* ASCII encoded string */

--- a/Include/import.h
+++ b/Include/import.h
@@ -40,9 +40,13 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
+#endif
+#ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _PyImport_GetModule(PyObject *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleString(const char *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
+PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);
+PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Include/import.h
+++ b/Include/import.h
@@ -41,8 +41,10 @@ PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
 #endif
+PyAPI_FUNC(PyObject *) PyImport_GetModule(PyObject *name);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _PyImport_GetModule(PyObject *name);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleWithError(PyObject *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleString(const char *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
 PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -192,8 +192,8 @@ PyAPI_FUNC(int) PyModule_ExecDef(PyObject *module, PyModuleDef *def);
 PyAPI_FUNC(PyObject *) PyModule_Create2(struct PyModuleDef*,
                                      int apiver);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyModule_Create2(struct PyModuleDef*,
-                                         int apiver);
+PyAPI_FUNC(PyObject *) _PyModule_CreateInitialized(struct PyModuleDef*,
+                                                   int apiver);
 #endif
 
 #ifdef Py_LIMITED_API

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -191,6 +191,10 @@ PyAPI_FUNC(int) PyModule_ExecDef(PyObject *module, PyModuleDef *def);
 
 PyAPI_FUNC(PyObject *) PyModule_Create2(struct PyModuleDef*,
                                      int apiver);
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(PyObject *) _PyModule_Create2(struct PyModuleDef*,
+                                         int apiver);
+#endif
 
 #ifdef Py_LIMITED_API
 #define PyModule_Create(module) \

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -52,7 +52,6 @@ typedef struct _is {
 
     int64_t id;
 
-    PyObject *modules;
     PyObject *modules_by_index;
     PyObject *sysdict;
     PyObject *builtins;

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
@@ -1,0 +1,4 @@
+``PyInterpreterState`` has a "modules" field that is copied into
+``sys.modules`` during interpreter startup.  This causes problems if a
+program replaces ``sys.modules`` with something else.  To solve this we
+eliminate ``PyInterpreterState.modules``.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6483,7 +6483,16 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
         return NULL;
     }
 
-    module = PyDict_GetItemWithError(modules_dict, module_name);
+    module = PyObject_GetItem(modules_dict, module_name);
+    if (PyDict_Check(modules_dict)) {
+        module = PyDict_GetItemWithError(modules_dict, module_name);
+    } else {
+        module = PyObject_GetItem(modules_dict, module_name);
+        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
+            // For backward-comaptibility we copy the behavior
+            // of PyDict_GetItemWithError().
+            PyErr_Clear();
+    }
     if (module == NULL) {
         if (PyErr_Occurred())
             return NULL;

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6483,11 +6483,11 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
         if (module == NULL)
             return NULL;
         global = getattribute(module, global_name, self->proto >= 4);
-        Py_DECREF(module);
     }
     else {
         global = getattribute(module, global_name, self->proto >= 4);
     }
+    Py_DECREF(module);
     return global;
 }
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6418,9 +6418,7 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
 /*[clinic end generated code: output=becc08d7f9ed41e3 input=e2e6a865de093ef4]*/
 {
     PyObject *global;
-    PyObject *modules_dict;
     PyObject *module;
-    _Py_IDENTIFIER(modules);
 
     /* Try to map the old names used in Python 2.x to the new ones used in
        Python 3.x.  We do this only with old pickle protocols and when the
@@ -6477,22 +6475,7 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
         }
     }
 
-    modules_dict = _PySys_GetObjectId(&PyId_modules);
-    if (modules_dict == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "unable to get sys.modules");
-        return NULL;
-    }
-
-    module = PyObject_GetItem(modules_dict, module_name);
-    if (PyDict_Check(modules_dict)) {
-        module = PyDict_GetItemWithError(modules_dict, module_name);
-    } else {
-        module = PyObject_GetItem(modules_dict, module_name);
-        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
-            // For backward-comaptibility we copy the behavior
-            // of PyDict_GetItemWithError().
-            PyErr_Clear();
-    }
+    module = PyImport_GetModule(module_name);
     if (module == NULL) {
         if (PyErr_Occurred())
             return NULL;

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1707,7 +1707,7 @@ MODULE_INITFUNC(void)
     if (errors_module == NULL) {
         errors_module = PyModule_New(MODULE_NAME ".errors");
         if (errors_module != NULL) {
-            PyDict_SetItem(sys_modules, errmod_name, errors_module);
+            PyObject_SetItem(sys_modules, errmod_name, errors_module);
             /* gives away the reference to errors_module */
             PyModule_AddObject(m, "errors", errors_module);
         }
@@ -1717,7 +1717,7 @@ MODULE_INITFUNC(void)
     if (model_module == NULL) {
         model_module = PyModule_New(MODULE_NAME ".model");
         if (model_module != NULL) {
-            PyDict_SetItem(sys_modules, modelmod_name, model_module);
+            PyObject_SetItem(sys_modules, modelmod_name, model_module);
             /* gives away the reference to model_module */
             PyModule_AddObject(m, "model", model_module);
         }

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1643,7 +1643,6 @@ MODULE_INITFUNC(void)
     PyObject *errors_module;
     PyObject *modelmod_name;
     PyObject *model_module;
-    PyObject *sys_modules;
     PyObject *tmpnum, *tmpstr;
     PyObject *codes_dict;
     PyObject *rev_codes_dict;
@@ -1693,11 +1692,6 @@ MODULE_INITFUNC(void)
     */
     PyModule_AddStringConstant(m, "native_encoding", "UTF-8");
 
-    sys_modules = PySys_GetObject("modules");
-    if (sys_modules == NULL) {
-        Py_DECREF(m);
-        return NULL;
-    }
     d = PyModule_GetDict(m);
     if (d == NULL) {
         Py_DECREF(m);
@@ -1707,7 +1701,7 @@ MODULE_INITFUNC(void)
     if (errors_module == NULL) {
         errors_module = PyModule_New(MODULE_NAME ".errors");
         if (errors_module != NULL) {
-            PyObject_SetItem(sys_modules, errmod_name, errors_module);
+            _PyImport_SetModule(errmod_name, errors_module);
             /* gives away the reference to errors_module */
             PyModule_AddObject(m, "errors", errors_module);
         }
@@ -1717,7 +1711,7 @@ MODULE_INITFUNC(void)
     if (model_module == NULL) {
         model_module = PyModule_New(MODULE_NAME ".model");
         if (model_module != NULL) {
-            PyObject_SetItem(sys_modules, modelmod_name, model_module);
+            _PyImport_SetModule(modelmod_name, model_module);
             /* gives away the reference to model_module */
             PyModule_AddObject(m, "model", model_module);
         }

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -161,11 +161,16 @@ _add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
 PyObject *
 PyModule_Create2(struct PyModuleDef* module, int module_api_version)
 {
+    _PyImport_EnsureInitialized(PyThreadState_GET()->interp);
+    return _PyModule_Create2(module, module_api_version);
+}
+
+PyObject *
+_PyModule_Create2(struct PyModuleDef* module, int module_api_version)
+{
     const char* name;
     PyModuleObject *m;
-    PyInterpreterState *interp = PyThreadState_Get()->interp;
-    if (interp->modules == NULL)
-        Py_FatalError("Python import machinery not initialized");
+
     if (!PyModuleDef_Init(module))
         return NULL;
     name = module->m_name;

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -161,7 +161,8 @@ _add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
 PyObject *
 PyModule_Create2(struct PyModuleDef* module, int module_api_version)
 {
-    _PyImport_EnsureInitialized(PyThreadState_GET()->interp);
+    if (!_PyImport_IsInitialized(PyThreadState_GET()->interp))
+        Py_FatalError("Python import machinery not initialized");
     return _PyModule_CreateInitialized(module, module_api_version);
 }
 

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -162,11 +162,11 @@ PyObject *
 PyModule_Create2(struct PyModuleDef* module, int module_api_version)
 {
     _PyImport_EnsureInitialized(PyThreadState_GET()->interp);
-    return _PyModule_Create2(module, module_api_version);
+    return _PyModule_CreateInitialized(module, module_api_version);
 }
 
 PyObject *
-_PyModule_Create2(struct PyModuleDef* module, int module_api_version)
+_PyModule_CreateInitialized(struct PyModuleDef* module, int module_api_version)
 {
     const char* name;
     PyModuleObject *m;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3912,16 +3912,7 @@ import_copyreg(void)
        by storing a reference to the cached module in a static variable, but
        this broke when multiple embedded interpreters were in use (see issue
        #17408 and #19088). */
-    PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules)) {
-        copyreg_module = PyDict_GetItemWithError(modules, copyreg_str);
-    } else {
-        copyreg_module = PyObject_GetItem(modules, copyreg_str);
-        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
-            // For backward-comaptibility we copy the behavior
-            // of PyDict_GetItemWithError().
-            PyErr_Clear();
-    }
+    copyreg_module = _PyImport_GetModuleWithError(copyreg_str);
     if (copyreg_module != NULL) {
         Py_INCREF(copyreg_module);
         return copyreg_module;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3913,7 +3913,15 @@ import_copyreg(void)
        this broke when multiple embedded interpreters were in use (see issue
        #17408 and #19088). */
     PyObject *modules = PyImport_GetModuleDict();
-    copyreg_module = PyDict_GetItemWithError(modules, copyreg_str);
+    if (PyDict_Check(modules)) {
+        copyreg_module = PyDict_GetItemWithError(modules, copyreg_str);
+    } else {
+        copyreg_module = PyObject_GetItem(modules, copyreg_str);
+        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
+            // For backward-comaptibility we copy the behavior
+            // of PyDict_GetItemWithError().
+            PyErr_Clear();
+    }
     if (copyreg_module != NULL) {
         Py_INCREF(copyreg_module);
         return copyreg_module;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3901,7 +3901,6 @@ import_copyreg(void)
 {
     PyObject *copyreg_str;
     PyObject *copyreg_module;
-    PyInterpreterState *interp = PyThreadState_GET()->interp;
     _Py_IDENTIFIER(copyreg);
 
     copyreg_str = _PyUnicode_FromId(&PyId_copyreg);
@@ -3913,7 +3912,8 @@ import_copyreg(void)
        by storing a reference to the cached module in a static variable, but
        this broke when multiple embedded interpreters were in use (see issue
        #17408 and #19088). */
-    copyreg_module = PyDict_GetItemWithError(interp->modules, copyreg_str);
+    PyObject *modules = PyImport_GetModuleDict();
+    copyreg_module = PyDict_GetItemWithError(modules, copyreg_str);
     if (copyreg_module != NULL) {
         Py_INCREF(copyreg_module);
         return copyreg_module;

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -44,7 +44,6 @@ static PyObject *
 get_warnings_attr(const char *attr, int try_import)
 {
     static PyObject *warnings_str = NULL;
-    PyObject *all_modules;
     PyObject *warnings_module, *obj;
 
     if (warnings_str == NULL) {
@@ -64,9 +63,7 @@ get_warnings_attr(const char *attr, int try_import)
         }
     }
     else {
-        all_modules = PyImport_GetModuleDict();
-
-        warnings_module = PyDict_GetItem(all_modules, warnings_str);
+        warnings_module = _PyImport_GetModule(warnings_str);
         if (warnings_module == NULL)
             return NULL;
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2685,7 +2685,7 @@ _PyBuiltin_Init(void)
         PyType_Ready(&PyZip_Type) < 0)
         return NULL;
 
-    mod = PyModule_Create(&builtinsmodule);
+    mod = _PyModule_Create2(&builtinsmodule, PYTHON_API_VERSION);
     if (mod == NULL)
         return NULL;
     dict = PyModule_GetDict(mod);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2685,7 +2685,7 @@ _PyBuiltin_Init(void)
         PyType_Ready(&PyZip_Type) < 0)
         return NULL;
 
-    mod = _PyModule_Create2(&builtinsmodule, PYTHON_API_VERSION);
+    mod = _PyModule_CreateInitialized(&builtinsmodule, PYTHON_API_VERSION);
     if (mod == NULL)
         return NULL;
     dict = PyModule_GetDict(mod);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5054,7 +5054,7 @@ import_from(PyObject *v, PyObject *name)
         Py_DECREF(pkgname);
         return NULL;
     }
-    x = PyDict_GetItem(PyImport_GetModuleDict(), fullmodname);
+    x = _PyImport_GetModule(fullmodname);
     Py_DECREF(fullmodname);
     if (x == NULL) {
         goto error;

--- a/Python/import.c
+++ b/Python/import.c
@@ -301,14 +301,13 @@ _PyImport_Fini(void)
 /* Helper for sys */
 
 PyObject *
-_PyImport_GetModuleDict(PyThreadState *tstate)
+_PyImport_GetModuleDict(PyInterpreterState *interp)
 {
-    if (tstate->interp->sysdict == NULL)
-        Py_FatalError("_PyImport_GetModuleDict: no sys module!");
+    if (interp->sysdict == NULL)
+        Py_FatalError("PyImport_GetModuleDict: no sys module!");
 
     _Py_IDENTIFIER(modules);
-    PyObject *modules = _PyDict_GetItemId(tstate->interp->sysdict,
-                                          &PyId_modules);
+    PyObject *modules = _PyDict_GetItemId(interp->sysdict, &PyId_modules);
     if (modules == NULL)
         Py_FatalError("lost sys.modules");
     return modules;
@@ -317,7 +316,7 @@ _PyImport_GetModuleDict(PyThreadState *tstate)
 PyObject *
 PyImport_GetModuleDict(void)
 {
-    return _PyImport_GetModuleDict(PyThreadState_GET());
+    return _PyImport_GetModuleDict(PyThreadState_GET()->interp);
 }
 
 /* In some corner cases it is important to be sure that the import

--- a/Python/import.c
+++ b/Python/import.c
@@ -495,7 +495,6 @@ PyImport_Cleanup(void)
     /* Clear and delete the modules directory.  Actual modules will
        still be there only if imported during the execution of some
        destructor. */
-    interp->modules = NULL;
     Py_DECREF(modules);
 
     /* Once more */

--- a/Python/import.c
+++ b/Python/import.c
@@ -327,7 +327,11 @@ PyImport_GetModuleDict(void)
 void
 _PyImport_EnsureInitialized(PyInterpreterState *interp)
 {
-    if (interp->modules == NULL)
+    if (interp->sysdict == NULL)
+        goto notinitialized;
+    _Py_IDENTIFIER(modules);
+    PyObject *modules = _PyDict_GetItemId(interp->sysdict, &PyId_modules);
+    if (modules == NULL)
         goto notinitialized;
     return;
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -367,24 +367,6 @@ _PyImport_GetModuleWithError(PyObject *name)
 }
 
 PyObject *
-_PyImport_GetModuleString(const char *name)
-{
-    PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules)) {
-        return PyDict_GetItemString(modules, name);
-    }
-
-    PyObject *mod = PyMapping_GetItemString(modules, name);
-    // For backward-comaptibility we copy the behavior
-    // of PyDict_GetItemString().
-    if (PyErr_Occurred()) {
-        PyErr_Clear();
-    }
-    Py_XDECREF(mod);
-    return mod;
-}
-
-PyObject *
 _PyImport_GetModuleId(struct _Py_Identifier *nameid)
 {
     PyObject *name = _PyUnicode_FromId(nameid); /* borrowed */
@@ -1815,9 +1797,10 @@ PyImport_ImportModuleLevel(const char *name, PyObject *globals, PyObject *locals
 PyObject *
 PyImport_ReloadModule(PyObject *m)
 {
+    _Py_IDENTIFIER(imp);
     _Py_IDENTIFIER(reload);
     PyObject *reloaded_module = NULL;
-    PyObject *imp = _PyImport_GetModuleString("imp");
+    PyObject *imp = _PyImport_GetModuleId(&PyId_imp);
     if (imp == NULL) {
         imp = PyImport_ImportModule("imp");
         if (imp == NULL) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -1894,7 +1894,7 @@ PyImport_Import(PyObject *module_name)
     Py_DECREF(r);
 
     r = _PyImport_GetModule(module_name);
-    if (r != NULL)
+    if (r != NULL) {
         Py_INCREF(r);
     }
     else if (!PyErr_Occurred()) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -601,6 +601,14 @@ _PyImport_FixupBuiltin(PyObject *mod, const char *name)
 PyObject *
 _PyImport_FindExtensionObject(PyObject *name, PyObject *filename)
 {
+    PyObject *modules = PyImport_GetModuleDict();
+    return _PyImport_FindExtensionObjectEx(name, filename, modules);
+}
+
+PyObject *
+_PyImport_FindExtensionObjectEx(PyObject *name, PyObject *filename,
+                                PyObject *modules)
+{
     PyObject *mod, *mdict, *key;
     PyModuleDef* def;
     if (extensions == NULL)
@@ -616,7 +624,7 @@ _PyImport_FindExtensionObject(PyObject *name, PyObject *filename)
         /* Module does not support repeated initialization */
         if (def->m_base.m_copy == NULL)
             return NULL;
-        mod = PyImport_AddModuleObject(name);
+        mod = _PyImport_AddModuleObject(name, modules);
         if (mod == NULL)
             return NULL;
         mdict = PyModule_GetDict(mod);
@@ -631,14 +639,14 @@ _PyImport_FindExtensionObject(PyObject *name, PyObject *filename)
         mod = def->m_base.m_init();
         if (mod == NULL)
             return NULL;
-        if (PyDict_SetItem(PyImport_GetModuleDict(), name, mod) == -1) {
+        if (PyDict_SetItem(modules, name, mod) == -1) {
             Py_DECREF(mod);
             return NULL;
         }
         Py_DECREF(mod);
     }
     if (_PyState_AddModule(mod, def) < 0) {
-        PyDict_DelItem(PyImport_GetModuleDict(), name);
+        PyDict_DelItem(modules, name);
         Py_DECREF(mod);
         return NULL;
     }
@@ -650,13 +658,13 @@ _PyImport_FindExtensionObject(PyObject *name, PyObject *filename)
 }
 
 PyObject *
-_PyImport_FindBuiltin(const char *name)
+_PyImport_FindBuiltin(const char *name, PyObject *modules)
 {
     PyObject *res, *nameobj;
     nameobj = PyUnicode_InternFromString(name);
     if (nameobj == NULL)
         return NULL;
-    res = _PyImport_FindExtensionObject(nameobj, nameobj);
+    res = _PyImport_FindExtensionObjectEx(nameobj, nameobj, modules);
     Py_DECREF(nameobj);
     return res;
 }
@@ -671,6 +679,12 @@ PyObject *
 PyImport_AddModuleObject(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
+    return _PyImport_AddModuleObject(name, modules);
+}
+
+PyObject *
+_PyImport_AddModuleObject(PyObject *name, PyObject *modules)
+{
     PyObject *m;
 
     if ((m = PyDict_GetItemWithError(modules, name)) != NULL &&

--- a/Python/import.c
+++ b/Python/import.c
@@ -301,22 +301,17 @@ _PyImport_Fini(void)
 /* Helper for sys */
 
 PyObject *
-_PyImport_GetModuleDict(PyInterpreterState *interp)
+PyImport_GetModuleDict(void)
 {
-    if (interp->sysdict == NULL)
+    PyObject *sysdict = PyThreadState_GET()->interp->sysdict;
+    if (sysdict == NULL)
         Py_FatalError("PyImport_GetModuleDict: no sys module!");
 
     _Py_IDENTIFIER(modules);
-    PyObject *modules = _PyDict_GetItemId(interp->sysdict, &PyId_modules);
+    PyObject *modules = _PyDict_GetItemId(sysdict, &PyId_modules);
     if (modules == NULL)
         Py_FatalError("lost sys.modules");
     return modules;
-}
-
-PyObject *
-PyImport_GetModuleDict(void)
-{
-    return _PyImport_GetModuleDict(PyThreadState_GET()->interp);
 }
 
 /* In some corner cases it is important to be sure that the import

--- a/Python/import.c
+++ b/Python/import.c
@@ -339,12 +339,9 @@ _PyImport_GetModule(PyObject *name)
 
     PyObject *mod = PyObject_GetItem(modules, name);
     // For backward-comaptibility we copy the behavior of PyDict_GetItem().
-    if (mod == NULL) {
-        if (PyErr_Occurred())
-            PyErr_Clear();
-    } else {
-        Py_DECREF(mod);
-    }
+    if (PyErr_Occurred())
+        PyErr_Clear();
+    Py_XDECREF(mod);
     return mod;
 }
 
@@ -358,7 +355,7 @@ _PyImport_GetModuleWithError(PyObject *name)
     PyObject *mod = PyObject_GetItem(modules, name);
     // For backward-comaptibility we copy the behavior
     // of PyDict_GetItemWithError().
-    if (mod == NULL && !PyMapping_HasKey(modules, name))
+    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
         PyErr_Clear();
     return mod;
 }
@@ -373,12 +370,9 @@ _PyImport_GetModuleString(const char *name)
     PyObject *mod = PyMapping_GetItemString(modules, name);
     // For backward-comaptibility we copy the behavior
     // of PyDict_GetItemString().
-    if (mod == NULL) {
-        if (PyErr_Occurred())
-            PyErr_Clear();
-    } else {
-        Py_DECREF(mod);
-    }
+    if (PyErr_Occurred())
+        PyErr_Clear();
+    Py_XDECREF(mod);
     return mod;
 }
 
@@ -416,7 +410,7 @@ PyImport_GetModule(PyObject *name)
         return PyDict_GetItemWithError(modules, name);
 
     PyObject *m = PyObject_GetItem(modules, name);
-    if (m == NULL && !PyMapping_HasKey(modules, name))
+    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
         PyErr_Clear();
     return m;
 }
@@ -799,14 +793,14 @@ _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
         m = PyObject_GetItem(modules, name);
         // For backward-comaptibility we copy the behavior
         // of PyDict_GetItemWithError().
-        if (m == NULL && !PyMapping_HasKey(modules, name))
+        if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
             PyErr_Clear();
-    }
-    if (m != NULL && PyModule_Check(m)) {
-        return m;
     }
     if (PyErr_Occurred()) {
         return NULL;
+    }
+    if (m != NULL && PyModule_Check(m)) {
+        return m;
     }
     m = PyModule_NewObject(name);
     if (m == NULL)
@@ -838,11 +832,12 @@ static void
 remove_module(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (!PyMapping_HasKey(modules, name))
-        return;
-    if (PyMapping_DelItem(modules, name) < 0)
+    if (PyMapping_DelItem(modules, name) < 0) {
+        if (!PyMapping_HasKey(modules, name))
+            return;
         Py_FatalError("import:  deleting existing key in"
                       "sys.modules failed");
+    }
 }
 
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -336,7 +336,7 @@ PyObject *
 _PyImport_GetModule(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules)) {
+    if (PyDict_CheckExact(modules)) {
         return PyDict_GetItem(modules, name);
     }
 
@@ -353,7 +353,7 @@ PyObject *
 _PyImport_GetModuleWithError(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules)) {
+    if (PyDict_CheckExact(modules)) {
         return PyDict_GetItemWithError(modules, name);
     }
 
@@ -400,7 +400,7 @@ PyImport_GetModule(PyObject *name)
         return NULL;
     }
     Py_INCREF(modules);
-    if (PyDict_Check(modules)) {
+    if (PyDict_CheckExact(modules)) {
         m = PyDict_GetItemWithError(modules, name);  /* borrowed */
         Py_XINCREF(m);
     }
@@ -785,7 +785,7 @@ PyObject *
 _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
 {
     PyObject *m;
-    if (PyDict_Check(modules)) {
+    if (PyDict_CheckExact(modules)) {
         m = PyDict_GetItemWithError(modules, name);
     }
     else {

--- a/Python/import.c
+++ b/Python/import.c
@@ -400,18 +400,21 @@ _PyImport_SetModuleString(const char *name, PyObject *m) {
 PyObject *
 PyImport_GetModule(PyObject *name)
 {
-    _Py_IDENTIFIER(modules);
-    PyObject *modules = _PySys_GetObjectId(&PyId_modules);
+    PyObject *m;
+    PyObject *modules = PyImport_GetModuleDict();
     if (modules == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "unable to get sys.modules");
         return NULL;
     }
-    if (PyDict_Check(modules))
-        return PyDict_GetItemWithError(modules, name);
-
-    PyObject *m = PyObject_GetItem(modules, name);
-    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
-        PyErr_Clear();
+    Py_INCREF(modules);
+    if (PyDict_Check(modules)) {
+        m = PyDict_GetItemWithError(modules, name);
+    } else {
+        m = PyObject_GetItem(modules, name);
+        if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
+            PyErr_Clear();
+    }
+    Py_DECREF(modules);
     return m;
 }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -338,10 +338,13 @@ _PyImport_GetModule(PyObject *name)
         return PyDict_GetItem(modules, name);
 
     PyObject *mod = PyObject_GetItem(modules, name);
-    if (mod == NULL && PyErr_Occurred())
-        // For backward-comaptibility we copy the behavior
-        // of PyDict_GetItem().
-        PyErr_Clear();
+    // For backward-comaptibility we copy the behavior of PyDict_GetItem().
+    if (mod == NULL) {
+        if (PyErr_Occurred())
+            PyErr_Clear();
+    } else {
+        Py_DECREF(mod);
+    }
     return mod;
 }
 
@@ -353,9 +356,9 @@ _PyImport_GetModuleWithError(PyObject *name)
         return PyDict_GetItemWithError(modules, name);
 
     PyObject *mod = PyObject_GetItem(modules, name);
+    // For backward-comaptibility we copy the behavior
+    // of PyDict_GetItemWithError().
     if (mod == NULL && !PyMapping_HasKey(modules, name))
-        // For backward-comaptibility we copy the behavior
-        // of PyDict_GetItemWithError().
         PyErr_Clear();
     return mod;
 }
@@ -368,10 +371,14 @@ _PyImport_GetModuleString(const char *name)
         return PyDict_GetItemString(modules, name);
 
     PyObject *mod = PyMapping_GetItemString(modules, name);
-    if (mod == NULL && PyErr_Occurred())
-        // For backward-comaptibility we copy the behavior
-        // of PyDict_GetItemString().
-        PyErr_Clear();
+    // For backward-comaptibility we copy the behavior
+    // of PyDict_GetItemString().
+    if (mod == NULL) {
+        if (PyErr_Occurred())
+            PyErr_Clear();
+    } else {
+        Py_DECREF(mod);
+    }
     return mod;
 }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -318,19 +318,16 @@ PyImport_GetModuleDict(void)
    machinery has been initialized (or not cleaned up yet).  For
    example, see issue #4236 and PyModule_Create2(). */
 
-void
-_PyImport_EnsureInitialized(PyInterpreterState *interp)
+int
+_PyImport_IsInitialized(PyInterpreterState *interp)
 {
     if (interp->sysdict == NULL)
-        goto notinitialized;
+        return 0;
     _Py_IDENTIFIER(modules);
     PyObject *modules = _PyDict_GetItemId(interp->sysdict, &PyId_modules);
     if (modules == NULL)
-        goto notinitialized;
-    return;
-
-notinitialized:
-    Py_FatalError("Python import machinery not initialized");
+        return 0;
+    return 1;
 }
 
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -555,7 +555,15 @@ int
 _PyImport_FixupExtensionObject(PyObject *mod, PyObject *name,
                                PyObject *filename)
 {
-    PyObject *modules, *dict, *key;
+    PyObject *modules = PyImport_GetModuleDict();
+    return _PyImport_FixupExtensionObjectEx(mod, name, filename, modules);
+}
+
+int
+_PyImport_FixupExtensionObjectEx(PyObject *mod, PyObject *name,
+                                 PyObject *filename, PyObject *modules)
+{
+    PyObject *dict, *key;
     struct PyModuleDef *def;
     int res;
     if (extensions == NULL) {
@@ -572,7 +580,6 @@ _PyImport_FixupExtensionObject(PyObject *mod, PyObject *name,
         PyErr_BadInternalCall();
         return -1;
     }
-    modules = PyImport_GetModuleDict();
     if (PyDict_SetItem(modules, name, mod) < 0)
         return -1;
     if (_PyState_AddModule(mod, def) < 0) {
@@ -604,14 +611,14 @@ _PyImport_FixupExtensionObject(PyObject *mod, PyObject *name,
 }
 
 int
-_PyImport_FixupBuiltin(PyObject *mod, const char *name)
+_PyImport_FixupBuiltin(PyObject *mod, const char *name, PyObject *modules)
 {
     int res;
     PyObject *nameobj;
     nameobj = PyUnicode_InternFromString(name);
     if (nameobj == NULL)
         return -1;
-    res = _PyImport_FixupExtensionObject(mod, nameobj, nameobj);
+    res = _PyImport_FixupExtensionObjectEx(mod, nameobj, nameobj, modules);
     Py_DECREF(nameobj);
     return res;
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -346,6 +346,21 @@ _PyImport_GetModule(PyObject *name)
 }
 
 PyObject *
+_PyImport_GetModuleWithError(PyObject *name)
+{
+    PyObject *modules = PyImport_GetModuleDict();
+    if (PyDict_Check(modules))
+        return PyDict_GetItemWithError(modules, name);
+
+    PyObject *mod = PyObject_GetItem(modules, name);
+    if (mod == NULL && !PyMapping_HasKey(modules, name))
+        // For backward-comaptibility we copy the behavior
+        // of PyDict_GetItemWithError().
+        PyErr_Clear();
+    return mod;
+}
+
+PyObject *
 _PyImport_GetModuleString(const char *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
@@ -379,6 +394,24 @@ int
 _PyImport_SetModuleString(const char *name, PyObject *m) {
     PyObject *modules = PyImport_GetModuleDict();
     return PyMapping_SetItemString(modules, name, m);
+}
+
+PyObject *
+PyImport_GetModule(PyObject *name)
+{
+    _Py_IDENTIFIER(modules);
+    PyObject *modules = _PySys_GetObjectId(&PyId_modules);
+    if (modules == NULL) {
+        PyErr_SetString(PyExc_RuntimeError, "unable to get sys.modules");
+        return NULL;
+    }
+    if (PyDict_Check(modules))
+        return PyDict_GetItemWithError(modules, name);
+
+    PyObject *m = PyObject_GetItem(modules, name);
+    if (m == NULL && !PyMapping_HasKey(modules, name))
+        PyErr_Clear();
+    return m;
 }
 
 
@@ -752,17 +785,7 @@ PyImport_AddModuleObject(PyObject *name)
 PyObject *
 _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
 {
-    PyObject *m;
-
-    if (PyDict_Check(modules))
-        m = PyDict_GetItemWithError(modules, name);
-    else {
-        m = PyObject_GetItem(modules, name);
-        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
-            // For backward-comaptibility we copy the behavior
-            // of PyDict_GetItemWithError().
-            PyErr_Clear();
-    }
+    PyObject *m = _PyImport_GetModuleWithError(name);
     if (m != NULL && PyModule_Check(m)) {
         return m;
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -825,10 +825,10 @@ static void
 remove_module(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (!PyMapping_HasKey(modules, name)) {
-        return;
-    }
     if (PyMapping_DelItem(modules, name) < 0) {
+        if (!PyMapping_HasKey(modules, name)) {
+            return;
+        }
         Py_FatalError("import:  deleting existing key in"
                       "sys.modules failed");
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -792,7 +792,16 @@ PyImport_AddModuleObject(PyObject *name)
 PyObject *
 _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
 {
-    PyObject *m = _PyImport_GetModuleWithError(name);
+    PyObject *m;
+    if (PyDict_Check(modules)) {
+        m = PyDict_GetItemWithError(modules, name);
+    } else {
+        m = PyObject_GetItem(modules, name);
+        // For backward-comaptibility we copy the behavior
+        // of PyDict_GetItemWithError().
+        if (m == NULL && !PyMapping_HasKey(modules, name))
+            PyErr_Clear();
+    }
     if (m != NULL && PyModule_Check(m)) {
         return m;
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -320,6 +320,21 @@ PyImport_GetModuleDict(void)
     return _PyImport_GetModuleDict(PyThreadState_GET());
 }
 
+/* In some corner cases it is important to be sure that the import
+   machinery has been initialized (or not cleaned up yet).  For
+   example, see issue #4236 and PyModule_Create2(). */
+
+void
+_PyImport_EnsureInitialized(PyInterpreterState *interp)
+{
+    if (interp->modules == NULL)
+        goto notinitialized;
+    return;
+
+notinitialized:
+    Py_FatalError("Python import machinery not initialized");
+}
+
 
 /* List of names to clear in sys */
 static const char * const sys_deletes[] = {

--- a/Python/import.c
+++ b/Python/import.c
@@ -628,14 +628,6 @@ PyImport_GetMagicTag(void)
 
 int
 _PyImport_FixupExtensionObject(PyObject *mod, PyObject *name,
-                               PyObject *filename)
-{
-    PyObject *modules = PyImport_GetModuleDict();
-    return _PyImport_FixupExtensionObjectEx(mod, name, filename, modules);
-}
-
-int
-_PyImport_FixupExtensionObjectEx(PyObject *mod, PyObject *name,
                                  PyObject *filename, PyObject *modules)
 {
     PyObject *dict, *key;
@@ -693,7 +685,7 @@ _PyImport_FixupBuiltin(PyObject *mod, const char *name, PyObject *modules)
     nameobj = PyUnicode_InternFromString(name);
     if (nameobj == NULL)
         return -1;
-    res = _PyImport_FixupExtensionObjectEx(mod, nameobj, nameobj, modules);
+    res = _PyImport_FixupExtensionObject(mod, nameobj, nameobj, modules);
     Py_DECREF(nameobj);
     return res;
 }
@@ -1191,6 +1183,7 @@ _imp_create_builtin(PyObject *module, PyObject *spec)
         return NULL;
     }
 
+    PyObject *modules = NULL;
     for (p = PyImport_Inittab; p->name != NULL; p++) {
         PyModuleDef *def;
         if (_PyUnicode_EqualToASCIIString(name, p->name)) {
@@ -1216,7 +1209,11 @@ _imp_create_builtin(PyObject *module, PyObject *spec)
                     return NULL;
                 }
                 def->m_base.m_init = p->initfunc;
-                if (_PyImport_FixupExtensionObject(mod, name, name) < 0) {
+                if (modules == NULL) {
+                    modules = PyImport_GetModuleDict();
+                }
+                if (_PyImport_FixupExtensionObject(mod, name, name,
+                                                   modules) < 0) {
                     Py_DECREF(name);
                     return NULL;
                 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -833,9 +833,10 @@ static void
 remove_module(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
+    if (!PyMapping_HasKey(modules, name)) {
+        return;
+    }
     if (PyMapping_DelItem(modules, name) < 0) {
-        if (!PyMapping_HasKey(modules, name))
-            return;
         Py_FatalError("import:  deleting existing key in"
                       "sys.modules failed");
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -360,7 +360,7 @@ _PyImport_GetModuleWithError(PyObject *name)
     PyObject *mod = PyObject_GetItem(modules, name);
     // For backward-comaptibility we copy the behavior
     // of PyDict_GetItemWithError().
-    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name)) {
+    if (PyErr_ExceptionMatches(PyExc_KeyError)) {
         PyErr_Clear();
     }
     return mod;
@@ -406,8 +406,9 @@ PyImport_GetModule(PyObject *name)
     }
     else {
         m = PyObject_GetItem(modules, name);
-        if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
+        if (PyErr_ExceptionMatches(PyExc_KeyError)) {
             PyErr_Clear();
+        }
     }
     Py_DECREF(modules);
     return m;
@@ -792,8 +793,9 @@ _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
         m = PyObject_GetItem(modules, name);
         // For backward-comaptibility we copy the behavior
         // of PyDict_GetItemWithError().
-        if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
+        if (PyErr_ExceptionMatches(PyExc_KeyError)) {
             PyErr_Clear();
+        }
     }
     if (PyErr_Occurred()) {
         return NULL;

--- a/Python/import.c
+++ b/Python/import.c
@@ -304,13 +304,15 @@ PyObject *
 PyImport_GetModuleDict(void)
 {
     PyObject *sysdict = PyThreadState_GET()->interp->sysdict;
-    if (sysdict == NULL)
+    if (sysdict == NULL) {
         Py_FatalError("PyImport_GetModuleDict: no sys module!");
+    }
 
     _Py_IDENTIFIER(modules);
     PyObject *modules = _PyDict_GetItemId(sysdict, &PyId_modules);
-    if (modules == NULL)
+    if (modules == NULL) {
         Py_FatalError("lost sys.modules");
+    }
     return modules;
 }
 
@@ -334,13 +336,15 @@ PyObject *
 _PyImport_GetModule(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules))
+    if (PyDict_Check(modules)) {
         return PyDict_GetItem(modules, name);
+    }
 
     PyObject *mod = PyObject_GetItem(modules, name);
     // For backward-comaptibility we copy the behavior of PyDict_GetItem().
-    if (PyErr_Occurred())
+    if (PyErr_Occurred()) {
         PyErr_Clear();
+    }
     Py_XDECREF(mod);
     return mod;
 }
@@ -349,14 +353,16 @@ PyObject *
 _PyImport_GetModuleWithError(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules))
+    if (PyDict_Check(modules)) {
         return PyDict_GetItemWithError(modules, name);
+    }
 
     PyObject *mod = PyObject_GetItem(modules, name);
     // For backward-comaptibility we copy the behavior
     // of PyDict_GetItemWithError().
-    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
+    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name)) {
         PyErr_Clear();
+    }
     return mod;
 }
 
@@ -364,14 +370,16 @@ PyObject *
 _PyImport_GetModuleString(const char *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules))
+    if (PyDict_Check(modules)) {
         return PyDict_GetItemString(modules, name);
+    }
 
     PyObject *mod = PyMapping_GetItemString(modules, name);
     // For backward-comaptibility we copy the behavior
     // of PyDict_GetItemString().
-    if (PyErr_Occurred())
+    if (PyErr_Occurred()) {
         PyErr_Clear();
+    }
     Py_XDECREF(mod);
     return mod;
 }
@@ -380,19 +388,22 @@ PyObject *
 _PyImport_GetModuleId(struct _Py_Identifier *nameid)
 {
     PyObject *name = _PyUnicode_FromId(nameid); /* borrowed */
-    if (name == NULL)
+    if (name == NULL) {
         return NULL;
+    }
     return _PyImport_GetModule(name);
 }
 
 int
-_PyImport_SetModule(PyObject *name, PyObject *m) {
+_PyImport_SetModule(PyObject *name, PyObject *m)
+{
     PyObject *modules = PyImport_GetModuleDict();
     return PyObject_SetItem(modules, name, m);
 }
 
 int
-_PyImport_SetModuleString(const char *name, PyObject *m) {
+_PyImport_SetModuleString(const char *name, PyObject *m)
+{
     PyObject *modules = PyImport_GetModuleDict();
     return PyMapping_SetItemString(modules, name, m);
 }
@@ -410,7 +421,8 @@ PyImport_GetModule(PyObject *name)
     if (PyDict_Check(modules)) {
         m = PyDict_GetItemWithError(modules, name);  /* borrowed */
         Py_XINCREF(m);
-    } else {
+    }
+    else {
         m = PyObject_GetItem(modules, name);
         if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
             PyErr_Clear();
@@ -793,7 +805,8 @@ _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
     PyObject *m;
     if (PyDict_Check(modules)) {
         m = PyDict_GetItemWithError(modules, name);
-    } else {
+    }
+    else {
         m = PyObject_GetItem(modules, name);
         // For backward-comaptibility we copy the behavior
         // of PyDict_GetItemWithError().

--- a/Python/import.c
+++ b/Python/import.c
@@ -330,6 +330,27 @@ _PyImport_IsInitialized(PyInterpreterState *interp)
     return 1;
 }
 
+PyObject *
+_PyImport_GetModule(PyObject *name)
+{
+    PyObject *modules = PyImport_GetModuleDict();
+    return PyDict_GetItem(modules, name);
+}
+
+PyObject *
+_PyImport_GetModuleString(const char *name)
+{
+    PyObject *modules = PyImport_GetModuleDict();
+    return PyDict_GetItemString(modules, name);
+}
+
+PyObject *
+_PyImport_GetModuleId(struct _Py_Identifier *name)
+{
+    PyObject *modules = PyImport_GetModuleDict();
+    return _PyDict_GetItemId(modules, name);
+}
+
 
 /* List of names to clear in sys */
 static const char * const sys_deletes[] = {
@@ -853,7 +874,6 @@ module_dict_for_exec(PyObject *name)
 static PyObject *
 exec_code_in_module(PyObject *name, PyObject *module_dict, PyObject *code_object)
 {
-    PyObject *modules = PyImport_GetModuleDict();
     PyObject *v, *m;
 
     v = PyEval_EvalCode(code_object, module_dict, module_dict);
@@ -863,7 +883,8 @@ exec_code_in_module(PyObject *name, PyObject *module_dict, PyObject *code_object
     }
     Py_DECREF(v);
 
-    if ((m = PyDict_GetItem(modules, name)) == NULL) {
+    m = _PyImport_GetModule(name);
+    if (m == NULL) {
         PyErr_Format(PyExc_ImportError,
                      "Loaded module %R not found in sys.modules",
                      name);
@@ -1565,8 +1586,7 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
         Py_INCREF(abs_name);
     }
 
-    PyObject *modules = PyImport_GetModuleDict();
-    mod = PyDict_GetItem(modules, abs_name);
+    mod = _PyImport_GetModule(abs_name);
     if (mod != NULL && mod != Py_None) {
         _Py_IDENTIFIER(__spec__);
         _Py_IDENTIFIER(_initializing);
@@ -1653,8 +1673,7 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
                     goto error;
                 }
 
-                PyObject *modules = PyImport_GetModuleDict();
-                final_mod = PyDict_GetItem(modules, to_return);
+                final_mod = _PyImport_GetModule(to_return);
                 Py_DECREF(to_return);
                 if (final_mod == NULL) {
                     PyErr_Format(PyExc_KeyError,
@@ -1709,8 +1728,7 @@ PyImport_ReloadModule(PyObject *m)
 {
     _Py_IDENTIFIER(reload);
     PyObject *reloaded_module = NULL;
-    PyObject *modules = PyImport_GetModuleDict();
-    PyObject *imp = PyDict_GetItemString(modules, "imp");
+    PyObject *imp = _PyImport_GetModuleString("imp");
     if (imp == NULL) {
         imp = PyImport_ImportModule("imp");
         if (imp == NULL) {
@@ -1745,7 +1763,6 @@ PyImport_Import(PyObject *module_name)
     PyObject *globals = NULL;
     PyObject *import = NULL;
     PyObject *builtins = NULL;
-    PyObject *modules = NULL;
     PyObject *r = NULL;
 
     /* Initialize constant string objects */
@@ -1800,9 +1817,8 @@ PyImport_Import(PyObject *module_name)
         goto err;
     Py_DECREF(r);
 
-    modules = PyImport_GetModuleDict();
-    r = PyDict_GetItemWithError(modules, module_name);
-    if (r != NULL) {
+    r = _PyImport_GetModule(module_name);
+    if (r != NULL)
         Py_INCREF(r);
     }
     else if (!PyErr_Occurred()) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -301,12 +301,23 @@ _PyImport_Fini(void)
 /* Helper for sys */
 
 PyObject *
+_PyImport_GetModuleDict(PyThreadState *tstate)
+{
+    if (tstate->interp->sysdict == NULL)
+        Py_FatalError("_PyImport_GetModuleDict: no sys module!");
+
+    _Py_IDENTIFIER(modules);
+    PyObject *modules = _PyDict_GetItemId(tstate->interp->sysdict,
+                                          &PyId_modules);
+    if (modules == NULL)
+        Py_FatalError("lost sys.modules");
+    return modules;
+}
+
+PyObject *
 PyImport_GetModuleDict(void)
 {
-    PyInterpreterState *interp = PyThreadState_GET()->interp;
-    if (interp->modules == NULL)
-        Py_FatalError("PyImport_GetModuleDict: no module dictionary!");
-    return interp->modules;
+    return _PyImport_GetModuleDict(PyThreadState_GET());
 }
 
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -347,7 +347,7 @@ PyImport_Cleanup(void)
     Py_ssize_t pos;
     PyObject *key, *value, *dict;
     PyInterpreterState *interp = PyThreadState_GET()->interp;
-    PyObject *modules = interp->modules;
+    PyObject *modules = PyImport_GetModuleDict();
     PyObject *weaklist = NULL;
     const char * const *p;
 
@@ -1549,7 +1549,8 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
         Py_INCREF(abs_name);
     }
 
-    mod = PyDict_GetItem(interp->modules, abs_name);
+    PyObject *modules = PyImport_GetModuleDict();
+    mod = PyDict_GetItem(modules, abs_name);
     if (mod != NULL && mod != Py_None) {
         _Py_IDENTIFIER(__spec__);
         _Py_IDENTIFIER(_initializing);
@@ -1636,7 +1637,8 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
                     goto error;
                 }
 
-                final_mod = PyDict_GetItem(interp->modules, to_return);
+                PyObject *modules = PyImport_GetModuleDict();
+                final_mod = PyDict_GetItem(modules, to_return);
                 Py_DECREF(to_return);
                 if (final_mod == NULL) {
                     PyErr_Format(PyExc_KeyError,

--- a/Python/import.c
+++ b/Python/import.c
@@ -369,6 +369,18 @@ _PyImport_GetModuleId(struct _Py_Identifier *nameid)
     return _PyImport_GetModule(name);
 }
 
+int
+_PyImport_SetModule(PyObject *name, PyObject *m) {
+    PyObject *modules = PyImport_GetModuleDict();
+    return PyObject_SetItem(modules, name, m);
+}
+
+int
+_PyImport_SetModuleString(const char *name, PyObject *m) {
+    PyObject *modules = PyImport_GetModuleDict();
+    return PyMapping_SetItemString(modules, name, m);
+}
+
 
 /* List of names to clear in sys */
 static const char * const sys_deletes[] = {

--- a/Python/import.c
+++ b/Python/import.c
@@ -408,7 +408,8 @@ PyImport_GetModule(PyObject *name)
     }
     Py_INCREF(modules);
     if (PyDict_Check(modules)) {
-        m = PyDict_GetItemWithError(modules, name);
+        m = PyDict_GetItemWithError(modules, name);  /* borrowed */
+        Py_XINCREF(m);
     } else {
         m = PyObject_GetItem(modules, name);
         if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))

--- a/Python/import.c
+++ b/Python/import.c
@@ -334,21 +334,39 @@ PyObject *
 _PyImport_GetModule(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    return PyDict_GetItem(modules, name);
+    if (PyDict_Check(modules))
+        return PyDict_GetItem(modules, name);
+
+    PyObject *mod = PyObject_GetItem(modules, name);
+    if (mod == NULL && PyErr_Occurred())
+        // For backward-comaptibility we copy the behavior
+        // of PyDict_GetItem().
+        PyErr_Clear();
+    return mod;
 }
 
 PyObject *
 _PyImport_GetModuleString(const char *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    return PyDict_GetItemString(modules, name);
+    if (PyDict_Check(modules))
+        return PyDict_GetItemString(modules, name);
+
+    PyObject *mod = PyMapping_GetItemString(modules, name);
+    if (mod == NULL && PyErr_Occurred())
+        // For backward-comaptibility we copy the behavior
+        // of PyDict_GetItemString().
+        PyErr_Clear();
+    return mod;
 }
 
 PyObject *
-_PyImport_GetModuleId(struct _Py_Identifier *name)
+_PyImport_GetModuleId(struct _Py_Identifier *nameid)
 {
-    PyObject *modules = PyImport_GetModuleDict();
-    return _PyDict_GetItemId(modules, name);
+    PyObject *name = _PyUnicode_FromId(nameid); /* borrowed */
+    if (name == NULL)
+        return NULL;
+    return _PyImport_GetModule(name);
 }
 
 
@@ -440,7 +458,7 @@ PyImport_Cleanup(void)
             if (Py_VerboseFlag && PyUnicode_Check(key))
                 PySys_FormatStderr("# cleanup[2] removing %U\n", key);
             STORE_MODULE_WEAKREF(key, value);
-            PyDict_SetItem(modules, key, Py_None);
+            PyObject_SetItem(modules, key, Py_None);
         }
     }
 
@@ -592,10 +610,10 @@ _PyImport_FixupExtensionObjectEx(PyObject *mod, PyObject *name,
         PyErr_BadInternalCall();
         return -1;
     }
-    if (PyDict_SetItem(modules, name, mod) < 0)
+    if (PyObject_SetItem(modules, name, mod) < 0)
         return -1;
     if (_PyState_AddModule(mod, def) < 0) {
-        PyDict_DelItem(modules, name);
+        PyMapping_DelItem(modules, name);
         return -1;
     }
     if (def->m_size == -1) {
@@ -676,14 +694,14 @@ _PyImport_FindExtensionObjectEx(PyObject *name, PyObject *filename,
         mod = def->m_base.m_init();
         if (mod == NULL)
             return NULL;
-        if (PyDict_SetItem(modules, name, mod) == -1) {
+        if (PyObject_SetItem(modules, name, mod) == -1) {
             Py_DECREF(mod);
             return NULL;
         }
         Py_DECREF(mod);
     }
     if (_PyState_AddModule(mod, def) < 0) {
-        PyDict_DelItem(modules, name);
+        PyMapping_DelItem(modules, name);
         Py_DECREF(mod);
         return NULL;
     }
@@ -724,8 +742,16 @@ _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
 {
     PyObject *m;
 
-    if ((m = PyDict_GetItemWithError(modules, name)) != NULL &&
-        PyModule_Check(m)) {
+    if (PyDict_Check(modules))
+        m = PyDict_GetItemWithError(modules, name);
+    else {
+        m = PyObject_GetItem(modules, name);
+        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
+            // For backward-comaptibility we copy the behavior
+            // of PyDict_GetItemWithError().
+            PyErr_Clear();
+    }
+    if (m != NULL && PyModule_Check(m)) {
         return m;
     }
     if (PyErr_Occurred()) {
@@ -734,7 +760,7 @@ _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
     m = PyModule_NewObject(name);
     if (m == NULL)
         return NULL;
-    if (PyDict_SetItem(modules, name, m) != 0) {
+    if (PyObject_SetItem(modules, name, m) != 0) {
         Py_DECREF(m);
         return NULL;
     }
@@ -761,9 +787,9 @@ static void
 remove_module(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_GetItem(modules, name) == NULL)
+    if (!PyMapping_HasKey(modules, name))
         return;
-    if (PyDict_DelItem(modules, name) < 0)
+    if (PyMapping_DelItem(modules, name) < 0)
         Py_FatalError("import:  deleting existing key in"
                       "sys.modules failed");
 }

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -215,7 +215,8 @@ _PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *fp)
     else
         Py_INCREF(path);
 
-    if (_PyImport_FixupExtensionObject(m, name_unicode, path) < 0)
+    PyObject *modules = PyImport_GetModuleDict();
+    if (_PyImport_FixupExtensionObject(m, name_unicode, path, modules) < 0)
         goto error;
 
     Py_DECREF(name_unicode);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1183,7 +1183,7 @@ Py_NewInterpreter(void)
         Py_FatalError("Py_NewInterpreter: can't make modules dictionary");
     interp->modules = modules;
 
-    sysmod = _PyImport_FindBuiltin("sys");
+    sysmod = _PyImport_FindBuiltin("sys", modules);
     if (sysmod != NULL) {
         interp->sysdict = PyModule_GetDict(sysmod);
         if (interp->sysdict == NULL)
@@ -1194,7 +1194,7 @@ Py_NewInterpreter(void)
         _PySys_EndInit(interp->sysdict);
     }
 
-    bimod = _PyImport_FindBuiltin("builtins");
+    bimod = _PyImport_FindBuiltin("builtins", modules);
     if (bimod != NULL) {
         interp->builtins = PyModule_GetDict(bimod);
         if (interp->builtins == NULL)

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -650,7 +650,6 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
     PyObject *modules = PyDict_New();
     if (modules == NULL)
         Py_FatalError("Py_InitializeCore: can't make modules dictionary");
-    interp->modules = modules;
 
     sysmod = _PySys_BeginInit();
     if (sysmod == NULL)
@@ -1181,7 +1180,6 @@ Py_NewInterpreter(void)
     PyObject *modules = PyDict_New();
     if (modules == NULL)
         Py_FatalError("Py_NewInterpreter: can't make modules dictionary");
-    interp->modules = modules;
 
     sysmod = _PyImport_FindBuiltin("sys", modules);
     if (sysmod != NULL) {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -297,7 +297,7 @@ initimport(PyInterpreterState *interp, PyObject *sysmod)
     if (Py_VerboseFlag) {
         PySys_FormatStderr("import sys # builtin\n");
     }
-    if (PyDict_SetItemString(sys_modules, "_imp", impmod) < 0) {
+    if (PyMapping_SetItemString(sys_modules, "_imp", impmod) < 0) {
         Py_FatalError("Py_Initialize: can't save _imp to sys.modules");
     }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -262,7 +262,6 @@ initimport(PyInterpreterState *interp, PyObject *sysmod)
 {
     PyObject *importlib;
     PyObject *impmod;
-    PyObject *sys_modules;
     PyObject *value;
 
     /* Import _importlib through its frozen version, _frozen_importlib. */
@@ -293,11 +292,7 @@ initimport(PyInterpreterState *interp, PyObject *sysmod)
     else if (Py_VerboseFlag) {
         PySys_FormatStderr("import _imp # builtin\n");
     }
-    sys_modules = PyImport_GetModuleDict();
-    if (Py_VerboseFlag) {
-        PySys_FormatStderr("import sys # builtin\n");
-    }
-    if (PyMapping_SetItemString(sys_modules, "_imp", impmod) < 0) {
+    if (_PyImport_SetModuleString("_imp", impmod) < 0) {
         Py_FatalError("Py_Initialize: can't save _imp to sys.modules");
     }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1887,9 +1887,8 @@ wait_for_thread_shutdown(void)
 #ifdef WITH_THREAD
     _Py_IDENTIFIER(_shutdown);
     PyObject *result;
-    PyThreadState *tstate = PyThreadState_GET();
-    PyObject *threading = PyMapping_GetItemString(tstate->interp->modules,
-                                                  "threading");
+    PyObject *modules = PyImport_GetModuleDict();
+    PyObject *threading = PyMapping_GetItemString(modules, "threading");
     if (threading == NULL) {
         /* threading not imported */
         PyErr_Clear();

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1885,13 +1885,13 @@ wait_for_thread_shutdown(void)
 #ifdef WITH_THREAD
     _Py_IDENTIFIER(_shutdown);
     PyObject *result;
-    PyObject *modules = PyImport_GetModuleDict();
-    PyObject *threading = PyMapping_GetItemString(modules, "threading");
+    PyObject *threading = _PyImport_GetModuleString("threading");
     if (threading == NULL) {
         /* threading not imported */
         PyErr_Clear();
         return;
     }
+    Py_INCREF(threading);
     result = _PyObject_CallMethodId(threading, &PyId__shutdown, NULL);
     if (result == NULL) {
         PyErr_WriteUnraisable(threading);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -647,9 +647,20 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
     if (!_PyFloat_Init())
         Py_FatalError("Py_InitializeCore: can't init float");
 
-    interp->modules = PyDict_New();
-    if (interp->modules == NULL)
+    PyObject *modules = PyDict_New();
+    if (modules == NULL)
         Py_FatalError("Py_InitializeCore: can't make modules dictionary");
+    interp->modules = modules;
+
+    sysmod = _PySys_BeginInit();
+    if (sysmod == NULL)
+        Py_FatalError("Py_InitializeCore: can't initialize sys");
+    interp->sysdict = PyModule_GetDict(sysmod);
+    if (interp->sysdict == NULL)
+        Py_FatalError("Py_InitializeCore: can't initialize sys dict");
+    Py_INCREF(interp->sysdict);
+    PyDict_SetItemString(interp->sysdict, "modules", modules);
+    _PyImport_FixupBuiltin(sysmod, "sys");
 
     /* Init Unicode implementation; relies on the codec registry */
     if (_PyUnicode_Init() < 0)
@@ -669,17 +680,6 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
 
     /* initialize builtin exceptions */
     _PyExc_Init(bimod);
-
-    sysmod = _PySys_BeginInit();
-    if (sysmod == NULL)
-        Py_FatalError("Py_InitializeCore: can't initialize sys");
-    interp->sysdict = PyModule_GetDict(sysmod);
-    if (interp->sysdict == NULL)
-        Py_FatalError("Py_InitializeCore: can't initialize sys dict");
-    Py_INCREF(interp->sysdict);
-    _PyImport_FixupBuiltin(sysmod, "sys");
-    PyDict_SetItemString(interp->sysdict, "modules",
-                         interp->modules);
 
     /* Set up a preliminary stderr printer until we have enough
        infrastructure for the io module in place. */
@@ -1178,7 +1178,21 @@ Py_NewInterpreter(void)
 
     /* XXX The following is lax in error checking */
 
-    interp->modules = PyDict_New();
+    PyObject *modules = PyDict_New();
+    if (modules == NULL)
+        Py_FatalError("Py_NewInterpreter: can't make modules dictionary");
+    interp->modules = modules;
+
+    sysmod = _PyImport_FindBuiltin("sys");
+    if (sysmod != NULL) {
+        interp->sysdict = PyModule_GetDict(sysmod);
+        if (interp->sysdict == NULL)
+            goto handle_error;
+        Py_INCREF(interp->sysdict);
+        PyDict_SetItemString(interp->sysdict, "modules", modules);
+        PySys_SetPath(Py_GetPath());
+        _PySys_EndInit(interp->sysdict);
+    }
 
     bimod = _PyImport_FindBuiltin("builtins");
     if (bimod != NULL) {
@@ -1191,18 +1205,9 @@ Py_NewInterpreter(void)
     /* initialize builtin exceptions */
     _PyExc_Init(bimod);
 
-    sysmod = _PyImport_FindBuiltin("sys");
     if (bimod != NULL && sysmod != NULL) {
         PyObject *pstderr;
 
-        interp->sysdict = PyModule_GetDict(sysmod);
-        if (interp->sysdict == NULL)
-            goto handle_error;
-        Py_INCREF(interp->sysdict);
-        _PySys_EndInit(interp->sysdict);
-        PySys_SetPath(Py_GetPath());
-        PyDict_SetItemString(interp->sysdict, "modules",
-                             interp->modules);
         /* Set up a preliminary stderr printer until we have enough
            infrastructure for the io module in place. */
         pstderr = PyFile_NewStdPrinter(fileno(stderr));

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -659,7 +659,7 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
         Py_FatalError("Py_InitializeCore: can't initialize sys dict");
     Py_INCREF(interp->sysdict);
     PyDict_SetItemString(interp->sysdict, "modules", modules);
-    _PyImport_FixupBuiltin(sysmod, "sys");
+    _PyImport_FixupBuiltin(sysmod, "sys", modules);
 
     /* Init Unicode implementation; relies on the codec registry */
     if (_PyUnicode_Init() < 0)
@@ -671,7 +671,7 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
     bimod = _PyBuiltin_Init();
     if (bimod == NULL)
         Py_FatalError("Py_InitializeCore: can't initialize builtins modules");
-    _PyImport_FixupBuiltin(bimod, "builtins");
+    _PyImport_FixupBuiltin(bimod, "builtins", modules);
     interp->builtins = PyModule_GetDict(bimod);
     if (interp->builtins == NULL)
         Py_FatalError("Py_InitializeCore: can't initialize builtins dict");

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -41,6 +41,7 @@ _Py_IDENTIFIER(name);
 _Py_IDENTIFIER(stdin);
 _Py_IDENTIFIER(stdout);
 _Py_IDENTIFIER(stderr);
+_Py_IDENTIFIER(threading);
 
 #ifdef __cplusplus
 extern "C" {
@@ -1880,7 +1881,7 @@ wait_for_thread_shutdown(void)
 #ifdef WITH_THREAD
     _Py_IDENTIFIER(_shutdown);
     PyObject *result;
-    PyObject *threading = _PyImport_GetModuleString("threading");
+    PyObject *threading = _PyImport_GetModuleId(&PyId_threading);
     if (threading == NULL) {
         /* threading not imported */
         PyErr_Clear();

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -97,7 +97,6 @@ PyInterpreterState_New(void)
         if (head_mutex == NULL)
             Py_FatalError("Can't initialize threads for interpreter");
 #endif
-        interp->modules = NULL;
         interp->modules_by_index = NULL;
         interp->sysdict = NULL;
         interp->builtins = NULL;
@@ -158,7 +157,6 @@ PyInterpreterState_Clear(PyInterpreterState *interp)
     Py_CLEAR(interp->codec_search_path);
     Py_CLEAR(interp->codec_search_cache);
     Py_CLEAR(interp->codec_error_registry);
-    Py_CLEAR(interp->modules);
     Py_CLEAR(interp->modules_by_index);
     Py_CLEAR(interp->sysdict);
     Py_CLEAR(interp->builtins);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -159,8 +159,9 @@ static PyObject *
 sys_displayhook(PyObject *self, PyObject *o)
 {
     PyObject *outf;
-    PyInterpreterState *interp = PyThreadState_GET()->interp;
-    PyObject *modules = interp->modules;
+    PyObject *modules = PyImport_GetModuleDict();
+    if (modules == NULL)
+        return NULL;
     PyObject *builtins;
     static PyObject *newline = NULL;
     int err;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1930,7 +1930,7 @@ _PySys_BeginInit(void)
     PyObject *m, *sysdict, *version_info;
     int res;
 
-    m = _PyModule_Create2(&sysmodule, PYTHON_API_VERSION);
+    m = _PyModule_CreateInitialized(&sysmodule, PYTHON_API_VERSION);
     if (m == NULL)
         return NULL;
     sysdict = PyModule_GetDict(m);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1930,7 +1930,7 @@ _PySys_BeginInit(void)
     PyObject *m, *sysdict, *version_info;
     int res;
 
-    m = PyModule_Create(&sysmodule);
+    m = _PyModule_Create2(&sysmodule, PYTHON_API_VERSION);
     if (m == NULL)
         return NULL;
     sysdict = PyModule_GetDict(m);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -159,14 +159,11 @@ static PyObject *
 sys_displayhook(PyObject *self, PyObject *o)
 {
     PyObject *outf;
-    PyObject *modules = PyImport_GetModuleDict();
-    if (modules == NULL)
-        return NULL;
     PyObject *builtins;
     static PyObject *newline = NULL;
     int err;
 
-    builtins = _PyDict_GetItemId(modules, &PyId_builtins);
+    builtins = _PyImport_GetModuleId(&PyId_builtins);
     if (builtins == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "lost builtins module");
         return NULL;


### PR DESCRIPTION
(see http://bugs.python.org/issue28411)

<!-- issue-number: bpo-28411 -->
https://bugs.python.org/issue28411
<!-- /issue-number -->
