### PR TITLE
bpo-30374: Fixed several bugs in win_add2path.py

### DIFF
--- a/Tools/scripts/win_add2path.py
+++ b/Tools/scripts/win_add2path.py
@@ -11,43 +11,67 @@ import sys
 import site
 import os
 import winreg
+import ctypes
 
 HKCU = winreg.HKEY_CURRENT_USER
 ENV = "Environment"
 PATH = "PATH"
-DEFAULT = "%PATH%"
 
 def modify():
     pythonpath = os.path.dirname(os.path.normpath(sys.executable))
     scripts = os.path.join(pythonpath, "Scripts")
     appdata = os.environ["APPDATA"]
-    if hasattr(site, "USER_SITE"):
-        usersite = site.USER_SITE.replace(appdata, "%APPDATA%")
-        userpath = os.path.dirname(usersite)
-        userscripts = os.path.join(userpath, "Scripts")
-    else:
-        userscripts = None
 
     with winreg.CreateKey(HKCU, ENV) as key:
         try:
-            envpath = winreg.QueryValueEx(key, PATH)[0]
-        except OSError:
-            envpath = DEFAULT
+            envpath, dtype = winreg.QueryValueEx(key, PATH)
+        except FileNotFoundError:
+            envpath, dtype = "", winreg.REG_EXPAND_SZ
+            pass
+        except:
+            raise OSError("Failed to load PATH value")
 
-        paths = [envpath]
+        if hasattr(site, "USER_SITE") and dtype == winreg.REG_EXPAND_SZ:
+            usersite = site.USER_SITE.replace(appdata, "%APPDATA%")
+            userpath = os.path.dirname(usersite)
+            userscripts = os.path.join(userpath, "Scripts")
+        elif dtype == winreg.REG_SZ:
+            userpath = site.USER_SITE
+            userscripts = os.path.join(userpath, "Scripts")
+        else:
+            userscripts = None
+
+        paths = []
         for path in (pythonpath, scripts, userscripts):
-            if path and path not in envpath and os.path.isdir(path):
+            if path and path not in envpath:
                 paths.append(path)
 
-        envpath = os.pathsep.join(paths)
-        winreg.SetValueEx(key, PATH, 0, winreg.REG_EXPAND_SZ, envpath)
+        if envpath == "":
+            envpath = os.pathsep.join(paths)
+        else:
+            envpath = os.pathsep.join([envpath] + paths)
+        winreg.SetValueEx(key, PATH, 0, dtype, envpath)
         return paths, envpath
+
+def refresh_environment_variables():
+        HWND_BROADCAST = 0xFFFF
+        WM_SETTINGCHANGE = 0x001A
+        SMTO_ABORTIFHUNG = 0x0002
+        if not ctypes.windll.user32.SendMessageTimeoutW(
+                HWND_BROADCAST,
+                WM_SETTINGCHANGE,
+                0,
+                ENV,
+                SMTO_ABORTIFHUNG,
+                1000):
+            raise ctypes.WinError()
 
 def main():
     paths, envpath = modify()
     if len(paths) > 1:
+        refresh_environment_variables()
         print("Path(s) added:")
-        print('\n'.join(paths[1:]))
+        print('\n'.join(paths))
     else:
         print("No path was added")
     print("\nPATH is now:\n%s\n" % envpath)

--- a/Tools/scripts/win_add2path.py
+++ b/Tools/scripts/win_add2path.py
@@ -30,10 +30,10 @@ def modify():
         except:
             raise OSError("Failed to load PATH value")
 
-		userscripts = None
+        userscripts = None
         if hasattr(site, "USER_SITE"):
             if dtype == winreg.REG_EXPAND_SZ:
-			    usersite = site.USER_SITE.replace(appdata, "%APPDATA%")
+                usersite = site.USER_SITE.replace(appdata, "%APPDATA%")
                 userpath = os.path.dirname(usersite)
                 userscripts = os.path.join(userpath, "Scripts")
             elif dtype == winreg.REG_SZ:

--- a/Tools/scripts/win_add2path.py
+++ b/Tools/scripts/win_add2path.py
@@ -7,11 +7,11 @@ Copyright (c) 2008 by Christian Heimes <christian@cheimes.de>
 Licensed to PSF under a Contributor Agreement.
 """
 
-import sys
-import site
-import os
-import winreg
 import ctypes
+import os
+import site
+import sys
+import winreg
 
 HKCU = winreg.HKEY_CURRENT_USER
 ENV = "Environment"
@@ -27,19 +27,18 @@ def modify():
             envpath, dtype = winreg.QueryValueEx(key, PATH)
         except FileNotFoundError:
             envpath, dtype = "", winreg.REG_EXPAND_SZ
-            pass
         except:
             raise OSError("Failed to load PATH value")
 
-        if hasattr(site, "USER_SITE") and dtype == winreg.REG_EXPAND_SZ:
-            usersite = site.USER_SITE.replace(appdata, "%APPDATA%")
-            userpath = os.path.dirname(usersite)
-            userscripts = os.path.join(userpath, "Scripts")
-        elif dtype == winreg.REG_SZ:
-            userpath = site.USER_SITE
-            userscripts = os.path.join(userpath, "Scripts")
-        else:
-            userscripts = None
+		userscripts = None
+        if hasattr(site, "USER_SITE"):
+            if dtype == winreg.REG_EXPAND_SZ:
+			    usersite = site.USER_SITE.replace(appdata, "%APPDATA%")
+                userpath = os.path.dirname(usersite)
+                userscripts = os.path.join(userpath, "Scripts")
+            elif dtype == winreg.REG_SZ:
+                userpath = site.USER_SITE
+                userscripts = os.path.join(userpath, "Scripts")
 
         paths = []
         for path in (pythonpath, scripts, userscripts):


### PR DESCRIPTION
* Discard `DEFAULT = "%PATH%"`. The system PATH is effective to all users[[1]](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682653) so adding "%PATH%" in user PATH is unnecessary.
*  `os.path.isdir()` always return False because the input path includes `"%APPDATA%"` and also because the USER_SITE directory does not yet exist when Python is just installed. It is now deleted to make paths be added correctly.
* The script compulsively sets the type of PATH var to REG_EXPAND_SZ to make the reference `"%APPDATA%"` effective[[2]](https://msdn.microsoft.com/en-us/library/windows/desktop/ms724884) . However this is not a good practice (brought forward by Eryk Sun in the [issue](http://bugs.python.org/issue30374)). Now the script does not change the type of PATH. If it's REG_SZ, the absolute path of `%APPDATA%` will be added instead.
* The script needs users to log off and then log back on to take effect. Now it takes effect immediately by broadcasting a `WM_SETTINGCHANG` message[[3]](http://support.microsoft.com/kb/104011) after the change of env vars.
* Now displays error massages when fails to load PATH values or fails to refresh env vars.



<!-- issue-number: [bpo-30374](https://bugs.python.org/issue30374) -->
https://bugs.python.org/issue30374
<!-- /issue-number -->
