### PR TITLE
[2.7] bpo-30375: Correct the stacklevel of regex compiling warnings. (#1595)

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -42,6 +42,10 @@ Extension Modules
 Library
 -------
 
+- bpo-30375: Warnings emitted when compile a regular expression now always
+  point to the line in the user code.  Previously they could point into inners
+  of the re module if emitted from inside of groups or conditionals.
+
 - bpo-30363: Running Python with the -3 option now warns about regular
   expression syntax that is invalid or has different semantic in Python 3
   or will change the behavior in future Python versions.


### PR DESCRIPTION
Warnings emitted when compile a regular expression now always point
to the line in the user code.  Previously they could point into inners
of the re module if emitted from inside of groups or conditionals.

(cherry picked from commit c7ac7280c321b3c1679fe5f657a6be0f86adf173)