### PR TITLE
Removed trailing semicolon in datetime doc

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -368,7 +368,7 @@ Example usage:
     >>> nine_years = ten_years - year
     >>> nine_years, nine_years.days // 365
     (datetime.timedelta(3285), 9)
-    >>> three_years = nine_years // 3;
+    >>> three_years = nine_years // 3
     >>> three_years, three_years.days // 365
     (datetime.timedelta(1095), 3)
     >>> abs(three_years - ten_years) == 2 * three_years + year


### PR DESCRIPTION
I noticed a single trailing semicolon in the `datetime` docs ([link](https://docs.python.org/3/library/datetime.html?highlight=datetime#datetime.timedelta.total_seconds)). It isn't used in a compound statement and seems to be inconsistent with the other surrounding examples.
