### PR TITLE
[3.6] bpo-27103: regrtest disables -W if -R is used (#1651)

### DIFF
--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -343,5 +343,10 @@ def _parse_args(args, **kwargs):
                     ns.use_resources.append(r)
     if ns.random_seed is not None:
         ns.randomize = True
+    if ns.huntrleaks and ns.verbose3:
+        ns.verbose3 = False
+        print("WARNING: Disable --verbose3 because it's incompatible with "
+              "--huntrleaks: see http://bugs.python.org/issue27103",
+              file=sys.stderr)
 
     return ns


### PR DESCRIPTION
Workaround for a regrtest bug.
(cherry picked from commit fcdd9b6b7e73427ce5aa63cf095312f603c4edce)