### PR TITLE
bpo-28087: Reenable poll() tests on macOS

### DIFF
--- a/Lib/test/eintrdata/eintr_tester.py
+++ b/Lib/test/eintrdata/eintr_tester.py
@@ -433,8 +433,6 @@ class SelectEINTRTest(EINTRBaseTest):
         self.stop_alarm()
         self.assertGreaterEqual(dt, self.sleep_time)
 
-    @unittest.skipIf(sys.platform == "darwin",
-                     "poll may fail on macOS; see issue #28087")
     @unittest.skipUnless(hasattr(select, 'poll'), 'need select.poll')
     def test_poll(self):
         poller = select.poll()

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -661,9 +661,6 @@ class BaseTestAPI:
         if HAS_UNIX_SOCKETS and self.family == socket.AF_UNIX:
             self.skipTest("Not applicable to AF_UNIX sockets.")
 
-        if sys.platform == "darwin" and self.use_poll:
-            self.skipTest("poll may fail on macOS; see issue #28087")
-
         class TestClient(BaseClient):
             def handle_expt(self):
                 self.socket.recv(1024, socket.MSG_OOB)


### PR DESCRIPTION
Reenable select.poll() tests in test_asyncore and test_eintr
on macOS.

macOS 10.12.0 and 10.12.1 has a bug in poll(), but 10.12.2 was
released with a fix. Expect that users upgrade regulary and so get
10.2.2 or newer which don't have the bug.