### PR TITLE
ENH: 🐍 snake

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12125,7 +12125,7 @@ PyUnicode_IsIdentifier(PyObject *self)
     int kind;
     void *data;
     Py_ssize_t i;
-    Py_UCS4 first;
+    Py_UCS4 chr;
 
     if (PyUnicode_READY(self) == -1) {
         Py_FatalError("identifier not ready");
@@ -12146,13 +12146,17 @@ PyUnicode_IsIdentifier(PyObject *self)
        definition of XID_Start and XID_Continue, it is sufficient
        to check just for these, except that _ must be allowed
        as starting an identifier.  */
-    first = PyUnicode_READ(kind, data, 0);
-    if (!_PyUnicode_IsXidStart(first) && first != 0x5F /* LOW LINE */)
+    chr = PyUnicode_READ(kind, data, 0);
+    if (!_PyUnicode_IsXidStart(chr) && chr != 0x5F /* LOW LINE */ && chr != 0x1F40D)
         return 0;
 
     for (i = 1; i < PyUnicode_GET_LENGTH(self); i++)
-        if (!_PyUnicode_IsXidContinue(PyUnicode_READ(kind, data, i)))
+    {
+        chr = PyUnicode_READ(kind, data, i);
+        if (!_PyUnicode_IsXidContinue(chr) && chr != 0x1F40D)
             return 0;
+    }
+
     return 1;
 }
 


### PR DESCRIPTION
Special case the identifier validation to allow 🐍 to be used in
identifiers

----
This works in the terminal (assuming you have the right fonts, showing both with and without mark up as the :snake: do not render for me in the escaped code)

```
(bleeding) ✔ ~                                                                                                    
18:38 $ python
Python 3.7.0a0 (heads/enh_🐍_snek:2bfe3d18dad, May 20 2017, 18:32:35)                                             
[GCC 6.3.1 20170306] on linux                                                                                     
Type "help", "copyright", "credits" or "license" for more information.                                            
>>> 🐍 = 1
>>> 🐍 + 🐍 
2                                                                                                                 
>>>                                                                                                               
(bleeding) ✔ ~  
```

(bleeding) ✔ ~                                                                                                    
18:38 $ python
Python 3.7.0a0 (heads/enh_🐍_snek:2bfe3d18dad, May 20 2017, 18:32:35)                                             
[GCC 6.3.1 20170306] on linux                                                                                     
Type "help", "copyright", "credits" or "license" for more information.                                            
>>> 🐍 = 1
>>> 🐍 + 🐍 
2                                                                                                                 
>>>                                                                                                               
(bleeding) ✔ ~  

![tsn](https://cloud.githubusercontent.com/assets/199813/26279834/7c923ff4-3d8c-11e7-884e-906c2439040f.png)

----

It also works in the jupyter notebook (again assuming you have the right fonts)

![sn](https://cloud.githubusercontent.com/assets/199813/26279815/d4340cfc-3d8b-11e7-9beb-47690c68e785.png)


