### PR TITLE
gh-57187: Add support for extended attributes on FreeBSD

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2781,18 +2781,21 @@ def supports_extended_attributes():
 
 @unittest.skipUnless(supports_extended_attributes(),
                      "no non-broken extended attribute support")
-# Kernels < 2.6.39 don't respect setxattr flags.
-@support.requires_linux_version(2, 6, 39)
 class ExtendedAttributeTests(unittest.TestCase):
 
     def _check_xattrs_str(self, s, getxattr, setxattr, removexattr, listxattr, **kwargs):
         fn = support.TESTFN
+        if sys.platform.startswith("freebsd"):
+            xattr_errno = errno.ENOATTR
+        else:
+            xattr_errno = errno.ENODATA
+
         self.addCleanup(support.unlink, fn)
         create_file(fn)
 
         with self.assertRaises(OSError) as cm:
             getxattr(fn, s("user.test"), **kwargs)
-        self.assertEqual(cm.exception.errno, errno.ENODATA)
+        self.assertEqual(cm.exception.errno, xattr_errno)
 
         init_xattr = listxattr(fn)
         self.assertIsInstance(init_xattr, list)
@@ -2811,7 +2814,7 @@ class ExtendedAttributeTests(unittest.TestCase):
 
         with self.assertRaises(OSError) as cm:
             setxattr(fn, s("user.test2"), b"bye", os.XATTR_REPLACE, **kwargs)
-        self.assertEqual(cm.exception.errno, errno.ENODATA)
+        self.assertEqual(cm.exception.errno, xattr_errno)
 
         setxattr(fn, s("user.test2"), b"foo", os.XATTR_CREATE, **kwargs)
         xattr.add("user.test2")
@@ -2820,7 +2823,7 @@ class ExtendedAttributeTests(unittest.TestCase):
 
         with self.assertRaises(OSError) as cm:
             getxattr(fn, s("user.test"), **kwargs)
-        self.assertEqual(cm.exception.errno, errno.ENODATA)
+        self.assertEqual(cm.exception.errno, xattr_errno)
 
         xattr.remove("user.test")
         self.assertEqual(set(listxattr(fn)), xattr)
@@ -2840,14 +2843,23 @@ class ExtendedAttributeTests(unittest.TestCase):
         self._check_xattrs_str(os.fsencode, *args, **kwargs)
         support.unlink(support.TESTFN)
 
+    # Kernels < 2.6.39 don't respect setxattr flags.
+    @support.requires_linux_version(2, 6, 39)
+    @support.requires_freebsd_version(5)
     def test_simple(self):
         self._check_xattrs(os.getxattr, os.setxattr, os.removexattr,
                            os.listxattr)
 
+    # Kernels < 2.6.39 don't respect setxattr flags.
+    @support.requires_linux_version(2, 6, 39)
+    @support.requires_freebsd_version(5)
     def test_lpath(self):
         self._check_xattrs(os.getxattr, os.setxattr, os.removexattr,
                            os.listxattr, follow_symlinks=False)
 
+    # Kernels < 2.6.39 don't respect setxattr flags.
+    @support.requires_linux_version(2, 6, 39)
+    @support.requires_freebsd_version(5)
     def test_fds(self):
         def getxattr(path, *args):
             with open(path, "rb") as fp:

--- a/Misc/NEWS.d/next/Library/2018-03-02-23-38-36.bpo-12978.GmUrw4.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-02-23-38-36.bpo-12978.GmUrw4.rst
@@ -1,0 +1,1 @@
+Add support for extended attributes on FreeBSD

--- a/configure
+++ b/configure
@@ -7710,7 +7710,7 @@ sys/stat.h sys/syscall.h sys/sys_domain.h sys/termio.h sys/time.h \
 sys/times.h sys/types.h sys/uio.h sys/un.h sys/utsname.h sys/wait.h pty.h \
 libutil.h sys/resource.h netpacket/packet.h sysexits.h bluetooth.h \
 linux/tipc.h linux/random.h spawn.h util.h alloca.h endian.h \
-sys/endian.h sys/sysmacros.h
+sys/endian.h sys/sysmacros.h sys/extattr.h
 do :
   as_ac_Header=`$as_echo "ac_cv_header_$ac_header" | $as_tr_sh`
 ac_fn_c_check_header_mongrel "$LINENO" "$ac_header" "$as_ac_Header" "$ac_includes_default"

--- a/configure.ac
+++ b/configure.ac
@@ -2062,7 +2062,7 @@ sys/stat.h sys/syscall.h sys/sys_domain.h sys/termio.h sys/time.h \
 sys/times.h sys/types.h sys/uio.h sys/un.h sys/utsname.h sys/wait.h pty.h \
 libutil.h sys/resource.h netpacket/packet.h sysexits.h bluetooth.h \
 linux/tipc.h linux/random.h spawn.h util.h alloca.h endian.h \
-sys/endian.h sys/sysmacros.h)
+sys/endian.h sys/sysmacros.h sys/extattr.h)
 AC_HEADER_DIRENT
 AC_HEADER_MAJOR
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1045,6 +1045,9 @@
 /* Define to 1 if you have the <sys/event.h> header file. */
 #undef HAVE_SYS_EVENT_H
 
+/* Define to 1 if you have the <sys/extattr.h> header file. */
+#undef HAVE_SYS_EXTATTR_H
+
 /* Define to 1 if you have the <sys/file.h> header file. */
 #undef HAVE_SYS_FILE_H
 


### PR DESCRIPTION
Extended attributes are supported on FreeBSD, but have
a different API than on Linux. This implements a compatibility
layer so that the same set of python functions map to the
equivalent FreeBSD functions.

This is the patch for issue: https://bugs.python.org/issue12978

<!-- issue-number: bpo-12978 -->
https://bugs.python.org/issue12978
<!-- /issue-number -->


<!-- gh-issue-number: gh-57187 -->
* Issue: gh-57187
<!-- /gh-issue-number -->
