### PR TITLE
bpo-30394: smtplib leaves open sockets around if SMTPConnectError is raised in __init__

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -250,6 +250,7 @@ class SMTP:
         if host:
             (code, msg) = self.connect(host, port)
             if code != 220:
+                self.close()
                 raise SMTPConnectError(code, msg)
         if local_hostname is not None:
             self.local_hostname = local_hostname


### PR DESCRIPTION
Opening PR based on patch file from https://bugs.python.org/issue30394