### PR TITLE
[3.6] Fix typos in multiple `.rst` files (GH-1668)

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -295,7 +295,7 @@ an error value).
    :c:data:`PyExc_Warning` is a subclass of :c:data:`PyExc_Exception`;
    the default warning category is :c:data:`PyExc_RuntimeWarning`. The standard
    Python warning categories are available as global variables whose names are
-   enumerated at :ref:`standarwarningcategories`.
+   enumerated at :ref:`standardwarningcategories`.
 
    For information about warning control, see the documentation for the
    :mod:`warnings` module and the :option:`-W` option in the command line
@@ -958,7 +958,7 @@ Notes:
    Only defined on Windows; protect code that uses this by testing that the
    preprocessor macro ``MS_WINDOWS`` is defined.
 
-.. _standarwarningcategories:
+.. _standardwarningcategories:
 
 Standard Warning Categories
 ===========================
@@ -971,7 +971,7 @@ the variables:
 .. index::
    single: PyExc_Warning
    single: PyExc_BytesWarning
-   single: PyExc_DepricationWarning
+   single: PyExc_DeprecationWarning
    single: PyExc_FutureWarning
    single: PyExc_ImportWarning
    single: PyExc_PendingDeprecationWarning
@@ -994,7 +994,7 @@ the variables:
 +------------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_ImportWarning`            | :exc:`ImportWarning`            |          |
 +------------------------------------------+---------------------------------+----------+
-| :c:data:`PyExc_PendingDepricationWarning`| :exc:`PendingDeprecationWarning`|          |
+| :c:data:`PyExc_PendingDeprecationWarning`| :exc:`PendingDeprecationWarning`|          |
 +------------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_ResourceWarning`          | :exc:`ResourceWarning`          |          |
 +------------------------------------------+---------------------------------+----------+

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1683,7 +1683,7 @@ Implementing structured logging
 -------------------------------
 
 Although most logging messages are intended for reading by humans, and thus not
-readily machine-parseable, there might be cirumstances where you want to output
+readily machine-parseable, there might be circumstances where you want to output
 messages in a structured format which *is* capable of being parsed by a program
 (without needing complex regular expressions to parse the log message). This is
 straightforward to achieve using the logging package. There are a number of

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -266,10 +266,10 @@ immediate playback::
             'Draw circle with given radius an options extent and steps:  CIRCLE 50'
             circle(*parse(arg))
         def do_position(self, arg):
-            'Print the current turle position:  POSITION'
+            'Print the current turtle position:  POSITION'
             print('Current position is %d %d\n' % position())
         def do_heading(self, arg):
-            'Print the current turle heading in degrees:  HEADING'
+            'Print the current turtle heading in degrees:  HEADING'
             print('Current heading is %d\n' % (heading(),))
         def do_color(self, arg):
             'Set the color:  COLOR BLUE'

--- a/Doc/library/email.compat32-message.rst
+++ b/Doc/library/email.compat32-message.rst
@@ -67,7 +67,7 @@ Here are the methods of the :class:`Message` class:
 
       Return the entire message flattened as a string.  When optional *unixfrom*
       is true, the envelope header is included in the returned string.
-      *unixfrom* defaults to ``False``.  For backward compabitility reasons,
+      *unixfrom* defaults to ``False``.  For backward compatibility reasons,
       *maxheaderlen* defaults to ``0``, so if you want a different value you
       must override it explicitly (the value specified for *max_line_length* in
       the policy will be ignored by this method).  The *policy* argument may be

--- a/Doc/library/email.contentmanager.rst
+++ b/Doc/library/email.contentmanager.rst
@@ -157,7 +157,7 @@ Currently the email package provides only one concrete content manager,
        MIME charset name, use the standard charset instead.
 
        If *cte* is set, encode the payload using the specified content transfer
-       encoding, and set the :mailheader:`Content-Transfer-Endcoding` header to
+       encoding, and set the :mailheader:`Content-Transfer-Encoding` header to
        that value.  Possible values for *cte* are ``quoted-printable``,
        ``base64``, ``7bit``, ``8bit``, and ``binary``.  If the input cannot be
        encoded in the specified encoding (for example, specifying a *cte* of
@@ -203,5 +203,5 @@ Currently the email package provides only one concrete content manager,
 
 .. rubric:: Footnotes
 
-.. [1] Oringally added in 3.4 as a :term:`provisional module <provisional
+.. [1] Originally added in 3.4 as a :term:`provisional module <provisional
        package>`

--- a/Doc/library/email.errors.rst
+++ b/Doc/library/email.errors.rst
@@ -102,9 +102,9 @@ All defect classes are subclassed from :class:`email.errors.MessageDefect`.
   return false even though its content type claims to be :mimetype:`multipart`.
 
 * :class:`InvalidBase64PaddingDefect` -- When decoding a block of base64
-  enocded bytes, the padding was not correct.  Enough padding is added to
+  encoded bytes, the padding was not correct.  Enough padding is added to
   perform the decode, but the resulting decoded bytes may be invalid.
 
 * :class:`InvalidBase64CharactersDefect` -- When decoding a block of base64
-  enocded bytes, characters outside the base64 alphebet were encountered.
+  encoded bytes, characters outside the base64 alphabet were encountered.
   The characters are ignored, but the resulting decoded bytes may be invalid.

--- a/Doc/library/email.generator.rst
+++ b/Doc/library/email.generator.rst
@@ -88,8 +88,8 @@ over channels that are not "8 bit clean".
       If ``cte_type`` is ``7bit``, convert the bytes with the high bit set as
       needed using an ASCII-compatible :mailheader:`Content-Transfer-Encoding`.
       That is, transform parts with non-ASCII
-      :mailheader:`Cotnent-Transfer-Encoding`
-      (:mailheader:`Content-Transfer-Encoding: 8bit`) to an ASCII compatibile
+      :mailheader:`Content-Transfer-Encoding`
+      (:mailheader:`Content-Transfer-Encoding: 8bit`) to an ASCII compatible
       :mailheader:`Content-Transfer-Encoding`, and encode RFC-invalid non-ASCII
       bytes in headers using the MIME ``unknown-8bit`` character set, thus
       rendering them RFC-compliant.

--- a/Doc/library/email.headerregistry.rst
+++ b/Doc/library/email.headerregistry.rst
@@ -451,5 +451,5 @@ construct structured values to assign to specific headers.
 
 .. rubric:: Footnotes
 
-.. [1] Oringally added in 3.3 as a :term:`provisional module <provisional
+.. [1] Originally added in 3.3 as a :term:`provisional module <provisional
        package>`

--- a/Doc/library/email.message.rst
+++ b/Doc/library/email.message.rst
@@ -52,7 +52,7 @@ message objects.
 
 .. class:: EmailMessage(policy=default)
 
-   If *policy* is specified use the rules it specifies to udpate and serialize
+   If *policy* is specified use the rules it specifies to update and serialize
    the representation of the message.  If *policy* is not set, use the
    :class:`~email.policy.default` policy, which follows the rules of the email
    RFCs except for line endings (instead of the RFC mandated ``\r\n``, it uses
@@ -63,7 +63,7 @@ message objects.
 
       Return the entire message flattened as a string.  When optional
       *unixfrom* is true, the envelope header is included in the returned
-      string.  *unixfrom* defaults to ``False``.  For backward compabitility
+      string.  *unixfrom* defaults to ``False``.  For backward compatibility
       with the base :class:`~email.message.Message` class *maxheaderlen* is
       accepted, but defaults to ``None``, which means that by default the line
       length is controlled by the
@@ -213,7 +213,7 @@ message objects.
          del msg['subject']
          msg['subject'] = 'Python roolz!'
 
-      If the :mod:`policy` defines certain haders to be unique (as the standard
+      If the :mod:`policy` defines certain headers to be unique (as the standard
       policies do), this method may raise a :exc:`ValueError` when an attempt
       is made to assign a value to such a header when one already exists.  This
       behavior is intentional for consistency's sake, but do not depend on it
@@ -558,7 +558,7 @@ message objects.
       the part a candidate match if the value of the header is ``inline``.
 
       If none of the candidates matches any of the preferences in
-      *preferneclist*, return ``None``.
+      *preferencelist*, return ``None``.
 
       Notes: (1) For most applications the only *preferencelist* combinations
       that really make sense are ``('plain',)``, ``('html', 'plain')``, and the
@@ -746,6 +746,6 @@ message objects.
 
 .. rubric:: Footnotes
 
-.. [1] Oringally added in 3.4 as a :term:`provisional module <provisional
+.. [1] Originally added in 3.4 as a :term:`provisional module <provisional
        package>`.  Docs for legacy message class moved to
        :ref:`compat32_message`.

--- a/Doc/library/email.mime.rst
+++ b/Doc/library/email.mime.rst
@@ -242,7 +242,7 @@ Here are the classes:
 
    Unless the *_charset* argument is explicitly set to ``None``, the
    MIMEText object created will have both a :mailheader:`Content-Type` header
-   with a ``charset`` parameter, and a :mailheader:`Content-Transfer-Endcoding`
+   with a ``charset`` parameter, and a :mailheader:`Content-Transfer-Encoding`
    header.  This means that a subsequent ``set_payload`` call will not result
    in an encoded payload, even if a charset is passed in the ``set_payload``
    command.  You can "reset" this behavior by deleting the

--- a/Doc/library/email.parser.rst
+++ b/Doc/library/email.parser.rst
@@ -139,7 +139,7 @@ message body, instead setting the payload to the raw body.
 .. class:: BytesParser(_class=None, *, policy=policy.compat32)
 
    Create a :class:`BytesParser` instance.  The *_class* and *policy*
-   arguments have the same meaning and sematnics as the *_factory*
+   arguments have the same meaning and semantics as the *_factory*
    and *policy* arguments of :class:`BytesFeedParser`.
 
    Note: **The policy keyword should always be specified**; The default will

--- a/Doc/library/email.policy.rst
+++ b/Doc/library/email.policy.rst
@@ -276,7 +276,7 @@ added matters.  To illustrate::
       Called when a header is added to an :class:`~email.message.EmailMessage`
       or :class:`~email.message.Message` object.  If the returned value is not
       ``0`` or ``None``, and there are already a number of headers with the
-      name *name* greather than or equal to the value returned, a
+      name *name* greater than or equal to the value returned, a
       :exc:`ValueError` is raised.
 
       Because the default behavior of ``Message.__setitem__`` is to append the
@@ -533,7 +533,7 @@ more closely to the RFCs relevant to their domains.
 
    The same as ``SMTP`` except that :attr:`~EmailPolicy.utf8` is ``True``.
    Useful for serializing messages to a message store without using encoded
-   words in the headers.  Should only be used for SMTP trasmission if the
+   words in the headers.  Should only be used for SMTP transmission if the
    sender or recipient addresses have non-ASCII characters (the
    :meth:`smtplib.SMTP.send_message` method handles this automatically).
 
@@ -647,5 +647,5 @@ The header objects and their attributes are described in
 
 .. rubric:: Footnotes
 
-.. [1] Oringally added in 3.3 as a :term:`provisional feature <provisional
+.. [1] Originally added in 3.3 as a :term:`provisional feature <provisional
        package>`.

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -243,7 +243,7 @@ The following exceptions are the exceptions that are usually raised.
 
    .. note::
 
-      It should not be used to indicate that an operater or method is not
+      It should not be used to indicate that an operator or method is not
       meant to be supported at all -- in that case either leave the operator /
       method undefined or, if a subclass, set it to :data:`None`.
 

--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -118,7 +118,7 @@ AU_read objects, as returned by :func:`.open` above, have the following methods:
 
 .. method:: AU_read.getnchannels()
 
-   Returns number of audio channels (1 for mone, 2 for stereo).
+   Returns number of audio channels (1 for mono, 2 for stereo).
 
 
 .. method:: AU_read.getsampwidth()

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -1797,7 +1797,7 @@ Input methods
    :param prompt: string
 
    Pop up a dialog window for input of a string. Parameter title is
-   the title of the dialog window, propmt is a text mostly describing
+   the title of the dialog window, prompt is a text mostly describing
    what information to input.
    Return the string input. If the dialog is canceled, return ``None``. ::
 

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -108,7 +108,7 @@ DOMEventStream Objects
       :class:`xml.dom.minidom.Element` if event equals :data:`START_ELEMENT` or
       :data:`END_ELEMENT` or :class:`xml.dom.minidom.Text` if event equals
       :data:`CHARACTERS`.
-      The current node does not contain informations about its children, unless
+      The current node does not contain information about its children, unless
       :func:`expandNode` is called.
 
    .. method:: expandNode(node)

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -636,7 +636,7 @@ which are used to control the execution of a generator function.
    without yielding another value, an :exc:`StopAsyncIteration` exception is
    raised by the awaitable.
    If the generator function does not catch the passed-in exception, or
-   raises a different exception, then when the awaitalbe is run that exception
+   raises a different exception, then when the awaitable is run that exception
    propagates to the caller of the awaitable.
 
 .. index:: exception: GeneratorExit

--- a/Lib/email/architecture.rst
+++ b/Lib/email/architecture.rst
@@ -66,7 +66,7 @@ data payloads.
 Message Lifecycle
 -----------------
 
-The general lifecyle of a message is:
+The general lifecycle of a message is:
 
     Creation
         A `Message` object can be created by a Parser, or it can be


### PR DESCRIPTION
(cherry picked from commit 3378b2062c7fbb77a9b5e6d315d6b94160fac69a)