### PR TITLE
bpo-24658: Fix read/write on file with a size greater than 2GB on OSX

### DIFF
--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -84,7 +84,7 @@ PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 #if defined(MS_WINDOWS) || defined(__APPLE__)
     /* On Windows, the count parameter of read() is an int (bpo-9015, bpo-9611).
        On macOS 10.13, read() and write() with more than INT_MAX bytes
-       fails with EINVAL (bpo-24658). */
+       fail with EINVAL (bpo-24658). */
 #   define _PY_READ_MAX  INT_MAX
 #   define _PY_WRITE_MAX INT_MAX
 #else

--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -83,13 +83,12 @@ PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 
 #if defined(MS_WINDOWS) || defined(__APPLE__)
 /* On Windows, the count parameter of read() is an int.
-   macOS fails when reading or writing more than 2GB, see #24658
-*/
-#define _PY_READ_MAX  INT_MAX
-#define _PY_WRITE_MAX INT_MAX
+ * macOS fails when reading or writing more than 2GB, see bpo-24658 */
+#   define _PY_READ_MAX  INT_MAX
+#   define _PY_WRITE_MAX INT_MAX
 #else
-#define _PY_READ_MAX  PY_SSIZE_T_MAX
-#define _PY_WRITE_MAX PY_SSIZE_T_MAX
+#   define _PY_READ_MAX  PY_SSIZE_T_MAX
+#   define _PY_WRITE_MAX PY_SSIZE_T_MAX
 /* write() should truncate count to PY_SSIZE_T_MAX, but it's safer
  * to do it ourself to have a portable behaviour */
 #endif

--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -81,6 +81,17 @@ PyAPI_FUNC(int) _Py_EncodeLocaleEx(
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 
+#if defined(MS_WINDOWS) || defined(__APPLE__)
+/* On Windows, the count parameter of read() is an int
+   See issue #24658
+*/
+#define _PY_READ_MAX  INT_MAX
+#define _PY_WRITE_MAX INT_MAX
+#else
+#define _PY_READ_MAX  PY_SSIZE_T_MAX
+#define _PY_WRITE_MAX PY_SSIZE_T_MAX
+#endif
+
 #ifdef MS_WINDOWS
 struct _Py_stat_struct {
     unsigned long st_dev;

--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -82,8 +82,9 @@ PyAPI_FUNC(int) _Py_EncodeLocaleEx(
 PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 
 #if defined(MS_WINDOWS) || defined(__APPLE__)
-    /* On Windows, the count parameter of read() is an int.
-       macOS fails when reading or writing more than 2GB, see bpo-24658 */
+    /* On Windows, the count parameter of read() is an int (bpo-9015, bpo-9611).
+       On macOS 10.13, read() and write() with more than INT_MAX bytes
+       fails with EINVAL (bpo-24658). */
 #   define _PY_READ_MAX  INT_MAX
 #   define _PY_WRITE_MAX INT_MAX
 #else

--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -83,7 +83,7 @@ PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 
 #if defined(MS_WINDOWS) || defined(__APPLE__)
 /* On Windows, the count parameter of read() is an int
-   See issue #24658
+   Add the support of MacOS with the issue #24658
 */
 #define _PY_READ_MAX  INT_MAX
 #define _PY_WRITE_MAX INT_MAX

--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -82,15 +82,14 @@ PyAPI_FUNC(int) _Py_EncodeLocaleEx(
 PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 
 #if defined(MS_WINDOWS) || defined(__APPLE__)
-/* On Windows, the count parameter of read() is an int.
- * macOS fails when reading or writing more than 2GB, see bpo-24658 */
+    /* On Windows, the count parameter of read() is an int.
+       macOS fails when reading or writing more than 2GB, see bpo-24658 */
 #   define _PY_READ_MAX  INT_MAX
 #   define _PY_WRITE_MAX INT_MAX
 #else
+    /* write() should truncate the input to PY_SSIZE_T_MAX bytes */
 #   define _PY_READ_MAX  PY_SSIZE_T_MAX
 #   define _PY_WRITE_MAX PY_SSIZE_T_MAX
-/* write() should truncate count to PY_SSIZE_T_MAX, but it's safer
- * to do it ourself to have a portable behaviour */
 #endif
 
 #ifdef MS_WINDOWS

--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -90,6 +90,8 @@ PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 #else
 #define _PY_READ_MAX  PY_SSIZE_T_MAX
 #define _PY_WRITE_MAX PY_SSIZE_T_MAX
+/* write() should truncate count to PY_SSIZE_T_MAX, but it's safer
+ * to do it ourself to have a portable behaviour */
 #endif
 
 #ifdef MS_WINDOWS

--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -87,7 +87,8 @@ PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 #   define _PY_READ_MAX  INT_MAX
 #   define _PY_WRITE_MAX INT_MAX
 #else
-    /* write() should truncate the input to PY_SSIZE_T_MAX bytes */
+    /* write() should truncate the input to PY_SSIZE_T_MAX bytes,
+       but it's safer to do it ourself to have a portable behaviour */
 #   define _PY_READ_MAX  PY_SSIZE_T_MAX
 #   define _PY_WRITE_MAX PY_SSIZE_T_MAX
 #endif

--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -82,8 +82,8 @@ PyAPI_FUNC(int) _Py_EncodeLocaleEx(
 PyAPI_FUNC(PyObject *) _Py_device_encoding(int);
 
 #if defined(MS_WINDOWS) || defined(__APPLE__)
-/* On Windows, the count parameter of read() is an int
-   Add the support of MacOS with the issue #24658
+/* On Windows, the count parameter of read() is an int.
+   macOS fails when reading or writing more than 2GB, see #24658
 */
 #define _PY_READ_MAX  INT_MAX
 #define _PY_WRITE_MAX INT_MAX

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -45,9 +45,9 @@ class LargeFileTest:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
 
-    @bigmemtest(size=_2G, memuse=1)
-    def test_large_reads_writes(self, _size):
+    def test_large_reads_writes(self):
         # see issue #24658
+        size = size / 10
         requires('largefile',
                  'test requires %s bytes and a long time to run' % size)
         self.addCleanup(unlink, TESTFN)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -45,7 +45,8 @@ class LargeFileTest:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
 
-    def test_large_reads_writes(self):
+    @bigmemtest(size=_2G, memuse=1)
+    def test_large_reads_writes(self, _size):
         # see issue #24658
         requires('largefile',
                  'test requires %s bytes and a long time to run' % size)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -46,10 +46,7 @@ class LargeFileTest:
                                        'with mode "wb"')
 
     def test_large_reads_writes(self):
-        # see issue #24658
-        requires('largefile',
-                 'test requires %s bytes and a long time to run' % size)
-
+        # bpo-24658: Test that a read greater than 2GB does not fail.
         with self.open(TESTFN, "rb") as f:
             self.assertEqual(len(f.read()), size + 1)
             self.assertEqual(f.tell(), size + 1)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -45,7 +45,8 @@ class LargeFileTest:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
 
-    def test_large_read(self):
+    @bigmemtest(size=_2G, memuse=1)
+    def test_large_read(self, _size):
         # bpo-24658: Test that a read greater than 2GB does not fail.
         with self.open(TESTFN, "rb") as f:
             self.assertEqual(len(f.read()), size + 1)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -49,19 +49,9 @@ class LargeFileTest:
         # see issue #24658
         requires('largefile',
                  'test requires %s bytes and a long time to run' % size)
-        # self.addCleanup(unlink, TESTFN)
-        # with self.open(TESTFN, "wb") as f:
-        #     b = b'x' * size
-        #     self.assertEqual(f.write(b), size)
-        #     self.assertEqual(f.tell(), size)
-        with self.open(TESTFN, "wb") as f:
-            f.seek(size)
-            f.write(b'a')
-            f.flush()
-            self.assertEqual(f.tell(), size + 1)
 
         with self.open(TESTFN, "rb") as f:
-            f.read()
+            self.assertEqual(len(f.read()), size + 1)
             self.assertEqual(f.tell(), size + 1)
 
     def test_osstat(self):

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -49,6 +49,7 @@ class LargeFileTest:
         # see issue #24658
         requires('largefile',
                  'test requires %s bytes and a long time to run' % size)
+        self.addCleanup(unlink, TESTFN)
         with self.open(TESTFN, "wb") as f:
             b = b'x' * size
             self.assertEqual(f.write(b), size)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -47,18 +47,22 @@ class LargeFileTest:
 
     def test_large_reads_writes(self):
         # see issue #24658
-        size = size / 10
         requires('largefile',
                  'test requires %s bytes and a long time to run' % size)
-        self.addCleanup(unlink, TESTFN)
+        # self.addCleanup(unlink, TESTFN)
+        # with self.open(TESTFN, "wb") as f:
+        #     b = b'x' * size
+        #     self.assertEqual(f.write(b), size)
+        #     self.assertEqual(f.tell(), size)
         with self.open(TESTFN, "wb") as f:
-            b = b'x' * size
-            self.assertEqual(f.write(b), size)
-            self.assertEqual(f.tell(), size)
+            f.seek(size)
+            f.write(b'a')
+            f.flush()
+            self.assertEqual(f.tell(), size + 1)
 
         with self.open(TESTFN, "rb") as f:
             f.read()
-            self.assertEqual(f.tell(), size)
+            self.assertEqual(f.tell(), size + 1)
 
     def test_osstat(self):
         self.assertEqual(os.stat(TESTFN)[stat.ST_SIZE], size+1)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -5,7 +5,7 @@ import os
 import stat
 import sys
 import unittest
-from test.support import TESTFN, requires, unlink, bigmemtest, _2G
+from test.support import TESTFN, requires, unlink
 import io  # C implementation of io
 import _pyio as pyio # Python implementation of io
 

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -45,7 +45,7 @@ class LargeFileTest:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
 
-    def test_large_reads_writes(self):
+    def test_large_read(self):
         # bpo-24658: Test that a read greater than 2GB does not fail.
         with self.open(TESTFN, "rb") as f:
             self.assertEqual(len(f.read()), size + 1)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -5,7 +5,7 @@ import os
 import stat
 import sys
 import unittest
-from test.support import TESTFN, requires, unlink
+from test.support import TESTFN, requires, unlink, bigmemtest, _2G
 import io  # C implementation of io
 import _pyio as pyio # Python implementation of io
 
@@ -44,6 +44,19 @@ class LargeFileTest:
         if not os.stat(TESTFN)[stat.ST_SIZE] == 0:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
+
+    def test_large_reads_writes(self):
+        # see issue #24658
+        requires('largefile',
+                 'test requires %s bytes and a long time to run' % size)
+        with self.open(TESTFN, "wb") as f:
+            b = b'x' * size
+            self.assertEqual(f.write(b), size)
+            self.assertEqual(f.tell(), size)
+
+        with self.open(TESTFN, "rb") as f:
+            f.read()
+            self.assertEqual(f.tell(), size)
 
     def test_osstat(self):
         self.assertEqual(os.stat(TESTFN)[stat.ST_SIZE], size+1)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -5,7 +5,7 @@ import os
 import stat
 import sys
 import unittest
-from test.support import TESTFN, requires, unlink, bigmemtest, _2G
+from test.support import TESTFN, requires, unlink, bigmemtest
 import io  # C implementation of io
 import _pyio as pyio # Python implementation of io
 

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -5,7 +5,7 @@ import os
 import stat
 import sys
 import unittest
-from test.support import TESTFN, requires, unlink
+from test.support import TESTFN, requires, unlink, bigmemtest, _2G
 import io  # C implementation of io
 import _pyio as pyio # Python implementation of io
 

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -45,7 +45,7 @@ class LargeFileTest:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
 
-    # _pyio.FileIO.readall() uses a temporary bytearray then casted to bytes
+    # _pyio.FileIO.readall() uses a temporary bytearray then casted to bytes,
     # so memuse=2 is needed
     @bigmemtest(size=size, memuse=2, dry_run=False)
     def test_large_read(self, _size):

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -49,7 +49,7 @@ class LargeFileTest:
     def test_large_read(self, _size):
         # bpo-24658: Test that a read greater than 2GB does not fail.
         with self.open(TESTFN, "rb") as f:
-            self.assertEqual(len(f.read()), size)
+            self.assertEqual(len(f.read()), size + 1)
             self.assertEqual(f.tell(), size + 1)
 
     def test_osstat(self):

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -45,7 +45,7 @@ class LargeFileTest:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
 
-    @bigmemtest(size=size, memuse=1, dry_run=False)
+    @bigmemtest(size=size, memuse=2, dry_run=False)
     def test_large_read(self, _size):
         # bpo-24658: Test that a read greater than 2GB does not fail.
         with self.open(TESTFN, "rb") as f:

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -10,7 +10,7 @@ import io  # C implementation of io
 import _pyio as pyio # Python implementation of io
 
 # size of file to create (>2 GiB; 2 GiB == 2,147,483,648 bytes)
-size = 2500000000
+size = 2_500_000_000
 
 class LargeFileTest:
     """Test that each file function works as expected for large
@@ -45,7 +45,7 @@ class LargeFileTest:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
 
-    @bigmemtest(size=_2G, memuse=1)
+    @bigmemtest(size=size+1, memuse=1)
     def test_large_read(self, _size):
         # bpo-24658: Test that a read greater than 2GB does not fail.
         with self.open(TESTFN, "rb") as f:

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -45,6 +45,8 @@ class LargeFileTest:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
 
+    # _pyio.FileIO.readall() uses a temporary bytearray then casted to bytes
+    # so memuse=2 is needed
     @bigmemtest(size=size, memuse=2, dry_run=False)
     def test_large_read(self, _size):
         # bpo-24658: Test that a read greater than 2GB does not fail.

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -45,11 +45,11 @@ class LargeFileTest:
             raise cls.failureException('File was not truncated by opening '
                                        'with mode "wb"')
 
-    @bigmemtest(size=size+1, memuse=1)
+    @bigmemtest(size=size, memuse=1, dry_run=False)
     def test_large_read(self, _size):
         # bpo-24658: Test that a read greater than 2GB does not fail.
         with self.open(TESTFN, "rb") as f:
-            self.assertEqual(len(f.read()), size + 1)
+            self.assertEqual(len(f.read()), size)
             self.assertEqual(f.tell(), size + 1)
 
     def test_osstat(self):

--- a/Misc/NEWS.d/next/macOS/2018-10-17-14-36-08.bpo-24658.Naddgx.rst
+++ b/Misc/NEWS.d/next/macOS/2018-10-17-14-36-08.bpo-24658.Naddgx.rst
@@ -1,1 +1,1 @@
-Fix read/write on file with a size > 2GB on macOS
+On macOS, fix reading from and writing into a file with a size larger than 2GiB.

--- a/Misc/NEWS.d/next/macOS/2018-10-17-14-36-08.bpo-24658.Naddgx.rst
+++ b/Misc/NEWS.d/next/macOS/2018-10-17-14-36-08.bpo-24658.Naddgx.rst
@@ -1,1 +1,1 @@
-On macOS, fix reading from and writing into a file with a size larger than 2GiB.
+On macOS, fix reading from and writing into a file with a size larger than 2 GiB.

--- a/Misc/NEWS.d/next/macOS/2018-10-17-14-36-08.bpo-24658.Naddgx.rst
+++ b/Misc/NEWS.d/next/macOS/2018-10-17-14-36-08.bpo-24658.Naddgx.rst
@@ -1,0 +1,1 @@
+Fix read/write on file with a size > 2GB on macOS

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -791,11 +791,9 @@ _io_FileIO_read_impl(fileio *self, Py_ssize_t size)
     if (size < 0)
         return _io_FileIO_readall_impl(self);
 
-#ifdef MS_WINDOWS
-    /* On Windows, the count parameter of read() is an int */
-    if (size > INT_MAX)
-        size = INT_MAX;
-#endif
+    if (size > _PY_READ_MAX) {
+        size = _PY_READ_MAX;
+    }
 
     bytes = PyBytes_FromStringAndSize(NULL, size);
     if (bytes == NULL)

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1471,18 +1471,9 @@ _Py_read(int fd, void *buf, size_t count)
      * handler raised an exception. */
     assert(!PyErr_Occurred());
 
-#ifdef MS_WINDOWS
-    if (count > INT_MAX) {
-        /* On Windows, the count parameter of read() is an int */
-        count = INT_MAX;
+    if (count > _PY_READ_MAX) {
+        count = _PY_READ_MAX;
     }
-#else
-    if (count > PY_SSIZE_T_MAX) {
-        /* if count is greater than PY_SSIZE_T_MAX,
-         * read() result is undefined */
-        count = PY_SSIZE_T_MAX;
-    }
-#endif
 
     _Py_BEGIN_SUPPRESS_IPH
     do {
@@ -1533,15 +1524,10 @@ _Py_write_impl(int fd, const void *buf, size_t count, int gil_held)
            depending on heap usage). */
         count = 32767;
     }
-    else if (count > INT_MAX)
-        count = INT_MAX;
-#else
-    if (count > PY_SSIZE_T_MAX) {
-        /* write() should truncate count to PY_SSIZE_T_MAX, but it's safer
-         * to do it ourself to have a portable behaviour. */
-        count = PY_SSIZE_T_MAX;
-    }
 #endif
+    if (count > _PY_WRITE_MAX) {
+        count = _PY_WRITE_MAX;
+    }
 
     if (gil_held) {
         do {


### PR DESCRIPTION


<!-- issue-number: [bpo-24658](https://bugs.python.org/issue24658) -->
https://bugs.python.org/issue24658
<!-- /issue-number -->
