### PR TITLE
[3.5] Fix typos in multiple `.rst` files (GH-1668)

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -295,7 +295,7 @@ an error value).
    :c:data:`PyExc_Warning` is a subclass of :c:data:`PyExc_Exception`;
    the default warning category is :c:data:`PyExc_RuntimeWarning`. The standard
    Python warning categories are available as global variables whose names are
-   enumerated at :ref:`standarwarningcategories`.
+   enumerated at :ref:`standardwarningcategories`.
 
    For information about warning control, see the documentation for the
    :mod:`warnings` module and the :option:`-W` option in the command line
@@ -937,7 +937,7 @@ Notes:
    Only defined on Windows; protect code that uses this by testing that the
    preprocessor macro ``MS_WINDOWS`` is defined.
 
-.. _standarwarningcategories:
+.. _standardwarningcategories:
 
 Standard Warning Categories
 ===========================
@@ -950,7 +950,7 @@ the variables:
 .. index::
    single: PyExc_Warning
    single: PyExc_BytesWarning
-   single: PyExc_DepricationWarning
+   single: PyExc_DeprecationWarning
    single: PyExc_FutureWarning
    single: PyExc_ImportWarning
    single: PyExc_PendingDeprecationWarning
@@ -973,7 +973,7 @@ the variables:
 +------------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_ImportWarning`            | :exc:`ImportWarning`            |          |
 +------------------------------------------+---------------------------------+----------+
-| :c:data:`PyExc_PendingDepricationWarning`| :exc:`PendingDeprecationWarning`|          |
+| :c:data:`PyExc_PendingDeprecationWarning`| :exc:`PendingDeprecationWarning`|          |
 +------------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_ResourceWarning`          | :exc:`ResourceWarning`          |          |
 +------------------------------------------+---------------------------------+----------+

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1683,7 +1683,7 @@ Implementing structured logging
 -------------------------------
 
 Although most logging messages are intended for reading by humans, and thus not
-readily machine-parseable, there might be cirumstances where you want to output
+readily machine-parseable, there might be circumstances where you want to output
 messages in a structured format which *is* capable of being parsed by a program
 (without needing complex regular expressions to parse the log message). This is
 straightforward to achieve using the logging package. There are a number of

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -266,10 +266,10 @@ immediate playback::
             'Draw circle with given radius an options extent and steps:  CIRCLE 50'
             circle(*parse(arg))
         def do_position(self, arg):
-            'Print the current turle position:  POSITION'
+            'Print the current turtle position:  POSITION'
             print('Current position is %d %d\n' % position())
         def do_heading(self, arg):
-            'Print the current turle heading in degrees:  HEADING'
+            'Print the current turtle heading in degrees:  HEADING'
             print('Current heading is %d\n' % (heading(),))
         def do_color(self, arg):
             'Set the color:  COLOR BLUE'

--- a/Doc/library/email.contentmanager.rst
+++ b/Doc/library/email.contentmanager.rst
@@ -62,7 +62,7 @@ this module.
 .. class:: EmailMessage(policy=default)
 
    If *policy* is specified (it must be an instance of a :mod:`~email.policy`
-   class) use the rules it specifies to udpate and serialize the representation
+   class) use the rules it specifies to update and serialize the representation
    of the message.  If *policy* is not set, use the
    :class:`~email.policy.default` policy, which follows the rules of the email
    RFCs except for line endings (instead of the RFC mandated ``\r\n``, it uses
@@ -108,7 +108,7 @@ this module.
       the part a candidate match if the value of the header is ``inline``.
 
       If none of the candidates matches any of the preferences in
-      *preferneclist*, return ``None``.
+      *preferencelist*, return ``None``.
 
       Notes: (1) For most applications the only *preferencelist* combinations
       that really make sense are ``('plain',)``, ``('html', 'plain')``, and the
@@ -396,7 +396,7 @@ Currently the email package provides only one concrete content manager,
        MIME charset name, use the standard charset instead.
 
        If *cte* is set, encode the payload using the specified content transfer
-       encoding, and set the :mailheader:`Content-Transfer-Endcoding` header to
+       encoding, and set the :mailheader:`Content-Transfer-Encoding` header to
        that value.  For ``str`` objects, if it is not set use heuristics to
        determine the most compact encoding.  Possible values for *cte* are
        ``quoted-printable``, ``base64``, ``7bit``, ``8bit``, and ``binary``.

--- a/Doc/library/email.errors.rst
+++ b/Doc/library/email.errors.rst
@@ -108,9 +108,9 @@ this class is *not* an exception!
   return false even though its content type claims to be :mimetype:`multipart`.
 
 * :class:`InvalidBase64PaddingDefect` -- When decoding a block of base64
-  enocded bytes, the padding was not correct.  Enough padding is added to
+  encoded bytes, the padding was not correct.  Enough padding is added to
   perform the decode, but the resulting decoded bytes may be invalid.
 
 * :class:`InvalidBase64CharactersDefect` -- When decoding a block of base64
-  enocded bytes, characters outside the base64 alphebet were encountered.
+  encoded bytes, characters outside the base64 alphabet were encountered.
   The characters are ignored, but the resulting decoded bytes may be invalid.

--- a/Doc/library/email.message.rst
+++ b/Doc/library/email.message.rst
@@ -50,7 +50,7 @@ Here are the methods of the :class:`Message` class:
 
       Return the entire message flattened as a string.  When optional *unixfrom*
       is true, the envelope header is included in the returned string.
-      *unixfrom* defaults to ``False``.  For backward compabitility reasons,
+      *unixfrom* defaults to ``False``.  For backward compatibility reasons,
       *maxheaderlen* defaults to ``0``, so if you want a different value you
       must override it explicitly (the value specified for *max_line_length* in
       the policy will be ignored by this method).  The *policy* argument may be

--- a/Doc/library/email.mime.rst
+++ b/Doc/library/email.mime.rst
@@ -203,7 +203,7 @@ Here are the classes:
 
    Unless the *_charset* argument is explicitly set to ``None``, the
    MIMEText object created will have both a :mailheader:`Content-Type` header
-   with a ``charset`` parameter, and a :mailheader:`Content-Transfer-Endcoding`
+   with a ``charset`` parameter, and a :mailheader:`Content-Transfer-Encoding`
    header.  This means that a subsequent ``set_payload`` call will not result
    in an encoded payload, even if a charset is passed in the ``set_payload``
    command.  You can "reset" this behavior by deleting the

--- a/Doc/library/email.policy.rst
+++ b/Doc/library/email.policy.rst
@@ -540,7 +540,7 @@ more closely to the RFCs relevant to their domains.
 
    The same as ``SMTP`` except that :attr:`~EmailPolicy.utf8` is ``True``.
    Useful for serializing messages to a message store without using encoded
-   words in the headers.  Should only be used for SMTP trasmission if the
+   words in the headers.  Should only be used for SMTP transmission if the
    sender or recipient addresses have non-ASCII characters (the
    :meth:`smtplib.SMTP.send_message` method handles this automatically).
 

--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -118,7 +118,7 @@ AU_read objects, as returned by :func:`.open` above, have the following methods:
 
 .. method:: AU_read.getnchannels()
 
-   Returns number of audio channels (1 for mone, 2 for stereo).
+   Returns number of audio channels (1 for mono, 2 for stereo).
 
 
 .. method:: AU_read.getsampwidth()

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1220,7 +1220,7 @@ always available.
    |                  |  * ``None`` if this information is unknown              |
    +------------------+---------------------------------------------------------+
    | :const:`version` | Name and version of the thread library. It is a string, |
-   |                  | or ``None`` if these informations are unknown.          |
+   |                  | or ``None`` if this information is unknown.             |
    +------------------+---------------------------------------------------------+
 
    .. versionadded:: 3.3

--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -1797,7 +1797,7 @@ Input methods
    :param prompt: string
 
    Pop up a dialog window for input of a string. Parameter title is
-   the title of the dialog window, propmt is a text mostly describing
+   the title of the dialog window, prompt is a text mostly describing
    what information to input.
    Return the string input. If the dialog is canceled, return ``None``. ::
 

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -108,7 +108,7 @@ DOMEventStream Objects
       :class:`xml.dom.minidom.Element` if event equals :data:`START_ELEMENT` or
       :data:`END_ELEMENT` or :class:`xml.dom.minidom.Text` if event equals
       :data:`CHARACTERS`.
-      The current node does not contain informations about its children, unless
+      The current node does not contain information about its children, unless
       :func:`expandNode` is called.
 
    .. method:: expandNode(node)

--- a/Lib/email/architecture.rst
+++ b/Lib/email/architecture.rst
@@ -66,7 +66,7 @@ data payloads.
 Message Lifecycle
 -----------------
 
-The general lifecyle of a message is:
+The general lifecycle of a message is:
 
     Creation
         A `Message` object can be created by a Parser, or it can be

--- a/Misc/HISTORY
+++ b/Misc/HISTORY
@@ -3285,7 +3285,7 @@ Library
 - Issue #11382: Trivial system calls, such as dup() or pipe(), needn't
   release the GIL.  Patch by Charles-François Natali.
 
-- Issue #11223: Add threading._info() function providing informations about
+- Issue #11223: Add threading._info() function providing information about
   the thread implementation.
 
 - Issue #11731: simplify/enhance email parser/generator API by introducing

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -7238,7 +7238,7 @@ Library
 - Issue #17702: On error, os.environb now suppresses the exception context
   when raising a new KeyError with the original key.
 
-- Issue #16809: Fixed some tkinter incompabilities with Tcl/Tk 8.6.
+- Issue #16809: Fixed some tkinter incompatibilities with Tcl/Tk 8.6.
 
 - Issue #16809: Tkinter's splitlist() and split() methods now accept Tcl_Obj
   argument.

--- a/Modules/zlib/configure
+++ b/Modules/zlib/configure
@@ -859,7 +859,7 @@ echo prefix = $prefix >> configure.log
 echo sharedlibdir = $sharedlibdir >> configure.log
 echo uname = $uname >> configure.log
 
-# update Makefile with the configure results
+# udpate Makefile with the configure results
 sed < ${SRCDIR}Makefile.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#

--- a/Modules/zlib/configure
+++ b/Modules/zlib/configure
@@ -859,7 +859,7 @@ echo prefix = $prefix >> configure.log
 echo sharedlibdir = $sharedlibdir >> configure.log
 echo uname = $uname >> configure.log
 
-# udpate Makefile with the configure results
+# update Makefile with the configure results
 sed < ${SRCDIR}Makefile.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#


### PR DESCRIPTION
I fixed the same typos as in my previous PR #1668 (and also, a couple new ones specific to the `3.5` docs). Sorry for the confusion with the other PR's, @serhiy-storchaka !
