### PR TITLE
[2.7] Fix typos in multiple `.rst` files (GH-1668)

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -290,7 +290,7 @@ is a separate error indicator for each thread.
    :c:data:`PyExc_Warning` is a subclass of :c:data:`PyExc_Exception`;
    the default warning category is :c:data:`PyExc_RuntimeWarning`. The standard
    Python warning categories are available as global variables whose names are
-   enumerated at :ref:`standarwarningcategories`.
+   enumerated at :ref:`standardwarningcategories`.
 
    For information about warning control, see the documentation for the
    :mod:`warnings` module and the :option:`-W` option in the command line
@@ -665,7 +665,7 @@ Notes:
    Only defined on VMS; protect code that uses this by testing that the
    preprocessor macro ``__VMS`` is defined.
 
-.. _standarwarningcategories:
+.. _standardwarningcategories:
 
 Standard Warning Categories
 ===========================
@@ -678,7 +678,7 @@ the variables:
 .. index::
    single: PyExc_Warning
    single: PyExc_BytesWarning
-   single: PyExc_DepricationWarning
+   single: PyExc_DeprecationWarning
    single: PyExc_FutureWarning
    single: PyExc_ImportWarning
    single: PyExc_PendingDeprecationWarning
@@ -700,7 +700,7 @@ the variables:
 +------------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_ImportWarning`            | :exc:`ImportWarning`            |          |
 +------------------------------------------+---------------------------------+----------+
-| :c:data:`PyExc_PendingDepricationWarning`| :exc:`PendingDeprecationWarning`|          |
+| :c:data:`PyExc_PendingDeprecationWarning`| :exc:`PendingDeprecationWarning`|          |
 +------------------------------------------+---------------------------------+----------+
 | :c:data:`PyExc_RuntimeWarning`           | :exc:`RuntimeWarning`           |          |
 +------------------------------------------+---------------------------------+----------+

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -814,7 +814,7 @@ Implementing structured logging
 -------------------------------
 
 Although most logging messages are intended for reading by humans, and thus not
-readily machine-parseable, there might be cirumstances where you want to output
+readily machine-parseable, there might be circumstances where you want to output
 messages in a structured format which *is* capable of being parsed by a program
 (without needing complex regular expressions to parse the log message). This is
 straightforward to achieve using the logging package. There are a number of

--- a/Doc/library/email.mime.rst
+++ b/Doc/library/email.mime.rst
@@ -210,7 +210,7 @@ Here are the classes:
 
    Unless the ``_charset`` parameter is explicitly set to ``None``, the
    MIMEText object created will have both a :mailheader:`Content-Type` header
-   with a ``charset`` parameter, and a :mailheader:`Content-Transfer-Endcoding`
+   with a ``charset`` parameter, and a :mailheader:`Content-Transfer-Encoding`
    header.  This means that a subsequent ``set_payload`` call will not result
    in an encoded payload, even if a charset is passed in the ``set_payload``
    command.  You can "reset" this behavior by deleting the

--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -117,7 +117,7 @@ AU_read objects, as returned by :func:`.open` above, have the following methods:
 
 .. method:: AU_read.getnchannels()
 
-   Returns number of audio channels (1 for mone, 2 for stereo).
+   Returns number of audio channels (1 for mono, 2 for stereo).
 
 
 .. method:: AU_read.getsampwidth()

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -1207,15 +1207,15 @@ Library
 
 - Issue #24091: Fixed various crashes in corner cases in cElementTree.
 
-- Issue #15267: HTTPConnection.request() now is compatibile with old-style
+- Issue #15267: HTTPConnection.request() now is compatible with old-style
   classes (such as TemporaryFile).  Original patch by Atsuo Ishimoto.
 
 - Issue #20014: array.array() now accepts unicode typecodes.  Based on patch by
   Vajrasky Kok.
 
-- Issue #23637: Showing a warning no longer fails with UnicodeErrror.
+- Issue #23637: Showing a warning no longer fails with UnicodeError.
   Formatting unicode warning in the file with the path containing non-ascii
-  characters no longer fails with UnicodeErrror.
+  characters no longer fails with UnicodeError.
 
 - Issue #24134: Reverted issue #24134 changes.
 
@@ -1956,7 +1956,7 @@ Library
   sequence is used on some terminal (ex: TERM=xterm-256color") to enable
   support of 8 bit characters.
 
-- Issue #22017: Correct reference counting errror in the initialization of the
+- Issue #22017: Correct reference counting error in the initialization of the
   _warnings module.
 
 - Issue #21868: Prevent turtle crash when undo buffer set to a value less
@@ -2889,7 +2889,7 @@ Library
 - Issue #11973: Fix a problem in kevent. The flags and fflags fields are now
   properly handled as unsigned.
 
-- Issue #16809: Fixed some tkinter incompabilities with Tcl/Tk 8.6.
+- Issue #16809: Fixed some tkinter incompatibilities with Tcl/Tk 8.6.
 
 - Issue #16809: Tkinter's splitlist() and split() methods now accept Tcl_Obj
   argument.

--- a/Modules/zlib/configure
+++ b/Modules/zlib/configure
@@ -859,7 +859,7 @@ echo prefix = $prefix >> configure.log
 echo sharedlibdir = $sharedlibdir >> configure.log
 echo uname = $uname >> configure.log
 
-# update Makefile with the configure results
+# udpate Makefile with the configure results
 sed < ${SRCDIR}Makefile.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#

--- a/Modules/zlib/configure
+++ b/Modules/zlib/configure
@@ -859,7 +859,7 @@ echo prefix = $prefix >> configure.log
 echo sharedlibdir = $sharedlibdir >> configure.log
 echo uname = $uname >> configure.log
 
-# udpate Makefile with the configure results
+# update Makefile with the configure results
 sed < ${SRCDIR}Makefile.in "
 /^CC *=/s#=.*#=$CC#
 /^CFLAGS *=/s#=.*#=$CFLAGS#


### PR DESCRIPTION
I fixed many of the same typos as in my previous PR #1668 . There were fewer typos overall in the `2.7` docs (at least of the same words as the other PR).
