### PR TITLE
bpo-30427: eliminate redundant type checks in os.path.normcase()

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -45,16 +45,10 @@ def normcase(s):
 
     Makes all characters lowercase and all slashes into backslashes."""
     s = os.fspath(s)
-    try:
-        if isinstance(s, bytes):
-            return s.replace(b'/', b'\\').lower()
-        else:
-            return s.replace('/', '\\').lower()
-    except (TypeError, AttributeError):
-        if not isinstance(s, (bytes, str)):
-            raise TypeError("normcase() argument must be str or bytes, "
-                            "not %r" % s.__class__.__name__) from None
-        raise
+    if isinstance(s, bytes):
+        return s.replace(b'/', b'\\').lower()
+    else:
+        return s.replace('/', '\\').lower()
 
 
 # Return whether a path is absolute.

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -49,11 +49,7 @@ def _get_sep(path):
 
 def normcase(s):
     """Normalize case of pathname.  Has no effect under Posix"""
-    s = os.fspath(s)
-    if not isinstance(s, (bytes, str)):
-        raise TypeError("normcase() argument must be str or bytes, "
-                        "not '{}'".format(s.__class__.__name__))
-    return s
+    return os.fspath(s)
 
 
 # Return whether a path is absolute.

--- a/Misc/NEWS.d/next/Library/2019-03-28-21-17-08.bpo-30427.lxzvbw.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-28-21-17-08.bpo-30427.lxzvbw.rst
@@ -1,0 +1,1 @@
+``os.path.normcase()`` relies on ``os.fspath()`` to check the type of its argument. Redundant checks have been removed from its ``posixpath.normcase()`` and ``ntpath.normcase()`` implementations.

--- a/Misc/NEWS.d/next/Library/2019-03-28-21-17-08.bpo-30427.lxzvbw.rst
+++ b/Misc/NEWS.d/next/Library/2019-03-28-21-17-08.bpo-30427.lxzvbw.rst
@@ -1,1 +1,2 @@
 ``os.path.normcase()`` relies on ``os.fspath()`` to check the type of its argument. Redundant checks have been removed from its ``posixpath.normcase()`` and ``ntpath.normcase()`` implementations.
+Patch by Wolfgang Maier.


### PR DESCRIPTION


<!-- issue-number: [bpo-30427](https://bugs.python.org/issue30427) -->
https://bugs.python.org/issue30427
<!-- /issue-number -->
