### PR TITLE
bpo-25532: Protect against infinite loops in inspect.unwrap()

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -506,10 +506,13 @@ def unwrap(func, *, stop=None):
             return hasattr(f, '__wrapped__') and not stop(f)
     f = func  # remember the original func for error reporting
     memo = {id(f)} # Memoise by id to tolerate non-hashable objects
+    unwrap_count = 0
+    recursion_limit = sys.getrecursionlimit()
     while _is_wrapper(func):
         func = func.__wrapped__
         id_func = id(func)
-        if id_func in memo:
+        unwrap_count += 1
+        if (id_func in memo) or (unwrap_count >= recursion_limit):
             raise ValueError('wrapper loop when unwrapping {!r}'.format(f))
         memo.add(id_func)
     return func

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -508,13 +508,11 @@ def unwrap(func, *, stop=None):
     # Memoise by id to tolerate non-hashable objects, but store objects to
     # ensure they aren't destroyed, which would allow their IDs to be reused.
     memo = {id(f): f}
-    unwrap_count = 0
     recursion_limit = sys.getrecursionlimit()
     while _is_wrapper(func):
         func = func.__wrapped__
         id_func = id(func)
-        unwrap_count += 1
-        if (id_func in memo) or (unwrap_count >= recursion_limit):
+        if (id_func in memo) or (len(memo) >= recursion_limit):
             raise ValueError('wrapper loop when unwrapping {!r}'.format(f))
         memo[id_func] = func
     return func

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -505,7 +505,9 @@ def unwrap(func, *, stop=None):
         def _is_wrapper(f):
             return hasattr(f, '__wrapped__') and not stop(f)
     f = func  # remember the original func for error reporting
-    memo = {id(f)} # Memoise by id to tolerate non-hashable objects
+    # Memoise by id to tolerate non-hashable objects, but store objects to
+    # ensure they aren't destroyed, which would allow their IDs to be reused.
+    memo = {id(f): f}
     unwrap_count = 0
     recursion_limit = sys.getrecursionlimit()
     while _is_wrapper(func):
@@ -514,7 +516,7 @@ def unwrap(func, *, stop=None):
         unwrap_count += 1
         if (id_func in memo) or (unwrap_count >= recursion_limit):
             raise ValueError('wrapper loop when unwrapping {!r}'.format(f))
-        memo.add(id_func)
+        memo[id_func] = func
     return func
 
 # -------------------------------------------------- source code extraction

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -989,6 +989,10 @@ Library
 - Issue #29581: ABCMeta.__new__ now accepts ``**kwargs``, allowing abstract base
   classes to use keyword parameters in __init_subclass__. Patch by Nate Soares.
 
+- Issue #25532: inspect.unwrap() will now only try to unwrap an object
+  sys.getrecursionlimit() times, to protect against objects which create a new
+  object on every attribute access.
+
 Windows
 -------
 


### PR DESCRIPTION
Some objects, such as `unittest.mock.call`, generate a new similar object every time you access `obj.__wrapped__`. This isn't caught by the memoise loop protection, because each object has a different ID. So a call like `inspect.getsourcelines(unittest.mock.call)` goes into an infinite loop, using ever more memory as it creates new objects.

This implements @ncoghlan's suggestion in [issue 22532](http://bugs.python.org/issue25532): if we've unwrapped something `sys.getrecursionlimit()` times, assume it's an infinite chain and give up. Things like `getsourcelines()` will fail, but an exception is better than using up all the memory.

IPython's inspection machinery already has a similar check, with an arbitrary limit of 100 unwraps. That returns the original object if the limit is exceeded, rather than throwing an error.
https://github.com/ipython/ipython/blob/6.0.0/IPython/core/oinspect.py#L279