### PR TITLE
[2.7] bpo-30003: Fix handling escape characters in HZ codec

### DIFF
--- a/Lib/test/test_codecencodings_cn.py
+++ b/Lib/test/test_codecencodings_cn.py
@@ -82,6 +82,10 @@ class Test_HZ(test_multibytecodec_support.TestBase, unittest.TestCase):
         (b'ab~cd', 'replace', u'ab\uFFFDd'),
         (b'ab\xffcd', 'replace', u'ab\uFFFDcd'),
         (b'ab~{\x81\x81\x41\x44~}cd', 'replace', u'ab\uFFFD\uFFFD\u804Acd'),
+        # issue 30003
+        (u'ab~cd', 'strict',  b'ab~~cd'), # escape ~
+        (b'~{Dc~~:C~}', 'strict', None),  # ~~ only in ASCII mode
+        (b'~{Dc~\n:C~}', 'strict', None), # ~\n only in ASCII mode
     )
 
 def test_main():

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -49,6 +49,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30003: Fix handling escape characters in HZ codec.  Based on patch
+  by Ma Lin.
+
 - bpo-30375: Warnings emitted when compile a regular expression now always
   point to the line in the user code.  Previously they could point into inners
   of the re module if emitted from inside of groups or conditionals.


### PR DESCRIPTION
cherry-pick for commit 89a5e03244370f41ce9bed5cea38e0dd620edb73, #1556 