### PR TITLE
bpo-30372 Clarify status of __builtins__

### DIFF
--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -164,21 +164,21 @@ Builtins and restricted execution
 
 .. index:: pair: restricted; execution
 
-The builtins namespace associated with the execution of a code block is actually
-found by looking up the name ``__builtins__`` in its global namespace; this
-should be a dictionary or a module (in the latter case the module's dictionary
-is used).  By default, when in the :mod:`__main__` module, ``__builtins__`` is
-the built-in module :mod:`builtins`; when in any other module,
-``__builtins__`` is an alias for the dictionary of the :mod:`builtins` module
-itself.  ``__builtins__`` can be set to a user-created dictionary to create a
-weak form of restricted execution.
-
 .. impl-detail::
 
    Users should not touch ``__builtins__``; it is strictly an implementation
    detail.  Users wanting to override values in the builtins namespace should
    :keyword:`import` the :mod:`builtins` module and modify its
    attributes appropriately.
+
+The builtins namespace associated with the execution of a code block
+is actually found by looking up the name ``__builtins__`` in its
+global namespace; this should be a dictionary or a module (in the
+latter case the module's dictionary is used).  By default, when in the
+:mod:`__main__` module, ``__builtins__`` is the built-in module
+:mod:`builtins`; when in any other module, ``__builtins__`` is an
+alias for the dictionary of the :mod:`builtins` module itself.
+
 
 .. _dynamic-features:
 


### PR DESCRIPTION
Fixes wording on status of __builtins__ as implementation detail.

Reorders paragraphs to make clear that __builtins__ is a CPython implementation detail and removes sentence on hacking __builtins__ to create limited execution.