### PR TITLE
bpo-30432: FileInput doesn't accept PathLike objects for file names

### DIFF
--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -189,6 +189,10 @@ class FileInput:
                  mode="r", openhook=None):
         if isinstance(files, str):
             files = (files,)
+
+        elif isinstance(files, os.PathLike):
+            files = (os.fspath(files), )
+
         else:
             if files is None:
                 files = sys.argv[1:]

--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -189,10 +189,8 @@ class FileInput:
                  mode="r", openhook=None):
         if isinstance(files, str):
             files = (files,)
-
         elif isinstance(files, os.PathLike):
             files = (os.fspath(files), )
-
         else:
             if files is None:
                 files = sys.argv[1:]

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -21,6 +21,7 @@ except ImportError:
 
 from io import BytesIO, StringIO
 from fileinput import FileInput, hook_encoded
+from pathlib import Path
 
 from test.support import verbose, TESTFN, check_warnings
 from test.support import unlink as safe_unlink
@@ -529,6 +530,22 @@ class FileInputTests(unittest.TestCase):
             self.assertEqual(src.linesread, [''])
             self.assertRaises(StopIteration, next, fi)
             self.assertEqual(src.linesread, [])
+
+    def test_pathlib_file(self):
+        t1 = None
+        try:
+            t1 = Path(writeTmp(1, ["Pathlib file."]))
+            fi = FileInput(t1)
+
+            line = fi.readline()
+            self.assertEqual(line, 'Pathlib file.')
+            self.assertEqual(fi.lineno(), 1)
+            self.assertEqual(fi.filelineno(), 1)
+            self.assertEqual(fi.filename(), os.fspath(t1))
+            fi.close()
+        finally:
+            remove_tempfiles(t1)
+
 
 class MockFileInput:
     """A class that mocks out fileinput.FileInput for use during unit tests"""

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -535,14 +535,12 @@ class FileInputTests(unittest.TestCase):
         t1 = None
         try:
             t1 = Path(writeTmp(1, ["Pathlib file."]))
-            fi = FileInput(t1)
-
-            line = fi.readline()
-            self.assertEqual(line, 'Pathlib file.')
-            self.assertEqual(fi.lineno(), 1)
-            self.assertEqual(fi.filelineno(), 1)
-            self.assertEqual(fi.filename(), os.fspath(t1))
-            fi.close()
+            with FileInput(t1) as fi:
+                line = fi.readline()
+                self.assertEqual(line, 'Pathlib file.')
+                self.assertEqual(fi.lineno(), 1)
+                self.assertEqual(fi.filelineno(), 1)
+                self.assertEqual(fi.filename(), os.fspath(t1))
         finally:
             remove_tempfiles(t1)
 


### PR DESCRIPTION
FileInput fails if a single `PathLike` is passed in as `files` due to attempting to wrap it in a tuple:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/fileinput.py", line 198, in __init__
    files = tuple(files)
TypeError: 'PosixPath' object is not iterable
```