### PR TITLE
[3.6] bpo-29941: Add --with-assertions configure flag to enable C assertions (GH-1731)

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -154,6 +154,10 @@ Library
 Build
 -----
 
+- bpo-29941: Add ``--with-assertions`` configure flag to explicitly enable
+  C ``assert()`` checks. Defaults to off. ``--with-pydebug`` implies
+  ``--with-assertions``.
+
 - bpo-28787: Fix out-of-tree builds of Python when configured with
   ``--with--dtrace``.
 

--- a/configure
+++ b/configure
@@ -818,6 +818,7 @@ with_suffix
 enable_shared
 enable_profiling
 with_pydebug
+with_assertions
 enable_optimizations
 with_lto
 with_hash_algorithm
@@ -1513,6 +1514,7 @@ Optional Packages:
                           compiler
   --with-suffix=.exe      set executable suffix
   --with-pydebug          build with Py_DEBUG defined
+  --with-assertions       build with C assertions enabled
   --with-lto              Enable Link Time Optimization in PGO builds.
                           Disabled by default.
   --with-hash-algorithm=[fnv|siphash24]
@@ -6515,6 +6517,33 @@ $as_echo "no" >&6; }
 fi
 
 
+# Check for --with-assertions. Py_DEBUG implies assertions, but also changes
+# the ABI. This allows enabling assertions without changing the ABI.
+assertions='false'
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-assertions" >&5
+$as_echo_n "checking for --with-assertions... " >&6; }
+
+# Check whether --with-assertions was given.
+if test "${with_assertions+set}" = set; then :
+  withval=$with_assertions;
+if test "$withval" != no
+then
+  assertions='true'
+fi
+fi
+
+if test "$assertions" = 'true'; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+elif test "$Py_DEBUG" = 'true'; then
+  assertions='true'
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: implied by --with-pydebug" >&5
+$as_echo "implied by --with-pydebug" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
 # Enable optimization flags
 
 
@@ -7424,7 +7453,7 @@ case "$CC" in
     ;;
 esac
 
-if test "$Py_DEBUG" = 'true'; then
+if test "$assertions" = 'true'; then
   :
 else
   OPT="-DNDEBUG $OPT"

--- a/configure.ac
+++ b/configure.ac
@@ -1258,6 +1258,27 @@ else AC_MSG_RESULT(no); Py_DEBUG='false'
 fi],
 [AC_MSG_RESULT(no)])
 
+# Check for --with-assertions. Py_DEBUG implies assertions, but also changes
+# the ABI. This allows enabling assertions without changing the ABI.
+assertions='false'
+AC_MSG_CHECKING(for --with-assertions)
+AC_ARG_WITH(assertions,
+            AC_HELP_STRING([--with-assertions], [build with C assertions enabled]),
+[
+if test "$withval" != no
+then
+  assertions='true'
+fi],
+[])
+if test "$assertions" = 'true'; then
+  AC_MSG_RESULT(yes)
+elif test "$Py_DEBUG" = 'true'; then
+  assertions='true'
+  AC_MSG_RESULT(implied by --with-pydebug)
+else
+  AC_MSG_RESULT(no)
+fi
+
 # Enable optimization flags
 AC_SUBST(DEF_MAKE_ALL_RULE)
 AC_SUBST(DEF_MAKE_RULE)
@@ -1855,7 +1876,7 @@ case "$CC" in
     ;;
 esac
 
-if test "$Py_DEBUG" = 'true'; then
+if test "$assertions" = 'true'; then
   :
 else
   OPT="-DNDEBUG $OPT"


### PR DESCRIPTION
Defaults to 'no', but as before assertions are implied by --with-pydebug..
(cherry picked from commit ddbfa2c35b298a56f0b813656745bca9cb7334f1)