### PR TITLE
[3.6] bpo-30395 _PyGILState_Reinit deadlock fix (GH-1734)

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -552,6 +552,7 @@ Eric Groo
 Daniel Andrade Groppe
 Dag Gruneau
 Filip Gruszczyński
+Andrii Grynenko
 Grzegorz Grzywacz
 Thomas Guettler
 Yuyang Guo

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -743,6 +743,10 @@ _PyGILState_Fini(void)
 void
 _PyGILState_Reinit(void)
 {
+#ifdef WITH_THREAD
+    head_mutex = NULL;
+    HEAD_INIT();
+#endif
     PyThreadState *tstate = PyGILState_GetThisThreadState();
     PyThread_delete_key(autoTLSkey);
     if ((autoTLSkey = PyThread_create_key()) == -1)


### PR DESCRIPTION
head_lock could be held by another thread when fork happened. We should
reset it to avoid deadlock.
(cherry picked from commit f82c951d1c5416f3550d544e50ff5662d3836e73)