### PR TITLE
gh-71456: Treat ::FFFF: addresses as IPv4 for ordering and contains.

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -376,8 +376,10 @@ def get_mixed_type_key(obj):
 
     """
     if isinstance(obj, _BaseNetwork):
+        obj = obj.ipv4_mapped or obj
         return obj._get_networks_key()
     elif isinstance(obj, _BaseAddress):
+        obj = obj.ipv4_mapped or obj
         return obj._get_address_key()
     return NotImplemented
 
@@ -422,6 +424,15 @@ class _IPAddressBase:
             msg = "%d (>= 2**%d) is not permitted as an IPv%d address"
             raise AddressValueError(msg % (address, self._max_prefixlen,
                                            self._version))
+
+    @property
+    def ipv4_mapped(self):
+        """Returns an IPv4 address, maybe mapped by RFC 5156 from ::ffff:
+
+        Returns:
+            An IPv4Address instance or None
+        """
+        return None
 
     def _check_packed_address(self, address, expected_len):
         address_len = len(address)
@@ -668,6 +679,8 @@ class _BaseNetwork(_IPAddressBase):
         return hash(int(self.network_address) ^ int(self.netmask))
 
     def __contains__(self, other):
+        if other._version == 6 and self._version == 4:
+            other = other.ipv4_mapped or other
         # always false if one is v4 and the other is v6.
         if self._version != other._version:
             return False
@@ -1917,6 +1930,19 @@ class IPv6Address(_BaseV6, _BaseAddress):
         self._ip = self._ip_int_from_string(addr_str)
 
     @property
+    def ipv4_mapped(self):
+        """Return the IPv4 mapped address.
+
+        Returns:
+            If the IPv6 address is a v4 mapped address, return the
+            IPv4 mapped address. Return None otherwise.
+
+        """
+        if (self._ip >> 32) != 0xFFFF:
+            return None
+        return IPv4Address(self._ip & 0xFFFFFFFF)
+
+    @property
     def packed(self):
         """The binary representation of this address."""
         return v6_int_to_packed(self._ip)
@@ -2011,19 +2037,6 @@ class IPv6Address(_BaseV6, _BaseAddress):
 
         """
         return self._ip == 1
-
-    @property
-    def ipv4_mapped(self):
-        """Return the IPv4 mapped address.
-
-        Returns:
-            If the IPv6 address is a v4 mapped address, return the
-            IPv4 mapped address. Return None otherwise.
-
-        """
-        if (self._ip >> 32) != 0xFFFF:
-            return None
-        return IPv4Address(self._ip & 0xFFFFFFFF)
 
     @property
     def teredo(self):

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -583,7 +583,10 @@ class ComparisonTests(unittest.TestCase):
     v6net = ipaddress.IPv6Network(1)
     v6intf = ipaddress.IPv6Interface(1)
 
-    v4_addresses = [v4addr, v4intf]
+    v4mapaddr = ipaddress.IPv6Address('::ffff:0:1')
+    v4mapnet = ipaddress.IPv6Address('::ffff:0:1')
+
+    v4_addresses = [v4addr, v4intf, v4mapaddr]
     v4_objects = v4_addresses + [v4net]
     v6_addresses = [v6addr, v6intf]
     v6_objects = v6_addresses + [v6net]
@@ -684,7 +687,7 @@ class ComparisonTests(unittest.TestCase):
 
     def test_mixed_type_key(self):
         # with get_mixed_type_key, you can sort addresses and network.
-        v4_ordered = [self.v4addr, self.v4net, self.v4intf]
+        v4_ordered = [self.v4addr, self.v4mapaddr, self.v4net, self.v4intf]
         v6_ordered = [self.v6addr, self.v6net, self.v6intf]
         self.assertEqual(v4_ordered,
                          sorted(self.v4_objects,


### PR DESCRIPTION
Moves the ipv4_mapped property from the IPV6 address to be generic to all classes, and has it be statically None for the other cases.

<!-- gh-issue-number: gh-71456 -->
* Issue: gh-71456
<!-- /gh-issue-number -->
