### PR TITLE
bpo-9883: writexml on a DocumentFragment acts on children

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -2,6 +2,7 @@
 
 import copy
 import pickle
+from io import StringIO
 from test.support import findfile
 import unittest
 
@@ -188,6 +189,14 @@ class MinidomTest(unittest.TestCase):
         frag.unlink()
         dom.unlink()
 
+    def testWriteXMLChildFragment(self):
+        dom, orig, c1, c2, c3, frag = self._create_fragment_test_nodes()
+        written = StringIO()
+        frag.writexml(writer=written, indent=' ', addindent='-', newl=':')
+        self.assertEquals(written.getvalue(), ' foo: bar: bat:')
+        frag.unlink()
+        dom.unlink()
+
     def testLegalChildren(self):
         dom = Document()
         elem = dom.createElement('element')
@@ -235,8 +244,10 @@ class MinidomTest(unittest.TestCase):
 
     def testUnlink(self):
         dom = parse(tstfile)
+        self.confirm(isinstance(dom, Document))
         self.assertTrue(dom.childNodes)
         dom.unlink()
+        self.confirm(isinstance(dom, Document))
         self.assertFalse(dom.childNodes)
 
     def testContext(self):

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -340,6 +340,9 @@ class DocumentFragment(Node):
     def __init__(self):
         self.childNodes = NodeList()
 
+    def writexml(self, writer, indent="", addindent="", newl=""):
+        for node in self.childNodes:
+            node.writexml(writer, indent, addindent, newl)
 
 class Attr(Node):
     __slots__=('_name', '_value', 'namespaceURI',


### PR DESCRIPTION
Adds writexml method as well as a test to make sure it works. Since there was no attribute previously, the only behavior change is if a client introspects the available attributes on this node type specifically. There seems to be no other test coverage for writexml whatsoever.

<!-- issue-number: [bpo-9883](https://bugs.python.org/issue9883) -->
https://bugs.python.org/issue9883
<!-- /issue-number -->
