### PR TITLE
[3.5] bpo-30376: Update outdated WindowObject references (GH-1630)

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -290,8 +290,8 @@ The module :mod:`curses` defines the following functions:
 
 .. function:: initscr()
 
-   Initialize the library. Return a :class:`WindowObject` which represents the
-   whole screen.
+   Initialize the library. Return a :ref:`window <curses-window-objects>` object
+   which represents the whole screen.
 
    .. note::
 
@@ -383,8 +383,8 @@ The module :mod:`curses` defines the following functions:
 .. function:: newwin(nlines, ncols)
               newwin(nlines, ncols, begin_y, begin_x)
 
-   Return a new window, whose left-upper corner is at  ``(begin_y, begin_x)``, and
-   whose height/width is  *nlines*/*ncols*.
+   Return a new :ref:`window <curses-window-objects>`, whose left-upper corner
+   is at  ``(begin_y, begin_x)``, and whose height/width is  *nlines*/*ncols*.
 
    By default, the window will extend from the  specified position to the lower
    right corner of the screen.
@@ -1679,10 +1679,10 @@ You can instantiate a :class:`Textbox` object as follows:
 .. class:: Textbox(win)
 
    Return a textbox widget object.  The *win* argument should be a curses
-   :class:`WindowObject` in which the textbox is to be contained. The edit cursor
-   of the textbox is initially located at the upper left hand corner of the
-   containing window, with coordinates ``(0, 0)``. The instance's
-   :attr:`stripspaces` flag is initially on.
+   :ref:`window <curses-window-objects>` object in which the textbox is to
+   be contained. The edit cursor of the textbox is initially located at the
+   upper left hand corner of the containing window, with coordinates ``(0, 0)``.
+   The instance's :attr:`stripspaces` flag is initially on.
 
    :class:`Textbox` objects have the following methods:
 


### PR DESCRIPTION
(cherry picked from commit 93fc20b73eea3da0b6305aaee951e5dd22d5c408)