### PR TITLE
[3.6] bpo-21056: Document return type of next method of csv reader 

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -401,8 +401,10 @@ Reader objects (:class:`DictReader` instances and objects returned by the
 
 .. method:: csvreader.__next__()
 
-   Return the next row of the reader's iterable object as a list, parsed according
-   to the current dialect.  Usually you should call this as ``next(reader)``.
+   Return the next row of the reader's iterable object as a list (if the object
+   was returned from :func:`reader`) or a dict (if it is a :class:`DictReader`
+   instance), parsed according to the current dialect.  Usually you should call
+   this as ``next(reader)``.
 
 
 Reader objects have the following public attributes:


### PR DESCRIPTION
(GH-146)

(cherry picked from commit d618c8c6d31b9b288f8a070417683974eb98e3ba)