### PR TITLE
bpo-24899: Add docs for pathlib.Path.absolute and pathlib to os.path correspondence

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -636,22 +636,6 @@ Concrete paths provide the following methods in addition to pure paths
 methods.  Many of these methods can raise an :exc:`OSError` if a system
 call fails (for example because the path doesn't exist):
 
-.. method:: Path.absolute()
-
-   Return an absolute version of this path.  This function works
-   even if the path doesn't point to anything.
-
-   No normalization is done, i.e. all ``.`` and ``..`` will be kept along.
-   Use :meth:`Path.resolve` to get the canonical path to a file.
-
-   Usage example::
-
-      >>> Path.cwd()
-      PosixPath('/dev')
-      >>> Path('null').absolute()
-      PosixPath('/dev/null')
-
-
 .. classmethod:: Path.cwd()
 
    Return a new path object representing the current directory (as returned

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1078,6 +1078,16 @@ Correspondence to tools in the os package
 If you're more familiar with :mod:`os.path` module, here's a correspondence
 table on how the same things may be accomplished with pathlib.
 
+.. note::
+   Although :func:`os.path.relpath` and :meth:`PurePath.relative_to` have some
+   overlapping use cases, :meth:`PurePath.relative_to` is more oriented towards
+   answering the question "Relative to a given parent directory, how do I reach
+   this descendant path?" whereas :func:`os.path.relpath` is implemented to
+   answer the "How do I get to path A from path B?".
+
+   If the parameter passed to :meth:`PurePath.relative_to` is not a parent
+   node of the object, :exc:`ValueError` exception is raised.
+
 ============================   ==============================
 os and os.path                 pathlib
 ============================   ==============================

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -636,6 +636,22 @@ Concrete paths provide the following methods in addition to pure paths
 methods.  Many of these methods can raise an :exc:`OSError` if a system
 call fails (for example because the path doesn't exist):
 
+.. method:: Path.absolute()
+
+   Return an absolute version of this path.  This function works
+   even if the path doesn't point to anything.
+
+   No normalization is done, i.e. all '.' and '..' will be kept along.
+   Use resolve() to get the canonical path to a file.
+
+   Usage example::
+
+      >>> Path.cwd()
+      PosixPath('/dev')
+      >>> Path('null').absolute()
+      PosixPath('/dev/null')
+
+
 .. classmethod:: Path.cwd()
 
    Return a new path object representing the current directory (as returned
@@ -1055,3 +1071,31 @@ call fails (for example because the path doesn't exist):
       'Text file contents'
 
    .. versionadded:: 3.5
+
+Correspondence to tools in the os package
+-----------------------------------------
+
+If you're more familiar with :mod:`os.path` module, here's a correspondence
+table on how the same things may be accomplished with pathlib.
+
+============================   ==============================
+os and os.path                 pathlib
+============================   ==============================
+:func:`os.path.abspath`        :func:`Path.absolute`
+:func:`os.getcwd`              :func:`Path.cwd`
+:func:`os.path.abspath`        :meth:`Path.absolute`
+:func:`os.path.exists`         :meth:`Path.exists`
+:func:`os.path.expanduser`     :meth:`Path.expanduser` and
+                               :meth:`Path.home`
+:func:`os.stat`                :meth:`Path.group`
+:func:`os.path.isdir`          :meth:`Path.is_dir`
+:func:`os.path.isfile`         :meth:`Path.is_file`
+:func:`os.path.islink`         :meth:`Path.is_symlink`
+:func:`os.stat`                :meth:`Path.owner`
+:func:`os.stat`                :meth:`Path.stat`
+:func:`os.path.isabs`          :meth:`PurePath.is_absolute`
+:func:`os.path.join`           :func:`PurePath.joinpath`
+:func:`os.path.basename`       :data:`PurePath.name`
+:func:`os.path.dirname`        :data:`PurePath.parent`
+:func:`os.path.splitext`       :data:`PurePath.suffix`
+============================   ==============================

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1072,38 +1072,32 @@ call fails (for example because the path doesn't exist):
 
    .. versionadded:: 3.5
 
-Correspondence to tools in the :mod:`os` package
-------------------------------------------------
+Correspondence to tools in the :mod:`os` module
+-----------------------------------------------
 
-If you're more familiar with :mod:`os.path` module, here's a correspondence
-table on how the same things may be accomplished with :mod:`pathlib`.
+Below is a table mapping various :mod:`os` functions to their corresponding
+:class:`PurePath`/:class:`Path` equivalent.
 
 .. note::
 
    Although :func:`os.path.relpath` and :meth:`PurePath.relative_to` have some
-   overlapping use cases, :meth:`PurePath.relative_to` is more oriented towards
-   answering the question "Relative to a given parent directory, how do I reach
-   this descendant path?" whereas :func:`os.path.relpath` is implemented to
-   answer the "How do I get to path A from path B?".
-
-   If the parameter passed to :meth:`PurePath.relative_to` is not a parent
-   node of the object, :exc:`ValueError` exception is raised.
+   overlapping use-cases, their semantics differ enough to warrant not
+   considering them equivalent.
 
 ============================   ==============================
 os and os.path                 pathlib
 ============================   ==============================
-:func:`os.path.abspath`        :func:`Path.absolute`
+:func:`os.path.abspath`        :meth:`Path.resolve`
 :func:`os.getcwd`              :func:`Path.cwd`
-:func:`os.path.abspath`        :meth:`Path.absolute`
 :func:`os.path.exists`         :meth:`Path.exists`
 :func:`os.path.expanduser`     :meth:`Path.expanduser` and
                                :meth:`Path.home`
-:func:`os.stat`                :meth:`Path.group`
 :func:`os.path.isdir`          :meth:`Path.is_dir`
 :func:`os.path.isfile`         :meth:`Path.is_file`
 :func:`os.path.islink`         :meth:`Path.is_symlink`
-:func:`os.stat`                :meth:`Path.owner`
-:func:`os.stat`                :meth:`Path.stat`
+:func:`os.stat`                :meth:`Path.stat`,
+                               :meth:`Path.owner`,
+                               :meth:`Path.group`
 :func:`os.path.isabs`          :meth:`PurePath.is_absolute`
 :func:`os.path.join`           :func:`PurePath.joinpath`
 :func:`os.path.basename`       :data:`PurePath.name`

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -641,8 +641,8 @@ call fails (for example because the path doesn't exist):
    Return an absolute version of this path.  This function works
    even if the path doesn't point to anything.
 
-   No normalization is done, i.e. all '.' and '..' will be kept along.
-   Use resolve() to get the canonical path to a file.
+   No normalization is done, i.e. all ``.`` and ``..`` will be kept along.
+   Use :meth:`Path.resolve` to get the canonical path to a file.
 
    Usage example::
 
@@ -1072,13 +1072,14 @@ call fails (for example because the path doesn't exist):
 
    .. versionadded:: 3.5
 
-Correspondence to tools in the os package
------------------------------------------
+Correspondence to tools in the :mod:`os` package
+------------------------------------------------
 
 If you're more familiar with :mod:`os.path` module, here's a correspondence
-table on how the same things may be accomplished with pathlib.
+table on how the same things may be accomplished with :mod:`pathlib`.
 
 .. note::
+
    Although :func:`os.path.relpath` and :meth:`PurePath.relative_to` have some
    overlapping use cases, :meth:`PurePath.relative_to` is more oriented towards
    answering the question "Relative to a given parent directory, how do I reach

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1748,3 +1748,4 @@ evilzero
 Dhushyanth Ramasamy
 Subhendu Ghosh
 Sanjay Sundaresan
+Jamiel Almeida

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -33,6 +33,7 @@ Fred Allen
 Jeff Allen
 Ray Allen
 Billy G. Allie
+Jamiel Almeida
 Kevin Altis
 Skyler Leigh Amador
 Joe Amenta
@@ -436,6 +437,7 @@ Tim Everett
 Paul Everitt
 David Everly
 Daniel Evers
+evilzero
 Winston Ewert
 Greg Ewing
 Martijn Faassen
@@ -523,6 +525,7 @@ Elazar (אלעזר) Gershuni
 Ben Gertzfield
 Nadim Ghaznavi
 Dinu Gherman
+Subhendu Ghosh
 Jonathan Giddy
 Johannes Gijsbers
 Michael Gilfix
@@ -1239,6 +1242,7 @@ Jérôme Radix
 Burton Radons
 Abhilash Raj
 Shorya Raj
+Dhushyanth Ramasamy
 Jeff Ramnani
 Bayard Randel
 Varpu Rantala
@@ -1502,6 +1506,7 @@ Nathan Sullivan
 Mark Summerfield
 Reuben Sumner
 Eryk Sun
+Sanjay Sundaresan
 Marek Šuppa
 Hisao Suzuki
 Kalle Svensson
@@ -1744,8 +1749,3 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
-evilzero
-Dhushyanth Ramasamy
-Subhendu Ghosh
-Sanjay Sundaresan
-Jamiel Almeida


### PR DESCRIPTION
Documentation changes for `pathlib` to have a map for people that are more familiar with `os.path`.

Briefly discussed with @brettcannon and @gpshead