### PR TITLE
Fixed a typo in the HTMLParser.feed docstrings

### DIFF
--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -102,7 +102,7 @@ class HTMLParser(_markupbase.ParserBase):
         _markupbase.ParserBase.reset(self)
 
     def feed(self, data):
-        r"""Feed data to the parser.
+        """Feed data to the parser.
 
         Call this as often as you want, with as little or as much text
         as you want (may include '\n').


### PR DESCRIPTION
The docstring started with an 'r', like a rawstring.