### PR TITLE
gh-72587: prevent Py_DEBUG builds from trying to import limited ABI modules

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-03-10-37-29.bpo-28401.RprDIg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-03-10-37-29.bpo-28401.RprDIg.rst
@@ -1,2 +1,3 @@
-Stable ABI extensions will no longer be found by the import machinery on
-debug builds of Python.  Importing them never worked, anyway.
+Debug builds will no longer to attempt to import extension modules built
+for the ABI as they were never compatible to begin with.
+Patch by Stefano Rivera.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-03-10-37-29.bpo-28401.RprDIg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-03-10-37-29.bpo-28401.RprDIg.rst
@@ -1,0 +1,2 @@
+Stable ABI extensions will no longer be found by the import machinery on
+debug builds of Python.  Importing them never worked, anyway.

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -38,7 +38,9 @@ const char *_PyImport_DynLoadFiletab[] = {
     ".dll",
 #else  /* !__CYGWIN__ */
     "." SOABI ".so",
+#ifndef Py_DEBUG
     ".abi" PYTHON_ABI_STRING ".so",
+#endif /* ! Py_DEBUG */
     ".so",
 #endif  /* __CYGWIN__ */
     NULL,


### PR DESCRIPTION
[Issue 28401](https://bugs.python.org/issue28401): Don't attempt to import the stable API extensions, they are not supported in PyDEBUG builds (which don't implement that ABI).

<!-- issue-number: bpo-28401 -->
https://bugs.python.org/issue28401
<!-- /issue-number -->


<!-- gh-issue-number: gh-72587 -->
* Issue: gh-72587
<!-- /gh-issue-number -->
