### PR TITLE
bpo-22257: Private C-API for core runtime initialization (PEP 432).

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -19,8 +19,14 @@ PyAPI_FUNC(wchar_t *) Py_GetPythonHome(void);
  */
 PyAPI_FUNC(int) Py_SetStandardStreamEncoding(const char *encoding,
                                              const char *errors);
+
+/* PEP 432 Multi-phase initialization API (Private while provisional!) */
+PyAPI_FUNC(void) _Py_InitializeCore(const _PyCoreConfig *);
+PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
+PyAPI_FUNC(int) _Py_InitializeMainInterpreter(int install_sigs);
 #endif
 
+/* Initialization and finalization */
 PyAPI_FUNC(void) Py_Initialize(void);
 PyAPI_FUNC(void) Py_InitializeEx(int);
 #ifndef Py_LIMITED_API
@@ -29,6 +35,8 @@ PyAPI_FUNC(void) _Py_InitializeEx_Private(int, int);
 PyAPI_FUNC(void) Py_Finalize(void);
 PyAPI_FUNC(int) Py_FinalizeEx(void);
 PyAPI_FUNC(int) Py_IsInitialized(void);
+
+/* Subinterpreter support */
 PyAPI_FUNC(PyThreadState *) Py_NewInterpreter(void);
 PyAPI_FUNC(void) Py_EndInterpreter(PyThreadState *);
 
@@ -85,7 +93,7 @@ PyAPI_FUNC(void) _PyImportHooks_Init(void);
 PyAPI_FUNC(int) _PyFrame_Init(void);
 PyAPI_FUNC(int) _PyFloat_Init(void);
 PyAPI_FUNC(int) PyByteArray_Init(void);
-PyAPI_FUNC(void) _Py_HashRandomization_Init(void);
+PyAPI_FUNC(void) _Py_HashRandomization_Init(_PyCoreConfig *core_config);
 #endif
 
 /* Various internal finalizers */

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -23,6 +23,16 @@ typedef struct _is PyInterpreterState;
 #else
 typedef PyObject* (*_PyFrameEvalFunction)(struct _frame *, int);
 
+
+typedef struct {
+    int ignore_environment;
+    int use_hash_seed;
+    unsigned long hash_seed;
+    int _disable_importlib; /* Needed by freeze_importlib */
+} _PyCoreConfig;
+
+#define _PyCoreConfig_INIT {0, -1, 0, 0}
+
 typedef struct _is {
 
     struct _is *next;
@@ -42,6 +52,7 @@ typedef struct _is {
     int codecs_initialized;
     int fscodec_initialized;
 
+    _PyCoreConfig core_config;
 #ifdef HAVE_DLOPEN
     int dlopenflags;
 #endif

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -389,11 +389,6 @@ read_command_line(int argc, wchar_t **argv, _Py_CommandLineDetails *cmdline)
         exit(1);
     }
 
-	// TODO: Move these to core runtime init.
-    Py_HashRandomizationFlag = 1;
-    _Py_HashRandomization_Init();
-    PySys_ResetWarnOptions();
-
     _PyOS_ResetGetOpt();
 
     while ((c = _PyOS_GetOpt(argc, argv, PROGRAM_OPTS)) != EOF) {
@@ -584,6 +579,7 @@ Py_Main(int argc, wchar_t **argv)
 #endif
     int stdin_is_interactive = 0;
     _Py_CommandLineDetails cmdline = _Py_CommandLineDetails_INIT;
+    _PyCoreConfig core_config = _PyCoreConfig_INIT;
     PyCompilerFlags cf;
     PyObject *main_importer_path = NULL;
 
@@ -602,10 +598,15 @@ Py_Main(int argc, wchar_t **argv)
             break;
         }
         if (c == 'E' || c == 'I') {
-            Py_IgnoreEnvironmentFlag++;
+            core_config.ignore_environment++;
             break;
         }
     }
+
+    /* Initialize the core language runtime */
+    Py_IgnoreEnvironmentFlag = core_config.ignore_environment;
+    core_config._disable_importlib = 0;
+    _Py_InitializeCore(&core_config);
 
     /* Reprocess the command line with the language runtime available */
     if (read_command_line(argc, argv, &cmdline)) {
@@ -680,6 +681,7 @@ Py_Main(int argc, wchar_t **argv)
         for (i = 0; i < PyList_GET_SIZE(cmdline.warning_options); i++) {
             PySys_AddWarnOptionUnicode(PyList_GET_ITEM(cmdline.warning_options, i));
         }
+        Py_DECREF(cmdline.warning_options);
     }
 
     stdin_is_interactive = Py_FdIsInteractive(stdin, (char *)0);
@@ -767,9 +769,10 @@ Py_Main(int argc, wchar_t **argv)
 #else
     Py_SetProgramName(argv[0]);
 #endif
-    Py_Initialize();
-    Py_XDECREF(cmdline.warning_options);
+    if (_Py_InitializeMainInterpreter(1))
+        Py_FatalError("Py_Main: Py_InitializeMainInterpreter failed");
 
+    /* TODO: Move this to _PyRun_PrepareMain */
     if (!Py_QuietFlag && (Py_VerboseFlag ||
                         (cmdline.command == NULL && cmdline.filename == NULL &&
                          cmdline.module == NULL && stdin_is_interactive))) {
@@ -779,6 +782,7 @@ Py_Main(int argc, wchar_t **argv)
             fprintf(stderr, "%s\n", COPYRIGHT);
     }
 
+    /* TODO: Move this to _Py_InitializeMainInterpreter */
     if (cmdline.command != NULL) {
         /* Backup _PyOS_optind and force sys.argv[0] = '-c' */
         _PyOS_optind--;

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -380,14 +380,6 @@ read_command_line(int argc, wchar_t **argv, _Py_CommandLineDetails *cmdline)
     wchar_t *command = NULL;
     wchar_t *module = NULL;
     int c;
-    char *opt;
-
-    opt = Py_GETENV("PYTHONMALLOC");
-    if (_PyMem_SetupAllocators(opt) < 0) {
-        fprintf(stderr,
-                "Error in PYTHONMALLOC: unknown allocator \"%s\"!\n", opt);
-        exit(1);
-    }
 
     _PyOS_ResetGetOpt();
 
@@ -601,6 +593,13 @@ Py_Main(int argc, wchar_t **argv)
             core_config.ignore_environment++;
             break;
         }
+    }
+
+    char *pymalloc = Py_GETENV("PYTHONMALLOC");
+    if (_PyMem_SetupAllocators(pymalloc) < 0) {
+        fprintf(stderr,
+            "Error in PYTHONMALLOC: unknown allocator \"%s\"!\n", pymalloc);
+        exit(1);
     }
 
     /* Initialize the core language runtime */

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -599,11 +599,11 @@ init_hash_secret(int use_hash_seed,
 }
 
 void
-_Py_HashRandomization_Init(void)
+_Py_HashRandomization_Init(_PyCoreConfig *core_config)
 {
     char *seed_text;
-    int use_hash_seed = -1;
-    unsigned long hash_seed;
+    int use_hash_seed = core_config->use_hash_seed;
+    unsigned long hash_seed = core_config->hash_seed;
 
     if (use_hash_seed < 0) {
         seed_text = Py_GETENV("PYTHONHASHSEED");
@@ -611,6 +611,8 @@ _Py_HashRandomization_Init(void)
             Py_FatalError("PYTHONHASHSEED must be \"random\" or an integer "
                           "in range [0; 4294967295]");
         }
+        core_config->use_hash_seed = use_hash_seed;
+        core_config->hash_seed = hash_seed;
     }
     init_hash_secret(use_hash_seed, hash_seed);
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -525,7 +525,7 @@ _Py_InitializeMainInterpreter(int install_sigs)
     if (!tstate)
         Py_FatalError("Py_Initialize: failed to read thread state");
     interp = tstate->interp;
-    if (!tstate)
+    if (!interp)
         Py_FatalError("Py_Initialize: failed to get interpreter");
 
     /* Now finish configuring the main interpreter */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -436,7 +436,11 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
 
 #ifdef WITH_THREAD
     /* We can't call _PyEval_FiniThreads() in Py_FinalizeEx because
+       destroying the GIL might fail when it is being referenced from
+       another running thread (see issue #9901).
+       Instead we destroy the previously created GIL here, which ensures
        that we can call Py_Initialize / Py_FinalizeEx multiple times. */
+    _PyEval_FiniThreads();
     /* Auto-thread-state API */
     _PyGILState_Init(interp, tstate);
 #endif /* WITH_THREAD */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -360,9 +360,6 @@ initexternalimport(PyInterpreterState *interp)
  * Py_ReadConfig and Py_EndInitialization
  */
 
-/* #define _INIT_DEBUG_PRINT(msg) printf(msg) */
-#define _INIT_DEBUG_PRINT(msg)
-
 void _Py_InitializeCore(const _PyCoreConfig *config)
 {
     PyInterpreterState *interp;
@@ -420,27 +417,23 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
         Py_LegacyWindowsStdioFlag = add_flag(Py_LegacyWindowsStdioFlag, p);
 #endif
 
-    _INIT_DEBUG_PRINT("INITIALISING HASH RANDOMISATION\n");
     _Py_HashRandomization_Init(&core_config);
     if (!core_config.use_hash_seed || core_config.hash_seed) {
         /* Random or non-zero hash seed */
         Py_HashRandomizationFlag = 1;
     }
 
-    _INIT_DEBUG_PRINT("MAKING FIRST INTERPRETER\n");
     _PyInterpreterState_Init();
     interp = PyInterpreterState_New();
     if (interp == NULL)
         Py_FatalError("Py_InitializeCore: can't make main interpreter");
     interp->core_config = core_config;
 
-    _INIT_DEBUG_PRINT("MAKING FIRST THREAD STATE\n");
     tstate = PyThreadState_New(interp);
     if (tstate == NULL)
         Py_FatalError("Py_InitializeCore: can't make first thread");
     (void) PyThreadState_Swap(tstate);
 
-    _INIT_DEBUG_PRINT("INITIALISING GIL STATE API\n");
 #ifdef WITH_THREAD
     /* We can't call _PyEval_FiniThreads() in Py_FinalizeEx because
        that we can call Py_Initialize / Py_FinalizeEx multiple times. */
@@ -448,7 +441,6 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
     _PyGILState_Init(interp, tstate);
 #endif /* WITH_THREAD */
 
-    _INIT_DEBUG_PRINT("PREPARING BUILTIN TYPES\n");
     _Py_ReadyTypes();
 
     if (!_PyFrame_Init())
@@ -463,21 +455,17 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
     if (!_PyFloat_Init())
         Py_FatalError("Py_InitializeCore: can't init float");
 
-    _INIT_DEBUG_PRINT("CREATING MODULES CACHE\n");
     interp->modules = PyDict_New();
     if (interp->modules == NULL)
         Py_FatalError("Py_InitializeCore: can't make modules dictionary");
 
-    _INIT_DEBUG_PRINT("INITIALISING UNICODE SUPPORT\n");
     /* Init Unicode implementation; relies on the codec registry */
     if (_PyUnicode_Init() < 0)
         Py_FatalError("Py_InitializeCore: can't initialize unicode");
 
-    _INIT_DEBUG_PRINT("INITIALISING STRUCTSEQ\n");
     if (_PyStructSequence_Init() < 0)
         Py_FatalError("Py_InitializeCore: can't initialize structseq");
 
-    _INIT_DEBUG_PRINT("INITIALISING BUILTINS MODULE\n");
     bimod = _PyBuiltin_Init();
     if (bimod == NULL)
         Py_FatalError("Py_InitializeCore: can't initialize builtins modules");
@@ -487,26 +475,20 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
         Py_FatalError("Py_InitializeCore: can't initialize builtins dict");
     Py_INCREF(interp->builtins);
 
-    _INIT_DEBUG_PRINT("INITIALISING BUILTIN EXCEPTIONS\n");
     /* initialize builtin exceptions */
     _PyExc_Init(bimod);
 
-    _INIT_DEBUG_PRINT("CREATING SYS MODULE\n");
     sysmod = _PySys_BeginInit();
     if (sysmod == NULL)
         Py_FatalError("Py_InitializeCore: can't initialize sys");
-    _INIT_DEBUG_PRINT("CACHING REFERENCE TO SYS NAMESPACE\n");
     interp->sysdict = PyModule_GetDict(sysmod);
     if (interp->sysdict == NULL)
         Py_FatalError("Py_InitializeCore: can't initialize sys dict");
     Py_INCREF(interp->sysdict);
-    _INIT_DEBUG_PRINT("FIX UP SYS MODULE IMPORT METADATA\n");
     _PyImport_FixupBuiltin(sysmod, "sys");
-    _INIT_DEBUG_PRINT("PUBLISHING REFERENCE TO MODULES CACHE\n");
     PyDict_SetItemString(interp->sysdict, "modules",
                          interp->modules);
 
-    _INIT_DEBUG_PRINT("INITIALISING PRELIMINARY STDERR\n");
     /* Set up a preliminary stderr printer until we have enough
        infrastructure for the io module in place. */
     pstderr = PyFile_NewStdPrinter(fileno(stderr));
@@ -516,17 +498,13 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
     PySys_SetObject("__stderr__", pstderr);
     Py_DECREF(pstderr);
 
-    _INIT_DEBUG_PRINT("INITIALISING CORE IMPORT SYSTEM\n");
     _PyImport_Init();
 
-    _INIT_DEBUG_PRINT("INITIALISING IMPORT HOOK SYSTEM\n");
     _PyImportHooks_Init();
 
-    _INIT_DEBUG_PRINT("INITIALISING WARNINGS MODULE\n");
     /* Initialize _warnings. */
     _PyWarnings_Init();
 
-    _INIT_DEBUG_PRINT("INITIALISING BUILTIN AND FROZEN IMPORTS\n");
     /* This call sets up builtin and frozen import support */
     if (!interp->core_config._disable_importlib) {
         initimport(interp, sysmod);
@@ -623,7 +601,6 @@ _Py_InitializeEx_Private(int install_sigs, int install_importlib)
     _Py_InitializeMainInterpreter(install_sigs);
 }
 
-#undef _INIT_DEBUG_PRINT
 
 void
 Py_InitializeEx(int install_sigs)


### PR DESCRIPTION
(Patch by Nick Coghlan / @ncoghlan)

Mostly this adds _PyCoreConfig/_Py_InitializeCore() and reorganizes interpreter initialization code around them.  The changes align with PEP 432.  The new functions are introduced here as "private" C-API while the PEP is discussed. Regardless of the status of the PEP, the changes here are an improvement to interpreter startup. As such we are making the changes now, but keeping the C-API private.