### PR TITLE
bpo-30444: Added ability to set pager module's see more text

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1441,9 +1441,11 @@ class _PlainTextDoc(TextDoc):
 
 # --------------------------------------------------------- user interfaces
 
-def pager(text):
+def pager(text, more_text = '-- more --'):
     """The first time this is called, determine what kind of pager to use."""
     global pager
+    global pager_more_text
+    pager_more_text = more_text
     pager = getpager()
     pager(text)
 
@@ -1527,6 +1529,7 @@ def _escape_stdout(text):
 def ttypager(text):
     """Page through text on a text terminal."""
     lines = plain(_escape_stdout(text)).split('\n')
+    global pager_more_text
     try:
         import tty
         fd = sys.stdin.fileno()
@@ -1547,7 +1550,7 @@ def ttypager(text):
         r = inc = h - 1
         sys.stdout.write('\n'.join(lines[:inc]) + '\n')
         while lines[r:]:
-            sys.stdout.write('-- more --')
+            sys.stdout.write(pager_more_text)
             sys.stdout.flush()
             c = getchar()
 


### PR DESCRIPTION
As of now, their is no way to change the text `-- more --` that is displayed while using pager module. This PR will introduce this feature to the pager module so that we can use pager module, more effectively in our own applications for piping the text.

### Old usage
```python
pager("text to pipe")
```
### New usage
```python
pager("text to pipe", "text to display in the see more section")
```

I am new to python project. Please guide me if i need to make any changes regarding this PR.

Issue: https://bugs.python.org/issue30444