### PR TITLE
 bpo-30445 test was failing due to 'in comparison' being appended to the Recursi…

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -339,12 +339,12 @@ class TracebackFormatTests(unittest.TestCase):
 
         expected = result_f.splitlines()
         actual = stderr_f.getvalue().splitlines()
-
         # Check the output text matches expectations
         # 2nd last line contains the repetition count
         self.assertEqual(actual[:-2], expected[:-2])
         self.assertRegex(actual[-2], expected[-2])
-        self.assertEqual(actual[-1], expected[-1])
+        # last line can have additional text appended
+        self.assertIn(expected[-1], actual[-1])
 
         # Check the recursion count is roughly as expected
         rec_limit = sys.getrecursionlimit()

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -339,6 +339,7 @@ class TracebackFormatTests(unittest.TestCase):
 
         expected = result_f.splitlines()
         actual = stderr_f.getvalue().splitlines()
+
         # Check the output text matches expectations
         # 2nd last line contains the repetition count
         self.assertEqual(actual[:-2], expected[:-2])


### PR DESCRIPTION
…onError. This is allowed behavior, so changed test to allow appending