### PR TITLE
bpo-30457: Add new pending method for asyncio lock primitives

### DIFF
--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -155,6 +155,10 @@ class Lock(_ContextManagerMixin):
             extra = '{},waiters:{}'.format(extra, len(self._waiters))
         return '<{} [{}]>'.format(res[1:-1], extra)
 
+    def pending(self):
+        """Return the num of waiters pending to be woken up"""
+        return len(self._waiters)
+
     def locked(self):
         """Return True if lock is acquired."""
         return self._locked
@@ -224,6 +228,10 @@ class Event:
         if self._waiters:
             extra = '{},waiters:{}'.format(extra, len(self._waiters))
         return '<{} [{}]>'.format(res[1:-1], extra)
+
+    def pending(self):
+        """Return the num of waiters pending to be woken up"""
+        return len(self._waiters)
 
     def is_set(self):
         """Return True if and only if the internal flag is true."""
@@ -302,6 +310,10 @@ class Condition(_ContextManagerMixin):
         if self._waiters:
             extra = '{},waiters:{}'.format(extra, len(self._waiters))
         return '<{} [{}]>'.format(res[1:-1], extra)
+
+    def pending(self):
+        """Return the num of waiters pending to be woken up"""
+        return len(self._waiters)
 
     @coroutine
     def wait(self):
@@ -423,6 +435,10 @@ class Semaphore(_ContextManagerMixin):
             if not waiter.done():
                 waiter.set_result(None)
                 return
+
+    def pending(self):
+        """Return the num of waiters pending to be woken up"""
+        return len(self._waiters)
 
     def locked(self):
         """Returns True if semaphore can not be acquired immediately."""


### PR DESCRIPTION
Currently, there is no way to access to the number of waiters pending to be woken up. This information can be useful for those environments which create and delete asyncio primitives instances depending if there are waiters still to be processed.

The following example shows an example of the DogPile solution that uses the Event lock mechanism. Each time that there is a miss in the cache, a new Event is created and it will be removed by the last waiter.

```
import asyncio

cache = {}
events = {}

async def get(process, key):
    try:
        return cache[key]
    except KeyError:
        try:
            await events[key].wait()
            if len(events[key]._waiters) == 0:
                events.pop(key)
            return cache[key]
        except KeyError:
            events[key] = asyncio.Event()
            # simulates some IO to get the Key
            await asyncio.sleep(0.1)
            cache[key] = "some random value"
            events[key].set()


async def main():
    tasks = [get(i, "foo") for i in range(1, 10)]
    await asyncio.gather(*tasks)

asyncio.get_event_loop().run_until_complete(main())
```

This PR make public and accessible the number of Python via the `pending()` method.