### PR TITLE
[3.5] bpo-30394: Fix a socket leak in smtplib.SMTP.__init__()

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -250,6 +250,7 @@ class SMTP:
         if host:
             (code, msg) = self.connect(host, port)
             if code != 220:
+                self.close()
                 raise SMTPConnectError(code, msg)
         if local_hostname is not None:
             self.local_hostname = local_hostname


### PR DESCRIPTION
backport of #1700 for 3.5