### PR TITLE
[3.5] bpo-30160: Clarify intended usage of wfile (gh-1300)

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -105,7 +105,8 @@ of which this module provides three different variants:
 
       Contains the output stream for writing a response back to the
       client. Proper adherence to the HTTP protocol must be used when writing to
-      this stream.
+      this stream in order to achieve successful interoperation with HTTP
+      clients.
 
    :class:`BaseHTTPRequestHandler` has the following attributes:
 


### PR DESCRIPTION
The library does not enforce compliance with the HTTP protocol,
so violations are not technically disallowed. Extend the stream's
description to avoid suggesting that intentional protocol violations are
not supported.
(cherry picked from commit a083c8e)