### PR TITLE
bpo-30464: Fix comment in gammavariate

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -539,7 +539,7 @@ class Random(_random.Random):
                     return x * beta
 
         elif alpha == 1.0:
-            # expovariate(1)
+            # expovariate(1/beta)
             u = random()
             while u <= 1e-7:
                 u = random()


### PR DESCRIPTION
A comment in the gammavariate function in random.py make it seems that when alpha is 1 it's equivalent on calling expovariate(1),  but it should be expovariate(1/beta)

also discussed in:
https://mail.python.org/pipermail/python-bugs-list/2001-January/003752.html

where Ivan Frohne says:

Now it happens that a gamma-distributed random variable with parameters A =
1 and B has the (much simpler) exponential distribution with density
function

    g(x; 1, B) = exp(-x/B) / B.
