### PR TITLE
bpo-30439: Add a basic high-level interpreters module.

### DIFF
--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -38,8 +38,6 @@ It defines the following functions:
 
    Finalize and destroy the identified interpreter.
 
-.. XXX must not be running?
-
 
 .. function:: run_string(id, command)
 
@@ -54,8 +52,16 @@ It defines the following functions:
    how :func:`exec` works.  This aligns with how interpreters are not
    inherently threaded.
 
-.. XXX must not be running already?
 .. XXX sys.exit() (and SystemExit) is swallowed?
+
+
+.. function:: run_string_unrestricted(id, command, ns=None)
+
+   Like :c:func:`run_string` but returns the dict in which the code
+   was executed.  It also supports providing a namespace that gets
+   merged into the execution namespace before execution.  Note that
+   this allows objects to leak between interpreters, which may not
+   be desirable.
 
 
 **Caveats:**

--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -28,7 +28,18 @@ support multiple interpreters.
 It defines the following functions:
 
 
-.. XXX TBD
+.. function:: create()
+
+   Initialize a new Python interpreter and return its identifier.  The
+   interpreter will be created in the current thread and will remain
+   idle until something is run in it.
+
+
+.. function:: destroy(id)
+
+   Finalize and destroy the identified interpreter.
+
+.. XXX must not be running?
 
 
 **Caveats:**

--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -41,6 +41,11 @@ It defines the following functions:
    Return the ID of the currently running interpreter.
 
 
+.. function:: get_main()
+
+   Return the ID of the main interpreter.
+
+
 .. function:: is_running(id)
 
    Return whether or not the identified interpreter is currently

--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -27,7 +27,6 @@ support multiple interpreters.
 
 It defines the following functions:
 
-
 .. function:: create()
 
    Initialize a new Python interpreter and return its identifier.  The
@@ -40,6 +39,23 @@ It defines the following functions:
    Finalize and destroy the identified interpreter.
 
 .. XXX must not be running?
+
+
+.. function:: run_string(id, command)
+
+   A wrapper around :c:func:`PyRun_SimpleString` which runs the provided
+   Python program using the identified interpreter.  Providing an
+   invalid or unknown ID results in a RuntimeError, likewise if the main
+   interpreter or any other running interpreter is used.
+
+   Any value returned from the code is thrown away, similar to what
+   threads do.  If the code results in an exception then that exception
+   is raised in the thread in which run_string() was called, similar to
+   how :func:`exec` works.  This aligns with how interpreters are not
+   inherently threaded.
+
+.. XXX must not be running already?
+.. XXX sys.exit() (and SystemExit) is swallowed?
 
 
 **Caveats:**

--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -1,0 +1,37 @@
+:mod:`_interpreters` --- Low-level interpreters API
+===================================================
+
+.. module:: _interpreters
+   :synopsis: Low-level interpreters API.
+
+.. versionadded:: 3,7
+
+  :ref:`_sub-interpreter-support`
+
+threading
+
+--------------
+
+This module provides low-level primitives for working with multiple
+Python interpreters in the same process.
+
+.. XXX The :mod:`interpreters` module provides an easier to use and
+   higher-level API built on top of this module.
+
+This module is optional.  It is provided by Python implementations which
+support multiple interpreters.
+
+.. XXX For systems lacking the :mod:`_interpreters` module, the
+   :mod:`_dummy_interpreters` module is available.  It duplicates this
+   module's interface and can be used as a drop-in replacement.
+
+It defines the following functions:
+
+
+.. XXX TBD
+
+
+**Caveats:**
+
+* ...
+

--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -10,11 +10,9 @@
 
 This module provides low-level primitives for working with multiple
 Python interpreters in the same runtime in the current process.
-.. XXX The :mod:`interpreters` module provides an easier to use and
-   higher-level API built on top of this module.
 
 More information about (sub)interpreters is found at
-:ref:`_sub-interpreter-support`, including what data is shared between
+:ref:`sub-interpreter-support`, including what data is shared between
 interpreters and what is unique.  Note particularly that interpreters
 aren't inherently threaded, even though they track and manage Python
 threads.  To run code in an interpreter in a different OS thread, call
@@ -30,9 +28,6 @@ For example::
 
 This module is optional.  It is provided by Python implementations which
 support multiple interpreters.
-.. XXX For systems lacking the :mod:`_interpreters` module, the
-   :mod:`_dummy_interpreters` module is available.  It duplicates this
-   module's interface and can be used as a drop-in replacement.
 
 It defines the following functions:
 

--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -6,21 +6,30 @@
 
 .. versionadded:: 3,7
 
-  :ref:`_sub-interpreter-support`
-
-threading
-
 --------------
 
 This module provides low-level primitives for working with multiple
-Python interpreters in the same process.
-
+Python interpreters in the same runtime in the current process.
 .. XXX The :mod:`interpreters` module provides an easier to use and
    higher-level API built on top of this module.
 
+More information about (sub)interpreters is found at
+:ref:`_sub-interpreter-support`, including what data is shared between
+interpreters and what is unique.  Note particularly that interpreters
+aren't inherently threaded, even though they track and manage Python
+threads.  To run code in an interpreter in a different OS thread, call
+:func:`run_string` in a function that you run in a new Python thread.
+For example::
+
+   id = _interpreters.create()
+   def f():
+       _interpreters.run_string(id, 'print("in a thread")')
+
+   t = threading.Thread(target=f)
+   t.start()
+
 This module is optional.  It is provided by Python implementations which
 support multiple interpreters.
-
 .. XXX For systems lacking the :mod:`_interpreters` module, the
    :mod:`_dummy_interpreters` module is available.  It duplicates this
    module's interface and can be used as a drop-in replacement.
@@ -42,9 +51,10 @@ It defines the following functions:
 .. function:: run_string(id, command)
 
    A wrapper around :c:func:`PyRun_SimpleString` which runs the provided
-   Python program using the identified interpreter.  Providing an
-   invalid or unknown ID results in a RuntimeError, likewise if the main
-   interpreter or any other running interpreter is used.
+   Python program in the main thread of the identified interpreter.
+   Providing an invalid or unknown ID results in a RuntimeError,
+   likewise if the main interpreter or any other running interpreter
+   is used.
 
    Any value returned from the code is thrown away, similar to what
    threads do.  If the code results in an exception then that exception
@@ -62,9 +72,3 @@ It defines the following functions:
    merged into the execution namespace before execution.  Note that
    this allows objects to leak between interpreters, which may not
    be desirable.
-
-
-**Caveats:**
-
-* ...
-

--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -50,9 +50,9 @@ It defines the following functions:
    threads do.  If the code results in an exception then that exception
    is raised in the thread in which run_string() was called, similar to
    how :func:`exec` works.  This aligns with how interpreters are not
-   inherently threaded.
-
-.. XXX sys.exit() (and SystemExit) is swallowed?
+   inherently threaded.  Note that SystemExit (as raised by sys.exit())
+   is not treated any differently and will result in the process ending
+   if not caught explicitly.
 
 
 .. function:: run_string_unrestricted(id, command, ns=None)

--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -41,6 +41,12 @@ It defines the following functions:
    Return the ID of the currently running interpreter.
 
 
+.. function:: is_running(id)
+
+   Return whether or not the identified interpreter is currently
+   running any code.
+
+
 .. function:: create()
 
    Initialize a new Python interpreter and return its identifier.  The

--- a/Doc/library/_interpreters.rst
+++ b/Doc/library/_interpreters.rst
@@ -31,6 +31,16 @@ support multiple interpreters.
 
 It defines the following functions:
 
+.. function:: enumerate()
+
+   Return a list of the IDs of every existing interpreter.
+
+
+.. function:: get_current()
+
+   Return the ID of the currently running interpreter.
+
+
 .. function:: create()
 
    Initialize a new Python interpreter and return its identifier.  The

--- a/Doc/library/concurrency.rst
+++ b/Doc/library/concurrency.rst
@@ -29,3 +29,4 @@ The following are support modules for some of the above services:
    dummy_threading.rst
    _thread.rst
    _dummy_thread.rst
+   _interpreters.rst

--- a/Doc/library/interpreters.rst
+++ b/Doc/library/interpreters.rst
@@ -1,0 +1,64 @@
+:mod:`interpreters` --- high-level interpreters API
+===================================================
+
+.. module:: interpreters
+   :synopsis: High-level interpreters API.
+
+**Source code:** :source:`Lib/interpreters.py`
+
+.. versionadded:: 3,7
+
+--------------
+
+This module provides high-level interfaces for interacting with
+the Python interpreters.  It is built on top of the lower- level
+:mod:`_interpreters` module.
+
+.. XXX Summarize :ref:`_sub-interpreter-support` here.
+
+This module defines the following functions:
+
+.. function:: enumerate()
+
+   Return a list of all existing interpreters.
+
+
+.. function:: get_current()
+
+   Return the currently running interpreter.
+
+
+.. function:: get_main()
+
+   Return the main interpreter.
+
+
+.. function:: create()
+
+   Initialize a new Python interpreter and return it.  The
+   interpreter will be created in the current thread and will remain
+   idle until something is run in it.
+
+
+This module also defines the following class:
+
+.. class:: Interpreter(id)
+
+   ``id`` is the interpreter's ID.
+
+   .. property:: id
+
+      The interpreter's ID.
+
+   .. method:: is_running()
+
+      Return whether or not the interpreter is currently running.
+
+   .. method:: destroy()
+
+      Finalize and destroy the interpreter.
+
+   .. method:: run(code)
+
+      Run the provided Python code in the interpreter, in the current
+      OS thread.  Supported code: source text.

--- a/Lib/interpreters.py
+++ b/Lib/interpreters.py
@@ -1,0 +1,79 @@
+"""Interpreters module providing a high-level API to Python interpreters."""
+
+import _interpreters
+
+
+__all__ = ['enumerate', 'current', 'main', 'create', 'Interpreter']
+
+
+def enumerate():
+    """Return a list of all existing interpreters."""
+    return [Interpreter(id)
+            for id in _interpreters.enumerate()]
+
+
+def current():
+    """Return the currently running interpreter."""
+    id = _interpreters.get_current()
+    return Interpreter(id)
+
+
+def main():
+    """Return the main interpreter."""
+    id = _interpreters.get_main()
+    return Interpreter(id)
+
+
+def create():
+    """Return a new Interpreter.
+
+    The interpreter is created in the current OS thread.  It will remain
+    idle until its run() method is called.
+    """
+    id = _interpreters.create()
+    return Interpreter(id)
+
+
+class Interpreter:
+    """A single Python interpreter in the current runtime."""
+
+    def __init__(self, id):
+        self._id = id
+
+    def __repr__(self):
+        return '{}(id={!r})'.format(type(self).__name__, self._id)
+
+    def __eq__(self, other):
+        try:
+            other_id = other.id
+        except AttributeError:
+            return False
+        return self._id == other_id
+
+    @property
+    def id(self):
+        """The interpreter's ID."""
+        return self._id
+
+    def is_running(self):
+        """Return whether or not the interpreter is currently running."""
+        return _interpreters.is_running(self._id)
+
+    def destroy(self):
+        """Finalize and destroy the interpreter.
+        
+        After calling destroy(), all operations on this interpreter
+        will fail.
+        """
+        _interpreters.destroy(self._id)
+
+    def run(self, code):
+        """Run the provided Python code in this interpreter.
+
+        If the code is a string then it will be run as it would by
+        calling exec().  Other kinds of code are not supported.
+        """
+        if isinstance(code, str):
+            _interpreters.run_string(self._id, code)
+        else:
+            raise NotImplementedError

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -357,6 +357,9 @@ class RunStringTests(TestBase):
                 with open(filename, 'w') as out:
                     out.write('{}')
                 os.write(w, b'done!')
+
+                # Kill the unittest runner in the child process.
+                os._exit(1)
             else:
                 import select
                 try:
@@ -365,7 +368,6 @@ class RunStringTests(TestBase):
                     os.close(r)
                     os.close(w)
             """).format(filename, expected)
-        # XXX Kill the child process in a unittest-friendly way.
         interpreters.run_string(self.id, script)
         self.assert_file_contains(expected)
 

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -111,6 +111,16 @@ class GetCurrentTests(TestBase):
         self.assertEqual(id2, id1)
 
 
+class GetMainTests(TestBase):
+
+    def test_main(self):
+        expected, = interpreters.enumerate()
+        main = interpreters.get_main()
+
+        self.assertEqual(main, 0)
+        self.assertEqual(main, expected)
+
+
 class IsRunningTests(TestBase):
 
     def test_main_running(self):

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -111,6 +111,36 @@ class GetCurrentTests(TestBase):
         self.assertEqual(id2, id1)
 
 
+class IsRunningTests(TestBase):
+
+    def test_main_running(self):
+        main, = interpreters.enumerate()
+        sub = interpreters.create()
+        main_running = interpreters.is_running(main)
+        sub_running = interpreters.is_running(sub)
+
+        self.assertTrue(main_running)
+        self.assertFalse(sub_running)
+
+    def test_sub_running(self):
+        main, = interpreters.enumerate()
+        sub1 = interpreters.create()
+        sub2 = interpreters.create()
+        ns = interpreters.run_string_unrestricted(sub1, dedent(f"""
+            import _interpreters
+            main = _interpreters.is_running({main})
+            sub1 = _interpreters.is_running({sub1})
+            sub2 = _interpreters.is_running({sub2})
+            """))
+        main_running = ns['main']
+        sub1_running = ns['sub1']
+        sub2_running = ns['sub2']
+
+        self.assertTrue(main_running)
+        self.assertTrue(sub1_running)
+        self.assertFalse(sub2_running)
+
+
 class CreateTests(TestBase):
 
     def test_in_main(self):

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -1,0 +1,11 @@
+import unittest
+from test import support
+interpreters = support.import_module('_interpreters')
+
+
+class InterpretersTests(unittest.TestCase):
+    pass
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -1,10 +1,165 @@
+import threading
 import unittest
+
 from test import support
 interpreters = support.import_module('_interpreters')
 
 
 class InterpretersTests(unittest.TestCase):
-    pass
+
+    def setUp(self):
+        self.ids = []
+        self.lock = threading.Lock()
+
+    def tearDown(self):
+        for id in self.ids:
+            try:
+                interpreters.destroy(id)
+            except RuntimeError:
+                pass  # already destroyed
+
+    def _create(self):
+        id = interpreters.create()
+        self.ids.append(id)
+        return id
+
+    def test_create_in_main(self):
+        id = interpreters.create()
+        self.ids.append(id)
+
+        self.assertIn(id, interpreters._enumerate())
+
+    def test_create_unique_id(self):
+        seen = set()
+        for _ in range(100):
+            id = self._create()
+            interpreters.destroy(id)
+            seen.add(id)
+
+        self.assertEqual(len(seen), 100)
+
+    def test_create_in_thread(self):
+        id = None
+        def f():
+            nonlocal id
+            id = interpreters.create()
+            self.ids.append(id)
+            self.lock.acquire()
+            self.lock.release()
+
+        t = threading.Thread(target=f)
+        with self.lock:
+            t.start()
+        t.join()
+        self.assertIn(id, interpreters._enumerate())
+
+    @unittest.skip('waiting for run_string()')
+    def test_create_in_subinterpreter(self):
+        raise NotImplementedError
+
+    @unittest.skip('waiting for run_string()')
+    def test_create_in_threaded_subinterpreter(self):
+        raise NotImplementedError
+
+    def test_create_after_destroy_all(self):
+        before = set(interpreters._enumerate())
+        # Create 3 subinterpreters.
+        ids = []
+        for _ in range(3):
+            id = interpreters.create()
+            ids.append(id)
+        # Now destroy them.
+        for id in ids:
+            interpreters.destroy(id)
+        # Finally, create another.
+        id = interpreters.create()
+        self.ids.append(id)
+        self.assertEqual(set(interpreters._enumerate()), before | {id})
+
+    def test_create_after_destroy_some(self):
+        before = set(interpreters._enumerate())
+        # Create 3 subinterpreters.
+        id1 = interpreters.create()
+        id2 = interpreters.create()
+        self.ids.append(id2)
+        id3 = interpreters.create()
+        # Now destroy 2 of them.
+        interpreters.destroy(id1)
+        interpreters.destroy(id3)
+        # Finally, create another.
+        id = interpreters.create()
+        self.ids.append(id)
+        self.assertEqual(set(interpreters._enumerate()), before | {id, id2})
+
+    def test_destroy_one(self):
+        id1 = self._create()
+        id2 = self._create()
+        id3 = self._create()
+        self.assertIn(id2, interpreters._enumerate())
+        interpreters.destroy(id2)
+        self.assertNotIn(id2, interpreters._enumerate())
+        self.assertIn(id1, interpreters._enumerate())
+        self.assertIn(id3, interpreters._enumerate())
+
+    def test_destroy_all(self):
+        before = set(interpreters._enumerate())
+        ids = set()
+        for _ in range(3):
+            id = self._create()
+            ids.add(id)
+        self.assertEqual(set(interpreters._enumerate()), before | ids)
+        for id in ids:
+            interpreters.destroy(id)
+        self.assertEqual(set(interpreters._enumerate()), before)
+
+    def test_destroy_main(self):
+        main, = interpreters._enumerate()
+        with self.assertRaises(RuntimeError):
+            interpreters.destroy(main)
+
+        def f():
+            with self.assertRaises(RuntimeError):
+                interpreters.destroy(main)
+
+        t = threading.Thread(target=f)
+        t.start()
+        t.join()
+
+    def test_destroy_already_destroyed(self):
+        id = interpreters.create()
+        interpreters.destroy(id)
+        with self.assertRaises(RuntimeError):
+            interpreters.destroy(id)
+
+    def test_destroy_does_not_exist(self):
+        with self.assertRaises(RuntimeError):
+            interpreters.destroy(1_000_000)
+
+    def test_destroy_bad_id(self):
+        with self.assertRaises(RuntimeError):
+            interpreters.destroy(-1)
+
+    @unittest.skip('waiting for run_string()')
+    def test_destroy_from_current(self):
+        raise NotImplementedError
+
+    @unittest.skip('waiting for run_string()')
+    def test_destroy_from_sibling(self):
+        raise NotImplementedError
+
+    def test_destroy_from_other_thread(self):
+        id = interpreters.create()
+        self.ids.append(id)
+        def f():
+            interpreters.destroy(id)
+
+        t = threading.Thread(target=f)
+        t.start()
+        t.join()
+
+    @unittest.skip('waiting for run_string()')
+    def test_destroy_still_running(self):
+        raise NotImplementedError
 
 
 if __name__ == "__main__":

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -300,7 +300,7 @@ class RunStringTests(TestBase):
     def assert_file_contains(self, expected, filename=None):
         if filename is None:
             filename = self.filename
-        self.assertIsNot(filename, None)
+        self.assertIsNotNone(filename)
         with open(filename) as out:
             content = out.read()
         self.assertEqual(content, expected)
@@ -470,6 +470,15 @@ class RunStringUnrestrictedTests(TestBase):
         ns = interpreters.run_string_unrestricted(self.id, script, updates)
 
         self.assertEqual(ns['__name__'], '__main__')
+
+    def test_main_not_shared(self):
+        ns1 = interpreters.run_string_unrestricted(self.id, 'spam = True')
+        ns2 = interpreters.run_string_unrestricted(self.id, 'eggs = False')
+
+        self.assertIn('spam', ns1)
+        self.assertNotIn('eggs', ns1)
+        self.assertIn('eggs', ns2)
+        self.assertNotIn('spam', ns2)
 
     def test_return_execution_namespace(self):
         script = dedent("""

--- a/Lib/test/test__interpreters.py
+++ b/Lib/test/test__interpreters.py
@@ -54,8 +54,8 @@ class InterpreterTests(unittest.TestCase):
             time.sleep(1_000_000)
             """)
         filename = script_helper.make_script(self.dirname, 'interp', script)
-        proc = script_helper.spawn_python(filename)
-        retcode = proc.wait()
+        with script_helper.spawn_python(filename) as proc:
+            retcode = proc.wait()
 
         self.assertEqual(retcode, 0)
 

--- a/Lib/test/test_interpreters.py
+++ b/Lib/test/test_interpreters.py
@@ -1,0 +1,167 @@
+import ast
+import os.path
+import shutil
+import tempfile
+from textwrap import dedent
+import threading
+import unittest
+
+from test import support
+
+_interpreters = support.import_module('_interpreters')
+interpreters = support.import_module('interpreters')
+
+
+class TestBase(unittest.TestCase):
+
+    def setUp(self):
+        self.dirname = None
+
+    def tearDown(self):
+        if self.dirname is not None:
+            try:
+                shutil.rmtree(self.dirname)
+            except FileNotFoundError:
+                pass  # already deleted
+
+        for id in _interpreters.enumerate():
+            if id == 0:  # main
+                continue
+            try:
+                _interpreters.destroy(id)
+            except RuntimeError:
+                pass  # already destroyed
+
+    def _resolve_filename(self, name):
+        if self.dirname is None:
+            self.dirname = tempfile.mkdtemp()
+        return os.path.join(self.dirname, name)
+
+    def _empty_file(self, name):
+        filename = self._resolve_filename(name)
+        support.create_empty_file(filename)
+        return filename
+
+    def assert_file_contains(self, filename, expected):
+        with open(filename) as out:
+            content = out.read()
+        self.assertEqual(content, expected)
+
+
+class ModuleTests(TestBase):
+
+    def test_enumerate(self):
+        main_id = _interpreters.get_main()
+        got = interpreters.enumerate()
+        self.assertEqual(set(i.id for i in got), {main_id})
+
+        id1 = _interpreters.create()
+        id2 = _interpreters.create()
+        got = interpreters.enumerate()
+        self.assertEqual(set(i.id for i in got), {main_id, id1, id2})
+
+    def test_current(self):
+        main_id = _interpreters.get_main()
+        current = interpreters.current()
+        self.assertEqual(current.id, main_id)
+
+        id = _interpreters.create()
+        script = dedent("""
+            import interpreters
+            interp = interpreters.current()
+            """)
+        ns = _interpreters.run_string_unrestricted(id, script)
+        current = ns['interp']
+        self.assertEqual(current.id, id)
+
+    def test_main(self):
+        expected = _interpreters.get_main()
+        main = interpreters.main()
+
+        self.assertEqual(main.id, expected)
+
+    def test_create(self):
+        main_id = _interpreters.get_main()
+        interp = interpreters.create()
+
+        self.assertIsInstance(interp, interpreters.Interpreter)
+        self.assertGreater(interp.id, main_id)
+
+
+class InterpreterTests(TestBase):
+
+    def test_repr(self):
+        interp = interpreters.Interpreter(10)
+        result = repr(interp)
+
+        self.assertEqual(result, 'Interpreter(id=10)')
+
+    def test_equality(self):
+        interp1 = interpreters.Interpreter(0)
+        interp2 = interpreters.Interpreter(10)
+        interp3 = interpreters.Interpreter(10)
+        different = (interp1 == interp2)
+        same = (interp2 == interp3)
+        identity = (interp1 == interp1)
+
+        self.assertFalse(different)
+        self.assertTrue(same)
+        self.assertTrue(identity)
+
+    def test_id(self):
+        interp = interpreters.Interpreter(10)
+        id = interp.id
+
+        self.assertEqual(id, 10)
+
+    def test_is_running(self):
+        interp = interpreters.create()
+        is_running = interp.is_running()
+        self.assertFalse(is_running)
+
+        script = 'is_running = interp.is_running()'
+        ns = _interpreters.run_string_unrestricted(interp.id, script, {
+                'interp': interp,
+                })
+        is_running = ns['is_running']
+        self.assertTrue(is_running)
+
+    def test_destroy(self):
+        before = set(_interpreters.enumerate())
+        interp = interpreters.create()
+        self.assertEqual(set(_interpreters.enumerate()), before | {interp.id})
+
+        interp.destroy()
+        after = set(_interpreters.enumerate())
+
+        self.assertEqual(before, after)
+
+    def test_run_string(self):
+        filename = self._empty_file('spam')
+        data = 'success!'
+        script = dedent(f"""
+            with open('{filename}', 'w') as out:
+                out.write('{data}')
+            """)
+        interp = interpreters.create()
+
+        interp.run(script)
+        self.assert_file_contains(filename, data)
+
+    def test_run_unsupported(self):
+        script = 'raise Exception'
+        interp = interpreters.create()
+
+        with self.assertRaises(NotImplementedError):
+            interp.run(None)
+        with self.assertRaises(NotImplementedError):
+            interp.run(10)
+        node = compile(script, '<script>', 'exec', ast.PyCF_ONLY_AST)
+        with self.assertRaises(NotImplementedError):
+            interp.run(node)
+        code = compile(script, '<script>', 'exec')
+        with self.assertRaises(NotImplementedError):
+            interp.run(code)
+        f = lambda: None
+        with self.assertRaises(NotImplementedError):
+            interp.run(f)

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -180,9 +180,12 @@ _run_string_in_main(PyInterpreterState *interp, const char *codestr,
     }
 
     // Restore __main__.
+    PyObject *exc = NULL, *value = NULL, *tb = NULL;
+    PyErr_Fetch(&exc, &value, &tb);
     if (PyMapping_SetItemString(interp->modules, "__main__", main_mod) < 0) {
-        // XXX Chain exceptions...
-        //PyErr_Restore(exc, value, tb);
+        _PyErr_ChainExceptions(exc, value, tb);
+    } else {
+        PyErr_Restore(exc, value, tb);
     }
     Py_DECREF(main_mod);
 

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -321,6 +321,19 @@ Return the ID of current interpreter.");
 
 
 static PyObject *
+interp_get_main(PyObject *self)
+{
+    // Currently, 0 is always the main interpreter.
+    return PyLong_FromLongLong(0);
+}
+
+PyDoc_STRVAR(get_main_doc,
+"get_main() -> ID\n\
+\n\
+Return the ID of main interpreter.");
+
+
+static PyObject *
 interp_run_string(PyObject *self, PyObject *args)
 {
     PyObject *id, *code;
@@ -455,6 +468,8 @@ static PyMethodDef module_functions[] = {
      METH_NOARGS, enumerate_doc},
     {"get_current",             (PyCFunction)interp_get_current,
      METH_NOARGS, get_current_doc},
+    {"get_main",                (PyCFunction)interp_get_main,
+     METH_NOARGS, get_main_doc},
     {"is_running",              (PyCFunction)interp_is_running,
      METH_VARARGS, is_running_doc},
 

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -279,6 +279,13 @@ interp_run_string(PyObject *self, PyObject *args)
         Py_RETURN_NONE;
 }
 
+PyDoc_STRVAR(run_string_doc,
+"run_string(ID, sourcetext) -> run_id\n\
+\n\
+Execute the provided string in the identified interpreter.\n\
+See PyRun_SimpleStrings.");
+
+
 static PyMethodDef module_functions[] = {
     {"create",      (PyCFunction)interp_create,
      METH_VARARGS, create_doc},
@@ -288,8 +295,8 @@ static PyMethodDef module_functions[] = {
     {"_enumerate",  (PyCFunction)interp_enumerate,
      METH_NOARGS, NULL},
 
-    {"_run_string", (PyCFunction)interp_run_string,
-     METH_VARARGS, NULL},
+    {"run_string",  (PyCFunction)interp_run_string,
+     METH_VARARGS, run_string_doc},
 
     {NULL,          NULL}           /* sentinel */
 };

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -1,0 +1,43 @@
+
+/* interpreters module */
+/* low-level access to interpreter primitives */
+
+#include "Python.h"
+
+
+static PyMethodDef module_functions[] = {
+    {NULL, NULL}           /* sentinel */
+};
+
+
+/* initialization function */
+
+PyDoc_STRVAR(module_doc,
+"This module provides primitive operations to manage Python interpreters.\n\
+The 'interpreters' module provides a more convenient interface.");
+
+static struct PyModuleDef interpretersmodule = {
+    PyModuleDef_HEAD_INIT,
+    "_interpreters",
+    module_doc,
+    -1,
+    module_functions,
+    NULL,
+    NULL,
+    NULL,
+    NULL
+};
+
+
+PyMODINIT_FUNC
+PyInit__interpreters(void)
+{
+    PyObject *module;
+
+    module = PyModule_Create(&interpretersmodule);
+    if (module == NULL)
+        return NULL;
+
+
+    return module;
+}

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -299,6 +299,27 @@ interp_enumerate(PyObject *self)
     return ids;
 }
 
+PyDoc_STRVAR(enumerate_doc,
+"enumerate() -> [ID]\n\
+\n\
+Return a list containing the ID of every existing interpreter.");
+
+
+static PyObject *
+interp_get_current(PyObject *self)
+{
+    PyInterpreterState *interp =_get_current();
+    if (interp == NULL)
+        return NULL;
+    return _get_id(interp);
+}
+
+PyDoc_STRVAR(get_current_doc,
+"get_current() -> ID\n\
+\n\
+Return the ID of current interpreter.");
+
+
 static PyObject *
 interp_run_string(PyObject *self, PyObject *args)
 {
@@ -402,8 +423,10 @@ static PyMethodDef module_functions[] = {
     {"destroy",                 (PyCFunction)interp_destroy,
      METH_VARARGS, destroy_doc},
 
-    {"_enumerate",              (PyCFunction)interp_enumerate,
-     METH_NOARGS, NULL},
+    {"enumerate",               (PyCFunction)interp_enumerate,
+     METH_NOARGS, enumerate_doc},
+    {"get_current",             (PyCFunction)interp_get_current,
+     METH_NOARGS, get_current_doc},
 
     {"run_string",              (PyCFunction)interp_run_string,
      METH_VARARGS, run_string_doc},

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -3,53 +3,131 @@
 /* low-level access to interpreter primitives */
 
 #include "Python.h"
+#include "frameobject.h"
 
 
-static PyObject *
-_get_id(PyInterpreterState *interp)
+static PyInterpreterState *
+_get_current(void)
 {
-    unsigned long id = PyInterpreterState_GetID(interp);
-    if (id == 0 && PyErr_Occurred() != NULL)
+    PyThreadState *tstate;
+
+    tstate = PyThreadState_Get();
+    if (tstate == NULL)
         return NULL;
-    return PyLong_FromUnsignedLong(id);
+    return tstate->interp;
 }
 
 static PyInterpreterState *
-_look_up(PyObject *requested_id)
+_look_up_int64(PY_INT64_T requested_id)
 {
-    PyObject * id;
-    PyInterpreterState *interp;
+    if (requested_id < 0)
+        goto error;
 
-    interp = PyInterpreterState_Head();
+    PyInterpreterState *interp = PyInterpreterState_Head();
     while (interp != NULL) {
-        id = _get_id(interp);
-        if (id == NULL)
+        PY_INT64_T id = PyInterpreterState_GetID(interp);
+        if (id < 0)
             return NULL;
         if (requested_id == id)
             return interp;
         interp = PyInterpreterState_Next(interp);
     }
 
+error:
     PyErr_Format(PyExc_RuntimeError,
-                 "unrecognized interpreter ID %R", requested_id);
+                 "unrecognized interpreter ID %lld", requested_id);
     return NULL;
 }
 
-static PyObject *
-_get_current(void)
+static PyInterpreterState *
+_look_up(PyObject *requested_id)
 {
-    PyThreadState *tstate;
-    PyInterpreterState *interp;
-
-    tstate = PyThreadState_Get();
-    if (tstate == NULL)
+    long long id = PyLong_AsLongLong(requested_id);
+    if (id == -1 && PyErr_Occurred() != NULL)
         return NULL;
-    interp = tstate->interp;
-
-    // get ID
-    return _get_id(interp);
+    // XXX Fail if larger than INT64_MAX?
+    return _look_up_int64(id);
 }
 
+static PyObject *
+_get_id(PyInterpreterState *interp)
+{
+    PY_INT64_T id = PyInterpreterState_GetID(interp);
+    if (id < 0)
+        return NULL;
+    return PyLong_FromLongLong(id);
+}
+
+static int
+_is_running(PyInterpreterState *interp)
+{
+    PyThreadState *tstate = PyInterpreterState_ThreadHead(interp);
+    if (PyThreadState_Next(tstate) != NULL) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "interpreter has more than one thread");
+        return -1;
+    }
+    PyFrameObject *frame = _PyThreadState_GetFrame(tstate);
+    if (frame == NULL) {
+        if (PyErr_Occurred() != NULL)
+            return -1;
+        return 0;
+    }
+    return (int)(frame->f_executing);
+}
+
+static int
+_ensure_not_running(PyInterpreterState *interp)
+{
+    int is_running = _is_running(interp);
+    if (is_running < 0)
+        return -1;
+    if (is_running) {
+        PyErr_Format(PyExc_RuntimeError, "interpreter already running");
+        return -1;
+    }
+    return 0;
+}
+
+static int
+_run_string(PyInterpreterState *interp, const char *codestr)
+{
+    PyObject *result = NULL;
+    PyObject *exc = NULL, *value = NULL, *tb = NULL;
+
+    if (_ensure_not_running(interp) < 0)
+        return -1;
+
+    // Switch to interpreter.
+    PyThreadState *tstate = PyInterpreterState_ThreadHead(interp);
+    PyThreadState *save_tstate = PyThreadState_Swap(tstate);
+
+    // Run the string (see PyRun_SimpleStringFlags).
+    // XXX How to handle sys.exit()?
+    PyObject *m = PyImport_AddModule("__main__");
+    if (m == NULL) {
+        PyErr_Fetch(&exc, &value, &tb);
+        goto done;
+    }
+    PyObject *d = PyModule_GetDict(m);
+    result = PyRun_StringFlags(codestr, Py_file_input, d, d, NULL);
+    if (result == NULL) {
+        // Get the exception from the subinterpreter.
+        PyErr_Fetch(&exc, &value, &tb);
+        goto done;
+    }
+    Py_DECREF(result);  // We throw away the result.
+
+done:
+    // Switch back.
+    if (save_tstate != NULL)
+        PyThreadState_Swap(save_tstate);
+
+    // Propagate any exception out to the caller.
+    PyErr_Restore(exc, value, tb);
+
+    return (result == NULL) ? -1 : 0;
+}
 
 /* module level code ********************************************************/
 
@@ -93,19 +171,25 @@ interp_destroy(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    // Ensure the ID is not the current interpreter.
-    PyObject *current = _get_current();
+    // Look up the interpreter.
+    PyInterpreterState *interp = _look_up(id);
+    if (interp == NULL)
+        return NULL;
+
+    // Ensure we don't try to destroy the current interpreter.
+    PyInterpreterState *current = _get_current();
     if (current == NULL)
         return NULL;
-    if (PyObject_RichCompareBool(id, current, Py_EQ) != 0) {
+    if (interp == current) {
         PyErr_SetString(PyExc_RuntimeError,
                         "cannot destroy the current interpreter");
         return NULL;
     }
 
-    // Look up the interpreter.
-    PyInterpreterState *interp = _look_up(id);
-    if (interp == NULL)
+    // Ensure the interpreter isn't running.
+    /* XXX We *could* support destroying a running interpreter but
+       aren't going to worry about it for now. */
+    if (_ensure_not_running(interp) < 0)
         return NULL;
 
     // Destroy the interpreter.
@@ -156,11 +240,44 @@ interp_enumerate(PyObject *self)
     return ids;
 }
 
-PyDoc_STRVAR(enumerate_doc,
-"enumerate() -> [ID]\n\
-\n\
-Return a list containing the ID of every existing interpreter.");
+static PyObject *
+interp_run_string(PyObject *self, PyObject *args)
+{
+    PyObject *id, *code;
+    if (!PyArg_UnpackTuple(args, "run_string", 2, 2, &id, &code))
+        return NULL;
+    if (!PyLong_Check(id)) {
+        PyErr_SetString(PyExc_TypeError, "first arg (ID) must be an int");
+        return NULL;
+    }
+    if (!PyUnicode_Check(code)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "second arg (code) must be a string");
+        return NULL;
+    }
 
+    // Look up the interpreter.
+    PyInterpreterState *interp = _look_up(id);
+    if (interp == NULL)
+        return NULL;
+
+    // Extract code.
+    Py_ssize_t size;
+    const char *codestr = PyUnicode_AsUTF8AndSize(code, &size);
+    if (codestr == NULL)
+        return NULL;
+    if (strlen(codestr) != (size_t)size) {
+        PyErr_SetString(PyExc_ValueError,
+                        "source code string cannot contain null bytes");
+        return NULL;
+    }
+
+    // Run the code in the interpreter.
+    if (_run_string(interp, codestr) < 0)
+        return NULL;
+    else
+        Py_RETURN_NONE;
+}
 
 static PyMethodDef module_functions[] = {
     {"create",      (PyCFunction)interp_create,
@@ -168,8 +285,11 @@ static PyMethodDef module_functions[] = {
     {"destroy",     (PyCFunction)interp_destroy,
      METH_VARARGS, destroy_doc},
 
-    {"_enumerate",   (PyCFunction)interp_enumerate,
-     METH_NOARGS, enumerate_doc},
+    {"_enumerate",  (PyCFunction)interp_enumerate,
+     METH_NOARGS, NULL},
+
+    {"_run_string", (PyCFunction)interp_run_string,
+     METH_VARARGS, NULL},
 
     {NULL,          NULL}           /* sentinel */
 };

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -45,7 +45,7 @@ _look_up(PyObject *requested_id)
     long long id = PyLong_AsLongLong(requested_id);
     if (id == -1 && PyErr_Occurred() != NULL)
         return NULL;
-    // XXX Fail if larger than INT64_MAX?
+    assert(id <= INT64_MAX);
     return _look_up_int64(id);
 }
 
@@ -100,7 +100,6 @@ _run_string(PyInterpreterState *interp, const char *codestr, PyObject *updates)
     PyThreadState *save_tstate = PyThreadState_Swap(tstate);
 
     // Run the string (see PyRun_SimpleStringFlags).
-    // XXX How to handle sys.exit()?
     PyObject *exc = NULL, *value = NULL, *tb = NULL;
     PyObject *ns = NULL;
     // XXX Force a fresh __main__ module?
@@ -140,8 +139,6 @@ done:
 }
 
 /* module level code ********************************************************/
-
-// XXX track count?
 
 static PyObject *
 interp_create(PyObject *self, PyObject *args)
@@ -205,10 +202,9 @@ interp_destroy(PyObject *self, PyObject *args)
     // Destroy the interpreter.
     //PyInterpreterState_Delete(interp);
     PyThreadState *tstate, *save_tstate;
-    tstate = PyInterpreterState_ThreadHead(interp);  // XXX Is this the right one?
+    tstate = PyInterpreterState_ThreadHead(interp);
     save_tstate = PyThreadState_Swap(tstate);
-    // XXX Stop current execution?
-    Py_EndInterpreter(tstate);  // XXX Handle possible errors?
+    Py_EndInterpreter(tstate);
     PyThreadState_Swap(save_tstate);
 
     Py_RETURN_NONE;
@@ -228,8 +224,6 @@ interp_enumerate(PyObject *self)
 {
     PyObject *ids, *id;
     PyInterpreterState *interp;
-
-    // XXX Handle multiple main interpreters.
 
     ids = PyList_New(0);
     if (ids == NULL)

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -5,8 +5,173 @@
 #include "Python.h"
 
 
+static PyObject *
+_get_id(PyInterpreterState *interp)
+{
+    unsigned long id = PyInterpreterState_GetID(interp);
+    if (id == 0 && PyErr_Occurred() != NULL)
+        return NULL;
+    return PyLong_FromUnsignedLong(id);
+}
+
+static PyInterpreterState *
+_look_up(PyObject *requested_id)
+{
+    PyObject * id;
+    PyInterpreterState *interp;
+
+    interp = PyInterpreterState_Head();
+    while (interp != NULL) {
+        id = _get_id(interp);
+        if (id == NULL)
+            return NULL;
+        if (requested_id == id)
+            return interp;
+        interp = PyInterpreterState_Next(interp);
+    }
+
+    PyErr_Format(PyExc_RuntimeError,
+                 "unrecognized interpreter ID %R", requested_id);
+    return NULL;
+}
+
+static PyObject *
+_get_current(void)
+{
+    PyThreadState *tstate;
+    PyInterpreterState *interp;
+
+    tstate = PyThreadState_Get();
+    if (tstate == NULL)
+        return NULL;
+    interp = tstate->interp;
+
+    // get ID
+    return _get_id(interp);
+}
+
+
+/* module level code ********************************************************/
+
+// XXX track count?
+
+static PyObject *
+interp_create(PyObject *self, PyObject *args)
+{
+    if (!PyArg_UnpackTuple(args, "create", 0, 0))
+        return NULL;
+
+    // Create and initialize the new interpreter.
+    PyThreadState *tstate, *save_tstate;
+    save_tstate = PyThreadState_Swap(NULL);
+    tstate = Py_NewInterpreter();
+    PyThreadState_Swap(save_tstate);
+    if (tstate == NULL) {
+        /* Since no new thread state was created, there is no exception to
+           propagate; raise a fresh one after swapping in the old thread
+           state. */
+        PyErr_SetString(PyExc_RuntimeError, "interpreter creation failed");
+        return NULL;
+    }
+    return _get_id(tstate->interp);
+}
+
+PyDoc_STRVAR(create_doc,
+"create() -> ID\n\
+\n\
+Create a new interpreter and return a unique generated ID.");
+
+
+static PyObject *
+interp_destroy(PyObject *self, PyObject *args)
+{
+    PyObject *id;
+    if (!PyArg_UnpackTuple(args, "destroy", 1, 1, &id))
+        return NULL;
+    if (!PyLong_Check(id)) {
+        PyErr_SetString(PyExc_TypeError, "ID must be an int");
+        return NULL;
+    }
+
+    // Ensure the ID is not the current interpreter.
+    PyObject *current = _get_current();
+    if (current == NULL)
+        return NULL;
+    if (PyObject_RichCompareBool(id, current, Py_EQ) != 0) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "cannot destroy the current interpreter");
+        return NULL;
+    }
+
+    // Look up the interpreter.
+    PyInterpreterState *interp = _look_up(id);
+    if (interp == NULL)
+        return NULL;
+
+    // Destroy the interpreter.
+    //PyInterpreterState_Delete(interp);
+    PyThreadState *tstate, *save_tstate;
+    tstate = PyInterpreterState_ThreadHead(interp);  // XXX Is this the right one?
+    save_tstate = PyThreadState_Swap(tstate);
+    // XXX Stop current execution?
+    Py_EndInterpreter(tstate);  // XXX Handle possible errors?
+    PyThreadState_Swap(save_tstate);
+
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(destroy_doc,
+"destroy(ID)\n\
+\n\
+Destroy the identified interpreter.\n\
+\n\
+Attempting to destroy the current interpreter results in a RuntimeError.\n\
+So does an unrecognized ID.");
+
+
+static PyObject *
+interp_enumerate(PyObject *self)
+{
+    PyObject *ids, *id;
+    PyInterpreterState *interp;
+
+    // XXX Handle multiple main interpreters.
+
+    ids = PyList_New(0);
+    if (ids == NULL)
+        return NULL;
+
+    interp = PyInterpreterState_Head();
+    while (interp != NULL) {
+        id = _get_id(interp);
+        if (id == NULL)
+            return NULL;
+        // insert at front of list
+        if (PyList_Insert(ids, 0, id) < 0)
+            return NULL;
+
+        interp = PyInterpreterState_Next(interp);
+    }
+
+    return ids;
+}
+
+PyDoc_STRVAR(enumerate_doc,
+"enumerate() -> [ID]\n\
+\n\
+Return a list containing the ID of every existing interpreter.");
+
+
 static PyMethodDef module_functions[] = {
-    {NULL, NULL}           /* sentinel */
+    {"create",      (PyCFunction)interp_create,
+     METH_VARARGS, create_doc},
+    {"destroy",     (PyCFunction)interp_destroy,
+     METH_VARARGS, destroy_doc},
+
+    {"_enumerate",   (PyCFunction)interp_enumerate,
+     METH_NOARGS, enumerate_doc},
+
+    {NULL,          NULL}           /* sentinel */
 };
 
 

--- a/Modules/_interpretersmodule.c
+++ b/Modules/_interpretersmodule.c
@@ -417,6 +417,34 @@ merged into the execution namespace before the code is executed.\n\
 See PyRun_SimpleStrings.");
 
 
+static PyObject *
+interp_is_running(PyObject *self, PyObject *args)
+{
+    PyObject *id;
+    if (!PyArg_UnpackTuple(args, "is_running", 1, 1, &id))
+        return NULL;
+    if (!PyLong_Check(id)) {
+        PyErr_SetString(PyExc_TypeError, "ID must be an int");
+        return NULL;
+    }
+
+    PyInterpreterState *interp = _look_up(id);
+    if (interp == NULL)
+        return NULL;
+    int is_running = _is_running(interp);
+    if (is_running < 0)
+        return NULL;
+    if (is_running)
+        Py_RETURN_TRUE;
+    Py_RETURN_FALSE;
+}
+
+PyDoc_STRVAR(is_running_doc,
+"is_running(id) -> bool\n\
+\n\
+Return whether or not the identified interpreter is running.");
+
+
 static PyMethodDef module_functions[] = {
     {"create",                  (PyCFunction)interp_create,
      METH_VARARGS, create_doc},
@@ -427,6 +455,8 @@ static PyMethodDef module_functions[] = {
      METH_NOARGS, enumerate_doc},
     {"get_current",             (PyCFunction)interp_get_current,
      METH_NOARGS, get_current_doc},
+    {"is_running",              (PyCFunction)interp_is_running,
+     METH_VARARGS, is_running_doc},
 
     {"run_string",              (PyCFunction)interp_run_string,
      METH_VARARGS, run_string_doc},

--- a/setup.py
+++ b/setup.py
@@ -694,6 +694,9 @@ class PyBuildExt(build_ext):
         # syslog daemon interface
         exts.append( Extension('syslog', ['syslogmodule.c']) )
 
+        # Python interface to subinterpreter C-API.
+        exts.append(Extension('_interpreters', ['_interpretersmodule.c']))
+
         #
         # Here ends the simple stuff.  From here on, modules need certain
         # libraries, are platform-specific, or present other surprises.


### PR DESCRIPTION
(based on #1802)

Note that, unlike the preceding 2 patches, this one adds a "public" module to the stdlib.  As such it requires more careful attention to the API/abstractions, as well as stronger consensus from python-dev and the other major Python implementations.  As such, this PR is equally a proof-of-concept and a proposal.