### PR TITLE
bpo-30466: Add brief explanation of classes to tutorial

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -4,6 +4,12 @@
 Classes
 *******
 
+Classes provide a means of bundling data and functionality together.  Creating
+a new class creates a new *type* of object, allowing new *instances* of that
+type to be made.  Each class instance can have attributes attached to it for
+maintaining its state.  Class instances can also have methods (defined by its
+class) for modifying its state.
+
 Compared with other programming languages, Python's class mechanism adds classes
 with a minimum of new syntax and semantics.  It is a mixture of the class
 mechanisms found in C++ and Modula-3.  Python classes provide all the standard


### PR DESCRIPTION
This could certainly use more work. A "what are classes" or "why classes" section would be great, especially one that explains the various class terminology.

We could alternatively or additionally link to external resources that explain classes at a beginner-friendly level.

The "A First Look at Classes" section could also probably be moved up the page or it could be noted that beginners can skip over the first couple sections before it.