### PR TITLE
bpo-30449: Improve __slots__ documentation

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1625,12 +1625,11 @@ more space
 
 One can also prevent *__dict__* and *__weakref__* from being created by
 inheriting solely from slotted classes or builtin types and declaring
-slots that do not include ``'__dict__'`` and ``'__weakref__'``. The
-following example explicitly allows *__dict__*::
+slots that do not include ``'__dict__'`` and ``'__weakref__'``. For example::
 
    class Slotted:
        """This class only has foo and bar attributes,
-       __dict__ (and thus flexible attributes) is disallowed.
+       and disallows __dict__ (and thus flexible attributes)
        """
        __slots__ = 'foo', 'bar'
 
@@ -1638,27 +1637,18 @@ Slotted classes (aside from variable-length built-in types
 such as :class:`int`, :class:`bytes` and :class:`tuple`)
 can allow *__dict__* and *__weakref__* by adding 
 ``'__dict__'`` and ``'__weakref__'`` to *__slots__*, respectively.
-For example::
+The following example explicitly allows *__dict__*::
 
    class FlexibleSlotted(Slotted):
        """This class optimizes foo and bar, but allows other attributes"""
-       __slots__ = '__dict__', # instance will have parent's slots too.
-
+       __slots__ = '__dict__', # instances will have parent's slots too.
 
 If *__dict__* is not allowed, any attempts to assign to an unslotted
 variable raises :exc:`AttributeError`.
 
-Since *__slots__* implicitly creates *member_descriptors* (data
-descriptors, like *property*, in the class), the
-optimizations still apply for attributes named in *__slots__* in spite of
-the *__dict__*.
-
 Child classes using *__slots__* should only name the additional slots,
 else the slots created by the parents will be inaccessable slots in
 the instance (wasting some space).
-
-Otherwise, attributes available in the parent will be accessible,
-including *__dict__* and *__weakref__*.
 
 One can use multiple inheritance with slots, but only one parent can have
 non-empty *__slots__*. To maximize reusability with abstract base
@@ -1679,6 +1669,12 @@ Notes on using *__slots__*
 
 * When inheriting from a class without *__slots__*, the *__dict__* attribute
   of that class will always be accessible.
+
+* Without a *__dict__* variable, instances cannot be assigned new
+  variables not listed in the *__slots__* definition. Attempts to assign
+  to an unlisted variable name raises :exc:`AttributeError`. If dynamic
+  assignment of new variables is desired, then add ``'__dict__'`` to the
+  sequence of strings in the *__slots__* declaration.
 
 * Without a *__weakref__* variable for each instance, classes defining
   *__slots__* do not support weak references to its instances. If weak reference

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1615,29 +1615,37 @@ __slots__
 ^^^^^^^^^
 
 By default, instances of classes have a dictionary for attribute storage.
+Dictionaries allows for flexibility in creation of attributes for
+instances.
 
-However, we could use a data structure that takes up less space than a
-dictionary if we know the attributes to expect on class creation.
+If we know what attributes we will use, we can, by defining *__slots__*,
+use a data structure that only uses space that is minimally required for
+those attribute values. Dictionary flexibility usually requires much
+more space
 
-Thus, we can override this default by defining *__slots__* in a class
-definition.
-
-The *__slots__* declaration takes a sequence of instance variables and reserves
-just enough space in each instance to hold a reference to a value for each
-variable.
-
-Space is saved because *__dict__* is not used for these variables.
-
-One can prevent *__dict__* and *__weakref__* from being created by
+One can also prevent *__dict__* and *__weakref__* from being created by
 inheriting solely from slotted classes or builtin types and declaring
-slots that doesn't include ``'__dict__'`` and ``'__weakref__'``.
+slots that do not include ``'__dict__'`` and ``'__weakref__'``. The
+following example explicitly allows *__dict__*::
+
+   class Slotted:
+       """This class only has foo and bar attributes,
+       __dict__ (and thus flexible attributes) is disallowed.
+       """
+       __slots__ = 'foo', 'bar'
 
 Slotted classes (aside from variable-length built-in types
 such as :class:`int`, :class:`bytes` and :class:`tuple`)
-can allow *__dict__* and *__weakref__* by adding # XXX is weakref true?
+can allow *__dict__* and *__weakref__* by adding 
 ``'__dict__'`` and ``'__weakref__'`` to *__slots__*, respectively.
+For example::
 
-If *__dict__* is not allowed, attempts to assign to an unslotted
+   class FlexibleSlotted(Slotted):
+       """This class optimizes foo and bar, but allows other attributes"""
+       __slots__ = '__dict__', # instance will have parent's slots too.
+
+
+If *__dict__* is not allowed, any attempts to assign to an unslotted
 variable raises :exc:`AttributeError`.
 
 Since *__slots__* implicitly creates *member_descriptors* (data

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1614,14 +1614,29 @@ instances cannot override the behavior of a property.
 __slots__
 ^^^^^^^^^
 
-By default, instances of classes have a dictionary for attribute storage.  This
-wastes space for objects having very few instance variables.  The space
-consumption can become acute when creating large numbers of instances.
+By default, instances of classes have a dictionary for attribute storage.
 
 The default can be overridden by defining *__slots__* in a class definition.
+
 The *__slots__* declaration takes a sequence of instance variables and reserves
-just enough space in each instance to hold a value for each variable.  Space is
-saved because *__dict__* is not created for each instance.
+just enough space in each instance to hold a reference to a value for each
+variable.
+
+Space is saved because *__dict__* is not used for these variables.
+
+One can prevent *__dict__* and *__weakref__* from being created by
+inheriting solely from slotted classes or builtin types.
+
+*__dict__* and *__weakref__* can be allowed by adding them to *__slots__*.
+
+Since slots implicitly create *member_descriptors* (data descriptors), the
+optimizations still apply for attributes named in *__slots__*.
+
+Child classes using *__slots__* should only name the additional slots,
+else the slots created by the parents will be inaccessable.
+
+One can use multiple inheritance with slots, but only one parent can have
+non-empty *__slots__*.
 
 
 .. data:: object.__slots__
@@ -1634,10 +1649,6 @@ saved because *__dict__* is not created for each instance.
 
 Notes on using *__slots__*
 """"""""""""""""""""""""""
-
-* When inheriting from a class without *__slots__*, the *__dict__* attribute of
-  that class will always be accessible, so a *__slots__* definition in the
-  subclass is meaningless.
 
 * Without a *__dict__* variable, instances cannot be assigned new variables not
   listed in the *__slots__* definition.  Attempts to assign to an unlisted
@@ -1656,9 +1667,9 @@ Notes on using *__slots__*
   *__slots__*; otherwise, the class attribute would overwrite the descriptor
   assignment.
 
-* The action of a *__slots__* declaration is limited to the class where it is
-  defined.  As a result, subclasses will have a *__dict__* unless they also define
-  *__slots__* (which must only contain names of any *additional* slots).
+* For classes in an inheritance tree that defines *__slots__*, subclasses
+  will have a *__dict__* unless they also define *__slots__* (which must only
+  contain names of any additional slots).
 
 * If a class defines a slot also defined in a base class, the instance variable
   defined by the base class slot is inaccessible (except by retrieving its

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1615,13 +1615,13 @@ __slots__
 ^^^^^^^^^
 
 By default, instances of classes have a dictionary for attribute storage.
-Dictionaries allows for flexibility in creation of attributes for
+Dictionaries allow for flexibility in creation of attributes for
 instances.
 
 If we know what attributes we will use, we can, by defining *__slots__*,
 use a data structure that only uses space that is minimally required for
 those attribute values. Dictionary flexibility usually requires much
-more space
+more space.
 
 One can also prevent *__dict__* and *__weakref__* from being created by
 inheriting solely from slotted classes or builtin types and declaring

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1616,7 +1616,11 @@ __slots__
 
 By default, instances of classes have a dictionary for attribute storage.
 
-The default can be overridden by defining *__slots__* in a class definition.
+However, we could use a data structure that takes up less space than a
+dictionary if we know the attributes to expect on class creation.
+
+Thus, we can override this default by defining *__slots__* in a class
+definition.
 
 The *__slots__* declaration takes a sequence of instance variables and reserves
 just enough space in each instance to hold a reference to a value for each
@@ -1625,18 +1629,33 @@ variable.
 Space is saved because *__dict__* is not used for these variables.
 
 One can prevent *__dict__* and *__weakref__* from being created by
-inheriting solely from slotted classes or builtin types.
+inheriting solely from slotted classes or builtin types and declaring
+slots that doesn't include ``'__dict__'`` and ``'__weakref__'``.
 
-*__dict__* and *__weakref__* can be allowed by adding them to *__slots__*.
+Slotted classes (aside from variable-length built-in types
+such as :class:`int`, :class:`bytes` and :class:`tuple`)
+can allow *__dict__* and *__weakref__* by adding # XXX is weakref true?
+``'__dict__'`` and ``'__weakref__'`` to *__slots__*, respectively.
 
-Since slots implicitly create *member_descriptors* (data descriptors), the
-optimizations still apply for attributes named in *__slots__*.
+If *__dict__* is not allowed, attempts to assign to an unslotted
+variable raises :exc:`AttributeError`.
+
+Since *__slots__* implicitly creates *member_descriptors* (data
+descriptors, like *property*, in the class), the
+optimizations still apply for attributes named in *__slots__* in spite of
+the *__dict__*.
 
 Child classes using *__slots__* should only name the additional slots,
-else the slots created by the parents will be inaccessable.
+else the slots created by the parents will be inaccessable slots in
+the instance (wasting some space).
+
+Otherwise, attributes available in the parent will be accessible,
+including *__dict__* and *__weakref__*.
 
 One can use multiple inheritance with slots, but only one parent can have
-non-empty *__slots__*.
+non-empty *__slots__*. To maximize reusability with abstract base
+classes and mixins, or any non-instantiable class, declare slots to
+be empty.
 
 
 .. data:: object.__slots__
@@ -1650,11 +1669,8 @@ non-empty *__slots__*.
 Notes on using *__slots__*
 """"""""""""""""""""""""""
 
-* Without a *__dict__* variable, instances cannot be assigned new variables not
-  listed in the *__slots__* definition.  Attempts to assign to an unlisted
-  variable name raises :exc:`AttributeError`. If dynamic assignment of new
-  variables is desired, then add ``'__dict__'`` to the sequence of strings in
-  the *__slots__* declaration.
+* When inheriting from a class without *__slots__*, the *__dict__* attribute
+  of that class will always be accessible.
 
 * Without a *__weakref__* variable for each instance, classes defining
   *__slots__* do not support weak references to its instances. If weak reference
@@ -1684,7 +1700,7 @@ Notes on using *__slots__*
   corresponding to each key.
 
 * *__class__* assignment works only if both classes have the same *__slots__*.
-
+  
 
 .. _class-customization:
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1635,7 +1635,7 @@ slots that do not include ``'__dict__'`` and ``'__weakref__'``. For example::
 
 Slotted classes (aside from variable-length built-in types
 such as :class:`int`, :class:`bytes` and :class:`tuple`)
-can allow *__dict__* and *__weakref__* by adding 
+can allow *__dict__* and *__weakref__* by adding
 ``'__dict__'`` and ``'__weakref__'`` to *__slots__*, respectively.
 The following example explicitly allows *__dict__*::
 
@@ -1704,7 +1704,7 @@ Notes on using *__slots__*
   corresponding to each key.
 
 * *__class__* assignment works only if both classes have the same *__slots__*.
-  
+
 
 .. _class-customization:
 


### PR DESCRIPTION
This improves new information flow of __slots__ documentation, separates description of behaviors, removes some erroneous statements, and adds a few examples.

See also http://bugs.python.org/issue30449