### PR TITLE
bpo-30451: parse windows path error in webbrowser.get() and lead to webbrowser.Error: could not locate runnable browser

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -47,7 +47,10 @@ def get(using=None):
     for browser in alternatives:
         if '%s' in browser:
             # User gave us a command line, split it into name and args
-            browser = shlex.split(browser)
+            if sys.platform[:3] == 'win':
+                browser = shlex.split(browser, posix=False)
+            else:
+                browser = shlex.split(browser)
             if browser[-1] == '&':
                 return BackgroundBrowser(browser[:-1])
             else:


### PR DESCRIPTION
a bug when platform is not posix, lead to 
webbrowser.Error: could not locate runnable browser
see below:
import shlex
shlex.split('C:\\a\\chrome.exe', comments=False, posix=True)
['C:achrome.exe']
shlex.split('C:\\a\\chrome.exe', comments=False, posix=False)
['C:\\a\\chrome.exe']