### PR TITLE
[3.6] bpo-29943: Do not replace the function PySlice_GetIndicesEx() with a macro (GH-1049)

### DIFF
--- a/Include/sliceobject.h
+++ b/Include/sliceobject.h
@@ -45,11 +45,13 @@ PyAPI_FUNC(int) PySlice_GetIndicesEx(PyObject *r, Py_ssize_t length,
                                      Py_ssize_t *step, Py_ssize_t *slicelength);
 
 #if !defined(Py_LIMITED_API) || (Py_LIMITED_API+0 >= 0x03050400 && Py_LIMITED_API+0 < 0x03060000) || Py_LIMITED_API+0 >= 0x03060100
+#ifdef Py_LIMITED_API
 #define PySlice_GetIndicesEx(slice, length, start, stop, step, slicelen) (  \
     PySlice_Unpack((slice), (start), (stop), (step)) < 0 ?                  \
     ((*(slicelen) = 0), -1) :                                               \
     ((*(slicelen) = PySlice_AdjustIndices((length), (start), (stop), *(step))), \
      0))
+#endif
 PyAPI_FUNC(int) PySlice_Unpack(PyObject *slice,
                                Py_ssize_t *start, Py_ssize_t *stop, Py_ssize_t *step);
 PyAPI_FUNC(Py_ssize_t) PySlice_AdjustIndices(Py_ssize_t length,

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -153,6 +153,13 @@ Library
   exception) to exception(s) raised in the dispatched methods.
   Patch by Petr Motejlek.
 
+C API
+-----
+
+- Issue #27867: Function PySlice_GetIndicesEx() no longer replaced with a macro
+  if Py_LIMITED_API is not set.
+
+
 Build
 -----
 
@@ -451,8 +458,8 @@ C API
 -----
 
 - Issue #27867: Function PySlice_GetIndicesEx() is replaced with a macro if
-  Py_LIMITED_API is set to the value between 0x03050400 and 0x03060000 (not
-  including) or 0x03060100 or higher.
+  Py_LIMITED_API is not set or set to the value between 0x03050400
+  and 0x03060000 (not including) or 0x03060100 or higher.
 
 - Issue #29083: Fixed the declaration of some public API functions.
   PyArg_VaParse() and PyArg_VaParseTupleAndKeywords() were not available in

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -451,8 +451,8 @@ C API
 -----
 
 - Issue #27867: Function PySlice_GetIndicesEx() is replaced with a macro if
-  Py_LIMITED_API is not set or set to the value between 0x03050400
-  and 0x03060000 (not including) or 0x03060100 or higher.
+  Py_LIMITED_API is set to the value between 0x03050400 and 0x03060000 (not
+  including) or 0x03060100 or higher.
 
 - Issue #29083: Fixed the declaration of some public API functions.
   PyArg_VaParse() and PyArg_VaParseTupleAndKeywords() were not available in


### PR DESCRIPTION
if Py_LIMITED_API is not defined.
(cherry picked from commit 49a9059)