### PR TITLE
 bpo-13349: repr object in tuple.index ValueError message

### DIFF
--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -568,7 +568,8 @@ tuple_index_impl(PyTupleObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "tuple.index(x): x not in tuple");
+
+    PyErr_Format(PyExc_ValueError, "%R not in tuple", value);
     return NULL;
 }
 


### PR DESCRIPTION
The old error of `tuple.index(x): x not in tuple` seemed very confusing to me. It was also harder to quickly understand what the program was doing wrong. This saves people a second pass through the program under the debugger because they can just see what the invalid value was.

The reason I am explicitly calling repr instead of using `%R` is that I didn't want to call repr twice if I didn't need to. If people think that is fine the format can just be `tuple.index(%R): %R not in tuple` instead.