### PR TITLE
bpo-30490: Allow to the Event.set method pass an exception

### DIFF
--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -229,17 +229,22 @@ class Event:
         """Return True if and only if the internal flag is true."""
         return self._value
 
-    def set(self):
+    def set(self, exc=None):
         """Set the internal flag to true. All coroutines waiting for it to
         become true are awakened. Coroutine that call wait() once the flag is
         true will not block at all.
+
+        If `exc` is set waiters are awakened using a `set_exception`.
         """
         if not self._value:
             self._value = True
 
             for fut in self._waiters:
                 if not fut.done():
-                    fut.set_result(True)
+                    if not exc:
+                        fut.set_result(True)
+                    else:
+                        fut.set_exception(exc)
 
     def clear(self):
         """Reset the internal flag to false. Subsequently, coroutines calling

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -362,6 +362,25 @@ class EventTests(test_utils.TestCase):
         self.assertTrue(t.done())
         self.assertTrue(t.result())
 
+    def test_set_exc(self):
+        ev = asyncio.Event(loop=self.loop)
+        result = []
+
+        @asyncio.coroutine
+        def c(result):
+            try:
+                yield from ev.wait()
+            except Exception as e:
+                result.append(e)
+
+        t = asyncio.Task(c(result), loop=self.loop)
+
+        test_utils.run_briefly(self.loop)
+        e = Exception()
+        ev.set(exc=e)
+        test_utils.run_briefly(self.loop)
+        self.assertEqual([e], result)
+
 
 class ConditionTests(test_utils.TestCase):
 


### PR DESCRIPTION
Having the Event as the way to synchronize 1:N coroutines, the none happy path should be able to be expressed making possible call the `set_exception` for each future related to each waiter.

As an example the following code trying to implement a way to avoid the dogpile effect for a DNS cache. If the coro that holds the event fails, the original exception is also broadcasted to the waiters.

```python
if key in throttle_dns_events:
    yield from throttle_dns_events[key].wait()
else:
    throttle_dns_events[key] = Event(loop=loop)
    try:
        addrs = yield from \
            resolver.resolve(host, port, family=family)
        cached_hosts.add(key, addrs)
        throttle_dns_events[key].set()
    except Exception as e:
        # any DNS exception, independently of the implementation
        # is set for the waiters to raise the same exception.
        throttle_dns_events[key].set(exc=e)
        raise
    finally:
        throttle_dns_events.pop(key)
```