### PR TITLE
bpo-11874 argparse assertion failure

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -327,19 +327,15 @@ class HelpFormatter(object):
             if len(prefix) + len(usage) > text_width:
 
                 # break usage into wrappable parts
-                part_regexp = '|'.join([
-                    r'\(.*?\)+\s',
-                    r'\[.*?\]+\s',
-                    r'\(.*?\)+$',
-                    r'\[.*?\]+$',
-                    r'\S+',
-                ])
+                part_regexp = (
+                    r'\(.*?\)+(?=\s|$)|'
+                    r'\[.*?\]+(?=\s|$)|'
+                    r'\S+'
+                )
                 opt_usage = format(optionals, groups)
                 pos_usage = format(positionals, groups)
                 opt_parts = _re.findall(part_regexp, opt_usage)
                 pos_parts = _re.findall(part_regexp, pos_usage)
-                opt_parts = [part.strip() for part in opt_parts]
-                pos_parts = [part.strip() for part in pos_parts]
                 assert ' '.join(opt_parts) == opt_usage
                 assert ' '.join(pos_parts) == pos_usage
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -327,11 +327,19 @@ class HelpFormatter(object):
             if len(prefix) + len(usage) > text_width:
 
                 # break usage into wrappable parts
-                part_regexp = r'\(.*?\)+|\[.*?\]+|\S+'
+                part_regexp = '|'.join([
+                    r'\(.*?\)+\s',
+                    r'\[.*?\]+\s',
+                    r'\(.*?\)+$',
+                    r'\[.*?\]+$',
+                    r'\S+',
+                ])
                 opt_usage = format(optionals, groups)
                 pos_usage = format(positionals, groups)
                 opt_parts = _re.findall(part_regexp, opt_usage)
                 pos_parts = _re.findall(part_regexp, pos_usage)
+                opt_parts = [part.strip() for part in opt_parts]
+                pos_parts = [part.strip() for part in pos_parts]
                 assert ' '.join(opt_parts) == opt_usage
                 assert ' '.join(pos_parts) == pos_usage
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4953,7 +4953,7 @@ class TestAddArgumentMetavar(TestCase):
         self.do_test_exception(nargs=None, metavar=tuple())
 
     def test_nargs_None_metavar_length1(self):
-        self.do_test_no_exception(nargs=None, metavar=("1"))
+        self.do_test_no_exception(nargs=None, metavar=("1",))
 
     def test_nargs_None_metavar_length2(self):
         self.do_test_exception(nargs=None, metavar=("1", "2"))
@@ -4970,7 +4970,7 @@ class TestAddArgumentMetavar(TestCase):
         self.do_test_exception(nargs="?", metavar=tuple())
 
     def test_nargs_optional_metavar_length1(self):
-        self.do_test_no_exception(nargs="?", metavar=("1"))
+        self.do_test_no_exception(nargs="?", metavar=("1",))
 
     def test_nargs_optional_metavar_length2(self):
         self.do_test_exception(nargs="?", metavar=("1", "2"))
@@ -4987,7 +4987,7 @@ class TestAddArgumentMetavar(TestCase):
         self.do_test_exception(nargs="*", metavar=tuple())
 
     def test_nargs_zeroormore_metavar_length1(self):
-        self.do_test_no_exception(nargs="*", metavar=("1"))
+        self.do_test_exception(nargs="*", metavar=("1",))
 
     def test_nargs_zeroormore_metavar_length2(self):
         self.do_test_no_exception(nargs="*", metavar=("1", "2"))
@@ -5004,7 +5004,7 @@ class TestAddArgumentMetavar(TestCase):
         self.do_test_exception(nargs="+", metavar=tuple())
 
     def test_nargs_oneormore_metavar_length1(self):
-        self.do_test_no_exception(nargs="+", metavar=("1"))
+        self.do_test_exception(nargs="+", metavar=("1",))
 
     def test_nargs_oneormore_metavar_length2(self):
         self.do_test_no_exception(nargs="+", metavar=("1", "2"))
@@ -5021,7 +5021,7 @@ class TestAddArgumentMetavar(TestCase):
         self.do_test_no_exception(nargs="...", metavar=tuple())
 
     def test_nargs_remainder_metavar_length1(self):
-        self.do_test_no_exception(nargs="...", metavar=("1"))
+        self.do_test_no_exception(nargs="...", metavar=("1",))
 
     def test_nargs_remainder_metavar_length2(self):
         self.do_test_no_exception(nargs="...", metavar=("1", "2"))
@@ -5038,7 +5038,7 @@ class TestAddArgumentMetavar(TestCase):
         self.do_test_exception(nargs="A...", metavar=tuple())
 
     def test_nargs_parser_metavar_length1(self):
-        self.do_test_no_exception(nargs="A...", metavar=("1"))
+        self.do_test_no_exception(nargs="A...", metavar=("1",))
 
     def test_nargs_parser_metavar_length2(self):
         self.do_test_exception(nargs="A...", metavar=("1", "2"))
@@ -5055,7 +5055,7 @@ class TestAddArgumentMetavar(TestCase):
         self.do_test_exception(nargs=1, metavar=tuple())
 
     def test_nargs_1_metavar_length1(self):
-        self.do_test_no_exception(nargs=1, metavar=("1"))
+        self.do_test_no_exception(nargs=1, metavar=("1",))
 
     def test_nargs_1_metavar_length2(self):
         self.do_test_exception(nargs=1, metavar=("1", "2"))
@@ -5072,7 +5072,7 @@ class TestAddArgumentMetavar(TestCase):
         self.do_test_exception(nargs=2, metavar=tuple())
 
     def test_nargs_2_metavar_length1(self):
-        self.do_test_no_exception(nargs=2, metavar=("1"))
+        self.do_test_exception(nargs=2, metavar=("1",))
 
     def test_nargs_2_metavar_length2(self):
         self.do_test_no_exception(nargs=2, metavar=("1", "2"))
@@ -5089,7 +5089,7 @@ class TestAddArgumentMetavar(TestCase):
         self.do_test_exception(nargs=3, metavar=tuple())
 
     def test_nargs_3_metavar_length1(self):
-        self.do_test_no_exception(nargs=3, metavar=("1"))
+        self.do_test_exception(nargs=3, metavar=("1",))
 
     def test_nargs_3_metavar_length2(self):
         self.do_test_exception(nargs=3, metavar=("1", "2"))

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -5116,6 +5116,30 @@ class TestImportStar(TestCase):
         ]
         self.assertEqual(sorted(items), sorted(argparse.__all__))
 
+
+class TestWrappingMetavar(TestCase):
+
+    def setUp(self):
+        self.parser = ErrorRaisingArgumentParser(
+            'this_is_spammy_prog_with_a_long_name_sorry_about_the_name'
+        )
+        # this metavar was triggering library assertion errors due to usage
+        # message formatting incorrectly splitting on the ] chars within
+        metavar = '<http[s]://example:1234>'
+        self.parser.add_argument('--proxy', metavar=metavar)
+
+    def test_help_with_metavar(self):
+        help_text = self.parser.format_help()
+        self.assertEqual(help_text, textwrap.dedent('''\
+            usage: this_is_spammy_prog_with_a_long_name_sorry_about_the_name
+                   [-h] [--proxy <http[s]://example:1234>]
+
+            optional arguments:
+              -h, --help            show this help message and exit
+              --proxy <http[s]://example:1234>
+            '''))
+
+
 def test_main():
     support.run_unittest(__name__)
     # Remove global references to avoid looking like we have refleaks.

--- a/Misc/NEWS.d/next/Library/2018-05-23-00-26-27.bpo-11874.glK5iP.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-23-00-26-27.bpo-11874.glK5iP.rst
@@ -1,0 +1,2 @@
+Use a better regex when breaking usage into wrappable parts. Avoids bogus
+assertion errors from custom metavar strings.


### PR DESCRIPTION
```
import argparse

parser = argparse.ArgumentParser('prog'*8)
parser.add_argument('--proxy', metavar='<http[s]://example:1234>')

args = parser.parse_args(['--help'])
```

The script above triggers assertion errors from argparse library code (specifically, from [here](https://github.com/python/cpython/blob/2b44e302ec3079363c4d5c875677945953705c58/Lib/argparse.py#L333-L334)).  

This bug that has been floating around for years, and has already bitten several people before it bit me.  See for example:

http://bugs.python.org/issue25058
http://bugs.python.org/issue14046
http://bugs.python.org/issue24089 
http://bugs.python.org/issue11874 

There are a few ways we could deal with it:

1.  Just remove the asserts, which are bogus.  
2.  Disallow using characters `(`, `[`, `)`, `]` in metavar strings.
3.  Tighten up the [`part_regexp`](https://github.com/python/cpython/blob/2b44e302ec3079363c4d5c875677945953705c58/Lib/argparse.py#L328) pattern.
4.  Don't use regex.  


1 - The only consequence here would be that wrapped usage messages might be jacked-up if people use characters like `)` and `]` in their metavar strings.  But this seems like a sloppy and poor resolution.  
2 - a sound approach, but it's not backwards compat.  Using those troublesome characters in metavars only causes problems when there is line-wrapping, so users may have existing scripts which don't currently hit the issue, and those scripts would suddenly start failing.  That's a deal-breaker.  
4 - probably the most ideal approach, but it requires rewriting a large chunk of `argparse` code.  Some other guys tried this in issue11874.  Their patches have just been sitting there for 5 years with little interest, so I'm hesitant to go down that route again.  

Went with 3 in this PR.  The tightened up regex also matches a space (or end) after the closing bracket.  In fact it is not possible to solve the underlying issue exactly with regex, since metavar can theoretically be any arbitrary string.  After my patch, the `AssertionError` can still fire if a metavar contains a substring like `] -v [`.  That would be a much rarer/pathological case, unlike the current failure mode which users can and will bump into fairly easily.  `argparse.py` code is not pretty but the test coverage is quite good (1500+ tests) so I'm confident that improving the regex at least doesn't cause any extra issues.  

This is the "**practicality beats purity**" approach.   

<!-- issue-number: bpo-11874 -->
https://bugs.python.org/issue11874
<!-- /issue-number -->
