### PR TITLE
[3.5] Fix the signature of JSONDecodeError (no end parameter). (GH-1827)

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -485,7 +485,7 @@ Encoders and Decoders
 Exceptions
 ----------
 
-.. exception:: JSONDecodeError(msg, doc, pos, end=None)
+.. exception:: JSONDecodeError(msg, doc, pos)
 
    Subclass of :exc:`ValueError` with the following additional attributes:
 


### PR DESCRIPTION
Unlikely to the simplejson module, json.JSONDecodeError doesn't accept the end argument.
(cherry picked from commit 5becf38)