### PR TITLE
[3.6] bpo-30398: Add a docstring for re.error. (GH-1647)

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -828,15 +828,15 @@ form.
 
    .. attribute:: pos
 
-      The index of *pattern* where compilation failed.
+      The index in *pattern* where compilation failed (may be ``None``).
 
    .. attribute:: lineno
 
-      The line corresponding to *pos*.
+      The line corresponding to *pos* (may be ``None``).
 
    .. attribute:: colno
 
-      The column corresponding to *pos*.
+      The column corresponding to *pos* (may be ``None``).
 
    .. versionchanged:: 3.5
       Added additional attributes.

--- a/Lib/sre_constants.py
+++ b/Lib/sre_constants.py
@@ -21,6 +21,17 @@ from _sre import MAXREPEAT, MAXGROUPS
 # should this really be here?
 
 class error(Exception):
+    """Exception raised for invalid regular expressions.
+
+    Attributes:
+
+        msg: The unformatted error message
+        pattern: The regular expression pattern
+        pos: The index in the pattern where compilation failed (may be None)
+        lineno: The line corresponding to pos (may be None)
+        colno: The column corresponding to pos (may be None)
+    """
+
     def __init__(self, msg, pattern=None, pos=None):
         self.msg = msg
         self.pattern = pattern


### PR DESCRIPTION
Also document that some attributes may be None.
(cherry picked from commit 12d6b5d)