### PR TITLE
bpo-16500: Don't use string constants for os.register_at_fork() behavior

### DIFF
--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -49,10 +49,12 @@ Operating System Utilities
 
 .. c:function:: void PyOS_AfterFork_Child()
 
-   Function to update some internal state after a process fork.  This
-   should be called from the child process after calling :c:func:`fork`
-   or any similar function that clones the current process.
-   Only available on systems where :c:func:`fork` is defined.
+   Function to update internal interpreter state after a process fork.
+   This must be called from the child process after calling :c:func:`fork`,
+   or any similar function that clones the current process, if there is
+   any chance the process will call back into the Python interpreter.
+   Only available on systems where :c:func:`fork` is defined as determined
+   by the ``HAVE_FORK`` C preprocessor define.
 
    .. versionadded:: 3.7
 

--- a/Doc/c-api/sys.rst
+++ b/Doc/c-api/sys.rst
@@ -53,8 +53,7 @@ Operating System Utilities
    This must be called from the child process after calling :c:func:`fork`,
    or any similar function that clones the current process, if there is
    any chance the process will call back into the Python interpreter.
-   Only available on systems where :c:func:`fork` is defined as determined
-   by the ``HAVE_FORK`` C preprocessor define.
+   Only available on systems where :c:func:`fork` is defined.
 
    .. versionadded:: 3.7
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3284,7 +3284,8 @@ written in Python, such as a mail server's external command delivery program.
                                after_in_child=None)
 
    Register callables to be executed when a new child process is forked
-   using :func:`os.fork`.  The parameters are optional and keyword-only.
+   using :func:`os.fork` or similar process cloning APIs.
+   The parameters are optional and keyword-only.
    Each specifies a different call point.
 
    * *before* is a function called before forking a child process.

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3290,10 +3290,11 @@ written in Python, such as a mail server's external command delivery program.
    * *before* is a function called before forking a child process.
    * *after_in_parent* is a function called from the parent process
      after forking a child process.
-   * *after_in_child* is a function called from the child process
-     if control is expected to return to the Python interpreter.  A
-     typical :mod:`subprocess` launch will not trigger this as the
-     child is not going to return to the interpreter.
+   * *after_in_child* is a function called from the child process.
+
+   These calls are only made if control is expected to return to the
+   Python interpreter.  A typical :mod:`subprocess` launch will not
+   trigger them as the child is not going to re-enter the interpreter.
 
    Functions registered for execution before forking are called in
    reverse registration order.  Functions registered for execution

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3280,18 +3280,20 @@ written in Python, such as a mail server's external command delivery program.
    subprocesses.
 
 
-.. function:: register_at_fork(func, when)
+.. function:: register_at_fork(*, before=None, after_in_parent=None, \
+                               after_in_child=None)
 
-   Register *func* as a function to be executed when a new child process
-   is forked.  *when* is a constant specifying at which point the function is
-   called and can take the following values:
+   Register callables to be executed when a new child process is forked
+   using :func:`os.fork`.  The parameters are optional and keyword-only.
+   Each specifies a different call point.
 
-   * ``os.BEFORE_FORK`` means the function is called before forking a child
-     process.
-   * ``os.AFTER_FORK_PARENT`` means the function is called from the parent
-     process after forking a child process.
-   * ``os.AFTER_FORK_CHILD`` means the function is called from the child
-     process if control is expected to return to the Python interpreter.
+   * *before* is a function called before forking a child process.
+   * *after_in_parent* is a function called from the parent process
+     after forking a child process.
+   * *after_in_child* is a function called from the child process
+     if control is expected to return to the Python interpreter.  A
+     typical :mod:`subprocess` launch will not trigger this as the
+     child is not going to return to the interpreter.
 
    Functions registered for execution before forking are called in
    reverse registration order.  Functions registered for execution
@@ -3301,6 +3303,8 @@ written in Python, such as a mail server's external command delivery program.
    Note that :c:func:`fork` calls made by third-party C code may not
    call those functions, unless it explicitly calls :c:func:`PyOS_BeforeFork`,
    :c:func:`PyOS_AfterFork_Parent` and :c:func:`PyOS_AfterFork_Child`.
+
+   There is no way to unregister a function.
 
    Availability: Unix.
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3283,13 +3283,15 @@ written in Python, such as a mail server's external command delivery program.
 .. function:: register_at_fork(func, when)
 
    Register *func* as a function to be executed when a new child process
-   is forked.  *when* is a string specifying at which point the function is
+   is forked.  *when* is a constant specifying at which point the function is
    called and can take the following values:
 
-   * *"before"* means the function is called before forking a child process;
-   * *"parent"* means the function is called from the parent process after
-     forking a child process;
-   * *"child"* means the function is called from the child process.
+   * ``os.BEFORE_FORK`` means the function is called before forking a child
+     process.
+   * ``os.AFTER_FORK_PARENT`` means the function is called from the parent
+     process after forking a child process.
+   * ``os.AFTER_FORK_CHILD`` means the function is called from the child
+     process if control is expected to return to the Python interpreter.
 
    Functions registered for execution before forking are called in
    reverse registration order.  Functions registered for execution

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -94,6 +94,11 @@ from os.path import (curdir, pardir, sep, pathsep, defpath, extsep, altsep,
 
 del _names
 
+if _exists("register_at_fork"):
+    # Constants for use with os.register_at_fork()'s when parameter.
+    BEFORE_FORK = "before"
+    AFTER_FORK_CHILD = "child"
+    AFTER_FORK_PARENT = "parent"
 
 if _exists("_have_functions"):
     _globals = globals()

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -94,12 +94,6 @@ from os.path import (curdir, pardir, sep, pathsep, defpath, extsep, altsep,
 
 del _names
 
-if _exists("register_at_fork"):
-    # Constants for use with os.register_at_fork()'s when parameter.
-    BEFORE_FORK = "before"
-    AFTER_FORK_CHILD = "child"
-    AFTER_FORK_PARENT = "parent"
-
 if _exists("_have_functions"):
     _globals = globals()
     def _add(str, fn):

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -94,6 +94,7 @@ from os.path import (curdir, pardir, sep, pathsep, defpath, extsep, altsep,
 
 del _names
 
+
 if _exists("_have_functions"):
     _globals = globals()
     def _add(str, fn):

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -765,7 +765,7 @@ setstate = _inst.setstate
 getrandbits = _inst.getrandbits
 
 if hasattr(_os, "fork"):
-    _os.register_at_fork(_inst.seed, when=_os.AFTER_FORK_CHILD)
+    _os.register_at_fork(after_in_child=_inst.seed)
 
 
 if __name__ == '__main__':

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -765,7 +765,7 @@ setstate = _inst.setstate
 getrandbits = _inst.getrandbits
 
 if hasattr(_os, "fork"):
-    _os.register_at_fork(_inst.seed, when='child')
+    _os.register_at_fork(_inst.seed, when=_os.AFTER_FORK_CHILD)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -189,19 +189,19 @@ class PosixTester(unittest.TestCase):
             self.assertEqual(pid, res.si_pid)
 
     @unittest.skipUnless(hasattr(os, 'fork'), "test needs os.fork()")
-    def test_register_after_fork(self):
+    def test_register_at_fork(self):
         code = """if 1:
             import os
 
             r, w = os.pipe()
             fin_r, fin_w = os.pipe()
 
-            os.register_at_fork(lambda: os.write(w, b'A'), when='before')
-            os.register_at_fork(lambda: os.write(w, b'B'), when='before')
-            os.register_at_fork(lambda: os.write(w, b'C'), when='parent')
-            os.register_at_fork(lambda: os.write(w, b'D'), when='parent')
-            os.register_at_fork(lambda: os.write(w, b'E'), when='child')
-            os.register_at_fork(lambda: os.write(w, b'F'), when='child')
+            os.register_at_fork(lambda: os.write(w, b'A'), when=os.BEFORE_FORK)
+            os.register_at_fork(lambda: os.write(w, b'B'), when=os.BEFORE_FORK)
+            os.register_at_fork(lambda: os.write(w, b'C'), when=os.AFTER_FORK_PARENT)
+            os.register_at_fork(lambda: os.write(w, b'D'), when=os.AFTER_FORK_PARENT)
+            os.register_at_fork(lambda: os.write(w, b'E'), when=os.AFTER_FORK_CHILD)
+            os.register_at_fork(lambda: os.write(w, b'F'), when=os.AFTER_FORK_CHILD)
 
             pid = os.fork()
             if pid == 0:

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -193,11 +193,23 @@ class PosixTester(unittest.TestCase):
         with self.assertRaises(TypeError, msg="Positional args not allowed"):
             os.register_at_fork(lambda: None)
         with self.assertRaises(TypeError, msg="Args must be callable"):
-            os.register_at_fork(before=2, after_in_child="three",
-                                after_in_parent=b"Five")
+            os.register_at_fork(before=2)
+        with self.assertRaises(TypeError, msg="Args must be callable"):
+            os.register_at_fork(after_in_child="three")
+        with self.assertRaises(TypeError, msg="Args must be callable"):
+            os.register_at_fork(after_in_parent=b"Five")
         with self.assertRaises(TypeError, msg="Args must not be None"):
-            os.register_at_fork(before=None, after_in_child=None,
-                                after_in_parent=None)
+            os.register_at_fork(before=None)
+        with self.assertRaises(TypeError, msg="Args must not be None"):
+            os.register_at_fork(after_in_child=None)
+        with self.assertRaises(TypeError, msg="Args must not be None"):
+            os.register_at_fork(after_in_parent=None)
+        with self.assertRaises(TypeError, msg="Invalid arg was allowed"):
+            # Ensure a combination of valid and invalid is an error.
+            os.register_at_fork(before=None, after_in_parent=lambda: 3)
+        with self.assertRaises(TypeError, msg="Invalid arg was allowed"):
+            # Ensure a combination of valid and invalid is an error.
+            os.register_at_fork(before=lambda: None, after_in_child='')
         # We test actual registrations in their own process so as not to
         # pollute this one.  There is no way to unregister for cleanup.
         code = """if 1:

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1359,5 +1359,5 @@ def _after_fork():
         assert len(_active) == 1
 
 
-if hasattr(_os, "fork"):
-    _os.register_at_fork(_after_fork, when="child")
+if hasattr(_os, "register_at_fork"):
+    _os.register_at_fork(after_in_child=_after_fork)

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1832,7 +1832,7 @@ PyDoc_STRVAR(os_register_at_fork__doc__,
 "                 after_in_parent=None)\n"
 "--\n"
 "\n"
-"Register a code to be called when forking a new process via os.fork().\n"
+"Register a callable to be called when forking a new process via os.fork().\n"
 "\n"
 "  before\n"
 "    Zero arg callable to be called in the parent before the fork() syscall.\n"
@@ -6546,4 +6546,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=27bab718edec64c6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=19831e9abadaac28 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1832,18 +1832,17 @@ PyDoc_STRVAR(os_register_at_fork__doc__,
 "                 after_in_parent=None)\n"
 "--\n"
 "\n"
-"Register a callable to be called when forking a new process via os.fork().\n"
+"Registers callables to be called when forking a new process.\n"
 "\n"
 "  before\n"
-"    Zero arg callable to be called in the parent before the fork() syscall.\n"
+"    A callable to be called in the parent before the fork() syscall.\n"
 "  after_in_child\n"
-"    Zero arg callable to be called in the child before os.fork() returns.\n"
+"    A callable to be called in the child after fork().\n"
 "  after_in_parent\n"
-"    Zero arg callable to be called in the parent before os.fork() returns.\n"
+"    A callable to be called in the parent after fork().\n"
 "\n"
-"\'before\' callbacks are called in reverse order before forking.\n"
-"\'after_in_child\' callbacks are called in order after forking in the child.\n"
-"\'after_in_parent\' callbacks are called in order after forking in the parent.");
+"\'before\' callbacks are called in reverse order.\n"
+"\'after_in_child\' and \'after_in_parent\' callbacks are called in order.");
 
 #define OS_REGISTER_AT_FORK_METHODDEF    \
     {"register_at_fork", (PyCFunction)os_register_at_fork, METH_FASTCALL, os_register_at_fork__doc__},
@@ -6546,4 +6545,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=e87a841007afa62b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1c548b06f18b8358 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1841,9 +1841,9 @@ PyDoc_STRVAR(os_register_at_fork__doc__,
 "  after_in_parent\n"
 "    Zero arg callable to be called in the parent before os.fork() returns.\n"
 "\n"
-"``before`` callbacks are called in reverse order before forking.\n"
-"``after_in_child`` callbacks are called in order after forking in the child.\n"
-"``after_in_parent`` callbacks are called in order after forking in the parent.");
+"\'before\' callbacks are called in reverse order before forking.\n"
+"\'after_in_child\' callbacks are called in order after forking in the child.\n"
+"\'after_in_parent\' callbacks are called in order after forking in the parent.");
 
 #define OS_REGISTER_AT_FORK_METHODDEF    \
     {"register_at_fork", (PyCFunction)os_register_at_fork, METH_FASTCALL, os_register_at_fork__doc__},
@@ -6546,4 +6546,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=19831e9abadaac28 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e87a841007afa62b input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1832,7 +1832,7 @@ PyDoc_STRVAR(os_register_at_fork__doc__,
 "                 after_in_parent=None)\n"
 "--\n"
 "\n"
-"Registers callables to be called when forking a new process.\n"
+"Register callables to be called when forking a new process.\n"
 "\n"
 "  before\n"
 "    A callable to be called in the parent before the fork() syscall.\n"
@@ -6545,4 +6545,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=1c548b06f18b8358 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dce741f527ddbfa4 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1828,40 +1828,45 @@ exit:
 #if defined(HAVE_FORK)
 
 PyDoc_STRVAR(os_register_at_fork__doc__,
-"register_at_fork($module, func, /, when)\n"
+"register_at_fork($module, /, *, before=None, after_in_child=None,\n"
+"                 after_in_parent=None)\n"
 "--\n"
 "\n"
-"Register a callable object to be called when forking.\n"
+"Register a code to be called when forking a new process via os.fork().\n"
 "\n"
-"  func\n"
-"    Function or callable\n"
-"  when\n"
-"    os.BEFORE_FORK, os.AFTER_FORK_CHILD, os.AFTER_FORK_PARENT\n"
+"  before\n"
+"    Zero arg callable to be called in the parent before the fork() syscall.\n"
+"  after_in_child\n"
+"    Zero arg callable to be called in the child before os.fork() returns.\n"
+"  after_in_parent\n"
+"    Zero arg callable to be called in the parent before os.fork() returns.\n"
 "\n"
-"os.BEFORE_FORK callbacks are called in reverse order before forking.\n"
-"os.AFTER_FORK_CHILD callbacks are called in order after forking, in the child process.\n"
-"os.AFTER_FORK_PARENT callbacks are called in order after forking, in the parent process.");
+"``before`` callbacks are called in reverse order before forking.\n"
+"``after_in_child`` callbacks are called in order after forking in the child.\n"
+"``after_in_parent`` callbacks are called in order after forking in the parent.");
 
 #define OS_REGISTER_AT_FORK_METHODDEF    \
     {"register_at_fork", (PyCFunction)os_register_at_fork, METH_FASTCALL, os_register_at_fork__doc__},
 
 static PyObject *
-os_register_at_fork_impl(PyObject *module, PyObject *func, const char *when);
+os_register_at_fork_impl(PyObject *module, PyObject *before,
+                         PyObject *after_in_child, PyObject *after_in_parent);
 
 static PyObject *
 os_register_at_fork(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"", "when", NULL};
-    static _PyArg_Parser _parser = {"Os:register_at_fork", _keywords, 0};
-    PyObject *func;
-    const char *when;
+    static const char * const _keywords[] = {"before", "after_in_child", "after_in_parent", NULL};
+    static _PyArg_Parser _parser = {"|$OOO:register_at_fork", _keywords, 0};
+    PyObject *before = NULL;
+    PyObject *after_in_child = NULL;
+    PyObject *after_in_parent = NULL;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
-        &func, &when)) {
+        &before, &after_in_child, &after_in_parent)) {
         goto exit;
     }
-    return_value = os_register_at_fork_impl(module, func, when);
+    return_value = os_register_at_fork_impl(module, before, after_in_child, after_in_parent);
 
 exit:
     return return_value;
@@ -6541,4 +6546,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=30f4881161078e93 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=27bab718edec64c6 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1836,11 +1836,11 @@ PyDoc_STRVAR(os_register_at_fork__doc__,
 "  func\n"
 "    Function or callable\n"
 "  when\n"
-"    \'before\', \'child\' or \'parent\'\n"
+"    os.BEFORE_FORK, os.AFTER_FORK_CHILD, os.AFTER_FORK_PARENT\n"
 "\n"
-"\'before\' callbacks are called in reverse order before forking.\n"
-"\'child\' callbacks are called in order after forking, in the child process.\n"
-"\'parent\' callbacks are called in order after forking, in the parent process.");
+"os.BEFORE_FORK callbacks are called in reverse order before forking.\n"
+"os.AFTER_FORK_CHILD callbacks are called in order after forking, in the child process.\n"
+"os.AFTER_FORK_PARENT callbacks are called in order after forking, in the parent process.");
 
 #define OS_REGISTER_AT_FORK_METHODDEF    \
     {"register_at_fork", (PyCFunction)os_register_at_fork, METH_FASTCALL, os_register_at_fork__doc__},
@@ -6541,4 +6541,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=699e11c5579a104e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=30f4881161078e93 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5322,16 +5322,16 @@ os.register_at_fork
 
 Register a callable to be called when forking a new process via os.fork().
 
-``before`` callbacks are called in reverse order before forking.
-``after_in_child`` callbacks are called in order after forking in the child.
-``after_in_parent`` callbacks are called in order after forking in the parent.
+'before' callbacks are called in reverse order before forking.
+'after_in_child' callbacks are called in order after forking in the child.
+'after_in_parent' callbacks are called in order after forking in the parent.
 
 [clinic start generated code]*/
 
 static PyObject *
 os_register_at_fork_impl(PyObject *module, PyObject *before,
                          PyObject *after_in_child, PyObject *after_in_parent)
-/*[clinic end generated code: output=5398ac75e8e97625 input=d69dbd16e6e48e66]*/
+/*[clinic end generated code: output=5398ac75e8e97625 input=44962e2b3bb9ce2e]*/
 {
     PyInterpreterState *interp;
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5337,7 +5337,7 @@ os.register_at_fork
     after_in_parent: object=NULL
         A callable to be called in the parent after fork().
 
-Registers callables to be called when forking a new process.
+Register callables to be called when forking a new process.
 
 'before' callbacks are called in reverse order.
 'after_in_child' and 'after_in_parent' callbacks are called in order.
@@ -5347,7 +5347,7 @@ Registers callables to be called when forking a new process.
 static PyObject *
 os_register_at_fork_impl(PyObject *module, PyObject *before,
                          PyObject *after_in_child, PyObject *after_in_parent)
-/*[clinic end generated code: output=5398ac75e8e97625 input=78bc3d28ba7bf117]*/
+/*[clinic end generated code: output=5398ac75e8e97625 input=cd1187aa85d2312e]*/
 {
     PyInterpreterState *interp;
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5313,7 +5313,7 @@ os_spawnve_impl(PyObject *module, int mode, path_t *path, PyObject *argv,
 #ifdef HAVE_FORK
 
 /* Helper function to validate arguments.
-   Returns 0 on success.  1 on failure with a TypeError raised.
+   Returns 0 on success.  non-zero on failure with a TypeError raised.
    If obj is non-NULL it must be callable.  */
 static int
 check_null_or_callable(PyObject *obj, const char* obj_name)
@@ -5321,7 +5321,7 @@ check_null_or_callable(PyObject *obj, const char* obj_name)
     if (obj && !PyCallable_Check(obj)) {
         PyErr_Format(PyExc_TypeError, "'%s' must be callable, not %R",
                      obj_name, Py_TYPE(obj));
-        return 1;
+        return -1;
     }
     return 0;
 }
@@ -5331,24 +5331,23 @@ os.register_at_fork
 
     *
     before: object=NULL
-        Zero arg callable to be called in the parent before the fork() syscall.
+        A callable to be called in the parent before the fork() syscall.
     after_in_child: object=NULL
-        Zero arg callable to be called in the child before os.fork() returns.
+        A callable to be called in the child after fork().
     after_in_parent: object=NULL
-        Zero arg callable to be called in the parent before os.fork() returns.
+        A callable to be called in the parent after fork().
 
-Register a callable to be called when forking a new process via os.fork().
+Registers callables to be called when forking a new process.
 
-'before' callbacks are called in reverse order before forking.
-'after_in_child' callbacks are called in order after forking in the child.
-'after_in_parent' callbacks are called in order after forking in the parent.
+'before' callbacks are called in reverse order.
+'after_in_child' and 'after_in_parent' callbacks are called in order.
 
 [clinic start generated code]*/
 
 static PyObject *
 os_register_at_fork_impl(PyObject *module, PyObject *before,
                          PyObject *after_in_child, PyObject *after_in_parent)
-/*[clinic end generated code: output=5398ac75e8e97625 input=44962e2b3bb9ce2e]*/
+/*[clinic end generated code: output=5398ac75e8e97625 input=78bc3d28ba7bf117]*/
 {
     PyInterpreterState *interp;
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5319,8 +5319,8 @@ static int
 check_null_or_callable(PyObject *obj, const char* obj_name)
 {
     if (obj && !PyCallable_Check(obj)) {
-        PyErr_Format(PyExc_TypeError, "'%s' must be callable, not %R",
-                     obj_name, Py_TYPE(obj));
+        PyErr_Format(PyExc_TypeError, "'%s' must be callable, not %s",
+                     obj_name, Py_TYPE(obj)->tp_name);
         return -1;
     }
     return 0;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5316,19 +5316,19 @@ os.register_at_fork
         Function or callable
     /
     when: str
-        'before', 'child' or 'parent'
+        os.BEFORE_FORK, os.AFTER_FORK_CHILD, os.AFTER_FORK_PARENT
 
 Register a callable object to be called when forking.
 
-'before' callbacks are called in reverse order before forking.
-'child' callbacks are called in order after forking, in the child process.
-'parent' callbacks are called in order after forking, in the parent process.
+os.BEFORE_FORK callbacks are called in reverse order before forking.
+os.AFTER_FORK_CHILD callbacks are called in order after forking, in the child process.
+os.AFTER_FORK_PARENT callbacks are called in order after forking, in the parent process.
 
 [clinic start generated code]*/
 
 static PyObject *
 os_register_at_fork_impl(PyObject *module, PyObject *func, const char *when)
-/*[clinic end generated code: output=8943be81a644750c input=5fc05efa4d42eb84]*/
+/*[clinic end generated code: output=8943be81a644750c input=fde1c6bde63beb91]*/
 {
     PyInterpreterState *interp;
     PyObject **lst;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5320,7 +5320,7 @@ os.register_at_fork
     after_in_parent: object=NULL
         Zero arg callable to be called in the parent before os.fork() returns.
 
-Register a code to be called when forking a new process via os.fork().
+Register a callable to be called when forking a new process via os.fork().
 
 ``before`` callbacks are called in reverse order before forking.
 ``after_in_child`` callbacks are called in order after forking in the child.
@@ -5331,7 +5331,7 @@ Register a code to be called when forking a new process via os.fork().
 static PyObject *
 os_register_at_fork_impl(PyObject *module, PyObject *before,
                          PyObject *after_in_child, PyObject *after_in_parent)
-/*[clinic end generated code: output=5398ac75e8e97625 input=19db3f3cb0d7017a]*/
+/*[clinic end generated code: output=5398ac75e8e97625 input=d69dbd16e6e48e66]*/
 {
     PyInterpreterState *interp;
 


### PR DESCRIPTION
Add `os` module constants and updates all uses and documentation instead of string literals.
This allows for cleaner code with less chance of a typo in a string value showing up at runtime.
Linters and similar tools can flag incorrect constant names before run time.