### PR TITLE
bpo-29626: spacing issue when using help in argparse

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -553,7 +553,10 @@ class HelpFormatter(object):
                 default = self._get_default_metavar_for_optional(action)
                 args_string = self._format_args(action, default)
                 for option_string in action.option_strings:
-                    parts.append('%s %s' % (option_string, args_string))
+                    if args_string:
+                        parts.append('%s %s' % (option_string, args_string))
+                    else:
+                        parts.append('%s' % (option_string))
 
             return ', '.join(parts)
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -556,7 +556,7 @@ class HelpFormatter(object):
                     if args_string:
                         parts.append('%s %s' % (option_string, args_string))
                     else:
-                        parts.append('%s' % (option_string))
+                        parts.append('%s' % (option_string,))
 
             return ', '.join(parts)
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -3893,6 +3893,26 @@ class TestHelpNone(HelpTestCase):
     version = ''
 
 
+class TestHelpEmptyStringMetavar(HelpTestCase):
+    """Test specifying metavar as an empty string."""
+
+    parser_signature = Sig(prog='PROG')
+    argument_signatures = [
+        Sig('-f', '--foo', metavar=''),
+    ]
+    argument_group_signatures = []
+    usage = '''\
+        usage: PROG [-h] [-f]
+        '''
+    help = usage + '''\
+
+        optional arguments:
+          -h, --help  show this help message and exit
+          -f, --foo
+        '''
+    version = ''
+
+
 class TestHelpTupleMetavar(HelpTestCase):
     """Test specifying metavar as a tuple"""
 


### PR DESCRIPTION
A  metavar value of an empty string was causing an extra space to be printed in argparse help.

For example, the created test case was printing:
-f , --foo   (extra space before the comma)
instead of
-f, --foo
