### PR TITLE
bpo-30492: Allow make clinic to work out of tree.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -528,7 +528,7 @@ coverage-report: regen-grammar regen-importlib
 # (depends on python having already been built)
 .PHONY=clinic
 clinic: $(BUILDPYTHON) $(srcdir)/Modules/_blake2/blake2s_impl.c
-	$(RUNSHARED) $(PYTHON_FOR_BUILD) ./Tools/clinic/clinic.py --make
+	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(srcdir)/Tools/clinic/clinic.py --make --srcdir $(srcdir)
 
 # Build the interpreter
 $(BUILDPYTHON):	Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4335,7 +4335,10 @@ def main(argv):
     cmdline.add_argument("-o", "--output", type=str)
     cmdline.add_argument("-v", "--verbose", action='store_true')
     cmdline.add_argument("--converters", action='store_true')
-    cmdline.add_argument("--make", action='store_true')
+    cmdline.add_argument("--make", action='store_true',
+                         help="Walk --srcdir to run over all relevant files.")
+    cmdline.add_argument("--srcdir", type=str, default=".",
+                         help="The directory tree to walk in --make mode.")
     cmdline.add_argument("filename", type=str, nargs="*")
     ns = cmdline.parse_args(argv)
 
@@ -4406,7 +4409,12 @@ def main(argv):
             print()
             cmdline.print_usage()
             sys.exit(-1)
-        for root, dirs, files in os.walk('.'):
+        if not ns.srcdir:
+            print("Usage error: --srcdir must not be empty with --make.")
+            print()
+            cmdline.print_usage()
+            sys.exit(-1)
+        for root, dirs, files in os.walk(ns.srcdir):
             for rcs_dir in ('.svn', '.git', '.hg', 'build', 'externals'):
                 if rcs_dir in dirs:
                     dirs.remove(rcs_dir)

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4337,7 +4337,7 @@ def main(argv):
     cmdline.add_argument("--converters", action='store_true')
     cmdline.add_argument("--make", action='store_true',
                          help="Walk --srcdir to run over all relevant files.")
-    cmdline.add_argument("--srcdir", type=str, default=".",
+    cmdline.add_argument("--srcdir", type=str, default=os.curdir,
                          help="The directory tree to walk in --make mode.")
     cmdline.add_argument("filename", type=str, nargs="*")
     ns = cmdline.parse_args(argv)


### PR DESCRIPTION
This allows `make clinic` to work when run out of the source tree.