### PR TITLE
bpo-30493: Increase base64 coverage

### DIFF
--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -511,6 +511,9 @@ class BaseXYTestCase(unittest.TestCase):
         eq(base64.a85decode(b'y+<U', foldspaces=True, adobe=False), b' '*6)
         eq(base64.a85decode(b'y+9', foldspaces=True, adobe=False), b' '*5)
 
+        self.assertRaises(ValueError, base64.a85decode, b'aaaay', foldspaces=True)
+        eq(base64.a85decode(b'aaaaay', foldspaces=True), b'\xc9\x80\x0b@    ')
+
         self.check_other_types(base64.a85decode, b'GB\\6`E-ZP=Df.1GEb>',
                                b"www.python.org")
 


### PR DESCRIPTION
Added tests to ensure a85decode correctly handles the 'y' character within the byte like object when foldspaces is true.


While attempting to increase coverage I found two lines of code within base64.py that appear to never execute:
  - line 472
  - line 501


Line 472:
The only time the TypeError except block (line 467) executes is when _b85dec[c] resolves to None for one of the c (characters) in chunk.

Then within the except block the c (characters) within chunk are iterated through until the None is hit then a ValueError is raised (line 470). Making it impossible for line 472 to execute.


Line 501:
s is assigned a value in the expression `s = input.read(MAXBINSIZE)` (line 494), due to this len(s) is only ever not equal to MAXBINSIZE if the end of input has been reached and nothing was read or the last chunk of data was read from input which has a len less than MAXBINSIZE but non-zero.

Therefore the only way to enter into the while loop (line 497) is if there are no more characters left to be read from input, yet all that happens in the while loop is the read function is called on input with a non zero parameter (`MAXBINSIZE-len(s)` must be greater than zero for the while to have executed) then when it returns nothing (it always will) execution breaks out of the while loop without modifiying s.