### PR TITLE
bpo-30530: Descriptor HowTo: update Function.__get__

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -282,7 +282,7 @@ this::
         . . .
         def __get__(self, obj, objtype=None):
             "Simulate func_descr_get() in Objects/funcobject.c"
-            return types.MethodType(self, obj, objtype)
+            return types.MethodType(self, obj)
 
 Running the interpreter shows how the function descriptor works in practice::
 


### PR DESCRIPTION
The creation of the method like in the example did not work, because in
Python 3.6 ``MethodType`` takes 2 arguments (not 3). In Python 2 works,
so the fix is for Python 3.6 and up.

```
...
TypeError: method expected 2 arguments, got 3
```