### PR TITLE
[2.7] bpo-29766: Do not force --with-lto to true for --enable-optimizations

### DIFF
--- a/configure
+++ b/configure
@@ -6399,7 +6399,6 @@ if test "$Py_OPT" = 'true' ; then
   # compile working code using it and both test_distutils and test_gdb are
   # broken when you do managed to get a toolchain that works with it.  People
   # who want LTO need to use --with-lto themselves.
-  Py_LTO='true'
   DEF_MAKE_ALL_RULE="profile-opt"
   REQUIRE_PGO="yes"
   DEF_MAKE_RULE="build_all"


### PR DESCRIPTION
This fixes a faulty backport to the Python 2.7 branch only of https://bugs.python.org/issue28032. Details in the https://bugs.python.org/issue29766.

Pinging @gpshead as it was his change ;)