### PR TITLE
[3.6] bpo-17188: add missing periods at the end of sentences (GH-1875)

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -630,11 +630,11 @@ Additional information on exceptions can be found in section :ref:`exceptions`,
 and information about handling exceptions is in section :ref:`try`.
 
 .. versionchanged:: 3.3
-    :const:`None` is now permitted as ``Y`` in ``raise X from Y``
+    :const:`None` is now permitted as ``Y`` in ``raise X from Y``.
 
 .. versionadded:: 3.3
     The ``__suppress_context__`` attribute to suppress automatic display of the
-    exception context
+    exception context.
 
 .. _break:
 


### PR DESCRIPTION
(cherry picked from commit 9efad1e5aef32a6d8ca288793e8ee6df8782f615)