### PR TITLE
bpo-30519: Add daemon keyword to Timer class constructor

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -850,12 +850,14 @@ For example::
    t.start()  # after 30 seconds, "hello, world" will be printed
 
 
-.. class:: Timer(interval, function, args=None, kwargs=None)
+.. class:: Timer(interval, function, args=None, kwargs=None, daemon=None)
 
    Create a timer that will run *function* with arguments *args* and  keyword
    arguments *kwargs*, after *interval* seconds have passed.
    If *args* is ``None`` (the default) then an empty list will be used.
    If *kwargs* is ``None`` (the default) then an empty dict will be used.
+   The *daemon* argument behaves identically to that of the same name in the
+   :class:`Thread` constructor.
 
    .. versionchanged:: 3.3
       changed from a factory function to a class.

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1160,14 +1160,14 @@ class Thread:
 class Timer(Thread):
     """Call a function after a specified number of seconds:
 
-            t = Timer(30.0, f, args=None, kwargs=None)
+            t = Timer(30.0, f, args=None, kwargs=None, daemon=None)
             t.start()
             t.cancel()     # stop the timer's action if it's still waiting
 
     """
 
-    def __init__(self, interval, function, args=None, kwargs=None):
-        Thread.__init__(self)
+    def __init__(self, interval, function, args=None, kwargs=None, daemon=None):
+        Thread.__init__(self, daemon=daemon)
         self.interval = interval
         self.function = function
         self.args = args if args is not None else []


### PR DESCRIPTION
Currently in order to have daemonic Timer objects one must instantiate the class, set daemonic status through the property (Timer.daemon=True), and then start the Timer. It would be nice to have the ability to set the daemonic status of the Timer class during instantiation, similar to what is possible with the Thread superclass.