### PR TITLE
Reinstate the lost job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     - os: linux
       language: c
       compiler: clang
+      # gcc also works, but to keep the # of concurrent builds down, we use one C
+      # compiler here and the other to run the coverage build.
       env:
         - TESTING=cpython
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,17 @@ branches:
     - master
     - /^\d\.\d$/
 
-os:
-  - linux
-  # macOS builds are disabled as the machines are under-provisioned on Travis,
-  # adding up to an extra hour completing a full CI run.
-
-compiler:
-  - clang
-  # gcc also works, but to keep the # of concurrent builds down, we use one C
-  # compiler here and the other to run the coverage build.
-
-env:
-  - TESTING=cpython
-
 matrix:
   fast_finish: true
   allow_failures:
     - env:
        - TESTING=coverage
   include:
+    - os: linux
+      language: c
+      compiler: clang
+      env:
+        - TESTING=cpython
     - os: linux
       language: python
       # Build the docs against a stable version of Python so code bugs don't hold up doc-related PRs.


### PR DESCRIPTION
Travis CI changed the behavior with regards to the default job when there is only one is defined at the top level and many are additionally defined in `matrix.include`. (See https://github.com/travis-ci/travis-ci/issues/4681 for discussion.)

This PR reinstates the job which is no longer generated as a result.