### PR TITLE
[3.6] Fix a trivial typo in global section (GH-1497)

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -940,7 +940,7 @@ annotation.
    builtin: eval
    builtin: compile
 
-**Programmer's note:** the :keyword:`global` is a directive to the parser.  It
+**Programmer's note:** :keyword:`global` is a directive to the parser.  It
 applies only to code parsed at the same time as the :keyword:`global` statement.
 In particular, a :keyword:`global` statement contained in a string or code
 object supplied to the built-in :func:`exec` function does not affect the code


### PR DESCRIPTION
(cherry picked from commit f34c6850203a2406c4950af7a9c8a134145df4ea)