### PR TITLE
[2.7] Fix a trivial typo in global section (GH-1497)

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -972,7 +972,7 @@ definition, function definition, or :keyword:`import` statement.
    builtin: execfile
    builtin: compile
 
-**Programmer's note:** the :keyword:`global` is a directive to the parser.  It
+**Programmer's note:** :keyword:`global` is a directive to the parser.  It
 applies only to code parsed at the same time as the :keyword:`global` statement.
 In particular, a :keyword:`global` statement contained in an :keyword:`exec`
 statement does not affect the code block *containing* the :keyword:`exec`


### PR DESCRIPTION
(cherry picked from commit f34c6850203a2406c4950af7a9c8a134145df4ea)