### PR TITLE
[3.5] Fix Travis config to reinstate test build (GH-1879)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,25 +11,19 @@ branches:
     - master
     - /^\d\.\d$/
 
-os:
-  - linux
-  # macOS builds are disabled as the machines are under-provisioned on Travis,
-  # adding up to an extra hour completing a full CI run.
-
-compiler:
-  - clang
-  # gcc also works, but to keep the # of concurrent builds down, we use one C
-  # compiler here and the other to run the coverage build.
-
-env:
-  - TESTING=cpython
-
 matrix:
   fast_finish: true
   allow_failures:
     - env:
        - TESTING=coverage
   include:
+    - os: linux
+      language: c
+      compiler: clang
+      # gcc also works, but to keep the # of concurrent builds down, we use one C
+      # compiler here and the other to run the coverage build.
+      env:
+        - TESTING=cpython
     - os: linux
       language: python
       python: 3.6


### PR DESCRIPTION
(cherry picked from commit a5aa72ac789052411797c6f079ffff0a9fdbf82c)