### PR TITLE
bpo-30532: email.policy.SMTP.fold() mangles long headers

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -341,8 +341,6 @@ class TokenList(list):
             # avoid infinite recursion.
             ws = part.pop_leading_fws()
             if ws is not None:
-                # Peel off the leading whitespace and make it sticky, to
-                # avoid infinite recursion.
                 folded.stickyspace = ws
                 if folded.append_if_fits(part):
                     continue

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -343,7 +343,7 @@ class TokenList(list):
             if ws is not None:
                 # Peel off the leading whitespace and make it sticky, to
                 # avoid infinite recursion.
-                folded.stickyspace = str(part.pop(0))
+                folded.stickyspace = ws
                 if folded.append_if_fits(part):
                     continue
             if part.has_fws:

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -341,7 +341,7 @@ class TokenList(list):
             # avoid infinite recursion.
             ws = part.pop_leading_fws()
             if ws is not None:
-                folded.stickyspace = ws
+                folded.stickyspace = str(ws)
                 if folded.append_if_fits(part):
                     continue
             if part.has_fws:

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2711,5 +2711,17 @@ class TestFolding(TestEmailBase):
         self._test(parser.get_unstructured('xxx   ' + 'y'*77),
                    'xxx  \n ' + 'y'*77 + '\n')
 
+    def test_long_filename_attachment(self):
+        folded = self.policy.fold('Content-Disposition', 'attachment; filename="TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TES.txt"')
+        self.assertEqual(
+            'Content-Disposition: attachment;\n filename="TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TES.txt"\n',
+            folded
+        )
+        folded = self.policy.fold('Content-Disposition', 'attachment; filename="TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_T.txt"')
+        self.assertEqual(
+            'Content-Disposition: attachment;\n filename="TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_TEST_T.txt"\n',
+            folded
+        )
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -628,6 +628,7 @@ Wouter van Heyst
 Kelsey Hightower
 Jason Hildebrand
 Aaron Hill
+Joel Hillacre
 Richie Hindle
 Konrad Hinsen
 David Hobley

--- a/Misc/NEWS.d/next/Library/2017-06-26-11-01-59.bpo-30532.qTeL1o.rst
+++ b/Misc/NEWS.d/next/Library/2017-06-26-11-01-59.bpo-30532.qTeL1o.rst
@@ -1,0 +1,1 @@
+Fix email header value parser dropping folding white space in certain cases.


### PR DESCRIPTION
Pull request for http://bugs.python.org/issue30532