### PR TITLE
[2.7] bpo-22702: Clarify documentation of str.join & bytes.join (GH-156)

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1068,9 +1068,10 @@ string functions based on regular expressions.
 
 .. method:: str.join(iterable)
 
-   Return a string which is the concatenation of the strings in the
-   :term:`iterable` *iterable*.  The separator between elements is the string
-   providing this method.
+   Return a string which is the concatenation of the strings in *iterable*.
+   A :exc:`TypeError` will be raised if there are any non-string values in
+   *iterable*, including :class:`bytes` objects.  The separator between
+   elements is the string providing this method.
 
 
 .. method:: str.ljust(width[, fillchar])


### PR DESCRIPTION
The "iterable iterable" phrasing created confusion between the term
reference and the parameter name.

This simplifies the phrasing to just use the parameter name
without linking directly to the term definition..
(cherry picked from commit 08e2f355d04d3cbea5751ce1275306ee3f569b32)