### PR TITLE
bpo-30436: Fix exception raised for invalid parent.

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1215,6 +1215,10 @@ an :term:`importer`.
 
    .. versionadded:: 3.4
 
+   .. versionchanged:: 3.7
+      Raises :exc:`ModuleNotFoundError` instead of :exc:`AttributeError` if
+      **package** can be imported but is missing the :attr:`__path__` attribute.
+
 .. function:: module_from_spec(spec)
 
    Create a new module based on **spec** and

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1217,7 +1217,8 @@ an :term:`importer`.
 
    .. versionchanged:: 3.7
       Raises :exc:`ModuleNotFoundError` instead of :exc:`AttributeError` if
-      **package** can be imported but is missing the :attr:`__path__` attribute.
+      **package** is in fact not a package (i.e. lacks a :attr:`__path__`
+      attribute).
 
 .. function:: module_from_spec(spec)
 

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -84,11 +84,16 @@ def find_spec(name, package=None):
     if fullname not in sys.modules:
         parent_name = fullname.rpartition('.')[0]
         if parent_name:
-            # Use builtins.__import__() in case someone replaced it.
-            parent = __import__(parent_name, fromlist=['__path__'])
-            return _find_spec(fullname, parent.__path__)
+            try:
+                parent_path = __import__(parent_name,
+                                         fromlist=['__path__']).__path__
+            except AttributeError as e:
+                raise ModuleNotFoundError(
+                    "Error while finding module specification for '{}'.".format(
+                        fullname)) from e
         else:
-            return _find_spec(fullname, None)
+            parent_path = None
+        return _find_spec(fullname, parent_path)
     else:
         module = sys.modules[fullname]
         if module is None:

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -89,8 +89,8 @@ def find_spec(name, package=None):
                                          fromlist=['__path__']).__path__
             except AttributeError as e:
                 raise ModuleNotFoundError(
-                    "Error while finding module specification for '{}'.".format(
-                        fullname)) from e
+                    "Error while finding module specification for '{}'."
+                    .format(fullname), name=fullname) from e
         else:
             parent_path = None
         return _find_spec(fullname, parent_path)

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -84,13 +84,13 @@ def find_spec(name, package=None):
     if fullname not in sys.modules:
         parent_name = fullname.rpartition('.')[0]
         if parent_name:
+            parent = __import__(parent_name, fromlist=['__path__'])
             try:
-                parent_path = __import__(parent_name,
-                                         fromlist=['__path__']).__path__
+                parent_path = parent.__path__
             except AttributeError as e:
                 raise ModuleNotFoundError(
-                    "Error while finding module specification for '{}'."
-                    .format(fullname), name=fullname) from e
+                    f"Error while finding module specification for "
+                    f"'{fullname}'.", name=fullname) from e
         else:
             parent_path = None
         return _find_spec(fullname, parent_path)

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -89,7 +89,7 @@ def find_spec(name, package=None):
                 parent_path = parent.__path__
             except AttributeError as e:
                 raise ModuleNotFoundError(
-                    f"Error while finding module specification for "
+                    "Error while finding module specification for "
                     f"'{fullname}'.", name=fullname) from e
         else:
             parent_path = None

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -90,7 +90,7 @@ def find_spec(name, package=None):
             except AttributeError as e:
                 raise ModuleNotFoundError(
                     f"__path__ attribute not found on {parent_name!r}"
-                    f"while trying to find {fullname!r}.", name=fullname) from e
+                    f"while trying to find {fullname!r}", name=fullname) from e
         else:
             parent_path = None
         return _find_spec(fullname, parent_path)

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -90,7 +90,7 @@ def find_spec(name, package=None):
             except AttributeError as e:
                 raise ModuleNotFoundError(
                     f"__path__ attribute not found on {parent_name!r}"
-                    f"while trying to import {fullname!r}.", name=fullname) from e
+                    f"while trying to find {fullname!r}.", name=fullname) from e
         else:
             parent_path = None
         return _find_spec(fullname, parent_path)

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -89,8 +89,8 @@ def find_spec(name, package=None):
                 parent_path = parent.__path__
             except AttributeError as e:
                 raise ModuleNotFoundError(
-                    "Error while finding module specification for "
-                    f"'{fullname}'.", name=fullname) from e
+                    "__path__ attribute missing on parent of "
+                    f"{fullname!r}.", name=fullname) from e
         else:
             parent_path = None
         return _find_spec(fullname, parent_path)

--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -89,8 +89,8 @@ def find_spec(name, package=None):
                 parent_path = parent.__path__
             except AttributeError as e:
                 raise ModuleNotFoundError(
-                    "__path__ attribute missing on parent of "
-                    f"{fullname!r}.", name=fullname) from e
+                    f"__path__ attribute not found on {parent_name!r}"
+                    f"while trying to import {fullname!r}.", name=fullname) from e
         else:
             parent_path = None
         return _find_spec(fullname, parent_path)

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -427,7 +427,7 @@ class CmdLineTest(unittest.TestCase):
         tests = (
             ('builtins', br'No code object available'),
             ('builtins.x', br'Error while finding module specification.*'
-                br'AttributeError'),
+                br'ModuleNotFoundError'),
             ('builtins.x.y', br'Error while finding module specification.*'
                 br'ModuleNotFoundError.*No module named.*not a package'),
             ('os.path', br'loader.*cannot handle'),

--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -522,12 +522,7 @@ class FindSpecTests:
             self.assertNotIn(name, sorted(sys.modules))
             self.assertNotIn(fullname, sorted(sys.modules))
 
-    def test_ModuleNotFoundError_raised_for_broken_module_name(self):
-        """
-        Test that calling find_spec with broken name raises ModuleNotFoundError.
-
-        See issue 30436 for discussion of this behaviour.
-        """
+    def test_find_submodule_in_module(self):
         with self.assertRaises(ModuleNotFoundError):
             self.util.find_spec('module.name')
 

--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -522,6 +522,15 @@ class FindSpecTests:
             self.assertNotIn(name, sorted(sys.modules))
             self.assertNotIn(fullname, sorted(sys.modules))
 
+    def test_ModuleNotFoundError_raised_for_broken_module_name(self):
+        """
+        Test that calling find_spec with broken name raises ModuleNotFoundError.
+
+        See issue 30436 for discussion of this behaviour.
+        """
+        with self.assertRaises(ModuleNotFoundError):
+            self.util.find_spec('module.name')
+
 
 (Frozen_FindSpecTests,
  Source_FindSpecTests

--- a/Lib/test/test_importlib/test_util.py
+++ b/Lib/test/test_importlib/test_util.py
@@ -523,6 +523,8 @@ class FindSpecTests:
             self.assertNotIn(fullname, sorted(sys.modules))
 
     def test_find_submodule_in_module(self):
+        # ModuleNotFoundError raised when a module is specified as
+        # a parent instead of a package.
         with self.assertRaises(ModuleNotFoundError):
             self.util.find_spec('module.name')
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -345,6 +345,10 @@ Extension Modules
 Library
 -------
 
+- bpo-30436: `importlib.find_spec()` raises ModuleNotFoundError instead of
+  AttributeError if the package can be imported but is missing the __path__
+  attribute.
+
 - bpo-16500: Allow registering at-fork handlers.
 
 - bpo-30470: Deprecate invalid ctypes call protection on Windows.  Patch by

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -345,10 +345,6 @@ Extension Modules
 Library
 -------
 
-- bpo-30436: `importlib.find_spec()` raises ModuleNotFoundError instead of
-  AttributeError if the package can be imported but is missing the __path__
-  attribute.
-
 - bpo-16500: Allow registering at-fork handlers.
 
 - bpo-30470: Deprecate invalid ctypes call protection on Windows.  Patch by
@@ -363,6 +359,10 @@ Library
 - bpo-30149: inspect.signature() now supports callables with
   variable-argument parameters wrapped with partialmethod.
   Patch by Dong-hee Na.
+  
+- bpo-30436: importlib.find_spec() raises ModuleNotFoundError instead of
+  AttributeError if the specified parent module is not a package
+  (i.e. lacks a __path__ attribute).
 
 - bpo-30301: Fix AttributeError when using SimpleQueue.empty() under
   *spawn* and *forkserver* start methods.


### PR DESCRIPTION
Changes `find_spec()` to raise `ModuleNotFoundError` instead of
`AttributeError` when parent does not exist or is not a package.