### PR TITLE
[2.7] bpo-30499: Remove a deprecated note about sets. (GH-1848)

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2004,9 +2004,7 @@ The constructors for both classes work the same:
 
    Note, the *elem* argument to the :meth:`__contains__`, :meth:`remove`, and
    :meth:`discard` methods may be a set.  To support searching for an equivalent
-   frozenset, the *elem* set is temporarily mutated during the search and then
-   restored.  During the search, the *elem* set should not be read or mutated
-   since it does not have a meaningful value.
+   frozenset, a temporary one is created from *elem*.
 
 
 .. seealso::


### PR DESCRIPTION
(cherry picked from commit 0737ee20671d60802a7ef40f653fe449f1921de0)