### PR TITLE
bpo-17852: Maintain a list of BufferedWriter objects.  Flush them on exit.

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2593,5 +2593,8 @@ def _flush_all_writers():
     # finalized before the buffered writer wrapping it then any buffered
     # data will be lost.
     for w in _all_writers:
-        w.flush()
+        try:
+            w.flush()
+        except:
+            pass
 atexit.register(_flush_all_writers)

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1185,6 +1185,7 @@ class BufferedWriter(_BufferedIOMixin):
         self.buffer_size = buffer_size
         self._write_buf = bytearray()
         self._write_lock = Lock()
+        _register_writer(self)
 
     def writable(self):
         return self.raw.writable()
@@ -2574,3 +2575,23 @@ class StringIO(TextIOWrapper):
     def detach(self):
         # This doesn't make sense on StringIO.
         self._unsupported("detach")
+
+
+# ____________________________________________________________
+
+import atexit, weakref
+
+_all_writers = weakref.WeakKeyDictionary()
+
+def _register_writer(w):
+    # keep weak-ref to buffered writer
+    _all_writers[w] = True
+
+def _flush_all_writers():
+    # Ensure all buffered writers are flushed before proceeding with
+    # normal shutdown.  Otherwise, if the underlying file objects get
+    # finalized before the buffered writer wrapping it then any buffered
+    # data will be lost.
+    for w in _all_writers:
+        w.flush()
+atexit.register(_flush_all_writers)

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2581,11 +2581,11 @@ class StringIO(TextIOWrapper):
 
 import atexit, weakref
 
-_all_writers = weakref.WeakKeyDictionary()
+_all_writers = weakref.WeakSet()
 
 def _register_writer(w):
     # keep weak-ref to buffered writer
-    _all_writers[w] = True
+    _all_writers.add(w)
 
 def _flush_all_writers():
     # Ensure all buffered writers are flushed before proceeding with

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-04-12-46-25.bpo-17852.OxAtCg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-04-12-46-25.bpo-17852.OxAtCg.rst
@@ -1,0 +1,2 @@
+Maintain a list of open buffered files, flush them before exiting the
+interpreter.  Based on a patch from Armin Rigo.

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -766,6 +766,8 @@ PyInit__io(void)
         !(_PyIO_empty_bytes = PyBytes_FromStringAndSize(NULL, 0)))
         goto fail;
 
+    _Py_PyAtExit(_PyIO_atexit_flush);
+
     state->initialized = 1;
 
     return m;

--- a/Modules/_io/_iomodule.h
+++ b/Modules/_io/_iomodule.h
@@ -183,3 +183,5 @@ extern PyObject *_PyIO_empty_str;
 extern PyObject *_PyIO_empty_bytes;
 
 extern PyTypeObject _PyBytesIOBuffer_Type;
+
+extern void _PyIO_atexit_flush(void);


### PR DESCRIPTION
In Python 3, the buffer and the underlying file object are separate
and so the order in which objects are finalized matters.  This is
unlike Python 2 where the file and buffer were a single object and
finalization was done for both at the same time.  In Python 3, if
the file is finalized and closed before the buffer then the data in
the buffer is lost.

This change adds a doubly linked list of open file buffers.  An atexit
hook ensures they are flushed before proceeding with interpreter
shutdown.  This is addition does not remove the need to properly close
files as there are other reasons why buffered data could get lost during
finalization.

Initial patch by Armin Rigo.

<!-- issue-number: bpo-17852 -->
https://bugs.python.org/issue17852
<!-- /issue-number -->
