### PR TITLE
bpo-30544: _io._WindowsConsoleIO.write raises the wrong error when WriteConsoleW fails

### DIFF
--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -966,7 +966,6 @@ _io__WindowsConsoleIO_write_impl(winconsoleio *self, Py_buffer *b)
     BOOL res = TRUE;
     wchar_t *wbuf;
     DWORD len, wlen, n = 0;
-    DWORD err;
 
     if (self->handle == INVALID_HANDLE_VALUE)
         return err_closed();
@@ -1001,10 +1000,7 @@ _io__WindowsConsoleIO_write_impl(winconsoleio *self, Py_buffer *b)
     wlen = MultiByteToWideChar(CP_UTF8, 0, b->buf, len, wbuf, wlen);
     if (wlen) {
         res = WriteConsoleW(self->handle, wbuf, wlen, &n, NULL);
-        if (!res)
-            err = GetLastError();
-
-        if (n < wlen) {
+        if (res && n < wlen) {
             /* Wrote fewer characters than expected, which means our
              * len value may be wrong. So recalculate it from the
              * characters that were written. As this could potentially
@@ -1023,6 +1019,7 @@ _io__WindowsConsoleIO_write_impl(winconsoleio *self, Py_buffer *b)
     Py_END_ALLOW_THREADS
 
     if (!res) {
+        DWORD err = GetLastError();
         PyMem_Free(wbuf);
         return PyErr_SetFromWindowsErr(err);
     }


### PR DESCRIPTION
Found due to this: https://github.com/pytest-dev/py/issues/103