### PR TITLE
Fix skipping test_UNC_path on AppVeyor due to a different error being raised

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -597,7 +597,7 @@ class PathsTests(unittest.TestCase):
         try:
             os.listdir(unc)
         except OSError as e:
-            if e.errno in (errno.EPERM, errno.EACCES):
+            if e.errno in (errno.EPERM, errno.EACCES, errno.ENOENT):
                 # See issue #15338
                 self.skipTest("cannot access administrative share %r" % (unc,))
             raise


### PR DESCRIPTION
We get `ERROR_BAD_NETPATH` (53) on AppVeyor which is translated to ENOENT (2).

Let AppVeyor run this of course first.