### PR TITLE
bpo-30557: faulthandler now correctly filters and displays exception codes on Windows

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -755,6 +755,32 @@ class FaultHandlerTests(unittest.TestCase):
                 name)
 
     @unittest.skipUnless(MS_WINDOWS, 'specific to Windows')
+    def test_raise_nonfatal_exception(self):
+        # These exceptions are not strictly errors. Letting
+        # faulthandler display the traceback when they are
+        # raised is likely to result in noise. However, they
+        # may still terminate the process if there is no
+        # handler installed for them (which there typically
+        # is, e.g. for debug messages).
+        for exc in (
+            0x00000000,
+            0x34567890,
+            0x40000000,
+            0x40001000,
+            0x70000000,
+            0x7FFFFFFF,
+        ):
+            output, exitcode = self.get_output(f"""
+                import faulthandler
+                faulthandler.enable()
+                faulthandler._raise_exception(0x{exc:x})
+                """
+            )
+            self.assertEqual(output, [])
+            # Actual exception code has bit 4 cleared
+            self.assertEqual(exitcode, exc & ~0x10000000)
+
+    @unittest.skipUnless(MS_WINDOWS, 'specific to Windows')
     def test_disable_windows_exc_handler(self):
         code = dedent("""
             import faulthandler

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -345,6 +345,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30557: faulthandler now correctly filters and displays exception codes
+  on Windows
+
 - bpo-30245: Fix possible overflow when organize struct.pack_into
   error message.  Patch by Yuan Liu.
   

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -373,7 +373,7 @@ faulthandler_exc_handler(struct _EXCEPTION_POINTERS *exc_info)
     DWORD code = exc_info->ExceptionRecord->ExceptionCode;
     DWORD flags = exc_info->ExceptionRecord->ExceptionFlags;
 
-    /* only log fatal exceptions */
+    /* bpo-30557: only log fatal exceptions */
     if (!(code & 0x80000000)) {
         /* call the next exception handler */
         return EXCEPTION_CONTINUE_SEARCH;

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -374,7 +374,7 @@ faulthandler_exc_handler(struct _EXCEPTION_POINTERS *exc_info)
     DWORD flags = exc_info->ExceptionRecord->ExceptionFlags;
 
     /* only log fatal exceptions */
-    if (flags & EXCEPTION_NONCONTINUABLE) {
+    if (!(code & 0x80000000)) {
         /* call the next exception handler */
         return EXCEPTION_CONTINUE_SEARCH;
     }
@@ -391,8 +391,8 @@ faulthandler_exc_handler(struct _EXCEPTION_POINTERS *exc_info)
     case EXCEPTION_IN_PAGE_ERROR: PUTS(fd, "page error"); break;
     case EXCEPTION_STACK_OVERFLOW: PUTS(fd, "stack overflow"); break;
     default:
-        PUTS(fd, "code ");
-        _Py_DumpDecimal(fd, code);
+        PUTS(fd, "code 0x");
+        _Py_DumpHexadecimal(fd, code, 8);
     }
     PUTS(fd, "\n\n");
 


### PR DESCRIPTION
bpo-30557: faulthandler now correctly filters and displays exception codes on Windows