### PR TITLE
bpo-30544: _io._WindowsConsoleIO.write raises the wrong error when WriteConsoleW fails (#1912)

### DIFF
--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -1017,7 +1017,7 @@ _io__WindowsConsoleIO_write_impl(winconsoleio *self, Py_buffer *b)
     wlen = MultiByteToWideChar(CP_UTF8, 0, b->buf, len, wbuf, wlen);
     if (wlen) {
         res = WriteConsoleW(self->handle, wbuf, wlen, &n, NULL);
-        if (n < wlen) {
+        if (res && n < wlen) {
             /* Wrote fewer characters than expected, which means our
              * len value may be wrong. So recalculate it from the
              * characters that were written. As this could potentially


### PR DESCRIPTION
bpo-30544: _io._WindowsConsoleIO.write raises the wrong error when WriteConsoleW fails (#1912)