### PR TITLE
[3.5] Turn on macOS builds for Travis (GH-1846)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,24 @@ branches:
 matrix:
   fast_finish: true
   allow_failures:
-    - env:
-       - TESTING=coverage
+    - env: OPTIONAL=true
   include:
     - os: linux
       language: c
       compiler: clang
       # gcc also works, but to keep the # of concurrent builds down, we use one C
-      # compiler here and the other to run the coverage build.
-      env:
-        - TESTING=cpython
+      # compiler here and the other to run the coverage build. Clang is preferred
+      # in this instance for its better error messages.
+      env: TESTING=cpython
+    - os: osx
+      language: c
+      compiler: clang
+      # Testing under macOS is optional until testing stability has been demonstrated.
+      env: OPTIONAL=true
     - os: linux
       language: python
       python: 3.6
-      env:
-        - TESTING=docs
+      env: TESTING=docs
       before_script:
         - cd Doc
         # Sphinx is pinned so that new versions that introduce new warnings won't suddenly cause build failures.
@@ -39,8 +42,7 @@ matrix:
     - os: linux
       language: c
       compiler: gcc
-      env:
-        - TESTING=coverage
+      env: OPTIONAL=true
       before_script:
         - |
             if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.(rst|yml)$)|(^Doc)/'


### PR DESCRIPTION
Initially the macOS builds are allowed to fail until such time that they can be determined to be stable and not add an unacceptable amount of time to the overall Travis-passing process.
(cherry picked from commit 21c2dd7cf8414c903f0e83cf1d6b7f02f645f422)