### PR TITLE
[2.7] Turn on macOS builds for Travis (GH-1846)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,19 +12,36 @@ branches:
     - /^\d\.\d$/
 
 matrix:
+<<<<<<< HEAD
+=======
+  fast_finish: true
+  allow_failures:
+    - env: OPTIONAL=true
+>>>>>>> 21c2dd7cf8... Turn on macOS builds for Travis (GH-1846)
   include:
     - os: linux
       language: c
       compiler: clang
       # gcc also works, but to keep the # of concurrent builds down, we use one C
-      # compiler here and the other to run the coverage build.
-      env:
-        - TESTING=cpython
+      # compiler here and the other to run the coverage build. Clang is preferred
+      # in this instance for its better error messages.
+      env: TESTING=cpython
+    - os: osx
+      language: c
+      compiler: clang
+      # Testing under macOS is optional until testing stability has been demonstrated.
+      env: OPTIONAL=true
     - os: linux
       language: python
+<<<<<<< HEAD
       python: 2.7
       env:
         - TESTING=docs
+=======
+      # Build the docs against a stable version of Python so code bugs don't hold up doc-related PRs.
+      python: 3.6
+      env: TESTING=docs
+>>>>>>> 21c2dd7cf8... Turn on macOS builds for Travis (GH-1846)
       before_script:
         - cd Doc
         # Sphinx is pinned so that new versions that introduce new warnings won't suddenly cause build failures.
@@ -32,6 +49,32 @@ matrix:
         - python -m pip install sphinx~=1.6.1
       script:
         - make check suspicious html SPHINXOPTS="-q -W -j4"
+<<<<<<< HEAD
+=======
+    - os: linux
+      language: c
+      compiler: gcc
+      env: OPTIONAL=true
+      before_script:
+        - |
+            if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.(rst|yml)$)|(^Doc)|(^Misc)/'
+            then
+              echo "Only docs were updated, stopping build process."
+              exit
+            fi
+            ./configure
+            make -s -j4
+            # Need a venv that can parse covered code.
+            ./python -m venv venv
+            ./venv/bin/python -m pip install -U coverage
+      script:
+        # Skip tests that re-run the entire test suite.
+        - ./venv/bin/python -m coverage run --pylib -m test -uall -x test_multiprocessing_fork -x test_multiprocessing_forkserver -x test_multiprocessing_spawn
+      after_script:  # Probably should be after_success once test suite updated to run under coverage.py.
+        # Make the `coverage` command available to Codecov w/ a version of Python that can parse all source files.
+        - source ./venv/bin/activate
+        - bash <(curl -s https://codecov.io/bash)
+>>>>>>> 21c2dd7cf8... Turn on macOS builds for Travis (GH-1846)
 
 # Travis provides only 2 cores, so don't overdue the parallelism and waste memory.
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,9 @@ branches:
     - /^\d\.\d$/
 
 matrix:
-<<<<<<< HEAD
-=======
   fast_finish: true
   allow_failures:
     - env: OPTIONAL=true
->>>>>>> 21c2dd7cf8... Turn on macOS builds for Travis (GH-1846)
   include:
     - os: linux
       language: c
@@ -33,15 +30,8 @@ matrix:
       env: OPTIONAL=true
     - os: linux
       language: python
-<<<<<<< HEAD
       python: 2.7
-      env:
-        - TESTING=docs
-=======
-      # Build the docs against a stable version of Python so code bugs don't hold up doc-related PRs.
-      python: 3.6
       env: TESTING=docs
->>>>>>> 21c2dd7cf8... Turn on macOS builds for Travis (GH-1846)
       before_script:
         - cd Doc
         # Sphinx is pinned so that new versions that introduce new warnings won't suddenly cause build failures.
@@ -49,32 +39,6 @@ matrix:
         - python -m pip install sphinx~=1.6.1
       script:
         - make check suspicious html SPHINXOPTS="-q -W -j4"
-<<<<<<< HEAD
-=======
-    - os: linux
-      language: c
-      compiler: gcc
-      env: OPTIONAL=true
-      before_script:
-        - |
-            if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.(rst|yml)$)|(^Doc)|(^Misc)/'
-            then
-              echo "Only docs were updated, stopping build process."
-              exit
-            fi
-            ./configure
-            make -s -j4
-            # Need a venv that can parse covered code.
-            ./python -m venv venv
-            ./venv/bin/python -m pip install -U coverage
-      script:
-        # Skip tests that re-run the entire test suite.
-        - ./venv/bin/python -m coverage run --pylib -m test -uall -x test_multiprocessing_fork -x test_multiprocessing_forkserver -x test_multiprocessing_spawn
-      after_script:  # Probably should be after_success once test suite updated to run under coverage.py.
-        # Make the `coverage` command available to Codecov w/ a version of Python that can parse all source files.
-        - source ./venv/bin/activate
-        - bash <(curl -s https://codecov.io/bash)
->>>>>>> 21c2dd7cf8... Turn on macOS builds for Travis (GH-1846)
 
 # Travis provides only 2 cores, so don't overdue the parallelism and waste memory.
 before_script:


### PR DESCRIPTION
Initially the macOS builds are allowed to fail until such time that they can be determined to be stable and not add an unacceptable amount of time to the overall Travis-passing process.
(cherry picked from commit 21c2dd7cf8414c903f0e83cf1d6b7f02f645f422)