### PR TITLE
Simplify code in warnings modules

### DIFF
--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -397,9 +397,13 @@ class WarningMessage(object):
 
     def __init__(self, message, category, filename, lineno, file=None,
                  line=None, source=None):
-        local_values = locals()
-        for attr in self._WARNING_DETAILS:
-            setattr(self, attr, local_values[attr])
+        self.message = message
+        self.category = category
+        self.filename = filename
+        self.lineno = lineno
+        self.file = file
+        self.line = line
+        self.source = source
         self._category_name = category.__name__ if category else None
 
     def __str__(self):


### PR DESCRIPTION
Metaprogramming a list of attributes was excessive, and made the code less readable and slower.