### PR TITLE
bpo-29535: Not all datetime objects are using hashing randomization

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1394,7 +1394,7 @@ Basic customization
 
    .. note::
 
-      By default, the :meth:`__hash__` values of str, bytes and datetime
+      By default, the :meth:`__hash__` values of str, bytes and some datetime
       objects are "salted" with an unpredictable random value.  Although they
       remain constant within an individual Python process, they are not
       predictable between repeated invocations of Python.

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -267,7 +267,7 @@ Miscellaneous options
    turned on by default.
 
    On previous versions of Python, this option turns on hash randomization,
-   so that the :meth:`__hash__` values of str, bytes and datetime
+   so that the :meth:`__hash__` values of str, bytes and some datetime objects
    are "salted" with an unpredictable random value.  Although they remain
    constant within an individual Python process, they are not predictable
    between repeated invocations of Python.
@@ -540,7 +540,7 @@ conflict.
 .. envvar:: PYTHONHASHSEED
 
    If this variable is not set or set to ``random``, a random value is used
-   to seed the hashes of str, bytes and datetime objects.
+   to seed the hashes of str, bytes and some datetime objects.
 
    If :envvar:`PYTHONHASHSEED` is set to an integer value, it is used as a fixed
    seed for generating the hash() of the types covered by the hash


### PR DESCRIPTION
Security concern: pending feedback on issue bpo-29535, here is an update of the documentation.  It should make it clear that not all ``datetime`` objects come with randomized hashes.

<!-- issue-number: bpo-29535 -->
https://bugs.python.org/issue29535
<!-- /issue-number -->
