### PR TITLE
bpo-28206: Document signals Handlers, Sigmasks and Signals enums

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -67,10 +67,10 @@ Module contents
    signal (SIG*), handler (:const:`SIG_DFL`, :const:`SIG_IGN`) and sigmask
    (:const:`SIG_BLOCK`, :const:`SIG_UNBLOCK`, :const:`SIG_SETMASK`)
    related constants listed below were turned into
-   :class:`enums <enum.IntEnum>`.
+   :class:`enums <enum.IntEnum>` (respectively :class:`Handlers` and :class:`Sigmasks`).
    :func:`getsignal`, :func:`pthread_sigmask`, :func:`sigpending` and
    :func:`sigwait` functions return human-readable
-   :class:`enums <enum.IntEnum>`.
+   :class:`enums <enum.IntEnum>` as :class:`Signals` objects.
 
 
 The variables defined in the :mod:`signal` module are:

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -478,8 +478,8 @@ The :mod:`signal` module defines the following functions:
 
 .. _signal-example:
 
-Example
--------
+Examples
+--------
 
 Here is a minimal example program. It uses the :func:`alarm` function to limit
 the time spent waiting to open a file; this is useful if the file is for a
@@ -502,6 +502,21 @@ be sent, and the handler raises an exception. ::
    fd = os.open('/dev/ttyS0', os.O_RDWR)
 
    signal.alarm(0)          # Disable the alarm
+
+:class:`enums <enum.IntEnum>` types can be used to convert from signal code to string, or the reverse::
+
+   import signal, os
+
+   def handler(signum, frame):
+       # signum is an integer code, get the signal name using the signal.Signal enum
+       signame = signal.Signals(signum).name
+       print(f'Signal handler called with signal {signame} of code {signum}')
+
+   # attach a handler for signal.SIGINT
+   signame = 'SIGINT'
+   signal.signal(signal.Signals[signame], handler)
+
+
 
 Note on SIGPIPE
 ---------------

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -67,7 +67,7 @@ Module contents
    signal (SIG*), handler (:const:`SIG_DFL`, :const:`SIG_IGN`) and sigmask
    (:const:`SIG_BLOCK`, :const:`SIG_UNBLOCK`, :const:`SIG_SETMASK`)
    related constants listed below were turned into
-   :class:`enums <enum.IntEnum>` (respectively :class:`Handlers` and :class:`Sigmasks`).
+   :class:`enums <enum.IntEnum>` (:class:`Handlers` and :class:`Sigmasks` respectively).
    :func:`getsignal`, :func:`pthread_sigmask`, :func:`sigpending` and
    :func:`sigwait` functions return human-readable
    :class:`enums <enum.IntEnum>` as :class:`Signals` objects.


### PR DESCRIPTION
Document the 3 module level `IntEnum` classes in `signals`.

See http://bugs.python.org/issue28206

<!-- issue-number: [bpo-28206](https://www.bugs.python.org/issue28206) -->
https://bugs.python.org/issue28206
<!-- /issue-number -->
