### PR TITLE
bpo-30567: Fix refleak in sys.getwindowsversion

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -973,10 +973,10 @@ sys_getwindowsversion(PyObject *self)
         }
         PyMem_RawFree(verblock);
     }
-    PyStructSequence_SET_ITEM(version, pos++, PyTuple_Pack(3,
-        PyLong_FromLong(realMajor),
-        PyLong_FromLong(realMinor),
-        PyLong_FromLong(realBuild)
+    PyStructSequence_SET_ITEM(version, pos++, Py_BuildValue("(kkk)",
+        realMajor,
+        realMinor,
+        realBuild
     ));
 
     if (PyErr_Occurred()) {


### PR DESCRIPTION
There is a ref leak in `sys.getwindowsversion` due to using `PyTuple_Pack` and forgetting that it increments the ref count of passed in objects. Found here: https://github.com/python/cpython/pull/1927#issuecomment-306019512.

Clearly shows up in `python -m test -R 3:2 test_sys`

@eryksun