### PR TITLE
Only run AppVeyor on long-lived branches

### DIFF
--- a/.github/appveyor.yml
+++ b/.github/appveyor.yml
@@ -1,5 +1,10 @@
 version: 3.7.0a0.{build}
 clone_depth: 5
+branches:
+  only:
+    - master
+    - /\d\.\d/
+    - buildbot-custom
 build_script:
 - cmd: PCbuild\build.bat -e
 test_script:


### PR DESCRIPTION
Also on the short-lived `buildbot-custom` branch.