### PR TITLE
[3.5] Only run AppVeyor on long-lived branches (GH-1941)

### DIFF
--- a/.github/appveyor.yml
+++ b/.github/appveyor.yml
@@ -1,5 +1,10 @@
 version: 3.5.3+.{build}
 clone_depth: 5
+branches:
+  only:
+    - master
+    - /\d\.\d/
+    - buildbot-custom
 build_script:
 - cmd: PCbuild\build.bat -e
 test_script:


### PR DESCRIPTION
Also on the short-lived `buildbot-custom` branch.
(cherry picked from commit d3bedf356aca04ed9135a84b08)