### PR TITLE
[3.6] Fix skipping test_UNC_path on AppVeyor due to a different error…

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -567,7 +567,7 @@ class PathsTests(unittest.TestCase):
         try:
             os.listdir(unc)
         except OSError as e:
-            if e.errno in (errno.EPERM, errno.EACCES):
+            if e.errno in (errno.EPERM, errno.EACCES, errno.ENOENT):
                 # See issue #15338
                 self.skipTest("cannot access administrative share %r" % (unc,))
             raise


### PR DESCRIPTION
… being raised (GH-1920)

We get `ERROR_BAD_NETPATH` (53) on AppVeyor which is translated to
ENOENT (2).
(cherry picked from commit 7a99625e0d95cd88ed8842d8677b5beea1fde5ae)