### PR TITLE
Skip UNC tests on AppVeyor in case of ENOENT

### DIFF
--- a/Lib/test/test_import.py
+++ b/Lib/test/test_import.py
@@ -548,7 +548,7 @@ class PathsTests(unittest.TestCase):
         try:
             os.listdir(unc)
         except OSError as e:
-            if e.errno in (errno.EPERM, errno.EACCES):
+            if e.errno in (errno.EPERM, errno.EACCES, errno.ENOENT):
                 # See issue #15338
                 self.skipTest("cannot access administrative share %r" % (unc,))
             raise

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -256,7 +256,7 @@ class TclTest(unittest.TestCase):
             try:
                 p = Popen(cmd, stdout=PIPE, stderr=PIPE)
             except WindowsError as e:
-                if e.winerror == 5:
+                if e.winerror == 5 or e.winerror == 53:
                     self.skipTest('Not permitted to start the child process')
                 else:
                     raise

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -256,7 +256,7 @@ class TclTest(unittest.TestCase):
             try:
                 p = Popen(cmd, stdout=PIPE, stderr=PIPE)
             except WindowsError as e:
-                if e.winerror == 5 or e.winerror == 53:
+                if e.winerror == 5 or e.winerror == 2:
                     self.skipTest('Not permitted to start the child process')
                 else:
                     raise


### PR DESCRIPTION
Basically a backport of GH-1920.