### PR TITLE
Install dependencies in Travis OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,10 @@ matrix:
       compiler: clang
       # Testing under macOS is optional until testing stability has been demonstrated.
       env: OPTIONAL=true
+      before_install:
+        - brew install openssl xz
+        - export CPPFLAGS="-I$(brew --prefix openssl)/include"
+        - export LDFLAGS="-L$(brew --prefix openssl)/lib"
     - os: linux
       language: python
       # Build the docs against a stable version of Python so code bugs don't hold up doc-related PRs.

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
 # Travis provides only 2 cores, so don't overdue the parallelism and waste memory.
 before_script:
   - |
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.(rst|yml)$)|(^Doc)|(^Misc)/'
+      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.rst$)|(^Doc)|(^Misc)/'
       then
         echo "Only docs were updated, stopping build process."
         exit


### PR DESCRIPTION
I'm not sure whether the `export`s will be effective or not; we'll see.  If it doesn't work, we can try `brew link -f openssl`