### PR TITLE
[3.6] bpo-30530: Update Descriptor How To Documentation (GH-1845)

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -282,7 +282,7 @@ this::
         . . .
         def __get__(self, obj, objtype=None):
             "Simulate func_descr_get() in Objects/funcobject.c"
-            return types.MethodType(self, obj, objtype)
+            return types.MethodType(self, obj)
 
 Running the interpreter shows how the function descriptor works in practice::
 


### PR DESCRIPTION
Update the code example in Functions and Methods section
Remove objtype argument in MethodType
(cherry picked from commit 1bced56567335745f91676192fc39c06aab30da9)