### PR TITLE
bpo-29464: Rename METH_FASTCALL to METH_FASTCALL|METH_KEYWORDS and make

### DIFF
--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -16,10 +16,12 @@ PyAPI_DATA(PyTypeObject) PyCFunction_Type;
 #define PyCFunction_Check(op) (Py_TYPE(op) == &PyCFunction_Type)
 
 typedef PyObject *(*PyCFunction)(PyObject *, PyObject *);
-typedef PyObject *(*_PyCFunctionFast) (PyObject *self, PyObject **args,
-                                       Py_ssize_t nargs, PyObject *kwnames);
+typedef PyObject *(*_PyCFunctionFast) (PyObject *, PyObject **, Py_ssize_t);
 typedef PyObject *(*PyCFunctionWithKeywords)(PyObject *, PyObject *,
                                              PyObject *);
+typedef PyObject *(*_PyCFunctionFastWithKeywords) (PyObject *,
+                                                   PyObject **, Py_ssize_t,
+                                                   PyObject *);
 typedef PyObject *(*PyNoArgsFunction)(PyObject *);
 
 PyAPI_FUNC(PyCFunction) PyCFunction_GetFunction(PyObject *);

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -912,14 +912,10 @@ done:
 }
 
 static PyObject *
-deque_rotate(dequeobject *deque, PyObject **args, Py_ssize_t nargs,
-             PyObject *kwnames)
+deque_rotate(dequeobject *deque, PyObject **args, Py_ssize_t nargs)
 {
     Py_ssize_t n=1;
 
-    if (!_PyArg_NoStackKeywords("rotate", kwnames)) {
-        return NULL;
-    }
     if (!_PyArg_ParseStack(args, nargs, "|n:rotate", &n)) {
         return NULL;
     }
@@ -1052,8 +1048,7 @@ deque_len(dequeobject *deque)
 }
 
 static PyObject *
-deque_index(dequeobject *deque, PyObject **args, Py_ssize_t nargs,
-            PyObject *kwnames)
+deque_index(dequeobject *deque, PyObject **args, Py_ssize_t nargs)
 {
     Py_ssize_t i, n, start=0, stop=Py_SIZE(deque);
     PyObject *v, *item;
@@ -1062,9 +1057,6 @@ deque_index(dequeobject *deque, PyObject **args, Py_ssize_t nargs,
     size_t start_state = deque->state;
     int cmp;
 
-    if (!_PyArg_NoStackKeywords("index", kwnames)) {
-        return NULL;
-    }
     if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index", &v,
                            _PyEval_SliceIndexNotNone, &start,
                            _PyEval_SliceIndexNotNone, &stop)) {
@@ -1133,17 +1125,13 @@ PyDoc_STRVAR(index_doc,
 */
 
 static PyObject *
-deque_insert(dequeobject *deque, PyObject **args, Py_ssize_t nargs,
-             PyObject *kwnames)
+deque_insert(dequeobject *deque, PyObject **args, Py_ssize_t nargs)
 {
     Py_ssize_t index;
     Py_ssize_t n = Py_SIZE(deque);
     PyObject *value;
     PyObject *rv;
 
-    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
-        return NULL;
-    }
     if (!_PyArg_ParseStack(args, nargs, "nO:insert", &index, &value)) {
         return NULL;
     }

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -2774,7 +2774,7 @@ typedef struct {
 } XMLParserObject;
 
 static PyObject*
-_elementtree_XMLParser_doctype(XMLParserObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames);
+_elementtree_XMLParser_doctype(XMLParserObject *self, PyObject **args, Py_ssize_t nargs);
 static PyObject *
 _elementtree_XMLParser_doctype_impl(XMLParserObject *self, PyObject *name,
                                     PyObject *pubid, PyObject *system);

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -967,7 +967,7 @@ generate_hash_name_list(void)
 
 /* a PyMethodDef structure for the constructor */
 #define CONSTRUCTOR_METH_DEF(NAME)  \
-    {"openssl_" #NAME, (PyCFunction)EVP_new_ ## NAME, METH_FASTCALL, \
+    {"openssl_" #NAME, (PyCFunction)EVP_new_ ## NAME, METH_FASTCALL | METH_KEYWORDS, \
         PyDoc_STR("Returns a " #NAME \
                   " hash object; optionally initialized with a string") \
     }

--- a/Modules/_io/clinic/_iomodule.c.h
+++ b/Modules/_io/clinic/_iomodule.c.h
@@ -127,7 +127,7 @@ PyDoc_STRVAR(_io_open__doc__,
 "opened in a binary mode.");
 
 #define _IO_OPEN_METHODDEF    \
-    {"open", (PyCFunction)_io_open, METH_FASTCALL, _io_open__doc__},
+    {"open", (PyCFunction)_io_open, METH_FASTCALL|METH_KEYWORDS, _io_open__doc__},
 
 static PyObject *
 _io_open_impl(PyObject *module, PyObject *file, const char *mode,
@@ -158,4 +158,4 @@ _io_open(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e6011c784fe6589b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7e0ab289d8465580 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/bufferedio.c.h
+++ b/Modules/_io/clinic/bufferedio.c.h
@@ -97,14 +97,10 @@ static PyObject *
 _io__Buffered_peek_impl(buffered *self, Py_ssize_t size);
 
 static PyObject *
-_io__Buffered_peek(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__Buffered_peek(buffered *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = 0;
-
-    if (!_PyArg_NoStackKeywords("peek", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|n:peek",
         &size)) {
@@ -128,14 +124,10 @@ static PyObject *
 _io__Buffered_read_impl(buffered *self, Py_ssize_t n);
 
 static PyObject *
-_io__Buffered_read(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__Buffered_read(buffered *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _Py_convert_optional_to_ssize_t, &n)) {
@@ -159,14 +151,10 @@ static PyObject *
 _io__Buffered_read1_impl(buffered *self, Py_ssize_t n);
 
 static PyObject *
-_io__Buffered_read1(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__Buffered_read1(buffered *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
-
-    if (!_PyArg_NoStackKeywords("read1", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|n:read1",
         &n)) {
@@ -252,14 +240,10 @@ static PyObject *
 _io__Buffered_readline_impl(buffered *self, Py_ssize_t size);
 
 static PyObject *
-_io__Buffered_readline(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__Buffered_readline(buffered *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
-
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -283,15 +267,11 @@ static PyObject *
 _io__Buffered_seek_impl(buffered *self, PyObject *targetobj, int whence);
 
 static PyObject *
-_io__Buffered_seek(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__Buffered_seek(buffered *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *targetobj;
     int whence = 0;
-
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
         &targetobj, &whence)) {
@@ -315,14 +295,10 @@ static PyObject *
 _io__Buffered_truncate_impl(buffered *self, PyObject *pos);
 
 static PyObject *
-_io__Buffered_truncate(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__Buffered_truncate(buffered *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *pos = Py_None;
-
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "truncate",
         0, 1,
@@ -500,4 +476,4 @@ _io_BufferedRandom___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4f7490f82427c63b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2b817df0bf814ddc input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/bytesio.c.h
+++ b/Modules/_io/clinic/bytesio.c.h
@@ -164,14 +164,10 @@ static PyObject *
 _io_BytesIO_read_impl(bytesio *self, Py_ssize_t size);
 
 static PyObject *
-_io_BytesIO_read(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_BytesIO_read(bytesio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -199,14 +195,10 @@ static PyObject *
 _io_BytesIO_read1_impl(bytesio *self, Py_ssize_t size);
 
 static PyObject *
-_io_BytesIO_read1(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_BytesIO_read1(bytesio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
-
-    if (!_PyArg_NoStackKeywords("read1", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:read1",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -235,14 +227,10 @@ static PyObject *
 _io_BytesIO_readline_impl(bytesio *self, Py_ssize_t size);
 
 static PyObject *
-_io_BytesIO_readline(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_BytesIO_readline(bytesio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
-
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -271,14 +259,10 @@ static PyObject *
 _io_BytesIO_readlines_impl(bytesio *self, PyObject *arg);
 
 static PyObject *
-_io_BytesIO_readlines(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_BytesIO_readlines(bytesio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
-
-    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "readlines",
         0, 1,
@@ -342,14 +326,10 @@ static PyObject *
 _io_BytesIO_truncate_impl(bytesio *self, Py_ssize_t size);
 
 static PyObject *
-_io_BytesIO_truncate(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_BytesIO_truncate(bytesio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = self->pos;
-
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:truncate",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -380,15 +360,11 @@ static PyObject *
 _io_BytesIO_seek_impl(bytesio *self, Py_ssize_t pos, int whence);
 
 static PyObject *
-_io_BytesIO_seek(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_BytesIO_seek(bytesio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t pos;
     int whence = 0;
-
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "n|i:seek",
         &pos, &whence)) {
@@ -468,4 +444,4 @@ _io_BytesIO___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9e63715414bffb2a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=20946f5a2ed4492b input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/fileio.c.h
+++ b/Modules/_io/clinic/fileio.c.h
@@ -208,14 +208,10 @@ static PyObject *
 _io_FileIO_read_impl(fileio *self, Py_ssize_t size);
 
 static PyObject *
-_io_FileIO_read(fileio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_FileIO_read(fileio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -284,15 +280,11 @@ static PyObject *
 _io_FileIO_seek_impl(fileio *self, PyObject *pos, int whence);
 
 static PyObject *
-_io_FileIO_seek(fileio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_FileIO_seek(fileio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *pos;
     int whence = 0;
-
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
         &pos, &whence)) {
@@ -342,14 +334,10 @@ static PyObject *
 _io_FileIO_truncate_impl(fileio *self, PyObject *posobj);
 
 static PyObject *
-_io_FileIO_truncate(fileio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_FileIO_truncate(fileio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *posobj = NULL;
-
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "truncate",
         0, 1,
@@ -385,4 +373,4 @@ _io_FileIO_isatty(fileio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO_FILEIO_TRUNCATE_METHODDEF
     #define _IO_FILEIO_TRUNCATE_METHODDEF
 #endif /* !defined(_IO_FILEIO_TRUNCATE_METHODDEF) */
-/*[clinic end generated code: output=2c6a5470100a8f10 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1af8b4031633b763 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/iobase.c.h
+++ b/Modules/_io/clinic/iobase.c.h
@@ -180,14 +180,10 @@ static PyObject *
 _io__IOBase_readline_impl(PyObject *self, Py_ssize_t limit);
 
 static PyObject *
-_io__IOBase_readline(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__IOBase_readline(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t limit = -1;
-
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
         _Py_convert_optional_to_ssize_t, &limit)) {
@@ -216,14 +212,10 @@ static PyObject *
 _io__IOBase_readlines_impl(PyObject *self, Py_ssize_t hint);
 
 static PyObject *
-_io__IOBase_readlines(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__IOBase_readlines(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t hint = -1;
-
-    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:readlines",
         _Py_convert_optional_to_ssize_t, &hint)) {
@@ -255,14 +247,10 @@ static PyObject *
 _io__RawIOBase_read_impl(PyObject *self, Py_ssize_t n);
 
 static PyObject *
-_io__RawIOBase_read(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__RawIOBase_read(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|n:read",
         &n)) {
@@ -291,4 +279,4 @@ _io__RawIOBase_readall(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__RawIOBase_readall_impl(self);
 }
-/*[clinic end generated code: output=8361ae8d81d072bf input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1dc5cc1a9977d73f input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/stringio.c.h
+++ b/Modules/_io/clinic/stringio.c.h
@@ -54,14 +54,10 @@ static PyObject *
 _io_StringIO_read_impl(stringio *self, Py_ssize_t size);
 
 static PyObject *
-_io_StringIO_read(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_StringIO_read(stringio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -88,14 +84,10 @@ static PyObject *
 _io_StringIO_readline_impl(stringio *self, Py_ssize_t size);
 
 static PyObject *
-_io_StringIO_readline(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_StringIO_readline(stringio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
-
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -124,14 +116,10 @@ static PyObject *
 _io_StringIO_truncate_impl(stringio *self, Py_ssize_t size);
 
 static PyObject *
-_io_StringIO_truncate(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_StringIO_truncate(stringio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = self->pos;
-
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:truncate",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -162,15 +150,11 @@ static PyObject *
 _io_StringIO_seek_impl(stringio *self, Py_ssize_t pos, int whence);
 
 static PyObject *
-_io_StringIO_seek(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_StringIO_seek(stringio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t pos;
     int whence = 0;
-
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "n|i:seek",
         &pos, &whence)) {
@@ -302,4 +286,4 @@ _io_StringIO_seekable(stringio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_StringIO_seekable_impl(self);
 }
-/*[clinic end generated code: output=443f5dd99bbbd053 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a5e963d90b4eedc0 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/textio.c.h
+++ b/Modules/_io/clinic/textio.c.h
@@ -46,7 +46,7 @@ PyDoc_STRVAR(_io_IncrementalNewlineDecoder_decode__doc__,
 "\n");
 
 #define _IO_INCREMENTALNEWLINEDECODER_DECODE_METHODDEF    \
-    {"decode", (PyCFunction)_io_IncrementalNewlineDecoder_decode, METH_FASTCALL, _io_IncrementalNewlineDecoder_decode__doc__},
+    {"decode", (PyCFunction)_io_IncrementalNewlineDecoder_decode, METH_FASTCALL|METH_KEYWORDS, _io_IncrementalNewlineDecoder_decode__doc__},
 
 static PyObject *
 _io_IncrementalNewlineDecoder_decode_impl(nldecoder_object *self,
@@ -185,7 +185,7 @@ PyDoc_STRVAR(_io_TextIOWrapper_reconfigure__doc__,
 "This also does an implicit stream flush.");
 
 #define _IO_TEXTIOWRAPPER_RECONFIGURE_METHODDEF    \
-    {"reconfigure", (PyCFunction)_io_TextIOWrapper_reconfigure, METH_FASTCALL, _io_TextIOWrapper_reconfigure__doc__},
+    {"reconfigure", (PyCFunction)_io_TextIOWrapper_reconfigure, METH_FASTCALL|METH_KEYWORDS, _io_TextIOWrapper_reconfigure__doc__},
 
 static PyObject *
 _io_TextIOWrapper_reconfigure_impl(textio *self,
@@ -266,14 +266,10 @@ static PyObject *
 _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n);
 
 static PyObject *
-_io_TextIOWrapper_read(textio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_TextIOWrapper_read(textio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _Py_convert_optional_to_ssize_t, &n)) {
@@ -297,14 +293,10 @@ static PyObject *
 _io_TextIOWrapper_readline_impl(textio *self, Py_ssize_t size);
 
 static PyObject *
-_io_TextIOWrapper_readline(textio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_TextIOWrapper_readline(textio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
-
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|n:readline",
         &size)) {
@@ -328,15 +320,11 @@ static PyObject *
 _io_TextIOWrapper_seek_impl(textio *self, PyObject *cookieObj, int whence);
 
 static PyObject *
-_io_TextIOWrapper_seek(textio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_TextIOWrapper_seek(textio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *cookieObj;
     int whence = 0;
-
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
         &cookieObj, &whence)) {
@@ -377,14 +365,10 @@ static PyObject *
 _io_TextIOWrapper_truncate_impl(textio *self, PyObject *pos);
 
 static PyObject *
-_io_TextIOWrapper_truncate(textio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io_TextIOWrapper_truncate(textio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *pos = Py_None;
-
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "truncate",
         0, 1,
@@ -515,4 +499,4 @@ _io_TextIOWrapper_close(textio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_TextIOWrapper_close_impl(self);
 }
-/*[clinic end generated code: output=8ffc6d2557c9c620 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=937989df0a8abfc3 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/winconsoleio.c.h
+++ b/Modules/_io/clinic/winconsoleio.c.h
@@ -215,14 +215,10 @@ static PyObject *
 _io__WindowsConsoleIO_read_impl(winconsoleio *self, Py_ssize_t size);
 
 static PyObject *
-_io__WindowsConsoleIO_read(winconsoleio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_io__WindowsConsoleIO_read(winconsoleio *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:read",
         _Py_convert_optional_to_ssize_t, &size)) {
@@ -332,4 +328,4 @@ _io__WindowsConsoleIO_isatty(winconsoleio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF
     #define _IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF
 #endif /* !defined(_IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF) */
-/*[clinic end generated code: output=3bbf6f893a58f476 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7f74992fcd5bd89d input=a9049054013a1b77]*/

--- a/Modules/_sha3/clinic/sha3module.c.h
+++ b/Modules/_sha3/clinic/sha3module.c.h
@@ -99,7 +99,7 @@ PyDoc_STRVAR(_sha3_shake_128_digest__doc__,
 "Return the digest value as a string of binary data.");
 
 #define _SHA3_SHAKE_128_DIGEST_METHODDEF    \
-    {"digest", (PyCFunction)_sha3_shake_128_digest, METH_FASTCALL, _sha3_shake_128_digest__doc__},
+    {"digest", (PyCFunction)_sha3_shake_128_digest, METH_FASTCALL|METH_KEYWORDS, _sha3_shake_128_digest__doc__},
 
 static PyObject *
 _sha3_shake_128_digest_impl(SHA3object *self, unsigned long length);
@@ -129,7 +129,7 @@ PyDoc_STRVAR(_sha3_shake_128_hexdigest__doc__,
 "Return the digest value as a string of hexadecimal digits.");
 
 #define _SHA3_SHAKE_128_HEXDIGEST_METHODDEF    \
-    {"hexdigest", (PyCFunction)_sha3_shake_128_hexdigest, METH_FASTCALL, _sha3_shake_128_hexdigest__doc__},
+    {"hexdigest", (PyCFunction)_sha3_shake_128_hexdigest, METH_FASTCALL|METH_KEYWORDS, _sha3_shake_128_hexdigest__doc__},
 
 static PyObject *
 _sha3_shake_128_hexdigest_impl(SHA3object *self, unsigned long length);
@@ -151,4 +151,4 @@ _sha3_shake_128_hexdigest(SHA3object *self, PyObject **args, Py_ssize_t nargs, P
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f2278bf0852a7850 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7c1ac102411764f2 input=a9049054013a1b77]*/

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1817,15 +1817,12 @@ to the format string S.format.  See help(struct) for more on format\n\
 strings.");
 
 static PyObject *
-s_pack(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+s_pack(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyStructObject *soself;
     PyObject *result;
 
     /* Validate arguments. */
-    if (!_PyArg_NoStackKeywords("pack", kwnames)) {
-        return NULL;
-    }
     soself = (PyStructObject *)self;
     assert(PyStruct_Check(self));
     assert(soself->s_codes != NULL);
@@ -1859,16 +1856,13 @@ offset.  Note that the offset is a required argument.  See\n\
 help(struct) for more on format strings.");
 
 static PyObject *
-s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyStructObject *soself;
     Py_buffer buffer;
     Py_ssize_t offset;
 
     /* Validate arguments.  +1 is for the first arg as buffer. */
-    if (!_PyArg_NoStackKeywords("pack_into", kwnames)) {
-        return NULL;
-    }
     soself = (PyStructObject *)self;
     assert(PyStruct_Check(self));
     assert(soself->s_codes != NULL);
@@ -2126,14 +2120,10 @@ Return a bytes object containing the values v1, v2, ... packed according\n\
 to the format string.  See help(struct) for more on format strings.");
 
 static PyObject *
-pack(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+pack(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *s_object = NULL;
     PyObject *format, *result;
-
-    if (!_PyArg_NoStackKeywords("pack", kwnames)) {
-        return NULL;
-    }
 
     if (nargs == 0) {
         PyErr_SetString(PyExc_TypeError, "missing format argument");
@@ -2144,7 +2134,7 @@ pack(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     if (!cache_struct_converter(format, &s_object)) {
         return NULL;
     }
-    result = s_pack(s_object, args + 1, nargs - 1, kwnames);
+    result = s_pack(s_object, args + 1, nargs - 1);
     Py_DECREF(s_object);
     return result;
 }
@@ -2158,14 +2148,10 @@ that the offset is a required argument.  See help(struct) for more\n\
 on format strings.");
 
 static PyObject *
-pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *s_object = NULL;
     PyObject *format, *result;
-
-    if (!_PyArg_NoStackKeywords("pack_into", kwnames)) {
-        return NULL;
-    }
 
     if (nargs == 0) {
         PyErr_SetString(PyExc_TypeError, "missing format argument");
@@ -2176,7 +2162,7 @@ pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     if (!cache_struct_converter(format, &s_object)) {
         return NULL;
     }
-    result = s_pack_into(s_object, args + 1, nargs - 1, kwnames);
+    result = s_pack_into(s_object, args + 1, nargs - 1);
     Py_DECREF(s_object);
     return result;
 }

--- a/Modules/cjkcodecs/clinic/multibytecodec.c.h
+++ b/Modules/cjkcodecs/clinic/multibytecodec.c.h
@@ -14,7 +14,7 @@ PyDoc_STRVAR(_multibytecodec_MultibyteCodec_encode__doc__,
 "registered with codecs.register_error that can handle UnicodeEncodeErrors.");
 
 #define _MULTIBYTECODEC_MULTIBYTECODEC_ENCODE_METHODDEF    \
-    {"encode", (PyCFunction)_multibytecodec_MultibyteCodec_encode, METH_FASTCALL, _multibytecodec_MultibyteCodec_encode__doc__},
+    {"encode", (PyCFunction)_multibytecodec_MultibyteCodec_encode, METH_FASTCALL|METH_KEYWORDS, _multibytecodec_MultibyteCodec_encode__doc__},
 
 static PyObject *
 _multibytecodec_MultibyteCodec_encode_impl(MultibyteCodecObject *self,
@@ -52,7 +52,7 @@ PyDoc_STRVAR(_multibytecodec_MultibyteCodec_decode__doc__,
 "codecs.register_error that is able to handle UnicodeDecodeErrors.\"");
 
 #define _MULTIBYTECODEC_MULTIBYTECODEC_DECODE_METHODDEF    \
-    {"decode", (PyCFunction)_multibytecodec_MultibyteCodec_decode, METH_FASTCALL, _multibytecodec_MultibyteCodec_decode__doc__},
+    {"decode", (PyCFunction)_multibytecodec_MultibyteCodec_decode, METH_FASTCALL|METH_KEYWORDS, _multibytecodec_MultibyteCodec_decode__doc__},
 
 static PyObject *
 _multibytecodec_MultibyteCodec_decode_impl(MultibyteCodecObject *self,
@@ -89,7 +89,7 @@ PyDoc_STRVAR(_multibytecodec_MultibyteIncrementalEncoder_encode__doc__,
 "\n");
 
 #define _MULTIBYTECODEC_MULTIBYTEINCREMENTALENCODER_ENCODE_METHODDEF    \
-    {"encode", (PyCFunction)_multibytecodec_MultibyteIncrementalEncoder_encode, METH_FASTCALL, _multibytecodec_MultibyteIncrementalEncoder_encode__doc__},
+    {"encode", (PyCFunction)_multibytecodec_MultibyteIncrementalEncoder_encode, METH_FASTCALL|METH_KEYWORDS, _multibytecodec_MultibyteIncrementalEncoder_encode__doc__},
 
 static PyObject *
 _multibytecodec_MultibyteIncrementalEncoder_encode_impl(MultibyteIncrementalEncoderObject *self,
@@ -138,7 +138,7 @@ PyDoc_STRVAR(_multibytecodec_MultibyteIncrementalDecoder_decode__doc__,
 "\n");
 
 #define _MULTIBYTECODEC_MULTIBYTEINCREMENTALDECODER_DECODE_METHODDEF    \
-    {"decode", (PyCFunction)_multibytecodec_MultibyteIncrementalDecoder_decode, METH_FASTCALL, _multibytecodec_MultibyteIncrementalDecoder_decode__doc__},
+    {"decode", (PyCFunction)_multibytecodec_MultibyteIncrementalDecoder_decode, METH_FASTCALL|METH_KEYWORDS, _multibytecodec_MultibyteIncrementalDecoder_decode__doc__},
 
 static PyObject *
 _multibytecodec_MultibyteIncrementalDecoder_decode_impl(MultibyteIncrementalDecoderObject *self,
@@ -199,14 +199,10 @@ _multibytecodec_MultibyteStreamReader_read_impl(MultibyteStreamReaderObject *sel
                                                 PyObject *sizeobj);
 
 static PyObject *
-_multibytecodec_MultibyteStreamReader_read(MultibyteStreamReaderObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_multibytecodec_MultibyteStreamReader_read(MultibyteStreamReaderObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *sizeobj = Py_None;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "read",
         0, 1,
@@ -232,14 +228,10 @@ _multibytecodec_MultibyteStreamReader_readline_impl(MultibyteStreamReaderObject 
                                                     PyObject *sizeobj);
 
 static PyObject *
-_multibytecodec_MultibyteStreamReader_readline(MultibyteStreamReaderObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_multibytecodec_MultibyteStreamReader_readline(MultibyteStreamReaderObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *sizeobj = Py_None;
-
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "readline",
         0, 1,
@@ -265,14 +257,10 @@ _multibytecodec_MultibyteStreamReader_readlines_impl(MultibyteStreamReaderObject
                                                      PyObject *sizehintobj);
 
 static PyObject *
-_multibytecodec_MultibyteStreamReader_readlines(MultibyteStreamReaderObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_multibytecodec_MultibyteStreamReader_readlines(MultibyteStreamReaderObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *sizehintobj = Py_None;
-
-    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "readlines",
         0, 1,
@@ -342,4 +330,4 @@ PyDoc_STRVAR(_multibytecodec___create_codec__doc__,
 
 #define _MULTIBYTECODEC___CREATE_CODEC_METHODDEF    \
     {"__create_codec", (PyCFunction)_multibytecodec___create_codec, METH_O, _multibytecodec___create_codec__doc__},
-/*[clinic end generated code: output=12192026a9d55d48 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dc2352619de9d74f input=a9049054013a1b77]*/

--- a/Modules/clinic/_asynciomodule.c.h
+++ b/Modules/clinic/_asynciomodule.c.h
@@ -267,7 +267,7 @@ PyDoc_STRVAR(_asyncio_Task_current_task__doc__,
 "None is returned when called not in the context of a Task.");
 
 #define _ASYNCIO_TASK_CURRENT_TASK_METHODDEF    \
-    {"current_task", (PyCFunction)_asyncio_Task_current_task, METH_FASTCALL|METH_CLASS, _asyncio_Task_current_task__doc__},
+    {"current_task", (PyCFunction)_asyncio_Task_current_task, METH_FASTCALL|METH_KEYWORDS|METH_CLASS, _asyncio_Task_current_task__doc__},
 
 static PyObject *
 _asyncio_Task_current_task_impl(PyTypeObject *type, PyObject *loop);
@@ -299,7 +299,7 @@ PyDoc_STRVAR(_asyncio_Task_all_tasks__doc__,
 "By default all tasks for the current event loop are returned.");
 
 #define _ASYNCIO_TASK_ALL_TASKS_METHODDEF    \
-    {"all_tasks", (PyCFunction)_asyncio_Task_all_tasks, METH_FASTCALL|METH_CLASS, _asyncio_Task_all_tasks__doc__},
+    {"all_tasks", (PyCFunction)_asyncio_Task_all_tasks, METH_FASTCALL|METH_KEYWORDS|METH_CLASS, _asyncio_Task_all_tasks__doc__},
 
 static PyObject *
 _asyncio_Task_all_tasks_impl(PyTypeObject *type, PyObject *loop);
@@ -399,7 +399,7 @@ PyDoc_STRVAR(_asyncio_Task_get_stack__doc__,
 "returned for a suspended coroutine.");
 
 #define _ASYNCIO_TASK_GET_STACK_METHODDEF    \
-    {"get_stack", (PyCFunction)_asyncio_Task_get_stack, METH_FASTCALL, _asyncio_Task_get_stack__doc__},
+    {"get_stack", (PyCFunction)_asyncio_Task_get_stack, METH_FASTCALL|METH_KEYWORDS, _asyncio_Task_get_stack__doc__},
 
 static PyObject *
 _asyncio_Task_get_stack_impl(TaskObj *self, PyObject *limit);
@@ -435,7 +435,7 @@ PyDoc_STRVAR(_asyncio_Task_print_stack__doc__,
 "to sys.stderr.");
 
 #define _ASYNCIO_TASK_PRINT_STACK_METHODDEF    \
-    {"print_stack", (PyCFunction)_asyncio_Task_print_stack, METH_FASTCALL, _asyncio_Task_print_stack__doc__},
+    {"print_stack", (PyCFunction)_asyncio_Task_print_stack, METH_FASTCALL|METH_KEYWORDS, _asyncio_Task_print_stack__doc__},
 
 static PyObject *
 _asyncio_Task_print_stack_impl(TaskObj *self, PyObject *limit,
@@ -466,7 +466,7 @@ PyDoc_STRVAR(_asyncio_Task__step__doc__,
 "\n");
 
 #define _ASYNCIO_TASK__STEP_METHODDEF    \
-    {"_step", (PyCFunction)_asyncio_Task__step, METH_FASTCALL, _asyncio_Task__step__doc__},
+    {"_step", (PyCFunction)_asyncio_Task__step, METH_FASTCALL|METH_KEYWORDS, _asyncio_Task__step__doc__},
 
 static PyObject *
 _asyncio_Task__step_impl(TaskObj *self, PyObject *exc);
@@ -495,7 +495,7 @@ PyDoc_STRVAR(_asyncio_Task__wakeup__doc__,
 "\n");
 
 #define _ASYNCIO_TASK__WAKEUP_METHODDEF    \
-    {"_wakeup", (PyCFunction)_asyncio_Task__wakeup, METH_FASTCALL, _asyncio_Task__wakeup__doc__},
+    {"_wakeup", (PyCFunction)_asyncio_Task__wakeup, METH_FASTCALL|METH_KEYWORDS, _asyncio_Task__wakeup__doc__},
 
 static PyObject *
 _asyncio_Task__wakeup_impl(TaskObj *self, PyObject *fut);
@@ -517,4 +517,4 @@ _asyncio_Task__wakeup(TaskObj *self, PyObject **args, Py_ssize_t nargs, PyObject
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3dfec49689cebd4c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fe651840e0466fa9 input=a9049054013a1b77]*/

--- a/Modules/clinic/_bz2module.c.h
+++ b/Modules/clinic/_bz2module.c.h
@@ -115,7 +115,7 @@ PyDoc_STRVAR(_bz2_BZ2Decompressor_decompress__doc__,
 "the unused_data attribute.");
 
 #define _BZ2_BZ2DECOMPRESSOR_DECOMPRESS_METHODDEF    \
-    {"decompress", (PyCFunction)_bz2_BZ2Decompressor_decompress, METH_FASTCALL, _bz2_BZ2Decompressor_decompress__doc__},
+    {"decompress", (PyCFunction)_bz2_BZ2Decompressor_decompress, METH_FASTCALL|METH_KEYWORDS, _bz2_BZ2Decompressor_decompress__doc__},
 
 static PyObject *
 _bz2_BZ2Decompressor_decompress_impl(BZ2Decompressor *self, Py_buffer *data,
@@ -174,4 +174,4 @@ _bz2_BZ2Decompressor___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0e97a1d716b35a14 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=835673574cf12cc4 input=a9049054013a1b77]*/

--- a/Modules/clinic/_codecsmodule.c.h
+++ b/Modules/clinic/_codecsmodule.c.h
@@ -55,7 +55,7 @@ PyDoc_STRVAR(_codecs_encode__doc__,
 "codecs.register_error that can handle ValueErrors.");
 
 #define _CODECS_ENCODE_METHODDEF    \
-    {"encode", (PyCFunction)_codecs_encode, METH_FASTCALL, _codecs_encode__doc__},
+    {"encode", (PyCFunction)_codecs_encode, METH_FASTCALL|METH_KEYWORDS, _codecs_encode__doc__},
 
 static PyObject *
 _codecs_encode_impl(PyObject *module, PyObject *obj, const char *encoding,
@@ -94,7 +94,7 @@ PyDoc_STRVAR(_codecs_decode__doc__,
 "codecs.register_error that can handle ValueErrors.");
 
 #define _CODECS_DECODE_METHODDEF    \
-    {"decode", (PyCFunction)_codecs_decode, METH_FASTCALL, _codecs_decode__doc__},
+    {"decode", (PyCFunction)_codecs_decode, METH_FASTCALL|METH_KEYWORDS, _codecs_decode__doc__},
 
 static PyObject *
 _codecs_decode_impl(PyObject *module, PyObject *obj, const char *encoding,
@@ -160,15 +160,11 @@ _codecs_escape_decode_impl(PyObject *module, Py_buffer *data,
                            const char *errors);
 
 static PyObject *
-_codecs_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("escape_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "s*|z:escape_decode",
         &data, &errors)) {
@@ -198,15 +194,11 @@ _codecs_escape_encode_impl(PyObject *module, PyObject *data,
                            const char *errors);
 
 static PyObject *
-_codecs_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *data;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("escape_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O!|z:escape_encode",
         &PyBytes_Type, &data, &errors)) {
@@ -231,15 +223,11 @@ _codecs_unicode_internal_decode_impl(PyObject *module, PyObject *obj,
                                      const char *errors);
 
 static PyObject *
-_codecs_unicode_internal_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_unicode_internal_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("unicode_internal_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|z:unicode_internal_decode",
         &obj, &errors)) {
@@ -264,16 +252,12 @@ _codecs_utf_7_decode_impl(PyObject *module, Py_buffer *data,
                           const char *errors, int final);
 
 static PyObject *
-_codecs_utf_7_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_7_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_7_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_7_decode",
         &data, &errors, &final)) {
@@ -303,16 +287,12 @@ _codecs_utf_8_decode_impl(PyObject *module, Py_buffer *data,
                           const char *errors, int final);
 
 static PyObject *
-_codecs_utf_8_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_8_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_8_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_8_decode",
         &data, &errors, &final)) {
@@ -342,16 +322,12 @@ _codecs_utf_16_decode_impl(PyObject *module, Py_buffer *data,
                            const char *errors, int final);
 
 static PyObject *
-_codecs_utf_16_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_16_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_16_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_decode",
         &data, &errors, &final)) {
@@ -381,16 +357,12 @@ _codecs_utf_16_le_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final);
 
 static PyObject *
-_codecs_utf_16_le_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_16_le_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_16_le_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_le_decode",
         &data, &errors, &final)) {
@@ -420,16 +392,12 @@ _codecs_utf_16_be_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final);
 
 static PyObject *
-_codecs_utf_16_be_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_16_be_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_16_be_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_be_decode",
         &data, &errors, &final)) {
@@ -460,17 +428,13 @@ _codecs_utf_16_ex_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int byteorder, int final);
 
 static PyObject *
-_codecs_utf_16_ex_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_16_ex_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int byteorder = 0;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_16_ex_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zii:utf_16_ex_decode",
         &data, &errors, &byteorder, &final)) {
@@ -500,16 +464,12 @@ _codecs_utf_32_decode_impl(PyObject *module, Py_buffer *data,
                            const char *errors, int final);
 
 static PyObject *
-_codecs_utf_32_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_32_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_32_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_decode",
         &data, &errors, &final)) {
@@ -539,16 +499,12 @@ _codecs_utf_32_le_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final);
 
 static PyObject *
-_codecs_utf_32_le_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_32_le_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_32_le_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_le_decode",
         &data, &errors, &final)) {
@@ -578,16 +534,12 @@ _codecs_utf_32_be_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int final);
 
 static PyObject *
-_codecs_utf_32_be_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_32_be_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_32_be_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_be_decode",
         &data, &errors, &final)) {
@@ -618,17 +570,13 @@ _codecs_utf_32_ex_decode_impl(PyObject *module, Py_buffer *data,
                               const char *errors, int byteorder, int final);
 
 static PyObject *
-_codecs_utf_32_ex_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_32_ex_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int byteorder = 0;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_32_ex_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zii:utf_32_ex_decode",
         &data, &errors, &byteorder, &final)) {
@@ -658,15 +606,11 @@ _codecs_unicode_escape_decode_impl(PyObject *module, Py_buffer *data,
                                    const char *errors);
 
 static PyObject *
-_codecs_unicode_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_unicode_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("unicode_escape_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "s*|z:unicode_escape_decode",
         &data, &errors)) {
@@ -696,15 +640,11 @@ _codecs_raw_unicode_escape_decode_impl(PyObject *module, Py_buffer *data,
                                        const char *errors);
 
 static PyObject *
-_codecs_raw_unicode_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_raw_unicode_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("raw_unicode_escape_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "s*|z:raw_unicode_escape_decode",
         &data, &errors)) {
@@ -734,15 +674,11 @@ _codecs_latin_1_decode_impl(PyObject *module, Py_buffer *data,
                             const char *errors);
 
 static PyObject *
-_codecs_latin_1_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_latin_1_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("latin_1_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|z:latin_1_decode",
         &data, &errors)) {
@@ -772,15 +708,11 @@ _codecs_ascii_decode_impl(PyObject *module, Py_buffer *data,
                           const char *errors);
 
 static PyObject *
-_codecs_ascii_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_ascii_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("ascii_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|z:ascii_decode",
         &data, &errors)) {
@@ -810,16 +742,12 @@ _codecs_charmap_decode_impl(PyObject *module, Py_buffer *data,
                             const char *errors, PyObject *mapping);
 
 static PyObject *
-_codecs_charmap_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_charmap_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     PyObject *mapping = NULL;
-
-    if (!_PyArg_NoStackKeywords("charmap_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zO:charmap_decode",
         &data, &errors, &mapping)) {
@@ -851,16 +779,12 @@ _codecs_mbcs_decode_impl(PyObject *module, Py_buffer *data,
                          const char *errors, int final);
 
 static PyObject *
-_codecs_mbcs_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_mbcs_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("mbcs_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:mbcs_decode",
         &data, &errors, &final)) {
@@ -894,16 +818,12 @@ _codecs_oem_decode_impl(PyObject *module, Py_buffer *data,
                         const char *errors, int final);
 
 static PyObject *
-_codecs_oem_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_oem_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("oem_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|zi:oem_decode",
         &data, &errors, &final)) {
@@ -937,17 +857,13 @@ _codecs_code_page_decode_impl(PyObject *module, int codepage,
                               Py_buffer *data, const char *errors, int final);
 
 static PyObject *
-_codecs_code_page_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_code_page_decode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int codepage;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
     int final = 0;
-
-    if (!_PyArg_NoStackKeywords("code_page_decode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iy*|zi:code_page_decode",
         &codepage, &data, &errors, &final)) {
@@ -979,15 +895,11 @@ _codecs_readbuffer_encode_impl(PyObject *module, Py_buffer *data,
                                const char *errors);
 
 static PyObject *
-_codecs_readbuffer_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_readbuffer_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("readbuffer_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "s*|z:readbuffer_encode",
         &data, &errors)) {
@@ -1017,15 +929,11 @@ _codecs_unicode_internal_encode_impl(PyObject *module, PyObject *obj,
                                      const char *errors);
 
 static PyObject *
-_codecs_unicode_internal_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_unicode_internal_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("unicode_internal_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|z:unicode_internal_encode",
         &obj, &errors)) {
@@ -1050,15 +958,11 @@ _codecs_utf_7_encode_impl(PyObject *module, PyObject *str,
                           const char *errors);
 
 static PyObject *
-_codecs_utf_7_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_7_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("utf_7_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:utf_7_encode",
         &str, &errors)) {
@@ -1083,15 +987,11 @@ _codecs_utf_8_encode_impl(PyObject *module, PyObject *str,
                           const char *errors);
 
 static PyObject *
-_codecs_utf_8_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_8_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("utf_8_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:utf_8_encode",
         &str, &errors)) {
@@ -1116,16 +1016,12 @@ _codecs_utf_16_encode_impl(PyObject *module, PyObject *str,
                            const char *errors, int byteorder);
 
 static PyObject *
-_codecs_utf_16_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_16_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
     int byteorder = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_16_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|zi:utf_16_encode",
         &str, &errors, &byteorder)) {
@@ -1150,15 +1046,11 @@ _codecs_utf_16_le_encode_impl(PyObject *module, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_utf_16_le_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_16_le_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("utf_16_le_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:utf_16_le_encode",
         &str, &errors)) {
@@ -1183,15 +1075,11 @@ _codecs_utf_16_be_encode_impl(PyObject *module, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_utf_16_be_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_16_be_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("utf_16_be_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:utf_16_be_encode",
         &str, &errors)) {
@@ -1216,16 +1104,12 @@ _codecs_utf_32_encode_impl(PyObject *module, PyObject *str,
                            const char *errors, int byteorder);
 
 static PyObject *
-_codecs_utf_32_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_32_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
     int byteorder = 0;
-
-    if (!_PyArg_NoStackKeywords("utf_32_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|zi:utf_32_encode",
         &str, &errors, &byteorder)) {
@@ -1250,15 +1134,11 @@ _codecs_utf_32_le_encode_impl(PyObject *module, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_utf_32_le_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_32_le_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("utf_32_le_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:utf_32_le_encode",
         &str, &errors)) {
@@ -1283,15 +1163,11 @@ _codecs_utf_32_be_encode_impl(PyObject *module, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_utf_32_be_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_utf_32_be_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("utf_32_be_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:utf_32_be_encode",
         &str, &errors)) {
@@ -1316,15 +1192,11 @@ _codecs_unicode_escape_encode_impl(PyObject *module, PyObject *str,
                                    const char *errors);
 
 static PyObject *
-_codecs_unicode_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_unicode_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("unicode_escape_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:unicode_escape_encode",
         &str, &errors)) {
@@ -1349,15 +1221,11 @@ _codecs_raw_unicode_escape_encode_impl(PyObject *module, PyObject *str,
                                        const char *errors);
 
 static PyObject *
-_codecs_raw_unicode_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_raw_unicode_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("raw_unicode_escape_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:raw_unicode_escape_encode",
         &str, &errors)) {
@@ -1382,15 +1250,11 @@ _codecs_latin_1_encode_impl(PyObject *module, PyObject *str,
                             const char *errors);
 
 static PyObject *
-_codecs_latin_1_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_latin_1_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("latin_1_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:latin_1_encode",
         &str, &errors)) {
@@ -1415,15 +1279,11 @@ _codecs_ascii_encode_impl(PyObject *module, PyObject *str,
                           const char *errors);
 
 static PyObject *
-_codecs_ascii_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_ascii_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("ascii_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:ascii_encode",
         &str, &errors)) {
@@ -1448,16 +1308,12 @@ _codecs_charmap_encode_impl(PyObject *module, PyObject *str,
                             const char *errors, PyObject *mapping);
 
 static PyObject *
-_codecs_charmap_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_charmap_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
     PyObject *mapping = NULL;
-
-    if (!_PyArg_NoStackKeywords("charmap_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|zO:charmap_encode",
         &str, &errors, &mapping)) {
@@ -1509,15 +1365,11 @@ static PyObject *
 _codecs_mbcs_encode_impl(PyObject *module, PyObject *str, const char *errors);
 
 static PyObject *
-_codecs_mbcs_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_mbcs_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("mbcs_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:mbcs_encode",
         &str, &errors)) {
@@ -1545,15 +1397,11 @@ static PyObject *
 _codecs_oem_encode_impl(PyObject *module, PyObject *str, const char *errors);
 
 static PyObject *
-_codecs_oem_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_oem_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("oem_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "U|z:oem_encode",
         &str, &errors)) {
@@ -1582,16 +1430,12 @@ _codecs_code_page_encode_impl(PyObject *module, int code_page, PyObject *str,
                               const char *errors);
 
 static PyObject *
-_codecs_code_page_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_code_page_encode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int code_page;
     PyObject *str;
     const char *errors = NULL;
-
-    if (!_PyArg_NoStackKeywords("code_page_encode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iU|z:code_page_encode",
         &code_page, &str, &errors)) {
@@ -1623,15 +1467,11 @@ _codecs_register_error_impl(PyObject *module, const char *errors,
                             PyObject *handler);
 
 static PyObject *
-_codecs_register_error(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_codecs_register_error(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *errors;
     PyObject *handler;
-
-    if (!_PyArg_NoStackKeywords("register_error", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "sO:register_error",
         &errors, &handler)) {
@@ -1696,4 +1536,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=11fdb992ba55fd73 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=894910ed4900eeae input=a9049054013a1b77]*/

--- a/Modules/clinic/_cryptmodule.c.h
+++ b/Modules/clinic/_cryptmodule.c.h
@@ -20,15 +20,11 @@ static PyObject *
 crypt_crypt_impl(PyObject *module, const char *word, const char *salt);
 
 static PyObject *
-crypt_crypt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+crypt_crypt(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *word;
     const char *salt;
-
-    if (!_PyArg_NoStackKeywords("crypt", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ss:crypt",
         &word, &salt)) {
@@ -39,4 +35,4 @@ crypt_crypt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ebdc6b6a5dec4539 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f5a6aff28d43154f input=a9049054013a1b77]*/

--- a/Modules/clinic/_datetimemodule.c.h
+++ b/Modules/clinic/_datetimemodule.c.h
@@ -14,7 +14,7 @@ PyDoc_STRVAR(datetime_datetime_now__doc__,
 "If no tz is specified, uses local timezone.");
 
 #define DATETIME_DATETIME_NOW_METHODDEF    \
-    {"now", (PyCFunction)datetime_datetime_now, METH_FASTCALL|METH_CLASS, datetime_datetime_now__doc__},
+    {"now", (PyCFunction)datetime_datetime_now, METH_FASTCALL|METH_KEYWORDS|METH_CLASS, datetime_datetime_now__doc__},
 
 static PyObject *
 datetime_datetime_now_impl(PyTypeObject *type, PyObject *tz);
@@ -36,4 +36,4 @@ datetime_datetime_now(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyO
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ff78f2f51687e9a9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=93cb014e47dae4b3 input=a9049054013a1b77]*/

--- a/Modules/clinic/_dbmmodule.c.h
+++ b/Modules/clinic/_dbmmodule.c.h
@@ -52,16 +52,12 @@ _dbm_dbm_get_impl(dbmobject *self, const char *key,
                   Py_ssize_clean_t key_length, PyObject *default_value);
 
 static PyObject *
-_dbm_dbm_get(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_dbm_dbm_get(dbmobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *key;
     Py_ssize_clean_t key_length;
     PyObject *default_value = NULL;
-
-    if (!_PyArg_NoStackKeywords("get", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "s#|O:get",
         &key, &key_length, &default_value)) {
@@ -90,16 +86,12 @@ _dbm_dbm_setdefault_impl(dbmobject *self, const char *key,
                          PyObject *default_value);
 
 static PyObject *
-_dbm_dbm_setdefault(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_dbm_dbm_setdefault(dbmobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *key;
     Py_ssize_clean_t key_length;
     PyObject *default_value = NULL;
-
-    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "s#|O:setdefault",
         &key, &key_length, &default_value)) {
@@ -133,16 +125,12 @@ dbmopen_impl(PyObject *module, const char *filename, const char *flags,
              int mode);
 
 static PyObject *
-dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *filename;
     const char *flags = "r";
     int mode = 438;
-
-    if (!_PyArg_NoStackKeywords("open", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "s|si:open",
         &filename, &flags, &mode)) {
@@ -153,4 +141,4 @@ dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=35a8df9a8e4ed18f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=627d28ce1f3188dc input=a9049054013a1b77]*/

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -136,7 +136,7 @@ PyDoc_STRVAR(_elementtree_Element_find__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_FIND_METHODDEF    \
-    {"find", (PyCFunction)_elementtree_Element_find, METH_FASTCALL, _elementtree_Element_find__doc__},
+    {"find", (PyCFunction)_elementtree_Element_find, METH_FASTCALL|METH_KEYWORDS, _elementtree_Element_find__doc__},
 
 static PyObject *
 _elementtree_Element_find_impl(ElementObject *self, PyObject *path,
@@ -167,7 +167,7 @@ PyDoc_STRVAR(_elementtree_Element_findtext__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_FINDTEXT_METHODDEF    \
-    {"findtext", (PyCFunction)_elementtree_Element_findtext, METH_FASTCALL, _elementtree_Element_findtext__doc__},
+    {"findtext", (PyCFunction)_elementtree_Element_findtext, METH_FASTCALL|METH_KEYWORDS, _elementtree_Element_findtext__doc__},
 
 static PyObject *
 _elementtree_Element_findtext_impl(ElementObject *self, PyObject *path,
@@ -200,7 +200,7 @@ PyDoc_STRVAR(_elementtree_Element_findall__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_FINDALL_METHODDEF    \
-    {"findall", (PyCFunction)_elementtree_Element_findall, METH_FASTCALL, _elementtree_Element_findall__doc__},
+    {"findall", (PyCFunction)_elementtree_Element_findall, METH_FASTCALL|METH_KEYWORDS, _elementtree_Element_findall__doc__},
 
 static PyObject *
 _elementtree_Element_findall_impl(ElementObject *self, PyObject *path,
@@ -231,7 +231,7 @@ PyDoc_STRVAR(_elementtree_Element_iterfind__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_ITERFIND_METHODDEF    \
-    {"iterfind", (PyCFunction)_elementtree_Element_iterfind, METH_FASTCALL, _elementtree_Element_iterfind__doc__},
+    {"iterfind", (PyCFunction)_elementtree_Element_iterfind, METH_FASTCALL|METH_KEYWORDS, _elementtree_Element_iterfind__doc__},
 
 static PyObject *
 _elementtree_Element_iterfind_impl(ElementObject *self, PyObject *path,
@@ -262,7 +262,7 @@ PyDoc_STRVAR(_elementtree_Element_get__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_GET_METHODDEF    \
-    {"get", (PyCFunction)_elementtree_Element_get, METH_FASTCALL, _elementtree_Element_get__doc__},
+    {"get", (PyCFunction)_elementtree_Element_get, METH_FASTCALL|METH_KEYWORDS, _elementtree_Element_get__doc__},
 
 static PyObject *
 _elementtree_Element_get_impl(ElementObject *self, PyObject *key,
@@ -310,7 +310,7 @@ PyDoc_STRVAR(_elementtree_Element_iter__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_ITER_METHODDEF    \
-    {"iter", (PyCFunction)_elementtree_Element_iter, METH_FASTCALL, _elementtree_Element_iter__doc__},
+    {"iter", (PyCFunction)_elementtree_Element_iter, METH_FASTCALL|METH_KEYWORDS, _elementtree_Element_iter__doc__},
 
 static PyObject *
 _elementtree_Element_iter_impl(ElementObject *self, PyObject *tag);
@@ -339,7 +339,7 @@ PyDoc_STRVAR(_elementtree_Element_getiterator__doc__,
 "\n");
 
 #define _ELEMENTTREE_ELEMENT_GETITERATOR_METHODDEF    \
-    {"getiterator", (PyCFunction)_elementtree_Element_getiterator, METH_FASTCALL, _elementtree_Element_getiterator__doc__},
+    {"getiterator", (PyCFunction)_elementtree_Element_getiterator, METH_FASTCALL|METH_KEYWORDS, _elementtree_Element_getiterator__doc__},
 
 static PyObject *
 _elementtree_Element_getiterator_impl(ElementObject *self, PyObject *tag);
@@ -392,15 +392,11 @@ _elementtree_Element_insert_impl(ElementObject *self, Py_ssize_t index,
                                  PyObject *subelement);
 
 static PyObject *
-_elementtree_Element_insert(ElementObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_elementtree_Element_insert(ElementObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t index;
     PyObject *subelement;
-
-    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "nO!:insert",
         &index, &Element_Type, &subelement)) {
@@ -459,15 +455,11 @@ _elementtree_Element_makeelement_impl(ElementObject *self, PyObject *tag,
                                       PyObject *attrib);
 
 static PyObject *
-_elementtree_Element_makeelement(ElementObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_elementtree_Element_makeelement(ElementObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *tag;
     PyObject *attrib;
-
-    if (!_PyArg_NoStackKeywords("makeelement", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "makeelement",
         2, 2,
@@ -519,15 +511,11 @@ _elementtree_Element_set_impl(ElementObject *self, PyObject *key,
                               PyObject *value);
 
 static PyObject *
-_elementtree_Element_set(ElementObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_elementtree_Element_set(ElementObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *key;
     PyObject *value;
-
-    if (!_PyArg_NoStackKeywords("set", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "set",
         2, 2,
@@ -608,15 +596,11 @@ _elementtree_TreeBuilder_start_impl(TreeBuilderObject *self, PyObject *tag,
                                     PyObject *attrs);
 
 static PyObject *
-_elementtree_TreeBuilder_start(TreeBuilderObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_elementtree_TreeBuilder_start(TreeBuilderObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *tag;
     PyObject *attrs = Py_None;
-
-    if (!_PyArg_NoStackKeywords("start", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "start",
         1, 2,
@@ -699,16 +683,12 @@ _elementtree_XMLParser_doctype_impl(XMLParserObject *self, PyObject *name,
                                     PyObject *pubid, PyObject *system);
 
 static PyObject *
-_elementtree_XMLParser_doctype(XMLParserObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_elementtree_XMLParser_doctype(XMLParserObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *name;
     PyObject *pubid;
     PyObject *system;
-
-    if (!_PyArg_NoStackKeywords("doctype", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "doctype",
         3, 3,
@@ -735,15 +715,11 @@ _elementtree_XMLParser__setevents_impl(XMLParserObject *self,
                                        PyObject *events_to_report);
 
 static PyObject *
-_elementtree_XMLParser__setevents(XMLParserObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_elementtree_XMLParser__setevents(XMLParserObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *events_queue;
     PyObject *events_to_report = Py_None;
-
-    if (!_PyArg_NoStackKeywords("_setevents", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "_setevents",
         1, 2,
@@ -755,4 +731,4 @@ _elementtree_XMLParser__setevents(XMLParserObject *self, PyObject **args, Py_ssi
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6606b1018d2562e1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=75d0ff80e20b830f input=a9049054013a1b77]*/

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -15,15 +15,11 @@ static PyObject *
 _gdbm_gdbm_get_impl(dbmobject *self, PyObject *key, PyObject *default_value);
 
 static PyObject *
-_gdbm_gdbm_get(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_gdbm_gdbm_get(dbmobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *key;
     PyObject *default_value = Py_None;
-
-    if (!_PyArg_NoStackKeywords("get", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "get",
         1, 2,
@@ -50,15 +46,11 @@ _gdbm_gdbm_setdefault_impl(dbmobject *self, PyObject *key,
                            PyObject *default_value);
 
 static PyObject *
-_gdbm_gdbm_setdefault(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_gdbm_gdbm_setdefault(dbmobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *key;
     PyObject *default_value = Py_None;
-
-    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "setdefault",
         1, 2,
@@ -245,16 +237,12 @@ static PyObject *
 dbmopen_impl(PyObject *module, const char *name, const char *flags, int mode);
 
 static PyObject *
-dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *name;
     const char *flags = "r";
     int mode = 438;
-
-    if (!_PyArg_NoStackKeywords("open", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "s|si:open",
         &name, &flags, &mode)) {
@@ -265,4 +253,4 @@ dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=94c5713a85dab560 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9c72502b30bb7485 input=a9049054013a1b77]*/

--- a/Modules/clinic/_hashopenssl.c.h
+++ b/Modules/clinic/_hashopenssl.c.h
@@ -12,7 +12,7 @@ PyDoc_STRVAR(_hashlib_scrypt__doc__,
 "scrypt password-based key derivation function.");
 
 #define _HASHLIB_SCRYPT_METHODDEF    \
-    {"scrypt", (PyCFunction)_hashlib_scrypt, METH_FASTCALL, _hashlib_scrypt__doc__},
+    {"scrypt", (PyCFunction)_hashlib_scrypt, METH_FASTCALL|METH_KEYWORDS, _hashlib_scrypt__doc__},
 
 static PyObject *
 _hashlib_scrypt_impl(PyObject *module, Py_buffer *password, Py_buffer *salt,
@@ -57,4 +57,4 @@ exit:
 #ifndef _HASHLIB_SCRYPT_METHODDEF
     #define _HASHLIB_SCRYPT_METHODDEF
 #endif /* !defined(_HASHLIB_SCRYPT_METHODDEF) */
-/*[clinic end generated code: output=71f1e033efe4ac9a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=eda2a998d5b29030 input=a9049054013a1b77]*/

--- a/Modules/clinic/_lzmamodule.c.h
+++ b/Modules/clinic/_lzmamodule.c.h
@@ -81,7 +81,7 @@ PyDoc_STRVAR(_lzma_LZMADecompressor_decompress__doc__,
 "the unused_data attribute.");
 
 #define _LZMA_LZMADECOMPRESSOR_DECOMPRESS_METHODDEF    \
-    {"decompress", (PyCFunction)_lzma_LZMADecompressor_decompress, METH_FASTCALL, _lzma_LZMADecompressor_decompress__doc__},
+    {"decompress", (PyCFunction)_lzma_LZMADecompressor_decompress, METH_FASTCALL|METH_KEYWORDS, _lzma_LZMADecompressor_decompress__doc__},
 
 static PyObject *
 _lzma_LZMADecompressor_decompress_impl(Decompressor *self, Py_buffer *data,
@@ -236,15 +236,11 @@ _lzma__decode_filter_properties_impl(PyObject *module, lzma_vli filter_id,
                                      Py_buffer *encoded_props);
 
 static PyObject *
-_lzma__decode_filter_properties(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_lzma__decode_filter_properties(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     lzma_vli filter_id;
     Py_buffer encoded_props = {NULL, NULL};
-
-    if (!_PyArg_NoStackKeywords("_decode_filter_properties", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&y*:_decode_filter_properties",
         lzma_vli_converter, &filter_id, &encoded_props)) {
@@ -260,4 +256,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=473cf89eb501c28b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d4e3802d0dea9af3 input=a9049054013a1b77]*/

--- a/Modules/clinic/_opcode.c.h
+++ b/Modules/clinic/_opcode.c.h
@@ -15,16 +15,12 @@ static int
 _opcode_stack_effect_impl(PyObject *module, int opcode, PyObject *oparg);
 
 static PyObject *
-_opcode_stack_effect(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_opcode_stack_effect(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int opcode;
     PyObject *oparg = Py_None;
     int _return_value;
-
-    if (!_PyArg_NoStackKeywords("stack_effect", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "i|O:stack_effect",
         &opcode, &oparg)) {
@@ -39,4 +35,4 @@ _opcode_stack_effect(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=38f3bf305b3bb601 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=616105b05b55eb45 input=a9049054013a1b77]*/

--- a/Modules/clinic/_operator.c.h
+++ b/Modules/clinic/_operator.c.h
@@ -43,15 +43,11 @@ static PyObject *
 _operator_add_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_add(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_add(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("add", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "add",
         2, 2,
@@ -77,15 +73,11 @@ static PyObject *
 _operator_sub_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_sub(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_sub(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("sub", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "sub",
         2, 2,
@@ -111,15 +103,11 @@ static PyObject *
 _operator_mul_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_mul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_mul(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("mul", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "mul",
         2, 2,
@@ -145,15 +133,11 @@ static PyObject *
 _operator_matmul_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_matmul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_matmul(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("matmul", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "matmul",
         2, 2,
@@ -179,15 +163,11 @@ static PyObject *
 _operator_floordiv_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_floordiv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_floordiv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("floordiv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "floordiv",
         2, 2,
@@ -213,15 +193,11 @@ static PyObject *
 _operator_truediv_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_truediv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_truediv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("truediv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "truediv",
         2, 2,
@@ -247,15 +223,11 @@ static PyObject *
 _operator_mod_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_mod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_mod(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("mod", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "mod",
         2, 2,
@@ -326,15 +298,11 @@ static PyObject *
 _operator_lshift_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_lshift(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_lshift(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("lshift", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "lshift",
         2, 2,
@@ -360,15 +328,11 @@ static PyObject *
 _operator_rshift_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_rshift(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_rshift(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("rshift", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "rshift",
         2, 2,
@@ -422,15 +386,11 @@ static PyObject *
 _operator_and__impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_and_(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_and_(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("and_", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "and_",
         2, 2,
@@ -456,15 +416,11 @@ static PyObject *
 _operator_xor_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_xor(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_xor(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("xor", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "xor",
         2, 2,
@@ -490,15 +446,11 @@ static PyObject *
 _operator_or__impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_or_(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_or_(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("or_", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "or_",
         2, 2,
@@ -524,15 +476,11 @@ static PyObject *
 _operator_iadd_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_iadd(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_iadd(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("iadd", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "iadd",
         2, 2,
@@ -558,15 +506,11 @@ static PyObject *
 _operator_isub_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_isub(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_isub(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("isub", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "isub",
         2, 2,
@@ -592,15 +536,11 @@ static PyObject *
 _operator_imul_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_imul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_imul(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("imul", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "imul",
         2, 2,
@@ -626,15 +566,11 @@ static PyObject *
 _operator_imatmul_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_imatmul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_imatmul(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("imatmul", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "imatmul",
         2, 2,
@@ -660,15 +596,11 @@ static PyObject *
 _operator_ifloordiv_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_ifloordiv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_ifloordiv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("ifloordiv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "ifloordiv",
         2, 2,
@@ -694,15 +626,11 @@ static PyObject *
 _operator_itruediv_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_itruediv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_itruediv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("itruediv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "itruediv",
         2, 2,
@@ -728,15 +656,11 @@ static PyObject *
 _operator_imod_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_imod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_imod(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("imod", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "imod",
         2, 2,
@@ -762,15 +686,11 @@ static PyObject *
 _operator_ilshift_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_ilshift(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_ilshift(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("ilshift", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "ilshift",
         2, 2,
@@ -796,15 +716,11 @@ static PyObject *
 _operator_irshift_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_irshift(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_irshift(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("irshift", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "irshift",
         2, 2,
@@ -830,15 +746,11 @@ static PyObject *
 _operator_iand_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_iand(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_iand(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("iand", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "iand",
         2, 2,
@@ -864,15 +776,11 @@ static PyObject *
 _operator_ixor_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_ixor(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_ixor(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("ixor", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "ixor",
         2, 2,
@@ -898,15 +806,11 @@ static PyObject *
 _operator_ior_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_ior(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_ior(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("ior", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "ior",
         2, 2,
@@ -932,15 +836,11 @@ static PyObject *
 _operator_concat_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_concat(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_concat(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("concat", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "concat",
         2, 2,
@@ -966,15 +866,11 @@ static PyObject *
 _operator_iconcat_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_iconcat(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_iconcat(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("iconcat", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "iconcat",
         2, 2,
@@ -1000,16 +896,12 @@ static int
 _operator_contains_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_contains(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_contains(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
     int _return_value;
-
-    if (!_PyArg_NoStackKeywords("contains", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "contains",
         2, 2,
@@ -1039,16 +931,12 @@ static Py_ssize_t
 _operator_indexOf_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_indexOf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_indexOf(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
     Py_ssize_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("indexOf", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "indexOf",
         2, 2,
@@ -1078,16 +966,12 @@ static Py_ssize_t
 _operator_countOf_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_countOf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_countOf(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
     Py_ssize_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("countOf", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "countOf",
         2, 2,
@@ -1117,15 +1001,11 @@ static PyObject *
 _operator_getitem_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_getitem(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_getitem(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("getitem", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "getitem",
         2, 2,
@@ -1152,16 +1032,12 @@ _operator_setitem_impl(PyObject *module, PyObject *a, PyObject *b,
                        PyObject *c);
 
 static PyObject *
-_operator_setitem(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_setitem(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
     PyObject *c;
-
-    if (!_PyArg_NoStackKeywords("setitem", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "setitem",
         3, 3,
@@ -1187,15 +1063,11 @@ static PyObject *
 _operator_delitem_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_delitem(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_delitem(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("delitem", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "delitem",
         2, 2,
@@ -1221,15 +1093,11 @@ static PyObject *
 _operator_eq_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_eq(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_eq(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("eq", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "eq",
         2, 2,
@@ -1255,15 +1123,11 @@ static PyObject *
 _operator_ne_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_ne(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_ne(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("ne", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "ne",
         2, 2,
@@ -1289,15 +1153,11 @@ static PyObject *
 _operator_lt_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_lt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_lt(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("lt", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "lt",
         2, 2,
@@ -1323,15 +1183,11 @@ static PyObject *
 _operator_le_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_le(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_le(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("le", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "le",
         2, 2,
@@ -1357,15 +1213,11 @@ static PyObject *
 _operator_gt_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_gt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_gt(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("gt", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "gt",
         2, 2,
@@ -1391,15 +1243,11 @@ static PyObject *
 _operator_ge_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_ge(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_ge(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("ge", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "ge",
         2, 2,
@@ -1425,15 +1273,11 @@ static PyObject *
 _operator_pow_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_pow(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_pow(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "pow",
         2, 2,
@@ -1459,15 +1303,11 @@ static PyObject *
 _operator_ipow_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_ipow(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_ipow(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("ipow", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "ipow",
         2, 2,
@@ -1502,15 +1342,11 @@ static PyObject *
 _operator_is__impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_is_(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_is_(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("is_", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "is_",
         2, 2,
@@ -1536,15 +1372,11 @@ static PyObject *
 _operator_is_not_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator_is_not(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_is_not(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("is_not", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "is_not",
         2, 2,
@@ -1577,16 +1409,12 @@ _operator_length_hint_impl(PyObject *module, PyObject *obj,
                            Py_ssize_t default_value);
 
 static PyObject *
-_operator_length_hint(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator_length_hint(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     Py_ssize_t default_value = 0;
     Py_ssize_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("length_hint", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|n:length_hint",
         &obj, &default_value)) {
@@ -1625,15 +1453,11 @@ static PyObject *
 _operator__compare_digest_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-_operator__compare_digest(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_operator__compare_digest(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("_compare_digest", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "_compare_digest",
         2, 2,
@@ -1645,4 +1469,4 @@ _operator__compare_digest(PyObject *module, PyObject **args, Py_ssize_t nargs, P
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=fa8d3eeea396bbec input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7c42956af269cb21 input=a9049054013a1b77]*/

--- a/Modules/clinic/_pickle.c.h
+++ b/Modules/clinic/_pickle.c.h
@@ -207,15 +207,11 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
                                   PyObject *global_name);
 
 static PyObject *
-_pickle_Unpickler_find_class(UnpicklerObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_pickle_Unpickler_find_class(UnpicklerObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *module_name;
     PyObject *global_name;
-
-    if (!_PyArg_NoStackKeywords("find_class", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "find_class",
         2, 2,
@@ -388,7 +384,7 @@ PyDoc_STRVAR(_pickle_dump__doc__,
 "2, so that the pickle data stream is readable with Python 2.");
 
 #define _PICKLE_DUMP_METHODDEF    \
-    {"dump", (PyCFunction)_pickle_dump, METH_FASTCALL, _pickle_dump__doc__},
+    {"dump", (PyCFunction)_pickle_dump, METH_FASTCALL|METH_KEYWORDS, _pickle_dump__doc__},
 
 static PyObject *
 _pickle_dump_impl(PyObject *module, PyObject *obj, PyObject *file,
@@ -434,7 +430,7 @@ PyDoc_STRVAR(_pickle_dumps__doc__,
 "Python 2, so that the pickle data stream is readable with Python 2.");
 
 #define _PICKLE_DUMPS_METHODDEF    \
-    {"dumps", (PyCFunction)_pickle_dumps, METH_FASTCALL, _pickle_dumps__doc__},
+    {"dumps", (PyCFunction)_pickle_dumps, METH_FASTCALL|METH_KEYWORDS, _pickle_dumps__doc__},
 
 static PyObject *
 _pickle_dumps_impl(PyObject *module, PyObject *obj, PyObject *protocol,
@@ -490,7 +486,7 @@ PyDoc_STRVAR(_pickle_load__doc__,
 "string instances as bytes objects.");
 
 #define _PICKLE_LOAD_METHODDEF    \
-    {"load", (PyCFunction)_pickle_load, METH_FASTCALL, _pickle_load__doc__},
+    {"load", (PyCFunction)_pickle_load, METH_FASTCALL|METH_KEYWORDS, _pickle_load__doc__},
 
 static PyObject *
 _pickle_load_impl(PyObject *module, PyObject *file, int fix_imports,
@@ -538,7 +534,7 @@ PyDoc_STRVAR(_pickle_loads__doc__,
 "string instances as bytes objects.");
 
 #define _PICKLE_LOADS_METHODDEF    \
-    {"loads", (PyCFunction)_pickle_loads, METH_FASTCALL, _pickle_loads__doc__},
+    {"loads", (PyCFunction)_pickle_loads, METH_FASTCALL|METH_KEYWORDS, _pickle_loads__doc__},
 
 static PyObject *
 _pickle_loads_impl(PyObject *module, PyObject *data, int fix_imports,
@@ -564,4 +560,4 @@ _pickle_loads(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=639dd0eb8de16c3c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a6243aaa6ea98732 input=a9049054013a1b77]*/

--- a/Modules/clinic/_sre.c.h
+++ b/Modules/clinic/_sre.c.h
@@ -160,7 +160,7 @@ PyDoc_STRVAR(_sre_SRE_Pattern_match__doc__,
 "Matches zero or more characters at the beginning of the string.");
 
 #define _SRE_SRE_PATTERN_MATCH_METHODDEF    \
-    {"match", (PyCFunction)_sre_SRE_Pattern_match, METH_FASTCALL, _sre_SRE_Pattern_match__doc__},
+    {"match", (PyCFunction)_sre_SRE_Pattern_match, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Pattern_match__doc__},
 
 static PyObject *
 _sre_SRE_Pattern_match_impl(PatternObject *self, PyObject *string,
@@ -193,7 +193,7 @@ PyDoc_STRVAR(_sre_SRE_Pattern_fullmatch__doc__,
 "Matches against all of the string");
 
 #define _SRE_SRE_PATTERN_FULLMATCH_METHODDEF    \
-    {"fullmatch", (PyCFunction)_sre_SRE_Pattern_fullmatch, METH_FASTCALL, _sre_SRE_Pattern_fullmatch__doc__},
+    {"fullmatch", (PyCFunction)_sre_SRE_Pattern_fullmatch, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Pattern_fullmatch__doc__},
 
 static PyObject *
 _sre_SRE_Pattern_fullmatch_impl(PatternObject *self, PyObject *string,
@@ -228,7 +228,7 @@ PyDoc_STRVAR(_sre_SRE_Pattern_search__doc__,
 "Return None if no position in the string matches.");
 
 #define _SRE_SRE_PATTERN_SEARCH_METHODDEF    \
-    {"search", (PyCFunction)_sre_SRE_Pattern_search, METH_FASTCALL, _sre_SRE_Pattern_search__doc__},
+    {"search", (PyCFunction)_sre_SRE_Pattern_search, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Pattern_search__doc__},
 
 static PyObject *
 _sre_SRE_Pattern_search_impl(PatternObject *self, PyObject *string,
@@ -261,7 +261,7 @@ PyDoc_STRVAR(_sre_SRE_Pattern_findall__doc__,
 "Return a list of all non-overlapping matches of pattern in string.");
 
 #define _SRE_SRE_PATTERN_FINDALL_METHODDEF    \
-    {"findall", (PyCFunction)_sre_SRE_Pattern_findall, METH_FASTCALL, _sre_SRE_Pattern_findall__doc__},
+    {"findall", (PyCFunction)_sre_SRE_Pattern_findall, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Pattern_findall__doc__},
 
 static PyObject *
 _sre_SRE_Pattern_findall_impl(PatternObject *self, PyObject *string,
@@ -296,7 +296,7 @@ PyDoc_STRVAR(_sre_SRE_Pattern_finditer__doc__,
 "For each match, the iterator returns a match object.");
 
 #define _SRE_SRE_PATTERN_FINDITER_METHODDEF    \
-    {"finditer", (PyCFunction)_sre_SRE_Pattern_finditer, METH_FASTCALL, _sre_SRE_Pattern_finditer__doc__},
+    {"finditer", (PyCFunction)_sre_SRE_Pattern_finditer, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Pattern_finditer__doc__},
 
 static PyObject *
 _sre_SRE_Pattern_finditer_impl(PatternObject *self, PyObject *string,
@@ -328,7 +328,7 @@ PyDoc_STRVAR(_sre_SRE_Pattern_scanner__doc__,
 "\n");
 
 #define _SRE_SRE_PATTERN_SCANNER_METHODDEF    \
-    {"scanner", (PyCFunction)_sre_SRE_Pattern_scanner, METH_FASTCALL, _sre_SRE_Pattern_scanner__doc__},
+    {"scanner", (PyCFunction)_sre_SRE_Pattern_scanner, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Pattern_scanner__doc__},
 
 static PyObject *
 _sre_SRE_Pattern_scanner_impl(PatternObject *self, PyObject *string,
@@ -361,7 +361,7 @@ PyDoc_STRVAR(_sre_SRE_Pattern_split__doc__,
 "Split string by the occurrences of pattern.");
 
 #define _SRE_SRE_PATTERN_SPLIT_METHODDEF    \
-    {"split", (PyCFunction)_sre_SRE_Pattern_split, METH_FASTCALL, _sre_SRE_Pattern_split__doc__},
+    {"split", (PyCFunction)_sre_SRE_Pattern_split, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Pattern_split__doc__},
 
 static PyObject *
 _sre_SRE_Pattern_split_impl(PatternObject *self, PyObject *string,
@@ -393,7 +393,7 @@ PyDoc_STRVAR(_sre_SRE_Pattern_sub__doc__,
 "Return the string obtained by replacing the leftmost non-overlapping occurrences of pattern in string by the replacement repl.");
 
 #define _SRE_SRE_PATTERN_SUB_METHODDEF    \
-    {"sub", (PyCFunction)_sre_SRE_Pattern_sub, METH_FASTCALL, _sre_SRE_Pattern_sub__doc__},
+    {"sub", (PyCFunction)_sre_SRE_Pattern_sub, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Pattern_sub__doc__},
 
 static PyObject *
 _sre_SRE_Pattern_sub_impl(PatternObject *self, PyObject *repl,
@@ -426,7 +426,7 @@ PyDoc_STRVAR(_sre_SRE_Pattern_subn__doc__,
 "Return the tuple (new_string, number_of_subs_made) found by replacing the leftmost non-overlapping occurrences of pattern with the replacement repl.");
 
 #define _SRE_SRE_PATTERN_SUBN_METHODDEF    \
-    {"subn", (PyCFunction)_sre_SRE_Pattern_subn, METH_FASTCALL, _sre_SRE_Pattern_subn__doc__},
+    {"subn", (PyCFunction)_sre_SRE_Pattern_subn, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Pattern_subn__doc__},
 
 static PyObject *
 _sre_SRE_Pattern_subn_impl(PatternObject *self, PyObject *repl,
@@ -484,7 +484,7 @@ PyDoc_STRVAR(_sre_compile__doc__,
 "\n");
 
 #define _SRE_COMPILE_METHODDEF    \
-    {"compile", (PyCFunction)_sre_compile, METH_FASTCALL, _sre_compile__doc__},
+    {"compile", (PyCFunction)_sre_compile, METH_FASTCALL|METH_KEYWORDS, _sre_compile__doc__},
 
 static PyObject *
 _sre_compile_impl(PyObject *module, PyObject *pattern, int flags,
@@ -521,7 +521,7 @@ PyDoc_STRVAR(_sre_SRE_Match_expand__doc__,
 "Return the string obtained by doing backslash substitution on the string template, as done by the sub() method.");
 
 #define _SRE_SRE_MATCH_EXPAND_METHODDEF    \
-    {"expand", (PyCFunction)_sre_SRE_Match_expand, METH_FASTCALL, _sre_SRE_Match_expand__doc__},
+    {"expand", (PyCFunction)_sre_SRE_Match_expand, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Match_expand__doc__},
 
 static PyObject *
 _sre_SRE_Match_expand_impl(MatchObject *self, PyObject *template);
@@ -554,7 +554,7 @@ PyDoc_STRVAR(_sre_SRE_Match_groups__doc__,
 "    Is used for groups that did not participate in the match.");
 
 #define _SRE_SRE_MATCH_GROUPS_METHODDEF    \
-    {"groups", (PyCFunction)_sre_SRE_Match_groups, METH_FASTCALL, _sre_SRE_Match_groups__doc__},
+    {"groups", (PyCFunction)_sre_SRE_Match_groups, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Match_groups__doc__},
 
 static PyObject *
 _sre_SRE_Match_groups_impl(MatchObject *self, PyObject *default_value);
@@ -587,7 +587,7 @@ PyDoc_STRVAR(_sre_SRE_Match_groupdict__doc__,
 "    Is used for groups that did not participate in the match.");
 
 #define _SRE_SRE_MATCH_GROUPDICT_METHODDEF    \
-    {"groupdict", (PyCFunction)_sre_SRE_Match_groupdict, METH_FASTCALL, _sre_SRE_Match_groupdict__doc__},
+    {"groupdict", (PyCFunction)_sre_SRE_Match_groupdict, METH_FASTCALL|METH_KEYWORDS, _sre_SRE_Match_groupdict__doc__},
 
 static PyObject *
 _sre_SRE_Match_groupdict_impl(MatchObject *self, PyObject *default_value);
@@ -623,15 +623,11 @@ static Py_ssize_t
 _sre_SRE_Match_start_impl(MatchObject *self, PyObject *group);
 
 static PyObject *
-_sre_SRE_Match_start(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_sre_SRE_Match_start(MatchObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *group = NULL;
     Py_ssize_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("start", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "start",
         0, 1,
@@ -661,15 +657,11 @@ static Py_ssize_t
 _sre_SRE_Match_end_impl(MatchObject *self, PyObject *group);
 
 static PyObject *
-_sre_SRE_Match_end(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_sre_SRE_Match_end(MatchObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *group = NULL;
     Py_ssize_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("end", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "end",
         0, 1,
@@ -699,14 +691,10 @@ static PyObject *
 _sre_SRE_Match_span_impl(MatchObject *self, PyObject *group);
 
 static PyObject *
-_sre_SRE_Match_span(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_sre_SRE_Match_span(MatchObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *group = NULL;
-
-    if (!_PyArg_NoStackKeywords("span", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "span",
         0, 1,
@@ -777,4 +765,4 @@ _sre_SRE_Scanner_search(ScannerObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _sre_SRE_Scanner_search_impl(self);
 }
-/*[clinic end generated code: output=28b0cc05da4ac219 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6e3fb17fef1be436 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -66,14 +66,10 @@ static PyObject *
 _ssl__SSLSocket_peer_certificate_impl(PySSLSocket *self, int binary_mode);
 
 static PyObject *
-_ssl__SSLSocket_peer_certificate(PySSLSocket *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_ssl__SSLSocket_peer_certificate(PySSLSocket *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int binary_mode = 0;
-
-    if (!_PyArg_NoStackKeywords("peer_certificate", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|p:peer_certificate",
         &binary_mode)) {
@@ -473,7 +469,7 @@ PyDoc_STRVAR(_ssl__SSLContext_load_cert_chain__doc__,
 "\n");
 
 #define _SSL__SSLCONTEXT_LOAD_CERT_CHAIN_METHODDEF    \
-    {"load_cert_chain", (PyCFunction)_ssl__SSLContext_load_cert_chain, METH_FASTCALL, _ssl__SSLContext_load_cert_chain__doc__},
+    {"load_cert_chain", (PyCFunction)_ssl__SSLContext_load_cert_chain, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLContext_load_cert_chain__doc__},
 
 static PyObject *
 _ssl__SSLContext_load_cert_chain_impl(PySSLContext *self, PyObject *certfile,
@@ -505,7 +501,7 @@ PyDoc_STRVAR(_ssl__SSLContext_load_verify_locations__doc__,
 "\n");
 
 #define _SSL__SSLCONTEXT_LOAD_VERIFY_LOCATIONS_METHODDEF    \
-    {"load_verify_locations", (PyCFunction)_ssl__SSLContext_load_verify_locations, METH_FASTCALL, _ssl__SSLContext_load_verify_locations__doc__},
+    {"load_verify_locations", (PyCFunction)_ssl__SSLContext_load_verify_locations, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLContext_load_verify_locations__doc__},
 
 static PyObject *
 _ssl__SSLContext_load_verify_locations_impl(PySSLContext *self,
@@ -547,7 +543,7 @@ PyDoc_STRVAR(_ssl__SSLContext__wrap_socket__doc__,
 "\n");
 
 #define _SSL__SSLCONTEXT__WRAP_SOCKET_METHODDEF    \
-    {"_wrap_socket", (PyCFunction)_ssl__SSLContext__wrap_socket, METH_FASTCALL, _ssl__SSLContext__wrap_socket__doc__},
+    {"_wrap_socket", (PyCFunction)_ssl__SSLContext__wrap_socket, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLContext__wrap_socket__doc__},
 
 static PyObject *
 _ssl__SSLContext__wrap_socket_impl(PySSLContext *self, PyObject *sock,
@@ -580,7 +576,7 @@ PyDoc_STRVAR(_ssl__SSLContext__wrap_bio__doc__,
 "\n");
 
 #define _SSL__SSLCONTEXT__WRAP_BIO_METHODDEF    \
-    {"_wrap_bio", (PyCFunction)_ssl__SSLContext__wrap_bio, METH_FASTCALL, _ssl__SSLContext__wrap_bio__doc__},
+    {"_wrap_bio", (PyCFunction)_ssl__SSLContext__wrap_bio, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLContext__wrap_bio__doc__},
 
 static PyObject *
 _ssl__SSLContext__wrap_bio_impl(PySSLContext *self, PySSLMemoryBIO *incoming,
@@ -704,7 +700,7 @@ PyDoc_STRVAR(_ssl__SSLContext_get_ca_certs__doc__,
 "been used at least once.");
 
 #define _SSL__SSLCONTEXT_GET_CA_CERTS_METHODDEF    \
-    {"get_ca_certs", (PyCFunction)_ssl__SSLContext_get_ca_certs, METH_FASTCALL, _ssl__SSLContext_get_ca_certs__doc__},
+    {"get_ca_certs", (PyCFunction)_ssl__SSLContext_get_ca_certs, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLContext_get_ca_certs__doc__},
 
 static PyObject *
 _ssl__SSLContext_get_ca_certs_impl(PySSLContext *self, int binary_form);
@@ -767,14 +763,10 @@ static PyObject *
 _ssl_MemoryBIO_read_impl(PySSLMemoryBIO *self, int len);
 
 static PyObject *
-_ssl_MemoryBIO_read(PySSLMemoryBIO *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_ssl_MemoryBIO_read(PySSLMemoryBIO *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int len = -1;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|i:read",
         &len)) {
@@ -856,15 +848,11 @@ static PyObject *
 _ssl_RAND_add_impl(PyObject *module, Py_buffer *view, double entropy);
 
 static PyObject *
-_ssl_RAND_add(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_ssl_RAND_add(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer view = {NULL, NULL};
     double entropy;
-
-    if (!_PyArg_NoStackKeywords("RAND_add", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "s*d:RAND_add",
         &view, &entropy)) {
@@ -1023,7 +1011,7 @@ PyDoc_STRVAR(_ssl_txt2obj__doc__,
 "long name are also matched.");
 
 #define _SSL_TXT2OBJ_METHODDEF    \
-    {"txt2obj", (PyCFunction)_ssl_txt2obj, METH_FASTCALL, _ssl_txt2obj__doc__},
+    {"txt2obj", (PyCFunction)_ssl_txt2obj, METH_FASTCALL|METH_KEYWORDS, _ssl_txt2obj__doc__},
 
 static PyObject *
 _ssl_txt2obj_impl(PyObject *module, const char *txt, int name);
@@ -1089,7 +1077,7 @@ PyDoc_STRVAR(_ssl_enum_certificates__doc__,
 "a set of OIDs or the boolean True.");
 
 #define _SSL_ENUM_CERTIFICATES_METHODDEF    \
-    {"enum_certificates", (PyCFunction)_ssl_enum_certificates, METH_FASTCALL, _ssl_enum_certificates__doc__},
+    {"enum_certificates", (PyCFunction)_ssl_enum_certificates, METH_FASTCALL|METH_KEYWORDS, _ssl_enum_certificates__doc__},
 
 static PyObject *
 _ssl_enum_certificates_impl(PyObject *module, const char *store_name);
@@ -1128,7 +1116,7 @@ PyDoc_STRVAR(_ssl_enum_crls__doc__,
 "X509_ASN_ENCODING or PKCS_7_ASN_ENCODING.");
 
 #define _SSL_ENUM_CRLS_METHODDEF    \
-    {"enum_crls", (PyCFunction)_ssl_enum_crls, METH_FASTCALL, _ssl_enum_crls__doc__},
+    {"enum_crls", (PyCFunction)_ssl_enum_crls, METH_FASTCALL|METH_KEYWORDS, _ssl_enum_crls__doc__},
 
 static PyObject *
 _ssl_enum_crls_impl(PyObject *module, const char *store_name);
@@ -1180,4 +1168,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=30284eec805dbdf8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2d1424e6cc647fa8 input=a9049054013a1b77]*/

--- a/Modules/clinic/_struct.c.h
+++ b/Modules/clinic/_struct.c.h
@@ -84,7 +84,7 @@ PyDoc_STRVAR(Struct_unpack_from__doc__,
 "See help(struct) for more on format strings.");
 
 #define STRUCT_UNPACK_FROM_METHODDEF    \
-    {"unpack_from", (PyCFunction)Struct_unpack_from, METH_FASTCALL, Struct_unpack_from__doc__},
+    {"unpack_from", (PyCFunction)Struct_unpack_from, METH_FASTCALL|METH_KEYWORDS, Struct_unpack_from__doc__},
 
 static PyObject *
 Struct_unpack_from_impl(PyStructObject *self, Py_buffer *buffer,
@@ -198,15 +198,11 @@ static PyObject *
 unpack_impl(PyObject *module, PyStructObject *s_object, Py_buffer *buffer);
 
 static PyObject *
-unpack(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unpack(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyStructObject *s_object = NULL;
     Py_buffer buffer = {NULL, NULL};
-
-    if (!_PyArg_NoStackKeywords("unpack", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&y*:unpack",
         cache_struct_converter, &s_object, &buffer)) {
@@ -236,7 +232,7 @@ PyDoc_STRVAR(unpack_from__doc__,
 "See help(struct) for more on format strings.");
 
 #define UNPACK_FROM_METHODDEF    \
-    {"unpack_from", (PyCFunction)unpack_from, METH_FASTCALL, unpack_from__doc__},
+    {"unpack_from", (PyCFunction)unpack_from, METH_FASTCALL|METH_KEYWORDS, unpack_from__doc__},
 
 static PyObject *
 unpack_from_impl(PyObject *module, PyStructObject *s_object,
@@ -288,15 +284,11 @@ iter_unpack_impl(PyObject *module, PyStructObject *s_object,
                  PyObject *buffer);
 
 static PyObject *
-iter_unpack(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+iter_unpack(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyStructObject *s_object = NULL;
     PyObject *buffer;
-
-    if (!_PyArg_NoStackKeywords("iter_unpack", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&O:iter_unpack",
         cache_struct_converter, &s_object, &buffer)) {
@@ -310,4 +302,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=351350320f31ca82 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fce060787b4c5261 input=a9049054013a1b77]*/

--- a/Modules/clinic/_tkinter.c.h
+++ b/Modules/clinic/_tkinter.c.h
@@ -263,15 +263,11 @@ _tkinter_tkapp_createcommand_impl(TkappObject *self, const char *name,
                                   PyObject *func);
 
 static PyObject *
-_tkinter_tkapp_createcommand(TkappObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_tkinter_tkapp_createcommand(TkappObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *name;
     PyObject *func;
-
-    if (!_PyArg_NoStackKeywords("createcommand", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "sO:createcommand",
         &name, &func)) {
@@ -324,16 +320,12 @@ _tkinter_tkapp_createfilehandler_impl(TkappObject *self, PyObject *file,
                                       int mask, PyObject *func);
 
 static PyObject *
-_tkinter_tkapp_createfilehandler(TkappObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_tkinter_tkapp_createfilehandler(TkappObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *file;
     int mask;
     PyObject *func;
-
-    if (!_PyArg_NoStackKeywords("createfilehandler", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "OiO:createfilehandler",
         &file, &mask, &func)) {
@@ -389,15 +381,11 @@ _tkinter_tkapp_createtimerhandler_impl(TkappObject *self, int milliseconds,
                                        PyObject *func);
 
 static PyObject *
-_tkinter_tkapp_createtimerhandler(TkappObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_tkinter_tkapp_createtimerhandler(TkappObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int milliseconds;
     PyObject *func;
-
-    if (!_PyArg_NoStackKeywords("createtimerhandler", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO:createtimerhandler",
         &milliseconds, &func)) {
@@ -421,14 +409,10 @@ static PyObject *
 _tkinter_tkapp_mainloop_impl(TkappObject *self, int threshold);
 
 static PyObject *
-_tkinter_tkapp_mainloop(TkappObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_tkinter_tkapp_mainloop(TkappObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int threshold = 0;
-
-    if (!_PyArg_NoStackKeywords("mainloop", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|i:mainloop",
         &threshold)) {
@@ -452,14 +436,10 @@ static PyObject *
 _tkinter_tkapp_dooneevent_impl(TkappObject *self, int flags);
 
 static PyObject *
-_tkinter_tkapp_dooneevent(TkappObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_tkinter_tkapp_dooneevent(TkappObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int flags = 0;
-
-    if (!_PyArg_NoStackKeywords("dooneevent", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|i:dooneevent",
         &flags)) {
@@ -572,7 +552,7 @@ _tkinter_create_impl(PyObject *module, const char *screenName,
                      const char *use);
 
 static PyObject *
-_tkinter_create(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_tkinter_create(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *screenName = NULL;
@@ -583,10 +563,6 @@ _tkinter_create(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     int wantTk = 1;
     int sync = 0;
     const char *use = NULL;
-
-    if (!_PyArg_NoStackKeywords("create", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|zssiiiiz:create",
         &screenName, &baseName, &className, &interactive, &wantobjects, &wantTk, &sync, &use)) {
@@ -662,4 +638,4 @@ exit:
 #ifndef _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
     #define _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
 #endif /* !defined(_TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF) */
-/*[clinic end generated code: output=ed14e0bb0cd9c8e0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3b9241f7c703ae4f input=a9049054013a1b77]*/

--- a/Modules/clinic/_tracemalloc.c.h
+++ b/Modules/clinic/_tracemalloc.c.h
@@ -90,14 +90,10 @@ static PyObject *
 _tracemalloc_start_impl(PyObject *module, Py_ssize_t nframe);
 
 static PyObject *
-_tracemalloc_start(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_tracemalloc_start(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t nframe = 1;
-
-    if (!_PyArg_NoStackKeywords("start", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|n:start",
         &nframe)) {
@@ -189,4 +185,4 @@ _tracemalloc_get_traced_memory(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _tracemalloc_get_traced_memory_impl(module);
 }
-/*[clinic end generated code: output=ca7b197d1bdcdf27 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c9a0111391b3ec45 input=a9049054013a1b77]*/

--- a/Modules/clinic/_weakref.c.h
+++ b/Modules/clinic/_weakref.c.h
@@ -44,15 +44,11 @@ _weakref__remove_dead_weakref_impl(PyObject *module, PyObject *dct,
                                    PyObject *key);
 
 static PyObject *
-_weakref__remove_dead_weakref(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_weakref__remove_dead_weakref(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *dct;
     PyObject *key;
-
-    if (!_PyArg_NoStackKeywords("_remove_dead_weakref", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O!O:_remove_dead_weakref",
         &PyDict_Type, &dct, &key)) {
@@ -63,4 +59,4 @@ _weakref__remove_dead_weakref(PyObject *module, PyObject **args, Py_ssize_t narg
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=05ecbb46c85839a2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=87ddb70850080222 input=a9049054013a1b77]*/

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -95,7 +95,7 @@ PyDoc_STRVAR(_winapi_ConnectNamedPipe__doc__,
 "\n");
 
 #define _WINAPI_CONNECTNAMEDPIPE_METHODDEF    \
-    {"ConnectNamedPipe", (PyCFunction)_winapi_ConnectNamedPipe, METH_FASTCALL, _winapi_ConnectNamedPipe__doc__},
+    {"ConnectNamedPipe", (PyCFunction)_winapi_ConnectNamedPipe, METH_FASTCALL|METH_KEYWORDS, _winapi_ConnectNamedPipe__doc__},
 
 static PyObject *
 _winapi_ConnectNamedPipe_impl(PyObject *module, HANDLE handle,
@@ -138,7 +138,7 @@ _winapi_CreateFile_impl(PyObject *module, LPCTSTR file_name,
                         DWORD flags_and_attributes, HANDLE template_file);
 
 static PyObject *
-_winapi_CreateFile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_CreateFile(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     LPCTSTR file_name;
@@ -149,10 +149,6 @@ _winapi_CreateFile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     DWORD flags_and_attributes;
     HANDLE template_file;
     HANDLE _return_value;
-
-    if (!_PyArg_NoStackKeywords("CreateFile", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "skk" F_POINTER "kk" F_HANDLE ":CreateFile",
         &file_name, &desired_access, &share_mode, &security_attributes, &creation_disposition, &flags_and_attributes, &template_file)) {
@@ -184,15 +180,11 @@ _winapi_CreateJunction_impl(PyObject *module, LPWSTR src_path,
                             LPWSTR dst_path);
 
 static PyObject *
-_winapi_CreateJunction(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_CreateJunction(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     LPWSTR src_path;
     LPWSTR dst_path;
-
-    if (!_PyArg_NoStackKeywords("CreateJunction", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "uu:CreateJunction",
         &src_path, &dst_path)) {
@@ -222,7 +214,7 @@ _winapi_CreateNamedPipe_impl(PyObject *module, LPCTSTR name, DWORD open_mode,
                              LPSECURITY_ATTRIBUTES security_attributes);
 
 static PyObject *
-_winapi_CreateNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_CreateNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     LPCTSTR name;
@@ -234,10 +226,6 @@ _winapi_CreateNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs, PyO
     DWORD default_timeout;
     LPSECURITY_ATTRIBUTES security_attributes;
     HANDLE _return_value;
-
-    if (!_PyArg_NoStackKeywords("CreateNamedPipe", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "skkkkkk" F_POINTER ":CreateNamedPipe",
         &name, &open_mode, &pipe_mode, &max_instances, &out_buffer_size, &in_buffer_size, &default_timeout, &security_attributes)) {
@@ -274,15 +262,11 @@ static PyObject *
 _winapi_CreatePipe_impl(PyObject *module, PyObject *pipe_attrs, DWORD size);
 
 static PyObject *
-_winapi_CreatePipe(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_CreatePipe(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *pipe_attrs;
     DWORD size;
-
-    if (!_PyArg_NoStackKeywords("CreatePipe", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "Ok:CreatePipe",
         &pipe_attrs, &size)) {
@@ -322,7 +306,7 @@ _winapi_CreateProcess_impl(PyObject *module, Py_UNICODE *application_name,
                            PyObject *startup_info);
 
 static PyObject *
-_winapi_CreateProcess(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_CreateProcess(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_UNICODE *application_name;
@@ -334,10 +318,6 @@ _winapi_CreateProcess(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     PyObject *env_mapping;
     Py_UNICODE *current_directory;
     PyObject *startup_info;
-
-    if (!_PyArg_NoStackKeywords("CreateProcess", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ZZOOikOZO:CreateProcess",
         &application_name, &command_line, &proc_attrs, &thread_attrs, &inherit_handles, &creation_flags, &env_mapping, &current_directory, &startup_info)) {
@@ -372,7 +352,7 @@ _winapi_DuplicateHandle_impl(PyObject *module, HANDLE source_process_handle,
                              DWORD options);
 
 static PyObject *
-_winapi_DuplicateHandle(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_DuplicateHandle(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HANDLE source_process_handle;
@@ -382,10 +362,6 @@ _winapi_DuplicateHandle(PyObject *module, PyObject **args, Py_ssize_t nargs, PyO
     BOOL inherit_handle;
     DWORD options = 0;
     HANDLE _return_value;
-
-    if (!_PyArg_NoStackKeywords("DuplicateHandle", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "" F_HANDLE "" F_HANDLE "ki|k:DuplicateHandle",
         &source_process_handle, &source_handle, &target_process_handle, &desired_access, &inherit_handle, &options)) {
@@ -635,17 +611,13 @@ _winapi_OpenProcess_impl(PyObject *module, DWORD desired_access,
                          BOOL inherit_handle, DWORD process_id);
 
 static PyObject *
-_winapi_OpenProcess(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_OpenProcess(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     DWORD desired_access;
     BOOL inherit_handle;
     DWORD process_id;
     HANDLE _return_value;
-
-    if (!_PyArg_NoStackKeywords("OpenProcess", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "kik:OpenProcess",
         &desired_access, &inherit_handle, &process_id)) {
@@ -676,15 +648,11 @@ static PyObject *
 _winapi_PeekNamedPipe_impl(PyObject *module, HANDLE handle, int size);
 
 static PyObject *
-_winapi_PeekNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_PeekNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HANDLE handle;
     int size = 0;
-
-    if (!_PyArg_NoStackKeywords("PeekNamedPipe", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "|i:PeekNamedPipe",
         &handle, &size)) {
@@ -702,7 +670,7 @@ PyDoc_STRVAR(_winapi_ReadFile__doc__,
 "\n");
 
 #define _WINAPI_READFILE_METHODDEF    \
-    {"ReadFile", (PyCFunction)_winapi_ReadFile, METH_FASTCALL, _winapi_ReadFile__doc__},
+    {"ReadFile", (PyCFunction)_winapi_ReadFile, METH_FASTCALL|METH_KEYWORDS, _winapi_ReadFile__doc__},
 
 static PyObject *
 _winapi_ReadFile_impl(PyObject *module, HANDLE handle, int size,
@@ -744,17 +712,13 @@ _winapi_SetNamedPipeHandleState_impl(PyObject *module, HANDLE named_pipe,
                                      PyObject *collect_data_timeout);
 
 static PyObject *
-_winapi_SetNamedPipeHandleState(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_SetNamedPipeHandleState(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HANDLE named_pipe;
     PyObject *mode;
     PyObject *max_collection_count;
     PyObject *collect_data_timeout;
-
-    if (!_PyArg_NoStackKeywords("SetNamedPipeHandleState", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "OOO:SetNamedPipeHandleState",
         &named_pipe, &mode, &max_collection_count, &collect_data_timeout)) {
@@ -780,15 +744,11 @@ _winapi_TerminateProcess_impl(PyObject *module, HANDLE handle,
                               UINT exit_code);
 
 static PyObject *
-_winapi_TerminateProcess(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_TerminateProcess(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HANDLE handle;
     UINT exit_code;
-
-    if (!_PyArg_NoStackKeywords("TerminateProcess", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "I:TerminateProcess",
         &handle, &exit_code)) {
@@ -812,15 +772,11 @@ static PyObject *
 _winapi_WaitNamedPipe_impl(PyObject *module, LPCTSTR name, DWORD timeout);
 
 static PyObject *
-_winapi_WaitNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_WaitNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     LPCTSTR name;
     DWORD timeout;
-
-    if (!_PyArg_NoStackKeywords("WaitNamedPipe", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "sk:WaitNamedPipe",
         &name, &timeout)) {
@@ -846,16 +802,12 @@ _winapi_WaitForMultipleObjects_impl(PyObject *module, PyObject *handle_seq,
                                     BOOL wait_flag, DWORD milliseconds);
 
 static PyObject *
-_winapi_WaitForMultipleObjects(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_WaitForMultipleObjects(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *handle_seq;
     BOOL wait_flag;
     DWORD milliseconds = INFINITE;
-
-    if (!_PyArg_NoStackKeywords("WaitForMultipleObjects", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "Oi|k:WaitForMultipleObjects",
         &handle_seq, &wait_flag, &milliseconds)) {
@@ -885,16 +837,12 @@ _winapi_WaitForSingleObject_impl(PyObject *module, HANDLE handle,
                                  DWORD milliseconds);
 
 static PyObject *
-_winapi_WaitForSingleObject(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_winapi_WaitForSingleObject(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HANDLE handle;
     DWORD milliseconds;
     long _return_value;
-
-    if (!_PyArg_NoStackKeywords("WaitForSingleObject", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "k:WaitForSingleObject",
         &handle, &milliseconds)) {
@@ -916,7 +864,7 @@ PyDoc_STRVAR(_winapi_WriteFile__doc__,
 "\n");
 
 #define _WINAPI_WRITEFILE_METHODDEF    \
-    {"WriteFile", (PyCFunction)_winapi_WriteFile, METH_FASTCALL, _winapi_WriteFile__doc__},
+    {"WriteFile", (PyCFunction)_winapi_WriteFile, METH_FASTCALL|METH_KEYWORDS, _winapi_WriteFile__doc__},
 
 static PyObject *
 _winapi_WriteFile_impl(PyObject *module, HANDLE handle, PyObject *buffer,
@@ -941,4 +889,4 @@ _winapi_WriteFile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9555c16ed2d95a9f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=afa6bd61eb0f18d2 input=a9049054013a1b77]*/

--- a/Modules/clinic/arraymodule.c.h
+++ b/Modules/clinic/arraymodule.c.h
@@ -71,14 +71,10 @@ static PyObject *
 array_array_pop_impl(arrayobject *self, Py_ssize_t i);
 
 static PyObject *
-array_array_pop(arrayobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+array_array_pop(arrayobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t i = -1;
-
-    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|n:pop",
         &i)) {
@@ -112,15 +108,11 @@ static PyObject *
 array_array_insert_impl(arrayobject *self, Py_ssize_t i, PyObject *v);
 
 static PyObject *
-array_array_insert(arrayobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+array_array_insert(arrayobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t i;
     PyObject *v;
-
-    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "nO:insert",
         &i, &v)) {
@@ -214,15 +206,11 @@ static PyObject *
 array_array_fromfile_impl(arrayobject *self, PyObject *f, Py_ssize_t n);
 
 static PyObject *
-array_array_fromfile(arrayobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+array_array_fromfile(arrayobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *f;
     Py_ssize_t n;
-
-    if (!_PyArg_NoStackKeywords("fromfile", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "On:fromfile",
         &f, &n)) {
@@ -464,17 +452,13 @@ array__array_reconstructor_impl(PyObject *module, PyTypeObject *arraytype,
                                 PyObject *items);
 
 static PyObject *
-array__array_reconstructor(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+array__array_reconstructor(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyTypeObject *arraytype;
     int typecode;
     enum machine_format_code mformat_code;
     PyObject *items;
-
-    if (!_PyArg_NoStackKeywords("_array_reconstructor", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "OCiO:_array_reconstructor",
         &arraytype, &typecode, &mformat_code, &items)) {
@@ -521,4 +505,4 @@ PyDoc_STRVAR(array_arrayiterator___setstate____doc__,
 
 #define ARRAY_ARRAYITERATOR___SETSTATE___METHODDEF    \
     {"__setstate__", (PyCFunction)array_arrayiterator___setstate__, METH_O, array_arrayiterator___setstate____doc__},
-/*[clinic end generated code: output=fb4a67e697d7c0b0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c7dfe61312b236a9 input=a9049054013a1b77]*/

--- a/Modules/clinic/audioop.c.h
+++ b/Modules/clinic/audioop.c.h
@@ -16,16 +16,12 @@ audioop_getsample_impl(PyObject *module, Py_buffer *fragment, int width,
                        Py_ssize_t index);
 
 static PyObject *
-audioop_getsample(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_getsample(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     Py_ssize_t index;
-
-    if (!_PyArg_NoStackKeywords("getsample", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*in:getsample",
         &fragment, &width, &index)) {
@@ -55,15 +51,11 @@ static PyObject *
 audioop_max_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_max(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_max(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("max", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:max",
         &fragment, &width)) {
@@ -93,15 +85,11 @@ static PyObject *
 audioop_minmax_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_minmax(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_minmax(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("minmax", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:minmax",
         &fragment, &width)) {
@@ -131,15 +119,11 @@ static PyObject *
 audioop_avg_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_avg(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_avg(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("avg", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:avg",
         &fragment, &width)) {
@@ -169,15 +153,11 @@ static PyObject *
 audioop_rms_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_rms(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_rms(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("rms", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:rms",
         &fragment, &width)) {
@@ -208,15 +188,11 @@ audioop_findfit_impl(PyObject *module, Py_buffer *fragment,
                      Py_buffer *reference);
 
 static PyObject *
-audioop_findfit(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_findfit(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     Py_buffer reference = {NULL, NULL};
-
-    if (!_PyArg_NoStackKeywords("findfit", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*y*:findfit",
         &fragment, &reference)) {
@@ -251,15 +227,11 @@ audioop_findfactor_impl(PyObject *module, Py_buffer *fragment,
                         Py_buffer *reference);
 
 static PyObject *
-audioop_findfactor(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_findfactor(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     Py_buffer reference = {NULL, NULL};
-
-    if (!_PyArg_NoStackKeywords("findfactor", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*y*:findfactor",
         &fragment, &reference)) {
@@ -294,15 +266,11 @@ audioop_findmax_impl(PyObject *module, Py_buffer *fragment,
                      Py_ssize_t length);
 
 static PyObject *
-audioop_findmax(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_findmax(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     Py_ssize_t length;
-
-    if (!_PyArg_NoStackKeywords("findmax", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*n:findmax",
         &fragment, &length)) {
@@ -332,15 +300,11 @@ static PyObject *
 audioop_avgpp_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_avgpp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_avgpp(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("avgpp", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:avgpp",
         &fragment, &width)) {
@@ -370,15 +334,11 @@ static PyObject *
 audioop_maxpp_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_maxpp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_maxpp(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("maxpp", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:maxpp",
         &fragment, &width)) {
@@ -408,15 +368,11 @@ static PyObject *
 audioop_cross_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_cross(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_cross(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("cross", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:cross",
         &fragment, &width)) {
@@ -447,16 +403,12 @@ audioop_mul_impl(PyObject *module, Py_buffer *fragment, int width,
                  double factor);
 
 static PyObject *
-audioop_mul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_mul(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     double factor;
-
-    if (!_PyArg_NoStackKeywords("mul", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*id:mul",
         &fragment, &width, &factor)) {
@@ -487,17 +439,13 @@ audioop_tomono_impl(PyObject *module, Py_buffer *fragment, int width,
                     double lfactor, double rfactor);
 
 static PyObject *
-audioop_tomono(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_tomono(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     double lfactor;
     double rfactor;
-
-    if (!_PyArg_NoStackKeywords("tomono", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*idd:tomono",
         &fragment, &width, &lfactor, &rfactor)) {
@@ -528,17 +476,13 @@ audioop_tostereo_impl(PyObject *module, Py_buffer *fragment, int width,
                       double lfactor, double rfactor);
 
 static PyObject *
-audioop_tostereo(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_tostereo(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     double lfactor;
     double rfactor;
-
-    if (!_PyArg_NoStackKeywords("tostereo", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*idd:tostereo",
         &fragment, &width, &lfactor, &rfactor)) {
@@ -569,16 +513,12 @@ audioop_add_impl(PyObject *module, Py_buffer *fragment1,
                  Py_buffer *fragment2, int width);
 
 static PyObject *
-audioop_add(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_add(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment1 = {NULL, NULL};
     Py_buffer fragment2 = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("add", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*y*i:add",
         &fragment1, &fragment2, &width)) {
@@ -612,16 +552,12 @@ static PyObject *
 audioop_bias_impl(PyObject *module, Py_buffer *fragment, int width, int bias);
 
 static PyObject *
-audioop_bias(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_bias(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     int bias;
-
-    if (!_PyArg_NoStackKeywords("bias", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*ii:bias",
         &fragment, &width, &bias)) {
@@ -651,15 +587,11 @@ static PyObject *
 audioop_reverse_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_reverse(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_reverse(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("reverse", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:reverse",
         &fragment, &width)) {
@@ -689,15 +621,11 @@ static PyObject *
 audioop_byteswap_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_byteswap(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_byteswap(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("byteswap", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:byteswap",
         &fragment, &width)) {
@@ -728,16 +656,12 @@ audioop_lin2lin_impl(PyObject *module, Py_buffer *fragment, int width,
                      int newwidth);
 
 static PyObject *
-audioop_lin2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_lin2lin(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     int newwidth;
-
-    if (!_PyArg_NoStackKeywords("lin2lin", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*ii:lin2lin",
         &fragment, &width, &newwidth)) {
@@ -770,7 +694,7 @@ audioop_ratecv_impl(PyObject *module, Py_buffer *fragment, int width,
                     int weightA, int weightB);
 
 static PyObject *
-audioop_ratecv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_ratecv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
@@ -781,10 +705,6 @@ audioop_ratecv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *state;
     int weightA = 1;
     int weightB = 0;
-
-    if (!_PyArg_NoStackKeywords("ratecv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*iiiiO|ii:ratecv",
         &fragment, &width, &nchannels, &inrate, &outrate, &state, &weightA, &weightB)) {
@@ -814,15 +734,11 @@ static PyObject *
 audioop_lin2ulaw_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_lin2ulaw(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_lin2ulaw(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("lin2ulaw", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:lin2ulaw",
         &fragment, &width)) {
@@ -852,15 +768,11 @@ static PyObject *
 audioop_ulaw2lin_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_ulaw2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_ulaw2lin(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("ulaw2lin", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:ulaw2lin",
         &fragment, &width)) {
@@ -890,15 +802,11 @@ static PyObject *
 audioop_lin2alaw_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_lin2alaw(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_lin2alaw(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("lin2alaw", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:lin2alaw",
         &fragment, &width)) {
@@ -928,15 +836,11 @@ static PyObject *
 audioop_alaw2lin_impl(PyObject *module, Py_buffer *fragment, int width);
 
 static PyObject *
-audioop_alaw2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_alaw2lin(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
-
-    if (!_PyArg_NoStackKeywords("alaw2lin", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*i:alaw2lin",
         &fragment, &width)) {
@@ -967,16 +871,12 @@ audioop_lin2adpcm_impl(PyObject *module, Py_buffer *fragment, int width,
                        PyObject *state);
 
 static PyObject *
-audioop_lin2adpcm(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_lin2adpcm(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     PyObject *state;
-
-    if (!_PyArg_NoStackKeywords("lin2adpcm", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*iO:lin2adpcm",
         &fragment, &width, &state)) {
@@ -1007,16 +907,12 @@ audioop_adpcm2lin_impl(PyObject *module, Py_buffer *fragment, int width,
                        PyObject *state);
 
 static PyObject *
-audioop_adpcm2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+audioop_adpcm2lin(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer fragment = {NULL, NULL};
     int width;
     PyObject *state;
-
-    if (!_PyArg_NoStackKeywords("adpcm2lin", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*iO:adpcm2lin",
         &fragment, &width, &state)) {
@@ -1032,4 +928,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=4eaee23043922a41 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e2076026235d7f0f input=a9049054013a1b77]*/

--- a/Modules/clinic/binascii.c.h
+++ b/Modules/clinic/binascii.c.h
@@ -40,7 +40,7 @@ PyDoc_STRVAR(binascii_b2a_uu__doc__,
 "Uuencode line of data.");
 
 #define BINASCII_B2A_UU_METHODDEF    \
-    {"b2a_uu", (PyCFunction)binascii_b2a_uu, METH_FASTCALL, binascii_b2a_uu__doc__},
+    {"b2a_uu", (PyCFunction)binascii_b2a_uu, METH_FASTCALL|METH_KEYWORDS, binascii_b2a_uu__doc__},
 
 static PyObject *
 binascii_b2a_uu_impl(PyObject *module, Py_buffer *data, int backtick);
@@ -107,7 +107,7 @@ PyDoc_STRVAR(binascii_b2a_base64__doc__,
 "Base64-code line of data.");
 
 #define BINASCII_B2A_BASE64_METHODDEF    \
-    {"b2a_base64", (PyCFunction)binascii_b2a_base64, METH_FASTCALL, binascii_b2a_base64__doc__},
+    {"b2a_base64", (PyCFunction)binascii_b2a_base64, METH_FASTCALL|METH_KEYWORDS, binascii_b2a_base64__doc__},
 
 static PyObject *
 binascii_b2a_base64_impl(PyObject *module, Py_buffer *data, int newline);
@@ -276,16 +276,12 @@ static unsigned int
 binascii_crc_hqx_impl(PyObject *module, Py_buffer *data, unsigned int crc);
 
 static PyObject *
-binascii_crc_hqx(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+binascii_crc_hqx(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int crc;
     unsigned int _return_value;
-
-    if (!_PyArg_NoStackKeywords("crc_hqx", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*I:crc_hqx",
         &data, &crc)) {
@@ -319,16 +315,12 @@ static unsigned int
 binascii_crc32_impl(PyObject *module, Py_buffer *data, unsigned int crc);
 
 static PyObject *
-binascii_crc32(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+binascii_crc32(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int crc = 0;
     unsigned int _return_value;
-
-    if (!_PyArg_NoStackKeywords("crc32", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|I:crc32",
         &data, &crc)) {
@@ -492,7 +484,7 @@ PyDoc_STRVAR(binascii_a2b_qp__doc__,
 "Decode a string of qp-encoded data.");
 
 #define BINASCII_A2B_QP_METHODDEF    \
-    {"a2b_qp", (PyCFunction)binascii_a2b_qp, METH_FASTCALL, binascii_a2b_qp__doc__},
+    {"a2b_qp", (PyCFunction)binascii_a2b_qp, METH_FASTCALL|METH_KEYWORDS, binascii_a2b_qp__doc__},
 
 static PyObject *
 binascii_a2b_qp_impl(PyObject *module, Py_buffer *data, int header);
@@ -531,7 +523,7 @@ PyDoc_STRVAR(binascii_b2a_qp__doc__,
 "are both encoded.  When quotetabs is set, space and tabs are encoded.");
 
 #define BINASCII_B2A_QP_METHODDEF    \
-    {"b2a_qp", (PyCFunction)binascii_b2a_qp, METH_FASTCALL, binascii_b2a_qp__doc__},
+    {"b2a_qp", (PyCFunction)binascii_b2a_qp, METH_FASTCALL|METH_KEYWORDS, binascii_b2a_qp__doc__},
 
 static PyObject *
 binascii_b2a_qp_impl(PyObject *module, Py_buffer *data, int quotetabs,
@@ -562,4 +554,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=490f08a964e97390 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2878727c0cf4f636 input=a9049054013a1b77]*/

--- a/Modules/clinic/cmathmodule.c.h
+++ b/Modules/clinic/cmathmodule.c.h
@@ -647,15 +647,11 @@ static PyObject *
 cmath_log_impl(PyObject *module, Py_complex x, PyObject *y_obj);
 
 static PyObject *
-cmath_log(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+cmath_log(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_complex x;
     PyObject *y_obj = NULL;
-
-    if (!_PyArg_NoStackKeywords("log", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "D|O:log",
         &x, &y_obj)) {
@@ -736,15 +732,11 @@ static PyObject *
 cmath_rect_impl(PyObject *module, double r, double phi);
 
 static PyObject *
-cmath_rect(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+cmath_rect(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     double r;
     double phi;
-
-    if (!_PyArg_NoStackKeywords("rect", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "dd:rect",
         &r, &phi)) {
@@ -859,7 +851,7 @@ PyDoc_STRVAR(cmath_isclose__doc__,
 "not close to anything, even itself. inf and -inf are only close to themselves.");
 
 #define CMATH_ISCLOSE_METHODDEF    \
-    {"isclose", (PyCFunction)cmath_isclose, METH_FASTCALL, cmath_isclose__doc__},
+    {"isclose", (PyCFunction)cmath_isclose, METH_FASTCALL|METH_KEYWORDS, cmath_isclose__doc__},
 
 static int
 cmath_isclose_impl(PyObject *module, Py_complex a, Py_complex b,
@@ -890,4 +882,4 @@ cmath_isclose(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=11a0b5bb8a652de6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=51ba28d27d10264e input=a9049054013a1b77]*/

--- a/Modules/clinic/fcntlmodule.c.h
+++ b/Modules/clinic/fcntlmodule.c.h
@@ -25,16 +25,12 @@ static PyObject *
 fcntl_fcntl_impl(PyObject *module, int fd, int code, PyObject *arg);
 
 static PyObject *
-fcntl_fcntl(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+fcntl_fcntl(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     int code;
     PyObject *arg = NULL;
-
-    if (!_PyArg_NoStackKeywords("fcntl", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&i|O:fcntl",
         conv_descriptor, &fd, &code, &arg)) {
@@ -87,17 +83,13 @@ fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
                  PyObject *ob_arg, int mutate_arg);
 
 static PyObject *
-fcntl_ioctl(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+fcntl_ioctl(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     unsigned int code;
     PyObject *ob_arg = NULL;
     int mutate_arg = 1;
-
-    if (!_PyArg_NoStackKeywords("ioctl", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&I|Op:ioctl",
         conv_descriptor, &fd, &code, &ob_arg, &mutate_arg)) {
@@ -125,15 +117,11 @@ static PyObject *
 fcntl_flock_impl(PyObject *module, int fd, int code);
 
 static PyObject *
-fcntl_flock(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+fcntl_flock(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     int code;
-
-    if (!_PyArg_NoStackKeywords("flock", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&i:flock",
         conv_descriptor, &fd, &code)) {
@@ -180,7 +168,7 @@ fcntl_lockf_impl(PyObject *module, int fd, int code, PyObject *lenobj,
                  PyObject *startobj, int whence);
 
 static PyObject *
-fcntl_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+fcntl_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
@@ -188,10 +176,6 @@ fcntl_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyObject *lenobj = NULL;
     PyObject *startobj = NULL;
     int whence = 0;
-
-    if (!_PyArg_NoStackKeywords("lockf", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&i|OOi:lockf",
         conv_descriptor, &fd, &code, &lenobj, &startobj, &whence)) {
@@ -202,4 +186,4 @@ fcntl_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f189ac833d1448af input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6105e3ada306f434 input=a9049054013a1b77]*/

--- a/Modules/clinic/gcmodule.c.h
+++ b/Modules/clinic/gcmodule.c.h
@@ -79,7 +79,7 @@ PyDoc_STRVAR(gc_collect__doc__,
 "The number of unreachable objects is returned.");
 
 #define GC_COLLECT_METHODDEF    \
-    {"collect", (PyCFunction)gc_collect, METH_FASTCALL, gc_collect__doc__},
+    {"collect", (PyCFunction)gc_collect, METH_FASTCALL|METH_KEYWORDS, gc_collect__doc__},
 
 static Py_ssize_t
 gc_collect_impl(PyObject *module, int generation);
@@ -255,4 +255,4 @@ PyDoc_STRVAR(gc_is_tracked__doc__,
 
 #define GC_IS_TRACKED_METHODDEF    \
     {"is_tracked", (PyCFunction)gc_is_tracked, METH_O, gc_is_tracked__doc__},
-/*[clinic end generated code: output=8f487abc53fe4161 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5a58583f00ab018e input=a9049054013a1b77]*/

--- a/Modules/clinic/grpmodule.c.h
+++ b/Modules/clinic/grpmodule.c.h
@@ -11,7 +11,7 @@ PyDoc_STRVAR(grp_getgrgid__doc__,
 "If id is not valid, raise KeyError.");
 
 #define GRP_GETGRGID_METHODDEF    \
-    {"getgrgid", (PyCFunction)grp_getgrgid, METH_FASTCALL, grp_getgrgid__doc__},
+    {"getgrgid", (PyCFunction)grp_getgrgid, METH_FASTCALL|METH_KEYWORDS, grp_getgrgid__doc__},
 
 static PyObject *
 grp_getgrgid_impl(PyObject *module, PyObject *id);
@@ -43,7 +43,7 @@ PyDoc_STRVAR(grp_getgrnam__doc__,
 "If name is not valid, raise KeyError.");
 
 #define GRP_GETGRNAM_METHODDEF    \
-    {"getgrnam", (PyCFunction)grp_getgrnam, METH_FASTCALL, grp_getgrnam__doc__},
+    {"getgrnam", (PyCFunction)grp_getgrnam, METH_FASTCALL|METH_KEYWORDS, grp_getgrnam__doc__},
 
 static PyObject *
 grp_getgrnam_impl(PyObject *module, PyObject *name);
@@ -86,4 +86,4 @@ grp_getgrall(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return grp_getgrall_impl(module);
 }
-/*[clinic end generated code: output=fb690db5e676d378 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e7ef2cbc437eedcb input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -15,15 +15,11 @@ static PyObject *
 math_gcd_impl(PyObject *module, PyObject *a, PyObject *b);
 
 static PyObject *
-math_gcd(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+math_gcd(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *a;
     PyObject *b;
-
-    if (!_PyArg_NoStackKeywords("gcd", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "gcd",
         2, 2,
@@ -136,15 +132,11 @@ static PyObject *
 math_ldexp_impl(PyObject *module, double x, PyObject *i);
 
 static PyObject *
-math_ldexp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+math_ldexp(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     double x;
     PyObject *i;
-
-    if (!_PyArg_NoStackKeywords("ldexp", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "dO:ldexp",
         &x, &i)) {
@@ -261,15 +253,11 @@ static PyObject *
 math_fmod_impl(PyObject *module, double x, double y);
 
 static PyObject *
-math_fmod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+math_fmod(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     double x;
     double y;
-
-    if (!_PyArg_NoStackKeywords("fmod", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "dd:fmod",
         &x, &y)) {
@@ -294,15 +282,11 @@ static PyObject *
 math_hypot_impl(PyObject *module, double x, double y);
 
 static PyObject *
-math_hypot(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+math_hypot(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     double x;
     double y;
-
-    if (!_PyArg_NoStackKeywords("hypot", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "dd:hypot",
         &x, &y)) {
@@ -327,15 +311,11 @@ static PyObject *
 math_pow_impl(PyObject *module, double x, double y);
 
 static PyObject *
-math_pow(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+math_pow(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     double x;
     double y;
-
-    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "dd:pow",
         &x, &y)) {
@@ -505,7 +485,7 @@ PyDoc_STRVAR(math_isclose__doc__,
 "only close to themselves.");
 
 #define MATH_ISCLOSE_METHODDEF    \
-    {"isclose", (PyCFunction)math_isclose, METH_FASTCALL, math_isclose__doc__},
+    {"isclose", (PyCFunction)math_isclose, METH_FASTCALL|METH_KEYWORDS, math_isclose__doc__},
 
 static int
 math_isclose_impl(PyObject *module, double a, double b, double rel_tol,
@@ -536,4 +516,4 @@ math_isclose(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c9f1ac6ded547cc8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d9bfbd645d273209 input=a9049054013a1b77]*/

--- a/Modules/clinic/md5module.c.h
+++ b/Modules/clinic/md5module.c.h
@@ -72,7 +72,7 @@ PyDoc_STRVAR(_md5_md5__doc__,
 "Return a new MD5 hash object; optionally initialized with a string.");
 
 #define _MD5_MD5_METHODDEF    \
-    {"md5", (PyCFunction)_md5_md5, METH_FASTCALL, _md5_md5__doc__},
+    {"md5", (PyCFunction)_md5_md5, METH_FASTCALL|METH_KEYWORDS, _md5_md5__doc__},
 
 static PyObject *
 _md5_md5_impl(PyObject *module, PyObject *string);
@@ -94,4 +94,4 @@ _md5_md5(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=0a975e22cf33f833 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3139ae340ad1ea4e input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -28,7 +28,7 @@ PyDoc_STRVAR(os_stat__doc__,
 "  an open file descriptor.");
 
 #define OS_STAT_METHODDEF    \
-    {"stat", (PyCFunction)os_stat, METH_FASTCALL, os_stat__doc__},
+    {"stat", (PyCFunction)os_stat, METH_FASTCALL|METH_KEYWORDS, os_stat__doc__},
 
 static PyObject *
 os_stat_impl(PyObject *module, path_t *path, int dir_fd, int follow_symlinks);
@@ -66,7 +66,7 @@ PyDoc_STRVAR(os_lstat__doc__,
 "Equivalent to stat(path, follow_symlinks=False).");
 
 #define OS_LSTAT_METHODDEF    \
-    {"lstat", (PyCFunction)os_lstat, METH_FASTCALL, os_lstat__doc__},
+    {"lstat", (PyCFunction)os_lstat, METH_FASTCALL|METH_KEYWORDS, os_lstat__doc__},
 
 static PyObject *
 os_lstat_impl(PyObject *module, path_t *path, int dir_fd);
@@ -126,7 +126,7 @@ PyDoc_STRVAR(os_access__doc__,
 "  has the specified access to the path.");
 
 #define OS_ACCESS_METHODDEF    \
-    {"access", (PyCFunction)os_access, METH_FASTCALL, os_access__doc__},
+    {"access", (PyCFunction)os_access, METH_FASTCALL|METH_KEYWORDS, os_access__doc__},
 
 static int
 os_access_impl(PyObject *module, path_t *path, int mode, int dir_fd,
@@ -234,7 +234,7 @@ PyDoc_STRVAR(os_chdir__doc__,
 "  If this functionality is unavailable, using it raises an exception.");
 
 #define OS_CHDIR_METHODDEF    \
-    {"chdir", (PyCFunction)os_chdir, METH_FASTCALL, os_chdir__doc__},
+    {"chdir", (PyCFunction)os_chdir, METH_FASTCALL|METH_KEYWORDS, os_chdir__doc__},
 
 static PyObject *
 os_chdir_impl(PyObject *module, path_t *path);
@@ -272,7 +272,7 @@ PyDoc_STRVAR(os_fchdir__doc__,
 "Equivalent to os.chdir(fd).");
 
 #define OS_FCHDIR_METHODDEF    \
-    {"fchdir", (PyCFunction)os_fchdir, METH_FASTCALL, os_fchdir__doc__},
+    {"fchdir", (PyCFunction)os_fchdir, METH_FASTCALL|METH_KEYWORDS, os_fchdir__doc__},
 
 static PyObject *
 os_fchdir_impl(PyObject *module, int fd);
@@ -324,7 +324,7 @@ PyDoc_STRVAR(os_chmod__doc__,
 "  If they are unavailable, using them will raise a NotImplementedError.");
 
 #define OS_CHMOD_METHODDEF    \
-    {"chmod", (PyCFunction)os_chmod, METH_FASTCALL, os_chmod__doc__},
+    {"chmod", (PyCFunction)os_chmod, METH_FASTCALL|METH_KEYWORDS, os_chmod__doc__},
 
 static PyObject *
 os_chmod_impl(PyObject *module, path_t *path, int mode, int dir_fd,
@@ -365,7 +365,7 @@ PyDoc_STRVAR(os_fchmod__doc__,
 "Equivalent to os.chmod(fd, mode).");
 
 #define OS_FCHMOD_METHODDEF    \
-    {"fchmod", (PyCFunction)os_fchmod, METH_FASTCALL, os_fchmod__doc__},
+    {"fchmod", (PyCFunction)os_fchmod, METH_FASTCALL|METH_KEYWORDS, os_fchmod__doc__},
 
 static PyObject *
 os_fchmod_impl(PyObject *module, int fd, int mode);
@@ -403,7 +403,7 @@ PyDoc_STRVAR(os_lchmod__doc__,
 "Equivalent to chmod(path, mode, follow_symlinks=False).\"");
 
 #define OS_LCHMOD_METHODDEF    \
-    {"lchmod", (PyCFunction)os_lchmod, METH_FASTCALL, os_lchmod__doc__},
+    {"lchmod", (PyCFunction)os_lchmod, METH_FASTCALL|METH_KEYWORDS, os_lchmod__doc__},
 
 static PyObject *
 os_lchmod_impl(PyObject *module, path_t *path, int mode);
@@ -447,7 +447,7 @@ PyDoc_STRVAR(os_chflags__doc__,
 "unavailable, using it will raise a NotImplementedError.");
 
 #define OS_CHFLAGS_METHODDEF    \
-    {"chflags", (PyCFunction)os_chflags, METH_FASTCALL, os_chflags__doc__},
+    {"chflags", (PyCFunction)os_chflags, METH_FASTCALL|METH_KEYWORDS, os_chflags__doc__},
 
 static PyObject *
 os_chflags_impl(PyObject *module, path_t *path, unsigned long flags,
@@ -490,7 +490,7 @@ PyDoc_STRVAR(os_lchflags__doc__,
 "Equivalent to chflags(path, flags, follow_symlinks=False).");
 
 #define OS_LCHFLAGS_METHODDEF    \
-    {"lchflags", (PyCFunction)os_lchflags, METH_FASTCALL, os_lchflags__doc__},
+    {"lchflags", (PyCFunction)os_lchflags, METH_FASTCALL|METH_KEYWORDS, os_lchflags__doc__},
 
 static PyObject *
 os_lchflags_impl(PyObject *module, path_t *path, unsigned long flags);
@@ -528,7 +528,7 @@ PyDoc_STRVAR(os_chroot__doc__,
 "Change root directory to path.");
 
 #define OS_CHROOT_METHODDEF    \
-    {"chroot", (PyCFunction)os_chroot, METH_FASTCALL, os_chroot__doc__},
+    {"chroot", (PyCFunction)os_chroot, METH_FASTCALL|METH_KEYWORDS, os_chroot__doc__},
 
 static PyObject *
 os_chroot_impl(PyObject *module, path_t *path);
@@ -565,7 +565,7 @@ PyDoc_STRVAR(os_fsync__doc__,
 "Force write of fd to disk.");
 
 #define OS_FSYNC_METHODDEF    \
-    {"fsync", (PyCFunction)os_fsync, METH_FASTCALL, os_fsync__doc__},
+    {"fsync", (PyCFunction)os_fsync, METH_FASTCALL|METH_KEYWORDS, os_fsync__doc__},
 
 static PyObject *
 os_fsync_impl(PyObject *module, int fd);
@@ -621,7 +621,7 @@ PyDoc_STRVAR(os_fdatasync__doc__,
 "Force write of fd to disk without forcing update of metadata.");
 
 #define OS_FDATASYNC_METHODDEF    \
-    {"fdatasync", (PyCFunction)os_fdatasync, METH_FASTCALL, os_fdatasync__doc__},
+    {"fdatasync", (PyCFunction)os_fdatasync, METH_FASTCALL|METH_KEYWORDS, os_fdatasync__doc__},
 
 static PyObject *
 os_fdatasync_impl(PyObject *module, int fd);
@@ -679,7 +679,7 @@ PyDoc_STRVAR(os_chown__doc__,
 "  If they are unavailable, using them will raise a NotImplementedError.");
 
 #define OS_CHOWN_METHODDEF    \
-    {"chown", (PyCFunction)os_chown, METH_FASTCALL, os_chown__doc__},
+    {"chown", (PyCFunction)os_chown, METH_FASTCALL|METH_KEYWORDS, os_chown__doc__},
 
 static PyObject *
 os_chown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid,
@@ -723,7 +723,7 @@ PyDoc_STRVAR(os_fchown__doc__,
 "Equivalent to os.chown(fd, uid, gid).");
 
 #define OS_FCHOWN_METHODDEF    \
-    {"fchown", (PyCFunction)os_fchown, METH_FASTCALL, os_fchown__doc__},
+    {"fchown", (PyCFunction)os_fchown, METH_FASTCALL|METH_KEYWORDS, os_fchown__doc__},
 
 static PyObject *
 os_fchown_impl(PyObject *module, int fd, uid_t uid, gid_t gid);
@@ -762,7 +762,7 @@ PyDoc_STRVAR(os_lchown__doc__,
 "Equivalent to os.chown(path, uid, gid, follow_symlinks=False).");
 
 #define OS_LCHOWN_METHODDEF    \
-    {"lchown", (PyCFunction)os_lchown, METH_FASTCALL, os_lchown__doc__},
+    {"lchown", (PyCFunction)os_lchown, METH_FASTCALL|METH_KEYWORDS, os_lchown__doc__},
 
 static PyObject *
 os_lchown_impl(PyObject *module, path_t *path, uid_t uid, gid_t gid);
@@ -848,7 +848,7 @@ PyDoc_STRVAR(os_link__doc__,
 "  NotImplementedError.");
 
 #define OS_LINK_METHODDEF    \
-    {"link", (PyCFunction)os_link, METH_FASTCALL, os_link__doc__},
+    {"link", (PyCFunction)os_link, METH_FASTCALL|METH_KEYWORDS, os_link__doc__},
 
 static PyObject *
 os_link_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
@@ -901,7 +901,7 @@ PyDoc_STRVAR(os_listdir__doc__,
 "entries \'.\' and \'..\' even if they are present in the directory.");
 
 #define OS_LISTDIR_METHODDEF    \
-    {"listdir", (PyCFunction)os_listdir, METH_FASTCALL, os_listdir__doc__},
+    {"listdir", (PyCFunction)os_listdir, METH_FASTCALL|METH_KEYWORDS, os_listdir__doc__},
 
 static PyObject *
 os_listdir_impl(PyObject *module, path_t *path);
@@ -1034,7 +1034,7 @@ PyDoc_STRVAR(os__getvolumepathname__doc__,
 "A helper function for ismount on Win32.");
 
 #define OS__GETVOLUMEPATHNAME_METHODDEF    \
-    {"_getvolumepathname", (PyCFunction)os__getvolumepathname, METH_FASTCALL, os__getvolumepathname__doc__},
+    {"_getvolumepathname", (PyCFunction)os__getvolumepathname, METH_FASTCALL|METH_KEYWORDS, os__getvolumepathname__doc__},
 
 static PyObject *
 os__getvolumepathname_impl(PyObject *module, PyObject *path);
@@ -1073,7 +1073,7 @@ PyDoc_STRVAR(os_mkdir__doc__,
 "The mode argument is ignored on Windows.");
 
 #define OS_MKDIR_METHODDEF    \
-    {"mkdir", (PyCFunction)os_mkdir, METH_FASTCALL, os_mkdir__doc__},
+    {"mkdir", (PyCFunction)os_mkdir, METH_FASTCALL|METH_KEYWORDS, os_mkdir__doc__},
 
 static PyObject *
 os_mkdir_impl(PyObject *module, path_t *path, int mode, int dir_fd);
@@ -1141,7 +1141,7 @@ PyDoc_STRVAR(os_getpriority__doc__,
 "Return program scheduling priority.");
 
 #define OS_GETPRIORITY_METHODDEF    \
-    {"getpriority", (PyCFunction)os_getpriority, METH_FASTCALL, os_getpriority__doc__},
+    {"getpriority", (PyCFunction)os_getpriority, METH_FASTCALL|METH_KEYWORDS, os_getpriority__doc__},
 
 static PyObject *
 os_getpriority_impl(PyObject *module, int which, int who);
@@ -1176,7 +1176,7 @@ PyDoc_STRVAR(os_setpriority__doc__,
 "Set program scheduling priority.");
 
 #define OS_SETPRIORITY_METHODDEF    \
-    {"setpriority", (PyCFunction)os_setpriority, METH_FASTCALL, os_setpriority__doc__},
+    {"setpriority", (PyCFunction)os_setpriority, METH_FASTCALL|METH_KEYWORDS, os_setpriority__doc__},
 
 static PyObject *
 os_setpriority_impl(PyObject *module, int which, int who, int priority);
@@ -1216,7 +1216,7 @@ PyDoc_STRVAR(os_rename__doc__,
 "  If they are unavailable, using them will raise a NotImplementedError.");
 
 #define OS_RENAME_METHODDEF    \
-    {"rename", (PyCFunction)os_rename, METH_FASTCALL, os_rename__doc__},
+    {"rename", (PyCFunction)os_rename, METH_FASTCALL|METH_KEYWORDS, os_rename__doc__},
 
 static PyObject *
 os_rename_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
@@ -1261,7 +1261,7 @@ PyDoc_STRVAR(os_replace__doc__,
 "  If they are unavailable, using them will raise a NotImplementedError.\"");
 
 #define OS_REPLACE_METHODDEF    \
-    {"replace", (PyCFunction)os_replace, METH_FASTCALL, os_replace__doc__},
+    {"replace", (PyCFunction)os_replace, METH_FASTCALL|METH_KEYWORDS, os_replace__doc__},
 
 static PyObject *
 os_replace_impl(PyObject *module, path_t *src, path_t *dst, int src_dir_fd,
@@ -1305,7 +1305,7 @@ PyDoc_STRVAR(os_rmdir__doc__,
 "  If it is unavailable, using it will raise a NotImplementedError.");
 
 #define OS_RMDIR_METHODDEF    \
-    {"rmdir", (PyCFunction)os_rmdir, METH_FASTCALL, os_rmdir__doc__},
+    {"rmdir", (PyCFunction)os_rmdir, METH_FASTCALL|METH_KEYWORDS, os_rmdir__doc__},
 
 static PyObject *
 os_rmdir_impl(PyObject *module, path_t *path, int dir_fd);
@@ -1341,7 +1341,7 @@ PyDoc_STRVAR(os_system__doc__,
 "Execute the command in a subshell.");
 
 #define OS_SYSTEM_METHODDEF    \
-    {"system", (PyCFunction)os_system, METH_FASTCALL, os_system__doc__},
+    {"system", (PyCFunction)os_system, METH_FASTCALL|METH_KEYWORDS, os_system__doc__},
 
 static long
 os_system_impl(PyObject *module, Py_UNICODE *command);
@@ -1380,7 +1380,7 @@ PyDoc_STRVAR(os_system__doc__,
 "Execute the command in a subshell.");
 
 #define OS_SYSTEM_METHODDEF    \
-    {"system", (PyCFunction)os_system, METH_FASTCALL, os_system__doc__},
+    {"system", (PyCFunction)os_system, METH_FASTCALL|METH_KEYWORDS, os_system__doc__},
 
 static long
 os_system_impl(PyObject *module, PyObject *command);
@@ -1452,7 +1452,7 @@ PyDoc_STRVAR(os_unlink__doc__,
 "  If it is unavailable, using it will raise a NotImplementedError.");
 
 #define OS_UNLINK_METHODDEF    \
-    {"unlink", (PyCFunction)os_unlink, METH_FASTCALL, os_unlink__doc__},
+    {"unlink", (PyCFunction)os_unlink, METH_FASTCALL|METH_KEYWORDS, os_unlink__doc__},
 
 static PyObject *
 os_unlink_impl(PyObject *module, path_t *path, int dir_fd);
@@ -1491,7 +1491,7 @@ PyDoc_STRVAR(os_remove__doc__,
 "  If it is unavailable, using it will raise a NotImplementedError.");
 
 #define OS_REMOVE_METHODDEF    \
-    {"remove", (PyCFunction)os_remove, METH_FASTCALL, os_remove__doc__},
+    {"remove", (PyCFunction)os_remove, METH_FASTCALL|METH_KEYWORDS, os_remove__doc__},
 
 static PyObject *
 os_remove_impl(PyObject *module, path_t *path, int dir_fd);
@@ -1573,7 +1573,7 @@ PyDoc_STRVAR(os_utime__doc__,
 "  If they are unavailable, using them will raise a NotImplementedError.");
 
 #define OS_UTIME_METHODDEF    \
-    {"utime", (PyCFunction)os_utime, METH_FASTCALL, os_utime__doc__},
+    {"utime", (PyCFunction)os_utime, METH_FASTCALL|METH_KEYWORDS, os_utime__doc__},
 
 static PyObject *
 os_utime_impl(PyObject *module, path_t *path, PyObject *times, PyObject *ns,
@@ -1611,7 +1611,7 @@ PyDoc_STRVAR(os__exit__doc__,
 "Exit to the system with specified status, without normal exit processing.");
 
 #define OS__EXIT_METHODDEF    \
-    {"_exit", (PyCFunction)os__exit, METH_FASTCALL, os__exit__doc__},
+    {"_exit", (PyCFunction)os__exit, METH_FASTCALL|METH_KEYWORDS, os__exit__doc__},
 
 static PyObject *
 os__exit_impl(PyObject *module, int status);
@@ -1654,15 +1654,11 @@ static PyObject *
 os_execv_impl(PyObject *module, path_t *path, PyObject *argv);
 
 static PyObject *
-os_execv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_execv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     path_t path = PATH_T_INITIALIZE("execv", "path", 0, 0);
     PyObject *argv;
-
-    if (!_PyArg_NoStackKeywords("execv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&O:execv",
         path_converter, &path, &argv)) {
@@ -1695,7 +1691,7 @@ PyDoc_STRVAR(os_execve__doc__,
 "    Dictionary of strings mapping to strings.");
 
 #define OS_EXECVE_METHODDEF    \
-    {"execve", (PyCFunction)os_execve, METH_FASTCALL, os_execve__doc__},
+    {"execve", (PyCFunction)os_execve, METH_FASTCALL|METH_KEYWORDS, os_execve__doc__},
 
 static PyObject *
 os_execve_impl(PyObject *module, path_t *path, PyObject *argv, PyObject *env);
@@ -1747,16 +1743,12 @@ static PyObject *
 os_spawnv_impl(PyObject *module, int mode, path_t *path, PyObject *argv);
 
 static PyObject *
-os_spawnv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_spawnv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int mode;
     path_t path = PATH_T_INITIALIZE("spawnv", "path", 0, 0);
     PyObject *argv;
-
-    if (!_PyArg_NoStackKeywords("spawnv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO&O:spawnv",
         &mode, path_converter, &path, &argv)) {
@@ -1798,17 +1790,13 @@ os_spawnve_impl(PyObject *module, int mode, path_t *path, PyObject *argv,
                 PyObject *env);
 
 static PyObject *
-os_spawnve(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_spawnve(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int mode;
     path_t path = PATH_T_INITIALIZE("spawnve", "path", 0, 0);
     PyObject *argv;
     PyObject *env;
-
-    if (!_PyArg_NoStackKeywords("spawnve", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO&OO:spawnve",
         &mode, path_converter, &path, &argv, &env)) {
@@ -1845,7 +1833,7 @@ PyDoc_STRVAR(os_register_at_fork__doc__,
 "\'after_in_child\' and \'after_in_parent\' callbacks are called in order.");
 
 #define OS_REGISTER_AT_FORK_METHODDEF    \
-    {"register_at_fork", (PyCFunction)os_register_at_fork, METH_FASTCALL, os_register_at_fork__doc__},
+    {"register_at_fork", (PyCFunction)os_register_at_fork, METH_FASTCALL|METH_KEYWORDS, os_register_at_fork__doc__},
 
 static PyObject *
 os_register_at_fork_impl(PyObject *module, PyObject *before,
@@ -1930,7 +1918,7 @@ PyDoc_STRVAR(os_sched_get_priority_max__doc__,
 "Get the maximum scheduling priority for policy.");
 
 #define OS_SCHED_GET_PRIORITY_MAX_METHODDEF    \
-    {"sched_get_priority_max", (PyCFunction)os_sched_get_priority_max, METH_FASTCALL, os_sched_get_priority_max__doc__},
+    {"sched_get_priority_max", (PyCFunction)os_sched_get_priority_max, METH_FASTCALL|METH_KEYWORDS, os_sched_get_priority_max__doc__},
 
 static PyObject *
 os_sched_get_priority_max_impl(PyObject *module, int policy);
@@ -1964,7 +1952,7 @@ PyDoc_STRVAR(os_sched_get_priority_min__doc__,
 "Get the minimum scheduling priority for policy.");
 
 #define OS_SCHED_GET_PRIORITY_MIN_METHODDEF    \
-    {"sched_get_priority_min", (PyCFunction)os_sched_get_priority_min, METH_FASTCALL, os_sched_get_priority_min__doc__},
+    {"sched_get_priority_min", (PyCFunction)os_sched_get_priority_min, METH_FASTCALL|METH_KEYWORDS, os_sched_get_priority_min__doc__},
 
 static PyObject *
 os_sched_get_priority_min_impl(PyObject *module, int policy);
@@ -2075,16 +2063,12 @@ os_sched_setscheduler_impl(PyObject *module, pid_t pid, int policy,
                            struct sched_param *param);
 
 static PyObject *
-os_sched_setscheduler(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_sched_setscheduler(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     int policy;
     struct sched_param param;
-
-    if (!_PyArg_NoStackKeywords("sched_setscheduler", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "iO&:sched_setscheduler",
         &pid, &policy, convert_sched_param, &param)) {
@@ -2151,15 +2135,11 @@ os_sched_setparam_impl(PyObject *module, pid_t pid,
                        struct sched_param *param);
 
 static PyObject *
-os_sched_setparam(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_sched_setparam(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     struct sched_param param;
-
-    if (!_PyArg_NoStackKeywords("sched_setparam", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "O&:sched_setparam",
         &pid, convert_sched_param, &param)) {
@@ -2250,15 +2230,11 @@ static PyObject *
 os_sched_setaffinity_impl(PyObject *module, pid_t pid, PyObject *mask);
 
 static PyObject *
-os_sched_setaffinity(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_sched_setaffinity(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     PyObject *mask;
-
-    if (!_PyArg_NoStackKeywords("sched_setaffinity", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "O:sched_setaffinity",
         &pid, &mask)) {
@@ -2476,7 +2452,7 @@ PyDoc_STRVAR(os_getpgid__doc__,
 "Call the system call getpgid(), and return the result.");
 
 #define OS_GETPGID_METHODDEF    \
-    {"getpgid", (PyCFunction)os_getpgid, METH_FASTCALL, os_getpgid__doc__},
+    {"getpgid", (PyCFunction)os_getpgid, METH_FASTCALL|METH_KEYWORDS, os_getpgid__doc__},
 
 static PyObject *
 os_getpgid_impl(PyObject *module, pid_t pid);
@@ -2629,15 +2605,11 @@ static PyObject *
 os_kill_impl(PyObject *module, pid_t pid, Py_ssize_t signal);
 
 static PyObject *
-os_kill(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_kill(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     Py_ssize_t signal;
-
-    if (!_PyArg_NoStackKeywords("kill", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "n:kill",
         &pid, &signal)) {
@@ -2666,15 +2638,11 @@ static PyObject *
 os_killpg_impl(PyObject *module, pid_t pgid, int signal);
 
 static PyObject *
-os_killpg(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_killpg(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     pid_t pgid;
     int signal;
-
-    if (!_PyArg_NoStackKeywords("killpg", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "i:killpg",
         &pgid, &signal)) {
@@ -2827,15 +2795,11 @@ static PyObject *
 os_setreuid_impl(PyObject *module, uid_t ruid, uid_t euid);
 
 static PyObject *
-os_setreuid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_setreuid(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     uid_t ruid;
     uid_t euid;
-
-    if (!_PyArg_NoStackKeywords("setreuid", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&O&:setreuid",
         _Py_Uid_Converter, &ruid, _Py_Uid_Converter, &euid)) {
@@ -2864,15 +2828,11 @@ static PyObject *
 os_setregid_impl(PyObject *module, gid_t rgid, gid_t egid);
 
 static PyObject *
-os_setregid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_setregid(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     gid_t rgid;
     gid_t egid;
-
-    if (!_PyArg_NoStackKeywords("setregid", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&O&:setregid",
         _Py_Gid_Converter, &rgid, _Py_Gid_Converter, &egid)) {
@@ -2942,7 +2902,7 @@ PyDoc_STRVAR(os_wait3__doc__,
 "  (pid, status, rusage)");
 
 #define OS_WAIT3_METHODDEF    \
-    {"wait3", (PyCFunction)os_wait3, METH_FASTCALL, os_wait3__doc__},
+    {"wait3", (PyCFunction)os_wait3, METH_FASTCALL|METH_KEYWORDS, os_wait3__doc__},
 
 static PyObject *
 os_wait3_impl(PyObject *module, int options);
@@ -2979,7 +2939,7 @@ PyDoc_STRVAR(os_wait4__doc__,
 "  (pid, status, rusage)");
 
 #define OS_WAIT4_METHODDEF    \
-    {"wait4", (PyCFunction)os_wait4, METH_FASTCALL, os_wait4__doc__},
+    {"wait4", (PyCFunction)os_wait4, METH_FASTCALL|METH_KEYWORDS, os_wait4__doc__},
 
 static PyObject *
 os_wait4_impl(PyObject *module, pid_t pid, int options);
@@ -3031,16 +2991,12 @@ static PyObject *
 os_waitid_impl(PyObject *module, idtype_t idtype, id_t id, int options);
 
 static PyObject *
-os_waitid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_waitid(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     idtype_t idtype;
     id_t id;
     int options;
-
-    if (!_PyArg_NoStackKeywords("waitid", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "i" _Py_PARSE_PID "i:waitid",
         &idtype, &id, &options)) {
@@ -3074,15 +3030,11 @@ static PyObject *
 os_waitpid_impl(PyObject *module, pid_t pid, int options);
 
 static PyObject *
-os_waitpid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_waitpid(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     int options;
-
-    if (!_PyArg_NoStackKeywords("waitpid", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "i:waitpid",
         &pid, &options)) {
@@ -3116,15 +3068,11 @@ static PyObject *
 os_waitpid_impl(PyObject *module, intptr_t pid, int options);
 
 static PyObject *
-os_waitpid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_waitpid(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     intptr_t pid;
     int options;
-
-    if (!_PyArg_NoStackKeywords("waitpid", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_INTPTR "i:waitpid",
         &pid, &options)) {
@@ -3182,7 +3130,7 @@ PyDoc_STRVAR(os_symlink__doc__,
 "  If it is unavailable, using it will raise a NotImplementedError.");
 
 #define OS_SYMLINK_METHODDEF    \
-    {"symlink", (PyCFunction)os_symlink, METH_FASTCALL, os_symlink__doc__},
+    {"symlink", (PyCFunction)os_symlink, METH_FASTCALL|METH_KEYWORDS, os_symlink__doc__},
 
 static PyObject *
 os_symlink_impl(PyObject *module, path_t *src, path_t *dst,
@@ -3310,15 +3258,11 @@ static PyObject *
 os_setpgid_impl(PyObject *module, pid_t pid, pid_t pgrp);
 
 static PyObject *
-os_setpgid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_setpgid(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     pid_t pid;
     pid_t pgrp;
-
-    if (!_PyArg_NoStackKeywords("setpgid", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "" _Py_PARSE_PID ":setpgid",
         &pid, &pgrp)) {
@@ -3378,15 +3322,11 @@ static PyObject *
 os_tcsetpgrp_impl(PyObject *module, int fd, pid_t pgid);
 
 static PyObject *
-os_tcsetpgrp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_tcsetpgrp(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     pid_t pgid;
-
-    if (!_PyArg_NoStackKeywords("tcsetpgrp", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "i" _Py_PARSE_PID ":tcsetpgrp",
         &fd, &pgid)) {
@@ -3412,7 +3352,7 @@ PyDoc_STRVAR(os_open__doc__,
 "  If it is unavailable, using it will raise a NotImplementedError.");
 
 #define OS_OPEN_METHODDEF    \
-    {"open", (PyCFunction)os_open, METH_FASTCALL, os_open__doc__},
+    {"open", (PyCFunction)os_open, METH_FASTCALL|METH_KEYWORDS, os_open__doc__},
 
 static int
 os_open_impl(PyObject *module, path_t *path, int flags, int mode, int dir_fd);
@@ -3453,7 +3393,7 @@ PyDoc_STRVAR(os_close__doc__,
 "Close a file descriptor.");
 
 #define OS_CLOSE_METHODDEF    \
-    {"close", (PyCFunction)os_close, METH_FASTCALL, os_close__doc__},
+    {"close", (PyCFunction)os_close, METH_FASTCALL|METH_KEYWORDS, os_close__doc__},
 
 static PyObject *
 os_close_impl(PyObject *module, int fd);
@@ -3489,15 +3429,11 @@ static PyObject *
 os_closerange_impl(PyObject *module, int fd_low, int fd_high);
 
 static PyObject *
-os_closerange(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_closerange(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd_low;
     int fd_high;
-
-    if (!_PyArg_NoStackKeywords("closerange", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ii:closerange",
         &fd_low, &fd_high)) {
@@ -3548,7 +3484,7 @@ PyDoc_STRVAR(os_dup2__doc__,
 "Duplicate file descriptor.");
 
 #define OS_DUP2_METHODDEF    \
-    {"dup2", (PyCFunction)os_dup2, METH_FASTCALL, os_dup2__doc__},
+    {"dup2", (PyCFunction)os_dup2, METH_FASTCALL|METH_KEYWORDS, os_dup2__doc__},
 
 static PyObject *
 os_dup2_impl(PyObject *module, int fd, int fd2, int inheritable);
@@ -3595,16 +3531,12 @@ static PyObject *
 os_lockf_impl(PyObject *module, int fd, int command, Py_off_t length);
 
 static PyObject *
-os_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     int command;
     Py_off_t length;
-
-    if (!_PyArg_NoStackKeywords("lockf", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iiO&:lockf",
         &fd, &command, Py_off_t_converter, &length)) {
@@ -3634,17 +3566,13 @@ static Py_off_t
 os_lseek_impl(PyObject *module, int fd, Py_off_t position, int how);
 
 static PyObject *
-os_lseek(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_lseek(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_off_t position;
     int how;
     Py_off_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("lseek", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO&i:lseek",
         &fd, Py_off_t_converter, &position, &how)) {
@@ -3673,15 +3601,11 @@ static PyObject *
 os_read_impl(PyObject *module, int fd, Py_ssize_t length);
 
 static PyObject *
-os_read(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_read(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_ssize_t length;
-
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "in:read",
         &fd, &length)) {
@@ -3716,16 +3640,12 @@ static Py_ssize_t
 os_readv_impl(PyObject *module, int fd, PyObject *buffers);
 
 static PyObject *
-os_readv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_readv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     PyObject *buffers;
     Py_ssize_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("readv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO:readv",
         &fd, &buffers)) {
@@ -3761,16 +3681,12 @@ static PyObject *
 os_pread_impl(PyObject *module, int fd, int length, Py_off_t offset);
 
 static PyObject *
-os_pread(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_pread(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     int length;
     Py_off_t offset;
-
-    if (!_PyArg_NoStackKeywords("pread", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iiO&:pread",
         &fd, &length, Py_off_t_converter, &offset)) {
@@ -3797,16 +3713,12 @@ static Py_ssize_t
 os_write_impl(PyObject *module, int fd, Py_buffer *data);
 
 static PyObject *
-os_write(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_write(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_buffer data = {NULL, NULL};
     Py_ssize_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("write", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iy*:write",
         &fd, &data)) {
@@ -3837,7 +3749,7 @@ PyDoc_STRVAR(os_fstat__doc__,
 "Equivalent to os.stat(fd).");
 
 #define OS_FSTAT_METHODDEF    \
-    {"fstat", (PyCFunction)os_fstat, METH_FASTCALL, os_fstat__doc__},
+    {"fstat", (PyCFunction)os_fstat, METH_FASTCALL|METH_KEYWORDS, os_fstat__doc__},
 
 static PyObject *
 os_fstat_impl(PyObject *module, int fd);
@@ -3975,16 +3887,12 @@ static Py_ssize_t
 os_writev_impl(PyObject *module, int fd, PyObject *buffers);
 
 static PyObject *
-os_writev(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_writev(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     PyObject *buffers;
     Py_ssize_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("writev", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO:writev",
         &fd, &buffers)) {
@@ -4021,17 +3929,13 @@ static Py_ssize_t
 os_pwrite_impl(PyObject *module, int fd, Py_buffer *buffer, Py_off_t offset);
 
 static PyObject *
-os_pwrite(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_pwrite(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_buffer buffer = {NULL, NULL};
     Py_off_t offset;
     Py_ssize_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("pwrite", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iy*O&:pwrite",
         &fd, &buffer, Py_off_t_converter, &offset)) {
@@ -4068,7 +3972,7 @@ PyDoc_STRVAR(os_mkfifo__doc__,
 "  If it is unavailable, using it will raise a NotImplementedError.");
 
 #define OS_MKFIFO_METHODDEF    \
-    {"mkfifo", (PyCFunction)os_mkfifo, METH_FASTCALL, os_mkfifo__doc__},
+    {"mkfifo", (PyCFunction)os_mkfifo, METH_FASTCALL|METH_KEYWORDS, os_mkfifo__doc__},
 
 static PyObject *
 os_mkfifo_impl(PyObject *module, path_t *path, int mode, int dir_fd);
@@ -4119,7 +4023,7 @@ PyDoc_STRVAR(os_mknod__doc__,
 "  If it is unavailable, using it will raise a NotImplementedError.");
 
 #define OS_MKNOD_METHODDEF    \
-    {"mknod", (PyCFunction)os_mknod, METH_FASTCALL, os_mknod__doc__},
+    {"mknod", (PyCFunction)os_mknod, METH_FASTCALL|METH_KEYWORDS, os_mknod__doc__},
 
 static PyObject *
 os_mknod_impl(PyObject *module, path_t *path, int mode, dev_t device,
@@ -4238,16 +4142,12 @@ static dev_t
 os_makedev_impl(PyObject *module, int major, int minor);
 
 static PyObject *
-os_makedev(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_makedev(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int major;
     int minor;
     dev_t _return_value;
-
-    if (!_PyArg_NoStackKeywords("makedev", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ii:makedev",
         &major, &minor)) {
@@ -4280,15 +4180,11 @@ static PyObject *
 os_ftruncate_impl(PyObject *module, int fd, Py_off_t length);
 
 static PyObject *
-os_ftruncate(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_ftruncate(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_off_t length;
-
-    if (!_PyArg_NoStackKeywords("ftruncate", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO&:ftruncate",
         &fd, Py_off_t_converter, &length)) {
@@ -4314,7 +4210,7 @@ PyDoc_STRVAR(os_truncate__doc__,
 "  If this functionality is unavailable, using it raises an exception.");
 
 #define OS_TRUNCATE_METHODDEF    \
-    {"truncate", (PyCFunction)os_truncate, METH_FASTCALL, os_truncate__doc__},
+    {"truncate", (PyCFunction)os_truncate, METH_FASTCALL|METH_KEYWORDS, os_truncate__doc__},
 
 static PyObject *
 os_truncate_impl(PyObject *module, path_t *path, Py_off_t length);
@@ -4362,16 +4258,12 @@ os_posix_fallocate_impl(PyObject *module, int fd, Py_off_t offset,
                         Py_off_t length);
 
 static PyObject *
-os_posix_fallocate(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_posix_fallocate(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_off_t offset;
     Py_off_t length;
-
-    if (!_PyArg_NoStackKeywords("posix_fallocate", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO&O&:posix_fallocate",
         &fd, Py_off_t_converter, &offset, Py_off_t_converter, &length)) {
@@ -4409,17 +4301,13 @@ os_posix_fadvise_impl(PyObject *module, int fd, Py_off_t offset,
                       Py_off_t length, int advice);
 
 static PyObject *
-os_posix_fadvise(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_posix_fadvise(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     Py_off_t offset;
     Py_off_t length;
     int advice;
-
-    if (!_PyArg_NoStackKeywords("posix_fadvise", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO&O&i:posix_fadvise",
         &fd, Py_off_t_converter, &offset, Py_off_t_converter, &length, &advice)) {
@@ -4448,15 +4336,11 @@ static PyObject *
 os_putenv_impl(PyObject *module, PyObject *name, PyObject *value);
 
 static PyObject *
-os_putenv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_putenv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *name;
     PyObject *value;
-
-    if (!_PyArg_NoStackKeywords("putenv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "UU:putenv",
         &name, &value)) {
@@ -4485,15 +4369,11 @@ static PyObject *
 os_putenv_impl(PyObject *module, PyObject *name, PyObject *value);
 
 static PyObject *
-os_putenv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_putenv(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *name = NULL;
     PyObject *value = NULL;
-
-    if (!_PyArg_NoStackKeywords("putenv", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&O&:putenv",
         PyUnicode_FSConverter, &name, PyUnicode_FSConverter, &value)) {
@@ -4621,7 +4501,7 @@ PyDoc_STRVAR(os_WIFCONTINUED__doc__,
 "job control stop.");
 
 #define OS_WIFCONTINUED_METHODDEF    \
-    {"WIFCONTINUED", (PyCFunction)os_WIFCONTINUED, METH_FASTCALL, os_WIFCONTINUED__doc__},
+    {"WIFCONTINUED", (PyCFunction)os_WIFCONTINUED, METH_FASTCALL|METH_KEYWORDS, os_WIFCONTINUED__doc__},
 
 static int
 os_WIFCONTINUED_impl(PyObject *module, int status);
@@ -4660,7 +4540,7 @@ PyDoc_STRVAR(os_WIFSTOPPED__doc__,
 "Return True if the process returning status was stopped.");
 
 #define OS_WIFSTOPPED_METHODDEF    \
-    {"WIFSTOPPED", (PyCFunction)os_WIFSTOPPED, METH_FASTCALL, os_WIFSTOPPED__doc__},
+    {"WIFSTOPPED", (PyCFunction)os_WIFSTOPPED, METH_FASTCALL|METH_KEYWORDS, os_WIFSTOPPED__doc__},
 
 static int
 os_WIFSTOPPED_impl(PyObject *module, int status);
@@ -4699,7 +4579,7 @@ PyDoc_STRVAR(os_WIFSIGNALED__doc__,
 "Return True if the process returning status was terminated by a signal.");
 
 #define OS_WIFSIGNALED_METHODDEF    \
-    {"WIFSIGNALED", (PyCFunction)os_WIFSIGNALED, METH_FASTCALL, os_WIFSIGNALED__doc__},
+    {"WIFSIGNALED", (PyCFunction)os_WIFSIGNALED, METH_FASTCALL|METH_KEYWORDS, os_WIFSIGNALED__doc__},
 
 static int
 os_WIFSIGNALED_impl(PyObject *module, int status);
@@ -4738,7 +4618,7 @@ PyDoc_STRVAR(os_WIFEXITED__doc__,
 "Return True if the process returning status exited via the exit() system call.");
 
 #define OS_WIFEXITED_METHODDEF    \
-    {"WIFEXITED", (PyCFunction)os_WIFEXITED, METH_FASTCALL, os_WIFEXITED__doc__},
+    {"WIFEXITED", (PyCFunction)os_WIFEXITED, METH_FASTCALL|METH_KEYWORDS, os_WIFEXITED__doc__},
 
 static int
 os_WIFEXITED_impl(PyObject *module, int status);
@@ -4777,7 +4657,7 @@ PyDoc_STRVAR(os_WEXITSTATUS__doc__,
 "Return the process return code from status.");
 
 #define OS_WEXITSTATUS_METHODDEF    \
-    {"WEXITSTATUS", (PyCFunction)os_WEXITSTATUS, METH_FASTCALL, os_WEXITSTATUS__doc__},
+    {"WEXITSTATUS", (PyCFunction)os_WEXITSTATUS, METH_FASTCALL|METH_KEYWORDS, os_WEXITSTATUS__doc__},
 
 static int
 os_WEXITSTATUS_impl(PyObject *module, int status);
@@ -4816,7 +4696,7 @@ PyDoc_STRVAR(os_WTERMSIG__doc__,
 "Return the signal that terminated the process that provided the status value.");
 
 #define OS_WTERMSIG_METHODDEF    \
-    {"WTERMSIG", (PyCFunction)os_WTERMSIG, METH_FASTCALL, os_WTERMSIG__doc__},
+    {"WTERMSIG", (PyCFunction)os_WTERMSIG, METH_FASTCALL|METH_KEYWORDS, os_WTERMSIG__doc__},
 
 static int
 os_WTERMSIG_impl(PyObject *module, int status);
@@ -4855,7 +4735,7 @@ PyDoc_STRVAR(os_WSTOPSIG__doc__,
 "Return the signal that stopped the process that provided the status value.");
 
 #define OS_WSTOPSIG_METHODDEF    \
-    {"WSTOPSIG", (PyCFunction)os_WSTOPSIG, METH_FASTCALL, os_WSTOPSIG__doc__},
+    {"WSTOPSIG", (PyCFunction)os_WSTOPSIG, METH_FASTCALL|METH_KEYWORDS, os_WSTOPSIG__doc__},
 
 static int
 os_WSTOPSIG_impl(PyObject *module, int status);
@@ -4931,7 +4811,7 @@ PyDoc_STRVAR(os_statvfs__doc__,
 "  If this functionality is unavailable, using it raises an exception.");
 
 #define OS_STATVFS_METHODDEF    \
-    {"statvfs", (PyCFunction)os_statvfs, METH_FASTCALL, os_statvfs__doc__},
+    {"statvfs", (PyCFunction)os_statvfs, METH_FASTCALL|METH_KEYWORDS, os_statvfs__doc__},
 
 static PyObject *
 os_statvfs_impl(PyObject *module, path_t *path);
@@ -4968,7 +4848,7 @@ PyDoc_STRVAR(os__getdiskusage__doc__,
 "Return disk usage statistics about the given path as a (total, free) tuple.");
 
 #define OS__GETDISKUSAGE_METHODDEF    \
-    {"_getdiskusage", (PyCFunction)os__getdiskusage, METH_FASTCALL, os__getdiskusage__doc__},
+    {"_getdiskusage", (PyCFunction)os__getdiskusage, METH_FASTCALL|METH_KEYWORDS, os__getdiskusage__doc__},
 
 static PyObject *
 os__getdiskusage_impl(PyObject *module, Py_UNICODE *path);
@@ -5010,16 +4890,12 @@ static long
 os_fpathconf_impl(PyObject *module, int fd, int name);
 
 static PyObject *
-os_fpathconf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_fpathconf(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     int name;
     long _return_value;
-
-    if (!_PyArg_NoStackKeywords("fpathconf", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO&:fpathconf",
         &fd, conv_path_confname, &name)) {
@@ -5050,7 +4926,7 @@ PyDoc_STRVAR(os_pathconf__doc__,
 "  If this functionality is unavailable, using it raises an exception.");
 
 #define OS_PATHCONF_METHODDEF    \
-    {"pathconf", (PyCFunction)os_pathconf, METH_FASTCALL, os_pathconf__doc__},
+    {"pathconf", (PyCFunction)os_pathconf, METH_FASTCALL|METH_KEYWORDS, os_pathconf__doc__},
 
 static long
 os_pathconf_impl(PyObject *module, path_t *path, int name);
@@ -5198,7 +5074,7 @@ PyDoc_STRVAR(os_startfile__doc__,
 "the underlying Win32 ShellExecute function doesn\'t work if it is.");
 
 #define OS_STARTFILE_METHODDEF    \
-    {"startfile", (PyCFunction)os_startfile, METH_FASTCALL, os_startfile__doc__},
+    {"startfile", (PyCFunction)os_startfile, METH_FASTCALL|METH_KEYWORDS, os_startfile__doc__},
 
 static PyObject *
 os_startfile_impl(PyObject *module, path_t *filepath, Py_UNICODE *operation);
@@ -5263,7 +5139,7 @@ PyDoc_STRVAR(os_device_encoding__doc__,
 "If the device is not a terminal, return None.");
 
 #define OS_DEVICE_ENCODING_METHODDEF    \
-    {"device_encoding", (PyCFunction)os_device_encoding, METH_FASTCALL, os_device_encoding__doc__},
+    {"device_encoding", (PyCFunction)os_device_encoding, METH_FASTCALL|METH_KEYWORDS, os_device_encoding__doc__},
 
 static PyObject *
 os_device_encoding_impl(PyObject *module, int fd);
@@ -5301,16 +5177,12 @@ static PyObject *
 os_setresuid_impl(PyObject *module, uid_t ruid, uid_t euid, uid_t suid);
 
 static PyObject *
-os_setresuid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_setresuid(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     uid_t ruid;
     uid_t euid;
     uid_t suid;
-
-    if (!_PyArg_NoStackKeywords("setresuid", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&O&O&:setresuid",
         _Py_Uid_Converter, &ruid, _Py_Uid_Converter, &euid, _Py_Uid_Converter, &suid)) {
@@ -5339,16 +5211,12 @@ static PyObject *
 os_setresgid_impl(PyObject *module, gid_t rgid, gid_t egid, gid_t sgid);
 
 static PyObject *
-os_setresgid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_setresgid(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     gid_t rgid;
     gid_t egid;
     gid_t sgid;
-
-    if (!_PyArg_NoStackKeywords("setresgid", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&O&O&:setresgid",
         _Py_Gid_Converter, &rgid, _Py_Gid_Converter, &egid, _Py_Gid_Converter, &sgid)) {
@@ -5420,7 +5288,7 @@ PyDoc_STRVAR(os_getxattr__doc__,
 "  the link points to.");
 
 #define OS_GETXATTR_METHODDEF    \
-    {"getxattr", (PyCFunction)os_getxattr, METH_FASTCALL, os_getxattr__doc__},
+    {"getxattr", (PyCFunction)os_getxattr, METH_FASTCALL|METH_KEYWORDS, os_getxattr__doc__},
 
 static PyObject *
 os_getxattr_impl(PyObject *module, path_t *path, path_t *attribute,
@@ -5468,7 +5336,7 @@ PyDoc_STRVAR(os_setxattr__doc__,
 "  the link points to.");
 
 #define OS_SETXATTR_METHODDEF    \
-    {"setxattr", (PyCFunction)os_setxattr, METH_FASTCALL, os_setxattr__doc__},
+    {"setxattr", (PyCFunction)os_setxattr, METH_FASTCALL|METH_KEYWORDS, os_setxattr__doc__},
 
 static PyObject *
 os_setxattr_impl(PyObject *module, path_t *path, path_t *attribute,
@@ -5521,7 +5389,7 @@ PyDoc_STRVAR(os_removexattr__doc__,
 "  the link points to.");
 
 #define OS_REMOVEXATTR_METHODDEF    \
-    {"removexattr", (PyCFunction)os_removexattr, METH_FASTCALL, os_removexattr__doc__},
+    {"removexattr", (PyCFunction)os_removexattr, METH_FASTCALL|METH_KEYWORDS, os_removexattr__doc__},
 
 static PyObject *
 os_removexattr_impl(PyObject *module, path_t *path, path_t *attribute,
@@ -5569,7 +5437,7 @@ PyDoc_STRVAR(os_listxattr__doc__,
 "  the link points to.");
 
 #define OS_LISTXATTR_METHODDEF    \
-    {"listxattr", (PyCFunction)os_listxattr, METH_FASTCALL, os_listxattr__doc__},
+    {"listxattr", (PyCFunction)os_listxattr, METH_FASTCALL|METH_KEYWORDS, os_listxattr__doc__},
 
 static PyObject *
 os_listxattr_impl(PyObject *module, path_t *path, int follow_symlinks);
@@ -5692,15 +5560,11 @@ static PyObject *
 os_set_inheritable_impl(PyObject *module, int fd, int inheritable);
 
 static PyObject *
-os_set_inheritable(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_set_inheritable(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     int inheritable;
-
-    if (!_PyArg_NoStackKeywords("set_inheritable", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ii:set_inheritable",
         &fd, &inheritable)) {
@@ -5764,15 +5628,11 @@ os_set_handle_inheritable_impl(PyObject *module, intptr_t handle,
                                int inheritable);
 
 static PyObject *
-os_set_handle_inheritable(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+os_set_handle_inheritable(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     intptr_t handle;
     int inheritable;
-
-    if (!_PyArg_NoStackKeywords("set_handle_inheritable", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_INTPTR "p:set_handle_inheritable",
         &handle, &inheritable)) {
@@ -5821,7 +5681,7 @@ PyDoc_STRVAR(os_DirEntry_stat__doc__,
 "Return stat_result object for the entry; cached per entry.");
 
 #define OS_DIRENTRY_STAT_METHODDEF    \
-    {"stat", (PyCFunction)os_DirEntry_stat, METH_FASTCALL, os_DirEntry_stat__doc__},
+    {"stat", (PyCFunction)os_DirEntry_stat, METH_FASTCALL|METH_KEYWORDS, os_DirEntry_stat__doc__},
 
 static PyObject *
 os_DirEntry_stat_impl(DirEntry *self, int follow_symlinks);
@@ -5851,7 +5711,7 @@ PyDoc_STRVAR(os_DirEntry_is_dir__doc__,
 "Return True if the entry is a directory; cached per entry.");
 
 #define OS_DIRENTRY_IS_DIR_METHODDEF    \
-    {"is_dir", (PyCFunction)os_DirEntry_is_dir, METH_FASTCALL, os_DirEntry_is_dir__doc__},
+    {"is_dir", (PyCFunction)os_DirEntry_is_dir, METH_FASTCALL|METH_KEYWORDS, os_DirEntry_is_dir__doc__},
 
 static int
 os_DirEntry_is_dir_impl(DirEntry *self, int follow_symlinks);
@@ -5886,7 +5746,7 @@ PyDoc_STRVAR(os_DirEntry_is_file__doc__,
 "Return True if the entry is a file; cached per entry.");
 
 #define OS_DIRENTRY_IS_FILE_METHODDEF    \
-    {"is_file", (PyCFunction)os_DirEntry_is_file, METH_FASTCALL, os_DirEntry_is_file__doc__},
+    {"is_file", (PyCFunction)os_DirEntry_is_file, METH_FASTCALL|METH_KEYWORDS, os_DirEntry_is_file__doc__},
 
 static int
 os_DirEntry_is_file_impl(DirEntry *self, int follow_symlinks);
@@ -5963,7 +5823,7 @@ PyDoc_STRVAR(os_scandir__doc__,
 "If path is None, uses the path=\'.\'.");
 
 #define OS_SCANDIR_METHODDEF    \
-    {"scandir", (PyCFunction)os_scandir, METH_FASTCALL, os_scandir__doc__},
+    {"scandir", (PyCFunction)os_scandir, METH_FASTCALL|METH_KEYWORDS, os_scandir__doc__},
 
 static PyObject *
 os_scandir_impl(PyObject *module, path_t *path);
@@ -6000,7 +5860,7 @@ PyDoc_STRVAR(os_fspath__doc__,
 "types raise a TypeError.");
 
 #define OS_FSPATH_METHODDEF    \
-    {"fspath", (PyCFunction)os_fspath, METH_FASTCALL, os_fspath__doc__},
+    {"fspath", (PyCFunction)os_fspath, METH_FASTCALL|METH_KEYWORDS, os_fspath__doc__},
 
 static PyObject *
 os_fspath_impl(PyObject *module, PyObject *path);
@@ -6032,7 +5892,7 @@ PyDoc_STRVAR(os_getrandom__doc__,
 "Obtain a series of random bytes.");
 
 #define OS_GETRANDOM_METHODDEF    \
-    {"getrandom", (PyCFunction)os_getrandom, METH_FASTCALL, os_getrandom__doc__},
+    {"getrandom", (PyCFunction)os_getrandom, METH_FASTCALL|METH_KEYWORDS, os_getrandom__doc__},
 
 static PyObject *
 os_getrandom_impl(PyObject *module, Py_ssize_t size, int flags);
@@ -6545,4 +6405,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=499329dda38d40c9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=949867cb46218339 input=a9049054013a1b77]*/

--- a/Modules/clinic/pyexpat.c.h
+++ b/Modules/clinic/pyexpat.c.h
@@ -18,15 +18,11 @@ pyexpat_xmlparser_Parse_impl(xmlparseobject *self, PyObject *data,
                              int isfinal);
 
 static PyObject *
-pyexpat_xmlparser_Parse(xmlparseobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+pyexpat_xmlparser_Parse(xmlparseobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *data;
     int isfinal = 0;
-
-    if (!_PyArg_NoStackKeywords("Parse", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|i:Parse",
         &data, &isfinal)) {
@@ -128,15 +124,11 @@ pyexpat_xmlparser_ExternalEntityParserCreate_impl(xmlparseobject *self,
                                                   const char *encoding);
 
 static PyObject *
-pyexpat_xmlparser_ExternalEntityParserCreate(xmlparseobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+pyexpat_xmlparser_ExternalEntityParserCreate(xmlparseobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *context;
     const char *encoding = NULL;
-
-    if (!_PyArg_NoStackKeywords("ExternalEntityParserCreate", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "z|s:ExternalEntityParserCreate",
         &context, &encoding)) {
@@ -199,14 +191,10 @@ static PyObject *
 pyexpat_xmlparser_UseForeignDTD_impl(xmlparseobject *self, int flag);
 
 static PyObject *
-pyexpat_xmlparser_UseForeignDTD(xmlparseobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+pyexpat_xmlparser_UseForeignDTD(xmlparseobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int flag = 1;
-
-    if (!_PyArg_NoStackKeywords("UseForeignDTD", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|p:UseForeignDTD",
         &flag)) {
@@ -245,7 +233,7 @@ PyDoc_STRVAR(pyexpat_ParserCreate__doc__,
 "Return a new XML parser object.");
 
 #define PYEXPAT_PARSERCREATE_METHODDEF    \
-    {"ParserCreate", (PyCFunction)pyexpat_ParserCreate, METH_FASTCALL, pyexpat_ParserCreate__doc__},
+    {"ParserCreate", (PyCFunction)pyexpat_ParserCreate, METH_FASTCALL|METH_KEYWORDS, pyexpat_ParserCreate__doc__},
 
 static PyObject *
 pyexpat_ParserCreate_impl(PyObject *module, const char *encoding,
@@ -301,4 +289,4 @@ exit:
 #ifndef PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
     #define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
 #endif /* !defined(PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF) */
-/*[clinic end generated code: output=a51f9d31aff1a757 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5d2e355f2b48e6c3 input=a9049054013a1b77]*/

--- a/Modules/clinic/resource.c.h
+++ b/Modules/clinic/resource.c.h
@@ -66,15 +66,11 @@ static PyObject *
 resource_setrlimit_impl(PyObject *module, int resource, PyObject *limits);
 
 static PyObject *
-resource_setrlimit(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+resource_setrlimit(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int resource;
     PyObject *limits;
-
-    if (!_PyArg_NoStackKeywords("setrlimit", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO:setrlimit",
         &resource, &limits)) {
@@ -161,4 +157,4 @@ exit:
 #ifndef RESOURCE_PRLIMIT_METHODDEF
     #define RESOURCE_PRLIMIT_METHODDEF
 #endif /* !defined(RESOURCE_PRLIMIT_METHODDEF) */
-/*[clinic end generated code: output=158aace6e532949e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d7dabf49ce5b767f input=a9049054013a1b77]*/

--- a/Modules/clinic/sha1module.c.h
+++ b/Modules/clinic/sha1module.c.h
@@ -72,7 +72,7 @@ PyDoc_STRVAR(_sha1_sha1__doc__,
 "Return a new SHA1 hash object; optionally initialized with a string.");
 
 #define _SHA1_SHA1_METHODDEF    \
-    {"sha1", (PyCFunction)_sha1_sha1, METH_FASTCALL, _sha1_sha1__doc__},
+    {"sha1", (PyCFunction)_sha1_sha1, METH_FASTCALL|METH_KEYWORDS, _sha1_sha1__doc__},
 
 static PyObject *
 _sha1_sha1_impl(PyObject *module, PyObject *string);
@@ -94,4 +94,4 @@ _sha1_sha1(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8e6b04c7e0407be2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=594cf600d6ba4776 input=a9049054013a1b77]*/

--- a/Modules/clinic/sha256module.c.h
+++ b/Modules/clinic/sha256module.c.h
@@ -72,7 +72,7 @@ PyDoc_STRVAR(_sha256_sha256__doc__,
 "Return a new SHA-256 hash object; optionally initialized with a string.");
 
 #define _SHA256_SHA256_METHODDEF    \
-    {"sha256", (PyCFunction)_sha256_sha256, METH_FASTCALL, _sha256_sha256__doc__},
+    {"sha256", (PyCFunction)_sha256_sha256, METH_FASTCALL|METH_KEYWORDS, _sha256_sha256__doc__},
 
 static PyObject *
 _sha256_sha256_impl(PyObject *module, PyObject *string);
@@ -102,7 +102,7 @@ PyDoc_STRVAR(_sha256_sha224__doc__,
 "Return a new SHA-224 hash object; optionally initialized with a string.");
 
 #define _SHA256_SHA224_METHODDEF    \
-    {"sha224", (PyCFunction)_sha256_sha224, METH_FASTCALL, _sha256_sha224__doc__},
+    {"sha224", (PyCFunction)_sha256_sha224, METH_FASTCALL|METH_KEYWORDS, _sha256_sha224__doc__},
 
 static PyObject *
 _sha256_sha224_impl(PyObject *module, PyObject *string);
@@ -124,4 +124,4 @@ _sha256_sha224(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7ef4927ee2a3aac4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=84e7b8365b3ca4d3 input=a9049054013a1b77]*/

--- a/Modules/clinic/sha512module.c.h
+++ b/Modules/clinic/sha512module.c.h
@@ -72,7 +72,7 @@ PyDoc_STRVAR(_sha512_sha512__doc__,
 "Return a new SHA-512 hash object; optionally initialized with a string.");
 
 #define _SHA512_SHA512_METHODDEF    \
-    {"sha512", (PyCFunction)_sha512_sha512, METH_FASTCALL, _sha512_sha512__doc__},
+    {"sha512", (PyCFunction)_sha512_sha512, METH_FASTCALL|METH_KEYWORDS, _sha512_sha512__doc__},
 
 static PyObject *
 _sha512_sha512_impl(PyObject *module, PyObject *string);
@@ -102,7 +102,7 @@ PyDoc_STRVAR(_sha512_sha384__doc__,
 "Return a new SHA-384 hash object; optionally initialized with a string.");
 
 #define _SHA512_SHA384_METHODDEF    \
-    {"sha384", (PyCFunction)_sha512_sha384, METH_FASTCALL, _sha512_sha384__doc__},
+    {"sha384", (PyCFunction)_sha512_sha384, METH_FASTCALL|METH_KEYWORDS, _sha512_sha384__doc__},
 
 static PyObject *
 _sha512_sha384_impl(PyObject *module, PyObject *string);
@@ -124,4 +124,4 @@ _sha512_sha384(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7bb7a49159e9b469 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2f6ad0831d16c35f input=a9049054013a1b77]*/

--- a/Modules/clinic/signalmodule.c.h
+++ b/Modules/clinic/signalmodule.c.h
@@ -80,15 +80,11 @@ static PyObject *
 signal_signal_impl(PyObject *module, int signalnum, PyObject *handler);
 
 static PyObject *
-signal_signal(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+signal_signal(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int signalnum;
     PyObject *handler;
-
-    if (!_PyArg_NoStackKeywords("signal", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO:signal",
         &signalnum, &handler)) {
@@ -151,15 +147,11 @@ static PyObject *
 signal_siginterrupt_impl(PyObject *module, int signalnum, int flag);
 
 static PyObject *
-signal_siginterrupt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+signal_siginterrupt(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int signalnum;
     int flag;
-
-    if (!_PyArg_NoStackKeywords("siginterrupt", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ii:siginterrupt",
         &signalnum, &flag)) {
@@ -194,16 +186,12 @@ signal_setitimer_impl(PyObject *module, int which, double seconds,
                       double interval);
 
 static PyObject *
-signal_setitimer(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+signal_setitimer(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int which;
     double seconds;
     double interval = 0.0;
-
-    if (!_PyArg_NoStackKeywords("setitimer", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "id|d:setitimer",
         &which, &seconds, &interval)) {
@@ -263,15 +251,11 @@ static PyObject *
 signal_pthread_sigmask_impl(PyObject *module, int how, PyObject *mask);
 
 static PyObject *
-signal_pthread_sigmask(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+signal_pthread_sigmask(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int how;
     PyObject *mask;
-
-    if (!_PyArg_NoStackKeywords("pthread_sigmask", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iO:pthread_sigmask",
         &how, &mask)) {
@@ -360,15 +344,11 @@ signal_sigtimedwait_impl(PyObject *module, PyObject *sigset,
                          PyObject *timeout_obj);
 
 static PyObject *
-signal_sigtimedwait(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+signal_sigtimedwait(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *sigset;
     PyObject *timeout_obj;
-
-    if (!_PyArg_NoStackKeywords("sigtimedwait", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "sigtimedwait",
         2, 2,
@@ -399,15 +379,11 @@ signal_pthread_kill_impl(PyObject *module, unsigned long thread_id,
                          int signalnum);
 
 static PyObject *
-signal_pthread_kill(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+signal_pthread_kill(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     unsigned long thread_id;
     int signalnum;
-
-    if (!_PyArg_NoStackKeywords("pthread_kill", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ki:pthread_kill",
         &thread_id, &signalnum)) {
@@ -464,4 +440,4 @@ exit:
 #ifndef SIGNAL_PTHREAD_KILL_METHODDEF
     #define SIGNAL_PTHREAD_KILL_METHODDEF
 #endif /* !defined(SIGNAL_PTHREAD_KILL_METHODDEF) */
-/*[clinic end generated code: output=1a795d863c3bb302 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9403ef0c5d0f7ee0 input=a9049054013a1b77]*/

--- a/Modules/clinic/symtablemodule.c.h
+++ b/Modules/clinic/symtablemodule.c.h
@@ -16,16 +16,12 @@ _symtable_symtable_impl(PyObject *module, const char *str,
                         PyObject *filename, const char *startstr);
 
 static PyObject *
-_symtable_symtable(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_symtable_symtable(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *str;
     PyObject *filename;
     const char *startstr;
-
-    if (!_PyArg_NoStackKeywords("symtable", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "sO&s:symtable",
         &str, PyUnicode_FSDecoder, &filename, &startstr)) {
@@ -36,4 +32,4 @@ _symtable_symtable(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=388595f822b1fc79 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ef379e514fde8477 input=a9049054013a1b77]*/

--- a/Modules/clinic/unicodedata.c.h
+++ b/Modules/clinic/unicodedata.c.h
@@ -20,15 +20,11 @@ unicodedata_UCD_decimal_impl(PyObject *self, int chr,
                              PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_decimal(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicodedata_UCD_decimal(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int chr;
     PyObject *default_value = NULL;
-
-    if (!_PyArg_NoStackKeywords("decimal", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "C|O:decimal",
         &chr, &default_value)) {
@@ -57,15 +53,11 @@ static PyObject *
 unicodedata_UCD_digit_impl(PyObject *self, int chr, PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_digit(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicodedata_UCD_digit(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int chr;
     PyObject *default_value = NULL;
-
-    if (!_PyArg_NoStackKeywords("digit", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "C|O:digit",
         &chr, &default_value)) {
@@ -95,15 +87,11 @@ unicodedata_UCD_numeric_impl(PyObject *self, int chr,
                              PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_numeric(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicodedata_UCD_numeric(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int chr;
     PyObject *default_value = NULL;
-
-    if (!_PyArg_NoStackKeywords("numeric", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "C|O:numeric",
         &chr, &default_value)) {
@@ -312,15 +300,11 @@ unicodedata_UCD_normalize_impl(PyObject *self, const char *form,
                                PyObject *input);
 
 static PyObject *
-unicodedata_UCD_normalize(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicodedata_UCD_normalize(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *form;
     PyObject *input;
-
-    if (!_PyArg_NoStackKeywords("normalize", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "sU:normalize",
         &form, &input)) {
@@ -348,15 +332,11 @@ static PyObject *
 unicodedata_UCD_name_impl(PyObject *self, int chr, PyObject *default_value);
 
 static PyObject *
-unicodedata_UCD_name(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicodedata_UCD_name(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int chr;
     PyObject *default_value = NULL;
-
-    if (!_PyArg_NoStackKeywords("name", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "C|O:name",
         &chr, &default_value)) {
@@ -399,4 +379,4 @@ unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=f69c0bbd7294870b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7ec9a3c8fbfd3c3a input=a9049054013a1b77]*/

--- a/Modules/clinic/zlibmodule.c.h
+++ b/Modules/clinic/zlibmodule.c.h
@@ -14,7 +14,7 @@ PyDoc_STRVAR(zlib_compress__doc__,
 "    Compression level, in 0-9 or -1.");
 
 #define ZLIB_COMPRESS_METHODDEF    \
-    {"compress", (PyCFunction)zlib_compress, METH_FASTCALL, zlib_compress__doc__},
+    {"compress", (PyCFunction)zlib_compress, METH_FASTCALL|METH_KEYWORDS, zlib_compress__doc__},
 
 static PyObject *
 zlib_compress_impl(PyObject *module, Py_buffer *data, int level);
@@ -57,7 +57,7 @@ PyDoc_STRVAR(zlib_decompress__doc__,
 "    The initial output buffer size.");
 
 #define ZLIB_DECOMPRESS_METHODDEF    \
-    {"decompress", (PyCFunction)zlib_decompress, METH_FASTCALL, zlib_decompress__doc__},
+    {"decompress", (PyCFunction)zlib_decompress, METH_FASTCALL|METH_KEYWORDS, zlib_decompress__doc__},
 
 static PyObject *
 zlib_decompress_impl(PyObject *module, Py_buffer *data, int wbits,
@@ -119,7 +119,7 @@ PyDoc_STRVAR(zlib_compressobj__doc__,
 "    containing subsequences that are likely to occur in the input data.");
 
 #define ZLIB_COMPRESSOBJ_METHODDEF    \
-    {"compressobj", (PyCFunction)zlib_compressobj, METH_FASTCALL, zlib_compressobj__doc__},
+    {"compressobj", (PyCFunction)zlib_compressobj, METH_FASTCALL|METH_KEYWORDS, zlib_compressobj__doc__},
 
 static PyObject *
 zlib_compressobj_impl(PyObject *module, int level, int method, int wbits,
@@ -166,7 +166,7 @@ PyDoc_STRVAR(zlib_decompressobj__doc__,
 "    dictionary as used by the compressor that produced the input data.");
 
 #define ZLIB_DECOMPRESSOBJ_METHODDEF    \
-    {"decompressobj", (PyCFunction)zlib_decompressobj, METH_FASTCALL, zlib_decompressobj__doc__},
+    {"decompressobj", (PyCFunction)zlib_decompressobj, METH_FASTCALL|METH_KEYWORDS, zlib_decompressobj__doc__},
 
 static PyObject *
 zlib_decompressobj_impl(PyObject *module, int wbits, PyObject *zdict);
@@ -247,7 +247,7 @@ PyDoc_STRVAR(zlib_Decompress_decompress__doc__,
 "Call the flush() method to clear these buffers.");
 
 #define ZLIB_DECOMPRESS_DECOMPRESS_METHODDEF    \
-    {"decompress", (PyCFunction)zlib_Decompress_decompress, METH_FASTCALL, zlib_Decompress_decompress__doc__},
+    {"decompress", (PyCFunction)zlib_Decompress_decompress, METH_FASTCALL|METH_KEYWORDS, zlib_Decompress_decompress__doc__},
 
 static PyObject *
 zlib_Decompress_decompress_impl(compobject *self, Py_buffer *data,
@@ -296,14 +296,10 @@ static PyObject *
 zlib_Compress_flush_impl(compobject *self, int mode);
 
 static PyObject *
-zlib_Compress_flush(compobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+zlib_Compress_flush(compobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int mode = Z_FINISH;
-
-    if (!_PyArg_NoStackKeywords("flush", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|i:flush",
         &mode)) {
@@ -375,14 +371,10 @@ static PyObject *
 zlib_Decompress_flush_impl(compobject *self, Py_ssize_t length);
 
 static PyObject *
-zlib_Decompress_flush(compobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+zlib_Decompress_flush(compobject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t length = DEF_BUF_SIZE;
-
-    if (!_PyArg_NoStackKeywords("flush", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|O&:flush",
         ssize_t_converter, &length)) {
@@ -412,15 +404,11 @@ static PyObject *
 zlib_adler32_impl(PyObject *module, Py_buffer *data, unsigned int value);
 
 static PyObject *
-zlib_adler32(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+zlib_adler32(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int value = 1;
-
-    if (!_PyArg_NoStackKeywords("adler32", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|I:adler32",
         &data, &value)) {
@@ -455,15 +443,11 @@ static PyObject *
 zlib_crc32_impl(PyObject *module, Py_buffer *data, unsigned int value);
 
 static PyObject *
-zlib_crc32(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+zlib_crc32(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer data = {NULL, NULL};
     unsigned int value = 0;
-
-    if (!_PyArg_NoStackKeywords("crc32", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*|I:crc32",
         &data, &value)) {
@@ -483,4 +467,4 @@ exit:
 #ifndef ZLIB_COMPRESS_COPY_METHODDEF
     #define ZLIB_COMPRESS_COPY_METHODDEF
 #endif /* !defined(ZLIB_COMPRESS_COPY_METHODDEF) */
-/*[clinic end generated code: output=c7abf02e091bcad3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e0184313eb431e95 input=a9049054013a1b77]*/

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -521,9 +521,19 @@ _PyMethodDef_RawFastCallDict(PyMethodDef *method, PyObject *self, PyObject **arg
 
     case METH_FASTCALL:
     {
+        if (kwargs != NULL && PyDict_GET_SIZE(kwargs) != 0) {
+            goto no_keyword_error;
+        }
+
+        result = (*(_PyCFunctionFast)meth) (self, args, nargs);
+        break;
+    }
+
+    case METH_FASTCALL | METH_KEYWORDS:
+    {
         PyObject **stack;
         PyObject *kwnames;
-        _PyCFunctionFast fastmeth = (_PyCFunctionFast)meth;
+        _PyCFunctionFastWithKeywords fastmeth = (_PyCFunctionFastWithKeywords)meth;
 
         if (_PyStack_UnpackDict(args, nargs, kwargs, &stack, &kwnames) < 0) {
             goto exit;
@@ -631,8 +641,15 @@ _PyMethodDef_RawFastCallKeywords(PyMethodDef *method, PyObject *self, PyObject *
         break;
 
     case METH_FASTCALL:
+        if (nkwargs) {
+            goto no_keyword_error;
+        }
+        result = ((_PyCFunctionFast)meth) (self, args, nargs);
+        break;
+
+    case METH_FASTCALL | METH_KEYWORDS:
         /* Fast-path: avoid temporary dict to pass keyword arguments */
-        result = ((_PyCFunctionFast)meth) (self, args, nargs, kwnames);
+        result = ((_PyCFunctionFastWithKeywords)meth) (self, args, nargs, kwnames);
         break;
 
     case METH_VARARGS:

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -51,7 +51,7 @@ PyDoc_STRVAR(bytearray_translate__doc__,
 "The remaining characters are mapped through the given translation table.");
 
 #define BYTEARRAY_TRANSLATE_METHODDEF    \
-    {"translate", (PyCFunction)bytearray_translate, METH_FASTCALL, bytearray_translate__doc__},
+    {"translate", (PyCFunction)bytearray_translate, METH_FASTCALL|METH_KEYWORDS, bytearray_translate__doc__},
 
 static PyObject *
 bytearray_translate_impl(PyByteArrayObject *self, PyObject *table,
@@ -94,15 +94,11 @@ static PyObject *
 bytearray_maketrans_impl(Py_buffer *frm, Py_buffer *to);
 
 static PyObject *
-bytearray_maketrans(void *null, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytearray_maketrans(void *null, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer frm = {NULL, NULL};
     Py_buffer to = {NULL, NULL};
-
-    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*y*:maketrans",
         &frm, &to)) {
@@ -144,16 +140,12 @@ bytearray_replace_impl(PyByteArrayObject *self, Py_buffer *old,
                        Py_buffer *new, Py_ssize_t count);
 
 static PyObject *
-bytearray_replace(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytearray_replace(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer old = {NULL, NULL};
     Py_buffer new = {NULL, NULL};
     Py_ssize_t count = -1;
-
-    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*y*|n:replace",
         &old, &new, &count)) {
@@ -189,7 +181,7 @@ PyDoc_STRVAR(bytearray_split__doc__,
 "    -1 (the default value) means no limit.");
 
 #define BYTEARRAY_SPLIT_METHODDEF    \
-    {"split", (PyCFunction)bytearray_split, METH_FASTCALL, bytearray_split__doc__},
+    {"split", (PyCFunction)bytearray_split, METH_FASTCALL|METH_KEYWORDS, bytearray_split__doc__},
 
 static PyObject *
 bytearray_split_impl(PyByteArrayObject *self, PyObject *sep,
@@ -263,7 +255,7 @@ PyDoc_STRVAR(bytearray_rsplit__doc__,
 "Splitting is done starting at the end of the bytearray and working to the front.");
 
 #define BYTEARRAY_RSPLIT_METHODDEF    \
-    {"rsplit", (PyCFunction)bytearray_rsplit, METH_FASTCALL, bytearray_rsplit__doc__},
+    {"rsplit", (PyCFunction)bytearray_rsplit, METH_FASTCALL|METH_KEYWORDS, bytearray_rsplit__doc__},
 
 static PyObject *
 bytearray_rsplit_impl(PyByteArrayObject *self, PyObject *sep,
@@ -324,15 +316,11 @@ static PyObject *
 bytearray_insert_impl(PyByteArrayObject *self, Py_ssize_t index, int item);
 
 static PyObject *
-bytearray_insert(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytearray_insert(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t index;
     int item;
-
-    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "nO&:insert",
         &index, _getbytevalue, &item)) {
@@ -405,14 +393,10 @@ static PyObject *
 bytearray_pop_impl(PyByteArrayObject *self, Py_ssize_t index);
 
 static PyObject *
-bytearray_pop(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytearray_pop(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t index = -1;
-
-    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|n:pop",
         &index)) {
@@ -469,14 +453,10 @@ static PyObject *
 bytearray_strip_impl(PyByteArrayObject *self, PyObject *bytes);
 
 static PyObject *
-bytearray_strip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytearray_strip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
-
-    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "strip",
         0, 1,
@@ -504,14 +484,10 @@ static PyObject *
 bytearray_lstrip_impl(PyByteArrayObject *self, PyObject *bytes);
 
 static PyObject *
-bytearray_lstrip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytearray_lstrip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
-
-    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "lstrip",
         0, 1,
@@ -539,14 +515,10 @@ static PyObject *
 bytearray_rstrip_impl(PyByteArrayObject *self, PyObject *bytes);
 
 static PyObject *
-bytearray_rstrip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytearray_rstrip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
-
-    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "rstrip",
         0, 1,
@@ -575,7 +547,7 @@ PyDoc_STRVAR(bytearray_decode__doc__,
 "    can handle UnicodeDecodeErrors.");
 
 #define BYTEARRAY_DECODE_METHODDEF    \
-    {"decode", (PyCFunction)bytearray_decode, METH_FASTCALL, bytearray_decode__doc__},
+    {"decode", (PyCFunction)bytearray_decode, METH_FASTCALL|METH_KEYWORDS, bytearray_decode__doc__},
 
 static PyObject *
 bytearray_decode_impl(PyByteArrayObject *self, const char *encoding,
@@ -623,7 +595,7 @@ PyDoc_STRVAR(bytearray_splitlines__doc__,
 "true.");
 
 #define BYTEARRAY_SPLITLINES_METHODDEF    \
-    {"splitlines", (PyCFunction)bytearray_splitlines, METH_FASTCALL, bytearray_splitlines__doc__},
+    {"splitlines", (PyCFunction)bytearray_splitlines, METH_FASTCALL|METH_KEYWORDS, bytearray_splitlines__doc__},
 
 static PyObject *
 bytearray_splitlines_impl(PyByteArrayObject *self, int keepends);
@@ -707,14 +679,10 @@ static PyObject *
 bytearray_reduce_ex_impl(PyByteArrayObject *self, int proto);
 
 static PyObject *
-bytearray_reduce_ex(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytearray_reduce_ex(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int proto = 0;
-
-    if (!_PyArg_NoStackKeywords("__reduce_ex__", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|i:__reduce_ex__",
         &proto)) {
@@ -743,4 +711,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=f0079d8ee82614f7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e53f10084457a46b input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -17,7 +17,7 @@ PyDoc_STRVAR(bytes_split__doc__,
 "    -1 (the default value) means no limit.");
 
 #define BYTES_SPLIT_METHODDEF    \
-    {"split", (PyCFunction)bytes_split, METH_FASTCALL, bytes_split__doc__},
+    {"split", (PyCFunction)bytes_split, METH_FASTCALL|METH_KEYWORDS, bytes_split__doc__},
 
 static PyObject *
 bytes_split_impl(PyBytesObject *self, PyObject *sep, Py_ssize_t maxsplit);
@@ -136,7 +136,7 @@ PyDoc_STRVAR(bytes_rsplit__doc__,
 "Splitting is done starting at the end of the bytes and working to the front.");
 
 #define BYTES_RSPLIT_METHODDEF    \
-    {"rsplit", (PyCFunction)bytes_rsplit, METH_FASTCALL, bytes_rsplit__doc__},
+    {"rsplit", (PyCFunction)bytes_rsplit, METH_FASTCALL|METH_KEYWORDS, bytes_rsplit__doc__},
 
 static PyObject *
 bytes_rsplit_impl(PyBytesObject *self, PyObject *sep, Py_ssize_t maxsplit);
@@ -190,14 +190,10 @@ static PyObject *
 bytes_strip_impl(PyBytesObject *self, PyObject *bytes);
 
 static PyObject *
-bytes_strip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytes_strip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
-
-    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "strip",
         0, 1,
@@ -225,14 +221,10 @@ static PyObject *
 bytes_lstrip_impl(PyBytesObject *self, PyObject *bytes);
 
 static PyObject *
-bytes_lstrip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytes_lstrip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
-
-    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "lstrip",
         0, 1,
@@ -260,14 +252,10 @@ static PyObject *
 bytes_rstrip_impl(PyBytesObject *self, PyObject *bytes);
 
 static PyObject *
-bytes_rstrip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytes_rstrip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
-
-    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "rstrip",
         0, 1,
@@ -293,7 +281,7 @@ PyDoc_STRVAR(bytes_translate__doc__,
 "The remaining characters are mapped through the given translation table.");
 
 #define BYTES_TRANSLATE_METHODDEF    \
-    {"translate", (PyCFunction)bytes_translate, METH_FASTCALL, bytes_translate__doc__},
+    {"translate", (PyCFunction)bytes_translate, METH_FASTCALL|METH_KEYWORDS, bytes_translate__doc__},
 
 static PyObject *
 bytes_translate_impl(PyBytesObject *self, PyObject *table,
@@ -336,15 +324,11 @@ static PyObject *
 bytes_maketrans_impl(Py_buffer *frm, Py_buffer *to);
 
 static PyObject *
-bytes_maketrans(void *null, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytes_maketrans(void *null, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer frm = {NULL, NULL};
     Py_buffer to = {NULL, NULL};
-
-    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*y*:maketrans",
         &frm, &to)) {
@@ -386,16 +370,12 @@ bytes_replace_impl(PyBytesObject *self, Py_buffer *old, Py_buffer *new,
                    Py_ssize_t count);
 
 static PyObject *
-bytes_replace(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+bytes_replace(PyBytesObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_buffer old = {NULL, NULL};
     Py_buffer new = {NULL, NULL};
     Py_ssize_t count = -1;
-
-    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "y*y*|n:replace",
         &old, &new, &count)) {
@@ -432,7 +412,7 @@ PyDoc_STRVAR(bytes_decode__doc__,
 "    can handle UnicodeDecodeErrors.");
 
 #define BYTES_DECODE_METHODDEF    \
-    {"decode", (PyCFunction)bytes_decode, METH_FASTCALL, bytes_decode__doc__},
+    {"decode", (PyCFunction)bytes_decode, METH_FASTCALL|METH_KEYWORDS, bytes_decode__doc__},
 
 static PyObject *
 bytes_decode_impl(PyBytesObject *self, const char *encoding,
@@ -467,7 +447,7 @@ PyDoc_STRVAR(bytes_splitlines__doc__,
 "true.");
 
 #define BYTES_SPLITLINES_METHODDEF    \
-    {"splitlines", (PyCFunction)bytes_splitlines, METH_FASTCALL, bytes_splitlines__doc__},
+    {"splitlines", (PyCFunction)bytes_splitlines, METH_FASTCALL|METH_KEYWORDS, bytes_splitlines__doc__},
 
 static PyObject *
 bytes_splitlines_impl(PyBytesObject *self, int keepends);
@@ -519,4 +499,4 @@ bytes_fromhex(PyTypeObject *type, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a82999760469bbec input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9e3374bd7d04c163 input=a9049054013a1b77]*/

--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -15,15 +15,11 @@ static PyObject *
 dict_fromkeys_impl(PyTypeObject *type, PyObject *iterable, PyObject *value);
 
 static PyObject *
-dict_fromkeys(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+dict_fromkeys(PyTypeObject *type, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *iterable;
     PyObject *value = Py_None;
-
-    if (!_PyArg_NoStackKeywords("fromkeys", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "fromkeys",
         1, 2,
@@ -58,15 +54,11 @@ static PyObject *
 dict_get_impl(PyDictObject *self, PyObject *key, PyObject *default_value);
 
 static PyObject *
-dict_get(PyDictObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+dict_get(PyDictObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *key;
     PyObject *default_value = Py_None;
-
-    if (!_PyArg_NoStackKeywords("get", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "get",
         1, 2,
@@ -95,15 +87,11 @@ dict_setdefault_impl(PyDictObject *self, PyObject *key,
                      PyObject *default_value);
 
 static PyObject *
-dict_setdefault(PyDictObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+dict_setdefault(PyDictObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *key;
     PyObject *default_value = Py_None;
-
-    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "setdefault",
         1, 2,
@@ -115,4 +103,4 @@ dict_setdefault(PyDictObject *self, PyObject **args, Py_ssize_t nargs, PyObject 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=49e03ab4360f5be0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8d09902e60b7ab02 input=a9049054013a1b77]*/

--- a/Objects/clinic/floatobject.c.h
+++ b/Objects/clinic/floatobject.c.h
@@ -53,14 +53,10 @@ static PyObject *
 float___round___impl(PyObject *self, PyObject *o_ndigits);
 
 static PyObject *
-float___round__(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+float___round__(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *o_ndigits = NULL;
-
-    if (!_PyArg_NoStackKeywords("__round__", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "__round__",
         0, 1,
@@ -267,15 +263,11 @@ float___set_format___impl(PyTypeObject *type, const char *typestr,
                           const char *fmt);
 
 static PyObject *
-float___set_format__(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+float___set_format__(PyTypeObject *type, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     const char *typestr;
     const char *fmt;
-
-    if (!_PyArg_NoStackKeywords("__set_format__", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ss:__set_format__",
         &typestr, &fmt)) {
@@ -313,4 +305,4 @@ float___format__(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b2271e7413b36162 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=90c06ea9d72130cc input=a9049054013a1b77]*/

--- a/Objects/clinic/listobject.c.h
+++ b/Objects/clinic/listobject.c.h
@@ -15,15 +15,11 @@ static PyObject *
 list_insert_impl(PyListObject *self, Py_ssize_t index, PyObject *object);
 
 static PyObject *
-list_insert(PyListObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+list_insert(PyListObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t index;
     PyObject *object;
-
-    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "nO:insert",
         &index, &object)) {
@@ -104,14 +100,10 @@ static PyObject *
 list_pop_impl(PyListObject *self, Py_ssize_t index);
 
 static PyObject *
-list_pop(PyListObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+list_pop(PyListObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t index = -1;
-
-    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "|n:pop",
         &index)) {
@@ -130,7 +122,7 @@ PyDoc_STRVAR(list_sort__doc__,
 "Stable sort *IN PLACE*.");
 
 #define LIST_SORT_METHODDEF    \
-    {"sort", (PyCFunction)list_sort, METH_FASTCALL, list_sort__doc__},
+    {"sort", (PyCFunction)list_sort, METH_FASTCALL|METH_KEYWORDS, list_sort__doc__},
 
 static PyObject *
 list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse);
@@ -188,16 +180,12 @@ list_index_impl(PyListObject *self, PyObject *value, Py_ssize_t start,
                 Py_ssize_t stop);
 
 static PyObject *
-list_index(PyListObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+list_index(PyListObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *value;
     Py_ssize_t start = 0;
     Py_ssize_t stop = PY_SSIZE_T_MAX;
-
-    if (!_PyArg_NoStackKeywords("index", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index",
         &value, _PyEval_SliceIndexNotNone, &start, _PyEval_SliceIndexNotNone, &stop)) {
@@ -297,4 +285,4 @@ list___reversed__(PyListObject *self, PyObject *Py_UNUSED(ignored))
 {
     return list___reversed___impl(self);
 }
-/*[clinic end generated code: output=63cbe6d6320e916f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4a4f72a5e7ff5068 input=a9049054013a1b77]*/

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -139,7 +139,7 @@ PyDoc_STRVAR(int_to_bytes__doc__,
 "    is raised.");
 
 #define INT_TO_BYTES_METHODDEF    \
-    {"to_bytes", (PyCFunction)int_to_bytes, METH_FASTCALL, int_to_bytes__doc__},
+    {"to_bytes", (PyCFunction)int_to_bytes, METH_FASTCALL|METH_KEYWORDS, int_to_bytes__doc__},
 
 static PyObject *
 int_to_bytes_impl(PyObject *self, Py_ssize_t length, PyObject *byteorder,
@@ -186,7 +186,7 @@ PyDoc_STRVAR(int_from_bytes__doc__,
 "    Indicates whether two\'s complement is used to represent the integer.");
 
 #define INT_FROM_BYTES_METHODDEF    \
-    {"from_bytes", (PyCFunction)int_from_bytes, METH_FASTCALL|METH_CLASS, int_from_bytes__doc__},
+    {"from_bytes", (PyCFunction)int_from_bytes, METH_FASTCALL|METH_KEYWORDS|METH_CLASS, int_from_bytes__doc__},
 
 static PyObject *
 int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
@@ -211,4 +211,4 @@ int_from_bytes(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyObject *
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c1ce9c11929b0bab input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c9adfdc329651cc4 input=a9049054013a1b77]*/

--- a/Objects/clinic/odictobject.c.h
+++ b/Objects/clinic/odictobject.c.h
@@ -9,7 +9,7 @@ PyDoc_STRVAR(OrderedDict_fromkeys__doc__,
 "Create a new ordered dictionary with keys from iterable and values set to value.");
 
 #define ORDEREDDICT_FROMKEYS_METHODDEF    \
-    {"fromkeys", (PyCFunction)OrderedDict_fromkeys, METH_FASTCALL|METH_CLASS, OrderedDict_fromkeys__doc__},
+    {"fromkeys", (PyCFunction)OrderedDict_fromkeys, METH_FASTCALL|METH_KEYWORDS|METH_CLASS, OrderedDict_fromkeys__doc__},
 
 static PyObject *
 OrderedDict_fromkeys_impl(PyTypeObject *type, PyObject *seq, PyObject *value);
@@ -42,7 +42,7 @@ PyDoc_STRVAR(OrderedDict_setdefault__doc__,
 "Return the value for key if key is in the dictionary, else default.");
 
 #define ORDEREDDICT_SETDEFAULT_METHODDEF    \
-    {"setdefault", (PyCFunction)OrderedDict_setdefault, METH_FASTCALL, OrderedDict_setdefault__doc__},
+    {"setdefault", (PyCFunction)OrderedDict_setdefault, METH_FASTCALL|METH_KEYWORDS, OrderedDict_setdefault__doc__},
 
 static PyObject *
 OrderedDict_setdefault_impl(PyODictObject *self, PyObject *key,
@@ -76,7 +76,7 @@ PyDoc_STRVAR(OrderedDict_popitem__doc__,
 "Pairs are returned in LIFO order if last is true or FIFO order if false.");
 
 #define ORDEREDDICT_POPITEM_METHODDEF    \
-    {"popitem", (PyCFunction)OrderedDict_popitem, METH_FASTCALL, OrderedDict_popitem__doc__},
+    {"popitem", (PyCFunction)OrderedDict_popitem, METH_FASTCALL|METH_KEYWORDS, OrderedDict_popitem__doc__},
 
 static PyObject *
 OrderedDict_popitem_impl(PyODictObject *self, int last);
@@ -108,7 +108,7 @@ PyDoc_STRVAR(OrderedDict_move_to_end__doc__,
 "Raise KeyError if the element does not exist.");
 
 #define ORDEREDDICT_MOVE_TO_END_METHODDEF    \
-    {"move_to_end", (PyCFunction)OrderedDict_move_to_end, METH_FASTCALL, OrderedDict_move_to_end__doc__},
+    {"move_to_end", (PyCFunction)OrderedDict_move_to_end, METH_FASTCALL|METH_KEYWORDS, OrderedDict_move_to_end__doc__},
 
 static PyObject *
 OrderedDict_move_to_end_impl(PyODictObject *self, PyObject *key, int last);
@@ -131,4 +131,4 @@ OrderedDict_move_to_end(PyODictObject *self, PyObject **args, Py_ssize_t nargs, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=a19a24ac37b42e5e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b2f82eca6e8c8084 input=a9049054013a1b77]*/

--- a/Objects/clinic/tupleobject.c.h
+++ b/Objects/clinic/tupleobject.c.h
@@ -18,16 +18,12 @@ tuple_index_impl(PyTupleObject *self, PyObject *value, Py_ssize_t start,
                  Py_ssize_t stop);
 
 static PyObject *
-tuple_index(PyTupleObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+tuple_index(PyTupleObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *value;
     Py_ssize_t start = 0;
     Py_ssize_t stop = PY_SSIZE_T_MAX;
-
-    if (!_PyArg_NoStackKeywords("index", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index",
         &value, _PyEval_SliceIndexNotNone, &start, _PyEval_SliceIndexNotNone, &stop)) {
@@ -99,4 +95,4 @@ tuple___getnewargs__(PyTupleObject *self, PyObject *Py_UNUSED(ignored))
 {
     return tuple___getnewargs___impl(self);
 }
-/*[clinic end generated code: output=70b4de94a0002ec3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d24a9893b3a740c6 input=a9049054013a1b77]*/

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -77,15 +77,11 @@ static PyObject *
 unicode_center_impl(PyObject *self, Py_ssize_t width, Py_UCS4 fillchar);
 
 static PyObject *
-unicode_center(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicode_center(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t width;
     Py_UCS4 fillchar = ' ';
-
-    if (!_PyArg_NoStackKeywords("center", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "n|O&:center",
         &width, convert_uc, &fillchar)) {
@@ -113,7 +109,7 @@ PyDoc_STRVAR(unicode_encode__doc__,
 "    codecs.register_error that can handle UnicodeEncodeErrors.");
 
 #define UNICODE_ENCODE_METHODDEF    \
-    {"encode", (PyCFunction)unicode_encode, METH_FASTCALL, unicode_encode__doc__},
+    {"encode", (PyCFunction)unicode_encode, METH_FASTCALL|METH_KEYWORDS, unicode_encode__doc__},
 
 static PyObject *
 unicode_encode_impl(PyObject *self, const char *encoding, const char *errors);
@@ -146,7 +142,7 @@ PyDoc_STRVAR(unicode_expandtabs__doc__,
 "If tabsize is not given, a tab size of 8 characters is assumed.");
 
 #define UNICODE_EXPANDTABS_METHODDEF    \
-    {"expandtabs", (PyCFunction)unicode_expandtabs, METH_FASTCALL, unicode_expandtabs__doc__},
+    {"expandtabs", (PyCFunction)unicode_expandtabs, METH_FASTCALL|METH_KEYWORDS, unicode_expandtabs__doc__},
 
 static PyObject *
 unicode_expandtabs_impl(PyObject *self, int tabsize);
@@ -429,15 +425,11 @@ static PyObject *
 unicode_ljust_impl(PyObject *self, Py_ssize_t width, Py_UCS4 fillchar);
 
 static PyObject *
-unicode_ljust(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicode_ljust(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t width;
     Py_UCS4 fillchar = ' ';
-
-    if (!_PyArg_NoStackKeywords("ljust", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "n|O&:ljust",
         &width, convert_uc, &fillchar)) {
@@ -482,14 +474,10 @@ static PyObject *
 unicode_strip_impl(PyObject *self, PyObject *chars);
 
 static PyObject *
-unicode_strip(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicode_strip(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *chars = Py_None;
-
-    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "strip",
         0, 1,
@@ -517,14 +505,10 @@ static PyObject *
 unicode_lstrip_impl(PyObject *self, PyObject *chars);
 
 static PyObject *
-unicode_lstrip(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicode_lstrip(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *chars = NULL;
-
-    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "lstrip",
         0, 1,
@@ -552,14 +536,10 @@ static PyObject *
 unicode_rstrip_impl(PyObject *self, PyObject *chars);
 
 static PyObject *
-unicode_rstrip(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicode_rstrip(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *chars = NULL;
-
-    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "rstrip",
         0, 1,
@@ -593,16 +573,12 @@ unicode_replace_impl(PyObject *self, PyObject *old, PyObject *new,
                      Py_ssize_t count);
 
 static PyObject *
-unicode_replace(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicode_replace(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *old;
     PyObject *new;
     Py_ssize_t count = -1;
-
-    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "UU|n:replace",
         &old, &new, &count)) {
@@ -629,15 +605,11 @@ static PyObject *
 unicode_rjust_impl(PyObject *self, Py_ssize_t width, Py_UCS4 fillchar);
 
 static PyObject *
-unicode_rjust(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicode_rjust(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_ssize_t width;
     Py_UCS4 fillchar = ' ';
-
-    if (!_PyArg_NoStackKeywords("rjust", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "n|O&:rjust",
         &width, convert_uc, &fillchar)) {
@@ -664,7 +636,7 @@ PyDoc_STRVAR(unicode_split__doc__,
 "    -1 (the default value) means no limit.");
 
 #define UNICODE_SPLIT_METHODDEF    \
-    {"split", (PyCFunction)unicode_split, METH_FASTCALL, unicode_split__doc__},
+    {"split", (PyCFunction)unicode_split, METH_FASTCALL|METH_KEYWORDS, unicode_split__doc__},
 
 static PyObject *
 unicode_split_impl(PyObject *self, PyObject *sep, Py_ssize_t maxsplit);
@@ -737,7 +709,7 @@ PyDoc_STRVAR(unicode_rsplit__doc__,
 "Splits are done starting at the end of the string and working to the front.");
 
 #define UNICODE_RSPLIT_METHODDEF    \
-    {"rsplit", (PyCFunction)unicode_rsplit, METH_FASTCALL, unicode_rsplit__doc__},
+    {"rsplit", (PyCFunction)unicode_rsplit, METH_FASTCALL|METH_KEYWORDS, unicode_rsplit__doc__},
 
 static PyObject *
 unicode_rsplit_impl(PyObject *self, PyObject *sep, Py_ssize_t maxsplit);
@@ -771,7 +743,7 @@ PyDoc_STRVAR(unicode_splitlines__doc__,
 "true.");
 
 #define UNICODE_SPLITLINES_METHODDEF    \
-    {"splitlines", (PyCFunction)unicode_splitlines, METH_FASTCALL, unicode_splitlines__doc__},
+    {"splitlines", (PyCFunction)unicode_splitlines, METH_FASTCALL|METH_KEYWORDS, unicode_splitlines__doc__},
 
 static PyObject *
 unicode_splitlines_impl(PyObject *self, int keepends);
@@ -833,16 +805,12 @@ static PyObject *
 unicode_maketrans_impl(PyObject *x, PyObject *y, PyObject *z);
 
 static PyObject *
-unicode_maketrans(void *null, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+unicode_maketrans(void *null, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *x;
     PyObject *y = NULL;
     PyObject *z = NULL;
-
-    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|UU:maketrans",
         &x, &y, &z)) {
@@ -962,4 +930,4 @@ unicode_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return unicode_sizeof_impl(self);
 }
-/*[clinic end generated code: output=339a83c0c100dd17 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8fd799fd7f2cc724 input=a9049054013a1b77]*/

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2341,8 +2341,8 @@ dict_update_common(PyObject *self, PyObject *args, PyObject *kwds,
 }
 
 /* Note: dict.update() uses the METH_VARARGS|METH_KEYWORDS calling convention.
-   Using METH_FASTCALL would make dict.update(**dict2) calls slower, see the
-   issue #29312. */
+   Using METH_FASTCALL|METH_KEYWORDS would make dict.update(**dict2) calls
+   slower, see the issue #29312. */
 static PyObject *
 dict_update(PyObject *self, PyObject *args, PyObject *kwds)
 {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3340,7 +3340,7 @@ static PyMethodDef type_methods[] = {
     TYPE_MRO_METHODDEF
     TYPE___SUBCLASSES___METHODDEF
     {"__prepare__", (PyCFunction)type_prepare,
-     METH_FASTCALL | METH_CLASS,
+     METH_FASTCALL | METH_KEYWORDS | METH_CLASS,
      PyDoc_STR("__prepare__() -> dict\n"
                "used to create the namespace for the class statement")},
     TYPE___INSTANCECHECK___METHODDEF

--- a/PC/clinic/_testconsole.c.h
+++ b/PC/clinic/_testconsole.c.h
@@ -11,7 +11,7 @@ PyDoc_STRVAR(_testconsole_write_input__doc__,
 "Writes UTF-16-LE encoded bytes to the console as if typed by a user.");
 
 #define _TESTCONSOLE_WRITE_INPUT_METHODDEF    \
-    {"write_input", (PyCFunction)_testconsole_write_input, METH_FASTCALL, _testconsole_write_input__doc__},
+    {"write_input", (PyCFunction)_testconsole_write_input, METH_FASTCALL|METH_KEYWORDS, _testconsole_write_input__doc__},
 
 static PyObject *
 _testconsole_write_input_impl(PyObject *module, PyObject *file,
@@ -47,7 +47,7 @@ PyDoc_STRVAR(_testconsole_read_output__doc__,
 "Reads a str from the console as written to stdout.");
 
 #define _TESTCONSOLE_READ_OUTPUT_METHODDEF    \
-    {"read_output", (PyCFunction)_testconsole_read_output, METH_FASTCALL, _testconsole_read_output__doc__},
+    {"read_output", (PyCFunction)_testconsole_read_output, METH_FASTCALL|METH_KEYWORDS, _testconsole_read_output__doc__},
 
 static PyObject *
 _testconsole_read_output_impl(PyObject *module, PyObject *file);
@@ -79,4 +79,4 @@ exit:
 #ifndef _TESTCONSOLE_READ_OUTPUT_METHODDEF
     #define _TESTCONSOLE_READ_OUTPUT_METHODDEF
 #endif /* !defined(_TESTCONSOLE_READ_OUTPUT_METHODDEF) */
-/*[clinic end generated code: output=30d2a80143b65e6f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ac80ed19e6edc0af input=a9049054013a1b77]*/

--- a/PC/clinic/msvcrtmodule.c.h
+++ b/PC/clinic/msvcrtmodule.c.h
@@ -43,16 +43,12 @@ static PyObject *
 msvcrt_locking_impl(PyObject *module, int fd, int mode, long nbytes);
 
 static PyObject *
-msvcrt_locking(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+msvcrt_locking(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     int mode;
     long nbytes;
-
-    if (!_PyArg_NoStackKeywords("locking", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "iil:locking",
         &fd, &mode, &nbytes)) {
@@ -82,16 +78,12 @@ static long
 msvcrt_setmode_impl(PyObject *module, int fd, int flags);
 
 static PyObject *
-msvcrt_setmode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+msvcrt_setmode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int fd;
     int flags;
     long _return_value;
-
-    if (!_PyArg_NoStackKeywords("setmode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ii:setmode",
         &fd, &flags)) {
@@ -124,16 +116,12 @@ static long
 msvcrt_open_osfhandle_impl(PyObject *module, intptr_t handle, int flags);
 
 static PyObject *
-msvcrt_open_osfhandle(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+msvcrt_open_osfhandle(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     intptr_t handle;
     int flags;
     long _return_value;
-
-    if (!_PyArg_NoStackKeywords("open_osfhandle", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, ""_Py_PARSE_INTPTR"i:open_osfhandle",
         &handle, &flags)) {
@@ -442,16 +430,12 @@ static long
 msvcrt_CrtSetReportFile_impl(PyObject *module, int type, int file);
 
 static PyObject *
-msvcrt_CrtSetReportFile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+msvcrt_CrtSetReportFile(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int type;
     int file;
     long _return_value;
-
-    if (!_PyArg_NoStackKeywords("CrtSetReportFile", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ii:CrtSetReportFile",
         &type, &file)) {
@@ -486,16 +470,12 @@ static long
 msvcrt_CrtSetReportMode_impl(PyObject *module, int type, int mode);
 
 static PyObject *
-msvcrt_CrtSetReportMode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+msvcrt_CrtSetReportMode(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int type;
     int mode;
     long _return_value;
-
-    if (!_PyArg_NoStackKeywords("CrtSetReportMode", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ii:CrtSetReportMode",
         &type, &mode)) {
@@ -589,4 +569,4 @@ exit:
 #ifndef MSVCRT_SET_ERROR_MODE_METHODDEF
     #define MSVCRT_SET_ERROR_MODE_METHODDEF
 #endif /* !defined(MSVCRT_SET_ERROR_MODE_METHODDEF) */
-/*[clinic end generated code: output=9e82abfdd357b0da input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8e9e57c48c4defcc input=a9049054013a1b77]*/

--- a/PC/clinic/winreg.c.h
+++ b/PC/clinic/winreg.c.h
@@ -77,7 +77,7 @@ PyDoc_STRVAR(winreg_HKEYType___exit____doc__,
 "\n");
 
 #define WINREG_HKEYTYPE___EXIT___METHODDEF    \
-    {"__exit__", (PyCFunction)winreg_HKEYType___exit__, METH_FASTCALL, winreg_HKEYType___exit____doc__},
+    {"__exit__", (PyCFunction)winreg_HKEYType___exit__, METH_FASTCALL|METH_KEYWORDS, winreg_HKEYType___exit____doc__},
 
 static PyObject *
 winreg_HKEYType___exit___impl(PyHKEYObject *self, PyObject *exc_type,
@@ -141,16 +141,12 @@ winreg_ConnectRegistry_impl(PyObject *module, Py_UNICODE *computer_name,
                             HKEY key);
 
 static PyObject *
-winreg_ConnectRegistry(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_ConnectRegistry(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     Py_UNICODE *computer_name;
     HKEY key;
     HKEY _return_value;
-
-    if (!_PyArg_NoStackKeywords("ConnectRegistry", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "ZO&:ConnectRegistry",
         &computer_name, clinic_HKEY_converter, &key)) {
@@ -192,16 +188,12 @@ static HKEY
 winreg_CreateKey_impl(PyObject *module, HKEY key, Py_UNICODE *sub_key);
 
 static PyObject *
-winreg_CreateKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_CreateKey(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
     Py_UNICODE *sub_key;
     HKEY _return_value;
-
-    if (!_PyArg_NoStackKeywords("CreateKey", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&Z:CreateKey",
         clinic_HKEY_converter, &key, &sub_key)) {
@@ -243,7 +235,7 @@ PyDoc_STRVAR(winreg_CreateKeyEx__doc__,
 "If the function fails, an OSError exception is raised.");
 
 #define WINREG_CREATEKEYEX_METHODDEF    \
-    {"CreateKeyEx", (PyCFunction)winreg_CreateKeyEx, METH_FASTCALL, winreg_CreateKeyEx__doc__},
+    {"CreateKeyEx", (PyCFunction)winreg_CreateKeyEx, METH_FASTCALL|METH_KEYWORDS, winreg_CreateKeyEx__doc__},
 
 static HKEY
 winreg_CreateKeyEx_impl(PyObject *module, HKEY key, Py_UNICODE *sub_key,
@@ -300,15 +292,11 @@ static PyObject *
 winreg_DeleteKey_impl(PyObject *module, HKEY key, Py_UNICODE *sub_key);
 
 static PyObject *
-winreg_DeleteKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_DeleteKey(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
     Py_UNICODE *sub_key;
-
-    if (!_PyArg_NoStackKeywords("DeleteKey", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&u:DeleteKey",
         clinic_HKEY_converter, &key, &sub_key)) {
@@ -346,7 +334,7 @@ PyDoc_STRVAR(winreg_DeleteKeyEx__doc__,
 "On unsupported Windows versions, NotImplementedError is raised.");
 
 #define WINREG_DELETEKEYEX_METHODDEF    \
-    {"DeleteKeyEx", (PyCFunction)winreg_DeleteKeyEx, METH_FASTCALL, winreg_DeleteKeyEx__doc__},
+    {"DeleteKeyEx", (PyCFunction)winreg_DeleteKeyEx, METH_FASTCALL|METH_KEYWORDS, winreg_DeleteKeyEx__doc__},
 
 static PyObject *
 winreg_DeleteKeyEx_impl(PyObject *module, HKEY key, Py_UNICODE *sub_key,
@@ -391,15 +379,11 @@ static PyObject *
 winreg_DeleteValue_impl(PyObject *module, HKEY key, Py_UNICODE *value);
 
 static PyObject *
-winreg_DeleteValue(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_DeleteValue(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
     Py_UNICODE *value;
-
-    if (!_PyArg_NoStackKeywords("DeleteValue", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&Z:DeleteValue",
         clinic_HKEY_converter, &key, &value)) {
@@ -433,15 +417,11 @@ static PyObject *
 winreg_EnumKey_impl(PyObject *module, HKEY key, int index);
 
 static PyObject *
-winreg_EnumKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_EnumKey(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
     int index;
-
-    if (!_PyArg_NoStackKeywords("EnumKey", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&i:EnumKey",
         clinic_HKEY_converter, &key, &index)) {
@@ -484,15 +464,11 @@ static PyObject *
 winreg_EnumValue_impl(PyObject *module, HKEY key, int index);
 
 static PyObject *
-winreg_EnumValue(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_EnumValue(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
     int index;
-
-    if (!_PyArg_NoStackKeywords("EnumValue", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&i:EnumValue",
         clinic_HKEY_converter, &key, &index)) {
@@ -607,16 +583,12 @@ winreg_LoadKey_impl(PyObject *module, HKEY key, Py_UNICODE *sub_key,
                     Py_UNICODE *file_name);
 
 static PyObject *
-winreg_LoadKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_LoadKey(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
     Py_UNICODE *sub_key;
     Py_UNICODE *file_name;
-
-    if (!_PyArg_NoStackKeywords("LoadKey", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&uu:LoadKey",
         clinic_HKEY_converter, &key, &sub_key, &file_name)) {
@@ -648,7 +620,7 @@ PyDoc_STRVAR(winreg_OpenKey__doc__,
 "If the function fails, an OSError exception is raised.");
 
 #define WINREG_OPENKEY_METHODDEF    \
-    {"OpenKey", (PyCFunction)winreg_OpenKey, METH_FASTCALL, winreg_OpenKey__doc__},
+    {"OpenKey", (PyCFunction)winreg_OpenKey, METH_FASTCALL|METH_KEYWORDS, winreg_OpenKey__doc__},
 
 static HKEY
 winreg_OpenKey_impl(PyObject *module, HKEY key, Py_UNICODE *sub_key,
@@ -700,7 +672,7 @@ PyDoc_STRVAR(winreg_OpenKeyEx__doc__,
 "If the function fails, an OSError exception is raised.");
 
 #define WINREG_OPENKEYEX_METHODDEF    \
-    {"OpenKeyEx", (PyCFunction)winreg_OpenKeyEx, METH_FASTCALL, winreg_OpenKeyEx__doc__},
+    {"OpenKeyEx", (PyCFunction)winreg_OpenKeyEx, METH_FASTCALL|METH_KEYWORDS, winreg_OpenKeyEx__doc__},
 
 static HKEY
 winreg_OpenKeyEx_impl(PyObject *module, HKEY key, Py_UNICODE *sub_key,
@@ -795,15 +767,11 @@ static PyObject *
 winreg_QueryValue_impl(PyObject *module, HKEY key, Py_UNICODE *sub_key);
 
 static PyObject *
-winreg_QueryValue(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_QueryValue(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
     Py_UNICODE *sub_key;
-
-    if (!_PyArg_NoStackKeywords("QueryValue", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&Z:QueryValue",
         clinic_HKEY_converter, &key, &sub_key)) {
@@ -838,15 +806,11 @@ static PyObject *
 winreg_QueryValueEx_impl(PyObject *module, HKEY key, Py_UNICODE *name);
 
 static PyObject *
-winreg_QueryValueEx(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_QueryValueEx(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
     Py_UNICODE *name;
-
-    if (!_PyArg_NoStackKeywords("QueryValueEx", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&Z:QueryValueEx",
         clinic_HKEY_converter, &key, &name)) {
@@ -886,15 +850,11 @@ static PyObject *
 winreg_SaveKey_impl(PyObject *module, HKEY key, Py_UNICODE *file_name);
 
 static PyObject *
-winreg_SaveKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_SaveKey(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
     Py_UNICODE *file_name;
-
-    if (!_PyArg_NoStackKeywords("SaveKey", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&u:SaveKey",
         clinic_HKEY_converter, &key, &file_name)) {
@@ -941,7 +901,7 @@ winreg_SetValue_impl(PyObject *module, HKEY key, Py_UNICODE *sub_key,
                      Py_ssize_clean_t value_length);
 
 static PyObject *
-winreg_SetValue(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_SetValue(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
@@ -949,10 +909,6 @@ winreg_SetValue(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     DWORD type;
     Py_UNICODE *value;
     Py_ssize_clean_t value_length;
-
-    if (!_PyArg_NoStackKeywords("SetValue", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&Zku#:SetValue",
         clinic_HKEY_converter, &key, &sub_key, &type, &value, &value_length)) {
@@ -1015,7 +971,7 @@ winreg_SetValueEx_impl(PyObject *module, HKEY key, Py_UNICODE *value_name,
                        PyObject *reserved, DWORD type, PyObject *value);
 
 static PyObject *
-winreg_SetValueEx(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+winreg_SetValueEx(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     HKEY key;
@@ -1023,10 +979,6 @@ winreg_SetValueEx(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *reserved;
     DWORD type;
     PyObject *value;
-
-    if (!_PyArg_NoStackKeywords("SetValueEx", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O&ZOkO:SetValueEx",
         clinic_HKEY_converter, &key, &value_name, &reserved, &type, &value)) {
@@ -1139,4 +1091,4 @@ winreg_QueryReflectionKey(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=57f166c252c5ba7a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9f7991a8580bbd93 input=a9049054013a1b77]*/

--- a/PC/clinic/winsound.c.h
+++ b/PC/clinic/winsound.c.h
@@ -14,7 +14,7 @@ PyDoc_STRVAR(winsound_PlaySound__doc__,
 "    Flag values, ored together.  See module documentation.");
 
 #define WINSOUND_PLAYSOUND_METHODDEF    \
-    {"PlaySound", (PyCFunction)winsound_PlaySound, METH_FASTCALL, winsound_PlaySound__doc__},
+    {"PlaySound", (PyCFunction)winsound_PlaySound, METH_FASTCALL|METH_KEYWORDS, winsound_PlaySound__doc__},
 
 static PyObject *
 winsound_PlaySound_impl(PyObject *module, PyObject *sound, int flags);
@@ -51,7 +51,7 @@ PyDoc_STRVAR(winsound_Beep__doc__,
 "    How long the sound should play, in milliseconds.");
 
 #define WINSOUND_BEEP_METHODDEF    \
-    {"Beep", (PyCFunction)winsound_Beep, METH_FASTCALL, winsound_Beep__doc__},
+    {"Beep", (PyCFunction)winsound_Beep, METH_FASTCALL|METH_KEYWORDS, winsound_Beep__doc__},
 
 static PyObject *
 winsound_Beep_impl(PyObject *module, int frequency, int duration);
@@ -84,7 +84,7 @@ PyDoc_STRVAR(winsound_MessageBeep__doc__,
 "x defaults to MB_OK.");
 
 #define WINSOUND_MESSAGEBEEP_METHODDEF    \
-    {"MessageBeep", (PyCFunction)winsound_MessageBeep, METH_FASTCALL, winsound_MessageBeep__doc__},
+    {"MessageBeep", (PyCFunction)winsound_MessageBeep, METH_FASTCALL|METH_KEYWORDS, winsound_MessageBeep__doc__},
 
 static PyObject *
 winsound_MessageBeep_impl(PyObject *module, int type);
@@ -106,4 +106,4 @@ winsound_MessageBeep(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=102a556c665a277d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d22e41446929d3ef input=a9049054013a1b77]*/

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -991,15 +991,10 @@ builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
 
 /* AC: cannot convert yet, as needs PEP 457 group support in inspect */
 static PyObject *
-builtin_getattr(PyObject *self, PyObject **args, Py_ssize_t nargs,
-                PyObject *kwnames)
+builtin_getattr(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *v, *result, *dflt = NULL;
     PyObject *name;
-
-    if (!_PyArg_NoStackKeywords("getattr", kwnames)) {
-        return NULL;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "getattr", 2, 3, &v, &name, &dflt))
         return NULL;
@@ -1301,15 +1296,10 @@ PyTypeObject PyMap_Type = {
 
 /* AC: cannot convert yet, as needs PEP 457 group support in inspect */
 static PyObject *
-builtin_next(PyObject *self, PyObject **args, Py_ssize_t nargs,
-             PyObject *kwnames)
+builtin_next(PyObject *self, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *it, *res;
     PyObject *def = NULL;
-
-    if (!_PyArg_NoStackKeywords("next", kwnames)) {
-        return NULL;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "next", 1, 2, &it, &def))
         return NULL;
@@ -2130,7 +2120,7 @@ PyDoc_STRVAR(builtin_sorted__doc__,
 "reverse flag can be set to request the result in descending order.");
 
 #define BUILTIN_SORTED_METHODDEF    \
-    {"sorted", (PyCFunction)builtin_sorted, METH_FASTCALL, builtin_sorted__doc__},
+    {"sorted", (PyCFunction)builtin_sorted, METH_FASTCALL | METH_KEYWORDS, builtin_sorted__doc__},
 
 static PyObject *
 builtin_sorted(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
@@ -2622,7 +2612,7 @@ PyTypeObject PyZip_Type = {
 
 static PyMethodDef builtin_methods[] = {
     {"__build_class__", (PyCFunction)builtin___build_class__,
-     METH_FASTCALL, build_class_doc},
+     METH_FASTCALL | METH_KEYWORDS, build_class_doc},
     {"__import__",      (PyCFunction)builtin___import__, METH_VARARGS | METH_KEYWORDS, import_doc},
     BUILTIN_ABS_METHODDEF
     BUILTIN_ALL_METHODDEF
@@ -2656,7 +2646,7 @@ static PyMethodDef builtin_methods[] = {
     BUILTIN_OCT_METHODDEF
     BUILTIN_ORD_METHODDEF
     BUILTIN_POW_METHODDEF
-    {"print",           (PyCFunction)builtin_print,      METH_FASTCALL, print_doc},
+    {"print",           (PyCFunction)builtin_print,      METH_FASTCALL | METH_KEYWORDS, print_doc},
     BUILTIN_REPR_METHODDEF
     {"round",           (PyCFunction)builtin_round,      METH_VARARGS | METH_KEYWORDS, round_doc},
     BUILTIN_SETATTR_METHODDEF

--- a/Python/clinic/_warnings.c.h
+++ b/Python/clinic/_warnings.c.h
@@ -9,7 +9,7 @@ PyDoc_STRVAR(warnings_warn__doc__,
 "Issue a warning, or maybe ignore it or raise an exception.");
 
 #define WARNINGS_WARN_METHODDEF    \
-    {"warn", (PyCFunction)warnings_warn, METH_FASTCALL, warnings_warn__doc__},
+    {"warn", (PyCFunction)warnings_warn, METH_FASTCALL|METH_KEYWORDS, warnings_warn__doc__},
 
 static PyObject *
 warnings_warn_impl(PyObject *module, PyObject *message, PyObject *category,
@@ -35,4 +35,4 @@ warnings_warn(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=acadf1788059034c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=74b1a7d1ee41816d input=a9049054013a1b77]*/

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -88,15 +88,11 @@ static PyObject *
 builtin_format_impl(PyObject *module, PyObject *value, PyObject *format_spec);
 
 static PyObject *
-builtin_format(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_format(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *value;
     PyObject *format_spec = NULL;
-
-    if (!_PyArg_NoStackKeywords("format", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|U:format",
         &value, &format_spec)) {
@@ -154,7 +150,7 @@ PyDoc_STRVAR(builtin_compile__doc__,
 "in addition to any features explicitly specified.");
 
 #define BUILTIN_COMPILE_METHODDEF    \
-    {"compile", (PyCFunction)builtin_compile, METH_FASTCALL, builtin_compile__doc__},
+    {"compile", (PyCFunction)builtin_compile, METH_FASTCALL|METH_KEYWORDS, builtin_compile__doc__},
 
 static PyObject *
 builtin_compile_impl(PyObject *module, PyObject *source, PyObject *filename,
@@ -197,15 +193,11 @@ static PyObject *
 builtin_divmod_impl(PyObject *module, PyObject *x, PyObject *y);
 
 static PyObject *
-builtin_divmod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_divmod(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *x;
     PyObject *y;
-
-    if (!_PyArg_NoStackKeywords("divmod", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "divmod",
         2, 2,
@@ -238,16 +230,12 @@ builtin_eval_impl(PyObject *module, PyObject *source, PyObject *globals,
                   PyObject *locals);
 
 static PyObject *
-builtin_eval(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_eval(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *source;
     PyObject *globals = Py_None;
     PyObject *locals = Py_None;
-
-    if (!_PyArg_NoStackKeywords("eval", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "eval",
         1, 3,
@@ -280,16 +268,12 @@ builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
                   PyObject *locals);
 
 static PyObject *
-builtin_exec(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_exec(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *source;
     PyObject *globals = Py_None;
     PyObject *locals = Py_None;
-
-    if (!_PyArg_NoStackKeywords("exec", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "exec",
         1, 3,
@@ -338,15 +322,11 @@ static PyObject *
 builtin_hasattr_impl(PyObject *module, PyObject *obj, PyObject *name);
 
 static PyObject *
-builtin_hasattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_hasattr(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     PyObject *name;
-
-    if (!_PyArg_NoStackKeywords("hasattr", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "hasattr",
         2, 2,
@@ -387,16 +367,12 @@ builtin_setattr_impl(PyObject *module, PyObject *obj, PyObject *name,
                      PyObject *value);
 
 static PyObject *
-builtin_setattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_setattr(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     PyObject *name;
     PyObject *value;
-
-    if (!_PyArg_NoStackKeywords("setattr", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "setattr",
         3, 3,
@@ -424,15 +400,11 @@ static PyObject *
 builtin_delattr_impl(PyObject *module, PyObject *obj, PyObject *name);
 
 static PyObject *
-builtin_delattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_delattr(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     PyObject *name;
-
-    if (!_PyArg_NoStackKeywords("delattr", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "delattr",
         2, 2,
@@ -537,16 +509,12 @@ static PyObject *
 builtin_pow_impl(PyObject *module, PyObject *x, PyObject *y, PyObject *z);
 
 static PyObject *
-builtin_pow(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_pow(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *x;
     PyObject *y;
     PyObject *z = Py_None;
-
-    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "pow",
         2, 3,
@@ -578,14 +546,10 @@ static PyObject *
 builtin_input_impl(PyObject *module, PyObject *prompt);
 
 static PyObject *
-builtin_input(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_input(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *prompt = NULL;
-
-    if (!_PyArg_NoStackKeywords("input", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "input",
         0, 1,
@@ -626,15 +590,11 @@ static PyObject *
 builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start);
 
 static PyObject *
-builtin_sum(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_sum(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *iterable;
     PyObject *start = NULL;
-
-    if (!_PyArg_NoStackKeywords("sum", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "sum",
         1, 2,
@@ -665,15 +625,11 @@ builtin_isinstance_impl(PyObject *module, PyObject *obj,
                         PyObject *class_or_tuple);
 
 static PyObject *
-builtin_isinstance(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_isinstance(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *obj;
     PyObject *class_or_tuple;
-
-    if (!_PyArg_NoStackKeywords("isinstance", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "isinstance",
         2, 2,
@@ -704,15 +660,11 @@ builtin_issubclass_impl(PyObject *module, PyObject *cls,
                         PyObject *class_or_tuple);
 
 static PyObject *
-builtin_issubclass(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+builtin_issubclass(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *cls;
     PyObject *class_or_tuple;
-
-    if (!_PyArg_NoStackKeywords("issubclass", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "issubclass",
         2, 2,
@@ -724,4 +676,4 @@ builtin_issubclass(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e1a7417a7b33eeec input=a9049054013a1b77]*/
+/*[clinic end generated code: output=09752daa8cdd6ec7 input=a9049054013a1b77]*/

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -82,15 +82,11 @@ _imp__fix_co_filename_impl(PyObject *module, PyCodeObject *code,
                            PyObject *path);
 
 static PyObject *
-_imp__fix_co_filename(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_imp__fix_co_filename(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyCodeObject *code;
     PyObject *path;
-
-    if (!_PyArg_NoStackKeywords("_fix_co_filename", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O!U:_fix_co_filename",
         &PyCode_Type, &code, &path)) {
@@ -279,15 +275,11 @@ static PyObject *
 _imp_create_dynamic_impl(PyObject *module, PyObject *spec, PyObject *file);
 
 static PyObject *
-_imp_create_dynamic(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+_imp_create_dynamic(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *spec;
     PyObject *file = NULL;
-
-    if (!_PyArg_NoStackKeywords("create_dynamic", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_UnpackStack(args, nargs, "create_dynamic",
         1, 2,
@@ -369,4 +361,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=b970357dbbe25ee4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d068dd493e513604 input=a9049054013a1b77]*/

--- a/Python/clinic/marshal.c.h
+++ b/Python/clinic/marshal.c.h
@@ -27,16 +27,12 @@ marshal_dump_impl(PyObject *module, PyObject *value, PyObject *file,
                   int version);
 
 static PyObject *
-marshal_dump(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+marshal_dump(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *value;
     PyObject *file;
     int version = Py_MARSHAL_VERSION;
-
-    if (!_PyArg_NoStackKeywords("dump", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "OO|i:dump",
         &value, &file, &version)) {
@@ -88,15 +84,11 @@ static PyObject *
 marshal_dumps_impl(PyObject *module, PyObject *value, int version);
 
 static PyObject *
-marshal_dumps(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
+marshal_dumps(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *value;
     int version = Py_MARSHAL_VERSION;
-
-    if (!_PyArg_NoStackKeywords("dumps", kwnames)) {
-        goto exit;
-    }
 
     if (!_PyArg_ParseStack(args, nargs, "O|i:dumps",
         &value, &version)) {
@@ -142,4 +134,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=7b147a648614af7e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=15e284a34abfd26a input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -710,6 +710,11 @@ class CLanguage(Language):
 
         parser_prototype_fastcall = normalize_snippet("""
             static PyObject *
+            {c_basename}({self_type}{self_name}, PyObject **args, Py_ssize_t nargs)
+            """)
+
+        parser_prototype_fastcall_keywords = normalize_snippet("""
+            static PyObject *
             {c_basename}({self_type}{self_name}, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
             """)
 
@@ -828,10 +833,6 @@ class CLanguage(Language):
                 parser_prototype = parser_prototype_fastcall
 
                 parser_definition = parser_body(parser_prototype, normalize_snippet("""
-                    if ({self_type_check}!_PyArg_NoStackKeywords("{name}", kwnames)) {{
-                        goto exit;
-                    }}
-
                     if (!_PyArg_UnpackStack(args, nargs, "{name}",
                         {unpack_min}, {unpack_max},
                         {parse_arguments})) {{
@@ -859,10 +860,6 @@ class CLanguage(Language):
                 parser_prototype = parser_prototype_fastcall
 
                 parser_definition = parser_body(parser_prototype, normalize_snippet("""
-                    if ({self_type_check}!_PyArg_NoStackKeywords("{name}", kwnames)) {{
-                        goto exit;
-                    }}
-
                     if (!_PyArg_ParseStack(args, nargs, "{format_units}:{name}",
                         {parse_arguments})) {{
                         goto exit;
@@ -883,9 +880,9 @@ class CLanguage(Language):
                     """, indent=4))
 
         elif not new_or_init:
-            flags = "METH_FASTCALL"
+            flags = "METH_FASTCALL|METH_KEYWORDS"
 
-            parser_prototype = parser_prototype_fastcall
+            parser_prototype = parser_prototype_fastcall_keywords
 
             body = normalize_snippet("""
                 if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,


### PR DESCRIPTION
the bare METH_FASTCALL be used for functions with positional-only
parameters.