### PR TITLE
[3.6] bpo-30417: Disable 'cpu' and 'tzdata' resources on Travis (GH-1928)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
       env: OPTIONAL=true
       before_script:
         - |
-            if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.(rst|yml)$)|(^Doc)/'
+            if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.rst$)|(^Doc)|(^Misc)'
             then
               echo "Only docs were updated, stopping build process."
               exit
@@ -57,16 +57,16 @@ matrix:
             ./venv/bin/python -m pip install -U coverage
       script:
         # Skip tests that re-run the entire test suite.
-        - ./venv/bin/python -m coverage run --pylib -m test -uall -x test_multiprocessing_fork -x test_multiprocessing_forkserver -x test_multiprocessing_spawn
+        - ./venv/bin/python -m coverage run --pylib -m test -uall,-cpu,-tzdata -x test_multiprocessing_fork -x test_multiprocessing_forkserver -x test_multiprocessing_spawn
       after_script:  # Probably should be after_success once test suite updated to run under coverage.py.
         # Make the `coverage` command available to Codecov w/ a version of Python that can parse all source files.
         - source ./venv/bin/activate
         - bash <(curl -s https://codecov.io/bash)
 
-# Travis provides only 2 cores, so don't overdue the parallelism and waste memory.
+# Travis provides only 2 cores, so don't overdo the parallelism and waste memory.
 before_script:
   - |
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.(rst|yml)$)|(^Doc)/'
+      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.rst$)|(^Doc)|(^Misc)'
       then
         echo "Only docs were updated, stopping build process."
         exit
@@ -76,7 +76,7 @@ before_script:
 
 script:
   # `-r -w` implicitly provided through `make buildbottest`.
-  - make buildbottest TESTOPTS="-j4"
+  - make buildbottest TESTOPTS="-j4 -uall,-cpu,-tzdata"
 
 notifications:
   email: false


### PR DESCRIPTION
Also weakens the 'should this be run?' regex to allow all builds when .travis.yml changes.
(cherry picked from commit c53b13b270767948fddb58b287149c499f9a03c4)