### PR TITLE
bpo-30583: s/datetuil/dateutil

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1853,11 +1853,11 @@ only EST (fixed offset -5 hours), or only EDT (fixed offset -4 hours)).
 
 .. seealso::
 
-   `datetuil.tz <https://dateutil.readthedocs.io/en/stable/tz.html>`_
+   `dateutil.tz <https://dateutil.readthedocs.io/en/stable/tz.html>`_
       The standard library has :class:`timezone` class for handling arbitrary
       fixed offsets from UTC and :attr:`timezone.utc` as UTC timezone instance.
 
-      *datetuil.tz* library brings the *IANA timezone database* (also known as the
+      *dateutil.tz* library brings the *IANA timezone database* (also known as the
       Olson database) to Python and its usage is recommended.
 
    `IANA timezone database <https://www.iana.org/time-zones>`_


### PR DESCRIPTION
Typo from [this commit](https://github.com/python/cpython/commit/94c8a3f91fbba72845706853d28bd5af8fc11875#diff-5a85d656ffad06e86bee33767ae24f33R1852) went unnoticed and is present in official docs [here](https://docs.python.org/3.6/library/datetime.html#tzinfo-objects) and [here](https://docs.python.org/3.7/library/datetime.html#tzinfo-objects).  