### PR TITLE
[3.6] bpo-29822: make inspect.isabstract() work during __init_subclass__

### DIFF
--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -232,6 +232,30 @@ class TestPredicates(IsTestBase):
         self.assertFalse(inspect.isabstract(int))
         self.assertFalse(inspect.isabstract(5))
 
+    def test_isabstract_during_init_subclass(self):
+        from abc import ABCMeta, abstractmethod
+        isabstract_checks = []
+        class AbstractChecker(metaclass=ABCMeta):
+            def __init_subclass__(cls):
+                isabstract_checks.append(inspect.isabstract(cls))
+        class AbstractClassExample(AbstractChecker):
+            @abstractmethod
+            def foo(self):
+                pass
+        class ClassExample(AbstractClassExample):
+            def foo(self):
+                pass
+        self.assertEqual(isabstract_checks, [True, False])
+
+        isabstract_checks.clear()
+        class AbstractChild(AbstractClassExample):
+            pass
+        class AbstractGrandchild(AbstractChild):
+            pass
+        class ConcreteGrandchild(ClassExample):
+            pass
+        self.assertEqual(isabstract_checks, [True, True, False])
+
 
 class TestInterpreterStack(IsTestBase):
     def __init__(self, *args, **kwargs):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -45,6 +45,9 @@ Core and Builtins
 Library
 -------
 
+- bpo-29822: inspect.isabstract() now works during __init_subclass__.  Patch
+  by Nate Soares.
+
 - bpo-30557: faulthandler now correctly filters and displays exception codes
   on Windows
 
@@ -96,6 +99,9 @@ Library
   Jim Fasarakis-Hilliard and Ivan Levkivskyi.
 
 - bpo-30205: Fix getsockname() for unbound AF_UNIX sockets on Linux.
+
+- bpo-29960: Preserve generator state when _random.Random.setstate()
+  raises an exception.  Patch by Bryan Olson.
 
 - bpo-30070: Fixed leaks and crashes in errors handling in the parser module.
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -54,6 +54,9 @@ Library
 - bpo-30378: Fix the problem that logging.handlers.SysLogHandler cannot
   handle IPv6 addresses.
 
+- bpo-29960: Preserve generator state when _random.Random.setstate()
+  raises an exception.  Patch by Bryan Olson.
+
 - bpo-30414: multiprocessing.Queue._feed background running
   thread do not break from main loop on exception.
 
@@ -96,9 +99,6 @@ Library
   Jim Fasarakis-Hilliard and Ivan Levkivskyi.
 
 - bpo-30205: Fix getsockname() for unbound AF_UNIX sockets on Linux.
-
-- bpo-29960: Preserve generator state when _random.Random.setstate()
-  raises an exception.  Patch by Bryan Olson.
 
 - bpo-30070: Fixed leaks and crashes in errors handling in the parser module.
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -54,9 +54,6 @@ Library
 - bpo-30378: Fix the problem that logging.handlers.SysLogHandler cannot
   handle IPv6 addresses.
 
-- bpo-29960: Preserve generator state when _random.Random.setstate()
-  raises an exception.  Patch by Bryan Olson.
-
 - bpo-30414: multiprocessing.Queue._feed background running
   thread do not break from main loop on exception.
 


### PR DESCRIPTION
This is a backport of #678 to python 3.6. It depends on #527, which was only recently backported (#1282), and I might have made this backport too soon, in which case I apologized.

Also, I'm not entirely sure that I used the cherry picker tool correctly, because (e.g) a new news item snuck into Misc/NEWS when the backport was generated; I'll clean that up shortly, but I recommend having someone double-check that I'm doing this right :-)