### PR TITLE
bpo-30584: Fix test_os fails on non-English Windows

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -472,7 +472,7 @@ class StatAttributeTests(unittest.TestCase):
         # force CreateFile to fail with ERROR_ACCESS_DENIED.
         DETACHED_PROCESS = 8
         subprocess.check_call(
-            ['icacls.exe', fname, '/deny', 'Users:(S)'],
+            ['icacls.exe', fname, '/deny', '*S-1-5-32-545:(S)'],
             creationflags=DETACHED_PROCESS
         )
         result = os.stat(fname)

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -472,6 +472,8 @@ class StatAttributeTests(unittest.TestCase):
         # force CreateFile to fail with ERROR_ACCESS_DENIED.
         DETACHED_PROCESS = 8
         subprocess.check_call(
+            # bpo-30584: Use security identifier *S-1-5-32-545 instead
+            # of localized "Users" to not depend on the locale.
             ['icacls.exe', fname, '/deny', '*S-1-5-32-545:(S)'],
             creationflags=DETACHED_PROCESS
         )

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1132,6 +1132,7 @@ William Orr
 Michele Orrù
 Tomáš Orsava
 Oleg Oshmyan
+Denis Osipov
 Denis S. Otkidach
 Peter Otten
 Michael Otteneder


### PR DESCRIPTION
On Microsoft Support page [Well-known security identifiers in Windows operating systems](https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems) said:

> A security identifier (SID) is a unique value of variable length that is used to identify a security principal or security group in Windows operating systems. Well-known SIDs are a group of SIDs that identify generic users or generic groups. Their values remain constant across all operating systems.

So I suggest to use SID (*S-1-5-32-545) instead of name (Users).