### PR TITLE
gh-42010: IDLE Editor Bottom Scroll Bar

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -122,6 +122,7 @@ class EditorWindow(object):
         self.prompt_last_line = ''  # Override in PyShell
         self.text_frame = text_frame = Frame(top)
         self.vbar = vbar = Scrollbar(text_frame, name='vbar')
+        self.hbar = hbar = Scrollbar(text_frame, orient="horizontal", name='hbar')
         width = idleConf.GetOption('main', 'EditorWindow', 'width', type='int')
         text_options = {
                 'name': 'text',
@@ -212,6 +213,9 @@ class EditorWindow(object):
         vbar['command'] = self.handle_yview
         vbar.grid(row=1, column=2, sticky=NSEW)
         text['yscrollcommand'] = vbar.set
+        hbar['command'] = text.xview
+        hbar.pack(side='bottom', fill='x')
+        text['xscrollcommand'] = hbar.set
         text['font'] = idleConf.GetFont(self.root, 'main', 'EditorWindow')
         text.grid(row=1, column=1, sticky=NSEW)
         text.focus_set()

--- a/Lib/idlelib/idle_test/test_textview.py
+++ b/Lib/idlelib/idle_test/test_textview.py
@@ -69,10 +69,10 @@ class ViewWindowTest(unittest.TestCase):
         view.destroy()
 
 
-class AutoHideScrollbarTest(unittest.TestCase):
+class AutoShowScrollbarTest(unittest.TestCase):
     # Method set is tested in ScrollableTextFrameTest
     def test_forbidden_geometry(self):
-        scroll = tv.AutoHideScrollbar(root)
+        scroll = tv.AutoShowScrollbar(root)
         self.assertRaises(TclError, scroll.pack)
         self.assertRaises(TclError, scroll.place)
 

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -856,6 +856,7 @@ class PyShell(OutputWindow):
     ]
 
     allow_line_numbers = False
+    allow_hbar = False
 
     # New classes
     from idlelib.history import History

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -10,7 +10,7 @@ from functools import update_wrapper
 from idlelib.colorizer import color_config
 
 
-class AutoHideScrollbar(Scrollbar):
+class AutoShowScrollbar(Scrollbar):
     """A scrollbar that is automatically hidden when not needed.
 
     Only the grid geometry manager is supported.
@@ -53,7 +53,7 @@ class ScrollableTextFrame(Frame):
         self.grid_columnconfigure(0, weight=1)
 
         # vertical scrollbar
-        self.yscroll = AutoHideScrollbar(self, orient=VERTICAL,
+        self.yscroll = AutoShowScrollbar(self, orient=VERTICAL,
                                          takefocus=False,
                                          command=text.yview)
         self.yscroll.grid(row=0, column=1, sticky=NS)
@@ -61,7 +61,7 @@ class ScrollableTextFrame(Frame):
 
         # horizontal scrollbar - only when wrap is set to NONE
         if wrap == NONE:
-            self.xscroll = AutoHideScrollbar(self, orient=HORIZONTAL,
+            self.xscroll = AutoShowScrollbar(self, orient=HORIZONTAL,
                                              takefocus=False,
                                              command=text.xview)
             self.xscroll.grid(row=1, column=0, sticky=EW)


### PR DESCRIPTION
Adds a horizontal scroll bar to the IDLE Editor windows.

<!-- issue-number: [bpo-1207613](https://bugs.python.org/issue1207613) -->
https://bugs.python.org/issue1207613
<!-- /issue-number -->


<!-- gh-issue-number: gh-42010 -->
* Issue: gh-42010
<!-- /gh-issue-number -->
