### PR TITLE
bpo-30566: Fix IndexError in the punycode codec

### DIFF
--- a/Lib/encodings/punycode.py
+++ b/Lib/encodings/punycode.py
@@ -143,7 +143,7 @@ def decode_generalized_number(extended, extpos, bias, errors):
             digit = char - 22 # 0x30-26
         elif errors == "strict":
             raise UnicodeError("Invalid extended code point '%s'"
-                               % extended[extpos])
+                               % extended[extpos-1])
         else:
             return extpos, None
         t = T(j, bias)

--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1335,6 +1335,11 @@ for i in punycode_testcases:
     if len(i)!=2:
         print(repr(i))
 
+punycode_decode_exceptions = [
+    (b"xn--w&",
+     UnicodeError),
+    ]
+
 
 class PunycodeTest(unittest.TestCase):
     def test_encode(self):
@@ -1355,6 +1360,12 @@ class PunycodeTest(unittest.TestCase):
             puny = puny.decode("ascii").encode("ascii")
             self.assertEqual(uni, puny.decode("punycode"))
 
+    # Make sure punycode codec raises the right kind of exception
+    # when given invalid punycode to decode
+    def test_decode_exceptions(self):
+        for byt, exception in punycode_decode_exceptions:
+            with self.assertRaises(exception):
+                byt.decode('punycode')
 
 class UnicodeInternalTest(unittest.TestCase):
     @unittest.skipUnless(SIZEOF_WCHAR_T == 4, 'specific to 32-bit wchar_t')

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -605,6 +605,7 @@ Rycharde Hawkes
 Ben Hayden
 Jochen Hayek
 Tim Heaney
+Vikram Hegde
 Henrik Heimbuerger
 Christian Heimes
 Thomas Heller


### PR DESCRIPTION
A bug in the punycode codec raises an IndexError when we attempt to decode the string "xn--w&". The fix is straightforward and obvious one-liner. Bug number:  bpo-30566

<!-- issue-number: bpo-30566 -->
https://bugs.python.org/issue30566
<!-- /issue-number -->
