### PR TITLE
bpo-30594: Fix spurious DECREF in newPySSLSocket

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -599,6 +599,7 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
     self->ssl = NULL;
     self->Socket = NULL;
     self->ctx = sslctx;
+    Py_INCREF(sslctx);
     self->shutdown_seen_zero = 0;
     self->handshake_done = 0;
     self->owner = NULL;
@@ -612,8 +613,6 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
         }
         self->server_hostname = hostname;
     }
-
-    Py_INCREF(sslctx);
 
     /* Make sure the SSL error state is initialized */
     (void) ERR_get_state();


### PR DESCRIPTION
In newPySSLSocket, it sets up the new 'self' object, which among other
things owns a reference to the parent SSLContext in 'self->ctx'.

It then tries to idna-decode the given server_hostname, and if this
fails it does Py_DECREF(self) and returns.

The Py_DECREF(self) causes the PySSLSocket destructor to run, which
calls Py_DECREF(self->ctx), which releases the reference to the parent
SSLContext object.

However... as currently written, we don't actually *take* the
reference to the parent SSLContext until *after* the idna-decoding
step. I.e., this does a Py_DECREF on an object that was never
Py_INCREFed. Eventually we get a segfault.