### PR TITLE
[3.5] bpo-30594: Fixed refcounting in newPySSLSocket (GH-1992)

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -570,6 +570,7 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
     self->ssl = NULL;
     self->Socket = NULL;
     self->ctx = sslctx;
+    Py_INCREF(sslctx);
     self->shutdown_seen_zero = 0;
     self->handshake_done = 0;
     self->owner = NULL;
@@ -583,8 +584,6 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
         }
         self->server_hostname = hostname;
     }
-
-    Py_INCREF(sslctx);
 
     /* Make sure the SSL error state is initialized */
     (void) ERR_get_state();


### PR DESCRIPTION
If pass a server_hostname= that fails IDNA decoding to SSLContext.wrap_socket or SSLContext.wrap_bio, then the SSLContext object had a spurious Py_DECREF called on it, eventually leading to segfaults.
(cherry picked from commit 65ece7ca2366308fa91a39a8dfa255e6bdce3cca)