### PR TITLE
bpo-30592: Fixed error messages for some builtins.

### DIFF
--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -949,7 +949,7 @@ itemgetter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *item;
     Py_ssize_t nitems;
 
-    if (!_PyArg_NoKeywords("itemgetter()", kwds))
+    if (!_PyArg_NoKeywords("itemgetter", kwds))
         return NULL;
 
     nitems = PyTuple_GET_SIZE(args);
@@ -1124,7 +1124,7 @@ attrgetter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *attr;
     Py_ssize_t nattrs, idx, char_idx;
 
-    if (!_PyArg_NoKeywords("attrgetter()", kwds))
+    if (!_PyArg_NoKeywords("attrgetter", kwds))
         return NULL;
 
     nattrs = PyTuple_GET_SIZE(args);

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -435,7 +435,7 @@ random_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     RandomObject *self;
     PyObject *tmp;
 
-    if (type == &Random_Type && !_PyArg_NoKeywords("Random()", kwds))
+    if (type == &Random_Type && !_PyArg_NoKeywords("Random", kwds))
         return NULL;
 
     self = (RandomObject *)type->tp_alloc(type, 0);

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1218,7 +1218,7 @@ PyObject* pysqlite_connection_call(pysqlite_Connection* self, PyObject* args, Py
         return NULL;
     }
 
-    if (!_PyArg_NoKeywords(MODULE_NAME ".Connection()", kwargs))
+    if (!_PyArg_NoKeywords(MODULE_NAME ".Connection", kwargs))
         return NULL;
 
     if (!PyArg_ParseTuple(args, "O", &sql))

--- a/Modules/_sqlite/row.c
+++ b/Modules/_sqlite/row.c
@@ -41,7 +41,7 @@ pysqlite_row_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 
     assert(type != NULL && type->tp_alloc != NULL);
 
-    if (!_PyArg_NoKeywords("Row()", kwargs))
+    if (!_PyArg_NoKeywords("Row", kwargs))
         return NULL;
     if (!PyArg_ParseTuple(args, "OO", &cursor, &data))
         return NULL;

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2568,7 +2568,7 @@ array_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *initial = NULL, *it = NULL;
     const struct arraydescr *descr;
 
-    if (type == &Arraytype && !_PyArg_NoKeywords("array.array()", kwds))
+    if (type == &Arraytype && !_PyArg_NoKeywords("array.array", kwds))
         return NULL;
 
     if (!PyArg_ParseTuple(args, "C|O:array", &c, &initial))

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -871,7 +871,7 @@ cycle_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *saved;
     cycleobject *lz;
 
-    if (type == &cycle_type && !_PyArg_NoKeywords("cycle()", kwds))
+    if (type == &cycle_type && !_PyArg_NoKeywords("cycle", kwds))
         return NULL;
 
     if (!PyArg_UnpackTuple(args, "cycle", 1, 1, &iterable))
@@ -1072,7 +1072,7 @@ dropwhile_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *it;
     dropwhileobject *lz;
 
-    if (type == &dropwhile_type && !_PyArg_NoKeywords("dropwhile()", kwds))
+    if (type == &dropwhile_type && !_PyArg_NoKeywords("dropwhile", kwds))
         return NULL;
 
     if (!PyArg_UnpackTuple(args, "dropwhile", 2, 2, &func, &seq))
@@ -1240,7 +1240,7 @@ takewhile_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *it;
     takewhileobject *lz;
 
-    if (type == &takewhile_type && !_PyArg_NoKeywords("takewhile()", kwds))
+    if (type == &takewhile_type && !_PyArg_NoKeywords("takewhile", kwds))
         return NULL;
 
     if (!PyArg_UnpackTuple(args, "takewhile", 2, 2, &func, &seq))
@@ -1408,7 +1408,7 @@ islice_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     Py_ssize_t numargs;
     isliceobject *lz;
 
-    if (type == &islice_type && !_PyArg_NoKeywords("islice()", kwds))
+    if (type == &islice_type && !_PyArg_NoKeywords("islice", kwds))
         return NULL;
 
     if (!PyArg_UnpackTuple(args, "islice", 2, 4, &seq, &a1, &a2, &a3))
@@ -1662,7 +1662,7 @@ starmap_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *it;
     starmapobject *lz;
 
-    if (type == &starmap_type && !_PyArg_NoKeywords("starmap()", kwds))
+    if (type == &starmap_type && !_PyArg_NoKeywords("starmap", kwds))
         return NULL;
 
     if (!PyArg_UnpackTuple(args, "starmap", 2, 2, &func, &seq))
@@ -1820,7 +1820,7 @@ chain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *source;
 
-    if (type == &chain_type && !_PyArg_NoKeywords("chain()", kwds))
+    if (type == &chain_type && !_PyArg_NoKeywords("chain", kwds))
         return NULL;
 
     source = PyObject_GetIter(args);
@@ -3769,7 +3769,7 @@ filterfalse_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     filterfalseobject *lz;
 
     if (type == &filterfalse_type &&
-        !_PyArg_NoKeywords("filterfalse()", kwds))
+        !_PyArg_NoKeywords("filterfalse", kwds))
         return NULL;
 
     if (!PyArg_UnpackTuple(args, "filterfalse", 2, 2, &func, &seq))

--- a/Modules/zipimport.c
+++ b/Modules/zipimport.c
@@ -69,7 +69,7 @@ zipimporter_init(ZipImporter *self, PyObject *args, PyObject *kwds)
     PyObject *filename = NULL;
     Py_ssize_t len, flen;
 
-    if (!_PyArg_NoKeywords("zipimporter()", kwds))
+    if (!_PyArg_NoKeywords("zipimporter", kwds))
         return -1;
 
     if (!PyArg_ParseTuple(args, "O&:zipimporter",

--- a/Objects/boolobject.c
+++ b/Objects/boolobject.c
@@ -45,7 +45,7 @@ bool_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *x = Py_False;
     long ok;
 
-    if (!_PyArg_NoKeywords("bool()", kwds))
+    if (!_PyArg_NoKeywords("bool", kwds))
         return NULL;
     if (!PyArg_UnpackTuple(args, "bool", 0, 1, &x))
         return NULL;

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -74,7 +74,7 @@ range_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     rangeobject *obj;
     PyObject *start = NULL, *stop = NULL, *step = NULL;
 
-    if (!_PyArg_NoKeywords("range()", kw))
+    if (!_PyArg_NoKeywords("range", kw))
         return NULL;
 
     if (PyTuple_Size(args) <= 1) {

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1083,7 +1083,7 @@ frozenset_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyObject *iterable = NULL, *result;
 
-    if (type == &PyFrozenSet_Type && !_PyArg_NoKeywords("frozenset()", kwds))
+    if (type == &PyFrozenSet_Type && !_PyArg_NoKeywords("frozenset", kwds))
         return NULL;
 
     if (!PyArg_UnpackTuple(args, type->tp_name, 0, 1, &iterable))
@@ -2006,7 +2006,7 @@ set_init(PySetObject *self, PyObject *args, PyObject *kwds)
 {
     PyObject *iterable = NULL;
 
-    if (!_PyArg_NoKeywords("set()", kwds))
+    if (!_PyArg_NoKeywords("set", kwds))
         return -1;
     if (!PyArg_UnpackTuple(args, Py_TYPE(self)->tp_name, 0, 1, &iterable))
         return -1;

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -297,7 +297,7 @@ slice_new(PyTypeObject *type, PyObject *args, PyObject *kw)
 
     start = stop = step = NULL;
 
-    if (!_PyArg_NoKeywords("slice()", kw))
+    if (!_PyArg_NoKeywords("slice", kw))
         return NULL;
 
     if (!PyArg_UnpackTuple(args, "slice", 1, 3, &start, &stop, &step))

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -332,7 +332,7 @@ weakref___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     PyObject *tmp;
 
-    if (!_PyArg_NoKeywords("ref()", kwargs))
+    if (!_PyArg_NoKeywords("ref", kwargs))
         return -1;
 
     if (parse_weakref_init_args("__init__", args, kwargs, &tmp, &tmp))

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -429,7 +429,7 @@ filter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *it;
     filterobject *lz;
 
-    if (type == &PyFilter_Type && !_PyArg_NoKeywords("filter()", kwds))
+    if (type == &PyFilter_Type && !_PyArg_NoKeywords("filter", kwds))
         return NULL;
 
     if (!PyArg_UnpackTuple(args, "filter", 2, 2, &func, &seq))
@@ -1125,7 +1125,7 @@ map_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     mapobject *lz;
     Py_ssize_t numargs, i;
 
-    if (type == &PyMap_Type && !_PyArg_NoKeywords("map()", kwds))
+    if (type == &PyMap_Type && !_PyArg_NoKeywords("map", kwds))
         return NULL;
 
     numargs = PyTuple_Size(args);
@@ -2446,7 +2446,7 @@ zip_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     PyObject *result;
     Py_ssize_t tuplesize;
 
-    if (type == &PyZip_Type && !_PyArg_NoKeywords("zip()", kwds))
+    if (type == &PyZip_Type && !_PyArg_NoKeywords("zip", kwds))
         return NULL;
 
     /* args must be a tuple */


### PR DESCRIPTION
Error messages when pass keyword arguments to some builtins that
don't support keyword arguments contained double parenthesis: "()()".
The regression was intriduced by bpo-30534.