### PR TITLE
bpo-30598: _PySys_EndInit() now duplicates warnoptions

### DIFF
--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2136,10 +2136,10 @@ _PySys_EndInit(PyObject *sysdict)
         if (warnoptions == NULL)
             return -1;
     }
-    else {
-        Py_INCREF(warnoptions);
-    }
-    SET_SYS_FROM_STRING_BORROW_INT_RESULT("warnoptions", warnoptions);
+
+    SET_SYS_FROM_STRING_INT_RESULT("warnoptions",
+                                   PyList_GetSlice(warnoptions,
+                                                   0, Py_SIZE(warnoptions)));
 
     SET_SYS_FROM_STRING_BORROW_INT_RESULT("_xoptions", get_xoptions());
 


### PR DESCRIPTION
Fix a reference in subinterpreters, like test_callbacks_leak() of
test_atexit.

warnoptions is a list used to pass options from the command line to
the sys module constructor. Before this change, the list was shared
by multiple interpreter which is not the expected behaviour. Each
interpreter should have their own independent mutable world.

This change duplicates the list in each interpreter. So each
interpreter owns its own list, so each interpreter can clear its own
list.