### PR TITLE
[3.6] bpo-30584: Fix test_os fails on non-English Windows (GH-1980)

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -473,7 +473,9 @@ class StatAttributeTests(unittest.TestCase):
         # force CreateFile to fail with ERROR_ACCESS_DENIED.
         DETACHED_PROCESS = 8
         subprocess.check_call(
-            ['icacls.exe', fname, '/deny', 'Users:(S)'],
+            # bpo-30584: Use security identifier *S-1-5-32-545 instead
+            # of localized "Users" to not depend on the locale.
+            ['icacls.exe', fname, '/deny', '*S-1-5-32-545:(S)'],
             creationflags=DETACHED_PROCESS
         )
         result = os.stat(fname)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1121,6 +1121,7 @@ William Orr
 Michele Orrù
 Tomáš Orsava
 Oleg Oshmyan
+Denis Osipov
 Denis S. Otkidach
 Peter Otten
 Michael Otteneder


### PR DESCRIPTION
* Fix bpo-30584

* Adding a comment mentionning the bpo and explaining what is the identifier

* Add Denis Osipov to Misc/ACKS
(cherry picked from commit 897bba75632dfce87c355e3cd4700468357715a7)