### PR TITLE
[3.6] bpo-30601: Fix a refleak in WindowsConsoleIO (#2003)

### DIFF
--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -101,7 +101,7 @@ char _PyIO_get_console_type(PyObject *path_or_fd) {
 
     DWORD length;
     wchar_t name_buf[MAX_PATH], *pname_buf = name_buf;
-    
+
     length = GetFullPathNameW(decoded_wstr, MAX_PATH, pname_buf, NULL);
     if (length > MAX_PATH) {
         pname_buf = PyMem_New(wchar_t, length);
@@ -305,8 +305,7 @@ _io__WindowsConsoleIO___init___impl(winconsoleio *self, PyObject *nameobj,
     self->fd = fd;
 
     if (fd < 0) {
-        PyObject *decodedname = Py_None;
-        Py_INCREF(decodedname);
+        PyObject *decodedname;
 
         int d = PyUnicode_FSDecoder(nameobj, (void*)&decodedname);
         if (!d)


### PR DESCRIPTION
Fix a reference leak in _io._WindowsConsoleIO: PyUnicode_FSDecoder()
always initialize decodedname when it succeed and it doesn't clear
input decodedname object.
(cherry picked from commit 29adc13bd797d9c9e7fcb893a7c49ce7f7ad388c)