### PR TITLE
bpo-30603: test textwrap.dedent with declining indent level

### DIFF
--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -754,6 +754,11 @@ def foo():
         expect = "Foo\n  Bar\n\n Baz\n"
         self.assertEqual(expect, dedent(text))
 
+        # Uneven indentation with declining indent level.
+        text = "     Foo\n    Bar\n"  # 5 spaces, then 4
+        expect = " Foo\nBar\n"
+        self.assertEqual(expect, dedent(text))
+
     # dedent() should not mangle internal tabs
     def test_dedent_preserve_internal_tabs(self):
         text = "  hello\tthere\n  how are\tyou?"


### PR DESCRIPTION
Coverage tool shows that a case in textwrap.dedent previously untested:  When dedent initially sees a longer indent, followed by a shorter indent, so that it has to revise its margin estimate downward. 

Added test for this case.