### PR TITLE
bpo-30605: Fix compiling binary regexs with BytesWarnings enabled.

### DIFF
--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -765,7 +765,7 @@ def _parse(source, state, verbose, nested, first=False):
                         if not first or subpattern:
                             import warnings
                             warnings.warn(
-                                'Flags not at the start of the expression %s%s' % (
+                                'Flags not at the start of the expression %r%s' % (
                                     source.string[:20],  # truncate long regexes
                                     ' (truncated)' if len(source.string) > 20 else '',
                                 ),

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1368,7 +1368,7 @@ class ReTests(unittest.TestCase):
             self.assertTrue(re.match(p, lower_char))
         self.assertEqual(
             str(warns.warnings[0].message),
-            'Flags not at the start of the expression %s' % p
+            "Flags not at the start of the expression '%s'" % p
         )
         self.assertEqual(warns.warnings[0].filename, __file__)
 
@@ -1377,7 +1377,7 @@ class ReTests(unittest.TestCase):
             self.assertTrue(re.match(p, lower_char))
         self.assertEqual(
             str(warns.warnings[0].message),
-            'Flags not at the start of the expression %s (truncated)' % p[:20]
+            "Flags not at the start of the expression '%s' (truncated)" % p[:20]
         )
         self.assertEqual(warns.warnings[0].filename, __file__)
 
@@ -1933,16 +1933,16 @@ ELSE
 
         # equal: test bytes patterns
         re.purge()
-        pattern2 = re.compile(b'abc')
-        self.assertEqual(hash(pattern2), hash(pattern1))
-        self.assertEqual(pattern2, pattern1)
-
-        # not equal: pattern of a different types (str vs bytes),
-        # comparison must not raise a BytesWarning
-        re.purge()
-        pattern3 = re.compile('abc')
         with warnings.catch_warnings():
             warnings.simplefilter('error', BytesWarning)
+            pattern2 = re.compile(b'abc')
+            self.assertEqual(hash(pattern2), hash(pattern1))
+            self.assertEqual(pattern2, pattern1)
+
+            # not equal: pattern of a different types (str vs bytes),
+            # comparison must not raise a BytesWarning
+            re.purge()
+            pattern3 = re.compile('abc')
             self.assertNotEqual(pattern3, pattern1)
 
     def test_bug_29444(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1685,7 +1685,7 @@ Jakub Wilk
 Gerald S. Williams
 Jason Williams
 John Williams
-Roy Willams
+Roy Williams
 Sue Williams
 Carol Willing
 Steven Willis

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1685,6 +1685,7 @@ Jakub Wilk
 Gerald S. Williams
 Jason Williams
 John Williams
+Roy Willams
 Sue Williams
 Carol Willing
 Steven Willis

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -646,6 +646,9 @@ Library
 - bpo-29851: importlib.reload() now raises ModuleNotFoundError if the
   module lacks a spec.
 
+- bpo-30605: re.compile() no longer raises a BytesWarning when compiling a
+  bytes instance.
+
 - Issue #28556: Various updates to typing module: typing.Counter, typing.ChainMap,
   improved ABC caching, etc. Original PRs by Jelle Zijlstra, Ivan Levkivskyi,
   Manuel Krebber, and Łukasz Langa.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -350,6 +350,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30605: re.compile() no longer raises a BytesWarning when compiling a
+  bytes instance with misplaced inline modifier.  Patch by Roy Williams.
+
 - bpo-30418: On Windows, subprocess.Popen.communicate() now also ignore EINVAL
   on stdin.write() if the child process is still running but closed the pipe.
 
@@ -645,9 +648,6 @@ Library
 
 - bpo-29851: importlib.reload() now raises ModuleNotFoundError if the
   module lacks a spec.
-
-- bpo-30605: re.compile() no longer raises a BytesWarning when compiling a
-  bytes instance.
 
 - Issue #28556: Various updates to typing module: typing.Counter, typing.ChainMap,
   improved ABC caching, etc. Original PRs by Jelle Zijlstra, Ivan Levkivskyi,


### PR DESCRIPTION
Running our unit tests with `-bb` enabled triggered this failure.