### PR TITLE
[3.6] bpo-29478: Fix passing max_line_length=None from Compat32 policy

### DIFF
--- a/Lib/email/_policybase.py
+++ b/Lib/email/_policybase.py
@@ -361,8 +361,12 @@ class Compat32(Policy):
             # Assume it is a Header-like object.
             h = value
         if h is not None:
-            parts.append(h.encode(linesep=self.linesep,
-                                  maxlinelen=self.max_line_length))
+            # The Header class interprets a value of None for maxlinelen as the
+            # default value of 78, as recommended by RFC 2822.
+            maxlinelen = 0
+            if self.max_line_length is not None:
+                maxlinelen = self.max_line_length
+            parts.append(h.encode(linesep=self.linesep, maxlinelen=maxlinelen))
         parts.append(self.linesep)
         return ''.join(parts)
 

--- a/Lib/test/test_email/test_generator.py
+++ b/Lib/test/test_email/test_generator.py
@@ -162,6 +162,13 @@ class TestGeneratorBase:
                 g.flatten(msg)
                 self.assertEqual(s.getvalue(), self.typ(expected))
 
+    def test_compat32_max_line_length_does_not_fold_when_none(self):
+        msg = self.msgmaker(self.typ(self.refold_long_expected[0]))
+        s = self.ioclass()
+        g = self.genclass(s, policy=policy.compat32.clone(max_line_length=None))
+        g.flatten(msg)
+        self.assertEqual(s.getvalue(), self.typ(self.refold_long_expected[0]))
+
 
 class TestGenerator(TestGeneratorBase, TestEmailBase):
 


### PR DESCRIPTION
(cherry picked from commit 03a9c7a0d2a27e91b540f92f0f019ef47d3fce6a)

backport of #595 