### PR TITLE
bpo-30595: Increase test_queue_feeder_donot_stop_onexc() timeout

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -764,7 +764,8 @@ class _TestQueue(BaseTestCase):
             q = self.Queue()
             q.put(NotSerializable())
             q.put(True)
-            self.assertTrue(q.get(timeout=0.1))
+            # bpo-30595: use a timeout of 1 second for slow buildbots
+            self.assertTrue(q.get(timeout=1.0))
 
 #
 #


### PR DESCRIPTION
test_queue_feeder_donot_stop_onexc() now uses a timeout of 1 second
on Queue.get(), instead of 0.1 second, for slow buildbots.