### PR TITLE
bpo-30595: Fix multiprocessing.Queue.get(timeout)

### DIFF
--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -101,7 +101,7 @@ class Queue(object):
             try:
                 if block:
                     timeout = deadline - time.time()
-                    if timeout < 0 or not self._poll(timeout):
+                    if not self._poll(timeout):
                         raise Empty
                 elif not self._poll():
                     raise Empty

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -350,10 +350,14 @@ Extension Modules
 Library
 -------
 
+- bpo-30595: multiprocessing.Queue.get() with a timeout now polls its reader in
+  non-blocking mode if it succeeded to aquire the lock but the acquire took
+  longer than the timeout.
+
 - bpo-30605: re.compile() no longer raises a BytesWarning when compiling a
   bytes instance with misplaced inline modifier.  Patch by Roy Williams.
 
-- bpo-29870: Fix ssl sockets leaks when connection is aborted in asyncio/ssl 
+- bpo-29870: Fix ssl sockets leaks when connection is aborted in asyncio/ssl
   implementation. Patch by Michaël Sghaïer.
 
 - bpo-29743: Closing transport during handshake process leaks open socket.


### PR DESCRIPTION
multiprocessing.Queue.get() with a timeout now polls its reader in
non-blocking mode if it succeeded to aquire the lock but the acquire
took longer than the timeout.

Co-Authored-By: Grzegorz Grzywacz <grzgrzgrz3@gmail.com>