### PR TITLE
[3.6] bpo-27585: Fix waiter cancellation in asyncio.Lock

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -45,6 +45,9 @@ Core and Builtins
 Library
 -------
 
+- bpo-27585: Fix waiter cancellation in asyncio.Lock.
+  Patch by Mathieu Sornay.
+
 - bpo-30418: On Windows, subprocess.Popen.communicate() now also ignore EINVAL
   on stdin.write() if the child process is still running but closed the pipe.
 


### PR DESCRIPTION
Avoid a deadlock when the waiter who is about to take the lock is
cancelled

Issue #27585