### PR TITLE
[3.5] bpo-27585: Fix waiter cancellation in asyncio.Lock

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -56,6 +56,9 @@ Extension Modules
 Library
 -------
 
+- bpo-27585: Fix waiter cancellation in asyncio.Lock.
+  Patch by Mathieu Sornay.
+
 - bpo-30418: On Windows, subprocess.Popen.communicate() now also ignore EINVAL
   on stdin.write() if the child process is still running but closed the pipe.
 


### PR DESCRIPTION
Avoid a deadlock when the waiter who is about to take the lock is
cancelled

Issue #27585