### PR TITLE
Make codecov config on master the only config used

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,5 @@
 codecov:
+  strict_yaml_branch: master
   notify:
     require_ci_to_pass: true
 comment: off


### PR DESCRIPTION
This will allow for centralized management of the Codecov config to prevent skew as well as easier management going forward.

Closes python/core-workflow#81.