### PR TITLE
[3.6] bpo-30192: Check that Python is 64-bit before enabling BLAKE2_USE_SSE. (GH-1332)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -897,8 +897,11 @@ class PyBuildExt(build_ext):
         blake2_deps.append('hashlib.h')
 
         blake2_macros = []
-        if not cross_compiling and os.uname().machine == "x86_64":
-            # Every x86_64 machine has at least SSE2.
+        if (not cross_compiling and
+                os.uname().machine == "x86_64" and
+                sys.maxsize >  2**32):
+            # Every x86_64 machine has at least SSE2.  Check for sys.maxsize
+            # in case that kernel is 64-bit but userspace is 32-bit.
             blake2_macros.append(('BLAKE2_USE_SSE', '1'))
 
         exts.append( Extension('_blake2',


### PR DESCRIPTION

(cherry picked from commit 6c991bdee7ec4bedd8c1b8d3812dc884b654b57c)