### PR TITLE
bpo-28907: fix test_pydoc for case that build is in sub-directory.

### DIFF
--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -459,7 +459,8 @@ class PydocDocTest(unittest.TestCase):
     def test_mixed_case_module_names_are_lower_cased(self):
         # issue16484
         doc_link = get_pydoc_link(xml.etree.ElementTree)
-        self.assertIn('xml.etree.elementtree', doc_link)
+        if doc_link:
+            self.assertIn('xml.etree.elementtree', doc_link)
 
     def test_issue8225(self):
         # Test issue8225 to ensure no doc link appears for xml.etree


### PR DESCRIPTION
The pydoc function getdocloc() is broken in the case of building Python
in a sub-directory.  It cannot build 'basedir' as it does and assume
that is the location of standard modules.  Skip
test_mixed_case_module_names_are_lower_cased() test if getdocloc()
cannot find the module.  Fixes bug #28907.