### PR TITLE
bpo-30600: Fix error messages (condition order in Argument Clinic)

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -148,6 +148,18 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         msg = r"__contains__\(\) takes no keyword arguments"
         self.assertRaisesRegex(TypeError, msg, {}.__contains__, x=2, y=2)
 
+    def test_varargs3_kw(self):
+        msg = r"bool\(\) takes no keyword arguments"
+        self.assertRaisesRegex(TypeError, msg, bool, x=2)
+
+    def test_varargs4_kw(self):
+        msg = r"^index\(\) takes no keyword arguments$"
+        self.assertRaisesRegex(TypeError, msg, [].index, x=2)
+
+    def test_varargs5_kw(self):
+        msg = r"^hasattr\(\) takes no keyword arguments$"
+        self.assertRaisesRegex(TypeError, msg, hasattr, x=2)
+
     def test_oldargs0_1(self):
         msg = r"keys\(\) takes no arguments \(1 given\)"
         self.assertRaisesRegex(TypeError, msg, {}.keys, 0)

--- a/Modules/_io/clinic/bufferedio.c.h
+++ b/Modules/_io/clinic/bufferedio.c.h
@@ -102,12 +102,12 @@ _io__Buffered_peek(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *
     PyObject *return_value = NULL;
     Py_ssize_t size = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "|n:peek",
-        &size)) {
+    if (!_PyArg_NoStackKeywords("peek", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("peek", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|n:peek",
+        &size)) {
         goto exit;
     }
     return_value = _io__Buffered_peek_impl(self, size);
@@ -133,12 +133,12 @@ _io__Buffered_read(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
-        _Py_convert_optional_to_ssize_t, &n)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
+        _Py_convert_optional_to_ssize_t, &n)) {
         goto exit;
     }
     return_value = _io__Buffered_read_impl(self, n);
@@ -164,12 +164,12 @@ _io__Buffered_read1(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|n:read1",
-        &n)) {
+    if (!_PyArg_NoStackKeywords("read1", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read1", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|n:read1",
+        &n)) {
         goto exit;
     }
     return_value = _io__Buffered_read1_impl(self, n);
@@ -257,12 +257,12 @@ _io__Buffered_readline(buffered *self, PyObject **args, Py_ssize_t nargs, PyObje
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io__Buffered_readline_impl(self, size);
@@ -289,12 +289,12 @@ _io__Buffered_seek(buffered *self, PyObject **args, Py_ssize_t nargs, PyObject *
     PyObject *targetobj;
     int whence = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
-        &targetobj, &whence)) {
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
+        &targetobj, &whence)) {
         goto exit;
     }
     return_value = _io__Buffered_seek_impl(self, targetobj, whence);
@@ -320,13 +320,13 @@ _io__Buffered_truncate(buffered *self, PyObject **args, Py_ssize_t nargs, PyObje
     PyObject *return_value = NULL;
     PyObject *pos = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "truncate",
-        0, 1,
-        &pos)) {
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "truncate",
+        0, 1,
+        &pos)) {
         goto exit;
     }
     return_value = _io__Buffered_truncate_impl(self, pos);
@@ -500,4 +500,4 @@ _io_BufferedRandom___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3cf3262c9b157dc1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4f7490f82427c63b input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/bytesio.c.h
+++ b/Modules/_io/clinic/bytesio.c.h
@@ -169,12 +169,12 @@ _io_BytesIO_read(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io_BytesIO_read_impl(self, size);
@@ -204,12 +204,12 @@ _io_BytesIO_read1(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:read1",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("read1", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read1", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read1",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io_BytesIO_read1_impl(self, size);
@@ -240,12 +240,12 @@ _io_BytesIO_readline(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io_BytesIO_readline_impl(self, size);
@@ -276,13 +276,13 @@ _io_BytesIO_readlines(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *return_value = NULL;
     PyObject *arg = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "readlines",
-        0, 1,
-        &arg)) {
+    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "readlines",
+        0, 1,
+        &arg)) {
         goto exit;
     }
     return_value = _io_BytesIO_readlines_impl(self, arg);
@@ -347,12 +347,12 @@ _io_BytesIO_truncate(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *return_value = NULL;
     Py_ssize_t size = self->pos;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:truncate",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:truncate",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io_BytesIO_truncate_impl(self, size);
@@ -386,12 +386,12 @@ _io_BytesIO_seek(bytesio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     Py_ssize_t pos;
     int whence = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "n|i:seek",
-        &pos, &whence)) {
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "n|i:seek",
+        &pos, &whence)) {
         goto exit;
     }
     return_value = _io_BytesIO_seek_impl(self, pos, whence);
@@ -468,4 +468,4 @@ _io_BytesIO___init__(PyObject *self, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=733795434f838b71 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9e63715414bffb2a input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/fileio.c.h
+++ b/Modules/_io/clinic/fileio.c.h
@@ -213,12 +213,12 @@ _io_FileIO_read(fileio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io_FileIO_read_impl(self, size);
@@ -290,12 +290,12 @@ _io_FileIO_seek(fileio *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyObject *pos;
     int whence = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
-        &pos, &whence)) {
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
+        &pos, &whence)) {
         goto exit;
     }
     return_value = _io_FileIO_seek_impl(self, pos, whence);
@@ -347,13 +347,13 @@ _io_FileIO_truncate(fileio *self, PyObject **args, Py_ssize_t nargs, PyObject *k
     PyObject *return_value = NULL;
     PyObject *posobj = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "truncate",
-        0, 1,
-        &posobj)) {
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "truncate",
+        0, 1,
+        &posobj)) {
         goto exit;
     }
     return_value = _io_FileIO_truncate_impl(self, posobj);
@@ -385,4 +385,4 @@ _io_FileIO_isatty(fileio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO_FILEIO_TRUNCATE_METHODDEF
     #define _IO_FILEIO_TRUNCATE_METHODDEF
 #endif /* !defined(_IO_FILEIO_TRUNCATE_METHODDEF) */
-/*[clinic end generated code: output=a4044e2d878248d0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2c6a5470100a8f10 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/iobase.c.h
+++ b/Modules/_io/clinic/iobase.c.h
@@ -185,12 +185,12 @@ _io__IOBase_readline(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *return_value = NULL;
     Py_ssize_t limit = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
-        _Py_convert_optional_to_ssize_t, &limit)) {
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
+        _Py_convert_optional_to_ssize_t, &limit)) {
         goto exit;
     }
     return_value = _io__IOBase_readline_impl(self, limit);
@@ -221,12 +221,12 @@ _io__IOBase_readlines(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObjec
     PyObject *return_value = NULL;
     Py_ssize_t hint = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:readlines",
-        _Py_convert_optional_to_ssize_t, &hint)) {
+    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:readlines",
+        _Py_convert_optional_to_ssize_t, &hint)) {
         goto exit;
     }
     return_value = _io__IOBase_readlines_impl(self, hint);
@@ -260,12 +260,12 @@ _io__RawIOBase_read(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|n:read",
-        &n)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|n:read",
+        &n)) {
         goto exit;
     }
     return_value = _io__RawIOBase_read_impl(self, n);
@@ -291,4 +291,4 @@ _io__RawIOBase_readall(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _io__RawIOBase_readall_impl(self);
 }
-/*[clinic end generated code: output=d3f59c135231baae input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8361ae8d81d072bf input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/stringio.c.h
+++ b/Modules/_io/clinic/stringio.c.h
@@ -59,12 +59,12 @@ _io_StringIO_read(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *k
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io_StringIO_read_impl(self, size);
@@ -93,12 +93,12 @@ _io_StringIO_readline(stringio *self, PyObject **args, Py_ssize_t nargs, PyObjec
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:readline",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io_StringIO_readline_impl(self, size);
@@ -129,12 +129,12 @@ _io_StringIO_truncate(stringio *self, PyObject **args, Py_ssize_t nargs, PyObjec
     PyObject *return_value = NULL;
     Py_ssize_t size = self->pos;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:truncate",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:truncate",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io_StringIO_truncate_impl(self, size);
@@ -168,12 +168,12 @@ _io_StringIO_seek(stringio *self, PyObject **args, Py_ssize_t nargs, PyObject *k
     Py_ssize_t pos;
     int whence = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "n|i:seek",
-        &pos, &whence)) {
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "n|i:seek",
+        &pos, &whence)) {
         goto exit;
     }
     return_value = _io_StringIO_seek_impl(self, pos, whence);
@@ -302,4 +302,4 @@ _io_StringIO_seekable(stringio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_StringIO_seekable_impl(self);
 }
-/*[clinic end generated code: output=03429d95ed7cd92f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=443f5dd99bbbd053 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/textio.c.h
+++ b/Modules/_io/clinic/textio.c.h
@@ -271,12 +271,12 @@ _io_TextIOWrapper_read(textio *self, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *return_value = NULL;
     Py_ssize_t n = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
-        _Py_convert_optional_to_ssize_t, &n)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
+        _Py_convert_optional_to_ssize_t, &n)) {
         goto exit;
     }
     return_value = _io_TextIOWrapper_read_impl(self, n);
@@ -302,12 +302,12 @@ _io_TextIOWrapper_readline(textio *self, PyObject **args, Py_ssize_t nargs, PyOb
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|n:readline",
-        &size)) {
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|n:readline",
+        &size)) {
         goto exit;
     }
     return_value = _io_TextIOWrapper_readline_impl(self, size);
@@ -334,12 +334,12 @@ _io_TextIOWrapper_seek(textio *self, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *cookieObj;
     int whence = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
-        &cookieObj, &whence)) {
+    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("seek", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|i:seek",
+        &cookieObj, &whence)) {
         goto exit;
     }
     return_value = _io_TextIOWrapper_seek_impl(self, cookieObj, whence);
@@ -382,13 +382,13 @@ _io_TextIOWrapper_truncate(textio *self, PyObject **args, Py_ssize_t nargs, PyOb
     PyObject *return_value = NULL;
     PyObject *pos = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "truncate",
-        0, 1,
-        &pos)) {
+    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("truncate", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "truncate",
+        0, 1,
+        &pos)) {
         goto exit;
     }
     return_value = _io_TextIOWrapper_truncate_impl(self, pos);
@@ -515,4 +515,4 @@ _io_TextIOWrapper_close(textio *self, PyObject *Py_UNUSED(ignored))
 {
     return _io_TextIOWrapper_close_impl(self);
 }
-/*[clinic end generated code: output=7d0dc8eae4b725a1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8ffc6d2557c9c620 input=a9049054013a1b77]*/

--- a/Modules/_io/clinic/winconsoleio.c.h
+++ b/Modules/_io/clinic/winconsoleio.c.h
@@ -220,12 +220,12 @@ _io__WindowsConsoleIO_read(winconsoleio *self, PyObject **args, Py_ssize_t nargs
     PyObject *return_value = NULL;
     Py_ssize_t size = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
-        _Py_convert_optional_to_ssize_t, &size)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:read",
+        _Py_convert_optional_to_ssize_t, &size)) {
         goto exit;
     }
     return_value = _io__WindowsConsoleIO_read_impl(self, size);
@@ -332,4 +332,4 @@ _io__WindowsConsoleIO_isatty(winconsoleio *self, PyObject *Py_UNUSED(ignored))
 #ifndef _IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF
     #define _IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF
 #endif /* !defined(_IO__WINDOWSCONSOLEIO_ISATTY_METHODDEF) */
-/*[clinic end generated code: output=f2a240ec6af12a20 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3bbf6f893a58f476 input=a9049054013a1b77]*/

--- a/Modules/cjkcodecs/clinic/multibytecodec.c.h
+++ b/Modules/cjkcodecs/clinic/multibytecodec.c.h
@@ -204,13 +204,13 @@ _multibytecodec_MultibyteStreamReader_read(MultibyteStreamReaderObject *self, Py
     PyObject *return_value = NULL;
     PyObject *sizeobj = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "read",
-        0, 1,
-        &sizeobj)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "read",
+        0, 1,
+        &sizeobj)) {
         goto exit;
     }
     return_value = _multibytecodec_MultibyteStreamReader_read_impl(self, sizeobj);
@@ -237,13 +237,13 @@ _multibytecodec_MultibyteStreamReader_readline(MultibyteStreamReaderObject *self
     PyObject *return_value = NULL;
     PyObject *sizeobj = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "readline",
-        0, 1,
-        &sizeobj)) {
+    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readline", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "readline",
+        0, 1,
+        &sizeobj)) {
         goto exit;
     }
     return_value = _multibytecodec_MultibyteStreamReader_readline_impl(self, sizeobj);
@@ -270,13 +270,13 @@ _multibytecodec_MultibyteStreamReader_readlines(MultibyteStreamReaderObject *sel
     PyObject *return_value = NULL;
     PyObject *sizehintobj = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "readlines",
-        0, 1,
-        &sizehintobj)) {
+    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readlines", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "readlines",
+        0, 1,
+        &sizehintobj)) {
         goto exit;
     }
     return_value = _multibytecodec_MultibyteStreamReader_readlines_impl(self, sizehintobj);
@@ -342,4 +342,4 @@ PyDoc_STRVAR(_multibytecodec___create_codec__doc__,
 
 #define _MULTIBYTECODEC___CREATE_CODEC_METHODDEF    \
     {"__create_codec", (PyCFunction)_multibytecodec___create_codec, METH_O, _multibytecodec___create_codec__doc__},
-/*[clinic end generated code: output=26710ffd4b3c7d7e input=a9049054013a1b77]*/
+/*[clinic end generated code: output=12192026a9d55d48 input=a9049054013a1b77]*/

--- a/Modules/clinic/_codecsmodule.c.h
+++ b/Modules/clinic/_codecsmodule.c.h
@@ -166,12 +166,12 @@ _codecs_escape_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "s*|z:escape_decode",
-        &data, &errors)) {
+    if (!_PyArg_NoStackKeywords("escape_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("escape_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "s*|z:escape_decode",
+        &data, &errors)) {
         goto exit;
     }
     return_value = _codecs_escape_decode_impl(module, &data, errors);
@@ -204,12 +204,12 @@ _codecs_escape_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     PyObject *data;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "O!|z:escape_encode",
-        &PyBytes_Type, &data, &errors)) {
+    if (!_PyArg_NoStackKeywords("escape_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("escape_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O!|z:escape_encode",
+        &PyBytes_Type, &data, &errors)) {
         goto exit;
     }
     return_value = _codecs_escape_encode_impl(module, data, errors);
@@ -237,12 +237,12 @@ _codecs_unicode_internal_decode(PyObject *module, PyObject **args, Py_ssize_t na
     PyObject *obj;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|z:unicode_internal_decode",
-        &obj, &errors)) {
+    if (!_PyArg_NoStackKeywords("unicode_internal_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("unicode_internal_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|z:unicode_internal_decode",
+        &obj, &errors)) {
         goto exit;
     }
     return_value = _codecs_unicode_internal_decode_impl(module, obj, errors);
@@ -271,12 +271,12 @@ _codecs_utf_7_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_7_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_7_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_7_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_7_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_7_decode_impl(module, &data, errors, final);
@@ -310,12 +310,12 @@ _codecs_utf_8_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_8_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_8_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_8_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_8_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_8_decode_impl(module, &data, errors, final);
@@ -349,12 +349,12 @@ _codecs_utf_16_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_16_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_16_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_16_decode_impl(module, &data, errors, final);
@@ -388,12 +388,12 @@ _codecs_utf_16_le_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_le_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_16_le_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_16_le_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_le_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_16_le_decode_impl(module, &data, errors, final);
@@ -427,12 +427,12 @@ _codecs_utf_16_be_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_be_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_16_be_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_16_be_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_16_be_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_16_be_decode_impl(module, &data, errors, final);
@@ -468,12 +468,12 @@ _codecs_utf_16_ex_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     int byteorder = 0;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zii:utf_16_ex_decode",
-        &data, &errors, &byteorder, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_16_ex_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_16_ex_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zii:utf_16_ex_decode",
+        &data, &errors, &byteorder, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_16_ex_decode_impl(module, &data, errors, byteorder, final);
@@ -507,12 +507,12 @@ _codecs_utf_32_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_32_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_32_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_32_decode_impl(module, &data, errors, final);
@@ -546,12 +546,12 @@ _codecs_utf_32_le_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_le_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_32_le_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_32_le_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_le_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_32_le_decode_impl(module, &data, errors, final);
@@ -585,12 +585,12 @@ _codecs_utf_32_be_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_be_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_32_be_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_32_be_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:utf_32_be_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_32_be_decode_impl(module, &data, errors, final);
@@ -626,12 +626,12 @@ _codecs_utf_32_ex_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     int byteorder = 0;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zii:utf_32_ex_decode",
-        &data, &errors, &byteorder, &final)) {
+    if (!_PyArg_NoStackKeywords("utf_32_ex_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_32_ex_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zii:utf_32_ex_decode",
+        &data, &errors, &byteorder, &final)) {
         goto exit;
     }
     return_value = _codecs_utf_32_ex_decode_impl(module, &data, errors, byteorder, final);
@@ -664,12 +664,12 @@ _codecs_unicode_escape_decode(PyObject *module, PyObject **args, Py_ssize_t narg
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "s*|z:unicode_escape_decode",
-        &data, &errors)) {
+    if (!_PyArg_NoStackKeywords("unicode_escape_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("unicode_escape_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "s*|z:unicode_escape_decode",
+        &data, &errors)) {
         goto exit;
     }
     return_value = _codecs_unicode_escape_decode_impl(module, &data, errors);
@@ -702,12 +702,12 @@ _codecs_raw_unicode_escape_decode(PyObject *module, PyObject **args, Py_ssize_t 
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "s*|z:raw_unicode_escape_decode",
-        &data, &errors)) {
+    if (!_PyArg_NoStackKeywords("raw_unicode_escape_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("raw_unicode_escape_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "s*|z:raw_unicode_escape_decode",
+        &data, &errors)) {
         goto exit;
     }
     return_value = _codecs_raw_unicode_escape_decode_impl(module, &data, errors);
@@ -740,12 +740,12 @@ _codecs_latin_1_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyOb
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|z:latin_1_decode",
-        &data, &errors)) {
+    if (!_PyArg_NoStackKeywords("latin_1_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("latin_1_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|z:latin_1_decode",
+        &data, &errors)) {
         goto exit;
     }
     return_value = _codecs_latin_1_decode_impl(module, &data, errors);
@@ -778,12 +778,12 @@ _codecs_ascii_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|z:ascii_decode",
-        &data, &errors)) {
+    if (!_PyArg_NoStackKeywords("ascii_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ascii_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|z:ascii_decode",
+        &data, &errors)) {
         goto exit;
     }
     return_value = _codecs_ascii_decode_impl(module, &data, errors);
@@ -817,12 +817,12 @@ _codecs_charmap_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyOb
     const char *errors = NULL;
     PyObject *mapping = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zO:charmap_decode",
-        &data, &errors, &mapping)) {
+    if (!_PyArg_NoStackKeywords("charmap_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("charmap_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zO:charmap_decode",
+        &data, &errors, &mapping)) {
         goto exit;
     }
     return_value = _codecs_charmap_decode_impl(module, &data, errors, mapping);
@@ -858,12 +858,12 @@ _codecs_mbcs_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:mbcs_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("mbcs_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("mbcs_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:mbcs_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_mbcs_decode_impl(module, &data, errors, final);
@@ -901,12 +901,12 @@ _codecs_oem_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|zi:oem_decode",
-        &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("oem_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("oem_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|zi:oem_decode",
+        &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_oem_decode_impl(module, &data, errors, final);
@@ -945,12 +945,12 @@ _codecs_code_page_decode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     const char *errors = NULL;
     int final = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "iy*|zi:code_page_decode",
-        &codepage, &data, &errors, &final)) {
+    if (!_PyArg_NoStackKeywords("code_page_decode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("code_page_decode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iy*|zi:code_page_decode",
+        &codepage, &data, &errors, &final)) {
         goto exit;
     }
     return_value = _codecs_code_page_decode_impl(module, codepage, &data, errors, final);
@@ -985,12 +985,12 @@ _codecs_readbuffer_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, P
     Py_buffer data = {NULL, NULL};
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "s*|z:readbuffer_encode",
-        &data, &errors)) {
+    if (!_PyArg_NoStackKeywords("readbuffer_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readbuffer_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "s*|z:readbuffer_encode",
+        &data, &errors)) {
         goto exit;
     }
     return_value = _codecs_readbuffer_encode_impl(module, &data, errors);
@@ -1023,12 +1023,12 @@ _codecs_unicode_internal_encode(PyObject *module, PyObject **args, Py_ssize_t na
     PyObject *obj;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|z:unicode_internal_encode",
-        &obj, &errors)) {
+    if (!_PyArg_NoStackKeywords("unicode_internal_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("unicode_internal_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|z:unicode_internal_encode",
+        &obj, &errors)) {
         goto exit;
     }
     return_value = _codecs_unicode_internal_encode_impl(module, obj, errors);
@@ -1056,12 +1056,12 @@ _codecs_utf_7_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_7_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("utf_7_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_7_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_7_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_utf_7_encode_impl(module, str, errors);
@@ -1089,12 +1089,12 @@ _codecs_utf_8_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_8_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("utf_8_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_8_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_8_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_utf_8_encode_impl(module, str, errors);
@@ -1123,12 +1123,12 @@ _codecs_utf_16_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     const char *errors = NULL;
     int byteorder = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|zi:utf_16_encode",
-        &str, &errors, &byteorder)) {
+    if (!_PyArg_NoStackKeywords("utf_16_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_16_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|zi:utf_16_encode",
+        &str, &errors, &byteorder)) {
         goto exit;
     }
     return_value = _codecs_utf_16_encode_impl(module, str, errors, byteorder);
@@ -1156,12 +1156,12 @@ _codecs_utf_16_le_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_16_le_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("utf_16_le_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_16_le_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_16_le_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_utf_16_le_encode_impl(module, str, errors);
@@ -1189,12 +1189,12 @@ _codecs_utf_16_be_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_16_be_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("utf_16_be_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_16_be_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_16_be_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_utf_16_be_encode_impl(module, str, errors);
@@ -1223,12 +1223,12 @@ _codecs_utf_32_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     const char *errors = NULL;
     int byteorder = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|zi:utf_32_encode",
-        &str, &errors, &byteorder)) {
+    if (!_PyArg_NoStackKeywords("utf_32_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_32_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|zi:utf_32_encode",
+        &str, &errors, &byteorder)) {
         goto exit;
     }
     return_value = _codecs_utf_32_encode_impl(module, str, errors, byteorder);
@@ -1256,12 +1256,12 @@ _codecs_utf_32_le_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_32_le_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("utf_32_le_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_32_le_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_32_le_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_utf_32_le_encode_impl(module, str, errors);
@@ -1289,12 +1289,12 @@ _codecs_utf_32_be_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_32_be_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("utf_32_be_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("utf_32_be_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:utf_32_be_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_utf_32_be_encode_impl(module, str, errors);
@@ -1322,12 +1322,12 @@ _codecs_unicode_escape_encode(PyObject *module, PyObject **args, Py_ssize_t narg
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:unicode_escape_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("unicode_escape_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("unicode_escape_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:unicode_escape_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_unicode_escape_encode_impl(module, str, errors);
@@ -1355,12 +1355,12 @@ _codecs_raw_unicode_escape_encode(PyObject *module, PyObject **args, Py_ssize_t 
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:raw_unicode_escape_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("raw_unicode_escape_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("raw_unicode_escape_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:raw_unicode_escape_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_raw_unicode_escape_encode_impl(module, str, errors);
@@ -1388,12 +1388,12 @@ _codecs_latin_1_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyOb
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:latin_1_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("latin_1_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("latin_1_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:latin_1_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_latin_1_encode_impl(module, str, errors);
@@ -1421,12 +1421,12 @@ _codecs_ascii_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:ascii_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("ascii_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ascii_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:ascii_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_ascii_encode_impl(module, str, errors);
@@ -1455,12 +1455,12 @@ _codecs_charmap_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyOb
     const char *errors = NULL;
     PyObject *mapping = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|zO:charmap_encode",
-        &str, &errors, &mapping)) {
+    if (!_PyArg_NoStackKeywords("charmap_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("charmap_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|zO:charmap_encode",
+        &str, &errors, &mapping)) {
         goto exit;
     }
     return_value = _codecs_charmap_encode_impl(module, str, errors, mapping);
@@ -1515,12 +1515,12 @@ _codecs_mbcs_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:mbcs_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("mbcs_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("mbcs_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:mbcs_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_mbcs_encode_impl(module, str, errors);
@@ -1551,12 +1551,12 @@ _codecs_oem_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "U|z:oem_encode",
-        &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("oem_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("oem_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "U|z:oem_encode",
+        &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_oem_encode_impl(module, str, errors);
@@ -1589,12 +1589,12 @@ _codecs_code_page_encode(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     PyObject *str;
     const char *errors = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "iU|z:code_page_encode",
-        &code_page, &str, &errors)) {
+    if (!_PyArg_NoStackKeywords("code_page_encode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("code_page_encode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iU|z:code_page_encode",
+        &code_page, &str, &errors)) {
         goto exit;
     }
     return_value = _codecs_code_page_encode_impl(module, code_page, str, errors);
@@ -1629,12 +1629,12 @@ _codecs_register_error(PyObject *module, PyObject **args, Py_ssize_t nargs, PyOb
     const char *errors;
     PyObject *handler;
 
-    if (!_PyArg_ParseStack(args, nargs, "sO:register_error",
-        &errors, &handler)) {
+    if (!_PyArg_NoStackKeywords("register_error", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("register_error", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "sO:register_error",
+        &errors, &handler)) {
         goto exit;
     }
     return_value = _codecs_register_error_impl(module, errors, handler);
@@ -1696,4 +1696,4 @@ exit:
 #ifndef _CODECS_CODE_PAGE_ENCODE_METHODDEF
     #define _CODECS_CODE_PAGE_ENCODE_METHODDEF
 #endif /* !defined(_CODECS_CODE_PAGE_ENCODE_METHODDEF) */
-/*[clinic end generated code: output=36fb42f450a3b4dc input=a9049054013a1b77]*/
+/*[clinic end generated code: output=11fdb992ba55fd73 input=a9049054013a1b77]*/

--- a/Modules/clinic/_cryptmodule.c.h
+++ b/Modules/clinic/_cryptmodule.c.h
@@ -26,12 +26,12 @@ crypt_crypt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     const char *word;
     const char *salt;
 
-    if (!_PyArg_ParseStack(args, nargs, "ss:crypt",
-        &word, &salt)) {
+    if (!_PyArg_NoStackKeywords("crypt", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("crypt", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ss:crypt",
+        &word, &salt)) {
         goto exit;
     }
     return_value = crypt_crypt_impl(module, word, salt);
@@ -39,4 +39,4 @@ crypt_crypt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3fd5d3625a6f32fe input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ebdc6b6a5dec4539 input=a9049054013a1b77]*/

--- a/Modules/clinic/_dbmmodule.c.h
+++ b/Modules/clinic/_dbmmodule.c.h
@@ -59,12 +59,12 @@ _dbm_dbm_get(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     Py_ssize_clean_t key_length;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "s#|O:get",
-        &key, &key_length, &default_value)) {
+    if (!_PyArg_NoStackKeywords("get", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("get", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "s#|O:get",
+        &key, &key_length, &default_value)) {
         goto exit;
     }
     return_value = _dbm_dbm_get_impl(self, key, key_length, default_value);
@@ -97,12 +97,12 @@ _dbm_dbm_setdefault(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject
     Py_ssize_clean_t key_length;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "s#|O:setdefault",
-        &key, &key_length, &default_value)) {
+    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "s#|O:setdefault",
+        &key, &key_length, &default_value)) {
         goto exit;
     }
     return_value = _dbm_dbm_setdefault_impl(self, key, key_length, default_value);
@@ -140,12 +140,12 @@ dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     const char *flags = "r";
     int mode = 438;
 
-    if (!_PyArg_ParseStack(args, nargs, "s|si:open",
-        &filename, &flags, &mode)) {
+    if (!_PyArg_NoStackKeywords("open", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("open", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "s|si:open",
+        &filename, &flags, &mode)) {
         goto exit;
     }
     return_value = dbmopen_impl(module, filename, flags, mode);
@@ -153,4 +153,4 @@ dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4fdb7be8bd03cbce input=a9049054013a1b77]*/
+/*[clinic end generated code: output=35a8df9a8e4ed18f input=a9049054013a1b77]*/

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -398,12 +398,12 @@ _elementtree_Element_insert(ElementObject *self, PyObject **args, Py_ssize_t nar
     Py_ssize_t index;
     PyObject *subelement;
 
-    if (!_PyArg_ParseStack(args, nargs, "nO!:insert",
-        &index, &Element_Type, &subelement)) {
+    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "nO!:insert",
+        &index, &Element_Type, &subelement)) {
         goto exit;
     }
     return_value = _elementtree_Element_insert_impl(self, index, subelement);
@@ -465,13 +465,13 @@ _elementtree_Element_makeelement(ElementObject *self, PyObject **args, Py_ssize_
     PyObject *tag;
     PyObject *attrib;
 
-    if (!_PyArg_UnpackStack(args, nargs, "makeelement",
-        2, 2,
-        &tag, &attrib)) {
+    if (!_PyArg_NoStackKeywords("makeelement", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("makeelement", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "makeelement",
+        2, 2,
+        &tag, &attrib)) {
         goto exit;
     }
     return_value = _elementtree_Element_makeelement_impl(self, tag, attrib);
@@ -525,13 +525,13 @@ _elementtree_Element_set(ElementObject *self, PyObject **args, Py_ssize_t nargs,
     PyObject *key;
     PyObject *value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "set",
-        2, 2,
-        &key, &value)) {
+    if (!_PyArg_NoStackKeywords("set", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("set", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "set",
+        2, 2,
+        &key, &value)) {
         goto exit;
     }
     return_value = _elementtree_Element_set_impl(self, key, value);
@@ -614,13 +614,13 @@ _elementtree_TreeBuilder_start(TreeBuilderObject *self, PyObject **args, Py_ssiz
     PyObject *tag;
     PyObject *attrs = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "start",
-        1, 2,
-        &tag, &attrs)) {
+    if (!_PyArg_NoStackKeywords("start", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("start", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "start",
+        1, 2,
+        &tag, &attrs)) {
         goto exit;
     }
     return_value = _elementtree_TreeBuilder_start_impl(self, tag, attrs);
@@ -706,13 +706,13 @@ _elementtree_XMLParser_doctype(XMLParserObject *self, PyObject **args, Py_ssize_
     PyObject *pubid;
     PyObject *system;
 
-    if (!_PyArg_UnpackStack(args, nargs, "doctype",
-        3, 3,
-        &name, &pubid, &system)) {
+    if (!_PyArg_NoStackKeywords("doctype", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("doctype", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "doctype",
+        3, 3,
+        &name, &pubid, &system)) {
         goto exit;
     }
     return_value = _elementtree_XMLParser_doctype_impl(self, name, pubid, system);
@@ -741,13 +741,13 @@ _elementtree_XMLParser__setevents(XMLParserObject *self, PyObject **args, Py_ssi
     PyObject *events_queue;
     PyObject *events_to_report = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "_setevents",
-        1, 2,
-        &events_queue, &events_to_report)) {
+    if (!_PyArg_NoStackKeywords("_setevents", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("_setevents", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "_setevents",
+        1, 2,
+        &events_queue, &events_to_report)) {
         goto exit;
     }
     return_value = _elementtree_XMLParser__setevents_impl(self, events_queue, events_to_report);
@@ -755,4 +755,4 @@ _elementtree_XMLParser__setevents(XMLParserObject *self, PyObject **args, Py_ssi
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=fbc92d64735adec0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6606b1018d2562e1 input=a9049054013a1b77]*/

--- a/Modules/clinic/_gdbmmodule.c.h
+++ b/Modules/clinic/_gdbmmodule.c.h
@@ -21,13 +21,13 @@ _gdbm_gdbm_get(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "get",
-        1, 2,
-        &key, &default_value)) {
+    if (!_PyArg_NoStackKeywords("get", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("get", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "get",
+        1, 2,
+        &key, &default_value)) {
         goto exit;
     }
     return_value = _gdbm_gdbm_get_impl(self, key, default_value);
@@ -56,13 +56,13 @@ _gdbm_gdbm_setdefault(dbmobject *self, PyObject **args, Py_ssize_t nargs, PyObje
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "setdefault",
-        1, 2,
-        &key, &default_value)) {
+    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "setdefault",
+        1, 2,
+        &key, &default_value)) {
         goto exit;
     }
     return_value = _gdbm_gdbm_setdefault_impl(self, key, default_value);
@@ -252,12 +252,12 @@ dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     const char *flags = "r";
     int mode = 438;
 
-    if (!_PyArg_ParseStack(args, nargs, "s|si:open",
-        &name, &flags, &mode)) {
+    if (!_PyArg_NoStackKeywords("open", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("open", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "s|si:open",
+        &name, &flags, &mode)) {
         goto exit;
     }
     return_value = dbmopen_impl(module, name, flags, mode);
@@ -265,4 +265,4 @@ dbmopen(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=03a3a63a814ada93 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=94c5713a85dab560 input=a9049054013a1b77]*/

--- a/Modules/clinic/_lzmamodule.c.h
+++ b/Modules/clinic/_lzmamodule.c.h
@@ -242,12 +242,12 @@ _lzma__decode_filter_properties(PyObject *module, PyObject **args, Py_ssize_t na
     lzma_vli filter_id;
     Py_buffer encoded_props = {NULL, NULL};
 
-    if (!_PyArg_ParseStack(args, nargs, "O&y*:_decode_filter_properties",
-        lzma_vli_converter, &filter_id, &encoded_props)) {
+    if (!_PyArg_NoStackKeywords("_decode_filter_properties", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("_decode_filter_properties", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&y*:_decode_filter_properties",
+        lzma_vli_converter, &filter_id, &encoded_props)) {
         goto exit;
     }
     return_value = _lzma__decode_filter_properties_impl(module, filter_id, &encoded_props);
@@ -260,4 +260,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=5f7a915fb7e41453 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=473cf89eb501c28b input=a9049054013a1b77]*/

--- a/Modules/clinic/_opcode.c.h
+++ b/Modules/clinic/_opcode.c.h
@@ -22,12 +22,12 @@ _opcode_stack_effect(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
     PyObject *oparg = Py_None;
     int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "i|O:stack_effect",
-        &opcode, &oparg)) {
+    if (!_PyArg_NoStackKeywords("stack_effect", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("stack_effect", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "i|O:stack_effect",
+        &opcode, &oparg)) {
         goto exit;
     }
     _return_value = _opcode_stack_effect_impl(module, opcode, oparg);
@@ -39,4 +39,4 @@ _opcode_stack_effect(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=62858005ac85baa9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=38f3bf305b3bb601 input=a9049054013a1b77]*/

--- a/Modules/clinic/_operator.c.h
+++ b/Modules/clinic/_operator.c.h
@@ -49,13 +49,13 @@ _operator_add(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "add",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("add", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("add", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "add",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_add_impl(module, a, b);
@@ -83,13 +83,13 @@ _operator_sub(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "sub",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("sub", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("sub", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "sub",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_sub_impl(module, a, b);
@@ -117,13 +117,13 @@ _operator_mul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "mul",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("mul", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("mul", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "mul",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_mul_impl(module, a, b);
@@ -151,13 +151,13 @@ _operator_matmul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "matmul",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("matmul", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("matmul", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "matmul",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_matmul_impl(module, a, b);
@@ -185,13 +185,13 @@ _operator_floordiv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "floordiv",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("floordiv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("floordiv", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "floordiv",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_floordiv_impl(module, a, b);
@@ -219,13 +219,13 @@ _operator_truediv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "truediv",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("truediv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("truediv", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "truediv",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_truediv_impl(module, a, b);
@@ -253,13 +253,13 @@ _operator_mod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "mod",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("mod", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("mod", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "mod",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_mod_impl(module, a, b);
@@ -332,13 +332,13 @@ _operator_lshift(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lshift",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("lshift", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lshift", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "lshift",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_lshift_impl(module, a, b);
@@ -366,13 +366,13 @@ _operator_rshift(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "rshift",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("rshift", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("rshift", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "rshift",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_rshift_impl(module, a, b);
@@ -428,13 +428,13 @@ _operator_and_(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "and_",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("and_", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("and_", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "and_",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_and__impl(module, a, b);
@@ -462,13 +462,13 @@ _operator_xor(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "xor",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("xor", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("xor", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "xor",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_xor_impl(module, a, b);
@@ -496,13 +496,13 @@ _operator_or_(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "or_",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("or_", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("or_", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "or_",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_or__impl(module, a, b);
@@ -530,13 +530,13 @@ _operator_iadd(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "iadd",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("iadd", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("iadd", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "iadd",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_iadd_impl(module, a, b);
@@ -564,13 +564,13 @@ _operator_isub(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "isub",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("isub", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("isub", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "isub",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_isub_impl(module, a, b);
@@ -598,13 +598,13 @@ _operator_imul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "imul",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("imul", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("imul", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "imul",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_imul_impl(module, a, b);
@@ -632,13 +632,13 @@ _operator_imatmul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "imatmul",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("imatmul", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("imatmul", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "imatmul",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_imatmul_impl(module, a, b);
@@ -666,13 +666,13 @@ _operator_ifloordiv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ifloordiv",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("ifloordiv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ifloordiv", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "ifloordiv",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_ifloordiv_impl(module, a, b);
@@ -700,13 +700,13 @@ _operator_itruediv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "itruediv",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("itruediv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("itruediv", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "itruediv",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_itruediv_impl(module, a, b);
@@ -734,13 +734,13 @@ _operator_imod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "imod",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("imod", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("imod", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "imod",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_imod_impl(module, a, b);
@@ -768,13 +768,13 @@ _operator_ilshift(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ilshift",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("ilshift", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ilshift", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "ilshift",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_ilshift_impl(module, a, b);
@@ -802,13 +802,13 @@ _operator_irshift(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "irshift",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("irshift", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("irshift", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "irshift",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_irshift_impl(module, a, b);
@@ -836,13 +836,13 @@ _operator_iand(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "iand",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("iand", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("iand", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "iand",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_iand_impl(module, a, b);
@@ -870,13 +870,13 @@ _operator_ixor(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ixor",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("ixor", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ixor", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "ixor",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_ixor_impl(module, a, b);
@@ -904,13 +904,13 @@ _operator_ior(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ior",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("ior", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ior", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "ior",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_ior_impl(module, a, b);
@@ -938,13 +938,13 @@ _operator_concat(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "concat",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("concat", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("concat", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "concat",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_concat_impl(module, a, b);
@@ -972,13 +972,13 @@ _operator_iconcat(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "iconcat",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("iconcat", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("iconcat", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "iconcat",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_iconcat_impl(module, a, b);
@@ -1007,13 +1007,13 @@ _operator_contains(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *b;
     int _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "contains",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("contains", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("contains", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "contains",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     _return_value = _operator_contains_impl(module, a, b);
@@ -1046,13 +1046,13 @@ _operator_indexOf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *b;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "indexOf",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("indexOf", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("indexOf", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "indexOf",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     _return_value = _operator_indexOf_impl(module, a, b);
@@ -1085,13 +1085,13 @@ _operator_countOf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *b;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "countOf",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("countOf", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("countOf", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "countOf",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     _return_value = _operator_countOf_impl(module, a, b);
@@ -1123,13 +1123,13 @@ _operator_getitem(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "getitem",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("getitem", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("getitem", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "getitem",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_getitem_impl(module, a, b);
@@ -1159,13 +1159,13 @@ _operator_setitem(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *b;
     PyObject *c;
 
-    if (!_PyArg_UnpackStack(args, nargs, "setitem",
-        3, 3,
-        &a, &b, &c)) {
+    if (!_PyArg_NoStackKeywords("setitem", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setitem", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "setitem",
+        3, 3,
+        &a, &b, &c)) {
         goto exit;
     }
     return_value = _operator_setitem_impl(module, a, b, c);
@@ -1193,13 +1193,13 @@ _operator_delitem(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "delitem",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("delitem", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("delitem", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "delitem",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_delitem_impl(module, a, b);
@@ -1227,13 +1227,13 @@ _operator_eq(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "eq",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("eq", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("eq", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "eq",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_eq_impl(module, a, b);
@@ -1261,13 +1261,13 @@ _operator_ne(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ne",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("ne", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ne", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "ne",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_ne_impl(module, a, b);
@@ -1295,13 +1295,13 @@ _operator_lt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lt",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("lt", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lt", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "lt",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_lt_impl(module, a, b);
@@ -1329,13 +1329,13 @@ _operator_le(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "le",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("le", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("le", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "le",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_le_impl(module, a, b);
@@ -1363,13 +1363,13 @@ _operator_gt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "gt",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("gt", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("gt", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "gt",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_gt_impl(module, a, b);
@@ -1397,13 +1397,13 @@ _operator_ge(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ge",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("ge", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ge", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "ge",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_ge_impl(module, a, b);
@@ -1431,13 +1431,13 @@ _operator_pow(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "pow",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "pow",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_pow_impl(module, a, b);
@@ -1465,13 +1465,13 @@ _operator_ipow(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "ipow",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("ipow", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ipow", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "ipow",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_ipow_impl(module, a, b);
@@ -1508,13 +1508,13 @@ _operator_is_(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "is_",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("is_", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("is_", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "is_",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_is__impl(module, a, b);
@@ -1542,13 +1542,13 @@ _operator_is_not(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "is_not",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("is_not", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("is_not", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "is_not",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator_is_not_impl(module, a, b);
@@ -1584,12 +1584,12 @@ _operator_length_hint(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     Py_ssize_t default_value = 0;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|n:length_hint",
-        &obj, &default_value)) {
+    if (!_PyArg_NoStackKeywords("length_hint", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("length_hint", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|n:length_hint",
+        &obj, &default_value)) {
         goto exit;
     }
     _return_value = _operator_length_hint_impl(module, obj, default_value);
@@ -1631,13 +1631,13 @@ _operator__compare_digest(PyObject *module, PyObject **args, Py_ssize_t nargs, P
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "_compare_digest",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("_compare_digest", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("_compare_digest", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "_compare_digest",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = _operator__compare_digest_impl(module, a, b);
@@ -1645,4 +1645,4 @@ _operator__compare_digest(PyObject *module, PyObject **args, Py_ssize_t nargs, P
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=c030b6747fddd9c6 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fa8d3eeea396bbec input=a9049054013a1b77]*/

--- a/Modules/clinic/_pickle.c.h
+++ b/Modules/clinic/_pickle.c.h
@@ -213,13 +213,13 @@ _pickle_Unpickler_find_class(UnpicklerObject *self, PyObject **args, Py_ssize_t 
     PyObject *module_name;
     PyObject *global_name;
 
-    if (!_PyArg_UnpackStack(args, nargs, "find_class",
-        2, 2,
-        &module_name, &global_name)) {
+    if (!_PyArg_NoStackKeywords("find_class", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("find_class", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "find_class",
+        2, 2,
+        &module_name, &global_name)) {
         goto exit;
     }
     return_value = _pickle_Unpickler_find_class_impl(self, module_name, global_name);
@@ -564,4 +564,4 @@ _pickle_loads(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b921d325b2f7a096 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=639dd0eb8de16c3c input=a9049054013a1b77]*/

--- a/Modules/clinic/_sre.c.h
+++ b/Modules/clinic/_sre.c.h
@@ -629,13 +629,13 @@ _sre_SRE_Match_start(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyObj
     PyObject *group = NULL;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "start",
-        0, 1,
-        &group)) {
+    if (!_PyArg_NoStackKeywords("start", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("start", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "start",
+        0, 1,
+        &group)) {
         goto exit;
     }
     _return_value = _sre_SRE_Match_start_impl(self, group);
@@ -667,13 +667,13 @@ _sre_SRE_Match_end(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyObjec
     PyObject *group = NULL;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "end",
-        0, 1,
-        &group)) {
+    if (!_PyArg_NoStackKeywords("end", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("end", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "end",
+        0, 1,
+        &group)) {
         goto exit;
     }
     _return_value = _sre_SRE_Match_end_impl(self, group);
@@ -704,13 +704,13 @@ _sre_SRE_Match_span(MatchObject *self, PyObject **args, Py_ssize_t nargs, PyObje
     PyObject *return_value = NULL;
     PyObject *group = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "span",
-        0, 1,
-        &group)) {
+    if (!_PyArg_NoStackKeywords("span", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("span", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "span",
+        0, 1,
+        &group)) {
         goto exit;
     }
     return_value = _sre_SRE_Match_span_impl(self, group);
@@ -777,4 +777,4 @@ _sre_SRE_Scanner_search(ScannerObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _sre_SRE_Scanner_search_impl(self);
 }
-/*[clinic end generated code: output=5fe47c49e475cccb input=a9049054013a1b77]*/
+/*[clinic end generated code: output=28b0cc05da4ac219 input=a9049054013a1b77]*/

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -71,12 +71,12 @@ _ssl__SSLSocket_peer_certificate(PySSLSocket *self, PyObject **args, Py_ssize_t 
     PyObject *return_value = NULL;
     int binary_mode = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "|p:peer_certificate",
-        &binary_mode)) {
+    if (!_PyArg_NoStackKeywords("peer_certificate", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("peer_certificate", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|p:peer_certificate",
+        &binary_mode)) {
         goto exit;
     }
     return_value = _ssl__SSLSocket_peer_certificate_impl(self, binary_mode);
@@ -772,12 +772,12 @@ _ssl_MemoryBIO_read(PySSLMemoryBIO *self, PyObject **args, Py_ssize_t nargs, PyO
     PyObject *return_value = NULL;
     int len = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|i:read",
-        &len)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|i:read",
+        &len)) {
         goto exit;
     }
     return_value = _ssl_MemoryBIO_read_impl(self, len);
@@ -862,12 +862,12 @@ _ssl_RAND_add(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     Py_buffer view = {NULL, NULL};
     double entropy;
 
-    if (!_PyArg_ParseStack(args, nargs, "s*d:RAND_add",
-        &view, &entropy)) {
+    if (!_PyArg_NoStackKeywords("RAND_add", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("RAND_add", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "s*d:RAND_add",
+        &view, &entropy)) {
         goto exit;
     }
     return_value = _ssl_RAND_add_impl(module, &view, entropy);
@@ -1180,4 +1180,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=53cd9100580b45a2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2ab0e4fdb2d2acbc input=a9049054013a1b77]*/

--- a/Modules/clinic/_struct.c.h
+++ b/Modules/clinic/_struct.c.h
@@ -204,12 +204,12 @@ unpack(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     PyStructObject *s_object = NULL;
     Py_buffer buffer = {NULL, NULL};
 
-    if (!_PyArg_ParseStack(args, nargs, "O&y*:unpack",
-        cache_struct_converter, &s_object, &buffer)) {
+    if (!_PyArg_NoStackKeywords("unpack", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("unpack", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&y*:unpack",
+        cache_struct_converter, &s_object, &buffer)) {
         goto exit;
     }
     return_value = unpack_impl(module, s_object, &buffer);
@@ -294,12 +294,12 @@ iter_unpack(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyStructObject *s_object = NULL;
     PyObject *buffer;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&O:iter_unpack",
-        cache_struct_converter, &s_object, &buffer)) {
+    if (!_PyArg_NoStackKeywords("iter_unpack", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("iter_unpack", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&O:iter_unpack",
+        cache_struct_converter, &s_object, &buffer)) {
         goto exit;
     }
     return_value = iter_unpack_impl(module, s_object, buffer);
@@ -310,4 +310,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=03e0d193ab1983f9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=351350320f31ca82 input=a9049054013a1b77]*/

--- a/Modules/clinic/_tkinter.c.h
+++ b/Modules/clinic/_tkinter.c.h
@@ -269,12 +269,12 @@ _tkinter_tkapp_createcommand(TkappObject *self, PyObject **args, Py_ssize_t narg
     const char *name;
     PyObject *func;
 
-    if (!_PyArg_ParseStack(args, nargs, "sO:createcommand",
-        &name, &func)) {
+    if (!_PyArg_NoStackKeywords("createcommand", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("createcommand", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "sO:createcommand",
+        &name, &func)) {
         goto exit;
     }
     return_value = _tkinter_tkapp_createcommand_impl(self, name, func);
@@ -331,12 +331,12 @@ _tkinter_tkapp_createfilehandler(TkappObject *self, PyObject **args, Py_ssize_t 
     int mask;
     PyObject *func;
 
-    if (!_PyArg_ParseStack(args, nargs, "OiO:createfilehandler",
-        &file, &mask, &func)) {
+    if (!_PyArg_NoStackKeywords("createfilehandler", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("createfilehandler", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "OiO:createfilehandler",
+        &file, &mask, &func)) {
         goto exit;
     }
     return_value = _tkinter_tkapp_createfilehandler_impl(self, file, mask, func);
@@ -395,12 +395,12 @@ _tkinter_tkapp_createtimerhandler(TkappObject *self, PyObject **args, Py_ssize_t
     int milliseconds;
     PyObject *func;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO:createtimerhandler",
-        &milliseconds, &func)) {
+    if (!_PyArg_NoStackKeywords("createtimerhandler", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("createtimerhandler", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO:createtimerhandler",
+        &milliseconds, &func)) {
         goto exit;
     }
     return_value = _tkinter_tkapp_createtimerhandler_impl(self, milliseconds, func);
@@ -426,12 +426,12 @@ _tkinter_tkapp_mainloop(TkappObject *self, PyObject **args, Py_ssize_t nargs, Py
     PyObject *return_value = NULL;
     int threshold = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "|i:mainloop",
-        &threshold)) {
+    if (!_PyArg_NoStackKeywords("mainloop", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("mainloop", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|i:mainloop",
+        &threshold)) {
         goto exit;
     }
     return_value = _tkinter_tkapp_mainloop_impl(self, threshold);
@@ -457,12 +457,12 @@ _tkinter_tkapp_dooneevent(TkappObject *self, PyObject **args, Py_ssize_t nargs, 
     PyObject *return_value = NULL;
     int flags = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "|i:dooneevent",
-        &flags)) {
+    if (!_PyArg_NoStackKeywords("dooneevent", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("dooneevent", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|i:dooneevent",
+        &flags)) {
         goto exit;
     }
     return_value = _tkinter_tkapp_dooneevent_impl(self, flags);
@@ -584,12 +584,12 @@ _tkinter_create(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     int sync = 0;
     const char *use = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "|zssiiiiz:create",
-        &screenName, &baseName, &className, &interactive, &wantobjects, &wantTk, &sync, &use)) {
+    if (!_PyArg_NoStackKeywords("create", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("create", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|zssiiiiz:create",
+        &screenName, &baseName, &className, &interactive, &wantobjects, &wantTk, &sync, &use)) {
         goto exit;
     }
     return_value = _tkinter_create_impl(module, screenName, baseName, className, interactive, wantobjects, wantTk, sync, use);
@@ -662,4 +662,4 @@ exit:
 #ifndef _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
     #define _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
 #endif /* !defined(_TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF) */
-/*[clinic end generated code: output=328e29a146c4a63b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ed14e0bb0cd9c8e0 input=a9049054013a1b77]*/

--- a/Modules/clinic/_tracemalloc.c.h
+++ b/Modules/clinic/_tracemalloc.c.h
@@ -95,12 +95,12 @@ _tracemalloc_start(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *return_value = NULL;
     Py_ssize_t nframe = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|n:start",
-        &nframe)) {
+    if (!_PyArg_NoStackKeywords("start", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("start", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|n:start",
+        &nframe)) {
         goto exit;
     }
     return_value = _tracemalloc_start_impl(module, nframe);
@@ -189,4 +189,4 @@ _tracemalloc_get_traced_memory(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     return _tracemalloc_get_traced_memory_impl(module);
 }
-/*[clinic end generated code: output=159ce5d627964f09 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ca7b197d1bdcdf27 input=a9049054013a1b77]*/

--- a/Modules/clinic/_weakref.c.h
+++ b/Modules/clinic/_weakref.c.h
@@ -50,12 +50,12 @@ _weakref__remove_dead_weakref(PyObject *module, PyObject **args, Py_ssize_t narg
     PyObject *dct;
     PyObject *key;
 
-    if (!_PyArg_ParseStack(args, nargs, "O!O:_remove_dead_weakref",
-        &PyDict_Type, &dct, &key)) {
+    if (!_PyArg_NoStackKeywords("_remove_dead_weakref", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("_remove_dead_weakref", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O!O:_remove_dead_weakref",
+        &PyDict_Type, &dct, &key)) {
         goto exit;
     }
     return_value = _weakref__remove_dead_weakref_impl(module, dct, key);
@@ -63,4 +63,4 @@ _weakref__remove_dead_weakref(PyObject *module, PyObject **args, Py_ssize_t narg
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b686303486bdfefd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=05ecbb46c85839a2 input=a9049054013a1b77]*/

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -150,12 +150,12 @@ _winapi_CreateFile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     HANDLE template_file;
     HANDLE _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "skk" F_POINTER "kk" F_HANDLE ":CreateFile",
-        &file_name, &desired_access, &share_mode, &security_attributes, &creation_disposition, &flags_and_attributes, &template_file)) {
+    if (!_PyArg_NoStackKeywords("CreateFile", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("CreateFile", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "skk" F_POINTER "kk" F_HANDLE ":CreateFile",
+        &file_name, &desired_access, &share_mode, &security_attributes, &creation_disposition, &flags_and_attributes, &template_file)) {
         goto exit;
     }
     _return_value = _winapi_CreateFile_impl(module, file_name, desired_access, share_mode, security_attributes, creation_disposition, flags_and_attributes, template_file);
@@ -190,12 +190,12 @@ _winapi_CreateJunction(PyObject *module, PyObject **args, Py_ssize_t nargs, PyOb
     LPWSTR src_path;
     LPWSTR dst_path;
 
-    if (!_PyArg_ParseStack(args, nargs, "uu:CreateJunction",
-        &src_path, &dst_path)) {
+    if (!_PyArg_NoStackKeywords("CreateJunction", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("CreateJunction", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "uu:CreateJunction",
+        &src_path, &dst_path)) {
         goto exit;
     }
     return_value = _winapi_CreateJunction_impl(module, src_path, dst_path);
@@ -235,12 +235,12 @@ _winapi_CreateNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs, PyO
     LPSECURITY_ATTRIBUTES security_attributes;
     HANDLE _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "skkkkkk" F_POINTER ":CreateNamedPipe",
-        &name, &open_mode, &pipe_mode, &max_instances, &out_buffer_size, &in_buffer_size, &default_timeout, &security_attributes)) {
+    if (!_PyArg_NoStackKeywords("CreateNamedPipe", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("CreateNamedPipe", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "skkkkkk" F_POINTER ":CreateNamedPipe",
+        &name, &open_mode, &pipe_mode, &max_instances, &out_buffer_size, &in_buffer_size, &default_timeout, &security_attributes)) {
         goto exit;
     }
     _return_value = _winapi_CreateNamedPipe_impl(module, name, open_mode, pipe_mode, max_instances, out_buffer_size, in_buffer_size, default_timeout, security_attributes);
@@ -280,12 +280,12 @@ _winapi_CreatePipe(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *pipe_attrs;
     DWORD size;
 
-    if (!_PyArg_ParseStack(args, nargs, "Ok:CreatePipe",
-        &pipe_attrs, &size)) {
+    if (!_PyArg_NoStackKeywords("CreatePipe", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("CreatePipe", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "Ok:CreatePipe",
+        &pipe_attrs, &size)) {
         goto exit;
     }
     return_value = _winapi_CreatePipe_impl(module, pipe_attrs, size);
@@ -335,12 +335,12 @@ _winapi_CreateProcess(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     Py_UNICODE *current_directory;
     PyObject *startup_info;
 
-    if (!_PyArg_ParseStack(args, nargs, "ZZOOikOZO:CreateProcess",
-        &application_name, &command_line, &proc_attrs, &thread_attrs, &inherit_handles, &creation_flags, &env_mapping, &current_directory, &startup_info)) {
+    if (!_PyArg_NoStackKeywords("CreateProcess", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("CreateProcess", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ZZOOikOZO:CreateProcess",
+        &application_name, &command_line, &proc_attrs, &thread_attrs, &inherit_handles, &creation_flags, &env_mapping, &current_directory, &startup_info)) {
         goto exit;
     }
     return_value = _winapi_CreateProcess_impl(module, application_name, command_line, proc_attrs, thread_attrs, inherit_handles, creation_flags, env_mapping, current_directory, startup_info);
@@ -383,12 +383,12 @@ _winapi_DuplicateHandle(PyObject *module, PyObject **args, Py_ssize_t nargs, PyO
     DWORD options = 0;
     HANDLE _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "" F_HANDLE "" F_HANDLE "ki|k:DuplicateHandle",
-        &source_process_handle, &source_handle, &target_process_handle, &desired_access, &inherit_handle, &options)) {
+    if (!_PyArg_NoStackKeywords("DuplicateHandle", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("DuplicateHandle", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "" F_HANDLE "" F_HANDLE "ki|k:DuplicateHandle",
+        &source_process_handle, &source_handle, &target_process_handle, &desired_access, &inherit_handle, &options)) {
         goto exit;
     }
     _return_value = _winapi_DuplicateHandle_impl(module, source_process_handle, source_handle, target_process_handle, desired_access, inherit_handle, options);
@@ -643,12 +643,12 @@ _winapi_OpenProcess(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     DWORD process_id;
     HANDLE _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "kik:OpenProcess",
-        &desired_access, &inherit_handle, &process_id)) {
+    if (!_PyArg_NoStackKeywords("OpenProcess", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("OpenProcess", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "kik:OpenProcess",
+        &desired_access, &inherit_handle, &process_id)) {
         goto exit;
     }
     _return_value = _winapi_OpenProcess_impl(module, desired_access, inherit_handle, process_id);
@@ -682,12 +682,12 @@ _winapi_PeekNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     HANDLE handle;
     int size = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "|i:PeekNamedPipe",
-        &handle, &size)) {
+    if (!_PyArg_NoStackKeywords("PeekNamedPipe", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("PeekNamedPipe", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "|i:PeekNamedPipe",
+        &handle, &size)) {
         goto exit;
     }
     return_value = _winapi_PeekNamedPipe_impl(module, handle, size);
@@ -752,12 +752,12 @@ _winapi_SetNamedPipeHandleState(PyObject *module, PyObject **args, Py_ssize_t na
     PyObject *max_collection_count;
     PyObject *collect_data_timeout;
 
-    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "OOO:SetNamedPipeHandleState",
-        &named_pipe, &mode, &max_collection_count, &collect_data_timeout)) {
+    if (!_PyArg_NoStackKeywords("SetNamedPipeHandleState", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("SetNamedPipeHandleState", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "OOO:SetNamedPipeHandleState",
+        &named_pipe, &mode, &max_collection_count, &collect_data_timeout)) {
         goto exit;
     }
     return_value = _winapi_SetNamedPipeHandleState_impl(module, named_pipe, mode, max_collection_count, collect_data_timeout);
@@ -786,12 +786,12 @@ _winapi_TerminateProcess(PyObject *module, PyObject **args, Py_ssize_t nargs, Py
     HANDLE handle;
     UINT exit_code;
 
-    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "I:TerminateProcess",
-        &handle, &exit_code)) {
+    if (!_PyArg_NoStackKeywords("TerminateProcess", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("TerminateProcess", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "I:TerminateProcess",
+        &handle, &exit_code)) {
         goto exit;
     }
     return_value = _winapi_TerminateProcess_impl(module, handle, exit_code);
@@ -818,12 +818,12 @@ _winapi_WaitNamedPipe(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     LPCTSTR name;
     DWORD timeout;
 
-    if (!_PyArg_ParseStack(args, nargs, "sk:WaitNamedPipe",
-        &name, &timeout)) {
+    if (!_PyArg_NoStackKeywords("WaitNamedPipe", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("WaitNamedPipe", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "sk:WaitNamedPipe",
+        &name, &timeout)) {
         goto exit;
     }
     return_value = _winapi_WaitNamedPipe_impl(module, name, timeout);
@@ -853,12 +853,12 @@ _winapi_WaitForMultipleObjects(PyObject *module, PyObject **args, Py_ssize_t nar
     BOOL wait_flag;
     DWORD milliseconds = INFINITE;
 
-    if (!_PyArg_ParseStack(args, nargs, "Oi|k:WaitForMultipleObjects",
-        &handle_seq, &wait_flag, &milliseconds)) {
+    if (!_PyArg_NoStackKeywords("WaitForMultipleObjects", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("WaitForMultipleObjects", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "Oi|k:WaitForMultipleObjects",
+        &handle_seq, &wait_flag, &milliseconds)) {
         goto exit;
     }
     return_value = _winapi_WaitForMultipleObjects_impl(module, handle_seq, wait_flag, milliseconds);
@@ -892,12 +892,12 @@ _winapi_WaitForSingleObject(PyObject *module, PyObject **args, Py_ssize_t nargs,
     DWORD milliseconds;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "k:WaitForSingleObject",
-        &handle, &milliseconds)) {
+    if (!_PyArg_NoStackKeywords("WaitForSingleObject", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("WaitForSingleObject", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" F_HANDLE "k:WaitForSingleObject",
+        &handle, &milliseconds)) {
         goto exit;
     }
     _return_value = _winapi_WaitForSingleObject_impl(module, handle, milliseconds);
@@ -941,4 +941,4 @@ _winapi_WriteFile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2beb984508fb040a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9555c16ed2d95a9f input=a9049054013a1b77]*/

--- a/Modules/clinic/arraymodule.c.h
+++ b/Modules/clinic/arraymodule.c.h
@@ -76,12 +76,12 @@ array_array_pop(arrayobject *self, PyObject **args, Py_ssize_t nargs, PyObject *
     PyObject *return_value = NULL;
     Py_ssize_t i = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|n:pop",
-        &i)) {
+    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|n:pop",
+        &i)) {
         goto exit;
     }
     return_value = array_array_pop_impl(self, i);
@@ -118,12 +118,12 @@ array_array_insert(arrayobject *self, PyObject **args, Py_ssize_t nargs, PyObjec
     Py_ssize_t i;
     PyObject *v;
 
-    if (!_PyArg_ParseStack(args, nargs, "nO:insert",
-        &i, &v)) {
+    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "nO:insert",
+        &i, &v)) {
         goto exit;
     }
     return_value = array_array_insert_impl(self, i, v);
@@ -220,12 +220,12 @@ array_array_fromfile(arrayobject *self, PyObject **args, Py_ssize_t nargs, PyObj
     PyObject *f;
     Py_ssize_t n;
 
-    if (!_PyArg_ParseStack(args, nargs, "On:fromfile",
-        &f, &n)) {
+    if (!_PyArg_NoStackKeywords("fromfile", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("fromfile", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "On:fromfile",
+        &f, &n)) {
         goto exit;
     }
     return_value = array_array_fromfile_impl(self, f, n);
@@ -472,12 +472,12 @@ array__array_reconstructor(PyObject *module, PyObject **args, Py_ssize_t nargs, 
     enum machine_format_code mformat_code;
     PyObject *items;
 
-    if (!_PyArg_ParseStack(args, nargs, "OCiO:_array_reconstructor",
-        &arraytype, &typecode, &mformat_code, &items)) {
+    if (!_PyArg_NoStackKeywords("_array_reconstructor", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("_array_reconstructor", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "OCiO:_array_reconstructor",
+        &arraytype, &typecode, &mformat_code, &items)) {
         goto exit;
     }
     return_value = array__array_reconstructor_impl(module, arraytype, typecode, mformat_code, items);
@@ -521,4 +521,4 @@ PyDoc_STRVAR(array_arrayiterator___setstate____doc__,
 
 #define ARRAY_ARRAYITERATOR___SETSTATE___METHODDEF    \
     {"__setstate__", (PyCFunction)array_arrayiterator___setstate__, METH_O, array_arrayiterator___setstate____doc__},
-/*[clinic end generated code: output=d186a7553c1f1a41 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=fb4a67e697d7c0b0 input=a9049054013a1b77]*/

--- a/Modules/clinic/audioop.c.h
+++ b/Modules/clinic/audioop.c.h
@@ -23,12 +23,12 @@ audioop_getsample(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     int width;
     Py_ssize_t index;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*in:getsample",
-        &fragment, &width, &index)) {
+    if (!_PyArg_NoStackKeywords("getsample", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("getsample", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*in:getsample",
+        &fragment, &width, &index)) {
         goto exit;
     }
     return_value = audioop_getsample_impl(module, &fragment, width, index);
@@ -61,12 +61,12 @@ audioop_max(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:max",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("max", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("max", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:max",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_max_impl(module, &fragment, width);
@@ -99,12 +99,12 @@ audioop_minmax(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:minmax",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("minmax", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("minmax", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:minmax",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_minmax_impl(module, &fragment, width);
@@ -137,12 +137,12 @@ audioop_avg(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:avg",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("avg", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("avg", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:avg",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_avg_impl(module, &fragment, width);
@@ -175,12 +175,12 @@ audioop_rms(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:rms",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("rms", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("rms", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:rms",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_rms_impl(module, &fragment, width);
@@ -214,12 +214,12 @@ audioop_findfit(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     Py_buffer fragment = {NULL, NULL};
     Py_buffer reference = {NULL, NULL};
 
-    if (!_PyArg_ParseStack(args, nargs, "y*y*:findfit",
-        &fragment, &reference)) {
+    if (!_PyArg_NoStackKeywords("findfit", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("findfit", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*y*:findfit",
+        &fragment, &reference)) {
         goto exit;
     }
     return_value = audioop_findfit_impl(module, &fragment, &reference);
@@ -257,12 +257,12 @@ audioop_findfactor(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     Py_buffer fragment = {NULL, NULL};
     Py_buffer reference = {NULL, NULL};
 
-    if (!_PyArg_ParseStack(args, nargs, "y*y*:findfactor",
-        &fragment, &reference)) {
+    if (!_PyArg_NoStackKeywords("findfactor", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("findfactor", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*y*:findfactor",
+        &fragment, &reference)) {
         goto exit;
     }
     return_value = audioop_findfactor_impl(module, &fragment, &reference);
@@ -300,12 +300,12 @@ audioop_findmax(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     Py_buffer fragment = {NULL, NULL};
     Py_ssize_t length;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*n:findmax",
-        &fragment, &length)) {
+    if (!_PyArg_NoStackKeywords("findmax", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("findmax", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*n:findmax",
+        &fragment, &length)) {
         goto exit;
     }
     return_value = audioop_findmax_impl(module, &fragment, length);
@@ -338,12 +338,12 @@ audioop_avgpp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:avgpp",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("avgpp", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("avgpp", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:avgpp",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_avgpp_impl(module, &fragment, width);
@@ -376,12 +376,12 @@ audioop_maxpp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:maxpp",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("maxpp", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("maxpp", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:maxpp",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_maxpp_impl(module, &fragment, width);
@@ -414,12 +414,12 @@ audioop_cross(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:cross",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("cross", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("cross", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:cross",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_cross_impl(module, &fragment, width);
@@ -454,12 +454,12 @@ audioop_mul(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     int width;
     double factor;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*id:mul",
-        &fragment, &width, &factor)) {
+    if (!_PyArg_NoStackKeywords("mul", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("mul", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*id:mul",
+        &fragment, &width, &factor)) {
         goto exit;
     }
     return_value = audioop_mul_impl(module, &fragment, width, factor);
@@ -495,12 +495,12 @@ audioop_tomono(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     double lfactor;
     double rfactor;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*idd:tomono",
-        &fragment, &width, &lfactor, &rfactor)) {
+    if (!_PyArg_NoStackKeywords("tomono", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("tomono", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*idd:tomono",
+        &fragment, &width, &lfactor, &rfactor)) {
         goto exit;
     }
     return_value = audioop_tomono_impl(module, &fragment, width, lfactor, rfactor);
@@ -536,12 +536,12 @@ audioop_tostereo(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     double lfactor;
     double rfactor;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*idd:tostereo",
-        &fragment, &width, &lfactor, &rfactor)) {
+    if (!_PyArg_NoStackKeywords("tostereo", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("tostereo", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*idd:tostereo",
+        &fragment, &width, &lfactor, &rfactor)) {
         goto exit;
     }
     return_value = audioop_tostereo_impl(module, &fragment, width, lfactor, rfactor);
@@ -576,12 +576,12 @@ audioop_add(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     Py_buffer fragment2 = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*y*i:add",
-        &fragment1, &fragment2, &width)) {
+    if (!_PyArg_NoStackKeywords("add", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("add", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*y*i:add",
+        &fragment1, &fragment2, &width)) {
         goto exit;
     }
     return_value = audioop_add_impl(module, &fragment1, &fragment2, width);
@@ -619,12 +619,12 @@ audioop_bias(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     int width;
     int bias;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*ii:bias",
-        &fragment, &width, &bias)) {
+    if (!_PyArg_NoStackKeywords("bias", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("bias", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*ii:bias",
+        &fragment, &width, &bias)) {
         goto exit;
     }
     return_value = audioop_bias_impl(module, &fragment, width, bias);
@@ -657,12 +657,12 @@ audioop_reverse(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:reverse",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("reverse", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("reverse", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:reverse",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_reverse_impl(module, &fragment, width);
@@ -695,12 +695,12 @@ audioop_byteswap(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:byteswap",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("byteswap", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("byteswap", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:byteswap",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_byteswap_impl(module, &fragment, width);
@@ -735,12 +735,12 @@ audioop_lin2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     int width;
     int newwidth;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*ii:lin2lin",
-        &fragment, &width, &newwidth)) {
+    if (!_PyArg_NoStackKeywords("lin2lin", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lin2lin", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*ii:lin2lin",
+        &fragment, &width, &newwidth)) {
         goto exit;
     }
     return_value = audioop_lin2lin_impl(module, &fragment, width, newwidth);
@@ -782,12 +782,12 @@ audioop_ratecv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     int weightA = 1;
     int weightB = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*iiiiO|ii:ratecv",
-        &fragment, &width, &nchannels, &inrate, &outrate, &state, &weightA, &weightB)) {
+    if (!_PyArg_NoStackKeywords("ratecv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ratecv", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*iiiiO|ii:ratecv",
+        &fragment, &width, &nchannels, &inrate, &outrate, &state, &weightA, &weightB)) {
         goto exit;
     }
     return_value = audioop_ratecv_impl(module, &fragment, width, nchannels, inrate, outrate, state, weightA, weightB);
@@ -820,12 +820,12 @@ audioop_lin2ulaw(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:lin2ulaw",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("lin2ulaw", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lin2ulaw", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:lin2ulaw",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_lin2ulaw_impl(module, &fragment, width);
@@ -858,12 +858,12 @@ audioop_ulaw2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:ulaw2lin",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("ulaw2lin", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ulaw2lin", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:ulaw2lin",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_ulaw2lin_impl(module, &fragment, width);
@@ -896,12 +896,12 @@ audioop_lin2alaw(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:lin2alaw",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("lin2alaw", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lin2alaw", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:lin2alaw",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_lin2alaw_impl(module, &fragment, width);
@@ -934,12 +934,12 @@ audioop_alaw2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     Py_buffer fragment = {NULL, NULL};
     int width;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*i:alaw2lin",
-        &fragment, &width)) {
+    if (!_PyArg_NoStackKeywords("alaw2lin", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("alaw2lin", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*i:alaw2lin",
+        &fragment, &width)) {
         goto exit;
     }
     return_value = audioop_alaw2lin_impl(module, &fragment, width);
@@ -974,12 +974,12 @@ audioop_lin2adpcm(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     int width;
     PyObject *state;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*iO:lin2adpcm",
-        &fragment, &width, &state)) {
+    if (!_PyArg_NoStackKeywords("lin2adpcm", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lin2adpcm", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*iO:lin2adpcm",
+        &fragment, &width, &state)) {
         goto exit;
     }
     return_value = audioop_lin2adpcm_impl(module, &fragment, width, state);
@@ -1014,12 +1014,12 @@ audioop_adpcm2lin(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     int width;
     PyObject *state;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*iO:adpcm2lin",
-        &fragment, &width, &state)) {
+    if (!_PyArg_NoStackKeywords("adpcm2lin", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("adpcm2lin", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*iO:adpcm2lin",
+        &fragment, &width, &state)) {
         goto exit;
     }
     return_value = audioop_adpcm2lin_impl(module, &fragment, width, state);
@@ -1032,4 +1032,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=ee7c63ec28a11b78 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4eaee23043922a41 input=a9049054013a1b77]*/

--- a/Modules/clinic/binascii.c.h
+++ b/Modules/clinic/binascii.c.h
@@ -283,12 +283,12 @@ binascii_crc_hqx(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     unsigned int crc;
     unsigned int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*I:crc_hqx",
-        &data, &crc)) {
+    if (!_PyArg_NoStackKeywords("crc_hqx", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("crc_hqx", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*I:crc_hqx",
+        &data, &crc)) {
         goto exit;
     }
     _return_value = binascii_crc_hqx_impl(module, &data, crc);
@@ -326,12 +326,12 @@ binascii_crc32(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     unsigned int crc = 0;
     unsigned int _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|I:crc32",
-        &data, &crc)) {
+    if (!_PyArg_NoStackKeywords("crc32", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("crc32", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|I:crc32",
+        &data, &crc)) {
         goto exit;
     }
     _return_value = binascii_crc32_impl(module, &data, crc);
@@ -562,4 +562,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=9db57e86dbe7b2fa input=a9049054013a1b77]*/
+/*[clinic end generated code: output=490f08a964e97390 input=a9049054013a1b77]*/

--- a/Modules/clinic/cmathmodule.c.h
+++ b/Modules/clinic/cmathmodule.c.h
@@ -653,12 +653,12 @@ cmath_log(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     Py_complex x;
     PyObject *y_obj = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "D|O:log",
-        &x, &y_obj)) {
+    if (!_PyArg_NoStackKeywords("log", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("log", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "D|O:log",
+        &x, &y_obj)) {
         goto exit;
     }
     return_value = cmath_log_impl(module, x, y_obj);
@@ -742,12 +742,12 @@ cmath_rect(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     double r;
     double phi;
 
-    if (!_PyArg_ParseStack(args, nargs, "dd:rect",
-        &r, &phi)) {
+    if (!_PyArg_NoStackKeywords("rect", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("rect", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "dd:rect",
+        &r, &phi)) {
         goto exit;
     }
     return_value = cmath_rect_impl(module, r, phi);
@@ -890,4 +890,4 @@ cmath_isclose(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=93eff5d4c242ee57 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=11a0b5bb8a652de6 input=a9049054013a1b77]*/

--- a/Modules/clinic/fcntlmodule.c.h
+++ b/Modules/clinic/fcntlmodule.c.h
@@ -32,12 +32,12 @@ fcntl_fcntl(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     int code;
     PyObject *arg = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&i|O:fcntl",
-        conv_descriptor, &fd, &code, &arg)) {
+    if (!_PyArg_NoStackKeywords("fcntl", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("fcntl", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&i|O:fcntl",
+        conv_descriptor, &fd, &code, &arg)) {
         goto exit;
     }
     return_value = fcntl_fcntl_impl(module, fd, code, arg);
@@ -95,12 +95,12 @@ fcntl_ioctl(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyObject *ob_arg = NULL;
     int mutate_arg = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&I|Op:ioctl",
-        conv_descriptor, &fd, &code, &ob_arg, &mutate_arg)) {
+    if (!_PyArg_NoStackKeywords("ioctl", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ioctl", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&I|Op:ioctl",
+        conv_descriptor, &fd, &code, &ob_arg, &mutate_arg)) {
         goto exit;
     }
     return_value = fcntl_ioctl_impl(module, fd, code, ob_arg, mutate_arg);
@@ -131,12 +131,12 @@ fcntl_flock(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     int fd;
     int code;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&i:flock",
-        conv_descriptor, &fd, &code)) {
+    if (!_PyArg_NoStackKeywords("flock", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("flock", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&i:flock",
+        conv_descriptor, &fd, &code)) {
         goto exit;
     }
     return_value = fcntl_flock_impl(module, fd, code);
@@ -189,12 +189,12 @@ fcntl_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyObject *startobj = NULL;
     int whence = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&i|OOi:lockf",
-        conv_descriptor, &fd, &code, &lenobj, &startobj, &whence)) {
+    if (!_PyArg_NoStackKeywords("lockf", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lockf", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&i|OOi:lockf",
+        conv_descriptor, &fd, &code, &lenobj, &startobj, &whence)) {
         goto exit;
     }
     return_value = fcntl_lockf_impl(module, fd, code, lenobj, startobj, whence);
@@ -202,4 +202,4 @@ fcntl_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b67e9579722e6d4f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f189ac833d1448af input=a9049054013a1b77]*/

--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -21,13 +21,13 @@ math_gcd(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     PyObject *a;
     PyObject *b;
 
-    if (!_PyArg_UnpackStack(args, nargs, "gcd",
-        2, 2,
-        &a, &b)) {
+    if (!_PyArg_NoStackKeywords("gcd", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("gcd", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "gcd",
+        2, 2,
+        &a, &b)) {
         goto exit;
     }
     return_value = math_gcd_impl(module, a, b);
@@ -142,12 +142,12 @@ math_ldexp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     double x;
     PyObject *i;
 
-    if (!_PyArg_ParseStack(args, nargs, "dO:ldexp",
-        &x, &i)) {
+    if (!_PyArg_NoStackKeywords("ldexp", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ldexp", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "dO:ldexp",
+        &x, &i)) {
         goto exit;
     }
     return_value = math_ldexp_impl(module, x, i);
@@ -267,12 +267,12 @@ math_fmod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     double x;
     double y;
 
-    if (!_PyArg_ParseStack(args, nargs, "dd:fmod",
-        &x, &y)) {
+    if (!_PyArg_NoStackKeywords("fmod", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("fmod", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "dd:fmod",
+        &x, &y)) {
         goto exit;
     }
     return_value = math_fmod_impl(module, x, y);
@@ -300,12 +300,12 @@ math_hypot(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     double x;
     double y;
 
-    if (!_PyArg_ParseStack(args, nargs, "dd:hypot",
-        &x, &y)) {
+    if (!_PyArg_NoStackKeywords("hypot", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("hypot", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "dd:hypot",
+        &x, &y)) {
         goto exit;
     }
     return_value = math_hypot_impl(module, x, y);
@@ -333,12 +333,12 @@ math_pow(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     double x;
     double y;
 
-    if (!_PyArg_ParseStack(args, nargs, "dd:pow",
-        &x, &y)) {
+    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "dd:pow",
+        &x, &y)) {
         goto exit;
     }
     return_value = math_pow_impl(module, x, y);
@@ -536,4 +536,4 @@ math_isclose(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=71806f73a5c4bf0b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c9f1ac6ded547cc8 input=a9049054013a1b77]*/

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -1660,12 +1660,12 @@ os_execv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     path_t path = PATH_T_INITIALIZE("execv", "path", 0, 0);
     PyObject *argv;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&O:execv",
-        path_converter, &path, &argv)) {
+    if (!_PyArg_NoStackKeywords("execv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("execv", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&O:execv",
+        path_converter, &path, &argv)) {
         goto exit;
     }
     return_value = os_execv_impl(module, &path, argv);
@@ -1754,12 +1754,12 @@ os_spawnv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     path_t path = PATH_T_INITIALIZE("spawnv", "path", 0, 0);
     PyObject *argv;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO&O:spawnv",
-        &mode, path_converter, &path, &argv)) {
+    if (!_PyArg_NoStackKeywords("spawnv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("spawnv", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO&O:spawnv",
+        &mode, path_converter, &path, &argv)) {
         goto exit;
     }
     return_value = os_spawnv_impl(module, mode, &path, argv);
@@ -1806,12 +1806,12 @@ os_spawnve(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     PyObject *argv;
     PyObject *env;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO&OO:spawnve",
-        &mode, path_converter, &path, &argv, &env)) {
+    if (!_PyArg_NoStackKeywords("spawnve", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("spawnve", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO&OO:spawnve",
+        &mode, path_converter, &path, &argv, &env)) {
         goto exit;
     }
     return_value = os_spawnve_impl(module, mode, &path, argv, env);
@@ -2082,12 +2082,12 @@ os_sched_setscheduler(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     int policy;
     struct sched_param param;
 
-    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "iO&:sched_setscheduler",
-        &pid, &policy, convert_sched_param, &param)) {
+    if (!_PyArg_NoStackKeywords("sched_setscheduler", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("sched_setscheduler", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "iO&:sched_setscheduler",
+        &pid, &policy, convert_sched_param, &param)) {
         goto exit;
     }
     return_value = os_sched_setscheduler_impl(module, pid, policy, &param);
@@ -2157,12 +2157,12 @@ os_sched_setparam(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     pid_t pid;
     struct sched_param param;
 
-    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "O&:sched_setparam",
-        &pid, convert_sched_param, &param)) {
+    if (!_PyArg_NoStackKeywords("sched_setparam", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("sched_setparam", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "O&:sched_setparam",
+        &pid, convert_sched_param, &param)) {
         goto exit;
     }
     return_value = os_sched_setparam_impl(module, pid, &param);
@@ -2256,12 +2256,12 @@ os_sched_setaffinity(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObje
     pid_t pid;
     PyObject *mask;
 
-    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "O:sched_setaffinity",
-        &pid, &mask)) {
+    if (!_PyArg_NoStackKeywords("sched_setaffinity", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("sched_setaffinity", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "O:sched_setaffinity",
+        &pid, &mask)) {
         goto exit;
     }
     return_value = os_sched_setaffinity_impl(module, pid, mask);
@@ -2635,12 +2635,12 @@ os_kill(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     pid_t pid;
     Py_ssize_t signal;
 
-    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "n:kill",
-        &pid, &signal)) {
+    if (!_PyArg_NoStackKeywords("kill", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("kill", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "n:kill",
+        &pid, &signal)) {
         goto exit;
     }
     return_value = os_kill_impl(module, pid, signal);
@@ -2672,12 +2672,12 @@ os_killpg(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     pid_t pgid;
     int signal;
 
-    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "i:killpg",
-        &pgid, &signal)) {
+    if (!_PyArg_NoStackKeywords("killpg", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("killpg", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "i:killpg",
+        &pgid, &signal)) {
         goto exit;
     }
     return_value = os_killpg_impl(module, pgid, signal);
@@ -2833,12 +2833,12 @@ os_setreuid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     uid_t ruid;
     uid_t euid;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&O&:setreuid",
-        _Py_Uid_Converter, &ruid, _Py_Uid_Converter, &euid)) {
+    if (!_PyArg_NoStackKeywords("setreuid", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setreuid", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&O&:setreuid",
+        _Py_Uid_Converter, &ruid, _Py_Uid_Converter, &euid)) {
         goto exit;
     }
     return_value = os_setreuid_impl(module, ruid, euid);
@@ -2870,12 +2870,12 @@ os_setregid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     gid_t rgid;
     gid_t egid;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&O&:setregid",
-        _Py_Gid_Converter, &rgid, _Py_Gid_Converter, &egid)) {
+    if (!_PyArg_NoStackKeywords("setregid", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setregid", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&O&:setregid",
+        _Py_Gid_Converter, &rgid, _Py_Gid_Converter, &egid)) {
         goto exit;
     }
     return_value = os_setregid_impl(module, rgid, egid);
@@ -3038,12 +3038,12 @@ os_waitid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     id_t id;
     int options;
 
-    if (!_PyArg_ParseStack(args, nargs, "i" _Py_PARSE_PID "i:waitid",
-        &idtype, &id, &options)) {
+    if (!_PyArg_NoStackKeywords("waitid", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("waitid", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "i" _Py_PARSE_PID "i:waitid",
+        &idtype, &id, &options)) {
         goto exit;
     }
     return_value = os_waitid_impl(module, idtype, id, options);
@@ -3080,12 +3080,12 @@ os_waitpid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     pid_t pid;
     int options;
 
-    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "i:waitpid",
-        &pid, &options)) {
+    if (!_PyArg_NoStackKeywords("waitpid", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("waitpid", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "i:waitpid",
+        &pid, &options)) {
         goto exit;
     }
     return_value = os_waitpid_impl(module, pid, options);
@@ -3122,12 +3122,12 @@ os_waitpid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     intptr_t pid;
     int options;
 
-    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_INTPTR "i:waitpid",
-        &pid, &options)) {
+    if (!_PyArg_NoStackKeywords("waitpid", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("waitpid", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_INTPTR "i:waitpid",
+        &pid, &options)) {
         goto exit;
     }
     return_value = os_waitpid_impl(module, pid, options);
@@ -3316,12 +3316,12 @@ os_setpgid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     pid_t pid;
     pid_t pgrp;
 
-    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "" _Py_PARSE_PID ":setpgid",
-        &pid, &pgrp)) {
+    if (!_PyArg_NoStackKeywords("setpgid", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setpgid", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_PID "" _Py_PARSE_PID ":setpgid",
+        &pid, &pgrp)) {
         goto exit;
     }
     return_value = os_setpgid_impl(module, pid, pgrp);
@@ -3384,12 +3384,12 @@ os_tcsetpgrp(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     int fd;
     pid_t pgid;
 
-    if (!_PyArg_ParseStack(args, nargs, "i" _Py_PARSE_PID ":tcsetpgrp",
-        &fd, &pgid)) {
+    if (!_PyArg_NoStackKeywords("tcsetpgrp", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("tcsetpgrp", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "i" _Py_PARSE_PID ":tcsetpgrp",
+        &fd, &pgid)) {
         goto exit;
     }
     return_value = os_tcsetpgrp_impl(module, fd, pgid);
@@ -3495,12 +3495,12 @@ os_closerange(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     int fd_low;
     int fd_high;
 
-    if (!_PyArg_ParseStack(args, nargs, "ii:closerange",
-        &fd_low, &fd_high)) {
+    if (!_PyArg_NoStackKeywords("closerange", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("closerange", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ii:closerange",
+        &fd_low, &fd_high)) {
         goto exit;
     }
     return_value = os_closerange_impl(module, fd_low, fd_high);
@@ -3602,12 +3602,12 @@ os_lockf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int command;
     Py_off_t length;
 
-    if (!_PyArg_ParseStack(args, nargs, "iiO&:lockf",
-        &fd, &command, Py_off_t_converter, &length)) {
+    if (!_PyArg_NoStackKeywords("lockf", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lockf", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iiO&:lockf",
+        &fd, &command, Py_off_t_converter, &length)) {
         goto exit;
     }
     return_value = os_lockf_impl(module, fd, command, length);
@@ -3642,12 +3642,12 @@ os_lseek(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int how;
     Py_off_t _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO&i:lseek",
-        &fd, Py_off_t_converter, &position, &how)) {
+    if (!_PyArg_NoStackKeywords("lseek", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lseek", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO&i:lseek",
+        &fd, Py_off_t_converter, &position, &how)) {
         goto exit;
     }
     _return_value = os_lseek_impl(module, fd, position, how);
@@ -3679,12 +3679,12 @@ os_read(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int fd;
     Py_ssize_t length;
 
-    if (!_PyArg_ParseStack(args, nargs, "in:read",
-        &fd, &length)) {
+    if (!_PyArg_NoStackKeywords("read", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("read", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "in:read",
+        &fd, &length)) {
         goto exit;
     }
     return_value = os_read_impl(module, fd, length);
@@ -3723,12 +3723,12 @@ os_readv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     PyObject *buffers;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO:readv",
-        &fd, &buffers)) {
+    if (!_PyArg_NoStackKeywords("readv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("readv", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO:readv",
+        &fd, &buffers)) {
         goto exit;
     }
     _return_value = os_readv_impl(module, fd, buffers);
@@ -3768,12 +3768,12 @@ os_pread(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     int length;
     Py_off_t offset;
 
-    if (!_PyArg_ParseStack(args, nargs, "iiO&:pread",
-        &fd, &length, Py_off_t_converter, &offset)) {
+    if (!_PyArg_NoStackKeywords("pread", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pread", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iiO&:pread",
+        &fd, &length, Py_off_t_converter, &offset)) {
         goto exit;
     }
     return_value = os_pread_impl(module, fd, length, offset);
@@ -3804,12 +3804,12 @@ os_write(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames)
     Py_buffer data = {NULL, NULL};
     Py_ssize_t _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "iy*:write",
-        &fd, &data)) {
+    if (!_PyArg_NoStackKeywords("write", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("write", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iy*:write",
+        &fd, &data)) {
         goto exit;
     }
     _return_value = os_write_impl(module, fd, &data);
@@ -3982,12 +3982,12 @@ os_writev(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     PyObject *buffers;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO:writev",
-        &fd, &buffers)) {
+    if (!_PyArg_NoStackKeywords("writev", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("writev", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO:writev",
+        &fd, &buffers)) {
         goto exit;
     }
     _return_value = os_writev_impl(module, fd, buffers);
@@ -4029,12 +4029,12 @@ os_pwrite(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     Py_off_t offset;
     Py_ssize_t _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "iy*O&:pwrite",
-        &fd, &buffer, Py_off_t_converter, &offset)) {
+    if (!_PyArg_NoStackKeywords("pwrite", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pwrite", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iy*O&:pwrite",
+        &fd, &buffer, Py_off_t_converter, &offset)) {
         goto exit;
     }
     _return_value = os_pwrite_impl(module, fd, &buffer, offset);
@@ -4245,12 +4245,12 @@ os_makedev(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     int minor;
     dev_t _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "ii:makedev",
-        &major, &minor)) {
+    if (!_PyArg_NoStackKeywords("makedev", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("makedev", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ii:makedev",
+        &major, &minor)) {
         goto exit;
     }
     _return_value = os_makedev_impl(module, major, minor);
@@ -4286,12 +4286,12 @@ os_ftruncate(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     int fd;
     Py_off_t length;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO&:ftruncate",
-        &fd, Py_off_t_converter, &length)) {
+    if (!_PyArg_NoStackKeywords("ftruncate", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ftruncate", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO&:ftruncate",
+        &fd, Py_off_t_converter, &length)) {
         goto exit;
     }
     return_value = os_ftruncate_impl(module, fd, length);
@@ -4369,12 +4369,12 @@ os_posix_fallocate(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     Py_off_t offset;
     Py_off_t length;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO&O&:posix_fallocate",
-        &fd, Py_off_t_converter, &offset, Py_off_t_converter, &length)) {
+    if (!_PyArg_NoStackKeywords("posix_fallocate", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("posix_fallocate", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO&O&:posix_fallocate",
+        &fd, Py_off_t_converter, &offset, Py_off_t_converter, &length)) {
         goto exit;
     }
     return_value = os_posix_fallocate_impl(module, fd, offset, length);
@@ -4417,12 +4417,12 @@ os_posix_fadvise(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     Py_off_t length;
     int advice;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO&O&i:posix_fadvise",
-        &fd, Py_off_t_converter, &offset, Py_off_t_converter, &length, &advice)) {
+    if (!_PyArg_NoStackKeywords("posix_fadvise", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("posix_fadvise", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO&O&i:posix_fadvise",
+        &fd, Py_off_t_converter, &offset, Py_off_t_converter, &length, &advice)) {
         goto exit;
     }
     return_value = os_posix_fadvise_impl(module, fd, offset, length, advice);
@@ -4454,12 +4454,12 @@ os_putenv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     PyObject *name;
     PyObject *value;
 
-    if (!_PyArg_ParseStack(args, nargs, "UU:putenv",
-        &name, &value)) {
+    if (!_PyArg_NoStackKeywords("putenv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("putenv", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "UU:putenv",
+        &name, &value)) {
         goto exit;
     }
     return_value = os_putenv_impl(module, name, value);
@@ -4491,12 +4491,12 @@ os_putenv(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     PyObject *name = NULL;
     PyObject *value = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&O&:putenv",
-        PyUnicode_FSConverter, &name, PyUnicode_FSConverter, &value)) {
+    if (!_PyArg_NoStackKeywords("putenv", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("putenv", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&O&:putenv",
+        PyUnicode_FSConverter, &name, PyUnicode_FSConverter, &value)) {
         goto exit;
     }
     return_value = os_putenv_impl(module, name, value);
@@ -5017,12 +5017,12 @@ os_fpathconf(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     int name;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO&:fpathconf",
-        &fd, conv_path_confname, &name)) {
+    if (!_PyArg_NoStackKeywords("fpathconf", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("fpathconf", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO&:fpathconf",
+        &fd, conv_path_confname, &name)) {
         goto exit;
     }
     _return_value = os_fpathconf_impl(module, fd, name);
@@ -5308,12 +5308,12 @@ os_setresuid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     uid_t euid;
     uid_t suid;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&O&O&:setresuid",
-        _Py_Uid_Converter, &ruid, _Py_Uid_Converter, &euid, _Py_Uid_Converter, &suid)) {
+    if (!_PyArg_NoStackKeywords("setresuid", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setresuid", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&O&O&:setresuid",
+        _Py_Uid_Converter, &ruid, _Py_Uid_Converter, &euid, _Py_Uid_Converter, &suid)) {
         goto exit;
     }
     return_value = os_setresuid_impl(module, ruid, euid, suid);
@@ -5346,12 +5346,12 @@ os_setresgid(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     gid_t egid;
     gid_t sgid;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&O&O&:setresgid",
-        _Py_Gid_Converter, &rgid, _Py_Gid_Converter, &egid, _Py_Gid_Converter, &sgid)) {
+    if (!_PyArg_NoStackKeywords("setresgid", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setresgid", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&O&O&:setresgid",
+        _Py_Gid_Converter, &rgid, _Py_Gid_Converter, &egid, _Py_Gid_Converter, &sgid)) {
         goto exit;
     }
     return_value = os_setresgid_impl(module, rgid, egid, sgid);
@@ -5698,12 +5698,12 @@ os_set_inheritable(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     int fd;
     int inheritable;
 
-    if (!_PyArg_ParseStack(args, nargs, "ii:set_inheritable",
-        &fd, &inheritable)) {
+    if (!_PyArg_NoStackKeywords("set_inheritable", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("set_inheritable", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ii:set_inheritable",
+        &fd, &inheritable)) {
         goto exit;
     }
     return_value = os_set_inheritable_impl(module, fd, inheritable);
@@ -5770,12 +5770,12 @@ os_set_handle_inheritable(PyObject *module, PyObject **args, Py_ssize_t nargs, P
     intptr_t handle;
     int inheritable;
 
-    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_INTPTR "p:set_handle_inheritable",
-        &handle, &inheritable)) {
+    if (!_PyArg_NoStackKeywords("set_handle_inheritable", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("set_handle_inheritable", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "" _Py_PARSE_INTPTR "p:set_handle_inheritable",
+        &handle, &inheritable)) {
         goto exit;
     }
     return_value = os_set_handle_inheritable_impl(module, handle, inheritable);
@@ -6545,4 +6545,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=dce741f527ddbfa4 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=499329dda38d40c9 input=a9049054013a1b77]*/

--- a/Modules/clinic/pyexpat.c.h
+++ b/Modules/clinic/pyexpat.c.h
@@ -24,12 +24,12 @@ pyexpat_xmlparser_Parse(xmlparseobject *self, PyObject **args, Py_ssize_t nargs,
     PyObject *data;
     int isfinal = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|i:Parse",
-        &data, &isfinal)) {
+    if (!_PyArg_NoStackKeywords("Parse", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("Parse", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|i:Parse",
+        &data, &isfinal)) {
         goto exit;
     }
     return_value = pyexpat_xmlparser_Parse_impl(self, data, isfinal);
@@ -134,12 +134,12 @@ pyexpat_xmlparser_ExternalEntityParserCreate(xmlparseobject *self, PyObject **ar
     const char *context;
     const char *encoding = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "z|s:ExternalEntityParserCreate",
-        &context, &encoding)) {
+    if (!_PyArg_NoStackKeywords("ExternalEntityParserCreate", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ExternalEntityParserCreate", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "z|s:ExternalEntityParserCreate",
+        &context, &encoding)) {
         goto exit;
     }
     return_value = pyexpat_xmlparser_ExternalEntityParserCreate_impl(self, context, encoding);
@@ -204,12 +204,12 @@ pyexpat_xmlparser_UseForeignDTD(xmlparseobject *self, PyObject **args, Py_ssize_
     PyObject *return_value = NULL;
     int flag = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|p:UseForeignDTD",
-        &flag)) {
+    if (!_PyArg_NoStackKeywords("UseForeignDTD", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("UseForeignDTD", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|p:UseForeignDTD",
+        &flag)) {
         goto exit;
     }
     return_value = pyexpat_xmlparser_UseForeignDTD_impl(self, flag);
@@ -301,4 +301,4 @@ exit:
 #ifndef PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
     #define PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF
 #endif /* !defined(PYEXPAT_XMLPARSER_USEFOREIGNDTD_METHODDEF) */
-/*[clinic end generated code: output=0548a6b12157e29b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a51f9d31aff1a757 input=a9049054013a1b77]*/

--- a/Modules/clinic/resource.c.h
+++ b/Modules/clinic/resource.c.h
@@ -72,12 +72,12 @@ resource_setrlimit(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     int resource;
     PyObject *limits;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO:setrlimit",
-        &resource, &limits)) {
+    if (!_PyArg_NoStackKeywords("setrlimit", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setrlimit", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO:setrlimit",
+        &resource, &limits)) {
         goto exit;
     }
     return_value = resource_setrlimit_impl(module, resource, limits);
@@ -161,4 +161,4 @@ exit:
 #ifndef RESOURCE_PRLIMIT_METHODDEF
     #define RESOURCE_PRLIMIT_METHODDEF
 #endif /* !defined(RESOURCE_PRLIMIT_METHODDEF) */
-/*[clinic end generated code: output=3af613da48e0f8c9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=158aace6e532949e input=a9049054013a1b77]*/

--- a/Modules/clinic/signalmodule.c.h
+++ b/Modules/clinic/signalmodule.c.h
@@ -86,12 +86,12 @@ signal_signal(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     int signalnum;
     PyObject *handler;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO:signal",
-        &signalnum, &handler)) {
+    if (!_PyArg_NoStackKeywords("signal", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("signal", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO:signal",
+        &signalnum, &handler)) {
         goto exit;
     }
     return_value = signal_signal_impl(module, signalnum, handler);
@@ -157,12 +157,12 @@ signal_siginterrupt(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     int signalnum;
     int flag;
 
-    if (!_PyArg_ParseStack(args, nargs, "ii:siginterrupt",
-        &signalnum, &flag)) {
+    if (!_PyArg_NoStackKeywords("siginterrupt", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("siginterrupt", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ii:siginterrupt",
+        &signalnum, &flag)) {
         goto exit;
     }
     return_value = signal_siginterrupt_impl(module, signalnum, flag);
@@ -201,12 +201,12 @@ signal_setitimer(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     double seconds;
     double interval = 0.0;
 
-    if (!_PyArg_ParseStack(args, nargs, "id|d:setitimer",
-        &which, &seconds, &interval)) {
+    if (!_PyArg_NoStackKeywords("setitimer", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setitimer", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "id|d:setitimer",
+        &which, &seconds, &interval)) {
         goto exit;
     }
     return_value = signal_setitimer_impl(module, which, seconds, interval);
@@ -269,12 +269,12 @@ signal_pthread_sigmask(PyObject *module, PyObject **args, Py_ssize_t nargs, PyOb
     int how;
     PyObject *mask;
 
-    if (!_PyArg_ParseStack(args, nargs, "iO:pthread_sigmask",
-        &how, &mask)) {
+    if (!_PyArg_NoStackKeywords("pthread_sigmask", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pthread_sigmask", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iO:pthread_sigmask",
+        &how, &mask)) {
         goto exit;
     }
     return_value = signal_pthread_sigmask_impl(module, how, mask);
@@ -366,13 +366,13 @@ signal_sigtimedwait(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     PyObject *sigset;
     PyObject *timeout_obj;
 
-    if (!_PyArg_UnpackStack(args, nargs, "sigtimedwait",
-        2, 2,
-        &sigset, &timeout_obj)) {
+    if (!_PyArg_NoStackKeywords("sigtimedwait", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("sigtimedwait", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "sigtimedwait",
+        2, 2,
+        &sigset, &timeout_obj)) {
         goto exit;
     }
     return_value = signal_sigtimedwait_impl(module, sigset, timeout_obj);
@@ -405,12 +405,12 @@ signal_pthread_kill(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     unsigned long thread_id;
     int signalnum;
 
-    if (!_PyArg_ParseStack(args, nargs, "ki:pthread_kill",
-        &thread_id, &signalnum)) {
+    if (!_PyArg_NoStackKeywords("pthread_kill", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pthread_kill", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ki:pthread_kill",
+        &thread_id, &signalnum)) {
         goto exit;
     }
     return_value = signal_pthread_kill_impl(module, thread_id, signalnum);
@@ -464,4 +464,4 @@ exit:
 #ifndef SIGNAL_PTHREAD_KILL_METHODDEF
     #define SIGNAL_PTHREAD_KILL_METHODDEF
 #endif /* !defined(SIGNAL_PTHREAD_KILL_METHODDEF) */
-/*[clinic end generated code: output=c1a3f374b2c77e5d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=1a795d863c3bb302 input=a9049054013a1b77]*/

--- a/Modules/clinic/symtablemodule.c.h
+++ b/Modules/clinic/symtablemodule.c.h
@@ -23,12 +23,12 @@ _symtable_symtable(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *filename;
     const char *startstr;
 
-    if (!_PyArg_ParseStack(args, nargs, "sO&s:symtable",
-        &str, PyUnicode_FSDecoder, &filename, &startstr)) {
+    if (!_PyArg_NoStackKeywords("symtable", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("symtable", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "sO&s:symtable",
+        &str, PyUnicode_FSDecoder, &filename, &startstr)) {
         goto exit;
     }
     return_value = _symtable_symtable_impl(module, str, filename, startstr);
@@ -36,4 +36,4 @@ _symtable_symtable(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=071dee4d836e2cfd input=a9049054013a1b77]*/
+/*[clinic end generated code: output=388595f822b1fc79 input=a9049054013a1b77]*/

--- a/Modules/clinic/unicodedata.c.h
+++ b/Modules/clinic/unicodedata.c.h
@@ -26,12 +26,12 @@ unicodedata_UCD_decimal(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObj
     int chr;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "C|O:decimal",
-        &chr, &default_value)) {
+    if (!_PyArg_NoStackKeywords("decimal", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("decimal", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "C|O:decimal",
+        &chr, &default_value)) {
         goto exit;
     }
     return_value = unicodedata_UCD_decimal_impl(self, chr, default_value);
@@ -63,12 +63,12 @@ unicodedata_UCD_digit(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObjec
     int chr;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "C|O:digit",
-        &chr, &default_value)) {
+    if (!_PyArg_NoStackKeywords("digit", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("digit", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "C|O:digit",
+        &chr, &default_value)) {
         goto exit;
     }
     return_value = unicodedata_UCD_digit_impl(self, chr, default_value);
@@ -101,12 +101,12 @@ unicodedata_UCD_numeric(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObj
     int chr;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "C|O:numeric",
-        &chr, &default_value)) {
+    if (!_PyArg_NoStackKeywords("numeric", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("numeric", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "C|O:numeric",
+        &chr, &default_value)) {
         goto exit;
     }
     return_value = unicodedata_UCD_numeric_impl(self, chr, default_value);
@@ -318,12 +318,12 @@ unicodedata_UCD_normalize(PyObject *self, PyObject **args, Py_ssize_t nargs, PyO
     const char *form;
     PyObject *input;
 
-    if (!_PyArg_ParseStack(args, nargs, "sU:normalize",
-        &form, &input)) {
+    if (!_PyArg_NoStackKeywords("normalize", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("normalize", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "sU:normalize",
+        &form, &input)) {
         goto exit;
     }
     return_value = unicodedata_UCD_normalize_impl(self, form, input);
@@ -354,12 +354,12 @@ unicodedata_UCD_name(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject
     int chr;
     PyObject *default_value = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "C|O:name",
-        &chr, &default_value)) {
+    if (!_PyArg_NoStackKeywords("name", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("name", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "C|O:name",
+        &chr, &default_value)) {
         goto exit;
     }
     return_value = unicodedata_UCD_name_impl(self, chr, default_value);
@@ -399,4 +399,4 @@ unicodedata_UCD_lookup(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=fcb86aaa3fa40876 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f69c0bbd7294870b input=a9049054013a1b77]*/

--- a/Modules/clinic/zlibmodule.c.h
+++ b/Modules/clinic/zlibmodule.c.h
@@ -301,12 +301,12 @@ zlib_Compress_flush(compobject *self, PyObject **args, Py_ssize_t nargs, PyObjec
     PyObject *return_value = NULL;
     int mode = Z_FINISH;
 
-    if (!_PyArg_ParseStack(args, nargs, "|i:flush",
-        &mode)) {
+    if (!_PyArg_NoStackKeywords("flush", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("flush", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|i:flush",
+        &mode)) {
         goto exit;
     }
     return_value = zlib_Compress_flush_impl(self, mode);
@@ -380,12 +380,12 @@ zlib_Decompress_flush(compobject *self, PyObject **args, Py_ssize_t nargs, PyObj
     PyObject *return_value = NULL;
     Py_ssize_t length = DEF_BUF_SIZE;
 
-    if (!_PyArg_ParseStack(args, nargs, "|O&:flush",
-        ssize_t_converter, &length)) {
+    if (!_PyArg_NoStackKeywords("flush", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("flush", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|O&:flush",
+        ssize_t_converter, &length)) {
         goto exit;
     }
     return_value = zlib_Decompress_flush_impl(self, length);
@@ -418,12 +418,12 @@ zlib_adler32(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     Py_buffer data = {NULL, NULL};
     unsigned int value = 1;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|I:adler32",
-        &data, &value)) {
+    if (!_PyArg_NoStackKeywords("adler32", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("adler32", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|I:adler32",
+        &data, &value)) {
         goto exit;
     }
     return_value = zlib_adler32_impl(module, &data, value);
@@ -461,12 +461,12 @@ zlib_crc32(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     Py_buffer data = {NULL, NULL};
     unsigned int value = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*|I:crc32",
-        &data, &value)) {
+    if (!_PyArg_NoStackKeywords("crc32", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("crc32", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*|I:crc32",
+        &data, &value)) {
         goto exit;
     }
     return_value = zlib_crc32_impl(module, &data, value);
@@ -483,4 +483,4 @@ exit:
 #ifndef ZLIB_COMPRESS_COPY_METHODDEF
     #define ZLIB_COMPRESS_COPY_METHODDEF
 #endif /* !defined(ZLIB_COMPRESS_COPY_METHODDEF) */
-/*[clinic end generated code: output=fa1b5f4a6208c342 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c7abf02e091bcad3 input=a9049054013a1b77]*/

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -100,12 +100,12 @@ bytearray_maketrans(void *null, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     Py_buffer frm = {NULL, NULL};
     Py_buffer to = {NULL, NULL};
 
-    if (!_PyArg_ParseStack(args, nargs, "y*y*:maketrans",
-        &frm, &to)) {
+    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*y*:maketrans",
+        &frm, &to)) {
         goto exit;
     }
     return_value = bytearray_maketrans_impl(&frm, &to);
@@ -151,12 +151,12 @@ bytearray_replace(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, Py
     Py_buffer new = {NULL, NULL};
     Py_ssize_t count = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*y*|n:replace",
-        &old, &new, &count)) {
+    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*y*|n:replace",
+        &old, &new, &count)) {
         goto exit;
     }
     return_value = bytearray_replace_impl(self, &old, &new, count);
@@ -330,12 +330,12 @@ bytearray_insert(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyO
     Py_ssize_t index;
     int item;
 
-    if (!_PyArg_ParseStack(args, nargs, "nO&:insert",
-        &index, _getbytevalue, &item)) {
+    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "nO&:insert",
+        &index, _getbytevalue, &item)) {
         goto exit;
     }
     return_value = bytearray_insert_impl(self, index, item);
@@ -410,12 +410,12 @@ bytearray_pop(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyObje
     PyObject *return_value = NULL;
     Py_ssize_t index = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|n:pop",
-        &index)) {
+    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|n:pop",
+        &index)) {
         goto exit;
     }
     return_value = bytearray_pop_impl(self, index);
@@ -474,13 +474,13 @@ bytearray_strip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyOb
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "strip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "strip",
+        0, 1,
+        &bytes)) {
         goto exit;
     }
     return_value = bytearray_strip_impl(self, bytes);
@@ -509,13 +509,13 @@ bytearray_lstrip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyO
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
+        0, 1,
+        &bytes)) {
         goto exit;
     }
     return_value = bytearray_lstrip_impl(self, bytes);
@@ -544,13 +544,13 @@ bytearray_rstrip(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, PyO
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
+        0, 1,
+        &bytes)) {
         goto exit;
     }
     return_value = bytearray_rstrip_impl(self, bytes);
@@ -712,12 +712,12 @@ bytearray_reduce_ex(PyByteArrayObject *self, PyObject **args, Py_ssize_t nargs, 
     PyObject *return_value = NULL;
     int proto = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "|i:__reduce_ex__",
-        &proto)) {
+    if (!_PyArg_NoStackKeywords("__reduce_ex__", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("__reduce_ex__", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|i:__reduce_ex__",
+        &proto)) {
         goto exit;
     }
     return_value = bytearray_reduce_ex_impl(self, proto);
@@ -743,4 +743,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=f5c364927425fae8 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=f0079d8ee82614f7 input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -195,13 +195,13 @@ bytes_strip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "strip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "strip",
+        0, 1,
+        &bytes)) {
         goto exit;
     }
     return_value = bytes_strip_impl(self, bytes);
@@ -230,13 +230,13 @@ bytes_lstrip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *k
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
+        0, 1,
+        &bytes)) {
         goto exit;
     }
     return_value = bytes_lstrip_impl(self, bytes);
@@ -265,13 +265,13 @@ bytes_rstrip(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *k
     PyObject *return_value = NULL;
     PyObject *bytes = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
-        0, 1,
-        &bytes)) {
+    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
+        0, 1,
+        &bytes)) {
         goto exit;
     }
     return_value = bytes_rstrip_impl(self, bytes);
@@ -342,12 +342,12 @@ bytes_maketrans(void *null, PyObject **args, Py_ssize_t nargs, PyObject *kwnames
     Py_buffer frm = {NULL, NULL};
     Py_buffer to = {NULL, NULL};
 
-    if (!_PyArg_ParseStack(args, nargs, "y*y*:maketrans",
-        &frm, &to)) {
+    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*y*:maketrans",
+        &frm, &to)) {
         goto exit;
     }
     return_value = bytes_maketrans_impl(&frm, &to);
@@ -393,12 +393,12 @@ bytes_replace(PyBytesObject *self, PyObject **args, Py_ssize_t nargs, PyObject *
     Py_buffer new = {NULL, NULL};
     Py_ssize_t count = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "y*y*|n:replace",
-        &old, &new, &count)) {
+    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "y*y*|n:replace",
+        &old, &new, &count)) {
         goto exit;
     }
     return_value = bytes_replace_impl(self, &old, &new, count);
@@ -519,4 +519,4 @@ bytes_fromhex(PyTypeObject *type, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=2504c1225108d348 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=a82999760469bbec input=a9049054013a1b77]*/

--- a/Objects/clinic/dictobject.c.h
+++ b/Objects/clinic/dictobject.c.h
@@ -21,13 +21,13 @@ dict_fromkeys(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyObject *k
     PyObject *iterable;
     PyObject *value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "fromkeys",
-        1, 2,
-        &iterable, &value)) {
+    if (!_PyArg_NoStackKeywords("fromkeys", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("fromkeys", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "fromkeys",
+        1, 2,
+        &iterable, &value)) {
         goto exit;
     }
     return_value = dict_fromkeys_impl(type, iterable, value);
@@ -64,13 +64,13 @@ dict_get(PyDictObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "get",
-        1, 2,
-        &key, &default_value)) {
+    if (!_PyArg_NoStackKeywords("get", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("get", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "get",
+        1, 2,
+        &key, &default_value)) {
         goto exit;
     }
     return_value = dict_get_impl(self, key, default_value);
@@ -101,13 +101,13 @@ dict_setdefault(PyDictObject *self, PyObject **args, Py_ssize_t nargs, PyObject 
     PyObject *key;
     PyObject *default_value = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "setdefault",
-        1, 2,
-        &key, &default_value)) {
+    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setdefault", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "setdefault",
+        1, 2,
+        &key, &default_value)) {
         goto exit;
     }
     return_value = dict_setdefault_impl(self, key, default_value);
@@ -115,4 +115,4 @@ dict_setdefault(PyDictObject *self, PyObject **args, Py_ssize_t nargs, PyObject 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=4d57df133cf66e53 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=49e03ab4360f5be0 input=a9049054013a1b77]*/

--- a/Objects/clinic/floatobject.c.h
+++ b/Objects/clinic/floatobject.c.h
@@ -58,13 +58,13 @@ float___round__(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *return_value = NULL;
     PyObject *o_ndigits = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "__round__",
-        0, 1,
-        &o_ndigits)) {
+    if (!_PyArg_NoStackKeywords("__round__", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("__round__", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "__round__",
+        0, 1,
+        &o_ndigits)) {
         goto exit;
     }
     return_value = float___round___impl(self, o_ndigits);
@@ -273,12 +273,12 @@ float___set_format__(PyTypeObject *type, PyObject **args, Py_ssize_t nargs, PyOb
     const char *typestr;
     const char *fmt;
 
-    if (!_PyArg_ParseStack(args, nargs, "ss:__set_format__",
-        &typestr, &fmt)) {
+    if (!_PyArg_NoStackKeywords("__set_format__", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("__set_format__", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ss:__set_format__",
+        &typestr, &fmt)) {
         goto exit;
     }
     return_value = float___set_format___impl(type, typestr, fmt);
@@ -313,4 +313,4 @@ float___format__(PyObject *self, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=dc6b0b67a7e40c93 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b2271e7413b36162 input=a9049054013a1b77]*/

--- a/Objects/clinic/listobject.c.h
+++ b/Objects/clinic/listobject.c.h
@@ -21,12 +21,12 @@ list_insert(PyListObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     Py_ssize_t index;
     PyObject *object;
 
-    if (!_PyArg_ParseStack(args, nargs, "nO:insert",
-        &index, &object)) {
+    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("insert", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "nO:insert",
+        &index, &object)) {
         goto exit;
     }
     return_value = list_insert_impl(self, index, object);
@@ -109,12 +109,12 @@ list_pop(PyListObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwname
     PyObject *return_value = NULL;
     Py_ssize_t index = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "|n:pop",
-        &index)) {
+    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pop", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "|n:pop",
+        &index)) {
         goto exit;
     }
     return_value = list_pop_impl(self, index);
@@ -195,12 +195,12 @@ list_index(PyListObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     Py_ssize_t start = 0;
     Py_ssize_t stop = PY_SSIZE_T_MAX;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index",
-        &value, _PyEval_SliceIndexNotNone, &start, _PyEval_SliceIndexNotNone, &stop)) {
+    if (!_PyArg_NoStackKeywords("index", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("index", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index",
+        &value, _PyEval_SliceIndexNotNone, &start, _PyEval_SliceIndexNotNone, &stop)) {
         goto exit;
     }
     return_value = list_index_impl(self, value, start, stop);
@@ -297,4 +297,4 @@ list___reversed__(PyListObject *self, PyObject *Py_UNUSED(ignored))
 {
     return list___reversed___impl(self);
 }
-/*[clinic end generated code: output=71deae70ca0e6799 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=63cbe6d6320e916f input=a9049054013a1b77]*/

--- a/Objects/clinic/tupleobject.c.h
+++ b/Objects/clinic/tupleobject.c.h
@@ -25,12 +25,12 @@ tuple_index(PyTupleObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kw
     Py_ssize_t start = 0;
     Py_ssize_t stop = PY_SSIZE_T_MAX;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index",
-        &value, _PyEval_SliceIndexNotNone, &start, _PyEval_SliceIndexNotNone, &stop)) {
+    if (!_PyArg_NoStackKeywords("index", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("index", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index",
+        &value, _PyEval_SliceIndexNotNone, &start, _PyEval_SliceIndexNotNone, &stop)) {
         goto exit;
     }
     return_value = tuple_index_impl(self, value, start, stop);
@@ -99,4 +99,4 @@ tuple___getnewargs__(PyTupleObject *self, PyObject *Py_UNUSED(ignored))
 {
     return tuple___getnewargs___impl(self);
 }
-/*[clinic end generated code: output=145bcfff64e8c809 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=70b4de94a0002ec3 input=a9049054013a1b77]*/

--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -83,12 +83,12 @@ unicode_center(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     Py_ssize_t width;
     Py_UCS4 fillchar = ' ';
 
-    if (!_PyArg_ParseStack(args, nargs, "n|O&:center",
-        &width, convert_uc, &fillchar)) {
+    if (!_PyArg_NoStackKeywords("center", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("center", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "n|O&:center",
+        &width, convert_uc, &fillchar)) {
         goto exit;
     }
     return_value = unicode_center_impl(self, width, fillchar);
@@ -435,12 +435,12 @@ unicode_ljust(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     Py_ssize_t width;
     Py_UCS4 fillchar = ' ';
 
-    if (!_PyArg_ParseStack(args, nargs, "n|O&:ljust",
-        &width, convert_uc, &fillchar)) {
+    if (!_PyArg_NoStackKeywords("ljust", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ljust", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "n|O&:ljust",
+        &width, convert_uc, &fillchar)) {
         goto exit;
     }
     return_value = unicode_ljust_impl(self, width, fillchar);
@@ -487,13 +487,13 @@ unicode_strip(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyObject *return_value = NULL;
     PyObject *chars = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "strip",
-        0, 1,
-        &chars)) {
+    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("strip", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "strip",
+        0, 1,
+        &chars)) {
         goto exit;
     }
     return_value = unicode_strip_impl(self, chars);
@@ -522,13 +522,13 @@ unicode_lstrip(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *return_value = NULL;
     PyObject *chars = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
-        0, 1,
-        &chars)) {
+    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("lstrip", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "lstrip",
+        0, 1,
+        &chars)) {
         goto exit;
     }
     return_value = unicode_lstrip_impl(self, chars);
@@ -557,13 +557,13 @@ unicode_rstrip(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *return_value = NULL;
     PyObject *chars = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
-        0, 1,
-        &chars)) {
+    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("rstrip", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "rstrip",
+        0, 1,
+        &chars)) {
         goto exit;
     }
     return_value = unicode_rstrip_impl(self, chars);
@@ -600,12 +600,12 @@ unicode_replace(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *new;
     Py_ssize_t count = -1;
 
-    if (!_PyArg_ParseStack(args, nargs, "UU|n:replace",
-        &old, &new, &count)) {
+    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("replace", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "UU|n:replace",
+        &old, &new, &count)) {
         goto exit;
     }
     return_value = unicode_replace_impl(self, old, new, count);
@@ -635,12 +635,12 @@ unicode_rjust(PyObject *self, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     Py_ssize_t width;
     Py_UCS4 fillchar = ' ';
 
-    if (!_PyArg_ParseStack(args, nargs, "n|O&:rjust",
-        &width, convert_uc, &fillchar)) {
+    if (!_PyArg_NoStackKeywords("rjust", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("rjust", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "n|O&:rjust",
+        &width, convert_uc, &fillchar)) {
         goto exit;
     }
     return_value = unicode_rjust_impl(self, width, fillchar);
@@ -840,12 +840,12 @@ unicode_maketrans(void *null, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyObject *y = NULL;
     PyObject *z = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|UU:maketrans",
-        &x, &y, &z)) {
+    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("maketrans", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|UU:maketrans",
+        &x, &y, &z)) {
         goto exit;
     }
     return_value = unicode_maketrans_impl(x, y, z);
@@ -962,4 +962,4 @@ unicode_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return unicode_sizeof_impl(self);
 }
-/*[clinic end generated code: output=88b06f61edd282f9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=339a83c0c100dd17 input=a9049054013a1b77]*/

--- a/PC/clinic/msvcrtmodule.c.h
+++ b/PC/clinic/msvcrtmodule.c.h
@@ -50,12 +50,12 @@ msvcrt_locking(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     int mode;
     long nbytes;
 
-    if (!_PyArg_ParseStack(args, nargs, "iil:locking",
-        &fd, &mode, &nbytes)) {
+    if (!_PyArg_NoStackKeywords("locking", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("locking", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "iil:locking",
+        &fd, &mode, &nbytes)) {
         goto exit;
     }
     return_value = msvcrt_locking_impl(module, fd, mode, nbytes);
@@ -89,12 +89,12 @@ msvcrt_setmode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     int flags;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "ii:setmode",
-        &fd, &flags)) {
+    if (!_PyArg_NoStackKeywords("setmode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setmode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ii:setmode",
+        &fd, &flags)) {
         goto exit;
     }
     _return_value = msvcrt_setmode_impl(module, fd, flags);
@@ -131,12 +131,12 @@ msvcrt_open_osfhandle(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     int flags;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, ""_Py_PARSE_INTPTR"i:open_osfhandle",
-        &handle, &flags)) {
+    if (!_PyArg_NoStackKeywords("open_osfhandle", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("open_osfhandle", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, ""_Py_PARSE_INTPTR"i:open_osfhandle",
+        &handle, &flags)) {
         goto exit;
     }
     _return_value = msvcrt_open_osfhandle_impl(module, handle, flags);
@@ -449,12 +449,12 @@ msvcrt_CrtSetReportFile(PyObject *module, PyObject **args, Py_ssize_t nargs, PyO
     int file;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "ii:CrtSetReportFile",
-        &type, &file)) {
+    if (!_PyArg_NoStackKeywords("CrtSetReportFile", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("CrtSetReportFile", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ii:CrtSetReportFile",
+        &type, &file)) {
         goto exit;
     }
     _return_value = msvcrt_CrtSetReportFile_impl(module, type, file);
@@ -493,12 +493,12 @@ msvcrt_CrtSetReportMode(PyObject *module, PyObject **args, Py_ssize_t nargs, PyO
     int mode;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "ii:CrtSetReportMode",
-        &type, &mode)) {
+    if (!_PyArg_NoStackKeywords("CrtSetReportMode", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("CrtSetReportMode", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ii:CrtSetReportMode",
+        &type, &mode)) {
         goto exit;
     }
     _return_value = msvcrt_CrtSetReportMode_impl(module, type, mode);
@@ -589,4 +589,4 @@ exit:
 #ifndef MSVCRT_SET_ERROR_MODE_METHODDEF
     #define MSVCRT_SET_ERROR_MODE_METHODDEF
 #endif /* !defined(MSVCRT_SET_ERROR_MODE_METHODDEF) */
-/*[clinic end generated code: output=be516d0e78532ba3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=9e82abfdd357b0da input=a9049054013a1b77]*/

--- a/PC/clinic/winreg.c.h
+++ b/PC/clinic/winreg.c.h
@@ -148,12 +148,12 @@ winreg_ConnectRegistry(PyObject *module, PyObject **args, Py_ssize_t nargs, PyOb
     HKEY key;
     HKEY _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "ZO&:ConnectRegistry",
-        &computer_name, clinic_HKEY_converter, &key)) {
+    if (!_PyArg_NoStackKeywords("ConnectRegistry", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("ConnectRegistry", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "ZO&:ConnectRegistry",
+        &computer_name, clinic_HKEY_converter, &key)) {
         goto exit;
     }
     _return_value = winreg_ConnectRegistry_impl(module, computer_name, key);
@@ -199,12 +199,12 @@ winreg_CreateKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     Py_UNICODE *sub_key;
     HKEY _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&Z:CreateKey",
-        clinic_HKEY_converter, &key, &sub_key)) {
+    if (!_PyArg_NoStackKeywords("CreateKey", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("CreateKey", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&Z:CreateKey",
+        clinic_HKEY_converter, &key, &sub_key)) {
         goto exit;
     }
     _return_value = winreg_CreateKey_impl(module, key, sub_key);
@@ -306,12 +306,12 @@ winreg_DeleteKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     HKEY key;
     Py_UNICODE *sub_key;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&u:DeleteKey",
-        clinic_HKEY_converter, &key, &sub_key)) {
+    if (!_PyArg_NoStackKeywords("DeleteKey", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("DeleteKey", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&u:DeleteKey",
+        clinic_HKEY_converter, &key, &sub_key)) {
         goto exit;
     }
     return_value = winreg_DeleteKey_impl(module, key, sub_key);
@@ -397,12 +397,12 @@ winreg_DeleteValue(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     HKEY key;
     Py_UNICODE *value;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&Z:DeleteValue",
-        clinic_HKEY_converter, &key, &value)) {
+    if (!_PyArg_NoStackKeywords("DeleteValue", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("DeleteValue", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&Z:DeleteValue",
+        clinic_HKEY_converter, &key, &value)) {
         goto exit;
     }
     return_value = winreg_DeleteValue_impl(module, key, value);
@@ -439,12 +439,12 @@ winreg_EnumKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     HKEY key;
     int index;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&i:EnumKey",
-        clinic_HKEY_converter, &key, &index)) {
+    if (!_PyArg_NoStackKeywords("EnumKey", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("EnumKey", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&i:EnumKey",
+        clinic_HKEY_converter, &key, &index)) {
         goto exit;
     }
     return_value = winreg_EnumKey_impl(module, key, index);
@@ -490,12 +490,12 @@ winreg_EnumValue(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *
     HKEY key;
     int index;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&i:EnumValue",
-        clinic_HKEY_converter, &key, &index)) {
+    if (!_PyArg_NoStackKeywords("EnumValue", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("EnumValue", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&i:EnumValue",
+        clinic_HKEY_converter, &key, &index)) {
         goto exit;
     }
     return_value = winreg_EnumValue_impl(module, key, index);
@@ -614,12 +614,12 @@ winreg_LoadKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     Py_UNICODE *sub_key;
     Py_UNICODE *file_name;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&uu:LoadKey",
-        clinic_HKEY_converter, &key, &sub_key, &file_name)) {
+    if (!_PyArg_NoStackKeywords("LoadKey", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("LoadKey", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&uu:LoadKey",
+        clinic_HKEY_converter, &key, &sub_key, &file_name)) {
         goto exit;
     }
     return_value = winreg_LoadKey_impl(module, key, sub_key, file_name);
@@ -801,12 +801,12 @@ winreg_QueryValue(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     HKEY key;
     Py_UNICODE *sub_key;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&Z:QueryValue",
-        clinic_HKEY_converter, &key, &sub_key)) {
+    if (!_PyArg_NoStackKeywords("QueryValue", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("QueryValue", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&Z:QueryValue",
+        clinic_HKEY_converter, &key, &sub_key)) {
         goto exit;
     }
     return_value = winreg_QueryValue_impl(module, key, sub_key);
@@ -844,12 +844,12 @@ winreg_QueryValueEx(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     HKEY key;
     Py_UNICODE *name;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&Z:QueryValueEx",
-        clinic_HKEY_converter, &key, &name)) {
+    if (!_PyArg_NoStackKeywords("QueryValueEx", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("QueryValueEx", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&Z:QueryValueEx",
+        clinic_HKEY_converter, &key, &name)) {
         goto exit;
     }
     return_value = winreg_QueryValueEx_impl(module, key, name);
@@ -892,12 +892,12 @@ winreg_SaveKey(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     HKEY key;
     Py_UNICODE *file_name;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&u:SaveKey",
-        clinic_HKEY_converter, &key, &file_name)) {
+    if (!_PyArg_NoStackKeywords("SaveKey", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("SaveKey", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&u:SaveKey",
+        clinic_HKEY_converter, &key, &file_name)) {
         goto exit;
     }
     return_value = winreg_SaveKey_impl(module, key, file_name);
@@ -950,12 +950,12 @@ winreg_SetValue(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     Py_UNICODE *value;
     Py_ssize_clean_t value_length;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&Zku#:SetValue",
-        clinic_HKEY_converter, &key, &sub_key, &type, &value, &value_length)) {
+    if (!_PyArg_NoStackKeywords("SetValue", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("SetValue", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&Zku#:SetValue",
+        clinic_HKEY_converter, &key, &sub_key, &type, &value, &value_length)) {
         goto exit;
     }
     return_value = winreg_SetValue_impl(module, key, sub_key, type, value, value_length);
@@ -1024,12 +1024,12 @@ winreg_SetValueEx(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject 
     DWORD type;
     PyObject *value;
 
-    if (!_PyArg_ParseStack(args, nargs, "O&ZOkO:SetValueEx",
-        clinic_HKEY_converter, &key, &value_name, &reserved, &type, &value)) {
+    if (!_PyArg_NoStackKeywords("SetValueEx", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("SetValueEx", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O&ZOkO:SetValueEx",
+        clinic_HKEY_converter, &key, &value_name, &reserved, &type, &value)) {
         goto exit;
     }
     return_value = winreg_SetValueEx_impl(module, key, value_name, reserved, type, value);
@@ -1139,4 +1139,4 @@ winreg_QueryReflectionKey(PyObject *module, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ddc72b006143d33d input=a9049054013a1b77]*/
+/*[clinic end generated code: output=57f166c252c5ba7a input=a9049054013a1b77]*/

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -94,12 +94,12 @@ builtin_format(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *value;
     PyObject *format_spec = NULL;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|U:format",
-        &value, &format_spec)) {
+    if (!_PyArg_NoStackKeywords("format", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("format", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|U:format",
+        &value, &format_spec)) {
         goto exit;
     }
     return_value = builtin_format_impl(module, value, format_spec);
@@ -203,13 +203,13 @@ builtin_divmod(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kw
     PyObject *x;
     PyObject *y;
 
-    if (!_PyArg_UnpackStack(args, nargs, "divmod",
-        2, 2,
-        &x, &y)) {
+    if (!_PyArg_NoStackKeywords("divmod", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("divmod", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "divmod",
+        2, 2,
+        &x, &y)) {
         goto exit;
     }
     return_value = builtin_divmod_impl(module, x, y);
@@ -245,13 +245,13 @@ builtin_eval(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *globals = Py_None;
     PyObject *locals = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "eval",
-        1, 3,
-        &source, &globals, &locals)) {
+    if (!_PyArg_NoStackKeywords("eval", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("eval", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "eval",
+        1, 3,
+        &source, &globals, &locals)) {
         goto exit;
     }
     return_value = builtin_eval_impl(module, source, globals, locals);
@@ -287,13 +287,13 @@ builtin_exec(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *globals = Py_None;
     PyObject *locals = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "exec",
-        1, 3,
-        &source, &globals, &locals)) {
+    if (!_PyArg_NoStackKeywords("exec", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("exec", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "exec",
+        1, 3,
+        &source, &globals, &locals)) {
         goto exit;
     }
     return_value = builtin_exec_impl(module, source, globals, locals);
@@ -344,13 +344,13 @@ builtin_hasattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     PyObject *obj;
     PyObject *name;
 
-    if (!_PyArg_UnpackStack(args, nargs, "hasattr",
-        2, 2,
-        &obj, &name)) {
+    if (!_PyArg_NoStackKeywords("hasattr", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("hasattr", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "hasattr",
+        2, 2,
+        &obj, &name)) {
         goto exit;
     }
     return_value = builtin_hasattr_impl(module, obj, name);
@@ -394,13 +394,13 @@ builtin_setattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     PyObject *name;
     PyObject *value;
 
-    if (!_PyArg_UnpackStack(args, nargs, "setattr",
-        3, 3,
-        &obj, &name, &value)) {
+    if (!_PyArg_NoStackKeywords("setattr", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("setattr", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "setattr",
+        3, 3,
+        &obj, &name, &value)) {
         goto exit;
     }
     return_value = builtin_setattr_impl(module, obj, name, value);
@@ -430,13 +430,13 @@ builtin_delattr(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *k
     PyObject *obj;
     PyObject *name;
 
-    if (!_PyArg_UnpackStack(args, nargs, "delattr",
-        2, 2,
-        &obj, &name)) {
+    if (!_PyArg_NoStackKeywords("delattr", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("delattr", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "delattr",
+        2, 2,
+        &obj, &name)) {
         goto exit;
     }
     return_value = builtin_delattr_impl(module, obj, name);
@@ -544,13 +544,13 @@ builtin_pow(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyObject *y;
     PyObject *z = Py_None;
 
-    if (!_PyArg_UnpackStack(args, nargs, "pow",
-        2, 3,
-        &x, &y, &z)) {
+    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("pow", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "pow",
+        2, 3,
+        &x, &y, &z)) {
         goto exit;
     }
     return_value = builtin_pow_impl(module, x, y, z);
@@ -583,13 +583,13 @@ builtin_input(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *return_value = NULL;
     PyObject *prompt = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "input",
-        0, 1,
-        &prompt)) {
+    if (!_PyArg_NoStackKeywords("input", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("input", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "input",
+        0, 1,
+        &prompt)) {
         goto exit;
     }
     return_value = builtin_input_impl(module, prompt);
@@ -632,13 +632,13 @@ builtin_sum(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwnam
     PyObject *iterable;
     PyObject *start = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "sum",
-        1, 2,
-        &iterable, &start)) {
+    if (!_PyArg_NoStackKeywords("sum", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("sum", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "sum",
+        1, 2,
+        &iterable, &start)) {
         goto exit;
     }
     return_value = builtin_sum_impl(module, iterable, start);
@@ -671,13 +671,13 @@ builtin_isinstance(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *obj;
     PyObject *class_or_tuple;
 
-    if (!_PyArg_UnpackStack(args, nargs, "isinstance",
-        2, 2,
-        &obj, &class_or_tuple)) {
+    if (!_PyArg_NoStackKeywords("isinstance", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("isinstance", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "isinstance",
+        2, 2,
+        &obj, &class_or_tuple)) {
         goto exit;
     }
     return_value = builtin_isinstance_impl(module, obj, class_or_tuple);
@@ -710,13 +710,13 @@ builtin_issubclass(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
     PyObject *cls;
     PyObject *class_or_tuple;
 
-    if (!_PyArg_UnpackStack(args, nargs, "issubclass",
-        2, 2,
-        &cls, &class_or_tuple)) {
+    if (!_PyArg_NoStackKeywords("issubclass", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("issubclass", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "issubclass",
+        2, 2,
+        &cls, &class_or_tuple)) {
         goto exit;
     }
     return_value = builtin_issubclass_impl(module, cls, class_or_tuple);
@@ -724,4 +724,4 @@ builtin_issubclass(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=17fedd2dec148677 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e1a7417a7b33eeec input=a9049054013a1b77]*/

--- a/Python/clinic/import.c.h
+++ b/Python/clinic/import.c.h
@@ -88,12 +88,12 @@ _imp__fix_co_filename(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObj
     PyCodeObject *code;
     PyObject *path;
 
-    if (!_PyArg_ParseStack(args, nargs, "O!U:_fix_co_filename",
-        &PyCode_Type, &code, &path)) {
+    if (!_PyArg_NoStackKeywords("_fix_co_filename", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("_fix_co_filename", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O!U:_fix_co_filename",
+        &PyCode_Type, &code, &path)) {
         goto exit;
     }
     return_value = _imp__fix_co_filename_impl(module, code, path);
@@ -285,13 +285,13 @@ _imp_create_dynamic(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObjec
     PyObject *spec;
     PyObject *file = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "create_dynamic",
-        1, 2,
-        &spec, &file)) {
+    if (!_PyArg_NoStackKeywords("create_dynamic", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("create_dynamic", kwnames)) {
+    if (!_PyArg_UnpackStack(args, nargs, "create_dynamic",
+        1, 2,
+        &spec, &file)) {
         goto exit;
     }
     return_value = _imp_create_dynamic_impl(module, spec, file);
@@ -369,4 +369,4 @@ exit:
 #ifndef _IMP_EXEC_DYNAMIC_METHODDEF
     #define _IMP_EXEC_DYNAMIC_METHODDEF
 #endif /* !defined(_IMP_EXEC_DYNAMIC_METHODDEF) */
-/*[clinic end generated code: output=c1d0e65d04114958 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b970357dbbe25ee4 input=a9049054013a1b77]*/

--- a/Python/clinic/marshal.c.h
+++ b/Python/clinic/marshal.c.h
@@ -34,12 +34,12 @@ marshal_dump(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwna
     PyObject *file;
     int version = Py_MARSHAL_VERSION;
 
-    if (!_PyArg_ParseStack(args, nargs, "OO|i:dump",
-        &value, &file, &version)) {
+    if (!_PyArg_NoStackKeywords("dump", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("dump", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "OO|i:dump",
+        &value, &file, &version)) {
         goto exit;
     }
     return_value = marshal_dump_impl(module, value, file, version);
@@ -94,12 +94,12 @@ marshal_dumps(PyObject *module, PyObject **args, Py_ssize_t nargs, PyObject *kwn
     PyObject *value;
     int version = Py_MARSHAL_VERSION;
 
-    if (!_PyArg_ParseStack(args, nargs, "O|i:dumps",
-        &value, &version)) {
+    if (!_PyArg_NoStackKeywords("dumps", kwnames)) {
         goto exit;
     }
 
-    if (!_PyArg_NoStackKeywords("dumps", kwnames)) {
+    if (!_PyArg_ParseStack(args, nargs, "O|i:dumps",
+        &value, &version)) {
         goto exit;
     }
     return_value = marshal_dumps_impl(module, value, version);
@@ -142,4 +142,4 @@ exit:
 
     return return_value;
 }
-/*[clinic end generated code: output=9dec2158b8c5d975 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7b147a648614af7e input=a9049054013a1b77]*/

--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -828,13 +828,13 @@ class CLanguage(Language):
                 parser_prototype = parser_prototype_fastcall
 
                 parser_definition = parser_body(parser_prototype, normalize_snippet("""
-                    if (!_PyArg_UnpackStack(args, nargs, "{name}",
-                        {unpack_min}, {unpack_max},
-                        {parse_arguments})) {{
+                    if ({self_type_check}!_PyArg_NoStackKeywords("{name}", kwnames)) {{
                         goto exit;
                     }}
 
-                    if ({self_type_check}!_PyArg_NoStackKeywords("{name}", kwnames)) {{
+                    if (!_PyArg_UnpackStack(args, nargs, "{name}",
+                        {unpack_min}, {unpack_max},
+                        {parse_arguments})) {{
                         goto exit;
                     }}
                     """, indent=4))
@@ -859,12 +859,12 @@ class CLanguage(Language):
                 parser_prototype = parser_prototype_fastcall
 
                 parser_definition = parser_body(parser_prototype, normalize_snippet("""
-                    if (!_PyArg_ParseStack(args, nargs, "{format_units}:{name}",
-                        {parse_arguments})) {{
+                    if ({self_type_check}!_PyArg_NoStackKeywords("{name}", kwnames)) {{
                         goto exit;
                     }}
 
-                    if ({self_type_check}!_PyArg_NoStackKeywords("{name}", kwnames)) {{
+                    if (!_PyArg_ParseStack(args, nargs, "{format_units}:{name}",
+                        {parse_arguments})) {{
                         goto exit;
                     }}
                     """, indent=4))


### PR DESCRIPTION
The function '_PyArg_ParseStack()' and
'_PyArg_UnpackStack' were failing (with error
"XXX() takes Y argument (Z given)") before
the function '_PyArg_NoStackKeywords()' was called.
Thus, the latter did not raise its more meaningful
error : "XXX() takes no keyword arguments".