### PR TITLE
[3.5] Make codecov config on master the only config used (GH-2041)

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,4 +1,5 @@
 codecov:
+  strict_yaml_branch: master
   notify:
     require_ci_to_pass: true
 comment: off


### PR DESCRIPTION
This will allow for centralized management of the Codecov config to prevent skew as well as easier management going forward.

Closes python/core-workflowGH-81.
(cherry picked from commit 11ffb4543bc000dea527bcc0417e2f8bda13790f)