### PR TITLE
[3.6] bpo-30266: support "= None" pattern in AbstractContextManager (…

### DIFF
--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -1,6 +1,7 @@
 """Utilities for with-statement contexts.  See PEP 343."""
 import abc
 import sys
+import _collections_abc
 from collections import deque
 from functools import wraps
 
@@ -25,9 +26,7 @@ class AbstractContextManager(abc.ABC):
     @classmethod
     def __subclasshook__(cls, C):
         if cls is AbstractContextManager:
-            if (any("__enter__" in B.__dict__ for B in C.__mro__) and
-                any("__exit__" in B.__dict__ for B in C.__mro__)):
-                return True
+            return _collections_abc._check_methods(C, "__enter__", "__exit__")
         return NotImplemented
 
 

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -44,6 +44,16 @@ class TestAbstractContextManager(unittest.TestCase):
 
         self.assertTrue(issubclass(DefaultEnter, AbstractContextManager))
 
+        class NoEnter(ManagerFromScratch):
+            __enter__ = None
+
+        self.assertFalse(issubclass(NoEnter, AbstractContextManager))
+
+        class NoExit(ManagerFromScratch):
+            __exit__ = None
+
+        self.assertFalse(issubclass(NoExit, AbstractContextManager))
+
 
 class ContextManagerTestCase(unittest.TestCase):
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -96,6 +96,10 @@ Library
 - bpo-30048: Fixed ``Task.cancel()`` can be ignored when the task is
   running coroutine and the coroutine returned without any more ``await``.
 
+- bpo-30266: contextlib.AbstractContextManager now supports anti-registration
+  by setting __enter__ = None or __exit__ = None, following the pattern
+  introduced in bpo-25958. Patch by Jelle Zijlstra.
+
 - bpo-30298: Weaken the condition of deprecation warnings for inline modifiers.
   Now allowed several subsequential inline modifiers at the start of the
   pattern (e.g. ``'(?i)(?s)...'``).  In verbose mode whitespaces and comments


### PR DESCRIPTION
…GH-1448)

contextlib.AbstractContextManager now supports anti-registration
by setting __enter__ = None or __exit__ = None, following the pattern
introduced in bpo-25958..
(cherry picked from commit 57161aac5eb9bcb0b43e551a1937ff0a84c1ec52)