### PR TITLE
[3.5] bpo-30417: Disable `cpu` resource on AppVeyor (GH-1951).

### DIFF
--- a/.github/appveyor.yml
+++ b/.github/appveyor.yml
@@ -8,7 +8,7 @@ branches:
 build_script:
 - cmd: PCbuild\build.bat -e
 test_script:
-- cmd: PCbuild\rt.bat -q -uall -rwW --timeout=1200 -j0
+- cmd: PCbuild\rt.bat -q -uall -u-cpu -rwW --timeout=1200 -j0
 
 # Only trigger AppVeyor if actual code or its configuration changes
 only_commits:


### PR DESCRIPTION
(cherry picked from commit 42e3acda86829def9adc354fbee77597b849bf9e)