### PR TITLE
[2.7] bpo-25409: Clarify fnmatch and fnmatchcase documentation (GH-1535)

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -44,9 +44,8 @@ patterns.
 .. function:: fnmatch(filename, pattern)
 
    Test whether the *filename* string matches the *pattern* string, returning
-   :const:`True` or :const:`False`.  If the operating system is case-insensitive,
-   then both parameters will be normalized to all lower- or upper-case before
-   the comparison is performed.  :func:`fnmatchcase` can be used to perform a
+   :const:`True` or :const:`False`.  Both parameters are case-normalized
+   using :func:`os.path.normcase`. :func:`fnmatchcase` can be used to perform a
    case-sensitive comparison, regardless of whether that's standard for the
    operating system.
 
@@ -64,7 +63,8 @@ patterns.
 .. function:: fnmatchcase(filename, pattern)
 
    Test whether *filename* matches *pattern*, returning :const:`True` or
-   :const:`False`; the comparison is case-sensitive.
+   :const:`False`; the comparison is case-sensitive and does not apply
+   :func:`os.path.normcase`.
 
 
 .. function:: filter(names, pattern)


### PR DESCRIPTION
Mention that fnmatchcase does not call normcase, and fnmatch does.
(cherry picked from commit e5f6e86c48c7b2eb9e1d6a0e72867b4d8b4720f3)