### PR TITLE
bpo-30621:  import json before using json module

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -412,6 +412,7 @@ sent over a network connection to some distant machine.
 If you have an object ``x``, you can view its JSON string representation with a
 simple line of code::
 
+   >>> import json
    >>> json.dumps([1, 'simple', 'list'])
    '[1, "simple", "list"]'
 


### PR DESCRIPTION
In Input and Output in Python tutorial, json module is used without `import json`.