### PR TITLE
bpo-28556: Updates to typing module

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -350,6 +350,10 @@ Extension Modules
 Library
 -------
 
+- bpo-28556: Updates to typing module: Add generic AsyncContextManager, add
+  support for ContextManager on all versions. Original PRs by Jelle Zijlstra
+  and Ivan Levkivskyi
+
 - bpo-30605: re.compile() no longer raises a BytesWarning when compiling a
   bytes instance with misplaced inline modifier.  Patch by Roy Williams.
 


### PR DESCRIPTION
This PR contains two updates to ``typing`` module:
* Support ``ContextManager`` on all versions (original PR by Jelle Zijlstra).
* Add generic ``AsyncContextManager``.

This needs to be backported to 3.5 and 3.6 (preferably _before_ Monday).

Attn: @gvanrossum 