### PR TITLE
bpo-30629: Fix call lower() twice

### DIFF
--- a/Lib/html/parser.py
+++ b/Lib/html/parser.py
@@ -418,7 +418,7 @@ class HTMLParser(_markupbase.ParserBase):
                 self.handle_data(rawdata[i:gtpos])
                 return gtpos
 
-        self.handle_endtag(elem.lower())
+        self.handle_endtag(elem)
         self.clear_cdata_mode()
         return gtpos
 


### PR DESCRIPTION
https://bugs.python.org/issue30629
https://github.com/python/cpython/blob/master/Lib/html/parser.py#L415

```python
        elem = match.group(1).lower() # script or style
        if self.cdata_elem is not None:
            if elem != self.cdata_elem:
                self.handle_data(rawdata[i:gtpos])
                return gtpos

        self.handle_endtag(elem.lower())
```

elem is lowercase string because `lower()` is called at the first line.
So the last line of calling `lower()` is unnecessary.