### PR TITLE
bpo-30626: Fix error handling in PyImport_Import().

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -1784,9 +1784,13 @@ PyImport_Import(PyObject *module_name)
     Py_DECREF(r);
 
     modules = PyImport_GetModuleDict();
-    r = PyDict_GetItem(modules, module_name);
-    if (r != NULL)
+    r = PyDict_GetItemWithError(modules, module_name);
+    if (r != NULL) {
         Py_INCREF(r);
+    }
+    else if (!PyErr_Occurred()) {
+        PyErr_SetObject(PyExc_KeyError, module_name);
+    }
 
   err:
     Py_XDECREF(globals);


### PR DESCRIPTION
In rare circumstances PyImport_Import() could return NULL without raising
an error.