### PR TITLE
[3.5] bpo-30508: Don't log exceptions if Task/Future "cancel()" method was called

### DIFF
--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -240,6 +240,7 @@ class Future:
         change the future's state to cancelled, schedule the callbacks and
         return True.
         """
+        self._log_traceback = False
         if self._state != _PENDING:
             return False
         self._state = _CANCELLED

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -208,6 +208,7 @@ class Task(futures.Future):
         terminates with a CancelledError exception (even if cancel()
         was not called).
         """
+        self._log_traceback = False
         if self.done():
             return False
         if self._fut_waiter is not None:

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -315,6 +315,14 @@ class FutureTests(test_utils.TestCase):
         self.assertFalse(m_log.error.called)
 
     @mock.patch('asyncio.base_events.logger')
+    def test_tb_logger_not_called_after_cancel(self, m_log):
+        fut = asyncio.Future(loop=self.loop)
+        fut.set_exception(Exception())
+        fut.cancel()
+        del fut
+        self.assertFalse(m_log.error.called)
+
+    @mock.patch('asyncio.base_events.logger')
     def test_tb_logger_result_unretrieved(self, m_log):
         fut = asyncio.Future(loop=self.loop)
         fut.set_result(42)

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1828,6 +1828,25 @@ class TaskTests(test_utils.TestCase):
         })
         mock_handler.reset_mock()
 
+    @mock.patch('asyncio.base_events.logger')
+    def test_tb_logger_not_called_after_cancel(self, m_log):
+        loop = asyncio.new_event_loop()
+        self.set_event_loop(loop)
+
+        @asyncio.coroutine
+        def coro():
+            raise TypeError
+
+        @asyncio.coroutine
+        def runner():
+            task = loop.create_task(coro())
+            yield from asyncio.sleep(0.05, loop=loop)
+            task.cancel()
+            task = None
+
+        loop.run_until_complete(runner())
+        self.assertFalse(m_log.error.called)
+
     @mock.patch('asyncio.coroutines.logger')
     def test_coroutine_never_yielded(self, m_log):
         with set_coroutine_debug(True):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -56,6 +56,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30508: Don't log exceptions if Task/Future "cancel()" method was
+  called.
+
 - bpo-28556: Updates to typing module: Add generic AsyncContextManager, add
   support for ContextManager on all versions. Original PRs by Jelle Zijlstra
   and Ivan Levkivskyi


### PR DESCRIPTION
Base PR https://github.com/python/cpython/pull/2050