### PR TITLE
[3.6] bpo-28994: Fixed errors handling in atexit._run_exitfuncs(). (GH-2034)

### DIFF
--- a/Lib/test/test_atexit.py
+++ b/Lib/test/test_atexit.py
@@ -23,6 +23,9 @@ def raise1():
 def raise2():
     raise SystemError
 
+def exit():
+    raise SystemExit
+
 
 class GeneralTest(unittest.TestCase):
 
@@ -75,6 +78,13 @@ class GeneralTest(unittest.TestCase):
 
         self.assertRaises(ZeroDivisionError, atexit._run_exitfuncs)
         self.assertIn("ZeroDivisionError", self.stream.getvalue())
+
+    def test_exit(self):
+        # be sure a SystemExit is handled properly
+        atexit.register(exit)
+
+        self.assertRaises(SystemExit, atexit._run_exitfuncs)
+        self.assertEqual(self.stream.getvalue(), '')
 
     def test_print_tracebacks(self):
         # Issue #18776: the tracebacks should be printed when errors occur.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -49,6 +49,9 @@ Core and Builtins
 Library
 -------
 
+- bpo-28994: The traceback no longer displayed for SystemExit raised in
+  a callback registered by atexit.
+
 - bpo-30508: Don't log exceptions if Task/Future "cancel()" method was
   called.
 

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -97,7 +97,7 @@ atexit_callfuncs(void)
                 Py_XDECREF(exc_tb);
             }
             PyErr_Fetch(&exc_type, &exc_value, &exc_tb);
-            if (!PyErr_ExceptionMatches(PyExc_SystemExit)) {
+            if (!PyErr_GivenExceptionMatches(exc_type, PyExc_SystemExit)) {
                 PySys_WriteStderr("Error in atexit._run_exitfuncs:\n");
                 PyErr_NormalizeException(&exc_type, &exc_value, &exc_tb);
                 PyErr_Display(exc_type, exc_value, exc_tb);


### PR DESCRIPTION
The traceback no longer displayed for SystemExit raised in a callback registered by atexit..
(cherry picked from commit 3fd54d4a7e604067e2bc0f8cfd58bdbdc09fa7f4)