### PR TITLE
bpo-30639: Lazily compute repr for error

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -662,8 +662,8 @@ def getfile(object):
         object = object.f_code
     if iscode(object):
         return object.co_filename
-    raise TypeError('object of type {} is not a module, class, method, '
-                    'function, traceback, frame, or code object'.format(
+    raise TypeError('module, class, method, function, traceback, frame, or '
+                    'code object was expected, got {}'.format(
                     type(object).__name__))
 
 def getmodulename(path):

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -664,7 +664,7 @@ def getfile(object):
         return object.co_filename
     raise TypeError('object of type {} is not a module, class, method, '
                     'function, traceback, frame, or code object'.format(
-                        type(object).__name__))
+                    type(object).__name__))
 
 def getmodulename(path):
     """Return the module name for a given file, or None."""

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -640,15 +640,6 @@ def cleandoc(doc):
             lines.pop(0)
         return '\n'.join(lines)
 
-class SourceNotFindableError(TypeError):
-    """Exception raised by getfile() when the object has no link to its source.
-    """
-    def __init__(self, obj):
-        self.obj = obj
-
-    def __str__(self):
-        return ('{!r} is not a module, class, method, '
-                'function, traceback, frame, or code object').format(self.obj)
 
 def getfile(object):
     """Work out which source or compiled file an object was defined in."""
@@ -672,7 +663,9 @@ def getfile(object):
         object = object.f_code
     if iscode(object):
         return object.co_filename
-    raise SourceNotFindableError(object)
+    raise TypeError('object of type {} is not a module, class, method, '
+                    'function, traceback, frame, or code object'.format(
+                        type(object).__name__))
 
 def getmodulename(path):
     """Return the module name for a given file, or None."""

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -640,6 +640,16 @@ def cleandoc(doc):
             lines.pop(0)
         return '\n'.join(lines)
 
+class SourceNotFindableError(TypeError):
+    """Exception raised by getfile() when the object has no link to its source.
+    """
+    def __init__(self, obj):
+        self.obj = obj
+
+    def __str__(self):
+        return ('{!r} is not a module, class, method, '
+                'function, traceback, frame, or code object').format(self.obj)
+
 def getfile(object):
     """Work out which source or compiled file an object was defined in."""
     if ismodule(object):
@@ -662,8 +672,7 @@ def getfile(object):
         object = object.f_code
     if iscode(object):
         return object.co_filename
-    raise TypeError('{!r} is not a module, class, method, '
-                    'function, traceback, frame, or code object'.format(object))
+    raise SourceNotFindableError(object)
 
 def getmodulename(path):
     """Return the module name for a given file, or None."""

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -640,7 +640,6 @@ def cleandoc(doc):
             lines.pop(0)
         return '\n'.join(lines)
 
-
 def getfile(object):
     """Work out which source or compiled file an object was defined in."""
     if ismodule(object):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -463,6 +463,14 @@ class TestRetrievingSourceCode(GetSourceBase):
         with self.assertRaises(TypeError):
             inspect.getfile(C)
 
+    def test_getfile_broken_repr(self):
+        class ErrorRepr:
+            def __repr__(self):
+                raise Exception('xyz')
+        er = ErrorRepr()
+        with self.assertRaises(TypeError):
+            inspect.getfile(er)
+
     def test_getmodule_recursion(self):
         from types import ModuleType
         name = '__inspect_dummy'

--- a/Misc/NEWS.d/next/Library/2017-10-24-12-24-56.bpo-30639.ptNM9a.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-24-12-24-56.bpo-30639.ptNM9a.rst
@@ -1,0 +1,2 @@
+:func:`inspect.getfile` no longer computes the repr of unknown objects to
+display in an error message, to protect against badly behaved custom reprs.


### PR DESCRIPTION
If the `TypeError` is caught and handled by calling code, there's no need to compute the object's repr for the error message - the repr may take a long time (real case encountered in IPython & Jedi), or it may throw another error.

If the error results in a traceback, it will still compute the repr and produce the message as before.

I think this defensiveness is worthwhile for `inspect` functions because, by design, we're calling them with arbitrary objects which might be badly behaved, and expecting them to be useful nonetheless.

An alternative fix would be to use `object.__repr__()` to always get the plain `<foo object at 0x123abc...>` representation.

<!-- issue-number: bpo-30639 -->
https://bugs.python.org/issue30639
<!-- /issue-number -->
