### PR TITLE
bpo-30642: IDLE: Fix test_query refleak

### DIFF
--- a/Lib/idlelib/idle_test/test_query.py
+++ b/Lib/idlelib/idle_test/test_query.py
@@ -258,6 +258,7 @@ class QueryGuiTest(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
+        del cls.dialog.destroy
         del cls.dialog
         cls.root.destroy()
         del cls.root


### PR DESCRIPTION
Cause by not deleting `mock.Mock()` object after teardown class.