### PR TITLE
[3.6] bpo-30604: Fix __PyCodeExtraState_Get() prototype

### DIFF
--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -60,7 +60,7 @@ typedef struct _co_extra_state {
 } __PyCodeExtraState;
 
 /* This is temporary for backwards compat in 3.6 and will be removed in 3.7 */
-__PyCodeExtraState* __PyCodeExtraState_Get();
+__PyCodeExtraState* __PyCodeExtraState_Get(void);
 
 /* State unique per thread */
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -571,8 +571,8 @@ PyThreadState_Swap(PyThreadState *newts)
     return oldts;
 }
 
-__PyCodeExtraState* 
-__PyCodeExtraState_Get() {
+__PyCodeExtraState*
+__PyCodeExtraState_Get(void) {
     PyInterpreterState* interp = PyThreadState_Get()->interp;
 
     HEAD_LOCK();


### PR DESCRIPTION
Replace __PyCodeExtraState_Get() with __PyCodeExtraState_Get(void) to
fix the following GCC warning:

./Include/pystate.h:63:1: warning: function declaration isn't a prototype [-Wstrict-prototypes]
 __PyCodeExtraState* __PyCodeExtraState_Get();