### PR TITLE
bpo-28180: Fix test_capi.test_forced_io_encoding()

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -480,7 +480,7 @@ class EmbeddingTests(unittest.TestCase):
 
     def test_forced_io_encoding(self):
         # Checks forced configuration of embedded interpreter IO streams
-        env = {"PYTHONIOENCODING": "utf-8:surrogateescape"}
+        env = dict(os.environ, PYTHONIOENCODING="utf-8:surrogateescape")
         out, err = self.run_embedded_interpreter("forced_io_encoding", env=env)
         if support.verbose > 1:
             print()


### PR DESCRIPTION
Don't run Python in an empty environment, but copy the current
environment and set PYTHONIOENCODING. So the test works also on
Python compiled in shared mode (using libpython).