### PR TITLE
bpo-30654: Do not reset SIGINT handler to SIG_DFL in finisignal

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,10 @@ What's New in Python 2.7.14?
 Core and Builtins
 -----------------
 
+- bpo-30654: Fixed reset of the SIGINT handler to SIG_DFL on interpreter
+  shutdown even when there was a custom handler set previously. Patch by
+  Philipp Kerling.
+
 - bpo-27945: Fixed various segfaults with dict when input collections are
   mutated during searching, inserting or comparing.  Based on patches by
   Duane Griffin and Tim Mitchell.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -95,13 +95,6 @@ static PyObject *DefaultHandler;
 static PyObject *IgnoreHandler;
 static PyObject *IntHandler;
 
-/* On Solaris 8, gcc will produce a warning that the function
-   declaration is not a prototype. This is caused by the definition of
-   SIG_DFL as (void (*)())0; the correct declaration would have been
-   (void (*)(int))0. */
-
-static PyOS_sighandler_t old_siginthandler = SIG_DFL;
-
 #ifdef HAVE_GETITIMER
 static PyObject *ItimerError;
 
@@ -622,7 +615,7 @@ initsignal(void)
         /* Install default int handler */
         Py_INCREF(IntHandler);
         Py_SETREF(Handlers[SIGINT].func, IntHandler);
-        old_siginthandler = PyOS_setsig(SIGINT, signal_handler);
+        PyOS_setsig(SIGINT, signal_handler);
     }
 
 #ifdef SIGHUP
@@ -865,14 +858,11 @@ finisignal(void)
     int i;
     PyObject *func;
 
-    PyOS_setsig(SIGINT, old_siginthandler);
-    old_siginthandler = SIG_DFL;
-
     for (i = 1; i < NSIG; i++) {
         func = Handlers[i].func;
         Handlers[i].tripped = 0;
         Handlers[i].func = NULL;
-        if (i != SIGINT && func != NULL && func != Py_None &&
+        if (func != NULL && func != Py_None &&
             func != DefaultHandler && func != IgnoreHandler)
             PyOS_setsig(i, SIG_DFL);
         Py_XDECREF(func);


### PR DESCRIPTION
Instead of saving old_siginthandler which will always be SIG_DFL, just use the normal reset code. This means that SIGINT will *not* be reset to SIG_DFL if it had a custom C handler during initialization, since `func` will be `Py_None` then.

I'm not sure if this is the intended behavior. But the prior behavior was broken, so it's an improvement.

https://bugs.python.org/issue30654