### PR TITLE
[3.6]bpo-30642: Fix ref leak in idle_test.test_macosx (#2163)

### DIFF
--- a/Lib/idlelib/idle_test/test_macosx.py
+++ b/Lib/idlelib/idle_test/test_macosx.py
@@ -77,6 +77,10 @@ class SetupTest(unittest.TestCase):
         requires('gui')
         cls.root = tk.Tk()
         cls.root.withdraw()
+        def cmd(tkpath, func):
+            assert isinstance(tkpath, str)
+            assert isinstance(func, type(cmd))
+        cls.root.createcommand = cmd
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
(cherry picked from commit 8323189ff1a19566f923c04b95e4d17fa57d1f56)