### PR TITLE
bpo-30656 Fixing documentation for PyModule_New() - now refers to proper function 'PyModule_NewObject()'

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -50,7 +50,7 @@ Module Objects
 
 .. c:function:: PyObject* PyModule_New(const char *name)
 
-   Similar to :c:func:`PyImport_NewObject`, but the name is a UTF-8 encoded
+   Similar to :c:func:`PyModule_NewObject`, but the name is a UTF-8 encoded
    string instead of a Unicode object.
 
 


### PR DESCRIPTION
This should be backported for all Python 3 versions.