### PR TITLE
bpo-27922: Stop gui flash when run IDLE's test_parenmatch

### DIFF
--- a/Lib/idlelib/idle_test/test_parenmatch.py
+++ b/Lib/idlelib/idle_test/test_parenmatch.py
@@ -24,6 +24,7 @@ class ParenMatchTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.root = Tk()
+        cls.root.withdraw()
         cls.text = Text(cls.root)
         cls.editwin = DummyEditwin(cls.text)
         cls.editwin.text_frame = Mock()


### PR DESCRIPTION
Does not work when run 9 times in refleak test.