### PR TITLE
[3.6]bpo-27922: Stop gui flash from idle_test.test_parenmatch (#2171)

### DIFF
--- a/Lib/idlelib/idle_test/test_parenmatch.py
+++ b/Lib/idlelib/idle_test/test_parenmatch.py
@@ -24,6 +24,7 @@ class ParenMatchTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.root = Tk()
+        cls.root.withdraw()
         cls.text = Text(cls.root)
         cls.editwin = DummyEditwin(cls.text)
         cls.editwin.text_frame = Mock()


### PR DESCRIPTION
For unknown reasons, this does not work when running leak tests.
(cherry picked from commit 049cf2bb44038351e1b2eed4fc7b1b522329e550)