### PR TITLE
[2.7] bpo-30657: Check & prevent integer overflow in PyString_DecodeEscape

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -152,6 +152,7 @@ Gregory Bond
 Matias Bordese
 Jonas Borgström
 Jurjen Bos
+Jay Bosamiya
 Peter Bosch
 Dan Boswell
 Eric Bouck

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 2.7.14?
 Core and Builtins
 -----------------
 
+- bpo-30657: Fixed possible integer overflow in PyString_DecodeEscape.
+  Patch by Jay Bosamiya.
+
 - bpo-27945: Fixed various segfaults with dict when input collections are
   mutated during searching, inserting or comparing.  Based on patches by
   Duane Griffin and Tim Mitchell.

--- a/Objects/stringobject.c
+++ b/Objects/stringobject.c
@@ -612,7 +612,13 @@ PyObject *PyString_DecodeEscape(const char *s,
     char *p, *buf;
     const char *end;
     PyObject *v;
-    Py_ssize_t newlen = recode_encoding ? 4*len:len;
+    Py_ssize_t newlen;
+    /* Check for integer overflow */
+    if (recode_encoding && (len > PY_SSIZE_T_MAX / 4)) {
+        PyErr_SetString(PyExc_OverflowError, "string is too large");
+        return NULL;
+    }
+    newlen = recode_encoding ? 4*len:len;
     v = PyString_FromStringAndSize((char *)NULL, newlen);
     if (v == NULL)
         return NULL;


### PR DESCRIPTION
See https://bugs.python.org/issue30657 for the issue and POC for overflow.