### PR TITLE
[3.6] bpo-30649: test_os tolerates 50 ms delta for utime (#2156)

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -622,9 +622,12 @@ class UtimeTests(unittest.TestCase):
 
         if not self.support_subsecond(self.fname):
             delta = 1.0
+        elif os.name == 'nt':
+            # On Windows, the usual resolution of time.time() is 15.6 ms.
+            # bpo-30649: Tolerate 50 ms for slow Windows buildbots.
+            delta = 0.050
         else:
-            # On Windows, the usual resolution of time.time() is 15.6 ms
-            delta = 0.020
+            delta = 0.010
         st = os.stat(self.fname)
         msg = ("st_time=%r, current=%r, dt=%r"
                % (st.st_mtime, current, st.st_mtime - current))

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -627,7 +627,9 @@ class UtimeTests(unittest.TestCase):
             # bpo-30649: Tolerate 50 ms for slow Windows buildbots.
             delta = 0.050
         else:
-            delta = 0.010
+            # bpo-30649: PPC64 Fedora 3.x buildbot requires
+            # at least a delta of 14 ms
+            delta = 0.020
         st = os.stat(self.fname)
         msg = ("st_time=%r, current=%r, dt=%r"
                % (st.st_mtime, current, st.st_mtime - current))


### PR DESCRIPTION
On Windows, tolerate a delta of 50 ms instead of 20 ms in
test_utime_current() and test_utime_current_old() of test_os.

On other platforms, reduce the delta from 20 ms to 10 ms.
(cherry picked from commit c94caca65cd38802243b5279cf85ee44ffb2abb8)