### PR TITLE
bpo-30649: Revert utime delta in test_os

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -626,7 +626,9 @@ class UtimeTests(unittest.TestCase):
             # bpo-30649: Tolerate 50 ms for slow Windows buildbots.
             delta = 0.050
         else:
-            delta = 0.010
+            # bpo-30649: PPC64 Fedora 3.x buildbot requires
+            # at least a delta of 14 ms
+            delta = 0.020
         st = os.stat(self.fname)
         msg = ("st_time=%r, current=%r, dt=%r"
                % (st.st_mtime, current, st.st_mtime - current))


### PR DESCRIPTION
PPC64 Fedora 3.x buildbot requires at least a delta of 14 ms: revert
the utime delta to 20 ms.

I tried 10 ms, but test_os failed on the PPC64 Fedora 3.x buildbot.