### PR TITLE
bpo-30662: fixed OrderedDict.__init__ docstring re PEP 468

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -85,8 +85,7 @@ class OrderedDict(dict):
 
     def __init__(*args, **kwds):
         '''Initialize an ordered dictionary.  The signature is the same as
-        regular dictionaries.  As of Python 3.6, keyword argument insertion
-        order is preserved (PEP 468).
+        regular dictionaries.  Keyword argument order is preserved.
         '''
         if not args:
             raise TypeError("descriptor '__init__' of 'OrderedDict' object "

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -86,7 +86,7 @@ class OrderedDict(dict):
     def __init__(*args, **kwds):
         '''Initialize an ordered dictionary.  The signature is the same as
         regular dictionaries.  As of Python 3.6, keyword argument insertion
-        order is stable. (PEP 468)
+        order is preserved (PEP 468).
         '''
         if not args:
             raise TypeError("descriptor '__init__' of 'OrderedDict' object "

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -85,7 +85,7 @@ class OrderedDict(dict):
 
     def __init__(*args, **kwds):
         '''Initialize an ordered dictionary.  The signature is the same as
-        regular dictionaries. As of Python 3.6, keyword argument insertion
+        regular dictionaries.  As of Python 3.6, keyword argument insertion
         order is stable. (PEP 468)
         '''
         if not args:

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -86,8 +86,7 @@ class OrderedDict(dict):
     def __init__(*args, **kwds):
         '''Initialize an ordered dictionary.  The signature is the same as
         regular dictionaries. As of Python 3.6, keyword argument insertion
-        order is stable, not arbitrary as it was in Python 3.5 and earlier
-        releases. (PEP 468)
+        order is stable. (PEP 468)
         '''
         if not args:
             raise TypeError("descriptor '__init__' of 'OrderedDict' object "

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -85,9 +85,9 @@ class OrderedDict(dict):
 
     def __init__(*args, **kwds):
         '''Initialize an ordered dictionary.  The signature is the same as
-        regular dictionaries, but keyword arguments are not recommended because
-        their insertion order is arbitrary.
-
+        regular dictionaries. As of Python 3.6, keyword argument insertion
+        order is stable, not arbitrary as it was in Python 3.5 and earlier
+        releases. (PEP 468)
         '''
         if not args:
             raise TypeError("descriptor '__init__' of 'OrderedDict' object "

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -882,7 +882,7 @@ odict_eq(PyObject *a, PyObject *b)
 
 PyDoc_STRVAR(odict_init__doc__,
 "Initialize an ordered dictionary.  The signature is the same as\n\
-        regular dictionaries. As of Python 3.6, keyword argument insertion\n\
+        regular dictionaries.  As of Python 3.6, keyword argument insertion\n\
         order is stable. (PEP 468)\n\
 \n\
         ");

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -883,7 +883,7 @@ odict_eq(PyObject *a, PyObject *b)
 PyDoc_STRVAR(odict_init__doc__,
 "Initialize an ordered dictionary.  The signature is the same as\n\
         regular dictionaries.  As of Python 3.6, keyword argument insertion\n\
-        order is stable. (PEP 468)\n\
+        order is preserved (PEP 468).\n\
 \n\
         ");
 

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -882,8 +882,8 @@ odict_eq(PyObject *a, PyObject *b)
 
 PyDoc_STRVAR(odict_init__doc__,
 "Initialize an ordered dictionary.  The signature is the same as\n\
-        regular dictionaries, but keyword arguments are not recommended because\n\
-        their insertion order is arbitrary.\n\
+        regular dictionaries. As of Python 3.6, keyword argument insertion\n\
+        order is stable. (PEP 468)\n\
 \n\
         ");
 

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -882,8 +882,7 @@ odict_eq(PyObject *a, PyObject *b)
 
 PyDoc_STRVAR(odict_init__doc__,
 "Initialize an ordered dictionary.  The signature is the same as\n\
-        regular dictionaries.  As of Python 3.6, keyword argument insertion\n\
-        order is preserved (PEP 468).\n\
+        regular dictionaries.  Keyword argument order is preserved.\n\
 \n\
         ");
 


### PR DESCRIPTION
As of Python 3.6, [PEP 468](https://www.python.org/dev/peps/pep-0468/) indicates that kwarg order is no longer arbitrary, but stable wrt to the order of args stated in source code. OrderedDict's docstring should be clear about that, not describe the situation that obtained in Python 3.5 and prior.