### PR TITLE
bpo-30565: Remove PEP 538 warnings

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -401,10 +401,6 @@ get_default_standard_stream_error_handler(void)
 }
 
 #ifdef PY_COERCE_C_LOCALE
-static const char *_C_LOCALE_COERCION_WARNING =
-    "Python detected LC_CTYPE=C: LC_CTYPE coerced to %.20s (set another locale "
-    "or PYTHONCOERCECLOCALE=0 to disable this locale coercion behavior).\n";
-
 static void
 _coerce_default_locale_settings(const _LocaleCoercionTarget *target)
 {
@@ -419,7 +415,6 @@ _coerce_default_locale_settings(const _LocaleCoercionTarget *target)
                 "Error setting LC_CTYPE, skipping C locale coercion\n");
         return;
     }
-    fprintf(stderr, _C_LOCALE_COERCION_WARNING, newloc);
 
     /* Reconfigure with the overridden environment variables */
     setlocale(LC_ALL, "");
@@ -463,26 +458,6 @@ _Py_CoerceLegacyLocale(void)
     /* No C locale warning here, as Py_Initialize will emit one later */
 #endif
 }
-
-
-#ifdef PY_WARN_ON_C_LOCALE
-static const char *_C_LOCALE_WARNING =
-    "Python runtime initialized with LC_CTYPE=C (a locale with default ASCII "
-    "encoding), which may cause Unicode compatibility problems. Using C.UTF-8, "
-    "C.utf8, or UTF-8 (if available) as alternative Unicode-compatible "
-    "locales is recommended.\n";
-
-static void
-_emit_stderr_warning_for_c_locale(void)
-{
-    const char *coerce_c_locale = getenv("PYTHONCOERCECLOCALE");
-    if (coerce_c_locale == NULL || strncmp(coerce_c_locale, "0", 2) != 0) {
-        if (_Py_LegacyLocaleDetected()) {
-            fprintf(stderr, "%s", _C_LOCALE_WARNING);
-        }
-    }
-}
-#endif
 
 
 /* Global initializations.  Can be undone by Py_Finalize().  Don't
@@ -561,9 +536,6 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
        the locale's charset without having to switch
        locales. */
     setlocale(LC_CTYPE, "");
-#ifdef PY_WARN_ON_C_LOCALE
-    _emit_stderr_warning_for_c_locale();
-#endif
 #endif
 #endif
 

--- a/configure
+++ b/configure
@@ -835,7 +835,6 @@ enable_ipv6
 with_doc_strings
 with_pymalloc
 with_c_locale_coercion
-with_c_locale_warning
 with_valgrind
 with_dtrace
 with_fpectl
@@ -1532,9 +1531,6 @@ Optional Packages:
   --with(out)-pymalloc    disable/enable specialized mallocs
   --with(out)-c-locale-coercion
                           disable/enable C locale coercion to a UTF-8 based
-                          locale
-  --with(out)-c-locale-warning
-                          disable/enable locale compatibility warning in the C
                           locale
   --with-valgrind         Enable Valgrind support
   --with(out)-dtrace      disable/enable DTrace support
@@ -11077,29 +11073,6 @@ $as_echo "#define PY_COERCE_C_LOCALE 1" >>confdefs.h
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_c_locale_coercion" >&5
 $as_echo "$with_c_locale_coercion" >&6; }
-
-# Check for --with-c-locale-warning
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-c-locale-warning" >&5
-$as_echo_n "checking for --with-c-locale-warning... " >&6; }
-
-# Check whether --with-c-locale-warning was given.
-if test "${with_c_locale_warning+set}" = set; then :
-  withval=$with_c_locale_warning;
-fi
-
-
-if test -z "$with_c_locale_warning"
-then
-    with_c_locale_warning="yes"
-fi
-if test "$with_c_locale_warning" != "no"
-then
-
-$as_echo "#define PY_WARN_ON_C_LOCALE 1" >>confdefs.h
-
-fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_c_locale_warning" >&5
-$as_echo "$with_c_locale_warning" >&6; }
 
 # Check for Valgrind support
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-valgrind" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -3342,23 +3342,6 @@ then
 fi
 AC_MSG_RESULT($with_c_locale_coercion)
 
-# Check for --with-c-locale-warning
-AC_MSG_CHECKING(for --with-c-locale-warning)
-AC_ARG_WITH(c-locale-warning,
-            AS_HELP_STRING([--with(out)-c-locale-warning],
-              [disable/enable locale compatibility warning in the C locale]))
-
-if test -z "$with_c_locale_warning"
-then
-    with_c_locale_warning="yes"
-fi
-if test "$with_c_locale_warning" != "no"
-then
-    AC_DEFINE(PY_WARN_ON_C_LOCALE, 1,
-      [Define to emit a locale compatibility warning in the C locale])
-fi
-AC_MSG_RESULT($with_c_locale_warning)
-
 # Check for Valgrind support
 AC_MSG_CHECKING([for --with-valgrind])
 AC_ARG_WITH([valgrind],

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1253,9 +1253,6 @@
 /* Define to printf format modifier for Py_ssize_t */
 #undef PY_FORMAT_SIZE_T
 
-/* Define to emit a locale compatibility warning in the C locale */
-#undef PY_WARN_ON_C_LOCALE
-
 /* Define if you want to build an interpreter with many run-time checks. */
 #undef Py_DEBUG
 


### PR DESCRIPTION
Writing warnings to stderr causes many test failures and the warning
cannot be disabled.