### PR TITLE
[3.6] Fix trivial typo in Readme (GH-2185)

### DIFF
--- a/Doc/using/index.rst
+++ b/Doc/using/index.rst
@@ -6,7 +6,7 @@
 
 
 This part of the documentation is devoted to general information on the setup
-of the Python environment on different platform, the invocation of the
+of the Python environment on different platforms, the invocation of the
 interpreter and things that make working with Python easier.
 
 


### PR DESCRIPTION
Replace platform with platforms.
(cherry picked from commit 4ebf03d109f827c91a23256a447c1d74a203dfee)