### PR TITLE
Fix 9 year old typo in code that may never have been triggered

### DIFF
--- a/Lib/asynchat.py
+++ b/Lib/asynchat.py
@@ -122,7 +122,7 @@ class async_chat(asyncore.dispatcher):
             return
 
         if isinstance(data, str) and self.use_encoding:
-            data = bytes(str, self.encoding)
+            data = bytes(data, self.encoding)
         self.ac_in_buffer = self.ac_in_buffer + data
 
         # Continue to search for self.terminator in self.ac_in_buffer,


### PR DESCRIPTION
Seems like this was never actually hit in reality (`socket.recv()` would have had to return a unicode `str` instead of the typical `bytes`).