### PR TITLE
[3.5] bpo-30231: Remove skipped test_imaplib tests (#1419)

### DIFF
--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -917,23 +917,6 @@ class RemoteIMAP_SSLTest(RemoteIMAPTest):
             _server = self.imap_class(self.host, self.port)
             self.check_logincapa(_server)
 
-    @unittest.skipIf(True,
-                     "bpo-30175: FIXME: cyrus.andrew.cmu.edu doesn't accept "
-                     "our randomly generated client x509 certificate anymore")
-    def test_logincapa_with_client_certfile(self):
-        with transient_internet(self.host):
-            _server = self.imap_class(self.host, self.port, certfile=CERTFILE)
-            self.check_logincapa(_server)
-
-    @unittest.skipIf(True,
-                     "bpo-30175: FIXME: cyrus.andrew.cmu.edu doesn't accept "
-                     "our randomly generated client x509 certificate anymore")
-    def test_logincapa_with_client_ssl_context(self):
-        with transient_internet(self.host):
-            _server = self.imap_class(
-                self.host, self.port, ssl_context=self.create_ssl_context())
-            self.check_logincapa(_server)
-
     def test_logout(self):
         with transient_internet(self.host):
             _server = self.imap_class(self.host, self.port)


### PR DESCRIPTION
The public cyrus.andrew.cmu.edu IMAP server (port 993) doesn't accept
TLS connection using our self-signed x509 certificate. Remove the two
tests which are already skipped.