### PR TITLE
typo in random.shuffle's docstring

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -262,7 +262,7 @@ class Random(_random.Random):
         """Shuffle list x in place, and return None.
 
         Optional argument random is a 0-argument function returning a
-        random float in [0.0, 1.0); if it is the default None, the
+        random float in [0.0, 1.0]; if it is the default None, the
         standard random.random will be used.
 
         """


### PR DESCRIPTION
The brackets do not match: [0.0, 1.0)

I changed it to be square brackets on both sides: [0.0, 1.0]