### PR TITLE
[3.6] bpo-30659 : Use ** for kwargs in namedtuple._replace() signatur…

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -866,7 +866,7 @@ field names, the method and attribute names start with an underscore.
     .. versionchanged:: 3.1
         Returns an :class:`OrderedDict` instead of a regular :class:`dict`.
 
-.. method:: somenamedtuple._replace(kwargs)
+.. method:: somenamedtuple._replace(**kwargs)
 
     Return a new instance of the named tuple replacing specified fields with new
     values::


### PR DESCRIPTION
…e (GH-2173)

(cherry picked from commit 184bd82ba8106785ba22f0d2477dbd08bef821fb)