### PR TITLE
[3.6]bpo-15786: Fix IDLE autocomplete return problem. (#2198)

### DIFF
--- a/Lib/idlelib/autocomplete_w.py
+++ b/Lib/idlelib/autocomplete_w.py
@@ -325,8 +325,9 @@ class AutoCompleteWindow:
             return "break"
 
         elif keysym == "Return":
+            self.complete()
             self.hide_window()
-            return None
+            return 'break'
 
         elif (self.mode == COMPLETE_ATTRIBUTES and keysym in
               ("period", "space", "parenleft", "parenright", "bracketleft",


### PR DESCRIPTION
Before, <return> would not, for instance, complete 're.c' to 're.compile' even with 'compile' highlighted.  Now it does.  Before, <return> was inserted into text, which in Shell meant compile() and possibly execute.  Now cursor is left after completion.
(cherry picked from commit 32fd874afe55e396e3c9a5af35e7bb3d8e0b8f02)