### PR TITLE
bpo-27485: Rename and deprecate undocumented functions in urllib.parse

### DIFF
--- a/Lib/lib2to3/fixes/fix_urllib.py
+++ b/Lib/lib2to3/fixes/fix_urllib.py
@@ -16,9 +16,9 @@ MAPPING = {"urllib":  [
                      "pathname2url", "url2pathname"]),
                 ("urllib.parse",
                     ["quote", "quote_plus", "unquote", "unquote_plus",
-                     "urlencode", "_splitattr", "_splithost", "_splitnport",
-                     "_splitpasswd", "_splitport", "_splitquery", "_splittag",
-                     "_splittype", "_splituser", "_splitvalue", ]),
+                     "urlencode", "splitattr", "splithost", "splitnport",
+                     "splitpasswd", "splitport", "splitquery", "splittag",
+                     "splittype", "splituser", "splitvalue", ]),
                 ("urllib.error",
                     ["ContentTooShortError"])],
            "urllib2" : [

--- a/Lib/lib2to3/fixes/fix_urllib.py
+++ b/Lib/lib2to3/fixes/fix_urllib.py
@@ -16,9 +16,9 @@ MAPPING = {"urllib":  [
                      "pathname2url", "url2pathname"]),
                 ("urllib.parse",
                     ["quote", "quote_plus", "unquote", "unquote_plus",
-                     "urlencode", "splitattr", "splithost", "splitnport",
-                     "splitpasswd", "splitport", "splitquery", "splittag",
-                     "splittype", "splituser", "splitvalue", ]),
+                     "urlencode", "_splitattr", "_splithost", "_splitnport",
+                     "_splitpasswd", "_splitport", "_splitquery", "_splittag",
+                     "_splittype", "_splituser", "_splitvalue", ]),
                 ("urllib.error",
                     ["ContentTooShortError"])],
            "urllib2" : [

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -113,7 +113,7 @@ class MimeTypes:
         Optional `strict' argument when False adds a bunch of commonly found,
         but non-standard types.
         """
-        scheme, url = urllib.parse.splittype(url)
+        scheme, url = urllib.parse._splittype(url)
         if scheme == 'data':
             # syntax of data URLs:
             # dataurl   := "data:" [ mediatype ] [ ";base64" ] "," data

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1144,83 +1144,83 @@ class DeprecationTest(unittest.TestCase):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splittype('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splittype() is deprecated as of 3.7, '
+                         'urllib.parse.splittype() is deprecated as of 3.8, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splithost_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splithost('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splithost() is deprecated as of 3.7, '
+                         'urllib.parse.splithost() is deprecated as of 3.8, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splituser_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splituser('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splituser() is deprecated as of 3.7, '
+                         'urllib.parse.splituser() is deprecated as of 3.8, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitpasswd_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splitpasswd('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitpasswd() is deprecated as of 3.7, '
+                         'urllib.parse.splitpasswd() is deprecated as of 3.8, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitport_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splitport('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitport() is deprecated as of 3.7, '
+                         'urllib.parse.splitport() is deprecated as of 3.8, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitnport_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splitnport('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitnport() is deprecated as of 3.7, '
+                         'urllib.parse.splitnport() is deprecated as of 3.8, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitquery_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splitquery('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitquery() is deprecated as of 3.7, '
+                         'urllib.parse.splitquery() is deprecated as of 3.8, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splittag_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splittag('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splittag() is deprecated as of 3.7, '
+                         'urllib.parse.splittag() is deprecated as of 3.8, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitattr_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splitattr('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitattr() is deprecated as of 3.7, '
+                         'urllib.parse.splitattr() is deprecated as of 3.8, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitvalue_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.splitvalue('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.splitvalue() is deprecated as of 3.7, '
+                         'urllib.parse.splitvalue() is deprecated as of 3.8, '
                          'use urllib.parse.parse_qsl() instead')
 
     def test_to_bytes_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.to_bytes('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.to_bytes() is deprecated as of 3.7')
+                         'urllib.parse.to_bytes() is deprecated as of 3.8')
 
     def test_unwrap(self):
         with self.assertWarns(DeprecationWarning) as cm:
             urllib.parse.unwrap('')
         self.assertEqual(str(cm.warning),
-                         'urllib.parse.unwrap() is deprecated as of 3.7')
+                         'urllib.parse.unwrap() is deprecated as of 3.8')
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1,5 +1,6 @@
 import unittest
 import urllib.parse
+import warnings
 
 RFC1808_BASE = "http://a/b/c/d;p?q#f"
 RFC2396_BASE = "http://a/b/c/d;p?q"
@@ -993,7 +994,7 @@ class Utility_Tests(unittest.TestCase):
     # In Python 2 this test class was in test_urllib.
 
     def test_splittype(self):
-        splittype = urllib.parse.splittype
+        splittype = urllib.parse._splittype
         self.assertEqual(splittype('type:opaquestring'), ('type', 'opaquestring'))
         self.assertEqual(splittype('opaquestring'), (None, 'opaquestring'))
         self.assertEqual(splittype(':opaquestring'), (None, ':opaquestring'))
@@ -1001,7 +1002,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splittype('type:opaque:string'), ('type', 'opaque:string'))
 
     def test_splithost(self):
-        splithost = urllib.parse.splithost
+        splithost = urllib.parse._splithost
         self.assertEqual(splithost('//www.example.org:80/foo/bar/baz.html'),
                          ('www.example.org:80', '/foo/bar/baz.html'))
         self.assertEqual(splithost('//www.example.org:80'),
@@ -1030,7 +1031,7 @@ class Utility_Tests(unittest.TestCase):
                          ('example.net', '/file#'))
 
     def test_splituser(self):
-        splituser = urllib.parse.splituser
+        splituser = urllib.parse._splituser
         self.assertEqual(splituser('User:Pass@www.python.org:080'),
                          ('User:Pass', 'www.python.org:080'))
         self.assertEqual(splituser('@www.python.org:080'),
@@ -1045,7 +1046,7 @@ class Utility_Tests(unittest.TestCase):
     def test_splitpasswd(self):
         # Some of the password examples are not sensible, but it is added to
         # confirming to RFC2617 and addressing issue4675.
-        splitpasswd = urllib.parse.splitpasswd
+        splitpasswd = urllib.parse._splitpasswd
         self.assertEqual(splitpasswd('user:ab'), ('user', 'ab'))
         self.assertEqual(splitpasswd('user:a\nb'), ('user', 'a\nb'))
         self.assertEqual(splitpasswd('user:a\tb'), ('user', 'a\tb'))
@@ -1061,7 +1062,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitpasswd(':ab'), ('', 'ab'))
 
     def test_splitport(self):
-        splitport = urllib.parse.splitport
+        splitport = urllib.parse._splitport
         self.assertEqual(splitport('parrot:88'), ('parrot', '88'))
         self.assertEqual(splitport('parrot'), ('parrot', None))
         self.assertEqual(splitport('parrot:'), ('parrot', None))
@@ -1072,7 +1073,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitport(':88'), ('', '88'))
 
     def test_splitnport(self):
-        splitnport = urllib.parse.splitnport
+        splitnport = urllib.parse._splitnport
         self.assertEqual(splitnport('parrot:88'), ('parrot', 88))
         self.assertEqual(splitnport('parrot'), ('parrot', -1))
         self.assertEqual(splitnport('parrot', 55), ('parrot', 55))
@@ -1086,7 +1087,7 @@ class Utility_Tests(unittest.TestCase):
     def test_splitquery(self):
         # Normal cases are exercised by other tests; ensure that we also
         # catch cases with no port specified (testcase ensuring coverage)
-        splitquery = urllib.parse.splitquery
+        splitquery = urllib.parse._splitquery
         self.assertEqual(splitquery('http://python.org/fake?foo=bar'),
                          ('http://python.org/fake', 'foo=bar'))
         self.assertEqual(splitquery('http://python.org/fake?foo=bar?'),
@@ -1096,7 +1097,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitquery('?foo=bar'), ('', 'foo=bar'))
 
     def test_splittag(self):
-        splittag = urllib.parse.splittag
+        splittag = urllib.parse._splittag
         self.assertEqual(splittag('http://example.com?foo=bar#baz'),
                          ('http://example.com?foo=bar', 'baz'))
         self.assertEqual(splittag('http://example.com?foo=bar#'),
@@ -1108,7 +1109,7 @@ class Utility_Tests(unittest.TestCase):
                          ('http://example.com?foo=bar#baz', 'boo'))
 
     def test_splitattr(self):
-        splitattr = urllib.parse.splitattr
+        splitattr = urllib.parse._splitattr
         self.assertEqual(splitattr('/path;attr1=value1;attr2=value2'),
                          ('/path', ['attr1=value1', 'attr2=value2']))
         self.assertEqual(splitattr('/path;'), ('/path', ['']))
@@ -1119,7 +1120,7 @@ class Utility_Tests(unittest.TestCase):
     def test_splitvalue(self):
         # Normal cases are exercised by other tests; test pathological cases
         # with no key/value pairs. (testcase ensuring coverage)
-        splitvalue = urllib.parse.splitvalue
+        splitvalue = urllib.parse._splitvalue
         self.assertEqual(splitvalue('foo=bar'), ('foo', 'bar'))
         self.assertEqual(splitvalue('foo='), ('foo', ''))
         self.assertEqual(splitvalue('=bar'), ('', 'bar'))
@@ -1127,14 +1128,99 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitvalue('foo=bar=baz'), ('foo', 'bar=baz'))
 
     def test_to_bytes(self):
-        result = urllib.parse.to_bytes('http://www.python.org')
+        result = urllib.parse._to_bytes('http://www.python.org')
         self.assertEqual(result, 'http://www.python.org')
-        self.assertRaises(UnicodeError, urllib.parse.to_bytes,
+        self.assertRaises(UnicodeError, urllib.parse._to_bytes,
                           'http://www.python.org/medi\u00e6val')
 
     def test_unwrap(self):
-        url = urllib.parse.unwrap('<URL:type://host/path>')
+        url = urllib.parse._unwrap('<URL:type://host/path>')
         self.assertEqual(url, 'type://host/path')
+
+
+class DeprecationTest(unittest.TestCase):
+
+    def test_splittype_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splittype()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splittype() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_splithost_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splithost()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splithost() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_splituser_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splituser()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splituser() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_splitpasswd_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splitpasswd()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splitpasswd() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_splitport_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splitport()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splitport() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_splitnport_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splitnport()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splitnport() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_splitquery_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splitquery()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splitquery() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_splittag_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splittag()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splittag() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_splitattr_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splitattr()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splitattr() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_splitvalue_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.splitvalue()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.splitvalue() is deprecated as of 3.7, '
+                         'use urllib.parse.urlparse() instead')
+
+    def test_to_bytes_deprecation(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.to_bytes()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.to_bytes() is deprecated as of 3.7')
+
+    def test_unwrap(self):
+        with self.assertWarns(DeprecationWarning) as cm:
+            urllib.parse.unwrap()
+        self.assertEqual(str(cm.warning),
+                         'urllib.parse.unwrap() is deprecated as of 3.7')
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -994,7 +994,7 @@ class Utility_Tests(unittest.TestCase):
     # In Python 2 this test class was in test_urllib.
 
     def test_splittype(self):
-        splittype = urllib.parse._splittype
+        splittype = urllib.parse.splittype
         self.assertEqual(splittype('type:opaquestring'), ('type', 'opaquestring'))
         self.assertEqual(splittype('opaquestring'), (None, 'opaquestring'))
         self.assertEqual(splittype(':opaquestring'), (None, ':opaquestring'))
@@ -1002,7 +1002,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splittype('type:opaque:string'), ('type', 'opaque:string'))
 
     def test_splithost(self):
-        splithost = urllib.parse._splithost
+        splithost = urllib.parse.splithost
         self.assertEqual(splithost('//www.example.org:80/foo/bar/baz.html'),
                          ('www.example.org:80', '/foo/bar/baz.html'))
         self.assertEqual(splithost('//www.example.org:80'),
@@ -1031,7 +1031,7 @@ class Utility_Tests(unittest.TestCase):
                          ('example.net', '/file#'))
 
     def test_splituser(self):
-        splituser = urllib.parse._splituser
+        splituser = urllib.parse.splituser
         self.assertEqual(splituser('User:Pass@www.python.org:080'),
                          ('User:Pass', 'www.python.org:080'))
         self.assertEqual(splituser('@www.python.org:080'),
@@ -1046,7 +1046,7 @@ class Utility_Tests(unittest.TestCase):
     def test_splitpasswd(self):
         # Some of the password examples are not sensible, but it is added to
         # confirming to RFC2617 and addressing issue4675.
-        splitpasswd = urllib.parse._splitpasswd
+        splitpasswd = urllib.parse.splitpasswd
         self.assertEqual(splitpasswd('user:ab'), ('user', 'ab'))
         self.assertEqual(splitpasswd('user:a\nb'), ('user', 'a\nb'))
         self.assertEqual(splitpasswd('user:a\tb'), ('user', 'a\tb'))
@@ -1062,7 +1062,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitpasswd(':ab'), ('', 'ab'))
 
     def test_splitport(self):
-        splitport = urllib.parse._splitport
+        splitport = urllib.parse.splitport
         self.assertEqual(splitport('parrot:88'), ('parrot', '88'))
         self.assertEqual(splitport('parrot'), ('parrot', None))
         self.assertEqual(splitport('parrot:'), ('parrot', None))
@@ -1073,7 +1073,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitport(':88'), ('', '88'))
 
     def test_splitnport(self):
-        splitnport = urllib.parse._splitnport
+        splitnport = urllib.parse.splitnport
         self.assertEqual(splitnport('parrot:88'), ('parrot', 88))
         self.assertEqual(splitnport('parrot'), ('parrot', -1))
         self.assertEqual(splitnport('parrot', 55), ('parrot', 55))
@@ -1087,7 +1087,7 @@ class Utility_Tests(unittest.TestCase):
     def test_splitquery(self):
         # Normal cases are exercised by other tests; ensure that we also
         # catch cases with no port specified (testcase ensuring coverage)
-        splitquery = urllib.parse._splitquery
+        splitquery = urllib.parse.splitquery
         self.assertEqual(splitquery('http://python.org/fake?foo=bar'),
                          ('http://python.org/fake', 'foo=bar'))
         self.assertEqual(splitquery('http://python.org/fake?foo=bar?'),
@@ -1097,7 +1097,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitquery('?foo=bar'), ('', 'foo=bar'))
 
     def test_splittag(self):
-        splittag = urllib.parse._splittag
+        splittag = urllib.parse.splittag
         self.assertEqual(splittag('http://example.com?foo=bar#baz'),
                          ('http://example.com?foo=bar', 'baz'))
         self.assertEqual(splittag('http://example.com?foo=bar#'),
@@ -1109,7 +1109,7 @@ class Utility_Tests(unittest.TestCase):
                          ('http://example.com?foo=bar#baz', 'boo'))
 
     def test_splitattr(self):
-        splitattr = urllib.parse._splitattr
+        splitattr = urllib.parse.splitattr
         self.assertEqual(splitattr('/path;attr1=value1;attr2=value2'),
                          ('/path', ['attr1=value1', 'attr2=value2']))
         self.assertEqual(splitattr('/path;'), ('/path', ['']))
@@ -1120,7 +1120,7 @@ class Utility_Tests(unittest.TestCase):
     def test_splitvalue(self):
         # Normal cases are exercised by other tests; test pathological cases
         # with no key/value pairs. (testcase ensuring coverage)
-        splitvalue = urllib.parse._splitvalue
+        splitvalue = urllib.parse.splitvalue
         self.assertEqual(splitvalue('foo=bar'), ('foo', 'bar'))
         self.assertEqual(splitvalue('foo='), ('foo', ''))
         self.assertEqual(splitvalue('=bar'), ('', 'bar'))
@@ -1128,13 +1128,13 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitvalue('foo=bar=baz'), ('foo', 'bar=baz'))
 
     def test_to_bytes(self):
-        result = urllib.parse._to_bytes('http://www.python.org')
+        result = urllib.parse.to_bytes('http://www.python.org')
         self.assertEqual(result, 'http://www.python.org')
         self.assertRaises(UnicodeError, urllib.parse._to_bytes,
                           'http://www.python.org/medi\u00e6val')
 
     def test_unwrap(self):
-        url = urllib.parse._unwrap('<URL:type://host/path>')
+        url = urllib.parse.unwrap('<URL:type://host/path>')
         self.assertEqual(url, 'type://host/path')
 
 
@@ -1142,83 +1142,83 @@ class DeprecationTest(unittest.TestCase):
 
     def test_splittype_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splittype()
+            urllib.parse.splittype('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splittype() is deprecated as of 3.7, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splithost_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splithost()
+            urllib.parse.splithost('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splithost() is deprecated as of 3.7, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splituser_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splituser()
+            urllib.parse.splituser('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splituser() is deprecated as of 3.7, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitpasswd_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitpasswd()
+            urllib.parse.splitpasswd('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splitpasswd() is deprecated as of 3.7, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitport_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitport()
+            urllib.parse.splitport('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splitport() is deprecated as of 3.7, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitnport_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitnport()
+            urllib.parse.splitnport('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splitnport() is deprecated as of 3.7, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitquery_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitquery()
+            urllib.parse.splitquery('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splitquery() is deprecated as of 3.7, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splittag_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splittag()
+            urllib.parse.splittag('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splittag() is deprecated as of 3.7, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitattr_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitattr()
+            urllib.parse.splitattr('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splitattr() is deprecated as of 3.7, '
                          'use urllib.parse.urlparse() instead')
 
     def test_splitvalue_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.splitvalue()
+            urllib.parse.splitvalue('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.splitvalue() is deprecated as of 3.7, '
-                         'use urllib.parse.urlparse() instead')
+                         'use urllib.parse.parse_qsl() instead')
 
     def test_to_bytes_deprecation(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.to_bytes()
+            urllib.parse.to_bytes('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.to_bytes() is deprecated as of 3.7')
 
     def test_unwrap(self):
         with self.assertWarns(DeprecationWarning) as cm:
-            urllib.parse.unwrap()
+            urllib.parse.unwrap('')
         self.assertEqual(str(cm.warning),
                          'urllib.parse.unwrap() is deprecated as of 3.7')
 

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -916,7 +916,7 @@ def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
 
 
 def to_bytes(url):
-    warnings.warn("urllib.parse.to_bytes() is deprecated as of 3.7",
+    warnings.warn("urllib.parse.to_bytes() is deprecated as of 3.8",
                   DeprecationWarning, stacklevel=2)
     return _to_bytes(url)
 
@@ -936,7 +936,7 @@ def _to_bytes(url):
 
 
 def unwrap(url):
-    warnings.warn("urllib.parse.unwrap() is deprecated as of 3.7",
+    warnings.warn("urllib.parse.unwrap() is deprecated as of 3.8",
                   DeprecationWarning, stacklevel=2)
     return _unwrap(url)
 
@@ -951,7 +951,7 @@ def _unwrap(url):
 
 
 def splittype(url):
-    warnings.warn("urllib.parse.splittype() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splittype() is deprecated as of 3.8, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
     return _splittype(url)
@@ -972,7 +972,7 @@ def _splittype(url):
 
 
 def splithost(url):
-    warnings.warn("urllib.parse.splithost() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splithost() is deprecated as of 3.8, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
     return _splithost(url)
@@ -995,7 +995,7 @@ def _splithost(url):
 
 
 def splituser(host):
-    warnings.warn("urllib.parse.splituser() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splituser() is deprecated as of 3.8, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
     return _splituser(host)
@@ -1008,7 +1008,7 @@ def _splituser(host):
 
 
 def splitpasswd(user):
-    warnings.warn("urllib.parse.splitpasswd() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splitpasswd() is deprecated as of 3.8, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
     return _splitpasswd(user)
@@ -1021,7 +1021,7 @@ def _splitpasswd(user):
 
 
 def splitport(host):
-    warnings.warn("urllib.parse.splitport() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splitport() is deprecated as of 3.8, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
     return _splitport(host)
@@ -1044,7 +1044,7 @@ def _splitport(host):
 
 
 def splitnport(host, defport=-1):
-    warnings.warn("urllib.parse.splitnport() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splitnport() is deprecated as of 3.8, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
     return _splitnport(host, defport)
@@ -1068,7 +1068,7 @@ def _splitnport(host, defport=-1):
 
 
 def splitquery(url):
-    warnings.warn("urllib.parse.splitquery() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splitquery() is deprecated as of 3.8, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
     return _splitquery(url)
@@ -1083,7 +1083,7 @@ def _splitquery(url):
 
 
 def splittag(url):
-    warnings.warn("urllib.parse.splittag() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splittag() is deprecated as of 3.8, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
     return _splittag(url)
@@ -1098,7 +1098,7 @@ def _splittag(url):
 
 
 def splitattr(url):
-    warnings.warn("urllib.parse.splitattr() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splitattr() is deprecated as of 3.8, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
     return _splitattr(url)
@@ -1112,7 +1112,7 @@ def _splitattr(url):
 
 
 def splitvalue(attr):
-    warnings.warn("urllib.parse.splitvalue() is deprecated as of 3.7, "
+    warnings.warn("urllib.parse.splitvalue() is deprecated as of 3.8, "
                   "use urllib.parse.parse_qsl() instead",
                   DeprecationWarning, stacklevel=2)
     return _splitvalue(attr)

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -289,7 +289,7 @@ by reference to a primary resource and additional identifying information.
 """
 
 _ParseResultBase.__doc__ = """
-ParseResult(scheme, netloc, path, params,  query, fragment)
+ParseResult(scheme, netloc, path, params, query, fragment)
 
 A 6-tuple that contains components of a parsed URL.
 """
@@ -915,7 +915,7 @@ def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
     return '&'.join(l)
 
 
-def to_bytes(url=''):
+def to_bytes(url):
     warnings.warn("urllib.parse.to_bytes() is deprecated as of 3.7",
                   DeprecationWarning, stacklevel=2)
     return _to_bytes(url)
@@ -935,7 +935,7 @@ def _to_bytes(url):
     return url
 
 
-def unwrap(url=''):
+def unwrap(url):
     warnings.warn("urllib.parse.unwrap() is deprecated as of 3.7",
                   DeprecationWarning, stacklevel=2)
     return _unwrap(url)
@@ -950,7 +950,7 @@ def _unwrap(url):
     return url
 
 
-def splittype(url=''):
+def splittype(url):
     warnings.warn("urllib.parse.splittype() is deprecated as of 3.7, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
@@ -971,7 +971,7 @@ def _splittype(url):
     return None, url
 
 
-def splithost(url=''):
+def splithost(url):
     warnings.warn("urllib.parse.splithost() is deprecated as of 3.7, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
@@ -994,11 +994,11 @@ def _splithost(url):
     return None, url
 
 
-def splituser(url=''):
+def splituser(host):
     warnings.warn("urllib.parse.splituser() is deprecated as of 3.7, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
-    return _splituser(url)
+    return _splituser(host)
 
 
 def _splituser(host):
@@ -1007,11 +1007,11 @@ def _splituser(host):
     return (user if delim else None), host
 
 
-def splitpasswd(url=''):
+def splitpasswd(user):
     warnings.warn("urllib.parse.splitpasswd() is deprecated as of 3.7, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
-    return _splitpasswd(url)
+    return _splitpasswd(user)
 
 
 def _splitpasswd(user):
@@ -1020,11 +1020,11 @@ def _splitpasswd(user):
     return user, (passwd if delim else None)
 
 
-def splitport(url=''):
+def splitport(host):
     warnings.warn("urllib.parse.splitport() is deprecated as of 3.7, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
-    return _splitport(url)
+    return _splitport(host)
 
 
 # splittag('/path#tag') --> '/path', 'tag'
@@ -1043,11 +1043,11 @@ def _splitport(host):
     return host, None
 
 
-def splitnport(url=''):
+def splitnport(host, defport=-1):
     warnings.warn("urllib.parse.splitnport() is deprecated as of 3.7, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
-    return _splitnport(url)
+    return _splitnport(host, defport)
 
 
 def _splitnport(host, defport=-1):
@@ -1067,7 +1067,7 @@ def _splitnport(host, defport=-1):
     return host, defport
 
 
-def splitquery(url=''):
+def splitquery(url):
     warnings.warn("urllib.parse.splitquery() is deprecated as of 3.7, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
@@ -1082,7 +1082,7 @@ def _splitquery(url):
     return url, None
 
 
-def splittag(url=''):
+def splittag(url):
     warnings.warn("urllib.parse.splittag() is deprecated as of 3.7, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
@@ -1097,7 +1097,7 @@ def _splittag(url):
     return url, None
 
 
-def splitattr(url=''):
+def splitattr(url):
     warnings.warn("urllib.parse.splitattr() is deprecated as of 3.7, "
                   "use urllib.parse.urlparse() instead",
                   DeprecationWarning, stacklevel=2)
@@ -1111,11 +1111,11 @@ def _splitattr(url):
     return words[0], words[1:]
 
 
-def splitvalue(url=''):
+def splitvalue(attr):
     warnings.warn("urllib.parse.splitvalue() is deprecated as of 3.7, "
-                  "use urllib.parse.urlparse() instead",
+                  "use urllib.parse.parse_qsl() instead",
                   DeprecationWarning, stacklevel=2)
-    return _splitvalue(url)
+    return _splitvalue(attr)
 
 
 def _splitvalue(attr):

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -30,6 +30,7 @@ test_urlparse.py provides a good indicator of parsing behavior.
 import re
 import sys
 import collections
+import warnings
 
 __all__ = ["urlparse", "urlunparse", "urljoin", "urldefrag",
            "urlsplit", "urlunsplit", "urlencode", "parse_qs",
@@ -913,7 +914,14 @@ def urlencode(query, doseq=False, safe='', encoding=None, errors=None,
                         l.append(k + '=' + elt)
     return '&'.join(l)
 
-def to_bytes(url):
+
+def to_bytes(url=''):
+    warnings.warn("urllib.parse.to_bytes() is deprecated as of 3.7",
+                  DeprecationWarning, stacklevel=2)
+    return _to_bytes(url)
+
+
+def _to_bytes(url):
     """to_bytes(u"URL") --> 'URL'."""
     # Most URL schemes require ASCII. If that changes, the conversion
     # can be relaxed.
@@ -926,7 +934,14 @@ def to_bytes(url):
                                " contains non-ASCII characters")
     return url
 
-def unwrap(url):
+
+def unwrap(url=''):
+    warnings.warn("urllib.parse.unwrap() is deprecated as of 3.7",
+                  DeprecationWarning, stacklevel=2)
+    return _unwrap(url)
+
+
+def _unwrap(url):
     """unwrap('<URL:type://host/path>') --> 'type://host/path'."""
     url = str(url).strip()
     if url[:1] == '<' and url[-1:] == '>':
@@ -934,8 +949,16 @@ def unwrap(url):
     if url[:4] == 'URL:': url = url[4:].strip()
     return url
 
+
+def splittype(url=''):
+    warnings.warn("urllib.parse.splittype() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splittype(url)
+
+
 _typeprog = None
-def splittype(url):
+def _splittype(url):
     """splittype('type:opaquestring') --> 'type', 'opaquestring'."""
     global _typeprog
     if _typeprog is None:
@@ -947,8 +970,16 @@ def splittype(url):
         return scheme.lower(), data
     return None, url
 
+
+def splithost(url=''):
+    warnings.warn("urllib.parse.splithost() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splithost(url)
+
+
 _hostprog = None
-def splithost(url):
+def _splithost(url):
     """splithost('//host[:port]/path') --> 'host[:port]', '/path'."""
     global _hostprog
     if _hostprog is None:
@@ -962,19 +993,43 @@ def splithost(url):
         return host_port, path
     return None, url
 
-def splituser(host):
+
+def splituser(url=''):
+    warnings.warn("urllib.parse.splituser() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splituser(url)
+
+
+def _splituser(host):
     """splituser('user[:passwd]@host[:port]') --> 'user[:passwd]', 'host[:port]'."""
     user, delim, host = host.rpartition('@')
     return (user if delim else None), host
 
-def splitpasswd(user):
+
+def splitpasswd(url=''):
+    warnings.warn("urllib.parse.splitpasswd() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splitpasswd(url)
+
+
+def _splitpasswd(user):
     """splitpasswd('user:passwd') -> 'user', 'passwd'."""
     user, delim, passwd = user.partition(':')
     return user, (passwd if delim else None)
 
+
+def splitport(url=''):
+    warnings.warn("urllib.parse.splitport() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splitport(url)
+
+
 # splittag('/path#tag') --> '/path', 'tag'
 _portprog = None
-def splitport(host):
+def _splitport(host):
     """splitport('host:port') --> 'host', 'port'."""
     global _portprog
     if _portprog is None:
@@ -987,7 +1042,15 @@ def splitport(host):
             return host, port
     return host, None
 
-def splitnport(host, defport=-1):
+
+def splitnport(url=''):
+    warnings.warn("urllib.parse.splitnport() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splitnport(url)
+
+
+def _splitnport(host, defport=-1):
     """Split host and port, returning numeric port.
     Return given default port if no ':' found; defaults to -1.
     Return numerical port if a valid number are found after ':'.
@@ -1003,27 +1066,59 @@ def splitnport(host, defport=-1):
         return host, nport
     return host, defport
 
-def splitquery(url):
+
+def splitquery(url=''):
+    warnings.warn("urllib.parse.splitquery() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splitquery(url)
+
+
+def _splitquery(url):
     """splitquery('/path?query') --> '/path', 'query'."""
     path, delim, query = url.rpartition('?')
     if delim:
         return path, query
     return url, None
 
-def splittag(url):
+
+def splittag(url=''):
+    warnings.warn("urllib.parse.splittag() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splittag(url)
+
+
+def _splittag(url):
     """splittag('/path#tag') --> '/path', 'tag'."""
     path, delim, tag = url.rpartition('#')
     if delim:
         return path, tag
     return url, None
 
-def splitattr(url):
+
+def splitattr(url=''):
+    warnings.warn("urllib.parse.splitattr() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splitattr(url)
+
+
+def _splitattr(url):
     """splitattr('/path;attr1=value1;attr2=value2;...') ->
         '/path', ['attr1=value1', 'attr2=value2', ...]."""
     words = url.split(';')
     return words[0], words[1:]
 
-def splitvalue(attr):
+
+def splitvalue(url=''):
+    warnings.warn("urllib.parse.splitvalue() is deprecated as of 3.7, "
+                  "use urllib.parse.urlparse() instead",
+                  DeprecationWarning, stacklevel=2)
+    return _splitvalue(url)
+
+
+def _splitvalue(attr):
     """splitvalue('attr=value') --> 'attr', 'value'."""
     attr, delim, value = attr.partition('=')
     return attr, (value if delim else None)

--- a/Lib/xmlrpc/client.py
+++ b/Lib/xmlrpc/client.py
@@ -1214,7 +1214,7 @@ class Transport:
         if isinstance(host, tuple):
             host, x509 = host
 
-        auth, host = urllib.parse.splituser(host)
+        auth, host = urllib.parse._splituser(host)
 
         if auth:
             auth = urllib.parse.unquote_to_bytes(auth)
@@ -1413,10 +1413,10 @@ class ServerProxy:
         # establish a "logical" server connection
 
         # get the url
-        type, uri = urllib.parse.splittype(uri)
+        type, uri = urllib.parse._splittype(uri)
         if type not in ("http", "https"):
             raise OSError("unsupported XML-RPC protocol")
-        self.__host, self.__handler = urllib.parse.splithost(uri)
+        self.__host, self.__handler = urllib.parse._splithost(uri)
         if not self.__handler:
             self.__handler = "/RPC2"
 

--- a/Misc/NEWS.d/next/Library/2018-04-25-14-05-21.bpo-27485.nclVSU.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-25-14-05-21.bpo-27485.nclVSU.rst
@@ -1,0 +1,1 @@
+Rename and deprecate undocumented functions in :func:`urllib.parse`.


### PR DESCRIPTION
The following functions were undocumented:
`splitattr`, `splithost`, `splitnport`, `splitpasswd`, `splitport`, `splitquery`, `splittag`, `splittype`, `splituser`, `splitvalue`, `to_bytes`, `unwrap`

A note in the 2.7 documentation for `urllib` stated that Python 3 does not expose these helper functions, but yet they were still available.

<!-- issue-number: bpo-27485 -->
https://bugs.python.org/issue27485
<!-- /issue-number -->
