### PR TITLE
bpo-30603: add tests to textwrap.dedent

### DIFF
--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -754,6 +754,11 @@ def foo():
         expect = "Foo\n  Bar\n\n Baz\n"
         self.assertEqual(expect, dedent(text))
 
+        # Uneven indentation with declining indent level.
+        text = "     Foo\n    Bar\n"  # 5 spaces, then 4
+        expect = " Foo\nBar\n"
+        self.assertEqual(expect, dedent(text))
+
     # dedent() should not mangle internal tabs
     def test_dedent_preserve_internal_tabs(self):
         text = "  hello\tthere\n  how are\tyou?"

--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -754,9 +754,20 @@ def foo():
         expect = "Foo\n  Bar\n\n Baz\n"
         self.assertEqual(expect, dedent(text))
 
+    def test_dedent_declining(self):
         # Uneven indentation with declining indent level.
         text = "     Foo\n    Bar\n"  # 5 spaces, then 4
         expect = " Foo\nBar\n"
+        self.assertEqual(expect, dedent(text))
+
+        # Declining indent level with blank line.
+        text = "     Foo\n\n    Bar\n"  # 5 spaces, blank, then 4
+        expect = " Foo\n\nBar\n"
+        self.assertEqual(expect, dedent(text))
+
+        # Declining indent level with whitespace only line.
+        text = "     Foo\n    \n    Bar\n"  # 5 spaces, then 4, then 4
+        expect = " Foo\n\nBar\n"
         self.assertEqual(expect, dedent(text))
 
     # dedent() should not mangle internal tabs


### PR DESCRIPTION
Adding additional tests of declining indent levels, as suggested by Emily Morehouse [on bpo](http://bugs.python.org/issue30603).