### PR TITLE
bpo-30669: add --indent flag to json.tool

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -27,7 +27,7 @@ def main():
                         help='write the output of infile to outfile')
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
-    parser.add_argument('--indent', action='indent', default=4,
+    parser.add_argument('--indent', action='store', default=4, type=int,
                         help='level of indentation used for pretty printing')
     options = parser.parse_args()
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -27,11 +27,14 @@ def main():
                         help='write the output of infile to outfile')
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
+    parser.add_argument('--indent', action='indent', default=4,
+                        help='level of indentation used for pretty printing')
     options = parser.parse_args()
 
     infile = options.infile or sys.stdin
     outfile = options.outfile or sys.stdout
     sort_keys = options.sort_keys
+    indent = options.indent or 4
     with infile:
         try:
             if sort_keys:
@@ -42,7 +45,7 @@ def main():
         except ValueError as e:
             raise SystemExit(e)
     with outfile:
-        json.dump(obj, outfile, sort_keys=sort_keys, indent=4)
+        json.dump(obj, outfile, sort_keys=sort_keys, indent=indent)
         outfile.write('\n')
 
 


### PR DESCRIPTION
Resolves this issue: http://bugs.python.org/issue30669

I have been using the json.tool quite often by running `cat my-file.json | python -m json.tool` or (`:%! python -m json.tool` in vim) to pretty print the json file, but I would like to customize the indentation level to 2 indentation spaces instead of default of 4. Unfortunately, `json.tool` is hard-coded to use 4 spaces for indentation, so I am submitting this PR to enable this ability.

BTW: This is my first PR to cpython, so any suggestions or feedback on this PR would be great :-)

