### PR TITLE
bpo-30602: Fix refleak in os.spawnv()

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5165,7 +5165,7 @@ os_spawnv_impl(PyObject *module, int mode, path_t *path, PyObject *argv)
             return NULL;
         }
         if (i == 0 && !argvlist[0][0]) {
-            free_string_array(argvlist, i);
+            free_string_array(argvlist, i + 1);
             PyErr_SetString(
                 PyExc_ValueError,
                 "spawnv() arg 2 first element cannot be empty");


### PR DESCRIPTION
When os.spawnv() fails while handling arguments, free correctly
argvlist: pass lastarg+1 rather than lastarg to free_string_array()
to also free the first item.