### PR TITLE
[3.6] bpo-30605: Fix compiling binary regexs with BytesWarnings enabled. (GH-2016)

### DIFF
--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -736,7 +736,7 @@ def _parse(source, state, verbose, nested, first=False):
                         if not first or subpattern:
                             import warnings
                             warnings.warn(
-                                'Flags not at the start of the expression %s%s' % (
+                                'Flags not at the start of the expression %r%s' % (
                                     source.string[:20],  # truncate long regexes
                                     ' (truncated)' if len(source.string) > 20 else '',
                                 ),

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1346,7 +1346,7 @@ class ReTests(unittest.TestCase):
             self.assertTrue(re.match(p, lower_char))
         self.assertEqual(
             str(warns.warnings[0].message),
-            'Flags not at the start of the expression %s' % p
+            'Flags not at the start of the expression %r' % p
         )
         self.assertEqual(warns.warnings[0].filename, __file__)
 
@@ -1355,9 +1355,21 @@ class ReTests(unittest.TestCase):
             self.assertTrue(re.match(p, lower_char))
         self.assertEqual(
             str(warns.warnings[0].message),
-            'Flags not at the start of the expression %s (truncated)' % p[:20]
+            'Flags not at the start of the expression %r (truncated)' % p[:20]
         )
         self.assertEqual(warns.warnings[0].filename, __file__)
+
+        # bpo-30605: Compiling a bytes instance regex was throwing a BytesWarning
+        with warnings.catch_warnings():
+            warnings.simplefilter('error', BytesWarning)
+            p = b'A(?i)'
+            with self.assertWarns(DeprecationWarning) as warns:
+                self.assertTrue(re.match(p, b'a'))
+            self.assertEqual(
+                str(warns.warnings[0].message),
+                'Flags not at the start of the expression %r' % p
+            )
+            self.assertEqual(warns.warnings[0].filename, __file__)
 
         with self.assertWarns(DeprecationWarning):
             self.assertTrue(re.match('(?s).(?i)' + upper_char, '\n' + lower_char))

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1663,6 +1663,7 @@ Jakub Wilk
 Gerald S. Williams
 Jason Williams
 John Williams
+Roy Williams
 Sue Williams
 Carol Willing
 Steven Willis

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -51,6 +51,9 @@ Core and Builtins
 Library
 -------
 
+- bpo-30605: re.compile() no longer raises a BytesWarning when compiling a
+  bytes instance with misplaced inline modifier.  Patch by Roy Williams.
+
 - [Security] bpo-29591: Update expat copy from 2.1.1 to 2.2.0 to get fixes
   of CVE-2016-0718 and CVE-2016-4472. See
   https://sourceforge.net/p/expat/bugs/537/ for more information.


### PR DESCRIPTION
Running our unit tests with `-bb` enabled triggered this failure..
(cherry picked from commit 171b9a354e816eebc6d4c3a8553303942e9c5025)