### PR TITLE
[3.5] bpo-30650: Fixed a syntax error: missed right parentheses (GH-2154)

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -12812,7 +12812,7 @@ all_ins(PyObject *m)
     if (PyModule_AddIntMacro(m, SCHED_RR)) return -1;
 #endif
 #ifdef SCHED_SPORADIC
-    if (PyModule_AddIntMacro(m, SCHED_SPORADIC) return -1;
+    if (PyModule_AddIntMacro(m, SCHED_SPORADIC)) return -1;
 #endif
 #ifdef SCHED_BATCH
     if (PyModule_AddIntMacro(m, SCHED_BATCH)) return -1;


### PR DESCRIPTION
(cherry picked from commit 0d32218)