### PR TITLE
bpo-30679: __aexit__ is not called on KeyboardInterrupt

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -452,6 +452,11 @@ class BaseEventLoop(events.AbstractEventLoop):
         try:
             self.run_forever()
         except:
+            if new_task and not future.done():
+                # A signal from outside interrupted the execution. Cancel the
+                # coroutine and wait for the exit handlers to finish
+                future.cancel()
+                self.run_forever()
             if new_task and future.done() and not future.cancelled():
                 # The coroutine raised a BaseException. Consume the exception
                 # to not log a warning, the caller doesn't have access to the


### PR DESCRIPTION
Hi,

Here is the example code I am running:
```python
import asyncio

class it:
	async def __aenter__(self):
		return self
	async def __aexit__(self, *_):
		print('EXIT')

async def main():
	async with it():
		await asyncio.sleep(100)

asyncio.get_event_loop().run_until_complete(main())
```

When this gets interrupted by a SIGINT,I would expect this code to display `EXIT` before the `KeyboardInterrupt` stacktrace. But instead the `__aexit__` function is simply not called.



Here is how I understand things:

A `KeyboardInterrupt` gets raised in `loop.run_forever`, which is caught by the [except clause in `run_until_complete`](https://github.com/arthurdarcet/cpython/blob/d8db05c51f35f8ea0281e98f1b11939369409115/Lib/asyncio/base_events.py#L454). But this clause is supposed to handle errors that occurs in the coroutine, and not outside of it. And so, when this `KeyboardInterrupt` is raised again at the end of the `except`, the underlying coroutine is not cancelled and simply discarded (and the associated warning is hidden because it is explicitly disabled [here](https://github.com/arthurdarcet/cpython/blob/d8db05c51f35f8ea0281e98f1b11939369409115/Lib/asyncio/base_events.py#L449).


The proposed change cancels the underlying coroutine when `run_forever` is interrupted from outside, and then relaunch `run_forever` so that any remaining event handler can finish. It will be stopped right after because of the `done_callback` that is still present.


I have absolutely no idea if this proposed solution is anywhere near the right approach. If it is, I will add some tests to this PR.

Thank you, and sorry for the noise if this is "expected behaviour"
