### PR TITLE
[3.5] bpo-30626: Fix error handling in PyImport_Import(). (GH-2103)

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -1806,9 +1806,13 @@ PyImport_Import(PyObject *module_name)
     Py_DECREF(r);
 
     modules = PyImport_GetModuleDict();
-    r = PyDict_GetItem(modules, module_name);
-    if (r != NULL)
+    r = PyDict_GetItemWithError(modules, module_name);
+    if (r != NULL) {
         Py_INCREF(r);
+    }
+    else if (!PyErr_Occurred()) {
+        PyErr_SetObject(PyExc_KeyError, module_name);
+    }
 
   err:
     Py_XDECREF(globals);


### PR DESCRIPTION
In rare circumstances PyImport_Import() could return NULL without raising
an error.
(cherry picked from commit 145541c)