### PR TITLE
bpo-1360: Add warning to Queue.get() docs about block=True

### DIFF
--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -150,6 +150,11 @@ provide the public methods described below.
    Otherwise (*block* is false), return an item if one is immediately available,
    else raise the :exc:`Empty` exception (*timeout* is ignored in that case).
 
+   Prior to 3.0 on POSIX systems, and for all versions on Windows, if
+   *block* is true and *timeout* is ``None``, this operation goes into
+   an uninterruptible wait on an underlying lock. This means that no exceptions
+   can occur, and in particular a SIGINT will not trigger a :exc:`KeyboardInterrupt`.
+
 
 .. method:: Queue.get_nowait()
 


### PR DESCRIPTION
When Queue.get() is called with `block=True` and `timeout=None`,
the thread will block and wait on the Queue's not_empty condition
variable without a timeout. Under these conditions, per the discussion
in https://bugs.python.org/issue1360 , if the main thread is waiting on
the get(), it will not respond to SIGINT.

This can be a source of confusion in scripts which want to use Queues to
wait on async processes, as Ctrl+C is commonplace.
As noted in issue1360, this is unlikely to change because it would slow down
lock acquisition, so update the docs to include a warning instead.

I don't think there are other particularly interesting scenarios which
deserve explicit mention in the docs.
Needs to be backported to 2.7, and all 3.x maintenance branches.

<!-- issue-number: [bpo-1360](https://bugs.python.org/issue1360) -->
https://bugs.python.org/issue1360
<!-- /issue-number -->
