### PR TITLE
bpo-30681: Change error handling to return None in case of invalid date

### DIFF
--- a/Lib/email/headerregistry.py
+++ b/Lib/email/headerregistry.py
@@ -300,7 +300,13 @@ class DateHeader:
             kwds['parse_tree'] = parser.TokenList()
             return
         if isinstance(value, str):
+            kwds['decoded'] = value
             value = utils.parsedate_to_datetime(value)
+            if value is None:
+                kwds['defects'].append(errors.InvalidHeaderDefect('Invalid value in date'))
+                kwds['datetime'] = None
+                kwds['parse_tree'] = parser.TokenList()
+                return
         kwds['datetime'] = value
         kwds['decoded'] = utils.format_datetime(kwds['datetime'])
         kwds['parse_tree'] = cls.value_parser(kwds['decoded'])

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -207,11 +207,19 @@ def make_msgid(idstring=None, domain=None):
 
 
 def parsedate_to_datetime(data):
-    *dtuple, tz = _parsedate_tz(data)
-    if tz is None:
-        return datetime.datetime(*dtuple[:6])
-    return datetime.datetime(*dtuple[:6],
-            tzinfo=datetime.timezone(datetime.timedelta(seconds=tz)))
+    try:
+        *dtuple, tz = _parsedate_tz(data)
+    except TypeError:
+        # _parsedate_tz(data) returned None due to failure to parse
+        return None
+    try:
+        if tz is None:
+            return datetime.datetime(*dtuple[:6])
+        return datetime.datetime(*dtuple[:6],
+                tzinfo=datetime.timezone(datetime.timedelta(seconds=tz)))
+    except ValueError:
+        # Date parsed ok, but one or more component values are invalid
+        return None
 
 
 def parseaddr(addr):

--- a/Lib/test/test_email/__init__.py
+++ b/Lib/test/test_email/__init__.py
@@ -37,9 +37,11 @@ class TestEmailBase(unittest.TestCase):
     # Backward compatibility to minimize test_email test changes.
     ndiffAssertEqual = unittest.TestCase.assertEqual
 
-    def _msgobj(self, filename):
+    def _msgobj(self, filename, policy=None):
+        if policy is None:
+            policy = self.policy
         with openfile(filename) as fp:
-            return email.message_from_file(fp, policy=self.policy)
+            return email.message_from_file(fp, policy=policy)
 
     def _str_msg(self, string, message=None, policy=None):
         if policy is None:

--- a/Lib/test/test_email/data/msg_47.txt
+++ b/Lib/test/test_email/data/msg_47.txt
@@ -1,0 +1,6 @@
+Date: Tue, 06 Jun 2017 27:39:33 +0600
+From: "123@abuse.net" <123@example.com>
+To: <123@abuse.net>
+Subject: VIARGA|CIALIS|LEVITRA
+
+### PHARRMACY ON1INE 24/7 ###

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3012,6 +3012,16 @@ class TestMiscellaneous(TestEmailBase):
         eq(time.localtime(t)[:6], timetup[:6])
         eq(int(time.strftime('%Y', timetup[:9])), 2003)
 
+    def test_parsedate_to_datetime_returns_None_for_invalid_strings(self):
+        self.assertIsNone(utils.parsedate_to_datetime(''))
+        self.assertIsNone(utils.parsedate_to_datetime('0'))
+        self.assertIsNone(utils.parsedate_to_datetime('A Complete Waste of Time'))
+
+    def test_parsedate_to_datetime_returns_None_for_invalid_dates(self):
+        self.assertIsNone(utils.parsedate_to_datetime('Tue, 06 Jun 2017 27:39:33 +0600'))
+        self.assertIsNone(utils.parsedate_to_datetime('Tue, 06 Jun 2017 07:39:33 +2600'))
+        self.assertIsNone(utils.parsedate_to_datetime('Tue, 06 Jun 2017 27:39:33'))
+
     def test_mktime_tz(self):
         self.assertEqual(utils.mktime_tz((1970, 1, 1, 0, 0, 0,
                                           -1, -1, -1, 0)), 0)


### PR DESCRIPTION
In email.utils.parsedate_to_datetime(), check failure to parse date, or invalid date components (such as hour outside 0..23), and return None rather than raising an exception.

Add tests to confirm this behaviour.