### PR TITLE
[3.5] bpo-30656: Fix Python C API Module Objects documentation (GH-2170)

### DIFF
--- a/Doc/c-api/module.rst
+++ b/Doc/c-api/module.rst
@@ -50,7 +50,7 @@ Module Objects
 
 .. c:function:: PyObject* PyModule_New(const char *name)
 
-   Similar to :c:func:`PyImport_NewObject`, but the name is a UTF-8 encoded
+   Similar to :c:func:`PyModule_NewObject`, but the name is a UTF-8 encoded
    string instead of a Unicode object.
 
 


### PR DESCRIPTION
`PyModule_New()` now refers to `PyModule_NewObject()`
(cherry picked from commit 2d0afef82a07afdb666f2ca0c533aac5d39155cd)