### PR TITLE
[3.6] [email] bpo-29478: Fix passing max_line_length=None from Compat…

### DIFF
--- a/Lib/email/_policybase.py
+++ b/Lib/email/_policybase.py
@@ -361,8 +361,12 @@ class Compat32(Policy):
             # Assume it is a Header-like object.
             h = value
         if h is not None:
-            parts.append(h.encode(linesep=self.linesep,
-                                  maxlinelen=self.max_line_length))
+            # The Header class interprets a value of None for maxlinelen as the
+            # default value of 78, as recommended by RFC 2822.
+            maxlinelen = 0
+            if self.max_line_length is not None:
+                maxlinelen = self.max_line_length
+            parts.append(h.encode(linesep=self.linesep, maxlinelen=maxlinelen))
         parts.append(self.linesep)
         return ''.join(parts)
 

--- a/Lib/test/test_email/test_generator.py
+++ b/Lib/test/test_email/test_generator.py
@@ -162,6 +162,13 @@ class TestGeneratorBase:
                 g.flatten(msg)
                 self.assertEqual(s.getvalue(), self.typ(expected))
 
+    def test_compat32_max_line_length_does_not_fold_when_none(self):
+        msg = self.msgmaker(self.typ(self.refold_long_expected[0]))
+        s = self.ioclass()
+        g = self.genclass(s, policy=policy.compat32.clone(max_line_length=None))
+        g.flatten(msg)
+        self.assertEqual(s.getvalue(), self.typ(self.refold_long_expected[0]))
+
 
 class TestGenerator(TestGeneratorBase, TestEmailBase):
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -308,6 +308,7 @@ Garrett Cooper
 Greg Copeland
 Ian Cordasco
 Aldo Cortesi
+Mircea Cosbuc
 David Costanzo
 Scott Cotton
 Greg Couch

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -48,6 +48,9 @@ Core and Builtins
 - bpo-29714: Fix a regression that bytes format may fail when containing zero
   bytes inside.
 
+- bpo-29478: If max_line_length=None is specified while using the Compat32 policy,
+  it is no longer ignored.  Patch by Mircea Cosbuc.
+
 Library
 -------
 


### PR DESCRIPTION
…32 policy (GH-595)

If max_line_length=None is specified while using the Compat32 policy,
it is no longer ignored..
(cherry picked from commit b459f7482612d340b88b62edc024628595ec6337)