### PR TITLE
[3.6] bpo-30682: Removed a too-strict assertion that failed for certain f-strings. (GH-2232)

### DIFF
--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -780,5 +780,11 @@ f'{a * x()}'"""
         self.assertEqual(f'{d["foo"]}', 'bar')
         self.assertEqual(f"{d['foo']}", 'bar')
 
+    def test_backslash_char(self):
+        # Check eval of a backslash followed by a control char.
+        # See bpo-30682: this used to raise an assert in pydebug mode.
+        self.assertEqual(eval('f"\\\n"'), '')
+        self.assertEqual(eval('f"\\\r"'), '')
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 3.6.2 release candidate 1?
 Core and Builtins
 -----------------
 
+- bpo-30682: Removed a too-strict assertion that failed for certain f-strings,
+  such as eval("f'\\\n'") and eval("f'\\\r'").
+
 - bpo-30604: Move co_extra_freefuncs to not be per-thread to avoid crashes
 
 - bpo-29104: Fixed parsing backslashes in f-strings.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4887,6 +4887,8 @@ FstringParser_ConcatFstring(FstringParser *state, const char **str,
             /* Do nothing. Just leave last_str alone (and possibly
                NULL). */
         } else if (!state->last_str) {
+            /*  Note that the literal can be zero length, if the
+                input string is "\\\n" or "\\\r", among others. */
             state->last_str = literal;
             literal = NULL;
         } else {
@@ -4896,8 +4898,6 @@ FstringParser_ConcatFstring(FstringParser *state, const char **str,
                 return -1;
             literal = NULL;
         }
-        assert(!state->last_str ||
-               PyUnicode_GET_LENGTH(state->last_str) != 0);
 
         /* We've dealt with the literal now. It can't be leaked on further
            errors. */


### PR DESCRIPTION
This caused a segfault on eval("f'\\\n'") and eval("f'\\\r'") in debug build..
(cherry picked from commit 11e97f2f80bf65cc828c127eafc95229df35d403)