### PR TITLE
bpo-30645: use an internal variable while iterating in imp.load_package()

### DIFF
--- a/Lib/imp.py
+++ b/Lib/imp.py
@@ -203,7 +203,7 @@ def load_package(name, path):
         extensions = (machinery.SOURCE_SUFFIXES[:] +
                       machinery.BYTECODE_SUFFIXES[:])
         for extension in extensions:
-            init_path = os.path.join(path, '__init__'+extension)
+            init_path = os.path.join(path, '__init__' + extension)
             if os.path.exists(init_path):
                 path = init_path
                 break

--- a/Lib/imp.py
+++ b/Lib/imp.py
@@ -203,8 +203,9 @@ def load_package(name, path):
         extensions = (machinery.SOURCE_SUFFIXES[:] +
                       machinery.BYTECODE_SUFFIXES[:])
         for extension in extensions:
-            path = os.path.join(path, '__init__'+extension)
-            if os.path.exists(path):
+            init_path = os.path.join(path, '__init__'+extension)
+            if os.path.exists(init_path):
+                path = init_path
                 break
         else:
             raise ValueError('{!r} is not a package'.format(path))

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -57,6 +57,7 @@ Ankur Ankan
 Heidi Annexstad
 Ramchandra Apte
 Éric Araujo
+Alexandru Ardelean
 Alicia Arlen
 Jeffrey Armstrong
 Jason Asbahr

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -400,6 +400,10 @@ Library
 - bpo-30508: Don't log exceptions if Task/Future "cancel()" method was
   called.
 
+- bpo-30645: Fix path creation of __init__.pyc in imp.load_package(),
+  for cases when a package is only shipped with bytecodes. This bug
+  was not noticeable if the source-code of __init__.py was available.
+
 - bpo-11822: The dis.dis() function now is able to disassemble nested
   code objects.
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -400,9 +400,9 @@ Library
 - bpo-30508: Don't log exceptions if Task/Future "cancel()" method was
   called.
 
-- bpo-30645: Fix path creation of __init__.pyc in imp.load_package(),
-  for cases when a package is only shipped with bytecodes. This bug
-  was not noticeable if the source-code of __init__.py was available.
+- bpo-30645: Fix path calculation in `imp.load_package()`, fixing it for
+  cases when a package is only shipped with bytecodes. Patch by
+  Alexandru Ardelean.
 
 - bpo-11822: The dis.dis() function now is able to disassemble nested
   code objects.


### PR DESCRIPTION
The imp.load_package() function is marked as deprecated,
however, some packages (like virtualenv) seem to use it.

The problem with that loop, is that if the .py file
does not exist, you'll get a
`<path-to-package>__init__.py/__init__.pyc` file.

When shipping only Python bytecodes, we don't want that.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>