### PR TITLE
bpo-30698: asyncio shutdown the ssl layer cleanly.

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -365,6 +365,8 @@ Extension Modules
 Library
 -------
 
+- bpo-30698: Asyncio sslproto shutdown the ssl layer cleanly
+
 - bpo-30038: Fix race condition between signal delivery and wakeup file
   descriptor.  Patch by Nathaniel Smith.
 


### PR DESCRIPTION
Asyncio on shutdown do not send shutdown confirmation to the other side.
_SSLPipe after doing unwrap is calling shutdown calback where transport
is closed and quit ssldata wont be sent. Having this callback in
_SSLPipe feels wrong and its removed.

Removing callback from _SSLPipe.shutdown should not break any api.

https://bugs.python.org/issue30698