### PR TITLE
[3.5] bpo-29887: Test normalization now fails if download fails (GH-905)

### DIFF
--- a/Lib/test/test_normalization.py
+++ b/Lib/test/test_normalization.py
@@ -42,10 +42,10 @@ class NormalizationTest(unittest.TestCase):
             testdata = open_urlresource(TESTDATAURL, encoding="utf-8",
                                         check=check_version)
         except PermissionError:
-            self.skipTest(f"Permission error when downloading {TESTDATAURL} "
-                          f"into the test data directory")
+            self.skipTest("Permission error when downloading %s "
+                          "into the test data directory" % TESTDATAURL)
         except (OSError, HTTPException):
-            self.fail(f"Could not retrieve {TESTDATAURL}")
+            self.fail("Could not retrieve %s" % TESTDATAURL)
 
         with testdata:
             self.run_normalization_tests(testdata)

--- a/Lib/test/test_normalization.py
+++ b/Lib/test/test_normalization.py
@@ -37,15 +37,20 @@ def unistr(data):
 
 class NormalizationTest(unittest.TestCase):
     def test_main(self):
-        part = None
-        part1_data = {}
         # Hit the exception early
         try:
             testdata = open_urlresource(TESTDATAURL, encoding="utf-8",
                                         check=check_version)
         except (OSError, HTTPException):
-            self.skipTest("Could not retrieve " + TESTDATAURL)
-        self.addCleanup(testdata.close)
+            self.fail(f"Could not retrieve {TESTDATAURL}")
+
+        with testdata:
+            self.run_normalization_tests(testdata)
+
+    def run_normalization_tests(self, testdata):
+        part = None
+        part1_data = {}
+
         for line in testdata:
             if '#' in line:
                 line = line.split('#')[0]

--- a/Lib/test/test_normalization.py
+++ b/Lib/test/test_normalization.py
@@ -41,6 +41,9 @@ class NormalizationTest(unittest.TestCase):
         try:
             testdata = open_urlresource(TESTDATAURL, encoding="utf-8",
                                         check=check_version)
+        except PermissionError:
+            self.skipTest(f"Permission error when downloading {TESTDATAURL} "
+                          f"into the test data directory")
         except (OSError, HTTPException):
             self.fail(f"Could not retrieve {TESTDATAURL}")
 


### PR DESCRIPTION
* test_normalization fails if download fails

bpo-29887. The test is still skipped if "-u urlfetch" option is not
passed to regrtest (python3 -m test -u urlfetch test_normalization).

* Fix ResourceWarning in test_normalization

bpo-29887: Fix ResourceWarning in test_normalization if tests are
interrupted by CTRL+c.
(cherry picked from commit 722a3af092b94983aa26f5e591fb1b45e2c2a0ff)