### PR TITLE
bpo-25684: ttk.OptionMenu radiobuttons aren't unique between instance…

### DIFF
--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -276,9 +276,30 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, optmenu['menu'].invoke, -1)
         self.assertEqual(optmenu._variable.get(), items[0])
 
+        optmenu.destroy()
+
+        # specifying a callback
+        success = []
+        def cb_test(item):
+            self.assertEqual(item, items[1])
+            success.append(True)
+        optmenu = ttk.OptionMenu(self.root, self.textvar, 'a', command=cb_test,
+            *items)
+        optmenu['menu'].invoke(1)
+        if not success:
+            self.fail("Menu callback not invoked")
+
+        optmenu.destroy()
+
+    def test_unique_radiobuttons(self):
         # check that radiobuttons are unique across instances (bpo25684)
+        items = ('a', 'b', 'c')
+        default = 'a'
+        optmenu = ttk.OptionMenu(self.root, self.textvar, default, *items)
         textvar2 = tkinter.StringVar(self.root)
         optmenu2 = ttk.OptionMenu(self.root, textvar2, default, *items)
+        optmenu.pack()
+        optmenu.wait_visibility()
         optmenu2.pack()
         optmenu2.wait_visibility()
         optmenu['menu'].invoke(1)
@@ -295,19 +316,6 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         optmenu.destroy()
         del textvar2, optmenu_radiobutton_name, optmenu2_radiobutton_name
         optmenu2.destroy()
-
-        # specifying a callback
-        success = []
-        def cb_test(item):
-            self.assertEqual(item, items[1])
-            success.append(True)
-        optmenu = ttk.OptionMenu(self.root, self.textvar, 'a', command=cb_test,
-            *items)
-        optmenu['menu'].invoke(1)
-        if not success:
-            self.fail("Menu callback not invoked")
-
-        optmenu.destroy()
 
 
 tests_gui = (LabeledScaleTest, OptionMenuTest)

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -276,7 +276,25 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         self.assertRaises(tkinter.TclError, optmenu['menu'].invoke, -1)
         self.assertEqual(optmenu._variable.get(), items[0])
 
+        # check that radiobuttons are unique across instances (bpo25684)
+        textvar2 = tkinter.StringVar(self.root)
+        optmenu2 = ttk.OptionMenu(self.root, textvar2, default, *items)
+        optmenu2.pack()
+        optmenu2.wait_visibility()
+        optmenu['menu'].invoke(1)
+        optmenu2['menu'].invoke(2)
+        optmenu_radiobutton_name = optmenu['menu'].entrycget(0, 'variable')
+        optmenu2_radiobutton_name = optmenu2['menu'].entrycget(0, 'variable')
+        self.assertNotEqual(optmenu_radiobutton_name,
+                            optmenu2_radiobutton_name)
+        self.assertEqual(self.root.tk.globalgetvar(optmenu_radiobutton_name),
+                         items[1])
+        self.assertEqual(self.root.tk.globalgetvar(optmenu2_radiobutton_name),
+                         items[2])
+
         optmenu.destroy()
+        del textvar2, optmenu_radiobutton_name, optmenu2_radiobutton_name
+        optmenu2.destroy()
 
         # specifying a callback
         success = []

--- a/Lib/tkinter/test/test_ttk/test_extensions.py
+++ b/Lib/tkinter/test/test_ttk/test_extensions.py
@@ -304,17 +304,16 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
         optmenu2.wait_visibility()
         optmenu['menu'].invoke(1)
         optmenu2['menu'].invoke(2)
-        optmenu_radiobutton_name = optmenu['menu'].entrycget(0, 'variable')
-        optmenu2_radiobutton_name = optmenu2['menu'].entrycget(0, 'variable')
-        self.assertNotEqual(optmenu_radiobutton_name,
-                            optmenu2_radiobutton_name)
-        self.assertEqual(self.root.tk.globalgetvar(optmenu_radiobutton_name),
+        optmenu_stringvar_name = optmenu['menu'].entrycget(0, 'variable')
+        optmenu2_stringvar_name = optmenu2['menu'].entrycget(0, 'variable')
+        self.assertNotEqual(optmenu_stringvar_name,
+                            optmenu2_stringvar_name)
+        self.assertEqual(self.root.tk.globalgetvar(optmenu_stringvar_name),
                          items[1])
-        self.assertEqual(self.root.tk.globalgetvar(optmenu2_radiobutton_name),
+        self.assertEqual(self.root.tk.globalgetvar(optmenu2_stringvar_name),
                          items[2])
 
         optmenu.destroy()
-        del textvar2, optmenu_radiobutton_name, optmenu2_radiobutton_name
         optmenu2.destroy()
 
 

--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -1635,7 +1635,8 @@ class OptionMenu(Menubutton):
         menu.delete(0, 'end')
         for val in values:
             menu.add_radiobutton(label=val,
-                command=tkinter._setit(self._variable, val, self._callback))
+                command=tkinter._setit(self._variable, val, self._callback),
+                variable=self._variable)
 
         if default:
             self._variable.set(default)

--- a/Misc/NEWS.d/next/Library/2017-07-17-11-35-00.bpo-25684.usELVx.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-17-11-35-00.bpo-25684.usELVx.rst
@@ -1,0 +1,2 @@
+Change ``ttk.OptionMenu`` radiobuttons to be unique across instances of
+``OptionMenu``.


### PR DESCRIPTION
…s of OptionMenu

Solution based on workaround by Bryan Oakley at https://stackoverflow.com/questions/33831289/ttk-optionmenu-displaying-check-mark-on-all-menus

to set the `variable` attribute of the OptionMenu when the radiobuttons are added.

<!-- issue-number: bpo-25684 -->
https://bugs.python.org/issue25684
<!-- /issue-number -->
