### PR TITLE
[3.5] bpo-30176: Add missing curses cell attributes constants

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -1271,27 +1271,63 @@ The :mod:`curses` module defines the following data members:
    A string representing the current version of the module.  Also available as
    :const:`__version__`.
 
-Several constants are available to specify character cell attributes:
+Some constants are available to specify character cell attributes.
+The exact constants available are system dependent.
 
 +------------------+-------------------------------+
 | Attribute        | Meaning                       |
 +==================+===============================+
-| ``A_ALTCHARSET`` | Alternate character set mode. |
+| ``A_ALTCHARSET`` | Alternate character set mode  |
 +------------------+-------------------------------+
-| ``A_BLINK``      | Blink mode.                   |
+| ``A_BLINK``      | Blink mode                    |
 +------------------+-------------------------------+
-| ``A_BOLD``       | Bold mode.                    |
+| ``A_BOLD``       | Bold mode                     |
 +------------------+-------------------------------+
-| ``A_DIM``        | Dim mode.                     |
+| ``A_DIM``        | Dim mode                      |
 +------------------+-------------------------------+
-| ``A_NORMAL``     | Normal attribute.             |
+| ``A_INVIS``      | Invisible or blank mode       |
++------------------+-------------------------------+
+| ``A_NORMAL``     | Normal attribute              |
++------------------+-------------------------------+
+| ``A_PROTECT``    | Protected mode                |
 +------------------+-------------------------------+
 | ``A_REVERSE``    | Reverse background and        |
-|                  | foreground colors.            |
+|                  | foreground colors             |
 +------------------+-------------------------------+
-| ``A_STANDOUT``   | Standout mode.                |
+| ``A_STANDOUT``   | Standout mode                 |
 +------------------+-------------------------------+
-| ``A_UNDERLINE``  | Underline mode.               |
+| ``A_UNDERLINE``  | Underline mode                |
++------------------+-------------------------------+
+| ``A_HORIZONTAL`` | Horizontal highlight          |
++------------------+-------------------------------+
+| ``A_LEFT``       | Left highlight                |
++------------------+-------------------------------+
+| ``A_LOW``        | Low highlight                 |
++------------------+-------------------------------+
+| ``A_RIGHT``      | Right highlight               |
++------------------+-------------------------------+
+| ``A_TOP``        | Top highlight                 |
++------------------+-------------------------------+
+| ``A_VERTICAL``   | Vertical highlight            |
++------------------+-------------------------------+
+| ``A_CHARTEXT``   | Bit-mask to extract a         |
+|                  | character                     |
++------------------+-------------------------------+
+
+Several constants are available to extract corresponding attributes returned
+by some methods.
+
++------------------+-------------------------------+
+| Bit-mask         | Meaning                       |
++==================+===============================+
+| ``A_ATTRIBUTES`` | Bit-mask to extract           |
+|                  | attributes                    |
++------------------+-------------------------------+
+| ``A_CHARTEXT``   | Bit-mask to extract a         |
+|                  | character                     |
++------------------+-------------------------------+
+| ``A_COLOR``      | Bit-mask to extract           |
+|                  | color-pair field information  |
 +------------------+-------------------------------+
 
 Keys are referred to by integer constants with names starting with  ``KEY_``.

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -270,6 +270,8 @@ C API
 Documentation
 -------------
 
+- bpo-30176: Add missing attribute related constants in curses documentation.
+
 - bpo-26985: Add missing info of code object in inspect documentation.
 
 - bpo-28929: Link the documentation to its source file on GitHub.


### PR DESCRIPTION
backport to 3.5 for #1302 