### PR TITLE
__getattribute__'s docs no longer tells users that __getattribute__ can call __getattr__

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1465,11 +1465,11 @@ access (use of, assignment to, or deletion of ``x.name``) for class instances.
 
    Called unconditionally to implement attribute accesses for instances of the
    class. If the class also defines :meth:`__getattr__`, the latter will not be
-   called unless :meth:`__getattribute__` either calls it explicitly or raises an
-   :exc:`AttributeError`. This method should return the (computed) attribute value
-   or raise an :exc:`AttributeError` exception. In order to avoid infinite
-   recursion in this method, its implementation should always call the base class
-   method with the same name to access any attributes it needs, for example,
+   called unless :meth:`__getattribute__` raises an :exc:`AttributeError`. This
+   method should return the (computed) attribute value or raise an
+   :exc:`AttributeError` exception. In order to avoid infinite recursion in this
+   method, its implementation should always call the base class method with the
+   same name to access any attributes it needs, for example,
    ``object.__getattribute__(self, name)``.
 
    .. note::


### PR DESCRIPTION
Removed the words "either calls it explicitly or" from the explanation of `__getattribute__` in the [data model](https://docs.python.org/3/reference/datamodel.html) documentation:

> Called unconditionally to implement attribute accesses for instances of the class. If the class also defines `__getattr__()`, the latter will not be called unless `__getattribute__()` ~~either calls it explicitly or~~ raises an `AttributeError`. This method should return the (computed) attribute value or raise an `AttributeError` exception. In order to avoid infinite recursion in this method, its implementation should always call the base class method with the same name to access any attributes it needs, for example, `object.__getattribute__(self, name)`.

The documentation here is slightly wrong because `__getattribute__` should never call `__getattr__`. This confused me for a long time.

Attributes are looked up in the following methods in this order:

1. `__get__`
2. `__getattribute__`
3. `__getattr__`

Just like `__get__` does not call `__getattribute__`, `__getattribute__` does not call `__getattr__`. Instead, `__getattr__` is called iff `__getattribute__` raises an `AttributeError`.

An example illustrating why `__getattr__` should not be called from `__getattribute__` is below:

    class A:
        def __getattribute__(self, name):
            try:
                return super().__getattribute__(name)
            except AttributeError:
                return self.__getattr__(name)

        def __getattr__(self, name):
            print("Could not find attribute `{}`".format(name))
            raise AttributeError


    a = A() 
    a.x`

prints this to the console:

    Could not find attribute `x`
    Could not find attribute `x`
    Traceback (most recent call last):
      File "attribute_errors.py", line 14, in <module>
        a.x
      File "attribute_errors.py", line 10, in __getattr__
        raise AttributeError
    AttributeError

In this example, `__getattribute__` directly calls `__getattribute__` when `x` is not found in `A`. The `__getattr__` could not resolve the attribute lookup, so it (appropriately) raises an `AttributeError`. That means that `__getattribute__` indirectly raised an `AttributeError`, which triggers `__getattr__`.

`__getattr__` therefore gets called twice, which is incorrect behavior.

This PR just fixes the docs so that others won't get confused.