### PR TITLE
[3.6] bpo-30500: Fix the NEWS entry

### DIFF
--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -14,7 +14,7 @@ Library
 -------
 
 - [Security] bpo-30500: Fix urllib.parse.splithost() to correctly parse
-  fragments. For example, ``splithost('http://127.0.0.1#@evil.com/')`` now
+  fragments. For example, ``splithost('//127.0.0.1#@evil.com/')`` now
   correctly returns the ``127.0.0.1`` host, instead of treating ``@evil.com``
   as the host in an authentification (``login@host``).
 


### PR DESCRIPTION
splithost() expects an URL starting with "//" not with "http://".