### PR TITLE
[security] bpo-13617: Reject embedded null characters in wchar* strings.

### DIFF
--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -756,23 +756,27 @@ PyAPI_FUNC(Py_UCS4*) PyUnicode_AsUCS4(
 PyAPI_FUNC(Py_UCS4*) PyUnicode_AsUCS4Copy(PyObject *unicode);
 #endif
 
+#ifndef Py_LIMITED_API
 /* Return a read-only pointer to the Unicode object's internal
    Py_UNICODE buffer.
    If the wchar_t/Py_UNICODE representation is not yet available, this
    function will calculate it. */
 
-#ifndef Py_LIMITED_API
 PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicode(
     PyObject *unicode           /* Unicode object */
     ) /* Py_DEPRECATED(3.3) */;
-#endif
+
+/* Similar to PyUnicode_AsUnicode(), but raises a ValueError if the string
+   contains null characters. */
+PyAPI_FUNC(const Py_UNICODE *) _PyUnicode_AsUnicode(
+    PyObject *unicode           /* Unicode object */
+    );
 
 /* Return a read-only pointer to the Unicode object's internal
    Py_UNICODE buffer and save the length at size.
    If the wchar_t/Py_UNICODE representation is not yet available, this
    function will calculate it. */
 
-#ifndef Py_LIMITED_API
 PyAPI_FUNC(Py_UNICODE *) PyUnicode_AsUnicodeAndSize(
     PyObject *unicode,          /* Unicode object */
     Py_ssize_t *size            /* location where to save the length */

--- a/Lib/ctypes/test/test_loading.py
+++ b/Lib/ctypes/test/test_loading.py
@@ -62,6 +62,8 @@ class LoaderTest(unittest.TestCase):
             windll["kernel32"].GetModuleHandleW
             windll.LoadLibrary("kernel32").GetModuleHandleW
             WinDLL("kernel32").GetModuleHandleW
+            # embedded null character
+            self.assertRaises(ValueError, windll.LoadLibrary, "kernel32\0")
 
     @unittest.skipUnless(os.name == "nt",
                          'test specific to Windows')

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -152,7 +152,7 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(ValueError, __import__, '')
         self.assertRaises(TypeError, __import__, 'sys', name='sys')
         # embedded null character
-        self.assertRaises(TypeError, __import__, 'a\x00b')
+        self.assertRaises(ModuleNotFoundError, __import__, 'string\x00')
 
     def test_abs(self):
         # int
@@ -1013,8 +1013,8 @@ class BuiltinTest(unittest.TestCase):
             self.assertEqual(fp.read(1000), 'YYY'*100)
 
         # embedded null character
-        self.assertRaises(TypeError, open, b'a\x00b')
-        self.assertRaises(TypeError, open, 'a\x00b')
+        self.assertRaises(ValueError, open, b'a\x00b')
+        self.assertRaises(ValueError, open, 'a\x00b')
 
     def test_open_default_encoding(self):
         old_environ = dict(os.environ)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -151,6 +151,8 @@ class BuiltinTest(unittest.TestCase):
         self.assertRaises(TypeError, __import__, 1, 2, 3, 4)
         self.assertRaises(ValueError, __import__, '')
         self.assertRaises(TypeError, __import__, 'sys', name='sys')
+        # embedded null character
+        self.assertRaises(TypeError, __import__, 'a\x00b')
 
     def test_abs(self):
         # int
@@ -1009,6 +1011,10 @@ class BuiltinTest(unittest.TestCase):
             self.assertEqual(fp.readline(100), ' John\n')
             self.assertEqual(fp.read(300), 'XXX'*100)
             self.assertEqual(fp.read(1000), 'YYY'*100)
+
+        # embedded null character
+        self.assertRaises(TypeError, open, b'a\x00b')
+        self.assertRaises(TypeError, open, 'a\x00b')
 
     def test_open_default_encoding(self):
         old_environ = dict(os.environ)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1012,9 +1012,9 @@ class BuiltinTest(unittest.TestCase):
             self.assertEqual(fp.read(300), 'XXX'*100)
             self.assertEqual(fp.read(1000), 'YYY'*100)
 
-        # embedded null character
-        self.assertRaises(ValueError, open, b'a\x00b')
+        # embedded null bytes and characters
         self.assertRaises(ValueError, open, 'a\x00b')
+        self.assertRaises(ValueError, open, b'a\x00b')
 
     def test_open_default_encoding(self):
         old_environ = dict(os.environ)

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -81,7 +81,7 @@ class TestCurses(unittest.TestCase):
         win2 = curses.newwin(15,15, 5,5)
 
         for meth in [stdscr.addch, stdscr.addstr]:
-            for args in [('a'), ('a', curses.A_BOLD),
+            for args in [('a',), ('a', curses.A_BOLD),
                          (4,4, 'a'), (5,5, 'a', curses.A_BOLD)]:
                 with self.subTest(meth=meth.__qualname__, args=args):
                     meth(*args)
@@ -194,6 +194,15 @@ class TestCurses(unittest.TestCase):
         self.assertRaises(ValueError, stdscr.instr, -2)
         self.assertRaises(ValueError, stdscr.instr, 2, 3, -2)
 
+    def test_embedded_null_chars(self):
+        # reject embedded null bytes and characters
+        stdscr = self.stdscr
+        for arg in ['a', b'a']:
+            with self.subTest(arg=arg):
+                self.assertRaises(ValueError, stdscr.addstr, 'a\0')
+                self.assertRaises(ValueError, stdscr.addnstr, 'a\0', 1)
+                self.assertRaises(ValueError, stdscr.insstr, 'a\0')
+                self.assertRaises(ValueError, stdscr.insnstr, 'a\0', 1)
 
     def test_module_funcs(self):
         "Test module-level functions"

--- a/Lib/test/test_grp.py
+++ b/Lib/test/test_grp.py
@@ -51,8 +51,7 @@ class GroupDatabaseTestCase(unittest.TestCase):
         self.assertRaises(TypeError, grp.getgrnam)
         self.assertRaises(TypeError, grp.getgrall, 42)
         # reject embedded null bytes and characters
-        self.assertRaises(TypeError, grp.getgrnam, b'a\x00b')
-        self.assertRaises(TypeError, grp.getgrnam, 'a\x00b')
+        self.assertRaises(ValueError, grp.getgrnam, 'a\x00b')
 
         # try to get some errors
         bynames = {}

--- a/Lib/test/test_grp.py
+++ b/Lib/test/test_grp.py
@@ -50,6 +50,9 @@ class GroupDatabaseTestCase(unittest.TestCase):
         self.assertRaises(TypeError, grp.getgrgid)
         self.assertRaises(TypeError, grp.getgrnam)
         self.assertRaises(TypeError, grp.getgrall, 42)
+        # reject embedded null bytes and characters
+        self.assertRaises(TypeError, grp.getgrnam, b'a\x00b')
+        self.assertRaises(TypeError, grp.getgrnam, 'a\x00b')
 
         # try to get some errors
         bynames = {}

--- a/Lib/test/test_grp.py
+++ b/Lib/test/test_grp.py
@@ -50,7 +50,7 @@ class GroupDatabaseTestCase(unittest.TestCase):
         self.assertRaises(TypeError, grp.getgrgid)
         self.assertRaises(TypeError, grp.getgrnam)
         self.assertRaises(TypeError, grp.getgrall, 42)
-        # reject embedded null bytes and characters
+        # embedded null character
         self.assertRaises(ValueError, grp.getgrnam, 'a\x00b')
 
         # try to get some errors

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -314,6 +314,10 @@ class ImportTests(unittest.TestCase):
         loader.get_data(imp.__file__)  # File should be closed
         loader.get_data(imp.__file__)  # Will need to create a newly opened file
 
+    def test_load_source(self):
+        self.assertRaisesRegex(TypeError, 'embedded NUL character',
+                               imp.load_source, __name__, __file__ + "\0")
+
 
 class ReloadTests(unittest.TestCase):
 

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -315,7 +315,7 @@ class ImportTests(unittest.TestCase):
         loader.get_data(imp.__file__)  # Will need to create a newly opened file
 
     def test_load_source(self):
-        with self.assertRaisesRegex(ValueError, 'embedded null byte'):
+        with self.assertRaisesRegex(ValueError, 'embedded null'):
             imp.load_source(__name__, __file__ + "\0")
 
 

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -315,8 +315,8 @@ class ImportTests(unittest.TestCase):
         loader.get_data(imp.__file__)  # Will need to create a newly opened file
 
     def test_load_source(self):
-        self.assertRaisesRegex(TypeError, 'embedded NUL character',
-                               imp.load_source, __name__, __file__ + "\0")
+        with self.assertRaisesRegex(ValueError, 'embedded null byte'):
+            imp.load_source(__name__, __file__ + "\0")
 
 
 class ReloadTests(unittest.TestCase):

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -346,9 +346,14 @@ class TestCollation(unittest.TestCase):
         self.assertLess(locale.strcoll('a', 'b'), 0)
         self.assertEqual(locale.strcoll('a', 'a'), 0)
         self.assertGreater(locale.strcoll('b', 'a'), 0)
+        # embedded null character
+        self.assertRaises(ValueError, locale.strcoll, 'a\0', 'a')
+        self.assertRaises(ValueError, locale.strcoll, 'a', 'a\0')
 
     def test_strxfrm(self):
         self.assertLess(locale.strxfrm('a'), locale.strxfrm('b'))
+        # embedded null character
+        self.assertRaises(ValueError, locale.strxfrm, 'a\0')
 
 
 class TestEnUSCollation(BaseLocalizedTest, TestCollation):

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -126,6 +126,10 @@ class TimeTestCase(unittest.TestCase):
             except ValueError:
                 self.fail('conversion specifier: %r failed.' % format)
 
+        self.assertRaises(TypeError, time.strftime, b'%S', tt)
+        # embedded null character
+        self.assertRaises(ValueError, time.strftime, '%S\0', tt)
+
     def _bounds_checking(self, func):
         # Make sure that strftime() checks the bounds of the various parts
         # of the time tuple (0 is valid for *all* values).

--- a/Lib/test/test_winsound.py
+++ b/Lib/test/test_winsound.py
@@ -96,6 +96,8 @@ class PlaySoundTest(unittest.TestCase):
         self.assertRaises(TypeError, winsound.PlaySound, "bad",
                           winsound.SND_MEMORY)
         self.assertRaises(TypeError, winsound.PlaySound, 1, 0)
+        # embedded null character
+        self.assertRaises(ValueError, winsound.PlaySound, 'bad\0', 0)
 
     def test_keyword_args(self):
         safe_PlaySound(flags=winsound.SND_ALIAS, sound="SystemExit")

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1253,18 +1253,13 @@ static PyObject *load_library(PyObject *self, PyObject *args)
     PyObject *nameobj;
     PyObject *ignored;
     HMODULE hMod;
-    Py_ssize_t namesize;
 
     if (!PyArg_ParseTuple(args, "U|O:LoadLibrary", &nameobj, &ignored))
         return NULL;
 
-    name = PyUnicode_AsUnicodeAndSize(nameobj, &namesize);
+    name = _PyUnicode_AsUnicode(nameobj);
     if (!name)
         return NULL;
-    if (wcslen(name) != (size_t)namesize) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
-        return NULL;
-    }
 
     hMod = LoadLibraryW(name);
     if (!hMod)

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1253,12 +1253,18 @@ static PyObject *load_library(PyObject *self, PyObject *args)
     PyObject *nameobj;
     PyObject *ignored;
     HMODULE hMod;
-    if (!PyArg_ParseTuple(args, "O|O:LoadLibrary", &nameobj, &ignored))
+    Py_ssize_t namesize;
+
+    if (!PyArg_ParseTuple(args, "U|O:LoadLibrary", &nameobj, &ignored))
         return NULL;
 
-    name = PyUnicode_AsUnicode(nameobj);
+    name = PyUnicode_AsUnicodeAndSize(nameobj, &namesize);
     if (!name)
         return NULL;
+    if (wcslen(name) != (size_t)namesize) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        return NULL;
+    }
 
     hMod = LoadLibraryW(name);
     if (!hMod)

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -343,10 +343,17 @@ PyCurses_ConvertToString(PyCursesWindowObject *win, PyObject *obj,
 {
     if (PyUnicode_Check(obj)) {
 #ifdef HAVE_NCURSESW
+        Py_ssize_t wlen;
         assert (wstr != NULL);
-        *wstr = PyUnicode_AsWideCharString(obj, NULL);
+
+        *wstr = PyUnicode_AsWideCharString(obj, &wlen);
         if (*wstr == NULL)
             return 0;
+        if (wlen != wcslen(wstr)) {
+            PyErr_SetString(PyExc_TypeError,
+                            "embedded null character");
+            return 0;
+        }
         return 2;
 #else
         assert (wstr == NULL);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -341,6 +341,7 @@ static int
 PyCurses_ConvertToString(PyCursesWindowObject *win, PyObject *obj,
                          PyObject **bytes, wchar_t **wstr)
 {
+    char *str;
     if (PyUnicode_Check(obj)) {
 #ifdef HAVE_NCURSESW
         Py_ssize_t wlen;
@@ -360,12 +361,20 @@ PyCurses_ConvertToString(PyCursesWindowObject *win, PyObject *obj,
         *bytes = PyUnicode_AsEncodedString(obj, win->encoding, NULL);
         if (*bytes == NULL)
             return 0;
+        /* check for embedded null bytes */
+        if (PyBytes_AsStringAndSize(*bytes, &str, NULL) < 0) {
+            return 0;
+        }
         return 1;
 #endif
     }
     else if (PyBytes_Check(obj)) {
         Py_INCREF(obj);
         *bytes = obj;
+        /* check for embedded null bytes */
+        if (PyBytes_AsStringAndSize(*bytes, &str, NULL) < 0) {
+            return 0;
+        }
         return 1;
     }
 

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -344,17 +344,11 @@ PyCurses_ConvertToString(PyCursesWindowObject *win, PyObject *obj,
     char *str;
     if (PyUnicode_Check(obj)) {
 #ifdef HAVE_NCURSESW
-        Py_ssize_t wlen;
         assert (wstr != NULL);
 
-        *wstr = PyUnicode_AsWideCharString(obj, &wlen);
+        *wstr = PyUnicode_AsWideCharString(obj, NULL);
         if (*wstr == NULL)
             return 0;
-        if (wcslen(wstr) != (size_t)wlen) {
-            PyErr_SetString(PyExc_ValueError,
-                            "embedded null character");
-            return 0;
-        }
         return 2;
 #else
         assert (wstr == NULL);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -349,8 +349,8 @@ PyCurses_ConvertToString(PyCursesWindowObject *win, PyObject *obj,
         *wstr = PyUnicode_AsWideCharString(obj, &wlen);
         if (*wstr == NULL)
             return 0;
-        if (wlen != wcslen(wstr)) {
-            PyErr_SetString(PyExc_TypeError,
+        if (wcslen(wstr) != (size_t)wlen) {
+            PyErr_SetString(PyExc_ValueError,
                             "embedded null character");
             return 0;
         }

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -271,11 +271,10 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
 
     if (fd < 0) {
 #ifdef MS_WINDOWS
-        Py_ssize_t length;
         if (!PyUnicode_FSDecoder(nameobj, &stringobj)) {
             return -1;
         }
-        widename = PyUnicode_AsUnicodeAndSize(stringobj, &length);
+        widename = PyUnicode_AsUnicode(stringobj);
         if (widename == NULL)
             return -1;
 #else

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -224,7 +224,7 @@ PyLocale_strcoll(PyObject* self, PyObject* args)
                         "embedded null character");
         goto done;
     }
-    ws2 = PyUnicode_AsWideCharString(os2, NULL);
+    ws2 = PyUnicode_AsWideCharString(os2, &wlen);
     if (ws2 == NULL)
         goto done;
     if (wcslen(ws2) != (size_t)wlen) {

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -220,7 +220,7 @@ PyLocale_strcoll(PyObject* self, PyObject* args)
     if (ws1 == NULL)
         goto done;
     if (wcslen(ws1) != (size_t)wlen) {
-        PyErr_SetString(PyExc_TypeError,
+        PyErr_SetString(PyExc_ValueError,
                         "embedded null character");
         goto done;
     }
@@ -228,7 +228,7 @@ PyLocale_strcoll(PyObject* self, PyObject* args)
     if (ws2 == NULL)
         goto done;
     if (wcslen(ws2) != (size_t)wlen) {
-        PyErr_SetString(PyExc_TypeError,
+        PyErr_SetString(PyExc_ValueError,
                         "embedded null character");
         goto done;
     }
@@ -264,7 +264,7 @@ PyLocale_strxfrm(PyObject* self, PyObject* args)
     if (s == NULL)
         goto exit;
     if (wcslen(s) != (size_t)n1) {
-        PyErr_SetString(PyExc_TypeError,
+        PyErr_SetString(PyExc_ValueError,
                         "embedded null character");
         goto exit;
     }

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -219,7 +219,7 @@ PyLocale_strcoll(PyObject* self, PyObject* args)
     ws1 = PyUnicode_AsWideCharString(os1, &wlen);
     if (ws1 == NULL)
         goto done;
-    if (wlen != wcslen(ws1)) {
+    if (wcslen(ws1) != (size_t)wlen) {
         PyErr_SetString(PyExc_TypeError,
                         "embedded null character");
         goto done;
@@ -227,7 +227,7 @@ PyLocale_strcoll(PyObject* self, PyObject* args)
     ws2 = PyUnicode_AsWideCharString(os2, NULL);
     if (ws2 == NULL)
         goto done;
-    if (wlen != wcslen(ws2)) {
+    if (wcslen(ws2) != (size_t)wlen) {
         PyErr_SetString(PyExc_TypeError,
                         "embedded null character");
         goto done;
@@ -263,7 +263,7 @@ PyLocale_strxfrm(PyObject* self, PyObject* args)
     s = PyUnicode_AsWideCharString(str, &n1);
     if (s == NULL)
         goto exit;
-    if (n1 != wcslen(s)) {
+    if (wcslen(s) != (size_t)n1) {
         PyErr_SetString(PyExc_TypeError,
                         "embedded null character");
         goto exit;

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -211,27 +211,16 @@ PyLocale_strcoll(PyObject* self, PyObject* args)
 {
     PyObject *os1, *os2, *result = NULL;
     wchar_t *ws1 = NULL, *ws2 = NULL;
-    Py_ssize_t wlen;
 
     if (!PyArg_ParseTuple(args, "UU:strcoll", &os1, &os2))
         return NULL;
     /* Convert the unicode strings to wchar[]. */
-    ws1 = PyUnicode_AsWideCharString(os1, &wlen);
+    ws1 = PyUnicode_AsWideCharString(os1, NULL);
     if (ws1 == NULL)
         goto done;
-    if (wcslen(ws1) != (size_t)wlen) {
-        PyErr_SetString(PyExc_ValueError,
-                        "embedded null character");
-        goto done;
-    }
-    ws2 = PyUnicode_AsWideCharString(os2, &wlen);
+    ws2 = PyUnicode_AsWideCharString(os2, NULL);
     if (ws2 == NULL)
         goto done;
-    if (wcslen(ws2) != (size_t)wlen) {
-        PyErr_SetString(PyExc_ValueError,
-                        "embedded null character");
-        goto done;
-    }
     /* Collate the strings. */
     result = PyLong_FromLong(wcscoll(ws1, ws2));
   done:

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -845,13 +845,19 @@ _winapi_CreateProcess_impl(PyObject *module, Py_UNICODE *application_name,
         return NULL;
 
     if (env_mapping != Py_None) {
+        Py_ssize_t size;
         environment = getenvironment(env_mapping);
-        if (! environment)
+        if (environment == NULL) {
             return NULL;
-        wenvironment = PyUnicode_AsUnicode(environment);
-        if (wenvironment == NULL)
-        {
-            Py_XDECREF(environment);
+        }
+        wenvironment = PyUnicode_AsUnicodeAndSize(environment, &size);
+        if (wenvironment == NULL) {
+            Py_DECREF(environment);
+            return NULL;
+        }
+        if (wcslen(wenvironment) != (size_t)size) {
+            Py_DECREF(environment);
+            PyErr_SetString(PyExc_ValueError, "embedded null character");
             return NULL;
         }
     }

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -845,19 +845,13 @@ _winapi_CreateProcess_impl(PyObject *module, Py_UNICODE *application_name,
         return NULL;
 
     if (env_mapping != Py_None) {
-        Py_ssize_t size;
         environment = getenvironment(env_mapping);
         if (environment == NULL) {
             return NULL;
         }
-        wenvironment = PyUnicode_AsUnicodeAndSize(environment, &size);
+        wenvironment = _PyUnicode_AsUnicode(environment);
         if (wenvironment == NULL) {
             Py_DECREF(environment);
-            return NULL;
-        }
-        if (wcslen(wenvironment) != (size_t)size) {
-            Py_DECREF(environment);
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
             return NULL;
         }
     }

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -830,7 +830,7 @@ _winapi_CreateProcess_impl(PyObject *module, Py_UNICODE *application_name,
     PROCESS_INFORMATION pi;
     STARTUPINFOW si;
     PyObject* environment;
-    wchar_t *wenvironment;
+    const wchar_t *wenvironment;
 
     ZeroMemory(&si, sizeof(si));
     si.cb = sizeof(si);

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2655,14 +2655,13 @@ array_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
                 Py_UNICODE *ustr;
                 Py_ssize_t n;
 
-                ustr = PyUnicode_AsUnicode(initial);
+                ustr = PyUnicode_AsUnicodeAndSize(initial, &n);
                 if (ustr == NULL) {
                     PyErr_NoMemory();
                     Py_DECREF(a);
                     return NULL;
                 }
 
-                n = PyUnicode_GET_DATA_SIZE(initial);
                 if (n > 0) {
                     arrayobject *self = (arrayobject *)a;
                     char *item = self->ob_item;

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2652,7 +2652,7 @@ array_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
                 Py_DECREF(v);
             }
             else if (initial != NULL && PyUnicode_Check(initial))  {
-                Py_UNICODE *ustr;
+                const Py_UNICODE *ustr;
                 Py_ssize_t n;
 
                 ustr = PyUnicode_AsUnicodeAndSize(initial, &n);
@@ -2665,15 +2665,15 @@ array_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
                 if (n > 0) {
                     arrayobject *self = (arrayobject *)a;
                     char *item = self->ob_item;
-                    item = (char *)PyMem_Realloc(item, n);
+                    item = (char *)PyMem_Realloc(item, n * sizeof(Py_UNICODE));
                     if (item == NULL) {
                         PyErr_NoMemory();
                         Py_DECREF(a);
                         return NULL;
                     }
                     self->ob_item = item;
-                    Py_SIZE(self) = n / sizeof(Py_UNICODE);
-                    memcpy(item, ustr, n);
+                    Py_SIZE(self) = n;
+                    memcpy(item, ustr, n * sizeof(Py_UNICODE));
                     self->allocated = Py_SIZE(self);
                 }
             }

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2652,28 +2652,29 @@ array_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
                 Py_DECREF(v);
             }
             else if (initial != NULL && PyUnicode_Check(initial))  {
-                const Py_UNICODE *ustr;
+                Py_UNICODE *ustr;
                 Py_ssize_t n;
 
-                ustr = PyUnicode_AsUnicodeAndSize(initial, &n);
+                ustr = PyUnicode_AsUnicode(initial);
                 if (ustr == NULL) {
                     PyErr_NoMemory();
                     Py_DECREF(a);
                     return NULL;
                 }
 
+                n = PyUnicode_GET_DATA_SIZE(initial);
                 if (n > 0) {
                     arrayobject *self = (arrayobject *)a;
                     char *item = self->ob_item;
-                    item = (char *)PyMem_Realloc(item, n * sizeof(Py_UNICODE));
+                    item = (char *)PyMem_Realloc(item, n);
                     if (item == NULL) {
                         PyErr_NoMemory();
                         Py_DECREF(a);
                         return NULL;
                     }
                     self->ob_item = item;
-                    Py_SIZE(self) = n;
-                    memcpy(item, ustr, n * sizeof(Py_UNICODE));
+                    Py_SIZE(self) = n / sizeof(Py_UNICODE);
+                    memcpy(item, ustr, n);
                     self->allocated = Py_SIZE(self);
                 }
             }

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -151,6 +151,7 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
 
     if ((bytes = PyUnicode_EncodeFSDefault(name)) == NULL)
         return NULL;
+    /* check for embedded null bytes */
     if (PyBytes_AsStringAndSize(bytes, &name_chars, NULL) == -1)
         goto out;
 

--- a/Modules/nismodule.c
+++ b/Modules/nismodule.c
@@ -169,6 +169,7 @@ nis_match (PyObject *self, PyObject *args, PyObject *kwdict)
         return NULL;
     if ((bkey = PyUnicode_EncodeFSDefault(ukey)) == NULL)
         return NULL;
+    /* check for embedded null bytes */
     if (PyBytes_AsStringAndSize(bkey, &key, &keylen) == -1) {
         Py_DECREF(bkey);
         return NULL;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3756,15 +3756,10 @@ os__getfinalpathname_impl(PyObject *module, PyObject *path)
     int result_length;
     PyObject *result;
     const wchar_t *path_wchar;
-    Py_ssize_t pathsize;
 
-    path_wchar = PyUnicode_AsUnicodeAndSize(path, &pathsize);
+    path_wchar = _PyUnicode_AsUnicode(path);
     if (path_wchar == NULL)
         return NULL;
-    if (wcslen(path_wchar) != (size_t)pathsize) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
-        return NULL;
-    }
 
     hFile = CreateFileW(
         path_wchar,
@@ -7178,7 +7173,6 @@ static PyObject *
 win_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     const wchar_t *path;
-    Py_ssize_t pathsize;
     DWORD n_bytes_returned;
     DWORD io_result;
     PyObject *po, *result;
@@ -7197,13 +7191,9 @@ win_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
                           ))
         return NULL;
 
-    path = PyUnicode_AsUnicodeAndSize(po, &pathsize);
+    path = _PyUnicode_AsUnicode(po);
     if (path == NULL)
         return NULL;
-    if (wcslen(path) != (size_t)pathsize) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
-        return NULL;
-    }
 
     /* First get a handle to the reparse point */
     Py_BEGIN_ALLOW_THREADS

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8991,7 +8991,7 @@ os_putenv_impl(PyObject *module, PyObject *name, PyObject *value)
         return NULL;
     }
 
-    env = PyUnicode_AsUnicodeAndSize(uncode, &size);
+    env = PyUnicode_AsUnicodeAndSize(unicode, &size);
     if (env == NULL)
         goto error;
     if (size > _MAX_ENV) {

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -158,6 +158,7 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
 
     if ((bytes = PyUnicode_EncodeFSDefault(arg)) == NULL)
         return NULL;
+    /* check for embedded null bytes */
     if (PyBytes_AsStringAndSize(bytes, &name, NULL) == -1)
         goto out;
     if ((p = getpwnam(name)) == NULL) {

--- a/Modules/spwdmodule.c
+++ b/Modules/spwdmodule.c
@@ -134,6 +134,7 @@ spwd_getspnam_impl(PyObject *module, PyObject *arg)
 
     if ((bytes = PyUnicode_EncodeFSDefault(arg)) == NULL)
         return NULL;
+    /* check for embedded null bytes */
     if (PyBytes_AsStringAndSize(bytes, &name, NULL) == -1)
         goto out;
     if ((p = getspnam(name)) == NULL) {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -4138,6 +4138,20 @@ PyUnicode_AsUnicode(PyObject *unicode)
     return PyUnicode_AsUnicodeAndSize(unicode, NULL);
 }
 
+const Py_UNICODE *
+_PyUnicode_AsUnicode(PyObject *unicode)
+{
+    Py_ssize_t size;
+    const Py_UNICODE *wstr;
+
+    wstr = PyUnicode_AsUnicodeAndSize(unicode, &size);
+    if (wstr && wcslen(wstr) != (size_t)size) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        return NULL;
+    }
+    return wstr;
+}
+
 
 Py_ssize_t
 PyUnicode_GetSize(PyObject *unicode)

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -594,10 +594,8 @@ summary_setproperty(msiobj* si, PyObject *args)
         return NULL;
 
     if (PyUnicode_Check(data)) {
-        Py_ssize_t size;
-        WCHAR *value = PyUnicode_AsUnicodeAndSize(data, &size);
-        if (wcslen(value) != (size_t)size) {
-            PyErr_SetString(PyExc_ValueError, "embedded null character");
+        WCHAR *value = _PyUnicode_AsUnicode(data);
+        if (value == NULL) {
             return NULL;
         }
         status = MsiSummaryInfoSetPropertyW(si->h, field, VT_LPSTR,

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -594,8 +594,14 @@ summary_setproperty(msiobj* si, PyObject *args)
         return NULL;
 
     if (PyUnicode_Check(data)) {
+        Py_ssize_t size;
+        WCHAR *value = PyUnicode_AsUnicodeAndSize(data, &size);
+        if (wcslen(value) != (size_t)size) {
+            PyErr_SetString(PyExc_ValueError, "embedded null character");
+            return NULL;
+        }
         status = MsiSummaryInfoSetPropertyW(si->h, field, VT_LPSTR,
-            0, NULL, PyUnicode_AsUnicode(data));
+            0, NULL, value);
     } else if (PyLong_CheckExact(data)) {
         long value = PyLong_AsLong(data);
         if (value == -1 && PyErr_Occurred()) {

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -190,7 +190,7 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
 {
     dl_funcptr p;
     char funcname[258], *import_python;
-    wchar_t *wpathname;
+    const wchar_t *wpathname;
 
 #ifndef _DEBUG
     _Py_CheckPython3();

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -191,19 +191,14 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
     dl_funcptr p;
     char funcname[258], *import_python;
     wchar_t *wpathname;
-    Py_ssize_t pathsize;
 
 #ifndef _DEBUG
     _Py_CheckPython3();
 #endif
 
-    wpathname = PyUnicode_AsUnicodeAndSize(pathname, &pathsize);
+    wpathname = _PyUnicode_AsUnicode(pathname);
     if (wpathname == NULL)
         return NULL;
-    if (wcslen(wpathname) != (size_t)pathsize) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
-        return NULL;
-    }
 
     PyOS_snprintf(funcname, sizeof(funcname), "%.20s_%.200s", prefix, shortname);
 

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -191,14 +191,19 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
     dl_funcptr p;
     char funcname[258], *import_python;
     wchar_t *wpathname;
+    Py_ssize_t pathsize;
 
 #ifndef _DEBUG
     _Py_CheckPython3();
 #endif
 
-    wpathname = PyUnicode_AsUnicode(pathname);
+    wpathname = PyUnicode_AsUnicodeAndSize(pathname, &pathsize);
     if (wpathname == NULL)
         return NULL;
+    if (wcslen(wpathname) != (size_t)pathsize) {
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
+        return NULL;
+    }
 
     PyOS_snprintf(funcname, sizeof(funcname), "%.20s_%.200s", prefix, shortname);
 

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -711,16 +711,11 @@ _Py_stat(PyObject *path, struct stat *statbuf)
 #ifdef MS_WINDOWS
     int err;
     struct _stat wstatbuf;
-    wchar_t *wpath;
-    Py_ssize_t pathlen;
+    const wchar_t *wpath;
 
-    wpath = PyUnicode_AsUnicodeAndSize(path, &pathlen);
+    wpath = _PyUnicode_AsUnicode(path);
     if (wpath == NULL)
         return -2;
-    if (wcslen(wpath) != (size_t)pathlen) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
-        return -2;
-    }
 
     err = _wstat(wpath, &wstatbuf);
     if (!err)
@@ -1096,7 +1091,7 @@ _Py_fopen_obj(PyObject *path, const char *mode)
     FILE *f;
     int async_err = 0;
 #ifdef MS_WINDOWS
-    wchar_t *wpath;
+    const wchar_t *wpath;
     wchar_t wmode[10];
     int usize;
     Py_ssize_t pathlen;
@@ -1111,13 +1106,9 @@ _Py_fopen_obj(PyObject *path, const char *mode)
                      Py_TYPE(path));
         return NULL;
     }
-    wpath = PyUnicode_AsUnicodeAndSize(path, &pathlen);
+    wpath = _PyUnicode_AsUnicode(path);
     if (wpath == NULL)
         return NULL;
-    if (wcslen(wpath) != (size_t)pathlen) {
-        PyErr_SetString(PyExc_ValueError, "embedded null character");
-        return NULL;
-    }
 
     usize = MultiByteToWideChar(CP_ACP, 0, mode, -1, wmode, sizeof(wmode));
     if (usize == 0) {

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1094,7 +1094,6 @@ _Py_fopen_obj(PyObject *path, const char *mode)
     const wchar_t *wpath;
     wchar_t wmode[10];
     int usize;
-    Py_ssize_t pathlen;
 
 #ifdef WITH_THREAD
     assert(PyGILState_Check());

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -717,7 +717,7 @@ _Py_stat(PyObject *path, struct stat *statbuf)
     wpath = PyUnicode_AsUnicodeAndSize(path, &pathlen);
     if (wpath == NULL)
         return -2;
-    if (wcslen(wpath) != pathlen) {
+    if (wcslen(wpath) != (size_t)pathlen) {
         PyErr_SetString(PyExc_ValueError, "embedded null character");
         return -2;
     }
@@ -1114,7 +1114,7 @@ _Py_fopen_obj(PyObject *path, const char *mode)
     wpath = PyUnicode_AsUnicodeAndSize(path, &pathlen);
     if (wpath == NULL)
         return NULL;
-    if (wcslen(wpath) != pathlen) {
+    if (wcslen(wpath) != (size_t)pathlen) {
         PyErr_SetString(PyExc_ValueError, "embedded null character");
         return NULL;
     }

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -718,7 +718,7 @@ _Py_stat(PyObject *path, struct stat *statbuf)
     if (wpath == NULL)
         return -2;
     if (wcslen(wpath) != pathlen) {
-        PyErr_SetString(PyExc_TypeError, "embedded null character");
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
         return -2;
     }
 
@@ -1115,7 +1115,7 @@ _Py_fopen_obj(PyObject *path, const char *mode)
     if (wpath == NULL)
         return NULL;
     if (wcslen(wpath) != pathlen) {
-        PyErr_SetString(PyExc_TypeError, "embedded null character");
+        PyErr_SetString(PyExc_ValueError, "embedded null character");
         return NULL;
     }
 


### PR DESCRIPTION
Based on patch by Victor Stinner.