### PR TITLE
bpo-30726: Fix elementtree warnings on Windows due to expat upgrade

### DIFF
--- a/PCbuild/_elementtree.vcxproj
+++ b/PCbuild/_elementtree.vcxproj
@@ -63,7 +63,6 @@
     <ClCompile>
       <AdditionalIncludeDirectories>..\Modules\expat;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;USE_PYEXPAT_CAPI;XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <DisableSpecificWarnings>4244;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <BaseAddress>0x1D100000</BaseAddress>

--- a/PCbuild/_elementtree.vcxproj
+++ b/PCbuild/_elementtree.vcxproj
@@ -62,7 +62,8 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>..\Modules\expat;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>USE_PYEXPAT_CAPI;XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;USE_PYEXPAT_CAPI;XML_STATIC;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <DisableSpecificWarnings>4244;4267;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <BaseAddress>0x1D100000</BaseAddress>


### PR DESCRIPTION
We are getting:

```
Warning	C4005	'HAVE_MEMMOVE': macro redefinition	_elementtree	c:\users\segev\prj\python\cpython\modules\expat\winconfig.h	34	
Warning	C4267	'=': conversion from 'size_t' to 'unsigned char', possible loss of data	_elementtree	c:\users\segev\prj\python\cpython\modules\expat\siphash.h	316	
Warning	C4996	'getenv': This function or variable may be unsafe. Consider using _dupenv_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.	_elementtree	C:\Users\Segev\prj\python\cpython\Modules\expat\xmlparse.c	796	
Warning	C4005	'HAVE_MEMMOVE': macro redefinition	_elementtree	c:\users\segev\prj\python\cpython\modules\expat\winconfig.h	34	
Warning	C4005	'HAVE_MEMMOVE': macro redefinition	_elementtree	c:\users\segev\prj\python\cpython\modules\expat\winconfig.h	34
```

And in 64-bit:
```
c:\users\segev\prj\python\cpython\modules\expat\siphash.h(201): warning C4244: 'initializing': conversion from '__int64' to 'char', possible loss of data
```

I'm not sure how many Python versions this affects.