### PR TITLE
[3.6] Fix trivial typo in idlelib/config.py (GH-2309)

### DIFF
--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -7,7 +7,7 @@ which duplicate the defaults will be removed from the user's
 configuration files, and if a user file becomes empty, it will be
 deleted.
 
-The configuration database maps options to values.  Comceptually, the
+The configuration database maps options to values.  Conceptually, the
 database keys are tuples (config-type, section, item).  As implemented,
 there are  separate dicts for default and user values.  Each has
 config-type keys 'main', 'extensions', 'highlight', and 'keys'.  The


### PR DESCRIPTION
Comceptually -> Conceptually
(cherry picked from commit f3e8209)