### PR TITLE
[3.6] bpo-30616: Functional API of enum allows to create empty enums (#2304)

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -381,7 +381,7 @@ class EnumMeta(type):
         # special processing needed for names?
         if isinstance(names, str):
             names = names.replace(',', ' ').split()
-        if isinstance(names, (tuple, list)) and isinstance(names[0], str):
+        if isinstance(names, (tuple, list)) and names and isinstance(names[0], str):
             original_names, names = names, []
             last_values = []
             for count, name in enumerate(original_names):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2291,6 +2291,26 @@ class TestIntFlag(unittest.TestCase):
             self.assertIs(type(e), Perm)
 
 
+    def test_programatic_function_from_empty_list(self):
+        Perm = enum.IntFlag('Perm', [])
+        lst = list(Perm)
+        self.assertEqual(len(lst), len(Perm))
+        self.assertEqual(len(Perm), 0, Perm)
+        Thing = enum.Enum('Thing', [])
+        lst = list(Thing)
+        self.assertEqual(len(lst), len(Thing))
+        self.assertEqual(len(Thing), 0, Thing)
+
+
+    def test_programatic_function_from_empty_tuple(self):
+        Perm = enum.IntFlag('Perm', ())
+        lst = list(Perm)
+        self.assertEqual(len(lst), len(Perm))
+        self.assertEqual(len(Perm), 0, Perm)
+        Thing = enum.Enum('Thing', ())
+        self.assertEqual(len(lst), len(Thing))
+        self.assertEqual(len(Thing), 0, Thing)
+
     def test_containment(self):
         Perm = self.Perm
         R, W, X = Perm

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -86,6 +86,9 @@ Core and Builtins
 Library
 -------
 
+- bpo-30616: Functional API of enum allows to create empty enums.
+  Patched by Dong-hee Na
+  
 - bpo-30038: Fix race condition between signal delivery and wakeup file
   descriptor.  Patch by Nathaniel Smith.
 


### PR DESCRIPTION
cherry-pick from dcc8ce44c74492670e6bfbde588a2acbf8f365e0