### PR TITLE
bpo-30619: fix

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -939,7 +939,7 @@ The module defines the following classes, functions and decorators:
 
        Union[int, str] == Union[str, int]
 
-   * When a class and its subclass are present, the former is skipped, e.g.::
+   * When a class and its subclass are present, the latter is skipped, e.g.::
 
        Union[int, object] == object
 


### PR DESCRIPTION
Following [bug #30619](http://bugs.python.org/issue30619).

It was the example (and not the text) which is consistent with PEP 483:

    Corollary: Union[..., object, ...] returns object

So, the correction is simply to substitute 'former' for 'latter'.