### PR TITLE
bpo-30731: python.manifest fix

### DIFF
--- a/Misc/NEWS.d/next/Windows/2017-07-13-11-22-53.bpo-30731.nmMDwI.rst
+++ b/Misc/NEWS.d/next/Windows/2017-07-13-11-22-53.bpo-30731.nmMDwI.rst
@@ -1,0 +1,1 @@
+Add a missing xmlns to python.manifest so that it matches the schema.

--- a/PC/python.manifest
+++ b/PC/python.manifest
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-  <trustInfo>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
     <security>
       <requestedPrivileges>
         <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
       </requestedPrivileges>
     </security>
   </trustInfo>
-  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
-    <application> 
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/>
       <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/>
       <supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}"/>
       <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}"/>
       <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
-    </application> 
+    </application>
   </compatibility>
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>


### PR DESCRIPTION
I'm not seeing the typo mentioned in the issue ([PC/python.manifest:3](https://github.com/python/cpython/blob/396998e0c6ee7e555133c53ce42224046b1255f7/PC/python.manifest#L3)) but the xmlns is missing so I added it. Also trimmed some trailing whitespace because really...

For reference, here is a manifest generated by default on stuff built with VS2015:
```xml
<?xml version='1.0' encoding='UTF-8' standalone='yes'?>
<assembly xmlns='urn:schemas-microsoft-com:asm.v1' manifestVersion='1.0'>
  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
    <security>
      <requestedPrivileges>
        <requestedExecutionLevel level='asInvoker' uiAccess='false' />
      </requestedPrivileges>
    </security>
  </trustInfo>
</assembly>
```

Documentation on this seems surprisingly poor on MSDN. Or maybe I just failed to find it...