### PR TITLE
Add "Misc/NEWS.d" directory tree for "blurb"

### DIFF
--- a/Misc/NEWS.d/next/Build/README.rst
+++ b/Misc/NEWS.d/next/Build/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *Build* section in this directory.

--- a/Misc/NEWS.d/next/C API/README.rst
+++ b/Misc/NEWS.d/next/C API/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *C API* section in this directory.

--- a/Misc/NEWS.d/next/Core and Builtins/README.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *Core and Builtins* section in this directory.

--- a/Misc/NEWS.d/next/Documentation/README.rst
+++ b/Misc/NEWS.d/next/Documentation/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *Documentation* section in this directory.

--- a/Misc/NEWS.d/next/IDLE/README.rst
+++ b/Misc/NEWS.d/next/IDLE/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *IDLE* section in this directory.

--- a/Misc/NEWS.d/next/Library/README.rst
+++ b/Misc/NEWS.d/next/Library/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *Library* section in this directory.

--- a/Misc/NEWS.d/next/Security/README.rst
+++ b/Misc/NEWS.d/next/Security/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *Security* section in this directory.

--- a/Misc/NEWS.d/next/Tests/README.rst
+++ b/Misc/NEWS.d/next/Tests/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *Tests* section in this directory.

--- a/Misc/NEWS.d/next/Tools-Demos/README.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *Tools/Demos* section in this directory.

--- a/Misc/NEWS.d/next/Windows/README.rst
+++ b/Misc/NEWS.d/next/Windows/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *Windows* section in this directory.

--- a/Misc/NEWS.d/next/macOS/README.rst
+++ b/Misc/NEWS.d/next/macOS/README.rst
@@ -1,0 +1,1 @@
+Put news entry ``blurb`` files for the *macOS* section in this directory.


### PR DESCRIPTION
Add "Misc/NEWS.d" directory tree for "blurb".

CPython workflow is changing!  We're going to start using "blurb"
to manage Misc/NEWS entries:
    https://github.com/python/core-workflow
(This will be a big win for release managers, honest.)

This checkin simply populates the "Misc/NEWS.d" subdirectory tree
so that people can start putting their news entries in there.
No other changes (yet).