### PR TITLE
bpo-36700: Updated obsolete references for RFC 3548 to RFC 4648

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -2,7 +2,7 @@
 ===============================================================
 
 .. module:: base64
-   :synopsis: RFC 3548: Base16, Base32, Base64 Data Encodings;
+   :synopsis: RFC 4648: Base16, Base32, Base64 Data Encodings;
               Base85 and Ascii85
 
 **Source code:** :source:`Lib/base64.py`
@@ -16,10 +16,10 @@
 This module provides functions for encoding binary data to printable
 ASCII characters and decoding such encodings back to binary data.
 It provides encoding and decoding functions for the encodings specified in
-:rfc:`3548`, which defines the Base16, Base32, and Base64 algorithms,
+:rfc:`4648`, which defines the Base16, Base32, and Base64 algorithms,
 and for the de-facto standard Ascii85 and Base85 encodings.
 
-The :rfc:`3548` encodings are suitable for encoding binary data so that it can
+The :rfc:`4648` encodings are suitable for encoding binary data so that it can
 safely sent by email, used as parts of URLs, or included as part of an HTTP
 POST request.  The encoding algorithm is not the same as the
 :program:`uuencode` program.
@@ -28,7 +28,7 @@ There are two interfaces provided by this module.  The modern interface
 supports encoding :term:`bytes-like objects <bytes-like object>` to ASCII
 :class:`bytes`, and decoding :term:`bytes-like objects <bytes-like object>` or
 strings containing ASCII to :class:`bytes`.  Both base-64 alphabets
-defined in :rfc:`3548` (normal, and URL- and filesystem-safe) are supported.
+defined in :rfc:`4648` (normal, and URL- and filesystem-safe) are supported.
 
 The legacy interface does not support decoding from strings, but it does
 provide functions for encoding and decoding to and from :term:`file objects
@@ -124,12 +124,13 @@ The modern interface provides:
    whether a lowercase alphabet is acceptable as input.  For security purposes,
    the default is ``False``.
 
-   :rfc:`3548` allows for optional mapping of the digit 0 (zero) to the letter O
+   One might desire an optional mapping of the digit 0 (zero) to the letter O
    (oh), and for optional mapping of the digit 1 (one) to either the letter I (eye)
    or letter L (el).  The optional argument *map01* when not ``None``, specifies
    which letter the digit 1 should be mapped to (when *map01* is not ``None``, the
    digit 0 is always mapped to the letter O).  For security purposes the default is
-   ``None``, so that 0 and 1 are not allowed in the input.
+   ``None``, so that 0 and 1 are not allowed in the input. Note that :rfc:`4648`
+    (which made :rfc:`3548` obsolete) did not allow such a mapping.
 
    A :exc:`binascii.Error` is raised if *s* is
    incorrectly padded or if there are non-alphabet characters present in the

--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -130,7 +130,7 @@ The modern interface provides:
    which letter the digit 1 should be mapped to (when *map01* is not ``None``, the
    digit 0 is always mapped to the letter O).  For security purposes the default is
    ``None``, so that 0 and 1 are not allowed in the input. Note that :rfc:`4648`
-    (which made :rfc:`3548` obsolete) did not allow such a mapping.
+   (which made :rfc:`3548` obsolete) did not allow such a mapping.
 
    A :exc:`binascii.Error` is raised if *s* is
    incorrectly padded or if there are non-alphabet characters present in the

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -3,7 +3,7 @@
 """Base16, Base32, Base64 (RFC 4648), Base85 and Ascii85 data encodings"""
 
 # Modified 04-Oct-1995 by Jack Jansen to use binascii module
-# Modified 30-Dec-2003 by Barry Warsaw to add full RFC 4648 support
+# Modified 30-Dec-2003 by Barry Warsaw to add full RFC 3548 support
 # Modified 22-May-2007 by Guido van Rossum to use bytes everywhere
 
 import re

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -1,9 +1,9 @@
 #! /usr/bin/env python3
 
-"""Base16, Base32, Base64 (RFC 3548), Base85 and Ascii85 data encodings"""
+"""Base16, Base32, Base64 (RFC 4648), Base85 and Ascii85 data encodings"""
 
 # Modified 04-Oct-1995 by Jack Jansen to use binascii module
-# Modified 30-Dec-2003 by Barry Warsaw to add full RFC 3548 support
+# Modified 30-Dec-2003 by Barry Warsaw to add full RFC 4648 support
 # Modified 22-May-2007 by Guido van Rossum to use bytes everywhere
 
 import re
@@ -183,13 +183,14 @@ def b32decode(s, casefold=False, map01=None):
     Optional casefold is a flag specifying whether a lowercase alphabet is
     acceptable as input.  For security purposes, the default is False.
 
-    RFC 3548 allows for optional mapping of the digit 0 (zero) to the
+    One might desire an optional mapping of the digit 0 (zero) to the
     letter O (oh), and for optional mapping of the digit 1 (one) to
     either the letter I (eye) or letter L (el).  The optional argument
     map01 when not None, specifies which letter the digit 1 should be
     mapped to (when map01 is not None, the digit 0 is always mapped to
     the letter O).  For security purposes the default is None, so that
-    0 and 1 are not allowed in the input.
+    0 and 1 are not allowed in the input. Note that RFC 4648 (which
+    made RFC 3548 obsolete) did not allow such a mapping.
 
     The result is returned as a bytes object.  A binascii.Error is raised if
     the input is incorrectly padded or if there are non-alphabet
@@ -248,7 +249,7 @@ def b32decode(s, casefold=False, map01=None):
 
 
 
-# RFC 3548, Base 16 Alphabet specifies uppercase, but hexlify() returns
+# RFC 4648, Base 16 Alphabet specifies uppercase, but hexlify() returns
 # lowercase.  The RFC also recommends against accepting input case
 # insensitively.
 def b16encode(s):


### PR DESCRIPTION
Updating just the documentation for base64 library. The RFC that was reference was obsolete. The description of both the old and new RFCs was incorrect in saying that they allowed optional changes; the proposed new wording makes this clear without deprecating the option.

<!-- issue-number: [bpo-36700](https://bugs.python.org/issue36700) -->
https://bugs.python.org/issue36700
<!-- /issue-number -->
