### PR TITLE
[3.5] bpo-30619: Clarify typing.Union documentation (GH-2326)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -861,7 +861,7 @@ The module defines the following classes, functions and decorators:
 
        Union[int, str] == Union[str, int]
 
-   * When a class and its subclass are present, the former is skipped, e.g.::
+   * When a class and its subclass are present, the latter is skipped, e.g.::
 
        Union[int, object] == object
 


### PR DESCRIPTION
When a class and its subclass are present, the latter is skipped.
(cherry picked from commit 6580c19bbbe7bc9bc0884699afd69184f523b32e)