### PR TITLE
bpo-30709: Fixed bad getter example from Doc/Descriptor#Properties

### DIFF
--- a/Doc/howto/descriptor.rst
+++ b/Doc/howto/descriptor.rst
@@ -252,10 +252,10 @@ to wrap access to the value attribute in a property data descriptor::
 
     class Cell(object):
         . . .
-        def getvalue(self, obj):
-            "Recalculate cell before returning value"
+        def getvalue(self):
+            "Recalculate the cell before returning value"
             self.recalc()
-            return obj._value
+            return self._value
         value = property(getvalue)
 
 


### PR DESCRIPTION
- I recreated the branch that is current even with master
- Previous conversation: https://github.com/python/cpython/pull/2288
- About the commit,
    + The purpose of `obj` in the example is implicit
    + As an argument the `obj` will cause errors when using `Cell('b10').value` because it expects more arguments, but 1 given