### PR TITLE
bpo-30721: Show correct syntax hint in Py3 when using Py2 redirection syntax

### DIFF
--- a/Lib/test/test_print.py
+++ b/Lib/test/test_print.py
@@ -155,9 +155,35 @@ class TestPy2MigrationHint(unittest.TestCase):
 
         self.assertIn('print("Hello World", end=" ")', str(context.exception))
 
-    def test_string_with_stream_redirection(self):
+    def test_print_string_with_stream_redirection(self):
         import sys
         python2_print_str = 'print >> sys.stderr, "message"'
+        with self.assertRaises(TypeError) as context:
+            exec(python2_print_str)
+
+        self.assertIn('Did you mean "print(<message>, '
+                'file=<output_stream>)', str(context.exception))
+
+    def test_print_with_stream_redirection_using_max(self):
+        import sys
+        python2_print_str = 'max >> sys.stderr'
+        with self.assertRaises(TypeError) as context:
+            exec(python2_print_str)
+
+        self.assertNotIn('Did you mean "print(<message>, '
+                'file=<output_stream>)', str(context.exception))
+
+    def test_print_with_stream_redirection_using_rrshift(self):
+        import sys
+
+        class OverrideRRShift:
+
+            def __rrshift__(self, lhs):
+                return 0 # Force result independent of LHS
+
+        self.assertEqual(print >> OverrideRRShift(), 0)
+
+        python2_print_str = 'print >> 42'
         with self.assertRaises(TypeError) as context:
             exec(python2_print_str)
 

--- a/Lib/test/test_print.py
+++ b/Lib/test/test_print.py
@@ -161,7 +161,8 @@ class TestPy2MigrationHint(unittest.TestCase):
         with self.assertRaises(TypeError) as context:
             exec(python2_print_str)
 
-        self.assertIn('print(message, file={:100!r}).format(sys.stderr)', str(context.exception))
+        self.assertIn('Did you mean "print(<message>, '
+                'file=<output_stream>)', str(context.exception))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_print.py
+++ b/Lib/test/test_print.py
@@ -157,7 +157,6 @@ class TestPy2MigrationHint(unittest.TestCase):
         self.assertIn('print("Hello World", end=" ")', str(context.exception))
 
     def test_stream_redirection_hint_for_py2_migration(self):
-
         # Test correct hint produced for Py2 redirection syntax
         with self.assertRaises(TypeError) as context:
             print >> sys.stderr, "message"
@@ -181,7 +180,7 @@ class TestPy2MigrationHint(unittest.TestCase):
             print << sys.stderr
         self.assertNotIn('Did you mean', str(context.exception))
 
-        # Test stream redirection with right argument implemented __rrshift__
+        # Ensure right operand implementing rrshift still works
         class OverrideRRShift:
             def __rrshift__(self, lhs):
                 return 42 # Force result independent of LHS

--- a/Lib/test/test_print.py
+++ b/Lib/test/test_print.py
@@ -155,6 +155,14 @@ class TestPy2MigrationHint(unittest.TestCase):
 
         self.assertIn('print("Hello World", end=" ")', str(context.exception))
 
+    def test_string_with_stream_redirection(self):
+        import sys
+        python2_print_str = 'print >> sys.stderr, "message"'
+        with self.assertRaises(TypeError) as context:
+            exec(python2_print_str)
+
+        self.assertIn('print(message, file={:100!r}).format(sys.stderr)', str(context.exception))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_print.py
+++ b/Lib/test/test_print.py
@@ -1,4 +1,5 @@
 import unittest
+import sys
 from io import StringIO
 
 from test import support
@@ -156,43 +157,32 @@ class TestPy2MigrationHint(unittest.TestCase):
         self.assertIn('print("Hello World", end=" ")', str(context.exception))
 
     def test_stream_redirection_hint_for_py2_migration(self):
-        import sys
 
         # Test correct hint produced for Py2 redirection syntax
-        python2_print_str = 'print >> sys.stderr, "message"'
         with self.assertRaises(TypeError) as context:
-            exec(python2_print_str)
-
+            print >> sys.stderr, "message"
         self.assertIn('Did you mean "print(<message>, '
                 'file=<output_stream>)', str(context.exception))
 
-        # Test correct hint is produced in thecase where RHS implements
+        # Test correct hint is produced in the case where RHS implements
         # __rrshift__ but returns NotImplemented
-        python2_print_str = 'print >> 42'
         with self.assertRaises(TypeError) as context:
-            exec(python2_print_str)
-
+            print >> 42
         self.assertIn('Did you mean "print(<message>, '
                 'file=<output_stream>)', str(context.exception))
 
         # Test stream redirection hint is specific to print
-        python2_print_str = 'max >> sys.stderr'
         with self.assertRaises(TypeError) as context:
-            exec(python2_print_str)
-
+            max >> sys.stderr
         self.assertNotIn('Did you mean ', str(context.exception))
 
-        # Test stream redirection hint is specific to rrshift
-        python2_print_str = 'print << sys.stderr'
+        # Test stream redirection hint is specific to rshift
         with self.assertRaises(TypeError) as context:
-            exec(python2_print_str)
-
-        self.assertNotIn('Did you mean "print(<message>, '
-                'file=<output_stream>)', str(context.exception))
+            print << sys.stderr
+        self.assertNotIn('Did you mean', str(context.exception))
 
         # Test stream redirection with right argument implemented __rrshift__
         class OverrideRRShift:
-
             def __rrshift__(self, lhs):
                 return 42 # Force result independent of LHS
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,9 +10,6 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
-- bpo-30721: ``print`` now shows correct usage hint for using Python 2
-  redirection syntax. Patch by Sanyam Khurana.
-
 - bpo-30814: Fixed a race condition when import a submodule from a package.
 
 - bpo-30736: The internal unicodedata database has been upgraded to Unicode

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 3.7.0 alpha 1?
 Core and Builtins
 -----------------
 
+- bpo-30721: ``print`` now shows correct usage hint for using Python 2
+  redirection syntax. Patch by Sanyam Khurana.
+
 - bpo-30814: Fixed a race condition when import a submodule from a package.
 
 - bpo-30736: The internal unicodedata database has been upgraded to Unicode

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-18-15-15-20.bpo-30721.Hmc56z.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-18-15-15-20.bpo-30721.Hmc56z.rst
@@ -1,0 +1,2 @@
+``print`` now shows correct usage hint for using Python 2 redirection
+syntax. Patch by Sanyam Khurana.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-18-15-15-20.bpo-30721.Hmc56z.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-18-15-15-20.bpo-30721.Hmc56z.rst
@@ -1,2 +1,2 @@
 ``print`` now shows correct usage hint for using Python 2 redirection
-syntax. Patch by Sanyam Khurana.
+syntax.  Patch by Sanyam Khurana.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -822,7 +822,7 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
 
         if (op_slot == NB_SLOT(nb_rshift) &&
             PyCFunction_Check(v) &&
-            strncmp(((PyCFunctionObject *)v)->m_ml->ml_name, "print", 6) == 0)
+            strcmp(((PyCFunctionObject *)v) -> m_ml -> ml_name, "print") == 0)
         {
             PyErr_Format(PyExc_TypeError,
                 "unsupported operand type(s) for %.100s: "

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -819,6 +819,21 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
     PyObject *result = binary_op1(v, w, op_slot);
     if (result == Py_NotImplemented) {
         Py_DECREF(result);
+
+        if (strcmp(op_name, ">>") == 0 && \
+                strcmp(v->ob_type->tp_name, "builtin_function_or_method") == 0) {
+            PyErr_Format(PyExc_TypeError,
+                 "unsupported operand type(s) for %.100s: "
+                 "'%.100s' and '%.100s'. Did you mean \"print(%s, "
+                 "file={:100!r}).format(%s))\"",
+                 op_name,
+                 v->ob_type->tp_name,
+                 w->ob_type->tp_name,
+                 "message",
+                 "sys.stderr");
+            return NULL;
+        }
+
         return binop_type_error(v, w, op_name);
     }
     return result;

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -821,10 +821,9 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
         Py_DECREF(result);
 
         if (op_slot == NB_SLOT(nb_rshift) &&
-                PyCFunction_Check(v) &&
-                strncmp(((PyCFunctionObject *)v) -> m_ml -> ml_name, "print", 6) == 0)
+            PyCFunction_Check(v) &&
+            strncmp(((PyCFunctionObject *)v)->m_ml->ml_name, "print", 6) == 0)
         {
-
             PyErr_Format(PyExc_TypeError,
                 "unsupported operand type(s) for %.100s: "
                 "'%.100s' and '%.100s'. Did you mean \"print(<message>, "

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -821,7 +821,7 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
         Py_DECREF(result);
 
         if (op_slot == NB_SLOT(nb_rshift) && \
-                strcmp(v->ob_type->tp_name, "builtin_function_or_method") == 0) {
+                PyCFunction_Check(v) && strcmp(((PyCFunctionObject *)v) -> m_ml -> ml_name, "print") == 0) {
 
             PyErr_Format(PyExc_TypeError,
                 "unsupported operand type(s) for %.100s: "

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -820,8 +820,10 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
     if (result == Py_NotImplemented) {
         Py_DECREF(result);
 
-        if (op_slot == NB_SLOT(nb_rshift) && \
-                PyCFunction_Check(v) && strcmp(((PyCFunctionObject *)v) -> m_ml -> ml_name, "print") == 0) {
+        if (op_slot == NB_SLOT(nb_rshift) &&
+                PyCFunction_Check(v) &&
+                strncmp(((PyCFunctionObject *)v) -> m_ml -> ml_name, "print", 6) == 0)
+        {
 
             PyErr_Format(PyExc_TypeError,
                 "unsupported operand type(s) for %.100s: "

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -820,7 +820,7 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
     if (result == Py_NotImplemented) {
         Py_DECREF(result);
 
-        if (op_slot == 96 && \
+        if (op_slot == NB_SLOT(nb_rshift) && \
                 strcmp(v->ob_type->tp_name, "builtin_function_or_method") == 0) {
 
             PyErr_Format(PyExc_TypeError,

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -822,7 +822,7 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
 
         if (op_slot == NB_SLOT(nb_rshift) &&
             PyCFunction_Check(v) &&
-            strcmp(((PyCFunctionObject *)v) -> m_ml -> ml_name, "print") == 0)
+            strcmp(((PyCFunctionObject *)v)->m_ml->ml_name, "print") == 0)
         {
             PyErr_Format(PyExc_TypeError,
                 "unsupported operand type(s) for %.100s: "

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -820,17 +820,16 @@ binary_op(PyObject *v, PyObject *w, const int op_slot, const char *op_name)
     if (result == Py_NotImplemented) {
         Py_DECREF(result);
 
-        if (strcmp(op_name, ">>") == 0 && \
+        if (op_slot == 96 && \
                 strcmp(v->ob_type->tp_name, "builtin_function_or_method") == 0) {
+
             PyErr_Format(PyExc_TypeError,
-                 "unsupported operand type(s) for %.100s: "
-                 "'%.100s' and '%.100s'. Did you mean \"print(%s, "
-                 "file={:100!r}).format(%s))\"",
-                 op_name,
-                 v->ob_type->tp_name,
-                 w->ob_type->tp_name,
-                 "message",
-                 "sys.stderr");
+                "unsupported operand type(s) for %.100s: "
+                "'%.100s' and '%.100s'. Did you mean \"print(<message>, "
+                "file=<output_stream>)\"",
+                op_name,
+                v->ob_type->tp_name,
+                w->ob_type->tp_name);
             return NULL;
         }
 


### PR DESCRIPTION
This is a work in progress for issue: http://bugs.python.org/issue30721

@ncoghlan I'm not sure how should I get the value that is being entered on the command line. What I know is it would be in `PyObject *w`, but I'm unable to get the right method from the doc to read the buffer.

So, for now, I've hard-coded the value just to make the test case pass. Could you please help me with the former problem and give me a pointer on it.

Also, after writing this patch, I realize, that `binary_op` is a generic function, and this code should be placed in function `binop_type_error`. Would you please guide me about these things? 

Thanks!

<!-- issue-number: bpo-30721 -->
https://bugs.python.org/issue30721
<!-- /issue-number -->
