### PR TITLE
[3.6] bpo-30602: Fix lastarg in os.spawnve() (#2287)

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5189,7 +5189,7 @@ os_spawnve_impl(PyObject *module, int mode, path_t *path, PyObject *argv,
             goto fail_1;
         }
         if (i == 0 && !argvlist[0][0]) {
-            lastarg = i;
+            lastarg = i + 1;
             PyErr_SetString(
                 PyExc_ValueError,
                 "spawnv() arg 2 first element cannot be empty");


### PR DESCRIPTION
Fix a regression introduced by myself in the commit
526b22657cb18fe79118c2ea68511aca09430c2c.
(cherry picked from commit c8d6ab2e25ff212702d387e516e258b1d8c52910)