### PR TITLE
[3.5] bpo-30645: don't append to an inner loop path in imp.load_package() (GH-2268)

### DIFF
--- a/Lib/imp.py
+++ b/Lib/imp.py
@@ -203,8 +203,9 @@ def load_package(name, path):
         extensions = (machinery.SOURCE_SUFFIXES[:] +
                       machinery.BYTECODE_SUFFIXES[:])
         for extension in extensions:
-            path = os.path.join(path, '__init__'+extension)
-            if os.path.exists(path):
+            init_path = os.path.join(path, '__init__' + extension)
+            if os.path.exists(init_path):
+                path = init_path
                 break
         else:
             raise ValueError('{!r} is not a package'.format(path))

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -56,6 +56,7 @@ Ankur Ankan
 Heidi Annexstad
 Ramchandra Apte
 Éric Araujo
+Alexandru Ardelean
 Alicia Arlen
 Jeffrey Armstrong
 Jason Asbahr

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -79,6 +79,10 @@ Library
   correctly returns the ``127.0.0.1`` host, instead of treating ``@evil.com``
   as the host in an authentification (``login@host``).
 
+- bpo-30645: Fix path calculation in imp.load_package(), fixing it for
+  cases when a package is only shipped with bytecodes. Patch by
+  Alexandru Ardelean.
+
 - bpo-23890: unittest.TestCase.assertRaises() now manually breaks a reference
   cycle to not keep objects alive longer than expected.
 


### PR DESCRIPTION
Bug didn't manifest itself when importing a module with source as .py files are always the first on the search path. The issue only showed up in bytecode-only packages where the calculated file path would be ``__init__.py/__init__.pyc``.

Patch by Alexandru Ardelean.
(cherry picked from commit c38e32a10061a7c6d54e7e53ffabf7af7998f045)