### PR TITLE
bpo-24813: IDLE: Add default title to help_about

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -463,7 +463,7 @@ class EditorWindow(object):
     def about_dialog(self, event=None):
         "Handle Help 'About IDLE' event."
         # Synchronize with macosx.overrideRootMenu.about_dialog.
-        help_about.AboutDialog(self.top,'About IDLE')
+        help_about.AboutDialog(self.top)
 
     def config_dialog(self, event=None):
         "Handle Options 'Configure IDLE' event."

--- a/Lib/idlelib/help_about.py
+++ b/Lib/idlelib/help_about.py
@@ -2,7 +2,7 @@
 
 """
 import os
-from sys import version
+from platform import python_version
 
 from tkinter import Toplevel, Frame, Label, Button, PhotoImage
 from tkinter import SUNKEN, TOP, BOTTOM, LEFT, X, BOTH, W, EW, NSEW, E
@@ -14,7 +14,7 @@ class AboutDialog(Toplevel):
     """Modal about dialog for idle
 
     """
-    def __init__(self, parent, title, _htest=False, _utest=False):
+    def __init__(self, parent, title=None, _htest=False, _utest=False):
         """Create popup, do not return until tk widget destroyed.
 
         parent - parent of this dialog
@@ -32,7 +32,7 @@ class AboutDialog(Toplevel):
         self.fg = "#ffffff"
         self.create_widgets()
         self.resizable(height=False, width=False)
-        self.title(title)
+        self.title(title or f'About IDLE {python_version()}')
         self.transient(parent)
         self.grab_set()
         self.protocol("WM_DELETE_WINDOW", self.ok)
@@ -48,7 +48,6 @@ class AboutDialog(Toplevel):
             self.wait_window()
 
     def create_widgets(self):
-        release = version[:version.index(' ')]
         frame = Frame(self, borderwidth=2, relief=SUNKEN)
         frame_buttons = Frame(self)
         frame_buttons.pack(side=BOTTOM, fill=X)
@@ -80,7 +79,7 @@ class AboutDialog(Toplevel):
                       justify=LEFT, fg=self.fg, bg=self.bg)
         email.grid(row=6, column=0, columnspan=2, sticky=W, padx=10, pady=0)
         docs = Label(frame_background, text='https://docs.python.org/' +
-                     version[:3] + '/library/idle.html',
+                     python_version()[:3] + '/library/idle.html',
                      justify=LEFT, fg=self.fg, bg=self.bg)
         docs.grid(row=7, column=0, columnspan=2, sticky=W, padx=10, pady=0)
 
@@ -88,7 +87,8 @@ class AboutDialog(Toplevel):
               height=2, bg=self.bg).grid(row=8, column=0, sticky=EW,
                                          columnspan=3, padx=5, pady=5)
 
-        pyver = Label(frame_background, text='Python version:  ' + release,
+        pyver = Label(frame_background,
+                      text='Python version:  ' + python_version(),
                       fg=self.fg, bg=self.bg)
         pyver.grid(row=9, column=0, sticky=W, padx=10, pady=0)
         tkver = Label(frame_background, text='Tk version:  ' + tk_patchlevel,
@@ -113,7 +113,8 @@ class AboutDialog(Toplevel):
               height=2, bg=self.bg).grid(row=11, column=0, sticky=EW,
                                          columnspan=3, padx=5, pady=5)
 
-        idlever = Label(frame_background, text='IDLE version:   ' + release,
+        idlever = Label(frame_background,
+                        text='IDLE version:   ' + python_version(),
                         fg=self.fg, bg=self.bg)
         idlever.grid(row=12, column=0, sticky=W, padx=10, pady=0)
         idle_buttons = Frame(frame_background, bg=self.bg)

--- a/Lib/idlelib/idle_test/test_help_about.py
+++ b/Lib/idlelib/idle_test/test_help_about.py
@@ -10,6 +10,7 @@ from idlelib.idle_test.mock_tk import Mbox_func
 from idlelib.help_about import AboutDialog as About
 from idlelib import textview
 import os.path
+from platform import python_version
 
 class LiveDialogTest(unittest.TestCase):
     """Simulate user clicking buttons other than [Close].
@@ -77,6 +78,28 @@ class LiveDialogTest(unittest.TestCase):
                     f.readline().strip(),
                     dialog._current_textview.text.get('3.0', '3.end'))
             dialog._current_textview.destroy()
+
+
+class DefaultTitleTest(unittest.TestCase):
+    "Test default title."
+
+    @classmethod
+    def setUpClass(cls):
+        requires('gui')
+        cls.root = Tk()
+        cls.root.withdraw()
+        cls.dialog = About(cls.root, _utest=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.dialog
+        cls.root.update_idletasks()
+        cls.root.destroy()
+        del cls.root
+
+    def test_dialog_title(self):
+        """Test about dialog title"""
+        self.assertEqual(self.dialog.title(), f'About IDLE {python_version()}')
 
 
 class CloseTest(unittest.TestCase):

--- a/Lib/idlelib/macosx.py
+++ b/Lib/idlelib/macosx.py
@@ -165,7 +165,7 @@ def overrideRootMenu(root, flist):
         "Handle Help 'About IDLE' event."
         # Synchronize with editor.EditorWindow.about_dialog.
         from idlelib import help_about
-        help_about.AboutDialog(root, 'About IDLE')
+        help_about.AboutDialog(root)
 
     def config_dialog(event=None):
         "Handle Options 'Configure IDLE' event."


### PR DESCRIPTION
- Changed help_about to have a default title with the version included.  
- Changed editor and macosx to not send a title to help_about.
- Changed unittests to check both when a title is an argument and when it's not.

Note: Did not change title on htest.