### PR TITLE
bpo-30726: expat: Fix compiler warnings on Windows 64-bit

### DIFF
--- a/Modules/expat/siphash.h
+++ b/Modules/expat/siphash.h
@@ -198,7 +198,7 @@ static struct siphash *sip24_update(struct siphash *H, const void *src, size_t l
 
 
 static uint64_t sip24_final(struct siphash *H) {
-	char left = H->p - H->buf;
+	char left = (char)(H->p - H->buf);
 	uint64_t b = (H->c + left) << 56;
 
 	switch (left) {
@@ -313,7 +313,7 @@ static int sip24_valid(void) {
 	sip_tokey(&k, "\000\001\002\003\004\005\006\007\010\011\012\013\014\015\016\017");
 
 	for (i = 0; i < sizeof in; ++i) {
-		in[i] = i;
+		in[i] = (unsigned char)i;
 
 		if (siphash24(in, i, &k) != SIP_U8TO64_LE(vectors[i]))
 			return 0;


### PR DESCRIPTION
Explicitly cast on integer downcasting to fix compiler warnings.

(cherry picked from libexpat commit 788bff7a3baad1983b15b17c29e19e1a1a795c48)