### PR TITLE
[3.6] Fix a typo in a comment in coroutines.py (GH-2267)

### DIFF
--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -197,7 +197,7 @@ def coroutine(func):
     """
     if _inspect_iscoroutinefunction(func):
         # In Python 3.5 that's all we need to do for coroutines
-        # defiend with "async def".
+        # defined with "async def".
         # Wrapping in CoroWrapper will happen via
         # 'sys.set_coroutine_wrapper' function.
         return func


### PR DESCRIPTION
defiend -> defined
(cherry picked from commit cab469245d7635447c5e04fa6ed860b067dfc26b)