### PR TITLE
bpo-30647: Check nl_langinfo(CODESET) in locale coercion

### DIFF
--- a/Lib/test/test_c_locale_coercion.py
+++ b/Lib/test/test_c_locale_coercion.py
@@ -46,7 +46,8 @@ _C_UTF8_LOCALES = ("C.UTF-8", "C.utf8", "UTF-8")
 def _set_locale_in_subprocess(locale_name):
     cmd_fmt = "import locale; print(locale.setlocale(locale.LC_CTYPE, '{}'))"
     if hasattr(locale, "nl_langinfo") and hasattr(locale, "CODESET"):
-        cmd_fmt += "; print(locale.nl_langinfo(locale.CODESET))"
+        # If there's no valid CODESET, we expect coercion to be skipped
+        cmd_fmt += "; import sys; sys.exit(not locale.nl_langinfo(locale.CODESET))"
     cmd = cmd_fmt.format(locale_name)
     result, py_cmd = run_python_until_end("-c", cmd, __isolated=True)
     return result.rc == 0

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -478,11 +478,6 @@ _Py_CoerceLegacyLocale(void)
         const char *locale_override = getenv("LC_ALL");
         if (locale_override == NULL || *locale_override == '\0') {
             /* LC_ALL is also not set (or is set to an empty string) */
-#if !defined(__APPLE__) && defined(HAVE_LANGINFO_H) && defined(CODESET)
-            /* Save the initial locale on platforms where we may need it later */
-            const char *initial_locale =
-#endif
-            setlocale(LC_CTYPE, NULL);
             const _LocaleCoercionTarget *target = NULL;
             for (target = _TARGET_LOCALES; target->locale_name; target++) {
                 const char *new_locale = setlocale(LC_CTYPE,
@@ -494,7 +489,7 @@ _Py_CoerceLegacyLocale(void)
                     if (!codeset || *codeset == '\0') {
                         /* CODESET is not set or empty, so skip coercion */
                         new_locale = NULL;
-                        setlocale(LC_CTYPE, initial_locale);
+                        setlocale(LC_CTYPE, "");
                         continue;
                     }
 #endif

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -478,7 +478,11 @@ _Py_CoerceLegacyLocale(void)
         const char *locale_override = getenv("LC_ALL");
         if (locale_override == NULL || *locale_override == '\0') {
             /* LC_ALL is also not set (or is set to an empty string) */
-            const char *initial_locale = setlocale(LC_CTYPE, NULL);
+#if !defined(__APPLE__) && defined(HAVE_LANGINFO_H) && defined(CODESET)
+            /* Save the initial locale on platforms where we may need it later */
+            const char *initial_locale =
+#endif
+            setlocale(LC_CTYPE, NULL);
             const _LocaleCoercionTarget *target = NULL;
             for (target = _TARGET_LOCALES; target->locale_name; target++) {
                 const char *new_locale = setlocale(LC_CTYPE,

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -484,7 +484,7 @@ _Py_CoerceLegacyLocale(void)
                 const char *new_locale = setlocale(LC_CTYPE,
                                                    target->locale_name);
                 if (new_locale != NULL) {
-#if defined(HAVE_LANGINFO_H) && defined(CODESET)
+#if !defined(__APPLE__) && defined(HAVE_LANGINFO_H) && defined(CODESET)
                     /* Also ensure that nl_langinfo works in this locale */
                     char *codeset = nl_langinfo(CODESET);
                     if (!codeset || *codeset == '\0') {


### PR DESCRIPTION
- On some versions of FreeBSD, setting the "UTF-8" locale
  succeeds, but a subsequent "nl_langinfo(CODESET)" fails
- adding a check for this in the coercion logic means that
  coercion will happen on systems where this check succeeds,
  and will be skipped otherwise
- that way CPython should automatically adapt to changes in
  platform behaviour, rather than needing a new release to
  enable coercion at build time
- this also allows UTF-8 to be re-enabled as a coercion
  target, restoring the locale coercion behaviour on Mac OS X