### PR TITLE
[3.5] bpo-30745: Fix compiler warnings introduced in bpo-30730. (GH-2376)

### DIFF
--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -844,8 +844,7 @@ _winapi_CreateProcess_impl(PyObject *module, Py_UNICODE *application_name,
     PROCESS_INFORMATION pi;
     STARTUPINFOW si;
     PyObject* environment;
-    const wchar_t *wenvironment;
-    Py_ssize_t wenvironment_size;
+    wchar_t *wenvironment;
 
     ZeroMemory(&si, sizeof(si));
     si.cb = sizeof(si);


### PR DESCRIPTION
(cherry picked from commit 0ee32c1)