### PR TITLE
bpo-29097: Forego fold detection on windows for low timestamp values

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1572,6 +1572,17 @@ class datetime(date):
             # 23 hours at 1969-09-30 13:00:00 in Kwajalein.
             # Let's probe 24 hours in the past to detect a transition:
             max_fold_seconds = 24 * 3600
+
+            # On Windows localtime_s throws an OSError for negative values,
+            # thus we can't perform fold detection for values of time less
+            # than the max time fold. See comments in _datetimemodule's
+            # version of this method for more details.
+            try:
+                converter(-1)
+            except OSError:
+                if t < max_fold_seconds:
+                    return result
+
             y, m, d, hh, mm, ss = converter(t - max_fold_seconds)[:6]
             probe1 = cls(y, m, d, hh, mm, ss, us, tz)
             trans = result - probe1 - timedelta(0, max_fold_seconds)

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -6,6 +6,7 @@ time zone and DST data sources.
 
 import time as _time
 import math as _math
+import sys
 
 def _cmp(x, y):
     return 0 if x == y else 1 if x > y else -1
@@ -1577,11 +1578,8 @@ class datetime(date):
             # thus we can't perform fold detection for values of time less
             # than the max time fold. See comments in _datetimemodule's
             # version of this method for more details.
-            try:
-                converter(-1)
-            except OSError:
-                if t < max_fold_seconds:
-                    return result
+            if sys.platform.startswith("win") and t < max_fold_seconds:
+                return result
 
             y, m, d, hh, mm, ss = converter(t - max_fold_seconds)[:6]
             probe1 = cls(y, m, d, hh, mm, ss, us, tz)

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -1578,7 +1578,7 @@ class datetime(date):
             # thus we can't perform fold detection for values of time less
             # than the max time fold. See comments in _datetimemodule's
             # version of this method for more details.
-            if sys.platform.startswith("win") and t < max_fold_seconds:
+            if t < max_fold_seconds and sys.platform.startswith("win"):
                 return result
 
             y, m, d, hh, mm, ss = converter(t - max_fold_seconds)[:6]

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -70,7 +70,7 @@ class TestModule(unittest.TestCase):
                     if not name.startswith('__') and not name.endswith('__'))
         allowed = set(['MAXYEAR', 'MINYEAR', 'date', 'datetime',
                        'datetime_CAPI', 'time', 'timedelta', 'timezone',
-                       'tzinfo'])
+                       'tzinfo', 'sys'])
         self.assertEqual(names - allowed, set([]))
 
     def test_divide_and_round(self):

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -4944,6 +4944,13 @@ class TestLocalTimeDisambiguation(unittest.TestCase):
         self.assertEqual(t0.fold, 0)
         self.assertEqual(t1.fold, 1)
 
+
+    def test_fromtimestamp_low_fold_detection(self):
+        # Ensure that fold detection doesn't cause an
+        # OSError for really low values, see bpo-29097
+        self.assertEqual(datetime.fromtimestamp(0).fold, 0)
+
+
     @support.run_with_tz('EST+05EDT,M3.2.0,M11.1.0')
     def test_timestamp(self):
         dt0 = datetime(2014, 11, 2, 1, 30)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -4944,12 +4944,10 @@ class TestLocalTimeDisambiguation(unittest.TestCase):
         self.assertEqual(t0.fold, 0)
         self.assertEqual(t1.fold, 1)
 
-
     def test_fromtimestamp_low_fold_detection(self):
         # Ensure that fold detection doesn't cause an
         # OSError for really low values, see bpo-29097
         self.assertEqual(datetime.fromtimestamp(0).fold, 0)
-
 
     @support.run_with_tz('EST+05EDT,M3.2.0,M11.1.0')
     def test_timestamp(self):

--- a/Misc/NEWS.d/next/Windows/2018-05-16-11-31-17.bpo-29097.9mqEuI.rst
+++ b/Misc/NEWS.d/next/Windows/2018-05-16-11-31-17.bpo-29097.9mqEuI.rst
@@ -1,2 +1,3 @@
-Fix bug where ``datetime.fromtimestamp`` erronously throws an OSError on
-Windows for values between 0 and 86400
+Fix bug where :meth:`datetime.fromtimestamp` erronously throws an
+:exc:`OSError` on Windows for values between 0 and 86400.
+Patch by Ammar Askar.

--- a/Misc/NEWS.d/next/Windows/2018-05-16-11-31-17.bpo-29097.9mqEuI.rst
+++ b/Misc/NEWS.d/next/Windows/2018-05-16-11-31-17.bpo-29097.9mqEuI.rst
@@ -1,0 +1,2 @@
+Fix bug where ``datetime.fromtimestamp`` erronously throws an OSError on
+Windows for values between 0 and 86400

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4640,7 +4640,7 @@ datetime_from_timet_and_us(PyObject *cls, TM_FUNC f, time_t timet, int us,
 #ifdef MS_WINDOWS
         && (timet - max_fold_seconds > 0)
 #endif
-    	) {
+        ) {
         long long probe_seconds, result_seconds, transition;
 
         result_seconds = utc_to_seconds(year, month, day,

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4627,15 +4627,16 @@ datetime_from_timet_and_us(PyObject *cls, TM_FUNC f, time_t timet, int us,
     /* local timezone requires to compute fold */
     if (tzinfo == Py_None && f == _PyTime_localtime
     /* On Windows, passing a negative value to local results
-    * in an OSError because localtime_s on Windows does
-    * not support negative timestamps. Unfortunately this
-    * means that fold detection for time values between
-    * 0 and max_fold_seconds will result in an identical
-    * error since we subtract max_fold_seconds to detect a
-    * fold. However, since we know there haven't been any
-    * folds in the interval [0, max_fold_seconds) in any
-    * timezone, we can hackily just forego fold detection
-    * for this time range on Windows. */
+     * in an OSError because localtime_s on Windows does
+     * not support negative timestamps. Unfortunately this
+     * means that fold detection for time values between
+     * 0 and max_fold_seconds will result in an identical
+     * error since we subtract max_fold_seconds to detect a
+     * fold. However, since we know there haven't been any
+     * folds in the interval [0, max_fold_seconds) in any
+     * timezone, we can hackily just forego fold detection
+     * for this time range.
+     */
 #ifdef MS_WINDOWS
         && (timet - max_fold_seconds > 0)
 #endif

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4625,7 +4625,21 @@ datetime_from_timet_and_us(PyObject *cls, TM_FUNC f, time_t timet, int us,
     second = Py_MIN(59, tm.tm_sec);
 
     /* local timezone requires to compute fold */
-    if (tzinfo == Py_None && f == _PyTime_localtime) {
+    if (tzinfo == Py_None && f == _PyTime_localtime
+    /* On Windows, passing a negative value to local results
+    * in an OSError because localtime_s on Windows does
+    * not support negative timestamps. Unfortunately this
+    * means that fold detection for time values between
+    * 0 and max_fold_seconds will result in an identical
+    * error since we subtract max_fold_seconds to detect a
+    * fold. However, since we know there haven't been any
+    * folds in the interval [0, max_fold_seconds) in any
+    * timezone, we can hackily just forego fold detection
+    * for this time range on Windows. */
+#ifdef MS_WINDOWS
+        && (timet - max_fold_seconds > 0)
+#endif
+    	) {
         long long probe_seconds, result_seconds, transition;
 
         result_seconds = utc_to_seconds(year, month, day,


### PR DESCRIPTION
See the bug tracker for more details on why I think this is a clean way to resolve this issue https://bugs.python.org/issue29097

<!-- issue-number: bpo-29097 -->
https://bugs.python.org/issue29097
<!-- /issue-number -->
