### PR TITLE
bpo-31943: Add asyncio.Handle.cancelled() method

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -867,6 +867,12 @@ Handle
       Cancel the call.  If the callback is already canceled or executed,
       this method has no effect.
 
+   .. method:: cancelled()
+
+      Return ``True`` if the call was cancelled.
+
+      .. versionadded:: 3.7
+
 
 Event loop examples
 -------------------

--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -117,6 +117,9 @@ class Handle:
             self._callback = None
             self._args = None
 
+    def cancelled(self):
+        return self._cancelled
+
     def _run(self):
         try:
             self._callback(*self._args)

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2305,10 +2305,10 @@ class HandleTests(test_utils.TestCase):
         h = asyncio.Handle(callback, args, self.loop)
         self.assertIs(h._callback, callback)
         self.assertIs(h._args, args)
-        self.assertFalse(h._cancelled)
+        self.assertFalse(h.cancelled())
 
         h.cancel()
-        self.assertTrue(h._cancelled)
+        self.assertTrue(h.cancelled())
 
     def test_callback_with_exception(self):
         def callback():
@@ -2494,11 +2494,11 @@ class TimerTests(unittest.TestCase):
         h = asyncio.TimerHandle(when, callback, args, mock.Mock())
         self.assertIs(h._callback, callback)
         self.assertIs(h._args, args)
-        self.assertFalse(h._cancelled)
+        self.assertFalse(h.cancelled())
 
         # cancel
         h.cancel()
-        self.assertTrue(h._cancelled)
+        self.assertTrue(h.cancelled())
         self.assertIsNone(h._callback)
         self.assertIsNone(h._args)
 

--- a/Misc/NEWS.d/next/Library/2017-11-04-19-28-08.bpo-31943.bxw5gM.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-04-19-28-08.bpo-31943.bxw5gM.rst
@@ -1,0 +1,1 @@
+Add a ``cancelled()`` method to :class:`asyncio.Handle`.  Patch by Marat Sharafutdinov.


### PR DESCRIPTION
It would be handy to access the loop's time the Handle's callback will be called at if you are using delayed calls with "delay" (not "when") argument.
Also it is useful to know whether the call was cancelled through the special attribute.

<!-- issue-number: bpo-31943 -->
https://bugs.python.org/issue31943
<!-- /issue-number -->
