### PR TITLE
bpo-27523: Silence Socket Depreciation Warnings.

### DIFF
--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -13,6 +13,8 @@
 # endif
 
 #else /* MS_WINDOWS */
+/* disable annoying winsock warnings. */
+# define _WINSOCK_DEPRECATED_NO_WARNINGS
 # include <winsock2.h>
 /* Windows 'supports' CMSG_LEN, but does not follow the POSIX standard
  * interface at all, so there is no point including the code that


### PR DESCRIPTION
This should silence all deprecation warnings in the socket module.

I am not sure if this is a trivial change as it only adds to lines to ``socketmodule.h`` to silence the warnings before the include of ``winsock2.h``.

Happy merging, and cherry picking into master.