### PR TITLE
[3.5] bpo-30746: Prohibited the '=' character in environment variable names (GH-2382)

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2205,133 +2205,7 @@ class PidTests(unittest.TestCase):
         self.assertEqual(status, (pid, 0))
 
 
-<<<<<<< HEAD
-=======
 class SpawnTests(unittest.TestCase):
-    def create_args(self, *, with_env=False, use_bytes=False):
-        self.exitcode = 17
-
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
-
-        if not with_env:
-            code = 'import sys; sys.exit(%s)' % self.exitcode
-        else:
-            self.env = dict(os.environ)
-            # create an unique key
-            self.key = str(uuid.uuid4())
-            self.env[self.key] = self.key
-            # read the variable from os.environ to check that it exists
-            code = ('import sys, os; magic = os.environ[%r]; sys.exit(%s)'
-                    % (self.key, self.exitcode))
-
-        with open(filename, "w") as fp:
-            fp.write(code)
-
-        args = [sys.executable, filename]
-        if use_bytes:
-            args = [os.fsencode(a) for a in args]
-            self.env = {os.fsencode(k): os.fsencode(v)
-                        for k, v in self.env.items()}
-
-        return args
-
-    @requires_os_func('spawnl')
-    def test_spawnl(self):
-        args = self.create_args()
-        exitcode = os.spawnl(os.P_WAIT, args[0], *args)
-        self.assertEqual(exitcode, self.exitcode)
-
-    @requires_os_func('spawnle')
-    def test_spawnle(self):
-        args = self.create_args(with_env=True)
-        exitcode = os.spawnle(os.P_WAIT, args[0], *args, self.env)
-        self.assertEqual(exitcode, self.exitcode)
-
-    @requires_os_func('spawnlp')
-    def test_spawnlp(self):
-        args = self.create_args()
-        exitcode = os.spawnlp(os.P_WAIT, args[0], *args)
-        self.assertEqual(exitcode, self.exitcode)
-
-    @requires_os_func('spawnlpe')
-    def test_spawnlpe(self):
-        args = self.create_args(with_env=True)
-        exitcode = os.spawnlpe(os.P_WAIT, args[0], *args, self.env)
-        self.assertEqual(exitcode, self.exitcode)
-
-    @requires_os_func('spawnv')
-    def test_spawnv(self):
-        args = self.create_args()
-        exitcode = os.spawnv(os.P_WAIT, args[0], args)
-        self.assertEqual(exitcode, self.exitcode)
-
-    @requires_os_func('spawnve')
-    def test_spawnve(self):
-        args = self.create_args(with_env=True)
-        exitcode = os.spawnve(os.P_WAIT, args[0], args, self.env)
-        self.assertEqual(exitcode, self.exitcode)
-
-    @requires_os_func('spawnvp')
-    def test_spawnvp(self):
-        args = self.create_args()
-        exitcode = os.spawnvp(os.P_WAIT, args[0], args)
-        self.assertEqual(exitcode, self.exitcode)
-
-    @requires_os_func('spawnvpe')
-    def test_spawnvpe(self):
-        args = self.create_args(with_env=True)
-        exitcode = os.spawnvpe(os.P_WAIT, args[0], args, self.env)
-        self.assertEqual(exitcode, self.exitcode)
-
-    @requires_os_func('spawnv')
-    def test_nowait(self):
-        args = self.create_args()
-        pid = os.spawnv(os.P_NOWAIT, args[0], args)
-        result = os.waitpid(pid, 0)
-        self.assertEqual(result[0], pid)
-        status = result[1]
-        if hasattr(os, 'WIFEXITED'):
-            self.assertTrue(os.WIFEXITED(status))
-            self.assertEqual(os.WEXITSTATUS(status), self.exitcode)
-        else:
-            self.assertEqual(status, self.exitcode << 8)
-
-    @requires_os_func('spawnve')
-    def test_spawnve_bytes(self):
-        # Test bytes handling in parse_arglist and parse_envlist (#28114)
-        args = self.create_args(with_env=True, use_bytes=True)
-        exitcode = os.spawnve(os.P_WAIT, args[0], args, self.env)
-        self.assertEqual(exitcode, self.exitcode)
-
-    @requires_os_func('spawnl')
-    def test_spawnl_noargs(self):
-        args = self.create_args()
-        self.assertRaises(ValueError, os.spawnl, os.P_NOWAIT, args[0])
-        self.assertRaises(ValueError, os.spawnl, os.P_NOWAIT, args[0], '')
-
-    @requires_os_func('spawnle')
-    def test_spawnle_noargs(self):
-        args = self.create_args()
-        self.assertRaises(ValueError, os.spawnle, os.P_NOWAIT, args[0], {})
-        self.assertRaises(ValueError, os.spawnle, os.P_NOWAIT, args[0], '', {})
-
-    @requires_os_func('spawnv')
-    def test_spawnv_noargs(self):
-        args = self.create_args()
-        self.assertRaises(ValueError, os.spawnv, os.P_NOWAIT, args[0], ())
-        self.assertRaises(ValueError, os.spawnv, os.P_NOWAIT, args[0], [])
-        self.assertRaises(ValueError, os.spawnv, os.P_NOWAIT, args[0], ('',))
-        self.assertRaises(ValueError, os.spawnv, os.P_NOWAIT, args[0], [''])
-
-    @requires_os_func('spawnve')
-    def test_spawnve_noargs(self):
-        args = self.create_args()
-        self.assertRaises(ValueError, os.spawnve, os.P_NOWAIT, args[0], (), {})
-        self.assertRaises(ValueError, os.spawnve, os.P_NOWAIT, args[0], [], {})
-        self.assertRaises(ValueError, os.spawnve, os.P_NOWAIT, args[0], ('',), {})
-        self.assertRaises(ValueError, os.spawnve, os.P_NOWAIT, args[0], [''], {})
-
     def _test_invalid_env(self, spawn):
         args = [sys.executable, '-c', 'pass']
 
@@ -2378,16 +2252,15 @@ class SpawnTests(unittest.TestCase):
         exitcode = spawn(os.P_WAIT, args[0], args, newenv)
         self.assertEqual(exitcode, 0)
 
-    @requires_os_func('spawnve')
+    @unittest.skipUnless(hasattr(os, 'spawnve'), "test needs os.spawnve")
     def test_spawnve_invalid_env(self):
         self._test_invalid_env(os.spawnve)
 
-    @requires_os_func('spawnvpe')
+    @unittest.skipUnless(hasattr(os, 'spawnvpe'), "test needs os.spawnvpe")
     def test_spawnvpe_invalid_env(self):
         self._test_invalid_env(os.spawnvpe)
 
 
->>>>>>> 77703942c5... bpo-30746: Prohibited the '=' character in environment variable names (#2382)
 # The introduction of this TestCase caused at least two different errors on
 # *nix buildbots. Temporarily skip this to let the buildbots move along.
 @unittest.skip("Skip due to platform/environment differences on *NIX buildbots")

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2184,6 +2184,183 @@ class PidTests(unittest.TestCase):
         self.assertEqual(status, (pid, 0))
 
 
+<<<<<<< HEAD
+=======
+class SpawnTests(unittest.TestCase):
+    def create_args(self, *, with_env=False, use_bytes=False):
+        self.exitcode = 17
+
+        filename = support.TESTFN
+        self.addCleanup(support.unlink, filename)
+
+        if not with_env:
+            code = 'import sys; sys.exit(%s)' % self.exitcode
+        else:
+            self.env = dict(os.environ)
+            # create an unique key
+            self.key = str(uuid.uuid4())
+            self.env[self.key] = self.key
+            # read the variable from os.environ to check that it exists
+            code = ('import sys, os; magic = os.environ[%r]; sys.exit(%s)'
+                    % (self.key, self.exitcode))
+
+        with open(filename, "w") as fp:
+            fp.write(code)
+
+        args = [sys.executable, filename]
+        if use_bytes:
+            args = [os.fsencode(a) for a in args]
+            self.env = {os.fsencode(k): os.fsencode(v)
+                        for k, v in self.env.items()}
+
+        return args
+
+    @requires_os_func('spawnl')
+    def test_spawnl(self):
+        args = self.create_args()
+        exitcode = os.spawnl(os.P_WAIT, args[0], *args)
+        self.assertEqual(exitcode, self.exitcode)
+
+    @requires_os_func('spawnle')
+    def test_spawnle(self):
+        args = self.create_args(with_env=True)
+        exitcode = os.spawnle(os.P_WAIT, args[0], *args, self.env)
+        self.assertEqual(exitcode, self.exitcode)
+
+    @requires_os_func('spawnlp')
+    def test_spawnlp(self):
+        args = self.create_args()
+        exitcode = os.spawnlp(os.P_WAIT, args[0], *args)
+        self.assertEqual(exitcode, self.exitcode)
+
+    @requires_os_func('spawnlpe')
+    def test_spawnlpe(self):
+        args = self.create_args(with_env=True)
+        exitcode = os.spawnlpe(os.P_WAIT, args[0], *args, self.env)
+        self.assertEqual(exitcode, self.exitcode)
+
+    @requires_os_func('spawnv')
+    def test_spawnv(self):
+        args = self.create_args()
+        exitcode = os.spawnv(os.P_WAIT, args[0], args)
+        self.assertEqual(exitcode, self.exitcode)
+
+    @requires_os_func('spawnve')
+    def test_spawnve(self):
+        args = self.create_args(with_env=True)
+        exitcode = os.spawnve(os.P_WAIT, args[0], args, self.env)
+        self.assertEqual(exitcode, self.exitcode)
+
+    @requires_os_func('spawnvp')
+    def test_spawnvp(self):
+        args = self.create_args()
+        exitcode = os.spawnvp(os.P_WAIT, args[0], args)
+        self.assertEqual(exitcode, self.exitcode)
+
+    @requires_os_func('spawnvpe')
+    def test_spawnvpe(self):
+        args = self.create_args(with_env=True)
+        exitcode = os.spawnvpe(os.P_WAIT, args[0], args, self.env)
+        self.assertEqual(exitcode, self.exitcode)
+
+    @requires_os_func('spawnv')
+    def test_nowait(self):
+        args = self.create_args()
+        pid = os.spawnv(os.P_NOWAIT, args[0], args)
+        result = os.waitpid(pid, 0)
+        self.assertEqual(result[0], pid)
+        status = result[1]
+        if hasattr(os, 'WIFEXITED'):
+            self.assertTrue(os.WIFEXITED(status))
+            self.assertEqual(os.WEXITSTATUS(status), self.exitcode)
+        else:
+            self.assertEqual(status, self.exitcode << 8)
+
+    @requires_os_func('spawnve')
+    def test_spawnve_bytes(self):
+        # Test bytes handling in parse_arglist and parse_envlist (#28114)
+        args = self.create_args(with_env=True, use_bytes=True)
+        exitcode = os.spawnve(os.P_WAIT, args[0], args, self.env)
+        self.assertEqual(exitcode, self.exitcode)
+
+    @requires_os_func('spawnl')
+    def test_spawnl_noargs(self):
+        args = self.create_args()
+        self.assertRaises(ValueError, os.spawnl, os.P_NOWAIT, args[0])
+        self.assertRaises(ValueError, os.spawnl, os.P_NOWAIT, args[0], '')
+
+    @requires_os_func('spawnle')
+    def test_spawnle_noargs(self):
+        args = self.create_args()
+        self.assertRaises(ValueError, os.spawnle, os.P_NOWAIT, args[0], {})
+        self.assertRaises(ValueError, os.spawnle, os.P_NOWAIT, args[0], '', {})
+
+    @requires_os_func('spawnv')
+    def test_spawnv_noargs(self):
+        args = self.create_args()
+        self.assertRaises(ValueError, os.spawnv, os.P_NOWAIT, args[0], ())
+        self.assertRaises(ValueError, os.spawnv, os.P_NOWAIT, args[0], [])
+        self.assertRaises(ValueError, os.spawnv, os.P_NOWAIT, args[0], ('',))
+        self.assertRaises(ValueError, os.spawnv, os.P_NOWAIT, args[0], [''])
+
+    @requires_os_func('spawnve')
+    def test_spawnve_noargs(self):
+        args = self.create_args()
+        self.assertRaises(ValueError, os.spawnve, os.P_NOWAIT, args[0], (), {})
+        self.assertRaises(ValueError, os.spawnve, os.P_NOWAIT, args[0], [], {})
+        self.assertRaises(ValueError, os.spawnve, os.P_NOWAIT, args[0], ('',), {})
+        self.assertRaises(ValueError, os.spawnve, os.P_NOWAIT, args[0], [''], {})
+
+    @requires_os_func('spawnve')
+    def test_spawnve_invalid_env(self):
+        # null character in the enviroment variable name
+        args = [sys.executable, '-c', 'pass']
+        newenv = os.environ.copy()
+        newenv["FRUIT\0VEGETABLE"] = "cabbage"
+        try:
+            exitcode = os.spawnve(os.P_WAIT, args[0], args, newenv)
+        except ValueError:
+            pass
+        else:
+            self.assertEqual(exitcode, 127)
+
+        # null character in the enviroment variable value
+        args = [sys.executable, '-c', 'pass']
+        newenv = os.environ.copy()
+        newenv["FRUIT"] = "orange\0VEGETABLE=cabbage"
+        try:
+            exitcode = os.spawnve(os.P_WAIT, args[0], args, newenv)
+        except ValueError:
+            pass
+        else:
+            self.assertEqual(exitcode, 127)
+
+        # equal character in the enviroment variable name
+        args = [sys.executable, '-c', 'pass']
+        newenv = os.environ.copy()
+        newenv["FRUIT=ORANGE"] = "lemon"
+        try:
+            exitcode = os.spawnve(os.P_WAIT, args[0], args, newenv)
+        except ValueError:
+            pass
+        else:
+            self.assertEqual(exitcode, 127)
+
+        # equal character in the enviroment variable value
+        filename = support.TESTFN
+        self.addCleanup(support.unlink, filename)
+        with open(filename, "w") as fp:
+            fp.write('import sys, os\n'
+                     'if os.getenv("FRUIT") != "orange=lemon":\n'
+                     '    raise AssertionError')
+        args = [sys.executable, filename]
+        newenv = os.environ.copy()
+        newenv["FRUIT"] = "orange=lemon"
+        exitcode = os.spawnve(os.P_WAIT, args[0], args, newenv)
+        self.assertEqual(exitcode, 0)
+
+
+>>>>>>> 77703942c5... bpo-30746: Prohibited the '=' character in environment variable names (#2382)
 # The introduction of this TestCase caused at least two different errors on
 # *nix buildbots. Temporarily skip this to let the buildbots move along.
 @unittest.skip("Skip due to platform/environment differences on *NIX buildbots")

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -747,6 +747,21 @@ class PosixTester(unittest.TestCase):
             self.assertEqual(type(k), item_type)
             self.assertEqual(type(v), item_type)
 
+    @unittest.skipUnless(hasattr(os, "putenv"), "requires os.putenv()")
+    def test_putenv(self):
+        with self.assertRaises(ValueError):
+            os.putenv('FRUIT\0VEGETABLE', 'cabbage')
+        with self.assertRaises(ValueError):
+            os.putenv(b'FRUIT\0VEGETABLE', b'cabbage')
+        with self.assertRaises(ValueError):
+            os.putenv('FRUIT', 'orange\0VEGETABLE=cabbage')
+        with self.assertRaises(ValueError):
+            os.putenv(b'FRUIT', b'orange\0VEGETABLE=cabbage')
+        with self.assertRaises(ValueError):
+            os.putenv('FRUIT=ORANGE', 'lemon')
+        with self.assertRaises(ValueError):
+            os.putenv(b'FRUIT=ORANGE', b'lemon')
+
     @unittest.skipUnless(hasattr(posix, 'getcwd'), 'test needs posix.getcwd()')
     def test_getcwd_long_pathnames(self):
         dirname = 'getcwd-test-directory-0123456789abcdef-01234567890abcdef'

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -59,6 +59,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30746: Prohibited the '=' character in environment variable names in
+  ``os.putenv()`` and ``os.spawn*()``.
+
 - [Security] bpo-30730: Prevent environment variables injection in subprocess on
   Windows.  Prevent passing other environment variables and command arguments.
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4963,48 +4963,26 @@ parse_envlist(PyObject* env, Py_ssize_t *envc_ptr)
             Py_DECREF(key2);
             goto error;
         }
-<<<<<<< HEAD
 
-        k = PyBytes_AsString(key2);
-        v = PyBytes_AsString(val2);
+        k = PyBytes_AS_STRING(key2);
+        v = PyBytes_AS_STRING(val2);
+        /* Search from index 1 because on Windows starting '=' is allowed for
+           defining hidden environment variables. */
+        if (*k == '\0' || strchr(k + 1, '=') != NULL) {
+            PyErr_SetString(PyExc_ValueError, "illegal environment variable name");
+            goto error;
+        }
         len = PyBytes_GET_SIZE(key2) + PyBytes_GET_SIZE(val2) + 2;
 
         p = PyMem_NEW(char, len);
         if (p == NULL) {
             PyErr_NoMemory();
-=======
-        /* Search from index 1 because on Windows starting '=' is allowed for
-           defining hidden environment variables. */
-        if (PyUnicode_GET_LENGTH(key2) == 0 ||
-            PyUnicode_FindChar(key2, '=', 1, PyUnicode_GET_LENGTH(key2), 1) != -1)
-        {
-            PyErr_SetString(PyExc_ValueError, "illegal environment variable name");
-            goto error;
-        }
-        keyval = PyUnicode_FromFormat("%U=%U", key2, val2);
-#else
-        if (!PyUnicode_FSConverter(key, &key2))
-            goto error;
-        if (!PyUnicode_FSConverter(val, &val2)) {
->>>>>>> 77703942c5... bpo-30746: Prohibited the '=' character in environment variable names (#2382)
             Py_DECREF(key2);
             Py_DECREF(val2);
             goto error;
         }
-<<<<<<< HEAD
         PyOS_snprintf(p, len, "%s=%s", k, v);
         envlist[envc++] = p;
-=======
-        if (PyBytes_GET_SIZE(key2) == 0 ||
-            strchr(PyBytes_AS_STRING(key2) + 1, '=') != NULL)
-        {
-            PyErr_SetString(PyExc_ValueError, "illegal environment variable name");
-            goto error;
-        }
-        keyval = PyBytes_FromFormat("%s=%s", PyBytes_AS_STRING(key2),
-                                             PyBytes_AS_STRING(val2));
-#endif
->>>>>>> 77703942c5... bpo-30746: Prohibited the '=' character in environment variable names (#2382)
         Py_DECREF(key2);
         Py_DECREF(val2);
     }
@@ -9148,13 +9126,8 @@ os_putenv_impl(PyObject *module, PyObject *name, PyObject *value)
 {
     PyObject *bytes = NULL;
     char *env;
-<<<<<<< HEAD
-    char *name_string = PyBytes_AsString(name);
-    char *value_string = PyBytes_AsString(value);
-=======
     const char *name_string = PyBytes_AS_STRING(name);
     const char *value_string = PyBytes_AS_STRING(value);
->>>>>>> 77703942c5... bpo-30746: Prohibited the '=' character in environment variable names (#2382)
 
     if (strchr(name_string, '=') != NULL) {
         PyErr_SetString(PyExc_ValueError, "illegal environment variable name");


### PR DESCRIPTION
in `os.putenv()` and `os.spawn*()`..
(cherry picked from commit 77703942c5997dff00c48f10df1b29b11645624c)