### PR TITLE
bpo-31328: Add missing _sha3 module to Setup.dist

### DIFF
--- a/Modules/Setup.dist
+++ b/Modules/Setup.dist
@@ -253,6 +253,7 @@ _symtable symtablemodule.c
 #_sha1 sha1module.c
 #_sha256 sha256module.c
 #_sha512 sha512module.c
+#_sha3 _sha3/sha3module.c
 
 # _blake module
 #_blake2 _blake2/blake2module.c _blake2/blake2b_impl.c _blake2/blake2s_impl.c


### PR DESCRIPTION


<!-- issue-number: bpo-31328 -->
https://bugs.python.org/issue31328
<!-- /issue-number -->
