### PR TITLE
bpo-30523: regrtest --list-cases now supports --match

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -256,9 +256,13 @@ class Regrtest:
             if isinstance(test, unittest.TestSuite):
                 self._list_cases(test)
             elif isinstance(test, unittest.TestCase):
-                print(test.id())
+                if support._match_test(test):
+                    print(test.id())
 
     def list_cases(self):
+        support.verbose = False
+        support.match_tests = self.ns.match_tests
+
         for test in self.selected:
             abstest = get_abs_module(self.ns, test)
             try:

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1905,6 +1905,23 @@ def _run_suite(suite):
         raise TestFailed(err)
 
 
+def _match_test(test):
+    global match_tests
+
+    if match_tests is None:
+        return True
+    test_id = test.id()
+
+    for match_test in match_tests:
+        if fnmatch.fnmatchcase(test_id, match_test):
+            return True
+
+        for name in test_id.split("."):
+            if fnmatch.fnmatchcase(name, match_test):
+                return True
+    return False
+
+
 def run_unittest(*classes):
     """Run tests from unittest.TestCase-derived classes."""
     valid_types = (unittest.TestSuite, unittest.TestCase)
@@ -1919,20 +1936,7 @@ def run_unittest(*classes):
             suite.addTest(cls)
         else:
             suite.addTest(unittest.makeSuite(cls))
-    def case_pred(test):
-        if match_tests is None:
-            return True
-        test_id = test.id()
-
-        for match_test in match_tests:
-            if fnmatch.fnmatchcase(test_id, match_test):
-                return True
-
-            for name in test_id.split("."):
-                if fnmatch.fnmatchcase(name, match_test):
-                    return True
-        return False
-    _filter_suite(suite, case_pred)
+    _filter_suite(suite, _match_test)
     _run_suite(suite)
 
 #=======================================================================

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -837,9 +837,18 @@ class ArgsTestCase(BaseTestCase):
                     pass
         """)
         testname = self.create_test(code=code)
+
+        # Test --list-cases
         all_methods = ['%s.Tests.test_method1' % testname,
                        '%s.Tests.test_method2' % testname]
         output = self.run_tests('--list-cases', testname)
+        self.assertEqual(output.splitlines(), all_methods)
+
+        # Test --list-cases with --match
+        all_methods = ['%s.Tests.test_method1' % testname]
+        output = self.run_tests('--list-cases',
+                                '-m', 'test_method1',
+                                testname)
         self.assertEqual(output.splitlines(), all_methods)
 
     def test_crashed(self):


### PR DESCRIPTION
* regrtest --list-cases now supports --match and --match-file options.
  Example: ./python -m test --list-cases -m FileTests test_os
* Add support.match_test() function.