### PR TITLE
[WIP] bpo-30703: More reentrant signal handler

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -54,6 +54,7 @@ PyAPI_FUNC(int) PyEval_MergeCompilerFlags(PyCompilerFlags *cf);
 #endif
 
 PyAPI_FUNC(int) Py_AddPendingCall(int (*func)(void *), void *arg);
+PyAPI_FUNC(void) _PyEval_SignalReceived(void);
 PyAPI_FUNC(int) Py_MakePendingCalls(void);
 
 /* Protection against deeply nested recursive calls

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -248,7 +248,7 @@ trip_signal(int sig_num)
         /* Set is_tripped after setting .tripped, as it gets
            cleared in PyErr_CheckSignals() before .tripped. */
         is_tripped = 1;
-        Py_AddPendingCall(checksignals_witharg, NULL);
+        _PyEval_SignalReceived();
     }
 
     /* And then write to the wakeup fd *after* setting all the globals and


### PR DESCRIPTION
Modify the signal handler to not call Py_AddPendingCall() function
since this function uses a lock and a list, and so is unlikely to be
reentrant. Add a new _PyEval_SignalReceived() function which only
writes into an atomic variable and so is reentrant.