### PR TITLE
bpo-30441: Fix bug when modifying os.environ while iterating over it

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -697,8 +697,9 @@ class _Environ(MutableMapping):
             raise KeyError(key) from None
 
     def __iter__(self):
-        data = list(self._data)
-        for key in data:
+        # list() from dict object is an atomic operation
+        keys = list(self._data)
+        for key in keys:
             yield self.decodekey(key)
 
     def __len__(self):

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -697,7 +697,8 @@ class _Environ(MutableMapping):
             raise KeyError(key) from None
 
     def __iter__(self):
-        for key in self._data:
+        data = list(self._data)
+        for key in data:
             yield self.decodekey(key)
 
     def __len__(self):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -835,6 +835,21 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
         self.assertIs(cm.exception.args[0], missing)
         self.assertTrue(cm.exception.__suppress_context__)
 
+    def test_iter_error_when_os_environ_changes(self):
+        def _iter_environ_change():
+            for key, value in os.environ.items():
+                yield key, value
+
+        iter_environ = _iter_environ_change()
+        key, value = next(iter_environ)  # start iteration over os.environ
+
+        # add a new key in os.environ mapping
+        new_key = "__{}".format(key)
+        os.environ[new_key] = value
+
+        next(iter_environ)  # force iteration over modified mapping
+        self.assertEqual(os.environ[new_key], value)
+
 
 class WalkTests(unittest.TestCase):
     """Tests for os.walk()."""

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -835,7 +835,8 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
         self.assertIs(cm.exception.args[0], missing)
         self.assertTrue(cm.exception.__suppress_context__)
 
-    def _test_environ_iteration(self, iterator):
+    def _test_environ_iteration(self, collection):
+        iterator = iter(collection)
         new_key = "__new_key__"
 
         next(iterator)  # start iteration over os.environ.items
@@ -843,22 +844,20 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
         # add a new key in os.environ mapping
         os.environ[new_key] = "test_environ_iteration"
 
-        next(iterator)  # force iteration over modified mapping
-        self.assertEqual(os.environ[new_key], "test_environ_iteration")
-
-        del os.environ[new_key]
+        try:
+            next(iterator)  # force iteration over modified mapping
+            self.assertEqual(os.environ[new_key], "test_environ_iteration")
+        finally:
+            del os.environ[new_key]
 
     def test_iter_error_when_changing_os_environ(self):
-        iter_environ = iter(os.environ)
-        self._test_environ_iteration(iter_environ)
+        self._test_environ_iteration(os.environ)
 
     def test_iter_error_when_changing_os_environ_items(self):
-        iter_environ_items = iter(os.environ.items())
-        self._test_environ_iteration(iter_environ_items)
+        self._test_environ_iteration(os.environ.items())
 
     def test_iter_error_when_changing_os_environ_values(self):
-        iter_environ_values = iter(os.environ.values())
-        self._test_environ_iteration(iter_environ_values)
+        self._test_environ_iteration(os.environ.values())
 
 
 class WalkTests(unittest.TestCase):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -848,17 +848,17 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
 
         del os.environ[new_key]
 
-    def test_iter_error_when_changin_os_environ(self):
+    def test_iter_error_when_changing_os_environ(self):
         iter_environ = iter(os.environ)
         self._test_environ_iteration(iter_environ)
 
-    def test_iter_error_when_changin_os_environ_items(self):
-        iter_environ = iter(os.environ.items())
-        self._test_environ_iteration(iter_environ)
+    def test_iter_error_when_changing_os_environ_items(self):
+        iter_environ_items = iter(os.environ.items())
+        self._test_environ_iteration(iter_environ_items)
 
-    def test_iter_error_when_changin_os_environ_values(self):
-        iter_environ = iter(os.environ.values())
-        self._test_environ_iteration(iter_environ)
+    def test_iter_error_when_changing_os_environ_values(self):
+        iter_environ_values = iter(os.environ.values())
+        self._test_environ_iteration(iter_environ_values)
 
 
 class WalkTests(unittest.TestCase):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -835,20 +835,30 @@ class EnvironTests(mapping_tests.BasicTestMappingProtocol):
         self.assertIs(cm.exception.args[0], missing)
         self.assertTrue(cm.exception.__suppress_context__)
 
-    def test_iter_error_when_os_environ_changes(self):
-        def _iter_environ_change():
-            for key, value in os.environ.items():
-                yield key, value
+    def _test_environ_iteration(self, iterator):
+        new_key = "__new_key__"
 
-        iter_environ = _iter_environ_change()
-        key, value = next(iter_environ)  # start iteration over os.environ
+        next(iterator)  # start iteration over os.environ.items
 
         # add a new key in os.environ mapping
-        new_key = "__{}".format(key)
-        os.environ[new_key] = value
+        os.environ[new_key] = "test_environ_iteration"
 
-        next(iter_environ)  # force iteration over modified mapping
-        self.assertEqual(os.environ[new_key], value)
+        next(iterator)  # force iteration over modified mapping
+        self.assertEqual(os.environ[new_key], "test_environ_iteration")
+
+        del os.environ[new_key]
+
+    def test_iter_error_when_changin_os_environ(self):
+        iter_environ = iter(os.environ)
+        self._test_environ_iteration(iter_environ)
+
+    def test_iter_error_when_changin_os_environ_items(self):
+        iter_environ = iter(os.environ.items())
+        self._test_environ_iteration(iter_environ)
+
+    def test_iter_error_when_changin_os_environ_values(self):
+        iter_environ = iter(os.environ.values())
+        self._test_environ_iteration(iter_environ)
 
 
 class WalkTests(unittest.TestCase):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1087,6 +1087,7 @@ Fredrik Nehr
 Tony Nelson
 Trent Nelson
 Andrew Nester
+Osvaldo Santana Neto
 Chad Netzer
 Max Neunhöffer
 Anthon van der Neut
@@ -1760,4 +1761,3 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
-Osvaldo Santana Neto

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1760,3 +1760,4 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
+Osvaldo Santana Neto

--- a/Misc/NEWS.d/next/Library/2017-06-29-14-25-14.bpo-30441.3Wh9kc.rst
+++ b/Misc/NEWS.d/next/Library/2017-06-29-14-25-14.bpo-30441.3Wh9kc.rst
@@ -1,0 +1,1 @@
+Fix bug when modifying os.environ while iterating over it


### PR DESCRIPTION
Opening this pull request at Serhiy Storchaka's [request](http://bugs.python.org/issue30441#msg296847) to correct [Bug #30441](http://bugs.python.org/issue30441).

Question: Would not it be better to use tuple() instead of list() at `Lib/os.py:700`?