### PR TITLE
bpo-30801: Fix for shoutdown process error with python 3.4 and pyqt/PySide

### DIFF
--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -297,6 +297,7 @@ class BaseProcess(object):
             traceback.print_exc()
         finally:
             util.info('process exiting with exitcode %d' % exitcode)
+            #check if windows platform and Python 3.4
             if sys.platform.startswith('win') and sys.version_info[:2] == (3, 4):
                 # checks if app is running frozen
                 is_frozen = (hasattr(sys, "frozen") or # new py2exe

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -299,7 +299,7 @@ class BaseProcess(object):
             util.info('process exiting with exitcode %d' % exitcode)
             #check if windows platform and Python 3.4
             if sys.platform.startswith('win') and sys.version_info[:2] == (3, 4):
-                # checks if app is running frozen
+                # checks if forzen app
                 is_frozen = (hasattr(sys, "frozen") or # new py2exe
                              hasattr(sys, "importers") or # old py2exe
                              imp.is_frozen("__main__")) # tools/freeze

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -18,6 +18,7 @@ import sys
 import signal
 import itertools
 from _weakrefset import WeakSet
+import imp
 
 #
 #
@@ -296,9 +297,14 @@ class BaseProcess(object):
             traceback.print_exc()
         finally:
             util.info('process exiting with exitcode %d' % exitcode)
-            sys.stdout.flush()
-            sys.stderr.flush()
-
+            if sys.version_info[:2] != (3, 4):
+                # checks if app is running frozen
+                is_frozen = (hasattr(sys, "frozen") or # new py2exe
+                             hasattr(sys, "importers") or # old py2exe
+                             imp.is_frozen("__main__")) # tools/freeze
+                if not is_frozen:
+                    sys.stdout.flush()
+                    sys.stderr.flush()
         return exitcode
 
 #

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -297,7 +297,7 @@ class BaseProcess(object):
             traceback.print_exc()
         finally:
             util.info('process exiting with exitcode %d' % exitcode)
-            if sys.platform.startswith('win') and sys.version_info[:2] != (3, 4):
+            if sys.platform.startswith('win') and sys.version_info[:2] == (3, 4):
                 # checks if app is running frozen
                 is_frozen = (hasattr(sys, "frozen") or # new py2exe
                              hasattr(sys, "importers") or # old py2exe
@@ -305,6 +305,10 @@ class BaseProcess(object):
                 if not is_frozen:
                     sys.stdout.flush()
                     sys.stderr.flush()
+            else:
+                sys.stdout.flush()
+                sys.stderr.flush()
+
         return exitcode
 
 #

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -297,7 +297,7 @@ class BaseProcess(object):
             traceback.print_exc()
         finally:
             util.info('process exiting with exitcode %d' % exitcode)
-            if sys.version_info[:2] != (3, 4):
+            if sys.platform.startswith('win') and sys.version_info[:2] != (3, 4):
                 # checks if app is running frozen
                 is_frozen = (hasattr(sys, "frozen") or # new py2exe
                              hasattr(sys, "importers") or # old py2exe


### PR DESCRIPTION
This is a fix for an error that it is happend when shutdown manager process with a frozen app.
   https://github.com/pyinstaller/pyinstaller/issues/1937