### PR TITLE
bpo-30703: Improve signal delivery

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -54,6 +54,7 @@ PyAPI_FUNC(int) PyEval_MergeCompilerFlags(PyCompilerFlags *cf);
 #endif
 
 PyAPI_FUNC(int) Py_AddPendingCall(int (*func)(void *), void *arg);
+PyAPI_FUNC(void) _PyEval_SignalReceived(void);
 PyAPI_FUNC(int) Py_MakePendingCalls(void);
 
 /* Protection against deeply nested recursive calls

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -943,14 +943,17 @@ class PendingSignalsTests(unittest.TestCase):
 
 
 class StressTest(unittest.TestCase):
+    """
+    Stress signal delivery, especially when a signal arrives in
+    the middle of recomputing the signal state or executing
+    previously tripped signal handlers.
+    """
 
     @unittest.skipUnless(hasattr(signal, "setitimer"),
                          "test needs setitimer()")
-    def test_stress_delivery(self):
+    def test_stress_delivery_dependent(self):
         """
-        Stress signal delivery, especially when a signal arrives in
-        the middle of recomputing the signal state or executing
-        previously tripped signal handlers.
+        This test uses dependent signal handlers.
         """
         N = 10000
         sigs = []
@@ -989,6 +992,43 @@ class StressTest(unittest.TestCase):
 
             os.kill(os.getpid(), signal.SIGUSR1)
             expected_sigs += 1
+            while len(sigs) < expected_sigs and time.time() < deadline:
+                time.sleep(1e-5)
+
+        # All ITIMER_REAL signals should have been delivered to the
+        # Python handler
+        self.assertEqual(len(sigs), N, "Some signals were lost")
+
+    @unittest.skipUnless(hasattr(signal, "setitimer"),
+                         "test needs setitimer()")
+    def test_stress_delivery_simultaneous(self):
+        """
+        This test uses simultaneous signal handlers.
+        """
+        N = 10000
+        sigs = []
+
+        def handler(signum, frame):
+            sigs.append(signum)
+
+        def setsig(signum, handler):
+            old_handler = signal.signal(signum, handler)
+            self.addCleanup(signal.signal, signum, old_handler)
+
+        setsig(signal.SIGUSR1, handler)
+        setsig(signal.SIGALRM, handler)  # for ITIMER_REAL
+
+        expected_sigs = 0
+        deadline = time.time() + 15.0
+
+        while expected_sigs < N:
+            # Hopefully the SIGALRM will be received somewhere during
+            # initial processing of SIGUSR1.
+            signal.setitimer(signal.ITIMER_REAL, 1e-6 + random.random() * 1e-5)
+            os.kill(os.getpid(), signal.SIGUSR1)
+
+            expected_sigs += 2
+            # Wait for handlers to run to avoid signal coalescing
             while len(sigs) < expected_sigs and time.time() < deadline:
                 time.sleep(1e-5)
 

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -1,4 +1,5 @@
 import os
+import random
 import signal
 import socket
 import subprocess
@@ -939,6 +940,61 @@ class PendingSignalsTests(unittest.TestCase):
             if exitcode != 3:
                 raise Exception("Child error (exit code %s): %s" %
                                 (exitcode, stdout))
+
+
+class StressTest(unittest.TestCase):
+
+    @unittest.skipUnless(hasattr(signal, "setitimer"),
+                         "test needs setitimer()")
+    def test_stress_delivery(self):
+        """
+        Stress signal delivery, especially when a signal arrives in
+        the middle of recomputing the signal state or executing
+        previously tripped signal handlers.
+        """
+        N = 10000
+        sigs = []
+
+        def first_handler(signum, frame):
+            # 1e-6 is the minimum non-zero value for `setitimer()`.
+            # Choose a random delay so as to improve chances of
+            # triggering a race condition.  Ideally the signal is received
+            # when inside critical signal-handling routines such as
+            # Py_MakePendingCalls().
+            signal.setitimer(signal.ITIMER_REAL, 1e-6 + random.random() * 1e-5)
+
+        def second_handler(signum=None, frame=None):
+            sigs.append(signum)
+
+        def setsig(signum, handler):
+            old_handler = signal.signal(signum, handler)
+            self.addCleanup(signal.signal, signum, old_handler)
+
+        # Here on Linux, SIGPROF > SIGALRM > SIGUSR1.  By using both
+        # ascending and descending sequences (SIGUSR1 then SIGALRM,
+        # SIGPROF then SIGALRM), we maximize chances of hitting a bug.
+        setsig(signal.SIGPROF, first_handler)
+        setsig(signal.SIGUSR1, first_handler)
+        setsig(signal.SIGALRM, second_handler)  # for ITIMER_REAL
+
+        expected_sigs = 0
+        deadline = time.time() + 15.0
+
+        while expected_sigs < N:
+            os.kill(os.getpid(), signal.SIGPROF)
+            expected_sigs += 1
+            # Wait for handlers to run to avoid signal coalescing
+            while len(sigs) < expected_sigs and time.time() < deadline:
+                time.sleep(1e-5)
+
+            os.kill(os.getpid(), signal.SIGUSR1)
+            expected_sigs += 1
+            while len(sigs) < expected_sigs and time.time() < deadline:
+                time.sleep(1e-5)
+
+        # All ITIMER_REAL signals should have been delivered to the
+        # Python handler
+        self.assertEqual(len(sigs), N, "Some signals were lost")
 
 
 def tearDownModule():

--- a/Misc/NEWS.d/next/Core and Builtins/2017-06-28-21-07-32.bpo-30703.ULCdFp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-06-28-21-07-32.bpo-30703.ULCdFp.rst
@@ -1,0 +1,6 @@
+Improve signal delivery.
+
+Avoid using Py_AddPendingCall from signal handler, to avoid calling signal-
+unsafe functions. The tests I'm adding here fail without the rest of the
+patch, on Linux and OS X. This means our signal delivery logic had defects
+(some signals could be lost).

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -189,12 +189,6 @@ It raises KeyboardInterrupt.");
 
 
 static int
-checksignals_witharg(void * unused)
-{
-    return PyErr_CheckSignals();
-}
-
-static int
 report_wakeup_write_error(void *data)
 {
     int save_errno = errno;

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -244,9 +244,9 @@ trip_signal(int sig_num)
     _PyEval_SignalReceived();
 
     /* And then write to the wakeup fd *after* setting all the globals and
-       doing the Py_AddPendingCall. We used to write to the wakeup fd and then
-       set the flag, but this allowed the following sequence of events
-       (especially on windows, where trip_signal runs in a new thread):
+       doing the _PyEval_SignalReceived. We used to write to the wakeup fd
+       and then set the flag, but this allowed the following sequence of events
+       (especially on windows, where trip_signal may run in a new thread):
 
        - main thread blocks on select([wakeup_fd], ...)
        - signal arrives
@@ -281,6 +281,8 @@ trip_signal(int sig_num)
                 wakeup.send_err_set = 1;
                 wakeup.send_errno = errno;
                 wakeup.send_win_error = GetLastError();
+                /* Py_AddPendingCall() isn't signal-safe, but we
+                   still use it for this exceptional case. */
                 Py_AddPendingCall(report_wakeup_send_error, NULL);
             }
         }
@@ -294,6 +296,8 @@ trip_signal(int sig_num)
             rc = _Py_write_noraise(fd, &byte, 1);
 
             if (rc < 0) {
+                /* Py_AddPendingCall() isn't signal-safe, but we
+                   still use it for this exceptional case. */
                 Py_AddPendingCall(report_wakeup_write_error,
                                   (void *)(intptr_t)errno);
             }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -392,7 +392,7 @@ _PyEval_SignalReceived(void)
 {
     /* bpo-30703: Function called when the C signal handler of Python gets a
        signal. We cannot queue a callback using Py_AddPendingCall() since this
-       function is not reentrant (use a lock and a list). */
+       function is not reentrant (uses a lock and a list). */
     SIGNAL_PENDING_CALLS();
 }
 
@@ -419,7 +419,7 @@ Py_MakePendingCalls(void)
     busy = 1;
 
     /* Python signal handler doesn't really queue a callback: it only signals
-       that an UNIX signal was received, see _PyEval_SignalReceived(). */
+       that a signal was received, see _PyEval_SignalReceived(). */
     UNSIGNAL_PENDING_CALLS();
     if (PyErr_CheckSignals() < 0) {
         SIGNAL_PENDING_CALLS();

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -140,6 +140,15 @@ static long dxp[256];
     do { pending_async_exc = 0; COMPUTE_EVAL_BREAKER(); } while (0)
 
 
+/* This single variable consolidates all requests to break out of the fast path
+   in the eval loop. */
+static _Py_atomic_int eval_breaker = {0};
+/* Request for running pending calls. */
+static _Py_atomic_int pendingcalls_to_do = {0};
+/* Request for looking at the `async_exc` field of the current thread state.
+   Guarded by the GIL. */
+static int pending_async_exc = 0;
+
 #ifdef WITH_THREAD
 
 #ifdef HAVE_ERRNO_H
@@ -149,16 +158,8 @@ static long dxp[256];
 
 static PyThread_type_lock pending_lock = 0; /* for pending calls */
 static unsigned long main_thread = 0;
-/* This single variable consolidates all requests to break out of the fast path
-   in the eval loop. */
-static _Py_atomic_int eval_breaker = {0};
 /* Request for dropping the GIL */
 static _Py_atomic_int gil_drop_request = {0};
-/* Request for running pending calls. */
-static _Py_atomic_int pendingcalls_to_do = {0};
-/* Request for looking at the `async_exc` field of the current thread state.
-   Guarded by the GIL. */
-static int pending_async_exc = 0;
 
 #include "ceval_gil.h"
 
@@ -253,9 +254,6 @@ PyEval_ReInitThreads(void)
     _PyThreadState_DeleteExcept(current_tstate);
 }
 
-#else
-static _Py_atomic_int eval_breaker = {0};
-static int pending_async_exc = 0;
 #endif /* WITH_THREAD */
 
 /* This function is used to signal that async exceptions are waiting to be
@@ -330,6 +328,15 @@ PyEval_RestoreThread(PyThreadState *tstate)
 #endif
 */
 
+void
+_PyEval_SignalReceived(void)
+{
+    /* bpo-30703: Function called when the C signal handler of Python gets a
+       signal. We cannot queue a callback using Py_AddPendingCall() since this
+       function is not reentrant (uses a lock and a list). */
+    SIGNAL_PENDING_CALLS();
+}
+
 #ifdef WITH_THREAD
 
 /* The WITH_THREAD implementation is thread-safe.  It allows
@@ -387,15 +394,6 @@ Py_AddPendingCall(int (*func)(void *), void *arg)
     return result;
 }
 
-void
-_PyEval_SignalReceived(void)
-{
-    /* bpo-30703: Function called when the C signal handler of Python gets a
-       signal. We cannot queue a callback using Py_AddPendingCall() since this
-       function is not reentrant (uses a lock and a list). */
-    SIGNAL_PENDING_CALLS();
-}
-
 int
 Py_MakePendingCalls(void)
 {
@@ -422,9 +420,9 @@ Py_MakePendingCalls(void)
        that a signal was received, see _PyEval_SignalReceived(). */
     UNSIGNAL_PENDING_CALLS();
     if (PyErr_CheckSignals() < 0) {
-        SIGNAL_PENDING_CALLS();
-        r = -1;
-        goto end;
+        busy = 0;
+        SIGNAL_PENDING_CALLS(); /* We're not done yet */
+        return -1;
     }
 
     /* perform a bounded number of calls, in case of recursion */
@@ -449,12 +447,12 @@ Py_MakePendingCalls(void)
             break;
         r = func(arg);
         if (r) {
-            SIGNAL_PENDING_CALLS();
-            break;
+            busy = 0;
+            SIGNAL_PENDING_CALLS(); /* We're not done yet */
+            return -1;
         }
     }
 
-end:
     busy = 0;
     return r;
 }
@@ -491,7 +489,6 @@ static struct {
 } pendingcalls[NPENDINGCALLS];
 static volatile int pendingfirst = 0;
 static volatile int pendinglast = 0;
-static _Py_atomic_int pendingcalls_to_do = {0};
 
 int
 Py_AddPendingCall(int (*func)(void *), void *arg)
@@ -525,7 +522,14 @@ Py_MakePendingCalls(void)
     if (busy)
         return 0;
     busy = 1;
+
     UNSIGNAL_PENDING_CALLS();
+    if (PyErr_CheckSignals() < 0) {
+        busy = 0;
+        SIGNAL_PENDING_CALLS(); /* We're not done yet */
+        return -1;
+    }
+
     for (;;) {
         int i;
         int (*func)(void *);


### PR DESCRIPTION
Avoid using Py_AddPendingCall from signal handler, to avoid calling signal-unsafe functions.