### PR TITLE
bpo-30769: Fix reference leak introduced in 77703942c59

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1610,6 +1610,7 @@ Andi Vajda
 Case Van Horsen
 John Mark Vandenberg
 Kyle VanderBeek
+Eric N. Vander Weele
 Andrew Vant
 Atul Varma
 Dmitry Vasiliev

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4900,6 +4900,8 @@ parse_envlist(PyObject* env, Py_ssize_t *envc_ptr)
             PyUnicode_FindChar(key2, '=', 1, PyUnicode_GET_LENGTH(key2), 1) != -1)
         {
             PyErr_SetString(PyExc_ValueError, "illegal environment variable name");
+            Py_DECREF(key2);
+            Py_DECREF(val2);
             goto error;
         }
         keyval = PyUnicode_FromFormat("%U=%U", key2, val2);
@@ -4914,6 +4916,8 @@ parse_envlist(PyObject* env, Py_ssize_t *envc_ptr)
             strchr(PyBytes_AS_STRING(key2) + 1, '=') != NULL)
         {
             PyErr_SetString(PyExc_ValueError, "illegal environment variable name");
+            Py_DECREF(key2);
+            Py_DECREF(val2);
             goto error;
         }
         keyval = PyBytes_FromFormat("%s=%s", PyBytes_AS_STRING(key2),


### PR DESCRIPTION
New error condition paths were introduced, which did not decrement
`key2` and `val2` objects.  Therefore, decrement references before
jumping to the error label.

Signed-off-by: Eric N. Vander Weele <ericvw@gmail.com>