### PR TITLE
bpo-30782: Allow limiting the number of concurrent tasks in asyncio.as_completed

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -405,7 +405,7 @@ def _wait(fs, timeout, return_when, loop):
 
 
 # This is *not* a @coroutine!  It is just an iterator (yielding Futures).
-def as_completed(fs, *, loop=None, timeout=None):
+def as_completed(fs, *, loop=None, timeout=None, limit=None):
     """Return an iterator whose values are coroutines.
 
     When waiting for the yielded coroutines you'll get the results (or

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -423,7 +423,7 @@ def as_completed(fs, *, loop=None, timeout=None):
 
     Note: The futures 'f' are not necessarily members of fs.
     """
-    if futures.isfuture(fs) or coroutines.iscoroutine(fs):
+    if futures.isfuture(fs):
         raise TypeError("expect a list of futures, not %s" % type(fs).__name__)
     loop = loop if loop is not None else events.get_event_loop()
     todo = {ensure_future(f, loop=loop) for f in set(fs)}

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1104,7 +1104,7 @@ class BaseTaskTests:
         executions is kept to a given value.
         """
         num_futures = 10
-        limit = 10  # TODO: limit is not implemented yet
+        limit = 3
 
         def gen():
             yield 0


### PR DESCRIPTION
See http://bugs.python.org/issue30782 - I propose adding a "limit" argument to asyncio.as_completed.

Justification is in the linked bug and my blog posts: http://www.artificialworlds.net/blog/2017/06/12/making-100-million-requests-with-python-aiohttp/

The "Allow passing a coroutine to as_completed" part may be the most controversial because it turns off checking for some types of error, but I think it is necessary to achieve what I am trying to do.