### PR TITLE
[3.6] bpo-29910: IDLE no longer deletes a character after commenting …

### DIFF
--- a/Lib/idlelib/autocomplete.py
+++ b/Lib/idlelib/autocomplete.py
@@ -60,6 +60,7 @@ class AutoComplete:
         if a function call is needed.
         """
         self.open_completions(True, False, True)
+        return "break"
 
     def try_open_completions_event(self, event):
         """Happens when it would be nice to open a completion list, but not

--- a/Lib/idlelib/calltip_w.py
+++ b/Lib/idlelib/calltip_w.py
@@ -89,24 +89,27 @@ class CallTip:
             # If the event was triggered by the same event that unbinded
             # this function, the function will be called nevertheless,
             # so do nothing in this case.
-            return
+            return None
         curline, curcol = map(int, self.widget.index("insert").split('.'))
         if curline < self.parenline or \
            (curline == self.parenline and curcol <= self.parencol) or \
            self.widget.compare("insert", ">", MARK_RIGHT):
             self.hidetip()
+            return "break"
         else:
             self.position_window()
             if self.checkhide_after_id is not None:
                 self.widget.after_cancel(self.checkhide_after_id)
             self.checkhide_after_id = \
                 self.widget.after(CHECKHIDE_TIME, self.checkhide_event)
+            return None
 
     def hide_event(self, event):
         if not self.tipwindow:
             # See the explanation in checkhide_event.
-            return
+            return None
         self.hidetip()
+        return "break"
 
     def hidetip(self):
         if not self.tipwindow:

--- a/Lib/idlelib/calltips.py
+++ b/Lib/idlelib/calltips.py
@@ -47,6 +47,7 @@ class CallTips:
     def force_open_calltip_event(self, event):
         "The user selected the menu entry or hotkey, open the tip."
         self.open_calltip(True)
+        return "break"
 
     def try_open_calltip_event(self, event):
         """Happens when it would be nice to open a CallTip, but not really

--- a/Lib/idlelib/codecontext.py
+++ b/Lib/idlelib/codecontext.py
@@ -89,6 +89,7 @@ class CodeContext:
         idleConf.SetOption("extensions", "CodeContext", "visible",
                            str(self.label is not None))
         idleConf.SaveUserCfgFiles()
+        return "break"
 
     def get_line_info(self, linenum):
         """Get the line indent value, text, and any block start keyword

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1,4 +1,3 @@
-import importlib
 import importlib.abc
 import importlib.util
 import os
@@ -147,7 +146,7 @@ class EditorWindow(object):
         text.bind("<<python-docs>>", self.python_docs)
         text.bind("<<about-idle>>", self.about_dialog)
         text.bind("<<open-config-dialog>>", self.config_dialog)
-        text.bind("<<open-module>>", self.open_module)
+        text.bind("<<open-module>>", self.open_module_event)
         text.bind("<<do-nothing>>", lambda event: "break")
         text.bind("<<select-all>>", self.select_all)
         text.bind("<<remove-selection>>", self.remove_selection)
@@ -294,7 +293,7 @@ class EditorWindow(object):
     def home_callback(self, event):
         if (event.state & 4) != 0 and event.keysym == "Home":
             # state&4==Control. If <Control-Home>, use the Tk binding.
-            return
+            return None
         if self.text.index("iomark") and \
            self.text.compare("iomark", "<=", "insert lineend") and \
            self.text.compare("insert linestart", "<=", "iomark"):
@@ -423,6 +422,7 @@ class EditorWindow(object):
         rmenu.tk_popup(event.x_root, event.y_root)
         if iswin:
             self.text.config(cursor="ibeam")
+        return "break"
 
     rmenu_specs = [
         # ("Label", "<<virtual-event>>", "statefuncname"), ...
@@ -464,11 +464,13 @@ class EditorWindow(object):
         "Handle Help 'About IDLE' event."
         # Synchronize with macosx.overrideRootMenu.about_dialog.
         help_about.AboutDialog(self.top)
+        return "break"
 
     def config_dialog(self, event=None):
         "Handle Options 'Configure IDLE' event."
         # Synchronize with macosx.overrideRootMenu.config_dialog.
         configdialog.ConfigDialog(self.top,'Settings')
+        return "break"
 
     def help_dialog(self, event=None):
         "Handle Help 'IDLE Help' event."
@@ -478,6 +480,7 @@ class EditorWindow(object):
         else:
             parent = self.top
         help.show_idlehelp(parent)
+        return "break"
 
     def python_docs(self, event=None):
         if sys.platform[:3] == 'win':
@@ -497,7 +500,7 @@ class EditorWindow(object):
     def copy(self,event):
         if not self.text.tag_ranges("sel"):
             # There is no selection, so do nothing and maybe interrupt.
-            return
+            return None
         self.text.event_generate("<<Copy>>")
         return "break"
 
@@ -515,6 +518,7 @@ class EditorWindow(object):
     def remove_selection(self, event=None):
         self.text.tag_remove("sel", "1.0", "end")
         self.text.see("insert")
+        return "break"
 
     def move_at_edge_if_selection(self, edge_index):
         """Cursor move begins at start or end of selection
@@ -575,8 +579,9 @@ class EditorWindow(object):
             return "break"
         text.mark_set("insert", "%d.0" % lineno)
         text.see("insert")
+        return "break"
 
-    def open_module(self, event=None):
+    def open_module(self):
         """Get module name from user and open it.
 
         Return module path or None for calls by open_class_browser
@@ -600,21 +605,27 @@ class EditorWindow(object):
                 self.io.loadfile(file_path)
         return file_path
 
+    def open_module_event(self, event):
+        self.open_module()
+        return "break"
+
     def open_class_browser(self, event=None):
         filename = self.io.filename
         if not (self.__class__.__name__ == 'PyShellEditorWindow'
                 and filename):
             filename = self.open_module()
             if filename is None:
-                return
+                return "break"
         head, tail = os.path.split(filename)
         base, ext = os.path.splitext(tail)
         from idlelib import browser
         browser.ClassBrowser(self.flist, base, [head])
+        return "break"
 
     def open_path_browser(self, event=None):
         from idlelib import pathbrowser
         pathbrowser.PathBrowser(self.flist)
+        return "break"
 
     def open_turtle_demo(self, event = None):
         import subprocess
@@ -623,6 +634,7 @@ class EditorWindow(object):
                '-c',
                'from turtledemo.__main__ import main; main()']
         subprocess.Popen(cmd, shell=False)
+        return "break"
 
     def gotoline(self, lineno):
         if lineno is not None and lineno > 0:
@@ -879,6 +891,7 @@ class EditorWindow(object):
 
     def center_insert_event(self, event):
         self.center()
+        return "break"
 
     def center(self, mark="insert"):
         text = self.text
@@ -910,6 +923,7 @@ class EditorWindow(object):
 
     def close_event(self, event):
         self.close()
+        return "break"
 
     def maybesave(self):
         if self.io:
@@ -1357,6 +1371,7 @@ class EditorWindow(object):
             line = lines[pos]
             lines[pos] = '##' + line
         self.set_region(head, tail, chars, lines)
+        return "break"
 
     def uncomment_region_event(self, event):
         head, tail, chars, lines = self.get_region()
@@ -1370,6 +1385,7 @@ class EditorWindow(object):
                 line = line[1:]
             lines[pos] = line
         self.set_region(head, tail, chars, lines)
+        return "break"
 
     def tabify_region_event(self, event):
         head, tail, chars, lines = self.get_region()
@@ -1382,6 +1398,7 @@ class EditorWindow(object):
                 ntabs, nspaces = divmod(effective, tabwidth)
                 lines[pos] = '\t' * ntabs + ' ' * nspaces + line[raw:]
         self.set_region(head, tail, chars, lines)
+        return "break"
 
     def untabify_region_event(self, event):
         head, tail, chars, lines = self.get_region()
@@ -1390,6 +1407,7 @@ class EditorWindow(object):
         for pos in range(len(lines)):
             lines[pos] = lines[pos].expandtabs(tabwidth)
         self.set_region(head, tail, chars, lines)
+        return "break"
 
     def toggle_tabs_event(self, event):
         if self.askyesno(

--- a/Lib/idlelib/idle_test/test_parenmatch.py
+++ b/Lib/idlelib/idle_test/test_parenmatch.py
@@ -95,14 +95,14 @@ class ParenMatchTest(unittest.TestCase):
         pm = self.get_parenmatch()
 
         text.insert('insert', '# this is a commen)')
-        self.assertIsNone(pm.paren_closed_event('event'))
+        pm.paren_closed_event('event')
 
         text.insert('insert', '\ndef')
-        self.assertIsNone(pm.flash_paren_event('event'))
-        self.assertIsNone(pm.paren_closed_event('event'))
+        pm.flash_paren_event('event')
+        pm.paren_closed_event('event')
 
         text.insert('insert', ' a, *arg)')
-        self.assertIsNone(pm.paren_closed_event('event'))
+        pm.paren_closed_event('event')
 
     def test_handle_restore_timer(self):
         pm = self.get_parenmatch()

--- a/Lib/idlelib/parenmatch.py
+++ b/Lib/idlelib/parenmatch.py
@@ -94,26 +94,28 @@ class ParenMatch:
                    .get_surrounding_brackets())
         if indices is None:
             self.bell()
-            return
+            return "break"
         self.activate_restore()
         self.create_tag(indices)
         self.set_timeout_last()
+        return "break"
 
     def paren_closed_event(self, event):
         # If it was a shortcut and not really a closing paren, quit.
         closer = self.text.get("insert-1c")
         if closer not in _openers:
-            return
+            return "break"
         hp = HyperParser(self.editwin, "insert-1c")
         if not hp.is_in_code():
-            return
+            return "break"
         indices = hp.get_surrounding_brackets(_openers[closer], True)
         if indices is None:
             self.bell()
-            return
+            return "break"
         self.activate_restore()
         self.create_tag(indices)
         self.set_timeout()
+        return "break"
 
     def restore_event(self, event=None):
         self.text.tag_delete("paren")

--- a/Lib/idlelib/runscript.py
+++ b/Lib/idlelib/runscript.py
@@ -63,6 +63,7 @@ class ScriptBinding:
             return 'break'
         if not self.tabnanny(filename):
             return 'break'
+        return "break"
 
     def tabnanny(self, filename):
         # XXX: tabnanny should work on binary files as well

--- a/Lib/idlelib/scrolledlist.py
+++ b/Lib/idlelib/scrolledlist.py
@@ -76,6 +76,7 @@ class ScrolledList:
         index = self.listbox.index("active")
         self.select(index)
         menu.tk_popup(event.x_root, event.y_root)
+        return "break"
 
     def make_menu(self):
         menu = Menu(self.listbox, tearoff=0)

--- a/Lib/idlelib/zoomheight.py
+++ b/Lib/idlelib/zoomheight.py
@@ -20,6 +20,7 @@ class ZoomHeight:
     def zoom_height_event(self, event):
         top = self.editwin.top
         zoom_height(top)
+        return "break"
 
 
 def zoom_height(top):

--- a/Misc/NEWS.d/next/IDLE/2017-06-26-22-45-27.bpo-29910.mqHh7u.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-06-26-22-45-27.bpo-29910.mqHh7u.rst
@@ -1,0 +1,3 @@
+IDLE no longer deletes a character after commenting out a region by a key
+shortcut.  Add ``return 'break'`` for this and other potential conflicts
+between IDLE and default key bindings.


### PR DESCRIPTION
…out a region (GH-825)

This happened because shortcut has a class binding and 'break' was not returned.
Fix other potential conflicts between IDLE and default key bindings.

* Add news item

* Update NEWS
(cherry picked from commit 213ce12)