### PR TITLE
[3.6] Fix trivial typo in json module docstring (GH-2274)

### DIFF
--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -76,7 +76,7 @@ Specializing JSON object encoding::
     >>> def encode_complex(obj):
     ...     if isinstance(obj, complex):
     ...         return [obj.real, obj.imag]
-    ...     raise TypeError(repr(o) + " is not JSON serializable")
+    ...     raise TypeError(repr(obj) + " is not JSON serializable")
     ...
     >>> json.dumps(2 + 1j, default=encode_complex)
     '[2.0, 1.0]'


### PR DESCRIPTION
(cherry picked from commit 76c567ee27342d76f631a35c8291b715b2a61f3e)