### PR TITLE
[2.7] bpo-30705: Fix test_regrtest.test_crashed()

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1945,3 +1945,17 @@ class SuppressCrashReport:
                 resource.setrlimit(resource.RLIMIT_CORE, self.old_value)
             except (ValueError, OSError):
                 pass
+
+
+def _crash_python():
+    """Deliberate crash of Python.
+
+    Python can be killed by a segmentation fault (SIGSEGV), a bus error
+    (SIGBUS), or a different error depending on the platform.
+
+    Use SuppressCrashReport() to prevent a crash report from popping up.
+    """
+
+    import ctypes
+    with SuppressCrashReport():
+        ctypes.string_at(0)

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -473,7 +473,7 @@ class ArgsTestCase(BaseTestCase):
 
     def test_crashed(self):
         # Any code which causes a crash
-        code = 'import ctypes; ctypes.string_at(0)'
+        code = 'import test.support; test.support._crash_python()'
         crash_test = self.create_test(name="crash", code=code)
         ok_test = self.create_test(name="ok")
 

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1277,7 +1277,7 @@ class POSIXProcessTestCase(BaseTestCase):
 
         code = textwrap.dedent("""
              import ctypes
-             from test.support import SuppressCrashReport
+             from test.support import _crash_python
 
              libc = ctypes.CDLL({libc_name!r})
              libc.ptrace({PTRACE_TRACEME}, 0, 0)
@@ -1288,9 +1288,8 @@ class POSIXProcessTestCase(BaseTestCase):
             raise unittest.SkipTest('ptrace() failed - unable to test')
 
         code += textwrap.dedent("""
-             with SuppressCrashReport():
-                # Crash the process
-                libc.printf(ctypes.c_char_p(0xdeadbeef))  # Crash the process.
+             # Crash the process
+             _crash_python()
         """)
         child = subprocess.Popen([sys.executable, '-c', code])
         try:


### PR DESCRIPTION
* Add test.support._crash_python() which triggers a crash but uses
  test.support.SuppressCrashReport() to prevent a crash report from
  popping up.
* Modify test_child_terminated_in_stopped_state() of test_subprocess
  and test_crashed() of test_regrtest to use _crash_python().