### PR TITLE
bpo-30704, bpo-30604: Fix memleak in code_dealloc()

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -427,7 +427,8 @@ code_dealloc(PyCodeObject *co)
             }
         }
 
-        PyMem_FREE(co->co_extra);
+        PyMem_Free(co_extra->ce_extras);
+        PyMem_Free(co_extra);
     }
 
     Py_XDECREF(co->co_code);


### PR DESCRIPTION
Free also co_extra->ce_extras, not only co_extra.