### PR TITLE
[3.6] bpo-30704, bpo-30604: Fix memleak in code_dealloc() (#2455)

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -422,7 +422,8 @@ code_dealloc(PyCodeObject *co)
             }
         }
 
-        PyMem_FREE(co->co_extra);
+        PyMem_Free(co_extra->ce_extras);
+        PyMem_Free(co_extra);
     }
 
     Py_XDECREF(co->co_code);


### PR DESCRIPTION
Free also co_extra->ce_extras, not only co_extra.
(cherry picked from commit 23e7944eba1968bb8432fdc4cc96d4fdd2c1a230)