### PR TITLE
[3.6] Clarification to the `break` statement (GH-2453)

### DIFF
--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -157,7 +157,7 @@ Later we will see more functions that return iterables and take iterables as arg
 :keyword:`break` and :keyword:`continue` Statements, and :keyword:`else` Clauses on Loops
 =========================================================================================
 
-The :keyword:`break` statement, like in C, breaks out of the smallest enclosing
+The :keyword:`break` statement, like in C, breaks out of the innermost enclosing
 :keyword:`for` or :keyword:`while` loop.
 
 Loop statements may have an ``else`` clause; it is executed when the loop


### PR DESCRIPTION
Clarify that the break statement breaks out of the innermost enclosing for or while loop.
(cherry picked from commit 36fc896740319d2c03aa2054a90a999c162517ef)