### PR TITLE
[3.5] bpo-30775: Clear potential ref cycle between Process and Process target (GH-2470)

### DIFF
--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -104,6 +104,9 @@ class BaseProcess(object):
         _cleanup()
         self._popen = self._Popen(self)
         self._sentinel = self._popen.sentinel
+        # Avoid a refcycle if the target function holds an indirect
+        # reference to the process object (see bpo-30775)
+        del self._target, self._args, self._kwargs
         _children.add(self)
 
     def terminate(self):

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -191,6 +191,12 @@ def get_value(self):
 # Testcases
 #
 
+class DummyCallable:
+    def __call__(self, q, c):
+        assert isinstance(c, DummyCallable)
+        q.put(5)
+
+
 class _TestProcess(BaseTestCase):
 
     ALLOWED_TYPES = ('processes', 'threads')
@@ -397,6 +403,18 @@ class _TestProcess(BaseTestCase):
         event.set()
         p.join()
         self.assertTrue(wait_for_handle(sentinel, timeout=1))
+
+    def test_lose_target_ref(self):
+        c = DummyCallable()
+        wr = weakref.ref(c)
+        q = self.Queue()
+        p = self.Process(target=c, args=(q, c))
+        del c
+        p.start()
+        p.join()
+        self.assertIs(wr(), None)
+        self.assertEqual(q.get(), 5)
+
 
 #
 #


### PR DESCRIPTION
* Clear potential ref cycle between Process and Process target

Besides Process.join() not being called, this was an indirect cause of bpo-30775.
The threading module already does this.

* Add issue reference.
(cherry picked from commit 79d37ae979a65ada0b2ac820279ccc3b1cd41ba6)