### PR TITLE
[2.7] bpo-30775: Clear potential ref cycle between Process and Process target (GH-2470)

### DIFF
--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -128,6 +128,9 @@ class Process(object):
         else:
             from .forking import Popen
         self._popen = Popen(self)
+        # Avoid a refcycle if the target function holds an indirect
+        # reference to the process object (see bpo-30775)
+        del self._target, self._args, self._kwargs
         _current_process._children.add(self)
 
     def terminate(self):

--- a/Lib/test/test_multiprocessing.py
+++ b/Lib/test/test_multiprocessing.py
@@ -175,6 +175,12 @@ def get_value(self):
 # Testcases
 #
 
+class DummyCallable(object):
+    def __call__(self, q, c):
+        assert isinstance(c, DummyCallable)
+        q.put(5)
+
+
 class _TestProcess(BaseTestCase):
 
     ALLOWED_TYPES = ('processes', 'threads')
@@ -354,6 +360,18 @@ class _TestProcess(BaseTestCase):
             p.start()
             p.join(5)
             self.assertEqual(p.exitcode, reason)
+
+    def test_lose_target_ref(self):
+        c = DummyCallable()
+        wr = weakref.ref(c)
+        q = self.Queue()
+        p = self.Process(target=c, args=(q, c))
+        del c
+        p.start()
+        p.join()
+        self.assertIs(wr(), None)
+        self.assertEqual(q.get(), 5)
+
 
 #
 #


### PR DESCRIPTION
* Clear potential ref cycle between Process and Process target

Besides Process.join() not being called, this was an indirect cause of bpo-30775.
The threading module already does this.

* Add issue reference.
(cherry picked from commit 79d37ae979a65ada0b2ac820279ccc3b1cd41ba6)