### PR TITLE
bpo-30805: Avoid race condition of `self._debug` in event loop

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1147,14 +1147,17 @@ class BaseEventLoop(events.AbstractEventLoop):
         if bufsize != 0:
             raise ValueError("bufsize must be 0")
         protocol = protocol_factory()
-        if self._debug:
+        # save debug to avoid race condition in case debug is enabled
+        # before transport returns
+        debug = self._debug
+        if debug:
             # don't log parameters: they may contain sensitive information
             # (password) and may be too long
             debug_log = 'run shell command %r' % cmd
             self._log_subprocess(debug_log, stdin, stdout, stderr)
         transport = yield from self._make_subprocess_transport(
             protocol, cmd, True, stdin, stdout, stderr, bufsize, **kwargs)
-        if self._debug:
+        if debug:
             logger.info('%s: %r', debug_log, transport)
         return transport, protocol
 
@@ -1176,7 +1179,10 @@ class BaseEventLoop(events.AbstractEventLoop):
                                 "a bytes or text string, not %s"
                                 % type(arg).__name__)
         protocol = protocol_factory()
-        if self._debug:
+        # save debug to avoid race condition in case debug is enabled
+        # before transport returns
+        debug = self._debug
+        if debug:
             # don't log parameters: they may contain sensitive information
             # (password) and may be too long
             debug_log = 'execute program %r' % program
@@ -1184,7 +1190,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         transport = yield from self._make_subprocess_transport(
             protocol, popen_args, False, stdin, stdout, stderr,
             bufsize, **kwargs)
-        if self._debug:
+        if debug:
             logger.info('%s: %r', debug_log, transport)
         return transport, protocol
 


### PR DESCRIPTION
If a process is schedule to run in the event loop with debug disabled
and debug is then enabled before the process finishes it will result in
a traceback: log_debug undefined.