### PR TITLE
bpo-9566: Fixed _ssl module warnings

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1555,7 +1555,7 @@ cipher_to_dict(const SSL_CIPHER *cipher)
     cipher_protocol = SSL_CIPHER_get_version(cipher);
     cipher_id = SSL_CIPHER_get_id(cipher);
     SSL_CIPHER_description(cipher, buf, sizeof(buf) - 1);
-    len = strlen(buf);
+    len = (int)strlen(buf);
     if (len > 1 && buf[len-1] == '\n')
         buf[len-1] = '\0';
     strength_bits = SSL_CIPHER_get_bits(cipher, &alg_bits);
@@ -4073,7 +4073,7 @@ memory_bio_dealloc(PySSLMemoryBIO *self)
 static PyObject *
 memory_bio_get_pending(PySSLMemoryBIO *self, void *c)
 {
-    return PyLong_FromLong(BIO_ctrl_pending(self->bio));
+    return PyLong_FromSize_t(BIO_ctrl_pending(self->bio));
 }
 
 PyDoc_STRVAR(PySSL_memory_bio_pending_doc,
@@ -4109,7 +4109,7 @@ _ssl_MemoryBIO_read_impl(PySSLMemoryBIO *self, int len)
     int avail, nbytes;
     PyObject *result;
 
-    avail = BIO_ctrl_pending(self->bio);
+    avail = (int)BIO_ctrl_pending(self->bio);
     if ((len < 0) || (len > avail))
         len = avail;
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1555,6 +1555,7 @@ cipher_to_dict(const SSL_CIPHER *cipher)
     cipher_protocol = SSL_CIPHER_get_version(cipher);
     cipher_id = SSL_CIPHER_get_id(cipher);
     SSL_CIPHER_description(cipher, buf, sizeof(buf) - 1);
+    /* Downcast to avoid a warning. Safe since buf is always 512 bytes */
     len = (int)strlen(buf);
     if (len > 1 && buf[len-1] == '\n')
         buf[len-1] = '\0';


### PR DESCRIPTION
Split from https://github.com/python/cpython/pull/2492 on request by @haypo 

The following remain:
- [x] `..\Modules\_ssl.c(2947): warning C4244: '=': conversion from 'Py_ssize_t' to 'int', possible loss of data`
  The Py_buffer can *theoretically* be larger... But I'm not sure that the protocol even supports that...
  Should this be casted away or fixed some other way?
- [x] `..\Modules\_ssl.c(4158): warning C4244: 'function': conversion from 'Py_ssize_t' to 'int', possible loss of data`
  Someone can *theoretically* pass a buffer big enough... But I doubt such a buffer is going to be written at once...
  Should this be casted away...?

<!-- issue-number: bpo-9566 -->
https://bugs.python.org/issue9566
<!-- /issue-number -->
