### PR TITLE
bpo-30813: Fix unittest when hunting refleaks

### DIFF
--- a/Lib/unittest/test/test_discovery.py
+++ b/Lib/unittest/test/test_discovery.py
@@ -528,6 +528,9 @@ class TestDiscovery(unittest.TestCase):
             pickle.loads(pickle.dumps(test, proto))
 
     def test_discover_with_module_that_raises_SkipTest_on_import(self):
+        if not unittest.BaseTestSuite._cleanup:
+            raise unittest.SkipTest("Suite cleanup is disabled")
+
         loader = unittest.TestLoader()
 
         def _get_module_from_name(name):
@@ -548,6 +551,9 @@ class TestDiscovery(unittest.TestCase):
             pickle.loads(pickle.dumps(suite, proto))
 
     def test_discover_with_init_module_that_raises_SkipTest_on_import(self):
+        if not unittest.BaseTestSuite._cleanup:
+            raise unittest.SkipTest("Suite cleanup is disabled")
+
         vfs = {abspath('/foo'): ['my_package'],
                abspath('/foo/my_package'): ['__init__.py', 'test_module.py']}
         self.setup_import_issue_package_tests(vfs)


### PR DESCRIPTION
bpo-11798, bpo-16662, bpo-16935, bpo-30813: Skip
test_discover_with_module_that_raises_SkipTest_on_import() and
test_discover_with_init_module_that_raises_SkipTest_on_import() of
test_unittest when hunting reference leaks using regrtest.