### PR TITLE
[3.6] bpo-30812: Fix test_warnings, restore _showwarnmsg (#2504)

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -727,10 +727,15 @@ class _WarningsTests(BaseTest, unittest.TestCase):
         text = 'del _showwarnmsg test'
         with original_warnings.catch_warnings(module=self.module):
             self.module.filterwarnings("always", category=UserWarning)
-            del self.module._showwarnmsg
-            with support.captured_output('stderr') as stream:
-                self.module.warn(text)
-                result = stream.getvalue()
+
+            show = self.module._showwarnmsg
+            try:
+                del self.module._showwarnmsg
+                with support.captured_output('stderr') as stream:
+                    self.module.warn(text)
+                    result = stream.getvalue()
+            finally:
+                self.module._showwarnmsg = show
         self.assertIn(text, result)
 
     def test_showwarning_not_callable(self):


### PR DESCRIPTION
bpo-26568, bpo-30812: Fix test_showwarnmsg_missing(): restore the
attribute after removing it.
(cherry picked from commit 7eebeb8fb84e2a9cb73903a08c59cf1d3b32cee0)