### PR TITLE
[3.5] bpo-30280: Cleanup threads in ayncio tests (#2501)

### DIFF
--- a/Lib/asyncio/test_utils.py
+++ b/Lib/asyncio/test_utils.py
@@ -33,6 +33,7 @@ from . import selectors
 from . import tasks
 from .coroutines import coroutine
 from .log import logger
+from test import support
 
 
 if sys.platform == 'win32':  # pragma: no cover
@@ -455,6 +456,7 @@ class TestCase(unittest.TestCase):
     def setUp(self):
         self._get_running_loop = events._get_running_loop
         events._get_running_loop = lambda: None
+        self._thread_cleanup = support.threading_setup()
 
     def tearDown(self):
         self.unpatch_get_running_loop()
@@ -464,6 +466,10 @@ class TestCase(unittest.TestCase):
         # Detect CPython bug #23353: ensure that yield/yield-from is not used
         # in an except block of a generator
         self.assertEqual(sys.exc_info(), (None, None, None))
+
+        self.doCleanups()
+        support.threading_cleanup(*self._thread_cleanup)
+        support.reap_children()
 
     if not compat.PY34:
         # Python 3.3 compatibility

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -24,15 +24,13 @@ MOCK_ANY = mock.ANY
 
 class TestBaseSelectorEventLoop(BaseSelectorEventLoop):
 
-    def close(self):
-        # Don't call the close() method of the parent class, because the
-        # selector is mocked
-        self._closed = True
-
     def _make_self_pipe(self):
         self._ssock = mock.Mock()
         self._csock = mock.Mock()
         self._internal_fds += 1
+
+    def _close_self_pipe(self):
+        pass
 
 
 def list_to_buffer(l=()):


### PR DESCRIPTION
* bpo-30280: asyncio now cleans up threads

asyncio base TestCase now uses threading_setup() and
threading_cleanup() of test.support to cleanup threads.

* asyncio: Fix TestBaseSelectorEventLoop cleanup

bpo-30280: TestBaseSelectorEventLoop of
test.test_asyncio.test_selector_events now correctly closes the event
loop: cleanup its executor to not leak threads.

Don't override the close() method of the event loop, only override
the_close_self_pipe() method.

(cherry picked from commit b9030674624c181d6e9047cdb14ad65bb6c84c66)