### PR TITLE
bpo-30818: test_ftplib calls asyncore.close_all()

### DIFF
--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -470,6 +470,7 @@ class TestFTPClass(TestCase):
     def tearDown(self):
         self.client.close()
         self.server.stop()
+        asyncore.close_all(ignore_all=True)
 
     def check_data(self, received, expected):
         self.assertEqual(len(received), len(expected))
@@ -795,6 +796,7 @@ class TestIPv6Environment(TestCase):
     def tearDown(self):
         self.client.close()
         self.server.stop()
+        asyncore.close_all(ignore_all=True)
 
     def test_af(self):
         self.assertEqual(self.client.af, socket.AF_INET6)
@@ -853,6 +855,7 @@ class TestTLS_FTPClass(TestCase):
     def tearDown(self):
         self.client.close()
         self.server.stop()
+        asyncore.close_all(ignore_all=True)
 
     def test_control_connection(self):
         self.assertNotIsInstance(self.client.sock, ssl.SSLSocket)


### PR DESCRIPTION
Always clear asyncore socket map using
asyncore.close_all(ignore_all=True) in tearDown() method.

This change should fix this warning:

Warning -- asyncore.socket_map was modified by test_ftplib
  Before: {}
  After:  {4: <test.test_ftplib.DummyTLS_FTPServer 127.0.0.1:0 at 0x805feccf0>}