### PR TITLE
Modify configury to link with the compiler driver under HP-UX

### DIFF
--- a/configure
+++ b/configure
@@ -9219,7 +9219,8 @@ then
 			LDSHARED='$(CC) -shared'
 			LDCXXSHARED='$(CXX) -shared'
 		else
-			LDSHARED='ld -b'
+			LDSHARED='$(CC) -b'
+			LDCXXSHARED='$(CXX) -shared'
 		fi ;;
 	Darwin/1.3*)
 		LDSHARED='$(CC) -bundle'

--- a/configure.ac
+++ b/configure.ac
@@ -2464,7 +2464,8 @@ then
 			LDSHARED='$(CC) -shared'
 			LDCXXSHARED='$(CXX) -shared'
 		else
-			LDSHARED='ld -b'
+			LDSHARED='$(CC) -b'
+			LDCXXSHARED='$(CXX) -b'
 		fi ;;
 	Darwin/1.3*)
 		LDSHARED='$(CC) -bundle'


### PR DESCRIPTION
Modify configury to link with the compiler driver under HP-UX when not using gcc.

http://bugs.python.org/issue30183
