### PR TITLE
bpo-30183: Modify configure to link with the compiler driver under HP-UX

### DIFF
--- a/configure
+++ b/configure
@@ -9219,7 +9219,8 @@ then
 			LDSHARED='$(CC) -shared'
 			LDCXXSHARED='$(CXX) -shared'
 		else
-			LDSHARED='ld -b'
+			LDSHARED='$(CC) -b'
+			LDCXXSHARED='$(CXX) -shared'
 		fi ;;
 	Darwin/1.3*)
 		LDSHARED='$(CC) -bundle'

--- a/configure.ac
+++ b/configure.ac
@@ -2464,7 +2464,8 @@ then
 			LDSHARED='$(CC) -shared'
 			LDCXXSHARED='$(CXX) -shared'
 		else
-			LDSHARED='ld -b'
+			LDSHARED='$(CC) -b'
+			LDCXXSHARED='$(CXX) -b'
 		fi ;;
 	Darwin/1.3*)
 		LDSHARED='$(CC) -bundle'


### PR DESCRIPTION
When building with the native A cc compiler under HPUX, the linker command 'ld -d' can't accept the compiler commands that tell it to use 64-bit mode.  This results in a failed link, either when the library linking ld command fails to recognize +DD64 or when an ABI mismatch is found when $CC is used later.
This PR makes the obvious change to use the compiler drivers to link under hpux when gcc is not the compiler used.

<!-- issue-number: bpo-30183 -->
https://bugs.python.org/issue30183
<!-- /issue-number -->
