### PR TITLE
[2.7] bpo-11975: fixed placement of .. _func-list: in functions.rst

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -698,7 +698,6 @@ section.
       Support for a tuple of type information was added.
 
 
-.. _func-list:
 .. function:: issubclass(class, classinfo)
 
    Return true if *class* is a subclass (direct, indirect or :term:`virtual
@@ -742,6 +741,7 @@ section.
    (such as a dictionary, set, or frozen set).
 
 
+.. _func-list:
 .. class:: list([iterable])
    :noindex:
 


### PR DESCRIPTION
@serhiy-storchaka i made a mistake - placed func-list in a wrong place in my previous PR https://github.com/python/cpython/pull/2518
This PR fixes it.