### PR TITLE
bpo-30794: added kill() method to multiprocessing.Process

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -601,7 +601,7 @@ The :mod:`multiprocessing` package mostly replicates the API of the
    .. method:: kill()
 
       Same as :meth:`terminate()` but using the ``SIGKILL`` signal on Unix.
-      
+
       .. versionadded:: 3.7
 
    .. method:: close()

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -598,6 +598,10 @@ The :mod:`multiprocessing` package mostly replicates the API of the
          acquired a lock or semaphore etc. then terminating it is liable to
          cause other processes to deadlock.
 
+   .. method:: kill()
+
+      Same as :meth:`terminate()` but using the ``SIGKILL`` signal on Unix.
+
    .. method:: close()
 
       Close the :class:`Process` object, releasing all resources associated

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -601,6 +601,8 @@ The :mod:`multiprocessing` package mostly replicates the API of the
    .. method:: kill()
 
       Same as :meth:`terminate()` but using the ``SIGKILL`` signal on Unix.
+      
+      .. versionadded:: 3.7
 
    .. method:: close()
 

--- a/Lib/multiprocessing/popen_fork.py
+++ b/Lib/multiprocessing/popen_fork.py
@@ -49,15 +49,21 @@ class Popen(object):
             return self.poll(os.WNOHANG if timeout == 0.0 else 0)
         return self.returncode
 
-    def terminate(self):
+    def _send_signal(self, sig):
         if self.returncode is None:
             try:
-                os.kill(self.pid, signal.SIGTERM)
+                os.kill(self.pid, sig)
             except ProcessLookupError:
                 pass
             except OSError:
                 if self.wait(timeout=0.1) is None:
                     raise
+
+    def terminate(self):
+        self._send_signal(signal.SIGTERM)
+
+    def kill(self):
+        self._send_signal(signal.SIGKILL)
 
     def _launch(self, process_obj):
         code = 1

--- a/Lib/multiprocessing/popen_spawn_win32.py
+++ b/Lib/multiprocessing/popen_spawn_win32.py
@@ -97,5 +97,7 @@ class Popen(object):
                 if self.wait(timeout=1.0) is None:
                     raise
 
+    kill = terminate
+
     def close(self):
         self.finalizer()

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -122,6 +122,13 @@ class BaseProcess(object):
         self._check_closed()
         self._popen.terminate()
 
+    def kill(self):
+        '''
+        Terminate process; sends SIGKILL signal or uses TerminateProcess()
+        '''
+        self._check_closed()
+        self._popen.kill()
+
     def join(self, timeout=None):
         '''
         Wait until child process terminates

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -277,18 +277,18 @@ class _TestProcess(BaseTestCase):
         self.assertNotIn(p, self.active_children())
 
     @classmethod
-    def _test_terminate(cls):
+    def _test_sleep_some(cls):
         time.sleep(100)
 
     @classmethod
     def _test_sleep(cls, delay):
         time.sleep(delay)
 
-    def test_terminate(self):
+    def _test_signal(self, meth, sig):
         if self.TYPE == 'threads':
             self.skipTest('test not appropriate for {}'.format(self.TYPE))
 
-        p = self.Process(target=self._test_terminate)
+        p = self.Process(target=self._test_sleep_some)
         p.daemon = True
         p.start()
 
@@ -309,7 +309,7 @@ class _TestProcess(BaseTestCase):
         # XXX maybe terminating too soon causes the problems on Gentoo...
         time.sleep(1)
 
-        p.terminate()
+        meth(p)
 
         if hasattr(signal, 'alarm'):
             # On the Gentoo buildbot waitpid() often seems to block forever.
@@ -335,60 +335,13 @@ class _TestProcess(BaseTestCase):
 
         # sometimes get p.exitcode == 0 on Windows ...
         if os.name != 'nt':
-            self.assertEqual(p.exitcode, -signal.SIGTERM)
+            self.assertEqual(p.exitcode, -sig)
+
+    def test_terminate(self):
+        self._test_signal(multiprocessing.Process.terminate, signal.SIGTERM)
 
     def test_kill(self):
-        if self.TYPE == 'threads':
-            self.skipTest('test not appropriate for {}'.format(self.TYPE))
-
-        p = self.Process(target=self._test_terminate)
-        p.daemon = True
-        p.start()
-
-        self.assertEqual(p.is_alive(), True)
-        self.assertIn(p, self.active_children())
-        self.assertEqual(p.exitcode, None)
-
-        join = TimingWrapper(p.join)
-
-        self.assertEqual(join(0), None)
-        self.assertTimingAlmostEqual(join.elapsed, 0.0)
-        self.assertEqual(p.is_alive(), True)
-
-        self.assertEqual(join(-1), None)
-        self.assertTimingAlmostEqual(join.elapsed, 0.0)
-        self.assertEqual(p.is_alive(), True)
-
-        # XXX maybe terminating too soon causes the problems on Gentoo...
-        time.sleep(1)
-
-        p.kill()
-
-        if hasattr(signal, 'alarm'):
-            # On the Gentoo buildbot waitpid() often seems to block forever.
-            # We use alarm() to interrupt it if it blocks for too long.
-            def handler(*args):
-                raise RuntimeError('join took too long: %s' % p)
-            old_handler = signal.signal(signal.SIGALRM, handler)
-            try:
-                signal.alarm(10)
-                self.assertEqual(join(), None)
-            finally:
-                signal.alarm(0)
-                signal.signal(signal.SIGALRM, old_handler)
-        else:
-            self.assertEqual(join(), None)
-
-        self.assertTimingAlmostEqual(join.elapsed, 0.0)
-
-        self.assertEqual(p.is_alive(), False)
-        self.assertNotIn(p, self.active_children())
-
-        p.join()
-
-        # sometimes get p.exitcode == 0 on Windows ...
-        if os.name != 'nt':
-            self.assertEqual(p.exitcode, -signal.SIGKILL)
+        self._test_signal(multiprocessing.Process.kill, signal.SIGKILL)
 
     def test_cpu_count(self):
         try:
@@ -515,7 +468,7 @@ class _TestProcess(BaseTestCase):
         for p in procs:
             self.assertEqual(p.exitcode, 0)
 
-        procs = [self.Process(target=self._test_terminate)
+        procs = [self.Process(target=self._test_sleep_some)
                  for i in range(N)]
         for p in procs:
             p.start()

--- a/Misc/NEWS.d/next/Library/2017-07-04-22-00-20.bpo-30794.qFwozm.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-04-22-00-20.bpo-30794.qFwozm.rst
@@ -1,0 +1,2 @@
+Added multiprocessing.Process.kill method to terminate using the SIGKILL
+signal on Unix.


### PR DESCRIPTION
kill() is the same as terminate() but sends SIGKILL instead of SIGTERM. On Windows it's the same as terminate() and wasn't tested. I'd appreciate if someone could try it.