### PR TITLE
bpo-30822: Fix testing of datetime module.

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -2271,7 +2271,8 @@ else:
          _check_tzinfo_arg, _check_tzname, _check_utc_offset, _cmp, _cmperror,
          _date_class, _days_before_month, _days_before_year, _days_in_month,
          _format_time, _is_leap, _isoweek1monday, _math, _ord2ymd,
-         _time, _time_class, _tzinfo_class, _wrap_strftime, _ymd2ord)
+         _time, _time_class, _tzinfo_class, _wrap_strftime, _ymd2ord,
+         _divide_and_round)
     # XXX Since import * above excludes names that start with _,
     # docstring does not get overwritten. In the future, it may be
     # appropriate to maintain a single module level docstring and

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -62,7 +62,7 @@ class TestModule(unittest.TestCase):
 
     def test_name_cleanup(self):
         if '_Pure' in self.__class__.__name__:
-            return self.skipTest('Only run for Fast C implementation')
+            self.skipTest('Only run for Fast C implementation')
 
         datetime = datetime_module
         names = set(name for name in dir(datetime)
@@ -74,7 +74,7 @@ class TestModule(unittest.TestCase):
 
     def test_divide_and_round(self):
         if '_Fast' in self.__class__.__name__:
-            return self.skipTest('Only run for Pure Python implementation')
+            self.skipTest('Only run for Pure Python implementation')
 
         dar = datetime_module._divide_and_round
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -61,7 +61,7 @@ class TestModule(unittest.TestCase):
         self.assertEqual(datetime.MAXYEAR, 9999)
 
     def test_name_cleanup(self):
-        if self._test_type == 'Pure':
+        if '_Pure' in self.__class__.__name__:
             return self.skipTest('Only run for Fast C implementation')
 
         datetime = datetime_module
@@ -73,7 +73,7 @@ class TestModule(unittest.TestCase):
         self.assertEqual(names - allowed, set([]))
 
     def test_divide_and_round(self):
-        if self._test_type == 'Fast':
+        if '_Fast' in self.__class__.__name__:
             return self.skipTest('Only run for Pure Python implementation')
 
         dar = datetime_module._divide_and_round
@@ -2853,7 +2853,7 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
         self.assertRaises(TypeError, t.strftime, "%Z")
 
         # Issue #6697:
-        if self._test_type == 'Fast':
+        if '_Fast' in self.__class__.__name__:
             Badtzname.tz = '\ud800'
             self.assertRaises(ValueError, t.strftime, "%Z")
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -61,7 +61,7 @@ class TestModule(unittest.TestCase):
         self.assertEqual(datetime.MAXYEAR, 9999)
 
     def test_name_cleanup(self):
-        if '_Fast' not in str(self):
+        if self._test_type == 'Pure':
             return
         datetime = datetime_module
         names = set(name for name in dir(datetime)
@@ -72,8 +72,9 @@ class TestModule(unittest.TestCase):
         self.assertEqual(names - allowed, set([]))
 
     def test_divide_and_round(self):
-        if '_Fast' in str(self):
+        if self._test_type == 'Fast':
             return
+
         dar = datetime_module._divide_and_round
 
         self.assertEqual(dar(-10, -3), 3)
@@ -2851,7 +2852,7 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
         self.assertRaises(TypeError, t.strftime, "%Z")
 
         # Issue #6697:
-        if '_Fast' in str(self):
+        if self._test_type == 'Fast':
             Badtzname.tz = '\ud800'
             self.assertRaises(ValueError, t.strftime, "%Z")
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -62,7 +62,8 @@ class TestModule(unittest.TestCase):
 
     def test_name_cleanup(self):
         if self._test_type == 'Pure':
-            return
+            return self.skipTest('Only run for Fast C implementation')
+
         datetime = datetime_module
         names = set(name for name in dir(datetime)
                     if not name.startswith('__') and not name.endswith('__'))
@@ -73,7 +74,7 @@ class TestModule(unittest.TestCase):
 
     def test_divide_and_round(self):
         if self._test_type == 'Fast':
-            return
+            return self.skipTest('Only run for Pure Python implementation')
 
         dar = datetime_module._divide_and_round
 

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -20,7 +20,7 @@ test_suffixes = ["_Pure", "_Fast"]
 # XXX(gb) First run all the _Pure tests, then all the _Fast tests.  You might
 # not believe this, but in spite of all the sys.modules trickery running a _Pure
 # test last will leave a mix of pure and native datetime stuff lying around.
-test_classes = []
+all_test_classes = []
 
 for module, suffix in zip(test_modules, test_suffixes):
     test_classes = []
@@ -46,9 +46,10 @@ for module, suffix in zip(test_modules, test_suffixes):
             sys.modules.update(cls_._save_sys_modules)
         cls.setUpClass = setUpClass
         cls.tearDownClass = tearDownClass
+    all_test_classes.extend(test_classes)
 
 def test_main():
-    run_unittest(*test_classes)
+    run_unittest(*all_test_classes)
 
 if __name__ == "__main__":
     test_main()

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -33,7 +33,8 @@ for module, suffix in zip(test_modules, test_suffixes):
             suit = cls()
             test_classes.extend(type(test) for test in suit)
     for cls in test_classes:
-        cls.__name__ = name + suffix
+        cls.__qualname__ += suffix
+        cls._test_type = suffix[1:]
         @classmethod
         def setUpClass(cls_, module=module):
             cls_._save_sys_modules = sys.modules.copy()

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -33,8 +33,8 @@ for module, suffix in zip(test_modules, test_suffixes):
             suit = cls()
             test_classes.extend(type(test) for test in suit)
     for cls in test_classes:
+        cls.__name__ += suffix
         cls.__qualname__ += suffix
-        cls._test_type = suffix[1:]
         @classmethod
         def setUpClass(cls_, module=module):
             cls_._save_sys_modules = sys.modules.copy()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1601,6 +1601,7 @@ Doobee R. Tzeck
 Eren Türkay
 Lionel Ulmer
 Adnan Umer
+Utkarsh Upadhyay
 Roger Upole
 Daniel Urban
 Michael Urman


### PR DESCRIPTION
On `master` and in versions 3.6 and 3.5, there is a bug in how certain tests are executed differently for the C extension and python extension. The execution of the tests (in `datetimetester.py`) depends on the following condition (or the negation thereof):

```python
if '_Fast' in str(self):
    # ...
```

The `cls.__name__` is modified in the `test_datetime.py` to be:

```python
    cls.__name__ = name + suffix   # suffix in ['_Fast', '_Pure']
```

However, `str(self)` to derives the class name from `cls.__qualname__` and not `cls.__name__`. This meant that `_Fast` was never in `str(self)` and, hence, some of the tests were being unnecessarily skipped (notably `test_name_cleanup`, which was failing).

This PR fixes the problem by clearly setting a string value on the class (`_test_type`) and then conditioning tests based on that value. Also, instead of editing the `__name__` of the class, the `__qualname__` is edited so that the tests show the correct variant of the test being run in verbose mode, which helps reduce confusion [1].

Also, on `master` and in version 3.6, there was another bug which prevented all tests from running because of an accidental resetting of the global variable `test_classes` inside a loop. That is fixed in a separate commit.

#1493 depends on this PR.

 - [x] Backport to 3.6
 - [x] Backport to 3.5

[1]: Example on [core-mentorship archives (accessible only to members)](https://mail.python.org/mailman/private/core-mentorship/2017-June/004086.html).