### PR TITLE
[2.7] bpo-30759: Fix test_multibytecodec_support

### DIFF
--- a/Lib/test/test_multibytecodec_support.py
+++ b/Lib/test/test_multibytecodec_support.py
@@ -256,7 +256,7 @@ class TestBase:
 
                 self.assertEqual(ostream.getvalue(), self.tstring[0])
 
-class TestBase_Mapping(unittest.TestCase):
+class TestBase_Mapping(object):
     pass_enctest = []
     pass_dectest = []
     supmaps = []


### PR DESCRIPTION
TestBase_Mapping doesn't inherit from unittest.TestCase anymore, but
object, since it's not a real test case but only a base base. All
child classes already inherit from unittest.TestCase.