### PR TITLE
[2.7] bpo-30759: Rename test_ file that is really a support file to remove test_prefix.

### DIFF
--- a/Lib/test/multibytecodec_support.py
+++ b/Lib/test/multibytecodec_support.py
@@ -1,4 +1,4 @@
-# test_multibytecodec_support.py
+# multibytecodec_support.py
 #   Common Unittest Routines for CJK codecs
 #
 

--- a/Lib/test/test_codecencodings_cn.py
+++ b/Lib/test/test_codecencodings_cn.py
@@ -4,12 +4,12 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class Test_GB2312(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_GB2312(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'gb2312'
-    tstring = test_multibytecodec_support.load_teststring('gb2312')
+    tstring = multibytecodec_support.load_teststring('gb2312')
     codectests = (
         # invalid bytes
         ("abc\x81\x81\xc1\xc4", "strict",  None),
@@ -20,9 +20,9 @@ class Test_GB2312(test_multibytecodec_support.TestBase, unittest.TestCase):
         ("\xc1\x64", "strict", None),
     )
 
-class Test_GBK(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_GBK(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'gbk'
-    tstring = test_multibytecodec_support.load_teststring('gbk')
+    tstring = multibytecodec_support.load_teststring('gbk')
     codectests = (
         # invalid bytes
         ("abc\x80\x80\xc1\xc4", "strict",  None),
@@ -34,9 +34,9 @@ class Test_GBK(test_multibytecodec_support.TestBase, unittest.TestCase):
         (u"\u30fb", "strict", None),
     )
 
-class Test_GB18030(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_GB18030(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'gb18030'
-    tstring = test_multibytecodec_support.load_teststring('gb18030')
+    tstring = multibytecodec_support.load_teststring('gb18030')
     codectests = (
         # invalid bytes
         ("abc\x80\x80\xc1\xc4", "strict",  None),
@@ -55,9 +55,9 @@ class Test_GB18030(test_multibytecodec_support.TestBase, unittest.TestCase):
     )
     has_iso10646 = True
 
-class Test_HZ(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_HZ(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'hz'
-    tstring = test_multibytecodec_support.load_teststring('hz')
+    tstring = multibytecodec_support.load_teststring('hz')
     codectests = (
         # test '~\n' (3 lines)
         (b'This sentence is in ASCII.\n'

--- a/Lib/test/test_codecencodings_hk.py
+++ b/Lib/test/test_codecencodings_hk.py
@@ -4,12 +4,12 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class Test_Big5HKSCS(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_Big5HKSCS(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'big5hkscs'
-    tstring = test_multibytecodec_support.load_teststring('big5hkscs')
+    tstring = multibytecodec_support.load_teststring('big5hkscs')
     codectests = (
         # invalid bytes
         ("abc\x80\x80\xc1\xc4", "strict",  None),

--- a/Lib/test/test_codecencodings_iso2022.py
+++ b/Lib/test/test_codecencodings_iso2022.py
@@ -1,7 +1,7 @@
 # Codec encoding tests for ISO 2022 encodings.
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
 COMMON_CODEC_TESTS = (
@@ -11,23 +11,23 @@ COMMON_CODEC_TESTS = (
         (b'ab\x1B$def', 'replace', u'ab\uFFFD'),
     )
 
-class Test_ISO2022_JP(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_ISO2022_JP(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'iso2022_jp'
-    tstring = test_multibytecodec_support.load_teststring('iso2022_jp')
+    tstring = multibytecodec_support.load_teststring('iso2022_jp')
     codectests = COMMON_CODEC_TESTS + (
         (b'ab\x1BNdef', 'replace', u'ab\x1BNdef'),
     )
 
-class Test_ISO2022_JP2(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_ISO2022_JP2(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'iso2022_jp_2'
-    tstring = test_multibytecodec_support.load_teststring('iso2022_jp')
+    tstring = multibytecodec_support.load_teststring('iso2022_jp')
     codectests = COMMON_CODEC_TESTS + (
         (b'ab\x1BNdef', 'replace', u'abdef'),
     )
 
-class Test_ISO2022_KR(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_ISO2022_KR(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'iso2022_kr'
-    tstring = test_multibytecodec_support.load_teststring('iso2022_kr')
+    tstring = multibytecodec_support.load_teststring('iso2022_kr')
     codectests = COMMON_CODEC_TESTS + (
         (b'ab\x1BNdef', 'replace', u'ab\x1BNdef'),
     )

--- a/Lib/test/test_codecencodings_jp.py
+++ b/Lib/test/test_codecencodings_jp.py
@@ -4,12 +4,12 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class Test_CP932(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_CP932(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'cp932'
-    tstring = test_multibytecodec_support.load_teststring('shift_jis')
+    tstring = multibytecodec_support.load_teststring('shift_jis')
     codectests = (
         # invalid bytes
         ("abc\x81\x00\x81\x00\x82\x84", "strict",  None),
@@ -22,10 +22,10 @@ class Test_CP932(test_multibytecodec_support.TestBase, unittest.TestCase):
         ("\x81\x5f\x81\x61\x81\x7c", "replace", u"\uff3c\u2225\uff0d"),
     )
 
-class Test_EUC_JISX0213(test_multibytecodec_support.TestBase,
+class Test_EUC_JISX0213(multibytecodec_support.TestBase,
                         unittest.TestCase):
     encoding = 'euc_jisx0213'
-    tstring = test_multibytecodec_support.load_teststring('euc_jisx0213')
+    tstring = multibytecodec_support.load_teststring('euc_jisx0213')
     codectests = (
         # invalid bytes
         ("abc\x80\x80\xc1\xc4", "strict",  None),
@@ -52,10 +52,10 @@ eucjp_commontests = (
     ("\xc1\x64", "strict", None),
 )
 
-class Test_EUC_JP_COMPAT(test_multibytecodec_support.TestBase,
+class Test_EUC_JP_COMPAT(multibytecodec_support.TestBase,
                          unittest.TestCase):
     encoding = 'euc_jp'
-    tstring = test_multibytecodec_support.load_teststring('euc_jp')
+    tstring = multibytecodec_support.load_teststring('euc_jp')
     codectests = eucjp_commontests + (
         ("\xa1\xc0\\", "strict", u"\uff3c\\"),
         (u"\xa5", "strict", "\x5c"),
@@ -70,17 +70,17 @@ shiftjis_commonenctests = (
     ("abc\x80\x80\x82\x84def", "ignore",  u"abc\uff44def"),
 )
 
-class Test_SJIS_COMPAT(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_SJIS_COMPAT(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'shift_jis'
-    tstring = test_multibytecodec_support.load_teststring('shift_jis')
+    tstring = multibytecodec_support.load_teststring('shift_jis')
     codectests = shiftjis_commonenctests + (
         ("\\\x7e", "strict", u"\\\x7e"),
         ("\x81\x5f\x81\x61\x81\x7c", "strict", u"\uff3c\u2016\u2212"),
     )
 
-class Test_SJISX0213(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_SJISX0213(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'shift_jisx0213'
-    tstring = test_multibytecodec_support.load_teststring('shift_jisx0213')
+    tstring = multibytecodec_support.load_teststring('shift_jisx0213')
     codectests = (
         # invalid bytes
         ("abc\x80\x80\x82\x84", "strict",  None),

--- a/Lib/test/test_codecencodings_kr.py
+++ b/Lib/test/test_codecencodings_kr.py
@@ -4,12 +4,12 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class Test_CP949(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_CP949(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'cp949'
-    tstring = test_multibytecodec_support.load_teststring('cp949')
+    tstring = multibytecodec_support.load_teststring('cp949')
     codectests = (
         # invalid bytes
         ("abc\x80\x80\xc1\xc4", "strict",  None),
@@ -19,9 +19,9 @@ class Test_CP949(test_multibytecodec_support.TestBase, unittest.TestCase):
         ("abc\x80\x80\xc1\xc4", "ignore",  u"abc\uc894"),
     )
 
-class Test_EUCKR(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_EUCKR(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'euc_kr'
-    tstring = test_multibytecodec_support.load_teststring('euc_kr')
+    tstring = multibytecodec_support.load_teststring('euc_kr')
     codectests = (
         # invalid bytes
         ("abc\x80\x80\xc1\xc4", "strict",  None),
@@ -49,9 +49,9 @@ class Test_EUCKR(test_multibytecodec_support.TestBase, unittest.TestCase):
         ("\xc1\xc4", "strict", u"\uc894"),
     )
 
-class Test_JOHAB(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_JOHAB(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'johab'
-    tstring = test_multibytecodec_support.load_teststring('johab')
+    tstring = multibytecodec_support.load_teststring('johab')
     codectests = (
         # invalid bytes
         ("abc\x80\x80\xc1\xc4", "strict",  None),

--- a/Lib/test/test_codecencodings_tw.py
+++ b/Lib/test/test_codecencodings_tw.py
@@ -4,12 +4,12 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class Test_Big5(test_multibytecodec_support.TestBase, unittest.TestCase):
+class Test_Big5(multibytecodec_support.TestBase, unittest.TestCase):
     encoding = 'big5'
-    tstring = test_multibytecodec_support.load_teststring('big5')
+    tstring = multibytecodec_support.load_teststring('big5')
     codectests = (
         # invalid bytes
         ("abc\x80\x80\xc1\xc4", "strict",  None),

--- a/Lib/test/test_codecmaps_cn.py
+++ b/Lib/test/test_codecmaps_cn.py
@@ -4,20 +4,20 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class TestGB2312Map(test_multibytecodec_support.TestBase_Mapping,
+class TestGB2312Map(multibytecodec_support.TestBase_Mapping,
                    unittest.TestCase):
     encoding = 'gb2312'
     mapfileurl = 'http://www.pythontest.net/unicode/EUC-CN.TXT'
 
-class TestGBKMap(test_multibytecodec_support.TestBase_Mapping,
+class TestGBKMap(multibytecodec_support.TestBase_Mapping,
                    unittest.TestCase):
     encoding = 'gbk'
     mapfileurl = 'http://www.pythontest.net/unicode/CP936.TXT'
 
-class TestGB18030Map(test_multibytecodec_support.TestBase_Mapping,
+class TestGB18030Map(multibytecodec_support.TestBase_Mapping,
                      unittest.TestCase):
     encoding = 'gb18030'
     mapfileurl = 'http://www.pythontest.net/unicode/gb-18030-2000.xml'

--- a/Lib/test/test_codecmaps_hk.py
+++ b/Lib/test/test_codecmaps_hk.py
@@ -4,10 +4,10 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class TestBig5HKSCSMap(test_multibytecodec_support.TestBase_Mapping,
+class TestBig5HKSCSMap(multibytecodec_support.TestBase_Mapping,
                        unittest.TestCase):
     encoding = 'big5hkscs'
     mapfileurl = 'http://www.pythontest.net/unicode/BIG5HKSCS-2004.TXT'

--- a/Lib/test/test_codecmaps_jp.py
+++ b/Lib/test/test_codecmaps_jp.py
@@ -4,10 +4,10 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class TestCP932Map(test_multibytecodec_support.TestBase_Mapping,
+class TestCP932Map(multibytecodec_support.TestBase_Mapping,
                    unittest.TestCase):
     encoding = 'cp932'
     mapfileurl = 'http://www.pythontest.net/unicode/CP932.TXT'
@@ -22,14 +22,14 @@ class TestCP932Map(test_multibytecodec_support.TestBase_Mapping,
         supmaps.append((chr(i), unichr(i+0xfec0)))
 
 
-class TestEUCJPCOMPATMap(test_multibytecodec_support.TestBase_Mapping,
+class TestEUCJPCOMPATMap(multibytecodec_support.TestBase_Mapping,
                          unittest.TestCase):
     encoding = 'euc_jp'
     mapfilename = 'EUC-JP.TXT'
     mapfileurl = 'http://www.pythontest.net/unicode/EUC-JP.TXT'
 
 
-class TestSJISCOMPATMap(test_multibytecodec_support.TestBase_Mapping,
+class TestSJISCOMPATMap(multibytecodec_support.TestBase_Mapping,
                         unittest.TestCase):
     encoding = 'shift_jis'
     mapfilename = 'SHIFTJIS.TXT'
@@ -43,14 +43,14 @@ class TestSJISCOMPATMap(test_multibytecodec_support.TestBase_Mapping,
         ('\x81_', u'\\'),
     ]
 
-class TestEUCJISX0213Map(test_multibytecodec_support.TestBase_Mapping,
+class TestEUCJISX0213Map(multibytecodec_support.TestBase_Mapping,
                          unittest.TestCase):
     encoding = 'euc_jisx0213'
     mapfilename = 'EUC-JISX0213.TXT'
     mapfileurl = 'http://www.pythontest.net/unicode/EUC-JISX0213.TXT'
 
 
-class TestSJISX0213Map(test_multibytecodec_support.TestBase_Mapping,
+class TestSJISX0213Map(multibytecodec_support.TestBase_Mapping,
                        unittest.TestCase):
     encoding = 'shift_jisx0213'
     mapfilename = 'SHIFT_JISX0213.TXT'

--- a/Lib/test/test_codecmaps_kr.py
+++ b/Lib/test/test_codecmaps_kr.py
@@ -4,16 +4,16 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class TestCP949Map(test_multibytecodec_support.TestBase_Mapping,
+class TestCP949Map(multibytecodec_support.TestBase_Mapping,
                    unittest.TestCase):
     encoding = 'cp949'
     mapfileurl = 'http://www.pythontest.net/unicode/CP949.TXT'
 
 
-class TestEUCKRMap(test_multibytecodec_support.TestBase_Mapping,
+class TestEUCKRMap(multibytecodec_support.TestBase_Mapping,
                    unittest.TestCase):
     encoding = 'euc_kr'
     mapfileurl = 'http://www.pythontest.net/unicode/EUC-KR.TXT'
@@ -23,7 +23,7 @@ class TestEUCKRMap(test_multibytecodec_support.TestBase_Mapping,
     pass_dectest = [('\xa4\xd4', u'\u3164')]
 
 
-class TestJOHABMap(test_multibytecodec_support.TestBase_Mapping,
+class TestJOHABMap(multibytecodec_support.TestBase_Mapping,
                    unittest.TestCase):
     encoding = 'johab'
     mapfileurl = 'http://www.pythontest.net/unicode/JOHAB.TXT'

--- a/Lib/test/test_codecmaps_tw.py
+++ b/Lib/test/test_codecmaps_tw.py
@@ -4,15 +4,15 @@
 #
 
 from test import test_support
-from test import test_multibytecodec_support
+from test import multibytecodec_support
 import unittest
 
-class TestBIG5Map(test_multibytecodec_support.TestBase_Mapping,
+class TestBIG5Map(multibytecodec_support.TestBase_Mapping,
                   unittest.TestCase):
     encoding = 'big5'
     mapfileurl = 'http://www.pythontest.net/unicode/BIG5.TXT'
 
-class TestCP950Map(test_multibytecodec_support.TestBase_Mapping,
+class TestCP950Map(multibytecodec_support.TestBase_Mapping,
                    unittest.TestCase):
     encoding = 'cp950'
     mapfileurl = 'http://www.pythontest.net/unicode/CP950.TXT'


### PR DESCRIPTION
I thought I had run the full test suite before the last checkin, but
obviously I didn't.  test_multibytecodec_support.py isn't really a test file,
it is a support file that contains a base test class.  Rename it to
multibytecodec_support so that regrtest test discovery doesn't think it is a
test file that should be run.
(cherry picked from commit 75d9aca97ad3c3d823d2f2211f579454b3216f51)