### PR TITLE
[2.7] bpo-29796: test_weakref: Fix collect_in_thread() on Windows

### DIFF
--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -58,7 +58,7 @@ class RefCycle:
 
 
 @contextlib.contextmanager
-def collect_in_thread(period=0.0001):
+def collect_in_thread(period=0.001):
     """
     Ensure GC collections happen in a different thread, at a high frequency.
     """


### PR DESCRIPTION
Sleep 1 ms instead of 0.1 ms to workaround a rounding issue on
Windows. On Windows, time.sleep(0.0001) sleeps 0 ms, so
collect_in_thread() calls gc.collect() in a loop and tests using this
thread takes too long. Sleep 1 ms so time.sleep() sleeps 15.6 ms on
Windows.