### PR TITLE
bpo-23835: Enforce that configparser defaults are strings

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -610,9 +610,6 @@ class RawConfigParser(MutableMapping):
         self._converters = ConverterMapping(self)
         self._proxies = self._dict()
         self._proxies[default_section] = SectionProxy(self, default_section)
-        if defaults:
-            for key, value in defaults.items():
-                self._defaults[self.optionxform(key)] = value
         self._delimiters = tuple(delimiters)
         if delimiters == ('=', ':'):
             self._optcre = self.OPTCRE_NV if allow_no_value else self.OPTCRE
@@ -637,6 +634,8 @@ class RawConfigParser(MutableMapping):
             self._interpolation = Interpolation()
         if converters is not _UNSET:
             self._converters.update(converters)
+        if defaults:
+            self.read_dict({default_section: defaults})
 
     def defaults(self):
         return self._defaults

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -857,8 +857,12 @@ boolean {0[0]} NO
 
     def test_defaults_keyword(self):
         # test that bpo-23835 is fixed
-        cf = self.newconfig(defaults={1:2.4})
-        cf = self.newconfig(defaults={"a":5.2})
+        cf = self.newconfig(defaults={1: 2.4})
+        self.assertEqual(cf['DEFAULT']['1'], '2.4')
+        self.assertAlmostEqual(cf['DEFAULT'].getfloat('1'), 2.4)
+        cf = self.newconfig(defaults={"A": 5.2})
+        self.assertEqual(cf['DEFAULT']['a'], '5.2')
+        self.assertAlmostEqual(cf['DEFAULT'].getfloat('a'), 5.2)
 
 
 class StrictTestCase(BasicTestCase, unittest.TestCase):

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -855,6 +855,11 @@ boolean {0[0]} NO
         self.assertEqual(cf.get('DEFAULT', 'test'), 'test')
         self.assertEqual(cf['DEFAULT']['test'], 'test')
 
+    def test_defaults_keyword(self):
+        # test that bpo-23835 is fixed
+        cf = self.newconfig(defaults={1:2.4})
+        cf = self.newconfig(defaults={"a":5.2})
+
 
 class StrictTestCase(BasicTestCase, unittest.TestCase):
     config_class = configparser.RawConfigParser

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -858,11 +858,11 @@ boolean {0[0]} NO
     def test_defaults_keyword(self):
         # test that bpo-23835 is fixed
         cf = self.newconfig(defaults={1: 2.4})
-        self.assertEqual(cf['DEFAULT']['1'], '2.4')
-        self.assertAlmostEqual(cf['DEFAULT'].getfloat('1'), 2.4)
+        self.assertEqual(cf[self.default_section]['1'], '2.4')
+        self.assertAlmostEqual(cf[self.default_section].getfloat('1'), 2.4)
         cf = self.newconfig(defaults={"A": 5.2})
-        self.assertEqual(cf['DEFAULT']['a'], '5.2')
-        self.assertAlmostEqual(cf['DEFAULT'].getfloat('a'), 5.2)
+        self.assertEqual(cf[self.default_section]['a'], '5.2')
+        self.assertAlmostEqual(cf[self.default_section].getfloat('a'), 5.2)
 
 
 class StrictTestCase(BasicTestCase, unittest.TestCase):


### PR DESCRIPTION
This is the patch attached to https://bugs.python.org/issue23835, updated to master.

<!-- issue-number: bpo-23835 -->
https://bugs.python.org/issue23835
<!-- /issue-number -->
