### PR TITLE
[2.7] Remove outdated FOX from GUI FAQ (GH-2538)

### DIFF
--- a/Doc/faq/gui.rst
+++ b/Doc/faq/gui.rst
@@ -70,15 +70,6 @@ Python bindings for `the FLTK toolkit <http://www.fltk.org>`_, a simple yet
 powerful and mature cross-platform windowing system, are available from `the
 PyFLTK project <http://pyfltk.sourceforge.net>`_.
 
-
-FOX
-----
-
-A wrapper for `the FOX toolkit <http://www.fox-toolkit.org/>`_ called `FXpy
-<http://fxpy.sourceforge.net/>`_ is available.  FOX supports both Unix variants
-and Windows.
-
-
 OpenGL
 ------
 


### PR DESCRIPTION
FXpy doesn't have a Python 3 port and it only
supports Python 2.2 and older versions.

Reported by Alex Walters on docs@p.o.

(cherry picked from commit d3ed2877a798d07df75422afe136b4727e500c99)