### PR TITLE
bpo-30845: Enhance test_concurrent_futures cleanup

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2079,7 +2079,6 @@ def reap_children():
     stick around to hog resources and create problems when looking
     for refleaks.
     """
-
     # Reap all our dead child processes so we don't leave zombies around.
     # These hog resources and might be causing some of the buildbots to die.
     if hasattr(os, 'waitpid'):
@@ -2090,6 +2089,8 @@ def reap_children():
                 pid, status = os.waitpid(any_process, os.WNOHANG)
                 if pid == 0:
                     break
+                print("Warning -- reap_children() reaped child process %s"
+                      % pid, file=sys.stderr)
             except:
                 break
 

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -63,6 +63,8 @@ class ExecutorMixin:
     worker_count = 5
 
     def setUp(self):
+        self._thread_cleanup = test.support.threading_setup()
+
         self.t1 = time.time()
         try:
             self.executor = self.executor_type(max_workers=self.worker_count)
@@ -72,10 +74,15 @@ class ExecutorMixin:
 
     def tearDown(self):
         self.executor.shutdown(wait=True)
+        self.executor = None
+
         dt = time.time() - self.t1
         if test.support.verbose:
             print("%.2fs" % dt, end=' ')
         self.assertLess(dt, 60, "synchronization issue: test lasted too long")
+
+        test.support.threading_cleanup(*self._thread_cleanup)
+        test.support.reap_children()
 
     def _prime_executor(self):
         # Make sure that the executor is ready to do work before running the


### PR DESCRIPTION
bpo-30845: reap_children() now logs warnings.