### PR TITLE
[3.6] bpo-30319: socket.close() now ignores ECONNRESET (#2565)

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-07-04-13-48-21.bpo-30319.hg_3TX.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-04-13-48-21.bpo-30319.hg_3TX.rst
@@ -1,0 +1,1 @@
+socket.close() now ignores ECONNRESET error.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2704,7 +2704,9 @@ sock_close(PySocketSockObject *s)
         Py_BEGIN_ALLOW_THREADS
         res = SOCKETCLOSE(fd);
         Py_END_ALLOW_THREADS
-        if (res < 0) {
+        /* bpo-30319: The peer can already have closed the connection.
+           Python ignores ECONNRESET on close(). */
+        if (res < 0 && errno != ECONNRESET) {
             return s->errorhandler();
         }
     }


### PR DESCRIPTION
socket.close() was modified in Python 3.6 to raise OSError on
failure: see bpo-26685.
(cherry picked from commit 67e1478dba6efe60b8e1890192014b8b06dd6bd9)