### PR TITLE
bpo-30854: Fix compile error when --without-threads

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-07-05-16-54-59.bpo-30854.sPADRI.rst
+++ b/Misc/NEWS.d/next/Build/2017-07-05-16-54-59.bpo-30854.sPADRI.rst
@@ -1,1 +1,2 @@
-Fix compile error when --without-threads
+Fix compile error when compiling --without-threads.
+Patch by Masayuki Yamamoto.

--- a/Misc/NEWS.d/next/Build/2017-07-05-16-54-59.bpo-30854.sPADRI.rst
+++ b/Misc/NEWS.d/next/Build/2017-07-05-16-54-59.bpo-30854.sPADRI.rst
@@ -1,0 +1,1 @@
+Fix compile error when --without-threads

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -548,7 +548,7 @@ Py_MakePendingCalls(void)
         arg = pendingcalls[i].arg;
         pendingfirst = (i + 1) % NPENDINGCALLS;
         if (func(arg) < 0) {
-            goto error:
+            goto error;
         }
     }
     busy = 0;


### PR DESCRIPTION
I found a syntax error when compiling without threads.  In that place, the colon has been used instead of semicolon at end of statement. I open one line change PR that replaces colon with semicolon for master branch.

related changeset:
- 3024c05 [3.6] bpo-30703: Improve signal delivery (GH-2415) (#2527)
- c08177a bpo-30703: Improve signal delivery (#2415)

https://bugs.python.org/issue30854