### PR TITLE
[3.6] bpo-30854: Fix compile error when --without-threads (GH-2581)

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-07-05-16-54-59.bpo-30854.sPADRI.rst
+++ b/Misc/NEWS.d/next/Build/2017-07-05-16-54-59.bpo-30854.sPADRI.rst
@@ -1,0 +1,2 @@
+Fix compile error when compiling --without-threads.
+Patch by Masayuki Yamamoto.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -621,7 +621,7 @@ Py_MakePendingCalls(void)
         arg = pendingcalls[i].arg;
         pendingfirst = (i + 1) % NPENDINGCALLS;
         if (func(arg) < 0) {
-            goto error:
+            goto error;
         }
     }
     busy = 0;


### PR DESCRIPTION
* bpo-30854: Fix compile error when --without-threads

* bpo-30854: fix news
(cherry picked from commit 0c3116309307ad2c7f8e2d2096612f4ab33cbb62)