### PR TITLE
[2.7] bpo-30850: Use specialized assert methods in bsddb tests.

### DIFF
--- a/Lib/bsddb/test/test_associate.py
+++ b/Lib/bsddb/test/test_associate.py
@@ -233,7 +233,7 @@ class AssociateTestCase(unittest.TestCase):
         self.assertEqual(vals, None, vals)
 
         vals = secDB.pget('Unknown', txn=txn)
-        self.assertTrue(vals[0] == 99 or vals[0] == '99', vals)
+        self.assertIn(vals[0], (99, '99'), vals)
         vals[1].index('Unknown')
         vals[1].index('Unnamed')
         vals[1].index('unknown')
@@ -247,7 +247,8 @@ class AssociateTestCase(unittest.TestCase):
             if type(self.keytype) == type(''):
                 self.assertTrue(int(rec[0]))  # for primary db, key is a number
             else:
-                self.assertTrue(rec[0] and type(rec[0]) == type(0))
+                self.assertTrue(rec[0])
+                self.assertIs(type(rec[0]), int)
             count = count + 1
             if verbose:
                 print rec
@@ -262,7 +263,7 @@ class AssociateTestCase(unittest.TestCase):
 
         # test cursor pget
         vals = self.cur.pget('Unknown', flags=db.DB_LAST)
-        self.assertTrue(vals[1] == 99 or vals[1] == '99', vals)
+        self.assertIn(vals[1], (99, '99'), vals)
         self.assertEqual(vals[0], 'Unknown')
         vals[2].index('Unknown')
         vals[2].index('Unnamed')

--- a/Lib/bsddb/test/test_basics.py
+++ b/Lib/bsddb/test/test_basics.py
@@ -597,7 +597,7 @@ class BasicTestCase(unittest.TestCase):
 
         d.put("abcde", "ABCDE");
         num = d.truncate()
-        self.assertTrue(num >= 1, "truncate returned <= 0 on non-empty database")
+        self.assertGreaterEqual(num, 1, "truncate returned <= 0 on non-empty database")
         num = d.truncate()
         self.assertEqual(num, 0,
                 "truncate on empty DB returned nonzero (%r)" % (num,))
@@ -616,9 +616,9 @@ class BasicTestCase(unittest.TestCase):
     if db.version() >= (4, 6):
         def test08_exists(self) :
             self.d.put("abcde", "ABCDE")
-            self.assertTrue(self.d.exists("abcde") == True,
+            self.assertEqual(self.d.exists("abcde"), True,
                     "DB->exists() returns wrong value")
-            self.assertTrue(self.d.exists("x") == False,
+            self.assertEqual(self.d.exists("x"), False,
                     "DB->exists() returns wrong value")
 
     #----------------------------------------
@@ -773,7 +773,7 @@ class BasicTransactionTestCase(BasicTestCase):
             if verbose:
                 print 'log file: ' + log
             logs = self.env.log_archive(db.DB_ARCH_REMOVE)
-            self.assertTrue(not logs)
+            self.assertFalse(logs)
 
         self.txn = self.env.txn_begin()
 
@@ -785,9 +785,9 @@ class BasicTransactionTestCase(BasicTestCase):
             self.d.put("abcde", "ABCDE", txn=txn)
             txn.commit()
             txn = self.env.txn_begin()
-            self.assertTrue(self.d.exists("abcde", txn=txn) == True,
+            self.assertEqual(self.d.exists("abcde", txn=txn), True,
                     "DB->exists() returns wrong value")
-            self.assertTrue(self.d.exists("x", txn=txn) == False,
+            self.assertEqual(self.d.exists("x", txn=txn), False,
                     "DB->exists() returns wrong value")
             txn.abort()
 
@@ -802,7 +802,7 @@ class BasicTransactionTestCase(BasicTestCase):
         d.put("abcde", "ABCDE");
         txn = self.env.txn_begin()
         num = d.truncate(txn)
-        self.assertTrue(num >= 1, "truncate returned <= 0 on non-empty database")
+        self.assertGreaterEqual(num, 1, "truncate returned <= 0 on non-empty database")
         num = d.truncate(txn)
         self.assertEqual(num, 0,
                 "truncate on empty DB returned nonzero (%r)" % (num,))
@@ -1086,7 +1086,7 @@ class PrivateObject(unittest.TestCase) :
         a = "example of private object"
         self.obj.set_private(a)
         b = self.obj.get_private()
-        self.assertTrue(a is b)  # Object identity
+        self.assertIs(a, b)  # Object identity
 
     def test03_leak_assignment(self) :
         a = "example of private object"

--- a/Lib/bsddb/test/test_dbshelve.py
+++ b/Lib/bsddb/test/test_dbshelve.py
@@ -248,7 +248,7 @@ class DBShelveTestCase(unittest.TestCase):
             self.assertEqual(value.L, [x] * 10)
 
         else:
-            self.assertTrue(0, 'Unknown key type, fix the test')
+            self.fail('Unknown key type, fix the test')
 
 #----------------------------------------------------------------------
 

--- a/Lib/bsddb/test/test_dbtables.py
+++ b/Lib/bsddb/test/test_dbtables.py
@@ -82,8 +82,8 @@ class TableDBTestCase(unittest.TestCase):
             colval = pickle.loads(values[0][colname])
         else :
             colval = pickle.loads(bytes(values[0][colname], "iso8859-1"))
-        self.assertTrue(colval > 3.141)
-        self.assertTrue(colval < 3.142)
+        self.assertGreater(colval, 3.141)
+        self.assertLess(colval, 3.142)
 
 
     def test02(self):

--- a/Lib/bsddb/test/test_distributed_transactions.py
+++ b/Lib/bsddb/test/test_distributed_transactions.py
@@ -79,7 +79,7 @@ class DBTxn_distributed(unittest.TestCase):
         recovered_txns=self.dbenv.txn_recover()
         self.assertEqual(self.num_txns,len(recovered_txns))
         for gid,txn in recovered_txns :
-            self.assertTrue(gid in txns)
+            self.assertIn(gid, txns)
         del txn
         del recovered_txns
 
@@ -122,7 +122,7 @@ class DBTxn_distributed(unittest.TestCase):
     # Be sure there are not pending transactions.
     # Check also database size.
         recovered_txns=self.dbenv.txn_recover()
-        self.assertTrue(len(recovered_txns)==0)
+        self.assertEqual(len(recovered_txns), 0)
         self.assertEqual(len(committed_txns),self.db.stat()["nkeys"])
 
 class DBTxn_distributedSYNC(DBTxn_distributed):

--- a/Lib/bsddb/test/test_lock.py
+++ b/Lib/bsddb/test/test_lock.py
@@ -129,7 +129,7 @@ class LockingTestCase(unittest.TestCase):
         end_time=time.time()
         deadlock_detection.end=True
         # Floating point rounding
-        self.assertTrue((end_time-start_time) >= 0.0999)
+        self.assertGreaterEqual(end_time-start_time, 0.0999)
         self.env.lock_put(lock)
         t.join()
 
@@ -137,7 +137,7 @@ class LockingTestCase(unittest.TestCase):
         self.env.lock_id_free(anID2)
 
         if db.version() >= (4,6):
-            self.assertTrue(deadlock_detection.count>0)
+            self.assertGreater(deadlock_detection.count, 0)
 
     def theThread(self, lockType):
         import sys

--- a/Lib/bsddb/test/test_misc.py
+++ b/Lib/bsddb/test/test_misc.py
@@ -25,7 +25,7 @@ class MiscTestCase(unittest.TestCase):
     def test02_db_home(self):
         env = db.DBEnv()
         # check for crash fixed when db_home is used before open()
-        self.assertTrue(env.db_home is None)
+        self.assertIsNone(env.db_home)
         env.open(self.homeDir, db.DB_CREATE)
         if sys.version_info[0] < 3 :
             self.assertEqual(self.homeDir, env.db_home)

--- a/Lib/bsddb/test/test_recno.py
+++ b/Lib/bsddb/test/test_recno.py
@@ -18,7 +18,7 @@ class SimpleRecnoTestCase(unittest.TestCase):
         def assertIsInstance(self, obj, datatype, msg=None) :
             return self.assertEqual(type(obj), datatype, msg=msg)
         def assertGreaterEqual(self, a, b, msg=None) :
-            return self.assertTrue(a>=b, msg=msg)
+            return self.assertGreaterEqual(a, b, msg=msg)
 
 
     def setUp(self):

--- a/Lib/bsddb/test/test_replication.py
+++ b/Lib/bsddb/test/test_replication.py
@@ -186,20 +186,18 @@ class DBReplicationManager(DBReplication) :
         d = d.values()[0]  # There is only one
         self.assertEqual(d[0], "127.0.0.1")
         self.assertEqual(d[1], client_port)
-        self.assertTrue((d[2]==db.DB_REPMGR_CONNECTED) or \
-                (d[2]==db.DB_REPMGR_DISCONNECTED))
+        self.assertIn(d[2], (db.DB_REPMGR_CONNECTED, db.DB_REPMGR_DISCONNECTED))
 
         d = self.dbenvClient.repmgr_site_list()
         self.assertEqual(len(d), 1)
         d = d.values()[0]  # There is only one
         self.assertEqual(d[0], "127.0.0.1")
         self.assertEqual(d[1], master_port)
-        self.assertTrue((d[2]==db.DB_REPMGR_CONNECTED) or \
-                (d[2]==db.DB_REPMGR_DISCONNECTED))
+        self.assertIn(d[2], (db.DB_REPMGR_CONNECTED, db.DB_REPMGR_DISCONNECTED))
 
         if db.version() >= (4,6) :
             d = self.dbenvMaster.repmgr_stat(flags=db.DB_STAT_CLEAR);
-            self.assertTrue("msgs_queued" in d)
+            self.assertIn("msgs_queued", d)
 
         self.dbMaster=db.DB(self.dbenvMaster)
         txn=self.dbenvMaster.txn_begin()
@@ -247,7 +245,7 @@ class DBReplicationManager(DBReplication) :
         if time.time()>=timeout and startup_timeout:
             self.skipTest("replication test skipped due to random failure, "
                 "see issue 3892")
-        self.assertTrue(time.time()<timeout)
+        self.assertLess(time.time(), timeout)
         self.assertEqual("123", v)
 
         txn=self.dbenvMaster.txn_begin()
@@ -260,7 +258,7 @@ class DBReplicationManager(DBReplication) :
             txn.commit()
             if v is None :
                 time.sleep(0.02)
-        self.assertTrue(time.time()<timeout)
+        self.assertLess(time.time(), timeout)
         self.assertEqual(None, v)
 
 class DBBaseReplication(DBReplication) :
@@ -381,7 +379,7 @@ class DBBaseReplication(DBReplication) :
         while (time.time()<timeout) and not (self.confirmed_master and
                 self.client_startupdone) :
             time.sleep(0.02)
-        self.assertTrue(time.time()<timeout)
+        self.assertLess(time.time(), timeout)
 
         self.dbMaster=db.DB(self.dbenvMaster)
         txn=self.dbenvMaster.txn_begin()
@@ -410,7 +408,7 @@ class DBBaseReplication(DBReplication) :
             break
 
         d = self.dbenvMaster.rep_stat(flags=db.DB_STAT_CLEAR);
-        self.assertTrue("master_changes" in d)
+        self.assertIn("master_changes", d)
 
         txn=self.dbenvMaster.txn_begin()
         self.dbMaster.put("ABC", "123", txn=txn)
@@ -424,7 +422,7 @@ class DBBaseReplication(DBReplication) :
             txn.commit()
             if v is None :
                 time.sleep(0.02)
-        self.assertTrue(time.time()<timeout)
+        self.assertLess(time.time(), timeout)
         self.assertEqual("123", v)
 
         txn=self.dbenvMaster.txn_begin()
@@ -437,7 +435,7 @@ class DBBaseReplication(DBReplication) :
             txn.commit()
             if v is None :
                 time.sleep(0.02)
-        self.assertTrue(time.time()<timeout)
+        self.assertLess(time.time(), timeout)
         self.assertEqual(None, v)
 
     if db.version() >= (4,7) :

--- a/Lib/bsddb/test/test_sequence.py
+++ b/Lib/bsddb/test/test_sequence.py
@@ -82,7 +82,7 @@ class DBSequenceTest(unittest.TestCase):
         stat = self.seq.stat()
         for param in ('nowait', 'min', 'max', 'value', 'current',
                       'flags', 'cache_size', 'last_value', 'wait'):
-            self.assertTrue(param in stat, "parameter %s isn't in stat info" % param)
+            self.assertIn(param, stat, "parameter %s isn't in stat info" % param)
 
     if db.version() >= (4,7) :
         # This code checks a crash solved in Berkeley DB 4.7

--- a/Lib/bsddb/test/test_thread.py
+++ b/Lib/bsddb/test/test_thread.py
@@ -85,7 +85,7 @@ class ConcurrentDataStoreBase(BaseThreadedTestCase):
         readers_per_writer=self.readers//self.writers
         self.assertEqual(self.records,self.writers*records_per_writer)
         self.assertEqual(self.readers,self.writers*readers_per_writer)
-        self.assertTrue((records_per_writer%readers_per_writer)==0)
+        self.assertEqual(records_per_writer%readers_per_writer, 0)
         readers = []
 
         for x in xrange(self.readers):
@@ -213,7 +213,7 @@ class SimpleThreadedBase(BaseThreadedTestCase):
         readers_per_writer=self.readers//self.writers
         self.assertEqual(self.records,self.writers*records_per_writer)
         self.assertEqual(self.readers,self.writers*readers_per_writer)
-        self.assertTrue((records_per_writer%readers_per_writer)==0)
+        self.assertEqual(records_per_writer%readers_per_writer, 0)
 
         readers = []
         for x in xrange(self.readers):
@@ -339,7 +339,7 @@ class ThreadedTransactionsBase(BaseThreadedTestCase):
         readers_per_writer=self.readers//self.writers
         self.assertEqual(self.records,self.writers*records_per_writer)
         self.assertEqual(self.readers,self.writers*readers_per_writer)
-        self.assertTrue((records_per_writer%readers_per_writer)==0)
+        self.assertEqual(records_per_writer%readers_per_writer, 0)
 
         readers=[]
         for x in xrange(self.readers):

--- a/Lib/test/test_bsddb.py
+++ b/Lib/test/test_bsddb.py
@@ -172,7 +172,7 @@ class TestBSDDB(unittest.TestCase):
 
     def test_first_while_deleting(self):
         # Test for bug 1725856
-        self.assertTrue(len(self.d) >= 2, "test requires >=2 items")
+        self.assertGreaterEqual(len(self.d), 2, "test requires >=2 items")
         for _ in self.d:
             key = self.f.first()[0]
             del self.f[key]
@@ -180,7 +180,7 @@ class TestBSDDB(unittest.TestCase):
 
     def test_last_while_deleting(self):
         # Test for bug 1725856's evil twin
-        self.assertTrue(len(self.d) >= 2, "test requires >=2 items")
+        self.assertGreaterEqual(len(self.d), 2, "test requires >=2 items")
         for _ in self.d:
             key = self.f.last()[0]
             del self.f[key]
@@ -197,7 +197,7 @@ class TestBSDDB(unittest.TestCase):
     def test_has_key(self):
         for k in self.d:
             self.assertTrue(self.f.has_key(k))
-        self.assertTrue(not self.f.has_key('not here'))
+        self.assertFalse(self.f.has_key('not here'))
 
     def test_clear(self):
         self.f.clear()
@@ -271,7 +271,7 @@ class TestBSDDB(unittest.TestCase):
 
         self.assertEqual(nc1, nc2)
         self.assertEqual(nc1, nc4)
-        self.assertTrue(nc3 == nc1+1)
+        self.assertEqual(nc3, nc1+1)
 
     def test_popitem(self):
         k, v = self.f.popitem()


### PR DESCRIPTION
This provides more information on test failures.