### PR TITLE
[3.5] bpo-30855: Trying to fix test_use on Windows.

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -854,8 +854,7 @@ class Misc:
             self.tk.call('winfo', 'height', self._w))
     def winfo_id(self):
         """Return identifier ID for this widget."""
-        return self.tk.getint(
-            self.tk.call('winfo', 'id', self._w))
+        return int(self.tk.call('winfo', 'id', self._w), 0)
     def winfo_interps(self, displayof=0):
         """Return the name of all Tcl interpreters for this display."""
         args = ('winfo', 'interps') + self._displayof(displayof)

--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -91,9 +91,10 @@ class ToplevelTest(AbstractToplevelTest, unittest.TestCase):
         widget = self.create()
         self.assertEqual(widget['use'], '')
         parent = self.create(container=True)
-        wid = parent.winfo_id()
-        widget2 = self.create(use=wid)
-        self.assertEqual(int(widget2['use']), wid)
+        wid = hex(parent.winfo_id())
+        with self.subTest(wid=wid):
+            widget2 = self.create(use=wid)
+            self.assertEqual(widget2['use'], wid)
 
 
 @add_standard_options(StandardOptionsTests)


### PR DESCRIPTION
Avoid possible weird behavior of WideInt convertion.
"winfo id" always returns string hexadecimal representation.

(cherry picked from commit b9d672491d5082c541bf267eb7bb99fdc6529324)