### PR TITLE
StreamHandler.__repr__: ensure that stream.name is a string

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -999,7 +999,7 @@ class StreamHandler(Handler):
 
     def __repr__(self):
         level = getLevelName(self.level)
-        name = getattr(self.stream, 'name', '')
+        name = str(getattr(self.stream, 'name', ''))
         if name:
             name += ' '
         return '<%s %s(%s)>' % (self.__class__.__name__, name, level)


### PR DESCRIPTION
This fixes a TypeError in case the `name` is a integer.

Ref: https://github.com/pytest-dev/pytest/issues/2555