### PR TITLE
bpo-30861: Return StreamReeader remaining buffer before raise excepiton

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -516,7 +516,7 @@ class StreamReader:
         if seplen == 0:
             raise ValueError('Separator should be at least one-byte string')
 
-        if self._exception is not None:
+        if self._exception is not None and not self._buffer:
             raise self._exception
 
         # Consume whole buffer except last bytes, which length is
@@ -571,6 +571,11 @@ class StreamReader:
                 self._buffer.clear()
                 raise IncompleteReadError(chunk, None)
 
+            # All data that was in the buffer has been returned, if there is
+            # an exception dont wait and just raise the exception.
+            if self._exception is not None:
+                raise self._exception
+
             # _wait_for_data() will resume reading if stream was paused.
             yield from self._wait_for_data('readuntil')
 
@@ -606,7 +611,15 @@ class StreamReader:
         """
 
         if self._exception is not None:
-            raise self._exception
+            # If some data came into the buffer and its
+            # still pending to be proccessed return it but
+            # just raise the last exception.
+            if self._buffer and n > 0:
+                data = bytes(self._buffer[:n])
+                del self._buffer[:n]
+                return data
+            else:
+                raise self._exception
 
         if n == 0:
             return b''


### PR DESCRIPTION
The current implementation of StreamReader does not take care of the status of the buffer, once an exception has been set via `set_exception` any call to the read methods won't be able to get the missing data still pending to be processed.

From the point of view of the developer, if there is no scheduled task for waiting for data into the Streamreader between a network data gets into the buffer socket and a closing connection by the other peer arrives, the developer won't be able to gather the previous data.

This PR take care first of the remaining buffer and try to return first to the user, and only when the buffer has run out raises the proper exception