### PR TITLE
Make test_shutil test_disk_usage not depend on the cwd filesystem.

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1304,7 +1304,7 @@ class TestShutil(unittest.TestCase):
     @unittest.skipUnless(hasattr(shutil, 'disk_usage'),
                          "disk_usage not available on this platform")
     def test_disk_usage(self):
-        usage = shutil.disk_usage(__file__)
+        usage = shutil.disk_usage(os.path.dirname(__file__))
         self.assertGreater(usage.total, 0)
         self.assertGreater(usage.used, 0)
         self.assertGreaterEqual(usage.free, 0)

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1304,12 +1304,12 @@ class TestShutil(unittest.TestCase):
     @unittest.skipUnless(hasattr(shutil, 'disk_usage'),
                          "disk_usage not available on this platform")
     def test_disk_usage(self):
-        usage = shutil.disk_usage(os.getcwd())
+        usage = shutil.disk_usage(__file__)
         self.assertGreater(usage.total, 0)
-        self.assertGreaterEqual(usage.used, 0)
+        self.assertGreater(usage.used, 0)
         self.assertGreaterEqual(usage.free, 0)
         self.assertGreaterEqual(usage.total, usage.used)
-        self.assertGreaterEqual(usage.total, usage.free)
+        self.assertGreater(usage.total, usage.free)
 
     @unittest.skipUnless(UID_GID_SUPPORT, "Requires grp and pwd support")
     @unittest.skipUnless(hasattr(os, 'chown'), 'requires os.chown')

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1306,10 +1306,10 @@ class TestShutil(unittest.TestCase):
     def test_disk_usage(self):
         usage = shutil.disk_usage(os.getcwd())
         self.assertGreater(usage.total, 0)
-        self.assertGreater(usage.used, 0)
+        self.assertGreaterEqual(usage.used, 0)
         self.assertGreaterEqual(usage.free, 0)
         self.assertGreaterEqual(usage.total, usage.used)
-        self.assertGreater(usage.total, usage.free)
+        self.assertGreaterEqual(usage.total, usage.free)
 
     @unittest.skipUnless(UID_GID_SUPPORT, "Requires grp and pwd support")
     @unittest.skipUnless(hasattr(os, 'chown'), 'requires os.chown')


### PR DESCRIPTION
Don't assume so much about the test execution environment's getcwd()
filesystem space usage reports.