### PR TITLE
[3.5] Fix case in .gitignore (GH-2607)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ PCbuild/*.VC.opendb
 PCbuild/.vs/
 PCbuild/amd64/
 PCbuild/obj/
-PCBuild/win32/
+PCbuild/win32/
 .purify
 Parser/pgen
 __pycache__


### PR DESCRIPTION
(cherry picked from commit be5ebe58776a02d53bcf5e43ab946b555c0e025f)