### PR TITLE
gh-74973: fix proxy works uncorrectly if registry value end with a semicolon

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -2710,6 +2710,8 @@ elif os.name == 'nt':
             if test == '<local>':
                 if '.' not in rawHost:
                     return 1
+            if test == '':
+                continue
             test = test.replace(".", r"\.")     # mask dots
             test = test.replace("*", r".*")     # change glob sequence
             test = test.replace("?", r".")      # change glob char


### PR DESCRIPTION
The function proxy_bypass_registry will return 1 if registry value end
with a semicolon because a NULL string will be contained in the variable
proxyOverride while using proxyOverride.split(';'). And therefore, our
proxy will never work correctly.

<!-- gh-issue-number: gh-74973 -->
* Issue: gh-74973
<!-- /gh-issue-number -->
