### PR TITLE
[3.6] bpo-30779: IDLE -- Factor ConfigChanges class from configdialog…

### DIFF
--- a/Lib/idlelib/idle_test/test_config.py
+++ b/Lib/idlelib/idle_test/test_config.py
@@ -9,12 +9,13 @@ from idlelib import config
 
 # Tests should not depend on fortuitous user configurations.
 # They must not affect actual user .cfg files.
-# Replace user parsers with empty parsers that cannot be saved.
+# Replace user parsers with empty parsers that cannot be saved
+# due to getting '' as the filename when created.
 
 idleConf = config.idleConf
 usercfg = idleConf.userCfg
 testcfg = {}
-usermain = testcfg['main'] = config.IdleUserConfParser('')  # filename
+usermain = testcfg['main'] = config.IdleUserConfParser('')
 userhigh = testcfg['highlight'] = config.IdleUserConfParser('')
 userkeys = testcfg['keys'] = config.IdleUserConfParser('')
 
@@ -134,6 +135,87 @@ class CurrentColorKeysTest(unittest.TestCase):
         self.assertEqual(self.colorkeys('Keys'), 'Custom Keys')
         usermain.remove_section('Keys')
         userkeys.remove_section('Custom Keys')
+
+
+class ChangesTest(unittest.TestCase):
+
+    empty = {'main':{}, 'highlight':{}, 'keys':{}, 'extensions':{}}
+
+    def load(self):  # Test_add_option verifies that this works.
+        changes = self.changes
+        changes.add_option('main', 'Msec', 'mitem', 'mval')
+        changes.add_option('highlight', 'Hsec', 'hitem', 'hval')
+        changes.add_option('keys', 'Ksec', 'kitem', 'kval')
+        return changes
+
+    loaded = {'main': {'Msec': {'mitem': 'mval'}},
+              'highlight': {'Hsec': {'hitem': 'hval'}},
+              'keys': {'Ksec': {'kitem':'kval'}},
+              'extensions': {}}
+
+    def setUp(self):
+        self.changes = config.ConfigChanges()
+
+    def test_init(self):
+        self.assertEqual(self.changes, self.empty)
+
+    def test_add_option(self):
+        changes = self.load()
+        self.assertEqual(changes, self.loaded)
+        changes.add_option('main', 'Msec', 'mitem', 'mval')
+        self.assertEqual(changes, self.loaded)
+
+    def test_save_option(self):  # Static function does not touch changes.
+        save_option = self.changes.save_option
+        self.assertTrue(save_option('main', 'Indent', 'what', '0'))
+        self.assertFalse(save_option('main', 'Indent', 'what', '0'))
+        self.assertEqual(usermain['Indent']['what'], '0')
+
+        self.assertTrue(save_option('main', 'Indent', 'use-spaces', '0'))
+        self.assertEqual(usermain['Indent']['use-spaces'], '0')
+        self.assertTrue(save_option('main', 'Indent', 'use-spaces', '1'))
+        self.assertFalse(usermain.has_option('Indent', 'use-spaces'))
+        usermain.remove_section('Indent')
+
+    def test_save_added(self):
+        changes = self.load()
+        changes.save_all()
+        self.assertEqual(usermain['Msec']['mitem'], 'mval')
+        self.assertEqual(userhigh['Hsec']['hitem'], 'hval')
+        self.assertEqual(userkeys['Ksec']['kitem'], 'kval')
+        usermain.remove_section('Msec')
+        userhigh.remove_section('Hsec')
+        userkeys.remove_section('Ksec')
+
+    def test_save_help(self):
+        changes = self.changes
+        changes.save_option('main', 'HelpFiles', 'IDLE', 'idledoc')
+        changes.add_option('main', 'HelpFiles', 'ELDI', 'codeldi')
+        changes.save_all()
+        self.assertFalse(usermain.has_option('HelpFiles', 'IDLE'))
+        self.assertTrue(usermain.has_option('HelpFiles', 'ELDI'))
+
+    def test_save_default(self):  # Cover 2nd and 3rd false branches.
+        changes = self.changes
+        changes.add_option('main', 'Indent', 'use-spaces', '1')
+        # save_option returns False; cfg_type_changed remains False.
+
+    # TODO: test that save_all calls usercfg Saves.
+
+    def test_delete_section(self):
+        changes = self.load()
+        changes.delete_section('main', 'fake')  # Test no exception.
+        self.assertEqual(changes, self.loaded)  # Test nothing deleted.
+        for cfgtype, section in (('main', 'Msec'), ('keys', 'Ksec')):
+            changes.delete_section(cfgtype, section)
+            with self.assertRaises(KeyError):
+                changes[cfgtype][section]  # Test section gone.
+        # TODO Test change to userkeys and maybe save call.
+
+    def test_clear(self):
+        changes = self.load()
+        changes.clear()
+        self.assertEqual(changes, self.empty)
 
 
 class WarningTest(unittest.TestCase):

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -3,7 +3,7 @@
 Half the class creates dialog, half works with user customizations.
 Coverage: 46% just by creating dialog, 56% with current tests.
 """
-from idlelib.configdialog import ConfigDialog, idleConf  # test import
+from idlelib.configdialog import ConfigDialog, idleConf, changes
 from test.support import requires
 requires('gui')
 from tkinter import Tk
@@ -21,17 +21,13 @@ testcfg = {
     'extensions': config.IdleUserConfParser(''),
 }
 
-# ConfigDialog.changed_items is a 3-level hierarchical dictionary of
-# pending changes that mirrors the multilevel user config dict.
-# For testing, record args in a list for comparison with expected.
-changes = []
 root = None
 configure = None
+mainpage = changes['main']
+highpage = changes['highlight']
+keyspage = changes['keys']
 
-
-class TestDialog(ConfigDialog):
-    def add_changed_item(self, *args):
-        changes.append(args)
+class TestDialog(ConfigDialog): pass  # Delete?
 
 
 def setUpModule():
@@ -63,31 +59,28 @@ class FontTabTest(unittest.TestCase):
         default_size = str(default_font[1])
         default_bold = default_font[2] == 'bold'
         configure.font_name.set('Test Font')
-        expected = [
-            ('main', 'EditorWindow', 'font', 'Test Font'),
-            ('main', 'EditorWindow', 'font-size', default_size),
-            ('main', 'EditorWindow', 'font-bold', default_bold)]
-        self.assertEqual(changes, expected)
+        expected = {'EditorWindow': {'font': 'Test Font',
+                                     'font-size': default_size,
+                                     'font-bold': str(default_bold)}}
+        self.assertEqual(mainpage, expected)
         changes.clear()
         configure.font_size.set(20)
-        expected = [
-            ('main', 'EditorWindow', 'font', 'Test Font'),
-            ('main', 'EditorWindow', 'font-size', '20'),
-            ('main', 'EditorWindow', 'font-bold', default_bold)]
-        self.assertEqual(changes, expected)
+        expected = {'EditorWindow': {'font': 'Test Font',
+                                     'font-size': '20',
+                                     'font-bold': str(default_bold)}}
+        self.assertEqual(mainpage, expected)
         changes.clear()
         configure.font_bold.set(not default_bold)
-        expected = [
-            ('main', 'EditorWindow', 'font', 'Test Font'),
-            ('main', 'EditorWindow', 'font-size', '20'),
-            ('main', 'EditorWindow', 'font-bold', not default_bold)]
-        self.assertEqual(changes, expected)
+        expected = {'EditorWindow': {'font': 'Test Font',
+                                     'font-size': '20',
+                                     'font-bold': str(not default_bold)}}
+        self.assertEqual(mainpage, expected)
 
     #def test_sample(self): pass  # TODO
 
     def test_tabspace(self):
         configure.space_num.set(6)
-        self.assertEqual(changes, [('main', 'Indent', 'num-spaces', 6)])
+        self.assertEqual(mainpage, {'Indent': {'num-spaces': '6'}})
 
 
 class HighlightTest(unittest.TestCase):
@@ -111,19 +104,19 @@ class GeneralTest(unittest.TestCase):
 
     def test_startup(self):
         configure.radio_startup_edit.invoke()
-        self.assertEqual(changes,
-                         [('main', 'General', 'editor-on-startup', 1)])
+        self.assertEqual(mainpage,
+                         {'General': {'editor-on-startup': '1'}})
 
     def test_autosave(self):
         configure.radio_save_auto.invoke()
-        self.assertEqual(changes, [('main', 'General', 'autosave', 1)])
+        self.assertEqual(mainpage, {'General': {'autosave': '1'}})
 
     def test_editor_size(self):
         configure.entry_win_height.insert(0, '1')
-        self.assertEqual(changes, [('main', 'EditorWindow', 'height', '140')])
+        self.assertEqual(mainpage, {'EditorWindow': {'height': '140'}})
         changes.clear()
         configure.entry_win_width.insert(0, '1')
-        self.assertEqual(changes, [('main', 'EditorWindow', 'width', '180')])
+        self.assertEqual(mainpage, {'EditorWindow': {'width': '180'}})
 
     #def test_help_sources(self): pass  # TODO
 


### PR DESCRIPTION
…, put in config; test. (GH-2612)

* In config, put dump test code in a function; run it and unittest in 'if __name__ == '__main__'.
* Add class config.ConfigChanges based on changes_class_v4.py on bpo issue.
* Add class test_config.ChangesTest, partly based on configdialog_tests_v1.py on bpo issue.
* Revise configdialog to use ConfigChanges, mostly as specified in tracker msg297804.
* Revise test_configdialog to match configdialog changes.  All tests pass in both files.
* Remove configdialog functions unused or moved to ConfigChanges.
Cheryl Sabella contributed parts of the patch.
(cherry picked from commit 349abd9)