### PR TITLE
[3.6] bpo-8231: Call idlelib.IdleConf.GetUserCfgDir only once. (GH-2629)

### DIFF
--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -172,10 +172,10 @@ class IdleConf:
         "Populate default and user config parser dictionaries."
         #build idle install path
         if __name__ != '__main__': # we were imported
-            idleDir=os.path.dirname(__file__)
+            idleDir = os.path.dirname(__file__)
         else: # we were exec'ed (for testing only)
-            idleDir=os.path.abspath(sys.path[0])
-        userDir=self.GetUserCfgDir()
+            idleDir = os.path.abspath(sys.path[0])
+        self.userdir = userDir = self.GetUserCfgDir()
 
         defCfgFiles = {}
         usrCfgFiles = {}

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -103,8 +103,8 @@ class EditorWindow(object):
             self.tkinter_vars = {}  # keys: Tkinter event names
                                     # values: Tkinter variable instances
             self.top.instance_dict = {}
-        self.recent_files_path = os.path.join(idleConf.GetUserCfgDir(),
-                'recent-files.lst')
+        self.recent_files_path = os.path.join(
+                idleConf.userdir, 'recent-files.lst')
         self.text_frame = text_frame = Frame(top)
         self.vbar = vbar = Scrollbar(text_frame, name='vbar')
         self.width = idleConf.GetOption('main', 'EditorWindow',

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -117,8 +117,8 @@ class PyShellEditorWindow(EditorWindow):
         self.text.bind("<<clear-breakpoint-here>>", self.clear_breakpoint_here)
         self.text.bind("<<open-python-shell>>", self.flist.open_shell)
 
-        self.breakpointPath = os.path.join(idleConf.GetUserCfgDir(),
-                                           'breakpoints.lst')
+        self.breakpointPath = os.path.join(
+                idleConf.userdir, 'breakpoints.lst')
         # whenever a file is changed, restore breakpoints
         def filename_changed_hook(old_hook=self.io.filename_change_hook,
                                   self=self):

--- a/Misc/NEWS.d/next/IDLE/2017-07-07-21-10-55.bpo-8231.yEge3L.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-07-07-21-10-55.bpo-8231.yEge3L.rst
@@ -1,0 +1,1 @@
+IDLE: call config.IdleConf.GetUserCfgDir only once.


### PR DESCRIPTION
(cherry picked from commit 223c7e7)