### PR TITLE
bpo-30879: os.listdir() and os.scandir() now emit bytes names when

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3411,9 +3411,22 @@ class TestScandir(unittest.TestCase):
     def test_bytes(self):
         self.create_file("file.txt")
 
-        for cls in bytes, bytearray, memoryview:
+        path_bytes = os.fsencode(self.path)
+        entries = list(os.scandir(path_bytes))
+        self.assertEqual(len(entries), 1, entries)
+        entry = entries[0]
+
+        self.assertEqual(entry.name, b'file.txt')
+        self.assertEqual(entry.path,
+                         os.fsencode(os.path.join(self.path, 'file.txt')))
+
+    def test_bytes_like(self):
+        self.create_file("file.txt")
+
+        for cls in bytearray, memoryview:
             path_bytes = cls(os.fsencode(self.path))
-            entries = list(os.scandir(path_bytes))
+            with self.assertWarns(DeprecationWarning):
+                entries = list(os.scandir(path_bytes))
             self.assertEqual(len(entries), 1, entries)
             entry = entries[0]
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3411,14 +3411,17 @@ class TestScandir(unittest.TestCase):
     def test_bytes(self):
         self.create_file("file.txt")
 
-        path_bytes = os.fsencode(self.path)
-        entries = list(os.scandir(path_bytes))
-        self.assertEqual(len(entries), 1, entries)
-        entry = entries[0]
+        for cls in bytes, bytearray, memoryview:
+            path_bytes = cls(os.fsencode(self.path))
+            entries = list(os.scandir(path_bytes))
+            self.assertEqual(len(entries), 1, entries)
+            entry = entries[0]
 
-        self.assertEqual(entry.name, b'file.txt')
-        self.assertEqual(entry.path,
-                         os.fsencode(os.path.join(self.path, 'file.txt')))
+            self.assertEqual(entry.name, b'file.txt')
+            self.assertEqual(entry.path,
+                             os.fsencode(os.path.join(self.path, 'file.txt')))
+            self.assertIs(type(entry.name), bytes)
+            self.assertIs(type(entry.path), bytes)
 
     @unittest.skipUnless(os.listdir in os.supports_fd,
                          'fd support for listdir required for this test.')

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -653,9 +653,12 @@ class PosixTester(unittest.TestCase):
     def test_listdir_bytes(self):
         # When listdir is called with a bytes object,
         # the returned strings are of type bytes.
-        # Bytes-like objects are supported too.
-        for cls in bytes, bytearray, memoryview:
-            names = posix.listdir(cls(b'.'))
+        self.assertIn(os.fsencode(support.TESTFN), posix.listdir(b'.'))
+
+    def test_listdir_bytes_like(self):
+        for cls in bytearray, memoryview:
+            with self.assertWarns(DeprecationWarning):
+                names = posix.listdir(cls(b'.'))
             self.assertIn(os.fsencode(support.TESTFN), names)
             for name in names:
                 self.assertIs(type(name), bytes)

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -643,17 +643,22 @@ class PosixTester(unittest.TestCase):
         self.assertRaises(OSError, posix.chdir, support.TESTFN)
 
     def test_listdir(self):
-        self.assertTrue(support.TESTFN in posix.listdir(os.curdir))
+        self.assertIn(support.TESTFN, posix.listdir(os.curdir))
 
     def test_listdir_default(self):
         # When listdir is called without argument,
         # it's the same as listdir(os.curdir).
-        self.assertTrue(support.TESTFN in posix.listdir())
+        self.assertIn(support.TESTFN, posix.listdir())
 
     def test_listdir_bytes(self):
         # When listdir is called with a bytes object,
         # the returned strings are of type bytes.
-        self.assertTrue(os.fsencode(support.TESTFN) in posix.listdir(b'.'))
+        # Bytes-like objects are supported too.
+        for cls in bytes, bytearray, memoryview:
+            names = posix.listdir(cls(b'.'))
+            self.assertIn(os.fsencode(support.TESTFN), names)
+            for name in names:
+                self.assertIs(type(name), bytes)
 
     @unittest.skipUnless(posix.listdir in os.supports_fd,
                          "test needs fd support for posix.listdir()")

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -376,6 +376,9 @@ Extension Modules
 Library
 -------
 
+- bpo-30879: os.listdir() and os.scandir() now emit bytes names when called
+  with bytes-like argument.
+
 - bpo-30746: Prohibited the '=' character in environment variable names in
   ``os.putenv()`` and ``os.spawn*()``.
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -3588,8 +3588,8 @@ _posix_listdir(path_t *path, PyObject *list)
         const char *name;
         if (path->narrow) {
             name = path->narrow;
-            /* only return bytes if they specified a bytes object */
-            return_str = !(PyBytes_Check(path->object));
+            /* only return bytes if they specified a bytes-like object */
+            return_str = !PyObject_CheckBuffer(path->object);
         }
         else {
             name = ".";
@@ -11842,7 +11842,7 @@ DirEntry_from_posix_info(path_t *path, const char *name, Py_ssize_t name_len,
             goto error;
     }
 
-    if (!path->narrow || !PyBytes_Check(path->object)) {
+    if (!path->narrow || !PyObject_CheckBuffer(path->object)) {
         entry->name = PyUnicode_DecodeFSDefaultAndSize(name, name_len);
         if (joined_path)
             entry->path = PyUnicode_DecodeFSDefault(joined_path);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1037,6 +1037,8 @@ path_converter(PyObject *o, void *p)
         Py_INCREF(bytes);
     }
     else if (is_buffer) {
+        /* XXX Replace PyObject_CheckBuffer with PyBytes_Check in other code
+           after removing suport of non-bytes buffer objects. */
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
             "%s%s%s should be %s, not %.200s",
             path->function_name ? path->function_name : "",


### PR DESCRIPTION
called with bytes-like argument.