### PR TITLE
[2.7] bpo-29854: Fix segfault in call_readline()

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-07-07-02-18-57.bpo-29854.J8wKb_.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-07-02-18-57.bpo-29854.J8wKb_.rst
@@ -1,0 +1,2 @@
+Fix segfault in readline when using readline's history-size option.  Patch
+by Nir Soffer.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1161,15 +1161,17 @@ call_readline(FILE *sys_stdin, FILE *sys_stdout, char *prompt)
     if (n > 0) {
         const char *line;
         int length = _py_get_history_length();
-        if (length > 0)
+        if (length > 0) {
+            HIST_ENTRY *hist_ent;
 #ifdef __APPLE__
             if (using_libedit_emulation) {
                 /* handle older 0-based or newer 1-based indexing */
-                line = history_get(length + libedit_history_start - 1)->line;
+                hist_ent = history_get(length + libedit_history_start - 1);
             } else
 #endif /* __APPLE__ */
-            line = history_get(length)->line;
-        else
+                hist_ent = history_get(length);
+            line = hist_ent ? hist_ent->line : "";
+        } else
             line = "";
         if (strcmp(p, line))
             add_history(p);


### PR DESCRIPTION
Tested on Fedora 25, FreeBSD 10.3, FreeBSD 11.0.

On OS X 10.11.6, python 2.7 builds without readline since configure fail to find rl_resize_terminal in -lreadline, so I could not test it.

@berkerpeksag, @haypo please review.

(cherry picked from commit fae8f4a9cb88a68eb14750cbb8ddf8740fd67b8b)