### PR TITLE
[3.5] bpo-30886: Fix multiprocessing.Queue.join_thread() (#2642)

### DIFF
--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -169,14 +169,7 @@ class Queue(object):
         self._thread.start()
         debug('... done self._thread.start()')
 
-        # On process exit we will wait for data to be flushed to pipe.
-        #
-        # However, if this process created the queue then all
-        # processes which use the queue will be descendants of this
-        # process.  Therefore waiting for the queue to be flushed
-        # is pointless once all the child processes have been joined.
-        created_by_this_process = (self._opid == os.getpid())
-        if not self._joincancelled and not created_by_this_process:
+        if not self._joincancelled:
             self._jointhread = Finalize(
                 self._thread, Queue._finalize_join,
                 [weakref.ref(self._thread)],

--- a/Misc/NEWS.d/next/Library/2017-07-10-12-14-22.bpo-30886.nqQj34.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-10-12-14-22.bpo-30886.nqQj34.rst
@@ -1,0 +1,3 @@
+Fix multiprocessing.Queue.join_thread(): it now waits until the thread
+completes, even if the thread was started by the same process which created
+the queue.


### PR DESCRIPTION
multiprocessing.Queue.join_thread() now waits until the thread
completes, even if the thread was started by the same process which
created the queue.

Fix the following warning which occurs randomly when running
test_handle_called_with_mp_queue of test_logging.QueueListenerTest:

Warning -- threading_cleanup() failed to cleanup -1 threads after 4 sec (count: 0, dangling: 1)
(cherry picked from commit 3b69d911c57ef591ac0c0f47a66dbcad8337f33a)