### PR TITLE
[3.6] bpo-30892: Fix _elementtree module initialization (#2647)

### DIFF
--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3947,6 +3947,11 @@ PyInit__elementtree(void)
     st->deepcopy_obj = PyObject_GetAttrString(temp, "deepcopy");
     Py_XDECREF(temp);
 
+    if (st->deepcopy_obj == NULL) {
+        return NULL;
+    }
+
+    assert(!PyErr_Occurred());
     if (!(st->elementpath_obj = PyImport_ImportModule("xml.etree.ElementPath")))
         return NULL;
 


### PR DESCRIPTION
Handle getattr(copy, 'deepcopy') error in _elementtree module
initialization.
(cherry picked from commit b136f11f3a51f9282ae992bac68f170ca5563b55)