### PR TITLE
bpo-28879 : add date if missing in smtplib.send_message

### DIFF
--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -496,7 +496,9 @@ An :class:`SMTP` instance has the following methods:
    specified in :rfc:`5322`\: *from_addr* is set to the :mailheader:`Sender`
    field if it is present, and otherwise to the :mailheader:`From` field.
    *to_addrs* combines the values (if any) of the :mailheader:`To`,
-   :mailheader:`Cc`, and :mailheader:`Bcc` fields from *msg*.  If exactly one
+   :mailheader:`Cc`, and :mailheader:`Bcc` fields from *msg*.  If there's no 
+   *Date* header inside the message, ``send_message`` will add one to the data.
+   If exactly one
    set of :mailheader:`Resent-*` headers appear in the message, the regular
    headers are ignored and the :mailheader:`Resent-*` headers are used instead.
    If the message contains more than one set of :mailheader:`Resent-*` headers,

--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -496,7 +496,7 @@ An :class:`SMTP` instance has the following methods:
    specified in :rfc:`5322`\: *from_addr* is set to the :mailheader:`Sender`
    field if it is present, and otherwise to the :mailheader:`From` field.
    *to_addrs* combines the values (if any) of the :mailheader:`To`,
-   :mailheader:`Cc`, and :mailheader:`Bcc` fields from *msg*.  If there's no 
+   :mailheader:`Cc`, and :mailheader:`Bcc` fields from *msg*.  If there's no
    *Date* header inside the message, ``send_message`` will add one to the data.
    If exactly one
    set of :mailheader:`Resent-*` headers appear in the message, the regular

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -928,6 +928,12 @@ class SMTP:
             header_prefix = 'Resent-'
         else:
             raise ValueError("message has more than one 'Resent-' header block")
+        
+        # RFC 5322 section 3.6, 4th Paragraph
+        if msg.get('Date',None) is None:
+            msg['Date'] = email.utils.formatdate()
+        
+        
         if from_addr is None:
             # Prefer the sender field per RFC 2822:3.6.2.
             from_addr = (msg[header_prefix + 'Sender']

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -928,12 +928,11 @@ class SMTP:
             header_prefix = 'Resent-'
         else:
             raise ValueError("message has more than one 'Resent-' header block")
-        
+
         # RFC 5322 section 3.6, 4th Paragraph
         if msg.get('Date',None) is None:
             msg['Date'] = email.utils.formatdate()
-        
-        
+
         if from_addr is None:
             # Prefer the sender field per RFC 2822:3.6.2.
             from_addr = (msg[header_prefix + 'Sender']

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -930,7 +930,7 @@ class SMTP:
             raise ValueError("message has more than one 'Resent-' header block")
 
         # RFC 5322 section 3.6, 4th Paragraph
-        if msg.get('Date',None) is None:
+        if msg.get('Date', None) is None:
             msg['Date'] = email.utils.formatdate()
 
         if from_addr is None:

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -17,6 +17,7 @@ import errno
 import textwrap
 
 import unittest
+from unittest.mock import patch
 from test import support, mock_socket
 
 try:
@@ -549,7 +550,10 @@ class DebuggingServerTests(unittest.TestCase):
             smtp.send_message(m)
         smtp.close()
 
-    def testSendMessageAddDateIfMissing(self):
+    @patch('email.utils.formatdate')
+    def testSendMessageAddDateIfMissing(self, mocked_date_obj):
+        current_date = 'Thu, 1 Jan 1970 17:42:00 +0000'
+        mocked_date_obj.return_value = current_date
         m = email.mime.text.MIMEText('A test message')
         m['From'] = 'foo@bar.com'
         m['To'] = 'John'
@@ -572,8 +576,7 @@ class DebuggingServerTests(unittest.TestCase):
         mexpect = '%s%s\n%s' % (MSG_BEGIN, m.as_string(), MSG_END)
         self.assertEqual(self.output.getvalue(), mexpect)
         debugout = smtpd.DEBUGSTREAM.getvalue()
-        current_moment = email.utils.formatdate()
-        Date = re.compile(''.join(("\\\\nDate: ",current_moment[:16])),re.MULTILINE)
+        Date = re.compile(''.join(("\\\\nDate: ", current_date)), re.MULTILINE)
         self.assertRegex(debugout, Date)
 
 

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -577,8 +577,6 @@ class DebuggingServerTests(unittest.TestCase):
         self.assertRegex(debugout, Date)
 
 
-
-
 class NonConnectingTests(unittest.TestCase):
 
     def testNotConnected(self):

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -576,7 +576,7 @@ class DebuggingServerTests(unittest.TestCase):
         mexpect = '%s%s\n%s' % (MSG_BEGIN, m.as_string(), MSG_END)
         self.assertEqual(self.output.getvalue(), mexpect)
         debugout = smtpd.DEBUGSTREAM.getvalue()
-        Date = re.compile(''.join(("\\\\nDate: ", current_date)), re.MULTILINE)
+        Date = re.compile(''.join(("\\nDate: ", current_date)), re.MULTILINE)
         self.assertRegex(debugout, Date)
 
 

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -549,6 +549,36 @@ class DebuggingServerTests(unittest.TestCase):
             smtp.send_message(m)
         smtp.close()
 
+    def testSendMessageAddDateIfMissing(self):
+        m = email.mime.text.MIMEText('A test message')
+        m['From'] = 'foo@bar.com'
+        m['To'] = 'John'
+        m['CC'] = 'Sally, Fred'
+        m['Bcc'] = 'John Root <root@localhost>, "Dinsdale" <warped@silly.walks.com>'
+        smtp = smtplib.SMTP(HOST, self.port, local_hostname='localhost', timeout=3)
+        smtp.send_message(m)
+        # XXX (see comment in testSend)
+        time.sleep(0.01)
+        smtp.quit()
+
+        self.client_evt.set()
+        self.serv_evt.wait()
+        self.output.flush()
+        # The Resent-Bcc headers are deleted before serialization.
+        del m['Bcc']
+        del m['Resent-Bcc']
+        # Add the X-Peer header that DebuggingServer adds
+        m['X-Peer'] = socket.gethostbyname('localhost')
+        mexpect = '%s%s\n%s' % (MSG_BEGIN, m.as_string(), MSG_END)
+        self.assertEqual(self.output.getvalue(), mexpect)
+        debugout = smtpd.DEBUGSTREAM.getvalue()
+        current_moment = email.utils.formatdate()
+        Date = re.compile(''.join(("\\\\nDate: ",current_moment[:16])),re.MULTILINE)
+        self.assertRegex(debugout, Date)
+
+
+
+
 class NonConnectingTests(unittest.TestCase):
 
     def testNotConnected(self):

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -576,7 +576,7 @@ class DebuggingServerTests(unittest.TestCase):
         mexpect = '%s%s\n%s' % (MSG_BEGIN, m.as_string(), MSG_END)
         self.assertEqual(self.output.getvalue(), mexpect)
         debugout = smtpd.DEBUGSTREAM.getvalue()
-        Date = re.compile(''.join(("\\nDate: ", current_date)), re.MULTILINE)
+        Date = re.compile(''.join(("\\\\nDate: ", re.escape(current_date))), re.MULTILINE)
         self.assertRegex(debugout, Date)
 
 

--- a/Misc/NEWS.d/next/Library/2018-01-13-15-52-00.bpo-28879.aW2gj0.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-13-15-52-00.bpo-28879.aW2gj0.rst
@@ -1,0 +1,2 @@
+Fix ``smtplib.send_message`` to add Date header if it is missing as per
+RFC5322.


### PR DESCRIPTION
Hi I've tried to change the patch submitted on bpo-28879 to be on a github PR.

It's my first time contributing through PR, please let me know what I did wrong.

Regards,
Eric Lafontaine

<!-- issue-number: bpo-28879 -->
https://bugs.python.org/issue28879
<!-- /issue-number -->
