### PR TITLE
bpo-30900: IDLE: Fix configdialog should use wm_withdraw

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -47,7 +47,7 @@ class ConfigDialog(Toplevel):
         self.parent = parent
         if _htest:
             parent.instance_dict = {}
-        self.withdraw()
+        self.wm_withdraw()
 
         self.configure(borderwidth=5)
         self.title(title or 'IDLE Preferences')


### PR DESCRIPTION
This should also be backported to 3.6, since #2307 has been backported to 3.6, too.