### PR TITLE
bpo-30779: IDLE: fix delete_section calls in configdialog

### DIFF
--- a/Lib/idlelib/config.py
+++ b/Lib/idlelib/config.py
@@ -794,7 +794,8 @@ class ConfigChanges(dict):
         add_option: Add option and value to changes.
         save_option: Save option and value to config parser.
         save_all: Save all the changes to the config parser and file.
-        delete_section: Delete section if it exists.
+        delete_section: If section exists,
+                        delete from changes, userCfg, and file.
         clear: Clear all changes by clearing each page.
     """
     def __init__(self):

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -839,7 +839,7 @@ class ConfigDialog(Toplevel):
             return
         self.deactivate_current_config()
         # Remove key set from changes, config, and file.
-        changes.remove(keyset_name)
+        changes.delete_section('keys', keyset_name)
         # Reload user key set list.
         item_list = idleConf.GetSectionList('user', 'keys')
         item_list.sort()
@@ -873,7 +873,7 @@ class ConfigDialog(Toplevel):
             return
         self.deactivate_current_config()
         # Remove theme from changes, config, and file.
-        changes.delete_section('highlight')
+        changes.delete_section('highlight', theme_name)
         # Reload user theme list.
         item_list = idleConf.GetSectionList('user', 'highlight')
         item_list.sort()

--- a/Lib/idlelib/idle_test/test_config.py
+++ b/Lib/idlelib/idle_test/test_config.py
@@ -188,6 +188,7 @@ class ChangesTest(unittest.TestCase):
         userkeys.remove_section('Ksec')
 
     def test_save_help(self):
+        # Any change to HelpFiles overwrites entire section.
         changes = self.changes
         changes.save_option('main', 'HelpFiles', 'IDLE', 'idledoc')
         changes.add_option('main', 'HelpFiles', 'ELDI', 'codeldi')
@@ -207,10 +208,12 @@ class ChangesTest(unittest.TestCase):
         changes.delete_section('main', 'fake')  # Test no exception.
         self.assertEqual(changes, self.loaded)  # Test nothing deleted.
         for cfgtype, section in (('main', 'Msec'), ('keys', 'Ksec')):
+            testcfg[cfgtype].SetOption(section, 'name', 'value')
             changes.delete_section(cfgtype, section)
             with self.assertRaises(KeyError):
-                changes[cfgtype][section]  # Test section gone.
-        # TODO Test change to userkeys and maybe save call.
+                changes[cfgtype][section]  # Test section gone from changes
+                testcfg[cfgtype][section]  # and from mock userCfg.
+        # TODO test for save call.
 
     def test_clear(self):
         changes = self.load()


### PR DESCRIPTION
changes.delete_section requires 2 parameters, so I was receiving an error message when trying to delete a custom theme.