### PR TITLE
Use `with open(...)` in `dump_stats`

### DIFF
--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -82,10 +82,9 @@ class Profile(_lsprof.Profiler):
 
     def dump_stats(self, file):
         import marshal
-        f = open(file, 'wb')
         self.create_stats()
-        marshal.dump(self.stats, f)
-        f.close()
+        with open(file, 'wb') as f:
+            marshal.dump(self.stats, f)
 
     def create_stats(self):
         self.disable()


### PR DESCRIPTION
I've been getting a bunch of Bad File Descriptor errors the last few days from the `f.close()` call at the end of `dump_stats`. Fixed it locally by patching `dump_stats` as above.

This change has already been made in [3.6](https://github.com/python/cpython/blob/master/Lib/cProfile.py#L46).