### PR TITLE
bpo-30797: Avoid _GNU_SOURCE redefined warning in xmlparse.c

### DIFF
--- a/Modules/expat/xmlparse.c
+++ b/Modules/expat/xmlparse.c
@@ -4,7 +4,7 @@
    77fea421d361dca90041d0040ecf1dca651167fadf2af79e990e35168d70d933 (2.2.1+)
 */
 
-#define _GNU_SOURCE                     /* syscall prototype */
+#define _GNU_SOURCE 1                   /* syscall prototype */
 
 #include <stddef.h>
 #include <string.h>                     /* memset(), memcpy() */


### PR DESCRIPTION
cc @ned-deily 

Same as: https://github.com/python/cpython/commit/05b72ede95521b2d897cb4c7b034139b5437c592 but for 3.7. Also in 3.5 and 2.7. I can submit back port pull requests if you wish.