### PR TITLE
[3.5] bpo-30797: Avoid _GNU_SOURCE redefined warning in xmlparse.c (GH-2670)

### DIFF
--- a/Modules/expat/xmlparse.c
+++ b/Modules/expat/xmlparse.c
@@ -4,7 +4,7 @@
    77fea421d361dca90041d0040ecf1dca651167fadf2af79e990e35168d70d933 (2.2.1+)
 */
 
-#define _GNU_SOURCE                     /* syscall prototype */
+#define _GNU_SOURCE 1                   /* syscall prototype */
 
 #include <stddef.h>
 #include <string.h>                     /* memset(), memcpy() */


### PR DESCRIPTION
(cherry picked from commit f52325598e7a9683787d76a42009fc16790a0089)

@haypo 