### PR TITLE
bpo-30908: Fix dangling thread in test_os.TestSendfile

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2639,6 +2639,7 @@ class TestSendfile(unittest.TestCase):
         self.client.close()
         if self.server.running:
             self.server.stop()
+        self.server = None
 
     def sendfile_wrapper(self, sock, file, offset, nbytes, headers=[], trailers=[]):
         """A higher level wrapper representing how an application is


### PR DESCRIPTION
tearDown() now clears explicitly the self.server variable to make
sure that the thread is completely cleared when tearDownClass()
checks if all threads have been cleaned up.

Fix the following warning:

$ ./python -m test --fail-env-changed -m test.test_os.TestSendfile.test_keywords -R 3:1 test_os
(...)
Warning -- threading_cleanup() failed to cleanup 0 threads after 3 sec (count: 0, dangling: 2)
(...)
Tests result: ENV CHANGED