### PR TITLE
bpo-30910 - Add fexceptions to ppc64le build

### DIFF
--- a/configure
+++ b/configure
@@ -6017,6 +6017,10 @@ then
 	    SCO_SV*) OPT="$OPT -m486 -DSCO5"
 	    ;;
         esac
+        case $(uname -m) in
+            ppc64le) OPT="$OPT -fexceptions"
+            ;;
+        esac
 	;;
 
     *)


### PR DESCRIPTION
The -fexception flag is needed to correctly deal with exceptions in code that is written in both C and C++.