### PR TITLE
bpo-29571 - test_re needs en_US.iso88591 locale check in test_locale_flag()

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -1479,6 +1479,12 @@ class ReTests(unittest.TestCase):
     def test_locale_flag(self):
         import locale
         _, enc = locale.getlocale(locale.LC_CTYPE)
+        for loc in 'en_US.iso88591', 'en_US.utf8':
+            try:
+                locale.setlocale(locale.LC_CTYPE, loc)
+            except locale.Error:
+                # Unsupported locale on this system
+                self.skipTest('test needs %s locale' % loc)
         # Search non-ASCII letter
         for i in range(128, 256):
             try:


### PR DESCRIPTION
The fix proposes to add a check for en_US.iso88591 in test_localeflag. This should fix test_re for languages like en_IN till another fix is done, which is requiring a lot of code.
The error for en_IN locale and some others can also be found here :- https://hastebin.com/ecabuvovuj.sql