### PR TITLE
bpo-30911: Add tests for bad boolean arguments for accelerated json

### DIFF
--- a/Lib/test/test_json/test_speedups.py
+++ b/Lib/test/test_json/test_speedups.py
@@ -1,6 +1,11 @@
 from test.test_json import CTest
 
 
+class BadBool:
+    def __bool__(self):
+        1/0
+
+
 class TestSpeedups(CTest):
     def test_scanstring(self):
         self.assertEqual(self.json.decoder.scanstring.__module__, "_json")
@@ -17,8 +22,25 @@ class TestDecode(CTest):
     def test_make_scanner(self):
         self.assertRaises(AttributeError, self.json.scanner.c_make_scanner, 1)
 
+    def test_bad_bool_args(self):
+        def test(value):
+            self.json.decoder.JSONDecoder(strict=BadBool()).decode(value)
+        self.assertRaises(ZeroDivisionError, test, '""')
+        self.assertRaises(ZeroDivisionError, test, '{}')
+
+
+class TestEncode(CTest):
     def test_make_encoder(self):
         self.assertRaises(TypeError, self.json.encoder.c_make_encoder,
             (True, False),
             b"\xCD\x7D\x3D\x4E\x12\x4C\xF9\x79\xD7\x52\xBA\x82\xF2\x27\x4A\x7D\xA0\xCA\x75",
             None)
+
+    def test_bad_bool_args(self):
+        def test(name):
+            self.json.encoder.JSONEncoder(**{name: BadBool()}).encode({'a': 1})
+        self.assertRaises(ZeroDivisionError, test, 'skipkeys')
+        self.assertRaises(ZeroDivisionError, test, 'ensure_ascii')
+        self.assertRaises(ZeroDivisionError, test, 'check_circular')
+        self.assertRaises(ZeroDivisionError, test, 'allow_nan')
+        self.assertRaises(ZeroDivisionError, test, 'sort_keys')


### PR DESCRIPTION
encoder and decoder.