### PR TITLE
[2.7] bpo-29766: Fix configure/.ac to match LTO/enable-optimizations behavior.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1383,7 +1383,6 @@ if test "$Py_OPT" = 'true' ; then
   # compile working code using it and both test_distutils and test_gdb are
   # broken when you do managed to get a toolchain that works with it.  People
   # who want LTO need to use --with-lto themselves.
-  Py_LTO='true'
   DEF_MAKE_ALL_RULE="profile-opt"
   REQUIRE_PGO="yes"
   DEF_MAKE_RULE="build_all"


### PR DESCRIPTION
This should fix https://bugs.python.org/issue29766#msg297996.

See also #1858 and 1f29cefc87c4c2ee629367ebe97a287d8e0b3e29.