### PR TITLE
bpo-30931: Ensure the right socket is retrieved in asyncore

### DIFF
--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -801,7 +801,6 @@ class BaseTestAPI:
             if t.is_alive():
                 self.fail("join() timed out")
 
-    @unittest.expectedFailure
     def test_map_altered_in_loop(self):
         family = self.family
         fail = self.fail


### PR DESCRIPTION


<!-- issue-number: [bpo-30931](https://bugs.python.org/issue30931) -->
https://bugs.python.org/issue30931
<!-- /issue-number -->
