### PR TITLE
bpo-30836: fix test_c_locale_coercion on AIX

### DIFF
--- a/Lib/test/test_c_locale_coercion.py
+++ b/Lib/test/test_c_locale_coercion.py
@@ -17,7 +17,14 @@ from test.support.script_helper import (
 
 # Set our expectation for the default encoding used in the C locale
 # for the filesystem encoding and the standard streams
-C_LOCALE_STREAM_ENCODING = "ascii"
+
+# AIX uses latin-1 in the C locale, other *nix platforms use ASCII
+if sys.platform.startswith("aix"):
+    C_LOCALE_STREAM_ENCODING = "latin-1"
+else:
+    C_LOCALE_STREAM_ENCODING = "ascii"
+
+# FS encoding is UTF-8 on macOS, other *nix platforms use the locale encoding
 if sys.platform == "darwin":
     C_LOCALE_FS_ENCODING = "utf-8"
 else:

--- a/Lib/test/test_c_locale_coercion.py
+++ b/Lib/test/test_c_locale_coercion.py
@@ -18,9 +18,9 @@ from test.support.script_helper import (
 # Set our expectation for the default encoding used in the C locale
 # for the filesystem encoding and the standard streams
 
-# AIX uses latin-1 in the C locale, other *nix platforms use ASCII
+# AIX uses iso8859-1 in the C locale, other *nix platforms use ASCII
 if sys.platform.startswith("aix"):
-    C_LOCALE_STREAM_ENCODING = "latin-1"
+    C_LOCALE_STREAM_ENCODING = "iso8859-1"
 else:
     C_LOCALE_STREAM_ENCODING = "ascii"
 


### PR DESCRIPTION
AIX uses latin-1 in the C locale, not ASCII

AIX doesn't currently provide any of the locale
coercion locales, but we leave locale coercion
enabled in case one gets added in the future.