### PR TITLE
bpo-30971: Improve code readability of json.tool

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -25,22 +25,22 @@ def main():
                         help='a JSON file to be validated or pretty-printed')
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
                         help='write the output of infile to outfile')
-    parser.add_argument('--sort-keys', action='store_true', default=False,
-                        help='sort the output of dictionaries alphabetically by key')
+    parser.add_argument('--sort-keys', action='store_true',
+                        help='sort dictionary outputs alphabetically by key')
     options = parser.parse_args()
 
+    # Read input JSON
     infile = options.infile or sys.stdin
-    outfile = options.outfile or sys.stdout
     sort_keys = options.sort_keys
+    hook = collections.OrderedDict if sort_keys else None
     with infile:
         try:
-            if sort_keys:
-                obj = json.load(infile)
-            else:
-                obj = json.load(infile,
-                                object_pairs_hook=collections.OrderedDict)
+            obj = json.load(infile, object_pairs_hook=hook)
         except ValueError as e:
             raise SystemExit(e)
+
+    # Output JSON
+    outfile = options.outfile or sys.stdout
     with outfile:
         json.dump(obj, outfile, sort_keys=sort_keys, indent=4)
         outfile.write('\n')

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -22,27 +22,26 @@ def main():
                    'to validate and pretty-print JSON objects.')
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('infile', nargs='?', type=argparse.FileType(),
+                        default=sys.stdin,
                         help='a JSON file to be validated or pretty-printed')
     parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
+                        default=sys.stdout,
                         help='write the output of infile to outfile')
     parser.add_argument('--sort-keys', action='store_true',
-                        help='sort dictionary outputs alphabetically by key')
+                        help='sort dictionaries output alphabetically by key')
     options = parser.parse_args()
 
     # Read input JSON
-    infile = options.infile or sys.stdin
-    sort_keys = options.sort_keys
-    hook = collections.OrderedDict if sort_keys else None
-    with infile:
+    hook = collections.OrderedDict if options.sort_keys else None
+    with options.infile as infile:
         try:
             obj = json.load(infile, object_pairs_hook=hook)
         except ValueError as e:
             raise SystemExit(e)
 
     # Output JSON
-    outfile = options.outfile or sys.stdout
-    with outfile:
-        json.dump(obj, outfile, sort_keys=sort_keys, indent=4)
+    with options.outfile as outfile:
+        json.dump(obj, outfile, sort_keys=options.sort_keys, indent=4)
         outfile.write('\n')
 
 

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -28,7 +28,7 @@ def main():
                         default=sys.stdout,
                         help='write the output of infile to outfile')
     parser.add_argument('--sort-keys', action='store_true',
-                        help='sort dictionaries output alphabetically by key')
+                        help='sort the output of dictionaries by key')
     options = parser.parse_args()
 
     # Read input JSON

--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -31,7 +31,6 @@ def main():
                         help='sort the output of dictionaries by key')
     options = parser.parse_args()
 
-    # Read input JSON
     hook = collections.OrderedDict if options.sort_keys else None
     with options.infile as infile:
         try:
@@ -39,7 +38,6 @@ def main():
         except ValueError as e:
             raise SystemExit(e)
 
-    # Output JSON
     with options.outfile as outfile:
         json.dump(obj, outfile, sort_keys=options.sort_keys, indent=4)
         outfile.write('\n')


### PR DESCRIPTION
Several months ago I worked on pull requests to add new options to the `json.tool` command line utility. These pull requests are still open, pending further design discussion and consensus on whether to add them:

+ https://github.com/python/cpython/pull/345 to add indentation / whitespace options ([`bpo-29636`](http://bugs.python.org/issue29636)).
+ https://github.com/python/cpython/pull/201 to display non-ascii characters ([`bpo-27413`](http://bugs.python.org/issue27413)).

Related, https://github.com/python/cpython/pull/346 fixed a small testing bug in `json.tool` and was merged.

Since #345 and #201 have been inactive for some time, I wanted to take the non-controversial code changes from those PRs. This PR contains readability improvements and minor refactoring to `json.tool`. The goal is to get some of the previous work merged and make the `json.tool` source easier to maintain and enhance going forward. Admittedly, the changes are quite minor.