### PR TITLE
[3.4] bpo-30939: Avoid Sphinx deprecation warning in docs build. (#2721)

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -15,6 +15,7 @@ from os import path
 from time import asctime
 from pprint import pformat
 from docutils.io import StringOutput
+from docutils.parsers.rst import Directive
 from docutils.utils import new_document
 
 from docutils import nodes, utils
@@ -22,7 +23,6 @@ from docutils import nodes, utils
 from sphinx import addnodes
 from sphinx.builders import Builder
 from sphinx.util.nodes import split_explicit_title
-from sphinx.util.compat import Directive
 from sphinx.writers.html import HTMLTranslator
 from sphinx.writers.text import TextWriter
 from sphinx.writers.latex import LaTeXTranslator


### PR DESCRIPTION
(cherry picked from commit 50f58163a69abe2f35e91044d1df165ee7bdbb42)

<!-- issue-number: bpo-30939 -->
https://bugs.python.org/issue30939
<!-- /issue-number -->
