### PR TITLE
[2.7] bpo-30939: Avoid Sphinx deprecation warning in docs build. (#2721)

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -13,9 +13,9 @@ ISSUE_URI = 'https://bugs.python.org/issue%s'
 SOURCE_URI = 'https://github.com/python/cpython/tree/2.7/%s'
 
 from docutils import nodes, utils
+from docutils.parsers.rst import Directive
 
 from sphinx.util.nodes import split_explicit_title
-from sphinx.util.compat import Directive
 from sphinx.writers.html import HTMLTranslator
 from sphinx.writers.latex import LaTeXTranslator
 


### PR DESCRIPTION
(cherry picked from commit 50f58163a69abe2f35e91044d1df165ee7bdbb42)