### PR TITLE
[3.6] bpo-30936: Fix a reference leak in json when fail to sort keys. (GH-2712)

### DIFF
--- a/Lib/test/test_json/test_speedups.py
+++ b/Lib/test/test_json/test_speedups.py
@@ -44,3 +44,7 @@ class TestEncode(CTest):
         self.assertRaises(ZeroDivisionError, test, 'check_circular')
         self.assertRaises(ZeroDivisionError, test, 'allow_nan')
         self.assertRaises(ZeroDivisionError, test, 'sort_keys')
+
+    def test_unsortable_keys(self):
+        with self.assertRaises(TypeError):
+            self.json.encoder.JSONEncoder(sort_keys=True).encode({'a': 1, 1: 'a'})

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1601,8 +1601,10 @@ encoder_listencode_dict(PyEncoderObject *s, _PyAccu *acc,
     if (items == NULL)
         goto bail;
     sortkeys = PyObject_IsTrue(s->sort_keys);
-    if (sortkeys < 0 || (sortkeys && PyList_Sort(items) < 0))
+    if (sortkeys < 0 || (sortkeys && PyList_Sort(items) < 0)) {
+        Py_DECREF(items);
         goto bail;
+    }
     it = PyObject_GetIter(items);
     Py_DECREF(items);
     if (it == NULL)


### PR DESCRIPTION
(cherry picked from commit 49f6449ef4b81537c19b82329caaf60596c516c2)