### PR TITLE
[2.7] bpo-30911: Add tests for bad boolean arguments for accelerated json (GH-2690)

### DIFF
--- a/Lib/json/tests/test_speedups.py
+++ b/Lib/json/tests/test_speedups.py
@@ -1,6 +1,11 @@
 from json.tests import CTest
 
 
+class BadBool:
+    def __nonzero__(self):
+        1/0
+
+
 class TestSpeedups(CTest):
     def test_scanstring(self):
         self.assertEqual(self.json.decoder.scanstring.__module__, "_json")
@@ -16,8 +21,31 @@ class TestDecode(CTest):
     def test_make_scanner(self):
         self.assertRaises(AttributeError, self.json.scanner.c_make_scanner, 1)
 
+    def test_bad_bool_args(self):
+        def test(value):
+            self.json.decoder.JSONDecoder(strict=BadBool()).decode(value)
+        self.assertRaises(ZeroDivisionError, test, '""')
+        self.assertRaises(ZeroDivisionError, test, '{}')
+        self.assertRaises(ZeroDivisionError, test, u'""')
+        self.assertRaises(ZeroDivisionError, test, u'{}')
+
+
+class TestEncode(CTest):
     def test_make_encoder(self):
         self.assertRaises(TypeError, self.json.encoder.c_make_encoder,
             None,
             "\xCD\x7D\x3D\x4E\x12\x4C\xF9\x79\xD7\x52\xBA\x82\xF2\x27\x4A\x7D\xA0\xCA\x75",
             None)
+
+    def test_bad_bool_args(self):
+        def test(name):
+            self.json.encoder.JSONEncoder(**{name: BadBool()}).encode({'a': 1})
+        self.assertRaises(ZeroDivisionError, test, 'skipkeys')
+        self.assertRaises(ZeroDivisionError, test, 'ensure_ascii')
+        self.assertRaises(ZeroDivisionError, test, 'check_circular')
+        self.assertRaises(ZeroDivisionError, test, 'allow_nan')
+        self.assertRaises(ZeroDivisionError, test, 'sort_keys')
+
+    def test_bad_encoding(self):
+        with self.assertRaises(UnicodeEncodeError):
+            self.json.encoder.JSONEncoder(encoding=u'\udcff').encode({'key': 123})


### PR DESCRIPTION
encoder and decoder.
(cherry picked from commit d3aaa2f1496aae0809c9ec9623fa528d3a2c16c2)