### PR TITLE
bpo-30937: Make usage of newline='' consistent in csv documentation

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -172,7 +172,7 @@ The :mod:`csv` module defines the following classes:
    A short usage example::
 
        >>> import csv
-       >>> with open('names.csv') as csvfile:
+       >>> with open('names.csv', newline='') as csvfile:
        ...     reader = csv.DictReader(csvfile)
        ...     for row in reader:
        ...         print(row['first_name'], row['last_name'])
@@ -211,7 +211,7 @@ The :mod:`csv` module defines the following classes:
 
        import csv
 
-       with open('names.csv', 'w') as csvfile:
+       with open('names.csv', 'w', newline='') as csvfile:
            fieldnames = ['first_name', 'last_name']
            writer = csv.DictWriter(csvfile, fieldnames=fieldnames)
 
@@ -270,7 +270,7 @@ The :mod:`csv` module defines the following classes:
 
 An example for :class:`Sniffer` use::
 
-   with open('example.csv') as csvfile:
+   with open('example.csv', newline='') as csvfile:
        dialect = csv.Sniffer().sniff(csvfile.read(1024))
        csvfile.seek(0)
        reader = csv.reader(csvfile, dialect)


### PR DESCRIPTION
The newline comment was added as part of https://github.com/python/cpython/commit/9188702a7574a5cd94e4b91562a96553507554c1
bpo issue: https://bugs.python.org/issue7198

but looks like when the `DictReader`  and `DictWriter` documentation was added, this was overlooked. Note these classes use a simple csv.writer/reader function underneath so they potentially have the same problems with quoted fields and embedded newlines.