### PR TITLE
bpo-28638: speed up namedtuple creation by avoiding exec

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -880,12 +880,15 @@ field names, the method and attribute names start with an underscore.
 
 .. attribute:: somenamedtuple._source
 
-    A string with the pure Python source code used to create the named
-    tuple class.  The source makes the named tuple self-documenting.
-    It can be printed, executed using :func:`exec`, or saved to a file
-    and imported.
+    A string with pure Python source code that can be used to create an
+    equivalent named tuple class.  The source makes the named tuple
+    self-documenting. It can be printed, executed using :func:`exec`, or
+    saved to a file and imported.
 
     .. versionadded:: 3.3
+
+    .. versionchanged:: 3.7
+       ``_source`` is no longer used to created the named tuple class.
 
 .. attribute:: somenamedtuple._fields
 

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -888,7 +888,8 @@ field names, the method and attribute names start with an underscore.
     .. versionadded:: 3.3
 
     .. versionchanged:: 3.7
-       ``_source`` is no longer used to created the named tuple class.
+       ``_source`` is no longer used to create the named tuple class implementation, but contains
+       an equivalent implementation.
 
 .. attribute:: somenamedtuple._fields
 

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -357,7 +357,6 @@ _new_template = '''
 def __new__(_cls, {arg_list}):
     return _tuple_new(_cls, ({arg_list}))
 '''
-_new_doc_template = 'Create new instance of {typename}({arg_list})'
 
 
 class _source_descriptor:
@@ -414,56 +413,54 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
                 or _iskeyword(name)
                 or name.startswith('_')
                 or name in seen):
-                field_names[index] = '_%d' % index
+                field_names[index] = f'_{index:d}'
             seen.add(name)
     for name in [typename] + field_names:
         if type(name) is not str:
             raise TypeError('Type names and field names must be strings')
         if not name.isidentifier():
             raise ValueError('Type names and field names must be valid '
-                             'identifiers: %r' % name)
+                             f'identifiers: {name!r}')
         if _iskeyword(name):
             raise ValueError('Type names and field names cannot be a '
-                             'keyword: %r' % name)
+                             f'keyword: {name!r}')
     seen = set()
     for name in field_names:
         if name.startswith('_') and not rename:
             raise ValueError('Field names cannot start with an underscore: '
-                             '%r' % name)
+                             f'{name!r}')
         if name in seen:
-            raise ValueError('Encountered duplicate field name: %r' % name)
+            raise ValueError(f'Encountered duplicate field name: {name!r}')
         seen.add(name)
 
     arg_list = repr(tuple(field_names)).replace("'", "")[1:-1]
     num_fields = len(field_names)
-    repr_fmt = '(' + ', '.join(_repr_template.format(name=name)
-                               for name in field_names) + ')'
+    repr_fmt = '(' + ', '.join(f'{name}=%r' for name in field_names) + ')'
 
     namespace = {'_tuple_new': tuple.__new__}
     new_source = _new_template.format(arg_list=arg_list)
     exec(new_source, namespace)
     __new__ = namespace['__new__']
-    __new__.__doc__ = _new_doc_template.format(typename=typename, arg_list=arg_list)
+    __new__.__doc__ = f'Create new instance of {typename}({arg_list})'
 
     @classmethod
     def _make(cls, iterable, new=tuple.__new__, len=len, num_fields=num_fields):
         result = new(cls, iterable)
         if len(result) != cls._num_fields:
-            raise TypeError('Expected %d arguments, got %d' %
-                            (num_fields, len(result)))
+            raise TypeError(f'Expected {num_fields} arguments, got {len(result)}')
         return result
 
-    _make.__func__.__doc__ = ('Make a new {typename} object from a sequence '
-                              'or iterable').format(typename=typename)
+    _make.__func__.__doc__ = (f'Make a new {typename} object from a sequence '
+                              'or iterable')
 
     def _replace(_self, **kwds):
         result = _self._make(map(kwds.pop, _self._fields, _self))
         if kwds:
-            raise ValueError('Got unexpected field names: %r' % list(kwds))
+            raise ValueError(f'Got unexpected field names: {list(kwds)}')
         return result
 
-    _replace.__doc__ = ('Return a new {typename} object replacing specified '
-                        'fields with new values').format(typename=typename)
+    _replace.__doc__ = (f'Return a new {typename} object replacing specified '
+                        'fields with new values')
 
     def __repr__(self):
         'Return a nicely formatted representation string'
@@ -477,14 +474,13 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
         'Return self as a plain tuple.  Used by copy and pickle.'
         return tuple(self)
 
-    module_name = 'namedtuple_{typename}'.format(typename=typename)
+    module_name = f'namedtuple_{typename}'
     for method in (__new__, _make.__func__, _replace, __repr__, _asdict, __getnewargs__):
         method.__module__ = module_name
-        method.__qualname__ = '{typename}.{name}'.format(typename=typename, name=method.__name__)
+        method.__qualname__ = f'{typename}.{method.__name__}'
 
     class_namespace = {
-        '__doc__': '{typename}({arg_list})'.format(typename=typename,
-                                                   arg_list=arg_list),
+        '__doc__': f'{typename}({arg_list})',
         '__slots__': (),
         '_fields': tuple(field_names),
         '__new__': __new__,
@@ -498,7 +494,7 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
         '_source': _source_descriptor(),
     }
     for index, name in enumerate(field_names):
-        doc = 'Alias for field number {index:d}'.format(index=index)
+        doc = f'Alias for field number {index:d}'
         class_namespace[name] = property(_itemgetter(index), doc=doc)
 
     result = type(typename, (tuple,), class_namespace)

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -303,57 +303,13 @@ except ImportError:
 ### namedtuple
 ################################################################################
 
-_class_template = """\
-from builtins import property as _property, tuple as _tuple
-from operator import itemgetter as _itemgetter
-from collections import OrderedDict
-
-class {typename}(tuple):
-    '{typename}({arg_list})'
-
-    __slots__ = ()
-
-    _fields = {field_names!r}
-
-    def __new__(_cls, {arg_list}):
-        'Create new instance of {typename}({arg_list})'
-        return _tuple.__new__(_cls, ({arg_list}))
-
-    @classmethod
-    def _make(cls, iterable, new=tuple.__new__, len=len):
-        'Make a new {typename} object from a sequence or iterable'
-        result = new(cls, iterable)
-        if len(result) != {num_fields:d}:
-            raise TypeError('Expected {num_fields:d} arguments, got %d' % len(result))
-        return result
-
-    def _replace(_self, **kwds):
-        'Return a new {typename} object replacing specified fields with new values'
-        result = _self._make(map(kwds.pop, {field_names!r}, _self))
-        if kwds:
-            raise ValueError('Got unexpected field names: %r' % list(kwds))
-        return result
-
-    def __repr__(self):
-        'Return a nicely formatted representation string'
-        return self.__class__.__name__ + '({repr_fmt})' % self
-
-    def _asdict(self):
-        'Return a new OrderedDict which maps field names to their values.'
-        return OrderedDict(zip(self._fields, self))
-
-    def __getnewargs__(self):
-        'Return self as a plain tuple.  Used by copy and pickle.'
-        return tuple(self)
-
-{field_defs}
-"""
-
 _repr_template = '{name}=%r'
-
-_field_template = '''\
-    {name} = _property(_itemgetter({index:d}), doc='Alias for field number {index:d}')
+_new_template = '''
+def __new__(_cls, {arg_list}):
+    'Create new instance of {typename}({arg_list})'
+    return _tuple.__new__(_cls, ({arg_list}))
 '''
+
 
 def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None):
     """Returns a new subclass of tuple with named fields.
@@ -412,26 +368,62 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
             raise ValueError('Encountered duplicate field name: %r' % name)
         seen.add(name)
 
-    # Fill-in the class template
-    class_definition = _class_template.format(
-        typename = typename,
-        field_names = tuple(field_names),
-        num_fields = len(field_names),
-        arg_list = repr(tuple(field_names)).replace("'", "")[1:-1],
-        repr_fmt = ', '.join(_repr_template.format(name=name)
-                             for name in field_names),
-        field_defs = '\n'.join(_field_template.format(index=index, name=name)
-                               for index, name in enumerate(field_names))
+    arg_list = repr(tuple(field_names)).replace("'", "")[1:-1]
+    num_fields = len(field_names)
+    repr_fmt = '(' + ', '.join(_repr_template.format(name=name) for name in field_names) + ')'
+
+    namespace = {'_tuple': tuple}
+    exec(_new_template.format(typename=typename, arg_list=arg_list), namespace)
+    __new__ = namespace['__new__']
+
+    @classmethod
+    def _make(cls, iterable, new=tuple.__new__, len=len):
+        result = new(cls, iterable)
+        if len(result) != num_fields:
+            raise TypeError('Expected %d arguments, got %d' % (num_fields, len(result)))
+        return result
+
+    _make.__func__.__doc__ = 'Make a new {typename} object from a sequence or iterable'.format(typename=typename)
+
+    def _replace(_self, **kwds):
+        result = _self._make(map(kwds.pop, field_names, _self))
+        if kwds:
+            raise ValueError('Got unexpected field names: %r' % list(kwds))
+        return result
+
+    _replace.__doc__ = (
+        'Return a new {typename} object replacing specified fields with new values'.format(
+            typename=typename)
     )
 
-    # Execute the template string in a temporary namespace and support
-    # tracing utilities by setting a value for frame.f_globals['__name__']
-    namespace = dict(__name__='namedtuple_%s' % typename)
-    exec(class_definition, namespace)
-    result = namespace[typename]
-    result._source = class_definition
-    if verbose:
-        print(result._source)
+    def __repr__(self):
+        'Return a nicely formatted representation string'
+        return self.__class__.__name__ + repr_fmt % self
+
+    def _asdict(self):
+        'Return a new OrderedDict which maps field names to their values.'
+        return OrderedDict(zip(self._fields, self))
+
+    def __getnewargs__(self):
+        'Return self as a plain tuple.  Used by copy and pickle.'
+        return tuple(self)
+
+    class_namespace = {
+        '__doc__': '{typename}({arg_list})'.format(typename=typename, arg_list=arg_list),
+        '__slots__': (),
+        '_fields': tuple(field_names),
+        '__new__': __new__,
+        '_make': _make,
+        '_replace': _replace,
+        '__repr__': __repr__,
+        '_asdict': _asdict,
+        '__getnewargs__': __getnewargs__,
+    }
+    for index, name in enumerate(field_names):
+        doc = 'Alias for field number {index:d}'.format(index=index)
+        class_namespace[name] = property(_itemgetter(index), doc=doc)
+
+    result = type(typename, (tuple,), class_namespace)
 
     # For pickling to work, the __module__ variable needs to be set to the frame
     # where the named tuple is created.  Bypass this step in environments where

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -477,6 +477,11 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
         'Return self as a plain tuple.  Used by copy and pickle.'
         return tuple(self)
 
+    module_name = 'namedtuple_{typename}'.format(typename=typename)
+    for method in (__new__, _make.__func__, _replace, __repr__, _asdict, __getnewargs__):
+        method.__module__ = module_name
+        method.__qualname__ = '{typename}.{name}'.format(typename=typename, name=method.__name__)
+
     class_namespace = {
         '__doc__': '{typename}({arg_list})'.format(typename=typename,
                                                    arg_list=arg_list),

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -355,9 +355,9 @@ _field_template = '''\
 _repr_template = '{name}=%r'
 _new_template = '''
 def __new__(_cls, {arg_list}):
-    'Create new instance of {typename}({arg_list})'
     return _tuple_new(_cls, ({arg_list}))
 '''
+_new_doc_template = 'Create new instance of {typename}({arg_list})'
 
 
 class _source_descriptor:
@@ -440,9 +440,10 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
                                for name in field_names) + ')'
 
     namespace = {'_tuple_new': tuple.__new__}
-    new_source = _new_template.format(typename=typename, arg_list=arg_list)
+    new_source = _new_template.format(arg_list=arg_list)
     exec(new_source, namespace)
     __new__ = namespace['__new__']
+    __new__.__doc__ = _new_doc_template.format(typename=typename, arg_list=arg_list)
 
     @classmethod
     def _make(cls, iterable, new=tuple.__new__, len=len, num_fields=num_fields):

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -356,7 +356,7 @@ _repr_template = '{name}=%r'
 _new_template = '''
 def __new__(_cls, {arg_list}):
     'Create new instance of {typename}({arg_list})'
-    return _tuple.__new__(_cls, ({arg_list}))
+    return _tuple_new(_cls, ({arg_list}))
 '''
 
 
@@ -439,17 +439,17 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
     repr_fmt = '(' + ', '.join(_repr_template.format(name=name)
                                for name in field_names) + ')'
 
-    namespace = {'_tuple': tuple}
+    namespace = {'_tuple_new': tuple.__new__}
     new_source = _new_template.format(typename=typename, arg_list=arg_list)
     exec(new_source, namespace)
     __new__ = namespace['__new__']
 
     @classmethod
-    def _make(cls, iterable, new=tuple.__new__, len=len):
+    def _make(cls, iterable, new=tuple.__new__, len=len, num_fields=num_fields):
         result = new(cls, iterable)
         if len(result) != cls._num_fields:
             raise TypeError('Expected %d arguments, got %d' %
-                            (cls._num_fields, len(result)))
+                            (num_fields, len(result)))
         return result
 
     _make.__func__.__doc__ = ('Make a new {typename} object from a sequence '

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -194,7 +194,6 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(Point.__module__, __name__)
         self.assertEqual(Point.__getitem__, tuple.__getitem__)
         self.assertEqual(Point._fields, ('x', 'y'))
-        self.assertIn('class Point(tuple)', Point._source)
 
         self.assertRaises(ValueError, namedtuple, 'abc%', 'efg ghi')       # type has non-alpha char
         self.assertRaises(ValueError, namedtuple, 'class', 'efg ghi')      # type has keyword
@@ -404,22 +403,8 @@ class TestNamedTuple(unittest.TestCase):
             pass
         self.assertEqual(repr(B(1)), 'B(x=1)')
 
-    def test_source(self):
-        # verify that _source can be run through exec()
-        tmp = namedtuple('NTColor', 'red green blue')
-        globals().pop('NTColor', None)          # remove artifacts from other tests
-        exec(tmp._source, globals())
-        self.assertIn('NTColor', globals())
-        c = NTColor(10, 20, 30)
-        self.assertEqual((c.red, c.green, c.blue), (10, 20, 30))
-        self.assertEqual(NTColor._fields, ('red', 'green', 'blue'))
-        globals().pop('NTColor', None)          # clean-up after this test
-
     def test_keyword_only_arguments(self):
         # See issue 25628
-        with support.captured_stdout() as template:
-            NT = namedtuple('NT', ['x', 'y'], verbose=True)
-        self.assertIn('class NT', NT._source)
         with self.assertRaises(TypeError):
             NT = namedtuple('NT', ['x', 'y'], True)
 

--- a/Misc/NEWS.d/next/Library/2017-08-27-14-03-50.bpo-28638.W4CQxG.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-27-14-03-50.bpo-28638.W4CQxG.rst
@@ -1,0 +1,2 @@
+Speed up namedtuple class creation by 4x by avoiding usage of exec(). Patch
+by Jelle Zijlstra.


### PR DESCRIPTION
Creating a namedtuple is relatively slow because it uses exec().
This commit reduces the exec()'ed code, but still uses exec() for
creating the `__new__` method. I don't know of a way to avoid using
exec() for `__new__` beyond manipulating bytecode directly.

However, avoiding exec() for creating the class itself still yields
a significant speedup. In an unscientific benchmark I ran, creating
1000 namedtuple classes now takes about 0.14 s instead of 0.44 s.

There is one backward compatibility break: namedtuples no longer have
a _source attribute, because we no longer exec() their source. I kept
the verbose=True argument around for compatibility, but it now does
nothing.

cc @sixolet @methane 

<!-- issue-number: bpo-28638 -->
https://bugs.python.org/issue28638
<!-- /issue-number -->
