### PR TITLE
bpo-30450: Adds alternate download approach for nuget.exe

### DIFF
--- a/PCbuild/find_python.bat
+++ b/PCbuild/find_python.bat
@@ -42,7 +42,8 @@
     @echo Downloading nuget...
     @rem NB: Must use single quotes around NUGET here, NOT double!
     @rem Otherwise, a space in the path would break things
-    @powershell.exe -Command Invoke-WebRequest %_Py_NUGET_URL% -OutFile '%_Py_NUGET%'
+    @rem If it fails, retry with any available copy of Python
+    @powershell.exe -Command Invoke-WebRequest %_Py_NUGET_URL% -OutFile '%_Py_NUGET%' || @py -c "%~dp0\urlretrieve.py" "%_Py_NUGET_URL%" "%_Py_NUGET%"
 )
 @echo Installing Python via nuget...
 @"%_Py_NUGET%" install pythonx86 -ExcludeVersion -OutputDirectory "%_Py_EXTERNALS_DIR%"

--- a/PCbuild/urlretrieve.py
+++ b/PCbuild/urlretrieve.py
@@ -20,7 +20,7 @@ except ImportError:
             sys.exit(2)
 else:
     USING = "requests.get"
-    
+
     def urlretrieve(url, filename):
         r = get(url, stream=True)
         r.raise_for_status()

--- a/PCbuild/urlretrieve.py
+++ b/PCbuild/urlretrieve.py
@@ -1,0 +1,39 @@
+# Simple Python script to download a file. Used as a fallback
+# when other more reliable methods fail.
+#
+from __future__ import print_function
+import sys
+
+try:
+    from requests import get
+except ImportError:
+    try:
+        from urllib.request import urlretrieve
+        USING = "urllib.request.urlretrieve"
+    except ImportError:
+        try:
+            from urllib import urlretrieve
+            USING = "urllib.retrieve"
+        except ImportError:
+            print("Python at", sys.executable, "is not suitable",
+                  "for downloading files.", file=sys.stderr)
+            sys.exit(2)
+else:
+    USING = "requests.get"
+    
+    def urlretrieve(url, filename):
+        r = get(url, stream=True)
+        r.raise_for_status()
+        with open(filename, 'wb') as f:
+            for chunk in r.iter_content(chunk_size=1024):
+                f.write(chunk)
+        return filename
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3:
+        print("Usage: urlretrieve.py [url] [filename]", file=sys.stderr)
+        sys.exit(1)
+    URL = sys.argv[1]
+    FILENAME = sys.argv[2]
+    print("Downloading from", URL, "to", FILENAME, "using", USING)
+    urlretrieve(URL, FILENAME)


### PR DESCRIPTION
When Powershell.exe fails, fall back on any Python version at all in order to get an up-to-date Python version via nuget.