### PR TITLE
bpo-30450: Fall back to git.exe if no Python is found.

### DIFF
--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -41,6 +41,10 @@ if "%DO_FETCH%"=="false" goto end
 if "%ORG%"=="" (set ORG=python)
 call "%PCBUILD%find_python.bat" "%PYTHON%"
 
+if "%PYTHON%"=="" (
+    where /Q git || echo Python 3.6 could not be found or installed, and git.exe is not on your PATH && exit /B 1
+)
+
 echo.Fetching external libraries...
 
 set libraries=

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -55,6 +55,9 @@ set libraries=%libraries%                                       xz-5.2.2
 for %%e in (%libraries%) do (
     if exist "%EXTERNALS_DIR%\%%e" (
         echo.%%e already exists, skipping.
+    ) else if "%PYTHON%"=="" (
+        echo.Fetching %%e with git...
+        git clone --depth 1 https://github.com/%ORG%/cpython-source-deps --branch %%e "%EXTERNALS_DIR%\%%e"
     ) else (
         echo.Fetching %%e...
         %PYTHON% "%PCBUILD%get_external.py" -O %ORG% %%e
@@ -71,6 +74,9 @@ if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 for %%b in (%binaries%) do (
     if exist "%EXTERNALS_DIR%\%%b" (
         echo.%%b already exists, skipping.
+    ) else if "%PYTHON%"=="" (
+        echo.Fetching %%b with git...
+        git clone --depth 1 https://github.com/%ORG%/cpython-bin-deps --branch %%b "%EXTERNALS_DIR%\%%b"
     ) else (
         echo.Fetching %%b...
         %PYTHON% "%PCBUILD%get_external.py" -b -O %ORG% %%b


### PR DESCRIPTION
As a last resort, assume git.exe is on PATH and use it to shallow-clone our dependencies.

This should work on the buildbots that do not have up-to-date versions of PowerShell.