### PR TITLE
bpo-30951: Documentation fix co_names (inspect module)

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -268,7 +268,7 @@ def iscode(object):
         co_kwonlyargcount   number of keyword only arguments (not including ** arg)
         co_lnotab           encoded mapping of line numbers to bytecode indices
         co_name             name with which this code object was defined
-        co_names            tuple of names of local variables
+        co_names            tuple of names of global variables
         co_nlocals          number of local variables
         co_stacksize        virtual machine stack space required
         co_varnames         tuple of names of arguments and local variables"""


### PR DESCRIPTION
Fixed documentation error in inspect module for `co_names` description. Previously claimed to be tuple of local variable names when it is really a tuple of global variable names.

Relevant Stackoverflow post:
https://stackoverflow.com/questions/45147260/what-is-co-names