### PR TITLE
bpo-30951: Correct co_names documentation in inspect module

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -277,7 +277,7 @@ def iscode(object):
         co_kwonlyargcount   number of keyword only arguments (not including ** arg)
         co_lnotab           encoded mapping of line numbers to bytecode indices
         co_name             name with which this code object was defined
-        co_names            tuple of names of local variables
+        co_names            tuple of names other than arguments and function locals
         co_nlocals          number of local variables
         co_stacksize        virtual machine stack space required
         co_varnames         tuple of names of arguments and local variables"""


### PR DESCRIPTION
Previously `co_names` was described as containing names of local variables. `co_names` however contains names of global variables (`co_varnames` contains local variable names). Documentation was updated to reflect this.

Relevant stackoverflow post:

https://stackoverflow.com/questions/45147260/what-is-co-names

<!-- issue-number: [bpo-30951](https://bugs.python.org/issue30951) -->
https://bugs.python.org/issue30951
<!-- /issue-number -->
