### PR TITLE
bpo-27268: Fix incorrect error message on float('')

### DIFF
--- a/Python/pystrtod.c
+++ b/Python/pystrtod.c
@@ -353,15 +353,15 @@ PyOS_string_to_double(const char *s,
     else if (!endptr && (fail_pos == s || *fail_pos != '\0'))
         PyErr_Format(PyExc_ValueError,
                       "could not convert string to float: "
-                      "%.200s", s);
+                      "'%.200s'", s);
     else if (fail_pos == s)
         PyErr_Format(PyExc_ValueError,
                       "could not convert string to float: "
-                      "%.200s", s);
+                      "'%.200s'", s);
     else if (errno == ERANGE && fabs(x) >= 1.0 && overflow_exception)
         PyErr_Format(overflow_exception,
                       "value too large to convert to float: "
-                      "%.200s", s);
+                      "'%.200s'", s);
     else
         result = x;
 

--- a/Python/pystrtod.c
+++ b/Python/pystrtod.c
@@ -431,8 +431,8 @@ _Py_string_to_number_with_underscores(
   error:
     PyMem_Free(dup);
     PyErr_Format(PyExc_ValueError,
-		 "could not convert string to %s: "
-		 "%R", what, obj);
+                 "could not convert string to %s: "
+                 "%R", what, obj);
     return NULL;
 }
 


### PR DESCRIPTION
<!-- issue-number: [bpo-27268](https://www.bugs.python.org/issue27268) -->
https://bugs.python.org/issue27268
<!-- /issue-number -->
