### PR TITLE
Improve doc of IncrementalEncoder

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -554,19 +554,19 @@ define in order to be compatible with the Python codec registry.
       if necessary, to reset the encoder and to get the output.
 
 
-.. method:: IncrementalEncoder.getstate()
+   .. method:: getstate()
 
-   Return the current state of the encoder which must be an integer. The
-   implementation should make sure that ``0`` is the most common state. (States
-   that are more complicated than integers can be converted into an integer by
-   marshaling/pickling the state and encoding the bytes of the resulting string
-   into an integer).
+      Return the current state of the encoder which must be an integer. The
+      implementation should make sure that ``0`` is the most common
+      state. (States that are more complicated than integers can be converted
+      into an integer by marshaling/pickling the state and encoding the bytes
+      of the resulting string into an integer).
 
 
-.. method:: IncrementalEncoder.setstate(state)
+   .. method:: setstate(state)
 
-   Set the state of the encoder to *state*. *state* must be an encoder state
-   returned by :meth:`getstate`.
+      Set the state of the encoder to *state*. *state* must be an encoder state
+      returned by :meth:`getstate`.
 
 
 .. _incremental-decoder-objects:


### PR DESCRIPTION
`getstate` and `setstate` are instance methods just like `encode` and `reset`, but currently they look like static/class methods [in the docs](https://docs.python.org/3/library/codecs.html#codecs.IncrementalEncoder), which is slightly confusing:

<img width="1884" alt="screen shot 2017-07-18 at 10 39 47 am" src="https://user-images.githubusercontent.com/4149852/28322970-8118150c-6ba5-11e7-8d57-598c1b79639e.png">