### PR TITLE
bpo-30962: Add caching to Logger.isEnabledFor()

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1252,7 +1252,8 @@ class Manager(object):
 
         _acquireLock()
         for logger in self.loggerDict.values():
-            logger._cache.clear()
+            if isinstance(logger, Logger):
+                logger._cache.clear()
         _releaseLock()
 
 #---------------------------------------------------------------------------
@@ -1556,7 +1557,9 @@ class Logger(Filterer):
         """
         Is this logger enabled for level 'level'?
         """
-        if level not in self._cache:
+        try:
+            return self._cache[level]
+        except KeyError:
             _acquireLock()
             if self.manager.disable >= level:
                 self._cache[level] = False
@@ -1564,7 +1567,7 @@ class Logger(Filterer):
                 self._cache[level] = level >= self.getEffectiveLevel()
             _releaseLock()
 
-        return self._cache[level]
+            return self._cache[level]
 
     def getChild(self, suffix):
         """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1562,12 +1562,12 @@ class Logger(Filterer):
         except KeyError:
             _acquireLock()
             if self.manager.disable >= level:
-                self._cache[level] = False
+                is_enabled = self._cache[level] = False
             else:
-                self._cache[level] = level >= self.getEffectiveLevel()
+                is_enabled = self._cache[level] = level >= self.getEffectiveLevel()
             _releaseLock()
 
-            return self._cache[level]
+            return is_enabled
 
     def getChild(self, suffix):
         """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1254,6 +1254,7 @@ class Manager(object):
         for logger in self.loggerDict.values():
             if isinstance(logger, Logger):
                 logger._cache.clear()
+        self.root._cache.clear()
         _releaseLock()
 
 #---------------------------------------------------------------------------

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4094,6 +4094,62 @@ class LoggerTest(BaseTest):
                 unpickled = pickle.loads(s)
                 self.assertIs(unpickled, logger)
 
+    def test_caching(self):
+        root = self.root_logger
+        logger1 = logging.getLogger("abc")
+        logger2 = logging.getLogger("abc.def")
+
+        # Set root logger level and ensure cache is empty
+        root.setLevel(logging.ERROR)
+        self.assertEqual(logger2.getEffectiveLevel(), logging.ERROR)
+        self.assertEqual(logger2._cache, {})
+
+        # Ensure cache is populated and calls are consistent
+        self.assertTrue(logger2.isEnabledFor(logging.ERROR))
+        self.assertFalse(logger2.isEnabledFor(logging.DEBUG))
+        self.assertEqual(logger2._cache, {logging.ERROR: True, logging.DEBUG: False})
+        self.assertEqual(root._cache, {})
+        self.assertTrue(logger2.isEnabledFor(logging.ERROR))
+
+        # Ensure root cache gets populated
+        self.assertEqual(root._cache, {})
+        self.assertTrue(root.isEnabledFor(logging.ERROR))
+        self.assertEqual(root._cache, {logging.ERROR: True})
+
+        # Set parent logger level and ensure caches are emptied
+        logger1.setLevel(logging.CRITICAL)
+        self.assertEqual(logger2.getEffectiveLevel(), logging.CRITICAL)
+        self.assertEqual(logger2._cache, {})
+
+        # Ensure logger2 uses parent logger's effective level
+        self.assertFalse(logger2.isEnabledFor(logging.ERROR))
+
+        # Set level to NOTSET and ensure caches are empty
+        logger2.setLevel(logging.NOTSET)
+        self.assertEqual(logger2.getEffectiveLevel(), logging.CRITICAL)
+        self.assertEqual(logger2._cache, {})
+        self.assertEqual(logger1._cache, {})
+        self.assertEqual(root._cache, {})
+
+        # Verify logger2 follows parent and not root
+        self.assertFalse(logger2.isEnabledFor(logging.ERROR))
+        self.assertTrue(logger2.isEnabledFor(logging.CRITICAL))
+        self.assertFalse(logger1.isEnabledFor(logging.ERROR))
+        self.assertTrue(logger1.isEnabledFor(logging.CRITICAL))
+        self.assertTrue(root.isEnabledFor(logging.ERROR))
+
+        # Disable logging in manager and ensure caches are clear
+        logging.disable()
+        self.assertEqual(logger2.getEffectiveLevel(), logging.CRITICAL)
+        self.assertEqual(logger2._cache, {})
+        self.assertEqual(logger1._cache, {})
+        self.assertEqual(root._cache, {})
+
+        # Ensure no loggers are enabled
+        self.assertFalse(logger1.isEnabledFor(logging.CRITICAL))
+        self.assertFalse(logger2.isEnabledFor(logging.CRITICAL))
+        self.assertFalse(root.isEnabledFor(logging.CRITICAL))
+
 
 class BaseFileTest(BaseTest):
     "Base class for handler tests that write log files"
@@ -4404,29 +4460,6 @@ class NTEventLogHandlerTest(BaseTest):
             break
         msg = 'Record not found in event log, went back %d records' % GO_BACK
         self.assertTrue(found, msg=msg)
-
-
-class CachingTest(BaseTest):
-    def test_caching(self):
-        root = self.root_logger
-        level1 = logging.getLogger("abc")
-        level2 = logging.getLogger("abc.def")
-
-        root.setLevel(logging.ERROR)
-        self.assertEqual(level2._cache, {})  # Cache is empty
-
-        self.assertTrue(level2.isEnabledFor(logging.ERROR))
-        self.assertEqual(level2._cache, {logging.ERROR: True})  # Cache is populated
-        self.assertEqual(root._cache, {})  # Root cache is empty
-        self.assertTrue(level2.isEnabledFor(logging.ERROR))
-
-        level1.setLevel(logging.CRITICAL)
-        self.assertEqual(level2._cache, {})  # Cache is empty
-        self.assertEqual(root._cache, {})  # Root cache is empty
-
-        self.assertFalse(level2.isEnabledFor(logging.ERROR))
-        self.assertTrue(root.isEnabledFor(logging.ERROR))
-        self.assertEqual(root._cache, {logging.ERROR: True})  # Root cache is populated
 
 
 class MiscTestCase(unittest.TestCase):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4406,6 +4406,29 @@ class NTEventLogHandlerTest(BaseTest):
         self.assertTrue(found, msg=msg)
 
 
+class CachingTest(BaseTest):
+    def test_caching(self):
+        root = self.root_logger
+        level1 = logging.getLogger("abc")
+        level2 = logging.getLogger("abc.def")
+
+        root.setLevel(logging.ERROR)
+        self.assertEqual(level2._cache, {})  # Cache is empty
+
+        self.assertTrue(level2.isEnabledFor(logging.ERROR))
+        self.assertEqual(level2._cache, {logging.ERROR: True})  # Cache is populated
+        self.assertEqual(root._cache, {})  # Root cache is empty
+        self.assertTrue(level2.isEnabledFor(logging.ERROR))
+
+        level1.setLevel(logging.CRITICAL)
+        self.assertEqual(level2._cache, {})  # Cache is empty
+        self.assertEqual(root._cache, {})  # Root cache is empty
+
+        self.assertFalse(level2.isEnabledFor(logging.ERROR))
+        self.assertTrue(root.isEnabledFor(logging.ERROR))
+        self.assertEqual(root._cache, {logging.ERROR: True})  # Root cache is populated
+
+
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
         blacklist = {'logThreads', 'logMultiprocessing',

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -135,7 +135,9 @@ class BaseTest(unittest.TestCase):
             logging._handlers.clear()
             logging._handlers.update(self.saved_handlers)
             logging._handlerList[:] = self.saved_handler_list
-            loggerDict = logging.getLogger().manager.loggerDict
+            manager = logging.getLogger().manager
+            manager.disable = 0
+            loggerDict = manager.loggerDict
             loggerDict.clear()
             loggerDict.update(self.saved_loggers)
             logger_states = self.logger_states


### PR DESCRIPTION
This is a simple and brute-force caching method, but cuts the time required to log non-enabled levels in half.

Another approach would be to move the cache dictionary to the manager. This would speed up cache clearing, but take additional lookups during normal operation.

``` python
import timeit

count = 10000000

set_up = """
import logging
level1 = logging.getLogger('1')
level2 = logging.getLogger('1.2')
level3 = logging.getLogger('1.2.3')
"""

set_up_with_caching = """
import logging_with_caching as logging
level1 = logging.getLogger('1')
level2 = logging.getLogger('1.2')
level3 = logging.getLogger('1.2.3')
"""

statement = "level3.debug('Debug message')"

orig = timeit.timeit(statement, setup=set_up, number=count)
caching = timeit.timeit(statement, setup=set_up_with_caching, number=count)

print('Non-caching:  ', orig)
print('With Caching: ', caching)
print('Time decrease: %.2f%%' % ((orig - caching) / orig * 100))
```
``` console
Non-caching:   8.451851543039083
With Caching:  4.039903722004965
Time decrease: 52.20%
```

<!-- issue-number: bpo-30962 -->
https://bugs.python.org/issue30962
<!-- /issue-number -->
