### PR TITLE
bpo-29225: Fix install_lib.get_outputs() for inplace extensions

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1489,6 +1489,7 @@ Tage Stabell-Kulo
 Quentin Stafford-Fraser
 Frank Stajano
 Joel Stanley
+Elvis Stansvik
 Anthony Starks
 David Steele
 Oliver Steele

--- a/Misc/NEWS.d/next/Library/2017-07-19-10-01-52.bpo-29225.9gHpls.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-19-10-01-52.bpo-29225.9gHpls.rst
@@ -1,0 +1,1 @@
+Fix ``install_lib.get_outputs()`` for inplace extensions.


### PR DESCRIPTION
The install command would previously assume that extensions are built in the build directory, leading to incorrect result from `get_outputs()` when they are built inplace, thus preventing their installation.

See https://bugs.python.org/issue29225.

A test case `test_get_outputs_inplace_ext` is included. The test case would fail with:

```
======================================================================
FAIL: test_get_outputs_inplace_ext (distutils.tests.test_install_lib.InstallLibTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/estan/cpython/Lib/distutils/tests/test_install_lib.py", line 91, in test_get_outputs_inplace_ext
    self.assertEqual(expected, actual)
AssertionError: Lists differ: ['/tmp/tmpqgxt4ah0/foo.cpython-37dm-x86_64-linux-gnu.so'] != ['/tmp/tmpqgxt4ah0/dm-x86_64-linux-gnu.so']

First differing element 0:
'/tmp/tmpqgxt4ah0/foo.cpython-37dm-x86_64-linux-gnu.so'
'/tmp/tmpqgxt4ah0/dm-x86_64-linux-gnu.so'

- ['/tmp/tmpqgxt4ah0/foo.cpython-37dm-x86_64-linux-gnu.so']
?                    --------------

+ ['/tmp/tmpqgxt4ah0/dm-x86_64-linux-gnu.so']

----------------------------------------------------------------------
Ran 237 tests in 2.109s

FAILED (failures=1, skipped=25)
Traceback (most recent call last):
  File "/home/estan/cpython/Lib/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/estan/cpython/Lib/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/estan/cpython/Lib/distutils/tests/__init__.py", line 36, in <module>
    run_unittest(test_suite())
  File "/home/estan/cpython/Lib/test/support/__init__.py", line 1940, in run_unittest
    _run_suite(suite)
  File "/home/estan/cpython/Lib/test/support/__init__.py", line 1905, in _run_suite
    raise TestFailed(err)
test.support.TestFailed: Traceback (most recent call last):
  File "/home/estan/cpython/Lib/distutils/tests/test_install_lib.py", line 91, in test_get_outputs_inplace_ext
    self.assertEqual(expected, actual)
AssertionError: Lists differ: ['/tmp/tmpqgxt4ah0/foo.cpython-37dm-x86_64-linux-gnu.so'] != ['/tmp/tmpqgxt4ah0/dm-x86_64-linux-gnu.so']

First differing element 0:
'/tmp/tmpqgxt4ah0/foo.cpython-37dm-x86_64-linux-gnu.so'
'/tmp/tmpqgxt4ah0/dm-x86_64-linux-gnu.so'

- ['/tmp/tmpqgxt4ah0/foo.cpython-37dm-x86_64-linux-gnu.so']
?                    --------------

+ ['/tmp/tmpqgxt4ah0/dm-x86_64-linux-gnu.so']
```

Notice the missing `foo.cpython-37` part in the `get_outputs()` result. With this fix, the test case passes.