### PR TITLE
bpo-30966: Add multiprocessing.SimpleQueue.close()

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -862,6 +862,12 @@ For an example of the usage of queues for interprocess communication see
 
       Put *item* into the queue.
 
+   .. method:: close()
+
+      Close the queue.
+
+      .. versionadded:: 3.7
+
 
 .. class:: JoinableQueue([maxsize])
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -210,6 +210,14 @@ math
 New :func:`~math.remainder` function, implementing the IEEE 754-style remainder
 operation. (Contributed by Mark Dickinson in :issue:`29962`.)
 
+
+multiprocessing
+---------------
+
+The :class:`multiprocessing.SimpleQueue` class has a new
+:meth:`~multiprocessing.SimpleQueue.close` method to explicitly close the
+queue.
+
 os
 --
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2,25 +2,26 @@
 # Unit tests for the multiprocessing package
 #
 
-import unittest
-import queue as pyqueue
-import time
+import array
+import errno
+import gc
 import io
 import itertools
-import sys
-import os
-import gc
-import errno
-import signal
-import array
-import socket
-import random
 import logging
-import struct
 import operator
-import weakref
-import test.support
+import os
+import pickle
+import queue as pyqueue
+import random
+import signal
+import socket
+import struct
+import sys
 import test.support.script_helper
+import time
+import unittest
+from unittest import mock
+import weakref
 
 
 # Skip tests if _multiprocessing wasn't built.
@@ -4238,7 +4239,6 @@ class TestSimpleQueue(unittest.TestCase):
 
     def test_close(self):
         queue = multiprocessing.SimpleQueue()
-
         queue.close()
 
         # closing a queue twice should not fail
@@ -4251,6 +4251,10 @@ class TestSimpleQueue(unittest.TestCase):
             queue.get()
         with self.assertRaises(ValueError):
             queue.empty()
+        with self.assertRaises(ValueError):
+            with mock.patch('multiprocessing.queues.context.assert_spawning'):
+                # Test SimpleQueue.__getstate__()
+                pickle.dumps(queue)
 
 #
 # Mixins

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4236,6 +4236,22 @@ class TestSimpleQueue(unittest.TestCase):
 
         proc.join()
 
+    def test_close(self):
+        queue = multiprocessing.SimpleQueue()
+
+        queue.close()
+
+        # closing a queue twice should not fail
+        queue.close()
+
+        # operations on closed queue fail with ValueError
+        with self.assertRaises(ValueError):
+            queue.put("data")
+        with self.assertRaises(ValueError):
+            queue.get()
+        with self.assertRaises(ValueError):
+            queue.empty()
+
 #
 # Mixins
 #

--- a/Misc/NEWS.d/next/Library/2017-07-19-12-29-54.bpo-30966.QzFQPf.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-19-12-29-54.bpo-30966.QzFQPf.rst
@@ -1,0 +1,2 @@
+Add a new close() method to multiprocessing.SimpleQueue to explicitly close
+the queue.


### PR DESCRIPTION
Add a new close() method to multiprocessing.SimpleQueue to explicitly
closes the queue. This is called automatically when the queue is
garbage collected.