### PR TITLE
bpo-30969: Fix docs about the comparison in absence of __contains__

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1444,7 +1444,7 @@ y`` returns ``True`` if ``y.__contains__(x)`` returns a true value, and
 
 For user-defined classes which do not define :meth:`__contains__` but do define
 :meth:`__iter__`, ``x in y`` is ``True`` if some value ``z``, for which the 
-expression``x is z or x == z`` is True, is produced while iterating over ``y``.  
+expression``x is z or x == z`` is true, is produced while iterating over ``y``.  
 If an exception is raised during the iteration, it is as if :keyword:`in` raised 
 that exception.
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1444,7 +1444,7 @@ y`` returns ``True`` if ``y.__contains__(x)`` returns a true value, and
 
 For user-defined classes which do not define :meth:`__contains__` but do define
 :meth:`__iter__`, ``x in y`` is ``True`` if some value ``z``, for which the 
-expression``x is z or x == z`` is true, is produced while iterating over ``y``.  
+expression ``x is z or x == z`` is true, is produced while iterating over ``y``.  
 If an exception is raised during the iteration, it is as if :keyword:`in` raised 
 that exception.
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1443,14 +1443,15 @@ y`` returns ``True`` if ``y.__contains__(x)`` returns a true value, and
 ``False`` otherwise.
 
 For user-defined classes which do not define :meth:`__contains__` but do define
-:meth:`__iter__`, ``x in y`` is ``True`` if some value ``z`` with ``x == z`` is
-produced while iterating over ``y``.  If an exception is raised during the
-iteration, it is as if :keyword:`in` raised that exception.
+:meth:`__iter__`, ``x in y`` is ``True`` if some value ``z``, for which the 
+expression``x is z or x == z`` is True, is produced while iterating over ``y``.  
+If an exception is raised during the iteration, it is as if :keyword:`in` raised 
+that exception.
 
 Lastly, the old-style iteration protocol is tried: if a class defines
 :meth:`__getitem__`, ``x in y`` is ``True`` if and only if there is a non-negative
-integer index *i* such that ``x == y[i]``, and all lower integer indices do not
-raise :exc:`IndexError` exception.  (If any other exception is raised, it is as
+integer index *i* such that ``x is y[i] or x == y[i]``, and no lower integer index
+raises the :exc:`IndexError` exception.  (If any other exception is raised, it is as
 if :keyword:`in` raised that exception).
 
 .. index::

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1443,9 +1443,9 @@ y`` returns ``True`` if ``y.__contains__(x)`` returns a true value, and
 ``False`` otherwise.
 
 For user-defined classes which do not define :meth:`__contains__` but do define
-:meth:`__iter__`, ``x in y`` is ``True`` if some value ``z``, for which the 
-expression ``x is z or x == z`` is true, is produced while iterating over ``y``.  
-If an exception is raised during the iteration, it is as if :keyword:`in` raised 
+:meth:`__iter__`, ``x in y`` is ``True`` if some value ``z``, for which the
+expression ``x is z or x == z`` is true, is produced while iterating over ``y``.
+If an exception is raised during the iteration, it is as if :keyword:`in` raised
 that exception.
 
 Lastly, the old-style iteration protocol is tried: if a class defines


### PR DESCRIPTION
The documentation doesn't match the implementation, which clearly does `x is y or x == y` to check if `x` is the element `y` from a container. Both the `__iter__` and the index-iteration method test the elements using `is` first. While the document says that `x is x` means that `x == x` should be true, it is not true for example in the case of `nan`:

```>>> x = float('nan') 
>>> x == x
False
>>> x is x
True```

The following demonstrates the behaviour that is against the documented behaviour:

```>>> class Foo:
...     def __iter__(self):
...         return iter([x])
... 
>>> x in Foo()
True
>>> any(x == i for i in Foo())
False
>>> class Bar:
...     def __getitem__(self):
...         return [x].__getitem__(self)
... 
>>> class Bar:
...     def __getitem__(self, i):
...         return [x].__getitem__(i)
... 
>>> x in Bar
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: argument of type 'type' is not iterable
>>> x in Bar()
True
>>> any(x == i for i in Bar())
False```

<!-- issue-number: [bpo-30969](https://bugs.python.org/issue30969) -->
https://bugs.python.org/issue30969
<!-- /issue-number -->
