### PR TITLE
fix one typo (from "yingyang" to "yinyang") # skip issue

### DIFF
--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -2367,7 +2367,7 @@ The demo scripts are:
 | wikipedia      | a pattern from the wikipedia | :func:`clone`,        |
 |                | article on turtle graphics   | :func:`undo`          |
 +----------------+------------------------------+-----------------------+
-| yingyang       | another elementary example   | :func:`circle`        |
+| yinyang        | another elementary example   | :func:`circle`        |
 +----------------+------------------------------+-----------------------+
 
 Have fun!


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3983683/28404051-35557612-6d5a-11e7-8adb-b0a84d4d50c7.png)
