### PR TITLE
[2.7] Fix typo in Turtle Docs: yingyang -> yinyang (GH-2770)

### DIFF
--- a/Doc/library/turtle.rst
+++ b/Doc/library/turtle.rst
@@ -2219,7 +2219,7 @@ The demoscripts are:
 | wikipedia      | a pattern from the wikipedia | :func:`clone`,        |
 |                | article on turtle graphics   | :func:`undo`          |
 +----------------+------------------------------+-----------------------+
-| yingyang       | another elementary example   | :func:`circle`        |
+| yinyang        | another elementary example   | :func:`circle`        |
 +----------------+------------------------------+-----------------------+
 
 Have fun!


### PR DESCRIPTION
(cherry picked from commit fff2a21057b98732562098e3bdd65980551f0135)