### PR TITLE
[3.5] bpo-30822: regrtest: remove tzdata

### DIFF
--- a/Lib/test/libregrtest/__init__.py
+++ b/Lib/test/libregrtest/__init__.py
@@ -1,5 +1,0 @@
-# We import importlib *ASAP* in order to test #15386
-import importlib
-
-from test.libregrtest.cmdline import _parse_args, RESOURCE_NAMES, ALL_RESOURCES
-from test.libregrtest.main import main

--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -214,10 +214,7 @@ ALL_RESOURCES = ('audio', 'curses', 'largefile', 'network',
 #
 # - extralagefile (ex: test_zipfile64): really too slow to be enabled
 #   "by default"
-# - tzdata: while needed to validate fully test_datetime, it makes
-#   test_datetime too slow (15-20 min on some buildbots) and so is disabled by
-#   default (see bpo-30822).
-RESOURCE_NAMES = ALL_RESOURCES + ('extralargefile', 'tzdata')
+RESOURCE_NAMES = ALL_RESOURCES + ('extralargefile',)
 
 # When tests are run from the Python build directory, it is best practice
 # to keep the test files in a subfolder.  This eases the cleanup of leftover

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -204,9 +204,9 @@ class ParseArgsTestCase(unittest.TestCase):
                 self.checkError([opt, 'foo'], 'invalid resource')
 
                 # all + a resource not part of "all"
-                ns = regrtest._parse_args([opt, 'all,tzdata'])
+                ns = regrtest._parse_args([opt, 'all,extralargefile'])
                 self.assertEqual(ns.use_resources,
-                                 list(regrtest.ALL_RESOURCES) + ['tzdata'])
+                                 list(regrtest.ALL_RESOURCES) + ['extralargefile'])
 
                 # test another resource which is not part of "all"
                 ns = regrtest._parse_args([opt, 'extralargefile'])

--- a/Misc/NEWS.d/next/Tests/2017-07-20-14-29-54.bpo-30822.X0wREo.rst
+++ b/Misc/NEWS.d/next/Tests/2017-07-20-14-29-54.bpo-30822.X0wREo.rst
@@ -1,5 +1,2 @@
-regrtest: Exclude tzdata from regrtest --all. When running the test suite
-using --use=all / -u all, exclude tzdata since it makes test_datetime too
-slow (15-20 min on some buildbots) which then times out on some buildbots.
-Fix also regrtest command line parser to allow passing -u extralargefile to
+Fix regrtest command line parser to allow passing -u extralargefile to
 run test_zipfile64.


### PR DESCRIPTION
* Oops, tzdata was introduced in Python 3.6: remove it from regrtest
* Remove also ``Lib/test/libregrtest/__init__.py`` file: add by mistake on a backport.
