### PR TITLE
[2.7] bpo-30822: regrtest: fix -u extralargefile

### DIFF
--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -250,9 +250,15 @@ PROGRESS_UPDATE = 30.0   # seconds
 
 from test import test_support
 
-RESOURCE_NAMES = ('audio', 'curses', 'largefile', 'network', 'bsddb',
-                  'decimal', 'cpu', 'subprocess', 'urlfetch', 'gui',
-                  'xpickle')
+ALL_RESOURCES = ('audio', 'curses', 'largefile', 'network', 'bsddb',
+                 'decimal', 'cpu', 'subprocess', 'urlfetch', 'gui',
+                 'xpickle')
+
+# Other resources excluded from --use=all:
+#
+# - extralagefile (ex: test_zipfile64): really too slow to be enabled
+#   "by default"
+RESOURCE_NAMES = ALL_RESOURCES + ('extralargefile',)
 
 TEMPDIR = os.path.abspath(tempfile.gettempdir())
 
@@ -420,7 +426,7 @@ def main(tests=None, testdir=None, verbose=0, quiet=False,
             u = [x.lower() for x in a.split(',')]
             for r in u:
                 if r == 'all':
-                    use_resources[:] = RESOURCE_NAMES
+                    use_resources[:] = ALL_RESOURCES
                     continue
                 remove = False
                 if r[0] == '-':

--- a/Misc/NEWS.d/next/Tests/2017-07-20-14-29-54.bpo-30822.X0wREo.rst
+++ b/Misc/NEWS.d/next/Tests/2017-07-20-14-29-54.bpo-30822.X0wREo.rst
@@ -1,0 +1,2 @@
+Fix regrtest command line parser to allow passing -u extralargefile to
+run test_zipfile64.


### PR DESCRIPTION
Fix also regrtest command line parser to allow passing -u
extralargefile to run test_zipfile64.