### PR TITLE
bpo-30980: Fix double close in asyncore.file_wrapper

### DIFF
--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -619,8 +619,9 @@ if os.name == 'posix':
         def close(self):
             if self.fd < 0:
                 return
-            os.close(self.fd)
+            fd = self.fd
             self.fd = -1
+            os.close(fd)
 
         def fileno(self):
             return self.fd

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -431,9 +431,11 @@ class FileWrapperTest(unittest.TestCase):
     def test_close_twice(self):
         fd = os.open(support.TESTFN, os.O_RDONLY)
         f = asyncore.file_wrapper(fd)
-        os.close(fd)
+        os.close(f.fd)  # file_wrapper dupped fd
 
-        f.close()
+        with self.assertRaises(OSError):
+            f.close()
+
         self.assertEqual(f.fd, -1)
         # calling close twice should not fail
         f.close()

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -431,8 +431,9 @@ class FileWrapperTest(unittest.TestCase):
     def test_close_twice(self):
         fd = os.open(support.TESTFN, os.O_RDONLY)
         f = asyncore.file_wrapper(fd)
-        os.close(f.fd)  # file_wrapper dupped fd
+        os.close(fd)
 
+        os.close(f.fd)  # file_wrapper dupped fd
         with self.assertRaises(OSError):
             f.close()
 


### PR DESCRIPTION
test_close_twice was not considering the fact that file_wrapper is
duping the file descriptor. Closing the original descriptor left the
duped one open, hiding the fact that close protection is not effective.