### PR TITLE
[3.6] bpo-30964: Mention ensurepip in package installation docs (GH-2…

### DIFF
--- a/Doc/installing/index.rst
+++ b/Doc/installing/index.rst
@@ -211,6 +211,17 @@ On such systems, it is often better to use a virtual environment or a
 per-user installation when installing packages with ``pip``.
 
 
+Pip not installed
+-----------------
+
+It is possible that ``pip`` does not get installed by default. One potential fix is::
+
+    python -m ensurepip --default-pip
+
+There are also additional resources for `installing pip.
+<https://packaging.python.org/tutorials/installing-packages/#install-pip-setuptools-and-wheel>`__
+
+
 Installing binary extensions
 ----------------------------
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -802,6 +802,7 @@ Kim Knapp
 Lenny Kneler
 Pat Knight
 Jeff Knupp
+Nicholas Kobald
 Kubilay Kocak
 Greg Kochanski
 Manvisha Kodali


### PR DESCRIPTION
…786)

Adds a new 'Pip not installed' section that covers
running `ensurepip` manually, and also references
the relevant section of the Python Packaging User
Guide.
(cherry picked from commit b3527bfefd7a0188d43a2d7515ac6addd97a8202)

tagging @ncoghlan 