### PR TITLE
bpo-29606: urllib rejects newline in FTP

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1502,6 +1502,8 @@ class FTPHandler(BaseHandler):
         host = req.host
         if not host:
             raise URLError('ftp error: no host given')
+        if '\n' in unquote(host):
+            raise URLError("ftp error: illegal newline character")
         host, port = splitport(host)
         if port is None:
             port = ftplib.FTP_PORT
@@ -2010,6 +2012,8 @@ class URLopener:
         if not isinstance(url, str):
             raise URLError('ftp error: proxy support for ftp protocol currently not implemented')
         import mimetypes
+        if '\n' in unquote(url):
+            raise URLError("ftp error: illegal newline character")
         host, path = splithost(url)
         if not host: raise URLError('ftp error: no host given')
         host, port = splitport(host)

--- a/Misc/NEWS.d/next/Library/2017-07-21-12-05-23.bpo-29606.MPgBLH.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-21-12-05-23.bpo-29606.MPgBLH.rst
@@ -1,0 +1,3 @@
+FTPHandler.ftp_open() and URLOpener.open_ftp() of urllib.request now
+raise an exception if the unquoted URL contains a newline character
+(U+000A, "\n").


### PR DESCRIPTION
FTPHandler.ftp_open() and URLOpener.open_ftp() of urllib.request now
raise an exception if the unquoted URL contains a newline character
(U+000A, "\n").

Co-Authored-By: Dong-hee Na <donghee.na92@gmail.com>