### PR TITLE
bpo-30983: eval frame rename in pep 0523 broke gdb's python extension

### DIFF
--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1502,8 +1502,10 @@ class Frame(object):
         return False
 
     def is_evalframeex(self):
-        '''Is this a PyEval_EvalFrameEx frame?'''
-        if self._gdbframe.name() == 'PyEval_EvalFrameEx':
+        '''Is this a PyEval_EvalFrameEx or _PyEval_EvalFrameDefault (PEP 0523)
+        frame?'''
+        if self._gdbframe.name() in ('PyEval_EvalFrameEx',
+                                     '_PyEval_EvalFrameDefault'):
             '''
             I believe we also need to filter on the inline
             struct frame_id.inline_depth, only regarding frames with


### PR DESCRIPTION
pep 0523 renames PyEval_EvalFrameEx to _PyEval_EvalFrameDefault while the gdb python extension only looks for PyEval_EvalFrameEx to understand if it is dealing with a frame.

Final effect is that attaching gdb to a python3.6 process doesnt resolve python objects. Eg. py-list and py-bt dont work properly.

This patch fixes that. Tested locally on python3.6