### PR TITLE
[3.5] bpo-29403: Fix mock's broken autospec behavior on method-bound builtin functions (GH-3)

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -177,7 +177,7 @@ def _set_signature(mock, original, instance=False):
     skipfirst = isinstance(original, type)
     result = _get_signature_object(original, instance, skipfirst)
     if result is None:
-        return
+        return mock
     func, sig = result
     def checksig(*args, **kwargs):
         sig.bind(*args, **kwargs)

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -1,3 +1,5 @@
+import time
+import types
 import unittest
 
 from unittest.mock import (
@@ -854,6 +856,19 @@ class SpecSignatureTest(unittest.TestCase):
         check_data_descriptor(foo.slot)
         # plain data descriptor
         check_data_descriptor(foo.desc)
+
+
+    def test_autospec_on_bound_builtin_function(self):
+        meth = types.MethodType(time.ctime, time.time())
+        self.assertIsInstance(meth(), str)
+        mocked = create_autospec(meth)
+
+        # no signature, so no spec to check against
+        mocked()
+        mocked.assert_called_once_with()
+        mocked.reset_mock()
+        mocked(4, 5, 6)
+        mocked.assert_called_once_with(4, 5, 6)
 
 
 class TestCallList(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2017-07-20-02-29-49.bpo-29403.3RinCV.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-20-02-29-49.bpo-29403.3RinCV.rst
@@ -1,0 +1,2 @@
+Fix ``unittest.mock``'s autospec to not fail on method-bound builtin
+functions.  Patch by Aaron Gallagher.


### PR DESCRIPTION
Cython will, in the right circumstances, offer a MethodType instance
where im_func is a builtin function. Any instance of MethodType is
automatically assumed to be a Python-defined function (more
specifically, a function that has an inspectable signature), but
_set_signature was still conservative in its assumptions. As a result
_set_signature would return early with None instead of a mock since
the im_func had no inspectable signature. This causes problems
deeper inside mock, as _set_signature is assumed to _always_
return a mock, and nothing checked its return value.

In similar corner cases, autospec will simply not check the spec of the
function, so _set_signature is amended to now return early with the
original, not-wrapped mock object.

Patch by Aaron Gallagher.

(cherry picked from commit 856cbcc12f2e4cca93af5dc7ed6bcea4dd942f10)

<!-- issue-number: bpo-29403 -->
https://bugs.python.org/issue29403
<!-- /issue-number -->
