### PR TITLE
bpo-30981: IDLE: Augment one configdialog font page test

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -153,6 +153,14 @@ class ConfigDialog(Toplevel):
     def create_page_font_tab(self):
         """Return frame of widgets for Font/Tabs tab.
 
+        Enable users to provisionally change font face, size, or
+        boldness and to see the consequence of proposed choices.  Each
+        action set 3 options in changes structuree and changes the
+        corresponding aspect of the font sample on this page and
+        highlight sample on highlight page.
+
+        Enable users to change spaces entered for indent tabs.
+
         Tk Variables:
             font_name: Font face.
             font_size: Font size.
@@ -161,7 +169,7 @@ class ConfigDialog(Toplevel):
             space_num: Indentation width.
 
         Data Attribute:
-            edit_font: Font widget with default font name, size, and weight.
+            edit_font: Font with default font name, size, and weight.
 
         Methods:
             load_font_cfg: Set vars and fontlist.

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -8,7 +8,6 @@ from test.support import requires
 requires('gui')
 from tkinter import Tk, BooleanVar
 import unittest
-from unittest import mock
 import idlelib.config as config
 from idlelib.idle_test.mock_idle import Func
 
@@ -76,7 +75,7 @@ class FontTabTest(unittest.TestCase):
 
     def test_bold_toggle(self):
         bt = dialog.bold_toggle
-        mock_bold = bt['variable'] = BooleanVar()
+        mock_bold = bt['variable'] = BooleanVar(root)
         mock_command = bt['command'] = Func()
         bt.invoke()
         self.assertEqual(mock_command.called, 1)

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -6,8 +6,9 @@ Coverage: 46% just by creating dialog, 60% with current tests.
 from idlelib.configdialog import ConfigDialog, idleConf, changes
 from test.support import requires
 requires('gui')
-from tkinter import Tk
+from tkinter import Tk, BooleanVar
 import unittest
+from unittest import mock
 import idlelib.config as config
 from idlelib.idle_test.mock_idle import Func
 
@@ -45,7 +46,6 @@ def tearDownModule():
     del root
 
 
-@unittest.skip("skip failing tests until fixed")
 class FontTabTest(unittest.TestCase):
 
     def setUp(self):
@@ -75,11 +75,16 @@ class FontTabTest(unittest.TestCase):
         self.assertEqual(mainpage, expected)
 
     def test_bold_toggle(self):
-        d = dialog
-        d.set_samples = Func()
-        d.bold_toggle.toggle()
-        self.assertEqual(d.set_samples.called, 1)
-        del d.set_samples
+        bt = dialog.bold_toggle
+        mock_bold = bt['variable'] = BooleanVar()
+        mock_command = bt['command'] = Func()
+        bt.invoke()
+        self.assertEqual(mock_command.called, 1)
+        self.assertEqual(bt['onvalue'], mock_bold.get())
+        bt.invoke()
+        self.assertEqual(mock_command.called, 2)
+        self.assertEqual(bt['offvalue'], mock_bold.get())
+        del mock_command, mock_bold
 
     def test_set_samples(self):
         d = dialog


### PR DESCRIPTION
Remove broken test of bold_toggle and test with its command, set_samples.

<!-- issue-number: bpo-30981 -->
https://bugs.python.org/issue30981
<!-- /issue-number -->
