### PR TITLE
gh-75171: Fix parsing address headers with dots start/end display name

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -928,12 +928,12 @@ class DisplayName(Phrase):
         if res[0].token_type == 'cfws':
             res.pop(0)
         else:
-            if res[0][0].token_type == 'cfws':
+            if isinstance(res[0][0], TokenList) and res[0][0].token_type == 'cfws':
                 res[0] = TokenList(res[0][1:])
         if res[-1].token_type == 'cfws':
             res.pop()
         else:
-            if res[-1][-1].token_type == 'cfws':
+            if isinstance(res[-1][-1], TokenList) and res[-1][-1].token_type == 'cfws':
                 res[-1] = TokenList(res[-1][:-1])
         return res.value
 

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1167,6 +1167,26 @@ class TestAddressHeader(TestHeaderBase):
             'example.com',
             None),
 
+        'name_ending_with_dot_without_space':
+            ('John X.<jxd@example.com>',
+             [errors.ObsoleteHeaderDefect],
+             '"John X." <jxd@example.com>',
+             'John X.',
+             'jxd@example.com',
+             'jxd',
+             'example.com',
+             None),
+
+        'name_starting_with_dot':
+            ('. Doe <jxd@example.com>',
+             [errors.InvalidHeaderDefect, errors.ObsoleteHeaderDefect],
+             '". Doe" <jxd@example.com>',
+             '. Doe',
+             'jxd@example.com',
+             'jxd',
+             'example.com',
+             None),
+
         }
 
         # XXX: Need many more examples, and in particular some with names in
@@ -1224,7 +1244,7 @@ class TestAddressHeader(TestHeaderBase):
             'Harry W. Hastings')
 
     def test_complex_address_list(self):
-        examples = list(self.example_params.values())
+        examples = list(self.example_params.values())[:-1]
         source = ('dummy list:;, another: (empty);,' +
                  ', '.join([x[0] for x in examples[:4]]) + ', ' +
                  r'"A \"list\"": ' +


### PR DESCRIPTION
In `email._header_value_parser.DisplayName()`, ensure we're dealing with a `TokenList` before trying to access its `token_type` attribute. This scenario is encountered when parsing a display name starting with a dot (".") or ending with a dot and without whitespace separating it from the angle bracket starting the address.

Add tests to confirm.

<!-- issue-number: [bpo-30988](https://bugs.python.org/issue30988) -->
https://bugs.python.org/issue30988
<!-- /issue-number -->


<!-- gh-issue-number: gh-75171 -->
* Issue: gh-75171
<!-- /gh-issue-number -->
