### PR TITLE
bpo-30989: Sort in TimedRotatingFileHandler only when needed.

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -356,10 +356,10 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
                 suffix = fileName[plen:]
                 if self.extMatch.match(suffix):
                     result.append(os.path.join(dirName, fileName))
-        result.sort()
         if len(result) < self.backupCount:
             result = []
         else:
+            result.sort()
             result = result[:len(result) - self.backupCount]
         return result
 


### PR DESCRIPTION
TimedRotatingFileHandler's getFilesToDelete should sort only when `len(result)` > backupCount

<!-- issue-number: bpo-30989 -->
https://bugs.python.org/issue30989
<!-- /issue-number -->
