### PR TITLE
bpo-27790: Remove /LTCG from distutils linker flags in debug builds

### DIFF
--- a/Lib/distutils/_msvccompiler.py
+++ b/Lib/distutils/_msvccompiler.py
@@ -237,7 +237,7 @@ class MSVCCompiler(CCompiler) :
             ldflags.extend(('/nodefaultlib:libucrt.lib', 'ucrt.lib'))
 
         ldflags_debug = [
-            '/nologo', '/INCREMENTAL:NO', '/LTCG', '/DEBUG:FULL'
+            '/nologo', '/INCREMENTAL:NO', '/DEBUG:FULL'
         ]
 
         self.ldflags_exe = [*ldflags, '/MANIFEST:EMBED,ID=1']


### PR DESCRIPTION
This avoids a warning:

    LINK : /LTCG specified but no code generation required; remove /LTCG
    from the link command line to improve linker performance

<!-- issue-number: bpo-27790 -->
https://bugs.python.org/issue27790
<!-- /issue-number -->
