### PR TITLE
[3.5] bpo-30822: Fix testing of datetime module. (GH-2530) (GH-2783)

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -2135,7 +2135,8 @@ else:
          _check_tzinfo_arg, _check_tzname, _check_utc_offset, _cmp, _cmperror,
          _date_class, _days_before_month, _days_before_year, _days_in_month,
          _format_time, _is_leap, _isoweek1monday, _math, _ord2ymd,
-         _time, _time_class, _tzinfo_class, _wrap_strftime, _ymd2ord)
+         _time, _time_class, _tzinfo_class, _wrap_strftime, _ymd2ord,
+         _divide_and_round)
     # XXX Since import * above excludes names that start with _,
     # docstring does not get overwritten. In the future, it may be
     # appropriate to maintain a single module level docstring and

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -53,8 +53,9 @@ class TestModule(unittest.TestCase):
         self.assertEqual(datetime.MAXYEAR, 9999)
 
     def test_name_cleanup(self):
-        if '_Fast' not in str(self):
-            return
+        if '_Pure' in self.__class__.__name__:
+            self.skipTest('Only run for Fast C implementation')
+
         datetime = datetime_module
         names = set(name for name in dir(datetime)
                     if not name.startswith('__') and not name.endswith('__'))
@@ -64,8 +65,9 @@ class TestModule(unittest.TestCase):
         self.assertEqual(names - allowed, set([]))
 
     def test_divide_and_round(self):
-        if '_Fast' in str(self):
-            return
+        if '_Fast' in self.__class__.__name__:
+            self.skipTest('Only run for Pure Python implementation')
+
         dar = datetime_module._divide_and_round
 
         self.assertEqual(dar(-10, -3), 3)
@@ -2733,7 +2735,7 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
         self.assertRaises(TypeError, t.strftime, "%Z")
 
         # Issue #6697:
-        if '_Fast' in str(self):
+        if '_Fast' in self.__class__.__name__:
             Badtzname.tz = '\ud800'
             self.assertRaises(ValueError, t.strftime, "%Z")
 

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -27,6 +27,7 @@ for module, suffix in zip(test_modules, test_suffixes):
         if not (isinstance(cls, type) and issubclass(cls, unittest.TestCase)):
             continue
         cls.__name__ = name + suffix
+        cls.__qualname__ = name + suffix
         @classmethod
         def setUpClass(cls_, module=module):
             cls_._save_sys_modules = sys.modules.copy()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1547,6 +1547,7 @@ Doobee R. Tzeck
 Eren Türkay
 Lionel Ulmer
 Adnan Umer
+Utkarsh Upadhyay
 Roger Upole
 Daniel Urban
 Michael Urman


### PR DESCRIPTION
Only C implementation was tested..
(cherry picked from commit 287c5594edc1ca08db64d1f4739cc36bfe75ae75)

<!-- issue-number: bpo-30822 -->
https://bugs.python.org/issue30822
<!-- /issue-number -->
