### PR TITLE
[3.6] bpo-30822: Fix testing of datetime module. (GH-2530) (GH-2783)

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -2271,7 +2271,8 @@ else:
          _check_tzinfo_arg, _check_tzname, _check_utc_offset, _cmp, _cmperror,
          _date_class, _days_before_month, _days_before_year, _days_in_month,
          _format_time, _is_leap, _isoweek1monday, _math, _ord2ymd,
-         _time, _time_class, _tzinfo_class, _wrap_strftime, _ymd2ord)
+         _time, _time_class, _tzinfo_class, _wrap_strftime, _ymd2ord,
+         _divide_and_round)
     # XXX Since import * above excludes names that start with _,
     # docstring does not get overwritten. In the future, it may be
     # appropriate to maintain a single module level docstring and

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -61,8 +61,9 @@ class TestModule(unittest.TestCase):
         self.assertEqual(datetime.MAXYEAR, 9999)
 
     def test_name_cleanup(self):
-        if '_Fast' not in str(self):
-            return
+        if '_Pure' in self.__class__.__name__:
+            self.skipTest('Only run for Fast C implementation')
+
         datetime = datetime_module
         names = set(name for name in dir(datetime)
                     if not name.startswith('__') and not name.endswith('__'))
@@ -72,8 +73,9 @@ class TestModule(unittest.TestCase):
         self.assertEqual(names - allowed, set([]))
 
     def test_divide_and_round(self):
-        if '_Fast' in str(self):
-            return
+        if '_Fast' in self.__class__.__name__:
+            self.skipTest('Only run for Pure Python implementation')
+
         dar = datetime_module._divide_and_round
 
         self.assertEqual(dar(-10, -3), 3)
@@ -2851,7 +2853,7 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
         self.assertRaises(TypeError, t.strftime, "%Z")
 
         # Issue #6697:
-        if '_Fast' in str(self):
+        if '_Fast' in self.__class__.__name__:
             Badtzname.tz = '\ud800'
             self.assertRaises(ValueError, t.strftime, "%Z")
 

--- a/Lib/test/test_datetime.py
+++ b/Lib/test/test_datetime.py
@@ -20,7 +20,7 @@ test_suffixes = ["_Pure", "_Fast"]
 # XXX(gb) First run all the _Pure tests, then all the _Fast tests.  You might
 # not believe this, but in spite of all the sys.modules trickery running a _Pure
 # test last will leave a mix of pure and native datetime stuff lying around.
-test_classes = []
+all_test_classes = []
 
 for module, suffix in zip(test_modules, test_suffixes):
     test_classes = []
@@ -33,7 +33,8 @@ for module, suffix in zip(test_modules, test_suffixes):
             suit = cls()
             test_classes.extend(type(test) for test in suit)
     for cls in test_classes:
-        cls.__name__ = name + suffix
+        cls.__name__ += suffix
+        cls.__qualname__ += suffix
         @classmethod
         def setUpClass(cls_, module=module):
             cls_._save_sys_modules = sys.modules.copy()
@@ -46,9 +47,10 @@ for module, suffix in zip(test_modules, test_suffixes):
             sys.modules.update(cls_._save_sys_modules)
         cls.setUpClass = setUpClass
         cls.tearDownClass = tearDownClass
+    all_test_classes.extend(test_classes)
 
 def test_main():
-    run_unittest(*test_classes)
+    run_unittest(*all_test_classes)
 
 if __name__ == "__main__":
     test_main()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1583,6 +1583,7 @@ Doobee R. Tzeck
 Eren Türkay
 Lionel Ulmer
 Adnan Umer
+Utkarsh Upadhyay
 Roger Upole
 Daniel Urban
 Michael Urman


### PR DESCRIPTION
Only C implementation was tested..
(cherry picked from commit 287c5594edc1ca08db64d1f4739cc36bfe75ae75)

<!-- issue-number: bpo-30822 -->
https://bugs.python.org/issue30822
<!-- /issue-number -->
