### PR TITLE
bpo-30994: Avoid copying socket_map before polling

### DIFF
--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -127,7 +127,7 @@ def poll(timeout=0.0, map=None):
         map = socket_map
     if map:
         r = []; w = []; e = []
-        for fd, obj in list(map.items()):
+        for fd, obj in map.items():
             is_r = obj.readable()
             is_w = obj.writable()
             if is_r:
@@ -170,7 +170,7 @@ def poll2(timeout=0.0, map=None):
         timeout = int(timeout*1000)
     pollster = select.poll()
     if map:
-        for fd, obj in list(map.items()):
+        for fd, obj in map.items():
             flags = 0
             if obj.readable():
                 flags |= select.POLLIN | select.POLLPRI


### PR DESCRIPTION
Asyncore is not thread safe, and cannot be called from multiple threads.
Hence it does not need to copy the socket_map when preparing for poll or
select.

<!-- issue-number: bpo-30994 -->
https://bugs.python.org/issue30994
<!-- /issue-number -->
