### PR TITLE
[3.6] Make test_shutil test_disk_usage not depend on the cwd fs; GH-2597

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1294,7 +1294,7 @@ class TestShutil(unittest.TestCase):
     @unittest.skipUnless(hasattr(shutil, 'disk_usage'),
                          "disk_usage not available on this platform")
     def test_disk_usage(self):
-        usage = shutil.disk_usage(os.getcwd())
+        usage = shutil.disk_usage(os.path.dirname(__file__))
         self.assertGreater(usage.total, 0)
         self.assertGreater(usage.used, 0)
         self.assertGreaterEqual(usage.free, 0)


### PR DESCRIPTION
Make test_shutil test_disk_usage not depend on the current working directory's filesystem.
(cherry picked from commit 529746c90584069270cd122920270bd7be38bca3)