### PR TITLE
bpo-30940: fix docs for round if second arg is None

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1297,7 +1297,7 @@ are always available.  They are listed here in alphabetical order.
    arguments starting at ``0``).
 
 
-.. function:: round(number[, ndigits])
+.. function:: round(number, ndigits=None)
 
    Return *number* rounded to *ndigits* precision after the decimal
    point.  If *ndigits* is omitted or is ``None``, it returns the
@@ -1308,7 +1308,7 @@ are always available.  They are listed here in alphabetical order.
    equally close, rounding is done toward the even choice (so, for example,
    both ``round(0.5)`` and ``round(-0.5)`` are ``0``, and ``round(1.5)`` is
    ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
-   negative).  The return value is an integer if *ndigits* is omitted or *None*.
+   negative).  The return value is an integer if *ndigits* is omitted or ``None``.
    Otherwise the return value has the same type as *number*.
 
    For a general Python object ``number``, ``round(number, ndigits)`` delegates to

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1300,7 +1300,7 @@ are always available.  They are listed here in alphabetical order.
 .. function:: round(number, ndigits=None)
 
    Return *number* rounded to *ndigits* precision after the decimal
-   point.  If *ndigits* is omitted or is ``None``, it returns the
+   point.  If *ndigits* is omitted or ``None``, it returns the
    nearest integer to its input.
 
    For the built-in types supporting :func:`round`, values are rounded to the

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1300,7 +1300,7 @@ are always available.  They are listed here in alphabetical order.
 .. function:: round(number, ndigits=None)
 
    Return *number* rounded to *ndigits* precision after the decimal
-   point.  If *ndigits* is omitted or ``None``, it returns the
+   point.  If *ndigits* is omitted or is ``None``, it returns the
    nearest integer to its input.
 
    For the built-in types supporting :func:`round`, values are rounded to the
@@ -1308,7 +1308,7 @@ are always available.  They are listed here in alphabetical order.
    equally close, rounding is done toward the even choice (so, for example,
    both ``round(0.5)`` and ``round(-0.5)`` are ``0``, and ``round(1.5)`` is
    ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
-   negative).  The return value is an integer if *ndigits* is omitted or ``None``.
+   negative).  The return value is an integer if *ndigits* is omitted or is ``None``.
    Otherwise the return value has the same type as *number*.
 
    For a general Python object ``number``, ``round(number, ndigits)`` delegates to

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1308,8 +1308,8 @@ are always available.  They are listed here in alphabetical order.
    equally close, rounding is done toward the even choice (so, for example,
    both ``round(0.5)`` and ``round(-0.5)`` are ``0``, and ``round(1.5)`` is
    ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
-   negative).  The return value is an integer if called with one argument,
-   otherwise of the same type as *number*.
+   negative).  The return value is an integer if *ndigits* is omitted or *None*.
+   Otherwise the return value has the same type as *number*.
 
    For a general Python object ``number``, ``round(number, ndigits)`` delegates to
    ``number.__round__(ndigits)``.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2086,7 +2086,7 @@ builtin_round(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 PyDoc_STRVAR(round_doc,
-"round(number[, ndigits]) -> number\n\
+"round(number, ndigits=None) -> number\n\
 \n\
 Round a number to a given precision in decimal digits (default 0 digits).\n\
 This returns an int when called with one argument, otherwise the\n\

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2089,7 +2089,7 @@ PyDoc_STRVAR(round_doc,
 "round(number, ndigits=None) -> number\n\
 \n\
 Round a number to a given precision in decimal digits (default 0 digits).\n\
-This returns an int when called with one argument, otherwise the\n\
+This returns an int if ndigits is omitted or is None, otherwise the\n\
 same type as the number. ndigits may be negative.");
 
 


### PR DESCRIPTION


<!-- issue-number: bpo-30940 -->
https://bugs.python.org/issue30940
<!-- /issue-number -->
