### PR TITLE
[2.7] closes bpo-8450: a better error message when http status line isn't received

### DIFF
--- a/Lib/httplib.py
+++ b/Lib/httplib.py
@@ -399,7 +399,7 @@ class HTTPResponse:
         if not line:
             # Presumably, the server closed the connection before
             # sending a valid response.
-            raise BadStatusLine(line)
+            raise BadStatusLine("No status line received - the server has closed the connection")
         try:
             [version, status, reason] = line.split(None, 2)
         except ValueError:


### PR DESCRIPTION
When the server has closed the connection before sending a status-line,
the client's error message should have a more descriptive error message

https://bugs.python.org/issue8450

<!-- issue-number: [bpo-8450](https://www.bugs.python.org/issue8450) -->
https://bugs.python.org/issue8450
<!-- /issue-number -->
