### PR TITLE
bpo-29572: Update macOS installer build to OpenSSL 1.0.2k (#457)

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -242,9 +242,9 @@ def library_recipes():
 
         result.extend([
           dict(
-              name="OpenSSL 1.0.2j",
-              url="https://www.openssl.org/source/openssl-1.0.2j.tar.gz",
-              checksum='96322138f0b69e61b7212bc53d5e912b',
+              name="OpenSSL 1.0.2k",
+              url="https://www.openssl.org/source/openssl-1.0.2k.tar.gz",
+              checksum='f965fc0bf01bf882b31314b61391ae65',
               patches=[
                   "openssl_sdk_makedepend.patch",
                    ],

--- a/Mac/BuildScript/openssl_sdk_makedepend.patch
+++ b/Mac/BuildScript/openssl_sdk_makedepend.patch
@@ -1,6 +1,6 @@
 # HG changeset patch
 #
-# 	using openssl 1.0.2j
+# 	using openssl 1.0.2k
 #
 # - support building with an OS X SDK
 


### PR DESCRIPTION
(cherry picked from commit cfcd76777e35c83d548d8736f5d7dc92fe56d806)

<!-- issue-number: bpo-29572 -->
https://bugs.python.org/issue29572
<!-- /issue-number -->
