### PR TITLE
bpo-30188: test_nntplib catch also ssl.SSLEOFError

### DIFF
--- a/Lib/test/test_nntplib.py
+++ b/Lib/test/test_nntplib.py
@@ -274,6 +274,11 @@ class NetworkedNNTPTestsMixin:
 NetworkedNNTPTestsMixin.wrap_methods()
 
 
+EOF_ERRORS = [EOFError]
+if ssl is not None:
+    EOF_ERRORS.append(ssl.SSLEOFError)
+
+
 class NetworkedNNTPTests(NetworkedNNTPTestsMixin, unittest.TestCase):
     # This server supports STARTTLS (gmane doesn't)
     NNTP_HOST = 'news.trigofacile.com'
@@ -289,7 +294,7 @@ class NetworkedNNTPTests(NetworkedNNTPTestsMixin, unittest.TestCase):
             try:
                 cls.server = cls.NNTP_CLASS(cls.NNTP_HOST, timeout=TIMEOUT,
                                             usenetrc=False)
-            except EOFError:
+            except EOF_ERRORS:
                 raise unittest.SkipTest(f"{cls} got EOF error on connecting "
                                         f"to {cls.NNTP_HOST!r}")
 


### PR DESCRIPTION
Catch also ssl.SSLEOFError in NetworkedNNTPTests setUpClass().
EOFError was already catched.

<!-- issue-number: bpo-30188 -->
https://bugs.python.org/issue30188
<!-- /issue-number -->
