### PR TITLE
[3.6] bpo-30908: Fix dangling thread in test_os.TestSendfile (#2680)

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2621,6 +2621,7 @@ class TestSendfile(unittest.TestCase):
         self.client.close()
         if self.server.running:
             self.server.stop()
+        self.server = None
 
     def sendfile_wrapper(self, sock, file, offset, nbytes, headers=[], trailers=[]):
         """A higher level wrapper representing how an application is


### PR DESCRIPTION
tearDown() now clears explicitly the self.server variable to make
sure that the thread is completely cleared when tearDownClass()
checks if all threads have been cleaned up.

Fix the following warning:

$ ./python -m test --fail-env-changed -m test.test_os.TestSendfile.test_keywords -R 3:1 test_os
(...)
Warning -- threading_cleanup() failed to cleanup 0 threads after 3 sec (count: 0, dangling: 2)
(...)
Tests result: ENV CHANGED
(cherry picked from commit d1cc037d1442cc35d1b194ec8e50901514360949)

<!-- issue-number: bpo-30908 -->
https://bugs.python.org/issue30908
<!-- /issue-number -->
