### PR TITLE
bpo-30304: Fix TestCase.assertMultiLineEqual docs

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -1243,7 +1243,7 @@ Test cases
       Test that the multiline string *first* is equal to the string *second*.
       When not equal a diff of the two strings highlighting the differences
       will be included in the error message. This method is used by default
-      when comparing strings with :meth:`assertEqual`.
+      when comparing Unicode strings with :meth:`assertEqual`.
 
       .. versionadded:: 3.1
 


### PR DESCRIPTION
Added 'Unicode' word back in documentation of TestCase.assertMultiLineEqual
as the old text was misleading because “str” objects are also strings, but the 
default does not apply to “str” objects.

<!-- issue-number: bpo-30304 -->
https://bugs.python.org/issue30304
<!-- /issue-number -->
