### PR TITLE
bpo-31018: Switch to #pragma pack from __declspec(align) in _tracemalloc

### DIFF
--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -83,7 +83,7 @@ typedef struct
 #ifdef __GNUC__
 __attribute__((packed))
 #elif defined(_MSC_VER)
-_declspec(align(4))
+#pragma pack(push, 4)
 #endif
 {
     /* filename cannot be NULL: "<unknown>" is used if the Python frame
@@ -91,6 +91,9 @@ _declspec(align(4))
     PyObject *filename;
     unsigned int lineno;
 } frame_t;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 
 typedef struct {


### PR DESCRIPTION
```
..\Modules\_tracemalloc.c(88): warning C4359: '<unnamed-tag>': Alignment specifier is less than actual alignment (8), and will be ignored.
```

The _tracemalloc `frame_t` packing optimization is not working in Windows x64.

For this to actually work we simply need to use `#pragma pack` instead.

<!-- issue-number: bpo-31018 -->
https://bugs.python.org/issue31018
<!-- /issue-number -->
