### PR TITLE
bpo-31019: multiprocessing.Pool.terminate() now joins "dead" processes

### DIFF
--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -599,10 +599,8 @@ class Pool(object):
         if pool and hasattr(pool[0], 'terminate'):
             util.debug('joining pool workers')
             for p in pool:
-                if p.is_alive():
-                    # worker has not yet exited
-                    util.debug('cleaning up worker %d' % p.pid)
-                    p.join()
+                util.debug('cleaning up worker %d' % p.pid)
+                p.join()
 
     def __enter__(self):
         return self

--- a/Misc/NEWS.d/next/Library/2017-07-24-19-38-49.bpo-31019.Kk8H5i.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-24-19-38-49.bpo-31019.Kk8H5i.rst
@@ -1,0 +1,3 @@
+multiprocessing.Pool.terminate() now also joins "dead" processes even if
+their is_alive() method returns false. The change prevents leaking
+"dangling" processes.


### PR DESCRIPTION
bpo-31019: Pool.terminate() now also joins "dead" processes even if
their is_alive() method returns false. The change prevents leaking
"dangling" processes.

<!-- issue-number: bpo-31019 -->
https://bugs.python.org/issue31019
<!-- /issue-number -->
