### PR TITLE
bpo-30814, bpo-30876: Add new import test files to projects.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1204,6 +1204,8 @@ LIBSUBDIRS=	tkinter tkinter/test tkinter/test/test_tkinter \
 		test/test_import/data \
 		test/test_import/data/circular_imports \
 		test/test_import/data/circular_imports/subpkg \
+		test/test_import/data/package \
+		test/test_import/data/package2 \
 		test/test_importlib/namespace_pkgs \
 		test/test_importlib/namespace_pkgs/both_portions \
 		test/test_importlib/namespace_pkgs/both_portions/foo \

--- a/PCbuild/lib.pyproj
+++ b/PCbuild/lib.pyproj
@@ -1127,6 +1127,10 @@
     <Compile Include="test\test_import\data\circular_imports\subpkg\subpackage2.py" />
     <Compile Include="test\test_import\data\circular_imports\subpkg\util.py" />
     <Compile Include="test\test_import\data\circular_imports\util.py" />
+    <Compile Include="test\test_import\data\package\__init__.py" />
+    <Compile Include="test\test_import\data\package\submodule.py" />
+    <Compile Include="test\test_import\data\package2\submodule1.py" />
+    <Compile Include="test\test_import\data\package2\submodule2.py" />
     <Compile Include="test\test_import\__init__.py" />
     <Compile Include="test\test_import\__main__.py" />
     <Compile Include="test\test_index.py" />
@@ -1786,6 +1790,8 @@
     <Folder Include="test\test_import\data\" />
     <Folder Include="test\test_import\data\circular_imports" />
     <Folder Include="test\test_import\data\circular_imports\subpkg" />
+    <Folder Include="test\test_import\data\package" />
+    <Folder Include="test\test_import\data\package2" />
     <Folder Include="test\test_json" />
     <Folder Include="test\test_tools" />
     <Folder Include="test\test_warnings" />


### PR DESCRIPTION
I forget to include directories with new test files in the list of the library directories. This caused that these test files were not installed.

<!-- issue-number: bpo-30814 -->
https://bugs.python.org/issue30814
<!-- /issue-number -->
