### PR TITLE
bpo-9566: Silence warning in gcmodule.c caused by pydtrace.h

### DIFF
--- a/Include/pydtrace.h
+++ b/Include/pydtrace.h
@@ -29,7 +29,7 @@ static inline void PyDTrace_LINE(const char *arg0, const char *arg1, int arg2) {
 static inline void PyDTrace_FUNCTION_ENTRY(const char *arg0, const char *arg1, int arg2)  {}
 static inline void PyDTrace_FUNCTION_RETURN(const char *arg0, const char *arg1, int arg2) {}
 static inline void PyDTrace_GC_START(int arg0) {}
-static inline void PyDTrace_GC_DONE(int arg0) {}
+static inline void PyDTrace_GC_DONE(Py_ssize_t arg0) {}
 static inline void PyDTrace_INSTANCE_NEW_START(int arg0) {}
 static inline void PyDTrace_INSTANCE_NEW_DONE(int arg0) {}
 static inline void PyDTrace_INSTANCE_DELETE_START(int arg0) {}


### PR DESCRIPTION
```
..\Modules\gcmodule.c(1085): warning C4244: 'function': conversion from 'Py_ssize_t' to 'int', possible loss of data
```

Caused by DTrace stubs being defined as taking int. The real one takes a long (Include/pydtrace.d:12), which is probably 64-bit on architectures where DTrace is available but it is 32-bit on Windows x64. It really needs a `Py_ssize_t` but I'm not familiar enough with DTrace to change pydtrace.d. I think we can simply change the stub to a larger integer type without it causing issues... And maybe if someone really finds an issue he can also change pydtrace.d in the future.

<!-- issue-number: bpo-9566 -->
https://bugs.python.org/issue9566
<!-- /issue-number -->
