### PR TITLE
[3.6] Minor typo in curses.rst (GH-2763)

### DIFF
--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -65,7 +65,7 @@ and full support for mouse and keyboard input.
 The Python curses module
 ------------------------
 
-Thy Python module is a fairly simple wrapper over the C functions provided by
+The Python module is a fairly simple wrapper over the C functions provided by
 curses; if you're already familiar with curses programming in C, it's really
 easy to transfer that knowledge to Python.  The biggest difference is that the
 Python interface makes things simpler by merging different C functions such as


### PR DESCRIPTION
I found a tiny typo in the curses how-to: changed 'Thy' to 'The' on line 68.
(cherry picked from commit d439d3e)