### PR TITLE
bpo-30931: Fix asyncore race condition

### DIFF
--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -887,7 +887,7 @@ class PollTests(unittest.TestCase):
         self.assertEqual(testmap, {})
         self.assertEqual(read_calls, [1])
 
-    def test_poll_close_replace_dispatchers(self):
+    def test_poll_close_reuse_fd(self):
         testmap = {}
         read_calls = []
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -973,6 +973,7 @@ Vladimir Marangozov
 Colin Marc
 Vincent Marchetti
 David Marek
+Jaume Marhuenda
 Doug Marien
 Sven Marnach
 Alex Martelli

--- a/Misc/NEWS.d/next/Library/2017-07-24-23-52-39.bpo-30931.mZMsJ7.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-24-23-52-39.bpo-30931.mZMsJ7.rst
@@ -1,3 +1,3 @@
 asyncore: poll() and poll2() functions now check before calling handlers if a
 dispatcher was closed and its file descriptor was reused by a newly registered
-dispatcher: handlers of closed dispatchers are no more called.
+dispatcher: handlers of closed dispatchers are no longer called.

--- a/Misc/NEWS.d/next/Library/2017-07-24-23-52-39.bpo-30931.mZMsJ7.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-24-23-52-39.bpo-30931.mZMsJ7.rst
@@ -1,0 +1,2 @@
+asyncore: poll() and poll2() now get objects from the asyncore map before
+calling handlers, since handlers can modify the map.

--- a/Misc/NEWS.d/next/Library/2017-07-24-23-52-39.bpo-30931.mZMsJ7.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-24-23-52-39.bpo-30931.mZMsJ7.rst
@@ -1,3 +1,3 @@
-asyncore: poll() and poll2() functions now check if a dispatcher was closed (if
-it's file descriptor is no more in the map) before calling its handlers:
-handlers of closed dispatchers are no more called.
+asyncore: poll() and poll2() functions now check before calling handlers if a
+dispatcher was closed and its file descriptor was reused by a newly registered
+dispatcher: handlers of closed dispatchers are no more called.

--- a/Misc/NEWS.d/next/Library/2017-07-24-23-52-39.bpo-30931.mZMsJ7.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-24-23-52-39.bpo-30931.mZMsJ7.rst
@@ -1,2 +1,3 @@
-asyncore: poll() and poll2() now get objects from the asyncore map before
-calling handlers, since handlers can modify the map.
+asyncore: poll() and poll2() functions now check if a dispatcher was closed (if
+it's file descriptor is no more in the map) before calling its handlers:
+handlers of closed dispatchers are no more called.


### PR DESCRIPTION
poll() and poll2() now get objects from the asyncore map before
calling handlers, since handlers can modify the map.

Detect also if a ready dispatcher was closed by a previous handler,
before its handler is executed. Don't run handlers of closed
dispatchers, even if the file descriptor was reused by a newly
registered dispatcher.

Co-Authored-By: Jaume Marhuenda <jaume.marhuenda@datastax.com>

<!-- issue-number: bpo-30931 -->
https://bugs.python.org/issue30931
<!-- /issue-number -->
