### PR TITLE
bpo-30732: json.dumps() lacks information about RecursionError relate…

### DIFF
--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1502,7 +1502,16 @@ encoder_listencode_obj(PyEncoderObject *s, _PyAccu *acc,
                 return -1;
             }
         }
+
         newobj = PyObject_CallFunctionObjArgs(s->defaultfn, obj, NULL);
+
+        if (obj != NULL && newobj != NULL && newobj->ob_type == obj->ob_type) {
+                PyErr_SetString(PyExc_TypeError, "Default serialization function returning same type");
+                Py_DECREF(newobj);
+                Py_XDECREF(ident);
+                return -1;
+        }
+
         if (newobj == NULL) {
             Py_XDECREF(ident);
             return -1;


### PR DESCRIPTION
…d to default function

<!-- issue-number: bpo-30732 -->
https://bugs.python.org/issue30732
<!-- /issue-number -->
