### PR TITLE
[3.3][security] bpo-26657: Fix Windows directory traversal vulnerability with http.se…

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -793,9 +793,9 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         words = filter(None, words)
         path = os.getcwd()
         for word in words:
-            drive, word = os.path.splitdrive(word)
-            head, word = os.path.split(word)
-            if word in (os.curdir, os.pardir): continue
+            if os.path.dirname(word) or word in (os.curdir, os.pardir):
+                # Ignore components that are not a simple file/directory name
+                continue
             path = os.path.join(path, word)
         if trailing_slash:
             path += '/'

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -12,6 +12,7 @@ import os
 import sys
 import re
 import base64
+import ntpath
 import shutil
 import urllib.parse
 import http.client
@@ -702,6 +703,24 @@ class SimpleHTTPRequestHandlerTestCase(unittest.TestCase):
         self.assertEqual(path, self.translated)
         path = self.handler.translate_path('//filename?foo=bar')
         self.assertEqual(path, self.translated)
+
+    def test_windows_colon(self):
+        with support.swap_attr(server.os, 'path', ntpath):
+            path = self.handler.translate_path('c:c:c:foo/filename')
+            path = path.replace(ntpath.sep, os.sep)
+            self.assertEqual(path, self.translated)
+
+            path = self.handler.translate_path('\\c:../filename')
+            path = path.replace(ntpath.sep, os.sep)
+            self.assertEqual(path, self.translated)
+
+            path = self.handler.translate_path('c:\\c:..\\foo/filename')
+            path = path.replace(ntpath.sep, os.sep)
+            self.assertEqual(path, self.translated)
+
+            path = self.handler.translate_path('c:c:foo\\c:c:bar/filename')
+            path = path.replace(ntpath.sep, os.sep)
+            self.assertEqual(path, self.translated)
 
 
 def test_main(verbose=None):

--- a/Misc/NEWS.d/next/Security/2017-07-11-22-07-03.bpo-26657.wvpzFD.rst
+++ b/Misc/NEWS.d/next/Security/2017-07-11-22-07-03.bpo-26657.wvpzFD.rst
@@ -1,0 +1,3 @@
+Fix directory traversal vulnerability with http.server on Windows. This
+fixes a regression that was introduced in 3.3.4rc1 and 3.4.0rc1. Based on
+patch by Philipp Hagemeister.


### PR DESCRIPTION
…rver (#782)

Based on patch by Philipp Hagemeister.  This fixes a regression caused by
revision f4377699fd47.

(cherry picked from commit d274b3f1f1e2d8811733fb952c9f18d7da3a376a)
(cherry picked from commit 6f6bc1da8aaae52664e7747e328d26eb59c0e74f)

<!-- issue-number: bpo-26657 -->
https://bugs.python.org/issue26657
<!-- /issue-number -->
