### PR TITLE
bpo-31028: Fix test_pydoc when run directly

### DIFF
--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -360,7 +360,7 @@ def get_pydoc_html(module):
 def get_pydoc_link(module):
     "Returns a documentation web link of a module"
     dirname = os.path.dirname
-    basedir = dirname(dirname(os.path.abspath(__file__)))
+    basedir = dirname(dirname(os.path.realpath(__file__)))
     doc = pydoc.TextDoc()
     loc = doc.getdocloc(module, basedir=basedir)
     return loc

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -360,7 +360,7 @@ def get_pydoc_html(module):
 def get_pydoc_link(module):
     "Returns a documentation web link of a module"
     dirname = os.path.dirname
-    basedir = dirname(dirname(__file__))
+    basedir = dirname(dirname(os.path.abspath(__file__)))
     doc = pydoc.TextDoc()
     loc = doc.getdocloc(module, basedir=basedir)
     return loc


### PR DESCRIPTION
Fix get_pydoc_link() of test_pydoc to fix "./python
Lib/test/test_pydoc.py": get the absolute path to __file__ to prevent
relative directories.

<!-- issue-number: bpo-31028 -->
https://bugs.python.org/issue31028
<!-- /issue-number -->
