### PR TITLE
[3.5] bpo-31036: use an existing Misc/NEWS rather than trying to use blurb

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -40,9 +40,9 @@ help:
 
 build:
 	-mkdir -p build
-	# Look first for a Misc/NEWS file (building from a source release tarball
-	# or old repo) and use that, otherwise look for a Misc/NEWS.d directory
-	# (building from a newer repo) and use blurb to generate the NEWS file.
+# Look first for a Misc/NEWS file (building from a source release tarball
+# or old repo) and use that, otherwise look for a Misc/NEWS.d directory
+# (building from a newer repo) and use blurb to generate the NEWS file.
 	@if [ -f  ../Misc/NEWS ] ; then \
 		echo "Using existing Misc/NEWS file"; \
 		cp ../Misc/NEWS build/NEWS; \

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -40,7 +40,19 @@ help:
 
 build:
 	-mkdir -p build
-	$(BLURB) merge -f build/NEWS
+	# Look first for a Misc/NEWS file (building from a source release tarball
+	# or old repo) and use that, otherwise look for a Misc/NEWS.d directory
+	# (building from a newer repo) and use blurb to generate the NEWS file.
+	@if [ -f  ../Misc/NEWS ] ; then \
+		echo "Using existing Misc/NEWS file"; \
+		cp ../Misc/NEWS build/NEWS; \
+	elif [ -d ../Misc/NEWS.d ]; then \
+		echo "Building NEWS from Misc/NEWS.d with blurb"; \
+		$(BLURB) merge -f build/NEWS; \
+	else \
+		echo "Neither Misc/NEWS.d nor Misc/NEWS found; cannot build docs"; \
+		exit 1; \
+	fi
 	$(SPHINXBUILD) $(ALLSPHINXOPTS)
 	@echo
 


### PR DESCRIPTION
This change should allow docs to be built from either a Git repo (with Misc/NEWS.d files) or from a source tarball (or other source) that has a Misc/NEWS file (as generated by blurb or otherwise).  The PR is against 3.5 since blurb support has not yet been pushed into 3.6 and master.

<!-- issue-number: bpo-31036 -->
https://bugs.python.org/issue31036
<!-- /issue-number -->
