### PR TITLE
bpo-31019: Fix multiprocessing.Process.is_alive()

### DIFF
--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -148,10 +148,16 @@ class BaseProcess(object):
         if self is _current_process:
             return True
         assert self._parent_pid == os.getpid(), 'can only test a child process'
+
         if self._popen is None:
             return False
-        self._popen.poll()
-        return self._popen.returncode is None
+
+        returncode = self._popen.poll()
+        if returncode is None:
+            return True
+        else:
+            _children.discard(self)
+            return False
 
     def close(self):
         '''


### PR DESCRIPTION
bpo-31019: multiprocessing.Process.is_alive() now removes the process
from the _children set if the process completed.

The change prevents leaking "dangling" processes.

<!-- issue-number: bpo-31019 -->
https://bugs.python.org/issue31019
<!-- /issue-number -->
