### PR TITLE
bpo-30778: Skip test_bsddb3 on Windows XP

### DIFF
--- a/Lib/test/test_bsddb3.py
+++ b/Lib/test/test_bsddb3.py
@@ -28,6 +28,10 @@ if 'silent' in sys.argv:  # take care of old flag, just in case
     verbose = False
     sys.argv.remove('silent')
 
+# bpo-30778: test_bsddb3 crashs randomly on Windows XP
+if hasattr(sys, 'getwindowsversion') and sys.getwindowsversion()[:2] <= (6, 0):
+    raise unittest.SkipTest("bpo-30778: skip tests on Windows XP")
+
 
 class TimingCheck(unittest.TestCase):
 

--- a/Lib/test/test_bsddb3.py
+++ b/Lib/test/test_bsddb3.py
@@ -29,7 +29,7 @@ if 'silent' in sys.argv:  # take care of old flag, just in case
     sys.argv.remove('silent')
 
 # bpo-30778: test_bsddb3 crashs randomly on Windows XP
-if hasattr(sys, 'getwindowsversion') and sys.getwindowsversion()[:2] <= (6, 0):
+if hasattr(sys, 'getwindowsversion') and sys.getwindowsversion()[:2] < (6, 0):
     raise unittest.SkipTest("bpo-30778: skip tests on Windows XP")
 
 


### PR DESCRIPTION


<!-- issue-number: bpo-30778 -->
https://bugs.python.org/issue30778
<!-- /issue-number -->
