### PR TITLE
[3.6] bpo-30845: Enhance test_concurrent_futures cleanup (#2564)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2053,7 +2053,6 @@ def reap_children():
     stick around to hog resources and create problems when looking
     for refleaks.
     """
-
     # Reap all our dead child processes so we don't leave zombies around.
     # These hog resources and might be causing some of the buildbots to die.
     if hasattr(os, 'waitpid'):
@@ -2064,6 +2063,8 @@ def reap_children():
                 pid, status = os.waitpid(any_process, os.WNOHANG)
                 if pid == 0:
                     break
+                print("Warning -- reap_children() reaped child process %s"
+                      % pid, file=sys.stderr)
             except:
                 break
 

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -63,6 +63,8 @@ class ExecutorMixin:
     worker_count = 5
 
     def setUp(self):
+        self._thread_cleanup = test.support.threading_setup()
+
         self.t1 = time.time()
         try:
             self.executor = self.executor_type(max_workers=self.worker_count)
@@ -72,10 +74,15 @@ class ExecutorMixin:
 
     def tearDown(self):
         self.executor.shutdown(wait=True)
+        self.executor = None
+
         dt = time.time() - self.t1
         if test.support.verbose:
             print("%.2fs" % dt, end=' ')
         self.assertLess(dt, 60, "synchronization issue: test lasted too long")
+
+        test.support.threading_cleanup(*self._thread_cleanup)
+        test.support.reap_children()
 
     def _prime_executor(self):
         # Make sure that the executor is ready to do work before running the


### PR DESCRIPTION
* bpo-30845: reap_children() now logs warnings

* bpo-30845: Enhance test_concurrent_futures cleanup

In setUp() and tearDown() methods of test_concurrent_futures tests,
make sure that tests don't leak threads nor processes. Clear
explicitly the reference to the executor to make it that it's
destroyed (to prevent "dangling threads" warning).

(cherry picked from commit 3df9dec425b0254df1cdf41922fd8d6b08bf47e4)

<!-- issue-number: bpo-30845 -->
https://bugs.python.org/issue30845
<!-- /issue-number -->
