### PR TITLE
[3.6] bpo-30595: Fix multiprocessing.Queue.get(timeout) (#2027)

### DIFF
--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -101,7 +101,7 @@ class Queue(object):
             try:
                 if block:
                     timeout = deadline - time.time()
-                    if timeout < 0 or not self._poll(timeout):
+                    if not self._poll(timeout):
                         raise Empty
                 elif not self._poll():
                     raise Empty

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -782,7 +782,8 @@ class _TestQueue(BaseTestCase):
             q = self.Queue()
             q.put(NotSerializable())
             q.put(True)
-            self.assertTrue(q.get(timeout=0.1))
+            # bpo-30595: use a timeout of 1 second for slow buildbots
+            self.assertTrue(q.get(timeout=1.0))
 
 #
 #

--- a/Misc/NEWS.d/next/Library/2017-07-26-04-46-12.bpo-30595.-zJ7d8.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-26-04-46-12.bpo-30595.-zJ7d8.rst
@@ -1,0 +1,3 @@
+multiprocessing.Queue.get() with a timeout now polls its reader in non-
+blocking mode if it succeeded to aquire the lock but the acquire took longer
+than the timeout.


### PR DESCRIPTION


<!-- issue-number: bpo-30595 -->
https://bugs.python.org/issue30595
<!-- /issue-number -->
