### PR TITLE
[2.7] bpo-31019: Fix multiprocessing.Process.is_alive() (#2875)

### DIFF
--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -156,10 +156,16 @@ class Process(object):
         if self is _current_process:
             return True
         assert self._parent_pid == os.getpid(), 'can only test a child process'
+
         if self._popen is None:
             return False
-        self._popen.poll()
-        return self._popen.returncode is None
+
+        returncode = self._popen.poll()
+        if returncode is None:
+            return True
+        else:
+            _current_process._children.discard(self)
+            return False
 
     @property
     def name(self):


### PR DESCRIPTION
multiprocessing.Process.is_alive() now removes the process from the
_children set if the process completed.

The change prevents leaking "dangling" processes.
(cherry picked from commit 2db64823c20538a6cfc6033661fab5711d2d4585)

<!-- issue-number: bpo-31019 -->
https://bugs.python.org/issue31019
<!-- /issue-number -->
