### PR TITLE
[2.7] bpo-30595: Fix multiprocessing.Queue.get(timeout)

### DIFF
--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -128,7 +128,7 @@ class Queue(object):
             try:
                 if block:
                     timeout = deadline - time.time()
-                    if timeout < 0 or not self._poll(timeout):
+                    if not self._poll(timeout):
                         raise Empty
                 elif not self._poll():
                     raise Empty

--- a/Misc/NEWS.d/next/Library/2017-07-26-04-46-12.bpo-30595.-zJ7d8.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-26-04-46-12.bpo-30595.-zJ7d8.rst
@@ -1,0 +1,3 @@
+multiprocessing.Queue.get() with a timeout now polls its reader in non-
+blocking mode if it succeeded to aquire the lock but the acquire took longer
+than the timeout.


### PR DESCRIPTION
* bpo-30595: Fix multiprocessing.Queue.get(timeout) (#2027)

multiprocessing.Queue.get() with a timeout now polls its reader in
non-blocking mode if it succeeded to aquire the lock but the acquire
took longer than the timeout.

Co-Authored-By: Grzegorz Grzywacz <grzgrzgrz3@gmail.com>
(cherry picked from commit 1b7863c3b6519c6e134c28cab8b8af0dea43e375)

* bpo-30595: Increase test_queue_feeder_donot_stop_onexc() timeout (#2148)

_test_multiprocessing.test_queue_feeder_donot_stop_onexc() now uses a
timeout of 1 second on Queue.get(), instead of 0.1 second, for slow
buildbots.
(cherry picked from commit 8f6eeaf21cdf4aea25fdefeec814a1ce07453fe9)

(cherry picked from commit e42339d3a08a8fde3349722def85d7a8e49899be)

<!-- issue-number: bpo-30595 -->
https://bugs.python.org/issue30595
<!-- /issue-number -->
