### PR TITLE
[3.5] bpo-30119: fix ftplib.FTP.putline() to throw an error for a illegal command (#1214)

### DIFF
--- a/Lib/ftplib.py
+++ b/Lib/ftplib.py
@@ -187,6 +187,8 @@ class FTP:
 
     # Internal: send one line to the server, appending CRLF
     def putline(self, line):
+        if '\r' in line or '\n' in line:
+            raise ValueError('an illegal newline character should not be contained')
         line = line + CRLF
         if self.debugging > 1:
             print('*put*', self.sanitize(line))

--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -482,6 +482,9 @@ class TestFTPClass(TestCase):
         self.assertEqual(self.client.sanitize('PASS 12345'), repr('PASS *****'))
 
     def test_exceptions(self):
+        self.assertRaises(ValueError, self.client.sendcmd, 'echo 40\r\n0')
+        self.assertRaises(ValueError, self.client.sendcmd, 'echo 40\n0')
+        self.assertRaises(ValueError, self.client.sendcmd, 'echo 40\r0')
         self.assertRaises(ftplib.error_temp, self.client.sendcmd, 'echo 400')
         self.assertRaises(ftplib.error_temp, self.client.sendcmd, 'echo 499')
         self.assertRaises(ftplib.error_perm, self.client.sendcmd, 'echo 500')
@@ -490,7 +493,8 @@ class TestFTPClass(TestCase):
 
     def test_all_errors(self):
         exceptions = (ftplib.error_reply, ftplib.error_temp, ftplib.error_perm,
-                      ftplib.error_proto, ftplib.Error, OSError, EOFError)
+                      ftplib.error_proto, ftplib.Error, OSError,
+                      EOFError)
         for x in exceptions:
             try:
                 raise x('exception not included in all_errors set')

--- a/Misc/NEWS.d/next/Library/2017-07-26-15-11-17.bpo-30119.DZ6C_S.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-26-15-11-17.bpo-30119.DZ6C_S.rst
@@ -1,0 +1,2 @@
+ftplib.FTP.putline() now throws ValueError on commands that contains CR or
+LF. Patch by Dong-hee Na.


### PR DESCRIPTION
cherry-pick from 2b1e6e9

<!-- issue-number: bpo-30119 -->
https://bugs.python.org/issue30119
<!-- /issue-number -->
