### PR TITLE
[3.5] bpo-30616: Functional API of enum allows to create empty enums (#2304)

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -330,7 +330,7 @@ class EnumMeta(type):
         # special processing needed for names?
         if isinstance(names, str):
             names = names.replace(',', ' ').split()
-        if isinstance(names, (tuple, list)) and isinstance(names[0], str):
+        if isinstance(names, (tuple, list)) and names and isinstance(names[0], str):
             names = [(e, i) for (i, e) in enumerate(names, start)]
 
         # Here, names is either an iterable of (name, value) or a mapping.

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -762,6 +762,18 @@ class TestEnum(unittest.TestCase):
             self.assertIn(e, SummerMonth)
             self.assertIs(type(e), SummerMonth)
 
+    def test_programmatic_function_from_list(self):
+        SummerMonth = Enum('SummerMonth', [])
+        lst = list(SummerMonth)
+        self.assertEqual(len(lst), len(SummerMonth))
+        self.assertEqual(len(SummerMonth), 0, SummerMonth)
+
+    def test_programmatic_function_from_empty_tuple(self):
+        SummerMonth = Enum('SummerMonth', ())
+        lst = list(SummerMonth)
+        self.assertEqual(len(lst), len(SummerMonth))
+        self.assertEqual(len(SummerMonth), 0, SummerMonth)
+
     def test_programmatic_function_type(self):
         SummerMonth = Enum('SummerMonth', 'june july august', type=int)
         lst = list(SummerMonth)

--- a/Misc/NEWS.d/next/Library/2017-07-26-15-37-30.bpo-30616.zbIqAq.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-26-15-37-30.bpo-30616.zbIqAq.rst
@@ -1,0 +1,1 @@
+Functional API of enum allows to create empty enums. Patched by Dong-hee Na


### PR DESCRIPTION
cherry-pick from dcc8ce4

<!-- issue-number: bpo-30616 -->
https://bugs.python.org/issue30616
<!-- /issue-number -->
