### PR TITLE
bpo-9566: Silence a warning in Python/getargs.c (Windows x64)

### DIFF
--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2055,7 +2055,7 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
 
     kwtuple = parser->kwtuple;
     pos = parser->pos;
-    len = pos + PyTuple_GET_SIZE(kwtuple);
+    len = pos + (int)PyTuple_GET_SIZE(kwtuple);
 
     if (len > STATIC_FREELIST_ENTRIES) {
         freelist.entries = PyMem_NEW(freelistentry_t, len);


### PR DESCRIPTION
```
..\Python\getargs.c(2058): warning C4244: '=': conversion from 'Py_ssize_t' to 'int', possible loss of data
```

`parser->kwtuple` is created in [Python/getargs.c:1958](https://github.com/python/cpython/blob/2db64823c20538a6cfc6033661fab5711d2d4585/Python/getargs.c#L1958) with a size of type `int`, so the cast should be safe. Alternatively, we can convert the `len` and `i` local variables to be of `Py_ssize_t`.

Follow up to https://github.com/python/cpython/pull/2492.

<!-- issue-number: bpo-9566 -->
https://bugs.python.org/issue9566
<!-- /issue-number -->
