### PR TITLE
bpo-30188: fix TypeError in test_nntplib

### DIFF
--- a/Lib/test/test_nntplib.py
+++ b/Lib/test/test_nntplib.py
@@ -274,9 +274,9 @@ class NetworkedNNTPTestsMixin:
 NetworkedNNTPTestsMixin.wrap_methods()
 
 
-EOF_ERRORS = [EOFError]
+EOF_ERRORS = (EOFError,)
 if ssl is not None:
-    EOF_ERRORS.append(ssl.SSLEOFError)
+    EOF_ERRORS += (ssl.SSLEOFError,)
 
 
 class NetworkedNNTPTests(NetworkedNNTPTestsMixin, unittest.TestCase):


### PR DESCRIPTION
fixes regression of 5b4feb7

<!-- issue-number: bpo-30188 -->
https://bugs.python.org/issue30188
<!-- /issue-number -->
