### PR TITLE
[3.6] Fix build batch files (#2750)

### DIFF
--- a/Tools/msi/buildrelease.bat
+++ b/Tools/msi/buildrelease.bat
@@ -29,6 +29,7 @@ set DOWNLOAD_URL=https://www.python.org/ftp/python/{version}/{arch}{releasename}
 
 set D=%~dp0
 set PCBUILD=%D%..\..\PCBuild\
+if "%Py_OutDir%"=="" set Py_OutDir=%PCBUILD%
 set EXTERNALS=%D%..\..\externals\windows-installer\
 
 set BUILDX86=
@@ -110,12 +111,12 @@ exit /B 0
 
 if "%1" EQU "x86" (
     set PGO=
-    set BUILD=%PCBUILD%win32\
+    set BUILD=%Py_OutDir%win32\
     set BUILD_PLAT=Win32
     set OUTDIR_PLAT=win32
     set OBJDIR_PLAT=x86
 ) else (
-    set BUILD=%PCBUILD%amd64\
+    set BUILD=%Py_OutDir%amd64\
     set PGO=%~2
     set BUILD_PLAT=x64
     set OUTDIR_PLAT=amd64
@@ -167,7 +168,7 @@ if not "%SKIPBUILD%" EQU "1" (
 if "%OUTDIR_PLAT%" EQU "win32" (
     %MSBUILD% "%D%launcher\launcher.wixproj" /p:Platform=x86 %CERTOPTS% /p:ReleaseUri=%RELEASE_URI%
     if errorlevel 1 exit /B
-) else if not exist "%PCBUILD%win32\en-us\launcher.msi" (
+) else if not exist "%Py_OutDir%win32\en-us\launcher.msi" (
     %MSBUILD% "%D%launcher\launcher.wixproj" /p:Platform=x86 %CERTOPTS% /p:ReleaseUri=%RELEASE_URI%
     if errorlevel 1 exit /B
 )

--- a/Tools/msi/make_zip.proj
+++ b/Tools/msi/make_zip.proj
@@ -16,8 +16,9 @@
         <TargetPath>$(OutputPath)\$(TargetName)$(TargetExt)</TargetPath>
         <CleanCommand>rmdir /q/s "$(IntermediateOutputPath)\zip_$(ArchName)"</CleanCommand>
         <Arguments>"$(PythonExe)" "$(MSBuildThisFileDirectory)\make_zip.py"</Arguments>
-        <Arguments>$(Arguments) -e -o "$(TargetPath)" -t "$(IntermediateOutputPath)\zip_$(ArchName)" -a $(ArchName)</Arguments>
+        <Arguments>$(Arguments) -e -o "$(TargetPath)" -t "$(IntermediateOutputPath)\zip_$(ArchName)" -b "$(BuildPath.TrimEnd(`\`))"</Arguments>
         <Environment>set DOC_FILENAME=python$(PythonVersion).chm</Environment>
+        <Environment>$(Environment)%0D%0Aset PYTHONPATH=$(PySourcePath)Lib</Environment>
         <Environment Condition="Exists($(CRTRedist))">$(Environment)%0D%0Aset VCREDIST_PATH=$(CRTRedist)\$(Platform)</Environment>
     </PropertyGroup>
 

--- a/Tools/msi/make_zip.py
+++ b/Tools/msi/make_zip.py
@@ -106,23 +106,23 @@ def include_in_tools(p):
 BASE_NAME = 'python{0.major}{0.minor}'.format(sys.version_info)
 
 FULL_LAYOUT = [
-    ('/', 'PCBuild/$arch', 'python.exe', is_not_debug),
-    ('/', 'PCBuild/$arch', 'pythonw.exe', is_not_debug),
-    ('/', 'PCBuild/$arch', 'python{}.dll'.format(sys.version_info.major), is_not_debug),
-    ('/', 'PCBuild/$arch', '{}.dll'.format(BASE_NAME), is_not_debug),
-    ('DLLs/', 'PCBuild/$arch', '*.pyd', is_not_debug),
-    ('DLLs/', 'PCBuild/$arch', '*.dll', is_not_debug_or_python),
+    ('/', '$build', 'python.exe', is_not_debug),
+    ('/', '$build', 'pythonw.exe', is_not_debug),
+    ('/', '$build', 'python{}.dll'.format(sys.version_info.major), is_not_debug),
+    ('/', '$build', '{}.dll'.format(BASE_NAME), is_not_debug),
+    ('DLLs/', '$build', '*.pyd', is_not_debug),
+    ('DLLs/', '$build', '*.dll', is_not_debug_or_python),
     ('include/', 'include', '*.h', None),
     ('include/', 'PC', 'pyconfig.h', None),
     ('Lib/', 'Lib', '**/*', include_in_lib),
-    ('libs/', 'PCBuild/$arch', '*.lib', include_in_libs),
+    ('libs/', '$build', '*.lib', include_in_libs),
     ('Tools/', 'Tools', '**/*', include_in_tools),
 ]
 
 EMBED_LAYOUT = [
-    ('/', 'PCBuild/$arch', 'python*.exe', is_not_debug),
-    ('/', 'PCBuild/$arch', '*.pyd', is_not_debug),
-    ('/', 'PCBuild/$arch', '*.dll', is_not_debug),
+    ('/', '$build', 'python*.exe', is_not_debug),
+    ('/', '$build', '*.pyd', is_not_debug),
+    ('/', '$build', '*.dll', is_not_debug),
     ('{}.zip'.format(BASE_NAME), 'Lib', '**/*', include_in_embeddable_lib),
 ]
 
@@ -187,15 +187,15 @@ def main():
     parser.add_argument('-o', '--out', metavar='file', help='The name of the output archive', type=Path, default=None)
     parser.add_argument('-t', '--temp', metavar='dir', help='A directory to temporarily extract files into', type=Path, default=None)
     parser.add_argument('-e', '--embed', help='Create an embedding layout', action='store_true', default=False)
-    parser.add_argument('-a', '--arch', help='Specify the architecture to use (win32/amd64)', type=str, default="win32")
+    parser.add_argument('-b', '--build', help='Specify the build directory', type=Path, default=None)
     ns = parser.parse_args()
 
     source = ns.source or (Path(__file__).resolve().parent.parent.parent)
     out = ns.out
-    arch = ns.arch
+    build = ns.build or Path(sys.exec_prefix)
     assert isinstance(source, Path)
     assert not out or isinstance(out, Path)
-    assert isinstance(arch, str)
+    assert isinstance(build, Path)
 
     if ns.temp:
         temp = ns.temp
@@ -218,7 +218,10 @@ def main():
 
     try:
         for t, s, p, c in layout:
-            fs = source / s.replace("$arch", arch)
+            if s == '$build':
+                fs = build
+            else:
+                fs = source / s
             files = rglob(fs, p, c)
             extra_files = []
             if s == 'Lib' and p == '**/*':

--- a/Tools/nuget/build.bat
+++ b/Tools/nuget/build.bat
@@ -2,6 +2,7 @@
 setlocal
 set D=%~dp0
 set PCBUILD=%D%..\..\PCBuild\
+if "%Py_OutDir%"=="" set Py_OutDir=%PCBUILD%
 
 set BUILDX86=
 set BUILDX64=
@@ -28,7 +29,7 @@ if defined PACKAGES set PACKAGES="/p:Packages=%PACKAGES%"
 
 if defined BUILDX86 (
     if defined REBUILD ( call "%PCBUILD%build.bat" -e -r
-    ) else if not exist "%PCBUILD%win32\python.exe" call "%PCBUILD%build.bat" -e
+    ) else if not exist "%Py_OutDir%win32\python.exe" call "%PCBUILD%build.bat" -e
     if errorlevel 1 goto :eof
 
     %MSBUILD% "%D%make_pkg.proj" /p:Configuration=Release /p:Platform=x86 %OUTPUT% %PACKAGES%
@@ -37,7 +38,7 @@ if defined BUILDX86 (
 
 if defined BUILDX64 (
     if defined REBUILD ( call "%PCBUILD%build.bat" -p x64 -e -r
-    ) else if not exist "%PCBUILD%amd64\python.exe" call "%PCBUILD%build.bat" -p x64 -e
+    ) else if not exist "%Py_OutDir%amd64\python.exe" call "%PCBUILD%build.bat" -p x64 -e
     if errorlevel 1 goto :eof
 
     %MSBUILD% "%D%make_pkg.proj" /p:Configuration=Release /p:Platform=x64 %OUTPUT% %PACKAGES%

--- a/Tools/nuget/make_pkg.proj
+++ b/Tools/nuget/make_pkg.proj
@@ -4,6 +4,7 @@
         <ProjectGuid>{10487945-15D1-4092-A214-338395C4116B}</ProjectGuid>
         <OutputName>python</OutputName>
         <OutputName Condition="$(Platform) == 'x86'">$(OutputName)x86</OutputName>
+        <OutputName Condition="$(BuildForDaily) == 'true'">$(OutputName)daily</OutputName>
         <OutputSuffix></OutputSuffix>
         <SupportSigning>false</SupportSigning>
         <BuildForRelease Condition="$(BuildForRelease) == ''">true</BuildForRelease>
@@ -15,6 +16,7 @@
         <Nuget Condition="$(Nuget) == ''">$(ExternalsDir)\windows-installer\nuget\nuget.exe</Nuget>
         <NuspecVersion>$(MajorVersionNumber).$(MinorVersionNumber).$(MicroVersionNumber)</NuspecVersion>
         <NuspecVersion Condition="$(ReleaseLevelName) != ''">$(NuspecVersion)-$(ReleaseLevelName)</NuspecVersion>
+        <NuspecVersion Condition="$(BuildForDaily) == 'true'">$(MajorVersionNumber).$(MinorVersionNumber).$(DailyBuildVersion)</NuspecVersion>
         <SignOutput>false</SignOutput>
         <TargetName>$(OutputName).$(NuspecVersion)</TargetName>
         <TargetExt>.nupkg</TargetExt>
@@ -23,7 +25,7 @@
         <CleanCommand>rmdir /q/s "$(IntermediateOutputPath)"</CleanCommand>
         
         <PythonArguments>"$(PythonExe)" "$(MSBuildThisFileDirectory)\..\msi\make_zip.py"</PythonArguments>
-        <PythonArguments>$(PythonArguments) -t "$(IntermediateOutputPath)" -a $(ArchName)</PythonArguments>
+        <PythonArguments>$(PythonArguments) -t "$(IntermediateOutputPath)" -b "$(BuildPath.TrimEnd(`\`))"</PythonArguments>
         
         <PipArguments>"$(IntermediateOutputPath)\python.exe" -B -c "import sys; sys.path.append(r'$(PySourcePath)\Lib'); import ensurepip; ensurepip._main()"</PipArguments>
         <PackageArguments Condition="$(Packages) != ''">"$(IntermediateOutputPath)\python.exe" -B -m pip install -U $(Packages)</PackageArguments>
@@ -35,7 +37,9 @@
         <NugetArguments>$(NugetArguments) -NoPackageAnalysis -NonInteractive</NugetArguments>
         
         <Environment>set DOC_FILENAME=python$(PythonVersion).chm</Environment>
+        <Environment>$(Environment)%0D%0Aset PYTHONPATH=$(PySourcePath)Lib</Environment>
         <Environment Condition="Exists($(CRTRedist))">$(Environment)%0D%0Aset VCREDIST_PATH=$(CRTRedist)\$(Platform)</Environment>
+        <Environment>$(Environment)%0D%0Amkdir "$(OutputPath.Trim(`\`))" &gt;nul 2&gt;nul</Environment>
     </PropertyGroup>
 
     <Target Name="_NugetMissing" BeforeTargets="_Build" Condition="!Exists($(Nuget))">

--- a/Tools/nuget/pythondaily.nuspec
+++ b/Tools/nuget/pythondaily.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>pythondaily</id>
+    <title>Python (Daily build)</title>
+    <version>0.0.0.0</version>
+    <authors>Python Software Foundation</authors>
+    <licenseUrl>https://docs.python.org/3/license.html</licenseUrl>
+    <projectUrl>https://www.python.org/</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Installs an unsigned, untested build of Python for test purposes only.</description>
+    <iconUrl>https://www.python.org/static/favicon.ico</iconUrl>
+    <tags>python</tags>
+  </metadata>
+  <files>
+    <file src="**\*" target="tools" />
+  </files>
+</package>


### PR DESCRIPTION
* Enable building MSI, zip and nuget packages when Py_OutDir is set.
* Restore the --build option, which got reverted at some point.
* Ensure output directory is created.
* Enables BuildForDaily and DailyBuildVersion options for nuget package.