### PR TITLE
[3.5] bpo-30980: Fix double close in asyncore.file_wrapper

### DIFF
--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -618,8 +618,9 @@ if os.name == 'posix':
         def close(self):
             if self.fd < 0:
                 return
-            os.close(self.fd)
+            fd = self.fd
             self.fd = -1
+            os.close(fd)
 
         def fileno(self):
             return self.fd

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -428,7 +428,10 @@ class FileWrapperTest(unittest.TestCase):
         f = asyncore.file_wrapper(fd)
         os.close(fd)
 
-        f.close()
+        os.close(f.fd)  # file_wrapper dupped fd
+        with self.assertRaises(OSError):
+            f.close()
+
         self.assertEqual(f.fd, -1)
         # calling close twice should not fail
         f.close()


### PR DESCRIPTION
* bpo-30980: Fix close test to fail

test_close_twice was not considering the fact that file_wrapper is
duping the file descriptor. Closing the original descriptor left the
duped one open, hiding the fact that close protection is not effective.

* bpo-30980: Fix double close protection

Invalidated self.fd before closing, handling correctly the case when
os.close raises.

* bpo-30980: Fix fd leak introduced in the fixed test

<!-- issue-number: bpo-30980 -->
https://bugs.python.org/issue30980
<!-- /issue-number -->
