### PR TITLE
bpo-9566: Change HANDLE argument parsing to unsigned in msvcrtmodule.c

### DIFF
--- a/PC/clinic/msvcrtmodule.c.h
+++ b/PC/clinic/msvcrtmodule.c.h
@@ -123,7 +123,7 @@ msvcrt_open_osfhandle(PyObject *module, PyObject **args, Py_ssize_t nargs)
     int flags;
     long _return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, ""_Py_PARSE_INTPTR"i:open_osfhandle",
+    if (!_PyArg_ParseStack(args, nargs, ""_Py_PARSE_UINTPTR"i:open_osfhandle",
         &handle, &flags)) {
         goto exit;
     }
@@ -437,7 +437,7 @@ msvcrt_CrtSetReportFile(PyObject *module, PyObject **args, Py_ssize_t nargs)
     void *file;
     void *_return_value;
 
-    if (!_PyArg_ParseStack(args, nargs, "i"_Py_PARSE_INTPTR":CrtSetReportFile",
+    if (!_PyArg_ParseStack(args, nargs, "i"_Py_PARSE_UINTPTR":CrtSetReportFile",
         &type, &file)) {
         goto exit;
     }
@@ -569,4 +569,4 @@ exit:
 #ifndef MSVCRT_SET_ERROR_MODE_METHODDEF
     #define MSVCRT_SET_ERROR_MODE_METHODDEF
 #endif /* !defined(MSVCRT_SET_ERROR_MODE_METHODDEF) */
-/*[clinic end generated code: output=e86cf578e7f1ffd2 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=66787cb934b8a3c2 input=a9049054013a1b77]*/

--- a/PC/msvcrtmodule.c
+++ b/PC/msvcrtmodule.c
@@ -35,7 +35,7 @@
 /*[python input]
 class HANDLE_converter(CConverter):
     type = 'void *'
-    format_unit = '"_Py_PARSE_INTPTR"'
+    format_unit = '"_Py_PARSE_UINTPTR"'
 
 class HANDLE_return_converter(CReturnConverter):
     type = 'void *'
@@ -65,7 +65,7 @@ class wchar_t_return_converter(CReturnConverter):
         data.return_conversion.append(
             'return_value = PyUnicode_FromOrdinal(_return_value);\n')
 [python start generated code]*/
-/*[python end generated code: output=da39a3ee5e6b4b0d input=2b25dc89e9e59534]*/
+/*[python end generated code: output=da39a3ee5e6b4b0d input=d102511df3cda2eb]*/
 
 /*[clinic input]
 module msvcrt


### PR DESCRIPTION
A fix after https://github.com/python/cpython/pull/2492, I guess the values were truncated before. Tests are failing in Windows x64.

I ran the test suite locally (Default flags) making sure it passes now with the *correct* Python version.

Barring weird failure from `test.test_uuid.TestInternals.test_ipconfig_getnode` related to encoding, I think subprocess uses cp1255 while the console seems to be set to cp862 in my computer. Maybe Python should be deciding on the code page for use by subprocess by using `GetConsoleOutputCP`. Who knows if that's always the right thing to do...

😓

@zooba @haypo 

<!-- issue-number: bpo-9566 -->
https://bugs.python.org/issue9566
<!-- /issue-number -->
