### PR TITLE
bpo-31053: Fix the command example to be equivalent to previous one

### DIFF
--- a/Doc/using/venv-create.inc
+++ b/Doc/using/venv-create.inc
@@ -33,7 +33,7 @@ On Windows, invoke the ``venv`` command as follows::
 Alternatively, if you configured the ``PATH`` and ``PATHEXT`` variables for
 your :ref:`Python installation <using-on-windows>`::
 
-    c:\>python -m venv myenv c:\path\to\myenv
+    c:\>python -m venv c:\path\to\myenv
 
 The command, if run with ``-h``, will show the available options::
 


### PR DESCRIPTION
If the command to be equivalent to the previous one, the argument ``myenv`` is unnecessary.

<!-- issue-number: bpo-31053 -->
https://bugs.python.org/issue31053
<!-- /issue-number -->
