### PR TITLE
[3.6] bpo-31028: Fix test_pydoc when run directly (#2864)

### DIFF
--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -361,7 +361,7 @@ def get_pydoc_html(module):
 def get_pydoc_link(module):
     "Returns a documentation web link of a module"
     dirname = os.path.dirname
-    basedir = dirname(dirname(__file__))
+    basedir = dirname(dirname(os.path.realpath(__file__)))
     doc = pydoc.TextDoc()
     loc = doc.getdocloc(module, basedir=basedir)
     return loc


### PR DESCRIPTION
* bpo-31028: Fix test_pydoc when run directly

Fix get_pydoc_link() of test_pydoc to fix "./python
Lib/test/test_pydoc.py": get the absolute path to __file__ to prevent
relative directories.

* Use realpath() instead of abspath()

(cherry picked from commit fd46561167af6cd697191dd7ebb8c2fef5ad6493)

<!-- issue-number: bpo-31028 -->
https://bugs.python.org/issue31028
<!-- /issue-number -->
