### PR TITLE
[3.5] bpo-30876: Add new import test files to projects. (GH-2851).

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1187,6 +1187,7 @@ LIBSUBDIRS=	tkinter tkinter/test tkinter/test/test_tkinter \
 		test/test_import/data \
 		test/test_import/data/circular_imports \
 		test/test_import/data/circular_imports/subpkg \
+		test/test_import/data/package2 \
 		test/test_importlib/namespace_pkgs \
 		test/test_importlib/namespace_pkgs/both_portions \
 		test/test_importlib/namespace_pkgs/both_portions/foo \


### PR DESCRIPTION
(cherry picked from commit d5ed47dea25e04a3a144eddf99a4ac4a29242dbc)

<!-- issue-number: bpo-30876 -->
https://bugs.python.org/issue30876
<!-- /issue-number -->
