### PR TITLE
bpo-31057: pydoc for tempfile.TemporaryDirectory should say it return…

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -775,8 +775,8 @@ class SpooledTemporaryFile:
 
 
 class TemporaryDirectory(object):
-    """Create and return a temporary directory.  This has the same
-    behavior as mkdtemp but can be used as a context manager.  For
+    """Create a temporary directory, returning its name. This has the
+    same behavior as mkdtemp but can be used as a context manager.  For
     example:
 
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
…s the name

Change the documentation for tempfile.TemporaryDirectory so that
it says that the return value is the name of the directory.

<!-- issue-number: bpo-31057 -->
https://bugs.python.org/issue31057
<!-- /issue-number -->
