### PR TITLE
[2.7] bpo-31044: Skip test_posix.test_makedev() on FreeBSD (#2915)

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -287,7 +287,7 @@ class PosixTester(unittest.TestCase):
         self.assertRaises(TypeError, posix.minor)
         self.assertRaises((ValueError, OverflowError), posix.minor, -1)
 
-        if sys.platform.startswith('freebsd') and dev >= 0x1_0000_0000:
+        if sys.platform.startswith('freebsd') and dev >= 0x100000000:
             self.skipTest("bpo-31044: on FreeBSD CURRENT, minor() truncates "
                           "64-bit dev to 32-bit")
 

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -287,6 +287,10 @@ class PosixTester(unittest.TestCase):
         self.assertRaises(TypeError, posix.minor)
         self.assertRaises((ValueError, OverflowError), posix.minor, -1)
 
+        if sys.platform.startswith('freebsd') and dev >= 0x1_0000_0000:
+            self.skipTest("bpo-31044: on FreeBSD CURRENT, minor() truncates "
+                          "64-bit dev to 32-bit")
+
         self.assertEqual(posix.makedev(major, minor), dev)
         self.assertEqual(posix.makedev(int(major), int(minor)), dev)
         self.assertEqual(posix.makedev(long(major), long(minor)), dev)


### PR DESCRIPTION
There is a bug in FreeBSD CURRENT with 64-bit dev_t. Skip the test if
dev_t is larger than 32-bit, until the bug is fixed in FreeBSD
CURRENT.
(cherry picked from commit 12953ffe12ac781332b384c36b25d12216b1db62)

<!-- issue-number: bpo-31044 -->
https://bugs.python.org/issue31044
<!-- /issue-number -->
