### PR TITLE
bpo-30640: Fix undefined behavior in _PyFunction_FastCallDict(), PyEval_EvalCodeEx()

### DIFF
--- a/Objects/call.c
+++ b/Objects/call.c
@@ -374,7 +374,7 @@ _PyFunction_FastCallDict(PyObject *func, PyObject **args, Py_ssize_t nargs,
 
     result = _PyEval_EvalCodeWithName((PyObject*)co, globals, (PyObject *)NULL,
                                       args, nargs,
-                                      k, k + 1, nk, 2,
+                                      k, k != NULL ? k + 1 : NULL, nk, 2,
                                       d, nd, kwdefs,
                                       closure, name, qualname);
     Py_XDECREF(kwtuple);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4220,7 +4220,8 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
 {
     return _PyEval_EvalCodeWithName(_co, globals, locals,
                                     args, argcount,
-                                    kws, kws + 1, kwcount, 2,
+                                    kws, kws != NULL ? kws + 1 : NULL,
+                                    kwcount, 2,
                                     defs, defcount,
                                     kwdefs, closure,
                                     NULL, NULL);


### PR DESCRIPTION
In `_PyFunction_FastCallDict()`, `k` can be set to NULL, and arithmetic on a null pointer is undefined behavior. There is the same issue in `PyEval_EvalCodeEx()`.

<!-- issue-number: bpo-30640 -->
https://bugs.python.org/issue30640
<!-- /issue-number -->
