### PR TITLE
bpo-31048: If we haven't passed the transport to the protocol yet, close it ourself

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -473,6 +473,8 @@ class SSLProtocol(protocols.Protocol):
         if self._session_established:
             self._session_established = False
             self._loop.call_soon(self._app_protocol.connection_lost, exc)
+        else:
+            self._app_transport.close()
         self._transport = None
         self._app_transport = None
         self._wakeup_waiter(exc)


### PR DESCRIPTION
Suggested fix for the `ResourceWarning` described in the issue. If we haven't yet passed the `_SSLProtocolTransport` to the user protocol we need to close it our self. We might also to close the `_SSLProtocolTransport`, after calling the protocol's `connection_lost`, but I'm not sure...

I'm not truly familiar with this code, so please review carefully.

<!-- issue-number: bpo-31048 -->
https://bugs.python.org/issue31048
<!-- /issue-number -->
