### PR TITLE
[3.6] bpo-31060: IDLE: Finish regrouping ConfigDialog methods (GH-2908)

### DIFF
--- a/Misc/NEWS.d/next/IDLE/2017-07-27-14-48-42.bpo-31060.GdY_VY.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-07-27-14-48-42.bpo-31060.GdY_VY.rst
@@ -1,0 +1,3 @@
+IDLE - Finish rearranging methods of ConfigDialog Grouping methods
+pertaining to each tab and the buttons will aid writing tests and improving
+the tabs and will enable splitting the groups into classes.


### PR DESCRIPTION
Finish resorting the 72 ConfigDialog methods into 7 groups that represent the dialog, action buttons, and font, highlight, keys, general, and extension pages.  This will help with continuing to add tests and improve the pages. It will enable splitting ConfigDialog into 6 or 7 more comprehensible classes.
(cherry picked from commit b166080)

<!-- issue-number: bpo-31060 -->
https://bugs.python.org/issue31060
<!-- /issue-number -->
