### PR TITLE
bpo-28095: Re-enable temporarily disabled part of test_startup_import…

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -492,9 +492,7 @@ class StartupImportTests(unittest.TestCase):
                            'heapq', 'itertools', 'keyword', 'operator',
                            'reprlib', 'types', 'weakref'
                           }.difference(sys.builtin_module_names)
-        # http://bugs.python.org/issue28095
-        if sys.platform != 'darwin':
-            self.assertFalse(modules.intersection(collection_mods), stderr)
+        self.assertFalse(modules.intersection(collection_mods), stderr)
 
     def test_startup_interactivehook(self):
         r = subprocess.Popen([sys.executable, '-c',


### PR DESCRIPTION
…s on macOS

The changes for bpo-29585 eliminate the extra imports on macOS that caused
the original test failure.

This reverts commit 8a2150aae6db4d664c96a038ef6abacd4bcbcdc9.

<!-- issue-number: bpo-28095 -->
https://bugs.python.org/issue28095
<!-- /issue-number -->
