### PR TITLE
bpo-30302: Update WhatsNew and documentation.

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -313,7 +313,7 @@ Notes:
   unusual results for negative timedeltas.  For example:
 
   >>> timedelta(hours=-5)
-  datetime.timedelta(-1, 68400)
+  datetime.timedelta(days=-1, seconds=68400)
   >>> print(_)
   -1 day, 19:00:00
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -455,6 +455,9 @@ Changes in the Python API
   :func:`socket.fromshare` a socket :func:`~socket.socket.share`-ed in older
   Python versions.
 
+* ``repr`` for :class:`datetime.timedelta` has changed to include keyword arguments
+  in the output. (Contributed by Utkarsh Upadhyay in :issue:`30302`.)
+
 
 CPython bytecode changes
 ------------------------


### PR DESCRIPTION
This adds a new item to `Porting to Python 3.7` section and fixes a small issue with the datetime documentation.

<!-- issue-number: bpo-30302 -->
https://bugs.python.org/issue30302
<!-- /issue-number -->
