### PR TITLE
bpo-31067: test_subprocess calls reap_children()

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -56,6 +56,8 @@ class BaseTestCase(unittest.TestCase):
             inst.wait()
         subprocess._cleanup()
         self.assertFalse(subprocess._active, "subprocess._active not empty")
+        self.doCleanups()
+        support.reap_children()
 
     def assertStderrEqual(self, stderr, expected, msg=None):
         # In a debug build, stuff like "[6580 refs]" is printed to stderr at


### PR DESCRIPTION
test_subprocess now also calls reap_children() in tearDown(), not
only on setUp().

<!-- issue-number: bpo-31067 -->
https://bugs.python.org/issue31067
<!-- /issue-number -->
