### PR TITLE
bpo-31066: Fix test_httpservers.test_last_modified()

### DIFF
--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -335,9 +335,11 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         self.tempdir = tempfile.mkdtemp(dir=basetempdir)
         self.tempdir_name = os.path.basename(self.tempdir)
         self.base_url = '/' + self.tempdir_name
-        with open(os.path.join(self.tempdir, 'test'), 'wb') as temp:
+        tempname = os.path.join(self.tempdir, 'test')
+        with open(tempname, 'wb') as temp:
             temp.write(self.data)
-            mtime = os.fstat(temp.fileno()).st_mtime
+            temp.flush()
+        mtime = os.stat(tempname).st_mtime
         # compute last modification datetime for browser cache tests
         last_modif = datetime.datetime.fromtimestamp(mtime,
             datetime.timezone.utc)
@@ -471,7 +473,7 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         headers['If-Modified-Since'] = email.utils.format_datetime(new_dt,
             usegmt=True)
         response = self.request(self.base_url + '/test', headers=headers)
-        self.check_status_and_reason(response, HTTPStatus.NOT_MODIFIED)        
+        self.check_status_and_reason(response, HTTPStatus.NOT_MODIFIED)
 
     def test_browser_cache_file_changed(self):
         # with If-Modified-Since earlier than Last-Modified, must return 200
@@ -491,7 +493,7 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         headers['If-Modified-Since'] = self.last_modif_header
         headers['If-None-Match'] = "*"
         response = self.request(self.base_url + '/test', headers=headers)
-        self.check_status_and_reason(response, HTTPStatus.OK)        
+        self.check_status_and_reason(response, HTTPStatus.OK)
 
     def test_invalid_requests(self):
         response = self.request('/', method='FOO')


### PR DESCRIPTION
Write the temporary file on disk and then get its modification time.

<!-- issue-number: bpo-31066 -->
https://bugs.python.org/issue31066
<!-- /issue-number -->
