### PR TITLE
bpo-30581: Windows: os.cpu_count() returns wrong number of processors

### DIFF
--- a/Misc/NEWS.d/next/Windows/2017-08-04-10-05-19.bpo-30581.OQhR7l.rst
+++ b/Misc/NEWS.d/next/Windows/2017-08-04-10-05-19.bpo-30581.OQhR7l.rst
@@ -1,2 +1,2 @@
-The behavior of os.cpu_count() has changed on Windows. Windows will never
-return, nor have access to, more than 32 CPUs on a 32 bit build of Python.
+os.cpu_count() now returns the correct number of processors on Windows
+when the number of logical processors is greater than 64.

--- a/Misc/NEWS.d/next/Windows/2017-08-04-10-05-19.bpo-30581.OQhR7l.rst
+++ b/Misc/NEWS.d/next/Windows/2017-08-04-10-05-19.bpo-30581.OQhR7l.rst
@@ -1,0 +1,2 @@
+The behavior of os.cpu_count() has changed on Windows. Windows will never
+return, nor have access to, more than 32 CPUs on a 32 bit build of Python.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11128,9 +11128,22 @@ os_cpu_count_impl(PyObject *module)
 {
     int ncpu = 0;
 #ifdef MS_WINDOWS
-    SYSTEM_INFO sysinfo;
-    GetSystemInfo(&sysinfo);
-    ncpu = sysinfo.dwNumberOfProcessors;
+    /* Vista is supported and the GetMaximumProcessorCount API is Win7+
+       Need to fallback to Vista behavior if this call isn't present */
+    HINSTANCE hKernel32;
+    hKernel32 = GetModuleHandleW(L"KERNEL32");
+
+    static DWORD(CALLBACK *_GetMaximumProcessorCount)(WORD) = NULL;
+    *(FARPROC*)&_GetMaximumProcessorCount = GetProcAddress(hKernel32,
+        "GetMaximumProcessorCount");
+    if (_GetMaximumProcessorCount != NULL) {
+        ncpu = _GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS);
+    }
+    else {
+        SYSTEM_INFO sysinfo;
+        GetSystemInfo(&sysinfo);
+        ncpu = sysinfo.dwNumberOfProcessors;
+    }
 #elif defined(__hpux)
     ncpu = mpctl(MPC_GETNUMSPUS, NULL, NULL);
 #elif defined(HAVE_SYSCONF) && defined(_SC_NPROCESSORS_ONLN)


### PR DESCRIPTION
os.cpu_count() returns wrong number of processors on system with > 64 logical processors

<!-- issue-number: bpo-30581 -->
https://bugs.python.org/issue30581
<!-- /issue-number -->
