### PR TITLE
[3.6] bpo-30853: IDLE: Convert font and general vars to use VarTrace …

### DIFF
--- a/Misc/NEWS.d/next/IDLE/2017-07-27-10-01-14.bpo-30853.enPvvc.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-07-27-10-01-14.bpo-30853.enPvvc.rst
@@ -1,0 +1,5 @@
+IDLE -- Factor a VarTrace class out of ConfigDialog.
+
+Instance tracers manages pairs consisting of a tk variable and a
+callback function.  When tracing is turned on, setting the variable
+calls the function.  Test coverage for the new class is 100%.


### PR DESCRIPTION
…(GH-2914)

Instance tracers manages pairs consisting of a tk variable and a
callback function.  When tracing is turned on, setting the variable
calls the function.  Test coverage for the new class is 100%.
(cherry picked from commit 5b59154)

<!-- issue-number: bpo-30853 -->
https://bugs.python.org/issue30853
<!-- /issue-number -->
