### PR TITLE
bpo-31027: Fix test_listcomps failure when run directly

### DIFF
--- a/Lib/test/test_listcomps.py
+++ b/Lib/test/test_listcomps.py
@@ -139,7 +139,7 @@ def test_main(verbose=None):
         import gc
         counts = [None] * 5
         for i in range(len(counts)):
-            support.run_doctest(test_genexps, verbose)
+            support.run_doctest(test_listcomps, verbose)
             gc.collect()
             counts[i] = sys.gettotalrefcount()
         print(counts)


### PR DESCRIPTION


<!-- issue-number: bpo-31027 -->
https://bugs.python.org/issue31027
<!-- /issue-number -->
