### PR TITLE
[3.5] Fix trivial typo in multiprocessing documentation (GH-2930)

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1018,7 +1018,7 @@ Connection objects are usually created using :func:`Pipe` -- see also
    .. method:: recv()
 
       Return an object sent from the other end of the connection using
-      :meth:`send`.  Blocks until there its something to receive.  Raises
+      :meth:`send`.  Blocks until there is something to receive.  Raises
       :exc:`EOFError` if there is nothing left to receive
       and the other end was closed.
 


### PR DESCRIPTION
(cherry picked from commit 6fcb69dad579cc9a7dc15eabead43b6c37464f8c)