### PR TITLE
bpo-31084: QueueHandler not formatting messages

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1372,13 +1372,14 @@ class QueueHandler(logging.Handler):
         of the record while leaving the original intact.
         """
         # The format operation gets traceback text into record.exc_text
-        # (if there's exception data), and also puts the message into
-        # record.message. We can then use this to replace the original
+        # (if there's exception data), and also returns the formatted
+        # message. We can then use this to replace the original
         # msg + args, as these might be unpickleable. We also zap the
         # exc_info attribute, as it's no longer needed and, if not None,
         # will typically not be pickleable.
-        self.format(record)
-        record.msg = record.message
+        msg = self.format(record)
+        record.message = msg
+        record.msg = msg
         record.args = None
         record.exc_info = None
         return record

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3126,6 +3126,7 @@ class QueueHandlerTest(BaseTest):
         BaseTest.setUp(self)
         self.queue = queue.Queue(-1)
         self.que_hdlr = logging.handlers.QueueHandler(self.queue)
+        self.name = 'que'
         self.que_logger = logging.getLogger('que')
         self.que_logger.propagate = False
         self.que_logger.setLevel(logging.WARNING)
@@ -3146,6 +3147,19 @@ class QueueHandlerTest(BaseTest):
         self.assertTrue(isinstance(data, logging.LogRecord))
         self.assertEqual(data.name, self.que_logger.name)
         self.assertEqual((data.msg, data.args), (msg, None))
+
+    def test_formatting(self):
+        msg = self.next_message()
+        levelname = logging.getLevelName(logging.WARNING)
+        log_format_str = '{name} -> {levelname}: {message}'
+        formatted_msg = log_format_str.format(name=self.name,
+                                              levelname=levelname, message=msg)
+        formatter = logging.Formatter(self.log_format)
+        self.que_hdlr.setFormatter(formatter)
+        self.que_logger.warning(msg)
+        log_record = self.queue.get_nowait()
+        self.assertEqual(formatted_msg, log_record.msg)
+        self.assertEqual(formatted_msg, log_record.message)
 
     @unittest.skipUnless(hasattr(logging.handlers, 'QueueListener'),
                          'logging.handlers.QueueListener required for this test')


### PR DESCRIPTION
According to the internal documentation of the `QueueHandler`'s prepare method it is expected that `self.format(record)` will format the message and put the message into `record.message`. However, this is not the case and `self.format(record)` only returns the message.

The fix uses the return value of `self.format(record)` to put the formatted message into `record.message` and `record.msg`

**EDIT:** CLA was signed (and is probably pending)

<!-- issue-number: bpo-31084 -->
https://bugs.python.org/issue31084
<!-- /issue-number -->
