### PR TITLE
[2.7] bpo-29519: weakref spewing exceptions during interp finalization

### DIFF
--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -53,7 +53,7 @@ class WeakValueDictionary(UserDict.UserDict):
         args = args[1:]
         if len(args) > 1:
             raise TypeError('expected at most 1 arguments, got %d' % len(args))
-        def remove(wr, selfref=ref(self)):
+        def remove(wr, selfref=ref(self), _atomic_removal=_remove_dead_weakref):
             self = selfref()
             if self is not None:
                 if self._iterating:
@@ -61,7 +61,7 @@ class WeakValueDictionary(UserDict.UserDict):
                 else:
                     # Atomic removal is necessary since this function
                     # can be called asynchronously by the GC
-                    _remove_dead_weakref(self.data, wr.key)
+                    _atomic_removal(self.data, wr.key)
         self._remove = remove
         # A list of keys to be removed
         self._pending_removals = []

--- a/Misc/NEWS.d/next/Library/2017-07-31-19-32-57.bpo-29519._j1awg.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-31-19-32-57.bpo-29519._j1awg.rst
@@ -1,0 +1,2 @@
+Fix weakref spewing exceptions during interpreter shutdown when used with a
+rare combination of multiprocessing and custom codecs.


### PR DESCRIPTION
(cherry pick from 9cd7e17640a49635d1c1f8c2989578a8fc2c1de6)

<!-- issue-number: bpo-29519 -->
https://bugs.python.org/issue29519
<!-- /issue-number -->
