### PR TITLE
[2.7] bpo-25684: ttk.OptionMenu radiobuttons weren't unique (GH-2276)

### DIFF
--- a/Lib/lib-tk/test/test_ttk/test_extensions.py
+++ b/Lib/lib-tk/test/test_ttk/test_extensions.py
@@ -284,6 +284,31 @@ class OptionMenuTest(AbstractTkTest, unittest.TestCase):
 
         optmenu.destroy()
 
+    def test_unique_radiobuttons(self):
+        # check that radiobuttons are unique across instances (bpo25684)
+        items = ('a', 'b', 'c')
+        default = 'a'
+        optmenu = ttk.OptionMenu(self.root, self.textvar, default, *items)
+        textvar2 = tkinter.StringVar(self.root)
+        optmenu2 = ttk.OptionMenu(self.root, textvar2, default, *items)
+        optmenu.pack()
+        optmenu.wait_visibility()
+        optmenu2.pack()
+        optmenu2.wait_visibility()
+        optmenu['menu'].invoke(1)
+        optmenu2['menu'].invoke(2)
+        optmenu_stringvar_name = optmenu['menu'].entrycget(0, 'variable')
+        optmenu2_stringvar_name = optmenu2['menu'].entrycget(0, 'variable')
+        self.assertNotEqual(optmenu_stringvar_name,
+                            optmenu2_stringvar_name)
+        self.assertEqual(self.root.tk.globalgetvar(optmenu_stringvar_name),
+                         items[1])
+        self.assertEqual(self.root.tk.globalgetvar(optmenu2_stringvar_name),
+                         items[2])
+
+        optmenu.destroy()
+        optmenu2.destroy()
+
 
 tests_gui = (LabeledScaleTest, OptionMenuTest)
 

--- a/Lib/lib-tk/ttk.py
+++ b/Lib/lib-tk/ttk.py
@@ -1612,7 +1612,8 @@ class OptionMenu(Menubutton):
         menu.delete(0, 'end')
         for val in values:
             menu.add_radiobutton(label=val,
-                command=Tkinter._setit(self._variable, val, self._callback))
+                command=Tkinter._setit(self._variable, val, self._callback),
+                variable=self._variable)
 
         if default:
             self._variable.set(default)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1228,6 +1228,7 @@ James Rutherford
 Chris Ryland
 Constantina S.
 Matthieu S
+Cheryl Sabella
 Patrick Sabin
 Sébastien Sablé
 Suman Saha

--- a/Misc/NEWS.d/next/Library/2017-07-17-11-35-00.bpo-25684.usELVx.rst
+++ b/Misc/NEWS.d/next/Library/2017-07-17-11-35-00.bpo-25684.usELVx.rst
@@ -1,0 +1,2 @@
+Change ``ttk.OptionMenu`` radiobuttons to be unique across instances of
+``OptionMenu``.


### PR DESCRIPTION
between instances of OptionMenu.
(cherry picked from commit a568e5273382a5dca0c27274f7d8e34c41a87d4d)

<!-- issue-number: bpo-25684 -->
https://bugs.python.org/issue25684
<!-- /issue-number -->
