### PR TITLE
[3.6] bpo-30640: Fix undefined behavior in _PyFunction_FastCallDict()…

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4192,7 +4192,8 @@ PyEval_EvalCodeEx(PyObject *_co, PyObject *globals, PyObject *locals,
 {
     return _PyEval_EvalCodeWithName(_co, globals, locals,
                                     args, argcount,
-                                    kws, kws + 1, kwcount, 2,
+                                    kws, kws != NULL ? kws + 1 : NULL,
+                                    kwcount, 2,
                                     defs, defcount,
                                     kwdefs, closure,
                                     NULL, NULL);
@@ -5074,7 +5075,7 @@ _PyFunction_FastCallDict(PyObject *func, PyObject **args, Py_ssize_t nargs,
 
     result = _PyEval_EvalCodeWithName((PyObject*)co, globals, (PyObject *)NULL,
                                       args, nargs,
-                                      k, k + 1, nk, 2,
+                                      k, k != NULL ? k + 1 : NULL, nk, 2,
                                       d, nd, kwdefs,
                                       closure, name, qualname);
     Py_XDECREF(kwtuple);


### PR DESCRIPTION
… and PyEval_EvalCodeEx() (GH-2919)

k + 1 was calculated with k = NULL.
(cherry picked from commit c6ea8974e2d939223bfd6d64ee13ec89c090d2e0)

<!-- issue-number: bpo-30640 -->
https://bugs.python.org/issue30640
<!-- /issue-number -->
