### PR TITLE
bpo-20849: allow existing directory in shutil.copytree

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -312,7 +312,7 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
     else:
         ignored_names = set()
 
-    os.makedirs(dst)
+    os.makedirs(dst, exist_ok=True)
     errors = []
     for name in names:
         if name in ignored_names:


### PR DESCRIPTION
This is a legacy thing that wasn't updated with https://docs.python.org/3/library/os.html#os.makedirs

<!-- issue-number: bpo-20849 -->
https://bugs.python.org/issue20849
<!-- /issue-number -->

Let us not bikeshed this time!