### PR TITLE
bpo-31080: allow `logging.config.fileConfig` to accept kwargs and/or args.

### DIFF
--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -715,7 +715,12 @@ a corresponding section in the configuration file.
 The ``args`` entry, when :func:`eval`\ uated in the context of the ``logging``
 package's namespace, is the list of arguments to the constructor for the handler
 class. Refer to the constructors for the relevant handlers, or to the examples
-below, to see how typical entries are constructed.
+below, to see how typical entries are constructed. If not provided, it defaults
+to ``()``.
+
+The optional ``kwargs`` entry, when :func:`eval`\ uated in the context of the
+``logging`` package's namespace, is the keyword argument dict to the constructor
+for the handler class. If not provided, it defaults to ``{}``.
 
 .. code-block:: ini
 
@@ -754,6 +759,7 @@ below, to see how typical entries are constructed.
    level=WARN
    formatter=form07
    args=('localhost', 'from@abc', ['user1@abc', 'user2@xyz'], 'Logger Subject')
+   kwargs={'timeout': 10.0}
 
    [handler_hand08]
    class=handlers.MemoryHandler
@@ -767,6 +773,7 @@ below, to see how typical entries are constructed.
    level=NOTSET
    formatter=form09
    args=('localhost:9022', '/log', 'GET')
+   kwargs={'secure': True}
 
 Sections which specify formatter configuration are typified by the following.
 

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -143,9 +143,11 @@ def _install_handlers(cp, formatters):
             klass = eval(klass, vars(logging))
         except (AttributeError, NameError):
             klass = _resolve(klass)
-        args = section["args"]
+        args = section.get("args", '()')
         args = eval(args, vars(logging))
-        h = klass(*args)
+        kwargs = section.get("kwargs", '{}')
+        kwargs = eval(kwargs, vars(logging))
+        h = klass(*args, **kwargs)
         if "level" in section:
             level = section["level"]
             h.setLevel(level)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1273,7 +1273,7 @@ class ConfigFileTest(BaseTest):
     datefmt=
     """
 
-    # config7 adds a compiler logger.
+    # config7 adds a compiler logger, and uses kwargs instead of args.
     config7 = """
     [loggers]
     keys=root,parser,compiler
@@ -1304,7 +1304,7 @@ class ConfigFileTest(BaseTest):
     class=StreamHandler
     level=NOTSET
     formatter=form1
-    args=(sys.stdout,)
+    kwargs={'stream': sys.stdout,}
 
     [formatter_form1]
     format=%(levelname)s ++ %(message)s

--- a/Misc/NEWS.d/next/Library/2017-08-01-18-26-55.bpo-31080.2CFVCO.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-01-18-26-55.bpo-31080.2CFVCO.rst
@@ -1,0 +1,1 @@
+Allow `logging.config.fileConfig` to accept kwargs and/or args.


### PR DESCRIPTION
Allow `logging.config.fileConfig` to accept kwargs and/or args.

http://bugs.python.org/issue31080


<!-- issue-number: bpo-31080 -->
https://bugs.python.org/issue31080
<!-- /issue-number -->
