### PR TITLE
Discourage type(m).foo = with non-Mock objects

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -805,6 +805,13 @@ object::
     3
     >>> p.assert_called_once_with()
 
+.. note::
+
+    Only use `type(m).foo = ...` with Mock objects! Mock objects create a separate
+    type per instance, so patching the type doesn't impact other Mock objects. If
+    you want to apply a PropertyMock to a non-mock instance, use `patch` as shown
+    above, to ensure the PropertyMock is cleaned up and doesn't leak to other tests. 
+
 
 Calling
 ~~~~~~~


### PR DESCRIPTION
The PropertyMock documentation contains an example showing the application of a PropertyMock as attribute of a Mock object via `type(m).foo = PropertyMock(...)`. This is only safe for Mock objects because of their unusual magic to create a new subtype per instance. I am working in a codebase where this example was cargo-culted for use with non-Mock objects, causing patch leakage to other instances of the same class in later tests.

This is dangerous example code to present; if we are going to have it in the docs, it needs to be clearly called out that it's only appropriate for Mock objects, because they are special.