### PR TITLE
bpo-31104 : Preserve URL within normpath function

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -339,6 +339,9 @@ def normpath(path):
         path.startswith('//') and not path.startswith('///')):
         initial_slashes = 2
     comps = path.split('/')
+    # Preserve URL (if path is a URL)
+    if comps[0] in ['http:', 'https:']:
+        comps[0] += '/'
     new_comps = []
     for comp in comps:
         if comp in ('', '.'):


### PR DESCRIPTION
Handle unwanted truncation of forward slash in case of URL input for normpath function.
For Example - path = 'https://google.com'
The current output of normpath function would be - 'https:/google.com'
After changes the output would be  - 'https://google.com'

<!-- issue-number: bpo-31104 -->
https://bugs.python.org/issue31104
<!-- /issue-number -->
