### PR TITLE
[3.6] bpo-30978: str.format_map() now passes key lookup exceptions through. (GH-2790)

### DIFF
--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -471,7 +471,7 @@ class ReTests(unittest.TestCase):
             m[(0,)]
         with self.assertRaisesRegex(IndexError, 'no such group'):
             m[(0, 1)]
-        with self.assertRaisesRegex(KeyError, 'a2'):
+        with self.assertRaisesRegex(IndexError, 'no such group'):
             'a1={a2}'.format_map(m)
 
         m = pat.match('ac')

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -1279,6 +1279,13 @@ class UnicodeTest(string_tests.CommonTest,
         self.assertRaises(ValueError, '{}'.format_map, 'a')
         self.assertRaises(ValueError, '{a} {}'.format_map, {"a" : 2, "b" : 1})
 
+        class BadMapping:
+            def __getitem__(self, key):
+                return 1/0
+        self.assertRaises(KeyError, '{a}'.format_map, {})
+        self.assertRaises(TypeError, '{a}'.format_map, [])
+        self.assertRaises(ZeroDivisionError, '{a}'.format_map, BadMapping())
+
     def test_format_huge_precision(self):
         format_string = ".{}f".format(sys.maxsize + 1)
         with self.assertRaises(ValueError):

--- a/Misc/NEWS.d/next/Core and Builtins/2017-07-21-07-39-05.bpo-30978.f0jODc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-07-21-07-39-05.bpo-30978.f0jODc.rst
@@ -1,0 +1,2 @@
+str.format_map() now passes key lookup exceptions through.
+Previously any exception was replaced with a KeyError exception.

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -412,18 +412,22 @@ get_field_object(SubString *input, PyObject *args, PyObject *kwargs,
     if (index == -1) {
         /* look up in kwargs */
         PyObject *key = SubString_new_object(&first);
-        if (key == NULL)
+        if (key == NULL) {
             goto error;
-
-        /* Use PyObject_GetItem instead of PyDict_GetItem because this
-           code is no longer just used with kwargs. It might be passed
-           a non-dict when called through format_map. */
-        if ((kwargs == NULL) || (obj = PyObject_GetItem(kwargs, key)) == NULL) {
+        }
+        if (kwargs == NULL) {
             PyErr_SetObject(PyExc_KeyError, key);
             Py_DECREF(key);
             goto error;
         }
+        /* Use PyObject_GetItem instead of PyDict_GetItem because this
+           code is no longer just used with kwargs. It might be passed
+           a non-dict when called through format_map. */
+        obj = PyObject_GetItem(kwargs, key);
         Py_DECREF(key);
+        if (obj == NULL) {
+            goto error;
+        }
     }
     else {
         /* If args is NULL, we have a format string with a positional field


### PR DESCRIPTION
Previously any exception was replaced with a KeyError exception.
(cherry picked from commit 5075416)

<!-- issue-number: bpo-30978 -->
https://bugs.python.org/issue30978
<!-- /issue-number -->
