### PR TITLE
[3.6] Improve grammar in asyncio documentation (GH-2993)

### DIFF
--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -52,7 +52,7 @@ Cancellation
 ------------
 
 Cancellation of tasks is not common in classic programming. In asynchronous
-programming, not only it is something common, but you have to prepare your
+programming, not only is it something common, but you have to prepare your
 code to handle it.
 
 Futures and tasks can be cancelled explicitly with their :meth:`Future.cancel`


### PR DESCRIPTION
"not only is it .." is the correct form, as opposed to:
"not only it is ..."
(cherry picked from commit 87c3c5de731af18a271f4559cd69ccb8d050208f)