### PR TITLE
Add a minimal unit test for Python/frozen.c.

### DIFF
--- a/Lib/test/test_frozen.py
+++ b/Lib/test/test_frozen.py
@@ -1,0 +1,30 @@
+"""Basic test of the frozen module (source is in Python/frozen.c)."""
+
+# The Python/frozen.c source code contains a marshalled Python module
+# and therefore depends on the marshal format as well as the bytecode
+# format.  If those formats have been changed then frozen.c needs to be
+# updated.
+#
+# The test_importlib also tests this module but because those tests
+# are much more complicated, it might be unclear why they are failing.
+# Invalid marshalled data in frozen.c could case the interpreter to
+# crash when __hello__ is imported.
+
+import sys
+import unittest
+from test.support import captured_stdout
+from importlib import util
+
+
+class TestFrozen(unittest.TestCase):
+    def test_frozen(self):
+        name = '__hello__'
+        if name in sys.modules:
+            del sys.modules[name]
+        with captured_stdout() as out:
+            import __hello__
+        self.assertEqual(out.getvalue(), 'Hello world!\n')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
If the marshal or bytecode formats get changed, frozen.c needs to
be updated as well.  It can be easy to miss this step and not doing
so can cause test_importlib to crash in mysterious ways.  Add an
explict unit test to make it easier to track down the problem.