### PR TITLE
[3.6] bpo-31107: Fix copyreg mangled slot names calculation. (GH-2989)

### DIFF
--- a/Lib/copyreg.py
+++ b/Lib/copyreg.py
@@ -128,7 +128,11 @@ def _slotnames(cls):
                         continue
                     # mangled names
                     elif name.startswith('__') and not name.endswith('__'):
-                        names.append('_%s%s' % (c.__name__, name))
+                        stripped = c.__name__.lstrip('_')
+                        if stripped:
+                            names.append('_%s%s' % (stripped, name))
+                        else:
+                            names.append(name)
                     else:
                         names.append(name)
 

--- a/Lib/test/test_copyreg.py
+++ b/Lib/test/test_copyreg.py
@@ -16,6 +16,12 @@ class WithWeakref(object):
 class WithPrivate(object):
     __slots__ = ('__spam',)
 
+class _WithLeadingUnderscoreAndPrivate(object):
+    __slots__ = ('__spam',)
+
+class ___(object):
+    __slots__ = ('__spam',)
+
 class WithSingleString(object):
     __slots__ = 'spam'
 
@@ -104,6 +110,10 @@ class CopyRegTestCase(unittest.TestCase):
         self.assertEqual(copyreg._slotnames(WithWeakref), [])
         expected = ['_WithPrivate__spam']
         self.assertEqual(copyreg._slotnames(WithPrivate), expected)
+        expected = ['_WithLeadingUnderscoreAndPrivate__spam']
+        self.assertEqual(copyreg._slotnames(_WithLeadingUnderscoreAndPrivate),
+                         expected)
+        self.assertEqual(copyreg._slotnames(___), ['__spam'])
         self.assertEqual(copyreg._slotnames(WithSingleString), ['spam'])
         expected = ['eggs', 'spam']
         expected.sort()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -592,6 +592,7 @@ David Harrigan
 Brian Harring
 Jonathan Hartley
 Travis B. Hartwell
+Shane Harvey
 Larry Hastings
 Tim Hatch
 Shane Hathaway

--- a/Misc/NEWS.d/next/Library/2017-08-02-12-48-15.bpo-31107.1t2hn5.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-02-12-48-15.bpo-31107.1t2hn5.rst
@@ -1,0 +1,2 @@
+Fix `copyreg._slotnames()` mangled attribute calculation for classes whose
+name begins with an underscore. Patch by Shane Harvey.


### PR DESCRIPTION
(cherry picked from commit c4c9866064f03646c686d7e08b00aeb203c35c19)

<!-- issue-number: bpo-31107 -->
https://bugs.python.org/issue31107
<!-- /issue-number -->
