### PR TITLE
bpo-31129: Split RawConfigParser.items() in to two methods

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -118,10 +118,13 @@ ConfigParser -- responsible for parsing a list of
         insensitively defined as 0, false, no, off for False, and 1, true,
         yes, on for True).  Returns False or True.
 
-    items(section=_UNSET, raw=False, vars=None)
-        If section is given, return a list of tuples with (name, value) for
-        each option in the section. Otherwise, return a list of tuples with
-        (section_name, section_proxy) for each section, including DEFAULTSECT.
+    items()
+        Return a list of tuples with (section_name, section_proxy) for each
+        section, including DEFAULTSECT.
+
+    section_items(section, raw=False, vars=None)
+        Return a list of tuples with (name, value) for each option in the
+        section.
 
     remove_section(section)
         Remove the given file section and all its options.
@@ -828,7 +831,15 @@ class RawConfigParser(MutableMapping):
         return self._get_conv(section, option, self._convert_to_boolean,
                               raw=raw, vars=vars, fallback=fallback, **kwargs)
 
-    def items(self, section=_UNSET, raw=False, vars=None):
+    def items(self, *args, **kwargs):
+        if len(args) != 0 or len(kwargs) != 0:
+            warnings.warn("Calling the 'items' method with arguments is"
+                          " deprecated, use 'section_items' instead",
+                          DeprecationWarning, stacklevel=2)
+            return self.section_items(*args, **kwargs)
+        return super().items()
+
+    def section_items(self, section, raw=False, vars=None):
         """Return a list of (name, value) tuples for each option in a section.
 
         All % interpolations are expanded in the return values, based on the
@@ -839,8 +850,6 @@ class RawConfigParser(MutableMapping):
 
         The section DEFAULT is special.
         """
-        if section is _UNSET:
-            return super().items()
         d = self._defaults.copy()
         try:
             d.update(self._sections[section])

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -510,7 +510,8 @@ class ExtendedInterpolation(Interpolation):
                         option, section, rawval, ":".join(path)) from None
                 if "$" in v:
                     self._interpolate_some(parser, opt, accum, v, sect,
-                                           dict(parser.items(sect, raw=True)),
+                                           dict(parser.section_items(
+                                               sect, raw=True)),
                                            depth + 1)
                 else:
                     accum.append(v)

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -90,7 +90,7 @@ class BasicTestCase(CfgParserTestCaseClass):
         L.sort()
         eq = self.assertEqual
         eq(L, E)
-        L = cf.items('Spacey Bar From The Beginning')
+        L = cf.section_items('Spacey Bar From The Beginning')
         L.sort()
         eq(L, F)
 
@@ -775,11 +775,11 @@ boolean {0[0]} NO
             key{0[1]} |%(name)s|
             getdefault{0[1]} |%(default)s|
         """.format(self.delimiters), defaults={"default": "<default>"})
-        L = list(cf.items("section", vars={'value': 'value'}))
+        L = list(cf.section_items("section", vars={'value': 'value'}))
         L.sort()
         self.assertEqual(L, expected)
         with self.assertRaises(configparser.NoSectionError):
-            cf.items("no such section")
+            cf.section_items("no such section")
 
     def test_popitem(self):
         cf = self.fromstring("""
@@ -1321,10 +1321,10 @@ class ConfigParserTestCaseTrickyFile(CfgParserTestCaseClass, unittest.TestCase):
         longname = 'yeah, sections can be indented as well'
         self.assertFalse(cf.getboolean(longname, 'are they subsections'))
         self.assertEqual(cf.get(longname, 'lets use some Unicode'), '片仮名')
-        self.assertEqual(len(cf.items('another one!')), 5) # 4 in section and
-                                                           # `go` from DEFAULT
+        # 4 in section and `go` from DEFAULT
+        self.assertEqual(len(cf.section_items('another one!')), 5)
         with self.assertRaises(configparser.InterpolationMissingOptionError):
-            cf.items('no values here')
+            cf.section_items('no values here')
         self.assertEqual(cf.get('tricky interpolation', 'lets'), 'do this')
         self.assertEqual(cf.get('tricky interpolation', 'lets'),
                          cf.get('tricky interpolation', 'go'))

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -93,6 +93,10 @@ class BasicTestCase(CfgParserTestCaseClass):
         L = cf.section_items('Spacey Bar From The Beginning')
         L.sort()
         eq(L, F)
+        with self.assertWarns(DeprecationWarning):
+            L = cf.items('Spacey Bar From The Beginning')
+        L.sort()
+        eq(L, F)
 
         # mapping access
         L = [section for section in cf]
@@ -781,6 +785,14 @@ boolean {0[0]} NO
         with self.assertRaises(configparser.NoSectionError):
             cf.section_items("no such section")
 
+        with self.assertWarns(DeprecationWarning):
+            L = list(cf.items("section", vars={'value': 'value'}))
+        L.sort()
+        self.assertEqual(L, expected)
+        with self.assertRaises(configparser.NoSectionError):
+            with self.assertWarns(DeprecationWarning):
+                cf.section_items("no such section")
+
     def test_popitem(self):
         cf = self.fromstring("""
             [section1]
@@ -1325,6 +1337,11 @@ class ConfigParserTestCaseTrickyFile(CfgParserTestCaseClass, unittest.TestCase):
         self.assertEqual(len(cf.section_items('another one!')), 5)
         with self.assertRaises(configparser.InterpolationMissingOptionError):
             cf.section_items('no values here')
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(len(cf.items('another one!')), 5)
+        with self.assertRaises(configparser.InterpolationMissingOptionError):
+            with self.assertWarns(DeprecationWarning):
+                cf.section_items('no values here')
         self.assertEqual(cf.get('tricky interpolation', 'lets'), 'do this')
         self.assertEqual(cf.get('tricky interpolation', 'lets'),
                          cf.get('tricky interpolation', 'go'))


### PR DESCRIPTION
RawConfigParser.section_items() contains the codepath that was run in .items() when arguments were passed.  .items() continues to pass through to super().items() when no arguments are passed.  If arguments are given, it emits a DeprecationWarning and passes through to .section_items().

<!-- issue-number: bpo-31129 -->
https://bugs.python.org/issue31129
<!-- /issue-number -->
