### PR TITLE
bpo-31130: Fix test_idle reference leaks

### DIFF
--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -41,6 +41,7 @@ def tearDownModule():
     global root, dialog
     idleConf.userCfg = usercfg
     tracers.detach()
+    tracers.clear()
     del dialog
     root.update_idletasks()
     root.destroy()
@@ -444,6 +445,7 @@ class VarTraceTest(unittest.TestCase):
 
     def setUp(self):
         changes.clear()
+        tracers.detach()
         tracers.clear()
         self.v1 = IntVar(root)
         self.v2 = BooleanVar(root)


### PR DESCRIPTION
test_configdialog:

* VarTraceTest.setUp() now calls tracers.detach() before calling
  tracers.clear().
* tearDownModule() now calls tracers.clear() after calling
  tracers.detach().

<!-- issue-number: bpo-31130 -->
https://bugs.python.org/issue31130
<!-- /issue-number -->
