### PR TITLE
[3.6] bpo-31130: IDLE -- stop leaks in test_configdialog. (GH-3016)

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -1856,6 +1856,7 @@ class VarTrace:
 
     def clear(self):
         "Clear lists (for tests)."
+        # Call after all tests in a module to avoid memory leaks.
         self.untraced.clear()
         self.traced.clear()
 

--- a/Misc/NEWS.d/next/IDLE/2017-08-07-14-02-56.bpo-31130.FbsC7f.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-08-07-14-02-56.bpo-31130.FbsC7f.rst
@@ -1,0 +1,1 @@
+IDLE -- stop leaks in test_configdialog. Initial patch by Victor Stinner.


### PR DESCRIPTION
Initial patch by Victor Stinner.
(cherry picked from commit 733d0f6)

<!-- issue-number: bpo-31130 -->
https://bugs.python.org/issue31130
<!-- /issue-number -->
