### PR TITLE
bpo-31135: ttk: fix LabeledScale and OptionMenu destroy() method

### DIFF
--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -1543,11 +1543,12 @@ class LabeledScale(Frame):
         try:
             self._variable.trace_vdelete('w', self.__tracecb)
         except AttributeError:
-            # widget has been destroyed already
             pass
         else:
             del self._variable
-            Frame.destroy(self)
+        super().destroy()
+        self.label = None
+        self.scale = None
 
 
     def _adjust(self, *args):
@@ -1644,5 +1645,8 @@ class OptionMenu(Menubutton):
 
     def destroy(self):
         """Destroy this widget and its associated variable."""
-        del self._variable
-        Menubutton.destroy(self)
+        try:
+            del self._variable
+        except AttributeError:
+            pass
+        super().destroy()

--- a/Misc/NEWS.d/next/Library/2017-08-08-14-44-37.bpo-31135.HH94xR.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-08-14-44-37.bpo-31135.HH94xR.rst
@@ -1,0 +1,4 @@
+ttk: fix the destroy() method of LabeledScale and OptionMenu classes.
+Call the parent destroy() method even if the used attribute doesn't
+exist. The LabeledScale.destroy() method now also explicitly clears label and
+scale attributes to help the garbage collector to destroy all widgets.


### PR DESCRIPTION
Call the parent destroy() method even if the used attribute doesn't
exist.

<!-- issue-number: bpo-31135 -->
https://bugs.python.org/issue31135
<!-- /issue-number -->
