### PR TITLE
[2.7] bpo-31135: ttk: fix LabeledScale and OptionMenu destroy() method

### DIFF
--- a/Lib/lib-tk/ttk.py
+++ b/Lib/lib-tk/ttk.py
@@ -1521,7 +1521,9 @@ class LabeledScale(Frame, object):
             pass
         else:
             del self._variable
-            Frame.destroy(self)
+        Frame.destroy(self)
+        self.label = None
+        self.scale = None
 
 
     def _adjust(self, *args):
@@ -1620,5 +1622,8 @@ class OptionMenu(Menubutton):
 
     def destroy(self):
         """Destroy this widget and its associated variable."""
-        del self._variable
+        try:
+            del self._variable
+        except AttributeError:
+            pass
         Menubutton.destroy(self)

--- a/Misc/NEWS.d/next/Library/2017-08-08-14-59-26.bpo-31135.9q1QdB.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-08-14-59-26.bpo-31135.9q1QdB.rst
@@ -1,0 +1,4 @@
+ttk: Fix LabeledScale and OptionMenu destroy() method. Call the parent
+destroy() method even if the used attribute doesn't exist. The
+LabeledScale.destroy() method now also explicitly clears label and scale
+attributes to help the garbage collector to destroy all widgets.


### PR DESCRIPTION
Call the parent destroy() method even if the used
attribute doesn't exist.

The LabeledScale.destroy() method now also explicitely clears label
and scale attributes to help the garbage collector to destroy all
widgets.

<!-- issue-number: bpo-31135 -->
https://bugs.python.org/issue31135
<!-- /issue-number -->
