### PR TITLE
bpo-26510: Allow argparse add_subparsers to take `required` kwarg.

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1539,8 +1539,8 @@ Sub-commands
 
 .. method:: ArgumentParser.add_subparsers([title], [description], [prog], \
                                           [parser_class], [action], \
-                                          [option_string], [dest], [help], \
-                                          [metavar])
+                                          [option_string], [dest], [required] \
+                                          [help], [metavar])
 
    Many programs split up their functionality into a number of sub-commands,
    for example, the ``svn`` program can invoke sub-commands like ``svn
@@ -1575,6 +1575,9 @@ Sub-commands
 
    * dest_ - name of the attribute under which sub-command name will be
      stored; by default ``None`` and no value is stored
+
+   * required_ - Whether or not a subcommand must be provided, by default
+     ``True``.
 
    * help_ - help for sub-parser group in help output, by default ``None``
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1066,6 +1066,7 @@ class _SubParsersAction(Action):
                  prog,
                  parser_class,
                  dest=SUPPRESS,
+                 required=False,
                  help=None,
                  metavar=None):
 
@@ -1079,6 +1080,7 @@ class _SubParsersAction(Action):
             dest=dest,
             nargs=PARSER,
             choices=self._name_parser_map,
+            required=required,
             help=help,
             metavar=metavar)
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1066,7 +1066,7 @@ class _SubParsersAction(Action):
                  prog,
                  parser_class,
                  dest=SUPPRESS,
-                 required=False,
+                 required=True,
                  help=None,
                  metavar=None):
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1911,7 +1911,8 @@ class TestAddSubparsers(TestCase):
         # Should parse the sub command
         ret = parser.parse_args(['run'])
         self.assertEqual(ret.command, 'run')
-        # Should error when missing the command
+
+        # Error when the command is missing
         self.assertArgumentParserError(parser.parse_args, ())
 
     def test_required_subparsers_via_attribute(self):
@@ -1937,6 +1938,7 @@ class TestAddSubparsers(TestCase):
         parser = ErrorRaisingArgumentParser()
         subparsers = parser.add_subparsers(dest='command', required=False)
         subparsers.add_parser('run')
+        # No error here
         ret = parser.parse_args(())
         self.assertIsNone(ret.command)
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1807,7 +1807,7 @@ class TestAddSubparsers(TestCase):
             'bar', type=float, help='bar help')
 
         # check that only one subparsers argument can be added
-        subparsers_kwargs = {}
+        subparsers_kwargs = {'required': False}
         if aliases:
             subparsers_kwargs['metavar'] = 'COMMAND'
             subparsers_kwargs['title'] = 'commands'
@@ -1926,6 +1926,19 @@ class TestAddSubparsers(TestCase):
         subparsers = parser.add_subparsers(dest='command', required=True)
         subparsers.add_parser('run')
         self._test_required_subparsers(parser)
+
+    def test_required_subparsers_default(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers(dest='command')
+        subparsers.add_parser('run')
+        self._test_required_subparsers(parser)
+
+    def test_optional_subparsers(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers(dest='command', required=False)
+        subparsers.add_parser('run')
+        ret = parser.parse_args(())
+        self.assertIsNone(ret.command)
 
     def test_help(self):
         self.assertEqual(self.parser.format_usage(),

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1907,6 +1907,26 @@ class TestAddSubparsers(TestCase):
         self.assertEqual(NS(foo=False, bar='1', baz='2'),
                          parser.parse_args('1 2'.split()))
 
+    def _test_required_subparsers(self, parser):
+        # Should parse the sub command
+        ret = parser.parse_args(['run'])
+        self.assertEqual(ret.command, 'run')
+        # Should error when missing the command
+        self.assertArgumentParserError(parser.parse_args, ())
+
+    def test_required_subparsers_via_attribute(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers(dest='command')
+        subparsers.required = True
+        subparsers.add_parser('run')
+        self._test_required_subparsers(parser)
+
+    def test_required_subparsers_via_kwarg(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers(dest='command', required=True)
+        subparsers.add_parser('run')
+        self._test_required_subparsers(parser)
+
     def test_help(self):
         self.assertEqual(self.parser.format_usage(),
                          'usage: PROG [-h] [--foo] bar {1,2,3} ...\n')

--- a/Misc/NEWS.d/next/Library/2017-09-19-13-29-29.bpo-26510.oncW6V.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-19-13-29-29.bpo-26510.oncW6V.rst
@@ -1,0 +1,3 @@
+Fix regression in ``add_subparsers``: subparsers are now required by
+default. For optional subparsers, ``required=False`` may be passed as a
+keyword argument to ``add_subparsers``.  Patch by Anthony Sottile

--- a/Misc/NEWS.d/next/Library/2017-09-19-13-29-29.bpo-26510.oncW6V.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-19-13-29-29.bpo-26510.oncW6V.rst
@@ -1,3 +1,3 @@
-Fix regression in ``add_subparsers``: subparsers are now required by
-default. For optional subparsers, ``required=False`` may be passed as a
-keyword argument to ``add_subparsers``.  Patch by Anthony Sottile
+argparse subparsers are now required by default.  This matches behaviour in Python 2.
+For optional subparsers, call ``add_subparsers(required=False)``.
+Patch by Anthony Sottile.

--- a/Misc/NEWS.d/next/Library/2017-09-19-13-29-29.bpo-26510.oncW6V.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-19-13-29-29.bpo-26510.oncW6V.rst
@@ -1,3 +1,3 @@
 argparse subparsers are now required by default.  This matches behaviour in Python 2.
-For optional subparsers, call ``add_subparsers(required=False)``.
+For optional subparsers, use the new parameter ``add_subparsers(required=False)``.
 Patch by Anthony Sottile.


### PR DESCRIPTION
I added both a test to demonstrate the current behaviour / workaround as well as the new behaviour.

I'm torn between setting the default `required=True` (which was the python2 behaviour) and setting `required=False` (the current python3 behaviour).

If we're ok with `required=True`, I'll change that up :)

<!-- issue-number: bpo-26510 -->
https://bugs.python.org/issue26510
<!-- /issue-number -->
