### PR TITLE
bpo-31149: Doc: Add Japanese to the language switcher.

### DIFF
--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -21,6 +21,7 @@
   var all_languages = {
       'en': 'English',
       'fr': 'Français',
+      'ja': 'Japanese',
   };
 
   function build_version_select(current_version, current_release) {


### PR DESCRIPTION
Japanese translation have reached the prerequisites from PEP 545, their last step is to be added to the language switcher.

Current build has been reviewed by Inada and is OK: https://docs.python.org/ja/3.7/


<!-- issue-number: bpo-31149 -->
https://bugs.python.org/issue31149
<!-- /issue-number -->
