### PR TITLE
[2.7] bpo-31133: PCbuild: downgrade pcbuild.sln to support VS 2010

### DIFF
--- a/PCbuild/pcbuild.sln
+++ b/PCbuild/pcbuild.sln
@@ -1,4 +1,4 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
+Microsoft Visual Studio Solution File, Format Version 11.00
 # Visual Studio 2010
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{553EC33E-9816-4996-A660-5D6186A0B0B3}"
 	ProjectSection(SolutionItems) = preProject


### PR DESCRIPTION
bpo-31133: Downgrade PCbuild/pcbuild.sln from format version 12.00 to
11.00 to support Visual Studio 2010 and newer, not only VS 2013 and
newer.

<!-- issue-number: bpo-31133 -->
https://bugs.python.org/issue31133
<!-- /issue-number -->
