### PR TITLE
bpo-31155: Encode set, frozenset, bytearray, and iterators as json arrays

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -261,19 +261,19 @@ def _get_sequence_types():
     # FIXME: there are a bunch of other sequences in the Python standard library,
     # such as an array.array, queue.Queue, collections.deque.
     return (list, tuple, set, frozenset, bytearray)
-    
+
 def _get_iterator_types():
     """Iterator types that should be encoded as a json array"""
     # FIXME: Are these types defined in builtins or the standard library somewhere?
-    str_iterator   = type(iter( str()    ))
-    list_iterator  = type(iter( list()   ))
-    tuple_iterator = type(iter( tuple()  ))
-    range_iterator = type(iter( range(0) ))
-    list_reverseiterator = type(reversed( list()  )) 
-    reverseiterator      = type(reversed( tuple() )) #same as <class 'reversed'>
-    
+    str_iterator   = type(iter(str()))
+    list_iterator  = type(iter(list()))
+    tuple_iterator = type(iter(tuple()))
+    range_iterator = type(iter(range(0)))
+    list_reverseiterator = type(reversed(list()))
+    # same as <class 'reversed'>
+    reverseiterator      = type(reversed(tuple())
     return (str_iterator, list_iterator, tuple_iterator, range_iterator,
-                      list_reverseiterator, reverseiterator)
+            list_reverseiterator, reverseiterator)
 
 def _get_iterable_types():
     """Returns a tuple of all types that should be encoded as a json array"""

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -270,10 +270,14 @@ def _get_iterator_types():
     tuple_iterator = type(iter(tuple()))
     range_iterator = type(iter(range(0)))
     list_reverseiterator = type(reversed(list()))
-    # same as <class 'reversed'>
-    reverseiterator      = type(reversed(tuple())
+    # reverseiterator is same as <class 'reversed'>
+    reverseiterator      = type(reversed(tuple()))
+    dict_keyiterator = type(iter(dict().keys()))
+    dict_valueiterator = type(iter(dict().values()))
+    dict_itemiterator = type(iter(dict().items()))
     return (str_iterator, list_iterator, tuple_iterator, range_iterator,
-            list_reverseiterator, reverseiterator)
+            list_reverseiterator, reverseiterator,
+           dict_keyiterator, dict_valueiterator, dict_itemiterator)
 
 def _get_iterable_types():
     """Returns a tuple of all types that should be encoded as a json array"""


### PR DESCRIPTION
Based on a discussion on Stack Overflow
https://stackoverflow.com/questions/45457946/python-efficient-reverse-list-json-serialisation/45458128#45458128

I wrote out a solution that is general enough to support most of core Python.

If there are performance issues with the `iterable_types` nonlocal lookup, these could be pulled in as local variables to the inner `_iterencode_*` functions.

As written, a user would have to monkey patch `json.encoder._get_iterable_types()` (or one of the functions it calls) if they wanted to be able to encode their own sequence-like containers or iterators as a json array.

If there are plans for the json library to sequence-like classes and iterators that are part of the core language, part of the standard library, and in third party modules, then some modifications will be needed so that monkey patching isn't necessary.

<!-- issue-number: bpo-31155 -->
https://bugs.python.org/issue31155
<!-- /issue-number -->
