### PR TITLE
bpo-31160: Fix test_builtin for zombie process

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1568,6 +1568,10 @@ class PtyTests(unittest.TestCase):
             self.fail("got %d lines in pipe but expected 2, child output was:\n%s"
                       % (len(lines), child_output))
         os.close(fd)
+
+        pid, status = os.waitpid(pid, 0)
+        self.assertEqual(status, 0)
+
         return lines
 
     def check_input_tty(self, prompt, terminal_input, stdio_encoding=None):


### PR DESCRIPTION
PtyTests.run_child() now calls os.waitpid() to read the exit status
of the child process to avoid creating zombie process and leaking
processes in the background.

<!-- issue-number: bpo-31160 -->
https://bugs.python.org/issue31160
<!-- /issue-number -->
