### PR TITLE
[3.6] bpo-31160: Backport reap_children() fixes from master to 3.6

### DIFF
--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -143,6 +143,10 @@ def runtest(ns, test):
 runtest.stringio = None
 
 
+def post_test_cleanup():
+    support.reap_children()
+
+
 def runtest_inner(ns, test, display_failure=True):
     support.unload(test)
 
@@ -170,6 +174,7 @@ def runtest_inner(ns, test, display_failure=True):
             if ns.huntrleaks:
                 refleak = dash_R(the_module, test, test_runner, ns.huntrleaks)
             test_time = time.time() - start_time
+        post_test_cleanup()
     except support.ResourceDenied as msg:
         if not ns.quiet and not ns.pgo:
             print(test, "skipped --", msg, flush=True)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1560,6 +1560,10 @@ class PtyTests(unittest.TestCase):
             self.fail("got %d lines in pipe but expected 2, child output was:\n%s"
                       % (len(lines), child_output))
         os.close(fd)
+
+        pid, status = os.waitpid(pid, 0)
+        self.assertEqual(status, 0)
+
         return lines
 
     def check_input_tty(self, prompt, terminal_input, stdio_encoding=None):


### PR DESCRIPTION
* Fix test_builtin for zombie process (GH-3043)
* regrtest now reaps child processes (GH-3044)


<!-- issue-number: bpo-31160 -->
https://bugs.python.org/issue31160
<!-- /issue-number -->
