### PR TITLE
bpo-30824: Add .json mimetype

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -439,6 +439,7 @@ def _default_mime_types():
         '.jpeg'   : 'image/jpeg',
         '.jpg'    : 'image/jpeg',
         '.js'     : 'application/javascript',
+        '.json'   : 'application/json',
         '.ksh'    : 'text/plain',
         '.latex'  : 'application/x-latex',
         '.m1v'    : 'video/mpeg',


### PR DESCRIPTION
The `.json` extension should have a recognized mimetype as registered by the IANA.

See discussion: https://mail.python.org/pipermail/python-ideas/2017-August/046666.html

<!-- issue-number: bpo-30824 -->
https://bugs.python.org/issue30824
<!-- /issue-number -->
