### PR TITLE
bpo-31160: test_builtin: don't check waitpid() status

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1569,8 +1569,8 @@ class PtyTests(unittest.TestCase):
                       % (len(lines), child_output))
         os.close(fd)
 
-        pid, status = os.waitpid(pid, 0)
-        self.assertEqual(status, 0)
+        # Wait until the child process completes
+        os.waitpid(pid, 0)
 
         return lines
 


### PR DESCRIPTION


<!-- issue-number: bpo-31160 -->
https://bugs.python.org/issue31160
<!-- /issue-number -->
