### PR TITLE
bpo-31159: fix language switch regex on unknown yet built languages. …

### DIFF
--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -21,6 +21,7 @@
   var all_languages = {
       'en': 'English',
       'fr': 'Français',
+      'ja': 'Japanese',
   };
 
   function build_version_select(current_version, current_release) {

--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -109,7 +109,7 @@
   // Returns the path segment of the language as a string, like 'fr/'
   // or '' if not found.
   function language_segment_from_url(url) {
-    var language_regexp = '\.org/(' + Object.keys(all_languages).join('|') + '/)';
+    var language_regexp = '\.org/([a-z]{2}(?:-[a-z]{2})?/)';
     var match = url.match(language_regexp);
     if (match !== null)
         return match[1];
@@ -119,7 +119,7 @@
   // Returns the path segment of the version as a string, like '3.6/'
   // or '' if not found.
   function version_segment_in_url(url) {
-    var language_segment = '(?:(?:' + Object.keys(all_languages).join('|') + ')/)';
+    var language_segment = '(?:[a-z]{2}(?:-[a-z]{2})?/)';
     var version_segment = '(?:(?:' + version_regexs.join('|') + ')/)';
     var version_regexp = '\\.org/' + language_segment + '?(' + version_segment + ')';
     var match = url.match(version_regexp);


### PR DESCRIPTION
…(#3039)

This fix a regex issue (a missing non-matching group around an 'or'
list) and the specific possible case where a translation is built but
not yet in known by the picker, but not explicitly listing possible
languages in the regex.
(cherry picked from commit 122081deef86174beee965be1207fa46ea23533d)

<!-- issue-number: bpo-31159 -->
https://bugs.python.org/issue31159
<!-- /issue-number -->
