### PR TITLE
bpo-31149: Doc: Add Japanese to the language switcher. (#3028)

### DIFF
--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -21,6 +21,7 @@
   var all_languages = {
       'en': 'English',
       'fr': 'Français',
+      'ja': 'Japanese',
   };
 
   function build_version_select(current_version, current_release) {


### PR DESCRIPTION
(cherry picked from commit c82b7f332aff606af6c9c163da75f1e86514125e)

Don't merge until https://github.com/python/cpython/pull/3051 which is fixing an issue when adding the third language.

<!-- issue-number: bpo-31149 -->
https://bugs.python.org/issue31149
<!-- /issue-number -->
