### PR TITLE
bpo-31171: add `-lpthread' to build multiprocessing for linux platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1606,8 +1606,10 @@ class PyBuildExt(build_ext):
         elif host_platform.startswith('netbsd'):
             macros = dict()
             libraries = []
-
-        else:                                   # Linux and other unices
+        elif host_platform.startswith(('linux')):
+            macros = dict()
+            libraries = ['pthread']
+        else:                                   # Other unixes
             macros = dict()
             libraries = ['rt']
 
@@ -1626,6 +1628,7 @@ class PyBuildExt(build_ext):
         if sysconfig.get_config_var('WITH_THREAD'):
             exts.append ( Extension('_multiprocessing', multiprocessing_srcs,
                                     define_macros=list(macros.items()),
+                                    libraries=libraries,
                                     include_dirs=["Modules/_multiprocessing"]))
         else:
             missing.append('_multiprocessing')


### PR DESCRIPTION
It fixed multiprocessing.BoundedSemaphore of 32-bit python could not work
while cross compiling on linux platform.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

<!-- issue-number: bpo-31171 -->
https://bugs.python.org/issue31171
<!-- /issue-number -->
