### PR TITLE
bpo-31160: test_tempfile: Fix reap_children() warning

### DIFF
--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -78,7 +78,6 @@ class BaseTestCase(unittest.TestCase):
     def tearDown(self):
         self._warnings_manager.__exit__(None, None, None)
 
-
     def nameCheck(self, name, dir, pre, suf):
         (ndir, nbase) = os.path.split(name)
         npre  = nbase[:len(pre)]
@@ -184,12 +183,15 @@ class TestRandomNameSequence(BaseTestCase):
         try:
             pid = os.fork()
             if not pid:
+                # child process
                 os.close(read_fd)
                 os.write(write_fd, next(self.r).encode("ascii"))
                 os.close(write_fd)
                 # bypass the normal exit handlers- leave those to
                 # the parent.
                 os._exit(0)
+
+            # parent process
             parent_value = next(self.r)
             child_value = os.read(read_fd, len(parent_value)).decode("ascii")
         finally:
@@ -200,6 +202,10 @@ class TestRandomNameSequence(BaseTestCase):
                     os.kill(pid, signal.SIGKILL)
                 except OSError:
                     pass
+
+                # Read the process exit status to avoid zombie process
+                os.waitpid(pid, 0)
+
             os.close(read_fd)
             os.close(write_fd)
         self.assertNotEqual(child_value, parent_value)


### PR DESCRIPTION
TestRandomNameSequence.test_process_awareness() now calls
os.waitpid() to avoid leaking a zombie process.

<!-- issue-number: bpo-31160 -->
https://bugs.python.org/issue31160
<!-- /issue-number -->
