### PR TITLE
bpo-31151: Add socketserver.ForkingMixIn.server_close()

### DIFF
--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -144,7 +144,7 @@ class SocketServerTest(unittest.TestCase):
         t.join()
         server.server_close()
         self.assertEqual(-1, server.socket.fileno())
-        if isinstance(server, socketserver.ForkingMixIn):
+        if HAVE_FORKING and isinstance(server, socketserver.ForkingMixIn):
             # bpo-31151: Check that ForkingMixIn.server_close() waits until
             # all children completed
             self.assertFalse(server.active_children)

--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -144,6 +144,10 @@ class SocketServerTest(unittest.TestCase):
         t.join()
         server.server_close()
         self.assertEqual(-1, server.socket.fileno())
+        if isinstance(server, socketserver.ForkingMixIn):
+            # bpo-31151: Check that ForkingMixIn.server_close() waits until
+            # all children completed
+            self.assertFalse(server.active_children)
         if verbose: print("done")
 
     def stream_examine(self, proto, addr):
@@ -371,10 +375,7 @@ class ThreadingErrorTestServer(socketserver.ThreadingMixIn,
 
 if HAVE_FORKING:
     class ForkingErrorTestServer(socketserver.ForkingMixIn, BaseErrorTestServer):
-        def wait_done(self):
-            [child] = self.active_children
-            os.waitpid(child, 0)
-            self.active_children.clear()
+        pass
 
 
 class SocketWriterTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2017-08-10-13-20-02.bpo-31151.730VBI.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-10-13-20-02.bpo-31151.730VBI.rst
@@ -1,0 +1,2 @@
+socketserver.ForkingMixIn.server_close() now waits until all child processes
+completed to prevent leaking zombie processes.


### PR DESCRIPTION
socketserver.ForkingMixIn.server_close() now waits until
all child processes completed to prevent leaking zombie processes.

<!-- issue-number: bpo-31151 -->
https://bugs.python.org/issue31151
<!-- /issue-number -->
