### PR TITLE
bpo-31227: regrtest reseeds RNG before each test

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -239,9 +239,10 @@ class Regrtest:
                 print("Couldn't find starting test (%s), using all tests"
                       % self.ns.start, file=sys.stderr)
 
+        if self.ns.random_seed is None:
+            self.ns.random_seed = random.randrange(2 ** 32)
+
         if self.ns.randomize:
-            if self.ns.random_seed is None:
-                self.ns.random_seed = random.randrange(10000000)
             random.seed(self.ns.random_seed)
             random.shuffle(self.selected)
 
@@ -441,8 +442,8 @@ class Regrtest:
                    or self.tests or self.ns.args)):
             self.display_header()
 
-        if self.ns.randomize:
-            print("Using random seed", self.ns.random_seed)
+        if self.ns.random_seed is not None:
+            print("Random seed: {}".format(self.ns.random_seed))
 
         if self.ns.forever:
             self.tests = self._test_forever(list(self.selected))

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -457,9 +457,9 @@ class BaseTestCase(unittest.TestCase):
         self.check_line(output, 'Tests result: %s' % result)
 
     def parse_random_seed(self, output):
-        match = self.regex_search(r'Using random seed ([0-9]+)', output)
+        match = self.regex_search(r'Random seed: ([0-9]+)', output)
         randseed = int(match.group(1))
-        self.assertTrue(0 <= randseed <= 10000000, randseed)
+        self.assertTrue(0 <= randseed < 2 ** 32, randseed)
         return randseed
 
     def run_command(self, args, input=None, exitcode=0, **kw):

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -950,7 +950,7 @@ class ArgsTestCase(BaseTestCase):
         self.check_executed_tests(output, [testname], env_changed=testname,
                                   fail_env_changed=True)
 
-    def test_random_reseed(self):
+    def check_random_reseed(self, parallel):
         # bpo-31174: Each test file should be run with the same random seed
         code = textwrap.dedent("""
             import random
@@ -963,7 +963,10 @@ class ArgsTestCase(BaseTestCase):
         testname = self.create_test(code=code)
 
         tests = [testname] * 3
-        output = self.run_tests(*tests)
+        if parallel:
+            output = self.run_tests("-j3", *tests)
+        else:
+            output = self.run_tests(*tests)
         self.check_executed_tests(output, tests)
 
         # Get random numbers
@@ -975,6 +978,12 @@ class ArgsTestCase(BaseTestCase):
         # All "random" numbers must be the same
         numbers = set(numbers)
         self.assertEqual(len(numbers), 1, numbers)
+
+    def test_random_reseed_sequential(self):
+        self.check_random_reseed(False)
+
+    def test_random_reseed_parallel(self):
+        self.check_random_reseed(True)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Tests/2017-08-10-14-11-09.bpo-31174.ARF9nb.rst
+++ b/Misc/NEWS.d/next/Tests/2017-08-10-14-11-09.bpo-31174.ARF9nb.rst
@@ -1,0 +1,2 @@
+regrtest now reseeds the random RNG before each test file. Use also more
+entropy for the seed: 2**32 (32 bits) rather than 10_000_000 (24 bits).


### PR DESCRIPTION
regrtest now reseeds the random RNG before each test file.

Use also more entropy for the seed: 2**32 (32 bits) rather than
10_000_000 (24 bits).

<!-- issue-number: bpo-31227 -->
https://bugs.python.org/issue31227
<!-- /issue-number -->
