### PR TITLE
[3.6] bpo-31160: Backport reap_children() fixes from master to 3.6

### DIFF
--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -143,6 +143,10 @@ def runtest(ns, test):
 runtest.stringio = None
 
 
+def post_test_cleanup():
+    support.reap_children()
+
+
 def runtest_inner(ns, test, display_failure=True):
     support.unload(test)
 
@@ -170,6 +174,7 @@ def runtest_inner(ns, test, display_failure=True):
             if ns.huntrleaks:
                 refleak = dash_R(the_module, test, test_runner, ns.huntrleaks)
             test_time = time.time() - start_time
+        post_test_cleanup()
     except support.ResourceDenied as msg:
         if not ns.quiet and not ns.pgo:
             print(test, "skipped --", msg, flush=True)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1560,6 +1560,10 @@ class PtyTests(unittest.TestCase):
             self.fail("got %d lines in pipe but expected 2, child output was:\n%s"
                       % (len(lines), child_output))
         os.close(fd)
+
+        pid, status = os.waitpid(pid, 0)
+        self.assertEqual(status, 0)
+
         return lines
 
     def check_input_tty(self, prompt, terminal_input, stdio_encoding=None):

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1561,8 +1561,8 @@ class PtyTests(unittest.TestCase):
                       % (len(lines), child_output))
         os.close(fd)
 
-        pid, status = os.waitpid(pid, 0)
-        self.assertEqual(status, 0)
+        # Wait until the child process completes
+        os.waitpid(pid, 0)
 
         return lines
 

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -78,7 +78,6 @@ class BaseTestCase(unittest.TestCase):
     def tearDown(self):
         self._warnings_manager.__exit__(None, None, None)
 
-
     def nameCheck(self, name, dir, pre, suf):
         (ndir, nbase) = os.path.split(name)
         npre  = nbase[:len(pre)]
@@ -184,12 +183,15 @@ class TestRandomNameSequence(BaseTestCase):
         try:
             pid = os.fork()
             if not pid:
+                # child process
                 os.close(read_fd)
                 os.write(write_fd, next(self.r).encode("ascii"))
                 os.close(write_fd)
                 # bypass the normal exit handlers- leave those to
                 # the parent.
                 os._exit(0)
+
+            # parent process
             parent_value = next(self.r)
             child_value = os.read(read_fd, len(parent_value)).decode("ascii")
         finally:
@@ -200,6 +202,10 @@ class TestRandomNameSequence(BaseTestCase):
                     os.kill(pid, signal.SIGKILL)
                 except OSError:
                     pass
+
+                # Read the process exit status to avoid zombie process
+                os.waitpid(pid, 0)
+
             os.close(read_fd)
             os.close(write_fd)
         self.assertNotEqual(child_value, parent_value)


### PR DESCRIPTION
* Fix test_builtin for zombie process (GH-3043)
* regrtest now reaps child processes (GH-3044)
* test_builtin: don't check waitpid() status (GH-3050)
* test_tempfile: Fix reap_children() warning (GH-3056)


<!-- issue-number: bpo-31160 -->
https://bugs.python.org/issue31160
<!-- /issue-number -->
