### PR TITLE
bpo-31178: Avoid concatenating bytes with str in subprocess error

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1311,8 +1311,8 @@ class Popen(object):
                 except ValueError:
                     exception_name = b'SubprocessError'
                     hex_errno = b'0'
-                    err_msg = errpipe_data.decode(errors="surrogatepass")
-                    err_msg = "Bad exception data from child: '%s'" % err_msg
+                    err_msg = "Bad exception data from child: {!s}".format(
+                                  bytes(errpipe_data))
                 child_exception_type = getattr(
                         builtins, exception_name.decode('ascii'),
                         SubprocessError)

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1307,7 +1307,10 @@ class Popen(object):
                 try:
                     exception_name, hex_errno, err_msg = (
                             errpipe_data.split(b':', 2))
-                    err_msg = err_msg.decode(errors="surrogatepass")
+                    # The encoding here should match the encoding
+                    # written in by the subprocess implementations
+                    # like _posixsubprocess
+                    err_msg = err_msg.decode()
                 except ValueError:
                     exception_name = b'SubprocessError'
                     hex_errno = b'0'

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1314,7 +1314,7 @@ class Popen(object):
                 except ValueError:
                     exception_name = b'SubprocessError'
                     hex_errno = b'0'
-                    err_msg = "Bad exception data from child: {!s}".format(
+                    err_msg = "Bad exception data from child: {!r}".format(
                                   bytes(errpipe_data))
                 child_exception_type = getattr(
                         builtins, exception_name.decode('ascii'),

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1307,15 +1307,15 @@ class Popen(object):
                 try:
                     exception_name, hex_errno, err_msg = (
                             errpipe_data.split(b':', 2))
+                    err_msg = err_msg.decode(errors="surrogatepass")
                 except ValueError:
                     exception_name = b'SubprocessError'
                     hex_errno = b'0'
-                    err_msg = (b'Bad exception data from child: ' +
-                               repr(errpipe_data))
+                    err_msg = errpipe_data.decode(errors="surrogatepass")
+                    err_msg = "Bad exception data from child: '%s'" % err_msg
                 child_exception_type = getattr(
                         builtins, exception_name.decode('ascii'),
                         SubprocessError)
-                err_msg = err_msg.decode(errors="surrogatepass")
                 if issubclass(child_exception_type, OSError) and hex_errno:
                     errno_num = int(hex_errno, 16)
                     child_exec_never_called = (err_msg == "noexec")

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1311,7 +1311,7 @@ class Popen(object):
                     # written in by the subprocess implementations
                     # like _posixsubprocess
                     err_msg = err_msg.decode()
-                except ValueError:
+                except (ValueError, UnicodeError):
                     exception_name = b'SubprocessError'
                     hex_errno = b'0'
                     err_msg = "Bad exception data from child: {!r}".format(

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1311,10 +1311,10 @@ class Popen(object):
                     # written in by the subprocess implementations
                     # like _posixsubprocess
                     err_msg = err_msg.decode()
-                except (ValueError, UnicodeError):
+                except ValueError:
                     exception_name = b'SubprocessError'
                     hex_errno = b'0'
-                    err_msg = "Bad exception data from child: {!r}".format(
+                    err_msg = 'Bad exception data from child: {!r}'.format(
                                   bytes(errpipe_data))
                 child_exception_type = getattr(
                         builtins, exception_name.decode('ascii'),

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1485,6 +1485,50 @@ class POSIXProcessTestCase(BaseTestCase):
         else:
             self.fail("Expected OSError: %s" % desired_exception)
 
+    # We mock the __del__ method for Popen in the next two tests
+    # because it does cleanup based on the pid returned by fork_exec
+    # along with issuing a resource warning if it still exists. Since
+    # we don't actually spawn a process in these tests we can forego
+    # the destructor. An alternative would be to set _child_created to
+    # False before the destructor is called but there is no easy way
+    # to do that
+    @mock.patch.object(subprocess.Popen, "__del__")
+    @mock.patch("subprocess._posixsubprocess.fork_exec")
+    def test_exception_errpipe_normal(self, fork_exec, destructor):
+        """Test error passing done through errpipe_write in the good case"""
+        def proper_error(*args):
+            errpipe_write = args[13]
+            # 15 is the unix error code for EISDIR: 'is a directory'
+            os.write(errpipe_write, b"OSError:15:")
+            return 0
+
+        fork_exec.side_effect = proper_error
+
+        with self.assertRaises(IsADirectoryError):
+            subprocess.Popen(["cmd"])
+
+    @mock.patch.object(subprocess.Popen, "__del__")
+    @mock.patch("subprocess._posixsubprocess.fork_exec")
+    def test_exception_errpipe_bad_data(self, fork_exec, destructor):
+        """Test error passing done through errpipe_write where its not
+        in the expected format"""
+        error_data = b"\xFF\x00\xDE\xAD"
+        def bad_error(*args):
+            errpipe_write = args[13]
+            # Anything can be in the pipe, no assumptions should
+            # be made about its encoding, so we'll write some
+            # arbitrary hex bytes to test it out
+            os.write(errpipe_write, error_data)
+            return 0
+
+        fork_exec.side_effect = bad_error
+
+        with self.assertRaises(subprocess.SubprocessError) as e:
+            subprocess.Popen(["cmd"])
+
+        self.assertIn(repr(error_data), str(e.exception))
+
+
     def test_restore_signals(self):
         # Code coverage for both values of restore_signals to make sure it
         # at least does not blow up.

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1505,7 +1505,7 @@ class POSIXProcessTestCase(BaseTestCase):
         fork_exec.side_effect = proper_error
 
         with self.assertRaises(IsADirectoryError):
-            subprocess.Popen(["cmd"])
+            subprocess.Popen(["non_existent_command"])
 
     @mock.patch.object(subprocess.Popen, "__del__")
     @mock.patch("subprocess._posixsubprocess.fork_exec")
@@ -1524,7 +1524,7 @@ class POSIXProcessTestCase(BaseTestCase):
         fork_exec.side_effect = bad_error
 
         with self.assertRaises(subprocess.SubprocessError) as e:
-            subprocess.Popen(["cmd"])
+            subprocess.Popen(["non_existent_command"])
 
         self.assertIn(repr(error_data), str(e.exception))
 

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1498,8 +1498,9 @@ class POSIXProcessTestCase(BaseTestCase):
         """Test error passing done through errpipe_write in the good case"""
         def proper_error(*args):
             errpipe_write = args[13]
-            # 15 is the unix error code for EISDIR: 'is a directory'
-            os.write(errpipe_write, b"OSError:15:")
+            # Write the hex for the error code EISDIR: 'is a directory'
+            err_code = '{:x}'.format(errno.EISDIR).encode()
+            os.write(errpipe_write, b"OSError:" + err_code + b":")
             return 0
 
         fork_exec.side_effect = proper_error

--- a/Misc/NEWS.d/next/Library/2017-09-05-14-55-28.bpo-31178.JrSFo7.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-05-14-55-28.bpo-31178.JrSFo7.rst
@@ -1,0 +1,1 @@
+Fix string concatenation bug in rare error path in the subprocess module


### PR DESCRIPTION
This particular fix makes most sense in my opinion because a decode is only required if we're dealing with the subprocess output. If we're falling back to a default error because that fails there's no need to generate an error message in bytes only to have it be turned it into a str later.

<!-- issue-number: bpo-31178 -->
https://bugs.python.org/issue31178
<!-- /issue-number -->
