### PR TITLE
bpo-31179: Make dict.copy() up to 5.5 times faster.

### DIFF
--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -309,6 +309,19 @@ class DictTest(unittest.TestCase):
             d2 = d.copy()
             self.assertEqual(gc.is_tracked(d), gc.is_tracked(d2))
 
+    def test_copy_noncompact(self):
+        # Dicts don't compact themselves on del/pop operations.
+        # Copy will use a slow merging strategy that produces
+        # a compacted copy when roughly 33% of dict is a non-used
+        # keys-space (to optimize memory footprint).
+        # In this test we want to hit the slow/compacting
+        # branch of dict.copy() and make sure it works OK.
+        d = {k: k for k in range(1000)}
+        for k in range(950):
+            del d[k]
+        d2 = d.copy()
+        self.assertEqual(d2, d)
+
     def test_get(self):
         d = {}
         self.assertIs(d.get('c'), None)

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -271,10 +271,43 @@ class DictTest(unittest.TestCase):
         self.assertEqual(baddict3.fromkeys({"a", "b", "c"}), res)
 
     def test_copy(self):
-        d = {1:1, 2:2, 3:3}
-        self.assertEqual(d.copy(), {1:1, 2:2, 3:3})
+        d = {1: 1, 2: 2, 3: 3}
+        self.assertIsNot(d.copy(), d)
+        self.assertEqual(d.copy(), d)
+        self.assertEqual(d.copy(), {1: 1, 2: 2, 3: 3})
+
+        copy = d.copy()
+        d[4] = 4
+        self.assertNotEqual(copy, d)
+
         self.assertEqual({}.copy(), {})
         self.assertRaises(TypeError, d.copy, None)
+
+    def test_copy_fuzz(self):
+        for dict_size in [10, 100, 1000, 10000, 100000]:
+            dict_size = random.randrange(
+                dict_size // 2, dict_size + dict_size // 2)
+            with self.subTest(dict_size=dict_size):
+                d = {}
+                for i in range(dict_size):
+                    d[i] = i
+
+                d2 = d.copy()
+                self.assertIsNot(d2, d)
+                self.assertEqual(d, d2)
+                d2['key'] = 'value'
+                self.assertNotEqual(d, d2)
+                self.assertEqual(len(d2), len(d) + 1)
+
+    def test_copy_maintains_tracking(self):
+        class A:
+            pass
+
+        key = A()
+
+        for d in ({}, {'a': 1}, {key: 'val'}):
+            d2 = d.copy()
+            self.assertEqual(gc.is_tracked(d), gc.is_tracked(d2))
 
     def test_get(self):
         d = {}

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-10-17-32-48.bpo-31179.XcgLYI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-10-17-32-48.bpo-31179.XcgLYI.rst
@@ -1,0 +1,1 @@
+Make dict.copy() up to 5.5 times faster.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2564,7 +2564,7 @@ PyDict_Copy(PyObject *o)
     }
 
     if (PyDict_CheckExact(mp) && mp->ma_values == NULL &&
-            ((double)mp->ma_used / mp->ma_keys->dk_nentries) >= 0.8)
+            (mp->ma_used >= (mp->ma_keys->dk_nentries * 2) / 3))
     {
         /* Use fast-copy if:
 
@@ -2573,7 +2573,7 @@ PyDict_Copy(PyObject *o)
            (2) 'mp' is not a split-dict; and
 
            (3) if 'mp' is non-compact ('del' operation does not resize dicts),
-               do fast-copy only if it has at most 20% non-used keys.
+               do fast-copy only if it has at most 1/3 non-used keys.
 
            The last condition (3) is important to guard against a pathalogical
            case when a large dict is almost emptied with multiple del/pop


### PR DESCRIPTION
<!-- issue-number: bpo-31179 -->
https://bugs.python.org/issue31179
<!-- /issue-number -->
