### PR TITLE
Fix typo in 3.7 What's New

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -247,7 +247,7 @@ Peterson.)
 urllib.parse
 ------------
 
-:func:`urllib.parse.quote` has been updated to from RFC 2396 to RFC 3986,
+:func:`urllib.parse.quote` has been updated from RFC 2396 to RFC 3986,
 adding `~` to the set of characters that is never quoted by default.
 (Contributed by Christian Theune and Ratnadeep Debnath in :issue:`16285`.)
 


### PR DESCRIPTION
Noticed the typo while reading the [What's New for 3.7](https://docs.python.org/3.7/whatsnew/3.7.html#urllib-parse).

Typo was originally introduced in https://github.com/python/cpython/commit/21024f06622c4c55b666adb130797a4ee205d005. Tagging author @rtnpro to confirm that the fix is correct.