### PR TITLE
[2.7] bpo-31173: Rewrite WSTOPSIG test of test_subprocess (#3055)

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -28,6 +28,11 @@ try:
 except ImportError:
     threading = None
 
+try:
+    import _testcapi
+except ImportError:
+    _testcapi = None
+
 mswindows = (sys.platform == "win32")
 
 #
@@ -1265,40 +1270,28 @@ class POSIXProcessTestCase(BaseTestCase):
 
         self.assertEqual(p2.returncode, 0, "Unexpected error: " + repr(stderr))
 
-    @unittest.skipIf(not ctypes, 'ctypes module required')
-    @unittest.skipIf(not sys.executable, 'Test requires sys.executable')
-    def test_child_terminated_in_stopped_state(self):
+    @unittest.skipUnless(_testcapi is not None
+                         and hasattr(_testcapi, 'W_STOPCODE'),
+                         'need _testcapi.W_STOPCODE')
+    def test_stopped(self):
         """Test wait() behavior when waitpid returns WIFSTOPPED; issue29335."""
-        PTRACE_TRACEME = 0  # From glibc and MacOS (PT_TRACE_ME).
-        libc_name = ctypes.util.find_library('c')
-        libc = ctypes.CDLL(libc_name)
-        if not hasattr(libc, 'ptrace'):
-            raise unittest.SkipTest('ptrace() required')
+        args = [sys.executable, '-c', 'pass']
+        proc = subprocess.Popen(args)
 
-        code = textwrap.dedent("""
-             import ctypes
-             from test.support import _crash_python
+        # Wait until the real process completes to avoid zombie process
+        pid = proc.pid
+        pid, status = os.waitpid(pid, 0)
+        self.assertEqual(status, 0)
 
-             libc = ctypes.CDLL({libc_name!r})
-             libc.ptrace({PTRACE_TRACEME}, 0, 0)
-        """.format(libc_name=libc_name, PTRACE_TRACEME=PTRACE_TRACEME))
+        status = _testcapi.W_STOPCODE(3)
 
-        child = subprocess.Popen([sys.executable, '-c', code])
-        if child.wait() != 0:
-            raise unittest.SkipTest('ptrace() failed - unable to test')
+        def mock_waitpid(pid, flags):
+            return (pid, status)
 
-        code += textwrap.dedent("""
-             # Crash the process
-             _crash_python()
-        """)
-        child = subprocess.Popen([sys.executable, '-c', code])
-        try:
-            returncode = child.wait()
-        except:
-            child.kill()  # Clean up the hung stopped process.
-            raise
-        self.assertNotEqual(0, returncode)
-        self.assertLess(returncode, 0)  # signal death, likely SIGSEGV.
+        with test_support.swap_attr(os, 'waitpid', mock_waitpid):
+            returncode = proc.wait()
+
+        self.assertEqual(returncode, -3)
 
 
 @unittest.skipUnless(mswindows, "Windows specific tests")

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -15,6 +15,10 @@
 #  include <crtdbg.h>
 #endif
 
+#ifdef HAVE_SYS_WAIT_H
+#include <sys/wait.h>           /* For W_STOPCODE */
+#endif
+
 #ifdef WITH_THREAD
 #include "pythread.h"
 #endif /* WITH_THREAD */
@@ -2523,6 +2527,7 @@ msvcrt_CrtSetReportMode(PyObject* self, PyObject *args)
     return PyInt_FromLong(res);
 }
 
+
 static PyObject*
 msvcrt_CrtSetReportFile(PyObject* self, PyObject *args)
 {
@@ -2536,6 +2541,20 @@ msvcrt_CrtSetReportFile(PyObject* self, PyObject *args)
     res = (long)_CrtSetReportFile(type, (_HFILE)file);
 
     return PyInt_FromLong(res);
+}
+#endif
+
+
+#ifdef W_STOPCODE
+static PyObject*
+py_w_stopcode(PyObject *self, PyObject *args)
+{
+    int sig, status;
+    if (!PyArg_ParseTuple(args, "i", &sig)) {
+        return NULL;
+    }
+    status = W_STOPCODE(sig);
+    return PyLong_FromLong(status);
 }
 #endif
 
@@ -2655,6 +2674,9 @@ static PyMethodDef TestMethods[] = {
 #ifdef MS_WINDOWS
     {"CrtSetReportMode", (PyCFunction)msvcrt_CrtSetReportMode, METH_VARARGS},
     {"CrtSetReportFile", (PyCFunction)msvcrt_CrtSetReportFile, METH_VARARGS},
+#endif
+#ifdef W_STOPCODE
+    {"W_STOPCODE", py_w_stopcode, METH_VARARGS},
 #endif
     {NULL, NULL} /* sentinel */
 };


### PR DESCRIPTION
The current test_child_terminated_in_stopped_state() function test
creates a child process which calls ptrace(PTRACE_TRACEME, 0, 0) and
then crash (SIGSEGV). The problem is that calling os.waitpid() in the
parent process is not enough to close the process: the child process
remains alive and so the unit test leaks a child process in a
strange state. Closing the child process requires non-trivial code,
maybe platform specific.

Remove the functional test and replaces it with an unit test which
mocks os.waitpid() using a new _testcapi.W_STOPCODE() function to
test the WIFSTOPPED() path.
(cherry picked from commit 7b7c6dcfff6a35333988a3c74c895ed19dff2e09)

<!-- issue-number: bpo-31173 -->
https://bugs.python.org/issue31173
<!-- /issue-number -->
