### PR TITLE
fix bpo-31183: allowing `dis` to disassemble async generator and coroutine objects

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -146,7 +146,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
    method, a function, a generator, an asynchronous generator, a couroutine,
    a code object, a string of source code or a byte sequence of raw bytecode.
    For a module, it disassembles all functions. For a class, it disassembles
-   all methods (including class and static methods). For a code object or 
+   all methods (including class and static methods). For a code object or
    sequence of raw bytecode, it prints one line per bytecode instruction.
    It also recursively disassembles nested code objects (the code of
    comprehensions, generator expressions and nested functions, and the code

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -87,7 +87,7 @@ code.
 
       Return a formatted view of the bytecode operations (the same as printed by
       :func:`dis.dis`, but returned as a multi-line string).
-      
+
    .. method:: info()
 
       Return a formatted multi-line string with detailed information about the
@@ -126,7 +126,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
    releases.
 
    .. versionadded:: 3.2
-   
+
    .. versionchanged:: 3.7
       This can now handle asynchronous generator and coroutine objects.
 
@@ -172,7 +172,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
 
    .. versionchanged:: 3.7
       Implemented recursive disassembling and added *depth* parameter.
-      
+
    .. versionchanged:: 3.7
       This can now handle asynchronous generator and coroutine objects.
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -94,7 +94,7 @@ code.
       code object, like :func:`code_info`.
 
    .. versionchanged:: 3.7
-      This can now handle asynchronous generator and coroutine objects.
+      This can now handle coroutine and asynchronous generator objects.
 
 Example::
 
@@ -128,7 +128,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
    .. versionadded:: 3.2
 
    .. versionchanged:: 3.7
-      This can now handle asynchronous generator and coroutine objects.
+      This can now handle coroutine and asynchronous generator objects.
 
 
 .. function:: show_code(x, *, file=None)
@@ -174,7 +174,7 @@ operation is being performed, so the intermediate analysis object isn't useful:
       Implemented recursive disassembling and added *depth* parameter.
 
    .. versionchanged:: 3.7
-      This can now handle asynchronous generator and coroutine objects.
+      This can now handle coroutine and asynchronous generator objects.
 
 
 .. function:: distb(tb=None, *, file=None)

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -87,11 +87,14 @@ code.
 
       Return a formatted view of the bytecode operations (the same as printed by
       :func:`dis.dis`, but returned as a multi-line string).
-
+      
    .. method:: info()
 
       Return a formatted multi-line string with detailed information about the
       code object, like :func:`code_info`.
+
+   .. versionchanged:: 3.7
+      This can now handle asynchronous generator and coroutine objects.
 
 Example::
 
@@ -123,6 +126,9 @@ operation is being performed, so the intermediate analysis object isn't useful:
    releases.
 
    .. versionadded:: 3.2
+   
+   .. versionchanged:: 3.7
+      This can now handle asynchronous generator and coroutine objects.
 
 
 .. function:: show_code(x, *, file=None)
@@ -166,6 +172,9 @@ operation is being performed, so the intermediate analysis object isn't useful:
 
    .. versionchanged:: 3.7
       Implemented recursive disassembling and added *depth* parameter.
+      
+   .. versionchanged:: 3.7
+      This can now handle asynchronous generator and coroutine objects.
 
 
 .. function:: distb(tb=None, *, file=None)

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -53,8 +53,9 @@ code.
 .. class:: Bytecode(x, *, first_line=None, current_offset=None)
 
 
-   Analyse the bytecode corresponding to a function, generator, method, string
-   of source code, or a code object (as returned by :func:`compile`).
+   Analyse the bytecode corresponding to a function, generator, asynchronous
+   generator, coroutine, method, string of source code, or a code object (as
+   returned by :func:`compile`).
 
    This is a convenience wrapper around many of the functions listed below, most
    notably :func:`get_instructions`, as iterating over a :class:`Bytecode`
@@ -114,7 +115,8 @@ operation is being performed, so the intermediate analysis object isn't useful:
 .. function:: code_info(x)
 
    Return a formatted multi-line string with detailed code object information
-   for the supplied function, generator, method, source code string or code object.
+   for the supplied function, generator, asynchronous generator, coroutine,
+   method, source code string or code object.
 
    Note that the exact contents of code info strings are highly implementation
    dependent and they may change arbitrarily across Python VMs or Python
@@ -141,12 +143,13 @@ operation is being performed, so the intermediate analysis object isn't useful:
 .. function:: dis(x=None, *, file=None, depth=None)
 
    Disassemble the *x* object.  *x* can denote either a module, a class, a
-   method, a function, a generator, a code object, a string of source code or
-   a byte sequence of raw bytecode.  For a module, it disassembles all functions.
-   For a class, it disassembles all methods (including class and static methods).
-   For a code object or sequence of raw bytecode, it prints one line per bytecode
-   instruction.  It also recursively disassembles nested code objects (the code
-   of comprehensions, generator expressions and nested functions, and the code
+   method, a function, a generator, an asynchronous generator, a couroutine,
+   a code object, a string of source code or a byte sequence of raw bytecode.
+   For a module, it disassembles all functions. For a class, it disassembles
+   all methods (including class and static methods). For a code object or 
+   sequence of raw bytecode, it prints one line per bytecode instruction.
+   It also recursively disassembles nested code objects (the code of
+   comprehensions, generator expressions and nested functions, and the code
    used for building nested classes).
    Strings are first compiled to code objects with the :func:`compile`
    built-in function before being disassembled.  If no object is provided, this

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -32,7 +32,7 @@ def _try_compile(source, name):
     return c
 
 def dis(x=None, *, file=None, depth=None):
-    """Disassemble classes, methods, functions, generators, 
+    """Disassemble classes, methods, functions, generators,
        asynchronous generators, coroutines, or code.
 
     With no argument, disassemble the last traceback.
@@ -112,7 +112,7 @@ def pretty_flags(flags):
     return ", ".join(names)
 
 def _get_code_object(x):
-    """Helper to handle methods, functions, generators, 
+    """Helper to handle methods, functions, generators,
        asynchronous generators, coroutines, strings and
        raw code objects"""
     if hasattr(x, '__func__'): # Method

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -32,7 +32,7 @@ def _try_compile(source, name):
     return c
 
 def dis(x=None, *, file=None, depth=None):
-    """Disassemble classes, methods, functions, other compiled objects, or code.
+    """Disassemble classes, methods, functions, and other compiled objects.
 
        With no argument, disassemble the last traceback.
 

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -32,11 +32,13 @@ def _try_compile(source, name):
     return c
 
 def dis(x=None, *, file=None, depth=None):
-    """Disassemble classes, methods, functions, generators,
-       asynchronous generators, coroutines, or code.
+    """Disassemble classes, methods, functions, other compiled objects, or code.
 
-    With no argument, disassemble the last traceback.
+       With no argument, disassemble the last traceback.
 
+       Compiled objects currently include generator objects, async generator
+       objects, and coroutine objects, all of which store their code object
+       in a special attribute.
     """
     if x is None:
         distb(file=file)
@@ -112,9 +114,7 @@ def pretty_flags(flags):
     return ", ".join(names)
 
 def _get_code_object(x):
-    """Helper to handle methods, functions, generators,
-       asynchronous generators, coroutines, strings and
-       raw code objects"""
+    """Helper to handle methods, compiled or raw code objects, and strings."""
     if hasattr(x, '__func__'): # Method
         x = x.__func__
     if hasattr(x, '__code__'): # Function

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -32,7 +32,8 @@ def _try_compile(source, name):
     return c
 
 def dis(x=None, *, file=None, depth=None):
-    """Disassemble classes, methods, functions, generators, or code.
+    """Disassemble classes, methods, functions, generators, 
+       asynchronous generators, coroutines, or code.
 
     With no argument, disassemble the last traceback.
 
@@ -46,6 +47,10 @@ def dis(x=None, *, file=None, depth=None):
         x = x.__code__
     if hasattr(x, 'gi_code'):  # Generator
         x = x.gi_code
+    if hasattr(x, 'ag_code'):  # Async generator
+        x = x.ag_code
+    if hasattr(x, 'cr_code'):  # Coroutine
+        x = x.cr_code
     if hasattr(x, '__dict__'):  # Class or module
         items = sorted(x.__dict__.items())
         for name, x1 in items:
@@ -107,13 +112,19 @@ def pretty_flags(flags):
     return ", ".join(names)
 
 def _get_code_object(x):
-    """Helper to handle methods, functions, generators, strings and raw code objects"""
+    """Helper to handle methods, functions, generators, 
+       asynchronous generators, coroutines, strings and
+       raw code objects"""
     if hasattr(x, '__func__'): # Method
         x = x.__func__
     if hasattr(x, '__code__'): # Function
         x = x.__code__
     if hasattr(x, 'gi_code'):  # Generator
         x = x.gi_code
+    if hasattr(x, 'ag_code'):  # Async generator
+        x = x.ag_code
+    if hasattr(x, 'cr_code'):  # Coroutine
+        x = x.cr_code
     if isinstance(x, str):     # Source code
         x = _try_compile(x, "<disassembly>")
     if hasattr(x, 'co_code'):  # Code object

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -34,11 +34,11 @@ def _try_compile(source, name):
 def dis(x=None, *, file=None, depth=None):
     """Disassemble classes, methods, functions, and other compiled objects.
 
-       With no argument, disassemble the last traceback.
+    With no argument, disassemble the last traceback.
 
-       Compiled objects currently include generator objects, async generator
-       objects, and coroutine objects, all of which store their code object
-       in a special attribute.
+    Compiled objects currently include generator objects, async generator
+    objects, and coroutine objects, all of which store their code object
+    in a special attribute.
     """
     if x is None:
         distb(file=file)

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -43,16 +43,19 @@ def dis(x=None, *, file=None, depth=None):
     if x is None:
         distb(file=file)
         return
-    if hasattr(x, '__func__'):  # Method
+    # Extract functions from methods.
+    if hasattr(x, '__func__'):
         x = x.__func__
-    if hasattr(x, '__code__'):  # Function
+    # Extract compiled code objects from...
+    if hasattr(x, '__code__'):  # ...a function, or
         x = x.__code__
-    if hasattr(x, 'gi_code'):  # Generator
+    elif hasattr(x, 'gi_code'):  #...a generator object, or
         x = x.gi_code
-    if hasattr(x, 'ag_code'):  # Async generator
+    elif hasattr(x, 'ag_code'):  #...an asynchronous generator object, or
         x = x.ag_code
-    if hasattr(x, 'cr_code'):  # Coroutine
+    elif hasattr(x, 'cr_code'):  #...a coroutine.
         x = x.cr_code
+    # Perform the disassembly.
     if hasattr(x, '__dict__'):  # Class or module
         items = sorted(x.__dict__.items())
         for name, x1 in items:
@@ -115,19 +118,23 @@ def pretty_flags(flags):
 
 def _get_code_object(x):
     """Helper to handle methods, compiled or raw code objects, and strings."""
-    if hasattr(x, '__func__'): # Method
+    # Extract functions from methods.
+    if hasattr(x, '__func__'):
         x = x.__func__
-    if hasattr(x, '__code__'): # Function
+    # Extract compiled code objects from...
+    if hasattr(x, '__code__'):  # ...a function, or
         x = x.__code__
-    if hasattr(x, 'gi_code'):  # Generator
+    elif hasattr(x, 'gi_code'):  #...a generator object, or
         x = x.gi_code
-    if hasattr(x, 'ag_code'):  # Async generator
+    elif hasattr(x, 'ag_code'):  #...an asynchronous generator object, or
         x = x.ag_code
-    if hasattr(x, 'cr_code'):  # Coroutine
+    elif hasattr(x, 'cr_code'):  #...a coroutine.
         x = x.cr_code
-    if isinstance(x, str):     # Source code
+    # Handle source code.
+    if isinstance(x, str):
         x = _try_compile(x, "<disassembly>")
-    if hasattr(x, 'co_code'):  # Code object
+    # By now, if we don't have a code object, we can't disassemble x.
+    if hasattr(x, 'co_code'):
         return x
     raise TypeError("don't know how to disassemble %s objects" %
                     type(x).__name__)

--- a/Lib/dis.py
+++ b/Lib/dis.py
@@ -461,8 +461,8 @@ def findlinestarts(code):
 class Bytecode:
     """The bytecode operations of a piece of code
 
-    Instantiate this with a function, method, string of code, or a code object
-    (as returned by compile()).
+    Instantiate this with a function, method, other compiled object, string of
+    code, or a code object (as returned by compile()).
 
     Iterating over this yields the bytecode operations as Instruction instances.
     """

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1105,12 +1105,14 @@ class BytecodeTests(unittest.TestCase):
         self.assertEqual(list(actual), expected_opinfo_outer)
 
     def test_source_line_in_disassembly(self):
-        # Use the line in the source code (split extracts the line no)
-        actual = dis.Bytecode(simple).dis().split(" ")[0]
-        expected = "{:>3}".format(simple.__code__.co_firstlineno)
+        # Use the line in the source code
+        actual = dis.Bytecode(simple).dis()
+        actual = actual.lstrip(" ").partition(" ")[0]  # extract the line num
+        expected = str(simple.__code__.co_firstlineno)
         self.assertEqual(actual, expected)
         # Use an explicit first line number (split extracts the line no)
-        actual = dis.Bytecode(simple, first_line=350).dis().split(" ")[0]
+        actual = dis.Bytecode(simple, first_line=350).dis()
+        actual = actual.lstrip(" ").partition(" ")[0]  # extract the line num
         self.assertEqual(actual, "350")
 
     def test_info(self):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -335,7 +335,8 @@ async def _ag(x):
     yield x
 
 async def _co(x):
-    await _ag(x)
+    async for item in _ag(x):
+        pass
 
 def _h(y):
     def foo(x):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -1070,12 +1070,14 @@ class BytecodeTests(unittest.TestCase):
         self.assertEqual(list(actual), expected_opinfo_outer)
 
     def test_source_line_in_disassembly(self):
-        # Use the line in the source code (split extracts the line no)
-        actual = dis.Bytecode(simple).dis().split(" ")[0]
-        expected = "{:>3}".format(simple.__code__.co_firstlineno)
+        # Use the line in the source code
+        actual = dis.Bytecode(simple).dis()
+        actual = actual.strip().partition(" ")[0]  # extract the line no
+        expected = str(simple.__code__.co_firstlineno)
         self.assertEqual(actual, expected)
-        # Use an explicit first line number (split extracts the line no)
-        actual = dis.Bytecode(simple, first_line=350).dis().split(" ")[0]
+        # Use an explicit first line number
+        actual = dis.Bytecode(simple, first_line=350).dis()
+        actual = actual.strip().partition(" ")[0]  # extract the line no
         self.assertEqual(actual, "350")
 
     def test_info(self):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -332,10 +332,10 @@ dis_fstring = """\
 
 def _g(x):
     yield x
-    
+
 async def _ag(x):
     yield x
-    
+
 async def _co(x):
     await _ag(x)
 
@@ -409,7 +409,7 @@ def ignore_coroutine_never_awaited_warnings():
     (a) when expected they're clutter, (b) on CPython 3.5.x where x < 3, this
     warning can trigger a segfault if we run with warnings turned into errors:
     https://bugs.python.org/issue27811.
-    
+
     (Adapted from python-trio/trio/.../test_run.py)
     """
     with warnings.catch_warnings():
@@ -433,7 +433,7 @@ def ignore_coroutine_never_awaited_warnings():
             # to make sure.
             for _ in range(4):
                 gc.collect()
-        
+
 class DisTests(unittest.TestCase):
 
     maxDiff = None
@@ -578,12 +578,12 @@ class DisTests(unittest.TestCase):
         gen_func_disas = self.get_disassembly(_g)  # Disassemble generator function
         gen_disas = self.get_disassembly(_g(1))  # Disassemble generator itself
         self.assertEqual(gen_disas, gen_func_disas)
-        
+
     def test_disassemble_async_generator(self):
         agen_func_disas = self.get_disassembly(_ag) # Disassemble async generator function
         agen_disas = self.get_disassembly(_ag(1)) # Disassemble async generator itself
         self.assertEqual(agen_disas, agen_func_disas)
-        
+
     def test_disassemble_coroutine(self):
         coro_func_disas = self.get_disassembly(_co) # Disassemble coroutine function
         with ignore_coroutine_never_awaited_warnings():

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -9,6 +9,8 @@ import io
 import re
 import types
 import contextlib
+import warnings
+import gc
 
 def get_tb():
     def _error():
@@ -330,6 +332,12 @@ dis_fstring = """\
 
 def _g(x):
     yield x
+    
+async def _ag(x):
+    yield x
+    
+async def _co(x):
+    await _ag(x)
 
 def _h(y):
     def foo(x):
@@ -390,6 +398,42 @@ Disassembly of <code object <listcomp> at 0x..., file "%s", line %d>:
        _h.__code__.co_firstlineno + 3,
 )
 
+
+
+@contextlib.contextmanager
+def ignore_coroutine_never_awaited_warnings():
+    """
+    The coroutine test leaks a coroutine, and thus triggers the
+    "RuntimeWarning: coroutine '...' was never awaited" message. This context
+    manager should be used anywhere this happens to hide those messages, because
+    (a) when expected they're clutter, (b) on CPython 3.5.x where x < 3, this
+    warning can trigger a segfault if we run with warnings turned into errors:
+    https://bugs.python.org/issue27811.
+    
+    (Adapted from python-trio/trio/.../test_run.py)
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="coroutine '.*' was never awaited"
+        )
+        try:
+            yield
+        finally:
+            # Make sure to trigger any coroutine __del__ methods now, before
+            # we leave the context manager.
+
+            # In the test suite we sometimes want to call gc.collect() to make sure
+            # that any objects with noisy __del__ methods (e.g. unawaited coroutines)
+            # get collected before we continue, so their noise doesn't leak into
+            # unrelated tests.
+            #
+            # On PyPy, coroutine objects (for example) can survive at least 1 round of
+            # garbage collection, because executing their __del__ method to print the
+            # warning can cause them to be resurrected. So we call collect a few times
+            # to make sure.
+            for _ in range(4):
+                gc.collect()
+        
 class DisTests(unittest.TestCase):
 
     maxDiff = None
@@ -534,6 +578,17 @@ class DisTests(unittest.TestCase):
         gen_func_disas = self.get_disassembly(_g)  # Disassemble generator function
         gen_disas = self.get_disassembly(_g(1))  # Disassemble generator itself
         self.assertEqual(gen_disas, gen_func_disas)
+        
+    def test_disassemble_async_generator(self):
+        agen_func_disas = self.get_disassembly(_ag) # Disassemble async generator function
+        agen_disas = self.get_disassembly(_ag(1)) # Disassemble async generator itself
+        self.assertEqual(agen_disas, agen_func_disas)
+        
+    def test_disassemble_coroutine(self):
+        coro_func_disas = self.get_disassembly(_co) # Disassemble coroutine function
+        with ignore_coroutine_never_awaited_warnings():
+            coro_disas = self.get_disassembly(_co(1)) # Disassemble coroutine itself
+        self.assertEqual(coro_disas, coro_func_disas)
 
     def test_disassemble_fstring(self):
         self.do_disassembly_test(_fstring, dis_fstring)
@@ -1050,12 +1105,12 @@ class BytecodeTests(unittest.TestCase):
         self.assertEqual(list(actual), expected_opinfo_outer)
 
     def test_source_line_in_disassembly(self):
-        # Use the line in the source code
-        actual = dis.Bytecode(simple).dis()[:3]
+        # Use the line in the source code (split extracts the line no)
+        actual = dis.Bytecode(simple).dis().split(" ")[0]
         expected = "{:>3}".format(simple.__code__.co_firstlineno)
         self.assertEqual(actual, expected)
-        # Use an explicit first line number
-        actual = dis.Bytecode(simple, first_line=350).dis()[:3]
+        # Use an explicit first line number (split extracts the line no)
+        actual = dis.Bytecode(simple, first_line=350).dis().split(" ")[0]
         self.assertEqual(actual, "350")
 
     def test_info(self):

--- a/Lib/test/test_dis.py
+++ b/Lib/test/test_dis.py
@@ -540,12 +540,12 @@ class DisTests(unittest.TestCase):
 
     def test_disassemble_generator(self):
         gen_func_disas = self.get_disassembly(_g)  # Generator function
-        gen_disas = self.get_disassembly(_g(1))  # Generator object
+        gen_disas = self.get_disassembly(_g(1))  # Generator iterator
         self.assertEqual(gen_disas, gen_func_disas)
 
     def test_disassemble_async_generator(self):
         agen_func_disas = self.get_disassembly(_ag)  # Async generator function
-        agen_disas = self.get_disassembly(_ag(1))  # Async generator object
+        agen_disas = self.get_disassembly(_ag(1))  # Async generator iterator
         self.assertEqual(agen_disas, agen_func_disas)
 
     def test_disassemble_coroutine(self):

--- a/Misc/NEWS.d/next/Library/2017-08-13-09-17-01.bpo-31183.-2_YGj.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-13-09-17-01.bpo-31183.-2_YGj.rst
@@ -1,0 +1,2 @@
+`dis` now works with asynchronous generator and coroutine objects. Patch by
+George Collins based on diagnosis by Luciano Ramalho.


### PR DESCRIPTION
I've tried to stay as close to the resolution of issue-21947 as possible; this just extends that to two new types of objects: async generator objects and coroutine objects.

This shouldn't have any backwards-compatibility concerns unless someone was relying on dis breaking on one of these.

The patch to dis is trivial; adding a test and suppressing the warning was slightly less so. As mentioned in comments, I pulled the coroutine testing approach from Trio (except for inlining the gc_collect_harder function).

Thanks to Luciano Ramalho for the substantive solution!

<!-- issue-number: bpo-31183 -->
https://bugs.python.org/issue31183
<!-- /issue-number -->
