### PR TITLE
bpo-5001, bpo-31169: Fix two uninformative asserts in multiprocessing/managers.py

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -86,7 +86,7 @@ def convert_to_error(kind, result):
         return result
     elif kind in ('#TRACEBACK', '#UNSERIALIZABLE'):
         if not isinstance(result, str):
-            raise SystemError(
+            raise TypeError(
                 "Result {0!r} (kind '{1}') type is {2}, not str".format(
                     result, kind, type(result)))
         if kind == '#UNSERIALIZABLE':

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -84,12 +84,15 @@ def dispatch(c, id, methodname, args=(), kwds={}):
 def convert_to_error(kind, result):
     if kind == '#ERROR':
         return result
-    elif kind == '#TRACEBACK':
-        assert type(result) is str
-        return  RemoteError(result)
-    elif kind == '#UNSERIALIZABLE':
-        assert type(result) is str
-        return RemoteError('Unserializable message: %s\n' % result)
+    elif kind in ('#TRACEBACK', '#UNSERIALIZABLE'):
+        if not isinstance(result, str):
+            raise SystemError(
+                "Result {0!r} (kind '{1}') type is {2}, not str".format(
+                    result, kind, type(result)))
+        if kind == '#UNSERIALIZABLE':
+            return RemoteError('Unserializable message: %s\n' % result)
+        else:
+            return RemoteError(result)
     else:
         return ValueError('Unrecognized message type')
 

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -94,7 +94,7 @@ def convert_to_error(kind, result):
         else:
             return RemoteError(result)
     else:
-        return ValueError('Unrecognized message type')
+        return ValueError('Unrecognized message type {!r}'.format(kind))
 
 class RemoteError(Exception):
     def __str__(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1465,6 +1465,7 @@ Ville Skyttä
 Michael Sloan
 Nick Sloan
 Václav Šmilauer
+Allen W. Smith
 Christopher Smith
 Eric V. Smith
 Gregory P. Smith

--- a/Misc/NEWS.d/next/Library/2017-08-12-09-25-55.bpo-5001.huQi2Y.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-12-09-25-55.bpo-5001.huQi2Y.rst
@@ -1,0 +1,9 @@
+There are a number of uninformative asserts in the `multiprocessing` module,
+as noted in issue 5001. This change fixes two of the most potentially
+problematic ones, since they are in error-reporting code, in the
+`multiprocessing.managers.convert_to_error` function. (It also makes more
+informative a ValueError message.) The only potentially problematic change
+is that the AssertionError is now a TypeError; however, this should also
+help distinguish it from an AssertionError being *reported* by the
+function/its caller (such as in issue 31169). - Patch by Allen W. Smith
+(drallensmith on github).


### PR DESCRIPTION
There are quite a few uninformative asserts in the multiprocessing code, as discussed in [issue5001](https://bugs.python.org/issue5001) and [issue31169](https://bugs.python.org/issue31169). One of them that is most potentially problematic is in error-reporting code, in convert_to_error. (I will try to work on some of the other asserts when I have the time, but I am running low on disk space and suspect a clone of the entire cpython repository would be rather large...) For this PR, the identical code is present in 2.7.13 and 3.5.3, and I strongly suspect in all other versions between 2.7 and 3.7.

<!-- issue-number: bpo-5001 -->
https://bugs.python.org/issue5001
<!-- /issue-number -->
