### PR TITLE
bpo-31161: only check for parens error for SyntaxError

### DIFF
--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -156,6 +156,34 @@ class ExceptionTests(unittest.TestCase):
         ckmsg(s, "'continue' not properly in loop")
         ckmsg("continue\n", "'continue' not properly in loop")
 
+    def testSyntaxErrorMissingParens(self):
+        def ckmsg(src, msg, exception=SyntaxError):
+            try:
+                compile(src, '<fragment>', 'exec')
+            except exception as e:
+                if e.msg != msg:
+                    self.fail("expected %s, got %s" % (msg, e.msg))
+            else:
+                self.fail("failed to get expected SyntaxError")
+
+        s = '''print "old style"'''
+        ckmsg(s, "Missing parentheses in call to 'print'. "
+                 "Did you mean print(\"old style\")?")
+
+        s = '''print "old style",'''
+        ckmsg(s, "Missing parentheses in call to 'print'. "
+                 "Did you mean print(\"old style\", end=\" \")?")
+
+        s = '''exec "old style"'''
+        ckmsg(s, "Missing parentheses in call to 'exec'")
+
+        # should not apply to subclasses, see issue #31161
+        s = '''if True:\nprint "No indent"'''
+        ckmsg(s, "expected an indented block", IndentationError)
+
+        s = '''if True:\n        print()\n\texec "mixed tabs and spaces"'''
+        ckmsg(s, "inconsistent use of tabs and spaces in indentation", TabError)
+
     def testSyntaxErrorOffset(self):
         def check(src, lineno, offset):
             with self.assertRaises(SyntaxError) as cm:

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -10,6 +10,9 @@ What's New in Python 3.6.3 release candidate 1?
 Core and Builtins
 -----------------
 
+- bpo-31161: Make sure the 'Missing parentheses' syntax error message is
+  only applied to SyntaxError, not to subclasses. Patch by Martijn Pieters.
+
 - bpo-30814: Fixed a race condition when import a submodule from a package.
 
 - bpo-30597: ``print`` now shows expected input in custom error message when

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1356,11 +1356,17 @@ SyntaxError_init(PySyntaxErrorObject *self, PyObject *args, PyObject *kwds)
 
         Py_DECREF(info);
 
+        /*
+         * Issue #21669: Custom error for 'print' & 'exec' as statements
+         *
+         * Only applies to SyntaxError instances, not to subclasses such
+         * as TabError or IndentationError (see issue #31161)
+         */
         /* Issue #21669: Custom error for 'print' & 'exec' as statements */
-        if (self->text && PyUnicode_Check(self->text)) {
-            if (_report_missing_parentheses(self) < 0) {
-                return -1;
-            }
+        if ((PyObject*)Py_TYPE(self) == PyExc_SyntaxError &&
+                self->text && PyUnicode_Check(self->text) &&
+                _report_missing_parentheses(self) < 0) {
+            return -1;
         }
     }
     return 0;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -1362,7 +1362,6 @@ SyntaxError_init(PySyntaxErrorObject *self, PyObject *args, PyObject *kwds)
          * Only applies to SyntaxError instances, not to subclasses such
          * as TabError or IndentationError (see issue #31161)
          */
-        /* Issue #21669: Custom error for 'print' & 'exec' as statements */
         if ((PyObject*)Py_TYPE(self) == PyExc_SyntaxError &&
                 self->text && PyUnicode_Check(self->text) &&
                 _report_missing_parentheses(self) < 0) {


### PR DESCRIPTION
Subclasses such as IndentError and TabError should not have this message
applied.

<!-- issue-number: bpo-31161 -->
https://bugs.python.org/issue31161
<!-- /issue-number -->

(note: this is a backport of GH-3082 made without using cherry_picker)
