### PR TITLE
bpo-26669: Fix nan arg value error in pytime.c

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -792,7 +792,7 @@ class CPyTimeTestCase:
                 debug_info = {'value': value, 'rounding': time_rnd}
                 with self.assertRaises(OverflowError, msg=debug_info):
                     pytime_converter(value, time_rnd)
-
+        
     def check_int_rounding(self, pytime_converter, expected_func,
                            unit_to_sec=1, value_filter=None):
         self._check_rounding(pytime_converter, expected_func,
@@ -827,6 +827,11 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
                                 lambda secs: secs * SEC_TO_NS,
                                 value_filter=c_int_filter)
 
+        # test nan
+        for time_rnd, _ in ROUNDING_MODES:
+            with self.assertRaises(TypeError):
+                PyTime_FromSeconds(float('nan'))
+
     def test_FromSecondsObject(self):
         from _testcapi import PyTime_FromSecondsObject
 
@@ -837,6 +842,11 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
         self.check_float_rounding(
             PyTime_FromSecondsObject,
             lambda ns: self.decimal_round(ns * SEC_TO_NS))
+        
+        # test nan
+        for time_rnd, _ in ROUNDING_MODES:
+            with self.assertRaises(ValueError):
+                PyTime_FromSecondsObject(float('nan'), time_rnd)
 
     def test_AsSecondsDouble(self):
         from _testcapi import PyTime_AsSecondsDouble
@@ -850,6 +860,11 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
         self.check_int_rounding(lambda ns, rnd: PyTime_AsSecondsDouble(ns),
                                 float_converter,
                                 NS_TO_SEC)
+
+        # test nan
+        for time_rnd, _ in ROUNDING_MODES:
+            with self.assertRaises(TypeError):
+                PyTime_AsSecondsDouble(float('nan'))
 
     def create_decimal_converter(self, denominator):
         denom = decimal.Decimal(denominator)
@@ -956,6 +971,11 @@ class TestOldPyTime(CPyTimeTestCase, unittest.TestCase):
                                   self.create_converter(SEC_TO_US),
                                   value_filter=self.time_t_filter)
 
+         # test nan
+        for time_rnd, _ in ROUNDING_MODES:
+            with self.assertRaises(ValueError):
+                pytime_object_to_timeval(float('nan'), time_rnd)
+
     def test_object_to_timespec(self):
         from _testcapi import pytime_object_to_timespec
 
@@ -966,6 +986,11 @@ class TestOldPyTime(CPyTimeTestCase, unittest.TestCase):
         self.check_float_rounding(pytime_object_to_timespec,
                                   self.create_converter(SEC_TO_NS),
                                   value_filter=self.time_t_filter)
+
+        # test nan
+        for time_rnd, _ in ROUNDING_MODES:
+            with self.assertRaises(ValueError):
+                pytime_object_to_timespec(float('nan'), time_rnd)
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -792,7 +792,7 @@ class CPyTimeTestCase:
                 debug_info = {'value': value, 'rounding': time_rnd}
                 with self.assertRaises(OverflowError, msg=debug_info):
                     pytime_converter(value, time_rnd)
-        
+
     def check_int_rounding(self, pytime_converter, expected_func,
                            unit_to_sec=1, value_filter=None):
         self._check_rounding(pytime_converter, expected_func,
@@ -842,7 +842,7 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
         self.check_float_rounding(
             PyTime_FromSecondsObject,
             lambda ns: self.decimal_round(ns * SEC_TO_NS))
-        
+
         # test nan
         for time_rnd, _ in ROUNDING_MODES:
             with self.assertRaises(ValueError):

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -489,6 +489,10 @@ class TimeTestCase(unittest.TestCase):
         self.assertRaises(OSError, time.localtime, invalid_time_t)
         self.assertRaises(OSError, time.ctime, invalid_time_t)
 
+        # Issue #26669: check for localtime() failure
+        self.assertRaises(ValueError, time.localtime, float("nan"))
+        self.assertRaises(ValueError, time.ctime, float("nan"))
+
     def test_get_clock_info(self):
         clocks = ['clock', 'perf_counter', 'process_time', 'time']
         if hasattr(time, 'monotonic'):

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -134,6 +134,11 @@ _PyTime_ObjectToDenominator(PyObject *obj, time_t *sec, long *numerator,
 
     if (PyFloat_Check(obj)) {
         double d = PyFloat_AsDouble(obj);
+        if (Py_IS_NAN(d)) {
+            *numerator = 0;
+            PyErr_SetString(PyExc_ValueError, "Invalid value NaN (not a number)");
+            return -1;
+        }
         return _PyTime_DoubleToDenominator(d, sec, numerator,
                                            denominator, round);
     }
@@ -306,6 +311,10 @@ _PyTime_FromObject(_PyTime_t *t, PyObject *obj, _PyTime_round_t round,
     if (PyFloat_Check(obj)) {
         double d;
         d = PyFloat_AsDouble(obj);
+        if (Py_IS_NAN(d)) {
+            PyErr_SetString(PyExc_ValueError, "Invalid value NaN (not a number)");
+            return -1;
+        }
         return _PyTime_FromFloatObject(t, d, round, unit_to_ns);
     }
     else {

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -155,10 +155,11 @@ _PyTime_ObjectToTime_t(PyObject *obj, time_t *sec, _PyTime_round_t round)
         volatile double d;
 
         d = PyFloat_AsDouble(obj);
-        if (isnan(d)) {
-            PyErr_SetString(PyExc_ValueError, "Invalid Value");
+        if (Py_IS_NAN(d)) {
+            PyErr_SetString(PyExc_ValueError, "Invalid value NaN (not a number)");
             return -1;
         }
+
         d = _PyTime_Round(d, round);
         (void)modf(d, &intpart);
 

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -155,6 +155,10 @@ _PyTime_ObjectToTime_t(PyObject *obj, time_t *sec, _PyTime_round_t round)
         volatile double d;
 
         d = PyFloat_AsDouble(obj);
+        if (isnan(d)) {
+            PyErr_SetString(PyExc_ValueError, "Invalid Value");
+            return -1;
+        }
         d = _PyTime_Round(d, round);
         (void)modf(d, &intpart);
 


### PR DESCRIPTION
* Make value error message for nan value
Previously, it did not show error message in arm system
* Add test case for nan value

<!-- issue-number: bpo-26669 -->
https://bugs.python.org/issue26669
<!-- /issue-number -->
