### PR TITLE
bpo-30983: Add Bruno Penteado to ACKS

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1184,6 +1184,7 @@ Berker Peksag
 Andreas Pelme
 Steven Pemberton
 Bo Peng
+Bruno "Polaco" Penteado
 Santiago Peresón
 George Peristerakis
 Thomas Perl


### PR DESCRIPTION
Title says all.

<!-- issue-number: bpo-30983 -->
https://bugs.python.org/issue30983
<!-- /issue-number -->
