### PR TITLE
[3.6] bpo-31002: IDLE: Add tests for configdialog keys tab (GH-2996)

### DIFF
--- a/Misc/NEWS.d/next/IDLE/2017-08-03-17-54-02.bpo-31002.kUSgTE.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-08-03-17-54-02.bpo-31002.kUSgTE.rst
@@ -1,0 +1,1 @@
+Add tests for configdialog keys tab. Patch by Cheryl Sabella.


### PR DESCRIPTION
Patch by Cheryl Sabella.
(cherry picked from commit 2f89646)

<!-- issue-number: bpo-31002 -->
https://bugs.python.org/issue31002
<!-- /issue-number -->
