### PR TITLE
[3.6] Revert "[3.6] bpo-30983: eval frame rename in pep 0523 broke gdb's py…

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2017-08-14-15-37-38.bpo-30983.A7UzX8.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2017-08-14-15-37-38.bpo-30983.A7UzX8.rst
@@ -1,4 +1,0 @@
-With PEP 523, gdb's Python integration stopped working properly for frames
-using the ``_PyEval_EvalFrameDefault`` function.  Affected functionality
-included `py-list` and `py-bt`.  This is now fixed.  Patch by Bruno "Polaco"
-Penteado.

--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -1502,10 +1502,8 @@ class Frame(object):
         return False
 
     def is_evalframeex(self):
-        '''Is this a PyEval_EvalFrameEx or _PyEval_EvalFrameDefault (PEP 0523)
-        frame?'''
-        if self._gdbframe.name() in ('PyEval_EvalFrameEx',
-                                     '_PyEval_EvalFrameDefault'):
+        '''Is this a PyEval_EvalFrameEx frame?'''
+        if self._gdbframe.name() == 'PyEval_EvalFrameEx':
             '''
             I believe we also need to filter on the inline
             struct frame_id.inline_depth, only regarding frames with


### PR DESCRIPTION
…thon extension (GH-2803) (#3090)"

This reverts commit 09b77165e3fffa7b7ff160ad06042cdcfa004bf5.

<!-- issue-number: bpo-30983 -->
https://bugs.python.org/issue30983
<!-- /issue-number -->
