### PR TITLE
bpo-31069, test_multiprocessing: Fix dangling process

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2596,12 +2596,13 @@ class _TestManagerRestart(BaseTestCase):
         manager.start()
 
         p = self.Process(target=self._putter, args=(manager.address, authkey))
-        p.daemon = True
         p.start()
+        p.join()
         queue = manager.get_queue()
         self.assertEqual(queue.get(), 'hello world')
         del queue
         manager.shutdown()
+
         manager = QueueManager(
             address=addr, authkey=authkey, serializer=SERIALIZER)
         try:


### PR DESCRIPTION
Fix a warning about dangling processes in test_rapid_restart() of
_test_multiprocessing: join the process.

<!-- issue-number: bpo-31069 -->
https://bugs.python.org/issue31069
<!-- /issue-number -->
