### PR TITLE
[2.7] bpo-31069, test_multiprocessing: Fix dangling process (#3103)

### DIFF
--- a/Lib/test/test_multiprocessing.py
+++ b/Lib/test/test_multiprocessing.py
@@ -1583,12 +1583,13 @@ class _TestManagerRestart(BaseTestCase):
         manager.start()
 
         p = self.Process(target=self._putter, args=(manager.address, authkey))
-        p.daemon = True
         p.start()
+        p.join()
         queue = manager.get_queue()
         self.assertEqual(queue.get(), 'hello world')
         del queue
         manager.shutdown()
+
         manager = QueueManager(
             address=addr, authkey=authkey, serializer=SERIALIZER)
         manager.start()


### PR DESCRIPTION
Fix a warning about dangling processes in test_rapid_restart() of
_test_multiprocessing: join the process.
(cherry picked from commit 17657bb9458ff8f8804b7637d61686a68f4b9471)

<!-- issue-number: bpo-31069 -->
https://bugs.python.org/issue31069
<!-- /issue-number -->
