### PR TITLE
bpo-31354: Fixing a bug related to LTO only build

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -464,7 +464,7 @@ profile-opt:
 	$(MAKE) profile-removal
 
 build_all_generate_profile:
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS) $(PGO_PROF_GEN_FLAG) @LTOFLAGS@" LDFLAGS="$(LDFLAGS) $(PGO_PROF_GEN_FLAG) @LTOFLAGS@" LIBS="$(LIBS)"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS) $(PGO_PROF_GEN_FLAG)" LDFLAGS="$(LDFLAGS) $(PGO_PROF_GEN_FLAG)" LIBS="$(LIBS)"
 
 run_profile_task:
 	@ # FIXME: can't run for a cross build
@@ -474,7 +474,7 @@ build_all_merge_profile:
 	$(LLVM_PROF_MERGER)
 
 build_all_use_profile:
-	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS) $(PGO_PROF_USE_FLAG) @LTOFLAGS@" LDFLAGS="$(LDFLAGS) @LTOFLAGS@"
+	$(MAKE) @DEF_MAKE_RULE@ CFLAGS_NODIST="$(CFLAGS) $(PGO_PROF_USE_FLAG)" LDFLAGS="$(LDFLAGS)"
 
 # Compile and run with gcov
 .PHONY=coverage coverage-lcov coverage-report

--- a/Misc/NEWS.d/next/Build/2017-09-08-11-48-11.bpo-31354.4f-VJK.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-08-11-48-11.bpo-31354.4f-VJK.rst
@@ -1,0 +1,1 @@
+Allow --with-lto to be used on all builds, not just `make profile-opt`.

--- a/configure
+++ b/configure
@@ -681,7 +681,6 @@ LLVM_PROF_FILE
 LLVM_PROF_MERGER
 PGO_PROF_USE_FLAG
 PGO_PROF_GEN_FLAG
-LTOFLAGS
 DEF_MAKE_RULE
 DEF_MAKE_ALL_RULE
 ABIFLAGS
@@ -1516,8 +1515,8 @@ Optional Packages:
   --with-suffix=.exe      set executable suffix
   --with-pydebug          build with Py_DEBUG defined
   --with-assertions       build with C assertions enabled
-  --with-lto              Enable Link Time Optimization in PGO builds.
-                          Disabled by default.
+  --with-lto              Enable Link Time Optimization in any build. Disabled
+                          by default.
   --with-hash-algorithm=[fnv|siphash24]
                           select hash algorithm
   --with-address-sanitizer
@@ -6546,7 +6545,6 @@ else
 fi
 
 # Enable LTO flags
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-lto" >&5
 $as_echo_n "checking for --with-lto... " >&6; }
 
@@ -6592,6 +6590,8 @@ if test "$Py_LTO" = 'true' ; then
       esac
       ;;
   esac
+  CFLAGS="$CFLAGS $LTOFLAGS"
+  LDFLAGS="$LDFLAGS $LTOFLAGS"
 fi
 
 # Enable PGO flags.

--- a/configure.ac
+++ b/configure.ac
@@ -1305,9 +1305,8 @@ else
 fi
 
 # Enable LTO flags
-AC_SUBST(LTOFLAGS)
 AC_MSG_CHECKING(for --with-lto)
-AC_ARG_WITH(lto, AS_HELP_STRING([--with-lto], [Enable Link Time Optimization in PGO builds. Disabled by default.]),
+AC_ARG_WITH(lto, AS_HELP_STRING([--with-lto], [Enable Link Time Optimization in any build. Disabled by default.]),
 [
 if test "$withval" != no
 then
@@ -1342,6 +1341,8 @@ if test "$Py_LTO" = 'true' ; then
       esac
       ;;
   esac
+  CFLAGS="$CFLAGS $LTOFLAGS"
+  LDFLAGS="$LDFLAGS $LTOFLAGS"
 fi
 
 # Enable PGO flags.


### PR DESCRIPTION
Dear Reviewers,

Following several [previous communications](https://mail.python.org/pipermail/python-dev/2017-August/148781.html), this pull request enables compilation of cpython with lto only optimization. While configure’s flag `--with-lto` is to be used, a new make target has been added: `make build_all_lto` .

I am looking forward to receive feedback from you.

Best regards,
Octavian


<!-- issue-number: bpo-31354 -->
https://bugs.python.org/issue31354
<!-- /issue-number -->
