### PR TITLE
bpo-31149: Doc: Write all languages names in english for consistency.

### DIFF
--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -20,7 +20,7 @@
 
   var all_languages = {
       'en': 'English',
-      'fr': 'Français',
+      'fr': 'French',
       'ja': 'Japanese',
   };
 


### PR DESCRIPTION
We'll wrote all languages in english, it does not make much differences for us (from france) with the same alphabet, but according to Inada:

> My preference is "Japanese".
After selecting drop down list, we can type "jap" to select Japanese.
On the other hand, we should use IME to input "日本語".  It's not so easy as input alphabets.

<!-- issue-number: bpo-31149 -->
https://bugs.python.org/issue31149
<!-- /issue-number -->
