### PR TITLE
[3.6] bpo-31221: patchcheck ignores external libraries (#3109)

### DIFF
--- a/Tools/scripts/patchcheck.py
+++ b/Tools/scripts/patchcheck.py
@@ -13,7 +13,8 @@ import untabify
 
 # Excluded directories which are copies of external libraries:
 # don't check their coding style
-EXCLUDE_DIRS = [os.path.join('Modules', '_ctypes', 'libffi_osx'),
+EXCLUDE_DIRS = [os.path.join('Modules', '_ctypes', 'libffi'),
+                os.path.join('Modules', '_ctypes', 'libffi_osx'),
                 os.path.join('Modules', '_ctypes', 'libffi_msvc'),
                 os.path.join('Modules', '_decimal', 'libmpdec'),
                 os.path.join('Modules', 'expat'),


### PR DESCRIPTION
Python 3.6 backport: exclude also Modules/_ctypes/libffi/

<!-- issue-number: bpo-31221 -->
https://bugs.python.org/issue31221
<!-- /issue-number -->
