### PR TITLE
[2.7] bpo-31149: backport: Update the language selection in the docs language switch. (GH-3114)

### DIFF
--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -20,7 +20,7 @@
 
   var all_languages = {
       'en': 'English',
-      'fr': 'Français',
+      'fr': 'French',
       'ja': 'Japanese',
   };
 


### PR DESCRIPTION
Change the option for `Français` into `French` to be consistent with the other language selections that are already in English.
(cherry picked from commit b616b972999cdd5fe54ef8a43c131a27ca538dee)

<!-- issue-number: bpo-31149 -->
https://bugs.python.org/issue31149
<!-- /issue-number -->
