### PR TITLE
bpo-30871: Add "make pythoninfo"

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -999,6 +999,8 @@ TESTPYTHON=	$(RUNSHARED) ./$(BUILDPYTHON) $(TESTPYTHONOPTS)
 TESTRUNNER=	$(TESTPYTHON) $(srcdir)/Tools/scripts/run_tests.py
 TESTTIMEOUT=	1200
 
+.PHONY: test testall testuniversal buildbottest pythoninfo
+
 # Run a basic set of regression tests.
 # This excludes some tests that are particularly resource-intensive.
 test:		@DEF_MAKE_RULE@ platform
@@ -1036,6 +1038,9 @@ buildbottest:	build_all platform
 			pybuildbot.identify "CC='$(CC)'" "CXX='$(CXX)'"; \
 		fi
 		$(TESTRUNNER) -j 1 -u all -W --slowest --fail-env-changed --timeout=$(TESTTIMEOUT) $(TESTOPTS)
+
+pythoninfo: build_all
+		$(RUNSHARED) ./$(BUILDPYTHON) -m test.pythoninfo
 
 QUICKTESTOPTS=	$(TESTOPTS) -x test_subprocess test_io test_lib2to3 \
 		test_multibytecodec test_urllib2_localnet test_itertools \


### PR DESCRIPTION
This command will be used on buildbots to easily run "./python -m test.pythoninfo" in a dedicated buildbot step. The tricky part is to build the command to run Python: when shared library is enabled, "./python.exe" on macOS, etc.

<!-- issue-number: bpo-30871 -->
https://bugs.python.org/issue30871
<!-- /issue-number -->
