### PR TITLE
[2.7] The `Show Source` was broken because of a change made in sphinx 1.5.1

### DIFF
--- a/Doc/tools/templates/layout.html
+++ b/Doc/tools/templates/layout.html
@@ -46,7 +46,7 @@
 <h3>{{ _('This Page') }}</h3>
 <ul class="this-page-menu">
   <li><a href="{{ pathto('bugs') }}">{% trans %}Report a Bug{% endtrans %}</a></li>
-  <li><a href="https://github.com/python/cpython/blob/{{ version }}/Doc/{{ sourcename|replace('txt', 'rst') }}"
+  <li><a href="https://github.com/python/cpython/blob/{{ version }}/Doc/{{ sourcename|replace('.rst.txt', '.rst') }}"
          rel="nofollow">{% trans %}Show Source{% endtrans %}</a>
   </li>
 </ul>


### PR DESCRIPTION
In Sphinx 1.4.9, the sourcename was "index.txt".
In Sphinx 1.5.1+, it is now "index.rst.txt".

(cherry picked from commit b9ff498793611d1c6a9b99df464812931a1e2d69)