### PR TITLE
Fix changed file detection on travis when the PR commits predate master commits.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,7 +94,7 @@ before_script:
       fi
 
       # Prints changed files in this commit to help debug doc-only build issues.
-      echo "Files_changed: "
+      echo "Files changed: "
       echo $files_changed
 
       if ! echo $files_changed | grep -qvE '(\.rst$)|(^Doc)|(^Misc)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -89,11 +89,12 @@ before_script:
         # Pull requests are slightly complicated because merging the PR commit without
         # rebasing causes it to retain its old commit date. Meaning in history if any
         # commits have been made on master that post-date it, they will be accidentally
-        # included in the diff if we use the simple TRAVIS_COMMIT_RANGE method
+        # included in the diff if we use the TRAVIS_COMMIT_RANGE variable.
         files_changed=$(git diff --name-only HEAD $(git merge-base HEAD $TRAVIS_BRANCH))
       fi
 
-      echo "files_changed: "
+      # Prints changed files in this commit to help debug doc-only build issues.
+      echo "Files_changed: "
       echo $files_changed
 
       if ! echo $files_changed | grep -qvE '(\.rst$)|(^Doc)|(^Misc)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,20 @@ matrix:
 before_script:
   - |
       set -e
-      if ! git diff --name-only $TRAVIS_COMMIT_RANGE | grep -qvE '(\.rst$)|(^Doc)|(^Misc)'
+      if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+        files_changed=$(git diff --name-only $TRAVIS_COMMIT_RANGE)
+      else
+        # Pull requests are slightly complicated because merging the PR commit without
+        # rebasing causes it to retain its old commit date. Meaning in history if any
+        # commits have been made on master that post-date it, they will be accidentally
+        # included in the diff if we use the simple TRAVIS_COMMIT_RANGE method
+        files_changed=$(git diff --name-only HEAD $(git merge-base HEAD $TRAVIS_BRANCH))
+      fi
+
+      echo "files_changed: "
+      echo $files_changed
+
+      if ! echo $files_changed | grep -qvE '(\.rst$)|(^Doc)|(^Misc)'
       then
         echo "Only docs were updated, stopping build process."
         exit


### PR DESCRIPTION
See https://github.com/python/core-workflow/issues/14 for my investigation into this.

I got the command for the pull request file detection from http://eng.localytics.com/best-practices-and-common-mistakes-with-travis-ci/ though there's is hardcoded to only work for master
```bash
CHANGES=$(git --no-pager diff --name-only FETCH_HEAD $(git merge-base FETCH_HEAD master))  
[ -n "$(grep '^rails' <<< "$CHANGES")" ] && testRails
```

additionally I found the exact same command here: https://stackoverflow.com/a/41159710 
and here: https://stackoverflow.com/questions/25071579/list-all-files-changed-in-a-pull-request-in-git-github

I've also made the script print out what files changed so this is easier to debug if it becomes an issue again in the future.