### PR TITLE
bpo-30923: Revert flag that is not recognized by an obsolete gcc v…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2119,9 +2119,6 @@ class PyBuildExt(build_ext):
         else:
             raise DistutilsError("_decimal: unsupported architecture")
 
-        if 'gcc' in cc: # Suppressing the warnings in the source is too verbose.
-            extra_compile_args.append('-Wno-implicit-fallthrough')
-
         # Workarounds for toolchain bugs:
         if sysconfig.get_config_var('HAVE_IPA_PURE_CONST_BUG'):
             # Some versions of gcc miscompile inline asm:


### PR DESCRIPTION
…ersion.

<!-- issue-number: bpo-30923 -->
https://bugs.python.org/issue30923
<!-- /issue-number -->
