### PR TITLE
bpo-31231: Fix pythoninfo in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ before_script:
         echo "$changes"
         exit 1
       fi
-      ./python -m test.pythoninfo
+      make pythoninfo
 
 script:
   # Using the built Python as patchcheck.py is built around the idea of using


### PR DESCRIPTION
bpo-31231, bpo-30871: Replace "./python -m test.pythoninfo" with
"make pythoninfo", since macOS uses ./python.exe.

<!-- issue-number: bpo-31231 -->
https://bugs.python.org/issue31231
<!-- /issue-number -->
