### PR TITLE
bpo-30830: test_logging: don't use daemon threads

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3272,7 +3272,6 @@ if hasattr(logging.handlers, 'QueueListener'):
             for i in range(self.repeat):
                 queue = multiprocessing.Queue()
                 self.setup_and_log(queue, '%s_%s' %(self.id(), i))
-                # time.sleep(1)
                 items = list(self.get_all_from_queue(queue))
                 queue.close()
                 queue.join_thread()

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -68,7 +68,7 @@ try:
 except ImportError:
     pass
 
-STOP_TIMEOUT = 2.0
+STOP_TIMEOUT = 60.0
 
 
 class BaseTest(unittest.TestCase):


### PR DESCRIPTION
test_logging:

* Don't use daemon threads, but regular threads
* Replace hardcoded literal constants with a new STOP_TIMEOUT
  constant.
* Fix servers: don't call fail() since the method doesn't exist, but
  raise directly an AssertionError

<!-- issue-number: bpo-30830 -->
https://bugs.python.org/issue30830
<!-- /issue-number -->
