### PR TITLE
bpo-9566 & bpo-30747: Silence warnings from pyatomic.h macros

### DIFF
--- a/Include/pyatomic.h
+++ b/Include/pyatomic.h
@@ -351,15 +351,21 @@ inline int _Py_atomic_load_32bit(volatile int* value, int order) {
 }
 
 #define _Py_atomic_store_explicit(ATOMIC_VAL, NEW_VAL, ORDER) \
+  __pragma(warning(push)) \
+  __pragma(warning(disable: 4133)) \
   if (sizeof(*ATOMIC_VAL._value) == 8) { \
     _Py_atomic_store_64bit(ATOMIC_VAL._value, NEW_VAL, ORDER) } else { \
-    _Py_atomic_store_32bit(ATOMIC_VAL._value, NEW_VAL, ORDER) } 
+    _Py_atomic_store_32bit(ATOMIC_VAL._value, NEW_VAL, ORDER) } \
+  __pragma(warning(pop))
 
 #define _Py_atomic_load_explicit(ATOMIC_VAL, ORDER) \
   ( \
+    __pragma(warning(push)) \
+    __pragma(warning(disable: 4133)) \
     sizeof(*(ATOMIC_VAL._value)) == 8 ? \
     _Py_atomic_load_64bit(ATOMIC_VAL._value, ORDER) : \
     _Py_atomic_load_32bit(ATOMIC_VAL._value, ORDER) \
+    __pragma(warning(pop)) \
   )
 #elif defined(_M_ARM) || defined(_M_ARM64)
 typedef enum _Py_memory_order {

--- a/Include/pyatomic.h
+++ b/Include/pyatomic.h
@@ -351,21 +351,15 @@ inline int _Py_atomic_load_32bit(volatile int* value, int order) {
 }
 
 #define _Py_atomic_store_explicit(ATOMIC_VAL, NEW_VAL, ORDER) \
-  __pragma(warning(push)) \
-  __pragma(warning(disable: 4133)) \
   if (sizeof(*ATOMIC_VAL._value) == 8) { \
-    _Py_atomic_store_64bit(ATOMIC_VAL._value, NEW_VAL, ORDER) } else { \
-    _Py_atomic_store_32bit(ATOMIC_VAL._value, NEW_VAL, ORDER) } \
-  __pragma(warning(pop))
+    _Py_atomic_store_64bit((volatile long long*)ATOMIC_VAL._value, NEW_VAL, ORDER) } else { \
+    _Py_atomic_store_32bit((volatile long*)ATOMIC_VAL._value, NEW_VAL, ORDER) } \
 
 #define _Py_atomic_load_explicit(ATOMIC_VAL, ORDER) \
   ( \
-    __pragma(warning(push)) \
-    __pragma(warning(disable: 4133)) \
     sizeof(*(ATOMIC_VAL._value)) == 8 ? \
-    _Py_atomic_load_64bit(ATOMIC_VAL._value, ORDER) : \
-    _Py_atomic_load_32bit(ATOMIC_VAL._value, ORDER) \
-    __pragma(warning(pop)) \
+    _Py_atomic_load_64bit((volatile long long*)ATOMIC_VAL._value, ORDER) : \
+    _Py_atomic_load_32bit((volatile long*)ATOMIC_VAL._value, ORDER) \
   )
 #elif defined(_M_ARM) || defined(_M_ARM64)
 typedef enum _Py_memory_order {

--- a/Include/pyatomic.h
+++ b/Include/pyatomic.h
@@ -353,7 +353,7 @@ inline int _Py_atomic_load_32bit(volatile int* value, int order) {
 #define _Py_atomic_store_explicit(ATOMIC_VAL, NEW_VAL, ORDER) \
   if (sizeof(*ATOMIC_VAL._value) == 8) { \
     _Py_atomic_store_64bit((volatile long long*)ATOMIC_VAL._value, NEW_VAL, ORDER) } else { \
-    _Py_atomic_store_32bit((volatile long*)ATOMIC_VAL._value, NEW_VAL, ORDER) } \
+    _Py_atomic_store_32bit((volatile long*)ATOMIC_VAL._value, NEW_VAL, ORDER) }
 
 #define _Py_atomic_load_explicit(ATOMIC_VAL, ORDER) \
   ( \


### PR DESCRIPTION
Apparently MSVC is too stupid to understand that the alternate branch is not taken and emits a warning for it:
```
warning C4133: 'function': incompatible types - from 'volatile uintptr_t *' to 'volatile int *'
```

Warnings added in https://github.com/python/cpython/pull/2383.

cc @Paxxi @pitrou

<!-- issue-number: bpo-9566 -->
https://bugs.python.org/issue9566
<!-- /issue-number -->
