### PR TITLE
bpo-30923: Disable warning that has been part of -Wextra since gcc-7.0.

### DIFF
--- a/Modules/_decimal/libmpdec/io.c
+++ b/Modules/_decimal/libmpdec/io.c
@@ -45,6 +45,12 @@
    PEP-3101 formatting for numeric types. */
 
 
+/* Disable warning that is part of -Wextra since gcc 7.0. */
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && __GNUC__ >= 7
+  #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+
+
 /*
  * Work around the behavior of tolower() and strcasecmp() in certain
  * locales. For example, in tr_TR.utf8:


### PR DESCRIPTION


<!-- issue-number: bpo-30923 -->
https://bugs.python.org/issue30923
<!-- /issue-number -->
