### PR TITLE
bpo-31235: Fix ResourceWarning in test_logging

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -797,6 +797,8 @@ if threading:
             """
             self.close()
             self._thread.join(timeout)
+            asyncore.close_all(map=self._map, ignore_all=True)
+
             alive = self._thread.is_alive()
             self._thread = None
             if alive:


### PR DESCRIPTION


<!-- issue-number: bpo-31235 -->
https://bugs.python.org/issue31235
<!-- /issue-number -->
