### PR TITLE
[3.6] bpo-31235: Fix ResourceWarning in test_logging (#3147)

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -770,6 +770,7 @@ if threading:
             """
             self.close()
             self._thread.join(timeout)
+            asyncore.close_all(map=self._map, ignore_all=True)
             self._thread = None
 
     class ControlMixin(object):


### PR DESCRIPTION
(cherry picked from commit a7719e27b3cad0f2b86cb932a76cbe55c541b02e)

<!-- issue-number: bpo-31235 -->
https://bugs.python.org/issue31235
<!-- /issue-number -->
