### PR TITLE
[3.6] bpo-31234: test_threading: fix ref cycle (#3150)

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1066,6 +1066,8 @@ class ThreadingExceptionTests(BaseTestCase):
         thread.join()
         self.assertIsNotNone(thread.exc)
         self.assertIsInstance(thread.exc, RuntimeError)
+        # explicitly break the reference cycle to not leak a dangling thread
+        thread.exc = None
 
 class TimerTests(BaseTestCase):
 


### PR DESCRIPTION
test_bare_raise_in_brand_new_thread() now explicitly breaks a
reference cycle to not leak a dangling thread.
(cherry picked from commit 3d284c081fc3042036adfe1bf2ce92c34d743b0b)

<!-- issue-number: bpo-31234 -->
https://bugs.python.org/issue31234
<!-- /issue-number -->
