### PR TITLE
[3.6] bpo-31206: IDLE: Factor HighPage class from ConfigDialog (GH-3141)

### DIFF
--- a/Misc/NEWS.d/next/IDLE/2017-08-18-14-13-42.bpo-31206.F1-tKK.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-08-18-14-13-42.bpo-31206.F1-tKK.rst
@@ -1,0 +1,2 @@
+IDLE: Factor HighPage(Frame) class from ConfigDialog. Patch by Cheryl
+Sabella.


### PR DESCRIPTION
This is the first half of a patch similar to the one for for bpo-31205.  It is being split into 2 PRs to avoid what happened with PR-3096 -- an incomprehensible diff that could not be cleanly backported to 3.6.  This half copies several methods of ConfigDialog and turns them into a new class.
(cherry picked from commit a32e40561a24de373d1c5a437a8aa329758ba8e4)

<!-- issue-number: bpo-31206 -->
https://bugs.python.org/issue31206
<!-- /issue-number -->
