### PR TITLE
Touch up the contributing notes

### DIFF
--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -12,10 +12,6 @@ Build Status
 
   + `Stable buildbots <http://buildbot.python.org/3.6.stable/>`_
 
-- 3.5
-
-  + `Stable buildbots <http://buildbot.python.org/3.5.stable/>`_
-
 - 2.7
 
   + `Stable buildbots <http://buildbot.python.org/2.7.stable/>`_
@@ -23,20 +19,21 @@ Build Status
 
 Contribution Guidelines
 -----------------------
-Please read the `devguide <https://cpython-devguide.readthedocs.io/>`_ for
+Please read the `devguide <https://devguide.python.org/>`_ for
 guidance on how to contribute to this project. The documentation covers
 everything from how to build the code to submitting a pull request. There are
 also suggestions on how you can most effectively help the project.
 
 Please be aware that our workflow does deviate slightly from the typical GitHub
 project. Details on how to properly submit a pull request are covered in
-`Lifecycle of a Pull Request <https://cpython-devguide.readthedocs.io/pullrequest.html>`_.
-One key point is to keep comments on GitHub to only those related to the reviewing
-the code in the pull request. All other discussions -- e.g. about the issue being
-fixed -- should happen on bugs.python.org.
+`Lifecycle of a Pull Request <https://cpython-devguide.readthedocs.io/pullrequest/>`_.
+We utilize various bots and status checks to help with this, so do follow what
+they say. The key points that are not covered by a bot or status check are:
 
-If you are making a code contribution or large documentation contribution,
-please feel free to add yourself to the ``Misc/ACKS`` file alphabetically.
+- All discussions that are not directly related to the code in the pull request
+  should happen on bugs.python.org
+- Upon your first non-trivial pull request (which includes documentation changes),
+  feel free to add yourself to ``Misc/ACKS``
 
 
 Code of Conduct

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -27,8 +27,9 @@ also suggestions on how you can most effectively help the project.
 Please be aware that our workflow does deviate slightly from the typical GitHub
 project. Details on how to properly submit a pull request are covered in
 `Lifecycle of a Pull Request <https://cpython-devguide.readthedocs.io/pullrequest/>`_.
-We utilize various bots and status checks to help with this, so do follow what
-they say. The key points that are not covered by a bot or status check are:
+We utilize various bots and status checks to help with this, so do follow the
+comments they leaves and their "Details" links, respectively. The key points of
+our workflow that are not covered by a bot or status check are:
 
 - All discussions that are not directly related to the code in the pull request
   should happen on bugs.python.org

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -36,7 +36,7 @@ Please be aware that our workflow does deviate slightly from the typical GitHub
 project. Details on how to properly submit a pull request are covered in
 `Lifecycle of a Pull Request <https://devguide.python.org/pullrequest/>`_.
 We utilize various bots and status checks to help with this, so do follow the
-comments they leaves and their "Details" links, respectively. The key points of
+comments they leave and their "Details" links, respectively. The key points of
 our workflow that are not covered by a bot or status check are:
 
 - All discussions that are not directly related to the code in the pull request

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -26,7 +26,7 @@ also suggestions on how you can most effectively help the project.
 
 Please be aware that our workflow does deviate slightly from the typical GitHub
 project. Details on how to properly submit a pull request are covered in
-`Lifecycle of a Pull Request <https://cpython-devguide.readthedocs.io/pullrequest/>`_.
+`Lifecycle of a Pull Request <https://devguide.python.org/pullrequest/>`_.
 We utilize various bots and status checks to help with this, so do follow the
 comments they leaves and their "Details" links, respectively. The key points of
 our workflow that are not covered by a bot or status check are:

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -17,6 +17,13 @@ Build Status
   + `Stable buildbots <http://buildbot.python.org/2.7.stable/>`_
 
 
+Thank You
+---------
+First off, thanks for contributing to the maintenance of the Python programming
+language and the CPython interpreter! Even if your contribution is not
+ultimately accepted, the fact you put time and effort into helping out is
+greatly appreciated.
+
 Contribution Guidelines
 -----------------------
 Please read the `devguide <https://devguide.python.org/>`_ for

--- a/.github/CONTRIBUTING.rst
+++ b/.github/CONTRIBUTING.rst
@@ -24,6 +24,7 @@ language and the CPython interpreter! Even if your contribution is not
 ultimately accepted, the fact you put time and effort into helping out is
 greatly appreciated.
 
+
 Contribution Guidelines
 -----------------------
 Please read the `devguide <https://devguide.python.org/>`_ for
@@ -42,6 +43,16 @@ our workflow that are not covered by a bot or status check are:
   should happen on bugs.python.org
 - Upon your first non-trivial pull request (which includes documentation changes),
   feel free to add yourself to ``Misc/ACKS``
+
+
+Setting Expectations
+--------------------
+Due to the fact that this project is entirely volunteer-run (i.e. no one is paid
+to work on Python full-time), we unfortunately can make no guarantees as to if
+or when a core developer will get around to reviewing your pull request.
+If no core developer has done a review or responded to changes made because of a
+"changes requested" review, please feel free to email python-dev to ask if
+someone could take a look at your pull request.
 
 
 Code of Conduct


### PR DESCRIPTION
Beyond just updating links, the contributing notes now list exactly the key things that are not covered (currently) by a bot or status check (which also mentioning one should pay attention to those bots and status checks).