### PR TITLE
bpo-31203: Added constant socket.IP_PKTINFO

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7267,6 +7267,9 @@ PyInit__socket(void)
 #ifdef  IP_TRANSPARENT
     PyModule_AddIntMacro(m, IP_TRANSPARENT);
 #endif
+#ifdef  IP_PKTINFO
+    PyModule_AddIntMacro(m, IP_PKTINFO);
+#endif
 
     /* IPv6 [gs]etsockopt options, defined in RFC2553 */
 #ifdef  IPV6_JOIN_GROUP


### PR DESCRIPTION
After this patch, `print(socket.IP_PKTINFO)` returns `8` as defined in http://elixir.free-electrons.com/linux/v4.12.8/source/include/uapi/linux/in.h#L96

<!-- issue-number: bpo-31203 -->
https://bugs.python.org/issue31203
<!-- /issue-number -->
