### PR TITLE
[2.7] bpo-30263: regrtest: add system load average

### DIFF
--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -85,7 +85,7 @@ class BaseTestCase(unittest.TestCase):
         self.assertRegexpMatches(output, regex)
 
     def parse_executed_tests(self, output):
-        regex = (r'^[0-9]+:[0-9]+:[0-9]+ \[ *[0-9]+(?:/ *[0-9]+)*\] (%s)'
+        regex = (r'^[0-9]+:[0-9]+:[0-9]+ (?:load avg: [0-9]+\.[0-9]{2} )?\[ *[0-9]+(?:/ *[0-9]+)*\] (%s)'
                  % self.TESTNAME_REGEX)
         parser = re.finditer(regex, output, re.MULTILINE)
         return list(match.group(1) for match in parser)


### PR DESCRIPTION
Add the CPU count in the header.

<!-- issue-number: bpo-30263 -->
https://bugs.python.org/issue30263
<!-- /issue-number -->
