### PR TITLE
[3.6] bpo-31247: xmlrpc.server: break reference cycle (#3166)

### DIFF
--- a/Lib/xmlrpc/server.py
+++ b/Lib/xmlrpc/server.py
@@ -264,10 +264,14 @@ class SimpleXMLRPCDispatcher:
         except:
             # report exception back to server
             exc_type, exc_value, exc_tb = sys.exc_info()
-            response = dumps(
-                Fault(1, "%s:%s" % (exc_type, exc_value)),
-                encoding=self.encoding, allow_none=self.allow_none,
-                )
+            try:
+                response = dumps(
+                    Fault(1, "%s:%s" % (exc_type, exc_value)),
+                    encoding=self.encoding, allow_none=self.allow_none,
+                    )
+            finally:
+                # Break reference cycle
+                exc_type = exc_value = exc_tb = None
 
         return response.encode(self.encoding, 'xmlcharrefreplace')
 
@@ -359,10 +363,14 @@ class SimpleXMLRPCDispatcher:
                     )
             except:
                 exc_type, exc_value, exc_tb = sys.exc_info()
-                results.append(
-                    {'faultCode' : 1,
-                     'faultString' : "%s:%s" % (exc_type, exc_value)}
-                    )
+                try:
+                    results.append(
+                        {'faultCode' : 1,
+                         'faultString' : "%s:%s" % (exc_type, exc_value)}
+                        )
+                finally:
+                    # Break reference cycle
+                    exc_type = exc_value = exc_tb = None
         return results
 
     def _dispatch(self, method, params):
@@ -624,10 +632,14 @@ class MultiPathXMLRPCServer(SimpleXMLRPCServer):
             # (each dispatcher should have handled their own
             # exceptions)
             exc_type, exc_value = sys.exc_info()[:2]
-            response = dumps(
-                Fault(1, "%s:%s" % (exc_type, exc_value)),
-                encoding=self.encoding, allow_none=self.allow_none)
-            response = response.encode(self.encoding, 'xmlcharrefreplace')
+            try:
+                response = dumps(
+                    Fault(1, "%s:%s" % (exc_type, exc_value)),
+                    encoding=self.encoding, allow_none=self.allow_none)
+                response = response.encode(self.encoding, 'xmlcharrefreplace')
+            finally:
+                # Break reference cycle
+                exc_type = exc_value = None
         return response
 
 class CGIXMLRPCRequestHandler(SimpleXMLRPCDispatcher):

--- a/Misc/NEWS.d/next/Library/2017-08-21-17-50-27.bpo-31247.8S3zJp.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-21-17-50-27.bpo-31247.8S3zJp.rst
@@ -1,0 +1,2 @@
+xmlrpc.server now explicitly breaks reference cycles when using
+sys.exc_info() in code handling exceptions.


### PR DESCRIPTION
xmlrpc.server now explicitly breaks reference cycles when using
sys.exc_info() in code handling exceptions.
(cherry picked from commit 84524454d0ba77d299741c47bd0f5841ac3f66ce)

<!-- issue-number: bpo-31247 -->
https://bugs.python.org/issue31247
<!-- /issue-number -->
