### PR TITLE
bpo-31065: Add doc about Popen.poll returns None.

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -584,7 +584,7 @@ Instances of the :class:`Popen` class have the following methods:
 .. method:: Popen.poll()
 
    Check if child process has terminated.  Set and return
-   :attr:`~Popen.returncode` attribute.
+   :attr:`~Popen.returncode` attribute. Otherwise, returns ``None``.
 
 
 .. method:: Popen.wait(timeout=None)


### PR DESCRIPTION
See https://bugs.python.org/issue31065 for more details.

<!-- issue-number: bpo-31065 -->
https://bugs.python.org/issue31065
<!-- /issue-number -->
