### PR TITLE
bpo-23835: [docs] configparser converts defaults to strings

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -944,6 +944,11 @@ ConfigParser Objects
    .. versionchanged:: 3.5
       The *converters* argument was added.
 
+   .. versionchanged:: 3.7
+      The *defaults* argument is read with :meth:`read_dict()`,
+      providing consistent behavior across the parser: non-string
+      keys and values are implicitly converted to strings.
+
 
    .. method:: defaults()
 
@@ -1325,4 +1330,3 @@ Exceptions
 .. [1] Config parsers allow for heavy customization.  If you are interested in
        changing the behaviour outlined by the footnote reference, consult the
        `Customizing Parser Behaviour`_ section.
-

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1578,6 +1578,7 @@ Jason Tishler
 Christian Tismer
 Jim Tittsler
 Frank J. Tobin
+James Tocknell
 Bennett Todd
 R Lindsay Todd
 Eugene Toder

--- a/Misc/NEWS.d/next/Library/2017-08-21-16-06-19.bpo-23835.da_4Kz.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-21-16-06-19.bpo-23835.da_4Kz.rst
@@ -1,0 +1,4 @@
+configparser: reading defaults in the ``ConfigParser()`` constructor is now
+using ``read_dict()``, making its behavior consistent with the rest of the
+parser.  Non-string keys and values in the defaults dictionary are now being
+implicitly converted to strings.  Patch by James Tocknell.


### PR DESCRIPTION
Title says all.

<!-- issue-number: bpo-23835 -->
https://bugs.python.org/issue23835
<!-- /issue-number -->
