### PR TITLE
[3.6] bpo-31238: pydoc ServerThread.stop() clears ref cycle

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2266,6 +2266,9 @@ def _start_server(urlhandler, port):
         def stop(self):
             """Stop the server and this thread nicely"""
             self.docserver.quit = True
+            # explicitly break a reference cycle: DocServer.callback
+            # has indirectly a reference to ServerThread.
+            self.docserver = None
             self.serving = False
             self.url = None
 


### PR DESCRIPTION
ServerThread.stop() now explicitly sets its docserver attribute to
None to break a reference cycle.

<!-- issue-number: bpo-31238 -->
https://bugs.python.org/issue31238
<!-- /issue-number -->
