### PR TITLE
bpo-31249: Fix ref cycle in ThreadPoolExecutor

### DIFF
--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -150,5 +150,4 @@ class ThreadPoolExecutor(_base.Executor):
         if wait:
             for t in self._threads:
                 t.join()
-            self._threads.clear()
     shutdown.__doc__ = _base.Executor.shutdown.__doc__

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -150,5 +150,5 @@ class ThreadPoolExecutor(_base.Executor):
         if wait:
             for t in self._threads:
                 t.join()
-        self._threads.clear()
+            self._threads.clear()
     shutdown.__doc__ = _base.Executor.shutdown.__doc__

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -54,8 +54,10 @@ class _WorkItem(object):
 
         try:
             result = self.fn(*self.args, **self.kwargs)
-        except BaseException as e:
-            self.future.set_exception(e)
+        except BaseException as exc:
+            self.future.set_exception(exc)
+            # Break a reference cycle with the exception 'exc'
+            self = None
         else:
             self.future.set_result(result)
 
@@ -148,4 +150,5 @@ class ThreadPoolExecutor(_base.Executor):
         if wait:
             for t in self._threads:
                 t.join()
+        self._threads.clear()
     shutdown.__doc__ = _base.Executor.shutdown.__doc__

--- a/Misc/NEWS.d/next/Library/2017-08-22-12-44-48.bpo-31249.STPbb9.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-22-12-44-48.bpo-31249.STPbb9.rst
@@ -1,3 +1,2 @@
 concurrent.futures: WorkItem.run() used by ThreadPoolExecutor now breaks a
 reference cycle between an exception object and the WorkItem object.
-ThreadPoolExecutor.shutdown(wait=True) now also clears its threads set.

--- a/Misc/NEWS.d/next/Library/2017-08-22-12-44-48.bpo-31249.STPbb9.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-22-12-44-48.bpo-31249.STPbb9.rst
@@ -1,3 +1,3 @@
 concurrent.futures: WorkItem.run() used by ThreadPoolExecutor now breaks a
 reference cycle between an exception object and the WorkItem object.
-ThreadPoolExecutor.shutdown() now also clears its threads set.
+ThreadPoolExecutor.shutdown(wait=True) now also clears its threads set.

--- a/Misc/NEWS.d/next/Library/2017-08-22-12-44-48.bpo-31249.STPbb9.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-22-12-44-48.bpo-31249.STPbb9.rst
@@ -1,0 +1,3 @@
+concurrent.futures: WorkItem.run() used by ThreadPoolExecutor now breaks a
+reference cycle between an exception object and the WorkItem object.
+ThreadPoolExecutor.shutdown() now also clears its threads set.


### PR DESCRIPTION
WorkItem.run() of concurrent.futures used by ThreadPoolExecutor now
breaks a reference cycle between an exception object and the WorkItem
object.

ThreadPoolExecutor.shutdown(wait=True) now also clears the set of
threads.

<!-- issue-number: bpo-31249 -->
https://bugs.python.org/issue31249
<!-- /issue-number -->
