### PR TITLE
bpo-737999 Fix codeop.compile_command docstring

### DIFF
--- a/Doc/library/code.rst
+++ b/Doc/library/code.rst
@@ -56,7 +56,7 @@ build applications which provide an interactive interpreter prompt.
 
    *source* is the source string; *filename* is the optional filename from which
    source was read, defaulting to ``'<input>'``; and *symbol* is the optional
-   grammar start symbol, which should be either ``'single'`` (the default) or
+   grammar start symbol, which should be ``'single'`` (the default), ``'exec'`` or
    ``'eval'``.
 
    Returns a code object (the same as ``compile(source, filename, symbol)``) if the

--- a/Doc/library/codeop.rst
+++ b/Doc/library/codeop.rst
@@ -42,9 +42,12 @@ To do just the former:
    :exc:`SyntaxError` is raised if there is invalid Python syntax, and
    :exc:`OverflowError` or :exc:`ValueError` if there is an invalid literal.
 
-   The *symbol* argument determines whether *source* is compiled as a statement
-   (``'single'``, the default) or as an :term:`expression` (``'eval'``).  Any
-   other value will cause :exc:`ValueError` to  be raised.
+   The *symbol* argument determines whether *source* is compiled as a single statement
+   (``'single'``, the default), as a sequence of statements (``'exec'``) or
+   as an :term:`expression` (``'eval'``).  Any other value will cause :exc:`ValueError`
+   to  be raised. If *symbol* is ``'single'`` and *source* is an expression, executing
+   the resulting code object will print a representation of the object the expression
+   evaluates to unless it evaluates to None.
 
    .. note::
 

--- a/Lib/codeop.py
+++ b/Lib/codeop.py
@@ -109,7 +109,7 @@ def compile_command(source, filename="<input>", symbol="single"):
     source -- the source string; may contain \n characters
     filename -- optional filename from which source was read; default
                 "<input>"
-    symbol -- optional grammar start symbol; "single" (default) or "eval"
+    symbol -- optional grammar start symbol; "single" (default), "eval" or "exec"
 
     Return value / exceptions raised:
 

--- a/Misc/NEWS.d/next/Library/2017-08-22.bpo-737999.NTEpBM.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-22.bpo-737999.NTEpBM.rst
@@ -1,0 +1,1 @@
+Improve documentation for codeop.compile_command and code.compile_command.


### PR DESCRIPTION
codeop.compile_command actually accepts symbol="exec" too

<!-- issue-number: bpo-737999 -->
https://bugs.python.org/issue737999
<!-- /issue-number -->
