### PR TITLE
bpo-31229: fix wrong error messages when too many keyword arguments are received

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -197,24 +197,23 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
 
     def test_varargs14_kw(self):
         msg = r"^product\(\) takes at most 1 keyword argument \(2 given\)$"
-        self.assertRaisesRegex(TypeError, msg, itertools.product, 0, a=1, b=2)
+        self.assertRaisesRegex(TypeError, msg,
+                               itertools.product, 0, repeat=1, foo=2)
 
     def test_varargs15_kw(self):
         msg = r"^ImportError\(\) takes at most 2 keyword arguments \(3 given\)$"
-        self.assertRaisesRegex(TypeError, msg, ImportError, 0, a=1, b=2, c=3)
+        self.assertRaisesRegex(TypeError, msg,
+                               ImportError, 0, name=1, path=2, foo=3)
 
     def test_varargs16_kw(self):
         msg = r"^min\(\) takes at most 2 keyword arguments \(3 given\)$"
-        self.assertRaisesRegex(TypeError, msg, min, 0, a=1, b=2, c=3)
+        self.assertRaisesRegex(TypeError, msg,
+                               min, 0, default=1, key=2, foo=3)
 
     def test_varargs17_kw(self):
-        msg = r"^max\(\) takes at most 2 keyword arguments \(3 given\)$"
-        self.assertRaisesRegex(TypeError, msg, max, 0, a=1, b=2, c=3)
-
-    def test_varargs18_kw(self):
         msg = r"^print\(\) takes at most 4 keyword arguments \(5 given\)$"
         self.assertRaisesRegex(TypeError, msg,
-                               print, 0, a=1, b=2, c=3, d=4, e=5)
+                               print, 0, sep=1, end=2, file=3, flush=4, foo=5)
 
     def test_oldargs0_1(self):
         msg = r"keys\(\) takes no arguments \(1 given\)"

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -7,6 +7,7 @@ except ImportError:
     _testcapi = None
 import struct
 import collections
+import itertools
 
 # The test cases here cover several paths through the function calling
 # code.  They depend on the METH_XXX flag that is used to define a C
@@ -193,6 +194,24 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
     def test_varargs13_kw(self):
         msg = r"^classmethod\(\) takes no keyword arguments$"
         self.assertRaisesRegex(TypeError, msg, classmethod, func=id)
+
+    def test_varargs14_kw(self):
+        msg = r"^product\(\) takes at most 1 keyword argument \(2 given\)$"
+        self.assertRaisesRegex(TypeError, msg, itertools.product, 0, a=1, b=2)
+
+    def test_varargs15_kw(self):
+        msg = r"^ImportError\(\) takes at most 2 keyword arguments \(3 given\)$"
+        self.assertRaisesRegex(TypeError, msg, ImportError, 0, a=1, b=2, c=3)
+
+    def test_varargs16_kw(self):
+        msg = r"^function takes at most 2 keyword arguments \(3 given\)$"
+        self.assertRaisesRegex(TypeError, msg, min, 0, a=1, b=2, c=3)
+        self.assertRaisesRegex(TypeError, msg, max, 0, a=1, b=2, c=3)
+
+    def test_varargs17_kw(self):
+        msg = r"^print\(\) takes at most 4 keyword arguments \(5 given\)$"
+        self.assertRaisesRegex(TypeError, msg,
+                               print, 0, a=1, b=2, c=3, d=4, e=5)
 
     def test_oldargs0_1(self):
         msg = r"keys\(\) takes no arguments \(1 given\)"

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -204,11 +204,14 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         self.assertRaisesRegex(TypeError, msg, ImportError, 0, a=1, b=2, c=3)
 
     def test_varargs16_kw(self):
-        msg = r"^function takes at most 2 keyword arguments \(3 given\)$"
+        msg = r"^min\(\) takes at most 2 keyword arguments \(3 given\)$"
         self.assertRaisesRegex(TypeError, msg, min, 0, a=1, b=2, c=3)
-        self.assertRaisesRegex(TypeError, msg, max, 0, a=1, b=2, c=3)
 
     def test_varargs17_kw(self):
+        msg = r"^max\(\) takes at most 2 keyword arguments \(3 given\)$"
+        self.assertRaisesRegex(TypeError, msg, max, 0, a=1, b=2, c=3)
+
+    def test_varargs18_kw(self):
         msg = r"^print\(\) takes at most 4 keyword arguments \(5 given\)$"
         self.assertRaisesRegex(TypeError, msg,
                                print, 0, a=1, b=2, c=3, d=4, e=5)

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1655,10 +1655,11 @@ vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
     nkwargs = (kwargs == NULL) ? 0 : PyDict_GET_SIZE(kwargs);
     if (nargs + nkwargs > len) {
         PyErr_Format(PyExc_TypeError,
-                     "%.200s%s takes at most %d argument%s (%zd given)",
+                     "%.200s%s takes at most %d %sargument%s (%zd given)",
                      (fname == NULL) ? "function" : fname,
                      (fname == NULL) ? "" : "()",
                      len,
+                     (nargs == 0) ? "keyword " : "",
                      (len == 1) ? "" : "s",
                      nargs + nkwargs);
         return cleanreturn(0, &freelist);
@@ -2078,10 +2079,11 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
     }
     if (nargs + nkwargs > len) {
         PyErr_Format(PyExc_TypeError,
-                     "%.200s%s takes at most %d argument%s (%zd given)",
+                     "%.200s%s takes at most %d %sargument%s (%zd given)",
                      (parser->fname == NULL) ? "function" : parser->fname,
                      (parser->fname == NULL) ? "" : "()",
                      len,
+                     (nargs == 0) ? "keyword " : "",
                      (len == 1) ? "" : "s",
                      nargs + nkwargs);
         return cleanreturn(0, &freelist);

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1654,6 +1654,8 @@ vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
     nargs = PyTuple_GET_SIZE(args);
     nkwargs = (kwargs == NULL) ? 0 : PyDict_GET_SIZE(kwargs);
     if (nargs + nkwargs > len) {
+        /* adding "keyword" (when nargs == 0) prevents producing wrong error
+           messages in some special cases (see bpo-31229). */
         PyErr_Format(PyExc_TypeError,
                      "%.200s%s takes at most %d %sargument%s (%zd given)",
                      (fname == NULL) ? "function" : fname,
@@ -2078,6 +2080,8 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
         nkwargs = 0;
     }
     if (nargs + nkwargs > len) {
+        /* adding "keyword" (when nargs == 0) prevents producing wrong error
+           messages in some special cases (see bpo-31229). */
         PyErr_Format(PyExc_TypeError,
                      "%.200s%s takes at most %d %sargument%s (%zd given)",
                      (parser->fname == NULL) ? "function" : parser->fname,

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1654,7 +1654,7 @@ vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
     nargs = PyTuple_GET_SIZE(args);
     nkwargs = (kwargs == NULL) ? 0 : PyDict_GET_SIZE(kwargs);
     if (nargs + nkwargs > len) {
-        /* adding "keyword" (when nargs == 0) prevents producing wrong error
+        /* Adding "keyword" (when nargs == 0) prevents producing wrong error
            messages in some special cases (see bpo-31229). */
         PyErr_Format(PyExc_TypeError,
                      "%.200s%s takes at most %d %sargument%s (%zd given)",
@@ -2080,7 +2080,7 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
         nkwargs = 0;
     }
     if (nargs + nkwargs > len) {
-        /* adding "keyword" (when nargs == 0) prevents producing wrong error
+        /* Adding "keyword" (when nargs == 0) prevents producing wrong error
            messages in some special cases (see bpo-31229). */
         PyErr_Format(PyExc_TypeError,
                      "%.200s%s takes at most %d %sargument%s (%zd given)",


### PR DESCRIPTION
according to http://bugs.python.org/issue31229, fix the error messages produced when calling the following with too many keyword arguments:
- itertools.product()
- ImportError
- min()
- max()
- print()

<!-- issue-number: bpo-31229 -->
https://bugs.python.org/issue31229
<!-- /issue-number -->
