### PR TITLE
[2.7] bpo-31258: test_signal: call waitpid() to prevent zombie process

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -185,6 +185,9 @@ class InterProcessSignalTests(unittest.TestCase):
                 self.fail('Test deadlocked after %d seconds.' %
                           self.MAX_DURATION)
 
+            # read the exit status to not leak a zombie process
+            os.waitpid(child, 0)
+
 
 @unittest.skipIf(sys.platform == "win32", "Not valid on Windows")
 class BasicSignalTests(unittest.TestCase):


### PR DESCRIPTION


<!-- issue-number: bpo-31258 -->
https://bugs.python.org/issue31258
<!-- /issue-number -->
