### PR TITLE
[3.6] bpo-31234: fork_wait tests now join threads (#3139)

### DIFF
--- a/Lib/test/fork_wait.py
+++ b/Lib/test/fork_wait.py
@@ -11,7 +11,8 @@ active threads survive in the child after a fork(); this is an error.
 
 import os, sys, time, unittest
 import test.support as support
-_thread = support.import_module('_thread')
+
+threading = support.import_module('threading')
 
 LONGSLEEP = 2
 SHORTSLEEP = 0.5
@@ -20,8 +21,19 @@ NUM_THREADS = 4
 class ForkWait(unittest.TestCase):
 
     def setUp(self):
+        self._threading_key = support.threading_setup()
         self.alive = {}
         self.stop = 0
+        self.threads = []
+
+    def tearDown(self):
+        # Stop threads
+        self.stop = 1
+        for thread in self.threads:
+            thread.join()
+        thread = None
+        self.threads.clear()
+        support.threading_cleanup(*self._threading_key)
 
     def f(self, id):
         while not self.stop:
@@ -43,10 +55,11 @@ class ForkWait(unittest.TestCase):
         self.assertEqual(spid, cpid)
         self.assertEqual(status, 0, "cause = %d, exit = %d" % (status&0xff, status>>8))
 
-    @support.reap_threads
     def test_wait(self):
         for i in range(NUM_THREADS):
-            _thread.start_new(self.f, (i,))
+            thread = threading.Thread(target=self.f, args=(i,))
+            thread.start()
+            self.threads.append(thread)
 
         # busy-loop to wait for threads
         deadline = time.monotonic() + 10.0
@@ -75,8 +88,4 @@ class ForkWait(unittest.TestCase):
             os._exit(n)
         else:
             # Parent
-            try:
-                self.wait_impl(cpid)
-            finally:
-                # Tell threads to die
-                self.stop = 1
+            self.wait_impl(cpid)


### PR DESCRIPTION
fork_wait.py tests now joins threads, to not leak running threads in
the background.

(cherry picked from commit c99d41f9c0304fcf06550515c3db55f93a629e9e)

<!-- issue-number: bpo-31234 -->
https://bugs.python.org/issue31234
<!-- /issue-number -->
