### PR TITLE
bpo-31234: test_threaded_import: fix test_side_effect_import()

### DIFF
--- a/Lib/test/test_threaded_import.py
+++ b/Lib/test/test_threaded_import.py
@@ -230,7 +230,8 @@ class ThreadedImportTests(unittest.TestCase):
                 import random
             t = threading.Thread(target=target)
             t.start()
-            t.join()"""
+            t.join()
+            t = None"""
         sys.path.insert(0, os.curdir)
         self.addCleanup(sys.path.remove, os.curdir)
         filename = TESTFN + ".py"
@@ -241,6 +242,7 @@ class ThreadedImportTests(unittest.TestCase):
         self.addCleanup(rmtree, '__pycache__')
         importlib.invalidate_caches()
         __import__(TESTFN)
+        del sys.modules[TESTFN]
 
 
 @reap_threads


### PR DESCRIPTION
* Don't leak the module into sys.modules
* Avoid dangling thread

<!-- issue-number: bpo-31234 -->
https://bugs.python.org/issue31234
<!-- /issue-number -->
