### PR TITLE
bpo-22536: Set the filename in FileNotFoundError.

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1327,15 +1327,15 @@ class Popen(object):
                     child_exec_never_called = (err_msg == "noexec")
                     if child_exec_never_called:
                         err_msg = ""
+                        # The error must be from chdir(cwd).
+                        err_filename = cwd
+                    else:
+                        err_filename = orig_executable
                     if errno_num != 0:
                         err_msg = os.strerror(errno_num)
                         if errno_num == errno.ENOENT:
-                            if child_exec_never_called:
-                                # The error must be from chdir(cwd).
-                                err_msg += ': ' + repr(cwd)
-                            else:
-                                err_msg += ': ' + repr(orig_executable)
-                    raise child_exception_type(errno_num, err_msg)
+                            err_msg += ': ' + repr(err_filename)
+                    raise child_exception_type(errno_num, err_msg, err_filename)
                 raise child_exception_type(err_msg)
 
 

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1371,6 +1371,16 @@ class ProcessTestCase(BaseTestCase):
         fds_after_exception = os.listdir(fd_directory)
         self.assertEqual(fds_before_popen, fds_after_exception)
 
+    def test_file_not_found_includes_filename(self):
+        with self.assertRaises(FileNotFoundError) as c:
+            subprocess.call(['/opt/nonexistent_binary', 'with', 'some', 'args'])
+        self.assertEqual(c.exception.filename, '/opt/nonexistent_binary')
+
+    def test_file_not_found_with_bad_cwd(self):
+        with self.assertRaises(FileNotFoundError) as c:
+            subprocess.Popen(['exit', '0'], cwd='/some/nonexistent/directory')
+        self.assertEqual(c.exception.filename, '/some/nonexistent/directory')
+
 
 class RunFuncTestCase(BaseTestCase):
     def run_python(self, code, **kwargs):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -379,6 +379,9 @@ Extension Modules
 Library
 -------
 
+- bpo-22536: The subprocess module now sets the filename when FileNotFoundError
+  is raised on POSIX systems due to the executable or cwd not being found.
+
 - bpo-30119: ftplib.FTP.putline() now throws ValueError on commands that contains
   CR or LF. Patch by Dong-hee Na.
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -379,9 +379,6 @@ Extension Modules
 Library
 -------
 
-- bpo-22536: The subprocess module now sets the filename when FileNotFoundError
-  is raised on POSIX systems due to the executable or cwd not being found.
-
 - bpo-30119: ftplib.FTP.putline() now throws ValueError on commands that contains
   CR or LF. Patch by Dong-hee Na.
 

--- a/Misc/NEWS.d/next/Library/2017-08-23.bpo-22536._narf_.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-23.bpo-22536._narf_.rst
@@ -1,0 +1,2 @@
+The subprocess module now sets the filename when FileNotFoundError
+is raised on POSIX systems due to the executable or cwd not being found.


### PR DESCRIPTION
Have the subprocess module set the filename in the FileNotFoundError
exception raised on POSIX systems when the executable or cwd are missing.

<!-- issue-number: bpo-22536 -->
https://bugs.python.org/issue22536
<!-- /issue-number -->
