### PR TITLE
bpo-31271: fix an assertion failure in io.TextIOWrapper.write

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3228,15 +3228,9 @@ class TextIOWrapperTest(unittest.TestCase):
     def test_illegal_encoder(self):
         # Issue 31271: Calling write() while the return value of encoder's
         # encode() is invalid shouldn't cause an assertion failure.
-        class BadEncoder():
-            def encode(self, dummy):
-                return 42
-        def _get_bad_encoder(dummy):
-            return BadEncoder()
-        quopri = codecs.lookup("quopri")
-        with support.swap_attr(quopri, '_is_text_encoding', True), \
-             support.swap_attr(quopri, 'incrementalencoder', _get_bad_encoder):
-            t = io.TextIOWrapper(io.BytesIO(b'foo'), encoding="quopri")
+        rot13 = codecs.lookup("rot13")
+        with support.swap_attr(rot13, '_is_text_encoding', True):
+            t = io.TextIOWrapper(io.BytesIO(b'foo'), encoding="rot13")
         self.assertRaises(TypeError, t.write, 'bar')
 
     def test_illegal_decoder(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-25-20-43-22.bpo-31271.YMduKF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-25-20-43-22.bpo-31271.YMduKF.rst
@@ -1,0 +1,2 @@
+Fix an assertion failure in the write() method of `io.TextIOWrapper`, when
+the encoder doesn't return a bytes object. Patch by Oren Milman.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1381,8 +1381,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
         return NULL;
     if (!PyBytes_Check(b)) {
         PyErr_Format(PyExc_TypeError,
-                     "encode() should have returned a bytes object, not "
-                     "'%.200s'",
+                     "encoder should return a bytes object, not '%.200s'",
                      Py_TYPE(b)->tp_name);
         Py_DECREF(b);
         return NULL;

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1379,6 +1379,14 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
     Py_DECREF(text);
     if (b == NULL)
         return NULL;
+    if (!PyBytes_Check(b)) {
+        PyErr_Format(PyExc_TypeError,
+                     "encode() should have returned a bytes object, not "
+                     "'%.200s'",
+                     Py_TYPE(b)->tp_name);
+        Py_DECREF(b);
+        return NULL;
+    }
 
     if (self->pending_bytes == NULL) {
         self->pending_bytes = PyList_New(0);


### PR DESCRIPTION
- in textio.c: add a check whether encoder's encode() returned a bytes object.
- in test_io.py: add a test to verify the assertion doesn't fail anymore.

<!-- issue-number: bpo-31271 -->
https://bugs.python.org/issue31271
<!-- /issue-number -->
