### PR TITLE
bpo-31275: Small refactoring to silence a fall-through warning.

### DIFF
--- a/Modules/cjkcodecs/_codecs_iso2022.c
+++ b/Modules/cjkcodecs/_codecs_iso2022.c
@@ -807,15 +807,9 @@ jisx0213_encoder(const Py_UCS4 *data, Py_ssize_t *length, void *config)
     case 2: /* second character of unicode pair */
         coded = find_pairencmap((ucs2_t)data[0], (ucs2_t)data[1],
                                 jisx0213_pair_encmap, JISX0213_ENCPAIRS);
-        if (coded == DBCINV) {
-            *length = 1;
-            coded = find_pairencmap((ucs2_t)data[0], 0,
-                      jisx0213_pair_encmap, JISX0213_ENCPAIRS);
-            if (coded == DBCINV)
-                return MAP_UNMAPPABLE;
-        }
-        else
+        if (coded != DBCINV)
             return coded;
+        /* fall through */
 
     case -1: /* flush unterminated */
         *length = 1;


### PR DESCRIPTION


<!-- issue-number: bpo-31275 -->
https://bugs.python.org/issue31275
<!-- /issue-number -->
