### PR TITLE
bpo-31281: Fix pathlib.Path incompatibility in fileinput

### DIFF
--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -330,7 +330,7 @@ class FileInput:
         else:
             if self._inplace:
                 self._backupfilename = (
-                    self._filename + (self._backup or ".bak"))
+                    os.fspath(self._filename) + (self._backup or ".bak"))
                 try:
                     os.unlink(self._backupfilename)
                 except OSError:

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -544,6 +544,19 @@ class FileInputTests(unittest.TestCase):
         finally:
             remove_tempfiles(t1)
 
+    def test_pathlib_file_inplace(self):
+        t1 = None
+        try:
+            t1 = Path(writeTmp(1, ['Pathlib file.']))
+            with FileInput(t1, inplace=True) as fi:
+                line = fi.readline()
+                self.assertEqual(line, 'Pathlib file.')
+                print('Modified %s' % line)
+            with open(t1) as f:
+                self.assertEqual(f.read(), 'Modified Pathlib file.\n')
+        finally:
+            remove_tempfiles(t1)
+
 
 class MockFileInput:
     """A class that mocks out fileinput.FileInput for use during unit tests"""

--- a/Misc/NEWS.d/next/Library/2017-08-29-07-14-14.bpo-31281.DcFyNs.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-29-07-14-14.bpo-31281.DcFyNs.rst
@@ -1,0 +1,2 @@
+Fix ``fileinput.FileInput(files, inplace=True)`` when ``files`` contain
+``pathlib.Path`` objects.


### PR DESCRIPTION
`fileinput` otherwise works fine with `pathlib.Path` filenames, but when `inplace` is set to `True`, the `Path` object needs to be converted to a `str` first, or appending a `str` suffix with `+` would fail:

```py
import fileinput
import pathlib
with fileinput.input(files=(pathlib.Path('in.txt'),), inplace=True) as fp:
    for line in fp:
        print(line, end='')
```

=>

```python-traceback
Traceback (most recent call last):
  File "./pathlib-fileinput.py", line 6, in <module>
    for line in fp:
  File "/Users/zmwang/.pyenv/versions/3.6.1/lib/python3.6/fileinput.py", line 250, in __next__
    line = self._readline()
  File "/Users/zmwang/.pyenv/versions/3.6.1/lib/python3.6/fileinput.py", line 331, in _readline
    self._filename + (self._backup or ".bak"))
TypeError: unsupported operand type(s) for +: 'PosixPath' and 'str'
```

<!-- issue-number: bpo-31281 -->
https://bugs.python.org/issue31281
<!-- /issue-number -->
