### PR TITLE
bpo-26656 clarify re.compile documentation

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -490,9 +490,10 @@ form.
 
 .. function:: compile(pattern, flags=0)
 
-   Compile a regular expression pattern into a regular expression object, which
-   can be used for matching using its :func:`~regex.match` and
-   :func:`~regex.search` methods, described below.
+   Compile a regular expression pattern into a :ref:`regular expression object
+   <re-objects>`, which can be used for matching using its
+   :func:`~regex.match`, :func:`~regex.search` and other methods, described
+   below.
 
    The expression's behaviour can be modified by specifying a *flags* value.
    Values can be any of the following variables, combined using bitwise OR (the

--- a/Misc/NEWS.d/next/Documentation/2017-08-26-14-25-26.bpo-26656.ILVP13.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-08-26-14-25-26.bpo-26656.ILVP13.rst
@@ -1,5 +1,0 @@
-documentation of re.compile improved
-
-The re.compile mention of compiled regular expression objects now links to
-the relevant heading. Also, it is more explicit that more than the methods
-listed can be used.

--- a/Misc/NEWS.d/next/Documentation/2017-08-26-14-25-26.bpo-26656.ILVP13.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-08-26-14-25-26.bpo-26656.ILVP13.rst
@@ -1,0 +1,5 @@
+documentation of re.compile improved
+
+The re.compile mention of compiled regular expression objects now links to
+the relevant heading. Also, it is more explicit that more than the methods
+listed can be used.


### PR DESCRIPTION
Add link to regular expression object heading in re.compile documentation and clarify that it has more than 2 methods.

<!-- issue-number: bpo-26656 -->
https://bugs.python.org/issue26656
<!-- /issue-number -->
