### PR TITLE
bpo-31284: IDLE: Fix WindowList warning message when running tests

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -388,7 +388,10 @@ class EditorWindow(object):
     def postwindowsmenu(self):
         # Only called when Windows menu exists
         menu = self.menudict['windows']
-        end = menu.index("end")
+        try:
+            end = menu.index("end")
+        except TclError:
+            return
         if end is None:
             end = -1
         if end > self.wmenu_end:


### PR DESCRIPTION


<!-- issue-number: bpo-31284 -->
https://bugs.python.org/issue31284
<!-- /issue-number -->
