### PR TITLE
[2.7] bpo-28261: Prevent raising SystemError where PyArg_ParseTuple is used to parse non-args

### DIFF
--- a/Lib/test/test_audioop.py
+++ b/Lib/test/test_audioop.py
@@ -325,6 +325,10 @@ class TestAudioop(unittest.TestCase):
             self.assertEqual(audioop.ratecv(datas[w], w, 1, 8000, 8000, None, 30, 10)[0],
                              expected[w])
 
+        self.assertRaises(TypeError, audioop.ratecv, b'', 1, 1, 8000, 8000, 42)
+        self.assertRaises(TypeError, audioop.ratecv,
+                          b'', 1, 1, 8000, 8000, (1, (42,)))
+
     def test_reverse(self):
         for w in 1, 2, 4:
             self.assertEqual(audioop.reverse(b'', w), b'')

--- a/Modules/audioop.c
+++ b/Modules/audioop.c
@@ -1086,7 +1086,7 @@ audioop_ratecv(PyObject *self, PyObject *args)
     char *cp, *ncp;
     int len, size, nchannels, inrate, outrate, weightA, weightB;
     int chan, d, *prev_i, *cur_i, cur_o;
-    PyObject *state, *samps, *str, *rv = NULL;
+    PyObject *state, *samps, *str, *rv = NULL, *channel;
     int bytes_per_frame;
 
     weightA = 1;
@@ -1152,6 +1152,10 @@ audioop_ratecv(PyObject *self, PyObject *args)
             prev_i[chan] = cur_i[chan] = 0;
     }
     else {
+        if (!PyTuple_Check(state)) {
+            PyErr_SetString(PyExc_TypeError, "state must be a tuple or None");
+            goto exit;
+        }
         if (!PyArg_ParseTuple(state,
                         "iO!;audioop.ratecv: illegal state argument",
                         &d, &PyTuple_Type, &samps))
@@ -1162,7 +1166,13 @@ audioop_ratecv(PyObject *self, PyObject *args)
             goto exit;
         }
         for (chan = 0; chan < nchannels; chan++) {
-            if (!PyArg_ParseTuple(PyTuple_GetItem(samps, chan),
+            channel = PyTuple_GetItem(samps, chan);
+            if (!PyTuple_Check(channel)) {
+                PyErr_SetString(PyExc_TypeError,
+                                "ratecv(): illegal state argument");
+                goto exit;
+            }
+            if (!PyArg_ParseTuple(channel,
                                   "ii:ratecv", &prev_i[chan],
                                                &cur_i[chan]))
                 goto exit;


### PR DESCRIPTION
this is a partial backport of #3119.
(the 3 bugs that cause a SystemError to be raised and are fixed in #3198 don't exist on 2.7. This is because on 2.7, the code of these bugs uses PyArg_Parse (which doesn't assume it received a tuple) instead of PyArg_ParseTuple.)

<!-- issue-number: bpo-28261 -->
https://bugs.python.org/issue28261
<!-- /issue-number -->
