### PR TITLE
Enable nuget RC packages

### DIFF
--- a/Tools/nuget/make_pkg.proj
+++ b/Tools/nuget/make_pkg.proj
@@ -14,6 +14,7 @@
 
     <PropertyGroup>
         <NuspecVersion>$(MajorVersionNumber).$(MinorVersionNumber).$(MicroVersionNumber)</NuspecVersion>
+        <NuspecVersion Condition="$(ReleaseLevelName) != ''">$(NuspecVersion)-$(ReleaseLevelName)</NuspecVersion>
         <SignOutput>false</SignOutput>
         <TargetName>$(OutputName).$(NuspecVersion)</TargetName>
         <TargetExt>.nupkg</TargetExt>


### PR DESCRIPTION
The RC nuget packages were generated without RC markings, which means they couldn't be uploaded.

I regenerated them with this change (taken from master) and now they're fine, and this change will help keep them from failing in the future.