### PR TITLE
 bpo-26656: Add a reference link to the regular expression objects

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -490,7 +490,8 @@ form.
 
 .. function:: compile(pattern, flags=0)
 
-   Compile a regular expression pattern into a regular expression object, which
+   Compile a regular expression pattern into a
+   :ref:`regular expression object<re-objects>`, which
    can be used for matching using its :func:`~regex.match` and
    :func:`~regex.search` methods, described below.
 


### PR DESCRIPTION
As per http://bugs.python.org/issue26656

<!-- issue-number: bpo-26656 -->
https://bugs.python.org/issue26656
<!-- /issue-number -->
