### PR TITLE
[3.6] bpo-31287: IDLE - do not alter tkinter.messagebox in configdial…

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -18,7 +18,7 @@ from tkinter.ttk import (Button, Checkbutton, Entry, Frame, Label, LabelFrame,
                          Notebook, Radiobutton, Scrollbar, Style)
 import tkinter.colorchooser as tkColorChooser
 import tkinter.font as tkFont
-import tkinter.messagebox as tkMessageBox
+from tkinter import messagebox
 
 from idlelib.config import idleConf, ConfigChanges
 from idlelib.config_key import GetKeysDialog
@@ -1227,6 +1227,10 @@ class HighPage(Frame):
             value = theme[element]
             idleConf.userCfg['highlight'].SetOption(theme_name, element, value)
 
+    def askyesno(self, *args, **kwargs):
+        # Make testing easier.  Could change implementation.
+        messagebox.askyesno(*args, **kwargs)
+
     def delete_custom(self):
         """Handle event to delete custom theme.
 
@@ -1251,7 +1255,7 @@ class HighPage(Frame):
         """
         theme_name = self.custom_name.get()
         delmsg = 'Are you sure you wish to delete the theme %r ?'
-        if not tkMessageBox.askyesno(
+        if not self.askyesno(
                 'Delete Theme',  delmsg % theme_name, parent=self):
             return
         self.cd.deactivate_current_config()
@@ -1669,6 +1673,10 @@ class KeysPage(Frame):
             value = keyset[event]
             idleConf.userCfg['keys'].SetOption(keyset_name, event, value)
 
+    def askyesno(self, *args, **kwargs):
+        # Make testing easier.  Could change implementation.
+        messagebox.askyesno(*args, **kwargs)
+
     def delete_custom_keys(self):
         """Handle event to delete a custom key set.
 
@@ -1678,7 +1686,7 @@ class KeysPage(Frame):
         """
         keyset_name = self.custom_name.get()
         delmsg = 'Are you sure you wish to delete the key set %r ?'
-        if not tkMessageBox.askyesno(
+        if not self.askyesno(
                 'Delete Key Set',  delmsg % keyset_name, parent=self):
             return
         self.cd.deactivate_current_config()

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -643,7 +643,7 @@ class HighPageTest(unittest.TestCase):
         eq = self.assertEqual
         d = self.page
         d.button_delete_custom.state(('!disabled',))
-        yesno = configdialog.tkMessageBox.askyesno = Func()
+        yesno = d.askyesno = Func()
         dialog.deactivate_current_config = Func()
         dialog.activate_config_changes = Func()
 
@@ -678,7 +678,7 @@ class HighPageTest(unittest.TestCase):
         eq(d.set_theme_type.called, 1)
 
         del dialog.activate_config_changes, dialog.deactivate_current_config
-        del configdialog.tkMessageBox.askyesno
+        del d.askyesno
 
 
 class KeysPageTest(unittest.TestCase):
@@ -1034,7 +1034,7 @@ class KeysPageTest(unittest.TestCase):
         eq = self.assertEqual
         d = self.page
         d.button_delete_custom_keys.state(('!disabled',))
-        yesno = configdialog.tkMessageBox.askyesno = Func()
+        yesno = d.askyesno = Func()
         dialog.deactivate_current_config = Func()
         dialog.activate_config_changes = Func()
 
@@ -1069,7 +1069,7 @@ class KeysPageTest(unittest.TestCase):
         eq(d.set_keys_type.called, 1)
 
         del dialog.activate_config_changes, dialog.deactivate_current_config
-        del configdialog.tkMessageBox.askyesno
+        del d.askyesno
 
 
 class GenPageTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/IDLE/2017-08-27-15-31-33.bpo-31287.aZERfI.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-08-27-15-31-33.bpo-31287.aZERfI.rst
@@ -1,0 +1,1 @@
+IDLE - Do not modify tkinter.message in test_configdialog.


### PR DESCRIPTION
…og tests. (GH-3220)

(cherry picked from commit 3457f42)

<!-- issue-number: bpo-31287 -->
https://bugs.python.org/issue31287
<!-- /issue-number -->
