### PR TITLE
bpo-30780: IDLE: Fix for configdialog test with messagebox

### DIFF
--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -643,6 +643,7 @@ class HighPageTest(unittest.TestCase):
         eq = self.assertEqual
         d = self.page
         d.button_delete_custom.state(('!disabled',))
+        orig_askyesno = configdialog.tkMessageBox.askyesno
         yesno = configdialog.tkMessageBox.askyesno = Func()
         dialog.deactivate_current_config = Func()
         dialog.activate_config_changes = Func()
@@ -678,7 +679,7 @@ class HighPageTest(unittest.TestCase):
         eq(d.set_theme_type.called, 1)
 
         del dialog.activate_config_changes, dialog.deactivate_current_config
-        del configdialog.tkMessageBox.askyesno
+        configdialog.tkMessageBox.askyesno = orig_askyesno
 
 
 class KeysPageTest(unittest.TestCase):
@@ -1034,6 +1035,7 @@ class KeysPageTest(unittest.TestCase):
         eq = self.assertEqual
         d = self.page
         d.button_delete_custom_keys.state(('!disabled',))
+        orig_askyesno = configdialog.tkMessageBox.askyesno
         yesno = configdialog.tkMessageBox.askyesno = Func()
         dialog.deactivate_current_config = Func()
         dialog.activate_config_changes = Func()
@@ -1069,7 +1071,7 @@ class KeysPageTest(unittest.TestCase):
         eq(d.set_keys_type.called, 1)
 
         del dialog.activate_config_changes, dialog.deactivate_current_config
-        del configdialog.tkMessageBox.askyesno
+        configdialog.tkMessageBox.askyesno = orig_askyesno
 
 
 class GenPageTest(unittest.TestCase):


### PR DESCRIPTION


<!-- issue-number: bpo-30780 -->
https://bugs.python.org/issue30780
<!-- /issue-number -->
