### PR TITLE
[3.6] bpo-26656: Improve re.compile documentation (GH-3211)

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -490,9 +490,10 @@ form.
 
 .. function:: compile(pattern, flags=0)
 
-   Compile a regular expression pattern into a regular expression object, which
-   can be used for matching using its :func:`~regex.match` and
-   :func:`~regex.search` methods, described below.
+   Compile a regular expression pattern into a :ref:`regular expression object
+   <re-objects>`, which can be used for matching using its
+   :func:`~regex.match`, :func:`~regex.search` and other methods, described
+   below.
 
    The expression's behaviour can be modified by specifying a *flags* value.
    Values can be any of the following variables, combined using bitwise OR (the


### PR DESCRIPTION
- Link to the regular expressions object documentation
- Clarify that it can be used with more than the two methods currently stated.
(cherry picked from commit ed94a8b2851914bcda3a77b28b25517b8baa91e6)

<!-- issue-number: bpo-26656 -->
https://bugs.python.org/issue26656
<!-- /issue-number -->
