### PR TITLE
bpo-31291: fix an assertion failure in zipimport.zipimporter.get_data()

### DIFF
--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -517,6 +517,12 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
             zi = zipimport.zipimporter(TEMP_ZIP)
             self.assertEqual(data, zi.get_data(name))
             self.assertIn('zipimporter object', repr(zi))
+            # Issue #31291: There shouldn't be an assertion failure in
+            # get_data().
+            class FunnyStr(str):
+                def replace(self, old, new):
+                    return 42
+            self.assertEqual(data, zi.get_data(FunnyStr(name)))
         finally:
             z.close()
             os.remove(TEMP_ZIP)

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -517,11 +517,22 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
             zi = zipimport.zipimporter(TEMP_ZIP)
             self.assertEqual(data, zi.get_data(name))
             self.assertIn('zipimporter object', repr(zi))
-            # Issue #31291: There shouldn't be an assertion failure in
-            # get_data().
-            class FunnyStr(str):
-                def replace(self, old, new):
-                    return 42
+        finally:
+            z.close()
+            os.remove(TEMP_ZIP)
+
+    def test_issue31291(self):
+        # There shouldn't be an assertion failure in get_data().
+        class FunnyStr(str):
+            def replace(self, old, new):
+                return 42
+        z = ZipFile(TEMP_ZIP, "w")
+        try:
+            name = "test31291.dat"
+            data = b'foo'
+            z.writestr(name, data)
+            z.close()
+            zi = zipimport.zipimporter(TEMP_ZIP)
             self.assertEqual(data, zi.get_data(FunnyStr(name)))
         finally:
             z.close()

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-28-11-51-29.bpo-31291.t8QggK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-28-11-51-29.bpo-31291.t8QggK.rst
@@ -1,3 +1,3 @@
 Fix an assertion failure in `zipimport.zipimporter.get_data` on Windows,
-when the return value of `pathname.replace('/','\\')` isn't a string. Patch by
-Oren Milman.
+when the return value of ``pathname.replace('/','\\')`` isn't a string.
+Patch by Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-28-11-51-29.bpo-31291.t8QggK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-28-11-51-29.bpo-31291.t8QggK.rst
@@ -1,3 +1,3 @@
 Fix an assertion failure in `zipimport.zipimporter.get_data` on Windows,
-when the return value of pathname.replace('/','\\') isn't a string. Patch by
+when the return value of `pathname.replace('/','\\')` isn't a string. Patch by
 Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-28-11-51-29.bpo-31291.t8QggK.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-28-11-51-29.bpo-31291.t8QggK.rst
@@ -1,0 +1,3 @@
+Fix an assertion failure in `zipimport.zipimporter.get_data` on Windows,
+when the return value of pathname.replace('/','\\') isn't a string. Patch by
+Oren Milman.

--- a/Modules/zipimport.c
+++ b/Modules/zipimport.c
@@ -651,7 +651,8 @@ zipimport_zipimporter_get_data_impl(ZipImporter *self, PyObject *path)
     Py_ssize_t path_start, path_len, len;
 
 #ifdef ALTSEP
-    path = _PyObject_CallMethodId(path, &PyId_replace, "CC", ALTSEP, SEP);
+    path = _PyObject_CallMethodId((PyObject *)&PyUnicode_Type, &PyId_replace,
+                                  "OCC", path, ALTSEP, SEP);
     if (!path)
         return NULL;
 #else


### PR DESCRIPTION
- in `zipimport.c`: replace the C equivalent of `pathname.replace('/', '\\')` with
`str.replace(pathname, '/', '\\')`.
- in `test_zipimport.py`: add a test to verify the assertion failure is no more.

<!-- issue-number: bpo-31291 -->
https://bugs.python.org/issue31291
<!-- /issue-number -->
