### PR TITLE
bpo-31293: Fix crashes in truediv and mul of a timedelta by a float with a bad as_integer_ratio() method

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -869,22 +869,22 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
     def test_issue31293(self):
         # The interpreter shouldn't crash in case a timedelta is divided or
         # multiplied by a float with a bad as_integer_ratio() method.
-        def _get_bad_float(bad_ratio):
+        def get_bad_float(bad_ratio):
             class BadFloat(float):
                 def as_integer_ratio(self):
                     return bad_ratio
             return BadFloat()
 
         with self.assertRaises(TypeError):
-            timedelta() / _get_bad_float(1 << 1000)
+            timedelta() / get_bad_float(1 << 1000)
         with self.assertRaises(TypeError):
-            timedelta() * _get_bad_float(1 << 1000)
+            timedelta() * get_bad_float(1 << 1000)
 
         for bad_ratio in [(), (42, ), (1, 2, 3)]:
             with self.assertRaises(ValueError):
-                timedelta() / _get_bad_float(bad_ratio)
+                timedelta() / get_bad_float(bad_ratio)
             with self.assertRaises(ValueError):
-                timedelta() * _get_bad_float(bad_ratio)
+                timedelta() * get_bad_float(bad_ratio)
 
 
 #############################################################################

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -869,13 +869,22 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
     def test_issue31293(self):
         # The interpreter shouldn't crash in case a timedelta is divided or
         # multiplied by a float with a bad as_integer_ratio() method.
-        class BadFloat(float):
-            def as_integer_ratio(self):
-                return 1 << 1000
+        def _get_bad_float(bad_ratio):
+            class BadFloat(float):
+                def as_integer_ratio(self):
+                    return bad_ratio
+            return BadFloat()
+
         with self.assertRaises(TypeError):
-            timedelta() / BadFloat()
+            timedelta() / _get_bad_float(1 << 1000)
         with self.assertRaises(TypeError):
-            timedelta() * BadFloat()
+            timedelta() * _get_bad_float(1 << 1000)
+
+        for bad_ratio in [(), (42, ), (1, 2, 3)]:
+            with self.assertRaises(ValueError):
+                timedelta() / _get_bad_float(bad_ratio)
+            with self.assertRaises(ValueError):
+                timedelta() * _get_bad_float(bad_ratio)
 
 
 #############################################################################

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -871,7 +871,7 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         # multiplied by a float with a bad as_integer_ratio() method.
         class BadFloat(float):
             def as_integer_ratio(self):
-                return (1 << 1000) - 1
+                return 1 << 1000
         self.assertRaises(TypeError, truediv, timedelta(), BadFloat())
         self.assertRaises(TypeError, mul, timedelta(), BadFloat())
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -18,7 +18,7 @@ import unittest
 
 from array import array
 
-from operator import lt, le, gt, ge, eq, ne, truediv, floordiv, mod
+from operator import lt, le, gt, ge, eq, ne, truediv, floordiv, mod, mul
 
 from test import support
 
@@ -865,6 +865,15 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         self.assertRaises(ZeroDivisionError, divmod, t, zerotd)
 
         self.assertRaises(TypeError, divmod, t, 10)
+
+    def test_issue31293(self):
+        # The interpreter shouldn't crash in case a timedelta is divided or
+        # multiplied by a float with a bad as_integer_ratio() method.
+        class BadFloat(float):
+            def as_integer_ratio(self):
+                return (1 << 1000) - 1
+        self.assertRaises(TypeError, truediv, timedelta(), BadFloat())
+        self.assertRaises(TypeError, mul, timedelta(), BadFloat())
 
 
 #############################################################################

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -18,7 +18,7 @@ import unittest
 
 from array import array
 
-from operator import lt, le, gt, ge, eq, ne, truediv, floordiv, mod, mul
+from operator import lt, le, gt, ge, eq, ne, truediv, floordiv, mod
 
 from test import support
 
@@ -872,8 +872,10 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         class BadFloat(float):
             def as_integer_ratio(self):
                 return 1 << 1000
-        self.assertRaises(TypeError, truediv, timedelta(), BadFloat())
-        self.assertRaises(TypeError, mul, timedelta(), BadFloat())
+        with self.assertRaises(TypeError):
+            timedelta() / BadFloat()
+        with self.assertRaises(TypeError):
+            timedelta() * BadFloat()
 
 
 #############################################################################

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-28-17-51-42.bpo-31293.eMYZXj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-28-17-51-42.bpo-31293.eMYZXj.rst
@@ -1,0 +1,2 @@
+Fix crashes in true division and multiplication of a timedelta object by a
+float with a bad as_integer_ratio() method. Patch by Oren Milman.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1652,6 +1652,33 @@ multiply_int_timedelta(PyObject *intobj, PyDateTime_Delta *delta)
 }
 
 static PyObject *
+get_float_as_integer_ratio(PyObject *floatobj)
+{
+    PyObject *ratio;
+
+    assert(floatobj && PyFloat_Check(floatobj));
+    ratio = _PyObject_CallMethodId(floatobj, &PyId_as_integer_ratio, NULL);
+    if (ratio == NULL) {
+        return NULL;
+    }
+    if (!PyTuple_Check(ratio)) {
+        PyErr_Format(PyExc_TypeError,
+                     "unexpected return type from as_integer_ratio(): "
+                     "expected tuple, got '%.200s'",
+                     Py_TYPE(ratio)->tp_name);
+        Py_DECREF(ratio);
+        return NULL;
+    }
+    if (PyTuple_Size(ratio) != 2) {
+        PyErr_SetString(PyExc_ValueError,
+                        "as_integer_ratio() must return a 2-tuple");
+        Py_DECREF(ratio);
+        return NULL;
+    }
+    return ratio;
+}
+
+static PyObject *
 multiply_float_timedelta(PyObject *floatobj, PyDateTime_Delta *delta)
 {
     PyObject *result = NULL;
@@ -1661,14 +1688,8 @@ multiply_float_timedelta(PyObject *floatobj, PyDateTime_Delta *delta)
     pyus_in = delta_to_microseconds(delta);
     if (pyus_in == NULL)
         return NULL;
-    ratio = _PyObject_CallMethodId(floatobj, &PyId_as_integer_ratio, NULL);
-    if (ratio == NULL)
-        goto error;
-    if (!PyTuple_Check(ratio)) {
-        PyErr_Format(PyExc_TypeError,
-                     "unexpected return type from as_integer_ratio(): "
-                     "expected tuple, got '%.200s'",
-                     Py_TYPE(ratio)->tp_name);
+    ratio = get_float_as_integer_ratio(floatobj);
+    if (ratio == NULL) {
         goto error;
     }
     temp = PyNumber_Multiply(pyus_in, PyTuple_GET_ITEM(ratio, 0));
@@ -1766,14 +1787,8 @@ truedivide_timedelta_float(PyDateTime_Delta *delta, PyObject *f)
     pyus_in = delta_to_microseconds(delta);
     if (pyus_in == NULL)
         return NULL;
-    ratio = _PyObject_CallMethodId(f, &PyId_as_integer_ratio, NULL);
-    if (ratio == NULL)
-        goto error;
-    if (!PyTuple_Check(ratio)) {
-        PyErr_Format(PyExc_TypeError,
-                     "unexpected return type from as_integer_ratio(): "
-                     "expected tuple, got '%.200s'",
-                     Py_TYPE(ratio)->tp_name);
+    ratio = get_float_as_integer_ratio(f);
+    if (ratio == NULL) {
         goto error;
     }
     temp = PyNumber_Multiply(pyus_in, PyTuple_GET_ITEM(ratio, 1));

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1665,9 +1665,10 @@ multiply_float_timedelta(PyObject *floatobj, PyDateTime_Delta *delta)
     if (ratio == NULL)
         goto error;
     if (!PyTuple_Check(ratio)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Can't multiply timedelta object by float with "
-                        "bad as_integer_ratio() method");
+        PyErr_Format(PyExc_TypeError,
+                     "unexpected return type from as_integer_ratio(): "
+                     "expected tuple, got '%.200s'",
+                     Py_TYPE(ratio)->tp_name);
         goto error;
     }
     temp = PyNumber_Multiply(pyus_in, PyTuple_GET_ITEM(ratio, 0));
@@ -1769,9 +1770,10 @@ truedivide_timedelta_float(PyDateTime_Delta *delta, PyObject *f)
     if (ratio == NULL)
         goto error;
     if (!PyTuple_Check(ratio)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "Can't divide timedelta object by float with "
-                        "bad as_integer_ratio() method");
+        PyErr_Format(PyExc_TypeError,
+                     "unexpected return type from as_integer_ratio(): "
+                     "expected tuple, got '%.200s'",
+                     Py_TYPE(ratio)->tp_name);
         goto error;
     }
     temp = PyNumber_Multiply(pyus_in, PyTuple_GET_ITEM(ratio, 1));

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1664,6 +1664,12 @@ multiply_float_timedelta(PyObject *floatobj, PyDateTime_Delta *delta)
     ratio = _PyObject_CallMethodId(floatobj, &PyId_as_integer_ratio, NULL);
     if (ratio == NULL)
         goto error;
+    if (!PyTuple_Check(ratio)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Can't multiply timedelta object by float with "
+                        "bad as_integer_ratio() method");
+        goto error;
+    }
     temp = PyNumber_Multiply(pyus_in, PyTuple_GET_ITEM(ratio, 0));
     Py_DECREF(pyus_in);
     pyus_in = NULL;
@@ -1762,6 +1768,12 @@ truedivide_timedelta_float(PyDateTime_Delta *delta, PyObject *f)
     ratio = _PyObject_CallMethodId(f, &PyId_as_integer_ratio, NULL);
     if (ratio == NULL)
         goto error;
+    if (!PyTuple_Check(ratio)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "Can't divide timedelta object by float with "
+                        "bad as_integer_ratio() method");
+        goto error;
+    }
     temp = PyNumber_Multiply(pyus_in, PyTuple_GET_ITEM(ratio, 1));
     Py_DECREF(pyus_in);
     pyus_in = NULL;


### PR DESCRIPTION
- in `_datetimemodule.c` - add checks whether as_integer_ratio() returned a tuple.
- in `datetimetester.py` - add tests to verify that the crashes are no more.

<!-- issue-number: bpo-31293 -->
https://bugs.python.org/issue31293
<!-- /issue-number -->
