### PR TITLE
bpo-30737: Update link to the Devguide

### DIFF
--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -7,7 +7,7 @@ available <https://docs.python.org/dev/download.html>`_.
 
 Documentation on authoring Python documentation, including information about
 both style and markup, is available in the "`Documenting Python
-<https://docs.python.org/devguide/documenting.html>`_" chapter of the
+<https://devguide.python.org/documenting.html>`_" chapter of the
 developers guide.
 
 

--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -109,10 +109,10 @@ see the make targets above).
 Contributing
 ============
 
-Bugs in the content should be reported to the 
+Bugs in the content should be reported to the
 `Python bug tracker <https://bugs.python.org>`_.
 
-Bugs in the toolset should be reported in the 
+Bugs in the toolset should be reported in the
 `Sphinx bug tracker <https://github.com/sphinx-doc/sphinx/issues>`_.
 
 You can also send a mail to the Python Documentation Team at docs@python.org,

--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -7,7 +7,7 @@ available <https://docs.python.org/dev/download.html>`_.
 
 Documentation on authoring Python documentation, including information about
 both style and markup, is available in the "`Documenting Python
-<https://devguide.python.org/documenting.html>`_" chapter of the
+<https://devguide.python.org/documenting/>`_" chapter of the
 developers guide.
 
 

--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -88,5 +88,5 @@ the `core-mentorship mailing list`_ is a friendly place to get answers to
 any and all questions pertaining to the process of fixing issues in Python.
 
 .. _Documentation bugs: https://bugs.python.org/issue?@filter=status&@filter=components&components=4&status=1&@columns=id,activity,title,status&@sort=-activity
-.. _Python Developer's Guide: https://docs.python.org/devguide/
+.. _Python Developer's Guide: https://devguide.python.org/
 .. _core-mentorship mailing list: https://mail.python.org/mailman/listinfo/core-mentorship/

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -167,7 +167,7 @@ several useful pieces of freely distributable software.  The source will compile
 and run out of the box on most UNIX platforms.
 
 Consult the `Getting Started section of the Python Developer's Guide
-<https://docs.python.org/devguide/setup.html>`__ for more
+<https://devguide.python.org/setup.html>`__ for more
 information on getting the source code and compiling it.
 
 
@@ -223,7 +223,7 @@ newsgroups and on the Python home page at https://www.python.org/; an RSS feed o
 news is available.
 
 You can also access the development version of Python through Git.  See
-`The Python Developer's Guide <https://docs.python.org/devguide/>`_ for details.
+`The Python Developer's Guide <https://devguide.python.org/>`_ for details.
 
 
 How do I submit bug reports and patches for Python?
@@ -239,7 +239,7 @@ report bugs to Python, you can obtain your Roundup password through Roundup's
 `password reset procedure <https://bugs.python.org/user?@template=forgotten>`_.
 
 For more information on how Python is developed, consult `the Python Developer's
-Guide <https://docs.python.org/devguide/>`_.
+Guide <https://devguide.python.org/>`_.
 
 
 Are there any published articles about Python that I can reference?

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -167,7 +167,7 @@ several useful pieces of freely distributable software.  The source will compile
 and run out of the box on most UNIX platforms.
 
 Consult the `Getting Started section of the Python Developer's Guide
-<https://devguide.python.org/setup.html>`__ for more
+<https://devguide.python.org/setup/>`__ for more
 information on getting the source code and compiling it.
 
 

--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -538,7 +538,7 @@ the Python interface.  Often this isn't because they're difficult to
 implement, but because no one has needed them yet.  Also, Python
 doesn't yet support the menu library associated with ncurses.
 Patches adding support for these would be welcome; see
-`the Python Developer's Guide <https://docs.python.org/devguide/>`_ to
+`the Python Developer's Guide <https://devguide.python.org/>`_ to
 learn more about submitting patches to Python.
 
 * `Writing Programs with NCURSES <http://invisible-island.net/ncurses/ncurses-intro.html>`_:

--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -67,7 +67,7 @@ Building Python
 If you want to compile CPython yourself, first thing you should do is get the
 `source <https://www.python.org/downloads/source/>`_. You can download either the
 latest release's source or just grab a fresh `clone
-<https://devguide.python.org/setup.html#getting-the-source-code>`_.  (If you want
+<https://devguide.python.org/setup/#getting-the-source-code>`_.  (If you want
 to contribute patches, you will need a clone.)
 
 The build process consists in the usual ::

--- a/Doc/using/unix.rst
+++ b/Doc/using/unix.rst
@@ -67,7 +67,7 @@ Building Python
 If you want to compile CPython yourself, first thing you should do is get the
 `source <https://www.python.org/downloads/source/>`_. You can download either the
 latest release's source or just grab a fresh `clone
-<https://docs.python.org/devguide/setup.html#getting-the-source-code>`_.  (If you want
+<https://devguide.python.org/setup.html#getting-the-source-code>`_.  (If you want
 to contribute patches, you will need a clone.)
 
 The build process consists in the usual ::

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -896,7 +896,7 @@ Compiling Python on Windows
 If you want to compile CPython yourself, first thing you should do is get the
 `source <https://www.python.org/downloads/source/>`_. You can download either the
 latest release's source or just grab a fresh `checkout
-<https://devguide.python.org/setup.html#getting-the-source-code>`_.
+<https://devguide.python.org/setup/#getting-the-source-code>`_.
 
 The source tree contains a build solution and project files for Microsoft
 Visual Studio 2015, which is the compiler used to build the official Python

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -896,7 +896,7 @@ Compiling Python on Windows
 If you want to compile CPython yourself, first thing you should do is get the
 `source <https://www.python.org/downloads/source/>`_. You can download either the
 latest release's source or just grab a fresh `checkout
-<https://docs.python.org/devguide/setup.html#getting-the-source-code>`_.
+<https://devguide.python.org/setup.html#getting-the-source-code>`_.
 
 The source tree contains a build solution and project files for Microsoft
 Visual Studio 2015, which is the compiler used to build the official Python

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -232,7 +232,7 @@ have adopted Sphinx as their documentation tool.
 
 .. seealso::
 
-   `Documenting Python <https://docs.python.org/devguide/documenting.html>`__
+   `Documenting Python <https://devguide.python.org/documenting.html>`__
        Describes how to write for Python's documentation.
 
    `Sphinx <http://sphinx-doc.org/>`__

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -232,7 +232,7 @@ have adopted Sphinx as their documentation tool.
 
 .. seealso::
 
-   `Documenting Python <https://devguide.python.org/documenting.html>`__
+   `Documenting Python <https://devguide.python.org/documenting/>`__
        Describes how to write for Python's documentation.
 
    `Sphinx <http://sphinx-doc.org/>`__

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -1960,7 +1960,7 @@ Other Improvements
   ``.py`` extension.  (Contributed by Paul Moore in :issue:`18569`.)
 
 * A new ``make`` target `coverage-report
-  <https://devguide.python.org/coverage.html#measuring-coverage-of-c-code-with-gcov-and-lcov>`_
+  <https://devguide.python.org/coverage/#measuring-coverage-of-c-code-with-gcov-and-lcov>`_
   will build python, run the test suite, and generate an HTML coverage report
   for the C codebase using ``gcov`` and `lcov
   <http://ltp.sourceforge.net/coverage/lcov.php>`_.

--- a/Doc/whatsnew/3.4.rst
+++ b/Doc/whatsnew/3.4.rst
@@ -1960,7 +1960,7 @@ Other Improvements
   ``.py`` extension.  (Contributed by Paul Moore in :issue:`18569`.)
 
 * A new ``make`` target `coverage-report
-  <https://docs.python.org/devguide/coverage.html#measuring-coverage-of-c-code-with-gcov-and-lcov>`_
+  <https://devguide.python.org/coverage.html#measuring-coverage-of-c-code-with-gcov-and-lcov>`_
   will build python, run the test suite, and generate an HTML coverage report
   for the C codebase using ``gcov`` and `lcov
   <http://ltp.sourceforge.net/coverage/lcov.php>`_.
@@ -2176,7 +2176,7 @@ The following obsolete and previously deprecated APIs and features have been
 removed:
 
 * The unmaintained ``Misc/TextMate`` and ``Misc/vim`` directories have been
-  removed (see the `devguide <https://docs.python.org/devguide>`_
+  removed (see the `devguide <https://devguide.python.org>`_
   for suggestions on what to use instead).
 
 * The ``SO`` makefile macro is removed (it was replaced by the

--- a/Grammar/Grammar
+++ b/Grammar/Grammar
@@ -1,7 +1,7 @@
 # Grammar for Python
 
 # NOTE WELL: You should also follow all the steps listed at
-# https://docs.python.org/devguide/grammar.html
+# https://devguide.python.org/grammar.html
 
 # Start symbols for the grammar:
 #       single_input is a single interactive statement;

--- a/Grammar/Grammar
+++ b/Grammar/Grammar
@@ -1,7 +1,7 @@
 # Grammar for Python
 
 # NOTE WELL: You should also follow all the steps listed at
-# https://devguide.python.org/grammar.html
+# https://devguide.python.org/grammar/
 
 # Start symbols for the grammar:
 #       single_input is a single interactive statement;

--- a/Mac/README
+++ b/Mac/README
@@ -98,7 +98,7 @@ In general, universal builds depend on specific features provided by the
 Apple-supplied compilers and other build tools included in Apple's Xcode
 development tools.  You should install Xcode and the command line tools
 component appropriate for the OS X release you are running on.  See the
-Python Developer's Guide (http://devguide.python.org/setup.html)
+Python Developer's Guide (https://devguide.python.org/setup/)
 for more information.
 
 2.1 Flavors of universal binaries
@@ -355,4 +355,4 @@ Resources
 
   *  http://www.python.org/community/sigs/current/pythonmac-sig/
 
-  *  http://devguide.python.org/
+  *  https://devguide.python.org/

--- a/Mac/README
+++ b/Mac/README
@@ -98,7 +98,7 @@ In general, universal builds depend on specific features provided by the
 Apple-supplied compilers and other build tools included in Apple's Xcode
 development tools.  You should install Xcode and the command line tools
 component appropriate for the OS X release you are running on.  See the
-Python Developer's Guide (http://docs.python.org/devguide/setup.html)
+Python Developer's Guide (http://devguide.python.org/setup.html)
 for more information.
 
 2.1 Flavors of universal binaries
@@ -355,4 +355,4 @@ Resources
 
   *  http://www.python.org/community/sigs/current/pythonmac-sig/
 
-  *  http://docs.python.org/devguide/
+  *  http://devguide.python.org/

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -627,6 +627,7 @@ Thomas Herve
 Bernhard Herzog
 Magnus L. Hetland
 Raymond Hettinger
+Lisa Hewus Fresh
 Kevan Heydon
 Wouter van Heyst
 Kelsey Hightower

--- a/Misc/Porting
+++ b/Misc/Porting
@@ -1,1 +1,1 @@
-This document is moved to https://docs.python.org/devguide/faq.html#how-do-i-port-python-to-a-new-platform
+This document is moved to https://devguide.python.org/porting/

--- a/Misc/python.man
+++ b/Misc/python.man
@@ -438,7 +438,7 @@ Main website:  https://www.python.org/
 .br
 Documentation:  https://docs.python.org/
 .br
-Developer resources:  https://docs.python.org/devguide/
+Developer resources:  https://devguide.python.org/
 .br
 Downloads:  https://www.python.org/downloads/
 .br

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ General Information
 - Source code: https://github.com/python/cpython
 - Issue tracker: https://bugs.python.org
 - Documentation: https://docs.python.org
-- Developer's Guide: https://docs.python.org/devguide/
+- Developer's Guide: https://devguide.python.org/
 
 Contributing to CPython
 -----------------------
@@ -36,7 +36,7 @@ Contributing to CPython
 For more complete instructions on contributing to CPython development,
 see the `Developer Guide`_.
 
-.. _Developer Guide: https://docs.python.org/devguide/
+.. _Developer Guide: https://devguide.python.org/
 
 Using Python
 ------------


### PR DESCRIPTION
The Devguide has a new url so all the old links are updated.

<!-- issue-number: bpo-30737 -->
https://bugs.python.org/issue30737
<!-- /issue-number -->
