### PR TITLE
bpo-31294: Fix ZeroMQSocketListener and ZeroMQSocketHandler examples

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1258,8 +1258,8 @@ socket is created separately and passed to the handler (as its 'queue')::
 
     class ZeroMQSocketHandler(QueueHandler):
         def enqueue(self, record):
-            data = json.dumps(record.__dict__)
-            self.queue.send_string(data)
+            self.queue.send_json(record.__dict__)
+
 
     handler = ZeroMQSocketHandler(sock)
 
@@ -1275,8 +1275,7 @@ data needed by the handler to create the socket::
             super().__init__(socket)
 
         def enqueue(self, record):
-            data = json.dumps(record.__dict__)
-            self.queue.send_string(data)
+            self.queue.send_json(record.__dict__)
 
         def close(self):
             self.queue.close()
@@ -1297,8 +1296,8 @@ of queues, for example a ZeroMQ 'subscribe' socket. Here's an example::
             super().__init__(socket, *handlers, **kwargs)
 
         def dequeue(self):
-            msg = self.queue.recv()
-            return logging.makeLogRecord(json.loads(msg))
+            msg = self.queue.recv_json()
+            return logging.makeLogRecord(msg)
 
 
 .. seealso::

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -1259,7 +1259,7 @@ socket is created separately and passed to the handler (as its 'queue')::
     class ZeroMQSocketHandler(QueueHandler):
         def enqueue(self, record):
             data = json.dumps(record.__dict__)
-            self.queue.send(data)
+            self.queue.send_string(data)
 
     handler = ZeroMQSocketHandler(sock)
 
@@ -1272,11 +1272,11 @@ data needed by the handler to create the socket::
             self.ctx = ctx or zmq.Context()
             socket = zmq.Socket(self.ctx, socktype)
             socket.bind(uri)
-            QueueHandler.__init__(self, socket)
+            super().__init__(socket)
 
         def enqueue(self, record):
             data = json.dumps(record.__dict__)
-            self.queue.send(data)
+            self.queue.send_string(data)
 
         def close(self):
             self.queue.close()
@@ -1292,8 +1292,9 @@ of queues, for example a ZeroMQ 'subscribe' socket. Here's an example::
         def __init__(self, uri, *handlers, **kwargs):
             self.ctx = kwargs.get('ctx') or zmq.Context()
             socket = zmq.Socket(self.ctx, zmq.SUB)
-            socket.setsockopt(zmq.SUBSCRIBE, '')  # subscribe to everything
+            socket.setsockopt_string(zmq.SUBSCRIBE, '')  # subscribe to everything
             socket.connect(uri)
+            super().__init__(socket, *handlers, **kwargs)
 
         def dequeue(self):
             msg = self.queue.recv()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1559,6 +1559,7 @@ Martin Teichmann
 Gustavo Temple
 Mikhail Terekhov
 Victor Terrón
+Pablo Galindo
 Richard M. Tew
 Tobias Thelen
 Christian Theune

--- a/Misc/NEWS.d/next/Documentation/2017-09-07-20-49-09.bpo-31294.WgI18w.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-09-07-20-49-09.bpo-31294.WgI18w.rst
@@ -1,0 +1,2 @@
+Fix incomplete code snippet in the ZeroMQSocketListener and
+ZeroMQSocketHandler examples and adapt them to Python 3.


### PR DESCRIPTION
This PR fixes two documentation issues regarding the `ZeroMQSocketListener` and `ZeroMQSocketHandler` examples in [the Logging Cookbook](https://docs.python.org/3/howto/logging-cookbook.html#subclassing-queuehandler-a-zeromq-example):

- The first issue is that in the `__ init__` method for the `ZeroMQSocketListener` the base class `__ init__` is never called and therefore the internal variables are not correctly initialized. This leads to an empty `handlers` attribute and a undefined `queue` attribute.

- The second issue is that `zmq.Socket.send` and `zmq.Socket.setsockopt` only admits bytecode variables and therefore it fails in Python3 when using plain strings. The fix is to use `zmq.Socket.send_string`and `mq.Socket.setsockopt_string` instead.

<!-- issue-number: bpo-31294 -->
https://bugs.python.org/issue31294
<!-- /issue-number -->
