### PR TITLE
bpo-31299: Implementation of ignore_modules argument for traceback functions

### DIFF
--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -36,7 +36,7 @@ The module defines the following functions:
        Added negative *limit* support.
 
 
-.. function:: print_exception(etype, value, tb, limit=None, file=None, chain=True)
+.. function:: print_exception(etype, value, tb, limit=None, file=None, ignore_modules=(), chain=True)
 
    Print exception information and stack trace entries from traceback object
    *tb* to *file*. This differs from :func:`print_tb` in the following
@@ -53,23 +53,27 @@ The module defines the following functions:
    If *chain* is true (the default), then chained exceptions (the
    :attr:`__cause__` or :attr:`__context__` attributes of the exception) will be
    printed as well, like the interpreter itself does when printing an unhandled
-   exception.
+   exception. *ignore_modules* should be an iterable containing absolute
+   module names. Stack trace entries from modules listed in *ignore_modules* will
+   not be displayed.
 
    .. versionchanged:: 3.5
       The *etype* argument is ignored and inferred from the type of *value*.
+   .. versionadded:: 3.7
+       *ignore_modules* argument.
 
 
-.. function:: print_exc(limit=None, file=None, chain=True)
+.. function:: print_exc(limit=None, file=None, ignore_modules=(), chain=True)
 
    This is a shorthand for ``print_exception(*sys.exc_info(), limit, file,
-   chain)``.
+   ignore_modules, chain)``.
 
 
-.. function:: print_last(limit=None, file=None, chain=True)
+.. function:: print_last(limit=None, file=None, ignore_modules=(), chain=True)
 
    This is a shorthand for ``print_exception(sys.last_type, sys.last_value,
-   sys.last_traceback, limit, file, chain)``.  In general it will work only
-   after an exception has reached an interactive prompt (see
+   sys.last_traceback, limit, file, ignore_modules, chain)``.  In general it will
+   work only after an exception has reached an interactive prompt (see
    :data:`sys.last_type`).
 
 
@@ -126,7 +130,7 @@ The module defines the following functions:
    which exception occurred is the always last string in the list.
 
 
-.. function:: format_exception(etype, value, tb, limit=None, chain=True)
+.. function:: format_exception(etype, value, tb, limit=None, ignore_modules=(), chain=True)
 
    Format a stack trace and the exception information.  The arguments  have the
    same meaning as the corresponding arguments to :func:`print_exception`.  The
@@ -138,7 +142,7 @@ The module defines the following functions:
       The *etype* argument is ignored and inferred from the type of *value*.
 
 
-.. function:: format_exc(limit=None, chain=True)
+.. function:: format_exc(limit=None, ignore_modules=(), chain=True)
 
    This is like ``print_exc(limit)`` but returns a string instead of printing to
    a file.
@@ -239,12 +243,14 @@ capture data for later printing in a lightweight fashion.
 
       Note that when locals are captured, they are also shown in the traceback.
 
-   .. method:: format(*, chain=True)
+   .. method:: format(*, ignore_modules=(), chain=True)
 
       Format the exception.
 
-      If *chain* is not ``True``, ``__cause__`` and ``__context__`` will not
-      be formatted.
+      If *chain* is not ``True``, ``__cause__`` and ``__context__`` will not be
+      formatted. *ignore_modules* should be an iterable containing absolute
+      module names. Stack trace entries from modules listed in *ignore_modules*
+      will not be returned.
 
       The return value is a generator of strings, each ending in a newline and
       some containing internal newlines. :func:`~traceback.print_exception`
@@ -252,6 +258,9 @@ capture data for later printing in a lightweight fashion.
 
       The message indicating which exception occurred is always the last
       string in the output.
+
+      .. versionadded:: 3.7
+          *ignore_modules* keyword argument.
 
    .. method::  format_exception_only()
 

--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -8,7 +8,7 @@ import unittest
 import re
 from test import support
 from test.support import TESTFN, Error, captured_output, unlink, cpython_only
-from test.support.script_helper import assert_python_ok
+from test.support.script_helper import assert_python_ok, make_script
 import textwrap
 
 import traceback
@@ -1045,6 +1045,73 @@ class TestTracebackException(unittest.TestCase):
         # see issue #24695
         exc = traceback.TracebackException(Exception, Exception("haven"), None)
         self.assertEqual(list(exc.format()), ["Exception: haven\n"])
+
+
+class IgnoredModulesTest(unittest.TestCase):
+
+    def test_namespace_package(self):
+        with support.temp_dir() as pkg_container, \
+             support.temp_dir(f'{pkg_container}/pkg') as pkg, \
+             support.temp_dir(f'{pkg}/subpkg') as subpkg, \
+             support.change_cwd(path=pkg_container):
+            module_name = make_script(subpkg, 'module', '1/0')
+            try:
+                from pkg.subpkg import module
+            except Exception as e:
+                tb_exc = traceback.TracebackException.from_exception(e)
+
+            for mod in ('pkg', 'pkg.subpkg', 'pkg.subpkg.module'):
+                with self.subTest(ignored=mod):
+                    header, *stack, error = tb_exc.format(ignore_modules=(mod,))
+                    self.assertEqual(len(stack), 1)
+                    self.assertNotIn(module_name, stack[0])
+                    self.assertIn('ZeroDivisionError', error)
+
+            # The first part of the name isn't the top-level package
+            for mod in ('pk', 'subpkg.module'):
+                with self.subTest(ignored=mod):
+                    header, *stack, error = tb_exc.format(ignore_modules=(mod,))
+                    self.assertEqual(len(stack), 2)
+                    self.assertIn(__file__, stack[0])
+                    self.assertIn(module_name, stack[1])
+                    self.assertIn('ZeroDivisionError', error)
+
+    def test_single_file_module(self):
+        with support.temp_dir() as script_dir:
+            import runpy
+            script_name = make_script(script_dir, 'script', '1/0')
+            try:
+                runpy.run_path(script_name)
+            except Exception as e:
+                tb_exc = traceback.TracebackException.from_exception(e)
+
+            header, *stack, error = tb_exc.format(ignore_modules=('runpy',))
+            self.assertEqual(len(stack), 2)
+            self.assertIn(__file__, stack[0])
+            self.assertIn(script_name, stack[1])
+            self.assertIn('ZeroDivisionError', error)
+
+    def test_frozen_module(self):
+        with support.temp_dir() as script_dir, \
+             support.change_cwd(path=script_dir):
+            module_name = make_script(script_dir, 'module', '1/0')
+            import _frozen_importlib
+            try:
+                _frozen_importlib.__import__('module')
+            except Exception as e:
+                tb_exc = traceback.TracebackException.from_exception(e)
+
+            # Ignoring these frozen modules and their parent package must
+            # produce the same traceback
+            ignored = [('_frozen_importlib', '_frozen_importlib_external'),
+                       ('importlib',)]
+            for mod in ignored:
+                with self.subTest(ignored=mod):
+                    header, *stack, error = tb_exc.format(ignore_modules=mod)
+                    self.assertEqual(len(stack), 2)
+                    self.assertIn(__file__, stack[0])
+                    self.assertIn(module_name, stack[1])
+                    self.assertIn('ZeroDivisionError', error)
 
 
 class MiscTest(unittest.TestCase):

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -379,6 +379,10 @@ Extension Modules
 Library
 -------
 
+- bpo-31299: ``traceback.TracebackException.format`` and :mod:`traceback`
+  functions that use it now accept the ``ignore_modules`` argument: a list of
+  modules, stack trace entries from which should be hidden.
+
 - bpo-30119: ftplib.FTP.putline() now throws ValueError on commands that contains
   CR or LF. Patch by Dong-hee Na.
 

--- a/Misc/NEWS
+++ b/Misc/NEWS
@@ -379,10 +379,6 @@ Extension Modules
 Library
 -------
 
-- bpo-31299: ``traceback.TracebackException.format`` and :mod:`traceback`
-  functions that use it now accept the ``ignore_modules`` argument: a list of
-  modules, stack trace entries from which should be hidden.
-
 - bpo-30119: ftplib.FTP.putline() now throws ValueError on commands that contains
   CR or LF. Patch by Dong-hee Na.
 

--- a/Misc/NEWS.d/next/Library/2017-08-29-10-52-12.bpo-31299.-a7atn.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-29-10-52-12.bpo-31299.-a7atn.rst
@@ -1,0 +1,3 @@
+``traceback.TracebackException.format`` and :mod:`traceback` functions that
+use it now accept the ``ignore_modules`` argument: a list of modules, stack
+trace entries from which should be hidden.


### PR DESCRIPTION


<!-- issue-number: bpo-31299 -->
https://bugs.python.org/issue31299
<!-- /issue-number -->
