### PR TITLE
bpo-29400: sys.settracestate.

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -31,6 +31,7 @@ PyAPI_FUNC(PyObject *) PyEval_CallMethod(PyObject *obj,
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(void) PyEval_SetProfile(Py_tracefunc, PyObject *);
 PyAPI_FUNC(void) PyEval_SetTrace(Py_tracefunc, PyObject *);
+PyAPI_FUNC(void) _PyEval_SetTraceEx(Py_tracefunc, PyObject *, int);
 PyAPI_FUNC(void) _PyEval_SetCoroutineWrapper(PyObject *);
 PyAPI_FUNC(PyObject *) _PyEval_GetCoroutineWrapper(void);
 PyAPI_FUNC(void) _PyEval_SetAsyncGenFirstiter(PyObject *);

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -101,6 +101,7 @@ typedef int (*Py_tracefunc)(PyObject *, struct _frame *, int, PyObject *);
 #define PyTrace_C_CALL 4
 #define PyTrace_C_EXCEPTION 5
 #define PyTrace_C_RETURN 6
+#define PyTrace_INSTRUCTION 7
 #endif
 
 #ifdef Py_LIMITED_API
@@ -124,6 +125,7 @@ typedef struct _ts {
        the trace/profile. */
     int tracing;
     int use_tracing;
+    int trace_instructions; /* whether to trace every instruction. */
 
     Py_tracefunc c_profilefunc;
     Py_tracefunc c_tracefunc;

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -793,6 +793,7 @@ Jan Kim
 Taek Joo Kim
 Sam Kimbrel
 Tomohiko Kinebuchi
+George King
 James King
 W. Trevor King
 Paul Kippes

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4587,6 +4587,10 @@ maybe_call_line_trace(Py_tracefunc func, PyObject *obj,
         frame->f_lineno = line;
         result = call_trace(func, obj, tstate, frame, PyTrace_LINE, Py_None);
     }
+    else if (tstate->trace_instructions) {
+        result = call_trace(func, obj, tstate, frame, PyTrace_INSTRUCTION,
+                            Py_None);
+    }
     *instr_prev = frame->f_lasti;
     return result;
 }
@@ -4609,22 +4613,31 @@ PyEval_SetProfile(Py_tracefunc func, PyObject *arg)
 }
 
 void
-PyEval_SetTrace(Py_tracefunc func, PyObject *arg)
+_PyEval_SetTraceEx(Py_tracefunc func, PyObject *traceobj,
+                   int trace_instructions)
 {
     PyThreadState *tstate = PyThreadState_GET();
-    PyObject *temp = tstate->c_traceobj;
+    PyObject *old_traceobj = tstate->c_traceobj;
     _Py_TracingPossible += (func != NULL) - (tstate->c_tracefunc != NULL);
-    Py_XINCREF(arg);
+    Py_XINCREF(traceobj);
     tstate->c_tracefunc = NULL;
     tstate->c_traceobj = NULL;
-    /* Must make sure that profiling is not ignored if 'temp' is freed */
+    /* Make sure that profiling is not ignored if 'old_traceobj' is freed */
     tstate->use_tracing = tstate->c_profilefunc != NULL;
-    Py_XDECREF(temp);
+    Py_XDECREF(old_traceobj);
     tstate->c_tracefunc = func;
-    tstate->c_traceobj = arg;
+    tstate->c_traceobj = traceobj;
+    tstate->trace_instructions = trace_instructions;
     /* Flag that tracing or profiling is turned on */
     tstate->use_tracing = ((func != NULL)
                            || (tstate->c_profilefunc != NULL));
+}
+
+void
+PyEval_SetTrace(Py_tracefunc func, PyObject *arg)
+{
+    /* trace_instructions=False. */
+    _PyEval_SetTraceEx(func, arg, 0);
 }
 
 void

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -252,6 +252,7 @@ new_threadstate(PyInterpreterState *interp, int init)
         tstate->recursion_critical = 0;
         tstate->tracing = 0;
         tstate->use_tracing = 0;
+        tstate->trace_instructions = 0;
         tstate->gilstate_counter = 0;
         tstate->async_exc = NULL;
 #ifdef WITH_THREAD
@@ -461,6 +462,7 @@ PyThreadState_Clear(PyThreadState *tstate)
 
     tstate->c_profilefunc = NULL;
     tstate->c_tracefunc = NULL;
+
     Py_CLEAR(tstate->c_profileobj);
     Py_CLEAR(tstate->c_traceobj);
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -351,18 +351,20 @@ same value.");
  * Cached interned string objects used for calling the profile and
  * trace functions.  Initialized by trace_init().
  */
-static PyObject *whatstrings[7] = {NULL, NULL, NULL, NULL, NULL, NULL, NULL};
+static PyObject *whatstrings[8] = {
+    NULL, NULL, NULL, NULL, NULL, NULL, NULL,NULL};
 
 static int
 trace_init(void)
 {
-    static const char * const whatnames[7] = {
+    static const char * const whatnames[8] = {
         "call", "exception", "line", "return",
-        "c_call", "c_exception", "c_return"
+        "c_call", "c_exception", "c_return",
+        "instruction"
     };
     PyObject *name;
     int i;
-    for (i = 0; i < 7; ++i) {
+    for (i = 0; i < 8; ++i) {
         if (whatstrings[i] == NULL) {
             name = PyUnicode_InternFromString(whatnames[i]);
             if (name == NULL)
@@ -432,7 +434,7 @@ trace_trampoline(PyObject *self, PyFrameObject *frame,
         return 0;
     result = call_trampoline(callback, frame, what, arg);
     if (result == NULL) {
-        PyEval_SetTrace(NULL, NULL);
+        _PyEval_SetTraceEx(NULL, NULL, 0);
         Py_CLEAR(frame->f_trace);
         return -1;
     }
@@ -465,15 +467,48 @@ function call.  See the debugger chapter in the library manual."
 );
 
 static PyObject *
+sys_settracestate(PyObject *self, PyObject *args, PyObject *kwargs)
+{
+    PyObject *trace_func = NULL;
+    int trace_instructions;
+    static char *keywords[] = {"trace_func", "trace_instructions", 0};
+    if (trace_init() == -1)
+        return NULL;
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|$p:settracestate",
+                                     keywords, &trace_func,
+                                     &trace_instructions))
+        return NULL;
+
+    if (trace_func == Py_None)
+        _PyEval_SetTraceEx(NULL, NULL, 0);
+    else
+        _PyEval_SetTraceEx(trace_trampoline, trace_func, trace_instructions);
+    Py_RETURN_NONE;
+}
+
+PyDoc_STRVAR(settracestate_doc,
+"settracestate(function)\n\
+\n\
+Set the global debug tracing function, and enable instruction tracing.  \n\
+TODO: refer to the detailed documentation (also fix settrace doc above)."
+);
+
+static PyObject *
 sys_gettrace(PyObject *self, PyObject *args)
 {
     PyThreadState *tstate = PyThreadState_GET();
-    PyObject *temp = tstate->c_traceobj;
+    PyObject *trace_func = tstate->c_traceobj;
 
-    if (temp == NULL)
-        temp = Py_None;
-    Py_INCREF(temp);
-    return temp;
+    if (tstate->trace_instructions) {
+        PyErr_Format(PyExc_ValueError,
+            "trace_instructions has been set to True; "
+            "use sys.getttracestate to capture the complete state");
+        return NULL;
+    }
+    if (trace_func == NULL)
+        trace_func = Py_None;
+    Py_INCREF(trace_func);
+    return trace_func;
 }
 
 PyDoc_STRVAR(gettrace_doc,
@@ -481,6 +516,30 @@ PyDoc_STRVAR(gettrace_doc,
 \n\
 Return the global debug tracing function set with sys.settrace.\n\
 See the debugger chapter in the library manual."
+);
+
+static PyObject *
+sys_gettracestate(PyObject *self, PyObject *args)
+{
+    PyThreadState *tstate = PyThreadState_GET();
+    PyObject *trace_func = tstate->c_traceobj;
+    PyObject *trace_instructions = PyBool_FromLong(tstate->trace_instructions);
+
+    if (trace_func == NULL)
+        trace_func = Py_None;
+    Py_INCREF(trace_func);
+
+    return Py_BuildValue("{s:O,s:O}", "trace_func", trace_func,
+        "trace_instructions", trace_instructions);
+}
+
+PyDoc_STRVAR(gettracestate_doc,
+"gettracestate()\n\
+\n\
+Returns a dictionary containing the complete tracing state. \n\
+Currently this consists of \"tracefunc\", the global tracing function, \n\
+and \"trace_instructions\", a boolean indicating whether instruction \n\
+tracing is enabled."
 );
 
 static PyObject *
@@ -1435,7 +1494,10 @@ static PyMethodDef sys_methods[] = {
     {"setrecursionlimit", sys_setrecursionlimit, METH_VARARGS,
      setrecursionlimit_doc},
     {"settrace",        sys_settrace, METH_O, settrace_doc},
+    {"settracestate",    (PyCFunction)sys_settracestate, METH_VARARGS | METH_KEYWORDS,
+     settracestate_doc},
     {"gettrace",        sys_gettrace, METH_NOARGS, gettrace_doc},
+    {"gettracestate",    sys_gettracestate, METH_NOARGS, gettracestate_doc},
     {"call_tracing", sys_call_tracing, METH_VARARGS, call_tracing_doc},
     {"_debugmallocstats", sys_debugmallocstats, METH_NOARGS,
      debugmallocstats_doc},


### PR DESCRIPTION
This patch adds a new pair of functions to sys: `settracestate` and `gettracestate`. The old `settrace`/`gettrace` pair are now equivalent to calling `settracestate` with `trace_instructions=False`; when set to `True`, the tracer callback is called for every bytecode instruction. This is useful for observing and instrumenting bytecode, e.g. for intraline code coverage. `gettracestate` returns a dictionary that completely represents the tracing state. The old `gettrace` now raises an exception if `trace_instructions=True`, because it is no longer capturing the complete state. This guards against subtle failure for existing code that uses the `old = gettrace(); ... ; settrace(old)` idiom.

<!-- issue-number: bpo-29400 -->
https://bugs.python.org/issue29400
<!-- /issue-number -->
