### PR TITLE
bpo-27923: Minor API improvements for binary sequences (PEP 467)

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -2303,8 +2303,11 @@ data and are closely related to string objects in a variety of other ways.
    other ways:
 
    * A zero-filled bytes object of a specified length: ``bytes(10)``
+     (deprecated in version 3.7)
    * From an iterable of integers: ``bytes(range(20))``
    * Copying existing binary data via the buffer protocol:  ``bytes(obj)``
+   * Using the :meth:`~bytes.zeros` constructor: ``bytes.zeros(10)``
+   * Using the :meth:`~bytes.byte` single-byte constructor: ``bytes.byte(65)``
 
    Also see the :ref:`bytes <func-bytes>` built-in.
 
@@ -2375,8 +2378,11 @@ objects.
 
    * Creating an empty instance: ``bytearray()``
    * Creating a zero-filled instance with a given length: ``bytearray(10)``
+     (deprecated in version 3.7)
    * From an iterable of integers: ``bytearray(range(20))``
    * Copying existing binary data via the buffer protocol:  ``bytearray(b'Hi!')``
+   * Using the :meth:`~bytearray.zeros` constructor: ``bytearray.zeros(10)``
+   * Using the :meth:`~bytearray.byte` single-byte constructor: ``bytearray.byte(65)``
 
    As bytearray objects are mutable, they support the
    :ref:`mutable <typesseq-mutable>` sequence operations in addition to the
@@ -2545,6 +2551,14 @@ arbitrary binary data.
 
    .. versionchanged:: 3.3
       Also accept an integer in the range 0 to 255 as the subsequence.
+
+
+.. classmethod:: bytes.iterbytes()
+                 bytearray.iterbytes()
+
+   Return an iterator that produce :class:`bytes` objects of length 1.
+
+   .. versionadded:: 3.7
 
 
 .. method:: bytes.join(iterable)
@@ -3680,6 +3694,12 @@ copying.
 
       .. versionchanged:: 3.5
          The source format is no longer restricted when casting to a byte view.
+
+   .. classmethod:: memoryview.iterbytes()
+
+      Return an iterator that produce :class:`bytes` objects of length 1.
+
+      .. versionadded:: 3.7
 
    There are also several readonly attributes available:
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -108,7 +108,7 @@ locale remains active when the core interpreter is initialized.
        PEP written and implemented by Nick Coghlan.
 
 
-.. _whatsnew37-pep467
+.. _whatsnew37-pep467:
 
 PEP 467: Minor API improvements for binary sequences
 ----------------------------------------------------

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -108,6 +108,23 @@ locale remains active when the core interpreter is initialized.
        PEP written and implemented by Nick Coghlan.
 
 
+.. _whatsnew37-pep467
+
+PEP 467: Minor API improvements for binary sequences
+----------------------------------------------------
+
+:pep:`467` adds four small adjustments to the APIs of the :class:`bytes`, :class:`bytearray` and :class:`memoryview` types to make it easier to operate entirely in the binary domain:
+
+* Deprecate passing single integer values to :class:`bytes` and :class:`bytearray`
+* Add :meth:`bytes.zeros` and :meth:`bytearray.zeros` alternative constructors
+* Add :meth:`bytes.byte` and :meth:`bytearray.byte` alternative constructors
+* Add :meth:`bytes.iterbytes`, :meth:`bytearray.iterbytes` and :meth:`memoryview.iterbytes` alternative iterators
+
+.. seealso::
+
+    :pep:`467` -- Minor API improvements for binary sequences
+
+
 Other Language Changes
 ======================
 

--- a/Include/bytes_methods.h
+++ b/Include/bytes_methods.h
@@ -41,6 +41,7 @@ extern const char _Py_isdigit__doc__[];
 extern const char _Py_islower__doc__[];
 extern const char _Py_isupper__doc__[];
 extern const char _Py_istitle__doc__[];
+extern const char _Py_iterbytes__doc__[];
 extern const char _Py_lower__doc__[];
 extern const char _Py_upper__doc__[];
 extern const char _Py_title__doc__[];

--- a/Lib/sre_compile.py
+++ b/Lib/sre_compile.py
@@ -262,7 +262,7 @@ def _optimize_charset(charset, iscased=None, fixup=None, fixes=None):
     # internal: optimize character set
     out = []
     tail = []
-    charmap = bytearray(256)
+    charmap = bytearray.zeros(256)
     hascased = False
     for op, av in charset:
         while True:
@@ -373,7 +373,7 @@ def _optimize_charset(charset, iscased=None, fixup=None, fixes=None):
 
     charmap = bytes(charmap) # should be hashable
     comps = {}
-    mapping = bytearray(256)
+    mapping = bytearray.zeros(256)
     block = 0
     data = bytearray()
     for i in range(0, 65536, 256):

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -659,7 +659,7 @@ plain ol' Python and is guaranteed to be available.
 
     >>> import builtins
     >>> tests = doctest.DocTestFinder().find(builtins)
-    >>> 790 < len(tests) < 810 # approximate number of objects with docstrings
+    >>> 800 < len(tests) < 850 # approximate number of objects with docstrings
     True
     >>> real_tests = [t for t in tests if len(t.examples) > 0]
     >>> len(real_tests) # objects that actually have doctests

--- a/Lib/test/test_memoryview.py
+++ b/Lib/test/test_memoryview.py
@@ -383,6 +383,15 @@ class AbstractMemoryTests:
         self.assertEqual(c.format, "H")
         self.assertEqual(d.format, "H")
 
+    def test_iterbytes(self):
+        for tp in self._types:
+            b = tp(self._source)
+            m = self._view(b)
+            it = m.iterbytes()
+            for byte in m:
+                self.assertEqual(next(it), bytes([byte]))
+            self.assertRaises(StopIteration, next, it)
+
 
 # Variations on source objects for the buffer: bytes-like objects, then arrays
 # with itemsize > 1.

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1759,6 +1759,7 @@ Masazumi Yoshikawa
 Arnaud Ysmal
 Bernard Yue
 Moshe Zadka
+Elias Zamaria
 Milan Zamazal
 Artur Zaprzala
 Mike Zarnstorff

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-29-11-51-08.bpo-27923.y1IldO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-29-11-51-08.bpo-27923.y1IldO.rst
@@ -1,0 +1,1 @@
+Minor API improvements for binary sequences (PEP 467)

--- a/Objects/bytes_methods.c
+++ b/Objects/bytes_methods.c
@@ -239,6 +239,10 @@ _Py_bytes_istitle(const char *cptr, Py_ssize_t len)
 }
 
 
+PyDoc_STRVAR_shared(_Py_iterbytes__doc__,
+"B.iterbytes() -> iterator that produces length 1 bytes objects instead of integers");
+
+
 PyDoc_STRVAR_shared(_Py_lower__doc__,
 "B.lower() -> copy of B\n\
 \n\

--- a/Objects/clinic/bytearrayobject.c.h
+++ b/Objects/clinic/bytearrayobject.c.h
@@ -648,6 +648,67 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(bytearray_zeros__doc__,
+"zeros($type, size, /)\n"
+"--\n"
+"\n"
+"Create a bytearray object of size given by the parameter initialized with null bytes.\n"
+"\n"
+"Parameter must be 0 or a positive integer.\n"
+"Example: bytearray.zeros(3) -> bytearray(b\\\'\\\\x00\\\\x00\\\\x00\')");
+
+#define BYTEARRAY_ZEROS_METHODDEF    \
+    {"zeros", (PyCFunction)bytearray_zeros, METH_O|METH_CLASS, bytearray_zeros__doc__},
+
+static PyObject *
+bytearray_zeros_impl(PyTypeObject *type, int size);
+
+static PyObject *
+bytearray_zeros(PyTypeObject *type, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    int size;
+
+    if (!PyArg_Parse(arg, "i:zeros", &size)) {
+        goto exit;
+    }
+    return_value = bytearray_zeros_impl(type, size);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(bytearray_byte__doc__,
+"byte($type, x, /)\n"
+"--\n"
+"\n"
+"Create a bytearray object, consisting of a single byte.\n"
+"\n"
+"Parameter must be in range(0, 256)\n"
+"bytearray.byte(x) is equivalent to bytearray([x])\n"
+"Example: bytearray.byte(3) -> bytearray(b\'\\x03\')");
+
+#define BYTEARRAY_BYTE_METHODDEF    \
+    {"byte", (PyCFunction)bytearray_byte, METH_O|METH_CLASS, bytearray_byte__doc__},
+
+static PyObject *
+bytearray_byte_impl(PyTypeObject *type, int x);
+
+static PyObject *
+bytearray_byte(PyTypeObject *type, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    int x;
+
+    if (!PyArg_Parse(arg, "i:byte", &x)) {
+        goto exit;
+    }
+    return_value = bytearray_byte_impl(type, x);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(bytearray_reduce__doc__,
 "__reduce__($self, /)\n"
 "--\n"
@@ -711,4 +772,4 @@ bytearray_sizeof(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return bytearray_sizeof_impl(self);
 }
-/*[clinic end generated code: output=e53f10084457a46b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=26f8911786111e2b input=a9049054013a1b77]*/

--- a/Objects/clinic/bytesobject.c.h
+++ b/Objects/clinic/bytesobject.c.h
@@ -499,4 +499,65 @@ bytes_fromhex(PyTypeObject *type, PyObject *arg)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9e3374bd7d04c163 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(bytes_zeros__doc__,
+"zeros($type, size, /)\n"
+"--\n"
+"\n"
+"Create a bytes object of size given by the parameter initialized with null bytes.\n"
+"\n"
+"Parameter must be 0 or a positive integer.\n"
+"Example: bytes.zeros(3) -> b\\\'\\\\x00\\\\x00\\\\x00\'");
+
+#define BYTES_ZEROS_METHODDEF    \
+    {"zeros", (PyCFunction)bytes_zeros, METH_O|METH_CLASS, bytes_zeros__doc__},
+
+static PyObject *
+bytes_zeros_impl(PyTypeObject *type, int size);
+
+static PyObject *
+bytes_zeros(PyTypeObject *type, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    int size;
+
+    if (!PyArg_Parse(arg, "i:zeros", &size)) {
+        goto exit;
+    }
+    return_value = bytes_zeros_impl(type, size);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(bytes_byte__doc__,
+"byte($type, x, /)\n"
+"--\n"
+"\n"
+"Create a bytes object, consisting of a single byte.\n"
+"\n"
+"Parameter must be in range(0, 256)\n"
+"bytes.byte(x) is equivalent to bytes([x])\n"
+"Example: bytes.byte(3) -> b\'\\x03\'");
+
+#define BYTES_BYTE_METHODDEF    \
+    {"byte", (PyCFunction)bytes_byte, METH_O|METH_CLASS, bytes_byte__doc__},
+
+static PyObject *
+bytes_byte_impl(PyTypeObject *type, int x);
+
+static PyObject *
+bytes_byte(PyTypeObject *type, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    int x;
+
+    if (!PyArg_Parse(arg, "i:byte", &x)) {
+        goto exit;
+    }
+    return_value = bytes_byte_impl(type, x);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=13231af5ad06dec3 input=a9049054013a1b77]*/


### PR DESCRIPTION
This is basically my original attempt to implement PEP 467, with some minor changes to make it work with Python 3.7.

<!-- issue-number: bpo-27923 -->
https://bugs.python.org/issue27923
<!-- /issue-number -->
