### PR TITLE
bpo-31292: Fix distutils check --restructuredtext for include directives

### DIFF
--- a/Lib/distutils/command/check.py
+++ b/Lib/distutils/command/check.py
@@ -120,13 +120,13 @@ class check(Command):
 
     def _check_rst_data(self, data):
         """Returns warnings when the provided data doesn't compile."""
-        source_desc = '{} (long_description)'.format(self.distribution.script_name or 'distutils')
+        source_path = self.distribution.script_name or 'setup.py'
         parser = Parser()
         settings = frontend.OptionParser(components=(Parser,)).get_default_values()
         settings.tab_width = 4
         settings.pep_references = None
         settings.rfc_references = None
-        reporter = SilentReporter(source_desc,
+        reporter = SilentReporter(source_path,
                           settings.report_level,
                           settings.halt_level,
                           stream=settings.warning_stream,
@@ -134,8 +134,9 @@ class check(Command):
                           encoding=settings.error_encoding,
                           error_handler=settings.error_encoding_error_handler)
 
-        document = nodes.document(settings, reporter, source=source_desc)
-        document.note_source(source_desc, -1)
+        document = nodes.document(settings, reporter, source=source_path)
+        # the include and csv_table directives need this to be a path
+        document.note_source(source_path, -1)
         try:
             parser.parse(data, document)
         except AttributeError as e:

--- a/Lib/distutils/command/check.py
+++ b/Lib/distutils/command/check.py
@@ -120,13 +120,13 @@ class check(Command):
 
     def _check_rst_data(self, data):
         """Returns warnings when the provided data doesn't compile."""
-        source_path = self.distribution.script_name or 'long_description'
+        source_desc = '{} (long_description)'.format(self.distribution.script_name or 'distutils')
         parser = Parser()
         settings = frontend.OptionParser(components=(Parser,)).get_default_values()
         settings.tab_width = 4
         settings.pep_references = None
         settings.rfc_references = None
-        reporter = SilentReporter(source_path,
+        reporter = SilentReporter(source_desc,
                           settings.report_level,
                           settings.halt_level,
                           stream=settings.warning_stream,
@@ -134,8 +134,8 @@ class check(Command):
                           encoding=settings.error_encoding,
                           error_handler=settings.error_encoding_error_handler)
 
-        document = nodes.document(settings, reporter, source=source_path)
-        document.note_source(source_path, -1)
+        document = nodes.document(settings, reporter, source=source_desc)
+        document.note_source(source_desc, -1)
         try:
             parser.parse(data, document)
         except AttributeError as e:

--- a/Lib/distutils/command/check.py
+++ b/Lib/distutils/command/check.py
@@ -120,7 +120,7 @@ class check(Command):
 
     def _check_rst_data(self, data):
         """Returns warnings when the provided data doesn't compile."""
-        source_path = StringIO()
+        source_path = self.distribution.script_name or 'long_description'
         parser = Parser()
         settings = frontend.OptionParser(components=(Parser,)).get_default_values()
         settings.tab_width = 4
@@ -135,7 +135,7 @@ class check(Command):
                           error_handler=settings.error_encoding_error_handler)
 
         document = nodes.document(settings, reporter, source=source_path)
-        document.note_source(source_path, -1)
+        document.note_source(StringIO(), -1)
         try:
             parser.parse(data, document)
         except AttributeError as e:

--- a/Lib/distutils/command/check.py
+++ b/Lib/distutils/command/check.py
@@ -135,7 +135,7 @@ class check(Command):
                           error_handler=settings.error_encoding_error_handler)
 
         document = nodes.document(settings, reporter, source=source_path)
-        document.note_source(StringIO(), -1)
+        document.note_source(source_path, -1)
         try:
             parser.parse(data, document)
         except AttributeError as e:

--- a/Lib/distutils/tests/includetest.rst
+++ b/Lib/distutils/tests/includetest.rst
@@ -1,0 +1,1 @@
+This should be included.

--- a/Lib/distutils/tests/test_check.py
+++ b/Lib/distutils/tests/test_check.py
@@ -1,7 +1,7 @@
 """Tests for distutils.command.check."""
-import os
 import textwrap
 import unittest
+from pathlib import Path
 from test.support import run_unittest
 
 from distutils.command.check import check, HAS_DOCUTILS
@@ -12,6 +12,10 @@ try:
     import pygments
 except ImportError:
     pygments = None
+
+
+HERE = Path(__file__).parent
+INCLUDE_TEST_PATH = (HERE / 'includetest.rst').relative_to(Path.cwd())
 
 
 class CheckTestCase(support.LoggingSilencer,
@@ -101,7 +105,7 @@ class CheckTestCase(support.LoggingSilencer,
         self.assertEqual(cmd._warnings, 0)
 
         # check that includes work to test #31292
-        metadata['long_description'] = 'title\n=====\n\n.. include:: ' + os.devnull
+        metadata['long_description'] = 'title\n=====\n\n.. include:: {}'.format(INCLUDE_TEST_PATH)
         cmd = self._run(metadata, strict=1, restructuredtext=1)
         self.assertEqual(cmd._warnings, 0)
 

--- a/Lib/distutils/tests/test_check.py
+++ b/Lib/distutils/tests/test_check.py
@@ -1,4 +1,5 @@
 """Tests for distutils.command.check."""
+import os
 import textwrap
 import unittest
 from test.support import run_unittest
@@ -96,6 +97,11 @@ class CheckTestCase(support.LoggingSilencer,
 
         # and non-broken rest, including a non-ASCII character to test #12114
         metadata['long_description'] = 'title\n=====\n\ntest \u00df'
+        cmd = self._run(metadata, strict=1, restructuredtext=1)
+        self.assertEqual(cmd._warnings, 0)
+
+        # check that includes work to test #31292
+        metadata['long_description'] = f'title\n=====\n\n.. include:: {os.devnull}'
         cmd = self._run(metadata, strict=1, restructuredtext=1)
         self.assertEqual(cmd._warnings, 0)
 

--- a/Lib/distutils/tests/test_check.py
+++ b/Lib/distutils/tests/test_check.py
@@ -101,7 +101,7 @@ class CheckTestCase(support.LoggingSilencer,
         self.assertEqual(cmd._warnings, 0)
 
         # check that includes work to test #31292
-        metadata['long_description'] = f'title\n=====\n\n.. include:: {os.devnull}'
+        metadata['long_description'] = 'title\n=====\n\n.. include:: ' + os.devnull
         cmd = self._run(metadata, strict=1, restructuredtext=1)
         self.assertEqual(cmd._warnings, 0)
 

--- a/Misc/NEWS.d/next/Library/2017-08-30-20-27-00.bpo-31292.dKIaZb.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-30-20-27-00.bpo-31292.dKIaZb.rst
@@ -1,0 +1,2 @@
+Fix ``setup.py check --restructuredtext`` for
+files containing ``.. include::`` directives.


### PR DESCRIPTION
<!-- issue-number: bpo-31292 -->
https://bugs.python.org/issue31292
<!-- /issue-number -->
