### PR TITLE
bpo-31250, test_asyncio: fix dangling threads

### DIFF
--- a/Lib/asyncio/test_utils.py
+++ b/Lib/asyncio/test_utils.py
@@ -437,12 +437,19 @@ def get_function_source(func):
 
 
 class TestCase(unittest.TestCase):
+    @staticmethod
+    def close_loop(loop):
+        executor = loop._default_executor
+        if executor is not None:
+            executor.shutdown(wait=True)
+        loop.close()
+
     def set_event_loop(self, loop, *, cleanup=True):
         assert loop is not None
         # ensure that the event loop is passed explicitly in asyncio
         events.set_event_loop(None)
         if cleanup:
-            self.addCleanup(loop.close)
+            self.addCleanup(self.close_loop, loop)
 
     def new_test_loop(self, gen=None):
         loop = TestLoop(gen)

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -380,6 +380,7 @@ class BaseFutureTests:
         self.assertTrue(asyncio.isfuture(f2))
         self.assertEqual(res, 'oi')
         self.assertNotEqual(ident, threading.get_ident())
+        ex.shutdown(wait=True)
 
     def test_wrap_future_future(self):
         f1 = self._new_future(loop=self.loop)
@@ -395,6 +396,7 @@ class BaseFutureTests:
             f1 = ex.submit(run, 'oi')
             f2 = asyncio.wrap_future(f1)
             self.assertIs(self.loop, f2._loop)
+            ex.shutdown(wait=True)
 
     def test_wrap_future_cancel(self):
         f1 = concurrent.futures.Future()

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -529,7 +529,6 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
             self.loop._loop_self_reading)
 
     def test_loop_self_reading_exception(self):
-        self.loop.close = mock.Mock()
         self.loop.call_exception_handler = mock.Mock()
         self.proactor.recv.side_effect = OSError()
         self.loop._loop_self_reading()


### PR DESCRIPTION
* Explicitly call shutdown(wait=True) on executors to wait until all
  threads complete to prevent side effects between tests.
* Fix test_loop_self_reading_exception(): don't mock loop.close().
  Previously, the original close() method was called rather than the
  mock, because how set_event_loop() registered loop.close().

<!-- issue-number: bpo-31250 -->
https://bugs.python.org/issue31250
<!-- /issue-number -->
