### PR TITLE
bpo-30940: specify what happens if ndigits is None or omitted

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1311,8 +1311,9 @@ are always available.  They are listed here in alphabetical order.
    negative).  The return value is an integer if *ndigits* is omitted or is ``None``.
    Otherwise the return value has the same type as *number*.
 
-   For a general Python object ``number``, ``round`` delegates to
-   ``number.__round__``.
+   For a general Python object, ``round(number)`` or ``round(number, None)``
+   delegates to ``number.__round__()``, and ``round(number, ndigits)`` delegates
+   to ``number.__round__(ndigits)``.
 
    .. note::
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1297,10 +1297,10 @@ are always available.  They are listed here in alphabetical order.
    arguments starting at ``0``).
 
 
-.. function:: round(number[, ndigits])
+.. function:: round(number, ndigits=None)
 
    Return *number* rounded to *ndigits* precision after the decimal
-   point.  If *ndigits* is omitted or is ``None``, it returns the
+   point.  If *ndigits* is omitted or ``None``, it returns the
    nearest integer to its input.
 
    For the built-in types supporting :func:`round`, values are rounded to the
@@ -1308,11 +1308,11 @@ are always available.  They are listed here in alphabetical order.
    equally close, rounding is done toward the even choice (so, for example,
    both ``round(0.5)`` and ``round(-0.5)`` are ``0``, and ``round(1.5)`` is
    ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
-   negative).  The return value is an integer if called with one argument,
-   otherwise of the same type as *number*.
+   negative).  The return value is an integer if *ndigits* is omitted or is ``None``.
+   Otherwise the return value has the same type as *number*.
 
-   For a general Python object ``number``, ``round(number, ndigits)`` delegates to
-   ``number.__round__(ndigits)``.
+   For a general Python object ``number``, ``round`` delegates to
+   ``number.__round__``.
 
    .. note::
 

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -490,7 +490,8 @@ form.
 
 .. function:: compile(pattern, flags=0)
 
-   Compile a regular expression pattern into a regular expression object, which
+   Compile a regular expression pattern into a
+   :ref:`regular expression object<re-objects>`, which
    can be used for matching using its :func:`~regex.match` and
    :func:`~regex.search` methods, described below.
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2087,10 +2087,10 @@ builtin_round(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 PyDoc_STRVAR(round_doc,
-"round(number[, ndigits]) -> number\n\
+"round(number, ndigits=None) -> number\n\
 \n\
 Round a number to a given precision in decimal digits (default 0 digits).\n\
-This returns an int when called with one argument, otherwise the\n\
+This returns an int when ndigits is omitted or is None, otherwise the\n\
 same type as the number. ndigits may be negative.");
 
 


### PR DESCRIPTION
I've added the latest changes that were mentioned in the bug tracker. 

<!-- issue-number: bpo-30940 -->
https://bugs.python.org/issue30940
<!-- /issue-number -->
