### PR TITLE
bpo-31315: Fix an assertion failure in imp.create_dynamic(), when spec.name is not a string

### DIFF
--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -23,11 +23,11 @@ def requires_load_dynamic(meth):
                            'imp.load_dynamic() required')(meth)
 
 def requires_create_dynamic(meth):
-    """A decorator to skip tests that rely on imp.create_dynamic().
+    """A decorator for CPython-only tests that rely on imp.create_dynamic().
 
-    Some Python implementations might not provide imp.create_dynamic(). In
-    such implementations, this decorator causes decorated tests to be skipped
-    through the normal unittest mechanism.
+    On some platforms, CPython might not provide imp.create_dynamic().
+    In such cases and in other implementations, this decorator causes
+    decorated tests to be skipped through the normal unittest mechanism.
     """
     meth = support.cpython_only(meth)
     supported = hasattr(imp, 'create_dynamic')

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -23,11 +23,16 @@ def requires_load_dynamic(meth):
                            'imp.load_dynamic() required')(meth)
 
 def requires_create_dynamic(meth):
-    """Decorator to skip a test if not running under CPython or lacking
-    imp.create_dynamic()."""
+    """A decorator to skip tests that rely on imp.create_dynamic().
+
+    Some Python implementations might not provide imp.create_dynamic(). In
+    such implementations, this decorator causes decorated tests to be skipped
+    through the normal unittest mechanism.
+    """
     meth = support.cpython_only(meth)
-    return unittest.skipIf(not hasattr(imp, 'create_dynamic'),
-                           'imp.create_dynamic() required')(meth)
+    supported = hasattr(imp, 'create_dynamic')
+    deco = unittest.skipIf(not supported, 'imp.create_dynamic() required')
+    return deco(meth)
 
 
 @unittest.skipIf(_thread is None, '_thread module is required')

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -21,6 +21,7 @@ def requires_load_dynamic(meth):
     meth = support.cpython_only(meth)
     return unittest.skipIf(not hasattr(imp, 'load_dynamic'),
                            'imp.load_dynamic() required')(meth)
+
 def requires_create_dynamic(meth):
     """Decorator to skip a test if not running under CPython or lacking
     imp.create_dynamic()."""

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -21,6 +21,12 @@ def requires_load_dynamic(meth):
     meth = support.cpython_only(meth)
     return unittest.skipIf(not hasattr(imp, 'load_dynamic'),
                            'imp.load_dynamic() required')(meth)
+def requires_create_dynamic(meth):
+    """Decorator to skip a test if not running under CPython or lacking
+    imp.create_dynamic()."""
+    meth = support.cpython_only(meth)
+    return unittest.skipIf(not hasattr(imp, 'create_dynamic'),
+                           'imp.create_dynamic() required')(meth)
 
 
 @unittest.skipIf(_thread is None, '_thread module is required')
@@ -317,6 +323,16 @@ class ImportTests(unittest.TestCase):
     def test_load_source(self):
         with self.assertRaisesRegex(ValueError, 'embedded null'):
             imp.load_source(__name__, __file__ + "\0")
+
+    @requires_create_dynamic
+    def test_issue31315(self):
+        # There shouldn't be an assertion failure in imp.create_dynamic(),
+        # when spec.name is not a string.
+        class BadSpec:
+            name = 42
+            origin = 'foo'
+        with self.assertRaises(TypeError):
+            imp.create_dynamic(BadSpec())
 
 
 class ReloadTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-01-00-40-58.bpo-31315.ZX20bl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-01-00-40-58.bpo-31315.ZX20bl.rst
@@ -1,0 +1,2 @@
+Fix an assertion failure in imp.create_dynamic(), when spec.name is not a
+string. Patch by Oren Milman.

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -103,6 +103,11 @@ _PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *fp)
     if (name_unicode == NULL) {
         return NULL;
     }
+    if (!PyUnicode_Check(name_unicode)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "spec.name must be a string");
+        goto error;
+    }
 
     name = get_encoded_name(name_unicode, &hook_prefix);
     if (name == NULL) {


### PR DESCRIPTION
- in `importdl.c` - add a check whether spec.name is not a string.
- in `test_imp.py` - add a test to verify that the assertion failure is no more.

<!-- issue-number: bpo-31315 -->
https://bugs.python.org/issue31315
<!-- /issue-number -->
