### PR TITLE
bpo-31325: bug in RobotFileParser.parse

### DIFF
--- a/Lib/urllib/robotparser.py
+++ b/Lib/urllib/robotparser.py
@@ -16,6 +16,8 @@ import urllib.request
 
 __all__ = ["RobotFileParser"]
 
+req_rate = collections.namedtuple('req_rate', 'requests seconds')
+
 class RobotFileParser:
     """ This class provides a set of methods to read, parse and answer
     questions about a single robots.txt file.
@@ -136,11 +138,7 @@ class RobotFileParser:
                         # check if all values are sane
                         if (len(numbers) == 2 and numbers[0].strip().isdigit()
                             and numbers[1].strip().isdigit()):
-                            req_rate = collections.namedtuple('req_rate',
-                                                              'requests seconds')
-                            entry.req_rate = req_rate
-                            entry.req_rate.requests = int(numbers[0])
-                            entry.req_rate.seconds = int(numbers[1])
+                            entry.req_rate = req_rate(requests=int(numbers[0]), seconds=int(numbers[1]))
                         state = 2
         if state == 2:
             self._add_entry(entry)


### PR DESCRIPTION
The req_rate assigned to the new entry was a new namedtuple type,
rather than an instance of that type.

Credits to eesmith for finding this bug:
https://news.ycombinator.com/item?id=15136961

<!-- issue-number: bpo-31325 -->
https://bugs.python.org/issue31325
<!-- /issue-number -->
