### PR TITLE
bpo-31321: Fix traceback.clear_frames()

### DIFF
--- a/Lib/traceback.py
+++ b/Lib/traceback.py
@@ -211,12 +211,23 @@ def extract_stack(f=None, limit=None):
 
 def clear_frames(tb):
     "Clear all references to local variables in the frames of a traceback."
+    seen = set()
     while tb is not None:
-        try:
-            tb.tb_frame.clear()
-        except RuntimeError:
-            # Ignore the exception raised if the frame is still executing.
-            pass
+        frame = tb.tb_frame
+        while True:
+            key = id(frame)
+            if key in seen:
+                break
+            seen.add(key)
+
+            try:
+                frame.clear()
+            except RuntimeError:
+                # Ignore the exception raised if the frame is still executing.
+                pass
+            frame = frame.f_back
+            if frame is None:
+                break
         tb = tb.tb_next
 
 

--- a/Misc/NEWS.d/next/Library/2017-09-01-16-51-04.bpo-31321.AXtvkT.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-01-16-51-04.bpo-31321.AXtvkT.rst
@@ -1,0 +1,2 @@
+traceback.clear_frames() now iterates on frames to clear all frames of each
+traceback object, not only the first frame.


### PR DESCRIPTION
traceback.clear_frames() now iterates on frames to clear all frames
of each traceback object, not only the first frame.

<!-- issue-number: bpo-31321 -->
https://bugs.python.org/issue31321
<!-- /issue-number -->
