### PR TITLE
bpo-31250, test_asyncio: fix EventLoopTestsMixin.tearDown()

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -258,8 +258,8 @@ class EventLoopTestsMixin:
         if not self.loop.is_closed():
             test_utils.run_briefly(self.loop)
 
-        self.loop.close()
-        gc.collect()
+        self.doCleanups()
+        support.gc_collect()
         super().tearDown()
 
     def test_run_until_complete_nesting(self):


### PR DESCRIPTION
Call doCleanups() to close the loop after calling
executor.shutdown(wait=True): see TestCase.set_event_loop() of
asyncio.test_utils.

Replace also gc.collect() with support.gc_collect().

<!-- issue-number: bpo-31250 -->
https://bugs.python.org/issue31250
<!-- /issue-number -->
