### PR TITLE
bpo-31326: ProcessPoolExecutor waits for the call queue thread

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -495,10 +495,11 @@ class ProcessPoolExecutor(_base.Executor):
         # To reduce the risk of opening too many files, remove references to
         # objects that use file descriptors.
         self._queue_management_thread = None
-        self._call_queue.close()
-        if wait:
-            self._call_queue.join_thread()
-        self._call_queue = None
+        if self._call_queue is not None:
+            self._call_queue.close()
+            if wait:
+                self._call_queue.join_thread()
+            self._call_queue = None
         self._result_queue = None
         self._processes = None
     shutdown.__doc__ = _base.Executor.shutdown.__doc__

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -495,6 +495,9 @@ class ProcessPoolExecutor(_base.Executor):
         # To reduce the risk of opening too many files, remove references to
         # objects that use file descriptors.
         self._queue_management_thread = None
+        self._call_queue.close()
+        if wait:
+            self._call_queue.join_thread()
         self._call_queue = None
         self._result_queue = None
         self._processes = None

--- a/Misc/NEWS.d/next/Library/2017-09-01-18-48-06.bpo-31326.TB05tV.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-01-18-48-06.bpo-31326.TB05tV.rst
@@ -1,0 +1,3 @@
+concurrent.futures.ProcessPoolExecutor.shutdown() now explicitly closes the
+call queue. Moreover, shutdown(wait=True) now also join the call queue
+thread, to prevent leaking a dangling thread.


### PR DESCRIPTION
concurrent.futures.ProcessPoolExecutor.shutdown() now explicitly
closes the call queue. Moreover, shutdown(wait=True) now also join
the call queue thread, to prevent leaking a dangling thread.

<!-- issue-number: bpo-31326 -->
https://bugs.python.org/issue31326
<!-- /issue-number -->
