### PR TITLE
bpo-30581: Backport to 3.6: Windows: os.cpu_count() returns wrong number of processors

### DIFF
--- a/Misc/NEWS.d/next/Windows/2017-08-04-10-05-19.bpo-30581.OQhR7l.rst
+++ b/Misc/NEWS.d/next/Windows/2017-08-04-10-05-19.bpo-30581.OQhR7l.rst
@@ -1,0 +1,2 @@
+os.cpu_count() now returns the correct number of processors on Windows
+when the number of logical processors is greater than 64.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -11002,9 +11002,22 @@ os_cpu_count_impl(PyObject *module)
 {
     int ncpu = 0;
 #ifdef MS_WINDOWS
-    SYSTEM_INFO sysinfo;
-    GetSystemInfo(&sysinfo);
-    ncpu = sysinfo.dwNumberOfProcessors;
+    /* Vista is supported and the GetMaximumProcessorCount API is Win7+
+       Need to fallback to Vista behavior if this call isn't present */
+    HINSTANCE hKernel32;
+    hKernel32 = GetModuleHandleW(L"KERNEL32");
+
+    static DWORD(CALLBACK *_GetMaximumProcessorCount)(WORD) = NULL;
+    *(FARPROC*)&_GetMaximumProcessorCount = GetProcAddress(hKernel32,
+        "GetMaximumProcessorCount");
+    if (_GetMaximumProcessorCount != NULL) {
+        ncpu = _GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS);
+    }
+    else {
+        SYSTEM_INFO sysinfo;
+        GetSystemInfo(&sysinfo);
+        ncpu = sysinfo.dwNumberOfProcessors;
+    }
 #elif defined(__hpux)
     ncpu = mpctl(MPC_GETNUMSPUS, NULL, NULL);
 #elif defined(HAVE_SYSCONF) && defined(_SC_NPROCESSORS_ONLN)


### PR DESCRIPTION
Related: bpo-30581: Windows: os.cpu_count() returns wrong number of processors #2934


<!-- issue-number: bpo-30581 -->
https://bugs.python.org/issue30581
<!-- /issue-number -->
