### PR TITLE
Expose `worker_target` and `workitem_cls` as arugments to customize `ThreadPoolExecutor` behaviour

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -142,11 +142,11 @@ And::
       control the threading.Thread names for worker threads created by
       the pool for easier debugging.
 
-   .. versionadded:: 3.6
+   .. versionadded:: 3.7
       The *worker_target* argument was added to allow users to
       customize the execution for worker threads created by the pool.
 
-   .. versionadded:: 3.6
+   .. versionadded:: 3.7
       The *workitem_cls* argument was added to allow users to
       control the work item's behaviour.
 

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -142,6 +142,15 @@ And::
       control the threading.Thread names for worker threads created by
       the pool for easier debugging.
 
+   .. versionadded:: 3.6
+      The *worker_target* argument was added to allow users to
+      customize the execution for worker threads created by the pool.
+
+   .. versionadded:: 3.6
+      The *workitem_cls* argument was added to allow users to
+      control the work item's behaviour.
+
+
 .. _threadpoolexecutor-example:
 
 ThreadPoolExecutor Example


### PR DESCRIPTION
With the two arguments, we can esaily to customize behaviour when I submit task to a `ThreadPoolExecutor` instance. It's more useful when I want to execute coroutine function with this executor. For example, 

```python
import asyncio
from asyncio.futures import _chain_future
from asyncio.tasks import run_coroutine_threadsafe
from concurrent.futures import ThreadPoolExecutor
from concurrent.futures.thread import _WorkItem
import queue

async def task():
    print('run coroutine task')

def _worker(executor_reference, work_queue):
    loop = asyncio.get_event_loop()
    def _work_consumer():
        try:
            try:
                work_item = work_queue.get_nowait()
            except queue.Empty:
                return

            if work_item is not None:
                work_item.run()
                # Delete references to object. See issue16284
                del work_item
                continue
            executor = executor_reference()
            # Exit if:
            #   - The interpreter is shutting down OR
            #   - The executor that owns the worker has been collected OR
            #   - The executor that owns the worker has been shutdown.
            if _shutdown or executor is None or executor._shutdown:
                # Notice other workers
                work_queue.put(None)
                return
            del executor
        except BaseException:
            _base.LOGGER.critical('Exception in worker', exc_info=True)

    def _work_callback():
        _work_consumer()
        loop.call_later(0.2, _work_callback)

    loop.call_later(0.2, _work_callback)
    loop.run_forever()

class _CoroutineWorkItem(_WorkItem):

    def run(self):
        if not self.future.set_running_or_notify_cancel():
            return
        try:
            result = self.fn(*self.args, **self.kwargs)
        except BaseException as exc:
            self.future.set_exception(exc)
            # Break a reference cycle with the exception 'exc'
            self = None
        else:
            loop = asyncio.get_event_loop()
            c_result = run_coroutine_threadsafe(result, loop)
            _chain_future(c_result, result)

executor = ThreadPoolExecutor(worker_target=_worker)
```

With this, we can run coroutine in any pattern programs and don't care about whether the main framework supports. Also, in mamy non asynchronous web application, we can use `asyncio` releated features in this way. I think people will like this. Although, I can write an another `ThreadPoolExecutor`, but I think we should reuse as more code in standard lib as we can. Lastly, this makes `ThreadPoolExecutor` more flexible.