### PR TITLE
[3.6] Fix a c.f.as_completed() refleak previously introduced in bpo-27144 (GH-3270)

### DIFF
--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -406,7 +406,7 @@ class AsCompletedTests:
         # to finished futures.
         futures_list = [Future() for _ in range(8)]
         futures_list.append(create_future(state=CANCELLED_AND_NOTIFIED))
-        futures_list.append(create_future(state=SUCCESSFUL_FUTURE))
+        futures_list.append(create_future(state=FINISHED, result=42))
 
         with self.assertRaises(futures.TimeoutError):
             for future in futures.as_completed(futures_list, timeout=0):


### PR DESCRIPTION
(cherry picked from commit 2ef3760)

<!-- issue-number: bpo-27144 -->
https://bugs.python.org/issue27144
<!-- /issue-number -->
