### PR TITLE
bpo-31330: Clarify that multiple new lines are reduced to one.

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -426,9 +426,9 @@ should not be line-wrapped::
     -h, --help  show this help message and exit
 
 :class:`RawTextHelpFormatter` maintains whitespace for all sorts of help text,
-including argument descriptions. However, multiple new lines in epilog and
-description are replaced with one. If you prefer to use multiple new lines,
-add white space between the new line characters.
+including argument descriptions. However, multiple new lines are replaced with
+one. If you wish to preserve multiple blank lines, add spaces between the
+newlines.
 
 :class:`ArgumentDefaultsHelpFormatter` automatically adds information about
 default values to each of the argument help messages::

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -426,7 +426,9 @@ should not be line-wrapped::
     -h, --help  show this help message and exit
 
 :class:`RawTextHelpFormatter` maintains whitespace for all sorts of help text,
-including argument descriptions.
+including argument descriptions. However, multiple new lines in epilog and
+description are replaced with one. If you prefer to use multiple new lines,
+add white space between the new line characters.
 
 :class:`ArgumentDefaultsHelpFormatter` automatically adds information about
 default values to each of the argument help messages::


### PR DESCRIPTION
As per http://bugs.python.org/issue31330. I've added a couple of sentences explaining the behaviour and providing the solution.

<!-- issue-number: bpo-31330 -->
https://bugs.python.org/issue31330
<!-- /issue-number -->
