### PR TITLE
[3.6] Fix a typo in the Programming FAQ. (GH-3230)

### DIFF
--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -1638,7 +1638,7 @@ collected.
 
 Despite the cycle collector, it's still a good idea to define an explicit
 ``close()`` method on objects to be called whenever you're done with them.  The
-``close()`` method can then remove attributes that refer to subobjecs.  Don't
+``close()`` method can then remove attributes that refer to subobjects.  Don't
 call :meth:`__del__` directly -- :meth:`__del__` should call ``close()`` and
 ``close()`` should make sure that it can be called more than once for the same
 object.


### PR DESCRIPTION
subobjects, not subobjecs.
(cherry picked from commit e9d978fd1bc122395efc91a82b16b2c4b968441d)