### PR TITLE
[3.6] bpo-29212: Fix the ugly repr() ThreadPoolExecutor thread name

### DIFF
--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -7,6 +7,7 @@ __author__ = 'Brian Quinlan (brian@sweetapp.com)'
 
 import atexit
 from concurrent.futures import _base
+import itertools
 import queue
 import threading
 import weakref
@@ -83,6 +84,10 @@ def _worker(executor_reference, work_queue):
         _base.LOGGER.critical('Exception in worker', exc_info=True)
 
 class ThreadPoolExecutor(_base.Executor):
+
+    # Used to assign unique thread names when thread_name_prefix is not supplied.
+    _counter = itertools.count().__next__
+
     def __init__(self, max_workers=None, thread_name_prefix=''):
         """Initializes a new ThreadPoolExecutor instance.
 
@@ -103,7 +108,8 @@ class ThreadPoolExecutor(_base.Executor):
         self._threads = set()
         self._shutdown = False
         self._shutdown_lock = threading.Lock()
-        self._thread_name_prefix = thread_name_prefix
+        self._thread_name_prefix = (thread_name_prefix or
+                                    ("ThreadPoolExecutor-%d" % self._counter()))
 
     def submit(self, fn, *args, **kwargs):
         with self._shutdown_lock:

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -191,10 +191,9 @@ class ThreadPoolShutdownTest(ThreadPoolMixin, ExecutorShutdownTest, BaseTestCase
         del executor
 
         for t in threads:
-            # We don't particularly care what the default name is, just that
-            # it has a default name implying that it is a ThreadPoolExecutor
-            # followed by what looks like a thread number.
-            self.assertRegex(t.name, r'^.*ThreadPoolExecutor.*_[0-4]$')
+            # Ensure that our default name is reasonably sane and unique when
+            # no thread_name_prefix was supplied.
+            self.assertRegex(t.name, r'ThreadPoolExecutor-\d+_[0-4]$')
             t.join()
 
 

--- a/Misc/NEWS.d/next/Library/2017-09-03-14-31-00.bpo-29212.bicycl.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-03-14-31-00.bpo-29212.bicycl.rst
@@ -1,0 +1,3 @@
+Fix concurrent.futures.thread.ThreadPoolExecutor threads to have a non repr()
+based thread name by default when no thread_name_prefix is supplied.  They will
+now identify themselves as "ThreadPoolExecutor-y_n".


### PR DESCRIPTION
(GH-2315)
Fixes the newly introduced ugly default thread name for concurrent.futures
thread.ThreadPoolExecutor threads.  They'll now resemble the old <=3.5
threading default Thread-x names by being named ThreadPoolExecutor-y_n..
(cherry picked from commit a3d91b43c2851312fb942f31afa12f5961706db6)

<!-- issue-number: bpo-29212 -->
https://bugs.python.org/issue29212
<!-- /issue-number -->
