### PR TITLE
bpo-12383: Also ignore __PYVENV_LAUNCHER__

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -651,6 +651,7 @@ class ProcessTestCase(BaseTestCase):
             # on adding even when the environment in exec is empty.
             # Gentoo sandboxes also force LD_PRELOAD and SANDBOX_* to exist.
             return ('VERSIONER' in n or '__CF' in n or  # MacOS
+                    '__PYVENV_LAUNCHER__' in n or # MacOS framework build
                     n == 'LD_PRELOAD' or n.startswith('SANDBOX') or # Gentoo
                     n == 'LC_CTYPE') # Locale coercion triggered
 


### PR DESCRIPTION
Used in macOS framework builds.

<!-- issue-number: bpo-12383 -->
https://bugs.python.org/issue12383
<!-- /issue-number -->
