### PR TITLE
bpo-31336: Speed up type creation, which is highly dominated by slow dict lookups.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-13-12-04-23.bpo-31336.gi2ahY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-13-12-04-23.bpo-31336.gi2ahY.rst
@@ -1,0 +1,2 @@
+Speed up class creation by reducing overhead in the necessary special method
+lookups.  Patch by Stefan Behnel.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-13-12-04-23.bpo-31336.gi2ahY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-13-12-04-23.bpo-31336.gi2ahY.rst
@@ -1,2 +1,2 @@
-Speed up class creation by reducing overhead in the necessary special method
-lookups.  Patch by Stefan Behnel.
+Speed up class creation by 10-20% by reducing the overhead in the
+necessary special method lookups.  Patch by Stefan Behnel.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3026,6 +3026,9 @@ _PyType_Lookup(PyTypeObject *type, PyObject *name)
         }
     }
 
+    /* We may end up clearing live exceptions below, so make sure it's ours. */
+    assert(!PyErr_Occurred());
+
     res = find_name_in_mro(type, name, &error);
     /* Only put NULL results into cache if there was no error. */
     if (error) {
@@ -7001,6 +7004,8 @@ update_one_slot(PyTypeObject *type, slotdef *p)
         } while (p->offset == offset);
         return p;
     }
+    /* We may end up clearing live exceptions below, so make sure it's ours. */
+    assert(!PyErr_Occurred());
     do {
         /* Use faster uncached lookup as we won't get any cache hits during type setup. */
         descr = find_name_in_mro(type, p->name_strobj, &error);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -6990,6 +6990,7 @@ update_one_slot(PyTypeObject *type, slotdef *p)
         return p;
     }
     do {
+        /* Use faster uncached lookup as we won't get any cache hits during type setup. */
         descr = _PyType_LookupUncached(type, p->name_strobj, &error);
         if (descr == NULL) {
             if (error) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2966,12 +2966,13 @@ _PyType_LookupUncached(PyTypeObject *type, PyObject *name, int *error)
     mro = type->tp_mro;
 
     if (mro == NULL) {
-        if ((type->tp_flags & Py_TPFLAGS_READYING) == 0 &&
-                PyType_Ready(type) < 0) {
-            *error = -1;
-            return NULL;
+        if ((type->tp_flags & Py_TPFLAGS_READYING) == 0) {
+            if (PyType_Ready(type) < 0) {
+                *error = -1;
+                return NULL;
+            }
+            mro = type->tp_mro;
         }
-        mro = type->tp_mro;
         if (mro == NULL) {
             *error = 1;
             return NULL;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3037,8 +3037,9 @@ _PyType_Lookup(PyTypeObject *type, PyObject *name)
            the same type will call it again -- hopefully
            in a context that propagates the exception out.
         */
-        if (error == -1)
+        if (error == -1) {
             PyErr_Clear();
+        }
         return NULL;
     }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2989,8 +2989,12 @@ find_name_in_mro(PyTypeObject *type, PyObject *name, int *error)
         base = PyTuple_GET_ITEM(mro, i);
         assert(PyType_Check(base));
         dict = ((PyTypeObject *)base)->tp_dict;
-        assert(dict && PyDict_Check(dict));
-        res = _PyDict_GetItem_KnownHash(dict, name, hash);
+        assert(dict);
+        if (PyDict_CheckExact(dict)) {
+            res = _PyDict_GetItem_KnownHash(dict, name, hash);
+        } else {
+            res = PyObject_GetItem(dict, name);
+        }
         if (res != NULL)
             break;
         if (PyErr_Occurred()) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2946,7 +2946,7 @@ PyType_GetSlot(PyTypeObject *type, int slot)
    This returns a borrowed reference, and might set an exception.
    'error' is set to: -1: error with exception; 1: error without exception; 0: ok */
 static PyObject *
-_PyType_LookupUncached(PyTypeObject *type, PyObject *name, int *error)
+find_name_in_mro(PyTypeObject *type, PyObject *name, int *error)
 {
     Py_ssize_t i, n;
     PyObject *mro, *res, *base, *dict;
@@ -3026,7 +3026,7 @@ _PyType_Lookup(PyTypeObject *type, PyObject *name)
         }
     }
 
-    res = _PyType_LookupUncached(type, name, &error);
+    res = find_name_in_mro(type, name, &error);
     /* Only put NULL results into cache if there was no error. */
     if (error) {
         /* It's not ideal to clear the error condition,
@@ -7003,7 +7003,7 @@ update_one_slot(PyTypeObject *type, slotdef *p)
     }
     do {
         /* Use faster uncached lookup as we won't get any cache hits during type setup. */
-        descr = _PyType_LookupUncached(type, p->name_strobj, &error);
+        descr = find_name_in_mro(type, p->name_strobj, &error);
         if (descr == NULL) {
             if (error == -1) {
                 /* It is unlikely by not impossible that there has been an exception

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2993,9 +2993,10 @@ find_name_in_mro(PyTypeObject *type, PyObject *name, int *error)
         res = _PyDict_GetItem_KnownHash(dict, name, hash);
         if (res != NULL)
             break;
-        /* _PyType_Lookup() ignored and cleared lookup errors and we keep this
-           bad behaviour, instead of returning NULL and setting error = -1. */
-        PyErr_Clear();
+        if (PyErr_Occurred()) {
+            *error = -1;
+            goto done;
+        }
     }
     *error = 0;
 done:

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2950,7 +2950,17 @@ find_name_in_mro(PyTypeObject *type, PyObject *name, int *error)
 {
     Py_ssize_t i, n;
     PyObject *mro, *res, *base, *dict;
-    Py_hash_t hash = -1;
+    Py_hash_t hash;
+
+    if (!PyUnicode_CheckExact(name) ||
+        (hash = ((PyASCIIObject *) name)->hash) == -1)
+    {
+        hash = PyObject_Hash(name);
+        if (hash == -1) {
+            *error = -1;
+            return NULL;
+        }
+    }
 
     /* Look in tp_dict of types in MRO */
     mro = type->tp_mro;
@@ -2980,22 +2990,9 @@ find_name_in_mro(PyTypeObject *type, PyObject *name, int *error)
         assert(PyType_Check(base));
         dict = ((PyTypeObject *)base)->tp_dict;
         assert(dict);
-        /* Optimise for the extremely common case: dict for lookup, unicode name. */
         if (PyDict_CheckExact(dict)) {
-            if (hash == -1) {
-                if (!PyUnicode_CheckExact(name) ||
-                    (hash = ((PyASCIIObject *) name)->hash) == -1)
-                {
-                    hash = PyObject_Hash(name);
-                    if (hash == -1) {
-                        *error = -1;
-                        goto done;
-                    }
-                }
-            }
             res = _PyDict_GetItem_KnownHash(dict, name, hash);
         } else {
-            /* Every other combination is much less safe, so be conservative. */
             res = PyObject_GetItem(dict, name);
         }
         if (res != NULL)

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2989,12 +2989,8 @@ find_name_in_mro(PyTypeObject *type, PyObject *name, int *error)
         base = PyTuple_GET_ITEM(mro, i);
         assert(PyType_Check(base));
         dict = ((PyTypeObject *)base)->tp_dict;
-        assert(dict);
-        if (PyDict_CheckExact(dict)) {
-            res = _PyDict_GetItem_KnownHash(dict, name, hash);
-        } else {
-            res = PyObject_GetItem(dict, name);
-        }
+        assert(dict && PyDict_Check(dict));
+        res = _PyDict_GetItem_KnownHash(dict, name, hash);
         if (res != NULL)
             break;
         if (PyErr_Occurred()) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2993,10 +2993,9 @@ find_name_in_mro(PyTypeObject *type, PyObject *name, int *error)
         res = _PyDict_GetItem_KnownHash(dict, name, hash);
         if (res != NULL)
             break;
-        if (PyErr_Occurred()) {
-            *error = -1;
-            goto done;
-        }
+        /* _PyType_Lookup() ignored and cleared lookup errors and we keep this
+           bad behaviour, instead of returning NULL and setting error = -1. */
+        PyErr_Clear();
     }
     *error = 0;
 done:

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2375,18 +2375,20 @@ type_new(PyTypeObject *metatype, PyObject *args, PyObject *kwds)
     /* Adjust for empty tuple bases */
     nbases = PyTuple_GET_SIZE(bases);
     if (nbases == 0) {
-        bases = PyTuple_Pack(1, &PyBaseObject_Type);
+        base = &PyBaseObject_Type;
+        bases = PyTuple_Pack(1, base);
         if (bases == NULL)
             goto error;
         nbases = 1;
     }
-    else
+    else {
         Py_INCREF(bases);
 
-    /* Calculate best base, and check that all bases are type objects */
-    base = best_base(bases);
-    if (base == NULL) {
-        goto error;
+        /* Calculate best base, and check that all bases are type objects */
+        base = best_base(bases);
+        if (base == NULL) {
+            goto error;
+        }
     }
 
     dict = PyDict_Copy(orig_dict);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3000,8 +3000,8 @@ _PyType_Lookup(PyTypeObject *type, PyObject *name)
     }
 
     res = NULL;
-    /* keep a strong reference to mro because type->tp_mro can be replaced
-       during PyDict_GetItem(dict, name)  */
+    /* Keep a strong reference to mro because type->tp_mro can be replaced
+       during dict lookup, e.g. when comparing to non-string keys. */
     Py_INCREF(mro);
     assert(PyTuple_Check(mro));
     n = PyTuple_GET_SIZE(mro);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3013,6 +3013,9 @@ _PyType_Lookup(PyTypeObject *type, PyObject *name)
         res = _PyDict_GetItem_KnownHash(dict, name, hash);
         if (res != NULL)
             break;
+        /* Ignore any errors during lookup - unlikely to happen,
+           but not impossible. */
+        PyErr_Clear();
     }
     Py_DECREF(mro);
 


### PR DESCRIPTION
This gives me around 20% better performance for ``class Test: pass``. Admittedly, that's a micro-benchmark, but the change is obvious enough to not merit staying slow.

<!-- issue-number: bpo-31336 -->
https://bugs.python.org/issue31336
<!-- /issue-number -->
