### PR TITLE
bpo-31339: Rewrite time.asctime() and time.ctime()

### DIFF
--- a/Misc/NEWS.d/next/Security/2017-09-04-21-24-51.bpo-31339.YSczZN.rst
+++ b/Misc/NEWS.d/next/Security/2017-09-04-21-24-51.bpo-31339.YSczZN.rst
@@ -1,0 +1,4 @@
+Rewrite time.asctime() and time.ctime(). Backport and adapt the _asctime()
+function from the master branch to not depend on the implementation of
+asctime() and ctime() from the external C library. This change fixes a bug
+when Python is run using the musl C library.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -477,8 +477,10 @@ time_strftime(PyObject *self, PyObject *args)
     if (tup == NULL) {
         time_t tt = time(NULL);
         buf = *localtime(&tt);
-    } else if (!gettmarg(tup, &buf))
+    } else if (!gettmarg(tup, &buf)
+               || !checktm(&buf)) {
         return NULL;
+    }
 
     /* Checks added to make sure strftime() does not crash Python by
        indexing blindly into some array for a textual representation


### PR DESCRIPTION
Backport and adapt the _asctime() function from the master branch to
not depend on the implementation of asctime() and ctime() from the
external C library. This change fixes a bug when Python is run using
the musl C library.

<!-- issue-number: bpo-31339 -->
https://bugs.python.org/issue31339
<!-- /issue-number -->
