### PR TITLE
bpo-31339: time.asctime() raise on year > 9999

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -123,15 +123,8 @@ class TimeTestCase(unittest.TestCase):
         time.asctime(time.gmtime(self.t))
         self.assertRaises(TypeError, time.asctime, 0)
         self.assertRaises(TypeError, time.asctime, ())
-        # XXX: Posix compiant asctime should refuse to convert
-        # year > 9999, but Linux implementation does not.
-        # self.assertRaises(ValueError, time.asctime,
-        #                  (12345, 1, 0, 0, 0, 0, 0, 0, 0))
-        # XXX: For now, just make sure we don't have a crash:
-        try:
+        with self.assertRaises(ValueError):
             time.asctime((12345, 1, 1, 0, 0, 0, 0, 1, 0))
-        except ValueError:
-            pass
 
     @unittest.skipIf(not hasattr(time, "tzset"),
         "time module has no attribute tzset")

--- a/Misc/NEWS.d/next/Security/2017-09-04-21-24-51.bpo-31339.YSczZN.rst
+++ b/Misc/NEWS.d/next/Security/2017-09-04-21-24-51.bpo-31339.YSczZN.rst
@@ -1,0 +1,2 @@
+time.asctime() now raises a ValueError for year larger than 9999 to prevent a
+crash when Python is run using the musl C library.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -571,6 +571,12 @@ time_asctime(PyObject *self, PyObject *args)
         buf = *localtime(&tt);
     } else if (!gettmarg(tup, &buf))
         return NULL;
+    /* bpo-31339: Restrict to years < 10,000 so the output fits
+       into 24 characters */
+    if (buf.tm_year > 9999) {
+        PyErr_SetString(PyExc_ValueError, "year larger than 9999");
+        return NULL;
+    }
     p = asctime(&buf);
     if (p == NULL) {
         PyErr_SetString(PyExc_ValueError, "invalid time");


### PR DESCRIPTION
time.asctime() now raises a ValueError for year larger than 9999 to prevent a crash when Python is run using the musl C library.

<!-- issue-number: bpo-31339 -->
https://bugs.python.org/issue31339
<!-- /issue-number -->
