### PR TITLE
remote note about IRIX in aifc

### DIFF
--- a/Doc/library/aifc.rst
+++ b/Doc/library/aifc.rst
@@ -18,12 +18,6 @@ AIFF is Audio Interchange File Format, a format for storing digital audio
 samples in a file.  AIFF-C is a newer version of the format that includes the
 ability to compress the audio data.
 
-.. note::
-
-   Some operations may only work under IRIX; these will raise :exc:`ImportError`
-   when attempting to import the :mod:`cl` module, which is only available on
-   IRIX.
-
 Audio files have a number of parameters that describe the audio data. The
 sampling rate or frame rate is the number of times per second the sound is
 sampled.  The number of channels indicate if the audio is mono, stereo, or


### PR DESCRIPTION
This comment hasn't been true since Python 3.0. See 2095cfea89279489e10a7f9772a025b49502143a.