### PR TITLE
Travis: use ccache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,10 @@ dist: trusty
 sudo: false
 group: beta
 
-# To cache doc-building dependencies.
-cache: pip
+# To cache doc-building dependencies and C compiler output.
+cache:
+    - pip
+    - ccache
 
 branches:
   only:


### PR DESCRIPTION
ccache caches C compiler output and speeds up compiling the same file a lot.

Kudos to Alex for the idea.