### PR TITLE
closes bpo-31347: _PyObject_FastCall_Prepend: do not call memcpy if args might be NULL

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-04-16-35-06.bpo-31347.KDuf2w.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-04-16-35-06.bpo-31347.KDuf2w.rst
@@ -1,0 +1,1 @@
+Fix possible undefined behavior in _PyObject_FastCall_Prepend.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -854,9 +854,9 @@ _PyObject_FastCall_Prepend(PyObject *callable,
 
     /* use borrowed references */
     args2[0] = obj;
-    memcpy(&args2[1],
-           args,
-           (nargs - 1)* sizeof(PyObject *));
+    if (nargs > 1) {
+        memcpy(&args2[1], args, (nargs - 1) * sizeof(PyObject *));
+    }
 
     result = _PyObject_FastCall(callable, args2, nargs);
     if (args2 != small_stack) {


### PR DESCRIPTION
Passing NULL as the second argument to to memcpy is undefined behavior even if the size is 0.

<!-- issue-number: bpo-31347 -->
https://bugs.python.org/issue31347
<!-- /issue-number -->
