### PR TITLE
[2.7] bpo-30450: Don't use `where`, it doesn't exist on XP

### DIFF
--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -32,8 +32,11 @@ if "%DO_FETCH%"=="false" goto end
 if "%ORG%"=="" (set ORG=python)
 call "%PCBUILD%find_python.bat" "%PYTHON%"
 
-if "%PYTHON%"=="" (
-    where /Q git || echo Python 3.6 could not be found or installed, and git.exe is not on your PATH && exit /B 1
+git 2>&1 > nul
+if ERRORLEVEL 9009 (
+    if "%PYTHON%"=="" (
+        echo Python 3.6 could not be found or installed, and git.exe is not on your PATH && exit /B 1
+    )
 )
 
 echo.Fetching external libraries...


### PR DESCRIPTION


<!-- issue-number: bpo-30450 -->
https://bugs.python.org/issue30450
<!-- /issue-number -->
