### PR TITLE
Add comment to explain the implications of not sorting keywords

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -432,6 +432,10 @@ def _make_key(args, kwds, typed,
     saves space and improves lookup speed.
 
     """
+    # All of code below relies on kwds preserving the order input by the user.
+    # Formerly, we sorted() the kwds before looping.  The new way is *much*
+    # faster; however, it means that f(x=1, y=2) will now be treated as a
+    # distinct call from f(y=2, x=1) which will be cached separately.
     key = args
     if kwds:
         key += kwd_mark


### PR DESCRIPTION
In Python 3.6, sorted() was removed from _make_key() for the lru_cache and instead rely on guaranteed keyword argument order preservation.  This makes keyword argument handling faster but it also causes multiple callers with a different keyword argument order to be cached as separate items.  Depending on your point of view, this is either a performance regression (increased number of cache misses) or a performance enhancement (faster computation of keys).