### PR TITLE
Revert "bpo-17852: Maintain a list of BufferedWriter objects.  Flush them on exit."

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1185,7 +1185,6 @@ class BufferedWriter(_BufferedIOMixin):
         self.buffer_size = buffer_size
         self._write_buf = bytearray()
         self._write_lock = Lock()
-        _register_writer(self)
 
     def writable(self):
         return self.raw.writable()
@@ -2575,26 +2574,3 @@ class StringIO(TextIOWrapper):
     def detach(self):
         # This doesn't make sense on StringIO.
         self._unsupported("detach")
-
-
-# ____________________________________________________________
-
-import atexit, weakref
-
-_all_writers = weakref.WeakSet()
-
-def _register_writer(w):
-    # keep weak-ref to buffered writer
-    _all_writers.add(w)
-
-def _flush_all_writers():
-    # Ensure all buffered writers are flushed before proceeding with
-    # normal shutdown.  Otherwise, if the underlying file objects get
-    # finalized before the buffered writer wrapping it then any buffered
-    # data will be lost.
-    for w in _all_writers:
-        try:
-            w.flush()
-        except:
-            pass
-atexit.register(_flush_all_writers)

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-04-12-46-25.bpo-17852.OxAtCg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-04-12-46-25.bpo-17852.OxAtCg.rst
@@ -1,2 +1,0 @@
-Maintain a list of open buffered files, flush them before exiting the
-interpreter.  Based on a patch from Armin Rigo.

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -766,8 +766,6 @@ PyInit__io(void)
         !(_PyIO_empty_bytes = PyBytes_FromStringAndSize(NULL, 0)))
         goto fail;
 
-    _Py_PyAtExit(_PyIO_atexit_flush);
-
     state->initialized = 1;
 
     return m;

--- a/Modules/_io/_iomodule.h
+++ b/Modules/_io/_iomodule.h
@@ -183,5 +183,3 @@ extern PyObject *_PyIO_empty_str;
 extern PyObject *_PyIO_empty_bytes;
 
 extern PyTypeObject _PyBytesIOBuffer_Type;
-
-extern void _PyIO_atexit_flush(void);

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -196,7 +196,7 @@ bufferediobase_write(PyObject *self, PyObject *args)
 }
 
 
-typedef struct _buffered {
+typedef struct {
     PyObject_HEAD
 
     PyObject *raw;
@@ -240,17 +240,7 @@ typedef struct _buffered {
 
     PyObject *dict;
     PyObject *weakreflist;
-
-    /* a doubly-linked chained list of "buffered" objects that need to
-       be flushed when the process exits */
-    struct _buffered *next, *prev;
 } buffered;
-
-/* the actual list of buffered objects */
-static buffered buffer_list_end = {
-    .next = &buffer_list_end,
-    .prev = &buffer_list_end
-};
 
 /*
     Implementation notes:
@@ -397,15 +387,6 @@ _enter_buffered_busy(buffered *self)
 
 
 static void
-remove_from_linked_list(buffered *self)
-{
-    self->next->prev = self->prev;
-    self->prev->next = self->next;
-    self->prev = NULL;
-    self->next = NULL;
-}
-
-static void
 buffered_dealloc(buffered *self)
 {
     self->finalizing = 1;
@@ -413,8 +394,6 @@ buffered_dealloc(buffered *self)
         return;
     _PyObject_GC_UNTRACK(self);
     self->ok = 0;
-    if (self->next != NULL)
-        remove_from_linked_list(self);
     if (self->weakreflist != NULL)
         PyObject_ClearWeakRefs((PyObject *)self);
     Py_CLEAR(self->raw);
@@ -1838,31 +1817,8 @@ _io_BufferedWriter___init___impl(buffered *self, PyObject *raw,
     self->fast_closed_checks = (Py_TYPE(self) == &PyBufferedWriter_Type &&
                                 Py_TYPE(raw) == &PyFileIO_Type);
 
-    if (self->next == NULL) {
-        self->prev = &buffer_list_end;
-        self->next = buffer_list_end.next;
-        buffer_list_end.next->prev = self;
-        buffer_list_end.next = self;
-    }
-
     self->ok = 1;
     return 0;
-}
-
-/*
-* Ensure all buffered writers are flushed before proceeding with
-* normal shutdown.  Otherwise, if the underlying file objects get
-* finalized before the buffered writer wrapping it then any buffered
-* data will be lost.
-*/
-void _PyIO_atexit_flush(void)
-{
-    while (buffer_list_end.next != &buffer_list_end) {
-        buffered *buf = buffer_list_end.next;
-        remove_from_linked_list(buf);
-        buffered_flush(buf, NULL);
-        PyErr_Clear();
-    }
 }
 
 static Py_ssize_t


### PR DESCRIPTION
Reverts python/cpython#1908
Reason: This change causes test_threading test_4_daemon_threads to seemingly fail at random times.  I suspect either the test is buggy or this changed has exposed some other bug.  The behaviour seems to be based on a race condition.  I'm reverting it for now.

<!-- issue-number: bpo-17852 -->
https://bugs.python.org/issue17852
<!-- /issue-number -->
