### PR TITLE
[2.7] bpo-30102: Call OPENSSL_add_all_algorithms_noconf (GH-3112)

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-08-16-21-14-31.bpo-30102.1sPqmc.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-16-21-14-31.bpo-30102.1sPqmc.rst
@@ -1,0 +1,4 @@
+The ssl and hashlib modules now call OPENSSL_add_all_algorithms_noconf() on
+OpenSSL < 1.1.0. The function detects CPU features and enables optimizations
+on some CPU architectures such as POWER8. Patch is based on research from
+Gustavo Serra Scalet.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -899,8 +899,11 @@ init_hashlib(void)
 {
     PyObject *m, *openssl_md_meth_names;
 
-    OpenSSL_add_all_digests();
+#ifndef OPENSSL_VERSION_1_1
+    /* Load all digest algorithms and initialize cpuid */
+    OPENSSL_add_all_algorithms_noconf();
     ERR_load_crypto_strings();
+#endif
 
     /* TODO build EVP_functions openssl_* entries dynamically based
      * on what hashes are supported rather than listing many

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4084,9 +4084,14 @@ init_ssl(void)
     if (PySocketModule_ImportModuleAndAPI())
         return;
 
+#ifndef OPENSSL_VERSION_1_1
+    /* Load all algorithms and initialize cpuid */
+    OPENSSL_add_all_algorithms_noconf();
     /* Init OpenSSL */
     SSL_load_error_strings();
     SSL_library_init();
+#endif
+
 #ifdef WITH_THREAD
 #ifdef HAVE_OPENSSL_CRYPTO_LOCK
     /* note that this will start threading if not already started */
@@ -4098,7 +4103,6 @@ init_ssl(void)
     _ssl_locks_count++;
 #endif
 #endif  /* WITH_THREAD */
-    OpenSSL_add_all_algorithms();
 
     /* Add symbols to module dict */
     PySSLErrorObject = PyErr_NewExceptionWithDoc(


### PR DESCRIPTION
The ssl and hashlib modules now call OPENSSL_add_all_algorithms_noconf() on
OpenSSL < 1.1.0. The function detects CPU features and enables optimizations
on some CPU architectures such as POWER8. Patch is based on research from
Gustavo Serra Scalet.

Signed-off-by: Christian Heimes <christian@python.org>
(cherry picked from commit c941e62)

<!-- issue-number: bpo-30102 -->
https://bugs.python.org/issue30102
<!-- /issue-number -->
