### PR TITLE
[3.6] bpo-30445: Allow appended output in RecursionError message

### DIFF
--- a/Lib/test/test_traceback.py
+++ b/Lib/test/test_traceback.py
@@ -344,7 +344,8 @@ class TracebackFormatTests(unittest.TestCase):
         # 2nd last line contains the repetition count
         self.assertEqual(actual[:-2], expected[:-2])
         self.assertRegex(actual[-2], expected[-2])
-        self.assertEqual(actual[-1], expected[-1])
+        # last line can have additional text appended
+        self.assertIn(expected[-1], actual[-1])
 
         # Check the recursion count is roughly as expected
         rec_limit = sys.getrecursionlimit()


### PR DESCRIPTION
Running under coverage sometimes causes 'in comparison' to be added to the end of the RecursionError message, which is acceptable.

Patched by Maria Mckinley

(cherry picked from commit 3480ef9dd3177be8c0d71a74853dca6e5b11fbe1)

<!-- issue-number: bpo-30445 -->
https://bugs.python.org/issue30445
<!-- /issue-number -->
