### PR TITLE
Stop test_xmlrpc from writing to sys.stderr

### DIFF
--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -328,6 +328,10 @@ class XMLRPCTestCase(unittest.TestCase):
                 self.handled = True
                 self.close_connection = False
 
+            def log_message(self, format, *args):
+                # don't clobber sys.stderr
+                pass
+
         def run_server():
             server.socket.settimeout(float(1))  # Don't hang if client fails
             server.handle_request()  # First request and attempt at second


### PR DESCRIPTION
One test case of test_xmlrpc uses HTTPServer with a subclass of
BaseHTTPRequestHandler. The BaseRequestHandler class logs to
sys.stderr by default. Override log_message() to not clobber
test output.

Signed-off-by: Christian Heimes <christian@python.org>