### PR TITLE
bpo-31320: No traceback to sys.stderr in test_ssl

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1853,10 +1853,13 @@ if _have_threads:
                         self.sock, server_side=True)
                     self.server.selected_npn_protocols.append(self.sslconn.selected_npn_protocol())
                     self.server.selected_alpn_protocols.append(self.sslconn.selected_alpn_protocol())
-                except (ssl.SSLError, ConnectionResetError) as e:
+                except (ssl.SSLError, ConnectionResetError, OSError) as e:
                     # We treat ConnectionResetError as though it were an
                     # SSLError - OpenSSL on Ubuntu abruptly closes the
                     # connection when asked to use an unsupported protocol.
+                    #
+                    # OSError may occur with wrong protocols, e.g. both
+                    # sides use PROTOCOL_TLS_SERVER.
                     #
                     # XXX Various errors can have happened here, for example
                     # a mismatching protocol version, an invalid certificate,

--- a/Misc/NEWS.d/next/Tests/2017-09-05-14-23-35.bpo-31320.JRDHx7.rst
+++ b/Misc/NEWS.d/next/Tests/2017-09-05-14-23-35.bpo-31320.JRDHx7.rst
@@ -1,0 +1,1 @@
+Silence traceback in test_ssl


### PR DESCRIPTION
In case PROTOCOL_TLS_SERVER is used for both client context and server
context, the test thread dies with OSError. Catch OSError to avoid
traceback on sys.stderr

Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: bpo-31320 -->
https://bugs.python.org/issue31320
<!-- /issue-number -->
