### PR TITLE
[3.6] _pickle: Fix whichmodule() (GH-3358)

### DIFF
--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1705,7 +1705,7 @@ whichmodule(PyObject *global, PyObject *dotted_path)
 
     /* If no module is found, use __main__. */
     module_name = _PyUnicode_FromId(&PyId___main__);
-    Py_INCREF(module_name);
+    Py_XINCREF(module_name);
     return module_name;
 }
 


### PR DESCRIPTION
_PyUnicode_FromId() can return NULL: replace Py_INCREF() with
Py_XINCREF().

Fix coverity report: CID 1417269.
(cherry picked from commit af46eb8)