### PR TITLE
[3.6] bpo-30442: Skips refcount test in test_xml_etree under coverage (#1767)

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1523,6 +1523,7 @@ class BugsTest(unittest.TestCase):
         self.assertEqual(t.find('.//paragraph').text,
             'A new cultivar of Begonia plant named \u2018BCT9801BEG\u2019.')
 
+    @unittest.skipIf(sys.gettrace(), "Skips under coverage.")
     def test_bug_xmltoolkit63(self):
         # Check reference leak.
         def xmltoolkit63():


### PR DESCRIPTION
(cherry picked from commit 1de4705d00168afa8c5b6741af02e21fc609af58)

<!-- issue-number: bpo-30442 -->
https://bugs.python.org/issue30442
<!-- /issue-number -->
