### PR TITLE
bpo-29781: Fix SSLObject.version before handshake

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1746,6 +1746,7 @@ class SimpleBackgroundTests(unittest.TestCase):
         sslobj = ctx.wrap_bio(incoming, outgoing, False, 'localhost')
         self.assertIs(sslobj._sslobj.owner, sslobj)
         self.assertIsNone(sslobj.cipher())
+        self.assertIsNone(sslobj.version())
         self.assertIsNotNone(sslobj.shared_ciphers())
         self.assertRaises(ValueError, sslobj.getpeercert)
         if 'tls-unique' in ssl.CHANNEL_BINDING_TYPES:
@@ -1753,6 +1754,7 @@ class SimpleBackgroundTests(unittest.TestCase):
         self.ssl_io_loop(sock, incoming, outgoing, sslobj.do_handshake)
         self.assertTrue(sslobj.cipher())
         self.assertIsNotNone(sslobj.shared_ciphers())
+        self.assertIsNotNone(sslobj.version())
         self.assertTrue(sslobj.getpeercert())
         if 'tls-unique' in ssl.CHANNEL_BINDING_TYPES:
             self.assertTrue(sslobj.get_channel_binding('tls-unique'))

--- a/Misc/NEWS.d/next/Security/2017-09-05-15-26-30.bpo-29781.LwYtBP.rst
+++ b/Misc/NEWS.d/next/Security/2017-09-05-15-26-30.bpo-29781.LwYtBP.rst
@@ -1,0 +1,2 @@
+SSLObject.version() now correctly returns None when handshake over BIO has
+not been performed yet.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1706,6 +1706,10 @@ _ssl__SSLSocket_version_impl(PySSLSocket *self)
 
     if (self->ssl == NULL)
         Py_RETURN_NONE;
+    if (!SSL_is_init_finished(self->ssl)) {
+        /* handshake not finished */
+        Py_RETURN_NONE;
+    }
     version = SSL_get_version(self->ssl);
     if (!strcmp(version, "unknown"))
         Py_RETURN_NONE;


### PR DESCRIPTION
SSLObject.version() now correctly returns None when handshake over BIO has
not been performed yet.

Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: bpo-29781 -->
https://bugs.python.org/issue29781
<!-- /issue-number -->
