### PR TITLE
[3.6] bpo-30662: fixed OrderedDict.__init__ docstring re PEP 468 (GH-…

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -85,9 +85,7 @@ class OrderedDict(dict):
 
     def __init__(*args, **kwds):
         '''Initialize an ordered dictionary.  The signature is the same as
-        regular dictionaries, but keyword arguments are not recommended because
-        their insertion order is arbitrary.
-
+        regular dictionaries.  Keyword argument order is preserved.
         '''
         if not args:
             raise TypeError("descriptor '__init__' of 'OrderedDict' object "

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -875,8 +875,7 @@ odict_eq(PyObject *a, PyObject *b)
 
 PyDoc_STRVAR(odict_init__doc__,
 "Initialize an ordered dictionary.  The signature is the same as\n\
-        regular dictionaries, but keyword arguments are not recommended because\n\
-        their insertion order is arbitrary.\n\
+        regular dictionaries.  Keyword argument order is preserved.\n\
 \n\
         ");
 


### PR DESCRIPTION
…2179)

* fixed OrderedDict.__init__ docstring re PEP 468

* tightened comment and mirrored to C impl

* added space after period per marco-buttu

* preserved substituted for stable

* drop references to Python 3.6 and PEP 468
(cherry picked from commit faa57cbe7074b26807cd7ed89a7b173b5cbf3086)

<!-- issue-number: bpo-30662 -->
https://bugs.python.org/issue30662
<!-- /issue-number -->
