### PR TITLE
bpo-17852: Maintain a list of BufferedWriter objects.  Flush them on exit.

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2593,5 +2593,8 @@ def _flush_all_writers():
     # finalized before the buffered writer wrapping it then any buffered
     # data will be lost.
     for w in _all_writers:
-        w.flush()
+        try:
+            w.flush()
+        except:
+            pass
 atexit.register(_flush_all_writers)

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1185,6 +1185,7 @@ class BufferedWriter(_BufferedIOMixin):
         self.buffer_size = buffer_size
         self._write_buf = bytearray()
         self._write_lock = Lock()
+        _register_writer(self)
 
     def writable(self):
         return self.raw.writable()
@@ -2574,3 +2575,23 @@ class StringIO(TextIOWrapper):
     def detach(self):
         # This doesn't make sense on StringIO.
         self._unsupported("detach")
+
+
+# ____________________________________________________________
+
+import atexit, weakref
+
+_all_writers = weakref.WeakKeyDictionary()
+
+def _register_writer(w):
+    # keep weak-ref to buffered writer
+    _all_writers[w] = True
+
+def _flush_all_writers():
+    # Ensure all buffered writers are flushed before proceeding with
+    # normal shutdown.  Otherwise, if the underlying file objects get
+    # finalized before the buffered writer wrapping it then any buffered
+    # data will be lost.
+    for w in _all_writers:
+        w.flush()
+atexit.register(_flush_all_writers)

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2581,11 +2581,11 @@ class StringIO(TextIOWrapper):
 
 import atexit, weakref
 
-_all_writers = weakref.WeakKeyDictionary()
+_all_writers = weakref.WeakSet()
 
 def _register_writer(w):
     # keep weak-ref to buffered writer
-    _all_writers[w] = True
+    _all_writers.add(w)
 
 def _flush_all_writers():
     # Ensure all buffered writers are flushed before proceeding with

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-04-12-46-25.bpo-17852.OxAtCg.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-04-12-46-25.bpo-17852.OxAtCg.rst
@@ -1,0 +1,2 @@
+Maintain a list of open buffered files, flush them before exiting the
+interpreter.  Based on a patch from Armin Rigo.

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -766,6 +766,8 @@ PyInit__io(void)
         !(_PyIO_empty_bytes = PyBytes_FromStringAndSize(NULL, 0)))
         goto fail;
 
+    _Py_PyAtExit(_PyIO_atexit_flush);
+
     state->initialized = 1;
 
     return m;

--- a/Modules/_io/_iomodule.h
+++ b/Modules/_io/_iomodule.h
@@ -183,3 +183,5 @@ extern PyObject *_PyIO_empty_str;
 extern PyObject *_PyIO_empty_bytes;
 
 extern PyTypeObject _PyBytesIOBuffer_Type;
+
+extern void _PyIO_atexit_flush(void);


### PR DESCRIPTION
This is a fixed (hopefully) version of my previous patch.  Checking buf->ok and buf->finalizing is necessary, as suggested by Antoine Pitrou.

<!-- issue-number: bpo-17852 -->
https://bugs.python.org/issue17852
<!-- /issue-number -->
