### PR TITLE
Revert "pytime: include winsock2, so we can have a complete timeval type (#3377)"

### DIFF
--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1,7 +1,6 @@
 #include "Python.h"
 #ifdef MS_WINDOWS
 #include <windows.h>
-#include <winsock2.h> /* struct timeval */
 #endif
 
 #if defined(__APPLE__)


### PR DESCRIPTION
This reverts commit 833860615bedfd2484ac0623d6f01ff0578ba09f, as it broke Windows builds.