### PR TITLE
bpo-27340: Use memoryview in SSLSocket.sendall()

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -959,12 +959,12 @@ class SSLSocket(socket):
                 raise ValueError(
                     "non-zero flags not allowed in calls to sendall() on %s" %
                     self.__class__)
-            amount = len(data)
             count = 0
-            view = memoryview(data)
-            while (count < amount):
-                v = self.send(view[count:])
-                count += v
+            with memoryview(data) as view, view.cast("B") as byte_view:
+                amount = len(byte_view)
+                while count < amount:
+                    v = self.send(byte_view[count:])
+                    count += v
         else:
             return socket.sendall(self, data, flags)
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -961,8 +961,9 @@ class SSLSocket(socket):
                     self.__class__)
             amount = len(data)
             count = 0
+            view = memoryview(data)
             while (count < amount):
-                v = self.send(data[count:])
+                v = self.send(view[count:])
                 count += v
         else:
             return socket.sendall(self, data, flags)

--- a/Misc/NEWS.d/next/Library/2017-09-06-06-50-41.bpo-27340.GgekV5.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-06-06-50-41.bpo-27340.GgekV5.rst
@@ -1,3 +1,3 @@
-SSLSocket.sendall() now uses memoryview to create slices of data. This fix
+SSLSocket.sendall() now uses memoryview to create slices of data. This fixes
 support for all bytes-like object. It is also more efficient and avoids
 costly copies.

--- a/Misc/NEWS.d/next/Library/2017-09-06-06-50-41.bpo-27340.GgekV5.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-06-06-50-41.bpo-27340.GgekV5.rst
@@ -1,0 +1,3 @@
+SSLSocket.sendall() now uses memoryview to create slices of data. This fix
+support for all bytes-like object. It is also more efficient and avoids
+costly copies.


### PR DESCRIPTION
SSLSocket.sendall() now uses memoryview to create slices of data. This fix
support for all bytes-like object. It is also more efficient and avoids
costly copies.

Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: bpo-27340 -->
https://bugs.python.org/issue27340
<!-- /issue-number -->
