### PR TITLE
bpo-21649: Add RFC 7525 and Mozilla server side TLS

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -2328,3 +2328,9 @@ successful call of :func:`~ssl.RAND_add`, :func:`~ssl.RAND_bytes` or
 
    `IANA TLS: Transport Layer Security (TLS) Parameters <https://www.iana.org/assignments/tls-parameters/tls-parameters.xml>`_
        IANA
+
+   `RFC 7525: Recommendations for Secure Use of Transport Layer Security (TLS) and Datagram Transport Layer Security (DTLS) <https://tools.ietf.org/html/rfc7525>`_
+       IETF
+
+   `Mozilla's Server Side TLS recommendations <https://wiki.mozilla.org/Security/Server_Side_TLS>`_
+       Mozilla

--- a/Misc/NEWS.d/next/Documentation/2017-09-06-10-11-57.bpo-21649.EUvqA9.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-09-06-10-11-57.bpo-21649.EUvqA9.rst
@@ -1,0 +1,1 @@
+Add RFC 7525 and Mozilla server side TLS links to SSL documentation.


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: bpo-21649 -->
https://bugs.python.org/issue21649
<!-- /issue-number -->
