### PR TITLE
bpo-10496 Runing Inside docker container from non root user raises KeyError

### DIFF
--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -244,7 +244,10 @@ def expanduser(path):
     if i == 1:
         if 'HOME' not in os.environ:
             import pwd
-            userhome = pwd.getpwuid(os.getuid()).pw_dir
+            try:
+                userhome = pwd.getpwuid(os.getuid()).pw_dir
+            except KeyError:
+                return path
         else:
             userhome = os.environ['HOME']
     else:


### PR DESCRIPTION
When i try to run youtube-dl inside docker container from non root user i recieve this error:

failed to import the site module traceback (most recent call last): file "/usr/lib/python3.6/site.py", line 544, in main() file "/usr/lib/python3.6/site.py", line 530, in main known_paths = addusersitepackages(known_paths) file "/usr/lib/python3.6/site.py", line 282, in addusersitepackages user_site = getusersitepackages() file "/usr/lib/python3.6/site.py", line 258, in getusersitepackages user_base = getuserbase() # this will also set user_base file "/usr/lib/python3.6/site.py", line 248, in getuserbase user_base = get_config_var('userbase') file "/usr/lib/python3.6/sysconfig.py", line 601, in get_config_var return get_config_vars().get(name) file "/usr/lib/python3.6/sysconfig.py", line 558, in get_config_vars _config_vars['userbase'] = _getuserbase() file "/usr/lib/python3.6/sysconfig.py", line 205, in _getuserbase return joinuser("~", ".local") file "/usr/lib/python3.6/sysconfig.py", line 184, in joinuser return os.path.expanduser(os.path.join(*args)) file "/usr/lib/python3.6/posixpath.py", line 247, in expanduser userhome = pwd.getpwuid(os.getuid()).pw_dir keyerror: 'getpwuid(): uid not found: 1000'

I believe this problem is described here:
http://blog.dscpl.com.au/2015/12/unknown-user-when-running-docker.html



this simple fix make it work again

<!-- issue-number: bpo-10496 -->
https://bugs.python.org/issue10496
<!-- /issue-number -->
