### PR TITLE
bpo-31307: Allow use of bytes object as a single argument in ConfigParser.read

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -1023,7 +1023,7 @@ ConfigParser Objects
       .. versionadded:: 3.6.1
          The *filenames* parameter accepts a :term:`path-like object`.
 
-      .. versionadded:: 3.7.0
+      .. versionadded:: 3.7
          The *filenames* parameter accepts a :class:`bytes` object.
 
 

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -994,14 +994,14 @@ ConfigParser Objects
 
       Attempt to read and parse a list of filenames, returning a list of
       filenames which were successfully parsed.
-
-      If *filenames* is a string, a :class:`bytes` object or
-      :term:`path-like object`, it is treated as a single filename.  If a file
-      named in *filenames* cannot be opened, that file will be ignored.  This
-      is designed so that you can specify a list of potential configuration
-      file locations (for example, the current directory, the user's home
-      directory, and some system-wide directory), and all existing
-      configuration files in the list will be read.
+      
+      If *filenames* is a string, a :class:`bytes` object or a
+      :term:`path-like object`, it is treated as
+      a single filename.  If a file named in *filenames* cannot be opened, that
+      file will be ignored.  This is designed so that you can specify a list of
+      potential configuration file locations (for example, the current
+      directory, the user's home directory, and some system-wide directory),
+      and all existing configuration files in the list will be read.
 
       If none of the named files exist, the :class:`ConfigParser`
       instance will contain an empty dataset.  An application which requires

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -994,7 +994,7 @@ ConfigParser Objects
 
       Attempt to read and parse a list of filenames, returning a list of
       filenames which were successfully parsed.
-      
+
       If *filenames* is a string, a :class:`bytes` object or a
       :term:`path-like object`, it is treated as
       a single filename.  If a file named in *filenames* cannot be opened, that

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -995,12 +995,13 @@ ConfigParser Objects
       Attempt to read and parse a list of filenames, returning a list of
       filenames which were successfully parsed.
 
-      If *filenames* is a string or :term:`path-like object`, it is treated as
-      a single filename.  If a file named in *filenames* cannot be opened, that
-      file will be ignored.  This is designed so that you can specify a list of
-      potential configuration file locations (for example, the current
-      directory, the user's home directory, and some system-wide directory),
-      and all existing configuration files in the list will be read.
+      If *filenames* is a string, a :class:`bytes` object or
+      :term:`path-like object`, it is treated as a single filename.  If a file
+      named in *filenames* cannot be opened, that file will be ignored.  This
+      is designed so that you can specify a list of potential configuration
+      file locations (for example, the current directory, the user's home
+      directory, and some system-wide directory), and all existing
+      configuration files in the list will be read.
 
       If none of the named files exist, the :class:`ConfigParser`
       instance will contain an empty dataset.  An application which requires
@@ -1021,6 +1022,9 @@ ConfigParser Objects
 
       .. versionadded:: 3.6.1
          The *filenames* parameter accepts a :term:`path-like object`.
+
+      .. versionadded:: 3.7.0
+         The *filenames* parameter accepts a :class:`bytes` object.
 
 
    .. method:: read_file(f, source=None)

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -687,7 +687,7 @@ class RawConfigParser(MutableMapping):
 
         Return list of successfully read files.
         """
-        if isinstance(filenames, (str, os.PathLike)):
+        if isinstance(filenames, (str, bytes, os.PathLike)):
             filenames = [filenames]
         read_ok = []
         for filename in filenames:

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -711,6 +711,7 @@ boolean {0[0]} NO
         if self.delimiters[0] != '=':
             self.skipTest('incompatible format')
         file1 = support.findfile("cfgparser.1")
+        file1_bytestring = file1.encode()
         # check when we pass a mix of readable and non-readable files:
         cf = self.newconfig()
         parsed_files = cf.read([file1, "nonexistent-file"])
@@ -739,6 +740,18 @@ boolean {0[0]} NO
         cf = self.newconfig()
         parsed_files = cf.read([])
         self.assertEqual(parsed_files, [])
+        # check when passing an existing bytestring path
+        cf = self.newconfig()
+        parsed_files = cf.read(file1_bytestring)
+        self.assertEqual(parsed_files, [file1_bytestring])
+        # check when passing an non-existing bytestring path
+        cf = self.newconfig()
+        parsed_files = cf.read(b'nonexistent-file')
+        self.assertEqual(parsed_files, [])
+        # check when passing both an existing and non-existing bytestring path
+        cf = self.newconfig()
+        parsed_files = cf.read([file1_bytestring, b'nonexistent-file'])
+        self.assertEqual(parsed_files, [file1_bytestring])
 
     # shared by subclasses
     def get_interpolation_config(self):

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -711,7 +711,6 @@ boolean {0[0]} NO
         if self.delimiters[0] != '=':
             self.skipTest('incompatible format')
         file1 = support.findfile("cfgparser.1")
-        file1_bytestring = file1.encode()
         # check when we pass a mix of readable and non-readable files:
         cf = self.newconfig()
         parsed_files = cf.read([file1, "nonexistent-file"])
@@ -740,6 +739,11 @@ boolean {0[0]} NO
         cf = self.newconfig()
         parsed_files = cf.read([])
         self.assertEqual(parsed_files, [])
+
+    def test_read_returns_file_list_with_bytestring_path(self):
+        if self.delimiters[0] != '=':
+            self.skipTest('incompatible format')
+        file1_bytestring = support.findfile("cfgparser.1").encode()
         # check when passing an existing bytestring path
         cf = self.newconfig()
         parsed_files = cf.read(file1_bytestring)

--- a/Misc/NEWS.d/next/Library/2017-09-07-12-50-28.bpo-31307.AVBiNY.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-07-12-50-28.bpo-31307.AVBiNY.rst
@@ -1,0 +1,2 @@
+Allow use of bytes object as a single argument in
+``configparser.ConfigParser.read()``.

--- a/Misc/NEWS.d/next/Library/2017-09-07-12-50-28.bpo-31307.AVBiNY.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-07-12-50-28.bpo-31307.AVBiNY.rst
@@ -1,2 +1,1 @@
-Allow use of bytes object as a single argument in
-``configparser.ConfigParser.read()``.
+Allow use of bytes objects for arguments to :func:`configparser.ConfigParser.read`.

--- a/Misc/NEWS.d/next/Library/2017-09-07-12-50-28.bpo-31307.AVBiNY.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-07-12-50-28.bpo-31307.AVBiNY.rst
@@ -1,1 +1,1 @@
-Allow use of bytes objects for arguments to :func:`configparser.ConfigParser.read`.
+Allow use of bytes objects for arguments to configparser.ConfigParser.read.

--- a/Misc/NEWS.d/next/Library/2017-09-07-12-50-28.bpo-31307.AVBiNY.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-07-12-50-28.bpo-31307.AVBiNY.rst
@@ -1,1 +1,2 @@
-Allow use of bytes objects for arguments to configparser.ConfigParser.read.
+Allow use of bytes objects for arguments to
+:meth:`configparser.ConfigParser.read`. Patch by Vincent Michel.


### PR DESCRIPTION
Fix issue [bpo-31307](http://bugs.python.org/issue31307) and [bpo-29627](http://bugs.python.org/issue29627).

<!-- issue-number: bpo-31307 -->
https://bugs.python.org/issue31307
<!-- /issue-number -->
