### PR TITLE
bpo-31252: Show example of itemgetter() applied to a dictionary

### DIFF
--- a/Doc/library/operator.rst
+++ b/Doc/library/operator.rst
@@ -321,6 +321,9 @@ expect a function argument.
       >>> itemgetter(slice(2,None))('ABCDEFG')
       'CDEFG'
 
+      >>> soldier = dict(rank='captain', name='dotterbart')
+      >>> itemgetter('rank')(soldier)
+      'captain'
 
    Example of using :func:`itemgetter` to retrieve specific fields from a
    tuple record:


### PR DESCRIPTION



<!-- issue-number: bpo-31252 -->
https://bugs.python.org/issue31252
<!-- /issue-number -->
