### PR TITLE
bpo-31389 Add an optional `header` argument to pdb.set_trace()

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -118,11 +118,15 @@ slightly different way:
    is entered.
 
 
-.. function:: set_trace()
+.. function:: set_trace(*, header=None)
 
-   Enter the debugger at the calling stack frame.  This is useful to hard-code a
-   breakpoint at a given point in a program, even if the code is not otherwise
-   being debugged (e.g. when an assertion fails).
+   Enter the debugger at the calling stack frame.  This is useful to hard-code
+   a breakpoint at a given point in a program, even if the code is not
+   otherwise being debugged (e.g. when an assertion fails).  If given,
+   ``header`` is printed to the console just before debugging begins.
+
+   .. versionadded:: 3.7
+      The keyword-only argument ``header``.
 
 
 .. function:: post_mortem(traceback=None)

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -232,6 +232,13 @@ New function :func:`os.register_at_fork` allows registering Python callbacks
 to be executed on a process fork.  (Contributed by Antoine Pitrou in
 :issue:`16500`.)
 
+pdb
+---
+
+:func:`~pdb.set_trace` now takes an optional ``header`` keyword-only
+argument.  If given, this is printed to the console just before debugging
+begins.
+
 string
 ------
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1581,8 +1581,11 @@ def runctx(statement, globals, locals):
 def runcall(*args, **kwds):
     return Pdb().runcall(*args, **kwds)
 
-def set_trace():
-    Pdb().set_trace(sys._getframe().f_back)
+def set_trace(*, header=None):
+    pdb = Pdb()
+    if header is not None:
+        pdb.message(header)
+    pdb.set_trace(sys._getframe().f_back)
 
 # Post-Mortem interface
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -9,9 +9,12 @@ import unittest
 import subprocess
 import textwrap
 
+from contextlib import ExitStack
+from io import StringIO
 from test import support
 # This little helper class is essential for testing pdb under doctest.
 from test.test_doctest import _FakeInput
+from unittest.mock import patch
 
 
 class PdbTestInput(object):
@@ -1106,6 +1109,15 @@ class PdbTestCase(unittest.TestCase):
         finally:
             if save_home is not None:
                 os.environ['HOME'] = save_home
+
+    def test_header(self):
+        stdout = StringIO()
+        header = 'Nobody expects... blah, blah, blah'
+        with ExitStack() as resources:
+            resources.enter_context(patch('sys.stdout', stdout))
+            resources.enter_context(patch.object(pdb.Pdb, 'set_trace'))
+            pdb.set_trace(header=header)
+        self.assertEqual(stdout.getvalue(), header + '\n')
 
     def tearDown(self):
         support.unlink(support.TESTFN)

--- a/Misc/NEWS.d/next/Library/2017-09-07-15-31-47.bpo-31389.jNFYqB.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-07-15-31-47.bpo-31389.jNFYqB.rst
@@ -1,0 +1,2 @@
+``pdb.set_trace()`` now takes an optional keyword-only argument ``header``.
+If given, this is printed to the console just before debugging begins.


### PR DESCRIPTION


<!-- issue-number: bpo-31389 -->
https://bugs.python.org/issue31389
<!-- /issue-number -->
