### PR TITLE
[3.4][Security] bpo-29572: Update Windows build to OpenSSL 1.0.2k (GH-443)

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-09-07-19-19-19.bpo-29572.iZ1XKK.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-07-19-19-19.bpo-29572.iZ1XKK.rst
@@ -1,0 +1,1 @@
+Update Windows build and OS X installers to use OpenSSL 1.0.2k.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -54,7 +54,7 @@ echo.Fetching external libraries...
 for %%e in (
             bzip2-1.0.6
             nasm-2.11.06
-            openssl-1.0.2j
+            openssl-1.0.2k
             tcl-8.6.1.0
             tk-8.6.1.0
             tix-8.4.3.4

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -5,7 +5,7 @@
     <OutDir>$(SolutionDir)</OutDir>
     <IntDir>$(SolutionDir)$(PlatformName)-temp-$(Configuration)\$(ProjectName)\</IntDir>
     <LinkIncremental>false</LinkIncremental>
-  </PropertyGroup>  
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)'=='x64'">
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
     <_PropertySheetDisplayName>amd64</_PropertySheetDisplayName>
@@ -20,7 +20,7 @@
     <sqlite3Dir>$(externalsDir)\sqlite-3.8.11.0</sqlite3Dir>
     <bz2Dir>$(externalsDir)\bzip2-1.0.6</bz2Dir>
     <lzmaDir>$(externalsDir)\xz-5.0.5</lzmaDir>
-    <opensslDir>$(externalsDir)\openssl-1.0.2j</opensslDir>
+    <opensslDir>$(externalsDir)\openssl-1.0.2k</opensslDir>
     <tcltkDir>$(externalsDir)\tcltk</tcltkDir>
     <tcltk64Dir>$(externalsDir)\tcltk64</tcltk64Dir>
     <tcltkLib>$(tcltkDir)\lib\tcl86t.lib;$(tcltkDir)\lib\tk86t.lib</tcltkLib>

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -171,7 +171,7 @@ _lzma
     Homepage:
         http://tukaani.org/xz/
 _ssl
-    Python wrapper for version 1.0.2j of the OpenSSL secure sockets
+    Python wrapper for version 1.0.2k of the OpenSSL secure sockets
     library, which is built by ssl.vcxproj
     Homepage:
         http://www.openssl.org/


### PR DESCRIPTION
(cherry picked from commit dd2000cbe475da48fdc94e8f05618e9f460077fd)

<!-- issue-number: bpo-29572 -->
https://bugs.python.org/issue29572
<!-- /issue-number -->
