### PR TITLE
[Security][3.4] bpo-29572: Update macOS installer build to OpenSSL 1.0.2k

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -237,9 +237,9 @@ def library_recipes():
 
         result.extend([
           dict(
-              name="OpenSSL 1.0.2e",
-              url="https://www.openssl.org/source/openssl-1.0.2e.tar.gz",
-              checksum='5262bfa25b60ed9de9f28d5d52d77fc5',
+              name="OpenSSL 1.0.2f",
+              url="https://www.openssl.org/source/openssl-1.0.2f.tar.gz",
+              checksum='b3bf73f507172be9292ea2a8c28b659d',
               patches=[
                   "openssl_sdk_makedepend.patch",
                    ],

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -237,9 +237,9 @@ def library_recipes():
 
         result.extend([
           dict(
-              name="OpenSSL 1.0.2f",
-              url="https://www.openssl.org/source/openssl-1.0.2f.tar.gz",
-              checksum='b3bf73f507172be9292ea2a8c28b659d',
+              name="OpenSSL 1.0.2g",
+              url="https://www.openssl.org/source/openssl-1.0.2g.tar.gz",
+              checksum='f3c710c045cdee5fd114feb69feba7aa',
               patches=[
                   "openssl_sdk_makedepend.patch",
                    ],

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -237,9 +237,9 @@ def library_recipes():
 
         result.extend([
           dict(
-              name="OpenSSL 1.0.2h",
-              url="https://www.openssl.org/source/openssl-1.0.2h.tar.gz",
-              checksum='9392e65072ce4b614c1392eefc1f23d0',
+              name="OpenSSL 1.0.2j",
+              url="https://www.openssl.org/source/openssl-1.0.2j.tar.gz",
+              checksum='96322138f0b69e61b7212bc53d5e912b',
               patches=[
                   "openssl_sdk_makedepend.patch",
                    ],

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -237,9 +237,9 @@ def library_recipes():
 
         result.extend([
           dict(
-              name="OpenSSL 1.0.2g",
-              url="https://www.openssl.org/source/openssl-1.0.2g.tar.gz",
-              checksum='f3c710c045cdee5fd114feb69feba7aa',
+              name="OpenSSL 1.0.2h",
+              url="https://www.openssl.org/source/openssl-1.0.2h.tar.gz",
+              checksum='9392e65072ce4b614c1392eefc1f23d0',
               patches=[
                   "openssl_sdk_makedepend.patch",
                    ],

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -237,9 +237,9 @@ def library_recipes():
 
         result.extend([
           dict(
-              name="OpenSSL 1.0.2j",
-              url="https://www.openssl.org/source/openssl-1.0.2j.tar.gz",
-              checksum='96322138f0b69e61b7212bc53d5e912b',
+              name="OpenSSL 1.0.2k",
+              url="https://www.openssl.org/source/openssl-1.0.2k.tar.gz",
+              checksum='f965fc0bf01bf882b31314b61391ae65',
               patches=[
                   "openssl_sdk_makedepend.patch",
                    ],

--- a/Mac/BuildScript/openssl_sdk_makedepend.patch
+++ b/Mac/BuildScript/openssl_sdk_makedepend.patch
@@ -1,18 +1,17 @@
 # HG changeset patch
-# Parent  ff8a7557607cffd626997e57ed31c1012a3018aa
+# Parent  d377390f787c0739a3e89f669def72d7167e5108
 # openssl_sdk_makedepend.patch
 #
-# 	using openssl 1.0.2e
+# 	using openssl 1.0.2f
 #
 # - support building with an OS X SDK
-# - allow "make depend" to use compilers with names other than "gcc"
 
 diff Configure
 
 diff --git a/Configure b/Configure
 --- a/Configure
 +++ b/Configure
-@@ -635,12 +635,12 @@
+@@ -638,12 +638,12 @@
  
  ##### MacOS X (a.k.a. Rhapsody or Darwin) setup
  "rhapsody-ppc-cc","cc:-O3 -DB_ENDIAN::(unknown):MACOSX_RHAPSODY::BN_LLONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${no_asm}::",
@@ -31,7 +30,7 @@ diff --git a/Configure b/Configure
  "debug-darwin-ppc-cc","cc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -DB_ENDIAN -g -Wall -O::-D_REENTRANT:MACOSX::BN_LLONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${ppc32_asm}:osx32:dlfcn:darwin-shared:-fPIC:-dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
  # iPhoneOS/iOS
  "iphoneos-cross","llvm-gcc:-O3 -isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fomit-frame-pointer -fno-common::-D_REENTRANT:iOS:-Wl,-search_paths_first%:BN_LLONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${no_asm}:dlfcn:darwin-shared:-fPIC -fno-common:-dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
-@@ -1714,8 +1714,7 @@
+@@ -1717,8 +1717,7 @@
  		s/^CC=.*$/CC= $cc/;
  		s/^AR=\s*ar/AR= $ar/;
  		s/^RANLIB=.*/RANLIB= $ranlib/;
@@ -41,16 +40,3 @@ diff --git a/Configure b/Configure
  		}
  	s/^CFLAG=.*$/CFLAG= $cflags/;
  	s/^DEPFLAG=.*$/DEPFLAG=$depflags/;
-diff --git a/util/domd b/util/domd
---- a/util/domd
-+++ b/util/domd
-@@ -14,8 +14,7 @@
- cp Makefile Makefile.save
- # fake the presence of Kerberos
- touch $TOP/krb5.h
--if ${MAKEDEPEND} --version 2>&1 | grep -q "clang" ||
--   echo $MAKEDEPEND | grep -q "gcc"; then
-+if true ; then
-     args=""
-     while [ $# -gt 0 ]; do
- 	if [ "$1" != "--" ]; then args="$args $1"; fi

--- a/Mac/BuildScript/openssl_sdk_makedepend.patch
+++ b/Mac/BuildScript/openssl_sdk_makedepend.patch
@@ -1,8 +1,6 @@
 # HG changeset patch
-# Parent  d377390f787c0739a3e89f669def72d7167e5108
-# openssl_sdk_makedepend.patch
 #
-# 	using openssl 1.0.2f
+# 	using openssl 1.0.2j
 #
 # - support building with an OS X SDK
 
@@ -11,7 +9,7 @@ diff Configure
 diff --git a/Configure b/Configure
 --- a/Configure
 +++ b/Configure
-@@ -638,12 +638,12 @@
+@@ -642,12 +642,12 @@
  
  ##### MacOS X (a.k.a. Rhapsody or Darwin) setup
  "rhapsody-ppc-cc","cc:-O3 -DB_ENDIAN::(unknown):MACOSX_RHAPSODY::BN_LLONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${no_asm}::",
@@ -30,13 +28,13 @@ diff --git a/Configure b/Configure
  "debug-darwin-ppc-cc","cc:-DBN_DEBUG -DREF_CHECK -DCONF_DEBUG -DCRYPTO_MDEBUG -DB_ENDIAN -g -Wall -O::-D_REENTRANT:MACOSX::BN_LLONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${ppc32_asm}:osx32:dlfcn:darwin-shared:-fPIC:-dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
  # iPhoneOS/iOS
  "iphoneos-cross","llvm-gcc:-O3 -isysroot \$(CROSS_TOP)/SDKs/\$(CROSS_SDK) -fomit-frame-pointer -fno-common::-D_REENTRANT:iOS:-Wl,-search_paths_first%:BN_LLONG RC4_CHAR RC4_CHUNK DES_UNROLL BF_PTR:${no_asm}:dlfcn:darwin-shared:-fPIC -fno-common:-dynamiclib:.\$(SHLIB_MAJOR).\$(SHLIB_MINOR).dylib",
-@@ -1717,8 +1717,7 @@
- 		s/^CC=.*$/CC= $cc/;
+@@ -1728,8 +1728,7 @@
  		s/^AR=\s*ar/AR= $ar/;
  		s/^RANLIB=.*/RANLIB= $ranlib/;
+ 		s/^RC=.*/RC= $windres/;
 -		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= $cc/ if $cc eq "gcc";
 -		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= $cc/ if $ecc eq "gcc" || $ecc eq "clang";
-+		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= $cc/
++		s/^MAKEDEPPROG=.*$/MAKEDEPPROG= $cc/;
  		}
  	s/^CFLAG=.*$/CFLAG= $cflags/;
  	s/^DEPFLAG=.*$/DEPFLAG=$depflags/;

--- a/Mac/BuildScript/openssl_sdk_makedepend.patch
+++ b/Mac/BuildScript/openssl_sdk_makedepend.patch
@@ -1,6 +1,6 @@
 # HG changeset patch
 #
-# 	using openssl 1.0.2j
+# 	using openssl 1.0.2k
 #
 # - support building with an OS X SDK
 

--- a/Misc/NEWS.d/next/Build/2017-09-07-19-26-26.bpo-26268.1Duz_M.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-07-19-26-26.bpo-26268.1Duz_M.rst
@@ -1,0 +1,1 @@
+Update OS X 10.5 installer to use OpenSSL 1.0.2f.

--- a/Misc/NEWS.d/next/Build/2017-09-07-19-30-45.bpo-26465.PhUgmq.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-07-19-30-45.bpo-26465.PhUgmq.rst
@@ -1,0 +1,2 @@
+Update OS X 10.5+ 32-bit-only installer to build and link with OpenSSL
+1.0.2g.

--- a/Misc/NEWS.d/next/Build/2017-09-07-19-31-38.bpo-26930.Z3eeRH.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-07-19-31-38.bpo-26930.Z3eeRH.rst
@@ -1,0 +1,2 @@
+Update OS X 10.5+ 32-bit-only installer to build and link with OpenSSL
+1.0.2h.

--- a/Misc/NEWS.d/next/Build/2017-09-07-19-32-39.bpo-28248.KY_-en.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-07-19-32-39.bpo-28248.KY_-en.rst
@@ -1,0 +1,1 @@
+Update Windows build and OS X installers to use OpenSSL 1.0.2j.


### PR DESCRIPTION
* bpo-26268: Update OS X 10.5+ installer build to use OpenSSL 1.0.2f.
* bpo-26465: Update OS X installer build to use OpenSSL 1.0.2g.
* bpo-26930: Update OS X 32-bit-only installer builds to use OpenSSL 1.0.2h.
* bpo-28248: Update macOS installer build to use OpenSSL 1.0.2j. Original patch by Mariatta Wijaya.
* bpo-29572: Update macOS installer build to OpenSSL 1.0.2k (#457) (#2835)


<!-- issue-number: bpo-29572 -->
https://bugs.python.org/issue29572
<!-- /issue-number -->
