### PR TITLE
bpo-31657: add test coverage for the __debug__ case (optimization levels)

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -328,19 +328,22 @@ class BuiltinTest(unittest.TestCase):
 
         codestr = '''def f():
         """doc"""
+        debug_enabled = False
+        if __debug__:
+            debug_enabled = True
         try:
             assert False
         except AssertionError:
-            return (True, f.__doc__)
+            return (True, f.__doc__, debug_enabled)
         else:
-            return (False, f.__doc__)
+            return (False, f.__doc__, debug_enabled)
         '''
         def f(): """doc"""
-        values = [(-1, __debug__, f.__doc__),
-                  (0, True, 'doc'),
-                  (1, False, 'doc'),
-                  (2, False, None)]
-        for optval, debugval, docstring in values:
+        values = [(-1, __debug__, f.__doc__, __debug__),
+                  (0, True, 'doc', True),
+                  (1, False, 'doc', False),
+                  (2, False, None, False)]
+        for optval, assertval, docstring, debugval in values:
             # test both direct compilation and compilation via AST
             codeobjs = []
             codeobjs.append(compile(codestr, "<test>", "exec", optimize=optval))
@@ -350,7 +353,7 @@ class BuiltinTest(unittest.TestCase):
                 ns = {}
                 exec(code, ns)
                 rv = ns['f']()
-                self.assertEqual(rv, (debugval, docstring))
+                self.assertEqual(rv, (assertval, docstring, debugval))
 
     def test_delattr(self):
         sys.spam = 1


### PR DESCRIPTION
This is a trivial patch in a larger series of patches related to optimization levels, but this change doesn't depend on that work, so I'm submitting it independently.

- Summary:

------------

```

There are currently three supported optimization levels (0, 1, and
2). Briefly summarized, they do the following.

    0: no optimizations
    1: remove assert statements and __debug__ blocks
    2: remove docstrings, assert statements, and __debug__ blocks

The current compile() tests for optimization levels in
Lib/test/test_builtin.py covers the assert and docstring cases,
but it doesn't test that __debug__ code blocks are included or
excluded based on the optimization level.

For example, if you change Python/compile.c to always include
__debug__ blocks regardless of the optimization level, the
existing compile() tests will continue to pass.

$ git diff Python/compile.c
diff --git a/Python/compile.c b/Python/compile.c
index 280ddc39e3..d65df098bb 100644
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4143,7 +4143,7 @@ expr_constant(struct compiler *c, expr_ty e)
         /* optimize away names that can't be reassigned */
         id = PyUnicode_AsUTF8(e->v.Name.id);
         if (id && strcmp(id, "__debug__") == 0)
-            return !c->c_optimize;
+            return 1;
         return -1;
     case NameConstant_kind: {
         PyObject *o = e->v.NameConstant.value;

This patch updates the compile tests in test_builtin.py to also
check that __debug__ blocks are included or excluded based on the
optimization level. It also renames debugval to assertval because
that value indicates whether or not an assert was raised. Based on
the following note from Misc/HISTORY, I suspect that's just a
holdover from when the two were more conflated.

Misc/HISTORY:

- The assert statement no longer tests __debug__ at runtime.  This
  means that assert statements cannot be disabled by assigning a
  false value to __debug__.

The -1 test case (optimization level of your current interpreter)
still conflates the two by relying on value of __debug__ in the
assert case, but that predates me and this patch for the
__debug__ case ;)

    (-1, __debug__, f.__doc__, __debug__)
```

--------------

- Let me know if you want a bug created for this or if the trivial prefix is enough.

Thanks for your time!

<!-- issue-number: bpo-31657 -->
https://bugs.python.org/issue31657
<!-- /issue-number -->
