### PR TITLE
bpo-28638: Optimize namedtuple() creation time by minimizing use of exec()

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -804,7 +804,7 @@ they add the ability to access fields by name instead of position index.
 
     .. versionchanged:: 3.7
        Remove the *verbose* parameter and the :attr:`_source` attribute.
-       
+
 .. doctest::
     :options: +NORMALIZE_WHITESPACE
 

--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -763,7 +763,7 @@ Named tuples assign meaning to each position in a tuple and allow for more reada
 self-documenting code.  They can be used wherever regular tuples are used, and
 they add the ability to access fields by name instead of position index.
 
-.. function:: namedtuple(typename, field_names, *, verbose=False, rename=False, module=None)
+.. function:: namedtuple(typename, field_names, *, rename=False, module=None)
 
     Returns a new tuple subclass named *typename*.  The new subclass is used to
     create tuple-like objects that have fields accessible by attribute lookup as
@@ -786,10 +786,6 @@ they add the ability to access fields by name instead of position index.
     converted to ``['abc', '_1', 'ghi', '_3']``, eliminating the keyword
     ``def`` and the duplicate fieldname ``abc``.
 
-    If *verbose* is true, the class definition is printed after it is
-    built.  This option is outdated; instead, it is simpler to print the
-    :attr:`_source` attribute.
-
     If *module* is defined, the ``__module__`` attribute of the named tuple is
     set to that value.
 
@@ -806,6 +802,9 @@ they add the ability to access fields by name instead of position index.
     .. versionchanged:: 3.6
        Added the *module* parameter.
 
+    .. versionchanged:: 3.7
+       Remove the *verbose* parameter and the :attr:`_source` attribute.
+       
 .. doctest::
     :options: +NORMALIZE_WHITESPACE
 
@@ -877,15 +876,6 @@ field names, the method and attribute names start with an underscore.
 
         >>> for partnum, record in inventory.items():
         ...     inventory[partnum] = record._replace(price=newprices[partnum], timestamp=time.now())
-
-.. attribute:: somenamedtuple._source
-
-    A string with the pure Python source code used to create the named
-    tuple class.  The source makes the named tuple self-documenting.
-    It can be printed, executed using :func:`exec`, or saved to a file
-    and imported.
-
-    .. versionadded:: 3.3
 
 .. attribute:: somenamedtuple._fields
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -435,6 +435,12 @@ API and Feature Removals
   Python 3.1, and has now been removed.  Use the :func:`~os.path.splitdrive`
   function instead.
 
+* :func:`collections.namedtuple` no longer supports the *verbose* parameter
+  or ``_source`` attribute which showed the generated source code for the
+  named tuple class.  This was part of an optimization designed to speed-up
+  class creation.  (Contributed by Jelle Zijlstra with further improvements
+  by INADA Naoki, Serhiy Storchaka, and Raymond Hettinger in :issue:`28638`.)
+
 * Functions :func:`bool`, :func:`float`, :func:`list` and :func:`tuple` no
   longer take keyword arguments.  The first argument of :func:`int` can now
   be passed only as positional argument.

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -357,7 +357,7 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
             raise ValueError('Field names cannot start with an underscore: '
                              f'{name!r}')
         if name in seen:
-            raise ValueError('Encountered duplicate field name: {name!r}')
+            raise ValueError(f'Encountered duplicate field name: {name!r}')
         seen.add(name)
 
     # Variables used in the methods and docstrings

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -301,58 +301,6 @@ except ImportError:
 ### namedtuple
 ################################################################################
 
-_class_template = """\
-from builtins import property as _property, tuple as _tuple
-from operator import itemgetter as _itemgetter
-from collections import OrderedDict
-
-class {typename}(tuple):
-    '{typename}({arg_list})'
-
-    __slots__ = ()
-
-    _fields = {field_names!r}
-
-    def __new__(_cls, {arg_list}):
-        'Create new instance of {typename}({arg_list})'
-        return _tuple.__new__(_cls, ({arg_list}))
-
-    @classmethod
-    def _make(cls, iterable, new=tuple.__new__, len=len):
-        'Make a new {typename} object from a sequence or iterable'
-        result = new(cls, iterable)
-        if len(result) != {num_fields:d}:
-            raise TypeError('Expected {num_fields:d} arguments, got %d' % len(result))
-        return result
-
-    def _replace(_self, **kwds):
-        'Return a new {typename} object replacing specified fields with new values'
-        result = _self._make(map(kwds.pop, {field_names!r}, _self))
-        if kwds:
-            raise ValueError('Got unexpected field names: %r' % list(kwds))
-        return result
-
-    def __repr__(self):
-        'Return a nicely formatted representation string'
-        return self.__class__.__name__ + '({repr_fmt})' % self
-
-    def _asdict(self):
-        'Return a new OrderedDict which maps field names to their values.'
-        return OrderedDict(zip(self._fields, self))
-
-    def __getnewargs__(self):
-        'Return self as a plain tuple.  Used by copy and pickle.'
-        return tuple(self)
-
-{field_defs}
-"""
-
-_repr_template = '{name}=%r'
-
-_field_template = '''\
-    {name} = _property(_itemgetter({index:d}), doc='Alias for field number {index:d}')
-'''
-
 def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None):
     """Returns a new subclass of tuple with named fields.
 
@@ -410,26 +358,71 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
             raise ValueError('Encountered duplicate field name: %r' % name)
         seen.add(name)
 
-    # Fill-in the class template
-    class_definition = _class_template.format(
-        typename = typename,
-        field_names = tuple(field_names),
-        num_fields = len(field_names),
-        arg_list = repr(tuple(field_names)).replace("'", "")[1:-1],
-        repr_fmt = ', '.join(_repr_template.format(name=name)
-                             for name in field_names),
-        field_defs = '\n'.join(_field_template.format(index=index, name=name)
-                               for index, name in enumerate(field_names))
-    )
+    # Closure variables used in the methods and docstrings
+    field_names = tuple(field_names)
+    num_fields = len(field_names)
+    arg_list = repr(field_names).replace("'", "")[1:-1]
+    repr_fmt = '(' + ', '.join(f'{name}=%r' for name in field_names) + ')'
+    tuple_new = tuple.__new__
+    _len = len
 
-    # Execute the template string in a temporary namespace and support
-    # tracing utilities by setting a value for frame.f_globals['__name__']
-    namespace = dict(__name__='namedtuple_%s' % typename)
-    exec(class_definition, namespace)
-    result = namespace[typename]
-    result._source = class_definition
-    if verbose:
-        print(result._source)
+    # Create all the named tuple methods to be added to the class namespace
+
+    def create_new():
+        s = f'def __new__(_cls, {arg_list}): return _tuple.__new__(_cls, ({arg_list}))'
+        namespace = dict(_tuple=tuple, __name__=f'namedtuple_{typename}')
+        exec(s, namespace)
+        __new__ = namespace['__new__']
+        __new__.__doc__ = f'Create new instance of {typename}({arg_list})'
+        return __new__
+
+    def create_make():
+        def _make(cls, iterable):
+            result = tuple_new(cls, iterable)
+            if _len(result) != num_fields:
+                raise TypeError(f'Expected {num_fields:d} arguments, got {len(result)}')
+            return result
+        _make.__doc__ = f'Make a new {typename} object from a sequence or iterable'
+        return classmethod(_make)
+
+    def create_replace():
+        def _replace(_self, **kwds):
+            result = _self._make(map(kwds.pop, field_names, _self))
+            if kwds:
+                raise ValueError(f'Got unexpected field names: {list(kwds)!r}')
+            return result
+        _replace.__doc__ = f'Return a new {typename} object replacing specified fields with new values'
+        return _replace
+
+    def __repr__(self):
+        'Return a nicely formatted representation string'
+        return self.__class__.__name__ + repr_fmt % self
+
+    def _asdict(self):
+        'Return a new OrderedDict which maps field names to their values.'
+        return OrderedDict(zip(self._fields, self))
+
+    def __getnewargs__(self):
+        'Return self as a plain tuple.  Used by copy and pickle.'
+        return tuple(self)
+
+    # Build-up the class namespace dictionary
+    # and use type() to build the result class
+    class_namespace = dict(
+        __slots__ = (),
+        __doc__ = f'{typename}({arg_list})',
+        _fields = field_names,
+        __new__ = create_new(),
+        _make = create_make(),
+        _replace = create_replace(),
+        __repr__ = __repr__,
+        _asdict = _asdict,
+        __getnewargs__ = __getnewargs__,
+    )
+    for index, name in enumerate(field_names):
+        class_namespace[name] = property(fget=_itemgetter(index),
+                                         doc=f'Alias for field number {index:d}')
+    result = type(typename, (tuple,), class_namespace)
 
     # For pickling to work, the __module__ variable needs to be set to the frame
     # where the named tuple is created.  Bypass this step in environments where

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -371,8 +371,8 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
     # Create all the named tuple methods to be added to the class namespace
 
     def create_new():
-        s = f'def __new__(_cls, {arg_list}): return _tuple.__new__(_cls, ({arg_list}))'
-        namespace = dict(_tuple=tuple, __name__=f'namedtuple_{typename}')
+        s = f'def __new__(_cls, {arg_list}): return _tuple_new(_cls, ({arg_list}))'
+        namespace = dict(_tuple_new=tuple_new, __name__=f'namedtuple_{typename}')
         exec(s, namespace)
         __new__ = namespace['__new__']
         __new__.__doc__ = f'Create new instance of {typename}({arg_list})'

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -303,7 +303,7 @@ except ImportError:
 
 _nt_itemgetters = {}
 
-def namedtuple(typename, field_names, *, verbose=False, rename=False, module=None):
+def namedtuple(typename, field_names, *, rename=False, module=None):
     """Returns a new subclass of tuple with named fields.
 
     >>> Point = namedtuple('Point', ['x', 'y'])
@@ -385,7 +385,8 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
             raise TypeError(f'Expected {num_fields} arguments, got {len(result)}')
         return result
 
-    _make.__doc__ = f'Make a new {typename} object from a sequence or iterable'
+    _make.__func__.__doc__ = (f'Make a new {typename} object from a sequence '
+                              'or iterable')
 
     def _replace(_self, **kwds):
         result = _self._make(map(kwds.pop, field_names, _self))

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -361,7 +361,7 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
         seen.add(name)
 
     # Variables used in the methods and docstrings
-    field_names = tuple(field_names)
+    field_names = tuple(map(_sys.intern, field_names))
     num_fields = len(field_names)
     arg_list = repr(field_names).replace("'", "")[1:-1]
     repr_fmt = '(' + ', '.join(f'{name}=%r' for name in field_names) + ')'

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -430,10 +430,11 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
     cache = _nt_itemgetters
     for index, name in enumerate(field_names):
         try:
-            itemgetter_object = cache[index]
+            itemgetter_object, doc = cache[index]
         except KeyError:
-            itemgetter_object = cache[index] = _itemgetter(index)
-        doc = _sys.intern(f'Alias for field number {index}')
+            itemgetter_object = _itemgetter(index)
+            doc = f'Alias for field number {index}'
+            cache[index] = itemgetter_object, doc
         class_namespace[name] = property(itemgetter_object, doc=doc)
 
     result = type(typename, (tuple,), class_namespace)

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -411,11 +411,12 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
 
     # Modify function metadata to help with introspection and debugging
 
-    for method in (__new__, _make.__func__, _replace, __repr__, _asdict, __getnewargs__):
+    for method in (__new__, _make.__func__, _replace,
+                   __repr__, _asdict, __getnewargs__):
         method.__module__ = module_name
         method.__qualname__ = f'{typename}.{method.__name__}'
 
-    # Helper functions used in the class creation
+    # Helper function used in the class creation
 
     def reuse_itemgetter(index):
         try:

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -365,14 +365,13 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
     num_fields = len(field_names)
     arg_list = repr(field_names).replace("'", "")[1:-1]
     repr_fmt = '(' + ', '.join(f'{name}=%r' for name in field_names) + ')'
-    module_name = f'namedtuple_{typename}'
     tuple_new = tuple.__new__
     _len = len
 
     # Create all the named tuple methods to be added to the class namespace
 
     s = f'def __new__(_cls, {arg_list}): return _tuple_new(_cls, ({arg_list}))'
-    namespace = {'_tuple_new': tuple_new, '__name__': module_name}
+    namespace = {'_tuple_new': tuple_new, '__name__': f'namedtuple_{typename}'}
     # Note: exec() has the side-effect of interning the typename and field names
     exec(s, namespace)
     __new__ = namespace['__new__']
@@ -413,7 +412,6 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
 
     for method in (__new__, _make.__func__, _replace,
                    __repr__, _asdict, __getnewargs__):
-        method.__module__ = module_name
         method.__qualname__ = f'{typename}.{method.__name__}'
 
     # Helper function used in the class creation

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -416,12 +416,12 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
 
     # Helper function used in the class creation
 
-    def reuse_itemgetter(index):
+    def reuse_itemgetter(index, cache=_nt_itemgetters):
         try:
-            return _nt_itemgetters[index]
+            return cache[index]
         except KeyError:
-            getter = _nt_itemgetters[index] = _itemgetter(index)
-            return getter
+            itemgetter_object = cache[index] = _itemgetter(index)
+            return itemgetter_object
 
     # Build-up the class namespace dictionary
     # and use type() to build the result class

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -408,6 +408,12 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
         'Return self as a plain tuple.  Used by copy and pickle.'
         return tuple(self)
 
+    # Modify function metadata to help with introspection and debugging
+
+    for method in (__new__, _make.__func__, _replace, __repr__, _asdict, __getnewargs__):
+        method.__module__ = module_name
+        method.__qualname__ = f'{typename}.{method.__name__}'
+
     # Helper functions used in the class creation
 
     def reuse_itemgetter(index):

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -372,7 +372,7 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
     # Create all the named tuple methods to be added to the class namespace
 
     s = f'def __new__(_cls, {arg_list}): return _tuple_new(_cls, ({arg_list}))'
-    namespace = dict(_tuple_new=tuple_new, __name__=module_name)
+    namespace = {'_tuple_new': tuple_new, '__name__': module_name}
     # Note: exec() has the side-effect of interning the typename and field names
     exec(s, namespace)
     __new__ = namespace['__new__']
@@ -427,17 +427,17 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
 
     # Build-up the class namespace dictionary
     # and use type() to build the result class
-    class_namespace = dict(
-        __doc__ = f'{typename}({arg_list})',
-        __slots__ = (),
-        _fields = field_names,
-        __new__ = __new__,
-        _make = _make,
-        _replace = _replace,
-        __repr__ = __repr__,
-        _asdict = _asdict,
-        __getnewargs__ = __getnewargs__,
-    )
+    class_namespace = {
+        '__doc__': f'{typename}({arg_list})',
+        '__slots__': (),
+        '_fields': field_names,
+        '__new__': __new__,
+        '_make': _make,
+        '_replace': _replace,
+        '__repr__': __repr__,
+        '_asdict': _asdict,
+        '__getnewargs__': __getnewargs__,
+    }
     for index, name in enumerate(field_names):
         doc = _sys.intern(f'Alias for field number {index}')
         class_namespace[name] = property(reuse_itemgetter(index), doc=doc)

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -429,11 +429,11 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
     }
     cache = _nt_itemgetters
     for index, name in enumerate(field_names):
-        doc = _sys.intern(f'Alias for field number {index}')
         try:
             itemgetter_object = cache[index]
         except KeyError:
             itemgetter_object = cache[index] = _itemgetter(index)
+        doc = _sys.intern(f'Alias for field number {index}')
         class_namespace[name] = property(itemgetter_object, doc=doc)
 
     result = type(typename, (tuple,), class_namespace)

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -438,7 +438,7 @@ def namedtuple(typename, field_names, *, rename=False, module=None):
         __getnewargs__ = __getnewargs__,
     )
     for index, name in enumerate(field_names):
-        doc = f'Alias for field number {index}'
+        doc = _sys.intern(f'Alias for field number {index}')
         class_namespace[name] = property(reuse_itemgetter(index), doc=doc)
 
     result = type(typename, (tuple,), class_namespace)

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -373,6 +373,7 @@ def namedtuple(typename, field_names, *, verbose=False, rename=False, module=Non
     def create_new():
         s = f'def __new__(_cls, {arg_list}): return _tuple_new(_cls, ({arg_list}))'
         namespace = dict(_tuple_new=tuple_new, __name__=f'namedtuple_{typename}')
+        # Note: exec() has the side-effect of interning the typename and field names
         exec(s, namespace)
         __new__ = namespace['__new__']
         __new__.__doc__ = f'Create new instance of {typename}({arg_list})'

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -194,7 +194,6 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(Point.__module__, __name__)
         self.assertEqual(Point.__getitem__, tuple.__getitem__)
         self.assertEqual(Point._fields, ('x', 'y'))
-        #self.assertIn('class Point(tuple)', Point._source)
 
         self.assertRaises(ValueError, namedtuple, 'abc%', 'efg ghi')       # type has non-alpha char
         self.assertRaises(ValueError, namedtuple, 'class', 'efg ghi')      # type has keyword
@@ -367,8 +366,7 @@ class TestNamedTuple(unittest.TestCase):
         self.assertEqual(newt, (10,20,30,40,50))
 
     def test_repr(self):
-        with support.captured_stdout() as template:
-            A = namedtuple('A', 'x', verbose=True)
+        A = namedtuple('A', 'x')
         self.assertEqual(repr(A(1)), 'A(x=1)')
         # repr should show the name of the subclass
         class B(A):

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -365,6 +365,61 @@ class TestNamedTuple(unittest.TestCase):
         newt = t._replace(itemgetter=10, property=20, self=30, cls=40, tuple=50)
         self.assertEqual(newt, (10,20,30,40,50))
 
+       # Broader test of all interesting names taken from the code, old
+       # template, and an example
+        words = {'Alias', 'At', 'AttributeError', 'Build', 'Bypass', 'Create',
+        'Encountered', 'Expected', 'Field', 'For', 'Got', 'Helper',
+        'IronPython', 'Jython', 'KeyError', 'Make', 'Modify', 'Note',
+        'OrderedDict', 'Point', 'Return', 'Returns', 'Type', 'TypeError',
+        'Used', 'Validate', 'ValueError', 'Variables', 'a', 'accessible', 'add',
+        'added', 'all', 'also', 'an', 'arg_list', 'args', 'arguments',
+        'automatically', 'be', 'build', 'builtins', 'but', 'by', 'cannot',
+        'class_namespace', 'classmethod', 'cls', 'collections', 'convert',
+        'copy', 'created', 'creation', 'd', 'debugging', 'defined', 'dict',
+        'dictionary', 'doc', 'docstring', 'docstrings', 'duplicate', 'effect',
+        'either', 'enumerate', 'environments', 'error', 'example', 'exec', 'f',
+        'f_globals', 'field', 'field_names', 'fields', 'formatted', 'frame',
+        'function', 'functions', 'generate', 'get', 'getter', 'got', 'greater',
+        'has', 'help', 'identifiers', 'index', 'indexable', 'instance',
+        'instantiate', 'interning', 'introspection', 'isidentifier',
+        'isinstance', 'itemgetter', 'iterable', 'join', 'keyword', 'keywords',
+        'kwds', 'len', 'like', 'list', 'map', 'maps', 'message', 'metadata',
+        'method', 'methods', 'module', 'module_name', 'must', 'name', 'named',
+        'namedtuple', 'namedtuple_', 'names', 'namespace', 'needs', 'new',
+        'nicely', 'num_fields', 'number', 'object', 'of', 'operator', 'option',
+        'p', 'particular', 'pickle', 'pickling', 'plain', 'pop', 'positional',
+        'property', 'r', 'regular', 'rename', 'replace', 'replacing', 'repr',
+        'repr_fmt', 'representation', 'result', 'reuse_itemgetter', 's', 'seen',
+        'self', 'sequence', 'set', 'side', 'specified', 'split', 'start',
+        'startswith', 'step', 'str', 'string', 'strings', 'subclass', 'sys',
+        'targets', 'than', 'the', 'their', 'this', 'to', 'tuple', 'tuple_new',
+        'type', 'typename', 'underscore', 'unexpected', 'unpack', 'up', 'use',
+        'used', 'user', 'valid', 'values', 'variable', 'verbose', 'where',
+        'which', 'work', 'x', 'y', 'z', 'zip'}
+        T = namedtuple('T', words)
+        # test __new__
+        values = tuple(range(len(words)))
+        t = T(*values)
+        self.assertEqual(t, values)
+        t = T(**dict(zip(T._fields, values)))
+        self.assertEqual(t, values)
+        # test _make
+        t = T._make(values)
+        self.assertEqual(t, values)
+        # exercise __repr__
+        repr(t)
+        # test _asdict
+        self.assertEqual(t._asdict(), dict(zip(T._fields, values)))
+        # test _replace
+        t = T._make(values)
+        newvalues = tuple(v*10 for v in values)
+        newt = t._replace(**dict(zip(T._fields, newvalues)))
+        self.assertEqual(newt, newvalues)
+        # test _fields
+        self.assertEqual(T._fields, tuple(words))
+        # test __getnewargs__
+        self.assertEqual(t.__getnewargs__(), values)
+
     def test_repr(self):
         A = namedtuple('A', 'x')
         self.assertEqual(repr(A(1)), 'A(x=1)')

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -428,6 +428,16 @@ class TestNamedTuple(unittest.TestCase):
             pass
         self.assertEqual(repr(B(1)), 'B(x=1)')
 
+    def test_keyword_only_arguments(self):
+        # See issue 25628
+        with self.assertRaises(TypeError):
+            NT = namedtuple('NT', ['x', 'y'], True)
+
+        NT = namedtuple('NT', ['abc', 'def'], rename=True)
+        self.assertEqual(NT._fields, ('abc', '_1'))
+        with self.assertRaises(TypeError):
+            NT = namedtuple('NT', ['abc', 'def'], False, True)
+
     def test_namedtuple_subclass_issue_24931(self):
         class Point(namedtuple('_Point', ['x', 'y'])):
             pass

--- a/Misc/NEWS.d/next/Library/2017-09-08-14-31-15.bpo-28638.lfbVyH.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-08-14-31-15.bpo-28638.lfbVyH.rst
@@ -1,0 +1,9 @@
+Changed the implementation strategy for collections.namedtuple() to
+substantially reduce the use of exec() in favor of precomputed methods. As a
+result, the *verbose* parameter and *_source* attribute are no longer
+supported.  The benefits include 1) having a smaller memory footprint for
+applications using multiple named tuples, 2) faster creation of the named
+tuple class (approx 4x to 6x depending on how it is measured), and 3) minor
+speed-ups for instance creation using __new__, _make, and _replace.  (The
+primary patch contributor is Jelle Zijlstra with further improvements by
+INADA Naoki, Serhiy Storchaka, and Raymond Hettinger.)


### PR DESCRIPTION
Current version passes tests but doesn't not support the _source attribute or the verbose option.

Obtains a 5x creation time speed-up and with small positive impacts on post creation performance.

=============== Baseline ===============
Cumulative time over 10,000 iterations:
     0.044  arg_checking
     0.238  templating
     2.907  exec
     3.257  all
Total with call overhead: 3.270 seconds

===== This verion ======
Cumulative time over 10,000 iterations:
     0.073  arg_checking
     0.306  template_and_exec
     0.207  non_exec
     0.626  all
Total with call overhead: 0.639 seconds

Ideas going forward
--------------------
* Cache the itemgetter instances
* Generate _source dynamically
* Need to compare to Jelle's patch

<!-- issue-number: bpo-28638 -->
https://bugs.python.org/issue28638
<!-- /issue-number -->
