### PR TITLE
bpo-25404: SSLContext.load_dh_params() non-ASCII path

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -14,7 +14,7 @@ import gc
 import os
 import errno
 import pprint
-import tempfile
+import shutil
 import urllib2
 import traceback
 import weakref
@@ -1000,6 +1000,10 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(cm.exception.errno, errno.ENOENT)
         with self.assertRaises(ssl.SSLError) as cm:
             ctx.load_dh_params(CERTFILE)
+        with support.temp_dir() as d:
+            fname = os.path.join(d, u'dhpäräm.pem')
+            shutil.copy(DHFILE, fname)
+            ctx.load_dh_params(fname)
 
     @skip_if_broken_ubuntu_ssl
     def test_session_stats(self):

--- a/Misc/NEWS.d/next/Library/2017-09-08-11-04-10.bpo-25404.pXetCl.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-08-11-04-10.bpo-25404.pXetCl.rst
@@ -1,0 +1,1 @@
+SSLContext.load_dh_params() now supports non-ASCII path.


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-25404 -->
https://bugs.python.org/issue25404
<!-- /issue-number -->
