### PR TITLE
delete dead locale initialization code for windows

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -264,11 +264,7 @@ error:
 static char*
 get_locale_encoding(void)
 {
-#ifdef MS_WINDOWS
-    char codepage[100];
-    PyOS_snprintf(codepage, sizeof(codepage), "cp%d", GetACP());
-    return get_codec_name(codepage);
-#elif defined(HAVE_LANGINFO_H) && defined(CODESET)
+#if defined(HAVE_LANGINFO_H) && defined(CODESET)
     char* codeset = nl_langinfo(CODESET);
     if (!codeset || codeset[0] == '\0') {
         PyErr_SetString(PyExc_ValueError, "CODESET is not set or empty");


### PR DESCRIPTION
This function is never called on Windows anymore.
