### PR TITLE
bpo-31399: Let OpenSSL verify hostname and IP address

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -146,9 +146,10 @@ Functions, Constants, and Exceptions
 
 .. exception:: CertificateError
 
-   Raised to signal an error with a certificate (such as mismatching
-   hostname).  Certificate errors detected by OpenSSL, though, raise
-   an :exc:`SSLCertVerificationError`.
+   An alias for :exc:`SSLCertVerificationError`.
+
+   .. versionchanged:: 3.7
+      The exception is now an alias for :exc:`SSLCertVerificationError`.
 
 
 Socket creation

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -593,26 +593,6 @@ Constants
    be passed, either to :meth:`SSLContext.load_verify_locations` or as a
    value of the ``ca_certs`` parameter to :func:`wrap_socket`.
 
-.. class:: HostFlags
-
-   :class:`enum.IntFlag` collection of all hostname verification flags for
-   :attr:`SSLContext.host_flags`
-
-   .. versionadded:: 3.7
-
-.. attribute:: HostFlags.HOSTFLAG_NO_PARTIAL_WILDCARDS
-
-   Dont' support wildcard certificate with partial matches, e.g.
-   ``www*.example.org``.
-
-.. attribute:: HostFlags.HOSTFLAG_NEVER_CHECK_SUBJECT
-
-   Ignore subject CN even if the certificate has no subject alternative
-   name extension.
-
-   .. note:: The flag is not available when the ssl module is compiled
-      with OpenSSL 1.0.2 or LibreSSL.
-
 .. class:: VerifyMode
 
    :class:`enum.IntEnum` collection of CERT_* constants.
@@ -876,6 +856,14 @@ Constants
    Protocol Negotiation* TLS extension as described in :rfc:`7301`.
 
    .. versionadded:: 3.5
+
+.. data:: HAS_NEVER_CHECK_COMMON_NAME
+
+   Whether the OpenSSL library has built-in support not checking subject
+   common name and :attr:`SSLContext.hostname_checks_common_name` is
+   writeable.
+
+   .. versionadded:: 3.7
 
 .. data:: HAS_ECDH
 
@@ -1763,12 +1751,16 @@ to speed up repeated connections from the same clients.
    The protocol version chosen when constructing the context.  This attribute
    is read-only.
 
-.. attribute:: SSLContext.host_flags
+.. attribute:: SSLContext.hostname_checks_common_name
 
-   The flags for validating host names. By default
-   :data:`HostFlags.HOSTFLAG_NO_PARTIAL_WILDCARDS` is set.
+   Whether :attr:`~SSLContext.check_hostname` falls back to verify the cert's
+   subject common name in the absence of a subject alternative name
+   extension (default: true).
 
    .. versionadded:: 3.7
+
+   .. note::
+      Only writeable with OpenSSL 1.1.0 or higher.
 
 .. attribute:: SSLContext.verify_flags
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -431,11 +431,12 @@ Certificate handling
       of the certificate, is now supported.
 
    .. versionchanged:: 3.7
-      The function is no longer used. Hostname matching is now performed
-      by OpenSSL.
+      The function is no longer used to TLS connections. Hostname matching
+      is now performed by OpenSSL.
 
       Allow wildcard when it is the leftmost and the only character
-      in that segment.
+      in that segment. Partial wildcards like ``www*.example.com`` are no
+      longer supported.
 
    .. deprecated:: 3.7
 
@@ -599,31 +600,15 @@ Constants
 
    .. versionadded:: 3.7
 
-.. attribute:: HostFlags.HOSTFLAG_ALWAYS_CHECK_SUBJECT
-
-   Consider subject CN even if the certificate contains at least one subject
-   alternative name. This flag violates :rfc:`6125`.
-
-.. attribute:: HostFlags.HOSTFLAG_NO_WILDCARDS
-
-   Don't support wildcard certificate, e.g. ``*.example.org``.
-
 .. attribute:: HostFlags.HOSTFLAG_NO_PARTIAL_WILDCARDS
 
    Dont' support wildcard certificate with partial matches, e.g.
    ``www*.example.org``.
 
-.. attribute:: HostFlags.HOSTFLAG_MULTI_LABEL_WILDCARDS
-
-   Wildcards match multiple labels, e.g. ``www.subdomain.example.org``
-   matches ``*.example.org`` This flag violates :rfc:`6125`.
-
-.. attribute:: HostFlags.HOSTFLAG_SINGLE_LABEL_SUBDOMAINS
-
 .. attribute:: HostFlags.HOSTFLAG_NEVER_CHECK_SUBJECT
 
    Ignore subject CN even if the certificate has no subject alternative
-   names.
+   name extension.
 
    .. note:: The flag is not available when the ssl module is compiled
       with OpenSSL 1.0.2 or LibreSSL.
@@ -1781,8 +1766,7 @@ to speed up repeated connections from the same clients.
 .. attribute:: SSLContext.host_flags
 
    The flags for validating host names. By default
-   :data:`HostFlags.HOSTFLAG_SINGLE_LABEL_SUBDOMAINS` and
-   :data:`HostFlags.HOSTFLAG_NO_PARTIAL_WILDCARDS` are set.
+   :data:`HostFlags.HOSTFLAG_NO_PARTIAL_WILDCARDS` is set.
 
    .. versionadded:: 3.7
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -430,8 +430,13 @@ Certificate handling
       of the certificate, is now supported.
 
    .. versionchanged:: 3.7
+      The function is no longer used. Hostname matching is now performed
+      by OpenSSL.
+
       Allow wildcard when it is the leftmost and the only character
       in that segment.
+
+   .. deprecated:: 3.7
 
 .. function:: cert_time_to_seconds(cert_time)
 
@@ -585,6 +590,42 @@ Constants
    Use of this setting requires a valid set of CA certificates to
    be passed, either to :meth:`SSLContext.load_verify_locations` or as a
    value of the ``ca_certs`` parameter to :func:`wrap_socket`.
+
+.. class:: HostFlags
+
+   :class:`enum.IntFlag` collection of all hostname verification flags for
+   :attr:`SSLContext.host_flags`
+
+   .. versionadded:: 3.7
+
+.. attribute:: HostFlags.HOSTFLAG_ALWAYS_CHECK_SUBJECT
+
+   Consider subject CN even if the certificate contains at least one subject
+   alternative name. This flag violates :rfc:`6125`.
+
+.. attribute:: HostFlags.HOSTFLAG_NO_WILDCARDS
+
+   Don't support wildcard certificate, e.g. ``*.example.org``.
+
+.. attribute:: HostFlags.HOSTFLAG_NO_PARTIAL_WILDCARDS
+
+   Dont' support wildcard certificate with partial matches, e.g.
+   ``www*.example.org``.
+
+.. attribute:: HostFlags.HOSTFLAG_MULTI_LABEL_WILDCARDS
+
+   Wildcards match multiple labels, e.g. ``www.subdomain.example.org``
+   matches ``*.example.org`` This flag violates :rfc:`6125`.
+
+.. attribute:: HostFlags.HOSTFLAG_SINGLE_LABEL_SUBDOMAINS
+
+.. attribute:: HostFlags.HOSTFLAG_NEVER_CHECK_SUBJECT
+
+   Ignore subject CN even if the certificate has no subject alternative
+   names.
+
+   .. note:: The flag is not available when the ssl module is compiled
+      with OpenSSL 1.0.2 or LibreSSL.
 
 .. class:: VerifyMode
 
@@ -1074,6 +1115,12 @@ SSL sockets also have the following additional methods and attributes:
    .. versionchanged:: 3.5
       The socket timeout is no more reset each time bytes are received or sent.
       The socket timeout is now to maximum total duration of the handshake.
+
+   .. versionchanged:: 3.7
+      Hostname or IP address is matched by OpenSSL during handshake. The
+      function :func:`match_hostname` is no longer used. In case OpenSSL
+      refuses a hostname or IP address, the handshake is aborted early and
+      a TLS alert message is send to the peer.
 
 .. method:: SSLSocket.getpeercert(binary_form=False)
 
@@ -1730,6 +1777,14 @@ to speed up repeated connections from the same clients.
    The protocol version chosen when constructing the context.  This attribute
    is read-only.
 
+.. attribute:: SSLContext.host_flags
+
+   The flags for validating host names. By default
+   :data:`HostFlags.HOSTFLAG_SINGLE_LABEL_SUBDOMAINS` and
+   :data:`HostFlags.HOSTFLAG_NO_PARTIAL_WILDCARDS` are set.
+
+   .. versionadded:: 3.7
+
 .. attribute:: SSLContext.verify_flags
 
    The flags for certificate verification operations. You can set flags like
@@ -2323,6 +2378,10 @@ protocols and applications, the service can be identified by the hostname;
 in this case, the :func:`match_hostname` function can be used.  This common
 check is automatically performed when :attr:`SSLContext.check_hostname` is
 enabled.
+
+.. versionchanged:: 3.7
+   Hostname matchings is now performed by OpenSSL. Python no longer uses
+   :func:`match_hostname`.
 
 In server mode, if you want to authenticate your clients using the SSL layer
 (rather than using a higher-level authentication mechanism), you'll also have

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -510,6 +510,32 @@ can be set within the scope of a group.
 ``'^$'`` or ``(?=-)`` that matches an empty string.
 (Contributed by Serhiy Storchaka in :issue:`25054`.)
 
+ssl
+---
+
+The ssl module now uses OpenSSL's builtin API instead of
+:func:`~ssl.match_hostname` to check host name or IP address. Values
+are validated during TLS handshake. Any cert validation error including
+a failing host name match now raises :exc:`~ssl.SSLCertVerificationError` and
+aborts the handshake with a proper TLS Alert message. The new exception
+contains additional information. Host name validation can be customized
+with :attr:`~ssl.SSLContext.host_flags`.
+(Contributed by Christian Heimes in :issue:`31399`.)
+
+.. note::
+   The improved host name check requires an OpenSSL 1.0.2 or 1.1 compatible
+   libssl. OpenSSL 0.9.8 and 1.0.1 are no longer supported. LibreSSL is
+   temporarily not supported until it gains the necessary OpenSSL 1.0.2 APIs.
+
+The ssl module no longer sends IP addresses in SNI TLS extension.
+(Contributed by Christian Heimes in :issue:`32185`.)
+
+:func:`~ssl.match_hostname` no longer supports partial wildcards like
+``www*.example.org``. :attr:`~ssl.SSLContext.host_flags` has partial
+wildcard matching disabled by default.
+(Contributed by Mandeep Singh in :issue:`23033` and Christian Heimes in
+:issue:`31399`.)
+
 string
 ------
 
@@ -1055,6 +1081,12 @@ Other CPython implementation changes
   to exceptions. Instead, the flag must be set (to cause the warnings to be
   emitted in the first place), and an explicit ``error::BytesWarning``
   warnings filter added to convert them to exceptions.
+
+* CPython' :mod:`ssl` module requires OpenSSL 1.0.2 or 1.1 compatible libssl.
+  OpenSSL 1.0.1 has reached end of lifetime on 2016-12-31 and is no longer
+  supported. LibreSSL is temporarily not supported as well. LibreSSL releases
+  up to version 2.6.4 are missing required OpenSSL 1.0.2 APIs.
+
 
 Documentation
 =============

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -590,12 +590,7 @@ class SSLProtocol(protocols.Protocol):
                 raise handshake_exc
 
             peercert = sslobj.getpeercert()
-            if not hasattr(self._sslcontext, 'check_hostname'):
-                # Verify hostname if requested, Python 3.4+ uses check_hostname
-                # and checks the hostname in do_handshake()
-                if (self._server_hostname and
-                        self._sslcontext.verify_mode != ssl.CERT_NONE):
-                    ssl.match_hostname(peercert, self._server_hostname)
+            # Since 3.7, the hostname is matched by OpenSSL during handshake.
         except BaseException as exc:
             if self._loop.get_debug():
                 if isinstance(exc, ssl.CertificateError):

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -590,7 +590,6 @@ class SSLProtocol(protocols.Protocol):
                 raise handshake_exc
 
             peercert = sslobj.getpeercert()
-            # Since 3.7, the hostname is matched by OpenSSL during handshake.
         except BaseException as exc:
             if self._loop.get_debug():
                 if isinstance(exc, ssl.CertificateError):

--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1375,7 +1375,8 @@ else:
             if key_file or cert_file:
                 context.load_cert_chain(cert_file, key_file)
             self._context = context
-            self._check_hostname = check_hostname
+            if check_hostname is not None:
+                self._context.check_hostname = check_hostname
 
         def connect(self):
             "Connect to a host on a given (SSL) port."
@@ -1389,13 +1390,6 @@ else:
 
             self.sock = self._context.wrap_socket(self.sock,
                                                   server_hostname=server_hostname)
-            if not self._context.check_hostname and self._check_hostname:
-                try:
-                    ssl.match_hostname(self.sock.getpeercert(), server_hostname)
-                except Exception:
-                    self.sock.shutdown(socket.SHUT_RDWR)
-                    self.sock.close()
-                    raise
 
     __all__.append("HTTPSConnection")
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -148,6 +148,10 @@ _IntEnum._convert(
     lambda name: name.startswith('CERT_'),
     source=_ssl)
 
+_IntFlag._convert(
+    'HostFlags', __name__,
+    lambda name: name.startswith('HOSTFLAG_'),
+    source=_ssl)
 
 PROTOCOL_SSLv23 = _SSLMethod.PROTOCOL_SSLv23 = _SSLMethod.PROTOCOL_TLS
 _PROTOCOL_NAMES = {value: name for name, value in _SSLMethod.__members__.items()}
@@ -216,9 +220,7 @@ _RESTRICTED_SERVER_CIPHERS = (
     '!aNULL:!eNULL:!MD5:!DSS:!RC4:!3DES'
 )
 
-
-class CertificateError(ValueError):
-    pass
+CertificateError = SSLCertVerificationError
 
 
 def _dnsname_match(dn, hostname):
@@ -472,6 +474,14 @@ class SSLContext(_SSLContext):
     @options.setter
     def options(self, value):
         super(SSLContext, SSLContext).options.__set__(self, value)
+
+    @property
+    def host_flags(self):
+        return HostFlags(super().host_flags)
+
+    @host_flags.setter
+    def host_flags(self, value):
+        super(SSLContext, SSLContext).host_flags.__set__(self, value)
 
     @property
     def verify_flags(self):

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -709,11 +709,6 @@ class SSLObject:
     def do_handshake(self):
         """Start the SSL/TLS handshake."""
         self._sslobj.do_handshake()
-        if self.context.check_hostname:
-            if not self.server_hostname:
-                raise ValueError("check_hostname needs server_hostname "
-                                 "argument")
-            match_hostname(self.getpeercert(), self.server_hostname)
 
     def unwrap(self):
         """Start the SSL shutdown handshake."""

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1148,11 +1148,13 @@ class EventLoopTestsMixin:
             with test_utils.disable_logger():
                 with self.assertRaisesRegex(
                         ssl.CertificateError,
-                        "hostname '127.0.0.1' doesn't match 'localhost'"):
+                        "IP address mismatch, certificate is not valid for "
+                        "'127.0.0.1'"):
                     self.loop.run_until_complete(f_c)
 
         # close connection
-        proto.transport.close()
+        # transport is None because TLS ALERT aborted the handshake
+        self.assertIsNone(proto.transport)
         server.close()
 
     @support.skip_unless_bind_unix_socket

--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -330,6 +330,9 @@ if ssl is not None:
                     return
                 elif err.args[0] == ssl.SSL_ERROR_EOF:
                     return self.handle_close()
+                # TODO: SSLError does not expose alert information
+                elif "SSLV3_ALERT_BAD_CERTIFICATE" in err.args[1]:
+                    return self.handle_close()
                 raise
             except OSError as err:
                 if err.args[0] == errno.ECONNABORTED:

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -485,7 +485,8 @@ class NewIMAPSSLTests(NewIMAPTestsMixin, unittest.TestCase):
         ssl_context.load_verify_locations(CAFILE)
 
         with self.assertRaisesRegex(ssl.CertificateError,
-                "hostname '127.0.0.1' doesn't match 'localhost'"):
+                "IP address mismatch, certificate is not valid for "
+                "'127.0.0.1'"):
             _, server = self._setup(SimpleIMAPHandler)
             client = self.imap_class(*server.server_address,
                                      ssl_context=ssl_context)
@@ -874,7 +875,8 @@ class ThreadedNetworkedTestsSSL(ThreadedNetworkedTests):
 
         with self.assertRaisesRegex(
                 ssl.CertificateError,
-                "hostname '127.0.0.1' doesn't match 'localhost'"):
+                "IP address mismatch, certificate is not valid for "
+                "'127.0.0.1'"):
             with self.reaped_server(SimpleIMAPHandler) as server:
                 client = self.imap_class(*server.server_address,
                                          ssl_context=ssl_context)

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -176,6 +176,9 @@ class DummyPOP3Handler(asynchat.async_chat):
                     return
                 elif err.args[0] == ssl.SSL_ERROR_EOF:
                     return self.handle_close()
+                # TODO: SSLError does not expose alert information
+                elif "SSLV3_ALERT_BAD_CERTIFICATE" in err.args[1]:
+                    return self.handle_close()
                 raise
             except OSError as err:
                 if err.args[0] == errno.ECONNABORTED:

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -988,6 +988,19 @@ class ContextTests(unittest.TestCase):
         self.assertEqual(ctx.verify_mode, ssl.CERT_REQUIRED)
         self.assertTrue(ctx.check_hostname)
 
+    def test_hostname_checks_common_name(self):
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        self.assertTrue(ctx.hostname_checks_common_name)
+        if ssl.HAS_NEVER_CHECK_COMMON_NAME:
+            ctx.hostname_checks_common_name = True
+            self.assertTrue(ctx.hostname_checks_common_name)
+            ctx.hostname_checks_common_name = False
+            self.assertFalse(ctx.hostname_checks_common_name)
+            ctx.hostname_checks_common_name = True
+            self.assertTrue(ctx.hostname_checks_common_name)
+        else:
+            with self.assertRaises(AttributeError):
+                ctx.hostname_checks_common_name = True
 
     @unittest.skipUnless(have_verify_flags(),
                          "verify_flags need OpenSSL > 0.9.8")

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2536,8 +2536,9 @@ class ThreadedTests(unittest.TestCase):
         with server:
             with client_context.wrap_socket(socket.socket(),
                                             server_hostname="invalid") as s:
-                with self.assertRaisesRegex(ssl.CertificateError,
-                                            "hostname 'invalid' doesn't match 'localhost'"):
+                with self.assertRaisesRegex(
+                        ssl.CertificateError,
+                        "Hostname mismatch, certificate is not valid for 'invalid'."):
                     s.connect((HOST, server.port))
 
         # missing server_hostname arg should cause an exception, too

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1511,6 +1511,16 @@ class SSLErrorTests(unittest.TestCase):
             ctx.wrap_bio(ssl.MemoryBIO(), ssl.MemoryBIO(),
                          server_hostname="xn--.com")
 
+    def test_bad_server_hostname(self):
+        ctx = ssl.create_default_context()
+        with self.assertRaises(ValueError):
+            ctx.wrap_bio(ssl.MemoryBIO(), ssl.MemoryBIO(),
+                         server_hostname="")
+        with self.assertRaises(ValueError):
+            ctx.wrap_bio(ssl.MemoryBIO(), ssl.MemoryBIO(),
+                         server_hostname=".example.org")
+
+
 class MemoryBIOTests(unittest.TestCase):
 
     def test_read_write(self):

--- a/Lib/test/test_urllib2_localnet.py
+++ b/Lib/test/test_urllib2_localnet.py
@@ -573,7 +573,7 @@ class TestUrlopen(unittest.TestCase):
                              cafile=CERT_fakehostname)
             # Good cert, but mismatching hostname
             handler = self.start_https_server(certfile=CERT_fakehostname)
-            with self.assertRaises(ssl.CertificateError) as cm:
+            with self.assertRaises(urllib.error.URLError) as cm:
                 self.urlopen("https://localhost:%s/bizarre" % handler.port,
                              cafile=CERT_fakehostname)
 

--- a/Misc/NEWS.d/next/Library/2017-09-08-14-05-33.bpo-31399.FtBrrt.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-08-14-05-33.bpo-31399.FtBrrt.rst
@@ -1,0 +1,1 @@
+Let OpenSSL verify hostname and IP addressw

--- a/Misc/NEWS.d/next/Library/2017-09-08-14-05-33.bpo-31399.FtBrrt.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-08-14-05-33.bpo-31399.FtBrrt.rst
@@ -1,1 +1,4 @@
-Let OpenSSL verify hostname and IP addressw
+The ssl module now uses OpenSSL's X509_VERIFY_PARAM_set1_host() and
+X509_VERIFY_PARAM_set1_ip() API to verify hostname and IP addresses. Subject
+common name fallback can be disabled with
+SSLContext.hostname_checks_common_name.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4185,8 +4185,8 @@ _ssl__SSLContext_get_ca_certs_impl(PySSLContext *self, int binary_form)
 static PyGetSetDef context_getsetlist[] = {
     {"check_hostname", (getter) get_check_hostname,
                        (setter) set_check_hostname, NULL},
-    {"host_flags", (getter) get_host_flags,
-                   (setter) set_host_flags, NULL},
+    {"_host_flags", (getter) get_host_flags,
+                    (setter) set_host_flags, NULL},
     {"options", (getter) get_options,
                 (setter) set_options, NULL},
     {"verify_flags", (getter) get_verify_flags,
@@ -5574,12 +5574,30 @@ PyInit__ssl(void)
                             SSL_OP_NO_COMPRESSION);
 #endif
 
+#ifdef X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
+    PyModule_AddIntConstant(m, "HOSTFLAG_ALWAYS_CHECK_SUBJECT",
+                            X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT);
+#endif
 #ifdef X509_CHECK_FLAG_NEVER_CHECK_SUBJECT
     PyModule_AddIntConstant(m, "HOSTFLAG_NEVER_CHECK_SUBJECT",
                             X509_CHECK_FLAG_NEVER_CHECK_SUBJECT);
 #endif
+#ifdef X509_CHECK_FLAG_NO_WILDCARDS
+    PyModule_AddIntConstant(m, "HOSTFLAG_NO_WILDCARDS",
+                            X509_CHECK_FLAG_NO_WILDCARDS);
+#endif
+#ifdef X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS
     PyModule_AddIntConstant(m, "HOSTFLAG_NO_PARTIAL_WILDCARDS",
                             X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
+#endif
+#ifdef X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS
+    PyModule_AddIntConstant(m, "HOSTFLAG_MULTI_LABEL_WILDCARDS",
+                            X509_CHECK_FLAG_MULTI_LABEL_WILDCARDS);
+#endif
+#ifdef X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS
+    PyModule_AddIntConstant(m, "HOSTFLAG_SINGLE_LABEL_SUBDOMAINS",
+                            X509_CHECK_FLAG_SINGLE_LABEL_SUBDOMAINS);
+#endif
 
 #if HAVE_SNI
     r = Py_True;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -64,10 +64,13 @@ static PySocketModule_APIObject PySocketModule;
 #include "openssl/rand.h"
 #include "openssl/bio.h"
 
-/* Set HAVE_X509_VERIFY_PARAM_SET1_HOST for non-autoconf builds */
 #ifndef HAVE_X509_VERIFY_PARAM_SET1_HOST
-#  if !defined(LIBRESSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER > 0x1000200fL
+#  ifdef LIBRESSL_VERSION_NUMBER
+#    error "LibreSSL is missing X509_VERIFY_PARAM_set1_host(), see https://github.com/libressl-portable/portable/issues/381"
+#  elif OPENSSL_VERSION_NUMBER > 0x1000200fL
 #    define HAVE_X509_VERIFY_PARAM_SET1_HOST
+#  else
+#    error "libssl is too old and does not support X509_VERIFY_PARAM_set1_host()"
 #  endif
 #endif
 
@@ -215,11 +218,6 @@ static int BIO_up_ref(BIO *b)
 
 static STACK_OF(X509_OBJECT) *X509_STORE_get0_objects(X509_STORE *store) {
     return store->objs;
-}
-
-static X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *store)
-{
-    return store->param;
 }
 
 static int

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -687,4 +687,7 @@ Py_NO_ENABLE_SHARED to find out.  Also support MS_NO_COREDLL for b/w compat */
 /* framework name */
 #define _PYTHONFRAMEWORK ""
 
+/* Define if libssl has X509_VERIFY_PARAM_set1_host and related function */
+#define HAVE_X509_VERIFY_PARAM_SET1_HOST 1
+
 #endif /* !Py_CONFIG_H */

--- a/setup.py
+++ b/setup.py
@@ -2157,13 +2157,16 @@ class PyBuildExt(build_ext):
         if krb5_h:
             ssl_incs.extend(krb5_h)
 
-        ssl_ext = Extension(
-            '_ssl', ['_ssl.c'],
-            include_dirs=openssl_includes,
-            library_dirs=openssl_libdirs,
-            libraries=openssl_libs,
-            depends=['socketmodule.h']
-        )
+        if config_vars.get("HAVE_X509_VERIFY_PARAM_SET1_HOST"):
+            ssl_ext = Extension(
+                '_ssl', ['_ssl.c'],
+                include_dirs=openssl_includes,
+                library_dirs=openssl_libdirs,
+                libraries=openssl_libs,
+                depends=['socketmodule.h']
+            )
+        else:
+            ssl_ext = None
 
         hashlib_ext = Extension(
             '_hashlib', ['_hashopenssl.c'],

--- a/setup.py
+++ b/setup.py
@@ -363,6 +363,16 @@ class PyBuildExt(build_ext):
             print_three_column(failed)
             print()
 
+        if any('_ssl' in l
+               for l in (missing, self.failed, self.failed_on_import)):
+            print()
+            print("Could not build the ssl module!")
+            print("Python requires an OpenSSL 1.0.2 or 1.1 compatible "
+                  "libssl with X509_VERIFY_PARAM_set1_host().")
+            print("LibreSSL 2.6.4 and earlier do not provide the necessary "
+                  "APIs, https://github.com/libressl-portable/portable/issues/381")
+            print()
+
     def build_extension(self, ext):
 
         if ext.name == '_ctypes':


### PR DESCRIPTION
Replace Python's custom ssl.match_hostname() with OpenSSL 1.0.2 APIs. The hostname or IP address are now verified by OpenSSL during the TLS handshake. A failure to verify the name results in a proper handshake abort with TLS Alert ``bad cert``.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-31399 -->
https://bugs.python.org/issue31399
<!-- /issue-number -->
