### PR TITLE
bpo-28182: restore backwards compatibility

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -485,18 +485,23 @@ fill_and_set_sslerror(PySSLSocket *sslsock, PyObject *type, int ssl_errno,
         }
 
         switch (verify_code) {
+#ifdef X509_V_ERR_HOSTNAME_MISMATCH
+        /* OpenSSL >= 1.0.2, LibreSSL >= 2.5.3 */
         case X509_V_ERR_HOSTNAME_MISMATCH:
             verify_obj = PyUnicode_FromFormat(
                 "Hostname mismatch, certificate is not valid for '%S'.",
                 sslsock->server_hostname
             );
             break;
+#endif
+#ifdef X509_V_ERR_IP_ADDRESS_MISMATCH
         case X509_V_ERR_IP_ADDRESS_MISMATCH:
             verify_obj = PyUnicode_FromFormat(
                 "IP address mismatch, certificate is not valid for '%S'.",
                 sslsock->server_hostname
             );
             break;
+#endif
         default:
             verify_str = X509_verify_cert_error_string(verify_code);
             if (verify_str != NULL) {


### PR DESCRIPTION
b3ad0e5127bdeb6e506301e0d65403fa23c4177b broke backwards compatibility with OpenSSL < 1.0.2.

Signed-off-by: Christian Heimes <christian@python.org>



<!-- issue-number: bpo-28182 -->
https://bugs.python.org/issue28182
<!-- /issue-number -->
