### PR TITLE
bpo-29639: change test.support.HOST, add HOSTv4

### DIFF
--- a/Lib/asyncore.py
+++ b/Lib/asyncore.py
@@ -287,7 +287,6 @@ class dispatcher:
 
     def set_socket(self, sock, map=None):
         self.socket = sock
-##        self.__dict__['socket'] = sock
         self._fileno = sock.fileno()
         self.add_channel(map)
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -601,9 +601,8 @@ def requires_mac_ver(*min_version):
     return decorator
 
 
-# Don't use "localhost", since resolving it uses the DNS under recent
-# Windows versions (see issue #18792).
-HOST = "127.0.0.1"
+HOST = "localhost"
+HOSTv4 = "127.0.0.1"
 HOSTv6 = "::1"
 
 

--- a/Lib/test/test_smtpd.py
+++ b/Lib/test/test_smtpd.py
@@ -170,11 +170,11 @@ class TestFamilyDetection(unittest.TestCase):
 
     @unittest.skipUnless(support.IPV6_ENABLED, "IPv6 not enabled")
     def test_socket_uses_IPv6(self):
-        server = smtpd.SMTPServer((support.HOSTv6, 0), (support.HOST, 0))
+        server = smtpd.SMTPServer((support.HOSTv6, 0), (support.HOSTv4, 0))
         self.assertEqual(server.socket.family, socket.AF_INET6)
 
     def test_socket_uses_IPv4(self):
-        server = smtpd.SMTPServer((support.HOST, 0), (support.HOSTv6, 0))
+        server = smtpd.SMTPServer((support.HOSTv4, 0), (support.HOSTv6, 0))
         self.assertEqual(server.socket.family, socket.AF_INET)
 
 

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -230,15 +230,6 @@ class DebuggingServerTests(unittest.TestCase):
         smtpd.DEBUGSTREAM.close()
         smtpd.DEBUGSTREAM = self.old_DEBUGSTREAM
 
-    def get_server_xpeer(self):
-        # Tests doing diffs of headers need the header our server adds.
-        # We use getpeername on the server socket because this exactly matches
-        # how smtpd.py gets the name to fill in for this header. :/
-        # Implementation specific, but socket.gethostbyname('localhost')
-        # does is _not_ the same thing.
-        return self.serv.socket.getpeername()[0]
-        #m['X-Peer'] = self.serv.socket.getpeername()[0]
-
     def get_output_without_xpeer(self):
         test_output = self.output.getvalue()
         return re.sub(r'(.*?)^X-Peer:\s*\S+\n(.*)', r'\1\2',

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -864,12 +864,12 @@ class GeneralModuleTests(unittest.TestCase):
             self.fail("Error testing host resolution mechanisms. (fqdn: %s, all: %s)" % (fqhn, repr(all_host_names)))
 
     def test_host_resolution(self):
-        for addr in [support.HOST, '10.0.0.1', '255.255.255.255']:
+        for addr in [support.HOSTv4, '10.0.0.1', '255.255.255.255']:
             self.assertEqual(socket.gethostbyname(addr), addr)
 
         # we don't test support.HOSTv6 because there's a chance it doesn't have
         # a matching name entry (e.g. 'ip6-localhost')
-        for host in [support.HOST]:
+        for host in [support.HOSTv4]:
             self.assertIn(host, socket.gethostbyaddr(host)[2])
 
     def test_host_resolution_bad_address(self):

--- a/Misc/NEWS.d/next/Tests/2017-09-08-15-59-07.bpo-29639.yIZecp.rst
+++ b/Misc/NEWS.d/next/Tests/2017-09-08-15-59-07.bpo-29639.yIZecp.rst
@@ -1,2 +1,2 @@
 test.support.HOST is now "localhost", a new HOSTv4 constant has been added
-for your ``127.0.0.1`` needs, similar to the existing HOSTv6 ``::``1 constant.
+for your ``127.0.0.1`` needs, similar to the existing HOSTv6 constant.

--- a/Misc/NEWS.d/next/Tests/2017-09-08-15-59-07.bpo-29639.yIZecp.rst
+++ b/Misc/NEWS.d/next/Tests/2017-09-08-15-59-07.bpo-29639.yIZecp.rst
@@ -1,0 +1,2 @@
+test.support.HOST is now "localhost", a new HOSTv4 constant has been added
+for your "127.0.0.1" needs, similar to the existing HOSTv6 "::1" constant.

--- a/Misc/NEWS.d/next/Tests/2017-09-08-15-59-07.bpo-29639.yIZecp.rst
+++ b/Misc/NEWS.d/next/Tests/2017-09-08-15-59-07.bpo-29639.yIZecp.rst
@@ -1,2 +1,2 @@
 test.support.HOST is now "localhost", a new HOSTv4 constant has been added
-for your ``127.0.0.1`` needs, similar to the existing HOSTv6 ``::1`` constant.
+for your ``127.0.0.1`` needs, similar to the existing HOSTv6 ``::``1 constant.

--- a/Misc/NEWS.d/next/Tests/2017-09-08-15-59-07.bpo-29639.yIZecp.rst
+++ b/Misc/NEWS.d/next/Tests/2017-09-08-15-59-07.bpo-29639.yIZecp.rst
@@ -1,2 +1,2 @@
 test.support.HOST is now "localhost", a new HOSTv4 constant has been added
-for your "127.0.0.1" needs, similar to the existing HOSTv6 "::1" constant.
+for your ``127.0.0.1`` needs, similar to the existing HOSTv6 ``::1`` constant.


### PR DESCRIPTION
test.support.HOST should be "localhost" as it was in the past. See the bpo-29639.

Tests that need the IP address should use HOSTv4 (added) or the existing HOSTv6 constant.

This changes the definition and fixes tests that needed updating to deal with HOST being
the hostname rather than the hardcoded IP address.

This is only the first step in addressing https://bugs.python.org/issue29639.

<!-- issue-number: bpo-29639 -->
https://bugs.python.org/issue29639
<!-- /issue-number -->
