### PR TITLE
[3.6] bpo-31400: Improve SSL error handling on Windows (GH-3463)

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-09-08-14-19-57.bpo-31400.YOTPKi.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-08-14-19-57.bpo-31400.YOTPKi.rst
@@ -1,0 +1,1 @@
+Improves SSL error handling to avoid losing error numbers.


### PR DESCRIPTION
* bpo-31392: Improve SSL error handling on Windows

* Remove unnecessary Windows mention in NEWS.
(cherry picked from commit e6eb48c10dc389d1d70657593de6a6cb3087d3d1)


<!-- issue-number: bpo-31400 -->
https://bugs.python.org/issue31400
<!-- /issue-number -->
