### PR TITLE
fix optparse support utf8

### DIFF
--- a/Lib/optparse.py
+++ b/Lib/optparse.py
@@ -1643,8 +1643,8 @@ class OptionParser (OptionContainer):
         help text provided with them, to 'file' (default stdout).
         """
         if file is None:
-            file = sys.stdout
-        file.write(self.format_help())
+            file = sys.stdout.buffer if int(sys.version_info[0]) is 3 else sys.stdout
+        file.write(self.format_help().encode('utf8'))
 
 # class OptionParser
 


### PR DESCRIPTION
Hello,

optparse is not supporting utf8 in Python 3.x on windows OS. it fixes the problem!

```
    parser.print_help()
  File "C:\Python35\lib\optparse.py", line 1646, in print_help
    file.write(self.format_help())
  File "C:\Python35\lib\encodings\cp437.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_map)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 28-32: character maps to <undefined>
```