### PR TITLE
bpo-31394: Clarify documentation about token type attribute

### DIFF
--- a/Doc/library/tokenize.rst
+++ b/Doc/library/tokenize.rst
@@ -17,7 +17,7 @@ as well, making it useful for implementing "pretty-printers," including
 colorizers for on-screen displays.
 
 To simplify token stream handling, all :ref:`operators` and :ref:`delimiters`
-tokens are returned using the generic :data:`~token.OP` token type.  The exact
+tokens and Ellipsis are returned using the generic :data:`~token.OP` token type.  The exact
 type can be determined by checking the ``exact_type`` property on the
 :term:`named tuple` returned from :func:`tokenize.tokenize`.
 

--- a/Doc/library/tokenize.rst
+++ b/Doc/library/tokenize.rst
@@ -16,7 +16,7 @@ implemented in Python.  The scanner in this module returns comments as tokens
 as well, making it useful for implementing "pretty-printers," including
 colorizers for on-screen displays.
 
-To simplify token stream handling, all :ref:`operators` and :ref:`delimiters`
+To simplify token stream handling, all :ref:`operator <operators>` and :ref:`delimiter <delimiters>`
 tokens and Ellipsis are returned using the generic :data:`~token.OP` token type.  The exact
 type can be determined by checking the ``exact_type`` property on the
 :term:`named tuple` returned from :func:`tokenize.tokenize`.

--- a/Doc/library/tokenize.rst
+++ b/Doc/library/tokenize.rst
@@ -17,7 +17,7 @@ as well, making it useful for implementing "pretty-printers," including
 colorizers for on-screen displays.
 
 To simplify token stream handling, all :ref:`operator <operators>` and :ref:`delimiter <delimiters>`
-tokens and Ellipsis are returned using the generic :data:`~token.OP` token type.  The exact
+tokens and :data:`Ellipsis` are returned using the generic :data:`~token.OP` token type.  The exact
 type can be determined by checking the ``exact_type`` property on the
 :term:`named tuple` returned from :func:`tokenize.tokenize`.
 


### PR DESCRIPTION
Make it clear that Ellipsis tokens are among these tokens, which have `type` attribute set to `token.OP`.

See https://bugs.python.org/issue31394 for the discussion.

<!-- issue-number: bpo-31394 -->
https://bugs.python.org/issue31394
<!-- /issue-number -->
