### PR TITLE
[3.5] bpo-31345: Backport docstring improvements to the C version of OrderedDict

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -157,9 +157,9 @@ class OrderedDict(dict):
         dict.clear(self)
 
     def popitem(self, last=True):
-        '''od.popitem() -> (k, v), return and remove a (key, value) pair.
-        Pairs are returned in LIFO order if last is true or FIFO order if false.
+        '''Remove and return a (key, value) pair from the dictionary.
 
+        Pairs are returned in LIFO order if last is true or FIFO order if false.
         '''
         if not self:
             raise KeyError('dictionary is empty')

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1152,10 +1152,12 @@ _odict_popkey(PyObject *od, PyObject *key, PyObject *failobj)
 /* popitem() */
 
 PyDoc_STRVAR(odict_popitem__doc__,
-"od.popitem() -> (k, v), return and remove a (key, value) pair.\n\
-        Pairs are returned in LIFO order if last is true or FIFO order if false.\n\
-\n\
-        ");
+"popitem($self, /, last=True)\n"
+"--\n"
+"\n"
+"Remove and return a (key, value) pair from the dictionary.\n"
+"\n"
+"Pairs are returned in LIFO order if last is true or FIFO order if false.");
 
 static PyObject *
 odict_popitem(PyObject *od, PyObject *args, PyObject *kwargs)


### PR DESCRIPTION
Updated the docstring of OrderedDict using 3.7 as example.

<!-- issue-number: bpo-31345 -->
https://bugs.python.org/issue31345
<!-- /issue-number -->
