### PR TITLE
bpo-31406: Fix crashes when comparing between a Decimal object and a bad Rational object

### DIFF
--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1749,6 +1749,19 @@ class UsabilityTest(unittest.TestCase):
             self.assertNotEqual(D('nan'), F(-9,123))
             self.assertNotEqual(F(-9,123), D('nan'))
 
+    def test_issue31406(self):
+        # A comparison between a Decimal object and a bad Rational
+        # object shouldn't crash the interpreter.
+        def _get_bad_rational(numer, denom):
+            class BadRational(fractions[self.decimal].Fraction):
+                numerator = numer
+                denominator = denom
+            return BadRational()
+
+        for numer, denom in [(None, 42), (42, None), (None, None)]:
+            with self.assertRaises(TypeError):
+                self.decimal.Decimal() < _get_bad_rational(numer, denom)
+
     def test_copy_and_deepcopy_methods(self):
         Decimal = self.decimal.Decimal
 

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1749,6 +1749,7 @@ class UsabilityTest(unittest.TestCase):
             self.assertNotEqual(D('nan'), F(-9,123))
             self.assertNotEqual(F(-9,123), D('nan'))
 
+    @cpython_only
     def test_issue31406(self):
         # A comparison between a Decimal object and a bad Rational
         # object shouldn't crash the interpreter.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-10-16-40-20.bpo-31406.LS3sR3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-10-16-40-20.bpo-31406.LS3sR3.rst
@@ -1,2 +1,2 @@
-Fix crashes when comparing between a Decimal object and a bad Rational
-object. Patch by Oren Milman.
+Fix crashes when comparing between a `decimal.Decimal` object and a bad
+`numbers.Rational` object. Patch by Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-10-16-40-20.bpo-31406.LS3sR3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-10-16-40-20.bpo-31406.LS3sR3.rst
@@ -1,0 +1,2 @@
+Fix crashes when comparing between a Decimal object and a bad Rational
+object. Patch by Oren Milman.

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -2840,6 +2840,13 @@ multiply_by_denominator(PyObject *v, PyObject *r, PyObject *context)
     if (tmp == NULL) {
         return NULL;
     }
+    if (!PyLong_Check(tmp)) {
+        PyErr_Format(PyExc_TypeError,
+                     "denominator must be integer, not '%.200s'",
+                     Py_TYPE(tmp)->tp_name);
+        Py_DECREF(tmp);
+        return NULL;
+    }
     denom = PyDec_FromLongExact(tmp, context);
     Py_DECREF(tmp);
     if (denom == NULL) {
@@ -2893,7 +2900,13 @@ numerator_as_decimal(PyObject *r, PyObject *context)
     if (tmp == NULL) {
         return NULL;
     }
-
+    if (!PyLong_Check(tmp)) {
+        PyErr_Format(PyExc_TypeError,
+                     "numerator must be integer, not '%.200s'",
+                     Py_TYPE(tmp)->tp_name);
+        Py_DECREF(tmp);
+        return NULL;
+    }
     num = PyDec_FromLongExact(tmp, context);
     Py_DECREF(tmp);
     return num;


### PR DESCRIPTION
- in _decimal.c - add checks whether numerator and denominator are integers.
- in test_decimal.py - add a test to verify that the crashes are no more.

<!-- issue-number: bpo-31406 -->
https://bugs.python.org/issue31406
<!-- /issue-number -->
