### PR TITLE
[Trivial] Remove a null statement that was necessary for --without-threads

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -623,7 +623,6 @@ internal_setblocking(PySocketSockObject *s, int block)
     result = 0;
 
   done:
-    ;  /* necessary for --without-threads flag */
     Py_END_ALLOW_THREADS
 
     if (result) {


### PR DESCRIPTION
This null statement is unneeded now that ``--without-threads`` has been removed.