### PR TITLE
bpo-31370: Simplify run_tests.py

### DIFF
--- a/Tools/scripts/run_tests.py
+++ b/Tools/scripts/run_tests.py
@@ -10,10 +10,6 @@ simply passing a -u option to this script.
 import os
 import sys
 import test.support
-try:
-    import threading
-except ImportError:
-    threading = None
 
 
 def is_multiprocess_flag(arg):
@@ -43,7 +39,7 @@ def main(regrtest_args):
                  ])
     if sys.platform == 'win32':
         args.append('-n')         # Silence alerts under Windows
-    if threading and not any(is_multiprocess_flag(arg) for arg in regrtest_args):
+    if not any(is_multiprocess_flag(arg) for arg in regrtest_args):
         args.extend(['-j', '0'])  # Use all CPU cores
     if not any(is_resource_use_flag(arg) for arg in regrtest_args):
         args.extend(['-u', 'all,-largefile,-audio,-gui'])


### PR DESCRIPTION
The `threading` module is now always available.

<!-- issue-number: bpo-31370 -->
https://bugs.python.org/issue31370
<!-- /issue-number -->
