### PR TITLE
bpo-31411: Prevent raising a SystemError in case warnings.onceregistry is not a dictionary

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -794,6 +794,18 @@ class _WarningsTests(BaseTest, unittest.TestCase):
         self.assertNotIn(b'Warning!', stderr)
         self.assertNotIn(b'Error', stderr)
 
+    @support.cpython_only
+    def test_issue31411(self):
+        # warn_explicit() shouldn't raise a SystemError in case
+        # warnings.onceregistry is required, but isn't a dictionary.
+        wmod = self.module
+        with original_warnings.catch_warnings(module=wmod):
+            wmod.filterwarnings('once')
+            with support.swap_attr(wmod, 'onceregistry', None):
+                with self.assertRaises(TypeError):
+                    wmod.warn_explicit(message='foo', category=Warning,
+                                       filename='bar', lineno=1, registry=None)
+
 
 class WarningsDisplayTests(BaseTest):
 

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -803,8 +803,7 @@ class _WarningsTests(BaseTest, unittest.TestCase):
             wmod.filterwarnings('once')
             with support.swap_attr(wmod, 'onceregistry', None):
                 with self.assertRaises(TypeError):
-                    wmod.warn_explicit(message='foo', category=Warning,
-                                       filename='bar', lineno=1, registry=None)
+                    wmod.warn_explicit('foo', Warning, 'bar', 1, registry=None)
 
 
 class WarningsDisplayTests(BaseTest):

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -797,7 +797,7 @@ class _WarningsTests(BaseTest, unittest.TestCase):
     @support.cpython_only
     def test_issue31411(self):
         # warn_explicit() shouldn't raise a SystemError in case
-        # warnings.onceregistry is required, but isn't a dictionary.
+        # warnings.onceregistry isn't a dictionary.
         wmod = self.module
         with original_warnings.catch_warnings(module=wmod):
             wmod.filterwarnings('once')

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-11-08-50-41.bpo-31411.HZz82I.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-11-08-50-41.bpo-31411.HZz82I.rst
@@ -1,0 +1,2 @@
+Raise a TypeError instead of SystemError in case warnings.onceregistry is
+not a dictionary. Patch by Oren Milman.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -86,6 +86,12 @@ get_once_registry(void)
             return NULL;
         return _PyRuntime.warnings.once_registry;
     }
+    if (!PyDict_Check(registry)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "warnings.onceregistry must be a dict");
+        Py_DECREF(registry);
+        return NULL;
+    }
     Py_DECREF(_PyRuntime.warnings.once_registry);
     _PyRuntime.warnings.once_registry = registry;
     return registry;
@@ -514,11 +520,6 @@ warn_explicit(PyObject *category, PyObject *message,
                 registry = get_once_registry();
                 if (registry == NULL)
                     goto cleanup;
-                if (!PyDict_Check(registry)) {
-                    PyErr_SetString(PyExc_TypeError,
-                                    "warnings.onceregistry must be a dict");
-                    goto cleanup;
-                }
             }
             /* _PyRuntime.warnings.once_registry[(text, category)] = 1 */
             rc = update_registry(registry, text, category, 0);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -437,7 +437,7 @@ warn_explicit(PyObject *category, PyObject *message,
         Py_RETURN_NONE;
 
     if (registry && !PyDict_Check(registry) && (registry != Py_None)) {
-        PyErr_SetString(PyExc_TypeError, "'registry' must be a dict");
+        PyErr_SetString(PyExc_TypeError, "'registry' must be a dict or None");
         return NULL;
     }
 
@@ -514,6 +514,11 @@ warn_explicit(PyObject *category, PyObject *message,
                 registry = get_once_registry();
                 if (registry == NULL)
                     goto cleanup;
+                if (!PyDict_Check(registry)) {
+                    PyErr_SetString(PyExc_TypeError,
+                                    "warnings.onceregistry must be a dict");
+                    goto cleanup;
+                }
             }
             /* _PyRuntime.warnings.once_registry[(text, category)] = 1 */
             rc = update_registry(registry, text, category, 0);


### PR DESCRIPTION
- in `_warnings.c`: add a check whether warnings.onceregistry is not a dictionary. while we are here, fix a related inaccurate error message.
- in `test_warnings/__init__.py`: add a test to verify that the SystemError is no more.

<!-- issue-number: bpo-31411 -->
https://bugs.python.org/issue31411
<!-- /issue-number -->
