### PR TITLE
[3.6] bpo-29526: Add reference to help('FORMATTING') in format() builtin (GH-166).

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -588,12 +588,14 @@ format as builtin_format
 
 Return value.__format__(format_spec)
 
-format_spec defaults to the empty string
+format_spec defaults to the empty string.
+See the Format Specification Mini-Language section of help('FORMATTING') for
+details.
 [clinic start generated code]*/
 
 static PyObject *
 builtin_format_impl(PyObject *module, PyObject *value, PyObject *format_spec)
-/*[clinic end generated code: output=2f40bdfa4954b077 input=6325e751a1b29b86]*/
+/*[clinic end generated code: output=2f40bdfa4954b077 input=88339c93ea522b33]*/
 {
     return PyObject_Format(value, format_spec);
 }

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -77,7 +77,9 @@ PyDoc_STRVAR(builtin_format__doc__,
 "\n"
 "Return value.__format__(format_spec)\n"
 "\n"
-"format_spec defaults to the empty string");
+"format_spec defaults to the empty string.\n"
+"See the Format Specification Mini-Language section of help(\'FORMATTING\') for\n"
+"details.");
 
 #define BUILTIN_FORMAT_METHODDEF    \
     {"format", (PyCFunction)builtin_format, METH_VARARGS, builtin_format__doc__},
@@ -674,4 +676,4 @@ builtin_issubclass(PyObject *module, PyObject *args)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=63483deb75805f7c input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2ef82846acdfa0f5 input=a9049054013a1b77]*/


### PR DESCRIPTION


<!-- issue-number: bpo-29526 -->
https://bugs.python.org/issue29526
<!-- /issue-number -->
