### PR TITLE
[2.7] bpo-29526: Add reference to help('FORMATTING') in format() builtin (GH-166).

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -374,7 +374,9 @@ PyDoc_STRVAR(format_doc,
 "format(value[, format_spec]) -> string\n\
 \n\
 Returns value.__format__(format_spec)\n\
-format_spec defaults to \"\"");
+format_spec defaults to the empty string.\n\
+See the Format Specification Mini-Language section of help('FORMATTING') for\n\
+details.");
 
 static PyObject *
 builtin_chr(PyObject *self, PyObject *args)


### PR DESCRIPTION


<!-- issue-number: bpo-29526 -->
https://bugs.python.org/issue29526
<!-- /issue-number -->
