### PR TITLE
[3.6] bpo-31411: Prevent raising a SystemError in case warnings.oncer…

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -794,6 +794,17 @@ class _WarningsTests(BaseTest, unittest.TestCase):
         self.assertNotIn(b'Warning!', stderr)
         self.assertNotIn(b'Error', stderr)
 
+    @support.cpython_only
+    def test_issue31411(self):
+        # warn_explicit() shouldn't raise a SystemError in case
+        # warnings.onceregistry isn't a dictionary.
+        wmod = self.module
+        with original_warnings.catch_warnings(module=wmod):
+            wmod.filterwarnings('once')
+            with support.swap_attr(wmod, 'onceregistry', None):
+                with self.assertRaises(TypeError):
+                    wmod.warn_explicit('foo', Warning, 'bar', 1, registry=None)
+
 
 class WarningsDisplayTests(BaseTest):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-11-08-50-41.bpo-31411.HZz82I.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-11-08-50-41.bpo-31411.HZz82I.rst
@@ -1,0 +1,2 @@
+Raise a TypeError instead of SystemError in case warnings.onceregistry is
+not a dictionary. Patch by Oren Milman.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -94,6 +94,12 @@ get_once_registry(void)
             return NULL;
         return _once_registry;
     }
+    if (!PyDict_Check(registry)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "warnings.onceregistry must be a dict");
+        Py_DECREF(registry);
+        return NULL;
+    }
     Py_DECREF(_once_registry);
     _once_registry = registry;
     return registry;
@@ -449,7 +455,7 @@ warn_explicit(PyObject *category, PyObject *message,
         Py_RETURN_NONE;
 
     if (registry && !PyDict_Check(registry) && (registry != Py_None)) {
-        PyErr_SetString(PyExc_TypeError, "'registry' must be a dict");
+        PyErr_SetString(PyExc_TypeError, "'registry' must be a dict or None");
         return NULL;
     }
 


### PR DESCRIPTION
…egistry is not a dictionary. (GH-3485).

(cherry picked from commit 252033d50effa08046ac34fcc406bc99796ab88b)


<!-- issue-number: bpo-31411 -->
https://bugs.python.org/issue31411
<!-- /issue-number -->
