### PR TITLE
[3.6] bpo-31373: remove overly strict float range checks (GH-3486)

### DIFF
--- a/Lib/test/test_float.py
+++ b/Lib/test/test_float.py
@@ -613,6 +613,12 @@ class IEEEFormatTestCase(unittest.TestCase):
                           ('<f', LE_FLOAT_NAN)]:
             struct.unpack(fmt, data)
 
+    @support.requires_IEEE_754
+    def test_serialized_float_rounding(self):
+        from _testcapi import FLT_MAX
+        self.assertEqual(struct.pack("<f", 3.40282356e38), struct.pack("<f", FLT_MAX))
+        self.assertEqual(struct.pack("<f", -3.40282356e38), struct.pack("<f", -FLT_MAX))
+
 class FormatTestCase(unittest.TestCase):
 
     def test_format(self):

--- a/Lib/test/test_getargs2.py
+++ b/Lib/test/test_getargs2.py
@@ -377,6 +377,12 @@ class Float_TestCase(unittest.TestCase):
         r = getargs_f(NAN)
         self.assertNotEqual(r, r)
 
+    @support.requires_IEEE_754
+    def test_f_rounding(self):
+        from _testcapi import getargs_f
+        self.assertEqual(getargs_f(3.40282356e38), FLT_MAX)
+        self.assertEqual(getargs_f(-3.40282356e38), -FLT_MAX)
+
     def test_d(self):
         from _testcapi import getargs_d
         self.assertEqual(getargs_d(4.25), 4.25)

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -2182,13 +2182,13 @@ _PyFloat_Pack4(double x, unsigned char *p, int le)
 
     }
     else {
+        float y = (float)x;
         int i, incr = 1;
 
-        if (fabs(x) > FLT_MAX && !Py_IS_INFINITY(x))
+        if (Py_IS_INFINITY(y) && !Py_IS_INFINITY(x))
             goto Overflow;
 
         unsigned char s[sizeof(float)];
-        float y = (float)x;
         memcpy(s, &y, sizeof(float));
 
         if ((float_format == ieee_little_endian_format && !le)

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -811,10 +811,6 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
         double dval = PyFloat_AsDouble(arg);
         if (PyErr_Occurred())
             RETURN_ERR_OCCURRED;
-        else if (dval > FLT_MAX)
-            *p = (float)INFINITY;
-        else if (dval < -FLT_MAX)
-            *p = (float)-INFINITY;
         else
             *p = (float) dval;
         break;


### PR DESCRIPTION



<!-- issue-number: bpo-31373 -->
https://bugs.python.org/issue31373
<!-- /issue-number -->
