### PR TITLE
bpo-31416: Fix assertion failures in case of a bad warnings.filters or warnings.defaultaction

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -805,6 +805,21 @@ class _WarningsTests(BaseTest, unittest.TestCase):
                 with self.assertRaises(TypeError):
                     wmod.warn_explicit('foo', Warning, 'bar', 1, registry=None)
 
+    @support.cpython_only
+    def test_issue31416(self):
+        # warn_explicit() shouldn't cause an assertion failure in case of a
+        # bad warnings.filters or warnings.defaultaction.
+        wmod = self.module
+        with original_warnings.catch_warnings(module=wmod):
+            wmod.filters = [(None, None, Warning, None, 0)]
+            with self.assertRaises(TypeError):
+                wmod.warn_explicit('foo', Warning, 'bar', 1)
+
+            wmod.filters = []
+            with support.swap_attr(wmod, 'defaultaction', None), \
+                 self.assertRaises(TypeError):
+                wmod.warn_explicit('foo', Warning, 'bar', 1)
+
 
 class WarningsDisplayTests(BaseTest):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-11-12-54-35.bpo-31416.2hlQFd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-11-12-54-35.bpo-31416.2hlQFd.rst
@@ -1,0 +1,2 @@
+Fix assertion failures in case of a bad warnings.filters or
+warnings.defaultaction. Patch by Oren Milman.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -111,8 +111,10 @@ get_default_action(void)
         return _PyRuntime.warnings.default_action;
     }
     if (!PyUnicode_Check(default_action)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "warnings.defaultaction must be a string");
+        PyErr_Format(PyExc_TypeError,
+                     MODULE_NAME ".defaultaction must be a string, "
+                     "not '%.200s'",
+                     Py_TYPE(default_action)->tp_name);
         Py_DECREF(default_action);
         return NULL;
     }
@@ -170,8 +172,9 @@ get_filter(PyObject *category, PyObject *text, Py_ssize_t lineno,
         ln_obj = PyTuple_GET_ITEM(tmp_item, 4);
 
         if (!PyUnicode_Check(action)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "action must be a string");
+            PyErr_Format(PyExc_TypeError,
+                         "action must be a string, not '%.200s'",
+                         Py_TYPE(action)->tp_name);
             Py_DECREF(tmp_item);
             return NULL;
         }

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -110,7 +110,12 @@ get_default_action(void)
         }
         return _PyRuntime.warnings.default_action;
     }
-
+    if (!PyUnicode_Check(default_action)) {
+        PyErr_SetString(PyExc_TypeError,
+                        "warnings.defaultaction must be a string");
+        Py_DECREF(default_action);
+        return NULL;
+    }
     Py_DECREF(_PyRuntime.warnings.default_action);
     _PyRuntime.warnings.default_action = default_action;
     return default_action;
@@ -164,6 +169,13 @@ get_filter(PyObject *category, PyObject *text, Py_ssize_t lineno,
         mod = PyTuple_GET_ITEM(tmp_item, 3);
         ln_obj = PyTuple_GET_ITEM(tmp_item, 4);
 
+        if (!PyUnicode_Check(action)) {
+            PyErr_SetString(PyExc_TypeError,
+                            "action must be a string");
+            Py_DECREF(tmp_item);
+            return NULL;
+        }
+
         good_msg = check_matched(msg, text);
         if (good_msg == -1) {
             Py_DECREF(tmp_item);
@@ -203,8 +215,6 @@ get_filter(PyObject *category, PyObject *text, Py_ssize_t lineno,
         return action;
     }
 
-    PyErr_SetString(PyExc_ValueError,
-                    MODULE_NAME ".defaultaction not found");
     return NULL;
 }
 


### PR DESCRIPTION
- in `_warnings.c`: add checks whether the action retrieved from warnings.filters is not a string, and whether warnings.defaultaction is not a string. while we are here, remove a wrong error message.
- in `test_warnings/__init__.py`: add a test to verify that the assertion failures are no more.

<!-- issue-number: bpo-31416 -->
https://bugs.python.org/issue31416
<!-- /issue-number -->
