### PR TITLE
bpo-30860: Fix deadcode in obmalloc.c

### DIFF
--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -297,9 +297,9 @@ _PyMem_Initialize(struct _pymem_runtime_state *state)
     state->allocators.obj = _pyobject;
 
 #ifdef WITH_PYMALLOC
+    Py_BUILD_ASSERT(NB_SMALL_SIZE_CLASSES == 64);
+
     for (int i = 0; i < 8; i++) {
-        if (NB_SMALL_SIZE_CLASSES <= i * 8)
-            break;
         for (int j = 0; j < 8; j++) {
             int x = i * 8 + j;
             poolp *addr = &(state->usedpools[2*(x)]);


### PR DESCRIPTION
Fix Coverity CID 1417587: _PyMem_Initialize() contains code which is
never executed.

<!-- issue-number: bpo-30860 -->
https://bugs.python.org/issue30860
<!-- /issue-number -->
