### PR TITLE
bpo-31414: IDLE -- fix tk entry box tests by deleting first.

### DIFF
--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -1128,15 +1128,18 @@ class GenPageTest(unittest.TestCase):
 
     def test_editor_size(self):
         d = self.page
-        d.win_height_int.insert(0, '1')
-        self.assertEqual(mainpage, {'EditorWindow': {'height': '140'}})
+        d.win_height_int.delete(0, 'end')
+        d.win_height_int.insert(0, '11')
+        self.assertEqual(mainpage, {'EditorWindow': {'height': '11'}})
         changes.clear()
-        d.win_width_int.insert(0, '1')
-        self.assertEqual(mainpage, {'EditorWindow': {'width': '180'}})
+        d.win_width_int.delete(0, 'end')
+        d.win_width_int.insert(0, '11')
+        self.assertEqual(mainpage, {'EditorWindow': {'width': '11'}})
 
     def test_autocomplete_wait(self):
-        self.page.auto_wait_int.insert(0, '1')
-        self.assertEqual(extpage, {'AutoComplete': {'popupwait': '12000'}})
+        self.page.auto_wait_int.delete(0, 'end')
+        self.page.auto_wait_int.insert(0, '11')
+        self.assertEqual(extpage, {'AutoComplete': {'popupwait': '11'}})
 
     def test_parenmatch(self):
         d = self.page
@@ -1144,8 +1147,9 @@ class GenPageTest(unittest.TestCase):
         d.paren_style_type['menu'].invoke(0)
         eq(extpage, {'ParenMatch': {'style': 'opener'}})
         changes.clear()
-        d.paren_flash_time.insert(0, '2')
-        eq(extpage, {'ParenMatch': {'flash-delay': '2500'}})
+        d.paren_flash_time.delete(0, 'end')
+        d.paren_flash_time.insert(0, '11')
+        eq(extpage, {'ParenMatch': {'flash-delay': '11'}})
         changes.clear()
         d.bell_on.invoke()
         eq(extpage, {'ParenMatch': {'bell': 'False'}})
@@ -1158,12 +1162,14 @@ class GenPageTest(unittest.TestCase):
         self.assertEqual(mainpage, {'General': {'autosave': '0'}})
 
     def test_paragraph(self):
-        self.page.format_width_int.insert(0, '1')
-        self.assertEqual(extpage, {'FormatParagraph': {'max-width': '172'}})
+        self.page.format_width_int.delete(0, 'end')
+        self.page.format_width_int.insert(0, '11')
+        self.assertEqual(extpage, {'FormatParagraph': {'max-width': '11'}})
 
     def test_context(self):
+        self.page.context_int.delete(0, 'end')
         self.page.context_int.insert(0, '1')
-        self.assertEqual(extpage, {'CodeContext': {'numlines': '13'}})
+        self.assertEqual(extpage, {'CodeContext': {'numlines': '1'}})
 
     def test_source_selected(self):
         d = self.page

--- a/Misc/NEWS.d/next/IDLE/2017-09-11-15-46-05.bpo-31414.wiepgK.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-11-15-46-05.bpo-31414.wiepgK.rst
@@ -1,0 +1,2 @@
+IDLE -- fix tk entry box tests by deleting first. Adding to an int entry is
+not the same as deleting and inserting because int('') will fail.


### PR DESCRIPTION
Adding to an int entry is not the same as deleting and inserting
because int('') will fail.


<!-- issue-number: bpo-31414 -->
https://bugs.python.org/issue31414
<!-- /issue-number -->
