### PR TITLE
[2.7] bpo-17085: test_socket: cancel scheduled alarm on test failure

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -733,6 +733,7 @@ class GeneralModuleTests(unittest.TestCase):
                 self.assertRaises(socket.timeout, c.sendall,
                                   b"x" * test_support.SOCK_MAX_SIZE)
         finally:
+            signal.alarm(0)
             signal.signal(signal.SIGALRM, old_alarm)
             c.close()
             s.close()


### PR DESCRIPTION
(cherry picked from commit 71fe8c00f6e2eda39d90c225c5f7635268cc4653)

<!-- issue-number: bpo-17085 -->
https://bugs.python.org/issue17085
<!-- /issue-number -->
