### PR TITLE
bpo-16251: pickle special methods and custom __getattr__

### DIFF
--- a/Lib/test/test_copy.py
+++ b/Lib/test/test_copy.py
@@ -881,6 +881,27 @@ class TestCopy(unittest.TestCase):
         self.assertIs(g.b.__self__, g)
         g.b()
 
+    def test_deepcopy_custom_getattr_recursion_limit_exceeded(self):
+        class Proxy(object):
+            def __init__(self, proxied_object):
+                self.proxied_object = proxied_object
+
+            def __getattr__(self, name):
+                return getattr(self.proxied_object, name)
+        one = Proxy(1)
+        two = copy.deepcopy(one)
+        self.assertEqual(one.proxied_object, two.proxied_object)
+
+    def test_deepcopy_custom_gettattr_non_callable(self):
+        class AttrDict(dict):
+            def __getattr__(self, name):
+                return self.get(name)
+
+        one = AttrDict()
+        one.update({'a': 1, 'b': 2})
+        two = copy.deepcopy(one)
+        self.assertEqual(one, two)
+
 
 def global_foo(x, y): return x+y
 


### PR DESCRIPTION
This PR doesn't change the lookup to types as the issue's title on BPO
suggests.  As Antoine and Raymond point out, there'd be significant danger of
breaking existing code.

Instead, we're doing the following:

* introducing a new function in `copyreg` called `getcallable()` that mimics
`getattr()` but swallows *all* exceptions (like `hasattr()` on Python 2) and
does some basic callability tests;

* switching all relevant usage of `hasattr()` and `getattr()` in `copy` and
`copyreg` to use `getcallable()` instead.

This fixes two common failure scenarios covered at length in bpo-16251, its
duplicates, as well as on StackOverflow, etc.  Worth fixing IMHO.

Funnily enough, the recursion limit exceeded scenario happened to work on
Python 2 since `hasattr()` there swallowed the RecursionError.


<!-- issue-number: bpo-16251 -->
https://bugs.python.org/issue16251
<!-- /issue-number -->
