### PR TITLE
bpo-31428: Prevent raising a SystemError in case the memo arg of ElementTree.Element.__deepcopy__() isn't a dictionary

### DIFF
--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -750,6 +750,13 @@ _elementtree_Element___deepcopy__(ElementObject *self, PyObject *memo)
     PyObject* tail;
     PyObject* id;
 
+    if (!PyDict_Check(memo)) {
+        PyErr_Format(PyExc_TypeError,
+                     "memo argument must be a dictionary, not '%.200s'",
+                     Py_TYPE(memo)->tp_name);
+        return NULL;
+    }
+
     tag = deepcopy(self->tag, memo);
     if (!tag)
         return NULL;

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -733,14 +733,14 @@ LOCAL(PyObject *) deepcopy(PyObject *, PyObject *);
 /*[clinic input]
 _elementtree.Element.__deepcopy__
 
-    memo: object
+    memo: object(subclass_of="&PyDict_Type")
     /
 
 [clinic start generated code]*/
 
 static PyObject *
-_elementtree_Element___deepcopy__(ElementObject *self, PyObject *memo)
-/*[clinic end generated code: output=d1f19851d17bf239 input=df24c2b602430b77]*/
+_elementtree_Element___deepcopy___impl(ElementObject *self, PyObject *memo)
+/*[clinic end generated code: output=eefc3df50465b642 input=a2d40348c0aade10]*/
 {
     Py_ssize_t i;
     ElementObject* element;
@@ -749,13 +749,6 @@ _elementtree_Element___deepcopy__(ElementObject *self, PyObject *memo)
     PyObject* text;
     PyObject* tail;
     PyObject* id;
-
-    if (!PyDict_Check(memo)) {
-        PyErr_Format(PyExc_TypeError,
-                     "memo argument must be a dictionary, not '%.200s'",
-                     Py_TYPE(memo)->tp_name);
-        return NULL;
-    }
 
     tag = deepcopy(self->tag, memo);
     if (!tag)
@@ -856,7 +849,8 @@ deepcopy(PyObject *object, PyObject *memo)
             /* Fall through to general case */
         }
         else if (Element_CheckExact(object)) {
-            return _elementtree_Element___deepcopy__((ElementObject *)object, memo);
+            return _elementtree_Element___deepcopy___impl(
+                (ElementObject *)object, memo);
         }
     }
 

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -70,6 +70,24 @@ PyDoc_STRVAR(_elementtree_Element___deepcopy____doc__,
 #define _ELEMENTTREE_ELEMENT___DEEPCOPY___METHODDEF    \
     {"__deepcopy__", (PyCFunction)_elementtree_Element___deepcopy__, METH_O, _elementtree_Element___deepcopy____doc__},
 
+static PyObject *
+_elementtree_Element___deepcopy___impl(ElementObject *self, PyObject *memo);
+
+static PyObject *
+_elementtree_Element___deepcopy__(ElementObject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *memo;
+
+    if (!PyArg_Parse(arg, "O!:__deepcopy__", &PyDict_Type, &memo)) {
+        goto exit;
+    }
+    return_value = _elementtree_Element___deepcopy___impl(self, memo);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_elementtree_Element___sizeof____doc__,
 "__sizeof__($self, /)\n"
 "--\n"
@@ -731,4 +749,4 @@ _elementtree_XMLParser__setevents(XMLParserObject *self, PyObject **args, Py_ssi
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=75d0ff80e20b830f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ed55bd5209c12364 input=a9049054013a1b77]*/


### PR DESCRIPTION


<!-- issue-number: bpo-31428 -->
https://bugs.python.org/issue31428
<!-- /issue-number -->
