### PR TITLE
bpo-31466: Enable a subclass to modify floatstr

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -203,11 +203,13 @@ class JSONEncoder(object):
             chunks = list(chunks)
         return ''.join(chunks)
 
-    def floatstr(self, o, allow_nan=self.allow_nan,
+    def floatstr(self, o, allow_nan=None,
                 _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
         # Check for specials.  Note that this type of test is processor
         # and/or platform-specific, so do tests which don't depend on the
         # internals.
+        if allow_nan is None:
+            allow_nan = self.allow_nan
 
         if o != o:
             text = 'NaN'

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -201,26 +201,7 @@ class JSONEncoder(object):
             chunks = list(chunks)
         return ''.join(chunks)
 
-    def iterencode(self, o, _one_shot=False):
-        """Encode the given object and yield each string
-        representation as available.
-
-        For example::
-
-            for chunk in JSONEncoder().iterencode(bigobject):
-                mysocket.write(chunk)
-
-        """
-        if self.check_circular:
-            markers = {}
-        else:
-            markers = None
-        if self.ensure_ascii:
-            _encoder = encode_basestring_ascii
-        else:
-            _encoder = encode_basestring
-
-        def floatstr(o, allow_nan=self.allow_nan,
+    def floatstr(o, allow_nan=self.allow_nan,
                 _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
             # Check for specials.  Note that this type of test is processor
             # and/or platform-specific, so do tests which don't depend on the
@@ -242,6 +223,24 @@ class JSONEncoder(object):
 
             return text
 
+    def iterencode(self, o, _one_shot=False):
+        """Encode the given object and yield each string
+        representation as available.
+
+        For example::
+
+            for chunk in JSONEncoder().iterencode(bigobject):
+                mysocket.write(chunk)
+
+        """
+        if self.check_circular:
+            markers = {}
+        else:
+            markers = None
+        if self.ensure_ascii:
+            _encoder = encode_basestring_ascii
+        else:
+            _encoder = encode_basestring
 
         if (_one_shot and c_make_encoder is not None
                 and self.indent is None):
@@ -251,7 +250,7 @@ class JSONEncoder(object):
                 self.skipkeys, self.allow_nan)
         else:
             _iterencode = _make_iterencode(
-                markers, self.default, _encoder, self.indent, floatstr,
+                markers, self.default, _encoder, self.indent, self.floatstr,
                 self.key_separator, self.item_separator, self.sort_keys,
                 self.skipkeys, _one_shot)
         return _iterencode(o, 0)

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -203,7 +203,7 @@ class JSONEncoder(object):
             chunks = list(chunks)
         return ''.join(chunks)
 
-    def floatstr(o, allow_nan=self.allow_nan,
+    def floatstr(self, o, allow_nan=self.allow_nan,
                 _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
         # Check for specials.  Note that this type of test is processor
         # and/or platform-specific, so do tests which don't depend on the

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -103,7 +103,7 @@ class JSONEncoder(object):
     key_separator = ': '
     def __init__(self, *, skipkeys=False, ensure_ascii=True,
             check_circular=True, allow_nan=True, sort_keys=False,
-            indent=None, separators=None, default=None):
+            indent=None, separators=None, default=None, floatstr=None):
         """Constructor for JSONEncoder, with sensible defaults.
 
         If skipkeys is false, then it is a TypeError to attempt
@@ -156,6 +156,8 @@ class JSONEncoder(object):
             self.item_separator = ','
         if default is not None:
             self.default = default
+        if floatstr is not None:
+            self.floatstr = floatstr
 
     def default(self, o):
         """Implement this method in a subclass such that it returns

--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -205,25 +205,25 @@ class JSONEncoder(object):
 
     def floatstr(o, allow_nan=self.allow_nan,
                 _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
-            # Check for specials.  Note that this type of test is processor
-            # and/or platform-specific, so do tests which don't depend on the
-            # internals.
+        # Check for specials.  Note that this type of test is processor
+        # and/or platform-specific, so do tests which don't depend on the
+        # internals.
 
-            if o != o:
-                text = 'NaN'
-            elif o == _inf:
-                text = 'Infinity'
-            elif o == _neginf:
-                text = '-Infinity'
-            else:
-                return _repr(o)
+        if o != o:
+            text = 'NaN'
+        elif o == _inf:
+            text = 'Infinity'
+        elif o == _neginf:
+            text = '-Infinity'
+        else:
+            return _repr(o)
 
-            if not allow_nan:
-                raise ValueError(
-                    "Out of range float values are not JSON compliant: " +
-                    repr(o))
+        if not allow_nan:
+            raise ValueError(
+                "Out of range float values are not JSON compliant: " +
+                repr(o))
 
-            return text
+        return text
 
     def iterencode(self, o, _one_shot=False):
         """Encode the given object and yield each string

--- a/Misc/NEWS.d/next/Library/2017-09-14-23-48-08.bpo-31466.ARyifU.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-14-23-48-08.bpo-31466.ARyifU.rst
@@ -1,0 +1,1 @@
+Allows the user to modify the fomat of floats when dumping a json file.


### PR DESCRIPTION
JSONEncoder subclasses could modify floatstr to create an ENG format.

So if my json file has distances in meters that are actually micros I will read:
25e-6
300e-6
instead of:
2.5e-05
0.0003 

The workaround now is to redefine iterencode which doesn't make a lot of sense. 

<!-- issue-number: bpo-31466 -->
https://bugs.python.org/issue31466
<!-- /issue-number -->
