### PR TITLE
[3.6] bpo-30923: Silence fall-through warnings included in -Wextra since gcc-7.0

### DIFF
--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3675,7 +3675,7 @@ _build_callargs(PyCFuncPtrObject *self, PyObject *argtypes,
         case (PARAMFLAG_FIN | PARAMFLAG_FOUT):
             *pinoutmask |= (1 << i); /* mark as inout arg */
             (*pnumretvals)++;
-            /* fall through to PARAMFLAG_FIN... */
+            /* fall through */
         case 0:
         case PARAMFLAG_FIN:
             /* 'in' parameter.  Copy it from inargs. */

--- a/Modules/_decimal/libmpdec/io.c
+++ b/Modules/_decimal/libmpdec/io.c
@@ -45,6 +45,12 @@
    PEP-3101 formatting for numeric types. */
 
 
+/* Disable warning that is part of -Wextra since gcc 7.0. */
+#if defined(__GNUC__) && !defined(__INTEL_COMPILER) && __GNUC__ >= 7
+  #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
+#endif
+
+
 /*
  * Work around the behavior of tolower() and strcasecmp() in certain
  * locales. For example, in tr_TR.utf8:

--- a/Modules/cjkcodecs/_codecs_iso2022.c
+++ b/Modules/cjkcodecs/_codecs_iso2022.c
@@ -807,15 +807,9 @@ jisx0213_encoder(const Py_UCS4 *data, Py_ssize_t *length, void *config)
     case 2: /* second character of unicode pair */
         coded = find_pairencmap((ucs2_t)data[0], (ucs2_t)data[1],
                                 jisx0213_pair_encmap, JISX0213_ENCPAIRS);
-        if (coded == DBCINV) {
-            *length = 1;
-            coded = find_pairencmap((ucs2_t)data[0], 0,
-                      jisx0213_pair_encmap, JISX0213_ENCPAIRS);
-            if (coded == DBCINV)
-                return MAP_UNMAPPABLE;
-        }
-        else
+        if (coded != DBCINV)
             return coded;
+        /* fall through */
 
     case -1: /* flush unterminated */
         *length = 1;

--- a/Objects/stringlib/codecs.h
+++ b/Objects/stringlib/codecs.h
@@ -330,7 +330,7 @@ STRINGLIB(utf8_encoder)(PyObject *unicode,
             case _Py_ERROR_REPLACE:
                 memset(p, '?', endpos - startpos);
                 p += (endpos - startpos);
-                /* fall through the ignore handler */
+                /* fall through */
             case _Py_ERROR_IGNORE:
                 i += (endpos - startpos - 1);
                 break;
@@ -378,7 +378,7 @@ STRINGLIB(utf8_encoder)(PyObject *unicode,
                 }
                 startpos = k;
                 assert(startpos < endpos);
-                /* fall through the default handler */
+                /* fall through */
             default:
                 rep = unicode_encode_call_errorhandler(
                       errors, &error_handler_obj, "utf-8", "surrogates not allowed",

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -1779,6 +1779,7 @@ unicode_dealloc(PyObject *unicode)
 
     case SSTATE_INTERNED_IMMORTAL:
         Py_FatalError("Immortal interned string died.");
+        /* fall through */
 
     default:
         Py_FatalError("Inconsistent interned string state.");
@@ -6816,7 +6817,7 @@ unicode_encode_ucs1(PyObject *unicode,
             case _Py_ERROR_REPLACE:
                 memset(str, '?', collend - collstart);
                 str += (collend - collstart);
-                /* fall through ignore error handler */
+                /* fall through */
             case _Py_ERROR_IGNORE:
                 pos = collend;
                 break;
@@ -6855,7 +6856,7 @@ unicode_encode_ucs1(PyObject *unicode,
                     break;
                 collstart = pos;
                 assert(collstart != collend);
-                /* fallback to general error handling */
+                /* fall through */
 
             default:
                 rep = unicode_encode_call_errorhandler(errors, &error_handler_obj,

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -1175,6 +1175,7 @@ ast_for_comp_op(struct compiling *c, const node *n)
                     return In;
                 if (strcmp(STR(n), "is") == 0)
                     return Is;
+                /* fall through */
             default:
                 PyErr_Format(PyExc_SystemError, "invalid comp_op: %s",
                              STR(n));
@@ -1189,6 +1190,7 @@ ast_for_comp_op(struct compiling *c, const node *n)
                     return NotIn;
                 if (strcmp(STR(CHILD(n, 0)), "is") == 0)
                     return IsNot;
+                /* fall through */
             default:
                 PyErr_Format(PyExc_SystemError, "invalid comp_op: %s %s",
                              STR(CHILD(n, 0)), STR(CHILD(n, 1)));
@@ -3149,6 +3151,7 @@ ast_for_flow_stmt(struct compiling *c, const node *n)
                 }
                 return Raise(expression, cause, LINENO(n), n->n_col_offset, c->c_arena);
             }
+            /* fall through */
         default:
             PyErr_Format(PyExc_SystemError,
                          "unexpected flow_stmt: %d", TYPE(ch));

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1875,9 +1875,11 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
             switch (oparg) {
             case 2:
                 cause = POP(); /* cause */
+                /* fall through */
             case 1:
                 exc = POP(); /* exc */
-            case 0: /* Fallthrough */
+                /* fall through */
+            case 0:
                 if (do_raise(exc, cause)) {
                     why = WHY_EXCEPTION;
                     goto fast_block_end;

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -4069,6 +4069,7 @@ expr_constant(struct compiler *c, expr_ty e)
         else if (o == Py_False)
             return 0;
     }
+    /* fall through */
     default:
         return -1;
     }
@@ -4361,13 +4362,13 @@ compiler_visit_expr(struct compiler *c, expr_ty e)
         switch (e->v.Attribute.ctx) {
         case AugLoad:
             ADDOP(c, DUP_TOP);
-            /* Fall through to load */
+            /* Fall through */
         case Load:
             ADDOP_NAME(c, LOAD_ATTR, e->v.Attribute.attr, names);
             break;
         case AugStore:
             ADDOP(c, ROT_TWO);
-            /* Fall through to save */
+            /* Fall through */
         case Store:
             ADDOP_NAME(c, STORE_ATTR, e->v.Attribute.attr, names);
             break;

--- a/Python/dtoa.c
+++ b/Python/dtoa.c
@@ -1454,7 +1454,7 @@ _Py_dg_strtod(const char *s00, char **se)
     switch (c) {
     case '-':
         sign = 1;
-        /* no break */
+        /* fall through */
     case '+':
         c = *++s;
     }
@@ -1523,7 +1523,7 @@ _Py_dg_strtod(const char *s00, char **se)
         switch (c) {
         case '-':
             esign = 1;
-            /* no break */
+            /* fall through */
         case '+':
             c = *++s;
         }
@@ -2441,7 +2441,7 @@ _Py_dg_dtoa(double dd, int mode, int ndigits,
         break;
     case 2:
         leftright = 0;
-        /* no break */
+        /* fall through */
     case 4:
         if (ndigits <= 0)
             ndigits = 1;
@@ -2449,7 +2449,7 @@ _Py_dg_dtoa(double dd, int mode, int ndigits,
         break;
     case 3:
         leftright = 0;
-        /* no break */
+        /* fall through */
     case 5:
         i = ndigits + k + 1;
         ilim = i;

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -312,6 +312,7 @@ parse_internal_render_format_spec(PyObject *format_spec,
                 format->thousands_separators = LT_UNDER_FOUR_LOCALE;
                 break;
             }
+            /* fall through */
         default:
             invalid_comma_type(format->type);
             return 0;

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2260,8 +2260,8 @@ skipitem(const char **p_format, va_list *p_va, int flags)
                 /* after 'e', only 's' and 't' is allowed */
                 goto err;
             format++;
-            /* explicit fallthrough to string cases */
         }
+        /* fall through */
 
     case 's': /* string */
     case 'z': /* string or None */

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1105,6 +1105,7 @@ r_object(RFILE *p)
 
     case TYPE_ASCII_INTERNED:
         is_interned = 1;
+        /* fall through */
     case TYPE_ASCII:
         n = r_long(p);
         if (PyErr_Occurred())
@@ -1117,6 +1118,7 @@ r_object(RFILE *p)
 
     case TYPE_SHORT_ASCII_INTERNED:
         is_interned = 1;
+        /* fall through */
     case TYPE_SHORT_ASCII:
         n = r_byte(p);
         if (n == EOF) {
@@ -1142,6 +1144,7 @@ r_object(RFILE *p)
 
     case TYPE_INTERNED:
         is_interned = 1;
+        /* fall through */
     case TYPE_UNICODE:
         {
         const char *buffer;

--- a/Python/pyhash.c
+++ b/Python/pyhash.c
@@ -393,13 +393,13 @@ siphash24(const void *src, Py_ssize_t src_sz) {
     pt = (uint8_t *)&t;
     m = (uint8_t *)in;
     switch (src_sz) {
-        case 7: pt[6] = m[6];
-        case 6: pt[5] = m[5];
-        case 5: pt[4] = m[4];
+        case 7: pt[6] = m[6]; /* fall through */
+        case 6: pt[5] = m[5]; /* fall through */
+        case 5: pt[4] = m[4]; /* fall through */
         case 4: memcpy(pt, m, sizeof(uint32_t)); break;
-        case 3: pt[2] = m[2];
-        case 2: pt[1] = m[1];
-        case 1: pt[0] = m[0];
+        case 3: pt[2] = m[2]; /* fall through */
+        case 2: pt[1] = m[1]; /* fall through */
+        case 1: pt[0] = m[0]; /* fall through */
     }
     b |= _le64toh(t);
 

--- a/Python/wordcode_helpers.h
+++ b/Python/wordcode_helpers.h
@@ -28,10 +28,13 @@ write_op_arg(_Py_CODEUNIT *codestr, unsigned char opcode,
     switch (ilen) {
         case 4:
             *codestr++ = PACKOPARG(EXTENDED_ARG, (oparg >> 24) & 0xff);
+            /* fall through */
         case 3:
             *codestr++ = PACKOPARG(EXTENDED_ARG, (oparg >> 16) & 0xff);
+            /* fall through */
         case 2:
             *codestr++ = PACKOPARG(EXTENDED_ARG, (oparg >> 8) & 0xff);
+            /* fall through */
         case 1:
             *codestr++ = PACKOPARG(opcode, oparg & 0xff);
             break;


### PR DESCRIPTION
* bpo-30923: Disable warning that has been part of -Wextra since gcc-7.0. (#3142)
* bpo-30923: Silence fall-through warnings included in -Wextra since gcc-7.0. (#3157)
* bpo-31275: Small refactoring to silence a fall-through warning. (#3206)


<!-- issue-number: bpo-30923 -->
https://bugs.python.org/issue30923
<!-- /issue-number -->
