### PR TITLE
bpo-31249: Fix test_concurrent_futures dangling thread

### DIFF
--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -222,11 +222,14 @@ class ProcessPoolShutdownTest(ProcessPoolMixin, ExecutorShutdownTest, BaseTestCa
         list(executor.map(abs, range(-5, 5)))
         queue_management_thread = executor._queue_management_thread
         processes = executor._processes
+        call_queue = executor._call_queue
         del executor
 
         queue_management_thread.join()
         for p in processes.values():
             p.join()
+        call_queue.close()
+        call_queue.join_thread()
 
 
 class WaitTests:


### PR DESCRIPTION
ProcessPoolShutdownTest.test_del_shutdown() now closes the call queue
and joins its thread, to prevent leaking a dangling thread.

<!-- issue-number: bpo-31249 -->
https://bugs.python.org/issue31249
<!-- /issue-number -->
