### PR TITLE
bpo-30830: logging.config.listen() calls server_close()

### DIFF
--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -887,7 +887,7 @@ def listen(port=DEFAULT_LOGGING_CONFIG_PORT, verify=None):
                 logging._acquireLock()
                 abort = self.abort
                 logging._releaseLock()
-            self.socket.close()
+            self.server_close()
 
     class Server(threading.Thread):
 


### PR DESCRIPTION
The ConfigSocketReceiver.serve_until_stopped() method from
logging.config.listen() now calls server_close() (of
socketserver.ThreadingTCPServer) rather than closing manually the
socket.

While this change has no effect yet, it will help to prevent dangling
threads once ThreadingTCPServer.server_close() will join spawned
threads (bpo-31233).

<!-- issue-number: bpo-30830 -->
https://bugs.python.org/issue30830
<!-- /issue-number -->
