### PR TITLE
[3.6] bpo-31394: Clarify documentation about token type attribute (GH…

### DIFF
--- a/Doc/library/tokenize.rst
+++ b/Doc/library/tokenize.rst
@@ -16,8 +16,9 @@ implemented in Python.  The scanner in this module returns comments as tokens
 as well, making it useful for implementing "pretty-printers," including
 colorizers for on-screen displays.
 
-To simplify token stream handling, all :ref:`operators` and :ref:`delimiters`
-tokens are returned using the generic :data:`token.OP` token type.  The exact
+To simplify token stream handling, all :ref:`operator <operators>` and
+:ref:`delimiter <delimiters>` tokens and :data:`Ellipsis` are returned using
+the generic :data:`~token.OP` token type.  The exact
 type can be determined by checking the ``exact_type`` property on the
 :term:`named tuple` returned from :func:`tokenize.tokenize`.
 


### PR DESCRIPTION
…-3469)

Make it clear that Ellipsis tokens also have type attribute set to token.OP..
(cherry picked from commit 5f8fbf917ebf2398aa75a1f271617e2e50ab7c88)


<!-- issue-number: bpo-31394 -->
https://bugs.python.org/issue31394
<!-- /issue-number -->
