### PR TITLE
bpo-31394: Make tokenize.rst PEP 8-compliant

### DIFF
--- a/Doc/library/tokenize.rst
+++ b/Doc/library/tokenize.rst
@@ -16,8 +16,9 @@ implemented in Python.  The scanner in this module returns comments as tokens
 as well, making it useful for implementing "pretty-printers," including
 colorizers for on-screen displays.
 
-To simplify token stream handling, all :ref:`operator <operators>` and :ref:`delimiter <delimiters>`
-tokens and :data:`Ellipsis` are returned using the generic :data:`~token.OP` token type.  The exact
+To simplify token stream handling, all :ref:`operator <operators>` and
+:ref:`delimiter <delimiters>` tokens and :data:`Ellipsis` are returned using
+the generic :data:`~token.OP` token type.  The exact
 type can be determined by checking the ``exact_type`` property on the
 :term:`named tuple` returned from :func:`tokenize.tokenize`.
 


### PR DESCRIPTION
The last commit contains lines longer than 80 characters.

<!-- issue-number: bpo-31394 -->
https://bugs.python.org/issue31394
<!-- /issue-number -->
