### PR TITLE
bpo-31429: Define TLS cipher suite on build time 

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -623,6 +623,12 @@ wildcard matching disabled by default.
 (Contributed by Mandeep Singh in :issue:`23033` and Christian Heimes in
 :issue:`31399`.)
 
+The default cipher suite selection of the ssl module now uses a blacklist
+approach rather than a hard-coded whitelist. Python no longer re-enables
+ciphers that have been blocked by OpenSSL security update. Default cipher
+suite selection can be configured on compile time.
+(Contributed by Christian Heimes in :issue:`31429`.)
+
 string
 ------
 

--- a/Misc/NEWS.d/next/Library/2018-01-28-22-40-05.bpo-31429.qNt8rQ.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-28-22-40-05.bpo-31429.qNt8rQ.rst
@@ -1,0 +1,4 @@
+The default cipher suite selection of the ssl module now uses a blacklist
+approach rather than a hard-coded whitelist. Python no longer re-enables
+ciphers that have been blocked by OpenSSL security update. Default cipher
+suite selection can be configured on compile time.

--- a/configure
+++ b/configure
@@ -840,6 +840,7 @@ enable_big_digits
 with_computed_gotos
 with_ensurepip
 with_openssl
+with_ssl_default_suites
 '
       ac_precious_vars='build_alias
 host_alias
@@ -1538,6 +1539,11 @@ Optional Packages:
   --with(out)-ensurepip=[=upgrade]
                           "install" or "upgrade" using bundled pip
   --with-openssl=DIR      root of the OpenSSL directory
+  --with-ssl-default-suites=[python|openssl|STRING]
+                          Override default cipher suites string, python: use
+                          Python's preferred selection (default), openssl:
+                          leave OpenSSL's defaults untouched, STRING: use a
+                          custom string, PROTOCOL_SSLv2 ignores the setting
 
 Some influential environment variables:
   MACHDEP     name for machine-dependent library files
@@ -16930,6 +16936,48 @@ $as_echo "#define HAVE_X509_VERIFY_PARAM_SET1_HOST 1" >>confdefs.h
     LDFLAGS="$save_LDFLAGS"
     LIBS="$save_LIBS"
 fi
+
+# ssl module default cipher suite string
+
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for --with-ssl-default-suites" >&5
+$as_echo_n "checking for --with-ssl-default-suites... " >&6; }
+
+# Check whether --with-ssl-default-suites was given.
+if test "${with_ssl_default_suites+set}" = set; then :
+  withval=$with_ssl_default_suites;
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $withval" >&5
+$as_echo "$withval" >&6; }
+case "$withval" in
+    python)
+        $as_echo "#define PY_SSL_DEFAULT_CIPHERS 1" >>confdefs.h
+
+        ;;
+    openssl)
+        $as_echo "#define PY_SSL_DEFAULT_CIPHERS 2" >>confdefs.h
+
+        ;;
+    *)
+        $as_echo "#define PY_SSL_DEFAULT_CIPHERS 0" >>confdefs.h
+
+        cat >>confdefs.h <<_ACEOF
+#define PY_SSL_DEFAULT_CIPHER_STRING "$withval"
+_ACEOF
+
+        ;;
+esac
+
+else
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: python" >&5
+$as_echo "python" >&6; }
+$as_echo "#define PY_SSL_DEFAULT_CIPHERS 1" >>confdefs.h
+
+
+fi
+
+
 
 # generate output files
 ac_config_files="$ac_config_files Makefile.pre Misc/python.pc Misc/python-config.sh"

--- a/configure.ac
+++ b/configure.ac
@@ -5497,6 +5497,43 @@ if test "$have_openssl" = yes; then
     LIBS="$save_LIBS"
 fi
 
+# ssl module default cipher suite string
+AH_TEMPLATE(PY_SSL_DEFAULT_CIPHERS,
+  [Default cipher suites list for ssl module.
+   1: Python's preferred selection, 2: leave OpenSSL defaults untouched, 0: custom string])
+AH_TEMPLATE(PY_SSL_DEFAULT_CIPHER_STRING,
+  [Cipher suite string for PY_SSL_DEFAULT_CIPHERS=0]
+)
+
+AC_MSG_CHECKING(for --with-ssl-default-suites)
+AC_ARG_WITH(ssl-default-suites,
+            AS_HELP_STRING([--with-ssl-default-suites=@<:@python|openssl|STRING@:>@],
+                           [Override default cipher suites string,
+                            python: use Python's preferred selection (default),
+                            openssl: leave OpenSSL's defaults untouched,
+                            STRING: use a custom string,
+                            PROTOCOL_SSLv2 ignores the setting]),
+[
+AC_MSG_RESULT($withval)
+case "$withval" in
+    python)
+        AC_DEFINE(PY_SSL_DEFAULT_CIPHERS, 1)
+        ;;
+    openssl)
+        AC_DEFINE(PY_SSL_DEFAULT_CIPHERS, 2)
+        ;;
+    *)
+        AC_DEFINE(PY_SSL_DEFAULT_CIPHERS, 0)
+        AC_DEFINE_UNQUOTED(PY_SSL_DEFAULT_CIPHER_STRING, "$withval")
+        ;;
+esac
+],
+[
+AC_MSG_RESULT(python)
+AC_DEFINE(PY_SSL_DEFAULT_CIPHERS, 1)
+])
+
+
 # generate output files
 AC_CONFIG_FILES(Makefile.pre Misc/python.pc Misc/python-config.sh)
 AC_CONFIG_FILES([Modules/ld_so_aix], [chmod +x Modules/ld_so_aix])

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1311,6 +1311,13 @@
 /* Define to printf format modifier for Py_ssize_t */
 #undef PY_FORMAT_SIZE_T
 
+/* Default cipher suites list for ssl module. 1: Python's preferred selection,
+   2: leave OpenSSL defaults untouched, 0: custom string */
+#undef PY_SSL_DEFAULT_CIPHERS
+
+/* Cipher suite string for PY_SSL_DEFAULT_CIPHERS=0 */
+#undef PY_SSL_DEFAULT_CIPHER_STRING
+
 /* Define to emit a locale compatibility warning in the C locale */
 #undef PY_WARN_ON_C_LOCALE
 


### PR DESCRIPTION
Until now Python used a hard coded white list of default TLS cipher
suites. The old approach has multiple downsides. OpenSSL's default
selection was completely overruled. Python did neither benefit from new
cipher suites (ChaCha20, TLS 1.3 suites) nor blacklisted cipher suites.
For example we used to re-enable 3DES.

Python now defaults to OpenSSL DEFAULT cipher suite selection and black
lists all unwanted ciphers. Downstream vendors can override the default
cipher list with --with-ssl-default-suites.

Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: bpo-31429 -->
https://bugs.python.org/issue31429
<!-- /issue-number -->
