### PR TITLE
bpo-31234: Fix dangling thread in test_ftp/poplib

### DIFF
--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -470,6 +470,8 @@ class TestFTPClass(TestCase):
     def tearDown(self):
         self.client.close()
         self.server.stop()
+        # Explicitly clear the attribute to prevent dangling thread
+        self.server = None
         asyncore.close_all(ignore_all=True)
 
     def check_data(self, received, expected):
@@ -800,6 +802,8 @@ class TestIPv6Environment(TestCase):
     def tearDown(self):
         self.client.close()
         self.server.stop()
+        # Explicitly clear the attribute to prevent dangling thread
+        self.server = None
         asyncore.close_all(ignore_all=True)
 
     def test_af(self):
@@ -859,6 +863,8 @@ class TestTLS_FTPClass(TestCase):
     def tearDown(self):
         self.client.close()
         self.server.stop()
+        # Explicitly clear the attribute to prevent dangling thread
+        self.server = None
         asyncore.close_all(ignore_all=True)
 
     def test_control_connection(self):

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -254,6 +254,8 @@ class TestPOP3Class(TestCase):
     def tearDown(self):
         self.client.close()
         self.server.stop()
+        # Explicitly clear the attribute to prevent dangling thread
+        self.server = None
 
     def test_getwelcome(self):
         self.assertEqual(self.client.getwelcome(),
@@ -436,6 +438,8 @@ class TestPOP3_TLSClass(TestPOP3Class):
                 # this exception
                 self.client.close()
         self.server.stop()
+        # Explicitly clear the attribute to prevent dangling thread
+        self.server = None
 
     def test_stls(self):
         self.assertRaises(poplib.error_proto, self.client.stls)
@@ -461,7 +465,8 @@ class TestTimeouts(TestCase):
 
     def tearDown(self):
         self.thread.join()
-        del self.thread  # Clear out any dangling Thread objects.
+        # Explicitly clear the attribute to prevent dangling thread
+        self.thread = None
 
     def server(self, evt, serv):
         serv.listen()


### PR DESCRIPTION
Explicitly clear the server attribute in test_ftplib and test_poplib
to prevent dangling thread.

<!-- issue-number: bpo-31234 -->
https://bugs.python.org/issue31234
<!-- /issue-number -->
