### PR TITLE
bpo-31234: Fix dangling thread in test_ftplib

### DIFF
--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -988,6 +988,8 @@ class TestTimeouts(TestCase):
     def tearDown(self):
         ftplib.FTP.port = self.old_port
         self.server_thread.join()
+        # Explicitly clear the attribute to prevent dangling thread
+        self.server_thread = None
 
     def server(self):
         # This method sets the evt 3 times:


### PR DESCRIPTION
Clear also self.server_thread attribute in TestTimeouts.tearDown().

<!-- issue-number: bpo-31234 -->
https://bugs.python.org/issue31234
<!-- /issue-number -->
