### PR TITLE
bpo-31455: avoid calling "PyObject_GetAttrString()" with a live exception set

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2400,29 +2400,6 @@ class TreeBuilderTest(unittest.TestCase):
         self.assertEqual(child.tail, 'tail')
         self.assertEqual(child.attrib, {})
 
-    def test_exceptions(self):
-        class RaisingBuilder:
-            def __init__(self, raise_in=None, what=ValueError):
-                self.raise_in = raise_in
-                self.what = what
-
-            def __getattr__(self, name):
-                if name == self.raise_in:
-                    raise self.what(self.raise_in)
-                def handle(*args):
-                    pass
-                return handle
-
-        ET.XMLParser(target=RaisingBuilder())
-        # cET also checks for 'close' and 'doctype', PyET does it only at need
-        for event in ('start', 'data', 'end', 'comment', 'pi'):
-            with self.assertRaisesRegex(ValueError, event):
-                ET.XMLParser(target=RaisingBuilder(event))
-
-        ET.XMLParser(target=RaisingBuilder(what=AttributeError))
-        for event in ('start', 'data', 'end', 'comment', 'pi'):
-            ET.XMLParser(target=RaisingBuilder(event, what=AttributeError))
-
     def test_dummy_builder(self):
         class BaseDummyBuilder:
             def close(self):
@@ -2520,6 +2497,31 @@ class TreeBuilderTest(unittest.TestCase):
         self.assertEqual(parser.close(),
             ('html', '-//W3C//DTD XHTML 1.0 Transitional//EN',
              'http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd'))
+
+    def test_builder_lookup_errors(self):
+        class RaisingBuilder:
+            def __init__(self, raise_in=None, what=ValueError):
+                self.raise_in = raise_in
+                self.what = what
+
+            def __getattr__(self, name):
+                if name == self.raise_in:
+                    raise self.what(self.raise_in)
+                def handle(*args):
+                    pass
+                return handle
+
+        ET.XMLParser(target=RaisingBuilder())
+        # cET also checks for 'close' and 'doctype', PyET does it only at need
+        for event in ('start', 'data', 'end', 'comment', 'pi'):
+            with self.assertRaisesRegex(ValueError, event):
+                ET.XMLParser(target=RaisingBuilder(event))
+
+        ET.XMLParser(target=RaisingBuilder(what=AttributeError))
+        for event in ('start', 'data', 'end', 'comment', 'pi'):
+            parser = ET.XMLParser(target=RaisingBuilder(event, what=AttributeError))
+            parser.feed(self.sample1)
+            self.assertIsNone(parser.close())
 
 
 class XMLParserTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2017-09-13-19-55-35.bpo-31544.beTh6t.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-13-19-55-35.bpo-31544.beTh6t.rst
@@ -1,0 +1,2 @@
+The C accelerator module of ElementTree ignored exceptions raised when
+looking up TreeBuilder target methods in XMLParser().

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3313,13 +3313,18 @@ _elementtree_XMLParser___init___impl(XMLParserObject *self, PyObject *html,
     self->target = target;
 
     self->handle_start = PyObject_GetAttrString(target, "start");
+    PyErr_Clear();
     self->handle_data = PyObject_GetAttrString(target, "data");
+    PyErr_Clear();
     self->handle_end = PyObject_GetAttrString(target, "end");
+    PyErr_Clear();
     self->handle_comment = PyObject_GetAttrString(target, "comment");
+    PyErr_Clear();
     self->handle_pi = PyObject_GetAttrString(target, "pi");
+    PyErr_Clear();
     self->handle_close = PyObject_GetAttrString(target, "close");
+    PyErr_Clear();
     self->handle_doctype = PyObject_GetAttrString(target, "doctype");
-
     PyErr_Clear();
 
     /* configure parser */

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3260,7 +3260,8 @@ xmlparser_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 }
 
 static int
-ignore_attribute_error(PyObject *value) {
+ignore_attribute_error(PyObject *value)
+{
     if (value == NULL) {
         if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
             return -1;
@@ -3324,26 +3325,33 @@ _elementtree_XMLParser___init___impl(XMLParserObject *self, PyObject *html,
     self->target = target;
 
     self->handle_start = PyObject_GetAttrString(target, "start");
-    if (ignore_attribute_error(self->handle_start))
+    if (ignore_attribute_error(self->handle_start)) {
         return -1;
+    }
     self->handle_data = PyObject_GetAttrString(target, "data");
-    if (ignore_attribute_error(self->handle_data))
+    if (ignore_attribute_error(self->handle_data)) {
         return -1;
+    }
     self->handle_end = PyObject_GetAttrString(target, "end");
-    if (ignore_attribute_error(self->handle_end))
+    if (ignore_attribute_error(self->handle_end)) {
         return -1;
+    }
     self->handle_comment = PyObject_GetAttrString(target, "comment");
-    if (ignore_attribute_error(self->handle_comment))
+    if (ignore_attribute_error(self->handle_comment)) {
         return -1;
+    }
     self->handle_pi = PyObject_GetAttrString(target, "pi");
-    if (ignore_attribute_error(self->handle_pi))
+    if (ignore_attribute_error(self->handle_pi)) {
         return -1;
+    }
     self->handle_close = PyObject_GetAttrString(target, "close");
-    if (ignore_attribute_error(self->handle_close))
+    if (ignore_attribute_error(self->handle_close)) {
         return -1;
+    }
     self->handle_doctype = PyObject_GetAttrString(target, "doctype");
-    if (ignore_attribute_error(self->handle_doctype))
+    if (ignore_attribute_error(self->handle_doctype)) {
         return -1;
+    }
 
     /* configure parser */
     EXPAT(SetUserData)(self->parser, self);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3259,6 +3259,17 @@ xmlparser_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return (PyObject *)self;
 }
 
+static int
+ignore_attribute_error(PyObject *value) {
+    if (value == NULL) {
+        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            return -1;
+        }
+        PyErr_Clear();
+    }
+    return 0;
+}
+
 /*[clinic input]
 _elementtree.XMLParser.__init__
 
@@ -3313,19 +3324,26 @@ _elementtree_XMLParser___init___impl(XMLParserObject *self, PyObject *html,
     self->target = target;
 
     self->handle_start = PyObject_GetAttrString(target, "start");
-    PyErr_Clear();
+    if (ignore_attribute_error(self->handle_start))
+        return -1;
     self->handle_data = PyObject_GetAttrString(target, "data");
-    PyErr_Clear();
+    if (ignore_attribute_error(self->handle_data))
+        return -1;
     self->handle_end = PyObject_GetAttrString(target, "end");
-    PyErr_Clear();
+    if (ignore_attribute_error(self->handle_end))
+        return -1;
     self->handle_comment = PyObject_GetAttrString(target, "comment");
-    PyErr_Clear();
+    if (ignore_attribute_error(self->handle_comment))
+        return -1;
     self->handle_pi = PyObject_GetAttrString(target, "pi");
-    PyErr_Clear();
+    if (ignore_attribute_error(self->handle_pi))
+        return -1;
     self->handle_close = PyObject_GetAttrString(target, "close");
-    PyErr_Clear();
+    if (ignore_attribute_error(self->handle_close))
+        return -1;
     self->handle_doctype = PyObject_GetAttrString(target, "doctype");
-    PyErr_Clear();
+    if (ignore_attribute_error(self->handle_doctype))
+        return -1;
 
     /* configure parser */
     EXPAT(SetUserData)(self->parser, self);


### PR DESCRIPTION



<!-- issue-number: bpo-31455 -->
https://bugs.python.org/issue31455
<!-- /issue-number -->
