### PR TITLE
API: Create directories when saving logs

### DIFF
--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -196,6 +196,8 @@ class TimedRotatingFileHandler(BaseRotatingHandler):
     files are kept - the oldest ones are deleted.
     """
     def __init__(self, filename, when='h', interval=1, backupCount=0, encoding=None, delay=False, utc=False, atTime=None):
+        if filename is not none:
+            os.makedirs(os.path.dirname(filename), exist_ok=True)
         BaseRotatingHandler.__init__(self, filename, 'a', encoding, delay)
         self.when = when.upper()
         self.backupCount = backupCount


### PR DESCRIPTION
Creates directory for saving logs, if folder in given file location is not available, for TimedRotatingFileHandler

To avoid errors when directory is not found.
Every time I am having to create trace->log->general (these folders and much more while writing logs in a file, this change helps me to reduce the time spent on creating folders manually)

!!! If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

[X.Y] <title from the original PR> GH-NNNN

Where: [X.Y] is the branch name, for example [3.6]

GH-NNNN refers to the PR number from `master`.

PLEASE: Remove this headline!!!
