### PR TITLE
bpo-31457: Allow for nested LoggerAdapter objects

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1739,6 +1739,27 @@ class LoggerAdapter(object):
         """
         return self.logger.hasHandlers()
 
+    def _log(self, level, msg, args, exc_info=None, extra=None, stack_info=False):
+        """
+        Low-level log implementation, proxied to allow nested logger adapters.
+        """
+        return self.logger._log(
+            level,
+            msg,
+            args,
+            exc_info=exc_info,
+            extra=extra,
+            stack_info=stack_info,
+        )
+
+    @property
+    def manager(self):
+        return self.logger.manager
+
+    @manager.setter
+    def set_manager(self, value):
+        self.logger.manager = value
+
     def __repr__(self):
         logger = self.logger
         level = getLevelName(logger.getEffectiveLevel())

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3986,6 +3986,17 @@ class LoggerAdapterTest(unittest.TestCase):
         self.assertFalse(self.logger.hasHandlers())
         self.assertFalse(self.adapter.hasHandlers())
 
+    def test_nested(self):
+        msg = 'Adapters can be nested, yo.'
+        adapter_adapter = logging.LoggerAdapter(logger=self.adapter, extra=None)
+        adapter_adapter.log(logging.CRITICAL, msg, self.recording)
+
+        self.assertEqual(len(self.recording.records), 1)
+        record = self.recording.records[0]
+        self.assertEqual(record.levelno, logging.CRITICAL)
+        self.assertEqual(record.msg, msg)
+        self.assertEqual(record.args, (self.recording,))
+
 
 class LoggerTest(BaseTest):
 

--- a/Misc/NEWS.d/next/Library/2017-09-13-13-33-39.bpo-31457.bIVBtI.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-13-13-33-39.bpo-31457.bIVBtI.rst
@@ -1,0 +1,1 @@
+LoggerAdapter objects can now be nested.


### PR DESCRIPTION
Some of the proxied methods use internal Logger state which isn't proxied,
causing failures if an adapter is applied to another adapter.

This commit fixes the issue, adds a new test for the use case.


<!-- issue-number: bpo-31457 -->
https://bugs.python.org/issue31457
<!-- /issue-number -->
