### PR TITLE
bpo-31458: Update Misc/NEWS link in What's New page

### DIFF
--- a/Doc/whatsnew/index.rst
+++ b/Doc/whatsnew/index.rst
@@ -28,7 +28,7 @@ anyone wishing to stay up-to-date after a new release.
    2.1.rst
    2.0.rst
 
-The "Changelog" is a HTML version of the file :source:`Misc/NEWS` which
+The "Changelog" is a HTML version of the file :source:`Misc/NEWS.d` which
 contains *all* nontrivial changes to Python for the current version.
 
 .. toctree::

--- a/README.rst
+++ b/README.rst
@@ -128,7 +128,7 @@ What's New
 We have a comprehensive overview of the changes in the `What's New in Python
 3.7 <https://docs.python.org/3.7/whatsnew/3.7.html>`_ document.  For a more
 detailed change log, read `Misc/NEWS
-<https://github.com/python/cpython/blob/master/Misc/NEWS>`_, but a full
+<https://github.com/python/cpython/blob/master/Misc/NEWS.d>`_, but a full
 accounting of changes can only be gleaned from the `commit history
 <https://github.com/python/cpython/commits/master>`_.
 


### PR DESCRIPTION
Link to `Misc/NEWS.d` instead

<!-- issue-number: bpo-31458 -->
https://bugs.python.org/issue31458
<!-- /issue-number -->
