### PR TITLE
_ssl_: Fix compiler warning

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3086,7 +3086,7 @@ _ssl__SSLContext__set_alpn_protocols_impl(PySSLContext *self,
 /*[clinic end generated code: output=87599a7f76651a9b input=9bba964595d519be]*/
 {
 #ifdef HAVE_ALPN
-    if (protos->len > UINT_MAX) {
+    if ((size_t)protos->len > UINT_MAX) {
         PyErr_Format(PyExc_OverflowError,
             "protocols longer than %d bytes", UINT_MAX);
         return NULL;


### PR DESCRIPTION
Cast Py_buffer.len (Py_ssize_t, signed) to size_t (unsigned) to
prevent the following warning:

Modules/_ssl.c:3089:21: warning: comparison between signed and
unsigned integer expressions [-Wsign-compare]