### PR TITLE
[3.6] bpo-31458: Update Misc/NEWS link in What's New page (GH-3555)

### DIFF
--- a/Doc/whatsnew/index.rst
+++ b/Doc/whatsnew/index.rst
@@ -27,7 +27,7 @@ anyone wishing to stay up-to-date after a new release.
    2.1.rst
    2.0.rst
 
-The "Changelog" is a HTML version of the file :source:`Misc/NEWS` which
+The "Changelog" is a HTML version of the file :source:`Misc/NEWS.d` which
 contains *all* nontrivial changes to Python for the current version.
 
 .. toctree::

--- a/README.rst
+++ b/README.rst
@@ -127,7 +127,7 @@ What's New
 We have a comprehensive overview of the changes in the `What's New in Python
 3.6 <https://docs.python.org/3.6/whatsnew/3.6.html>`_ document.  For a more
 detailed change log, read `Misc/NEWS
-<https://github.com/python/cpython/blob/3.6/Misc/NEWS>`_, but a full
+<https://github.com/python/cpython/blob/3.6/Misc/NEWS.d>`_, but a full
 accounting of changes can only be gleaned from the `commit history
 <https://github.com/python/cpython/commits/3.6>`_.
 


### PR DESCRIPTION
Update the link from Misc/NEWS to Misc/NEWS.d.
(cherry picked from commit 1b8f612e1800b6e58472113f4abe8ee7c31f4db7)

<!-- issue-number: bpo-31458 -->
https://bugs.python.org/issue31458
<!-- /issue-number -->
