### PR TITLE
Fixed the code example for cookie signing.

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -506,8 +506,9 @@ to users and later verify them to make sure they weren't tampered with::
     >>> AUTH_SIZE = 16
     >>>
     >>> def sign(cookie):
-    ...     h = blake2b(data=cookie, digest_size=AUTH_SIZE, key=SECRET_KEY)
-    ...     return h.hexdigest()
+    ...     h = blake2b(digest_size=AUTH_SIZE, key=SECRET_KEY)
+    ...     h.update(cookie)
+    ...     return h.hexdigest().encode('utf-8')
     >>>
     >>> cookie = b'user:vatrogasac'
     >>> sig = sign(cookie)
@@ -517,7 +518,7 @@ to users and later verify them to make sure they weren't tampered with::
     True
     >>> compare_digest(b'user:policajac', sig)
     False
-    >>> compare_digesty(cookie, '0102030405060708090a0b0c0d0e0f00')
+    >>> compare_digest(cookie, b'0102030405060708090a0b0c0d0e0f00')
     False
 
 Even though there's a native keyed hashing mode, BLAKE2 can, of course, be used


### PR DESCRIPTION
The [symmetrical cookie signing code example](https://docs.python.org/3/library/hashlib.html#keyed-hashing) had a few issues:
1. The `blake2b` function does not take the `data` keyword argument,
2. The hex digest returned by `sign` was a string, whereas `compare_digest` expects bytes-like objects.
3. There was a typo in `compare_digesty`.