### PR TITLE
consistently use Py_TYPE, Py_REFCNT, and correct initializer macros

### DIFF
--- a/Include/frameobject.h
+++ b/Include/frameobject.h
@@ -54,7 +54,7 @@ typedef struct _frame {
 
 PyAPI_DATA(PyTypeObject) PyFrame_Type;
 
-#define PyFrame_Check(op) ((op)->ob_type == &PyFrame_Type)
+#define PyFrame_Check(op) (Py_TYPE(op) == &PyFrame_Type)
 #define PyFrame_IsRestricted(f) \
 	((f)->f_builtins != (f)->f_tstate->interp->builtins)
 

--- a/Include/intobject.h
+++ b/Include/intobject.h
@@ -28,8 +28,8 @@ typedef struct {
 PyAPI_DATA(PyTypeObject) PyInt_Type;
 
 #define PyInt_Check(op) \
-		 PyType_FastSubclass((op)->ob_type, Py_TPFLAGS_INT_SUBCLASS)
-#define PyInt_CheckExact(op) ((op)->ob_type == &PyInt_Type)
+		 PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_INT_SUBCLASS)
+#define PyInt_CheckExact(op) (Py_TYPE(op) == &PyInt_Type)
 
 PyAPI_FUNC(PyObject *) PyInt_FromString(char*, char**, int);
 #ifdef Py_USING_UNICODE

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -108,7 +108,7 @@ typedef struct {
     ffi_type *atypes[1];
 } CThunkObject;
 extern PyTypeObject PyCThunk_Type;
-#define CThunk_CheckExact(v)        ((v)->ob_type == &PyCThunk_Type)
+#define CThunk_CheckExact(v)        (Py_TYPE(v) == &PyCThunk_Type)
 
 typedef struct {
     /* First part identical to tagCDataObject */

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1661,8 +1661,8 @@ static PyMappingMethods element_as_mapping = {
 };
 
 statichere PyTypeObject Element_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0, "Element", sizeof(ElementObject), 0,
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "Element", sizeof(ElementObject), 0,
     /* methods */
     (destructor)element_dealloc, /* tp_dealloc */
     0, /* tp_print */
@@ -2031,8 +2031,8 @@ treebuilder_getattr(TreeBuilderObject* self, char* name)
 }
 
 statichere PyTypeObject TreeBuilder_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0, "TreeBuilder", sizeof(TreeBuilderObject), 0,
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "TreeBuilder", sizeof(TreeBuilderObject), 0,
     /* methods */
     (destructor)treebuilder_dealloc, /* tp_dealloc */
     0, /* tp_print */
@@ -2897,8 +2897,8 @@ xmlparser_getattr(XMLParserObject* self, char* name)
 }
 
 statichere PyTypeObject XMLParser_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0, "XMLParser", sizeof(XMLParserObject), 0,
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "XMLParser", sizeof(XMLParserObject), 0,
     /* methods */
     (destructor)xmlparser_dealloc, /* tp_dealloc */
     0, /* tp_print */

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1767,8 +1767,7 @@ PyDoc_STRVAR(scanner_doc, "JSON scanner object");
 
 static
 PyTypeObject PyScannerType = {
-    PyObject_HEAD_INIT(NULL)
-    0,                    /* tp_internal */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "_json.Scanner",       /* tp_name */
     sizeof(PyScannerObject), /* tp_basicsize */
     0,                    /* tp_itemsize */
@@ -2344,8 +2343,7 @@ PyDoc_STRVAR(encoder_doc, "_iterencode(obj, _current_indent_level) -> iterable")
 
 static
 PyTypeObject PyEncoderType = {
-    PyObject_HEAD_INIT(NULL)
-    0,                    /* tp_internal */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "_json.Encoder",       /* tp_name */
     sizeof(PyEncoderObject), /* tp_basicsize */
     0,                    /* tp_itemsize */

--- a/Modules/_lsprof.c
+++ b/Modules/_lsprof.c
@@ -817,8 +817,7 @@ Profiler(custom_timer=None, time_unit=None, subcalls=True, builtins=True)\n\
 ");
 
 statichere PyTypeObject PyProfiler_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0,                                      /* ob_size */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "_lsprof.Profiler",                     /* tp_name */
     sizeof(ProfilerObject),                 /* tp_basicsize */
     0,                                      /* tp_itemsize */

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -293,7 +293,7 @@ void pysqlite_connection_dealloc(pysqlite_Connection* self)
     Py_XDECREF(self->statements);
     Py_XDECREF(self->cursors);
 
-    self->ob_type->tp_free((PyObject*)self);
+    Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 /*

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -135,7 +135,7 @@ static void pysqlite_cursor_dealloc(pysqlite_Cursor* self)
         PyObject_ClearWeakRefs((PyObject*)self);
     }
 
-    self->ob_type->tp_free((PyObject*)self);
+    Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
 PyObject* _pysqlite_get_converter(PyObject* key)

--- a/Modules/_sre.c
+++ b/Modules/_sre.c
@@ -2712,8 +2712,8 @@ static PyMemberDef pattern_members[] = {
 };
 
 statichere PyTypeObject Pattern_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0, "_" SRE_MODULE ".SRE_Pattern",
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "_" SRE_MODULE ".SRE_Pattern",
     sizeof(PatternObject), sizeof(SRE_CODE),
     (destructor)pattern_dealloc, /*tp_dealloc*/
     0,                                  /* tp_print */
@@ -3952,8 +3952,8 @@ static PyMemberDef scanner_members[] = {
 };
 
 statichere PyTypeObject Scanner_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0, "_" SRE_MODULE ".SRE_Scanner",
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "_" SRE_MODULE ".SRE_Scanner",
     sizeof(ScannerObject), 0,
     (destructor)scanner_dealloc, /*tp_dealloc*/
     0,				/* tp_print */

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -187,8 +187,7 @@ test_dict_iteration(PyObject* self)
  *   PyType_Ready if it hasn't already been called
  */
 static PyTypeObject _HashInheritanceTester_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0,                          /* Number of items for varobject */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "hashinheritancetester",            /* Name of this type */
     sizeof(PyObject),           /* Basic object size */
     0,                          /* Item size for varobject */
@@ -315,8 +314,7 @@ static PyBufferProcs memoryviewtester_as_buffer = {
 };
 
 static PyTypeObject _MemoryViewTester_Type = {
-    PyObject_HEAD_INIT(NULL)
-    0,                          /* Number of items for varobject */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "memoryviewtester",         /* Name of this type */
     sizeof(PyObject),           /* Basic object size */
     0,                          /* Item size for varobject */

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -1292,9 +1292,9 @@ array_tofile(arrayobject *self, PyObject *f)
         PyErr_SetString(PyExc_TypeError, "arg must be open file");
         return NULL;
     }
-    if (self->ob_size > 0) {
+    if (Py_SIZE(self) > 0) {
         if (fwrite(self->ob_item, self->ob_descr->itemsize,
-                   self->ob_size, fp) != (size_t)self->ob_size) {
+                   Py_SIZE(self), fp) != (size_t)Py_SIZE(self)) {
             PyErr_SetFromErrno(PyExc_IOError);
             clearerr(fp);
             return NULL;
@@ -1348,7 +1348,7 @@ array_fromlist(arrayobject *self, PyObject *list)
             if ((*self->ob_descr->setitem)(self,
                             Py_SIZE(self) - n + i, v) != 0) {
                 Py_SIZE(self) -= n;
-                if (itemsize && (self->ob_size > PY_SSIZE_T_MAX / itemsize)) {
+                if (itemsize && (Py_SIZE(self) > PY_SSIZE_T_MAX / itemsize)) {
                     return PyErr_NoMemory();
                 }
                 PyMem_RESIZE(item, char,
@@ -1444,7 +1444,7 @@ values,as if it had been read from a file using the fromfile() method).");
 static PyObject *
 array_tostring(arrayobject *self, PyObject *unused)
 {
-    if (self->ob_size <= PY_SSIZE_T_MAX / self->ob_descr->itemsize) {
+    if (Py_SIZE(self) <= PY_SSIZE_T_MAX / self->ob_descr->itemsize) {
         return PyString_FromStringAndSize(self->ob_item,
                             Py_SIZE(self) * self->ob_descr->itemsize);
     } else {
@@ -2289,8 +2289,8 @@ initarray(void)
 {
     PyObject *m;
 
-    Arraytype.ob_type = &PyType_Type;
-    PyArrayIter_Type.ob_type = &PyType_Type;
+    Py_TYPE(&Arraytype) = &PyType_Type;
+    Py_TYPE(&PyArrayIter_Type) = &PyType_Type;
     m = Py_InitModule3("array", a_methods, module_doc);
     if (m == NULL)
         return;

--- a/Modules/datetimemodule.c
+++ b/Modules/datetimemodule.c
@@ -3039,8 +3039,7 @@ static char tzinfo_doc[] =
 PyDoc_STR("Abstract base class for time zone info objects.");
 
 statichere PyTypeObject PyDateTime_TZInfoType = {
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "datetime.tzinfo",                          /* tp_name */
     sizeof(PyDateTime_TZInfo),                  /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -3564,8 +3563,7 @@ static PyNumberMethods time_as_number = {
 };
 
 statichere PyTypeObject PyDateTime_TimeType = {
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "datetime.time",                            /* tp_name */
     sizeof(PyDateTime_Time),                    /* tp_basicsize */
     0,                                          /* tp_itemsize */
@@ -4692,8 +4690,7 @@ static PyNumberMethods datetime_as_number = {
 };
 
 statichere PyTypeObject PyDateTime_DateTimeType = {
-    PyObject_HEAD_INIT(NULL)
-    0,                                          /* ob_size */
+    PyVarObject_HEAD_INIT(NULL, 0)
     "datetime.datetime",                        /* tp_name */
     sizeof(PyDateTime_DateTime),                /* tp_basicsize */
     0,                                          /* tp_itemsize */

--- a/Objects/bufferobject.c
+++ b/Objects/bufferobject.c
@@ -34,7 +34,7 @@ get_buf(PyBufferObject *self, void **ptr, Py_ssize_t *size,
     else {
         Py_ssize_t count, offset;
         readbufferproc proc = 0;
-        PyBufferProcs *bp = self->b_base->ob_type->tp_as_buffer;
+        PyBufferProcs *bp = Py_TYPE(self->b_base)->tp_as_buffer;
         if ((*bp->bf_getsegcount)(self->b_base, NULL) != 1) {
             PyErr_SetString(PyExc_TypeError,
                 "single-segment buffer object expected");
@@ -47,7 +47,7 @@ get_buf(PyBufferObject *self, void **ptr, Py_ssize_t *size,
             (buffer_type == ANY_BUFFER))
             proc = (readbufferproc)bp->bf_getwritebuffer;
         else if (buffer_type == CHAR_BUFFER) {
-            if (!PyType_HasFeature(self->ob_type,
+            if (!PyType_HasFeature(Py_TYPE(self),
                         Py_TPFLAGS_HAVE_GETCHARBUFFER)) {
             PyErr_SetString(PyExc_TypeError,
                 "Py_TPFLAGS_HAVE_GETCHARBUFFER needed");

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -368,8 +368,7 @@ static PyGetSetDef BaseException_getset[] = {
 
 
 static PyTypeObject _PyExc_BaseException = {
-    PyObject_HEAD_INIT(NULL)
-    0,                          /*ob_size*/
+    PyVarObject_HEAD_INIT(NULL, 0)
     EXC_MODULE_NAME "BaseException", /*tp_name*/
     sizeof(PyBaseExceptionObject), /*tp_basicsize*/
     0,                          /*tp_itemsize*/
@@ -419,8 +418,7 @@ PyObject *PyExc_BaseException = (PyObject *)&_PyExc_BaseException;
  */
 #define SimpleExtendsException(EXCBASE, EXCNAME, EXCDOC) \
 static PyTypeObject _PyExc_ ## EXCNAME = { \
-    PyObject_HEAD_INIT(NULL) \
-    0, \
+    PyVarObject_HEAD_INIT(NULL, 0) \
     EXC_MODULE_NAME # EXCNAME, \
     sizeof(PyBaseExceptionObject), \
     0, (destructor)BaseException_dealloc, 0, 0, 0, 0, 0, 0, 0, \
@@ -435,8 +433,7 @@ PyObject *PyExc_ ## EXCNAME = (PyObject *)&_PyExc_ ## EXCNAME
 
 #define MiddlingExtendsException(EXCBASE, EXCNAME, EXCSTORE, EXCDOC) \
 static PyTypeObject _PyExc_ ## EXCNAME = { \
-    PyObject_HEAD_INIT(NULL) \
-    0, \
+    PyVarObject_HEAD_INIT(NULL, 0) \
     EXC_MODULE_NAME # EXCNAME, \
     sizeof(Py ## EXCSTORE ## Object), \
     0, (destructor)EXCSTORE ## _dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
@@ -451,8 +448,7 @@ PyObject *PyExc_ ## EXCNAME = (PyObject *)&_PyExc_ ## EXCNAME
 
 #define ComplexExtendsException(EXCBASE, EXCNAME, EXCSTORE, EXCDEALLOC, EXCMETHODS, EXCMEMBERS, EXCSTR, EXCDOC) \
 static PyTypeObject _PyExc_ ## EXCNAME = { \
-    PyObject_HEAD_INIT(NULL) \
-    0, \
+    PyVarObject_HEAD_INIT(NULL, 0) \
     EXC_MODULE_NAME # EXCNAME, \
     sizeof(Py ## EXCSTORE ## Object), 0, \
     (destructor)EXCSTORE ## _dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
@@ -1679,8 +1675,7 @@ done:
 }
 
 static PyTypeObject _PyExc_UnicodeEncodeError = {
-    PyObject_HEAD_INIT(NULL)
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     EXC_MODULE_NAME "UnicodeEncodeError",
     sizeof(PyUnicodeErrorObject), 0,
     (destructor)UnicodeError_dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1764,8 +1759,7 @@ done:
 }
 
 static PyTypeObject _PyExc_UnicodeDecodeError = {
-    PyObject_HEAD_INIT(NULL)
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     EXC_MODULE_NAME "UnicodeDecodeError",
     sizeof(PyUnicodeErrorObject), 0,
     (destructor)UnicodeError_dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1862,8 +1856,7 @@ done:
 }
 
 static PyTypeObject _PyExc_UnicodeTranslateError = {
-    PyObject_HEAD_INIT(NULL)
-    0,
+    PyVarObject_HEAD_INIT(NULL, 0)
     EXC_MODULE_NAME "UnicodeTranslateError",
     sizeof(PyUnicodeErrorObject), 0,
     (destructor)UnicodeError_dealloc, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -427,7 +427,7 @@ close_the_file(PyFileObject *f)
     if (local_fp != NULL) {
         local_close = f->f_close;
         if (local_close != NULL && f->unlocked_count > 0) {
-            if (f->ob_refcnt > 0) {
+            if (Py_REFCNT(f) > 0) {
                 PyErr_SetString(PyExc_IOError,
                     "close() called during concurrent "
                     "operation on the same file object.");

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -65,7 +65,7 @@ PyFloat_GetMin(void)
     return DBL_MIN;
 }
 
-static PyTypeObject FloatInfoType = {0, 0, 0, 0, 0, 0};
+static PyTypeObject FloatInfoType;
 
 PyDoc_STRVAR(floatinfo__doc__,
 "sys.float_info\n\

--- a/Objects/intobject.c
+++ b/Objects/intobject.c
@@ -1486,7 +1486,7 @@ PyInt_ClearFreeList(void)
         for (i = 0, p = &list->objects[0];
              i < N_INTOBJECTS;
              i++, p++) {
-            if (PyInt_CheckExact(p) && p->ob_refcnt != 0)
+            if (PyInt_CheckExact(p) && Py_REFCNT(p) != 0)
                 u++;
         }
         next = list->next;
@@ -1497,7 +1497,7 @@ PyInt_ClearFreeList(void)
                  i < N_INTOBJECTS;
                  i++, p++) {
                 if (!PyInt_CheckExact(p) ||
-                    p->ob_refcnt == 0) {
+                    Py_REFCNT(p) == 0) {
                     Py_TYPE(p) = (struct _typeobject *)
                         free_list;
                     free_list = p;
@@ -1560,14 +1560,14 @@ PyInt_Fini(void)
             for (i = 0, p = &list->objects[0];
                  i < N_INTOBJECTS;
                  i++, p++) {
-                if (PyInt_CheckExact(p) && p->ob_refcnt != 0)
+                if (PyInt_CheckExact(p) && Py_REFCNT(p) != 0)
                     /* XXX(twouters) cast refcount to
                        long until %zd is universally
                        available
                      */
                     fprintf(stderr,
                 "#   <int at %p, refcnt=%ld, val=%ld>\n",
-                                p, (long)p->ob_refcnt,
+                                p, (long)Py_REFCNT(p),
                                 p->ob_ival);
             }
             list = list->next;

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -183,8 +183,7 @@ static PyMethodDef range_methods[] = {
 };
 
 PyTypeObject PyRange_Type = {
-    PyObject_HEAD_INIT(&PyType_Type)
-    0,                          /* Number of items for varobject */
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "xrange",                   /* Name of this type */
     sizeof(rangeobject),        /* Basic object size */
     0,                          /* Item size for varobject */
@@ -256,8 +255,7 @@ static PyMethodDef rangeiter_methods[] = {
 };
 
 static PyTypeObject Pyrangeiter_Type = {
-    PyObject_HEAD_INIT(&PyType_Type)
-    0,                                      /* ob_size */
+    PyVarObject_HEAD_INIT(&PyType_Type, 0)
     "rangeiterator",                        /* tp_name */
     sizeof(rangeiterobject),                /* tp_basicsize */
     0,                                      /* tp_itemsize */

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -583,13 +583,13 @@ set_tp_print(PySetObject *so, FILE *fp, int flags)
         if (status < 0)
             return status;
         Py_BEGIN_ALLOW_THREADS
-        fprintf(fp, "%s(...)", so->ob_type->tp_name);
+        fprintf(fp, "%s(...)", Py_TYPE(so)->tp_name);
         Py_END_ALLOW_THREADS
         return 0;
     }
 
     Py_BEGIN_ALLOW_THREADS
-    fprintf(fp, "%s([", so->ob_type->tp_name);
+    fprintf(fp, "%s([", Py_TYPE(so)->tp_name);
     Py_END_ALLOW_THREADS
     while (set_next(so, &pos, &entry)) {
         Py_BEGIN_ALLOW_THREADS
@@ -617,7 +617,7 @@ set_repr(PySetObject *so)
     if (status != 0) {
         if (status < 0)
             return NULL;
-        return PyString_FromFormat("%s(...)", so->ob_type->tp_name);
+        return PyString_FromFormat("%s(...)", Py_TYPE(so)->tp_name);
     }
 
     keys = PySequence_List((PyObject *)so);
@@ -628,7 +628,7 @@ set_repr(PySetObject *so)
     if (listrepr == NULL)
         goto done;
 
-    result = PyString_FromFormat("%s(%s)", so->ob_type->tp_name,
+    result = PyString_FromFormat("%s(%s)", Py_TYPE(so)->tp_name,
         PyString_AS_STRING(listrepr));
     Py_DECREF(listrepr);
 done:

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -196,7 +196,7 @@ weakref_repr(PyWeakReference *self)
 static PyObject *
 weakref_richcompare(PyWeakReference* self, PyWeakReference* other, int op)
 {
-    if ((op != Py_EQ && op != Py_NE) || self->ob_type != other->ob_type) {
+    if ((op != Py_EQ && op != Py_NE) || Py_TYPE(self) != Py_TYPE(other)) {
         Py_INCREF(Py_NotImplemented);
         return Py_NotImplemented;
     }
@@ -914,7 +914,7 @@ PyObject_ClearWeakRefs(PyObject *object)
 
     if (object == NULL
         || !PyType_SUPPORTS_WEAKREFS(Py_TYPE(object))
-        || object->ob_refcnt != 0) {
+        || Py_REFCNT(object) != 0) {
         PyErr_BadInternalCall();
         return;
     }
@@ -937,7 +937,7 @@ PyObject_ClearWeakRefs(PyObject *object)
             current->wr_callback = NULL;
             clear_weakref(current);
             if (callback != NULL) {
-                if (current->ob_refcnt > 0)
+                if (Py_REFCNT(current) > 0)
                     handle_callback(current, callback);
                 Py_DECREF(callback);
             }
@@ -955,7 +955,7 @@ PyObject_ClearWeakRefs(PyObject *object)
             for (i = 0; i < count; ++i) {
                 PyWeakReference *next = current->wr_next;
 
-                if (current->ob_refcnt > 0)
+                if (Py_REFCNT(current) > 0)
                 {
                     Py_INCREF(current);
                     PyTuple_SET_ITEM(tuple, i * 2, (PyObject *) current);


### PR DESCRIPTION
This no-op change makes 2.7 more consistent with 3.x to ease comparison and backports.
