### PR TITLE
[3.6] _ssl_: Fix compiler warning (GH-3559)

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -3024,6 +3024,12 @@ _ssl__SSLContext__set_alpn_protocols_impl(PySSLContext *self,
 /*[clinic end generated code: output=87599a7f76651a9b input=9bba964595d519be]*/
 {
 #ifdef HAVE_ALPN
+    if ((size_t)protos->len > UINT_MAX) {
+        PyErr_Format(PyExc_OverflowError,
+            "protocols longer than %d bytes", UINT_MAX);
+        return NULL;
+    }
+
     PyMem_FREE(self->alpn_protocols);
     self->alpn_protocols = PyMem_Malloc(protos->len);
     if (!self->alpn_protocols)


### PR DESCRIPTION
Cast Py_buffer.len (Py_ssize_t, signed) to size_t (unsigned) to
prevent the following warning:

Modules/_ssl.c:3089:21: warning: comparison between signed and
unsigned integer expressions [-Wsign-compare].
(cherry picked from commit 5a61559fb0776a9a0f08294ec9003cea13940430)

Also backports size check from 5cff6379797