### PR TITLE
bpo-28411: Isolate PyInterpreterState.modules

### DIFF
--- a/Include/import.h
+++ b/Include/import.h
@@ -40,6 +40,7 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyThreadState *tstate);
+PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *interp);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Include/import.h
+++ b/Include/import.h
@@ -38,6 +38,9 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
     );
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyThreadState *tstate);
+#endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(
     PyObject *name

--- a/Include/import.h
+++ b/Include/import.h
@@ -46,6 +46,9 @@ PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(
     PyObject *name
     );
 #endif
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *, PyObject *);
+#endif
 PyAPI_FUNC(PyObject *) PyImport_AddModule(
     const char *name            /* UTF-8 encoded string */
     );
@@ -95,9 +98,12 @@ PyAPI_FUNC(int) _PyImport_ReleaseLock(void);
 PyAPI_FUNC(void) _PyImport_ReInitLock(void);
 
 PyAPI_FUNC(PyObject *) _PyImport_FindBuiltin(
-    const char *name            /* UTF-8 encoded string */
+    const char *name,            /* UTF-8 encoded string */
+    PyObject *modules
     );
 PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObject(PyObject *, PyObject *);
+PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObjectEx(PyObject *, PyObject *,
+                                                       PyObject *);
 PyAPI_FUNC(int) _PyImport_FixupBuiltin(
     PyObject *mod,
     const char *name            /* UTF-8 encoded string */

--- a/Include/import.h
+++ b/Include/import.h
@@ -107,9 +107,12 @@ PyAPI_FUNC(PyObject *) _PyImport_FindExtensionObjectEx(PyObject *, PyObject *,
                                                        PyObject *);
 PyAPI_FUNC(int) _PyImport_FixupBuiltin(
     PyObject *mod,
-    const char *name            /* UTF-8 encoded string */
+    const char *name,            /* UTF-8 encoded string */
+    PyObject *modules
     );
 PyAPI_FUNC(int) _PyImport_FixupExtensionObject(PyObject*, PyObject *, PyObject *);
+PyAPI_FUNC(int) _PyImport_FixupExtensionObjectEx(PyObject*, PyObject *,
+                                                 PyObject *, PyObject *);
 
 struct _inittab {
     const char *name;           /* ASCII encoded string */

--- a/Include/import.h
+++ b/Include/import.h
@@ -39,7 +39,6 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyInterpreterState *);
 PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000

--- a/Include/import.h
+++ b/Include/import.h
@@ -39,7 +39,7 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *);
+PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Include/import.h
+++ b/Include/import.h
@@ -39,8 +39,8 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyThreadState *tstate);
-PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *interp);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleDict(PyInterpreterState *);
+PyAPI_FUNC(void) _PyImport_EnsureInitialized(PyInterpreterState *);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Include/import.h
+++ b/Include/import.h
@@ -109,9 +109,8 @@ PyAPI_FUNC(int) _PyImport_FixupBuiltin(
     const char *name,            /* UTF-8 encoded string */
     PyObject *modules
     );
-PyAPI_FUNC(int) _PyImport_FixupExtensionObject(PyObject*, PyObject *, PyObject *);
-PyAPI_FUNC(int) _PyImport_FixupExtensionObjectEx(PyObject*, PyObject *,
-                                                 PyObject *, PyObject *);
+PyAPI_FUNC(int) _PyImport_FixupExtensionObject(PyObject*, PyObject *,
+                                               PyObject *, PyObject *);
 
 struct _inittab {
     const char *name;           /* ASCII encoded string */

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -192,8 +192,8 @@ PyAPI_FUNC(int) PyModule_ExecDef(PyObject *module, PyModuleDef *def);
 PyAPI_FUNC(PyObject *) PyModule_Create2(struct PyModuleDef*,
                                      int apiver);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyModule_Create2(struct PyModuleDef*,
-                                         int apiver);
+PyAPI_FUNC(PyObject *) _PyModule_CreateInitialized(struct PyModuleDef*,
+                                                   int apiver);
 #endif
 
 #ifdef Py_LIMITED_API

--- a/Include/modsupport.h
+++ b/Include/modsupport.h
@@ -191,6 +191,10 @@ PyAPI_FUNC(int) PyModule_ExecDef(PyObject *module, PyModuleDef *def);
 
 PyAPI_FUNC(PyObject *) PyModule_Create2(struct PyModuleDef*,
                                      int apiver);
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(PyObject *) _PyModule_Create2(struct PyModuleDef*,
+                                         int apiver);
+#endif
 
 #ifdef Py_LIMITED_API
 #define PyModule_Create(module) \

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
@@ -1,3 +1,0 @@
-``PyInterpreterState`` has a "modules" field that is copied into
-``sys.modules`` during interpreter startup.  We restructure code
-to better isolate sys.modules, to make it easier to sync them up.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
@@ -1,0 +1,3 @@
+``PyInterpreterState`` has a "modules" field that is copied into
+``sys.modules`` during interpreter startup.  We restructure code
+to better isolate sys.modules, to make it easier to sync them up.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-11-09-24-21.bpo-28411.12SpAm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-11-09-24-21.bpo-28411.12SpAm.rst
@@ -1,0 +1,3 @@
+Change direct usage of PyInterpreterState.modules to PyImport_GetModuleDict().
+Also introduce more uniformity in other code that deals with sys.modules.
+This helps reduce complications when working on sys.modules.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -162,11 +162,16 @@ _add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
 PyObject *
 PyModule_Create2(struct PyModuleDef* module, int module_api_version)
 {
+    _PyImport_EnsureInitialized(PyThreadState_GET()->interp);
+    return _PyModule_Create2(module, module_api_version);
+}
+
+PyObject *
+_PyModule_Create2(struct PyModuleDef* module, int module_api_version)
+{
     const char* name;
     PyModuleObject *m;
-    PyInterpreterState *interp = PyThreadState_Get()->interp;
-    if (interp->modules == NULL)
-        Py_FatalError("Python import machinery not initialized");
+
     if (!PyModuleDef_Init(module))
         return NULL;
     name = module->m_name;

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -163,11 +163,11 @@ PyObject *
 PyModule_Create2(struct PyModuleDef* module, int module_api_version)
 {
     _PyImport_EnsureInitialized(PyThreadState_GET()->interp);
-    return _PyModule_Create2(module, module_api_version);
+    return _PyModule_CreateInitialized(module, module_api_version);
 }
 
 PyObject *
-_PyModule_Create2(struct PyModuleDef* module, int module_api_version)
+_PyModule_CreateInitialized(struct PyModuleDef* module, int module_api_version)
 {
     const char* name;
     PyModuleObject *m;

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -162,7 +162,8 @@ _add_methods_to_object(PyObject *module, PyObject *name, PyMethodDef *functions)
 PyObject *
 PyModule_Create2(struct PyModuleDef* module, int module_api_version)
 {
-    _PyImport_EnsureInitialized(PyThreadState_GET()->interp);
+    if (!_PyImport_IsInitialized(PyThreadState_GET()->interp))
+        Py_FatalError("Python import machinery not initialized");
     return _PyModule_CreateInitialized(module, module_api_version);
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3902,7 +3902,6 @@ import_copyreg(void)
 {
     PyObject *copyreg_str;
     PyObject *copyreg_module;
-    PyInterpreterState *interp = PyThreadState_GET()->interp;
     _Py_IDENTIFIER(copyreg);
 
     copyreg_str = _PyUnicode_FromId(&PyId_copyreg);
@@ -3914,7 +3913,8 @@ import_copyreg(void)
        by storing a reference to the cached module in a static variable, but
        this broke when multiple embedded interpreters were in use (see issue
        #17408 and #19088). */
-    copyreg_module = PyDict_GetItemWithError(interp->modules, copyreg_str);
+    PyObject *modules = PyImport_GetModuleDict();
+    copyreg_module = PyDict_GetItemWithError(modules, copyreg_str);
     if (copyreg_module != NULL) {
         Py_INCREF(copyreg_module);
         return copyreg_module;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2685,7 +2685,7 @@ _PyBuiltin_Init(void)
         PyType_Ready(&PyZip_Type) < 0)
         return NULL;
 
-    mod = PyModule_Create(&builtinsmodule);
+    mod = _PyModule_Create2(&builtinsmodule, PYTHON_API_VERSION);
     if (mod == NULL)
         return NULL;
     dict = PyModule_GetDict(mod);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2685,7 +2685,7 @@ _PyBuiltin_Init(void)
         PyType_Ready(&PyZip_Type) < 0)
         return NULL;
 
-    mod = _PyModule_Create2(&builtinsmodule, PYTHON_API_VERSION);
+    mod = _PyModule_CreateInitialized(&builtinsmodule, PYTHON_API_VERSION);
     if (mod == NULL)
         return NULL;
     dict = PyModule_GetDict(mod);

--- a/Python/import.c
+++ b/Python/import.c
@@ -297,13 +297,15 @@ PyImport_GetModuleDict(void)
 
     /* We aren't ready to do this yet.
     PyObject *sysdict = PyThreadState_GET()->interp->sysdict;
-    if (sysdict == NULL)
+    if (sysdict == NULL) {
         Py_FatalError("PyImport_GetModuleDict: no sys module!");
+    }
 
     _Py_IDENTIFIER(modules);
     PyObject *modules = _PyDict_GetItemId(sysdict, &PyId_modules);
-    if (modules == NULL)
+    if (modules == NULL) {
         Py_FatalError("lost sys.modules");
+    }
     return modules;
     */
 }
@@ -327,7 +329,6 @@ _PyImport_IsInitialized(PyInterpreterState *interp)
     */
     return 1;
 }
-
 
 /* List of names to clear in sys */
 static const char * const sys_deletes[] = {

--- a/Python/import.c
+++ b/Python/import.c
@@ -312,23 +312,20 @@ PyImport_GetModuleDict(void)
    machinery has been initialized (or not cleaned up yet).  For
    example, see issue #4236 and PyModule_Create2(). */
 
-void
-_PyImport_EnsureInitialized(PyInterpreterState *interp)
+int
+_PyImport_IsInitialized(PyInterpreterState *interp)
 {
     if (interp->modules == NULL)
-        goto notinitialized;
+        return 0;
     /* We aren't ready to do this yet.
     if (interp->sysdict == NULL)
-        goto notinitialized;
+        return 0;
     _Py_IDENTIFIER(modules);
     PyObject *modules = _PyDict_GetItemId(interp->sysdict, &PyId_modules);
     if (modules == NULL)
-        goto notinitialized;
+        return 0;
     */
-    return;
-
-notinitialized:
-    Py_FatalError("Python import machinery not initialized");
+    return 1;
 }
 
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -294,20 +294,6 @@ PyImport_GetModuleDict(void)
     if (interp->modules == NULL)
         Py_FatalError("PyImport_GetModuleDict: no module dictionary!");
     return interp->modules;
-
-    /* We aren't ready to do this yet.
-    PyObject *sysdict = PyThreadState_GET()->interp->sysdict;
-    if (sysdict == NULL) {
-        Py_FatalError("PyImport_GetModuleDict: no sys module!");
-    }
-
-    _Py_IDENTIFIER(modules);
-    PyObject *modules = _PyDict_GetItemId(sysdict, &PyId_modules);
-    if (modules == NULL) {
-        Py_FatalError("lost sys.modules");
-    }
-    return modules;
-    */
 }
 
 /* In some corner cases it is important to be sure that the import
@@ -319,14 +305,6 @@ _PyImport_IsInitialized(PyInterpreterState *interp)
 {
     if (interp->modules == NULL)
         return 0;
-    /* We aren't ready to do this yet.
-    if (interp->sysdict == NULL)
-        return 0;
-    _Py_IDENTIFIER(modules);
-    PyObject *modules = _PyDict_GetItemId(interp->sysdict, &PyId_modules);
-    if (modules == NULL)
-        return 0;
-    */
     return 1;
 }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -288,28 +288,24 @@ _PyImport_Fini(void)
 /* Helper for sys */
 
 PyObject *
-_PyImport_GetModuleDict(PyInterpreterState *interp)
+PyImport_GetModuleDict(void)
 {
+    PyInterpreterState *interp = PyThreadState_GET()->interp;
     if (interp->modules == NULL)
         Py_FatalError("PyImport_GetModuleDict: no module dictionary!");
     return interp->modules;
 
     /* We aren't ready to do this yet.
-    if (interp->sysdict == NULL)
+    PyObject *sysdict = PyThreadState_GET()->interp->sysdict;
+    if (sysdict == NULL)
         Py_FatalError("PyImport_GetModuleDict: no sys module!");
 
     _Py_IDENTIFIER(modules);
-    PyObject *modules = _PyDict_GetItemId(interp->sysdict, &PyId_modules);
+    PyObject *modules = _PyDict_GetItemId(sysdict, &PyId_modules);
     if (modules == NULL)
         Py_FatalError("lost sys.modules");
     return modules;
     */
-}
-
-PyObject *
-PyImport_GetModuleDict(void)
-{
-    return _PyImport_GetModuleDict(PyThreadState_GET()->interp);
 }
 
 /* In some corner cases it is important to be sure that the import

--- a/Python/import.c
+++ b/Python/import.c
@@ -323,6 +323,14 @@ _PyImport_EnsureInitialized(PyInterpreterState *interp)
 {
     if (interp->modules == NULL)
         goto notinitialized;
+    /* We aren't ready to do this yet.
+    if (interp->sysdict == NULL)
+        goto notinitialized;
+    _Py_IDENTIFIER(modules);
+    PyObject *modules = _PyDict_GetItemId(interp->sysdict, &PyId_modules);
+    if (modules == NULL)
+        goto notinitialized;
+    */
     return;
 
 notinitialized:

--- a/Python/import.c
+++ b/Python/import.c
@@ -288,20 +288,18 @@ _PyImport_Fini(void)
 /* Helper for sys */
 
 PyObject *
-_PyImport_GetModuleDict(PyThreadState *tstate)
+_PyImport_GetModuleDict(PyInterpreterState *interp)
 {
-    PyInterpreterState *interp = tstate->interp;
     if (interp->modules == NULL)
         Py_FatalError("PyImport_GetModuleDict: no module dictionary!");
     return interp->modules;
 
     /* We aren't ready to do this yet.
-    if (tstate->interp->sysdict == NULL)
-        Py_FatalError("_PyImport_GetModuleDict: no sys module!");
+    if (interp->sysdict == NULL)
+        Py_FatalError("PyImport_GetModuleDict: no sys module!");
 
     _Py_IDENTIFIER(modules);
-    PyObject *modules = _PyDict_GetItemId(tstate->interp->sysdict,
-                                          &PyId_modules);
+    PyObject *modules = _PyDict_GetItemId(interp->sysdict, &PyId_modules);
     if (modules == NULL)
         Py_FatalError("lost sys.modules");
     return modules;
@@ -311,7 +309,7 @@ _PyImport_GetModuleDict(PyThreadState *tstate)
 PyObject *
 PyImport_GetModuleDict(void)
 {
-    return _PyImport_GetModuleDict(PyThreadState_GET());
+    return _PyImport_GetModuleDict(PyThreadState_GET()->interp);
 }
 
 /* In some corner cases it is important to be sure that the import

--- a/Python/import.c
+++ b/Python/import.c
@@ -341,7 +341,7 @@ PyImport_Cleanup(void)
     Py_ssize_t pos;
     PyObject *key, *value, *dict;
     PyInterpreterState *interp = PyThreadState_GET()->interp;
-    PyObject *modules = interp->modules;
+    PyObject *modules = PyImport_GetModuleDict();
     PyObject *weaklist = NULL;
     const char * const *p;
 
@@ -1543,7 +1543,8 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
         Py_INCREF(abs_name);
     }
 
-    mod = PyDict_GetItem(interp->modules, abs_name);
+    PyObject *modules = PyImport_GetModuleDict();
+    mod = PyDict_GetItem(modules, abs_name);
     if (mod != NULL && mod != Py_None) {
         _Py_IDENTIFIER(__spec__);
         _Py_IDENTIFIER(_initializing);
@@ -1630,7 +1631,8 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
                     goto error;
                 }
 
-                final_mod = PyDict_GetItem(interp->modules, to_return);
+                PyObject *modules = PyImport_GetModuleDict();
+                final_mod = PyDict_GetItem(modules, to_return);
                 Py_DECREF(to_return);
                 if (final_mod == NULL) {
                     PyErr_Format(PyExc_KeyError,

--- a/Python/import.c
+++ b/Python/import.c
@@ -554,7 +554,15 @@ int
 _PyImport_FixupExtensionObject(PyObject *mod, PyObject *name,
                                PyObject *filename)
 {
-    PyObject *modules, *dict, *key;
+    PyObject *modules = PyImport_GetModuleDict();
+    return _PyImport_FixupExtensionObjectEx(mod, name, filename, modules);
+}
+
+int
+_PyImport_FixupExtensionObjectEx(PyObject *mod, PyObject *name,
+                                 PyObject *filename, PyObject *modules)
+{
+    PyObject *dict, *key;
     struct PyModuleDef *def;
     int res;
     if (extensions == NULL) {
@@ -571,7 +579,6 @@ _PyImport_FixupExtensionObject(PyObject *mod, PyObject *name,
         PyErr_BadInternalCall();
         return -1;
     }
-    modules = PyImport_GetModuleDict();
     if (PyDict_SetItem(modules, name, mod) < 0)
         return -1;
     if (_PyState_AddModule(mod, def) < 0) {
@@ -603,14 +610,14 @@ _PyImport_FixupExtensionObject(PyObject *mod, PyObject *name,
 }
 
 int
-_PyImport_FixupBuiltin(PyObject *mod, const char *name)
+_PyImport_FixupBuiltin(PyObject *mod, const char *name, PyObject *modules)
 {
     int res;
     PyObject *nameobj;
     nameobj = PyUnicode_InternFromString(name);
     if (nameobj == NULL)
         return -1;
-    res = _PyImport_FixupExtensionObject(mod, nameobj, nameobj);
+    res = _PyImport_FixupExtensionObjectEx(mod, nameobj, nameobj, modules);
     Py_DECREF(nameobj);
     return res;
 }

--- a/Python/import.c
+++ b/Python/import.c
@@ -288,12 +288,30 @@ _PyImport_Fini(void)
 /* Helper for sys */
 
 PyObject *
-PyImport_GetModuleDict(void)
+_PyImport_GetModuleDict(PyThreadState *tstate)
 {
-    PyInterpreterState *interp = PyThreadState_GET()->interp;
+    PyInterpreterState *interp = tstate->interp;
     if (interp->modules == NULL)
         Py_FatalError("PyImport_GetModuleDict: no module dictionary!");
     return interp->modules;
+
+    /* We aren't ready to do this yet.
+    if (tstate->interp->sysdict == NULL)
+        Py_FatalError("_PyImport_GetModuleDict: no sys module!");
+
+    _Py_IDENTIFIER(modules);
+    PyObject *modules = _PyDict_GetItemId(tstate->interp->sysdict,
+                                          &PyId_modules);
+    if (modules == NULL)
+        Py_FatalError("lost sys.modules");
+    return modules;
+    */
+}
+
+PyObject *
+PyImport_GetModuleDict(void)
+{
+    return _PyImport_GetModuleDict(PyThreadState_GET());
 }
 
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -314,6 +314,21 @@ PyImport_GetModuleDict(void)
     return _PyImport_GetModuleDict(PyThreadState_GET());
 }
 
+/* In some corner cases it is important to be sure that the import
+   machinery has been initialized (or not cleaned up yet).  For
+   example, see issue #4236 and PyModule_Create2(). */
+
+void
+_PyImport_EnsureInitialized(PyInterpreterState *interp)
+{
+    if (interp->modules == NULL)
+        goto notinitialized;
+    return;
+
+notinitialized:
+    Py_FatalError("Python import machinery not initialized");
+}
+
 
 /* List of names to clear in sys */
 static const char * const sys_deletes[] = {

--- a/Python/importdl.c
+++ b/Python/importdl.c
@@ -215,7 +215,8 @@ _PyImport_LoadDynamicModuleWithSpec(PyObject *spec, FILE *fp)
     else
         Py_INCREF(path);
 
-    if (_PyImport_FixupExtensionObject(m, name_unicode, path) < 0)
+    PyObject *modules = PyImport_GetModuleDict();
+    if (_PyImport_FixupExtensionObject(m, name_unicode, path, modules) < 0)
         goto error;
 
     Py_DECREF(name_unicode);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1908,9 +1908,8 @@ wait_for_thread_shutdown(void)
 {
     _Py_IDENTIFIER(_shutdown);
     PyObject *result;
-    PyThreadState *tstate = PyThreadState_GET();
-    PyObject *threading = PyMapping_GetItemString(tstate->interp->modules,
-                                                  "threading");
+    PyObject *modules = PyImport_GetModuleDict();
+    PyObject *threading = PyMapping_GetItemString(modules, "threading");
     if (threading == NULL) {
         /* threading not imported */
         PyErr_Clear();

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -688,7 +688,7 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
         Py_FatalError("Py_InitializeCore: can't initialize sys dict");
     Py_INCREF(interp->sysdict);
     PyDict_SetItemString(interp->sysdict, "modules", modules);
-    _PyImport_FixupBuiltin(sysmod, "sys");
+    _PyImport_FixupBuiltin(sysmod, "sys", modules);
 
     /* Init Unicode implementation; relies on the codec registry */
     if (_PyUnicode_Init() < 0)
@@ -700,7 +700,7 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
     bimod = _PyBuiltin_Init();
     if (bimod == NULL)
         Py_FatalError("Py_InitializeCore: can't initialize builtins modules");
-    _PyImport_FixupBuiltin(bimod, "builtins");
+    _PyImport_FixupBuiltin(bimod, "builtins", modules);
     interp->builtins = PyModule_GetDict(bimod);
     if (interp->builtins == NULL)
         Py_FatalError("Py_InitializeCore: can't initialize builtins dict");

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1208,7 +1208,7 @@ Py_NewInterpreter(void)
         Py_FatalError("Py_NewInterpreter: can't make modules dictionary");
     interp->modules = modules;
 
-    sysmod = _PyImport_FindBuiltin("sys");
+    sysmod = _PyImport_FindBuiltin("sys", modules);
     if (sysmod != NULL) {
         interp->sysdict = PyModule_GetDict(sysmod);
         if (interp->sysdict == NULL)
@@ -1219,7 +1219,7 @@ Py_NewInterpreter(void)
         _PySys_EndInit(interp->sysdict);
     }
 
-    bimod = _PyImport_FindBuiltin("builtins");
+    bimod = _PyImport_FindBuiltin("builtins", modules);
     if (bimod != NULL) {
         interp->builtins = PyModule_GetDict(bimod);
         if (interp->builtins == NULL)

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1940,7 +1940,7 @@ _PySys_BeginInit(void)
     PyObject *m, *sysdict, *version_info;
     int res;
 
-    m = _PyModule_Create2(&sysmodule, PYTHON_API_VERSION);
+    m = _PyModule_CreateInitialized(&sysmodule, PYTHON_API_VERSION);
     if (m == NULL)
         return NULL;
     sysdict = PyModule_GetDict(m);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1940,7 +1940,7 @@ _PySys_BeginInit(void)
     PyObject *m, *sysdict, *version_info;
     int res;
 
-    m = PyModule_Create(&sysmodule);
+    m = _PyModule_Create2(&sysmodule, PYTHON_API_VERSION);
     if (m == NULL)
         return NULL;
     sysdict = PyModule_GetDict(m);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -160,8 +160,9 @@ static PyObject *
 sys_displayhook(PyObject *self, PyObject *o)
 {
     PyObject *outf;
-    PyInterpreterState *interp = PyThreadState_GET()->interp;
-    PyObject *modules = interp->modules;
+    PyObject *modules = PyImport_GetModuleDict();
+    if (modules == NULL)
+        return NULL;
     PyObject *builtins;
     static PyObject *newline = NULL;
     int err;


### PR DESCRIPTION
A bunch of code currently uses PyInterpreterState.modules directly instead of PyImport_GetModuleDict().  This complicates efforts to make changes relative to sys.modules.  This patch switches to using PyImport_GetModuleDict() uniformly.  Also, a number of related uses of sys.modules are updated for uniformity for the same reason.

Note that this code was already reviewed and merged as part of #1638.  I reverted that and am now splitting it up into more focused parts.

<!-- issue-number: bpo-28411 -->
https://bugs.python.org/issue28411
<!-- /issue-number -->
