### PR TITLE
bpo-31475: fix argparse to support utf8

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2448,19 +2448,19 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
     # =====================
     def print_usage(self, file=None):
         if file is None:
-            file = _sys.stdout
-        self._print_message(self.format_usage(), file)
+            file = _sys.stdout.buffer if int(_sys.version_info[0]) is 3 else _sys.stdout
+        self._print_message(self.format_usage().encode('utf8'), file)
 
     def print_help(self, file=None):
         if file is None:
-            file = _sys.stdout
-        self._print_message(self.format_help(), file)
+            file = _sys.stdout.buffer if int(_sys.version_info[0]) is 3 else _sys.stdout
+        self._print_message(self.format_help().encode('utf8'), file)
 
     def _print_message(self, message, file=None):
         if message:
             if file is None:
-                file = _sys.stderr
-            file.write(message)
+                file = _sys.stderr.buffer if int(_sys.version_info[0]) is 3 else _sys.stderr
+            file.write(message if type(message) == bytes else message.encode('utf8'))
 
     # ===============
     # Exiting methods


### PR DESCRIPTION
Regarding #3468 discussion,  there is the same bug was in argparse (and optparse) which fixed in this PR.

Python2
```
    parser.print_help()
  File "C:\Python27\lib\argparse.py", line 2340, in print_help
    self._print_message(self.format_help(), file)
  File "C:\Python27\lib\argparse.py", line 2354, in _print_message
    file.write(message)
  File "C:\Python27\lib\encodings\cp437.py", line 12, in encode
    return codecs.charmap_encode(input,errors,encoding_map)
UnicodeEncodeError: 'charmap' codec can't encode characters in position 490-494: character maps to <undefined>
```

Python3
```
    parser.print_help()
  File "C:\Python35\lib\argparse.py", line 2358, in print_help
    self._print_message(self.format_help(), file)
  File "C:\Python35\lib\argparse.py", line 2364, in _print_message
    file.write(message)
  File "C:\Python35\lib\encodings\cp437.py", line 19, in encode
    return codecs.charmap_encode(input,self.errors,encoding_map)[0]
UnicodeEncodeError: 'charmap' codec can't encode characters in position 498-502: character maps to <undefined>
```

or let me know if there is a better solution?

Regards.

<!-- issue-number: bpo-31475 -->
https://bugs.python.org/issue31475
<!-- /issue-number -->
