### PR TITLE
bpo-31471: fix assertion failure in subprocess.Popen() on Windows, in case env has a bad keys() method

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2742,6 +2742,15 @@ class Win32ProcessTestCase(BaseTestCase):
                           stdout=subprocess.PIPE,
                           close_fds=True)
 
+    @support.cpython_only
+    def test_issue31471(self):
+        # There shouldn't be an assertion failure in Popen() in case the env
+        # argument has a bad keys() method.
+        class BadEnv(dict):
+            keys = None
+        with self.assertRaises(TypeError):
+            subprocess.Popen([sys.executable, "-c", "pass"], env=BadEnv())
+
     def test_close_fds(self):
         # close file descriptors
         rc = subprocess.call([sys.executable, "-c",

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-14-19-47-57.bpo-31471.0yiA5Q.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-14-19-47-57.bpo-31471.0yiA5Q.rst
@@ -1,0 +1,2 @@
+Fix an assertion failure in `subprocess.Popen()` on Windows, in case the env
+argument has a bad keys() method. Patch by Oren Milman.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -723,9 +723,13 @@ getenvironment(PyObject* environment)
     }
 
     keys = PyMapping_Keys(environment);
-    values = PyMapping_Values(environment);
-    if (!keys || !values)
+    if (!keys) {
         goto error;
+    }
+    values = PyMapping_Values(environment);
+    if (!values) {
+        goto error;
+    }
 
     envsize = PySequence_Fast_GET_SIZE(keys);
     if (PySequence_Fast_GET_SIZE(values) != envsize) {

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -713,7 +713,7 @@ getenvironment(PyObject* environment)
 {
     Py_ssize_t i, envsize, totalsize;
     Py_UCS4 *buffer = NULL, *p, *end;
-    PyObject *keys, *values, *res;
+    PyObject *keys, *values = NULL, *res;
 
     /* convert environment dictionary to windows environment string */
     if (! PyMapping_Check(environment)) {

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -713,7 +713,7 @@ getenvironment(PyObject* environment)
 {
     Py_ssize_t i, envsize, totalsize;
     Py_UCS4 *buffer = NULL, *p, *end;
-    PyObject *keys, *values = NULL, *res;
+    PyObject *keys, *values, *res;
 
     /* convert environment dictionary to windows environment string */
     if (! PyMapping_Check(environment)) {
@@ -724,7 +724,7 @@ getenvironment(PyObject* environment)
 
     keys = PyMapping_Keys(environment);
     if (!keys) {
-        goto error;
+        return NULL;
     }
     values = PyMapping_Values(environment);
     if (!values) {


### PR DESCRIPTION
- in `_winapi.c`: move the check whether `PyMapping_Keys()` failed to right after calling it.
- in `test_subprocess.py`: add a test to verify that the assertion failure is no more.

<!-- issue-number: bpo-31471 -->
https://bugs.python.org/issue31471
<!-- /issue-number -->
