### PR TITLE
bpo-31474: Fix -Wint-in-bool-context warnings

### DIFF
--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -72,9 +72,9 @@ PyAPI_FUNC(void) PyMem_Free(void *);
 /* Returns NULL to indicate error if a negative size or size larger than
    Py_ssize_t can represent is supplied.  Helps prevents security holes. */
 #define PyMem_MALLOC(n)		((size_t)(n) > (size_t)PY_SSIZE_T_MAX ? NULL \
-				: malloc((n) ? (n) : 1))
+				: malloc(((n) != 0) ? (n) : 1))
 #define PyMem_REALLOC(p, n)	((size_t)(n) > (size_t)PY_SSIZE_T_MAX  ? NULL \
-				: realloc((p), (n) ? (n) : 1))
+				: realloc((p), ((n) != 0) ? (n) : 1))
 #define PyMem_FREE		free
 
 #endif	/* PYMALLOC_DEBUG */

--- a/Misc/NEWS.d/next/Build/2017-09-14-19-38-19.bpo-31474.0s_mpD.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-14-19-38-19.bpo-31474.0s_mpD.rst
@@ -1,0 +1,1 @@
+Fix -Wint-in-bool-context warnings in PyMem_MALLOC and PyMem_REALLOC macros


### PR DESCRIPTION
Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: bpo-31474 -->
https://bugs.python.org/issue31474
<!-- /issue-number -->
