### PR TITLE
bpo-28556: typing.get_type_hints: better globalns for classes and modules

### DIFF
--- a/Lib/test/mod_generics_cache.py
+++ b/Lib/test/mod_generics_cache.py
@@ -1,14 +1,53 @@
 """Module for testing the behavior of generics across different modules."""
 
-from typing import TypeVar, Generic
-
-T = TypeVar('T')
-
-
-class A(Generic[T]):
-    pass
+import sys
+from textwrap import dedent
+from typing import TypeVar, Generic, Optional
 
 
-class B(Generic[T]):
+if sys.version_info[:2] >= (3, 6):
+    exec(dedent("""
+    default_a: Optional['A'] = None
+    default_b: Optional['B'] = None
+
+    T = TypeVar('T')
+
+
     class A(Generic[T]):
-        pass
+        some_b: 'B'
+
+
+    class B(Generic[T]):
+        class A(Generic[T]):
+            pass
+
+        my_inner_a1: 'B.A'
+        my_inner_a2: A
+        my_outer_a: 'A'  # unless somebody calls get_type_hints with localns=B.__dict__
+    """))
+else:  # This should stay in sync with the syntax above.
+    __annotations__ = dict(
+        default_a=Optional['A'],
+        default_b=Optional['B'],
+    )
+    default_a = None
+    default_b = None
+
+    T = TypeVar('T')
+
+
+    class A(Generic[T]):
+        __annotations__ = dict(
+            some_b='B'
+        )
+
+
+    class B(Generic[T]):
+        class A(Generic[T]):
+            pass
+
+        __annotations__ = dict(
+            my_inner_a1='B.A',
+            my_inner_a2=A,
+            my_outer_a='A'  # unless somebody calls get_type_hints with localns=B.__dict__
+        )

--- a/Misc/NEWS.d/next/Library/2017-09-14-11-02-56.bpo-28556.EUOiYs.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-14-11-02-56.bpo-28556.EUOiYs.rst
@@ -1,0 +1,2 @@
+typing.get_type_hints now finds the right globalns for classes and modules
+by default (when no ``globalns`` was specified by the caller).


### PR DESCRIPTION
This makes the default behavior (without specifying `globalns` manually) more
predictable for users, finds the right globalns automatically.

Implementation for classes assumes has a `__module__` attribute and that module
is present in `sys.modules`.  It does this recursively for all bases in the
MRO.  For modules, the implementation just uses their `__dict__` directly.

This is backwards compatible, will just raise fewer exceptions in naive user
code.

Originally implemented and reviewed at https://github.com/python/typing/pull/470.


<!-- issue-number: bpo-28556 -->
https://bugs.python.org/issue28556
<!-- /issue-number -->
