### PR TITLE
bpo-31480: IDLE - fix tests to pass with zzdummy extension disabled.

### DIFF
--- a/Lib/idlelib/config-extensions.def
+++ b/Lib/idlelib/config-extensions.def
@@ -55,7 +55,7 @@ bell= True
 # A fake extension for testing and example purposes.  When enabled and
 # invoked, inserts or deletes z-text at beginning of every line.
 [ZzDummy]
-enable= True
+enable= False
 enable_shell = False
 enable_editor = True
 z-text= Z

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -820,6 +820,7 @@ class KeysPageTest(unittest.TestCase):
         self.assertEqual(d.load_keys_list.called, 1)
 
     def test_keybinding(self):
+        idleConf.SetOption('extensions', 'ZzDummy', 'enable', 'True')
         d = self.page
         d.custom_name.set('my custom keys')
         d.bindingslist.delete(0, 'end')

--- a/Misc/NEWS.d/next/IDLE/2017-09-14-17-53-53.bpo-31480.4WJ0pl.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-14-17-53-53.bpo-31480.4WJ0pl.rst
@@ -1,0 +1,1 @@
+IDLE - make tests pass with zzdummy extension disabled by default.


### PR DESCRIPTION


<!-- issue-number: bpo-31480 -->
https://bugs.python.org/issue31480
<!-- /issue-number -->
