### PR TITLE
bpo-28411: Support other mappings in PyInterpreterState.modules.

### DIFF
--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -204,6 +204,11 @@ Importing Modules
    Return the dictionary used for the module administration (a.k.a.
    ``sys.modules``).  Note that this is a per-interpreter variable.
 
+.. c:function:: PyObject* PyImport_GetModule(PyObject *name)
+
+   Return the already imported module with the given name.
+
+   .. versionadded:: 3.7
 
 .. c:function:: PyObject* PyImport_GetImporter(PyObject *path)
 

--- a/Doc/c-api/import.rst
+++ b/Doc/c-api/import.rst
@@ -206,7 +206,9 @@ Importing Modules
 
 .. c:function:: PyObject* PyImport_GetModule(PyObject *name)
 
-   Return the already imported module with the given name.
+   Return the already imported module with the given name.  If the
+   module has not been imported yet then returns NULL but does not set
+   an error.  Returns NULL and sets an error if the lookup failed.
 
    .. versionadded:: 3.7
 

--- a/Include/import.h
+++ b/Include/import.h
@@ -38,11 +38,15 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
     );
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
+PyAPI_FUNC(PyObject *) PyImport_GetModule(PyObject *name);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
 PyAPI_FUNC(PyObject *) _PyImport_GetModule(PyObject *name);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleWithError(PyObject *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleString(const char *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
+PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *name,
+                                                 PyObject *modules);
 PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);
 PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
 #endif

--- a/Include/import.h
+++ b/Include/import.h
@@ -41,8 +41,6 @@ PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 PyAPI_FUNC(PyObject *) PyImport_GetModule(PyObject *name);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
-PyAPI_FUNC(PyObject *) _PyImport_GetModule(PyObject *name);
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleWithError(PyObject *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
 PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *name,
                                                  PyObject *modules);

--- a/Include/import.h
+++ b/Include/import.h
@@ -43,6 +43,8 @@ PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
 PyAPI_FUNC(PyObject *) _PyImport_GetModule(PyObject *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleString(const char *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
+PyAPI_FUNC(int) _PyImport_SetModule(PyObject *name, PyObject *module);
+PyAPI_FUNC(int) _PyImport_SetModuleString(const char *name, PyObject* module);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Include/import.h
+++ b/Include/import.h
@@ -43,7 +43,6 @@ PyAPI_FUNC(PyObject *) PyImport_GetModule(PyObject *name);
 PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
 PyAPI_FUNC(PyObject *) _PyImport_GetModule(PyObject *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleWithError(PyObject *name);
-PyAPI_FUNC(PyObject *) _PyImport_GetModuleString(const char *name);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
 PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *name,
                                                  PyObject *modules);

--- a/Include/import.h
+++ b/Include/import.h
@@ -40,6 +40,9 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
+PyAPI_FUNC(PyObject *) _PyImport_GetModule(PyObject *name);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleString(const char *name);
+PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
@@ -1,3 +1,0 @@
-``PyInterpreterState`` has a "modules" field that is copied into
-``sys.modules`` during interpreter startup.  Adding support for
-other mappings than dict gives us some flexibility.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-04-10-46-09.bpo-28411.IU9rQL.rst
@@ -1,0 +1,3 @@
+``PyInterpreterState`` has a "modules" field that is copied into
+``sys.modules`` during interpreter startup.  Adding support for
+other mappings than dict gives us some flexibility.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-11-09-11-20.bpo-28411.Ax91lz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-11-09-11-20.bpo-28411.Ax91lz.rst
@@ -1,0 +1,4 @@
+Switch to the abstract API when dealing with ``PyInterpreterState.modules``.
+This allows later support for all dict subclasses and other Mapping
+implementations.  Also add a ``PyImport_GetModule()`` function to reduce
+a bunch of duplicated code.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1721,8 +1721,8 @@ whichmodule(PyObject *global, PyObject *dotted_path)
             if (PyErr_Occurred()) {
                 return NULL;
             }
-		}
-	}
+        }
+    }
     else {
         PyObject *iterator = PyObject_GetIter(modules);
         if (iterator == NULL) {

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1654,9 +1654,7 @@ static PyObject *
 whichmodule(PyObject *global, PyObject *dotted_path)
 {
     PyObject *module_name;
-    PyObject *modules_dict;
-    PyObject *module;
-    Py_ssize_t i;
+    PyObject *modules;
     _Py_IDENTIFIER(__module__);
     _Py_IDENTIFIER(modules);
     _Py_IDENTIFIER(__main__);
@@ -1679,15 +1677,16 @@ whichmodule(PyObject *global, PyObject *dotted_path)
     assert(module_name == NULL);
 
     /* Fallback on walking sys.modules */
-    modules_dict = _PySys_GetObjectId(&PyId_modules);
-    if (modules_dict == NULL) {
+    modules = _PySys_GetObjectId(&PyId_modules);
+    if (modules == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "unable to get sys.modules");
         return NULL;
     }
 
-    i = 0;
-    while (PyDict_Next(modules_dict, &i, &module_name, &module)) {
+    PyObject *iterator = PyObject_GetIter(modules);
+    while ((module_name = PyIter_Next(iterator))) {
         PyObject *candidate;
+        PyObject *module = PyObject_GetItem(modules, module_name);
         if (PyUnicode_Check(module_name) &&
             _PyUnicode_EqualToASCIIString(module_name, "__main__"))
             continue;

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6490,7 +6490,16 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
         return NULL;
     }
 
-    module = PyDict_GetItemWithError(modules_dict, module_name);
+    module = PyObject_GetItem(modules_dict, module_name);
+    if (PyDict_Check(modules_dict)) {
+        module = PyDict_GetItemWithError(modules_dict, module_name);
+    } else {
+        module = PyObject_GetItem(modules_dict, module_name);
+        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
+            // For backward-comaptibility we copy the behavior
+            // of PyDict_GetItemWithError().
+            PyErr_Clear();
+    }
     if (module == NULL) {
         if (PyErr_Occurred())
             return NULL;

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6490,11 +6490,11 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
         if (module == NULL)
             return NULL;
         global = getattribute(module, global_name, self->proto >= 4);
-        Py_DECREF(module);
     }
     else {
         global = getattribute(module, global_name, self->proto >= 4);
     }
+    Py_DECREF(module);
     return global;
 }
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6425,9 +6425,7 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
 /*[clinic end generated code: output=becc08d7f9ed41e3 input=e2e6a865de093ef4]*/
 {
     PyObject *global;
-    PyObject *modules_dict;
     PyObject *module;
-    _Py_IDENTIFIER(modules);
 
     /* Try to map the old names used in Python 2.x to the new ones used in
        Python 3.x.  We do this only with old pickle protocols and when the
@@ -6484,22 +6482,7 @@ _pickle_Unpickler_find_class_impl(UnpicklerObject *self,
         }
     }
 
-    modules_dict = _PySys_GetObjectId(&PyId_modules);
-    if (modules_dict == NULL) {
-        PyErr_SetString(PyExc_RuntimeError, "unable to get sys.modules");
-        return NULL;
-    }
-
-    module = PyObject_GetItem(modules_dict, module_name);
-    if (PyDict_Check(modules_dict)) {
-        module = PyDict_GetItemWithError(modules_dict, module_name);
-    } else {
-        module = PyObject_GetItem(modules_dict, module_name);
-        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
-            // For backward-comaptibility we copy the behavior
-            // of PyDict_GetItemWithError().
-            PyErr_Clear();
-    }
+    module = PyImport_GetModule(module_name);
     if (module == NULL) {
         if (PyErr_Occurred())
             return NULL;

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1707,7 +1707,7 @@ MODULE_INITFUNC(void)
     if (errors_module == NULL) {
         errors_module = PyModule_New(MODULE_NAME ".errors");
         if (errors_module != NULL) {
-            PyDict_SetItem(sys_modules, errmod_name, errors_module);
+            PyObject_SetItem(sys_modules, errmod_name, errors_module);
             /* gives away the reference to errors_module */
             PyModule_AddObject(m, "errors", errors_module);
         }
@@ -1717,7 +1717,7 @@ MODULE_INITFUNC(void)
     if (model_module == NULL) {
         model_module = PyModule_New(MODULE_NAME ".model");
         if (model_module != NULL) {
-            PyDict_SetItem(sys_modules, modelmod_name, model_module);
+            PyObject_SetItem(sys_modules, modelmod_name, model_module);
             /* gives away the reference to model_module */
             PyModule_AddObject(m, "model", model_module);
         }

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1643,7 +1643,6 @@ MODULE_INITFUNC(void)
     PyObject *errors_module;
     PyObject *modelmod_name;
     PyObject *model_module;
-    PyObject *sys_modules;
     PyObject *tmpnum, *tmpstr;
     PyObject *codes_dict;
     PyObject *rev_codes_dict;
@@ -1693,11 +1692,6 @@ MODULE_INITFUNC(void)
     */
     PyModule_AddStringConstant(m, "native_encoding", "UTF-8");
 
-    sys_modules = PySys_GetObject("modules");
-    if (sys_modules == NULL) {
-        Py_DECREF(m);
-        return NULL;
-    }
     d = PyModule_GetDict(m);
     if (d == NULL) {
         Py_DECREF(m);
@@ -1707,7 +1701,7 @@ MODULE_INITFUNC(void)
     if (errors_module == NULL) {
         errors_module = PyModule_New(MODULE_NAME ".errors");
         if (errors_module != NULL) {
-            PyObject_SetItem(sys_modules, errmod_name, errors_module);
+            _PyImport_SetModule(errmod_name, errors_module);
             /* gives away the reference to errors_module */
             PyModule_AddObject(m, "errors", errors_module);
         }
@@ -1717,7 +1711,7 @@ MODULE_INITFUNC(void)
     if (model_module == NULL) {
         model_module = PyModule_New(MODULE_NAME ".model");
         if (model_module != NULL) {
-            PyObject_SetItem(sys_modules, modelmod_name, model_module);
+            _PyImport_SetModule(modelmod_name, model_module);
             /* gives away the reference to model_module */
             PyModule_AddObject(m, "model", model_module);
         }

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3913,9 +3913,8 @@ import_copyreg(void)
        by storing a reference to the cached module in a static variable, but
        this broke when multiple embedded interpreters were in use (see issue
        #17408 and #19088). */
-    copyreg_module = _PyImport_GetModuleWithError(copyreg_str);
+    copyreg_module = PyImport_GetModule(copyreg_str);
     if (copyreg_module != NULL) {
-        Py_INCREF(copyreg_module);
         return copyreg_module;
     }
     if (PyErr_Occurred()) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3914,7 +3914,15 @@ import_copyreg(void)
        this broke when multiple embedded interpreters were in use (see issue
        #17408 and #19088). */
     PyObject *modules = PyImport_GetModuleDict();
-    copyreg_module = PyDict_GetItemWithError(modules, copyreg_str);
+    if (PyDict_Check(modules)) {
+        copyreg_module = PyDict_GetItemWithError(modules, copyreg_str);
+    } else {
+        copyreg_module = PyObject_GetItem(modules, copyreg_str);
+        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
+            // For backward-comaptibility we copy the behavior
+            // of PyDict_GetItemWithError().
+            PyErr_Clear();
+    }
     if (copyreg_module != NULL) {
         Py_INCREF(copyreg_module);
         return copyreg_module;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3913,16 +3913,7 @@ import_copyreg(void)
        by storing a reference to the cached module in a static variable, but
        this broke when multiple embedded interpreters were in use (see issue
        #17408 and #19088). */
-    PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules)) {
-        copyreg_module = PyDict_GetItemWithError(modules, copyreg_str);
-    } else {
-        copyreg_module = PyObject_GetItem(modules, copyreg_str);
-        if (PyErr_Occurred() && PyErr_ExceptionMatches(PyExc_KeyError))
-            // For backward-comaptibility we copy the behavior
-            // of PyDict_GetItemWithError().
-            PyErr_Clear();
-    }
+    copyreg_module = _PyImport_GetModuleWithError(copyreg_str);
     if (copyreg_module != NULL) {
         Py_INCREF(copyreg_module);
         return copyreg_module;

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -57,11 +57,9 @@ get_warnings_attr(const char *attr, int try_import)
         }
     }
     else {
-        warnings_module = _PyImport_GetModule(warnings_str);
+        warnings_module = PyImport_GetModule(warnings_str);
         if (warnings_module == NULL)
             return NULL;
-
-        Py_INCREF(warnings_module);
     }
 
     if (!PyObject_HasAttrString(warnings_module, attr)) {

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -38,7 +38,6 @@ static PyObject *
 get_warnings_attr(const char *attr, int try_import)
 {
     static PyObject *warnings_str = NULL;
-    PyObject *all_modules;
     PyObject *warnings_module, *obj;
 
     if (warnings_str == NULL) {
@@ -58,9 +57,7 @@ get_warnings_attr(const char *attr, int try_import)
         }
     }
     else {
-        all_modules = PyImport_GetModuleDict();
-
-        warnings_module = PyDict_GetItem(all_modules, warnings_str);
+        warnings_module = _PyImport_GetModule(warnings_str);
         if (warnings_module == NULL)
             return NULL;
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4935,7 +4935,7 @@ import_from(PyObject *v, PyObject *name)
         Py_DECREF(pkgname);
         return NULL;
     }
-    x = PyDict_GetItem(PyImport_GetModuleDict(), fullmodname);
+    x = _PyImport_GetModule(fullmodname);
     Py_DECREF(fullmodname);
     if (x == NULL) {
         goto error;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4935,13 +4935,12 @@ import_from(PyObject *v, PyObject *name)
         Py_DECREF(pkgname);
         return NULL;
     }
-    x = _PyImport_GetModule(fullmodname);
+    x = PyImport_GetModule(fullmodname);
     Py_DECREF(fullmodname);
     if (x == NULL) {
         goto error;
     }
     Py_DECREF(pkgname);
-    Py_INCREF(x);
     return x;
  error:
     pkgpath = PyModule_GetFilenameObject(v);

--- a/Python/import.c
+++ b/Python/import.c
@@ -763,7 +763,16 @@ PyImport_AddModuleObject(PyObject *name)
 PyObject *
 _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
 {
-    PyObject *m = _PyImport_GetModuleWithError(name);
+    PyObject *m;
+    if (PyDict_Check(modules)) {
+        m = PyDict_GetItemWithError(modules, name);
+    } else {
+        m = PyObject_GetItem(modules, name);
+        // For backward-comaptibility we copy the behavior
+        // of PyDict_GetItemWithError().
+        if (m == NULL && !PyMapping_HasKey(modules, name))
+            PyErr_Clear();
+    }
     if (m != NULL && PyModule_Check(m)) {
         return m;
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -803,9 +803,10 @@ static void
 remove_module(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
+    if (!PyMapping_HasKey(modules, name)) {
+        return;
+    }
     if (PyMapping_DelItem(modules, name) < 0) {
-        if (!PyMapping_HasKey(modules, name))
-            return;
         Py_FatalError("import:  deleting existing key in"
                       "sys.modules failed");
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -316,10 +316,13 @@ _PyImport_GetModule(PyObject *name)
         return PyDict_GetItem(modules, name);
 
     PyObject *mod = PyObject_GetItem(modules, name);
-    if (mod == NULL && PyErr_Occurred())
-        // For backward-comaptibility we copy the behavior
-        // of PyDict_GetItem().
-        PyErr_Clear();
+    // For backward-comaptibility we copy the behavior of PyDict_GetItem().
+    if (mod == NULL) {
+        if (PyErr_Occurred())
+            PyErr_Clear();
+    } else {
+        Py_DECREF(mod);
+    }
     return mod;
 }
 
@@ -331,9 +334,9 @@ _PyImport_GetModuleWithError(PyObject *name)
         return PyDict_GetItemWithError(modules, name);
 
     PyObject *mod = PyObject_GetItem(modules, name);
+    // For backward-comaptibility we copy the behavior
+    // of PyDict_GetItemWithError().
     if (mod == NULL && !PyMapping_HasKey(modules, name))
-        // For backward-comaptibility we copy the behavior
-        // of PyDict_GetItemWithError().
         PyErr_Clear();
     return mod;
 }
@@ -346,10 +349,14 @@ _PyImport_GetModuleString(const char *name)
         return PyDict_GetItemString(modules, name);
 
     PyObject *mod = PyMapping_GetItemString(modules, name);
-    if (mod == NULL && PyErr_Occurred())
-        // For backward-comaptibility we copy the behavior
-        // of PyDict_GetItemString().
-        PyErr_Clear();
+    // For backward-comaptibility we copy the behavior
+    // of PyDict_GetItemString().
+    if (mod == NULL) {
+        if (PyErr_Occurred())
+            PyErr_Clear();
+    } else {
+        Py_DECREF(mod);
+    }
     return mod;
 }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -313,7 +313,7 @@ PyObject *
 _PyImport_GetModule(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules)) {
+    if (PyDict_CheckExact(modules)) {
         return PyDict_GetItem(modules, name);
     }
 
@@ -330,7 +330,7 @@ PyObject *
 _PyImport_GetModuleWithError(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules)) {
+    if (PyDict_CheckExact(modules)) {
         return PyDict_GetItemWithError(modules, name);
     }
 
@@ -377,7 +377,7 @@ PyImport_GetModule(PyObject *name)
         return NULL;
     }
     Py_INCREF(modules);
-    if (PyDict_Check(modules)) {
+    if (PyDict_CheckExact(modules)) {
         m = PyDict_GetItemWithError(modules, name);  /* borrowed */
         Py_XINCREF(m);
     }
@@ -755,7 +755,7 @@ PyObject *
 _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
 {
     PyObject *m;
-    if (PyDict_Check(modules)) {
+    if (PyDict_CheckExact(modules)) {
         m = PyDict_GetItemWithError(modules, name);
     }
     else {

--- a/Python/import.c
+++ b/Python/import.c
@@ -337,7 +337,7 @@ _PyImport_GetModuleWithError(PyObject *name)
     PyObject *mod = PyObject_GetItem(modules, name);
     // For backward-comaptibility we copy the behavior
     // of PyDict_GetItemWithError().
-    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name)) {
+    if (PyErr_ExceptionMatches(PyExc_KeyError)) {
         PyErr_Clear();
     }
     return mod;
@@ -383,8 +383,9 @@ PyImport_GetModule(PyObject *name)
     }
     else {
         m = PyObject_GetItem(modules, name);
-        if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
+        if (PyErr_ExceptionMatches(PyExc_KeyError)) {
             PyErr_Clear();
+        }
     }
     Py_DECREF(modules);
     return m;
@@ -762,8 +763,9 @@ _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
         m = PyObject_GetItem(modules, name);
         // For backward-comaptibility we copy the behavior
         // of PyDict_GetItemWithError().
-        if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
+        if (PyErr_ExceptionMatches(PyExc_KeyError)) {
             PyErr_Clear();
+        }
     }
     if (PyErr_Occurred()) {
         return NULL;

--- a/Python/import.c
+++ b/Python/import.c
@@ -344,24 +344,6 @@ _PyImport_GetModuleWithError(PyObject *name)
 }
 
 PyObject *
-_PyImport_GetModuleString(const char *name)
-{
-    PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules)) {
-        return PyDict_GetItemString(modules, name);
-    }
-
-    PyObject *mod = PyMapping_GetItemString(modules, name);
-    // For backward-comaptibility we copy the behavior
-    // of PyDict_GetItemString().
-    if (PyErr_Occurred()) {
-        PyErr_Clear();
-    }
-    Py_XDECREF(mod);
-    return mod;
-}
-
-PyObject *
 _PyImport_GetModuleId(struct _Py_Identifier *nameid)
 {
     PyObject *name = _PyUnicode_FromId(nameid); /* borrowed */
@@ -1790,9 +1772,10 @@ PyImport_ImportModuleLevel(const char *name, PyObject *globals, PyObject *locals
 PyObject *
 PyImport_ReloadModule(PyObject *m)
 {
+    _Py_IDENTIFIER(imp);
     _Py_IDENTIFIER(reload);
     PyObject *reloaded_module = NULL;
-    PyObject *imp = _PyImport_GetModuleString("imp");
+    PyObject *imp = _PyImport_GetModuleId(&PyId_imp);
     if (imp == NULL) {
         imp = PyImport_ImportModule("imp");
         if (imp == NULL) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -427,7 +427,6 @@ PyImport_Cleanup(void)
 
     if (modules == NULL)
         return; /* Already done */
-    Py_INCREF(modules);
 
     /* Delete some special variables first.  These are common
        places where user values hide and people complain when their

--- a/Python/import.c
+++ b/Python/import.c
@@ -347,6 +347,19 @@ _PyImport_GetModuleId(struct _Py_Identifier *nameid)
     return _PyImport_GetModule(name);
 }
 
+int
+_PyImport_SetModule(PyObject *name, PyObject *m) {
+    PyObject *modules = PyImport_GetModuleDict();
+    return PyObject_SetItem(modules, name, m);
+}
+
+int
+_PyImport_SetModuleString(const char *name, PyObject *m) {
+    PyObject *modules = PyImport_GetModuleDict();
+    return PyMapping_SetItemString(modules, name, m);
+}
+
+
 /* List of names to clear in sys */
 static const char * const sys_deletes[] = {
     "path", "argv", "ps1", "ps2",

--- a/Python/import.c
+++ b/Python/import.c
@@ -803,10 +803,10 @@ static void
 remove_module(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (!PyMapping_HasKey(modules, name)) {
-        return;
-    }
     if (PyMapping_DelItem(modules, name) < 0) {
+        if (!PyMapping_HasKey(modules, name)) {
+            return;
+        }
         Py_FatalError("import:  deleting existing key in"
                       "sys.modules failed");
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -378,18 +378,21 @@ _PyImport_SetModuleString(const char *name, PyObject *m) {
 PyObject *
 PyImport_GetModule(PyObject *name)
 {
-    _Py_IDENTIFIER(modules);
-    PyObject *modules = _PySys_GetObjectId(&PyId_modules);
+    PyObject *m;
+    PyObject *modules = PyImport_GetModuleDict();
     if (modules == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "unable to get sys.modules");
         return NULL;
     }
-    if (PyDict_Check(modules))
-        return PyDict_GetItemWithError(modules, name);
-
-    PyObject *m = PyObject_GetItem(modules, name);
-    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
-        PyErr_Clear();
+    Py_INCREF(modules);
+    if (PyDict_Check(modules)) {
+        m = PyDict_GetItemWithError(modules, name);
+    } else {
+        m = PyObject_GetItem(modules, name);
+        if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
+            PyErr_Clear();
+    }
+    Py_DECREF(modules);
     return m;
 }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -386,7 +386,8 @@ PyImport_GetModule(PyObject *name)
     }
     Py_INCREF(modules);
     if (PyDict_Check(modules)) {
-        m = PyDict_GetItemWithError(modules, name);
+        m = PyDict_GetItemWithError(modules, name);  /* borrowed */
+        Py_XINCREF(m);
     } else {
         m = PyObject_GetItem(modules, name);
         if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))

--- a/Python/import.c
+++ b/Python/import.c
@@ -322,6 +322,7 @@ _PyImport_GetModule(PyObject *name)
     if (PyErr_Occurred()) {
         PyErr_Clear();
     }
+    /* Return a borrowed reference instead of a new one. */
     Py_XDECREF(mod);
     return mod;
 }
@@ -340,6 +341,8 @@ _PyImport_GetModuleWithError(PyObject *name)
     if (PyErr_ExceptionMatches(PyExc_KeyError)) {
         PyErr_Clear();
     }
+    /* Return a borrowed reference instead of a new one. */
+    Py_XDECREF(mod);
     return mod;
 }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -424,6 +424,7 @@ PyImport_Cleanup(void)
 
     if (modules == NULL)
         return; /* Already done */
+    Py_INCREF(modules);
 
     /* Delete some special variables first.  These are common
        places where user values hide and people complain when their

--- a/Python/import.c
+++ b/Python/import.c
@@ -497,9 +497,13 @@ PyImport_Cleanup(void)
             PyErr_Clear();
         }
         else {
-            while ((value = PyIter_Next(iterator))) {
+            while ((key = PyIter_Next(iterator))) {
+                value = PyObject_GetItem(modules, key);
                 CLEAR_MODULE(key, value);
+                Py_DECREF(value);
+                Py_DECREF(key);
             }
+            Py_DECREF(iterator);
         }
     }
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -499,6 +499,10 @@ PyImport_Cleanup(void)
         else {
             while ((key = PyIter_Next(iterator))) {
                 value = PyObject_GetItem(modules, key);
+                if (value == NULL) {
+                    PyErr_Clear();
+                    continue;
+                }
                 CLEAR_MODULE(key, value);
                 Py_DECREF(value);
                 Py_DECREF(key);

--- a/Python/import.c
+++ b/Python/import.c
@@ -291,8 +291,9 @@ PyObject *
 PyImport_GetModuleDict(void)
 {
     PyInterpreterState *interp = PyThreadState_GET()->interp;
-    if (interp->modules == NULL)
+    if (interp->modules == NULL) {
         Py_FatalError("PyImport_GetModuleDict: no module dictionary!");
+    }
     return interp->modules;
 }
 
@@ -312,13 +313,15 @@ PyObject *
 _PyImport_GetModule(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules))
+    if (PyDict_Check(modules)) {
         return PyDict_GetItem(modules, name);
+    }
 
     PyObject *mod = PyObject_GetItem(modules, name);
     // For backward-comaptibility we copy the behavior of PyDict_GetItem().
-    if (PyErr_Occurred())
+    if (PyErr_Occurred()) {
         PyErr_Clear();
+    }
     Py_XDECREF(mod);
     return mod;
 }
@@ -327,14 +330,16 @@ PyObject *
 _PyImport_GetModuleWithError(PyObject *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules))
+    if (PyDict_Check(modules)) {
         return PyDict_GetItemWithError(modules, name);
+    }
 
     PyObject *mod = PyObject_GetItem(modules, name);
     // For backward-comaptibility we copy the behavior
     // of PyDict_GetItemWithError().
-    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
+    if (PyErr_Occurred() && !PyMapping_HasKey(modules, name)) {
         PyErr_Clear();
+    }
     return mod;
 }
 
@@ -342,14 +347,16 @@ PyObject *
 _PyImport_GetModuleString(const char *name)
 {
     PyObject *modules = PyImport_GetModuleDict();
-    if (PyDict_Check(modules))
+    if (PyDict_Check(modules)) {
         return PyDict_GetItemString(modules, name);
+    }
 
     PyObject *mod = PyMapping_GetItemString(modules, name);
     // For backward-comaptibility we copy the behavior
     // of PyDict_GetItemString().
-    if (PyErr_Occurred())
+    if (PyErr_Occurred()) {
         PyErr_Clear();
+    }
     Py_XDECREF(mod);
     return mod;
 }
@@ -358,19 +365,22 @@ PyObject *
 _PyImport_GetModuleId(struct _Py_Identifier *nameid)
 {
     PyObject *name = _PyUnicode_FromId(nameid); /* borrowed */
-    if (name == NULL)
+    if (name == NULL) {
         return NULL;
+    }
     return _PyImport_GetModule(name);
 }
 
 int
-_PyImport_SetModule(PyObject *name, PyObject *m) {
+_PyImport_SetModule(PyObject *name, PyObject *m)
+{
     PyObject *modules = PyImport_GetModuleDict();
     return PyObject_SetItem(modules, name, m);
 }
 
 int
-_PyImport_SetModuleString(const char *name, PyObject *m) {
+_PyImport_SetModuleString(const char *name, PyObject *m)
+{
     PyObject *modules = PyImport_GetModuleDict();
     return PyMapping_SetItemString(modules, name, m);
 }
@@ -388,7 +398,8 @@ PyImport_GetModule(PyObject *name)
     if (PyDict_Check(modules)) {
         m = PyDict_GetItemWithError(modules, name);  /* borrowed */
         Py_XINCREF(m);
-    } else {
+    }
+    else {
         m = PyObject_GetItem(modules, name);
         if (PyErr_Occurred() && !PyMapping_HasKey(modules, name))
             PyErr_Clear();
@@ -764,7 +775,8 @@ _PyImport_AddModuleObject(PyObject *name, PyObject *modules)
     PyObject *m;
     if (PyDict_Check(modules)) {
         m = PyDict_GetItemWithError(modules, name);
-    } else {
+    }
+    else {
         m = PyObject_GetItem(modules, name);
         // For backward-comaptibility we copy the behavior
         // of PyDict_GetItemWithError().

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -42,6 +42,7 @@ _Py_IDENTIFIER(name);
 _Py_IDENTIFIER(stdin);
 _Py_IDENTIFIER(stdout);
 _Py_IDENTIFIER(stderr);
+_Py_IDENTIFIER(threading);
 
 #ifdef __cplusplus
 extern "C" {
@@ -1911,7 +1912,7 @@ wait_for_thread_shutdown(void)
 {
     _Py_IDENTIFIER(_shutdown);
     PyObject *result;
-    PyObject *threading = _PyImport_GetModuleString("threading");
+    PyObject *threading = _PyImport_GetModuleId(&PyId_threading);
     if (threading == NULL) {
         /* threading not imported */
         PyErr_Clear();

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -318,7 +318,7 @@ initimport(PyInterpreterState *interp, PyObject *sysmod)
     if (Py_VerboseFlag) {
         PySys_FormatStderr("import sys # builtin\n");
     }
-    if (PyDict_SetItemString(sys_modules, "_imp", impmod) < 0) {
+    if (PyMapping_SetItemString(sys_modules, "_imp", impmod) < 0) {
         Py_FatalError("Py_Initialize: can't save _imp to sys.modules");
     }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -283,7 +283,6 @@ initimport(PyInterpreterState *interp, PyObject *sysmod)
 {
     PyObject *importlib;
     PyObject *impmod;
-    PyObject *sys_modules;
     PyObject *value;
 
     /* Import _importlib through its frozen version, _frozen_importlib. */
@@ -314,11 +313,7 @@ initimport(PyInterpreterState *interp, PyObject *sysmod)
     else if (Py_VerboseFlag) {
         PySys_FormatStderr("import _imp # builtin\n");
     }
-    sys_modules = PyImport_GetModuleDict();
-    if (Py_VerboseFlag) {
-        PySys_FormatStderr("import sys # builtin\n");
-    }
-    if (PyMapping_SetItemString(sys_modules, "_imp", impmod) < 0) {
+    if (_PyImport_SetModuleString("_imp", impmod) < 0) {
         Py_FatalError("Py_Initialize: can't save _imp to sys.modules");
     }
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1916,13 +1916,13 @@ wait_for_thread_shutdown(void)
 {
     _Py_IDENTIFIER(_shutdown);
     PyObject *result;
-    PyObject *modules = PyImport_GetModuleDict();
-    PyObject *threading = PyMapping_GetItemString(modules, "threading");
+    PyObject *threading = _PyImport_GetModuleString("threading");
     if (threading == NULL) {
         /* threading not imported */
         PyErr_Clear();
         return;
     }
+    Py_INCREF(threading);
     result = _PyObject_CallMethodId(threading, &PyId__shutdown, NULL);
     if (result == NULL) {
         PyErr_WriteUnraisable(threading);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1918,7 +1918,6 @@ wait_for_thread_shutdown(void)
         PyErr_Clear();
         return;
     }
-    Py_INCREF(threading);
     result = _PyObject_CallMethodId(threading, &PyId__shutdown, NULL);
     if (result == NULL) {
         PyErr_WriteUnraisable(threading);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -171,6 +171,7 @@ sys_displayhook(PyObject *self, PyObject *o)
         PyErr_SetString(PyExc_RuntimeError, "lost builtins module");
         return NULL;
     }
+    Py_DECREF(builtins);
 
     /* Print value except if None */
     /* After printing, also assign to '_' */

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -162,14 +162,11 @@ static PyObject *
 sys_displayhook(PyObject *self, PyObject *o)
 {
     PyObject *outf;
-    PyObject *modules = PyImport_GetModuleDict();
-    if (modules == NULL)
-        return NULL;
     PyObject *builtins;
     static PyObject *newline = NULL;
     int err;
 
-    builtins = _PyDict_GetItemId(modules, &PyId_builtins);
+    builtins = _PyImport_GetModuleId(&PyId_builtins);
     if (builtins == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "lost builtins module");
         return NULL;


### PR DESCRIPTION
The concrete PyDict_* API is used to interact with PyInterpreterState.modules in a number of places.  This isn't compatible with all dict subclasses, nor with other Mapping implementations.  This patch switches the concrete API usage to the corresponding abstract API calls.

We also add a PyImport_GetModule() function (and some other helpers) to reduce a bunch of code duplication.

Note that this code was already reviewed and merged as part of #1638.  I reverted that and am now splitting it up into more focused parts.

<!-- issue-number: bpo-28411 -->
https://bugs.python.org/issue28411
<!-- /issue-number -->
