### PR TITLE
[2.7] bpo-31471: Fix assertion failure in subprocess.Popen() on Windows, in case env has a bad keys() method. (GH-3580)

### DIFF
--- a/PC/_subprocess.c
+++ b/PC/_subprocess.c
@@ -341,9 +341,13 @@ getenvironment(PyObject* environment)
     envsize = PyMapping_Length(environment);
 
     keys = PyMapping_Keys(environment);
+    if (!keys) {
+        return NULL;
+    }
     values = PyMapping_Values(environment);
-    if (!keys || !values)
+    if (!values) {
         goto error;
+    }
 
     out = PyString_FromStringAndSize(NULL, 2048);
     if (! out)


### PR DESCRIPTION
the implementation of `PyMapping_Keys()` and `PyMapping_Values()` is different in 2.7, so the test we added to `test_subprocess.py` in 3.7 doesn't cause an assertion failure in 2.7.
we backport the change to `getenvironment()` anyway, because it is simple, and might prevent bugs we haven't thought of.

(this is a partial backport of #3580)

<!-- issue-number: bpo-31471 -->
https://bugs.python.org/issue31471
<!-- /issue-number -->
