### PR TITLE
bpo-31374: undef _POSIX_C_SOURCE in expat_config.h

### DIFF
--- a/Modules/expat/expat_config.h
+++ b/Modules/expat/expat_config.h
@@ -5,7 +5,16 @@
 #ifndef EXPAT_CONFIG_H
 #define EXPAT_CONFIG_H
 
+/* bpo-31374: Expat defines _POSIX_C_SOURCE before including expat_config.h,
+   but pyconfig.h redefines _POSIX_C_SOURCE on some platforms. Unset it to
+   prevent a compiler warning. */
+#ifdef _POSIX_C_SOURCE
+#  undef _POSIX_C_SOURCE
+#endif
+
+/* Get WORDS_BIGENDIAN and HAVE_MEMMOVE defines from pyconfig.h */
 #include <pyconfig.h>
+
 #ifdef WORDS_BIGENDIAN
 #define BYTEORDER 4321
 #else


### PR DESCRIPTION
Undefine _POSIX_C_SOURCE in Modules/expat/expat_config.h to fix a
compiler warning.

<!-- issue-number: bpo-31374 -->
https://bugs.python.org/issue31374
<!-- /issue-number -->
