### PR TITLE
bpo-26121: Fix description in Python 3.7 What's New

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -296,9 +296,8 @@ Optimizations
   (Contributed by Serhiy Storchaka in :issue:`24821`.)
 
 * Fast implementation from standard C library is now used for functions
-  :func:`~math.tgamma`, :func:`~math.lgamma`, :func:`~math.erf` and
-  :func:`~math.erfc` in the :mod:`math` module. (Contributed by Serhiy
-  Storchaka in :issue:`26121`.)
+  :func:`~math.erf` and :func:`~math.erfc` in the :mod:`math` module.
+  (Contributed by Serhiy Storchaka in :issue:`26121`.)
 
 * The :func:`os.fwalk` function has been sped up by 2 times.  This was done
   using the :func:`os.scandir` function.


### PR DESCRIPTION
The description of @serhiy-storchaka's improvements to math.erf and math.erfc in [What's New in Python 3.7](https://docs.python.org/3.7/whatsnew/3.7.html) incorrectly says that tgamma and lgamma now borrow from the standard C implementation (they did in his original PR, but were later removed in #637).

<!-- issue-number: bpo-26121 -->
https://bugs.python.org/issue26121
<!-- /issue-number -->
