### PR TITLE
bpo-31503: Customize module.__dir__.

### DIFF
--- a/Lib/test/test_pkg.py
+++ b/Lib/test/test_pkg.py
@@ -221,16 +221,12 @@ class TestPkg(unittest.TestCase):
 
         import t6
         self.assertEqual(fixdir(dir(t6)),
-                         ['__all__', '__cached__', '__doc__', '__file__',
-                          '__loader__', '__name__', '__package__', '__path__',
-                          '__spec__'])
+                         ['eggs', 'ham', 'spam'])
         s = """
             import t6
             from t6 import *
             self.assertEqual(fixdir(dir(t6)),
-                             ['__all__', '__cached__', '__doc__', '__file__',
-                              '__loader__', '__name__', '__package__',
-                              '__path__', '__spec__', 'eggs', 'ham', 'spam'])
+                             ['eggs', 'ham', 'spam'])
             self.assertEqual(dir(), ['eggs', 'ham', 'self', 'spam', 't6'])
             """
         self.run_code(s)

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-17-21-44-58.bpo-31503.jrzqsj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-17-21-44-58.bpo-31503.jrzqsj.rst
@@ -1,0 +1,1 @@
+dir(some_module) now returns __all__ if it is defined.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -730,11 +730,20 @@ module_dir(PyObject *self, PyObject *args)
 {
     _Py_IDENTIFIER(__dict__);
     PyObject *result = NULL;
+	PyObject *module_all = NULL;
     PyObject *dict = _PyObject_GetAttrId(self, &PyId___dict__);
-
-    if (dict != NULL) {
-        if (PyDict_Check(dict))
-            result = PyDict_Keys(dict);
+    PyObject *all = PyUnicode_FromString("__all__");
+    if (all != NULL && dict != NULL) {
+        if (PyDict_Check(dict)) {
+            module_all = PyDict_GetItem(dict, all);
+            if (module_all != NULL) {
+                /* We need to actually check if it's a list and then copy the items */
+				Py_INCREF(module_all);
+                result = module_all;
+            }
+            else
+                result = PyDict_Keys(dict);
+        }
         else {
             const char *name = PyModule_GetName(self);
             if (name)
@@ -743,7 +752,7 @@ module_dir(PyObject *self, PyObject *args)
                              name);
         }
     }
-
+    Py_XDECREF(all);
     Py_XDECREF(dict);
     return result;
 }


### PR DESCRIPTION
Allow dir(module) to be informed by module.__all__, if it exists.

`dir(some_module)` could provide a more useful result than it currently does.  Python already provides a protocol for specifying a module's API: `__all__`.  `dir(some_module)` would be more useful if it only returned what is in `some_module.__all__`, if it is defined.  This PR makes `dir(some_module)` basically return `some_module.__all__`, if it exists.  Otherwise, the old behavior is maintained.

<!-- issue-number: bpo-31503 -->
https://bugs.python.org/issue31503
<!-- /issue-number -->
