### PR TITLE
bpo-31458: Clarify that Changelog is built from Misc/NEWS.d directory

### DIFF
--- a/Doc/whatsnew/index.rst
+++ b/Doc/whatsnew/index.rst
@@ -28,8 +28,10 @@ anyone wishing to stay up-to-date after a new release.
    2.1.rst
    2.0.rst
 
-The "Changelog" is a HTML version of the file :source:`Misc/NEWS.d` which
-contains *all* nontrivial changes to Python for the current version.
+The "Changelog" is an HTML version of the `file built
+<https://pypi.org/project/blurb>`_ from the contents of the
+:source:`Misc/NEWS.d` directory tree, which contains *all* nontrivial changes
+to Python for the current version.
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION


<!-- issue-number: bpo-31458 -->
https://bugs.python.org/issue31458
<!-- /issue-number -->
