### PR TITLE
bpo-31492: Fix assertion failures in case of a module with a bad __name__ attribute

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -400,6 +400,18 @@ class ImportTests(unittest.TestCase):
         self.assertEqual(str(cm.exception),
             "cannot import name 'does_not_exist' from '<unknown module name>' (unknown location)")
 
+    @cpython_only
+    def test_issue31492(self):
+        # There shouldn't be an assertion failure in case of failing to import
+        # from a module with a bad __name__ attribute, or in case of failing
+        # to access an attribute of such a module.
+        with swap_attr(os, '__name__', None):
+            with self.assertRaises(ImportError):
+                from os import does_not_exist
+
+            with self.assertRaises(AttributeError):
+                os.does_not_exist
+
     def test_concurrency(self):
         sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'data'))
         try:

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-16-22-49-16.bpo-31492.RtyteL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-16-22-49-16.bpo-31492.RtyteL.rst
@@ -1,0 +1,3 @@
+Fix assertion failures in case of failing to import from a module with a bad
+``__name__`` attribute, and in case of failing to access an attribute of such
+a module. Patch by Oren Milman.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -687,13 +687,10 @@ module_getattro(PyModuleObject *m, PyObject *name)
     if (m->md_dict) {
         _Py_IDENTIFIER(__name__);
         mod_name = _PyDict_GetItemId(m->md_dict, &PyId___name__);
-        if (mod_name) {
+        if (mod_name && PyUnicode_Check(mod_name)) {
             PyErr_Format(PyExc_AttributeError,
                         "module '%U' has no attribute '%U'", mod_name, name);
             return NULL;
-        }
-        else if (PyErr_Occurred()) {
-            PyErr_Clear();
         }
     }
     PyErr_Format(PyExc_AttributeError,

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -680,7 +680,6 @@ static PyObject*
 module_getattro(PyModuleObject *m, PyObject *name)
 {
     PyObject *attr, *mod_name;
-    assert(PyUnicode_Check(name));
     attr = PyObject_GenericGetAttr((PyObject *)m, name);
     if (attr || !PyErr_ExceptionMatches(PyExc_AttributeError))
         return attr;

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -680,6 +680,7 @@ static PyObject*
 module_getattro(PyModuleObject *m, PyObject *name)
 {
     PyObject *attr, *mod_name;
+    assert(PyUnicode_Check(name));
     attr = PyObject_GenericGetAttr((PyObject *)m, name);
     if (attr || !PyErr_ExceptionMatches(PyExc_AttributeError))
         return attr;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4930,6 +4930,10 @@ import_from(PyObject *v, PyObject *name)
     if (pkgname == NULL) {
         goto error;
     }
+    if (!PyUnicode_Check(pkgname)) {
+        Py_DECREF(pkgname);
+        goto error;
+    }
     fullmodname = PyUnicode_FromFormat("%U.%U", pkgname, name);
     if (fullmodname == NULL) {
         Py_DECREF(pkgname);
@@ -4944,7 +4948,7 @@ import_from(PyObject *v, PyObject *name)
     return x;
  error:
     pkgpath = PyModule_GetFilenameObject(v);
-    if (pkgname == NULL) {
+    if (pkgname == NULL || !PyUnicode_Check(pkgname)) {
         pkgname_or_unknown = PyUnicode_FromString("<unknown module name>");
         if (pkgname_or_unknown == NULL) {
             Py_XDECREF(pkgpath);

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4931,7 +4931,7 @@ import_from(PyObject *v, PyObject *name)
         goto error;
     }
     if (!PyUnicode_Check(pkgname)) {
-        Py_DECREF(pkgname);
+        Py_CLEAR(pkgname);
         goto error;
     }
     fullmodname = PyUnicode_FromFormat("%U.%U", pkgname, name);
@@ -4948,7 +4948,7 @@ import_from(PyObject *v, PyObject *name)
     return x;
  error:
     pkgpath = PyModule_GetFilenameObject(v);
-    if (pkgname == NULL || !PyUnicode_Check(pkgname)) {
+    if (pkgname == NULL) {
         pkgname_or_unknown = PyUnicode_FromString("<unknown module name>");
         if (pkgname_or_unknown == NULL) {
             Py_XDECREF(pkgpath);


### PR DESCRIPTION
- in `moduleobject.c`: add a check whether the retrieved `__name__` attribute is a string. while we are here, remove a redundant call to `PyErr_Clear()`.
- in `ceval.c`: add a check whether the retrieved `__name__` attribute is not a string.
- in `test_import/__init__.py`: add a test to verify that the assertion failures are no more.


<!-- issue-number: bpo-31492 -->
https://bugs.python.org/issue31492
<!-- /issue-number -->
