### PR TITLE
bpo-31493: Fix code context update and font update timers.

### DIFF
--- a/Lib/idlelib/codecontext.py
+++ b/Lib/idlelib/codecontext.py
@@ -22,15 +22,14 @@ BLOCKOPENERS = {"class", "def", "elif", "else", "except", "finally", "for",
 UPDATEINTERVAL = 100 # millisec
 FONTUPDATEINTERVAL = 1000 # millisec
 
-getspacesfirstword =\
-                   lambda s, c=re.compile(r"^(\s*)(\w*)"): c.match(s).groups()
+def getspacesfirstword(s, c=re.compile(r"^(\s*)(\w*)")):
+    return c.match(s).groups()
 
 
 class CodeContext:
-    bgcolor = idleConf.GetOption("extensions", "CodeContext",
-                                 "bgcolor", type="str", default="LightGray")
-    fgcolor = idleConf.GetOption("extensions", "CodeContext",
-                                 "fgcolor", type="str", default="Black")
+    bgcolor = "LightGray"
+    fgcolor = "Black"
+
     def __init__(self, editwin):
         self.editwin = editwin
         self.text = editwin.text
@@ -43,19 +42,25 @@ class CodeContext:
         # starts the toplevel 'block' of the module.
         self.info = [(0, -1, "", False)]
         self.topvisible = 1
-        self.reload()
         # Start two update cycles, one for context lines, one for font changes.
-        self.text.after(UPDATEINTERVAL, self.timer_event)
-        self.text.after(FONTUPDATEINTERVAL, self.font_timer_event)
+        self.t1 = self.text.after(UPDATEINTERVAL, self.timer_event)
+        self.t2 = self.text.after(FONTUPDATEINTERVAL, self.font_timer_event)
 
     @classmethod
     def reload(cls):
         cls.context_depth = idleConf.GetOption("extensions", "CodeContext",
                                        "numlines", type="int", default=3)
-        cls.bgcolor = idleConf.GetOption("extensions", "CodeContext",
-                                     "bgcolor", type="str", default="LightGray")
-        cls.fgcolor = idleConf.GetOption("extensions", "CodeContext",
-                                     "fgcolor", type="str", default="Black")
+##        cls.bgcolor = idleConf.GetOption("extensions", "CodeContext",
+##                                     "bgcolor", type="str", default="LightGray")
+##        cls.fgcolor = idleConf.GetOption("extensions", "CodeContext",
+##                                     "fgcolor", type="str", default="Black")
+
+    def __del__(self):
+        try:
+            self.text.after_cancel(self.t1)
+            self.text.after_cancel(self.t2)
+        except:
+            pass
 
     def toggle_code_context_event(self, event=None):
         if not self.label:
@@ -74,14 +79,12 @@ class CodeContext:
             border = 0
             for widget in widgets:
                 border += widget.tk.getint(widget.cget('border'))
-            self.label = tkinter.Label(self.editwin.top,
-                                       text="\n" * (self.context_depth - 1),
-                                       anchor=W, justify=LEFT,
-                                       font=self.textfont,
-                                       bg=self.bgcolor, fg=self.fgcolor,
-                                       width=1, #don't request more than we get
-                                       padx=padx, border=border,
-                                       relief=SUNKEN)
+            self.label = tkinter.Label(
+                    self.editwin.top, text="\n" * (self.context_depth - 1),
+                    anchor=W, justify=LEFT, font=self.textfont,
+                    bg=self.bgcolor, fg=self.fgcolor,
+                    width=1, #don't request more than we get
+                    padx=padx, border=border, relief=SUNKEN)
             # Pack the label widget before and above the text_frame widget,
             # thus ensuring that it will appear directly above text_frame
             self.label.pack(side=TOP, fill=X, expand=False,
@@ -89,9 +92,6 @@ class CodeContext:
         else:
             self.label.destroy()
             self.label = None
-        idleConf.SetOption("main", "Theme", "contexton",
-                           str(self.label is not None))
-        idleConf.SaveUserCfgFiles()
         return "break"
 
     def get_line_info(self, linenum):
@@ -172,14 +172,14 @@ class CodeContext:
     def timer_event(self):
         if self.label:
             self.update_code_context()
-        self.text.after(UPDATEINTERVAL, self.timer_event)
+        self.t1 = self.text.after(UPDATEINTERVAL, self.timer_event)
 
     def font_timer_event(self):
         newtextfont = self.text["font"]
         if self.label and newtextfont != self.textfont:
             self.textfont = newtextfont
             self.label["font"] = self.textfont
-        self.text.after(FONTUPDATEINTERVAL, self.font_timer_event)
+        self.t2 = self.text.after(FONTUPDATEINTERVAL, self.font_timer_event)
 
 
 CodeContext.reload()

--- a/Misc/NEWS.d/next/IDLE/2017-09-16-23-43-39.bpo-31493.nmHMCR.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-16-23-43-39.bpo-31493.nmHMCR.rst
@@ -1,0 +1,3 @@
+IDLE code context -- fix code update and font update timers.
+
+Canceling timers prevents a warning message when test_idle completes.


### PR DESCRIPTION
Canceling timers prevents a warning message when test_idle completes.
(This is the minimum fix needed before upcoming releases.)


<!-- issue-number: bpo-31493 -->
https://bugs.python.org/issue31493
<!-- /issue-number -->
