### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ On Unix, Linux, BSD, macOS, and Cygwin::
 This will install Python as python3.
 
 You can pass many options to the configure script; run ``./configure --help``
-to find out more.  On macOS and Cygwin, the executable is called ``python.exe``;
+to find out more.  On Windows and Cygwin, the executable is called ``python.exe``;
 elsewhere it's just ``python``.
 
 On macOS, if you have configured Python with ``--enable-framework``, you


### PR DESCRIPTION
Windows was replaced with OSX/macOS. In macOS, the executable is called `python`, not `python.exe`.