### PR TITLE
bpo-31497: Add private helper `_PyType_Name()`.

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -501,6 +501,7 @@ PyAPI_FUNC(PyObject *) PyType_GenericAlloc(PyTypeObject *, Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyType_GenericNew(PyTypeObject *,
                                                PyObject *, PyObject *);
 #ifndef Py_LIMITED_API
+PyAPI_FUNC(const char *) _PyType_Name(PyTypeObject *);
 PyAPI_FUNC(PyObject *) _PyType_Lookup(PyTypeObject *, PyObject *);
 PyAPI_FUNC(PyObject *) _PyType_LookupId(PyTypeObject *, _Py_Identifier *);
 PyAPI_FUNC(PyObject *) _PyObject_LookupSpecial(PyObject *, _Py_Identifier *);

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -1284,7 +1284,7 @@ PyInit__functools(void)
 {
     int i;
     PyObject *m;
-    char *name;
+    const char *name;
     PyTypeObject *typelist[] = {
         &partial_type,
         &lru_cache_type,
@@ -1306,10 +1306,9 @@ PyInit__functools(void)
             Py_DECREF(m);
             return NULL;
         }
-        name = strchr(typelist[i]->tp_name, '.');
-        assert (name != NULL);
+        name = _PyType_Name(typelist[i]);
         Py_INCREF(typelist[i]);
-        PyModule_AddObject(m, name+1, (PyObject *)typelist[i]);
+        PyModule_AddObject(m, name, (PyObject *)typelist[i]);
     }
     return m;
 }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -4630,7 +4630,7 @@ PyInit_itertools(void)
 {
     int i;
     PyObject *m;
-    char *name;
+    const char *name;
     PyTypeObject *typelist[] = {
         &accumulate_type,
         &combinations_type,
@@ -4663,10 +4663,9 @@ PyInit_itertools(void)
     for (i=0 ; typelist[i] != NULL ; i++) {
         if (PyType_Ready(typelist[i]) < 0)
             return NULL;
-        name = strchr(typelist[i]->tp_name, '.');
-        assert (name != NULL);
+        name = _PyType_Name(typelist[i]);
         Py_INCREF(typelist[i]);
-        PyModule_AddObject(m, name+1, (PyObject *)typelist[i]);
+        PyModule_AddObject(m, name, (PyObject *)typelist[i]);
     }
 
     return m;

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -116,13 +116,7 @@ BaseException_str(PyBaseExceptionObject *self)
 static PyObject *
 BaseException_repr(PyBaseExceptionObject *self)
 {
-    const char *name;
-    const char *dot;
-
-    name = Py_TYPE(self)->tp_name;
-    dot = (const char *) strrchr(name, '.');
-    if (dot != NULL) name = dot+1;
-
+    const char *name = _PyType_Name(Py_TYPE(self));
     return PyUnicode_FromFormat("%s%R", name, self->args);
 }
 

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1471,16 +1471,9 @@ odict_repr(PyODictObject *self)
     int i;
     _Py_IDENTIFIER(items);
     PyObject *pieces = NULL, *result = NULL;
-    const char *classname;
-
-    classname = strrchr(Py_TYPE(self)->tp_name, '.');
-    if (classname == NULL)
-        classname = Py_TYPE(self)->tp_name;
-    else
-        classname++;
 
     if (PyODict_SIZE(self) == 0)
-        return PyUnicode_FromFormat("%s()", classname);
+        return PyUnicode_FromFormat("%s()", _PyType_Name(Py_TYPE(self)));
 
     i = Py_ReprEnter((PyObject *)self);
     if (i != 0) {
@@ -1532,7 +1525,8 @@ odict_repr(PyODictObject *self)
             goto Done;
     }
 
-    result = PyUnicode_FromFormat("%s(%R)", classname, pieces);
+    result = PyUnicode_FromFormat("%s(%R)",
+                                  _PyType_Name(Py_TYPE(self)), pieces);
 
 Done:
     Py_XDECREF(pieces);

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -388,11 +388,22 @@ check_set_special_type_attr(PyTypeObject *type, PyObject *value, const char *nam
     return 1;
 }
 
+const char *
+_PyType_Name(PyTypeObject *type)
+{
+    const char *s = strrchr(type->tp_name, '.');
+    if (s == NULL) {
+        s = type->tp_name;
+    }
+    else {
+        s++;
+    }
+    return s;
+}
+
 static PyObject *
 type_name(PyTypeObject *type, void *context)
 {
-    const char *s;
-
     if (type->tp_flags & Py_TPFLAGS_HEAPTYPE) {
         PyHeapTypeObject* et = (PyHeapTypeObject*)type;
 
@@ -400,12 +411,7 @@ type_name(PyTypeObject *type, void *context)
         return et->ht_name;
     }
     else {
-        s = strrchr(type->tp_name, '.');
-        if (s == NULL)
-            s = type->tp_name;
-        else
-            s++;
-        return PyUnicode_FromString(s);
+        return PyUnicode_FromString(_PyType_Name(type));
     }
 }
 
@@ -418,7 +424,7 @@ type_qualname(PyTypeObject *type, void *context)
         return et->ht_qualname;
     }
     else {
-        return type_name(type, context);
+        return PyUnicode_FromString(_PyType_Name(type));
     }
 }
 


### PR DESCRIPTION
This function returns the last component of `tp_name` after a dot.
Returns `tp_name` itself if it doesn't contain a dot.


<!-- issue-number: bpo-31497 -->
https://bugs.python.org/issue31497
<!-- /issue-number -->
