### PR TITLE
bpo-30528: Fix IPv{4,6}Network reverse_pointer

### DIFF
--- a/Lib/ipaddress.py
+++ b/Lib/ipaddress.py
@@ -1555,6 +1555,19 @@ class IPv4Network(_BaseV4, _BaseNetwork):
                     self.broadcast_address in IPv4Network('100.64.0.0/10')) and
                 not self.is_private)
 
+    def _reverse_pointer(self):
+        """Return the reverse DNS pointer name for the IPv4 address.
+
+        This implements the method described in RFC1035 3.5.
+
+        For networks for which no exact domain is matched the covering domain is returned.
+
+        >>> IPv4Network('127.0.0.0/13').reverse_pointer
+        '127.in-addr.arpa
+        """
+        octets = str(self.network_address).split('.')[:self.prefixlen // 8]
+        return '.'.join(reversed(['arpa', 'in-addr'] + octets))
+
 
 class _IPv4Constants:
     _linklocal_network = IPv4Network('169.254.0.0/16')
@@ -2261,6 +2274,15 @@ class IPv6Network(_BaseV6, _BaseNetwork):
         """
         return (self.network_address.is_site_local and
                 self.broadcast_address.is_site_local)
+
+    def _reverse_pointer(self):
+        """Return the reverse DNS pointer name for the IPv6 network.
+
+        This implements the method described in RFC3596 2.5.
+
+        """
+        chars = self.exploded.replace(':', '')[:self.prefixlen // 4]
+        return '.'.join(reversed(['arpa', 'ip6'] + list(chars)))
 
 
 class _IPv6Constants:

--- a/Lib/test/test_ipaddress.py
+++ b/Lib/test/test_ipaddress.py
@@ -477,6 +477,26 @@ class InterfaceTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
 class NetworkTestCase_v4(BaseTestCase, NetmaskTestMixin_v4):
     factory = ipaddress.IPv4Network
 
+    def test_reverse_pointer(self):
+        self.assertEqual(self.factory('0.0.0.0/0').reverse_pointer,
+                         'in-addr.arpa')
+        self.assertEqual(self.factory('127.0.0.0/8').reverse_pointer,
+                         '127.in-addr.arpa')
+        self.assertEqual(self.factory('127.128.0.0/9').reverse_pointer,
+                         '127.in-addr.arpa')
+        self.assertEqual(self.factory('127.254.0.0/15').reverse_pointer,
+                         '127.in-addr.arpa')
+        self.assertEqual(self.factory('127.255.0.0/16').reverse_pointer,
+                         '255.127.in-addr.arpa')
+        self.assertEqual(self.factory('127.255.123.0/24').reverse_pointer,
+                         '123.255.127.in-addr.arpa')
+        self.assertEqual(self.factory('127.255.123.128/25').reverse_pointer,
+                         '123.255.127.in-addr.arpa')
+        self.assertEqual(self.factory('127.255.123.254/31').reverse_pointer,
+                         '123.255.127.in-addr.arpa')
+        self.assertEqual(self.factory('127.111.222.255/32').reverse_pointer,
+                         '255.222.111.127.in-addr.arpa')
+
 
 class NetmaskTestMixin_v6(CommonTestMixin_v6):
     """Input validation on interfaces and networks is very similar"""
@@ -539,6 +559,18 @@ class InterfaceTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
 
 class NetworkTestCase_v6(BaseTestCase, NetmaskTestMixin_v6):
     factory = ipaddress.IPv6Network
+
+    def test_reverse_pointer(self):
+        self.assertEqual(self.factory('::/0').reverse_pointer,
+                         'ip6.arpa')
+        self.assertEqual(self.factory('2001:db8::/32').reverse_pointer,
+                         '8.b.d.0.1.0.0.2.ip6.arpa')
+        self.assertEqual(self.factory('2001:db8:1234::/48').reverse_pointer,
+                         '4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa')
+        self.assertEqual(self.factory('2001:db8:1234::/49').reverse_pointer,
+                         '4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa')
+        self.assertEqual(self.factory('2001:db8:1234:5678:90ab:cdef:cafe:b100').reverse_pointer,
+                         '0.0.1.b.e.f.a.c.f.e.d.c.b.a.0.9.8.7.6.5.4.3.2.1.8.b.d.0.1.0.0.2.ip6.arpa')
 
 
 class FactoryFunctionErrors(BaseTestCase):


### PR DESCRIPTION
Previous incorrect result for IPv4Network:

```
>>> ipaddress.IPv4Network('127.0.0.0/16').reverse_pointer
'0/16.0.0.127.in-addr.arpa'
```

New result:

```
>>> ipaddress.IPv4Network('127.0.0.0/16').reverse_pointer
'0.127.in-addr.arpa'
```

Previous incorrect result for IPv6Network:

```
>>> ipaddress.IPv6Network('2001:db8::/32').reverse_pointer
'2.3./.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa'
```

New result:

```
>>> ipaddress.IPv6Network('2001:db8::/32').reverse_pointer
'8.b.d.0.1.0.0.2.ip6.arpa'
```

<!-- issue-number: bpo-30528 -->
https://bugs.python.org/issue30528
<!-- /issue-number -->
