### PR TITLE
bpo-31501: Operator precedence  description  for arithmetic operators

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1687,8 +1687,8 @@ precedence and have a left-to-right chaining feature as described in the
 | ``+``, ``-``                                  | Addition and subtraction            |
 +-----------------------------------------------+-------------------------------------+
 | ``*``, ``@``, ``/``, ``//``, ``%``            | Multiplication, matrix              |
-|                                               | multiplication division,            |
-|                                               | remainder [#]_                      |
+|                                               | multiplication, division, floor     |
+|                                               | division, remainder [#]_            |
 +-----------------------------------------------+-------------------------------------+
 | ``+x``, ``-x``, ``~x``                        | Positive, negative, bitwise NOT     |
 +-----------------------------------------------+-------------------------------------+


### PR DESCRIPTION
!!! If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

[X.Y] <title from the original PR> GH-NNNN

Where: [X.Y] is the branch name, for example [3.6]

GH-NNNN refers to the PR number from `master`.

PLEASE: Remove this headline!!!


<!-- issue-number: bpo-31501 -->
https://bugs.python.org/issue31501
<!-- /issue-number -->
