### PR TITLE
bpo-31499, xml.etree: Fix xmlparser_gc_clear() crash

### DIFF
--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -65,6 +65,26 @@ class MiscTests(unittest.TestCase):
         del root
         support.gc_collect()
 
+    def test_parser_ref_cycle(self):
+        # bpo-31499: xmlparser_dealloc() crashed with a segmentation fault when
+        # xmlparser_gc_clear() was called previously by the garbage collector,
+        # when the parser was part of a reference cycle.
+
+        def parser_ref_cycle():
+            parser = cET.XMLParser()
+            # Create a reference cycle using an exception to keep the frame
+            # alive, so the parser will be destroyed by the garbage collector
+            try:
+                raise ValueError
+            except ValueError as exc:
+                err = exc
+
+        # Create a parser part of reference cycle
+        parser_ref_cycle()
+        # Trigger an explicit garbage collection to break the reference cycle
+        # and so destroy the parser
+        support.gc_collect()
+
 
 @unittest.skipUnless(cET, 'requires _elementtree')
 class TestAliasWorking(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2017-09-18-10-57-04.bpo-31499.BydYhf.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-18-10-57-04.bpo-31499.BydYhf.rst
@@ -1,1 +1,1 @@
-xml.etree: Fix a crash when a parser if part of a reference cycle.
+xml.etree: Fix a crash when a parser is part of a reference cycle.

--- a/Misc/NEWS.d/next/Library/2017-09-18-10-57-04.bpo-31499.BydYhf.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-18-10-57-04.bpo-31499.BydYhf.rst
@@ -1,0 +1,3 @@
+xml.etree: xmlparser_gc_clear() now sets self.parser to NULL to prevent a
+crash in xmlparser_dealloc() if xmlparser_gc_clear() was called previously
+by the garbage collector, because the parser was part of a reference cycle.

--- a/Misc/NEWS.d/next/Library/2017-09-18-10-57-04.bpo-31499.BydYhf.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-18-10-57-04.bpo-31499.BydYhf.rst
@@ -1,3 +1,1 @@
-xml.etree: xmlparser_gc_clear() now sets self.parser to NULL to prevent a
-crash in xmlparser_dealloc() if xmlparser_gc_clear() was called previously
-by the garbage collector, because the parser was part of a reference cycle.
+xml.etree: Fix a crash when a parser if part of a reference cycle.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3411,7 +3411,10 @@ xmlparser_gc_traverse(XMLParserObject *self, visitproc visit, void *arg)
 static int
 xmlparser_gc_clear(XMLParserObject *self)
 {
-    EXPAT(ParserFree)(self->parser);
+    if (self->parser != NULL) {
+        EXPAT(ParserFree)(self->parser);
+        self->parser = NULL;
+    }
 
     Py_CLEAR(self->handle_close);
     Py_CLEAR(self->handle_pi);

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3412,8 +3412,9 @@ static int
 xmlparser_gc_clear(XMLParserObject *self)
 {
     if (self->parser != NULL) {
-        EXPAT(ParserFree)(self->parser);
+        XML_Parser parser = self->parser;
         self->parser = NULL;
+        EXPAT(ParserFree)(parser);
     }
 
     Py_CLEAR(self->handle_close);


### PR DESCRIPTION
xml.etree: xmlparser_gc_clear() now sets self.parser to NULL to prevent a
crash in xmlparser_dealloc() if xmlparser_gc_clear() was called previously
by the garbage collector, because the parser was part of a reference cycle.

<!-- issue-number: bpo-31499 -->
https://bugs.python.org/issue31499
<!-- /issue-number -->
