### PR TITLE
bpo-31504: Update stdtypes.rst

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1583,6 +1583,12 @@ expression support in the :mod:`re` module).
          >>> 'Py' in 'Python'
          True
 
+      If the substring *sub* is ``''``, then `:meth:~str.find` method will return 
+      a value that is equal to ``len(str)``.
+
+         >>> 'abc'.find('')
+         3
+
 
 .. method:: str.format(*args, **kwargs)
 


### PR DESCRIPTION
Added behaviour of `find` when `substring` is `""`.

<!-- issue-number: bpo-31504 -->
https://bugs.python.org/issue31504
<!-- /issue-number -->
