### PR TITLE
bpo-31505: Fix an assertion failure in json, in case _json.make_encoder() received a bad encoder() argument

### DIFF
--- a/Lib/test/test_json/test_speedups.py
+++ b/Lib/test/test_json/test_speedups.py
@@ -37,25 +37,26 @@ class TestEncode(CTest):
             b"\xCD\x7D\x3D\x4E\x12\x4C\xF9\x79\xD7\x52\xBA\x82\xF2\x27\x4A\x7D\xA0\xCA\x75",
             None)
 
-    @test.support.cpython_only
-    def test_issue31505(self):
-        # There shouldn't be an assertion failure in case c_make_encoder()
-        # receives a bad encoder() argument.
-        def _bad_encoder1(*args):
+    def test_bad_str_encoder(self):
+        # Issue #31505: There shouldn't be an assertion failure in case
+        # c_make_encoder() receives a bad encoder() argument.
+        def bad_encoder1(*args):
             return None
-        enc = self.json.encoder.c_make_encoder(None, None, _bad_encoder1, None,
-                                               'foo', 'bar', None, None, None)
+        enc = self.json.encoder.c_make_encoder(None, lambda obj: str(obj),
+                                               bad_encoder1, None, ': ', ', ',
+                                               False, False, False)
         with self.assertRaises(TypeError):
-            enc(obj='spam', _current_indent_level=4)
+            enc('spam', 4)
         with self.assertRaises(TypeError):
-            enc(obj={'spam': 42}, _current_indent_level=4)
+            enc({'spam': 42}, 4)
 
-        def _bad_encoder2(*args):
+        def bad_encoder2(*args):
             1/0
-        enc = self.json.encoder.c_make_encoder(None, None, _bad_encoder2, None,
-                                               'foo', 'bar', None, None, None)
+        enc = self.json.encoder.c_make_encoder(None, lambda obj: str(obj),
+                                               bad_encoder2, None, ': ', ', ',
+                                               False, False, False)
         with self.assertRaises(ZeroDivisionError):
-            enc(obj='spam', _current_indent_level=4)
+            enc('spam', 4)
 
     def test_bad_bool_args(self):
         def test(name):

--- a/Lib/test/test_json/test_speedups.py
+++ b/Lib/test/test_json/test_speedups.py
@@ -38,7 +38,7 @@ class TestEncode(CTest):
             None)
 
     @test.support.cpython_only
-    def test_issueXXXXX(self):
+    def test_issue31505(self):
         # There shouldn't be an assertion failure in case c_make_encoder()
         # receives a bad encoder() argument.
         def _bad_encoder1(*args):

--- a/Lib/test/test_json/test_speedups.py
+++ b/Lib/test/test_json/test_speedups.py
@@ -1,5 +1,4 @@
 from test.test_json import CTest
-import test.support
 
 
 class BadBool:

--- a/Lib/test/test_json/test_speedups.py
+++ b/Lib/test/test_json/test_speedups.py
@@ -1,4 +1,5 @@
 from test.test_json import CTest
+import test.support
 
 
 class BadBool:
@@ -35,6 +36,26 @@ class TestEncode(CTest):
             (True, False),
             b"\xCD\x7D\x3D\x4E\x12\x4C\xF9\x79\xD7\x52\xBA\x82\xF2\x27\x4A\x7D\xA0\xCA\x75",
             None)
+
+    @test.support.cpython_only
+    def test_issueXXXXX(self):
+        # There shouldn't be an assertion failure in case c_make_encoder()
+        # receives a bad encoder() argument.
+        def _bad_encoder1(*args):
+            return None
+        enc = self.json.encoder.c_make_encoder(None, None, _bad_encoder1, None,
+                                               'foo', 'bar', None, None, None)
+        with self.assertRaises(TypeError):
+            enc(obj='spam', _current_indent_level=4)
+        with self.assertRaises(TypeError):
+            enc(obj={'spam': 42}, _current_indent_level=4)
+
+        def _bad_encoder2(*args):
+            1/0
+        enc = self.json.encoder.c_make_encoder(None, None, _bad_encoder2, None,
+                                               'foo', 'bar', None, None, None)
+        with self.assertRaises(ZeroDivisionError):
+            enc(obj='spam', _current_indent_level=4)
 
     def test_bad_bool_args(self):
         def test(name):

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-18-12-07-39.bpo-31505.VomaFa.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-18-12-07-39.bpo-31505.VomaFa.rst
@@ -1,0 +1,2 @@
+Fix an assertion failure in `json`, in case `_json.make_encoder()` received
+a bad `encoder()` argument. Patch by Oren Milman.

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1431,8 +1431,9 @@ encoder_encode_string(PyEncoderObject *s, PyObject *obj)
     /* Return the JSON representation of a string */
     PyObject *encoded;
 
-    if (s->fast_encode)
+    if (s->fast_encode) {
         return s->fast_encode(NULL, obj);
+    }
     encoded = PyObject_CallFunctionObjArgs(s->encoder, obj, NULL);
     if (encoded != NULL && !PyUnicode_Check(encoded)) {
         PyErr_Format(PyExc_TypeError,

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1430,12 +1430,10 @@ encoder_encode_string(PyEncoderObject *s, PyObject *obj)
 {
     /* Return the JSON representation of a string */
     PyObject *encoded;
-    if (s->fast_encode) {
-        encoded = s->fast_encode(NULL, obj);
-    }
-    else {
-        encoded = PyObject_CallFunctionObjArgs(s->encoder, obj, NULL);
-    }
+
+    if (s->fast_encode)
+        return s->fast_encode(NULL, obj);
+    encoded = PyObject_CallFunctionObjArgs(s->encoder, obj, NULL);
     if (encoded != NULL && !PyUnicode_Check(encoded)) {
         PyErr_Format(PyExc_TypeError,
                      "encoder() must return a string, not %.80s",

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1429,10 +1429,21 @@ static PyObject *
 encoder_encode_string(PyEncoderObject *s, PyObject *obj)
 {
     /* Return the JSON representation of a string */
-    if (s->fast_encode)
-        return s->fast_encode(NULL, obj);
-    else
-        return PyObject_CallFunctionObjArgs(s->encoder, obj, NULL);
+    PyObject *encoded;
+    if (s->fast_encode) {
+        encoded = s->fast_encode(NULL, obj);
+    }
+    else {
+        encoded = PyObject_CallFunctionObjArgs(s->encoder, obj, NULL);
+    }
+    if (encoded != NULL && !PyUnicode_Check(encoded)) {
+        PyErr_Format(PyExc_TypeError,
+                     "encoder() must return a string, not %.80s",
+                     Py_TYPE(encoded)->tp_name);
+        Py_DECREF(encoded);
+        return NULL;
+    }
+    return encoded;
 }
 
 static int


### PR DESCRIPTION
- in `_json.c`: add a check whether `encoder()` hasn't returned a string.
- in `test_json/test_speedups.py`: add a test to verify that the assertion failure is no more, and that the patch doesn't break anything when `encoder()` fails.

<!-- issue-number: bpo-31505 -->
https://bugs.python.org/issue31505
<!-- /issue-number -->
