### PR TITLE
bpo-31507 Add docstring to parseaddr function in email.utils.parseaddr

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -217,7 +217,7 @@ def parsedate_to_datetime(data):
 def parseaddr(addr):
     """
     Parse addr into its constituent realname and email address parts.
-    
+
     Return a tuple of realname and email address, unless the parse fails, in
     which case return a 2-tuple of ('', '').
     """

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -215,6 +215,12 @@ def parsedate_to_datetime(data):
 
 
 def parseaddr(addr):
+    """
+    Parse address – which should be the value of some address-containing field such as To or Cc
+    – into its constituent realname and email address parts.
+    Returns a tuple of that information, unless the parse fails, 
+    in which case a 2-tuple of ('', '') is returned.
+    """
     addrs = _AddressList(addr).addresslist
     if not addrs:
         return '', ''

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -216,10 +216,8 @@ def parsedate_to_datetime(data):
 
 def parseaddr(addr):
     """
-    Parse address – which should be the value of some address-containing field such as To or Cc
-    – into its constituent realname and email address parts.
-    Returns a tuple of that information, unless the parse fails,
-    in which case a 2-tuple of ('', '') is returned.
+    Parse address – which should be the value of some address-containing field such as To or Cc – into its constituent realname and email address parts.
+    Returns a tuple of that information, unless the parse fails, in which case a 2-tuple of ('', '') is returned.
     """
     addrs = _AddressList(addr).addresslist
     if not addrs:

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -218,7 +218,7 @@ def parseaddr(addr):
     """
     Parse address – which should be the value of some address-containing field such as To or Cc
     – into its constituent realname and email address parts.
-    Returns a tuple of that information, unless the parse fails, 
+    Returns a tuple of that information, unless the parse fails,
     in which case a 2-tuple of ('', '') is returned.
     """
     addrs = _AddressList(addr).addresslist

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -218,8 +218,8 @@ def parseaddr(addr):
     """
     Parse addr into its constituent realname and email address parts.
     
-    Return a tuple of realname and email address, unless the parse fails, in which
-    case return a 2-tuple of ('', '').
+    Return a tuple of realname and email address, unless the parse fails, in
+    which case return a 2-tuple of ('', '').
     """
     addrs = _AddressList(addr).addresslist
     if not addrs:

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -218,8 +218,8 @@ def parseaddr(addr):
     """
     Parse addr into its constituent realname and email address parts.
     
-    Return a tuple of realname and email address, unless the parse fails, in
-    which case return a 2-tuple of ('', '').
+    Return a tuple of realname and email address, unless the parse fails,
+    in which case return a 2-tuple of ('', '').
     """
     addrs = _AddressList(addr).addresslist
     if not addrs:

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -218,8 +218,8 @@ def parseaddr(addr):
     """
     Parse addr into its constituent realname and email address parts.
     
-    Return a tuple of realname and email address, unless the parse fails,
-    in which case return a 2-tuple of ('', '').
+    Return a tuple of realname and email address, unless the parse fails, in
+    which case return a 2-tuple of ('', '').
     """
     addrs = _AddressList(addr).addresslist
     if not addrs:

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -216,12 +216,10 @@ def parsedate_to_datetime(data):
 
 def parseaddr(addr):
     """
-    Parse address into its constituent 
-    realname and email address parts
+    Parse addr into its constituent realname and email address parts.
     
-    Returns a tuple of realname and email address,
-    unless the parse fails,
-    in which case a 2-tuple of ('', '') is returned.
+    Return a tuple of realname and email address, unless the parse fails, in which
+    case return a 2-tuple of ('', '')
     """
     addrs = _AddressList(addr).addresslist
     if not addrs:

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -216,8 +216,12 @@ def parsedate_to_datetime(data):
 
 def parseaddr(addr):
     """
-    Parse address – which should be the value of some address-containing field such as To or Cc – into its constituent realname and email address parts.
-    Returns a tuple of that information, unless the parse fails, in which case a 2-tuple of ('', '') is returned.
+    Parse address into its constituent 
+    realname and email address parts
+    
+    Returns a tuple of realname and email address,
+    unless the parse fails,
+    in which case a 2-tuple of ('', '') is returned.
     """
     addrs = _AddressList(addr).addresslist
     if not addrs:

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -219,7 +219,7 @@ def parseaddr(addr):
     Parse addr into its constituent realname and email address parts.
     
     Return a tuple of realname and email address, unless the parse fails, in which
-    case return a 2-tuple of ('', '')
+    case return a 2-tuple of ('', '').
     """
     addrs = _AddressList(addr).addresslist
     if not addrs:

--- a/Misc/NEWS.d/next/IDLE/2017-09-18.bpo-31507.dgs67n.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-18.bpo-31507.dgs67n.rst
@@ -1,0 +1,1 @@
+Adds docstring to email.utils.parseaddr

--- a/Misc/NEWS.d/next/IDLE/2017-09-18.bpo-31507.dgs67n.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-18.bpo-31507.dgs67n.rst
@@ -1,1 +1,0 @@
-Adds docstring to email.utils.parseaddr


### PR DESCRIPTION
Adds docstring to email.utils.parseaddr

Closes Issue31507 (hopefully) from python bug tracker


I'm new to this so please forgive me if I make mistakes

<!-- issue-number: bpo-31507 -->
https://bugs.python.org/issue31507
<!-- /issue-number -->
