### PR TITLE
bpo-31506: Improve the error message logic for object.__new__ and object.__init__.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-19-10-29-36.bpo-31506.pRVTRB.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-19-10-29-36.bpo-31506.pRVTRB.rst
@@ -1,0 +1,1 @@
+Improved the error message logic for object.__new__ and object.__init__.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3543,23 +3543,34 @@ excess_args(PyObject *args, PyObject *kwds)
 static int
 object_init(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    int err = 0;
     PyTypeObject *type = Py_TYPE(self);
-    if (excess_args(args, kwds) &&
-        (type->tp_new == object_new || type->tp_init != object_init)) {
-        PyErr_SetString(PyExc_TypeError, "object.__init__() takes no parameters");
-        err = -1;
+    if (excess_args(args, kwds)) {
+        if (type->tp_init != object_init) {
+            PyErr_SetString(PyExc_TypeError, "object() takes no arguments");
+            return -1;
+        }
+        if (type->tp_new == object_new) {
+            PyErr_Format(PyExc_TypeError, "%.200s() takes no arguments",
+                         type->tp_name);
+            return -1;
+        }
     }
-    return err;
+    return 0;
 }
 
 static PyObject *
 object_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    if (excess_args(args, kwds) &&
-        (type->tp_init == object_init || type->tp_new != object_new)) {
-        PyErr_SetString(PyExc_TypeError, "object() takes no parameters");
-        return NULL;
+    if (excess_args(args, kwds)) {
+        if (type->tp_new != object_new) {
+            PyErr_SetString(PyExc_TypeError, "object() takes no arguments");
+            return NULL;
+        }
+        if (type->tp_init == object_init) {
+            PyErr_Format(PyExc_TypeError, "%.200s() takes no arguments",
+                         type->tp_name);
+            return NULL;
+        }
     }
 
     if (type->tp_flags & Py_TPFLAGS_IS_ABSTRACT) {


### PR DESCRIPTION


<!-- issue-number: bpo-31506 -->
https://bugs.python.org/issue31506
<!-- /issue-number -->
