### PR TITLE
bpo-31518: Change TLS protocol for Debian

### DIFF
--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -710,11 +710,11 @@ class TestTLS_FTPClass(TestCase):
             self.client.auth()
             self.assertRaises(ValueError, self.client.auth)
         finally:
-            self.client.ssl_version = ssl.PROTOCOL_TLSv1
+            self.client.ssl_version = ssl.PROTOCOL_TLS
 
     def test_context(self):
         self.client.quit()
-        ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
         self.assertRaises(ValueError, ftplib.FTP_TLS, keyfile=CERTFILE,
                           context=ctx)
         self.assertRaises(ValueError, ftplib.FTP_TLS, certfile=CERTFILE,
@@ -739,7 +739,7 @@ class TestTLS_FTPClass(TestCase):
 
     def test_check_hostname(self):
         self.client.quit()
-        ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
         ctx.verify_mode = ssl.CERT_REQUIRED
         ctx.check_hostname = True
         ctx.load_verify_locations(CAFILE)

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -860,7 +860,7 @@ class HTTPSTest(TestCase):
         import ssl
         test_support.requires('network')
         with test_support.transient_internet('self-signed.pythontest.net'):
-            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             context.verify_mode = ssl.CERT_REQUIRED
             context.load_verify_locations(CERT_selfsigned_pythontestdotnet)
             h = httplib.HTTPSConnection('self-signed.pythontest.net', 443, context=context)
@@ -874,7 +874,7 @@ class HTTPSTest(TestCase):
         import ssl
         test_support.requires('network')
         with test_support.transient_internet('self-signed.pythontest.net'):
-            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS)
             context.verify_mode = ssl.CERT_REQUIRED
             context.load_verify_locations(CERT_localhost)
             h = httplib.HTTPSConnection('self-signed.pythontest.net', 443, context=context)
@@ -895,7 +895,7 @@ class HTTPSTest(TestCase):
         # The (valid) cert validates the HTTP hostname
         import ssl
         server = self.make_server(CERT_localhost)
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.verify_mode = ssl.CERT_REQUIRED
         context.load_verify_locations(CERT_localhost)
         h = httplib.HTTPSConnection('localhost', server.port, context=context)
@@ -907,7 +907,7 @@ class HTTPSTest(TestCase):
         # The (valid) cert doesn't validate the HTTP hostname
         import ssl
         server = self.make_server(CERT_fakehostname)
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.verify_mode = ssl.CERT_REQUIRED
         context.check_hostname = True
         context.load_verify_locations(CERT_fakehostname)

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1774,7 +1774,7 @@ else:
             else:
                 self.context = ssl.SSLContext(ssl_version
                                               if ssl_version is not None
-                                              else ssl.PROTOCOL_TLSv1)
+                                              else ssl.PROTOCOL_TLS)
                 self.context.verify_mode = (certreqs if certreqs is not None
                                             else ssl.CERT_NONE)
                 if cacerts:

--- a/Lib/test/test_urllib2_localnet.py
+++ b/Lib/test/test_urllib2_localnet.py
@@ -577,7 +577,7 @@ class TestUrlopen(BaseTestCase):
         sni_name = [None]
         def cb_sni(ssl_sock, server_name, initial_context):
             sni_name[0] = server_name
-        context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS)
         context.set_servername_callback(cb_sni)
         handler = self.start_https_server(context=context, certfile=CERT_localhost)
         context = ssl.create_default_context(cafile=CERT_localhost)

--- a/Misc/NEWS.d/next/Tests/2017-09-19-20-48-50.bpo-31518.KwTMMz.rst
+++ b/Misc/NEWS.d/next/Tests/2017-09-19-20-48-50.bpo-31518.KwTMMz.rst
@@ -1,0 +1,3 @@
+Debian Unstable has disabled TLS 1.0 and 1.1 for SSLv23_METHOD(). Change
+TLS/SSL protocol of some tests to PROTOCOL_TLS or PROTOCOL_TLSv1_2 to make
+them pass on Debian.


### PR DESCRIPTION
Debian Unstable has disabled TLS 1.0 and 1.1 for SSLv23_METHOD(). Change
TLS/SSL protocol of some tests to PROTOCOL_TLS or PROTOCOL_TLSv1_2 to
make them pass on Debian.

Signed-off-by: Christian Heimes <christian@python.org>

NOTE: master has already been fixed in PR #3058. I decided against a backport because the PR #3058 touches too much code.

<!-- issue-number: bpo-31518 -->
https://bugs.python.org/issue31518
<!-- /issue-number -->
