### PR TITLE
bpo-31453: [WIP] Allow to change TLS protocols on Debian

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-09-19-21-06-23.bpo-31453.obElH-.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-19-21-06-23.bpo-31453.obElH-.rst
@@ -1,0 +1,4 @@
+Undo Debian Unstable's patching for SSL_CTX. Allow all protocols with
+SSL_CTX_set_min_proto_version() again so they can be enabled and disabled
+with SSL_CTX_set_options(). The set_min_proto_version is not supported by
+Python, set_options is available as SSLContext.options.


### PR DESCRIPTION
**DO NOT MERGE**

Undo Debian Unstable's patching for SSL_CTX. Allow all protocols with
SSL_CTX_set_min_proto_version() again so they can be enabled and disabled
with SSL_CTX_set_options(). The set_min_proto_version is not supported by
Python, set_options is available as SSLContext.options.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-31453 -->
https://bugs.python.org/issue31453
<!-- /issue-number -->
