### PR TITLE
bpo-31500: Removed fixed size of IDLE config dialog.

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -105,7 +105,7 @@ class ConfigDialog(Toplevel):
             load_configs: Load pages except for extensions.
             activate_config_changes: Tell editors to reload.
         """
-        self.note = note = Notebook(self, width=450, height=450)
+        self.note = note = Notebook(self)
         self.highpage = HighPage(note)
         self.fontpage = FontPage(note, self.highpage)
         self.keyspage = KeysPage(note)


### PR DESCRIPTION
This one line of Serhiy Storchacka's patch is needed for other issues.


<!-- issue-number: bpo-31500 -->
https://bugs.python.org/issue31500
<!-- /issue-number -->
