### PR TITLE
bpo-27319, bpo-31508: Document deprecation in Treeview.selection().

### DIFF
--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -1109,7 +1109,7 @@ ttk.Treeview
       *items* becomes the new selection.
 
       .. versionchanged:: 3.6
-         *items* can be passeed as separate arguments, not just as a single tuple.
+         *items* can be passed as separate arguments, not just as a single tuple.
 
 
    .. method:: selection_add(*items)
@@ -1117,7 +1117,7 @@ ttk.Treeview
       Add *items* to the selection.
 
       .. versionchanged:: 3.6
-         *items* can be passeed as separate arguments, not just as a single tuple.
+         *items* can be passed as separate arguments, not just as a single tuple.
 
 
    .. method:: selection_remove(*items)
@@ -1125,7 +1125,7 @@ ttk.Treeview
       Remove *items* from the selection.
 
       .. versionchanged:: 3.6
-         *items* can be passeed as separate arguments, not just as a single tuple.
+         *items* can be passed as separate arguments, not just as a single tuple.
 
 
    .. method:: selection_toggle(*items)
@@ -1133,7 +1133,7 @@ ttk.Treeview
       Toggle the selection state of each item in *items*.
 
       .. versionchanged:: 3.6
-         *items* can be passeed as separate arguments, not just as a single tuple.
+         *items* can be passed as separate arguments, not just as a single tuple.
 
 
    .. method:: set(item, column=None, value=None)

--- a/Doc/library/tkinter.ttk.rst
+++ b/Doc/library/tkinter.ttk.rst
@@ -1099,25 +1099,41 @@ ttk.Treeview
       If *selop* is not specified, returns selected items. Otherwise, it will
       act according to the following selection methods.
 
+      .. deprecated-removed:: 3.6 3.8
+         Using ``selection()`` for changing the selection state is deprecated.
+         Use the following selection methods instead.
 
-   .. method:: selection_set(items)
+
+   .. method:: selection_set(*items)
 
       *items* becomes the new selection.
 
+      .. versionchanged:: 3.6
+         *items* can be passeed as separate arguments, not just as a single tuple.
 
-   .. method:: selection_add(items)
+
+   .. method:: selection_add(*items)
 
       Add *items* to the selection.
 
+      .. versionchanged:: 3.6
+         *items* can be passeed as separate arguments, not just as a single tuple.
 
-   .. method:: selection_remove(items)
+
+   .. method:: selection_remove(*items)
 
       Remove *items* from the selection.
 
+      .. versionchanged:: 3.6
+         *items* can be passeed as separate arguments, not just as a single tuple.
 
-   .. method:: selection_toggle(items)
+
+   .. method:: selection_toggle(*items)
 
       Toggle the selection state of each item in *items*.
+
+      .. versionchanged:: 3.6
+         *items* can be passeed as separate arguments, not just as a single tuple.
 
 
    .. method:: set(item, column=None, value=None)

--- a/Lib/tkinter/test/test_ttk/test_widgets.py
+++ b/Lib/tkinter/test/test_ttk/test_widgets.py
@@ -1556,7 +1556,7 @@ class TreeviewTest(AbstractWidgetTest, unittest.TestCase):
         self.tv.selection_toggle((c1, c3))
         self.assertEqual(self.tv.selection(), (c3, item2))
 
-        if sys.version_info >= (3, 7):
+        if sys.version_info >= (3, 8):
             import warnings
             warnings.warn(
                 'Deprecated API of Treeview.selection() should be removed')

--- a/Lib/tkinter/ttk.py
+++ b/Lib/tkinter/ttk.py
@@ -1404,13 +1404,13 @@ class Treeview(Widget, tkinter.XView, tkinter.YView):
             import warnings
             warnings.warn(
                 "The selop=None argument of selection() is deprecated "
-                "and will be removed in Python 3.7",
+                "and will be removed in Python 3.8",
                 DeprecationWarning, 3)
         elif selop in ('set', 'add', 'remove', 'toggle'):
             import warnings
             warnings.warn(
                 "The selop argument of selection() is deprecated "
-                "and will be removed in Python 3.7, "
+                "and will be removed in Python 3.8, "
                 "use selection_%s() instead" % (selop,),
                 DeprecationWarning, 3)
         else:


### PR DESCRIPTION
Defer removing old behavior to 3.8.
Document new feature of selection_set() and friends.


<!-- issue-number: bpo-27319 -->
https://bugs.python.org/issue27319
<!-- /issue-number -->
