### PR TITLE
bpo-30486: Make cell_set_contents() symbol private

### DIFF
--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -142,7 +142,7 @@ cell_get_contents(PyCellObject *op, void *closure)
     return op->ob_ref;
 }
 
-int
+static int
 cell_set_contents(PyCellObject *op, PyObject *obj)
 {
     Py_XINCREF(obj);


### PR DESCRIPTION
Don't export the cell_set_contents() symbol in the C API.

<!-- issue-number: bpo-30486 -->
https://bugs.python.org/issue30486
<!-- /issue-number -->
