### PR TITLE
[2.7] bpo-31530: Stop crashes when iterating over a file on multiple threads.

### DIFF
--- a/Lib/test/test_file2k.py
+++ b/Lib/test/test_file2k.py
@@ -653,6 +653,7 @@ class FileThreadingTests(unittest.TestCase):
         self._test_close_open_io(io_func)
 
     def test_iteration_torture(self):
+        # bpo-31530: Crash when concurrently iterate over a file.
         with open(self.filename, "wb") as fp:
             for i in xrange(2**20):
                 fp.write(b"0"*50 + b"\n")
@@ -666,6 +667,7 @@ class FileThreadingTests(unittest.TestCase):
             self._run_workers(iterate, 10)
 
     def test_iteration_seek(self):
+        # bpo-31530: Crash when concurrently seek and iterate over a file.
         with open(self.filename, "wb") as fp:
             for i in xrange(10000):
                 fp.write(b"0"*50 + b"\n")

--- a/Lib/test/test_file2k.py
+++ b/Lib/test/test_file2k.py
@@ -652,6 +652,36 @@ class FileThreadingTests(unittest.TestCase):
             self.f.writelines('')
         self._test_close_open_io(io_func)
 
+    def test_iteration_torture(self):
+        with open(self.filename, "wb") as fp:
+            for i in xrange(2**20):
+                fp.write(b"0"*50 + b"\n")
+        with open(self.filename, "rb") as f:
+            def iterate():
+                try:
+                    for l in f:
+                        pass
+                except IOError:
+                    pass
+            self._run_workers(iterate, 10)
+
+    def test_iteration_seek(self):
+        with open(self.filename, "wb") as fp:
+            for i in xrange(10000):
+                fp.write(b"0"*50 + b"\n")
+        with open(self.filename, "rb") as f:
+            it = iter([1] + [0]*10)  # one thread reads, others seek
+            def iterate():
+                try:
+                    if next(it):
+                        for l in f:
+                            pass
+                    else:
+                        for i in range(100):
+                            f.seek(i*100, 0)
+                except IOError:
+                    pass
+            self._run_workers(iterate, 10)
 
 @unittest.skipUnless(os.name == 'posix', 'test requires a posix system.')
 class TestFileSignalEINTR(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-20-18-28-09.bpo-31530.CdLOM7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-20-18-28-09.bpo-31530.CdLOM7.rst
@@ -1,0 +1,1 @@
+Fixed crashes when iterating over a file on multiple threads.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-20-18-28-09.bpo-31530.CdLOM7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-20-18-28-09.bpo-31530.CdLOM7.rst
@@ -1,1 +1,4 @@
 Fixed crashes when iterating over a file on multiple threads.
+seek() and next() methods of file objects now raise an exception during
+concurrent operation on the same file object.
+A lock can be used to prevent the error.

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -430,7 +430,7 @@ close_the_file(PyFileObject *f)
             if (Py_REFCNT(f) > 0) {
                 PyErr_SetString(PyExc_IOError,
                     "close() called during concurrent "
-                    "operation on the same file object.");
+                    "operation on the same file object");
             } else {
                 /* This should not happen unless someone is
                  * carelessly playing with the PyFileObject
@@ -438,7 +438,7 @@ close_the_file(PyFileObject *f)
                  * pointer. */
                 PyErr_SetString(PyExc_SystemError,
                     "PyFileObject locking error in "
-                    "destructor (refcnt <= 0 at close).");
+                    "destructor (refcnt <= 0 at close)");
             }
             return NULL;
         }
@@ -765,7 +765,7 @@ file_seek(PyFileObject *f, PyObject *args)
     if (f->unlocked_count > 0) {
         PyErr_SetString(PyExc_IOError,
             "seek() called during concurrent "
-            "operation on the same file object.");
+            "operation on the same file object");
         return NULL;
     }
     drop_readahead(f);
@@ -2338,7 +2338,7 @@ file_iternext(PyFileObject *f)
     if (f->unlocked_count > 0) {
         PyErr_SetString(PyExc_IOError,
             "next() called during concurrent "
-            "operation on the same file object.");
+            "operation on the same file object");
         return NULL;
     }
     l = readahead_get_line_skip(f, 0, READAHEAD_BUFSIZE);
@@ -2705,7 +2705,7 @@ int PyObject_AsFileDescriptor(PyObject *o)
     }
     else {
         PyErr_SetString(PyExc_TypeError,
-                        "argument must be an int, or have a fileno() method.");
+                        "argument must be an int, or have a fileno() method");
         return -1;
     }
 


### PR DESCRIPTION


<!-- issue-number: bpo-31530 -->
https://bugs.python.org/issue31530
<!-- /issue-number -->
