### PR TITLE
bpo-31516: current_thread() should not return a dummy thread at shutdown

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -554,7 +554,7 @@ class ThreadTests(BaseTestCase):
             import gc, threading
 
             main_thread = threading.current_thread()
-            assert main_thread is threading.main_thread()
+            assert main_thread is threading.main_thread()  # sanity check
 
             class RefCycle:
                 def __init__(self):
@@ -567,7 +567,7 @@ class ThreadTests(BaseTestCase):
                           threading.enumerate() == [main_thread])
 
             RefCycle()
-            gc.collect()
+            gc.collect()  # sanity check
             x = RefCycle()
         """
         _, out, err = assert_python_ok("-c", code)

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -547,6 +547,35 @@ class ThreadTests(BaseTestCase):
         self.assertEqual(err, b"")
         self.assertEqual(data, "Thread-1\nTrue\nTrue\n")
 
+    def test_main_thread_during_shutdown(self):
+        # bpo-31516: current_thread() should still point to the main thread
+        # at shutdown
+        code = """if 1:
+            import gc, threading
+
+            main_thread = threading.current_thread()
+            assert main_thread is threading.main_thread()
+
+            class RefCycle:
+                def __init__(self):
+                    self.cycle = self
+
+                def __del__(self):
+                    print("GC:",
+                          threading.current_thread() is main_thread,
+                          threading.main_thread() is main_thread,
+                          threading.enumerate() == [main_thread])
+
+            RefCycle()
+            gc.collect()
+            x = RefCycle()
+        """
+        _, out, err = assert_python_ok("-c", code)
+        data = out.decode()
+        self.assertEqual(err, b"")
+        self.assertEqual(data.splitlines(),
+                         ["GC: True True True"] * 2)
+
     def test_tstate_lock(self):
         # Test an implementation detail of Thread objects.
         started = _thread.allocate_lock()

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1158,8 +1158,8 @@ class Timer(Thread):
             self.function(*self.args, **self.kwargs)
         self.finished.set()
 
+
 # Special thread class to represent the main thread
-# This is garbage collected through an exit handler
 
 class _MainThread(Thread):
 
@@ -1272,7 +1272,6 @@ def _shutdown():
     while t:
         t.join()
         t = _pickSomeNonDaemonThread()
-    _main_thread._delete()
 
 def _pickSomeNonDaemonThread():
     for t in enumerate():

--- a/Misc/NEWS.d/next/Library/2017-09-20-18-43-01.bpo-31516.23Yuq3.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-20-18-43-01.bpo-31516.23Yuq3.rst
@@ -1,0 +1,1 @@
+``threading.current_thread()`` should not return a dummy thread at shutdown.


### PR DESCRIPTION



<!-- issue-number: bpo-31516 -->
https://bugs.python.org/issue31516
<!-- /issue-number -->
