### PR TITLE
bpo-31536: Avoid wholesale rebuild after `make regen-opcode`

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-09-20-20-38-28.bpo-31536.4UPttT.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-20-20-38-28.bpo-31536.4UPttT.rst
@@ -1,0 +1,1 @@
+Avoid wholesale rebuild after `make regen-opcode` if nothing changed.


### PR DESCRIPTION
After looking at other `regen` steps, I don't think this approach is the best one (see issue discussion).

<!-- issue-number: bpo-31536 -->
https://bugs.python.org/issue31536
<!-- /issue-number -->
