### PR TITLE
bpo-31532: Fix memory corruption due to allocator mix

### DIFF
--- a/Misc/NEWS.d/next/C API/2017-09-20-21-59-52.bpo-31532.s9Cw9_.rst
+++ b/Misc/NEWS.d/next/C API/2017-09-20-21-59-52.bpo-31532.s9Cw9_.rst
@@ -1,0 +1,2 @@
+Fix memory corruption due to allocator mix in getpath.c between Py_GetPath()
+and Py_SetPath()

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -735,7 +735,7 @@ calculate_path(void)
     bufsz += wcslen(zip_path) + 1;
     bufsz += wcslen(exec_prefix) + 1;
 
-    buf = PyMem_New(wchar_t, bufsz);
+    buf = PyMem_RawMalloc(bufsz * sizeof(wchar_t));
     if (buf == NULL) {
         Py_FatalError(
             "Not enough memory for dynamic PYTHONPATH");


### PR DESCRIPTION
Fix a memory corruption in getpath.c due to mixed memory allocators
between Py_GetPath() and Py_SetPath().

The fix use the Raw allocator to mimic the windows version.

This patch should be used from python3.6 to the current version

for more details, see the bug report and
  https://github.com/pyinstaller/pyinstaller/issues/2812


<!-- issue-number: bpo-31532 -->
https://bugs.python.org/issue31532
<!-- /issue-number -->
