### PR TITLE
bpo-29298: Fix crash with required subparsers without dest

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -727,6 +727,8 @@ def _get_action_name(argument):
         return argument.metavar
     elif argument.dest not in (None, SUPPRESS):
         return argument.dest
+    elif argument.choices:
+        return '{' + ','.join(argument.choices) + '}'
     else:
         return None
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2064,7 +2064,23 @@ class TestAddSubparsers(TestCase):
         parser = ErrorRaisingArgumentParser()
         subparsers = parser.add_subparsers()
         subparsers.add_parser('run')
-        self.assertArgumentParserError(parser.parse_args, ())
+        with self.assertRaises(ArgumentParserError) as excinfo:
+            parser.parse_args(())
+        self.assertRegex(
+            excinfo.exception.stderr,
+            'error: the following arguments are required: {run}\n$'
+        )
+
+    def test_wrong_argument_subparsers_no_destination_error(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers()
+        subparsers.add_parser('foo')
+        with self.assertRaises(ArgumentParserError) as excinfo:
+            parser.parse_args(('bar',))
+        self.assertRegex(
+            excinfo.exception.stderr,
+            r"error: argument {foo}: invalid choice: 'bar' \(choose from 'foo'\)\n$"
+        )
 
     def test_optional_subparsers(self):
         parser = ErrorRaisingArgumentParser()

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2062,7 +2062,7 @@ class TestAddSubparsers(TestCase):
 
     def test_required_subparsers_no_destination_error(self):
         parser = ErrorRaisingArgumentParser()
-        subparsers = parser.add_subparsers()
+        subparsers = parser.add_subparsers(required=True)
         subparsers.add_parser('foo')
         subparsers.add_parser('bar')
         with self.assertRaises(ArgumentParserError) as excinfo:
@@ -2074,7 +2074,7 @@ class TestAddSubparsers(TestCase):
 
     def test_wrong_argument_subparsers_no_destination_error(self):
         parser = ErrorRaisingArgumentParser()
-        subparsers = parser.add_subparsers()
+        subparsers = parser.add_subparsers(required=True)
         subparsers.add_parser('foo')
         subparsers.add_parser('bar')
         with self.assertRaises(ArgumentParserError) as excinfo:

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2063,23 +2063,25 @@ class TestAddSubparsers(TestCase):
     def test_required_subparsers_no_destination_error(self):
         parser = ErrorRaisingArgumentParser()
         subparsers = parser.add_subparsers()
-        subparsers.add_parser('run')
+        subparsers.add_parser('foo')
+        subparsers.add_parser('bar')
         with self.assertRaises(ArgumentParserError) as excinfo:
             parser.parse_args(())
         self.assertRegex(
             excinfo.exception.stderr,
-            'error: the following arguments are required: {run}\n$'
+            'error: the following arguments are required: {foo,bar}\n$'
         )
 
     def test_wrong_argument_subparsers_no_destination_error(self):
         parser = ErrorRaisingArgumentParser()
         subparsers = parser.add_subparsers()
         subparsers.add_parser('foo')
+        subparsers.add_parser('bar')
         with self.assertRaises(ArgumentParserError) as excinfo:
-            parser.parse_args(('bar',))
+            parser.parse_args(('baz',))
         self.assertRegex(
             excinfo.exception.stderr,
-            r"error: argument {foo}: invalid choice: 'bar' \(choose from 'foo'\)\n$"
+            r"error: argument {foo,bar}: invalid choice: 'baz' \(choose from 'foo', 'bar'\)\n$"
         )
 
     def test_optional_subparsers(self):

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2060,6 +2060,12 @@ class TestAddSubparsers(TestCase):
         ret = parser.parse_args(())
         self.assertIsNone(ret.command)
 
+    def test_required_subparsers_no_destination_error(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers()
+        subparsers.add_parser('run')
+        self.assertArgumentParserError(parser.parse_args, ())
+
     def test_optional_subparsers(self):
         parser = ErrorRaisingArgumentParser()
         subparsers = parser.add_subparsers(dest='command', required=False)

--- a/Misc/NEWS.d/next/Library/2017-09-20-14-43-03.bpo-29298._78CSN.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-20-14-43-03.bpo-29298._78CSN.rst
@@ -1,0 +1,2 @@
+Fix ``TypeError`` when required subparsers without ``dest`` do not receive
+arguments. Patch by Anthony Sottile.


### PR DESCRIPTION



<!-- issue-number: [bpo-29298](https://bugs.python.org/issue29298) -->
https://bugs.python.org/issue29298
<!-- /issue-number -->

Automerge-Triggered-By: GH:encukou