### PR TITLE
[WIP] bpo-31543: Optimize wrapper descriptors

### DIFF
--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -180,6 +180,15 @@ PyAPI_FUNC(PyObject *) _PyStack_AsDict(
     PyObject **values,
     PyObject *kwnames);
 
+/* Combine _PyStack_AsTuple() with _PyStack_AsDict().
+   Return 0 on success, or -1 on error. */
+PyAPI_FUNC(int) _PyStack_AsTupleAndDict(
+    PyObject **args,
+    Py_ssize_t nargs,
+    PyObject *kwnames,
+    PyObject **tuple,
+    PyObject **dict);
+
 /* Convert (args, nargs, kwargs: dict) into a (stack, nargs, kwnames: tuple).
 
    Return 0 on success, raise an exception and return -1 on error.

--- a/Include/descrobject.h
+++ b/Include/descrobject.h
@@ -23,6 +23,9 @@ typedef PyObject *(*wrapperfunc)(PyObject *self, PyObject *args,
 typedef PyObject *(*wrapperfunc_kwds)(PyObject *self, PyObject *args,
                                       void *wrapped, PyObject *kwds);
 
+typedef PyObject *(*wrapperfastfunc)(PyObject *self, PyObject **args,
+                                     Py_ssize_t nargs, void *wrapped);
+
 struct wrapperbase {
     const char *name;
     int offset;
@@ -31,6 +34,7 @@ struct wrapperbase {
     const char *doc;
     int flags;
     PyObject *name_strobj;
+    wrapperfastfunc fastwrapper;
 };
 
 /* Flags for above struct */

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5307,6 +5307,19 @@ check_num_args(PyObject *ob, int n)
     return 0;
 }
 
+static int
+check_fast_num_args(Py_ssize_t nargs, Py_ssize_t n)
+{
+    if (n == nargs) {
+        return 1;
+    }
+
+    PyErr_Format(
+        PyExc_TypeError,
+        "expected %d arguments, got %zd", n, nargs);
+    return 0;
+}
+
 /* Generic wrappers for overloadable 'operators' such as __getitem__ */
 
 /* There's a wrapper *function* for each distinct function typedef used
@@ -5326,6 +5339,23 @@ wrap_lenfunc(PyObject *self, PyObject *args, void *wrapped)
     res = (*func)(self);
     if (res == -1 && PyErr_Occurred())
         return NULL;
+    return PyLong_FromLong((long)res);
+}
+
+static PyObject *
+fastwrap_lenfunc(PyObject *self, PyObject **args, Py_ssize_t nargs,
+                 void *wrapped)
+{
+    lenfunc func = (lenfunc)wrapped;
+    Py_ssize_t res;
+
+    if (!check_fast_num_args(nargs, 0)) {
+        return NULL;
+    }
+    res = (*func)(self);
+    if (res == -1 && PyErr_Occurred()) {
+        return NULL;
+    }
     return PyLong_FromLong((long)res);
 }
 
@@ -5356,6 +5386,18 @@ wrap_binaryfunc(PyObject *self, PyObject *args, void *wrapped)
 }
 
 static PyObject *
+fastwrap_binaryfunc(PyObject *self, PyObject **args, Py_ssize_t nargs,
+                    void *wrapped)
+{
+    binaryfunc func = (binaryfunc)wrapped;
+
+    if (!check_fast_num_args(nargs, 1)) {
+        return NULL;
+    }
+    return (*func)(self, args[0]);
+}
+
+static PyObject *
 wrap_binaryfunc_l(PyObject *self, PyObject *args, void *wrapped)
 {
     binaryfunc func = (binaryfunc)wrapped;
@@ -5368,6 +5410,18 @@ wrap_binaryfunc_l(PyObject *self, PyObject *args, void *wrapped)
 }
 
 static PyObject *
+fastwrap_binaryfunc_l(PyObject *self, PyObject **args, Py_ssize_t nargs,
+                      void *wrapped)
+{
+    binaryfunc func = (binaryfunc)wrapped;
+
+    if (!check_fast_num_args(nargs, 1)) {
+        return NULL;
+    }
+    return (*func)(self, args[0]);
+}
+
+static PyObject *
 wrap_binaryfunc_r(PyObject *self, PyObject *args, void *wrapped)
 {
     binaryfunc func = (binaryfunc)wrapped;
@@ -5377,6 +5431,18 @@ wrap_binaryfunc_r(PyObject *self, PyObject *args, void *wrapped)
         return NULL;
     other = PyTuple_GET_ITEM(args, 0);
     return (*func)(other, self);
+}
+
+static PyObject *
+fastwrap_binaryfunc_r(PyObject *self, PyObject **args, Py_ssize_t nargs,
+                      void *wrapped)
+{
+    binaryfunc func = (binaryfunc)wrapped;
+
+    if (!check_fast_num_args(nargs, 1)) {
+        return NULL;
+    }
+    return (*func)(args[0], self);
 }
 
 static PyObject *
@@ -5414,6 +5480,18 @@ wrap_unaryfunc(PyObject *self, PyObject *args, void *wrapped)
 
     if (!check_num_args(args, 0))
         return NULL;
+    return (*func)(self);
+}
+
+static PyObject *
+fastwrap_unaryfunc(PyObject *self, PyObject **args, Py_ssize_t nargs,
+                   void *wrapped)
+{
+    unaryfunc func = (unaryfunc)wrapped;
+
+    if (!check_fast_num_args(nargs, 0)) {
+        return NULL;
+    }
     return (*func)(self);
 }
 
@@ -5644,6 +5722,18 @@ wrap_del(PyObject *self, PyObject *args, void *wrapped)
     destructor func = (destructor)wrapped;
 
     if (!check_num_args(args, 0))
+        return NULL;
+
+    (*func)(self);
+    Py_RETURN_NONE;
+}
+
+static PyObject *
+fastwrap_del(PyObject *self, PyObject **args, Py_ssize_t nargs, void *wrapped)
+{
+    destructor func = (destructor)wrapped;
+
+    if (!check_fast_num_args(nargs, 0))
         return NULL;
 
     (*func)(self);
@@ -7066,6 +7156,25 @@ init_slotdefs(void)
         p->name_strobj = PyUnicode_InternFromString(p->name);
         if (!p->name_strobj || !PyUnicode_CHECK_INTERNED(p->name_strobj))
             Py_FatalError("Out of memory interning slotdef names");
+        /* FIXME: update directly slotdefs. It's just that I was too lazy :-) */
+        if (p->wrapper == wrap_unaryfunc) {
+            p->fastwrapper = fastwrap_unaryfunc;
+        }
+        else if (p->wrapper == wrap_binaryfunc) {
+            p->fastwrapper = fastwrap_binaryfunc;
+        }
+        else if (p->wrapper == wrap_binaryfunc_l) {
+            p->fastwrapper = fastwrap_binaryfunc_l;
+        }
+        else if (p->wrapper == wrap_binaryfunc_r) {
+            p->fastwrapper = fastwrap_binaryfunc_r;
+        }
+        else if (p->wrapper == wrap_lenfunc) {
+            p->fastwrapper = fastwrap_lenfunc;
+        }
+        else if (p->wrapper == wrap_del) {
+            p->fastwrapper = fastwrap_del;
+        }
     }
     slotdefs_initialized = 1;
 }


### PR DESCRIPTION
Wrapper descriptors can now opt-in for the FASTCALL calling
convention.

Changes:

* wrapperbase structure: add fastwrapper member
* Add _PyWrapperDesr_FastCallKeywords() and
  _PyWrapperDesr_FastCallDict() which prevent the creation of a
  temporary tuple for positional arguments and dict for keyword
  arguments, when the wrapper supports the FASTCALL calling
  convention.
* Specialize some but not all wrappers in typeobject.c
* Add _PyStack_AsTupleAndDict() help

<!-- issue-number: bpo-31543 -->
https://bugs.python.org/issue31543
<!-- /issue-number -->
