### PR TITLE
[3.6] bpo-31500: IDLE: Scale default fonts on HiDPI displays. (GH-3639)

### DIFF
--- a/Lib/idlelib/filelist.py
+++ b/Lib/idlelib/filelist.py
@@ -113,8 +113,10 @@ class FileList:
 
 def _test():
     from idlelib.editor import fixwordbreaks
+    from idlelib.run import fix_scaling
     import sys
     root = Tk()
+    fix_scaling(root)
     fixwordbreaks(root)
     root.withdraw()
     flist = FileList(root)

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -12,6 +12,8 @@ import tkinter.messagebox as tkMessageBox
 if TkVersion < 8.5:
     root = Tk()  # otherwise create root in main
     root.withdraw()
+    from idlelib.run import fix_scaling
+    fix_scaling(root)
     tkMessageBox.showerror("Idle Cannot Start",
             "Idle requires tcl/tk 8.5+, not %s." % TkVersion,
             parent=root)
@@ -1457,6 +1459,8 @@ def main():
         NoDefaultRoot()
     root = Tk(className="Idle")
     root.withdraw()
+    from idlelib.run import fix_scaling
+    fix_scaling(root)
 
     # set application icon
     icondir = os.path.join(os.path.dirname(__file__), 'Icons')

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -184,6 +184,7 @@ def show_socket_error(err, address):
     import tkinter
     from tkinter.messagebox import showerror
     root = tkinter.Tk()
+    fix_scaling(root)
     root.withdraw()
     msg = f"IDLE's subprocess can't connect to {address[0]}:{address[1]}.\n"\
           f"Fatal OSError #{err.errno}: {err.strerror}.\n"\
@@ -275,6 +276,18 @@ def exit():
         atexit._clear()
     capture_warnings(False)
     sys.exit(0)
+
+
+def fix_scaling(root):
+    """Scale fonts on HiDPI displays."""
+    import tkinter.font
+    scaling = float(root.tk.call('tk', 'scaling'))
+    if scaling > 1.4:
+        for name in tkinter.font.names(root):
+            font = tkinter.font.Font(root=root, name=name, exists=True)
+            size = int(font['size'])
+            if size < 0:
+                font['size'] = round(-0.75*size)
 
 
 class MyRPCServer(rpc.RPCServer):

--- a/Misc/NEWS.d/next/IDLE/2017-09-18-10-43-03.bpo-31500.Y_YDxA.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-18-10-43-03.bpo-31500.Y_YDxA.rst
@@ -1,0 +1,1 @@
+Default fonts now are scaled on HiDPI displays.


### PR DESCRIPTION
(cherry picked from commit a96c96f)


<!-- issue-number: bpo-31500 -->
https://bugs.python.org/issue31500
<!-- /issue-number -->
