### PR TITLE
bpo-31423: Fix building the PDF documentation

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -95,8 +95,8 @@ latex_elements = {'inputenc': r'\usepackage[utf8x]{inputenc}', 'utf8extra': ''}
 # Additional stuff for the LaTeX preamble.
 latex_elements['preamble'] = r'''
 \authoraddress{
-  \strong{Python Software Foundation}\\
-  Email: \email{docs@python.org}
+  \sphinxstrong{Python Software Foundation}\\
+  Email: \sphinxemail{docs@python.org}
 }
 \let\Verbatim=\OriginalVerbatim
 \let\endVerbatim=\endOriginalVerbatim

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -90,7 +90,11 @@ html_split_index = True
 # ------------------------
 
 # Get LaTeX to handle Unicode correctly
-latex_elements = {'inputenc': r'\usepackage[utf8x]{inputenc}', 'utf8extra': ''}
+latex_elements = {
+    'inputenc': r'\usepackage[utf8x]{inputenc}',
+    'utf8extra': '',
+    'fontenc': r'\usepackage[T1,T2A]{fontenc}',
+}
 
 # Additional stuff for the LaTeX preamble.
 latex_elements['preamble'] = r'''

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -110,7 +110,7 @@ latex_elements['preamble'] = r'''
 latex_elements['papersize'] = 'a4'
 
 # The font size ('10pt', '11pt' or '12pt').
-latex_elements['font_size'] = '10pt'
+latex_elements['pointsize'] = '10pt'
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).


### PR DESCRIPTION
Use prefixed macro names for the `authoraddress` function, support Cyrillic characters and remove warnings when generating the PDF doc.
The LaTeX package for Cyrillic encodings is available thanks to `texlive-lang-cyrillic` (in `texlive-lang-all`).

<!-- issue-number: bpo-31423 -->
https://bugs.python.org/issue31423
<!-- /issue-number -->
