### PR TITLE
bpo-31564: NewType can subclass NewType

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -111,8 +111,7 @@ More precisely, the expression ``some_value is Derived(some_value)`` is always
 true at runtime.
 
 This also means that it is not possible to create a subtype of ``Derived``
-since it is an identity function at runtime, not an actual type. Similarly, it
-is not possible to create another :func:`NewType` based on a ``Derived`` type::
+since it is an identity function at runtime, not an actual type::
 
    from typing import NewType
 
@@ -121,8 +120,15 @@ is not possible to create another :func:`NewType` based on a ``Derived`` type::
    # Fails at runtime and does not typecheck
    class AdminUserId(UserId): pass
 
-   # Also does not typecheck
+However, it is possible to create a :func:`NewType` based on a 'derived' ``NewType``::
+
+   from typing import NewType
+
+   UserId = NewType('UserId', int)
+
    ProUserId = NewType('ProUserId', UserId)
+
+and typechecking for ``ProUserId`` will work as expected.
 
 See :pep:`484` for more details.
 


### PR DESCRIPTION
It has become possible to create a ``NewType`` from an existing  ``NewType``, see https://github.com/python/mypy/pull/3465 and https://github.com/python/peps/pull/271.

This is a small update to the documentation as a concequence of the above change.

I've logged this as an issue at #bpo-31564 as per @Mariatta request.

<!-- issue-number: bpo-31564 -->
https://bugs.python.org/issue31564
<!-- /issue-number -->
