### PR TITLE
[3.6] bpo-31423: Fix building the PDF documentation (GH-3693)

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -89,13 +89,17 @@ html_split_index = True
 # ------------------------
 
 # Get LaTeX to handle Unicode correctly
-latex_elements = {'inputenc': r'\usepackage[utf8x]{inputenc}', 'utf8extra': ''}
+latex_elements = {
+    'inputenc': r'\usepackage[utf8x]{inputenc}',
+    'utf8extra': '',
+    'fontenc': r'\usepackage[T1,T2A]{fontenc}',
+}
 
 # Additional stuff for the LaTeX preamble.
 latex_elements['preamble'] = r'''
 \authoraddress{
-  \strong{Python Software Foundation}\\
-  Email: \email{docs@python.org}
+  \sphinxstrong{Python Software Foundation}\\
+  Email: \sphinxemail{docs@python.org}
 }
 \let\Verbatim=\OriginalVerbatim
 \let\endVerbatim=\endOriginalVerbatim
@@ -105,7 +109,7 @@ latex_elements['preamble'] = r'''
 latex_elements['papersize'] = 'a4'
 
 # The font size ('10pt', '11pt' or '12pt').
-latex_elements['font_size'] = '10pt'
+latex_elements['pointsize'] = '10pt'
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, document class [howto/manual]).


### PR DESCRIPTION
Use prefixed macro names for the `authoraddress` function, add T2A to the font encoding in LaTeX sources to support Cyrillic characters in the PDF documentation, and replace the deprecated `font_size` config option with `pointsize`.
(cherry picked from commit da9b4cfb488119f2493a762fcb1d85c58494f51d)

<!-- issue-number: bpo-31423 -->
https://bugs.python.org/issue31423
<!-- /issue-number -->
