### PR TITLE
gh-66136: IDLE: Fix use of unsaved indicator in titlebar of shell window

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -921,8 +921,8 @@ class EditorWindow(object):
     def set_saved(self, flag):
         self.undo.set_saved(flag)
 
-    def reset_undo(self):
-        self.undo.reset_undo()
+    def reset_undo(self, set_saved_flag=True):
+        self.undo.reset_undo(set_saved_flag)
 
     def short_title(self):
         filename = self.io.filename

--- a/Lib/idlelib/idle_test/test_undo.py
+++ b/Lib/idlelib/idle_test/test_undo.py
@@ -87,6 +87,38 @@ class UndoDelegatorTest(unittest.TestCase):
         text.event_generate('<<undo>>')
         self.assertTupleEqual((d.pointer, d.can_merge), (2, False))
 
+    def test_reset_undo(self):
+        eq = self.assertEqual
+        d = self.delegator
+        orig_sch = d.saved_change_hook
+        d.saved_change_hook = Mock()
+
+        def set_text():
+            self.text.insert('insert', 'spam')
+            self.text.insert('insert', '\n')
+            self.text.insert('insert', 'this is the second line')
+
+        set_text()
+        eq(d.pointer, len(d.undolist))
+        self.assertNotEqual(d.pointer, d.saved)
+
+        # Default to set_saved_flag to True.
+        d.reset_undo()
+        eq(d.pointer, 0)
+        eq(d.undolist, [])
+        eq(d.undoblock, 0)
+        eq(d.saved, d.pointer)
+
+        # Don't mark as saved upon reset.
+        set_text()
+        d.reset_undo(False)
+        eq(d.pointer, 0)
+        eq(d.undolist, [])
+        eq(d.undoblock, 0)
+        eq(d.saved, -1)
+
+        d.saved_change_hook = orig_sch
+
     def test_get_set_saved(self):
         # test the getter method get_saved
         # test the setter method set_saved

--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -144,8 +144,8 @@ class IOBinding:
     def set_saved(self, flag):
         self.editwin.set_saved(flag)
 
-    def reset_undo(self):
-        self.editwin.reset_undo()
+    def reset_undo(self, set_saved_flag=True):
+        self.editwin.reset_undo(set_saved_flag)
 
     filename_change_hook = None
 

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -1247,6 +1247,18 @@ class PyShell(OutputWindow):
         self.interp.restart_subprocess(with_cwd=True)
 
     def showprompt(self):
+        """Display the prompt in the shell window.
+
+        Before the prompt is displayed, the text from the prior
+        prompt is stored in history and the text marks are moved
+        ahead to end of the text.  Once the prompt is written, the
+        text mark is set to capture insertions and the line and
+        column within the status bar is updated.  Also, the buffer
+        for undo and redo is cleared as the shell only allows
+        that functionality on the current line.  reset_undo is
+        called with a saved_flag of False so that clearing the
+        undo doesn't also get marked as a file save.
+        """
         self.resetoutput()
         try:
             s = str(sys.ps1)
@@ -1255,7 +1267,7 @@ class PyShell(OutputWindow):
         self.console.write(s)
         self.text.mark_set("insert", "end-1c")
         self.set_line_and_column()
-        self.io.reset_undo()
+        self.io.reset_undo(set_saved_flag=False)
 
     def resetoutput(self):
         source = self.text.get("iomark", "end-1c")

--- a/Lib/idlelib/undo.py
+++ b/Lib/idlelib/undo.py
@@ -47,12 +47,19 @@ class UndoDelegator(Delegator):
         pprint(self.undolist[self.pointer:])
         return "break"
 
-    def reset_undo(self):
+    def reset_undo(self, set_saved_flag=True):
+        """Reset the undo/redo history.
+
+        Clear the undo/redo history and optionally set the saved
+        status for the window based on the parameter.  If set_saved_flag
+        is True, then the window will look like it's been saved.  If
+        it's false, it will not be flagged as saved.
+        """
         self.was_saved = -1
         self.pointer = 0
         self.undolist = []
         self.undoblock = 0  # or a CommandSequence instance
-        self.set_saved(1)
+        self.set_saved(set_saved_flag)
 
     def set_saved(self, flag):
         if flag:
@@ -355,6 +362,8 @@ def _undo_delegator(parent):  # htest #
     undo.pack(side='left')
     redo = Button(undowin, text="Redo", command=lambda:d.redo_event(None))
     redo.pack(side='left')
+    reset = Button(undowin, text="Reset Undo", command=lambda:d.reset_undo())
+    reset.pack(side='left')
     dump = Button(undowin, text="Dump", command=lambda:d.dump_event(None))
     dump.pack(side='left')
 

--- a/Misc/NEWS.d/next/IDLE/2017-09-22-14-24-52.bpo-21937.jxG9wk.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-22-14-24-52.bpo-21937.jxG9wk.rst
@@ -1,0 +1,1 @@
+Fix use of unsaved indicator in titlebar of shell window.


### PR DESCRIPTION
In IDLE, the title in an editor or shell window is bookended by asterisks when changes are made to the text, indicating that the file needs to be saved.  However, the shell window was adding the asterisks as text was typed, but upon pressing the enter key, the asterisks disappeared.  This patch retains the asterisks after enter is pressed.

<!-- issue-number: bpo-21937 -->
https://bugs.python.org/issue21937
<!-- /issue-number -->


<!-- gh-issue-number: gh-66136 -->
* Issue: gh-66136
<!-- /gh-issue-number -->
