### PR TITLE
bpo-31556: asyncio.wait_for can cancel futures faster with timeout <= 0

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -335,10 +335,11 @@ def wait_for(fut, timeout, *, loop=None):
         return (yield from fut)
 
     if timeout <= 0:
+        fut = ensure_future(fut, loop=loop)
+
         if fut.done():
             return fut.result()
 
-        fut = ensure_future(fut, loop=loop)
         fut.cancel()
         raise futures.TimeoutError()
 

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -335,6 +335,9 @@ def wait_for(fut, timeout, *, loop=None):
         return (yield from fut)
 
     if timeout <= 0:
+        if fut.done():
+            return fut.result()
+
         fut = ensure_future(fut, loop=loop)
         fut.cancel()
         raise futures.TimeoutError()

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -334,6 +334,11 @@ def wait_for(fut, timeout, *, loop=None):
     if timeout is None:
         return (yield from fut)
 
+    if timeout == 0:
+        fut = ensure_future(fut, loop=loop)
+        fut.cancel()
+        raise futures.TimeoutError()
+
     waiter = loop.create_future()
     timeout_handle = loop.call_later(timeout, _release_waiter, waiter)
     cb = functools.partial(_release_waiter, waiter)

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -334,7 +334,7 @@ def wait_for(fut, timeout, *, loop=None):
     if timeout is None:
         return (yield from fut)
 
-    if timeout == 0:
+    if timeout <= 0:
         fut = ensure_future(fut, loop=loop)
         fut.cancel()
         raise futures.TimeoutError()

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -661,7 +661,21 @@ class BaseTaskTests:
         t.cancel()
         self.assertRaises(asyncio.CancelledError, loop.run_until_complete, t)
 
-    def test_wait_for_timeout_equals_0(self):
+    def test_wait_for_timeout_less_then_0_or_0_future_done(self):
+        def gen():
+            when = yield
+            self.assertAlmostEqual(0, when)
+
+        loop = self.new_test_loop(gen)
+
+        fut = self.new_future(loop)
+        fut.set_result('done')
+
+        ret = loop.run_until_complete(asyncio.wait_for(fut, 0, loop=loop))
+
+        self.assertEqual(ret, 'done')
+
+    def test_wait_for_timeout_less_then_0_or_0(self):
         def gen():
             when = yield
             self.assertAlmostEqual(0.2, when)

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -674,6 +674,28 @@ class BaseTaskTests:
         ret = loop.run_until_complete(asyncio.wait_for(fut, 0, loop=loop))
 
         self.assertEqual(ret, 'done')
+        self.assertTrue(fut.done())
+        self.assertAlmostEqual(0, loop.time())
+
+    def test_wait_for_timeout_less_then_0_or_0_coroutine_do_not_started(self):
+        def gen():
+            when = yield
+            self.assertAlmostEqual(0, when)
+
+        loop = self.new_test_loop(gen)
+
+        foo_started = False
+
+        @asyncio.coroutine
+        def foo():
+            nonlocal foo_started
+            foo_started = True
+
+        with self.assertRaises(asyncio.TimeoutError):
+            loop.run_until_complete(asyncio.wait_for(foo(), 0, loop=loop))
+
+        self.assertAlmostEqual(0, loop.time())
+        self.assertEqual(foo_started, False)
 
     def test_wait_for_timeout_less_then_0_or_0(self):
         def gen():

--- a/Misc/NEWS.d/next/Library/2017-09-22-23-48-49.bpo-31556.9J0u5H.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-22-23-48-49.bpo-31556.9J0u5H.rst
@@ -1,0 +1,1 @@
+Cancel asyncio.wait_for future faster if timeout==0

--- a/Misc/NEWS.d/next/Library/2017-09-22-23-48-49.bpo-31556.9J0u5H.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-22-23-48-49.bpo-31556.9J0u5H.rst
@@ -1,1 +1,1 @@
-Cancel asyncio.wait_for future faster if timeout==0
+Cancel asyncio.wait_for future faster if timeout <= 0


### PR DESCRIPTION



<!-- issue-number: bpo-31556 -->
https://bugs.python.org/issue31556
<!-- /issue-number -->
