### PR TITLE
bpo-31558: Add gc.freeze()

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -174,6 +174,33 @@ The :mod:`gc` module provides the following functions:
    .. versionadded:: 3.1
 
 
+.. function:: freeze()
+
+   Freeze all the objects tracked by gc - move them to a permanent generation
+   and ignore all the future collections. This can be used before a POSIX
+   fork() call to make the gc copy-on-write friendly or to speed up collection.
+   Also collection before a POSIX fork() call may free pages for future
+   allocation which can cause copy-on-write too so it's advised to disable gc
+   in master process and freeze before fork and enable gc in child process.
+
+   .. versionadded:: 3.7
+
+
+.. function:: unfreeze()
+
+   Unfreeze the objects in the permanent generation, put them back into the
+   oldest generation.
+
+   .. versionadded:: 3.7
+
+
+.. function:: get_freeze_count()
+
+   Return the number of objects in the permanent generation.
+
+   .. versionadded:: 3.7
+
+
 The following variables are provided for read-only access (you can mutate the
 values but should not rebind them):
 

--- a/Include/internal/mem.h
+++ b/Include/internal/mem.h
@@ -167,6 +167,8 @@ struct _gc_runtime_state {
     /* linked lists of container objects */
     struct gc_generation generations[NUM_GENERATIONS];
     PyGC_Head *generation0;
+    /* a permanent generation which won't be collected */
+    struct gc_generation permanent_generation;
     struct gc_generation_stats generation_stats[NUM_GENERATIONS];
     /* true if we are currently running the collector */
     int collecting;
@@ -185,7 +187,6 @@ struct _gc_runtime_state {
        collections, and are awaiting to undergo a full collection for
        the first time. */
     Py_ssize_t long_lived_pending;
-    struct gc_generation permanent_generation;
 };
 
 PyAPI_FUNC(void) _PyGC_Initialize(struct _gc_runtime_state *);

--- a/Include/internal/mem.h
+++ b/Include/internal/mem.h
@@ -185,6 +185,7 @@ struct _gc_runtime_state {
        collections, and are awaiting to undergo a full collection for
        the first time. */
     Py_ssize_t long_lived_pending;
+    struct gc_generation permanent_generation;
 };
 
 PyAPI_FUNC(void) _PyGC_Initialize(struct _gc_runtime_state *);

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -737,6 +737,8 @@ class GCTests(unittest.TestCase):
     def test_freeze(self):
         gc.freeze()
         self.assertGreater(gc.get_freeze_count(), 0)
+        gc.unfreeze()
+        self.assertEqual(gc.get_freeze_count(), 0)
 
 
 class GCCallbackTests(unittest.TestCase):

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -734,6 +734,10 @@ class GCTests(unittest.TestCase):
         self.assertEqual(new[1]["collections"], old[1]["collections"])
         self.assertEqual(new[2]["collections"], old[2]["collections"] + 1)
 
+    def test_freeze(self):
+        gc.freeze()
+        self.assertGreater(gc.get_freeze_stats(), 0)
+
 
 class GCCallbackTests(unittest.TestCase):
     def setUp(self):

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -736,7 +736,7 @@ class GCTests(unittest.TestCase):
 
     def test_freeze(self):
         gc.freeze()
-        self.assertGreater(gc.get_freeze_stats(), 0)
+        self.assertGreater(gc.get_freeze_count(), 0)
 
 
 class GCCallbackTests(unittest.TestCase):

--- a/Modules/clinic/gcmodule.c.h
+++ b/Modules/clinic/gcmodule.c.h
@@ -262,8 +262,8 @@ PyDoc_STRVAR(gc_freeze__doc__,
 "\n"
 "Freeze all current tracked objects and ignore them for future collections.\n"
 "\n"
-"This can be used before a fork to make the gc copy-on-write friendly.\n"
-"Note: collection before a fork may free pages for future allocation\n"
+"This can be used before a POSIX fork() call to make the gc copy-on-write friendly.\n"
+"Note: collection before a POSIX fork() call may free pages for future allocation\n"
 "which can cause copy-on-write.");
 
 #define GC_FREEZE_METHODDEF    \
@@ -278,11 +278,31 @@ gc_freeze(PyObject *module, PyObject *Py_UNUSED(ignored))
     return gc_freeze_impl(module);
 }
 
+PyDoc_STRVAR(gc_unfreeze__doc__,
+"unfreeze($module, /)\n"
+"--\n"
+"\n"
+"Unfreeze all objects in the permanent generation.\n"
+"\n"
+"Put all objects in the permanent generation back into oldest generation.");
+
+#define GC_UNFREEZE_METHODDEF    \
+    {"unfreeze", (PyCFunction)gc_unfreeze, METH_NOARGS, gc_unfreeze__doc__},
+
+static PyObject *
+gc_unfreeze_impl(PyObject *module);
+
+static PyObject *
+gc_unfreeze(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return gc_unfreeze_impl(module);
+}
+
 PyDoc_STRVAR(gc_get_freeze_count__doc__,
 "get_freeze_count($module, /)\n"
 "--\n"
 "\n"
-"Return the number of objects in permanent generations.");
+"Return the number of objects in the permanent generation.");
 
 #define GC_GET_FREEZE_COUNT_METHODDEF    \
     {"get_freeze_count", (PyCFunction)gc_get_freeze_count, METH_NOARGS, gc_get_freeze_count__doc__},
@@ -305,4 +325,4 @@ gc_get_freeze_count(PyObject *module, PyObject *Py_UNUSED(ignored))
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=004d91aafb1827f0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4f41ec4588154f2b input=a9049054013a1b77]*/

--- a/Modules/clinic/gcmodule.c.h
+++ b/Modules/clinic/gcmodule.c.h
@@ -255,4 +255,54 @@ PyDoc_STRVAR(gc_is_tracked__doc__,
 
 #define GC_IS_TRACKED_METHODDEF    \
     {"is_tracked", (PyCFunction)gc_is_tracked, METH_O, gc_is_tracked__doc__},
-/*[clinic end generated code: output=5a58583f00ab018e input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(gc_freeze__doc__,
+"freeze($module, /)\n"
+"--\n"
+"\n"
+"Freeze all current tracked objects and ignore them for future collections.\n"
+"\n"
+"This can be used before a fork to make the gc copy-on-write friendly.\n"
+"Note: collection before a fork may free pages for future allocation\n"
+"which can cause copy-on-write.");
+
+#define GC_FREEZE_METHODDEF    \
+    {"freeze", (PyCFunction)gc_freeze, METH_NOARGS, gc_freeze__doc__},
+
+static PyObject *
+gc_freeze_impl(PyObject *module);
+
+static PyObject *
+gc_freeze(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    return gc_freeze_impl(module);
+}
+
+PyDoc_STRVAR(gc_get_freeze_count__doc__,
+"get_freeze_count($module, /)\n"
+"--\n"
+"\n"
+"Return the number of objects in permanent generations.");
+
+#define GC_GET_FREEZE_COUNT_METHODDEF    \
+    {"get_freeze_count", (PyCFunction)gc_get_freeze_count, METH_NOARGS, gc_get_freeze_count__doc__},
+
+static int
+gc_get_freeze_count_impl(PyObject *module);
+
+static PyObject *
+gc_get_freeze_count(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    PyObject *return_value = NULL;
+    int _return_value;
+
+    _return_value = gc_get_freeze_count_impl(module);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=004d91aafb1827f0 input=a9049054013a1b77]*/

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -817,7 +817,7 @@ collect(int generation, Py_ssize_t *n_collected, Py_ssize_t *n_uncollectable,
         for (i = 0; i < NUM_GENERATIONS; i++)
             PySys_FormatStderr(" %zd",
                               gc_list_size(GEN_HEAD(i)));
-        PySys_WriteStderr("\ngc: objects in permanent generation: %d",
+        PySys_WriteStderr("\ngc: objects in permanent generation: %zd",
                          gc_list_size(&_PyRuntime.gc.permanent_generation.head));
         t1 = _PyTime_GetMonotonicClock();
 
@@ -1411,17 +1411,19 @@ gc_is_tracked(PyObject *module, PyObject *obj)
     return result;
 }
 
-PyDoc_STRVAR(gc_freeze__doc__,
-"freeze() -> None\n"
-"\n"
-"Freeze all current tracked objects and ignore them for future collections.\n"
-"This can be used before a fork to make the gc copy-on-write friendly.\n"
-"Note: collection before a fork may free pages for future allocation\n"
-"which can cause copy-on-write.\n"
-);
+/*[clinic input]
+gc.freeze
+
+Freeze all current tracked objects and ignore them for future collections.
+
+This can be used before a fork to make the gc copy-on-write friendly.
+Note: collection before a fork may free pages for future allocation
+which can cause copy-on-write.
+[clinic start generated code]*/
 
 static PyObject *
-gc_freeze(PyObject *module)
+gc_freeze_impl(PyObject *module)
+/*[clinic end generated code: output=502159d9cdc4c139 input=8798c406cd01d7c4]*/
 {
     for (int i = 0; i < NUM_GENERATIONS; ++i) {
         gc_list_merge(GEN_HEAD(i), &_PyRuntime.gc.permanent_generation.head);
@@ -1430,14 +1432,16 @@ gc_freeze(PyObject *module)
     Py_RETURN_NONE;
 }
 
-PyDoc_STRVAR(gc_get_freeze_stats__doc__,
-"get_freeze_stats() -> n\n"
-"\n"
-"Return the number of objects in permanent generations.\n"
-);
+/*[clinic input]
+gc.get_freeze_count -> int
 
-static PyObject *
-gc_get_freeze_stats(PyObject *module) {
+Return the number of objects in permanent generations.
+[clinic start generated code]*/
+
+static int
+gc_get_freeze_count_impl(PyObject *module)
+/*[clinic end generated code: output=e4e2ebcc77e5cbf3 input=590241a6a398cfa2]*/
+{
     return Py_BuildValue("i", gc_list_size(&_PyRuntime.gc.permanent_generation.head));
 }
 
@@ -1460,7 +1464,7 @@ PyDoc_STRVAR(gc__doc__,
 "get_referrers() -- Return the list of objects that refer to an object.\n"
 "get_referents() -- Return the list of objects that an object refers to.\n"
 "freeze() -- Freeze all tracked objects and ignore them for future collections.\n"
-"get_freeze_stats() -- Return the number of objects in the permanent generation.\n");
+"get_freeze_count() -- Return the number of objects in the permanent generation.\n");
 
 static PyMethodDef GcMethods[] = {
     GC_ENABLE_METHODDEF
@@ -1479,8 +1483,8 @@ static PyMethodDef GcMethods[] = {
         gc_get_referrers__doc__},
     {"get_referents",  gc_get_referents, METH_VARARGS,
         gc_get_referents__doc__},
-    {"freeze", gc_freeze, METH_NOARGS, gc_freeze__doc__},
-    {"get_freeze_stats", gc_get_freeze_stats, METH_NOARGS, gc_get_freeze_stats__doc__},
+    GC_FREEZE_METHODDEF
+    GC_GET_FREEZE_COUNT_METHODDEF
     {NULL,      NULL}           /* Sentinel */
 };
 


### PR DESCRIPTION
Introduces a new API that allows for moving all objects currently tracked by the garbage collector to a *permanent generation*, effectively removing them from future collection events.  This can be used to protect those objects from having their `PyGC_Head` mutated.  In effect, this enables great copy-on-write stability at `fork()`.  More details on the issue.

<!-- issue-number: bpo-31558 -->
https://bugs.python.org/issue31558
<!-- /issue-number -->
