### PR TITLE
bpo-31559: Remove test order dependence in idle_test.test_browser.

### DIFF
--- a/Lib/idlelib/idle_test/test_browser.py
+++ b/Lib/idlelib/idle_test/test_browser.py
@@ -65,7 +65,7 @@ class ClassBrowserTest(unittest.TestCase):
         del cb.top.destroy, cb.node.destroy
 
 
-# Same nested tree creation as in test_pyclbr.py except for super on C0.
+# Nested tree as in test_pyclbr.py except for supers on C0. C1.
 mb = pyclbr
 module, fname = 'test', 'test.py'
 f0 = mb.Function(module, 'f0', fname, 1)
@@ -79,7 +79,9 @@ C2 = mb._nest_class(C1, 'C2', 12)
 F3 = mb._nest_function(C2, 'F3', 14)
 mock_pyclbr_tree = {'f0': f0, 'C0': C0}
 
-# transform_children(mock_pyclbr_tree, 'test') mutates C0.name.
+# Adjust C0.name, C1.name so tests do not depend on order.
+browser.transform_children(mock_pyclbr_tree, 'test')
+browser.transform_children(C0.children)
 
 class TransformChildrenTest(unittest.TestCase):
 
@@ -138,7 +140,7 @@ class ModuleBrowserTreeItemTest(unittest.TestCase):
         self.assertIsInstance(sub0, browser.ChildBrowserTreeItem)
         self.assertIsInstance(sub1, browser.ChildBrowserTreeItem)
         self.assertEqual(sub0.name, 'f0')
-        self.assertEqual(sub1.name, 'C0')
+        self.assertEqual(sub1.name, 'C0(base)')
 
 
     def test_ondoubleclick(self):
@@ -172,13 +174,13 @@ class ChildBrowserTreeItemTest(unittest.TestCase):
 
     def test_init(self):
         eq = self.assertEqual
-        eq(self.cbt_C1.name, 'C1')
+        eq(self.cbt_C1.name, 'C1()')
         self.assertFalse(self.cbt_C1.isfunction)
         eq(self.cbt_f1.name, 'f1')
         self.assertTrue(self.cbt_f1.isfunction)
 
     def test_gettext(self):
-        self.assertEqual(self.cbt_C1.GetText(), 'class C1')
+        self.assertEqual(self.cbt_C1.GetText(), 'class C1()')
         self.assertEqual(self.cbt_f1.GetText(), 'def f1(...)')
 
     def test_geticonname(self):
@@ -221,7 +223,7 @@ class NestedChildrenTest(unittest.TestCase):
         # The tree items are processed in breadth first order.
         # Verify that processing each sublist hits every node and
         # in the right order.
-        expected_names = ['f0', 'C0',  # This is run before transform test.
+        expected_names = ['f0', 'C0(base)',
                           'f1', 'c1', 'F1', 'C1()',
                           'f2', 'C2',
                           'F3']

--- a/Misc/NEWS.d/next/IDLE/2017-09-23-12-52-24.bpo-31559.ydckYX.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-23-12-52-24.bpo-31559.ydckYX.rst
@@ -1,0 +1,1 @@
+Remove test order dependence in idle_test.test_browswer.

--- a/Misc/NEWS.d/next/IDLE/2017-09-23-12-52-24.bpo-31559.ydckYX.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-23-12-52-24.bpo-31559.ydckYX.rst
@@ -1,1 +1,1 @@
-Remove test order dependence in idle_test.test_browswer.
+Remove test order dependence in idle_test.test_browser.


### PR DESCRIPTION


<!-- issue-number: bpo-31559 -->
https://bugs.python.org/issue31559
<!-- /issue-number -->
