### PR TITLE
bpo-31569: globally fix case for PCbuild where it was PCBuild

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,7 @@ Python/bootstrap_hash.c       @python/crypto-team
 
 # Windows
 /PC/                          @python/windows-team
-/PCBuild/                     @python/windows-team
+/PCbuild/                     @python/windows-team
 
 # Windows installer packages
 /Tools/msi/                   @python/windows-team

--- a/.github/appveyor.yml
+++ b/.github/appveyor.yml
@@ -28,7 +28,7 @@ only_commits:
     - Modules/
     - Objects/
     - PC/
-    - PCBuild/
+    - PCbuild/
     - Parser/
     - Programs/
     - Python/

--- a/Doc/distutils/builtdist.rst
+++ b/Doc/distutils/builtdist.rst
@@ -368,7 +368,7 @@ Python itself for the platform you are targeting - it is not possible from a
 binary installation of Python (as the .lib etc file for other platforms are
 not included.)  In practice, this means the user of a 32 bit operating
 system will need to use Visual Studio 2008 to open the
-:file:`PCBuild/PCbuild.sln` solution in the Python source tree and build the
+:file:`PCbuild/PCbuild.sln` solution in the Python source tree and build the
 "x64" configuration of the 'pythoncore' project before cross-compiling
 extensions is possible.
 

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -186,7 +186,7 @@ options, run :program:`python -m test -h`.
 Some other ways to execute the regression tests depend on what platform the
 tests are being executed on. On Unix, you can run :program:`make test` at the
 top-level directory where Python was built. On Windows,
-executing :program:`rt.bat` from your :file:`PCBuild` directory will run all
+executing :program:`rt.bat` from your :file:`PCbuild` directory will run all
 regression tests.
 
 

--- a/Doc/make.bat
+++ b/Doc/make.bat
@@ -5,7 +5,7 @@ pushd %~dp0
 
 set this=%~n0
 
-call ..\PCBuild\find_python.bat %PYTHON%
+call ..\PCbuild\find_python.bat %PYTHON%
 if not defined SPHINXBUILD if defined PYTHON (
     %PYTHON% -c "import sphinx" > nul 2> nul
     if errorlevel 1 (

--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -23,7 +23,7 @@ BASE_PREFIX = os.path.normpath(sys.base_prefix)
 BASE_EXEC_PREFIX = os.path.normpath(sys.base_exec_prefix)
 
 # Path to the base directory of the project. On Windows the binary may
-# live in project/PCBuild/win32 or project/PCBuild/amd64.
+# live in project/PCbuild/win32 or project/PCbuild/amd64.
 # set for cross builds
 if "_PYTHON_PROJECT_BASE" in os.environ:
     project_base = os.path.abspath(os.environ["_PYTHON_PROJECT_BASE"])

--- a/Misc/NEWS.d/next/Build/2017-09-25-00-25-23.bpo-31569.TS49pM.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-25-00-25-23.bpo-31569.TS49pM.rst
@@ -1,0 +1,1 @@
+Correct PCBuild/ case to PCbuild/ in build scripts and documentation.

--- a/PC/bdist_wininst/bdist_wininst.vcxproj
+++ b/PC/bdist_wininst/bdist_wininst.vcxproj
@@ -39,7 +39,7 @@
     <RootNamespace>wininst</RootNamespace>
     <SupportPGO>false</SupportPGO>
   </PropertyGroup>
-  <Import Project="..\..\PCBuild\python.props" />
+  <Import Project="..\..\PCbuild\python.props" />
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
@@ -51,7 +51,7 @@
   </ImportGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-    <Import Project="..\..\PCBuild\pyproject.props" />
+    <Import Project="..\..\PCbuild\pyproject.props" />
   </ImportGroup>
   <PropertyGroup>
     <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>

--- a/PC/bdist_wininst/build.bat
+++ b/PC/bdist_wininst/build.bat
@@ -2,7 +2,7 @@
 setlocal
 
 set D=%~dp0
-set PCBUILD=%~dp0..\..\PCBuild\
+set PCBUILD=%~dp0..\..\PCbuild\
 
 
 echo Building Lib\distutils\command\wininst-xx.0.exe

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -169,11 +169,11 @@ static size_t num_installed_pythons = 0;
 
 static wchar_t * location_checks[] = {
     L"\\",
-    L"\\PCBuild\\win32\\",
-    L"\\PCBuild\\amd64\\",
+    L"\\PCbuild\\win32\\",
+    L"\\PCbuild\\amd64\\",
     /* To support early 32bit versions of Python that stuck the build binaries
-    * directly in PCBuild... */
-    L"\\PCBuild\\",
+    * directly in PCbuild... */
+    L"\\PCbuild\\",
     NULL
 };
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -32,13 +32,13 @@
     <PySourcePath Condition="!HasTrailingSlash($(PySourcePath))">$(PySourcePath)\</PySourcePath>
     
     <!-- Directory where build outputs are put -->
-    <BuildPath32 Condition="'$(Py_OutDir)' == ''">$(PySourcePath)PCBuild\win32\</BuildPath32>
+    <BuildPath32 Condition="'$(Py_OutDir)' == ''">$(PySourcePath)PCbuild\win32\</BuildPath32>
     <BuildPath32 Condition="'$(Py_OutDir)' != ''">$(Py_OutDir)\win32\</BuildPath32>
-    <BuildPath64 Condition="'$(Py_OutDir)' == ''">$(PySourcePath)PCBuild\amd64\</BuildPath64>
+    <BuildPath64 Condition="'$(Py_OutDir)' == ''">$(PySourcePath)PCbuild\amd64\</BuildPath64>
     <BuildPath64 Condition="'$(Py_OutDir)' != ''">$(Py_OutDir)\amd64\</BuildPath64>
     <BuildPath Condition="'$(ArchName)' == 'win32'">$(BuildPath32)</BuildPath>
     <BuildPath Condition="'$(ArchName)' == 'amd64'">$(BuildPath64)</BuildPath>
-    <BuildPath Condition="'$(BuildPath)' == ''">$(PySourcePath)PCBuild\$(ArchName)\</BuildPath>
+    <BuildPath Condition="'$(BuildPath)' == ''">$(PySourcePath)PCbuild\$(ArchName)\</BuildPath>
     <BuildPath Condition="!HasTrailingSlash($(BuildPath))">$(BuildPath)\</BuildPath>
     <BuildPath Condition="$(Configuration) == 'PGInstrument'">$(BuildPath)instrumented\</BuildPath>
     
@@ -118,11 +118,11 @@
     Override the version number when building by specifying OverrideVersion.
     For example:
     
-        PCBuild\build.bat "/p:OverrideVersion=3.5.2a1"
+        PCbuild\build.bat "/p:OverrideVersion=3.5.2a1"
     
     Use the -V option to check your version is valid:
     
-        PCBuild\build.bat -V "/p:OverrideVersion=3.5.2a1"
+        PCbuild\build.bat -V "/p:OverrideVersion=3.5.2a1"
           PythonVersionNumber: 3.5.2
           PythonVersion:       3.5.2a1
           PythonVersionHex:    0x030502A1

--- a/Tools/freeze/extensions_win32.ini
+++ b/Tools/freeze/extensions_win32.ini
@@ -26,34 +26,34 @@
 ; If you need others, add them here
 
 [_socket]
-dsp=%PYTHONPREFIX%\PCBuild\_socket.dsp
+dsp=%PYTHONPREFIX%\PCbuild\_socket.dsp
 
 [_sre]
-dsp=%PYTHONPREFIX%\PCBuild\_sre.dsp
+dsp=%PYTHONPREFIX%\PCbuild\_sre.dsp
 
 [unicodedata]
-dsp=%PYTHONPREFIX%\PCBuild\unicodedata.dsp
+dsp=%PYTHONPREFIX%\PCbuild\unicodedata.dsp
 
 [mmap]
-dsp=%PYTHONPREFIX%\PCBuild\mmap.dsp
+dsp=%PYTHONPREFIX%\PCbuild\mmap.dsp
 
 [winsound]
-dsp=%PYTHONPREFIX%\PCBuild\winsound.dsp
+dsp=%PYTHONPREFIX%\PCbuild\winsound.dsp
 libs=winmm.lib
 
 [parser]
-dsp=%PYTHONPREFIX%\PCBuild\parser.dsp
+dsp=%PYTHONPREFIX%\PCbuild\parser.dsp
 
 [select]
-dsp=%PYTHONPREFIX%\PCBuild\select.dsp
+dsp=%PYTHONPREFIX%\PCbuild\select.dsp
 
 [zlib]
-dsp=%PYTHONPREFIX%\PCBuild\zlib.dsp
+dsp=%PYTHONPREFIX%\PCbuild\zlib.dsp
 cl=/I %PYTHONPREFIX%\..\zlib-1.1.4 /D _WINDOWS /D WIN32
 libs=%PYTHONPREFIX%\..\zlib-1.1.4\zlib.lib /nodefaultlib:libc
 
 [winreg]
-dsp=%PYTHONPREFIX%\PCBuild\winreg.dsp
+dsp=%PYTHONPREFIX%\PCbuild\winreg.dsp
 libs=advapi32.lib
 
 

--- a/Tools/msi/README.txt
+++ b/Tools/msi/README.txt
@@ -64,7 +64,7 @@ Building the Installer
 
 Before building the installer, download extra build dependencies using
 Tools\msi\get_externals.bat. (Note that this is in addition to the
-similarly named file in PCBuild.)
+similarly named file in PCbuild.)
 
 For testing, the installer should be built with the Tools/msi/build.bat
 script:
@@ -72,7 +72,7 @@ script:
     build.bat [-x86] [-x64] [--doc] [--test-marker] [--pack]
 
 This script will build the required configurations of Python and
-generate an installer layout in PCBuild/(win32|amd64)/en-us.
+generate an installer layout in PCbuild/(win32|amd64)/en-us.
 
 Specify -x86 and/or -x64 to build for each platform. If neither is
 specified, both platforms will be built. Currently, both the debug and

--- a/Tools/msi/build.bat
+++ b/Tools/msi/build.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 set D=%~dp0
-set PCBUILD=%D%..\..\PCBuild\
+set PCBUILD=%D%..\..\PCbuild\
 
 set BUILDX86=
 set BUILDX64=

--- a/Tools/msi/buildrelease.bat
+++ b/Tools/msi/buildrelease.bat
@@ -28,7 +28,7 @@ rem     {msi}           MSI filename        core.msi
 set DOWNLOAD_URL=https://www.python.org/ftp/python/{version}/{arch}{releasename}/{msi}
 
 set D=%~dp0
-set PCBUILD=%D%..\..\PCBuild\
+set PCBUILD=%D%..\..\PCbuild\
 if "%Py_OutDir%"=="" set Py_OutDir=%PCBUILD%
 set EXTERNALS=%D%..\..\externals\windows-installer\
 

--- a/Tools/msi/exe/exe.wixproj
+++ b/Tools/msi/exe/exe.wixproj
@@ -45,7 +45,7 @@
     </Target>
     
     <Target Name="_MergeMiscNewsWithBlurb" AfterTargets="PrepareForBuild" Condition="$(Blurb) != '' and !Exists('$(PySourcePath)Misc\NEWS')">
-        <Exec Command="$(Blurb) merge -f &quot;$(BuildPath)NEWS.txt&quot;" WorkingDirectory="$(PCBuild)" />
+        <Exec Command="$(Blurb) merge -f &quot;$(BuildPath)NEWS.txt&quot;" WorkingDirectory="$(PCbuild)" />
     </Target>
     
     <Target Name="_MergeMiscNewsWithPython" AfterTargets="PrepareForBuild" Condition="$(Blurb) == '' and !Exists('$(PySourcePath)Misc\NEWS')">
@@ -58,8 +58,8 @@
             <HostPython>@(HostPython)</HostPython>
             <HostPython Condition="$(HostPython.Contains(';'))">$(HostPython.Remove($(HostPython.IndexOf(';'))))</HostPython>
         </PropertyGroup>
-        <Exec Command="&quot;$(HostPython)&quot; -m pip install -U blurb" WorkingDirectory="$(PCBuild)" />
-        <Exec Command="&quot;$(HostPython)&quot; -m blurb merge -f &quot;$(BuildPath)NEWS.txt&quot;" WorkingDirectory="$(PCBuild)" />
+        <Exec Command="&quot;$(HostPython)&quot; -m pip install -U blurb" WorkingDirectory="$(PCbuild)" />
+        <Exec Command="&quot;$(HostPython)&quot; -m blurb merge -f &quot;$(BuildPath)NEWS.txt&quot;" WorkingDirectory="$(PCbuild)" />
     </Target>
     
     <Import Project="..\msi.targets" />

--- a/Tools/msi/launcher/launcher.wixproj
+++ b/Tools/msi/launcher/launcher.wixproj
@@ -20,16 +20,16 @@
     </ItemGroup>
     
     <Target Name="_EnsurePyEx86" Condition="!Exists('$(BuildPath32)py.exe')" BeforeTargets="PrepareForBuild">
-        <MSBuild Projects="$(PySourcePath)PCBuild\pylauncher.vcxproj" Properties="Platform=Win32" />
+        <MSBuild Projects="$(PySourcePath)PCbuild\pylauncher.vcxproj" Properties="Platform=Win32" />
     </Target>
     <Target Name="_EnsurePywEx86" Condition="!Exists('$(BuildPath32)pyw.exe')" BeforeTargets="PrepareForBuild">
-        <MSBuild Projects="$(PySourcePath)PCBuild\pywlauncher.vcxproj" Properties="Platform=Win32" />
+        <MSBuild Projects="$(PySourcePath)PCbuild\pywlauncher.vcxproj" Properties="Platform=Win32" />
     </Target>
     <Target Name="_EnsurePyShellExt86" Condition="!Exists('$(BuildPath32)pyshellext.dll')" BeforeTargets="PrepareForBuild">
-        <MSBuild Projects="$(PySourcePath)PCBuild\pyshellext.vcxproj" Properties="Platform=Win32" />
+        <MSBuild Projects="$(PySourcePath)PCbuild\pyshellext.vcxproj" Properties="Platform=Win32" />
     </Target>
     <Target Name="_EnsurePyShellExt64" Condition="!Exists('$(BuildPath64)pyshellext.dll')" BeforeTargets="PrepareForBuild">
-        <MSBuild Projects="$(PySourcePath)PCBuild\pyshellext.vcxproj" Properties="Platform=x64" />
+        <MSBuild Projects="$(PySourcePath)PCbuild\pyshellext.vcxproj" Properties="Platform=x64" />
     </Target>
     
     <Import Project="..\msi.targets" />

--- a/Tools/msi/msi.props
+++ b/Tools/msi/msi.props
@@ -15,7 +15,7 @@
     </PropertyGroup>
 
     <Import Project="wix.props" />
-    <Import Project="..\..\PCBuild\tcltk.props" />
+    <Import Project="..\..\PCbuild\tcltk.props" />
 
     <PropertyGroup>
         <!--

--- a/Tools/msi/testrelease.bat
+++ b/Tools/msi/testrelease.bat
@@ -2,7 +2,7 @@
 @echo off
 
 set D=%~dp0
-set PCBUILD=%D%..\..\PCBuild\
+set PCBUILD=%D%..\..\PCbuild\
 
 set TARGETDIR=%TEMP%
 set TESTX86=

--- a/Tools/msi/uploadrelease.bat
+++ b/Tools/msi/uploadrelease.bat
@@ -2,7 +2,7 @@
 @echo off
 
 set D=%~dp0
-set PCBUILD=%D%..\..\PCBuild\
+set PCBUILD=%D%..\..\PCbuild\
 
 set HOST=
 set USER=

--- a/Tools/msi/wix.props
+++ b/Tools/msi/wix.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\PCBuild\python.props" />
+  <Import Project="..\..\PCbuild\python.props" />
   
   <PropertyGroup>
     <WixInstallPath Condition="'$(WixInstallPath)' == '' and Exists('$(MSBuildThisFileDirectory)\Wix')">$(MSBuildThisFileDirectory)\Wix\</WixInstallPath>

--- a/Tools/nuget/build.bat
+++ b/Tools/nuget/build.bat
@@ -1,7 +1,7 @@
 @echo off
 setlocal
 set D=%~dp0
-set PCBUILD=%D%..\..\PCBuild\
+set PCBUILD=%D%..\..\PCbuild\
 if "%Py_OutDir%"=="" set Py_OutDir=%PCBUILD%
 
 set BUILDX86=


### PR DESCRIPTION
While setting up the development environment for Windows I've noticed `PCbuild/` was sometimes  written with a different case. This pull-requests replaces all occasions of `PCBuild` with `PCbuild`.

<!-- issue-number: bpo-31569 -->
https://bugs.python.org/issue31569
<!-- /issue-number -->
