### PR TITLE
bpo-25359: Add missed "goto error" after setting an exception.

### DIFF
--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -941,6 +941,7 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     else {
         PyErr_SetString(PyExc_OSError,
                         "could not determine default encoding");
+        goto error;
     }
 
     /* Check we have been asked for a real text encoding */


### PR DESCRIPTION


<!-- issue-number: bpo-25359 -->
https://bugs.python.org/issue25359
<!-- /issue-number -->
