### PR TITLE
remove configure check for memmove

### DIFF
--- a/Modules/expat/expat_config.h
+++ b/Modules/expat/expat_config.h
@@ -12,6 +12,8 @@
 #define BYTEORDER 1234
 #endif
 
+#define HAVE_MEMMOVE 1
+
 #define XML_NS 1
 #define XML_DTD 1
 #define XML_CONTEXT_BYTES 1024

--- a/configure
+++ b/configure
@@ -12253,19 +12253,6 @@ fi
 done
 
 
-# Stuff for expat.
-for ac_func in memmove
-do :
-  ac_fn_c_check_func "$LINENO" "memmove" "ac_cv_func_memmove"
-if test "x$ac_cv_func_memmove" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_MEMMOVE 1
-_ACEOF
-
-fi
-done
-
-
 # check for long file support functions
 for ac_func in fseek64 fseeko fstatvfs ftell64 ftello statvfs
 do :

--- a/configure.ac
+++ b/configure.ac
@@ -3684,9 +3684,6 @@ AC_CHECK_FUNCS(forkpty,,
    )
 )
 
-# Stuff for expat.
-AC_CHECK_FUNCS(memmove)
-
 # check for long file support functions
 AC_CHECK_FUNCS(fseek64 fseeko fstatvfs ftell64 ftello statvfs)
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -601,9 +601,6 @@
 /* Define to 1 if you have the `mbrtowc' function. */
 #undef HAVE_MBRTOWC
 
-/* Define to 1 if you have the `memmove' function. */
-#undef HAVE_MEMMOVE
-
 /* Define to 1 if you have the <memory.h> header file. */
 #undef HAVE_MEMORY_H
 


### PR DESCRIPTION
Python requires C implementations provide memmove, so we shouldn't need to check for it. The only place using this configure check was expat, where we can simply always define HAVE_MEMMOVE.