### PR TITLE
bpo-31566: Fix an assertion failure in _warnings.warn() in case of a bad __name__ global

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -824,11 +824,10 @@ class _WarningsTests(BaseTest, unittest.TestCase):
     def test_issue31566(self):
         # warn() shouldn't cause an assertion failure in case of a bad
         # __name__ global.
-        wmod = self.module
         with support.swap_item(globals(), '__name__', b'foo'), \
              support.swap_item(globals(), '__file__', None), \
              support.captured_stderr():
-            wmod.warn('bar')
+            self.module.warn('bar')
 
 
 class WarningsDisplayTests(BaseTest):

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -824,10 +824,11 @@ class _WarningsTests(BaseTest, unittest.TestCase):
     def test_issue31566(self):
         # warn() shouldn't cause an assertion failure in case of a bad
         # __name__ global.
-        with support.swap_item(globals(), '__name__', b'foo'), \
-             support.swap_item(globals(), '__file__', None), \
-             support.captured_stderr():
-            self.module.warn('bar')
+        with original_warnings.catch_warnings(module=self.module):
+            self.module.filterwarnings('error')
+            with support.swap_item(globals(), '__name__', b'foo'), \
+                 support.swap_item(globals(), '__file__', None):
+                self.assertRaises(UserWarning, self.module.warn, 'bar')
 
 
 class WarningsDisplayTests(BaseTest):

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -825,7 +825,7 @@ class _WarningsTests(BaseTest, unittest.TestCase):
         # warn() shouldn't cause an assertion failure in case of a bad
         # __name__ global.
         with original_warnings.catch_warnings(module=self.module):
-            self.module.filterwarnings('error')
+            self.module.filterwarnings('error', category=UserWarning)
             with support.swap_item(globals(), '__name__', b'foo'), \
                  support.swap_item(globals(), '__file__', None):
                 self.assertRaises(UserWarning, self.module.warn, 'bar')

--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -820,6 +820,16 @@ class _WarningsTests(BaseTest, unittest.TestCase):
                  self.assertRaises(TypeError):
                 wmod.warn_explicit('foo', Warning, 'bar', 1)
 
+    @support.cpython_only
+    def test_issue31566(self):
+        # warn() shouldn't cause an assertion failure in case of a bad
+        # __name__ global.
+        wmod = self.module
+        with support.swap_item(globals(), '__name__', b'foo'), \
+             support.swap_item(globals(), '__file__', None), \
+             support.captured_stderr():
+            wmod.warn('bar')
+
 
 class WarningsDisplayTests(BaseTest):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-24-09-57-04.bpo-31566.OxwINs.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-24-09-57-04.bpo-31566.OxwINs.rst
@@ -1,0 +1,2 @@
+Fix an assertion failure in `_warnings.warn()` in case of a bad
+``__name__`` global. Patch by Oren Milman.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -684,7 +684,7 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
 
     /* Setup module. */
     *module = PyDict_GetItemString(globals, "__name__");
-    if (*module == NULL) {
+    if (*module == NULL || !PyUnicode_Check(*module)) {
         *module = PyUnicode_FromString("<string>");
         if (*module == NULL)
             goto handle_error;

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -684,15 +684,14 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
 
     /* Setup module. */
     *module = PyDict_GetItemString(globals, "__name__");
-    if (*module == NULL ||
-        (*module != Py_None && !PyUnicode_Check(*module)))
-    {
+    if (*module == Py_None || (*module != NULL && PyUnicode_Check(*module))) {
+        Py_INCREF(*module);
+    }
+    else {
         *module = PyUnicode_FromString("<string>");
         if (*module == NULL)
             goto handle_error;
     }
-    else
-        Py_INCREF(*module);
 
     /* Setup filename. */
     *filename = PyDict_GetItemString(globals, "__file__");

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -684,7 +684,9 @@ setup_context(Py_ssize_t stack_level, PyObject **filename, int *lineno,
 
     /* Setup module. */
     *module = PyDict_GetItemString(globals, "__name__");
-    if (*module == NULL || !PyUnicode_Check(*module)) {
+    if (*module == NULL ||
+        (*module != Py_None && !PyUnicode_Check(*module)))
+    {
         *module = PyUnicode_FromString("<string>");
         if (*module == NULL)
             goto handle_error;


### PR DESCRIPTION
- in `_warnings.c`: add a check whether `__name__` isn't a string.
- in `test_warnings/__init__.py`: add a test to verify that the assertion failure is no more.

<!-- issue-number: bpo-31566 -->
https://bugs.python.org/issue31566
<!-- /issue-number -->
