### PR TITLE
bpo-31570: Fix missing closing quote in email.examples.

### DIFF
--- a/Doc/includes/email-alternative.py
+++ b/Doc/includes/email-alternative.py
@@ -32,7 +32,7 @@ msg.add_alternative("""\
   <body>
     <p>Salut!</p>
     <p>Cela ressemble à un excellent
-        <a href="http://www.yummly.com/recipe/Roasted-Asparagus-Epicurious-203718>
+        <a href="http://www.yummly.com/recipe/Roasted-Asparagus-Epicurious-203718">
             recipie
         </a> déjeuner.
     </p>


### PR DESCRIPTION
No news needed. Not sure about back ports?

<!-- issue-number: bpo-31570 -->
https://bugs.python.org/issue31570
<!-- /issue-number -->
