### PR TITLE
[2.7]bpo-31507 Add docstring to parseaddr function in email.utils.parseaddr (GH-3647)

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -211,6 +211,12 @@ def parsedate_tz(data):
 
 
 def parseaddr(addr):
+    """
+    Parse addr into its constituent realname and email address parts.
+    
+    Return a tuple of realname and email address, unless the parse fails, in
+    which case return a 2-tuple of ('', '').
+    """
     addrs = _AddressList(addr).addresslist
     if not addrs:
         return '', ''


### PR DESCRIPTION



<!-- issue-number: bpo-31507 -->
https://bugs.python.org/issue31507
<!-- /issue-number -->
