### PR TITLE
[3.5] bpo-31568, Travis CI: Fix python3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
       # compiler here and the other to run the coverage build. Clang is preferred
       # in this instance for its better error messages.
       env: TESTING=cpython
+      before_install:
+        # work around https://github.com/travis-ci/travis-ci/issues/8363
+        - pyenv global system 3.5
     - os: osx
       language: c
       compiler: clang


### PR DESCRIPTION
Works around Travis CI bug about the python3.5 binary:
https://github.com/travis-ci/travis-ci/issues/8363

<!-- issue-number: bpo-31568 -->
https://bugs.python.org/issue31568
<!-- /issue-number -->
