### PR TITLE
[WIP] bpo-31573: PyStructSequence_New() checks the type

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-25-15-25-34.bpo-31573.4T5uoa.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-25-15-25-34.bpo-31573.4T5uoa.rst
@@ -1,0 +1,2 @@
+PyStructSequence_New() now raises an exception instead of crashing if the
+argument is not a type.


### PR DESCRIPTION
PyStructSequence_New() now validates the input type to raise an
exception instead of crashing.

<!-- issue-number: bpo-31573 -->
https://bugs.python.org/issue31573
<!-- /issue-number -->
