### PR TITLE
bpo-31577: Fix a crash in os.utime() in case of a bad ns argument

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -672,6 +672,7 @@ class UtimeTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             os.utime(self.fname, (5, 5), ns=(5, 5))
 
+    @support.cpython_only
     def test_issue31577(self):
         # The interpreter shouldn't crash in case utime() received a bad
         # ns argument.

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -672,6 +672,21 @@ class UtimeTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             os.utime(self.fname, (5, 5), ns=(5, 5))
 
+    def test_issue31577(self):
+        # The interpreter shouldn't crash in case utime() received a bad
+        # ns argument.
+        def get_bad_int(divmod_ret_val):
+            class BadInt:
+                def __divmod__(*args):
+                    return divmod_ret_val
+            return BadInt()
+        with self.assertRaises(TypeError):
+            os.utime(self.fname, ns=(get_bad_int(42), 1))
+        with self.assertRaises(TypeError):
+            os.utime(self.fname, ns=(get_bad_int(()), 1))
+        with self.assertRaises(TypeError):
+            os.utime(self.fname, ns=(get_bad_int((1, 2, 3)), 1))
+
 
 from test import mapping_tests
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-25-20-36-24.bpo-31577.jgYsSA.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-25-20-36-24.bpo-31577.jgYsSA.rst
@@ -1,0 +1,2 @@
+Fix a crash in `os.utime()` in case of a bad ns argument. Patch by Oren
+Milman.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -4587,6 +4587,12 @@ split_py_long_to_s_and_ns(PyObject *py_long, time_t *s, long *ns)
     divmod = PyNumber_Divmod(py_long, billion);
     if (!divmod)
         goto exit;
+    if (!PyTuple_Check(divmod) || PyTuple_GET_SIZE(divmod) != 2) {
+        PyErr_Format(PyExc_TypeError,
+                     "%.200s.__divmod__() must return a 2-tuple, not %.200s",
+                     Py_TYPE(py_long)->tp_name, Py_TYPE(divmod)->tp_name);
+        goto exit;
+    }
     *s = _PyLong_AsTime_t(PyTuple_GET_ITEM(divmod, 0));
     if ((*s == -1) && PyErr_Occurred())
         goto exit;


### PR DESCRIPTION
- in `posixmodule.c` - add a check whether `PyNumber_Divmod()` returned a 2-tuple.
- in `test_os.py` - add tests to verify that the crash is no more.

<!-- issue-number: bpo-31577 -->
https://bugs.python.org/issue31577
<!-- /issue-number -->
