### PR TITLE
bpo-31579: Fixed a possible leak in enumerate() with large indices.

### DIFF
--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -108,14 +108,18 @@ enum_next_long(enumobject *en, PyObject* next_item)
 
     if (en->en_longindex == NULL) {
         en->en_longindex = PyLong_FromSsize_t(PY_SSIZE_T_MAX);
-        if (en->en_longindex == NULL)
+        if (en->en_longindex == NULL) {
+            Py_DECREF(next_item);
             return NULL;
+        }
     }
     next_index = en->en_longindex;
     assert(next_index != NULL);
     stepped_up = PyNumber_Add(next_index, _PyLong_One);
-    if (stepped_up == NULL)
+    if (stepped_up == NULL) {
+        Py_DECREF(next_item);
         return NULL;
+    }
     en->en_longindex = stepped_up;
 
     if (result->ob_refcnt == 1) {


### PR DESCRIPTION


<!-- issue-number: bpo-31579 -->
https://bugs.python.org/issue31579
<!-- /issue-number -->
