### PR TITLE
bpo-31596: Add an interface for pthread_getcpuclockid(3)

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -166,12 +166,12 @@ The module defines the following functions and data items:
 
    Return the *clk_id* of the thread-specific CPU-time clock for the specified *thread_id*.
 
-   Use :func:`threading.get_ident()` or the :attr:`~threading.Thread.ident`
+   Use :func:`threading.get_ident` or the :attr:`~threading.Thread.ident`
    attribute of :class:`threading.Thread` objects to get a suitable value
    for *thread_id*.
 
    .. warning::
-      Passing an invalid or expired thread_id may result in
+      Passing an invalid or expired *thread_id* may result in
       undefined behavior, such as segmentation fault.
 
    Availability: Unix (see the man page for :manpage:`pthread_getcpuclockid(3)` for

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -162,6 +162,22 @@ The module defines the following functions and data items:
       :func:`perf_counter` or :func:`process_time` instead, depending on your
       requirements, to have a well defined behaviour.
 
+.. function:: pthread_getcpuclockid(thread_id)
+
+   Return the *clk_id* of the thread-specific CPU-time clock for the specified *thread_id*.
+
+   Use :func:`threading.get_ident()` or the :attr:`~threading.Thread.ident`
+   attribute of :class:`threading.Thread` objects to get a suitable value
+   for *thread_id*.
+
+   .. warning::
+      Passing an invalid or expired thread_id may result in
+      undefined behavior, such as segmentation fault.
+
+   Availability: Unix (see the man page for :manpage:`pthread_getcpuclockid(3)` for
+   further information)
+
+   .. versionadded:: 3.7
 
 .. function:: clock_getres(clk_id)
 

--- a/Misc/NEWS.d/next/Library/2017-09-26-11-38-52.bpo-31596.50Eyel.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-26-11-38-52.bpo-31596.50Eyel.rst
@@ -1,0 +1,1 @@
+Added pthread_getcpuclockid() to the time module

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -241,7 +241,7 @@ time_pthread_getcpuclockid(PyObject *self, PyObject *args)
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
-    return PyLong_FromLong((long)clk_id);
+    return PyLong_FromLong(clk_id);
 }
 
 PyDoc_STRVAR(pthread_getcpuclockid_doc,

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -20,6 +20,10 @@
 #include <io.h>
 #endif
 
+#if defined(HAVE_PTHREAD_H)
+#  include <pthread.h>
+#endif
+
 #if defined(__WATCOMC__) && !defined(__QNX__)
 #include <i86.h>
 #else
@@ -220,6 +224,31 @@ PyDoc_STRVAR(clock_getres_doc,
 \n\
 Return the resolution (precision) of the specified clock clk_id.");
 #endif   /* HAVE_CLOCK_GETRES */
+
+#ifdef HAVE_PTHREAD_GETCPUCLOCKID
+static PyObject *
+time_pthread_getcpuclockid(PyObject *self, PyObject *args)
+{
+    unsigned long thread_id;
+    int err;
+    clockid_t clk_id;
+    if (!PyArg_ParseTuple(args, "k:pthread_getcpuclockid", &thread_id)) {
+        return NULL;
+    }
+    err = pthread_getcpuclockid((pthread_t)thread_id, &clk_id);
+    if (err) {
+        errno = err;
+        PyErr_SetFromErrno(PyExc_OSError);
+        return NULL;
+    }
+    return PyLong_FromLong((long)clk_id);
+}
+
+PyDoc_STRVAR(pthread_getcpuclockid_doc,
+"pthread_getcpuclockid(thread_id) -> int\n\
+\n\
+Return the clk_id of a thread's CPU time clock.");
+#endif /* HAVE_PTHREAD_GETCPUCLOCKID */
 
 static PyObject *
 time_sleep(PyObject *self, PyObject *obj)
@@ -1287,6 +1316,9 @@ static PyMethodDef time_methods[] = {
 #endif
 #ifdef HAVE_CLOCK_GETRES
     {"clock_getres",    time_clock_getres, METH_VARARGS, clock_getres_doc},
+#endif
+#ifdef HAVE_PTHREAD_GETCPUCLOCKID
+    {"pthread_getcpuclockid", time_pthread_getcpuclockid, METH_VARARGS, pthread_getcpuclockid_doc},
 #endif
     {"sleep",           time_sleep, METH_O, sleep_doc},
     {"gmtime",          time_gmtime, METH_VARARGS, gmtime_doc},

--- a/configure
+++ b/configure
@@ -10588,6 +10588,17 @@ _ACEOF
 fi
 done
 
+      for ac_func in pthread_getcpuclockid
+do :
+  ac_fn_c_check_func "$LINENO" "pthread_getcpuclockid" "ac_cv_func_pthread_getcpuclockid"
+if test "x$ac_cv_func_pthread_getcpuclockid" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_PTHREAD_GETCPUCLOCKID 1
+_ACEOF
+
+fi
+done
+
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -3038,6 +3038,7 @@ if test "$posix_threads" = "yes"; then
             ;;
         esac])
       AC_CHECK_FUNCS(pthread_atfork)
+      AC_CHECK_FUNCS(pthread_getcpuclockid)
 fi
 
 

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -694,6 +694,9 @@
 /* Defined for Solaris 2.6 bug in pthread header. */
 #undef HAVE_PTHREAD_DESTRUCTOR
 
+/* Define to 1 if you have the `pthread_getcpuclockid' function. */
+#undef HAVE_PTHREAD_GETCPUCLOCKID
+
 /* Define to 1 if you have the <pthread.h> header file. */
 #undef HAVE_PTHREAD_H
 


### PR DESCRIPTION
Modeled on the interface for signal.pthread_kill

<!-- issue-number: bpo-31596 -->
https://bugs.python.org/issue31596
<!-- /issue-number -->
