### PR TITLE
bpo-31583: Fix 2to3 for using with --add-suffix option

### DIFF
--- a/Lib/lib2to3/main.py
+++ b/Lib/lib2to3/main.py
@@ -80,7 +80,7 @@ class StdoutRefactoringTool(refactor.MultiprocessRefactoringTool):
             filename += self._append_suffix
         if orig_filename != filename:
             output_dir = os.path.dirname(filename)
-            if not os.path.isdir(output_dir):
+            if not os.path.isdir(output_dir) and output_dir:
                 os.makedirs(output_dir)
             self.log_message('Writing converted %s to %s.', orig_filename,
                              filename)

--- a/Misc/NEWS.d/next/Tools-Demos/2017-09-26-10-11-21.bpo-31583.TM90_H.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2017-09-26-10-11-21.bpo-31583.TM90_H.rst
@@ -1,0 +1,2 @@
+Fix 2to3 for using with --add-suffix option without -o or --output-dir
+option for relative path to files in current directory.

--- a/Misc/NEWS.d/next/Tools-Demos/2017-09-26-10-11-21.bpo-31583.TM90_H.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2017-09-26-10-11-21.bpo-31583.TM90_H.rst
@@ -1,2 +1,2 @@
-Fix 2to3 for using with --add-suffix option without -o or --output-dir
+Fix 2to3 for using with --add-suffix option but without --output-dir
 option for relative path to files in current directory.


### PR DESCRIPTION
Fix 2to3 for using with --add-suffix option without -o or --output-dir option for relative path to files in current directory.

<!-- issue-number: bpo-31583 -->
https://bugs.python.org/issue31583
<!-- /issue-number -->
