### PR TITLE
[3.6] bpo-31579: Fixed a possible leak in enumerate() with large indices. (GH-3753).

### DIFF
--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -87,19 +87,25 @@ enum_next_long(enumobject *en, PyObject* next_item)
 
     if (en->en_longindex == NULL) {
         en->en_longindex = PyLong_FromSsize_t(PY_SSIZE_T_MAX);
-        if (en->en_longindex == NULL)
+        if (en->en_longindex == NULL) {
+            Py_DECREF(next_item);
             return NULL;
+        }
     }
     if (one == NULL) {
         one = PyLong_FromLong(1);
-        if (one == NULL)
+        if (one == NULL) {
+            Py_DECREF(next_item);
             return NULL;
+        }
     }
     next_index = en->en_longindex;
     assert(next_index != NULL);
     stepped_up = PyNumber_Add(next_index, one);
-    if (stepped_up == NULL)
+    if (stepped_up == NULL) {
+        Py_DECREF(next_item);
         return NULL;
+    }
     en->en_longindex = stepped_up;
 
     if (result->ob_refcnt == 1) {


### PR DESCRIPTION


<!-- issue-number: bpo-31579 -->
https://bugs.python.org/issue31579
<!-- /issue-number -->
