### PR TITLE
bpo-31586: Fix a SystemError in _collections._count_element() in case of a bad mapping arg

### DIFF
--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -2277,7 +2277,9 @@ _count_elements(PyObject *self, PyObject *args)
     dict_setitem = _PyType_LookupId(&PyDict_Type, &PyId___setitem__);
 
     if (mapping_get != NULL && mapping_get == dict_get &&
-        mapping_setitem != NULL && mapping_setitem == dict_setitem) {
+        mapping_setitem != NULL && mapping_setitem == dict_setitem &&
+        PyDict_Check(mapping))
+    {
         while (1) {
             /* Fast path advantages:
                    1. Eliminate double hashing


### PR DESCRIPTION
- in `_collectionsmodule.c` - add a check to make sure that the fast path is taken only if `mapping` is a dictionary.

<!-- issue-number: bpo-31586 -->
https://bugs.python.org/issue31586
<!-- /issue-number -->
