### PR TITLE
bpo-31588: Prevent raising a SystemError in class creation in case of a metaclass with a bad __prepare__() method

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -868,14 +868,14 @@ class ClassCreationTests(unittest.TestCase):
         # __prepare__() must return a mapping.
         class BadMeta(type):
             def __prepare__(*args):
-                pass
+                return None
         with self.assertRaises(TypeError):
             class Foo(metaclass=BadMeta):
                 pass
         # Also test the case in which the metaclass is not a type.
         class BadMeta:
             def __prepare__(*args):
-                pass
+                return None
         with self.assertRaises(TypeError):
             class Bar(metaclass=BadMeta()):
                 pass

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -867,16 +867,22 @@ class ClassCreationTests(unittest.TestCase):
     def test_bad___prepare__(self):
         # __prepare__() must return a mapping.
         class BadMeta(type):
+            @classmethod
             def __prepare__(*args):
                 return None
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError,
+                                    r'^BadMeta\.__prepare__\(\) must '
+                                    r'return a mapping, not NoneType$'):
             class Foo(metaclass=BadMeta):
                 pass
         # Also test the case in which the metaclass is not a type.
         class BadMeta:
+            @classmethod
             def __prepare__(*args):
                 return None
-        with self.assertRaises(TypeError):
+        with self.assertRaisesRegex(TypeError,
+                                    r'^<metaclass>\.__prepare__\(\) must '
+                                    r'return a mapping, not NoneType$'):
             class Bar(metaclass=BadMeta()):
                 pass
 

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -872,6 +872,12 @@ class ClassCreationTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             class Foo(metaclass=BadMetaclass):
                 pass
+        class BadMetaclass:
+            def __prepare__(*args):
+                pass
+        with self.assertRaises(TypeError):
+            class Bar(metaclass=BadMetaclass()):
+                pass
 
     def test_metaclass_derivation(self):
         # issue1294232: correct metaclass calculation

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -866,17 +866,18 @@ class ClassCreationTests(unittest.TestCase):
 
     def test_bad___prepare__(self):
         # __prepare__() must return a mapping.
-        class BadMetaclass(type):
+        class BadMeta(type):
             def __prepare__(*args):
                 pass
         with self.assertRaises(TypeError):
-            class Foo(metaclass=BadMetaclass):
+            class Foo(metaclass=BadMeta):
                 pass
-        class BadMetaclass:
+        # Also test the case in which metaclass is not a type.
+        class BadMeta:
             def __prepare__(*args):
                 pass
         with self.assertRaises(TypeError):
-            class Bar(metaclass=BadMetaclass()):
+            class Bar(metaclass=BadMeta()):
                 pass
 
     def test_metaclass_derivation(self):

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -872,7 +872,7 @@ class ClassCreationTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             class Foo(metaclass=BadMeta):
                 pass
-        # Also test the case in which metaclass is not a type.
+        # Also test the case in which the metaclass is not a type.
         class BadMeta:
             def __prepare__(*args):
                 pass

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -864,6 +864,15 @@ class ClassCreationTests(unittest.TestCase):
         self.assertIs(ns, expected_ns)
         self.assertEqual(len(kwds), 0)
 
+    def test_bad___prepare__(self):
+        # __prepare__() must return a mapping.
+        class BadMetaclass(type):
+            def __prepare__(*args):
+                pass
+        with self.assertRaises(TypeError):
+            class Foo(metaclass=BadMetaclass):
+                pass
+
     def test_metaclass_derivation(self):
         # issue1294232: correct metaclass calculation
         new_calls = []  # to check the order of __new__ calls

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-26-13-03-16.bpo-31588.wT9Iy7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-26-13-03-16.bpo-31588.wT9Iy7.rst
@@ -1,0 +1,2 @@
+Prevent raising a SystemError in class creation in case of a metaclass with
+a bad ``__prepare__()`` method. Patch by Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-26-13-03-16.bpo-31588.wT9Iy7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-26-13-03-16.bpo-31588.wT9Iy7.rst
@@ -1,2 +1,2 @@
-Raise a `TypeError` with a helpful error message in case class creation failed
+Raise a `TypeError` with a helpful error message when class creation fails
 due to a metaclass with a bad ``__prepare__()`` method. Patch by Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-26-13-03-16.bpo-31588.wT9Iy7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-26-13-03-16.bpo-31588.wT9Iy7.rst
@@ -1,2 +1,2 @@
-Raise a `TypeError` instead of `SystemError` in case class creation failed due
-to a metaclass with a bad ``__prepare__()`` method. Patch by Oren Milman.
+Raise a `TypeError` with a helpful error message in case class creation failed
+due to a metaclass with a bad ``__prepare__()`` method. Patch by Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-26-13-03-16.bpo-31588.wT9Iy7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-26-13-03-16.bpo-31588.wT9Iy7.rst
@@ -1,2 +1,2 @@
-Prevent raising a SystemError in class creation in case of a metaclass with
-a bad ``__prepare__()`` method. Patch by Oren Milman.
+Raise a `TypeError` instead of `SystemError` in case class creation failed due
+to a metaclass with a bad ``__prepare__()`` method. Patch by Oren Milman.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -157,6 +157,13 @@ builtin___build_class__(PyObject *self, PyObject **args, Py_ssize_t nargs,
         Py_DECREF(bases);
         return NULL;
     }
+    if (!PyMapping_Check(ns)) {
+        PyErr_Format(PyExc_TypeError,
+                     "%.200s.__prepare__() must return a mapping, not %.200s",
+                     isclass ? ((PyTypeObject *)meta)->tp_name : "<metaclass>",
+                     Py_TYPE(ns)->tp_name);
+        goto error;
+    }
     cell = PyEval_EvalCodeEx(PyFunction_GET_CODE(func), PyFunction_GET_GLOBALS(func), ns,
                              NULL, 0, NULL, 0, NULL, 0, NULL,
                              PyFunction_GET_CLOSURE(func));


### PR DESCRIPTION
- in `bltinmodule.c`: add a check whether ``__prepare__()`` returned a mapping.
- in `test_types.py`: add tests to verify that the `SystemError` is no more.

<!-- issue-number: bpo-31588 -->
https://bugs.python.org/issue31588
<!-- /issue-number -->
