### PR TITLE
bpo-31592: Fix an assertion failure in Python/ast.c in case of a bad unicodedata.normalize()

### DIFF
--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -431,6 +431,16 @@ class AST_Tests(unittest.TestCase):
             compile(empty_yield_from, "<test>", "exec")
         self.assertIn("field value is required", str(cm.exception))
 
+    @support.cpython_only
+    def test_issue31592(self):
+        # There shouldn't be an assertion failure in case of a bad
+        # unicodedata.normalize().
+        import unicodedata
+        def bad_normalize(*args):
+            return None
+        with support.swap_attr(unicodedata, 'normalize', bad_normalize):
+            self.assertRaises(TypeError, ast.parse, '\u03D5')
+
 
 class ASTHelpers_Test(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-26-16-05-04.bpo-31592.IFBZj9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-26-16-05-04.bpo-31592.IFBZj9.rst
@@ -1,0 +1,2 @@
+Fix an assertion failure in case of a bad `unicodedata.normalize()`. Patch
+by Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-26-16-05-04.bpo-31592.IFBZj9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-26-16-05-04.bpo-31592.IFBZj9.rst
@@ -1,2 +1,2 @@
-Fix an assertion failure in case of a bad `unicodedata.normalize()`. Patch
-by Oren Milman.
+Fixed an assertion failure in Python parser in case of a bad `unicodedata.normalize()`.
+Patch by Oren Milman.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -660,7 +660,8 @@ new_identifier(const char *n, struct compiling *c)
         /* Use _PyObject_FastCall() this way to conceal c->c_normalize_args
            from the user. */
         id2 = _PyObject_FastCall(c->c_normalize,
-                                 _PyList_ITEMS(c->c_normalize_args), 2);
+                                 ((PyTupleObject *)c->c_normalize_args)->ob_item,
+                                 2);
         Py_DECREF(id);
         if (!id2)
             return NULL;

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -661,6 +661,14 @@ new_identifier(const char *n, struct compiling *c)
         Py_DECREF(id);
         if (!id2)
             return NULL;
+        if (!PyUnicode_Check(id2)) {
+            PyErr_Format(PyExc_TypeError,
+                         "unicodedata.normalize() must return a string, not "
+                         "%.200s",
+                         Py_TYPE(id2)->tp_name);
+            Py_DECREF(id2);
+            return NULL;
+        }
         id = id2;
     }
     PyUnicode_InternInPlace(&id);

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -657,7 +657,11 @@ new_identifier(const char *n, struct compiling *c)
             return NULL;
         }
         PyTuple_SET_ITEM(c->c_normalize_args, 1, id);
-        id2 = PyObject_Call(c->c_normalize, c->c_normalize_args, NULL);
+        /* Use _PyObject_FastCall() this way to conceal c->c_normalize_args
+           from the user. */
+        id2 = _PyObject_FastCall(c->c_normalize,
+                                 ((PyTupleObject *)c->c_normalize_args)->ob_item,
+                                 2);
         Py_DECREF(id);
         if (!id2)
             return NULL;

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -645,18 +645,18 @@ new_identifier(const char *n, struct compiling *c)
        identifier; if so, normalize to NFKC. */
     if (!PyUnicode_IS_ASCII(id)) {
         PyObject *id2;
+        _Py_IDENTIFIER(NFKC);
         if (!c->c_normalize && !init_normalization(c)) {
             Py_DECREF(id);
             return NULL;
         }
-        PyObject *form = PyUnicode_FromString("NFKC");
+        PyObject *form = _PyUnicode_FromId(&PyId_NFKC);
         if (form == NULL) {
             Py_DECREF(id);
             return NULL;
         }
         PyObject *args[2] = {form, id};
         id2 = _PyObject_FastCall(c->c_normalize, args, 2);
-        Py_DECREF(form);
         Py_DECREF(id);
         if (!id2)
             return NULL;

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -660,8 +660,7 @@ new_identifier(const char *n, struct compiling *c)
         /* Use _PyObject_FastCall() this way to conceal c->c_normalize_args
            from the user. */
         id2 = _PyObject_FastCall(c->c_normalize,
-                                 ((PyTupleObject *)c->c_normalize_args)->ob_item,
-                                 2);
+                                 _PyList_ITEMS(c->c_normalize_args), 2);
         Py_DECREF(id);
         if (!id2)
             return NULL;


### PR DESCRIPTION
- in `ast.c`: add a check whether `unicodedata.normalize()` returned a string.
- in `test_ast.py`: add tests to verify that the assertion failure is no more.

<!-- issue-number: bpo-31592 -->
https://bugs.python.org/issue31592
<!-- /issue-number -->
