### PR TITLE
bpo-28293: The regex cache no longer completely dump when full.

### DIFF
--- a/Lib/re.py
+++ b/Lib/re.py
@@ -128,6 +128,13 @@ try:
 except ImportError:
     _locale = None
 
+# try _collections first to reduce startup cost
+try:
+    from _collections import OrderedDict
+except ImportError:
+    from collections import OrderedDict
+
+
 # public symbols
 __all__ = [
     "match", "fullmatch", "search", "sub", "subn", "split",
@@ -260,7 +267,7 @@ def escape(pattern):
 # --------------------------------------------------------------------
 # internals
 
-_cache = {}
+_cache = OrderedDict()
 
 _pattern_type = type(sre_compile.compile("", 0))
 
@@ -281,7 +288,10 @@ def _compile(pattern, flags):
     p = sre_compile.compile(pattern, flags)
     if not (flags & DEBUG):
         if len(_cache) >= _MAXCACHE:
-            _cache.clear()
+            try:
+                _cache.popitem(False)
+            except KeyError:
+                pass
         _cache[type(pattern), pattern, flags] = p
     return p
 

--- a/Misc/NEWS.d/next/Library/2017-09-26-17-51-17.bpo-28293.UC5pm4.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-26-17-51-17.bpo-28293.UC5pm4.rst
@@ -1,0 +1,1 @@
+The regex cache no longer completely dump when full.

--- a/Misc/NEWS.d/next/Library/2017-09-26-17-51-17.bpo-28293.UC5pm4.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-26-17-51-17.bpo-28293.UC5pm4.rst
@@ -1,1 +1,1 @@
-The regex cache no longer completely dump when full.
+The regular expression cache is no longer completely dumped when it is full.


### PR DESCRIPTION


<!-- issue-number: bpo-28293 -->
https://bugs.python.org/issue28293
<!-- /issue-number -->
