### PR TITLE
bpo-22140: Prevent double substitution of prefix in python-config.sh

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-09-26-22-39-58.bpo-22140.ZRf7Wn.rst
+++ b/Misc/NEWS.d/next/Build/2017-09-26-22-39-58.bpo-22140.ZRf7Wn.rst
@@ -1,0 +1,1 @@
+Prevent double substitution of prefix in python-config.sh.

--- a/Misc/python-config.sh.in
+++ b/Misc/python-config.sh.in
@@ -24,17 +24,18 @@ installed_prefix ()
     echo $RESULT
 }
 
-prefix_build="@prefix@"
 prefix_real=$(installed_prefix "$0")
 
 # Use sed to fix paths from their built-to locations to their installed-to
-# locations.
-prefix=$(echo "$prefix_build" | sed "s#$prefix_build#$prefix_real#")
-exec_prefix_build="@exec_prefix@"
-exec_prefix=$(echo "$exec_prefix_build" | sed "s#$exec_prefix_build#$prefix_real#")
-includedir=$(echo "@includedir@" | sed "s#$prefix_build#$prefix_real#")
-libdir=$(echo "@libdir@" | sed "s#$prefix_build#$prefix_real#")
-CFLAGS=$(echo "@CFLAGS@" | sed "s#$prefix_build#$prefix_real#")
+# locations. Keep prefix & exec_prefix using their original values in case
+# they are referenced in other configure variables, to prevent double
+# substitution, issue #22140.
+prefix="@prefix@"
+exec_prefix="@exec_prefix@"
+exec_prefix_real=${prefix_real}
+includedir=$(echo "@includedir@" | sed "s#$prefix#$prefix_real#")
+libdir=$(echo "@libdir@" | sed "s#$prefix#$prefix_real#")
+CFLAGS=$(echo "@CFLAGS@" | sed "s#$prefix#$prefix_real#")
 VERSION="@VERSION@"
 LIBM="@LIBM@"
 LIBC="@LIBC@"
@@ -47,8 +48,8 @@ LINKFORSHARED="@LINKFORSHARED@"
 OPT="@OPT@"
 PY_ENABLE_SHARED="@PY_ENABLE_SHARED@"
 LDVERSION="@LDVERSION@"
-LIBDEST=${prefix}/lib/python${VERSION}
-LIBPL=$(echo "@LIBPL@" | sed "s#$prefix_build#$prefix_real#")
+LIBDEST=${prefix_real}/lib/python${VERSION}
+LIBPL=$(echo "@LIBPL@" | sed "s#$prefix#$prefix_real#")
 SO="@EXT_SUFFIX@"
 PYTHONFRAMEWORK="@PYTHONFRAMEWORK@"
 INCDIR="-I$includedir/python${VERSION}${ABIFLAGS}"
@@ -73,10 +74,10 @@ for ARG in "$@"
 do
     case "$ARG" in
         --prefix)
-            echo "$prefix"
+            echo "$prefix_real"
         ;;
         --exec-prefix)
-            echo "$exec_prefix"
+            echo "$exec_prefix_real"
         ;;
         --includes)
             echo "$INCDIR $PLATINCDIR"


### PR DESCRIPTION
Fix the logic in python-config.sh to avoid attempting to substitute
prefix in a variable that might have already been subject to
substitution. This e.g. happened if @exec_prefix@ was defined as
"${prefix}" (which is the default of the configure script) -- in which
case the exec_prefix_build variable was initialized with
already-subtituted prefix, and then another round of substitution was
performed which might have resulted in duplicate prefix.

To avoid that, rename the variables so that the variables matching
likely configure names (prefix, exec_prefix) retain their original
values and a '_real' suffix is used for the real values of prefix.

Furthermore, replace the unnecessary prefix and exec_prefix
substitutions with direct prefix_real references since the sed
always replaced the whole string anyway by design.

<!-- issue-number: bpo-22140 -->
https://bugs.python.org/issue22140
<!-- /issue-number -->
