### PR TITLE
[3.6] bpo-31492: Fix assertion failures in case of a module with a bad __name__ attribute. (GH-3620).

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -353,6 +353,18 @@ class ImportTests(unittest.TestCase):
         with self.assertRaises(ImportError):
             from test_from_import_AttributeError import does_not_exist
 
+    @cpython_only
+    def test_issue31492(self):
+        # There shouldn't be an assertion failure in case of failing to import
+        # from a module with a bad __name__ attribute, or in case of failing
+        # to access an attribute of such a module.
+        with swap_attr(os, '__name__', None):
+            with self.assertRaises(ImportError):
+                from os import does_not_exist
+
+            with self.assertRaises(AttributeError):
+                os.does_not_exist
+
     def test_concurrency(self):
         sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'data'))
         try:

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-16-22-49-16.bpo-31492.RtyteL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-16-22-49-16.bpo-31492.RtyteL.rst
@@ -1,0 +1,3 @@
+Fix assertion failures in case of failing to import from a module with a bad
+``__name__`` attribute, and in case of failing to access an attribute of such
+a module. Patch by Oren Milman.

--- a/Objects/moduleobject.c
+++ b/Objects/moduleobject.c
@@ -667,13 +667,10 @@ module_getattro(PyModuleObject *m, PyObject *name)
     if (m->md_dict) {
         _Py_IDENTIFIER(__name__);
         mod_name = _PyDict_GetItemId(m->md_dict, &PyId___name__);
-        if (mod_name) {
+        if (mod_name && PyUnicode_Check(mod_name)) {
             PyErr_Format(PyExc_AttributeError,
                         "module '%U' has no attribute '%U'", mod_name, name);
             return NULL;
-        }
-        else if (PyErr_Occurred()) {
-            PyErr_Clear();
         }
     }
     PyErr_Format(PyExc_AttributeError,

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5254,6 +5254,10 @@ import_from(PyObject *v, PyObject *name)
     if (pkgname == NULL) {
         goto error;
     }
+    if (!PyUnicode_Check(pkgname)) {
+        Py_CLEAR(pkgname);
+        goto error;
+    }
     fullmodname = PyUnicode_FromFormat("%U.%U", pkgname, name);
     Py_DECREF(pkgname);
     if (fullmodname == NULL) {


### PR DESCRIPTION
(cherry picked from commit 6db7033192cd537ca987a65971acb01206c3ba82)


<!-- issue-number: bpo-31492 -->
https://bugs.python.org/issue31492
<!-- /issue-number -->
