### PR TITLE
[3.6] bpo-31285: Fix an assertion failure and a SystemError in warnings.warn_explicit. (GH-3219)

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -794,6 +794,42 @@ class _WarningsTests(BaseTest, unittest.TestCase):
         self.assertNotIn(b'Warning!', stderr)
         self.assertNotIn(b'Error', stderr)
 
+    def test_issue31285(self):
+        # warn_explicit() should neither raise a SystemError nor cause an
+        # assertion failure, in case the return value of get_source() has a
+        # bad splitlines() method.
+        def get_bad_loader(splitlines_ret_val):
+            class BadLoader:
+                def get_source(self, fullname):
+                    class BadSource(str):
+                        def splitlines(self):
+                            return splitlines_ret_val
+                    return BadSource('spam')
+            return BadLoader()
+
+        wmod = self.module
+        with original_warnings.catch_warnings(module=wmod):
+            wmod.filterwarnings('default', category=UserWarning)
+
+            with support.captured_stderr() as stderr:
+                wmod.warn_explicit(
+                    'foo', UserWarning, 'bar', 1,
+                    module_globals={'__loader__': get_bad_loader(42),
+                                    '__name__': 'foobar'})
+            self.assertIn('UserWarning: foo', stderr.getvalue())
+
+            show = wmod._showwarnmsg
+            try:
+                del wmod._showwarnmsg
+                with support.captured_stderr() as stderr:
+                    wmod.warn_explicit(
+                        'eggs', UserWarning, 'bar', 1,
+                        module_globals={'__loader__': get_bad_loader([42]),
+                                        '__name__': 'foobar'})
+                self.assertIn('UserWarning: eggs', stderr.getvalue())
+            finally:
+                wmod._showwarnmsg = show
+
     @support.cpython_only
     def test_issue31411(self):
         # warn_explicit() shouldn't raise a SystemError in case

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-27-21-18-30.bpo-31285.7lzaKV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-27-21-18-30.bpo-31285.7lzaKV.rst
@@ -1,0 +1,3 @@
+Fix an assertion failure in `warnings.warn_explicit`, when the return value
+of the received loader's get_source() has a bad splitlines() method. Patch
+by Oren Milman.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -900,9 +900,7 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
         }
 
         /* Split the source into lines. */
-        source_list = PyObject_CallMethodObjArgs(source,
-                                                 PyId_splitlines.object,
-                                                 NULL);
+        source_list = PyUnicode_Splitlines(source, 0);
         Py_DECREF(source);
         if (!source_list)
             return NULL;


### PR DESCRIPTION
(cherry picked from commit 91fb0afe181986b48abfc6092dcca912b39de51d)


<!-- issue-number: bpo-31285 -->
https://bugs.python.org/issue31285
<!-- /issue-number -->
