### PR TITLE
[3.6] bpo-25532: Protect against infinite loops in inspect.unwrap() (GH-1717)

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -505,13 +505,16 @@ def unwrap(func, *, stop=None):
         def _is_wrapper(f):
             return hasattr(f, '__wrapped__') and not stop(f)
     f = func  # remember the original func for error reporting
-    memo = {id(f)} # Memoise by id to tolerate non-hashable objects
+    # Memoise by id to tolerate non-hashable objects, but store objects to
+    # ensure they aren't destroyed, which would allow their IDs to be reused.
+    memo = {id(f): f}
+    recursion_limit = sys.getrecursionlimit()
     while _is_wrapper(func):
         func = func.__wrapped__
         id_func = id(func)
-        if id_func in memo:
+        if (id_func in memo) or (len(memo) >= recursion_limit):
             raise ValueError('wrapper loop when unwrapping {!r}'.format(f))
-        memo.add(id_func)
+        memo[id_func] = func
     return func
 
 # -------------------------------------------------- source code extraction

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -3557,6 +3557,19 @@ class TestSignatureDefinitions(unittest.TestCase):
                 self.assertIsNone(obj.__text_signature__)
 
 
+class NTimesUnwrappable:
+    def __init__(self, n):
+        self.n = n
+        self._next = None
+
+    @property
+    def __wrapped__(self):
+        if self.n <= 0:
+            raise Exception("Unwrapped too many times")
+        if self._next is None:
+            self._next = NTimesUnwrappable(self.n - 1)
+        return self._next
+
 class TestUnwrap(unittest.TestCase):
 
     def test_unwrap_one(self):
@@ -3611,6 +3624,11 @@ class TestUnwrap(unittest.TestCase):
             __hash__ = None
             __wrapped__ = func
         self.assertIsNone(inspect.unwrap(C()))
+
+    def test_recursion_limit(self):
+        obj = NTimesUnwrappable(sys.getrecursionlimit() + 1)
+        with self.assertRaisesRegex(ValueError, 'wrapper loop'):
+            inspect.unwrap(obj)
 
 class TestMain(unittest.TestCase):
     def test_only_source(self):

--- a/Misc/NEWS.d/next/Library/2017-09-27-08-11-38.bpo-25532.ey4Yez.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-27-08-11-38.bpo-25532.ey4Yez.rst
@@ -1,0 +1,3 @@
+inspect.unwrap() will now only try to unwrap an object
+sys.getrecursionlimit() times, to protect against objects which create a new
+object on every attribute access.


### PR DESCRIPTION
Some objects (like test mocks) auto-generate new objects on
attribute access, which can lead to an infinite loop in
inspect.unwrap().

Ensuring references are retained to otherwise temporary objects
and capping the size of the memo dict turns this case into a
conventional exception instead..
(cherry picked from commit f9169ce6b48c7cc7cc62d9eb5e4ee1ac7066d14b)


<!-- issue-number: bpo-25532 -->
https://bugs.python.org/issue25532
<!-- /issue-number -->
