### PR TITLE
[2.7] bpo-25359: Add missed "goto error" after setting an exception. (GH-3712)

### DIFF
--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -907,6 +907,7 @@ textiowrapper_init(textio *self, PyObject *args, PyObject *kwds)
     else {
         PyErr_SetString(PyExc_IOError,
                         "could not determine default encoding");
+        goto error;
     }
 
     /* Check we have been asked for a real text encoding */


### PR DESCRIPTION
(cherry picked from commit d6238a76c655e0feb13478505220dc9049f1682f)


<!-- issue-number: bpo-25359 -->
https://bugs.python.org/issue25359
<!-- /issue-number -->
