### PR TITLE
[2.7] bpo-31311: Fix a SystemError and a crash in ctypes._CData.__set…

### DIFF
--- a/Lib/ctypes/test/test_parameters.py
+++ b/Lib/ctypes/test/test_parameters.py
@@ -1,5 +1,6 @@
 import unittest, sys
 from ctypes.test import need_symbol
+import test.support
 
 class SimpleTypesTestCase(unittest.TestCase):
 
@@ -174,6 +175,26 @@ class SimpleTypesTestCase(unittest.TestCase):
         # ArgumentError: argument 1: ValueError: 99
         self.assertRaises(ArgumentError, func, 99)
 
+
+    @test.support.cpython_only
+    def test_issue31311(self):
+        # __setstate__ should neither raise a SystemError nor crash in case
+        # of a bad __dict__.
+        from ctypes import Structure
+
+        class BadStruct(Structure):
+            @property
+            def __dict__(self):
+                pass
+        with self.assertRaises(TypeError):
+            BadStruct().__setstate__({}, b'foo')
+
+        class WorseStruct(Structure):
+            @property
+            def __dict__(self):
+                1/0
+        with self.assertRaises(ZeroDivisionError):
+            WorseStruct().__setstate__({}, b'foo')
 
 ################################################################
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-08-31-17-52-56.bpo-31311.bNE2l-.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-08-31-17-52-56.bpo-31311.bNE2l-.rst
@@ -1,0 +1,2 @@
+Fix a crash in the ``__setstate__()`` method of `ctypes._CData`, in case of
+a bad ``__dict__``. Patch by Oren Milman.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -2786,6 +2786,16 @@ PyCData_setstate(PyObject *_self, PyObject *args)
         len = self->b_size;
     memmove(self->b_ptr, data, len);
     mydict = PyObject_GetAttrString(_self, "__dict__");
+    if (mydict == NULL) {
+        return NULL;
+    }
+    if (!PyDict_Check(mydict)) {
+        PyErr_Format(PyExc_TypeError,
+                     "%.200s.__dict__ must be a dictionary, not %.200s",
+                     Py_TYPE(_self)->tp_name, Py_TYPE(mydict)->tp_name);
+        Py_DECREF(mydict);
+        return NULL;
+    }
     res = PyDict_Update(mydict, dict);
     Py_DECREF(mydict);
     if (res == -1)


### PR DESCRIPTION
…state__(), in case of a bad __dict__. (GH-3254).

(cherry picked from commit 57c2561c8c5663aef55b00e3f29cba575ff36ccd)


<!-- issue-number: bpo-31311 -->
https://bugs.python.org/issue31311
<!-- /issue-number -->
