### PR TITLE
bpo-31602: Fix an assertion failure in zipimporter.get_source() in case of a bad zlib.decompress()

### DIFF
--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -680,7 +680,7 @@ class CompressedZipImportTestCase(UncompressedZipImportTestCase):
         try:
             name = 'bar.py'
             data = b'spam'
-            z.writestr(name, data, self.compression)
+            z.writestr(name, data, ZIP_DEFLATED)
             z.close()
             zi = zipimport.zipimporter(TEMP_ZIP)
             with support.swap_attr(zlib, 'decompress', bad_decompress):

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -678,9 +678,7 @@ class CompressedZipImportTestCase(UncompressedZipImportTestCase):
             return None
         with ZipFile(TEMP_ZIP, 'w') as zip_file:
             self.addCleanup(support.unlink, TEMP_ZIP)
-            name = 'bar.py'
-            data = b'spam'
-            zip_file.writestr(name, data, ZIP_DEFLATED)
+            zip_file.writestr('bar.py', b'print("hello world")', ZIP_DEFLATED)
         zi = zipimport.zipimporter(TEMP_ZIP)
         with support.swap_attr(zlib, 'decompress', bad_decompress):
             self.assertRaises(TypeError, zi.get_source, 'bar')

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -669,6 +669,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
 class CompressedZipImportTestCase(UncompressedZipImportTestCase):
     compression = ZIP_DEFLATED
 
+    @support.cpython_only
     def test_issue31602(self):
         # There shouldn't be an assertion failure in zipimporter.get_source()
         # in case of a bad zlib.decompress().

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -17,6 +17,10 @@ import doctest
 import inspect
 import io
 from traceback import extract_tb, extract_stack, print_tb
+try:
+    import zlib
+except ImportError:
+    zlib = None
 
 test_src = """\
 def get_name():
@@ -673,7 +677,6 @@ class CompressedZipImportTestCase(UncompressedZipImportTestCase):
     def test_issue31602(self):
         # There shouldn't be an assertion failure in zipimporter.get_source()
         # in case of a bad zlib.decompress().
-        import zlib
         def bad_decompress(*args):
             return None
         with ZipFile(TEMP_ZIP, 'w') as zip_file:

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -676,18 +676,14 @@ class CompressedZipImportTestCase(UncompressedZipImportTestCase):
         import zlib
         def bad_decompress(*args):
             return None
-        z = ZipFile(TEMP_ZIP, 'w')
-        try:
+        with ZipFile(TEMP_ZIP, 'w') as zip_file:
+            self.addCleanup(support.unlink, TEMP_ZIP)
             name = 'bar.py'
             data = b'spam'
-            z.writestr(name, data, ZIP_DEFLATED)
-            z.close()
-            zi = zipimport.zipimporter(TEMP_ZIP)
-            with support.swap_attr(zlib, 'decompress', bad_decompress):
-                self.assertRaises(TypeError, zi.get_source, 'bar')
-        finally:
-            z.close()
-            os.remove(TEMP_ZIP)
+            zip_file.writestr(name, data, ZIP_DEFLATED)
+        zi = zipimport.zipimporter(TEMP_ZIP)
+        with support.swap_attr(zlib, 'decompress', bad_decompress):
+            self.assertRaises(TypeError, zi.get_source, 'bar')
 
 
 class BadFileZipImportTestCase(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-27-09-30-03.bpo-31602.MtgLCn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-27-09-30-03.bpo-31602.MtgLCn.rst
@@ -1,2 +1,2 @@
-Fix an assertion failure in zipimporter.get_source() in case of a bad
-zlib.decompress(). Patch by Oren Milman.
+Fix an assertion failure in `zipimporter.get_source()` in case of a bad
+`zlib.decompress()`. Patch by Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-27-09-30-03.bpo-31602.MtgLCn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-27-09-30-03.bpo-31602.MtgLCn.rst
@@ -1,0 +1,2 @@
+Fix an assertion failure in zipimporter.get_source() in case of a bad
+zlib.decompress(). Patch by Oren Milman.

--- a/Modules/zipimport.c
+++ b/Modules/zipimport.c
@@ -1236,6 +1236,14 @@ get_data(PyObject *archive, PyObject *toc_entry)
     data = PyObject_CallFunction(decompress, "Oi", raw_data, -15);
     Py_DECREF(decompress);
     Py_DECREF(raw_data);
+    if (data != NULL && !PyBytes_Check(data)) {
+        PyErr_Format(PyExc_TypeError,
+                     "zlib.decompress() must return a bytes object, not "
+                     "%.200s",
+                     Py_TYPE(data)->tp_name);
+        Py_DECREF(data);
+        return NULL;
+    }
     return data;
 
 eof_error:


### PR DESCRIPTION
- in `zipimport.c`: add a check whether `zlib.decompress()` returned a bytes object.
- in `test_zipimport.py`: add a test to verify that the assertion failure is no more.

<!-- issue-number: bpo-31602 -->
https://bugs.python.org/issue31602
<!-- /issue-number -->
