### PR TITLE
[2.7] bpo-31593: test_socketserver waits child processes

### DIFF
--- a/Lib/test/test_socketserver.py
+++ b/Lib/test/test_socketserver.py
@@ -69,6 +69,20 @@ def simple_subprocess(testcase):
     testcase.assertEqual(72 << 8, status)
 
 
+def close_server(server):
+    server.server_close()
+
+    if hasattr(server, 'active_children'):
+        # ForkingMixIn: Manually reap all child processes, since server_close()
+        # calls waitpid() in non-blocking mode using the WNOHANG flag.
+        for pid in server.active_children.copy():
+            try:
+                os.waitpid(pid, 0)
+            except ChildProcessError:
+                pass
+        server.active_children.clear()
+
+
 @unittest.skipUnless(threading, 'Threading required for this test.')
 class SocketServerTest(unittest.TestCase):
     """Test all socket servers."""
@@ -118,7 +132,7 @@ class SocketServerTest(unittest.TestCase):
         class MyServer(svrcls):
             def handle_error(self, request, client_address):
                 self.close_request(request)
-                self.server_close()
+                close_server(self)
                 raise
 
         class MyHandler(hdlrbase):
@@ -158,7 +172,7 @@ class SocketServerTest(unittest.TestCase):
         if verbose: print "waiting for server"
         server.shutdown()
         t.join()
-        server.server_close()
+        close_server(server)
         self.assertRaises(socket.error, server.socket.fileno)
         if verbose: print "done"
 
@@ -314,6 +328,7 @@ class SocketServerTest(unittest.TestCase):
             s.shutdown()
         for t, s in threads:
             t.join()
+            close_server(s)
 
     def test_tcpserver_bind_leak(self):
         # Issue #22435: the server socket wouldn't be closed if bind()/listen()
@@ -347,7 +362,7 @@ class MiscTestCase(unittest.TestCase):
         s.close()
         server.handle_request()
         self.assertEqual(server.shutdown_called, 1)
-        server.server_close()
+        close_server(server)
 
 
 def test_main():


### PR DESCRIPTION


<!-- issue-number: bpo-31593 -->
https://bugs.python.org/issue31593
<!-- /issue-number -->
