### PR TITLE
bpo-31607: Add the listsize command for Pdb

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -412,6 +412,13 @@ by the local file.
 
    .. versionadded:: 3.2
 
+.. pdbcommand:: listsize [count]
+
+   If *count* is present, make the :pdbcmd:`list` command display *count* source
+   lines, otherwise display the number of lines that :pdbcmd:`list` prints.
+
+   .. versionadded:: 3.7
+
 .. pdbcommand:: a(rgs)
 
    Print the argument list of the current function.

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -133,6 +133,9 @@ class _rstr(str):
 # line_prefix = ': '    # Use this to get the old situation back
 line_prefix = '\n-> '   # Probably a better default
 
+# Number of lines that `list` prints
+DEFAULT_LIST_SIZE = 10
+
 class Pdb(bdb.Bdb, cmd.Cmd):
 
     _previous_sigint_handler = None
@@ -149,6 +152,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.mainpyfile = ''
         self._wait_for_mainpyfile = False
         self.tb_lineno = {}
+        self.list_size = DEFAULT_LIST_SIZE
         # Try to load readline if it exists
         try:
             import readline
@@ -1191,6 +1195,21 @@ class Pdb(bdb.Bdb, cmd.Cmd):
     complete_p = _complete_expression
     complete_pp = _complete_expression
 
+    def do_listsize(self, arg):
+        """listsize [count]
+
+        Make the `list` command display `count` source lines.
+        Default value is 10.
+        """
+
+        if not arg:
+            self.message(f'List size: {self.list_size}')
+        elif arg.isdigit():
+            self.list_size = int(arg)
+            self.message(f'List size: {self.list_size}')
+        else:
+            self.error('count number expected')
+
     def do_list(self, arg):
         """l(ist) [first [,last] | .]
 
@@ -1228,7 +1247,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         else:
             first = self.lineno + 1
         if last is None:
-            last = first + 10
+            last = first + self.list_size
         filename = self.curframe.f_code.co_filename
         breaklist = self.get_file_breaks(filename)
         try:

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -313,16 +313,19 @@ def test_list_commands():
     ...     ret = test_function_2('baz')
 
     >>> with PdbTestInput([  # doctest: +ELLIPSIS, +NORMALIZE_WHITESPACE
-    ...     'list',      # list first function
-    ...     'step',      # step into second function
-    ...     'list',      # list second function
-    ...     'list',      # continue listing to EOF
-    ...     'list 1,3',  # list specific lines
-    ...     'list x',    # invalid argument
-    ...     'next',      # step to import
-    ...     'next',      # step over import
-    ...     'step',      # step into do_nothing
-    ...     'longlist',  # list all lines
+    ...     'list',       # list first function
+    ...     'step',       # step into second function
+    ...     'listsize',   # list the printed line
+    ...     'listsize 5', # set the list size
+    ...     'listsize',   # list the printed line
+    ...     'list',       # list second function
+    ...     'list',       # continue listing to EOF
+    ...     'list 1,3',   # list specific lines
+    ...     'list x',     # invalid argument
+    ...     'next',       # step to import
+    ...     'next',       # step over import
+    ...     'step',       # step into do_nothing
+    ...     'longlist',   # list all lines
     ...     'source do_something',  # list all lines of function
     ...     'source fooxxx',        # something that doesn't exit
     ...     'continue',
@@ -339,6 +342,12 @@ def test_list_commands():
     --Call--
     > <doctest test.test_pdb.test_list_commands[0]>(1)test_function_2()
     -> def test_function_2(foo):
+    (Pdb) listsize
+    List size: 10
+    (Pdb) listsize 5
+    List size: 5
+    (Pdb) listsize
+    List size: 5
     (Pdb) list
       1  ->     def test_function_2(foo):
       2             import test.test_pdb
@@ -346,17 +355,13 @@ def test_list_commands():
       4             'some...'
       5             'more...'
       6             'code...'
+    (Pdb) list
       7             'to...'
       8             'make...'
       9             'a...'
      10             'long...'
      11             'listing...'
-    (Pdb) list
      12             'useful...'
-     13             '...'
-     14             '...'
-     15             return foo
-    [EOF]
     (Pdb) list 1,3
       1  ->     def test_function_2(foo):
       2             import test.test_pdb

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-27-12-29-43.bpo-31607.0KvteI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-27-12-29-43.bpo-31607.0KvteI.rst
@@ -1,0 +1,2 @@
+Add a new command *listsize* and allow to change the number of lines to
+print with the :pdbcmd:`list` command.


### PR DESCRIPTION
Add the command listsize, this commands allow to change the default
number of lines that the list command prints.


<!-- issue-number: bpo-31607 -->
https://bugs.python.org/issue31607
<!-- /issue-number -->
