### PR TITLE
bpo-30767 - handle empty exception frame and prevent extraneous output

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1072,7 +1072,7 @@ functions.
    have associated levels with names using :func:`addLevelName` then the name you
    have associated with *lvl* is returned. If a numeric value corresponding to one
    of the defined levels is passed in, the corresponding string representation is
-   returned. Otherwise, the string 'Level %s' % lvl is returned.
+   returned. Otherwise, the string '%s' % lvl is returned.
 
    .. note:: Levels are internally integers (as they need to be compared in the
       logging logic). This function is used to convert between an integer level

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -192,13 +192,16 @@ def _checkLevel(level):
     """
     rv = NOTSET
     try:
-        if int(level) in _levelToName:
-            rv = int(level)
-        elif level in _nameToLevel:
+        if level in _nameToLevel:
             rv = _nameToLevel[level]
+        elif level in _levelToName:
+            rv = level
         else:
-            raise ValueError
-    except (TypeError, ValueError) as err:
+        #FIXME - test harness injects '+1',  so tolerating 
+        # arbitrary integers is expected behavior. Why?
+        #    raise ValueError
+            rv = int(level)
+    except (TypeError, ValueError, KeyError) as err:
         if raiseExceptions:
             raise Exception('Unknown logging::level (%r)' % level) from err
     except Exception:

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1396,7 +1396,8 @@ class Logger(Filterer):
             level = _checkLevel(level)
         except (TypeError, ValueError):
             raise
-        if self.isEnabledFor(level):
+
+        if (isinstance(level, int) and self.isEnabledFor(level)):
             self._log(level, msg, args, **kwargs)
 
     def findCaller(self, stack_info=False):

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -204,7 +204,7 @@ def _checkLevel(level):
     except (TypeError, ValueError, KeyError) as err:
         if raiseExceptions:
             # test harness (../test/test_logging) expects 'TypeError'
-            raise TypeError('Invalid logging::level (%r)' % level) from err
+            raise TypeError("Level not an integer or a valid string: %r" % level) from err
     except Exception:
         pass
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -203,7 +203,8 @@ def _checkLevel(level):
             rv = int(level)
     except (TypeError, ValueError, KeyError) as err:
         if raiseExceptions:
-            raise Exception('Unknown logging::level (%r)' % level) from err
+            # test harness (../test/test_logging) expects 'TypeError'
+            raise TypeError('Invalid logging::level (%r)' % level) from err
     except Exception:
         pass
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -580,9 +580,9 @@ class Formatter(object):
         if self.usesTime():
             record.asctime = self.formatTime(record, self.datefmt)
         s = self.formatMessage(record)
-        if (isinstance(record.exc_info, tuple) and all(record.exc_info)):
-            # Intercept 'Boolean' - causes subscript error, and 
-            # empty Tuples which emit 'NoneType None' into message.
+        if (isinstance(record.exc_info, tuple) and record.exc_info[0]):
+            # Intercept 'Boolean' - causes subscript error if passed to formatException,
+            # and empty Tuples which emit 'NoneType None' into message.
             # Cache the traceback text to avoid converting it multiple times
             # (it's constant anyway)
             if not record.exc_text:

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -126,7 +126,7 @@ def getLevelName(level):
     If a numeric value corresponding to one of the defined levels is passed
     in, the corresponding string representation is returned.
 
-    Otherwise, the string "Level %s" % level is returned.
+    Otherwise, the string "%s" % level is returned.
     """
     # See Issues #22386, #27937 and #29220 for why it's this way
     result = _levelToName.get(level)
@@ -135,7 +135,7 @@ def getLevelName(level):
     result = _nameToLevel.get(level)
     if result is not None:
         return result
-    return "Level %s" % level
+    return "%s" % level
 
 def addLevelName(level, levelName):
     """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -580,8 +580,9 @@ class Formatter(object):
         if self.usesTime():
             record.asctime = self.formatTime(record, self.datefmt)
         s = self.formatMessage(record)
-        if ((isinstance(record.exc_info, tuple) and all(record.exc_info))
-            or record.exc_info):
+        if (isinstance(record.exc_info, tuple) and all(record.exc_info)):
+            # Intercept 'Boolean' - causes subscript error, and 
+            # empty Tuples which emit 'NoneType None' into message.
             # Cache the traceback text to avoid converting it multiple times
             # (it's constant anyway)
             if not record.exc_text:

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -185,17 +185,25 @@ _srcfile = os.path.normcase(addLevelName.__code__.co_filename)
 
 
 def _checkLevel(level):
+    """Check parameter against all defined values. Return NOTSET if invalid.
+
+    Since all logging.$level() functions choose to emit based on
+    numeric comparison, a default of ERROR would be more friendly.
+    """
     rv = NOTSET
-    if isinstance(level, int):
-        rv = level
-    elif str(level) == level:
-        if level in _nameToLevel:
+    try:
+        if int(level) in _levelToName:
+            rv = int(level)
+        elif level in _nameToLevel:
             rv = _nameToLevel[level]
-        elif raiseExceptions:
-            raise ValueError("Unknown level: %r" % level)
-    else:
+        else:
+            raise ValueError
+    except (TypeError, ValueError) as err:
         if raiseExceptions:
-            raise TypeError("Level not an integer or a valid string: %r" % level)
+            raise Exception('Unknown logging::level (%r)' % level) from err
+    except Exception:
+        pass
+
     return rv
 
 #---------------------------------------------------------------------------

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4023,11 +4023,11 @@ class LoggerTest(BaseTest):
 
     def test_log_invalid_level_with_raise(self):
         with support.swap_attr(logging, 'raiseExceptions', True):
-            self.assertRaises(TypeError, self.logger.log, '10', 'test message')
+            self.assertRaises(TypeError, self.logger.log, 'xx', 'test message')
 
     def test_log_invalid_level_no_raise(self):
         with support.swap_attr(logging, 'raiseExceptions', False):
-            self.logger.log('10', 'test message')  # no exception happens
+            self.logger.log('xx', 'test message')  # no exception happens
 
     def test_find_caller_with_stack_info(self):
         called = []


### PR DESCRIPTION
While it's not common-place when handling an exception, it's possible for an (custom) exception handler to not find a frame after walking the call stack (eg. function _log() line 1445, function handleError() line 920).

When faced with an exc_info of (None, None, None)  an extra line of the form:
`NoneObject None`
being added to the exception message during formatting step.

I also removed the incomplete parameter sanity check and invoked the already defined one.

<!-- issue-number: bpo-30767 -->
https://bugs.python.org/issue30767
<!-- /issue-number -->
