### PR TITLE
bpo-31618: Move opcode tracing to occur after the possible update to f_lineno.

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4454,10 +4454,6 @@ maybe_call_line_trace(Py_tracefunc func, PyObject *obj,
         *instr_lb = bounds.ap_lower;
         *instr_ub = bounds.ap_upper;
     }
-    /* Always emit an opcode event if we're tracing all opcodes. */
-    if (frame->f_trace_opcodes) {
-        result = call_trace(func, obj, tstate, frame, PyTrace_OPCODE, Py_None);
-    }
     /* If the last instruction falls at the start of a line or if it
        represents a jump backwards, update the frame's line number and
        then call the trace function if we're tracing source lines.
@@ -4467,6 +4463,10 @@ maybe_call_line_trace(Py_tracefunc func, PyObject *obj,
         if (frame->f_trace_lines) {
             result = call_trace(func, obj, tstate, frame, PyTrace_LINE, Py_None);
         }
+    }
+    /* Always emit an opcode event if we're tracing all opcodes. */
+    if (frame->f_trace_opcodes) {
+        result = call_trace(func, obj, tstate, frame, PyTrace_OPCODE, Py_None);
     }
     *instr_prev = frame->f_lasti;
     return result;


### PR DESCRIPTION
This patch moves the new opcode tracing added in commit 5a8516701f5140c8c989c40e261a4f4e20e8af86 to happen after frame->f_lineno is updated. With this patch, when both f_trace_lines and f_trace_opcodes are enabled the trace function will see the same line number for both the 'line' and 'opcode' events.

A side effect of this patch is that the order of event emission has been switched; 'line' now happens before 'opcode'. Maintaining the current order would require more elaborate logic.

<!-- issue-number: bpo-31618 -->
https://bugs.python.org/issue31618
<!-- /issue-number -->
