### PR TITLE
bpo-29729: uuid.UUID now accepts bytes-like object

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -76,8 +76,8 @@ which relays any information about the UUID's safety, using this enumeration:
    represent the UUID.
 
    .. versionchanged:: 3.7
-      *bytes* and *bytes_le* parameters now accept any bytes-like objects,
-      bytearray and memoryview for example, not only :class:`bytes`.
+      *bytes* and *bytes_le* parameters now accept any bytes-like objects of 16
+      bytes, bytearray and memoryview for example, not only :class:`bytes`.
 
 :class:`UUID` instances have these read-only attributes:
 

--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -75,6 +75,10 @@ which relays any information about the UUID's safety, using this enumeration:
    ``12345678-1234-5678-1234-567812345678`` where the 32 hexadecimal digits
    represent the UUID.
 
+   .. versionchanged:: 3.7
+      *bytes* and *bytes_le* parameters now accept any bytes-like objects,
+      bytearray and memoryview for example, not only :class:`bytes`.
+
 :class:`UUID` instances have these read-only attributes:
 
 .. attribute:: UUID.bytes

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -225,6 +225,7 @@ class BaseTestUUID:
         badvalue(lambda: self.uuid.UUID(bytes=b'abc'))
         badvalue(lambda: self.uuid.UUID(bytes=b'\0'*15))
         badvalue(lambda: self.uuid.UUID(bytes=b'\0'*17))
+        badtype(lambda: self.uuid.UUID(bytes=16))
 
         # Badly formed bytes_le.
         badtype(lambda: self.uuid.UUID(bytes_le='unicode'))
@@ -232,6 +233,7 @@ class BaseTestUUID:
         badvalue(lambda: self.uuid.UUID(bytes_le=b'abc'))
         badvalue(lambda: self.uuid.UUID(bytes_le=b'\0'*15))
         badvalue(lambda: self.uuid.UUID(bytes_le=b'\0'*17))
+        badtype(lambda: self.uuid.UUID(bytes_le=16))
 
         # Badly formed fields.
         badvalue(lambda: self.uuid.UUID(fields=(1,)))

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -213,14 +213,18 @@ class TestUUID(unittest.TestCase):
         badvalue(lambda: uuid.UUID('123456781234567812345678z2345678'))
 
         # Badly formed bytes.
-        badvalue(lambda: uuid.UUID(bytes='abc'))
-        badvalue(lambda: uuid.UUID(bytes='\0'*15))
-        badvalue(lambda: uuid.UUID(bytes='\0'*17))
+        badtype(lambda: uuid.UUID(bytes='unicode'))
+        badtype(lambda: uuid.UUID(bytes='u'*16))
+        badvalue(lambda: uuid.UUID(bytes=b'abc'))
+        badvalue(lambda: uuid.UUID(bytes=b'\0'*15))
+        badvalue(lambda: uuid.UUID(bytes=b'\0'*17))
 
         # Badly formed bytes_le.
-        badvalue(lambda: uuid.UUID(bytes_le='abc'))
-        badvalue(lambda: uuid.UUID(bytes_le='\0'*15))
-        badvalue(lambda: uuid.UUID(bytes_le='\0'*17))
+        badtype(lambda: uuid.UUID(bytes_le='unicode'))
+        badtype(lambda: uuid.UUID(bytes_le='u'*16))
+        badvalue(lambda: uuid.UUID(bytes_le=b'abc'))
+        badvalue(lambda: uuid.UUID(bytes_le=b'\0'*15))
+        badvalue(lambda: uuid.UUID(bytes_le=b'\0'*17))
 
         # Badly formed fields.
         badvalue(lambda: uuid.UUID(fields=(1,)))
@@ -458,8 +462,12 @@ class TestUUID(unittest.TestCase):
 
     def test_bytes_like(self):
         u = uuid.uuid4()
+
         self.assertEqual(uuid.UUID(bytes=memoryview(u.bytes)), u)
         self.assertEqual(uuid.UUID(bytes=bytearray(u.bytes)), u)
+
+        self.assertEqual(uuid.UUID(bytes_le=memoryview(u.bytes_le)), u)
+        self.assertEqual(uuid.UUID(bytes_le=bytearray(u.bytes_le)), u)
 
 
 class TestInternals(unittest.TestCase):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -456,6 +456,11 @@ class TestUUID(unittest.TestCase):
 
             self.assertNotEqual(parent_value, child_value)
 
+    def test_bytes_like(self):
+        u = uuid.uuid4()
+        self.assertEqual(uuid.UUID(bytes=memoryview(u.bytes)), u)
+        self.assertEqual(uuid.UUID(bytes=bytearray(u.bytes)), u)
+
 
 class TestInternals(unittest.TestCase):
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -166,7 +166,6 @@ class UUID:
         if bytes is not None:
             if len(bytes) != 16:
                 raise ValueError('bytes is not a 16-char string')
-            assert isinstance(bytes, bytes_), repr(bytes)
             int = int_.from_bytes(bytes, byteorder='big')
         if fields is not None:
             if len(fields) != 6:

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -159,14 +159,18 @@ class UUID:
                 raise ValueError('badly formed hexadecimal UUID string')
             int = int_(hex, 16)
         if bytes_le is not None:
+            if not isinstance(bytes_le, (bytes_, bytearray)):
+                bytes_le = bytes_(bytes_le)
             if len(bytes_le) != 16:
                 raise ValueError('bytes_le is not a 16-char string')
             bytes = (bytes_le[4-1::-1] + bytes_le[6-1:4-1:-1] +
                      bytes_le[8-1:6-1:-1] + bytes_le[8:])
         if bytes is not None:
+            int = int_.from_bytes(bytes, byteorder='big')
+            # test length after the conversion to raise a TypeError exception
+            # if 'bytes' type is str even if 'bytes' length is not 16
             if len(bytes) != 16:
                 raise ValueError('bytes is not a 16-char string')
-            int = int_.from_bytes(bytes, byteorder='big')
         if fields is not None:
             if len(fields) != 6:
                 raise ValueError('fields is not a 6-tuple')

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -160,7 +160,6 @@ class UUID:
                 raise ValueError('badly formed hexadecimal UUID string')
             int = int_(hex, 16)
         if bytes_le is not None:
-            # Don't cast int to bytes to get a TypeError above
             if not isinstance(bytes_le, (bytes_, bytearray, int_)):
                 bytes_le = bytes_(bytes_le)
             if len(bytes_le) != 16:

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -160,7 +160,8 @@ class UUID:
                 raise ValueError('badly formed hexadecimal UUID string')
             int = int_(hex, 16)
         if bytes_le is not None:
-            if not isinstance(bytes_le, (bytes_, bytearray)):
+            # Don't cast int to bytes to get a TypeError above
+            if not isinstance(bytes_le, (bytes_, bytearray, int_)):
                 bytes_le = bytes_(bytes_le)
             if len(bytes_le) != 16:
                 raise ValueError('bytes_le is not a 16-char string')

--- a/Misc/NEWS.d/next/Library/2017-09-28-16-21-13.bpo-29729.skDkJA.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-28-16-21-13.bpo-29729.skDkJA.rst
@@ -1,3 +1,3 @@
-uuid.UUID now accepts bytes-like object. The constructor doesn't require the
-'bytes' and 'bytes_le' arguments to be an instance of bytes: accept bytes-like
-types, bytearray and memoryview for example.
+uuid.UUID now accepts bytes-like object of 16 bytes. The constructor doesn't
+require the 'bytes' and 'bytes_le' arguments to be an instance of bytes: accept
+bytes-like types, bytearray and memoryview for example.

--- a/Misc/NEWS.d/next/Library/2017-09-28-16-21-13.bpo-29729.skDkJA.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-28-16-21-13.bpo-29729.skDkJA.rst
@@ -1,3 +1,3 @@
 uuid.UUID now accepts bytes-like object. The constructor doesn't require the
-'bytes' argument to be an instance of bytes: accept bytes-like types,
-bytearray and memoryview for example.
+'bytes' and 'bytes_le' arguments to be an instance of bytes: accept bytes-like
+types, bytearray and memoryview for example.

--- a/Misc/NEWS.d/next/Library/2017-09-28-16-21-13.bpo-29729.skDkJA.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-28-16-21-13.bpo-29729.skDkJA.rst
@@ -1,0 +1,3 @@
+uuid.UUID now accepts bytes-like object. The constructor doesn't require the
+'bytes' argument to be an instance of bytes: accept bytes-like types,
+bytearray and memoryview for example.


### PR DESCRIPTION
uuid.UUID doesn't require the 'bytes' argument to be an instance of
bytes: accept bytes-like types, bytearray and memoryview for example.

<!-- issue-number: bpo-29729 -->
https://bugs.python.org/issue29729
<!-- /issue-number -->
