### PR TITLE
bpo-31285: Remove splitlines identifier from Python/_warnings.c (forgot to remove it in #3219)

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -859,7 +859,6 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
 
     if (module_globals) {
         _Py_IDENTIFIER(get_source);
-        _Py_IDENTIFIER(splitlines);
         PyObject *tmp;
         PyObject *loader;
         PyObject *module_name;
@@ -869,8 +868,6 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
         PyObject *returned;
 
         if ((tmp = _PyUnicode_FromId(&PyId_get_source)) == NULL)
-            return NULL;
-        if ((tmp = _PyUnicode_FromId(&PyId_splitlines)) == NULL)
             return NULL;
 
         /* Check/get the requisite pieces needed for the loader. */


### PR DESCRIPTION
#3219 removed the only use of the splitlines identifier in `Python/_warnings.c`, so it should be completely removed.

<!-- issue-number: bpo-31285 -->
https://bugs.python.org/issue31285
<!-- /issue-number -->
