### PR TITLE
[2.7] bpo-31285: fix an assertion failure and a SystemError in warnings.warn_explicit (GH-3219)

### DIFF
--- a/Lib/test/test_warnings.py
+++ b/Lib/test/test_warnings.py
@@ -584,6 +584,29 @@ class _WarningsTests(BaseTest):
         self.assertNotIn(b'Warning!', stderr)
         self.assertNotIn(b'Error', stderr)
 
+    def test_issue31285(self):
+        # warn_explicit() shouldn't raise a SystemError in case the return
+        # value of get_source() has a bad splitlines() method.
+        def get_bad_loader(splitlines_ret_val):
+            class BadLoader:
+                def get_source(self, fullname):
+                    class BadSource(str):
+                        def splitlines(self):
+                            return splitlines_ret_val
+                    return BadSource('spam')
+            return BadLoader()
+
+        wmod = self.module
+        with original_warnings.catch_warnings(module=wmod):
+            wmod.filterwarnings('default', category=UserWarning)
+
+            with test_support.captured_stderr() as stderr:
+                wmod.warn_explicit(
+                    'foo', UserWarning, 'bar', 1,
+                    module_globals={'__loader__': get_bad_loader(42),
+                                    '__name__': 'foobar'})
+            self.assertIn('UserWarning: foo', stderr.getvalue())
+
     @test_support.cpython_only
     def test_issue31411(self):
         # warn_explicit() shouldn't raise a SystemError in case

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -644,7 +644,6 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
 
     if (module_globals) {
         static PyObject *get_source_name = NULL;
-        static PyObject *splitlines_name = NULL;
         PyObject *loader;
         PyObject *module_name;
         PyObject *source;
@@ -655,11 +654,6 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
         if (get_source_name == NULL) {
             get_source_name = PyString_InternFromString("get_source");
             if (!get_source_name)
-                return NULL;
-        }
-        if (splitlines_name == NULL) {
-            splitlines_name = PyString_InternFromString("splitlines");
-            if (!splitlines_name)
                 return NULL;
         }
 
@@ -684,8 +678,7 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
         }
 
         /* Split the source into lines. */
-        source_list = PyObject_CallMethodObjArgs(source, splitlines_name,
-                                                    NULL);
+        source_list = PyUnicode_Splitlines(source, 0);
         Py_DECREF(source);
         if (!source_list)
             return NULL;


### PR DESCRIPTION
This is a backport of #3219 , but actually also a backport of #3803 , which is a cleanup after #3219 .

Also, i removed the test that verifies that the assertion failure is no more, because in 2.7, the code assumes that the value returned by `splitlines()` is a string, and uses it without asserting it is a string, in such a way that causing some error (for testing purposes) is not simple (at least i didn't find a simple way).
ISTM that the first test is good enough to verify that the `splitlines()` attribute is ignored, and `PyUnicode_Splitlines()` is used directly.


<!-- issue-number: bpo-31285 -->
https://bugs.python.org/issue31285
<!-- /issue-number -->
