### PR TITLE
bpo-31158: Fix nondeterministic read in test_pty

### DIFF
--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -31,8 +31,8 @@ else:
 # Beware, on my Linux system, if I put 'foo\n' into a terminal fd, I get
 # back 'foo\r\n' at the other end.  The behavior depends on the termios
 # setting.  The newline translation may be OS-specific.  To make the
-# test suite deterministic and OS-independent, _os_readline and
-# normalize_output can be used.
+# test suite deterministic and OS-independent, the functions _readline
+# and normalize_output can be used.
 
 def normalize_output(data):
     # Some operating systems do conversions on newline.  We could possibly fix


### PR DESCRIPTION
Sometimes, the test suite fails in test_pty.test_basic()

https://bugs.python.org/issue31158

Acks to @haypo !!


<!-- issue-number: bpo-31158 -->
https://bugs.python.org/issue31158
<!-- /issue-number -->
