### PR TITLE
bpo-35095: Add append_bytes() and append_text() to Path class

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1176,6 +1176,25 @@ class Path(PurePath):
                             data.__class__.__name__)
         with self.open(mode='w', encoding=encoding, errors=errors) as f:
             return f.write(data)
+    
+    def append_bytes(self, data):
+        """
+        Open the file in bytes mode, write to it at its end, and close the file.
+        """
+        # type-check for the buffer interface before truncating the file
+        view = memoryview(data)
+        with self.open(mode='ab') as f:
+            return f.write(view)
+    
+    def append_text(self, data, encoding=None, errors=None):
+        """
+        Open the file in bytes mode, write to it at its end, and close the file.
+        """
+        if not isinstance(data, str):
+            raise TypeError('data must be str, not %s' %
+                            data.__class__.__name__)
+        with self.open(mode='a', encoding=encoding, errors=errors) as f:
+            return f.write(data)
 
     def touch(self, mode=0o666, exist_ok=True):
         """


### PR DESCRIPTION
Having `read_bytes()`, `read_text()`, `write_bytes()` and `write_text`(), one would expect to find `append_bytes()` and `append_text()` methods in the Path class.

<!-- issue-number: [bpo-35095](https://bugs.python.org/issue35095) -->
https://bugs.python.org/issue35095
<!-- /issue-number -->
