### PR TITLE
bpo-31620: asyncio.Queue leaks memory if the queue is empty and the consumers poll it frequently

### DIFF
--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -167,6 +167,12 @@ class Queue:
                 yield from getter
             except:
                 getter.cancel()  # Just in case getter is not done yet.
+
+                try:
+                    self._getters.remove(getter)
+                except ValueError:
+                    pass
+
                 if not self.empty() and not getter.cancelled():
                     # We were woken up by put_nowait(), but can't take
                     # the call.  Wake up the next in line.

--- a/Misc/NEWS.d/next/Library/2017-10-06-04-35-31.bpo-31620.gksLA1.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-06-04-35-31.bpo-31620.gksLA1.rst
@@ -1,0 +1,2 @@
+an empty asyncio.Queue now doesn't leak memory when queue.get pollers
+timeout


### PR DESCRIPTION


<!-- issue-number: bpo-31620 -->
https://bugs.python.org/issue31620
<!-- /issue-number -->
