### PR TITLE
bpo-31619 Compare only the number of digits in the check for overflow

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -2059,7 +2059,7 @@ long_from_binary_base(const char **str, int base, PyLongObject **res)
     *str = p;
     /* n <- # of Python digits needed, = ceiling(n/PyLong_SHIFT). */
     n = digits * bits_per_char + PyLong_SHIFT - 1;
-    if (n / bits_per_char < p - start) {
+    if (n / bits_per_char < digits) {
         PyErr_SetString(PyExc_ValueError,
                         "int string too large to convert");
         *res = NULL;


### PR DESCRIPTION
The issue was because the comparison was done between the number of digits and the length of the string. When the string can have chars other than digits, this comparison doesn't hold. Compare digits to digits.

Issue: bpo-31619

<!-- issue-number: bpo-31619 -->
https://bugs.python.org/issue31619
<!-- /issue-number -->
