### PR TITLE
bpo-31632: (asyncio) remove local reference to app protocol in _SSLProtocolTransport

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -293,11 +293,10 @@ class _SSLPipe(object):
 class _SSLProtocolTransport(transports._FlowControlMixin,
                             transports.Transport):
 
-    def __init__(self, loop, ssl_protocol, app_protocol):
+    def __init__(self, loop, ssl_protocol):
         self._loop = loop
         # SSLProtocol instance
         self._ssl_protocol = ssl_protocol
-        self._app_protocol = app_protocol
         self._closed = False
 
     def get_extra_info(self, name, default=None):
@@ -305,10 +304,10 @@ class _SSLProtocolTransport(transports._FlowControlMixin,
         return self._ssl_protocol._get_extra_info(name, default)
 
     def set_protocol(self, protocol):
-        self._app_protocol = protocol
+        self._ssl_protocol._app_protocol = protocol
 
     def get_protocol(self):
-        return self._app_protocol
+        return self._ssl_protocol._app_protocol
 
     def is_closing(self):
         return self._closed
@@ -431,8 +430,7 @@ class SSLProtocol(protocols.Protocol):
         self._waiter = waiter
         self._loop = loop
         self._app_protocol = app_protocol
-        self._app_transport = _SSLProtocolTransport(self._loop,
-                                                    self, self._app_protocol)
+        self._app_transport = _SSLProtocolTransport(self._loop, self)
         # _SSLPipe instance (None until the connection is made)
         self._sslpipe = None
         self._session_established = False

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -121,6 +121,14 @@ class SslProtoHandshakeTests(test_utils.TestCase):
         ssl_proto.connection_lost(None)
         self.assertIsNone(ssl_proto._get_extra_info('socket'))
 
+    def test_set_new_app_protocol(self):
+        waiter = asyncio.Future(loop=self.loop)
+        ssl_proto = self.ssl_protocol(waiter)
+        new_app_proto = asyncio.Protocol()
+        ssl_proto._app_transport.set_protocol(new_app_proto)
+        self.assertIs(ssl_proto._app_transport.get_protocol(), new_app_proto)
+        self.assertIs(ssl_proto._app_protocol, new_app_proto)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -856,6 +856,7 @@ Vladimir Kushnir
 Erno Kuusela
 Ross Lagerwall
 Cameron Laird
+Loïc Lajeanne
 David Lam
 Thomas Lamb
 Valerie Lambert

--- a/Misc/NEWS.d/next/Library/2017-10-04-11-37-14.bpo-31632.LiOC3C.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-04-11-37-14.bpo-31632.LiOC3C.rst
@@ -1,0 +1,2 @@
+Fix method set_protocol() of class _SSLProtocolTransport in asyncio module.
+This method was previously modifying a wrong reference to the protocol.


### PR DESCRIPTION
Fixes an issue about the `set_protocol()` method of class `_SSLProtocolTransport` https://bugs.python.org/issue31632.

`get_protocol()` and `set_protocol()` methods now act on right protocol instance (i.e. `_ssl_protocol._app_protocol`).
The reference to the app protocol was removed from `_SSLProtocolTransport` since it is not used anymore (and it will reduce the risk of similar mistakes in the future).
A test case was added to control the get_protocol / set_protocol feature.


<!-- issue-number: bpo-31632 -->
https://bugs.python.org/issue31632
<!-- /issue-number -->
