### PR TITLE
bpo-29843: Raise ValueError instead of OverflowError in case of a negative _length_ in a ctypes.Array subclass

### DIFF
--- a/Lib/ctypes/test/test_arrays.py
+++ b/Lib/ctypes/test/test_arrays.py
@@ -183,6 +183,24 @@ class ArrayTestCase(unittest.TestCase):
                 _type_ = c_int
                 _length_ = 1.87
 
+    def test_bad_length(self):
+        with self.assertRaises(ValueError):
+            class T(Array):
+                _type_ = c_int
+                _length_ = -1 << 1000
+        with self.assertRaises(ValueError):
+            class T(Array):
+                _type_ = c_int
+                _length_ = -1
+        with self.assertRaises(OverflowError):
+            class T(Array):
+                _type_ = c_int
+                _length_ = 1 << 1000
+        # _length_ might be zero.
+        class T(Array):
+            _type_ = c_int
+            _length_ = 0
+
     @unittest.skipUnless(sys.maxsize > 2**32, 'requires 64bit platform')
     @bigmemtest(size=_2G, memuse=1, dry_run=False)
     def test_large_array(self, size):

--- a/Misc/NEWS.d/next/Core and Builtins/2017-09-29-16-37-22.bpo-29843.RD5kyw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-09-29-16-37-22.bpo-29843.RD5kyw.rst
@@ -1,0 +1,2 @@
+Raise `ValueError` instead of `OverflowError` in case of a negative
+``_length_`` in a `ctypes.Array` subclass. Patch by Oren Milman.


### PR DESCRIPTION
- in `_ctypes.c`: add checks to find whether `_length_` is negative or too big, and raise an error accordingly.
- in `test_arrays.py`: add tests to verify that the right error is raised for various values of `_length_`.

<!-- issue-number: bpo-29843 -->
https://bugs.python.org/issue29843
<!-- /issue-number -->
