### PR TITLE
[2.7] bpo-31285: fix an assertion failure and a SystemError in warnings.warn_explicit (GH-3219)

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -684,8 +684,9 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
         }
 
         /* Split the source into lines. */
-        source_list = PyObject_CallMethodObjArgs(source, splitlines_name,
-                                                    NULL);
+        source_list = PyObject_CallMethodObjArgs((PyObject *)&PyString_Type,
+                                                 splitlines_name, source,
+                                                 NULL);
         Py_DECREF(source);
         if (!source_list)
             return NULL;


### PR DESCRIPTION
I removed (from the original PR) the test that verifies that the assertion failure is no more, because in 2.7, the code assumes that the value returned by splitlines() is a string, and uses it without asserting it is a string, in such a way that causing some error (for testing purposes) is not simple (at least i didn't find a simple way).
ISTM that the first test is good enough to verify that the splitlines() attribute is ignored, and PyUnicode_Splitlines() is used directly.


<!-- issue-number: bpo-31285 -->
https://bugs.python.org/issue31285
<!-- /issue-number -->
