### PR TITLE
explicitly list objects for the ar command

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -578,7 +578,7 @@ sharedmods: $(BUILDPYTHON) pybuilddir.txt Modules/_math.o
 # Build static library
 $(LIBRARY): $(LIBRARY_OBJS)
 	-rm -f $@
-	$(AR) $(ARFLAGS) $@ $^
+	$(AR) $(ARFLAGS) $@ $(LIBRARY_OBJS)
 
 libpython$(LDVERSION).so: $(LIBRARY_OBJS)
 	if test $(INSTSONAME) != $(LDLIBRARY); then \


### PR DESCRIPTION
$^ is not portable.

Followup to d15108a4789aa1e3c12b2890b770550c90a30913.

closes bpo-31625