### PR TITLE
bpo-15037: Add a workaround for getkey() in curses for ncurses 5.7 and earlier.

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -338,6 +338,9 @@ class TestCurses(unittest.TestCase):
         self.stdscr.getkey()
 
     @requires_curses_func('unget_wch')
+    # XXX Remove the decorator when ncurses on OpenBSD be updated
+    @unittest.skipIf(sys.platform.startswith("openbsd"),
+                     "OpenBSD's curses (v.5.7) has bugs")
     def test_unget_wch(self):
         stdscr = self.stdscr
         encoding = stdscr.encoding

--- a/Misc/NEWS.d/next/Library/2017-09-29-19-19-36.bpo-15037.ykimLK.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-29-19-19-36.bpo-15037.ykimLK.rst
@@ -1,0 +1,1 @@
+Added a workaround for getkey() in curses for ncurses 5.7 and earlier.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1160,8 +1160,16 @@ PyCursesWindow_GetKey(PyCursesWindowObject *self, PyObject *args)
         if (!PyErr_Occurred())
             PyErr_SetString(PyCursesError, "no input");
         return NULL;
-    } else if (rtn<=255) {
-        return Py_BuildValue("C", rtn);
+    } else if (rtn <= 255) {
+#ifdef NCURSES_VERSION_MAJOR
+#if NCURSES_VERSION_MAJOR*100+NCURSES_VERSION_MINOR <= 507
+        /* Work around a bug in ncurses 5.7 and earlier */
+        if (rtn < 0) {
+            rtn += 256;
+        }
+#endif
+#endif
+        return PyUnicode_FromOrdinal(rtn);
     } else {
         const char *knp;
 #if defined(__NetBSD__)


### PR DESCRIPTION
Skip a test for unget_wch()/get_wch() on OpenBSD since they are broken
in ncurses 5.7.


<!-- issue-number: bpo-15037 -->
https://bugs.python.org/issue15037
<!-- /issue-number -->
