### PR TITLE
[2.7] bpo-31627: Make test_mailbox be lenient to empty hostname. (GH-3821)

### DIFF
--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -654,7 +654,7 @@ class TestMaildir(TestMailbox, unittest.TestCase):
             hostname = hostname.replace(':', r'\072')
         pid = os.getpid()
         pattern = re.compile(r"(?P<time>\d+)\.M(?P<M>\d{1,6})P(?P<P>\d+)"
-                             r"Q(?P<Q>\d+)\.(?P<host>[^:/]+)")
+                             r"Q(?P<Q>\d+)\.(?P<host>[^:/]*)")
         previous_groups = None
         for x in xrange(repetitions):
             tmp_file = self._box._create_tmp()


### PR DESCRIPTION
(cherry picked from commit f4ea642cb60556231e714089a79d3c59c202661e)


<!-- issue-number: bpo-31627 -->
https://bugs.python.org/issue31627
<!-- /issue-number -->
