### PR TITLE
bpo-31649: Make IDLE's _htest, _utest parameters keyword-only.

### DIFF
--- a/Lib/idlelib/browser.py
+++ b/Lib/idlelib/browser.py
@@ -61,7 +61,7 @@ class ModuleBrowser:
     # This class is the base class for pathbrowser.PathBrowser.
     # Init and close are inherited, other methods are overriden.
 
-    def __init__(self, flist, name, path, _htest=False, _utest=False):
+    def __init__(self, flist, name, path, *, _htest=False, _utest=False):
         # XXX This API should change, if the file doesn't end in ".py"
         # XXX the code here is bogus!
         """Create a window for browsing a module's structure.

--- a/Lib/idlelib/config_key.py
+++ b/Lib/idlelib/config_key.py
@@ -14,7 +14,7 @@ class GetKeysDialog(Toplevel):
     keyerror_title = 'Key Sequence Error'
 
     def __init__(self, parent, title, action, currentKeySequences,
-                 _htest=False, _utest=False):
+                 *, _htest=False, _utest=False):
         """
         action - string, the name of the virtual event these keys will be
                  mapped to

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -41,7 +41,7 @@ class ConfigDialog(Toplevel):
     """Config dialog for IDLE.
     """
 
-    def __init__(self, parent, title='', _htest=False, _utest=False):
+    def __init__(self, parent, title='', *, _htest=False, _utest=False):
         """Show the tabbed dialog for user configuration.
 
         Args:

--- a/Lib/idlelib/help_about.py
+++ b/Lib/idlelib/help_about.py
@@ -23,7 +23,7 @@ class AboutDialog(Toplevel):
     """Modal about dialog for idle
 
     """
-    def __init__(self, parent, title=None, _htest=False, _utest=False):
+    def __init__(self, parent, title=None, *, _htest=False, _utest=False):
         """Create popup, do not return until tk widget destroyed.
 
         parent - parent of this dialog

--- a/Lib/idlelib/pathbrowser.py
+++ b/Lib/idlelib/pathbrowser.py
@@ -9,7 +9,7 @@ from idlelib.tree import TreeItem
 
 class PathBrowser(ModuleBrowser):
 
-    def __init__(self, flist, _htest=False, _utest=False):
+    def __init__(self, flist, *, _htest=False, _utest=False):
         """
         _htest - bool, change box location when running htest
         """

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -57,7 +57,7 @@ class ViewWindow(Toplevel):
     "A simple text viewer dialog for IDLE."
 
     def __init__(self, parent, title, text, modal=True,
-                 _htest=False, _utest=False):
+                 *, _htest=False, _utest=False):
         """Show the given text in a scrollable window with a 'close' button.
 
         If modal is left True, users cannot interact with other windows

--- a/Misc/NEWS.d/next/IDLE/2017-09-30-13-59-18.bpo-31649.LxN4Vb.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-30-13-59-18.bpo-31649.LxN4Vb.rst
@@ -1,0 +1,1 @@
+IDLE - Make _htest, _utest parameters keyword only.


### PR DESCRIPTION


<!-- issue-number: bpo-31649 -->
https://bugs.python.org/issue31649
<!-- /issue-number -->
