### PR TITLE
bpo-31460: Simplify the API of IDLE's Module Browser.

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -664,10 +664,8 @@ class EditorWindow(object):
             filename = self.open_module()
             if filename is None:
                 return "break"
-        head, tail = os.path.split(filename)
-        base, ext = os.path.splitext(tail)
         from idlelib import browser
-        browser.ModuleBrowser(self.flist, base, [head])
+        browser.ModuleBrowser(self.flist, filename)
         return "break"
 
     def open_path_browser(self, event=None):

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -665,7 +665,7 @@ class EditorWindow(object):
             if filename is None:
                 return "break"
         from idlelib import browser
-        browser.ModuleBrowser(self.flist, filename)
+        browser.ModuleBrowser(self.root, filename)
         return "break"
 
     def open_path_browser(self, event=None):

--- a/Lib/idlelib/idle_test/test_browser.py
+++ b/Lib/idlelib/idle_test/test_browser.py
@@ -24,15 +24,13 @@ class ModuleBrowserTest(unittest.TestCase):
         requires('gui')
         cls.root = Tk()
         cls.root.withdraw()
-        cls.flist = filelist.FileList(cls.root)
-        cls.file = __file__
-        cls.mb = browser.ModuleBrowser(cls.flist, __file__, _utest=True)
+        cls.mb = browser.ModuleBrowser(cls.root, __file__, _utest=True)
 
     @classmethod
     def tearDownClass(cls):
         cls.mb.close()
         cls.root.destroy()
-        del cls.root, cls.flist, cls.mb
+        del cls.root, cls.mb
 
     def test_init(self):
         mb = self.mb

--- a/Lib/idlelib/idle_test/test_browser.py
+++ b/Lib/idlelib/idle_test/test_browser.py
@@ -26,9 +26,7 @@ class ModuleBrowserTest(unittest.TestCase):
         cls.root.withdraw()
         cls.flist = filelist.FileList(cls.root)
         cls.file = __file__
-        cls.path = os.path.dirname(cls.file)
-        cls.module = os.path.basename(cls.file).rstrip('.py')
-        cls.mb = browser.ModuleBrowser(cls.flist, cls.module, [cls.path], _utest=True)
+        cls.mb = browser.ModuleBrowser(cls.flist, __file__, _utest=True)
 
     @classmethod
     def tearDownClass(cls):
@@ -39,15 +37,13 @@ class ModuleBrowserTest(unittest.TestCase):
     def test_init(self):
         mb = self.mb
         eq = self.assertEqual
-        eq(mb.name, self.module)
-        eq(mb.file, self.file)
-        eq(mb.flist, self.flist)
+        eq(mb.path, __file__)
         eq(pyclbr._modules, {})
         self.assertIsInstance(mb.node, TreeNode)
 
     def test_settitle(self):
         mb = self.mb
-        self.assertIn(self.module, mb.top.title())
+        self.assertIn(os.path.basename(__file__), mb.top.title())
         self.assertEqual(mb.top.iconname(), 'Module Browser')
 
     def test_rootnode(self):

--- a/Misc/NEWS.d/next/IDLE/2017-09-30-19-03-26.bpo-31460.HpveI6.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-09-30-19-03-26.bpo-31460.HpveI6.rst
@@ -1,0 +1,6 @@
+Simplify the API of IDLE's Module Browser.
+
+Passing a widget instead of an flist with a root widget opens the option of
+creating a browser frame that is only part of a window.  Passing a full file
+name instead of pieces assumed to come from a .py file opens the possibility
+of browsing python files that do not end in .py.


### PR DESCRIPTION

Passing a widget instead of an flist with a root widget opens the option of
creating a browser frame that is only part of a window.  Passing a full file
name instead of pieces assumed to come from a .py file opens the possibility
of browsing python files that do not end in .py.


<!-- issue-number: bpo-31460 -->
https://bugs.python.org/issue31460
<!-- /issue-number -->
