### PR TITLE
[2.7] bpo-31478: Prevent unwanted behavior in _random.Random.seed() in case the arg has a bad __abs__() method (GH-3596)

### DIFF
--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -317,7 +317,6 @@ class MersenneTwister_TestBasicOps(TestBasicOps):
         class BadLong(long):
             def __abs__(self):
                 1/0
-
         self.gen.seed(42)
         expected_value = self.gen.random()
         for seed_arg in [42L, BadInt(42), BadLong(42)]:

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -318,15 +318,11 @@ class MersenneTwister_TestBasicOps(TestBasicOps):
             def __abs__(self):
                 1/0
 
-        for seed_arg in [-42, 0, 42]:
+        self.gen.seed(42)
+        expected_value = self.gen.random()
+        for seed_arg in [42L, BadInt(42), BadLong(42)]:
             self.gen.seed(seed_arg)
-            expected_rand = self.gen.random()
-            self.gen.seed(long(seed_arg))
-            self.assertEqual(expected_rand, self.gen.random())
-            self.gen.seed(BadInt(seed_arg))
-            self.assertEqual(expected_rand, self.gen.random())
-            self.gen.seed(BadLong(seed_arg))
-            self.assertEqual(expected_rand, self.gen.random())
+            self.assertEqual(expected_value, self.gen.random())
 
     def test_setstate_first_arg(self):
         self.assertRaises(ValueError, self.gen.setstate, (1, None, None))

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -321,7 +321,7 @@ class MersenneTwister_TestBasicOps(TestBasicOps):
         expected_value = self.gen.random()
         for seed_arg in [42L, BadInt(42), BadLong(42)]:
             self.gen.seed(seed_arg)
-            self.assertEqual(expected_value, self.gen.random())
+            self.assertEqual(self.gen.random(), expected_value)
 
     def test_setstate_first_arg(self):
         self.assertRaises(ValueError, self.gen.setstate, (1, None, None))

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -307,6 +307,27 @@ class SystemRandom_TestBasicOps(TestBasicOps):
 class MersenneTwister_TestBasicOps(TestBasicOps):
     gen = random.Random()
 
+    @test_support.cpython_only
+    def test_bug_31478(self):
+        # _random.Random.seed() should ignore the __abs__() method of a
+        # long/int subclass argument.
+        class BadInt(int):
+            def __abs__(self):
+                1/0
+        class BadLong(long):
+            def __abs__(self):
+                1/0
+
+        for seed_arg in [-42, 0, 42]:
+            self.gen.seed(seed_arg)
+            expected_rand = self.gen.random()
+            self.gen.seed(long(seed_arg))
+            self.assertEqual(expected_rand, self.gen.random())
+            self.gen.seed(BadInt(seed_arg))
+            self.assertEqual(expected_rand, self.gen.random())
+            self.gen.seed(BadLong(seed_arg))
+            self.assertEqual(expected_rand, self.gen.random())
+
     def test_setstate_first_arg(self):
         self.assertRaises(ValueError, self.gen.setstate, (1, None, None))
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-01-18-59-40.bpo-31478.owtqoO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-01-18-59-40.bpo-31478.owtqoO.rst
@@ -1,0 +1,2 @@
+Prevent unwanted behavior in `_random.Random.seed()` in case the argument
+has a bad ``__abs__()`` method. Patch by Oren Milman.

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -231,8 +231,15 @@ random_seed(RandomObject *self, PyObject *args)
     /* If the arg is an int or long, use its absolute value; else use
      * the absolute value of its hash code.
      */
-    if (PyInt_Check(arg) || PyLong_Check(arg))
-        n = PyNumber_Absolute(arg);
+    if (PyInt_Check(arg)) {
+        /* Calling int.__abs__() (or long.__abs__()) prevents calling
+           arg.__abs__(), which might return an invalid value.
+           See issue #31478. */
+        n = PyInt_Type.tp_as_number->nb_absolute(arg);
+    }
+    else if (PyLong_Check(arg)) {
+        n = PyLong_Type.tp_as_number->nb_absolute(arg);
+    }
     else {
         long hash = PyObject_Hash(arg);
         if (hash == -1)

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -230,11 +230,10 @@ random_seed(RandomObject *self, PyObject *args)
     }
     /* If the arg is an int or long, use its absolute value; else use
      * the absolute value of its hash code.
+     * Calling int.__abs__() or long.__abs__() prevents calling arg.__abs__(),
+     * which might return an invalid value. See issue #31478.
      */
     if (PyInt_Check(arg)) {
-        /* Calling int.__abs__() (or long.__abs__()) prevents calling
-           arg.__abs__(), which might return an invalid value.
-           See issue #31478. */
         n = PyInt_Type.tp_as_number->nb_absolute(arg);
     }
     else if (PyLong_Check(arg)) {


### PR DESCRIPTION
* In case the argument of `_random.Random.seed()` is a `long`/`int` subclass, ignore its ``__abs__()`` method.
* Add a test to `test_random` to verify that such ``__abs__()`` methods are indeed ignored.

<!-- issue-number: bpo-31478 -->
https://bugs.python.org/issue31478
<!-- /issue-number -->
