### PR TITLE
IDLE: make filetypes a tuple constant.

### DIFF
--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -487,11 +487,11 @@ class IOBinding:
     opendialog = None
     savedialog = None
 
-    filetypes = [
+    filetypes = (
         ("Python files", "*.py *.pyw", "TEXT"),
         ("Text files", "*.txt", "TEXT"),
         ("All files", "*"),
-        ]
+        )
 
     defaultextension = '.py' if sys.platform == 'darwin' else ''
 


### PR DESCRIPTION
Non-tuples get converted to tuples by tkinter for the tk call.
