### PR TITLE
[3.6] IDLE: make filetypes a tuple constant. (GH-3847)

### DIFF
--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -487,11 +487,11 @@ class IOBinding:
     opendialog = None
     savedialog = None
 
-    filetypes = [
+    filetypes = (
         ("Python files", "*.py *.pyw", "TEXT"),
         ("Text files", "*.txt", "TEXT"),
         ("All files", "*"),
-        ]
+        )
 
     defaultextension = '.py' if sys.platform == 'darwin' else ''
 


### PR DESCRIPTION
Save a bit of code, plus non-tuples get converted anyway to tuples by tkinter for the tk call.
(cherry picked from commit 5961e7c156f90c7f9444ae95b9d3e55114ca2169)

!!! If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

PLEASE: Remove this headline!!!
