### PR TITLE
bpo-31659: ssl: Don't use textwrap.fill() to format PEM cert

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -91,7 +91,6 @@ ALERT_DESCRIPTION_UNKNOWN_PSK_IDENTITY
 """
 
 import ipaddress
-import textwrap
 import re
 import sys
 import os
@@ -1201,9 +1200,10 @@ def DER_cert_to_PEM_cert(der_cert_bytes):
     PEM version of it as a string."""
 
     f = str(base64.standard_b64encode(der_cert_bytes), 'ASCII', 'strict')
-    return (PEM_HEADER + '\n' +
-            textwrap.fill(f, 64) + '\n' +
-            PEM_FOOTER + '\n')
+    ss = [PEM_HEADER]
+    ss += [f[i:i+64] for i in range(0, len(f), 64)]
+    ss.append(PEM_FOOTER + '\n')
+    return '\n'.join(ss)
 
 def PEM_cert_to_DER_cert(pem_cert_string):
     """Takes a certificate in ASCII PEM format and returns the


### PR DESCRIPTION
DER_cert_to_PEM_cert() used textwrap.fill() to format PEM.
But it's library to wrap lines on word boundary, while PEM is
base64 encoded string.
Additionally, importing textwrap is little slow.

<!-- issue-number: bpo-31659 -->
https://bugs.python.org/issue31659
<!-- /issue-number -->
