### PR TITLE
[2.7] bpo-31158: Fix nondeterministic read in test_pty (#3808)

### DIFF
--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -11,6 +11,7 @@ import sys
 import select
 import signal
 import socket
+import io # readline
 import unittest
 
 TEST_STRING_1 = "I wish to buy a fish license.\n"
@@ -23,6 +24,16 @@ else:
     def debug(msg):
         pass
 
+
+# Note that os.read() is nondeterministic so we need to be very careful
+# to make the test suite deterministic.  A normal call to os.read() may
+# give us less than expected.
+#
+# Beware, on my Linux system, if I put 'foo\n' into a terminal fd, I get
+# back 'foo\r\n' at the other end.  The behavior depends on the termios
+# setting.  The newline translation may be OS-specific.  To make the
+# test suite deterministic and OS-independent, the functions _readline
+# and normalize_output can be used.
 
 def normalize_output(data):
     # Some operating systems do conversions on newline.  We could possibly
@@ -44,6 +55,12 @@ def normalize_output(data):
         return data.replace('\r\n', '\n')
 
     return data
+
+def _readline(fd):
+    """Read one line.  May block forever if no newline is read."""
+    reader = io.FileIO(fd, mode='rb', closefd=False)
+    return reader.readline()
+
 
 
 # Marginal testing of pty suite. Cannot do extensive 'do or fail' testing
@@ -97,14 +114,14 @@ class PtyTest(unittest.TestCase):
 
         debug("Writing to slave_fd")
         os.write(slave_fd, TEST_STRING_1)
-        s1 = os.read(master_fd, 1024)
+        s1 = _readline(master_fd)
         self.assertEqual('I wish to buy a fish license.\n',
                          normalize_output(s1))
 
         debug("Writing chunked output")
         os.write(slave_fd, TEST_STRING_2[:5])
         os.write(slave_fd, TEST_STRING_2[5:])
-        s2 = os.read(master_fd, 1024)
+        s2 = _readline(master_fd)
         self.assertEqual('For my pet fish, Eric.\n', normalize_output(s2))
 
         os.close(slave_fd)


### PR DESCRIPTION
(cherry picked from commit e6f62f69f07892b993910ff03c9db3ffa5cb9ca5)

<!-- issue-number: bpo-31158 -->
https://bugs.python.org/issue31158
<!-- /issue-number -->
