### PR TITLE
bpo-11063: Fix _uuid module on macOS

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -509,7 +509,7 @@ def _load_system_functions():
         pass
     elif _uuid is not None:
         _generate_time_safe = _uuid.generate_time_safe
-        _has_uuid_generate_time_safe = True
+        _has_uuid_generate_time_safe = _uuid.has_uuid_generate_time_safe
         return
 
     try:


### PR DESCRIPTION
On macOS, use uuid_generate_time() instead of
uuid_generate_time_safe() of libuuid, since uuid_generate_time_safe()
is not available.

<!-- issue-number: bpo-11063 -->
https://bugs.python.org/issue11063
<!-- /issue-number -->
