### PR TITLE
bpo-31510: Fix multiprocessing test_many_processes() on macOS

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -501,8 +501,13 @@ class _TestProcess(BaseTestCase):
         for p in procs:
             join_process(p)
         if os.name != 'nt':
+            exitcodes = [-signal.SIGTERM]
+            if sys.platform == 'darwin':
+                # bpo-31510: On macOS, killing a freshly started process with
+                # SIGTERM sometimes kills the process with SIGKILL.
+                exitcodes.append(-signal.SIGKILL)
             for p in procs:
-                self.assertEqual(p.exitcode, -signal.SIGTERM)
+                self.assertIn(p.exitcode, exitcodes)
 
     def test_lose_target_ref(self):
         c = DummyCallable()


### PR DESCRIPTION
On macOS, a process can exit with -SIGKILL if it is killed "early"
with SIGTERM.

<!-- issue-number: bpo-31510 -->
https://bugs.python.org/issue31510
<!-- /issue-number -->
