### PR TITLE
bpo-21983: Fix a crash in ctypes.cast() in case the type argument is a ctypes structured data type.

### DIFF
--- a/Lib/ctypes/test/test_cast.py
+++ b/Lib/ctypes/test/test_cast.py
@@ -82,5 +82,18 @@ class Test(unittest.TestCase):
         self.assertEqual(cast(cast(s, c_void_p), c_wchar_p).value,
                              "hiho")
 
+    def test_bad_type_arg(self):
+        # The type argument must be a ctypes pointer type.
+        array_type = c_byte * sizeof(c_int)
+        array = array_type()
+        self.assertRaises(TypeError, cast, array, None)
+        self.assertRaises(TypeError, cast, array, array_type)
+        class Struct(Structure):
+            _fields_ = [("a", c_int)]
+        self.assertRaises(TypeError, cast, array, Struct)
+        class MyUnion(Union):
+            _fields_ = [("a", c_int)]
+        self.assertRaises(TypeError, cast, array, MyUnion)
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-02-21-02-14.bpo-21983.UoC319.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-02-21-02-14.bpo-21983.UoC319.rst
@@ -1,0 +1,2 @@
+Fix a crash in `ctypes.cast()` in case the type argument is a ctypes
+structured data type. Patch by Eryk Sun and Oren Milman.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -5319,7 +5319,7 @@ cast_check_pointertype(PyObject *arg)
     if (PyCFuncPtrTypeObject_Check(arg))
         return 1;
     dict = PyType_stgdict(arg);
-    if (dict) {
+    if (dict != NULL && dict->proto != NULL) {
         if (PyUnicode_Check(dict->proto)
             && (strchr("sPzUZXO", PyUnicode_AsUTF8(dict->proto)[0]))) {
             /* simple pointer types, c_void_p, c_wchar_p, BSTR, ... */


### PR DESCRIPTION
In addition, add tests to `test_ctypes` to make sure that `cast()` raises a `TypeError` in case of a bad type argument (and doesn't crash). 

<!-- issue-number: bpo-21983 -->
https://bugs.python.org/issue21983
<!-- /issue-number -->
