### PR TITLE
bpo-31671: re: Convert RegexFlag to int before compile

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -326,6 +326,11 @@ Optimizations
   expressions <re>`.  Searching some patterns can now be up to 20 times faster.
   (Contributed by Serhiy Storchaka in :issue:`30285`.)
 
+* :func:`re.compile` now converts ``flags`` parameter to int object if
+  it is ``RegexFlag``.  It is now as fast as Python 3.5, and faster than
+  Python 3.6 about 10% depending on the pattern.
+  (Contributed by INADA Naoki in :issue:`31671`.)
+
 * :meth:`selectors.EpollSelector.modify`, :meth:`selectors.PollSelector.modify`
   and :meth:`selectors.DevpollSelector.modify` may be around 10% faster under
   heavy loads. (Contributed by Giampaolo Rodola' in :issue:`30014`)

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -274,6 +274,7 @@ _pattern_type = type(sre_compile.compile("", 0))
 _MAXCACHE = 512
 def _compile(pattern, flags):
     # internal: compile pattern
+    flags = int(flags)
     try:
         return _cache[type(pattern), pattern, flags]
     except KeyError:
@@ -330,6 +331,7 @@ copyreg.pickle(_pattern_type, _pickle, _compile)
 class Scanner:
     def __init__(self, lexicon, flags=0):
         from sre_constants import BRANCH, SUBPATTERN
+        flags = int(flags)
         self.lexicon = lexicon
         # combine phrases into a compound pattern
         p = []

--- a/Lib/re.py
+++ b/Lib/re.py
@@ -274,7 +274,8 @@ _pattern_type = type(sre_compile.compile("", 0))
 _MAXCACHE = 512
 def _compile(pattern, flags):
     # internal: compile pattern
-    flags = int(flags)
+    if isinstance(flags, RegexFlag):
+        flags = flags.value
     try:
         return _cache[type(pattern), pattern, flags]
     except KeyError:
@@ -331,7 +332,8 @@ copyreg.pickle(_pattern_type, _pickle, _compile)
 class Scanner:
     def __init__(self, lexicon, flags=0):
         from sre_constants import BRANCH, SUBPATTERN
-        flags = int(flags)
+        if isinstance(flags, RegexFlag):
+            flags = flags.value
         self.lexicon = lexicon
         # combine phrases into a compound pattern
         p = []

--- a/Misc/NEWS.d/next/Library/2017-10-04-21-28-44.bpo-31671.E-zfc9.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-04-21-28-44.bpo-31671.E-zfc9.rst
@@ -1,0 +1,2 @@
+Now ``re.compile()`` converts passed RegexFlag to normal int object before
+compiling. bm_regex_compile benchmark shows 14% performance improvements.


### PR DESCRIPTION
sre_compile does bit test (e.g. flags & SRE_FLAG_IGNORECASE) in loop.
`IntFlag.__and__` and `IntFlag.__new__` made it slower.

So convert it to normal int before passing flags to sre_compile.

<!-- issue-number: bpo-31671 -->
https://bugs.python.org/issue31671
<!-- /issue-number -->
