### PR TITLE
bpo-31673: Fixed typo in the name of Tkinter's method adderrorinfo().

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-10-03-14-37-46.bpo-31673.RFCrka.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-03-14-37-46.bpo-31673.RFCrka.rst
@@ -1,0 +1,1 @@
+Fixed typo in the name of Tkinter's method adderrorinfo().

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -1640,7 +1640,7 @@ _tkinter_tkapp_record_impl(TkappObject *self, const char *script)
 }
 
 /*[clinic input]
-_tkinter.tkapp.adderrinfo
+_tkinter.tkapp.adderrorinfo
 
     msg: str
     /
@@ -1648,8 +1648,8 @@ _tkinter.tkapp.adderrinfo
 [clinic start generated code]*/
 
 static PyObject *
-_tkinter_tkapp_adderrinfo_impl(TkappObject *self, const char *msg)
-/*[clinic end generated code: output=0e222ee2050eb357 input=4971399317d4c136]*/
+_tkinter_tkapp_adderrorinfo_impl(TkappObject *self, const char *msg)
+/*[clinic end generated code: output=52162eaca2ee53cb input=f4b37aec7c7e8c77]*/
 {
     CHECK_STRING_LENGTH(msg);
     CHECK_TCL_APPARTMENT;
@@ -3253,7 +3253,7 @@ static PyMethodDef Tkapp_methods[] =
     _TKINTER_TKAPP_EVAL_METHODDEF
     _TKINTER_TKAPP_EVALFILE_METHODDEF
     _TKINTER_TKAPP_RECORD_METHODDEF
-    _TKINTER_TKAPP_ADDERRINFO_METHODDEF
+    _TKINTER_TKAPP_ADDERRORINFO_METHODDEF
     {"setvar",                 Tkapp_SetVar, METH_VARARGS},
     {"globalsetvar",       Tkapp_GlobalSetVar, METH_VARARGS},
     {"getvar",       Tkapp_GetVar, METH_VARARGS},

--- a/Modules/clinic/_tkinter.c.h
+++ b/Modules/clinic/_tkinter.c.h
@@ -80,27 +80,27 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(_tkinter_tkapp_adderrinfo__doc__,
-"adderrinfo($self, msg, /)\n"
+PyDoc_STRVAR(_tkinter_tkapp_adderrorinfo__doc__,
+"adderrorinfo($self, msg, /)\n"
 "--\n"
 "\n");
 
-#define _TKINTER_TKAPP_ADDERRINFO_METHODDEF    \
-    {"adderrinfo", (PyCFunction)_tkinter_tkapp_adderrinfo, METH_O, _tkinter_tkapp_adderrinfo__doc__},
+#define _TKINTER_TKAPP_ADDERRORINFO_METHODDEF    \
+    {"adderrorinfo", (PyCFunction)_tkinter_tkapp_adderrorinfo, METH_O, _tkinter_tkapp_adderrorinfo__doc__},
 
 static PyObject *
-_tkinter_tkapp_adderrinfo_impl(TkappObject *self, const char *msg);
+_tkinter_tkapp_adderrorinfo_impl(TkappObject *self, const char *msg);
 
 static PyObject *
-_tkinter_tkapp_adderrinfo(TkappObject *self, PyObject *arg)
+_tkinter_tkapp_adderrorinfo(TkappObject *self, PyObject *arg)
 {
     PyObject *return_value = NULL;
     const char *msg;
 
-    if (!PyArg_Parse(arg, "s:adderrinfo", &msg)) {
+    if (!PyArg_Parse(arg, "s:adderrorinfo", &msg)) {
         goto exit;
     }
-    return_value = _tkinter_tkapp_adderrinfo_impl(self, msg);
+    return_value = _tkinter_tkapp_adderrorinfo_impl(self, msg);
 
 exit:
     return return_value;
@@ -638,4 +638,4 @@ exit:
 #ifndef _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
     #define _TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF
 #endif /* !defined(_TKINTER_TKAPP_DELETEFILEHANDLER_METHODDEF) */
-/*[clinic end generated code: output=3b9241f7c703ae4f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=ca36236c57713ba0 input=a9049054013a1b77]*/


### PR DESCRIPTION


<!-- issue-number: bpo-31673 -->
https://bugs.python.org/issue31673
<!-- /issue-number -->
