### PR TITLE
bpo-31678 Fix datetime.timedelta C function name in API documentation

### DIFF
--- a/Doc/c-api/datetime.rst
+++ b/Doc/c-api/datetime.rst
@@ -188,7 +188,7 @@ not be *NULL*, and the type is not checked:
    .. versionadded:: 3.3
 
 
-.. c:function:: int PyDateTime_DELTA_GET_MICROSECOND(PyDateTime_Delta *o)
+.. c:function:: int PyDateTime_DELTA_GET_MICROSECONDS(PyDateTime_Delta *o)
 
    Return the number of microseconds, as an int from 0 through 999999.
 


### PR DESCRIPTION
Fixed C function name for datetime.timedelta.

https://bugs.python.org/issue31678


<!-- issue-number: bpo-31678 -->
https://bugs.python.org/issue31678
<!-- /issue-number -->
