### PR TITLE
bpo-31704 Check HTTP response in uppercase

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -273,7 +273,7 @@ class HTTPResponse(io.BufferedIOBase):
             except ValueError:
                 # empty version will cause next test to fail.
                 version = ""
-        if not version.startswith("HTTP/"):
+        if not version.upper().startswith("HTTP/"):
             self._close_conn()
             raise BadStatusLine(line)
 

--- a/Misc/NEWS.d/next/Library/2017-10-05.bpo-31704.Rt3U9m.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-05.bpo-31704.Rt3U9m.rst
@@ -1,0 +1,1 @@
+Allow lowercase http responses (e.g. 'http/1.1 200 connection established\r\n') in proxy connections by changing the response string to uppercase before checking if it starts with HTTP.


### PR DESCRIPTION
Recently faced an issue with a proxy responding in lowercase http, which caused this:
```python
ProtocolError('Connection aborted.', BadStatusLine('http/1.1 200 connection established\r\n',))
```

Changing the string to uppercase before checking if it starts with HTTP fixes this issue and allows to use this proxy.

I know that the proxy is at fault here, but seeing as other applications (web browsers, office suite, text editors, etc.) still work behind this proxy, I think it might be a reasonable fix to have...

<!-- issue-number: bpo-31704 -->
https://bugs.python.org/issue31704
<!-- /issue-number -->
