### PR TITLE
bpo-31676: Fix test_imp.test_load_source() side effect

### DIFF
--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -310,8 +310,13 @@ class ImportTests(unittest.TestCase):
         loader.get_data(imp.__file__)  # Will need to create a newly opened file
 
     def test_load_source(self):
-        with self.assertRaisesRegex(ValueError, 'embedded null'):
-            imp.load_source(__name__, __file__ + "\0")
+        # Create a temporary module since load_source(name) modifies
+        # sys.modules[name] attributes like __loader___
+        modname = f"tmp{__name__}"
+        mod = type(sys.modules[__name__])(modname)
+        with support.swap_item(sys.modules, modname, mod):
+            with self.assertRaisesRegex(ValueError, 'embedded null'):
+                imp.load_source(modname, __file__ + "\0")
 
     @support.cpython_only
     def test_issue31315(self):


### PR DESCRIPTION
test_load_source() now replaces the current `__name__` module with a
temporary module to prevent side effects.

<!-- issue-number: bpo-31676 -->
https://bugs.python.org/issue31676
<!-- /issue-number -->
