### PR TITLE
bpo-31672: string: Use `re.A | re.I` flag for identifier pattern

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -755,8 +755,18 @@ attributes:
 
 * *idpattern* -- This is the regular expression describing the pattern for
   non-braced placeholders.  The default value is the regular expression
-  ``[_a-z][_a-z0-9]*``.  If this is given and *braceidpattern* is ``None``
-  this pattern will also apply to braced placeholders.
+  ``(?-i:[_a-zA-Z][_a-zA-Z0-9]*)``. Since default *flags* is
+  ``re.IGNORECASE``, ``[a-z]``Without local flag ``-i``, is used to avoid to match with non ASCII characters.
+  If this is given and *braceidpattern* is
+  ``None`` this pattern will also apply to braced placeholders.
+
+  .. note::
+
+     Default *flags* is ``re.IGNORECASE``.  So the pattern ``[a-z]`` can match
+     with some non ASCII characters.  That's why We use local ``-i`` flag here.
+
+     When overrinding this class, please consider overriding *flags* with ``0``
+     or ``re.IGNORECASE | re.ASCII``.
 
   .. versionchanged:: 3.7
      *braceidpattern* can be used to define separate patterns used inside and

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -761,7 +761,7 @@ attributes:
   .. note::
 
      Default *flags* is ``re.IGNORECASE``.  So the pattern ``[a-z]`` can match
-     with some non-ASCII characters.  That's why We use local ``-i`` flag here.
+     with some non-ASCII characters.  That's why we use local ``-i`` flag here.
 
      While *flags* is kept to ``re.IGNORECASE`` for backward compatibility,
      you can override it to ``0`` or ``re.IGNORECASE | re.ASCII`` when

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -755,18 +755,17 @@ attributes:
 
 * *idpattern* -- This is the regular expression describing the pattern for
   non-braced placeholders.  The default value is the regular expression
-  ``(?-i:[_a-zA-Z][_a-zA-Z0-9]*)``. Since default *flags* is
-  ``re.IGNORECASE``, ``[a-z]``Without local flag ``-i``, is used to avoid to match with non ASCII characters.
-  If this is given and *braceidpattern* is
+  ``(?-i:[_a-zA-Z][_a-zA-Z0-9]*)``.  If this is given and *braceidpattern* is
   ``None`` this pattern will also apply to braced placeholders.
 
   .. note::
 
      Default *flags* is ``re.IGNORECASE``.  So the pattern ``[a-z]`` can match
-     with some non ASCII characters.  That's why We use local ``-i`` flag here.
+     with some non-ASCII characters.  That's why We use local ``-i`` flag here.
 
-     When overrinding this class, please consider overriding *flags* with ``0``
-     or ``re.IGNORECASE | re.ASCII``.
+     While *flags* is kept to ``re.IGNORECASE`` for backward compatibility,
+     you can override it to ``0`` or ``re.IGNORECASE | re.ASCII`` when
+     subclassing.  It's simple way to avoid unexpected match like above example.
 
   .. versionchanged:: 3.7
      *braceidpattern* can be used to define separate patterns used inside and

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -760,8 +760,8 @@ attributes:
 
   .. note::
 
-     Default *flags* is ``re.IGNORECASE``.  So the pattern ``[a-z]`` can match
-     with some non-ASCII characters.  That's why we use local ``-i`` flag here.
+     Since default *flags* is ``re.IGNORECASE``, pattern ``[a-z]`` can match
+     with some non-ASCII characters. That's why we use local ``-i`` flag here.
 
      While *flags* is kept to ``re.IGNORECASE`` for backward compatibility,
      you can override it to ``0`` or ``re.IGNORECASE | re.ASCII`` when

--- a/Lib/string.py
+++ b/Lib/string.py
@@ -79,13 +79,13 @@ class Template(metaclass=_TemplateMetaclass):
     """A string class for supporting $-substitutions."""
 
     delimiter = '$'
-    idpattern = r'[_a-z][_a-z0-9]*'
+    # r'[a-z]' matches to non-ASCII letters when used with IGNORECASE,
+    # but without ASCII flag.  We can't add re.ASCII to flags because of
+    # backward compatibility.  So we use local -i flag and [a-zA-Z] pattern.
+    # See https://bugs.python.org/issue31672
+    idpattern = r'(?-i:[_a-zA-Z][_a-zA-Z0-9]*)'
     braceidpattern = None
-
-    # We use re.I | re.A while compiling Template.idpattern in the metaclass
-    # above, but since flags is part of the public API, we restore its original
-    # documented value after class creation for backward compatibility.
-    flags = _re.IGNORECASE | _re.ASCII
+    flags = _re.IGNORECASE
 
     def __init__(self, template):
         self.template = template
@@ -160,9 +160,6 @@ class Template(metaclass=_TemplateMetaclass):
                              self.pattern)
         return self.pattern.sub(convert, self.template)
 
-
-# Restore old, documented flag.  See Template.flags for detail.
-Template.flags = _re.IGNORECASE
 
 
 ########################################################################

--- a/Lib/string.py
+++ b/Lib/string.py
@@ -81,6 +81,10 @@ class Template(metaclass=_TemplateMetaclass):
     delimiter = '$'
     idpattern = r'[_a-z][_a-z0-9]*'
     braceidpattern = None
+
+    # We use re.I | re.A while compiling Template.idpattern in the metaclass
+    # above, but since flags is part of the public API, we restore its original
+    # documented value after class creation for backward compatibility.
     flags = _re.IGNORECASE | _re.ASCII
 
     def __init__(self, template):
@@ -157,8 +161,7 @@ class Template(metaclass=_TemplateMetaclass):
         return self.pattern.sub(convert, self.template)
 
 
-# We use re.I | re.A when compiling Template.idpattern, but restore old flag
-# for backward compatibility.
+# Restore old, documented flag.  See Template.flags for detail.
 Template.flags = _re.IGNORECASE
 
 

--- a/Lib/string.py
+++ b/Lib/string.py
@@ -81,7 +81,7 @@ class Template(metaclass=_TemplateMetaclass):
     delimiter = '$'
     idpattern = r'[_a-z][_a-z0-9]*'
     braceidpattern = None
-    flags = _re.IGNORECASE
+    flags = _re.IGNORECASE | _re.ASCII
 
     def __init__(self, template):
         self.template = template
@@ -156,6 +156,10 @@ class Template(metaclass=_TemplateMetaclass):
                              self.pattern)
         return self.pattern.sub(convert, self.template)
 
+
+# We use re.I | re.A when compiling Template.idpattern, but restore old flag
+# for backward compatibility.
+Template.flags = _re.IGNORECASE
 
 
 ########################################################################

--- a/Lib/test/test_string.py
+++ b/Lib/test/test_string.py
@@ -270,6 +270,10 @@ class TestTemplate(unittest.TestCase):
         raises(ValueError, s.substitute, dict(who='tim'))
         s = Template('$who likes $100')
         raises(ValueError, s.substitute, dict(who='tim'))
+        # Template.idpattern should match to only ASCII characters.
+        # https://bugs.python.org/issue31672
+        s = Template("$who likes $ı")  # (0x131, DOTLESS I)
+        raises(ValueError, s.substitute, dict(who='tim'))
 
     def test_idpattern_override(self):
         class PathPattern(Template):

--- a/Lib/test/test_string.py
+++ b/Lib/test/test_string.py
@@ -272,7 +272,9 @@ class TestTemplate(unittest.TestCase):
         raises(ValueError, s.substitute, dict(who='tim'))
         # Template.idpattern should match to only ASCII characters.
         # https://bugs.python.org/issue31672
-        s = Template("$who likes $ı")  # (0x131, DOTLESS I)
+        s = Template("$who likes $\u0131")  # (DOTLESS I)
+        raises(ValueError, s.substitute, dict(who='tim'))
+        s = Template("$who likes $\u0130")  # (LATIN CAPITAL LETTER I WITH DOT ABOVE)
         raises(ValueError, s.substitute, dict(who='tim'))
 
     def test_idpattern_override(self):

--- a/Misc/NEWS.d/next/Library/2017-10-12-02-47-16.bpo-31672.DaOkVd.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-12-02-47-16.bpo-31672.DaOkVd.rst
@@ -1,2 +1,2 @@
-``idpattern`` in ``string.Template`` matched some non ASCII characters. Now
-it uses ``-i`` regular expression local flag to avoid non ASCII characters.
+``idpattern`` in ``string.Template`` matched some non-ASCII characters. Now
+it uses ``-i`` regular expression local flag to avoid non-ASCII characters.

--- a/Misc/NEWS.d/next/Library/2017-10-12-02-47-16.bpo-31672.DaOkVd.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-12-02-47-16.bpo-31672.DaOkVd.rst
@@ -1,0 +1,2 @@
+``idpattern`` in ``string.Template`` matched some non ASCII characters. Now
+it uses ``-i`` regular expression local flag to avoid non ASCII characters.


### PR DESCRIPTION
As documented, identifier should be ASCII.
Since we forgot re.A flag, it matched to some non ASCII characters.

For backward compatibility, we need to remove re.A flag after
pattern is compiled.

<!-- issue-number: bpo-31672 -->
https://bugs.python.org/issue31672
<!-- /issue-number -->
