### PR TITLE
replaced double-quotes for single-quotes

### DIFF
--- a/Lib/imghdr.py
+++ b/Lib/imghdr.py
@@ -2,7 +2,7 @@
 
 from os import PathLike
 
-__all__ = ["what"]
+__all__ = ['what']
 
 #-------------------------#
 # Recognize image headers #


### PR DESCRIPTION
imghdr uses single-quotes for most strings. This PR replaces the double quotes found in `__all__` for single quotes to improve consistency.