### PR TITLE
closes bpo-31696: don't mention GCC in sys.version when building with clang

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-10-04-23-40-32.bpo-31696.Y3_aBV.rst
+++ b/Misc/NEWS.d/next/Build/2017-10-04-23-40-32.bpo-31696.Y3_aBV.rst
@@ -1,0 +1,2 @@
+Improve compiler version information in :data:`sys.version` when Python is
+built with Clang.

--- a/Python/getcompiler.c
+++ b/Python/getcompiler.c
@@ -5,15 +5,14 @@
 
 #ifndef COMPILER
 
-#ifdef __GNUC__
+// Note the __clang__ conditional has to come before the __GNUC__ one because
+// clang pretends to be GCC.
+#if defined(__clang__)
+#define COMPILER "\n[Clang " __clang_version__ "]"
+#elif defined(__GNUC__)
 #define COMPILER "\n[GCC " __VERSION__ "]"
-#endif
-
-#endif /* !COMPILER */
-
-#ifndef COMPILER
-
-#ifdef __cplusplus
+// Generic fallbacks.
+#elif defined(__cplusplus)
 #define COMPILER "[C++]"
 #else
 #define COMPILER "[C]"


### PR DESCRIPTION


<!-- issue-number: bpo-31696 -->
https://bugs.python.org/issue31696
<!-- /issue-number -->
