### PR TITLE
[WIP] bpo-31626: Rewrite _PyMem_DebugRawRealloc()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-05-18-38-47.bpo-31626.tDXcnr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-05-18-38-47.bpo-31626.tDXcnr.rst
@@ -1,0 +1,18 @@
+Rewrite _PyMem_DebugRawRealloc().
+
+Previously, _PyMem_DebugRawRealloc() expected that the old memory
+block remains readable and unchanged after realloc(). This assumption
+is wrong on OpenBSD.
+
+Rewrite _PyMem_DebugRawRealloc() as malloc()+free() rather than
+realloc(). Debug hooks are reused. The old memory block remains valid
+after the new memory block was allocated, so bytes can be safely
+copied in a portable way.
+
+The drawback is that _PyMem_DebugRawRealloc() now allocates a new
+memory block while the old memory block remains allocated, until the
+old memory block is freed, so the peak memory usage can be the double
+in the worst case.
+
+The second drawback is that the system realloc() is no more used in
+debug mode.


### PR DESCRIPTION
Previously, _PyMem_DebugRawRealloc() expected that the old memory
block remains readable and unchanged after realloc(). This assumption
is wrong on OpenBSD.

Rewrite _PyMem_DebugRawRealloc() as malloc()+free() rather than
realloc(). Debug hooks are reused. The old memory block remains valid
after the new memory block was allocated, so bytes can be safely
copied in a portable way.

The drawback is that _PyMem_DebugRawRealloc() now allocates a new
memory block while the old memory block remains allocated, until the
old memory block is freed, so the peak memory usage can be the double
in the worst case.

The second drawback is that the system realloc() is no more used in
debug mode.

<!-- issue-number: bpo-31626 -->
https://bugs.python.org/issue31626
<!-- /issue-number -->
