### PR TITLE
bpo-31655: Validate keyword names in SimpleNamespace constructor.

### DIFF
--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1069,6 +1069,8 @@ class SimpleNamespaceTests(unittest.TestCase):
 
         with self.assertRaises(TypeError):
             types.SimpleNamespace(1, 2, 3)
+        with self.assertRaises(TypeError):
+            types.SimpleNamespace(**{1: 2})
 
         self.assertEqual(len(ns1.__dict__), 0)
         self.assertEqual(vars(ns1), {})

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -44,8 +44,12 @@ namespace_init(_PyNamespaceObject *ns, PyObject *args, PyObject *kwds)
         PyErr_Format(PyExc_TypeError, "no positional arguments expected");
         return -1;
     }
-    if (kwds == NULL)
+    if (kwds == NULL) {
         return 0;
+    }
+    if (!PyArg_ValidateKeywordArguments(kwds)) {
+        return -1;
+    }
     return PyDict_Update(ns->ns_dict, kwds);
 }
 


### PR DESCRIPTION


<!-- issue-number: bpo-31655 -->
https://bugs.python.org/issue31655
<!-- /issue-number -->
