### PR TITLE
[2.7] bpo-31692: COUNT_ALLOCS now writes into stderr, fix also tests for COUNT_ALLOCS

### DIFF
--- a/Lib/json/tests/test_tool.py
+++ b/Lib/json/tests/test_tool.py
@@ -56,7 +56,9 @@ class TestTool(unittest.TestCase):
         infile = self._create_infile()
         rc, out, err = assert_python_ok('-m', 'json.tool', infile)
         self.assertEqual(out.splitlines(), self.expect.encode().splitlines())
-        self.assertEqual(err, b'')
+        # If COUNT_ALLOCS is defined, don't check stderr
+        if not hasattr(sys, 'getcounts'):
+            self.assertEqual(err, b'')
 
     def test_infile_outfile(self):
         infile = self._create_infile()
@@ -66,4 +68,6 @@ class TestTool(unittest.TestCase):
         with open(outfile, "r") as fp:
             self.assertEqual(fp.read(), self.expect)
         self.assertEqual(out, b'')
-        self.assertEqual(err, b'')
+        # If COUNT_ALLOCS is defined, don't check stderr
+        if not hasattr(sys, 'getcounts'):
+            self.assertEqual(err, b'')

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1795,6 +1795,9 @@ def py3k_bytes(b):
         except TypeError:
             return bytes(b)
 
+requires_type_collecting = unittest.skipIf(hasattr(sys, 'getcounts'),
+                        'types are immortal if COUNT_ALLOCS is defined')
+
 def args_from_interpreter_flags():
     """Return a list of command-line arguments reproducing the current
     settings in sys.flags."""

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -5,6 +5,7 @@
 
 import unittest, weakref
 from test import test_support
+from support import requires_type_collecting
 
 import abc
 from inspect import isabstract
@@ -208,6 +209,7 @@ class TestABC(unittest.TestCase):
         C()
         self.assertEqual(B.counter, 1)
 
+    @requires_type_collecting
     def test_cache_leak(self):
         # See issue #2521.
         class A(object):

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1,5 +1,6 @@
 import unittest
-from test.test_support import verbose, run_unittest, start_threads
+from test.support import (verbose, run_unittest, start_threads,
+                          requires_type_collecting)
 import sys
 import time
 import gc
@@ -90,6 +91,7 @@ class GCTests(unittest.TestCase):
         del a
         self.assertNotEqual(gc.collect(), 0)
 
+    @requires_type_collecting
     def test_newinstance(self):
         class A(object):
             pass

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -158,7 +158,7 @@ class HashRandomizationTests(unittest.TestCase):
             env.pop('PYTHONHASHSEED', None)
         cmd_line = [sys.executable, '-c', self.get_hash_command(repr_)]
         p = subprocess.Popen(cmd_line, stdin=subprocess.PIPE,
-                             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                             stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                              env=env)
         out, err = p.communicate()
         out = test_support.strip_python_stderr(out)

--- a/Lib/test/test_module.py
+++ b/Lib/test/test_module.py
@@ -1,6 +1,6 @@
 # Test the module type
 import unittest
-from test.test_support import run_unittest, gc_collect
+from test.support import run_unittest, gc_collect, requires_type_collecting
 
 import sys
 ModuleType = type(sys)
@@ -65,6 +65,7 @@ class ModuleTests(unittest.TestCase):
         gc_collect()
         self.assertEqual(f().__dict__["bar"], 4)
 
+    @requires_type_collecting
     def test_clear_dict_in_ref_cycle(self):
         destroyed = []
         m = ModuleType("foo")

--- a/Lib/test/test_multiprocessing.py
+++ b/Lib/test/test_multiprocessing.py
@@ -2610,7 +2610,9 @@ class TestNoForkBomb(unittest.TestCase):
         else:
             rc, out, err = test.script_helper.assert_python_ok(name)
             self.assertEqual(out.rstrip(), '123')
-            self.assertEqual(err, '')
+            # If COUNT_ALLOCS is defined, don't check stderr
+            if not hasattr(sys, 'getcounts'):
+                self.assertEqual(err, '')
 
 #
 # Issue 12098: check sys.flags of child matches that for parent

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -493,6 +493,7 @@ class ArgsTestCase(BaseTestCase):
             self.assertIn(line2, reflog)
 
     @unittest.skipUnless(Py_DEBUG, 'need a debug build')
+    @support.requires_type_collecting
     def test_huntrleaks(self):
         # test --huntrleaks
         code = textwrap.dedent("""

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -46,6 +46,12 @@ else:
     SETBINARY = ''
 
 
+
+# bpo-31692: If COUNT_ALLOCS is defined, stderr is flooded with allocation
+# statistics and so cannot be checked in a reliable way
+skip_unless_usable_stderr = test_support.requires_type_collecting
+
+
 class BaseTestCase(unittest.TestCase):
     def setUp(self):
         # Try to minimize the number of children we have so this test
@@ -272,6 +278,7 @@ class ProcessTestCase(BaseTestCase):
         tf.seek(0)
         self.assertEqual(tf.read(), "orange")
 
+    @skip_unless_usable_stderr
     def test_stderr_pipe(self):
         # stderr redirection
         p = subprocess.Popen([sys.executable, "-c",
@@ -280,6 +287,7 @@ class ProcessTestCase(BaseTestCase):
         self.addCleanup(p.stderr.close)
         self.assertStderrEqual(p.stderr.read(), "strawberry")
 
+    @skip_unless_usable_stderr
     def test_stderr_filedes(self):
         # stderr is set to open file descriptor
         tf = tempfile.TemporaryFile()
@@ -291,6 +299,7 @@ class ProcessTestCase(BaseTestCase):
         os.lseek(d, 0, 0)
         self.assertStderrEqual(os.read(d, 1024), "strawberry")
 
+    @skip_unless_usable_stderr
     def test_stderr_fileobj(self):
         # stderr is set to open file object
         tf = tempfile.TemporaryFile()
@@ -301,6 +310,7 @@ class ProcessTestCase(BaseTestCase):
         tf.seek(0)
         self.assertStderrEqual(tf.read(), "strawberry")
 
+    @skip_unless_usable_stderr
     def test_stderr_redirect_with_no_stdout_redirect(self):
         # test stderr=STDOUT while stdout=None (not set)
 
@@ -322,6 +332,7 @@ class ProcessTestCase(BaseTestCase):
         self.assertStderrEqual(stderr, b'') # should be empty
         self.assertEqual(p.returncode, 0)
 
+    @skip_unless_usable_stderr
     def test_stdout_stderr_pipe(self):
         # capture stdout and stderr to the same pipe
         p = subprocess.Popen([sys.executable, "-c",
@@ -334,6 +345,7 @@ class ProcessTestCase(BaseTestCase):
         self.addCleanup(p.stdout.close)
         self.assertStderrEqual(p.stdout.read(), "appleorange")
 
+    @skip_unless_usable_stderr
     def test_stdout_stderr_file(self):
         # capture stdout and stderr to the same open file
         tf = tempfile.TemporaryFile()
@@ -451,6 +463,7 @@ class ProcessTestCase(BaseTestCase):
         self.assertEqual(stdout, "pineapple")
         self.assertEqual(stderr, None)
 
+    @skip_unless_usable_stderr
     def test_communicate_stderr(self):
         p = subprocess.Popen([sys.executable, "-c",
                               'import sys; sys.stderr.write("pineapple")'],
@@ -459,6 +472,7 @@ class ProcessTestCase(BaseTestCase):
         self.assertEqual(stdout, None)
         self.assertStderrEqual(stderr, "pineapple")
 
+    @skip_unless_usable_stderr
     def test_communicate(self):
         p = subprocess.Popen([sys.executable, "-c",
                           'import sys,os;'
@@ -525,6 +539,7 @@ class ProcessTestCase(BaseTestCase):
         (stdout, stderr) = p.communicate(string_to_write)
         self.assertEqual(stdout, string_to_write)
 
+    @skip_unless_usable_stderr
     def test_writes_before_communicate(self):
         # stdin.write before communicate()
         p = subprocess.Popen([sys.executable, "-c",
@@ -1071,6 +1086,7 @@ class POSIXProcessTestCase(BaseTestCase):
         # Terminating a dead process
         self._kill_dead_process('terminate')
 
+    @skip_unless_usable_stderr
     def check_close_std_fds(self, fds):
         # Issue #9905: test that subprocess pipes still work properly with
         # some standard fds closed
@@ -1173,6 +1189,7 @@ class POSIXProcessTestCase(BaseTestCase):
     # When duping fds, if there arises a situation where one of the fds is
     # either 0, 1 or 2, it is possible that it is overwritten (#12607).
     # This tests all combinations of this.
+    @skip_unless_usable_stderr
     def test_swap_fds(self):
         self.check_swap_fds(0, 1, 2)
         self.check_swap_fds(0, 2, 1)

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1,7 +1,7 @@
 # Very rudimentary test of threading module
 
 import test.test_support
-from test.test_support import verbose, cpython_only
+from test.support import verbose, cpython_only, requires_type_collecting
 from test.script_helper import assert_python_ok
 
 import random
@@ -812,6 +812,7 @@ class ThreadingExceptionTests(BaseTestCase):
         self.assertIn("ZeroDivisionError", err)
         self.assertNotIn("Unhandled exception", err)
 
+    @requires_type_collecting
     def test_print_exception_stderr_is_none_1(self):
         script = r"""if 1:
             import sys

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -360,7 +360,9 @@ class ThreadTests(BaseTestCase):
         self.assertEqual(stdout.strip(),
             "Woke up, sleep function is: <built-in function sleep>")
         stderr = re.sub(r"^\[\d+ refs\]", "", stderr, re.MULTILINE).strip()
-        self.assertEqual(stderr, "")
+        # If COUNT_ALLOCS is defined, don't check stderr
+        if not hasattr(sys, 'getcounts'):
+            self.assertEqual(stderr, "")
 
     def test_enumerate_after_join(self):
         # Try hard to trigger #1703448: a thread is still returned in
@@ -437,7 +439,9 @@ class ThreadTests(BaseTestCase):
         """
         _, out, err = assert_python_ok("-c", code)
         self.assertEqual(out, '')
-        self.assertEqual(err, '')
+        # If COUNT_ALLOCS is defined, don't check stderr
+        if not hasattr(sys, 'getcounts'):
+            self.assertEqual(err, '')
 
     @unittest.skipUnless(hasattr(os, 'fork'), "needs os.fork()")
     def test_is_alive_after_fork(self):

--- a/Lib/test/test_tools.py
+++ b/Lib/test/test_tools.py
@@ -69,7 +69,9 @@ class PindentTests(unittest.TestCase):
 
             rc, out, err = assert_python_ok(self.script, '-d', data_path)
             self.assertEqual(out, b'')
-            self.assertEqual(err, b'')
+            # If COUNT_ALLOCS is defined, don't check stderr
+            if not hasattr(sys, 'getcounts'):
+                self.assertEqual(err, b'')
             backup = data_path + '~'
             self.assertTrue(os.path.exists(backup))
             with open(backup) as f:
@@ -82,7 +84,8 @@ class PindentTests(unittest.TestCase):
 
             rc, out, err = assert_python_ok(self.script, '-c', data_path)
             self.assertEqual(out, b'')
-            self.assertEqual(err, b'')
+            if not hasattr(sys, 'getcounts'):
+                self.assertEqual(err, b'')
             with open(backup) as f:
                 self.assertEqual(f.read(), clean)
             with open(data_path) as f:
@@ -93,7 +96,8 @@ class PindentTests(unittest.TestCase):
                 f.write(broken)
             rc, out, err = assert_python_ok(self.script, '-r', data_path)
             self.assertEqual(out, b'')
-            self.assertEqual(err, b'')
+            if not hasattr(sys, 'getcounts'):
+                self.assertEqual(err, b'')
             with open(backup) as f:
                 self.assertEqual(f.read(), broken)
             with open(data_path) as f:

--- a/Lib/test/test_warnings.py
+++ b/Lib/test/test_warnings.py
@@ -419,6 +419,8 @@ class WCmdLineTests(unittest.TestCase):
         rc, out, err = assert_python_ok("-Wxxx", "-c", "pass")
         self.assertIn(b"Invalid -W option ignored: invalid action: 'xxx'", err)
 
+    # Don't check stderr when COUNT_ALLOCS is defined
+    @test_support.requires_type_collecting
     def test_warnings_bootstrap(self):
         # Check that the warnings module does get loaded when -W<some option>
         # is used (see issue #10372 for an example of silent bootstrap failure).
@@ -575,6 +577,8 @@ class _WarningsTests(BaseTest):
         finally:
             globals_dict['__file__'] = oldfile
 
+    # Don't check stderr when COUNT_ALLOCS is defined
+    @test_support.requires_type_collecting
     def test_stderr_none(self):
         rc, stdout, stderr = assert_python_ok("-c",
             "import sys; sys.stderr = None; "

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -601,7 +601,7 @@ class ReferencesTestCase(TestBase):
         del c1, c2, C, D
         gc.collect()
 
-    @support.requires_type_collecting
+    @test_support.requires_type_collecting
     def test_callback_in_cycle_resurrection(self):
         import gc
 

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -601,6 +601,7 @@ class ReferencesTestCase(TestBase):
         del c1, c2, C, D
         gc.collect()
 
+    @support.requires_type_collecting
     def test_callback_in_cycle_resurrection(self):
         import gc
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-06-21-56-47.bpo-31692.osJuVJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-06-21-56-47.bpo-31692.osJuVJ.rst
@@ -1,0 +1,2 @@
+COUNT_ALLOCSi debug mode now writes allocations statistics into stderr,
+rather than stdout.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -481,7 +481,7 @@ Py_Finalize(void)
 
     /* Debugging stuff */
 #ifdef COUNT_ALLOCS
-    dump_counts(stdout);
+    dump_counts(stderr);
 #endif
 
     PRINT_TOTAL_REFS();


### PR DESCRIPTION
* bpo-31692: COUNT_ALLOCS now writes into stderr
* bpo-19527: Fixed tests with defined COUNT_ALLOCS.
* bpo-31692: Fix more tests for COUNT_ALLOCS


<!-- issue-number: bpo-31692 -->
https://bugs.python.org/issue31692
<!-- /issue-number -->
