### PR TITLE
bpo-31165: Detect mutated list in list_slice()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-06-22-08-50.bpo-31165.rH1Z10.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-06-22-08-50.bpo-31165.rH1Z10.rst
@@ -1,0 +1,2 @@
+Detect mutated list in list_slice(): check if the list size changed
+before/after allocating a new list object to prevent a crash.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -436,19 +436,25 @@ list_slice(PyListObject *a, Py_ssize_t ilow, Py_ssize_t ihigh)
 {
     PyListObject *np;
     PyObject **src, **dest;
-    Py_ssize_t i, len;
+    Py_ssize_t alen, i, len;
+    alen = Py_SIZE(a);
     if (ilow < 0)
         ilow = 0;
-    else if (ilow > Py_SIZE(a))
-        ilow = Py_SIZE(a);
+    else if (ilow > alen)
+        ilow = alen;
     if (ihigh < ilow)
         ihigh = ilow;
-    else if (ihigh > Py_SIZE(a))
-        ihigh = Py_SIZE(a);
+    else if (ihigh > alen)
+        ihigh = alen;
     len = ihigh - ilow;
     np = (PyListObject *) PyList_New(len);
     if (np == NULL)
         return NULL;
+
+    if (Py_SIZE(a) != alen) {
+        PyErr_SetString(PyExc_RuntimeError, "list mutated during slicing");
+        return NULL;
+    }
 
     src = a->ob_item + ilow;
     dest = np->ob_item;


### PR DESCRIPTION
Check if the list size changed before/after allocating a new list
object to prevent a crash.

<!-- issue-number: bpo-31165 -->
https://bugs.python.org/issue31165
<!-- /issue-number -->
