### PR TITLE
bpo-31719: Fix test_regrtest.test_crashed() on s390x

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1960,6 +1960,6 @@ def _crash_python():
     Use SuppressCrashReport() to prevent a crash report from popping up.
     """
 
-    import ctypes
+    import _testcapi
     with SuppressCrashReport():
-        ctypes.string_at(0)
+        _testcapi._read_null()

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -543,6 +543,8 @@ class ArgsTestCase(BaseTestCase):
                                 testname)
         self.assertEqual(output.splitlines(), all_methods)
 
+    @unittest.skipIf(sys.platform.startswith('aix'),
+                     "support._crash_python() doesn't work on AIX")
     def test_crashed(self):
         # Any code which causes a crash
         code = 'import test.support; test.support._crash_python()'

--- a/Misc/NEWS.d/next/Tests/2017-10-06-22-37-38.bpo-31719.gHyrV3.rst
+++ b/Misc/NEWS.d/next/Tests/2017-10-06-22-37-38.bpo-31719.gHyrV3.rst
@@ -1,0 +1,3 @@
+Fix test_regrtest.test_crashed() on s390x. Add a new _testcapi._read_null()
+function to crash Python in a reliable way on s390x. On s390x,
+ctypes.string_at(0) returns an empty string rather than crashing.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2566,6 +2566,22 @@ py_w_stopcode(PyObject *self, PyObject *args)
 #endif
 
 
+/* Read memory from NULL (address 0) to raise a SIGSEGV or SIGBUS signal
+   depending on the platform. This function is used by
+   test.support._crash_python() to "crash" Python. */
+static PyObject *
+read_null(PyObject *self, PyObject *args)
+{
+    volatile int *x;
+    volatile int y;
+
+    x = NULL;
+    y = *x;
+    return PyLong_FromLong(y);
+
+}
+
+
 static PyMethodDef TestMethods[] = {
     {"raise_exception",         raise_exception,                 METH_VARARGS},
     {"set_errno",               set_errno,                       METH_VARARGS},
@@ -2685,6 +2701,7 @@ static PyMethodDef TestMethods[] = {
 #ifdef W_STOPCODE
     {"W_STOPCODE", py_w_stopcode, METH_VARARGS},
 #endif
+    {"_read_null", (PyCFunction)read_null, METH_NOARGS},
     {NULL, NULL} /* sentinel */
 };
 


### PR DESCRIPTION
Add a new _testcapi._read_null() function to crash Python in a
reliable way on s390x.

On s390x, ctypes.string_at(0) returns an empty string rather than
crashing.

<!-- issue-number: bpo-31719 -->
https://bugs.python.org/issue31719
<!-- /issue-number -->
