### PR TITLE
bpo-31720: msilib.MSIError is spelled MsiError in documentation

### DIFF
--- a/Doc/library/msilib.rst
+++ b/Doc/library/msilib.rst
@@ -312,7 +312,7 @@ Record Objects
 Errors
 ------
 
-All wrappers around MSI functions raise :exc:`MsiError`; the string inside the
+All wrappers around MSI functions raise :exc:`MSIError`; the string inside the
 exception will contain more detail.
 
 


### PR DESCRIPTION
https://bugs.python.org/issue31720

<!-- issue-number: bpo-31720 -->
https://bugs.python.org/issue31720
<!-- /issue-number -->
