### PR TITLE
bpo-25862: Fix an assertion failure in io.TextIOWrapper.tell().

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -2149,6 +2149,7 @@ class TextIOWrapper(TextIOBase):
         self.buffer.write(b)
         if self._line_buffering and (haslf or "\r" in s):
             self.flush()
+        self._set_decoded_chars('')
         self._snapshot = None
         if self._decoder:
             self._decoder.reset()

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3549,6 +3549,13 @@ class TextIOWrapperTest(unittest.TestCase):
         expected = 'linesep' + os.linesep + 'LF\nLF\nCR\rCRLF\r\n'
         self.assertEqual(txt.detach().getvalue().decode('ascii'), expected)
 
+    def test_issue25862(self):
+        # tell() shouldn't cause an assertion failure if called after read().
+        t = self.TextIOWrapper(self.BytesIO(b'test'))
+        t.read(1)
+        t.read()
+        t.tell()
+
 
 class MemviewBytesIO(io.BytesIO):
     '''A BytesIO object whose read method returns memoryviews

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3550,10 +3550,14 @@ class TextIOWrapperTest(unittest.TestCase):
         self.assertEqual(txt.detach().getvalue().decode('ascii'), expected)
 
     def test_issue25862(self):
-        # tell() shouldn't cause an assertion failure if called after read().
-        t = self.TextIOWrapper(self.BytesIO(b'test'))
+        # Assertion failures occurred in tell() after read() and write().
+        t = self.TextIOWrapper(self.BytesIO(b'test'), encoding='ascii')
         t.read(1)
         t.read()
+        t.tell()
+        t = self.TextIOWrapper(self.BytesIO(b'test'), encoding='ascii')
+        t.read(1)
+        t.write('x')
         t.tell()
 
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-07-10-13-15.bpo-25862.FPYBA5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-07-10-13-15.bpo-25862.FPYBA5.rst
@@ -1,0 +1,2 @@
+Fix an assertion failure in the ``tell()`` method of ``io.TextIOWrapper``.
+Patch by Zackery Spytz.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-07-10-13-15.bpo-25862.FPYBA5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-07-10-13-15.bpo-25862.FPYBA5.rst
@@ -1,2 +1,2 @@
-Fix an assertion failure in the ``tell()`` method of ``io.TextIOWrapper``.
+Fix assertion failures in the ``tell()`` method of ``io.TextIOWrapper``.
 Patch by Zackery Spytz.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -694,6 +694,9 @@ typedef struct
     PyObject *dict;
 } textio;
 
+static void
+textiowrapper_set_decoded_chars(textio *self, PyObject *chars);
+
 /* A couple of specialized cases in order to bypass the slow incremental
    encoding methods for the most popular encodings. */
 
@@ -1606,6 +1609,7 @@ _io_TextIOWrapper_write_impl(textio *self, PyObject *text)
         Py_DECREF(ret);
     }
 
+    textiowrapper_set_decoded_chars(self, NULL);
     Py_CLEAR(self->snapshot);
 
     if (self->decoder) {

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1835,6 +1835,7 @@ _io_TextIOWrapper_read_impl(textio *self, Py_ssize_t n)
         if (result == NULL)
             goto fail;
 
+        textiowrapper_set_decoded_chars(self, NULL);
         Py_CLEAR(self->snapshot);
         return result;
     }


### PR DESCRIPTION
Calling `read()` can call `Py_CLEAR(self->snapshot)`, but `self->decoded_chars` is not set to `NULL` in this case. This can cause an assertion failure in `tell()`.

<!-- issue-number: bpo-25862 -->
https://bugs.python.org/issue25862
<!-- /issue-number -->
