### PR TITLE
bpo-31724: Skip test_xmlrpc_net

### DIFF
--- a/Lib/test/test_xmlrpc_net.py
+++ b/Lib/test/test_xmlrpc_net.py
@@ -4,6 +4,8 @@ from test import support
 
 import xmlrpc.client as xmlrpclib
 
+
+@unittest.skip('XXX: buildbot.python.org/all/xmlrpc/ is gone')
 class PythonBuildersTest(unittest.TestCase):
 
     def test_python_builders(self):


### PR DESCRIPTION
With the upgrade of buildbot.python.org from Buildbot 0.8.x to 0.9.x,
the xmlrpc interface has been removed.  This test is now skipped until
it can be rewritten to query a suitable substitute.

<!-- issue-number: bpo-31724 -->
https://bugs.python.org/issue31724
<!-- /issue-number -->
