### PR TITLE
bpo-31537: Fix bug in readline documentation example code

### DIFF
--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -312,13 +312,13 @@ sessions, by only appending the new history. ::
 
    try:
        readline.read_history_file(histfile)
-       h_len = readline.get_history_length()
+       h_len = readline.get_current_history_length()
    except FileNotFoundError:
        open(histfile, 'wb').close()
        h_len = 0
 
    def save(prev_h_len, histfile):
-       new_h_len = readline.get_history_length()
+       new_h_len = readline.get_current_history_length()
        readline.set_history_length(1000)
        readline.append_history_file(new_h_len - prev_h_len, histfile)
    atexit.register(save, h_len, histfile)

--- a/Misc/NEWS.d/next/Documentation/2017-10-08-23-02-14.bpo-31537.SiFNM8.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-10-08-23-02-14.bpo-31537.SiFNM8.rst
@@ -1,0 +1,2 @@
+Fix incorrect usage of ``get_history_length`` in readline documentation
+example code. Patch by Brad Smith.


### PR DESCRIPTION
Use `get_current_history_length` to get the current length of the history, not `get_history_length`. This fixes an issue where the example code's call to `append_history_file` in the `save` function would never actually write any lines to the file.

Fixes https://bugs.python.org/issue31537

<!-- issue-number: bpo-31537 -->
https://bugs.python.org/issue31537
<!-- /issue-number -->
