### PR TITLE
bpo-31701: faulthandler.enable() registers exc handler as last

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-10-09-12-22-57.bpo-31701.Ti8o41.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-09-12-22-57.bpo-31701.Ti8o41.rst
@@ -1,0 +1,3 @@
+On Windows, faulthandler.enable() now registers the exception handler as the
+last handler to be called, rather than the first to be called. It prevents
+handled C++ exceptions to be logged by faulthandler.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -457,7 +457,7 @@ faulthandler_enable(void)
 
 #ifdef MS_WINDOWS
     assert(fatal_error.exc_handler == NULL);
-    fatal_error.exc_handler = AddVectoredExceptionHandler(1, faulthandler_exc_handler);
+    fatal_error.exc_handler = AddVectoredExceptionHandler(0, faulthandler_exc_handler);
 #endif
     return 0;
 }


### PR DESCRIPTION
bpo-31701: On Windows, faulthandler.enable() now registers the
exception handler as the last handler to be called, rather than the
first to be called. It prevents handled C++ exceptions to be logged
by faulthandler.

<!-- issue-number: bpo-31701 -->
https://bugs.python.org/issue31701
<!-- /issue-number -->
