### PR TITLE
bpo-31732: Add TRACE level to the logging module

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -354,8 +354,13 @@ name is lost.
 +--------------+---------------+
 | ``DEBUG``    | 10            |
 +--------------+---------------+
+| ``TRACE``    | 5             |
++--------------+---------------+
 | ``NOTSET``   | 0             |
 +--------------+---------------+
+
+.. versionchanged:: 3.7
+   Added the :data:`TRACE` log level.
 
 
 .. _handler:
@@ -768,13 +773,13 @@ the options available to you.
 | funcName       | ``%(funcName)s``        | Name of function containing the logging call. |
 +----------------+-------------------------+-----------------------------------------------+
 | levelname      | ``%(levelname)s``       | Text logging level for the message            |
-|                |                         | (``'DEBUG'``, ``'INFO'``, ``'WARNING'``,      |
-|                |                         | ``'ERROR'``, ``'CRITICAL'``).                 |
+|                |                         | (``'TRACE'``, ``'DEBUG'``, ``'INFO'``,        |
+|                |                         | ``'WARNING'``, ``'ERROR'``, ``'CRITICAL'``).  |
 +----------------+-------------------------+-----------------------------------------------+
 | levelno        | ``%(levelno)s``         | Numeric logging level for the message         |
-|                |                         | (:const:`DEBUG`, :const:`INFO`,               |
-|                |                         | :const:`WARNING`, :const:`ERROR`,             |
-|                |                         | :const:`CRITICAL`).                           |
+|                |                         | (:const:`TRACE`, :const:`DEBUG`,              |
+|                |                         | :const:`INFO`, :const:`WARNING`,              |
+|                |                         | :const:`ERROR`, :const:`CRITICAL`).           |
 +----------------+-------------------------+-----------------------------------------------+
 | lineno         | ``%(lineno)d``          | Source line number where the logging call was |
 |                |                         | issued (if available).                        |
@@ -1009,6 +1014,12 @@ functions.
    are interpreted as for :func:`debug`.
 
 
+.. function:: trace(msg, *args, **kwargs)
+
+   Logs a message with level :const:`TRACE` on the root logger. The arguments are
+   interpreted as for :func:`debug`.
+
+
 .. function:: exception(msg, *args, **kwargs)
 
    Logs a message with level :const:`ERROR` on the root logger. The arguments are
@@ -1068,7 +1079,8 @@ functions.
 
    Returns the textual representation of logging level *lvl*. If the level is one
    of the predefined levels :const:`CRITICAL`, :const:`ERROR`, :const:`WARNING`,
-   :const:`INFO` or :const:`DEBUG` then you get the corresponding string. If you
+   :const:`INFO`, :const:`DEBUG` or :const:`TRACE`
+   then you get the corresponding string. If you
    have associated levels with names using :func:`addLevelName` then the name you
    have associated with *lvl* is returned. If a numeric value corresponding to one
    of the defined levels is passed in, the corresponding string representation is

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -264,6 +264,12 @@ Added another argument *monetary* in :meth:`format_string` of :mod:`locale`.
 If *monetary* is true, the conversion uses monetary thousands separator and
 grouping strings. (Contributed by Garvit in :issue:`10379`.)
 
+logging
+-------
+
+Added a new :data:`logging.TRACE` level, lower than :data:`DEBUG`. It can
+be used to log verbose debug traces like Python tracebacks.
+
 math
 ----
 

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -745,6 +745,7 @@ class SysLogHandler(logging.Handler):
         "crit":     LOG_CRIT,
         "critical": LOG_CRIT,
         "debug":    LOG_DEBUG,
+        "trace":    LOG_DEBUG,
         "emerg":    LOG_EMERG,
         "err":      LOG_ERR,
         "error":    LOG_ERR,        #  DEPRECATED
@@ -784,6 +785,7 @@ class SysLogHandler(logging.Handler):
     #gives unexpected results. See SF #1524081: in the Turkish locale,
     #"INFO".lower() != "info"
     priority_map = {
+        "TRACE" : "trace",
         "DEBUG" : "debug",
         "INFO" : "info",
         "WARNING" : "warning",
@@ -1047,6 +1049,7 @@ class NTEventLogHandler(logging.Handler):
             self._welu.AddSourceToRegistry(appname, dllname, logtype)
             self.deftype = win32evtlog.EVENTLOG_ERROR_TYPE
             self.typemap = {
+                logging.TRACE   : win32evtlog.EVENTLOG_INFORMATION_TYPE,
                 logging.DEBUG   : win32evtlog.EVENTLOG_INFORMATION_TYPE,
                 logging.INFO    : win32evtlog.EVENTLOG_INFORMATION_TYPE,
                 logging.WARNING : win32evtlog.EVENTLOG_WARNING_TYPE,

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -186,7 +186,7 @@ class BuiltinLevelsTest(BaseTest):
         INF = logging.LoggerAdapter(logging.getLogger("INF"), {})
         INF.setLevel(logging.INFO)
         DEB = logging.getLogger("DEB")
-        DEB.setLevel(logging.DEBUG)
+        DEB.setLevel(logging.TRACE)
 
         # These should log.
         ERR.log(logging.CRITICAL, m())
@@ -202,13 +202,16 @@ class BuiltinLevelsTest(BaseTest):
         DEB.warning(m())
         DEB.info(m())
         DEB.debug(m())
+        DEB.trace(m())
 
         # These should not log.
         ERR.warning(m())
         ERR.info(m())
         ERR.debug(m())
+        ERR.trace(m())
 
         INF.debug(m())
+        INF.trace(m())
 
         self.assert_log_lines([
             ('ERR', 'CRITICAL', '1'),
@@ -222,6 +225,7 @@ class BuiltinLevelsTest(BaseTest):
             ('DEB', 'WARNING', '9'),
             ('DEB', 'INFO', '10'),
             ('DEB', 'DEBUG', '11'),
+            ('DEB', 'TRACE', '12'),
         ])
 
     def test_nested_explicit(self):

--- a/Misc/NEWS.d/next/Library/2017-10-09-14-52-56.bpo-31732.tFoQrv.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-09-14-52-56.bpo-31732.tFoQrv.rst
@@ -1,0 +1,1 @@
+logging module: add TRACE level, trace() function and Logger.trace() method.


### PR DESCRIPTION
* Add logging.TRACE level
* Add logging.trace() function
* Add logging.Logger.trace() method
* SysLogHandler: map logging TRACE level to syslog LOG_DEBUG level
* NTEventLogHandler: map logging TRACE level to
  EVENTLOG_INFORMATION_TYPE

<!-- issue-number: bpo-31732 -->
https://bugs.python.org/issue31732
<!-- /issue-number -->
