### PR TITLE
[2.7] bpo-31733: Add PYTHONSHOWREFCOUNT env var

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -663,3 +663,10 @@ if Python was configured with the ``--with-pydebug`` build option.
 
    If set, Python will print memory allocation statistics every time a new
    object arena is created, and on shutdown.
+
+.. envvar:: PYTHONSHOWREFCOUNT
+
+   If set, Python will print the total reference count when the program
+   finishes or after each statement in the interactive interpreter.
+
+   .. versionadded:: 2.7.15

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-09-15-46-37.bpo-31733.pIf17N.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-09-15-46-37.bpo-31733.pIf17N.rst
@@ -1,0 +1,2 @@
+Add a new PYTHONSHOWREFCOUNT environment variable. In debug mode, Python now
+only print the total reference count if PYTHONSHOWREFCOUNT is set.


### PR DESCRIPTION
Add a new PYTHONSHOWREFCOUNT environment variable. In debug mode,
Python now only print the total reference count if PYTHONSHOWREFCOUNT
is set.

<!-- issue-number: bpo-31733 -->
https://bugs.python.org/issue31733
<!-- /issue-number -->
