### PR TITLE
[WIP] bpo-31314: Fix email.message_from_string with an oversized header.

### DIFF
--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -190,7 +190,9 @@ class Header:
         else:
             # The first line should be shorter to take into account the field
             # header.  Also subtract off 2 extra for the colon and space.
-            self._firstlinelen = maxlinelen - len(header_name) - 2
+            # bpo-31314: len(header_name) can be greater than maxlinelen.
+            # We need to calculate self._firstlinelen not to be negative. 
+            self._firstlinelen = max(maxlinelen - len(header_name) - 2, len(header_name) + 2)
         # Second and subsequent lines should subtract off the length in
         # columns of the continuation whitespace prefix.
         self._maxlinelen = maxlinelen - cws_expanded_len

--- a/Lib/email/test/test_email.py
+++ b/Lib/email/test/test_email.py
@@ -920,6 +920,18 @@ List: List-Unsubscribe: <https://lists.sourceforge.net/lists/listinfo/spamassass
 
 """)
 
+    def test_oversized_header_input(self):
+        raw_mail = """\
+From: <postmaster@example.com>
+To: <bounce@example.com>
+Subject: demo
+X-Overlong-Header-Name-causes-python-mail-to-crash-in-re-serialization-example:\x20
+
+Hello
+"""
+        mail = email.message_from_string(raw_mail)
+        message = mail.as_string()
+        self.assertEqual(message, raw_mail)
 
 
 # Test mangling of "From " lines in the body of a message

--- a/Misc/NEWS.d/next/Library/2017-10-10-03-37-06.bpo-31314.73uM3t.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-10-03-37-06.bpo-31314.73uM3t.rst
@@ -1,0 +1,2 @@
+Fix email.message_from_string with an oversized header. Now 
+Patch by Dong-hee Na.


### PR DESCRIPTION
bpo-31314: Fix email.message_from_string with an oversized header.


<!-- issue-number: bpo-31314 -->
https://bugs.python.org/issue31314
<!-- /issue-number -->
