### PR TITLE
bpo-31734: Raise a ValueError instead of crashing, when the get() method of an uninitialized sqlite3.Cache object is called

### DIFF
--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -397,6 +397,7 @@ class RegressionTests(unittest.TestCase):
             pass
         cache.get(None)  # Shouldn't raise a SystemError
 
+
 def suite():
     regression_suite = unittest.makeSuite(RegressionTests, "Check")
     return unittest.TestSuite((regression_suite,))

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -385,7 +385,7 @@ class RegressionTests(unittest.TestCase):
         self.assertRaises(ValueError, cache.get, None)
 
     @support.cpython_only
-    def CheckPartiallyInitializedCache(self):
+    def Check__init__Fail(self):
         # bpo-31734: A failure of the __init__() method of an already
         # initialized Cache object shouldn't cause the Cache object to be
         # partially initialized, and its get() method to raise a SystemError.

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -395,7 +395,7 @@ class RegressionTests(unittest.TestCase):
             cache.__init__()
         except TypeError:
             pass
-        cache.get(None)
+        cache.get(None)  # Shouldn't raise a SystemError
 
 def suite():
     regression_suite = unittest.makeSuite(RegressionTests, "Check")

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -24,6 +24,7 @@
 import datetime
 import unittest
 import sqlite3 as sqlite
+from test import support
 
 class RegressionTests(unittest.TestCase):
     def setUp(self):
@@ -376,6 +377,25 @@ class RegressionTests(unittest.TestCase):
                 counter += 1
         self.assertEqual(counter, 3, "should have returned exactly three rows")
 
+    @support.cpython_only
+    def CheckUninitializedCache(self):
+        # bpo-31734: Cache.get() shouldn't crash in case the Cache object is
+        # uninitialized.
+        cache = sqlite.Cache.__new__(sqlite.Cache)
+        self.assertRaises(ValueError, cache.get, None)
+
+    @support.cpython_only
+    def CheckPartiallyInitializedCache(self):
+        # bpo-31734: A failure of the __init__() method of an already
+        # initialized Cache object shouldn't result in the Cache object being
+        # partially initialized, which would cause its get() method to raise a
+        # SystemError.
+        cache = sqlite.Cache(str)
+        try:
+            cache.__init__()
+        except TypeError:
+            pass
+        cache.get(None)
 
 def suite():
     regression_suite = unittest.makeSuite(RegressionTests, "Check")

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -387,15 +387,14 @@ class RegressionTests(unittest.TestCase):
     @support.cpython_only
     def CheckPartiallyInitializedCache(self):
         # bpo-31734: A failure of the __init__() method of an already
-        # initialized Cache object shouldn't result in the Cache object being
-        # partially initialized, which would cause its get() method to raise a
-        # SystemError.
+        # initialized Cache object shouldn't cause the Cache object to be
+        # partially initialized, and its get() method to raise a SystemError.
         cache = sqlite.Cache(str)
         try:
-            cache.__init__()
+            cache.__init__()  # invalid number of arguments
         except TypeError:
             pass
-        cache.get(None)  # Shouldn't raise a SystemError
+        self.assertRaises(ValueError, cache.get, None)
 
 
 def suite():

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-09-16-58-33.bpo-31734.HCa6O5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-09-16-58-33.bpo-31734.HCa6O5.rst
@@ -1,0 +1,2 @@
+Raise a `ValueError` instead of crashing, when the `get()` method of an
+uninitialized `sqlite3.Cache` object is called. Patch by Oren Milman.

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -105,7 +105,7 @@ int pysqlite_cache_init(pysqlite_Cache* self, PyObject* args, PyObject* kwargs)
 
 void pysqlite_cache_dealloc(pysqlite_Cache* self)
 {
-    if (self->factory) {
+    if (self->factory != NULL) {
         deallocate_nodes(self);
         if (self->decref_factory) {
             Py_DECREF(self->factory);

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -61,6 +61,8 @@ static void deallocate_nodes(pysqlite_Cache* self) {
     pysqlite_Node* delete_node;
 
     node = self->first;
+    self->first = NULL;
+    self->last = NULL;
     while (node) {
         delete_node = node;
         node = node->next;
@@ -81,8 +83,6 @@ int pysqlite_cache_init(pysqlite_Cache* self, PyObject* args, PyObject* kwargs)
         self->factory = NULL;
     }
     deallocate_nodes(self);
-    self->first = NULL;
-    self->last = NULL;
     Py_CLEAR(self->mapping);
 
     if (!PyArg_ParseTuple(args, "O|i", &factory, &size)) {

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -81,6 +81,8 @@ int pysqlite_cache_init(pysqlite_Cache* self, PyObject* args, PyObject* kwargs)
         self->factory = NULL;
     }
     deallocate_nodes(self);
+    self->first = NULL;
+    self->last = NULL;
     Py_CLEAR(self->mapping);
 
     if (!PyArg_ParseTuple(args, "O|i", &factory, &size)) {
@@ -92,8 +94,6 @@ int pysqlite_cache_init(pysqlite_Cache* self, PyObject* args, PyObject* kwargs)
         size = 5;
     }
     self->size = size;
-    self->first = NULL;
-    self->last = NULL;
 
     self->mapping = PyDict_New();
     if (!self->mapping) {

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -76,12 +76,12 @@ int pysqlite_cache_init(pysqlite_Cache* self, PyObject* args, PyObject* kwargs)
         return -1;
     }
 
+    deallocate_nodes(self);
     /* minimum cache size is 5 entries */
     if (size < 5) {
         size = 5;
     }
     self->size = size;
-    deallocate_nodes(self);
     self->first = NULL;
     self->last = NULL;
 

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -54,11 +54,12 @@ void pysqlite_node_dealloc(pysqlite_Node* self)
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
+/* Iterate over all nodes and deallocate them. If there aren't any nodes, do
+   nothing. */
 static void deallocate_nodes(pysqlite_Cache* self) {
     pysqlite_Node* node;
     pysqlite_Node* delete_node;
 
-    /* iterate over all nodes and deallocate them */
     node = self->first;
     while (node) {
         delete_node = node;

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -56,7 +56,8 @@ void pysqlite_node_dealloc(pysqlite_Node* self)
 
 /* Iterate over all nodes and deallocate them. If there aren't any nodes, do
    nothing. */
-static void deallocate_nodes(pysqlite_Cache* self) {
+static void deallocate_nodes(pysqlite_Cache* self)
+{
     pysqlite_Node* node;
     pysqlite_Node* delete_node;
 


### PR DESCRIPTION
In addition:
* Prevent a Cache object from becoming partially initialized in case its `__init__()` method failed after it was already initialized. (And thus prevent the case of raising a `SystemError` by the `get()` method of a partially initialized Cache object. The fix for that would also prevent refleaks in case of calling the `__init__()` method of a Cache object more than once.)
* Prevent a memory leak in the deallocation of an uninitialized Cache object.
* Add tests to `test_sqlite`, to verify that the crash and the `SystemError` are no more.

<!-- issue-number: bpo-31734 -->
https://bugs.python.org/issue31734
<!-- /issue-number -->
