### PR TITLE
[WIP] bpo-31589: Build PDF using xelatex for better UTF8 support.

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -89,11 +89,10 @@ html_split_index = True
 # Options for LaTeX output
 # ------------------------
 
+latex_engine = 'xelatex'
+
 # Get LaTeX to handle Unicode correctly
 latex_elements = {
-    'inputenc': r'\usepackage[utf8x]{inputenc}',
-    'utf8extra': '',
-    'fontenc': r'\usepackage[T1,T2A]{fontenc}',
 }
 
 # Additional stuff for the LaTeX preamble.


### PR DESCRIPTION
Trying to fix: https://bugs.python.org/issue31589

I sucessfully built locally PDF for english and french, still have to try japanese, and still have to "diff" (at least visually) PDFs from pdflatex vs pdf from xelatex.


<!-- issue-number: bpo-31589 -->
https://bugs.python.org/issue31589
<!-- /issue-number -->
