### PR TITLE
bpo-30008: OpenSSL 1.1 compatibility without using deprecated API

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-11-05-17-06-44.bpo-30008.kUgT8v.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-05-17-06-44.bpo-30008.kUgT8v.rst
@@ -1,0 +1,1 @@
+OpenSSL 1.1 compatility: Remove use of deprecated API.

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -1012,7 +1012,7 @@ PyInit__hashlib(void)
 {
     PyObject *m, *openssl_md_meth_names;
 
-#ifndef OPENSSL_VERSION_1_1
+#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
     /* Load all digest algorithms and initialize cpuid */
     OPENSSL_add_all_algorithms_noconf();
     ERR_load_crypto_strings();

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4635,7 +4635,7 @@ PySSL_RAND(int len, int pseudo)
         return NULL;
     if (pseudo) {
 #ifdef OPENSSL_VERSION_1_1
-        ok = RAND_bytes((unsigned char*)PyBytes_AS_STRING(bytes), len);
+        ok = (_PyOS_URandom((unsigned char*)PyBytes_AS_STRING(bytes), len) == 0 ? 1 : 0);
 #else
         ok = RAND_pseudo_bytes((unsigned char*)PyBytes_AS_STRING(bytes), len);
 #endif

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5277,9 +5277,7 @@ PyInit__ssl(void)
         return NULL;
     PySocketModule = *socket_api;
 
-#ifdef OPENSSL_VERSION_1_1
-    OPENSSL_init_ssl(0, NULL);
-#else
+#ifndef OPENSSL_VERSION_1_1
     /* Load all algorithms and initialize cpuid */
     OPENSSL_add_all_algorithms_noconf();
     /* Init OpenSSL */


### PR DESCRIPTION
Note: RAND_pseudo_bytes() is deprecated so RAND_bytes() is used when pseudo is requested.

<!-- issue-number: bpo-30008 -->
https://bugs.python.org/issue30008
<!-- /issue-number -->
