### PR TITLE
bpo-31746: Fixed Segfaults in the sqlite module when uninitialized.

### DIFF
--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -425,16 +425,12 @@ class RegressionTests(unittest.TestCase):
 
     def CheckCursorInvalidIsolationLevel(self):
         """
-        When trying to call conn.corsor() when conn is a Connection object that
+        When trying to call conn.cursor() when conn is a Connection object that
         was not initialized properly, it caused a segfault. Now it should raise
         a ProgrammingError.
         """
-        try:
-            conn = sqlite.Connection.__new__(sqlite.Connection)
-            conn.__init__('', isolation_level='invalid isolation level')
-        except ValueError:
-            pass
-
+        conn = sqlite.Connection.__new__(sqlite.Connection)
+        self.assertRaises(ValueError, conn.__init__, '', isolation_level='invalid isolation level')
         self.assertRaises(sqlite.ProgrammingError, conn.cursor)
 
 

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -414,16 +414,16 @@ class RegressionTests(unittest.TestCase):
         val = cur.fetchone()[0]
         self.assertEqual(val, b'')
 
-    def CheckUninitializedIsolationLevel(self):
+    def test_uninitialized_isolation_level(self):
         """
         Previously trying to get the isolation level of an uninitialized Connection
         caused a segfault, now it should just return None.
         """
         conn = sqlite.Connection.__new__(sqlite.Connection)
-        self.assertEqual(conn.isolation_level, None)
+        with self.assertRaises(sqlite.ProgrammingError):
+            conn.isolation_level
 
-
-    def CheckCursorInvalidIsolationLevel(self):
+    def test_cursor_invalid_isolation_level(self):
         """
         When trying to call conn.cursor() when conn is a Connection object that
         was not initialized properly, it caused a segfault. Now it should raise
@@ -434,7 +434,7 @@ class RegressionTests(unittest.TestCase):
         self.assertRaises(sqlite.ProgrammingError, conn.cursor)
 
 
-    def CheckCloseInvalidConnection(self):
+    def test_close_invalid_connection(self):
         """
         Trying to call close() on a connection which was not initialized properly,
         it caused a segfault. Now it should raise a ProgrammingError.

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -456,3 +456,4 @@ def test():
 
 if __name__ == "__main__":
     test()
+

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -456,4 +456,3 @@ def test():
 
 if __name__ == "__main__":
     test()
-

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -260,6 +260,11 @@ int pysqlite_connection_register_cursor(pysqlite_Connection* connection, PyObjec
     }
     PyObject* weakref;
 
+    if (!connection->cursors) {
+        PyErr_SetString(pysqlite_ProgrammingError, "Could not get the cursors list.");
+        return 0;
+    }
+
     weakref = PyWeakref_NewRef((PyObject*)cursor, NULL);
     if (!weakref) {
         goto error;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -250,6 +250,12 @@ pysqlite_connection_dealloc(pysqlite_Connection *self)
  */
 int pysqlite_connection_register_cursor(pysqlite_Connection* connection, PyObject* cursor)
 {
+    if (!connection || !connection->cursors) {
+        PyErr_Format(PyExc_RuntimeError,
+                        "Tried to get a cursor of an uninitialized connection."
+                    );
+                    goto error;
+    }
     PyObject* weakref;
 
     weakref = PyWeakref_NewRef((PyObject*)cursor, NULL);
@@ -1225,6 +1231,9 @@ int pysqlite_check_thread(pysqlite_Connection* self)
 
 static PyObject* pysqlite_connection_get_isolation_level(pysqlite_Connection* self, void* unused)
 {
+    if (!self || !self->isolation_level) {
+        Py_RETURN_NONE;
+    }
     return Py_NewRef(self->isolation_level);
 }
 

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -294,10 +294,10 @@ static PyObject *
 pysqlite_connection_cursor_impl(pysqlite_Connection *self, PyObject *factory)
 /*[clinic end generated code: output=562432a9e6af2aa1 input=4127345aa091b650]*/
 {
-	if (self == NULL) {
-		return NULL;
-	}
-	
+        if (self == NULL) {
+                return NULL;
+        }
+        
     static char *kwlist[] = {"factory", NULL};
     PyObject* factory = NULL;
     PyObject* cursor;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -289,6 +289,12 @@ static PyObject *
 pysqlite_connection_cursor_impl(pysqlite_Connection *self, PyObject *factory)
 /*[clinic end generated code: output=562432a9e6af2aa1 input=4127345aa091b650]*/
 {
+	if (self == NULL) {
+		return NULL;
+	}
+	
+    static char *kwlist[] = {"factory", NULL};
+    PyObject* factory = NULL;
     PyObject* cursor;
 
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -255,9 +255,8 @@ int pysqlite_connection_register_cursor(pysqlite_Connection* connection, PyObjec
 {
     if (!connection || !connection->cursors) {
         PyErr_Format(pysqlite_ProgrammingError,
-                        "Tried to get a cursor of an uninitialized connection."
-                    );
-                    goto error;
+                        "Tried to get a cursor of an uninitialized connection.");
+        goto error;
     }
     PyObject* weakref;
 


### PR DESCRIPTION



<!-- issue-number: bpo-31746 -->
https://bugs.python.org/issue31746
<!-- /issue-number -->
