### PR TITLE
bpo-31748: configure Werror

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-11-10-42-02.bpo-31748.oaEZcq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-11-10-42-02.bpo-31748.oaEZcq.rst
@@ -1,0 +1,1 @@
+Support configure with -Wall by avoiding unused variables.

--- a/configure
+++ b/configure
@@ -6993,7 +6993,7 @@ if ac_fn_c_try_compile "$LINENO"; then :
            cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-	       void f(int **x) {}
+	       void f(int **x) {(void)x;}
 int
 main ()
 {
@@ -7541,7 +7541,7 @@ else
 #include <stdio.h>
 #include <pthread.h>
 
-void* routine(void* p){return NULL;}
+void* routine(void* p){(void)p; return NULL;}
 
 int main(){
   pthread_t p;
@@ -7597,7 +7597,7 @@ else
 #include <stdio.h>
 #include <pthread.h>
 
-void* routine(void* p){return NULL;}
+void* routine(void* p){(void)p; return NULL;}
 
 int main(){
   pthread_t p;
@@ -7647,7 +7647,7 @@ else
 #include <stdio.h>
 #include <pthread.h>
 
-void* routine(void* p){return NULL;}
+void* routine(void* p){(void)p; return NULL;}
 
 int main(){
   pthread_t p;
@@ -7697,7 +7697,7 @@ else
 #include <stdio.h>
 #include <pthread.h>
 
-void* routine(void* p){return NULL;}
+void* routine(void* p){(void)p; return NULL;}
 
 int main(){
   pthread_t p;
@@ -9058,7 +9058,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-pthread_t x; x = *(pthread_t*)0;
+pthread_t x; x = *(pthread_t*)0; (void)x;
   ;
   return 0;
 }
@@ -9156,7 +9156,7 @@ if test "$ac_cv_sizeof_pthread_key_t" -eq "$ac_cv_sizeof_int" ; then
 int
 main ()
 {
-pthread_key_t k; k * 1;
+pthread_key_t k; k = k * 2; (void)k;
   ;
   return 0;
 }
@@ -10562,7 +10562,7 @@ $as_echo_n "checking for pthread_create in -lpthread... " >&6; }
 #include <stdio.h>
 #include <pthread.h>
 
-void * start_routine (void *arg) { exit (0); }
+void * start_routine (void *arg) { (void)arg; exit (0); }
 int
 main ()
 {
@@ -10857,11 +10857,13 @@ else
 /* end confdefs.h.  */
 
       #include <stdio.h>
+      #include <stlib.h>
       #include <pthread.h>
       void *foo(void *parm) {
+        (void)parm;
         return NULL;
       }
-      main() {
+      int main() {
         pthread_attr_t attr;
         pthread_t id;
         if (pthread_attr_init(&attr)) exit(-1);
@@ -10949,7 +10951,7 @@ else
 int
 main ()
 {
-int domain = AF_INET6;
+int domain = AF_INET6; (void)domain;
   ;
   return 0;
 }
@@ -10981,7 +10983,7 @@ int
 main ()
 {
 struct sockaddr_in6 x;
-			    x.sin6_scope_id;
+			    (void)x.sin6_scope_id;
   ;
   return 0;
 }
@@ -11178,7 +11180,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-int can_raw_fd_frames = CAN_RAW_FD_FRAMES;
+int can_raw_fd_frames = CAN_RAW_FD_FRAMES; (void)can_raw_fd_frames;
   ;
   return 0;
 }
@@ -11471,9 +11473,7 @@ for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \
  getpriority getresuid getresgid getpwent getpwnam_r getpwuid_r getspnam getspent getsid getwd \
  if_nameindex \
- initgroups kill killpg lchmod lchown lockf linkat lstat lutimes madvise mmap \
- memrchr mbrtowc mkdirat mkfifo \
- mkfifoat mknod mknodat mktime mremap nice openat pathconf pause pipe2 plock poll \
+ madvise mkfifoat mknod mknodat mktime mremap nice openat pathconf pause pipe2 plock poll \
  posix_fallocate posix_fadvise posix_spawn posix_spawnp pread preadv preadv2 \
  pthread_condattr_setclock pthread_init pthread_kill putenv pwrite pwritev pwritev2 \
  readlink readlinkat readv realpath renameat \
@@ -11536,7 +11536,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=chroot
+void *x=chroot; (void)x
   ;
   return 0;
 }
@@ -11561,7 +11561,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=link
+void *x=link; (void)x
   ;
   return 0;
 }
@@ -11586,7 +11586,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=symlink
+void *x=symlink; (void)x
   ;
   return 0;
 }
@@ -11611,7 +11611,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=fchdir
+void *x=fchdir; (void)x
   ;
   return 0;
 }
@@ -11636,7 +11636,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=fsync
+void *x=fsync; (void)x
   ;
   return 0;
 }
@@ -11661,7 +11661,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=fdatasync
+void *x=fdatasync; (void)x
   ;
   return 0;
 }
@@ -11686,7 +11686,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=epoll_create
+void *x=epoll_create; (void)x
   ;
   return 0;
 }
@@ -11711,7 +11711,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=epoll_create1
+void *x=epoll_create1; (void)x
   ;
   return 0;
 }
@@ -11767,7 +11767,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=prlimit
+void *x=prlimit; (void)x
   ;
   return 0;
 }
@@ -11801,7 +11801,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void* p = ctermid_r
+void* p = ctermid_r; (void)p
   ;
   return 0;
 }
@@ -11830,7 +11830,7 @@ else
 int
 main ()
 {
-void* p = flock
+void* p = flock; (void)p
 
   ;
   return 0;
@@ -11918,7 +11918,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void* p = getpagesize
+void* p = getpagesize; (void)p
   ;
   return 0;
 }
@@ -11946,7 +11946,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-int res = unsetenv("DUMMY")
+int res = unsetenv("DUMMY"); ; (void)res
   ;
   return 0;
 }
@@ -12113,6 +12113,7 @@ else
 #include <unistd.h>
 int main(int argc, char*argv[])
 {
+  (void)argc;
   if(chflags(argv[0], 0) != 0)
     return 1;
   return 0;
@@ -12162,6 +12163,7 @@ else
 #include <unistd.h>
 int main(int argc, char*argv[])
 {
+  (void)argc;
   if(lchflags(argv[0], 0) != 0)
     return 1;
   return 0;
@@ -12265,7 +12267,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void* p = hstrerror; hstrerror(0)
+void* p = hstrerror; (void)p; hstrerror(0)
   ;
   return 0;
 }
@@ -12297,7 +12299,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void* p = inet_aton;inet_aton(0,0)
+void* p = inet_aton; (void)p; inet_aton(0,0)
   ;
   return 0;
 }
@@ -12329,7 +12331,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void* p = inet_pton
+void* p = inet_pton; (void)p
   ;
   return 0;
 }
@@ -12361,7 +12363,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void* p = setgroups
+void* p = setgroups; (void)p
   ;
   return 0;
 }
@@ -12686,7 +12688,8 @@ _ACEOF
 int
 main ()
 {
-gettimeofday((struct timeval*)0,(struct timezone*)0);
+struct timeval t;(void) gettimeofday(&t,(struct timezone*)0); (void)t;
+
   ;
   return 0;
 }
@@ -13559,7 +13562,7 @@ else
 int
 main ()
 {
-struct addrinfo a
+struct addrinfo a; (void)a
   ;
   return 0;
 }
@@ -13593,7 +13596,7 @@ else
 int
 main ()
 {
-struct sockaddr_storage s
+struct sockaddr_storage s; (void)s
   ;
   return 0;
 }
@@ -13628,7 +13631,7 @@ else
 int
 main ()
 {
-struct sockaddr_alg s
+struct sockaddr_alg s; (void)s
   ;
   return 0;
 }
@@ -13775,7 +13778,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-signed char c;
+signed char c; (void)c
   ;
   return 0;
 }
@@ -13797,7 +13800,7 @@ have_prototypes=no
 $as_echo_n "checking for prototypes... " >&6; }
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-int foo(int x) { return 0; }
+int foo(int x) {(void)x; return 0; }
 int
 main ()
 {
@@ -13864,7 +13867,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=socketpair
+void *x=socketpair; (void)x
   ;
   return 0;
 }
@@ -13892,7 +13895,9 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
+
 struct sockaddr x;
+(void)x;
 x.sa_len = 0;
   ;
   return 0;
@@ -14010,6 +14015,7 @@ main ()
             struct hostent *he;
             struct hostent_data data;
 
+            (void)data;
             (void) gethostbyname_r(name, he, &data);
 
   ;
@@ -15782,6 +15788,7 @@ main ()
 {
 
 struct stat st;
+(void)st;
 st.st_mtim.tv_nsec = 1;
 
   ;
@@ -15819,6 +15826,7 @@ main ()
 {
 
 struct stat st;
+(void)st;
 st.st_mtimespec.tv_nsec = 1;
 
   ;
@@ -15895,6 +15903,7 @@ main ()
 {
 
   int rtn;
+  (void)rtn;
   rtn = mvwdelch(0,0,0);
 
   ;
@@ -16002,7 +16011,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=is_term_resized
+void *x=is_term_resized; (void)x
   ;
   return 0;
 }
@@ -16028,7 +16037,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=resize_term
+void *x=resize_term; (void)x
   ;
   return 0;
 }
@@ -16054,7 +16063,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 int
 main ()
 {
-void *x=resizeterm
+void *x=resizeterm; (void)x
   ;
   return 0;
 }
@@ -16530,6 +16539,7 @@ else
 
 int main(int argc, char **argv)
 {
+    (void)argc; (void)argv;
     static void *targets[1] = { &&LABEL1 };
     goto LABEL2;
 LABEL1:
@@ -16727,6 +16737,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
     atomic_int value = ATOMIC_VAR_INIT(1);
     int main() {
       int loaded_value = atomic_load(&value);
+      (void)loaded_value;
       return 0;
     }
 

--- a/configure.ac
+++ b/configure.ac
@@ -1594,7 +1594,7 @@ yes)
            CFLAGS="$CFLAGS -Werror -Wstrict-aliasing"
            AC_COMPILE_IFELSE(
 	     [
-	       AC_LANG_PROGRAM([[void f(int **x) {}]],
+	       AC_LANG_PROGRAM([[void f(int **x) {(void)x;}]],
 	         [[double *x; f((int **) &x);]])
 	     ],[
 	       ac_cv_no_strict_aliasing=no
@@ -1963,7 +1963,7 @@ AC_CACHE_VAL(ac_cv_pthread_is_default,
 #include <stdio.h>
 #include <pthread.h>
 
-void* routine(void* p){return NULL;}
+void* routine(void* p){(void)p; return NULL;}
 
 int main(){
   pthread_t p;
@@ -1998,7 +1998,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
 
-void* routine(void* p){return NULL;}
+void* routine(void* p){(void)p; return NULL;}
 
 int main(){
   pthread_t p;
@@ -2027,7 +2027,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
 
-void* routine(void* p){return NULL;}
+void* routine(void* p){(void)p; return NULL;}
 
 int main(){
   pthread_t p;
@@ -2056,7 +2056,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
 
-void* routine(void* p){return NULL;}
+void* routine(void* p){(void)p; return NULL;}
 
 int main(){
   pthread_t p;
@@ -2335,7 +2335,7 @@ fi
 AC_MSG_CHECKING(for pthread_t)
 have_pthread_t=no
 AC_COMPILE_IFELSE([
-  AC_LANG_PROGRAM([[#include <pthread.h>]], [[pthread_t x; x = *(pthread_t*)0;]])
+  AC_LANG_PROGRAM([[#include <pthread.h>]], [[pthread_t x; x = *(pthread_t*)0; (void)x;]])
 ],[have_pthread_t=yes],[])
 AC_MSG_RESULT($have_pthread_t)
 if test "$have_pthread_t" = yes ; then
@@ -2352,7 +2352,7 @@ AC_CHECK_SIZEOF(pthread_key_t, [], [[#include <pthread.h>]])
 AC_MSG_CHECKING(whether pthread_key_t is compatible with int)
 if test "$ac_cv_sizeof_pthread_key_t" -eq "$ac_cv_sizeof_int" ; then
   AC_COMPILE_IFELSE(
-    [AC_LANG_PROGRAM([[#include <pthread.h>]], [[pthread_key_t k; k * 1;]])],
+    [AC_LANG_PROGRAM([[#include <pthread.h>]], [[pthread_key_t k; k = k * 2; (void)k;]])],
     [ac_pthread_key_t_is_arithmetic_type=yes],
     [ac_pthread_key_t_is_arithmetic_type=no]
   )
@@ -3097,7 +3097,7 @@ yes
 #include <stdio.h>
 #include <pthread.h>
 
-void * start_routine (void *arg) { exit (0); }]], [[
+void * start_routine (void *arg) { (void)arg; exit (0); }]], [[
 pthread_create (NULL, NULL, start_routine, NULL)]])],[
     AC_MSG_RESULT(yes)
     posix_threads=yes
@@ -3156,11 +3156,13 @@ if test "$posix_threads" = "yes"; then
       AC_CACHE_VAL(ac_cv_pthread_system_supported,
       [AC_RUN_IFELSE([AC_LANG_SOURCE([[
       #include <stdio.h>
+      #include <stlib.h>
       #include <pthread.h>
       void *foo(void *parm) {
+        (void)parm;
         return NULL;
       }
-      main() {
+      int main() {
         pthread_attr_t attr;
         pthread_t id;
         if (pthread_attr_init(&attr)) exit(-1);
@@ -3209,7 +3211,7 @@ dnl the check does not work on cross compilation case...
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ /* AF_INET6 available check */
 #include <sys/types.h>
 #include <sys/socket.h>]],
-[[int domain = AF_INET6;]])],[
+[[int domain = AF_INET6; (void)domain;]])],[
   AC_MSG_RESULT(yes)
   ipv6=yes
 ],[
@@ -3223,7 +3225,7 @@ if test "$ipv6" = "yes"; then
 	  AC_LANG_PROGRAM([[#include <sys/types.h>
 #include <netinet/in.h>]],
 			  [[struct sockaddr_in6 x;
-			    x.sin6_scope_id;]])
+			    (void)x.sin6_scope_id;]])
 	],[
 	  AC_MSG_RESULT(yes)
 	  ipv6=yes
@@ -3353,7 +3355,7 @@ fi
 AC_MSG_CHECKING(for CAN_RAW_FD_FRAMES)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[ /* CAN_RAW_FD_FRAMES available check */
 #include <linux/can/raw.h>]],
-[[int can_raw_fd_frames = CAN_RAW_FD_FRAMES;]])],[
+[[int can_raw_fd_frames = CAN_RAW_FD_FRAMES; (void)can_raw_fd_frames;]])],[
   AC_DEFINE(HAVE_LINUX_CAN_RAW_FD_FRAMES, 1, [Define if compiling using Linux 3.6 or later.])
   AC_MSG_RESULT(yes)
 ],[
@@ -3558,49 +3560,49 @@ AC_CHECK_DECL(dirfd,
 # For some functions, having a definition is not sufficient, since
 # we want to take their address.
 AC_MSG_CHECKING(for chroot)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=chroot]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=chroot; (void)x]])],
   [AC_DEFINE(HAVE_CHROOT, 1, Define if you have the 'chroot' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
 ])
 AC_MSG_CHECKING(for link)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=link]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=link; (void)x]])],
   [AC_DEFINE(HAVE_LINK, 1, Define if you have the 'link' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
 ])
 AC_MSG_CHECKING(for symlink)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=symlink]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=symlink; (void)x]])],
   [AC_DEFINE(HAVE_SYMLINK, 1, Define if you have the 'symlink' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
 ])
 AC_MSG_CHECKING(for fchdir)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=fchdir]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=fchdir; (void)x]])],
   [AC_DEFINE(HAVE_FCHDIR, 1, Define if you have the 'fchdir' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
 ])
 AC_MSG_CHECKING(for fsync)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=fsync]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=fsync; (void)x]])],
   [AC_DEFINE(HAVE_FSYNC, 1, Define if you have the 'fsync' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
 ])
 AC_MSG_CHECKING(for fdatasync)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=fdatasync]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <unistd.h>]], [[void *x=fdatasync; (void)x]])],
   [AC_DEFINE(HAVE_FDATASYNC, 1, Define if you have the 'fdatasync' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
 ])
 AC_MSG_CHECKING(for epoll)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/epoll.h>]], [[void *x=epoll_create]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/epoll.h>]], [[void *x=epoll_create; (void)x]])],
   [AC_DEFINE(HAVE_EPOLL, 1, Define if you have the 'epoll' functions.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
 ])
 AC_MSG_CHECKING(for epoll_create1)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/epoll.h>]], [[void *x=epoll_create1]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/epoll.h>]], [[void *x=epoll_create1; (void)x]])],
   [AC_DEFINE(HAVE_EPOLL_CREATE1, 1, Define if you have the 'epoll_create1' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
@@ -3618,7 +3620,7 @@ AC_MSG_CHECKING(for prlimit)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/time.h>
 #include <sys/resource.h>
-    ]], [[void *x=prlimit]])],
+    ]], [[void *x=prlimit; (void)x]])],
   [AC_DEFINE(HAVE_PRLIMIT, 1, Define if you have the 'prlimit' functions.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
@@ -3633,7 +3635,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 AC_MSG_CHECKING(for ctermid_r)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
-]], [[void* p = ctermid_r]])],
+]], [[void* p = ctermid_r; (void)p]])],
   [AC_DEFINE(HAVE_CTERMID_R, 1, Define if you have the 'ctermid_r' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
@@ -3643,7 +3645,7 @@ AC_CACHE_CHECK([for flock declaration], [ac_cv_flock_decl],
   [AC_COMPILE_IFELSE(
     [AC_LANG_PROGRAM(
       [#include <sys/file.h>],
-      [void* p = flock]
+      [void* p = flock; (void)p]
     )],
     [ac_cv_flock_decl=yes],
     [ac_cv_flock_decl=no]
@@ -3661,7 +3663,7 @@ fi
 AC_MSG_CHECKING(for getpagesize)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <unistd.h>
-]], [[void* p = getpagesize]])],
+]], [[void* p = getpagesize; (void)p]])],
   [AC_DEFINE(HAVE_GETPAGESIZE, 1, Define if you have the 'getpagesize' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
@@ -3670,7 +3672,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 AC_MSG_CHECKING(for broken unsetenv)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <stdlib.h>
-]], [[int res = unsetenv("DUMMY")]])],
+]], [[int res = unsetenv("DUMMY"); ; (void)res]])],
   [AC_MSG_RESULT(no)],
   [AC_DEFINE(HAVE_BROKEN_UNSETENV, 1, Define if `unsetenv` does not return an int.)
    AC_MSG_RESULT(yes)
@@ -3693,6 +3695,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <unistd.h>
 int main(int argc, char*argv[])
 {
+  (void)argc;
   if(chflags(argv[0], 0) != 0)
     return 1;
   return 0;
@@ -3715,6 +3718,7 @@ AC_RUN_IFELSE([AC_LANG_SOURCE([[
 #include <unistd.h>
 int main(int argc, char*argv[])
 {
+  (void)argc;
   if(lchflags(argv[0], 0) != 0)
     return 1;
   return 0;
@@ -3760,7 +3764,7 @@ esac
 AC_MSG_CHECKING(for hstrerror)
 AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <netdb.h>
-]], [[void* p = hstrerror; hstrerror(0)]])],
+]], [[void* p = hstrerror; (void)p; hstrerror(0)]])],
   [AC_DEFINE(HAVE_HSTRERROR, 1, Define if you have the 'hstrerror' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
@@ -3772,7 +3776,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-]], [[void* p = inet_aton;inet_aton(0,0)]])],
+]], [[void* p = inet_aton; (void)p; inet_aton(0,0)]])],
   [AC_DEFINE(HAVE_INET_ATON, 1, Define if you have the 'inet_aton' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
@@ -3784,7 +3788,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/socket.h>
 #include <netinet/in.h>
 #include <arpa/inet.h>
-]], [[void* p = inet_pton]])],
+]], [[void* p = inet_pton; (void)p]])],
   [AC_DEFINE(HAVE_INET_PTON, 1, Define if you have the 'inet_pton' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
@@ -3797,7 +3801,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #ifdef HAVE_GRP_H
 #include <grp.h>
 #endif
-]], [[void* p = setgroups]])],
+]], [[void* p = setgroups; (void)p]])],
   [AC_DEFINE(HAVE_SETGROUPS, 1, Define if you have the 'setgroups' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)
@@ -3834,7 +3838,8 @@ AC_CHECK_FUNCS(setpgrp,
 )
 AC_CHECK_FUNCS(gettimeofday,
   AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/time.h>]],
-  				     [[gettimeofday((struct timeval*)0,(struct timezone*)0);]])],
+    [[struct timeval t;(void) gettimeofday(&t,(struct timezone*)0); (void)t;]]
+  )],
     [],
     [AC_DEFINE(GETTIMEOFDAY_NO_TZ, 1,
       [Define if gettimeofday() does not have second (timezone) argument
@@ -4075,7 +4080,7 @@ AC_MSG_RESULT($was_it_defined)
 
 AC_MSG_CHECKING(for addrinfo)
 AC_CACHE_VAL(ac_cv_struct_addrinfo,
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netdb.h>]], [[struct addrinfo a]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <netdb.h>]], [[struct addrinfo a; (void)a]])],
   [ac_cv_struct_addrinfo=yes],
   [ac_cv_struct_addrinfo=no]))
 AC_MSG_RESULT($ac_cv_struct_addrinfo)
@@ -4087,7 +4092,7 @@ AC_MSG_CHECKING(for sockaddr_storage)
 AC_CACHE_VAL(ac_cv_struct_sockaddr_storage,
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #		include <sys/types.h>
-#		include <sys/socket.h>]], [[struct sockaddr_storage s]])],
+#		include <sys/socket.h>]], [[struct sockaddr_storage s; (void)s]])],
   [ac_cv_struct_sockaddr_storage=yes],
   [ac_cv_struct_sockaddr_storage=no]))
 AC_MSG_RESULT($ac_cv_struct_sockaddr_storage)
@@ -4100,7 +4105,7 @@ AC_CACHE_VAL(ac_cv_struct_sockaddr_alg,
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #		include <sys/types.h>
 #		include <sys/socket.h>
-#		include <linux/if_alg.h>]], [[struct sockaddr_alg s]])],
+#		include <linux/if_alg.h>]], [[struct sockaddr_alg s; (void)s]])],
   [ac_cv_struct_sockaddr_alg=yes],
   [ac_cv_struct_sockaddr_alg=no]))
 AC_MSG_RESULT($ac_cv_struct_sockaddr_alg)
@@ -4115,7 +4120,7 @@ AC_C_CONST
 
 works=no
 AC_MSG_CHECKING(for working signed char)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[signed char c;]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[signed char c; (void)c]])],
   [works=yes],
   [AC_DEFINE(signed, , [Define to empty if the keyword does not work.])]
 )
@@ -4123,7 +4128,7 @@ AC_MSG_RESULT($works)
 
 have_prototypes=no
 AC_MSG_CHECKING(for prototypes)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[int foo(int x) { return 0; }]], [[return foo(10);]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[int foo(int x) {(void)x; return 0; }]], [[return foo(10);]])],
   [AC_DEFINE(HAVE_PROTOTYPES, 1,
      [Define if your compiler supports function prototype])
    have_prototypes=yes],
@@ -4156,7 +4161,7 @@ AC_MSG_CHECKING(for socketpair)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 #include <sys/types.h>
 #include <sys/socket.h>
-]], [[void *x=socketpair]])],
+]], [[void *x=socketpair; (void)x]])],
   [AC_DEFINE(HAVE_SOCKETPAIR, 1, [Define if you have the 'socketpair' function.])
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)]
@@ -4165,7 +4170,9 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
 # check if sockaddr has sa_len member
 AC_MSG_CHECKING(if sockaddr has sa_len member)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/types.h>
-#include <sys/socket.h>]], [[struct sockaddr x;
+#include <sys/socket.h>]], [[
+struct sockaddr x;
+(void)x;
 x.sa_len = 0;]])],
   [AC_MSG_RESULT(yes)
    AC_DEFINE(HAVE_SOCKADDR_SA_LEN, 1, [Define if sockaddr has sa_len member])],
@@ -4225,6 +4232,7 @@ AC_CHECK_FUNC(gethostbyname_r, [
             struct hostent *he;
             struct hostent_data data;
 
+            (void)data;
             (void) gethostbyname_r(name, he, &data);
           ]])],
           [
@@ -4901,6 +4909,7 @@ AC_MSG_CHECKING(for tv_nsec in struct stat)
 AC_CACHE_VAL(ac_cv_stat_tv_nsec,
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/stat.h>]], [[
 struct stat st;
+(void)st;
 st.st_mtim.tv_nsec = 1;
 ]])],
 [ac_cv_stat_tv_nsec=yes],
@@ -4917,6 +4926,7 @@ AC_MSG_CHECKING(for tv_nsec2 in struct stat)
 AC_CACHE_VAL(ac_cv_stat_tv_nsec2,
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <sys/stat.h>]], [[
 struct stat st;
+(void)st;
 st.st_mtimespec.tv_nsec = 1;
 ]])],
 [ac_cv_stat_tv_nsec2=yes],
@@ -4948,6 +4958,7 @@ AC_MSG_CHECKING(whether mvwdelch is an expression)
 AC_CACHE_VAL(ac_cv_mvwdelch_is_expression,
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
   int rtn;
+  (void)rtn;
   rtn = mvwdelch(0,0,0);
 ]])],
 [ac_cv_mvwdelch_is_expression=yes],
@@ -4996,21 +5007,21 @@ void *x=is_pad
 )
 
 AC_MSG_CHECKING(for is_term_resized)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=is_term_resized]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=is_term_resized; (void)x]])],
   [AC_DEFINE(HAVE_CURSES_IS_TERM_RESIZED, 1, Define if you have the 'is_term_resized' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)]
 )
 
 AC_MSG_CHECKING(for resize_term)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=resize_term]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=resize_term; (void)x]])],
   [AC_DEFINE(HAVE_CURSES_RESIZE_TERM, 1, Define if you have the 'resize_term' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)]
 )
 
 AC_MSG_CHECKING(for resizeterm)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=resizeterm]])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=resizeterm; (void)x]])],
   [AC_DEFINE(HAVE_CURSES_RESIZETERM, 1, Define if you have the 'resizeterm' function.)
    AC_MSG_RESULT(yes)],
   [AC_MSG_RESULT(no)]
@@ -5233,6 +5244,7 @@ AC_CACHE_VAL(ac_cv_computed_gotos,
 AC_RUN_IFELSE([AC_LANG_SOURCE([[[
 int main(int argc, char **argv)
 {
+    (void)argc; (void)argv;
     static void *targets[1] = { &&LABEL1 };
     goto LABEL2;
 LABEL1:
@@ -5370,6 +5382,7 @@ AC_LINK_IFELSE(
     atomic_int value = ATOMIC_VAR_INIT(1);
     int main() {
       int loaded_value = atomic_load(&value);
+      (void)loaded_value;
       return 0;
     }
   ]])


### PR DESCRIPTION
Support configure with -Wall by avoiding unused variables, e.g.
(void)var.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-31748 -->
https://bugs.python.org/issue31748
<!-- /issue-number -->
