### PR TITLE
[2.7] bpo-31728: Prevent crashes in _elementtree due to unsafe cleanup of Element.text and Element.tail (GH-3924)

### DIFF
--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -53,6 +53,31 @@ class MiscTests(unittest.TestCase):
             del element.attrib
         self.assertEqual(element.attrib, {'A': 'B', 'C': 'D'})
 
+    def test_bpo_31728(self):
+        # A crash shouldn't happen in case garbage collection triggers a call
+        # to clear() or a reading of text or tail, while a setter or clear()
+        # is already running.
+        elem = cET.Element('elem')
+        class X:
+            def __del__(self):
+                elem.text
+                elem.tail
+                elem.clear()
+
+        elem.text = X()
+        elem.clear()  # shouldn't crash
+
+        elem.tail = X()
+        elem.clear()  # shouldn't crash
+
+        elem.text = X()
+        elem.text = X()  # shouldn't crash
+        elem.clear()
+
+        elem.tail = X()
+        elem.tail = X()  # shouldn't crash
+        elem.clear()
+
 
 def test_main():
     from test import test_xml_etree, test_xml_etree_c

--- a/Misc/NEWS.d/next/Library/2017-10-11-13-05-19.bpo-31728.XrVMME.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-11-13-05-19.bpo-31728.XrVMME.rst
@@ -1,0 +1,2 @@
+Prevent crashes in `_elementtree` due to unsafe cleanup of `Element.text`
+and `Element.tail`. Patch by Oren Milman.


### PR DESCRIPTION


<!-- issue-number: bpo-31728 -->
https://bugs.python.org/issue31728
<!-- /issue-number -->
