### PR TITLE
[2.7] bpo-31271: Fix an assertion failure in io.TextIOWrapper.write. (GH-3201)

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2666,6 +2666,22 @@ class TextIOWrapperTest(unittest.TestCase):
         t = self.TextIOWrapper(NonbytesStream('a'))
         self.assertEqual(t.read(), u'a')
 
+    def test_illegal_encoder(self):
+        # bpo-31271: A TypeError error should be raise in case the return
+        # value of encoder's encode() is invalid.
+        class BadEncoder:
+            def encode(self, dummy):
+                return u'spam'
+        def _get_bad_encoder(dummy):
+            return BadEncoder()
+        rot13 = codecs.lookup("rot13")
+        with support.swap_attr(rot13, '_is_text_encoding', True), \
+             support.swap_attr(rot13, 'incrementalencoder', _get_bad_encoder):
+            t = io.TextIOWrapper(io.BytesIO(b'foo'), encoding="rot13")
+        with self.assertRaises(TypeError):
+            t.write('bar')
+            t.flush()
+
     def test_illegal_decoder(self):
         # Issue #17106
         # Bypass the early encoding check added in issue 20404

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2667,8 +2667,8 @@ class TextIOWrapperTest(unittest.TestCase):
         self.assertEqual(t.read(), u'a')
 
     def test_illegal_encoder(self):
-        # bpo-31271: A TypeError error should be raise in case the return
-        # value of encoder's encode() is invalid.
+        # bpo-31271: A TypeError should be raise in case the return value of
+        # encoder's encode() is invalid.
         class BadEncoder:
             def encode(self, dummy):
                 return u'spam'

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2667,7 +2667,7 @@ class TextIOWrapperTest(unittest.TestCase):
         self.assertEqual(t.read(), u'a')
 
     def test_illegal_encoder(self):
-        # bpo-31271: A TypeError should be raise in case the return value of
+        # bpo-31271: A TypeError should be raised in case the return value of
         # encoder's encode() is invalid.
         class BadEncoder:
             def encode(self, dummy):

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2672,11 +2672,11 @@ class TextIOWrapperTest(unittest.TestCase):
         class BadEncoder:
             def encode(self, dummy):
                 return u'spam'
-        def _get_bad_encoder(dummy):
+        def get_bad_encoder(dummy):
             return BadEncoder()
         rot13 = codecs.lookup("rot13")
         with support.swap_attr(rot13, '_is_text_encoding', True), \
-             support.swap_attr(rot13, 'incrementalencoder', _get_bad_encoder):
+             support.swap_attr(rot13, 'incrementalencoder', get_bad_encoder):
             t = io.TextIOWrapper(io.BytesIO(b'foo'), encoding="rot13")
         with self.assertRaises(TypeError):
             t.write('bar')


### PR DESCRIPTION


<!-- issue-number: bpo-31271 -->
https://bugs.python.org/issue31271
<!-- /issue-number -->
