### PR TITLE
[2.7] bpo-31490: Fix an assertion failure in ctypes in case an _anonymous_ attr is defined only outside _fields_. (GH-3615)

### DIFF
--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -288,9 +288,9 @@ MakeAnonFields(PyObject *type)
         }
         if (Py_TYPE(descr) != &PyCField_Type) {
             PyErr_Format(PyExc_AttributeError,
-                         "'%U' is specified in _anonymous_ but not in "
-                         "_fields_",
-                         fname);
+                         "an item in _anonymous_ (index %zd) is not "
+                         "specified in _fields_",
+                         i);
             Py_DECREF(anon_names);
             Py_DECREF(descr);
             return -1;


### PR DESCRIPTION
Fix the #3780 backport to 2.7 (as `PyErr_Format()` in 2.7 doesn't support `%U` as a format specifier).

<!-- issue-number: bpo-31490 -->
https://bugs.python.org/issue31490
<!-- /issue-number -->
