### PR TITLE
bpo-31763: Add NOTICE level to the logging module

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -350,6 +350,8 @@ name is lost.
 +--------------+---------------+
 | ``WARNING``  | 30            |
 +--------------+---------------+
+| ``NOTICE``   | 25            |
++--------------+---------------+
 | ``INFO``     | 20            |
 +--------------+---------------+
 | ``DEBUG``    | 10            |
@@ -768,11 +770,12 @@ the options available to you.
 | funcName       | ``%(funcName)s``        | Name of function containing the logging call. |
 +----------------+-------------------------+-----------------------------------------------+
 | levelname      | ``%(levelname)s``       | Text logging level for the message            |
-|                |                         | (``'DEBUG'``, ``'INFO'``, ``'WARNING'``,      |
-|                |                         | ``'ERROR'``, ``'CRITICAL'``).                 |
+|                |                         | (``'DEBUG'``, ``'INFO'``, ``'NOTICE'``,       |
+|                |                         | ``'WARNING'``, ``'ERROR'``, ``'CRITICAL'``).  |
 +----------------+-------------------------+-----------------------------------------------+
 | levelno        | ``%(levelno)s``         | Numeric logging level for the message         |
 |                |                         | (:const:`DEBUG`, :const:`INFO`,               |
+|                |                         | :const:`NOTICE`,                              |
 |                |                         | :const:`WARNING`, :const:`ERROR`,             |
 |                |                         | :const:`CRITICAL`).                           |
 +----------------+-------------------------+-----------------------------------------------+
@@ -987,6 +990,12 @@ functions.
    interpreted as for :func:`debug`.
 
 
+.. function:: notice(msg, *args, **kwargs)
+
+   Logs a message with level :const:`NOTICE` on the root logger. The arguments are
+   interpreted as for :func:`debug`.
+
+
 .. function:: warning(msg, *args, **kwargs)
 
    Logs a message with level :const:`WARNING` on the root logger. The arguments
@@ -1068,11 +1077,12 @@ functions.
 
    Returns the textual representation of logging level *lvl*. If the level is one
    of the predefined levels :const:`CRITICAL`, :const:`ERROR`, :const:`WARNING`,
-   :const:`INFO` or :const:`DEBUG` then you get the corresponding string. If you
-   have associated levels with names using :func:`addLevelName` then the name you
-   have associated with *lvl* is returned. If a numeric value corresponding to one
-   of the defined levels is passed in, the corresponding string representation is
-   returned. Otherwise, the string 'Level %s' % lvl is returned.
+   :const:`NOTICE`, :const:`INFO` or :const:`DEBUG` then you get the corresponding
+   string. If you have associated levels with names using :func:`addLevelName` then
+   the name you have associated with *lvl* is returned. If a numeric value
+   corresponding to one of the defined levels is passed in, the corresponding
+   string representation is returned. Otherwise, the string 'Level %s' % lvl is
+   returned.
 
    .. note:: Levels are internally integers (as they need to be compared in the
       logging logic). This function is used to convert between an integer level

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -91,6 +91,7 @@ FATAL = CRITICAL
 ERROR = 40
 WARNING = 30
 WARN = WARNING
+NOTICE = 25
 INFO = 20
 DEBUG = 10
 NOTSET = 0
@@ -99,6 +100,7 @@ _levelToName = {
     CRITICAL: 'CRITICAL',
     ERROR: 'ERROR',
     WARNING: 'WARNING',
+    NOTICE: 'NOTICE',
     INFO: 'INFO',
     DEBUG: 'DEBUG',
     NOTSET: 'NOTSET',
@@ -109,6 +111,7 @@ _nameToLevel = {
     'ERROR': ERROR,
     'WARN': WARNING,
     'WARNING': WARNING,
+    'NOTICE': NOTICE,
     'INFO': INFO,
     'DEBUG': DEBUG,
     'NOTSET': NOTSET,
@@ -126,16 +129,18 @@ def getLevelName(level):
     If a numeric value corresponding to one of the defined levels is passed
     in, the corresponding string representation is returned.
 
-    Otherwise, the string "Level %s" % level is returned.
+    Otherwise, the string representation of 'level' is returned.
     """
     # See Issues #22386, #27937 and #29220 for why it's this way
     result = _levelToName.get(level)
     if result is not None:
         return result
-    result = _nameToLevel.get(level)
+
+    result = _nameToLevel.get(level.upper())
     if result is not None:
-        return result
-    return "Level %s" % level
+        return level
+
+    return "%s" % level
 
 def addLevelName(level, levelName):
     """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -35,7 +35,7 @@ __all__ = ['BASIC_FORMAT', 'BufferingFormatter', 'CRITICAL', 'DEBUG', 'ERROR',
            'exception', 'fatal', 'getLevelName', 'getLogger', 'getLoggerClass',
            'info', 'log', 'makeLogRecord', 'setLoggerClass', 'shutdown',
            'warn', 'warning', 'getLogRecordFactory', 'setLogRecordFactory',
-           'lastResort', 'raiseExceptions']
+           'lastResort', 'raiseExceptions', 'notice', 'NOTICE']
 
 import threading
 
@@ -122,7 +122,7 @@ def getLevelName(level):
     Return the textual representation of logging level 'level'.
 
     If the level is one of the predefined levels (CRITICAL, ERROR, WARNING,
-    INFO, DEBUG) then you get the corresponding string. If you have
+    NOTICE, INFO, DEBUG) then you get the corresponding string. If you have
     associated levels with names using addLevelName then the name you have
     associated with 'level' is returned.
 
@@ -439,9 +439,9 @@ class Formatter(object):
 
     %(name)s            Name of the logger (logging channel)
     %(levelno)s         Numeric logging level for the message (DEBUG, INFO,
-                        WARNING, ERROR, CRITICAL)
+                        NOTICE, WARNING, ERROR, CRITICAL)
     %(levelname)s       Text logging level for the message ("DEBUG", "INFO",
-                        "WARNING", "ERROR", "CRITICAL")
+                        "NOTICE", "WARNING", "ERROR", "CRITICAL")
     %(pathname)s        Full pathname of the source file where the logging
                         call was issued (if available)
     %(filename)s        Filename portion of pathname
@@ -1335,6 +1335,18 @@ class Logger(Filterer):
         if self.isEnabledFor(INFO):
             self._log(INFO, msg, args, **kwargs)
 
+    def notice(self, msg, *args, **kwargs):
+        """
+        Log 'msg % args' with severity 'NOTICE'.
+
+        To pass exception information, use the keyword argument exc_info with
+        a true value, e.g.
+
+        logger.info("Houston, we have a %s", "interesting problem", exc_info=1)
+        """
+        if self.isEnabledFor(NOTICE):
+            self._log(INFO, msg, args, **kwargs)
+
     def warning(self, msg, *args, **kwargs):
         """
         Log 'msg % args' with severity 'WARNING'.
@@ -1682,6 +1694,12 @@ class LoggerAdapter(object):
         """
         self.log(INFO, msg, *args, **kwargs)
 
+    def notice(self, msg, *args, **kwargs):
+        """
+        Delegate an notice call to the underlying logger.
+        """
+        self.log(NOTICE, msg, *args, **kwargs)
+
     def warning(self, msg, *args, **kwargs):
         """
         Delegate a warning call to the underlying logger.
@@ -1931,6 +1949,16 @@ def warn(msg, *args, **kwargs):
     warnings.warn("The 'warn' function is deprecated, "
         "use 'warning' instead", DeprecationWarning, 2)
     warning(msg, *args, **kwargs)
+
+def notice(msg, *args, **kwargs):
+    """
+    Log a message with severity 'NOTICE' on the root logger. If the logger has
+    no handlers, call basicConfig() to add a console handler with a pre-defined
+    format.
+    """
+    if len(root.handlers) == 0:
+        basicConfig()
+    root.info(msg, *args, **kwargs)
 
 def info(msg, *args, **kwargs):
     """

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -786,6 +786,7 @@ class SysLogHandler(logging.Handler):
     priority_map = {
         "DEBUG" : "debug",
         "INFO" : "info",
+        "NOTICE" : "notice",
         "WARNING" : "warning",
         "ERROR" : "error",
         "CRITICAL" : "critical"
@@ -1049,6 +1050,7 @@ class NTEventLogHandler(logging.Handler):
             self.typemap = {
                 logging.DEBUG   : win32evtlog.EVENTLOG_INFORMATION_TYPE,
                 logging.INFO    : win32evtlog.EVENTLOG_INFORMATION_TYPE,
+                logging.NOTICE  : win32evtlog.EVENTLOG_INFORMATION_TYPE,
                 logging.WARNING : win32evtlog.EVENTLOG_WARNING_TYPE,
                 logging.ERROR   : win32evtlog.EVENTLOG_ERROR_TYPE,
                 logging.CRITICAL: win32evtlog.EVENTLOG_ERROR_TYPE,

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -195,16 +195,19 @@ class BuiltinLevelsTest(BaseTest):
         INF.log(logging.CRITICAL, m())
         INF.error(m())
         INF.warning(m())
+        INF.notice(m())
         INF.info(m())
 
         DEB.log(logging.CRITICAL, m())
         DEB.error(m())
         DEB.warning(m())
+        DEB.notice(m())
         DEB.info(m())
         DEB.debug(m())
 
         # These should not log.
         ERR.warning(m())
+        ERR.notice(m())
         ERR.info(m())
         ERR.debug(m())
 
@@ -216,10 +219,12 @@ class BuiltinLevelsTest(BaseTest):
             ('INF', 'CRITICAL', '3'),
             ('INF', 'ERROR', '4'),
             ('INF', 'WARNING', '5'),
+            ('INF', 'NOTICE', '5.5'),
             ('INF', 'INFO', '6'),
             ('DEB', 'CRITICAL', '7'),
             ('DEB', 'ERROR', '8'),
             ('DEB', 'WARNING', '9'),
+            ('DEB', 'NOTICE', '9.5'),
             ('DEB', 'INFO', '10'),
             ('DEB', 'DEBUG', '11'),
         ])
@@ -239,6 +244,7 @@ class BuiltinLevelsTest(BaseTest):
 
         # These should not log.
         INF_ERR.warning(m())
+        INF_ERR.notice(m())
         INF_ERR.info(m())
         INF_ERR.debug(m())
 
@@ -263,6 +269,7 @@ class BuiltinLevelsTest(BaseTest):
         INF_UNDEF.log(logging.CRITICAL, m())
         INF_UNDEF.error(m())
         INF_UNDEF.warning(m())
+        INF_UNDEF.notice(m())
         INF_UNDEF.info(m())
         INF_ERR_UNDEF.log(logging.CRITICAL, m())
         INF_ERR_UNDEF.error(m())
@@ -270,6 +277,7 @@ class BuiltinLevelsTest(BaseTest):
         # These should not log.
         INF_UNDEF.debug(m())
         INF_ERR_UNDEF.warning(m())
+        INF_ERR_UNDEF.notice(m())
         INF_ERR_UNDEF.info(m())
         INF_ERR_UNDEF.debug(m())
 
@@ -277,6 +285,7 @@ class BuiltinLevelsTest(BaseTest):
             ('INF.UNDEF', 'CRITICAL', '1'),
             ('INF.UNDEF', 'ERROR', '2'),
             ('INF.UNDEF', 'WARNING', '3'),
+            ('INF.UNDEF', 'NOTICE', '3.5'),
             ('INF.UNDEF', 'INFO', '4'),
             ('INF.ERR.UNDEF', 'CRITICAL', '5'),
             ('INF.ERR.UNDEF', 'ERROR', '6'),


### PR DESCRIPTION
- Add logging.NOTICE level
- Add logging.notice() function
- Add logging.Logger.notice() method
- SysLogHandler: map logging NOTICE level to syslog LOG_INFO level
- NTEventLogHandler: map logging NOTICE level to EVENTLOG_INFORMATION_TYPE

https://bugs.python.org/issue31763

<!-- issue-number: bpo-31763 -->
https://bugs.python.org/issue31763
<!-- /issue-number -->
