### PR TITLE
bpo-31764: Prevent a crash in sqlite3.Cursor.close() in case the Cursor object is uninitialized

### DIFF
--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -186,12 +186,12 @@ class RegressionTests(unittest.TestCase):
 
         con = sqlite.connect(":memory:")
         cur = Cursor(con)
-        with self.assertRaisesRegex(sqlite.ProgrammingError,
-                                    r'^Base Cursor\.__init__ not called\.$'):
+        with self.assertRaises(sqlite.ProgrammingError):
             cur.execute("select 4+5").fetchall()
         with self.assertRaisesRegex(sqlite.ProgrammingError,
                                     r'^Base Cursor\.__init__ not called\.$'):
             cur.close()
+
     def CheckStrSubclass(self):
         """
         The Python 3.0 port of the module didn't cope with values of subclasses of str.

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -188,6 +188,7 @@ class RegressionTests(unittest.TestCase):
         cur = Cursor(con)
         with self.assertRaises(sqlite.ProgrammingError):
             cur.execute("select 4+5").fetchall()
+        self.assertRaises(sqlite.ProgrammingError, cur.close)
 
     def CheckStrSubclass(self):
         """

--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -186,10 +186,12 @@ class RegressionTests(unittest.TestCase):
 
         con = sqlite.connect(":memory:")
         cur = Cursor(con)
-        with self.assertRaises(sqlite.ProgrammingError):
+        with self.assertRaisesRegex(sqlite.ProgrammingError,
+                                    r'^Base Cursor\.__init__ not called\.$'):
             cur.execute("select 4+5").fetchall()
-        self.assertRaises(sqlite.ProgrammingError, cur.close)
-
+        with self.assertRaisesRegex(sqlite.ProgrammingError,
+                                    r'^Base Cursor\.__init__ not called\.$'):
+            cur.close()
     def CheckStrSubclass(self):
         """
         The Python 3.0 port of the module didn't cope with values of subclasses of str.

--- a/Misc/NEWS.d/next/Library/2017-10-11-22-18-04.bpo-31764.EMyIkK.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-11-22-18-04.bpo-31764.EMyIkK.rst
@@ -1,2 +1,2 @@
-Prevent a crash in `sqlite3.Cursor.close()` in case the Cursor object is
+Prevent a crash in `sqlite3.Cursor.close()` in case the `Cursor` object is
 uninitialized. Patch by Oren Milman.

--- a/Misc/NEWS.d/next/Library/2017-10-11-22-18-04.bpo-31764.EMyIkK.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-11-22-18-04.bpo-31764.EMyIkK.rst
@@ -1,0 +1,2 @@
+Prevent a crash in `sqlite3.Cursor.close()` in case the Cursor object is
+uninitialized. Patch by Oren Milman.

--- a/Misc/NEWS.d/next/Library/2017-10-11-22-18-04.bpo-31764.EMyIkK.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-11-22-18-04.bpo-31764.EMyIkK.rst
@@ -1,2 +1,2 @@
-Prevent a crash in `sqlite3.Cursor.close()` in case the `Cursor` object is
+Prevent a crash in ``sqlite3.Cursor.close()`` in case the ``Cursor`` object is
 uninitialized. Patch by Oren Milman.

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -890,6 +890,11 @@ PyObject* pysqlite_noop(pysqlite_Connection* self, PyObject* args)
 
 PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args)
 {
+    if (self->connection == NULL) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Base Cursor.__init__ not called.");
+        return NULL;
+    }
     if (!pysqlite_check_thread(self->connection) || !pysqlite_check_connection(self->connection)) {
         return NULL;
     }

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -890,7 +890,7 @@ PyObject* pysqlite_noop(pysqlite_Connection* self, PyObject* args)
 
 PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args)
 {
-    if (self->connection == NULL) {
+    if (!self->connection) {
         PyErr_SetString(pysqlite_ProgrammingError,
                         "Base Cursor.__init__ not called.");
         return NULL;


### PR DESCRIPTION
In addition, add a test to `test_sqlite` to make sure that the crash is no more.

<!-- issue-number: bpo-31764 -->
https://bugs.python.org/issue31764
<!-- /issue-number -->
