### PR TITLE
bpo-31567: Use decorator markup for staticmethod()/classmethod()

### DIFF
--- a/Doc/library/abc.rst
+++ b/Doc/library/abc.rst
@@ -278,7 +278,7 @@ The :mod:`abc` module also provides the following decorators:
        :func:`abstractmethod`, making this decorator redundant.
 
 
-.. decorator:: abstractproperty(fget=None, fset=None, fdel=None, doc=None)
+.. decorator:: abstractproperty
 
    A subclass of the built-in :func:`property`, indicating an abstract
    property.

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -196,9 +196,9 @@ are always available.  They are listed here in alphabetical order.
    base 16).  :exc:`ValueError` will be raised if *i* is outside that range.
 
 
-.. function:: classmethod(function)
+.. decorator:: classmethod
 
-   Return a class method for *function*.
+   Transforms a method into a class method.
 
    A class method receives the class as implicit first argument, just like an
    instance method receives the instance. To declare a class method, use this
@@ -1398,9 +1398,9 @@ are always available.  They are listed here in alphabetical order.
 
    For sorting examples and a brief sorting tutorial, see :ref:`sortinghowto`.
 
-.. function:: staticmethod(function)
+.. decorator:: staticmethod
 
-   Return a static method for *function*.
+   Transforms a method into a static method.
 
    A static method does not receive an implicit first argument. To declare a static
    method, use this idiom::

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -198,7 +198,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. decorator:: classmethod
 
-   Transforms a method into a class method.
+   Transform a method into a class method.
 
    A class method receives the class as implicit first argument, just like an
    instance method receives the instance. To declare a class method, use this
@@ -1400,7 +1400,7 @@ are always available.  They are listed here in alphabetical order.
 
 .. decorator:: staticmethod
 
-   Transforms a method into a static method.
+   Transform a method into a static method.
 
    A static method does not receive an implicit first argument. To declare a static
    method, use this idiom::

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -264,9 +264,9 @@ The :mod:`functools` module defines the following functions:
           return value
 
 
-.. decorator:: singledispatch(default)
+.. decorator:: singledispatch
 
-   Transforms a function into a :term:`single-dispatch <single
+   Transform a function into a :term:`single-dispatch <single
    dispatch>` :term:`generic function`.
 
    To define a generic function, decorate it with the ``@singledispatch``

--- a/Doc/library/test.rst
+++ b/Doc/library/test.rst
@@ -440,7 +440,7 @@ The :mod:`test.support` module defines the following functions:
    otherwise.
 
 
-.. decorator:: skip_unless_symlink()
+.. decorator:: skip_unless_symlink
 
    A decorator for running tests that require support for symbolic links.
 


### PR DESCRIPTION
staticmethod() and classmethod() are expected to be used with decorator, so documentation should mention it.

<!-- issue-number: bpo-31567 -->
https://bugs.python.org/issue31567
<!-- /issue-number -->
