### PR TITLE
bpo-25588: Fix regrtest when run inside IDLE

### DIFF
--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -1,6 +1,7 @@
 import atexit
 import faulthandler
 import os
+import io
 import signal
 import sys
 import unittest
@@ -14,17 +15,24 @@ from test.libregrtest.refleak import warm_caches
 
 
 def setup_tests(ns):
-    # Display the Python traceback on fatal errors (e.g. segfault)
-    faulthandler.enable(all_threads=True)
+    try:
+        stderr_fd = sys.stderr.fileno()
+    except io.UnsupportedOperation:
+        # For example, in IDLE, sys.stderr has no file descriptor,
+        # so faulthandler cannot be used.
+        stderr_fd = None
+    else:
+        # Display the Python traceback on fatal errors (e.g. segfault)
+        faulthandler.enable(all_threads=True, file=stderr_fd)
 
-    # Display the Python traceback on SIGALRM or SIGUSR1 signal
-    signals = []
-    if hasattr(signal, 'SIGALRM'):
-        signals.append(signal.SIGALRM)
-    if hasattr(signal, 'SIGUSR1'):
-        signals.append(signal.SIGUSR1)
-    for signum in signals:
-        faulthandler.register(signum, chain=True)
+        # Display the Python traceback on SIGALRM or SIGUSR1 signal
+        signals = []
+        if hasattr(signal, 'SIGALRM'):
+            signals.append(signal.SIGALRM)
+        if hasattr(signal, 'SIGUSR1'):
+            signals.append(signal.SIGUSR1)
+        for signum in signals:
+            faulthandler.register(signum, chain=True, file=stderr_fd)
 
     replace_stdout()
     support.record_original_stdout(sys.stdout)
@@ -109,7 +117,14 @@ def replace_stdout():
     """Set stdout encoder error handler to backslashreplace (as stderr error
     handler) to avoid UnicodeEncodeError when printing a traceback"""
     stdout = sys.stdout
-    sys.stdout = open(stdout.fileno(), 'w',
+    try:
+        fd = stdout.fileno()
+    except io.UnsupportedOperation:
+        # On IDLE, sys.stdout has no file descriptor and is not a TextIOWrapper
+        # object. Leaving sys.stdout unchanged.
+        return
+
+    sys.stdout = open(fd, 'w',
         encoding=stdout.encoding,
         errors="backslashreplace",
         closefd=False,

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -17,13 +17,10 @@ def setup_tests(ns):
     try:
         stderr_fd = sys.__stderr__.fileno()
     except (ValueError, AttributeError):
-        # In IDLE, sys.stderr.fileno() raises io.UnsupportedOperation: the
-        # stream has no file descriptor, and so faulthandler cannot be used.
-        #
         # Catch ValueError to catch io.UnsupportedOperation on TextIOBase
         # and ValueError on a closed stream.
         #
-        # Catch also AttributeError for stderr being None.
+        # Catch AttributeError for stderr being None.
         stderr_fd = None
     else:
         # Display the Python traceback on fatal errors (e.g. segfault)

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -1,7 +1,6 @@
 import atexit
 import faulthandler
 import os
-import io
 import signal
 import sys
 import unittest
@@ -17,9 +16,12 @@ from test.libregrtest.refleak import warm_caches
 def setup_tests(ns):
     try:
         stderr_fd = sys.stderr.fileno()
-    except io.UnsupportedOperation:
+    except ValueError:
         # For example, in IDLE, sys.stderr has no file descriptor,
         # so faulthandler cannot be used.
+        #
+        # Catch ValueError to catch io.UnsupportedOperation on TextIOBase
+        # and ValueError on a closed stream.
         stderr_fd = None
     else:
         # Display the Python traceback on fatal errors (e.g. segfault)
@@ -119,9 +121,12 @@ def replace_stdout():
     stdout = sys.stdout
     try:
         fd = stdout.fileno()
-    except io.UnsupportedOperation:
+    except ValueError:
         # On IDLE, sys.stdout has no file descriptor and is not a TextIOWrapper
         # object. Leaving sys.stdout unchanged.
+        #
+        # Catch ValueError to catch io.UnsupportedOperation on TextIOBase
+        # and ValueError on a closed stream.
         return
 
     sys.stdout = open(fd, 'w',

--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -15,13 +15,15 @@ from test.libregrtest.refleak import warm_caches
 
 def setup_tests(ns):
     try:
-        stderr_fd = sys.stderr.fileno()
-    except ValueError:
-        # For example, in IDLE, sys.stderr has no file descriptor,
-        # so faulthandler cannot be used.
+        stderr_fd = sys.__stderr__.fileno()
+    except (ValueError, AttributeError):
+        # In IDLE, sys.stderr.fileno() raises io.UnsupportedOperation: the
+        # stream has no file descriptor, and so faulthandler cannot be used.
         #
         # Catch ValueError to catch io.UnsupportedOperation on TextIOBase
         # and ValueError on a closed stream.
+        #
+        # Catch also AttributeError for stderr being None.
         stderr_fd = None
     else:
         # Display the Python traceback on fatal errors (e.g. segfault)


### PR DESCRIPTION
When regrtest in run inside IDLE, sys.stdout and sys.stderr are not
TextIOWrapper objects and have no file descriptor associated:
sys.stderr.fileno() raises io.UnsupportedOperation.

Disable faulthandler and don't replace sys.stdout in that case.

<!-- issue-number: bpo-25588 -->
https://bugs.python.org/issue25588
<!-- /issue-number -->
