### PR TITLE
bpo-30767: check formatException() input parameter for proper type, width and not None

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -520,7 +520,7 @@ class Formatter(object):
         """
         # check parameter for Tuple since it can be any "Truthy" type.
         # if sys.exc_info() didn't locate a stack frame, output is pointless
-        if not isinstance(ei, tuple) or ei[0] is None:
+        if not isinstance(ei, tuple) or (len(ei) < 3) or ei[0] is None:
             return ""
         sio = io.StringIO()
         tb = ei[2]

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -518,6 +518,10 @@ class Formatter(object):
         This default implementation just uses
         traceback.print_exception()
         """
+        # check parameter for Tuple since it can be any "Truthy" type.
+        # if sys.exc_info() didn't locate a stack frame, output is pointless
+        if not isinstance(ei, tuple) or ei[0] is None:
+            return ""
         sio = io.StringIO()
         tb = ei[2]
         # See issues #9427, #1553375. Commented out for now.


### PR DESCRIPTION
logger.log() can be invoked with a kwargs of `exc_info="a Truthy Value"` which can take the form of a long list of datatypes: integer, string, Object, etc. The function fails to check it's parameter datatype and blindly tries to reference elements as if only Tuples were possible. This immediately raises a TypeError and potentially an IndexError.

Furthermore if an earlier invocation of 'sys.exc_info()' was unable to find a stack frame it returns `(None, None, None)` which formatException() then unhelpfully renders into "NoneType None" as part of the stack trace.



<!-- issue-number: bpo-30767 -->
https://bugs.python.org/issue30767
<!-- /issue-number -->
