### PR TITLE
[2.7] bpo-30058: Fixed buffer overflow in select.kqueue.control(). (GH-1095).

### DIFF
--- a/Lib/test/test_kqueue.py
+++ b/Lib/test/test_kqueue.py
@@ -205,6 +205,30 @@ class TestKQueue(unittest.TestCase):
         b.close()
         kq.close()
 
+    def test_issue30058(self):
+        # changelist must be an iterable
+        kq = select.kqueue()
+        a, b = socket.socketpair()
+        ev = select.kevent(a, select.KQ_FILTER_READ, select.KQ_EV_ADD | select.KQ_EV_ENABLE)
+
+        kq.control([ev], 0)
+        # not a list
+        kq.control((ev,), 0)
+        # __len__ is not consistent with __iter__
+        class BadList:
+            def __len__(self):
+                return 0
+            def __iter__(self):
+                for i in range(100):
+                    yield ev
+        kq.control(BadList(), 0)
+        # doesn't have __len__
+        kq.control(iter([ev]), 0)
+
+        a.close()
+        b.close()
+        kq.close()
+
 def test_main():
     test_support.run_unittest(TestKQueue)
 

--- a/Misc/NEWS.d/next/Library/2017-10-12-19-00-53.bpo-30058.cENtry.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-12-19-00-53.bpo-30058.cENtry.rst
@@ -1,0 +1,1 @@
+Fixed buffer overflow in select.kqueue.control().


### PR DESCRIPTION
(cherry picked from commit de072100775cc29e6cd93a75466cecbd1086f258)


<!-- issue-number: bpo-30058 -->
https://bugs.python.org/issue30058
<!-- /issue-number -->
