### PR TITLE
bpo-31776: Missing "raise from None" in /Lib/xml/etree/ElementPath.py

### DIFF
--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -276,7 +276,7 @@ def iterfind(elem, path, namespaces=None):
             try:
                 selector.append(ops[token[0]](next, token))
             except StopIteration:
-                raise SyntaxError("invalid path")
+                raise SyntaxError("invalid path") from None
             try:
                 token = next()
                 if token[0] == "/":

--- a/Misc/NEWS.d/next/Library/2017-10-12-22-06-56.bpo-31776.6Vc_uP.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-12-22-06-56.bpo-31776.6Vc_uP.rst
@@ -1,0 +1,2 @@
+Fix missing "raise from None" for a exception chain located at
+/Lib/xml/etree/ElementPath.py

--- a/Misc/NEWS.d/next/Library/2017-10-12-22-06-56.bpo-31776.6Vc_uP.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-12-22-06-56.bpo-31776.6Vc_uP.rst
@@ -1,2 +1,0 @@
-Fix missing "raise from None" for a exception chain located at
-/Lib/xml/etree/ElementPath.py


### PR DESCRIPTION
Based on bpo-29762 (https://github.com/python/cpython/commit/5affd23e6f42125998724787025080a24839266e), there is an inconsistency on one exception chain in /Lib/xml/etree/ElementPath.py:

```python
     try:
         selector.append(ops[token[0]](next, token))
     except StopIteration:
        raise SyntaxError("invalid path")
```

should be
```python
     try:
         selector.append(ops[token[0]](next, token))
     except StopIteration:
        raise SyntaxError("invalid path") from None
```

<!-- issue-number: bpo-31776 -->
https://bugs.python.org/issue31776
<!-- /issue-number -->
