### PR TITLE
bpo-29696 Use structseq in string.Formatter.parse iterator response

### DIFF
--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -2863,13 +2863,31 @@ class StringModuleTest(unittest.TestCase):
         def parse(format):
             return list(_string.formatter_parser(format))
 
+        formatter = next(_string.formatter_parser("test"))
+        self.assertEqual(formatter.n_fields, 4)
+        self.assertEqual(formatter.n_unnamed_fields, 0)
+        self.assertEqual(formatter.n_sequence_fields, 4)
+        self.assertNotEqual(formatter.__class__,tuple)
+        self.assertIsInstance(formatter,tuple)
+        self.assertEqual(formatter.__class__.__name__,"FormatterItem")
+
         formatter = parse("prefix {2!s}xxx{0:^+10.3f}{obj.attr!s} {z[0]!s:10}")
-        self.assertEqual(formatter, [
+        expected_formatter = [
             ('prefix ', '2', '', 's'),
             ('xxx', '0', '^+10.3f', None),
             ('', 'obj.attr', '', 's'),
             (' ', 'z[0]', '10', 's'),
-        ])
+            ]
+
+        self.assertEqual(formatter, expected_formatter)
+
+        for result, expected in zip(formatter, expected_formatter):
+            self.assertEqual(expected,
+                    (result.literal_text,
+                     result.field_name,
+                     result.format_spec,
+                     result.conversion,))
+
 
         formatter = parse("prefix {} suffix")
         self.assertEqual(formatter, [

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -2882,13 +2882,10 @@ class StringModuleTest(unittest.TestCase):
         self.assertEqual(formatter, expected_formatter)
 
         for result, expected in zip(formatter, expected_formatter):
-            self.assertEqual(
-                    (result.literal_text,
-                     result.field_name,
-                     result.format_spec,
-                     result.conversion)
-                    ,expected)
-
+            self.assertEqual(result.literal_text, expected[0])
+            self.assertEqual(result.field_name, expected[1])
+            self.assertEqual(result.format_spec, expected[2])
+            self.assertEqual(result.conversion, expected[3])
 
         formatter = parse("prefix {} suffix")
         self.assertEqual(formatter, [

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -2867,9 +2867,9 @@ class StringModuleTest(unittest.TestCase):
         self.assertEqual(formatter.n_fields, 4)
         self.assertEqual(formatter.n_unnamed_fields, 0)
         self.assertEqual(formatter.n_sequence_fields, 4)
-        self.assertNotEqual(formatter.__class__,tuple)
-        self.assertIsInstance(formatter,tuple)
-        self.assertEqual(formatter.__class__.__name__,"FormatterItem")
+        self.assertNotEqual(formatter.__class__, tuple)
+        self.assertIsInstance(formatter, tuple)
+        self.assertEqual(formatter.__class__.__name__, "FormatterItem")
 
         formatter = parse("prefix {2!s}xxx{0:^+10.3f}{obj.attr!s} {z[0]!s:10}")
         expected_formatter = [

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -2882,11 +2882,12 @@ class StringModuleTest(unittest.TestCase):
         self.assertEqual(formatter, expected_formatter)
 
         for result, expected in zip(formatter, expected_formatter):
-            self.assertEqual(expected,
+            self.assertEqual(
                     (result.literal_text,
                      result.field_name,
                      result.format_spec,
-                     result.conversion,))
+                     result.conversion)
+                    ,expected)
 
 
         formatter = parse("prefix {} suffix")

--- a/Misc/NEWS.d/next/Library/2017-10-13-00-35-15.bpo-29696.aWzShQ.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-13-00-35-15.bpo-29696.aWzShQ.rst
@@ -1,0 +1,2 @@
+Use namedtuple (structseq ovbject) in string.Formatter.parse iterator
+response.

--- a/Misc/NEWS.d/next/Library/2017-10-13-00-35-15.bpo-29696.aWzShQ.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-13-00-35-15.bpo-29696.aWzShQ.rst
@@ -1,2 +1,2 @@
-Use namedtuple (structseq ovbject) in string.Formatter.parse iterator
+Use namedtuple (structseq object) in string.Formatter.parse iterator
 response.

--- a/Misc/NEWS.d/next/Library/2017-10-13-00-35-15.bpo-29696.aWzShQ.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-13-00-35-15.bpo-29696.aWzShQ.rst
@@ -1,2 +1,2 @@
-Use namedtuple (structseq object) in string.Formatter.parse iterator
+Use named tuple (structseq object) in string.Formatter.parse iterator
 response.

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -1062,11 +1062,6 @@ formatteriter_next(formatteriterobject *it)
         if (conversion_str == NULL)
             goto done;
 
-        Py_XINCREF(literal_str);
-        Py_XINCREF(field_name_str);
-        Py_XINCREF(format_spec_str);
-        Py_XINCREF(conversion_str);
-
         PyStructSequence_InitType(&FormatterIterResultType, &formatter_iter_result_desc);
         Py_INCREF((PyObject *) &FormatterIterResultType);
         res = PyStructSequence_New(&FormatterIterResultType);
@@ -1078,10 +1073,6 @@ formatteriter_next(formatteriterobject *it)
 
 
     done:
-        Py_XDECREF(literal_str);
-        Py_XDECREF(field_name_str);
-        Py_XDECREF(format_spec_str);
-        Py_XDECREF(conversion_str);
 
         return res;
     }

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -1031,7 +1031,7 @@ formatteriter_next(formatteriterobject *it)
         PyObject *field_name_str = NULL;
         PyObject *format_spec_str = NULL;
         PyObject *conversion_str = NULL;
-        PyObject* res = NULL;
+        PyObject *res = NULL;
 
         literal_str = SubString_new_object(&literal);
         if (literal_str == NULL)

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -1063,7 +1063,6 @@ formatteriter_next(formatteriterobject *it)
         if (conversion_str == NULL)
             goto error;
 
-        PyStructSequence_InitType(&FormatterIterResultType, &formatter_iter_result_desc);
         Py_INCREF((PyObject *) &FormatterIterResultType);
         res = PyStructSequence_New(&FormatterIterResultType);
 

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -1001,7 +1001,7 @@ static PyStructSequence_Field formatter_iter_result_fields[] = {
 static PyTypeObject FormatterIterResultType;
 
 static PyStructSequence_Desc formatter_iter_result_desc = {
-    "FormatterItem",
+    "string.FormatterItem",
     NULL,
     formatter_iter_result_fields,
     4

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -993,8 +993,10 @@ formatteriter_dealloc(formatteriterobject *it)
 static PyStructSequence_Field formatter_iter_result_fields[] = {
     {"literal_text", "Span of literal text."},
     {"field_name", "Specifies the object whose value is to be formatted."},
-    {"format_spec", "Contains a specification of how the value should be presented."},
-    {"conversion", "The conversion to be used. One of: ‘s’ (str), ‘r’ (repr) and ‘a’ (ascii)."},
+    {"format_spec", "Contains a specification of how the value \
+    should be presented."},
+    {"conversion", "The conversion to be used. One of: ‘s’ (str),\
+    ‘r’ (repr) and ‘a’ (ascii)."},
     {NULL}
 };
 
@@ -1032,7 +1034,7 @@ formatteriter_next(formatteriterobject *it)
         PyObject *field_name_str = NULL;
         PyObject *format_spec_str = NULL;
         PyObject *conversion_str = NULL;
-        PyObject *res = NULL;
+        PyObject *res;
 
         literal_str = SubString_new_object(&literal);
         if (literal_str == NULL)
@@ -1075,12 +1077,13 @@ formatteriter_next(formatteriterobject *it)
         PyStructSequence_SET_ITEM(res, 3, conversion_str); 
 
         return res;
+
     error:
         Py_XDECREF(literal_str);
         Py_XDECREF(field_name_str);
         Py_XDECREF(format_spec_str);
         Py_XDECREF(conversion_str);
-        return res;
+        return NULL;
     }
 }
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -15696,6 +15696,7 @@ static struct PyModuleDef _string_module = {
 PyMODINIT_FUNC
 PyInit__string(void)
 {
+    PyStructSequence_InitType(&FormatterIterResultType, &formatter_iter_result_desc);
     return PyModule_Create(&_string_module);
 }
 


### PR DESCRIPTION
This PR solves [bpo-29696](https://bugs.python.org/issue29696) improving the readability of the return value of `Formatter.parse`. Following the requirements of @rhettinger and @serhiy-storchaka, the c-code upstream of the `string` library was modified to maintain the `string` module lightweight. This also improves the `help` section of the result class with a brief description of the result fields.

Now, instead of:

```python
>>> Formatter().parse("mira como bebebn los peces en el {rio} {de} {la} plata")
<formatteriterator object at 0x7f1fc7c7f150>
>>> next(_)
('mira como bebebn los peces en el ', 'rio', '', None)
```

we obtain 

```python
>>> Formatter().parse("mira como bebebn los peces en el {rio} {de} {la} plata")
<formatteriterator object at 0x7f1fc7c7f150>
>>> next(_)
FormatterItem(literal_text='mira como bebebn los peces en el ', field_name='rio', format_spec='', conversion=None)
```

Please, indicate any change that is needed and I will be more than happy to change it. :smile: 

<!-- issue-number: bpo-29696 -->
https://bugs.python.org/issue29696
<!-- /issue-number -->
