### PR TITLE
bpo-31779: Prevent assertion failures and a crash when using an uninitialized struct.Struct object

### DIFF
--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -632,10 +632,10 @@ class StructTest(unittest.TestCase):
         # methods or accessing attributes of an uninitialized Struct object.
         s = struct.Struct.__new__(struct.Struct)
         self.assertRaises(ValueError, s.iter_unpack, b'foo')
-        self.assertRaises(ValueError, s.pack)
-        self.assertRaises(ValueError, s.pack_into)
+        self.assertRaises(ValueError, s.pack, 42)
+        self.assertRaises(ValueError, s.pack_into, bytearray(1), 0, 42)
         self.assertRaises(ValueError, s.unpack, b'bar')
-        self.assertRaises(ValueError, s.unpack_from, b'spam')
+        self.assertRaises(ValueError, s.unpack_from, b'spam', 0)
         self.assertRaises(ValueError, s.__sizeof__)
         with self.assertRaises(ValueError):
             s.format

--- a/Lib/test/test_struct.py
+++ b/Lib/test/test_struct.py
@@ -626,6 +626,20 @@ class StructTest(unittest.TestCase):
         s2 = struct.Struct(s.format.encode())
         self.assertEqual(s2.format, s.format)
 
+    @support.cpython_only
+    def test_uninitialized(self):
+        # A crash or an assertion failure shouldn't happen in case of calling
+        # methods or accessing attributes of an uninitialized Struct object.
+        s = struct.Struct.__new__(struct.Struct)
+        self.assertRaises(ValueError, s.iter_unpack, b'foo')
+        self.assertRaises(ValueError, s.pack)
+        self.assertRaises(ValueError, s.pack_into)
+        self.assertRaises(ValueError, s.unpack, b'bar')
+        self.assertRaises(ValueError, s.unpack_from, b'spam')
+        self.assertRaises(ValueError, s.__sizeof__)
+        with self.assertRaises(ValueError):
+            s.format
+
 
 class UnpackIteratorTest(unittest.TestCase):
     """

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-13-13-57-17.bpo-31779.SOlNo7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-13-13-57-17.bpo-31779.SOlNo7.rst
@@ -1,0 +1,2 @@
+Prevent assertion failures and a crash when using an uninitialized
+``struct.Struct`` object. Patch by Oren Milman.

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1515,7 +1515,7 @@ fail:
 }
 
 Py_LOCAL_INLINE(int)
-_check_struct(PyStructObject *self)
+check_struct(PyStructObject *self)
 {
     if (self->s_codes == NULL) {
         PyErr_SetString(PyExc_ValueError,
@@ -1543,7 +1543,7 @@ static PyObject *
 Struct_unpack_impl(PyStructObject *self, Py_buffer *buffer)
 /*[clinic end generated code: output=873a24faf02e848a input=3113f8e7038b2f6c]*/
 {
-    if (!_check_struct(self)) {
+    if (!check_struct(self)) {
         return NULL;
     }
     if (buffer->len != self->s_size) {
@@ -1575,7 +1575,7 @@ Struct_unpack_from_impl(PyStructObject *self, Py_buffer *buffer,
                         Py_ssize_t offset)
 /*[clinic end generated code: output=57fac875e0977316 input=97ade52422f8962f]*/
 {
-    if (!_check_struct(self)) {
+    if (!check_struct(self)) {
         return NULL;
     }
 
@@ -1705,7 +1705,7 @@ Struct_iter_unpack(PyStructObject *self, PyObject *buffer)
 {
     unpackiterobject *iter;
 
-    if (!_check_struct(self)) {
+    if (!check_struct(self)) {
         return NULL;
     }
 
@@ -1844,7 +1844,7 @@ s_pack(PyObject *self, PyObject **args, Py_ssize_t nargs)
     /* Validate arguments. */
     soself = (PyStructObject *)self;
     assert(PyStruct_Check(self));
-    if (!_check_struct(soself)) {
+    if (!check_struct(soself)) {
         return NULL;
     }
     if (nargs != soself->s_len)
@@ -1886,7 +1886,7 @@ s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs)
     /* Validate arguments.  +1 is for the first arg as buffer. */
     soself = (PyStructObject *)self;
     assert(PyStruct_Check(self));
-    if (!_check_struct(soself)) {
+    if (!check_struct(soself)) {
         return NULL;
     }
     if (nargs != (soself->s_len + 2))
@@ -1974,7 +1974,7 @@ s_pack_into(PyObject *self, PyObject **args, Py_ssize_t nargs)
 static PyObject *
 s_get_format(PyStructObject *self, void *unused)
 {
-    if (!_check_struct(self)) {
+    if (!check_struct(self)) {
         return NULL;
     }
     return PyUnicode_FromStringAndSize(PyBytes_AS_STRING(self->s_format),
@@ -1996,7 +1996,7 @@ s_sizeof(PyStructObject *self, void *unused)
     Py_ssize_t size;
     formatcode *code;
 
-    if (!_check_struct(self)) {
+    if (!check_struct(self)) {
         return NULL;
     }
     size = _PyObject_SIZE(Py_TYPE(self)) + sizeof(formatcode);

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1519,7 +1519,7 @@ check_struct(PyStructObject *self)
 {
     if (self->s_codes == NULL) {
         PyErr_SetString(PyExc_ValueError,
-                        "Struct.__init__() not called");
+                        "Struct.__init__() wasn't called");
         return 0;
     }
     return 1;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1517,7 +1517,7 @@ fail:
 Py_LOCAL_INLINE(int)
 _check_struct(PyStructObject *self)
 {
-    if (self->s_format == NULL || self->s_codes == NULL) {
+    if (self->s_codes == NULL) {
         PyErr_SetString(PyExc_ValueError,
                         "Struct.__init__() not called");
         return 0;


### PR DESCRIPTION
In addition, add tests to `test_struct` to make sure the assertion failures and the crash are no more.

<!-- issue-number: bpo-31779 -->
https://bugs.python.org/issue31779
<!-- /issue-number -->
