### PR TITLE
bpo-30156: Remove property_descr_get() hack

### DIFF
--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1365,9 +1365,7 @@ property_dealloc(PyObject *self)
 static PyObject *
 property_descr_get(PyObject *self, PyObject *obj, PyObject *type)
 {
-    static PyObject * volatile cached_args = NULL;
-    PyObject *args;
-    PyObject *ret;
+    PyObject *args[1];
     propertyobject *gs = (propertyobject *)self;
 
     if (obj == NULL || obj == Py_None) {
@@ -1378,29 +1376,9 @@ property_descr_get(PyObject *self, PyObject *obj, PyObject *type)
         PyErr_SetString(PyExc_AttributeError, "unreadable attribute");
         return NULL;
     }
-    args = cached_args;
-    cached_args = NULL;
-    if (!args) {
-        args = PyTuple_New(1);
-        if (!args)
-            return NULL;
-        _PyObject_GC_UNTRACK(args);
-    }
-    Py_INCREF(obj);
-    PyTuple_SET_ITEM(args, 0, obj);
-    ret = PyObject_Call(gs->prop_get, args, NULL);
-    if (cached_args == NULL && Py_REFCNT(args) == 1) {
-        assert(PyTuple_GET_SIZE(args) == 1);
-        assert(PyTuple_GET_ITEM(args, 0) == obj);
-        cached_args = args;
-        Py_DECREF(obj);
-    }
-    else {
-        assert(Py_REFCNT(args) >= 1);
-        _PyObject_GC_TRACK(args);
-        Py_DECREF(args);
-    }
-    return ret;
+
+    args[0] = obj;
+    return _PyObject_FastCall(gs->prop_get, args, 1);
 }
 
 static int


### PR DESCRIPTION
Remove the cached tuple which caused crashed, use
_PyObject_FastCall() instead.

Microbenchmark using:

    ./python -m perf timeit
        -s 'import collections;P=collections.namedtuple("P","x y");p=P(1, 2)'
        'p.x'

[ref] 80.4 ns +- 3.3 ns -> [fastcall] 103 ns +- 5 ns: 1.28x slower (+28%)

<!-- issue-number: bpo-30156 -->
https://bugs.python.org/issue30156
<!-- /issue-number -->
