### PR TITLE
bpo-31781: Prevent crashes when calling methods of an uninitialized zipimport.zipimporter object

### DIFF
--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -668,6 +668,19 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         with self.assertWarns(DeprecationWarning):
             zipimport.zipimporter(memoryview(os.fsencode(filename)))
 
+    @support.cpython_only
+    def testUninitializedZipimporter(self):
+        # The interpreter shouldn't crash in case of calling methods of an
+        # uninitialized zipimport.zipimporter object.
+        zi = zipimport.zipimporter.__new__(zipimport.zipimporter)
+        self.assertRaises(ValueError, zi.find_module, 'foo')
+        self.assertRaises(ValueError, zi.find_loader, 'foo')
+        self.assertRaises(ValueError, zi.load_module, 'foo')
+        self.assertRaises(ValueError, zi.get_filename, 'foo')
+        self.assertRaises(ValueError, zi.is_package, 'foo')
+        self.assertRaises(ValueError, zi.get_data, 'foo')
+        self.assertRaises(ValueError, zi.get_code, 'foo')
+
 
 @support.requires_zlib
 class CompressedZipImportTestCase(UncompressedZipImportTestCase):

--- a/Lib/test/test_zipimport.py
+++ b/Lib/test/test_zipimport.py
@@ -680,6 +680,7 @@ class UncompressedZipImportTestCase(ImportHooksBaseTestCase):
         self.assertRaises(ValueError, zi.is_package, 'foo')
         self.assertRaises(ValueError, zi.get_data, 'foo')
         self.assertRaises(ValueError, zi.get_code, 'foo')
+        self.assertRaises(ValueError, zi.get_source, 'foo')
 
 
 @support.requires_zlib

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-13-20-01-47.bpo-31781.cXE9SM.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-13-20-01-47.bpo-31781.cXE9SM.rst
@@ -1,0 +1,2 @@
+Prevent crashes when calling methods of an uninitialized
+``zipimport.zipimporter`` object. Patch by Oren Milman.

--- a/Modules/zipimport.c
+++ b/Modules/zipimport.c
@@ -322,6 +322,12 @@ get_module_info(ZipImporter *self, PyObject *fullname)
     PyObject *path, *fullpath, *item;
     struct st_zip_searchorder *zso;
 
+    if (self->prefix == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+                        "zipimporter.__init__() wasn't called");
+        return MI_ERROR;
+    }
+
     subname = get_subname(fullname);
     if (subname == NULL)
         return MI_ERROR;
@@ -651,6 +657,12 @@ zipimport_zipimporter_get_data_impl(ZipImporter *self, PyObject *path)
     PyObject *key;
     PyObject *toc_entry;
     Py_ssize_t path_start, path_len, len;
+
+    if (self->archive == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+                        "zipimporter.__init__() wasn't called");
+        return NULL;
+    }
 
 #ifdef ALTSEP
     path = _PyObject_CallMethodId((PyObject *)&PyUnicode_Type, &PyId_replace,
@@ -1475,6 +1487,12 @@ get_module_code(ZipImporter *self, PyObject *fullname,
     PyObject *code = NULL, *toc_entry, *subname;
     PyObject *path, *fullpath = NULL;
     struct st_zip_searchorder *zso;
+
+    if (self->prefix == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+                        "zipimporter.__init__() wasn't called");
+        return NULL;
+    }
 
     subname = get_subname(fullname);
     if (subname == NULL)


### PR DESCRIPTION
In addition, add a test to `test_zipimport` to make sure that the crashes are no more.

<!-- issue-number: bpo-31781 -->
https://bugs.python.org/issue31781
<!-- /issue-number -->
