### PR TITLE
bpo-31672: doc: Remove one sentence from library/string.rst

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -765,7 +765,7 @@ attributes:
 
      While *flags* is kept to ``re.IGNORECASE`` for backward compatibility,
      you can override it to ``0`` or ``re.IGNORECASE | re.ASCII`` when
-     subclassing.  It's simple way to avoid unexpected match like above example.
+     subclassing.
 
   .. versionchanged:: 3.7
      *braceidpattern* can be used to define separate patterns used inside and


### PR DESCRIPTION
This sentence is removed while backporting to 3.6 branch.
See https://github.com/python/cpython/pull/3982#discussion_r144555768

<!-- issue-number: bpo-31672 -->
https://bugs.python.org/issue31672
<!-- /issue-number -->
