### PR TITLE
Add missing word in docstring of assertAlmostEqual of TestCase.

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -852,7 +852,8 @@ class TestCase(object):
         """Fail if the two objects are unequal as determined by their
            difference rounded to the given number of decimal places
            (default 7) and comparing to zero, or by comparing that the
-           between the two objects is more than the given delta.
+           difference between the two objects is more than the given
+           delta.
 
            Note that decimal places (from zero) are usually not the same
            as significant digits (measured from the most significant digit).
@@ -896,7 +897,7 @@ class TestCase(object):
         """Fail if the two objects are equal as determined by their
            difference rounded to the given number of decimal places
            (default 7) and comparing to zero, or by comparing that the
-           between the two objects is less than the given delta.
+           difference between the two objects is less than the given delta.
 
            Note that decimal places (from zero) are usually not the same
            as significant digits (measured from the most significant digit).


### PR DESCRIPTION
A minor fix to the docstring of the `assertAlmostEqual` method of `TestCase`.

Added the word difference in the follwoing sentece - "... or by comparing that the _difference_ between the two objects is more than the given delta."
