### PR TITLE
bpo-31780: Fix incorrect message for format spec

### DIFF
--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -32,11 +32,11 @@ invalid_comma_type(Py_UCS4 presentation_type)
 {
     if (presentation_type > 32 && presentation_type < 128)
         PyErr_Format(PyExc_ValueError,
-                     "Cannot specify ',' or '_' with '%c'.",
+                     "Cannot specify ',' with '%c'.",
                      (char)presentation_type);
     else
         PyErr_Format(PyExc_ValueError,
-                     "Cannot specify ',' or '_' with '\\x%x'.",
+                     "Cannot specify ',' with '\\x%x'.",
                      (unsigned int)presentation_type);
 }
 


### PR DESCRIPTION
As can be checked in the discussion for [bpo-31780](https://bugs.python.org/issue31780) there is an incorrect error message when using the ',b', ',o' or ',x' formatters:

```python
>>> i = 10000
>>> for base in 'box':
        for sep in ',_':
            try:
                print(f'{i:{sep}{base}}')
            except ValueError as err:
                print(repr(err))

ValueError("Cannot specify ',' or '_' with 'b'.",)
1_1000_0110_1010_0000
ValueError("Cannot specify ',' or '_' with 'o'.",)
30_3240
ValueError("Cannot specify ',' or '_' with 'x'.",)
1_86a0
```

This PR fixes this so now we obtain:

```python
>>> i = 10000
>>> for base in 'box':
        for sep in ',_':
            try:
                print(f'{i:{sep}{base}}')
            except ValueError as err:
                print(repr(err))

ValueError("Cannot specify ',' with 'b'.",)
1_1000_0110_1010_0000
ValueError("Cannot specify ',' with 'o'.",)
30_3240
ValueError("Cannot specify ',' with 'x'.",)
1_86a0
```

<!-- issue-number: bpo-31780 -->
https://bugs.python.org/issue31780
<!-- /issue-number -->
