### PR TITLE
bpo-31786: Make select.poll.poll block if ms < 0 for every value of ms

### DIFF
--- a/Include/pytime.h
+++ b/Include/pytime.h
@@ -29,7 +29,10 @@ typedef enum {
     _PyTime_ROUND_CEILING=1,
     /* Round to nearest with ties going to nearest even integer.
        For example, used to round from a Python float. */
-    _PyTime_ROUND_HALF_EVEN
+    _PyTime_ROUND_HALF_EVEN=2,
+    /* Round away from zero 
+       For example, used for timeout if negative values are allowed. */
+    _PyTime_ROUND_UP=3
 } _PyTime_round_t;
 
 /* Convert a time_t to a PyLong. */

--- a/Include/pytime.h
+++ b/Include/pytime.h
@@ -31,9 +31,17 @@ typedef enum {
        For example, used to round from a Python float. */
     _PyTime_ROUND_HALF_EVEN=2,
     /* Round away from zero 
-       For example, used for timeout if negative values are allowed. */
-    _PyTime_ROUND_UP=3
+       For example, used for timeout. _PyTime_ROUND_CEILING rounds
+       -1e-9 to 0 milliseconds which causes bpo-31786 issue.
+       _PyTime_ROUND_UP rounds -1e-9 to -1 millisecond which keeps
+       the timeout sign as expected. select.poll(timeout) must block
+       for negative values." */
+    _PyTime_ROUND_UP=3,
+    /* _PyTime_ROUND_TIMEOUT (an alias for _PyTime_ROUND_UP) should be 
+       used for timeouts. */
+    _PyTime_ROUND_TIMEOUT = _PyTime_ROUND_UP
 } _PyTime_round_t;
+
 
 /* Convert a time_t to a PyLong. */
 PyAPI_FUNC(PyObject *) _PyLong_FromTime_t(

--- a/Lib/test/test_poll.py
+++ b/Lib/test/test_poll.py
@@ -207,34 +207,26 @@ class PollTests(unittest.TestCase):
     @unittest.skipUnless(threading, 'Threading required for this test.')
     @reap_threads
     def test_poll_blocks_with_negative_ms(self):
-
         for timeout_ms in [None, -1, -1.0, -0.1, -1e-100]:
-
-            # GIVEN
-
             # Create two file descriptors. This will be used to unlock
             # the blocking call to poll.poll inside the thread
-
             r, w = os.pipe()
-            self.addCleanup(os.close, r)
-            self.addCleanup(os.close, w)
-
             pollster = select.poll()
             pollster.register(r, select.POLLIN)
-
-            # WHEN
 
             poll_thread = threading.Thread(target=pollster.poll, args=(timeout_ms,))
             poll_thread.start()
             poll_thread.join(timeout=0.1)
-
-            # THEN
             self.assertTrue(poll_thread.is_alive())
 
             # Write to the pipe so pollster.poll unblocks and the thread ends.
             os.write(w, b'spam')
             poll_thread.join()
             self.assertFalse(poll_thread.is_alive())
+            os.close(r)
+            os.close(w)
+
+
 
 
 

--- a/Lib/test/test_poll.py
+++ b/Lib/test/test_poll.py
@@ -204,6 +204,19 @@ class PollTests(unittest.TestCase):
             os.write(w, b'spam')
             t.join()
 
+    def test_poll_blocks_with_negative_ms(self):
+
+        def poll_exec():
+            pollster = select.poll()
+            pollster.poll(-1e-100)
+
+        poll_thread = threading.Thread(target=poll_exec)
+        poll_thread.daemon = True
+        poll_thread.start()
+        poll_thread.join(timeout=0.1)
+        self.assertTrue(poll_thread.is_alive())
+
+
 
 def test_main():
     run_unittest(PollTests)

--- a/Lib/test/test_poll.py
+++ b/Lib/test/test_poll.py
@@ -204,17 +204,35 @@ class PollTests(unittest.TestCase):
             os.write(w, b'spam')
             t.join()
 
+    @unittest.skipUnless(threading, 'Threading required for this test.')
+    @reap_threads
     def test_poll_blocks_with_negative_ms(self):
 
-        def poll_exec():
-            pollster = select.poll()
-            pollster.poll(-1e-100)
+        # GIVEN
 
-        poll_thread = threading.Thread(target=poll_exec)
-        poll_thread.daemon = True
+        # Create two file descriptors. This will be used to unlock
+        # the blocking call to poll.poll inside the thread
+
+        r, w = os.pipe()
+        self.addCleanup(os.close, r)
+        self.addCleanup(os.close, w)
+
+        pollster = select.poll()
+        pollster.register(r, select.POLLIN)
+
+        # WHEN
+
+        poll_thread = threading.Thread(target=pollster.poll, args=(-1e-100,))
         poll_thread.start()
         poll_thread.join(timeout=0.1)
+
+        # THEN
         self.assertTrue(poll_thread.is_alive())
+
+        # Write to the pipe so pollster.poll unblocks and the thread ends.
+        os.write(w, b'spam')
+        poll_thread.join()
+        self.assertFalse(poll_thread.is_alive())
 
 
 

--- a/Lib/test/test_poll.py
+++ b/Lib/test/test_poll.py
@@ -227,9 +227,6 @@ class PollTests(unittest.TestCase):
             os.close(w)
 
 
-
-
-
 def test_main():
     run_unittest(PollTests)
 

--- a/Lib/test/test_poll.py
+++ b/Lib/test/test_poll.py
@@ -208,31 +208,33 @@ class PollTests(unittest.TestCase):
     @reap_threads
     def test_poll_blocks_with_negative_ms(self):
 
-        # GIVEN
+        for timeout_ms in [None, -1, -1.0, -0.1, -1e-100]:
 
-        # Create two file descriptors. This will be used to unlock
-        # the blocking call to poll.poll inside the thread
+            # GIVEN
 
-        r, w = os.pipe()
-        self.addCleanup(os.close, r)
-        self.addCleanup(os.close, w)
+            # Create two file descriptors. This will be used to unlock
+            # the blocking call to poll.poll inside the thread
 
-        pollster = select.poll()
-        pollster.register(r, select.POLLIN)
+            r, w = os.pipe()
+            self.addCleanup(os.close, r)
+            self.addCleanup(os.close, w)
 
-        # WHEN
+            pollster = select.poll()
+            pollster.register(r, select.POLLIN)
 
-        poll_thread = threading.Thread(target=pollster.poll, args=(-1e-100,))
-        poll_thread.start()
-        poll_thread.join(timeout=0.1)
+            # WHEN
 
-        # THEN
-        self.assertTrue(poll_thread.is_alive())
+            poll_thread = threading.Thread(target=pollster.poll, args=(timeout_ms,))
+            poll_thread.start()
+            poll_thread.join(timeout=0.1)
 
-        # Write to the pipe so pollster.poll unblocks and the thread ends.
-        os.write(w, b'spam')
-        poll_thread.join()
-        self.assertFalse(poll_thread.is_alive())
+            # THEN
+            self.assertTrue(poll_thread.is_alive())
+
+            # Write to the pipe so pollster.poll unblocks and the thread ends.
+            os.write(w, b'spam')
+            poll_thread.join()
+            self.assertFalse(poll_thread.is_alive())
 
 
 

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -33,6 +33,8 @@ class _PyTime(enum.IntEnum):
     ROUND_CEILING = 1
     # Round to nearest with ties going to nearest even integer
     ROUND_HALF_EVEN = 2
+    # Round away from zero
+    ROUND_UP = 3
 
 # Rounding modes supported by PyTime
 ROUNDING_MODES = (
@@ -40,6 +42,7 @@ ROUNDING_MODES = (
     (_PyTime.ROUND_FLOOR, decimal.ROUND_FLOOR),
     (_PyTime.ROUND_CEILING, decimal.ROUND_CEILING),
     (_PyTime.ROUND_HALF_EVEN, decimal.ROUND_HALF_EVEN),
+    (_PyTime.ROUND_UP, decimal.ROUND_UP),
 )
 
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-15-23-44-57.bpo-31786.XwdEP4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-15-23-44-57.bpo-31786.XwdEP4.rst
@@ -1,4 +1,4 @@
 Fix an issue that affects select.poll.poll and related functions in the
 select module. Now the affected functions will block for an infinite amount
 of time if any negative timeout it provided. This was not happening before
-for some values due to rounding issues.
+for some values due to rounding issues. Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-15-23-44-57.bpo-31786.XwdEP4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-15-23-44-57.bpo-31786.XwdEP4.rst
@@ -1,4 +1,3 @@
-Fix an issue that affects select.poll.poll and related functions in the
-select module. Now the affected functions will block for an infinite amount
-of time if any negative timeout it provided. This was not happening before
-for some values due to rounding issues. Patch by Pablo Galindo.
+Fix timeout rounding in the select module to round correctly negative timeouts between -1.0 and 0.0.
+The functions now block waiting for events as expected. Previously, the call was incorrectly non-blocking.
+Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-15-23-44-57.bpo-31786.XwdEP4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-15-23-44-57.bpo-31786.XwdEP4.rst
@@ -1,0 +1,4 @@
+Fix an issue that affects select.poll.poll and related functions in the
+select module. Now the affected functions will block for an infinite amount
+of time if any negative timeout it provided. This was not happening before
+for some values due to rounding issues.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3012,7 +3012,8 @@ check_time_rounding(int round)
 {
     if (round != _PyTime_ROUND_FLOOR
         && round != _PyTime_ROUND_CEILING
-        && round != _PyTime_ROUND_HALF_EVEN) {
+        && round != _PyTime_ROUND_HALF_EVEN
+        && round != _PyTime_ROUND_UP) {
         PyErr_SetString(PyExc_ValueError, "invalid rounding");
         return -1;
     }

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -213,7 +213,7 @@ select_select(PyObject *self, PyObject *args)
         tvp = (struct timeval *)NULL;
     else {
         if (_PyTime_FromSecondsObject(&timeout, timeout_obj,
-                                      _PyTime_ROUND_UP) < 0) {
+                                      _PyTime_ROUND_TIMEOUT) < 0) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "timeout must be a float or None");
@@ -221,7 +221,7 @@ select_select(PyObject *self, PyObject *args)
             return NULL;
         }
 
-        if (_PyTime_AsTimeval(timeout, &tv, _PyTime_ROUND_UP) == -1)
+        if (_PyTime_AsTimeval(timeout, &tv, _PyTime_ROUND_TIMEOUT) == -1)
             return NULL;
         if (tv.tv_sec < 0) {
             PyErr_SetString(PyExc_ValueError, "timeout must be non-negative");
@@ -540,7 +540,7 @@ poll_poll(pollObject *self, PyObject *args)
     }
     else {
         if (_PyTime_FromMillisecondsObject(&timeout, timeout_obj,
-                                           _PyTime_ROUND_UP) < 0) {
+                                           _PyTime_ROUND_TIMEOUT) < 0) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "timeout must be an integer or None");
@@ -548,7 +548,7 @@ poll_poll(pollObject *self, PyObject *args)
             return NULL;
         }
 
-        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
+        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_TIMEOUT);
         if (ms < INT_MIN || ms > INT_MAX) {
             PyErr_SetString(PyExc_OverflowError, "timeout is too large");
             return NULL;
@@ -896,7 +896,7 @@ devpoll_poll(devpollObject *self, PyObject *args)
     }
     else {
         if (_PyTime_FromMillisecondsObject(&timeout, timeout_obj,
-                                           _PyTime_ROUND_UP) < 0) {
+                                           _PyTime_ROUND_TIMEOUT) < 0) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "timeout must be an integer or None");
@@ -904,7 +904,7 @@ devpoll_poll(devpollObject *self, PyObject *args)
             return NULL;
         }
 
-        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
+        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_TIMEOUT);
         if (ms < -1 || ms > INT_MAX) {
             PyErr_SetString(PyExc_OverflowError, "timeout is too large");
             return NULL;
@@ -1513,7 +1513,7 @@ pyepoll_poll(pyEpoll_Object *self, PyObject *args, PyObject *kwds)
         /* epoll_wait() has a resolution of 1 millisecond, round towards
            infinity to wait at least timeout seconds. */
         if (_PyTime_FromSecondsObject(&timeout, timeout_obj,
-                                      _PyTime_ROUND_UP) < 0) {
+                                      _PyTime_ROUND_TIMEOUT) < 0) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "timeout must be an integer or None");
@@ -2128,7 +2128,7 @@ kqueue_queue_control(kqueue_queue_Object *self, PyObject *args)
     }
     else {
         if (_PyTime_FromSecondsObject(&timeout,
-                                      otimeout, _PyTime_ROUND_UP) < 0) {
+                                      otimeout, _PyTime_ROUND_TIMEOUT) < 0) {
             PyErr_Format(PyExc_TypeError,
                 "timeout argument must be a number "
                 "or None, got %.200s",

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -221,7 +221,7 @@ select_select(PyObject *self, PyObject *args)
             return NULL;
         }
 
-        if (_PyTime_AsTimeval(timeout, &tv, _PyTime_ROUND_CEILING) == -1)
+        if (_PyTime_AsTimeval(timeout, &tv, _PyTime_ROUND_UP) == -1)
             return NULL;
         if (tv.tv_sec < 0) {
             PyErr_SetString(PyExc_ValueError, "timeout must be non-negative");

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -221,7 +221,7 @@ select_select(PyObject *self, PyObject *args)
             return NULL;
         }
 
-        if (_PyTime_AsTimeval(timeout, &tv, _PyTime_ROUND_UP) == -1)
+        if (_PyTime_AsTimeval(timeout, &tv, _PyTime_ROUND_CEILING) == -1)
             return NULL;
         if (tv.tv_sec < 0) {
             PyErr_SetString(PyExc_ValueError, "timeout must be non-negative");
@@ -282,7 +282,7 @@ select_select(PyObject *self, PyObject *args)
                 n = 0;
                 break;
             }
-            _PyTime_AsTimeval_noraise(timeout, &tv, _PyTime_ROUND_UP);
+            _PyTime_AsTimeval_noraise(timeout, &tv, _PyTime_ROUND_CEILING);
             /* retry select() with the recomputed timeout */
         }
     } while (1);
@@ -594,7 +594,7 @@ poll_poll(pollObject *self, PyObject *args)
                 poll_result = 0;
                 break;
             }
-            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
+            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
             /* retry poll() with the recomputed timeout */
         }
     } while (1);
@@ -941,7 +941,7 @@ devpoll_poll(devpollObject *self, PyObject *args)
                 poll_result = 0;
                 break;
             }
-            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
+            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
             dvp.dp_timeout = (int)ms;
             /* retry devpoll() with the recomputed timeout */
         }

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1521,7 +1521,7 @@ pyepoll_poll(pyEpoll_Object *self, PyObject *args, PyObject *kwds)
             return NULL;
         }
 
-        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
+        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
         if (ms < INT_MIN || ms > INT_MAX) {
             PyErr_SetString(PyExc_OverflowError, "timeout is too large");
             return NULL;
@@ -1565,7 +1565,7 @@ pyepoll_poll(pyEpoll_Object *self, PyObject *args, PyObject *kwds)
                 nfds = 0;
                 break;
             }
-            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
+            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
             /* retry epoll_wait() with the recomputed timeout */
         }
     } while(1);

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -576,7 +576,7 @@ poll_poll(pollObject *self, PyObject *args)
     do {
         Py_BEGIN_ALLOW_THREADS
         errno = 0;
-        poll_result = poll(self->ufds, self->ufd_len, (int)ms);
+        poll_result = poll(self->ufds, self->ufd_len, ms > 0 ? (int)ms : -1);
         Py_END_ALLOW_THREADS
 
         if (errno != EINTR)

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -213,7 +213,7 @@ select_select(PyObject *self, PyObject *args)
         tvp = (struct timeval *)NULL;
     else {
         if (_PyTime_FromSecondsObject(&timeout, timeout_obj,
-                                      _PyTime_ROUND_CEILING) < 0) {
+                                      _PyTime_ROUND_UP) < 0) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "timeout must be a float or None");

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -221,7 +221,7 @@ select_select(PyObject *self, PyObject *args)
             return NULL;
         }
 
-        if (_PyTime_AsTimeval(timeout, &tv, _PyTime_ROUND_CEILING) == -1)
+        if (_PyTime_AsTimeval(timeout, &tv, _PyTime_ROUND_UP) == -1)
             return NULL;
         if (tv.tv_sec < 0) {
             PyErr_SetString(PyExc_ValueError, "timeout must be non-negative");
@@ -282,7 +282,7 @@ select_select(PyObject *self, PyObject *args)
                 n = 0;
                 break;
             }
-            _PyTime_AsTimeval_noraise(timeout, &tv, _PyTime_ROUND_CEILING);
+            _PyTime_AsTimeval_noraise(timeout, &tv, _PyTime_ROUND_UP);
             /* retry select() with the recomputed timeout */
         }
     } while (1);
@@ -540,7 +540,7 @@ poll_poll(pollObject *self, PyObject *args)
     }
     else {
         if (_PyTime_FromMillisecondsObject(&timeout, timeout_obj,
-                                           _PyTime_ROUND_CEILING) < 0) {
+                                           _PyTime_ROUND_UP) < 0) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "timeout must be an integer or None");
@@ -548,7 +548,7 @@ poll_poll(pollObject *self, PyObject *args)
             return NULL;
         }
 
-        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
+        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
         if (ms < INT_MIN || ms > INT_MAX) {
             PyErr_SetString(PyExc_OverflowError, "timeout is too large");
             return NULL;
@@ -576,7 +576,7 @@ poll_poll(pollObject *self, PyObject *args)
     do {
         Py_BEGIN_ALLOW_THREADS
         errno = 0;
-        poll_result = poll(self->ufds, self->ufd_len, ms > 0 ? (int)ms : -1);
+        poll_result = poll(self->ufds, self->ufd_len, (int)ms);
         Py_END_ALLOW_THREADS
 
         if (errno != EINTR)
@@ -594,7 +594,7 @@ poll_poll(pollObject *self, PyObject *args)
                 poll_result = 0;
                 break;
             }
-            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
+            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
             /* retry poll() with the recomputed timeout */
         }
     } while (1);
@@ -896,7 +896,7 @@ devpoll_poll(devpollObject *self, PyObject *args)
     }
     else {
         if (_PyTime_FromMillisecondsObject(&timeout, timeout_obj,
-                                           _PyTime_ROUND_CEILING) < 0) {
+                                           _PyTime_ROUND_UP) < 0) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "timeout must be an integer or None");
@@ -904,7 +904,7 @@ devpoll_poll(devpollObject *self, PyObject *args)
             return NULL;
         }
 
-        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
+        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
         if (ms < -1 || ms > INT_MAX) {
             PyErr_SetString(PyExc_OverflowError, "timeout is too large");
             return NULL;
@@ -941,7 +941,7 @@ devpoll_poll(devpollObject *self, PyObject *args)
                 poll_result = 0;
                 break;
             }
-            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
+            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
             dvp.dp_timeout = (int)ms;
             /* retry devpoll() with the recomputed timeout */
         }
@@ -1513,7 +1513,7 @@ pyepoll_poll(pyEpoll_Object *self, PyObject *args, PyObject *kwds)
         /* epoll_wait() has a resolution of 1 millisecond, round towards
            infinity to wait at least timeout seconds. */
         if (_PyTime_FromSecondsObject(&timeout, timeout_obj,
-                                      _PyTime_ROUND_CEILING) < 0) {
+                                      _PyTime_ROUND_UP) < 0) {
             if (PyErr_ExceptionMatches(PyExc_TypeError)) {
                 PyErr_SetString(PyExc_TypeError,
                                 "timeout must be an integer or None");
@@ -1521,7 +1521,7 @@ pyepoll_poll(pyEpoll_Object *self, PyObject *args, PyObject *kwds)
             return NULL;
         }
 
-        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
+        ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
         if (ms < INT_MIN || ms > INT_MAX) {
             PyErr_SetString(PyExc_OverflowError, "timeout is too large");
             return NULL;
@@ -1565,7 +1565,7 @@ pyepoll_poll(pyEpoll_Object *self, PyObject *args, PyObject *kwds)
                 nfds = 0;
                 break;
             }
-            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_CEILING);
+            ms = _PyTime_AsMilliseconds(timeout, _PyTime_ROUND_UP);
             /* retry epoll_wait() with the recomputed timeout */
         }
     } while(1);
@@ -2128,7 +2128,7 @@ kqueue_queue_control(kqueue_queue_Object *self, PyObject *args)
     }
     else {
         if (_PyTime_FromSecondsObject(&timeout,
-                                      otimeout, _PyTime_ROUND_CEILING) < 0) {
+                                      otimeout, _PyTime_ROUND_UP) < 0) {
             PyErr_Format(PyExc_TypeError,
                 "timeout argument must be a number "
                 "or None, got %.200s",

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -104,7 +104,7 @@ _PyTime_Round(double x, _PyTime_round_t round)
     }
     else {
         assert(round == _PyTime_ROUND_UP);
-        d = (d < 0.0) ? floor(d) : ceil(d);
+        d = (d >= 0.0) ? ceil(d) : floor(d);
     }
     return d;
 }
@@ -410,9 +410,18 @@ _PyTime_Divide(const _PyTime_t t, const _PyTime_t k,
             return t / k;
         }
     }
-    else {
+    else if (round == _PyTime_ROUND_FLOOR){
         if (t >= 0) {
             return t / k;
+        }
+        else {
+            return (t - (k - 1)) / k;
+        }
+    }
+    else {
+        assert(round == _PyTime_ROUND_UP);
+        if (t >= 0) {
+            return (t + k - 1) / k;
         }
         else {
             return (t - (k - 1)) / k;

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -103,6 +103,7 @@ _PyTime_Round(double x, _PyTime_round_t round)
         d = floor(d);
     }
     else {
+        assert(round == _PyTime_ROUND_UP);
         d = (d < 0.0) ? floor(d) : ceil(d);
     }
     return d;

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -99,8 +99,11 @@ _PyTime_Round(double x, _PyTime_round_t round)
     else if (round == _PyTime_ROUND_CEILING) {
         d = ceil(d);
     }
-    else {
+    else if (round == _PyTime_ROUND_FLOOR) {
         d = floor(d);
+    }
+    else {
+        d = (d < 0.0) ? floor(d) : ceil(d);
     }
     return d;
 }


### PR DESCRIPTION
Acording to the documentation select.poll.poll() is blocked for infinite timeout if the timeout argument is negative but:

```python
>>> import select
>>> poll = select.poll()
>>> poll.poll(-0.000000000000000001)
[]
```

This is due to rounding issues when making the syscall. This PR fixes that so the call to `poll.poll` will block if the argument is negative.

<!-- issue-number: bpo-31786 -->
https://bugs.python.org/issue31786
<!-- /issue-number -->
