### PR TITLE
bpo-31793: Documentation: Specialize smart-quotes for japanese.

### DIFF
--- a/Doc/docutils.conf
+++ b/Doc/docutils.conf
@@ -1,0 +1,2 @@
+[restructuredtext parser]
+smartquotes-locales: ja: ""''


### PR DESCRIPTION
Specializing and by doing so showing the way on how to specialize smart quoting of documentation in various languages.

I ran a test build using:

```
rm -f docutils.conf build/
sphinx-build -j8 -b html -d build/doctrees -D latex_elements.papersize= -D locale_dirs=/tmp/mdk/locales/ -D language=fr -D gettext_compact=0 -Ea -A daily=1 -A switchers=1 . build/html
mv build build_fr
sphinx-build -j8 -b html -d build/doctrees -D latex_elements.papersize= -D locale_dirs=/tmp/mdk/locales/ -D language=ja -D gettext_compact=0 -Ea -A daily=1 -A switchers=1 . build/html
mv build build_ja
sphinx-build -j8 -b html -d build/doctrees -D latex_elements.papersize= -Ea -A daily=1 -A switchers=1 . build/html
mv build build_en

cp /tmp/docutils.conf docutils.conf
sphinx-build -j8 -b html -d build/doctrees -D latex_elements.papersize= -D locale_dirs=/tmp/mdk/locales/ -D language=fr -D gettext_compact=0 -Ea -A daily=1 -A switchers=1 . build/html
mv build build_fr_docutils
sphinx-build -j8 -b html -d build/doctrees -D latex_elements.papersize= -D locale_dirs=/tmp/mdk/locales/ -D language=ja -D gettext_compact=0 -Ea -A daily=1 -A switchers=1 . build/html
mv build build_ja_docutils
sphinx-build -j8 -b html -d build/doctrees -D latex_elements.papersize= -Ea -A daily=1 -A switchers=1 . build/html
mv build build_en_docutils
```

```
$ cat docutils.conf 
[restructuredtext parser]
smartquotes-locales: ja: ""''
```

`fr` and `en` yielded not a single difference, but `ja` differed as expected, like:

```
< インタープリタ名は 「シェバン」 行としてアーカイブの起点に書込まれます。
---
> インタープリタ名は &quot;シェバン&quot; 行としてアーカイブの起点に書込まれます。
206,207c206,207
< <em>main</em> 引数は 「pkg.module:callable」 の形式を取り、
< アーカイブは 「pkg.module」 をインポートして実行され、
```

(6431 lines of diff on the generated HTML).


<!-- issue-number: bpo-31793 -->
https://bugs.python.org/issue31793
<!-- /issue-number -->
