### PR TITLE
bpo-31792: Restore os.environ in test_buffer when import numpy.

### DIFF
--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -17,7 +17,7 @@ from test import support
 from itertools import permutations, product
 from random import randrange, sample, choice
 import warnings
-import sys, array, io
+import sys, array, io, os
 from decimal import Decimal
 from fractions import Fraction
 
@@ -37,7 +37,8 @@ except ImportError:
     ctypes = None
 
 try:
-    with warnings.catch_warnings():
+    with support.EnvironmentVarGuard() as os.environ, \
+         warnings.catch_warnings():
         from numpy import ndarray as numpy_array
 except ImportError:
     numpy_array = None


### PR DESCRIPTION


<!-- issue-number: bpo-31792 -->
https://bugs.python.org/issue31792
<!-- /issue-number -->
