### PR TITLE
bpo-31799: Make module.__spec__ more discoverable

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1048,7 +1048,11 @@ find and load modules.
 
 .. class:: ModuleSpec(name, loader, *, origin=None, loader_state=None, is_package=None)
 
-   A specification for a module's import-system-related state.
+   A specification for a module's import-system-related state.  This is
+   typically exposed as the module's ``__spec__`` attribute.  In the
+   descriptions below, the parenthetical "dunder" version names the equivalent
+   attribute available directly on the module object.
+   E.g. ``module.__spec__.name == module.__name__``.
 
    .. versionadded:: 3.4
 

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1050,9 +1050,13 @@ find and load modules.
 
    A specification for a module's import-system-related state.  This is
    typically exposed as the module's ``__spec__`` attribute.  In the
-   descriptions below, the parenthetical "dunder" version names the equivalent
+   descriptions below, the names in parentheses give the corresponding
    attribute available directly on the module object.
-   E.g. ``module.__spec__.name == module.__name__``.
+   E.g. ``module.__spec__.origin == module.__file__``.  Note however that
+   while the *values* are usually equivalent, they can differ since there is
+   no synchronization between the two objects.  Thus it is possible to update
+   the module's ``__path__`` at runtime, and this will not be automatically
+   reflected in ``__spec__.submodule_search_locations``.
 
    .. versionadded:: 3.4
 

--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -519,8 +519,9 @@ and the loader that executes it.  Most importantly, it allows the
 import machinery to perform the boilerplate operations of loading,
 whereas without a module spec the loader had that responsibility.
 
-See :class:`~importlib.machinery.ModuleSpec` for more specifics on what
-information a module's spec may hold.
+The module's spec is exposed as the ``__spec__`` attribute on a module object.
+See :class:`~importlib.machinery.ModuleSpec` for details on the contents of
+the module spec.
 
 .. versionadded:: 3.4
 


### PR DESCRIPTION
This should be backported to Python 3.6

<!-- issue-number: bpo-31799 -->
https://bugs.python.org/issue31799
<!-- /issue-number -->
