### PR TITLE
bpo-31803: Remove time.clock()

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -575,7 +575,7 @@ procedure can be used to obtain a better constant for a given platform (see
 The method executes the number of Python calls given by the argument, directly
 and again under the profiler, measuring the time for both. It then computes the
 hidden overhead per profiler event, and returns that as a float.  For example,
-on a 1.8Ghz Intel Core i5 running Mac OS X, and using Python's time.clock() as
+on a 1.8Ghz Intel Core i5 running Mac OS X, and using Python's time.procedure() as
 the timer, the magical number is about 4.04e-6.
 
 The object of this exercise is to get a fairly consistent result. If your

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -137,27 +137,6 @@ Functions
       trailing newline.
 
 
-.. function:: clock()
-
-   .. index::
-      single: CPU time
-      single: processor time
-      single: benchmarking
-
-   On Unix, return the current processor time as a floating point number expressed
-   in seconds.  The precision, and in fact the very definition of the meaning of
-   "processor time", depends on that of the C function of the same name.
-
-   On Windows, this function returns wall-clock seconds elapsed since the first
-   call to this function, as a floating point number, based on the Win32 function
-   :c:func:`QueryPerformanceCounter`. The resolution is typically better than one
-   microsecond.
-
-   .. deprecated:: 3.3
-      The behaviour of this function depends on the platform: use
-      :func:`perf_counter` or :func:`process_time` instead, depending on your
-      requirements, to have a well defined behaviour.
-
 .. function:: pthread_getcpuclockid(thread_id)
 
    Return the *clk_id* of the thread-specific CPU-time clock for the specified *thread_id*.
@@ -219,7 +198,6 @@ Functions
    Supported clock names and the corresponding functions to read their value
    are:
 
-   * ``'clock'``: :func:`time.clock`
    * ``'monotonic'``: :func:`time.monotonic`
    * ``'perf_counter'``: :func:`time.perf_counter`
    * ``'process_time'``: :func:`time.process_time`
@@ -236,6 +214,8 @@ Functions
    - *resolution*: The resolution of the clock in seconds (:class:`float`)
 
    .. versionadded:: 3.3
+   .. versionchanged:: 3.7
+      ``'clock'`` is no more accepted since ``time.clock()`` was removed.
 
 
 .. function:: gmtime([secs])
@@ -289,6 +269,9 @@ Functions
 
 .. function:: perf_counter()
 
+   .. index::
+      single: benchmarking
+
    Return the value (in fractional seconds) of a performance counter, i.e. a
    clock with the highest available resolution to measure a short duration.  It
    does include time elapsed during sleep and is system-wide.  The reference
@@ -299,6 +282,11 @@ Functions
 
 
 .. function:: process_time()
+
+   .. index::
+      single: CPU time
+      single: processor time
+      single: benchmarking
 
    Return the value (in fractional seconds) of the sum of the system and user
    CPU time of the current process.  It does not include time elapsed during

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -297,6 +297,16 @@ string
 expression pattern for braced placeholders and non-braced placeholders
 separately.  (Contributed by Barry Warsaw in :issue:`1198569`.)
 
+time
+----
+
+The ``time.clock()`` function has been removed, it was deprecated since Python
+3.3.  The function was not portable: on Windows it mesured wall-clock, whereas
+it measured CPU time on Unix. Python provides better defined clocks with better
+resolution since Python 3.3: use :func:`time.perf_counter` or
+:func:`time.process_time` instead. (Contributed by Victor Stinner in
+:issue:`31803`.)
+
 unittest.mock
 -------------
 
@@ -539,6 +549,10 @@ that may require changes to your code.
 
 Changes in the Python API
 -------------------------
+
+* The ``time.clock()`` function has been removed: use :func:`time.perf_counter` or
+  :func:`time.process_time` instead. (Contributed by Victor Stinner in
+  :issue:`31803`.)
 
 * :meth:`pkgutil.walk_packages` now raises ValueError if *path* is a string.
   Previously an empty list was returned. (Contributed by Sanyam Khurana in

--- a/Lib/ctypes/test/test_numbers.py
+++ b/Lib/ctypes/test/test_numbers.py
@@ -241,7 +241,7 @@ class c_int_S(_SimpleCData):
 def run_test(rep, msg, func, arg=None):
 ##    items = [None] * rep
     items = range(rep)
-    from time import clock
+    from time import perf_counter as clock
     if arg is not None:
         start = clock()
         for i in items:

--- a/Lib/ctypes/test/test_strings.py
+++ b/Lib/ctypes/test/test_strings.py
@@ -194,7 +194,7 @@ class WStringTestCase(unittest.TestCase):
 
 def run_test(rep, msg, func, arg):
     items = range(rep)
-    from time import clock
+    from time import perf_counter as clock
     start = clock()
     for i in items:
         func(arg); func(arg); func(arg); func(arg); func(arg)

--- a/Lib/profile.py
+++ b/Lib/profile.py
@@ -195,7 +195,7 @@ class Profile:
             self.t = r[0] + r[1] - t # put back unrecorded delta
 
     # Dispatch routine for best timer program (return = scalar, fastest if
-    # an integer but float works too -- and time.clock() relies on that).
+    # an integer but float works too -- and time.process_time() relies on that).
 
     def trace_dispatch_i(self, frame, event, arg):
         timer = self.timer

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -60,13 +60,6 @@ class TimeTestCase(unittest.TestCase):
         self.assertFalse(info.monotonic)
         self.assertTrue(info.adjustable)
 
-    def test_clock(self):
-        time.clock()
-
-        info = time.get_clock_info('clock')
-        self.assertTrue(info.monotonic)
-        self.assertFalse(info.adjustable)
-
     @unittest.skipUnless(hasattr(time, 'clock_gettime'),
                          'need time.clock_gettime()')
     def test_clock_realtime(self):
@@ -503,7 +496,7 @@ class TimeTestCase(unittest.TestCase):
         self.assertRaises(ValueError, time.ctime, float("nan"))
 
     def test_get_clock_info(self):
-        clocks = ['clock', 'perf_counter', 'process_time', 'time']
+        clocks = ['perf_counter', 'process_time', 'time']
         if hasattr(time, 'monotonic'):
             clocks.append('monotonic')
 

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -259,7 +259,7 @@ def main(args=None, *, _wrap_timer=None):
     try:
         opts, args = getopt.getopt(args, "n:u:s:r:tcpvh",
                                    ["number=", "setup=", "repeat=",
-                                    "time", "clock", "process",
+                                    "time", "process",
                                     "verbose", "unit=", "help"])
     except getopt.error as err:
         print(err)

--- a/Lib/turtledemo/bytedesign.py
+++ b/Lib/turtledemo/bytedesign.py
@@ -23,7 +23,7 @@ mode as fast as possible.
 """
 
 from turtle import Turtle, mainloop
-from time import clock
+from time import perf_counter as clock
 
 # wrapper for any additional drawing routines
 # that need to know about each other

--- a/Lib/turtledemo/forest.py
+++ b/Lib/turtledemo/forest.py
@@ -13,7 +13,7 @@ http://homepage.univie.ac.at/erich.neuwirth/
 """
 from turtle import Turtle, colormode, tracer, mainloop
 from random import randrange
-from time import clock
+from time import perf_counter as clock
 
 def symRandom(n):
     return randrange(-n,n+1)

--- a/Lib/turtledemo/fractalcurves.py
+++ b/Lib/turtledemo/fractalcurves.py
@@ -12,7 +12,7 @@ methods are taken from the PythonCard example
 scripts for turtle-graphics.
 """
 from turtle import *
-from time import sleep, clock
+from time import sleep, perf_counter as clock
 
 class CurvesTurtle(Pen):
     # example derived from

--- a/Lib/turtledemo/penrose.py
+++ b/Lib/turtledemo/penrose.py
@@ -17,7 +17,7 @@ For more information see:
 """
 from turtle import *
 from math import cos, pi
-from time import clock, sleep
+from time import perf_counter as clock, sleep
 
 f = (5**0.5-1)/2.0   # (sqrt(5)-1)/2 -- golden ratio
 d = 2 * cos(3*pi/10)

--- a/Lib/turtledemo/tree.py
+++ b/Lib/turtledemo/tree.py
@@ -16,7 +16,7 @@ the current pen is cloned. So in the end
 there are 1024 turtles.
 """
 from turtle import Turtle, mainloop
-from time import clock
+from time import perf_counter as clock
 
 def tree(plist, l, a, f):
     """ plist is list of pens

--- a/Lib/turtledemo/wikipedia.py
+++ b/Lib/turtledemo/wikipedia.py
@@ -14,7 +14,7 @@ parallel.
 Followed by a complete undo().
 """
 from turtle import Screen, Turtle, mainloop
-from time import clock, sleep
+from time import perf_counter as clock, sleep
 
 def mn_eck(p, ne,sz):
     turtlelist = [p]

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -99,32 +99,6 @@ perf_counter(_Py_clock_info_t *info)
     return PyFloat_FromDouble(d);
 }
 
-#if defined(MS_WINDOWS) || defined(HAVE_CLOCK)
-#define PYCLOCK
-static PyObject*
-pyclock(_Py_clock_info_t *info)
-{
-#ifdef MS_WINDOWS
-    return perf_counter(info);
-#else
-    return floatclock(info);
-#endif
-}
-
-static PyObject *
-time_clock(PyObject *self, PyObject *unused)
-{
-    return pyclock(NULL);
-}
-
-PyDoc_STRVAR(clock_doc,
-"clock() -> floating point number\n\
-\n\
-Return the CPU time or real time since the start of the process or since\n\
-the first call to clock().  This has as much precision as the system\n\
-records.");
-#endif
-
 #ifdef HAVE_CLOCK_GETTIME
 static PyObject *
 time_clock_gettime(PyObject *self, PyObject *args)
@@ -1102,10 +1076,6 @@ time_get_clock_info(PyObject *self, PyObject *args)
 
     if (strcmp(name, "time") == 0)
         obj = floattime(&info);
-#ifdef PYCLOCK
-    else if (strcmp(name, "clock") == 0)
-        obj = pyclock(&info);
-#endif
     else if (strcmp(name, "monotonic") == 0)
         obj = pymonotonic(&info);
     else if (strcmp(name, "perf_counter") == 0)
@@ -1277,9 +1247,6 @@ PyInit_timezone(PyObject *m) {
 
 static PyMethodDef time_methods[] = {
     {"time",            time_time, METH_NOARGS, time_doc},
-#ifdef PYCLOCK
-    {"clock",           time_clock, METH_NOARGS, clock_doc},
-#endif
 #ifdef HAVE_CLOCK_GETTIME
     {"clock_gettime",   time_clock_gettime, METH_VARARGS, clock_gettime_doc},
 #endif


### PR DESCRIPTION
* Remove time.clock() function
* time.get_clock_info() doesn't accept 'clock' anymore
* Document the removal in What's New in Python 3.7
* Replace time.clock() with time.perf_counter() in the profile
  module, in turtledemo, and in ctypes tests.

<!-- issue-number: bpo-31803 -->
https://bugs.python.org/issue31803
<!-- /issue-number -->
