### PR TITLE
[2.7] bpo-31733, bpo-31692: Document 2 new env vars in What's New in Python 2.7

### DIFF
--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -2540,6 +2540,21 @@ exemption allowing new ``-3`` warnings to be added in any Python 2.7
 maintenance release.
 
 
+Two new environment variables for debug mode
+--------------------------------------------
+
+In debug mode, the ``[xxx refs]`` statistic is not written by default, the
+:envvar:`PYTHONSHOWREFCOUNT` environment variable now must also be set.
+(Contributed by Victor Stinner; :issue:`31733`.)
+
+When Python is compiled with ``COUNT_ALLOC`` defined, allocations counts are no
+more dumped by default anymore: the :envvar:`PYTHONSHOWALLOCCOUNT` environment
+variable now must also be set. Moreover, allocations counts are now dumped into
+stderr, rather than stdout. (Contributed by Victor Stinner; :issue:`31692`.)
+
+.. versionadded:: 2.7.15
+
+
 PEP 434: IDLE Enhancement Exception for All Branches
 ----------------------------------------------------
 

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -2547,9 +2547,9 @@ In debug mode, the ``[xxx refs]`` statistic is not written by default, the
 :envvar:`PYTHONSHOWREFCOUNT` environment variable now must also be set.
 (Contributed by Victor Stinner; :issue:`31733`.)
 
-When Python is compiled with ``COUNT_ALLOC`` defined, allocations counts are no
-more dumped by default anymore: the :envvar:`PYTHONSHOWALLOCCOUNT` environment
-variable now must also be set. Moreover, allocations counts are now dumped into
+When Python is compiled with ``COUNT_ALLOC`` defined, allocation counts are no
+longer dumped by default anymore: the :envvar:`PYTHONSHOWALLOCCOUNT` environment
+variable must now also be set. Moreover, allocation counts are now dumped into
 stderr, rather than stdout. (Contributed by Victor Stinner; :issue:`31692`.)
 
 .. versionadded:: 2.7.15


### PR DESCRIPTION
Document the new PYTHONSHOWREFCOUNT and
PYTHONSHOWALLOCCOUNT environment variables.

<!-- issue-number: bpo-31733 -->
https://bugs.python.org/issue31733
<!-- /issue-number -->
