### PR TITLE
bpo-31803: time.clock() now emits a DeprecationWarning

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -575,7 +575,7 @@ procedure can be used to obtain a better constant for a given platform (see
 The method executes the number of Python calls given by the argument, directly
 and again under the profiler, measuring the time for both. It then computes the
 hidden overhead per profiler event, and returns that as a float.  For example,
-on a 1.8Ghz Intel Core i5 running Mac OS X, and using Python's time.clock() as
+on a 1.8Ghz Intel Core i5 running Mac OS X, and using Python's time.process_time() as
 the timer, the magical number is about 4.04e-6.
 
 The object of this exercise is to get a fairly consistent result. If your

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -289,6 +289,9 @@ Functions
 
 .. function:: perf_counter()
 
+   .. index::
+      single: benchmarking
+
    Return the value (in fractional seconds) of a performance counter, i.e. a
    clock with the highest available resolution to measure a short duration.  It
    does include time elapsed during sleep and is system-wide.  The reference
@@ -299,6 +302,11 @@ Functions
 
 
 .. function:: process_time()
+
+   .. index::
+      single: CPU time
+      single: processor time
+      single: benchmarking
 
    Return the value (in fractional seconds) of the sum of the system and user
    CPU time of the current process.  It does not include time elapsed during

--- a/Lib/ctypes/test/test_numbers.py
+++ b/Lib/ctypes/test/test_numbers.py
@@ -241,7 +241,7 @@ class c_int_S(_SimpleCData):
 def run_test(rep, msg, func, arg=None):
 ##    items = [None] * rep
     items = range(rep)
-    from time import clock
+    from time import perf_counter as clock
     if arg is not None:
         start = clock()
         for i in items:

--- a/Lib/ctypes/test/test_strings.py
+++ b/Lib/ctypes/test/test_strings.py
@@ -194,7 +194,7 @@ class WStringTestCase(unittest.TestCase):
 
 def run_test(rep, msg, func, arg):
     items = range(rep)
-    from time import clock
+    from time import perf_counter as clock
     start = clock()
     for i in items:
         func(arg); func(arg); func(arg); func(arg); func(arg)

--- a/Lib/profile.py
+++ b/Lib/profile.py
@@ -195,7 +195,7 @@ class Profile:
             self.t = r[0] + r[1] - t # put back unrecorded delta
 
     # Dispatch routine for best timer program (return = scalar, fastest if
-    # an integer but float works too -- and time.clock() relies on that).
+    # an integer but float works too -- and time.process_time() relies on that).
 
     def trace_dispatch_i(self, frame, event, arg):
         timer = self.timer

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -9,6 +9,7 @@ import sysconfig
 import time
 import threading
 import unittest
+import warnings
 try:
     import _testcapi
 except ImportError:
@@ -64,9 +65,13 @@ class TimeTestCase(unittest.TestCase):
         self.assertTrue(info.adjustable)
 
     def test_clock(self):
-        time.clock()
+        with support.check_warnings(('time.clock has been deprecated',
+                                     DeprecationWarning)):
+            time.clock()
 
-        info = time.get_clock_info('clock')
+        with support.check_warnings(('time.clock has been deprecated',
+                                     DeprecationWarning)):
+            info = time.get_clock_info('clock')
         self.assertTrue(info.monotonic)
         self.assertFalse(info.adjustable)
 
@@ -511,7 +516,10 @@ class TimeTestCase(unittest.TestCase):
             clocks.append('monotonic')
 
         for name in clocks:
-            info = time.get_clock_info(name)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", "", DeprecationWarning)
+                info = time.get_clock_info(name)
+
             #self.assertIsInstance(info, dict)
             self.assertIsInstance(info.implementation, str)
             self.assertNotEqual(info.implementation, '')

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -65,12 +65,10 @@ class TimeTestCase(unittest.TestCase):
         self.assertTrue(info.adjustable)
 
     def test_clock(self):
-        with support.check_warnings(('time.clock has been deprecated',
-                                     DeprecationWarning)):
+        with self.assertWarns(DeprecationWarning):
             time.clock()
 
-        with support.check_warnings(('time.clock has been deprecated',
-                                     DeprecationWarning)):
+        with self.assertWarns(DeprecationWarning):
             info = time.get_clock_info('clock')
         self.assertTrue(info.monotonic)
         self.assertFalse(info.adjustable)
@@ -511,9 +509,8 @@ class TimeTestCase(unittest.TestCase):
 
         for name in clocks:
             if name == 'clock':
-                with support.check_warnings(('time.clock has been deprecated',
-                                             DeprecationWarning)):
-                    info = time.get_clock_info(name)
+                with self.assertWarns(DeprecationWarning):
+                    info = time.get_clock_info('clock')
             else:
                 info = time.get_clock_info(name)
 

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -432,8 +432,6 @@ class TimeTestCase(unittest.TestCase):
             pass
         self.assertEqual(time.strftime('%Z', tt), tzname)
 
-    @unittest.skipUnless(hasattr(time, 'monotonic'),
-                         'need time.monotonic')
     def test_monotonic(self):
         # monotonic() should not go backward
         times = [time.monotonic() for n in range(100)]
@@ -472,8 +470,6 @@ class TimeTestCase(unittest.TestCase):
         self.assertTrue(info.monotonic)
         self.assertFalse(info.adjustable)
 
-    @unittest.skipUnless(hasattr(time, 'monotonic'),
-                         'need time.monotonic')
     @unittest.skipUnless(hasattr(time, 'clock_settime'),
                          'need time.clock_settime')
     def test_monotonic_settime(self):
@@ -511,13 +507,14 @@ class TimeTestCase(unittest.TestCase):
         self.assertRaises(ValueError, time.ctime, float("nan"))
 
     def test_get_clock_info(self):
-        clocks = ['clock', 'perf_counter', 'process_time', 'time']
-        if hasattr(time, 'monotonic'):
-            clocks.append('monotonic')
+        clocks = ['clock', 'monotonic', 'perf_counter', 'process_time', 'time']
 
         for name in clocks:
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", "", DeprecationWarning)
+            if name == 'clock':
+                with support.check_warnings(('time.clock has been deprecated',
+                                             DeprecationWarning)):
+                    info = time.get_clock_info(name)
+            else:
                 info = time.get_clock_info(name)
 
             #self.assertIsInstance(info, dict)

--- a/Lib/turtledemo/bytedesign.py
+++ b/Lib/turtledemo/bytedesign.py
@@ -23,7 +23,7 @@ mode as fast as possible.
 """
 
 from turtle import Turtle, mainloop
-from time import clock
+from time import perf_counter as clock
 
 # wrapper for any additional drawing routines
 # that need to know about each other

--- a/Lib/turtledemo/forest.py
+++ b/Lib/turtledemo/forest.py
@@ -13,7 +13,7 @@ http://homepage.univie.ac.at/erich.neuwirth/
 """
 from turtle import Turtle, colormode, tracer, mainloop
 from random import randrange
-from time import clock
+from time import perf_counter as clock
 
 def symRandom(n):
     return randrange(-n,n+1)

--- a/Lib/turtledemo/fractalcurves.py
+++ b/Lib/turtledemo/fractalcurves.py
@@ -12,7 +12,7 @@ methods are taken from the PythonCard example
 scripts for turtle-graphics.
 """
 from turtle import *
-from time import sleep, clock
+from time import sleep, perf_counter as clock
 
 class CurvesTurtle(Pen):
     # example derived from

--- a/Lib/turtledemo/penrose.py
+++ b/Lib/turtledemo/penrose.py
@@ -17,7 +17,7 @@ For more information see:
 """
 from turtle import *
 from math import cos, pi
-from time import clock, sleep
+from time import perf_counter as clock, sleep
 
 f = (5**0.5-1)/2.0   # (sqrt(5)-1)/2 -- golden ratio
 d = 2 * cos(3*pi/10)

--- a/Lib/turtledemo/tree.py
+++ b/Lib/turtledemo/tree.py
@@ -16,7 +16,7 @@ the current pen is cloned. So in the end
 there are 1024 turtles.
 """
 from turtle import Turtle, mainloop
-from time import clock
+from time import perf_counter as clock
 
 def tree(plist, l, a, f):
     """ plist is list of pens

--- a/Lib/turtledemo/wikipedia.py
+++ b/Lib/turtledemo/wikipedia.py
@@ -14,7 +14,7 @@ parallel.
 Followed by a complete undo().
 """
 from turtle import Screen, Turtle, mainloop
-from time import clock, sleep
+from time import perf_counter as clock, sleep
 
 def mn_eck(p, ne,sz):
     turtlelist = [p]

--- a/Misc/NEWS.d/next/Library/2017-10-17-22-55-13.bpo-31803.YLL1gJ.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-17-22-55-13.bpo-31803.YLL1gJ.rst
@@ -1,0 +1,2 @@
+time.clock() and time.get_clock_info('clock') now emit a DeprecationWarning
+warning.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -104,6 +104,13 @@ perf_counter(_Py_clock_info_t *info)
 static PyObject*
 pyclock(_Py_clock_info_t *info)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                      "time.clock has been deprecated in Python 3.3 and will "
+                      "be removed from Python 3.8: "
+                      "use time.perf_counter or time.process_time "
+                      "instead", 1) < 0) {
+        return NULL;
+    }
 #ifdef MS_WINDOWS
     return perf_counter(info);
 #else


### PR DESCRIPTION
time.clock() and time.get_clock_info('clock') now emit a DeprecationWarning warning.



<!-- issue-number: bpo-31803 -->
https://bugs.python.org/issue31803
<!-- /issue-number -->
