### PR TITLE
bpo-31806: Use _PyTime_ROUND_TIMEOUT in _threadmodule.c, timemodule.c and socketmodule.c

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-10-17-23-27-03.bpo-31806.TzphdL.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-17-23-27-03.bpo-31806.TzphdL.rst
@@ -1,0 +1,4 @@
+Fix timeout rounding in time_sleep, lock_acquire_parse_args and
+socket_parse_timeout to round correctly negative timeouts between -1.0 and
+0.0. The functions now block waiting for events as expected. Previously, the
+call was incorrectly non-blocking. Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Library/2017-10-17-23-27-03.bpo-31806.TzphdL.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-17-23-27-03.bpo-31806.TzphdL.rst
@@ -1,4 +1,4 @@
-Fix timeout rounding in time_sleep, lock_acquire_parse_args and
-socket_parse_timeout to round correctly negative timeouts between -1.0 and
+Fix timeout rounding in time.sleep(), threading.Lock.acquire() and
+socket.socket.settimeout() to round correctly negative timeouts between -1.0 and
 0.0. The functions now block waiting for events as expected. Previously, the
 call was incorrectly non-blocking. Patch by Pablo Galindo.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -104,7 +104,7 @@ lock_acquire_parse_args(PyObject *args, PyObject *kwds,
 
     if (timeout_obj
         && _PyTime_FromSecondsObject(timeout,
-                                     timeout_obj, _PyTime_ROUND_CEILING) < 0)
+                                     timeout_obj, _PyTime_ROUND_TIMEOUT) < 0)
         return -1;
 
     if (!blocking && *timeout != unset_timeout ) {
@@ -122,7 +122,7 @@ lock_acquire_parse_args(PyObject *args, PyObject *kwds,
     else if (*timeout != unset_timeout) {
         _PyTime_t microseconds;
 
-        microseconds = _PyTime_AsMicroseconds(*timeout, _PyTime_ROUND_CEILING);
+        microseconds = _PyTime_AsMicroseconds(*timeout, _PyTime_ROUND_TIMEOUT);
         if (microseconds >= PY_TIMEOUT_MAX) {
             PyErr_SetString(PyExc_OverflowError,
                             "timeout value is too large");

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2539,7 +2539,7 @@ socket_parse_timeout(_PyTime_t *timeout, PyObject *timeout_obj)
     }
 
     if (_PyTime_FromSecondsObject(timeout,
-                                  timeout_obj, _PyTime_ROUND_CEILING) < 0)
+                                  timeout_obj, _PyTime_ROUND_TIMEOUT) < 0)
         return -1;
 
     if (*timeout < 0) {
@@ -2548,10 +2548,10 @@ socket_parse_timeout(_PyTime_t *timeout, PyObject *timeout_obj)
     }
 
 #ifdef MS_WINDOWS
-    overflow |= (_PyTime_AsTimeval(*timeout, &tv, _PyTime_ROUND_CEILING) < 0);
+    overflow |= (_PyTime_AsTimeval(*timeout, &tv, _PyTime_ROUND_TIMEOUT) < 0);
 #endif
 #ifndef HAVE_POLL
-    ms = _PyTime_AsMilliseconds(*timeout, _PyTime_ROUND_CEILING);
+    ms = _PyTime_AsMilliseconds(*timeout, _PyTime_ROUND_TIMEOUT);
     overflow |= (ms > INT_MAX);
 #endif
     if (overflow) {

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -238,7 +238,7 @@ static PyObject *
 time_sleep(PyObject *self, PyObject *obj)
 {
     _PyTime_t secs;
-    if (_PyTime_FromSecondsObject(&secs, obj, _PyTime_ROUND_CEILING))
+    if (_PyTime_FromSecondsObject(&secs, obj, _PyTime_ROUND_TIMEOUT))
         return NULL;
     if (secs < 0) {
         PyErr_SetString(PyExc_ValueError,


### PR DESCRIPTION
Following @haypo and @serhiy-storchaka instructions in #4003 (https://bugs.python.org/issue31786) `time_sleep`, `lock_acquire_parse_args` and `socket_parse_timeout` should use `_PyTime_ROUND_TIMEOUT` instead of `_PyTime_ROUND_CEILING`.


<!-- issue-number: bpo-31806 -->
https://bugs.python.org/issue31806
<!-- /issue-number -->
