### PR TITLE
[2.7] bpo-31786: Add test for select.poll.poll() with infinite timeout. (GH-4003).

### DIFF
--- a/Lib/test/test_poll.py
+++ b/Lib/test/test_poll.py
@@ -205,6 +205,28 @@ class PollTests(unittest.TestCase):
             os.write(w, b'spam')
             t.join()
 
+    @unittest.skipUnless(threading, 'Threading required for this test.')
+    @reap_threads
+    def test_poll_blocks_with_negative_ms(self):
+        for timeout_ms in [None, -1, -1.0]:
+            # Create two file descriptors. This will be used to unlock
+            # the blocking call to poll.poll inside the thread
+            r, w = os.pipe()
+            pollster = select.poll()
+            pollster.register(r, select.POLLIN)
+
+            poll_thread = threading.Thread(target=pollster.poll, args=(timeout_ms,))
+            poll_thread.start()
+            poll_thread.join(timeout=0.1)
+            self.assertTrue(poll_thread.is_alive())
+
+            # Write to the pipe so pollster.poll unblocks and the thread ends.
+            os.write(w, b'spam')
+            poll_thread.join()
+            self.assertFalse(poll_thread.is_alive())
+            os.close(r)
+            os.close(w)
+
 
 def test_main():
     run_unittest(PollTests)


### PR DESCRIPTION
(cherry picked from commit 2c15b29aea5d6b9c61aa42d2c24a07ff1edb4b46)


<!-- issue-number: bpo-31786 -->
https://bugs.python.org/issue31786
<!-- /issue-number -->
