### PR TITLE
[2.7] bpo-31334: Fix timeout in select.poll.poll() (GH-3277)

### DIFF
--- a/Lib/test/test_poll.py
+++ b/Lib/test/test_poll.py
@@ -208,7 +208,7 @@ class PollTests(unittest.TestCase):
     @unittest.skipUnless(threading, 'Threading required for this test.')
     @reap_threads
     def test_poll_blocks_with_negative_ms(self):
-        for timeout_ms in [None, -1, -1.0]:
+        for timeout_ms in [None, -1000, -1, -1.0]:
             # Create two file descriptors. This will be used to unlock
             # the blocking call to poll.poll inside the thread
             r, w = os.pipe()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -262,6 +262,7 @@ Brad Clements
 Robbie Clemons
 Steve Clift
 Hervé Coatanhay
+Riccardo Coccioli
 Nick Coghlan
 Josh Cogliati
 Dave Cole

--- a/Misc/NEWS.d/next/Library/2017-09-04-00-22-31.bpo-31334.9WYRfi.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-04-00-22-31.bpo-31334.9WYRfi.rst
@@ -1,0 +1,3 @@
+Fix ``poll.poll([timeout])`` in the ``select`` module for arbitrary negative
+timeouts on all OSes where it can only be a non-negative integer or -1.
+Patch by Riccardo Coccioli.


### PR DESCRIPTION
Always pass -1, or INFTIM where defined, to the poll() system call when
a negative timeout is passed to the poll.poll([timeout]) method in the
select module. Various OSes throw an error with arbitrary negative
values..
(cherry picked from commit 6cfa927ceb931ad968b5b03e4a2bffb64a8a0604)

https://bugs.python.org/issue31334

<!-- issue-number: bpo-31334 -->
https://bugs.python.org/issue31334
<!-- /issue-number -->
