### PR TITLE
bpo-31809: test secp ECDH curves

### DIFF
--- a/Misc/NEWS.d/next/Tests/2017-10-18-18-07-45.bpo-31809.KlQrkE.rst
+++ b/Misc/NEWS.d/next/Tests/2017-10-18-18-07-45.bpo-31809.KlQrkE.rst
@@ -1,0 +1,1 @@
+Add tests to verify connection with secp ECDH curves.


### PR DESCRIPTION
Add tests to verify connection with secp ECDH curves.


<!-- issue-number: bpo-31809 -->
https://bugs.python.org/issue31809
<!-- /issue-number -->
