### PR TITLE
Prevent TypeError if multiple waiters

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -215,7 +215,7 @@ class Server(events.AbstractServer):
 
     def _wakeup(self):
         waiters = self._waiters
-        self._waiters = None
+        self._waiters = []
         for waiter in waiters:
             if not waiter.done():
                 waiter.set_result(waiter)


### PR DESCRIPTION
Minor error that can occur if someone wait_closes and then someone else closes a server.