### PR TITLE
bpo-31454: Include information about "import X as Y" in tutorial

### DIFF
--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -124,11 +124,9 @@ following :keyword:`as` is bound directly to the imported module.
 This is effectively importing the module in the same way that ``import fibo``
 will do, with the only difference of it being available as ``fib``.
 
-It can be also used when utilising the ``from`` keyword with similar effects:
+It can be also used when utilising :keyword:`from` with similar effects::
 
-::
-
-   >>> import fibo import fib as fibonacci
+   >>> from fibo import fib as fibonacci
    >>> fibonacci(500)
    0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -112,6 +112,17 @@ Note that in general the practice of importing ``*`` from a module or package is
 frowned upon, since it often causes poorly readable code. However, it is okay to
 use it to save typing in interactive sessions.
 
+If as a user of the module you would like to import a module and make it available
+under a different name within the current namespace you can use ``import as``.
+
+   >>> import fibo as fib
+   >>> fib.fib(500)
+   0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
+
+This is effectively importing the module in the same way that ``import fibo``
+will do, with the only difference of it being available under a different name.
+
+
 .. note::
 
    For efficiency reasons, each module is only imported once per interpreter

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -112,15 +112,25 @@ Note that in general the practice of importing ``*`` from a module or package is
 frowned upon, since it often causes poorly readable code. However, it is okay to
 use it to save typing in interactive sessions.
 
-If as a user of the module you would like to import a module and make it available
-under a different name within the current namespace you can use ``import as``.
+If the module name is followed by :keyword:`as`, then the name
+following :keyword:`as` is bound directly to the imported module.
+
+::
 
    >>> import fibo as fib
    >>> fib.fib(500)
    0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 
 This is effectively importing the module in the same way that ``import fibo``
-will do, with the only difference of it being available under a different name.
+will do, with the only difference of it being available as ``fib``.
+
+It can be also used when utilising the ``from`` keyword with similar effects:
+
+::
+
+   >>> import fibo import fib as fibonacci
+   >>> fibonacci(500)
+   0 1 1 2 3 5 8 13 21 34 55 89 144 233 377
 
 
 .. note::

--- a/Doc/tutorial/modules.rst
+++ b/Doc/tutorial/modules.rst
@@ -124,7 +124,7 @@ following :keyword:`as` is bound directly to the imported module.
 This is effectively importing the module in the same way that ``import fibo``
 will do, with the only difference of it being available as ``fib``.
 
-It can be also used when utilising :keyword:`from` with similar effects::
+It can also be used when utilising :keyword:`from` with similar effects::
 
    >>> from fibo import fib as fibonacci
    >>> fibonacci(500)


### PR DESCRIPTION
Add some information about "import as" in the tutorial.

Happy to change the wording!

<!-- issue-number: bpo-31454 -->
https://bugs.python.org/issue31454
<!-- /issue-number -->
