### PR TITLE
bpo-31457: Make the `LoggerAdapter.manager` property settable

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1757,7 +1757,7 @@ class LoggerAdapter(object):
         return self.logger.manager
 
     @manager.setter
-    def set_manager(self, value):
+    def manager(self, value):
         self.logger.manager = value
 
     def __repr__(self):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -3982,12 +3982,25 @@ class LoggerAdapterTest(unittest.TestCase):
         msg = 'Adapters can be nested, yo.'
         adapter_adapter = logging.LoggerAdapter(logger=self.adapter, extra=None)
         adapter_adapter.log(logging.CRITICAL, msg, self.recording)
-
         self.assertEqual(len(self.recording.records), 1)
         record = self.recording.records[0]
         self.assertEqual(record.levelno, logging.CRITICAL)
         self.assertEqual(record.msg, msg)
         self.assertEqual(record.args, (self.recording,))
+        orig_manager = adapter_adapter.manager
+        self.assertIs(self.adapter.manager, orig_manager)
+        self.assertIs(self.logger.manager, orig_manager)
+        temp_manager = object()
+        try:
+            adapter_adapter.manager = temp_manager
+            self.assertIs(adapter_adapter.manager, temp_manager)
+            self.assertIs(self.adapter.manager, temp_manager)
+            self.assertIs(self.logger.manager, temp_manager)
+        finally:
+            adapter_adapter.manager = orig_manager
+        self.assertIs(adapter_adapter.manager, orig_manager)
+        self.assertIs(self.adapter.manager, orig_manager)
+        self.assertIs(self.logger.manager, orig_manager)
 
 
 class LoggerTest(BaseTest):

--- a/Misc/NEWS.d/next/Library/2017-10-18-16-48-09.bpo-31457._ovmzp.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-18-16-48-09.bpo-31457._ovmzp.rst
@@ -1,0 +1,1 @@
+The ``manager`` property on LoggerAdapter objects is now properly settable.


### PR DESCRIPTION
Due to a bug in the initial fix, the setter was in fact creating a different
property.  This is now fixed.

<!-- issue-number: bpo-31457 -->
https://bugs.python.org/issue31457
<!-- /issue-number -->
