### PR TITLE
bpo-31457: Don't omit inner `process()` calls with nested LogAdapters

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1713,7 +1713,7 @@ class LoggerAdapter(object):
         """
         if self.isEnabledFor(level):
             msg, kwargs = self.process(msg, kwargs)
-            self.logger._log(level, msg, args, **kwargs)
+            self.logger.log(level, msg, *args, **kwargs)
 
     def isEnabledFor(self, level):
         """
@@ -1759,6 +1759,10 @@ class LoggerAdapter(object):
     @manager.setter
     def manager(self, value):
         self.logger.manager = value
+
+    @property
+    def name(self):
+        return self.logger.name
 
     def __repr__(self):
         logger = self.logger

--- a/Misc/NEWS.d/next/Library/2017-10-18-19-05-17.bpo-31457.KlE6r8.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-18-19-05-17.bpo-31457.KlE6r8.rst
@@ -1,0 +1,2 @@
+If nested log adapters are used, the inner ``process()`` methods are no
+longer omitted.


### PR DESCRIPTION
This used to be the case on Python 2.  Commit 212b590e118e3650b596917021ed9612a918180b changed the implementation for Python 3, making the `log()` method of LogAdapter call `logger._log()` directly.  This makes nested log adapters not execute their ``process()`` method.  This patch fixes the issue.

Also, now proxying `name`, too, to make `repr()` work with nested log adapters.

New tests added.

<!-- issue-number: bpo-31457 -->
https://bugs.python.org/issue31457
<!-- /issue-number -->
