### PR TITLE
bpo-31618: Add NEWS entry for opcode tracing change.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-18-19-41-12.bpo-31618.liLDiS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-18-19-41-12.bpo-31618.liLDiS.rst
@@ -1,0 +1,7 @@
+The per-frame tracing logic added in 3.7a1 has been altered so that
+``frame->f_lineno`` is updated before either ``"line"`` or ``"opcode"``
+events are emitted. Previously, opcode events were emitted first, and
+therefore would occasionally see stale line numbers on the frame. The
+behavior of this feature has changed slightly as a result: when both
+``f_trace_lines`` and ``f_trace_opcodes`` are enabled, line events now occur
+first.


### PR DESCRIPTION
@ncoghlan here is the news entry to supplement PR #3798.

<!-- issue-number: bpo-31681 -->
https://bugs.python.org/issue31681
<!-- /issue-number -->
