### PR TITLE
bpo-17799: Explain real behaviour of sys.settrace and sys.setprofile

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1091,11 +1091,6 @@ Python-level trace functions in previous versions.
    | :const:`PyTrace_C_RETURN`    | Function object being called.        |
    +------------------------------+--------------------------------------+
 
-   Any trace function registered using :c:func:`PyEval_SetTrace` will not receive
-   :const:`PyTrace_C_CALL`, :const:`PyTrace_C_EXCEPTION` or :const:`PyTrace_C_RETURN`
-   as a value for the *what* parameter.
-
-
 .. c:var:: int PyTrace_CALL
 
    The value of the *what* parameter to a :c:type:`Py_tracefunc` function when a new
@@ -1160,8 +1155,10 @@ Python-level trace functions in previous versions.
 
    Set the tracing function to *func*.  This is similar to
    :c:func:`PyEval_SetProfile`, except the tracing function does receive line-number
-   events and does not receive any event related to C function objects being called.
-
+   events and does not receive any event related to C function objects being called.Any
+   trace function registered using :c:func:`PyEval_SetTrace` will not receive
+   :const:`PyTrace_C_CALL`, :const:`PyTrace_C_EXCEPTION` or :const:`PyTrace_C_RETURN`
+   as a value for the *what* parameter.
 
 .. _advanced-debugging:
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1091,6 +1091,10 @@ Python-level trace functions in previous versions.
    | :const:`PyTrace_C_RETURN`    | Function object being called.        |
    +------------------------------+--------------------------------------+
 
+   Any trace function registered using :c:func:`PyEval_SetTrace` will not recieve
+   :const:`PyTrace_C_CALL`, :const:`PyTrace_C_EXCEPTION`, :const:`PyTrace_C_RETURN`
+   or :const:`PyTrace_LINE` as a value for the *what* parameter.
+
 
 .. c:var:: int PyTrace_CALL
 
@@ -1156,7 +1160,7 @@ Python-level trace functions in previous versions.
 
    Set the tracing function to *func*.  This is similar to
    :c:func:`PyEval_SetProfile`, except the tracing function does receive line-number
-   events.
+   events or any event related to C function objects being called.
 
 
 .. _advanced-debugging:

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1155,7 +1155,7 @@ Python-level trace functions in previous versions.
 
    Set the tracing function to *func*.  This is similar to
    :c:func:`PyEval_SetProfile`, except the tracing function does receive line-number
-   events and does not receive any event related to C function objects being called.Any
+   events and does not receive any event related to C function objects being called. Any
    trace function registered using :c:func:`PyEval_SetTrace` will not receive
    :const:`PyTrace_C_CALL`, :const:`PyTrace_C_EXCEPTION` or :const:`PyTrace_C_RETURN`
    as a value for the *what* parameter.

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1091,7 +1091,7 @@ Python-level trace functions in previous versions.
    | :const:`PyTrace_C_RETURN`    | Function object being called.        |
    +------------------------------+--------------------------------------+
 
-   Any trace function registered using :c:func:`PyEval_SetTrace` will not recieve
+   Any trace function registered using :c:func:`PyEval_SetTrace` will not receive
    :const:`PyTrace_C_CALL`, :const:`PyTrace_C_EXCEPTION`, :const:`PyTrace_C_RETURN`
    or :const:`PyTrace_LINE` as a value for the *what* parameter.
 

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1147,8 +1147,8 @@ Python-level trace functions in previous versions.
    function as its first parameter, and may be any Python object, or *NULL*.  If
    the profile function needs to maintain state, using a different value for *obj*
    for each thread provides a convenient and thread-safe place to store it.  The
-   profile function is called for all monitored events except the line-number
-   events.
+   profile function is called for all monitored events except :const:`PyTrace_LINE`
+   and :const:`PyTrace_EXCEPTION`.
 
 
 .. c:function:: void PyEval_SetTrace(Py_tracefunc func, PyObject *obj)

--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1092,8 +1092,8 @@ Python-level trace functions in previous versions.
    +------------------------------+--------------------------------------+
 
    Any trace function registered using :c:func:`PyEval_SetTrace` will not receive
-   :const:`PyTrace_C_CALL`, :const:`PyTrace_C_EXCEPTION`, :const:`PyTrace_C_RETURN`
-   or :const:`PyTrace_LINE` as a value for the *what* parameter.
+   :const:`PyTrace_C_CALL`, :const:`PyTrace_C_EXCEPTION` or :const:`PyTrace_C_RETURN`
+   as a value for the *what* parameter.
 
 
 .. c:var:: int PyTrace_CALL
@@ -1160,7 +1160,7 @@ Python-level trace functions in previous versions.
 
    Set the tracing function to *func*.  This is similar to
    :c:func:`PyEval_SetProfile`, except the tracing function does receive line-number
-   events or any event related to C function objects being called.
+   events and does not receive any event related to C function objects being called.
 
 
 .. _advanced-debugging:

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1062,15 +1062,14 @@ always available.
 
    Profile functions should have three arguments: *frame*, *event*, and
    *arg*. *frame* is the current stack frame.  *event* is a string: ``'call'``,
-   ``'line'``, ``'return'``, ``'exception'``, ``'c_call'``, ``'c_return'``, or
+   ``'return'``, ``'exception'``, ``'c_call'``, ``'c_return'``, or
    ``'c_exception'``, ``'opcode'``. *arg* depends on the event type.
 
    The events have the following meaning:
 
    ``'call'``
       A function is called (or some other code block entered).  The
-      global trace function is called; *arg* is ``None``; the return value
-      specifies the local trace function.
+      profile function is called; *arg* is ``None``.
 
    ``'return'``
       A function (or other code block) is about to return.  The local trace

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1062,8 +1062,8 @@ always available.
 
    Profile functions should have three arguments: *frame*, *event*, and
    *arg*. *frame* is the current stack frame.  *event* is a string: ``'call'``,
-   ``'return'``, ``'exception'``, ``'c_call'``, ``'c_return'``, or
-   ``'c_exception'``. *arg* depends on the event type.
+   ``'return'``, ``'c_call'``, ``'c_return'``, or ``'c_exception'``. *arg* depends
+   on the event type.
 
    The events have the following meaning:
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1053,11 +1053,11 @@ always available.
    Set the system's profile function, which allows you to implement a Python source
    code profiler in Python.  See chapter :ref:`profile` for more information on the
    Python profiler.  The system's profile function is called similarly to the
-   system's trace function (see :func:`settrace`), but it isn't called for each
-   executed line of code (only on call and return, but the return event is reported
-   even when an exception has been set).  The function is thread-specific, but
-   there is no way for the profiler to know about context switches between threads,
-   so it does not make sense to use this in the presence of multiple threads. Also,
+   system's trace function (see :func:`settrace`), but it is called with different events,
+   for example it isn't called for each executed line of code (only on call and return,
+   but the return event is reported even when an exception has been set). The function is
+   thread-specific, but there is no way for the profiler to know about context switches between
+   threads, so it does not make sense to use this in the presence of multiple threads. Also,
    its return value is not used, so it can simply return ``None``.
 
    Profile functions should have three arguments: *frame*, *event*, and

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1063,7 +1063,7 @@ always available.
    Profile functions should have three arguments: *frame*, *event*, and
    *arg*. *frame* is the current stack frame.  *event* is a string: ``'call'``,
    ``'return'``, ``'exception'``, ``'c_call'``, ``'c_return'``, or
-   ``'c_exception'``, ``'opcode'``. *arg* depends on the event type.
+   ``'c_exception'``. *arg* depends on the event type.
 
    The events have the following meaning:
 
@@ -1072,15 +1072,9 @@ always available.
       profile function is called; *arg* is ``None``.
 
    ``'return'``
-      A function (or other code block) is about to return.  The local trace
+      A function (or other code block) is about to return.  The profile
       function is called; *arg* is the value that will be returned, or ``None``
-      if the event is caused by an exception being raised.  The trace function's
-      return value is ignored.
-
-   ``'exception'``
-      An exception has occurred.  The local trace function is called; *arg* is a
-      tuple ``(exception, value, traceback)``; the return value specifies the
-      new local trace function.
+      if the event is caused by an exception being raised.
 
    ``'c_call'``
       A C function is about to be called.  This may be an extension function or
@@ -1091,14 +1085,6 @@ always available.
 
    ``'c_exception'``
       A C function has raised an exception.  *arg* is the C function object.
-
-   ``'opcode'``
-      The interpreter is about to execute a new opcode (see :mod:`dis` for
-      opcode details).  The local trace function is called; *arg* is
-      ``None``; the return value specifies the new local trace function.
-      Per-opcode events are not emitted by default: they must be explicitly
-      requested by setting :attr:`f_trace_opcodes` to :const:`True` on the
-      frame.
 
    Note that as an exception is propagated down the chain of callers, an
    ``'exception'`` event is generated at each level.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1086,9 +1086,6 @@ always available.
    ``'c_exception'``
       A C function has raised an exception.  *arg* is the C function object.
 
-   Note that as an exception is propagated down the chain of callers, an
-   ``'exception'`` event is generated at each level.
-
 .. function:: setrecursionlimit(limit)
 
    Set the maximum depth of the Python interpreter stack to *limit*.  This limit

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1060,6 +1060,49 @@ always available.
    so it does not make sense to use this in the presence of multiple threads. Also,
    its return value is not used, so it can simply return ``None``.
 
+   Profile functions should have three arguments: *frame*, *event*, and
+   *arg*. *frame* is the current stack frame.  *event* is a string: ``'call'``,
+   ``'line'``, ``'return'``, ``'exception'``, ``'c_call'``, ``'c_return'``, or
+   ``'c_exception'``, ``'opcode'``. *arg* depends on the event type.
+
+   The events have the following meaning:
+
+   ``'call'``
+      A function is called (or some other code block entered).  The
+      global trace function is called; *arg* is ``None``; the return value
+      specifies the local trace function.
+
+   ``'return'``
+      A function (or other code block) is about to return.  The local trace
+      function is called; *arg* is the value that will be returned, or ``None``
+      if the event is caused by an exception being raised.  The trace function's
+      return value is ignored.
+
+   ``'exception'``
+      An exception has occurred.  The local trace function is called; *arg* is a
+      tuple ``(exception, value, traceback)``; the return value specifies the
+      new local trace function.
+
+   ``'c_call'``
+      A C function is about to be called.  This may be an extension function or
+      a built-in.  *arg* is the C function object.
+
+   ``'c_return'``
+      A C function has returned. *arg* is the C function object.
+
+   ``'c_exception'``
+      A C function has raised an exception.  *arg* is the C function object.
+
+   ``'opcode'``
+      The interpreter is about to execute a new opcode (see :mod:`dis` for
+      opcode details).  The local trace function is called; *arg* is
+      ``None``; the return value specifies the new local trace function.
+      Per-opcode events are not emitted by default: they must be explicitly
+      requested by setting :attr:`f_trace_opcodes` to :const:`True` on the
+      frame.
+
+   Note that as an exception is propagated down the chain of callers, an
+   ``'exception'`` event is generated at each level.
 
 .. function:: setrecursionlimit(limit)
 
@@ -1106,8 +1149,8 @@ always available.
 
    Trace functions should have three arguments: *frame*, *event*, and
    *arg*. *frame* is the current stack frame.  *event* is a string: ``'call'``,
-   ``'line'``, ``'return'``, ``'exception'``, ``'c_call'``, ``'c_return'``, or
-   ``'c_exception'``, ``'opcode'``. *arg* depends on the event type.
+   ``'line'``, ``'return'``, ``'exception'`` or ``'opcode'``.  *arg* depends on
+   the event type.
 
    The trace function is invoked (with *event* set to ``'call'``) whenever a new
    local scope is entered; it should return a reference to a local trace
@@ -1143,16 +1186,6 @@ always available.
       An exception has occurred.  The local trace function is called; *arg* is a
       tuple ``(exception, value, traceback)``; the return value specifies the
       new local trace function.
-
-   ``'c_call'``
-      A C function is about to be called.  This may be an extension function or
-      a built-in.  *arg* is the C function object.
-
-   ``'c_return'``
-      A C function has returned. *arg* is the C function object.
-
-   ``'c_exception'``
-      A C function has raised an exception.  *arg* is the C function object.
 
    ``'opcode'``
       The interpreter is about to execute a new opcode (see :mod:`dis` for

--- a/Misc/NEWS.d/next/Documentation/2018-01-22-21-13-46.bpo-17799.rdZ-Vk.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-22-21-13-46.bpo-17799.rdZ-Vk.rst
@@ -1,2 +1,2 @@
-Explain real behaviour of sys.settrace regarding C function object calls.
-Patch by Pablo Galindo Salgado.
+Explain real behaviour of sys.settrace and sys.setprofile and their C-API counterparts
+regarding which type of events are received in each function. Patch by Pablo Galindo Salgado.

--- a/Misc/NEWS.d/next/Documentation/2018-01-22-21-13-46.bpo-17799.rdZ-Vk.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-22-21-13-46.bpo-17799.rdZ-Vk.rst
@@ -1,0 +1,2 @@
+Explain real behaviour of sys.settrace regarding C function object calls.
+Patch by Pablo Galindo Salgado.


### PR DESCRIPTION
The docs for `sys.settrace` mention that:

> event is a string: 'call', 'line', 'return', 'exception', 'c_call', 'c_return', or 'c_exception'

But in the code for `ceval.c` the only point where `call_trace` is invoked with `PyTrace_C_CALL` or `PyTrace_C_RETURN` is under the `C_TRACE` macro. In this macro this line prevents any function set up using `sys.settrace` to call `call_trace` with the mentioned arguments:

```C
if (tstate->use_tracing && tstate->c_profilefunc)
```

Notice that from the code of `PyEval_SetTrace` and `PyEval_SetProfile`, only the later sets ` tstate->c_profilefunc` and therefore only functions installed using `sys.setprofile` will recieve a `c_call` for the event:

```C
void
PyEval_SetProfile(Py_tracefunc func, PyObject *arg)
{
     ...
    tstate->c_profilefunc = func;
    tstate->c_profileobj = arg;
    tstate->use_tracing = (func != NULL) || (tstate->c_tracefunc != NULL);
}

void
PyEval_SetTrace(Py_tracefunc func, PyObject *arg)
{
     ...
    tstate->c_tracefunc = func;
    tstate->c_traceobj = arg;
    tstate->use_tracing = ((func != NULL) || (tstate->c_profilefunc != NULL));
}
```

This PR updates the documentation clarifying the real behaviour of both functions.

<!-- issue-number: bpo-17799 -->
https://bugs.python.org/issue17799
<!-- /issue-number -->
