### PR TITLE
bpo-31810: Add smelly.py to check exported symbols

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,6 +91,8 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./python Tools/scripts/patchcheck.py --travis $TRAVIS_PULL_REQUEST; fi
   # `-r -w` implicitly provided through `make buildbottest`.
   - make buildbottest TESTOPTS="-j4 -uall,-cpu"
+  # Check if all symbols exported by libpython start with "Py" or "_Py"
+  - make smelly
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./python Tools/scripts/patchcheck.py --travis $TRAVIS_PULL_REQUEST; fi
   # `-r -w` implicitly provided through `make buildbottest`.
   - make buildbottest TESTOPTS="-j4 -uall,-cpu"
-  # Check if all symbols exported by libpython start with "Py" or "_Py"
+  # Check that all symbols exported by libpython start with "Py" or "_Py"
   - make smelly
 
 notifications:

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1659,7 +1659,7 @@ distclean: clobber
 				     -o -name '*.bak' ')' \
 				     -exec rm -f {} ';'
 
-# Check if all symbols exported by libpython start with "Py" or "_Py"
+# Check that all symbols exported by libpython start with "Py" or "_Py"
 smelly: @DEF_MAKE_RULE@
 	$(RUNSHARED) ./$(BUILDPYTHON) Tools/scripts/smelly.py
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1659,10 +1659,9 @@ distclean: clobber
 				     -o -name '*.bak' ')' \
 				     -exec rm -f {} ';'
 
-# Check for smelly exported symbols (not starting with Py/_Py)
+# Check if all symbols exported by libpython start with "Py" or "_Py"
 smelly: @DEF_MAKE_RULE@
-	nm -p $(LIBRARY) | \
-		sed -n "/ [TDB] /s/.* //p" | grep -v "^_*Py" | sort -u; \
+	$(RUNSHARED) ./$(BUILDPYTHON) Tools/scripts/smelly.py
 
 # Find files with funny names
 funny:

--- a/Tools/scripts/smelly.py
+++ b/Tools/scripts/smelly.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+# Script checking if all symbols exported by libpython start with "Py" or "_Py"
+
+import subprocess
+import sys
+import sysconfig
+
+
+def get_exported_symbols():
+    LIBRARY = sysconfig.get_config_var('LIBRARY')
+    if not LIBRARY:
+        raise Exception("failed to get LIBRARY")
+
+    args = ('nm', '-p', LIBRARY)
+    print("+ %s" % ' '.join(args))
+    proc = subprocess.run(args, stdout=subprocess.PIPE, universal_newlines=True)
+    if proc.returncode:
+        sys.stdout.write(proc.stdout)
+        sys.exit(proc.returncode)
+
+    stdout = proc.stdout.rstrip()
+    if not stdout:
+        raise Exception("command output is empty")
+    return stdout
+
+
+def get_smelly_symbols(stdout):
+    symbols = []
+    for line in stdout.splitlines():
+        # Split line '0000000000001b80 D PyTextIOWrapper_Type'
+        if not line:
+            continue
+        parts = line.split(maxsplit=2)
+        if len(parts) < 3:
+            continue
+        symtype = parts[1].strip()
+        if symtype not in 'TDB':
+            continue
+        symbol = parts[-1]
+        if symbol.startswith(('Py', '_Py')):
+            continue
+        symbols.append(symbol)
+    return symbols
+
+
+def main():
+    stdout = get_exported_symbols()
+    symbols = get_smelly_symbols(stdout)
+
+    if not symbols:
+        print("OK: no smelly symbol found")
+        sys.exit(0)
+
+    symbols.sort()
+    for symbol in symbols:
+        print("Smelly symbol: %s" % symbol)
+    print()
+    print("ERROR: Found %s smelly symbols!" % len(symbols))
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/Tools/scripts/smelly.py
+++ b/Tools/scripts/smelly.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Script checking if all symbols exported by libpython start with "Py" or "_Py"
+# Script checking that all symbols exported by libpython start with Py or _Py
 
 import subprocess
 import sys
@@ -42,7 +42,7 @@ def get_smelly_symbols(stdout):
         # If lowercase, the symbol is usually local; if uppercase, the symbol
         # is global (external).  There are however a few lowercase symbols that
         # are shown for special global symbols ("u", "v" and "w").
-        if symtype.islower() and symtype not in ("u", "v" "w"):
+        if symtype.islower() and symtype not in "uvw":
             ignored_symtypes.add(symtype)
             continue
 
@@ -59,8 +59,8 @@ def get_smelly_symbols(stdout):
 
 
 def main():
-    stdout = get_exported_symbols()
-    symbols = get_smelly_symbols(stdout)
+    nm_output = get_exported_symbols()
+    symbols = get_smelly_symbols(nm_output)
 
     if not symbols:
         print("OK: no smelly symbol found")

--- a/Tools/scripts/smelly.py
+++ b/Tools/scripts/smelly.py
@@ -34,6 +34,10 @@ def get_smelly_symbols(stdout):
         if len(parts) < 3:
             continue
         symtype = parts[1].strip()
+        # "T": The symbol is in the text (code) section.
+        # "D": The symbol is in the initialized data section.
+        # "B": The symbol is in the uninitialized data section (known as BSS).
+        # if uppercase, the symbol is global (external)
         if symtype not in 'TDB':
             continue
         symbol = parts[-1]


### PR DESCRIPTION
* Add Tools/scripts/smelly.py: script checking if all symbols
  exported by libpython start with "Py" or "_Py".
* Modify "make smelly" to run smelly.py: the command now fails with a
  non-zero exit code if libpython leaks a "smelly" symbol.
* Travis CI now runs "make smelly"

<!-- issue-number: bpo-31810 -->
https://bugs.python.org/issue31810
<!-- /issue-number -->
