### PR TITLE
bpo-31825: Fixed OverflowError in the 'unicode-escape' codec

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1203,6 +1203,8 @@ class EscapeDecodeTest(unittest.TestCase):
             check(br"\8", b"\\8")
         with self.assertWarns(DeprecationWarning):
             check(br"\9", b"\\9")
+        with self.assertWarns(DeprecationWarning):
+            check(b"\\\xfa", b"\\\xfa")
 
     def test_errors(self):
         decode = codecs.escape_decode
@@ -2474,6 +2476,8 @@ class UnicodeEscapeTest(unittest.TestCase):
             check(br"\8", "\\8")
         with self.assertWarns(DeprecationWarning):
             check(br"\9", "\\9")
+        with self.assertWarns(DeprecationWarning):
+            check(b"\\\xfa", "\\\xfa")
 
     def test_decode_errors(self):
         decode = codecs.unicode_escape_decode

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-20-14-07-46.bpo-31825.gJvmGW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-20-14-07-46.bpo-31825.gJvmGW.rst
@@ -1,0 +1,2 @@
+Fixed OverflowError in the 'unicode-escape' codec and in
+codecs.escape_decode() when decode an scaped non-ascii byte.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-20-14-07-46.bpo-31825.gJvmGW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-20-14-07-46.bpo-31825.gJvmGW.rst
@@ -1,2 +1,2 @@
 Fixed OverflowError in the 'unicode-escape' codec and in
-codecs.escape_decode() when decode an scaped non-ascii byte.
+codecs.escape_decode() when decode an escaped non-ascii byte.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1257,7 +1257,7 @@ PyObject *PyBytes_DecodeEscape(const char *s,
     if (first_invalid_escape != NULL) {
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                              "invalid escape sequence '\\%c'",
-                             *first_invalid_escape) < 0) {
+                             (unsigned char)*first_invalid_escape) < 0) {
             Py_DECREF(result);
             return NULL;
         }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -6136,7 +6136,7 @@ PyUnicode_DecodeUnicodeEscape(const char *s,
     if (first_invalid_escape != NULL) {
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                              "invalid escape sequence '\\%c'",
-                             *first_invalid_escape) < 0) {
+                             (unsigned char)*first_invalid_escape) < 0) {
             Py_DECREF(result);
             return NULL;
         }

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4147,7 +4147,7 @@ decode_utf8(struct compiling *c, const char **sPtr, const char *end)
 
 static int
 warn_invalid_escape_sequence(struct compiling *c, const node *n,
-                             char first_invalid_escape_char)
+                             unsigned char first_invalid_escape_char)
 {
     PyObject *msg = PyUnicode_FromFormat("invalid escape sequence \\%c",
                                          first_invalid_escape_char);


### PR DESCRIPTION
and in codecs.escape_decode() when decode an escaped non-ascii byte.


<!-- issue-number: bpo-31825 -->
https://bugs.python.org/issue31825
<!-- /issue-number -->
