### PR TITLE
bpo-31803: time.clock becomes an alias to time.perf_counter

### DIFF
--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -139,24 +139,19 @@ Functions
 
 .. function:: clock()
 
-   .. index::
-      single: CPU time
-      single: processor time
-      single: benchmarking
-
-   On Unix, return the current processor time as a floating point number expressed
-   in seconds.  The precision, and in fact the very definition of the meaning of
-   "processor time", depends on that of the C function of the same name.
-
-   On Windows, this function returns wall-clock seconds elapsed since the first
-   call to this function, as a floating point number, based on the Win32 function
-   :c:func:`QueryPerformanceCounter`. The resolution is typically better than one
-   microsecond.
+   Alias to :func:`perf_counter`.
 
    .. deprecated:: 3.3
-      The behaviour of this function depends on the platform: use
-      :func:`perf_counter` or :func:`process_time` instead, depending on your
-      requirements, to have a well defined behaviour.
+      On Python 3.6 and older, the behaviour of this function depends on the
+      platform: include time elapsed during sleep on Windows, don't include it
+      on other platforms.
+
+      Use :func:`perf_counter` or :func:`process_time` instead, depending on
+      your requirements.
+
+   .. versionchanged:: 3.7
+      :func:`time.clock` became an alias to :func:`time.perf_counter` in Python
+      3.7.
 
 .. function:: pthread_getcpuclockid(thread_id)
 
@@ -236,6 +231,8 @@ Functions
    - *resolution*: The resolution of the clock in seconds (:class:`float`)
 
    .. versionadded:: 3.3
+   .. versionchanged:: 3.7
+      ``'clock'`` is now an alias to ``'perf_counter'``.
 
 
 .. function:: gmtime([secs])

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -9,7 +9,6 @@ import sysconfig
 import time
 import threading
 import unittest
-import warnings
 try:
     import _testcapi
 except ImportError:
@@ -65,13 +64,17 @@ class TimeTestCase(unittest.TestCase):
         self.assertTrue(info.adjustable)
 
     def test_clock(self):
-        with self.assertWarns(DeprecationWarning):
-            time.clock()
+        time.clock()
 
-        with self.assertWarns(DeprecationWarning):
-            info = time.get_clock_info('clock')
+        info = time.get_clock_info('clock')
         self.assertTrue(info.monotonic)
         self.assertFalse(info.adjustable)
+
+    @support.cpython_only
+    def test_clock_alias(self):
+        self.assertIs(time.clock, time.perf_counter)
+        self.assertEqual(time.get_clock_info('clock'),
+                         time.get_clock_info('perf_counter'))
 
     @unittest.skipUnless(hasattr(time, 'clock_gettime'),
                          'need time.clock_gettime()')
@@ -508,12 +511,7 @@ class TimeTestCase(unittest.TestCase):
         clocks = ['clock', 'monotonic', 'perf_counter', 'process_time', 'time']
 
         for name in clocks:
-            if name == 'clock':
-                with self.assertWarns(DeprecationWarning):
-                    info = time.get_clock_info('clock')
-            else:
-                info = time.get_clock_info(name)
-
+            info = time.get_clock_info(name)
             #self.assertIsInstance(info, dict)
             self.assertIsInstance(info.implementation, str)
             self.assertNotEqual(info.implementation, '')

--- a/Misc/NEWS.d/next/Library/2017-10-17-22-55-13.bpo-31803.YLL1gJ.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-17-22-55-13.bpo-31803.YLL1gJ.rst
@@ -1,2 +1,0 @@
-time.clock() and time.get_clock_info('clock') now emit a DeprecationWarning
-warning.

--- a/Misc/NEWS.d/next/Library/2017-10-20-18-57-58.bpo-31803.0btU7y.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-20-18-57-58.bpo-31803.0btU7y.rst
@@ -1,0 +1,3 @@
+time.clock() is now an alias to time.perf_counter(). On Windows, it has no
+effect. On other platforms, it means that time.perf_counter() now includes
+time elapsed during sleep.


### PR DESCRIPTION
Remove time.clock() implementation, as time.clock becomes a simple
alias to time.perf_counter.

<!-- issue-number: bpo-31803 -->
https://bugs.python.org/issue31803
<!-- /issue-number -->
