### PR TITLE
bpo-31812: Add documentation translations to What's New in Python 3.7.

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -604,3 +604,24 @@ CPython bytecode changes
 
 * Added two new opcodes: :opcode:`LOAD_METHOD` and :opcode:`CALL_METHOD`.
   (Contributed by Yury Selivanov and INADA Naoki in :issue:`26110`.)
+
+
+Documentation
+=============
+
+.. _whatsnew37-pep545:
+
+PEP 545: Python Documentation Translations
+------------------------------------------
+
+:pep:`545` describes the process to translate Python documentation,
+and two translations have been added:
+
+- Japanese: https://docs.python.org/ja/ and associated github
+  repository: https://github.com/python/python-docs-ja
+
+- French: https://docs.python.org/fr/ and associated github
+  repository: https://github.com/python/python-docs-fr
+
+(Contributed by Julien Palard, Inada Naoki, and Victor Stinner in
+:issue:`issue26546`.)


### PR DESCRIPTION
Adding a what's changed entry for https://docs.python.org/fr/ and https://docs.python.org/ja/.

https://bugs.python.org/issue31812

<!-- issue-number: bpo-31812 -->
https://bugs.python.org/issue31812
<!-- /issue-number -->
