### PR TITLE
bpo-31589: Add config for LaTeX handling of stray Unicode chars in PDF

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -94,9 +94,10 @@ latex_engine = 'xelatex'
 
 # Get LaTeX to handle Unicode correctly
 latex_elements = {
+    'fontenc': r'\usepackage[T2A,TS1,T1]{fontenc}',
 }
 
-# Additional stuff for the LaTeX preamble.
+# Additional stuff for the LaTeX preamble (inc. handling of stray Unicode chars)
 latex_elements['preamble'] = r'''
 \authoraddress{
   \sphinxstrong{Python Software Foundation}\\
@@ -104,6 +105,15 @@ latex_elements['preamble'] = r'''
 }
 \let\Verbatim=\OriginalVerbatim
 \let\endVerbatim=\endOriginalVerbatim
+\ifx\XeTeXinterchartoks\undefined % not for xelatex
+\ifx\directlua\undefined          % not for lualatex
+\ifx\kanjiskip\undefined          % not for platex
+\usepackage{newunicodechar}
+\newunicodechar{ſ}{{\fontencoding{TS1}\fontfamily{lmr}\selectfont s}}
+\newunicodechar{K}{\ensuremath{\mathrm K}}
+\newunicodechar{−}{\textminus}
+\newunicodechar{Є}{{\fontencoding{T2A}\fontfamily{cmr}\selectfont\IeC{\CYRIE}}}
+\fi\fi\fi
 '''
 
 # The paper size ('letter' or 'a4').

--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -94,7 +94,10 @@ latex_engine = 'xelatex'
 
 # Get LaTeX to handle Unicode correctly
 latex_elements = {
-    'fontenc': r'\usepackage[T2A,TS1,T1]{fontenc}',
+    'passoptionstopackages': r'''
+\PassOptionsToPackage{T2A}{fontenc}%   for cyrillic Є
+\PassOptionsToPackage{warn}{textcomp}% unneeded with Sphinx 1.6.6 or later
+''',
 }
 
 # Additional stuff for the LaTeX preamble (inc. handling of stray Unicode chars)

--- a/Misc/NEWS.d/next/Documentation/2017-12-06-20-01-22.bpo-31589.ystCoY.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-12-06-20-01-22.bpo-31589.ystCoY.rst
@@ -1,0 +1,2 @@
+Provide latex Unicode configuration for successful PDF builds with pdfLaTeX.
+Patch by jfbu.


### PR DESCRIPTION
Does not modify config for xelatex, lualatex or platex (Japanese).


<!-- issue-number: bpo-31589 -->
https://bugs.python.org/issue31589
<!-- /issue-number -->
