### PR TITLE
bpo-6721: Sanitize logging locks while forking

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -225,10 +225,43 @@ def _releaseLock():
     if _lock:
         _lock.release()
 
+
 # Prevent a held logging lock from blocking a child from logging.
 os.register_at_fork(before=_acquireLock,
                     after_in_child=_releaseLock,
                     after_in_parent=_releaseLock)
+
+
+# A collection of instances with acquire and release methods (logging.Handler)
+# to be called before and after fork.  The weakref avoids us keeping discarded
+# Handler instances alive forever in case an odd program creates and destroys
+# many over its lifetime.
+_at_fork_acquire_release_weakset = weakref.WeakSet()
+
+
+def _at_fork_weak_calls(method_name):
+    for instance in _at_fork_acquire_release_weakset:
+        method = getattr(instance, method_name)
+        try:
+            method()
+        except Exception as err:
+            # Similar to what PyErr_WriteUnraisable does.
+            print("Ignoring exception from logging atfork", instance,
+                  method_name, "method:", err, file=sys.stderr)
+
+
+def _before_at_fork_weak_calls():
+    _at_fork_weak_calls('acquire')
+
+
+def _after_at_fork_weak_calls():
+    _at_fork_weak_calls('release')
+
+
+os.register_at_fork(before=_before_at_fork_weak_calls,
+                    after_in_child=_after_at_fork_weak_calls,
+                    after_in_parent=_after_at_fork_weak_calls)
+
 
 #---------------------------------------------------------------------------
 #   The logging record
@@ -800,9 +833,10 @@ class Handler(Filterer):
         Acquire a thread lock for serializing access to the underlying I/O.
         """
         self.lock = threading.RLock()
-        os.register_at_fork(before=self.acquire,
-                            after_in_child=self.release,
-                            after_in_parent=self.release)
+        # We put the instance itself in a single WeakSet as we MUST have only
+        # one atomic weak ref. used by both before and after atfork calls to
+        # guarantee matched pairs of acquire and release calls.
+        _at_fork_acquire_release_weakset.add(self)
 
     def acquire(self):
         """

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -227,40 +227,51 @@ def _releaseLock():
 
 
 # Prevent a held logging lock from blocking a child from logging.
-os.register_at_fork(before=_acquireLock,
-                    after_in_child=_releaseLock,
-                    after_in_parent=_releaseLock)
+
+if not hasattr(os, 'register_at_fork'):  # Windows and friends.
+    def _register_at_fork_acquire_release(instance):
+        pass  # no-op when os.register_at_fork does not exist.
+else:  # The os.register_at_fork API exists
+    os.register_at_fork(before=_acquireLock,
+                        after_in_child=_releaseLock,
+                        after_in_parent=_releaseLock)
+
+    # A collection of instances with acquire and release methods (logging.Handler)
+    # to be called before and after fork.  The weakref avoids us keeping discarded
+    # Handler instances alive forever in case an odd program creates and destroys
+    # many over its lifetime.
+    _at_fork_acquire_release_weakset = weakref.WeakSet()
 
 
-# A collection of instances with acquire and release methods (logging.Handler)
-# to be called before and after fork.  The weakref avoids us keeping discarded
-# Handler instances alive forever in case an odd program creates and destroys
-# many over its lifetime.
-_at_fork_acquire_release_weakset = weakref.WeakSet()
+    def _register_at_fork_acquire_release(instance):
+        # We put the instance itself in a single WeakSet as we MUST have only
+        # one atomic weak ref. used by both before and after atfork calls to
+        # guarantee matched pairs of acquire and release calls.
+        _at_fork_acquire_release_weakset.add(instance)
 
 
-def _at_fork_weak_calls(method_name):
-    for instance in _at_fork_acquire_release_weakset:
-        method = getattr(instance, method_name)
-        try:
-            method()
-        except Exception as err:
-            # Similar to what PyErr_WriteUnraisable does.
-            print("Ignoring exception from logging atfork", instance,
-                  method_name, "method:", err, file=sys.stderr)
+    def _at_fork_weak_calls(method_name):
+        for instance in _at_fork_acquire_release_weakset:
+            method = getattr(instance, method_name)
+            try:
+                method()
+            except Exception as err:
+                # Similar to what PyErr_WriteUnraisable does.
+                print("Ignoring exception from logging atfork", instance,
+                      method_name, "method:", err, file=sys.stderr)
 
 
-def _before_at_fork_weak_calls():
-    _at_fork_weak_calls('acquire')
+    def _before_at_fork_weak_calls():
+        _at_fork_weak_calls('acquire')
 
 
-def _after_at_fork_weak_calls():
-    _at_fork_weak_calls('release')
+    def _after_at_fork_weak_calls():
+        _at_fork_weak_calls('release')
 
 
-os.register_at_fork(before=_before_at_fork_weak_calls,
-                    after_in_child=_after_at_fork_weak_calls,
-                    after_in_parent=_after_at_fork_weak_calls)
+    os.register_at_fork(before=_before_at_fork_weak_calls,
+                        after_in_child=_after_at_fork_weak_calls,
+                        after_in_parent=_after_at_fork_weak_calls)
 
 
 #---------------------------------------------------------------------------

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -844,10 +844,7 @@ class Handler(Filterer):
         Acquire a thread lock for serializing access to the underlying I/O.
         """
         self.lock = threading.RLock()
-        # We put the instance itself in a single WeakSet as we MUST have only
-        # one atomic weak ref. used by both before and after atfork calls to
-        # guarantee matched pairs of acquire and release calls.
-        _at_fork_acquire_release_weakset.add(self)
+        _register_at_fork_acquire_release(self)
 
     def acquire(self):
         """

--- a/Misc/NEWS.d/next/Library/2018-09-13-10-09-19.bpo-6721.ZUL_F3.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-13-10-09-19.bpo-6721.ZUL_F3.rst
@@ -1,0 +1,2 @@
+Acquire the logging module's commonly used internal locks while fork()ing to
+avoid deadlocks in the child process.


### PR DESCRIPTION
This part is simple, acquire and release the logging lock and each logging handler's lock around fork.

A unittest is still needed (relatively trivial to create).

The `logging.handlers` module has a `QueueHandler` and `QueueListener` which uses the `queue` module... that is full of locks.  I'm not addressing that as I don't see an immediately obvious correct thing to do with that queue.  A QueueListener thread won't be running in the forked child anyways so the right thing for anyone using one of those is likely to remove the QueueHandler from their logging config entirely... unless they go on to re-establish their complicated queue based logging handler setup in the child.  suggestion: Do nothing.  Let people using QueueHandler deal with their own problems as their application sees fit.

<!-- issue-number: bpo-6721 -->
https://bugs.python.org/issue6721
<!-- /issue-number -->
