### PR TITLE
[3.6] bpo-28326: Fix multiprocessing.Process when stdout and/or stderr is closed or None. (GH-4073). 

### DIFF
--- a/Lib/multiprocessing/popen_fork.py
+++ b/Lib/multiprocessing/popen_fork.py
@@ -14,8 +14,14 @@ class Popen(object):
     method = 'fork'
 
     def __init__(self, process_obj):
-        sys.stdout.flush()
-        sys.stderr.flush()
+        try:
+            sys.stdout.flush()
+        except (AttributeError, ValueError):
+            pass
+        try:
+            sys.stderr.flush()
+        except (AttributeError, ValueError):
+            pass
         self.returncode = None
         self._launch(process_obj)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -425,6 +425,27 @@ class _TestProcess(BaseTestCase):
         self.assertEqual(q.get(), 5)
         close_queue(q)
 
+    @classmethod
+    def _test_error_on_stdio_flush(self, evt):
+        evt.set()
+
+    def test_error_on_stdio_flush(self):
+        streams = [io.StringIO(), None]
+        streams[0].close()
+        for stream_name in ('stdout', 'stderr'):
+            for stream in streams:
+                old_stream = getattr(sys, stream_name)
+                setattr(sys, stream_name, stream)
+                try:
+                    evt = self.Event()
+                    proc = self.Process(target=self._test_error_on_stdio_flush,
+                                        args=(evt,))
+                    proc.start()
+                    proc.join()
+                    self.assertTrue(evt.is_set())
+                finally:
+                    setattr(sys, stream_name, old_stream)
+
 
 #
 #

--- a/Misc/NEWS.d/next/Library/2017-10-22-11-06-02.bpo-28326.rxh7L4.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-22-11-06-02.bpo-28326.rxh7L4.rst
@@ -1,0 +1,1 @@
+Fix multiprocessing.Process when stdout and/or stderr is closed or None.


### PR DESCRIPTION
(cherry picked from commit daeefd2e049b74340307481112a39f77de0f4769)


<!-- issue-number: bpo-28326 -->
https://bugs.python.org/issue28326
<!-- /issue-number -->
