### PR TITLE
bpo-31653: Don't release the GIL if we can acquire a multiprocessing semaphore immediately

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-10-22-12-43-03.bpo-31653.ttfGvq.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-22-12-43-03.bpo-31653.ttfGvq.rst
@@ -1,0 +1,2 @@
+Don't release the GIL if we can acquire a multiprocessing semaphore
+immediately.

--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -304,19 +304,29 @@ semlock_acquire(SemLockObject *self, PyObject *args, PyObject *kwds)
         deadline.tv_nsec %= 1000000000;
     }
 
+    /* Check whether we can acquire without releasing the GIL and blocking */
     do {
-        Py_BEGIN_ALLOW_THREADS
-        if (blocking && timeout_obj == Py_None)
-            res = sem_wait(self->handle);
-        else if (!blocking)
-            res = sem_trywait(self->handle);
-        else
-            res = sem_timedwait(self->handle, &deadline);
-        Py_END_ALLOW_THREADS
+        res = sem_trywait(self->handle);
         err = errno;
-        if (res == MP_EXCEPTION_HAS_BEEN_SET)
-            break;
     } while (res < 0 && errno == EINTR && !PyErr_CheckSignals());
+    errno = err;
+
+    if (res < 0 && errno == EAGAIN && blocking) {
+        /* Couldn't acquire immediately, need to block */
+        do {
+            Py_BEGIN_ALLOW_THREADS
+            if (blocking && timeout_obj == Py_None)
+                res = sem_wait(self->handle);
+            else if (!blocking)
+                res = sem_trywait(self->handle);
+            else
+                res = sem_timedwait(self->handle, &deadline);
+            Py_END_ALLOW_THREADS
+            err = errno;
+            if (res == MP_EXCEPTION_HAS_BEEN_SET)
+                break;
+        } while (res < 0 && errno == EINTR && !PyErr_CheckSignals());
+    }
 
     if (res < 0) {
         errno = err;


### PR DESCRIPTION


<!-- issue-number: bpo-31653 -->
https://bugs.python.org/issue31653
<!-- /issue-number -->
