### PR TITLE
bpo-31653: Remove deadcode in semlock_acquire()

### DIFF
--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -315,12 +315,12 @@ semlock_acquire(SemLockObject *self, PyObject *args, PyObject *kwds)
         /* Couldn't acquire immediately, need to block */
         do {
             Py_BEGIN_ALLOW_THREADS
-            if (blocking && timeout_obj == Py_None)
+            if (timeout_obj == Py_None) {
                 res = sem_wait(self->handle);
-            else if (!blocking)
-                res = sem_trywait(self->handle);
-            else
+            }
+            else {
                 res = sem_timedwait(self->handle, &deadline);
+            }
             Py_END_ALLOW_THREADS
             err = errno;
             if (res == MP_EXCEPTION_HAS_BEEN_SET)


### PR DESCRIPTION
Fix the following Coverity warning:

```
>>>     CID 1420038:  Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "res = sem_trywait(self->han...".
321                     res = sem_trywait(self->handle);
```

The deadcode was introduced by the commit
c872d39d324cd6f1a71b73e10406bbaed192d35f.

<!-- issue-number: bpo-31653 -->
https://bugs.python.org/issue31653
<!-- /issue-number -->
