### PR TITLE
bpo-31854: Added mmap.ACCESS_DEFAULT to namespace.

### DIFF
--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -29,16 +29,20 @@ still needs to be closed when done).
    mapping.
 
 For both the Unix and Windows versions of the constructor, *access* may be
-specified as an optional keyword parameter. *access* accepts one of three
-values: :const:`ACCESS_READ`, :const:`ACCESS_WRITE`, or :const:`ACCESS_COPY`
-to specify read-only, write-through or copy-on-write memory respectively.
-*access* can be used on both Unix and Windows.  If *access* is not specified,
-Windows mmap returns a write-through mapping.  The initial memory values for
-all three access types are taken from the specified file.  Assignment to an
-:const:`ACCESS_READ` memory map raises a :exc:`TypeError` exception.
-Assignment to an :const:`ACCESS_WRITE` memory map affects both memory and the
-underlying file.  Assignment to an :const:`ACCESS_COPY` memory map affects
-memory but does not update the underlying file.
+specified as an optional keyword parameter. *access* accepts one of four
+values: :const:`ACCESS_READ`, :const:`ACCESS_WRITE`, or :const:`ACCESS_COPY` to
+specify read-only, write-through or copy-on-write memory respectively, or
+:const:`ACCESS_DEFAULT` to defer to *prot*.  *access* can be used on both Unix
+and Windows.  If *access* is not specified, Windows mmap returns a
+write-through mapping.  The initial memory values for all three access types
+are taken from the specified file.  Assignment to an :const:`ACCESS_READ`
+memory map raises a :exc:`TypeError` exception.  Assignment to an
+:const:`ACCESS_WRITE` memory map affects both memory and the underlying file.
+Assignment to an :const:`ACCESS_COPY` memory map affects memory but does not
+update the underlying file.
+
+.. versionchanged:: 3.7
+   Added :const:`ACCESS_DEFAULT` constant.
 
 To map anonymous memory, -1 should be passed as the fileno along with the length.
 

--- a/Misc/NEWS.d/next/Library/2017-10-23.bpo-31854.fh8334f.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-23.bpo-31854.fh8334f.rst
@@ -1,0 +1,1 @@
+Add ``mmap.ACCESS_DEFAULT`` constant.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1466,6 +1466,7 @@ PyInit_mmap(void)
 
     setint(dict, "ALLOCATIONGRANULARITY", (long)my_getallocationgranularity());
 
+    setint(dict, "ACCESS_DEFAULT", ACCESS_DEFAULT);
     setint(dict, "ACCESS_READ", ACCESS_READ);
     setint(dict, "ACCESS_WRITE", ACCESS_WRITE);
     setint(dict, "ACCESS_COPY", ACCESS_COPY);


### PR DESCRIPTION
This request adds `mmap.ACCESS_DEFAULT` into the namespace.  Accessing the default value might be necessary, if one needs to overwrite an `ACCESS` keyword argument.

I have that situation in numpy.memap, and currently just overwrite by `access=0` (=mmap.ACCESS_DEFAULT) if needed.  However, it would be better to track  `enum access_mode`.

<!-- issue-number: bpo-31854 -->
https://bugs.python.org/issue31854
<!-- /issue-number -->
