### PR TITLE
No issue #: Fix wording about Py_tss_NEEDS_INIT in docs

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1246,7 +1246,7 @@ CPython interpreter.  This API uses a new type :c:type:`Py_tss_t` instead of
 
 .. c:macro:: Py_tss_NEEDS_INIT
 
-   This macro expands to the default value for :c:type:`Py_tss_t` variables.
+   This macro expands to the initializer for :c:type:`Py_tss_t` variables.
    Note that this macro won't be defined with :ref:`Py_LIMITED_API <stable>`.
 
 


### PR DESCRIPTION
Docs-only change, replacing the word "default value" with "initializer" making more sense.
This change has been mentioned at [bpo-31828](https://bugs.python.org/issue31828), but not relate directly.

Related PR: https://github.com/python/peps/pull/436