### PR TITLE
remove support for splitting the ceval switch into multiple switches

### DIFF
--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -22,9 +22,6 @@
 
 #include <ctype.h>
 
-/* Turn this on if your compiler chokes on the big switch: */
-/* #define CASE_TOO_BIG 1 */
-
 #ifdef Py_DEBUG
 /* For debugging the interpreter: */
 #define LLTRACE  1      /* Low-level trace feature */
@@ -1662,9 +1659,6 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
             DISPATCH();
         }
 
-#ifdef CASE_TOO_BIG
-        default: switch (opcode) {
-#endif
         TARGET(RAISE_VARARGS) {
             PyObject *cause = NULL, *exc = NULL;
             switch (oparg) {
@@ -3372,10 +3366,6 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
                 opcode);
             PyErr_SetString(PyExc_SystemError, "unknown opcode");
             goto error;
-
-#ifdef CASE_TOO_BIG
-        }
-#endif
 
         } /* switch */
 


### PR DESCRIPTION
This kludge is from 1992 04691fc1c1b. Any C99 compiler is going to be able to handle the
ceval dispatch switch.

Anyway, we have much bigger switches than the ceval dispatch one around. (See,
e.g., Objects/unicodetype_db.h.)