### PR TITLE
bpo-31845: Fix reading flags from environment

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-24-21-27-32.bpo-31845.8OS-k3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-24-21-27-32.bpo-31845.8OS-k3.rst
@@ -1,0 +1,1 @@
+Environment variables are once more read correctly at interpreter startup.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -522,39 +522,33 @@ read_command_line(int argc, wchar_t **argv, _Py_CommandLineDetails *cmdline)
     return 0;
 }
 
+static void
+maybe_set_flag(int *flag, int value)
+{
+    /* Helper to set flag variables from command line options
+    *   - uses the higher of the two values if they're both set
+    *   - otherwise leaves the flag unset
+    */
+    if (*flag < value) {
+        *flag = value;
+    }
+}
+
 static int
 apply_command_line_and_environment(_Py_CommandLineDetails *cmdline)
 {
-    char *p;
-    Py_BytesWarningFlag = cmdline->bytes_warning;
-    Py_DebugFlag = cmdline->debug;
-    Py_InspectFlag = cmdline->inspect;
-    Py_InteractiveFlag = cmdline->interactive;
-    Py_IsolatedFlag = cmdline->isolated;
-    Py_OptimizeFlag = cmdline->optimization_level;
-    Py_DontWriteBytecodeFlag = cmdline->dont_write_bytecode;
-    Py_NoUserSiteDirectory = cmdline->no_user_site_directory;
-    Py_NoSiteFlag = cmdline->no_site_import;
-    Py_UnbufferedStdioFlag = cmdline->use_unbuffered_io;
-    Py_VerboseFlag = cmdline->verbosity;
-    Py_QuietFlag = cmdline->quiet_flag;
-
-    if (!Py_InspectFlag &&
-        (p = Py_GETENV("PYTHONINSPECT")) && *p != '\0') {
-        Py_InspectFlag = 1;
-        cmdline->inspect = 1;
-    }
-    if (!cmdline->use_unbuffered_io &&
-        (p = Py_GETENV("PYTHONUNBUFFERED")) && *p != '\0') {
-        Py_UnbufferedStdioFlag = 1;
-        cmdline->use_unbuffered_io = 1;
-    }
-
-    if (!Py_NoUserSiteDirectory &&
-        (p = Py_GETENV("PYTHONNOUSERSITE")) && *p != '\0') {
-        Py_NoUserSiteDirectory = 1;
-        cmdline->no_user_site_directory = 1;
-    }
+    maybe_set_flag(&Py_BytesWarningFlag, cmdline->bytes_warning);
+    maybe_set_flag(&Py_DebugFlag, cmdline->debug);
+    maybe_set_flag(&Py_InspectFlag, cmdline->inspect);
+    maybe_set_flag(&Py_InteractiveFlag, cmdline->interactive);
+    maybe_set_flag(&Py_IsolatedFlag, cmdline->isolated);
+    maybe_set_flag(&Py_OptimizeFlag, cmdline->optimization_level);
+    maybe_set_flag(&Py_DontWriteBytecodeFlag, cmdline->dont_write_bytecode);
+    maybe_set_flag(&Py_NoUserSiteDirectory, cmdline->no_user_site_directory);
+    maybe_set_flag(&Py_NoSiteFlag, cmdline->no_site_import);
+    maybe_set_flag(&Py_UnbufferedStdioFlag, cmdline->use_unbuffered_io);
+    maybe_set_flag(&Py_VerboseFlag, cmdline->verbosity);
+    maybe_set_flag(&Py_QuietFlag, cmdline->quiet_flag);
 
     /* TODO: Apply PYTHONWARNINGS & -W options to sys module here */
     /* TODO: Apply -X options to sys module here */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -217,15 +217,18 @@ Py_SetStandardStreamEncoding(const char *encoding, const char *errors)
 
 */
 
-static int
-add_flag(int flag, const char *envs)
+static void
+set_flag(int *flag, const char *envs)
 {
+    /* Helper to set flag variables from environment variables:
+    *   - uses the higher of the two values if they're both set
+    *   - otherwise sets the flag to 1
+    */
     int env = atoi(envs);
-    if (flag < env)
-        flag = env;
-    if (flag < 1)
-        flag = 1;
-    return flag;
+    if (*flag < env)
+        *flag = env;
+    if (*flag < 1)
+        *flag = 1;
 }
 
 static char*
@@ -612,22 +615,28 @@ void _Py_InitializeCore(const _PyCoreConfig *config)
 #endif
 
     if ((p = Py_GETENV("PYTHONDEBUG")) && *p != '\0')
-        Py_DebugFlag = add_flag(Py_DebugFlag, p);
+        set_flag(&Py_DebugFlag, p);
     if ((p = Py_GETENV("PYTHONVERBOSE")) && *p != '\0')
-        Py_VerboseFlag = add_flag(Py_VerboseFlag, p);
+        set_flag(&Py_VerboseFlag, p);
     if ((p = Py_GETENV("PYTHONOPTIMIZE")) && *p != '\0')
-        Py_OptimizeFlag = add_flag(Py_OptimizeFlag, p);
+        set_flag(&Py_OptimizeFlag, p);
+    if ((p = Py_GETENV("PYTHONINSPECT")) && *p != '\0')
+        set_flag(&Py_InspectFlag, p);
     if ((p = Py_GETENV("PYTHONDONTWRITEBYTECODE")) && *p != '\0')
-        Py_DontWriteBytecodeFlag = add_flag(Py_DontWriteBytecodeFlag, p);
+        set_flag(&Py_DontWriteBytecodeFlag, p);
+    if ((p = Py_GETENV("PYTHONNOUSERSITE")) && *p != '\0')
+        set_flag(&Py_NoUserSiteDirectory, p);
+    if ((p = Py_GETENV("PYTHONUNBUFFERED")) && *p != '\0')
+        set_flag(&Py_UnbufferedStdioFlag, p);
     /* The variable is only tested for existence here;
        _Py_HashRandomization_Init will check its value further. */
     if ((p = Py_GETENV("PYTHONHASHSEED")) && *p != '\0')
-        Py_HashRandomizationFlag = add_flag(Py_HashRandomizationFlag, p);
+        set_flag(&Py_HashRandomizationFlag, p);
 #ifdef MS_WINDOWS
     if ((p = Py_GETENV("PYTHONLEGACYWINDOWSFSENCODING")) && *p != '\0')
-        Py_LegacyWindowsFSEncodingFlag = add_flag(Py_LegacyWindowsFSEncodingFlag, p);
+        set_flag(&Py_LegacyWindowsFSEncodingFlag, p);
     if ((p = Py_GETENV("PYTHONLEGACYWINDOWSSTDIO")) && *p != '\0')
-        Py_LegacyWindowsStdioFlag = add_flag(Py_LegacyWindowsStdioFlag, p);
+        set_flag(&Py_LegacyWindowsStdioFlag, p);
 #endif
 
     _Py_HashRandomization_Init(&core_config);


### PR DESCRIPTION
The startup refactoring means command line settings
are now applied after settings are read from the
environment.

This updates the way command line settings are applied
to account for that, ensures more settings are first read
from the environment in _PyInitializeCore, and adds a
simple test case covering the flags that are easy to check.


<!-- issue-number: bpo-31845 -->
https://bugs.python.org/issue31845
<!-- /issue-number -->
