### PR TITLE
[2.7] bpo-25287: Improve test_crypt and skip it on OpenBSD. (GH-4111).

### DIFF
--- a/Lib/test/test_crypt.py
+++ b/Lib/test/test_crypt.py
@@ -1,14 +1,20 @@
+import sys
 from test import test_support
 import unittest
 
 crypt = test_support.import_module('crypt')
 
+if sys.platform.startswith('openbsd'):
+    raise unittest.SkipTest('The only supported method on OpenBSD is Blowfish')
+
 class CryptTestCase(unittest.TestCase):
 
     def test_crypt(self):
-        c = crypt.crypt('mypassword', 'ab')
-        if test_support.verbose:
-            print 'Test encryption: ', c
+        cr = crypt.crypt('mypassword', 'ab')
+        if cr is not None:
+            cr2 = crypt.crypt('mypassword', cr)
+            self.assertEqual(cr2, cr)
+
 
 def test_main():
     test_support.run_unittest(CryptTestCase)


### PR DESCRIPTION
(cherry picked from commit f52dff611cff2fb9e90340b4787eda50ab2d40c6)


<!-- issue-number: bpo-25287 -->
https://bugs.python.org/issue25287
<!-- /issue-number -->
