### PR TITLE
fix marshal uninitialized variable warnings

### DIFF
--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -465,6 +465,9 @@ PyMarshal_WriteLongToFile(long x, FILE *fp, int version)
 {
     WFILE wf;
     wf.fp = fp;
+    wf.str = NULL;
+    wf.ptr = NULL;
+    wf.end = NULL;
     wf.error = WFERR_OK;
     wf.depth = 0;
     wf.strings = NULL;
@@ -477,6 +480,9 @@ PyMarshal_WriteObjectToFile(PyObject *x, FILE *fp, int version)
 {
     WFILE wf;
     wf.fp = fp;
+    wf.str = NULL;
+    wf.ptr = NULL;
+    wf.end = NULL;
     wf.error = WFERR_OK;
     wf.depth = 0;
     wf.strings = (version > 0) ? PyDict_New() : NULL;


### PR DESCRIPTION
GCC says:
../cpython/Python/marshal.c: In function ‘PyMarshal_WriteLongToFile’:
../cpython/Python/marshal.c:70:35: warning: ‘wf.ptr’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                       else if ((p)->ptr != (p)->end) *(p)->ptr++ = (c); \
                                   ^~
../cpython/Python/marshal.c:70:47: warning: ‘wf.end’ may be used uninitialized in this function [-Wmaybe-uninitialized]
                       else if ((p)->ptr != (p)->end) *(p)->ptr++ = (c); \
                                               ^~
../cpython/Python/marshal.c:77:10: warning: ‘wf.str’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     if (p->str == NULL)
         ~^~~~~

This isn't a real problem because if the file pointer is not NULL, the
string-related fields are never touched. But, it doesn't hurt to set the unused
fields to NULL.
