### PR TITLE
bpo-20180: use Argument Clinic in itertools module where appropriate

### DIFF
--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -6,7 +6,7 @@ PyDoc_STRVAR(itertools_groupby__doc__,
 "groupby(iterable, key=None)\n"
 "--\n"
 "\n"
-"Create a groupby object.\n"
+"Return an iterator of groups of items as (key, group) pairs.\n"
 "\n"
 "  iterable\n"
 "    Elements to divide into groups according to the key function.\n"
@@ -14,20 +14,11 @@ PyDoc_STRVAR(itertools_groupby__doc__,
 "    Function computing a key value for each element.\n"
 "    If None, the elements themselves are used for grouping.\n"
 "\n"
-"This makes an iterator of (key, sub-iterator) pairs. In each such pair, the\n"
-"sub-iterator is a group of consecutive elements from the input iterable which\n"
-"all have the same key. The common key for the group is the first item in the\n"
-"pair.\n"
+"This groups together consecutive items from the given iterator.  Each group\n"
+"contains items for which the key gives the same result.\n"
 "\n"
-"Example:\n"
-">>> # group numbers by their absolute value\n"
-">>> elements = [1, -1, 2, 1]\n"
-">>> for (key, group) in itertools.groupby(elements, key=abs):\n"
-"...     print(\'key={} group={}\'.format(key, list(group)))\n"
-"...\n"
-"key=1 group=[1, -1]\n"
-"key=2 group=[2]\n"
-"key=1 group=[1]");
+"For each group, a (key, group) 2-tuple is yielded, where \"key\" is the common\n"
+"key value for the group and \"group\" is an iterator of the items in the group.");
 
 static PyObject *
 itertools_groupby_impl(PyTypeObject *type, PyObject *iterable, PyObject *key);
@@ -502,7 +493,7 @@ PyDoc_STRVAR(itertools_starmap__doc__,
 "Create a starmap object.\n"
 "\n"
 "Return an iterator whose values are returned from the function evaluated\n"
-"with a argument tuple taken from the given iterable.");
+"with argument tuples taken from the given iterable.");
 
 static PyObject *
 itertools_starmap_impl(PyTypeObject *type, PyObject *function,
@@ -554,7 +545,7 @@ PyDoc_STRVAR(itertools_chain_from_iterable__doc__,
 "\n"
 "Create a chain object.\n"
 "\n"
-"Alternate chain() contructor taking a single iterable argument\n"
+"Alternative chain() constructor taking a single iterable argument\n"
 "that evaluates lazily.");
 
 #define ITERTOOLS_CHAIN_FROM_ITERABLE_METHODDEF    \
@@ -1037,9 +1028,8 @@ PyDoc_STRVAR(itertools_count__doc__,
 "count(start=0, step=1)\n"
 "--\n"
 "\n"
-"Create a count object.\n"
+"Return an iterator which returns consecutive values.\n"
 "\n"
-"Return a count object whose .__next__() method returns consecutive values.\n"
 "Equivalent to:\n"
 "\n"
 "    def count(firstval=0, step=1):\n"
@@ -1093,7 +1083,7 @@ PyDoc_STRVAR(itertools_repeat___length_hint____doc__,
 "__length_hint__($self, /)\n"
 "--\n"
 "\n"
-"Private method returning an estimate of len(list(it)).");
+"Private method returning an estimate of len(list(self)).");
 
 #define ITERTOOLS_REPEAT___LENGTH_HINT___METHODDEF    \
     {"__length_hint__", (PyCFunction)itertools_repeat___length_hint__, METH_NOARGS, itertools_repeat___length_hint____doc__},
@@ -1151,4 +1141,4 @@ PyDoc_STRVAR(itertools_zip_longest___setstate____doc__,
 
 #define ITERTOOLS_ZIP_LONGEST___SETSTATE___METHODDEF    \
     {"__setstate__", (PyCFunction)itertools_zip_longest___setstate__, METH_O, itertools_zip_longest___setstate____doc__},
-/*[clinic end generated code: output=76fca89a64f5cd41 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c5bfdde0d01522db input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -1,0 +1,1142 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(groupby_new__doc__,
+"groupby(iterable, key=None)\n"
+"--\n"
+"\n"
+"Create a groupby object.\n"
+"\n"
+"  iterable\n"
+"    Elements to divide into groups according to the key function.\n"
+"  key\n"
+"    Function computing a key value for each element.\n"
+"    If None, the elements themselves are used for grouping.\n"
+"\n"
+"This makes an iterator of (key, sub-iterator) pairs. In each such pair, the\n"
+"sub-iterator is a group of consecutive elements from the input iterable which\n"
+"all have the same key. The common key for the group is the first item in the\n"
+"pair.\n"
+"\n"
+"Example:\n"
+">>> # group numbers by their absolute value\n"
+">>> elements = [1, -1, 2, 1]\n"
+">>> for (key, group) in itertools.groupby(elements, key=abs):\n"
+"...     print(\'key={} group={}\'.format(key, list(group)))\n"
+"...\n"
+"key=1 group=[1, -1]\n"
+"key=2 group=[2]\n"
+"key=1 group=[1]");
+
+static PyObject *
+groupby_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *key);
+
+static PyObject *
+groupby_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "key", NULL};
+    static _PyArg_Parser _parser = {"O|O:groupby", _keywords, 0};
+    PyObject *iterable;
+    PyObject *key = Py_None;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &iterable, &key)) {
+        goto exit;
+    }
+    return_value = groupby_new_impl(type, iterable, key);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(groupby_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define GROUPBY_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)groupby_reduce, METH_NOARGS, groupby_reduce__doc__},
+
+static PyObject *
+groupby_reduce_impl(groupbyobject *lz);
+
+static PyObject *
+groupby_reduce(groupbyobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return groupby_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(groupby_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define GROUPBY_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)groupby_setstate, METH_O, groupby_setstate__doc__},
+
+static PyObject *
+_grouper_new_impl(PyTypeObject *type, PyObject *parent, PyObject *tgtkey);
+
+static PyObject *
+_grouper_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *parent;
+    PyObject *tgtkey;
+
+    if ((type == &_grouper_type) &&
+        !_PyArg_NoKeywords("_grouper", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_ParseTuple(args, "O!O:_grouper",
+        &groupby_type, &parent, &tgtkey)) {
+        goto exit;
+    }
+    return_value = _grouper_new_impl(type, parent, tgtkey);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(_grouper_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define _GROUPER_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)_grouper_reduce, METH_NOARGS, _grouper_reduce__doc__},
+
+static PyObject *
+_grouper_reduce_impl(_grouperobject *lz);
+
+static PyObject *
+_grouper_reduce(_grouperobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return _grouper_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(teedataobject_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define TEEDATAOBJECT_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)teedataobject_reduce, METH_NOARGS, teedataobject_reduce__doc__},
+
+static PyObject *
+teedataobject_reduce_impl(teedataobject *tdo);
+
+static PyObject *
+teedataobject_reduce(teedataobject *tdo, PyObject *Py_UNUSED(ignored))
+{
+    return teedataobject_reduce_impl(tdo);
+}
+
+PyDoc_STRVAR(teedataobject_new__doc__,
+"teedataobject(iterable, values, next, /)\n"
+"--\n"
+"\n"
+"Data container common to multiple tee objects.");
+
+static PyObject *
+teedataobject_new_impl(PyTypeObject *type, PyObject *iterable,
+                       PyObject *values, PyObject *next);
+
+static PyObject *
+teedataobject_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *iterable;
+    PyObject *values;
+    PyObject *next;
+
+    if ((type == &teedataobject_type) &&
+        !_PyArg_NoKeywords("teedataobject", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_ParseTuple(args, "OO!O:teedataobject",
+        &iterable, &PyList_Type, &values, &next)) {
+        goto exit;
+    }
+    return_value = teedataobject_new_impl(type, iterable, values, next);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(tee_copy__doc__,
+"__copy__($self, /)\n"
+"--\n"
+"\n"
+"Returns an independent iterator.");
+
+#define TEE_COPY_METHODDEF    \
+    {"__copy__", (PyCFunction)tee_copy, METH_NOARGS, tee_copy__doc__},
+
+static PyObject *
+tee_copy_impl(teeobject *to);
+
+static PyObject *
+tee_copy(teeobject *to, PyObject *Py_UNUSED(ignored))
+{
+    return tee_copy_impl(to);
+}
+
+PyDoc_STRVAR(tee_new__doc__,
+"_tee(iterable, /)\n"
+"--\n"
+"\n"
+"Create a _tee object.\n"
+"\n"
+"An iterator wrapped to make it copyable.");
+
+static PyObject *
+tee_new_impl(PyTypeObject *type, PyObject *iterable);
+
+static PyObject *
+tee_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *iterable;
+
+    if ((type == &tee_type) &&
+        !_PyArg_NoKeywords("_tee", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "_tee",
+        1, 1,
+        &iterable)) {
+        goto exit;
+    }
+    return_value = tee_new_impl(type, iterable);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(tee_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define TEE_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)tee_reduce, METH_NOARGS, tee_reduce__doc__},
+
+static PyObject *
+tee_reduce_impl(teeobject *to);
+
+static PyObject *
+tee_reduce(teeobject *to, PyObject *Py_UNUSED(ignored))
+{
+    return tee_reduce_impl(to);
+}
+
+PyDoc_STRVAR(tee_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define TEE_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)tee_setstate, METH_O, tee_setstate__doc__},
+
+PyDoc_STRVAR(tee__doc__,
+"tee($module, iterable, n=2, /)\n"
+"--\n"
+"\n"
+"Returns a tuple of n independent iterators from a single iterable.\n"
+"\n"
+"  n\n"
+"    number of independent iterators to return\n"
+"\n"
+"Once this has been called, the original iterable should not be used anywhere\n"
+"else; otherwise, the iterable could get advanced without the tee objects (those\n"
+"in the returned tuple) being informed.");
+
+#define TEE_METHODDEF    \
+    {"tee", (PyCFunction)tee, METH_FASTCALL, tee__doc__},
+
+static PyObject *
+tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n);
+
+static PyObject *
+tee(PyObject *module, PyObject **args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *iterable;
+    Py_ssize_t n = 2;
+
+    if (!_PyArg_ParseStack(args, nargs, "O|n:tee",
+        &iterable, &n)) {
+        goto exit;
+    }
+    return_value = tee_impl(module, iterable, n);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(cycle_new__doc__,
+"cycle(iterable, /)\n"
+"--\n"
+"\n"
+"Create a cycle object.\n"
+"\n"
+"This object will return elements from the iterable until it is exhausted.\n"
+"Then it will repeat the sequence indefinitely.");
+
+static PyObject *
+cycle_new_impl(PyTypeObject *type, PyObject *iterable);
+
+static PyObject *
+cycle_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *iterable;
+
+    if ((type == &cycle_type) &&
+        !_PyArg_NoKeywords("cycle", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "cycle",
+        1, 1,
+        &iterable)) {
+        goto exit;
+    }
+    return_value = cycle_new_impl(type, iterable);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(cycle_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define CYCLE_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)cycle_reduce, METH_NOARGS, cycle_reduce__doc__},
+
+static PyObject *
+cycle_reduce_impl(cycleobject *lz);
+
+static PyObject *
+cycle_reduce(cycleobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return cycle_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(cycle_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define CYCLE_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)cycle_setstate, METH_O, cycle_setstate__doc__},
+
+PyDoc_STRVAR(dropwhile_new__doc__,
+"dropwhile(predicate, iterable, /)\n"
+"--\n"
+"\n"
+"Create a dropwhile object.\n"
+"\n"
+"Drops items from the iterable while predicate(item) is true.\n"
+"Afterwards, returns every element until the iterable is exhausted.");
+
+static PyObject *
+dropwhile_new_impl(PyTypeObject *type, PyObject *predicate,
+                   PyObject *iterable);
+
+static PyObject *
+dropwhile_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *predicate;
+    PyObject *iterable;
+
+    if ((type == &dropwhile_type) &&
+        !_PyArg_NoKeywords("dropwhile", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "dropwhile",
+        2, 2,
+        &predicate, &iterable)) {
+        goto exit;
+    }
+    return_value = dropwhile_new_impl(type, predicate, iterable);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(dropwhile_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define DROPWHILE_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)dropwhile_reduce, METH_NOARGS, dropwhile_reduce__doc__},
+
+static PyObject *
+dropwhile_reduce_impl(dropwhileobject *lz);
+
+static PyObject *
+dropwhile_reduce(dropwhileobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return dropwhile_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(dropwhile_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define DROPWHILE_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)dropwhile_setstate, METH_O, dropwhile_setstate__doc__},
+
+PyDoc_STRVAR(takewhile_new__doc__,
+"takewhile(predicate, iterable, /)\n"
+"--\n"
+"\n"
+"Create a takewhile object.\n"
+"\n"
+"Return successive entries from an iterable as long as the\n"
+"predicate evaluates to true for each entry.");
+
+static PyObject *
+takewhile_new_impl(PyTypeObject *type, PyObject *predicate,
+                   PyObject *iterable);
+
+static PyObject *
+takewhile_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *predicate;
+    PyObject *iterable;
+
+    if ((type == &takewhile_type) &&
+        !_PyArg_NoKeywords("takewhile", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "takewhile",
+        2, 2,
+        &predicate, &iterable)) {
+        goto exit;
+    }
+    return_value = takewhile_new_impl(type, predicate, iterable);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(takewhile_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define TAKEWHILE_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)takewhile_reduce, METH_NOARGS, takewhile_reduce__doc__},
+
+static PyObject *
+takewhile_reduce_impl(takewhileobject *lz);
+
+static PyObject *
+takewhile_reduce(takewhileobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return takewhile_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(takewhile_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define TAKEWHILE_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)takewhile_setstate, METH_O, takewhile_setstate__doc__},
+
+PyDoc_STRVAR(islice_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define ISLICE_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)islice_reduce, METH_NOARGS, islice_reduce__doc__},
+
+static PyObject *
+islice_reduce_impl(isliceobject *lz);
+
+static PyObject *
+islice_reduce(isliceobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return islice_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(islice_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define ISLICE_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)islice_setstate, METH_O, islice_setstate__doc__},
+
+PyDoc_STRVAR(starmap_new__doc__,
+"starmap(function, iterable)\n"
+"--\n"
+"\n"
+"Create a starmap object.\n"
+"\n"
+"Return an iterator whose values are returned from the function evaluated\n"
+"with a argument tuple taken from the given iterable.");
+
+static PyObject *
+starmap_new_impl(PyTypeObject *type, PyObject *function, PyObject *iterable);
+
+static PyObject *
+starmap_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"function", "iterable", NULL};
+    static _PyArg_Parser _parser = {"OO:starmap", _keywords, 0};
+    PyObject *function;
+    PyObject *iterable;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &function, &iterable)) {
+        goto exit;
+    }
+    return_value = starmap_new_impl(type, function, iterable);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(starmap_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define STARMAP_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)starmap_reduce, METH_NOARGS, starmap_reduce__doc__},
+
+static PyObject *
+starmap_reduce_impl(starmapobject *lz);
+
+static PyObject *
+starmap_reduce(starmapobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return starmap_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(chain_new_from_iterable__doc__,
+"from_iterable($type, iterable, /)\n"
+"--\n"
+"\n"
+"Create a chain object.\n"
+"\n"
+"Alternate chain() contructor taking a single iterable argument\n"
+"that evaluates lazily.");
+
+#define CHAIN_NEW_FROM_ITERABLE_METHODDEF    \
+    {"from_iterable", (PyCFunction)chain_new_from_iterable, METH_O|METH_CLASS, chain_new_from_iterable__doc__},
+
+PyDoc_STRVAR(chain_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define CHAIN_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)chain_reduce, METH_NOARGS, chain_reduce__doc__},
+
+static PyObject *
+chain_reduce_impl(chainobject *lz);
+
+static PyObject *
+chain_reduce(chainobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return chain_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(chain_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define CHAIN_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)chain_setstate, METH_O, chain_setstate__doc__},
+
+PyDoc_STRVAR(product_sizeof__doc__,
+"__sizeof__($self, /)\n"
+"--\n"
+"\n"
+"Returns size in memory, in bytes.");
+
+#define PRODUCT_SIZEOF_METHODDEF    \
+    {"__sizeof__", (PyCFunction)product_sizeof, METH_NOARGS, product_sizeof__doc__},
+
+static PyObject *
+product_sizeof_impl(productobject *lz);
+
+static PyObject *
+product_sizeof(productobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return product_sizeof_impl(lz);
+}
+
+PyDoc_STRVAR(product_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define PRODUCT_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)product_reduce, METH_NOARGS, product_reduce__doc__},
+
+static PyObject *
+product_reduce_impl(productobject *lz);
+
+static PyObject *
+product_reduce(productobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return product_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(product_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define PRODUCT_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)product_setstate, METH_O, product_setstate__doc__},
+
+PyDoc_STRVAR(combinations_new__doc__,
+"combinations(iterable, r)\n"
+"--\n"
+"\n"
+"Create a combinations object.\n"
+"\n"
+"Returns successive r-length combinations of elements in the iterable.\n"
+"\n"
+"Example:\n"
+"combinations(range(4), 3) --> (0,1,2), (0,1,3), (0,2,3), (1,2,3)");
+
+static PyObject *
+combinations_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t r);
+
+static PyObject *
+combinations_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "r", NULL};
+    static _PyArg_Parser _parser = {"On:combinations", _keywords, 0};
+    PyObject *iterable;
+    Py_ssize_t r;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &iterable, &r)) {
+        goto exit;
+    }
+    return_value = combinations_new_impl(type, iterable, r);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(combinations_sizeof__doc__,
+"__sizeof__($self, /)\n"
+"--\n"
+"\n"
+"Returns size in memory, in bytes.");
+
+#define COMBINATIONS_SIZEOF_METHODDEF    \
+    {"__sizeof__", (PyCFunction)combinations_sizeof, METH_NOARGS, combinations_sizeof__doc__},
+
+static PyObject *
+combinations_sizeof_impl(combinationsobject *co);
+
+static PyObject *
+combinations_sizeof(combinationsobject *co, PyObject *Py_UNUSED(ignored))
+{
+    return combinations_sizeof_impl(co);
+}
+
+PyDoc_STRVAR(combinations_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define COMBINATIONS_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)combinations_reduce, METH_NOARGS, combinations_reduce__doc__},
+
+static PyObject *
+combinations_reduce_impl(combinationsobject *lz);
+
+static PyObject *
+combinations_reduce(combinationsobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return combinations_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(combinations_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define COMBINATIONS_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)combinations_setstate, METH_O, combinations_setstate__doc__},
+
+PyDoc_STRVAR(cwr_new__doc__,
+"combinations_with_replacement(iterable, r)\n"
+"--\n"
+"\n"
+"Create a combinations object.\n"
+"\n"
+"Returns successive r-length combinations of elements in the iterable allowing\n"
+"individual elements to have successive repeats.\n"
+"\n"
+"Example:\n"
+"combinations_with_replacement(\'ABC\', 2) --> AA AB AC BB BC CC");
+
+static PyObject *
+cwr_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t r);
+
+static PyObject *
+cwr_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "r", NULL};
+    static _PyArg_Parser _parser = {"On:combinations_with_replacement", _keywords, 0};
+    PyObject *iterable;
+    Py_ssize_t r;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &iterable, &r)) {
+        goto exit;
+    }
+    return_value = cwr_new_impl(type, iterable, r);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(cwr_sizeof__doc__,
+"__sizeof__($self, /)\n"
+"--\n"
+"\n"
+"Returns size in memory, in bytes.");
+
+#define CWR_SIZEOF_METHODDEF    \
+    {"__sizeof__", (PyCFunction)cwr_sizeof, METH_NOARGS, cwr_sizeof__doc__},
+
+static PyObject *
+cwr_sizeof_impl(cwrobject *co);
+
+static PyObject *
+cwr_sizeof(cwrobject *co, PyObject *Py_UNUSED(ignored))
+{
+    return cwr_sizeof_impl(co);
+}
+
+PyDoc_STRVAR(cwr_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define CWR_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)cwr_reduce, METH_NOARGS, cwr_reduce__doc__},
+
+static PyObject *
+cwr_reduce_impl(cwrobject *lz);
+
+static PyObject *
+cwr_reduce(cwrobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return cwr_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(cwr_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define CWR_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)cwr_setstate, METH_O, cwr_setstate__doc__},
+
+PyDoc_STRVAR(permutations_new__doc__,
+"permutations(iterable, r=None)\n"
+"--\n"
+"\n"
+"Create a permutations object.\n"
+"\n"
+"Returns successive r-length permutations of elements in the iterable.\n"
+"\n"
+"Example:\n"
+"permutations(range(3), 2) --> (0,1), (0,2), (1,0), (1,2), (2,0), (2,1)");
+
+static PyObject *
+permutations_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *robj);
+
+static PyObject *
+permutations_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "r", NULL};
+    static _PyArg_Parser _parser = {"O|O:permutations", _keywords, 0};
+    PyObject *iterable;
+    PyObject *robj = Py_None;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &iterable, &robj)) {
+        goto exit;
+    }
+    return_value = permutations_new_impl(type, iterable, robj);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(permutations_sizeof__doc__,
+"__sizeof__($self, /)\n"
+"--\n"
+"\n"
+"Returns size in memory, in bytes.");
+
+#define PERMUTATIONS_SIZEOF_METHODDEF    \
+    {"__sizeof__", (PyCFunction)permutations_sizeof, METH_NOARGS, permutations_sizeof__doc__},
+
+static PyObject *
+permutations_sizeof_impl(permutationsobject *po);
+
+static PyObject *
+permutations_sizeof(permutationsobject *po, PyObject *Py_UNUSED(ignored))
+{
+    return permutations_sizeof_impl(po);
+}
+
+PyDoc_STRVAR(permutations_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define PERMUTATIONS_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)permutations_reduce, METH_NOARGS, permutations_reduce__doc__},
+
+static PyObject *
+permutations_reduce_impl(permutationsobject *po);
+
+static PyObject *
+permutations_reduce(permutationsobject *po, PyObject *Py_UNUSED(ignored))
+{
+    return permutations_reduce_impl(po);
+}
+
+PyDoc_STRVAR(permutations_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define PERMUTATIONS_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)permutations_setstate, METH_O, permutations_setstate__doc__},
+
+PyDoc_STRVAR(accumulate_new__doc__,
+"accumulate(iterable, func=None)\n"
+"--\n"
+"\n"
+"Create an accumulate object.\n"
+"\n"
+"Return series of accumulated sums (or other binary function results).");
+
+static PyObject *
+accumulate_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *func);
+
+static PyObject *
+accumulate_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "func", NULL};
+    static _PyArg_Parser _parser = {"O|O:accumulate", _keywords, 0};
+    PyObject *iterable;
+    PyObject *func = Py_None;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &iterable, &func)) {
+        goto exit;
+    }
+    return_value = accumulate_new_impl(type, iterable, func);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(accumulate_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define ACCUMULATE_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)accumulate_reduce, METH_NOARGS, accumulate_reduce__doc__},
+
+static PyObject *
+accumulate_reduce_impl(accumulateobject *lz);
+
+static PyObject *
+accumulate_reduce(accumulateobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return accumulate_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(accumulate_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define ACCUMULATE_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)accumulate_setstate, METH_O, accumulate_setstate__doc__},
+
+PyDoc_STRVAR(compress_new__doc__,
+"compress(data, selectors)\n"
+"--\n"
+"\n"
+"Create a compress object.\n"
+"\n"
+"Return data elements corresponding to true selector elements.\n"
+"Forms a shorter iterator from selected data elements using the\n"
+"selectors to choose the data elements.");
+
+static PyObject *
+compress_new_impl(PyTypeObject *type, PyObject *data, PyObject *selectors);
+
+static PyObject *
+compress_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"data", "selectors", NULL};
+    static _PyArg_Parser _parser = {"OO:compress", _keywords, 0};
+    PyObject *data;
+    PyObject *selectors;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &data, &selectors)) {
+        goto exit;
+    }
+    return_value = compress_new_impl(type, data, selectors);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(compress_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define COMPRESS_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)compress_reduce, METH_NOARGS, compress_reduce__doc__},
+
+static PyObject *
+compress_reduce_impl(compressobject *lz);
+
+static PyObject *
+compress_reduce(compressobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return compress_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(filterfalse_new__doc__,
+"filterfalse(function, iterable, /)\n"
+"--\n"
+"\n"
+"Create a filterfalse object.\n"
+"\n"
+"Return those items of iterable for which function(item) is false.\n"
+"If function is None, return the items that are false.");
+
+static PyObject *
+filterfalse_new_impl(PyTypeObject *type, PyObject *function,
+                     PyObject *iterable);
+
+static PyObject *
+filterfalse_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *function;
+    PyObject *iterable;
+
+    if ((type == &filterfalse_type) &&
+        !_PyArg_NoKeywords("filterfalse", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "filterfalse",
+        2, 2,
+        &function, &iterable)) {
+        goto exit;
+    }
+    return_value = filterfalse_new_impl(type, function, iterable);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(filterfalse_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define FILTERFALSE_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)filterfalse_reduce, METH_NOARGS, filterfalse_reduce__doc__},
+
+static PyObject *
+filterfalse_reduce_impl(filterfalseobject *lz);
+
+static PyObject *
+filterfalse_reduce(filterfalseobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return filterfalse_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(count_new__doc__,
+"count(start=None, step=None)\n"
+"--\n"
+"\n"
+"Create a count object.\n"
+"\n"
+"Return a count object whose .__next__() method returns consecutive values.\n"
+"Equivalent to:\n"
+"\n"
+"    def count(firstval=0, step=1):\n"
+"        x = firstval\n"
+"        while 1:\n"
+"            yield x\n"
+"            x += step");
+
+static PyObject *
+count_new_impl(PyTypeObject *type, PyObject *start, PyObject *step);
+
+static PyObject *
+count_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"start", "step", NULL};
+    static _PyArg_Parser _parser = {"|OO:count", _keywords, 0};
+    PyObject *start = NULL;
+    PyObject *step = NULL;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &start, &step)) {
+        goto exit;
+    }
+    return_value = count_new_impl(type, start, step);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(count_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define COUNT_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)count_reduce, METH_NOARGS, count_reduce__doc__},
+
+static PyObject *
+count_reduce_impl(countobject *lz);
+
+static PyObject *
+count_reduce(countobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return count_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(repeat_len__doc__,
+"__length_hint__($self, /)\n"
+"--\n"
+"\n"
+"Private method returning an estimate of len(list(it)).");
+
+#define REPEAT_LEN_METHODDEF    \
+    {"__length_hint__", (PyCFunction)repeat_len, METH_NOARGS, repeat_len__doc__},
+
+static PyObject *
+repeat_len_impl(repeatobject *ro);
+
+static PyObject *
+repeat_len(repeatobject *ro, PyObject *Py_UNUSED(ignored))
+{
+    return repeat_len_impl(ro);
+}
+
+PyDoc_STRVAR(repeat_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define REPEAT_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)repeat_reduce, METH_NOARGS, repeat_reduce__doc__},
+
+static PyObject *
+repeat_reduce_impl(repeatobject *ro);
+
+static PyObject *
+repeat_reduce(repeatobject *ro, PyObject *Py_UNUSED(ignored))
+{
+    return repeat_reduce_impl(ro);
+}
+
+PyDoc_STRVAR(zip_longest_reduce__doc__,
+"__reduce__($self, /)\n"
+"--\n"
+"\n"
+"Return state information for pickling.");
+
+#define ZIP_LONGEST_REDUCE_METHODDEF    \
+    {"__reduce__", (PyCFunction)zip_longest_reduce, METH_NOARGS, zip_longest_reduce__doc__},
+
+static PyObject *
+zip_longest_reduce_impl(ziplongestobject *lz);
+
+static PyObject *
+zip_longest_reduce(ziplongestobject *lz, PyObject *Py_UNUSED(ignored))
+{
+    return zip_longest_reduce_impl(lz);
+}
+
+PyDoc_STRVAR(zip_longest_setstate__doc__,
+"__setstate__($self, state, /)\n"
+"--\n"
+"\n"
+"Set state information for unpickling.");
+
+#define ZIP_LONGEST_SETSTATE_METHODDEF    \
+    {"__setstate__", (PyCFunction)zip_longest_setstate, METH_O, zip_longest_setstate__doc__},
+/*[clinic end generated code: output=a35685ba24a0567d input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -2,7 +2,7 @@
 preserve
 [clinic start generated code]*/
 
-PyDoc_STRVAR(groupby_new__doc__,
+PyDoc_STRVAR(itertools_groupby__doc__,
 "groupby(iterable, key=None)\n"
 "--\n"
 "\n"
@@ -30,10 +30,10 @@ PyDoc_STRVAR(groupby_new__doc__,
 "key=1 group=[1]");
 
 static PyObject *
-groupby_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *key);
+itertools_groupby_impl(PyTypeObject *type, PyObject *iterable, PyObject *key);
 
 static PyObject *
-groupby_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_groupby(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"iterable", "key", NULL};
@@ -45,44 +45,45 @@ groupby_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &iterable, &key)) {
         goto exit;
     }
-    return_value = groupby_new_impl(type, iterable, key);
+    return_value = itertools_groupby_impl(type, iterable, key);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(groupby_reduce__doc__,
+PyDoc_STRVAR(itertools_groupby___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define GROUPBY_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)groupby_reduce, METH_NOARGS, groupby_reduce__doc__},
+#define ITERTOOLS_GROUPBY___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_groupby___reduce__, METH_NOARGS, itertools_groupby___reduce____doc__},
 
 static PyObject *
-groupby_reduce_impl(groupbyobject *lz);
+itertools_groupby___reduce___impl(groupbyobject *lz);
 
 static PyObject *
-groupby_reduce(groupbyobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_groupby___reduce__(groupbyobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return groupby_reduce_impl(lz);
+    return itertools_groupby___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(groupby_setstate__doc__,
+PyDoc_STRVAR(itertools_groupby___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define GROUPBY_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)groupby_setstate, METH_O, groupby_setstate__doc__},
+#define ITERTOOLS_GROUPBY___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_groupby___setstate__, METH_O, itertools_groupby___setstate____doc__},
 
 static PyObject *
-_grouper_new_impl(PyTypeObject *type, PyObject *parent, PyObject *tgtkey);
+itertools__grouper_impl(PyTypeObject *type, PyObject *parent,
+                        PyObject *tgtkey);
 
 static PyObject *
-_grouper_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools__grouper(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     PyObject *parent;
@@ -96,60 +97,60 @@ _grouper_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &groupby_type, &parent, &tgtkey)) {
         goto exit;
     }
-    return_value = _grouper_new_impl(type, parent, tgtkey);
+    return_value = itertools__grouper_impl(type, parent, tgtkey);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(_grouper_reduce__doc__,
+PyDoc_STRVAR(itertools__grouper___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define _GROUPER_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)_grouper_reduce, METH_NOARGS, _grouper_reduce__doc__},
+#define ITERTOOLS__GROUPER___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools__grouper___reduce__, METH_NOARGS, itertools__grouper___reduce____doc__},
 
 static PyObject *
-_grouper_reduce_impl(_grouperobject *lz);
+itertools__grouper___reduce___impl(_grouperobject *lz);
 
 static PyObject *
-_grouper_reduce(_grouperobject *lz, PyObject *Py_UNUSED(ignored))
+itertools__grouper___reduce__(_grouperobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return _grouper_reduce_impl(lz);
+    return itertools__grouper___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(teedataobject_reduce__doc__,
+PyDoc_STRVAR(itertools_teedataobject___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define TEEDATAOBJECT_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)teedataobject_reduce, METH_NOARGS, teedataobject_reduce__doc__},
+#define ITERTOOLS_TEEDATAOBJECT___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_teedataobject___reduce__, METH_NOARGS, itertools_teedataobject___reduce____doc__},
 
 static PyObject *
-teedataobject_reduce_impl(teedataobject *tdo);
+itertools_teedataobject___reduce___impl(teedataobject *tdo);
 
 static PyObject *
-teedataobject_reduce(teedataobject *tdo, PyObject *Py_UNUSED(ignored))
+itertools_teedataobject___reduce__(teedataobject *tdo, PyObject *Py_UNUSED(ignored))
 {
-    return teedataobject_reduce_impl(tdo);
+    return itertools_teedataobject___reduce___impl(tdo);
 }
 
-PyDoc_STRVAR(teedataobject_new__doc__,
+PyDoc_STRVAR(itertools_teedataobject__doc__,
 "teedataobject(iterable, values, next, /)\n"
 "--\n"
 "\n"
 "Data container common to multiple tee objects.");
 
 static PyObject *
-teedataobject_new_impl(PyTypeObject *type, PyObject *iterable,
-                       PyObject *values, PyObject *next);
+itertools_teedataobject_impl(PyTypeObject *type, PyObject *iterable,
+                             PyObject *values, PyObject *next);
 
 static PyObject *
-teedataobject_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_teedataobject(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     PyObject *iterable;
@@ -164,31 +165,31 @@ teedataobject_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &iterable, &PyList_Type, &values, &next)) {
         goto exit;
     }
-    return_value = teedataobject_new_impl(type, iterable, values, next);
+    return_value = itertools_teedataobject_impl(type, iterable, values, next);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(tee_copy__doc__,
+PyDoc_STRVAR(itertools__tee___copy____doc__,
 "__copy__($self, /)\n"
 "--\n"
 "\n"
 "Returns an independent iterator.");
 
-#define TEE_COPY_METHODDEF    \
-    {"__copy__", (PyCFunction)tee_copy, METH_NOARGS, tee_copy__doc__},
+#define ITERTOOLS__TEE___COPY___METHODDEF    \
+    {"__copy__", (PyCFunction)itertools__tee___copy__, METH_NOARGS, itertools__tee___copy____doc__},
 
 static PyObject *
-tee_copy_impl(teeobject *to);
+itertools__tee___copy___impl(teeobject *to);
 
 static PyObject *
-tee_copy(teeobject *to, PyObject *Py_UNUSED(ignored))
+itertools__tee___copy__(teeobject *to, PyObject *Py_UNUSED(ignored))
 {
-    return tee_copy_impl(to);
+    return itertools__tee___copy___impl(to);
 }
 
-PyDoc_STRVAR(tee_new__doc__,
+PyDoc_STRVAR(itertools__tee__doc__,
 "_tee(iterable, /)\n"
 "--\n"
 "\n"
@@ -197,10 +198,10 @@ PyDoc_STRVAR(tee_new__doc__,
 "An iterator wrapped to make it copyable.");
 
 static PyObject *
-tee_new_impl(PyTypeObject *type, PyObject *iterable);
+itertools__tee_impl(PyTypeObject *type, PyObject *iterable);
 
 static PyObject *
-tee_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools__tee(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     PyObject *iterable;
@@ -214,40 +215,40 @@ tee_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &iterable)) {
         goto exit;
     }
-    return_value = tee_new_impl(type, iterable);
+    return_value = itertools__tee_impl(type, iterable);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(tee_reduce__doc__,
+PyDoc_STRVAR(itertools__tee___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define TEE_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)tee_reduce, METH_NOARGS, tee_reduce__doc__},
+#define ITERTOOLS__TEE___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools__tee___reduce__, METH_NOARGS, itertools__tee___reduce____doc__},
 
 static PyObject *
-tee_reduce_impl(teeobject *to);
+itertools__tee___reduce___impl(teeobject *to);
 
 static PyObject *
-tee_reduce(teeobject *to, PyObject *Py_UNUSED(ignored))
+itertools__tee___reduce__(teeobject *to, PyObject *Py_UNUSED(ignored))
 {
-    return tee_reduce_impl(to);
+    return itertools__tee___reduce___impl(to);
 }
 
-PyDoc_STRVAR(tee_setstate__doc__,
+PyDoc_STRVAR(itertools__tee___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define TEE_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)tee_setstate, METH_O, tee_setstate__doc__},
+#define ITERTOOLS__TEE___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools__tee___setstate__, METH_O, itertools__tee___setstate____doc__},
 
-PyDoc_STRVAR(tee__doc__,
+PyDoc_STRVAR(itertools_tee__doc__,
 "tee($module, iterable, n=2, /)\n"
 "--\n"
 "\n"
@@ -260,14 +261,14 @@ PyDoc_STRVAR(tee__doc__,
 "else; otherwise, the iterable could get advanced without the tee objects (those\n"
 "in the returned tuple) being informed.");
 
-#define TEE_METHODDEF    \
-    {"tee", (PyCFunction)tee, METH_FASTCALL, tee__doc__},
+#define ITERTOOLS_TEE_METHODDEF    \
+    {"tee", (PyCFunction)itertools_tee, METH_FASTCALL, itertools_tee__doc__},
 
 static PyObject *
-tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n);
+itertools_tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n);
 
 static PyObject *
-tee(PyObject *module, PyObject **args, Py_ssize_t nargs)
+itertools_tee(PyObject *module, PyObject **args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     PyObject *iterable;
@@ -277,13 +278,13 @@ tee(PyObject *module, PyObject **args, Py_ssize_t nargs)
         &iterable, &n)) {
         goto exit;
     }
-    return_value = tee_impl(module, iterable, n);
+    return_value = itertools_tee_impl(module, iterable, n);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(cycle_new__doc__,
+PyDoc_STRVAR(itertools_cycle__doc__,
 "cycle(iterable, /)\n"
 "--\n"
 "\n"
@@ -293,10 +294,10 @@ PyDoc_STRVAR(cycle_new__doc__,
 "Then it will repeat the sequence indefinitely.");
 
 static PyObject *
-cycle_new_impl(PyTypeObject *type, PyObject *iterable);
+itertools_cycle_impl(PyTypeObject *type, PyObject *iterable);
 
 static PyObject *
-cycle_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_cycle(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     PyObject *iterable;
@@ -310,40 +311,40 @@ cycle_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &iterable)) {
         goto exit;
     }
-    return_value = cycle_new_impl(type, iterable);
+    return_value = itertools_cycle_impl(type, iterable);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(cycle_reduce__doc__,
+PyDoc_STRVAR(itertools_cycle___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define CYCLE_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)cycle_reduce, METH_NOARGS, cycle_reduce__doc__},
+#define ITERTOOLS_CYCLE___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_cycle___reduce__, METH_NOARGS, itertools_cycle___reduce____doc__},
 
 static PyObject *
-cycle_reduce_impl(cycleobject *lz);
+itertools_cycle___reduce___impl(cycleobject *lz);
 
 static PyObject *
-cycle_reduce(cycleobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_cycle___reduce__(cycleobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return cycle_reduce_impl(lz);
+    return itertools_cycle___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(cycle_setstate__doc__,
+PyDoc_STRVAR(itertools_cycle___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define CYCLE_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)cycle_setstate, METH_O, cycle_setstate__doc__},
+#define ITERTOOLS_CYCLE___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_cycle___setstate__, METH_O, itertools_cycle___setstate____doc__},
 
-PyDoc_STRVAR(dropwhile_new__doc__,
+PyDoc_STRVAR(itertools_dropwhile__doc__,
 "dropwhile(predicate, iterable, /)\n"
 "--\n"
 "\n"
@@ -353,11 +354,11 @@ PyDoc_STRVAR(dropwhile_new__doc__,
 "Afterwards, returns every element until the iterable is exhausted.");
 
 static PyObject *
-dropwhile_new_impl(PyTypeObject *type, PyObject *predicate,
-                   PyObject *iterable);
+itertools_dropwhile_impl(PyTypeObject *type, PyObject *predicate,
+                         PyObject *iterable);
 
 static PyObject *
-dropwhile_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_dropwhile(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     PyObject *predicate;
@@ -372,40 +373,40 @@ dropwhile_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &predicate, &iterable)) {
         goto exit;
     }
-    return_value = dropwhile_new_impl(type, predicate, iterable);
+    return_value = itertools_dropwhile_impl(type, predicate, iterable);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(dropwhile_reduce__doc__,
+PyDoc_STRVAR(itertools_dropwhile___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define DROPWHILE_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)dropwhile_reduce, METH_NOARGS, dropwhile_reduce__doc__},
+#define ITERTOOLS_DROPWHILE___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_dropwhile___reduce__, METH_NOARGS, itertools_dropwhile___reduce____doc__},
 
 static PyObject *
-dropwhile_reduce_impl(dropwhileobject *lz);
+itertools_dropwhile___reduce___impl(dropwhileobject *lz);
 
 static PyObject *
-dropwhile_reduce(dropwhileobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_dropwhile___reduce__(dropwhileobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return dropwhile_reduce_impl(lz);
+    return itertools_dropwhile___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(dropwhile_setstate__doc__,
+PyDoc_STRVAR(itertools_dropwhile___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define DROPWHILE_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)dropwhile_setstate, METH_O, dropwhile_setstate__doc__},
+#define ITERTOOLS_DROPWHILE___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_dropwhile___setstate__, METH_O, itertools_dropwhile___setstate____doc__},
 
-PyDoc_STRVAR(takewhile_new__doc__,
+PyDoc_STRVAR(itertools_takewhile__doc__,
 "takewhile(predicate, iterable, /)\n"
 "--\n"
 "\n"
@@ -415,11 +416,11 @@ PyDoc_STRVAR(takewhile_new__doc__,
 "predicate evaluates to true for each entry.");
 
 static PyObject *
-takewhile_new_impl(PyTypeObject *type, PyObject *predicate,
-                   PyObject *iterable);
+itertools_takewhile_impl(PyTypeObject *type, PyObject *predicate,
+                         PyObject *iterable);
 
 static PyObject *
-takewhile_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_takewhile(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     PyObject *predicate;
@@ -434,68 +435,68 @@ takewhile_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &predicate, &iterable)) {
         goto exit;
     }
-    return_value = takewhile_new_impl(type, predicate, iterable);
+    return_value = itertools_takewhile_impl(type, predicate, iterable);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(takewhile_reduce__doc__,
+PyDoc_STRVAR(itertools_takewhile___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define TAKEWHILE_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)takewhile_reduce, METH_NOARGS, takewhile_reduce__doc__},
+#define ITERTOOLS_TAKEWHILE___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_takewhile___reduce__, METH_NOARGS, itertools_takewhile___reduce____doc__},
 
 static PyObject *
-takewhile_reduce_impl(takewhileobject *lz);
+itertools_takewhile___reduce___impl(takewhileobject *lz);
 
 static PyObject *
-takewhile_reduce(takewhileobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_takewhile___reduce__(takewhileobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return takewhile_reduce_impl(lz);
+    return itertools_takewhile___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(takewhile_setstate__doc__,
+PyDoc_STRVAR(itertools_takewhile___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define TAKEWHILE_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)takewhile_setstate, METH_O, takewhile_setstate__doc__},
+#define ITERTOOLS_TAKEWHILE___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_takewhile___setstate__, METH_O, itertools_takewhile___setstate____doc__},
 
-PyDoc_STRVAR(islice_reduce__doc__,
+PyDoc_STRVAR(itertools_islice___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define ISLICE_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)islice_reduce, METH_NOARGS, islice_reduce__doc__},
+#define ITERTOOLS_ISLICE___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_islice___reduce__, METH_NOARGS, itertools_islice___reduce____doc__},
 
 static PyObject *
-islice_reduce_impl(isliceobject *lz);
+itertools_islice___reduce___impl(isliceobject *lz);
 
 static PyObject *
-islice_reduce(isliceobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_islice___reduce__(isliceobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return islice_reduce_impl(lz);
+    return itertools_islice___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(islice_setstate__doc__,
+PyDoc_STRVAR(itertools_islice___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define ISLICE_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)islice_setstate, METH_O, islice_setstate__doc__},
+#define ITERTOOLS_ISLICE___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_islice___setstate__, METH_O, itertools_islice___setstate____doc__},
 
-PyDoc_STRVAR(starmap_new__doc__,
-"starmap(function, iterable)\n"
+PyDoc_STRVAR(itertools_starmap__doc__,
+"starmap(function, iterable, /)\n"
 "--\n"
 "\n"
 "Create a starmap object.\n"
@@ -504,46 +505,50 @@ PyDoc_STRVAR(starmap_new__doc__,
 "with a argument tuple taken from the given iterable.");
 
 static PyObject *
-starmap_new_impl(PyTypeObject *type, PyObject *function, PyObject *iterable);
+itertools_starmap_impl(PyTypeObject *type, PyObject *function,
+                       PyObject *iterable);
 
 static PyObject *
-starmap_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_starmap(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"function", "iterable", NULL};
-    static _PyArg_Parser _parser = {"OO:starmap", _keywords, 0};
     PyObject *function;
     PyObject *iterable;
 
-    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+    if ((type == &starmap_type) &&
+        !_PyArg_NoKeywords("starmap", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "starmap",
+        2, 2,
         &function, &iterable)) {
         goto exit;
     }
-    return_value = starmap_new_impl(type, function, iterable);
+    return_value = itertools_starmap_impl(type, function, iterable);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(starmap_reduce__doc__,
+PyDoc_STRVAR(itertools_starmap___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define STARMAP_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)starmap_reduce, METH_NOARGS, starmap_reduce__doc__},
+#define ITERTOOLS_STARMAP___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_starmap___reduce__, METH_NOARGS, itertools_starmap___reduce____doc__},
 
 static PyObject *
-starmap_reduce_impl(starmapobject *lz);
+itertools_starmap___reduce___impl(starmapobject *lz);
 
 static PyObject *
-starmap_reduce(starmapobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_starmap___reduce__(starmapobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return starmap_reduce_impl(lz);
+    return itertools_starmap___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(chain_new_from_iterable__doc__,
+PyDoc_STRVAR(itertools_chain_from_iterable__doc__,
 "from_iterable($type, iterable, /)\n"
 "--\n"
 "\n"
@@ -552,82 +557,82 @@ PyDoc_STRVAR(chain_new_from_iterable__doc__,
 "Alternate chain() contructor taking a single iterable argument\n"
 "that evaluates lazily.");
 
-#define CHAIN_NEW_FROM_ITERABLE_METHODDEF    \
-    {"from_iterable", (PyCFunction)chain_new_from_iterable, METH_O|METH_CLASS, chain_new_from_iterable__doc__},
+#define ITERTOOLS_CHAIN_FROM_ITERABLE_METHODDEF    \
+    {"from_iterable", (PyCFunction)itertools_chain_from_iterable, METH_O|METH_CLASS, itertools_chain_from_iterable__doc__},
 
-PyDoc_STRVAR(chain_reduce__doc__,
+PyDoc_STRVAR(itertools_chain___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define CHAIN_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)chain_reduce, METH_NOARGS, chain_reduce__doc__},
+#define ITERTOOLS_CHAIN___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_chain___reduce__, METH_NOARGS, itertools_chain___reduce____doc__},
 
 static PyObject *
-chain_reduce_impl(chainobject *lz);
+itertools_chain___reduce___impl(chainobject *lz);
 
 static PyObject *
-chain_reduce(chainobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_chain___reduce__(chainobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return chain_reduce_impl(lz);
+    return itertools_chain___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(chain_setstate__doc__,
+PyDoc_STRVAR(itertools_chain___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define CHAIN_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)chain_setstate, METH_O, chain_setstate__doc__},
+#define ITERTOOLS_CHAIN___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_chain___setstate__, METH_O, itertools_chain___setstate____doc__},
 
-PyDoc_STRVAR(product_sizeof__doc__,
+PyDoc_STRVAR(itertools_product___sizeof____doc__,
 "__sizeof__($self, /)\n"
 "--\n"
 "\n"
 "Returns size in memory, in bytes.");
 
-#define PRODUCT_SIZEOF_METHODDEF    \
-    {"__sizeof__", (PyCFunction)product_sizeof, METH_NOARGS, product_sizeof__doc__},
+#define ITERTOOLS_PRODUCT___SIZEOF___METHODDEF    \
+    {"__sizeof__", (PyCFunction)itertools_product___sizeof__, METH_NOARGS, itertools_product___sizeof____doc__},
 
 static PyObject *
-product_sizeof_impl(productobject *lz);
+itertools_product___sizeof___impl(productobject *lz);
 
 static PyObject *
-product_sizeof(productobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_product___sizeof__(productobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return product_sizeof_impl(lz);
+    return itertools_product___sizeof___impl(lz);
 }
 
-PyDoc_STRVAR(product_reduce__doc__,
+PyDoc_STRVAR(itertools_product___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define PRODUCT_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)product_reduce, METH_NOARGS, product_reduce__doc__},
+#define ITERTOOLS_PRODUCT___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_product___reduce__, METH_NOARGS, itertools_product___reduce____doc__},
 
 static PyObject *
-product_reduce_impl(productobject *lz);
+itertools_product___reduce___impl(productobject *lz);
 
 static PyObject *
-product_reduce(productobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_product___reduce__(productobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return product_reduce_impl(lz);
+    return itertools_product___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(product_setstate__doc__,
+PyDoc_STRVAR(itertools_product___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define PRODUCT_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)product_setstate, METH_O, product_setstate__doc__},
+#define ITERTOOLS_PRODUCT___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_product___setstate__, METH_O, itertools_product___setstate____doc__},
 
-PyDoc_STRVAR(combinations_new__doc__,
+PyDoc_STRVAR(itertools_combinations__doc__,
 "combinations(iterable, r)\n"
 "--\n"
 "\n"
@@ -639,10 +644,11 @@ PyDoc_STRVAR(combinations_new__doc__,
 "combinations(range(4), 3) --> (0,1,2), (0,1,3), (0,2,3), (1,2,3)");
 
 static PyObject *
-combinations_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t r);
+itertools_combinations_impl(PyTypeObject *type, PyObject *iterable,
+                            Py_ssize_t r);
 
 static PyObject *
-combinations_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_combinations(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"iterable", "r", NULL};
@@ -654,58 +660,58 @@ combinations_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &iterable, &r)) {
         goto exit;
     }
-    return_value = combinations_new_impl(type, iterable, r);
+    return_value = itertools_combinations_impl(type, iterable, r);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(combinations_sizeof__doc__,
+PyDoc_STRVAR(itertools_combinations___sizeof____doc__,
 "__sizeof__($self, /)\n"
 "--\n"
 "\n"
 "Returns size in memory, in bytes.");
 
-#define COMBINATIONS_SIZEOF_METHODDEF    \
-    {"__sizeof__", (PyCFunction)combinations_sizeof, METH_NOARGS, combinations_sizeof__doc__},
+#define ITERTOOLS_COMBINATIONS___SIZEOF___METHODDEF    \
+    {"__sizeof__", (PyCFunction)itertools_combinations___sizeof__, METH_NOARGS, itertools_combinations___sizeof____doc__},
 
 static PyObject *
-combinations_sizeof_impl(combinationsobject *co);
+itertools_combinations___sizeof___impl(combinationsobject *co);
 
 static PyObject *
-combinations_sizeof(combinationsobject *co, PyObject *Py_UNUSED(ignored))
+itertools_combinations___sizeof__(combinationsobject *co, PyObject *Py_UNUSED(ignored))
 {
-    return combinations_sizeof_impl(co);
+    return itertools_combinations___sizeof___impl(co);
 }
 
-PyDoc_STRVAR(combinations_reduce__doc__,
+PyDoc_STRVAR(itertools_combinations___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define COMBINATIONS_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)combinations_reduce, METH_NOARGS, combinations_reduce__doc__},
+#define ITERTOOLS_COMBINATIONS___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_combinations___reduce__, METH_NOARGS, itertools_combinations___reduce____doc__},
 
 static PyObject *
-combinations_reduce_impl(combinationsobject *lz);
+itertools_combinations___reduce___impl(combinationsobject *lz);
 
 static PyObject *
-combinations_reduce(combinationsobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_combinations___reduce__(combinationsobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return combinations_reduce_impl(lz);
+    return itertools_combinations___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(combinations_setstate__doc__,
+PyDoc_STRVAR(itertools_combinations___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define COMBINATIONS_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)combinations_setstate, METH_O, combinations_setstate__doc__},
+#define ITERTOOLS_COMBINATIONS___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_combinations___setstate__, METH_O, itertools_combinations___setstate____doc__},
 
-PyDoc_STRVAR(cwr_new__doc__,
+PyDoc_STRVAR(itertools_combinations_with_replacement__doc__,
 "combinations_with_replacement(iterable, r)\n"
 "--\n"
 "\n"
@@ -718,10 +724,12 @@ PyDoc_STRVAR(cwr_new__doc__,
 "combinations_with_replacement(\'ABC\', 2) --> AA AB AC BB BC CC");
 
 static PyObject *
-cwr_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t r);
+itertools_combinations_with_replacement_impl(PyTypeObject *type,
+                                             PyObject *iterable,
+                                             Py_ssize_t r);
 
 static PyObject *
-cwr_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_combinations_with_replacement(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"iterable", "r", NULL};
@@ -733,58 +741,58 @@ cwr_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &iterable, &r)) {
         goto exit;
     }
-    return_value = cwr_new_impl(type, iterable, r);
+    return_value = itertools_combinations_with_replacement_impl(type, iterable, r);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(cwr_sizeof__doc__,
+PyDoc_STRVAR(itertools_combinations_with_replacement___sizeof____doc__,
 "__sizeof__($self, /)\n"
 "--\n"
 "\n"
 "Returns size in memory, in bytes.");
 
-#define CWR_SIZEOF_METHODDEF    \
-    {"__sizeof__", (PyCFunction)cwr_sizeof, METH_NOARGS, cwr_sizeof__doc__},
+#define ITERTOOLS_COMBINATIONS_WITH_REPLACEMENT___SIZEOF___METHODDEF    \
+    {"__sizeof__", (PyCFunction)itertools_combinations_with_replacement___sizeof__, METH_NOARGS, itertools_combinations_with_replacement___sizeof____doc__},
 
 static PyObject *
-cwr_sizeof_impl(cwrobject *co);
+itertools_combinations_with_replacement___sizeof___impl(cwrobject *co);
 
 static PyObject *
-cwr_sizeof(cwrobject *co, PyObject *Py_UNUSED(ignored))
+itertools_combinations_with_replacement___sizeof__(cwrobject *co, PyObject *Py_UNUSED(ignored))
 {
-    return cwr_sizeof_impl(co);
+    return itertools_combinations_with_replacement___sizeof___impl(co);
 }
 
-PyDoc_STRVAR(cwr_reduce__doc__,
+PyDoc_STRVAR(itertools_combinations_with_replacement___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define CWR_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)cwr_reduce, METH_NOARGS, cwr_reduce__doc__},
+#define ITERTOOLS_COMBINATIONS_WITH_REPLACEMENT___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_combinations_with_replacement___reduce__, METH_NOARGS, itertools_combinations_with_replacement___reduce____doc__},
 
 static PyObject *
-cwr_reduce_impl(cwrobject *lz);
+itertools_combinations_with_replacement___reduce___impl(cwrobject *lz);
 
 static PyObject *
-cwr_reduce(cwrobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_combinations_with_replacement___reduce__(cwrobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return cwr_reduce_impl(lz);
+    return itertools_combinations_with_replacement___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(cwr_setstate__doc__,
+PyDoc_STRVAR(itertools_combinations_with_replacement___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define CWR_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)cwr_setstate, METH_O, cwr_setstate__doc__},
+#define ITERTOOLS_COMBINATIONS_WITH_REPLACEMENT___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_combinations_with_replacement___setstate__, METH_O, itertools_combinations_with_replacement___setstate____doc__},
 
-PyDoc_STRVAR(permutations_new__doc__,
+PyDoc_STRVAR(itertools_permutations__doc__,
 "permutations(iterable, r=None)\n"
 "--\n"
 "\n"
@@ -796,10 +804,11 @@ PyDoc_STRVAR(permutations_new__doc__,
 "permutations(range(3), 2) --> (0,1), (0,2), (1,0), (1,2), (2,0), (2,1)");
 
 static PyObject *
-permutations_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *robj);
+itertools_permutations_impl(PyTypeObject *type, PyObject *iterable,
+                            PyObject *robj);
 
 static PyObject *
-permutations_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_permutations(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"iterable", "r", NULL};
@@ -811,58 +820,58 @@ permutations_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &iterable, &robj)) {
         goto exit;
     }
-    return_value = permutations_new_impl(type, iterable, robj);
+    return_value = itertools_permutations_impl(type, iterable, robj);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(permutations_sizeof__doc__,
+PyDoc_STRVAR(itertools_permutations___sizeof____doc__,
 "__sizeof__($self, /)\n"
 "--\n"
 "\n"
 "Returns size in memory, in bytes.");
 
-#define PERMUTATIONS_SIZEOF_METHODDEF    \
-    {"__sizeof__", (PyCFunction)permutations_sizeof, METH_NOARGS, permutations_sizeof__doc__},
+#define ITERTOOLS_PERMUTATIONS___SIZEOF___METHODDEF    \
+    {"__sizeof__", (PyCFunction)itertools_permutations___sizeof__, METH_NOARGS, itertools_permutations___sizeof____doc__},
 
 static PyObject *
-permutations_sizeof_impl(permutationsobject *po);
+itertools_permutations___sizeof___impl(permutationsobject *po);
 
 static PyObject *
-permutations_sizeof(permutationsobject *po, PyObject *Py_UNUSED(ignored))
+itertools_permutations___sizeof__(permutationsobject *po, PyObject *Py_UNUSED(ignored))
 {
-    return permutations_sizeof_impl(po);
+    return itertools_permutations___sizeof___impl(po);
 }
 
-PyDoc_STRVAR(permutations_reduce__doc__,
+PyDoc_STRVAR(itertools_permutations___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define PERMUTATIONS_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)permutations_reduce, METH_NOARGS, permutations_reduce__doc__},
+#define ITERTOOLS_PERMUTATIONS___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_permutations___reduce__, METH_NOARGS, itertools_permutations___reduce____doc__},
 
 static PyObject *
-permutations_reduce_impl(permutationsobject *po);
+itertools_permutations___reduce___impl(permutationsobject *po);
 
 static PyObject *
-permutations_reduce(permutationsobject *po, PyObject *Py_UNUSED(ignored))
+itertools_permutations___reduce__(permutationsobject *po, PyObject *Py_UNUSED(ignored))
 {
-    return permutations_reduce_impl(po);
+    return itertools_permutations___reduce___impl(po);
 }
 
-PyDoc_STRVAR(permutations_setstate__doc__,
+PyDoc_STRVAR(itertools_permutations___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define PERMUTATIONS_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)permutations_setstate, METH_O, permutations_setstate__doc__},
+#define ITERTOOLS_PERMUTATIONS___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_permutations___setstate__, METH_O, itertools_permutations___setstate____doc__},
 
-PyDoc_STRVAR(accumulate_new__doc__,
+PyDoc_STRVAR(itertools_accumulate__doc__,
 "accumulate(iterable, func=None)\n"
 "--\n"
 "\n"
@@ -871,10 +880,11 @@ PyDoc_STRVAR(accumulate_new__doc__,
 "Return series of accumulated sums (or other binary function results).");
 
 static PyObject *
-accumulate_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *func);
+itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
+                          PyObject *func);
 
 static PyObject *
-accumulate_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_accumulate(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"iterable", "func", NULL};
@@ -886,40 +896,40 @@ accumulate_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &iterable, &func)) {
         goto exit;
     }
-    return_value = accumulate_new_impl(type, iterable, func);
+    return_value = itertools_accumulate_impl(type, iterable, func);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(accumulate_reduce__doc__,
+PyDoc_STRVAR(itertools_accumulate___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define ACCUMULATE_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)accumulate_reduce, METH_NOARGS, accumulate_reduce__doc__},
+#define ITERTOOLS_ACCUMULATE___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_accumulate___reduce__, METH_NOARGS, itertools_accumulate___reduce____doc__},
 
 static PyObject *
-accumulate_reduce_impl(accumulateobject *lz);
+itertools_accumulate___reduce___impl(accumulateobject *lz);
 
 static PyObject *
-accumulate_reduce(accumulateobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_accumulate___reduce__(accumulateobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return accumulate_reduce_impl(lz);
+    return itertools_accumulate___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(accumulate_setstate__doc__,
+PyDoc_STRVAR(itertools_accumulate___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define ACCUMULATE_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)accumulate_setstate, METH_O, accumulate_setstate__doc__},
+#define ITERTOOLS_ACCUMULATE___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_accumulate___setstate__, METH_O, itertools_accumulate___setstate____doc__},
 
-PyDoc_STRVAR(compress_new__doc__,
+PyDoc_STRVAR(itertools_compress__doc__,
 "compress(data, selectors)\n"
 "--\n"
 "\n"
@@ -930,10 +940,11 @@ PyDoc_STRVAR(compress_new__doc__,
 "selectors to choose the data elements.");
 
 static PyObject *
-compress_new_impl(PyTypeObject *type, PyObject *data, PyObject *selectors);
+itertools_compress_impl(PyTypeObject *type, PyObject *data,
+                        PyObject *selectors);
 
 static PyObject *
-compress_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_compress(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"data", "selectors", NULL};
@@ -945,31 +956,31 @@ compress_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &data, &selectors)) {
         goto exit;
     }
-    return_value = compress_new_impl(type, data, selectors);
+    return_value = itertools_compress_impl(type, data, selectors);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(compress_reduce__doc__,
+PyDoc_STRVAR(itertools_compress___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define COMPRESS_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)compress_reduce, METH_NOARGS, compress_reduce__doc__},
+#define ITERTOOLS_COMPRESS___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_compress___reduce__, METH_NOARGS, itertools_compress___reduce____doc__},
 
 static PyObject *
-compress_reduce_impl(compressobject *lz);
+itertools_compress___reduce___impl(compressobject *lz);
 
 static PyObject *
-compress_reduce(compressobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_compress___reduce__(compressobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return compress_reduce_impl(lz);
+    return itertools_compress___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(filterfalse_new__doc__,
+PyDoc_STRVAR(itertools_filterfalse__doc__,
 "filterfalse(function, iterable, /)\n"
 "--\n"
 "\n"
@@ -979,11 +990,11 @@ PyDoc_STRVAR(filterfalse_new__doc__,
 "If function is None, return the items that are false.");
 
 static PyObject *
-filterfalse_new_impl(PyTypeObject *type, PyObject *function,
-                     PyObject *iterable);
+itertools_filterfalse_impl(PyTypeObject *type, PyObject *function,
+                           PyObject *iterable);
 
 static PyObject *
-filterfalse_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_filterfalse(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     PyObject *function;
@@ -998,32 +1009,32 @@ filterfalse_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
         &function, &iterable)) {
         goto exit;
     }
-    return_value = filterfalse_new_impl(type, function, iterable);
+    return_value = itertools_filterfalse_impl(type, function, iterable);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(filterfalse_reduce__doc__,
+PyDoc_STRVAR(itertools_filterfalse___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define FILTERFALSE_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)filterfalse_reduce, METH_NOARGS, filterfalse_reduce__doc__},
+#define ITERTOOLS_FILTERFALSE___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_filterfalse___reduce__, METH_NOARGS, itertools_filterfalse___reduce____doc__},
 
 static PyObject *
-filterfalse_reduce_impl(filterfalseobject *lz);
+itertools_filterfalse___reduce___impl(filterfalseobject *lz);
 
 static PyObject *
-filterfalse_reduce(filterfalseobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_filterfalse___reduce__(filterfalseobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return filterfalse_reduce_impl(lz);
+    return itertools_filterfalse___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(count_new__doc__,
-"count(start=None, step=None)\n"
+PyDoc_STRVAR(itertools_count__doc__,
+"count(start=0, step=1)\n"
 "--\n"
 "\n"
 "Create a count object.\n"
@@ -1038,105 +1049,106 @@ PyDoc_STRVAR(count_new__doc__,
 "            x += step");
 
 static PyObject *
-count_new_impl(PyTypeObject *type, PyObject *start, PyObject *step);
+itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
+                     PyObject *long_step);
 
 static PyObject *
-count_new(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+itertools_count(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"start", "step", NULL};
     static _PyArg_Parser _parser = {"|OO:count", _keywords, 0};
-    PyObject *start = NULL;
-    PyObject *step = NULL;
+    PyObject *long_cnt = NULL;
+    PyObject *long_step = NULL;
 
     if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
-        &start, &step)) {
+        &long_cnt, &long_step)) {
         goto exit;
     }
-    return_value = count_new_impl(type, start, step);
+    return_value = itertools_count_impl(type, long_cnt, long_step);
 
 exit:
     return return_value;
 }
 
-PyDoc_STRVAR(count_reduce__doc__,
+PyDoc_STRVAR(itertools_count___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define COUNT_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)count_reduce, METH_NOARGS, count_reduce__doc__},
+#define ITERTOOLS_COUNT___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_count___reduce__, METH_NOARGS, itertools_count___reduce____doc__},
 
 static PyObject *
-count_reduce_impl(countobject *lz);
+itertools_count___reduce___impl(countobject *lz);
 
 static PyObject *
-count_reduce(countobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_count___reduce__(countobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return count_reduce_impl(lz);
+    return itertools_count___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(repeat_len__doc__,
+PyDoc_STRVAR(itertools_repeat___length_hint____doc__,
 "__length_hint__($self, /)\n"
 "--\n"
 "\n"
 "Private method returning an estimate of len(list(it)).");
 
-#define REPEAT_LEN_METHODDEF    \
-    {"__length_hint__", (PyCFunction)repeat_len, METH_NOARGS, repeat_len__doc__},
+#define ITERTOOLS_REPEAT___LENGTH_HINT___METHODDEF    \
+    {"__length_hint__", (PyCFunction)itertools_repeat___length_hint__, METH_NOARGS, itertools_repeat___length_hint____doc__},
 
 static PyObject *
-repeat_len_impl(repeatobject *ro);
+itertools_repeat___length_hint___impl(repeatobject *ro);
 
 static PyObject *
-repeat_len(repeatobject *ro, PyObject *Py_UNUSED(ignored))
+itertools_repeat___length_hint__(repeatobject *ro, PyObject *Py_UNUSED(ignored))
 {
-    return repeat_len_impl(ro);
+    return itertools_repeat___length_hint___impl(ro);
 }
 
-PyDoc_STRVAR(repeat_reduce__doc__,
+PyDoc_STRVAR(itertools_repeat___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define REPEAT_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)repeat_reduce, METH_NOARGS, repeat_reduce__doc__},
+#define ITERTOOLS_REPEAT___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_repeat___reduce__, METH_NOARGS, itertools_repeat___reduce____doc__},
 
 static PyObject *
-repeat_reduce_impl(repeatobject *ro);
+itertools_repeat___reduce___impl(repeatobject *ro);
 
 static PyObject *
-repeat_reduce(repeatobject *ro, PyObject *Py_UNUSED(ignored))
+itertools_repeat___reduce__(repeatobject *ro, PyObject *Py_UNUSED(ignored))
 {
-    return repeat_reduce_impl(ro);
+    return itertools_repeat___reduce___impl(ro);
 }
 
-PyDoc_STRVAR(zip_longest_reduce__doc__,
+PyDoc_STRVAR(itertools_zip_longest___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
 "\n"
 "Return state information for pickling.");
 
-#define ZIP_LONGEST_REDUCE_METHODDEF    \
-    {"__reduce__", (PyCFunction)zip_longest_reduce, METH_NOARGS, zip_longest_reduce__doc__},
+#define ITERTOOLS_ZIP_LONGEST___REDUCE___METHODDEF    \
+    {"__reduce__", (PyCFunction)itertools_zip_longest___reduce__, METH_NOARGS, itertools_zip_longest___reduce____doc__},
 
 static PyObject *
-zip_longest_reduce_impl(ziplongestobject *lz);
+itertools_zip_longest___reduce___impl(ziplongestobject *lz);
 
 static PyObject *
-zip_longest_reduce(ziplongestobject *lz, PyObject *Py_UNUSED(ignored))
+itertools_zip_longest___reduce__(ziplongestobject *lz, PyObject *Py_UNUSED(ignored))
 {
-    return zip_longest_reduce_impl(lz);
+    return itertools_zip_longest___reduce___impl(lz);
 }
 
-PyDoc_STRVAR(zip_longest_setstate__doc__,
+PyDoc_STRVAR(itertools_zip_longest___setstate____doc__,
 "__setstate__($self, state, /)\n"
 "--\n"
 "\n"
 "Set state information for unpickling.");
 
-#define ZIP_LONGEST_SETSTATE_METHODDEF    \
-    {"__setstate__", (PyCFunction)zip_longest_setstate, METH_O, zip_longest_setstate__doc__},
-/*[clinic end generated code: output=a35685ba24a0567d input=a9049054013a1b77]*/
+#define ITERTOOLS_ZIP_LONGEST___SETSTATE___METHODDEF    \
+    {"__setstate__", (PyCFunction)itertools_zip_longest___setstate__, METH_O, itertools_zip_longest___setstate____doc__},
+/*[clinic end generated code: output=76fca89a64f5cd41 input=a9049054013a1b77]*/

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -69,7 +69,7 @@ key value for the group and "group" is an iterator of the items in the group.
 
 static PyObject *
 itertools_groupby_impl(PyTypeObject *type, PyObject *iterable, PyObject *key)
-/*[clinic end generated code: output=83016d6c995ed8a5 input=6dbf07f491bd73ec]*/
+/*[clinic end generated code: output=83016d6c995ed8a5 input=8fc3935e146a29ac]*/
 {
     groupbyobject *gbo;
 
@@ -1482,7 +1482,7 @@ with argument tuples taken from the given iterable.
 static PyObject *
 itertools_starmap_impl(PyTypeObject *type, PyObject *function,
                        PyObject *iterable)
-/*[clinic end generated code: output=d190ae80479a0717 input=19c167576f25a714]*/
+/*[clinic end generated code: output=d190ae80479a0717 input=9c386834b6944945]*/
 {
     PyObject *it;
     starmapobject *lz;
@@ -1617,7 +1617,7 @@ that evaluates lazily.
 
 static PyObject *
 itertools_chain_from_iterable(PyTypeObject *type, PyObject *iterable)
-/*[clinic end generated code: output=39373d88650cc4fd input=d39acc2717d725a0]*/
+/*[clinic end generated code: output=39373d88650cc4fd input=1936d24c4142741a]*/
 {
     PyObject *source;
 
@@ -3509,7 +3509,7 @@ Equivalent to:
 static PyObject *
 itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
                      PyObject *long_step)
-/*[clinic end generated code: output=09a9250aebd00b1c input=20f1ce2f2484a91c]*/
+/*[clinic end generated code: output=09a9250aebd00b1c input=6bb1062328f66e44]*/
 {
     countobject *lz;
     int fast_mode;
@@ -3756,7 +3756,7 @@ Private method returning an estimate of len(list(self)).
 
 static PyObject *
 itertools_repeat___length_hint___impl(repeatobject *ro)
-/*[clinic end generated code: output=2338c14b3a3b1fc7 input=1e3f9bda2d073686]*/
+/*[clinic end generated code: output=2338c14b3a3b1fc7 input=2f485b33f08e8209]*/
 {
     if (ro->cnt == -1) {
         PyErr_SetString(PyExc_TypeError, "len() of unsized object");

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -7,6 +7,31 @@
    by Raymond D. Hettinger <python@rcn.com>
 */
 
+/*[clinic input]
+module itertools
+class itertools.groupby "groupbyobject *" "&groupby_type"
+class itertools._grouper "_grouperobject *" "&_grouper_type"
+class itertools._tee "teeobject *" "&tee_type"
+class itertools.teedataobject "teedataobject *" "&teedataobject_type"
+class itertools.cycle "cycleobject *" "&cycle_type"
+class itertools.dropwhile "dropwhileobject *" "&dropwhile_type"
+class itertools.takewhile "takewhileobject *" "&takewhile_type"
+class itertools.islice "isliceobject *" "&islice_type"
+class itertools.starmap "starmapobject *" "&starmap_type"
+class itertools.chain "chainobject *" "&chain_type"
+class itertools.product "productobject *" "&product_type"
+class itertools.combinations "combinationsobject *" "&combinations_type"
+class itertools.combinations_with_replacement "cwrobject *" "&cwr_type"
+class itertools.permutations "permutationsobject *" "&permutations_type"
+class itertools.accumulate "accumulateobject *" "&accumulate_type"
+class itertools.compress "compressobject *" "&compress_type"
+class itertools.filterfalse "filterfalseobject *" "&filterfalse_type"
+class itertools.count "countobject *" "&count_type"
+class itertools.repeat "repeatobject *" "&repeat_type"
+class itertools.zip_longest "ziplongestobject *" "&ziplongest_type"
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=95c340f2eacd0350]*/
+
 
 /* groupby object ************************************************************/
 
@@ -23,16 +48,39 @@ typedef struct {
 static PyTypeObject groupby_type;
 static PyObject *_grouper_create(groupbyobject *, PyObject *);
 
-static PyObject *
-groupby_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
-{
-    static char *kwargs[] = {"iterable", "key", NULL};
-    groupbyobject *gbo;
-    PyObject *it, *keyfunc = Py_None;
+/*[clinic input]
+@classmethod
+itertools.groupby.__new__ as groupby_new
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:groupby", kwargs,
-                                     &it, &keyfunc))
-        return NULL;
+    iterable: object
+        Elements to divide into groups according to the key function.
+    key: object = None
+        Function computing a key value for each element.
+        If None, the elements themselves are used for grouping.
+
+Create a groupby object.
+
+This makes an iterator of (key, sub-iterator) pairs. In each such pair, the
+sub-iterator is a group of consecutive elements from the input iterable which
+all have the same key. The common key for the group is the first item in the
+pair.
+
+Example:
+>>> # group numbers by their absolute value
+>>> elements = [1, -1, 2, 1]
+>>> for (key, group) in itertools.groupby(elements, key=abs):
+...     print('key={} group={}'.format(key, list(group)))
+...
+key=1 group=[1, -1]
+key=2 group=[2]
+key=1 group=[1]
+[clinic start generated code]*/
+
+static PyObject *
+groupby_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *key)
+/*[clinic end generated code: output=7d57fc22bba4949d input=6ad51fd161164a10]*/
+{
+    groupbyobject *gbo;
 
     gbo = (groupbyobject *)type->tp_alloc(type, 0);
     if (gbo == NULL)
@@ -40,9 +88,9 @@ groupby_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     gbo->tgtkey = NULL;
     gbo->currkey = NULL;
     gbo->currvalue = NULL;
-    gbo->keyfunc = keyfunc;
-    Py_INCREF(keyfunc);
-    gbo->it = PyObject_GetIter(it);
+    gbo->keyfunc = key;
+    Py_INCREF(key);
+    gbo->it = PyObject_GetIter(iterable);
     if (gbo->it == NULL) {
         Py_DECREF(gbo);
         return NULL;
@@ -137,8 +185,17 @@ groupby_next(groupbyobject *gbo)
     return r;
 }
 
+/*[clinic input]
+itertools.groupby.__reduce__ as groupby_reduce
+
+    lz: self(type="groupbyobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-groupby_reduce(groupbyobject *lz)
+groupby_reduce_impl(groupbyobject *lz)
+/*[clinic end generated code: output=81ccca5e1cd6ef82 input=c9328f12aa213161]*/
 {
     /* reduce as a 'new' call with an optional 'setstate' if groupby
      * has started
@@ -154,10 +211,19 @@ groupby_reduce(groupbyobject *lz)
     return value;
 }
 
-PyDoc_STRVAR(reduce_doc, "Return state information for pickling.");
+/*[clinic input]
+itertools.groupby.__setstate__ as groupby_setstate
+
+    lz: self(type="groupbyobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
 
 static PyObject *
 groupby_setstate(groupbyobject *lz, PyObject *state)
+/*[clinic end generated code: output=d668c44985ed8d2c input=1c009772af2ae55f]*/
 {
     PyObject *currkey, *currvalue, *tgtkey;
     if (!PyTuple_Check(state)) {
@@ -176,20 +242,11 @@ groupby_setstate(groupbyobject *lz, PyObject *state)
     Py_RETURN_NONE;
 }
 
-PyDoc_STRVAR(setstate_doc, "Set state information for unpickling.");
-
 static PyMethodDef groupby_methods[] = {
-    {"__reduce__",      (PyCFunction)groupby_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)groupby_setstate,    METH_O,
-     setstate_doc},
+    GROUPBY_REDUCE_METHODDEF
+    GROUPBY_SETSTATE_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
-
-PyDoc_STRVAR(groupby_doc,
-"groupby(iterable, key=None) -> make an iterator that returns consecutive\n\
-keys and groups from the iterable.  If the key function is not specified or\n\
-is None, the element itself is used for grouping.\n");
 
 static PyTypeObject groupby_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -214,7 +271,7 @@ static PyTypeObject groupby_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    groupby_doc,                        /* tp_doc */
+    groupby_new__doc__,                 /* tp_doc */
     (traverseproc)groupby_traverse,     /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -246,14 +303,19 @@ typedef struct {
 
 static PyTypeObject _grouper_type;
 
+/*[clinic input]
+@classmethod
+itertools._grouper.__new__ as _grouper_new
+
+    parent: object(subclass_of='&groupby_type')
+    tgtkey: object
+    /
+[clinic start generated code]*/
+
 static PyObject *
-_grouper_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+_grouper_new_impl(PyTypeObject *type, PyObject *parent, PyObject *tgtkey)
+/*[clinic end generated code: output=c2b3fdd3561b1103 input=280c2659160f7890]*/
 {
-    PyObject *parent, *tgtkey;
-
-    if (!PyArg_ParseTuple(args, "O!O", &groupby_type, &parent, &tgtkey))
-        return NULL;
-
     return _grouper_create((groupbyobject*) parent, tgtkey);
 }
 
@@ -319,8 +381,17 @@ _grouper_next(_grouperobject *igo)
     return r;
 }
 
+/*[clinic input]
+itertools._grouper.__reduce__ as _grouper_reduce
+
+    lz: self(type="_grouperobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-_grouper_reduce(_grouperobject *lz)
+_grouper_reduce_impl(_grouperobject *lz)
+/*[clinic end generated code: output=5d852dbd29c55aaf input=89204ccad93c8271]*/
 {
     if (((groupbyobject *)lz->parent)->currgrouper != lz) {
         return Py_BuildValue("N(())", _PyObject_GetBuiltin("iter"));
@@ -329,8 +400,7 @@ _grouper_reduce(_grouperobject *lz)
 }
 
 static PyMethodDef _grouper_methods[] = {
-    {"__reduce__",      (PyCFunction)_grouper_reduce,      METH_NOARGS,
-     reduce_doc},
+    _GROUPER_REDUCE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -503,8 +573,17 @@ teedataobject_dealloc(teedataobject *tdo)
     PyObject_GC_Del(tdo);
 }
 
+/*[clinic input]
+itertools.teedataobject.__reduce__ as teedataobject_reduce
+
+    tdo: self(type="teedataobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-teedataobject_reduce(teedataobject *tdo)
+teedataobject_reduce_impl(teedataobject *tdo)
+/*[clinic end generated code: output=2dd0ee192b561019 input=5067dad6127ce165]*/
 {
     int i;
     /* create a temporary list of already iterated values */
@@ -523,18 +602,29 @@ teedataobject_reduce(teedataobject *tdo)
 
 static PyTypeObject teedataobject_type;
 
+/*[clinic input]
+@classmethod
+itertools.teedataobject.__new__ as teedataobject_new
+
+    iterable: object
+    values: object(subclass_of='&PyList_Type')
+    next: object
+    /
+
+Data container common to multiple tee objects.
+[clinic start generated code]*/
+
 static PyObject *
-teedataobject_new(PyTypeObject *type, PyObject *args, PyObject *kw)
+teedataobject_new_impl(PyTypeObject *type, PyObject *iterable,
+                       PyObject *values, PyObject *next)
+/*[clinic end generated code: output=9bc76065decb56f6 input=cb41f9058761382a]*/
 {
     teedataobject *tdo;
-    PyObject *it, *values, *next;
     Py_ssize_t i, len;
 
     assert(type == &teedataobject_type);
-    if (!PyArg_ParseTuple(args, "OO!O", &it, &PyList_Type, &values, &next))
-        return NULL;
 
-    tdo = (teedataobject *)teedataobject_newinternal(it);
+    tdo = (teedataobject *)teedataobject_newinternal(iterable);
     if (!tdo)
         return NULL;
 
@@ -569,12 +659,9 @@ err:
 }
 
 static PyMethodDef teedataobject_methods[] = {
-    {"__reduce__",      (PyCFunction)teedataobject_reduce, METH_NOARGS,
-     reduce_doc},
+    TEEDATAOBJECT_REDUCE_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
-
-PyDoc_STRVAR(teedataobject_doc, "Data container common to multiple tee objects.");
 
 static PyTypeObject teedataobject_type = {
     PyVarObject_HEAD_INIT(0, 0)                 /* Must fill in type value later */
@@ -598,7 +685,7 @@ static PyTypeObject teedataobject_type = {
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
-    teedataobject_doc,                          /* tp_doc */
+    teedataobject_new__doc__,                   /* tp_doc */
     (traverseproc)teedataobject_traverse,       /* tp_traverse */
     (inquiry)teedataobject_clear,               /* tp_clear */
     0,                                          /* tp_richcompare */
@@ -648,8 +735,17 @@ tee_traverse(teeobject *to, visitproc visit, void *arg)
     return 0;
 }
 
+/*[clinic input]
+itertools._tee.__copy__ as tee_copy
+
+    to: self(type="teeobject *")
+
+Returns an independent iterator.
+[clinic start generated code]*/
+
 static PyObject *
-tee_copy(teeobject *to)
+tee_copy_impl(teeobject *to)
+/*[clinic end generated code: output=45629a9ebc19de67 input=da64ef9fac60a134]*/
 {
     teeobject *newto;
 
@@ -664,8 +760,6 @@ tee_copy(teeobject *to)
     return (PyObject *)newto;
 }
 
-PyDoc_STRVAR(teecopy_doc, "Returns an independent iterator.");
-
 static PyObject *
 tee_fromiterable(PyObject *iterable)
 {
@@ -676,7 +770,7 @@ tee_fromiterable(PyObject *iterable)
     if (it == NULL)
         return NULL;
     if (PyObject_TypeCheck(it, &tee_type)) {
-        to = (teeobject *)tee_copy((teeobject *)it);
+        to = (teeobject *)tee_copy_impl((teeobject *)it);
         goto done;
     }
 
@@ -698,13 +792,22 @@ done:
     return (PyObject *)to;
 }
 
-static PyObject *
-tee_new(PyTypeObject *type, PyObject *args, PyObject *kw)
-{
-    PyObject *iterable;
+/*[clinic input]
+@classmethod
+itertools._tee.__new__ as tee_new
 
-    if (!PyArg_UnpackTuple(args, "_tee", 1, 1, &iterable))
-        return NULL;
+    iterable: object
+    /
+
+Create a _tee object.
+
+An iterator wrapped to make it copyable.
+[clinic start generated code]*/
+
+static PyObject *
+tee_new_impl(PyTypeObject *type, PyObject *iterable)
+/*[clinic end generated code: output=35aa9c64122b5871 input=827b5f7b19c54dfa]*/
+{
     return tee_fromiterable(iterable);
 }
 
@@ -725,14 +828,34 @@ tee_dealloc(teeobject *to)
     PyObject_GC_Del(to);
 }
 
+/*[clinic input]
+itertools._tee.__reduce__ as tee_reduce
+
+    to: self(type="teeobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-tee_reduce(teeobject *to)
+tee_reduce_impl(teeobject *to)
+/*[clinic end generated code: output=46a6d7b07fec2a40 input=63c43d1a548a83c8]*/
 {
     return Py_BuildValue("O(())(Oi)", Py_TYPE(to), to->dataobj, to->index);
 }
 
+/*[clinic input]
+itertools._tee.__setstate__ as tee_setstate
+
+    to: self(type="teeobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 tee_setstate(teeobject *to, PyObject *state)
+/*[clinic end generated code: output=3ff5ca72492e2610 input=1ed8907a9f02d536]*/
 {
     teedataobject *tdo;
     int index;
@@ -753,13 +876,10 @@ tee_setstate(teeobject *to, PyObject *state)
     Py_RETURN_NONE;
 }
 
-PyDoc_STRVAR(teeobject_doc,
-"Iterator wrapped to make it copyable");
-
 static PyMethodDef tee_methods[] = {
-    {"__copy__",        (PyCFunction)tee_copy,     METH_NOARGS, teecopy_doc},
-    {"__reduce__",      (PyCFunction)tee_reduce,   METH_NOARGS, reduce_doc},
-    {"__setstate__",    (PyCFunction)tee_setstate, METH_O,      setstate_doc},
+    TEE_COPY_METHODDEF
+    TEE_REDUCE_METHODDEF
+    TEE_SETSTATE_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -785,7 +905,7 @@ static PyTypeObject tee_type = {
     0,                                  /* tp_setattro */
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,            /* tp_flags */
-    teeobject_doc,                      /* tp_doc */
+    tee_new__doc__,                     /* tp_doc */
     (traverseproc)tee_traverse,         /* tp_traverse */
     (inquiry)tee_clear,                 /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -806,15 +926,29 @@ static PyTypeObject tee_type = {
     PyObject_GC_Del,                    /* tp_free */
 };
 
+/*[clinic input]
+itertools.tee as tee
+
+    iterable: object
+    n: Py_ssize_t = 2
+        number of independent iterators to return
+    /
+
+Returns a tuple of n independent iterators from a single iterable.
+
+Once this has been called, the original iterable should not be used anywhere
+else; otherwise, the iterable could get advanced without the tee objects (those
+in the returned tuple) being informed.
+[clinic start generated code]*/
+
 static PyObject *
-tee(PyObject *self, PyObject *args)
+tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n)
+/*[clinic end generated code: output=5159f48b66c422b4 input=a72b8ce4e9aa7cc9]*/
 {
-    Py_ssize_t i, n=2;
-    PyObject *it, *iterable, *copyable, *result;
+    Py_ssize_t i;
+    PyObject *it, *copyable, *result;
     _Py_IDENTIFIER(__copy__);
 
-    if (!PyArg_ParseTuple(args, "O|n", &iterable, &n))
-        return NULL;
     if (n < 0) {
         PyErr_SetString(PyExc_ValueError, "n must be >= 0");
         return NULL;
@@ -851,9 +985,6 @@ tee(PyObject *self, PyObject *args)
     return result;
 }
 
-PyDoc_STRVAR(tee_doc,
-"tee(iterable, n=2) --> tuple of n independent iterators.");
-
 
 /* cycle object **************************************************************/
 
@@ -867,19 +998,26 @@ typedef struct {
 
 static PyTypeObject cycle_type;
 
+/*[clinic input]
+@classmethod
+itertools.cycle.__new__ as cycle_new
+
+    iterable: object
+    /
+
+Create a cycle object.
+
+This object will return elements from the iterable until it is exhausted.
+Then it will repeat the sequence indefinitely.
+[clinic start generated code]*/
+
 static PyObject *
-cycle_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+cycle_new_impl(PyTypeObject *type, PyObject *iterable)
+/*[clinic end generated code: output=9c3c6a645f54603e input=fdd6c11dca6b1efe]*/
 {
     PyObject *it;
-    PyObject *iterable;
     PyObject *saved;
     cycleobject *lz;
-
-    if (type == &cycle_type && !_PyArg_NoKeywords("cycle", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "cycle", 1, 1, &iterable))
-        return NULL;
 
     /* Get iterator. */
     it = PyObject_GetIter(iterable);
@@ -956,8 +1094,17 @@ cycle_next(cycleobject *lz)
     return item;
 }
 
+/*[clinic input]
+itertools.cycle.__reduce__ as cycle_reduce
+
+    lz: self(type="cycleobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-cycle_reduce(cycleobject *lz)
+cycle_reduce_impl(cycleobject *lz)
+/*[clinic end generated code: output=f2b1f8bfd1d6423a input=248c55bc398cd5fa]*/
 {
     /* Create a new cycle with the iterator tuple, then set the saved state */
     if (lz->it == NULL) {
@@ -980,8 +1127,19 @@ cycle_reduce(cycleobject *lz)
                          lz->firstpass);
 }
 
+/*[clinic input]
+itertools.cycle.__setstate__ as cycle_setstate
+
+    lz: self(type="cycleobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 cycle_setstate(cycleobject *lz, PyObject *state)
+/*[clinic end generated code: output=9c82d80fdebf7705 input=840f2f296fe555a9]*/
 {
     PyObject *saved=NULL;
     int firstpass;
@@ -1000,18 +1158,11 @@ cycle_setstate(cycleobject *lz, PyObject *state)
 }
 
 static PyMethodDef cycle_methods[] = {
-    {"__reduce__",      (PyCFunction)cycle_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)cycle_setstate,    METH_O,
-     setstate_doc},
+    CYCLE_REDUCE_METHODDEF
+    CYCLE_SETSTATE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(cycle_doc,
-"cycle(iterable) --> cycle object\n\
-\n\
-Return elements from the iterable until it is exhausted.\n\
-Then repeat the sequence indefinitely.");
 
 static PyTypeObject cycle_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -1036,7 +1187,7 @@ static PyTypeObject cycle_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    cycle_doc,                          /* tp_doc */
+    cycle_new__doc__,                   /* tp_doc */
     (traverseproc)cycle_traverse,       /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -1069,21 +1220,30 @@ typedef struct {
 
 static PyTypeObject dropwhile_type;
 
+/*[clinic input]
+@classmethod
+itertools.dropwhile.__new__ as dropwhile_new
+
+    predicate: object
+    iterable: object
+    /
+
+Create a dropwhile object.
+
+Drops items from the iterable while predicate(item) is true.
+Afterwards, returns every element until the iterable is exhausted.
+[clinic start generated code]*/
+
 static PyObject *
-dropwhile_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+dropwhile_new_impl(PyTypeObject *type, PyObject *predicate,
+                   PyObject *iterable)
+/*[clinic end generated code: output=68ccecb645b70e7c input=b4d0e3c961817403]*/
 {
-    PyObject *func, *seq;
     PyObject *it;
     dropwhileobject *lz;
 
-    if (type == &dropwhile_type && !_PyArg_NoKeywords("dropwhile", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "dropwhile", 2, 2, &func, &seq))
-        return NULL;
-
     /* Get iterator. */
-    it = PyObject_GetIter(seq);
+    it = PyObject_GetIter(iterable);
     if (it == NULL)
         return NULL;
 
@@ -1093,8 +1253,8 @@ dropwhile_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         Py_DECREF(it);
         return NULL;
     }
-    Py_INCREF(func);
-    lz->func = func;
+    Py_INCREF(predicate);
+    lz->func = predicate;
     lz->it = it;
     lz->start = 0;
 
@@ -1151,14 +1311,34 @@ dropwhile_next(dropwhileobject *lz)
     }
 }
 
+/*[clinic input]
+itertools.dropwhile.__reduce__ as dropwhile_reduce
+
+    lz: self(type="dropwhileobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-dropwhile_reduce(dropwhileobject *lz)
+dropwhile_reduce_impl(dropwhileobject *lz)
+/*[clinic end generated code: output=df490b72b8892732 input=6abc87d157f1ff18]*/
 {
     return Py_BuildValue("O(OO)l", Py_TYPE(lz), lz->func, lz->it, lz->start);
 }
 
+/*[clinic input]
+itertools.dropwhile.__setstate__ as dropwhile_setstate
+
+    lz: self(type="dropwhileobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 dropwhile_setstate(dropwhileobject *lz, PyObject *state)
+/*[clinic end generated code: output=fd28c2f3fc19f7a1 input=397b3ecd83cbe6a4]*/
 {
     int start = PyObject_IsTrue(state);
     if (start < 0)
@@ -1168,18 +1348,10 @@ dropwhile_setstate(dropwhileobject *lz, PyObject *state)
 }
 
 static PyMethodDef dropwhile_methods[] = {
-    {"__reduce__",      (PyCFunction)dropwhile_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)dropwhile_setstate,    METH_O,
-     setstate_doc},
+    DROPWHILE_REDUCE_METHODDEF
+    DROPWHILE_SETSTATE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
-
-PyDoc_STRVAR(dropwhile_doc,
-"dropwhile(predicate, iterable) --> dropwhile object\n\
-\n\
-Drop items from the iterable while predicate(item) is true.\n\
-Afterwards, return every element until the iterable is exhausted.");
 
 static PyTypeObject dropwhile_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -1204,7 +1376,7 @@ static PyTypeObject dropwhile_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    dropwhile_doc,                      /* tp_doc */
+    dropwhile_new__doc__,               /* tp_doc */
     (traverseproc)dropwhile_traverse,   /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -1237,21 +1409,30 @@ typedef struct {
 
 static PyTypeObject takewhile_type;
 
+/*[clinic input]
+@classmethod
+itertools.takewhile.__new__ as takewhile_new
+
+    predicate: object
+    iterable: object
+    /
+
+Create a takewhile object.
+
+Return successive entries from an iterable as long as the
+predicate evaluates to true for each entry.
+[clinic start generated code]*/
+
 static PyObject *
-takewhile_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+takewhile_new_impl(PyTypeObject *type, PyObject *predicate,
+                   PyObject *iterable)
+/*[clinic end generated code: output=ec1277335df81046 input=984bd1d6e5854510]*/
 {
-    PyObject *func, *seq;
     PyObject *it;
     takewhileobject *lz;
 
-    if (type == &takewhile_type && !_PyArg_NoKeywords("takewhile", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "takewhile", 2, 2, &func, &seq))
-        return NULL;
-
     /* Get iterator. */
-    it = PyObject_GetIter(seq);
+    it = PyObject_GetIter(iterable);
     if (it == NULL)
         return NULL;
 
@@ -1261,8 +1442,8 @@ takewhile_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         Py_DECREF(it);
         return NULL;
     }
-    Py_INCREF(func);
-    lz->func = func;
+    Py_INCREF(predicate);
+    lz->func = predicate;
     lz->it = it;
     lz->stop = 0;
 
@@ -1315,14 +1496,34 @@ takewhile_next(takewhileobject *lz)
     return NULL;
 }
 
+/*[clinic input]
+itertools.takewhile.__reduce__ as takewhile_reduce
+
+    lz: self(type="takewhileobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-takewhile_reduce(takewhileobject *lz)
+takewhile_reduce_impl(takewhileobject *lz)
+/*[clinic end generated code: output=f7b9e63cb66dc9e7 input=20da021310e98c13]*/
 {
     return Py_BuildValue("O(OO)l", Py_TYPE(lz), lz->func, lz->it, lz->stop);
 }
 
+/*[clinic input]
+itertools.takewhile.__setstate__ as takewhile_setstate
+
+    lz: self(type="takewhileobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
-takewhile_reduce_setstate(takewhileobject *lz, PyObject *state)
+takewhile_setstate(takewhileobject *lz, PyObject *state)
+/*[clinic end generated code: output=66165bddfa716106 input=84532fc48b901e96]*/
 {
     int stop = PyObject_IsTrue(state);
 
@@ -1333,17 +1534,10 @@ takewhile_reduce_setstate(takewhileobject *lz, PyObject *state)
 }
 
 static PyMethodDef takewhile_reduce_methods[] = {
-    {"__reduce__",      (PyCFunction)takewhile_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)takewhile_reduce_setstate,    METH_O,
-     setstate_doc},
+    TAKEWHILE_REDUCE_METHODDEF
+    TAKEWHILE_SETSTATE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
-PyDoc_STRVAR(takewhile_doc,
-"takewhile(predicate, iterable) --> takewhile object\n\
-\n\
-Return successive entries from an iterable as long as the \n\
-predicate evaluates to true for each entry.");
 
 static PyTypeObject takewhile_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -1368,7 +1562,7 @@ static PyTypeObject takewhile_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    takewhile_doc,                      /* tp_doc */
+    takewhile_new__doc__,               /* tp_doc */
     (traverseproc)takewhile_traverse,   /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -1541,8 +1735,17 @@ empty:
     return NULL;
 }
 
+/*[clinic input]
+itertools.islice.__reduce__ as islice_reduce
+
+    lz: self(type="isliceobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-islice_reduce(isliceobject *lz)
+islice_reduce_impl(isliceobject *lz)
+/*[clinic end generated code: output=17608d57ce05ea0f input=2f71fe7c46f200f2]*/
 {
     /* When unpickled, generate a new object with the same bounds,
      * then 'setstate' with the next and count
@@ -1574,8 +1777,19 @@ islice_reduce(isliceobject *lz)
         lz->cnt);
 }
 
+/*[clinic input]
+itertools.islice.__setstate__ as islice_setstate
+
+    lz: self(type="isliceobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 islice_setstate(isliceobject *lz, PyObject *state)
+/*[clinic end generated code: output=9d7a4479159c852e input=1e1a67c001a84c75]*/
 {
     Py_ssize_t cnt = PyLong_AsSsize_t(state);
 
@@ -1586,10 +1800,8 @@ islice_setstate(isliceobject *lz, PyObject *state)
 }
 
 static PyMethodDef islice_methods[] = {
-    {"__reduce__",      (PyCFunction)islice_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)islice_setstate,    METH_O,
-     setstate_doc},
+    ISLICE_REDUCE_METHODDEF
+    ISLICE_SETSTATE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -1659,21 +1871,28 @@ typedef struct {
 
 static PyTypeObject starmap_type;
 
+/*[clinic input]
+@classmethod
+itertools.starmap.__new__ as starmap_new
+
+    function: object
+    iterable: object
+
+Create a starmap object.
+
+Return an iterator whose values are returned from the function evaluated
+with a argument tuple taken from the given iterable.
+[clinic start generated code]*/
+
 static PyObject *
-starmap_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+starmap_new_impl(PyTypeObject *type, PyObject *function, PyObject *iterable)
+/*[clinic end generated code: output=18acf452cb6c526c input=579f9b3e0229a194]*/
 {
-    PyObject *func, *seq;
     PyObject *it;
     starmapobject *lz;
 
-    if (type == &starmap_type && !_PyArg_NoKeywords("starmap", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "starmap", 2, 2, &func, &seq))
-        return NULL;
-
     /* Get iterator. */
-    it = PyObject_GetIter(seq);
+    it = PyObject_GetIter(iterable);
     if (it == NULL)
         return NULL;
 
@@ -1683,8 +1902,8 @@ starmap_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         Py_DECREF(it);
         return NULL;
     }
-    Py_INCREF(func);
-    lz->func = func;
+    Py_INCREF(function);
+    lz->func = function;
     lz->it = it;
 
     return (PyObject *)lz;
@@ -1729,16 +1948,24 @@ starmap_next(starmapobject *lz)
     return result;
 }
 
+/*[clinic input]
+itertools.starmap.__reduce__ as starmap_reduce
+
+    lz: self(type="starmapobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-starmap_reduce(starmapobject *lz)
+starmap_reduce_impl(starmapobject *lz)
+/*[clinic end generated code: output=f37e06d630220ddd input=8101a8f2910ff54d]*/
 {
     /* Just pickle the iterator */
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
 }
 
 static PyMethodDef starmap_methods[] = {
-    {"__reduce__",      (PyCFunction)starmap_reduce,      METH_NOARGS,
-     reduce_doc},
+    STARMAP_REDUCE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -1771,7 +1998,7 @@ static PyTypeObject starmap_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    starmap_doc,                        /* tp_doc */
+    starmap_new__doc__,                 /* tp_doc */
     (traverseproc)starmap_traverse,     /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -1834,12 +2061,26 @@ chain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return chain_new_internal(type, source);
 }
 
+/*[clinic input]
+@classmethod
+itertools.chain.from_iterable as chain_new_from_iterable
+
+    iterable: object
+    /
+
+Create a chain object.
+
+Alternate chain() contructor taking a single iterable argument
+that evaluates lazily.
+[clinic start generated code]*/
+
 static PyObject *
-chain_new_from_iterable(PyTypeObject *type, PyObject *arg)
+chain_new_from_iterable(PyTypeObject *type, PyObject *iterable)
+/*[clinic end generated code: output=2d5fc751e73b5a67 input=1f1c99200abefc48]*/
 {
     PyObject *source;
 
-    source = PyObject_GetIter(arg);
+    source = PyObject_GetIter(iterable);
     if (source == NULL)
         return NULL;
 
@@ -1901,8 +2142,17 @@ chain_next(chainobject *lz)
     return NULL;
 }
 
+/*[clinic input]
+itertools.chain.__reduce__ as chain_reduce
+
+    lz: self(type="chainobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-chain_reduce(chainobject *lz)
+chain_reduce_impl(chainobject *lz)
+/*[clinic end generated code: output=b9cfb60a29f977bc input=3c84dbccd41cefd6]*/
 {
     if (lz->source) {
         /* we can't pickle function objects (itertools.from_iterable) so
@@ -1920,8 +2170,19 @@ chain_reduce(chainobject *lz)
     return NULL;
 }
 
+/*[clinic input]
+itertools.chain.__setstate__ as chain_setstate
+
+    lz: self(type="chainobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 chain_setstate(chainobject *lz, PyObject *state)
+/*[clinic end generated code: output=5985fde1d79cb81f input=e376ccaff1fb8e28]*/
 {
     PyObject *source, *active=NULL;
 
@@ -1951,19 +2212,10 @@ Return a chain object whose .__next__() method returns elements from the\n\
 first iterable until it is exhausted, then elements from the next\n\
 iterable, until all of the iterables are exhausted.");
 
-PyDoc_STRVAR(chain_from_iterable_doc,
-"chain.from_iterable(iterable) --> chain object\n\
-\n\
-Alternate chain() constructor taking a single iterable argument\n\
-that evaluates lazily.");
-
 static PyMethodDef chain_methods[] = {
-    {"from_iterable", (PyCFunction) chain_new_from_iterable, METH_O | METH_CLASS,
-     chain_from_iterable_doc},
-    {"__reduce__",      (PyCFunction)chain_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)chain_setstate,    METH_O,
-     setstate_doc},
+    CHAIN_NEW_FROM_ITERABLE_METHODDEF
+    CHAIN_REDUCE_METHODDEF
+    CHAIN_SETSTATE_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -2118,8 +2370,17 @@ product_dealloc(productobject *lz)
     Py_TYPE(lz)->tp_free(lz);
 }
 
+/*[clinic input]
+itertools.product.__sizeof__ as product_sizeof
+
+    lz: self(type="productobject *")
+
+Returns size in memory, in bytes.
+[clinic start generated code]*/
+
 static PyObject *
-product_sizeof(productobject *lz, void *unused)
+product_sizeof_impl(productobject *lz)
+/*[clinic end generated code: output=a943d0f6487dbee1 input=13df894cf42c4ae2]*/
 {
     Py_ssize_t res;
 
@@ -2127,8 +2388,6 @@ product_sizeof(productobject *lz, void *unused)
     res += PyTuple_GET_SIZE(lz->pools) * sizeof(Py_ssize_t);
     return PyLong_FromSsize_t(res);
 }
-
-PyDoc_STRVAR(sizeof_doc, "Returns size in memory, in bytes.");
 
 static int
 product_traverse(productobject *lz, visitproc visit, void *arg)
@@ -2225,8 +2484,17 @@ empty:
     return NULL;
 }
 
+/*[clinic input]
+itertools.product.__reduce__ as product_reduce
+
+    lz: self(type="productobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-product_reduce(productobject *lz)
+product_reduce_impl(productobject *lz)
+/*[clinic end generated code: output=780ff23bb8dd0557 input=d20b4bf62464277a]*/
 {
     if (lz->stopped) {
         return Py_BuildValue("O(())", Py_TYPE(lz));
@@ -2255,8 +2523,19 @@ product_reduce(productobject *lz)
     }
 }
 
+/*[clinic input]
+itertools.product.__setstate__ as product_setstate
+
+    lz: self(type="productobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 product_setstate(productobject *lz, PyObject *state)
+/*[clinic end generated code: output=e28c92b80c88e261 input=6e813de246d596e0]*/
 {
     PyObject *result;
     Py_ssize_t n, i;
@@ -2302,12 +2581,9 @@ product_setstate(productobject *lz, PyObject *state)
 }
 
 static PyMethodDef product_methods[] = {
-    {"__reduce__",      (PyCFunction)product_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)product_setstate,    METH_O,
-     setstate_doc},
-    {"__sizeof__",      (PyCFunction)product_sizeof,      METH_NOARGS,
-     sizeof_doc},
+    PRODUCT_REDUCE_METHODDEF
+    PRODUCT_SETSTATE_METHODDEF
+    PRODUCT_SIZEOF_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -2383,21 +2659,30 @@ typedef struct {
 
 static PyTypeObject combinations_type;
 
+/*[clinic input]
+@classmethod
+itertools.combinations.__new__ as combinations_new
+
+    iterable: object
+    r: Py_ssize_t
+
+Create a combinations object.
+
+Returns successive r-length combinations of elements in the iterable.
+
+Example:
+combinations(range(4), 3) --> (0,1,2), (0,1,3), (0,2,3), (1,2,3)
+[clinic start generated code]*/
+
 static PyObject *
-combinations_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+combinations_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t r)
+/*[clinic end generated code: output=dcd9df4d7c03311f input=95fa7897cc2fc49c]*/
 {
     combinationsobject *co;
     Py_ssize_t n;
-    Py_ssize_t r;
     PyObject *pool = NULL;
-    PyObject *iterable = NULL;
     Py_ssize_t *indices = NULL;
     Py_ssize_t i;
-    static char *kwargs[] = {"iterable", "r", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "On:combinations", kwargs,
-                                     &iterable, &r))
-        return NULL;
 
     pool = PySequence_Tuple(iterable);
     if (pool == NULL)
@@ -2448,8 +2733,17 @@ combinations_dealloc(combinationsobject *co)
     Py_TYPE(co)->tp_free(co);
 }
 
+/*[clinic input]
+itertools.combinations.__sizeof__ as combinations_sizeof
+
+    co: self(type="combinationsobject *")
+
+Returns size in memory, in bytes.
+[clinic start generated code]*/
+
 static PyObject *
-combinations_sizeof(combinationsobject *co, void *unused)
+combinations_sizeof_impl(combinationsobject *co)
+/*[clinic end generated code: output=b5bf6fa9dc59e413 input=aca277f15aec905e]*/
 {
     Py_ssize_t res;
 
@@ -2552,8 +2846,17 @@ empty:
     return NULL;
 }
 
+/*[clinic input]
+itertools.combinations.__reduce__ as combinations_reduce
+
+    lz: self(type="combinationsobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-combinations_reduce(combinationsobject *lz)
+combinations_reduce_impl(combinationsobject *lz)
+/*[clinic end generated code: output=2dbd90d424ca2a58 input=85cd3171e4f80093]*/
 {
     if (lz->result == NULL) {
         return Py_BuildValue("O(On)", Py_TYPE(lz), lz->pool, lz->r);
@@ -2581,8 +2884,19 @@ combinations_reduce(combinationsobject *lz)
     }
 }
 
+/*[clinic input]
+itertools.combinations.__setstate__ as combinations_setstate
+
+    lz: self(type="combinationsobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 combinations_setstate(combinationsobject *lz, PyObject *state)
+/*[clinic end generated code: output=07388313134a205e input=0e3f5c7702c3f205]*/
 {
     PyObject *result;
     Py_ssize_t i;
@@ -2623,20 +2937,11 @@ combinations_setstate(combinationsobject *lz, PyObject *state)
 }
 
 static PyMethodDef combinations_methods[] = {
-    {"__reduce__",      (PyCFunction)combinations_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)combinations_setstate,    METH_O,
-     setstate_doc},
-    {"__sizeof__",      (PyCFunction)combinations_sizeof,      METH_NOARGS,
-     sizeof_doc},
+    COMBINATIONS_REDUCE_METHODDEF
+    COMBINATIONS_SETSTATE_METHODDEF
+    COMBINATIONS_SIZEOF_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
-
-PyDoc_STRVAR(combinations_doc,
-"combinations(iterable, r) --> combinations object\n\
-\n\
-Return successive r-length combinations of elements in the iterable.\n\n\
-combinations(range(4), 3) --> (0,1,2), (0,1,3), (0,2,3), (1,2,3)");
 
 static PyTypeObject combinations_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -2661,7 +2966,7 @@ static PyTypeObject combinations_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    combinations_doc,                   /* tp_doc */
+    combinations_new__doc__,            /* tp_doc */
     (traverseproc)combinations_traverse,/* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -2722,22 +3027,32 @@ typedef struct {
 
 static PyTypeObject cwr_type;
 
+/*[clinic input]
+@classmethod
+itertools.combinations_with_replacement.__new__ as cwr_new
+
+    iterable: object
+    r: Py_ssize_t
+
+Create a combinations object.
+
+Returns successive r-length combinations of elements in the iterable allowing
+individual elements to have successive repeats.
+
+Example:
+combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC
+[clinic start generated code]*/
+
 static PyObject *
-cwr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+cwr_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t r)
+/*[clinic end generated code: output=14e1057a23897a3f input=9f05a18553d8ae6b]*/
 {
     cwrobject *co;
     Py_ssize_t n;
-    Py_ssize_t r;
     PyObject *pool = NULL;
-    PyObject *iterable = NULL;
     Py_ssize_t *indices = NULL;
     Py_ssize_t i;
     static char *kwargs[] = {"iterable", "r", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                                     "On:combinations_with_replacement",
-                                     kwargs, &iterable, &r))
-        return NULL;
 
     pool = PySequence_Tuple(iterable);
     if (pool == NULL)
@@ -2788,8 +3103,17 @@ cwr_dealloc(cwrobject *co)
     Py_TYPE(co)->tp_free(co);
 }
 
+/*[clinic input]
+itertools.combinations_with_replacement.__sizeof__ as cwr_sizeof
+
+    co: self(type="cwrobject *")
+
+Returns size in memory, in bytes.
+[clinic start generated code]*/
+
 static PyObject *
-cwr_sizeof(cwrobject *co, void *unused)
+cwr_sizeof_impl(cwrobject *co)
+/*[clinic end generated code: output=fa9aa8e2438d6659 input=140461199e63fd20]*/
 {
     Py_ssize_t res;
 
@@ -2886,8 +3210,17 @@ empty:
     return NULL;
 }
 
+/*[clinic input]
+itertools.combinations_with_replacement.__reduce__ as cwr_reduce
+
+    lz: self(type="cwrobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-cwr_reduce(cwrobject *lz)
+cwr_reduce_impl(cwrobject *lz)
+/*[clinic end generated code: output=f20771ee5c58bf7b input=699bd8614edb3264]*/
 {
     if (lz->result == NULL) {
         return Py_BuildValue("O(On)", Py_TYPE(lz), lz->pool, lz->r);
@@ -2914,8 +3247,19 @@ cwr_reduce(cwrobject *lz)
     }
 }
 
+/*[clinic input]
+itertools.combinations_with_replacement.__setstate__ as cwr_setstate
+
+    lz: self(type="cwrobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 cwr_setstate(cwrobject *lz, PyObject *state)
+/*[clinic end generated code: output=6b99738e81d51f65 input=f95a94fba268902e]*/
 {
     PyObject *result;
     Py_ssize_t n, i;
@@ -2953,21 +3297,11 @@ cwr_setstate(cwrobject *lz, PyObject *state)
 }
 
 static PyMethodDef cwr_methods[] = {
-    {"__reduce__",      (PyCFunction)cwr_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)cwr_setstate,    METH_O,
-     setstate_doc},
-    {"__sizeof__",      (PyCFunction)cwr_sizeof,      METH_NOARGS,
-     sizeof_doc},
+    CWR_REDUCE_METHODDEF
+    CWR_SETSTATE_METHODDEF
+    CWR_SIZEOF_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
-
-PyDoc_STRVAR(cwr_doc,
-"combinations_with_replacement(iterable, r) --> combinations_with_replacement object\n\
-\n\
-Return successive r-length combinations of elements in the iterable\n\
-allowing individual elements to have successive repeats.\n\
-combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC");
 
 static PyTypeObject cwr_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -2992,7 +3326,7 @@ static PyTypeObject cwr_type = {
     0,                                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,                            /* tp_flags */
-    cwr_doc,                                            /* tp_doc */
+    cwr_new__doc__,                                     /* tp_doc */
     (traverseproc)cwr_traverse,                         /* tp_traverse */
     0,                                                  /* tp_clear */
     0,                                                  /* tp_richcompare */
@@ -3051,23 +3385,32 @@ typedef struct {
 
 static PyTypeObject permutations_type;
 
+/*[clinic input]
+@classmethod
+itertools.permutations.__new__ as permutations_new
+
+    iterable: object
+    r as robj: object = None
+
+Create a permutations object.
+
+Returns successive r-length permutations of elements in the iterable.
+
+Example:
+permutations(range(3), 2) --> (0,1), (0,2), (1,0), (1,2), (2,0), (2,1)
+[clinic start generated code]*/
+
 static PyObject *
-permutations_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+permutations_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *robj)
+/*[clinic end generated code: output=582d59fa75ce954a input=13f00959831dc55e]*/
 {
     permutationsobject *po;
     Py_ssize_t n;
     Py_ssize_t r;
-    PyObject *robj = Py_None;
     PyObject *pool = NULL;
-    PyObject *iterable = NULL;
     Py_ssize_t *indices = NULL;
     Py_ssize_t *cycles = NULL;
     Py_ssize_t i;
-    static char *kwargs[] = {"iterable", "r", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:permutations", kwargs,
-                                     &iterable, &robj))
-        return NULL;
 
     pool = PySequence_Tuple(iterable);
     if (pool == NULL)
@@ -3135,8 +3478,17 @@ permutations_dealloc(permutationsobject *po)
     Py_TYPE(po)->tp_free(po);
 }
 
+/*[clinic input]
+itertools.permutations.__sizeof__ as permutations_sizeof
+
+    po: self(type="permutationsobject *")
+
+Returns size in memory, in bytes.
+[clinic start generated code]*/
+
 static PyObject *
-permutations_sizeof(permutationsobject *po, void *unused)
+permutations_sizeof_impl(permutationsobject *po)
+/*[clinic end generated code: output=b7e8c75b02b8e2c2 input=6cc92f69030f504d]*/
 {
     Py_ssize_t res;
 
@@ -3245,8 +3597,17 @@ empty:
     return NULL;
 }
 
+/*[clinic input]
+itertools.permutations.__reduce__ as permutations_reduce
+
+    po: self(type="permutationsobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-permutations_reduce(permutationsobject *po)
+permutations_reduce_impl(permutationsobject *po)
+/*[clinic end generated code: output=02671f3b618ce7da input=bd7744eca6b1b799]*/
 {
     if (po->result == NULL) {
         return Py_BuildValue("O(On)", Py_TYPE(po), po->pool, po->r);
@@ -3287,8 +3648,19 @@ permutations_reduce(permutationsobject *po)
     }
 }
 
+/*[clinic input]
+itertools.permutations.__setstate__ as permutations_setstate
+
+    po: self(type="permutationsobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 permutations_setstate(permutationsobject *po, PyObject *state)
+/*[clinic end generated code: output=86e8f8575c33f13a input=ecd8953efad338b0]*/
 {
     PyObject *indices, *cycles, *result;
     Py_ssize_t n, i;
@@ -3346,20 +3718,11 @@ permutations_setstate(permutationsobject *po, PyObject *state)
 }
 
 static PyMethodDef permuations_methods[] = {
-    {"__reduce__",      (PyCFunction)permutations_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)permutations_setstate,    METH_O,
-     setstate_doc},
-    {"__sizeof__",      (PyCFunction)permutations_sizeof,      METH_NOARGS,
-     sizeof_doc},
+    PERMUTATIONS_REDUCE_METHODDEF
+    PERMUTATIONS_SETSTATE_METHODDEF
+    PERMUTATIONS_SIZEOF_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
-
-PyDoc_STRVAR(permutations_doc,
-"permutations(iterable[, r]) --> permutations object\n\
-\n\
-Return successive r-length permutations of elements in the iterable.\n\n\
-permutations(range(3), 2) --> (0,1), (0,2), (1,0), (1,2), (2,0), (2,1)");
 
 static PyTypeObject permutations_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -3384,7 +3747,7 @@ static PyTypeObject permutations_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    permutations_doc,                   /* tp_doc */
+    permutations_new__doc__,            /* tp_doc */
     (traverseproc)permutations_traverse,/* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -3416,18 +3779,24 @@ typedef struct {
 
 static PyTypeObject accumulate_type;
 
-static PyObject *
-accumulate_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
-{
-    static char *kwargs[] = {"iterable", "func", NULL};
-    PyObject *iterable;
-    PyObject *it;
-    PyObject *binop = Py_None;
-    accumulateobject *lz;
+/*[clinic input]
+@classmethod
+itertools.accumulate.__new__ as accumulate_new
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:accumulate",
-                                     kwargs, &iterable, &binop))
-        return NULL;
+    iterable: object
+    func: object = None
+
+Create an accumulate object.
+
+Return series of accumulated sums (or other binary function results).
+[clinic start generated code]*/
+
+static PyObject *
+accumulate_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *func)
+/*[clinic end generated code: output=784ef75e8d15e887 input=12f7c760779995b6]*/
+{
+    PyObject *it;
+    accumulateobject *lz;
 
     /* Get iterator. */
     it = PyObject_GetIter(iterable);
@@ -3441,9 +3810,9 @@ accumulate_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
 
-    if (binop != Py_None) {
-        Py_XINCREF(binop);
-        lz->binop = binop;
+    if (func != Py_None) {
+        Py_XINCREF(func);
+        lz->binop = func;
     }
     lz->total = NULL;
     lz->it = it;
@@ -3497,8 +3866,17 @@ accumulate_next(accumulateobject *lz)
     return newtotal;
 }
 
+/*[clinic input]
+itertools.accumulate.__reduce__ as accumulate_reduce
+
+    lz: self(type="accumulateobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-accumulate_reduce(accumulateobject *lz)
+accumulate_reduce_impl(accumulateobject *lz)
+/*[clinic end generated code: output=2283d4373f698981 input=f247f0e80b550470]*/
 {
     if (lz->total == Py_None) {
         PyObject *it;
@@ -3522,8 +3900,19 @@ accumulate_reduce(accumulateobject *lz)
                             lz->total?lz->total:Py_None);
 }
 
+/*[clinic input]
+itertools.accumulate.__setstate__ as accumulate_setstate
+
+    lz: self(type="accumulateobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 accumulate_setstate(accumulateobject *lz, PyObject *state)
+/*[clinic end generated code: output=f29ac8c980f53fb5 input=7dfef829558611fc]*/
 {
     Py_INCREF(state);
     Py_XSETREF(lz->total, state);
@@ -3531,17 +3920,10 @@ accumulate_setstate(accumulateobject *lz, PyObject *state)
 }
 
 static PyMethodDef accumulate_methods[] = {
-    {"__reduce__",      (PyCFunction)accumulate_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)accumulate_setstate,    METH_O,
-     setstate_doc},
+    ACCUMULATE_REDUCE_METHODDEF
+    ACCUMULATE_SETSTATE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
-
-PyDoc_STRVAR(accumulate_doc,
-"accumulate(iterable[, func]) --> accumulate object\n\
-\n\
-Return series of accumulated sums (or other binary function results).");
 
 static PyTypeObject accumulate_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -3566,7 +3948,7 @@ static PyTypeObject accumulate_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    accumulate_doc,                     /* tp_doc */
+    accumulate_new__doc__,              /* tp_doc */
     (traverseproc)accumulate_traverse,  /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -3605,35 +3987,45 @@ typedef struct {
 
 static PyTypeObject compress_type;
 
+/*[clinic input]
+@classmethod
+itertools.compress.__new__ as compress_new
+
+    data: object
+    selectors: object
+
+Create a compress object.
+
+Return data elements corresponding to true selector elements.
+Forms a shorter iterator from selected data elements using the
+selectors to choose the data elements.
+[clinic start generated code]*/
+
 static PyObject *
-compress_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+compress_new_impl(PyTypeObject *type, PyObject *data, PyObject *selectors)
+/*[clinic end generated code: output=e3726e87f1cf6ba4 input=2d99935f390029a2]*/
 {
-    PyObject *seq1, *seq2;
-    PyObject *data=NULL, *selectors=NULL;
+    PyObject *data_iter=NULL, *selectors_iter=NULL;
     compressobject *lz;
-    static char *kwargs[] = {"data", "selectors", NULL};
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO:compress", kwargs, &seq1, &seq2))
-        return NULL;
-
-    data = PyObject_GetIter(seq1);
-    if (data == NULL)
+    data_iter = PyObject_GetIter(data);
+    if (data_iter == NULL)
         goto fail;
-    selectors = PyObject_GetIter(seq2);
-    if (selectors == NULL)
+    selectors_iter = PyObject_GetIter(selectors);
+    if (selectors_iter == NULL)
         goto fail;
 
     /* create compressobject structure */
     lz = (compressobject *)type->tp_alloc(type, 0);
     if (lz == NULL)
         goto fail;
-    lz->data = data;
-    lz->selectors = selectors;
+    lz->data = data_iter;
+    lz->selectors = selectors_iter;
     return (PyObject *)lz;
 
 fail:
-    Py_XDECREF(data);
-    Py_XDECREF(selectors);
+    Py_XDECREF(data_iter);
+    Py_XDECREF(selectors_iter);
     return NULL;
 }
 
@@ -3690,25 +4082,26 @@ compress_next(compressobject *lz)
     }
 }
 
+/*[clinic input]
+itertools.compress.__reduce__ as compress_reduce
+
+    lz: self(type="compressobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-compress_reduce(compressobject *lz)
+compress_reduce_impl(compressobject *lz)
+/*[clinic end generated code: output=bfc478e270a28115 input=3e864458db0eccf9]*/
 {
     return Py_BuildValue("O(OO)", Py_TYPE(lz),
         lz->data, lz->selectors);
 }
 
 static PyMethodDef compress_methods[] = {
-    {"__reduce__",      (PyCFunction)compress_reduce,      METH_NOARGS,
-     reduce_doc},
+    COMPRESS_REDUCE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
-
-PyDoc_STRVAR(compress_doc,
-"compress(data, selectors) --> iterator over selected data\n\
-\n\
-Return data elements corresponding to true selector elements.\n\
-Forms a shorter iterator from selected data elements using the\n\
-selectors to choose the data elements.");
 
 static PyTypeObject compress_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -3733,7 +4126,7 @@ static PyTypeObject compress_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    compress_doc,                       /* tp_doc */
+    compress_new__doc__,                /* tp_doc */
     (traverseproc)compress_traverse,    /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -3765,22 +4158,30 @@ typedef struct {
 
 static PyTypeObject filterfalse_type;
 
+/*[clinic input]
+@classmethod
+itertools.filterfalse.__new__ as filterfalse_new
+
+    function: object
+    iterable: object
+    /
+
+Create a filterfalse object.
+
+Return those items of iterable for which function(item) is false.
+If function is None, return the items that are false.
+[clinic start generated code]*/
+
 static PyObject *
-filterfalse_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+filterfalse_new_impl(PyTypeObject *type, PyObject *function,
+                     PyObject *iterable)
+/*[clinic end generated code: output=d8a4c0a668fcea69 input=3ea201239931baaa]*/
 {
-    PyObject *func, *seq;
     PyObject *it;
     filterfalseobject *lz;
 
-    if (type == &filterfalse_type &&
-        !_PyArg_NoKeywords("filterfalse", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "filterfalse", 2, 2, &func, &seq))
-        return NULL;
-
     /* Get iterator. */
-    it = PyObject_GetIter(seq);
+    it = PyObject_GetIter(iterable);
     if (it == NULL)
         return NULL;
 
@@ -3790,8 +4191,8 @@ filterfalse_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         Py_DECREF(it);
         return NULL;
     }
-    Py_INCREF(func);
-    lz->func = func;
+    Py_INCREF(function);
+    lz->func = function;
     lz->it = it;
 
     return (PyObject *)lz;
@@ -3848,23 +4249,25 @@ filterfalse_next(filterfalseobject *lz)
     }
 }
 
+/*[clinic input]
+itertools.filterfalse.__reduce__ as filterfalse_reduce
+
+    lz: self(type="filterfalseobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-filterfalse_reduce(filterfalseobject *lz)
+filterfalse_reduce_impl(filterfalseobject *lz)
+/*[clinic end generated code: output=ac8620bdd55ddf72 input=2b3852a10df5d06c]*/
 {
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
 }
 
 static PyMethodDef filterfalse_methods[] = {
-    {"__reduce__",      (PyCFunction)filterfalse_reduce,      METH_NOARGS,
-     reduce_doc},
+    FILTERFALSE_REDUCE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
-
-PyDoc_STRVAR(filterfalse_doc,
-"filterfalse(function or None, sequence) --> filterfalse object\n\
-\n\
-Return those items of sequence for which function(item) is false.\n\
-If function is None, return the items that are false.");
 
 static PyTypeObject filterfalse_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -3889,7 +4292,7 @@ static PyTypeObject filterfalse_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    filterfalse_doc,                    /* tp_doc */
+    filterfalse_new__doc__,             /* tp_doc */
     (traverseproc)filterfalse_traverse, /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -3939,35 +4342,48 @@ slow_mode:  when cnt == PY_SSIZE_T_MAX, step is not int(1), or cnt is a float.
 
 static PyTypeObject count_type;
 
+/*[clinic input]
+@classmethod
+itertools.count.__new__ as count_new
+
+    start: object = NULL
+    step: object = NULL
+
+Create a count object.
+
+Return a count object whose .__next__() method returns consecutive values.
+Equivalent to:
+
+    def count(firstval=0, step=1):
+        x = firstval
+        while 1:
+            yield x
+            x += step
+[clinic start generated code]*/
+
 static PyObject *
-count_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+count_new_impl(PyTypeObject *type, PyObject *start, PyObject *step)
+/*[clinic end generated code: output=1df9fad69d29f4ec input=2576781c3efb35bf]*/
 {
     countobject *lz;
     int fast_mode;
     Py_ssize_t cnt = 0;
-    PyObject *long_cnt = NULL;
-    PyObject *long_step = NULL;
-    long step;
-    static char *kwlist[] = {"start", "step", 0};
+    long step_long;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO:count",
-                    kwlist, &long_cnt, &long_step))
-        return NULL;
-
-    if ((long_cnt != NULL && !PyNumber_Check(long_cnt)) ||
-        (long_step != NULL && !PyNumber_Check(long_step))) {
+    if ((start != NULL && !PyNumber_Check(start)) ||
+        (step != NULL && !PyNumber_Check(step))) {
                     PyErr_SetString(PyExc_TypeError, "a number is required");
                     return NULL;
     }
 
-    fast_mode = (long_cnt == NULL || PyLong_Check(long_cnt)) &&
-                (long_step == NULL || PyLong_Check(long_step));
+    fast_mode = (start == NULL || PyLong_Check(start)) &&
+                (step == NULL || PyLong_Check(step));
 
     /* If not specified, start defaults to 0 */
-    if (long_cnt != NULL) {
+    if (start != NULL) {
         if (fast_mode) {
-            assert(PyLong_Check(long_cnt));
-            cnt = PyLong_AsSsize_t(long_cnt);
+            assert(PyLong_Check(start));
+            cnt = PyLong_AsSsize_t(start);
             if (cnt == -1 && PyErr_Occurred()) {
                 PyErr_Clear();
                 fast_mode = 0;
@@ -3975,47 +4391,47 @@ count_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         }
     } else {
         cnt = 0;
-        long_cnt = _PyLong_Zero;
+        start = _PyLong_Zero;
     }
-    Py_INCREF(long_cnt);
+    Py_INCREF(start);
 
     /* If not specified, step defaults to 1 */
-    if (long_step == NULL)
-        long_step = _PyLong_One;
-    Py_INCREF(long_step);
+    if (step == NULL)
+        step = _PyLong_One;
+    Py_INCREF(step);
 
-    assert(long_cnt != NULL && long_step != NULL);
+    assert(start != NULL && step != NULL);
 
     /* Fast mode only works when the step is 1 */
     if (fast_mode) {
-        assert(PyLong_Check(long_step));
-        step = PyLong_AsLong(long_step);
-        if (step != 1) {
+        assert(PyLong_Check(step));
+        step_long = PyLong_AsLong(step);
+        if (step_long != 1) {
             fast_mode = 0;
-            if (step == -1 && PyErr_Occurred())
+            if (step_long == -1 && PyErr_Occurred())
                 PyErr_Clear();
         }
     }
 
     if (fast_mode)
-        Py_CLEAR(long_cnt);
+        Py_CLEAR(start);
     else
         cnt = PY_SSIZE_T_MAX;
 
-    assert((cnt != PY_SSIZE_T_MAX && long_cnt == NULL && fast_mode) ||
-           (cnt == PY_SSIZE_T_MAX && long_cnt != NULL && !fast_mode));
+    assert((cnt != PY_SSIZE_T_MAX && start == NULL && fast_mode) ||
+           (cnt == PY_SSIZE_T_MAX && start != NULL && !fast_mode));
     assert(!fast_mode ||
-           (PyLong_Check(long_step) && PyLong_AS_LONG(long_step) == 1));
+           (PyLong_Check(step) && PyLong_AS_LONG(step) == 1));
 
     /* create countobject structure */
     lz = (countobject *)type->tp_alloc(type, 0);
     if (lz == NULL) {
-        Py_XDECREF(long_cnt);
+        Py_XDECREF(start);
         return NULL;
     }
     lz->cnt = cnt;
-    lz->long_cnt = long_cnt;
-    lz->long_step = long_step;
+    lz->long_cnt = start;
+    lz->long_step = step;
 
     return (PyObject *)lz;
 }
@@ -4091,8 +4507,17 @@ count_repr(countobject *lz)
                                 lz->long_cnt, lz->long_step);
 }
 
+/*[clinic input]
+itertools.count.__reduce__ as count_reduce
+
+    lz: self(type="countobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-count_reduce(countobject *lz)
+count_reduce_impl(countobject *lz)
+/*[clinic end generated code: output=64fec5d0ca5aa2cd input=8a68e97535b37707]*/
 {
     if (lz->cnt == PY_SSIZE_T_MAX)
         return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->long_cnt, lz->long_step);
@@ -4100,21 +4525,9 @@ count_reduce(countobject *lz)
 }
 
 static PyMethodDef count_methods[] = {
-    {"__reduce__",      (PyCFunction)count_reduce,      METH_NOARGS,
-     reduce_doc},
+    COUNT_REDUCE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
-
-PyDoc_STRVAR(count_doc,
-                         "count(start=0, step=1) --> count object\n\
-\n\
-Return a count object whose .__next__() method returns consecutive values.\n\
-Equivalent to:\n\n\
-    def count(firstval=0, step=1):\n\
-        x = firstval\n\
-        while 1:\n\
-            yield x\n\
-            x += step\n");
 
 static PyTypeObject count_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -4139,7 +4552,7 @@ static PyTypeObject count_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    count_doc,                          /* tp_doc */
+    count_new__doc__,                   /* tp_doc */
     (traverseproc)count_traverse,       /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4236,8 +4649,17 @@ repeat_repr(repeatobject *ro)
                                     ro->cnt);
 }
 
+/*[clinic input]
+itertools.repeat.__length_hint__ as repeat_len
+
+    ro: self(type="repeatobject *")
+
+Private method returning an estimate of len(list(it)).
+[clinic start generated code]*/
+
 static PyObject *
-repeat_len(repeatobject *ro)
+repeat_len_impl(repeatobject *ro)
+/*[clinic end generated code: output=f910fff81aefe178 input=59a6f9f93682bcaf]*/
 {
     if (ro->cnt == -1) {
         PyErr_SetString(PyExc_TypeError, "len() of unsized object");
@@ -4246,10 +4668,17 @@ repeat_len(repeatobject *ro)
     return PyLong_FromSize_t(ro->cnt);
 }
 
-PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(it)).");
+/*[clinic input]
+itertools.repeat.__reduce__ as repeat_reduce
+
+    ro: self(type="repeatobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
 
 static PyObject *
-repeat_reduce(repeatobject *ro)
+repeat_reduce_impl(repeatobject *ro)
+/*[clinic end generated code: output=8f15345d61cd588e input=4eab78b8fd9130d4]*/
 {
     /* unpickle this so that a new repeat iterator is constructed with an
      * object, then call __setstate__ on it to set cnt
@@ -4261,8 +4690,8 @@ repeat_reduce(repeatobject *ro)
 }
 
 static PyMethodDef repeat_methods[] = {
-    {"__length_hint__", (PyCFunction)repeat_len, METH_NOARGS, length_hint_doc},
-    {"__reduce__",      (PyCFunction)repeat_reduce, METH_NOARGS, reduce_doc},
+    REPEAT_LEN_METHODDEF
+    REPEAT_REDUCE_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -4487,8 +4916,17 @@ zip_longest_next(ziplongestobject *lz)
     return result;
 }
 
+/*[clinic input]
+itertools.zip_longest.__reduce__ as zip_longest_reduce
+
+    lz: self(type="ziplongestobject *")
+
+Return state information for pickling.
+[clinic start generated code]*/
+
 static PyObject *
-zip_longest_reduce(ziplongestobject *lz)
+zip_longest_reduce_impl(ziplongestobject *lz)
+/*[clinic end generated code: output=561995d1e971a31d input=25269cf781351ff5]*/
 {
 
     /* Create a new tuple with empty sequences where appropriate to pickle.
@@ -4514,8 +4952,19 @@ zip_longest_reduce(ziplongestobject *lz)
     return Py_BuildValue("ONO", Py_TYPE(lz), args, lz->fillvalue);
 }
 
+/*[clinic input]
+itertools.zip_longest.__setstate__ as zip_longest_setstate
+
+    lz: self(type="ziplongestobject *")
+    state: object
+    /
+
+Set state information for unpickling.
+[clinic start generated code]*/
+
 static PyObject *
 zip_longest_setstate(ziplongestobject *lz, PyObject *state)
+/*[clinic end generated code: output=55d1c40777c57700 input=0f40aa1fb87dd8c4]*/
 {
     Py_INCREF(state);
     Py_XSETREF(lz->fillvalue, state);
@@ -4523,10 +4972,8 @@ zip_longest_setstate(ziplongestobject *lz, PyObject *state)
 }
 
 static PyMethodDef zip_longest_methods[] = {
-    {"__reduce__",      (PyCFunction)zip_longest_reduce,      METH_NOARGS,
-     reduce_doc},
-    {"__setstate__",    (PyCFunction)zip_longest_setstate,    METH_O,
-     setstate_doc},
+    ZIP_LONGEST_REDUCE_METHODDEF
+    ZIP_LONGEST_SETSTATE_METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4619,7 +5066,7 @@ combinations_with_replacement(p, r)\n\
 
 
 static PyMethodDef module_methods[] = {
-    {"tee",     (PyCFunction)tee,       METH_VARARGS, tee_doc},
+    TEE_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -58,22 +58,13 @@ itertools.groupby.__new__
         Function computing a key value for each element.
         If None, the elements themselves are used for grouping.
 
-Create a groupby object.
+Return an iterator of groups of items as (key, group) pairs.
 
-This makes an iterator of (key, sub-iterator) pairs. In each such pair, the
-sub-iterator is a group of consecutive elements from the input iterable which
-all have the same key. The common key for the group is the first item in the
-pair.
+This groups together consecutive items from the given iterator.  Each group
+contains items for which the key gives the same result.
 
-Example:
->>> # group numbers by their absolute value
->>> elements = [1, -1, 2, 1]
->>> for (key, group) in itertools.groupby(elements, key=abs):
-...     print('key={} group={}'.format(key, list(group)))
-...
-key=1 group=[1, -1]
-key=2 group=[2]
-key=1 group=[1]
+For each group, a (key, group) 2-tuple is yielded, where "key" is the common
+key value for the group and "group" is an iterator of the items in the group.
 [clinic start generated code]*/
 
 static PyObject *
@@ -1485,7 +1476,7 @@ itertools.starmap.__new__
 Create a starmap object.
 
 Return an iterator whose values are returned from the function evaluated
-with a argument tuple taken from the given iterable.
+with argument tuples taken from the given iterable.
 [clinic start generated code]*/
 
 static PyObject *
@@ -1569,12 +1560,6 @@ itertools_starmap___reduce___impl(starmapobject *lz)
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
 }
 
-PyDoc_STRVAR(starmap_doc,
-"starmap(function, sequence) --> starmap object\n\
-\n\
-Return an iterator whose values are returned from the function evaluated\n\
-with an argument tuple taken from the given sequence.");
-
 
 /* chain object **************************************************************/
 
@@ -1626,7 +1611,7 @@ itertools.chain.from_iterable
 
 Create a chain object.
 
-Alternate chain() contructor taking a single iterable argument
+Alternative chain() constructor taking a single iterable argument
 that evaluates lazily.
 [clinic start generated code]*/
 
@@ -2413,7 +2398,7 @@ itertools_combinations___setstate__(combinationsobject *lz, PyObject *state)
                 yield tuple(pool[i] for i in indices)
 
         def combinations_with_replacement2(iterable, r):
-            'Alternate version that filters from product()'
+            'Alternative version that filters from product()'
             pool = tuple(iterable)
             n = len(pool)
             for indices in product(range(n), repeat=r):
@@ -3510,9 +3495,8 @@ itertools.count.__new__
     start as long_cnt: object(c_default="NULL") = 0
     step as long_step: object(c_default="NULL") = 1
 
-Create a count object.
+Return an iterator which returns consecutive values.
 
-Return a count object whose .__next__() method returns consecutive values.
 Equivalent to:
 
     def count(firstval=0, step=1):
@@ -3767,7 +3751,7 @@ itertools.repeat.__length_hint__
 
     ro: self(type="repeatobject *")
 
-Private method returning an estimate of len(list(it)).
+Private method returning an estimate of len(list(self)).
 [clinic start generated code]*/
 
 static PyObject *
@@ -4046,7 +4030,7 @@ defaults to None or can be specified by a keyword argument.\n\
 ");
 
 
-/* including clinic output must come after typdefs and PyObject type
+/* including clinic output must come after typedefs and PyObject type
    declarations, but before method arrays and type definitions */
 #include "clinic/itertoolsmodule.c.h"
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -50,7 +50,7 @@ static PyObject *_grouper_create(groupbyobject *, PyObject *);
 
 /*[clinic input]
 @classmethod
-itertools.groupby.__new__ as groupby_new
+itertools.groupby.__new__
 
     iterable: object
         Elements to divide into groups according to the key function.
@@ -77,8 +77,8 @@ key=1 group=[1]
 [clinic start generated code]*/
 
 static PyObject *
-groupby_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *key)
-/*[clinic end generated code: output=7d57fc22bba4949d input=6ad51fd161164a10]*/
+itertools_groupby_impl(PyTypeObject *type, PyObject *iterable, PyObject *key)
+/*[clinic end generated code: output=83016d6c995ed8a5 input=6dbf07f491bd73ec]*/
 {
     groupbyobject *gbo;
 
@@ -186,7 +186,7 @@ groupby_next(groupbyobject *gbo)
 }
 
 /*[clinic input]
-itertools.groupby.__reduce__ as groupby_reduce
+itertools.groupby.__reduce__
 
     lz: self(type="groupbyobject *")
 
@@ -194,8 +194,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-groupby_reduce_impl(groupbyobject *lz)
-/*[clinic end generated code: output=81ccca5e1cd6ef82 input=c9328f12aa213161]*/
+itertools_groupby___reduce___impl(groupbyobject *lz)
+/*[clinic end generated code: output=1117576d1ed9a02f input=890ace8ac7135075]*/
 {
     /* reduce as a 'new' call with an optional 'setstate' if groupby
      * has started
@@ -212,7 +212,7 @@ groupby_reduce_impl(groupbyobject *lz)
 }
 
 /*[clinic input]
-itertools.groupby.__setstate__ as groupby_setstate
+itertools.groupby.__setstate__
 
     lz: self(type="groupbyobject *")
     state: object
@@ -222,8 +222,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-groupby_setstate(groupbyobject *lz, PyObject *state)
-/*[clinic end generated code: output=d668c44985ed8d2c input=1c009772af2ae55f]*/
+itertools_groupby___setstate__(groupbyobject *lz, PyObject *state)
+/*[clinic end generated code: output=fb0fe7e1442cb9ef input=922ce677bd8128bb]*/
 {
     PyObject *currkey, *currvalue, *tgtkey;
     if (!PyTuple_Check(state)) {
@@ -255,7 +255,7 @@ static PyTypeObject _grouper_type;
 
 /*[clinic input]
 @classmethod
-itertools._grouper.__new__ as _grouper_new
+itertools._grouper.__new__
 
     parent: object(subclass_of='&groupby_type')
     tgtkey: object
@@ -263,8 +263,9 @@ itertools._grouper.__new__ as _grouper_new
 [clinic start generated code]*/
 
 static PyObject *
-_grouper_new_impl(PyTypeObject *type, PyObject *parent, PyObject *tgtkey)
-/*[clinic end generated code: output=c2b3fdd3561b1103 input=280c2659160f7890]*/
+itertools__grouper_impl(PyTypeObject *type, PyObject *parent,
+                        PyObject *tgtkey)
+/*[clinic end generated code: output=462efb1cdebb5914 input=dc180d7771fc8c59]*/
 {
     return _grouper_create((groupbyobject*) parent, tgtkey);
 }
@@ -332,7 +333,7 @@ _grouper_next(_grouperobject *igo)
 }
 
 /*[clinic input]
-itertools._grouper.__reduce__ as _grouper_reduce
+itertools._grouper.__reduce__
 
     lz: self(type="_grouperobject *")
 
@@ -340,8 +341,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-_grouper_reduce_impl(_grouperobject *lz)
-/*[clinic end generated code: output=5d852dbd29c55aaf input=89204ccad93c8271]*/
+itertools__grouper___reduce___impl(_grouperobject *lz)
+/*[clinic end generated code: output=0c943dcf1416a652 input=f7827a30541d4a7d]*/
 {
     if (((groupbyobject *)lz->parent)->currgrouper != lz) {
         return Py_BuildValue("N(())", _PyObject_GetBuiltin("iter"));
@@ -475,7 +476,7 @@ teedataobject_dealloc(teedataobject *tdo)
 }
 
 /*[clinic input]
-itertools.teedataobject.__reduce__ as teedataobject_reduce
+itertools.teedataobject.__reduce__
 
     tdo: self(type="teedataobject *")
 
@@ -483,8 +484,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-teedataobject_reduce_impl(teedataobject *tdo)
-/*[clinic end generated code: output=2dd0ee192b561019 input=5067dad6127ce165]*/
+itertools_teedataobject___reduce___impl(teedataobject *tdo)
+/*[clinic end generated code: output=f2a99b50ec4e486a input=60741bb5793ba221]*/
 {
     int i;
     /* create a temporary list of already iterated values */
@@ -505,7 +506,7 @@ static PyTypeObject teedataobject_type;
 
 /*[clinic input]
 @classmethod
-itertools.teedataobject.__new__ as teedataobject_new
+itertools.teedataobject.__new__
 
     iterable: object
     values: object(subclass_of='&PyList_Type')
@@ -516,9 +517,9 @@ Data container common to multiple tee objects.
 [clinic start generated code]*/
 
 static PyObject *
-teedataobject_new_impl(PyTypeObject *type, PyObject *iterable,
-                       PyObject *values, PyObject *next)
-/*[clinic end generated code: output=9bc76065decb56f6 input=cb41f9058761382a]*/
+itertools_teedataobject_impl(PyTypeObject *type, PyObject *iterable,
+                             PyObject *values, PyObject *next)
+/*[clinic end generated code: output=aa1f47b741113fe8 input=7adacfbe72522b7d]*/
 {
     teedataobject *tdo;
     Py_ssize_t i, len;
@@ -589,7 +590,7 @@ tee_traverse(teeobject *to, visitproc visit, void *arg)
 }
 
 /*[clinic input]
-itertools._tee.__copy__ as tee_copy
+itertools._tee.__copy__
 
     to: self(type="teeobject *")
 
@@ -597,8 +598,8 @@ Returns an independent iterator.
 [clinic start generated code]*/
 
 static PyObject *
-tee_copy_impl(teeobject *to)
-/*[clinic end generated code: output=45629a9ebc19de67 input=da64ef9fac60a134]*/
+itertools__tee___copy___impl(teeobject *to)
+/*[clinic end generated code: output=4f8d4b5446ebf739 input=406d53de6a8bcd06]*/
 {
     teeobject *newto;
 
@@ -623,7 +624,7 @@ tee_fromiterable(PyObject *iterable)
     if (it == NULL)
         return NULL;
     if (PyObject_TypeCheck(it, &tee_type)) {
-        to = (teeobject *)tee_copy_impl((teeobject *)it);
+        to = (teeobject *)itertools__tee___copy___impl((teeobject *)it);
         goto done;
     }
 
@@ -647,7 +648,7 @@ done:
 
 /*[clinic input]
 @classmethod
-itertools._tee.__new__ as tee_new
+itertools._tee.__new__
 
     iterable: object
     /
@@ -658,8 +659,8 @@ An iterator wrapped to make it copyable.
 [clinic start generated code]*/
 
 static PyObject *
-tee_new_impl(PyTypeObject *type, PyObject *iterable)
-/*[clinic end generated code: output=35aa9c64122b5871 input=827b5f7b19c54dfa]*/
+itertools__tee_impl(PyTypeObject *type, PyObject *iterable)
+/*[clinic end generated code: output=b02d3fd26c810c3f input=18df2ae1219e84ee]*/
 {
     return tee_fromiterable(iterable);
 }
@@ -682,7 +683,7 @@ tee_dealloc(teeobject *to)
 }
 
 /*[clinic input]
-itertools._tee.__reduce__ as tee_reduce
+itertools._tee.__reduce__
 
     to: self(type="teeobject *")
 
@@ -690,14 +691,14 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-tee_reduce_impl(teeobject *to)
-/*[clinic end generated code: output=46a6d7b07fec2a40 input=63c43d1a548a83c8]*/
+itertools__tee___reduce___impl(teeobject *to)
+/*[clinic end generated code: output=027e48b2c631ca10 input=b2bc0d599a4d7fc7]*/
 {
     return Py_BuildValue("O(())(Oi)", Py_TYPE(to), to->dataobj, to->index);
 }
 
 /*[clinic input]
-itertools._tee.__setstate__ as tee_setstate
+itertools._tee.__setstate__
 
     to: self(type="teeobject *")
     state: object
@@ -707,8 +708,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-tee_setstate(teeobject *to, PyObject *state)
-/*[clinic end generated code: output=3ff5ca72492e2610 input=1ed8907a9f02d536]*/
+itertools__tee___setstate__(teeobject *to, PyObject *state)
+/*[clinic end generated code: output=12add73314efd99b input=ea90c39c24d0f3a0]*/
 {
     teedataobject *tdo;
     int index;
@@ -730,7 +731,7 @@ tee_setstate(teeobject *to, PyObject *state)
 }
 
 /*[clinic input]
-itertools.tee as tee
+itertools.tee
 
     iterable: object
     n: Py_ssize_t = 2
@@ -745,8 +746,8 @@ in the returned tuple) being informed.
 [clinic start generated code]*/
 
 static PyObject *
-tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n)
-/*[clinic end generated code: output=5159f48b66c422b4 input=a72b8ce4e9aa7cc9]*/
+itertools_tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n)
+/*[clinic end generated code: output=1c64519cd859c2f0 input=228c65fd7d3317b6]*/
 {
     Py_ssize_t i;
     PyObject *it, *copyable, *result;
@@ -803,7 +804,7 @@ static PyTypeObject cycle_type;
 
 /*[clinic input]
 @classmethod
-itertools.cycle.__new__ as cycle_new
+itertools.cycle.__new__
 
     iterable: object
     /
@@ -815,8 +816,8 @@ Then it will repeat the sequence indefinitely.
 [clinic start generated code]*/
 
 static PyObject *
-cycle_new_impl(PyTypeObject *type, PyObject *iterable)
-/*[clinic end generated code: output=9c3c6a645f54603e input=fdd6c11dca6b1efe]*/
+itertools_cycle_impl(PyTypeObject *type, PyObject *iterable)
+/*[clinic end generated code: output=f60e5ec17a45b35c input=3678f0717ebd9fdc]*/
 {
     PyObject *it;
     PyObject *saved;
@@ -898,7 +899,7 @@ cycle_next(cycleobject *lz)
 }
 
 /*[clinic input]
-itertools.cycle.__reduce__ as cycle_reduce
+itertools.cycle.__reduce__
 
     lz: self(type="cycleobject *")
 
@@ -906,8 +907,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-cycle_reduce_impl(cycleobject *lz)
-/*[clinic end generated code: output=f2b1f8bfd1d6423a input=248c55bc398cd5fa]*/
+itertools_cycle___reduce___impl(cycleobject *lz)
+/*[clinic end generated code: output=04c68393689d7c99 input=27b04ed6b5b88508]*/
 {
     /* Create a new cycle with the iterator tuple, then set the saved state */
     if (lz->it == NULL) {
@@ -931,7 +932,7 @@ cycle_reduce_impl(cycleobject *lz)
 }
 
 /*[clinic input]
-itertools.cycle.__setstate__ as cycle_setstate
+itertools.cycle.__setstate__
 
     lz: self(type="cycleobject *")
     state: object
@@ -941,8 +942,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-cycle_setstate(cycleobject *lz, PyObject *state)
-/*[clinic end generated code: output=9c82d80fdebf7705 input=840f2f296fe555a9]*/
+itertools_cycle___setstate__(cycleobject *lz, PyObject *state)
+/*[clinic end generated code: output=cdc9986595a547c1 input=ad1db343aa10d21c]*/
 {
     PyObject *saved=NULL;
     int firstpass;
@@ -974,7 +975,7 @@ static PyTypeObject dropwhile_type;
 
 /*[clinic input]
 @classmethod
-itertools.dropwhile.__new__ as dropwhile_new
+itertools.dropwhile.__new__
 
     predicate: object
     iterable: object
@@ -987,9 +988,9 @@ Afterwards, returns every element until the iterable is exhausted.
 [clinic start generated code]*/
 
 static PyObject *
-dropwhile_new_impl(PyTypeObject *type, PyObject *predicate,
-                   PyObject *iterable)
-/*[clinic end generated code: output=68ccecb645b70e7c input=b4d0e3c961817403]*/
+itertools_dropwhile_impl(PyTypeObject *type, PyObject *predicate,
+                         PyObject *iterable)
+/*[clinic end generated code: output=7145293afdc3a8b0 input=73b05fd17a9e6304]*/
 {
     PyObject *it;
     dropwhileobject *lz;
@@ -1064,7 +1065,7 @@ dropwhile_next(dropwhileobject *lz)
 }
 
 /*[clinic input]
-itertools.dropwhile.__reduce__ as dropwhile_reduce
+itertools.dropwhile.__reduce__
 
     lz: self(type="dropwhileobject *")
 
@@ -1072,14 +1073,14 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-dropwhile_reduce_impl(dropwhileobject *lz)
-/*[clinic end generated code: output=df490b72b8892732 input=6abc87d157f1ff18]*/
+itertools_dropwhile___reduce___impl(dropwhileobject *lz)
+/*[clinic end generated code: output=caa51cb35e50a4ab input=b09fc961c8fe6244]*/
 {
     return Py_BuildValue("O(OO)l", Py_TYPE(lz), lz->func, lz->it, lz->start);
 }
 
 /*[clinic input]
-itertools.dropwhile.__setstate__ as dropwhile_setstate
+itertools.dropwhile.__setstate__
 
     lz: self(type="dropwhileobject *")
     state: object
@@ -1089,8 +1090,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-dropwhile_setstate(dropwhileobject *lz, PyObject *state)
-/*[clinic end generated code: output=fd28c2f3fc19f7a1 input=397b3ecd83cbe6a4]*/
+itertools_dropwhile___setstate__(dropwhileobject *lz, PyObject *state)
+/*[clinic end generated code: output=8c7958a3e6d50e6e input=82816bca774cd179]*/
 {
     int start = PyObject_IsTrue(state);
     if (start < 0)
@@ -1113,7 +1114,7 @@ static PyTypeObject takewhile_type;
 
 /*[clinic input]
 @classmethod
-itertools.takewhile.__new__ as takewhile_new
+itertools.takewhile.__new__
 
     predicate: object
     iterable: object
@@ -1126,9 +1127,9 @@ predicate evaluates to true for each entry.
 [clinic start generated code]*/
 
 static PyObject *
-takewhile_new_impl(PyTypeObject *type, PyObject *predicate,
-                   PyObject *iterable)
-/*[clinic end generated code: output=ec1277335df81046 input=984bd1d6e5854510]*/
+itertools_takewhile_impl(PyTypeObject *type, PyObject *predicate,
+                         PyObject *iterable)
+/*[clinic end generated code: output=5bc9c62001c2078a input=398cac32350430a3]*/
 {
     PyObject *it;
     takewhileobject *lz;
@@ -1199,7 +1200,7 @@ takewhile_next(takewhileobject *lz)
 }
 
 /*[clinic input]
-itertools.takewhile.__reduce__ as takewhile_reduce
+itertools.takewhile.__reduce__
 
     lz: self(type="takewhileobject *")
 
@@ -1207,14 +1208,14 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-takewhile_reduce_impl(takewhileobject *lz)
-/*[clinic end generated code: output=f7b9e63cb66dc9e7 input=20da021310e98c13]*/
+itertools_takewhile___reduce___impl(takewhileobject *lz)
+/*[clinic end generated code: output=11993dd71a14554a input=424104832bfafebf]*/
 {
     return Py_BuildValue("O(OO)l", Py_TYPE(lz), lz->func, lz->it, lz->stop);
 }
 
 /*[clinic input]
-itertools.takewhile.__setstate__ as takewhile_setstate
+itertools.takewhile.__setstate__
 
     lz: self(type="takewhileobject *")
     state: object
@@ -1224,8 +1225,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-takewhile_setstate(takewhileobject *lz, PyObject *state)
-/*[clinic end generated code: output=66165bddfa716106 input=84532fc48b901e96]*/
+itertools_takewhile___setstate__(takewhileobject *lz, PyObject *state)
+/*[clinic end generated code: output=b69837a8ab1ec04c input=7c246e534b9f3772]*/
 {
     int stop = PyObject_IsTrue(state);
 
@@ -1388,7 +1389,7 @@ empty:
 }
 
 /*[clinic input]
-itertools.islice.__reduce__ as islice_reduce
+itertools.islice.__reduce__
 
     lz: self(type="isliceobject *")
 
@@ -1396,8 +1397,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-islice_reduce_impl(isliceobject *lz)
-/*[clinic end generated code: output=17608d57ce05ea0f input=2f71fe7c46f200f2]*/
+itertools_islice___reduce___impl(isliceobject *lz)
+/*[clinic end generated code: output=61b4f96ec6efa99b input=dc27abdca2f519f0]*/
 {
     /* When unpickled, generate a new object with the same bounds,
      * then 'setstate' with the next and count
@@ -1430,7 +1431,7 @@ islice_reduce_impl(isliceobject *lz)
 }
 
 /*[clinic input]
-itertools.islice.__setstate__ as islice_setstate
+itertools.islice.__setstate__
 
     lz: self(type="isliceobject *")
     state: object
@@ -1440,8 +1441,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-islice_setstate(isliceobject *lz, PyObject *state)
-/*[clinic end generated code: output=9d7a4479159c852e input=1e1a67c001a84c75]*/
+itertools_islice___setstate__(isliceobject *lz, PyObject *state)
+/*[clinic end generated code: output=f1c8bd2785eb4533 input=f29f69486ecbed09]*/
 {
     Py_ssize_t cnt = PyLong_AsSsize_t(state);
 
@@ -1475,10 +1476,11 @@ static PyTypeObject starmap_type;
 
 /*[clinic input]
 @classmethod
-itertools.starmap.__new__ as starmap_new
+itertools.starmap.__new__
 
     function: object
     iterable: object
+    /
 
 Create a starmap object.
 
@@ -1487,8 +1489,9 @@ with a argument tuple taken from the given iterable.
 [clinic start generated code]*/
 
 static PyObject *
-starmap_new_impl(PyTypeObject *type, PyObject *function, PyObject *iterable)
-/*[clinic end generated code: output=18acf452cb6c526c input=579f9b3e0229a194]*/
+itertools_starmap_impl(PyTypeObject *type, PyObject *function,
+                       PyObject *iterable)
+/*[clinic end generated code: output=d190ae80479a0717 input=19c167576f25a714]*/
 {
     PyObject *it;
     starmapobject *lz;
@@ -1551,7 +1554,7 @@ starmap_next(starmapobject *lz)
 }
 
 /*[clinic input]
-itertools.starmap.__reduce__ as starmap_reduce
+itertools.starmap.__reduce__
 
     lz: self(type="starmapobject *")
 
@@ -1559,8 +1562,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-starmap_reduce_impl(starmapobject *lz)
-/*[clinic end generated code: output=f37e06d630220ddd input=8101a8f2910ff54d]*/
+itertools_starmap___reduce___impl(starmapobject *lz)
+/*[clinic end generated code: output=e950b174e0f21a26 input=55118eeb5a994ad9]*/
 {
     /* Just pickle the iterator */
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
@@ -1616,7 +1619,7 @@ chain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
 /*[clinic input]
 @classmethod
-itertools.chain.from_iterable as chain_new_from_iterable
+itertools.chain.from_iterable
 
     iterable: object
     /
@@ -1628,8 +1631,8 @@ that evaluates lazily.
 [clinic start generated code]*/
 
 static PyObject *
-chain_new_from_iterable(PyTypeObject *type, PyObject *iterable)
-/*[clinic end generated code: output=2d5fc751e73b5a67 input=1f1c99200abefc48]*/
+itertools_chain_from_iterable(PyTypeObject *type, PyObject *iterable)
+/*[clinic end generated code: output=39373d88650cc4fd input=d39acc2717d725a0]*/
 {
     PyObject *source;
 
@@ -1696,7 +1699,7 @@ chain_next(chainobject *lz)
 }
 
 /*[clinic input]
-itertools.chain.__reduce__ as chain_reduce
+itertools.chain.__reduce__
 
     lz: self(type="chainobject *")
 
@@ -1704,8 +1707,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-chain_reduce_impl(chainobject *lz)
-/*[clinic end generated code: output=b9cfb60a29f977bc input=3c84dbccd41cefd6]*/
+itertools_chain___reduce___impl(chainobject *lz)
+/*[clinic end generated code: output=6594f396824c2de6 input=40f1f72154df0600]*/
 {
     if (lz->source) {
         /* we can't pickle function objects (itertools.from_iterable) so
@@ -1724,7 +1727,7 @@ chain_reduce_impl(chainobject *lz)
 }
 
 /*[clinic input]
-itertools.chain.__setstate__ as chain_setstate
+itertools.chain.__setstate__
 
     lz: self(type="chainobject *")
     state: object
@@ -1734,8 +1737,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-chain_setstate(chainobject *lz, PyObject *state)
-/*[clinic end generated code: output=5985fde1d79cb81f input=e376ccaff1fb8e28]*/
+itertools_chain___setstate__(chainobject *lz, PyObject *state)
+/*[clinic end generated code: output=7559b01351fd0e8d input=282b90d35a6bb316]*/
 {
     PyObject *source, *active=NULL;
 
@@ -1873,7 +1876,7 @@ product_dealloc(productobject *lz)
 }
 
 /*[clinic input]
-itertools.product.__sizeof__ as product_sizeof
+itertools.product.__sizeof__
 
     lz: self(type="productobject *")
 
@@ -1881,8 +1884,8 @@ Returns size in memory, in bytes.
 [clinic start generated code]*/
 
 static PyObject *
-product_sizeof_impl(productobject *lz)
-/*[clinic end generated code: output=a943d0f6487dbee1 input=13df894cf42c4ae2]*/
+itertools_product___sizeof___impl(productobject *lz)
+/*[clinic end generated code: output=ce319a3d05d744f5 input=c6403571079153d2]*/
 {
     Py_ssize_t res;
 
@@ -1987,7 +1990,7 @@ empty:
 }
 
 /*[clinic input]
-itertools.product.__reduce__ as product_reduce
+itertools.product.__reduce__
 
     lz: self(type="productobject *")
 
@@ -1995,8 +1998,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-product_reduce_impl(productobject *lz)
-/*[clinic end generated code: output=780ff23bb8dd0557 input=d20b4bf62464277a]*/
+itertools_product___reduce___impl(productobject *lz)
+/*[clinic end generated code: output=c9b1bd63abda2a19 input=5e414e4498eef6ad]*/
 {
     if (lz->stopped) {
         return Py_BuildValue("O(())", Py_TYPE(lz));
@@ -2026,7 +2029,7 @@ product_reduce_impl(productobject *lz)
 }
 
 /*[clinic input]
-itertools.product.__setstate__ as product_setstate
+itertools.product.__setstate__
 
     lz: self(type="productobject *")
     state: object
@@ -2036,8 +2039,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-product_setstate(productobject *lz, PyObject *state)
-/*[clinic end generated code: output=e28c92b80c88e261 input=6e813de246d596e0]*/
+itertools_product___setstate__(productobject *lz, PyObject *state)
+/*[clinic end generated code: output=1093cdaf9d74fbb1 input=fb082dff31228560]*/
 {
     PyObject *result;
     Py_ssize_t n, i;
@@ -2112,7 +2115,7 @@ static PyTypeObject combinations_type;
 
 /*[clinic input]
 @classmethod
-itertools.combinations.__new__ as combinations_new
+itertools.combinations.__new__
 
     iterable: object
     r: Py_ssize_t
@@ -2126,8 +2129,9 @@ combinations(range(4), 3) --> (0,1,2), (0,1,3), (0,2,3), (1,2,3)
 [clinic start generated code]*/
 
 static PyObject *
-combinations_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t r)
-/*[clinic end generated code: output=dcd9df4d7c03311f input=95fa7897cc2fc49c]*/
+itertools_combinations_impl(PyTypeObject *type, PyObject *iterable,
+                            Py_ssize_t r)
+/*[clinic end generated code: output=87a689b39c40039c input=981959b2658374e7]*/
 {
     combinationsobject *co;
     Py_ssize_t n;
@@ -2185,7 +2189,7 @@ combinations_dealloc(combinationsobject *co)
 }
 
 /*[clinic input]
-itertools.combinations.__sizeof__ as combinations_sizeof
+itertools.combinations.__sizeof__
 
     co: self(type="combinationsobject *")
 
@@ -2193,8 +2197,8 @@ Returns size in memory, in bytes.
 [clinic start generated code]*/
 
 static PyObject *
-combinations_sizeof_impl(combinationsobject *co)
-/*[clinic end generated code: output=b5bf6fa9dc59e413 input=aca277f15aec905e]*/
+itertools_combinations___sizeof___impl(combinationsobject *co)
+/*[clinic end generated code: output=54a7cda813b82b34 input=34eef409ac1a2fde]*/
 {
     Py_ssize_t res;
 
@@ -2298,7 +2302,7 @@ empty:
 }
 
 /*[clinic input]
-itertools.combinations.__reduce__ as combinations_reduce
+itertools.combinations.__reduce__
 
     lz: self(type="combinationsobject *")
 
@@ -2306,8 +2310,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-combinations_reduce_impl(combinationsobject *lz)
-/*[clinic end generated code: output=2dbd90d424ca2a58 input=85cd3171e4f80093]*/
+itertools_combinations___reduce___impl(combinationsobject *lz)
+/*[clinic end generated code: output=257385f3109fc253 input=c617afc1831ea57d]*/
 {
     if (lz->result == NULL) {
         return Py_BuildValue("O(On)", Py_TYPE(lz), lz->pool, lz->r);
@@ -2336,7 +2340,7 @@ combinations_reduce_impl(combinationsobject *lz)
 }
 
 /*[clinic input]
-itertools.combinations.__setstate__ as combinations_setstate
+itertools.combinations.__setstate__
 
     lz: self(type="combinationsobject *")
     state: object
@@ -2346,8 +2350,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-combinations_setstate(combinationsobject *lz, PyObject *state)
-/*[clinic end generated code: output=07388313134a205e input=0e3f5c7702c3f205]*/
+itertools_combinations___setstate__(combinationsobject *lz, PyObject *state)
+/*[clinic end generated code: output=7a063028237bba6f input=69a478ddf0a05659]*/
 {
     PyObject *result;
     Py_ssize_t i;
@@ -2429,7 +2433,7 @@ static PyTypeObject cwr_type;
 
 /*[clinic input]
 @classmethod
-itertools.combinations_with_replacement.__new__ as cwr_new
+itertools.combinations_with_replacement.__new__
 
     iterable: object
     r: Py_ssize_t
@@ -2444,8 +2448,10 @@ combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC
 [clinic start generated code]*/
 
 static PyObject *
-cwr_new_impl(PyTypeObject *type, PyObject *iterable, Py_ssize_t r)
-/*[clinic end generated code: output=14e1057a23897a3f input=9f05a18553d8ae6b]*/
+itertools_combinations_with_replacement_impl(PyTypeObject *type,
+                                             PyObject *iterable,
+                                             Py_ssize_t r)
+/*[clinic end generated code: output=48b26856d4e659ca input=4c5c1a4806321373]*/
 {
     cwrobject *co;
     Py_ssize_t n;
@@ -2504,7 +2510,7 @@ cwr_dealloc(cwrobject *co)
 }
 
 /*[clinic input]
-itertools.combinations_with_replacement.__sizeof__ as cwr_sizeof
+itertools.combinations_with_replacement.__sizeof__
 
     co: self(type="cwrobject *")
 
@@ -2512,8 +2518,8 @@ Returns size in memory, in bytes.
 [clinic start generated code]*/
 
 static PyObject *
-cwr_sizeof_impl(cwrobject *co)
-/*[clinic end generated code: output=fa9aa8e2438d6659 input=140461199e63fd20]*/
+itertools_combinations_with_replacement___sizeof___impl(cwrobject *co)
+/*[clinic end generated code: output=cd85ff1bd7165cbd input=561122f1c93feeb6]*/
 {
     Py_ssize_t res;
 
@@ -2611,7 +2617,7 @@ empty:
 }
 
 /*[clinic input]
-itertools.combinations_with_replacement.__reduce__ as cwr_reduce
+itertools.combinations_with_replacement.__reduce__
 
     lz: self(type="cwrobject *")
 
@@ -2619,8 +2625,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-cwr_reduce_impl(cwrobject *lz)
-/*[clinic end generated code: output=f20771ee5c58bf7b input=699bd8614edb3264]*/
+itertools_combinations_with_replacement___reduce___impl(cwrobject *lz)
+/*[clinic end generated code: output=d7a2bd1efb0717ab input=115806b814307304]*/
 {
     if (lz->result == NULL) {
         return Py_BuildValue("O(On)", Py_TYPE(lz), lz->pool, lz->r);
@@ -2648,7 +2654,7 @@ cwr_reduce_impl(cwrobject *lz)
 }
 
 /*[clinic input]
-itertools.combinations_with_replacement.__setstate__ as cwr_setstate
+itertools.combinations_with_replacement.__setstate__
 
     lz: self(type="cwrobject *")
     state: object
@@ -2658,8 +2664,9 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-cwr_setstate(cwrobject *lz, PyObject *state)
-/*[clinic end generated code: output=6b99738e81d51f65 input=f95a94fba268902e]*/
+itertools_combinations_with_replacement___setstate__(cwrobject *lz,
+                                                     PyObject *state)
+/*[clinic end generated code: output=f31bf60e9a0fdb64 input=90156ecfad115fff]*/
 {
     PyObject *result;
     Py_ssize_t n, i;
@@ -2736,7 +2743,7 @@ static PyTypeObject permutations_type;
 
 /*[clinic input]
 @classmethod
-itertools.permutations.__new__ as permutations_new
+itertools.permutations.__new__
 
     iterable: object
     r as robj: object = None
@@ -2750,8 +2757,9 @@ permutations(range(3), 2) --> (0,1), (0,2), (1,0), (1,2), (2,0), (2,1)
 [clinic start generated code]*/
 
 static PyObject *
-permutations_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *robj)
-/*[clinic end generated code: output=582d59fa75ce954a input=13f00959831dc55e]*/
+itertools_permutations_impl(PyTypeObject *type, PyObject *iterable,
+                            PyObject *robj)
+/*[clinic end generated code: output=296a72fa76d620ea input=9c610a744a96feca]*/
 {
     permutationsobject *po;
     Py_ssize_t n;
@@ -2828,7 +2836,7 @@ permutations_dealloc(permutationsobject *po)
 }
 
 /*[clinic input]
-itertools.permutations.__sizeof__ as permutations_sizeof
+itertools.permutations.__sizeof__
 
     po: self(type="permutationsobject *")
 
@@ -2836,8 +2844,8 @@ Returns size in memory, in bytes.
 [clinic start generated code]*/
 
 static PyObject *
-permutations_sizeof_impl(permutationsobject *po)
-/*[clinic end generated code: output=b7e8c75b02b8e2c2 input=6cc92f69030f504d]*/
+itertools_permutations___sizeof___impl(permutationsobject *po)
+/*[clinic end generated code: output=ca6c540cd826805e input=a48cd95b50ebe54d]*/
 {
     Py_ssize_t res;
 
@@ -2947,7 +2955,7 @@ empty:
 }
 
 /*[clinic input]
-itertools.permutations.__reduce__ as permutations_reduce
+itertools.permutations.__reduce__
 
     po: self(type="permutationsobject *")
 
@@ -2955,8 +2963,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-permutations_reduce_impl(permutationsobject *po)
-/*[clinic end generated code: output=02671f3b618ce7da input=bd7744eca6b1b799]*/
+itertools_permutations___reduce___impl(permutationsobject *po)
+/*[clinic end generated code: output=05078054eb73c547 input=7d0d86cadf904e1f]*/
 {
     if (po->result == NULL) {
         return Py_BuildValue("O(On)", Py_TYPE(po), po->pool, po->r);
@@ -2998,7 +3006,7 @@ permutations_reduce_impl(permutationsobject *po)
 }
 
 /*[clinic input]
-itertools.permutations.__setstate__ as permutations_setstate
+itertools.permutations.__setstate__
 
     po: self(type="permutationsobject *")
     state: object
@@ -3008,8 +3016,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-permutations_setstate(permutationsobject *po, PyObject *state)
-/*[clinic end generated code: output=86e8f8575c33f13a input=ecd8953efad338b0]*/
+itertools_permutations___setstate__(permutationsobject *po, PyObject *state)
+/*[clinic end generated code: output=2e1ba087dd904e90 input=fc4822358c5a73e6]*/
 {
     PyObject *indices, *cycles, *result;
     Py_ssize_t n, i;
@@ -3080,7 +3088,7 @@ static PyTypeObject accumulate_type;
 
 /*[clinic input]
 @classmethod
-itertools.accumulate.__new__ as accumulate_new
+itertools.accumulate.__new__
 
     iterable: object
     func: object = None
@@ -3091,8 +3099,9 @@ Return series of accumulated sums (or other binary function results).
 [clinic start generated code]*/
 
 static PyObject *
-accumulate_new_impl(PyTypeObject *type, PyObject *iterable, PyObject *func)
-/*[clinic end generated code: output=784ef75e8d15e887 input=12f7c760779995b6]*/
+itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
+                          PyObject *func)
+/*[clinic end generated code: output=d516df8990181c36 input=5165c2dacdea3ac2]*/
 {
     PyObject *it;
     accumulateobject *lz;
@@ -3166,7 +3175,7 @@ accumulate_next(accumulateobject *lz)
 }
 
 /*[clinic input]
-itertools.accumulate.__reduce__ as accumulate_reduce
+itertools.accumulate.__reduce__
 
     lz: self(type="accumulateobject *")
 
@@ -3174,8 +3183,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-accumulate_reduce_impl(accumulateobject *lz)
-/*[clinic end generated code: output=2283d4373f698981 input=f247f0e80b550470]*/
+itertools_accumulate___reduce___impl(accumulateobject *lz)
+/*[clinic end generated code: output=b3dec81e417f3321 input=26f8ff5e3fbe4f24]*/
 {
     if (lz->total == Py_None) {
         PyObject *it;
@@ -3200,7 +3209,7 @@ accumulate_reduce_impl(accumulateobject *lz)
 }
 
 /*[clinic input]
-itertools.accumulate.__setstate__ as accumulate_setstate
+itertools.accumulate.__setstate__
 
     lz: self(type="accumulateobject *")
     state: object
@@ -3210,8 +3219,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-accumulate_setstate(accumulateobject *lz, PyObject *state)
-/*[clinic end generated code: output=f29ac8c980f53fb5 input=7dfef829558611fc]*/
+itertools_accumulate___setstate__(accumulateobject *lz, PyObject *state)
+/*[clinic end generated code: output=870a945d5dfd9a5f input=2387d0130fc610ad]*/
 {
     Py_INCREF(state);
     Py_XSETREF(lz->total, state);
@@ -3238,7 +3247,7 @@ static PyTypeObject compress_type;
 
 /*[clinic input]
 @classmethod
-itertools.compress.__new__ as compress_new
+itertools.compress.__new__
 
     data: object
     selectors: object
@@ -3251,8 +3260,9 @@ selectors to choose the data elements.
 [clinic start generated code]*/
 
 static PyObject *
-compress_new_impl(PyTypeObject *type, PyObject *data, PyObject *selectors)
-/*[clinic end generated code: output=e3726e87f1cf6ba4 input=2d99935f390029a2]*/
+itertools_compress_impl(PyTypeObject *type, PyObject *data,
+                        PyObject *selectors)
+/*[clinic end generated code: output=3d1b4774062aac69 input=551cf0d42e9c7cde]*/
 {
     PyObject *data_iter=NULL, *selectors_iter=NULL;
     compressobject *lz;
@@ -3332,7 +3342,7 @@ compress_next(compressobject *lz)
 }
 
 /*[clinic input]
-itertools.compress.__reduce__ as compress_reduce
+itertools.compress.__reduce__
 
     lz: self(type="compressobject *")
 
@@ -3340,8 +3350,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-compress_reduce_impl(compressobject *lz)
-/*[clinic end generated code: output=bfc478e270a28115 input=3e864458db0eccf9]*/
+itertools_compress___reduce___impl(compressobject *lz)
+/*[clinic end generated code: output=cdac22171e08d543 input=eb333a57f9d7cd3b]*/
 {
     return Py_BuildValue("O(OO)", Py_TYPE(lz),
         lz->data, lz->selectors);
@@ -3360,7 +3370,7 @@ static PyTypeObject filterfalse_type;
 
 /*[clinic input]
 @classmethod
-itertools.filterfalse.__new__ as filterfalse_new
+itertools.filterfalse.__new__
 
     function: object
     iterable: object
@@ -3373,9 +3383,9 @@ If function is None, return the items that are false.
 [clinic start generated code]*/
 
 static PyObject *
-filterfalse_new_impl(PyTypeObject *type, PyObject *function,
-                     PyObject *iterable)
-/*[clinic end generated code: output=d8a4c0a668fcea69 input=3ea201239931baaa]*/
+itertools_filterfalse_impl(PyTypeObject *type, PyObject *function,
+                           PyObject *iterable)
+/*[clinic end generated code: output=d5a2f454b8a9abb1 input=b22461be1e15822e]*/
 {
     PyObject *it;
     filterfalseobject *lz;
@@ -3450,7 +3460,7 @@ filterfalse_next(filterfalseobject *lz)
 }
 
 /*[clinic input]
-itertools.filterfalse.__reduce__ as filterfalse_reduce
+itertools.filterfalse.__reduce__
 
     lz: self(type="filterfalseobject *")
 
@@ -3458,8 +3468,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-filterfalse_reduce_impl(filterfalseobject *lz)
-/*[clinic end generated code: output=ac8620bdd55ddf72 input=2b3852a10df5d06c]*/
+itertools_filterfalse___reduce___impl(filterfalseobject *lz)
+/*[clinic end generated code: output=695bb9e7d9c7c8dd input=4251cf332a099624]*/
 {
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
 }
@@ -3495,10 +3505,10 @@ static PyTypeObject count_type;
 
 /*[clinic input]
 @classmethod
-itertools.count.__new__ as count_new
+itertools.count.__new__
 
-    start: object = NULL
-    step: object = NULL
+    start as long_cnt: object(c_default="NULL") = 0
+    step as long_step: object(c_default="NULL") = 1
 
 Create a count object.
 
@@ -3513,28 +3523,29 @@ Equivalent to:
 [clinic start generated code]*/
 
 static PyObject *
-count_new_impl(PyTypeObject *type, PyObject *start, PyObject *step)
-/*[clinic end generated code: output=1df9fad69d29f4ec input=2576781c3efb35bf]*/
+itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
+                     PyObject *long_step)
+/*[clinic end generated code: output=09a9250aebd00b1c input=20f1ce2f2484a91c]*/
 {
     countobject *lz;
     int fast_mode;
     Py_ssize_t cnt = 0;
-    long step_long;
+    long step;
 
-    if ((start != NULL && !PyNumber_Check(start)) ||
-        (step != NULL && !PyNumber_Check(step))) {
+    if ((long_cnt != NULL && !PyNumber_Check(long_cnt)) ||
+        (long_step != NULL && !PyNumber_Check(long_step))) {
                     PyErr_SetString(PyExc_TypeError, "a number is required");
                     return NULL;
     }
 
-    fast_mode = (start == NULL || PyLong_Check(start)) &&
-                (step == NULL || PyLong_Check(step));
+    fast_mode = (long_cnt == NULL || PyLong_Check(long_cnt)) &&
+                (long_step == NULL || PyLong_Check(long_step));
 
     /* If not specified, start defaults to 0 */
-    if (start != NULL) {
+    if (long_cnt != NULL) {
         if (fast_mode) {
-            assert(PyLong_Check(start));
-            cnt = PyLong_AsSsize_t(start);
+            assert(PyLong_Check(long_cnt));
+            cnt = PyLong_AsSsize_t(long_cnt);
             if (cnt == -1 && PyErr_Occurred()) {
                 PyErr_Clear();
                 fast_mode = 0;
@@ -3542,47 +3553,47 @@ count_new_impl(PyTypeObject *type, PyObject *start, PyObject *step)
         }
     } else {
         cnt = 0;
-        start = _PyLong_Zero;
+        long_cnt = _PyLong_Zero;
     }
-    Py_INCREF(start);
+    Py_INCREF(long_cnt);
 
     /* If not specified, step defaults to 1 */
-    if (step == NULL)
-        step = _PyLong_One;
-    Py_INCREF(step);
+    if (long_step == NULL)
+        long_step = _PyLong_One;
+    Py_INCREF(long_step);
 
-    assert(start != NULL && step != NULL);
+    assert(long_cnt != NULL && long_step != NULL);
 
     /* Fast mode only works when the step is 1 */
     if (fast_mode) {
-        assert(PyLong_Check(step));
-        step_long = PyLong_AsLong(step);
-        if (step_long != 1) {
+        assert(PyLong_Check(long_step));
+        step = PyLong_AsLong(long_step);
+        if (step != 1) {
             fast_mode = 0;
-            if (step_long == -1 && PyErr_Occurred())
+            if (step == -1 && PyErr_Occurred())
                 PyErr_Clear();
         }
     }
 
     if (fast_mode)
-        Py_CLEAR(start);
+        Py_CLEAR(long_cnt);
     else
         cnt = PY_SSIZE_T_MAX;
 
-    assert((cnt != PY_SSIZE_T_MAX && start == NULL && fast_mode) ||
-           (cnt == PY_SSIZE_T_MAX && start != NULL && !fast_mode));
+    assert((cnt != PY_SSIZE_T_MAX && long_cnt == NULL && fast_mode) ||
+           (cnt == PY_SSIZE_T_MAX && long_cnt != NULL && !fast_mode));
     assert(!fast_mode ||
-           (PyLong_Check(step) && PyLong_AS_LONG(step) == 1));
+           (PyLong_Check(long_step) && PyLong_AS_LONG(long_step) == 1));
 
     /* create countobject structure */
     lz = (countobject *)type->tp_alloc(type, 0);
     if (lz == NULL) {
-        Py_XDECREF(start);
+        Py_XDECREF(long_cnt);
         return NULL;
     }
     lz->cnt = cnt;
-    lz->long_cnt = start;
-    lz->long_step = step;
+    lz->long_cnt = long_cnt;
+    lz->long_step = long_step;
 
     return (PyObject *)lz;
 }
@@ -3659,7 +3670,7 @@ count_repr(countobject *lz)
 }
 
 /*[clinic input]
-itertools.count.__reduce__ as count_reduce
+itertools.count.__reduce__
 
     lz: self(type="countobject *")
 
@@ -3667,8 +3678,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-count_reduce_impl(countobject *lz)
-/*[clinic end generated code: output=64fec5d0ca5aa2cd input=8a68e97535b37707]*/
+itertools_count___reduce___impl(countobject *lz)
+/*[clinic end generated code: output=7b9930e2bafa91bc input=d2f794fb73706bbb]*/
 {
     if (lz->cnt == PY_SSIZE_T_MAX)
         return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->long_cnt, lz->long_step);
@@ -3752,7 +3763,7 @@ repeat_repr(repeatobject *ro)
 }
 
 /*[clinic input]
-itertools.repeat.__length_hint__ as repeat_len
+itertools.repeat.__length_hint__
 
     ro: self(type="repeatobject *")
 
@@ -3760,8 +3771,8 @@ Private method returning an estimate of len(list(it)).
 [clinic start generated code]*/
 
 static PyObject *
-repeat_len_impl(repeatobject *ro)
-/*[clinic end generated code: output=f910fff81aefe178 input=59a6f9f93682bcaf]*/
+itertools_repeat___length_hint___impl(repeatobject *ro)
+/*[clinic end generated code: output=2338c14b3a3b1fc7 input=1e3f9bda2d073686]*/
 {
     if (ro->cnt == -1) {
         PyErr_SetString(PyExc_TypeError, "len() of unsized object");
@@ -3771,7 +3782,7 @@ repeat_len_impl(repeatobject *ro)
 }
 
 /*[clinic input]
-itertools.repeat.__reduce__ as repeat_reduce
+itertools.repeat.__reduce__
 
     ro: self(type="repeatobject *")
 
@@ -3779,8 +3790,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-repeat_reduce_impl(repeatobject *ro)
-/*[clinic end generated code: output=8f15345d61cd588e input=4eab78b8fd9130d4]*/
+itertools_repeat___reduce___impl(repeatobject *ro)
+/*[clinic end generated code: output=f52f9e3a480349d5 input=d6aa5ae9a068c386]*/
 {
     /* unpickle this so that a new repeat iterator is constructed with an
      * object, then call __setstate__ on it to set cnt
@@ -3969,7 +3980,7 @@ zip_longest_next(ziplongestobject *lz)
 }
 
 /*[clinic input]
-itertools.zip_longest.__reduce__ as zip_longest_reduce
+itertools.zip_longest.__reduce__
 
     lz: self(type="ziplongestobject *")
 
@@ -3977,8 +3988,8 @@ Return state information for pickling.
 [clinic start generated code]*/
 
 static PyObject *
-zip_longest_reduce_impl(ziplongestobject *lz)
-/*[clinic end generated code: output=561995d1e971a31d input=25269cf781351ff5]*/
+itertools_zip_longest___reduce___impl(ziplongestobject *lz)
+/*[clinic end generated code: output=a893152414808221 input=ad9ccb9841a40b4c]*/
 {
 
     /* Create a new tuple with empty sequences where appropriate to pickle.
@@ -4005,7 +4016,7 @@ zip_longest_reduce_impl(ziplongestobject *lz)
 }
 
 /*[clinic input]
-itertools.zip_longest.__setstate__ as zip_longest_setstate
+itertools.zip_longest.__setstate__
 
     lz: self(type="ziplongestobject *")
     state: object
@@ -4015,8 +4026,8 @@ Set state information for unpickling.
 [clinic start generated code]*/
 
 static PyObject *
-zip_longest_setstate(ziplongestobject *lz, PyObject *state)
-/*[clinic end generated code: output=55d1c40777c57700 input=0f40aa1fb87dd8c4]*/
+itertools_zip_longest___setstate__(ziplongestobject *lz, PyObject *state)
+/*[clinic end generated code: output=14f31f6a347ee50a input=7af98e8fd8ae9107]*/
 {
     Py_INCREF(state);
     Py_XSETREF(lz->fillvalue, state);
@@ -4044,8 +4055,8 @@ defaults to None or can be specified by a keyword argument.\n\
 
 
 static PyMethodDef groupby_methods[] = {
-    GROUPBY_REDUCE_METHODDEF
-    GROUPBY_SETSTATE_METHODDEF
+    ITERTOOLS_GROUPBY___REDUCE___METHODDEF
+    ITERTOOLS_GROUPBY___SETSTATE___METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -4072,7 +4083,7 @@ static PyTypeObject groupby_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    groupby_new__doc__,                 /* tp_doc */
+    itertools_groupby__doc__,           /* tp_doc */
     (traverseproc)groupby_traverse,     /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4089,13 +4100,13 @@ static PyTypeObject groupby_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    groupby_new,                        /* tp_new */
+    itertools_groupby,                  /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef _grouper_methods[] = {
-    _GROUPER_REDUCE_METHODDEF
+    ITERTOOLS__GROUPER___REDUCE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4139,13 +4150,13 @@ static PyTypeObject _grouper_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    _grouper_new,                       /* tp_new */
+    itertools__grouper,                 /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef teedataobject_methods[] = {
-    TEEDATAOBJECT_REDUCE_METHODDEF
+    ITERTOOLS_TEEDATAOBJECT___REDUCE___METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -4171,7 +4182,7 @@ static PyTypeObject teedataobject_type = {
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
-    teedataobject_new__doc__,                   /* tp_doc */
+    itertools_teedataobject__doc__,             /* tp_doc */
     (traverseproc)teedataobject_traverse,       /* tp_traverse */
     (inquiry)teedataobject_clear,               /* tp_clear */
     0,                                          /* tp_richcompare */
@@ -4188,15 +4199,15 @@ static PyTypeObject teedataobject_type = {
     0,                                          /* tp_dictoffset */
     0,                                          /* tp_init */
     0,                                          /* tp_alloc */
-    teedataobject_new,                          /* tp_new */
+    itertools_teedataobject,                    /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
 };
 
 
 static PyMethodDef tee_methods[] = {
-    TEE_COPY_METHODDEF
-    TEE_REDUCE_METHODDEF
-    TEE_SETSTATE_METHODDEF
+    ITERTOOLS__TEE___COPY___METHODDEF
+    ITERTOOLS__TEE___REDUCE___METHODDEF
+    ITERTOOLS__TEE___SETSTATE___METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -4222,7 +4233,7 @@ static PyTypeObject tee_type = {
     0,                                  /* tp_setattro */
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,            /* tp_flags */
-    tee_new__doc__,                     /* tp_doc */
+    itertools__tee__doc__,              /* tp_doc */
     (traverseproc)tee_traverse,         /* tp_traverse */
     (inquiry)tee_clear,                 /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4239,14 +4250,14 @@ static PyTypeObject tee_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    tee_new,                            /* tp_new */
+    itertools__tee,                     /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef cycle_methods[] = {
-    CYCLE_REDUCE_METHODDEF
-    CYCLE_SETSTATE_METHODDEF
+    ITERTOOLS_CYCLE___REDUCE___METHODDEF
+    ITERTOOLS_CYCLE___SETSTATE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4274,7 +4285,7 @@ static PyTypeObject cycle_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    cycle_new__doc__,                   /* tp_doc */
+    itertools_cycle__doc__,             /* tp_doc */
     (traverseproc)cycle_traverse,       /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4291,14 +4302,14 @@ static PyTypeObject cycle_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    cycle_new,                          /* tp_new */
+    itertools_cycle,                    /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef dropwhile_methods[] = {
-    DROPWHILE_REDUCE_METHODDEF
-    DROPWHILE_SETSTATE_METHODDEF
+    ITERTOOLS_DROPWHILE___REDUCE___METHODDEF
+    ITERTOOLS_DROPWHILE___SETSTATE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4325,7 +4336,7 @@ static PyTypeObject dropwhile_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    dropwhile_new__doc__,               /* tp_doc */
+    itertools_dropwhile__doc__,         /* tp_doc */
     (traverseproc)dropwhile_traverse,   /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4342,14 +4353,14 @@ static PyTypeObject dropwhile_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    dropwhile_new,                      /* tp_new */
+    itertools_dropwhile,                /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef takewhile_reduce_methods[] = {
-    TAKEWHILE_REDUCE_METHODDEF
-    TAKEWHILE_SETSTATE_METHODDEF
+    ITERTOOLS_TAKEWHILE___REDUCE___METHODDEF
+    ITERTOOLS_TAKEWHILE___SETSTATE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4376,7 +4387,7 @@ static PyTypeObject takewhile_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    takewhile_new__doc__,               /* tp_doc */
+    itertools_takewhile__doc__,         /* tp_doc */
     (traverseproc)takewhile_traverse,   /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4393,14 +4404,14 @@ static PyTypeObject takewhile_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    takewhile_new,                      /* tp_new */
+    itertools_takewhile,                /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef islice_methods[] = {
-    ISLICE_REDUCE_METHODDEF
-    ISLICE_SETSTATE_METHODDEF
+    ITERTOOLS_ISLICE___REDUCE___METHODDEF
+    ITERTOOLS_ISLICE___SETSTATE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4450,7 +4461,7 @@ static PyTypeObject islice_type = {
 
 
 static PyMethodDef starmap_methods[] = {
-    STARMAP_REDUCE_METHODDEF
+    ITERTOOLS_STARMAP___REDUCE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4477,7 +4488,7 @@ static PyTypeObject starmap_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    starmap_new__doc__,                 /* tp_doc */
+    itertools_starmap__doc__,           /* tp_doc */
     (traverseproc)starmap_traverse,     /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4494,15 +4505,15 @@ static PyTypeObject starmap_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    starmap_new,                        /* tp_new */
+    itertools_starmap,                  /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef chain_methods[] = {
-    CHAIN_NEW_FROM_ITERABLE_METHODDEF
-    CHAIN_REDUCE_METHODDEF
-    CHAIN_SETSTATE_METHODDEF
+    ITERTOOLS_CHAIN_FROM_ITERABLE_METHODDEF
+    ITERTOOLS_CHAIN___REDUCE___METHODDEF
+    ITERTOOLS_CHAIN___SETSTATE___METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -4552,9 +4563,9 @@ static PyTypeObject chain_type = {
 
 
 static PyMethodDef product_methods[] = {
-    PRODUCT_REDUCE_METHODDEF
-    PRODUCT_SETSTATE_METHODDEF
-    PRODUCT_SIZEOF_METHODDEF
+    ITERTOOLS_PRODUCT___REDUCE___METHODDEF
+    ITERTOOLS_PRODUCT___SETSTATE___METHODDEF
+    ITERTOOLS_PRODUCT___SIZEOF___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4598,15 +4609,15 @@ static PyTypeObject product_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    product_new,                        /* tp_new */
+    product_new,                          /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef combinations_methods[] = {
-    COMBINATIONS_REDUCE_METHODDEF
-    COMBINATIONS_SETSTATE_METHODDEF
-    COMBINATIONS_SIZEOF_METHODDEF
+    ITERTOOLS_COMBINATIONS___REDUCE___METHODDEF
+    ITERTOOLS_COMBINATIONS___SETSTATE___METHODDEF
+    ITERTOOLS_COMBINATIONS___SIZEOF___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4633,7 +4644,7 @@ static PyTypeObject combinations_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    combinations_new__doc__,            /* tp_doc */
+    itertools_combinations__doc__,      /* tp_doc */
     (traverseproc)combinations_traverse,/* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4650,15 +4661,15 @@ static PyTypeObject combinations_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    combinations_new,                   /* tp_new */
+    itertools_combinations,             /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef cwr_methods[] = {
-    CWR_REDUCE_METHODDEF
-    CWR_SETSTATE_METHODDEF
-    CWR_SIZEOF_METHODDEF
+    ITERTOOLS_COMBINATIONS_WITH_REPLACEMENT___REDUCE___METHODDEF
+    ITERTOOLS_COMBINATIONS_WITH_REPLACEMENT___SETSTATE___METHODDEF
+    ITERTOOLS_COMBINATIONS_WITH_REPLACEMENT___SIZEOF___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4685,7 +4696,7 @@ static PyTypeObject cwr_type = {
     0,                                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,                            /* tp_flags */
-    cwr_new__doc__,                                     /* tp_doc */
+    itertools_combinations_with_replacement__doc__,     /* tp_doc */
     (traverseproc)cwr_traverse,                         /* tp_traverse */
     0,                                                  /* tp_clear */
     0,                                                  /* tp_richcompare */
@@ -4702,15 +4713,15 @@ static PyTypeObject cwr_type = {
     0,                                                  /* tp_dictoffset */
     0,                                                  /* tp_init */
     0,                                                  /* tp_alloc */
-    cwr_new,                                            /* tp_new */
+    itertools_combinations_with_replacement,            /* tp_new */
     PyObject_GC_Del,                                    /* tp_free */
 };
 
 
 static PyMethodDef permuations_methods[] = {
-    PERMUTATIONS_REDUCE_METHODDEF
-    PERMUTATIONS_SETSTATE_METHODDEF
-    PERMUTATIONS_SIZEOF_METHODDEF
+    ITERTOOLS_PERMUTATIONS___REDUCE___METHODDEF
+    ITERTOOLS_PERMUTATIONS___SETSTATE___METHODDEF
+    ITERTOOLS_PERMUTATIONS___SIZEOF___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4737,7 +4748,7 @@ static PyTypeObject permutations_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    permutations_new__doc__,            /* tp_doc */
+    itertools_permutations__doc__,      /* tp_doc */
     (traverseproc)permutations_traverse,/* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4754,14 +4765,14 @@ static PyTypeObject permutations_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    permutations_new,                   /* tp_new */
+    itertools_permutations,             /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef accumulate_methods[] = {
-    ACCUMULATE_REDUCE_METHODDEF
-    ACCUMULATE_SETSTATE_METHODDEF
+    ITERTOOLS_ACCUMULATE___REDUCE___METHODDEF
+    ITERTOOLS_ACCUMULATE___SETSTATE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4788,7 +4799,7 @@ static PyTypeObject accumulate_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    accumulate_new__doc__,              /* tp_doc */
+    itertools_accumulate__doc__,        /* tp_doc */
     (traverseproc)accumulate_traverse,  /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4805,13 +4816,13 @@ static PyTypeObject accumulate_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    accumulate_new,                     /* tp_new */
+    itertools_accumulate,               /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef compress_methods[] = {
-    COMPRESS_REDUCE_METHODDEF
+    ITERTOOLS_COMPRESS___REDUCE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4838,7 +4849,7 @@ static PyTypeObject compress_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    compress_new__doc__,                /* tp_doc */
+    itertools_compress__doc__,          /* tp_doc */
     (traverseproc)compress_traverse,    /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4855,13 +4866,13 @@ static PyTypeObject compress_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    compress_new,                       /* tp_new */
+    itertools_compress,                 /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef filterfalse_methods[] = {
-    FILTERFALSE_REDUCE_METHODDEF
+    ITERTOOLS_FILTERFALSE___REDUCE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4888,7 +4899,7 @@ static PyTypeObject filterfalse_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    filterfalse_new__doc__,             /* tp_doc */
+    itertools_filterfalse__doc__,       /* tp_doc */
     (traverseproc)filterfalse_traverse, /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4905,13 +4916,13 @@ static PyTypeObject filterfalse_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    filterfalse_new,                    /* tp_new */
+    itertools_filterfalse,              /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef count_methods[] = {
-    COUNT_REDUCE_METHODDEF
+    ITERTOOLS_COUNT___REDUCE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -4938,7 +4949,7 @@ static PyTypeObject count_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    count_new__doc__,                   /* tp_doc */
+    itertools_count__doc__,             /* tp_doc */
     (traverseproc)count_traverse,       /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4955,14 +4966,14 @@ static PyTypeObject count_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    count_new,                          /* tp_new */
+    itertools_count,                    /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
 
 static PyMethodDef repeat_methods[] = {
-    REPEAT_LEN_METHODDEF
-    REPEAT_REDUCE_METHODDEF
+    ITERTOOLS_REPEAT___LENGTH_HINT___METHODDEF
+    ITERTOOLS_REPEAT___REDUCE___METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 
@@ -5012,8 +5023,8 @@ static PyTypeObject repeat_type = {
 
 
 static PyMethodDef zip_longest_methods[] = {
-    ZIP_LONGEST_REDUCE_METHODDEF
-    ZIP_LONGEST_SETSTATE_METHODDEF
+    ITERTOOLS_ZIP_LONGEST___REDUCE___METHODDEF
+    ITERTOOLS_ZIP_LONGEST___SETSTATE___METHODDEF
     {NULL,              NULL}   /* sentinel */
 };
 
@@ -5096,7 +5107,7 @@ combinations_with_replacement(p, r)\n\
 
 
 static PyMethodDef module_methods[] = {
-    TEE_METHODDEF
+    ITERTOOLS_TEE_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -1,4 +1,3 @@
-
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "structmember.h"
@@ -29,8 +28,9 @@ class itertools.filterfalse "filterfalseobject *" "&filterfalse_type"
 class itertools.count "countobject *" "&count_type"
 class itertools.repeat "repeatobject *" "&repeat_type"
 class itertools.zip_longest "ziplongestobject *" "&ziplongest_type"
+
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=95c340f2eacd0350]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=12d01329782068a4]*/
 
 
 /* groupby object ************************************************************/
@@ -242,56 +242,6 @@ groupby_setstate(groupbyobject *lz, PyObject *state)
     Py_RETURN_NONE;
 }
 
-static PyMethodDef groupby_methods[] = {
-    GROUPBY_REDUCE_METHODDEF
-    GROUPBY_SETSTATE_METHODDEF
-    {NULL,              NULL}           /* sentinel */
-};
-
-static PyTypeObject groupby_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.groupby",                /* tp_name */
-    sizeof(groupbyobject),              /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)groupby_dealloc,        /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    groupby_new__doc__,                 /* tp_doc */
-    (traverseproc)groupby_traverse,     /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)groupby_next,         /* tp_iternext */
-    groupby_methods,                    /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    groupby_new,                        /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
-
 
 /* _grouper object (internal) ************************************************/
 
@@ -398,55 +348,6 @@ _grouper_reduce_impl(_grouperobject *lz)
     }
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->parent, lz->tgtkey);
 }
-
-static PyMethodDef _grouper_methods[] = {
-    _GROUPER_REDUCE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-
-static PyTypeObject _grouper_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools._grouper",               /* tp_name */
-    sizeof(_grouperobject),             /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)_grouper_dealloc,       /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,            /* tp_flags */
-    0,                                  /* tp_doc */
-    (traverseproc)_grouper_traverse,    /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)_grouper_next,        /* tp_iternext */
-    _grouper_methods,                   /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    _grouper_new,                       /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 
 /* tee object and with supporting function and objects ***********************/
@@ -658,54 +559,6 @@ err:
     return NULL;
 }
 
-static PyMethodDef teedataobject_methods[] = {
-    TEEDATAOBJECT_REDUCE_METHODDEF
-    {NULL,              NULL}           /* sentinel */
-};
-
-static PyTypeObject teedataobject_type = {
-    PyVarObject_HEAD_INIT(0, 0)                 /* Must fill in type value later */
-    "itertools._tee_dataobject",                /* tp_name */
-    sizeof(teedataobject),                      /* tp_basicsize */
-    0,                                          /* tp_itemsize */
-    /* methods */
-    (destructor)teedataobject_dealloc,          /* tp_dealloc */
-    0,                                          /* tp_print */
-    0,                                          /* tp_getattr */
-    0,                                          /* tp_setattr */
-    0,                                          /* tp_reserved */
-    0,                                          /* tp_repr */
-    0,                                          /* tp_as_number */
-    0,                                          /* tp_as_sequence */
-    0,                                          /* tp_as_mapping */
-    0,                                          /* tp_hash */
-    0,                                          /* tp_call */
-    0,                                          /* tp_str */
-    PyObject_GenericGetAttr,                    /* tp_getattro */
-    0,                                          /* tp_setattro */
-    0,                                          /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
-    teedataobject_new__doc__,                   /* tp_doc */
-    (traverseproc)teedataobject_traverse,       /* tp_traverse */
-    (inquiry)teedataobject_clear,               /* tp_clear */
-    0,                                          /* tp_richcompare */
-    0,                                          /* tp_weaklistoffset */
-    0,                                          /* tp_iter */
-    0,                                          /* tp_iternext */
-    teedataobject_methods,                      /* tp_methods */
-    0,                                          /* tp_members */
-    0,                                          /* tp_getset */
-    0,                                          /* tp_base */
-    0,                                          /* tp_dict */
-    0,                                          /* tp_descr_get */
-    0,                                          /* tp_descr_set */
-    0,                                          /* tp_dictoffset */
-    0,                                          /* tp_init */
-    0,                                          /* tp_alloc */
-    teedataobject_new,                          /* tp_new */
-    PyObject_GC_Del,                            /* tp_free */
-};
-
 
 static PyTypeObject tee_type;
 
@@ -875,56 +728,6 @@ tee_setstate(teeobject *to, PyObject *state)
     to->index = index;
     Py_RETURN_NONE;
 }
-
-static PyMethodDef tee_methods[] = {
-    TEE_COPY_METHODDEF
-    TEE_REDUCE_METHODDEF
-    TEE_SETSTATE_METHODDEF
-    {NULL,              NULL}           /* sentinel */
-};
-
-static PyTypeObject tee_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools._tee",                   /* tp_name */
-    sizeof(teeobject),                  /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)tee_dealloc,            /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    0,                                  /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,            /* tp_flags */
-    tee_new__doc__,                     /* tp_doc */
-    (traverseproc)tee_traverse,         /* tp_traverse */
-    (inquiry)tee_clear,                 /* tp_clear */
-    0,                                  /* tp_richcompare */
-    offsetof(teeobject, weakreflist),   /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)tee_next,             /* tp_iternext */
-    tee_methods,                        /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    tee_new,                            /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 /*[clinic input]
 itertools.tee as tee
@@ -1157,57 +960,6 @@ cycle_setstate(cycleobject *lz, PyObject *state)
     Py_RETURN_NONE;
 }
 
-static PyMethodDef cycle_methods[] = {
-    CYCLE_REDUCE_METHODDEF
-    CYCLE_SETSTATE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-
-static PyTypeObject cycle_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.cycle",                  /* tp_name */
-    sizeof(cycleobject),                /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)cycle_dealloc,          /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    cycle_new__doc__,                   /* tp_doc */
-    (traverseproc)cycle_traverse,       /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)cycle_next,           /* tp_iternext */
-    cycle_methods,                      /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    cycle_new,                          /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
-
 
 /* dropwhile object **********************************************************/
 
@@ -1347,56 +1099,6 @@ dropwhile_setstate(dropwhileobject *lz, PyObject *state)
     Py_RETURN_NONE;
 }
 
-static PyMethodDef dropwhile_methods[] = {
-    DROPWHILE_REDUCE_METHODDEF
-    DROPWHILE_SETSTATE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-static PyTypeObject dropwhile_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.dropwhile",              /* tp_name */
-    sizeof(dropwhileobject),            /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)dropwhile_dealloc,      /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    dropwhile_new__doc__,               /* tp_doc */
-    (traverseproc)dropwhile_traverse,   /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)dropwhile_next,       /* tp_iternext */
-    dropwhile_methods,                  /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    dropwhile_new,                      /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
-
 
 /* takewhile object **********************************************************/
 
@@ -1532,56 +1234,6 @@ takewhile_setstate(takewhileobject *lz, PyObject *state)
     lz->stop = stop;
     Py_RETURN_NONE;
 }
-
-static PyMethodDef takewhile_reduce_methods[] = {
-    TAKEWHILE_REDUCE_METHODDEF
-    TAKEWHILE_SETSTATE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-static PyTypeObject takewhile_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.takewhile",              /* tp_name */
-    sizeof(takewhileobject),            /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)takewhile_dealloc,      /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    takewhile_new__doc__,               /* tp_doc */
-    (traverseproc)takewhile_traverse,   /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)takewhile_next,       /* tp_iternext */
-    takewhile_reduce_methods,           /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    takewhile_new,                      /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 
 /* islice object *************************************************************/
@@ -1799,12 +1451,6 @@ islice_setstate(isliceobject *lz, PyObject *state)
     Py_RETURN_NONE;
 }
 
-static PyMethodDef islice_methods[] = {
-    ISLICE_REDUCE_METHODDEF
-    ISLICE_SETSTATE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
 PyDoc_STRVAR(islice_doc,
 "islice(iterable, stop) --> islice object\n\
 islice(iterable, start, stop[, step]) --> islice object\n\
@@ -1815,50 +1461,6 @@ otherwise, start defaults to zero.  Step defaults to one.  If\n\
 specified as another value, step determines how many values are \n\
 skipped between successive calls.  Works like a slice() on a list\n\
 but returns an iterator.");
-
-static PyTypeObject islice_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.islice",                 /* tp_name */
-    sizeof(isliceobject),               /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)islice_dealloc,         /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    islice_doc,                         /* tp_doc */
-    (traverseproc)islice_traverse,      /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)islice_next,          /* tp_iternext */
-    islice_methods,                     /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    islice_new,                         /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 
 /* starmap object ************************************************************/
@@ -1964,60 +1566,11 @@ starmap_reduce_impl(starmapobject *lz)
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
 }
 
-static PyMethodDef starmap_methods[] = {
-    STARMAP_REDUCE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
 PyDoc_STRVAR(starmap_doc,
 "starmap(function, sequence) --> starmap object\n\
 \n\
 Return an iterator whose values are returned from the function evaluated\n\
 with an argument tuple taken from the given sequence.");
-
-static PyTypeObject starmap_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.starmap",                /* tp_name */
-    sizeof(starmapobject),              /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)starmap_dealloc,        /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    starmap_new__doc__,                 /* tp_doc */
-    (traverseproc)starmap_traverse,     /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)starmap_next,         /* tp_iternext */
-    starmap_methods,                    /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    starmap_new,                        /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 
 /* chain object **************************************************************/
@@ -2211,57 +1764,6 @@ PyDoc_STRVAR(chain_doc,
 Return a chain object whose .__next__() method returns elements from the\n\
 first iterable until it is exhausted, then elements from the next\n\
 iterable, until all of the iterables are exhausted.");
-
-static PyMethodDef chain_methods[] = {
-    CHAIN_NEW_FROM_ITERABLE_METHODDEF
-    CHAIN_REDUCE_METHODDEF
-    CHAIN_SETSTATE_METHODDEF
-    {NULL,              NULL}           /* sentinel */
-};
-
-static PyTypeObject chain_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.chain",                  /* tp_name */
-    sizeof(chainobject),                /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)chain_dealloc,          /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    chain_doc,                          /* tp_doc */
-    (traverseproc)chain_traverse,       /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)chain_next,           /* tp_iternext */
-    chain_methods,                      /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    chain_new,                          /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 
 /* product object ************************************************************/
@@ -2580,13 +2082,6 @@ product_setstate(productobject *lz, PyObject *state)
     Py_RETURN_NONE;
 }
 
-static PyMethodDef product_methods[] = {
-    PRODUCT_REDUCE_METHODDEF
-    PRODUCT_SETSTATE_METHODDEF
-    PRODUCT_SIZEOF_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
 PyDoc_STRVAR(product_doc,
 "product(*iterables, repeat=1) --> product object\n\
 \n\
@@ -2600,50 +2095,6 @@ of repetitions with the optional repeat keyword argument. For example,\n\
 product(A, repeat=4) means the same as product(A, A, A, A).\n\n\
 product('ab', range(3)) --> ('a',0) ('a',1) ('a',2) ('b',0) ('b',1) ('b',2)\n\
 product((0,1), (0,1), (0,1)) --> (0,0,0) (0,0,1) (0,1,0) (0,1,1) (1,0,0) ...");
-
-static PyTypeObject product_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.product",                /* tp_name */
-    sizeof(productobject),              /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)product_dealloc,        /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    product_doc,                        /* tp_doc */
-    (traverseproc)product_traverse,     /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)product_next,         /* tp_iternext */
-    product_methods,                    /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    product_new,                        /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 
 /* combinations object *******************************************************/
@@ -2935,57 +2386,6 @@ combinations_setstate(combinationsobject *lz, PyObject *state)
     Py_XSETREF(lz->result, result);
     Py_RETURN_NONE;
 }
-
-static PyMethodDef combinations_methods[] = {
-    COMBINATIONS_REDUCE_METHODDEF
-    COMBINATIONS_SETSTATE_METHODDEF
-    COMBINATIONS_SIZEOF_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-static PyTypeObject combinations_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.combinations",           /* tp_name */
-    sizeof(combinationsobject),         /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)combinations_dealloc,   /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    combinations_new__doc__,            /* tp_doc */
-    (traverseproc)combinations_traverse,/* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)combinations_next,    /* tp_iternext */
-    combinations_methods,               /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    combinations_new,                   /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 
 /* combinations with replacement object **************************************/
@@ -3295,57 +2695,6 @@ cwr_setstate(cwrobject *lz, PyObject *state)
     Py_XSETREF(lz->result, result);
     Py_RETURN_NONE;
 }
-
-static PyMethodDef cwr_methods[] = {
-    CWR_REDUCE_METHODDEF
-    CWR_SETSTATE_METHODDEF
-    CWR_SIZEOF_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-static PyTypeObject cwr_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.combinations_with_replacement",          /* tp_name */
-    sizeof(cwrobject),                                  /* tp_basicsize */
-    0,                                                  /* tp_itemsize */
-    /* methods */
-    (destructor)cwr_dealloc,                            /* tp_dealloc */
-    0,                                                  /* tp_print */
-    0,                                                  /* tp_getattr */
-    0,                                                  /* tp_setattr */
-    0,                                                  /* tp_reserved */
-    0,                                                  /* tp_repr */
-    0,                                                  /* tp_as_number */
-    0,                                                  /* tp_as_sequence */
-    0,                                                  /* tp_as_mapping */
-    0,                                                  /* tp_hash */
-    0,                                                  /* tp_call */
-    0,                                                  /* tp_str */
-    PyObject_GenericGetAttr,                            /* tp_getattro */
-    0,                                                  /* tp_setattro */
-    0,                                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,                            /* tp_flags */
-    cwr_new__doc__,                                     /* tp_doc */
-    (traverseproc)cwr_traverse,                         /* tp_traverse */
-    0,                                                  /* tp_clear */
-    0,                                                  /* tp_richcompare */
-    0,                                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                                  /* tp_iter */
-    (iternextfunc)cwr_next,                             /* tp_iternext */
-    cwr_methods,                                        /* tp_methods */
-    0,                                                  /* tp_members */
-    0,                                                  /* tp_getset */
-    0,                                                  /* tp_base */
-    0,                                                  /* tp_dict */
-    0,                                                  /* tp_descr_get */
-    0,                                                  /* tp_descr_set */
-    0,                                                  /* tp_dictoffset */
-    0,                                                  /* tp_init */
-    0,                                                  /* tp_alloc */
-    cwr_new,                                            /* tp_new */
-    PyObject_GC_Del,                                    /* tp_free */
-};
 
 
 /* permutations object ********************************************************
@@ -3717,56 +3066,6 @@ permutations_setstate(permutationsobject *po, PyObject *state)
     Py_RETURN_NONE;
 }
 
-static PyMethodDef permuations_methods[] = {
-    PERMUTATIONS_REDUCE_METHODDEF
-    PERMUTATIONS_SETSTATE_METHODDEF
-    PERMUTATIONS_SIZEOF_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-static PyTypeObject permutations_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.permutations",           /* tp_name */
-    sizeof(permutationsobject),         /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)permutations_dealloc,   /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    permutations_new__doc__,            /* tp_doc */
-    (traverseproc)permutations_traverse,/* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)permutations_next,    /* tp_iternext */
-    permuations_methods,                /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    permutations_new,                   /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 /* accumulate object ********************************************************/
 
@@ -3919,56 +3218,6 @@ accumulate_setstate(accumulateobject *lz, PyObject *state)
     Py_RETURN_NONE;
 }
 
-static PyMethodDef accumulate_methods[] = {
-    ACCUMULATE_REDUCE_METHODDEF
-    ACCUMULATE_SETSTATE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-static PyTypeObject accumulate_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.accumulate",             /* tp_name */
-    sizeof(accumulateobject),           /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)accumulate_dealloc,     /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    accumulate_new__doc__,              /* tp_doc */
-    (traverseproc)accumulate_traverse,  /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)accumulate_next,      /* tp_iternext */
-    accumulate_methods,                 /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    accumulate_new,                     /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
-
 
 /* compress object ************************************************************/
 
@@ -4098,55 +3347,6 @@ compress_reduce_impl(compressobject *lz)
         lz->data, lz->selectors);
 }
 
-static PyMethodDef compress_methods[] = {
-    COMPRESS_REDUCE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-static PyTypeObject compress_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.compress",               /* tp_name */
-    sizeof(compressobject),             /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)compress_dealloc,       /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    compress_new__doc__,                /* tp_doc */
-    (traverseproc)compress_traverse,    /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)compress_next,        /* tp_iternext */
-    compress_methods,                   /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    compress_new,                       /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
-
 
 /* filterfalse object ************************************************************/
 
@@ -4263,55 +3463,6 @@ filterfalse_reduce_impl(filterfalseobject *lz)
 {
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
 }
-
-static PyMethodDef filterfalse_methods[] = {
-    FILTERFALSE_REDUCE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-static PyTypeObject filterfalse_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.filterfalse",            /* tp_name */
-    sizeof(filterfalseobject),          /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)filterfalse_dealloc,    /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    0,                                  /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    filterfalse_new__doc__,             /* tp_doc */
-    (traverseproc)filterfalse_traverse, /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)filterfalse_next,     /* tp_iternext */
-    filterfalse_methods,                /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    filterfalse_new,                    /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 
 /* count object ************************************************************/
@@ -4524,55 +3675,6 @@ count_reduce_impl(countobject *lz)
     return Py_BuildValue("O(n)", Py_TYPE(lz), lz->cnt);
 }
 
-static PyMethodDef count_methods[] = {
-    COUNT_REDUCE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
-static PyTypeObject count_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.count",                  /* tp_name */
-    sizeof(countobject),                /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)count_dealloc,          /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    (reprfunc)count_repr,               /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    count_new__doc__,                   /* tp_doc */
-    (traverseproc)count_traverse,       /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)count_next,           /* tp_iternext */
-    count_methods,                      /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    count_new,                          /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
-
 
 /* repeat object ************************************************************/
 
@@ -4689,60 +3791,10 @@ repeat_reduce_impl(repeatobject *ro)
         return Py_BuildValue("O(O)", Py_TYPE(ro), ro->element);
 }
 
-static PyMethodDef repeat_methods[] = {
-    REPEAT_LEN_METHODDEF
-    REPEAT_REDUCE_METHODDEF
-    {NULL,              NULL}           /* sentinel */
-};
-
 PyDoc_STRVAR(repeat_doc,
 "repeat(object [,times]) -> create an iterator which returns the object\n\
 for the specified number of times.  If not specified, returns the object\n\
 endlessly.");
-
-static PyTypeObject repeat_type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "itertools.repeat",                 /* tp_name */
-    sizeof(repeatobject),               /* tp_basicsize */
-    0,                                  /* tp_itemsize */
-    /* methods */
-    (destructor)repeat_dealloc,         /* tp_dealloc */
-    0,                                  /* tp_print */
-    0,                                  /* tp_getattr */
-    0,                                  /* tp_setattr */
-    0,                                  /* tp_reserved */
-    (reprfunc)repeat_repr,              /* tp_repr */
-    0,                                  /* tp_as_number */
-    0,                                  /* tp_as_sequence */
-    0,                                  /* tp_as_mapping */
-    0,                                  /* tp_hash */
-    0,                                  /* tp_call */
-    0,                                  /* tp_str */
-    PyObject_GenericGetAttr,            /* tp_getattro */
-    0,                                  /* tp_setattro */
-    0,                                  /* tp_as_buffer */
-    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
-        Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    repeat_doc,                         /* tp_doc */
-    (traverseproc)repeat_traverse,      /* tp_traverse */
-    0,                                  /* tp_clear */
-    0,                                  /* tp_richcompare */
-    0,                                  /* tp_weaklistoffset */
-    PyObject_SelfIter,                  /* tp_iter */
-    (iternextfunc)repeat_next,          /* tp_iternext */
-    repeat_methods,                     /* tp_methods */
-    0,                                  /* tp_members */
-    0,                                  /* tp_getset */
-    0,                                  /* tp_base */
-    0,                                  /* tp_dict */
-    0,                                  /* tp_descr_get */
-    0,                                  /* tp_descr_set */
-    0,                                  /* tp_dictoffset */
-    0,                                  /* tp_init */
-    0,                                  /* tp_alloc */
-    repeat_new,                         /* tp_new */
-    PyObject_GC_Del,                    /* tp_free */
-};
 
 /* ziplongest object *********************************************************/
 
@@ -4971,12 +4023,6 @@ zip_longest_setstate(ziplongestobject *lz, PyObject *state)
     Py_RETURN_NONE;
 }
 
-static PyMethodDef zip_longest_methods[] = {
-    ZIP_LONGEST_REDUCE_METHODDEF
-    ZIP_LONGEST_SETSTATE_METHODDEF
-    {NULL,              NULL}   /* sentinel */
-};
-
 PyDoc_STRVAR(zip_longest_doc,
 "zip_longest(iter1 [,iter2 [...]], [fillvalue=None]) --> zip_longest object\n\
 \n\
@@ -4987,6 +4033,990 @@ is exhausted and then it raises StopIteration.  When the shorter iterables\n\
 are exhausted, the fillvalue is substituted in their place.  The fillvalue\n\
 defaults to None or can be specified by a keyword argument.\n\
 ");
+
+
+/* including clinic output must come after typdefs and PyObject type
+   declarations, but before method arrays and type definitions */
+#include "clinic/itertoolsmodule.c.h"
+
+
+/* class methods and type definitions ****************************************/
+
+
+static PyMethodDef groupby_methods[] = {
+    GROUPBY_REDUCE_METHODDEF
+    GROUPBY_SETSTATE_METHODDEF
+    {NULL,              NULL}           /* sentinel */
+};
+
+static PyTypeObject groupby_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.groupby",                /* tp_name */
+    sizeof(groupbyobject),              /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)groupby_dealloc,        /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    groupby_new__doc__,                 /* tp_doc */
+    (traverseproc)groupby_traverse,     /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)groupby_next,         /* tp_iternext */
+    groupby_methods,                    /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    groupby_new,                        /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef _grouper_methods[] = {
+    _GROUPER_REDUCE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+
+static PyTypeObject _grouper_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools._grouper",               /* tp_name */
+    sizeof(_grouperobject),             /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)_grouper_dealloc,       /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,            /* tp_flags */
+    0,                                  /* tp_doc */
+    (traverseproc)_grouper_traverse,    /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)_grouper_next,        /* tp_iternext */
+    _grouper_methods,                   /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    _grouper_new,                       /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef teedataobject_methods[] = {
+    TEEDATAOBJECT_REDUCE_METHODDEF
+    {NULL,              NULL}           /* sentinel */
+};
+
+static PyTypeObject teedataobject_type = {
+    PyVarObject_HEAD_INIT(0, 0)                 /* Must fill in type value later */
+    "itertools._tee_dataobject",                /* tp_name */
+    sizeof(teedataobject),                      /* tp_basicsize */
+    0,                                          /* tp_itemsize */
+    /* methods */
+    (destructor)teedataobject_dealloc,          /* tp_dealloc */
+    0,                                          /* tp_print */
+    0,                                          /* tp_getattr */
+    0,                                          /* tp_setattr */
+    0,                                          /* tp_reserved */
+    0,                                          /* tp_repr */
+    0,                                          /* tp_as_number */
+    0,                                          /* tp_as_sequence */
+    0,                                          /* tp_as_mapping */
+    0,                                          /* tp_hash */
+    0,                                          /* tp_call */
+    0,                                          /* tp_str */
+    PyObject_GenericGetAttr,                    /* tp_getattro */
+    0,                                          /* tp_setattro */
+    0,                                          /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
+    teedataobject_new__doc__,                   /* tp_doc */
+    (traverseproc)teedataobject_traverse,       /* tp_traverse */
+    (inquiry)teedataobject_clear,               /* tp_clear */
+    0,                                          /* tp_richcompare */
+    0,                                          /* tp_weaklistoffset */
+    0,                                          /* tp_iter */
+    0,                                          /* tp_iternext */
+    teedataobject_methods,                      /* tp_methods */
+    0,                                          /* tp_members */
+    0,                                          /* tp_getset */
+    0,                                          /* tp_base */
+    0,                                          /* tp_dict */
+    0,                                          /* tp_descr_get */
+    0,                                          /* tp_descr_set */
+    0,                                          /* tp_dictoffset */
+    0,                                          /* tp_init */
+    0,                                          /* tp_alloc */
+    teedataobject_new,                          /* tp_new */
+    PyObject_GC_Del,                            /* tp_free */
+};
+
+
+static PyMethodDef tee_methods[] = {
+    TEE_COPY_METHODDEF
+    TEE_REDUCE_METHODDEF
+    TEE_SETSTATE_METHODDEF
+    {NULL,              NULL}           /* sentinel */
+};
+
+static PyTypeObject tee_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools._tee",                   /* tp_name */
+    sizeof(teeobject),                  /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)tee_dealloc,            /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    0,                                  /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,            /* tp_flags */
+    tee_new__doc__,                     /* tp_doc */
+    (traverseproc)tee_traverse,         /* tp_traverse */
+    (inquiry)tee_clear,                 /* tp_clear */
+    0,                                  /* tp_richcompare */
+    offsetof(teeobject, weakreflist),   /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)tee_next,             /* tp_iternext */
+    tee_methods,                        /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    tee_new,                            /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef cycle_methods[] = {
+    CYCLE_REDUCE_METHODDEF
+    CYCLE_SETSTATE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+
+static PyTypeObject cycle_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.cycle",                  /* tp_name */
+    sizeof(cycleobject),                /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)cycle_dealloc,          /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    cycle_new__doc__,                   /* tp_doc */
+    (traverseproc)cycle_traverse,       /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)cycle_next,           /* tp_iternext */
+    cycle_methods,                      /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    cycle_new,                          /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef dropwhile_methods[] = {
+    DROPWHILE_REDUCE_METHODDEF
+    DROPWHILE_SETSTATE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject dropwhile_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.dropwhile",              /* tp_name */
+    sizeof(dropwhileobject),            /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)dropwhile_dealloc,      /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    dropwhile_new__doc__,               /* tp_doc */
+    (traverseproc)dropwhile_traverse,   /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)dropwhile_next,       /* tp_iternext */
+    dropwhile_methods,                  /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    dropwhile_new,                      /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef takewhile_reduce_methods[] = {
+    TAKEWHILE_REDUCE_METHODDEF
+    TAKEWHILE_SETSTATE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject takewhile_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.takewhile",              /* tp_name */
+    sizeof(takewhileobject),            /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)takewhile_dealloc,      /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    takewhile_new__doc__,               /* tp_doc */
+    (traverseproc)takewhile_traverse,   /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)takewhile_next,       /* tp_iternext */
+    takewhile_reduce_methods,           /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    takewhile_new,                      /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef islice_methods[] = {
+    ISLICE_REDUCE_METHODDEF
+    ISLICE_SETSTATE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject islice_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.islice",                 /* tp_name */
+    sizeof(isliceobject),               /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)islice_dealloc,         /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    islice_doc,                         /* tp_doc */
+    (traverseproc)islice_traverse,      /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)islice_next,          /* tp_iternext */
+    islice_methods,                     /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    islice_new,                         /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef starmap_methods[] = {
+    STARMAP_REDUCE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject starmap_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.starmap",                /* tp_name */
+    sizeof(starmapobject),              /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)starmap_dealloc,        /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    starmap_new__doc__,                 /* tp_doc */
+    (traverseproc)starmap_traverse,     /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)starmap_next,         /* tp_iternext */
+    starmap_methods,                    /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    starmap_new,                        /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef chain_methods[] = {
+    CHAIN_NEW_FROM_ITERABLE_METHODDEF
+    CHAIN_REDUCE_METHODDEF
+    CHAIN_SETSTATE_METHODDEF
+    {NULL,              NULL}           /* sentinel */
+};
+
+static PyTypeObject chain_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.chain",                  /* tp_name */
+    sizeof(chainobject),                /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)chain_dealloc,          /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    chain_doc,                          /* tp_doc */
+    (traverseproc)chain_traverse,       /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)chain_next,           /* tp_iternext */
+    chain_methods,                      /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    chain_new,                          /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef product_methods[] = {
+    PRODUCT_REDUCE_METHODDEF
+    PRODUCT_SETSTATE_METHODDEF
+    PRODUCT_SIZEOF_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject product_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.product",                /* tp_name */
+    sizeof(productobject),              /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)product_dealloc,        /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    product_doc,                        /* tp_doc */
+    (traverseproc)product_traverse,     /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)product_next,         /* tp_iternext */
+    product_methods,                    /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    product_new,                        /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef combinations_methods[] = {
+    COMBINATIONS_REDUCE_METHODDEF
+    COMBINATIONS_SETSTATE_METHODDEF
+    COMBINATIONS_SIZEOF_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject combinations_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.combinations",           /* tp_name */
+    sizeof(combinationsobject),         /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)combinations_dealloc,   /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    combinations_new__doc__,            /* tp_doc */
+    (traverseproc)combinations_traverse,/* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)combinations_next,    /* tp_iternext */
+    combinations_methods,               /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    combinations_new,                   /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef cwr_methods[] = {
+    CWR_REDUCE_METHODDEF
+    CWR_SETSTATE_METHODDEF
+    CWR_SIZEOF_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject cwr_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.combinations_with_replacement",          /* tp_name */
+    sizeof(cwrobject),                                  /* tp_basicsize */
+    0,                                                  /* tp_itemsize */
+    /* methods */
+    (destructor)cwr_dealloc,                            /* tp_dealloc */
+    0,                                                  /* tp_print */
+    0,                                                  /* tp_getattr */
+    0,                                                  /* tp_setattr */
+    0,                                                  /* tp_reserved */
+    0,                                                  /* tp_repr */
+    0,                                                  /* tp_as_number */
+    0,                                                  /* tp_as_sequence */
+    0,                                                  /* tp_as_mapping */
+    0,                                                  /* tp_hash */
+    0,                                                  /* tp_call */
+    0,                                                  /* tp_str */
+    PyObject_GenericGetAttr,                            /* tp_getattro */
+    0,                                                  /* tp_setattro */
+    0,                                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,                            /* tp_flags */
+    cwr_new__doc__,                                     /* tp_doc */
+    (traverseproc)cwr_traverse,                         /* tp_traverse */
+    0,                                                  /* tp_clear */
+    0,                                                  /* tp_richcompare */
+    0,                                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                                  /* tp_iter */
+    (iternextfunc)cwr_next,                             /* tp_iternext */
+    cwr_methods,                                        /* tp_methods */
+    0,                                                  /* tp_members */
+    0,                                                  /* tp_getset */
+    0,                                                  /* tp_base */
+    0,                                                  /* tp_dict */
+    0,                                                  /* tp_descr_get */
+    0,                                                  /* tp_descr_set */
+    0,                                                  /* tp_dictoffset */
+    0,                                                  /* tp_init */
+    0,                                                  /* tp_alloc */
+    cwr_new,                                            /* tp_new */
+    PyObject_GC_Del,                                    /* tp_free */
+};
+
+
+static PyMethodDef permuations_methods[] = {
+    PERMUTATIONS_REDUCE_METHODDEF
+    PERMUTATIONS_SETSTATE_METHODDEF
+    PERMUTATIONS_SIZEOF_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject permutations_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.permutations",           /* tp_name */
+    sizeof(permutationsobject),         /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)permutations_dealloc,   /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    permutations_new__doc__,            /* tp_doc */
+    (traverseproc)permutations_traverse,/* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)permutations_next,    /* tp_iternext */
+    permuations_methods,                /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    permutations_new,                   /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef accumulate_methods[] = {
+    ACCUMULATE_REDUCE_METHODDEF
+    ACCUMULATE_SETSTATE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject accumulate_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.accumulate",             /* tp_name */
+    sizeof(accumulateobject),           /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)accumulate_dealloc,     /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    accumulate_new__doc__,              /* tp_doc */
+    (traverseproc)accumulate_traverse,  /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)accumulate_next,      /* tp_iternext */
+    accumulate_methods,                 /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    accumulate_new,                     /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef compress_methods[] = {
+    COMPRESS_REDUCE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject compress_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.compress",               /* tp_name */
+    sizeof(compressobject),             /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)compress_dealloc,       /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    compress_new__doc__,                /* tp_doc */
+    (traverseproc)compress_traverse,    /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)compress_next,        /* tp_iternext */
+    compress_methods,                   /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    compress_new,                       /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef filterfalse_methods[] = {
+    FILTERFALSE_REDUCE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject filterfalse_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.filterfalse",            /* tp_name */
+    sizeof(filterfalseobject),          /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)filterfalse_dealloc,    /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    0,                                  /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    filterfalse_new__doc__,             /* tp_doc */
+    (traverseproc)filterfalse_traverse, /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)filterfalse_next,     /* tp_iternext */
+    filterfalse_methods,                /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    filterfalse_new,                    /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef count_methods[] = {
+    COUNT_REDUCE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
+static PyTypeObject count_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.count",                  /* tp_name */
+    sizeof(countobject),                /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)count_dealloc,          /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    (reprfunc)count_repr,               /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    count_new__doc__,                   /* tp_doc */
+    (traverseproc)count_traverse,       /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)count_next,           /* tp_iternext */
+    count_methods,                      /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    count_new,                          /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef repeat_methods[] = {
+    REPEAT_LEN_METHODDEF
+    REPEAT_REDUCE_METHODDEF
+    {NULL,              NULL}           /* sentinel */
+};
+
+static PyTypeObject repeat_type = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "itertools.repeat",                 /* tp_name */
+    sizeof(repeatobject),               /* tp_basicsize */
+    0,                                  /* tp_itemsize */
+    /* methods */
+    (destructor)repeat_dealloc,         /* tp_dealloc */
+    0,                                  /* tp_print */
+    0,                                  /* tp_getattr */
+    0,                                  /* tp_setattr */
+    0,                                  /* tp_reserved */
+    (reprfunc)repeat_repr,              /* tp_repr */
+    0,                                  /* tp_as_number */
+    0,                                  /* tp_as_sequence */
+    0,                                  /* tp_as_mapping */
+    0,                                  /* tp_hash */
+    0,                                  /* tp_call */
+    0,                                  /* tp_str */
+    PyObject_GenericGetAttr,            /* tp_getattro */
+    0,                                  /* tp_setattro */
+    0,                                  /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
+        Py_TPFLAGS_BASETYPE,            /* tp_flags */
+    repeat_doc,                         /* tp_doc */
+    (traverseproc)repeat_traverse,      /* tp_traverse */
+    0,                                  /* tp_clear */
+    0,                                  /* tp_richcompare */
+    0,                                  /* tp_weaklistoffset */
+    PyObject_SelfIter,                  /* tp_iter */
+    (iternextfunc)repeat_next,          /* tp_iternext */
+    repeat_methods,                     /* tp_methods */
+    0,                                  /* tp_members */
+    0,                                  /* tp_getset */
+    0,                                  /* tp_base */
+    0,                                  /* tp_dict */
+    0,                                  /* tp_descr_get */
+    0,                                  /* tp_descr_set */
+    0,                                  /* tp_dictoffset */
+    0,                                  /* tp_init */
+    0,                                  /* tp_alloc */
+    repeat_new,                         /* tp_new */
+    PyObject_GC_Del,                    /* tp_free */
+};
+
+
+static PyMethodDef zip_longest_methods[] = {
+    ZIP_LONGEST_REDUCE_METHODDEF
+    ZIP_LONGEST_SETSTATE_METHODDEF
+    {NULL,              NULL}   /* sentinel */
+};
+
 
 static PyTypeObject ziplongest_type = {
     PyVarObject_HEAD_INIT(NULL, 0)


### PR DESCRIPTION
I applied my old patch for `itertools` from the old "AC Derby" days, fixed all that needed to be fixed and made a few minor AC-related fixes as suggested by @serhiy-storchaka on the issue tracker.

To get this working with the separate `clinic/itertoolsmodule.c.h` file, I also moved all of the method definition arrays and static object definitions to the end of the file, so that the `#include` statement could come before them.

Many thanks @serhiy-storchaka for reviewing the patch and providing guidance!

<!-- issue-number: bpo-20180 -->
https://bugs.python.org/issue20180
<!-- /issue-number -->
