### PR TITLE
bpo-31626: Fix _PyMem_DebugRawRealloc() on OpenBSD

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-01-15-48-03.bpo-31626.reLPxY.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-01-15-48-03.bpo-31626.reLPxY.rst
@@ -1,0 +1,7 @@
+Fix memory debug hooks on OpenBSD: fix _PyMem_DebugRawRealloc(). Previously,
+the old resized memory block was modified after realloc() success to fill now
+unused bytes with the DEADBYTE pattern. On OpenBSD, modifying the old memory
+block causes a fatal error. On OpenBSD, the function now erases the bytes
+*before* calling realloc(), but keep a copy of erased bytes to restore them if
+realloc() fails.  The behaviour on other platforms is unchanged: erased bytes
+*after* realloc() success. Patch co-written with Serhiy Storchaka.


### PR DESCRIPTION
Fix memory debug hooks on OpenBSD: fix _PyMem_DebugRawRealloc().
Previously, the old resized memory block was modified after realloc()
success to fill now unused bytes with the DEADBYTE pattern. On
OpenBSD, modifying the old memory block causes a fatal error.

On OpenBSD, the function now erases the bytes *before* calling
realloc(), but keep a copy of erased bytes to restore them if
realloc() fails.

The behaviour on other platforms is unchanged: erased bytes *after*
realloc() success.

Co-Authored-By: Serhiy Storchaka <storchaka@gmail.com>

<!-- issue-number: bpo-31626 -->
https://bugs.python.org/issue31626
<!-- /issue-number -->
