### PR TITLE
Returning 1 from the set_progress_handler handler cancels query

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -420,6 +420,9 @@ Connection Objects
 
       If you want to clear any previously installed progress handler, call the
       method with :const:`None` for *handler*.
+      
+      Returning ``1`` from the handler function will terminate the currently executing
+      query and cause it to raise a ``sqlite3.OperationalError`` exception.
 
 
    .. method:: set_trace_callback(trace_callback)

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -420,7 +420,7 @@ Connection Objects
 
       If you want to clear any previously installed progress handler, call the
       method with :const:`None` for *handler*.
-      
+
       Returning a non-zero value from the handler function will terminate the
       currently executing query and cause it to raise a
       ``sqlite3.OperationalError`` exception.

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -422,8 +422,8 @@ Connection Objects
       method with :const:`None` for *handler*.
 
       Returning a non-zero value from the handler function will terminate the
-      currently executing query and cause it to raise a
-      ``sqlite3.OperationalError`` exception.
+      currently executing query and cause it to raise an :exc:`OperationalError`
+      exception.
 
 
    .. method:: set_trace_callback(trace_callback)

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -421,8 +421,9 @@ Connection Objects
       If you want to clear any previously installed progress handler, call the
       method with :const:`None` for *handler*.
       
-      Returning ``1`` from the handler function will terminate the currently executing
-      query and cause it to raise a ``sqlite3.OperationalError`` exception.
+      Returning a non-zero value from the handler function will terminate the
+      currently executing query and cause it to raise a
+      ``sqlite3.OperationalError`` exception.
 
 
    .. method:: set_trace_callback(trace_callback)


### PR DESCRIPTION
This behaviour is currently undocumented by Python, but is covered in the SQLite docs here: https://sqlite.org/c3ref/progress_handler.html