### PR TITLE
bpo-30855: Fix winfo_id related Tkinter test on Windows.

### DIFF
--- a/Lib/lib-tk/test/test_tkinter/test_widgets.py
+++ b/Lib/lib-tk/test/test_tkinter/test_widgets.py
@@ -88,7 +88,8 @@ class ToplevelTest(AbstractToplevelTest, unittest.TestCase):
         widget = self.create()
         self.assertEqual(widget['use'], '')
         parent = self.create(container=True)
-        wid = hex(parent.winfo_id())
+        # hex() adds the 'L' suffix for longs
+        wid = '%#x' % parent.winfo_id()
         widget2 = self.create(use=wid)
         self.assertEqual(widget2['use'], wid)
 


### PR DESCRIPTION


<!-- issue-number: bpo-30855 -->
https://bugs.python.org/issue30855
<!-- /issue-number -->
