### PR TITLE
[3.6] bpo-31852: Fix segfault caused by using the async soft keyword

### DIFF
--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -632,6 +632,11 @@ def"', """\
     NUMBER     '1'           (1, 8) (1, 9)
     """)
 
+        self.check_tokenize("async\\", """\
+    ERRORTOKEN '\\\\'          (1, 5) (1, 6)
+    NAME       'async'       (1, 0) (1, 5)
+    """)
+
         self.check_tokenize("a = (async = 1)", """\
     NAME       'a'           (1, 0) (1, 1)
     OP         '='           (1, 2) (1, 3)

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-27-19-18-44.bpo-31852.P_4cVr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-27-19-18-44.bpo-31852.P_4cVr.rst
@@ -1,0 +1,2 @@
+Fix a segmentation fault caused by a combination of the async soft keyword
+and continuation lines.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1850,7 +1850,7 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
     /* Line continuation */
     if (c == '\\') {
         c = tok_nextc(tok);
-        if ( tok->async_def == 2){
+        if (tok->async_def == 2) {
             tok->done = E_SYNTAX;
             return ERRORTOKEN;
         }

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1563,6 +1563,7 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
                 /* The current token is 'async'.
                    Look ahead one token.*/
 
+                int async_def_prev = tok->async_def;
                 tok->async_def = 2;
 
                 struct tok_state ahead_tok;
@@ -1582,6 +1583,9 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
                     tok->async_def_indent = tok->indent;
                     tok->async_def = 1;
                     return ASYNC;
+                }
+                else{
+                    tok->async_def = async_def_prev;
                 }
             }
         }

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1563,6 +1563,8 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
                 /* The current token is 'async'.
                    Look ahead one token.*/
 
+                tok->async_def = 2;
+
                 struct tok_state ahead_tok;
                 char *ahead_tok_start = NULL, *ahead_tok_end = NULL;
                 int ahead_tok_kind;
@@ -1844,6 +1846,10 @@ tok_get(struct tok_state *tok, char **p_start, char **p_end)
     /* Line continuation */
     if (c == '\\') {
         c = tok_nextc(tok);
+        if ( tok->async_def == 2){
+            tok->done = E_SYNTAX;
+            return ERRORTOKEN;
+        }
         if (c != '\n') {
             tok->done = E_LINECONT;
             tok->cur = tok->inp;


### PR DESCRIPTION
This PR solves a segmentation fault in **Python 3.6** caused by a combination of the async soft keyword and continuation lines. Steps to reproduce:

```python
>>> async \
...
  File "<stdin>", line 1
    \ufffd\ufffdF\ufffd\ufffd
         ^
SyntaxError: invalid syntax
>>> async \
Segmentation fault
```

As @haypo mentioned in [the issue](https://bugs.python.org/issue31852) you can use [this file](https://bugs.python.org/file47237/async_parser_crash.py) to use the issue in the tokenizer to induce a buffer overflow. This PR solves this issue as well.

The current implementation checks if the current token is `ASYNC` and sets a sentient value (`2`) in the ` tok->async_def ` **before** looking for the token ahead (which is the step where the segfault happens). The value of ` tok->async_def ` gets overwritten after the lookahead by the usual value (`1`). As this particular issues are fixed by #1669 in the current master (3.7) this PR acts as a mere patch. 

<!-- issue-number: bpo-31852 -->
https://bugs.python.org/issue31852
<!-- /issue-number -->
