### PR TITLE
bpo-31870: add timeout parameter for get_server_certificate in ssl.py

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -456,14 +456,14 @@ Certificate handling
       previously. Return an integer (no fractions of a second in the
       input format)
 
-.. function:: get_server_certificate(addr, ssl_version=PROTOCOL_TLS, ca_certs=None)
+.. function:: get_server_certificate(addr, ssl_version=PROTOCOL_TLS, ca_certs=None, , timeout=_GLOBAL_DEFAULT_TIMEOUT)
 
    Given the address ``addr`` of an SSL-protected server, as a (*hostname*,
    *port-number*) pair, fetches the server's certificate, and returns it as a
    PEM-encoded string.  If ``ssl_version`` is specified, uses that version of
    the SSL protocol to attempt to connect to the server.  If ``ca_certs`` is
    specified, it should be a file containing a list of root certificates, the
-   same format as used for the same parameter in :func:`wrap_socket`.  The call
+   same format as used for the same parameter in :func:`wrap_socket`. If ``timeout`` is specified, use that timeout to receive certificate. The call
    will attempt to validate the server certificate against that set of root
    certificates, and will fail if the validation attempt fails.
 

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -158,7 +158,7 @@ _SSLv2_IF_EXISTS = getattr(_SSLMethod, 'PROTOCOL_SSLv2', None)
 if sys.platform == "win32":
     from _ssl import enum_certificates, enum_crls
 
-from socket import socket, AF_INET, SOCK_STREAM, create_connection
+from socket import socket, AF_INET, SOCK_STREAM, create_connection, _GLOBAL_DEFAULT_TIMEOUT
 from socket import SOL_SOCKET, SO_TYPE
 import base64        # for DER-to-PEM translation
 import errno
@@ -1218,7 +1218,8 @@ def PEM_cert_to_DER_cert(pem_cert_string):
     d = pem_cert_string.strip()[len(PEM_HEADER):-len(PEM_FOOTER)]
     return base64.decodebytes(d.encode('ASCII', 'strict'))
 
-def get_server_certificate(addr, ssl_version=PROTOCOL_TLS, ca_certs=None):
+def get_server_certificate(addr, ssl_version=PROTOCOL_TLS, ca_certs=None,
+                           timeout=_GLOBAL_DEFAULT_TIMEOUT):
     """Retrieve the certificate from the server at the specified address,
     and return it as a PEM-encoded string.
     If 'ca_certs' is specified, validate the server cert against it.
@@ -1232,7 +1233,7 @@ def get_server_certificate(addr, ssl_version=PROTOCOL_TLS, ca_certs=None):
     context = _create_stdlib_context(ssl_version,
                                      cert_reqs=cert_reqs,
                                      cafile=ca_certs)
-    with  create_connection(addr) as sock:
+    with  create_connection(addr, timeout=timeout) as sock:
         with context.wrap_socket(sock) as sslsock:
             dercert = sslsock.getpeercert(True)
     return DER_cert_to_PEM_cert(dercert)

--- a/Misc/NEWS.d/next/Library/2017-10-26-04-11-00.bpo-31870.hneilxlaowk.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-26-04-11-00.bpo-31870.hneilxlaowk.rst
@@ -1,0 +1,1 @@
+Added timeout support for func get_server_certificate in ssl module.


### PR DESCRIPTION
The original [**get_server_certificate**](https://github.com/python/cpython/blob/master/Lib/ssl.py#L1221) in [ssl.py](https://github.com/python/cpython/blob/master/Lib/ssl.py#L1221) does not support socket timeout, 

```
def get_server_certificate(addr, ssl_version=PROTOCOL_TLS, ca_certs=None):
    """Retrieve the certificate from the server at the specified address,
    and return it as a PEM-encoded string.
    If 'ca_certs' is specified, validate the server cert against it.
    If 'ssl_version' is specified, use it in the connection attempt."""

    host, port = addr
    if ca_certs is not None:
        cert_reqs = CERT_REQUIRED
    else:
        cert_reqs = CERT_NONE
    context = _create_stdlib_context(ssl_version,
                                     cert_reqs=cert_reqs,
                                     cafile=ca_certs)
    with  create_connection(addr) as sock:
        with context.wrap_socket(sock) as sslsock:
            dercert = sslsock.getpeercert(True)
    return DER_cert_to_PEM_cert(dercert)

```

After the patch, ssl.py can do it with a timeout parameter, ex: **www.qq.com**.

```
>>> import ssl
>>> ssl.get_server_certificate(("www.qq.com", 443), timeout=6)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python2.7/ssl.py", line 1017, in get_server_certificate
    with closing(create_connection(addr, timeout)) as sock:
  File "/usr/lib/python2.7/socket.py", line 575, in create_connection
    raise err
socket.error: [Errno 101] Network is unreachable
```

<!-- issue-number: bpo-31870 -->
https://bugs.python.org/issue31870
<!-- /issue-number -->
