### PR TITLE
[Trivial] Fix a memory leak in _msi.c

### DIFF
--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -283,6 +283,7 @@ msiobj_dealloc(msiobj* msidb)
 {
     MsiCloseHandle(msidb->h);
     msidb->h = 0;
+    PyObject_Del(msidb);
 }
 
 static PyObject*


### PR DESCRIPTION
If test_msilib had any non-trivial tests, this memory leak would cause test_msilib to fail when run with the `-R` option.