### PR TITLE
bpo-2445: Allow the UnixCCompiler.find_library_file to correctly find DLL import libs (.dll.a) on Cygwin

### DIFF
--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -81,6 +81,7 @@ class UnixCCompiler(CCompiler):
     xcode_stub_lib_format = dylib_lib_format
     if sys.platform == "cygwin":
         exe_extension = ".exe"
+        dylib_lib_extension = ".dll.a"
 
     def preprocess(self, source, output_file=None, macros=None,
                    include_dirs=None, extra_preargs=None, extra_postargs=None):


### PR DESCRIPTION
This is a fix/workaround to a rather old issue (https://bugs.python.org/issue2445) that still hasn't had a fix merged.

The original patch is by @ma8ma .  

This simple patch allows `UnixCCompiler.find_library_file`, which searching library directories (e.g. `/usr/lib`), to recognize `.dll.a` as matches for the library.  This is necessary on Cygwin where actual DLLs are not typically found under `<prefix>/lib`, but rather `<prefix>/bin` (because Windows searches `PATH` for DLLs).  However one does `.dll.a` import libs under `<prefix>/lib` (these are simple static archives that contain stubs for symbols actually found in the DLL, which can be used in lieu of the DLL itself for linking).  This satisfies that the library being searched for is typically found.

This is especially necessary now that the `_ctypes` module can only be built with `--with-system-ffi`; without this patch the system libffi cannot be found.

<!-- issue-number: bpo-2445 -->
https://bugs.python.org/issue2445
<!-- /issue-number -->
