### PR TITLE
bpo-31878: Fix _socket module compilation on Cygwin

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -234,7 +234,7 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
 # include <ctype.h>
 #endif
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__CYGWIN__)
 # include <sys/ioctl.h>
 #endif
 


### PR DESCRIPTION
In Cygwin, as on OSX, `ioctl()` is declared in `sys/ioctl.h`, and so needs this include.  This is necessary for the `_socket` module to compile successfully on that platform.

<!-- issue-number: bpo-31878 -->
https://bugs.python.org/issue31878
<!-- /issue-number -->