### PR TITLE
bpo-31811: added missing keywords to docs.

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -340,13 +340,13 @@ exactly as written here:
 
 .. sourcecode:: text
 
-   False      class      finally    is         return
-   None       continue   for        lambda     try
-   True       def        from       nonlocal   while
-   and        del        global     not        with
-   as         elif       if         or         yield
-   assert     else       import     pass
-   break      except     in         raise
+   False      await      else       import     pass
+   None       break      except     in         raise
+   True       class      finally    is         return
+   and        continue   for        lambda     try
+   as         def        from       nonlocal   while
+   assert     del        global     not        with
+   async      elif       if         or         yield
 
 .. _id-classes:
 


### PR DESCRIPTION
async and await keywords have been merged into upstream, but they are
all missing in the lexical analysis docs. This change adds them to the
appropriate keywords section in documentation.


<!-- issue-number: bpo-31810 -->
https://bugs.python.org/issue31811
<!-- /issue-number -->
