### PR TITLE
bpo-31858: IDLE -- Restrict shell prompt manipulaton to the shell.

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -99,10 +99,6 @@ class EditorWindow(object):
         self.flist = flist
         root = root or flist.root
         self.root = root
-        try:
-            sys.ps1
-        except AttributeError:
-            sys.ps1 = '>>> '
         self.menubar = Menu(root)
         self.top = top = windows.ListedToplevel(root, menu=self.menubar)
         if flist:
@@ -116,6 +112,8 @@ class EditorWindow(object):
             self.top.instance_dict = {}
         self.recent_files_path = os.path.join(
                 idleConf.userdir, 'recent-files.lst')
+
+        self.prompt_last_line = ''  # Override in PyShell
         self.text_frame = text_frame = Frame(top)
         self.vbar = vbar = Scrollbar(text_frame, name='vbar')
         self.width = idleConf.GetOption('main', 'EditorWindow',
@@ -1213,13 +1211,9 @@ class EditorWindow(object):
         assert have > 0
         want = ((have - 1) // self.indentwidth) * self.indentwidth
         # Debug prompt is multilined....
-        if self.context_use_ps1:
-            last_line_of_prompt = sys.ps1.split('\n')[-1]
-        else:
-            last_line_of_prompt = ''
         ncharsdeleted = 0
         while 1:
-            if chars == last_line_of_prompt:
+            if chars == self.prompt_last_line:  # '' unless PyShell
                 break
             chars = chars[:-1]
             ncharsdeleted = ncharsdeleted + 1
@@ -1288,8 +1282,7 @@ class EditorWindow(object):
             indent = line[:i]
             # strip whitespace before insert point unless it's in the prompt
             i = 0
-            last_line_of_prompt = sys.ps1.split('\n')[-1]
-            while line and line[-1] in " \t" and line != last_line_of_prompt:
+            while line and line[-1] in " \t" and line != self.prompt_last_line:
                 line = line[:-1]
                 i = i+1
             if i:

--- a/Misc/NEWS.d/next/IDLE/2017-10-26-20-20-19.bpo-31858.VuSA_e.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-10-26-20-20-19.bpo-31858.VuSA_e.rst
@@ -1,0 +1,4 @@
+IDLE -- Restrict shell prompt manipulaton to the shell. Editor and output
+windows only see an empty last prompt line.  This simplifies the code and
+fixes a minor bug when newline is inserted. Sys.ps1, if present, is read on
+Shell start-up, but is not set or changed.


### PR DESCRIPTION
Editor and output windows only see an empty last prompt line.  This
simplifies the code and fixes a minor bug when newline is inserted.
Sys.ps1, if present, is read on Shell start-up, but is not set or changed.


<!-- issue-number: bpo-31858 -->
https://bugs.python.org/issue31858
<!-- /issue-number -->
