### PR TITLE
bpo-31174: Improve the code of test_tools.test_unparse.

### DIFF
--- a/Lib/test/test_tools/test_unparse.py
+++ b/Lib/test/test_tools/test_unparse.py
@@ -268,12 +268,13 @@ class DirectoryTestCase(ASTTestCase):
     # test directories, relative to the root of the distribution
     test_directories = 'Lib', os.path.join('Lib', 'test')
 
-    def get_names(self):
-        if DirectoryTestCase.NAMES is not None:
-            return DirectoryTestCase.NAMES
+    @classmethod
+    def get_names(cls):
+        if cls.NAMES is not None:
+            return cls.NAMES
 
         names = []
-        for d in self.test_directories:
+        for d in cls.test_directories:
             test_dir = os.path.join(basepath, d)
             for n in os.listdir(test_dir):
                 if n.endswith('.py') and not n.startswith('bad'):
@@ -282,10 +283,9 @@ class DirectoryTestCase(ASTTestCase):
         # Test limited subset of files unless the 'cpu' resource is specified.
         if not test.support.is_resource_enabled("cpu"):
             names = random.sample(names, 10)
-            # bpo-31174: Store the names sample to always test the same files.
-            # It prevents false alarms when hunting reference leaks.
-            DirectoryTestCase.NAMES = names
-
+        # bpo-31174: Store the names sample to always test the same files.
+        # It prevents false alarms when hunting reference leaks.
+        cls.NAMES = names
         return names
 
     def test_files(self):


### PR DESCRIPTION
If `get_names()` is an instance method, it shouldn't cache its result statically. It should be a static method, but a class method works as well.


<!-- issue-number: bpo-31174 -->
https://bugs.python.org/issue31174
<!-- /issue-number -->
