### PR TITLE
bpo-16135: Cleanup: Code rot left over from OS/2 support

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -210,14 +210,10 @@ extern char        *ctermid_r(char *);
 #endif
 
 #ifndef HAVE_UNISTD_H
-#if defined(PYCC_VACPP)
-extern int mkdir(char *);
-#else
 #if ( defined(__WATCOMC__) || defined(_MSC_VER) ) && !defined(__QNX__)
 extern int mkdir(const char *);
 #else
 extern int mkdir(const char *, mode_t);
-#endif
 #endif
 #if defined(__IBMC__) || defined(__IBMCPP__)
 extern int chdir(char *);
@@ -3886,7 +3882,7 @@ os_mkdir_impl(PyObject *module, path_t *path, int mode, int dir_fd)
         result = mkdirat(dir_fd, path->narrow, mode);
     else
 #endif
-#if ( defined(__WATCOMC__) || defined(PYCC_VACPP) ) && !defined(__QNX__)
+#if defined(__WATCOMC__) && !defined(__QNX__)
         result = mkdir(path->narrow);
 #else
         result = mkdir(path->narrow, mode);

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -226,13 +226,6 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
 # include "pythread.h"
 #endif
 
-#if defined(PYCC_VACPP)
-# include <types.h>
-# include <io.h>
-# include <sys/ioctl.h>
-# include <utils.h>
-# include <ctype.h>
-#endif
 
 #if defined(__APPLE__) || defined(__CYGWIN__)
 # include <sys/ioctl.h>


### PR DESCRIPTION
Originally extracted from #4137, this removes the last remaining references to the `PYCC_VACPP` macro, which relates to supporting compiling with VisualAge C++ on OS/2.  OS/2 support was [removed](https://bugs.python.org/issue16135) in Python 3.4 as prescribed by PEP-11.  These last bits still survived.

Don't know if I need an issue on bpo for this as well...

@haypo 


<!-- issue-number: bpo-16135 -->
https://bugs.python.org/issue16135
<!-- /issue-number -->
