### PR TITLE
bpo-31882: Cygwin: fix/skip some tests to work around hang in asyncio/asyncore test suites

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -471,6 +471,7 @@ class EventLoopTestsMixin:
             self._basetest_sock_recv_into(httpd, sock)
 
     @support.skip_unless_bind_unix_socket
+    @unittest.skipIf(sys.platform == 'cygwin', 'cygwin has known bug')
     def test_unix_sock_client_ops(self):
         with test_utils.run_test_unix_server() as httpd:
             sock = socket.socket(socket.AF_UNIX)
@@ -962,6 +963,7 @@ class EventLoopTestsMixin:
         return server, path
 
     @support.skip_unless_bind_unix_socket
+    @unittest.skipIf(sys.platform == 'cygwin', 'cygwin has known bug')
     def test_create_unix_server(self):
         proto = MyProto(loop=self.loop)
         server, path = self._make_unix_server(lambda: proto)
@@ -1055,6 +1057,7 @@ class EventLoopTestsMixin:
 
     @support.skip_unless_bind_unix_socket
     @unittest.skipIf(ssl is None, 'No ssl module')
+    @unittest.skipIf(sys.platform == 'cygwin', 'cygwin has known bug')
     def test_create_unix_server_ssl(self):
         proto = MyProto(loop=self.loop)
         server, path = self._make_ssl_unix_server(
@@ -1115,6 +1118,7 @@ class EventLoopTestsMixin:
 
     @support.skip_unless_bind_unix_socket
     @unittest.skipIf(ssl is None, 'No ssl module')
+    @unittest.skipIf(sys.platform == 'cygwin', 'cygwin has known bug')
     def test_create_unix_server_ssl_verify_failed(self):
         proto = MyProto(loop=self.loop)
         server, path = self._make_ssl_unix_server(
@@ -1173,6 +1177,7 @@ class EventLoopTestsMixin:
 
     @support.skip_unless_bind_unix_socket
     @unittest.skipIf(ssl is None, 'No ssl module')
+    @unittest.skipIf(sys.platform == 'cygwin', 'cygwin has known bug')
     def test_create_unix_server_ssl_verified(self):
         proto = MyProto(loop=self.loop)
         server, path = self._make_ssl_unix_server(

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -636,6 +636,7 @@ class StreamReaderTests(test_utils.TestCase):
         self.assertEqual(msg, b"hello world!\n")
 
     @support.skip_unless_bind_unix_socket
+    @unittest.skipIf(sys.platform == 'cygwin', 'cygwin has known bug')
     def test_start_unix_server(self):
 
         class MyServer:

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -97,6 +97,12 @@ def bind_af_aware(sock, addr):
         sock.bind(addr)
 
 
+def setsock_no_peercred(sock):
+    if sys.platform == 'cygwin' and sock.family == socket.AF_UNIX:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_PEERCRED, None, 0)
+
+
+
 class HelperFunctionTests(unittest.TestCase):
     def test_readwriteexc(self):
         # Check exception handling behavior of read, write and _exception
@@ -469,6 +475,7 @@ class BaseServer(asyncore.dispatcher):
     def __init__(self, family, addr, handler=BaseTestHandler):
         asyncore.dispatcher.__init__(self)
         self.create_socket(family)
+        setsock_no_peercred(self.socket)
         self.set_reuse_addr()
         bind_af_aware(self.socket, addr)
         self.listen(5)
@@ -490,6 +497,7 @@ class BaseClient(BaseTestHandler):
     def __init__(self, family, address):
         BaseTestHandler.__init__(self)
         self.create_socket(family)
+        setsock_no_peercred(self.socket)
         self.connect(address)
 
     def handle_connect(self):
@@ -550,6 +558,7 @@ class BaseTestAPI:
             def __init__(self, family, addr):
                 BaseTestHandler.__init__(self)
                 self.create_socket(family)
+                setsock_no_peercred(self.socket)
                 bind_af_aware(self.socket, addr)
                 self.listen(5)
                 self.address = self.socket.getsockname()


### PR DESCRIPTION
From the issue:

> Some of the tests for asyncio and asyncore block forever on Cygwin, due to a known (and seemingly difficult to fix) [bug in Cygwin](https://cygwin.com/ml/cygwin/2017-01/msg00054.html) involving `SO_PEERCRED` on UNIX sockets.
> 
> `SO_PEERCRED` is a socket option that can be used to exchange file ownership info of the socket at the time the connection was established (specifically on UNIX sockets).  This feature is technically supported on Cygwin, but the effect of the bug is that if two sockets are opened on the same process (even without using `socketpair()`), the credential exchange protocol can cause connect() on the "client" socket to block unless the "server" socket is already `listen()`-ing.
> 
> This situation is not all that common in practice (it is not a problem if the "client" and "server" are separate processes).  But it does show up in the test suite in a number of places, since both sockets belong to the same process.

This PR fixes the issue in some cases by explicitly NULL-ifying the `SO_PEERCRED` struct on the socket.   This is preferable because with this small workaround those tests pass.  Unfortunately, in other cases it was difficult to do this just for the test suite without too much meddling, so I just marked those tests to be skipped. 

<!-- issue-number: bpo-31882 -->
https://bugs.python.org/issue31882
<!-- /issue-number -->
