### PR TITLE
bpo-31883: Skip locale test that causes heap corruption on older versions of Cygwin

### DIFF
--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -366,7 +366,8 @@ class TestEnUSCollation(BaseLocalizedTest, TestCollation):
         if enc not in ('utf-8', 'iso8859-1', 'cp1252'):
             raise unittest.SkipTest('encoding not suitable')
         if enc != 'iso8859-1' and (sys.platform == 'darwin' or is_android or
-                                   sys.platform.startswith('freebsd')):
+                                   sys.platform.startswith('freebsd') or
+                                   sys.platform == 'cygwin'):
             raise unittest.SkipTest('wcscoll/wcsxfrm have known bugs')
         BaseLocalizedTest.setUp(self)
 


### PR DESCRIPTION
> There is an acknowledged [bug](https://cygwin.com/ml/cygwin/2017-05/msg00149.html) in Cygwin's implementation of `wcsxfrm()` that can cause heap corruption in certain cases.  This bug has since been fixed in [Cygwin 2.8.1-1](https://cygwin.com/ml/cygwin-announce/2017-07/msg00002.html) and all current and future releases.  However, that was relatively recent (July 2017) so it may still crop up.
>
> I also have a workaround for this from the Python side, but rather than clutter the code with workarounds for platform-specific bugs I think it suffices just to skip the test in this case.

<!-- issue-number: bpo-31883 -->
https://bugs.python.org/issue31883
<!-- /issue-number -->
