### PR TITLE
bpo-31885: Cygwin: fix/skip some tests to work around hang in socket test suite

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1452,6 +1452,10 @@ class GeneralModuleTests(unittest.TestCase):
         # socketpair() is not strictly required, but it makes things easier.
         if not hasattr(signal, 'alarm') or not hasattr(socket, 'socketpair'):
             self.skipTest("signal.alarm and socket.socketpair required for this test")
+
+        if not with_timeout and sys.platform == 'cygwin':
+            self.skipTest("this test blocks due to a bug in Cygwin")
+
         # Our signal handlers clobber the C errno by calling a math function
         # with an invalid domain value.
         def ok_handler(*args):


### PR DESCRIPTION
> Like issue31882, this is to mention an upstream bug in Cygwin that causes one of the tests in the test_socket test suite to hang indefinitely.  That bug is [fixed upstream](https://cygwin.com/ml/cygwin-patches/2017-q2/msg00037.html), but for now it would still be better to skip the test on Cygwin.
> 
> The bug is that in some cases a blocking send() (particularly for a large amount data) cannot be interrupted by a signal even if SA_RESTART is not set.
> 
> Fixes to this issue, along with issue31882, issue31883, and issue31878 provide the bare minimum for Cygwin to at least compile (not necessarily all optional extension modules) and run the test suite from start to finish (though there may be other tests that cause the interpreter to lock up, but that are currently masked by other bugs).

<!-- issue-number: bpo-31885 -->
https://bugs.python.org/issue31885
<!-- /issue-number -->
