### PR TITLE
bpo-31890: define METH_STACKLESS

### DIFF
--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -91,7 +91,7 @@ PyAPI_FUNC(PyObject *) PyCFunction_NewEx(PyMethodDef *, PyObject *,
 #define METH_FASTCALL  0x0080
 #endif
 
-/* This bit is preserved for Stackless Python, next after this is 0x0200 */
+/* This bit is preserved for Stackless Python */
 #ifdef STACKLESS
 #define METH_STACKLESS 0x0100
 #else

--- a/Include/methodobject.h
+++ b/Include/methodobject.h
@@ -89,7 +89,16 @@ PyAPI_FUNC(PyObject *) PyCFunction_NewEx(PyMethodDef *, PyObject *,
 
 #ifndef Py_LIMITED_API
 #define METH_FASTCALL  0x0080
+#endif
 
+/* This bit is preserved for Stackless Python, next after this is 0x0200 */
+#ifdef STACKLESS
+#define METH_STACKLESS 0x0100
+#else
+#define METH_STACKLESS 0x0000
+#endif
+
+#ifndef Py_LIMITED_API
 typedef struct {
     PyObject_HEAD
     PyMethodDef *m_ml; /* Description of the C function to call */


### PR DESCRIPTION
Add METH_STACKLESS to prevent future collisions.



<!-- issue-number: bpo-31890 -->
https://bugs.python.org/issue31890
<!-- /issue-number -->
