### PR TITLE
[3.6] bpo-31065: Add doc about Popen.poll returning None. (GH-3169)

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -584,7 +584,7 @@ Instances of the :class:`Popen` class have the following methods:
 .. method:: Popen.poll()
 
    Check if child process has terminated.  Set and return
-   :attr:`~Popen.returncode` attribute.
+   :attr:`~Popen.returncode` attribute. Otherwise, returns ``None``.
 
 
 .. method:: Popen.wait(timeout=None)


### PR DESCRIPTION
(cherry picked from commit 006617ff7d6df3fdedcfe53e94ee2c52cc796437)

<!-- issue-number: bpo-31065 -->
https://bugs.python.org/issue31065
<!-- /issue-number -->
