### PR TITLE
bpo-25720: Fix the method for checking pad state of curses WINDOW

### DIFF
--- a/Include/py_curses.h
+++ b/Include/py_curses.h
@@ -7,7 +7,7 @@
 ** On Mac OS X 10.2 [n]curses.h and stdlib.h use different guards
 ** against multiple definition of wchar_t.
 */
-#ifdef	_BSD_WCHAR_T_DEFINED_
+#ifdef  _BSD_WCHAR_T_DEFINED_
 #define _WCHAR_T
 #endif
 #endif /* __APPLE__ */
@@ -17,7 +17,7 @@
 ** On FreeBSD, [n]curses.h and stdlib.h/wchar.h use different guards
 ** against multiple definition of wchar_t and wint_t.
 */
-#ifdef	_XOPEN_SOURCE_EXTENDED
+#ifdef  _XOPEN_SOURCE_EXTENDED
 #ifndef __FreeBSD_version
 #include <osreldate.h>
 #endif
@@ -79,12 +79,12 @@ extern "C" {
 /* Type declarations */
 
 typedef struct {
-	PyObject_HEAD
-	WINDOW *win;
-	char *encoding;
+    PyObject_HEAD
+    WINDOW *win;
+    char *encoding;
 } PyCursesWindowObject;
 
-#define PyCursesWindow_Check(v)	 (Py_TYPE(v) == &PyCursesWindow_Type)
+#define PyCursesWindow_Check(v)  (Py_TYPE(v) == &PyCursesWindow_Type)
 
 #define PyCurses_CAPSULE_NAME "_curses._C_API"
 

--- a/Include/py_curses.h
+++ b/Include/py_curses.h
@@ -10,11 +10,6 @@
 #ifdef	_BSD_WCHAR_T_DEFINED_
 #define _WCHAR_T
 #endif
-
-/* the following define is necessary for OS X 10.6; without it, the
-   Apple-supplied ncurses.h sets NCURSES_OPAQUE to 1, and then Python
-   can't get at the WINDOW flags field. */
-#define NCURSES_OPAQUE 0
 #endif /* __APPLE__ */
 
 #ifdef __FreeBSD__
@@ -44,6 +39,13 @@
 #endif
 #endif
 
+#if !defined(HAVE_CURSES_IS_PAD) && defined(WINDOW_HAS_FLAGS)
+/* The following definition is necessary for ncurses 5.7; without it,
+   some of [n]curses.h set NCURSES_OPAQUE to 1, and then Python
+   can't get at the WINDOW flags field. */
+#define NCURSES_OPAQUE 0
+#endif
+
 #ifdef HAVE_NCURSES_H
 #include <ncurses.h>
 #else
@@ -56,9 +58,12 @@
 
 #ifdef HAVE_NCURSES_H
 /* configure was checking <curses.h>, but we will
-   use <ncurses.h>, which has all these features. */
-#ifndef WINDOW_HAS_FLAGS
+   use <ncurses.h>, which has some or all these features. */
+#if !defined(WINDOW_HAS_FLAGS) && !(NCURSES_OPAQUE+0)
 #define WINDOW_HAS_FLAGS 1
+#endif
+#if !defined(HAVE_CURSES_IS_PAD) && NCURSES_VERSION_PATCH+0 >= 20090906
+#define HAVE_CURSES_IS_PAD 1
 #endif
 #ifndef MVWDELCH_IS_EXPRESSION
 #define MVWDELCH_IS_EXPRESSION 1

--- a/Misc/NEWS.d/next/Library/2017-10-29-17-52-40.bpo-25720.vSvb5h.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-29-17-52-40.bpo-25720.vSvb5h.rst
@@ -1,0 +1,2 @@
+Fix the method for checking pad state of curses WINDOW. Patch by Masayuki
+Yamamoto.

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -1084,9 +1084,10 @@ PyCursesWindow_EchoChar(PyCursesWindowObject *self, PyObject *args)
         return NULL;
 
 #ifdef py_is_pad
-    if (py_is_pad(self->win))
+    if (py_is_pad(self->win)) {
         return PyCursesCheckERR(pechochar(self->win, ch | attr),
                                 "echochar");
+    }
     else
 #endif
         return PyCursesCheckERR(wechochar(self->win, ch | attr),
@@ -1851,8 +1852,9 @@ PyCursesWindow_SubWin(PyCursesWindowObject *self, PyObject *args)
 
     /* printf("Subwin: %i %i %i %i   \n", nlines, ncols, begin_y, begin_x); */
 #ifdef py_is_pad
-    if (py_is_pad(self->win))
+    if (py_is_pad(self->win)) {
         win = subpad(self->win, nlines, ncols, begin_y, begin_x);
+    }
     else
 #endif
         win = subwin(self->win, nlines, ncols, begin_y, begin_x);

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -938,6 +938,12 @@ int py_mvwdelch(WINDOW *w, int y, int x)
 }
 #endif
 
+#if defined(HAVE_CURSES_IS_PAD)
+#define py_is_pad(win)      is_pad(win)
+#elif defined(WINDOW_HAS_FLAGS)
+#define py_is_pad(win)      ((win) ? ((win)->_flags & _ISPAD) != 0 : FALSE)
+#endif
+
 /* chgat, added by Fabian Kreutz <fabian.kreutz at gmx.net> */
 
 static PyObject *
@@ -1077,8 +1083,8 @@ PyCursesWindow_EchoChar(PyCursesWindowObject *self, PyObject *args)
     if (!PyCurses_ConvertToChtype(self, temp, &ch))
         return NULL;
 
-#ifdef WINDOW_HAS_FLAGS
-    if (self->win->_flags & _ISPAD)
+#ifdef py_is_pad
+    if (py_is_pad(self->win))
         return PyCursesCheckERR(pechochar(self->win, ch | attr),
                                 "echochar");
     else
@@ -1612,10 +1618,10 @@ PyCursesWindow_NoOutRefresh(PyCursesWindowObject *self, PyObject *args)
     int pminrow,pmincol,sminrow,smincol,smaxrow,smaxcol;
     int rtn;
 
-#ifndef WINDOW_HAS_FLAGS
+#ifndef py_is_pad
     if (0)
 #else
-        if (self->win->_flags & _ISPAD)
+        if (py_is_pad(self->win))
 #endif
         {
             switch(PyTuple_Size(args)) {
@@ -1775,10 +1781,10 @@ PyCursesWindow_Refresh(PyCursesWindowObject *self, PyObject *args)
     int pminrow,pmincol,sminrow,smincol,smaxrow,smaxcol;
     int rtn;
 
-#ifndef WINDOW_HAS_FLAGS
+#ifndef py_is_pad
     if (0)
 #else
-        if (self->win->_flags & _ISPAD)
+        if (py_is_pad(self->win))
 #endif
         {
             switch(PyTuple_Size(args)) {
@@ -1844,8 +1850,8 @@ PyCursesWindow_SubWin(PyCursesWindowObject *self, PyObject *args)
     }
 
     /* printf("Subwin: %i %i %i %i   \n", nlines, ncols, begin_y, begin_x); */
-#ifdef WINDOW_HAS_FLAGS
-    if (self->win->_flags & _ISPAD)
+#ifdef py_is_pad
+    if (py_is_pad(self->win))
         win = subpad(self->win, nlines, ncols, begin_y, begin_x);
     else
 #endif

--- a/configure
+++ b/configure
@@ -15699,6 +15699,10 @@ $as_echo "#define MVWDELCH_IS_EXPRESSION 1" >>confdefs.h
 
 fi
 
+# Issue #25720: ncurses has introduced the NCURSES_OPAQUE symbol making opaque
+# structs since version 5.7.  If the macro is defined as zero before including
+# [n]curses.h, ncurses will expose fields of the structs regardless of the
+# configuration.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether WINDOW has _flags" >&5
 $as_echo_n "checking whether WINDOW has _flags... " >&6; }
 if ${ac_cv_window_has_flags+:} false; then :
@@ -15706,7 +15710,10 @@ if ${ac_cv_window_has_flags+:} false; then :
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-#include <curses.h>
+
+  #define NCURSES_OPAQUE 0
+  #include <curses.h>
+
 int
 main ()
 {
@@ -15734,6 +15741,44 @@ if test "$ac_cv_window_has_flags" = yes
 then
 
 $as_echo "#define WINDOW_HAS_FLAGS 1" >>confdefs.h
+
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for is_pad" >&5
+$as_echo_n "checking for is_pad... " >&6; }
+if ${ac_cv_curses_is_pad+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <curses.h>
+int
+main ()
+{
+
+  bool b;
+  WINDOW *w;
+  b = is_pad(w);
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  ac_cv_curses_is_pad=yes
+else
+  ac_cv_curses_is_pad=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_curses_is_pad" >&5
+$as_echo "$ac_cv_curses_is_pad" >&6; }
+
+if test "$ac_cv_curses_is_pad" = yes
+then
+
+$as_echo "#define HAVE_CURSES_IS_PAD 1" >>confdefs.h
 
 fi
 

--- a/configure
+++ b/configure
@@ -15746,41 +15746,33 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for is_pad" >&5
 $as_echo_n "checking for is_pad... " >&6; }
-if ${ac_cv_curses_is_pad+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <curses.h>
 int
 main ()
 {
 
-  bool b;
-  WINDOW *w;
-  b = is_pad(w);
+#ifndef is_pad
+void *x=is_pad
+#endif
 
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_curses_is_pad=yes
-else
-  ac_cv_curses_is_pad=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_curses_is_pad" >&5
-$as_echo "$ac_cv_curses_is_pad" >&6; }
-
-if test "$ac_cv_curses_is_pad" = yes
-then
 
 $as_echo "#define HAVE_CURSES_IS_PAD 1" >>confdefs.h
 
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
 fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for is_term_resized" >&5
 $as_echo_n "checking for is_term_resized... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -4955,9 +4955,16 @@ then
   [Define if mvwdelch in curses.h is an expression.])
 fi
 
+# Issue #25720: ncurses has introduced the NCURSES_OPAQUE symbol making opaque
+# structs since version 5.7.  If the macro is defined as zero before including
+# [n]curses.h, ncurses will expose fields of the structs regardless of the
+# configuration.
 AC_MSG_CHECKING(whether WINDOW has _flags)
 AC_CACHE_VAL(ac_cv_window_has_flags,
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[
+  #define NCURSES_OPAQUE 0
+  #include <curses.h>
+]], [[
   WINDOW *w;
   w->_flags = 0;
 ]])],
@@ -4970,6 +4977,23 @@ if test "$ac_cv_window_has_flags" = yes
 then
   AC_DEFINE(WINDOW_HAS_FLAGS, 1,
   [Define if WINDOW in curses.h offers a field _flags.])
+fi
+
+AC_MSG_CHECKING(for is_pad)
+AC_CACHE_VAL(ac_cv_curses_is_pad,
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
+  bool b;
+  WINDOW *w;
+  b = is_pad(w);
+]])],
+[ac_cv_curses_is_pad=yes],
+[ac_cv_curses_is_pad=no]))
+AC_MSG_RESULT($ac_cv_curses_is_pad)
+
+if test "$ac_cv_curses_is_pad" = yes
+then
+  AC_DEFINE(HAVE_CURSES_IS_PAD, 1,
+  [Define if you have the 'is_pad' function or macro.])
 fi
 
 AC_MSG_CHECKING(for is_term_resized)

--- a/configure.ac
+++ b/configure.ac
@@ -4980,21 +4980,15 @@ then
 fi
 
 AC_MSG_CHECKING(for is_pad)
-AC_CACHE_VAL(ac_cv_curses_is_pad,
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[
-  bool b;
-  WINDOW *w;
-  b = is_pad(w);
+#ifndef is_pad
+void *x=is_pad
+#endif
 ]])],
-[ac_cv_curses_is_pad=yes],
-[ac_cv_curses_is_pad=no]))
-AC_MSG_RESULT($ac_cv_curses_is_pad)
-
-if test "$ac_cv_curses_is_pad" = yes
-then
-  AC_DEFINE(HAVE_CURSES_IS_PAD, 1,
-  [Define if you have the 'is_pad' function or macro.])
-fi
+  [AC_DEFINE(HAVE_CURSES_IS_PAD, 1, Define if you have the 'is_pad' function or macro.)
+   AC_MSG_RESULT(yes)],
+  [AC_MSG_RESULT(no)]
+)
 
 AC_MSG_CHECKING(for is_term_resized)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <curses.h>]], [[void *x=is_term_resized]])],

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -149,6 +149,9 @@
 /* Define to 1 if you have the <curses.h> header file. */
 #undef HAVE_CURSES_H
 
+/* Define if you have the 'is_pad' function or macro. */
+#undef HAVE_CURSES_IS_PAD
+
 /* Define if you have the 'is_term_resized' function. */
 #undef HAVE_CURSES_IS_TERM_RESIZED
 


### PR DESCRIPTION
### Highlights of changes

- Modify configure check for the WINDOW `_flags` field.
- Add configure check for [`is_pad`][is_pad] function/macro.
- Remove the definition of `NCURSES_OPAQUE` for Apple-specific.
- Define `NCURSES_OPAQUE` as zero in the case of no `is_pad()` and having WINDOW `_flags`.
- Modify the requirement for defining `WINDOW_HAS_FLAGS` when having *ncurses.h*.
- Add requirement for defining `HAVE_CURSES_IS_PAD` when having *ncurses.h*.
- Define `py_is_pad()` macro if `HAVE_CURSES_IS_PAD` or `WINDOW_HAS_FLAGS` are defined.
- Change conditional compilation: replace `WINDOW_HAS_FLAGS` with `py_is_pad`.

### Motivation

`WINDOW_HAS_FLAGS` will be defined by configure check, but if your platform has *ncurses.h*, [defines the macro always][py_curses_h].  Therefore, codes which check the WINDOW `_flags` field are enabled regardless of `NCURSES_OPAQUE` (added since [ncurses 5.7][ncurses57]), and a compile error occurs on platforms where WINDOW is actually opaque.

For this reason, these codes are modified to use ncurses `is_pad()` instead of checking the field.  If your platform does not provide the `is_pad()` (added since [ncurses 5.8][ncurses58] as a ncurses-specific feature), the existing way that checks the field will be enabled. In this case, `NCURSES_OPAQUE` is defined as zero before including *[n]curses.h*, for exposing WINDOW fields regardless of the configuraton.

Note: This change does not drop support for platforms where do not have both WINDOW `_flags` field and `is_pad()`.

[is_pad]: http://invisible-island.net/ncurses/man/curs_opaque.3x.html
[py_curses_h]: https://github.com/python/cpython/blob/master/Include/py_curses.h#L57-L62
[ncurses57]: http://invisible-island.net/ncurses/announce-5.7.html
[ncurses58]: http://invisible-island.net/ncurses/announce-5.8.html


<!-- issue-number: bpo-25720 -->
https://bugs.python.org/issue25720
<!-- /issue-number -->
