### PR TITLE
bpo-26228: pty.spawn hangs on FreeBSD, OS X, and Solaris

### DIFF
--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -2,8 +2,8 @@
 ========================================
 
 .. module:: pty
-   :platform: Linux
-   :synopsis: Pseudo-Terminal Handling for Linux.
+   :platform: Unix
+   :synopsis: Pseudo-Terminal Handling for Unix.
 
 .. moduleauthor:: Steen Lumholt
 .. sectionauthor:: Moshe Zadka <moshez@zadka.site.co.il>
@@ -16,9 +16,9 @@ The :mod:`pty` module defines operations for handling the pseudo-terminal
 concept: starting another process and being able to write to and read from its
 controlling terminal programmatically.
 
-Because pseudo-terminal handling is highly platform dependent, there is code to
-do it only for Linux. (The Linux code is supposed to work on other platforms,
-but hasn't been tested yet.)
+Pseudo-terminal handling is highly platform dependent. This code is mainly
+tested on Linux, FreeBSD, and OS X (it is supposed to work on other POSIX
+platforms).
 
 The :mod:`pty` module defines the following functions:
 
@@ -41,9 +41,13 @@ The :mod:`pty` module defines the following functions:
 
 .. function:: spawn(argv[, master_read[, stdin_read]])
 
-   Spawn a process, and connect its controlling terminal with the current
-   process's standard io. This is often used to baffle programs which insist on
-   reading from the controlling terminal.
+   Spawn a child process, and connect its controlling terminal with the
+   current process's standard io. This is often used to baffle programs which
+   insist on reading from the controlling terminal.
+
+   A loop copies STDIN of the current process to the child and data received
+   from the child to STDOUT of the current process. It is not signaled to the
+   child if STDIN of the current process closes down.
 
    The functions *master_read* and *stdin_read* should be functions which read from
    a file descriptor. The defaults try to read 1024 bytes each time they are

--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -137,7 +137,7 @@ def _copy(master_fd, master_read=_read, stdin_read=_read):
         if master_fd in rfds:
             data = master_read(master_fd)
             if not data:  # Reached EOF.
-                fds.remove(master_fd)
+                return
             else:
                 os.write(STDOUT_FILENO, data)
         if STDIN_FILENO in rfds:
@@ -153,7 +153,15 @@ def spawn(argv, master_read=_read, stdin_read=_read):
         argv = (argv,)
     pid, master_fd = fork()
     if pid == CHILD:
-        os.execlp(argv[0], *argv)
+        try:
+            os.execlp(argv[0], *argv)
+        except:
+            # If we wanted to be really clever, we would use
+            # the same method as subprocess() to pass the error
+            # back to the parent.  For now just dump stack trace.
+            traceback.print_exc()
+        finally:
+            os._exit(1)
     try:
         mode = tty.tcgetattr(STDIN_FILENO)
         tty.setraw(STDIN_FILENO)
@@ -163,6 +171,10 @@ def spawn(argv, master_read=_read, stdin_read=_read):
     try:
         _copy(master_fd, master_read, stdin_read)
     except OSError:
+        # Some OSes never return an EOF on pty, just raise
+        # an error instead.
+        pass
+    finally:
         if restore:
             tty.tcsetattr(STDIN_FILENO, tty.TCSAFLUSH, mode)
 

--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -8,6 +8,7 @@
 
 from select import select
 import os
+import sys
 import tty
 
 __all__ = ["openpty","fork","spawn"]
@@ -164,7 +165,7 @@ def spawn(argv, master_read=_read, stdin_read=_read):
             # If we wanted to be really clever, we would use
             # the same method as subprocess() to pass the error
             # back to the parent.  For now just dump stack trace.
-            traceback.print_exc()
+            sys.excepthook(*sys.exc_info())
         finally:
             os._exit(1)
     try:

--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -1,7 +1,7 @@
 """Pseudo terminal utilities."""
 
 # Bugs: No signal handling.  Doesn't set slave termios and window size.
-#       Only tested on Linux.
+#       Only tested on Linux, FreeBSD, and OS X.
 # See:  W. Richard Stevens. 1992.  Advanced Programming in the
 #       UNIX Environment.  Chapter 19.
 # Author: Steen Lumholt -- with additions by Guido.
@@ -133,6 +133,11 @@ def _copy(master_fd, master_read=_read, stdin_read=_read):
             standard input -> pty master    (stdin_read)"""
     fds = [master_fd, STDIN_FILENO]
     while True:
+        # The expected path to leave this infinite loop is that the
+        # child exits and its slave_fd is destroyed. In this case,
+        # master_fd will become ready in select() and reading from
+        # master_fd either raises an OSError (Input/output error) on
+        # Linux or returns EOF on BSD.
         rfds, wfds, xfds = select(fds, [], [])
         if master_fd in rfds:
             data = master_read(master_fd)

--- a/Lib/test/test_pty.py
+++ b/Lib/test/test_pty.py
@@ -293,7 +293,7 @@ class SmallPtyTests(unittest.TestCase):
         socketpair[1].close()
         os.close(write_to_stdin_fd)
 
-        # Expect two select calls, the last one will cause IndexError
+        # Expect two select calls, then a normal return on master EOF
         pty.select = self._mock_select
         self.select_rfds_lengths.append(2)
         self.select_rfds_results.append([mock_stdin_fd, masters[0]])
@@ -301,8 +301,7 @@ class SmallPtyTests(unittest.TestCase):
         # both encountered an EOF before the second select call.
         self.select_rfds_lengths.append(0)
 
-        with self.assertRaises(IndexError):
-            pty._copy(masters[0])
+        pty._copy(masters[0])
 
 
 def tearDownModule():

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1787,3 +1787,5 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
+Chris Torek
+Cornelius Diekmann

--- a/Misc/NEWS.d/next/Library/2017-10-29.bpo-26228.piIl5E.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-29.bpo-26228.piIl5E.rst
@@ -1,0 +1,1 @@
+pty.spawn no longer hangs on FreeBSD, OS X, and Solaris.


### PR DESCRIPTION
issue26228 as github PR.

This PR contains:
 * original patch of issue26228 by Chris
 * Update of docs
 * Update of pty test suite

According to the bpo discussion, this fixes `pty.spawn()` on FreeBSD, OS X, and Solaris.

<!-- issue-number: bpo-26228 -->
https://bugs.python.org/issue26228
<!-- /issue-number -->
