### PR TITLE
bpo-31304: Corrected typo in the documentation of multiprocessing.pool.Pool.starmap

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2181,7 +2181,7 @@ with the :class:`Pool` class.
 
       .. versionadded:: 3.3
 
-   .. method:: starmap_async(func, iterable[, chunksize[, callback[, error_back]]])
+   .. method:: starmap_async(func, iterable[, chunksize[, callback[, error_callback]]])
 
       A combination of :meth:`starmap` and :meth:`map_async` that iterates over
       *iterable* of iterables and calls *func* with the iterables unpacked.


### PR DESCRIPTION
From the issue:

>The documentation suggests that multiprocessing.pool.Pool. starmap_async has a kwarg called 'error_back', but it actually has a kwarg called 'error_callback' to handle errors, just like map_async.


<!-- issue-number: bpo-31304 -->
https://bugs.python.org/issue31304
<!-- /issue-number -->
