### PR TITLE
bpo-31897: Convert unexpected errors when read bogus binary plists …

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -557,7 +557,8 @@ class _BinaryPlistParser:
             self._object_offsets = self._read_ints(num_objects, offset_size)
             return self._read_object(self._object_offsets[top_object])
 
-        except (OSError, IndexError, struct.error):
+        except (OSError, IndexError, struct.error, OverflowError,
+                UnicodeDecodeError):
             raise InvalidFileException()
 
     def _get_size(self, tokenL):
@@ -575,6 +576,8 @@ class _BinaryPlistParser:
         if size in _BINARY_FORMAT:
             return struct.unpack('>' + _BINARY_FORMAT[size] * n, data)
         else:
+            if not size or len(data) != size * n:
+                raise InvalidFileException()
             return tuple(int.from_bytes(data[i: i + size], 'big')
                          for i in range(0, size * n, size))
 

--- a/Misc/NEWS.d/next/Library/2017-10-30-11-04-56.bpo-31897.yjwdEb.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-30-11-04-56.bpo-31897.yjwdEb.rst
@@ -1,0 +1,2 @@
+plistlib now catches more errors when read binary plists and raises
+InvalidFileException instead of unexpected exceptions.


### PR DESCRIPTION
…into InvalidFileException.


<!-- issue-number: bpo-31897 -->
https://bugs.python.org/issue31897
<!-- /issue-number -->
