### PR TITLE
bpo-31114: Fix the build when 'prefix' is '/' and DESTDIR is used.

### DIFF
--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -69,6 +69,11 @@ if HAS_USER_SITE:
 # and to SCHEME_KEYS here.
 SCHEME_KEYS = ('purelib', 'platlib', 'headers', 'scripts', 'data')
 
+def sanitize_base(dir):
+    if os.name == 'posix' and dir == '/':
+        dir = '/.'
+    return dir
+
 
 class install(Command):
 
@@ -310,12 +315,13 @@ class install(Command):
 
         # Now define config vars for the base directories so we can expand
         # everything else.
-        self.config_vars['base'] = self.install_base
-        self.config_vars['platbase'] = self.install_platbase
+        # Replace '/' with '/.', '//' is an undefined directory in posix.
+        self.config_vars['base'] = sanitize_base(self.install_base)
+        self.config_vars['platbase'] = sanitize_base(self.install_platbase)
 
         if DEBUG:
             from pprint import pprint
-            print("config vars:")
+            print("config vars: ")
             pprint(self.config_vars)
 
         # Expand "~" and configuration variables in the installation

--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -321,7 +321,7 @@ class install(Command):
 
         if DEBUG:
             from pprint import pprint
-            print("config vars: ")
+            print("config vars:")
             pprint(self.config_vars)
 
         # Expand "~" and configuration variables in the installation

--- a/Misc/NEWS.d/next/Build/2017-10-30-11-20-20.bpo-31114.T8NqOT.rst
+++ b/Misc/NEWS.d/next/Build/2017-10-30-11-20-20.bpo-31114.T8NqOT.rst
@@ -1,0 +1,1 @@
+Fix the build when the configure ``prefix`` is ``/`` and DESTDIR is used.

--- a/configure
+++ b/configure
@@ -778,7 +778,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -890,7 +889,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1143,15 +1141,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1289,7 +1278,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1442,7 +1431,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -2943,7 +2931,9 @@ fi
 
 
 
-if test "$prefix" != "/"; then
+if test "$prefix" = "/"; then
+    prefix="/."
+else
     prefix=`echo "$prefix" | sed -e 's/\/$//g'`
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -86,8 +86,10 @@ dnl Ensure that if prefix is specified, it does not end in a slash. If
 dnl it does, we get path names containing '//' which is both ugly and
 dnl can cause trouble.
 
-dnl Last slash shouldn't be stripped if prefix=/
-if test "$prefix" != "/"; then
+dnl Issue #31114, replace prefix=/ with '/.'.
+if test "$prefix" = "/"; then
+    prefix="/."
+else
     prefix=`echo "$prefix" | sed -e 's/\/$//g'`
 fi
 


### PR DESCRIPTION


<!-- issue-number: bpo-31114 -->
https://bugs.python.org/issue31114
<!-- /issue-number -->
