### PR TITLE
bpo-31222: Make (datetime|date|time).replace return subclass type in Pure Python

### DIFF
--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -828,7 +828,7 @@ class date:
             month = self._month
         if day is None:
             day = self._day
-        return date(year, month, day)
+        return type(self)(year, month, day)
 
     # Comparisons of date objects with other.
 
@@ -1316,7 +1316,7 @@ class time:
             tzinfo = self.tzinfo
         if fold is None:
             fold = self._fold
-        return time(hour, minute, second, microsecond, tzinfo, fold=fold)
+        return type(self)(hour, minute, second, microsecond, tzinfo, fold=fold)
 
     # Pickle support.
 
@@ -1597,7 +1597,7 @@ class datetime(date):
             tzinfo = self.tzinfo
         if fold is None:
             fold = self.fold
-        return datetime(year, month, day, hour, minute, second,
+        return type(self)(year, month, day, hour, minute, second,
                           microsecond, tzinfo, fold=fold)
 
     def _local_timezone(self):

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1521,11 +1521,11 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         self.assertRaises(ValueError, base.replace, year=2001)
 
     def test_subclass_replace(self):
-        class C(self.theclass):
+        class DateSubclass(self.theclass):
             pass
 
-        dt = C(2012, 1, 1)
-        self.assertIs(type(dt.replace(year=2013)), C)
+        dt = DateSubclass(2012, 1, 1)
+        self.assertIs(type(dt.replace(year=2013)), DateSubclass)
 
     def test_subclass_date(self):
 
@@ -2634,11 +2634,11 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         self.assertRaises(ValueError, base.replace, microsecond=1000000)
 
     def test_subclass_replace(self):
-        class C(self.theclass):
+        class TimeSubclass(self.theclass):
             pass
 
-        ctime = C(12, 30)
-        self.assertIs(type(ctime.replace(hour=10)), C)
+        ctime = TimeSubclass(12, 30)
+        self.assertIs(type(ctime.replace(hour=10)), TimeSubclass)
 
     def test_subclass_time(self):
 

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1520,6 +1520,13 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         base = cls(2000, 2, 29)
         self.assertRaises(ValueError, base.replace, year=2001)
 
+    def test_subclass_replace(self):
+        class C(self.theclass):
+            pass
+
+        dt = C(2012, 1, 1)
+        self.assertIs(type(dt.replace(year=2013)), C)
+
     def test_subclass_date(self):
 
         class C(self.theclass):
@@ -2625,6 +2632,13 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         self.assertRaises(ValueError, base.replace, minute=-1)
         self.assertRaises(ValueError, base.replace, second=100)
         self.assertRaises(ValueError, base.replace, microsecond=1000000)
+
+    def test_subclass_replace(self):
+        class C(self.theclass):
+            pass
+
+        ctime = C(12, 30)
+        self.assertIs(type(ctime.replace(hour=10)), C)
 
     def test_subclass_time(self):
 


### PR DESCRIPTION
Per the discussion [on the issue tracker](https://bugs.python.org/issue31222), the behavior of the pure python implementation of `datetime`, `date` and `time` are out of whack with the equivalent from `_datetimemodule.c`. Since the C version is almost certainly what's being used almost everywhere, this shouldn't have any real behavioral changes. [The equivalent bug in `pypy3`](https://bitbucket.org/pypy/pypy/issues/2635/datetimereplace-always-returns) has been fixed for some time.

<!-- issue-number: bpo-31222 -->
https://bugs.python.org/issue31222
<!-- /issue-number -->
