### PR TITLE
bpo-31903: Release the GIL when calling into SystemConfiguration

### DIFF
--- a/Misc/NEWS.d/next/macOS/2017-11-01-16-53-12.bpo-31903.K6jCVG.rst
+++ b/Misc/NEWS.d/next/macOS/2017-11-01-16-53-12.bpo-31903.K6jCVG.rst
@@ -1,2 +1,2 @@
-In `_scproxy`, drop the GIL when calling into `SystemConfiguration` to avoid
+In :mod:`_scproxy`, drop the GIL when calling into ``SystemConfiguration`` to avoid
 deadlocks.

--- a/Misc/NEWS.d/next/macOS/2017-11-01-16-53-12.bpo-31903.K6jCVG.rst
+++ b/Misc/NEWS.d/next/macOS/2017-11-01-16-53-12.bpo-31903.K6jCVG.rst
@@ -1,0 +1,2 @@
+In `_scproxy`, drop the GIL when calling into `SystemConfiguration` to avoid
+deadlocks.

--- a/Modules/_scproxy.c
+++ b/Modules/_scproxy.c
@@ -62,7 +62,10 @@ get_proxy_settings(PyObject* mod __attribute__((__unused__)))
     PyObject* v;
     int r;
 
+    Py_BEGIN_ALLOW_THREADS
     proxyDict = SCDynamicStoreCopyProxies(NULL);
+    Py_END_ALLOW_THREADS
+
     if (!proxyDict) {
         Py_RETURN_NONE;
     }
@@ -172,7 +175,10 @@ get_proxies(PyObject* mod __attribute__((__unused__)))
     int r;
     CFDictionaryRef proxyDict = NULL;
 
+    Py_BEGIN_ALLOW_THREADS
     proxyDict = SCDynamicStoreCopyProxies(NULL);
+    Py_END_ALLOW_THREADS
+
     if (proxyDict == NULL) {
         return PyDict_New();
     }


### PR DESCRIPTION
Per details in [issue tracker](https://bugs.python.org/issue31903), make sure we release the GIL when calling `SCDynamicStoreCopyProxies` to avoid potential deadlocking if other Python threads also call into `NSUserDefaults`.

<!-- issue-number: bpo-31903 -->
https://bugs.python.org/issue31903
<!-- /issue-number -->
