### PR TITLE
bpo-31904 : Python should support VxWorks RTOS 

### DIFF
--- a/Include/osdefs.h
+++ b/Include/osdefs.h
@@ -14,6 +14,10 @@ extern "C" {
 #define DELIM L';'
 #endif
 
+#ifdef __VXWORKS__
+#define DELIM L';'
+#endif
+
 /* Filename separator */
 #ifndef SEP
 #define SEP L'/'

--- a/Include/symtable.h
+++ b/Include/symtable.h
@@ -103,6 +103,10 @@ PyAPI_FUNC(void) PySymtable_Free(struct symtable *);
 #define SCOPE_OFFSET 11
 #define SCOPE_MASK (DEF_GLOBAL | DEF_LOCAL | DEF_PARAM | DEF_NONLOCAL)
 
+#ifdef __VXWORKS__
+  #undef LOCAL
+#endif
+
 #define LOCAL 1
 #define GLOBAL_EXPLICIT 2
 #define GLOBAL_IMPLICIT 3

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -92,13 +92,13 @@ CONFIGURE_LDFLAGS=	@LDFLAGS@
 # Avoid assigning CFLAGS, LDFLAGS, etc. so users can use them on the
 # command line to append to these values without stomping the pre-set
 # values.
-PY_CFLAGS=	$(sort $(BASECFLAGS) $(OPT) $(CONFIGURE_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(CONFIGURE_CPPFLAGS) )
-PY_CFLAGS_NODIST= $(sort $(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST) )
+PY_CFLAGS=	$(BASECFLAGS) $(OPT) $(CONFIGURE_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS)
+PY_CFLAGS_NODIST=$(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST)
 # Both CPPFLAGS and LDFLAGS need to contain the shell's value for setup.py to
 # be able to build extension modules using the directories specified in the
 # environment variables
-PY_CPPFLAGS=	$(sort $(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CONFIGURE_CPPFLAGS) $(CPPFLAGS) )
-PY_LDFLAGS=	$(sort $(CONFIGURE_LDFLAGS) $(LDFLAGS) )
+PY_CPPFLAGS=	$(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CONFIGURE_CPPFLAGS) $(CPPFLAGS)
+PY_LDFLAGS=	$(CONFIGURE_LDFLAGS) $(LDFLAGS)
 NO_AS_NEEDED=	@NO_AS_NEEDED@
 LDLAST=		@LDLAST@
 SGI_ABI=	@SGI_ABI@

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -92,13 +92,13 @@ CONFIGURE_LDFLAGS=	@LDFLAGS@
 # Avoid assigning CFLAGS, LDFLAGS, etc. so users can use them on the
 # command line to append to these values without stomping the pre-set
 # values.
-PY_CFLAGS=	$(BASECFLAGS) $(OPT) $(CONFIGURE_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS)
-PY_CFLAGS_NODIST=$(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST)
+PY_CFLAGS=	$(sort $(BASECFLAGS) $(OPT) $(CONFIGURE_CFLAGS) $(CFLAGS) $(EXTRA_CFLAGS) $(CONFIGURE_CPPFLAGS) )
+PY_CFLAGS_NODIST= $(sort $(CONFIGURE_CFLAGS_NODIST) $(CFLAGS_NODIST) )
 # Both CPPFLAGS and LDFLAGS need to contain the shell's value for setup.py to
 # be able to build extension modules using the directories specified in the
 # environment variables
-PY_CPPFLAGS=	$(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CONFIGURE_CPPFLAGS) $(CPPFLAGS)
-PY_LDFLAGS=	$(CONFIGURE_LDFLAGS) $(LDFLAGS)
+PY_CPPFLAGS=	$(sort $(BASECPPFLAGS) -I. -I$(srcdir)/Include $(CONFIGURE_CPPFLAGS) $(CPPFLAGS) )
+PY_LDFLAGS=	$(sort $(CONFIGURE_LDFLAGS) $(LDFLAGS) )
 NO_AS_NEEDED=	@NO_AS_NEEDED@
 LDLAST=		@LDLAST@
 SGI_ABI=	@SGI_ABI@

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -449,7 +449,11 @@ DTRACE_DEPS = \
 
 # Default target
 all:		@DEF_MAKE_ALL_RULE@
-build_all:	$(BUILDPYTHON) oldsharedmods sharedmods gdbhooks Programs/_testembed python-config
+ifeq ($(PY_ENABLE_SHARED),1)
+build_all:      $(BUILDPYTHON) oldsharedmods sharedmods gdbhooks Programs/_testembed python-config
+else
+build_all:      $(BUILDPYTHON) gdbhooks Programs/_testembed python-config
+endif
 
 # Compile a binary with profile guided optimization.
 profile-opt:

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -56,6 +56,7 @@ DTRACE_HEADERS= @DTRACE_HEADERS@
 DTRACE_OBJS=    @DTRACE_OBJS@
 
 GNULD=		@GNULD@
+PY_ENABLE_SHARED=@PY_ENABLE_SHARED@
 
 # Shell used by make (some versions default to the login shell, which is bad)
 SHELL=		/bin/sh
@@ -101,11 +102,19 @@ PY_LDFLAGS=	$(CONFIGURE_LDFLAGS) $(LDFLAGS)
 NO_AS_NEEDED=	@NO_AS_NEEDED@
 LDLAST=		@LDLAST@
 SGI_ABI=	@SGI_ABI@
-CCSHARED=	@CCSHARED@
-LINKFORSHARED=	@LINKFORSHARED@
-ARFLAGS=	@ARFLAGS@
+
+ifeq ($(PY_ENABLE_SHARED),1)
+CCSHARED=       @CCSHARED@
+LINKFORSHARED=  @LINKFORSHARED@
 # Extra C flags added for building the interpreter object files.
 CFLAGSFORSHARED=@CFLAGSFORSHARED@
+else
+CCSHARED=
+LINKFORSHARED=
+CFLAGSFORSHARED=
+endif
+
+ARFLAGS=	@ARFLAGS@
 # C flags used for building the interpreter object files
 PY_CORE_CFLAGS=	$(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE
 # Strict or non-strict aliasing flags used to compile dtoa.c, see above
@@ -440,7 +449,11 @@ DTRACE_DEPS = \
 
 # Default target
 all:		@DEF_MAKE_ALL_RULE@
-build_all:	$(BUILDPYTHON) oldsharedmods sharedmods gdbhooks Programs/_testembed python-config
+ifeq ($(PY_ENABLE_SHARED),1)
+build_all:      $(BUILDPYTHON) oldsharedmods sharedmods gdbhooks Programs/_testembed python-config
+else
+build_all:      $(BUILDPYTHON) gdbhooks Programs/_testembed python-config
+endif
 
 # Compile a binary with profile guided optimization.
 profile-opt:

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -56,6 +56,7 @@ DTRACE_HEADERS= @DTRACE_HEADERS@
 DTRACE_OBJS=    @DTRACE_OBJS@
 
 GNULD=		@GNULD@
+PY_ENABLE_SHARED=@PY_ENABLE_SHARED@
 
 # Shell used by make (some versions default to the login shell, which is bad)
 SHELL=		/bin/sh
@@ -101,11 +102,19 @@ PY_LDFLAGS=	$(CONFIGURE_LDFLAGS) $(LDFLAGS)
 NO_AS_NEEDED=	@NO_AS_NEEDED@
 LDLAST=		@LDLAST@
 SGI_ABI=	@SGI_ABI@
-CCSHARED=	@CCSHARED@
-LINKFORSHARED=	@LINKFORSHARED@
-ARFLAGS=	@ARFLAGS@
+
+ifeq ($(PY_ENABLE_SHARED),1)
+CCSHARED=       @CCSHARED@
+LINKFORSHARED=  @LINKFORSHARED@
 # Extra C flags added for building the interpreter object files.
 CFLAGSFORSHARED=@CFLAGSFORSHARED@
+else
+CCSHARED=
+LINKFORSHARED=
+CFLAGSFORSHARED=
+endif
+
+ARFLAGS=	@ARFLAGS@
 # C flags used for building the interpreter object files
 PY_CORE_CFLAGS=	$(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE
 # Strict or non-strict aliasing flags used to compile dtoa.c, see above

--- a/Modules/_multiprocessing/multiprocessing.h
+++ b/Modules/_multiprocessing/multiprocessing.h
@@ -32,8 +32,12 @@
 #  define BOOL int
 #  define UINT32 uint32_t
 #  define INT32 int32_t
-#  define TRUE 1
-#  define FALSE 0
+#  ifndef TRUE
+#    define TRUE 1
+#  endif
+#  ifndef FALSE
+#    define FALSE 0
+#  endif
 #  define INVALID_HANDLE_VALUE (-1)
 #endif
 

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -13,7 +13,9 @@
 #ifdef HAVE_SYS_RESOURCE_H
 #  include <sys/resource.h>
 #endif
-
+#ifdef __VXWORKS__
+#  include <ioLib.h>
+#endif
 /* Allocate at maximum 100 MB of the stack to raise the stack overflow */
 #define STACK_OVERFLOW_MAX_SIZE (100*1024*1024)
 

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -15,6 +15,10 @@
 #include <stropts.h>
 #endif
 
+#ifdef __VXWORKS__
+#include <ioLib.h>   /* ioctl() */
+#endif
+
 /*[clinic input]
 module fcntl
 [clinic start generated code]*/

--- a/Modules/getbuildinfo.c
+++ b/Modules/getbuildinfo.c
@@ -4,6 +4,11 @@
 #include <stdio.h>
 #endif
 
+#ifdef __VXWORKS__
+#undef DATE
+#undef TIME
+#endif
+
 #ifndef DATE
 #ifdef __DATE__
 #define DATE __DATE__

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1463,9 +1463,9 @@ PyInit_mmap(void)
 #endif
 
     setint(dict, "PAGESIZE", (long)my_getpagesize());
-
+#ifndef __VXWORKS__
     setint(dict, "ALLOCATIONGRANULARITY", (long)my_getallocationgranularity());
-
+#endif
     setint(dict, "ACCESS_READ", ACCESS_READ);
     setint(dict, "ACCESS_WRITE", ACCESS_WRITE);
     setint(dict, "ACCESS_COPY", ACCESS_COPY);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -174,6 +174,7 @@ corresponding Unix manual entries for more information on calls.");
 #define HAVE_FSYNC      1
 #define fsync _commit
 #else
+#ifndef __VXWORKS__
 /* Unix functions that the configure script doesn't check for */
 #define HAVE_EXECV      1
 #define HAVE_FORK       1
@@ -184,6 +185,7 @@ corresponding Unix manual entries for more information on calls.");
 #define HAVE_GETEUID    1
 #define HAVE_GETGID     1
 #define HAVE_GETPPID    1
+#endif
 #define HAVE_GETUID     1
 #define HAVE_KILL       1
 #define HAVE_OPENDIR    1

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -965,11 +965,18 @@ fill_siginfo(siginfo_t *si)
 
     PyStructSequence_SET_ITEM(result, 0, PyLong_FromLong((long)(si->si_signo)));
     PyStructSequence_SET_ITEM(result, 1, PyLong_FromLong((long)(si->si_code)));
+#ifdef __VXWORKS__   
+    PyStructSequence_SET_ITEM(result, 2, PyLong_FromLong(0L));
+    PyStructSequence_SET_ITEM(result, 3, PyLong_FromLong(0L));
+    PyStructSequence_SET_ITEM(result, 4, PyLong_FromLong(0L));
+    PyStructSequence_SET_ITEM(result, 5, PyLong_FromLong(0L));
+#else   
     PyStructSequence_SET_ITEM(result, 2, PyLong_FromLong((long)(si->si_errno)));
     PyStructSequence_SET_ITEM(result, 3, PyLong_FromPid(si->si_pid));
     PyStructSequence_SET_ITEM(result, 4, _PyLong_FromUid(si->si_uid));
     PyStructSequence_SET_ITEM(result, 5,
                                 PyLong_FromLong((long)(si->si_status)));
+#endif   
 #ifdef HAVE_SIGINFO_T_SI_BAND
     PyStructSequence_SET_ITEM(result, 6, PyLong_FromLong(si->si_band));
 #else

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -183,10 +183,7 @@ if_indextoname(index) -- return the corresponding interface name\n\
 #endif
 
 #ifdef __VXWORKS__
-# define HAVE_GETHOSTBYNAME_R
-# define HAVE_GETHOSTBYNAME_R_5_ARG
 # include <ipcom_sock2.h>
-# define gethostbyname_r( a1, a2, a3, a4, a5 )  ipcom_gethostbyname_r( a1, a2, a3, a4, a5 )
 # define gethostbyaddr_r( a1, a2, a3, a4, a5, a6, a7 )  ipcom_gethostbyaddr_r( a1, a2, a3, a4, a5, a6, a7 )
 # include <hostLib.h>
 #endif

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -542,7 +542,7 @@ set_error(void)
     return PyErr_SetFromErrno(PyExc_OSError);
 }
 
-
+#ifndef __VXWORKS__
 static PyObject *
 set_herror(int h_error)
 {
@@ -560,7 +560,7 @@ set_herror(int h_error)
 
     return NULL;
 }
-
+#endif
 
 static PyObject *
 set_gaierror(int error)
@@ -913,7 +913,7 @@ init_sockobject(PySocketSockObject *s,
     return 0;
 }
 
-
+#ifdef HAVE_SOCKETPAIR
 /* Create a new socket object.
    This just creates the object and initializes it.
    If the creation fails, return NULL and set an exception (implicit
@@ -933,7 +933,7 @@ new_sockobject(SOCKET_T fd, int family, int type, int proto)
     }
     return s;
 }
-
+#endif
 
 /* Lock to allow python interpreter to continue, but only allow one
    thread to be in gethostbyname or getaddrinfo */
@@ -2324,17 +2324,17 @@ cmsg_min_space(struct msghdr *msg, struct cmsghdr *cmsgh, size_t space)
     #endif
     if (msg->msg_controllen < 0)
         return 0;
+    if (space < cmsg_len_end)
+        space = cmsg_len_end;
+    cmsg_offset = (char *)cmsgh - (char *)msg->msg_control;
+    return (cmsg_offset <= (size_t)-1 - space &&
+            cmsg_offset + space <= msg->msg_controllen);
     #if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5)))
     #pragma GCC diagnostic pop
     #endif
     #ifdef __clang__
     #pragma clang diagnostic pop
     #endif
-    if (space < cmsg_len_end)
-        space = cmsg_len_end;
-    cmsg_offset = (char *)cmsgh - (char *)msg->msg_control;
-    return (cmsg_offset <= (size_t)-1 - space &&
-            cmsg_offset + space <= msg->msg_controllen);
 }
 
 /* If pointer CMSG_DATA(cmsgh) is in buffer msg->msg_control, set

--- a/Modules/syslogmodule.c
+++ b/Modules/syslogmodule.c
@@ -54,6 +54,10 @@ Revision history:
 
 #include <syslog.h>
 
+#ifndef LOG_UPTO
+#define	LOG_UPTO(pri)	((1 << ((pri)+1)) - 1)	/* all priorities through pri */
+#endif
+
 /*  only one instance, only one syslog, so globals should be ok  */
 static PyObject *S_ident_o = NULL;                      /*  identifier, held by openlog()  */
 static char S_log_open = 0;

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -1215,6 +1215,7 @@ PyInit_timezone(PyObject *m) {
 #if defined(HAVE_TZNAME) && !defined(__GLIBC__) && !defined(__CYGWIN__)
     PyObject *otz0, *otz1;
     tzset();
+#ifndef __VXWORKS__
     PyModule_AddIntConstant(m, "timezone", timezone);
 #ifdef HAVE_ALTZONE
     PyModule_AddIntConstant(m, "altzone", altzone);
@@ -1222,6 +1223,7 @@ PyInit_timezone(PyObject *m) {
     PyModule_AddIntConstant(m, "altzone", timezone-3600);
 #endif
     PyModule_AddIntConstant(m, "daylight", daylight);
+#endif    
     otz0 = PyUnicode_DecodeLocale(tzname[0], "surrogateescape");
     otz1 = PyUnicode_DecodeLocale(tzname[1], "surrogateescape");
     PyModule_AddObject(m, "tzname", Py_BuildValue("(NN)", otz0, otz1));

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -270,7 +270,7 @@ get_locale_encoding(void)
         return NULL;
     }
     return get_codec_name(codeset);
-#elif defined(__ANDROID__) || defined(__VXWORKS__)
+#elif defined(__ANDROID__)
     return get_codec_name("UTF-8");
 #else
     PyErr_SetNone(PyExc_NotImplementedError);
@@ -1420,6 +1420,10 @@ initfsencoding(PyInterpreterState *interp)
     {
         Py_FileSystemDefaultEncoding = "utf-8";
         Py_FileSystemDefaultEncodeErrors = "surrogatepass";
+    }
+#elif defined(__VXWORKS__)
+    {
+    Py_FileSystemDefaultEncoding = "ascii";
     }
 #else
     if (Py_FileSystemDefaultEncoding == NULL)

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1421,6 +1421,10 @@ initfsencoding(PyInterpreterState *interp)
         Py_FileSystemDefaultEncoding = "utf-8";
         Py_FileSystemDefaultEncodeErrors = "surrogatepass";
     }
+#elif defined(__VXWORKS__)
+    {
+    Py_FileSystemDefaultEncoding = "ascii";
+    }
 #else
     if (Py_FileSystemDefaultEncoding == NULL)
     {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -270,7 +270,7 @@ get_locale_encoding(void)
         return NULL;
     }
     return get_codec_name(codeset);
-#elif defined(__ANDROID__)
+#elif defined(__ANDROID__) || defined(__VXWORKS__)
     return get_codec_name("UTF-8");
 #else
     PyErr_SetNone(PyExc_NotImplementedError);

--- a/configure
+++ b/configure
@@ -3258,6 +3258,9 @@ then
 	*-*-cygwin*)
 		ac_sys_system=Cygwin
 		;;
+	*-*-vxworks*)
+		ac_sys_system=VxWorks
+		;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -3302,6 +3305,9 @@ if test "$cross_compiling" = yes; then
 	*-*-cygwin*)
 		_host_cpu=
 		;;
+	*-*-vxworks*)
+		_host_cpu=
+		;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -3320,6 +3326,10 @@ fi
 # wildcard, and that the wildcard does not include future systems
 # (which may remove their limitations).
 case $ac_sys_system/$ac_sys_release in
+  # On VxWorks if _XOPEN_SOURCE is defined the socket.h header 
+  # has undefined types.
+  VxWorks* )
+    define_xopen_source=no;;
   # On OpenBSD, select(2) is not available if _XOPEN_SOURCE is defined,
   # even though select is a POSIX function. Reported by J. Ribbens.
   # Reconfirmed for OpenBSD 3.3 by Zachary Hamm, for 3.4 by Jason Ish.

--- a/configure
+++ b/configure
@@ -13309,7 +13309,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_char_unsigned" >&5
 $as_echo "$ac_cv_c_char_unsigned" >&6; }
-if test $ac_cv_c_char_unsigned = yes && test "$GCC" != yes; then
+if test $ac_cv_c_char_unsigned = yes && test "$GCC" != yes && test "$ac_sys_system" != "VxWorks"  ; then
   $as_echo "#define __CHAR_UNSIGNED__ 1" >>confdefs.h
 
 fi

--- a/configure
+++ b/configure
@@ -2927,7 +2927,7 @@ $as_echo_n "checking for python interpreter for cross build... " >&6; }
 	    if $interp -c "import sys;sys.exit(not '.'.join(str(n) for n in sys.version_info[:2]) == '$PACKAGE_VERSION')"; then
 	        break
 	    fi
-            interp=
+ 
 	done
         if test x$interp = x; then
 	    as_fn_error $? "python$PACKAGE_VERSION interpreter not found" "$LINENO" 5

--- a/configure
+++ b/configure
@@ -3258,6 +3258,9 @@ then
 	*-*-cygwin*)
 		ac_sys_system=Cygwin
 		;;
+	*-*-vxworks*)
+		ac_sys_system=VxWorks
+		;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -3302,6 +3305,9 @@ if test "$cross_compiling" = yes; then
 	*-*-cygwin*)
 		_host_cpu=
 		;;
+	*-*-vxworks*)
+		_host_cpu=
+		;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -3320,6 +3326,10 @@ fi
 # wildcard, and that the wildcard does not include future systems
 # (which may remove their limitations).
 case $ac_sys_system/$ac_sys_release in
+  # On VxWorks if _XOPEN_SOURCE is defined the socket.h header 
+  # has undefined types.
+  VxWorks* )
+    define_xopen_source=no;;
   # On OpenBSD, select(2) is not available if _XOPEN_SOURCE is defined,
   # even though select is a POSIX function. Reported by J. Ribbens.
   # Reconfirmed for OpenBSD 3.3 by Zachary Hamm, for 3.4 by Jason Ish.
@@ -13299,7 +13309,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_c_char_unsigned" >&5
 $as_echo "$ac_cv_c_char_unsigned" >&6; }
-if test $ac_cv_c_char_unsigned = yes && test "$GCC" != yes; then
+if test $ac_cv_c_char_unsigned = yes && test "$GCC" != yes && test "$ac_sys_system" != "VxWorks"  ; then
   $as_echo "#define __CHAR_UNSIGNED__ 1" >>confdefs.h
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -377,6 +377,9 @@ then
 	*-*-cygwin*)
 		ac_sys_system=Cygwin
 		;;
+	*-*-vxworks*)
+	        ac_sys_system=VxWorks
+	        ;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -418,9 +421,12 @@ if test "$cross_compiling" = yes; then
 			_host_cpu=$host_cpu
 		esac
 		;;
-	*-*-cygwin*)
-		_host_cpu=
-		;;
+        *-*-cygwin*)
+                _host_cpu=
+                ;;
+        *-*-vxworks*)
+                _host_cpu=$host_cpu
+                ;;
 	*)
 		# for now, limit cross builds to known configurations
 		MACHDEP="unknown"
@@ -507,6 +513,11 @@ case $ac_sys_system/$ac_sys_release in
   # On QNX 6.3.2, defining _XOPEN_SOURCE prevents netdb.h from
   # defining NI_NUMERICHOST.
   QNX/6.3.2)
+    define_xopen_source=no
+    ;;
+  # On VxWorks, defining _XOPEN_SOURCE causes compile failures
+  # in network headers still using system V types.
+  VxWorks/*)
     define_xopen_source=no
     ;;
 
@@ -3996,7 +4007,10 @@ fi
 
 # checks for compiler characteristics
 
-AC_C_CHAR_UNSIGNED
+# test results in duplicate def of __CHAR_UNSIGNED__ on VxWorks
+if test "$ac_sys_system" != "VxWorks" ; then
+ AC_C_CHAR_UNSIGNED
+fi
 AC_C_CONST
 
 works=no

--- a/setup.py
+++ b/setup.py
@@ -275,6 +275,14 @@ class PyBuildExt(build_ext):
         if compiler is not None:
             (ccshared,cflags) = sysconfig.get_config_vars('CCSHARED','CFLAGS')
             args['compiler_so'] = compiler + ' ' + ccshared + ' ' + cflags
+            
+            #VxWorks uses '@filepath' extension to add include paths without overflowing windows cmd line buffer  
+            if host_platform == 'vxworks':
+                cppflags = sysconfig.get_config_var('CPPFLAGS').split()
+                for item in cppflags:
+                    self.announce('ITEM: "%s"' % item )
+                    if item.startswith('@'):
+                        args['compiler_so'] = compiler + ' ' + ccshared + ' ' + cflags + ' '+ item 
         self.compiler.set_executables(**args)
 
         build_ext.build_extensions(self)
@@ -503,7 +511,7 @@ class PyBuildExt(build_ext):
 
     def detect_math_libs(self):
         # Check for MacOS X, which doesn't need libm.a at all
-        if host_platform == 'darwin':
+        if (host_platform == 'darwin' or host_platform == 'vxworks'):
             return []
         else:
             return ['m']
@@ -516,7 +524,7 @@ class PyBuildExt(build_ext):
             add_dir_to_list(self.compiler.library_dirs, '/usr/local/lib')
             add_dir_to_list(self.compiler.include_dirs, '/usr/local/include')
         # only change this for cross builds for 3.3, issues on Mageia
-        if cross_compiling:
+        if ( cross_compiling and not host_platform == 'vxworks'):
             self.add_gcc_paths()
         self.add_multiarch_paths()
 
@@ -554,9 +562,10 @@ class PyBuildExt(build_ext):
                     for directory in reversed(options.dirs):
                         add_dir_to_list(dir_list, directory)
 
-        if (not cross_compiling and
+        if ((not cross_compiling and
                 os.path.normpath(sys.base_prefix) != '/usr' and
-                not sysconfig.get_config_var('PYTHONFRAMEWORK')):
+                not sysconfig.get_config_var('PYTHONFRAMEWORK')) or
+                host_platform == 'vxworks'):
             # OSX note: Don't add LIBDIR and INCLUDEDIR to building a framework
             # (PYTHONFRAMEWORK is set) to avoid # linking problems when
             # building a framework with different architectures than
@@ -565,6 +574,14 @@ class PyBuildExt(build_ext):
                             sysconfig.get_config_var("LIBDIR"))
             add_dir_to_list(self.compiler.include_dirs,
                             sysconfig.get_config_var("INCLUDEDIR"))
+
+        #VxWorks requires some macros from CPPFLAGS to select the correct CPU headers
+        if host_platform == 'vxworks':
+            cppflags = sysconfig.get_config_var('CPPFLAGS').split()
+            for item in cppflags:
+                self.announce('ITEM: "%s"' % item )
+                if item.startswith('-D'):
+                    self.compiler.define_macro(item[2:])
 
         # lib_dirs and inc_dirs are used to search for files;
         # if a file is found in one of those directories, it can
@@ -694,7 +711,8 @@ class PyBuildExt(build_ext):
         # pwd(3)
         exts.append( Extension('pwd', ['pwdmodule.c']) )
         # grp(3)
-        exts.append( Extension('grp', ['grpmodule.c']) )
+        if host_platform != 'vxworks':
+            exts.append( Extension('grp', ['grpmodule.c']) )
         # spwd, shadow passwords
         if (config_h_vars.get('HAVE_GETSPNAM', False) or
                 config_h_vars.get('HAVE_GETSPENT', False)):
@@ -827,13 +845,15 @@ class PyBuildExt(build_ext):
             libs = ['crypt']
         else:
             libs = []
-        exts.append( Extension('_crypt', ['_cryptmodule.c'], libraries=libs) )
+        if host_platform != 'vxworks':
+            exts.append( Extension('_crypt', ['_cryptmodule.c'], libraries=libs) )
 
         # CSV files
         exts.append( Extension('_csv', ['_csv.c']) )
 
         # POSIX subprocess module helper.
-        exts.append( Extension('_posixsubprocess', ['_posixsubprocess.c']) )
+        if host_platform != 'vxworks':
+            exts.append( Extension('_posixsubprocess', ['_posixsubprocess.c']) )
 
         # socket(2)
         exts.append( Extension('_socket', ['socketmodule.c'],
@@ -851,20 +871,31 @@ class PyBuildExt(build_ext):
                                ['/usr/kerberos/include'])
             if krb5_h:
                 ssl_incs += krb5_h
-        ssl_libs = find_library_file(self.compiler, 'ssl',lib_dirs,
+            if host_platform == 'vxworks':
+                ssl_libs = find_library_file(self.compiler, 'OPENSSL',lib_dirs, [] )
+                if (ssl_incs is not None and
+                    ssl_libs is not None):
+                    exts.append( Extension('_ssl', ['_ssl.c'],
+                                   include_dirs = ssl_incs,
+                                   library_dirs = ssl_libs,
+                                   libraries = ['OPENSSL', 'HASH'],
+                                   depends = ['socketmodule.h']), )
+                else:
+                    missing.append('_ssl')
+            else:
+                ssl_libs = find_library_file(self.compiler, 'ssl',lib_dirs,
                                      ['/usr/local/ssl/lib',
                                       '/usr/contrib/ssl/lib/'
                                      ] )
-
-        if (ssl_incs is not None and
-            ssl_libs is not None):
-            exts.append( Extension('_ssl', ['_ssl.c'],
+                if (ssl_incs is not None and
+                    ssl_libs is not None):
+                    exts.append( Extension('_ssl', ['_ssl.c'],
                                    include_dirs = ssl_incs,
                                    library_dirs = ssl_libs,
                                    libraries = ['ssl', 'crypto'],
                                    depends = ['socketmodule.h']), )
-        else:
-            missing.append('_ssl')
+                else:
+                    missing.append('_ssl')
 
         # find out which version of OpenSSL we have
         openssl_ver = 0
@@ -898,11 +929,18 @@ class PyBuildExt(build_ext):
             if have_usable_openssl:
                 # The _hashlib module wraps optimized implementations
                 # of hash functions from the OpenSSL library.
-                exts.append( Extension('_hashlib', ['_hashopenssl.c'],
+                if host_platform != 'vxworks':
+                    exts.append( Extension('_hashlib', ['_hashopenssl.c'],
                                        depends = ['hashlib.h'],
                                        include_dirs = ssl_incs,
                                        library_dirs = ssl_libs,
                                        libraries = ['ssl', 'crypto']) )
+                else :
+                    exts.append( Extension('_hashlib', ['_hashopenssl.c'],
+                                       depends = ['hashlib.h'],
+                                       include_dirs = ssl_incs,
+                                       library_dirs = ssl_libs,
+                                       libraries = ['OPENSSL', 'HASH']) )
             else:
                 print("warning: openssl 0x%08x is too old for _hashlib" %
                       openssl_ver)
@@ -1354,7 +1392,7 @@ class PyBuildExt(build_ext):
             missing.append('_gdbm')
 
         # Unix-only modules
-        if host_platform != 'win32':
+        if host_platform != 'win32' and host_platform != 'vxworks':
             # Steen Lumholt's termios module
             exts.append( Extension('termios', ['termios.c']) )
             # Jeremy Hylton's rlimit interface

--- a/setup.py
+++ b/setup.py
@@ -690,7 +690,7 @@ class PyBuildExt(build_ext):
         # Test multi-phase extension module init (PEP 489)
         exts.append( Extension('_testmultiphase', ['_testmultiphase.c']) )
         # profiler (_lsprof is for cProfile.py)
-        exts.append( Extension('_lsprof', ['_lsprof.c', 'rotatingtree.c'] )
+        exts.append( Extension('_lsprof', ['_lsprof.c', 'rotatingtree.c']) )
         # static Unicode character database
         exts.append( Extension('unicodedata', ['unicodedata.c'],
                                depends=['unicodedata_db.h', 'unicodename_db.h']) )


### PR DESCRIPTION
This pull request enables cpython to cross-build on **VxWorks** (the world’s leading RTOS and the only interplanetary OS)   

This does not provide complete configuration of all target systems possible. It's assumed that the user is familiar with **automake** cross-builds and has called **./configure** with the appropriate environment (CFLAGS,LDFLAGS, CC,CCP, etc) and appropriate site.config and configuration arguments.   

VxWorks 7 currently supports Intel, ARM and PowerPC processors running in 32bit and 64bit mode compiled with GCC, ICC, a llvm/clang variant, or Wind River’s Diab compiler. So the verification matrix is large and subsequent pull requests will address the various variants as they are validated.   

This pull also also includes some support for automake's **--enable-shared=no** functionality. If this non-default  flag is set, various targets and flags are disabled in Make.pre.in and thus the generated Makefile 

--------------------------------------------------------------------------------------------------------------
Validated with GCC 4.8.1.10 as provided with VxWorks 7 

```
. ./vxworks_env.sh && \
./configure --host=x86-wrs-vxworks --prefix=/yow-build40-lx1/bkuhl/workspace/vsbSim/usr/root \
--bindir=/yow-build40-lx1/bkuhl/workspace/vsbSim/usr/root/gnu/bin --includedir=/yow-build40-lx1/bkuhl/workspace/vsbSim/usr/h/public \
--libdir=/yow-build40-lx1/bkuhl/workspace/vsbSim/usr/lib/common  --build=i686-linux-gnu  --cache-file=config.vx.app --with-libm=no --with-ensurepip=no --with-suffix=.vxe
```
------------------------------------------------------------------------------------------------------------
.. and an appropriate site.config
```
#! /bin/sh
# config.vx.app - autoconf configuration file for VxWorks
#
# Copyright (c) 2017  Wind River Systems, Inc.
#
# This software is released under the terms of the 
# Python Software Foundation License Version 2
# included in this repository in the LICENSE file
# or at https://docs.python.org/3/license.html
#
# modification history
# -------------------- 
# 23sep17,brk  create
	

	#defined in UNIX layer, but just a wrapper to select()
	ac_cv_func_poll=no
	 
	# forces define of PY_FORMAT_LONG_LONG (Python)
	ac_cv_have_long_long_format=yes

	#Python wants these explicit when cross compiling
	
	ac_cv_file__dev_ptmx=no
	ac_cv_file__dev_ptc=no
	
	ac_cv_buggy_getaddrinfo=no
	
	ac_cv_func_gettimeofday=yes
	
	#ignore empty header in UNIX layer
	ac_cv_header_langinfo_h=no

        #avoid not finding pthread in various extra libs, 
        ac_cv_pthread_is_default=yes

        #gcc fails to compile endian test
        case $host in 
                 ppc*-vxworks )
                        ac_cv_c_bigendian=yes ;;
                 arm*-vxworks )
                        ac_cv_c_bigendian=no ;;
                 x86*-vxworks )
                        ac_cv_c_bigendian=no ;;
                 mips*-vxworks )
                        ac_cv_c_bigendian=yes ;;
        esac
```



<!-- issue-number: bpo-31904 -->
https://bugs.python.org/issue31904
<!-- /issue-number -->
