### PR TITLE
root.quit does not close the window

### DIFF
--- a/Tools/demo/redemo.py
+++ b/Tools/demo/redemo.py
@@ -166,7 +166,7 @@ class ReDemo:
 def main():
     root = Tk()
     demo = ReDemo(root)
-    root.protocol('WM_DELETE_WINDOW', root.quit)
+    root.protocol('WM_DELETE_WINDOW', root.destroy)
     root.mainloop()
 
 if __name__ == '__main__':


### PR DESCRIPTION
I tried this example code with python 3.6 but the close button (X) doesn't work. I found changing root.quit to root.destroy did work.

YMMV, but now you know :-)

!!! If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

PLEASE: Remove this headline!!!
