### PR TITLE
bpo-31909: fix missing HAVE_SYSCALL_GETRANDOM for libexpat.

### DIFF
--- a/configure
+++ b/configure
@@ -16407,6 +16407,7 @@ $as_echo "$have_getrandom_syscall" >&6; }
 if test "$have_getrandom_syscall" = yes; then
 
 $as_echo "#define HAVE_GETRANDOM_SYSCALL 1" >>confdefs.h
+$as_echo "#define HAVE_SYSCALL_GETRANDOM 1" >>confdefs.h
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -5361,6 +5361,8 @@ AC_MSG_RESULT($have_getrandom_syscall)
 if test "$have_getrandom_syscall" = yes; then
     AC_DEFINE(HAVE_GETRANDOM_SYSCALL, 1,
               [Define to 1 if the Linux getrandom() syscall is available])
+    AC_DEFINE(HAVE_SYSCALL_GETRANDOM, 1,
+              [Define to 1 if the Linux getrandom() syscall is available (libexpat)])
 fi
 
 # check if the getrandom() function is available


### PR DESCRIPTION
libexpat looks for HAVE_SYSCALL_GETRANDOM, not HAVE_GETRANDOM_SYSCALL.


<!-- issue-number: bpo-31909 -->
https://bugs.python.org/issue31909
<!-- /issue-number -->
