### PR TITLE
bpo-32204: Optimize asyncio.Future _schedule_callbacks

### DIFF
--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -120,13 +120,13 @@ class Future:
         The callbacks are scheduled to be called as soon as possible. Also
         clears the callback list.
         """
-        callbacks = self._callbacks[:]
-        if not callbacks:
+        if not self._callbacks:
             return
 
-        self._callbacks[:] = []
-        for callback in callbacks:
+        for callback in self._callbacks:
             self._loop.call_soon(callback, self)
+
+        self._callbacks.clear()
 
     def cancelled(self):
         """Return True if the future was cancelled."""


### PR DESCRIPTION
### Summary

While migrating our code to asyncio, we've noticed that performance was not up to our standards. We have been performing profiles to determine what are some quick wins we could contribute to python in order to increase asyncio's performance.

While investigating, we have noticed that the method `set_result` of `asyncio.Future` is very slow when a lot of callbacks are waiting for the future. When digging, we noticed that a full copy of all callbacks is made.

This PR corrects this issue and reduces the amount of time `set_result` takes on our benchmarks from 17% down to 2.5%

### Test plan
In addition to passing all unit tests, I performed a before and after profiles using `cProfile`:

#### Before:
![before](https://user-images.githubusercontent.com/205628/32213516-cca8fcd6-bdd8-11e7-98bc-034bb8e17100.png)

#### After:
![after](https://user-images.githubusercontent.com/205628/32213525-d181afb4-bdd8-11e7-9375-5b1738ea0e60.png)


<!-- issue-number: bpo-32204 -->
https://bugs.python.org/issue32204
<!-- /issue-number -->
