### PR TITLE
bpo-31908: Fix output of cover files for trace module command-line tool

### DIFF
--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -2,6 +2,7 @@ import os
 import sys
 from test.support import TESTFN, rmtree, unlink, captured_stdout
 from test.support.script_helper import assert_python_ok, assert_python_failure
+import textwrap
 import unittest
 
 import trace
@@ -364,6 +365,35 @@ class Test_Ignore(unittest.TestCase):
         self.assertFalse(ignore.names(jn('bar', 'z.py'), 'z'))
         # Matched before.
         self.assertTrue(ignore.names(jn('bar', 'baz.py'), 'baz'))
+
+# Created for Issue 31908 -- CLI utility not writing cover files
+class TestCoverageCommandLineOutput(unittest.TestCase):
+
+    codefile = 'tmp.py'
+    coverfile = 'tmp.cover'
+
+    def setUp(self):
+        with open(self.codefile, 'w') as f:
+            f.write(textwrap.dedent('''\
+            x = 42
+            if []:
+                print('unreachable')
+            '''))
+
+    def tearDown(self):
+        unlink(self.codefile)
+        unlink(self.coverfile)
+
+    def test_cover_files_written(self):
+        argv = '-m trace --count --missing'.split() + [self.codefile]
+        status, stdout, stderr = assert_python_ok(*argv)
+        self.assertTrue(os.path.exists(self.coverfile))
+        with open(self.coverfile) as f:
+            self.assertEqual(f.read(), textwrap.dedent('''\
+                    1: x = 42
+                    1: if []:
+                >>>>>>     print('unreachable')
+                '''))
 
 class TestCommandLine(unittest.TestCase):
 

--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -375,16 +375,27 @@ class TestCoverageCommandLineOutput(unittest.TestCase):
     def setUp(self):
         with open(self.codefile, 'w') as f:
             f.write(textwrap.dedent('''\
-            x = 42
-            if []:
-                print('unreachable')
+                x = 42
+                if []:
+                    print('unreachable')
             '''))
 
     def tearDown(self):
         unlink(self.codefile)
         unlink(self.coverfile)
 
-    def test_cover_files_written(self):
+    def test_cover_files_written_no_highlight(self):
+        argv = '-m trace --count'.split() + [self.codefile]
+        status, stdout, stderr = assert_python_ok(*argv)
+        self.assertTrue(os.path.exists(self.coverfile))
+        with open(self.coverfile) as f:
+            self.assertEqual(f.read(), textwrap.dedent('''\
+                    1: x = 42
+                    1: if []:
+                           print('unreachable')
+            '''))
+
+    def test_cover_files_written_with_highlight(self):
         argv = '-m trace --count --missing'.split() + [self.codefile]
         status, stdout, stderr = assert_python_ok(*argv)
         self.assertTrue(os.path.exists(self.coverfile))
@@ -393,7 +404,7 @@ class TestCoverageCommandLineOutput(unittest.TestCase):
                     1: x = 42
                     1: if []:
                 >>>>>>     print('unreachable')
-                '''))
+            '''))
 
 class TestCommandLine(unittest.TestCase):
 

--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -389,11 +389,11 @@ class TestCoverageCommandLineOutput(unittest.TestCase):
         status, stdout, stderr = assert_python_ok(*argv)
         self.assertTrue(os.path.exists(self.coverfile))
         with open(self.coverfile) as f:
-            self.assertEqual(f.read(), textwrap.dedent('''\
-                    1: x = 42
-                    1: if []:
-                           print('unreachable')
-            '''))
+            self.assertEqual(f.read(),
+                "    1: x = 42\n"
+                "    1: if []:\n"
+                "           print('unreachable')\n"
+            )
 
     def test_cover_files_written_with_highlight(self):
         argv = '-m trace --count --missing'.split() + [self.codefile]

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -275,16 +275,15 @@ class CoverageResults:
                 lnotab = _find_executable_linenos(filename)
             else:
                 lnotab = {}
-            if lnotab:
-                source = linecache.getlines(filename)
-                coverpath = os.path.join(dir, modulename + ".cover")
-                with open(filename, 'rb') as fp:
-                    encoding, _ = tokenize.detect_encoding(fp.readline)
-                n_hits, n_lines = self.write_results_file(coverpath, source,
-                                                          lnotab, count, encoding)
-                if summary and n_lines:
-                    percent = int(100 * n_hits / n_lines)
-                    sums[modulename] = n_lines, percent, modulename, filename
+            source = linecache.getlines(filename)
+            coverpath = os.path.join(dir, modulename + ".cover")
+            with open(filename, 'rb') as fp:
+                encoding, _ = tokenize.detect_encoding(fp.readline)
+            n_hits, n_lines = self.write_results_file(coverpath, source,
+                                                      lnotab, count, encoding)
+            if summary and n_lines:
+                percent = int(100 * n_hits / n_lines)
+                sums[modulename] = n_lines, percent, modulename, filename
 
 
         if summary and sums:

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -324,14 +324,14 @@ class CoverageResults:
                     outfile.write("%5d: " % lines_hit[lineno])
                     n_hits += 1
                     n_lines += 1
-                elif rx_blank.match(line):
-                    outfile.write("       ")
                 elif lineno in lnotab and not PRAGMA_NOCOVER in line:
                     # lines preceded by no marks weren't hit
                     # Highlight them if so indicated, unless the line contains
                     # #pragma: NO COVER
                     outfile.write(">>>>>> ")
                     n_lines += 1
+                elif rx_blank.match(line):
+                    outfile.write("       ")
                 else:
                     outfile.write("       ")
                 outfile.write(line.expandtabs(8))

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -73,9 +73,6 @@ def _unsettrace():
 
 PRAGMA_NOCOVER = "#pragma NO COVER"
 
-# Simple rx to find lines with no code.
-rx_blank = re.compile(r'^\s*(#.*)?$')
-
 class _Ignore:
     def __init__(self, modules=None, dirs=None):
         self._mods = set() if not modules else set(modules)

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -326,15 +326,14 @@ class CoverageResults:
                     n_lines += 1
                 elif rx_blank.match(line):
                     outfile.write("       ")
-                else:
+                elif lineno in lnotab and not PRAGMA_NOCOVER in line:
                     # lines preceded by no marks weren't hit
                     # Highlight them if so indicated, unless the line contains
                     # #pragma: NO COVER
-                    if lineno in lnotab and not PRAGMA_NOCOVER in line:
-                        outfile.write(">>>>>> ")
-                        n_lines += 1
-                    else:
-                        outfile.write("       ")
+                    outfile.write(">>>>>> ")
+                    n_lines += 1
+                else:
+                    outfile.write("       ")
                 outfile.write(line.expandtabs(8))
 
         return n_hits, n_lines

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -330,8 +330,6 @@ class CoverageResults:
                     # #pragma: NO COVER
                     outfile.write(">>>>>> ")
                     n_lines += 1
-                elif rx_blank.match(line):
-                    outfile.write("       ")
                 else:
                     outfile.write("       ")
                 outfile.write(line.expandtabs(8))

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -303,6 +303,7 @@ class CoverageResults:
 
     def write_results_file(self, path, lines, lnotab, lines_hit, encoding=None):
         """Return a coverage results file in path."""
+        # ``lnotab`` is a dict of executable lines, or a line number "table"
 
         try:
             outfile = open(path, "w", encoding=encoding)
@@ -322,8 +323,7 @@ class CoverageResults:
                     n_hits += 1
                     n_lines += 1
                 elif lineno in lnotab and not PRAGMA_NOCOVER in line:
-                    # lines preceded by no marks weren't hit
-                    # Highlight them if so indicated, unless the line contains
+                    # Highlight never-executed lines, unless the line contains
                     # #pragma: NO COVER
                     outfile.write(">>>>>> ")
                     n_lines += 1

--- a/Misc/NEWS.d/next/Library/2017-10-31.bpo-31908.g4xh8x.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-31.bpo-31908.g4xh8x.rst
@@ -1,0 +1,3 @@
+Fix output of cover files for ``trace`` module command-line tool.
+Previously emitted cover files only when ``--missing`` option was used.
+Patch by Michael Selik.


### PR DESCRIPTION
The `lnotab` variable -- a dict of executable lines -- is a helper for the `show_missing` parameter. When `show_missing` is false, we don't need to calculate that dict. However, emitting the cover files had been made conditional on that dict being non-empty in Commit f026dae130bf6f9015c4b212f16852ba4a3f3dec. This reverts part of the commit to ensure the cover files are emitted regardless of the `show_missing` argument.

Additionally, the `write_results_file` is refactored to clarify the purpose of `lnotab`.

<!-- issue-number: bpo-31908 -->
https://bugs.python.org/issue31908
<!-- /issue-number -->
