### PR TITLE
bpo-31910: Fix test_socket.test_create_connection()

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4533,6 +4533,10 @@ class NetworkConnectionNoServer(unittest.TestCase):
         expected_errnos = [ errno.ECONNREFUSED, ]
         if hasattr(errno, 'ENETUNREACH'):
             expected_errnos.append(errno.ENETUNREACH)
+        if hasattr(errno, 'EADDRNOTAVAIL'):
+            # bpo-31910: socket.create_connection() fails randomly
+            # with EADDRNOTAVAIL on Travis CI
+            expected_errnos.append(errno.EADDRNOTAVAIL)
 
         self.assertIn(cm.exception.errno, expected_errnos)
 


### PR DESCRIPTION
bpo-31910: test_create_connection() now catchs also EADDRNOTAVAIL to
fix the test on Travis CI.

<!-- issue-number: bpo-31910 -->
https://bugs.python.org/issue31910
<!-- /issue-number -->
