### PR TITLE
[2.7] bpo-31893: Fix a backporting error in 8cbf4e10646c3f5b8f0d274c2d7dea5bb6305f57.

### DIFF
--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1352,9 +1352,12 @@ kqueue_event_init(kqueue_event_Object *self, PyObject *args, PyObject *kwds)
     if (PyInt_Check(pfd)) {
         self->e.ident = PyInt_AsUnsignedLongMask(pfd);
     }
-    else {
-    if (PyInt_Check(pfd) || PyLong_Check(pfd)) {
-        self->e.ident = PyLong_AsSize_t(pfd);
+    else if (PyLong_Check(pfd)) {
+#if defined(HAVE_LONG_LONG) && (SIZEOF_UINTPTR_T == SIZEOF_LONG_LONG)
+        self->e.ident = PyLong_AsUnsignedLongLongMask(pfd);
+#else
+        self->e.ident = PyLong_AsUnsignedLongMask(pfd);
+#endif
     }
     else {
         self->e.ident = PyObject_AsFileDescriptor(pfd);


### PR DESCRIPTION


<!-- issue-number: bpo-31893 -->
https://bugs.python.org/issue31893
<!-- /issue-number -->
