### PR TITLE
bpo-27666: Fixed stack corruption in curses.box() and curses.ungetmouse().

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -92,7 +92,7 @@ class TestCurses(unittest.TestCase):
                 with self.subTest(meth=meth.__qualname__, args=args):
                     meth(*args)
 
-        for meth in [stdscr.box, stdscr.clear, stdscr.clrtobot,
+        for meth in [stdscr.clear, stdscr.clrtobot,
                      stdscr.clrtoeol, stdscr.cursyncup, stdscr.delch,
                      stdscr.deleteln, stdscr.erase, stdscr.getbegyx,
                      stdscr.getbkgd, stdscr.getkey, stdscr.getmaxyx,
@@ -125,6 +125,13 @@ class TestCurses(unittest.TestCase):
                                msg="Expected win.border() to raise TypeError"):
             win.border(65, 66, 67, 68,
                        69, [], 71, 72)
+
+        win.box(65, 67)
+        win.box('!', '_')
+        win.box(b':', b'~')
+        self.assertRaises(TypeError, win.box, 65, 66, 67)
+        self.assertRaises(TypeError, win.box, 65)
+        win.box()
 
         stdscr.clearok(1)
 

--- a/Misc/NEWS.d/next/Library/2017-11-01-18-13-42.bpo-27666.j2zRnF.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-01-18-13-42.bpo-27666.j2zRnF.rst
@@ -1,0 +1,3 @@
+Fixed stack corruption in curses.box() and curses.ungetmouse() when the size
+of types chtype or mmask_t is less than the size of C long.  curses.box()
+now accepts characters as arguments.  Based on patch by Steve Fink.


### PR DESCRIPTION


<!-- issue-number: bpo-27666 -->
https://bugs.python.org/issue27666
<!-- /issue-number -->
