### PR TITLE
bpo-31356: Add context manager to temporarily disable GC

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -33,6 +33,35 @@ The :mod:`gc` module provides the following functions:
    Disable automatic garbage collection.
 
 
+.. class:: Disabled()
+
+   Return a context manager object that disables the garbage collector and reenables the previous
+   state upon completion of the block.  
+   This is basically equivalent to::
+
+     from gc import enable, disable, isenabled
+
+     @contextmanager
+     def gc_disabled():
+         was_enabled_previously = isenabled()
+         gc.disable()
+         yield
+         if was_enabled_previously:
+             gc.enable()
+
+   And lets you write code like this::
+
+     with gc_disabled():
+         run_some_timing()
+
+     with gc_disabled():
+         # do_something_that_has_real_time_guarantees
+         # such as a pair trade, robotic braking, etc
+
+   without needing to explicitly enable and disable the garbage collector yourself. 
+   This context manager is implemented in C to assure atomicity, thread safety and speed.
+
+
 .. function:: isenabled()
 
    Returns true if automatic collection is enabled.

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -36,8 +36,7 @@ The :mod:`gc` module provides the following functions:
 .. class:: Disabled()
 
    Return a context manager object that disables the garbage collector and reenables the previous
-   state upon completion of the block.  
-   This is basically equivalent to::
+   state upon completion of the block. This is basically equivalent to::
 
      from gc import enable, disable, isenabled
 
@@ -58,7 +57,7 @@ The :mod:`gc` module provides the following functions:
          # do_something_that_has_real_time_guarantees
          # such as a pair trade, robotic braking, etc
 
-   without needing to explicitly enable and disable the garbage collector yourself. 
+   without needing to explicitly enable and disable the garbage collector yourself.
    This context manager is implemented in C to assure atomicity, thread safety and speed.
 
 

--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -33,7 +33,7 @@ The :mod:`gc` module provides the following functions:
    Disable automatic garbage collection.
 
 
-.. class:: Disabled()
+.. class:: ensure_disabled()
 
    Return a context manager object that disables the garbage collector and reenables the previous
    state upon completion of the block. This is basically equivalent to::
@@ -41,7 +41,7 @@ The :mod:`gc` module provides the following functions:
      from gc import enable, disable, isenabled
 
      @contextmanager
-     def gc_disabled():
+     def ensure_disabled():
          was_enabled_previously = isenabled()
          gc.disable()
          yield
@@ -50,10 +50,10 @@ The :mod:`gc` module provides the following functions:
 
    And lets you write code like this::
 
-     with gc_disabled():
+     with ensure_disabled():
          run_some_timing()
 
-     with gc_disabled():
+     with ensure_disabled():
          # do_something_that_has_real_time_guarantees
          # such as a pair trade, robotic braking, etc
 

--- a/Include/internal/mem.h
+++ b/Include/internal/mem.h
@@ -164,6 +164,7 @@ struct _gc_runtime_state {
 
     int enabled;
     int debug;
+    long disabled_threads;
     /* linked lists of container objects */
     struct gc_generation generations[NUM_GENERATIONS];
     PyGC_Head *generation0;

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1007,10 +1007,10 @@ class GCTogglingTests(unittest.TestCase):
             # empty __dict__.
             self.assertEqual(x, None)
 
-    def test_Disabled(self):
+    def test_ensure_disabled(self):
         original_status = gc.isenabled()
 
-        with gc.Disabled():
+        with gc.ensure_disabled():
             inside_status = gc.isenabled()
 
         after_status = gc.isenabled()
@@ -1018,12 +1018,12 @@ class GCTogglingTests(unittest.TestCase):
         self.assertEqual(inside_status, False)
         self.assertEqual(after_status, True)
 
-    def test_Disabled_with_gc_disabled(self):
+    def test_ensure_disabled_with_gc_disabled(self):
         gc.disable()
 
         original_status = gc.isenabled()
 
-        with gc.Disabled():
+        with gc.ensure_disabled():
             inside_status = gc.isenabled()
 
         after_status = gc.isenabled()
@@ -1032,7 +1032,7 @@ class GCTogglingTests(unittest.TestCase):
         self.assertEqual(after_status, False)
 
     @reap_threads
-    def test_Disabled_thread(self):
+    def test_ensure_disabled_thread(self):
 
         thread_original_status = None
         thread_inside_status = None
@@ -1044,15 +1044,14 @@ class GCTogglingTests(unittest.TestCase):
             nonlocal thread_after_status
             thread_original_status = gc.isenabled()
 
-            with gc.Disabled():
+            with gc.ensure_disabled():
                 thread_inside_status = gc.isenabled()
 
             thread_after_status = gc.isenabled()
-            print(thread_after_status)
 
         original_status = gc.isenabled()
 
-        with gc.Disabled():
+        with gc.ensure_disabled():
             inside_status_before_thread = gc.isenabled()
             thread = threading.Thread(target=disabling_thread)
             thread.start()

--- a/Lib/test/test_gc.py
+++ b/Lib/test/test_gc.py
@@ -1014,9 +1014,22 @@ class GCTogglingTests(unittest.TestCase):
             inside_status = gc.isenabled()
 
         after_status = gc.isenabled()
-        self.assertEqual(original_status,True)
-        self.assertEqual(inside_status,False)
-        self.assertEqual(after_status,True)
+        self.assertEqual(original_status, True)
+        self.assertEqual(inside_status, False)
+        self.assertEqual(after_status, True)
+
+    def test_Disabled_with_gc_disabled(self):
+        gc.disable()
+
+        original_status = gc.isenabled()
+
+        with gc.Disabled():
+            inside_status = gc.isenabled()
+
+        after_status = gc.isenabled()
+        self.assertEqual(original_status, False)
+        self.assertEqual(inside_status, False)
+        self.assertEqual(after_status, False)
 
     @reap_threads
     def test_Disabled_thread(self):
@@ -1048,13 +1061,13 @@ class GCTogglingTests(unittest.TestCase):
 
         after_status = gc.isenabled()
 
-        self.assertEqual(original_status,True)
-        self.assertEqual(inside_status_before_thread,False)
-        self.assertEqual(thread_original_status,False)
-        self.assertEqual(thread_inside_status,False)
-        self.assertEqual(thread_after_status,False)
-        self.assertEqual(inside_status_after_thread,False)
-        self.assertEqual(after_status,True)
+        self.assertEqual(original_status, True)
+        self.assertEqual(inside_status_before_thread, False)
+        self.assertEqual(thread_original_status, False)
+        self.assertEqual(thread_inside_status, False)
+        self.assertEqual(thread_after_status, False)
+        self.assertEqual(inside_status_after_thread, False)
+        self.assertEqual(after_status, True)
 
 
 def test_main():

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-02-00-34-42.bpo-31356.54Lb8U.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-02-00-34-42.bpo-31356.54Lb8U.rst
@@ -1,0 +1,3 @@
+Add a new contextmanager to the gc module that temporarily disables the GC
+and restores the previous state. The implementation is done in C to assure
+atomicity and speed.

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1547,7 +1547,7 @@ static struct PyMethodDef disabled_object_methods[] = {
 };
 
 static PyObject *
-new_thing(PyTypeObject *type, PyObject *args, PyObject *kwdict){
+new_disabled_obj(PyTypeObject *type, PyObject *args, PyObject *kwdict){
     disabled_object *self;
     self = (disabled_object *)type->tp_alloc(type, 0);
     return (PyObject *) self;
@@ -1592,7 +1592,7 @@ static PyTypeObject gc_disabled_type = {
     0,                                          /* tp_dictoffset */
     0,                                          /* tp_init */
     PyType_GenericAlloc,                        /* tp_alloc */
-    new_thing,                                  /* tp_new */
+    new_disabled_obj,                           /* tp_new */
     PyObject_Del,                               /* tp_free */
 };
 

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1510,11 +1510,11 @@ typedef struct {
     PyObject_HEAD
     int previous_gc_state;
     PyGILState_STATE gstate;
-} disabled_object;
+} ensure_disabled_object;
 
 
 static void
-disabled_object_dealloc(disabled_object *m_obj)
+ensure_disabled_object_dealloc(ensure_disabled_object *m_obj)
 {
     Py_TYPE(m_obj)->tp_free((PyObject*)m_obj);
 }
@@ -1522,7 +1522,7 @@ disabled_object_dealloc(disabled_object *m_obj)
 
 
 static PyObject *
-disabled__enter__method(disabled_object *self, PyObject *args)
+ensure_disabled__enter__method(ensure_disabled_object *self, PyObject *args)
 {
     self->gstate = PyGILState_Ensure();
     self->previous_gc_state = _PyRuntime.gc.enabled;
@@ -1531,7 +1531,7 @@ disabled__enter__method(disabled_object *self, PyObject *args)
 }
 
 static PyObject *
-disabled__exit__method(disabled_object *self, PyObject *args)
+ensure_disabled__exit__method(ensure_disabled_object *self, PyObject *args)
 {
     _PyRuntime.gc.enabled = self->previous_gc_state;
     PyGILState_Release(self->gstate);
@@ -1540,26 +1540,26 @@ disabled__exit__method(disabled_object *self, PyObject *args)
 
 
 
-static struct PyMethodDef disabled_object_methods[] = {
-    {"__enter__",       (PyCFunction) disabled__enter__method,      METH_NOARGS},
-    {"__exit__",        (PyCFunction) disabled__exit__method,       METH_VARARGS},
+static struct PyMethodDef ensure_disabled_object_methods[] = {
+    {"__enter__",       (PyCFunction) ensure_disabled__enter__method,      METH_NOARGS},
+    {"__exit__",        (PyCFunction) ensure_disabled__exit__method,       METH_VARARGS},
     {NULL,         NULL}       /* sentinel */
 };
 
 static PyObject *
 new_disabled_obj(PyTypeObject *type, PyObject *args, PyObject *kwdict){
-    disabled_object *self;
-    self = (disabled_object *)type->tp_alloc(type, 0);
+    ensure_disabled_object *self;
+    self = (ensure_disabled_object *)type->tp_alloc(type, 0);
     return (PyObject *) self;
 };
 
-static PyTypeObject gc_disabled_type = {
+static PyTypeObject gc_ensure_disabled_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
-    "gc.disabled",                              /* tp_name */
-    sizeof(disabled_object),                    /* tp_size */
+    "gc.ensure_disabled",                       /* tp_name */
+    sizeof(ensure_disabled_object),             /* tp_size */
     0,                                          /* tp_itemsize */
     /* methods */
-    (destructor) disabled_object_dealloc,       /* tp_dealloc */
+    (destructor) ensure_disabled_object_dealloc,/* tp_dealloc */
     0,                                          /* tp_print */
     0,                                          /* tp_getattr */
     0,                                          /* tp_setattr */
@@ -1582,7 +1582,7 @@ static PyTypeObject gc_disabled_type = {
     0,                                          /* tp_weaklistoffset */
     0,                                          /* tp_iter */
     0,                                          /* tp_iternext */
-    disabled_object_methods,                    /* tp_methods */
+    ensure_disabled_object_methods,             /* tp_methods */
     0,                                          /* tp_members */
     0,                                          /* tp_getset */
     0,                                          /* tp_base */
@@ -1637,9 +1637,9 @@ PyInit_gc(void)
     if (PyModule_AddObject(m, "callbacks", _PyRuntime.gc.callbacks) < 0)
         return NULL;
 
-    if (PyType_Ready(&gc_disabled_type) < 0)
+    if (PyType_Ready(&gc_ensure_disabled_type) < 0)
         return NULL;
-    if (PyModule_AddObject(m, "Disabled", (PyObject*) &gc_disabled_type) < 0)
+    if (PyModule_AddObject(m, "ensure_disabled", (PyObject*) &gc_ensure_disabled_type) < 0)
         return NULL;
 
 


### PR DESCRIPTION
As discussed in [the issue](https://bugs.python.org/issue31356) by @serhiy-storchaka , @rhettinger , @ncoghlan and @gpshead this PR implements a context manager that temporarily disables GC and restores it to its previous state. The implementation is done in C, using the GIL as the locking mechanism to evict the thread problems discussed in the issue.

The documentation is updated as well as the test suite to take this into account.

Please, indicate any change that is needed and I will be more than happy to change it. :smile:

<!-- issue-number: bpo-31356 -->
https://bugs.python.org/issue31356
<!-- /issue-number -->
