### PR TITLE
bpo-31920: Fix pygettext directory walk

### DIFF
--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -259,24 +259,6 @@ def containsAny(str, set):
     return 1 in [c in str for c in set]
 
 
-def _visit_pyfiles(list, dirname, names):
-    """Helper for getFilesForName()."""
-    # get extension for python source files
-    if '_py_ext' not in globals():
-        global _py_ext
-        _py_ext = importlib.machinery.SOURCE_SUFFIXES[0]
-
-    # don't recurse into CVS directories
-    if 'CVS' in names:
-        names.remove('CVS')
-
-    # add all *.py files to list
-    list.extend(
-        [os.path.join(dirname, file) for file in names
-         if os.path.splitext(file)[1] == _py_ext]
-        )
-
-
 def getFilesForName(name):
     """Get a list of module files for a filename, a module or package name,
     or a directory.
@@ -302,8 +284,17 @@ def getFilesForName(name):
     if os.path.isdir(name):
         # find all python files in directory
         list = []
+        # get extension for python source files
+        _py_ext = importlib.machinery.SOURCE_SUFFIXES[0]
         for root, dirs, files in os.walk(name):
-            _visit_pyfiles(list, root, dirs + files)
+            # don't recurse into CVS directories
+            if 'CVS' in dirs:
+                dirs.remove('CVS')
+            # add all *.py files to list
+            list.extend(
+                [os.path.join(root, file) for file in files
+                 if os.path.splitext(file)[1] == _py_ext]
+                )
         return list
     elif os.path.exists(name):
         # a single file

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -302,7 +302,8 @@ def getFilesForName(name):
     if os.path.isdir(name):
         # find all python files in directory
         list = []
-        os.walk(name, _visit_pyfiles, list)
+        for root, dirs, files in os.walk(name):
+            _visit_pyfiles(list, root, dirs + files)
         return list
     elif os.path.exists(name):
         # a single file


### PR DESCRIPTION
Can be backported to >=3.4 I think.

<!-- issue-number: bpo-31920 -->
https://bugs.python.org/issue31920
<!-- /issue-number -->
