### PR TITLE
bpo-31921: Pull logic for entering/leaving a frame into frameobject.c

### DIFF
--- a/Include/frameobject.h
+++ b/Include/frameobject.h
@@ -57,8 +57,12 @@ PyAPI_FUNC(PyFrameObject *) PyFrame_New(PyThreadState *, PyCodeObject *,
                                         PyObject *, PyObject *);
 
 /* only internal use */
-PyFrameObject* _PyFrame_New_NoTrack(PyThreadState *, PyCodeObject *,
-                                    PyObject *, PyObject *);
+PyFrameObject* _PyFrame_Enter_New(PyThreadState *, PyCodeObject *,
+                                  PyObject *, PyObject *);
+void _PyFrame_Enter(PyThreadState *tstate, PyFrameObject *f);
+/* This must match the prototype in pystate.c */
+void _PyFrame_Leave(PyThreadState *tstate, PyFrameObject *f);
+
 
 
 /* The rest of the interface is specific for frame objects */

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-02-10-12-05.bpo-31921.2qVlYP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-02-10-12-05.bpo-31921.2qVlYP.rst
@@ -1,0 +1,2 @@
+Standardize frame entry and exit. New internal functions _PyFrame_Enter,
+_PyFrame_Leave. Renamed _PyFrame_New_NoTrack to _PyFrame_Enter_New.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -264,12 +264,8 @@ function_code_fastcall(PyCodeObject *co, PyObject **args, Py_ssize_t nargs,
     PyObject *result;
 
     assert(globals != NULL);
-    /* XXX Perhaps we should create a specialized
-       _PyFrame_New_NoTrack() that doesn't take locals, but does
-       take builtins without sanity checking them.
-       */
     assert(tstate != NULL);
-    f = _PyFrame_New_NoTrack(tstate, co, globals, NULL);
+    f = _PyFrame_Enter_New(tstate, co, globals, NULL);
     if (f == NULL) {
         return NULL;
     }
@@ -281,16 +277,7 @@ function_code_fastcall(PyCodeObject *co, PyObject **args, Py_ssize_t nargs,
         fastlocals[i] = *args++;
     }
     result = PyEval_EvalFrameEx(f,0);
-
-    if (Py_REFCNT(f) > 1) {
-        Py_DECREF(f);
-        _PyObject_GC_TRACK(f);
-    }
-    else {
-        ++tstate->recursion_depth;
-        Py_DECREF(f);
-        --tstate->recursion_depth;
-    }
+    _PyFrame_Leave(tstate, f);
     return result;
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -431,6 +431,9 @@ _PyState_ClearModules(void)
     }
 }
 
+/* This must match the prototype in frameobject.h */
+void _PyFrame_Leave(PyThreadState *tstate, struct _frame *f);
+
 void
 PyThreadState_Clear(PyThreadState *tstate)
 {
@@ -438,7 +441,9 @@ PyThreadState_Clear(PyThreadState *tstate)
         fprintf(stderr,
           "PyThreadState_Clear: warning: thread still has a frame\n");
 
-    Py_CLEAR(tstate->frame);
+    while (tstate->frame) {
+        _PyFrame_Leave(tstate, tstate->frame);
+    }
 
     Py_CLEAR(tstate->dict);
     Py_CLEAR(tstate->async_exc);


### PR DESCRIPTION
Add new functions _PyFrame_Enter and _PyFrame_Leave for entering and leaving a frame.

Rename _PyFrame_New_NoTrack to _PyFrame_Enter_New, to communicate that it both creates a frame and enters it.

<!-- issue-number: bpo-31921 -->
https://bugs.python.org/issue31921
<!-- /issue-number -->
