### PR TITLE
bpo-31923: Fix spelling in sqlite3 docs

### DIFF
--- a/Doc/includes/sqlite3/load_extension.py
+++ b/Doc/includes/sqlite3/load_extension.py
@@ -11,7 +11,7 @@ con.execute("select load_extension('./fts3.so')")
 # alternatively you can load the extension using an API call:
 # con.load_extension("./fts3.so")
 
-# disable extension laoding again
+# disable extension loading again
 con.enable_load_extension(False)
 
 # example from SQLite wiki


### PR DESCRIPTION
"loading" was misspelled as "laoding"

<!-- issue-number: bpo-31923 -->
https://bugs.python.org/issue31923
<!-- /issue-number -->
