### PR TITLE
bpo-31924: Fix test_curses on NetBSD 8.

### DIFF
--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -330,7 +330,8 @@ class TestCurses(unittest.TestCase):
 
     @requires_curses_func('panel')
     def test_userptr_segfault(self):
-        panel = curses.panel.new_panel(self.stdscr)
+        w = curses.newwin(10, 10)
+        panel = curses.panel.new_panel(w)
         class A:
             def __del__(self):
                 panel.set_userptr(None)
@@ -339,7 +340,8 @@ class TestCurses(unittest.TestCase):
 
     @requires_curses_func('panel')
     def test_new_curses_panel(self):
-        panel = curses.panel.new_panel(self.stdscr)
+        w = curses.newwin(10, 10)
+        panel = curses.panel.new_panel(w)
         self.assertRaises(TypeError, type(panel))
 
     @requires_curses_func('is_term_resized')


### PR DESCRIPTION


<!-- issue-number: bpo-31924 -->
https://bugs.python.org/issue31924
<!-- /issue-number -->
