### PR TITLE
[3.6] Returning 1 from the set_progress_handler handler cancels query (GH-4120)

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -421,6 +421,10 @@ Connection Objects
       If you want to clear any previously installed progress handler, call the
       method with :const:`None` for *handler*.
 
+      Returning a non-zero value from the handler function will terminate the
+      currently executing query and cause it to raise an :exc:`OperationalError`
+      exception.
+
 
    .. method:: set_trace_callback(trace_callback)
 


### PR DESCRIPTION
(cherry picked from commit ac03c03b305273f39d5374e2826526d4ab6bb415)