### PR TITLE
bpo-31415: Support PYTHONPROFILEIMPORTTIME envvar equivalent to -X importtime

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -411,7 +411,8 @@ Miscellaneous options
    * ``-X importtime`` to show how long each import takes. It shows module name,
      cumulative time (including nested imports) and self time (exluding nested
      imports).  Note that its output may be broken in multi threaded application.
-     Typical usage is ``python3 -X importtime -c 'import asyncio'``.
+     Typical usage is ``python3 -X importtime -c 'import asyncio'``.  See also
+     :envvar:`PYTHONPROFILEIMPORTTIME`.
 
    It also allows passing arbitrary values and retrieving them through the
    :data:`sys._xoptions` dictionary.
@@ -429,7 +430,7 @@ Miscellaneous options
       The ``-X showalloccount`` option.
 
    .. versionadded:: 3.7
-      The ``-X importtime`` option.
+      The ``-X importtime`` and :envvar:`PYTHONPROFILEIMPORTTIME` options.
 
 
 Options you shouldn't use
@@ -648,6 +649,15 @@ conflict.
    frame. See the :func:`tracemalloc.start` for more information.
 
    .. versionadded:: 3.4
+
+
+.. envvar:: PYTHONPROFILEIMPORTTIME
+
+   If thjis environment variable is set to a non-empty string, Python will
+   show how long each import takes.  This is exactly equivalent to setting
+   ``-X importtime`` on the command line.
+
+   .. versionadded:: 3.7
 
 
 .. envvar:: PYTHONASYNCIODEBUG

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -653,7 +653,7 @@ conflict.
 
 .. envvar:: PYTHONPROFILEIMPORTTIME
 
-   If thjis environment variable is set to a non-empty string, Python will
+   If this environment variable is set to a non-empty string, Python will
    show how long each import takes.  This is exactly equivalent to setting
    ``-X importtime`` on the command line.
 

--- a/Misc/NEWS.d/3.7.0a2.rst
+++ b/Misc/NEWS.d/3.7.0a2.rst
@@ -166,7 +166,8 @@ special method lookups.  Patch by Stefan Behnel.
 .. section: Core and Builtins
 
 Add ``-X importtime`` option to show how long each import takes. It can be
-used to optimize application's startup time.
+used to optimize application's startup time.  Support the
+:envvar:`PYTHONPROFILEIMPORTTIME` as an equivalent way to enable this.
 
 ..
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -1682,10 +1682,17 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
          * _PyDict_GetItemId()
          */
         if (ximporttime == 0) {
-            PyObject *xoptions = PySys_GetXOptions();
-            if (xoptions) {
-                PyObject *value = _PyDict_GetItemId(xoptions, &PyId_importtime);
-                ximporttime = (value == Py_True);
+            char *envoption = Py_GETENV("PYTHONPROFILEIMPORTTIME");
+            if (envoption != NULL && strlen(envoption) > 0) {
+                ximporttime = 1;
+            }
+            else {
+                PyObject *xoptions = PySys_GetXOptions();
+                if (xoptions) {
+                    PyObject *value = _PyDict_GetItemId(
+                        xoptions, &PyId_importtime);
+                    ximporttime = (value == Py_True);
+                }
             }
             if (ximporttime) {
                 fputs("import time: self [us] | cumulative | imported package\n",


### PR DESCRIPTION
bpo-31415

This is an enhancement to the above issue which adds `PYTHONPROFILEIMPORTTIME` environment variable.  I'll comment on the issue as to the use case.

<!-- issue-number: bpo-31415 -->
https://bugs.python.org/issue31415
<!-- /issue-number -->
