### PR TITLE
gh-66477: ENH add introspection API for concurrent.futures Executor

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -115,10 +115,13 @@ Executor Objects
              which are currently being processed by the executor. The WorkItem
              object is a container holding the function *fn*, its arguments
              *args* and *kwargs* and the associated :class:`Future` in *future*.
-           - `waiting_tasks`:  a dictionary with WorkItems representing the
+           - `waiting_tasks`: a dictionary with WorkItems representing the
              tasks waiting to be processed by the executor. The WorkItem object
              is a container holding the function *fn*, its arguments *args* and
              *kwargs* and the associated :class:`Future` in *future*.
+           - `status`: a string holding the status of the executor. It can be
+             one of {"not_started", "running", "broken", "shutting_down",
+             "shutdown"}.
 
        .. versionchanged:: 3.7
           Added the *stat* method.

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -94,6 +94,73 @@ Executor Objects
               e.submit(shutil.copy, 'src3.txt', 'dest3.txt')
               e.submit(shutil.copy, 'src4.txt', 'dest4.txt')
 
+   The following :class:`Executor` methods are meant for use to introspect the
+   state of the :class:`Executor` and the tasks processed by it.
+
+    .. method:: worker_count()
+
+       Return the actual number of workers in the executor.
+
+       .. versionchanged:: 3.7
+          Added the *worker_count* method.
+
+    .. method:: active_worker_count()
+
+       Return the number of workers currently running a task in the executor.
+
+       .. versionchanged:: 3.7
+          Added the *active_worker_count* method.
+
+    .. method:: idle_worker_count()
+
+       Return the number of workers currently waiting for a new task to be
+       submitted to the executor.
+
+       .. versionchanged:: 3.7
+          Added the *idle_worker_count* method.
+
+    .. method:: task_count()
+
+       Return the number of task pending for the executor.
+
+       .. versionchanged:: 3.7
+          Added the *task_count* method.
+
+    .. method:: active_task_count()
+
+       Return the number of task which are currently being processed by the
+       executor.
+
+       .. versionchanged:: 3.7
+          Added the *active_task_count* method.
+
+    .. method:: waiting_task_count()
+
+       Return the number of task waiting to be processed by the executor.
+
+       .. versionchanged:: 3.7
+          Added the *waiting_task_count* method.
+
+    .. method:: active_tasks()
+
+       Return a dictionary with WorkItems representing the tasks which are
+       currently being processed by the executor. The WorkItem object is a
+       container holding the function *fn*, its arguments *args* and *kwargs*
+       and the associated :class:`Future` in *future*.
+
+       .. versionchanged:: 3.7
+          Added the *active_tasks* method.
+
+    .. method:: waiting_tasks()
+
+       Return a dictionary with WorkItems representing the tasks waiting to be
+       processed by the executor. The WorkItem object is a container holding
+       the function *fn*, its arguments *args* and *kwargs* and the associated
+       :class:`Future` in *future*.
+
+       .. versionchanged:: 3.7
+          Added the *waiting_tasks* method.
+
 
 ThreadPoolExecutor
 ------------------

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -94,72 +94,34 @@ Executor Objects
               e.submit(shutil.copy, 'src3.txt', 'dest3.txt')
               e.submit(shutil.copy, 'src4.txt', 'dest4.txt')
 
-   The following :class:`Executor` methods are meant for use to introspect the
-   state of the :class:`Executor` and the tasks processed by it.
+    .. method:: stat()
 
-    .. method:: worker_count()
 
-       Return the actual number of workers in the executor.
+       The following method is meant to introspect the state of the
+       :class:`Executor` and the tasks processed by it. It returns a dictionary
+       containing the following keys:
 
-       .. versionchanged:: 3.7
-          Added the *worker_count* method.
-
-    .. method:: active_worker_count()
-
-       Return the number of workers currently running a task in the executor.
-
-       .. versionchanged:: 3.7
-          Added the *active_worker_count* method.
-
-    .. method:: idle_worker_count()
-
-       Return the number of workers currently waiting for a new task to be
-       submitted to the executor.
-
-       .. versionchanged:: 3.7
-          Added the *idle_worker_count* method.
-
-    .. method:: task_count()
-
-       Return the number of task pending for the executor.
+           - `worker_count`: actual number of workers in the executor.
+           - `active_worker_count`: number of workers currently running a task
+             in the executor.
+           - `idle_worker_count`: number of workers currently waiting for a new
+             task to be submitted to the executor.
+           - `task_count`: number of task pending for the executor.
+           - `active_task_count`: number of task which are currently being
+             processed by the executor.
+           - `waiting_task_count`: number of task waiting to be processed by
+             the executor.
+           - `active_tasks`: a dictionary with WorkItems representing the tasks
+             which are currently being processed by the executor. The WorkItem
+             object is a container holding the function *fn*, its arguments
+             *args* and *kwargs* and the associated :class:`Future` in *future*.
+           - `waiting_tasks`:  a dictionary with WorkItems representing the
+             tasks waiting to be processed by the executor. The WorkItem object
+             is a container holding the function *fn*, its arguments *args* and
+             *kwargs* and the associated :class:`Future` in *future*.
 
        .. versionchanged:: 3.7
-          Added the *task_count* method.
-
-    .. method:: active_task_count()
-
-       Return the number of task which are currently being processed by the
-       executor.
-
-       .. versionchanged:: 3.7
-          Added the *active_task_count* method.
-
-    .. method:: waiting_task_count()
-
-       Return the number of task waiting to be processed by the executor.
-
-       .. versionchanged:: 3.7
-          Added the *waiting_task_count* method.
-
-    .. method:: active_tasks()
-
-       Return a dictionary with WorkItems representing the tasks which are
-       currently being processed by the executor. The WorkItem object is a
-       container holding the function *fn*, its arguments *args* and *kwargs*
-       and the associated :class:`Future` in *future*.
-
-       .. versionchanged:: 3.7
-          Added the *active_tasks* method.
-
-    .. method:: waiting_tasks()
-
-       Return a dictionary with WorkItems representing the tasks waiting to be
-       processed by the executor. The WorkItem object is a container holding
-       the function *fn*, its arguments *args* and *kwargs* and the associated
-       :class:`Future` in *future*.
-
-       .. versionchanged:: 3.7
-          Added the *waiting_tasks* method.
+          Added the *stat* method.
 
 
 ThreadPoolExecutor

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -620,28 +620,7 @@ class Executor(object):
         """
         pass
 
-    def worker_count(self):
-        raise NotImplementedError()
-
-    def active_worker_count(self):
-        raise NotImplementedError()
-
-    def idle_worker_count(self):
-        raise NotImplementedError()
-
-    def task_count(self):
-        raise NotImplementedError()
-
-    def active_task_count(self):
-        raise NotImplementedError()
-
-    def waiting_task_count(self):
-        raise NotImplementedError()
-
-    def active_tasks(self):
-        raise NotImplementedError()
-
-    def waiting_tasks(self):
+    def stat(self):
         raise NotImplementedError()
 
     def __enter__(self):

--- a/Lib/concurrent/futures/_base.py
+++ b/Lib/concurrent/futures/_base.py
@@ -306,6 +306,22 @@ def wait(fs, timeout=None, return_when=ALL_COMPLETED):
     done.update(waiter.finished_futures)
     return DoneAndNotDoneFutures(done, set(fs) - done)
 
+
+class _WorkItem(object):
+    def __init__(self, future, fn, args, kwargs):
+        self.future = future
+        self.fn = fn
+        self.args = args
+        self.kwargs = kwargs
+
+    def __str__(self):
+        return repr(self)
+
+    def __repr__(self):
+        return "<WorkItem: {} args: {} kwargs: {}>".format(self.fn, self.args,
+                                                           self.kwargs)
+
+
 class Future(object):
     """Represents the result of an asynchronous computation."""
 
@@ -603,6 +619,30 @@ class Executor(object):
                 executor have been reclaimed.
         """
         pass
+
+    def worker_count(self):
+        raise NotImplementedError()
+
+    def active_worker_count(self):
+        raise NotImplementedError()
+
+    def idle_worker_count(self):
+        raise NotImplementedError()
+
+    def task_count(self):
+        raise NotImplementedError()
+
+    def active_task_count(self):
+        raise NotImplementedError()
+
+    def waiting_task_count(self):
+        raise NotImplementedError()
+
+    def active_tasks(self):
+        raise NotImplementedError()
+
+    def waiting_tasks(self):
+        raise NotImplementedError()
 
     def __enter__(self):
         return self

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -41,13 +41,7 @@ def _python_exit():
 
 atexit.register(_python_exit)
 
-
-class _WorkItem(object):
-    def __init__(self, future, fn, args, kwargs):
-        self.future = future
-        self.fn = fn
-        self.args = args
-        self.kwargs = kwargs
+class _WorkItem(_base._WorkItem):
 
     def run(self):
         if not self.future.set_running_or_notify_cancel():
@@ -63,36 +57,48 @@ class _WorkItem(object):
             self.future.set_result(result)
 
 
-def _worker(executor_reference, work_queue, initializer, initargs):
-    if initializer is not None:
-        try:
-            initializer(*initargs)
-        except BaseException:
-            _base.LOGGER.critical('Exception in initializer:', exc_info=True)
-            executor = executor_reference()
-            if executor is not None:
-                executor._initializer_failed()
-            return
-    try:
-        while True:
-            work_item = work_queue.get(block=True)
-            if work_item is not None:
-                work_item.run()
-                # Delete references to object. See issue16284
-                del work_item
-                continue
-            executor = executor_reference()
-            # Exit if:
-            #   - The interpreter is shutting down OR
-            #   - The executor that owns the worker has been collected OR
-            #   - The executor that owns the worker has been shutdown.
-            if _shutdown or executor is None or executor._shutdown:
-                # Notice other workers
-                work_queue.put(None)
+class _Worker(threading.Thread):
+    """Worker Thread for ThreadPoolExecutor --used for introspection"""
+    def __init__(self, executor_reference, work_queue, initializer, initargs,
+                 name):
+        super().__init__(name=name)
+        self._executor_reference = executor_reference
+        self._work_queue = work_queue
+        self._initializer = initializer
+        self._initargs = initargs
+        self._work_item = None
+
+    def run(self):
+        if self._initializer is not None:
+            try:
+                self._initializer(*self._initargs)
+            except BaseException:
+                _base.LOGGER.critical('Exception in initializer:',
+                                      exc_info=True)
+                executor = self._executor_reference()
+                if executor is not None:
+                    executor._initializer_failed()
                 return
-            del executor
-    except BaseException:
-        _base.LOGGER.critical('Exception in worker', exc_info=True)
+        try:
+            while True:
+                self._work_item = self._work_queue.get(block=True)
+                if self._work_item is not None:
+                    self._work_item.run()
+                    # Delete references to object. See issue16284
+                    self._work_item = None
+                    continue
+                executor = self._executor_reference()
+                # Exit if:
+                #   - The interpreter is shutting down OR
+                #   - The executor that owns the worker has been collected OR
+                #   - The executor that owns the worker has been shutdown.
+                if _shutdown or executor is None or executor._shutdown:
+                    # Notice other workers
+                    self._work_queue.put(None)
+                    return
+                del executor
+        except BaseException:
+            _base.LOGGER.critical('Exception in worker', exc_info=True)
 
 
 class BrokenThreadPool(_base.BrokenExecutor):
@@ -154,22 +160,48 @@ class ThreadPoolExecutor(_base.Executor):
             return f
     submit.__doc__ = _base.Executor.submit.__doc__
 
+    def worker_count(self):
+        return len(self._threads)
+
+    def active_worker_count(self):
+        return self.active_task_count()
+
+    def idle_worker_count(self):
+        return self.worker_count() - self.active_worker_count()
+
+    def task_count(self):
+        return self.active_task_count() + self.waiting_task_count()
+
+    def active_task_count(self):
+        return sum(1 for t in self._threads if t._work_item)
+
+    def waiting_task_count(self):
+        return self._work_queue.qsize()
+
+    def active_tasks(self):
+        return set(t._work_item for t in self._threads
+                   if t._work_item)
+
+    def waiting_tasks(self):
+        active = self.active_tasks()
+        with self._work_queue.mutex:
+            return [task for task in self._work_queue.queue
+                    if task not in active]
+
     def _adjust_thread_count(self):
         # When the executor gets lost, the weakref callback will wake up
         # the worker threads.
         def weakref_cb(_, q=self._work_queue):
             q.put(None)
-        # TODO(bquinlan): Should avoid creating new threads if there are more
-        # idle threads than items in the work queue.
+        # Create a new thread if we're not at the max, and we
+        # don't have enough idle threads to handle pending tasks.
         num_threads = len(self._threads)
-        if num_threads < self._max_workers:
+        if (num_threads < self._max_workers and
+                self.idle_worker_count() < self._work_queue.qsize()):
             thread_name = '%s_%d' % (self._thread_name_prefix or self,
                                      num_threads)
-            t = threading.Thread(name=thread_name, target=_worker,
-                                 args=(weakref.ref(self, weakref_cb),
-                                       self._work_queue,
-                                       self._initializer,
-                                       self._initargs))
+            t = _Worker(weakref.ref(self, weakref_cb), self._work_queue,
+                        self._initializer, self._initargs, name=thread_name)
             t.daemon = True
             t.start()
             self._threads.add(t)

--- a/Misc/NEWS.d/next/Library/2017-11-09-15-36-01.bpo-22281.cA7VRH.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-09-15-36-01.bpo-22281.cA7VRH.rst
@@ -1,0 +1,1 @@
+Add introspection API for :class:`concurrent.futures.Executor`


### PR DESCRIPTION
This PR is building from the patch coming from the orignal issue (https://bugs.python.org/issue22281) [GH-66477] to add an introspection API for the `concurrent.futures` executors. The following methods are added:

* `worker_count()` : Total number of workers currently in the pool
* `active_worker_count()` : Number of workers currently processing a work item
* `idle_worker_count()`: Number of workers not processing a work item
---
* `task_count()`: Total number of tasks currently being handled by the pool
* `active_task_count()`: Number of tasks currently being processed by workers
* `waiting_task_count()`: Number of submitted tasks not yet being processed by a worker
---
* `active_tasks()`: A set of _WorkItem objects currently being processed by a worker.
* `waiting_tasks()`: A list of `_WorkItem` objects currently waiting to be processed by a worker.

The discussion in the orignal issue proposed to use properties instead of methods and to add a couple functionalities. I am up for inputs on that. I think a nice addition would be some indication of the work load in the `Executor`, by timing the idle time and active time of each tasks and collecting it.

<!-- issue-number: bpo-22281 -->
https://bugs.python.org/issue22281
<!-- /issue-number -->

<!-- gh-issue-number: gh-66477 -->
* Issue: gh-66477
<!-- /gh-issue-number -->
