### PR TITLE
[2.7] issue bpo-31932 Look for vcvarsall.bat under user AppData dir if not found elsewhere

### DIFF
--- a/Lib/distutils/msvc9compiler.py
+++ b/Lib/distutils/msvc9compiler.py
@@ -239,6 +239,10 @@ def find_vcvarsall(version):
             productdir = None
             log.debug("Unable to find productdir in registry")
 
+    # Trying MS python 2.7 tools in user home
+    if not productdir:
+        productdir = os.path.expanduser("~\AppData\Local\Programs\Common\Microsoft\Visual C++ for Python\9.0")
+
     if not productdir or not os.path.isdir(productdir):
         toolskey = "VS%0.f0COMNTOOLS" % version
         toolsdir = os.environ.get(toolskey, None)


### PR DESCRIPTION
Fix for issue 31932

Add a couple of extra lines to find_vcvarsall() in msvc9compiler.py to search under user AppData directory if cannot find VCVARSALL.BAT in system location.


<!-- issue-number: bpo-31932 -->
https://bugs.python.org/issue31932
<!-- /issue-number -->
