### PR TITLE
gh-75880: Deadlocks in `concurrent.futures.ProcessPoolExecutor` with unpickling error

### DIFF
--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -18,7 +18,7 @@ import threading
 import time
 import unittest
 import weakref
-from pickle import PicklingError
+from pickle import PicklingError, UnpicklingError
 
 from concurrent import futures
 from concurrent.futures._base import (
@@ -888,11 +888,12 @@ class ExecutorDeadlockTest:
         crash_cases = [
             # Check problem occuring while pickling a task in
             # the task_handler thread
-            (id, (ErrorAtPickle(),), PicklingError, "error at task pickle"),
+            (id, (ErrorAtPickle(),), PicklingError,
+             "error at task pickle"),
             # Check problem occuring while unpickling a task on workers
-            (id, (ExitAtUnpickle(),), BrokenProcessPool,
+            (id, (ExitAtUnpickle(),), SystemExit,
              "exit at task unpickle"),
-            (id, (ErrorAtUnpickle(),), BrokenProcessPool,
+            (id, (ErrorAtUnpickle(),), UnpicklingError,
              "error at task unpickle"),
             (id, (CrashAtUnpickle(),), BrokenProcessPool,
              "crash at task unpickle"),
@@ -913,9 +914,9 @@ class ExecutorDeadlockTest:
              "error during result pickle on worker"),
             # Check problem occuring while unpickling a task in
             # the result_handler thread
-            (_return_instance, (ErrorAtUnpickle,), BrokenProcessPool,
+            (_return_instance, (ErrorAtUnpickle,), UnpicklingError,
              "error during result unpickle in result_handler"),
-            (_return_instance, (ExitAtUnpickle,), BrokenProcessPool,
+            (_return_instance, (ExitAtUnpickle,), SystemExit,
              "exit during result unpickle in result_handler")
         ]
         for func, args, error, name in crash_cases:

--- a/Misc/NEWS.d/next/Library/2018-01-12-15-27-06.bpo-31699.l8g_ld.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-12-15-27-06.bpo-31699.l8g_ld.rst
@@ -1,0 +1,2 @@
+Fix :class:`concurrent.futures.ProcessPoolExecutor` so unpickling errors do
+not break the executor and are send back as errors on the faulty task.


### PR DESCRIPTION
When using `concurrent.futures.ProcessPoolExecutor` with objects that are not picklable or unpicklable, several situations results in a deadlock, with the interpreter frozen.

This is the case for different scenarios, for instance, https://gist.github.com/tomMoral/cc27a938d669edcf0286c57516942369. This PR is a follow up of #3895 and specifically fixes the unpickling behavior. With this PR, the unpickling failures do not result in broken executors. This is done by ensuring that the `_callItem` and the `_ResultItem` are sent in queues along the work_id with a specific communication protocol, which sends the `work_id` as bytes, followed by the object serialized by `pickle`.
To this end, we introduce private API in `multiprocessing.Queue` to allow modified serialization protocols.

Overall, the goal is to make `concurrent.futures.ProcessPoolExecutor` more robust to faulty user code.

This work was done as part of the tommoral/loky#48 with the intent to re-use the executor in multiple independent parts of the program, in collaboration with @ogrisel. See #1013 for more the details.



<!-- issue-number: [bpo-31699](https://bugs.python.org/issue31699) -->
https://bugs.python.org/issue31699
<!-- /issue-number -->


<!-- gh-issue-number: gh-75880 -->
* Issue: gh-75880
<!-- /gh-issue-number -->
