### PR TITLE
bpo-30057: Fix potential missed signal in signal.signal().

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -362,6 +362,7 @@ Vincent Delft
 Arnaud Delobelle
 Konrad Delong
 Erik Demaine
+Jeroen Demeyer
 Martin Dengler
 John Dennis
 L. Peter Deutsch

--- a/Misc/NEWS.d/next/Library/2017-11-03-19-11-43.bpo-30057.NCaijI.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-03-19-11-43.bpo-30057.NCaijI.rst
@@ -1,0 +1,1 @@
+Fix potential missed signal in signal.signal().

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -461,12 +461,15 @@ signal_signal_impl(PyObject *module, int signalnum, PyObject *handler)
     }
     else
         func = signal_handler;
+    /* Check for pending signals before changing signal handler */
+    if (PyErr_CheckSignals()) {
+        return NULL;
+    }
     if (PyOS_setsig(signalnum, func) == SIG_ERR) {
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
     old_handler = Handlers[signalnum].func;
-    _Py_atomic_store_relaxed(&Handlers[signalnum].tripped, 0);
     Py_INCREF(handler);
     Handlers[signalnum].func = handler;
     if (old_handler != NULL)


### PR DESCRIPTION
Bug report and patch by Jeroen Demeyer.


<!-- issue-number: bpo-30057 -->
https://bugs.python.org/issue30057
<!-- /issue-number -->
