### PR TITLE
[2.7] bpo-30057: Fix potential missed signal in signal.signal(). (GH-4258)

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -324,6 +324,7 @@ Vincent Delft
 Arnaud Delobelle
 Konrad Delong
 Erik Demaine
+Jeroen Demeyer
 Martin Dengler
 John Dennis
 L. Peter Deutsch

--- a/Misc/NEWS.d/next/Library/2017-11-03-19-11-43.bpo-30057.NCaijI.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-03-19-11-43.bpo-30057.NCaijI.rst
@@ -1,0 +1,1 @@
+Fix potential missed signal in signal.signal().

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -317,12 +317,15 @@ signal_signal(PyObject *self, PyObject *args)
     }
     else
         func = signal_handler;
+    /* Check for pending signals before changing signal handler */
+    if (PyErr_CheckSignals()) {
+        return NULL;
+    }
     if (PyOS_setsig(sig_num, func) == SIG_ERR) {
         PyErr_SetFromErrno(PyExc_RuntimeError);
         return NULL;
     }
     old_handler = Handlers[sig_num].func;
-    Handlers[sig_num].tripped = 0;
     Py_INCREF(obj);
     Handlers[sig_num].func = obj;
     if (old_handler != NULL)


### PR DESCRIPTION
Bug report and patch by Jeroen Demeyer.
(cherry picked from commit f6f90ff079a22b79a58d47b6117cc8a8c7d366f3)


<!-- issue-number: bpo-30057 -->
https://bugs.python.org/issue30057
<!-- /issue-number -->
