### PR TITLE
bpo-31940: Reject faulty lchown implementations

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-11-03-21-54-32.bpo-31940.fG1wnQ.rst
+++ b/Misc/NEWS.d/next/Build/2017-11-03-21-54-32.bpo-31940.fG1wnQ.rst
@@ -1,0 +1,2 @@
+Detect faulty ``lchmod`` implementation to fix ``shutil.copystat`` on alpine
+linux.  Patch by Anthony Sottile.

--- a/configure
+++ b/configure
@@ -11130,7 +11130,7 @@ for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  futimens futimes gai_strerror getentropy \
  getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \
  getpriority getresuid getresgid getpwent getspnam getspent getsid getwd \
- initgroups kill killpg lchmod lchown linkat lstat lutimes mmap \
+ initgroups kill killpg lchown linkat lstat lutimes mmap \
  memrchr mbrtowc mkdirat mkfifo \
  mkfifoat mknod mknodat mktime mremap nice openat pathconf pause pipe2 plock poll \
  posix_fallocate posix_fadvise pread \
@@ -11836,6 +11836,60 @@ if test "$ac_cv_have_lchflags" = yes ; then
 $as_echo "#define HAVE_LCHFLAGS 1" >>confdefs.h
 
 fi
+
+
+# on alpine, lchmod raises errno EOPNOTSUPP on symlinks
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for broken lchmod" >&5
+$as_echo_n "checking for broken lchmod... " >&6; }
+if ${ac_cv_have_lchmod+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  if test "$cross_compiling" = yes; then :
+  ac_cv_have_lchmod=cross
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <sys/stat.h>
+#include <unistd.h>
+int main(int argc, char*argv[])
+{
+  if (symlink(argv[0], "test"))
+    return 1;
+  if (lchmod("test", 0777))
+    return 1;
+  return 0;
+}
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+  ac_cv_have_lchmod=yes
+else
+  ac_cv_have_lchmod=no
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_have_lchmod" >&5
+$as_echo "$ac_cv_have_lchmod" >&6; }
+if test "$ac_cv_have_lchmod" = cross ; then
+  ac_fn_c_check_func "$LINENO" "lchmod" "ac_cv_func_lchmod"
+if test "x$ac_cv_func_lchmod" = xyes; then :
+  ac_cv_have_lchmod="yes"
+else
+  ac_cv_have_lchmod="no"
+fi
+
+fi
+if test "$ac_cv_have_lchmod" = yes ; then
+
+$as_echo "#define HAVE_LCHMOD 1" >>confdefs.h
+
+fi
+rm -f test
 
 case $ac_sys_system/$ac_sys_release in
 Darwin/*)

--- a/configure.ac
+++ b/configure.ac
@@ -3405,7 +3405,7 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  futimens futimes gai_strerror getentropy \
  getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \
  getpriority getresuid getresgid getpwent getspnam getspent getsid getwd \
- initgroups kill killpg lchmod lchown linkat lstat lutimes mmap \
+ initgroups kill killpg lchown linkat lstat lutimes mmap \
  memrchr mbrtowc mkdirat mkfifo \
  mkfifoat mknod mknodat mktime mremap nice openat pathconf pause pipe2 plock poll \
  posix_fallocate posix_fadvise pread \
@@ -3599,6 +3599,30 @@ fi
 if test "$ac_cv_have_lchflags" = yes ; then
   AC_DEFINE(HAVE_LCHFLAGS, 1, [Define to 1 if you have the 'lchflags' function.])
 fi
+
+
+# on alpine, lchmod raises errno EOPNOTSUPP on symlinks
+AC_CACHE_CHECK([for broken lchmod], [ac_cv_have_lchmod], [dnl
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <sys/stat.h>
+#include <unistd.h>
+int main(int argc, char*argv[])
+{
+  if (symlink(argv[0], "test"))
+    return 1;
+  if (lchmod("test", 0777))
+    return 1;
+  return 0;
+}
+]])],[ac_cv_have_lchmod=yes],[ac_cv_have_lchmod=no],[ac_cv_have_lchmod=cross])
+])
+if test "$ac_cv_have_lchmod" = cross ; then
+  AC_CHECK_FUNC([lchmod], [ac_cv_have_lchmod="yes"], [ac_cv_have_lchmod="no"])
+fi
+if test "$ac_cv_have_lchmod" = yes ; then
+  AC_DEFINE(HAVE_LCHMOD, 1, [Define to 1 if you have the `lchmod' function.])
+fi
+rm -f test
 
 dnl Check if system zlib has *Copy() functions
 dnl


### PR DESCRIPTION
Verified by compiling with alpine using the following Dockerfile and test script:

```dockerfile
FROM alpine
RUN apk update && \
    apk add expat-dev libressl-dev zlib-dev ncurses-dev bzip2-dev xz-dev \
        sqlite-dev libffi-dev tcl-dev linux-headers gdbm-dev readline-dev \
        gcc nano bash git python3 alpine-sdk
```

```bash
#!/usr/bin/env bash
set -euxo pipefail
docker build -t python-build .
docker run \
    --rm -ti \
    -v "$PWD/cpython:/src:ro" \
    python-build bash -exc '\
        cp -r /src /tmp/src && \
        cd /tmp/src && \
        ./configure || (cat config.log && exit 1) && \
        make -j8 && \
        ./python -m test.test_shutil \
    '
```

### Before

```
+ ./python -m test.test_shutil
..................s.................Es.E.....EssEE.....EE..ss..........s.................Fs......s.s..
======================================================================
ERROR: test_copy2_symlinks (__main__.TestShutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 531, in test_copy2_symlinks
    os.lchmod(src_link, stat.S_IRWXU | stat.S_IRWXO)
OSError: [Errno 95] Not supported: '/tmp/tmpcfxc61cw/baz'

======================================================================
ERROR: test_copy_symlinks (__main__.TestShutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 508, in test_copy_symlinks
    os.lchmod(src_link, stat.S_IRWXU | stat.S_IRWXO)
OSError: [Errno 95] Not supported: '/tmp/tmplde2crj7/baz'

======================================================================
ERROR: test_copymode_symlink_to_symlink (__main__.TestShutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 318, in test_copymode_symlink_to_symlink
    os.lchmod(src_link, stat.S_IRWXO|stat.S_IRWXG)
OSError: [Errno 95] Not supported: '/tmp/tmpr3v0c24m/baz'

======================================================================
ERROR: test_copystat_symlinks (__main__.TestShutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 364, in test_copystat_symlinks
    os.lchmod(src_link, stat.S_IRWXO)
OSError: [Errno 95] Not supported: '/tmp/tmplqh68wha/baz'

======================================================================
ERROR: test_copytree_dangling_symlinks (__main__.TestShutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 892, in test_copytree_dangling_symlinks
    shutil.copytree(src_dir, dst_dir, symlinks=True)
  File "/tmp/src/Lib/shutil.py", line 359, in copytree
    raise Error(errors)
shutil.Error: [('/tmp/tmpj76xsejs/test.txt', '/tmp/tmpg6s1ihql/destination3/test.txt', "[Errno 95] Not supported: '/tmp/tmpg6s1ihql/destination3/test.txt'")]

======================================================================
ERROR: test_copytree_symlink_dir (__main__.TestShutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 911, in test_copytree_symlink_dir
    shutil.copytree(src_dir, dst_dir, symlinks=True)
  File "/tmp/src/Lib/shutil.py", line 359, in copytree
    raise Error(errors)
shutil.Error: [('/tmp/tmpsa0vkix_/link_to_dir', '/tmp/tmpta37k_s9/destination2/link_to_dir', "[Errno 95] Not supported: '/tmp/tmpta37k_s9/destination2/link_to_dir'")]

======================================================================
ERROR: test_copytree_symlinks (__main__.TestShutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 651, in test_copytree_symlinks
    os.lchmod(src_link, stat.S_IRWXU | stat.S_IRWXO)
OSError: [Errno 95] Not supported: '/tmp/tmphrkx18bj/src/sub/link'

======================================================================
FAIL: test_unzip_zipfile (__main__.TestShutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 1118, in test_unzip_zipfile
    subprocess.check_output(zip_cmd, stderr=subprocess.STDOUT)
subprocess.CalledProcessError: Command '['unzip', '-t', '/tmp/tmppyfabhkq/archive.zip']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 1122, in test_unzip_zipfile
    self.fail(msg.format(exc, details))
AssertionError: Command '['unzip', '-t', '/tmp/tmppyfabhkq/archive.zip']' returned non-zero exit status 1.

**Unzip Output**
unzip: unrecognized option: t
BusyBox v1.26.2 (2017-10-04 13:37:41 GMT) multi-call binary.

Usage: unzip [-lnopq] FILE[.zip] [FILE]... [-x FILE...] [-d DIR]

Extract FILEs from ZIP archive

	-l	List contents (with -q for short form)
	-n	Never overwrite files (default: ask)
	-o	Overwrite
	-p	Print to stdout
	-q	Quiet
	-x FILE	Exclude FILEs
	-d DIR	Extract into DIR


----------------------------------------------------------------------
Ran 102 tests in 0.289s

FAILED (failures=1, errors=7, skipped=10)
```

### After

```
+ ./python -m test.test_shutil
..................s..................s.......s.s...........ss..........s.................Fs......s.s..
======================================================================
FAIL: test_unzip_zipfile (__main__.TestShutil)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 1118, in test_unzip_zipfile
    subprocess.check_output(zip_cmd, stderr=subprocess.STDOUT)
subprocess.CalledProcessError: Command '['unzip', '-t', '/tmp/tmp9zf_mymx/archive.zip']' returned non-zero exit status 1.

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/src/Lib/test/test_shutil.py", line 1122, in test_unzip_zipfile
    self.fail(msg.format(exc, details))
AssertionError: Command '['unzip', '-t', '/tmp/tmp9zf_mymx/archive.zip']' returned non-zero exit status 1.

**Unzip Output**
unzip: unrecognized option: t
BusyBox v1.26.2 (2017-10-04 13:37:41 GMT) multi-call binary.

Usage: unzip [-lnopq] FILE[.zip] [FILE]... [-x FILE...] [-d DIR]

Extract FILEs from ZIP archive

	-l	List contents (with -q for short form)
	-n	Never overwrite files (default: ask)
	-o	Overwrite
	-p	Print to stdout
	-q	Quiet
	-x FILE	Exclude FILEs
	-d DIR	Extract into DIR


----------------------------------------------------------------------
Ran 102 tests in 0.253s

FAILED (failures=1, skipped=10)
```

<!-- issue-number: bpo-31940 -->
https://bugs.python.org/issue31940
<!-- /issue-number -->
