### PR TITLE
bpo-31887: Adds documentations for special multipart/signed handling

### DIFF
--- a/Doc/library/email.generator.rst
+++ b/Doc/library/email.generator.rst
@@ -36,6 +36,10 @@ something that contains only ASCII characters, using the standard email RFC
 Content Transfer Encoding techniques for encoding email messages for transport
 over channels that are not "8 bit clean".
 
+To accomodate reproducible processing of SMIME-signed messages
+:class:`Generator` disables header folding for message parts of type
+``multipart/signed`` and all subparts.
+
 
 .. class:: BytesGenerator(outfp, mangle_from_=None, maxheaderlen=None, *, \
                           policy=None)


### PR DESCRIPTION
This pull request adds some information about the special multipart/signed handling to clear about disabling header folding.

<!-- issue-number: bpo-31887 -->
https://bugs.python.org/issue31887
<!-- /issue-number -->
