### PR TITLE
[2.7] bpo-9678: Fix determining the MAC address in the uuid module. (GH-4264)

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -339,8 +339,9 @@ def _find_mac(command, args, hw_identifiers, get_index):
 def _ifconfig_getnode():
     """Get the hardware address on Unix by running ifconfig."""
     # This works on Linux ('' or '-a'), Tru64 ('-av'), but not all Unixes.
+    keywords = ('hwaddr', 'ether', 'address:', 'lladdr')
     for args in ('', '-a', '-av'):
-        mac = _find_mac('ifconfig', args, ['hwaddr', 'ether'], lambda i: i+1)
+        mac = _find_mac('ifconfig', args, keywords, lambda i: i+1)
         if mac:
             return mac
 
@@ -353,7 +354,20 @@ def _arp_getnode():
         return None
 
     # Try getting the MAC addr from arp based on our IP address (Solaris).
-    return _find_mac('arp', '-an', [ip_addr], lambda i: -1)
+    mac = _find_mac('arp', '-an', [ip_addr], lambda i: -1)
+    if mac:
+        return mac
+
+    # This works on OpenBSD
+    mac = _find_mac('arp', '-an', [ip_addr], lambda i: i+1)
+    if mac:
+        return mac
+
+    # This works on Linux, FreeBSD and NetBSD
+    mac = _find_mac('arp', '-an', ['(%s)' % ip_addr],
+                    lambda i: i+2)
+    if mac:
+        return mac
 
 def _lanscan_getnode():
     """Get the hardware address on Unix by running lanscan."""

--- a/Misc/NEWS.d/next/Library/2017-11-03-22-05-47.bpo-9678.oD51q6.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-03-22-05-47.bpo-9678.oD51q6.rst
@@ -1,0 +1,6 @@
+Fixed determining the MAC address in the uuid module:
+
+* Using ifconfig on NetBSD and OpenBSD.
+* Using arp on Linux, FreeBSD, NetBSD and OpenBSD.
+
+Based on patch by Takayuki Shimizukawa.


### PR DESCRIPTION
* Using ifconfig on NetBSD and OpenBSD.
* Using arp on Linux, FreeBSD, NetBSD and OpenBSD.

Based on patch by Takayuki Shimizukawa..
(cherry picked from commit ee1a9a2b78d5b6bb1a8148fc5fcf365e6d4e9e67)


<!-- issue-number: bpo-9678 -->
https://bugs.python.org/issue9678
<!-- /issue-number -->
