### PR TITLE
[2.7] bpo-18699: Corrected documentation for window.chgat in curses module (GH-1430).

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -765,11 +765,11 @@ the following methods:
             window.chgat(y, x, num, attr)
 
    Set the attributes of *num* characters at the current cursor position, or at
-   position ``(y, x)`` if supplied. If no value of *num* is given or *num* = -1,
-   the attribute will  be set on all the characters to the end of the line.  This
-   function does not move the cursor. The changed line will be touched using the
-   :meth:`touchline` method so that the contents will be redisplayed by the next
-   window refresh.
+   position ``(y, x)`` if supplied. If *num* is not given or is ``-1``,
+   the attribute will be set on all the characters to the end of the line.  This
+   function moves cursor to position ``(y, x)`` if supplied. The changed line
+   will be touched using the :meth:`touchline` method so that the contents will
+   be redisplayed by the next window refresh.
 
 
 .. method:: window.clear()


### PR DESCRIPTION
(cherry picked from commit b838cc3ff4e039af949c6a19bd896e98e944dcbe)


<!-- issue-number: bpo-18699 -->
https://bugs.python.org/issue18699
<!-- /issue-number -->
