### PR TITLE
Misc. typos

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -374,7 +374,7 @@ Task
    running in different threads. While a task waits for the completion of a
    future, the event loop executes a new task.
 
-   The cancellation of a task is different from the cancelation of a
+   The cancellation of a task is different from the cancellation of a
    future. Calling :meth:`cancel` will throw a
    :exc:`~concurrent.futures.CancelledError` to the wrapped
    coroutine. :meth:`~Future.cancelled` only returns ``True`` if the

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1336,7 +1336,7 @@ always available.
    |                  |  * ``None`` if this information is unknown              |
    +------------------+---------------------------------------------------------+
    | :const:`version` | Name and version of the thread library. It is a string, |
-   |                  | or ``None`` if these informations are unknown.          |
+   |                  | or ``None`` if this information is unknown.             |
    +------------------+---------------------------------------------------------+
 
    .. versionadded:: 3.3

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2374,7 +2374,7 @@ Sealing mocks
     any new attribute on the sealed mock. The sealing process is performed recursively.
 
     If a mock instance is assigned to an attribute instead of being dynamically created
-    it wont be considered in the sealing chain. This allows to prevent seal from fixing
+    it won't be considered in the sealing chain. This allows to prevent seal from fixing
     part of the mock object.
 
         >>> mock = Mock()

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -788,7 +788,7 @@ of the OpenSSL license here::
      * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
      * SUCH DAMAGE.
      *
-     * The licence and distribution terms for any publically available version or
+     * The licence and distribution terms for any publicly available version or
      * derivative of this code cannot be changed.  i.e. this code cannot simply be
      * copied and put under another distribution licence
      * [including the GNU Public Licence.]

--- a/Doc/license.rst
+++ b/Doc/license.rst
@@ -788,7 +788,7 @@ of the OpenSSL license here::
      * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
      * SUCH DAMAGE.
      *
-     * The licence and distribution terms for any publicly available version or
+     * The licence and distribution terms for any publically available version or
      * derivative of this code cannot be changed.  i.e. this code cannot simply be
      * copied and put under another distribution licence
      * [including the GNU Public Licence.]

--- a/Doc/whatsnew/3.1.rst
+++ b/Doc/whatsnew/3.1.rst
@@ -69,7 +69,7 @@ modules.  The :mod:`configparser` module uses them by default.  This lets
 configuration files be read, modified, and then written back in their original
 order.  The *_asdict()* method for :func:`collections.namedtuple` now
 returns an ordered dictionary with the values appearing in the same order as
-the underlying tuple indicies.  The :mod:`json` module is being built-out with
+the underlying tuple indices.  The :mod:`json` module is being built-out with
 an *object_pairs_hook* to allow OrderedDicts to be built by the decoder.
 Support was also added for third-party tools like `PyYAML <http://pyyaml.org/>`_.
 

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -164,7 +164,7 @@ each with their own argument patterns and help displays::
 
     $ ./helm.py --help                         # top level help (launch and move)
     $ ./helm.py launch --help                  # help for launch options
-    $ ./helm.py launch --missiles              # set missiles=True and torpedos=False
+    $ ./helm.py launch --missiles              # set missiles=True and torpedoes=False
     $ ./helm.py steer --course 180 --speed 5   # set movement parameters
 
 .. seealso::

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -164,7 +164,7 @@ each with their own argument patterns and help displays::
 
     $ ./helm.py --help                         # top level help (launch and move)
     $ ./helm.py launch --help                  # help for launch options
-    $ ./helm.py launch --missiles              # set missiles=True and torpedoes=False
+    $ ./helm.py launch --missiles              # set missiles=True and torpedos=False
     $ ./helm.py steer --course 180 --speed 5   # set movement parameters
 
 .. seealso::

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -1504,7 +1504,7 @@ argument taking an iterable of handlers to be added to the root logger.
 A class level attribute :attr:`~logging.handlers.SysLogHandler.append_nul` has
 been added to :class:`~logging.handlers.SysLogHandler` to allow control of the
 appending of the ``NUL`` (``\000``) byte to syslog records, since for some
-deamons it is required while for others it is passed through to the log.
+daemons it is required while for others it is passed through to the log.
 
 
 
@@ -2003,7 +2003,7 @@ sys
 ---
 
 The :mod:`sys` module has a new :data:`~sys.thread_info` :term:`struct
-sequence` holding informations about the thread implementation
+sequence` holding information about the thread implementation
 (:issue:`11223`).
 
 
@@ -2040,7 +2040,7 @@ class instance, are now classes and may be subclassed.  (Contributed by Éric
 Araujo in :issue:`10968`.)
 
 The :class:`threading.Thread` constructor now accepts a ``daemon`` keyword
-argument to override the default behavior of inheriting the ``deamon`` flag
+argument to override the default behavior of inheriting the ``daemon`` flag
 value from the parent thread (:issue:`6064`).
 
 The formerly private function ``_thread.get_ident`` is now available as the

--- a/Include/object.h
+++ b/Include/object.h
@@ -604,7 +604,7 @@ introducing new functionality between major revisions (to avoid mid-version
 changes in the PYTHON_API_VERSION).
 
 Arbitration of the flag bit positions will need to be coordinated among
-all extension writers who publically release their extensions (this will
+all extension writers who publicly release their extensions (this will
 be fewer than you might expect!)..
 
 Most flags were removed as of Python 3.0 to make room for new flags.  (Some

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -212,7 +212,7 @@ PyAPI_FUNC(void) PyMem_SetAllocator(PyMemAllocatorDomain domain,
    - PyObject_Malloc(), PyObject_Realloc() and PyObject_Free()
 
    Newly allocated memory is filled with the byte 0xCB, freed memory is filled
-   with the byte 0xDB. Additionnal checks:
+   with the byte 0xDB. Additional checks:
 
    - detect API violations, ex: PyObject_Free() called on a buffer allocated
      by PyMem_Malloc()

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -132,11 +132,11 @@ PyAPI_FUNC(char *) _PyMem_Strdup(const char *str);
  */
 
 #define PyMem_New(type, n) \
-  ( ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :	\
-	( (type *) PyMem_Malloc((n) * sizeof(type)) ) )
+  ( ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :      \
+        ( (type *) PyMem_Malloc((n) * sizeof(type)) ) )
 #define PyMem_NEW(type, n) \
-  ( ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :	\
-	( (type *) PyMem_MALLOC((n) * sizeof(type)) ) )
+  ( ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :      \
+        ( (type *) PyMem_MALLOC((n) * sizeof(type)) ) )
 
 /*
  * The value of (p) is always clobbered by this macro regardless of success.
@@ -145,17 +145,17 @@ PyAPI_FUNC(char *) _PyMem_Strdup(const char *str);
  * caller's memory error handler to not lose track of it.
  */
 #define PyMem_Resize(p, type, n) \
-  ( (p) = ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :	\
-	(type *) PyMem_Realloc((p), (n) * sizeof(type)) )
+  ( (p) = ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :        \
+        (type *) PyMem_Realloc((p), (n) * sizeof(type)) )
 #define PyMem_RESIZE(p, type, n) \
-  ( (p) = ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :	\
-	(type *) PyMem_REALLOC((p), (n) * sizeof(type)) )
+  ( (p) = ((size_t)(n) > PY_SSIZE_T_MAX / sizeof(type)) ? NULL :        \
+        (type *) PyMem_REALLOC((p), (n) * sizeof(type)) )
 
 /* PyMem{Del,DEL} are left over from ancient days, and shouldn't be used
  * anymore.  They're just confusing aliases for PyMem_{Free,FREE} now.
  */
-#define PyMem_Del		PyMem_Free
-#define PyMem_DEL		PyMem_FREE
+#define PyMem_Del               PyMem_Free
+#define PyMem_DEL               PyMem_FREE
 
 #ifndef Py_LIMITED_API
 typedef enum {

--- a/Lib/hashlib.py
+++ b/Lib/hashlib.py
@@ -218,7 +218,7 @@ except ImportError:
         from_bytes = int.from_bytes
         while len(dkey) < dklen:
             prev = prf(salt + loop.to_bytes(4, 'big'))
-            # endianess doesn't matter here as long to / from use the same
+            # endianness doesn't matter here as long to / from use the same
             rkey = int.from_bytes(prev, 'big')
             for i in range(iterations - 1):
                 prev = prf(prev)

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -81,7 +81,7 @@ extension.cfg.  All take effect as soon as one clicks Apply or Ok.
 '<<zoom-height>>'.  Any (global) customizations made before 3.6.3 will
 not affect their keyset-specific customization after 3.6.3. and vice
 versa.
-  Inital patch by Charles Wohlganger, revised by Terry Jan Reedy.
+  Initial patch by Charles Wohlganger, revised by Terry Jan Reedy.
 
 bpo-31051:  Rearrange condigdialog General tab.
 Sort non-Help options into Window (Shell+Editor) and Editor (only).

--- a/Lib/idlelib/browser.py
+++ b/Lib/idlelib/browser.py
@@ -58,7 +58,7 @@ class ModuleBrowser:
     """Browse module classes and functions in IDLE.
     """
     # This class is also the base class for pathbrowser.PathBrowser.
-    # Init and close are inherited, other methods are overriden.
+    # Init and close are inherited, other methods are overridden.
     # PathBrowser.__init__ does not call __init__ below.
 
     def __init__(self, master, path, *, _htest=False, _utest=False):

--- a/Lib/idlelib/idle_test/test_replace.py
+++ b/Lib/idlelib/idle_test/test_replace.py
@@ -74,14 +74,14 @@ class ReplaceDialogTest(unittest.TestCase):
         replace()
         equal(text.get('1.8', '1.12'), 'asdf')
 
-        # dont "match word" case
+        # don't "match word" case
         text.mark_set('insert', '1.0')
         pv.set('is')
         rv.set('hello')
         replace()
         equal(text.get('1.2', '1.7'), 'hello')
 
-        # dont "match case" case
+        # don't "match case" case
         pv.set('string')
         rv.set('world')
         replace()

--- a/Lib/idlelib/paragraph.py
+++ b/Lib/idlelib/paragraph.py
@@ -158,7 +158,7 @@ def reformat_comment(data, limit, comment_header):
     newdata = reformat_paragraph(data, format_width)
     # re-split and re-insert the comment header.
     newdata = newdata.split("\n")
-    # If the block ends in a \n, we dont want the comment prefix
+    # If the block ends in a \n, we don't want the comment prefix
     # inserted after it. (Im not sure it makes sense to reformat a
     # comment block that is not made of complete lines, but whatever!)
     # Can't think of a clean solution, so we hack away

--- a/Lib/numbers.py
+++ b/Lib/numbers.py
@@ -35,7 +35,7 @@ class Complex(Number):
     In short, those are: a conversion to complex, .real, .imag, +, -,
     *, /, abs(), .conjugate, ==, and !=.
 
-    If it is given heterogenous arguments, and doesn't have special
+    If it is given heterogeneous arguments, and doesn't have special
     knowledge about them, it should fall back to the builtin complex
     type as described below.
     """

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -751,7 +751,7 @@ class Popen(object):
     @property
     def universal_newlines(self):
         # universal_newlines as retained as an alias of text_mode for API
-        # compatability. bpo-31756
+        # compatibility. bpo-31756
         return self.text_mode
 
     @universal_newlines.setter

--- a/Lib/test/decimaltestdata/abs.decTest
+++ b/Lib/test/decimaltestdata/abs.decTest
@@ -20,7 +20,7 @@
 version: 2.59
 
 -- This set of tests primarily tests the existence of the operator.
--- Additon, subtraction, rounding, and more overflows are tested
+-- Addition, subtraction, rounding, and more overflows are tested
 -- elsewhere.
 
 precision:   9

--- a/Lib/test/decimaltestdata/abs.decTest
+++ b/Lib/test/decimaltestdata/abs.decTest
@@ -20,7 +20,7 @@
 version: 2.59
 
 -- This set of tests primarily tests the existence of the operator.
--- Addition, subtraction, rounding, and more overflows are tested
+-- Additon, subtraction, rounding, and more overflows are tested
 -- elsewhere.
 
 precision:   9

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -1,5 +1,5 @@
 """
-Collect various informations about Python to help debugging test failures.
+Collect various information about Python to help debugging test failures.
 """
 from __future__ import print_function
 import errno
@@ -40,7 +40,7 @@ class PythonInfo:
 
     def get_infos(self):
         """
-        Get informations as a key:value dictionary where values are strings.
+        Get information as a key:value dictionary where values are strings.
         """
         return {key: str(value) for key, value in self.info.items()}
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2770,7 +2770,7 @@ class SaveSignals:
         import signal
         self.signal = signal
         self.signals = list(range(1, signal.NSIG))
-        # SIGKILL and SIGSTOP signals cannot be ignored nor catched
+        # SIGKILL and SIGSTOP signals cannot be ignored nor caught
         for signame in ('SIGKILL', 'SIGSTOP'):
             try:
                 signum = getattr(signal, signame)

--- a/Lib/test/test_codecmaps_kr.py
+++ b/Lib/test/test_codecmaps_kr.py
@@ -27,8 +27,8 @@ class TestJOHABMap(multibytecodec_support.TestBase_Mapping,
     encoding = 'johab'
     mapfileurl = 'http://www.pythontest.net/unicode/JOHAB.TXT'
     # KS X 1001 standard assigned 0x5c as WON SIGN.
-    # but, in early 90s that is the only era used johab widely,
-    # the most softwares implements it as REVERSE SOLIDUS.
+    # But the early 90s is the only era that used johab widely,
+    # most software implements it as REVERSE SOLIDUS.
     # So, we ignore the standard here.
     pass_enctest = [(b'\\', '\u20a9')]
     pass_dectest = [(b'\\', '\u20a9')]

--- a/Lib/test/test_exceptions.py
+++ b/Lib/test/test_exceptions.py
@@ -943,7 +943,7 @@ class ExceptionTests(unittest.TestCase):
         # equal to recursion_limit in PyErr_NormalizeException() and check
         # that a ResourceWarning is printed.
         # Prior to #22898, the recursivity of PyErr_NormalizeException() was
-        # controled by tstate->recursion_depth and a PyExc_RecursionErrorInst
+        # controlled by tstate->recursion_depth and a PyExc_RecursionErrorInst
         # singleton was being used in that case, that held traceback data and
         # locals indefinitely and would cause a segfault in _PyExc_Fini() upon
         # finalization of these locals.

--- a/Lib/test/test_hash.py
+++ b/Lib/test/test_hash.py
@@ -207,7 +207,7 @@ class StringlikeHashRandomizationTests(HashRandomizationTests):
             [-678966196, 573763426263223372, -820489388, -4282905804826039665],
             ],
         'siphash24': [
-            # NOTE: PyUCS2 layout depends on endianess
+            # NOTE: PyUCS2 layout depends on endianness
             # seed 0, 'abc'
             [1198583518, 4596069200710135518, 1198583518, 4596069200710135518],
             # seed 42, 'abc'

--- a/Lib/test/test_imp.py
+++ b/Lib/test/test_imp.py
@@ -112,7 +112,7 @@ class ImportTests(unittest.TestCase):
         # Martin von Loewis note what shared library cannot have non-ascii
         # character because init_xxx function cannot be compiled
         # and issue never happens for dynamic modules.
-        # But sources modified to follow generic way for processing pathes.
+        # But sources modified to follow generic way for processing paths.
 
         # the return encoding could be uppercase or None
         fs_encoding = sys.getfilesystemencoding()

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -683,7 +683,7 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
         nodesize = calcsize('Pn2P')
 
         od = OrderedDict()
-        check(od, basicsize + 8*p + 8 + 5*entrysize)  # 8byte indicies + 8*2//3 * entry table
+        check(od, basicsize + 8*p + 8 + 5*entrysize)  # 8byte indices + 8*2//3 * entry table
         od.x = 1
         check(od, basicsize + 8*p + 8 + 5*entrysize)
         od.update([(i, i) for i in range(3)])

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4675,7 +4675,7 @@ class TCPTimeoutTest(SocketTCPTest):
                          'test needs signal.alarm()')
     def testInterruptedTimeout(self):
         # XXX I don't know how to do this test on MSWindows or any other
-        # plaform that doesn't support signal.alarm() or os.kill(), though
+        # platform that doesn't support signal.alarm() or os.kill(), though
         # the bug should have existed on all platforms.
         self.serv.settimeout(5.0)   # must be longer than alarm
         class Alarm(Exception):

--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -427,7 +427,7 @@ class ThreadTests(BaseTestCase):
         t.daemon = True
         self.assertIn('daemon', repr(t))
 
-    def test_deamon_param(self):
+    def test_daemon_param(self):
         t = threading.Thread()
         self.assertFalse(t.daemon)
         t = threading.Thread(daemon=False)

--- a/Lib/test/test_unicode_file.py
+++ b/Lib/test/test_unicode_file.py
@@ -1,5 +1,5 @@
 # Test some Unicode file name semantics
-# We dont test many operations on files other than
+# We don't test many operations on files other than
 # that their names can be used with Unicode characters.
 import os, glob, time, shutil
 import unicodedata

--- a/Lib/test/test_unicode_file_functions.py
+++ b/Lib/test/test_unicode_file_functions.py
@@ -17,7 +17,7 @@ filenames = [
     '7_\u05d4\u05e9\u05e7\u05e6\u05e5\u05e1',
     '8_\u66e8\u66e9\u66eb',
     '9_\u66e8\u05e9\u3093\u0434\u0393\xdf',
-    # Specific code points: fn, NFC(fn) and NFKC(fn) all differents
+    # Specific code points: fn, NFC(fn) and NFKC(fn) all different
     '10_\u1fee\u1ffd',
     ]
 
@@ -29,13 +29,13 @@ filenames = [
 # U+2FAFF are not decomposed."
 if sys.platform != 'darwin':
     filenames.extend([
-        # Specific code points: NFC(fn), NFD(fn), NFKC(fn) and NFKD(fn) all differents
+        # Specific code points: NFC(fn), NFD(fn), NFKC(fn) and NFKD(fn) all different
         '11_\u0385\u03d3\u03d4',
         '12_\u00a8\u0301\u03d2\u0301\u03d2\u0308', # == NFD('\u0385\u03d3\u03d4')
         '13_\u0020\u0308\u0301\u038e\u03ab',       # == NFKC('\u0385\u03d3\u03d4')
         '14_\u1e9b\u1fc1\u1fcd\u1fce\u1fcf\u1fdd\u1fde\u1fdf\u1fed',
 
-        # Specific code points: fn, NFC(fn) and NFKC(fn) all differents
+        # Specific code points: fn, NFC(fn) and NFKC(fn) all different
         '15_\u1fee\u1ffd\ufad1',
         '16_\u2000\u2000\u2000A',
         '17_\u2001\u2001\u2001A',

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1864,7 +1864,7 @@ class LzmaTestsWithRandomBinaryFiles(AbstractTestsWithRandomBinaryFiles,
     compression = zipfile.ZIP_LZMA
 
 
-# Privide the tell() method but not seek()
+# Provide the tell() method but not seek()
 class Tellable:
     def __init__(self, fp):
         self.fp = fp

--- a/Lib/turtle.py
+++ b/Lib/turtle.py
@@ -2194,7 +2194,7 @@ class TPen(object):
 
         If turtleshape is a polygon, outline and interior of that polygon
         is drawn with the newly set colors.
-        For mor info see: pencolor, fillcolor
+        For more info see: pencolor, fillcolor
 
         Example (for a Turtle instance named turtle):
         >>> turtle.color('red', 'green')

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -942,7 +942,7 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
                           [], [divmod, 'x', 1, 5j, 2j, frozenset()])
         # comparing dicts
         self.assertCountEqual([{'a': 1}, {'b': 2}], [{'b': 2}, {'a': 1}])
-        # comparing heterogenous non-hashable sequences
+        # comparing heterogeneous non-hashable sequences
         self.assertCountEqual([1, 'x', divmod, []], [divmod, [], 'x', 1])
         self.assertRaises(self.failureException, self.assertCountEqual,
                           [], [divmod, [], 'x', 1, 5j, 2j, set()])

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -470,7 +470,7 @@ profile-run-stamp:
 	# Remove profile generation binary since we are done with it.
 	$(MAKE) clean
 	# This is an expensive target to build and it does not have proper
-	# makefile dependancy information.  So, we create a "stamp" file
+	# makefile dependency information.  So, we create a "stamp" file
 	# to record its completion and avoid re-running it.
 	touch $@
 

--- a/Misc/HISTORY
+++ b/Misc/HISTORY
@@ -9752,7 +9752,7 @@ Library
 - Issue #11382: Trivial system calls, such as dup() or pipe(), needn't
   release the GIL.  Patch by Charles-François Natali.
 
-- Issue #11223: Add threading._info() function providing informations about
+- Issue #11223: Add threading._info() function providing information about
   the thread implementation.
 
 - Issue #11731: simplify/enhance email parser/generator API by introducing
@@ -29642,7 +29642,7 @@ of the object in the message.
 - Fixed a bug in list.sort() that would occasionally dump core.
 
 - Fixed a bug in PyNumber_Power() that caused numeric arrays to fail
-when taken tothe real power.
+when taken to the real power.
 
 - Fixed a number of bugs in the file reading code, at least one of
 which could cause a core dump on NT, and one of which would
@@ -29689,7 +29689,7 @@ thanks to Charles Waldman.
 - Many nits fixed in the manuals, thanks to Fred Drake and many others
 (especially Rob Hooft and Andrew Kuchling).  The HTML version now uses
 HTML markup instead of inline GIF images for tables; only two images
-are left (for obsure bits of math).  The index of the HTML version has
+are left (for obscure bits of math).  The index of the HTML version has
 also been much improved.  Finally, it is once again possible to
 generate an Emacs info file from the library manual (but I don't
 commit to supporting this in future versions).
@@ -30341,7 +30341,7 @@ http://grail.cnri.reston.va.us/python/essays/packages.html
 for more info.
 
 - Changes to standard library subdirectory names: those subdirectories
-that are not packages have been renamed with a hypen in their name,
+that are not packages have been renamed with a hyphen in their name,
 e.g. lib-tk, lib-stdwin, plat-win, plat-linux2, plat-sunos5, dos-8x3.
 The test suite is now a package -- to run a test, you must now use
 "import test.test_foo".
@@ -34181,7 +34181,7 @@ You need STDWIN version 0.9.7 (released 30 June 1992) for the stdwin
 interface
 
 Dynamic loading is now supported for Sun (and other non-COFF systems)
-throug dld-3.2.3, as well as for SGI (a new version of Jack Jansen's
+through dld-3.2.3, as well as for SGI (a new version of Jack Jansen's
 DL is out, 1.4)
 
 The system-dependent code for the use of the select() system call is

--- a/Misc/NEWS.d/3.5.2rc1.rst
+++ b/Misc/NEWS.d/3.5.2rc1.rst
@@ -2006,7 +2006,7 @@ Adds validation of ucrtbase[d].dll version with warning for old versions.
 .. nonce: 102DA-
 .. section: Build
 
-Avoid error about nonexistant fileblocks.o file by using a lower-level check
+Avoid error about nonexistent fileblocks.o file by using a lower-level check
 for st_blocks in struct stat.
 
 ..

--- a/Misc/NEWS.d/3.6.0a1.rst
+++ b/Misc/NEWS.d/3.6.0a1.rst
@@ -3695,7 +3695,7 @@ Adds validation of ucrtbase[d].dll version with warning for old versions.
 .. nonce: 102DA-
 .. section: Build
 
-Avoid error about nonexistant fileblocks.o file by using a lower-level check
+Avoid error about nonexistent fileblocks.o file by using a lower-level check
 for st_blocks in struct stat.
 
 ..

--- a/Misc/NEWS.d/3.6.0a3.rst
+++ b/Misc/NEWS.d/3.6.0a3.rst
@@ -476,7 +476,7 @@ Update Windows builds to use OpenSSL 1.0.2h.
 Rename the platform directory from plat-$(MACHDEP) to
 plat-$(PLATFORM_TRIPLET). Rename the config directory (LIBPL) from
 config-$(LDVERSION) to config-$(LDVERSION)-$(PLATFORM_TRIPLET). Install the
-platform specifc _sysconfigdata module into the platform directory and
+platform specific _sysconfigdata module into the platform directory and
 rename it to include the ABIFLAGS.
 
 ..

--- a/Misc/NEWS.d/3.7.0a1.rst
+++ b/Misc/NEWS.d/3.7.0a1.rst
@@ -5779,7 +5779,7 @@ module>>', '<<check-module>>', and '<<zoom-height>>'.  Any (global)
 customizations made before 3.6.3 will not affect their keyset- specific
 customization after 3.6.3. and vice versa.
 
-Inital patch by Charles Wohlganger.
+Initial patch by Charles Wohlganger.
 
 ..
 

--- a/Misc/NEWS.d/3.7.0a2.rst
+++ b/Misc/NEWS.d/3.7.0a2.rst
@@ -424,7 +424,7 @@ Stop crashes when concurrently iterate over itertools.groupby() iterators.
 .. nonce: Csse77
 .. section: Library
 
-An iterator produced by itertools.groupby() iterator now becames exhausted
+An iterator produced by itertools.groupby() iterator now becomes exhausted
 after advancing the groupby iterator.
 
 ..
@@ -445,7 +445,7 @@ Cancel asyncio.wait_for future faster if timeout <= 0
 
 Allow passing a context object in
 :class:`concurrent.futures.ProcessPoolExecutor` constructor. Also, free job
-ressources in :class:`concurrent.futures.ProcessPoolExecutor` earlier to
+resources in :class:`concurrent.futures.ProcessPoolExecutor` earlier to
 improve memory usage when a worker waits for new jobs.
 
 ..
@@ -678,7 +678,7 @@ and Py_SetPath()
 .. nonce: vm8vGE
 .. section: C API
 
-Implement PEP 539 for Thread Specific Stroage (TSS) API: it is a new Thread
+Implement PEP 539 for Thread Specific Storage (TSS) API: it is a new Thread
 Local Storage (TLS) API to CPython which would supersede use of the existing
 TLS API within the CPython interpreter, while deprecating the existing API.
 PEP written by Erik M. Bray, patch by Masayuki Yamamoto.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -3745,7 +3745,7 @@ _build_callargs(PyCFuncPtrObject *self, PyObject *argtypes,
             /*
                XXX Is the following correct any longer?
                We must not pass a byref() to the array then but
-               the array instance itself. Then, we cannot retrive
+               the array instance itself. Then, we cannot retrieve
                the result from the PyCArgObject.
             */
             if (ob == NULL)

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -329,7 +329,7 @@ MakeAnonFields(PyObject *type)
 }
 
 /*
-  Retrive the (optional) _pack_ attribute from a type, the _fields_ attribute,
+  Retrieve the (optional) _pack_ attribute from a type, the _fields_ attribute,
   and create an StgDictObject.  Used for Structure and Union subclasses.
 */
 int
@@ -447,7 +447,7 @@ PyCStructUnionType_update_stgdict(PyObject *type, PyObject *fields, int isStruct
         stgdict->format = _ctypes_alloc_format_string(NULL, "T{");
     } else {
         /* PEP3118 doesn't support union, or packed structures (well,
-           only standard packing, but we dont support the pep for
+           only standard packing, but we don't support the pep for
            that). Use 'B' for bytes. */
         stgdict->format = _ctypes_alloc_format_string(NULL, "B");
     }

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -775,11 +775,11 @@ static PyMethodDef module_methods[] = {
 
 
 static struct PyModuleDef _posixsubprocessmodule = {
-	PyModuleDef_HEAD_INIT,
-	"_posixsubprocess",
-	module_doc,
-	-1,  /* No memory is needed. */
-	module_methods,
+        PyModuleDef_HEAD_INIT,
+        "_posixsubprocess",
+        module_doc,
+        -1,  /* No memory is needed. */
+        module_methods,
 };
 
 PyMODINIT_FUNC

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -220,7 +220,7 @@ _close_fds_by_brute_force(long start_fd, PyObject *py_fds_to_keep)
     Py_ssize_t keep_seq_idx;
     int fd_num;
     /* As py_fds_to_keep is sorted we can loop through the list closing
-     * fds inbetween any in the keep list falling within our range. */
+     * fds in between any in the keep list falling within our range. */
     for (keep_seq_idx = 0; keep_seq_idx < num_fds_to_keep; ++keep_seq_idx) {
         PyObject* py_keep_fd = PyTuple_GET_ITEM(py_fds_to_keep, keep_seq_idx);
         int keep_fd = PyLong_AsLong(py_keep_fd);

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -256,7 +256,7 @@ static PyThreadState *tcl_tstate = NULL;
     if (((TkappObject *)self)->threaded && \
         ((TkappObject *)self)->thread_id != Tcl_GetCurrentThread()) { \
         PyErr_SetString(PyExc_RuntimeError, \
-                        "Calling Tcl from different appartment"); \
+                        "Calling Tcl from different apartment"); \
         return 0; \
     }
 

--- a/Modules/expat/xmltok_impl.c
+++ b/Modules/expat/xmltok_impl.c
@@ -1733,7 +1733,7 @@ PREFIX(nameMatchesAscii)(const ENCODING *UNUSED_P(enc), const char *ptr1,
   for (; *ptr2; ptr1 += MINBPC(enc), ptr2++) {
     if (end1 - ptr1 < MINBPC(enc)) {
       /* This line cannot be executed.  THe incoming data has already
-       * been tokenized once, so imcomplete characters like this have
+       * been tokenized once, so incomplete characters like this have
        * already been eliminated from the input.  Retaining the
        * paranoia check is still valuable, however.
        */

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -334,7 +334,7 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
    gets ever fixed, perhaps checking for sys/version.h would be
    appropriate, which is 10/0 on the system with the bug. */
 #ifndef HAVE_GETNAMEINFO
-/* This bug seems to be fixed in Jaguar. Ths easiest way I could
+/* This bug seems to be fixed in Jaguar. The easiest way I could
    Find to check for Jaguar is that it has getnameinfo(), which
    older releases don't have */
 #undef HAVE_GETADDRINFO

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -1321,7 +1321,7 @@ PyDoc_STRVAR(unicodedata_docstring,
 "This module provides access to the Unicode Character Database which\n\
 defines character properties for all Unicode characters. The data in\n\
 this database is based on the UnicodeData.txt file version\n\
-" UNIDATA_VERSION " which is publically available from ftp://ftp.unicode.org/.\n\
+" UNIDATA_VERSION " which is publicly available from ftp://ftp.unicode.org/.\n\
 \n\
 The module uses the same names and symbols as defined by the\n\
 UnicodeData File Format " UNIDATA_VERSION ".");

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1032,7 +1032,7 @@ Fail:
 }
 
 /*
-Internal routine used by dictresize() to buid a hashtable of entries.
+Internal routine used by dictresize() to build a hashtable of entries.
 */
 static void
 build_indices(PyDictKeysObject *keys, PyDictKeyEntry *ep, Py_ssize_t n)

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -395,7 +395,7 @@ getpythonregpath(HKEY keyBase, int skipcore)
         if (skipcore)
             *szCur = '\0';
         else {
-            /* If we have no values, we dont need a ';' */
+            /* If we have no values, we don't need a ';' */
             if (numKeys) {
                 *(szCur++) = L';';
                 dataSize--;
@@ -718,7 +718,7 @@ calculate_path(void)
     machinepath = getpythonregpath(HKEY_LOCAL_MACHINE, skiphome);
     userpath = getpythonregpath(HKEY_CURRENT_USER, skiphome);
 #endif
-    /* We only use the default relative PYTHONPATH if we havent
+    /* We only use the default relative PYTHONPATH if we haven't
        anything better to use! */
     skipdefault = envpath!=NULL || pythonhome!=NULL || \
                   machinepath!=NULL || userpath!=NULL;

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -25,7 +25,7 @@ static char errNotAHandle[] = "Object is not a handle";
 
 /* The win32api module reports the function name that failed,
    but this concept is not in the Python core.
-   Hopefully it will one day, and in the meantime I dont
+   Hopefully it will one day, and in the meantime I don't
    want to lose this info...
 */
 #define PyErr_SetFromWindowsErrWithFunction(rc, fnname) \
@@ -506,9 +506,9 @@ PyWinObject_CloseHKEY(PyObject *obHandle)
 ** Note that fixupMultiSZ and countString have both had changes
 ** made to support "incorrect strings".  The registry specification
 ** calls for strings to be terminated with 2 null bytes.  It seems
-** some commercial packages install strings which dont conform,
+** some commercial packages install strings which don't conform,
 ** causing this code to fail - however, "regedit" etc still work
-** with these strings (ie only we dont!).
+** with these strings (ie only we don't!).
 */
 static void
 fixupMultiSZ(wchar_t **str, wchar_t *data, int len)

--- a/PC/winsound.c
+++ b/PC/winsound.c
@@ -29,7 +29,7 @@
    # Start playing the first bit of wav file asynchronously
    winsound.PlaySound('c:/windows/media/Chord.wav',
                    winsound.SND_FILENAME|winsound.SND_ASYNC)
-   # But dont let it go for too long...
+   # But don't let it go for too long...
    time.sleep(0.1)
    # ...Before stopping it
    winsound.PlaySound(None, 0)

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -391,7 +391,7 @@ call_show_warning(PyObject *category, PyObject *text, PyObject *message,
 
     /* If the source parameter is set, try to get the Python implementation.
        The Python implementation is able to log the traceback where the source
-       was allocated, whereas the C implementation doesnt. */
+       was allocated, whereas the C implementation doesn't. */
     show_fn = get_warnings_attr("_showwarnmsg", source != NULL);
     if (show_fn == NULL) {
         if (PyErr_Occurred())

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4287,7 +4287,7 @@ static void fstring_shift_node_locations(node *n, int lineno, int col_offset)
 
    `parent` is the enclosing node.
    `n` is the node which locations are going to be fixed relative to parent.
-   `expr_str` is the child node's string representation, incuding braces.
+   `expr_str` is the child node's string representation, including braces.
 */
 static void
 fstring_fix_node_location(const node *parent, node *n, char *expr_str)

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -817,7 +817,7 @@ pymonotonic(_PyTime_t *tp, _Py_clock_info_t *info, int raise)
         }
 
         /* Check that timebase.numer and timebase.denom can be casted to
-           _PyTime_t. In pratice, timebase uses uint32_t, so casting cannot
+           _PyTime_t. In practice, timebase uses uint32_t, so casting cannot
            overflow. At the end, only make sure that the type is uint32_t
            (_PyTime_t is 64-bit long). */
         assert(sizeof(timebase.numer) < sizeof(_PyTime_t));

--- a/Tools/c-globals/README
+++ b/Tools/c-globals/README
@@ -21,7 +21,7 @@ which addresses the situation for extension modules in general.
 
 Globals in the last category should be avoided as well.  The problem
 isn't with the Python runtime having state.  Rather, the problem is with
-that state being spread thoughout the codebase in dozens of individual
+that state being spread throughout the codebase in dozens of individual
 globals.  Unlike the other globals, the runtime state represents a set
 of values that are constantly shifting in a complex way.  When they are
 spread out it's harder to get a clear picture of what the runtime

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -100,7 +100,7 @@ dnl Check to see whether a particular set of modules exists. Similar to
 dnl PKG_CHECK_MODULES(), but does not set variables or print errors.
 dnl
 dnl Please remember that m4 expands AC_REQUIRE([PKG_PROG_PKG_CONFIG])
-dnl only at the first occurence in configure.ac, so if the first place
+dnl only at the first occurrence in configure.ac, so if the first place
 dnl it's called might be skipped (such as if it is within an "if", you
 dnl have to call PKG_CHECK_EXISTS manually
 AC_DEFUN([PKG_CHECK_EXISTS],

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -100,7 +100,7 @@ dnl Check to see whether a particular set of modules exists. Similar to
 dnl PKG_CHECK_MODULES(), but does not set variables or print errors.
 dnl
 dnl Please remember that m4 expands AC_REQUIRE([PKG_PROG_PKG_CONFIG])
-dnl only at the first occurrence in configure.ac, so if the first place
+dnl only at the first occurence in configure.ac, so if the first place
 dnl it's called might be skipped (such as if it is within an "if", you
 dnl have to call PKG_CHECK_EXISTS manually
 AC_DEFUN([PKG_CHECK_EXISTS],


### PR DESCRIPTION
Most are trivial. Some are user facing.  Found using:
`codespell -q 3 -I '../cpy-whitelist.txt'`
whereby the whitelist contained:
```
ans
dum
efford
iff
ot
nto
que
teh
te
thru
upto
whitespaces
```