### PR TITLE
[2.7] bpo-30806: Fix netrc.__repr__() format (GH-2491)

### DIFF
--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -130,12 +130,12 @@ class netrc:
         rep = ""
         for host in self.hosts.keys():
             attrs = self.hosts[host]
-            rep += f"machine {host}\n\tlogin {attrs[0]}\n"
+            rep += "machine {host}\n\tlogin {attrs[0]}\n".format(host=host, attrs=attrs)
             if attrs[1]:
-                rep += f"\taccount {attrs[1]}\n"
-            rep += f"\tpassword {attrs[2]}\n"
+                rep += "\taccount {attrs[1]}\n".format(attrs=attrs)
+            rep += "\tpassword {attrs[2]}\n".format(attrs=attrs)
         for macro in self.macros.keys():
-            rep += f"macdef {macro}\n"
+            rep += "macdef {macro}\n".format(macro=macro)
             for line in self.macros[macro]:
                 rep += line
             rep += "\n"

--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -130,15 +130,15 @@ class netrc:
         rep = ""
         for host in self.hosts.keys():
             attrs = self.hosts[host]
-            rep = rep + "machine "+ host + "\n\tlogin " + repr(attrs[0]) + "\n"
+            rep += f"machine {host}\n\tlogin {attrs[0]}\n"
             if attrs[1]:
-                rep = rep + "account " + repr(attrs[1])
-            rep = rep + "\tpassword " + repr(attrs[2]) + "\n"
+                rep += f"\taccount {attrs[1]}\n"
+            rep += f"\tpassword {attrs[2]}\n"
         for macro in self.macros.keys():
-            rep = rep + "macdef " + macro + "\n"
+            rep += f"macdef {macro}\n"
             for line in self.macros[macro]:
-                rep = rep + line
-            rep = rep + "\n"
+                rep += line
+            rep += "\n"
         return rep
 
 if __name__ == '__main__':

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -11,7 +11,7 @@ class NetrcTestCase(unittest.TestCase):
         if sys.platform != 'cygwin':
             mode += 't'
         temp_fd, temp_filename = tempfile.mkstemp()
-        with os.fdopen(temp_fd, mode=mode) as fp:
+        with os.fdopen(temp_fd, mode) as fp:
             fp.write(test_data)
         self.addCleanup(os.unlink, temp_filename)
         return netrc.netrc(temp_filename)

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -1,31 +1,31 @@
-import netrc, os, unittest, sys, tempfile, textwrap
+import netrc, os, unittest, sys, textwrap
 from test import test_support
 
 temp_filename = test_support.TESTFN
 
 class NetrcTestCase(unittest.TestCase):
 
-    def make_nrc(self, test_data):
+    def make_nrc(self, test_data, cleanup=True):
         test_data = textwrap.dedent(test_data)
         mode = 'w'
         if sys.platform != 'cygwin':
             mode += 't'
-        temp_fd, temp_filename = tempfile.mkstemp()
-        with os.fdopen(temp_fd, mode) as fp:
+        with open(temp_filename, mode) as fp:
             fp.write(test_data)
-        self.addCleanup(os.unlink, temp_filename)
+        if cleanup:
+            self.addCleanup(os.unlink, temp_filename)
         return netrc.netrc(temp_filename)
 
     def test_default(self):
         nrc = self.make_nrc("""\
             machine host1.domain.com login log1 password pass1 account acct1
             default login log2 password pass2
-            """)
+            """, cleanup=False)
         self.assertEqual(nrc.hosts['host1.domain.com'],
                          ('log1', 'acct1', 'pass1'))
         self.assertEqual(nrc.hosts['default'], ('log2', None, 'pass2'))
 
-        nrc2 = self.make_nrc(nrc.__repr__())
+        nrc2 = self.make_nrc(nrc.__repr__(), cleanup=True)
         self.assertEqual(nrc.hosts, nrc2.hosts)
 
     def test_macros(self):

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -1,4 +1,4 @@
-import netrc, os, unittest, sys, textwrap
+import netrc, os, unittest, sys, tempfile, textwrap
 from test import test_support
 
 temp_filename = test_support.TESTFN
@@ -10,7 +10,8 @@ class NetrcTestCase(unittest.TestCase):
         mode = 'w'
         if sys.platform != 'cygwin':
             mode += 't'
-        with open(temp_filename, mode) as fp:
+        temp_fd, temp_filename = tempfile.mkstemp()
+        with os.fdopen(temp_fd, mode=mode) as fp:
             fp.write(test_data)
         self.addCleanup(os.unlink, temp_filename)
         return netrc.netrc(temp_filename)
@@ -23,6 +24,9 @@ class NetrcTestCase(unittest.TestCase):
         self.assertEqual(nrc.hosts['host1.domain.com'],
                          ('log1', 'acct1', 'pass1'))
         self.assertEqual(nrc.hosts['default'], ('log2', None, 'pass2'))
+
+        nrc2 = self.make_nrc(nrc.__repr__())
+        self.assertEqual(nrc.hosts, nrc2.hosts)
 
     def test_macros(self):
         nrc = self.make_nrc("""\

--- a/Misc/NEWS.d/next/Library/2017-09-29.bpo-30806.lP5GrH.rst
+++ b/Misc/NEWS.d/next/Library/2017-09-29.bpo-30806.lP5GrH.rst
@@ -1,0 +1,1 @@
+Fix the string representation of a netrc object.


### PR DESCRIPTION
Backports the fix for https://bugs.python.org/issue30806 and updates the syntax for Python 2.7 compatibility.


<!-- issue-number: bpo-30806 -->
https://bugs.python.org/issue30806
<!-- /issue-number -->
