### PR TITLE
bpo-31942: Document optional support of start and stop attributes in Sequence.index method

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -973,12 +973,11 @@ Notes:
 
 (8)
    ``index`` raises :exc:`ValueError` when *x* is not found in *s*.
-   Not all implementations support passing the additional arguments
-   *i* and *j*.  These arguments allow efficient searching of
-   subsections of the sequence. Passing the extra arguments is roughly
-   equivalent to using ``s[i:j].index(x)``, only without copying any
-   data and with the returned index being relative to the start of the
-   sequence rather than the start of the slice.
+   Not all implementations support passing the additional arguments *i* and *j*.
+   These arguments allow efficient searching of subsections of the sequence. Passing
+   the extra arguments is roughly equivalent to using ``s[i:j].index(x)``, only
+   without copying any data and with the returned index being relative to
+   the start of the sequence rather than the start of the slice.
 
 
 .. _typesseq-immutable:

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -973,12 +973,12 @@ Notes:
 
 (8)
    ``index`` raises :exc:`ValueError` when *x* is not found in *s*.
-   Not all implementations support passing the additional arguments *i* and *j*.
-   When supported, these arguments allow efficient searching of
+   Not all implementations support passing the additional arguments
+   *i* and *j*.  These arguments allow efficient searching of
    subsections of the sequence. Passing the extra arguments is roughly
-   equivalent to using ``s[i:j].index(x)``, only without copying any data
-   and with the returned index being relative to the start of the sequence
-   rather than the start of the slice.
+   equivalent to using ``s[i:j].index(x)``, only without copying any
+   data and with the returned index being relative to the start of the
+   sequence rather than the start of the slice.
 
 
 .. _typesseq-immutable:

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -973,11 +973,12 @@ Notes:
 
 (8)
    ``index`` raises :exc:`ValueError` when *x* is not found in *s*.
-   When supported, the additional arguments to the index method allow
-   efficient searching of subsections of the sequence. Passing the extra
-   arguments is roughly equivalent to using ``s[i:j].index(x)``, only
-   without copying any data and with the returned index being relative to
-   the start of the sequence rather than the start of the slice.
+   Not all implementations support passing the additional arguments *i* and *j*.
+   When supported, these allow efficient searching of subsections of the
+   sequence. Passing the extra arguments is roughly equivalent to using
+   ``s[i:j].index(x)``, only without copying any data and with the
+   returned index being relative to the start of the sequence rather than
+   the start of the slice.
 
 
 .. _typesseq-immutable:

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -974,11 +974,11 @@ Notes:
 (8)
    ``index`` raises :exc:`ValueError` when *x* is not found in *s*.
    Not all implementations support passing the additional arguments *i* and *j*.
-   When supported, these allow efficient searching of subsections of the
-   sequence. Passing the extra arguments is roughly equivalent to using
-   ``s[i:j].index(x)``, only without copying any data and with the
-   returned index being relative to the start of the sequence rather than
-   the start of the slice.
+   When supported, these arguments allow efficient searching of
+   subsections of the sequence. Passing the extra arguments is roughly
+   equivalent to using ``s[i:j].index(x)``, only without copying any data
+   and with the returned index being relative to the start of the sequence
+   rather than the start of the slice.
 
 
 .. _typesseq-immutable:

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -900,8 +900,8 @@ class Sequence(Reversible, Collection):
         '''S.index(value, [start, [stop]]) -> integer -- return first index of value.
            Raises ValueError if the value is not present.
 
-           It is not required that all concrete implementations of
-           the Sequence class support start and stop attributes.
+           Supporting start and stop arguments is optional, but
+           recommended.
 
         '''
         if start is not None and start < 0:

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -902,7 +902,6 @@ class Sequence(Reversible, Collection):
 
            Supporting start and stop arguments is optional, but
            recommended.
-
         '''
         if start is not None and start < 0:
             start = max(len(self) + start, 0)

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -899,6 +899,10 @@ class Sequence(Reversible, Collection):
     def index(self, value, start=0, stop=None):
         '''S.index(value, [start, [stop]]) -> integer -- return first index of value.
            Raises ValueError if the value is not present.
+
+           It is however not required that all concrete implementations of
+           the Sequence class support start and stop attributes.
+
         '''
         if start is not None and start < 0:
             start = max(len(self) + start, 0)

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -900,7 +900,7 @@ class Sequence(Reversible, Collection):
         '''S.index(value, [start, [stop]]) -> integer -- return first index of value.
            Raises ValueError if the value is not present.
 
-           It is however not required that all concrete implementations of
+           It is not required that all concrete implementations of
            the Sequence class support start and stop attributes.
 
         '''


### PR DESCRIPTION
I changed the method docstring and also the html documentation to say that not all implementations are required to support  start and stop attributes. Is a NEWS entry required for this?

Bug: https://bugs.python.org/issue31942

<!-- issue-number: bpo-31942 -->
https://bugs.python.org/issue31942
<!-- /issue-number -->
