### PR TITLE
bpo-31944: Fixes build and Modify button

### DIFF
--- a/Misc/NEWS.d/next/Windows/2017-11-04-15-29-47.bpo-31944.0Bx8tZ.rst
+++ b/Misc/NEWS.d/next/Windows/2017-11-04-15-29-47.bpo-31944.0Bx8tZ.rst
@@ -1,0 +1,1 @@
+Fixes Modify button in Apps and Features dialog.

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -7,6 +7,7 @@
     <OutDir Condition="!HasTrailingSlash($(OutDir))">$(OutDir)\</OutDir>
     <Py_IntDir Condition="'$(Py_IntDir)' == ''">$(MSBuildThisFileDirectory)obj\</Py_IntDir>
     <IntDir>$(Py_IntDir)\$(MajorVersionNumber)$(MinorVersionNumber)$(ArchName)_$(Configuration)\$(ProjectName)\</IntDir>
+    <IntDir>$(IntDir.Replace(`\\`, `\`))</IntDir>
     <TargetName Condition="'$(TargetName)' == ''">$(ProjectName)</TargetName>
     <TargetName>$(TargetName)$(PyDebugExt)</TargetName>
     <GenerateManifest>false</GenerateManifest>

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -73,8 +73,8 @@
     possible version). Since we limit WINVER to Windows 7 anyway, it doesn't really
     matter which WinSDK version we use.
     -->
-    <DefaultWindowsSDKVersion Condition="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion) == '10.0.15063'">10.0.15063.0</DefaultWindowsSDKVersion>
-    <DefaultWindowsSDKVersion Condition="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion) == '10.0.15063'">10.0.15063.0</DefaultWindowsSDKVersion>
+    <DefaultWindowsSDKVersion Condition="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion) >= '10.0.15063'">10.0.15063.0</DefaultWindowsSDKVersion>
+    <DefaultWindowsSDKVersion Condition="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion) >= '10.0.15063'">10.0.15063.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion) == '10.0.14393'">10.0.14393.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion) == '10.0.14393'">10.0.14393.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion) == '10.0.10586'">10.0.10586.0</DefaultWindowsSDKVersion>

--- a/Tools/msi/bundle/bootstrap/pythonba.vcxproj
+++ b/Tools/msi/bundle/bootstrap/pythonba.vcxproj
@@ -26,12 +26,14 @@
     <ProjectGuid>{7A09B132-B3EE-499B-A700-A4B2157FEA3D}</ProjectGuid>
     <TargetName>PythonBA</TargetName>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <Import Project="..\..\wix.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <IntDir>$(Py_IntDir)\$(Configuration)_$(Platform)_Setup\Bootstrap\</IntDir>
+    <Py_IntDir Condition="'$(Py_IntDir)' == ''">$(PySourcePath)PCbuild\obj\</Py_IntDir>
+    <IntDir>$(Py_IntDir)\$(MajorVersionNumber)$(MinorVersionNumber)$(ArchName)_$(Configuration)\msi_$(ProjectName)\</IntDir>
+    <IntDir>$(IntDir.Replace(`\\`, `\`))</IntDir>
     <OutDir>$(IntDir)</OutDir>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />

--- a/Tools/msi/bundle/bundle.wxs
+++ b/Tools/msi/bundle/bundle.wxs
@@ -8,7 +8,6 @@
           IconSourceFile="..\..\..\PC\icons\setup.ico"
           Manufacturer="!(loc.Manufacturer)"
           AboutUrl="http://www.python.org/"
-          DisableModify="button"
           Compressed="no"
           dep:ProviderKey="CPython-$(var.MajorVersionNumber).$(var.MinorVersionNumber)$(var.PyArchExt)$(var.PyTestExt)">
     <BootstrapperApplication Id="PythonBA" SourceFile="$(var.BootstrapApp)">


### PR DESCRIPTION
Fixes the Modify button when installed on Windows 10.
Also makes the build work just a little better.

<!-- issue-number: bpo-31944 -->
https://bugs.python.org/issue31944
<!-- /issue-number -->
