### PR TITLE
bpo-31609: Fixes quotes in PCbuild/clean.bat

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-11-04-15-35-08.bpo-31609.k7_nBR.rst
+++ b/Misc/NEWS.d/next/Build/2017-11-04-15-35-08.bpo-31609.k7_nBR.rst
@@ -1,0 +1,1 @@
+Fixes quotes in PCbuild/clean.bat

--- a/PCbuild/clean.bat
+++ b/PCbuild/clean.bat
@@ -2,4 +2,4 @@
 rem A batch program to clean a particular configuration,
 rem just for convenience.
 
-call %~dp0build.bat -t Clean %*
+call "%~dp0build.bat" -t Clean %*


### PR DESCRIPTION
Fixes quotes in PCbuild/clean.bat

<!-- issue-number: bpo-31609 -->
https://bugs.python.org/issue31609
<!-- /issue-number -->
