### PR TITLE
bpo-25942: Added new parameter to subprocess.run(): cleanup_timeout

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -76,6 +76,14 @@ compatibility with older versions, see the :ref:`call-function-trio` section.
    The *universal_newlines* argument is equivalent  to *text* and is provided
    for backwards compatibility. By default, file objects are opened in binary mode.
 
+   If the current process recevies a :exc:`KeyboardInterrupt` and
+   *cleanup_timeout* is non-zero, the child process is given additional
+   time to finish before it is killed, to allow potential clean-up operations
+   in the child to complete. During this time, a second :exc:`KeyboardInterrupt`
+   will kill the child immediately. If *cleanup_timeout* is not specified,
+   then any remaining time from the original *timeout* is used, or 1 second
+   if no original *timeout* was specified.
+
    Examples::
 
       >>> subprocess.run(["ls", "-l"])  # doesn't capture output
@@ -97,8 +105,10 @@ compatibility with older versions, see the :ref:`call-function-trio` section.
       Added *encoding* and *errors* parameters
 
    .. versionchanged:: 3.7
-
       Added the *text* parameter, as a more understandable alias of *universal_newlines*
+
+   .. versionchanged:: 3.7
+      *cleanup_timeout* was added.
 
 .. class:: CompletedProcess
 
@@ -860,7 +870,7 @@ Prior to Python 3.5, these three functions comprised the high level API to
 subprocess. You can now use :func:`run` in many cases, but lots of existing code
 calls these functions.
 
-.. function:: call(args, *, stdin=None, stdout=None, stderr=None, shell=False, cwd=None, timeout=None)
+.. function:: call(args, *, stdin=None, stdout=None, stderr=None, shell=False, cwd=None, timeout=None, cleanup_timeout=None)
 
    Run the command described by *args*.  Wait for command to complete, then
    return the :attr:`~Popen.returncode` attribute.
@@ -885,6 +895,9 @@ calls these functions.
 
    .. versionchanged:: 3.3
       *timeout* was added.
+
+   .. versionchanged:: 3.7
+      *cleanup_timeout* was added.
 
 .. function:: check_call(args, *, stdin=None, stdout=None, stderr=None, shell=False, cwd=None, timeout=None)
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -76,13 +76,13 @@ compatibility with older versions, see the :ref:`call-function-trio` section.
    The *universal_newlines* argument is equivalent  to *text* and is provided
    for backwards compatibility. By default, file objects are opened in binary mode.
 
-   If the current process recevies a :exc:`KeyboardInterrupt` and
-   *cleanup_timeout* is non-zero, the child process is given additional
-   time to finish before it is killed, to allow potential clean-up operations
-   in the child to complete. During this time, a second :exc:`KeyboardInterrupt`
-   will kill the child immediately. If *cleanup_timeout* is not specified,
-   then any remaining time from the original *timeout* is used, or 1 second
-   if no original *timeout* was specified.
+   If the current process encounters an exception (e.g. :exc:`KeyboardInterrupt`)
+   while waiting for the child process and *cleanup_timeout* is non-zero,
+   the child process is given additional time to finish before it is killed,
+   to allow potential clean-up operations in the child to complete.
+   During this time, a second exception will kill the child immediately.
+   If *cleanup_timeout* is not specified, then any remaining time from the original
+   *timeout* is used, or 1 second if no original *timeout* was specified.
 
    Examples::
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -441,7 +441,6 @@ def run(*popenargs, input=None, timeout=None, check=False, cleanup_timeout=None,
                 process.wait()
                 raise KeyboardInterrupt
         except:
-            print("Killing!")
             process.kill()
             process.wait()
             raise

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -430,13 +430,18 @@ def run(*popenargs, input=None, timeout=None, check=False, cleanup_timeout=None,
                     cleanup_timeout = max(0.0, remaining_timeout)
 
             if cleanup_timeout == 0.0:
+                process.kill()
+                process.wait()
                 raise
             try:
                 process.wait(timeout=cleanup_timeout)
                 raise
             except TimeoutExpired:
+                process.kill()
+                process.wait()
                 raise KeyboardInterrupt
         except:
+            print("Killing!")
             process.kill()
             process.wait()
             raise

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -263,14 +263,7 @@ def call(*popenargs, timeout=None, **kwargs):
 
     retcode = call(["ls", "-l"])
     """
-    with Popen(*popenargs, **kwargs) as p:
-        try:
-            return p.wait(timeout=timeout)
-        except:
-            p.kill()
-            p.wait()
-            raise
-
+    return run(*popenargs, timeout=timeout, **kwargs).returncode
 
 def check_call(*popenargs, **kwargs):
     """Run command with arguments.  Wait for command to complete.  If

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -270,7 +270,7 @@ def call(*popenargs, timeout=None, cleanup_timeout=None, **kwargs):
     Example:
       retcode = call(["ls", "-l"])
     """
-    return run(*popenargs, timeout=timeout, cleanup_timeout=None, **kwargs).returncode
+    return run(*popenargs, timeout=timeout, cleanup_timeout=cleanup_timeout, **kwargs).returncode
 
 def check_call(*popenargs, **kwargs):
     """Run command with arguments.  Wait for command to complete.  If

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -270,7 +270,8 @@ def call(*popenargs, timeout=None, cleanup_timeout=None, **kwargs):
     Example:
       retcode = call(["ls", "-l"])
     """
-    return run(*popenargs, timeout=timeout, cleanup_timeout=cleanup_timeout, **kwargs).returncode
+    return run(*popenargs, timeout=timeout, cleanup_timeout=cleanup_timeout,
+               **kwargs).returncode
 
 def check_call(*popenargs, **kwargs):
     """Run command with arguments.  Wait for command to complete.  If
@@ -386,13 +387,16 @@ def run(*popenargs, input=None, timeout=None, check=False, cleanup_timeout=None,
     If timeout is given, and the process takes too long, a TimeoutExpired
     exception will be raised.
 
-    If the current process recevies a KeyboardInterrupt and
+    If the current process encounters any exception (e.g. KeyboardInterrupt) and
     cleanup_timeout is non-zero, the child process is given some additional
     time to finish before it is killed, to allow potential clean-up
-    operations in the child to complete. During this time, a second KeyboardInterrupt
-    will kill the child immediately. If cleanup_timeout is not specified,
-    then any remaining time from the original timeout is used, or 1.0 if no
-    original timeout was specified.
+    operations in the child to complete. During this time, a second exception
+    will kill the child immediately.
+
+    If cleanup_timeout is not specified, then a default value is chosen:
+    If timeout was provided, then any remaining time from the original timeout
+    is used.  Otherwise, if the exception is a KeyboardInterrupt, the child is
+    given 1 second to clean up. Otherwise, the child is killed immediately.
 
     There is an optional argument "input", allowing you to
     pass bytes or a string to the subprocess's stdin.  If you use this argument
@@ -422,28 +426,53 @@ def run(*popenargs, input=None, timeout=None, check=False, cleanup_timeout=None,
             stdout, stderr = process.communicate()
             raise TimeoutExpired(process.args, timeout, output=stdout,
                                  stderr=stderr)
-        except KeyboardInterrupt:
-            if cleanup_timeout is None:
-                cleanup_timeout = 1.0
-                if timeout:
-                    remaining_timeout = timeout - (_time() - start_time)
-                    cleanup_timeout = max(0.0, remaining_timeout)
-
-            if cleanup_timeout == 0.0:
-                process.kill()
-                process.wait()
-                raise
+        except BaseException as ex:
             try:
-                process.wait(timeout=cleanup_timeout)
-                raise
-            except TimeoutExpired:
+                if cleanup_timeout is None:
+                    # Choose a reasonable default
+                    if timeout:
+                        remaining_timeout = timeout - (_time() - start_time)
+                        cleanup_timeout = max(0.0, remaining_timeout)
+                    elif isinstance(ex, KeyboardInterrupt):
+                        # KeyboardInterrupts are:
+                        # 1. Typically automatically triggered in the child, too.
+                        #    Therefore, the child is likely to be already cleaning up
+                        #    (if we give it the chance).
+                        # 2. Generated interactively by humans at a keyboard.
+                        #    If the child is well-written (exits in response to SIGINT),
+                        #    a 1 second timeout is usually enough time for it to clean up.
+                        #    Othwerwise, 1 second seems like a tolerable delay in response to Ctrl+C,
+                        #    and a resonable price to pay for correct behavior in the well-written case.
+                        cleanup_timeout = 1.0
+                    else:
+                        # The above reasoning does not apply to arbitrary exceptions,
+                        # so kill the child immediately.
+                        cleanup_timeout = 0.0
+
+                if cleanup_timeout == 0.0:
+                    raise # Skip cleanup
+
+                # Close streams to/from child
+                streams = (process.stdin, process.stdout, process.stderr)
+                for f in filter(None, streams):
+                    try:
+                        f.close()
+                    except:
+                        pass  # Ignore EBADF or other errors.
+
+                try:
+                    process.wait(timeout=cleanup_timeout)
+                except:
+                    # Ignore cleanup errors;
+                    # original exception is always re-raised below
+                    pass
+            finally:
+                # Kill the child and re-raise original exception,
+                # regardless of successful/failed cleanup
                 process.kill()
                 process.wait()
-                raise KeyboardInterrupt
-        except:
-            process.kill()
-            process.wait()
-            raise
+                raise ex
+
         retcode = process.poll()
         if check and retcode:
             raise CalledProcessError(retcode, process.args,

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1504,13 +1504,14 @@ class RunFuncTestCase(BaseTestCase):
             # Send SIGINT to the current process group after a short delay
             time.sleep(0.5)
             os.killpg(os.getpgrp(), signal.SIGINT)
+        interrupter_thread = threading.Thread(target=interrupt_this_process_group)
 
         tf = tempfile.NamedTemporaryFile(delete=False)
         tf.close()
-
+        
         try:
             with self.assertRaises(KeyboardInterrupt):
-                threading.Thread(target=interrupt_this_process_group).start()
+                interrupter_thread.start()
                 subprocess.run([sys.executable, "-c",
                                 "import time\n"
                                 "try:\n"
@@ -1531,6 +1532,7 @@ class RunFuncTestCase(BaseTestCase):
             # Restore original process group
             os.setpgid(0, original_pgid)
             os.unlink(tf.name)
+            interrupter_thread.join()
 
 @unittest.skipIf(mswindows, "POSIX specific tests")
 class POSIXProcessTestCase(BaseTestCase):

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1508,7 +1508,7 @@ class RunFuncTestCase(BaseTestCase):
 
         tf = tempfile.NamedTemporaryFile(delete=False)
         tf.close()
-        
+
         try:
             with self.assertRaises(KeyboardInterrupt):
                 interrupter_thread.start()

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1509,7 +1509,7 @@ class RunFuncTestCase(BaseTestCase):
         tf.close()
 
         try:
-            with self.assertRaises(KeyboardInterrupt) as ex:
+            with self.assertRaises(KeyboardInterrupt):
                 threading.Thread(target=interrupt_this_process_group).start()
                 subprocess.run([sys.executable, "-c",
                                 "import time\n"

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1518,7 +1518,8 @@ class RunFuncTestCase(BaseTestCase):
                                 "  time.sleep(3.0)\n"
                                 "except KeyboardInterrupt:\n"
                                f"  time.sleep({cleanup_time})\n"
-                               f"  open('{tf.name}', 'w').write('cleaned up')\n"],
+                               f"  with open('{tf.name}', 'w') as f:\n"
+                                "    f.write('cleaned up')\n"],
                                 timeout=None, cleanup_timeout=cleanup_timeout,
                                 check=True)
 

--- a/Misc/NEWS.d/next/Library/2017-11-05-11-42-56.bpo-25942.o5lBhR.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-05-11-42-56.bpo-25942.o5lBhR.rst
@@ -1,0 +1,1 @@
+Added new parameter, ``cleanup_timeout``, to ``subprocess.run()``


### PR DESCRIPTION
**EDIT:** This PR was ultimately superseded by #5026

---

**Summary:**

`subprocess.call()` (and now also `subprocess.run()`) behave badly in the event of `SIGINT`, i.e. a user hitting `Ctrl+C` while the subprocess is running.  This was first reported by @pilcrow in [[bpo-25942](https://bugs.python.org/issue25942)][1].

[1]: https://bugs.python.org/issue25942

Several possible solutions were discussed (by @vadmium, @pilcrow, and @haypo), but no action was taken.  Among them was this suggestion from @haypo:

>If you really want to give time to the child process, I suggest to add a *new* optional parameter . For example `ctrlc_timeout=5.0`

IMHO, that is the best option, and certainly much better than the status quo.  I've implemented that solution in this PR. (It is also similar to a proposal by @vadmium in that thread.)

**Background: POSIX behavior for Ctrl+C**

In general, when the user hits `Ctrl+C`, the OS [sends `SIGINT` to *all processes* in the foreground process group][2], including any child processes launched via `subprocess call()`.  That is, both Python and it's child will automatically see the `SIGINT`; there is no need to explicitly send a duplicate `SIGINT` to the child.

[2]: https://unix.stackexchange.com/a/149756/109091

**What this PR does:**

Upon receiving the `SIGINT` in the form of a `KeyboardInterrupt`, `call()` will wait *again* for the child process, but with `cleanup_timeout`, giving the child process time to perform cleanup actions.  If that timeout expires, then the child process is killed.  (Alternatively, during this time, the user can hit `Ctrl+C` again to immediately stop waiting and kill the child process.)

**What this PR does not do:**

This PR attempts to make `subprocess.call()` behave in a less surprising manner in the context of interactive terminal applications, in which the user is likely to expect `Ctrl+C` to work properly.  If the child process does not handle `SIGINT` properly, we make no attempt to kill it via alternative means, such as `SIGTERM`.  If the developer needs such control over how the child is to be killed in the event of a `KeyboardInterrupt`, she should use the `Popen` API directly instead of calling `subprocess.call()` or `run()`.

**Open question 1:**

It is not entirely clear what the default value of `cleanup_timeout` should be.  Setting it to 0 by default seems to defeat the purpose and wouldn't help naïve users write code that "just works".

On the other hand, setting it to an arbitrary value like `5.0` seems... arbitrary.  If the cleanup takes a long time, then we'd be killing it too soon.  But if the child doesn't handle `SIGINT` anyway, then we'd be wasting 5 seconds for no reason (unless the user hits `Ctrl+C` a second time).

For now, I've set the default value as follows:
 - If `timeout` was specified, use that. The child cleanup time must be less than its total expected runtime.
 - If `timeout` was not specified, then use `1.0`.  If the child process handles `SIGINT`, this introduces no extra delay.  If it does not handle `SIGINT`, then 1 second seems like a reasonable delay for what is likely a rare event an interactive console application.

**Open question 2:**

According to the docs, `subprocess.call()` is equivalent to `subprocess.run().returncode`.  Yet, these are currently implemented as independent functions (and I left it that way).  Is there any objection to replacing `subprocess.call()` with the following?

```python
def call(*popenargs, timeout=None, cleanup_timeout=None, **kwargs):
    return run(*popenargs, timeout=timeout, cleanup_timeout=cleanup_timeout, **kwargs).returncode
```

(That would also allow me to remove the mostly duplicated test code in this PR.)

<!-- issue-number: [bpo-25942](https://bugs.python.org/issue25942) -->
https://bugs.python.org/issue25942
<!-- /issue-number -->
