### PR TITLE
bpo-22257: Mention startup refactoring in What's New

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -686,6 +686,20 @@ CPython bytecode changes
   (Contributed by Yury Selivanov and INADA Naoki in :issue:`26110`.)
 
 
+Other CPython implementation changes
+------------------------------------
+
+* In preparation for potential future changes to the public CPython runtime
+  initialization API (see :pep:`432` for details), CPython's internal startup
+  and configuration management logic has been significantly refactored. While
+  these updates are intended to be entirely transparent to both embedding
+  applications and users of the regular CPython CLI, they're being mentioned
+  here as the refactoring changes the internal order of various operations
+  during interpreter startup, and hence may uncover previously latent defects,
+  either in embedding applications, or in CPython itself.
+  (Contributed by Nick Coghlan and Eric Snow as part of :issue:`22257`.)
+
+
 Documentation
 =============
 


### PR DESCRIPTION
While technically a purely internal change, bpo-31845 was
a fairly significant externally visible bug caused by
these changes (environment variable based configuration
was being ignored due to a change in the relative order
of reading the environment and reading command line settings,
and the test suite was only testing the command line options)

Hence this note to essentially say "If you see odd startup
problems in 3.7 that you've never seen in previous releases,
it's probably our fault, so let us know, and we'll fix it".


<!-- issue-number: bpo-22257 -->
https://bugs.python.org/issue22257
<!-- /issue-number -->
