### PR TITLE
bpo-31947: names=None case is not handled by EnumMeta._create_ method

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -359,7 +359,7 @@ class EnumMeta(type):
             raise AttributeError('Cannot reassign members.')
         super().__setattr__(name, value)
 
-    def _create_(cls, class_name, names=None, *, module=None, qualname=None, type=None, start=1):
+    def _create_(cls, class_name, names, *, module=None, qualname=None, type=None, start=1):
         """Convenience method to create a new Enum class.
 
         `names` can be:


### PR DESCRIPTION
It seems to me that this method should not have `names=None` default value in signature, because that case is not handled, nor is it described as a possible value in the docstring.

Seems like maybe a copy and paste from `__call__`, which has basically same signature, but `names=None` is valid and handled there.

Or I humbly admit maybe there's something more going on that I'm not aware of. Anyway, I propose this small change.

<!-- issue-number: bpo-31947 -->
https://bugs.python.org/issue31947
<!-- /issue-number -->
