### PR TITLE
bpo-31949: Fixed several issues in printing tracebacks (PyTraceBack_Print()).

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-05-16-11-07.bpo-31949.2yNC_z.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-05-16-11-07.bpo-31949.2yNC_z.rst
@@ -1,0 +1,9 @@
+Fixed several issues in printing tracebacks (PyTraceBack_Print()).
+
+* Setting sys.tracebacklimit to 0 or less now suppresses printing tracebacks.
+* Setting sys.tracebacklimit to None now causes using the default limit.
+* Setting sys.tracebacklimit to an integer larger than LONG_MAX now means using
+  the limit LONG_MAX rather than the default limit.
+* Fixed integer overflows in the case of more than 2**31 traceback items on
+  Windows.
+* Fixed output errors handling.


### PR DESCRIPTION
* Setting sys.tracebacklimit to 0 or less now suppresses printing tracebacks.
* Setting sys.tracebacklimit to None now causes using the default limit.
* Setting sys.tracebacklimit to an integer larger than LONG_MAX now means using
  the limit LONG_MAX rather than the default limit.
* Fixed integer overflows in the case of more than 2**31 traceback items on
  Windows.
* Fixed output errors handling.

<!-- issue-number: bpo-31949 -->
https://bugs.python.org/issue31949
<!-- /issue-number -->
