### PR TITLE
[3.6] Fix miscellaneous typos  (GH-4275)

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -81,7 +81,7 @@ extension.cfg.  All take effect as soon as one clicks Apply or Ok.
 '<<zoom-height>>'.  Any (global) customizations made before 3.6.3 will
 not affect their keyset-specific customization after 3.6.3. and vice
 versa.
-  Inital patch by Charles Wohlganger, revised by Terry Jan Reedy.
+  Initial patch by Charles Wohlganger, revised by Terry Jan Reedy.
 
 bpo-31051:  Rearrange condigdialog General tab.
 Sort non-Help options into Window (Shell+Editor) and Editor (only).

--- a/Lib/idlelib/browser.py
+++ b/Lib/idlelib/browser.py
@@ -58,7 +58,7 @@ class ModuleBrowser:
     """Browse module classes and functions in IDLE.
     """
     # This class is also the base class for pathbrowser.PathBrowser.
-    # Init and close are inherited, other methods are overriden.
+    # Init and close are inherited, other methods are overridden.
     # PathBrowser.__init__ does not call __init__ below.
 
     def __init__(self, master, path, *, _htest=False, _utest=False):

--- a/Lib/idlelib/idle_test/test_replace.py
+++ b/Lib/idlelib/idle_test/test_replace.py
@@ -74,14 +74,14 @@ class ReplaceDialogTest(unittest.TestCase):
         replace()
         equal(text.get('1.8', '1.12'), 'asdf')
 
-        # dont "match word" case
+        # don't "match word" case
         text.mark_set('insert', '1.0')
         pv.set('is')
         rv.set('hello')
         replace()
         equal(text.get('1.2', '1.7'), 'hello')
 
-        # dont "match case" case
+        # don't "match case" case
         pv.set('string')
         rv.set('world')
         replace()

--- a/Lib/idlelib/paragraph.py
+++ b/Lib/idlelib/paragraph.py
@@ -158,7 +158,7 @@ def reformat_comment(data, limit, comment_header):
     newdata = reformat_paragraph(data, format_width)
     # re-split and re-insert the comment header.
     newdata = newdata.split("\n")
-    # If the block ends in a \n, we dont want the comment prefix
+    # If the block ends in a \n, we don't want the comment prefix
     # inserted after it. (Im not sure it makes sense to reformat a
     # comment block that is not made of complete lines, but whatever!)
     # Can't think of a clean solution, so we hack away


### PR DESCRIPTION
Backport idlelib changes in patch that fixed nearly 50 other files.
