### PR TITLE
bpo-31955: Correct distinguish of list and string values in set_executable() 

### DIFF
--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -151,10 +151,10 @@ class CCompiler:
             self.set_executable(key, kwargs[key])
 
     def set_executable(self, key, value):
-        if isinstance(value, basestring):
+        try:
+            setattr(self, key, value + []) 
+        except TypeError:
             setattr(self, key, split_quoted(value))
-        else:
-            setattr(self, key, value)
 
     def _find_macro(self, name):
         i = 0

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -154,7 +154,7 @@ class CCompiler:
         if hasattr(value, "strip"):
             setattr(self, key, split_quoted(value))
         else:
-            setattr(self, key, value) 
+            setattr(self, key, value)
 
     def _find_macro(self, name):
         i = 0

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -151,10 +151,10 @@ class CCompiler:
             self.set_executable(key, kwargs[key])
 
     def set_executable(self, key, value):
-        try:
-            setattr(self, key, value + []) 
-        except TypeError:
+        if hasattr(value, "strip"):
             setattr(self, key, split_quoted(value))
+        else:
+            setattr(self, key, value + []) 
 
     def _find_macro(self, name):
         i = 0

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -154,7 +154,7 @@ class CCompiler:
         if hasattr(value, "strip"):
             setattr(self, key, split_quoted(value))
         else:
-            setattr(self, key, value + []) 
+            setattr(self, key, value) 
 
     def _find_macro(self, name):
         i = 0

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -151,7 +151,7 @@ class CCompiler:
             self.set_executable(key, kwargs[key])
 
     def set_executable(self, key, value):
-        if isinstance(value, str):
+        if isinstance(value, basestring):
             setattr(self, key, split_quoted(value))
         else:
             setattr(self, key, value)


### PR DESCRIPTION
The check "if isinstance(value, str)" is incorrect, because type of value can be unicode, while it should be splitted as well.



<!-- issue-number: bpo-31955 -->
https://bugs.python.org/issue31955
<!-- /issue-number -->
