### PR TITLE
bpo-21862: Add -m option to cProfile for profiling modules

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -123,12 +123,14 @@ them in various ways.
 The file :mod:`cProfile` can also be invoked as a script to profile another
 script.  For example::
 
-   python -m cProfile [-o output_file] [-s sort_order] myscript.py
+   python -m cProfile [-o output_file] [-s sort_order] [-m module] myscript.py
 
 ``-o`` writes the profile results to a file instead of to stdout
 
 ``-s`` specifies one of the :func:`~pstats.Stats.sort_stats` sort values to sort
 the output by. This only applies when ``-o`` is not supplied.
+
+``-m`` specifies that a module is being profiled instead of a script.
 
 The :mod:`pstats` module's :class:`~pstats.Stats` class has a variety of methods
 for manipulating and printing the data saved into a profile results file::

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -133,6 +133,7 @@ the output by. This only applies when ``-o`` is not supplied.
 ``-m`` specifies that a module is being profiled instead of a script.
 
    .. versionadded:: 3.7
+      Added the ``-m`` option.
 
 The :mod:`pstats` module's :class:`~pstats.Stats` class has a variety of methods
 for manipulating and printing the data saved into a profile results file::

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -123,7 +123,7 @@ them in various ways.
 The file :mod:`cProfile` can also be invoked as a script to profile another
 script.  For example::
 
-   python -m cProfile [-o output_file] [-s sort_order] [-m module] myscript.py
+   python -m cProfile [-o output_file] [-s sort_order] (-m module | myscript.py)
 
 ``-o`` writes the profile results to a file instead of to stdout
 
@@ -131,6 +131,8 @@ script.  For example::
 the output by. This only applies when ``-o`` is not supplied.
 
 ``-m`` specifies that a module is being profiled instead of a script.
+
+   .. versionadded:: 3.7
 
 The :mod:`pstats` module's :class:`~pstats.Stats` class has a variety of methods
 for manipulating and printing the data saved into a profile results file::

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -255,6 +255,12 @@ contextlib
 :func:`contextlib.asynccontextmanager` has been added. (Contributed by
 Jelle Zijlstra in :issue:`29679`.)
 
+cProfile
+--------
+
+cProfile command line now accepts `-m module_name` as an alternative to
+script path. (Contributed by Sanyam Khurana in :issue:`21862`.)
+
 crypt
 -----
 

--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -121,9 +121,11 @@ def label(code):
 # ____________________________________________________________
 
 def main():
-    import os, sys
+    import os
+    import sys
+    import runpy
     from optparse import OptionParser
-    usage = "cProfile.py [-o output_file_path] [-s sort] scriptfile [arg] ..."
+    usage = "cProfile.py [-o output_file_path] [-s sort] [-m module | scriptfile] [arg] ..."
     parser = OptionParser(usage=usage)
     parser.allow_interspersed_args = False
     parser.add_option('-o', '--outfile', dest="outfile",
@@ -131,6 +133,8 @@ def main():
     parser.add_option('-s', '--sort', dest="sort",
         help="Sort order when printing to stdout, based on pstats.Stats class",
         default=-1)
+    parser.add_option('-m', dest="module", action="store_true",
+        help="Profile a library module", default=False)
 
     if not sys.argv[1:]:
         parser.print_usage()
@@ -140,16 +144,23 @@ def main():
     sys.argv[:] = args
 
     if len(args) > 0:
-        progname = args[0]
-        sys.path.insert(0, os.path.dirname(progname))
-        with open(progname, 'rb') as fp:
-            code = compile(fp.read(), progname, 'exec')
-        globs = {
-            '__file__': progname,
-            '__name__': '__main__',
-            '__package__': None,
-            '__cached__': None,
-        }
+        if options.module:
+            code = "runpy.run_module(modname, run_name='__main__')"
+            globs = {
+                'runpy': runpy,
+                'modname': args[0]
+            }
+        else:
+            progname = args[0]
+            sys.path.insert(0, os.path.dirname(progname))
+            with open(progname, 'rb') as fp:
+                code = compile(fp.read(), progname, 'exec')
+            globs = {
+                '__file__': progname,
+                '__name__': '__main__',
+                '__package__': None,
+                '__cached__': None,
+            }
         runctx(code, globs, None, options.outfile, options.sort)
     else:
         parser.print_usage()

--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -145,9 +145,9 @@ def main():
 
     if len(args) > 0:
         if options.module:
-            code = "runpy.run_module(modname, run_name='__main__')"
+            code = "run_module(modname, run_name='__main__')"
             globs = {
-                'runpy': runpy,
+                'run_module': runpy.run_module,
                 'modname': args[0]
             }
         else:

--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -44,7 +44,7 @@ class CProfileTest(ProfileTest):
         assert_python_failure('-m', 'cProfile', '-m')
 
         # Test failure for not-existent module
-        assert_python_failure('-m', 'cProfile', 'random_module_xyz')
+        assert_python_failure('-m', 'cProfile', '-m', 'random_module_xyz')
 
         # Test successful run
         assert_python_ok('-m', 'cProfile', '-m', 'timeit', '-n', '1')

--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -44,7 +44,7 @@ class CProfileTest(ProfileTest):
         assert_python_failure('-m', 'cProfile', '-m')
 
         # Test failure for not-existent module
-        assert_python_failure('-m', 'cProfile', 'random_module_xyz.py')
+        assert_python_failure('-m', 'cProfile', 'random_module_xyz')
 
         # Test successful run
         assert_python_ok('-m', 'cProfile', '-m', 'timeit', '-n', '1')

--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -6,6 +6,7 @@ from test.support import run_unittest, TESTFN, unlink
 # rip off all interesting stuff from test_profile
 import cProfile
 from test.test_profile import ProfileTest, regenerate_expected_output
+from test.support.script_helper import assert_python_failure, assert_python_ok
 
 
 class CProfileTest(ProfileTest):
@@ -34,6 +35,19 @@ class CProfileTest(ProfileTest):
                     sys.stderr = orig_stderr
         finally:
             unlink(TESTFN)
+
+    # Issue 21862
+    def test_module_path_option(self):
+        # Test -m switch with modules
+
+        # Test that -m switch needs an argument
+        assert_python_failure('-m', 'cProfile', '-m')
+
+        # Test failure for not-existent module
+        assert_python_failure('-m', 'cProfile', 'random_module_xyz.py')
+
+        # Test successful run
+        assert_python_ok('-m', 'cProfile', '-m', 'timeit', '-n', '1')
 
 
 def test_main():

--- a/Misc/NEWS.d/next/Library/2017-11-07-15-19-52.bpo-21862.RwietE.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-07-15-19-52.bpo-21862.RwietE.rst
@@ -1,0 +1,2 @@
+cProfile command line now accepts `-m module_name` as an alternative to
+script path. Patch by Sanyam Khurana.


### PR DESCRIPTION
Solves issue https://bugs.python.org/issue21862

<!-- issue-number: bpo-21862 -->
https://bugs.python.org/issue21862
<!-- /issue-number -->
