### PR TITLE
bpo-31843: sqlite3.connect() now accepts PathLike objects as database name

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -172,8 +172,8 @@ Module functions and constants
 
 .. function:: connect(database[, timeout, detect_types, isolation_level, check_same_thread, factory, cached_statements, uri])
 
-   Opens a connection to the SQLite database file *database* and return a
-   :class:`Connection` object.
+   Opens a connection to the SQLite database file *database*. By default returns a
+   :class:`Connection` object, unless a custom *factory* is given.
 
    *database* is a :term:`path-like object` giving the pathname (absolute or
    relative to the current  working directory) of the database file to be opened.

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -226,6 +226,7 @@ Module functions and constants
 
    .. versionchanged:: 3.4
       Added the *uri* parameter.
+
    .. versionchanged:: 3.7
       *database* can now also be a :term:`path-like object`, not only a string.
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -172,9 +172,13 @@ Module functions and constants
 
 .. function:: connect(database[, timeout, detect_types, isolation_level, check_same_thread, factory, cached_statements, uri])
 
-   Opens a connection to the SQLite database file *database*. You can use
-   ``":memory:"`` to open a database connection to a database that resides in RAM
-   instead of on disk.
+   Opens a connection to the SQLite database file *database* and return a
+   :class:`Connection` object.
+
+   *database* is a :term:`path-like object` giving the pathname (absolute or
+   relative to the current  working directory) of the database file to be opened.
+   You can use ``":memory:"`` to open a database connection to a database that
+   resides in RAM instead of on disk.
 
    When a database is accessed by multiple connections, and one of the processes
    modifies the database, the SQLite database is locked until that transaction is

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -226,6 +226,8 @@ Module functions and constants
 
    .. versionchanged:: 3.4
       Added the *uri* parameter.
+   .. versionchanged:: 3.7
+      *database* can now also be a :term:`path-like object`, not only a string.
 
 
 .. function:: register_converter(typename, callable)

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -160,6 +160,15 @@ class ConnectionTests(unittest.TestCase):
         with self.assertRaises(AttributeError):
             self.cx.in_transaction = True
 
+    def CheckOpenWithPathLikeObject(self):
+        """ Checks that we can succesfully connect to a database using an object that
+            is PathLike, i.e. has __fspath__(). """
+        self.addCleanup(unlink, TESTFN)
+        import pathlib
+        path = pathlib.Path(TESTFN)
+        with sqlite.connect(path) as cx:
+            cx.execute('create table test(id integer)')
+
     def CheckOpenUri(self):
         if sqlite.sqlite_version_info < (3, 7, 7):
             with self.assertRaises(sqlite.NotSupportedError):

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -164,8 +164,10 @@ class ConnectionTests(unittest.TestCase):
         """ Checks that we can succesfully connect to a database using an object that
             is PathLike, i.e. has __fspath__(). """
         self.addCleanup(unlink, TESTFN)
-        import pathlib
-        path = pathlib.Path(TESTFN)
+        class Path:
+            def __fspath__(self):
+                return TESTFN
+        path = Path()
         with sqlite.connect(path) as cx:
             cx.execute('create table test(id integer)')
 

--- a/Misc/NEWS.d/next/Library/2017-11-07-00-37-50.bpo-31843.lM2gkR.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-07-00-37-50.bpo-31843.lM2gkR.rst
@@ -1,0 +1,2 @@
+*database* argument of sqlite3.connect() now accepts a
+:term:`path-like object`, instead of just a string.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -127,6 +127,8 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
 #endif
     Py_END_ALLOW_THREADS
 
+    Py_DECREF(database_obj);
+
     if (rc != SQLITE_OK) {
         _pysqlite_seterror(self->db, NULL);
         return -1;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -76,6 +76,7 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     };
 
     char* database;
+    PyObject* database_obj;
     int detect_types = 0;
     PyObject* isolation_level = NULL;
     PyObject* factory = NULL;
@@ -85,13 +86,15 @@ int pysqlite_connection_init(pysqlite_Connection* self, PyObject* args, PyObject
     double timeout = 5.0;
     int rc;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|diOiOip", kwlist,
-                                     &database, &timeout, &detect_types,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&|diOiOip", kwlist,
+                                     PyUnicode_FSConverter, &database_obj, &timeout, &detect_types,
                                      &isolation_level, &check_same_thread,
                                      &factory, &cached_statements, &uri))
     {
         return -1;
     }
+
+    database = PyBytes_AsString(database_obj);
 
     self->initialized = 1;
 

--- a/Modules/_sqlite/module.c
+++ b/Modules/_sqlite/module.c
@@ -55,7 +55,7 @@ static PyObject* module_connect(PyObject* self, PyObject* args, PyObject*
         "check_same_thread", "factory", "cached_statements", "uri",
         NULL
     };
-    char* database;
+    PyObject* database;
     int detect_types = 0;
     PyObject* isolation_level;
     PyObject* factory = NULL;
@@ -66,7 +66,7 @@ static PyObject* module_connect(PyObject* self, PyObject* args, PyObject*
 
     PyObject* result;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "s|diOiOip", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O|diOiOip", kwlist,
                                      &database, &timeout, &detect_types,
                                      &isolation_level, &check_same_thread,
                                      &factory, &cached_statements, &uri))


### PR DESCRIPTION


<!-- issue-number: bpo-31843 -->
https://bugs.python.org/issue31843
<!-- /issue-number -->
