### PR TITLE
[2.7] Fix bpo-27666 backporting error in _cursesmodule.c 

### DIFF
--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -646,10 +646,10 @@ PyCursesWindow_Box(PyCursesWindowObject *self, PyObject *args)
     default:
         if (!PyArg_ParseTuple(args,"OO;verch,horch", &temp1, &temp2))
             return NULL;
-        if (!PyCurses_ConvertToChtype(self, temp1, &ch1)) {
+        if (!PyCurses_ConvertToChtype(temp1, &ch1)) {
             return NULL;
         }
-        if (!PyCurses_ConvertToChtype(self, temp2, &ch2)) {
+        if (!PyCurses_ConvertToChtype(temp2, &ch2)) {
             return NULL;
         }
     }


### PR DESCRIPTION


<!-- issue-number: bpo-27666 -->
https://bugs.python.org/issue27666
<!-- /issue-number -->
