### PR TITLE
bpo-31626: Fix _PyObject_DebugReallocApi()

### DIFF
--- a/Misc/NEWS.d/next/C API/2017-11-07-11-59-44.bpo-31626.LP-CoD.rst
+++ b/Misc/NEWS.d/next/C API/2017-11-07-11-59-44.bpo-31626.LP-CoD.rst
@@ -1,0 +1,3 @@
+When Python is built in debug mode, the memory debug hooks now fail with a
+fatal error if realloc() fails to shrink a memory block, because the debug
+hook just erased freed bytes without keeping a copy of them.


### PR DESCRIPTION
_PyObject_DebugReallocApi() now calls Py_FatalError() if realloc()
fails to shrink a memory block.

Call Py_FatalError() because _PyObject_DebugReallocApi() erased freed
bytes *before* realloc(), expecting that realloc() *cannot* fail to
shrink a memory block.

<!-- issue-number: bpo-31626 -->
https://bugs.python.org/issue31626
<!-- /issue-number -->
