### PR TITLE
bpo-31955: Fixed incorrect string type check - use isinstance(value, basestring)…

### DIFF
--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -160,7 +160,7 @@ class CCompiler:
             self.set_executable(key, args[key])
 
     def set_executable(self, key, value):
-        if isinstance(value, str):
+        if isinstance(value, basestring):
             setattr(self, key, split_quoted(value))
         else:
             setattr(self, key, value)

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -26,7 +26,7 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
 
     def test_set_executables(self):
         class MyCCompiler(CCompiler):
-            executables = {'compiler': '', 'compiler_cx': '', 'linker': ''}
+            executables = {'compiler': '', 'compiler_cxx': '', 'linker': ''}
 
         compiler = MyCCompiler()
 
@@ -36,9 +36,9 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
         self.assertEqual(compiler.compiler[2], 'mpicc')
 
         # set executable as string
-        compiler.set_executables(compiler_cxx='env OMPI_MPICXX=clang++ mpicx')
+        compiler.set_executables(compiler_cxx='env OMPI_MPICXX=clang++ mpicxx')
         self.assertEqual(len(compiler.compiler_cxx), 3)
-        self.assertEqual(compiler.compiler_cxx[2], 'mpicx')
+        self.assertEqual(compiler.compiler_cxx[2], 'mpicxx')
 
         # set executable as unicode string
         compiler.set_executables(linker=u'env OMPI_MPICXX=clang++ mpicxx')

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -32,18 +32,18 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
 
         # set executable as list
         compiler.set_executables(compiler=['env', 'OMPI_MPICC=clang', 'mpicc'])
-        self.assertEqual(len(compiler.executables['compiler']), 3)
-        self.assertEqual(len(compiler.executables['compiler'][2]), 'mpicc')
+        self.assertEqual(len(compiler.compiler), 3)
+        self.assertEqual(compiler.compiler[2], 'mpicc')
 
         # set executable as string
         compiler.set_executables(compiler_cxx='env OMPI_MPICXX=clang++ mpicx')
-        self.assertEqual(len(compiler.executables['compiler_cxx']), 3)
-        self.assertEqual(len(compiler.executables['compiler_cxx'][2]), 'mpicx')
+        self.assertEqual(len(compiler.compiler_cxx), 3)
+        self.assertEqual(compiler.compiler_cxx[2], 'mpicx')
 
         # set executable as unicode string
         compiler.set_executables(linker=u'env OMPI_MPICXX=clang++ mpicxx')
-        self.assertEqual(len(compiler.executables['linker']), 3)
-        self.assertEqual(len(compiler.executables['linker'][2]), u'mpicxx')
+        self.assertEqual(len(compiler.linker), 3)
+        self.assertEqual(compiler.linker[2], u'mpicxx')
 
     def test_gen_lib_options(self):
         compiler = FakeCompiler()

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -32,6 +32,7 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
 
         # set executable as list
         compiler.set_executables(compiler = ['/usr/bin/env', 'OMPI_MPICC=clang', '/usr/bin/mpicc.openmpi'])
+        print(compiler.executables)
         self.assertEqual(len(compiler.executables['compiler']) == 3)
         self.assertEqual(len(compiler.executables['compiler'][2]) == '/usr/bin/mpicc.openmpi')
 

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -33,17 +33,23 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
         # set executable as list
         compiler.set_executables(compiler=['env', 'OMPI_MPICC=clang', 'mpicc'])
         self.assertEqual(len(compiler.compiler), 3)
-        self.assertEqual(compiler.compiler[2], 'mpicc')
+        self.assertEqual(compiler.compiler, ['env',
+                                             'OMPI_MPICC=clang',
+                                             'mpicc'])
 
         # set executable as string
         compiler.set_executables(compiler_cxx='env OMPI_MPICXX=clang++ mpicxx')
         self.assertEqual(len(compiler.compiler_cxx), 3)
-        self.assertEqual(compiler.compiler_cxx[2], 'mpicxx')
+        self.assertEqual(compiler.compiler_cxx, ['env',
+                                                 'OMPI_MPICXX=clang++',
+                                                 'mpicxx'])
 
         # set executable as unicode string
         compiler.set_executables(linker=u'env OMPI_MPICXX=clang++ mpicxx')
         self.assertEqual(len(compiler.linker), 3)
-        self.assertEqual(compiler.linker[2], u'mpicxx')
+        self.assertEqual(compiler.linker, [u'env',
+                                           u'OMPI_MPICXX=clang++',
+                                           u'mpicxx'])
 
     def test_gen_lib_options(self):
         compiler = FakeCompiler()

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -32,19 +32,18 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
 
         # set executable as list
         compiler.set_executables(compiler = ['/usr/bin/env', 'OMPI_MPICC=clang', '/usr/bin/mpicc.openmpi'])
-        print(compiler.executables)
-        self.assertEqual(len(compiler.executables['compiler']) == 3)
-        self.assertEqual(len(compiler.executables['compiler'][2]) == '/usr/bin/mpicc.openmpi')
+        self.assertEqual(len(compiler.executables['compiler']), 3)
+        self.assertEqual(len(compiler.executables['compiler'][2]), '/usr/bin/mpicc.openmpi')
 
         # set executable as string
         compiler.set_executables(compiler_cxx = '/usr/bin/env OMPI_MPICXX=clang++ /usr/bin/mpicxx.openmpi')
-        self.assertEqual(len(compiler.executables['compiler_cxx']) == 3)
-        self.assertEqual(len(compiler.executables['compiler_cxx'][2]) == '/usr/bin/mpicxx.openmpi')
+        self.assertEqual(len(compiler.executables['compiler_cxx']), 3)
+        self.assertEqual(len(compiler.executables['compiler_cxx'][2]), '/usr/bin/mpicxx.openmpi')
 
         # set executable as unicode string
         compiler.set_executables(linker = u'/usr/bin/env OMPI_MPICXX=clang++ /usr/bin/mpicxx.openmpi')
-        self.assertEqual(len(compiler.executables['linker']) == 3)
-        self.assertEqual(len(compiler.executables['linker'][2]) == '/usr/bin/mpicxx.openmpi')
+        self.assertEqual(len(compiler.executables['linker']), 3)
+        self.assertEqual(len(compiler.executables['linker'][2]), '/usr/bin/mpicxx.openmpi')
 
     def test_gen_lib_options(self):
         compiler = FakeCompiler()

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -43,7 +43,7 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
         # set executable as unicode string
         compiler.set_executables(linker=u'env OMPI_MPICXX=clang++ mpicxx')
         self.assertEqual(len(compiler.executables['linker']), 3)
-        self.assertEqual(len(compiler.executables['linker'][2]), 'mpicxx')
+        self.assertEqual(len(compiler.executables['linker'][2]), u'mpicxx')
 
     def test_gen_lib_options(self):
         compiler = FakeCompiler()

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -24,6 +24,27 @@ class FakeCompiler(object):
 
 class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
 
+    def test_set_executables_unicode(self):
+        class MyCCompiler(CCompiler):
+            executables = {}
+
+        compiler = MyCCompiler()
+
+        # set executable as list
+        compiler.set_executables(compiler = ['/usr/bin/env', 'OMPI_MPICC=clang', '/usr/bin/mpicc.openmpi'])
+        self.assertEqual(len(compiler.executables['compiler']) == 3)
+        self.assertEqual(len(compiler.executables['compiler'][2]) == '/usr/bin/mpicc.openmpi')
+
+        # set executable as string
+        compiler.set_executables(compiler_cxx = '/usr/bin/env OMPI_MPICXX=clang++ /usr/bin/mpicxx.openmpi')
+        self.assertEqual(len(compiler.executables['compiler_cxx']) == 3)
+        self.assertEqual(len(compiler.executables['compiler_cxx'][2]) == '/usr/bin/mpicxx.openmpi')
+
+        # set executable as unicode string
+        compiler.set_executables(linker = u'/usr/bin/env OMPI_MPICXX=clang++ /usr/bin/mpicxx.openmpi')
+        self.assertEqual(len(compiler.executables['linker']) == 3)
+        self.assertEqual(len(compiler.executables['linker'][2]) == '/usr/bin/mpicxx.openmpi')
+
     def test_gen_lib_options(self):
         compiler = FakeCompiler()
         libdirs = ['lib1', 'lib2']

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -24,26 +24,26 @@ class FakeCompiler(object):
 
 class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
 
-    def test_set_executables_unicode(self):
+    def test_set_executables(self):
         class MyCCompiler(CCompiler):
-            executables = {'compiler':'', 'compiler_cxx':'', 'linker':''}
+            executables = {'compiler': '', 'compiler_cx': '', 'linker': ''}
 
         compiler = MyCCompiler()
 
         # set executable as list
-        compiler.set_executables(compiler = ['/usr/bin/env', 'OMPI_MPICC=clang', '/usr/bin/mpicc.openmpi'])
+        compiler.set_executables(compiler=['env', 'OMPI_MPICC=clang', 'mpicc'])
         self.assertEqual(len(compiler.executables['compiler']), 3)
-        self.assertEqual(len(compiler.executables['compiler'][2]), '/usr/bin/mpicc.openmpi')
+        self.assertEqual(len(compiler.executables['compiler'][2]), 'mpicc')
 
         # set executable as string
-        compiler.set_executables(compiler_cxx = '/usr/bin/env OMPI_MPICXX=clang++ /usr/bin/mpicxx.openmpi')
+        compiler.set_executables(compiler_cxx='env OMPI_MPICXX=clang++ mpicx')
         self.assertEqual(len(compiler.executables['compiler_cxx']), 3)
-        self.assertEqual(len(compiler.executables['compiler_cxx'][2]), '/usr/bin/mpicxx.openmpi')
+        self.assertEqual(len(compiler.executables['compiler_cxx'][2]), 'mpicx')
 
         # set executable as unicode string
-        compiler.set_executables(linker = u'/usr/bin/env OMPI_MPICXX=clang++ /usr/bin/mpicxx.openmpi')
+        compiler.set_executables(linker=u'env OMPI_MPICXX=clang++ mpicxx')
         self.assertEqual(len(compiler.executables['linker']), 3)
-        self.assertEqual(len(compiler.executables['linker'][2]), '/usr/bin/mpicxx.openmpi')
+        self.assertEqual(len(compiler.executables['linker'][2]), 'mpicxx')
 
     def test_gen_lib_options(self):
         compiler = FakeCompiler()

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -26,7 +26,7 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
 
     def test_set_executables_unicode(self):
         class MyCCompiler(CCompiler):
-            executables = {}
+            executables = {'compiler':'', 'compiler_cxx':'', 'linker':''}
 
         compiler = MyCCompiler()
 

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -32,21 +32,18 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
 
         # set executable as list
         compiler.set_executables(compiler=['env', 'OMPI_MPICC=clang', 'mpicc'])
-        self.assertEqual(len(compiler.compiler), 3)
         self.assertEqual(compiler.compiler, ['env',
                                              'OMPI_MPICC=clang',
                                              'mpicc'])
 
         # set executable as string
         compiler.set_executables(compiler_cxx='env OMPI_MPICXX=clang++ mpicxx')
-        self.assertEqual(len(compiler.compiler_cxx), 3)
         self.assertEqual(compiler.compiler_cxx, ['env',
                                                  'OMPI_MPICXX=clang++',
                                                  'mpicxx'])
 
         # set executable as unicode string
         compiler.set_executables(linker=u'env OMPI_MPICXX=clang++ mpicxx')
-        self.assertEqual(len(compiler.linker), 3)
         self.assertEqual(compiler.linker, [u'env',
                                            u'OMPI_MPICXX=clang++',
                                            u'mpicxx'])

--- a/Lib/distutils/tests/test_ccompiler.py
+++ b/Lib/distutils/tests/test_ccompiler.py
@@ -43,10 +43,10 @@ class CCompilerTestCase(support.EnvironGuard, unittest.TestCase):
                                                  'mpicxx'])
 
         # set executable as unicode string
-        compiler.set_executables(linker=u'env OMPI_MPICXX=clang++ mpicxx')
+        compiler.set_executables(linker=u'env OMPI_MPICXX=clang++ mpiCC')
         self.assertEqual(compiler.linker, [u'env',
                                            u'OMPI_MPICXX=clang++',
-                                           u'mpicxx'])
+                                           u'mpiCC'])
 
     def test_gen_lib_options(self):
         compiler = FakeCompiler()

--- a/Misc/NEWS.d/next/Library/2017-11-07-19-12-25.bpo-31955.1DWu-S.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-07-19-12-25.bpo-31955.1DWu-S.rst
@@ -1,0 +1,5 @@
+Fixed incorrect discrimination between string and list types in
+distutils.CCompiler.set_executables() method. Previously if unicode string
+was passed as executable value it was considered not as string, but as list.
+It caused TypeError: "coercing to Unicode: need string or buffer, list
+found" at unixccompiler.py, line 122, in _compile().

--- a/Misc/NEWS.d/next/Library/2017-11-07-19-12-25.bpo-31955.1DWu-S.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-07-19-12-25.bpo-31955.1DWu-S.rst
@@ -1,5 +1,1 @@
-Fixed incorrect discrimination between string and list types in
-distutils.CCompiler.set_executables() method. Previously if unicode string
-was passed as executable value it was considered not as string, but as list.
-It caused TypeError: "coercing to Unicode: need string or buffer, list
-found" at unixccompiler.py, line 122, in _compile().
+Fix CCompiler.set_executable() of distutils to handle properly Unicode strings.


### PR DESCRIPTION
Fixed incorrect string type check. Previously if unicode string was passed as executable value it was considered not as string, but as list.

<!-- issue-number: bpo-31955 -->
https://bugs.python.org/issue31955
<!-- /issue-number -->

Previous PR on this issue (#4296) was mistaken - for Python3 str is equivalent to basestring.