### PR TITLE
Correct the location of a function mentioned in a comment

### DIFF
--- a/Include/pyhash.h
+++ b/Include/pyhash.h
@@ -16,7 +16,7 @@ PyAPI_FUNC(Py_hash_t) _Py_HashBytes(const void*, Py_ssize_t);
 #define _PyHASH_MULTIPLIER 1000003UL  /* 0xf4243 */
 
 /* Parameters used for the numeric hash implementation.  See notes for
-   _Py_HashDouble in Objects/object.c.  Numeric hashes are based on
+   _Py_HashDouble in Python/pyhash.c.  Numeric hashes are based on
    reduction modulo the prime 2**_PyHASH_BITS - 1. */
 
 #if SIZEOF_VOID_P >= 8


### PR DESCRIPTION
The comment indicates the location of `_Py_HashDouble`, but the function has moved.  Correct the comment.
