### PR TITLE
bpo-31971: Fix IDLE test failure.

### DIFF
--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -844,22 +844,24 @@ class KeysPageTest(unittest.TestCase):
         eq = self.assertEqual
         d = self.page
         del d.set_keys_type
+        try:
+            # Builtin keyset selected.
+            d.keyset_source.set(True)
+            d.set_keys_type()
+            eq(d.builtinlist['state'], NORMAL)
+            eq(d.customlist['state'], DISABLED)
+            eq(d.button_delete_custom_keys.state(), ('disabled',))
 
-        # Builtin keyset selected.
-        d.keyset_source.set(True)
-        d.set_keys_type()
-        eq(d.builtinlist['state'], NORMAL)
-        eq(d.customlist['state'], DISABLED)
-        eq(d.button_delete_custom_keys.state(), ('disabled',))
-
-        # Custom keyset selected.
-        d.keyset_source.set(False)
-        d.set_keys_type()
-        eq(d.builtinlist['state'], DISABLED)
-        eq(d.custom_keyset_on.state(), ('selected',))
-        eq(d.customlist['state'], NORMAL)
-        eq(d.button_delete_custom_keys.state(), ())
-        d.set_keys_type = Func()
+            # Custom keyset selected.
+            d.keyset_source.set(False)
+            d.set_keys_type()
+            eq(d.builtinlist['state'], DISABLED)
+            self.assertIn(d.custom_keyset_on.state(),  # Issue 31971
+                          (('selected',), ('selected', 'hover')))
+            eq(d.customlist['state'], NORMAL)
+            eq(d.button_delete_custom_keys.state(), ())
+        finally:
+            d.set_keys_type = Func()
 
     def test_get_new_keys(self):
         eq = self.assertEqual

--- a/Misc/NEWS.d/next/IDLE/2017-11-07-23-32-19.bpo-31971.ZpBCeF.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-11-07-23-32-19.bpo-31971.ZpBCeF.rst
@@ -1,0 +1,3 @@
+Fix IDLE test failure.
+
+On one machine, tk sees a mouse cursor hovering over one widget.


### PR DESCRIPTION
On one machine, tk see a mouse cursor hovering over one widget.


<!-- issue-number: bpo-31971 -->
https://bugs.python.org/issue31971
<!-- /issue-number -->
