### PR TITLE
bpo-31976: Fix race condition when flushing a file is slow.

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1257,6 +1257,10 @@ class BufferedWriter(_BufferedIOMixin):
         with self._write_lock:
             if self.raw is None or self.closed:
                 return
+        # We have to release the lock and call self.flush() (which will
+        # probably just re-take the lock) in case flush has been overridden in
+        # a subclass or the user set self.flush to something. This is the same
+        # behavior as the C implementation.
         try:
             # may raise BlockingIOError or BrokenPipeError etc
             self.flush()

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1743,6 +1743,7 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
         self.assertTrue(b.closed)
 
     def test_slow_close_from_thread(self):
+        # Issue #31976
         rawio = self.SlowFlushRawIO()
         bufio = self.tp(rawio, 8)
         t = threading.Thread(target=bufio.close)
@@ -1750,6 +1751,7 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
         rawio.in_flush.wait()
         self.assertRaises(ValueError, bufio.write, b'spam')
         self.assertTrue(bufio.closed)
+        t.join()
 
 
 

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -168,6 +168,17 @@ class PyMisbehavedRawIO(MisbehavedRawIO, pyio.RawIOBase):
     pass
 
 
+class SlowFlushRawIO(MockRawIO):
+    def flush(self):
+        time.sleep(0.25)
+
+class CSlowFlushRawIO(SlowFlushRawIO, io.RawIOBase):
+    pass
+
+class PySlowFlushRawIO(SlowFlushRawIO, pyio.RawIOBase):
+    pass
+
+
 class CloseFailureIO(MockRawIO):
     closed = 0
 
@@ -1725,6 +1736,16 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
         b.write(b'spam')
         self.assertRaises(OSError, b.close) # exception not swallowed
         self.assertTrue(b.closed)
+
+    def test_slow_close_from_thread(self):
+        rawio = self.SlowFlushRawIO()
+        bufio = self.tp(rawio, 8)
+        t = threading.Thread(target=bufio.close)
+        t.start()
+        time.sleep(0.1) # Long enough that t is sleeping in bufio.close()
+        self.assertRaises(ValueError, bufio.write, b'spam')
+        self.assertTrue(bufio.closed)
+
 
 
 class CBufferedWriterTest(BufferedWriterTest, SizeofTest):
@@ -4085,7 +4106,8 @@ def load_tests(*args):
     # Put the namespaces of the IO module we are testing and some useful mock
     # classes in the __dict__ of each test.
     mocks = (MockRawIO, MisbehavedRawIO, MockFileIO, CloseFailureIO,
-             MockNonBlockWriterIO, MockUnseekableIO, MockRawIOWithoutRead)
+             MockNonBlockWriterIO, MockUnseekableIO, MockRawIOWithoutRead,
+             SlowFlushRawIO)
     all_members = io.__all__ + ["IncrementalNewlineDecoder"]
     c_io_ns = {name : getattr(io, name) for name in all_members}
     py_io_ns = {name : getattr(pyio, name) for name in all_members}

--- a/Misc/NEWS.d/next/Library/2017-11-09-21-36-32.bpo-31976.EOA7qY.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-09-21-36-32.bpo-31976.EOA7qY.rst
@@ -1,2 +1,2 @@
-Fixed race condition when flushing a file is slow, which can cause a
-segfault.
+Fix race condition when flushing a file is slow, which can cause a
+segfault if closing the file from another thread.

--- a/Misc/NEWS.d/next/Library/2017-11-09-21-36-32.bpo-31976.EOA7qY.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-09-21-36-32.bpo-31976.EOA7qY.rst
@@ -1,0 +1,2 @@
+Fixed race condition when flushing a file is slow, which can cause a
+segfault.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -347,6 +347,7 @@ _enter_buffered_busy(buffered *self)
     }
 
 #define IS_CLOSED(self) \
+    !self->buffer || \
     (self->fast_closed_checks \
      ? _PyFileIO_closed(self->raw) \
      : buffered_closed(self))
@@ -1971,13 +1972,14 @@ _io_BufferedWriter_write_impl(buffered *self, Py_buffer *buffer)
     Py_off_t offset;
 
     CHECK_INITIALIZED(self)
-    if (IS_CLOSED(self)) {
-        PyErr_SetString(PyExc_ValueError, "write to closed file");
-        return NULL;
-    }
 
     if (!ENTER_BUFFERED(self))
         return NULL;
+
+    if (IS_CLOSED(self)) {
+        PyErr_SetString(PyExc_ValueError, "write to closed file");
+        goto error;
+    }
 
     /* Fast path: the data to write can be fully buffered. */
     if (!VALID_READ_BUFFER(self) && !VALID_WRITE_BUFFER(self)) {

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -347,10 +347,10 @@ _enter_buffered_busy(buffered *self)
     }
 
 #define IS_CLOSED(self) \
-    !self->buffer || \
+    (!self->buffer || \
     (self->fast_closed_checks \
      ? _PyFileIO_closed(self->raw) \
-     : buffered_closed(self))
+     : buffered_closed(self)))
 
 #define CHECK_CLOSED(self, error_msg) \
     if (IS_CLOSED(self)) { \
@@ -1976,6 +1976,8 @@ _io_BufferedWriter_write_impl(buffered *self, Py_buffer *buffer)
     if (!ENTER_BUFFERED(self))
         return NULL;
 
+    /* Issue #31976: Check for closed file after acquiring the lock. Another
+       thread could be holding the lock while closing the file. */
     if (IS_CLOSED(self)) {
         PyErr_SetString(PyExc_ValueError, "write to closed file");
         goto error;


### PR DESCRIPTION
* Move IS_CLOSED check to after the acquiring the lock
* Add a check for self->buffer == NULL in IS_CLOSED
* Make _pyio.BufferedWriter close the same way the C version does
* Add unit tests

<!-- issue-number: bpo-31976 -->
https://bugs.python.org/issue31976
<!-- /issue-number -->
