### PR TITLE
[2.7] bpo-31764: Prevent a crash in sqlite3.Cursor.close() in case the Cursor object is uninitialized (GH-3958)

### DIFF
--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -177,6 +177,9 @@ class RegressionTests(unittest.TestCase):
             pass
         except:
             self.fail("should have raised ProgrammingError")
+        with self.assertRaisesRegexp(sqlite.ProgrammingError,
+                                     r'^Base Cursor\.__init__ not called\.$'):
+            cur.close()
 
     def CheckConnectionConstructorCallCheck(self):
         """

--- a/Misc/NEWS.d/next/Library/2017-11-08-11-02-01.bpo-31764.gtlhKj.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-08-11-02-01.bpo-31764.gtlhKj.rst
@@ -1,0 +1,2 @@
+Prevent a crash in ``sqlite3.Cursor.close()`` in case the ``Cursor`` object
+is uninitialized. Patch by Oren Milman.

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -1014,6 +1014,11 @@ PyObject* pysqlite_noop(pysqlite_Connection* self, PyObject* args)
 
 PyObject* pysqlite_cursor_close(pysqlite_Cursor* self, PyObject* args)
 {
+    if (!self->connection) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Base Cursor.__init__ not called.");
+        return NULL;
+    }
     if (!pysqlite_check_thread(self->connection) || !pysqlite_check_connection(self->connection)) {
         return NULL;
     }


### PR DESCRIPTION


<!-- issue-number: bpo-31764 -->
https://bugs.python.org/issue31764
<!-- /issue-number -->
