### PR TITLE
bpo-31338: Mention that Py_UNREACHABLE was added in 3.7

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -106,6 +106,8 @@ complete listing.
    all possible values are covered in ``case`` statements.  Use this in places
    where you might be tempted to put an ``assert(0)`` or ``abort()`` call.
 
+   .. versionadded:: 3.7
+
 .. c:macro:: Py_ABS(x)
 
    Return the absolute value of ``x``.


### PR DESCRIPTION
The macro was added for bpo-31338 in commit b2e5794.

I think this note is trivial enough to not need its own issue or NEWS entry.

<!-- issue-number: bpo-31338 -->
https://bugs.python.org/issue31338
<!-- /issue-number -->
