### PR TITLE
bpo-29179: Document the Py_UNUSED macro

### DIFF
--- a/Doc/c-api/intro.rst
+++ b/Doc/c-api/intro.rst
@@ -149,6 +149,13 @@ complete listing.
    Like ``getenv(s)``, but returns *NULL* if :option:`-E` was passed on the
    command line (i.e. if ``Py_IgnoreEnvironmentFlag`` is set).
 
+.. c:macro:: Py_UNUSED(arg)
+
+   Use this for unused arguments in a function definition to silence compiler
+   warnings, e.g. ``PyObject* func(PyObject *Py_UNUSED(ignored))``.
+
+   .. versionadded:: 3.4
+
 
 .. _api-objects:
 


### PR DESCRIPTION
Py_UNUSED has a public name, and is used in the wild outside CPython,
but was not documented. Rectify that.

The macro was added in bpo-19976 and referenced in bpo-26179.

<!-- issue-number: bpo-29179 -->
https://bugs.python.org/issue29179
<!-- /issue-number -->
