### PR TITLE
bpo-31985: Deprecate aifc.openfp

### DIFF
--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -63,6 +63,8 @@ The :mod:`sunau` module defines the following functions:
 
    A synonym for :func:`.open`, maintained for backwards compatibility.
 
+   .. versiondeprecated:: 3.7
+
 
 The :mod:`sunau` module defines the following exception:
 

--- a/Doc/library/sunau.rst
+++ b/Doc/library/sunau.rst
@@ -63,7 +63,7 @@ The :mod:`sunau` module defines the following functions:
 
    A synonym for :func:`.open`, maintained for backwards compatibility.
 
-   .. versiondeprecated:: 3.7
+   .. deprecated-removed:: 3.7 3.9
 
 
 The :mod:`sunau` module defines the following exception:

--- a/Doc/library/wave.rst
+++ b/Doc/library/wave.rst
@@ -51,7 +51,7 @@ The :mod:`wave` module defines the following function and exception:
 
    A synonym for :func:`.open`, maintained for backwards compatibility.
 
-   .. versiondeprecated:: 3.7
+   .. deprecated-removed:: 3.7 3.9
 
 
 .. exception:: Error

--- a/Doc/library/wave.rst
+++ b/Doc/library/wave.rst
@@ -51,6 +51,8 @@ The :mod:`wave` module defines the following function and exception:
 
    A synonym for :func:`.open`, maintained for backwards compatibility.
 
+   .. versiondeprecated:: 3.7
+
 
 .. exception:: Error
 

--- a/Lib/aifc.py
+++ b/Lib/aifc.py
@@ -915,7 +915,10 @@ def open(f, mode=None):
     else:
         raise Error("mode must be 'r', 'rb', 'w', or 'wb'")
 
-openfp = open # B/W compatibility
+def openfp(f, mode=None):
+    warnings.warn("aifc.openfp is deprecated since Python 3.7. "
+                  "Use aifc.open instead.", DeprecationWarning, stacklevel=2)
+    return open(f, mode=mode)
 
 if __name__ == '__main__':
     import sys

--- a/Lib/sndhdr.py
+++ b/Lib/sndhdr.py
@@ -160,7 +160,7 @@ def test_wav(h, f):
         return None
     f.seek(0)
     try:
-        w = wave.openfp(f, 'r')
+        w = wave.open(f, 'r')
     except (EOFError, wave.Error):
         return None
     return ('wav', w.getframerate(), w.getnchannels(),

--- a/Lib/sunau.py
+++ b/Lib/sunau.py
@@ -104,6 +104,7 @@ is destroyed.
 """
 
 from collections import namedtuple
+import warnings
 
 _sunau_params = namedtuple('_sunau_params',
                            'nchannels sampwidth framerate nframes comptype compname')
@@ -522,4 +523,7 @@ def open(f, mode=None):
     else:
         raise Error("mode must be 'r', 'rb', 'w', or 'wb'")
 
-openfp = open
+def openfp(f, mode=None):
+    warnings.warn("sunau.openfp is deprecated since Python 3.7. "
+                  "Use sunau.open instead.", DeprecationWarning, stacklevel=2)
+    return open(f, mode=mode)

--- a/Lib/test/audiotests.py
+++ b/Lib/test/audiotests.py
@@ -1,6 +1,7 @@
 from test.support import findfile, TESTFN, unlink
 import array
 import io
+from unittest import mock
 import pickle
 
 
@@ -47,6 +48,17 @@ class AudioTests:
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             dump = pickle.dumps(params, proto)
             self.assertEqual(pickle.loads(dump), params)
+
+
+class AudioMiscTests(AudioTests):
+
+    def test_openfp_deprecated(self):
+        arg = "arg"
+        mode = "mode"
+        with mock.patch(f"{self.module.__name__}.open") as mock_open, \
+             self.assertWarns(DeprecationWarning):
+            self.module.openfp(arg, mode=mode)
+            mock_open.assert_called_with(arg, mode=mode)
 
 
 class AudioWriteTests(AudioTests):

--- a/Lib/test/test_aifc.py
+++ b/Lib/test/test_aifc.py
@@ -7,6 +7,7 @@ import io
 import sys
 import struct
 import aifc
+import warnings
 
 
 class AifcTest(audiotests.AudioWriteTests,
@@ -145,6 +146,20 @@ class AifcALAWTest(AifcTest, unittest.TestCase):
 
 
 class AifcMiscTest(audiotests.AudioTests, unittest.TestCase):
+
+    @mock.patch("aifc.open")
+    def test_openfp_deprecated(self, mock_open):
+        arg = "arg"
+        mode = "mode"
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            aifc.openfp(arg, mode=mode)
+
+            self.assertTrue(len(w) == 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+
+        mock_open.assert_called_with(arg, mode=mode)
+
     def test_skipunknown(self):
         #Issue 2245
         #This file contains chunk types aifc doesn't recognize.

--- a/Lib/test/test_aifc.py
+++ b/Lib/test/test_aifc.py
@@ -145,16 +145,8 @@ class AifcALAWTest(AifcTest, unittest.TestCase):
         frames = byteswap(frames, 2)
 
 
-class AifcMiscTest(audiotests.AudioTests, unittest.TestCase):
-
-    @mock.patch("aifc.open")
-    def test_openfp_deprecated(self, mock_open):
-        arg = "arg"
-        mode = "mode"
-        with self.assertWarns(DeprecationWarning):
-            aifc.openfp(arg, mode=mode)
-
-        mock_open.assert_called_with(arg, mode=mode)
+class AifcMiscTest(audiotests.AudioMiscTests, unittest.TestCase):
+    module = aifc
 
     def test_skipunknown(self):
         #Issue 2245

--- a/Lib/test/test_aifc.py
+++ b/Lib/test/test_aifc.py
@@ -151,12 +151,8 @@ class AifcMiscTest(audiotests.AudioTests, unittest.TestCase):
     def test_openfp_deprecated(self, mock_open):
         arg = "arg"
         mode = "mode"
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with self.assertWarns(DeprecationWarning):
             aifc.openfp(arg, mode=mode)
-
-            self.assertTrue(len(w) == 1)
-            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
 
         mock_open.assert_called_with(arg, mode=mode)
 

--- a/Lib/test/test_pyclbr.py
+++ b/Lib/test/test_pyclbr.py
@@ -223,6 +223,8 @@ class PyclbrTest(TestCase):
         cm('random', ignore=('Random',))  # from _random import Random as CoreGenerator
         cm('cgi', ignore=('log',))      # set with = in module
         cm('pickle', ignore=('partial',))
+        # TODO(briancurtin): openfp is deprecated as of 3.7.
+        # Update this once it has been removed.
         cm('aifc', ignore=('openfp', '_aifc_params'))  # set with = in module
         cm('sre_parse', ignore=('dump', 'groups', 'pos')) # from sre_constants import *; property
         cm('pdb')

--- a/Lib/test/test_sunau.py
+++ b/Lib/test/test_sunau.py
@@ -117,5 +117,9 @@ class SunauULAWTest(SunauTest, unittest.TestCase):
         frames = byteswap(frames, 2)
 
 
+class SunauMiscTests(audiotests.AudioMiscTests, unittest.TestCase):
+    module = sunau
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_wave.py
+++ b/Lib/test/test_wave.py
@@ -103,7 +103,9 @@ class WavePCM32Test(WaveTest, unittest.TestCase):
         frames = byteswap(frames, 4)
 
 
-class MiscTestCase(unittest.TestCase):
+class MiscTestCase(audiotests.AudioMiscTests, unittest.TestCase):
+    module = wave
+
     def test__all__(self):
         blacklist = {'WAVE_FORMAT_PCM'}
         support.check__all__(self, wave, blacklist=blacklist)

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -87,6 +87,7 @@ import struct
 import sys
 from chunk import Chunk
 from collections import namedtuple
+import warnings
 
 _wave_params = namedtuple('_wave_params',
                      'nchannels sampwidth framerate nframes comptype compname')
@@ -502,4 +503,7 @@ def open(f, mode=None):
     else:
         raise Error("mode must be 'r', 'rb', 'w', or 'wb'")
 
-openfp = open # B/W compatibility
+def openfp(f, mode=None):
+    warnings.warn("wave.openfp is deprecated since Python 3.7. "
+                  "Use wave.open instead.", DeprecationWarning, stacklevel=2)
+    return open(f, mode=mode)

--- a/Misc/NEWS.d/next/Library/2017-11-08-16-51-52.bpo-31985.dE_fOB.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-08-16-51-52.bpo-31985.dE_fOB.rst
@@ -1,0 +1,4 @@
+Formally deprecated aifc.openfp. Since change
+7bc817d5ba917528e8bd07ec461c635291e7b06a in 1993, this had been pointing to
+aifc.open as a matter of backwards compatibility, though it had been both
+untested and undocumented.

--- a/Misc/NEWS.d/next/Library/2017-11-08-16-51-52.bpo-31985.dE_fOB.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-08-16-51-52.bpo-31985.dE_fOB.rst
@@ -1,4 +1,4 @@
-Formally deprecated aifc.openfp. Since change
-7bc817d5ba917528e8bd07ec461c635291e7b06a in 1993, this had been pointing to
-aifc.open as a matter of backwards compatibility, though it had been both
-untested and undocumented.
+Formally deprecated aifc.openfp, sunau.openfp, and wave.openfp. Since change
+7bc817d5ba917528e8bd07ec461c635291e7b06a in 1993, openfp in each of the three
+modules had been pointing to that module's open funciton as a matter of
+backwards compatibility, though it had been both untested and undocumented.


### PR DESCRIPTION
aifc.openfp had pointed to aifc.open since 1993* and it was both undocumented and untested since being assigned as a matter of backwards compatibility. This change begins its formal deprecation.

\* https://github.com/python/cpython/commit/7bc817d5ba917528e8bd07ec461c635291e7b06a

<!-- issue-number: bpo-31985 -->
https://bugs.python.org/issue31985
<!-- /issue-number -->
