### PR TITLE
[2.7] Fix DeprecationWarning in tests

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -609,6 +609,8 @@ class TestTotalOrdering(unittest.TestCase):
                 return self.value > other.value
             def __eq__(self, other):
                 return self.value == other.value
+            def __hash__(self):
+                return hash(self.value)
         self.assertTrue(A(1) != A(2))
         self.assertFalse(A(1) != A(1))
 
@@ -620,6 +622,8 @@ class TestTotalOrdering(unittest.TestCase):
                 return self.value > other.value
             def __eq__(self, other):
                 return self.value == other.value
+            def __hash__(self):
+                return hash(self.value)
         self.assertTrue(A(1) != A(2))
         self.assertFalse(A(1) != A(1))
 
@@ -633,6 +637,8 @@ class TestTotalOrdering(unittest.TestCase):
                 return self.value == other.value
             def __ne__(self, other):
                 raise RuntimeError(self, other)
+            def __hash__(self):
+                return hash(self.value)
         with self.assertRaises(RuntimeError):
             A(1) != A(2)
         with self.assertRaises(RuntimeError):
@@ -648,6 +654,8 @@ class TestTotalOrdering(unittest.TestCase):
                 return self.value == other.value
             def __ne__(self, other):
                 raise RuntimeError(self, other)
+            def __hash__(self):
+                return hash(self.value)
         with self.assertRaises(RuntimeError):
             A(1) != A(2)
         with self.assertRaises(RuntimeError):

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1491,6 +1491,8 @@ class RegressionTests(unittest.TestCase):
                 if K.i == 1:
                     next(g, None)
                 return True
+            def __hash__(self):
+                return 1
         g = next(groupby(range(10), K))[1]
         for j in range(2):
             next(g, None)  # shouldn't crash


### PR DESCRIPTION
Define __hash__() in test_functools and test_itertools to fix the
following warning:

DeprecationWarning: Overriding __eq__ blocks inheritance of __hash__ in 3.x