### PR TITLE
bpo-28441: Ensure `.exe` suffix in `sys.executable` on MinGW and Cygwin

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -757,6 +757,7 @@ Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile
 		-DEXEC_PREFIX='"$(exec_prefix)"' \
 		-DVERSION='"$(VERSION)"' \
 		-DVPATH='"$(VPATH)"' \
+		-DEXE_SUFFIX='"$(EXE)"' \
 		-o $@ $(srcdir)/Modules/getpath.c
 
 Programs/python.o: $(srcdir)/Programs/python.c

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -757,7 +757,6 @@ Modules/getpath.o: $(srcdir)/Modules/getpath.c Makefile
 		-DEXEC_PREFIX='"$(exec_prefix)"' \
 		-DVERSION='"$(VERSION)"' \
 		-DVPATH='"$(VPATH)"' \
-		-DEXE_SUFFIX='"$(EXE)"' \
 		-o $@ $(srcdir)/Modules/getpath.c
 
 Programs/python.o: $(srcdir)/Programs/python.c

--- a/Misc/NEWS.d/next/Library/2018-10-04-15-53-14.bpo-28441.2sQENe.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-04-15-53-14.bpo-28441.2sQENe.rst
@@ -1,0 +1,3 @@
+On Cygwin and MinGW, ensure that ``sys.executable`` always includes the full
+filename in the path, including the ``.exe`` suffix (unless it is a symbolic
+link).

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -646,8 +646,9 @@ calculate_program_full_path(const _PyCoreConfig *core_config,
      * sys.executable to return the name of a directory under the same
      * path (bpo-28441).
      */
-    if (program_full_path[0] != '\0')
+    if (program_full_path[0] != '\0') {
         add_exe_suffix(program_full_path);
+    }
 #endif
 
     config->program_full_path = _PyMem_RawWcsdup(program_full_path);

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -102,9 +102,8 @@ extern "C" {
 #endif
 
 
-#if !defined(PREFIX) || !defined(EXEC_PREFIX) || !defined(VERSION) || \
-    !defined(VPATH) || !defined(EXE_SUFFIX)
-#error "PREFIX, EXEC_PREFIX, VERSION, VPATH, and EXE_SUFFIX must be constant defined"
+#if !defined(PREFIX) || !defined(EXEC_PREFIX) || !defined(VERSION) || !defined(VPATH)
+#error "PREFIX, EXEC_PREFIX, VERSION, and VPATH must be constant defined"
 #endif
 
 #ifndef LANDMARK
@@ -301,19 +300,18 @@ absolutize(wchar_t *path)
 /* add_exe_suffix requires that progpath be allocated at least
    MAXPATHLEN + 1 bytes.
 */
+
+#ifndef EXE_SUFFIX
+#define EXE_SUFFIX L".exe"
+#endif
+
 static void
 add_exe_suffix(wchar_t *progpath)
 {
-    wchar_t *_suffix = Py_DecodeLocale(EXE_SUFFIX, NULL);
-    if (_suffix == NULL) {
-        Py_FatalError("Unable to decode suffix variables in getpath.c: "
-                      "memory error");
-    }
-
     /* Check for already have an executable suffix */
     size_t n = wcslen(progpath);
-    size_t s = wcslen(_suffix);
-    if (wcsncasecmp(_suffix, progpath+n-s, s) != 0) {
+    size_t s = wcslen(EXE_SUFFIX);
+    if (wcsncasecmp(EXE_SUFFIX, progpath+n-s, s) != 0) {
         if (n + s > MAXPATHLEN) {
             Py_FatalError("progpath overflow in getpath.c's add_exe_suffix()");
         }
@@ -321,7 +319,7 @@ add_exe_suffix(wchar_t *progpath)
         wchar_t orig[MAXPATHLEN+1];
         wcsncpy(orig, progpath, MAXPATHLEN);
 
-        wcsncpy(progpath+n, _suffix, s);
+        wcsncpy(progpath+n, EXE_SUFFIX, s);
         progpath[n+s] = '\0';
 
         if (!isxfile(progpath)) {
@@ -329,7 +327,6 @@ add_exe_suffix(wchar_t *progpath)
             wcsncpy(progpath, orig, MAXPATHLEN);
         }
     }
-    PyMem_RawFree(_suffix);
 }
 #endif
 
@@ -649,7 +646,7 @@ calculate_program_full_path(const _PyCoreConfig *core_config,
      * sys.executable to return the name of a directory under the same
      * path (bpo-28441).
      */
-    if (EXE_SUFFIX[0] != '\0' && program_full_path[0] != '\0')
+    if (program_full_path[0] != '\0')
         add_exe_suffix(program_full_path);
 #endif
 


### PR DESCRIPTION
Based on original patch by @ma8ma 

Note: This is needed to even the run the test suite on buildbots for affected platforms; e.g.:

```
./python.exe  ./Tools/scripts/run_tests.py -j 1 -u all -W --slowest --fail-env-changed --timeout=11700 -j2
/home/embray/src/python/test-worker/3.x.test-worker/build/python -u -W default -bb -E -W error::BytesWarning -m test -r -w -j 1 -u all -W --slowest --fail-env-changed --timeout=11700 -j2
Traceback (most recent call last):
  File "./Tools/scripts/run_tests.py", line 56, in <module>
    main(sys.argv[1:])
  File "./Tools/scripts/run_tests.py", line 52, in main
    os.execv(sys.executable, args)
PermissionError: [Errno 13] Permission denied
make: *** [Makefile:1073: buildbottest] Error 1
```

<!-- issue-number: [bpo-28441](https://www.bugs.python.org/issue28441) -->
https://bugs.python.org/issue28441
<!-- /issue-number -->

Possibly to do based on review of @methane :

- [x] clarify use of `./configure --with-suffix=`; possibly disable using it to override EXEEXT
  - This is still an open issue; I believe the feature currently has too much potential for misuse.  However, that should be addressed as a separate issue.
- [x] maybe add a platform-specific `#if defined(__CYGWIN__) || defined(__MINGW32__)` around the add_exe_suffix stuff
- [x] change or maybe remove note in docs for `sys.platform`
  - Because the affected platforms are dubiously supported in the first place, it's not worth mentioning in the main documentation.
- [x] change wording of news entry