### PR TITLE
bpo-31993: do not allocate large temporary buffers in pickle dump

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -203,7 +203,15 @@ class _Framer:
             if f.tell() >= self._FRAME_SIZE_TARGET or force:
                 with f.getbuffer() as data:
                     write = self.file_write
+                    # Issue a single call to the write nethod of the underlying
+                    # file object for the frame opcode with the size of the
+                    # frame. The concatenation is expected to be less expensive
+                    # than issuing an additional call to write.
                     write(FRAME + pack("<Q", len(data)))
+
+                    # Issue a separate call to write to append the frame
+                    # contents without concatenation to the above to avoid a
+                    # memory copy.
                     write(data)
                 f.seek(0)
                 f.truncate()

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -203,7 +203,7 @@ class _Framer:
             if f.tell() >= self._FRAME_SIZE_TARGET or force:
                 data = f.getbuffer()
                 write = self.file_write
-                # Issue a single call to the write nethod of the underlying
+                # Issue a single call to the write method of the underlying
                 # file object for the frame opcode with the size of the
                 # frame. The concatenation is expected to be less expensive
                 # than issuing an additional call to write.

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -713,11 +713,11 @@ class _Pickler:
             return
         n = len(obj)
         if n <= 0xff:
-            self._write_many(SHORT_BINBYTES, pack("<B", n), obj)
+            self.write(SHORT_BINBYTES + pack("<B", n) + obj)
         elif n > 0xffffffff and self.proto >= 4:
-            self._write_many(BINBYTES8, pack("<Q", n), obj)
+            self._write_many(BINBYTES8 + pack("<Q", n), obj)
         else:
-            self._write_many(BINBYTES, pack("<I", n), obj)
+            self._write_many(BINBYTES + pack("<I", n), obj)
         self.memoize(obj)
     dispatch[bytes] = save_bytes
 
@@ -726,11 +726,11 @@ class _Pickler:
             encoded = obj.encode('utf-8', 'surrogatepass')
             n = len(encoded)
             if n <= 0xff and self.proto >= 4:
-                self._write_many(SHORT_BINUNICODE, pack("<B", n), encoded)
+                self.write(SHORT_BINUNICODE + pack("<B", n) + encoded)
             elif n > 0xffffffff and self.proto >= 4:
-                self._write_many(BINUNICODE8, pack("<Q", n), encoded)
+                self._write_many(BINUNICODE8 + pack("<Q", n), encoded)
             else:
-                self._write_many(BINUNICODE, pack("<I", n), encoded)
+                self._write_many(BINUNICODE + pack("<I", n), encoded)
         else:
             obj = obj.replace("\\", "\\u005c")
             obj = obj.replace("\n", "\\u000a")

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -217,17 +217,18 @@ class _Framer:
             return self.file_write(data)
 
     def write_large_bytes(self, opcode, size_header, payload):
-        if len(payload) >= self._FRAME_SIZE_TARGET and self.current_frame:
-            # Terminate the current frame to write the next frame directly into
-            # the underlying file to skip the unnecessary memory allocations
-            # of a large temporary buffer.
-            self.commit_frame(force=True)
+        if len(payload) >= self._FRAME_SIZE_TARGET:
             write = self.file_write
-            frame_size = len(opcode) + len(size_header) + len(payload)
-            write(FRAME + pack("<Q", frame_size))
+            if self.current_frame:
+                # Terminate the current frame to write the next frame directly
+                # into the underlying file to skip the unnecessary memory
+                # allocations of a large temporary buffer.
+                self.commit_frame(force=True)
+                frame_size = len(opcode) + len(size_header) + len(payload)
+                write(FRAME + pack("<Q", frame_size))
 
-            # Be careful to not concatenate the header and the payload prior to
-            # calling 'write' as do not want to allocate a large temporary
+            # Be careful not to concatenate the header and the payload prior to
+            # calling 'write' as we do not want to allocate a large temporary
             # bytes object.
             write(opcode + size_header)
             write(payload)

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -188,6 +188,7 @@ class _Framer:
     def __init__(self, file_write):
         self.file_write = file_write
         self.current_frame = None
+        self.delayed_proto_opcode = None
 
     def start_framing(self):
         self.current_frame = io.BytesIO()
@@ -203,12 +204,23 @@ class _Framer:
             if f.tell() >= self._FRAME_SIZE_TARGET or force:
                 with f.getbuffer() as data:
                     n = len(data)
-                    write = self.file_write
-                    write(FRAME)
-                    write(pack("<Q", n))
-                    write(data)
+                    po = self.delayed_proto_opcode
+                    if po is None:
+                        self.file_write(FRAME + pack("<Q", n) + data)
+                    else:
+                        self.file_write(po + FRAME + pack("<Q", n) + data)
+                        self.delayed_proto_opcode = None
                 f.seek(0)
                 f.truncate()
+
+    def write_proto(self, data):
+        if self.current_frame:
+            # Store proto opcode to delay write when committing the first
+            # frame. The protocol opcode is inserted before the first frame
+            # opcode.
+            self.delayed_proto_opcode = data
+        else:
+            self.file_write(data)
 
     def write(self, data):
         if self.current_frame:
@@ -418,10 +430,10 @@ class _Pickler:
         if not hasattr(self, "_file_write"):
             raise PicklingError("Pickler.__init__() was not called by "
                                 "%s.__init__()" % (self.__class__.__name__,))
-        if self.proto >= 2:
-            self.write(PROTO + pack("<B", self.proto))
         if self.proto >= 4:
             self.framer.start_framing()
+        if self.proto >= 2:
+            self.framer.write_proto(PROTO + pack("<B", self.proto))
         self.save(obj)
         self.write(STOP)
         self.framer.end_framing()

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -228,6 +228,9 @@ class _Framer:
         else:
             write = self.write
 
+        # Be careful to not concatenate the chunks prior to calling 'write' as
+        # some chunks (typically the last of the list) can be very large and we
+        # do not want to allocate a large temporary bytes object.
         for chunk in chunks:
             write(chunk)
 

--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -202,8 +202,9 @@ class _Framer:
             f = self.current_frame
             if f.tell() >= self._FRAME_SIZE_TARGET or force:
                 with f.getbuffer() as data:
-                    self.file_write(FRAME + pack("<Q", len(data)))
-                    self.file_write(data)
+                    write = self.file_write
+                    write(FRAME + pack("<Q", len(data)))
+                    write(data)
                 f.seek(0)
                 f.truncate()
 

--- a/Lib/pickletools.py
+++ b/Lib/pickletools.py
@@ -2251,7 +2251,7 @@ def genops(pickle):
 ##############################################################################
 # A pickle optimizer.
 
-def optimize(pickled):
+def optimize(p):
     'Optimize a pickle string by removing unused PUT opcodes'
     put = 'PUT'
     get = 'GET'
@@ -2260,7 +2260,7 @@ def optimize(pickled):
     opcodes = []            # (op, idx) or (pos, end_pos)
     proto = 0
     protoheader = b''
-    for opcode, arg, pos, end_pos in _genops(pickled, yield_end_pos=True):
+    for opcode, arg, pos, end_pos in _genops(p, yield_end_pos=True):
         if 'PUT' in opcode.name:
             oldids.add(arg)
             opcodes.append((put, arg))
@@ -2279,7 +2279,7 @@ def optimize(pickled):
             if arg > proto:
                 proto = arg
             if pos == 0:
-                protoheader = pickled[pos:end_pos]
+                protoheader = p[pos:end_pos]
             else:
                 opcodes.append((pos, end_pos))
         else:
@@ -2305,7 +2305,7 @@ def optimize(pickled):
         elif op is get:
             data = pickler.get(newids[arg])
         else:
-            data = pickled[op:arg]
+            data = p[op:arg]
             frameless = len(data) > pickler.framer._FRAME_SIZE_TARGET
         pickler.framer.commit_frame(force=frameless)
         if frameless:

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2166,10 +2166,6 @@ class AbstractPickleTests(unittest.TestCase):
             self.assertEqual(obj, self.loads(some_frames_pickle))
 
     def test_framed_write_sizes(self):
-        if not hasattr(self, 'pickler'):
-            # This test requires passing a custom file-object to measure
-            # the number of calls to file.write and the size of each chunk.
-            return
         class Writer:
 
             def __init__(self):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2179,7 +2179,7 @@ class AbstractPickleTests(unittest.TestCase):
                 # Some chunks can be memoryview instances, we need to convert
                 # them to bytes to be able to call join
                 return b"".join([c.tobytes() if hasattr(c, 'tobytes') else c
-                                 for c in w.chunks])
+                                 for c in self.chunks])
 
         small_objects = [(str(i).encode('ascii'), i % 42, {'i': str(i)})
                          for i in range(int(1e4))]

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2105,9 +2105,11 @@ class AbstractPickleTests(unittest.TestCase):
                         pickler.fast = fast
                         pickler.dump(obj)
                         pickled = buf.getvalue()
+                    elif fast:
+                        continue
                     else:
-                        # Note that we cannot set the fast flag to True in
-                        # this case.
+                        # Fallback to self.dumps when fast=False and
+                        # self.pickler is not available.
                         pickled = self.dumps(obj, proto)
                     unpickled = self.loads(pickled)
                     # More informative error message in case of failure.
@@ -2165,8 +2167,9 @@ class AbstractPickleTests(unittest.TestCase):
 
     def test_framed_write_sizes(self):
         if not hasattr(self, 'pickler'):
+            # This test requires passing a custom file-object to measure
+            # the number of calls to file.write and the size of each chunk.
             return
-
         class Writer:
 
             def __init__(self):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2098,11 +2098,6 @@ class AbstractPickleTests(unittest.TestCase):
         obj = [b'x' * N, b'y' * N, 'z' * N]
         for proto in range(4, pickle.HIGHEST_PROTOCOL + 1):
             for fast in [True, False]:
-                if fast and not hasattr(self, 'pickler'):
-                    # The fast flag cannot be changed for test classes that
-                    # only expose the `self.dumps` method.
-                    continue
-
                 with self.subTest(proto=proto, fast=fast):
                     if hasattr(self, 'pickler'):
                         buf = io.BytesIO()
@@ -2111,6 +2106,8 @@ class AbstractPickleTests(unittest.TestCase):
                         pickler.dump(obj)
                         pickled = buf.getvalue()
                     else:
+                        # Note that we cannot set the fast flag to fast flag
+                        # to True in this case.
                         pickled = self.dumps(obj, proto)
                     unpickled = self.loads(pickled)
                     # More informative error message in case of failure.

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2113,6 +2113,10 @@ class AbstractPickleTests(unittest.TestCase):
                     else:
                         pickled = self.dumps(obj, proto)
                     unpickled = self.loads(pickled)
+                    # More informative error message in case of failure.
+                    self.assertEqual([len(x) for x in obj],
+                                     [len(x) for x in unpickled])
+                    # Perform full equality check if the lengths match.
                     self.assertEqual(obj, unpickled)
                     n_frames = count_opcode(pickle.FRAME, pickled)
                     if not fast:

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2106,8 +2106,8 @@ class AbstractPickleTests(unittest.TestCase):
                         pickler.dump(obj)
                         pickled = buf.getvalue()
                     else:
-                        # Note that we cannot set the fast flag to fast flag
-                        # to True in this case.
+                        # Note that we cannot set the fast flag to True in
+                        # this case.
                         pickled = self.dumps(obj, proto)
                     unpickled = self.loads(pickled)
                     # More informative error message in case of failure.

--- a/Lib/test/test_pickletools.py
+++ b/Lib/test/test_pickletools.py
@@ -16,6 +16,9 @@ class OptimizedPickleTests(AbstractPickleTests, AbstractPickleModuleTests):
     # Test relies on precise output of dumps()
     test_pickle_to_2x = None
 
+    # Test relies on writing by chunks into a file object.
+    test_framed_write_sizes = None
+
     def test_optimize_long_binget(self):
         data = [str(i) for i in range(257)]
         data.append(data[-1])

--- a/Lib/test/test_pickletools.py
+++ b/Lib/test/test_pickletools.py
@@ -17,7 +17,7 @@ class OptimizedPickleTests(AbstractPickleTests, AbstractPickleModuleTests):
     test_pickle_to_2x = None
 
     # Test relies on writing by chunks into a file object.
-    test_framed_write_sizes = None
+    test_framed_write_sizes_with_delayed_writer = None
 
     def test_optimize_long_binget(self):
         data = [str(i) for i in range(257)]

--- a/Lib/test/test_pickletools.py
+++ b/Lib/test/test_pickletools.py
@@ -7,6 +7,10 @@ import unittest
 
 class OptimizedPickleTests(AbstractPickleTests, AbstractPickleModuleTests):
 
+    # pickletools.optimize only works in-memory on pickle strings: it
+    # therefore is ok to include large objects inside a large frame.
+    frameless_blobs = False
+
     def dumps(self, arg, proto=None):
         return pickletools.optimize(pickle.dumps(arg, proto))
 

--- a/Lib/test/test_pickletools.py
+++ b/Lib/test/test_pickletools.py
@@ -7,10 +7,6 @@ import unittest
 
 class OptimizedPickleTests(AbstractPickleTests, AbstractPickleModuleTests):
 
-    # pickletools.optimize only works in-memory on pickle strings: it
-    # therefore is ok to include large objects inside a large frame.
-    frameless_blobs = False
-
     def dumps(self, arg, proto=None):
         return pickletools.optimize(pickle.dumps(arg, proto))
 

--- a/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
@@ -5,3 +5,10 @@ directly streamed into the underlying file object.
 Previously the C implementation would buffer all content and issue a
 single call to ``file.write`` at the end of the dump. With protocol 4
 this behavior has changed to issue one call to ``file.write`` per frame.
+
+The Python pickler with protocol 4 now dump each frame content as a
+memoryview to an IOBytes instance that will never be reused and the
+memoryview is no longer released after the call to write. This makes it
+possible for the file object to delay access to the memoryview of
+previous frames without forcing any additional memory copy as was
+already possible with the C pickler.

--- a/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
@@ -6,8 +6,8 @@ Previously the C implementation would buffer all content and issue a
 single call to ``file.write`` at the end of the dump. With protocol 4
 this behavior has changed to issue one call to ``file.write`` per frame.
 
-The Python pickler with protocol 4 now dump each frame content as a
-memoryview to an IOBytes instance that will never be reused and the
+The Python pickler with protocol 4 now dumps each frame content as a
+memoryview to an IOBytes instance that is never reused and the
 memoryview is no longer released after the call to write. This makes it
 possible for the file object to delay access to the memoryview of
 previous frames without forcing any additional memory copy as was

--- a/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
@@ -1,0 +1,3 @@
+The Python-based ``pickle._Pickler`` does no longer allocate temporary
+memory when dumping large ``bytes`` objects. Instead the data is directly
+streamed into the underlying file object.

--- a/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
@@ -1,3 +1,3 @@
-The C-based and Python-based picklers do no longer allocate temporary memory
-when dumping large ``bytes`` and ``str`` objects into a file object. Instead
-the data is directly streamed into the underlying file object.
+The picklers do no longer allocate temporary memory when dumping large
+``bytes`` and ``str`` objects into a file object. Instead the data is
+directly streamed into the underlying file object.

--- a/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
@@ -1,3 +1,3 @@
 The C-based and Python-based picklers do no longer allocate temporary memory
-when dumping large ``bytes`` objects into a file object. Instead the data is
-directly streamed into the underlying file object.
+when dumping large ``bytes`` and ``str`` objects into a file object. Instead
+the data is directly streamed into the underlying file object.

--- a/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
@@ -1,3 +1,3 @@
-The Python-based ``pickle._Pickler`` does no longer allocate temporary
-memory when dumping large ``bytes`` objects. Instead the data is directly
-streamed into the underlying file object.
+The C-based and Python-based picklers do no longer allocate temporary memory
+when dumping large ``bytes`` objects into a file object. Instead the data is
+directly streamed into the underlying file object.

--- a/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-10-00-05-08.bpo-31993.-OMNg8.rst
@@ -1,3 +1,7 @@
 The picklers do no longer allocate temporary memory when dumping large
 ``bytes`` and ``str`` objects into a file object. Instead the data is
 directly streamed into the underlying file object.
+
+Previously the C implementation would buffer all content and issue a
+single call to ``file.write`` at the end of the dump. With protocol 4
+this behavior has changed to issue one call to ``file.write`` per frame.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -956,7 +956,7 @@ _Pickler_OpcodeBoundary(PicklerObject *self)
          * to limit memory usage when dumping large complex objects to
          * a file.
          *
-         * self-write is NULL when called via dumps.
+         * self->write is NULL when called via dumps.
          */
         if (self->write != NULL) {
             if (_Pickler_FlushToFile(self) < 0) {

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -2080,7 +2080,7 @@ done:
 static int
 _Pickler_write_large_bytes(
     PicklerObject *self, const char *header, Py_ssize_t header_size,
-    PyObject *payload, Py_ssize_t payload_size)
+    PyObject *payload)
 {
     assert(self->output_buffer != NULL);
     assert(self->write != NULL);
@@ -2209,7 +2209,7 @@ save_bytes(PicklerObject *self, PyObject *obj)
         else {
             /* Bypass the in-memory buffer to directly stream large data
                into the underlying file object. */
-            if (_Pickler_write_large_bytes(self, header, len, obj, size) < 0) {
+            if (_Pickler_write_large_bytes(self, header, len, obj) < 0) {
                 return -1;
             }
         }
@@ -2339,7 +2339,7 @@ write_utf8(PicklerObject *self, const char *data, Py_ssize_t size)
         if (mem == NULL) {
             return -1;
         }
-        if (_Pickler_write_large_bytes(self, header, len, mem, size) < 0) {
+        if (_Pickler_write_large_bytes(self, header, len, mem) < 0) {
             Py_DECREF(mem);
             return -1;
         }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -951,6 +951,13 @@ _Pickler_OpcodeBoundary(PicklerObject *self)
         if(_Pickler_CommitFrame(self)) {
             return -1;
         }
+        /* Flush the content of the commited frame to the underlying
+         * file and reuse the pickler buffer for the next frame so as
+         * to limit memory usage when dumping large complex objects to
+         * a file.
+         *
+         * self-write is NULL when called via dumps.
+         */
         if (self->write != NULL) {
             if (_Pickler_FlushToFile(self) < 0) {
                 return -1;

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -943,8 +943,9 @@ _Pickler_OpcodeBoundary(PicklerObject *self)
 {
     Py_ssize_t frame_len;
 
-    if (!self->framing || self->frame_start == -1)
+    if (!self->framing || self->frame_start == -1) {
         return 0;
+    }
     frame_len = self->output_len - self->frame_start - FRAME_HEADER_SIZE;
     if (frame_len >= FRAME_SIZE_TARGET) {
         if(_Pickler_CommitFrame(self)) {

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -2073,21 +2073,14 @@ _Pickler_write_large_bytes(
     if (_Pickler_CommitFrame(self, 0)) {
         return -1;
     }
+    /* Disable frameing temporarily */
+    self->framing = 0;
 
-    /* Create a new frame dedicated to the large bytes. */
     if (_Pickler_Write(self, header, header_size) < 0) {
         return -1;
     }
-    if (_Pickler_CommitFrame(self, payload_size)) {
-        return -1;
-    }
-    /* Dump the buffer to the file. */
+    /* Dump the output buffer to the file. */
     if (_Pickler_FlushToFile(self) < 0) {
-        return -1;
-    }
-
-    /* Reinitialize the buffer for subsequent calls to _Pickler_Write. */
-    if (_Pickler_ClearBuffer(self) < 0) {
         return -1;
     }
 
@@ -2098,6 +2091,14 @@ _Pickler_write_large_bytes(
     if (result == NULL) {
         return -1;
     }
+
+    /* Reinitialize the buffer for subsequent calls to _Pickler_Write. */
+    if (_Pickler_ClearBuffer(self) < 0) {
+        return -1;
+    }
+
+    /* Re-enable framing for subsequent calls to _Pickler_Write. */
+    self->framing = 1;
 
     return 0;
 }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -2322,6 +2322,7 @@ write_utf8(PicklerObject *self, const char *data, Py_ssize_t size)
             return -1;
         }
         if (_Pickler_write_large_bytes(self, header, len, mem, size) < 0) {
+            Py_DECREF(mem);
             return -1;
         }
         Py_DECREF(mem);

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -2087,10 +2087,10 @@ _Pickler_write_large_bytes(
     /* Stream write the payload into the file without going through the
        output buffer. */
     result = PyObject_CallFunctionObjArgs(self->write, payload, NULL);
-    Py_XDECREF(result);
     if (result == NULL) {
         return -1;
     }
+    Py_DECREF(result);
 
     /* Reinitialize the buffer for subsequent calls to _Pickler_Write. */
     if (_Pickler_ClearBuffer(self) < 0) {


### PR DESCRIPTION
For all protocols: avoid concatenating large bytes and str with their opcode
and size header but instead issue an individual call to self.write(data).

For protocol 4: if the size of the opcode + size header + data is larger than
the target frame size, commit the current frame and bypass io.BytesIO to write
the next frame directly to the underlying file object.


<!-- issue-number: bpo-31993 -->
https://bugs.python.org/issue31993
<!-- /issue-number -->

Edit: this now includes changes both the Python and C implementations of the picklers.
  