### PR TITLE
[2.7] bpo-31927: Fix reading arbitrary data when parse a AF_BLUETOOTH address (GH-4235) (GH-4352)

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-11-02-18-26-40.bpo-31927.40K6kp.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-02-18-26-40.bpo-31927.40K6kp.rst
@@ -1,0 +1,2 @@
+Fixed reading arbitrary data when parse a AF_BLUETOOTH address on NetBSD and
+DragonFly BSD.


### PR DESCRIPTION
on NetBSD and DragonFly BSD.
(cherry picked from commit d3187158c09cf899e9849f335bdff10594209167).
(cherry picked from commit 596286f8f3c8e53ef010d6298464775dc900a515)


<!-- issue-number: bpo-31927 -->
https://bugs.python.org/issue31927
<!-- /issue-number -->
