### PR TITLE
Remove redundant 'exc = True' line

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -773,7 +773,6 @@ Is semantically equivalent to::
     mgr = (EXPR)
     aexit = type(mgr).__aexit__
     aenter = type(mgr).__aenter__(mgr)
-    exc = True
 
     VAR = await aenter
     try:


### PR DESCRIPTION
It can be removed after https://github.com/python/peps/commit/c28890fb421c906241da6da718f9eacc5a3109ee
