### PR TITLE
[bpo-32070] Clarify the behavior of the staticmethod builtin

### DIFF
--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -828,7 +828,8 @@ PyClassMethod_New(PyObject *callable)
              ...
 
    It can be called either on the class (e.g. C.f()) or on an instance
-   (e.g. C().f()); the instance is ignored except for its class.
+   (e.g. C().f()). Both the class and the instance are ignored, and
+   neither is passed implicitly as the first argument to the method.
 
    Static methods in Python are similar to those found in Java or C++.
    For a more advanced concept, see class methods above.
@@ -935,7 +936,8 @@ To declare a static method, use this idiom:\n\
              ...\n\
 \n\
 It can be called either on the class (e.g. C.f()) or on an instance\n\
-(e.g. C().f()).  The instance is ignored except for its class.\n\
+(e.g. C().f()). Both the class and the instance are ignored, and\n\
+neither is passed implicitly as the first argument to the method.\n\
 \n\
 Static methods in Python are similar to those found in Java or C++.\n\
 For a more advanced concept, see the classmethod builtin.");


### PR DESCRIPTION
It looks like the original staticmethod docstring might have been based on the classmethod docstring, and it seems like the current description might not be accurate. This change clarifies the docstring to explicitly state that neither the class nor instance is used at all in a static method.

<!-- issue-number: bpo-32070 -->
https://bugs.python.org/issue32070
<!-- /issue-number -->
