### PR TITLE
[2.7] bpo-21149: Workaround a GC finalization bug in logging.

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -636,12 +636,19 @@ def _removeHandlerRef(wr):
     # to prevent race conditions and failures during interpreter shutdown.
     acquire, release, handlers = _acquireLock, _releaseLock, _handlerList
     if acquire and release and handlers:
-        acquire()
         try:
-            if wr in handlers:
-                handlers.remove(wr)
-        finally:
-            release()
+            acquire()
+            try:
+                if wr in handlers:
+                    handlers.remove(wr)
+            finally:
+                release()
+        except TypeError:
+            # https://bugs.python.org/issue21149 - If the RLock object behind
+            # acquire() and release() has been partially finalized you may see
+            # an error about NoneType not being callable.  Absolutely nothing
+            # we can do in this GC during process shutdown situation.  Eat it.
+            pass
 
 def _addHandlerRef(handler):
     """

--- a/Misc/NEWS.d/next/Library/2017-11-10-17-19-24.bpo-21149.8UVfeT.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-10-17-19-24.bpo-21149.8UVfeT.rst
@@ -1,0 +1,4 @@
+Silence a `"'NoneType' object is not callable" in <function
+_removeHandlerRef ...> ignored'` error that could happen when a logging
+Handler is destroyed as part of cyclic garbage collection during process
+shutdown.

--- a/Misc/NEWS.d/next/Library/2017-11-10-17-19-24.bpo-21149.8UVfeT.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-10-17-19-24.bpo-21149.8UVfeT.rst
@@ -1,4 +1,3 @@
-Silence a `"'NoneType' object is not callable" in <function
-_removeHandlerRef ...> ignored'` error that could happen when a logging
-Handler is destroyed as part of cyclic garbage collection during process
-shutdown.
+Silence a `'NoneType' object is not callable` in `_removeHandlerRef` error
+that could happen when a logging Handler is destroyed as part of cyclic
+garbage collection during process shutdown.


### PR DESCRIPTION
The logging RLock instances may exist but the threading.RLock class
itself has already been emptied causing a
Exception TypeError: "'NoneType' object is not callable" in <function _removeHandlerRef ..."
to be printed to stderr on process termination.

This catches that exception and ignores it because there is absolutely
nothing we can or should do about it from the context of a weakref
handler called from the gc context.

<!-- issue-number: bpo-21149 -->
https://bugs.python.org/issue21149
<!-- /issue-number -->
