### PR TITLE
Move comments in configure.ac to more appropriate place.

### DIFF
--- a/configure
+++ b/configure
@@ -9542,6 +9542,9 @@ $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+# 'Real Time' functions on Solaris
+# posix4 on Solaris 2.6
+# pthread (first!) on Linux
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing sem_init" >&5
 $as_echo_n "checking for library containing sem_init... " >&6; }
 if ${ac_cv_search_sem_init+:} false; then :
@@ -9597,9 +9600,7 @@ if test "$ac_res" != no; then :
   test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 fi
- # 'Real Time' functions on Solaris
-						# posix4 on Solaris 2.6
-						# pthread (first!) on Linux
+
 
 # check if we need libintl for locale functions
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for textdomain in -lintl" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -2688,9 +2688,10 @@ void *x = uuid_generate_time_safe
   [AC_MSG_RESULT(no)]
 )
 
-AC_SEARCH_LIBS(sem_init, pthread rt posix4) 	# 'Real Time' functions on Solaris
-						# posix4 on Solaris 2.6
-						# pthread (first!) on Linux
+# 'Real Time' functions on Solaris
+# posix4 on Solaris 2.6
+# pthread (first!) on Linux
+AC_SEARCH_LIBS(sem_init, pthread rt posix4)
 
 # check if we need libintl for locale functions
 AC_CHECK_LIB(intl, textdomain,


### PR DESCRIPTION
After 7e666eed362f64fbf887713ec5c0f36516fec35f `configure.ac` and `configure` were
not completely synchronized.  Running `autoconf` produced different indentation.
But since indentation of comments looked weird due to mixing spaces and tabs,
it would be better to move them above the autoconf check.