### PR TITLE
bpo-16055: Fixes incorrect error text for int('1', base=1000)

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4811,7 +4811,7 @@ long_new_impl(PyTypeObject *type, PyObject *x, PyObject *obase)
         return NULL;
     if ((base != 0 && base < 2) || base > 36) {
         PyErr_SetString(PyExc_ValueError,
-                        "int() base must be >= 2 and <= 36");
+                        "int() base must be >= 2 and <= 36  or 0");
         return NULL;
     }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -4811,7 +4811,7 @@ long_new_impl(PyTypeObject *type, PyObject *x, PyObject *obase)
         return NULL;
     if ((base != 0 && base < 2) || base > 36) {
         PyErr_SetString(PyExc_ValueError,
-                        "int() base must be >= 2 and <= 36  or 0");
+                        "int() base must be >= 2 and <= 36, or 0");
         return NULL;
     }
 


### PR DESCRIPTION
The fix is already applied on previous versions of Python. This fix shall now also work in 3.7

<!-- issue-number: bpo-16055 -->
https://bugs.python.org/issue16055
<!-- /issue-number -->
