### PR TITLE
bpo-33541: Remove unused __pad function

### DIFF
--- a/Lib/_strptime.py
+++ b/Lib/_strptime.py
@@ -77,15 +77,6 @@ class LocaleTime(object):
         if time.tzname != self.tzname or time.daylight != self.daylight:
             raise ValueError("timezone changed during initialization")
 
-    def __pad(self, seq, front):
-        # Add '' to seq to either the front (is True), else the back.
-        seq = list(seq)
-        if front:
-            seq.insert(0, '')
-        else:
-            seq.append('')
-        return seq
-
     def __calc_weekday(self):
         # Set self.a_weekday and self.f_weekday using the calendar
         # module.

--- a/Misc/NEWS.d/next/Library/2018-05-16-12-32-48.bpo-33541.kQORPE.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-16-12-32-48.bpo-33541.kQORPE.rst
@@ -1,0 +1,2 @@
+Remove unused private method ``_strptime.LocaleTime.__pad`` (a.k.a.
+``_LocaleTime__pad``).


### PR DESCRIPTION
The function was added with the initial implementation 00efe7e.

Should be safe to remove as it is private and mangled.

<!-- issue-number: bpo-33541 -->
https://bugs.python.org/issue33541
<!-- /issue-number -->
