### PR TITLE
bpo-32012: Disallow trailing comma after genexpr without parenthesis.

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -638,18 +638,10 @@ Changes in Python behavior
 
       f(1 for x in [1],)
 
-      @deco(1 for x in [1])
-      def f():
-          pass
-
-      class C(1 for x in [1]):
-          pass
-
   Python 3.7 now correctly raises a :exc:`SyntaxError`, as a generator
   expression always needs to be directly inside a set of parentheses
-  and cannot have a comma on either side, and the duplication of the
-  parentheses can be omitted only on calls.
-  (Contributed by Serhiy Storchaka in :issue:`32012`.)
+  and cannot have a comma on either side.
+  (Contributed by Serhiy Storchaka in :issue:`XXXXX`.)
 
 
 Changes in the Python API

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -638,10 +638,18 @@ Changes in Python behavior
 
       f(1 for x in [1],)
 
+      @deco(1 for x in [1])
+      def f():
+          pass
+
+      class C(1 for x in [1]):
+          pass
+
   Python 3.7 now correctly raises a :exc:`SyntaxError`, as a generator
   expression always needs to be directly inside a set of parentheses
-  and cannot have a comma on either side.
-  (Contributed by Serhiy Storchaka in :issue:`XXXXX`.)
+  and cannot have a comma on either side, and the duplication of the
+  parentheses can be omitted only on calls.
+  (Contributed by Serhiy Storchaka in :issue:`32012`.)
 
 
 Changes in the Python API

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -630,6 +630,20 @@ This section lists previously described changes and other bugfixes
 that may require changes to your code.
 
 
+Changes in Python behavior
+--------------------------
+
+* Due to an oversight, earlier Python versions erroneously accepted the
+  following syntax::
+
+      f(1 for x in [1],)
+
+  Python 3.7 now correctly raises a :exc:`SyntaxError`, as a generator
+  expression always needs to be directly inside a set of parentheses
+  and cannot have a comma on either side.
+  (Contributed by Serhiy Storchaka in :issue:`XXXXX`.)
+
+
 Changes in the Python API
 -------------------------
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -641,7 +641,7 @@ Changes in Python behavior
   Python 3.7 now correctly raises a :exc:`SyntaxError`, as a generator
   expression always needs to be directly inside a set of parentheses
   and cannot have a comma on either side.
-  (Contributed by Serhiy Storchaka in :issue:`XXXXX`.)
+  (Contributed by Serhiy Storchaka in :issue:`32012`.)
 
 
 Changes in the Python API

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -125,17 +125,32 @@ SyntaxError: invalid syntax
 
 From ast_for_call():
 
->>> def f(it, *varargs):
+>>> def f(it, *varargs, **kwargs):
 ...     return list(it)
 >>> L = range(10)
 >>> f(x for x in L)
 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 >>> f(x for x in L, 1)
 Traceback (most recent call last):
-SyntaxError: Generator expression must be parenthesized if not sole argument
+SyntaxError: Generator expression must be parenthesized
+>>> f(x for x in L, y=1)
+Traceback (most recent call last):
+SyntaxError: Generator expression must be parenthesized
+>>> f(x for x in L, *[])
+Traceback (most recent call last):
+SyntaxError: Generator expression must be parenthesized
+>>> f(x for x in L, **{})
+Traceback (most recent call last):
+SyntaxError: Generator expression must be parenthesized
+>>> f(L, x for x in L)
+Traceback (most recent call last):
+SyntaxError: Generator expression must be parenthesized
 >>> f(x for x in L, y for y in L)
 Traceback (most recent call last):
-SyntaxError: Generator expression must be parenthesized if not sole argument
+SyntaxError: Generator expression must be parenthesized
+>>> f(x for x in L,)
+Traceback (most recent call last):
+SyntaxError: Generator expression must be parenthesized
 >>> f((x for x in L), 1)
 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -153,6 +153,17 @@ Traceback (most recent call last):
 SyntaxError: Generator expression must be parenthesized
 >>> f((x for x in L), 1)
 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+>>> def deco(*args):
+...     return lambda f: f
+>>> @deco(x for x in L)
+... def g(*args, **kwargs):
+...     pass
+Traceback (most recent call last):
+SyntaxError: invalid syntax
+>>> class C(x for x in L):
+...     pass
+Traceback (most recent call last):
+SyntaxError: invalid syntax
 
 >>> def g(*args, **kwargs):
 ...     print(args, sorted(kwargs.items()))

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -153,17 +153,6 @@ Traceback (most recent call last):
 SyntaxError: Generator expression must be parenthesized
 >>> f((x for x in L), 1)
 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
->>> def deco(*args):
-...     return lambda f: f
->>> @deco(x for x in L)
-... def g(*args, **kwargs):
-...     pass
-Traceback (most recent call last):
-SyntaxError: invalid syntax
->>> class C(x for x in L):
-...     pass
-Traceback (most recent call last):
-SyntaxError: invalid syntax
 
 >>> def g(*args, **kwargs):
 ...     print(args, sorted(kwargs.items()))

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
@@ -1,4 +1,4 @@
-SyntaxError is now raised when a generator expression without parenthesis is
-passed as an argument but followed by a trailing comma. A generator expression
-always needs to be directly inside a set of parentheses and cannot have a
-comma on either side.
+SyntaxError is now correctly raised when a generator expression without
+parenthesis is passed as an argument, but followed by a trailing comma.
+A generator expression always needs to be directly inside a set of parentheses
+and cannot have a comma on either side.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
@@ -1,4 +1,7 @@
-SyntaxError is now raised when a generator expression without parenthesis is
-passed as an argument but followed by a trailing comma. A generator expression
+SyntaxError is now correctly raised when a generator expression without
+parenthesis is passed as an argument, but followed by a trailing comma, or
+it is used instead of an argument list in a decorator expression, or
+instead of an inheritance list in a class definition.  A generator expression
 always needs to be directly inside a set of parentheses and cannot have a
-comma on either side.
+comma on either side.  The duplication of the parentheses can be omitted
+only on calls.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
@@ -1,4 +1,4 @@
-SyntaxError now is raised when a generator expression without parenthesis is
-passed as argument but followed by trailing comma. A generator expression
+SyntaxError is now raised when a generator expression without parenthesis is
+passed as an argument but followed by a trailing comma. A generator expression
 always needs to be directly inside a set of parentheses and cannot have a
 comma on either side.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
@@ -1,0 +1,4 @@
+SyntaxError now is raised when a generator expression without parenthesis is
+passed as argument but followed by trailing comma. A generator expression
+always needs to be directly inside a set of parentheses and cannot have a
+comma on either side.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-13-00-37-11.bpo-32012.Kprjqe.rst
@@ -1,7 +1,4 @@
-SyntaxError is now correctly raised when a generator expression without
-parenthesis is passed as an argument, but followed by a trailing comma, or
-it is used instead of an argument list in a decorator expression, or
-instead of an inheritance list in a class definition.  A generator expression
+SyntaxError is now raised when a generator expression without parenthesis is
+passed as an argument but followed by a trailing comma. A generator expression
 always needs to be directly inside a set of parentheses and cannot have a
-comma on either side.  The duplication of the parentheses can be omitted
-only on calls.
+comma on either side.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -611,7 +611,7 @@ static stmt_ty ast_for_with_stmt(struct compiling *, const node *, int);
 static stmt_ty ast_for_for_stmt(struct compiling *, const node *, int);
 
 /* Note different signature for ast_for_call */
-static expr_ty ast_for_call(struct compiling *, const node *, expr_ty, int);
+static expr_ty ast_for_call(struct compiling *, const node *, expr_ty);
 
 static PyObject *parsenumber(struct compiling *, const char *);
 static expr_ty parsestrplus(struct compiling *, const node *n);
@@ -1545,7 +1545,7 @@ ast_for_decorator(struct compiling *c, const node *n)
         name_expr = NULL;
     }
     else {
-        d = ast_for_call(c, CHILD(n, 3), name_expr, 0);
+        d = ast_for_call(c, CHILD(n, 3), name_expr);
         if (!d)
             return NULL;
         name_expr = NULL;
@@ -2368,7 +2368,7 @@ ast_for_trailer(struct compiling *c, const node *n, expr_ty left_expr)
             return Call(left_expr, NULL, NULL, LINENO(n),
                         n->n_col_offset, c->c_arena);
         else
-            return ast_for_call(c, CHILD(n, 1), left_expr, 1);
+            return ast_for_call(c, CHILD(n, 1), left_expr);
     }
     else if (TYPE(CHILD(n, 0)) == DOT) {
         PyObject *attr_id = NEW_IDENTIFIER(CHILD(n, 1));
@@ -2705,7 +2705,7 @@ ast_for_expr(struct compiling *c, const node *n)
 }
 
 static expr_ty
-ast_for_call(struct compiling *c, const node *n, expr_ty func, int allowgen)
+ast_for_call(struct compiling *c, const node *n, expr_ty func)
 {
     /*
       arglist: argument (',' argument)*  [',']
@@ -2728,10 +2728,6 @@ ast_for_call(struct compiling *c, const node *n, expr_ty func, int allowgen)
                 nargs++;
             else if (TYPE(CHILD(ch, 1)) == comp_for) {
                 nargs++;
-                if (!allowgen) {
-                    ast_error(c, ch, "invalid syntax");
-                    return NULL;
-                }
                 if (NCH(n) > 1) {
                     ast_error(c, ch, "Generator expression must be parenthesized");
                     return NULL;
@@ -3977,7 +3973,7 @@ ast_for_classdef(struct compiling *c, const node *n, asdl_seq *decorator_seq)
         if (!dummy_name)
             return NULL;
         dummy = Name(dummy_name, Load, LINENO(n), n->n_col_offset, c->c_arena);
-        call = ast_for_call(c, CHILD(n, 3), dummy, 0);
+        call = ast_for_call(c, CHILD(n, 3), dummy);
         if (!call)
             return NULL;
     }

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -11,6 +11,7 @@
 #include "pythonrun.h"
 
 #include <assert.h>
+#include <stdbool.h>
 
 static int validate_stmts(asdl_seq *);
 static int validate_exprs(asdl_seq *, expr_context_ty, int);
@@ -611,7 +612,7 @@ static stmt_ty ast_for_with_stmt(struct compiling *, const node *, int);
 static stmt_ty ast_for_for_stmt(struct compiling *, const node *, int);
 
 /* Note different signature for ast_for_call */
-static expr_ty ast_for_call(struct compiling *, const node *, expr_ty, int);
+static expr_ty ast_for_call(struct compiling *, const node *, expr_ty, bool);
 
 static PyObject *parsenumber(struct compiling *, const char *);
 static expr_ty parsestrplus(struct compiling *, const node *n);
@@ -1545,7 +1546,7 @@ ast_for_decorator(struct compiling *c, const node *n)
         name_expr = NULL;
     }
     else {
-        d = ast_for_call(c, CHILD(n, 3), name_expr, 0);
+        d = ast_for_call(c, CHILD(n, 3), name_expr, false);
         if (!d)
             return NULL;
         name_expr = NULL;
@@ -2368,7 +2369,7 @@ ast_for_trailer(struct compiling *c, const node *n, expr_ty left_expr)
             return Call(left_expr, NULL, NULL, LINENO(n),
                         n->n_col_offset, c->c_arena);
         else
-            return ast_for_call(c, CHILD(n, 1), left_expr, 1);
+            return ast_for_call(c, CHILD(n, 1), left_expr, true);
     }
     else if (TYPE(CHILD(n, 0)) == DOT) {
         PyObject *attr_id = NEW_IDENTIFIER(CHILD(n, 1));
@@ -2705,7 +2706,7 @@ ast_for_expr(struct compiling *c, const node *n)
 }
 
 static expr_ty
-ast_for_call(struct compiling *c, const node *n, expr_ty func, int allowgen)
+ast_for_call(struct compiling *c, const node *n, expr_ty func, bool allowgen)
 {
     /*
       arglist: argument (',' argument)*  [',']
@@ -3977,7 +3978,7 @@ ast_for_classdef(struct compiling *c, const node *n, asdl_seq *decorator_seq)
         if (!dummy_name)
             return NULL;
         dummy = Name(dummy_name, Load, LINENO(n), n->n_col_offset, c->c_arena);
-        call = ast_for_call(c, CHILD(n, 3), dummy, 0);
+        call = ast_for_call(c, CHILD(n, 3), dummy, false);
         if (!call)
             return NULL;
     }

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -611,7 +611,7 @@ static stmt_ty ast_for_with_stmt(struct compiling *, const node *, int);
 static stmt_ty ast_for_for_stmt(struct compiling *, const node *, int);
 
 /* Note different signature for ast_for_call */
-static expr_ty ast_for_call(struct compiling *, const node *, expr_ty);
+static expr_ty ast_for_call(struct compiling *, const node *, expr_ty, int);
 
 static PyObject *parsenumber(struct compiling *, const char *);
 static expr_ty parsestrplus(struct compiling *, const node *n);
@@ -1545,7 +1545,7 @@ ast_for_decorator(struct compiling *c, const node *n)
         name_expr = NULL;
     }
     else {
-        d = ast_for_call(c, CHILD(n, 3), name_expr);
+        d = ast_for_call(c, CHILD(n, 3), name_expr, 0);
         if (!d)
             return NULL;
         name_expr = NULL;
@@ -2368,7 +2368,7 @@ ast_for_trailer(struct compiling *c, const node *n, expr_ty left_expr)
             return Call(left_expr, NULL, NULL, LINENO(n),
                         n->n_col_offset, c->c_arena);
         else
-            return ast_for_call(c, CHILD(n, 1), left_expr);
+            return ast_for_call(c, CHILD(n, 1), left_expr, 1);
     }
     else if (TYPE(CHILD(n, 0)) == DOT) {
         PyObject *attr_id = NEW_IDENTIFIER(CHILD(n, 1));
@@ -2705,7 +2705,7 @@ ast_for_expr(struct compiling *c, const node *n)
 }
 
 static expr_ty
-ast_for_call(struct compiling *c, const node *n, expr_ty func)
+ast_for_call(struct compiling *c, const node *n, expr_ty func, int allowgen)
 {
     /*
       arglist: argument (',' argument)*  [',']
@@ -2728,6 +2728,10 @@ ast_for_call(struct compiling *c, const node *n, expr_ty func)
                 nargs++;
             else if (TYPE(CHILD(ch, 1)) == comp_for) {
                 nargs++;
+                if (!allowgen) {
+                    ast_error(c, ch, "invalid syntax");
+                    return NULL;
+                }
                 if (NCH(n) > 1) {
                     ast_error(c, ch, "Generator expression must be parenthesized");
                     return NULL;
@@ -3973,7 +3977,7 @@ ast_for_classdef(struct compiling *c, const node *n, asdl_seq *decorator_seq)
         if (!dummy_name)
             return NULL;
         dummy = Name(dummy_name, Load, LINENO(n), n->n_col_offset, c->c_arena);
-        call = ast_for_call(c, CHILD(n, 3), dummy);
+        call = ast_for_call(c, CHILD(n, 3), dummy, 0);
         if (!call)
             return NULL;
     }

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -11,7 +11,6 @@
 #include "pythonrun.h"
 
 #include <assert.h>
-#include <stdbool.h>
 
 static int validate_stmts(asdl_seq *);
 static int validate_exprs(asdl_seq *, expr_context_ty, int);
@@ -612,7 +611,7 @@ static stmt_ty ast_for_with_stmt(struct compiling *, const node *, int);
 static stmt_ty ast_for_for_stmt(struct compiling *, const node *, int);
 
 /* Note different signature for ast_for_call */
-static expr_ty ast_for_call(struct compiling *, const node *, expr_ty, bool);
+static expr_ty ast_for_call(struct compiling *, const node *, expr_ty, int);
 
 static PyObject *parsenumber(struct compiling *, const char *);
 static expr_ty parsestrplus(struct compiling *, const node *n);
@@ -1546,7 +1545,7 @@ ast_for_decorator(struct compiling *c, const node *n)
         name_expr = NULL;
     }
     else {
-        d = ast_for_call(c, CHILD(n, 3), name_expr, false);
+        d = ast_for_call(c, CHILD(n, 3), name_expr, 0);
         if (!d)
             return NULL;
         name_expr = NULL;
@@ -2369,7 +2368,7 @@ ast_for_trailer(struct compiling *c, const node *n, expr_ty left_expr)
             return Call(left_expr, NULL, NULL, LINENO(n),
                         n->n_col_offset, c->c_arena);
         else
-            return ast_for_call(c, CHILD(n, 1), left_expr, true);
+            return ast_for_call(c, CHILD(n, 1), left_expr, 1);
     }
     else if (TYPE(CHILD(n, 0)) == DOT) {
         PyObject *attr_id = NEW_IDENTIFIER(CHILD(n, 1));
@@ -2706,7 +2705,7 @@ ast_for_expr(struct compiling *c, const node *n)
 }
 
 static expr_ty
-ast_for_call(struct compiling *c, const node *n, expr_ty func, bool allowgen)
+ast_for_call(struct compiling *c, const node *n, expr_ty func, int allowgen)
 {
     /*
       arglist: argument (',' argument)*  [',']
@@ -3978,7 +3977,7 @@ ast_for_classdef(struct compiling *c, const node *n, asdl_seq *decorator_seq)
         if (!dummy_name)
             return NULL;
         dummy = Name(dummy_name, Load, LINENO(n), n->n_col_offset, c->c_arena);
-        call = ast_for_call(c, CHILD(n, 3), dummy, false);
+        call = ast_for_call(c, CHILD(n, 3), dummy, 0);
         if (!call)
             return NULL;
     }


### PR DESCRIPTION
https://mail.python.org/pipermail/python-dev/2017-November/150481.html

<!-- issue-number: bpo-32012 -->
https://bugs.python.org/issue32012
<!-- /issue-number -->
