### PR TITLE
bpo-32013: _pickle: Add missing Py_DECREF in error case in fast_save_enter()

### DIFF
--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1777,8 +1777,10 @@ fast_save_enter(PicklerObject *self, PyObject *obj)
             }
         }
         key = PyLong_FromVoidPtr(obj);
-        if (key == NULL)
+        if (key == NULL) {
+            self->fast_nesting = -1;
             return 0;
+        }
         if (PyDict_GetItemWithError(self->fast_memo, key)) {
             Py_DECREF(key);
             PyErr_Format(PyExc_ValueError,
@@ -1789,6 +1791,8 @@ fast_save_enter(PicklerObject *self, PyObject *obj)
             return 0;
         }
         if (PyErr_Occurred()) {
+            Py_DECREF(key);
+            self->fast_nesting = -1;
             return 0;
         }
         if (PyDict_SetItem(self->fast_memo, key, Py_None) < 0) {


### PR DESCRIPTION
Hi! As said on the issue filed. I'm new to the development/contribution process for Python, so I figured I'd start with something small, just get used to things.

As far as I understand, there should be a Py_DECREF in this conditional.

<!-- issue-number: bpo-32013 -->
https://bugs.python.org/issue32013
<!-- /issue-number -->
