### PR TITLE
bpo-32032: Test both implementations of module-level pickle API.

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2534,7 +2534,7 @@ class AbstractPickleModuleTests(unittest.TestCase):
         f = open(TESTFN, "wb")
         try:
             f.close()
-            self.assertRaises(ValueError, pickle.dump, 123, f)
+            self.assertRaises(ValueError, self.dump, 123, f)
         finally:
             os.remove(TESTFN)
 
@@ -2543,16 +2543,16 @@ class AbstractPickleModuleTests(unittest.TestCase):
         f = open(TESTFN, "wb")
         try:
             f.close()
-            self.assertRaises(ValueError, pickle.dump, 123, f)
+            self.assertRaises(ValueError, self.dump, 123, f)
         finally:
             os.remove(TESTFN)
 
     def test_load_from_and_dump_to_file(self):
         stream = io.BytesIO()
         data = [123, {}, 124]
-        pickle.dump(data, stream)
+        self.dump(data, stream)
         stream.seek(0)
-        unpickled = pickle.load(stream)
+        unpickled = self.load(stream)
         self.assertEqual(unpickled, data)
 
     def test_highest_protocol(self):
@@ -2562,24 +2562,12 @@ class AbstractPickleModuleTests(unittest.TestCase):
     def test_callapi(self):
         f = io.BytesIO()
         # With and without keyword arguments
-        pickle.dump(123, f, -1)
-        pickle.dump(123, file=f, protocol=-1)
-        pickle.dumps(123, -1)
-        pickle.dumps(123, protocol=-1)
-        pickle.Pickler(f, -1)
-        pickle.Pickler(f, protocol=-1)
-
-    def test_bad_init(self):
-        # Test issue3664 (pickle can segfault from a badly initialized Pickler).
-        # Override initialization without calling __init__() of the superclass.
-        class BadPickler(pickle.Pickler):
-            def __init__(self): pass
-
-        class BadUnpickler(pickle.Unpickler):
-            def __init__(self): pass
-
-        self.assertRaises(pickle.PicklingError, BadPickler().dump, 0)
-        self.assertRaises(pickle.UnpicklingError, BadUnpickler().load)
+        self.dump(123, f, -1)
+        self.dump(123, file=f, protocol=-1)
+        self.dumps(123, -1)
+        self.dumps(123, protocol=-1)
+        self.Pickler(f, -1)
+        self.Pickler(f, protocol=-1)
 
 
 class AbstractPersistentPicklerTests(unittest.TestCase):

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2569,6 +2569,18 @@ class AbstractPickleModuleTests(unittest.TestCase):
         self.Pickler(f, -1)
         self.Pickler(f, protocol=-1)
 
+    def test_bad_init(self):
+        # Test issue3664 (pickle can segfault from a badly initialized Pickler).
+        # Override initialization without calling __init__() of the superclass.
+        class BadPickler(self.Pickler):
+            def __init__(self): pass
+
+        class BadUnpickler(self.Unpickler):
+            def __init__(self): pass
+
+        self.assertRaises(pickle.PicklingError, BadPickler().dump, 0)
+        self.assertRaises(pickle.UnpicklingError, BadUnpickler().load)
+
 
 class AbstractPersistentPicklerTests(unittest.TestCase):
 

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -32,6 +32,7 @@ class PyPickleTests(AbstractPickleModuleTests):
     load = staticmethod(pickle._load)
     loads = staticmethod(pickle._loads)
     Pickler = pickle._Pickler
+    Unpickler = pickle._Unpickler
 
 
 class PyUnpicklerTests(AbstractUnpickleTests):
@@ -141,19 +142,7 @@ class PyChainDispatchTableTests(AbstractDispatchTableTests):
 
 if has_c_implementation:
     class CPickleTests(AbstractPickleModuleTests):
-        from _pickle import dump, dumps, load, loads, Pickler
-
-        def test_bad_init(self):
-            # Test issue3664 (pickle can segfault from a badly initialized Pickler).
-            # Override initialization without calling __init__() of the superclass.
-            class BadPickler(pickle.Pickler):
-                def __init__(self): pass
-
-            class BadUnpickler(pickle.Unpickler):
-                def __init__(self): pass
-
-            self.assertRaises(pickle.PicklingError, BadPickler().dump, 0)
-            self.assertRaises(pickle.UnpicklingError, BadUnpickler().load)
+        from _pickle import dump, dumps, load, loads, Pickler, Unpickler
 
     class CUnpicklerTests(PyUnpicklerTests):
         unpickler = _pickle.Unpickler

--- a/Lib/test/test_pickletools.py
+++ b/Lib/test/test_pickletools.py
@@ -2,10 +2,9 @@ import pickle
 import pickletools
 from test import support
 from test.pickletester import AbstractPickleTests
-from test.pickletester import AbstractPickleModuleTests
 import unittest
 
-class OptimizedPickleTests(AbstractPickleTests, AbstractPickleModuleTests):
+class OptimizedPickleTests(AbstractPickleTests):
 
     def dumps(self, arg, proto=None):
         return pickletools.optimize(pickle.dumps(arg, proto))


### PR DESCRIPTION


<!-- issue-number: bpo-32032 -->
https://bugs.python.org/issue32032
<!-- /issue-number -->
