### PR TITLE
bpo-32018: inspect.signature should follow PEP 8

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2521,11 +2521,14 @@ class Parameter:
 
         # Add annotation and default value
         if self._annotation is not _empty:
-            formatted = '{}:{}'.format(formatted,
+            formatted = '{}: {}'.format(formatted,
                                        formatannotation(self._annotation))
 
         if self._default is not _empty:
-            formatted = '{}={}'.format(formatted, repr(self._default))
+            if self._annotation is not _empty:
+                formatted = '{} = {}'.format(formatted, repr(self._default))
+            else:
+                formatted = '{}={}'.format(formatted, repr(self._default))
 
         if kind == _VAR_POSITIONAL:
             formatted = '*' + formatted

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -2875,12 +2875,12 @@ class TestSignatureObject(unittest.TestCase):
         def foo(a:int=1, *, b, c=None, **kwargs) -> 42:
             pass
         self.assertEqual(str(inspect.signature(foo)),
-                         '(a:int=1, *, b, c=None, **kwargs) -> 42')
+                         '(a: int = 1, *, b, c=None, **kwargs) -> 42')
 
         def foo(a:int=1, *args, b, c=None, **kwargs) -> 42:
             pass
         self.assertEqual(str(inspect.signature(foo)),
-                         '(a:int=1, *args, b, c=None, **kwargs) -> 42')
+                         '(a: int = 1, *args, b, c=None, **kwargs) -> 42')
 
         def foo():
             pass

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -824,7 +824,7 @@ class TestDescriptions(unittest.TestCase):
         T = typing.TypeVar('T')
         class C(typing.Generic[T], typing.Mapping[int, str]): ...
         self.assertEqual(pydoc.render_doc(foo).splitlines()[-1],
-                         'f\x08fo\x08oo\x08o(data:List[Any], x:int)'
+                         'f\x08fo\x08oo\x08o(data: List[Any], x: int)'
                          ' -> Iterator[Tuple[int, Any]]')
         self.assertEqual(pydoc.render_doc(C).splitlines()[2],
                          'class C\x08C(typing.Mapping)')

--- a/Misc/NEWS.d/next/Library/2017-11-16-02-32-41.bpo-32018.YMQ7Q2.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-16-02-32-41.bpo-32018.YMQ7Q2.rst
@@ -1,0 +1,2 @@
+inspect.signature should follow PEP 8, if the parameter has an annotation and a
+default value. Patch by Dong-hee Na.


### PR DESCRIPTION
If the parameter has an annotation and a default value,
it should follow PEP 8.


<!-- issue-number: bpo-32018 -->
https://bugs.python.org/issue32018
<!-- /issue-number -->
