### PR TITLE
bpo-32034: Make asyncio.IncompleteReadError pickleable.

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -49,6 +49,9 @@ class LimitOverrunError(Exception):
         super().__init__(message)
         self.consumed = consumed
 
+    def __reduce__(self):
+        return type(self), (self.args[0], self.consumed)
+
 
 @coroutine
 def open_connection(host=None, port=None, *,

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -35,6 +35,9 @@ class IncompleteReadError(EOFError):
         self.partial = partial
         self.expected = expected
 
+    def __reduce__(self):
+        return type(self), (self.partial, self.expected)
+
 
 class LimitOverrunError(Exception):
     """Reached the buffer limit while looking for a separator.

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -848,16 +848,20 @@ os.close(fd)
 
     def test_IncompleteReadError_pickleable(self):
         e = asyncio.IncompleteReadError(b'abc', 10)
-        e2 = pickle.loads(pickle.dumps(e))
-        self.assertEqual(str(e), str(e2))
-        self.assertEqual(e.partial, e2.partial)
-        self.assertEqual(e.expected, e2.expected)
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(pickle_protocol=proto):
+                e2 = pickle.loads(pickle.dumps(e, protocol=proto))
+                self.assertEqual(str(e), str(e2))
+                self.assertEqual(e.partial, e2.partial)
+                self.assertEqual(e.expected, e2.expected)
 
     def test_LimitOverrunError_pickleable(self):
         e = asyncio.LimitOverrunError('message', 10)
-        e2 = pickle.loads(pickle.dumps(e))
-        self.assertEqual(str(e), str(e2))
-        self.assertEqual(e.consumed, e2.consumed)
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            with self.subTest(pickle_protocol=proto):
+                e2 = pickle.loads(pickle.dumps(e, protocol=proto))
+                self.assertEqual(str(e), str(e2))
+                self.assertEqual(e.consumed, e2.consumed)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -853,6 +853,12 @@ os.close(fd)
         self.assertEqual(e.partial, e2.partial)
         self.assertEqual(e.expected, e2.expected)
 
+    def test_LimitOverrunError_pickleable(self):
+        e = asyncio.LimitOverrunError('message', 10)
+        e2 = pickle.loads(pickle.dumps(e))
+        self.assertEqual(str(e), str(e2))
+        self.assertEqual(e.consumed, e2.consumed)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -3,6 +3,7 @@
 import gc
 import os
 import queue
+import pickle
 import socket
 import sys
 import threading
@@ -844,6 +845,13 @@ os.close(fd)
         stream._transport.__repr__ = mock.Mock()
         stream._transport.__repr__.return_value = "<Transport>"
         self.assertEqual("<StreamReader t=<Transport>>", repr(stream))
+
+    def test_IncompleteReadError_pickleable(self):
+        e = asyncio.IncompleteReadError(b'abc', 10)
+        e2 = pickle.loads(pickle.dumps(e))
+        self.assertEqual(str(e), str(e2))
+        self.assertEqual(e.partial, e2.partial)
+        self.assertEqual(e.expected, e2.expected)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2017-11-15-13-44-28.bpo-32034.uHAOmu.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-15-13-44-28.bpo-32034.uHAOmu.rst
@@ -1,0 +1,1 @@
+Make asyncio.IncompleteReadError pickleable.

--- a/Misc/NEWS.d/next/Library/2017-11-15-13-44-28.bpo-32034.uHAOmu.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-15-13-44-28.bpo-32034.uHAOmu.rst
@@ -1,1 +1,1 @@
-Make asyncio.IncompleteReadError pickleable.
+Make asyncio.IncompleteReadError and LimitOverrunError pickleable.


### PR DESCRIPTION


<!-- issue-number: bpo-32034 -->
https://bugs.python.org/issue32034
<!-- /issue-number -->
