### PR TITLE
bpo-31808: Fix tarfile to support overwriting symlinks.

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -2198,10 +2198,14 @@ class TarFile(object):
         try:
             # For systems that support symbolic and hard links.
             if tarinfo.issym():
+                if os.path.lexists(targetpath):
+                    os.unlink(targetpath)
                 os.symlink(tarinfo.linkname, targetpath)
             else:
                 # See extract().
                 if os.path.exists(tarinfo._link_target):
+                    if os.path.lexists(targetpath):
+                        os.unlink(targetpath)
                     os.link(tarinfo._link_target, targetpath)
                 else:
                     self._extract_member(self._find_link_target(tarinfo),

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1265,7 +1265,6 @@ class WriteTest(WriteTestBase, unittest.TestCase):
         self.assertEqual(t.name, cmp_path or path.replace(os.sep, "/"))
 
 
-    @support.skip_unless_symlink
     def test_extractall_symlinks(self):
         # Test if extractall works properly when tarfile contains symlinks
         tempdir = os.path.join(TEMPDIR, "testsymlinks")

--- a/Misc/NEWS.d/next/Library/2017-11-16-17-25-34.bpo-31808.F4Q6R5.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-16-17-25-34.bpo-31808.F4Q6R5.rst
@@ -1,0 +1,1 @@
+Update tarfile to support overwriting symlinks. Patch by Dong-hee Na.


### PR DESCRIPTION




<!-- issue-number: bpo-31808 -->
https://bugs.python.org/issue31808
<!-- /issue-number -->
