### PR TITLE
[3.6] bpo-31701: faulthandler: ignore MSC and COM Windows exception (#3929)

### DIFF
--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -756,6 +756,22 @@ class FaultHandlerTests(unittest.TestCase):
                 name)
 
     @unittest.skipUnless(MS_WINDOWS, 'specific to Windows')
+    def test_ignore_exception(self):
+        for exc_code in (
+            0xE06D7363,   # MSC exception ("Emsc")
+            0xE0434352,   # COM Callable Runtime exception ("ECCR")
+        ):
+            code = f"""
+                    import faulthandler
+                    faulthandler.enable()
+                    faulthandler._raise_exception({exc_code})
+                    """
+            code = dedent(code)
+            output, exitcode = self.get_output(code)
+            self.assertEqual(output, [])
+            self.assertEqual(exitcode, exc_code)
+
+    @unittest.skipUnless(MS_WINDOWS, 'specific to Windows')
     def test_raise_nonfatal_exception(self):
         # These exceptions are not strictly errors. Letting
         # faulthandler display the traceback when they are

--- a/Misc/NEWS.d/next/Library/2017-10-09-17-42-30.bpo-31701.NRrVel.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-09-17-42-30.bpo-31701.NRrVel.rst
@@ -1,0 +1,1 @@
+On Windows, faulthandler.enable() now ignores MSC and COM exceptions.


### PR DESCRIPTION
(cherry picked from commit 6e3d6b5dc22cd06d8c4d44a38a8a3415e4bebb16)

<!-- issue-number: bpo-31701 -->
https://bugs.python.org/issue31701
<!-- /issue-number -->
