### PR TITLE
bpo-32046: Update 2to3 when converts operator.isCallable(obj).

### DIFF
--- a/Doc/library/2to3.rst
+++ b/Doc/library/2to3.rst
@@ -351,7 +351,7 @@ and off individually.  They are described here in more detail.
    ==================================  =============================================
    From                                To
    ==================================  =============================================
-   ``operator.isCallable(obj)``        ``hasattr(obj, '__call__')``
+   ``operator.isCallable(obj)``        ``callable(obj)``
    ``operator.sequenceIncludes(obj)``  ``operator.contains(obj)``
    ``operator.isSequenceType(obj)``    ``isinstance(obj, collections.abc.Sequence)``
    ``operator.isMappingType(obj)``     ``isinstance(obj, collections.abc.Mapping)``

--- a/Lib/lib2to3/fixes/fix_operator.py
+++ b/Lib/lib2to3/fixes/fix_operator.py
@@ -1,6 +1,6 @@
 """Fixer for operator functions.
 
-operator.isCallable(obj)       -> hasattr(obj, '__call__')
+operator.isCallable(obj)       -> callable(obj)
 operator.sequenceIncludes(obj) -> operator.contains(obj)
 operator.isSequenceType(obj)   -> isinstance(obj, collections.abc.Sequence)
 operator.isMappingType(obj)    -> isinstance(obj, collections.abc.Mapping)
@@ -49,11 +49,10 @@ class FixOperator(fixer_base.BaseFix):
     def _sequenceIncludes(self, node, results):
         return self._handle_rename(node, results, "contains")
 
-    @invocation("hasattr(%s, '__call__')")
+    @invocation("callable(%s)")
     def _isCallable(self, node, results):
         obj = results["obj"]
-        args = [obj.clone(), String(", "), String("'__call__'")]
-        return Call(Name("hasattr"), args, prefix=node.prefix)
+        return Call(Name("callable"), [obj.clone()], prefix=node.prefix)
 
     @invocation("operator.mul(%s)")
     def _repeat(self, node, results):

--- a/Lib/lib2to3/tests/test_fixers.py
+++ b/Lib/lib2to3/tests/test_fixers.py
@@ -4409,7 +4409,7 @@ class Test_operator(FixerTestCase):
 
     def test_operator_isCallable(self):
         b = "operator.isCallable(x)"
-        a = "hasattr(x, '__call__')"
+        a = "callable(x)"
         self.check(b, a)
 
     def test_operator_sequenceIncludes(self):
@@ -4468,7 +4468,7 @@ class Test_operator(FixerTestCase):
 
     def test_bare_isCallable(self):
         s = "isCallable(x)"
-        t = "You should use 'hasattr(x, '__call__')' here."
+        t = "You should use 'callable(x)' here."
         self.warns_unchanged(s, t)
 
     def test_bare_sequenceIncludes(self):

--- a/Misc/NEWS.d/next/Library/2017-11-16-20-09-45.bpo-32046.9sGDtw.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-16-20-09-45.bpo-32046.9sGDtw.rst
@@ -1,0 +1,2 @@
+Updates 2to3 to convert from operator.isCallable(obj) to callable(obj). 
+Patch by Dong-hee Na.


### PR DESCRIPTION



<!-- issue-number: bpo-32046 -->
https://bugs.python.org/issue32046
<!-- /issue-number -->
