### PR TITLE
Update atexit.rst

### DIFF
--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -21,7 +21,7 @@ program is killed by a signal not handled by Python, when a Python fatal
 internal error is detected, or when :func:`os._exit` is called.
 
 
-.. function:: register(func, *args, **kargs)
+.. function:: register(func, *args, **kwargs)
 
    Register *func* as a function to be executed at termination.  Any optional
    arguments that are to be passed to *func* must be passed as arguments to


### PR DESCRIPTION
Tiny typo: `kargs` -> `kwargs`