### PR TITLE
bpo-32050: Deprecate -x option

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -388,8 +388,7 @@ Miscellaneous options
    Skip the first line of the source, allowing use of non-Unix forms of
    ``#!cmd``.  This is intended for a DOS specific hack only.
 
-   .. note:: The line numbers in error messages will be off by one.
-
+   .. deprecated:: 3.7
 
 .. cmdoption:: -X
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-16-17-28-01.bpo-32050.hGcHYm.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-16-17-28-01.bpo-32050.hGcHYm.rst
@@ -1,0 +1,2 @@
+Deprecate the command line -x option. Using the option now emits a
+DeprecationWarning warning.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1491,6 +1491,16 @@ pymain_run_python(_PyMain *pymain)
     pymain_header(pymain);
     pymain_import_readline(pymain);
 
+    if (cmdline->skip_first_line) {
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                         "The command line -x option was deprecated "
+                         "in Python 3.7", 1)) {
+            PyErr_Print();
+            pymain->status = 1;
+            return;
+        }
+    }
+
     if (cmdline->filename != NULL) {
         pymain->main_importer_path = pymain_get_importer(cmdline->filename);
     }


### PR DESCRIPTION
* Using the -x option now emits a DeprecationWarning.
* Deprecate the -x option in the documentation.
* Write tests for -x and for -x deprecation

Fix also the documentation: the line number in correct when using -x:
pymain_open_filename() uses ungetc() to not skip the first newline
character.

<!-- issue-number: bpo-32050 -->
https://bugs.python.org/issue32050
<!-- /issue-number -->
