### PR TITLE
Docs: Update opcode for var-positional arguments

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1077,7 +1077,7 @@ All of the following opcodes use their arguments.
    Pops all function arguments, and the function itself off the stack, and
    pushes the return value. Note that this opcode pops at most three items
    from the stack. Var-positional and var-keyword arguments are packed
-   by :opcode:`BUILD_MAP_UNPACK_WITH_CALL` and
+   by :opcode:`BUILD_TUPLE_UNPACK_WITH_CALL` and
    :opcode:`BUILD_MAP_UNPACK_WITH_CALL`.
 
    .. versionadded:: 3.6


### PR DESCRIPTION
`BUILD_MAP_UNPACK_WITH_CALL` was duplicated for both var-positional and var-keyword arguments. The former was updated as `BUILD_TUPLE_UNPACK_WITH_CALL`.
