### PR TITLE
[3.6] Add check for channels of wav file in Lib/wave.py

### DIFF
--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -259,6 +259,8 @@ class Wave_read:
             self._sampwidth = (sampwidth + 7) // 8
         else:
             raise Error('unknown format: %r' % (wFormatTag,))
+        if self._channels == 0:
+            raise ValueError("The audio file in wav format should have at least one channel!")
         self._framesize = self._nchannels * self._sampwidth
         self._comptype = 'NONE'
         self._compname = 'not compressed'


### PR DESCRIPTION
I found a bug in wave.py because there is no check for self._channel in fmt reading function.
When I try to open a wav file which channel is zero, it  will crash bacause of divided by zero in initfp function.