### PR TITLE
bpo-29185: Fix `test_distutils` failures on Android

### DIFF
--- a/Lib/distutils/tests/test_archive_util.py
+++ b/Lib/distutils/tests/test_archive_util.py
@@ -162,7 +162,7 @@ class ArchiveUtilTestCase(support.TempdirManager,
         # now create another tarball using `tar`
         tarball2 = os.path.join(tmpdir, 'archive2.tar.gz')
         tar_cmd = ['tar', '-cf', 'archive2.tar', 'dist']
-        gzip_cmd = ['gzip', '-f9', 'archive2.tar']
+        gzip_cmd = ['gzip', '-f', '-9', 'archive2.tar']
         old_dir = os.getcwd()
         os.chdir(tmpdir)
         try:

--- a/Lib/distutils/tests/test_file_util.py
+++ b/Lib/distutils/tests/test_file_util.py
@@ -8,7 +8,7 @@ from distutils.file_util import move_file, copy_file
 from distutils import log
 from distutils.tests import support
 from distutils.errors import DistutilsFileError
-from test.support import run_unittest
+from test.support import run_unittest, unlink
 
 class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
 
@@ -80,6 +80,14 @@ class FileUtilTestCase(support.TempdirManager, unittest.TestCase):
     def test_copy_file_hard_link(self):
         with open(self.source, 'w') as f:
             f.write('some content')
+        # Check first that copy_file() will not fall back on copying the file
+        # instead of creating the hard link.
+        try:
+            os.link(self.source, self.target)
+        except OSError as e:
+            self.skipTest('os.link: %s' % e)
+        else:
+            unlink(self.target)
         st = os.stat(self.source)
         copy_file(self.source, self.target, link='hard')
         st2 = os.stat(self.source)


### PR DESCRIPTION
* Run gzip with separate command line options (Android understands
  '-f9' as the name of a file).
* Creation of a hard link is controled by SELinux on Android.



<!-- issue-number: bpo-29185 -->
https://bugs.python.org/issue29185
<!-- /issue-number -->
