### PR TITLE
bpo-34400: Fix undefined behavior in parsetok()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-14-03-52-43.bpo-34400.AJD0bz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-14-03-52-43.bpo-34400.AJD0bz.rst
@@ -1,0 +1,1 @@
+Fix undefined behavior in parsetok.c.  Patch by Zackery Spytz.

--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -225,7 +225,7 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
         }
         else
             started = 1;
-        len = a != NULL && b != NULL ? b - a : 0;
+        len = (a != NULL && b != NULL) ? b - a : 0;
         str = (char *) PyObject_MALLOC(len + 1);
         if (str == NULL) {
             err_ret->error = E_NOMEM;

--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -225,7 +225,7 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
         }
         else
             started = 1;
-        len = b - a; /* XXX this may compute NULL - NULL */
+        len = a != NULL && b != NULL ? b - a : 0;
         str = (char *) PyObject_MALLOC(len + 1);
         if (str == NULL) {
             err_ret->error = E_NOMEM;


### PR DESCRIPTION
Null pointers cannot be used in pointer arithmetic.

<!-- issue-number: [bpo-34400](https://www.bugs.python.org/issue34400) -->
https://bugs.python.org/issue34400
<!-- /issue-number -->
