### PR TITLE
bpo-32031: Fix pydoc `test_mixed_case_module_names_are_lower_cased`

### DIFF
--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -357,7 +357,7 @@ def get_pydoc_html(module):
 def get_pydoc_link(module):
     "Returns a documentation web link of a module"
     dirname = os.path.dirname
-    basedir = dirname(dirname(os.path.realpath(__file__)))
+    basedir = dirname(dirname(__file__))
     doc = pydoc.TextDoc()
     loc = doc.getdocloc(module, basedir=basedir)
     return loc


### PR DESCRIPTION
When there is a symlink in the directory path of the standard library.



<!-- issue-number: bpo-32031 -->
https://bugs.python.org/issue32031
<!-- /issue-number -->
