### PR TITLE
[2.7] Fix typo in atexit documentation. (GH-4419)

### DIFF
--- a/Doc/library/atexit.rst
+++ b/Doc/library/atexit.rst
@@ -37,7 +37,7 @@ simplest way to convert code that sets ``sys.exitfunc`` is to import
 :mod:`atexit` and register the function that had been bound to ``sys.exitfunc``.
 
 
-.. function:: register(func[, *args[, **kargs]])
+.. function:: register(func[, *args[, **kwargs]])
 
    Register *func* as a function to be executed at termination.  Any optional
    arguments that are to be passed to *func* must be passed as arguments to


### PR DESCRIPTION
`kargs` -> `kwargs`
(cherry picked from commit d505a29)

--me, basically mimicking @miss-islington

CC @Mariatta 