### PR TITLE
Fix BaseServer.finish_request arguments in docs

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -289,7 +289,7 @@ Server Objects
    .. XXX should the default implementations of these be documented, or should
       it be assumed that the user will look at socketserver.py?
 
-   .. method:: finish_request()
+   .. method:: finish_request(request, client_address)
 
       Actually processes the request by instantiating :attr:`RequestHandlerClass` and
       calling its :meth:`~BaseRequestHandler.handle` method.


### PR DESCRIPTION
`socketserver.BaseServer.finish_request` has two arguments `(request, client_address)`, but they have been omitted in the document.

Source: https://github.com/python/cpython/blob/master/Lib/socketserver.py#L355
Documents: https://docs.python.org/3/library/socketserver.html#socketserver.BaseServer.finish_request
