### PR TITLE
bpo-32116: Add csv2list() and list2csv() to csv module

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -447,3 +447,19 @@ class Sniffer:
                     hasHeader -= 1
 
         return hasHeader > 0
+
+def csv2list(file_name):
+    # import csv file to a list
+    list_name=[] 
+    with open(file_name) as csvfile:
+        readerfile = reader(csvfile)
+        for row in readerfile:
+            list_name.append(row)
+    return list_name
+
+def list2csv(list_name,file_name):
+    #write list to csv
+    with open(file_name, 'w', newline='') as csvfile:
+        writerfile = csv.writer(csvfile)
+        writerfile.writerows(list_name)
+    #it's a procedure, nothing returned


### PR DESCRIPTION
Added two subroutines.  One function to read a csv file to a list (csv2list) and another procedure to write list to a csv file.

<!-- issue-number: bpo-32116 -->
https://bugs.python.org/issue32116
<!-- /issue-number -->
