### PR TITLE
bpo-32059: detect_modules() in setup.py now also searches the sysroot…

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-11-18-11-19-28.bpo-32059.a0Hxgp.rst
+++ b/Misc/NEWS.d/next/Build/2017-11-18-11-19-28.bpo-32059.a0Hxgp.rst
@@ -1,0 +1,2 @@
+``detect_modules()`` in ``setup.py`` now also searches the sysroot paths
+when cross-compiling.

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ import importlib._bootstrap
 import importlib.util
 import sysconfig
 
-import distutils
 from distutils import log
 from distutils.errors import *
 from distutils.core import Extension, setup
@@ -72,10 +71,7 @@ def sysroot_paths(make_vars, subdirs):
 
     dirs = []
     for var_name in make_vars:
-        # When cross-compiling, the variables from the sysconfig module are
-        # those of the native python process. We need those of the current
-        # build instead and use distutils.sysconfig.
-        var = distutils.sysconfig.get_config_var(var_name)
+        var = sysconfig.get_config_var(var_name)
         if var is not None:
             m = re.search(r'--sysroot=([^"]\S*|"[^"]+")', var)
             if m is not None:
@@ -599,9 +595,7 @@ class PyBuildExt(build_ext):
         else:
             # Add the sysroot paths. 'sysroot' is a compiler option used to
             # set the logical path of the standard system headers and
-            # libraries. The 'CFLAGS', 'LDFLAGS' and 'CPPFLAGS' variables are
-            # the 'PY_CFLAGS', 'PY_LDFLAGS' and 'PY_CPPFLAGS' of the Makefile
-            # when they are obtained from distutils.sysconfig.
+            # libraries.
             lib_dirs = (self.compiler.library_dirs +
                         sysroot_paths(('LDFLAGS', 'CC'), system_lib_dirs))
             inc_dirs = (self.compiler.include_dirs +


### PR DESCRIPTION
… paths when cross-compiling



<!-- issue-number: bpo-32059 -->
https://bugs.python.org/issue32059
<!-- /issue-number -->
