### PR TITLE
bpo-32067: Deprecate non-escaped '{' in RE if not a part of recognized constructions.

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -575,6 +575,12 @@ Deprecated
 
 - The :mod:`macpath` is now deprecated and will be removed in Python 3.8.
 
+- Using non-escaped opening brace ``{`` in a :mod:`regular expression <re>`
+  outside of a character class and not as a part of constructions ``{m}``,
+  ``{m,n}``, ``{m,}`` and ``{,n}`` where *m* and *n* are non-negative
+  decimal numbers will cause emitting a :exc:`PendingDeprecationWarning`.
+  (Contributed by Serhiy Storchaka in :issue:`32067`.)
+
 
 Changes in the C API
 --------------------

--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -277,7 +277,7 @@ def parse_config_h(fp, g=None):
 # like old-style Setup files).
 _variable_rx = re.compile(r"([a-zA-Z][a-zA-Z0-9_]+)\s*=\s*(.*)")
 _findvar1_rx = re.compile(r"\$\(([A-Za-z][A-Za-z0-9_]*)\)")
-_findvar2_rx = re.compile(r"\${([A-Za-z][A-Za-z0-9_]*)}")
+_findvar2_rx = re.compile(r"\$\{([A-Za-z][A-Za-z0-9_]*)}")
 
 def parse_makefile(fn, g=None):
     """Parse a Makefile-style file.

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -109,7 +109,7 @@ InternalDate = re.compile(br'.*INTERNALDATE "'
         br' (?P<zonen>[-+])(?P<zoneh>[0-9][0-9])(?P<zonem>[0-9][0-9])'
         br'"')
 # Literal is no longer used; kept for backward compatibility.
-Literal = re.compile(br'.*{(?P<size>\d+)}$', re.ASCII)
+Literal = re.compile(br'.*\{(?P<size>\d+)}$', re.ASCII)
 MapCRLF = re.compile(br'\r\n|\r|\n')
 # We no longer exclude the ']' character from the data portion of the response
 # code, even though it violates the RFC.  Popular IMAP servers such as Gmail
@@ -125,7 +125,7 @@ Untagged_response = re.compile(br'\* (?P<type>[A-Z-]+)( (?P<data>.*))?')
 Untagged_status = re.compile(
     br'\* (?P<data>\d+) (?P<type>[A-Z-]+)( (?P<data2>.*))?', re.ASCII)
 # We compile these in _mode_xxx.
-_Literal = br'.*{(?P<size>\d+)}$'
+_Literal = br'.*\{(?P<size>\d+)}$'
 _Untagged_status = br'\* (?P<data>\d+) (?P<type>[A-Z-]+)( (?P<data2>.*))?'
 
 

--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -610,10 +610,6 @@ def _parse(source, state, verbose, nested, first=False):
             elif this == "+":
                 min, max = 1, MAXREPEAT
             elif this == "{":
-                if source.next == "}":
-                    subpatternappend((LITERAL, _ord(this)))
-                    continue
-
                 min, max = 0, MAXREPEAT
                 lo = hi = ""
                 while source.next in DIGITS:
@@ -623,7 +619,13 @@ def _parse(source, state, verbose, nested, first=False):
                         hi += sourceget()
                 else:
                     hi = lo
-                if not sourcematch("}"):
+                if not (lo or hi) or not sourcematch("}"):
+                    import warnings
+                    msg = "missing }" if lo or hi else "missing repetition number"
+                    warnings.warn(
+                        '%s at position %d' % (msg, source.tell()),
+                        PendingDeprecationWarning, stacklevel=nested + 6
+                    )
                     subpatternappend((LITERAL, _ord(this)))
                     source.seek(here)
                     continue

--- a/Lib/string.py
+++ b/Lib/string.py
@@ -57,7 +57,7 @@ class _TemplateMetaclass(type):
     %(delim)s(?:
       (?P<escaped>%(delim)s) |   # Escape sequence of two delimiters
       (?P<named>%(id)s)      |   # delimiter and a Python identifier
-      {(?P<braced>%(bid)s)}  |   # delimiter and a braced identifier
+      \{(?P<braced>%(bid)s)} |   # delimiter and a braced identifier
       (?P<invalid>)              # Other ill-formed delimiter exprs
     )
     """

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -211,7 +211,7 @@ def _parse_makefile(filename, vars=None):
     import re
     _variable_rx = re.compile(r"([a-zA-Z][a-zA-Z0-9_]+)\s*=\s*(.*)")
     _findvar1_rx = re.compile(r"\$\(([A-Za-z][A-Za-z0-9_]*)\)")
-    _findvar2_rx = re.compile(r"\${([A-Za-z][A-Za-z0-9_]*)}")
+    _findvar2_rx = re.compile(r"\$\{([A-Za-z][A-Za-z0-9_]*)}")
 
     if vars is None:
         vars = {}

--- a/Lib/test/test_re.py
+++ b/Lib/test/test_re.py
@@ -621,8 +621,18 @@ class ReTests(unittest.TestCase):
         self.assertTrue(re.match(r"^x{1,4}?$", "xxx"))
         self.assertTrue(re.match(r"^x{3,4}?$", "xxx"))
 
-        self.assertIsNone(re.match(r"^x{}$", "xxx"))
-        self.assertTrue(re.match(r"^x{}$", "x{}"))
+        with self.assertWarns(PendingDeprecationWarning):
+            p = re.compile(r"^x{}$")
+        self.assertIsNone(p.match("xxx"))
+        self.assertTrue(p.match("x{}"))
+        with self.assertWarns(PendingDeprecationWarning):
+            self.assertTrue(re.match(r"^x{a}$", "x{a}"))
+        with self.assertWarns(PendingDeprecationWarning):
+            self.assertTrue(re.match(r"^x{2$", "x{2"))
+        with self.assertWarns(PendingDeprecationWarning):
+            self.assertTrue(re.match(r"^x{2,3$", "x{2,3"))
+        with self.assertWarns(PendingDeprecationWarning):
+            self.assertTrue(re.match(r"^x{,}$", "x{,}"))
 
         self.checkPatternError(r'x{2,1}',
                                'min repeat greater than max repeat', 2)

--- a/Lib/test/test_string.py
+++ b/Lib/test/test_string.py
@@ -317,7 +317,7 @@ class TestTemplate(unittest.TestCase):
             pattern = r"""
             (?P<escaped>@{2})                   |
             @(?P<named>[_a-z][._a-z0-9]*)       |
-            @{(?P<braced>[_a-z][._a-z0-9]*)}    |
+            @\{(?P<braced>[_a-z][._a-z0-9]*)}   |
             (?P<invalid>@)
             """
         m = Mapping()
@@ -333,7 +333,7 @@ class TestTemplate(unittest.TestCase):
             (?P<badname>.*)                     |
             (?P<escaped>@{2})                   |
             @(?P<named>[_a-z][._a-z0-9]*)       |
-            @{(?P<braced>[_a-z][._a-z0-9]*)}    |
+            @\{(?P<braced>[_a-z][._a-z0-9]*)}   |
             (?P<invalid>@)                      |
             """
         s = BadPattern('@bag.foo.who likes to eat a bag of @bag.what')

--- a/Misc/NEWS.d/next/Library/2017-11-18-20-05-11.bpo-32067.v3RRDA.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-18-20-05-11.bpo-32067.v3RRDA.rst
@@ -1,0 +1,5 @@
+In regular expressions the character '{' outside of a character class is
+used for specifying the number of repetition numbers. If the following
+characters are not recognized as repetition numbers it will interpreted as a
+literal '{'. Now literal no-escaped '{' will emit a
+PendingDeprecationWarning.

--- a/Tools/scripts/texi2html.py
+++ b/Tools/scripts/texi2html.py
@@ -1704,7 +1704,7 @@ class HTMLHelp:
     Favorites tabs.
     """
 
-    codeprog = re.compile('@code{(.*?)}')
+    codeprog = re.compile(r'@code\{(.*?)}')
 
     def __init__(self,helpbase,dirname):
         self.helpbase    = helpbase


### PR DESCRIPTION


<!-- issue-number: bpo-32067 -->
https://bugs.python.org/issue32067
<!-- /issue-number -->
