### PR TITLE
bpo-1102: View.Fetch() now returns None when it's exhausted

### DIFF
--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -3,6 +3,7 @@ import pathlib
 import unittest
 from test.support import TESTFN, import_module, unlink
 msilib = import_module('msilib')
+import msilib.schema
 
 
 def initialize_db():

--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -30,6 +30,8 @@ class MsiDatabaseTestCase(unittest.TestCase):
             if record is None:
                 break
             properties.append(record.GetString(1))
+        view.Close()
+        db.Close()
         self.assertEqual(
             properties,
             [
@@ -37,7 +39,6 @@ class MsiDatabaseTestCase(unittest.TestCase):
                 'Manufacturer', 'ProductLanguage',
             ]
         )
-        view.Close()
         self.addCleanup(unlink, db_path)
 
 

--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -9,7 +9,12 @@ import msilib.schema
 def initialize_db():
     path = pathlib.Path(TESTFN) / 'test.msi'
     db = msilib.init_database(
-        path, msilib.schema, 'Python Tests', 'product_code', '1.0', 'PSF',
+        str(path),  # TODO: OpenDatabase() doesn't accept PathLike objects.
+        msilib.schema,
+        'Python Tests',
+        'product_code',
+        '1.0',
+        'PSF',
     )
     return db, path
 

--- a/Misc/NEWS.d/next/Windows/2017-11-19-09-46-27.bpo-1102.NY-g1F.rst
+++ b/Misc/NEWS.d/next/Windows/2017-11-19-09-46-27.bpo-1102.NY-g1F.rst
@@ -1,0 +1,4 @@
+Return ``None`` when ``View.Fetch()`` returns ``ERROR_NO_MORE_ITEMS``
+instead of raising ``MSIError``.
+
+Initial patch by Anthony Tuininga.

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -723,8 +723,12 @@ view_fetch(msiobj *view, PyObject*args)
     int status;
     MSIHANDLE result;
 
-    if ((status = MsiViewFetch(view->h, &result)) != ERROR_SUCCESS)
+    status = MsiViewFetch(view->h, &result);
+    if (status == ERROR_NO_MORE_ITEMS) {
+        Py_RETURN_NONE;
+    } else if (status != ERROR_SUCCESS) {
         return msierror(status);
+    }
 
     return record_new(result);
 }


### PR DESCRIPTION



<!-- issue-number: bpo-1102 -->
https://bugs.python.org/issue1102
<!-- /issue-number -->
