### PR TITLE
Remove outdated .pyo reference from msilib docs

### DIFF
--- a/Doc/library/msilib.rst
+++ b/Doc/library/msilib.rst
@@ -398,7 +398,7 @@ Directory Objects
 
    .. method:: remove_pyc()
 
-      Remove ``.pyc``/``.pyo`` files on uninstall.
+      Remove ``.pyc`` files on uninstall.
 
 
 .. seealso::


### PR DESCRIPTION
Since f299abdafa0f2b6eb7abae274861b19b361c96bc
the remove_pyc() method no longer tries to
remove .pyo files.
