### PR TITLE
bpo-10049: Add a "no-op" (null) context manager to contextlib

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -140,7 +140,7 @@ Functions and classes provided:
 .. function:: nullcontext(thing=None)
 
     Return a context manager that just returns *thing*. It is intended to be used
-    as a standin for an optional context manager, for example::
+    as a stand-in for an optional context manager, for example::
 
         def debug_trace(details):
             if __debug__:

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -137,6 +137,21 @@ Functions and classes provided:
    ``page.close()`` will be called when the :keyword:`with` block is exited.
 
 
+.. function:: nullcontext(thing=None)
+
+    Return a context manager that just returns *thing*. It is intended to be used 
+    as a standin for an optional context manager, for example::
+
+        def debug_trace(details):
+            if __debug__:
+                return TraceContext(details)
+            # Don't do anything special with the context in release mode
+            return nullcontext(details)
+
+        with debug_trace(details) as d:
+            # Suite is traced in debug mode, but runs normally otherwise
+
+
 .. function:: suppress(*exceptions)
 
    Return a context manager that suppresses any of the specified exceptions
@@ -431,24 +446,6 @@ some of the context managers being optional::
 As shown, :class:`ExitStack` also makes it quite easy to use :keyword:`with`
 statements to manage arbitrary resources that don't natively support the
 context management protocol.
-
-
-Simplifying support for single optional context managers
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-In the specific case of a single optional context manager, :class:`ExitStack`
-instances can be used as a "do nothing" context manager, allowing a context
-manager to easily be omitted without affecting the overall structure of
-the source code::
-
-   def debug_trace(details):
-       if __debug__:
-           return TraceContext(details)
-       # Don't do anything special with the context in release mode
-       return ExitStack()
-
-   with debug_trace():
-       # Suite is traced in debug mode, but runs normally otherwise
 
 
 Catching exceptions from ``__enter__`` methods

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -156,7 +156,7 @@ Functions and classes provided:
           with cm as file:
               # Perform processing on the file
 
-   .. versionadded: 3.7
+   .. versionadded:: 3.7
 
 
 .. function:: suppress(*exceptions)

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -139,7 +139,7 @@ Functions and classes provided:
 
 .. function:: nullcontext(thing=None)
 
-    Return a context manager that just returns *thing*. It is intended to be used 
+    Return a context manager that just returns *thing*. It is intended to be used
     as a standin for an optional context manager, for example::
 
         def debug_trace(details):

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -142,14 +142,16 @@ Functions and classes provided:
     Return a context manager that just returns *thing*. It is intended to be used
     as a stand-in for an optional context manager, for example::
 
-        def debug_trace(details):
-            if __debug__:
-                return TraceContext(details)
-            # Don't do anything special with the context in release mode
-            return nullcontext(details)
+        def process_file(file_or_path):
+            if isinstance(file_or_path, str):
+                # If string, open file
+                cm = open(file_or_path)
+            else:
+                # Caller is responsible for closing file
+                cm = nullcontext(file_or_path)
 
-        with debug_trace(details) as d:
-            # Suite is traced in debug mode, but runs normally otherwise
+            with cm as file:
+                # Perform processing on the file
 
 
 .. function:: suppress(*exceptions)

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -145,16 +145,16 @@ Functions and classes provided:
    otherwise does nothing. It is intended to be used as a stand-in for an
    optional context manager, for example::
 
-       def process_file(file_or_path):
-           if isinstance(file_or_path, str):
-               # If string, open file
-               cm = open(file_or_path)
-           else:
-               # Caller is responsible for closing file
-               cm = nullcontext(file_or_path)
+      def process_file(file_or_path):
+          if isinstance(file_or_path, str):
+              # If string, open file
+              cm = open(file_or_path)
+          else:
+              # Caller is responsible for closing file
+              cm = nullcontext(file_or_path)
 
-           with cm as file:
-               # Perform processing on the file
+          with cm as file:
+              # Perform processing on the file
 
    .. versionadded: 3.7
 

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -137,10 +137,13 @@ Functions and classes provided:
    ``page.close()`` will be called when the :keyword:`with` block is exited.
 
 
-.. function:: nullcontext(thing=None)
+.. _simplifying-support-for-single-optional-context-managers:
 
-    Return a context manager that just returns *thing*. It is intended to be used
-    as a stand-in for an optional context manager, for example::
+.. function:: nullcontext(enter_result=None)
+
+    Return a context manager that returns enter_result from ``__enter__``, but
+    otherwise does nothing. It is intended to be used as a stand-in for an
+    optional context manager, for example::
 
         def process_file(file_or_path):
             if isinstance(file_or_path, str):
@@ -152,6 +155,8 @@ Functions and classes provided:
 
             with cm as file:
                 # Perform processing on the file
+
+    .. versionadded: 3.7
 
 
 .. function:: suppress(*exceptions)

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -141,22 +141,22 @@ Functions and classes provided:
 
 .. function:: nullcontext(enter_result=None)
 
-    Return a context manager that returns enter_result from ``__enter__``, but
-    otherwise does nothing. It is intended to be used as a stand-in for an
-    optional context manager, for example::
+   Return a context manager that returns enter_result from ``__enter__``, but
+   otherwise does nothing. It is intended to be used as a stand-in for an
+   optional context manager, for example::
 
-        def process_file(file_or_path):
-            if isinstance(file_or_path, str):
-                # If string, open file
-                cm = open(file_or_path)
-            else:
-                # Caller is responsible for closing file
-                cm = nullcontext(file_or_path)
+       def process_file(file_or_path):
+           if isinstance(file_or_path, str):
+               # If string, open file
+               cm = open(file_or_path)
+           else:
+               # Caller is responsible for closing file
+               cm = nullcontext(file_or_path)
 
-            with cm as file:
-                # Perform processing on the file
+           with cm as file:
+               # Perform processing on the file
 
-    .. versionadded: 3.7
+   .. versionadded: 3.7
 
 
 .. function:: suppress(*exceptions)

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -475,7 +475,7 @@ class nullcontext(AbstractContextManager):
     """Context manager that does no additional processing.
 
     Used as a standin for a normal context manager, when a particular block of code is only sometimes used with a normal context manager:
-    
+
     cm = optional_cm if condition else nullcontext()
     with cm:
         # Perform operation, using optional_cm if condition is True
@@ -483,7 +483,7 @@ class nullcontext(AbstractContextManager):
 
     def __init__(self, thing=None):
         self.thing = thing
-    
+
     def __enter__(self):
         return self.thing
 

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -482,11 +482,11 @@ class nullcontext(AbstractContextManager):
         # Perform operation, using optional_cm if condition is True
     """
 
-    def __init__(self, thing=None):
-        self.thing = thing
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
 
     def __enter__(self):
-        return self.thing
+        return self.enter_result
 
     def __exit__(self, *excinfo):
         pass

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -474,7 +474,7 @@ class ExitStack(AbstractContextManager):
 class nullcontext(AbstractContextManager):
     """Context manager that does no additional processing.
 
-    Used as a stand-in for a normal context manager, when a particular 
+    Used as a stand-in for a normal context manager, when a particular
     block of code is only sometimes used with a normal context manager:
 
     cm = optional_cm if condition else nullcontext()

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -474,7 +474,8 @@ class ExitStack(AbstractContextManager):
 class nullcontext(AbstractContextManager):
     """Context manager that does no additional processing.
 
-    Used as a standin for a normal context manager, when a particular block of code is only sometimes used with a normal context manager:
+    Used as a stand-in for a normal context manager, when a particular 
+    block of code is only sometimes used with a normal context manager:
 
     cm = optional_cm if condition else nullcontext()
     with cm:

--- a/Lib/contextlib.py
+++ b/Lib/contextlib.py
@@ -5,7 +5,7 @@ import _collections_abc
 from collections import deque
 from functools import wraps
 
-__all__ = ["asynccontextmanager", "contextmanager", "closing",
+__all__ = ["asynccontextmanager", "contextmanager", "closing", "nullcontext",
            "AbstractContextManager", "ContextDecorator", "ExitStack",
            "redirect_stdout", "redirect_stderr", "suppress"]
 
@@ -469,3 +469,23 @@ class ExitStack(AbstractContextManager):
                 exc_details[1].__context__ = fixed_ctx
                 raise
         return received_exc and suppressed_exc
+
+
+class nullcontext(AbstractContextManager):
+    """Context manager that does no additional processing.
+
+    Used as a standin for a normal context manager, when a particular block of code is only sometimes used with a normal context manager:
+    
+    cm = optional_cm if condition else nullcontext()
+    with cm:
+        # Perform operation, using optional_cm if condition is True
+    """
+
+    def __init__(self, thing=None):
+        self.thing = thing
+    
+    def __enter__(self):
+        return self.thing
+
+    def __exit__(self, *excinfo):
+        pass

--- a/Lib/test/test_contextlib.py
+++ b/Lib/test/test_contextlib.py
@@ -252,6 +252,16 @@ class ClosingTestCase(unittest.TestCase):
                 1 / 0
         self.assertEqual(state, [1])
 
+
+class NullcontextTestCase(unittest.TestCase):
+    def test_nullcontext(self):
+        class C:
+            pass
+        c = C()
+        with nullcontext(c) as c_in:
+            self.assertIs(c_in, c)
+
+
 class FileContextTestCase(unittest.TestCase):
 
     def testWithOpen(self):

--- a/Misc/NEWS.d/next/Library/2017-11-19-18-42-31.bpo-10049.U91c0A.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-19-18-42-31.bpo-10049.U91c0A.rst
@@ -1,1 +1,0 @@
-Added nullcontext no-op context manager to contextlib

--- a/Misc/NEWS.d/next/Library/2017-11-19-18-42-31.bpo-10049.U91c0A.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-19-18-42-31.bpo-10049.U91c0A.rst
@@ -1,0 +1,1 @@
+Added nullcontext no-op context manager to contextlib

--- a/Misc/NEWS.d/next/Library/2017-11-22-17-21-01.bpo-10049.ttsBqb.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-22-17-21-01.bpo-10049.ttsBqb.rst
@@ -1,0 +1,3 @@
+Added *nullcontext* no-op context manager to contextlib. This provides a
+simpler and faster alternative to ExitStack() when handling optional context
+managers.


### PR DESCRIPTION
bpo-10049: Add a "no-op" (null) context manager to contextlib
Removed section in docs using ExitStack() for no-op context manager

<!-- issue-number: bpo-10049 -->
https://bugs.python.org/issue10049
<!-- /issue-number -->
