### PR TITLE
bpo-32088: Display Deprecation in debug mode

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -369,7 +369,9 @@ class EnsurePipTest(BaseTest):
                     self.fail(msg.format(exc, details))
         # Ensure pip is available in the virtual environment
         envpy = os.path.join(os.path.realpath(self.env_dir), self.bindir, self.exe)
-        cmd = [envpy, '-Im', 'pip', '--version']
+        # Ignore DeprecationWarning since pip code is not part of Python
+        cmd = [envpy, '-W', 'ignore::DeprecationWarning', '-I',
+               '-m', 'pip', '--version']
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                   stderr=subprocess.PIPE)
         out, err = p.communicate()
@@ -386,7 +388,8 @@ class EnsurePipTest(BaseTest):
         # http://bugs.python.org/issue19728
         # Check the private uninstall command provided for the Windows
         # installers works (at least in a virtual environment)
-        cmd = [envpy, '-Im', 'ensurepip._uninstall']
+        cmd = [envpy, '-W', 'ignore::DeprecationWarning', '-I',
+               '-m', 'ensurepip._uninstall']
         with EnvironmentVarGuard() as envvars:
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
                                       stderr=subprocess.PIPE)

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -508,10 +508,13 @@ except ImportError:
 # Module initialization
 _processoptions(sys.warnoptions)
 if not _warnings_defaults:
-    silence = [ImportWarning, PendingDeprecationWarning]
-    silence.append(DeprecationWarning)
-    for cls in silence:
-        simplefilter("ignore", category=cls)
+    py_debug = hasattr(sys, 'gettotalrefcount')
+    if not py_debug:
+        silence = [ImportWarning, PendingDeprecationWarning]
+        silence.append(DeprecationWarning)
+        for cls in silence:
+            simplefilter("ignore", category=cls)
+
     bytes_warning = sys.flags.bytes_warning
     if bytes_warning > 1:
         bytes_action = "error"
@@ -520,8 +523,9 @@ if not _warnings_defaults:
     else:
         bytes_action = "ignore"
     simplefilter(bytes_action, category=BytesWarning, append=1)
+
     # resource usage warnings are enabled by default in pydebug mode
-    if hasattr(sys, 'gettotalrefcount'):
+    if py_debug:
         resource_action = "always"
     else:
         resource_action = "ignore"

--- a/Misc/NEWS.d/next/Library/2017-11-20-15-28-31.bpo-32088.mV-4Nu.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-20-15-28-31.bpo-32088.mV-4Nu.rst
@@ -1,0 +1,3 @@
+warnings:  When Python is build is debug mode (``Py_DEBUG``),
+:exc:`DeprecationWarning`, :exc:`PendingDeprecationWarning` and
+:exc:`ImportWarning` warnings are now displayed by default.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1196,7 +1196,11 @@ create_filter(PyObject *category, const char *action)
 static PyObject *
 init_filters(void)
 {
+#ifndef Py_DEBUG
     PyObject *filters = PyList_New(5);
+#else
+    PyObject *filters = PyList_New(2);
+#endif
     unsigned int pos = 0;  /* Post-incremented in each use. */
     unsigned int x;
     const char *bytes_action, *resource_action;
@@ -1204,12 +1208,15 @@ init_filters(void)
     if (filters == NULL)
         return NULL;
 
+#ifndef Py_DEBUG
     PyList_SET_ITEM(filters, pos++,
                     create_filter(PyExc_DeprecationWarning, "ignore"));
     PyList_SET_ITEM(filters, pos++,
                     create_filter(PyExc_PendingDeprecationWarning, "ignore"));
     PyList_SET_ITEM(filters, pos++,
                     create_filter(PyExc_ImportWarning, "ignore"));
+#endif
+
     if (Py_BytesWarningFlag > 1)
         bytes_action = "error";
     else if (Py_BytesWarningFlag)


### PR DESCRIPTION
When Python is build is debug mode (Py_DEBUG), DeprecationWarning,
PendingDeprecationWarning and ImportWarning warnings are now
displayed by default.

test_venv: run "-m pip" and "-m ensurepip._uninstall" with -W
ignore::DeprecationWarning since pip code is not part of Python.

<!-- issue-number: bpo-32088 -->
https://bugs.python.org/issue32088
<!-- /issue-number -->
