### PR TITLE
bpo-32050: Fix -x option documentation

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -388,8 +388,6 @@ Miscellaneous options
    Skip the first line of the source, allowing use of non-Unix forms of
    ``#!cmd``.  This is intended for a DOS specific hack only.
 
-   .. note:: The line numbers in error messages will be off by one.
-
 
 .. cmdoption:: -X
 


### PR DESCRIPTION
The line number in correct when using the -x option: Py_Main() uses
ungetc() to not skip the first newline character.

<!-- issue-number: bpo-32050 -->
https://bugs.python.org/issue32050
<!-- /issue-number -->
