### PR TITLE
bpo-32105: add asyncio.BaseEventLoop.connect_accepted_socket versionadded to documentation.

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -501,6 +501,9 @@ Creating listening connections
    This method is a :ref:`coroutine <coroutine>`.  When completed, the
    coroutine returns a ``(transport, protocol)`` pair.
 
+   .. versionadded:: 3.5.3
+
+
 Watch file descriptors
 ----------------------
 

--- a/Misc/NEWS.d/next/Documentation/2017-11-21-10-54-16.bpo-32105.91mhWm.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-11-21-10-54-16.bpo-32105.91mhWm.rst
@@ -1,0 +1,1 @@
+Added asyncio.BaseEventLoop.connect_accepted_socket versionaddded marker.


### PR DESCRIPTION


<!-- issue-number: bpo-32105 -->
https://bugs.python.org/issue32105
<!-- /issue-number -->
