### PR TITLE
bpo-32109: Separated square brackets will generate a tuple instead of a list. (GH-4498)

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1136,7 +1136,6 @@ application).
    Lists may be constructed in several ways:
 
    * Using a pair of square brackets to denote the empty list: ``[]``
-   * Using square brackets, separating items with commas: ``[a]``, ``[a, b, c]``
    * Using a list comprehension: ``[x for x in iterable]``
    * Using the type constructor: ``list()`` or ``list(iterable)``
 


### PR DESCRIPTION
<!-- issue-number: bpo-32109 -->
https://bugs.python.org/issue32109
<!-- /issue-number -->
