### PR TITLE
bpo-32055: Raise SyntaxWarning for chained `in` and `not in`.

### DIFF
--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -612,7 +612,7 @@ class SyntaxTestCase(unittest.TestCase):
                 self.fail("SyntaxError is not a %s" % subclass.__name__)
             mo = re.search(errtext, str(err))
             if mo is None:
-                self.fail("SyntaxError did not contain '%r'" % (errtext,))
+                self.fail("SyntaxError did not contain %r" % (errtext,))
             self.assertEqual(err.filename, filename)
             if lineno is not None:
                 self.assertEqual(err.lineno, lineno)
@@ -620,6 +620,21 @@ class SyntaxTestCase(unittest.TestCase):
                 self.assertEqual(err.offset, offset)
         else:
             self.fail("compile() did not raise SyntaxError")
+
+    def _check_warning(self, code, warntext,
+                       filename="<testcase>", mode="exec"):
+        """Check that compiling code emits SyntaxWarning with warntext.
+
+        errtest is a regular expression that must be present in the
+        test of the exception raised.  If subclass is specified it
+        is the expected subclass of SyntaxError (e.g. IndentationError).
+        """
+        with self.assertWarns(SyntaxWarning) as cm:
+            compile(code, filename, mode)
+        warn = cm.warning
+        mo = re.search(warntext, str(warn))
+        if mo is None:
+            self.fail("SyntaxWarning did not contain %r" % (warntext,))
 
     def test_assign_call(self):
         self._check_error("f() = 1", "assign")
@@ -676,6 +691,13 @@ class SyntaxTestCase(unittest.TestCase):
         self._check_error("int(**{base: 10}, *['2'])",
                           "iterable argument unpacking follows "
                           "keyword argument unpacking")
+
+    def test_chained_in(self):
+        self._check_warning("a in b == c",
+                            "chained `in' is ambiguous")
+        self._check_warning("a not in b == c",
+                            "chained `not in' is ambiguous")
+
 
 def test_main():
     support.run_unittest(SyntaxTestCase)

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -2631,6 +2631,23 @@ ast_for_expr(struct compiling *c, const node *n)
                     if (!newoperator) {
                         return NULL;
                     }
+                    if ((newoperator == In || newoperator == NotIn) &&
+                        NCH(n) > 3)
+                    {
+                        PyObject *msg = PyUnicode_FromString(newoperator == In
+                                ? "chained `in' is ambiguous"
+                                : "chained `not in' is ambiguous");
+                        if (msg == NULL)
+                            return NULL;
+                        if (PyErr_WarnExplicitObject(PyExc_SyntaxWarning,
+                                    msg, c->c_filename, CHILD(n, i)->n_lineno,
+                                    NULL, NULL) == -1)
+                        {
+                            Py_DECREF(msg);
+                            return NULL;
+                        }
+                        Py_DECREF(msg);
+                    }
 
                     expression = ast_for_expr(c, CHILD(n, i + 1));
                     if (!expression) {


### PR DESCRIPTION


<!-- issue-number: bpo-32055 -->
https://bugs.python.org/issue32055
<!-- /issue-number -->
