### PR TITLE
bpo-34322: modification to Lib/distutils/ccompiler.py to simplify handling of compile arguments by subclasses

### DIFF
--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -364,11 +364,11 @@ class CCompiler:
         cc_args = pp_opts + ['-c']
         if debug:
             cc_args[:0] = ['-g']
-            cc_args += self.cc_args_debug
+            cc_args.expand(self.cc_args_debug)
         if before:
             cc_args[:0] = before
 
-        cc_args += self.cc_args
+        cc_args.expand(self.cc_args)
 
         return cc_args
 

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -118,6 +118,15 @@ class CCompiler:
         for key in self.executables.keys():
             self.set_executable(key, self.executables[key])
 
+
+        #adding these variables to bring it closer to how distutils.MSVCCompiler
+        #handles compiler arguments, to make it easier for users to customize
+        #their compile arguments, without breaking tests (some tests need to remove
+        #certain flags while keeping the others)
+
+        self.cc_args = []
+        self.cc_args_debug = []
+
     def set_executables(self, **kwargs):
         """Define the executables (and options for them) that will be run
         to perform the various stages of compilation.  The exact set of
@@ -355,8 +364,12 @@ class CCompiler:
         cc_args = pp_opts + ['-c']
         if debug:
             cc_args[:0] = ['-g']
+            cc_args += self.cc_args_debug
         if before:
             cc_args[:0] = before
+
+        cc_args += self.cc_args
+
         return cc_args
 
     def _fix_compile_args(self, output_dir, macros, include_dirs):

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -364,11 +364,11 @@ class CCompiler:
         cc_args = pp_opts + ['-c']
         if debug:
             cc_args[:0] = ['-g']
-            cc_args.expand(self.cc_args_debug)
+            cc_args.extend(self.cc_args_debug)
         if before:
             cc_args[:0] = before
 
-        cc_args.expand(self.cc_args)
+        cc_args.extend(self.cc_args)
 
         return cc_args
 

--- a/Misc/NEWS.d/next/Library/2018-08-02-10-52-26.bpo-34322.MYCS53.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-02-10-52-26.bpo-34322.MYCS53.rst
@@ -1,0 +1,1 @@
+modify ccompiler in distutils to simplify handling of compiler flags

--- a/Misc/NEWS.d/next/Library/2018-08-02-10-52-26.bpo-34322.MYCS53.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-02-10-52-26.bpo-34322.MYCS53.rst
@@ -1,1 +1,0 @@
-modify ccompiler in distutils to simplify handling of compiler flags


### PR DESCRIPTION
I am also working on fixing some bugs in `numpy`, where certain tests fail because the command line option, which is fine for the build, doesn't get removed for that test, which it breaks.  I noticed that the `MSVCCompiler` class, in that same test, removes the offending option from the argument list. I then realized that `ccompiler` , and by extension `unixccompiler` did not have a convention for handling or storing compile arguments, instead having `_get_cc_args()` to return them on demand only, based on its own input arguments.  This makes it messy for users to set their own default compiler arguments, especially without breaking tests. I modified `_get_cc_args` to add those flags to the values it returns, similarly to how `MSVCCompiler` sets these in its `compile()` method.

<!-- issue-number: [bpo-34322](https://www.bugs.python.org/issue34322) -->
https://bugs.python.org/issue34322
<!-- /issue-number -->
