### PR TITLE
bpo-32114: Updated the documentation for get_event_loop to reflect the policy change

### DIFF
--- a/Doc/library/asyncio-eventloops.rst
+++ b/Doc/library/asyncio-eventloops.rst
@@ -189,10 +189,14 @@ An event loop policy must implement the following interface:
 
 
 The default policy defines context as the current thread, and manages an event
-loop per thread that interacts with :mod:`asyncio`.  If the current thread
-doesn't already have an event loop associated with it, the default policy's
-:meth:`~AbstractEventLoopPolicy.get_event_loop` method creates one when
-called from the main thread, but raises :exc:`RuntimeError` otherwise.
+loop per thread that interacts with :mod:`asyncio`. An exception to this rule
+happens when :meth:`~AbstractEventLoopPolicy.get_event_loop` is called from a
+running future/coroutine, in which case it will return the current loop
+running that future/coroutine.
+If the current thread doesn't already have an event loop associated with it,
+the default policy's :meth:`~AbstractEventLoopPolicy.get_event_loop` method
+creates one when called from the main thread, but raises :exc:`RuntimeError`
+otherwise.
 
 
 Access to the global loop policy

--- a/Doc/library/asyncio-eventloops.rst
+++ b/Doc/library/asyncio-eventloops.rst
@@ -193,6 +193,7 @@ loop per thread that interacts with :mod:`asyncio`. An exception to this rule
 happens when :meth:`~AbstractEventLoopPolicy.get_event_loop` is called from a
 running future/coroutine, in which case it will return the current loop
 running that future/coroutine.
+
 If the current thread doesn't already have an event loop associated with it,
 the default policy's :meth:`~AbstractEventLoopPolicy.get_event_loop` method
 creates one when called from the main thread, but raises :exc:`RuntimeError`


### PR DESCRIPTION


<!-- issue-number: bpo-32114 -->
https://bugs.python.org/issue32114
<!-- /issue-number -->
