### PR TITLE
bpo-32030: Move PYTHONPATH to _PyMainInterpreterConfig

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -94,7 +94,7 @@ PyAPI_FUNC(wchar_t *) Py_GetPrefix(void);
 PyAPI_FUNC(wchar_t *) Py_GetExecPrefix(void);
 PyAPI_FUNC(wchar_t *) Py_GetPath(void);
 #ifdef Py_BUILD_CORE
-PyAPI_FUNC(wchar_t *) _Py_GetPathWithConfig(_PyCoreConfig *config);
+PyAPI_FUNC(wchar_t *) _Py_GetPathWithConfig(_PyMainInterpreterConfig *config);
 #endif
 PyAPI_FUNC(void)      Py_SetPath(const wchar_t *);
 #ifdef MS_WINDOWS

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -30,7 +30,6 @@ typedef struct {
     unsigned long hash_seed;
     int _disable_importlib; /* Needed by freeze_importlib */
     const char *allocator;  /* Memory allocator: _PyMem_SetupAllocators() */
-    wchar_t *module_search_path_env; /* PYTHONPATH environment variable */
     int dev_mode;           /* -X dev */
     int faulthandler;       /* -X faulthandler */
     int tracemalloc;        /* -X tracemalloc=N */
@@ -46,7 +45,6 @@ typedef struct {
      .hash_seed = 0, \
      ._disable_importlib = 0, \
      .allocator = NULL, \
-     .module_search_path_env = NULL, \
      .dev_mode = 0, \
      .faulthandler = 0, \
      .tracemalloc = 0, \
@@ -62,11 +60,13 @@ typedef struct {
  */
 typedef struct {
     int install_signal_handlers;
+    wchar_t *module_search_path_env; /* PYTHONPATH environment variable */
 } _PyMainInterpreterConfig;
 
 #define _PyMainInterpreterConfig_INIT \
     (_PyMainInterpreterConfig){\
-     .install_signal_handlers = -1}
+     .install_signal_handlers = -1, \
+     .module_search_path_env = NULL}
 
 typedef struct _is {
 

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -456,7 +456,7 @@ search_for_exec_prefix(wchar_t *argv0_path, wchar_t *home,
 }
 
 static void
-calculate_path(_PyCoreConfig *core_config)
+calculate_path(_PyMainInterpreterConfig *config)
 {
     extern wchar_t *Py_GetProgramName(void);
 
@@ -706,9 +706,9 @@ calculate_path(_PyCoreConfig *core_config)
     bufsz = 0;
 
     wchar_t *env_path = NULL;
-    if (core_config) {
-        if (core_config->module_search_path_env) {
-            bufsz += wcslen(core_config->module_search_path_env) + 1;
+    if (config) {
+        if (config->module_search_path_env) {
+            bufsz += wcslen(config->module_search_path_env) + 1;
         }
     }
     else {
@@ -752,9 +752,9 @@ calculate_path(_PyCoreConfig *core_config)
 
     /* Run-time value of $PYTHONPATH goes first */
     buf[0] = '\0';
-    if (core_config) {
-        if (core_config->module_search_path_env) {
-            wcscpy(buf, core_config->module_search_path_env);
+    if (config) {
+        if (config->module_search_path_env) {
+            wcscpy(buf, config->module_search_path_env);
             wcscat(buf, delimiter);
         }
     }
@@ -858,10 +858,10 @@ Py_SetPath(const wchar_t *path)
 }
 
 wchar_t *
-_Py_GetPathWithConfig(_PyCoreConfig *core_config)
+_Py_GetPathWithConfig(_PyMainInterpreterConfig *config)
 {
     if (!module_search_path) {
-        calculate_path(core_config);
+        calculate_path(config);
     }
     return module_search_path;
 }

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -624,7 +624,7 @@ error:
 
 
 static void
-calculate_path(_PyCoreConfig *core_config)
+calculate_path(_PyMainInterpreterConfig *config)
 {
     wchar_t argv0_path[MAXPATHLEN+1];
     wchar_t *buf;
@@ -637,8 +637,8 @@ calculate_path(_PyCoreConfig *core_config)
     wchar_t *userpath = NULL;
     wchar_t zip_path[MAXPATHLEN+1];
 
-    if (core_config) {
-        envpath = core_config->module_search_path_env;
+    if (config) {
+        envpath = config->module_search_path_env;
     }
     else if (!Py_IgnoreEnvironmentFlag) {
         envpath = _wgetenv(L"PYTHONPATH");
@@ -899,10 +899,10 @@ Py_SetPath(const wchar_t *path)
 }
 
 wchar_t *
-_Py_GetPathWithConfig(_PyCoreConfig *core_config)
+_Py_GetPathWithConfig(_PyMainInterpreterConfig *config)
 {
     if (!module_search_path) {
-        calculate_path(core_config);
+        calculate_path(config);
     }
     return module_search_path;
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -843,7 +843,7 @@ _Py_InitializeMainInterpreter(const _PyMainInterpreterConfig *config)
     /* GetPath may initialize state that _PySys_EndInit locks
        in, and so has to be called first. */
     /* TODO: Call Py_GetPath() in Py_ReadConfig, rather than here */
-    wchar_t *sys_path = _Py_GetPathWithConfig(&interp->core_config);
+    wchar_t *sys_path = _Py_GetPathWithConfig(&interp->config);
 
     if (interp->core_config._disable_importlib) {
         /* Special mode for freeze_importlib: run with no import system
@@ -1301,7 +1301,7 @@ new_interpreter(PyThreadState **tstate_p)
 
     /* XXX The following is lax in error checking */
 
-    wchar_t *sys_path = _Py_GetPathWithConfig(&interp->core_config);
+    wchar_t *sys_path = _Py_GetPathWithConfig(&interp->config);
 
     PyObject *modules = PyDict_New();
     if (modules == NULL) {


### PR DESCRIPTION
Move _PyCoreConfig.module_search_path_env to _PyMainInterpreterConfig
structure.

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
