### PR TITLE
bpo-32118: Document that, in sequence comparisons, reflexivity means otherwise u…

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1741,7 +1741,7 @@ precedence and have a left-to-right chaining feature as described in the
 .. [#] The Unicode standard distinguishes between :dfn:`code points`
    (e.g. U+0041) and :dfn:`abstract characters` (e.g. "LATIN CAPITAL LETTER A").
    While most abstract characters in Unicode are only represented using one
-   code point, there is a number of abstract characters that can in addition be
+   code point, there are a number of abstract characters that can in addition be
    represented using a sequence of more than one code point.  For example, the
    abstract character "LATIN CAPITAL LETTER C WITH CEDILLA" can be represented
    as a single :dfn:`precomposed character` at code position U+00C7, or as a

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1351,6 +1351,20 @@ built-in types.
     shorter collection is ordered first (for example, ``[1,2] < [1,2,3]`` is
     true).
 
+  - Enforcement of reflexivity also means that otherwise non-orderable
+    singletons are effectively ignored in ordered comparison::
+
+      >>> None is None
+      True
+      >>> None == None
+      True                  <-- None is reflexive, but not orderable:
+      >>> None < None
+      Traceback (most recent call last):
+        File "<stdin>", line 1, in <module>
+      TypeError: unorderable types: NoneType() < NoneType()
+      >>> [None, 1] < [None, 2]
+      True                  <-- lists are ordered despite unorderable elements
+
 * Mappings (instances of :class:`dict`) compare equal if and only if they have
   equal `(key, value)` pairs. Equality comparison of the keys and values
   enforces reflexivity.


### PR DESCRIPTION
…norderable objects are ignored

In sequence comparisons, the enforcement of reflexivity of elements means that only non-identical elements are actually compared. The docs then note, with example, that non-reflexive elements thus always "compare" equal inside the sequence.

This patch adds a second corollary, that non-orderable singletons (e.g. None) will also not break sequence comparison.

Yes, the consequence is logically derivable from the statement "element identity is compared first, and element comparison is performed only for distinct elements", but the first example is given because "For non-reflexive elements, the result is different than for strict element comparison, and may be surprising", which also holds for the example I add here: different from strict element comparison, which may lead to otherwise surprising results (it sure was surprising to me when I expected a list with Nones to fail to compare, hence why I went trawling through the docs). In the manner of the first example, explicit is better than implicit, and (I believe) it will be helpful for readers to have this second consequence demonstrated.

!!! If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

PLEASE: Remove this headline!!!


<!-- issue-number: bpo-32118 -->
https://bugs.python.org/issue32118
<!-- /issue-number -->
