### PR TITLE
[3.6] bpo-1102: View.Fetch() now returns None when it's exhausted (GH-4459)

### DIFF
--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -31,7 +31,6 @@ class MsiDatabaseTestCase(unittest.TestCase):
                 break
             properties.append(record.GetString(1))
         view.Close()
-        db.Close()
         self.assertEqual(
             properties,
             [

--- a/Misc/NEWS.d/next/Windows/2017-11-19-09-46-27.bpo-1102.NY-g1F.rst
+++ b/Misc/NEWS.d/next/Windows/2017-11-19-09-46-27.bpo-1102.NY-g1F.rst
@@ -1,0 +1,4 @@
+Return ``None`` when ``View.Fetch()`` returns ``ERROR_NO_MORE_ITEMS``
+instead of raising ``MSIError``.
+
+Initial patch by Anthony Tuininga.

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -729,8 +729,12 @@ view_fetch(msiobj *view, PyObject*args)
     int status;
     MSIHANDLE result;
 
-    if ((status = MsiViewFetch(view->h, &result)) != ERROR_SUCCESS)
+    status = MsiViewFetch(view->h, &result);
+    if (status == ERROR_NO_MORE_ITEMS) {
+        Py_RETURN_NONE;
+    } else if (status != ERROR_SUCCESS) {
         return msierror(status);
+    }
 
     return record_new(result);
 }


### PR DESCRIPTION


<!-- issue-number: bpo-1102 -->
https://bugs.python.org/issue1102
<!-- /issue-number -->
