### PR TITLE
[2.7] bpo-29512: Fix Lib/test/bisect.py shebang

### DIFF
--- a/Lib/test/bisect.py
+++ b/Lib/test/bisect.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python2
 """
 Command line tool to bisect failing CPython tests.
 


### PR DESCRIPTION
Replace python3 with python2.

<!-- issue-number: bpo-29512 -->
https://bugs.python.org/issue29512
<!-- /issue-number -->
