### PR TITLE
bpo-12382: Make OpenDatabase() raise better exception messages

### DIFF
--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -41,6 +41,16 @@ class MsiDatabaseTestCase(unittest.TestCase):
         )
         self.addCleanup(unlink, db_path)
 
+    def test_database_open_failed(self):
+        with self.assertRaises(msilib.MSIError) as cm:
+            msilib.OpenDatabase('non-existent.msi', msilib.MSIDBOPEN_READONLY)
+        self.assertEqual(str(cm.exception), 'open failed')
+
+    def test_database_create_failed(self):
+        with self.assertRaises(msilib.MSIError) as cm:
+            msilib.OpenDatabase(TESTFN + '.msi', msilib.MSIDBOPEN_CREATE)
+        self.assertEqual(str(cm.exception), 'create failed')
+
 
 class Test_make_id(unittest.TestCase):
     #http://msdn.microsoft.com/en-us/library/aa369212(v=vs.85).aspx

--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -48,8 +48,9 @@ class MsiDatabaseTestCase(unittest.TestCase):
         self.assertEqual(str(cm.exception), 'open failed')
 
     def test_database_create_failed(self):
+        db_path = os.path.join(TESTFN, 'test.msi')
         with self.assertRaises(msilib.MSIError) as cm:
-            msilib.OpenDatabase(os.path.join(TESTFN, 'test.msi'), msilib.MSIDBOPEN_CREATE)
+            msilib.OpenDatabase(db_path, msilib.MSIDBOPEN_CREATE)
         self.assertEqual(str(cm.exception), 'create failed')
 
 

--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -1,4 +1,5 @@
 """ Test suite for the code in msilib """
+import os.path
 import unittest
 from test.support import TESTFN, import_module, unlink
 msilib = import_module('msilib')
@@ -48,7 +49,7 @@ class MsiDatabaseTestCase(unittest.TestCase):
 
     def test_database_create_failed(self):
         with self.assertRaises(msilib.MSIError) as cm:
-            msilib.OpenDatabase(TESTFN + '.msi', msilib.MSIDBOPEN_CREATE)
+            msilib.OpenDatabase(os.path.join(TESTFN, 'test.msi'), msilib.MSIDBOPEN_CREATE)
         self.assertEqual(str(cm.exception), 'create failed')
 
 

--- a/Misc/NEWS.d/next/Library/2017-11-23-21-47-36.bpo-12382.xWT9k0.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-23-21-47-36.bpo-12382.xWT9k0.rst
@@ -1,0 +1,4 @@
+:func:`msilib.OpenDatabase` now raises a better exception message when it
+couldn't open or create a MSI file.
+
+Initial patch by William Tisäter.

--- a/Misc/NEWS.d/next/Library/2017-11-23-21-47-36.bpo-12382.xWT9k0.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-23-21-47-36.bpo-12382.xWT9k0.rst
@@ -1,4 +1,2 @@
 :func:`msilib.OpenDatabase` now raises a better exception message when it
-couldn't open or create an MSI file.
-
-Initial patch by William Tisäter.
+couldn't open or create an MSI file.  Initial patch by William Tisäter.

--- a/Misc/NEWS.d/next/Library/2017-11-23-21-47-36.bpo-12382.xWT9k0.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-23-21-47-36.bpo-12382.xWT9k0.rst
@@ -1,4 +1,4 @@
 :func:`msilib.OpenDatabase` now raises a better exception message when it
-couldn't open or create a MSI file.
+couldn't open or create an MSI file.
 
 Initial patch by William Tisäter.

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -315,6 +315,12 @@ msierror(int status)
         case ERROR_INVALID_PARAMETER:
             PyErr_SetString(MSIError, "invalid parameter");
             return NULL;
+        case ERROR_OPEN_FAILED:
+            PyErr_SetString(MSIError, "open failed");
+            return NULL;
+        case ERROR_CREATE_FAILED:
+            PyErr_SetString(MSIError, "create failed");
+            return NULL;
         default:
             PyErr_Format(MSIError, "unknown error %x", status);
             return NULL;


### PR DESCRIPTION
Previously, 'msilib.OpenDatabase()' function raised a
cryptical exception message when it couldn't open or
create an MSI file. For example:

    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    _msi.MSIError: unknown error 6e


<!-- issue-number: bpo-12382 -->
https://bugs.python.org/issue12382
<!-- /issue-number -->
