### PR TITLE
[3.6] bpo-30456: Clarify example for duplicates in second argument of isinstance (GH-1699)

### DIFF
--- a/Doc/library/2to3.rst
+++ b/Doc/library/2to3.rst
@@ -288,7 +288,8 @@ and off individually.  They are described here in more detail.
 
    Fixes duplicate types in the second argument of :func:`isinstance`.  For
    example, ``isinstance(x, (int, int))`` is converted to ``isinstance(x,
-   (int))``.
+   int)`` and ``isinstance(x, (int, float, int))`` is converted to
+   ``isinstance(x, (int, float))``.
 
 .. 2to3fixer:: itertools_imports
 


### PR DESCRIPTION
(cherry picked from commit 26248ef58dcf49619930ffa2e050ffa687a88601)


<!-- issue-number: bpo-30456 -->
https://bugs.python.org/issue30456
<!-- /issue-number -->
