### PR TITLE
bpo-12239: Make GetProperty() return None for VT_EMPTY

### DIFF
--- a/Lib/test/test_msilib.py
+++ b/Lib/test/test_msilib.py
@@ -53,6 +53,13 @@ class MsiDatabaseTestCase(unittest.TestCase):
             msilib.OpenDatabase(db_path, msilib.MSIDBOPEN_CREATE)
         self.assertEqual(str(cm.exception), 'create failed')
 
+    def test_get_property_vt_empty(self):
+        db, db_path = init_database()
+        summary = db.GetSummaryInformation(0)
+        self.assertIsNone(summary.GetProperty(msilib.PID_SECURITY))
+        db.Close()
+        self.addCleanup(unlink, db_path)
+
 
 class Test_make_id(unittest.TestCase):
     #http://msdn.microsoft.com/en-us/library/aa369212(v=vs.85).aspx

--- a/Misc/NEWS.d/next/Library/2017-11-24-14-07-55.bpo-12239.Nj3A0x.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-24-14-07-55.bpo-12239.Nj3A0x.rst
@@ -1,0 +1,2 @@
+Make :meth:`msilib.SummaryInformation.GetProperty` return ``None`` when the
+value of property is ``VT_EMPTY``.  Initial patch by Mark Mc Mahon.

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -575,6 +575,8 @@ summary_getproperty(msiobj* si, PyObject *args)
             if (sval != sbuf)
                 free(sval);
             return result;
+        case VT_EMPTY:
+            Py_RETURN_NONE;
     }
     PyErr_Format(PyExc_NotImplementedError, "result of type %d", type);
     return NULL;


### PR DESCRIPTION
The previous behavior was to raise an exception

    NotImplementedError: result of type 0

when the value of the property is VT_EMPTY.


<!-- issue-number: bpo-12239 -->
https://bugs.python.org/issue12239
<!-- /issue-number -->
