### PR TITLE
bpo-32030: Add _PyMainInterpreterConfig_ReadEnv()

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -30,7 +30,7 @@ typedef struct {
    Don't abort() the process on such error. */
 #define _Py_INIT_USER_ERR(MSG) \
     (_PyInitError){.prefix = _Py_INIT_GET_FUNC(), .msg = (MSG), .user_err = 1}
-#define _Py_INIT_NO_MEMORY() _Py_INIT_ERR("memory allocation failed")
+#define _Py_INIT_NO_MEMORY() _Py_INIT_USER_ERR("memory allocation failed")
 #define _Py_INIT_FAILED(err) \
     (err.msg != NULL)
 
@@ -42,11 +42,6 @@ PyAPI_FUNC(wchar_t *) Py_GetProgramName(void);
 
 PyAPI_FUNC(void) Py_SetPythonHome(wchar_t *);
 PyAPI_FUNC(wchar_t *) Py_GetPythonHome(void);
-#ifdef Py_BUILD_CORE
-PyAPI_FUNC(_PyInitError) _Py_GetPythonHomeWithConfig(
-    const _PyMainInterpreterConfig *config,
-    wchar_t **home);
-#endif
 
 #ifndef Py_LIMITED_API
 /* Only used by applications that embed the interpreter and need to
@@ -58,7 +53,11 @@ PyAPI_FUNC(int) Py_SetStandardStreamEncoding(const char *encoding,
 /* PEP 432 Multi-phase initialization API (Private while provisional!) */
 PyAPI_FUNC(_PyInitError) _Py_InitializeCore(const _PyCoreConfig *);
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
-PyAPI_FUNC(_PyInitError) _Py_ReadMainInterpreterConfig(_PyMainInterpreterConfig *);
+
+PyAPI_FUNC(_PyInitError) _PyMainInterpreterConfig_Read(_PyMainInterpreterConfig *);
+PyAPI_FUNC(_PyInitError) _PyMainInterpreterConfig_ReadEnv(_PyMainInterpreterConfig *);
+PyAPI_FUNC(void) _PyMainInterpreterConfig_Clear(_PyMainInterpreterConfig *);
+
 PyAPI_FUNC(_PyInitError) _Py_InitializeMainInterpreter(const _PyMainInterpreterConfig *);
 #endif
 

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -105,8 +105,14 @@ PyAPI_FUNC(void *) PyMem_Realloc(void *ptr, size_t new_size);
 PyAPI_FUNC(void) PyMem_Free(void *ptr);
 
 #ifndef Py_LIMITED_API
+/* strdup() using PyMem_RawMalloc() */
 PyAPI_FUNC(char *) _PyMem_RawStrdup(const char *str);
+
+/* strdup() using PyMem_Malloc() */
 PyAPI_FUNC(char *) _PyMem_Strdup(const char *str);
+
+/* wcsdup() using PyMem_RawMalloc() */
+PyAPI_FUNC(wchar_t*) _PyMem_RawWcsdup(const wchar_t *str);
 #endif
 
 /* Macros. */

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -60,16 +60,17 @@ typedef struct {
  */
 typedef struct {
     int install_signal_handlers;
-    wchar_t *module_search_path_env; /* PYTHONPATH environment variable */
-    wchar_t *pythonhome;    /* PYTHONHOME environment variable,
-                               see also Py_SetPythonHome(). */
+    /* PYTHONPATH environment variable */
+    wchar_t *module_search_path_env;
+    /* PYTHONHOME environment variable, see also Py_SetPythonHome(). */
+    wchar_t *home;
 } _PyMainInterpreterConfig;
 
 #define _PyMainInterpreterConfig_INIT \
     (_PyMainInterpreterConfig){\
      .install_signal_handlers = -1, \
      .module_search_path_env = NULL, \
-     .pythonhome = NULL}
+     .home = NULL}
 
 typedef struct _is {
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -455,6 +455,24 @@ PyMem_Free(void *ptr)
 }
 
 
+wchar_t*
+_PyMem_RawWcsdup(const wchar_t *str)
+{
+    size_t len = wcslen(str);
+    if (len > (size_t)PY_SSIZE_T_MAX / sizeof(wchar_t) - 1) {
+        return NULL;
+    }
+
+    size_t size = (len + 1) * sizeof(wchar_t);
+    wchar_t *str2 = PyMem_RawMalloc(size);
+    if (str2 == NULL) {
+        return NULL;
+    }
+
+    memcpy(str2, str, size);
+    return str2;
+}
+
 char *
 _PyMem_RawStrdup(const char *str)
 {

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -1011,7 +1011,7 @@ calculate_path(const _PyMainInterpreterConfig *main_config)
     int use_tmp = (main_config == NULL);
     if (use_tmp) {
         tmp_config = _PyMainInterpreterConfig_INIT;
-        err = _PyMainInterpreterConfig_ReadEnv(&tmp_config);
+        _PyInitError err = _PyMainInterpreterConfig_ReadEnv(&tmp_config);
         if (_Py_INIT_FAILED(err)) {
             goto fatal_error;
         }

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -689,26 +689,12 @@ error:
 }
 
 
-static _PyInitError
+static void
 calculate_init(PyCalculatePath *calculate,
                const _PyMainInterpreterConfig *main_config)
 {
-    _PyInitError err;
-
-    err = _Py_GetPythonHomeWithConfig(main_config, &calculate->home);
-    if (_Py_INIT_FAILED(err)) {
-        return err;
-    }
-
-    if (main_config) {
-        calculate->module_search_path_env = main_config->module_search_path_env;
-    }
-    else if (!Py_IgnoreEnvironmentFlag) {
-        wchar_t *path = _wgetenv(L"PYTHONPATH");
-        if (path && *path != '\0') {
-            calculate->module_search_path_env = path;
-        }
-    }
+    calculate->home = main_config->home;
+    calculate->module_search_path_env = main_config->module_search_path_env;
 
     calculate->path_env = _wgetenv(L"PATH");
 
@@ -717,8 +703,6 @@ calculate_init(PyCalculatePath *calculate,
         prog = L"python";
     }
     calculate->prog = prog;
-
-    return _Py_INIT_OK();
 }
 
 
@@ -1023,11 +1007,18 @@ calculate_path(const _PyMainInterpreterConfig *main_config)
     PyCalculatePath calculate;
     memset(&calculate, 0, sizeof(calculate));
 
-    _PyInitError err = calculate_init(&calculate, main_config);
-    if (_Py_INIT_FAILED(err)) {
-        calculate_free(&calculate);
-        _Py_FatalInitError(err);
+    _PyMainInterpreterConfig tmp_config;
+    int use_tmp = (main_config == NULL);
+    if (use_tmp) {
+        tmp_config = _PyMainInterpreterConfig_INIT;
+        err = _PyMainInterpreterConfig_ReadEnv(&tmp_config);
+        if (_Py_INIT_FAILED(err)) {
+            goto fatal_error;
+        }
+        main_config = &tmp_config;
     }
+
+    calculate_init(&calculate, main_config);
 
     PyPathConfig new_path_config;
     memset(&new_path_config, 0, sizeof(new_path_config));
@@ -1035,7 +1026,18 @@ calculate_path(const _PyMainInterpreterConfig *main_config)
     calculate_path_impl(&calculate, &new_path_config, main_config);
     path_config = new_path_config;
 
+    if (use_tmp) {
+        _PyMainInterpreterConfig_Clear(&tmp_config);
+    }
     calculate_free(&calculate);
+    return;
+
+fatal_error:
+    if (use_tmp) {
+        _PyMainInterpreterConfig_Clear(&tmp_config);
+    }
+    calculate_free(&calculate);
+    _Py_FatalInitError(err);
 }
 
 

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -1004,6 +1004,7 @@ calculate_free(PyCalculatePath *calculate)
 static void
 calculate_path(const _PyMainInterpreterConfig *main_config)
 {
+    _PyInitError err;
     PyCalculatePath calculate;
     memset(&calculate, 0, sizeof(calculate));
 
@@ -1011,7 +1012,7 @@ calculate_path(const _PyMainInterpreterConfig *main_config)
     int use_tmp = (main_config == NULL);
     if (use_tmp) {
         tmp_config = _PyMainInterpreterConfig_INIT;
-        _PyInitError err = _PyMainInterpreterConfig_ReadEnv(&tmp_config);
+        err = _PyMainInterpreterConfig_ReadEnv(&tmp_config);
         if (_Py_INIT_FAILED(err)) {
             goto fatal_error;
         }


### PR DESCRIPTION
Py_GetPath() and Py_Main() now call
_PyMainInterpreterConfig_ReadEnv() to share the same code to get
environment variables.

Changes:

* Add _PyMainInterpreterConfig_ReadEnv()
* Add _PyMainInterpreterConfig_Clear()
* Add _PyMem_RawWcsdup()
* _PyMainInterpreterConfig: rename pythonhome to home
* Rename _Py_ReadMainInterpreterConfig() to
  _PyMainInterpreterConfig_Read()
* Use _Py_INIT_USER_ERR(), instead of _Py_INIT_ERR(), for decoding
  errors: the user is able to fix the issue, it's not a bug in
  Python. Same change was made in _Py_INIT_NO_MEMORY().
* Remove _Py_GetPythonHomeWithConfig()

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
