### PR TITLE
bpo-32125: Remove Py_UseClassExceptionsFlag flag

### DIFF
--- a/Include/pydebug.h
+++ b/Include/pydebug.h
@@ -15,7 +15,6 @@ PyAPI_DATA(int) Py_InspectFlag;
 PyAPI_DATA(int) Py_OptimizeFlag;
 PyAPI_DATA(int) Py_NoSiteFlag;
 PyAPI_DATA(int) Py_BytesWarningFlag;
-PyAPI_DATA(int) Py_UseClassExceptionsFlag;
 PyAPI_DATA(int) Py_FrozenFlag;
 PyAPI_DATA(int) Py_IgnoreEnvironmentFlag;
 PyAPI_DATA(int) Py_DontWriteBytecodeFlag;

--- a/Misc/NEWS.d/next/C API/2017-11-24-21-25-43.bpo-32125.K8zWgn.rst
+++ b/Misc/NEWS.d/next/C API/2017-11-24-21-25-43.bpo-32125.K8zWgn.rst
@@ -1,0 +1,2 @@
+The ``Py_UseClassExceptionsFlag`` flag has been removed. It was deprecated
+and wasn't used anymore since Python 2.0.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -116,7 +116,6 @@ int Py_InspectFlag; /* Needed to determine whether to exit at SystemExit */
 int Py_OptimizeFlag = 0; /* Needed by compile.c */
 int Py_NoSiteFlag; /* Suppress 'import site' */
 int Py_BytesWarningFlag; /* Warn on str(bytes) and str(buffer) */
-int Py_UseClassExceptionsFlag = 1; /* Needed by bltinmodule.c: deprecated */
 int Py_FrozenFlag; /* Needed by getpath.c */
 int Py_IgnoreEnvironmentFlag; /* e.g. PYTHONPATH, PYTHONHOME */
 int Py_DontWriteBytecodeFlag; /* Suppress writing bytecode files (*.pyc) */

--- a/Tools/c-globals/ignored-globals.txt
+++ b/Tools/c-globals/ignored-globals.txt
@@ -393,7 +393,6 @@ Py_NoUserSiteDirectory
 Py_OptimizeFlag
 Py_QuietFlag
 Py_UnbufferedStdioFlag
-Py_UseClassExceptionsFlag
 Py_VerboseFlag
 
 


### PR DESCRIPTION
This flag was deprecated and wasn't used anymore since Python 2.0.

<!-- issue-number: bpo-306900 -->
https://bugs.python.org/issue306900
<!-- /issue-number -->
