### PR TITLE
bpo-28684: Remove useless import added by the previous commit

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -22,7 +22,6 @@ import errno
 import unittest
 from unittest import mock
 import weakref
-from test import support
 
 if sys.platform != 'win32':
     import tty


### PR DESCRIPTION


<!-- issue-number: bpo-28684 -->
https://bugs.python.org/issue28684
<!-- /issue-number -->
