### PR TITLE
bpo-32030: Add _PyMainInterpreterConfig.program_name

### DIFF
--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -64,6 +64,8 @@ typedef struct {
     wchar_t *module_search_path_env;
     /* PYTHONHOME environment variable, see also Py_SetPythonHome(). */
     wchar_t *home;
+    /* Program name, see also Py_GetProgramName() */
+    wchar_t *program_name;
 } _PyMainInterpreterConfig;
 
 #define _PyMainInterpreterConfig_INIT \

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -802,6 +802,14 @@ _PyMainInterpreterConfig_Read(_PyMainInterpreterConfig *config)
     if (config->install_signal_handlers < 0) {
         config->install_signal_handlers = 1;
     }
+
+    if (config->program_name == NULL) {
+        config->program_name = _PyMem_RawWcsdup(Py_GetProgramName());
+        if (config->program_name == NULL) {
+            return _Py_INIT_NO_MEMORY();
+        }
+    }
+
     return _Py_INIT_OK();
 }
 
@@ -809,10 +817,16 @@ _PyMainInterpreterConfig_Read(_PyMainInterpreterConfig *config)
 void
 _PyMainInterpreterConfig_Clear(_PyMainInterpreterConfig *config)
 {
-    PyMem_RawFree(config->module_search_path_env);
-    config->module_search_path_env = NULL;
-    PyMem_RawFree(config->home);
-    config->home = NULL;
+#define CLEAR(ATTR) \
+    do { \
+        PyMem_RawFree(ATTR); \
+        ATTR = NULL; \
+    } while (0)
+
+    CLEAR(config->module_search_path_env);
+    CLEAR(config->home);
+    CLEAR(config->program_name);
+#undef CLEAR
 }
 
 


### PR DESCRIPTION
* Py_Main() now calls Py_SetProgramName() earlier to be able to get
  the program name in _PyMainInterpreterConfig_ReadEnv().
* Rename prog to program_name
* Rename progpath to program_name

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
