### PR TITLE
bpo-32128: Skip test_nntplib.test_article_head_body()

### DIFF
--- a/Lib/test/test_nntplib.py
+++ b/Lib/test/test_nntplib.py
@@ -165,6 +165,7 @@ class NetworkedNNTPTestsMixin:
         # XXX this could exceptionally happen...
         self.assertNotIn(article.lines[-1], (b".", b".\n", b".\r\n"))
 
+    @unittest.skipIf(True, "FIXME: see bpo-32128")
     def test_article_head_body(self):
         resp, count, first, last, name = self.server.group(self.GROUP_NAME)
         # Try to find an available article


### PR DESCRIPTION
The NNTP server currently has troubles with SSL, whereas we don't
have the control on this server. This test blocks all CIs, so disable
it until a fix can be found.

<!-- issue-number: bpo-32128 -->
https://bugs.python.org/issue32128
<!-- /issue-number -->
