### PR TITLE
Improve Scheduler Objects documentation.

### DIFF
--- a/Doc/library/sched.rst
+++ b/Doc/library/sched.rst
@@ -69,7 +69,7 @@ Scheduler Objects
    Schedule a new event. The *time* argument should be a numeric type compatible
    with the return value of the *timefunc* function passed  to the constructor.
    Events scheduled for the same *time* will be executed in the order of their
-   *priority*.
+   *priority*. Lower number represents a higher priority.
 
    Executing the event means executing ``action(*argument, **kwargs)``.
    *argument* is a sequence holding the positional arguments for *action*.

--- a/Doc/library/sched.rst
+++ b/Doc/library/sched.rst
@@ -69,7 +69,7 @@ Scheduler Objects
    Schedule a new event. The *time* argument should be a numeric type compatible
    with the return value of the *timefunc* function passed  to the constructor.
    Events scheduled for the same *time* will be executed in the order of their
-   *priority*. Lower number represents a higher priority.
+   *priority*. A lower number represents a higher priority.
 
    Executing the event means executing ``action(*argument, **kwargs)``.
    *argument* is a sequence holding the positional arguments for *action*.


### PR DESCRIPTION
Mention that the lower the priority number, the higher priority it represents.
