### PR TITLE
bpo-32126: Skip asyncio test when sem_open() is not functional

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2156,7 +2156,9 @@ else:
             super().tearDown()
 
         def test_get_event_loop_new_process(self):
-            # Skip the test if the sem_open() implementation is broken.
+            # Issue bpo-32126: The multiprocessing module used by
+            # ProcessPoolExecutor is not functional when the
+            # multiprocessing.synchronize module cannot be imported.
             support.import_module('multiprocessing.synchronize')
             async def main():
                 pool = concurrent.futures.ProcessPoolExecutor()

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2156,6 +2156,8 @@ else:
             super().tearDown()
 
         def test_get_event_loop_new_process(self):
+            # Skip the test if the sem_open() implementation is broken.
+            support.import_module('multiprocessing.synchronize')
             async def main():
                 pool = concurrent.futures.ProcessPoolExecutor()
                 result = await self.loop.run_in_executor(

--- a/Misc/NEWS.d/next/Tests/2017-11-24-18-15-12.bpo-32126.PLmNLn.rst
+++ b/Misc/NEWS.d/next/Tests/2017-11-24-18-15-12.bpo-32126.PLmNLn.rst
@@ -1,0 +1,2 @@
+Skip test_get_event_loop_new_process in test.test_asyncio.test_events when
+sem_open() is not functional.


### PR DESCRIPTION


<!-- issue-number: bpo-32126 -->
https://bugs.python.org/issue32126
<!-- /issue-number -->
