### PR TITLE
mark fatal_error as noreturn

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2048,7 +2048,7 @@ fatal_output_debug(const char *msg)
 }
 #endif
 
-static void
+static void _Py_NO_RETURN
 fatal_error(const char *prefix, const char *msg, int status)
 {
     const int fd = fileno(stderr);


### PR DESCRIPTION
clang can't figure out that fatal_error is noreturn itself and emits warnings:

../cpython/Python/pylifecycle.c:2116:1: warning: function declared 'noreturn' should not return [-Winvalid-noreturn]
}
^
../cpython/Python/pylifecycle.c:2125:1: warning: function declared 'noreturn' should not return [-Winvalid-noreturn]
}
^
