### PR TITLE
bpo-11063: Handle uuid.h being in default include path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1680,12 +1680,11 @@ class PyBuildExt(build_ext):
 
         # Build the _uuid module if possible
         uuid_incs = find_file("uuid.h", inc_dirs, ["/usr/include/uuid"])
-        if uuid_incs:
+        if uuid_incs is not None:
             if self.compiler.find_library_file(lib_dirs, 'uuid'):
                 uuid_libs = ['uuid']
             else:
                 uuid_libs = []
-        if uuid_incs:
             self.extensions.append(Extension('_uuid', ['_uuidmodule.c'],
                                    libraries=uuid_libs,
                                    include_dirs=uuid_incs))


### PR DESCRIPTION
find_file() returns an empty list if it finds the requested
header on the standard include path, so header existence
checks need to be explicitly against "is not None".


<!-- issue-number: bpo-11063 -->
https://bugs.python.org/issue11063
<!-- /issue-number -->
