### PR TITLE
bpo-32096: Ensure test can find the encodings module

### DIFF
--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -132,7 +132,8 @@ static int test_forced_io_encoding(void)
 
 static int test_pre_initialization_api(void)
 {
-    wchar_t *program = Py_DecodeLocale("spam", NULL);
+    /* Leading "./" ensures getpath.c can still find the standard library */
+    wchar_t *program = Py_DecodeLocale("./spam", NULL);
     if (program == NULL) {
         fprintf(stderr, "Fatal error: cannot decode program name\n");
         return 1;


### PR DESCRIPTION


<!-- issue-number: bpo-32096 -->
https://bugs.python.org/issue32096
<!-- /issue-number -->
