### PR TITLE
bpo-32143: add f_fsid to os.statvfs()

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2436,7 +2436,7 @@ features:
    correspond to the members of the :c:type:`statvfs` structure, namely:
    :attr:`f_bsize`, :attr:`f_frsize`, :attr:`f_blocks`, :attr:`f_bfree`,
    :attr:`f_bavail`, :attr:`f_files`, :attr:`f_ffree`, :attr:`f_favail`,
-   :attr:`f_flag`, :attr:`f_namemax`.
+   :attr:`f_flag`, :attr:`f_namemax`, :attr:`f_fsid`.
 
    Two module-level constants are defined for the :attr:`f_flag` attribute's
    bit-flags: if :const:`ST_RDONLY` is set, the filesystem is mounted
@@ -2470,6 +2470,9 @@ features:
 
    .. versionchanged:: 3.6
       Accepts a :term:`path-like object`.
+
+   .. versionadded:: 3.7
+      Added :attr:`f_fsid`.
 
 
 .. data:: supports_dir_fd

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -352,6 +352,11 @@ class StatAttributeTests(unittest.TestCase):
         for value, member in enumerate(members):
             self.assertEqual(getattr(result, 'f_' + member), result[value])
 
+        self.assertTrue(isinstance(result.f_fsid, int))
+
+        # Test that the size of the tuple doesn't change
+        self.assertEqual(len(result), 10)
+
         # Make sure that assignment really fails
         try:
             result.f_bfree = 1

--- a/Misc/NEWS.d/next/Library/2017-11-26-17-28-26.bpo-32143.o7YdXL.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-26-17-28-26.bpo-32143.o7YdXL.rst
@@ -1,0 +1,1 @@
+os.statvfs() includes the f_fsid field from statvfs(2)

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1860,6 +1860,7 @@ static PyStructSequence_Field statvfs_result_fields[] = {
     {"f_favail", },
     {"f_flag",   },
     {"f_namemax",},
+    {"f_fsid",   },
     {0}
 };
 
@@ -9323,6 +9324,7 @@ _pystatvfs_fromstructstatvfs(struct statvfs st) {
     PyStructSequence_SET_ITEM(v, 8, PyLong_FromLong((long) st.f_flag));
     PyStructSequence_SET_ITEM(v, 9, PyLong_FromLong((long) st.f_namemax));
 #endif
+    PyStructSequence_SET_ITEM(v, 10, PyLong_FromUnsignedLong(st.f_fsid));
     if (PyErr_Occurred()) {
         Py_DECREF(v);
         return NULL;


### PR DESCRIPTION
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>


<!-- issue-number: bpo-32143 -->
https://bugs.python.org/issue32143
<!-- /issue-number -->
