### PR TITLE
[skip news] bpo-29879: Add versionadded where missing in typing.rst (and fix old Misc/NEWS)

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -146,6 +146,8 @@ See :pep:`484` for more details.
    ``Derived`` is expected. This is useful when you want to prevent logic
    errors with minimal runtime cost.
 
+.. versionadded:: 3.5.2
+
 Callable
 --------
 
@@ -494,6 +496,8 @@ The module defines the following classes, functions and decorators:
    ``Type[Any]`` is equivalent to ``Type`` which in turn is equivalent
    to ``type``, which is the root of Python's metaclass hierarchy.
 
+   .. versionadded:: 3.5.2
+
 .. class:: Iterable(Generic[T_co])
 
     A generic version of :class:`collections.abc.Iterable`.
@@ -674,6 +678,8 @@ The module defines the following classes, functions and decorators:
 
    A generic version of :class:`collections.defaultdict`.
 
+   .. versionadded:: 3.5.2
+
 .. class:: Counter(collections.Counter, Dict[T, int])
 
    A generic version of :class:`collections.Counter`.
@@ -762,6 +768,8 @@ The module defines the following classes, functions and decorators:
        def add_unicode_checkmark(text: Text) -> Text:
            return text + u' \u2713'
 
+   .. versionadded:: 3.5.2
+
 .. class:: io
 
    Wrapper namespace for I/O stream types.
@@ -846,6 +854,8 @@ The module defines the following classes, functions and decorators:
 
       UserId = NewType('UserId', int)
       first_user = UserId(1)
+
+   .. versionadded:: 3.5.2
 
 .. function:: cast(typ, val)
 
@@ -1054,3 +1064,5 @@ The module defines the following classes, functions and decorators:
    "forward reference", to hide the ``expensive_mod`` reference from the
    interpreter runtime.  Type annotations for local variables are not
    evaluated, so the second annotation does not need to be enclosed in quotes.
+
+   .. versionadded:: 3.5.2

--- a/Misc/NEWS.d/3.5.2rc1.rst
+++ b/Misc/NEWS.d/3.5.2rc1.rst
@@ -420,7 +420,7 @@ patch by ingrid.
 .. section: Library
 
 A new version of typing.py provides several new classes and features:
-@overload outside stubs, Reversible, DefaultDict, Text, ContextManager,
+@overload outside stubs, DefaultDict, Text, ContextManager,
 Type[], NewType(), TYPE_CHECKING, and numerous bug fixes (note that some of
 the new features are not yet implemented in mypy or other static analyzers).
 Also classes for PEP 492 (Awaitable, AsyncIterable, AsyncIterator) have been


### PR DESCRIPTION
This PR supersedes https://github.com/python/cpython/pull/784

<!-- issue-number: bpo-29879 -->
https://bugs.python.org/issue29879
<!-- /issue-number -->
