### PR TITLE
bpo-10544: Deprecate "yield" in comprehensions and generator expressions.

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -214,7 +214,8 @@ See also :pep:`530`.
    Asynchronous comprehensions were introduced.
 
 .. deprecated:: 3.7
-   ``yield`` and ``yield from`` deprecated in the implicitly nested scope
+   ``yield`` and ``yield from`` deprecated in the implicitly nested scope.
+
 
 .. _lists:
 
@@ -365,7 +366,8 @@ which is an asynchronous iterator (see :ref:`async-iterators`).
    with 3.7, any function can use asynchronous generator expressions.
 
 .. deprecated:: 3.7
-   ``yield`` and ``yield from`` deprecated in the implicitly nested scope
+   ``yield`` and ``yield from`` deprecated in the implicitly nested scope.
+
 
 .. _yieldexpr:
 
@@ -402,7 +404,7 @@ they will emit :exc:`SyntaxError`)..
 
 .. deprecated:: 3.7
    Yield expressions deprecated in the implicitly nested scopes used to
-   implement comprehensions and generator expressions
+   implement comprehensions and generator expressions.
 
 Generator functions are described below, while asynchronous generator
 functions are described separately in section

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -183,11 +183,20 @@ by considering each of the :keyword:`for` or :keyword:`if` clauses a block,
 nesting from left to right, and evaluating the expression to produce an element
 each time the innermost block is reached.
 
-Note that the comprehension is executed in a separate scope, so names assigned
-to in the target list don't "leak" into the enclosing scope.
+However, aside from the leftmost :keyword:`for` clause, the comprehension is
+executed in a separate implicitly nested scope. This ensures that names
+assigned to in the target list don't "leak" into the enclosing scope.
 
-Yield expressions are not allowed in comprehensions
-except the expression for the outermost iterable.
+The leftmost :keyword:`for` clause is evaluated directly in the enclosing scope
+and then passed as an argument to the implictly nested scope. Subsequent
+:keyword:`for` clauses cannot be evaluated in the enclosing scope since they
+may depend on the previous :keyword:`for` loop. For example:
+``[x*y for x in range(10) for y in bar(x)]``.
+
+To ensure the comprehension always results in a container of the appropriate
+type, ``yield`` and ``yield from`` expressions are prohibited in the implicitly
+nested scope (in Python 3.7, such expressions emit :exc:`DeprecationWarning`
+when compiled, in Python 3.8+ they will emit `:exc:`SyntaxError`).
 
 Since Python 3.6, in an :keyword:`async def` function, an :keyword:`async for`
 clause may be used to iterate over a :term:`asynchronous iterator`.
@@ -200,6 +209,12 @@ or :keyword:`await` expressions it is called an
 :dfn:`asynchronous comprehension`.  An asynchronous comprehension may
 suspend the execution of the coroutine function in which it appears.
 See also :pep:`530`.
+
+.. versionadded:: 3.6
+   Asynchronous comprehensions were introduced
+
+.. versionchanged:: 3.7
+   ``yield`` and ``yield from`` deprecated in the implicitly nested scope
 
 .. _lists:
 
@@ -329,8 +344,11 @@ range(10) for y in bar(x))``.
 The parentheses can be omitted on calls with only one argument.  See section
 :ref:`calls` for details.
 
-Yield expressions are not allowed in generator expressions
-except the expression for the outermost iterable.
+To avoid interfering with the expected operation of the generator expression
+itself, ``yield`` and ``yield from`` expressions are prohibited in the
+implicitly defined generator (in Python 3.7, such expressions emit
+:exc:`DeprecationWarning` when compiled, in Python 3.8+ they will emit
+`:exc:`SyntaxError`).
 
 If a generator expression contains either :keyword:`async for`
 clauses or :keyword:`await` expressions it is called an
@@ -338,10 +356,16 @@ clauses or :keyword:`await` expressions it is called an
 expression returns a new asynchronous generator object,
 which is an asynchronous iterator (see :ref:`async-iterators`).
 
+.. versionadded:: 3.6
+   Asynchronous generator expressions were introduced
+
 .. versionchanged:: 3.7
    Prior to Python 3.7, asynchronous generator expressions could
    only appear in :keyword:`async def` coroutines.  Starting
    with 3.7, any function can use asynchronous generator expressions.
+
+.. versionchanged:: 3.7
+   ``yield`` and ``yield from`` deprecated in the implicitly nested scope
 
 .. _yieldexpr:
 
@@ -370,8 +394,15 @@ coroutine function to be an asynchronous generator. For example::
     async def agen(): # defines an asynchronous generator function (PEP 525)
         yield 123
 
-Yield expressions are not allowed in comprehensions and generator expressions
-except the expression for the outermost iterable.
+Due to their side effects on the containing scope, ``yield`` expressions
+are not permitted as part of the implicitly defined scopes used to
+implement comprehensions and generator expressions (in Python 3.7, such
+expressions emit :exc:`DeprecationWarning` when compiled, in Python 3.8+
+they will emit `:exc:`SyntaxError`)..
+
+.. versionchanged:: 3.7
+   Yield expressions deprecated in the implicitly nested scopes used to
+   implement comprehensions and generator expressions
 
 Generator functions are described below, while asynchronous generator
 functions are described separately in section

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -196,7 +196,7 @@ may depend on the previous :keyword:`for` loop. For example:
 To ensure the comprehension always results in a container of the appropriate
 type, ``yield`` and ``yield from`` expressions are prohibited in the implicitly
 nested scope (in Python 3.7, such expressions emit :exc:`DeprecationWarning`
-when compiled, in Python 3.8+ they will emit `:exc:`SyntaxError`).
+when compiled, in Python 3.8+ they will emit :exc:`SyntaxError`).
 
 Since Python 3.6, in an :keyword:`async def` function, an :keyword:`async for`
 clause may be used to iterate over a :term:`asynchronous iterator`.
@@ -348,7 +348,7 @@ To avoid interfering with the expected operation of the generator expression
 itself, ``yield`` and ``yield from`` expressions are prohibited in the
 implicitly defined generator (in Python 3.7, such expressions emit
 :exc:`DeprecationWarning` when compiled, in Python 3.8+ they will emit
-`:exc:`SyntaxError`).
+:exc:`SyntaxError`).
 
 If a generator expression contains either :keyword:`async for`
 clauses or :keyword:`await` expressions it is called an
@@ -398,7 +398,7 @@ Due to their side effects on the containing scope, ``yield`` expressions
 are not permitted as part of the implicitly defined scopes used to
 implement comprehensions and generator expressions (in Python 3.7, such
 expressions emit :exc:`DeprecationWarning` when compiled, in Python 3.8+
-they will emit `:exc:`SyntaxError`)..
+they will emit :exc:`SyntaxError`)..
 
 .. versionchanged:: 3.7
    Yield expressions deprecated in the implicitly nested scopes used to

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -186,6 +186,9 @@ each time the innermost block is reached.
 Note that the comprehension is executed in a separate scope, so names assigned
 to in the target list don't "leak" into the enclosing scope.
 
+Yield expressions are not allowed in comprehensions
+except the expression for the outermost iterable.
+
 Since Python 3.6, in an :keyword:`async def` function, an :keyword:`async for`
 clause may be used to iterate over a :term:`asynchronous iterator`.
 A comprehension in an :keyword:`async def` function may consist of either a
@@ -326,6 +329,9 @@ range(10) for y in bar(x))``.
 The parentheses can be omitted on calls with only one argument.  See section
 :ref:`calls` for details.
 
+Yield expressions are not allowed in generator expressions
+except the expression for the outermost iterable.
+
 If a generator expression contains either :keyword:`async for`
 clauses or :keyword:`await` expressions it is called an
 :dfn:`asynchronous generator expression`.  An asynchronous generator
@@ -363,6 +369,9 @@ coroutine function to be an asynchronous generator. For example::
 
     async def agen(): # defines an asynchronous generator function (PEP 525)
         yield 123
+
+Yield expressions are not allowed in comprehensions and generator expressions
+except the expression for the outermost iterable.
 
 Generator functions are described below, while asynchronous generator
 functions are described separately in section

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -191,7 +191,7 @@ The leftmost :keyword:`for` clause is evaluated directly in the enclosing scope
 and then passed as an argument to the implictly nested scope. Subsequent
 :keyword:`for` clauses cannot be evaluated in the enclosing scope since they
 may depend on the previous :keyword:`for` loop. For example:
-``[x*y for x in range(10) for y in bar(x)]``.
+``[x*y for x in range(10) for y in range(x, x+10)]``.
 
 To ensure the comprehension always results in a container of the appropriate
 type, ``yield`` and ``yield from`` expressions are prohibited in the implicitly
@@ -211,9 +211,9 @@ suspend the execution of the coroutine function in which it appears.
 See also :pep:`530`.
 
 .. versionadded:: 3.6
-   Asynchronous comprehensions were introduced
+   Asynchronous comprehensions were introduced.
 
-.. versionchanged:: 3.7
+.. deprecated:: 3.7
    ``yield`` and ``yield from`` deprecated in the implicitly nested scope
 
 .. _lists:
@@ -339,7 +339,7 @@ immediately evaluated, so that an error produced by it can be seen before any
 other possible error in the code that handles the generator expression.
 Subsequent :keyword:`for` clauses cannot be evaluated immediately since they
 may depend on the previous :keyword:`for` loop. For example: ``(x*y for x in
-range(10) for y in bar(x))``.
+range(10) for y in range(x, x+10))``.
 
 The parentheses can be omitted on calls with only one argument.  See section
 :ref:`calls` for details.
@@ -357,14 +357,14 @@ expression returns a new asynchronous generator object,
 which is an asynchronous iterator (see :ref:`async-iterators`).
 
 .. versionadded:: 3.6
-   Asynchronous generator expressions were introduced
+   Asynchronous generator expressions were introduced.
 
 .. versionchanged:: 3.7
    Prior to Python 3.7, asynchronous generator expressions could
    only appear in :keyword:`async def` coroutines.  Starting
    with 3.7, any function can use asynchronous generator expressions.
 
-.. versionchanged:: 3.7
+.. deprecated:: 3.7
    ``yield`` and ``yield from`` deprecated in the implicitly nested scope
 
 .. _yieldexpr:
@@ -400,7 +400,7 @@ implement comprehensions and generator expressions (in Python 3.7, such
 expressions emit :exc:`DeprecationWarning` when compiled, in Python 3.8+
 they will emit :exc:`SyntaxError`)..
 
-.. versionchanged:: 3.7
+.. deprecated:: 3.7
    Yield expressions deprecated in the implicitly nested scopes used to
    implement comprehensions and generator expressions
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -183,14 +183,15 @@ by considering each of the :keyword:`for` or :keyword:`if` clauses a block,
 nesting from left to right, and evaluating the expression to produce an element
 each time the innermost block is reached.
 
-However, aside from the leftmost :keyword:`for` clause, the comprehension is
-executed in a separate implicitly nested scope. This ensures that names
-assigned to in the target list don't "leak" into the enclosing scope.
+However, aside from the iterable expression in the leftmost :keyword:`for` clause,
+the comprehension is executed in a separate implicitly nested scope. This ensures
+that names assigned to in the target list don't "leak" into the enclosing scope.
 
-The leftmost :keyword:`for` clause is evaluated directly in the enclosing scope
-and then passed as an argument to the implictly nested scope. Subsequent
-:keyword:`for` clauses cannot be evaluated in the enclosing scope since they
-may depend on the previous :keyword:`for` loop. For example:
+The iterable expression in the leftmost :keyword:`for` clause is evaluated
+directly in the enclosing scope and then passed as an argument to the implictly
+nested scope. Subsequent :keyword:`for` clauses and any filter condition in the
+leftmost :keyword:`for` clause cannot be evaluated in the enclosing scope as
+they may depend on the values obtained from the leftmost iterable. For example:
 ``[x*y for x in range(10) for y in range(x, x+10)]``.
 
 To ensure the comprehension always results in a container of the appropriate
@@ -335,12 +336,14 @@ brackets or curly braces.
 
 Variables used in the generator expression are evaluated lazily when the
 :meth:`~generator.__next__` method is called for the generator object (in the same
-fashion as normal generators).  However, the leftmost :keyword:`for` clause is
-immediately evaluated, so that an error produced by it can be seen before any
-other possible error in the code that handles the generator expression.
-Subsequent :keyword:`for` clauses cannot be evaluated immediately since they
-may depend on the previous :keyword:`for` loop. For example: ``(x*y for x in
-range(10) for y in range(x, x+10))``.
+fashion as normal generators).  However, the iterable expression in the
+leftmost :keyword:`for` clause is immediately evaluated, so that an error
+produced by it will be emitted at the point where the generator expression
+is defined, rather than at the point where the first value is retrieved.
+Subsequent :keyword:`for` clauses and any filter condition in the leftmost
+:keyword:`for` clause cannot be evaluated in the enclosing scope as they may
+depend on the values obtained from the leftmost iterable. For example:
+``(x*y for x in range(10) for y in range(x, x+10))``.
 
 The parentheses can be omitted on calls with only one argument.  See section
 :ref:`calls` for details.

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -556,6 +556,12 @@ Other CPython Implementation Changes
 Deprecated
 ==========
 
+* Yield expressions now are not deprecated in comprehensions and generator
+  expressions except the expression for the outermost iterable since
+  comprehensions and generator expressions are implemented using
+  an internal function.
+  (Contributed by Serhiy Storchaka in :issue:`10544`.)
+
 - Function :c:func:`PySlice_GetIndicesEx` is deprecated and replaced with
   a macro if ``Py_LIMITED_API`` is not set or set to the value between
   ``0x03050400`` and ``0x03060000`` (not including) or ``0x03060100`` or
@@ -672,12 +678,6 @@ Changes in Python behavior
   and cannot have a comma on either side, and the duplication of the
   parentheses can be omitted only on calls.
   (Contributed by Serhiy Storchaka in :issue:`32012` and :issue:`32023`.)
-
-* Yield expressions now are not allowed in comprehensions and generator
-  expressions except the expression for the outermost iterable since
-  comprehensions and generator expressions are implemented using
-  an internal function.
-  (Contributed by Serhiy Storchaka in :issue:`10544`.)
 
 
 Changes in the Python API

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -557,8 +557,8 @@ Deprecated
 ==========
 
 * Yield expressions (both ``yield`` and ``yield from`` clauses) are now deprecated
-  in comprehensions and generator expressions (aside from the outermost iterable
-  defined in the leftmost :keyword:`for` clause). This ensures that comprehensions
+  in comprehensions and generator expressions (aside from the iterable expression
+  in the leftmost :keyword:`for` clause). This ensures that comprehensions
   always immediately return a container of the appropriate type (rather than
   potentially returning a :term:`generator iterator` object), while generator
   expressions won't attempt to interleave their implicit output with the output

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -558,9 +558,9 @@ Deprecated
 
 * Yield expressions (both ``yield`` and ``yield from`` clauses) are now deprecated
   in comprehensions and generator expressions (aside from the outermost iterable
-  defined in the leftmost :keyword`for` clause). This ensures that comprehensions
+  defined in the leftmost :keyword:`for` clause). This ensures that comprehensions
   always immediately return a container of the appropriate type (rather than
-  potentially returning a :term:`generator-iterator` object), while generator
+  potentially returning a :term:`generator iterator` object), while generator
   expressions won't attempt to interleave their implicit output with the output
   from any explicit yield expressions.
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -673,6 +673,12 @@ Changes in Python behavior
   parentheses can be omitted only on calls.
   (Contributed by Serhiy Storchaka in :issue:`32012` and :issue:`32023`.)
 
+* Yield expressions now are not allowed in comprehensions and generator
+  expressions except the expression for the outermost iterable since
+  comprehensions and generator expressions are implemented using
+  an internal function.
+  (Contributed by Serhiy Storchaka in :issue:`10544`.)
+
 
 Changes in the Python API
 -------------------------

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -563,7 +563,10 @@ Deprecated
   potentially returning a :term:`generator-iterator` object), while generator
   expressions won't attempt to interleave their implicit output with the output
   from any explicit yield expressions.
-  (Contributed by Serhiy Storchaka in :issue:`10544`.)
+  
+  In Python 3.7, such expressions emit :exc:`DeprecationWarning` when compiled,
+  in Python 3.8+ they will emit :exc:`SyntaxError`. (Contributed by Serhiy
+  Storchaka in :issue:`10544`.)
 
 - Function :c:func:`PySlice_GetIndicesEx` is deprecated and replaced with
   a macro if ``Py_LIMITED_API`` is not set or set to the value between

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -556,10 +556,13 @@ Other CPython Implementation Changes
 Deprecated
 ==========
 
-* Yield expressions now are not deprecated in comprehensions and generator
-  expressions except the expression for the outermost iterable since
-  comprehensions and generator expressions are implemented using
-  an internal function.
+* Yield expressions (both ``yield`` and ``yield from`` clauses) are now deprecated
+  in comprehensions and generator expressions (aside from the outermost iterable
+  defined in the leftmost :keyword`for` clause). This ensures that comprehensions
+  always immediately return a container of the appropriate type (rather than
+  potentially returning a :term:`generator-iterator` object), while generator
+  expressions won't attempt to interleave their implicit output with the output
+  from any explicit yield expressions.
   (Contributed by Serhiy Storchaka in :issue:`10544`.)
 
 - Function :c:func:`PySlice_GetIndicesEx` is deprecated and replaced with

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -563,7 +563,7 @@ Deprecated
   potentially returning a :term:`generator-iterator` object), while generator
   expressions won't attempt to interleave their implicit output with the output
   from any explicit yield expressions.
-  
+
   In Python 3.7, such expressions emit :exc:`DeprecationWarning` when compiled,
   in Python 3.8+ they will emit :exc:`SyntaxError`. (Contributed by Serhiy
   Storchaka in :issue:`10544`.)

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -1830,15 +1830,7 @@ Yield by itself yields None:
 [None]
 
 
-
-An obscene abuse of a yield expression within a generator expression:
-
->>> list((yield 21) for i in range(4))
-Traceback (most recent call last):
-  ...
-SyntaxError: 'yield' inside generator expression
-
-And a more sane, but still weird usage:
+Yield is allowed only in the outermost iterable in generator expression:
 
 >>> def f(): list(i for i in [(yield 26)])
 >>> type(f())

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -1834,7 +1834,9 @@ Yield by itself yields None:
 An obscene abuse of a yield expression within a generator expression:
 
 >>> list((yield 21) for i in range(4))
-[21, None, 21, None, 21, None, 21, None]
+Traceback (most recent call last):
+  ...
+SyntaxError: 'yield' inside generator expression
 
 And a more sane, but still weird usage:
 
@@ -2103,10 +2105,6 @@ enclosing function a generator:
 <class 'generator'>
 
 >>> def f(): lambda x=(yield): 1
->>> type(f())
-<class 'generator'>
-
->>> def f(): x=(i for i in (yield) if (yield))
 >>> type(f())
 <class 'generator'>
 

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -845,16 +845,36 @@ class GrammarTests(unittest.TestCase):
         # Check yield in comprehensions
         def g(): [x for x in [(yield 1)]]
         def g(): [x for x in [(yield from ())]]
-        check_syntax_error(self, "def g(): [(yield x) for x in ()]")
-        check_syntax_error(self, "def g(): [x for x in () if not (yield x)]")
-        check_syntax_error(self, "def g(): [y for x in () for y in [(yield x)]]")
-        check_syntax_error(self, "def g(): {(yield x) for x in ()}")
-        check_syntax_error(self, "def g(): {(yield x): x for x in ()}")
-        check_syntax_error(self, "def g(): {x: (yield x) for x in ()}")
-        check_syntax_error(self, "def g(): ((yield x) for x in ())")
-        check_syntax_error(self, "def g(): [(yield from x) for x in ()]")
-        check_syntax_error(self, "class C: [(yield x) for x in ()]")
-        check_syntax_error(self, "[(yield x) for x in ()]")
+
+        def check(code, warntext):
+            with self.assertWarnsRegex(DeprecationWarning, warntext):
+                compile(code, '<test string>', 'exec')
+            import warnings
+            with warnings.catch_warnings():
+                warnings.filterwarnings('error', category=DeprecationWarning)
+                with self.assertRaisesRegex(SyntaxError, warntext):
+                    compile(code, '<test string>', 'exec')
+
+        check("def g(): [(yield x) for x in ()]",
+              "'yield' inside list comprehension")
+        check("def g(): [x for x in () if not (yield x)]",
+              "'yield' inside list comprehension")
+        check("def g(): [y for x in () for y in [(yield x)]]",
+              "'yield' inside list comprehension")
+        check("def g(): {(yield x) for x in ()}",
+              "'yield' inside set comprehension")
+        check("def g(): {(yield x): x for x in ()}",
+              "'yield' inside dict comprehension")
+        check("def g(): {x: (yield x) for x in ()}",
+              "'yield' inside dict comprehension")
+        check("def g(): ((yield x) for x in ())",
+              "'yield' inside generator expression")
+        check("def g(): [(yield from x) for x in ()]",
+              "'yield' inside list comprehension")
+        check("class C: [(yield x) for x in ()]",
+              "'yield' inside list comprehension")
+        check("[(yield x) for x in ()]",
+              "'yield' inside list comprehension")
 
     def test_raise(self):
         # 'raise' test [',' test]

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -841,6 +841,21 @@ class GrammarTests(unittest.TestCase):
         # Check annotation refleak on SyntaxError
         check_syntax_error(self, "def g(a:(yield)): pass")
 
+    def test_yield_in_comprehensions(self):
+        # Check yield in comprehensions
+        def g(): [x for x in [(yield 1)]]
+        def g(): [x for x in [(yield from ())]]
+        check_syntax_error(self, "def g(): [(yield x) for x in ()]")
+        check_syntax_error(self, "def g(): [x for x in () if not (yield x)]")
+        check_syntax_error(self, "def g(): [y for x in () for y in [(yield x)]]")
+        check_syntax_error(self, "def g(): {(yield x) for x in ()}")
+        check_syntax_error(self, "def g(): {(yield x): x for x in ()}")
+        check_syntax_error(self, "def g(): {x: (yield x) for x in ()}")
+        check_syntax_error(self, "def g(): ((yield x) for x in ())")
+        check_syntax_error(self, "def g(): [(yield from x) for x in ()]")
+        check_syntax_error(self, "class C: [(yield x) for x in ()]")
+        check_syntax_error(self, "[(yield x) for x in ()]")
+
     def test_raise(self):
         # 'raise' test [',' test]
         try: raise RuntimeError('just testing')

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-26-00-59-22.bpo-10544.fHOM3V.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-26-00-59-22.bpo-10544.fHOM3V.rst
@@ -1,2 +1,0 @@
-Yield expressions now are disallowed in comprehensions and generator
-expressions except the expression for the outermost iterable.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-26-00-59-22.bpo-10544.fHOM3V.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-26-00-59-22.bpo-10544.fHOM3V.rst
@@ -1,0 +1,2 @@
+Yield expressions now are disallowed in comprehensions and generator
+expressions except the expression for the outermost iterable.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-27-08-37-34.bpo-10544.07nioT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-27-08-37-34.bpo-10544.07nioT.rst
@@ -1,2 +1,3 @@
-Yield expressions now are deprecated in comprehensions and generator
-expressions except the expression for the outermost iterable.
+Yield expressions are now deprecated in comprehensions and generator
+expressions. They are still permitted in the definition of the outermost
+iterable, as that is evaluated directly in the enclosing scope.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-27-08-37-34.bpo-10544.07nioT.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-27-08-37-34.bpo-10544.07nioT.rst
@@ -1,0 +1,2 @@
+Yield expressions now are deprecated in comprehensions and generator
+expressions except the expression for the outermost iterable.

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1768,7 +1768,9 @@ symtable_handle_comprehension(struct symtable *st, expr_ty e,
                 NULL, NULL) == -1)
         {
             if (PyErr_ExceptionMatches(PyExc_DeprecationWarning)) {
-                /* Turn a DeprecationWarning into a SyntaxError. */
+                /* Replace the DeprecationWarning exception with a SyntaxError
+                   to get a more accurate error report */
+                PyErr_Clear();
                 PyErr_SetObject(PyExc_SyntaxError, msg);
                 PyErr_SyntaxLocationObject(st->st_filename,
                                            st->st_cur->ste_lineno,


### PR DESCRIPTION


<!-- issue-number: bpo-10544 -->
https://bugs.python.org/issue10544
<!-- /issue-number -->
