### PR TITLE
bpo-32157: Remove explicit quotes around %r and {!r}.

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -1166,7 +1166,7 @@ class IMAP4:
         self.mo = cre.match(s)
         if __debug__:
             if self.mo is not None and self.debug >= 5:
-                self._mesg("\tmatched r'%r' => %r" % (cre.pattern, self.mo.groups()))
+                self._mesg("\tmatched %r => %r" % (cre.pattern, self.mo.groups()))
         return self.mo is not None
 
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1381,7 +1381,7 @@ def getclosurevars(func):
         func = func.__func__
 
     if not isfunction(func):
-        raise TypeError("'{!r}' is not a Python function".format(func))
+        raise TypeError("{!r} is not a Python function".format(func))
 
     code = func.__code__
     # Nonlocal references are named in co_freevars and resolved
@@ -1624,7 +1624,7 @@ def getgeneratorlocals(generator):
     bound values."""
 
     if not isgenerator(generator):
-        raise TypeError("'{!r}' is not a Python generator".format(generator))
+        raise TypeError("{!r} is not a Python generator".format(generator))
 
     frame = getattr(generator, "gi_frame", None)
     if frame is not None:

--- a/Lib/multiprocessing/sharedctypes.py
+++ b/Lib/multiprocessing/sharedctypes.py
@@ -78,7 +78,7 @@ def Value(typecode_or_type, *args, lock=True, ctx=None):
         ctx = ctx or get_context()
         lock = ctx.RLock()
     if not hasattr(lock, 'acquire'):
-        raise AttributeError("'%r' has no method 'acquire'" % lock)
+        raise AttributeError("%r has no method 'acquire'" % lock)
     return synchronized(obj, lock, ctx=ctx)
 
 def Array(typecode_or_type, size_or_initializer, *, lock=True, ctx=None):
@@ -92,7 +92,7 @@ def Array(typecode_or_type, size_or_initializer, *, lock=True, ctx=None):
         ctx = ctx or get_context()
         lock = ctx.RLock()
     if not hasattr(lock, 'acquire'):
-        raise AttributeError("'%r' has no method 'acquire'" % lock)
+        raise AttributeError("%r has no method 'acquire'" % lock)
     return synchronized(obj, lock, ctx=ctx)
 
 def copy(obj):

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -54,7 +54,7 @@ class BlockingTestMixin:
             self.result = block_func(*block_args)
             # If block_func returned before our thread made the call, we failed!
             if not thread.startedEvent.is_set():
-                self.fail("blocking function '%r' appeared not to block" %
+                self.fail("blocking function %r appeared not to block" %
                           block_func)
             return self.result
         finally:


### PR DESCRIPTION


<!-- issue-number: bpo-32157 -->
https://bugs.python.org/issue32157
<!-- /issue-number -->
