### PR TITLE
bpo-32150: Expand tabs to spaces in C files.

### DIFF
--- a/Doc/includes/shoddy.c
+++ b/Doc/includes/shoddy.c
@@ -17,7 +17,7 @@ Shoddy_increment(Shoddy *self, PyObject *unused)
 static PyMethodDef Shoddy_methods[] = {
     {"increment", (PyCFunction)Shoddy_increment, METH_NOARGS,
      PyDoc_STR("increment state counter")},
-    {NULL,      NULL},
+    {NULL},
 };
 
 static int

--- a/Doc/includes/shoddy.c
+++ b/Doc/includes/shoddy.c
@@ -17,7 +17,7 @@ Shoddy_increment(Shoddy *self, PyObject *unused)
 static PyMethodDef Shoddy_methods[] = {
     {"increment", (PyCFunction)Shoddy_increment, METH_NOARGS,
      PyDoc_STR("increment state counter")},
-    {NULL,	NULL},
+    {NULL,      NULL},
 };
 
 static int

--- a/Include/bitset.h
+++ b/Include/bitset.h
@@ -7,7 +7,7 @@ extern "C" {
 
 /* Bitset interface */
 
-#define BYTE		char
+#define BYTE            char
 
 typedef BYTE *bitset;
 
@@ -18,13 +18,13 @@ int addbit(bitset bs, int ibit); /* Returns 0 if already set */
 int samebitset(bitset bs1, bitset bs2, int nbits);
 void mergebitset(bitset bs1, bitset bs2, int nbits);
 
-#define BITSPERBYTE	(8*sizeof(BYTE))
-#define NBYTES(nbits)	(((nbits) + BITSPERBYTE - 1) / BITSPERBYTE)
+#define BITSPERBYTE     (8*sizeof(BYTE))
+#define NBYTES(nbits)   (((nbits) + BITSPERBYTE - 1) / BITSPERBYTE)
 
-#define BIT2BYTE(ibit)	((ibit) / BITSPERBYTE)
-#define BIT2SHIFT(ibit)	((ibit) % BITSPERBYTE)
-#define BIT2MASK(ibit)	(1 << BIT2SHIFT(ibit))
-#define BYTE2BIT(ibyte)	((ibyte) * BITSPERBYTE)
+#define BIT2BYTE(ibit)  ((ibit) / BITSPERBYTE)
+#define BIT2SHIFT(ibit) ((ibit) % BITSPERBYTE)
+#define BIT2MASK(ibit)  (1 << BIT2SHIFT(ibit))
+#define BYTE2BIT(ibyte) ((ibyte) * BITSPERBYTE)
 
 #ifdef __cplusplus
 }

--- a/Include/bytesobject.h
+++ b/Include/bytesobject.h
@@ -52,9 +52,9 @@ PyAPI_FUNC(PyObject *) PyBytes_FromStringAndSize(const char *, Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyBytes_FromString(const char *);
 PyAPI_FUNC(PyObject *) PyBytes_FromObject(PyObject *);
 PyAPI_FUNC(PyObject *) PyBytes_FromFormatV(const char*, va_list)
-				Py_GCC_ATTRIBUTE((format(printf, 1, 0)));
+                                Py_GCC_ATTRIBUTE((format(printf, 1, 0)));
 PyAPI_FUNC(PyObject *) PyBytes_FromFormat(const char*, ...)
-				Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
+                                Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
 PyAPI_FUNC(Py_ssize_t) PyBytes_Size(PyObject *);
 PyAPI_FUNC(char *) PyBytes_AsString(PyObject *);
 PyAPI_FUNC(PyObject *) PyBytes_Repr(PyObject *, int);
@@ -72,8 +72,8 @@ PyAPI_FUNC(PyObject*) _PyBytes_FromHex(
     int use_bytearray);
 #endif
 PyAPI_FUNC(PyObject *) PyBytes_DecodeEscape(const char *, Py_ssize_t,
-						   const char *, Py_ssize_t,
-						   const char *);
+                                            const char *, Py_ssize_t,
+                                            const char *);
 #ifndef Py_LIMITED_API
 /* Helper for PyBytes_DecodeEscape that detects invalid escape chars. */
 PyAPI_FUNC(PyObject *) _PyBytes_DecodeEscape(const char *, Py_ssize_t,
@@ -132,10 +132,10 @@ PyAPI_FUNC(Py_ssize_t) _PyBytes_InsertThousandsGrouping(char *buffer,
 
 /* Flags used by string formatting */
 #define F_LJUST (1<<0)
-#define F_SIGN	(1<<1)
+#define F_SIGN  (1<<1)
 #define F_BLANK (1<<2)
-#define F_ALT	(1<<3)
-#define F_ZERO	(1<<4)
+#define F_ALT   (1<<3)
+#define F_ZERO  (1<<4)
 
 #ifndef Py_LIMITED_API
 /* The _PyBytesWriter structure is big: it contains an embedded "stack buffer".

--- a/Include/cellobject.h
+++ b/Include/cellobject.h
@@ -7,8 +7,8 @@ extern "C" {
 #endif
 
 typedef struct {
-	PyObject_HEAD
-	PyObject *ob_ref;	/* Content of the cell or NULL when empty */
+    PyObject_HEAD
+    PyObject *ob_ref;       /* Content of the cell or NULL when empty */
 } PyCellObject;
 
 PyAPI_DATA(PyTypeObject) PyCell_Type;

--- a/Include/classobject.h
+++ b/Include/classobject.h
@@ -30,13 +30,13 @@ PyAPI_FUNC(PyObject *) PyMethod_Self(PyObject *);
 #define PyMethod_GET_FUNCTION(meth) \
         (((PyMethodObject *)meth) -> im_func)
 #define PyMethod_GET_SELF(meth) \
-	(((PyMethodObject *)meth) -> im_self)
+        (((PyMethodObject *)meth) -> im_self)
 
 PyAPI_FUNC(int) PyMethod_ClearFreeList(void);
 
 typedef struct {
-	PyObject_HEAD
-	PyObject *func;
+    PyObject_HEAD
+    PyObject *func;
 } PyInstanceMethodObject;
 
 PyAPI_DATA(PyTypeObject) PyInstanceMethod_Type;

--- a/Include/code.h
+++ b/Include/code.h
@@ -20,17 +20,17 @@ typedef uint16_t _Py_CODEUNIT;
 /* Bytecode object */
 typedef struct {
     PyObject_HEAD
-    int co_argcount;		/* #arguments, except *args */
-    int co_kwonlyargcount;	/* #keyword only arguments */
-    int co_nlocals;		/* #local variables */
-    int co_stacksize;		/* #entries needed for evaluation stack */
-    int co_flags;		/* CO_..., see below */
-    int co_firstlineno;   /* first source line number */
-    PyObject *co_code;		/* instruction opcodes */
-    PyObject *co_consts;	/* list (constants used) */
-    PyObject *co_names;		/* list of strings (names used) */
-    PyObject *co_varnames;	/* tuple of strings (local variable names) */
-    PyObject *co_freevars;	/* tuple of strings (free variable names) */
+    int co_argcount;            /* #arguments, except *args */
+    int co_kwonlyargcount;      /* #keyword only arguments */
+    int co_nlocals;             /* #local variables */
+    int co_stacksize;           /* #entries needed for evaluation stack */
+    int co_flags;               /* CO_..., see below */
+    int co_firstlineno;         /* first source line number */
+    PyObject *co_code;          /* instruction opcodes */
+    PyObject *co_consts;        /* list (constants used) */
+    PyObject *co_names;         /* list of strings (names used) */
+    PyObject *co_varnames;      /* tuple of strings (local variable names) */
+    PyObject *co_freevars;      /* tuple of strings (free variable names) */
     PyObject *co_cellvars;      /* tuple of strings (cell variable names) */
     /* The rest aren't used in either hash or comparisons, except for co_name,
        used in both. This is done to preserve the name and line number
@@ -38,11 +38,11 @@ typedef struct {
        would collapse identical functions/lambdas defined on different lines.
     */
     Py_ssize_t *co_cell2arg;    /* Maps cell vars which are arguments. */
-    PyObject *co_filename;	/* unicode (where it was loaded from) */
-    PyObject *co_name;		/* unicode (name, for reference) */
-    PyObject *co_lnotab;	/* string (encoding addr<->lineno mapping) See
-				   Objects/lnotab_notes.txt for details. */
-    void *co_zombieframe;     /* for optimization only (see frameobject.c) */
+    PyObject *co_filename;      /* unicode (where it was loaded from) */
+    PyObject *co_name;          /* unicode (name, for reference) */
+    PyObject *co_lnotab;        /* string (encoding addr<->lineno mapping) See
+                                   Objects/lnotab_notes.txt for details. */
+    void *co_zombieframe;       /* for optimization only (see frameobject.c) */
     PyObject *co_weakreflist;   /* to support weakrefs to code objects */
     /* Scratch space for extra data relating to the code object.
        Type is a void* to keep the format private in codeobject.c to force
@@ -51,10 +51,10 @@ typedef struct {
 } PyCodeObject;
 
 /* Masks for co_flags above */
-#define CO_OPTIMIZED	0x0001
-#define CO_NEWLOCALS	0x0002
-#define CO_VARARGS	0x0004
-#define CO_VARKEYWORDS	0x0008
+#define CO_OPTIMIZED    0x0001
+#define CO_NEWLOCALS    0x0002
+#define CO_VARARGS      0x0004
+#define CO_VARKEYWORDS  0x0008
 #define CO_NESTED       0x0010
 #define CO_GENERATOR    0x0020
 /* The CO_NOFREE flag is set if there are no free or cell variables.
@@ -74,7 +74,7 @@ typedef struct {
 #if 0
 #define CO_GENERATOR_ALLOWED    0x1000
 #endif
-#define CO_FUTURE_DIVISION    	0x2000
+#define CO_FUTURE_DIVISION      0x2000
 #define CO_FUTURE_ABSOLUTE_IMPORT 0x4000 /* do absolute imports by default */
 #define CO_FUTURE_WITH_STATEMENT  0x8000
 #define CO_FUTURE_PRINT_FUNCTION  0x10000
@@ -101,9 +101,9 @@ PyAPI_DATA(PyTypeObject) PyCode_Type;
 
 /* Public interface */
 PyAPI_FUNC(PyCodeObject *) PyCode_New(
-	int, int, int, int, int, PyObject *, PyObject *,
-	PyObject *, PyObject *, PyObject *, PyObject *,
-	PyObject *, PyObject *, int, PyObject *);
+        int, int, int, int, int, PyObject *, PyObject *,
+        PyObject *, PyObject *, PyObject *, PyObject *,
+        PyObject *, PyObject *, int, PyObject *);
         /* same as struct above */
 
 /* Creates a new empty code object with the specified source location. */

--- a/Include/errcode.h
+++ b/Include/errcode.h
@@ -13,24 +13,24 @@ extern "C" {
    the parser only returns E_EOF when it hits EOF immediately, and it
    never returns E_OK. */
 
-#define E_OK		10	/* No error */
-#define E_EOF		11	/* End Of File */
-#define E_INTR		12	/* Interrupted */
-#define E_TOKEN		13	/* Bad token */
-#define E_SYNTAX	14	/* Syntax error */
-#define E_NOMEM		15	/* Ran out of memory */
-#define E_DONE		16	/* Parsing complete */
-#define E_ERROR		17	/* Execution error */
-#define E_TABSPACE	18	/* Inconsistent mixing of tabs and spaces */
-#define E_OVERFLOW      19	/* Node had too many children */
-#define E_TOODEEP	20	/* Too many indentation levels */
-#define E_DEDENT	21	/* No matching outer block for dedent */
-#define E_DECODE	22	/* Error in decoding into Unicode */
-#define E_EOFS		23	/* EOF in triple-quoted string */
-#define E_EOLS		24	/* EOL in single-quoted string */
-#define E_LINECONT	25	/* Unexpected characters after a line continuation */
+#define E_OK            10      /* No error */
+#define E_EOF           11      /* End Of File */
+#define E_INTR          12      /* Interrupted */
+#define E_TOKEN         13      /* Bad token */
+#define E_SYNTAX        14      /* Syntax error */
+#define E_NOMEM         15      /* Ran out of memory */
+#define E_DONE          16      /* Parsing complete */
+#define E_ERROR         17      /* Execution error */
+#define E_TABSPACE      18      /* Inconsistent mixing of tabs and spaces */
+#define E_OVERFLOW      19      /* Node had too many children */
+#define E_TOODEEP       20      /* Too many indentation levels */
+#define E_DEDENT        21      /* No matching outer block for dedent */
+#define E_DECODE        22      /* Error in decoding into Unicode */
+#define E_EOFS          23      /* EOF in triple-quoted string */
+#define E_EOLS          24      /* EOL in single-quoted string */
+#define E_LINECONT      25      /* Unexpected characters after a line continuation */
 #define E_IDENTIFIER    26      /* Invalid characters in identifier */
-#define E_BADSINGLE	27	/* Ill-formed single statement input */
+#define E_BADSINGLE     27      /* Ill-formed single statement input */
 
 #ifdef __cplusplus
 }

--- a/Include/funcobject.h
+++ b/Include/funcobject.h
@@ -20,17 +20,17 @@ extern "C" {
 
 typedef struct {
     PyObject_HEAD
-    PyObject *func_code;	/* A code object, the __code__ attribute */
-    PyObject *func_globals;	/* A dictionary (other mappings won't do) */
-    PyObject *func_defaults;	/* NULL or a tuple */
-    PyObject *func_kwdefaults;	/* NULL or a dict */
-    PyObject *func_closure;	/* NULL or a tuple of cell objects */
-    PyObject *func_doc;		/* The __doc__ attribute, can be anything */
-    PyObject *func_name;	/* The __name__ attribute, a string object */
-    PyObject *func_dict;	/* The __dict__ attribute, a dict or NULL */
-    PyObject *func_weakreflist;	/* List of weak references */
-    PyObject *func_module;	/* The __module__ attribute, can be anything */
-    PyObject *func_annotations;	/* Annotations, a dict or NULL */
+    PyObject *func_code;        /* A code object, the __code__ attribute */
+    PyObject *func_globals;     /* A dictionary (other mappings won't do) */
+    PyObject *func_defaults;    /* NULL or a tuple */
+    PyObject *func_kwdefaults;  /* NULL or a dict */
+    PyObject *func_closure;     /* NULL or a tuple of cell objects */
+    PyObject *func_doc;         /* The __doc__ attribute, can be anything */
+    PyObject *func_name;        /* The __name__ attribute, a string object */
+    PyObject *func_dict;        /* The __dict__ attribute, a dict or NULL */
+    PyObject *func_weakreflist; /* List of weak references */
+    PyObject *func_module;      /* The __module__ attribute, can be anything */
+    PyObject *func_annotations; /* Annotations, a dict or NULL */
     PyObject *func_qualname;    /* The qualified name */
 
     /* Invariant:
@@ -77,17 +77,17 @@ PyAPI_FUNC(PyObject *) _PyFunction_FastCallKeywords(
 #define PyFunction_GET_CODE(func) \
         (((PyFunctionObject *)func) -> func_code)
 #define PyFunction_GET_GLOBALS(func) \
-	(((PyFunctionObject *)func) -> func_globals)
+        (((PyFunctionObject *)func) -> func_globals)
 #define PyFunction_GET_MODULE(func) \
-	(((PyFunctionObject *)func) -> func_module)
+        (((PyFunctionObject *)func) -> func_module)
 #define PyFunction_GET_DEFAULTS(func) \
-	(((PyFunctionObject *)func) -> func_defaults)
+        (((PyFunctionObject *)func) -> func_defaults)
 #define PyFunction_GET_KW_DEFAULTS(func) \
-	(((PyFunctionObject *)func) -> func_kwdefaults)
+        (((PyFunctionObject *)func) -> func_kwdefaults)
 #define PyFunction_GET_CLOSURE(func) \
-	(((PyFunctionObject *)func) -> func_closure)
+        (((PyFunctionObject *)func) -> func_closure)
 #define PyFunction_GET_ANNOTATIONS(func) \
-	(((PyFunctionObject *)func) -> func_annotations)
+        (((PyFunctionObject *)func) -> func_annotations)
 
 /* The classmethod and staticmethod types lives here, too */
 PyAPI_DATA(PyTypeObject) PyClassMethod_Type;

--- a/Include/grammar.h
+++ b/Include/grammar.h
@@ -12,58 +12,58 @@ extern "C" {
 /* A label of an arc */
 
 typedef struct {
-    int		 lb_type;
-    char	*lb_str;
+    int          lb_type;
+    char        *lb_str;
 } label;
 
-#define EMPTY 0		/* Label number 0 is by definition the empty label */
+#define EMPTY 0         /* Label number 0 is by definition the empty label */
 
 /* A list of labels */
 
 typedef struct {
-    int		 ll_nlabels;
-    label	*ll_label;
+    int          ll_nlabels;
+    label       *ll_label;
 } labellist;
 
 /* An arc from one state to another */
 
 typedef struct {
-    short	a_lbl;		/* Label of this arc */
-    short	a_arrow;	/* State where this arc goes to */
+    short       a_lbl;          /* Label of this arc */
+    short       a_arrow;        /* State where this arc goes to */
 } arc;
 
 /* A state in a DFA */
 
 typedef struct {
-    int		 s_narcs;
-    arc		*s_arc;		/* Array of arcs */
+    int          s_narcs;
+    arc         *s_arc;         /* Array of arcs */
 
     /* Optional accelerators */
-    int		 s_lower;	/* Lowest label index */
-    int		 s_upper;	/* Highest label index */
-    int		*s_accel;	/* Accelerator */
-    int		 s_accept;	/* Nonzero for accepting state */
+    int          s_lower;       /* Lowest label index */
+    int          s_upper;       /* Highest label index */
+    int         *s_accel;       /* Accelerator */
+    int          s_accept;      /* Nonzero for accepting state */
 } state;
 
 /* A DFA */
 
 typedef struct {
-    int		 d_type;	/* Non-terminal this represents */
-    char	*d_name;	/* For printing */
-    int		 d_initial;	/* Initial state */
-    int		 d_nstates;
-    state	*d_state;	/* Array of states */
-    bitset	 d_first;
+    int          d_type;        /* Non-terminal this represents */
+    char        *d_name;        /* For printing */
+    int          d_initial;     /* Initial state */
+    int          d_nstates;
+    state       *d_state;       /* Array of states */
+    bitset       d_first;
 } dfa;
 
 /* A grammar */
 
 typedef struct {
-    int		 g_ndfas;
-    dfa		*g_dfa;		/* Array of DFAs */
-    labellist	 g_ll;
-    int		 g_start;	/* Start symbol of the grammar */
-    int		 g_accel;	/* Set if accelerators present */
+    int          g_ndfas;
+    dfa         *g_dfa;         /* Array of DFAs */
+    labellist    g_ll;
+    int          g_start;       /* Start symbol of the grammar */
+    int          g_accel;       /* Set if accelerators present */
 } grammar;
 
 /* FUNCTIONS */

--- a/Include/longintrepr.h
+++ b/Include/longintrepr.h
@@ -46,22 +46,22 @@ typedef uint32_t digit;
 typedef int32_t sdigit; /* signed variant of digit */
 typedef uint64_t twodigits;
 typedef int64_t stwodigits; /* signed variant of twodigits */
-#define PyLong_SHIFT	30
-#define _PyLong_DECIMAL_SHIFT	9 /* max(e such that 10**e fits in a digit) */
-#define _PyLong_DECIMAL_BASE	((digit)1000000000) /* 10 ** DECIMAL_SHIFT */
+#define PyLong_SHIFT    30
+#define _PyLong_DECIMAL_SHIFT   9 /* max(e such that 10**e fits in a digit) */
+#define _PyLong_DECIMAL_BASE    ((digit)1000000000) /* 10 ** DECIMAL_SHIFT */
 #elif PYLONG_BITS_IN_DIGIT == 15
 typedef unsigned short digit;
 typedef short sdigit; /* signed variant of digit */
 typedef unsigned long twodigits;
 typedef long stwodigits; /* signed variant of twodigits */
-#define PyLong_SHIFT	15
-#define _PyLong_DECIMAL_SHIFT	4 /* max(e such that 10**e fits in a digit) */
-#define _PyLong_DECIMAL_BASE	((digit)10000) /* 10 ** DECIMAL_SHIFT */
+#define PyLong_SHIFT    15
+#define _PyLong_DECIMAL_SHIFT   4 /* max(e such that 10**e fits in a digit) */
+#define _PyLong_DECIMAL_BASE    ((digit)10000) /* 10 ** DECIMAL_SHIFT */
 #else
 #error "PYLONG_BITS_IN_DIGIT should be 15 or 30"
 #endif
-#define PyLong_BASE	((digit)1 << PyLong_SHIFT)
-#define PyLong_MASK	((digit)(PyLong_BASE - 1))
+#define PyLong_BASE     ((digit)1 << PyLong_SHIFT)
+#define PyLong_MASK     ((digit)(PyLong_BASE - 1))
 
 #if PyLong_SHIFT % 5 != 0
 #error "longobject.c requires that PyLong_SHIFT be divisible by 5"
@@ -69,12 +69,12 @@ typedef long stwodigits; /* signed variant of twodigits */
 
 /* Long integer representation.
    The absolute value of a number is equal to
-   	SUM(for i=0 through abs(ob_size)-1) ob_digit[i] * 2**(SHIFT*i)
+        SUM(for i=0 through abs(ob_size)-1) ob_digit[i] * 2**(SHIFT*i)
    Negative numbers are represented with ob_size < 0;
    zero is represented by ob_size == 0.
    In a normalized number, ob_digit[abs(ob_size)-1] (the most significant
    digit) is never zero.  Also, in all cases, for all valid i,
-   	0 <= ob_digit[i] <= MASK.
+        0 <= ob_digit[i] <= MASK.
    The allocation function takes care of allocating extra memory
    so that ob_digit[0] ... ob_digit[abs(ob_size)-1] are actually available.
 
@@ -83,8 +83,8 @@ typedef long stwodigits; /* signed variant of twodigits */
 */
 
 struct _longobject {
-	PyObject_VAR_HEAD
-	digit ob_digit[1];
+    PyObject_VAR_HEAD
+    digit ob_digit[1];
 };
 
 PyAPI_FUNC(PyLongObject *) _PyLong_New(Py_ssize_t);

--- a/Include/node.h
+++ b/Include/node.h
@@ -8,12 +8,12 @@ extern "C" {
 #endif
 
 typedef struct _node {
-    short		n_type;
-    char		*n_str;
-    int			n_lineno;
-    int			n_col_offset;
-    int			n_nchildren;
-    struct _node	*n_child;
+    short               n_type;
+    char                *n_str;
+    int                 n_lineno;
+    int                 n_col_offset;
+    int                 n_nchildren;
+    struct _node        *n_child;
 } node;
 
 PyAPI_FUNC(node *) PyNode_New(int type);
@@ -25,12 +25,12 @@ PyAPI_FUNC(Py_ssize_t) _PyNode_SizeOf(node *n);
 #endif
 
 /* Node access functions */
-#define NCH(n)		((n)->n_nchildren)
+#define NCH(n)          ((n)->n_nchildren)
 
-#define CHILD(n, i)	(&(n)->n_child[i])
-#define RCHILD(n, i)	(CHILD(n, NCH(n) + i))
-#define TYPE(n)		((n)->n_type)
-#define STR(n)		((n)->n_str)
+#define CHILD(n, i)     (&(n)->n_child[i])
+#define RCHILD(n, i)    (CHILD(n, NCH(n) + i))
+#define TYPE(n)         ((n)->n_type)
+#define STR(n)          ((n)->n_str)
 #define LINENO(n)       ((n)->n_lineno)
 
 /* Assert that the type of a node is what we expect */

--- a/Include/parsetok.h
+++ b/Include/parsetok.h
@@ -21,13 +21,13 @@ typedef struct {
 } perrdetail;
 
 #if 0
-#define PyPARSE_YIELD_IS_KEYWORD	0x0001
+#define PyPARSE_YIELD_IS_KEYWORD        0x0001
 #endif
 
-#define PyPARSE_DONT_IMPLY_DEDENT	0x0002
+#define PyPARSE_DONT_IMPLY_DEDENT       0x0002
 
 #if 0
-#define PyPARSE_WITH_IS_KEYWORD		0x0003
+#define PyPARSE_WITH_IS_KEYWORD         0x0003
 #define PyPARSE_PRINT_IS_FUNCTION       0x0004
 #define PyPARSE_UNICODE_LITERALS        0x0008
 #endif

--- a/Include/patchlevel.h
+++ b/Include/patchlevel.h
@@ -8,28 +8,28 @@
 */
 
 /* Values for PY_RELEASE_LEVEL */
-#define PY_RELEASE_LEVEL_ALPHA	0xA
-#define PY_RELEASE_LEVEL_BETA	0xB
-#define PY_RELEASE_LEVEL_GAMMA	0xC     /* For release candidates */
-#define PY_RELEASE_LEVEL_FINAL	0xF	/* Serial should be 0 here */
-					/* Higher for patch releases */
+#define PY_RELEASE_LEVEL_ALPHA  0xA
+#define PY_RELEASE_LEVEL_BETA   0xB
+#define PY_RELEASE_LEVEL_GAMMA  0xC     /* For release candidates */
+#define PY_RELEASE_LEVEL_FINAL  0xF     /* Serial should be 0 here */
+                                        /* Higher for patch releases */
 
 /* Version parsed out into numeric values */
 /*--start constants--*/
-#define PY_MAJOR_VERSION	3
-#define PY_MINOR_VERSION	7
-#define PY_MICRO_VERSION	0
-#define PY_RELEASE_LEVEL	PY_RELEASE_LEVEL_ALPHA
-#define PY_RELEASE_SERIAL	2
+#define PY_MAJOR_VERSION        3
+#define PY_MINOR_VERSION        7
+#define PY_MICRO_VERSION        0
+#define PY_RELEASE_LEVEL        PY_RELEASE_LEVEL_ALPHA
+#define PY_RELEASE_SERIAL       2
 
 /* Version as a string */
-#define PY_VERSION      	"3.7.0a2+"
+#define PY_VERSION              "3.7.0a2+"
 /*--end constants--*/
 
 /* Version as a single 4-byte hex number, e.g. 0x010502B2 == 1.5.2b2.
    Use this for numeric comparisons, e.g. #if PY_VERSION_HEX >= ... */
 #define PY_VERSION_HEX ((PY_MAJOR_VERSION << 24) | \
-			(PY_MINOR_VERSION << 16) | \
-			(PY_MICRO_VERSION <<  8) | \
-			(PY_RELEASE_LEVEL <<  4) | \
-			(PY_RELEASE_SERIAL << 0))
+                        (PY_MINOR_VERSION << 16) | \
+                        (PY_MICRO_VERSION <<  8) | \
+                        (PY_RELEASE_LEVEL <<  4) | \
+                        (PY_RELEASE_SERIAL << 0))

--- a/Include/pgenheaders.h
+++ b/Include/pgenheaders.h
@@ -10,9 +10,9 @@ extern "C" {
 #include "Python.h"
 
 PyAPI_FUNC(void) PySys_WriteStdout(const char *format, ...)
-			Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
+                        Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
 PyAPI_FUNC(void) PySys_WriteStderr(const char *format, ...)
-			Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
+                        Py_GCC_ATTRIBUTE((format(printf, 1, 2)));
 
 #define addarc _Py_addarc
 #define addbit _Py_addbit

--- a/Include/pyfpe.h
+++ b/Include/pyfpe.h
@@ -135,9 +135,9 @@ extern double PyFPE_dummy(void *);
 
 #define PyFPE_START_PROTECT(err_string, leave_stmt) \
 if (!PyFPE_counter++ && setjmp(PyFPE_jbuf)) { \
-	PyErr_SetString(PyExc_FloatingPointError, err_string); \
-	PyFPE_counter = 0; \
-	leave_stmt; \
+        PyErr_SetString(PyExc_FloatingPointError, err_string); \
+        PyFPE_counter = 0; \
+        leave_stmt; \
 }
 
 /*

--- a/Include/sliceobject.h
+++ b/Include/sliceobject.h
@@ -21,7 +21,7 @@ let these be any arbitrary python type.  Py_None stands for omitted values.
 #ifndef Py_LIMITED_API
 typedef struct {
     PyObject_HEAD
-    PyObject *start, *stop, *step;	/* not NULL */
+    PyObject *start, *stop, *step;      /* not NULL */
 } PySliceObject;
 #endif
 

--- a/Mac/PythonLauncher/FileSettings.h
+++ b/Mac/PythonLauncher/FileSettings.h
@@ -24,18 +24,18 @@
 
 @interface FileSettings : NSObject <FileSettingsSource>
 {
-    NSString *interpreter;	// The pathname of the interpreter to use
-    NSArray *interpreters;	// List of known interpreters
-    BOOL honourhashbang;	// #! line overrides interpreter
-    BOOL debug;			// -d option: debug parser
-    BOOL verbose;		// -v option: verbose import
-    BOOL inspect;		// -i option: interactive mode after script
-    BOOL optimize;		// -O option: optimize bytecode
-    BOOL nosite;		// -S option: don't import site.py
-    BOOL tabs;			// -t option: warn about inconsistent tabs
-    NSString *others;		// other options
-    NSString *scriptargs;	// script arguments (not for preferences)
-    BOOL with_terminal;		// Run in terminal window
+    NSString *interpreter;      // The pathname of the interpreter to use
+    NSArray *interpreters;      // List of known interpreters
+    BOOL honourhashbang;        // #! line overrides interpreter
+    BOOL debug;                 // -d option: debug parser
+    BOOL verbose;               // -v option: verbose import
+    BOOL inspect;               // -i option: interactive mode after script
+    BOOL optimize;              // -O option: optimize bytecode
+    BOOL nosite;                // -S option: don't import site.py
+    BOOL tabs;                  // -t option: warn about inconsistent tabs
+    NSString *others;           // other options
+    NSString *scriptargs;       // script arguments (not for preferences)
+    BOOL with_terminal;         // Run in terminal window
 
     FileSettings *origsource;
     NSString *prefskey;

--- a/Mac/PythonLauncher/MyAppDelegate.h
+++ b/Mac/PythonLauncher/MyAppDelegate.h
@@ -4,8 +4,8 @@
 
 @interface MyAppDelegate : NSObject
 {
-    BOOL	initial_action_done;
-    BOOL	should_terminate;
+    BOOL        initial_action_done;
+    BOOL        should_terminate;
 }
 - (id)init;
 - (IBAction)showPreferences:(id)sender;

--- a/Modules/_weakref.c
+++ b/Modules/_weakref.c
@@ -138,15 +138,15 @@ weakref_functions[] =  {
 
 
 static struct PyModuleDef weakrefmodule = {
-	PyModuleDef_HEAD_INIT,
-	"_weakref",
-	"Weak-reference support module.",
-	-1,
-	weakref_functions,
-	NULL,
-	NULL,
-	NULL,
-	NULL
+    PyModuleDef_HEAD_INIT,
+    "_weakref",
+    "Weak-reference support module.",
+    -1,
+    weakref_functions,
+    NULL,
+    NULL,
+    NULL,
+    NULL
 };
 
 PyMODINIT_FUNC

--- a/Modules/rotatingtree.h
+++ b/Modules/rotatingtree.h
@@ -16,12 +16,12 @@ typedef struct rotating_node_s rotating_node_t;
 typedef int (*rotating_tree_enum_fn) (rotating_node_t *node, void *arg);
 
 struct rotating_node_s {
-	void *key;
-	rotating_node_t *left;
-	rotating_node_t *right;
+    void *key;
+    rotating_node_t *left;
+    rotating_node_t *right;
 };
 
 void RotatingTree_Add(rotating_node_t **root, rotating_node_t *node);
 rotating_node_t* RotatingTree_Get(rotating_node_t **root, void *key);
 int RotatingTree_Enum(rotating_node_t *root, rotating_tree_enum_fn enumfn,
-		      void *arg);
+                      void *arg);

--- a/Parser/parser.h
+++ b/Parser/parser.h
@@ -10,23 +10,23 @@ extern "C" {
 #define MAXSTACK 1500
 
 typedef struct {
-	int		 s_state;	/* State in current DFA */
-	dfa		*s_dfa;		/* Current DFA */
-	struct _node	*s_parent;	/* Where to add next node */
+    int              s_state;       /* State in current DFA */
+    dfa             *s_dfa;         /* Current DFA */
+    struct _node    *s_parent;      /* Where to add next node */
 } stackentry;
 
 typedef struct {
-	stackentry	*s_top;		/* Top entry */
-	stackentry	 s_base[MAXSTACK];/* Array of stack entries */
-					/* NB The stack grows down */
+    stackentry      *s_top;         /* Top entry */
+    stackentry       s_base[MAXSTACK];/* Array of stack entries */
+                                    /* NB The stack grows down */
 } stack;
 
 typedef struct {
-	stack	 	p_stack;	/* Stack of parser states */
-	grammar		*p_grammar;	/* Grammar to use */
-	node		*p_tree;	/* Top of parse tree */
+    stack           p_stack;        /* Stack of parser states */
+    grammar         *p_grammar;     /* Grammar to use */
+    node            *p_tree;        /* Top of parse tree */
 #ifdef PY_PARSER_REQUIRES_FUTURE_KEYWORD
-	unsigned long	p_flags;	/* see co_flags in Include/code.h */
+    unsigned long   p_flags;        /* see co_flags in Include/code.h */
 #endif
 } parser_state;
 

--- a/Python/dup2.c
+++ b/Python/dup2.c
@@ -19,13 +19,13 @@
 int
 dup2(int fd1, int fd2)
 {
-	if (fd1 != fd2) {
-		if (fcntl(fd1, F_GETFL) < 0)
-			return BADEXIT;
-		if (fcntl(fd2, F_GETFL) >= 0)
-			close(fd2);
-		if (fcntl(fd1, F_DUPFD, fd2) < 0)
-			return BADEXIT;
-	}
-	return fd2;
+    if (fd1 != fd2) {
+        if (fcntl(fd1, F_GETFL) < 0)
+            return BADEXIT;
+        if (fcntl(fd2, F_GETFL) >= 0)
+            close(fd2);
+        if (fcntl(fd1, F_DUPFD, fd2) < 0)
+            return BADEXIT;
+    }
+    return fd2;
 }

--- a/Python/getplatform.c
+++ b/Python/getplatform.c
@@ -8,5 +8,5 @@
 const char *
 Py_GetPlatform(void)
 {
-	return PLATFORM;
+    return PLATFORM;
 }

--- a/Python/getversion.c
+++ b/Python/getversion.c
@@ -8,8 +8,8 @@
 const char *
 Py_GetVersion(void)
 {
-	static char version[250];
-	PyOS_snprintf(version, sizeof(version), "%.80s (%.80s) %.80s",
-		      PY_VERSION, Py_GetBuildInfo(), Py_GetCompiler());
-	return version;
+    static char version[250];
+    PyOS_snprintf(version, sizeof(version), "%.80s (%.80s) %.80s",
+                  PY_VERSION, Py_GetBuildInfo(), Py_GetCompiler());
+    return version;
 }

--- a/Python/pyfpe.c
+++ b/Python/pyfpe.c
@@ -19,5 +19,5 @@ int PyFPE_counter = 0;
 double
 PyFPE_dummy(void *dummy)
 {
-	return 1.0;
+    return 1.0;
 }

--- a/Python/pystrhex.c
+++ b/Python/pystrhex.c
@@ -16,14 +16,14 @@ static PyObject *_Py_strhex_impl(const char* argbuf, const Py_ssize_t arglen,
     if (return_bytes) {
         /* If _PyBytes_FromSize() were public we could avoid malloc+copy. */
         retbuf = (Py_UCS1*) PyMem_Malloc(arglen*2);
-	if (!retbuf)
-	    return PyErr_NoMemory();
+        if (!retbuf)
+            return PyErr_NoMemory();
         retval = NULL;  /* silence a compiler warning, assigned later. */
     } else {
-	retval = PyUnicode_New(arglen*2, 127);
-	if (!retval)
-	    return NULL;
-	retbuf = PyUnicode_1BYTE_DATA(retval);
+        retval = PyUnicode_New(arglen*2, 127);
+        if (!retval)
+            return NULL;
+        retbuf = PyUnicode_1BYTE_DATA(retval);
     }
 
     /* make hex version of string, taken from shamodule.c */

--- a/Python/strdup.c
+++ b/Python/strdup.c
@@ -5,10 +5,10 @@
 char *
 strdup(const char *str)
 {
-	if (str != NULL) {
-		char *copy = malloc(strlen(str) + 1);
-		if (copy != NULL)
-			return strcpy(copy, str);
-	}
-	return NULL;
+    if (str != NULL) {
+        char *copy = malloc(strlen(str) + 1);
+        if (copy != NULL)
+            return strcpy(copy, str);
+    }
+    return NULL;
 }


### PR DESCRIPTION
Tabs in C files add a noise in the diff if the committer uses an editor which don't preserve tabs (see for example #4390). This can hide semantic changes in tab expansion changes. It is better to expand all tabs to spaces in the single commit that doesn't do anything other.

<!-- issue-number: bpo-32150 -->
https://bugs.python.org/issue32150
<!-- /issue-number -->
