### PR TITLE
bpo-32089: Use default action for ResourceWarning

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -532,26 +532,26 @@ class CmdLineTest(unittest.TestCase):
         out = self.run_xdev("-c", code)
         self.assertEqual(out,
                          "ignore::BytesWarning "
-                         "always::ResourceWarning "
+                         "default::ResourceWarning "
                          "default::Warning")
 
         out = self.run_xdev("-b", "-c", code)
         self.assertEqual(out,
                          "default::BytesWarning "
-                         "always::ResourceWarning "
+                         "default::ResourceWarning "
                          "default::Warning")
 
         out = self.run_xdev("-bb", "-c", code)
         self.assertEqual(out,
                          "error::BytesWarning "
-                         "always::ResourceWarning "
+                         "default::ResourceWarning "
                          "default::Warning")
 
         out = self.run_xdev("-Werror", "-c", code)
         self.assertEqual(out,
                          "error::Warning "
                          "ignore::BytesWarning "
-                         "always::ResourceWarning "
+                         "default::ResourceWarning "
                          "default::Warning")
 
         try:
@@ -572,19 +572,6 @@ class CmdLineTest(unittest.TestCase):
             code = "import faulthandler; print(faulthandler.is_enabled())"
             out = self.run_xdev("-c", code)
             self.assertEqual(out, "True")
-
-        # Make sure that ResourceWarning emitted twice at the same line number
-        # is logged twice
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
-        with open(filename, "w", encoding="utf8") as fp:
-            print("def func(): open(__file__)", file=fp)
-            print("func()", file=fp)
-            print("func()", file=fp)
-            fp.flush()
-
-        out = self.run_xdev(filename)
-        self.assertEqual(out.count(':1: ResourceWarning: '), 2, out)
 
 
 class IgnoreEnvironmentTest(unittest.TestCase):

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -540,7 +540,7 @@ if not _warnings_defaults:
 
     # resource usage warnings are enabled by default in pydebug mode
     if dev_mode or py_debug:
-        resource_action = "always"
+        resource_action = "default"
     else:
         resource_action = "ignore"
     simplefilter(resource_action, category=ResourceWarning, append=1)

--- a/Misc/NEWS.d/next/Library/2017-11-27-11-29-34.bpo-32089.6ydDYv.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-27-11-29-34.bpo-32089.6ydDYv.rst
@@ -1,0 +1,3 @@
+warnings: In development (-X dev) and debug mode (pydebug build), use the
+"default" action for ResourceWarning, rather than the "always" action, in
+the default warnings filters.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -13,7 +13,6 @@ _Py_IDENTIFIER(argv);
 _Py_IDENTIFIER(stderr);
 _Py_IDENTIFIER(ignore);
 _Py_IDENTIFIER(error);
-_Py_IDENTIFIER(always);
 _Py_static_string(PyId_default, "default");
 
 static int
@@ -1208,9 +1207,9 @@ init_filters(const _PyCoreConfig *config)
     _Py_Identifier *resource_action;
     /* resource usage warnings are enabled by default in pydebug mode */
 #ifdef Py_DEBUG
-    resource_action = &PyId_always;
+    resource_action = &PyId_default;
 #else
-    resource_action = (dev_mode ? &PyId_always : &PyId_ignore);
+    resource_action = (dev_mode ? &PyId_default: &PyId_ignore);
 #endif
     PyList_SET_ITEM(filters, pos++, create_filter(PyExc_ResourceWarning,
                     resource_action));


### PR DESCRIPTION
In development and debug mode, use the "default" action, rather than
the "always" action, for ResourceWarning in the default warnings
filters.

<!-- issue-number: bpo-32089 -->
https://bugs.python.org/issue32089
<!-- /issue-number -->
