### PR TITLE
[3.6] bpo-32107 - Backport bitmask check fix (GH-4576)

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -438,23 +438,12 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 
         self.assertEqual(mac, 0x1234567890ab)
 
-    def check_node(self, node, requires=None, check_bit=True):
+    def check_node(self, node, requires=None):
         if requires and node is None:
             self.skipTest('requires ' + requires)
         hex = '%012x' % node
         if support.verbose >= 2:
             print(hex, end=' ')
-        # The MAC address will be universally administered (i.e. the second
-        # least significant bit of the first octet must be unset) for any
-        # physical interface, such as an ethernet port or wireless adapter.
-        # There are some cases where this won't be the case.  Randomly
-        # generated MACs may not be universally administered, but they must
-        # have their multicast bit set, though this is tested in the
-        # `test_random_getnode()` method specifically.  Another case is the
-        # Travis-CI case, which apparently only has locally administered MAC
-        # addresses.
-        if check_bit and not os.getenv('TRAVIS'):
-            self.assertFalse(node & (1 << 41), '%012x' % node)
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
 
@@ -500,7 +489,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         # must be set for randomly generated MAC addresses.  See RFC 4122,
         # $4.1.6.
         self.assertTrue(node & (1 << 40), '%012x' % node)
-        self.check_node(node, check_bit=False)
+        self.check_node(node)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
@@ -509,13 +498,13 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
             node = uuid._unixdll_getnode()
         except TypeError:
             self.skipTest('requires uuid_generate_time')
-        self.check_node(node, check_bit=False)
+        self.check_node(node)
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
     def test_windll_getnode(self):
         node = uuid._windll_getnode()
-        self.check_node(node, check_bit=False)
+        self.check_node(node)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -438,60 +438,69 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 
         self.assertEqual(mac, 0x1234567890ab)
 
-    def check_node(self, node, requires=None, network=False):
+    def check_node(self, node, requires=None, check_bit=True):
         if requires and node is None:
             self.skipTest('requires ' + requires)
         hex = '%012x' % node
         if support.verbose >= 2:
             print(hex, end=' ')
-        if network:
-            # 47 bit will never be set in IEEE 802 addresses obtained
-            # from network cards.
-            self.assertFalse(node & 0x010000000000, hex)
+        # The MAC address will be universally administered (i.e. the second
+        # least significant bit of the first octet must be unset) for any
+        # physical interface, such as an ethernet port or wireless adapter.
+        # There are some cases where this won't be the case.  Randomly
+        # generated MACs may not be universally administered, but they must
+        # have their multicast bit set, though this is tested in the
+        # `test_random_getnode()` method specifically.  Another case is the
+        # Travis-CI case, which apparently only has locally administered MAC
+        # addresses.
+        if check_bit and not os.getenv('TRAVIS'):
+            self.assertFalse(node & (1 << 41), '%012x' % node)
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_ifconfig_getnode(self):
         node = uuid._ifconfig_getnode()
-        self.check_node(node, 'ifconfig', True)
+        self.check_node(node, 'ifconfig')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_ip_getnode(self):
         node = uuid._ip_getnode()
-        self.check_node(node, 'ip', True)
+        self.check_node(node, 'ip')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_arp_getnode(self):
         node = uuid._arp_getnode()
-        self.check_node(node, 'arp', True)
+        self.check_node(node, 'arp')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_lanscan_getnode(self):
         node = uuid._lanscan_getnode()
-        self.check_node(node, 'lanscan', True)
+        self.check_node(node, 'lanscan')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_netstat_getnode(self):
         node = uuid._netstat_getnode()
-        self.check_node(node, 'netstat', True)
+        self.check_node(node, 'netstat')
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     def test_ipconfig_getnode(self):
         node = uuid._ipconfig_getnode()
-        self.check_node(node, 'ipconfig', True)
+        self.check_node(node, 'ipconfig')
 
     @unittest.skipUnless(importable('win32wnet'), 'requires win32wnet')
     @unittest.skipUnless(importable('netbios'), 'requires netbios')
     def test_netbios_getnode(self):
         node = uuid._netbios_getnode()
-        self.check_node(node, network=True)
+        self.check_node(node)
 
     def test_random_getnode(self):
         node = uuid._random_getnode()
-        # Least significant bit of first octet must be set.
-        self.assertTrue(node & 0x010000000000, '%012x' % node)
-        self.check_node(node)
+        # The multicast bit, i.e. the least significant bit of first octet,
+        # must be set for randomly generated MAC addresses.  See RFC 4122,
+        # $4.1.6.
+        self.assertTrue(node & (1 << 40), '%012x' % node)
+        self.check_node(node, check_bit=False)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
@@ -500,13 +509,13 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
             node = uuid._unixdll_getnode()
         except TypeError:
             self.skipTest('requires uuid_generate_time')
-        self.check_node(node)
+        self.check_node(node, check_bit=False)
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
     def test_windll_getnode(self):
         node = uuid._windll_getnode()
-        self.check_node(node)
+        self.check_node(node, check_bit=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION


<!-- issue-number: bpo-32107 -->
https://bugs.python.org/issue32107
<!-- /issue-number -->
