### PR TITLE
asyncio: use directly socket.socketpair()

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -446,9 +446,6 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
     def sock_accept(self, sock):
         return self._proactor.accept(sock)
 
-    def _socketpair(self):
-        raise NotImplementedError
-
     def _close_self_pipe(self):
         if self._self_reading_future is not None:
             self._self_reading_future.cancel()
@@ -461,7 +458,7 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
 
     def _make_self_pipe(self):
         # A self-socket, really. :-)
-        self._ssock, self._csock = self._socketpair()
+        self._ssock, self._csock = socket.socketpair()
         self._ssock.setblocking(False)
         self._csock.setblocking(False)
         self._internal_fds += 1

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -96,9 +96,6 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
             self._selector.close()
             self._selector = None
 
-    def _socketpair(self):
-        raise NotImplementedError
-
     def _close_self_pipe(self):
         self._remove_reader(self._ssock.fileno())
         self._ssock.close()
@@ -109,7 +106,7 @@ class BaseSelectorEventLoop(base_events.BaseEventLoop):
 
     def _make_self_pipe(self):
         # A self-socket, really. :-)
-        self._ssock, self._csock = self._socketpair()
+        self._ssock, self._csock = socket.socketpair()
         self._ssock.setblocking(False)
         self._csock.setblocking(False)
         self._internal_fds += 1

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -55,9 +55,6 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
         super().__init__(selector)
         self._signal_handlers = {}
 
-    def _socketpair(self):
-        return socket.socketpair()
-
     def close(self):
         super().close()
         for sig in list(self._signal_handlers):
@@ -677,7 +674,7 @@ class _UnixSubprocessTransport(base_subprocess.BaseSubprocessTransport):
             # socket (which we use in order to detect closing of the
             # other end).  Notably this is needed on AIX, and works
             # just fine on other platforms.
-            stdin, stdin_w = self._loop._socketpair()
+            stdin, stdin_w = socket.socketpair()
 
             # Mark the write end of the stdin pipe as non-inheritable,
             # needed by close_fds=False on Python 3.3 and older

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -296,9 +296,6 @@ class PipeServer(object):
 class _WindowsSelectorEventLoop(selector_events.BaseSelectorEventLoop):
     """Windows version of selector event loop."""
 
-    def _socketpair(self):
-        return windows_utils.socketpair()
-
 
 class ProactorEventLoop(proactor_events.BaseProactorEventLoop):
     """Windows version of proactor event loop using IOCP."""
@@ -307,9 +304,6 @@ class ProactorEventLoop(proactor_events.BaseProactorEventLoop):
         if proactor is None:
             proactor = IocpProactor()
         super().__init__(proactor)
-
-    def _socketpair(self):
-        return windows_utils.socketpair()
 
     @coroutine
     def create_pipe_connection(self, protocol_factory, address):

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -444,15 +444,13 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
 
         self.ssock, self.csock = mock.Mock(), mock.Mock()
 
-        class EventLoop(BaseProactorEventLoop):
-            def _socketpair(s):
-                return (self.ssock, self.csock)
-
-        self.loop = EventLoop(self.proactor)
+        with mock.patch('asyncio.proactor_events.socket.socketpair',
+                        return_value=(self.ssock, self.csock)):
+            self.loop = BaseProactorEventLoop(self.proactor)
         self.set_event_loop(self.loop)
 
     @mock.patch.object(BaseProactorEventLoop, 'call_soon')
-    @mock.patch.object(BaseProactorEventLoop, '_socketpair')
+    @mock.patch('asyncio.proactor_events.socket.socketpair')
     def test_ctor(self, socketpair, call_soon):
         ssock, csock = socketpair.return_value = (
             mock.Mock(), mock.Mock())
@@ -505,14 +503,6 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
     def test_sock_accept(self):
         self.loop.sock_accept(self.sock)
         self.proactor.accept.assert_called_with(self.sock)
-
-    def test_socketpair(self):
-        class EventLoop(BaseProactorEventLoop):
-            # override the destructor to not log a ResourceWarning
-            def __del__(self):
-                pass
-        self.assertRaises(
-            NotImplementedError, EventLoop, self.proactor)
 
     def test_make_socket_transport(self):
         tr = self.loop._make_socket_transport(self.sock, asyncio.Protocol())

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -154,9 +154,6 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         self.loop.close()
         self.assertIsNone(self.loop._selector)
 
-    def test_socketpair(self):
-        self.assertRaises(NotImplementedError, self.loop._socketpair)
-
     def test_read_from_self_tryagain(self):
         self.loop._ssock.recv.side_effect = BlockingIOError
         self.assertIsNone(self.loop._read_from_self())

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -36,7 +36,7 @@ class ProactorTests(test_utils.TestCase):
         self.set_event_loop(self.loop)
 
     def test_close(self):
-        a, b = self.loop._socketpair()
+        a, b = socket.socketpair()
         trans = self.loop._make_socket_transport(a, asyncio.Protocol())
         f = asyncio.ensure_future(self.loop.sock_recv(b, 100))
         trans.close()

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -1,4 +1,5 @@
 import os
+import socket
 import sys
 import unittest
 from unittest import mock


### PR DESCRIPTION
Since Python 3.5, socket.socketpair() is also available on Windows,
and so can be used directly, rather than using
asyncio.windows_utils.socketpair().