### PR TITLE
bpo-32107 - Improve MAC address calculation and fix test_uuid.py

### DIFF
--- a/Doc/library/uuid.rst
+++ b/Doc/library/uuid.rst
@@ -156,10 +156,18 @@ The :mod:`uuid` module defines the following functions:
 
    Get the hardware address as a 48-bit positive integer.  The first time this
    runs, it may launch a separate program, which could be quite slow.  If all
-   attempts to obtain the hardware address fail, we choose a random 48-bit number
-   with its eighth bit set to 1 as recommended in RFC 4122.  "Hardware address"
-   means the MAC address of a network interface, and on a machine with multiple
-   network interfaces the MAC address of any one of them may be returned.
+   attempts to obtain the hardware address fail, we choose a random 48-bit
+   number with the multicast bit (least significant bit of the first octet)
+   set to 1 as recommended in RFC 4122.  "Hardware address" means the MAC
+   address of a network interface.  On a machine with multiple network
+   interfaces, universally administered MAC addresses (i.e. where the second
+   least significant bit of the first octet is *unset*) will be preferred over
+   locally administered MAC addresses, but with no other ordering guarantees.
+
+   .. versionchanged:: 3.7
+      Universally administered MAC addresses are preferred over locally
+      administered MAC addresses, since the former are guaranteed to be
+      globally unique, while the latter are not.
 
 .. index:: single: getnode
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -519,9 +519,16 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         if support.verbose >= 2:
             print(hex, end=' ')
         if network:
-            # 47 bit will never be set in IEEE 802 addresses obtained
-            # from network cards.
-            self.assertFalse(node & 0x010000000000, hex)
+            # The second least significant bit of the first octet signifies
+            # whether the MAC (IEEE 802, or EUI-48) address is universally (0)
+            # or locally (1) administered.  Network cards from hardware
+            # manufacturers will always be universally administered to
+            # guarantee global uniqueness of the MAC address.  This bit works
+            # out to be the 42nd bit counting from 1 being the least
+            # significant, or 1<<41.  For a good, simple explanation, see the
+            # section on Universal vs. local in this page:
+            # https://en.wikipedia.org/wiki/MAC_address
+            self.assertFalse(node & (1 << 41), hex)
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -512,9 +512,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 
         self.assertEqual(mac, 0x1234567890ab)
 
-    def check_node(self, node, requires=None, *,
-                   # Additional bitmask checks to perform.
-                   local=False, multicast=False):
+    def check_node(self, node, requires=None, *, admin=True):
         if requires and node is None:
             self.skipTest('requires ' + requires)
         hex = '%012x' % node
@@ -529,13 +527,8 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         # `test_random_getnode()` method specifically.  Another case is the
         # Travis-CI case, which apparently only has locally administered MAC
         # addresses.
-        if not local and not os.getenv('TRAVIS'):
+        if admin and not os.getenv('TRAVIS'):
             self.assertFalse(node & (1 << 41), '%012x' % node)
-        is_multicast = (node & (1 << 40))
-        if multicast:
-            self.assertTrue(is_multicast, '%012x' % node)
-        else:
-            self.assertFalse(is_multicast, '%012x' % node)
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
 
@@ -581,7 +574,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         # must be set for randomly generated MAC addresses.  See RFC 4122,
         # $4.1.6.
         self.assertTrue(node & (1 << 40), '%012x' % node)
-        self.check_node(node, local=True, multicast=True)
+        self.check_node(node, admin=False)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_unix_getnode(self):
@@ -591,13 +584,17 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
             node = self.uuid._unix_getnode()
         except TypeError:
             self.skipTest('requires uuid_generate_time')
-        self.check_node(node, 'unix')
+        # Since we don't know the provenance of the MAC address, don't check
+        # whether it is locally or universally administered.
+        self.check_node(node, 'unix', admin=False)
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
     def test_windll_getnode(self):
         node = self.uuid._windll_getnode()
-        self.check_node(node)
+        # Since we don't know the provenance of the MAC address, don't check
+        # whether it is locally or universally administered.
+        self.check_node(node, admin=False)
 
 
 class TestInternalsWithoutExtModule(BaseTestInternals, unittest.TestCase):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -524,11 +524,15 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
                         "%s is not an RFC 4122 node ID" % hex)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
+    @unittest.skipIf(os.getenv('TRAVIS'),
+                     'Travis-CI has no universally administered MAC addresses')
     def test_ifconfig_getnode(self):
         node = self.uuid._ifconfig_getnode()
         self.check_node(node, 'ifconfig', True)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
+    @unittest.skipIf(os.getenv('TRAVIS'),
+                     'Travis-CI has no universally administered MAC addresses')
     def test_ip_getnode(self):
         node = self.uuid._ip_getnode()
         self.check_node(node, 'ip', True)

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -562,7 +562,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
     def test_random_getnode(self):
         node = self.uuid._random_getnode()
         # Least significant bit of first octet must be set.
-        self.assertTrue(node & 0x010000000000, '%012x' % node)
+        self.assertTrue(node & (1 << 40), '%012x' % node)
         self.check_node(node)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -533,11 +533,15 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
                         "%s is not an RFC 4122 node ID" % hex)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
+    @unittest.skipIf(os.getenv('TRAVIS'),
+                     'Travis-CI has no universally administered MAC addresses')
     def test_ifconfig_getnode(self):
         node = self.uuid._ifconfig_getnode()
         self.check_node(node, 'ifconfig')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
+    @unittest.skipIf(os.getenv('TRAVIS'),
+                     'Travis-CI has no universally administered MAC addresses')
     def test_ip_getnode(self):
         node = self.uuid._ip_getnode()
         self.check_node(node, 'ip')

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -519,15 +519,6 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         if support.verbose >= 2:
             print(hex, end=' ')
         if network:
-            # The second least significant bit of the first octet signifies
-            # whether the MAC (IEEE 802, or EUI-48) address is universally (0)
-            # or locally (1) administered.  Network cards from hardware
-            # manufacturers will always be universally administered to
-            # guarantee global uniqueness of the MAC address.  This bit works
-            # out to be the 42nd bit counting from 1 being the least
-            # significant, or 1<<41.  For a good, simple explanation, see the
-            # section on Universal vs. local in this page:
-            # https://en.wikipedia.org/wiki/MAC_address
             self.assertFalse(node & (1 << 41), hex)
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -512,23 +512,12 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 
         self.assertEqual(mac, 0x1234567890ab)
 
-    def check_node(self, node, requires=None, *, check_bit=True):
+    def check_node(self, node, requires=None):
         if requires and node is None:
             self.skipTest('requires ' + requires)
         hex = '%012x' % node
         if support.verbose >= 2:
             print(hex, end=' ')
-        # The MAC address will be universally administered (i.e. the second
-        # least significant bit of the first octet must be unset) for any
-        # physical interface, such as an ethernet port or wireless adapter.
-        # There are some cases where this won't be the case.  Randomly
-        # generated MACs may not be universally administered, but they must
-        # have their multicast bit set, though this is tested in the
-        # `test_random_getnode()` method specifically.  Another case is the
-        # Travis-CI case, which apparently only has locally administered MAC
-        # addresses.
-        if check_bit and not os.getenv('TRAVIS'):
-            self.assertFalse(node & (1 << 41), '%012x' % node)
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
 
@@ -574,7 +563,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         # must be set for randomly generated MAC addresses.  See RFC 4122,
         # $4.1.6.
         self.assertTrue(node & (1 << 40), '%012x' % node)
-        self.check_node(node, check_bit=False)
+        self.check_node(node)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_unix_getnode(self):
@@ -586,7 +575,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
             self.skipTest('requires uuid_generate_time')
         # Since we don't know the provenance of the MAC address, don't check
         # whether it is locally or universally administered.
-        self.check_node(node, 'unix', check_bit=False)
+        self.check_node(node, 'unix')
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
@@ -594,7 +583,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         node = self.uuid._windll_getnode()
         # Since we don't know the provenance of the MAC address, don't check
         # whether it is locally or universally administered.
-        self.check_node(node, check_bit=False)
+        self.check_node(node)
 
 
 class TestInternalsWithoutExtModule(BaseTestInternals, unittest.TestCase):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -512,62 +512,69 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 
         self.assertEqual(mac, 0x1234567890ab)
 
-    def check_node(self, node, requires=None, network=False):
+    def check_node(self, node, requires=None, *, random=False):
         if requires and node is None:
             self.skipTest('requires ' + requires)
         hex = '%012x' % node
         if support.verbose >= 2:
             print(hex, end=' ')
-        if network:
-            self.assertFalse(node & (1 << 41), hex)
+        # The MAC address will be universally administered (i.e. the second
+        # least significant bit of the first octet must be unset) for any
+        # physical interface, such as an ethernet port or wireless adapter.
+        # There are some cases where this won't be the case.  Randomly
+        # generated MACs may not be universally administered, but they must
+        # have their multicast bit set, though this is tested in the
+        # `test_random_getnode()` method specifically.  Another case is the
+        # Travis-CI case, which apparently only has locally administered MAC
+        # addresses.
+        if not random and not os.getenv('TRAVIS'):
+            self.assertFalse(node & (1 << 41), '%012x' % node)
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
-    @unittest.skipIf(os.getenv('TRAVIS'),
-                     'Travis-CI has no universally administered MAC addresses')
     def test_ifconfig_getnode(self):
         node = self.uuid._ifconfig_getnode()
-        self.check_node(node, 'ifconfig', True)
+        self.check_node(node, 'ifconfig')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
-    @unittest.skipIf(os.getenv('TRAVIS'),
-                     'Travis-CI has no universally administered MAC addresses')
     def test_ip_getnode(self):
         node = self.uuid._ip_getnode()
-        self.check_node(node, 'ip', True)
+        self.check_node(node, 'ip')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_arp_getnode(self):
         node = self.uuid._arp_getnode()
-        self.check_node(node, 'arp', True)
+        self.check_node(node, 'arp')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_lanscan_getnode(self):
         node = self.uuid._lanscan_getnode()
-        self.check_node(node, 'lanscan', True)
+        self.check_node(node, 'lanscan')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_netstat_getnode(self):
         node = self.uuid._netstat_getnode()
-        self.check_node(node, 'netstat', True)
+        self.check_node(node, 'netstat')
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     def test_ipconfig_getnode(self):
         node = self.uuid._ipconfig_getnode()
-        self.check_node(node, 'ipconfig', True)
+        self.check_node(node, 'ipconfig')
 
     @unittest.skipUnless(importable('win32wnet'), 'requires win32wnet')
     @unittest.skipUnless(importable('netbios'), 'requires netbios')
     def test_netbios_getnode(self):
         node = self.uuid._netbios_getnode()
-        self.check_node(node, network=True)
+        self.check_node(node)
 
     def test_random_getnode(self):
         node = self.uuid._random_getnode()
-        # Least significant bit of first octet must be set.
+        # The multicast bit, i.e. the least significant bit of first octet,
+        # must be set for randomly generated MAC addresses.  See RFC 4122,
+        # $4.1.6.
         self.assertTrue(node & (1 << 40), '%012x' % node)
-        self.check_node(node)
+        self.check_node(node, random=True)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_unix_getnode(self):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -573,16 +573,12 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
             node = self.uuid._unix_getnode()
         except TypeError:
             self.skipTest('requires uuid_generate_time')
-        # Since we don't know the provenance of the MAC address, don't check
-        # whether it is locally or universally administered.
         self.check_node(node, 'unix')
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
     def test_windll_getnode(self):
         node = self.uuid._windll_getnode()
-        # Since we don't know the provenance of the MAC address, don't check
-        # whether it is locally or universally administered.
         self.check_node(node)
 
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -512,58 +512,55 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 
         self.assertEqual(mac, 0x1234567890ab)
 
-    def check_node(self, node, requires=None, network=False):
+    def check_node(self, node, requires=None):
         if requires and node is None:
             self.skipTest('requires ' + requires)
         hex = '%012x' % node
         if support.verbose >= 2:
             print(hex, end=' ')
-        if network:
-            # 47 bit will never be set in IEEE 802 addresses obtained
-            # from network cards.
-            self.assertFalse(node & 0x010000000000, hex)
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_ifconfig_getnode(self):
         node = self.uuid._ifconfig_getnode()
-        self.check_node(node, 'ifconfig', True)
+        self.check_node(node, 'ifconfig')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_ip_getnode(self):
         node = self.uuid._ip_getnode()
-        self.check_node(node, 'ip', True)
+        self.check_node(node, 'ip')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_arp_getnode(self):
         node = self.uuid._arp_getnode()
-        self.check_node(node, 'arp', True)
+        self.check_node(node, 'arp')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_lanscan_getnode(self):
         node = self.uuid._lanscan_getnode()
-        self.check_node(node, 'lanscan', True)
+        self.check_node(node, 'lanscan')
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_netstat_getnode(self):
         node = self.uuid._netstat_getnode()
-        self.check_node(node, 'netstat', True)
+        self.check_node(node, 'netstat')
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     def test_ipconfig_getnode(self):
         node = self.uuid._ipconfig_getnode()
-        self.check_node(node, 'ipconfig', True)
+        self.check_node(node, 'ipconfig')
 
     @unittest.skipUnless(importable('win32wnet'), 'requires win32wnet')
     @unittest.skipUnless(importable('netbios'), 'requires netbios')
     def test_netbios_getnode(self):
         node = self.uuid._netbios_getnode()
-        self.check_node(node, network=True)
+        self.check_node(node)
 
     def test_random_getnode(self):
         node = self.uuid._random_getnode()
         # Least significant bit of first octet must be set.
+        # See RFC 4122, $4.1.6.
         self.assertTrue(node & 0x010000000000, '%012x' % node)
         self.check_node(node)
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -512,7 +512,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 
         self.assertEqual(mac, 0x1234567890ab)
 
-    def check_node(self, node, requires=None, *, admin=True):
+    def check_node(self, node, requires=None, *, check_bit=True):
         if requires and node is None:
             self.skipTest('requires ' + requires)
         hex = '%012x' % node
@@ -527,7 +527,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         # `test_random_getnode()` method specifically.  Another case is the
         # Travis-CI case, which apparently only has locally administered MAC
         # addresses.
-        if admin and not os.getenv('TRAVIS'):
+        if check_bit and not os.getenv('TRAVIS'):
             self.assertFalse(node & (1 << 41), '%012x' % node)
         self.assertTrue(0 < node < (1 << 48),
                         "%s is not an RFC 4122 node ID" % hex)
@@ -574,7 +574,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         # must be set for randomly generated MAC addresses.  See RFC 4122,
         # $4.1.6.
         self.assertTrue(node & (1 << 40), '%012x' % node)
-        self.check_node(node, admin=False)
+        self.check_node(node, check_bit=False)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_unix_getnode(self):
@@ -586,7 +586,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
             self.skipTest('requires uuid_generate_time')
         # Since we don't know the provenance of the MAC address, don't check
         # whether it is locally or universally administered.
-        self.check_node(node, 'unix', admin=False)
+        self.check_node(node, 'unix', check_bit=False)
 
     @unittest.skipUnless(os.name == 'nt', 'requires Windows')
     @unittest.skipUnless(importable('ctypes'), 'requires ctypes')
@@ -594,7 +594,7 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         node = self.uuid._windll_getnode()
         # Since we don't know the provenance of the MAC address, don't check
         # whether it is locally or universally administered.
-        self.check_node(node, admin=False)
+        self.check_node(node, check_bit=False)
 
 
 class TestInternalsWithoutExtModule(BaseTestInternals, unittest.TestCase):

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -639,13 +639,13 @@ def _windll_getnode():
 
 def _random_getnode():
     """Get a random node ID."""
-    # RFC 4122, $4.1.6. says "For systems with no IEEE address, a randomly or
+    # RFC 4122, $4.1.6 says "For systems with no IEEE address, a randomly or
     # pseudo-randomly generated value may be used; see Section 4.5.  The
     # multicast bit must be set in such addresses, in order that they will
     # never conflict with addresses obtained from network cards."
     #
     # The "multicast bit" of a MAC address is defined to be "the least
-    # significant bit of the first octet".  This worlds out to be the 41st bit
+    # significant bit of the first octet".  This works out to be the 41st bit
     # counting from 1 being the least significant bit, or 1<<40.
     #
     # See https://en.wikipedia.org/wiki/MAC_address#Unicast_vs._multicast

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -404,7 +404,8 @@ def _arp_getnode():
     # This works on Linux, FreeBSD and NetBSD
     mac = _find_mac('arp', '-an', [os.fsencode('(%s)' % ip_addr)],
                     lambda i: i+2)
-    return mac
+    # Return None instead of 0.
+    return mac if mac else None
 
 def _lanscan_getnode():
     """Get the hardware address on Unix by running lanscan."""

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -351,8 +351,9 @@ def _popen(command, *args):
 # the Touch Bar on MacBook Pros.
 #
 # This bit works out to be the 42nd bit counting from 1 being the least
-# significant, or 1<<41.  We'll skip over any locally administered MAC
-# addresses, as it makes no sense to use those in UUID calculation.
+# significant, or 1<<41.  We'll prefer universally administered MAC addresses
+# over locally administered ones since the former are globally unique, but
+# we'll return the first of the latter found if that's all the machine has.
 #
 # See https://en.wikipedia.org/wiki/MAC_address#Universal_vs._local
 

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -374,7 +374,9 @@ def _find_mac(command, args, hw_identifiers, get_index):
                             word = words[get_index(i)]
                             mac = int(word.replace(b':', b''), 16)
                             if _is_universal(mac):
+                                print('%012x' % mac, 'universal', command)
                                 return mac
+                            print('%012x' % mac, 'local', command)
                             first_local_mac = first_local_mac or mac
                         except (ValueError, IndexError):
                             # Virtual interfaces, such as those provided by

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -374,9 +374,7 @@ def _find_mac(command, args, hw_identifiers, get_index):
                             word = words[get_index(i)]
                             mac = int(word.replace(b':', b''), 16)
                             if _is_universal(mac):
-                                print('%012x' % mac, 'universal', command)
                                 return mac
-                            print('%012x' % mac, 'local', command)
                             first_local_mac = first_local_mac or mac
                         except (ValueError, IndexError):
                             # Virtual interfaces, such as those provided by

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -404,8 +404,7 @@ def _arp_getnode():
     # This works on Linux, FreeBSD and NetBSD
     mac = _find_mac('arp', '-an', [os.fsencode('(%s)' % ip_addr)],
                     lambda i: i+2)
-    if mac:
-        return mac
+    return mac
 
 def _lanscan_getnode():
     """Get the hardware address on Unix by running lanscan."""

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -525,7 +525,7 @@ def _netbios_getnode():
         if _is_universal(mac):
             return mac
         first_local_mac = first_local_mac or mac
-    return None
+    return first_local_mac or None
 
 
 _generate_time_safe = _UuidCreate = None

--- a/Misc/NEWS.d/next/Library/2017-11-26-18-48-17.bpo-32107.h2ph2K.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-26-18-48-17.bpo-32107.h2ph2K.rst
@@ -1,0 +1,4 @@
+Improve the private ``*_getnode()`` methods for UUID1 such that universally
+administered MAC addresses are preferred over locally administered MAC
+addresses.  If only the latter is available, the first such one is returned.
+Improve the related tests and fix some bugs there as well.

--- a/Misc/NEWS.d/next/Library/2017-11-26-18-48-17.bpo-32107.h2ph2K.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-26-18-48-17.bpo-32107.h2ph2K.rst
@@ -1,4 +1,5 @@
-Improve the private ``*_getnode()`` methods for UUID1 such that universally
-administered MAC addresses are preferred over locally administered MAC
-addresses.  If only the latter is available, the first such one is returned.
-Improve the related tests and fix some bugs there as well.
+``uuid.getnode()`` now preferentially returns universally administered MAC
+addresses if available, over locally administered MAC addresses.  This makes a
+better guarantee for global uniqueness of UUIDs returned from
+``uuid.uuid1()``.  If only locally administered MAC addresses are available,
+the first such one found is returned.


### PR DESCRIPTION
Here's yet another attempt, but this time without the bitmask check for universally administered MAC addresses.  That check fails miserably on the buildbots *and* Travis, so it's not worth it.

<!-- issue-number: bpo-32107 -->
https://bugs.python.org/issue32107
<!-- /issue-number -->
