### PR TITLE
bpo-32165 Fix calling order of PyEval_InitThreads

### DIFF
--- a/Modules/_ctypes/callbacks.c
+++ b/Modules/_ctypes/callbacks.c
@@ -418,8 +418,8 @@ CThunkObject *_ctypes_alloc_callback(PyObject *callable,
 static void LoadPython(void)
 {
     if (!Py_IsInitialized()) {
-        PyEval_InitThreads();
         Py_Initialize();
+        PyEval_InitThreads();
     }
 }
 


### PR DESCRIPTION
As described in `Doc/c-api/init.rst`, `PyEval_InitThreads()` cannot be called
before `Py_Initialize()` function.

<!-- issue-number: bpo-32165 -->
https://bugs.python.org/issue32165
<!-- /issue-number -->
