### PR TITLE
bpo-32138: Skip on Android test_faulthandler tests that raise SIGSEGV

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -773,7 +773,7 @@ requires_lzma = unittest.skipUnless(lzma, 'requires lzma')
 
 is_jython = sys.platform.startswith('java')
 
-is_android = True if hasattr(sys, 'getandroidapilevel') else False
+is_android = hasattr(sys, 'getandroidapilevel')
 
 if sys.platform != 'win32':
     unix_shell = '/system/bin/sh' if is_android else '/bin/sh'

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -87,7 +87,7 @@ __all__ = [
     "bigmemtest", "bigaddrspacetest", "cpython_only", "get_attribute",
     "requires_IEEE_754", "skip_unless_xattr", "requires_zlib",
     "anticipate_failure", "load_package_tests", "detect_api_mismatch",
-    "check__all__", "requires_android_level", "requires_multiprocessing_queue",
+    "check__all__", "requires_multiprocessing_queue",
     "skip_unless_bind_unix_socket",
     # sys
     "is_jython", "is_android", "check_impl_detail", "unix_shell",
@@ -773,13 +773,7 @@ requires_lzma = unittest.skipUnless(lzma, 'requires lzma')
 
 is_jython = sys.platform.startswith('java')
 
-try:
-    # constant used by requires_android_level()
-    _ANDROID_API_LEVEL = sys.getandroidapilevel()
-    is_android = True
-except AttributeError:
-    # sys.getandroidapilevel() is only available on Android
-    is_android = False
+is_android = True if hasattr(sys, 'getandroidapilevel') else False
 
 if sys.platform != 'win32':
     unix_shell = '/system/bin/sh' if is_android else '/bin/sh'
@@ -1777,13 +1771,6 @@ def requires_resource(resource):
         return _id
     else:
         return unittest.skip("resource {0!r} is not enabled".format(resource))
-
-def requires_android_level(level, reason):
-    if is_android and _ANDROID_API_LEVEL < level:
-        return unittest.skip('%s at Android API level %d' %
-                             (reason, _ANDROID_API_LEVEL))
-    else:
-        return _id
 
 def cpython_only(test):
     """

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -6,7 +6,7 @@ import signal
 import subprocess
 import sys
 from test import support
-from test.support import script_helper, is_android, requires_android_level
+from test.support import script_helper, is_android
 import tempfile
 import threading
 import unittest
@@ -36,10 +36,6 @@ def temporary_filename():
         yield filename
     finally:
         support.unlink(filename)
-
-def requires_raise(test):
-    return (test if not is_android else
-                   requires_android_level(24, 'raise() is buggy')(test))
 
 class FaultHandlerTests(unittest.TestCase):
     def get_output(self, code, filename=None, fd=None):
@@ -140,7 +136,7 @@ class FaultHandlerTests(unittest.TestCase):
                 3,
                 'access violation')
 
-    @requires_raise
+    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
     def test_sigsegv(self):
         self.check_fatal_error("""
             import faulthandler
@@ -182,7 +178,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
     @unittest.skipUnless(hasattr(signal, 'SIGBUS'), 'need signal.SIGBUS')
-    @requires_raise
+    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
     def test_sigbus(self):
         self.check_fatal_error("""
             import _testcapi
@@ -197,7 +193,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
     @unittest.skipUnless(hasattr(signal, 'SIGILL'), 'need signal.SIGILL')
-    @requires_raise
+    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
     def test_sigill(self):
         self.check_fatal_error("""
             import _testcapi
@@ -241,7 +237,7 @@ class FaultHandlerTests(unittest.TestCase):
             '(?:Segmentation fault|Bus error)',
             other_regex='unable to raise a stack overflow')
 
-    @requires_raise
+    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
     def test_gil_released(self):
         self.check_fatal_error("""
             import faulthandler
@@ -251,7 +247,7 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'Segmentation fault')
 
-    @requires_raise
+    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
     def test_enable_file(self):
         with temporary_filename() as filename:
             self.check_fatal_error("""
@@ -266,7 +262,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
-    @requires_raise
+    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
     def test_enable_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:
             fd = fp.fileno()
@@ -280,7 +276,7 @@ class FaultHandlerTests(unittest.TestCase):
                 'Segmentation fault',
                 fd=fd)
 
-    @requires_raise
+    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
     def test_enable_single_thread(self):
         self.check_fatal_error("""
             import faulthandler
@@ -291,7 +287,7 @@ class FaultHandlerTests(unittest.TestCase):
             'Segmentation fault',
             all_threads=False)
 
-    @requires_raise
+    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
     def test_disable(self):
         code = """
             import faulthandler

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -29,6 +29,11 @@ def expected_traceback(lineno1, lineno2, header, min_count=1):
     else:
         return '^' + regex + '$'
 
+def skip_segfault_on_android(test):
+    # Issue #32138: Raising SIGSEGV on Android may not cause a crash.
+    return unittest.skipIf(is_android,
+                           'raising SIGSEGV on Android is unreliable')(test)
+
 @contextmanager
 def temporary_filename():
     filename = tempfile.mktemp()
@@ -136,7 +141,7 @@ class FaultHandlerTests(unittest.TestCase):
                 3,
                 'access violation')
 
-    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
+    @skip_segfault_on_android
     def test_sigsegv(self):
         self.check_fatal_error("""
             import faulthandler
@@ -178,7 +183,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
     @unittest.skipUnless(hasattr(signal, 'SIGBUS'), 'need signal.SIGBUS')
-    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
+    @skip_segfault_on_android
     def test_sigbus(self):
         self.check_fatal_error("""
             import _testcapi
@@ -193,7 +198,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(_testcapi is None, 'need _testcapi')
     @unittest.skipUnless(hasattr(signal, 'SIGILL'), 'need signal.SIGILL')
-    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
+    @skip_segfault_on_android
     def test_sigill(self):
         self.check_fatal_error("""
             import _testcapi
@@ -237,7 +242,7 @@ class FaultHandlerTests(unittest.TestCase):
             '(?:Segmentation fault|Bus error)',
             other_regex='unable to raise a stack overflow')
 
-    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
+    @skip_segfault_on_android
     def test_gil_released(self):
         self.check_fatal_error("""
             import faulthandler
@@ -247,7 +252,7 @@ class FaultHandlerTests(unittest.TestCase):
             3,
             'Segmentation fault')
 
-    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
+    @skip_segfault_on_android
     def test_enable_file(self):
         with temporary_filename() as filename:
             self.check_fatal_error("""
@@ -262,7 +267,7 @@ class FaultHandlerTests(unittest.TestCase):
 
     @unittest.skipIf(sys.platform == "win32",
                      "subprocess doesn't support pass_fds on Windows")
-    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
+    @skip_segfault_on_android
     def test_enable_fd(self):
         with tempfile.TemporaryFile('wb+') as fp:
             fd = fp.fileno()
@@ -276,7 +281,7 @@ class FaultHandlerTests(unittest.TestCase):
                 'Segmentation fault',
                 fd=fd)
 
-    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
+    @skip_segfault_on_android
     def test_enable_single_thread(self):
         self.check_fatal_error("""
             import faulthandler
@@ -287,7 +292,7 @@ class FaultHandlerTests(unittest.TestCase):
             'Segmentation fault',
             all_threads=False)
 
-    @unittest.skipIf(is_android, 'raising SIGSEGV on Android is unreliable')
+    @skip_segfault_on_android
     def test_disable(self):
         code = """
             import faulthandler

--- a/Misc/NEWS.d/next/Tests/2017-11-27-16-18-58.bpo-32138.QsTvf-.rst
+++ b/Misc/NEWS.d/next/Tests/2017-11-27-16-18-58.bpo-32138.QsTvf-.rst
@@ -1,0 +1,2 @@
+Skip on Android test_faulthandler tests that raise SIGSEGV and remove the
+test.support.requires_android_level decorator.


### PR DESCRIPTION
Remove the test.support.requires_android_level decorator.


<!-- issue-number: bpo-32138 -->
https://bugs.python.org/issue32138
<!-- /issue-number -->
