### PR TITLE
bpo-32154: Remove asyncio.selectors

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -677,6 +677,10 @@ Changes in Python behavior
 Changes in the Python API
 -------------------------
 
+* :mod:`asyncio`: The module doesn't export :mod:`selectors` and `_overlapped`
+  modules as ``asyncio.selectors`` and ``asyncio._overlapped``. Replace
+  ``from asyncio import selectors`` with ``import selectors`` for example.
+
 * :meth:`pkgutil.walk_packages` now raises ValueError if *path* is a string.
   Previously an empty list was returned. (Contributed by Sanyam Khurana in
   :issue:`24744`.)

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -677,9 +677,10 @@ Changes in Python behavior
 Changes in the Python API
 -------------------------
 
-* :mod:`asyncio`: The module doesn't export :mod:`selectors` and `_overlapped`
-  modules as ``asyncio.selectors`` and ``asyncio._overlapped``. Replace
-  ``from asyncio import selectors`` with ``import selectors`` for example.
+* :mod:`asyncio`: The module doesn't export :mod:`selectors` and
+  :mod:`_overlapped` modules as ``asyncio.selectors`` and
+  ``asyncio._overlapped``. Replace ``from asyncio import selectors`` with
+  ``import selectors`` for example.
 
 * :meth:`pkgutil.walk_packages` now raises ValueError if *path* is a string.
   Previously an empty list was returned. (Contributed by Sanyam Khurana in

--- a/Lib/asyncio/__init__.py
+++ b/Lib/asyncio/__init__.py
@@ -2,21 +2,6 @@
 
 import sys
 
-# The selectors module is in the stdlib in Python 3.4 but not in 3.3.
-# Do this first, so the other submodules can use "from . import selectors".
-# Prefer asyncio/selectors.py over the stdlib one, as ours may be newer.
-try:
-    from . import selectors
-except ImportError:
-    import selectors  # Will also be exported.
-
-if sys.platform == 'win32':
-    # Similar thing for _overlapped.
-    try:
-        from . import _overlapped
-    except ImportError:
-        import _overlapped  # Will also be exported.
-
 # This relies on each of the submodules having an __all__ variable.
 from .base_events import *
 from .coroutines import *

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -9,6 +9,7 @@ __all__ = ['BaseSelectorEventLoop']
 import collections
 import errno
 import functools
+import selectors
 import socket
 import warnings
 import weakref
@@ -21,7 +22,6 @@ from . import base_events
 from . import constants
 from . import events
 from . import futures
-from . import selectors
 from . import transports
 from . import sslproto
 from .coroutines import coroutine

--- a/Lib/asyncio/test_utils.py
+++ b/Lib/asyncio/test_utils.py
@@ -6,6 +6,7 @@ import io
 import logging
 import os
 import re
+import selectors
 import socket
 import socketserver
 import sys
@@ -28,7 +29,6 @@ except ImportError:  # pragma: no cover
 from . import base_events
 from . import events
 from . import futures
-from . import selectors
 from . import tasks
 from .coroutines import coroutine
 from .log import logger

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -2,6 +2,7 @@
 
 import errno
 import os
+import selectors
 import signal
 import socket
 import stat
@@ -18,7 +19,6 @@ from . import coroutines
 from . import events
 from . import futures
 from . import selector_events
-from . import selectors
 from . import transports
 from .coroutines import coroutine
 from .log import logger

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -1,5 +1,6 @@
 """Selector and proactor event loops for Windows."""
 
+import _overlapped
 import _winapi
 import errno
 import math
@@ -14,7 +15,6 @@ from . import proactor_events
 from . import selector_events
 from . import tasks
 from . import windows_utils
-from . import _overlapped
 from .coroutines import coroutine
 from .log import logger
 

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2141,7 +2141,7 @@ if sys.platform == 'win32':
         def test_remove_fds_after_closing(self):
             raise unittest.SkipTest("IocpEventLoop does not have add_reader()")
 else:
-    from asyncio import selectors
+    import selectors
 
     class UnixEventLoopTestsMixin(EventLoopTestsMixin):
         def setUp(self):

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -1,6 +1,7 @@
 """Tests for selector_events.py"""
 
 import errno
+import selectors
 import socket
 import unittest
 from unittest import mock
@@ -10,7 +11,6 @@ except ImportError:
     ssl = None
 
 import asyncio
-from asyncio import selectors
 from asyncio import test_utils
 from asyncio.selector_events import BaseSelectorEventLoop
 from asyncio.selector_events import _SelectorTransport

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -7,10 +7,10 @@ from unittest import mock
 if sys.platform != 'win32':
     raise unittest.SkipTest('Windows only')
 
+import _overlapped
 import _winapi
 
 import asyncio
-from asyncio import _overlapped
 from asyncio import test_utils
 from asyncio import windows_events
 

--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -9,9 +9,9 @@ from unittest import mock
 if sys.platform != 'win32':
     raise unittest.SkipTest('Windows only')
 
+import _overlapped
 import _winapi
 
-from asyncio import _overlapped
 from asyncio import windows_utils
 try:
     from test import support


### PR DESCRIPTION
* Remove asyncio.selectors and asyncio._overlapped symbols from the
  namespace of the asyncio module
* Replace "from asyncio import selectors" with "import selectors"
* Replace "from asyncio import _overlapped" with "import _overlapped"

asyncio.selectors was added to support Python 3.3, which doesn't have
selectors in its standard library, and Python 3.4 in the same code
base. Same rationale for asyncio._overlapped. Python 3.3 reached its
end of life, and asyncio is no more maintained as a third party
module on PyPI.

<!-- issue-number: bpo-32154 -->
https://bugs.python.org/issue32154
<!-- /issue-number -->
