### PR TITLE
asyncio: Remove asyncio/compat.py

### DIFF
--- a/Lib/asyncio/compat.py
+++ b/Lib/asyncio/compat.py
@@ -1,6 +1,0 @@
-"""Compatibility helpers for the different Python versions."""
-
-import sys
-
-PY35 = sys.version_info >= (3, 5)
-PY352 = sys.version_info >= (3, 5, 2)

--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -9,7 +9,6 @@ import sys
 import traceback
 import types
 
-from . import compat
 from . import constants
 from . import events
 from . import base_futures
@@ -151,35 +150,33 @@ class CoroWrapper:
     def gi_code(self):
         return self.gen.gi_code
 
-    if compat.PY35:
+    def __await__(self):
+        cr_await = getattr(self.gen, 'cr_await', None)
+        if cr_await is not None:
+            raise RuntimeError(
+                "Cannot await on coroutine {!r} while it's "
+                "awaiting for {!r}".format(self.gen, cr_await))
+        return self
 
-        def __await__(self):
-            cr_await = getattr(self.gen, 'cr_await', None)
-            if cr_await is not None:
-                raise RuntimeError(
-                    "Cannot await on coroutine {!r} while it's "
-                    "awaiting for {!r}".format(self.gen, cr_await))
-            return self
+    @property
+    def gi_yieldfrom(self):
+        return self.gen.gi_yieldfrom
 
-        @property
-        def gi_yieldfrom(self):
-            return self.gen.gi_yieldfrom
+    @property
+    def cr_await(self):
+        return self.gen.cr_await
 
-        @property
-        def cr_await(self):
-            return self.gen.cr_await
+    @property
+    def cr_running(self):
+        return self.gen.cr_running
 
-        @property
-        def cr_running(self):
-            return self.gen.cr_running
+    @property
+    def cr_code(self):
+        return self.gen.cr_code
 
-        @property
-        def cr_code(self):
-            return self.gen.cr_code
-
-        @property
-        def cr_frame(self):
-            return self.gen.cr_frame
+    @property
+    def cr_frame(self):
+        return self.gen.cr_frame
 
     def __del__(self):
         # Be careful accessing self.gen.frame -- self.gen might not exist.

--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -9,7 +9,6 @@ import sys
 import traceback
 
 from . import base_futures
-from . import compat
 from . import events
 
 
@@ -238,8 +237,7 @@ class Future:
         assert self.done(), "yield from wasn't used with future"
         return self.result()  # May raise too.
 
-    if compat.PY35:
-        __await__ = __iter__ # make compatible with 'await' expression
+    __await__ = __iter__ # make compatible with 'await' expression
 
 
 # Needed for testing purposes.

--- a/Lib/asyncio/queues.py
+++ b/Lib/asyncio/queues.py
@@ -5,7 +5,6 @@ __all__ = ['Queue', 'PriorityQueue', 'LifoQueue', 'QueueFull', 'QueueEmpty']
 import collections
 import heapq
 
-from . import compat
 from . import events
 from . import locks
 from .coroutines import coroutine
@@ -251,9 +250,3 @@ class LifoQueue(Queue):
 
     def _get(self):
         return self._queue.pop()
-
-
-if not compat.PY35:
-    JoinableQueue = Queue
-    """Deprecated alias for Queue."""
-    __all__.append('JoinableQueue')

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -12,7 +12,6 @@ if hasattr(socket, 'AF_UNIX'):
     __all__.extend(['open_unix_connection', 'start_unix_server'])
 
 from . import coroutines
-from . import compat
 from . import events
 from . import protocols
 from .coroutines import coroutine

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -13,7 +13,6 @@ import warnings
 import weakref
 
 from . import base_tasks
-from . import compat
 from . import coroutines
 from . import events
 from . import futures
@@ -525,7 +524,7 @@ def ensure_future(coro_or_future, *, loop=None):
         if task._source_traceback:
             del task._source_traceback[-1]
         return task
-    elif compat.PY35 and inspect.isawaitable(coro_or_future):
+    elif inspect.isawaitable(coro_or_future):
         return ensure_future(_wrap_awaitable(coro_or_future), loop=loop)
     else:
         raise TypeError('An asyncio.Future, a coroutine or an awaitable is '


### PR DESCRIPTION
The asyncio/compat.py file was written to support Python < 3.5 and
Python < 3.5.2. But Python 3.5 doesn't accept bugfixes anymore, only
security fixes. There is no more need to backport bugfixes to Python
3.5, and so no need to have a single code base for Python 3.5, 3.6
and 3.7.

Say hello (again) to "async" and "await", who became real keywords in
Python 3.7 ;-)