### PR TITLE
bpo-32108: Fix configparser when a section is assigned to itself.

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -140,6 +140,7 @@ ConfigParser -- responsible for parsing a list of
 
 from collections.abc import MutableMapping
 from collections import OrderedDict as _default_dict, ChainMap as _ChainMap
+from copy import deepcopy
 import functools
 import io
 import itertools
@@ -964,6 +965,7 @@ class RawConfigParser(MutableMapping):
 
         # XXX this is not atomic if read_dict fails at any point. Then again,
         # no update method in configparser is atomic in this implementation.
+        value = deepcopy(value)
         if key == self.default_section:
             self._defaults.clear()
         elif key in self._sections:

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -510,6 +510,14 @@ boolean {0[0]} NO
                              defaults={"key":"value"})
         self.assertTrue("Key" in cf["section"])
 
+    def test_assign_itself(self):
+        cf = self.newconfig()
+        cf['test'] = {'key': 'value'}
+        section = cf['test']
+        section['key'] = 'diffrent'
+        cf['test'] = section
+        self.assertEqual(dict(section), {'key': 'diffrent'})
+
     def test_default_case_sensitivity(self):
         cf = self.newconfig({"foo": "Bar"})
         self.assertEqual(

--- a/Misc/NEWS.d/next/Library/2017-11-28-19-51-50.bpo-32108.v4rCnZ.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-28-19-51-50.bpo-32108.v4rCnZ.rst
@@ -1,0 +1,2 @@
+Fix configparser when a section is assigned to itself. Patched by Dong-
+hee Na.


### PR DESCRIPTION



<!-- issue-number: bpo-32108 -->
https://bugs.python.org/issue32108
<!-- /issue-number -->
