### PR TITLE
bpo-32155: Bugfixes found by flake8 F841 warnings

### DIFF
--- a/Lib/distutils/config.py
+++ b/Lib/distutils/config.py
@@ -77,7 +77,7 @@ class PyPIRCCommand(Command):
                     # optional params
                     for key, default in (('repository',
                                           self.DEFAULT_REPOSITORY),
-                                         ('realm', self.DEFAULT_REALM),
+                                         ('realm', realm),
                                          ('password', None)):
                         if config.has_option(server, key):
                             current[key] = config.get(server, key)
@@ -106,7 +106,7 @@ class PyPIRCCommand(Command):
                         'password': config.get(server, 'password'),
                         'repository': repository,
                         'server': server,
-                        'realm': self.DEFAULT_REALM}
+                        'realm': realm}
 
         return {}
 

--- a/Lib/turtledemo/__main__.py
+++ b/Lib/turtledemo/__main__.py
@@ -136,7 +136,7 @@ class DemoWindow(object):
             import subprocess
             # Make sure we are the currently activated OS X application
             # so that our menu bar appears.
-            p = subprocess.Popen(
+            subprocess.run(
                     [
                         'osascript',
                         '-e', 'tell application "System Events"',

--- a/Misc/NEWS.d/next/Library/2017-11-28-15-06-07.bpo-32155.hWHGww.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-28-15-06-07.bpo-32155.hWHGww.rst
@@ -1,0 +1,1 @@
+Fix distutils.config: use the PyPIRCCommand.realm attribute if it is set.

--- a/Tools/scripts/treesync.py
+++ b/Tools/scripts/treesync.py
@@ -33,7 +33,7 @@ write_slave = "ask"
 write_master = "ask"
 
 def main():
-    global always_no, always_yes
+    global default_answer, always_no, always_yes, create_files
     global create_directories, write_master, write_slave
     opts, args = getopt.getopt(sys.argv[1:], "nym:s:d:f:a:")
     for o, a in opts:


### PR DESCRIPTION
* distutils.config: Use the PyPIRCCommand.realm attribute if set
* turtledemo: wait until macOS osascript command completes to not
  create a zombie process
* Tools/scripts/treesync.py: declare 'default_answer' and
  'create_files' as globals to modify them with the command line
  arguments. Previously, -y, -n, -f and -a options had no effect.

flake8 warning: "F841 local variable 'p' is assigned to but never
used".

<!-- issue-number: bpo-32155 -->
https://bugs.python.org/issue32155
<!-- /issue-number -->
