### PR TITLE
bpo-32155: Revert distutils.config change

### DIFF
--- a/Lib/distutils/config.py
+++ b/Lib/distutils/config.py
@@ -51,7 +51,6 @@ class PyPIRCCommand(Command):
         if os.path.exists(rc):
             self.announce('Using PyPI login from %s' % rc)
             repository = self.repository or self.DEFAULT_REPOSITORY
-            realm = self.realm or self.DEFAULT_REALM
 
             config = RawConfigParser()
             config.read(rc)
@@ -77,7 +76,7 @@ class PyPIRCCommand(Command):
                     # optional params
                     for key, default in (('repository',
                                           self.DEFAULT_REPOSITORY),
-                                         ('realm', realm),
+                                         ('realm', self.DEFAULT_REALM),
                                          ('password', None)):
                         if config.has_option(server, key):
                             current[key] = config.get(server, key)
@@ -106,7 +105,7 @@ class PyPIRCCommand(Command):
                         'password': config.get(server, 'password'),
                         'repository': repository,
                         'server': server,
-                        'realm': realm}
+                        'realm': self.DEFAULT_REALM}
 
         return {}
 

--- a/Misc/NEWS.d/next/Library/2017-11-28-15-06-07.bpo-32155.hWHGww.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-28-15-06-07.bpo-32155.hWHGww.rst
@@ -1,1 +1,0 @@
-Fix distutils.config: use the PyPIRCCommand.realm attribute if it is set.


### PR DESCRIPTION
Revert distutils changes of the commit
696b501cd11dc429a0f661adeb598bfaf89e4112 and remove the realm
variable.

<!-- issue-number: bpo-32155 -->
https://bugs.python.org/issue32155
<!-- /issue-number -->
