### PR TITLE
bpo-32124: C API preinit doc, change note formatting

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -54,12 +54,15 @@ The following functions can be safely called before Python is initialized:
   * :c:func:`PyMem_RawCalloc`
   * :c:func:`PyMem_RawFree`
 
-.. note::
+On the contrary, the following functions **should not be called** before
+:c:func:`Py_Initialize`:
 
-   The following functions **should not be called** before
-   :c:func:`Py_Initialize`: :c:func:`Py_EncodeLocale`, :c:func:`Py_GetPath`,
-   :c:func:`Py_GetPrefix`, :c:func:`Py_GetExecPrefix` and
-   :c:func:`Py_GetProgramFullPath` and :c:func:`Py_GetPythonHome`.
+* :c:func:`Py_EncodeLocale`
+* :c:func:`Py_GetExecPrefix`
+* :c:func:`Py_GetPath`
+* :c:func:`Py_GetPrefix`
+* :c:func:`Py_GetProgramFullPath`
+* :c:func:`Py_GetPythonHome`
 
 
 .. _global-conf-vars:


### PR DESCRIPTION
Format the list of functions that should not be called before
Py_Initialize() as a list, rather than a note.

<!-- issue-number: bpo-32124 -->
https://bugs.python.org/issue32124
<!-- /issue-number -->
