### PR TITLE
bpo-32100: Delete unneeded import in idlelib.pathbrowser.

### DIFF
--- a/Lib/idlelib/pathbrowser.py
+++ b/Lib/idlelib/pathbrowser.py
@@ -3,7 +3,6 @@ import os
 import sys
 
 from idlelib.browser import ModuleBrowser, ModuleBrowserTreeItem
-from idlelib.pyshell import PyShellFileList
 from idlelib.tree import TreeItem
 
 


### PR DESCRIPTION


<!-- issue-number: bpo-32100 -->
https://bugs.python.org/issue32100
<!-- /issue-number -->
