### PR TITLE
[3.6] bpo-32030: Fix test_sys.test_getallocatedblocks()

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -778,6 +778,10 @@ class SysModuleTest(unittest.TestCase):
     @unittest.skipUnless(hasattr(sys, "getallocatedblocks"),
                          "sys.getallocatedblocks unavailable on this build")
     def test_getallocatedblocks(self):
+        if (os.environ.get('PYTHONMALLOC', None)
+           and not sys.flags.ignore_environment):
+            self.skipTest("cannot test if PYTHONMALLOC env var is set")
+
         # Some sanity checks
         with_pymalloc = sysconfig.get_config_var('WITH_PYMALLOC')
         a = sys.getallocatedblocks()


### PR DESCRIPTION
Skip the test if PYTHONMALLOC environment variable is set.

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
