### PR TITLE
bpo-32159: Revert Misc/svnmap.txt

### DIFF
--- a/Misc/README
+++ b/Misc/README
@@ -22,5 +22,7 @@ README.AIX              Information about using Python on AIX
 README.coverity         Information about running Coverity's Prevent on Python
 README.valgrind         Information for Valgrind users, see valgrind-python.supp
 SpecialBuilds.txt       Describes extra symbols you can set for debug builds
+svnmap.txt              Map of old SVN revs and branches to hg changeset ids,
+                        help history-digging
 valgrind-python.supp    Valgrind suppression file, see README.valgrind
 vgrindefs               Python configuration for vgrind (a generic pretty printer)


### PR DESCRIPTION
Partially revert the commit fe2d5babba5d26de2093b6518316b268488187be.
Clarify the usage of this file in Misc/README.

<!-- issue-number: bpo-32159 -->
https://bugs.python.org/issue32159
<!-- /issue-number -->
