### PR TITLE
bpo-32178: Fix IndexError on invalid email group header parsing

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2278,7 +2278,7 @@ def get_group(value):
     if not value:
         group.defects.append(errors.InvalidHeaderDefect(
             "end of header in group"))
-    if value[0] != ';':
+    if not value or value[0] != ';':
         raise errors.HeaderParseError(
             "expected ';' at end of group but found {}".format(value))
     group.append(ValueTerminal(';', 'group-terminator'))


### PR DESCRIPTION
With some malformed email address list, the parser for email groups raises an `IndexError` instead of the correct `HeaderParseError`.

This results in a complete failure to parse the email while it is still preferable to just ignore the malformed header.

An example of such a malformed list is this:
`To: :Foo <foo@example.com> <bar@example.com>`

<!-- issue-number: bpo-32178 -->
https://bugs.python.org/issue32178
<!-- /issue-number -->
