### PR TITLE
bpo-31705: Skip test_socket.test_sha256() on ppc64

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5573,6 +5573,9 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
         else:
             return sock
 
+    # bpo-31705: On kernel older than 4.5, sendto() failed with ENOKEY,
+    # at least on ppc64le architecture
+    @support.requires_linux_version(4, 5)
     def test_sha256(self):
         expected = bytes.fromhex("ba7816bf8f01cfea414140de5dae2223b00361a396"
                                  "177a9cb410ff61f20015ad")

--- a/Misc/NEWS.d/next/Tests/2017-11-30-12-27-10.bpo-31705.yULW7O.rst
+++ b/Misc/NEWS.d/next/Tests/2017-11-30-12-27-10.bpo-31705.yULW7O.rst
@@ -1,0 +1,3 @@
+Skip test_socket.test_sha256() on Linux kernel older than 4.5. The test
+fails with ENOKEY on kernel 3.10 (on ppc64le). A fix was merged into the
+kernel 4.5.


### PR DESCRIPTION
Skip test_socket.test_sha256() on ppc64 for kernel version older than
4.11.

<!-- issue-number: bpo-31705 -->
https://bugs.python.org/issue31705
<!-- /issue-number -->
