### PR TITLE
bpo-32179: Fix handling of empty email address in header parsing

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -980,7 +980,7 @@ class LocalPart(TokenList):
             if (last_is_tl and tok.token_type == 'dot' and
                     last[-1].token_type == 'cfws'):
                 res[-1] = TokenList(last[:-1])
-            is_tl = isinstance(tok, TokenList)
+            is_tl = isinstance(tok, TokenList) and len(tok)
             if (is_tl and last.token_type == 'dot' and
                     tok[0].token_type == 'cfws'):
                 res.append(TokenList(tok[1:]))


### PR DESCRIPTION
In case an address email header contains and empty string, the tokenizer return a `BareQuotedString`
which is also a `TokenList`, but this list is empty and the parser fails to check this and insteads raises an `IndexError`.

For example an email with this header will trigger the `IndexError`:
`ReplyTo: ""`

<!-- issue-number: bpo-32179 -->
https://bugs.python.org/issue32179
<!-- /issue-number -->
