### PR TITLE
Fix Coverity CID-1420310: cast PY_TIMEOUT_MAX to _Py_time_t

### DIFF
--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -1363,7 +1363,7 @@ PyInit__thread(void)
     if (m == NULL)
         return NULL;
 
-    timeout_max = (double)PY_TIMEOUT_MAX * 1e-6;
+    timeout_max = (_PyTime_t)PY_TIMEOUT_MAX * 1e-6;
     time_max = _PyTime_AsSecondsDouble(_PyTime_MAX);
     timeout_max = Py_MIN(timeout_max, time_max);
     /* Round towards minus infinity */


### PR DESCRIPTION
Fix the following false-alarm warning:

    Result is not floating-point
    (UNINTENDED_INTEGER_DIVISION)integer_division: Dividing integer
    expressions 9223372036854775807LL and 1000LL, and then converting
    the integer quotient to type double. Any remainder, or fractional
    part of the quotient, is ignored.

    To compute and use a non-integer quotient, change or cast either
    operand to type double. If integer division is intended, consider
    indicating that by casting the result to type long long .