### PR TITLE
Fix CID-1414686: PyInit_readline() handles errors

### DIFF
--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1352,13 +1352,27 @@ PyInit_readline(void)
     if (m == NULL)
         return NULL;
 
+    if (PyModule_AddIntConstant(m, "_READLINE_VERSION",
+                                RL_READLINE_VERSION) < 0) {
+        goto error;
+    }
+    if (PyModule_AddIntConstant(m, "_READLINE_RUNTIME_VERSION",
+                                rl_readline_version) < 0) {
+        goto error;
+    }
+    if (PyModule_AddStringConstant(m, "_READLINE_LIBRARY_VERSION",
+                                   rl_library_version) < 0)
+    {
+        goto error;
+    }
+
     mod_state = (readlinestate *) PyModule_GetState(m);
     PyOS_ReadlineFunctionPointer = call_readline;
     setup_readline(mod_state);
 
-    PyModule_AddIntConstant(m, "_READLINE_VERSION", RL_READLINE_VERSION);
-    PyModule_AddIntConstant(m, "_READLINE_RUNTIME_VERSION", rl_readline_version);
-    PyModule_AddStringConstant(m, "_READLINE_LIBRARY_VERSION", rl_library_version);
-
     return m;
+
+error:
+    Py_DECREF(m);
+    return NULL;
 }


### PR DESCRIPTION
Handle PyModule_AddIntConstant() and PyModule_AddStringConstant()
failures. Add also constants before calling setup_readline(), since
setup_readline() registers callbacks which uses a reference to the
module, whereas the module is destroyed if adding constants fails.

Fix Coverity warning:

CID 1414686: Unchecked return value (CHECKED_RETURN)
2. check_return: Calling PyModule_AddStringConstant without checking
return value (as is done elsewhere 45 out of 55 times).