### PR TITLE
[2.7] bpo-32186: Release the GIL during fstat and lseek calls

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-11-30-20-33-22.bpo-32186.O42bVe.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-30-20-33-22.bpo-32186.O42bVe.rst
@@ -1,0 +1,4 @@
+Creating io.FileIO() object now releases the GIL when checking the file
+descriptor. io.FileIO.readall() and io.FileIO.read() now release the GIL
+when getting the file size.  Fixed hang of all threads with inaccessible
+NFS server.  Patch by Nir Soffer.

--- a/Misc/NEWS.d/next/Library/2017-11-30-20-33-22.bpo-32186.O42bVe.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-30-20-33-22.bpo-32186.O42bVe.rst
@@ -1,4 +1,4 @@
-Creating io.FileIO() object now releases the GIL when checking the file
-descriptor. io.FileIO.readall() and io.FileIO.read() now release the GIL
-when getting the file size.  Fixed hang of all threads with inaccessible
-NFS server.  Patch by Nir Soffer.
+Creating io.FileIO() and builtin file() objects now release the GIL when
+checking the file descriptor. io.FileIO.readall(), io.FileIO.read(), and
+file.read() now release the GIL when getting the file size.  Fixed hang of all
+threads with inaccessible NFS server.  Patch by Nir Soffer.


### PR DESCRIPTION
In fileio, there were 3 fstat() calls and one lseek() call that did not
release the GIL during the call. This can cause all threads to hang for
unlimited time when using io.FileIO with inaccessible NFS server.

<!-- issue-number: bpo-32186 -->
https://bugs.python.org/issue32186
<!-- /issue-number -->
