### PR TITLE
bpo-32186: Release the GIL during lseek and fstat

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-11-30-20-38-16.bpo-32186.O42bVe.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-30-20-38-16.bpo-32186.O42bVe.rst
@@ -1,0 +1,3 @@
+Fixed hang of all threads when using io.FileIO with inaccessible NFS server.
+Now only the thread accessing the problematic storage will hang.  Patch by
+Nir Soffer.

--- a/Misc/NEWS.d/next/Library/2017-11-30-20-38-16.bpo-32186.O42bVe.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-30-20-38-16.bpo-32186.O42bVe.rst
@@ -1,3 +1,3 @@
-Fixed hang of all threads when using io.FileIO with inaccessible NFS server.
-Now only the thread accessing the problematic storage will hang.  Patch by
-Nir Soffer.
+io.FileIO.readall() and io.FileIO.read() now release the GIL when
+getting the file size. Fixed hang of all threads with inaccessible NFS
+server.  Patch by Nir Soffer.

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -683,10 +683,12 @@ _io_FileIO_readall_impl(fileio *self)
     Py_ssize_t bytes_read = 0;
     Py_ssize_t n;
     size_t bufsize;
+    int fstat_result;
 
     if (self->fd < 0)
         return err_closed();
 
+    Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
 #ifdef MS_WINDOWS
     pos = _lseeki64(self->fd, 0L, SEEK_CUR);
@@ -694,8 +696,10 @@ _io_FileIO_readall_impl(fileio *self)
     pos = lseek(self->fd, 0L, SEEK_CUR);
 #endif
     _Py_END_SUPPRESS_IPH
+    fstat_result = _Py_fstat_noraise(self->fd, &status);
+    Py_END_ALLOW_THREADS
 
-    if (_Py_fstat_noraise(self->fd, &status) == 0)
+    if (fstat_result == 0)
         end = status.st_size;
     else
         end = (Py_off_t)-1;


### PR DESCRIPTION
In _io_FileIO_readall_impl, lseek and _Py_fstat_noraise were called
without releasing the GIL. This can cause all threads to hang for
unlimited time when calling FileIO.read() and the NFS server is not
accessible.

<!-- issue-number: bpo-32186 -->
https://bugs.python.org/issue32186
<!-- /issue-number -->
