### PR TITLE
bpo-32030: Cleanup "path config" code

### DIFF
--- a/Include/internal/pystate.h
+++ b/Include/internal/pystate.h
@@ -37,6 +37,22 @@ struct _gilstate_runtime_state {
 #define _PyGILState_check_enabled _PyRuntime.gilstate.check_enabled
 
 
+typedef struct {
+    /* Full path to the Python program */
+    wchar_t *program_full_path;
+    wchar_t *prefix;
+#ifdef MS_WINDOWS
+    wchar_t *dll_path;
+#else
+    wchar_t *exec_prefix;
+#endif
+    /* Set by Py_SetPath(), or computed by _PyPathConfig_Init() */
+    wchar_t *module_search_path;
+} _PyPathConfig;
+
+#define _PyPathConfig_INIT {.module_search_path = NULL}
+
+
 /* Full Python runtime state */
 
 typedef struct pyruntimestate {

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -564,6 +564,8 @@ PyMem_Free(void *ptr)
 wchar_t*
 _PyMem_RawWcsdup(const wchar_t *str)
 {
+    assert(str != NULL);
+
     size_t len = wcslen(str);
     if (len > (size_t)PY_SSIZE_T_MAX / sizeof(wchar_t) - 1) {
         return NULL;
@@ -582,13 +584,12 @@ _PyMem_RawWcsdup(const wchar_t *str)
 char *
 _PyMem_RawStrdup(const char *str)
 {
-    size_t size;
-    char *copy;
-
-    size = strlen(str) + 1;
-    copy = PyMem_RawMalloc(size);
-    if (copy == NULL)
+    assert(str != NULL);
+    size_t size = strlen(str) + 1;
+    char *copy = PyMem_RawMalloc(size);
+    if (copy == NULL) {
         return NULL;
+    }
     memcpy(copy, str, size);
     return copy;
 }
@@ -596,13 +597,12 @@ _PyMem_RawStrdup(const char *str)
 char *
 _PyMem_Strdup(const char *str)
 {
-    size_t size;
-    char *copy;
-
-    size = strlen(str) + 1;
-    copy = PyMem_Malloc(size);
-    if (copy == NULL)
+    assert(str != NULL);
+    size_t size = strlen(str) + 1;
+    char *copy = PyMem_Malloc(size);
+    if (copy == NULL) {
         return NULL;
+    }
     memcpy(copy, str, size);
     return copy;
 }


### PR DESCRIPTION
* Rename PyPathConfig structure to _PyPathConfig and move it to
  Include/internal/pystate.h
* Rename path_config to _Py_path_config
* _PyPathConfig: Rename program_name field to program_full_path
* Add assert(str != NULL); to _PyMem_RawWcsdup(), _PyMem_RawStrdup()
  and _PyMem_Strdup().
* Rename calculate_path() to pathconfig_global_init(). The function
  now does nothing if it's already initiallized.

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
