### PR TITLE
bpo-32030: Fix Py_GetPath(): init program_name

### DIFF
--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -117,10 +117,7 @@ extern "C" {
 
 typedef struct {
     wchar_t *path_env;                 /* PATH environment variable */
-    wchar_t *home;                     /* PYTHONHOME environment variable */
-    wchar_t *module_search_path_env;   /* PYTHONPATH environment variable */
 
-    wchar_t *program_name;             /* Program name */
     wchar_t *pythonpath;               /* PYTHONPATH define */
     wchar_t *prefix;                   /* PREFIX define */
     wchar_t *exec_prefix;              /* EXEC_PREFIX define */
@@ -360,14 +357,15 @@ find_env_config_value(FILE * env_file, const wchar_t * key, wchar_t * value)
    bytes long.
 */
 static int
-search_for_prefix(PyCalculatePath *calculate, wchar_t *prefix)
+search_for_prefix(const _PyMainInterpreterConfig *main_config,
+                  PyCalculatePath *calculate, wchar_t *prefix)
 {
     size_t n;
     wchar_t *vpath;
 
     /* If PYTHONHOME is set, we believe it unconditionally */
-    if (calculate->home) {
-        wcsncpy(prefix, calculate->home, MAXPATHLEN);
+    if (main_config->home) {
+        wcsncpy(prefix, main_config->home, MAXPATHLEN);
         prefix[MAXPATHLEN] = L'\0';
         wchar_t *delim = wcschr(prefix, DELIM);
         if (delim) {
@@ -426,9 +424,10 @@ search_for_prefix(PyCalculatePath *calculate, wchar_t *prefix)
 
 
 static void
-calculate_prefix(PyCalculatePath *calculate, wchar_t *prefix)
+calculate_prefix(const _PyMainInterpreterConfig *main_config,
+                 PyCalculatePath *calculate, wchar_t *prefix)
 {
-    calculate->prefix_found = search_for_prefix(calculate, prefix);
+    calculate->prefix_found = search_for_prefix(main_config, calculate, prefix);
     if (!calculate->prefix_found) {
         if (!Py_FrozenFlag) {
             fprintf(stderr,
@@ -470,18 +469,19 @@ calculate_reduce_prefix(PyCalculatePath *calculate, wchar_t *prefix)
    MAXPATHLEN bytes long.
 */
 static int
-search_for_exec_prefix(PyCalculatePath *calculate, wchar_t *exec_prefix)
+search_for_exec_prefix(const _PyMainInterpreterConfig *main_config,
+                       PyCalculatePath *calculate, wchar_t *exec_prefix)
 {
     size_t n;
 
     /* If PYTHONHOME is set, we believe it unconditionally */
-    if (calculate->home) {
-        wchar_t *delim = wcschr(calculate->home, DELIM);
+    if (main_config->home) {
+        wchar_t *delim = wcschr(main_config->home, DELIM);
         if (delim) {
             wcsncpy(exec_prefix, delim+1, MAXPATHLEN);
         }
         else {
-            wcsncpy(exec_prefix, calculate->home, MAXPATHLEN);
+            wcsncpy(exec_prefix, main_config->home, MAXPATHLEN);
         }
         exec_prefix[MAXPATHLEN] = L'\0';
         joinpath(exec_prefix, calculate->lib_python);
@@ -552,9 +552,12 @@ search_for_exec_prefix(PyCalculatePath *calculate, wchar_t *exec_prefix)
 
 
 static void
-calculate_exec_prefix(PyCalculatePath *calculate, wchar_t *exec_prefix)
+calculate_exec_prefix(const _PyMainInterpreterConfig *main_config,
+                      PyCalculatePath *calculate, wchar_t *exec_prefix)
 {
-    calculate->exec_prefix_found = search_for_exec_prefix(calculate, exec_prefix);
+    calculate->exec_prefix_found = search_for_exec_prefix(main_config,
+                                                          calculate,
+                                                          exec_prefix);
     if (!calculate->exec_prefix_found) {
         if (!Py_FrozenFlag) {
             fprintf(stderr,
@@ -585,7 +588,8 @@ calculate_reduce_exec_prefix(PyCalculatePath *calculate, wchar_t *exec_prefix)
 
 
 static _PyInitError
-calculate_program_full_path(PyCalculatePath *calculate, _PyPathConfig *config)
+calculate_program_full_path(const _PyMainInterpreterConfig *main_config,
+                            PyCalculatePath *calculate, _PyPathConfig *config)
 {
     wchar_t program_full_path[MAXPATHLEN+1];
     memset(program_full_path, 0, sizeof(program_full_path));
@@ -604,8 +608,8 @@ calculate_program_full_path(PyCalculatePath *calculate, _PyPathConfig *config)
      * other way to find a directory to start the search from.  If
      * $PATH isn't exported, you lose.
      */
-    if (wcschr(calculate->program_name, SEP)) {
-        wcsncpy(program_full_path, calculate->program_name, MAXPATHLEN);
+    if (wcschr(main_config->program_name, SEP)) {
+        wcsncpy(program_full_path, main_config->program_name, MAXPATHLEN);
     }
 #ifdef __APPLE__
      /* On Mac OS X, if a script uses an interpreter of the form
@@ -645,7 +649,7 @@ calculate_program_full_path(PyCalculatePath *calculate, _PyPathConfig *config)
                 wcsncpy(program_full_path, path, MAXPATHLEN);
             }
 
-            joinpath(program_full_path, calculate->program_name);
+            joinpath(program_full_path, main_config->program_name);
             if (isxfile(program_full_path)) {
                 break;
             }
@@ -810,14 +814,15 @@ calculate_zip_path(PyCalculatePath *calculate, const wchar_t *prefix)
 
 
 static _PyInitError
-calculate_module_search_path(PyCalculatePath *calculate,
+calculate_module_search_path(const _PyMainInterpreterConfig *main_config,
+                             PyCalculatePath *calculate,
                              const wchar_t *prefix, const wchar_t *exec_prefix,
                              _PyPathConfig *config)
 {
     /* Calculate size of return buffer */
     size_t bufsz = 0;
-    if (calculate->module_search_path_env != NULL) {
-        bufsz += wcslen(calculate->module_search_path_env) + 1;
+    if (main_config->module_search_path_env != NULL) {
+        bufsz += wcslen(main_config->module_search_path_env) + 1;
     }
 
     wchar_t *defpath = calculate->pythonpath;
@@ -851,8 +856,8 @@ calculate_module_search_path(PyCalculatePath *calculate,
     buf[0] = '\0';
 
     /* Run-time value of $PYTHONPATH goes first */
-    if (calculate->module_search_path_env) {
-        wcscpy(buf, calculate->module_search_path_env);
+    if (main_config->module_search_path_env) {
+        wcscpy(buf, main_config->module_search_path_env);
         wcscat(buf, delimiter);
     }
 
@@ -903,10 +908,6 @@ static _PyInitError
 calculate_init(PyCalculatePath *calculate,
                const _PyMainInterpreterConfig *main_config)
 {
-    calculate->home = main_config->home;
-    calculate->module_search_path_env = main_config->module_search_path_env;
-    calculate->program_name = main_config->program_name;
-
     size_t len;
     char *path = getenv("PATH");
     if (path) {
@@ -948,9 +949,12 @@ calculate_free(PyCalculatePath *calculate)
 
 
 static _PyInitError
-calculate_path_impl(PyCalculatePath *calculate, _PyPathConfig *config)
+calculate_path_impl(const _PyMainInterpreterConfig *main_config,
+                    PyCalculatePath *calculate, _PyPathConfig *config)
 {
-    _PyInitError err = calculate_program_full_path(calculate, config);
+    _PyInitError err;
+
+    err = calculate_program_full_path(main_config, calculate, config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -964,13 +968,13 @@ calculate_path_impl(PyCalculatePath *calculate, _PyPathConfig *config)
 
     wchar_t prefix[MAXPATHLEN+1];
     memset(prefix, 0, sizeof(prefix));
-    calculate_prefix(calculate, prefix);
+    calculate_prefix(main_config, calculate, prefix);
 
     calculate_zip_path(calculate, prefix);
 
     wchar_t exec_prefix[MAXPATHLEN+1];
     memset(exec_prefix, 0, sizeof(exec_prefix));
-    calculate_exec_prefix(calculate, exec_prefix);
+    calculate_exec_prefix(main_config, calculate, exec_prefix);
 
     if ((!calculate->prefix_found || !calculate->exec_prefix_found) &&
         !Py_FrozenFlag)
@@ -979,8 +983,8 @@ calculate_path_impl(PyCalculatePath *calculate, _PyPathConfig *config)
                 "Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]\n");
     }
 
-    err = calculate_module_search_path(calculate, prefix, exec_prefix,
-                                       config);
+    err = calculate_module_search_path(main_config, calculate,
+                                       prefix, exec_prefix, config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -1041,7 +1045,7 @@ _PyPathConfig_Init(const _PyMainInterpreterConfig *main_config)
     _PyPathConfig new_path_config;
     memset(&new_path_config, 0, sizeof(new_path_config));
 
-    err = calculate_path_impl(&calculate, &new_path_config);
+    err = calculate_path_impl(main_config, &calculate, &new_path_config);
     if (_Py_INIT_FAILED(err)) {
         pathconfig_clear(&new_path_config);
         goto done;
@@ -1068,14 +1072,26 @@ pathconfig_global_init(void)
     _PyMainInterpreterConfig config = _PyMainInterpreterConfig_INIT;
 
     err = _PyMainInterpreterConfig_ReadEnv(&config);
-    if (!_Py_INIT_FAILED(err)) {
-        err = _PyPathConfig_Init(&config);
-    }
-    _PyMainInterpreterConfig_Clear(&config);
-
     if (_Py_INIT_FAILED(err)) {
-        _Py_FatalInitError(err);
+        goto error;
     }
+
+    err = _PyMainInterpreterConfig_Read(&config);
+    if (_Py_INIT_FAILED(err)) {
+        goto error;
+    }
+
+    err = _PyPathConfig_Init(&config);
+    if (_Py_INIT_FAILED(err)) {
+        goto error;
+    }
+
+    _PyMainInterpreterConfig_Clear(&config);
+    return;
+
+error:
+    _PyMainInterpreterConfig_Clear(&config);
+    _Py_FatalInitError(err);
 }
 
 


### PR DESCRIPTION
* _PyMainInterpreterConfig_ReadEnv() now sets program_name from
  environment variables and pymain_parse_envvars() implements the
  falls back on argv[0].
* Remove _PyMain.program_name: use the program_name from
  _PyMainInterpreterConfig
* Move the Py_SetProgramName() call back to pymain_init_python(),
  just before _Py_InitializeCore().
* pathconfig_global_init() now also calls
  _PyMainInterpreterConfig_Read() to set program_name if it isn't set
  yet
* Cleanup PyCalculatePath: pass main_config to subfunctions to get
  directly fields from main_config (home, module_search_path_env and
  program_name)

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
