### PR TITLE
gh-76377: Rewrite plistlib with functional style.

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-12-01-23-15-38.bpo-32196.5w1QQF.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-01-23-15-38.bpo-32196.5w1QQF.rst
@@ -1,0 +1,2 @@
+Loading and saving plist files is now 10% faster.  Saving plist files with
+XML format can be up to 2 times faster.


### PR DESCRIPTION
This speeds up most loadings and savings around 10%.  Saving
with XML format has been sped up to 2 times.


<!-- issue-number: bpo-32196 -->
https://bugs.python.org/issue32196
<!-- /issue-number -->


<!-- gh-issue-number: gh-76377 -->
* Issue: gh-76377
<!-- /gh-issue-number -->
