### PR TITLE
bpo-32030: _PyPathConfig_Init() sets home and program_name

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -40,7 +40,6 @@ The following functions can be safely called before Python is initialized:
   * :c:func:`Py_GetCompiler`
   * :c:func:`Py_GetCopyright`
   * :c:func:`Py_GetPlatform`
-  * :c:func:`Py_GetProgramName`
   * :c:func:`Py_GetVersion`
 
 * Utilities:
@@ -59,8 +58,8 @@ The following functions can be safely called before Python is initialized:
    The following functions **should not be called** before
    :c:func:`Py_Initialize`: :c:func:`Py_EncodeLocale`, :c:func:`Py_GetPath`,
    :c:func:`Py_GetPrefix`, :c:func:`Py_GetExecPrefix`,
-   :c:func:`Py_GetProgramFullPath`, :c:func:`Py_GetPythonHome` and
-   :c:func:`PyEval_InitThreads`.
+   :c:func:`Py_GetProgramFullPath`, :c:func:`Py_GetPythonHome`,
+   :c:func:`Py_GetProgramName` and :c:func:`PyEval_InitThreads`.
 
 
 .. _global-conf-vars:

--- a/Include/internal/pystate.h
+++ b/Include/internal/pystate.h
@@ -48,12 +48,35 @@ typedef struct {
 #endif
     /* Set by Py_SetPath(), or computed by _PyPathConfig_Init() */
     wchar_t *module_search_path;
+    /* Python program name */
+    wchar_t *program_name;
+    /* Set by Py_SetPythonHome() or PYTHONHOME environment variable */
+    wchar_t *home;
 } _PyPathConfig;
 
-#define _PyPathConfig_INIT {.module_search_path = NULL}
+#ifdef MS_WINDOWS
+#define _PyPathConfig_INIT \
+    {.program_full_path = NULL, \
+     .prefix = NULL, \
+     .dll_path = NULL, \
+     .module_search_path = NULL, \
+     .program_name = NULL, \
+     .home = NULL}
+#else
+#define _PyPathConfig_INIT \
+    {.program_full_path = NULL, \
+     .prefix = NULL, \
+     .exec_prefix = NULL, \
+     .module_search_path = NULL, \
+     .program_name = NULL, \
+     .home = NULL}
+#endif
 
 PyAPI_DATA(_PyPathConfig) _Py_path_config;
 
+PyAPI_FUNC(_PyInitError) _PyPathConfig_Calculate(
+    _PyPathConfig *config,
+    const _PyMainInterpreterConfig *main_config);
 PyAPI_FUNC(void) _PyPathConfig_Clear(_PyPathConfig *config);
 
 

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -72,7 +72,8 @@ typedef struct {
     (_PyMainInterpreterConfig){\
      .install_signal_handlers = -1, \
      .module_search_path_env = NULL, \
-     .home = NULL}
+     .home = NULL, \
+     .program_name = NULL}
 
 typedef struct _is {
 

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -1008,16 +1008,10 @@ calculate_path_impl(const _PyMainInterpreterConfig *main_config,
 }
 
 
-/* Initialize paths for Py_GetPath(), Py_GetPrefix(), Py_GetExecPrefix()
-   and Py_GetProgramFullPath() */
 _PyInitError
-_PyPathConfig_Init(const _PyMainInterpreterConfig *main_config)
+_PyPathConfig_Calculate(_PyPathConfig *config,
+                        const _PyMainInterpreterConfig *main_config)
 {
-    if (_Py_path_config.module_search_path) {
-        /* Already initialized */
-        return _Py_INIT_OK();
-    }
-
     PyCalculatePath calculate;
     memset(&calculate, 0, sizeof(calculate));
 
@@ -1026,16 +1020,11 @@ _PyPathConfig_Init(const _PyMainInterpreterConfig *main_config)
         goto done;
     }
 
-    _PyPathConfig new_path_config;
-    memset(&new_path_config, 0, sizeof(new_path_config));
-
-    err = calculate_path_impl(main_config, &calculate, &new_path_config);
+    err = calculate_path_impl(main_config, &calculate, config);
     if (_Py_INIT_FAILED(err)) {
-        _PyPathConfig_Clear(&new_path_config);
         goto done;
     }
 
-    _Py_path_config = new_path_config;
     err = _Py_INIT_OK();
 
 done:

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -1058,38 +1058,23 @@ calculate_free(PyCalculatePath *calculate)
 }
 
 
-/* Initialize paths for Py_GetPath(), Py_GetPrefix(), Py_GetExecPrefix()
-   and Py_GetProgramFullPath() */
 _PyInitError
-_PyPathConfig_Init(const _PyMainInterpreterConfig *main_config)
+_PyPathConfig_Calculate(_PyPathConfig *config,
+                        const _PyMainInterpreterConfig *main_config)
 {
-    if (_Py_path_config.module_search_path) {
-        /* Already initialized */
-        return _Py_INIT_OK();
-    }
-
-    _PyInitError err;
-
     PyCalculatePath calculate;
     memset(&calculate, 0, sizeof(calculate));
 
     calculate_init(&calculate, main_config);
 
-    _PyPathConfig new_path_config;
-    memset(&new_path_config, 0, sizeof(new_path_config));
-
-    err = calculate_path_impl(main_config, &calculate, &new_path_config);
+    _PyInitError err = calculate_path_impl(main_config, &calculate, config);
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }
 
-    _Py_path_config = new_path_config;
     err = _Py_INIT_OK();
 
 done:
-    if (_Py_INIT_FAILED(err)) {
-        _PyPathConfig_Clear(&new_path_config);
-    }
     calculate_free(&calculate);
     return err;
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -804,7 +804,12 @@ _PyMainInterpreterConfig_Read(_PyMainInterpreterConfig *config)
     }
 
     if (config->program_name == NULL) {
-        config->program_name = _PyMem_RawWcsdup(Py_GetProgramName());
+#ifdef MS_WINDOWS
+        const wchar_t *program_name = L"python";
+#else
+        const wchar_t *program_name = L"python3";
+#endif
+        config->program_name = _PyMem_RawWcsdup(program_name);
         if (config->program_name == NULL) {
             return _Py_INIT_NO_MEMORY();
         }


### PR DESCRIPTION
_PyPathConfig_Init() now also initialize home and program_name:

* Rename existing _PyPathConfig_Init() to _PyPathConfig_Calculate().
  Add a new _PyPathConfig_Init() function in pathconfig.c which
  handles the _Py_path_config variable and call
  _PyPathConfig_Calculate().
* Add home and program_name fields to _PyPathConfig.home
* _PyPathConfig_Init() now initialize home and program_name
  from main_config
* Py_SetProgramName(), Py_SetPythonHome() and Py_GetPythonHome() now
  calls Py_FatalError() on failure, instead of silently ignoring
  failures.
* config_init_home() now gets directly _Py_path_config.home to only
  get the value set by Py_SetPythonHome(), or NULL if
  Py_SetPythonHome() was not called.
* config_get_program_name() now gets directly
  _Py_path_config.program_name to only get the value set by
  Py_SetProgramName(), or NULL if Py_SetProgramName() was not called.
* pymain_init_python() doesn't call Py_SetProgramName() anymore,
  _PyPathConfig_Init() now always sets the program name
* Call _PyMainInterpreterConfig_Read() in
  pymain_parse_cmdline_envvars_impl() to control the memory allocator

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
