### PR TITLE
bpo-25910: Fixes redirection from http to https

### DIFF
--- a/Doc/bugs.rst
+++ b/Doc/bugs.rst
@@ -68,7 +68,7 @@ taken on the bug.
 
 .. seealso::
 
-   `How to Report Bugs Effectively <http://www.chiark.greenend.org.uk/~sgtatham/bugs.html>`_
+   `How to Report Bugs Effectively <https://www.chiark.greenend.org.uk/~sgtatham/bugs.html>`_
       Article which goes into some detail about how to create a useful bug report.
       This describes what kind of information is useful and why it is useful.
 

--- a/Doc/faq/design.rst
+++ b/Doc/faq/design.rst
@@ -343,7 +343,7 @@ each Python stack frame.  Also, extensions can call back into Python at almost
 random moments.  Therefore, a complete threads implementation requires thread
 support for C.
 
-Answer 2: Fortunately, there is `Stackless Python <http://www.stackless.com>`_,
+Answer 2: Fortunately, there is `Stackless Python <https://bitbucket.org/stackless-dev/stackless/wiki/Home>`_,
 which has a completely redesigned interpreter loop that avoids the C stack.
 
 

--- a/Doc/faq/gui.rst
+++ b/Doc/faq/gui.rst
@@ -43,11 +43,11 @@ number of platforms, with Windows, Mac OS X, GTK, X11, all listed as
 current stable targets.  Language bindings are available for a number
 of languages including Python, Perl, Ruby, etc.
 
-wxPython (http://www.wxpython.org) is the Python binding for
-wxwidgets.  While it often lags slightly behind the official wxWidgets
-releases, it also offers a number of features via pure Python
-extensions that are not available in other language bindings.  There
-is an active wxPython user and developer community.
+wxPython (https://www.wxpython.org) is the Python binding for wxwidgets.
+While it often lags slightly behind the official wxWidgets releases, it also
+offers a number of features via pure Python extensions that are not
+available in other language bindings.  There is an active wxPython user and
+developer community.
 
 Both wxWidgets and wxPython are free, open source, software with
 permissive licences that allow their use in commercial products as
@@ -72,9 +72,9 @@ Gtk+
 
 The `GObject introspection bindings <https://wiki.gnome.org/Projects/PyGObject>`_
 for Python allow you to write GTK+ 3 applications.  There is also a
-`Python GTK+ 3 Tutorial <https://python-gtk-3-tutorial.readthedocs.org/en/latest/>`_.
+`Python GTK+ 3 Tutorial <https://python-gtk-3-tutorial.readthedocs.io>`_.
 
-The older PyGtk bindings for the `Gtk+ 2 toolkit <http://www.gtk.org>`_ have
+The older PyGtk bindings for the `Gtk+ 2 toolkit <https://www.gtk.org>`_ have
 been implemented by James Henstridge; see <http://www.pygtk.org>.
 
 Kivy

--- a/Doc/faq/gui.rst
+++ b/Doc/faq/gui.rst
@@ -43,11 +43,11 @@ number of platforms, with Windows, Mac OS X, GTK, X11, all listed as
 current stable targets.  Language bindings are available for a number
 of languages including Python, Perl, Ruby, etc.
 
-wxPython (https://www.wxpython.org) is the Python binding for wxwidgets.
-While it often lags slightly behind the official wxWidgets releases, it also
-offers a number of features via pure Python extensions that are not
-available in other language bindings.  There is an active wxPython user and
-developer community.
+`wxPython <https://www.wxpython.org>`_ is the Python binding for
+wxwidgets.  While it often lags slightly behind the official wxWidgets
+releases, it also offers a number of features via pure Python
+extensions that are not available in other language bindings.  There
+is an active wxPython user and developer community.
 
 Both wxWidgets and wxPython are free, open source, software with
 permissive licences that allow their use in commercial products as

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -419,7 +419,7 @@ Python program effectively only uses one CPU, due to the insistence that
 Back in the days of Python 1.5, Greg Stein actually implemented a comprehensive
 patch set (the "free threading" patches) that removed the GIL and replaced it
 with fine-grained locking.  Adam Olsen recently did a similar experiment
-in his `python-safethread <http://code.google.com/p/python-safethread/>`_
+in his `python-safethread <https://code.google.com/archive/p/python-safethread>`_
 project.  Unfortunately, both experiments exhibited a sharp drop in single-thread
 performance (at least 30% slower), due to the amount of fine-grained locking
 necessary to compensate for the removal of the GIL.

--- a/Doc/faq/programming.rst
+++ b/Doc/faq/programming.rst
@@ -100,7 +100,7 @@ which don't. One is Thomas Heller's py2exe (Windows only) at
 
     http://www.py2exe.org/
 
-Another tool is Anthony Tuininga's `cx_Freeze <http://cx-freeze.sourceforge.net/>`_.
+Another tool is Anthony Tuininga's `cx_Freeze <https://anthony-tuininga.github.io/cx_Freeze/>`_.
 
 
 Are there coding standards or a style guide for Python programs?

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -170,7 +170,7 @@ offender.
 How do I make an executable from a Python script?
 -------------------------------------------------
 
-See https://anthony-tuininga.github.io/cx_Freeze/ for a distutils extension
+See `cx_Freeze <https://anthony-tuininga.github.io/cx_Freeze/>`_ for a distutils extension
 that allows you to create console and GUI executables from Python code.
 `py2exe <http://www.py2exe.org/>`_, the most popular extension for building
 Python 2.x-based executables, does not yet support Python 3 but a version that

--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -170,8 +170,8 @@ offender.
 How do I make an executable from a Python script?
 -------------------------------------------------
 
-See http://cx-freeze.sourceforge.net/ for a distutils extension that allows you
-to create console and GUI executables from Python code.
+See https://anthony-tuininga.github.io/cx_Freeze/ for a distutils extension
+that allows you to create console and GUI executables from Python code.
 `py2exe <http://www.py2exe.org/>`_, the most popular extension for building
 Python 2.x-based executables, does not yet support Python 3 but a version that
 does is in development.

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -126,7 +126,7 @@ Glossary
 
    BDFL
       Benevolent Dictator For Life, a.k.a. `Guido van Rossum
-      <https://www.python.org/~guido/>`_, Python's creator.
+      <https://gvanrossum.github.io/>`_, Python's creator.
 
    binary file
       A :term:`file object` able to read and write

--- a/Doc/howto/curses.rst
+++ b/Doc/howto/curses.rst
@@ -543,7 +543,7 @@ learn more about submitting patches to Python.
 
 * `Writing Programs with NCURSES <http://invisible-island.net/ncurses/ncurses-intro.html>`_:
   a lengthy tutorial for C programmers.
-* `The ncurses man page <http://linux.die.net/man/3/ncurses>`_
+* `The ncurses man page <https://linux.die.net/man/3/ncurses>`_
 * `The ncurses FAQ <http://invisible-island.net/ncurses/ncurses.faq.html>`_
 * `"Use curses... don't swear" <https://www.youtube.com/watch?v=eN1eZtjLEnU>`_:
   video of a PyCon 2013 talk on controlling terminals using curses or Urwid.

--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -449,4 +449,4 @@ to make sure everything functions as expected in both versions of Python.
 
 .. _"What's New": https://docs.python.org/3/whatsnew/index.html
 
-.. _Why Python 3 exists: http://www.snarky.ca/why-python-3-exists
+.. _Why Python 3 exists: https://snarky.ca/why-python-3-exists

--- a/Doc/howto/unicode.rst
+++ b/Doc/howto/unicode.rst
@@ -217,7 +217,7 @@ To help understand the standard, Jukka Korpela has written `an introductory
 guide <https://www.cs.tut.fi/~jkorpela/unicode/guide.html>`_ to reading the
 Unicode character tables.
 
-Another `good introductory article <http://www.joelonsoftware.com/articles/Unicode.html>`_
+Another `good introductory article <https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/>`_
 was written by Joel Spolsky.
 If this introduction didn't make things clear to you, you should try
 reading this alternate article before continuing.
@@ -487,7 +487,7 @@ References
 Some good alternative discussions of Python's Unicode support are:
 
 * `Processing Text Files in Python 3 <http://python-notes.curiousefficiency.org/en/latest/python3/text_file_processing.html>`_, by Nick Coghlan.
-* `Pragmatic Unicode <http://nedbatchelder.com/text/unipain.html>`_, a PyCon 2012 presentation by Ned Batchelder.
+* `Pragmatic Unicode <https://nedbatchelder.com/text/unipain.html>`_, a PyCon 2012 presentation by Ned Batchelder.
 
 The :class:`str` type is described in the Python library reference at
 :ref:`textseq`.

--- a/Doc/library/email.generator.rst
+++ b/Doc/library/email.generator.rst
@@ -53,7 +53,7 @@ over channels that are not "8 bit clean".
    :data:`~email.policy.compat32` policy and ``False`` for all others).
    *mangle_from_* is intended for use when messages are stored in unix mbox
    format (see :mod:`mailbox` and `WHY THE CONTENT-LENGTH FORMAT IS BAD
-   <http://www.jwz.org/doc/content-length.html>`_).
+   <https://www.jwz.org/doc/content-length.html>`_).
 
    If *maxheaderlen* is not ``None``, refold any header lines that are longer
    than *maxheaderlen*, or if ``0``, do not rewrap any headers.  If
@@ -154,7 +154,7 @@ to be using :class:`BytesGenerator`, and not :class:`Generator`.
    :data:`~email.policy.compat32` policy and ``False`` for all others).
    *mangle_from_* is intended for use when messages are stored in unix mbox
    format (see :mod:`mailbox` and `WHY THE CONTENT-LENGTH FORMAT IS BAD
-   <http://www.jwz.org/doc/content-length.html>`_).
+   <https://www.jwz.org/doc/content-length.html>`_).
 
    If *maxheaderlen* is not ``None``, refold any header lines that are longer
    than *maxheaderlen*, or if ``0``, do not rewrap any headers.  If

--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -482,7 +482,7 @@ Keyed hashing
 
 Keyed hashing can be used for authentication as a faster and simpler
 replacement for `Hash-based message authentication code
-<http://en.wikipedia.org/wiki/Hash-based_message_authentication_code>`_ (HMAC).
+<https://en.wikipedia.org/wiki/Hash-based_message_authentication_code>`_ (HMAC).
 BLAKE2 can be securely used in prefix-MAC mode thanks to the
 indifferentiability property inherited from BLAKE.
 
@@ -694,7 +694,7 @@ implementation, extension code, and this documentation:
 
    You should have received a copy of the CC0 Public Domain Dedication along
    with this software. If not, see
-   http://creativecommons.org/publicdomain/zero/1.0/.
+   https://creativecommons.org/publicdomain/zero/1.0/.
 
 The following people have helped with development or contributed their changes
 to the project and the public domain according to the Creative Commons Public

--- a/Doc/library/othergui.rst
+++ b/Doc/library/othergui.rst
@@ -11,9 +11,9 @@ available for Python:
    `PyGObject <https://wiki.gnome.org/Projects/PyGObject>`_
       PyGObject provides introspection bindings for C libraries using
       `GObject <https://developer.gnome.org/gobject/stable/>`_.  One of
-      these libraries is the `GTK+ 3 <http://www.gtk.org/>`_ widget set.
+      these libraries is the `GTK+ 3 <https://www.gtk.org/>`_ widget set.
       GTK+ comes with many more widgets than Tkinter provides.  An online
-      `Python GTK+ 3 Tutorial <https://python-gtk-3-tutorial.readthedocs.org/en/latest/>`_
+      `Python GTK+ 3 Tutorial <https://python-gtk-3-tutorial.readthedocs.io/>`_
       is available.
 
    `PyGTK <http://www.pygtk.org/>`_
@@ -35,7 +35,7 @@ available for Python:
       Compared to PyQt, its licensing scheme is friendlier to non-open source
       applications.
 
-   `wxPython <http://www.wxpython.org>`_
+   `wxPython <https://www.wxpython.org>`_
       wxPython is a cross-platform GUI toolkit for Python that is built around
       the popular `wxWidgets <https://www.wxwidgets.org/>`_ (formerly wxWindows)
       C++ toolkit.  It provides a native look and feel for applications on

--- a/Doc/library/secrets.rst
+++ b/Doc/library/secrets.rst
@@ -130,7 +130,7 @@ Other functions
 
    Return ``True`` if strings *a* and *b* are equal, otherwise ``False``,
    in such a way as to reduce the risk of
-   `timing attacks <http://codahale.com/a-lesson-in-timing-attacks/>`_.
+   `timing attacks <https://codahale.com/a-lesson-in-timing-attacks/>`_.
    See :func:`hmac.compare_digest` for additional details.
 
 
@@ -173,7 +173,7 @@ three digits:
            break
 
 
-Generate an `XKCD-style passphrase <http://xkcd.com/936/>`_:
+Generate an `XKCD-style passphrase <https://xkcd.com/936/>`_:
 
 .. testcode::
 

--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -264,7 +264,7 @@ object.
 Edge and Level Trigger Polling (epoll) Objects
 ----------------------------------------------
 
-   http://linux.die.net/man/4/epoll
+   https://linux.die.net/man/4/epoll
 
    *eventmask*
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -107,7 +107,7 @@ This example uses the iterator form::
       The SQLite web page; the documentation describes the syntax and the
       available data types for the supported SQL dialect.
 
-   http://www.w3schools.com/sql/
+   https://www.w3schools.com/sql/
       Tutorial, reference and examples for learning SQL syntax.
 
    :pep:`249` - Database API Specification 2.0

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1546,7 +1546,7 @@ to speed up repeated connections from the same clients.
    .. versionadded:: 3.3
 
    .. seealso::
-      `SSL/TLS & Perfect Forward Secrecy <http://vincent.bernat.im/en/blog/2011-ssl-perfect-forward-secrecy.html>`_
+      `SSL/TLS & Perfect Forward Secrecy <https://vincent.bernat.im/en/blog/2011-ssl-perfect-forward-secrecy>`_
          Vincent Bernat.
 
 .. method:: SSLContext.wrap_socket(sock, server_side=False, \

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -38,7 +38,7 @@ this should open a window demonstrating a simple Tk interface.
    `Programming Python <http://learning-python.com/books/about-pp4e.html>`_
       Book by Mark Lutz, has excellent coverage of Tkinter.
 
-   `Modern Tkinter for Busy Python Developers <http://www.amazon.com/Modern-Tkinter-Python-Developers-ebook/dp/B0071QDNLO/>`_
+   `Modern Tkinter for Busy Python Developers <https://www.amazon.com/Modern-Tkinter-Python-Developers-ebook/dp/B0071QDNLO/>`_
       Book by Mark Rozerman about building attractive and modern graphical user interfaces with Python and Tkinter.
 
    `Python and Tkinter Programming <https://www.manning.com/books/python-and-tkinter-programming>`_
@@ -183,7 +183,7 @@ documentation that exists. Here are some hints:
    `ActiveState Tcl Home Page <http://tcl.activestate.com/>`_
       The Tk/Tcl development is largely taking place at ActiveState.
 
-   `Tcl and the Tk Toolkit <http://www.amazon.com/exec/obidos/ASIN/020163337X>`_
+   `Tcl and the Tk Toolkit <https://www.amazon.com/exec/obidos/ASIN/020163337X>`_
       The book by John Ousterhout, the inventor of Tcl.
 
    `Practical Programming in Tcl and Tk <http://www.beedub.com/book/>`_

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -56,7 +56,7 @@ test runner
       Kent Beck's original paper on testing frameworks using the pattern shared
       by :mod:`unittest`.
 
-   `Nose <https://nose.readthedocs.org/en/latest/>`_ and `py.test <http://pytest.org>`_
+   `Nose <https://nose.readthedocs.io/>`_ and `py.test <https://docs.pytest.org/>`_
       Third-party unittest frameworks with a lighter-weight syntax for writing
       tests.  For example, ``assert func(10) == 42``.
 

--- a/Doc/tutorial/interactive.rst
+++ b/Doc/tutorial/interactive.rst
@@ -51,4 +51,4 @@ bpython_.
 
 .. _GNU Readline: https://tiswww.case.edu/php/chet/readline/rltop.html
 .. _IPython: https://ipython.org/
-.. _bpython: http://www.bpython-interpreter.org/
+.. _bpython: https://www.bpython-interpreter.org/

--- a/Doc/using/mac.rst
+++ b/Doc/using/mac.rst
@@ -149,7 +149,7 @@ X by Apple, and the latest version can be downloaded and installed from
 https://www.activestate.com; it can also be built from source.
 
 *wxPython* is another popular cross-platform GUI toolkit that runs natively on
-Mac OS X. Packages and documentation are available from http://www.wxpython.org.
+Mac OS X. Packages and documentation are available from https://www.wxpython.org.
 
 *PyQt* is another popular cross-platform GUI toolkit that runs natively on Mac
 OS X. More information can be found at

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -291,9 +291,9 @@ for detailed information about platforms with pre-compiled installers.
       by Mark Pilgrim, 2004,
       ISBN 1-59059-356-1
 
-   `For Windows users <http://python.swaroopch.com/installation.html#installation-on-windows>`_
+   `For Windows users <https://python.swaroopch.com/installation.html#installation-on-windows>`_
       in "Installing Python"
-      in "`A Byte of Python <http://python.swaroopch.com/>`_"
+      in "`A Byte of Python <https://python.swaroopch.com/>`_"
       by Swaroop C H, 2003
 
 
@@ -871,11 +871,11 @@ shipped with PyWin32.  It is an embeddable IDE with a built-in debugger.
 cx_Freeze
 ---------
 
-`cx_Freeze <http://cx-freeze.sourceforge.net/>`_ is a :mod:`distutils`
-extension (see :ref:`extending-distutils`) which wraps Python scripts into
-executable Windows programs (:file:`{*}.exe` files).  When you have done this,
-you can distribute your application without requiring your users to install
-Python.
+`cx_Freeze <https://anthony-tuininga.github.io/cx_Freeze/>`_ is a
+:mod:`distutils` extension (see :ref:`extending-distutils`) which wraps
+Python scripts into executable Windows programs (:file:`{*}.exe` files).
+When you have done this, you can distribute your application without
+requiring your users to install Python.
 
 
 WConio

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -871,11 +871,11 @@ shipped with PyWin32.  It is an embeddable IDE with a built-in debugger.
 cx_Freeze
 ---------
 
-`cx_Freeze <https://anthony-tuininga.github.io/cx_Freeze/>`_ is a
-:mod:`distutils` extension (see :ref:`extending-distutils`) which wraps
-Python scripts into executable Windows programs (:file:`{*}.exe` files).
-When you have done this, you can distribute your application without
-requiring your users to install Python.
+`cx_Freeze <https://anthony-tuininga.github.io/cx_Freeze/>`_ is a :mod:`distutils`
+extension (see :ref:`extending-distutils`) which wraps Python scripts into
+executable Windows programs (:file:`{*}.exe` files).  When you have done this,
+you can distribute your application without requiring your users to install
+Python.
 
 
 WConio

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -1809,7 +1809,7 @@ wish to read the Tcl/Tk manual page describing the
 Ttk theme engine, available at
 https://www.tcl.tk/man/tcl8.5/TkCmd/ttk_intro.htm. Some
 screenshots of the Python/Ttk code in use are at
-http://code.google.com/p/python-ttk/wiki/Screenshots.
+https://code.google.com/archive/p/python-ttk/wikis/Screenshots.wiki.
 
 The :mod:`ttk` module was written by Guilherme Polo and added in
 :issue:`2983`.  An alternate version called ``Tile.py``, written by
@@ -1832,8 +1832,8 @@ https://pypi.python.org/pypi/unittest2.
 
 When used from the command line, the module can automatically discover
 tests.  It's not as fancy as `py.test <http://pytest.org>`__ or
-`nose <http://code.google.com/p/python-nose/>`__, but provides a simple way
-to run tests kept within a set of package directories.  For example,
+`nose <https://code.google.com/archive/p/python-nose>`__, but provides a
+simple way to run tests kept within a set of package directories.  For example,
 the following command will search the :file:`test/` subdirectory for
 any importable test files named ``test*.py``::
 

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -1832,7 +1832,7 @@ https://pypi.python.org/pypi/unittest2.
 
 When used from the command line, the module can automatically discover
 tests.  It's not as fancy as `py.test <http://pytest.org>`__ or
-`nose <https://code.google.com/archive/p/python-nose>`__, but provides a
+`nose <https://nose.readthedocs.io/>`__, but provides a
 simple way to run tests kept within a set of package directories.  For example,
 the following command will search the :file:`test/` subdirectory for
 any importable test files named ``test*.py``::

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -238,7 +238,7 @@ and the ``__annotations__`` attribute.
       and Guido van Rossum. Implemented by Ivan Levkivskyi.
 
    Tools that use or will use the new syntax:
-   `mypy <https://github.com/python/mypy>`_,
+   `mypy <http://www.mypy-lang.org/>`_,
    `pytype <https://github.com/google/pytype>`_, PyCharm, etc.
 
 

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -238,8 +238,8 @@ and the ``__annotations__`` attribute.
       and Guido van Rossum. Implemented by Ivan Levkivskyi.
 
    Tools that use or will use the new syntax:
-   `mypy <http://github.com/python/mypy>`_,
-   `pytype <http://github.com/google/pytype>`_, PyCharm, etc.
+   `mypy <https://github.com/python/mypy>`_,
+   `pytype <https://github.com/google/pytype>`_, PyCharm, etc.
 
 
 .. _whatsnew36-pep515:


### PR DESCRIPTION
This PR extracts changes from https://github.com/python/cpython/pull/1933

Currently focuses mostly on fixing link redirection from http to https.

cc @vstinner 

<!-- issue-number: bpo-25910 -->
https://bugs.python.org/issue25910
<!-- /issue-number -->
