### PR TITLE
bpo-32107: Fix consistency checks in test_uuid.

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -309,7 +309,11 @@ class BaseTestUUID:
 
         # Test it again to ensure consistency.
         node2 = self.uuid.getnode()
-        self.assertEqual(node1, node2, '%012x != %012x' % (node1, node2))
+        if not (node1 & (1 << 40)):
+            # Not randomly generated
+            self.assertEqual(node1, node2, '%012x != %012x' % (node1, node2))
+        elif node1 != node2 and support.verbose:
+            print("Can't retrieve a MAC address")
 
     def test_uuid1(self):
         equal = self.assertEqual
@@ -564,6 +568,9 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
         # $4.1.6.
         self.assertTrue(node & (1 << 40), '%012x' % node)
         self.check_node(node)
+
+        node2 = self.uuid._random_getnode()
+        self.assertNotEqual(node2, node, '%012x' % node)
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_unix_getnode(self):

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -309,11 +309,7 @@ class BaseTestUUID:
 
         # Test it again to ensure consistency.
         node2 = self.uuid.getnode()
-        if not (node1 & (1 << 40)):
-            # Not randomly generated
-            self.assertEqual(node1, node2, '%012x != %012x' % (node1, node2))
-        elif node1 != node2 and support.verbose:
-            print("Can't retrieve a MAC address")
+        self.assertEqual(node1, node2, '%012x != %012x' % (node1, node2))
 
     def test_uuid1(self):
         equal = self.assertEqual

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -674,14 +674,14 @@ def getnode():
         getters = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
                    _arp_getnode, _lanscan_getnode, _netstat_getnode]
 
-    for getter in getters:
+    for getter in getters + [_random_getnode]:
         try:
             _node = getter()
         except:
             continue
         if _node is not None:
             return _node
-    return _random_getnode()
+    assert False, '_random_getnode() returned None'
 
 
 _last_timestamp = None


### PR DESCRIPTION
get_node() should return a stable result only if there are other working methods beside generating an address randomly.


<!-- issue-number: bpo-32107 -->
https://bugs.python.org/issue32107
<!-- /issue-number -->
