### PR TITLE
Refactor PyImport_ImportModuleLevelObject().

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -1730,8 +1730,9 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
     }
     else {
         mod = import_find_and_load(abs_name);
-        if (mod == NULL)
+        if (mod == NULL) {
             goto error;
+        }
     }
 
     has_from = 0;

--- a/Python/import.c
+++ b/Python/import.c
@@ -1589,12 +1589,67 @@ resolve_name(PyObject *name, PyObject *globals, int level)
     return NULL;
 }
 
+static PyObject *
+import_find_and_load(PyObject *abs_name)
+{
+    _Py_IDENTIFIER(_find_and_load);
+    PyObject *mod = NULL;
+    PyInterpreterState *interp = PyThreadState_GET()->interp;
+    int import_time = interp->core_config.import_time;
+    static int import_level;
+    static _PyTime_t accumulated;
+
+    _PyTime_t t1 = 0, accumulated_copy = accumulated;
+
+    /* XOptions is initialized after first some imports.
+     * So we can't have negative cache before completed initialization.
+     * Anyway, importlib._find_and_load is much slower than
+     * _PyDict_GetItemIdWithError().
+     */
+    if (import_time) {
+        static int header = 1;
+        if (header) {
+            fputs("import time: self [us] | cumulative | imported package\n",
+                  stderr);
+            header = 0;
+        }
+
+        import_level++;
+        t1 = _PyTime_GetPerfCounter();
+        accumulated = 0;
+    }
+
+    if (PyDTrace_IMPORT_FIND_LOAD_START_ENABLED())
+        PyDTrace_IMPORT_FIND_LOAD_START(PyUnicode_AsUTF8(abs_name));
+
+    mod = _PyObject_CallMethodIdObjArgs(interp->importlib,
+                                        &PyId__find_and_load, abs_name,
+                                        interp->import_func, NULL);
+
+    if (PyDTrace_IMPORT_FIND_LOAD_DONE_ENABLED())
+        PyDTrace_IMPORT_FIND_LOAD_DONE(PyUnicode_AsUTF8(abs_name),
+                                       mod != NULL);
+
+    if (import_time) {
+        _PyTime_t cum = _PyTime_GetPerfCounter() - t1;
+
+        import_level--;
+        fprintf(stderr, "import time: %9ld | %10ld | %*s%s\n",
+                (long)_PyTime_AsMicroseconds(cum - accumulated, _PyTime_ROUND_CEILING),
+                (long)_PyTime_AsMicroseconds(cum, _PyTime_ROUND_CEILING),
+                import_level*2, "", PyUnicode_AsUTF8(abs_name));
+
+        accumulated = accumulated_copy + cum;
+    }
+
+    return mod;
+}
+
 PyObject *
 PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
                                  PyObject *locals, PyObject *fromlist,
                                  int level)
 {
-    _Py_IDENTIFIER(_find_and_load);
     _Py_IDENTIFIER(_handle_fromlist);
     PyObject *abs_name = NULL;
     PyObject *final_mod = NULL;
@@ -1674,58 +1729,9 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
         }
     }
     else {
-        int import_time = interp->core_config.import_time;
-        static int import_level;
-        static _PyTime_t accumulated;
-
-        _PyTime_t t1 = 0, accumulated_copy = accumulated;
-
-        /* XOptions is initialized after first some imports.
-         * So we can't have negative cache before completed initialization.
-         * Anyway, importlib._find_and_load is much slower than
-         * _PyDict_GetItemIdWithError().
-         */
-        if (import_time) {
-            static int header = 1;
-            if (header) {
-                fputs("import time: self [us] | cumulative | imported package\n",
-                      stderr);
-                header = 0;
-            }
-
-            import_level++;
-            t1 = _PyTime_GetPerfCounter();
-            accumulated = 0;
-        }
-
-        Py_XDECREF(mod);
-
-        if (PyDTrace_IMPORT_FIND_LOAD_START_ENABLED())
-            PyDTrace_IMPORT_FIND_LOAD_START(PyUnicode_AsUTF8(abs_name));
-
-        mod = _PyObject_CallMethodIdObjArgs(interp->importlib,
-                                            &PyId__find_and_load, abs_name,
-                                            interp->import_func, NULL);
-
-        if (PyDTrace_IMPORT_FIND_LOAD_DONE_ENABLED())
-            PyDTrace_IMPORT_FIND_LOAD_DONE(PyUnicode_AsUTF8(abs_name),
-                                           mod != NULL);
-
-        if (import_time) {
-            _PyTime_t cum = _PyTime_GetPerfCounter() - t1;
-
-            import_level--;
-            fprintf(stderr, "import time: %9ld | %10ld | %*s%s\n",
-                    (long)_PyTime_AsMicroseconds(cum - accumulated, _PyTime_ROUND_CEILING),
-                    (long)_PyTime_AsMicroseconds(cum, _PyTime_ROUND_CEILING),
-                    import_level*2, "", PyUnicode_AsUTF8(abs_name));
-
-            accumulated = accumulated_copy + cum;
-        }
-
-        if (mod == NULL) {
+        mod = import_find_and_load(abs_name);
+        if (mod == NULL)
             goto error;
-        }
     }
 
     has_from = 0;


### PR DESCRIPTION
Add import_find_and_load() helper function.  The addition of
the importtime option has made PyImport_ImportModuleLevelObject() large
and so using a helper seems worthwhile.  It also makes it clearer that
abs_name is the only argument needed by _find_and_load().
