### PR TITLE
bpo-19610: Warn if distutils is provided something other than a list to some fields

### DIFF
--- a/Doc/distutils/apiref.rst
+++ b/Doc/distutils/apiref.rst
@@ -286,9 +286,9 @@ the full reference.
    Distribution constructor. :func:`setup` creates a Distribution instance.
 
    .. versionchanged:: 3.7
-      :class:`~distutils.core.Distribution` now raises a :exc:`TypeError` if
-      ``classifiers``, ``keywords`` and ``platforms`` fields are not specified
-      as a list.
+      :class:`~distutils.core.Distribution` now warns if ``classifiers``,
+      ``keywords`` and ``platforms`` fields are not specified as a list or
+      a string.
 
 .. class:: Command
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -299,9 +299,7 @@ therefore included in source distributions.
 (Contributed by Ryan Gonzalez in :issue:`11913`.)
 
 :class:`distutils.core.setup` now warns if the ``classifiers``, ``keywords``
-and ``platforms`` fields are not specified as a list.  However, to minimize
-backwards incompatibility concerns, ``keywords`` and ``platforms`` fields
-still accept a comma separated string.
+and ``platforms`` fields are not specified as a list or a string.
 (Contributed by Berker Peksag in :issue:`19610`.)
 
 http.client

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -298,10 +298,10 @@ README.rst is now included in the list of distutils standard READMEs and
 therefore included in source distributions.
 (Contributed by Ryan Gonzalez in :issue:`11913`.)
 
-:class:`distutils.core.setup` now raises a :exc:`TypeError` if
-``classifiers``, ``keywords`` and ``platforms`` fields are not specified
-as a list.  However, to minimize backwards incompatibility concerns,
-``keywords`` and ``platforms`` fields still accept a comma separated string.
+:class:`distutils.core.setup` now warns if the ``classifiers``, ``keywords``
+and ``platforms`` fields are not specified as a list.  However, to minimize
+backwards incompatibility concerns, ``keywords`` and ``platforms`` fields
+still accept a comma separated string.
 (Contributed by Berker Peksag in :issue:`19610`.)
 
 http.client

--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -1223,7 +1223,7 @@ class DistributionMetadata:
         import distutils.versionpredicate
         for v in value:
             distutils.versionpredicate.VersionPredicate(v)
-        self.requires = value
+        self.requires = list(value)
 
     def get_provides(self):
         return self.provides or []
@@ -1242,7 +1242,7 @@ class DistributionMetadata:
         import distutils.versionpredicate
         for v in value:
             distutils.versionpredicate.VersionPredicate(v)
-        self.obsoletes = value
+        self.obsoletes = list(value)
 
 def fix_help_options(options):
     """Convert a 4-tuple 'help_options' list as found in various command

--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -26,6 +26,18 @@ from distutils.debug import DEBUG
 # to look for a Python module named after the command.
 command_re = re.compile(r'^[a-zA-Z]([a-zA-Z0-9_]*)$')
 
+def _ensure_list(value, fieldname):
+    if isinstance(value, str):
+        # a string containing comma separated values is okay.  It will
+        # be converted to a list by Distribution.finalize_options().
+        pass
+    elif not isinstance(value, list):
+        # passing a tuple or an iterator perhaps, warn and convert
+        typename = type(value).__name__
+        msg = f"Warning: '{fieldname}' should be a list, got type '{typename}'"
+        log.log(log.WARN, msg)
+        value = list(value)
+    return value
 
 class Distribution:
     """The core of the Distutils.  Most of the work hiding behind 'setup'
@@ -1186,39 +1198,19 @@ class DistributionMetadata:
         return self.keywords or []
 
     def set_keywords(self, value):
-        # If 'keywords' is a string, it will be converted to a list
-        # by Distribution.finalize_options(). To maintain backwards
-        # compatibility, do not raise an exception if 'keywords' is
-        # a string.
-        if not isinstance(value, (list, str)):
-            msg = "'keywords' should be a 'list', not %r"
-            warnings.warn(msg % type(value).__name__, RuntimeWarning, 2)
-            value = list(value)
-        self.keywords = value
+        self.keywords = _ensure_list(value, 'keywords')
 
     def get_platforms(self):
         return self.platforms or ["UNKNOWN"]
 
     def set_platforms(self, value):
-        # If 'platforms' is a string, it will be converted to a list
-        # by Distribution.finalize_options(). To maintain backwards
-        # compatibility, do not raise an exception if 'platforms' is
-        # a string.
-        if not isinstance(value, (list, str)):
-            msg = "'platforms' should be a 'list', not %r"
-            warnings.warn(msg % type(value).__name__, RuntimeWarning, 2)
-            value = list(value)
-        self.platforms = value
+        self.platforms = _ensure_list(value, 'platforms')
 
     def get_classifiers(self):
         return self.classifiers or []
 
     def set_classifiers(self, value):
-        if not isinstance(value, list):
-            msg = "'classifiers' should be a 'list', not %r"
-            warnings.warn(msg % type(value).__name__, RuntimeWarning, 2)
-            value = list(value)
-        self.classifiers = value
+        self.classifiers = _ensure_list(value, 'classifiers')
 
     def get_download_url(self):
         return self.download_url or "UNKNOWN"

--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -26,6 +26,7 @@ from distutils.debug import DEBUG
 # to look for a Python module named after the command.
 command_re = re.compile(r'^[a-zA-Z]([a-zA-Z0-9_]*)$')
 
+
 def _ensure_list(value, fieldname):
     if isinstance(value, str):
         # a string containing comma separated values is okay.  It will
@@ -38,6 +39,7 @@ def _ensure_list(value, fieldname):
         log.log(log.WARN, msg)
         value = list(value)
     return value
+
 
 class Distribution:
     """The core of the Distutils.  Most of the work hiding behind 'setup'

--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -9,10 +9,7 @@ import os
 import re
 from email import message_from_file
 
-try:
-    import warnings
-except ImportError:
-    warnings = None
+import warnings
 
 from distutils.errors import *
 from distutils.fancy_getopt import FancyGetopt, translate_longopt
@@ -241,10 +238,7 @@ Common commands: (see '--help-commands' for more)
                 attrs['license'] = attrs['licence']
                 del attrs['licence']
                 msg = "'licence' distribution option is deprecated; use 'license'"
-                if warnings is not None:
-                    warnings.warn(msg)
-                else:
-                    sys.stderr.write(msg + "\n")
+                warnings.warn(msg)
 
             # Now work on the rest of the attributes.  Any attribute that's
             # not already defined is invalid!
@@ -257,10 +251,7 @@ Common commands: (see '--help-commands' for more)
                     setattr(self, key, val)
                 else:
                     msg = "Unknown distribution option: %s" % repr(key)
-                    if warnings is not None:
-                        warnings.warn(msg)
-                    else:
-                        sys.stderr.write(msg + "\n")
+                    warnings.warn(msg)
 
         # no-user-cfg is handled before other command line args
         # because other args override the config files, and this

--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -9,7 +9,10 @@ import os
 import re
 from email import message_from_file
 
-import warnings
+try:
+    import warnings
+except ImportError:
+    warnings = None
 
 from distutils.errors import *
 from distutils.fancy_getopt import FancyGetopt, translate_longopt
@@ -238,7 +241,10 @@ Common commands: (see '--help-commands' for more)
                 attrs['license'] = attrs['licence']
                 del attrs['licence']
                 msg = "'licence' distribution option is deprecated; use 'license'"
-                warnings.warn(msg)
+                if warnings is not None:
+                    warnings.warn(msg)
+                else:
+                    sys.stderr.write(msg + "\n")
 
             # Now work on the rest of the attributes.  Any attribute that's
             # not already defined is invalid!

--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -1186,7 +1186,8 @@ class DistributionMetadata:
         # a string.
         if not isinstance(value, (list, str)):
             msg = "'keywords' should be a 'list', not %r"
-            raise TypeError(msg % type(value).__name__)
+            warnings.warn(msg % type(value).__name__, RuntimeWarning, 2)
+            value = list(value)
         self.keywords = value
 
     def get_platforms(self):
@@ -1199,7 +1200,8 @@ class DistributionMetadata:
         # a string.
         if not isinstance(value, (list, str)):
             msg = "'platforms' should be a 'list', not %r"
-            raise TypeError(msg % type(value).__name__)
+            warnings.warn(msg % type(value).__name__, RuntimeWarning, 2)
+            value = list(value)
         self.platforms = value
 
     def get_classifiers(self):
@@ -1208,7 +1210,8 @@ class DistributionMetadata:
     def set_classifiers(self, value):
         if not isinstance(value, list):
             msg = "'classifiers' should be a 'list', not %r"
-            raise TypeError(msg % type(value).__name__)
+            warnings.warn(msg % type(value).__name__, RuntimeWarning, 2)
+            value = list(value)
         self.classifiers = value
 
     def get_download_url(self):

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -368,10 +368,11 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
     def test_classifier_invalid_type(self):
         attrs = {'name': 'Boa', 'version': '3.0',
                  'classifiers': ('Programming Language :: Python :: 3',)}
-        msg = "should be a list"
         with captured_stderr() as error:
             d = Distribution(attrs)
-        self.assertIn(msg, error.getvalue())
+        # should have warning about passing a non-list
+        self.assertIn('should be a list', error.getvalue())
+        # should be converted to a list
         self.assertIsInstance(d.metadata.classifiers, list)
         self.assertEqual(d.metadata.classifiers,
                          list(attrs['classifiers']))
@@ -386,10 +387,11 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
     def test_keywords_invalid_type(self):
         attrs = {'name': 'Monty', 'version': '1.0',
                  'keywords': ('spam', 'eggs', 'life of brian')}
-        msg = "should be a list"
         with captured_stderr() as error:
             d = Distribution(attrs)
-        self.assertIn(msg, error.getvalue())
+        # should have warning about passing a non-list
+        self.assertIn('should be a list', error.getvalue())
+        # should be converted to a list
         self.assertIsInstance(d.metadata.keywords, list)
         self.assertEqual(d.metadata.keywords, list(attrs['keywords']))
 
@@ -403,10 +405,11 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
     def test_platforms_invalid_types(self):
         attrs = {'name': 'Monty', 'version': '1.0',
                  'platforms': ('GNU/Linux', 'Some Evil Platform')}
-        msg = "should be a list"
         with captured_stderr() as error:
             d = Distribution(attrs)
-        self.assertIn(msg, error.getvalue())
+        # should have warning about passing a non-list
+        self.assertIn('should be a list', error.getvalue())
+        # should be converted to a list
         self.assertIsInstance(d.metadata.platforms, list)
         self.assertEqual(d.metadata.platforms, list(attrs['platforms']))
 

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -11,8 +11,9 @@ from unittest import mock
 from distutils.dist import Distribution, fix_help_options, DistributionMetadata
 from distutils.cmd import Command
 
-from test.support import TESTFN, captured_stdout, captured_stderr, \
-     run_unittest
+from test.support import (
+     TESTFN, captured_stdout, captured_stderr, run_unittest
+)
 from distutils.tests import support
 from distutils import log
 

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -354,8 +354,11 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
         attrs = {'name': 'Boa', 'version': '3.0',
                  'classifiers': ('Programming Language :: Python :: 3',)}
         msg = "'classifiers' should be a 'list', not 'tuple'"
-        with self.assertRaises(TypeError, msg=msg):
-            Distribution(attrs)
+        with self.assertWarns(RuntimeWarning) as warns:
+            d = Distribution(attrs)
+            self.assertIsInstance(d.metadata.classifiers, list)
+            self.assertEqual(d.metadata.classifiers,
+                             list(attrs['classifiers']))
 
     def test_keywords(self):
         attrs = {'name': 'Monty', 'version': '1.0',
@@ -368,8 +371,10 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
         attrs = {'name': 'Monty', 'version': '1.0',
                  'keywords': ('spam', 'eggs', 'life of brian')}
         msg = "'keywords' should be a 'list', not 'tuple'"
-        with self.assertRaises(TypeError, msg=msg):
-            Distribution(attrs)
+        with self.assertWarns(RuntimeWarning) as warns:
+            d = Distribution(attrs)
+            self.assertIsInstance(d.metadata.keywords, list)
+            self.assertEqual(d.metadata.keywords, list(attrs['keywords']))
 
     def test_platforms(self):
         attrs = {'name': 'Monty', 'version': '1.0',
@@ -382,8 +387,10 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
         attrs = {'name': 'Monty', 'version': '1.0',
                  'platforms': ('GNU/Linux', 'Some Evil Platform')}
         msg = "'platforms' should be a 'list', not 'tuple'"
-        with self.assertRaises(TypeError, msg=msg):
-            Distribution(attrs)
+        with self.assertWarns(RuntimeWarning) as warns:
+            d = Distribution(attrs)
+            self.assertIsInstance(d.metadata.platforms, list)
+            self.assertEqual(d.metadata.platforms, list(attrs['platforms']))
 
     def test_download_url(self):
         attrs = {'name': 'Boa', 'version': '3.0',

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -354,11 +354,11 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
         attrs = {'name': 'Boa', 'version': '3.0',
                  'classifiers': ('Programming Language :: Python :: 3',)}
         msg = "'classifiers' should be a 'list', not 'tuple'"
-        with self.assertWarns(RuntimeWarning) as warns:
+        with self.assertWarnsRegex(RuntimeWarning, msg):
             d = Distribution(attrs)
-            self.assertIsInstance(d.metadata.classifiers, list)
-            self.assertEqual(d.metadata.classifiers,
-                             list(attrs['classifiers']))
+        self.assertIsInstance(d.metadata.classifiers, list)
+        self.assertEqual(d.metadata.classifiers,
+                         list(attrs['classifiers']))
 
     def test_keywords(self):
         attrs = {'name': 'Monty', 'version': '1.0',
@@ -371,10 +371,10 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
         attrs = {'name': 'Monty', 'version': '1.0',
                  'keywords': ('spam', 'eggs', 'life of brian')}
         msg = "'keywords' should be a 'list', not 'tuple'"
-        with self.assertWarns(RuntimeWarning) as warns:
+        with self.assertWarnsRegex(RuntimeWarning, msg):
             d = Distribution(attrs)
-            self.assertIsInstance(d.metadata.keywords, list)
-            self.assertEqual(d.metadata.keywords, list(attrs['keywords']))
+        self.assertIsInstance(d.metadata.keywords, list)
+        self.assertEqual(d.metadata.keywords, list(attrs['keywords']))
 
     def test_platforms(self):
         attrs = {'name': 'Monty', 'version': '1.0',
@@ -387,10 +387,10 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
         attrs = {'name': 'Monty', 'version': '1.0',
                  'platforms': ('GNU/Linux', 'Some Evil Platform')}
         msg = "'platforms' should be a 'list', not 'tuple'"
-        with self.assertWarns(RuntimeWarning) as warns:
+        with self.assertWarnsRegex(RuntimeWarning, msg):
             d = Distribution(attrs)
-            self.assertIsInstance(d.metadata.platforms, list)
-            self.assertEqual(d.metadata.platforms, list(attrs['platforms']))
+        self.assertIsInstance(d.metadata.platforms, list)
+        self.assertEqual(d.metadata.platforms, list(attrs['platforms']))
 
     def test_download_url(self):
         attrs = {'name': 'Boa', 'version': '3.0',

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -321,6 +321,13 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
                            "version": "1.0",
                            "requires": ["my.pkg (splat)"]})
 
+    def test_requires_to_list(self):
+        attrs = {"name": "package",
+                 "requires": iter(["other"])}
+        dist = Distribution(attrs)
+        self.assertIsInstance(dist.metadata.requires, list)
+
+
     def test_obsoletes(self):
         attrs = {"name": "package",
                  "version": "1.0",
@@ -342,6 +349,12 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
                           {"name": "package",
                            "version": "1.0",
                            "obsoletes": ["my.pkg (splat)"]})
+
+    def test_obsoletes_to_list(self):
+        attrs = {"name": "package",
+                 "obsoletes": iter(["other"])}
+        dist = Distribution(attrs)
+        self.assertIsInstance(dist.metadata.obsoletes, list)
 
     def test_classifier(self):
         attrs = {'name': 'Boa', 'version': '3.0',

--- a/Lib/distutils/tests/test_dist.py
+++ b/Lib/distutils/tests/test_dist.py
@@ -11,7 +11,8 @@ from unittest import mock
 from distutils.dist import Distribution, fix_help_options, DistributionMetadata
 from distutils.cmd import Command
 
-from test.support import TESTFN, captured_stdout, run_unittest
+from test.support import TESTFN, captured_stdout, captured_stderr, \
+     run_unittest
 from distutils.tests import support
 from distutils import log
 
@@ -353,9 +354,10 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
     def test_classifier_invalid_type(self):
         attrs = {'name': 'Boa', 'version': '3.0',
                  'classifiers': ('Programming Language :: Python :: 3',)}
-        msg = "'classifiers' should be a 'list', not 'tuple'"
-        with self.assertWarnsRegex(RuntimeWarning, msg):
+        msg = "should be a list"
+        with captured_stderr() as error:
             d = Distribution(attrs)
+        self.assertIn(msg, error.getvalue())
         self.assertIsInstance(d.metadata.classifiers, list)
         self.assertEqual(d.metadata.classifiers,
                          list(attrs['classifiers']))
@@ -370,9 +372,10 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
     def test_keywords_invalid_type(self):
         attrs = {'name': 'Monty', 'version': '1.0',
                  'keywords': ('spam', 'eggs', 'life of brian')}
-        msg = "'keywords' should be a 'list', not 'tuple'"
-        with self.assertWarnsRegex(RuntimeWarning, msg):
+        msg = "should be a list"
+        with captured_stderr() as error:
             d = Distribution(attrs)
+        self.assertIn(msg, error.getvalue())
         self.assertIsInstance(d.metadata.keywords, list)
         self.assertEqual(d.metadata.keywords, list(attrs['keywords']))
 
@@ -386,9 +389,10 @@ class MetadataTestCase(support.TempdirManager, support.EnvironGuard,
     def test_platforms_invalid_types(self):
         attrs = {'name': 'Monty', 'version': '1.0',
                  'platforms': ('GNU/Linux', 'Some Evil Platform')}
-        msg = "'platforms' should be a 'list', not 'tuple'"
-        with self.assertWarnsRegex(RuntimeWarning, msg):
+        msg = "should be a list"
+        with captured_stderr() as error:
             d = Distribution(attrs)
+        self.assertIn(msg, error.getvalue())
         self.assertIsInstance(d.metadata.platforms, list)
         self.assertEqual(d.metadata.platforms, list(attrs['platforms']))
 

--- a/Misc/NEWS.d/next/Library/2017-11-23-16-15-55.bpo-19610.Dlca2P.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-23-16-15-55.bpo-19610.Dlca2P.rst
@@ -1,5 +1,4 @@
-``setup()`` now raises :exc:`TypeError` for invalid types.
+``setup()`` now warns about invalid types for some fields.
 
-The ``distutils.dist.Distribution`` class now explicitly raises an exception
-when ``classifiers``, ``keywords`` and ``platforms`` fields are not
-specified as a list.
+The ``distutils.dist.Distribution`` class now warns when ``classifiers``,
+``keywords`` and ``platforms`` fields are not specified as a list.

--- a/Misc/NEWS.d/next/Library/2017-11-23-16-15-55.bpo-19610.Dlca2P.rst
+++ b/Misc/NEWS.d/next/Library/2017-11-23-16-15-55.bpo-19610.Dlca2P.rst
@@ -1,4 +1,4 @@
 ``setup()`` now warns about invalid types for some fields.
 
 The ``distutils.dist.Distribution`` class now warns when ``classifiers``,
-``keywords`` and ``platforms`` fields are not specified as a list.
+``keywords`` and ``platforms`` fields are not specified as a list or a string.


### PR DESCRIPTION
The commit of dcaed6b2d95 causes some 3rd party packages to fail to install, due to them passing a tuple for meta data fields.  Rather than raise TypeError, generate a RuntimeWarning and convert the value using list().

<!-- issue-number: bpo-19610 -->
https://bugs.python.org/issue19610
<!-- /issue-number -->
