### PR TITLE
Improve ensurepip's --help

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -183,14 +183,14 @@ def _main(argv=None):
         action="store_true",
         default=False,
         help=("Make an alternate install, installing only the X.Y versioned "
-              "scripts (Default: pipX, pipX.Y, easy_install-X.Y)"),
+              "scripts (Default: pipX, pipX.Y, easy_install-X.Y)."),
     )
     parser.add_argument(
         "--default-pip",
         action="store_true",
         default=False,
         help=("Make a default pip install, installing the unqualified pip "
-              "and easy_install in addition to the versioned scripts"),
+              "and easy_install in addition to the versioned scripts."),
     )
 
     args = parser.parse_args(argv)

--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -182,7 +182,7 @@ def _main(argv=None):
         "--altinstall",
         action="store_true",
         default=False,
-        help=("Make an alternate install, installing only the X.Y versioned"
+        help=("Make an alternate install, installing only the X.Y versioned "
               "scripts (Default: pipX, pipX.Y, easy_install-X.Y)"),
     )
     parser.add_argument(


### PR DESCRIPTION
Commit 1:

Add a space to ensurepip's --altinstall option

This changes the output from:
```
↪ python -m ensurepip --help
[...]
  --altinstall   Make an alternate install, installing only the X.Y
                 versionedscripts (Default: pipX, pipX.Y, easy_install-X.Y)
```
to:

```
↪ ./python -m ensurepip --help
[...]
  --altinstall   Make an alternate install, installing only the X.Y versioned
                 scripts (Default: pipX, pipX.Y, easy_install-X.Y)
```

Commit 2:

Add periods to the arguments of ensurepip that didn't have it

This makes --help for all optional arguments consistent and also makes it
consistent with pip --help.