### PR TITLE
bpo-32205: test.pythoninfo now prints the cross-built sysconfig data

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1071,7 +1071,7 @@ buildbottest:	build_all platform
 		$(TESTRUNNER) -j 1 -u all -W --slowest --fail-env-changed --timeout=$(TESTTIMEOUT) $(TESTOPTS)
 
 pythoninfo: build_all
-		$(RUNSHARED) ./$(BUILDPYTHON) -m test.pythoninfo
+		$(RUNSHARED) $(PYTHON_FOR_BUILD) -m test.pythoninfo
 
 QUICKTESTOPTS=	$(TESTOPTS) -x test_subprocess test_io test_lib2to3 \
 		test_multibytecodec test_urllib2_localnet test_itertools \

--- a/Misc/NEWS.d/next/Build/2017-12-03-14-31-01.bpo-32205.6eyXJm.rst
+++ b/Misc/NEWS.d/next/Build/2017-12-03-14-31-01.bpo-32205.6eyXJm.rst
@@ -1,0 +1,1 @@
+test.pythoninfo now prints the cross-built sysconfig data


### PR DESCRIPTION


<!-- issue-number: bpo-32205 -->
https://bugs.python.org/issue32205
<!-- /issue-number -->
