### PR TITLE
bpo-32028: Fix custom print suggestion having leading whitespace in print statement

### DIFF
--- a/Lib/test/test_print.py
+++ b/Lib/test/test_print.py
@@ -158,7 +158,7 @@ class TestPy2MigrationHint(unittest.TestCase):
 
     def test_string_with_leading_whitespace(self):
         python2_print_str = '''if 1:
-    print "Hello World"
+            print "Hello World"
         '''
         with self.assertRaises(SyntaxError) as context:
             exec(python2_print_str)

--- a/Lib/test/test_print.py
+++ b/Lib/test/test_print.py
@@ -156,6 +156,15 @@ class TestPy2MigrationHint(unittest.TestCase):
 
         self.assertIn('print("Hello World", end=" ")', str(context.exception))
 
+    def test_string_with_leading_whitespace(self):
+        python2_print_str = '''if 1:
+    print "Hello World"
+        '''
+        with self.assertRaises(SyntaxError) as context:
+            exec(python2_print_str)
+
+        self.assertIn('print("Hello World")', str(context.exception))
+
     def test_stream_redirection_hint_for_py2_migration(self):
         # Test correct hint produced for Py2 redirection syntax
         with self.assertRaises(TypeError) as context:

--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-03-22-29-13.bpo-32028.KC2w4Q.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-03-22-29-13.bpo-32028.KC2w4Q.rst
@@ -1,2 +1,3 @@
-Fix py2 to py3 custom print suggestion message having leading whitespaces in
-print statement. Patch by Sanyam Khurana.
+Leading whitespace is now correctly ignored when generating suggestions
+for converting Py2 print statements to Py3 builtin print function calls.
+Patch by Sanyam Khurana.

--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-03-22-29-13.bpo-32028.KC2w4Q.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-03-22-29-13.bpo-32028.KC2w4Q.rst
@@ -1,0 +1,2 @@
+Fix py2 to py3 custom print suggestion message having leading whitespaces in
+print statement. Patch by Sanyam Khurana.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2847,7 +2847,10 @@ _set_legacy_print_statement_msg(PySyntaxErrorObject *self, Py_ssize_t start)
     // PRINT_OFFSET is to remove `print ` word from the data.
     const int PRINT_OFFSET = 6;
     Py_ssize_t text_len = PyUnicode_GET_LENGTH(self->text);
-    PyObject *data = PyUnicode_Substring(self->text, PRINT_OFFSET, text_len);
+    // Issue 32028: Handle case when whitespace is used with print call
+    PyObject *initial_data = _PyUnicode_XStrip(self->text, 2, strip_sep_obj);
+    PyObject *data = PyUnicode_Substring(initial_data, PRINT_OFFSET, text_len);
+    Py_DECREF(initial_data);
 
     if (data == NULL) {
         Py_DECREF(strip_sep_obj);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2849,30 +2849,23 @@ _set_legacy_print_statement_msg(PySyntaxErrorObject *self, Py_ssize_t start)
     const int STRIP_BOTH = 2;
     // Issue 32028: Handle case when whitespace is used with print call
     PyObject *initial_data = _PyUnicode_XStrip(self->text, STRIP_BOTH, strip_sep_obj);
-
     if (initial_data == NULL) {
         Py_DECREF(strip_sep_obj);
         return -1;
     }
-
     Py_ssize_t text_len = PyUnicode_GET_LENGTH(initial_data);
-
     PyObject *data = PyUnicode_Substring(initial_data, PRINT_OFFSET, text_len);
     Py_DECREF(initial_data);
-
     if (data == NULL) {
         Py_DECREF(strip_sep_obj);
         return -1;
     }
-
     PyObject *new_data = _PyUnicode_XStrip(data, STRIP_BOTH, strip_sep_obj);
     Py_DECREF(data);
     Py_DECREF(strip_sep_obj);
-
     if (new_data == NULL) {
         return -1;
     }
-
     // gets the modified text_len after stripping `print `
     text_len = PyUnicode_GET_LENGTH(new_data);
     const char *maybe_end_arg = "";

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2849,29 +2849,40 @@ _set_legacy_print_statement_msg(PySyntaxErrorObject *self, Py_ssize_t start)
     const int STRIP_BOTH = 2;
     // Issue 32028: Handle case when whitespace is used with print call
     PyObject *initial_data = _PyUnicode_XStrip(self->text, STRIP_BOTH, strip_sep_obj);
-    Py_ssize_t text_len = PyUnicode_GET_LENGTH(initial_data);
-    PyObject *data = _PyUnicode_XStrip( \
-        PyUnicode_Substring(initial_data, PRINT_OFFSET, text_len), \
-        STRIP_BOTH, strip_sep_obj);
 
+    if (initial_data == NULL) {
+        Py_DECREF(strip_sep_obj);
+        return -1;
+    }
+
+    Py_ssize_t text_len = PyUnicode_GET_LENGTH(initial_data);
+
+    PyObject *data = PyUnicode_Substring(initial_data, PRINT_OFFSET, text_len);
     Py_DECREF(initial_data);
-    Py_DECREF(strip_sep_obj);
 
     if (data == NULL) {
+        Py_DECREF(strip_sep_obj);
+        return -1;
+    }
+
+    PyObject *new_data = _PyUnicode_XStrip(data, STRIP_BOTH, strip_sep_obj);
+    Py_DECREF(strip_sep_obj);
+
+    if (new_data == NULL) {
         return -1;
     }
 
     // gets the modified text_len after stripping `print `
-    text_len = PyUnicode_GET_LENGTH(data);
+    text_len = PyUnicode_GET_LENGTH(new_data);
     const char *maybe_end_arg = "";
-    if (text_len > 0 && PyUnicode_READ_CHAR(data, text_len-1) == ',') {
+    if (text_len > 0 && PyUnicode_READ_CHAR(new_data, text_len-1) == ',') {
         maybe_end_arg = " end=\" \"";
     }
     PyObject *error_msg = PyUnicode_FromFormat(
         "Missing parentheses in call to 'print'. Did you mean print(%U%s)?",
-        data, maybe_end_arg
+        new_data, maybe_end_arg
     );
-    Py_DECREF(data);
+    Py_DECREF(new_data);
     if (error_msg == NULL)
         return -1;
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2850,7 +2850,10 @@ _set_legacy_print_statement_msg(PySyntaxErrorObject *self, Py_ssize_t start)
     // Issue 32028: Handle case when whitespace is used with print call
     PyObject *initial_data = _PyUnicode_XStrip(self->text, STRIP_BOTH, strip_sep_obj);
     Py_ssize_t text_len = PyUnicode_GET_LENGTH(initial_data);
-    PyObject *data = PyUnicode_Substring(initial_data, PRINT_OFFSET, text_len);
+    PyObject *data = _PyUnicode_XStrip( \
+        PyUnicode_Substring(initial_data, PRINT_OFFSET, text_len), \
+        STRIP_BOTH, strip_sep_obj);
+
     Py_DECREF(initial_data);
     Py_DECREF(strip_sep_obj);
 

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2866,6 +2866,7 @@ _set_legacy_print_statement_msg(PySyntaxErrorObject *self, Py_ssize_t start)
     }
 
     PyObject *new_data = _PyUnicode_XStrip(data, STRIP_BOTH, strip_sep_obj);
+    Py_DECREF(data);
     Py_DECREF(strip_sep_obj);
 
     if (new_data == NULL) {


### PR DESCRIPTION
This fixes the newly added print suggestion for cases when there is leading whitespace in the initial data.

I've also added a test case for this. @ncoghlan Can you please check this?

<!-- issue-number: bpo-32028 -->
https://bugs.python.org/issue32028
<!-- /issue-number -->
