### PR TITLE
Revert "bpo-32197: Try to fix a compiler error on OS X introduced in bpo-32030. (#4681)"

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -40,7 +40,6 @@ The following functions can be safely called before Python is initialized:
   * :c:func:`Py_GetCompiler`
   * :c:func:`Py_GetCopyright`
   * :c:func:`Py_GetPlatform`
-  * :c:func:`Py_GetProgramName`
   * :c:func:`Py_GetVersion`
 
 * Utilities:
@@ -59,8 +58,8 @@ The following functions can be safely called before Python is initialized:
    The following functions **should not be called** before
    :c:func:`Py_Initialize`: :c:func:`Py_EncodeLocale`, :c:func:`Py_GetPath`,
    :c:func:`Py_GetPrefix`, :c:func:`Py_GetExecPrefix`,
-   :c:func:`Py_GetProgramFullPath`, :c:func:`Py_GetPythonHome` and
-   :c:func:`PyEval_InitThreads`.
+   :c:func:`Py_GetProgramFullPath`, :c:func:`Py_GetPythonHome`,
+   :c:func:`Py_GetProgramName` and :c:func:`PyEval_InitThreads`.
 
 
 .. _global-conf-vars:

--- a/Include/internal/pystate.h
+++ b/Include/internal/pystate.h
@@ -48,9 +48,36 @@ typedef struct {
 #endif
     /* Set by Py_SetPath(), or computed by _PyPathConfig_Init() */
     wchar_t *module_search_path;
+    /* Python program name */
+    wchar_t *program_name;
+    /* Set by Py_SetPythonHome() or PYTHONHOME environment variable */
+    wchar_t *home;
 } _PyPathConfig;
 
-#define _PyPathConfig_INIT {.module_search_path = NULL}
+#ifdef MS_WINDOWS
+#define _PyPathConfig_INIT \
+    {.program_full_path = NULL, \
+     .prefix = NULL, \
+     .dll_path = NULL, \
+     .module_search_path = NULL, \
+     .program_name = NULL, \
+     .home = NULL}
+#else
+#define _PyPathConfig_INIT \
+    {.program_full_path = NULL, \
+     .prefix = NULL, \
+     .exec_prefix = NULL, \
+     .module_search_path = NULL, \
+     .program_name = NULL, \
+     .home = NULL}
+#endif
+
+PyAPI_DATA(_PyPathConfig) _Py_path_config;
+
+PyAPI_FUNC(_PyInitError) _PyPathConfig_Calculate(
+    _PyPathConfig *config,
+    const _PyMainInterpreterConfig *main_config);
+PyAPI_FUNC(void) _PyPathConfig_Clear(_PyPathConfig *config);
 
 
 /* Full Python runtime state */

--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -105,11 +105,10 @@ PyAPI_FUNC(wchar_t *) Py_GetPath(void);
 #ifdef Py_BUILD_CORE
 PyAPI_FUNC(_PyInitError) _PyPathConfig_Init(
     const _PyMainInterpreterConfig *main_config);
-PyAPI_FUNC(void) _PyPathConfig_Fini(void);
 #endif
 PyAPI_FUNC(void)      Py_SetPath(const wchar_t *);
 #ifdef MS_WINDOWS
-int _Py_CheckPython3();
+int _Py_CheckPython3(void);
 #endif
 
 /* In their own files */

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -72,7 +72,8 @@ typedef struct {
     (_PyMainInterpreterConfig){\
      .install_signal_handlers = -1, \
      .module_search_path_env = NULL, \
-     .home = NULL}
+     .home = NULL, \
+     .program_name = NULL}
 
 typedef struct _is {
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -337,8 +337,9 @@ PYTHON_OBJS=	\
 		Python/importdl.o \
 		Python/marshal.o \
 		Python/modsupport.o \
-		Python/mystrtoul.o \
 		Python/mysnprintf.o \
+		Python/mystrtoul.o \
+		Python/pathconfig.o \
 		Python/peephole.o \
 		Python/pyarena.o \
 		Python/pyctype.o \

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -117,10 +117,7 @@ extern "C" {
 
 typedef struct {
     wchar_t *path_env;                 /* PATH environment variable */
-    wchar_t *home;                     /* PYTHONHOME environment variable */
-    wchar_t *module_search_path_env;   /* PYTHONPATH environment variable */
 
-    wchar_t *program_name;             /* Program name */
     wchar_t *pythonpath;               /* PYTHONPATH define */
     wchar_t *prefix;                   /* PREFIX define */
     wchar_t *exec_prefix;              /* EXEC_PREFIX define */
@@ -135,7 +132,6 @@ typedef struct {
 
 static const wchar_t delimiter[2] = {DELIM, '\0'};
 static const wchar_t separator[2] = {SEP, '\0'};
-static _PyPathConfig _Py_path_config = _PyPathConfig_INIT;
 
 
 /* Get file status. Encode the path to the locale encoding. */
@@ -360,14 +356,15 @@ find_env_config_value(FILE * env_file, const wchar_t * key, wchar_t * value)
    bytes long.
 */
 static int
-search_for_prefix(PyCalculatePath *calculate, wchar_t *prefix)
+search_for_prefix(const _PyMainInterpreterConfig *main_config,
+                  PyCalculatePath *calculate, wchar_t *prefix)
 {
     size_t n;
     wchar_t *vpath;
 
     /* If PYTHONHOME is set, we believe it unconditionally */
-    if (calculate->home) {
-        wcsncpy(prefix, calculate->home, MAXPATHLEN);
+    if (main_config->home) {
+        wcsncpy(prefix, main_config->home, MAXPATHLEN);
         prefix[MAXPATHLEN] = L'\0';
         wchar_t *delim = wcschr(prefix, DELIM);
         if (delim) {
@@ -426,9 +423,10 @@ search_for_prefix(PyCalculatePath *calculate, wchar_t *prefix)
 
 
 static void
-calculate_prefix(PyCalculatePath *calculate, wchar_t *prefix)
+calculate_prefix(const _PyMainInterpreterConfig *main_config,
+                 PyCalculatePath *calculate, wchar_t *prefix)
 {
-    calculate->prefix_found = search_for_prefix(calculate, prefix);
+    calculate->prefix_found = search_for_prefix(main_config, calculate, prefix);
     if (!calculate->prefix_found) {
         if (!Py_FrozenFlag) {
             fprintf(stderr,
@@ -470,18 +468,19 @@ calculate_reduce_prefix(PyCalculatePath *calculate, wchar_t *prefix)
    MAXPATHLEN bytes long.
 */
 static int
-search_for_exec_prefix(PyCalculatePath *calculate, wchar_t *exec_prefix)
+search_for_exec_prefix(const _PyMainInterpreterConfig *main_config,
+                       PyCalculatePath *calculate, wchar_t *exec_prefix)
 {
     size_t n;
 
     /* If PYTHONHOME is set, we believe it unconditionally */
-    if (calculate->home) {
-        wchar_t *delim = wcschr(calculate->home, DELIM);
+    if (main_config->home) {
+        wchar_t *delim = wcschr(main_config->home, DELIM);
         if (delim) {
             wcsncpy(exec_prefix, delim+1, MAXPATHLEN);
         }
         else {
-            wcsncpy(exec_prefix, calculate->home, MAXPATHLEN);
+            wcsncpy(exec_prefix, main_config->home, MAXPATHLEN);
         }
         exec_prefix[MAXPATHLEN] = L'\0';
         joinpath(exec_prefix, calculate->lib_python);
@@ -552,9 +551,12 @@ search_for_exec_prefix(PyCalculatePath *calculate, wchar_t *exec_prefix)
 
 
 static void
-calculate_exec_prefix(PyCalculatePath *calculate, wchar_t *exec_prefix)
+calculate_exec_prefix(const _PyMainInterpreterConfig *main_config,
+                      PyCalculatePath *calculate, wchar_t *exec_prefix)
 {
-    calculate->exec_prefix_found = search_for_exec_prefix(calculate, exec_prefix);
+    calculate->exec_prefix_found = search_for_exec_prefix(main_config,
+                                                          calculate,
+                                                          exec_prefix);
     if (!calculate->exec_prefix_found) {
         if (!Py_FrozenFlag) {
             fprintf(stderr,
@@ -585,7 +587,8 @@ calculate_reduce_exec_prefix(PyCalculatePath *calculate, wchar_t *exec_prefix)
 
 
 static _PyInitError
-calculate_program_full_path(PyCalculatePath *calculate, _PyPathConfig *config)
+calculate_program_full_path(const _PyMainInterpreterConfig *main_config,
+                            PyCalculatePath *calculate, _PyPathConfig *config)
 {
     wchar_t program_full_path[MAXPATHLEN+1];
     memset(program_full_path, 0, sizeof(program_full_path));
@@ -604,8 +607,8 @@ calculate_program_full_path(PyCalculatePath *calculate, _PyPathConfig *config)
      * other way to find a directory to start the search from.  If
      * $PATH isn't exported, you lose.
      */
-    if (wcschr(calculate->program_name, SEP)) {
-        wcsncpy(program_full_path, calculate->program_name, MAXPATHLEN);
+    if (wcschr(main_config->program_name, SEP)) {
+        wcsncpy(program_full_path, main_config->program_name, MAXPATHLEN);
     }
 #ifdef __APPLE__
      /* On Mac OS X, if a script uses an interpreter of the form
@@ -621,11 +624,13 @@ calculate_program_full_path(PyCalculatePath *calculate, _PyPathConfig *config)
     else if(0 == _NSGetExecutablePath(execpath, &nsexeclength) &&
             execpath[0] == SEP)
     {
-        size_t r = mbstowcs(program_full_path, execpath, MAXPATHLEN+1);
-        if (r == (size_t)-1 || r > MAXPATHLEN) {
-            /* Could not convert execpath, or it's too long. */
-            program_full_path[0] = '\0';
+        size_t len;
+        wchar_t *path = Py_DecodeLocale(execpath, &len);
+        if (path == NULL) {
+            return DECODE_LOCALE_ERR("executable path", len);
         }
+        wcsncpy(program_full_path, path, MAXPATHLEN);
+        PyMem_RawFree(path);
     }
 #endif /* __APPLE__ */
     else if (calculate->path_env) {
@@ -645,7 +650,7 @@ calculate_program_full_path(PyCalculatePath *calculate, _PyPathConfig *config)
                 wcsncpy(program_full_path, path, MAXPATHLEN);
             }
 
-            joinpath(program_full_path, calculate->program_name);
+            joinpath(program_full_path, main_config->program_name);
             if (isxfile(program_full_path)) {
                 break;
             }
@@ -810,14 +815,15 @@ calculate_zip_path(PyCalculatePath *calculate, const wchar_t *prefix)
 
 
 static _PyInitError
-calculate_module_search_path(PyCalculatePath *calculate,
+calculate_module_search_path(const _PyMainInterpreterConfig *main_config,
+                             PyCalculatePath *calculate,
                              const wchar_t *prefix, const wchar_t *exec_prefix,
                              _PyPathConfig *config)
 {
     /* Calculate size of return buffer */
     size_t bufsz = 0;
-    if (calculate->module_search_path_env != NULL) {
-        bufsz += wcslen(calculate->module_search_path_env) + 1;
+    if (main_config->module_search_path_env != NULL) {
+        bufsz += wcslen(main_config->module_search_path_env) + 1;
     }
 
     wchar_t *defpath = calculate->pythonpath;
@@ -851,8 +857,8 @@ calculate_module_search_path(PyCalculatePath *calculate,
     buf[0] = '\0';
 
     /* Run-time value of $PYTHONPATH goes first */
-    if (calculate->module_search_path_env) {
-        wcscpy(buf, calculate->module_search_path_env);
+    if (main_config->module_search_path_env) {
+        wcscpy(buf, main_config->module_search_path_env);
         wcscat(buf, delimiter);
     }
 
@@ -903,10 +909,6 @@ static _PyInitError
 calculate_init(PyCalculatePath *calculate,
                const _PyMainInterpreterConfig *main_config)
 {
-    calculate->home = main_config->home;
-    calculate->module_search_path_env = main_config->module_search_path_env;
-    calculate->program_name = main_config->program_name;
-
     size_t len;
     char *path = getenv("PATH");
     if (path) {
@@ -948,9 +950,12 @@ calculate_free(PyCalculatePath *calculate)
 
 
 static _PyInitError
-calculate_path_impl(PyCalculatePath *calculate, _PyPathConfig *config)
+calculate_path_impl(const _PyMainInterpreterConfig *main_config,
+                    PyCalculatePath *calculate, _PyPathConfig *config)
 {
-    _PyInitError err = calculate_program_full_path(calculate, config);
+    _PyInitError err;
+
+    err = calculate_program_full_path(main_config, calculate, config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -964,13 +969,13 @@ calculate_path_impl(PyCalculatePath *calculate, _PyPathConfig *config)
 
     wchar_t prefix[MAXPATHLEN+1];
     memset(prefix, 0, sizeof(prefix));
-    calculate_prefix(calculate, prefix);
+    calculate_prefix(main_config, calculate, prefix);
 
     calculate_zip_path(calculate, prefix);
 
     wchar_t exec_prefix[MAXPATHLEN+1];
     memset(exec_prefix, 0, sizeof(exec_prefix));
-    calculate_exec_prefix(calculate, exec_prefix);
+    calculate_exec_prefix(main_config, calculate, exec_prefix);
 
     if ((!calculate->prefix_found || !calculate->exec_prefix_found) &&
         !Py_FrozenFlag)
@@ -979,8 +984,8 @@ calculate_path_impl(PyCalculatePath *calculate, _PyPathConfig *config)
                 "Consider setting $PYTHONHOME to <prefix>[:<exec_prefix>]\n");
     }
 
-    err = calculate_module_search_path(calculate, prefix, exec_prefix,
-                                       config);
+    err = calculate_module_search_path(main_config, calculate,
+                                       prefix, exec_prefix, config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -1003,33 +1008,10 @@ calculate_path_impl(PyCalculatePath *calculate, _PyPathConfig *config)
 }
 
 
-static void
-pathconfig_clear(_PyPathConfig *config)
-{
-#define CLEAR(ATTR) \
-    do { \
-        PyMem_RawFree(ATTR); \
-        ATTR = NULL; \
-    } while (0)
-
-    CLEAR(config->prefix);
-    CLEAR(config->exec_prefix);
-    CLEAR(config->program_full_path);
-    CLEAR(config->module_search_path);
-#undef CLEAR
-}
-
-
-/* Initialize paths for Py_GetPath(), Py_GetPrefix(), Py_GetExecPrefix()
-   and Py_GetProgramFullPath() */
 _PyInitError
-_PyPathConfig_Init(const _PyMainInterpreterConfig *main_config)
+_PyPathConfig_Calculate(_PyPathConfig *config,
+                        const _PyMainInterpreterConfig *main_config)
 {
-    if (_Py_path_config.module_search_path) {
-        /* Already initialized */
-        return _Py_INIT_OK();
-    }
-
     PyCalculatePath calculate;
     memset(&calculate, 0, sizeof(calculate));
 
@@ -1038,103 +1020,16 @@ _PyPathConfig_Init(const _PyMainInterpreterConfig *main_config)
         goto done;
     }
 
-    _PyPathConfig new_path_config;
-    memset(&new_path_config, 0, sizeof(new_path_config));
-
-    err = calculate_path_impl(&calculate, &new_path_config);
+    err = calculate_path_impl(main_config, &calculate, config);
     if (_Py_INIT_FAILED(err)) {
-        pathconfig_clear(&new_path_config);
         goto done;
     }
 
-    _Py_path_config = new_path_config;
     err = _Py_INIT_OK();
 
 done:
     calculate_free(&calculate);
     return err;
-}
-
-
-static void
-pathconfig_global_init(void)
-{
-    if (_Py_path_config.module_search_path) {
-        /* Already initialized */
-        return;
-    }
-
-    _PyInitError err;
-    _PyMainInterpreterConfig config = _PyMainInterpreterConfig_INIT;
-
-    err = _PyMainInterpreterConfig_ReadEnv(&config);
-    if (!_Py_INIT_FAILED(err)) {
-        err = _PyPathConfig_Init(&config);
-    }
-    _PyMainInterpreterConfig_Clear(&config);
-
-    if (_Py_INIT_FAILED(err)) {
-        _Py_FatalInitError(err);
-    }
-}
-
-
-void
-_PyPathConfig_Fini(void)
-{
-    pathconfig_clear(&_Py_path_config);
-}
-
-
-/* External interface */
-void
-Py_SetPath(const wchar_t *path)
-{
-    if (path == NULL) {
-        pathconfig_clear(&_Py_path_config);
-        return;
-    }
-
-    _PyPathConfig new_config;
-    new_config.program_full_path = _PyMem_RawWcsdup(Py_GetProgramName());
-    new_config.exec_prefix = _PyMem_RawWcsdup(L"");
-    new_config.prefix = _PyMem_RawWcsdup(L"");
-    new_config.module_search_path = _PyMem_RawWcsdup(path);
-
-    pathconfig_clear(&_Py_path_config);
-    _Py_path_config = new_config;
-}
-
-
-wchar_t *
-Py_GetPath(void)
-{
-    pathconfig_global_init();
-    return _Py_path_config.module_search_path;
-}
-
-
-wchar_t *
-Py_GetPrefix(void)
-{
-    pathconfig_global_init();
-    return _Py_path_config.prefix;
-}
-
-
-wchar_t *
-Py_GetExecPrefix(void)
-{
-    pathconfig_global_init();
-    return _Py_path_config.exec_prefix;
-}
-
-
-wchar_t *
-Py_GetProgramFullPath(void)
-{
-    pathconfig_global_init();
-    return _Py_path_config.program_full_path;
 }
 
 #ifdef __cplusplus

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -412,7 +412,6 @@ typedef struct {
     /* non-zero if filename, command (-c) or module (-m) is set
        on the command line */
     int run_code;
-    wchar_t *program_name;
     /* Error message if a function failed */
     _PyInitError err;
     /* PYTHONWARNINGS env var */
@@ -429,7 +428,6 @@ typedef struct {
      .config = _PyMainInterpreterConfig_INIT, \
      .main_importer_path = NULL, \
      .run_code = -1, \
-     .program_name = NULL, \
      .err = _Py_INIT_OK(), \
      .env_warning_options = {0, NULL}}
 
@@ -455,7 +453,6 @@ pymain_free_impl(_PyMain *pymain)
 
     pymain_optlist_clear(&pymain->env_warning_options);
     Py_CLEAR(pymain->main_importer_path);
-    PyMem_RawFree(pymain->program_name);
 
     _PyMainInterpreterConfig_Clear(&pymain->config);
 
@@ -874,14 +871,21 @@ pymain_init_stdio(_PyMain *pymain)
 
 
 /* Get the program name: use PYTHONEXECUTABLE and __PYVENV_LAUNCHER__
-   environment variables on macOS if available, use argv[0] by default.
-
-   Return 0 on success.
-   Set pymain->err and return -1 on error. */
-static int
-pymain_get_program_name(_PyMain *pymain)
+   environment variables on macOS if available. */
+static _PyInitError
+config_get_program_name(_PyMainInterpreterConfig *config)
 {
-    assert(pymain->program_name == NULL);
+    assert(config->program_name == NULL);
+
+    /* If Py_SetProgramName() was called, use its value */
+    wchar_t *program_name = _Py_path_config.program_name;
+    if (program_name != NULL) {
+        config->program_name = _PyMem_RawWcsdup(program_name);
+        if (config->program_name == NULL) {
+            return _Py_INIT_NO_MEMORY();
+        }
+    }
+
 #ifdef __APPLE__
     char *p;
     /* On MacOS X, when the Python interpreter is embedded in an
@@ -894,17 +898,13 @@ pymain_get_program_name(_PyMain *pymain)
        See Lib/plat-mac/bundlebuiler.py for details about the bootstrap
        script. */
     if ((p = Py_GETENV("PYTHONEXECUTABLE")) && *p != '\0') {
-        wchar_t* buffer;
-        size_t len = strlen(p) + 1;
-
-        buffer = PyMem_RawMalloc(len * sizeof(wchar_t));
-        if (buffer == NULL) {
-            pymain->err = _Py_INIT_NO_MEMORY();
-            return -1;
+        size_t len;
+        wchar_t* program_name = Py_DecodeLocale(p, &len);
+        if (program_name == NULL) {
+            return SET_DECODE_ERROR("PYTHONEXECUTABLE environment "
+                                    "variable", len);
         }
-
-        mbstowcs(buffer, p, len);
-        pymain->program_name = buffer;
+        config->program_name = program_name;
     }
 #ifdef WITH_NEXT_FRAMEWORK
     else {
@@ -914,21 +914,30 @@ pymain_get_program_name(_PyMain *pymain)
              * the argv0 of the stub executable
              */
             size_t len;
-            wchar_t* wbuf = Py_DecodeLocale(pyvenv_launcher, &len);
-            if (wbuf == NULL) {
-                SET_DECODE_ERROR("__PYVENV_LAUNCHER__", len);
-                return -1;
+            wchar_t* program_name = Py_DecodeLocale(pyvenv_launcher, &len);
+            if (program_name == NULL) {
+                return SET_DECODE_ERROR("__PYVENV_LAUNCHER__ environment "
+                                        "variable", len);
             }
-            pymain->program_name = wbuf;
+            config->program_name = program_name;
         }
     }
 #endif   /* WITH_NEXT_FRAMEWORK */
 #endif   /* __APPLE__ */
 
-    if (pymain->program_name == NULL) {
+    return _Py_INIT_OK();
+}
+
+
+/* If config_get_program_name() found no program name: use argv[0] by default.
+   Return 0 on success. Set pymain->err and return -1 on error. */
+static int
+pymain_get_program_name(_PyMain *pymain)
+{
+    if (pymain->config.program_name == NULL) {
         /* Use argv[0] by default */
-        pymain->program_name = pymain_wstrdup(pymain, pymain->argv[0]);
-        if (pymain->program_name == NULL) {
+        pymain->config.program_name = pymain_wstrdup(pymain, pymain->argv[0]);
+        if (pymain->config.program_name == NULL) {
             return -1;
         }
     }
@@ -949,13 +958,6 @@ static int
 pymain_init_main_interpreter(_PyMain *pymain)
 {
     _PyInitError err;
-
-    /* TODO: Print any exceptions raised by these operations */
-    err = _PyMainInterpreterConfig_Read(&pymain->config);
-    if (_Py_INIT_FAILED(err)) {
-        pymain->err = err;
-        return -1;
-    }
 
     err = _Py_InitializeMainInterpreter(&pymain->config);
     if (_Py_INIT_FAILED(err)) {
@@ -1414,14 +1416,13 @@ config_init_pythonpath(_PyMainInterpreterConfig *config)
 
 
 static _PyInitError
-config_init_pythonhome(_PyMainInterpreterConfig *config)
+config_init_home(_PyMainInterpreterConfig *config)
 {
     wchar_t *home;
 
-    home = Py_GetPythonHome();
+    /* If Py_SetPythonHome() was called, use its value */
+    home = _Py_path_config.home;
     if (home) {
-        /* Py_SetPythonHome() has been called before Py_Main(),
-           use its value */
         config->home = _PyMem_RawWcsdup(home);
         if (config->home == NULL) {
             return _Py_INIT_NO_MEMORY();
@@ -1441,7 +1442,7 @@ config_init_pythonhome(_PyMainInterpreterConfig *config)
 _PyInitError
 _PyMainInterpreterConfig_ReadEnv(_PyMainInterpreterConfig *config)
 {
-    _PyInitError err = config_init_pythonhome(config);
+    _PyInitError err = config_init_home(config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -1451,11 +1452,9 @@ _PyMainInterpreterConfig_ReadEnv(_PyMainInterpreterConfig *config)
         return err;
     }
 
-    /* FIXME: _PyMainInterpreterConfig_Read() has the same code. Remove it
-       here? See also pymain_get_program_name() and pymain_parse_envvars(). */
-    config->program_name = _PyMem_RawWcsdup(Py_GetProgramName());
-    if (config->program_name == NULL) {
-        return _Py_INIT_NO_MEMORY();
+    err = config_get_program_name(config);
+    if (_Py_INIT_FAILED(err)) {
+        return err;
     }
 
     return _Py_INIT_OK();
@@ -1481,25 +1480,17 @@ pymain_parse_envvars(_PyMain *pymain)
     if (pymain_warnings_envvar(pymain) < 0) {
         return -1;
     }
-    if (pymain_get_program_name(pymain) < 0) {
-        return -1;
-    }
-    core_config->allocator = Py_GETENV("PYTHONMALLOC");
-
-    /* FIXME: move pymain_get_program_name() code into
-       _PyMainInterpreterConfig_ReadEnv().
-       Problem: _PyMainInterpreterConfig_ReadEnv() doesn't have access
-       to argv[0]. */
-    Py_SetProgramName(pymain->program_name);
-    /* Don't free program_name here: the argument to Py_SetProgramName
-       must remain valid until Py_FinalizeEx is called. The string is freed
-       by pymain_free(). */
 
     _PyInitError err = _PyMainInterpreterConfig_ReadEnv(&pymain->config);
     if (_Py_INIT_FAILED(pymain->err)) {
         pymain->err = err;
         return -1;
     }
+    if (pymain_get_program_name(pymain) < 0) {
+        return -1;
+    }
+
+    core_config->allocator = Py_GETENV("PYTHONMALLOC");
 
     /* -X options */
     if (pymain_get_xoption(pymain, L"showrefcount")) {
@@ -1552,6 +1543,12 @@ pymain_parse_cmdline_envvars_impl(_PyMain *pymain)
     pymain_set_global_config(pymain);
 
     if (pymain_parse_envvars(pymain) < 0) {
+        return -1;
+    }
+
+    _PyInitError err = _PyMainInterpreterConfig_Read(&pymain->config);
+    if (_Py_INIT_FAILED(err)) {
+        pymain->err = err;
         return -1;
     }
 
@@ -1671,6 +1668,14 @@ pymain_impl(_PyMain *pymain)
            other special meaning */
         pymain->status = 120;
     }
+
+    /* _PyPathConfig_Clear() cannot be called in Py_FinalizeEx().
+       Py_Initialize() and Py_Finalize() can be called multiple times, but it
+       must not "forget" parameters set by Py_SetProgramName(), Py_SetPath() or
+       Py_SetPythonHome(), whereas _PyPathConfig_Clear() clear all these
+       parameters. */
+    _PyPathConfig_Clear(&_Py_path_config);
+
     return 0;
 }
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -901,8 +901,8 @@ config_get_program_name(_PyMainInterpreterConfig *config)
         size_t len;
         wchar_t* program_name = Py_DecodeLocale(p, &len);
         if (program_name == NULL) {
-            return SET_DECODE_ERROR("PYTHONEXECUTABLE environment "
-                                    "variable", len);
+            return DECODE_LOCALE_ERR("PYTHONEXECUTABLE environment "
+                                     "variable", (Py_ssize_t)len);
         }
         config->program_name = program_name;
     }
@@ -916,8 +916,8 @@ config_get_program_name(_PyMainInterpreterConfig *config)
             size_t len;
             wchar_t* program_name = Py_DecodeLocale(pyvenv_launcher, &len);
             if (program_name == NULL) {
-                return SET_DECODE_ERROR("__PYVENV_LAUNCHER__ environment "
-                                        "variable", len);
+                return DECODE_LOCALE_ERR("__PYVENV_LAUNCHER__ environment "
+                                         "variable", (Py_ssize_t)len);
             }
             config->program_name = program_name;
         }

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -381,6 +381,7 @@
     <ClCompile Include="..\Python\modsupport.c" />
     <ClCompile Include="..\Python\mysnprintf.c" />
     <ClCompile Include="..\Python\mystrtoul.c" />
+    <ClCompile Include="..\Python\pathconfig.c" />
     <ClCompile Include="..\Python\peephole.c" />
     <ClCompile Include="..\Python\pyarena.c" />
     <ClCompile Include="..\Python\pyctype.c" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -896,6 +896,9 @@
     <ClCompile Include="..\Python\mystrtoul.c">
       <Filter>Python</Filter>
     </ClCompile>
+    <ClCompile Include="..\Python\pathconfig.c">
+      <Filter>Python</Filter>
+    </ClCompile>
     <ClCompile Include="..\Python\peephole.c">
       <Filter>Python</Filter>
     </ClCompile>

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -1,0 +1,266 @@
+/* Path configuration like module_search_path (sys.path) */
+
+#include "Python.h"
+#include "osdefs.h"
+#include "internal/pystate.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+_PyPathConfig _Py_path_config = _PyPathConfig_INIT;
+
+
+void
+_PyPathConfig_Clear(_PyPathConfig *config)
+{
+    /* _PyMem_SetDefaultAllocator() is needed to get a known memory allocator,
+       since Py_SetPath(), Py_SetPythonHome() and Py_SetProgramName() can be
+       called before Py_Initialize() which can changes the memory allocator. */
+    PyMemAllocatorEx old_alloc;
+    _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
+#define CLEAR(ATTR) \
+    do { \
+        PyMem_RawFree(ATTR); \
+        ATTR = NULL; \
+    } while (0)
+
+    CLEAR(config->prefix);
+    CLEAR(config->program_full_path);
+#ifdef MS_WINDOWS
+    CLEAR(config->dll_path);
+#else
+    CLEAR(config->exec_prefix);
+#endif
+    CLEAR(config->module_search_path);
+    CLEAR(config->home);
+    CLEAR(config->program_name);
+#undef CLEAR
+
+    PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+}
+
+
+/* Initialize paths for Py_GetPath(), Py_GetPrefix(), Py_GetExecPrefix()
+   and Py_GetProgramFullPath() */
+_PyInitError
+_PyPathConfig_Init(const _PyMainInterpreterConfig *main_config)
+{
+    if (_Py_path_config.module_search_path) {
+        /* Already initialized */
+        return _Py_INIT_OK();
+    }
+
+    _PyInitError err;
+    _PyPathConfig new_config = _PyPathConfig_INIT;
+
+    PyMemAllocatorEx old_alloc;
+    _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
+    /* Calculate program_full_path, prefix, exec_prefix (Unix)
+       or dll_path (Windows), and module_search_path */
+    err = _PyPathConfig_Calculate(&new_config, main_config);
+    if (_Py_INIT_FAILED(err)) {
+        _PyPathConfig_Clear(&new_config);
+        goto done;
+    }
+
+    /* Copy home and program_name from main_config */
+    if (main_config->home != NULL) {
+        new_config.home = _PyMem_RawWcsdup(main_config->home);
+        if (new_config.home == NULL) {
+            err = _Py_INIT_NO_MEMORY();
+            goto done;
+        }
+    }
+    else {
+        new_config.home = NULL;
+    }
+
+    new_config.program_name = _PyMem_RawWcsdup(main_config->program_name);
+    if (new_config.program_name == NULL) {
+        err = _Py_INIT_NO_MEMORY();
+        goto done;
+    }
+
+    _PyPathConfig_Clear(&_Py_path_config);
+    _Py_path_config = new_config;
+
+    err = _Py_INIT_OK();
+
+done:
+    PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+    return err;
+}
+
+
+static void
+pathconfig_global_init(void)
+{
+    if (_Py_path_config.module_search_path) {
+        /* Already initialized */
+        return;
+    }
+
+    _PyInitError err;
+    _PyMainInterpreterConfig config = _PyMainInterpreterConfig_INIT;
+
+    err = _PyMainInterpreterConfig_ReadEnv(&config);
+    if (_Py_INIT_FAILED(err)) {
+        goto error;
+    }
+
+    err = _PyMainInterpreterConfig_Read(&config);
+    if (_Py_INIT_FAILED(err)) {
+        goto error;
+    }
+
+    err = _PyPathConfig_Init(&config);
+    if (_Py_INIT_FAILED(err)) {
+        goto error;
+    }
+
+    _PyMainInterpreterConfig_Clear(&config);
+    return;
+
+error:
+    _PyMainInterpreterConfig_Clear(&config);
+    _Py_FatalInitError(err);
+}
+
+
+/* External interface */
+
+void
+Py_SetPath(const wchar_t *path)
+{
+    if (path == NULL) {
+        _PyPathConfig_Clear(&_Py_path_config);
+        return;
+    }
+
+    PyMemAllocatorEx old_alloc;
+    _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
+    _PyPathConfig new_config;
+    new_config.program_full_path = _PyMem_RawWcsdup(Py_GetProgramName());
+    new_config.prefix = _PyMem_RawWcsdup(L"");
+#ifdef MS_WINDOWS
+    new_config.dll_path = _PyMem_RawWcsdup(L"");
+#else
+    new_config.exec_prefix = _PyMem_RawWcsdup(L"");
+#endif
+    new_config.module_search_path = _PyMem_RawWcsdup(path);
+
+    /* steal the home and program_name values (to leave them unchanged) */
+    new_config.home = _Py_path_config.home;
+    _Py_path_config.home = NULL;
+    new_config.program_name = _Py_path_config.program_name;
+    _Py_path_config.program_name = NULL;
+
+    _PyPathConfig_Clear(&_Py_path_config);
+    _Py_path_config = new_config;
+
+    PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+}
+
+
+void
+Py_SetPythonHome(wchar_t *home)
+{
+    if (home == NULL) {
+        return;
+    }
+
+    PyMemAllocatorEx old_alloc;
+    _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
+    PyMem_RawFree(_Py_path_config.home);
+    _Py_path_config.home = _PyMem_RawWcsdup(home);
+
+    PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
+    if (_Py_path_config.home == NULL) {
+        Py_FatalError("Py_SetPythonHome() failed: out of memory");
+    }
+}
+
+
+void
+Py_SetProgramName(wchar_t *program_name)
+{
+    if (program_name == NULL || program_name[0] == L'\0') {
+        return;
+    }
+
+    PyMemAllocatorEx old_alloc;
+    _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
+    PyMem_RawFree(_Py_path_config.program_name);
+    _Py_path_config.program_name = _PyMem_RawWcsdup(program_name);
+
+    PyMem_SetAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
+
+    if (_Py_path_config.program_name == NULL) {
+        Py_FatalError("Py_SetProgramName() failed: out of memory");
+    }
+}
+
+
+wchar_t *
+Py_GetPath(void)
+{
+    pathconfig_global_init();
+    return _Py_path_config.module_search_path;
+}
+
+
+wchar_t *
+Py_GetPrefix(void)
+{
+    pathconfig_global_init();
+    return _Py_path_config.prefix;
+}
+
+
+wchar_t *
+Py_GetExecPrefix(void)
+{
+#ifdef MS_WINDOWS
+    return Py_GetPrefix();
+#else
+    pathconfig_global_init();
+    return _Py_path_config.exec_prefix;
+#endif
+}
+
+
+wchar_t *
+Py_GetProgramFullPath(void)
+{
+    pathconfig_global_init();
+    return _Py_path_config.program_full_path;
+}
+
+
+wchar_t*
+Py_GetPythonHome(void)
+{
+    pathconfig_global_init();
+    return _Py_path_config.home;
+}
+
+
+wchar_t *
+Py_GetProgramName(void)
+{
+    pathconfig_global_init();
+    return _Py_path_config.program_name;
+}
+
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
This reverts commit 13badcbc60cdbfae1dba1683fd2fae9d70717143.

Re-apply commits:

* "bpo-32030: _PyPathConfig_Init() sets home and program_name (#4673)"
  commit af5a895073c24637c094772b27526b94a12ec897.
* "bpo-32030: Fix config_get_program_name() on macOS (#4669)"
  commit e23c06e2b03452c9aaf0dae52296c85e572f9bcd.
* "bpo-32030: Add Python/pathconfig.c (#4668)"
  commit 0ea395ae964c9cd0f499e2ef0d0030c971201220.
* "bpo-32030: Don't call _PyPathConfig_Fini() in Py_FinalizeEx() (#4667)"
  commit ebac19dad6263141d5db0a2c923efe049dba99d2.
* "bpo-32030: Fix Py_GetPath(): init program_name (#4665)"
  commit 9ac3d8882712c9675c3d2f9f84af6b5729575cde.

Fix compilation error on macOS

<!-- issue-number: bpo-32197 -->
https://bugs.python.org/issue32197
<!-- /issue-number -->
