### PR TITLE
bpo-30928: Update idlelib/NEWS.txt to 2017 Dec 3.

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,22 @@ Released on 2018-06-18?
 ========================
 
 
+bpo-32164: Delete unused file idlelib/tabbedpages.py.
+Use of TabbedPageSet in configdialog was replaced by ttk.Notebook.
+
+bpo-32100: Fix old and new bugs in pathbrowser; improve tests.
+Patch mostly by Cheryl Sabella.
+
+bpo-31860: The font sample in the settings dialog is now editable.
+Edits persist while IDLE remains open.
+Patch by Serhiy Storchake and Terry Jan Reedy.
+
+bpo-31858: Restrict shell prompt manipulaton to the shell.
+Editor and output windows only see an empty last prompt line.  This
+simplifies the code and fixes a minor bug when newline is inserted.
+Sys.ps1, if present, is read on Shell start-up, but is not set or changed.
+Patch by Terry Jan Reedy.
+
 bpo-28603: Fix a TypeError that caused a shell restart when printing
 a traceback that includes an exception that is unhashable.
 Patch by Zane Bitter.


### PR DESCRIPTION
Patches are in 3.7.0a3 even if this update is not.

<!-- issue-number: bpo-30928 -->
https://bugs.python.org/issue30928
<!-- /issue-number -->
