### PR TITLE
bpo-32207: Improve tk event exception tracebacks in IDLE.

### DIFF
--- a/Misc/NEWS.d/next/IDLE/2017-12-04-15-04-43.bpo-32207.IzyAJo.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-12-04-15-04-43.bpo-32207.IzyAJo.rst
@@ -1,0 +1,10 @@
+Improve tk event exception tracebacks in IDLE.
+
+When tk event handling is driven by IDLE's run loop, a confusing
+
+and distracting queue.EMPTY traceback context is no longer added
+
+to tk event exception tracebacks.  The traceback is now the same
+
+as when event handling is driven by user code.  Patch based on  a suggestion
+by Serhiy Storchaka.

--- a/Misc/NEWS.d/next/IDLE/2017-12-04-15-04-43.bpo-32207.IzyAJo.rst
+++ b/Misc/NEWS.d/next/IDLE/2017-12-04-15-04-43.bpo-32207.IzyAJo.rst
@@ -1,10 +1,6 @@
 Improve tk event exception tracebacks in IDLE.
-
 When tk event handling is driven by IDLE's run loop, a confusing
-
 and distracting queue.EMPTY traceback context is no longer added
-
 to tk event exception tracebacks.  The traceback is now the same
-
-as when event handling is driven by user code.  Patch based on  a suggestion
-by Serhiy Storchaka.
+as when event handling is driven by user code.  Patch based on a
+suggestion by Serhiy Storchaka.


### PR DESCRIPTION

When tk event handling is driven by IDLE's run loop, a confusing
and distracting queue.EMPTY traceback context is no longer added
to tk event exception tracebacks.  The traceback is now the same
as when event handling is driven by user code.  Patch based on
a suggestion by Serhiy Storchaka.


<!-- issue-number: bpo-32207 -->
https://bugs.python.org/issue32207
<!-- /issue-number -->
