### PR TITLE
[bpo-28556] Minor fixes for typing module

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-12-05-02-03-07.bpo-28556.9Z_PsJ.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-05-02-03-07.bpo-28556.9Z_PsJ.rst
@@ -1,0 +1,3 @@
+Two minor fixes for ``typing`` module: allow shallow copying instances of
+generic classes, improve interaction of ``__init_subclass__`` with generics.
+Original PRs by Ivan Levkivskyi.


### PR DESCRIPTION
This needs to be backported to 3.5 and 3.6.

cc: @gvanrossum 

@ned-deily if possible, I think it would make sense to include these fixes in 3.6.4rc1


<!-- issue-number: bpo-28556 -->
https://bugs.python.org/issue28556
<!-- /issue-number -->
