### PR TITLE
[3.6] bpo-28791: Update macOS installer to use SQLite 3.21.0. (#4245)

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -315,9 +315,9 @@ def library_recipes():
                   ),
           ),
           dict(
-              name="SQLite 3.14.2",
-              url="https://www.sqlite.org/2016/sqlite-autoconf-3140200.tar.gz",
-              checksum='90c53cacb811db27f990b8292bd96159',
+              name="SQLite 3.21.0",
+              url="https://www.sqlite.org/2017/sqlite-autoconf-3210000.tar.gz",
+              checksum='7913de4c3126ba3c24689cb7a199ea31',
               extra_cflags=('-Os '
                             '-DSQLITE_ENABLE_FTS5 '
                             '-DSQLITE_ENABLE_FTS4 '

--- a/Misc/NEWS.d/next/Build/2017-11-02-20-13-46.bpo-28791.STt3jL.rst
+++ b/Misc/NEWS.d/next/Build/2017-11-02-20-13-46.bpo-28791.STt3jL.rst
@@ -1,0 +1,1 @@
+Update OS X installer to use SQLite 3.21.0.


### PR DESCRIPTION


<!-- issue-number: bpo-28791 -->
https://bugs.python.org/issue28791
<!-- /issue-number -->
