### PR TITLE
bpo-31392: Update macOS installer to use OpenSSL 1.0.2m

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -845,7 +845,6 @@ def build_universal_openssl(basedir, archList):
             "enable-tlsext",
             "no-ssl2",
             "no-ssl3",
-            "no-ssl3-method",
             # "enable-unit-test",
             "shared",
             "--install_prefix=%s"%shellQuote(archbase),

--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -213,9 +213,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.0.2k",
-              url="https://www.openssl.org/source/openssl-1.0.2k.tar.gz",
-              checksum='f965fc0bf01bf882b31314b61391ae65',
+              name="OpenSSL 1.0.2m",
+              url="https://www.openssl.org/source/openssl-1.0.2m.tar.gz",
+              checksum='10e9e37f492094b9ef296f68f24a7666',
               patches=[
                   "openssl_sdk_makedepend.patch",
                    ],

--- a/Misc/NEWS.d/next/macOS/2017-12-04-21-57-43.bpo-31392.f8huBC.rst
+++ b/Misc/NEWS.d/next/macOS/2017-12-04-21-57-43.bpo-31392.f8huBC.rst
@@ -1,0 +1,1 @@
+Update macOS installer to use OpenSSL 1.0.2m


### PR DESCRIPTION


<!-- issue-number: bpo-31392 -->
https://bugs.python.org/issue31392
<!-- /issue-number -->
