### PR TITLE
[3.6] bpo-28791: Update Windows builds to use SQLite 3.21.0. (GH-4246).

### DIFF
--- a/Misc/NEWS.d/next/Build/2017-11-02-20-30-57.bpo-28791.VaE3o8.rst
+++ b/Misc/NEWS.d/next/Build/2017-11-02-20-30-57.bpo-28791.VaE3o8.rst
@@ -1,0 +1,1 @@
+Update Windows builds to use SQLite 3.21.0.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -42,7 +42,7 @@ echo.Fetching external libraries...
 set libraries=
 set libraries=%libraries%                                    bzip2-1.0.6
 if NOT "%IncludeSSL%"=="false" set libraries=%libraries%     openssl-1.0.2k
-set libraries=%libraries%                                    sqlite-3.14.2.0
+set libraries=%libraries%                                    sqlite-3.21.0.0
 if NOT "%IncludeTkinter%"=="false" set libraries=%libraries% tcl-core-8.6.6.0
 if NOT "%IncludeTkinter%"=="false" set libraries=%libraries% tk-8.6.6.0
 if NOT "%IncludeTkinter%"=="false" set libraries=%libraries% tix-8.4.3.6

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -44,7 +44,7 @@
     
     <!-- Directories of external projects. tcltk is handled in tcltk.props -->
     <ExternalsDir>$([System.IO.Path]::GetFullPath(`$(PySourcePath)externals\`))</ExternalsDir>
-    <sqlite3Dir>$(ExternalsDir)sqlite-3.14.2.0\</sqlite3Dir>
+    <sqlite3Dir>$(ExternalsDir)sqlite-3.21.0.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
     <opensslDir>$(ExternalsDir)openssl-1.0.2k\</opensslDir>

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -212,7 +212,7 @@ _ssl
     functionality to _ssl or _hashlib. They will not clean up their output
     with the normal Clean target; CleanAll should be used instead.
 _sqlite3
-    Wraps SQLite 3.14.2.0, which is itself built by sqlite3.vcxproj
+    Wraps SQLite 3.21.0.0, which is itself built by sqlite3.vcxproj
     Homepage:
         http://www.sqlite.org/
 _tkinter


### PR DESCRIPTION
(cherry picked from commit 31af650ee25f65794b75d4dfefed6fe4758781c1)


<!-- issue-number: bpo-28791 -->
https://bugs.python.org/issue28791
<!-- /issue-number -->
