### PR TITLE
bpo-32217: Fixed freeze.py for Windows.

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2017-12-19-20-42-36.bpo-32217.axXcjA.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2017-12-19-20-42-36.bpo-32217.axXcjA.rst
@@ -1,0 +1,1 @@
+Fix freeze script on Windows.

--- a/Tools/freeze/freeze.py
+++ b/Tools/freeze/freeze.py
@@ -217,7 +217,12 @@ def main():
 
     # locations derived from options
     version = '%d.%d' % sys.version_info[:2]
-    flagged_version = version + sys.abiflags
+    if sys.platform != "win32":
+        # on Windows this will make freeze traceback
+        # because abiflags is not in sys.
+        flaggedver_sion = version + sys.abiflags
+    else:
+        flaggedver_sion = version
     if win:
         extensions_c = 'frozen_extensions.c'
     if ishome:

--- a/Tools/freeze/freeze.py
+++ b/Tools/freeze/freeze.py
@@ -220,9 +220,9 @@ def main():
     if sys.platform != "win32":
         # on Windows this will make freeze traceback
         # because abiflags is not in sys.
-        flaggedver_sion = version + sys.abiflags
+        flagged_version = version + sys.abiflags
     else:
-        flaggedver_sion = version
+        flagged_version = version
     if win:
         extensions_c = 'frozen_extensions.c'
     if ishome:

--- a/Tools/freeze/freeze.py
+++ b/Tools/freeze/freeze.py
@@ -217,7 +217,7 @@ def main():
 
     # locations derived from options
     version = '%d.%d' % sys.version_info[:2]
-    if sys.platform != "win32":
+    if not win:
         # on Windows this will make freeze traceback
         # because abiflags is not in sys.
         flagged_version = version + sys.abiflags

--- a/Tools/freeze/freeze.py
+++ b/Tools/freeze/freeze.py
@@ -218,8 +218,6 @@ def main():
     # locations derived from options
     version = '%d.%d' % sys.version_info[:2]
     if hasattr(sys, 'abiflags'):
-        # on Windows this will make freeze traceback
-        # because abiflags is not in sys.
         flagged_version = version + sys.abiflags
     else:
         flagged_version = version

--- a/Tools/freeze/freeze.py
+++ b/Tools/freeze/freeze.py
@@ -217,7 +217,7 @@ def main():
 
     # locations derived from options
     version = '%d.%d' % sys.version_info[:2]
-    if not win:
+    if hasattr(sys, 'abiflags'):
         # on Windows this will make freeze traceback
         # because abiflags is not in sys.
         flagged_version = version + sys.abiflags


### PR DESCRIPTION
On Windows freeze was never going to work because of this issue. This fix should hopefully make freeze work on Windows again for now.


<!-- issue-number: bpo-32217 -->
https://bugs.python.org/issue32217
<!-- /issue-number -->
