### PR TITLE
bpo-31380: Skip test_httpservers test_undecodable_file on macOS.

### DIFF
--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -384,7 +384,8 @@ class SimpleHTTPServerTestCase(BaseTestCase):
         reader.close()
         return body
 
-    @support.requires_mac_ver(10, 5)
+    @unittest.skipIf(sys.platform == 'darwin',
+                     'undecodable name cannot always be decoded on macOS')
     @unittest.skipIf(sys.platform == 'win32',
                      'undecodable name cannot be decoded on win32')
     @unittest.skipUnless(support.TESTFN_UNDECODABLE,

--- a/Misc/NEWS.d/next/Tests/2017-12-04-23-19-16.bpo-31380.VlMmHW.rst
+++ b/Misc/NEWS.d/next/Tests/2017-12-04-23-19-16.bpo-31380.VlMmHW.rst
@@ -1,0 +1,1 @@
+Skip test_httpservers test_undecodable_file on macOS: fails on APFS.


### PR DESCRIPTION
The undecodable file name cannot be created on APFS file systems which is becoming the default on macOS.  And the test was already being skipped on old macOS systems.  Testing on Linux should be sufficient.

<!-- issue-number: bpo-31380 -->
https://bugs.python.org/issue31380
<!-- /issue-number -->
