### PR TITLE
[2.7] Add a missing space in tkinter documentation. (GH-4692).

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -161,7 +161,7 @@ background material, while the second half can be taken to the keyboard as a
 handy reference.
 
 When trying to answer questions of the form "how do I do blah", it is often best
-to find out how to do"blah" in straight Tk, and then convert this back into the
+to find out how to do "blah" in straight Tk, and then convert this back into the
 corresponding :mod:`Tkinter` call. Python programmers can often guess at the
 correct Python command by looking at the Tk documentation. This means that in
 order to use Tkinter, you will have to know a little bit about Tk. This document


### PR DESCRIPTION
(cherry picked from commit ae342cf7deebdcf2035f4064609b32b2102dadcf)
