### PR TITLE
Misc questions, suggestions, and error corrections for dataclasses

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -709,7 +709,7 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, **kwargs):
     of either (name, type) or (name, type, Field) objects. Field
     objects are created by calling 'field(name, type [, Field])'.
 
-      C = make_class('C', [('a', int), ('b', int, Field(init=False))], bases=Base)
+      C = make_dataclass('C', [('a', int), ('b', int, Field(init=False))], bases=Base)
 
     is equivalent to:
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1,7 +1,6 @@
 import sys
 import types
 from copy import deepcopy
-import collections
 import inspect
 
 __all__ = ['dataclass',
@@ -446,11 +445,10 @@ def _set_attribute(cls, name, value):
 
 
 def _process_class(cls, repr, eq, order, hash, init, frozen):
-    # Use an OrderedDict because:
-    #  - Order matters!
+    # Note that order matters here.
     #  - Derived class fields overwrite base class fields, but the
     #    order is defined by the base class, which is found first.
-    fields = collections.OrderedDict()
+    fields = {}
 
     # Find our base classes in reverse MRO order, and exclude
     #  ourselves.  In reversed order so that more derived classes
@@ -621,9 +619,6 @@ def _isdataclass(obj):
     return not isinstance(obj, type) and hasattr(obj, _MARKER)
 
 
-# Shouldn't the default factor be collections.OrderedDict()?
-# The class itself is ordered and instances may or may not be
-# intrinsically ordered depending on the "ordered" keyword.
 def asdict(obj, *, dict_factory=dict):
     """Return the fields of a dataclass instance as a new dictionary mapping
     field names to field values.
@@ -727,7 +722,7 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, **kwargs):
         # Copy namespace since we're going to mutate it.
         namespace = namespace.copy()
 
-    anns = collections.OrderedDict((name, tp) for name, tp, *_ in fields)
+    anns = {name : tp for name, tp, *_ in fields}
     namespace['__annotations__'] = anns
     for item in fields:
         if len(item) == 3:

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1915,6 +1915,10 @@ class TestCase(unittest.TestCase):
         self.assertEqual((c.x, c.y), (10, 5))
         self.assertEqual(c.add_one(), 11)
 
+    def test_helper_make_dataclass_keywords(self):
+        C = make_dataclass('C', [('x', int), ('y', int)], order=True, hash=True)
+        self.assertLess(C(10, 20), C(10, 25))
+        self.assertEqual(hash(C(10, 20)), hash(C(10, 20)))
 
     def test_helper_make_dataclass_no_mutate_namespace(self):
         # Make sure a provided namespace isn't mutated.


### PR DESCRIPTION
These are for Eric's consideration:

* Fix typo leading to a SyntaxError in the make_dataclass docstring
* Let *make_dataclass* pass through keyword arguments (ordered, hash, frozen, etc)
* Replace "len(s)==0" with the faster and more idiomatic (PEP 8ish) "not s"
* Ask whether asdict() should return an OrderedDict instead of a regular dict
* Even though the class implementation details have "hash=None" as a way of turning off hashing, the dataclass API should use regular booleans and have the default be "hash=False" (as equivalent to "hash=None").  It is a bit of an API landmine to have hashing succeed in  this example:

```
>>> from dataclasses import dataclass
>>> @dataclass(hash=False)
... class C:
...     x: int
...
>>> hash(C(999))
-9223372036585142703
```