### PR TITLE
bpo-32223: Use UTF-8 encoding when reading config files

### DIFF
--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -403,7 +403,7 @@ Common commands: (see '--help-commands' for more)
         for filename in filenames:
             if DEBUG:
                 self.announce("  reading %s" % filename)
-            parser.read(filename)
+            parser.read(filename, encoding="UTF-8")
             for section in parser.sections():
                 options = parser.options(section)
                 opt_dict = self.get_option_dict(section)


### PR DESCRIPTION
This simply adds the `encoding="UTF-8"` argument and fixes the encoding problem when reading setup.cfg.

<!-- issue-number: bpo-32223 -->
https://bugs.python.org/issue32223
<!-- /issue-number -->
