### PR TITLE
bpo-32030: Simplify _PyCoreConfig_INIT macro

### DIFF
--- a/Include/internal/pystate.h
+++ b/Include/internal/pystate.h
@@ -54,23 +54,8 @@ typedef struct {
     wchar_t *home;
 } _PyPathConfig;
 
-#ifdef MS_WINDOWS
-#define _PyPathConfig_INIT \
-    {.program_full_path = NULL, \
-     .prefix = NULL, \
-     .dll_path = NULL, \
-     .module_search_path = NULL, \
-     .program_name = NULL, \
-     .home = NULL}
-#else
-#define _PyPathConfig_INIT \
-    {.program_full_path = NULL, \
-     .prefix = NULL, \
-     .exec_prefix = NULL, \
-     .module_search_path = NULL, \
-     .program_name = NULL, \
-     .home = NULL}
-#endif
+#define _PyPathConfig_INIT {.module_search_path = NULL}
+/* Note: _PyPathConfig_INIT sets other fields to 0/NULL */
 
 PyAPI_DATA(_PyPathConfig) _Py_path_config;
 
@@ -116,6 +101,7 @@ typedef struct pyruntimestate {
 } _PyRuntimeState;
 
 #define _PyRuntimeState_INIT {.initialized = 0, .core_initialized = 0}
+/* Note: _PyRuntimeState_INIT sets other fields to 0/NULL */
 
 PyAPI_DATA(_PyRuntimeState) _PyRuntime;
 PyAPI_FUNC(_PyInitError) _PyRuntimeState_Init(_PyRuntimeState *);

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -38,19 +38,8 @@ typedef struct {
     int show_alloc_count;   /* -X showalloccount */
 } _PyCoreConfig;
 
-#define _PyCoreConfig_INIT \
-    (_PyCoreConfig){\
-     .ignore_environment = 0, \
-     .use_hash_seed = -1, \
-     .hash_seed = 0, \
-     ._disable_importlib = 0, \
-     .allocator = NULL, \
-     .dev_mode = 0, \
-     .faulthandler = 0, \
-     .tracemalloc = 0, \
-     .import_time = 0, \
-     .show_ref_count = 0, \
-     .show_alloc_count = 0}
+#define _PyCoreConfig_INIT (_PyCoreConfig){.use_hash_seed = -1}
+/* Note: _PyCoreConfig_INIT sets other fields to 0/NULL */
 
 /* Placeholders while working on the new configuration API
  *
@@ -69,11 +58,8 @@ typedef struct {
 } _PyMainInterpreterConfig;
 
 #define _PyMainInterpreterConfig_INIT \
-    (_PyMainInterpreterConfig){\
-     .install_signal_handlers = -1, \
-     .module_search_path_env = NULL, \
-     .home = NULL, \
-     .program_name = NULL}
+    (_PyMainInterpreterConfig){.install_signal_handlers = -1}
+/* Note: _PyMainInterpreterConfig_INIT sets other fields to 0/NULL */
 
 typedef struct _is {
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -160,7 +160,7 @@ pymain_get_env_var(const char *name)
 
 
 static void
-pymain_run_statup(PyCompilerFlags *cf)
+pymain_run_startup(PyCompilerFlags *cf)
 {
     char *startup = Py_GETENV("PYTHONSTARTUP");
     if (startup == NULL || startup[0] == '\0') {
@@ -367,8 +367,6 @@ pymain_run_file(FILE *fp, const wchar_t *filename, PyCompilerFlags *p_cf)
 
 /* Main program */
 
-/*TODO: Add arg processing to PEP 432 as a new configuration setup API
- */
 typedef struct {
     size_t len;
     wchar_t **options;
@@ -949,8 +947,6 @@ pymain_get_program_name(_PyMain *pymain)
  *
  * Replaces previous call to Py_Initialize()
  *
- * TODO: Move environment queries (etc) into Py_ReadConfig
- *
  * Return 0 on success.
  * Set pymain->err and return -1 on error.
  */
@@ -1121,10 +1117,9 @@ pymain_run_filename(_PyMain *pymain)
 
     if (cmdline->filename == NULL && pymain->stdin_is_interactive) {
         Py_InspectFlag = 0; /* do exit on SystemExit */
-        pymain_run_statup(&pymain->cf);
+        pymain_run_startup(&pymain->cf);
         pymain_run_interactive_hook();
     }
-    /* XXX */
 
     if (pymain->main_importer_path != NULL) {
         pymain->status = pymain_run_main_from_importer(pymain);
@@ -1162,7 +1157,7 @@ pymain_repl(_PyMain *pymain)
 
     Py_InspectFlag = 0;
     pymain_run_interactive_hook();
-    /* XXX */
+
     int res = PyRun_AnyFileFlags(stdin, "<stdin>", &pymain->cf);
     pymain->status = (res != 0);
 }
@@ -1630,7 +1625,6 @@ pymain_init(_PyMain *pymain)
     }
 
     pymain->core_config._disable_importlib = 0;
-    /* TODO: Moar config options! */
     pymain->config.install_signal_handlers = 1;
 
     orig_argc = pymain->argc;           /* For Py_GetArgcArgv() */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -606,10 +606,6 @@ _Py_SetLocaleFromEnv(int category)
  * safe to call without calling Py_Initialize first)
  */
 
-/* TODO: Progressively move functionality from Py_BeginInitialization to
- * Py_ReadConfig and Py_EndInitialization
- */
-
 _PyInitError
 _Py_InitializeCore(const _PyCoreConfig *config)
 {
@@ -881,10 +877,9 @@ _Py_InitializeMainInterpreter(const _PyMainInterpreterConfig *config)
         return _Py_INIT_OK();
     }
 
-    /* TODO: Report exceptions rather than fatal errors below here */
-
-    if (_PyTime_Init() < 0)
+    if (_PyTime_Init() < 0) {
         return _Py_INIT_ERR("can't initialize time");
+    }
 
     /* GetPath may initialize state that _PySys_EndInit locks
        in, and so has to be called first. */


### PR DESCRIPTION
* Simplify _PyCoreConfig_INIT, _PyMainInterpreterConfig_INIT,
  _PyPathConfig_INIT macros: no need to set fields to 0/NULL, it's
  redundant (the C language sets them to 0/NULL for us).
* Fix typo: pymain_run_statup() => pymain_run_startup()
* Remove a few XXX/TODO

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
