### PR TITLE
bpo-32227: functools.singledispatch supports registering via type annotations

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -285,14 +285,14 @@ The :mod:`functools` module defines the following functions:
    parameter and decorating a function implementing the operation for that
    type::
 
-     >>> @fun.register(int)
-     ... def _(arg, verbose=False):
+     >>> @fun.register
+     ... def _(arg: int, verbose=False):
      ...     if verbose:
      ...         print("Strength in numbers, eh?", end=" ")
      ...     print(arg)
      ...
-     >>> @fun.register(list)
-     ... def _(arg, verbose=False):
+     >>> @fun.register
+     ... def _(arg: list, verbose=False):
      ...     if verbose:
      ...         print("Enumerate this:")
      ...     for i, elem in enumerate(arg):
@@ -305,6 +305,16 @@ The :mod:`functools` module defines the following functions:
      ...     print("Nothing.")
      ...
      >>> fun.register(type(None), nothing)
+
+   This form of the :func:`register` attribute can also be used as
+   a decorator (note: no type annotations on the function now)::
+
+     >>> @fun.register(complex)
+     ... def _(arg, verbose=False):
+     ...     if verbose:
+     ...         print("Strength in numbers, eh?", end=" ")
+     ...     print(arg)
+     ...
 
    The :func:`register` attribute returns the undecorated function which
    enables decorator stacking, pickling, as well as creating unit tests for
@@ -367,6 +377,9 @@ The :mod:`functools` module defines the following functions:
     <function fun at 0x103fe0000>
 
    .. versionadded:: 3.4
+
+   .. versionchanged:: 3.7
+   The :func:`register` attribute supports using type annotations.
 
 
 .. function:: update_wrapper(wrapper, wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=WRAPPER_UPDATES)

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -379,7 +379,7 @@ The :mod:`functools` module defines the following functions:
    .. versionadded:: 3.4
 
    .. versionchanged:: 3.7
-   The :func:`register` attribute supports using type annotations.
+      The :func:`register` attribute supports using type annotations.
 
 
 .. function:: update_wrapper(wrapper, wrapped, assigned=WRAPPER_ASSIGNMENTS, updated=WRAPPER_UPDATES)

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -312,8 +312,8 @@ The :mod:`functools` module defines the following functions:
      >>> @fun.register(complex)
      ... def _(arg, verbose=False):
      ...     if verbose:
-     ...         print("Strength in numbers, eh?", end=" ")
-     ...     print(arg)
+     ...         print("Better than complicated.", end=" ")
+     ...     print(arg.real, arg.imag)
      ...
 
    The :func:`register` attribute returns the undecorated function which

--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -281,9 +281,9 @@ The :mod:`functools` module defines the following functions:
      ...     print(arg)
 
    To add overloaded implementations to the function, use the :func:`register`
-   attribute of the generic function.  It is a decorator, taking a type
-   parameter and decorating a function implementing the operation for that
-   type::
+   attribute of the generic function.  It is a decorator.  For functions
+   annotated with types, the decorator will infer the type of the first
+   argument automatically::
 
      >>> @fun.register
      ... def _(arg: int, verbose=False):
@@ -298,16 +298,8 @@ The :mod:`functools` module defines the following functions:
      ...     for i, elem in enumerate(arg):
      ...         print(i, elem)
 
-   To enable registering lambdas and pre-existing functions, the
-   :func:`register` attribute can be used in a functional form::
-
-     >>> def nothing(arg, verbose=False):
-     ...     print("Nothing.")
-     ...
-     >>> fun.register(type(None), nothing)
-
-   This form of the :func:`register` attribute can also be used as
-   a decorator (note: no type annotations on the function now)::
+   For code which doesn't use type annotations, the appropriate type
+   argument can be passed explicitly to the decorator itself::
 
      >>> @fun.register(complex)
      ... def _(arg, verbose=False):
@@ -315,6 +307,15 @@ The :mod:`functools` module defines the following functions:
      ...         print("Better than complicated.", end=" ")
      ...     print(arg.real, arg.imag)
      ...
+
+
+   To enable registering lambdas and pre-existing functions, the
+   :func:`register` attribute can be used in a functional form::
+
+     >>> def nothing(arg, verbose=False):
+     ...     print("Nothing.")
+     ...
+     >>> fun.register(type(None), nothing)
 
    The :func:`register` attribute returns the undecorated function which
    enables decorator stacking, pickling, as well as creating unit tests for

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2188,7 +2188,5 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertTrue(str(exc.exception).endswith(msg_suffix))
 
 
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -10,6 +10,7 @@ import sys
 from test import support
 import threading
 import time
+import typing
 import unittest
 import unittest.mock
 from weakref import proxy
@@ -2118,6 +2119,75 @@ class TestSingleDispatch(unittest.TestCase):
             self.assertEqual(g(l), "list")
             g._clear_cache()
             self.assertEqual(len(td), 0)
+
+    def test_annotations(self):
+        @functools.singledispatch
+        def i(arg):
+            return "base"
+        @i.register
+        def _(arg: collections.abc.Mapping):
+            return "mapping"
+        @i.register
+        def _(arg: "collections.abc.Sequence"):
+            return "sequence"
+        self.assertEqual(i(None), "base")
+        self.assertEqual(i({"a": 1}), "mapping")
+        self.assertEqual(i([1, 2, 3]), "sequence")
+        self.assertEqual(i((1, 2, 3)), "sequence")
+        self.assertEqual(i("str"), "sequence")
+
+        # Registering classes as callables doesn't work with annotations,
+        # you need to pass the type explicitly.
+        @i.register(str)
+        class _:
+            def __init__(self, arg):
+                self.arg = arg
+
+            def __eq__(self, other):
+                return self.arg == other
+        self.assertEqual(i("str"), "str")
+
+    def test_invalid_registrations(self):
+        msg_prefix = "Invalid first argument to `register()`: "
+        msg_suffix = (
+            ". Use either `@register(some_class)` or plain `@register` on an "
+            "annotated function."
+        )
+        @functools.singledispatch
+        def i(arg):
+            return "base"
+        with self.assertRaises(TypeError) as exc:
+            @i.register(42)
+            def _(arg):
+                return "I annotated with a non-type"
+        self.assertTrue(str(exc.exception).startswith(msg_prefix + "42"))
+        self.assertTrue(str(exc.exception).endswith(msg_suffix))
+        with self.assertRaises(TypeError) as exc:
+            @i.register
+            def _(arg):
+                return "I forgot to annotate"
+        self.assertTrue(str(exc.exception).startswith(msg_prefix +
+            "<function TestSingleDispatch.test_invalid_registrations.<locals>._"
+        ))
+        self.assertTrue(str(exc.exception).endswith(msg_suffix))
+
+        # FIXME: The following will only work after PEP 560 is implemented.
+        return
+
+        with self.assertRaises(TypeError) as exc:
+            @i.register
+            def _(arg: typing.Iterable[str]):
+                # At runtime, dispatching on generics is impossible.
+                # When registering implementations with singledispatch, avoid
+                # types from `typing`. Instead, annotate with regular types
+                # or ABCs.
+                return "I annotated with a generic collection"
+        self.assertTrue(str(exc.exception).startswith(msg_prefix +
+            "<function TestSingleDispatch.test_invalid_registrations.<locals>._"
+        ))
+        self.assertTrue(str(exc.exception).endswith(msg_suffix))
+
+
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2017-12-05-13-25-15.bpo-32227.3vnWFS.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-05-13-25-15.bpo-32227.3vnWFS.rst
@@ -1,0 +1,2 @@
+``functools.singledispatch`` now supports registering implementations using
+type annotations.


### PR DESCRIPTION
With the patch attached to this issue, `@singledispatch` gains support for passing the type in `@register` via annotations.

This looks more natural and enables more thorough type checking without repeating yourself:
```py3
@singledispatch
def generic(arg): ...

@generic.register
def _(arg: str): ...

@generic.register
def _(arg: int): ...
```

The previous API is still available for backwards compatibility, as well as stacking, and use with classes (sic, I was surprised to learn it's used that way, too).

The patch should be uncontroversial, maybe except for the fact that it's importing the `typing` module if annotations are used. This is necessary because of forward references, usage of None as a type, and so on. More importantly, with PEP 563 it's mandatory.

<!-- issue-number: bpo-32227 -->
https://bugs.python.org/issue32227
<!-- /issue-number -->
