### PR TITLE
bpo-32030: pass interp to _PyImport_Init()

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -127,7 +127,7 @@ PyAPI_FUNC(const char *) _Py_gitversion(void);
 PyAPI_FUNC(PyObject *) _PyBuiltin_Init(void);
 PyAPI_FUNC(_PyInitError) _PySys_BeginInit(PyObject **sysmod);
 PyAPI_FUNC(int) _PySys_EndInit(PyObject *sysdict);
-PyAPI_FUNC(_PyInitError) _PyImport_Init(void);
+PyAPI_FUNC(_PyInitError) _PyImport_Init(PyInterpreterState *interp);
 PyAPI_FUNC(void) _PyExc_Init(PyObject * bltinmod);
 PyAPI_FUNC(_PyInitError) _PyImportHooks_Init(void);
 PyAPI_FUNC(int) _PyFrame_Init(void);

--- a/Python/import.c
+++ b/Python/import.c
@@ -31,8 +31,6 @@ extern struct _inittab _PyImport_Inittab[];
 
 struct _inittab *PyImport_Inittab = _PyImport_Inittab;
 
-static PyObject *initstr = NULL;
-
 /*[clinic input]
 module _imp
 [clinic start generated code]*/
@@ -43,14 +41,8 @@ module _imp
 /* Initialize things */
 
 _PyInitError
-_PyImport_Init(void)
+_PyImport_Init(PyInterpreterState *interp)
 {
-    PyInterpreterState *interp = PyThreadState_Get()->interp;
-    initstr = PyUnicode_InternFromString("__init__");
-    if (initstr == NULL) {
-        return _Py_INIT_ERR("Can't initialize import variables");
-    }
-
     interp->builtins_copy = PyDict_Copy(interp->builtins);
     if (interp->builtins_copy == NULL) {
         return _Py_INIT_ERR("Can't backup builtins dict");

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -751,7 +751,7 @@ _Py_InitializeCore(const _PyCoreConfig *config)
     PySys_SetObject("__stderr__", pstderr);
     Py_DECREF(pstderr);
 
-    err = _PyImport_Init();
+    err = _PyImport_Init(interp);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }


### PR DESCRIPTION
Remove also the initstr variable, unused since the commit
e69f0df45b709c25ac80617c41bbae16f56870fb pushed in 2012: "bpo-13959:
Re-implement imp.find_module() in Lib/imp.py"

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
