### PR TITLE
PyLong_FromString(): fix Coverity CID 1424951

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -2267,7 +2267,6 @@ just 1 digit at the start, so that the copying code was exercised for every
 digit beyond the first.
 ***/
         twodigits c;           /* current input character */
-        double fsize_z;
         Py_ssize_t size_z;
         Py_ssize_t digits = 0;
         int i;
@@ -2331,8 +2330,8 @@ digit beyond the first.
          * need to initialize z->ob_digit -- no slot is read up before
          * being stored into.
          */
-        fsize_z = digits * log_base_BASE[base] + 1;
-        if (fsize_z > MAX_LONG_DIGITS) {
+        double fsize_z = (double)digits * log_base_BASE[base] + 1.0;
+        if (fsize_z > (double)MAX_LONG_DIGITS) {
             /* The same exception as in _PyLong_New(). */
             PyErr_SetString(PyExc_OverflowError,
                             "too many digits in integer");


### PR DESCRIPTION
Explicitly cast digits (Py_ssize_t) to double to fix the following
false-alarm warning from Coverity:

"fsize_z = digits * log_base_BASE[base] + 1;"

CID 1424951: Incorrect expression (UNINTENDED_INTEGER_DIVISION)
Dividing integer expressions "9223372036854775783UL" and "4UL", and
then converting the integer quotient to type "double". Any remainder,
or fractional part of the quotient, is ignored.