### PR TITLE
bpo-31506: Improve the error message logic for object_new & object_init

### DIFF
--- a/Lib/test/test_class.py
+++ b/Lib/test/test_class.py
@@ -595,5 +595,54 @@ class ClassTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             type.__setattr__(A, b'x', None)
 
+    def testConstructorErrorMessages(self):
+        # bpo-31506: Improves the error message logic for object_new & object_init
+
+        # Class without any method overrides
+        class C:
+            pass
+
+        with self.assertRaisesRegex(TypeError, r'C\(\) takes no arguments'):
+            C(42)
+
+        with self.assertRaisesRegex(TypeError, r'C\(\) takes no arguments'):
+            C.__new__(C, 42)
+
+        with self.assertRaisesRegex(TypeError, r'C\(\).__init__\(\) takes no arguments'):
+            C().__init__(42)
+
+        with self.assertRaisesRegex(TypeError, r'C\(\) takes no arguments'):
+            object.__new__(C, 42)
+
+        with self.assertRaisesRegex(TypeError, r'C\(\).__init__\(\) takes no arguments'):
+            object.__init__(C(), 42)
+
+        # Class with both `__init__` & `__new__` method overriden
+        class D:
+            def __new__(cls, *args, **kwargs):
+                super().__new__(cls, *args, **kwargs)
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+        with self.assertRaisesRegex(TypeError, r'object.__new__\(\) takes no argument'):
+            D(42)
+
+        with self.assertRaisesRegex(TypeError, r'object.__new__\(\) takes no argument'):
+            D.__new__(D, 42)
+
+        with self.assertRaisesRegex(TypeError, r'object.__new__\(\) takes no argument'):
+            object.__new__(D, 42)
+
+        # Class that only overrides __init__
+        class E:
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+
+        with self.assertRaisesRegex(TypeError, r'object.__init__\(\) takes no argument'):
+            E().__init__(42)
+
+        with self.assertRaisesRegex(TypeError, r'object.__init__\(\) takes no argument'):
+            object.__init__(E(), 42)
+
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-07-23-44-29.bpo-31506.j1U2fU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-07-23-44-29.bpo-31506.j1U2fU.rst
@@ -1,0 +1,2 @@
+Improve the error message logic for object.__new__ and object.__init__.
+Patch by Sanyam Khurana.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3592,7 +3592,7 @@ object_init(PyObject *self, PyObject *args, PyObject *kwds)
     PyTypeObject *type = Py_TYPE(self);
     if (excess_args(args, kwds)) {
         if (type->tp_init != object_init) {
-            PyErr_SetString(PyExc_TypeError, "object().__init__() takes no arguments");
+            PyErr_SetString(PyExc_TypeError, "object.__init__() takes no arguments");
             return -1;
         }
         if (type->tp_new == object_new) {
@@ -3609,7 +3609,7 @@ object_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     if (excess_args(args, kwds)) {
         if (type->tp_new != object_new) {
-            PyErr_SetString(PyExc_TypeError, "object().__new__() takes no arguments");
+            PyErr_SetString(PyExc_TypeError, "object.__new__() takes no arguments");
             return NULL;
         }
         if (type->tp_init == object_init) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3596,7 +3596,7 @@ object_init(PyObject *self, PyObject *args, PyObject *kwds)
             return -1;
         }
         if (type->tp_new == object_new) {
-            PyErr_Format(PyExc_TypeError, "%.200s() takes no arguments",
+            PyErr_Format(PyExc_TypeError, "%.200s().__init__() takes no arguments",
                          type->tp_name);
             return -1;
         }
@@ -3609,7 +3609,7 @@ object_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     if (excess_args(args, kwds)) {
         if (type->tp_new != object_new) {
-            PyErr_SetString(PyExc_TypeError, "object() takes no arguments");
+            PyErr_SetString(PyExc_TypeError, "object().__new__() takes no arguments");
             return NULL;
         }
         if (type->tp_init == object_init) {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3592,7 +3592,7 @@ object_init(PyObject *self, PyObject *args, PyObject *kwds)
     PyTypeObject *type = Py_TYPE(self);
     if (excess_args(args, kwds)) {
         if (type->tp_init != object_init) {
-            PyErr_SetString(PyExc_TypeError, "object() takes no arguments");
+            PyErr_SetString(PyExc_TypeError, "object().__init__() takes no arguments");
             return -1;
         }
         if (type->tp_new == object_new) {


### PR DESCRIPTION
With this patch applied, the classes without any method overrides behaves like this:

```
>>> class C:
...     pass
...
>>> C(42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: C() takes no arguments
>>> C.__new__(C, 42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: C() takes no arguments
>>> C().__init__(42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: C().__init__() takes no arguments
>>> object.__new__(C, 42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: C() takes no arguments
>>> object.__init__(C(), 42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: C().__init__() takes no arguments
```

And for classes having method overrides, it behaves like this:

```
>>> class D:
...     def __new__(cls, *args, **kwds):
...         super().__new__(cls, *args, **kwds)
...     def __init__(self, *args, **kwds):
...         super().__init__(*args, **kwds)
...
>>> D(42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 3, in __new__
TypeError: object().__new__() takes no arguments
>>> D.__new__(D, 42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "<stdin>", line 3, in __new__
TypeError: object().__new__() takes no arguments
>>> object.__new__(D, 42)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: object().__new__() takes no arguments
```


cc @ncoghlan . I'm still trying to figure out the changes to be done for cases of `object.__init__(D(), 42)` and `D().__init__(42)` because they don't report error right now.

<!-- issue-number: bpo-31506 -->
https://bugs.python.org/issue31506
<!-- /issue-number -->
