### PR TITLE
bpo-32222: Fix pygettext skipping docstrings for funcs with arg typehints

### DIFF
--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -150,3 +150,13 @@ class Test_pygettext(unittest.TestCase):
         self.assertIn('doc1', msgids)
         self.assertIn('doc2', msgids)
         self.assertIn('doc3', msgids)
+
+    def test_classdocstring_early_colon(self):
+        """ Test docstring extraction for a class with colons occuring within
+        the parentheses.
+        """
+        msgids = self.extract_docstrings_from_str(textwrap.dedent('''\
+        class D(L[1:2], F({1: 2}), metaclass=M(lambda x: x)):
+            """doc"""
+        '''))
+        self.assertIn('doc', msgids)

--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import unittest
+import textwrap
 
 from test.support.script_helper import assert_python_ok
 from test.test_tools import skip_if_missing, toolsdir
@@ -27,6 +28,41 @@ class Test_pygettext(unittest.TestCase):
             key, val = line.split(':',1)
             headers[key] = val.strip()
         return headers
+
+    def get_msgids(self, data):
+        """ utility: return all msgids in .po file as a list of strings """
+        msgids = []
+        reading_msgid = False
+        cur_msgid = []
+        for line in data.split('\n'):
+            if reading_msgid:
+                if line.startswith('"'):
+                    cur_msgid.append(line.strip('"'))
+                else:
+                    msgids.append('\n'.join(cur_msgid))
+                    cur_msgid = []
+                    reading_msgid = False
+                    continue
+            if line.startswith('msgid '):
+                line = line[len('msgid '):]
+                cur_msgid.append(line.strip('"'))
+                reading_msgid = True
+        else:
+            if reading_msgid:
+                msgids.append('\n'.join(cur_msgid))
+
+        return msgids
+
+    def extract_docstrings_from_str(self, module_content):
+        """ utility: return all msgids extracted from module_content """
+        filename = 'test_docstrings.py'
+        with temp_cwd(None) as cwd:
+            with open(filename, 'w') as fp:
+                fp.write(module_content)
+            assert_python_ok(self.script, '-D', filename)
+            with open('messages.pot') as fp:
+                data = fp.read()
+        return self.get_msgids(data)
 
     def test_header(self):
         """Make sure the required fields are in the header, according to:
@@ -72,3 +108,46 @@ class Test_pygettext(unittest.TestCase):
 
             # This will raise if the date format does not exactly match.
             datetime.strptime(creationDate, '%Y-%m-%d %H:%M%z')
+
+    def test_funcdocstring_annotated_args(self):
+        """ Test docstrings for functions with annotated args """
+        msgids = self.extract_docstrings_from_str(textwrap.dedent('''\
+        def foo(bar: str):
+            """doc"""
+        '''))
+        self.assertIn('doc', msgids)
+
+    def test_funcdocstring_annotated_return(self):
+        """ Test docstrings for functions with annotated return type """
+        msgids = self.extract_docstrings_from_str(textwrap.dedent('''\
+        def foo(bar) -> str:
+            """doc"""
+        '''))
+        self.assertIn('doc', msgids)
+
+    def test_funcdocstring_defvalue_args(self):
+        """ Test docstring for functions with default arg values """
+        msgids = self.extract_docstrings_from_str(textwrap.dedent('''\
+        def foo(bar=()):
+            """doc"""
+        '''))
+        self.assertIn('doc', msgids)
+
+    def test_funcdocstring_multiple_funcs(self):
+        """ Test docstring extraction for multiple functions combining
+        annotated args, annotated return types and default arg values
+        """
+        msgids = self.extract_docstrings_from_str(textwrap.dedent('''\
+        def foo1(bar: tuple=()) -> str:
+            """doc1"""
+        
+        def foo2(bar: List[1:2]) -> (lambda x: x):
+            """doc2"""
+        
+        def foo3(bar: 'func'=lambda x: x) -> {1: 2}:
+            """doc3"""
+        '''))
+        self.assertIn('doc1', msgids)
+        self.assertIn('doc2', msgids)
+        self.assertIn('doc3', msgids)
+

--- a/Lib/test/test_tools/test_i18n.py
+++ b/Lib/test/test_tools/test_i18n.py
@@ -140,14 +140,13 @@ class Test_pygettext(unittest.TestCase):
         msgids = self.extract_docstrings_from_str(textwrap.dedent('''\
         def foo1(bar: tuple=()) -> str:
             """doc1"""
-        
+
         def foo2(bar: List[1:2]) -> (lambda x: x):
             """doc2"""
-        
+
         def foo3(bar: 'func'=lambda x: x) -> {1: 2}:
             """doc3"""
         '''))
         self.assertIn('doc1', msgids)
         self.assertIn('doc2', msgids)
         self.assertIn('doc3', msgids)
-

--- a/Misc/NEWS.d/next/Tools-Demos/2017-12-07-20-51-20.bpo-32222.hPBcGT.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2017-12-07-20-51-20.bpo-32222.hPBcGT.rst
@@ -1,0 +1,2 @@
+Fix pygettext not extracting docstrings for functions with type annotated
+arguments.

--- a/Misc/NEWS.d/next/Tools-Demos/2017-12-07-20-51-20.bpo-32222.hPBcGT.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2017-12-07-20-51-20.bpo-32222.hPBcGT.rst
@@ -1,3 +1,3 @@
 Fix pygettext not extracting docstrings for functions with type annotated
 arguments.
-Patch by Tobotimus
+Patch by Toby Harradine.

--- a/Misc/NEWS.d/next/Tools-Demos/2017-12-07-20-51-20.bpo-32222.hPBcGT.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2017-12-07-20-51-20.bpo-32222.hPBcGT.rst
@@ -1,2 +1,3 @@
 Fix pygettext not extracting docstrings for functions with type annotated
 arguments.
+Patch by Tobotimus

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -355,10 +355,9 @@ class TokenEater:
         # ignore anything until we see the param list closing parenthesis
         if ttype == tokenize.OP:
             if tstring == ')':
-                if self.__parencount == 1:
+                self.__parencount -= 1
+                if self.__parencount == 0:
                     self.__state = self.__suiteseen
-                else:
-                    self.__parencount -= 1
             elif tstring == '(':
                 # count nested parens
                 self.__parencount += 1

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -5,7 +5,7 @@
 # Minimally patched to make it even more xgettext compatible
 # by Peter Funk <pf@artcom-gmbh.de>
 #
-# 2002-11-22 JÃ¼rgen Hermann <jh@web.de>
+# 2002-11-22 Jürgen Hermann <jh@web.de>
 # Added checks that _() only contains string literals, and
 # command line args are resolved to module lists, i.e. you
 # can now pass a filename, a module or package name, or a
@@ -208,7 +208,7 @@ def make_escapes(pass_nonascii):
     global escapes, escape
     if pass_nonascii:
         # Allow non-ascii characters to pass through so that e.g. 'msgid
-        # "HÃ¶he"' would result not result in 'msgid "H\366he"'.  Otherwise we
+        # "Höhe"' would result not result in 'msgid "H\366he"'.  Otherwise we
         # escape any character outside the 32..126 range.
         mod = 128
         escape = escape_ascii

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -129,7 +129,7 @@ Options:
         The style name is case insensitive.  GNU style is the default.
 
     -v
-    --verbose 
+    --verbose
         Print the names of the files being processed.
 
     -V

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -5,7 +5,7 @@
 # Minimally patched to make it even more xgettext compatible
 # by Peter Funk <pf@artcom-gmbh.de>
 #
-# 2002-11-22 J�rgen Hermann <jh@web.de>
+# 2002-11-22 Jürgen Hermann <jh@web.de>
 # Added checks that _() only contains string literals, and
 # command line args are resolved to module lists, i.e. you
 # can now pass a filename, a module or package name, or a
@@ -208,7 +208,7 @@ def make_escapes(pass_nonascii):
     global escapes, escape
     if pass_nonascii:
         # Allow non-ascii characters to pass through so that e.g. 'msgid
-        # "H�he"' would result not result in 'msgid "H\366he"'.  Otherwise we
+        # "Höhe"' would result not result in 'msgid "H\366he"'.  Otherwise we
         # escape any character outside the 32..126 range.
         mod = 128
         escape = escape_ascii

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -343,16 +343,13 @@ class TokenEater:
                     self.__freshmodule = 0
                 return
             # class or func/method docstring?
-            if ttype == tokenize.NAME:
-                if tstring == 'def':
-                    self.__state = self.__funcseen
-                elif tstring == 'class':
-                    self.__state = self.__class_seen
+            if ttype == tokenize.NAME and tstring in ('def', 'class'):
+                self.__state = self.__suiteseen
                 return
         if ttype == tokenize.NAME and tstring in opts.keywords:
             self.__state = self.__keywordseen
 
-    def __funcseen(self, ttype, tstring, lineno):
+    def __suiteseen(self, ttype, tstring, lineno):
         # skip over any enclosure pairs until we see the colon
         if ttype == tokenize.OP:
             if tstring == ':' and not any(self.__enclosurecount.values()):
@@ -364,11 +361,6 @@ class TokenEater:
             elif tstring in ')]}':
                 enclosure = self.__get_enclosure_name(tstring)
                 self.__enclosurecount[enclosure] -= 1
-
-    def __class_seen(self, ttype, tstring, lineno):
-        # ignore anything until we see the colon
-        if ttype == tokenize.OP and tstring == ':':
-            self.__state = self.__suitedocstring
 
     def __suitedocstring(self, ttype, tstring, lineno):
         # ignore any intervening noise

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -5,7 +5,7 @@
 # Minimally patched to make it even more xgettext compatible
 # by Peter Funk <pf@artcom-gmbh.de>
 #
-# 2002-11-22 Jürgen Hermann <jh@web.de>
+# 2002-11-22 Jï¿½rgen Hermann <jh@web.de>
 # Added checks that _() only contains string literals, and
 # command line args are resolved to module lists, i.e. you
 # can now pass a filename, a module or package name, or a
@@ -208,7 +208,7 @@ def make_escapes(pass_nonascii):
     global escapes, escape
     if pass_nonascii:
         # Allow non-ascii characters to pass through so that e.g. 'msgid
-        # "Höhe"' would result not result in 'msgid "H\366he"'.  Otherwise we
+        # "Hï¿½he"' would result not result in 'msgid "H\366he"'.  Otherwise we
         # escape any character outside the 32..126 range.
         mod = 128
         escape = escape_ascii
@@ -340,12 +340,20 @@ class TokenEater:
                 elif ttype not in (tokenize.COMMENT, tokenize.NL):
                     self.__freshmodule = 0
                 return
-            # class docstring?
-            if ttype == tokenize.NAME and tstring in ('class', 'def'):
-                self.__state = self.__suiteseen
+            # class or func/method docstring?
+            if ttype == tokenize.NAME:
+                if tstring == 'def':
+                    self.__state = self.__funcseen
+                elif tstring == 'class':
+                    self.__state = self.__suiteseen
                 return
         if ttype == tokenize.NAME and tstring in opts.keywords:
             self.__state = self.__keywordseen
+
+    def __funcseen(self, ttype, tstring, lineno):
+        # ignore anything until we see the closing parenthesis
+        if ttype == tokenize.OP and tstring == ')':
+            self.__state = self.__suiteseen
 
     def __suiteseen(self, ttype, tstring, lineno):
         # ignore anything until we see the colon

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -320,6 +320,7 @@ class TokenEater:
         self.__lineno = -1
         self.__freshmodule = 1
         self.__curfile = None
+        self.__parencount = 0
 
     def __call__(self, ttype, tstring, stup, etup, line):
         # dispatch
@@ -351,9 +352,16 @@ class TokenEater:
             self.__state = self.__keywordseen
 
     def __funcseen(self, ttype, tstring, lineno):
-        # ignore anything until we see the closing parenthesis
-        if ttype == tokenize.OP and tstring == ')':
-            self.__state = self.__suiteseen
+        # ignore anything until we see the param list closing parenthesis
+        if ttype == tokenize.OP:
+            if tstring == ')':
+                if self.__parencount == 1:
+                    self.__state = self.__suiteseen
+                else:
+                    self.__parencount -= 1
+            elif tstring == '(':
+                # count nested parens
+                self.__parencount += 1
 
     def __suiteseen(self, ttype, tstring, lineno):
         # ignore anything until we see the colon


### PR DESCRIPTION
This changes the behaviour of the pygettext TokenEater when it sees a function definition; instead of searching for the colon at the end of the definition, it skips over everything until it sees the closing parenthesis at the end of the parameter list, *then* looks for the final colon.

<!-- issue-number: bpo-32222 -->
https://bugs.python.org/issue32222
<!-- /issue-number -->
