### PR TITLE
bpo-32237: Fix missing DECREF of mod

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -1729,6 +1729,7 @@ PyImport_ImportModuleLevelObject(PyObject *name, PyObject *globals,
         }
     }
     else {
+        Py_XDECREF(mod);
         mod = import_find_and_load(abs_name);
         if (mod == NULL) {
             goto error;


### PR DESCRIPTION
The code reorg in commit eea3cc1ef0dec0af193eedb4c1164263fbdfd8cc introduced a leak by accidentally dropping an Py_XDECREF(mod) call.  The fix is trivial.

<!-- issue-number: bpo-32237 -->
https://bugs.python.org/issue32237
<!-- /issue-number -->
