### PR TITLE
bpo-32247: Create dst dir if doesn't exist

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -312,7 +312,8 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
     else:
         ignored_names = set()
 
-    os.makedirs(dst)
+    if not os.path.isdir(dst):
+        os.makedirs(dst)
     errors = []
     for name in names:
         if name in ignored_names:


### PR DESCRIPTION
Don't call `os.makedirs(dst)` if destination directory already exists  as
this will throw error "OSError: [Errno 17] File exists".


<!-- issue-number: bpo-32247 -->
https://bugs.python.org/issue32247
<!-- /issue-number -->
