### PR TITLE
bpo-32206: Pdb can now run modules

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -62,8 +62,9 @@ useful than quitting the debugger upon program's exit.
    in a :file:`.pdbrc` file, see :ref:`debugger-commands`.
 
 .. versionadded:: 3.7
-   :file:`pdb.py` now accepts a ``-m`` option that execute modules similar to how
-   ``python3 -m`` does. The debugger will stop in the first line like with a script.
+   :file:`pdb.py` now accepts a ``-m`` option that execute modules similar to the way
+   ``python3 -m`` does. As with a script, the debugger will pause execution just
+   before the first line of the module.
 
 
 The typical usage to break into the debugger from a running program is to

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -61,6 +61,11 @@ useful than quitting the debugger upon program's exit.
    :file:`pdb.py` now accepts a ``-c`` option that executes commands as if given
    in a :file:`.pdbrc` file, see :ref:`debugger-commands`.
 
+.. versionadded:: 3.7
+   :file:`pdb.py` now accepts a ``-m`` option that execute modules similar to how
+   ``python3 -m`` does. The debugger will stop in the first line like with a script.
+
+
 The typical usage to break into the debugger from a running program is to
 insert ::
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -357,6 +357,10 @@ pdb
 argument.  If given, this is printed to the console just before debugging
 begins.  (Contributed by Barry Warsaw in :issue:`31389`.)
 
+pdb command line now accepts `-m module_name` as an alternative to
+script file. (Contributed by Mario Corchero in :issue:`32206`.)
+
+
 re
 --
 

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1532,7 +1532,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         __main__.__dict__.update({
             "__name__": "__main__",
             "__file__": self.mainpyfile,
-#            "__package__": module_name,  # Not needed, will rely on __spec__.parent
+            "__package__": module_name,
             "__loader__": mod_spec.loader,
             "__spec__": mod_spec,
             "__builtins__": __builtins__,

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1523,15 +1523,18 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     def _runmodule(self, module_name):
         self._wait_for_mainpyfile = True
-        self.mainpyfile = self.canonic(module_name)
+        self.mainpyfile = os.path.join(self.canonic(module_name), "__main__.py")
         self._user_requested_quit = False
         import runpy
-        mod_name, _, code = runpy._get_module_details(module_name)
+        mod_name, mod_spec, code = runpy._get_module_details(module_name)
         import __main__
         __main__.__dict__.clear()
         __main__.__dict__.update({
             "__name__": "__main__",
-            "__package__": module_name,
+            "__file__": self.mainpyfile,
+#            "__package__": module_name,  # Not needed, will rely on __spec__.parent
+            "__loader__": mod_spec.loader,
+            "__spec__": mod_spec,
             "__builtins__": __builtins__,
         })
         self.run(code)

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1523,10 +1523,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     def _runmodule(self, module_name):
         self._wait_for_mainpyfile = True
-        self.mainpyfile = os.path.join(self.canonic(module_name), "__main__.py")
         self._user_requested_quit = False
         import runpy
         mod_name, mod_spec, code = runpy._get_module_details(module_name)
+        self.mainpyfile = self.canonic(code.co_filename)
         import __main__
         __main__.__dict__.clear()
         __main__.__dict__.update({

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1525,10 +1525,16 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self._wait_for_mainpyfile = True
         self.mainpyfile = self.canonic(module_name)
         self._user_requested_quit = False
-        #code = f'import runpy; runpy.run_module("{module_name}", run_name="__main__")'
-        code = f'import runpy; runpy._run_module_as_main("{module_name}")'
-        statement = f'exec(compile("""{code}""", "{self.mainpyfile}", "exec"))'
-        self.run(statement)
+        import runpy
+        mod_name, _, code = runpy._get_module_details(module_name)
+        import __main__
+        __main__.__dict__.clear()
+        __main__.__dict__.update({
+            "__name__": "__main__",
+            "__package__": module_name,
+            "__builtins__": __builtins__,
+        })
+        self.run(code)
 
     def _runscript(self, filename):
         # The script has to run in __main__ namespace (or imports from

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1212,7 +1212,7 @@ class PdbModuleTestCase(PdbBaseTestCase):
             quit
         """
         stdout, stderr = self.run_pdb(script, commands)
-        self.assertTrue(any(f"/{self.module_name}/__main__.py(4)<module>()"
+        self.assertTrue(any(f"__main__.py(4)<module>()"
                             in l for l in stdout.splitlines()), stdout)
 
     def test_relative_imports(self):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1190,19 +1190,6 @@ class PdbModuleTestCase(PdbBaseTestCase):
         stdout, stderr = self._run_pdb(["-m", "pdb"], commands)
         self.assertIn("Debug the Python program given by pyfile.", stdout.splitlines())
 
-    def test_blocks_at_first_code_line(self):
-        script = """
-                #This is a comment, on line 2
-
-                print("SUCCESS")
-        """
-        commands = f"""
-            quit
-        """
-        stdout, stderr = self.run_pdb(script, commands)
-        self.assertTrue(any(f"/{self.module_name}/__main__.py(4)<module>()"
-                            in l for l in stdout.splitlines()), stdout)
-
     def test_module_without_a_main(self):
         module_name = 't_main'
         support.rmtree(module_name)

--- a/Misc/NEWS.d/next/Library/2017-12-07-13-14-40.bpo-32206.obm4OM.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-07-13-14-40.bpo-32206.obm4OM.rst
@@ -1,0 +1,1 @@
+Add support to run modules with pdb


### PR DESCRIPTION
This change allows pdb to run modules and not only script.

This is quite useful when working on "runnable" modules as there is no other way to run them at the moment.

Example running unittest as a module
```
$ ./python -m pdb -m unittest
> /mnt/d/linux/cpython/Lib/unittest/__main__.py(3)<module>()
-> import sys
(Pdb) c
----------------------------------------------------------------------
Ran 0 tests in 0.000s
OK
The program exited via sys.exit(). Exit status: False
> /mnt/d/linux/cpython/Lib/unittest/__main__.py(3)<module>()
-> import sys
(Pdb)  
```

There is an alternative implementation using runpy._run_module_as_main by applying:
https://github.com/mariocj89/cpython/commit/e00c7b2002a6e52219a9f830c2c797a4686afa79 (It still has some issues to fix)

<!-- issue-number: bpo-32206 -->
https://bugs.python.org/issue32206
<!-- /issue-number -->
