### PR TITLE
bpo-8722: Document __getattr__ behavior with AttributeError in property

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1455,10 +1455,13 @@ access (use of, assignment to, or deletion of ``x.name``) for class instances.
 
 .. method:: object.__getattr__(self, name)
 
-   Called when an attribute lookup has not found the attribute in the usual places
-   (i.e. it is not an instance attribute nor is it found in the class tree for
-   ``self``).  ``name`` is the attribute name. This method should return the
-   (computed) attribute value or raise an :exc:`AttributeError` exception.
+   Called when an attribute lookup has not found the attribute in the usual
+   places, namely when it is a :func:`property` attribute whose :meth:`__get__`
+   method raises an :exc:`AttributeError`, when :meth:`__getattribute__` raises
+   an :exc:`AttributeError` because *name* is not an instance attribute, or
+   when it is not found in the class tree for ``self``.  This method should
+   return the (computed) attribute value or raise an :exc:`AttributeError`
+   exception.
 
    Note that if the attribute is found through the normal mechanism,
    :meth:`__getattr__` is not called.  (This is an intentional asymmetry between

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1455,13 +1455,12 @@ access (use of, assignment to, or deletion of ``x.name``) for class instances.
 
 .. method:: object.__getattr__(self, name)
 
-   Called when an attribute lookup has not found the attribute in the usual
-   places, namely when it is a :func:`property` attribute whose :meth:`__get__`
-   method raises an :exc:`AttributeError`, when :meth:`__getattribute__` raises
-   an :exc:`AttributeError` because *name* is not an instance attribute, or
-   when it is not found in the class tree for ``self``.  This method should
-   return the (computed) attribute value or raise an :exc:`AttributeError`
-   exception.
+   Called when the default attribute access fails with an :exc:`AttributeError`
+   (either :meth:`__getattribute__` raises an :exc:`AttributeError` because
+   *name* is not an instance attribute or an attribute in the class tree
+   for ``self``; or :meth:`__get__` of a *name* property raises
+   :exc:`AttributeError`).  This method should either return the (computed)
+   attribute value or raise an :exc:`AttributeError` exception.
 
    Note that if the attribute is found through the normal mechanism,
    :meth:`__getattr__` is not called.  (This is an intentional asymmetry between

--- a/Misc/NEWS.d/next/Documentation/2018-02-03-06-11-37.bpo-8722.MPyVyj.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-02-03-06-11-37.bpo-8722.MPyVyj.rst
@@ -1,0 +1,2 @@
+Document :meth:`__getattr__` behavior with :exc:`AttributeError` in property
+:meth:`get`.

--- a/Misc/NEWS.d/next/Documentation/2018-02-03-06-11-37.bpo-8722.MPyVyj.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-02-03-06-11-37.bpo-8722.MPyVyj.rst
@@ -1,2 +1,2 @@
-Document :meth:`__getattr__` behavior with :exc:`AttributeError` in property
-:meth:`get`.
+Document :meth:`__getattr__` behavior when property :meth:`get` method
+raises :exc:`AttributeError`.


### PR DESCRIPTION
When a property get method raises an `AttributeError`, `__getattr__` is called if it exists. This is the same as when `__getattribute__` fails to find an attribute.


<!-- issue-number: bpo-8722 -->
https://bugs.python.org/issue8722
<!-- /issue-number -->
