### PR TITLE
bpo-22589: Changed MIME type of .bmp to "image/bmp"

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -410,7 +410,7 @@ def _default_mime_types():
         '.bat'    : 'text/plain',
         '.bcpio'  : 'application/x-bcpio',
         '.bin'    : 'application/octet-stream',
-        '.bmp'    : 'image/x-ms-bmp',
+        '.bmp'    : 'image/bmp',
         '.c'      : 'text/plain',
         '.cdf'    : 'application/x-netcdf',
         '.cpio'   : 'application/x-cpio',

--- a/Misc/NEWS.d/next/Library/2017-12-08-15-09-41.bpo-22589.8ouqI6.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-08-15-09-41.bpo-22589.8ouqI6.rst
@@ -1,0 +1,1 @@
+Changed MIME type of .bmp from 'image/x-ms-bmp' to 'image/bmp'


### PR DESCRIPTION
I added a NEWS entry. Is it required for this small change?

<!-- issue-number: bpo-22589 -->
https://bugs.python.org/issue22589
<!-- /issue-number -->
