### PR TITLE
bpo-32035: Update zipfile doc

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -385,7 +385,7 @@ ZipFile Objects
 
 .. method:: ZipFile.writestr(zinfo_or_arcname, data[, compress_type])
 
-   Write the string *data* to the archive; *zinfo_or_arcname* is either the file
+   Write the string or bytes *data* to the archive; *zinfo_or_arcname* is either the file
    name it will be given in the archive, or a :class:`ZipInfo` instance.  If it's
    an instance, at least the filename, date, and time must be given.  If it's a
    name, the date and time is set to the current date and time.


### PR DESCRIPTION
Updated the cpython/Doc/library/zipfile.rst documentation.

<!-- issue-number: bpo-32035 -->
https://bugs.python.org/issue32035
<!-- /issue-number -->
