### PR TITLE
[3.4] bpo-30657: Check & prevent integer overflow in PyString_DecodeEscape (GH-2174)

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -155,6 +155,7 @@ Gregory Bond
 Matias Bordese
 Jonas Borgström
 Jurjen Bos
+Jay Bosamiya
 Peter Bosch
 Dan Boswell
 Eric Bouck
@@ -616,6 +617,7 @@ Alan Hourihane
 Ken Howard
 Brad Howes
 Mike Hoy
+Miro Hrončok
 Chiu-Hsiang Hsu
 Chih-Hao Huang
 Christian Hudon

--- a/Misc/NEWS.d/next/Security/2017-12-01-18-51-03.bpo-30657.Fd8kId.rst
+++ b/Misc/NEWS.d/next/Security/2017-12-01-18-51-03.bpo-30657.Fd8kId.rst
@@ -1,0 +1,2 @@
+Fixed possible integer overflow in PyBytes_DecodeEscape, CVE-2017-1000158.
+Original patch by Jay Bosamiya; rebased to Python 3 by Miro Hrončok.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -368,7 +368,13 @@ PyObject *PyBytes_DecodeEscape(const char *s,
     char *p, *buf;
     const char *end;
     PyObject *v;
-    Py_ssize_t newlen = recode_encoding ? 4*len:len;
+    Py_ssize_t newlen;
+    /* Check for integer overflow */
+    if (recode_encoding && (len > PY_SSIZE_T_MAX / 4)) {
+        PyErr_SetString(PyExc_OverflowError, "string is too large");
+        return NULL;
+    }
+    newlen = recode_encoding ? 4*len:len;
     v = PyBytes_FromStringAndSize((char *)NULL, newlen);
     if (v == NULL)
         return NULL;


### PR DESCRIPTION
Fixes possible integer overflow in PyBytes_DecodeEscape, CVE-2017-1000158.
Original patch by Jay Bosamiya @jaybosamiya in https://github.com/python/cpython/pull/2174

<!-- issue-number: bpo-30657 -->
https://bugs.python.org/issue30657
<!-- /issue-number -->
