### PR TITLE
bpo-32257: [SSL] Support Disabling Renegotiation

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -412,6 +412,9 @@ class SSLContext(_SSLContext):
                 self._load_windows_store_certs(storename, purpose)
         self.set_default_verify_paths()
 
+    def disable_renegotiation(self):
+        self.options |= getattr(_ssl, "FLAGS_NO_RENEGOTIATE_CIPHERS", 0)
+
 
 def create_default_context(purpose=Purpose.SERVER_AUTH, cafile=None,
                            capath=None, cadata=None):

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -412,9 +412,6 @@ class SSLContext(_SSLContext):
                 self._load_windows_store_certs(storename, purpose)
         self.set_default_verify_paths()
 
-    def disable_renegotiation(self):
-        self.options |= getattr(_ssl, "FLAGS_NO_RENEGOTIATE_CIPHERS", 0)
-
 
 def create_default_context(purpose=Purpose.SERVER_AUTH, cafile=None,
                            capath=None, cadata=None):

--- a/Misc/NEWS.d/next/Library/2017-12-08-23-21-55.bpo-32257.af542C.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-08-23-21-55.bpo-32257.af542C.rst
@@ -1,0 +1,2 @@
+ Adding a new method in SSLContext so that we can disable renegotiation
+ easier. This resolves CVE-2009-3555 and attack demonstrated by thc-ssl-dos.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4297,6 +4297,12 @@ init_ssl(void)
     PyModule_AddIntConstant(m, "OP_NO_COMPRESSION",
                             SSL_OP_NO_COMPRESSION);
 #endif
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifdef SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS
+    PyModule_AddIntConstant(m, "FLAGS_NO_RENEGOTIATE_CIPHERS",
+                            SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS);
+#endif
+#endif
 
 #if HAVE_SNI
     r = Py_True;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -604,6 +604,17 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
             return NULL;
         }
     }
+
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
+#ifdef SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS
+
+    if (self->s3 && SSL_is_server(self->ssl)) {
+        self->ssl->s3->flags |= SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS;
+    }
+
+#endif
+#endif
+
     return self;
 }
 
@@ -4296,12 +4307,6 @@ init_ssl(void)
 #ifdef SSL_OP_NO_COMPRESSION
     PyModule_AddIntConstant(m, "OP_NO_COMPRESSION",
                             SSL_OP_NO_COMPRESSION);
-#endif
-#if OPENSSL_VERSION_NUMBER < 0x10100000L
-#ifdef SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS
-    PyModule_AddIntConstant(m, "FLAGS_NO_RENEGOTIATE_CIPHERS",
-                            SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS);
-#endif
 #endif
 
 #if HAVE_SNI

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -608,7 +608,7 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
 #if OPENSSL_VERSION_NUMBER < 0x10100000L
 #ifdef SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS
 
-    if (self->s3 && SSL_is_server(self->ssl)) {
+    if (self->ssl->s3 && SSL_is_server(self->ssl)) {
         self->ssl->s3->flags |= SSL3_FLAGS_NO_RENEGOTIATE_CIPHERS;
     }
 


### PR DESCRIPTION
Adding a new method in SSLContext so that we can disable
renegotiation easier. This resolves CVE-2009-3555 and
attack demonstrated by thc-ssl-dos.

<!-- issue-number: bpo-32257 -->
https://bugs.python.org/issue32257
<!-- /issue-number -->
