### PR TITLE
bpo-32253: Deprecate with statement and bare await for asyncio locks

### DIFF
--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -297,13 +297,6 @@ is equivalent to::
    finally:
        lock.release()
 
-Currently, :class:`Lock`, :class:`Condition`,
-:class:`Semaphore`, and :class:`BoundedSemaphore` objects may be used as
-:keyword:`async with` statement context managers.
-
-``async with lock`` is the preferable way for locking asyncio
-synchronization primitives.
-
 .. deprecated:: 3.7
 
    Lock acquiring using ``await lock`` or ``yield from lock`` and

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -139,7 +139,8 @@ Condition
    object, and it is used as the underlying lock.  Otherwise,
    a new :class:`Lock` object is created and used as the underlying lock.
 
-   Locks also support the :ref:`context management protocol <async-with-locks>`.
+   Conditions also support the :ref:`context management protocol
+   <async-with-locks>`.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
 
@@ -232,7 +233,8 @@ Semaphore
    defaults to ``1``. If the value given is less than ``0``, :exc:`ValueError`
    is raised.
 
-   Locks also support the :ref:`context management protocol <async-with-locks>`.
+   Semaphores also support the :ref:`context management protocol
+   <async-with-locks>`.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
 
@@ -268,7 +270,8 @@ BoundedSemaphore
    This raises :exc:`ValueError` in :meth:`~Semaphore.release` if it would
    increase the value above the initial value.
 
-   Locks also support the :ref:`context management protocol <async-with-locks>`.
+   Bounded semapthores also support the :ref:`context management
+   protocol <async-with-locks>`.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
 

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -23,11 +23,9 @@ module (:class:`~threading.Lock`, :class:`~threading.Event`,
 :class:`~threading.BoundedSemaphore`), but it has no *timeout* parameter. The
 :func:`asyncio.wait_for` function can be used to cancel a task after a timeout.
 
-Locks
------
 
 Lock
-^^^^
+----
 
 .. class:: Lock(\*, loop=None)
 
@@ -85,7 +83,7 @@ Lock
 
 
 Event
-^^^^^
+-----
 
 .. class:: Event(\*, loop=None)
 
@@ -126,7 +124,7 @@ Event
 
 
 Condition
-^^^^^^^^^
+---------
 
 .. class:: Condition(lock=None, \*, loop=None)
 
@@ -216,11 +214,8 @@ Condition
       This method is a :ref:`coroutine <coroutine>`.
 
 
-Semaphores
-----------
-
 Semaphore
-^^^^^^^^^
+---------
 
 .. class:: Semaphore(value=1, \*, loop=None)
 
@@ -264,7 +259,7 @@ Semaphore
 
 
 BoundedSemaphore
-^^^^^^^^^^^^^^^^
+----------------
 
 .. class:: BoundedSemaphore(value=1, \*, loop=None)
 
@@ -281,7 +276,7 @@ BoundedSemaphore
 .. _async-with-locks:
 
 Using locks, conditions, and semaphores in the :keyword:`async with` statement
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+------------------------------------------------------------------------------
 
 All of the objects provided by this module that have :meth:`acquire`
 and :meth:`release` methods can be used as context managers for a

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -278,11 +278,13 @@ BoundedSemaphore
 Using locks, conditions, and semaphores in the :keyword:`async with` statement
 ------------------------------------------------------------------------------
 
-All of the objects provided by this module that have :meth:`acquire`
-and :meth:`release` methods can be used as context managers for a
-:keyword:`async with` statement.  The :meth:`acquire` method will be
-called when the block is entered, and :meth:`release` will be called
-when the block is exited.  Hence, the following snippet::
+:class:`Lock`, :class:`Condition`, :class:`Semaphore`, and
+:class:`BoundedSemaphore` objects can be used in :keyword:`async with`
+statements.
+
+The :meth:`acquire` method will be called when the block is entered,
+and :meth:`release` will be called when the block is exited.  Hence,
+the following snippet::
 
    async with lock:
        # do something...
@@ -302,11 +304,8 @@ Currently, :class:`Lock`, :class:`Condition`,
 ``async with lock`` is the preferable way for locking asyncio
 synchronization primitives.
 
-Explicit :meth:`acquire` / :meth:`release` calls should be used if
-locking/unlocking is split into different functions.
-
 .. deprecated:: 3.7
 
-   Lock acquiring on ``await lock`` or ``yield from lock`` and
+   Lock acquiring using ``await lock`` or ``yield from lock`` and
    :keyword:`with` statement (``with await lock``, ``with (yield from
    lock)``) are deprecated.

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -52,7 +52,7 @@ Lock
 
    :meth:`acquire` is a coroutine and should be called with ``await``.
 
-   Locks also support the :ref:`context management protocol <async-with-locks>`.
+   Locks support the :ref:`context management protocol <async-with-locks>`.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
 
@@ -139,7 +139,7 @@ Condition
    object, and it is used as the underlying lock.  Otherwise,
    a new :class:`Lock` object is created and used as the underlying lock.
 
-   Conditions also support the :ref:`context management protocol
+   Conditions support the :ref:`context management protocol
    <async-with-locks>`.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
@@ -227,13 +227,11 @@ Semaphore
    counter can never go below zero; when :meth:`acquire` finds that it is zero,
    it blocks, waiting until some other coroutine calls :meth:`release`.
 
-   Semaphores also support the context management protocol.
-
    The optional argument gives the initial value for the internal counter; it
    defaults to ``1``. If the value given is less than ``0``, :exc:`ValueError`
    is raised.
 
-   Semaphores also support the :ref:`context management protocol
+   Semaphores support the :ref:`context management protocol
    <async-with-locks>`.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
@@ -270,7 +268,7 @@ BoundedSemaphore
    This raises :exc:`ValueError` in :meth:`~Semaphore.release` if it would
    increase the value above the initial value.
 
-   Bounded semapthores also support the :ref:`context management
+   Bounded semapthores support the :ref:`context management
    protocol <async-with-locks>`.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
@@ -278,8 +276,8 @@ BoundedSemaphore
 
 .. _async-with-locks:
 
-Using locks, conditions, and semaphores in the :keyword:`async with` statement
-------------------------------------------------------------------------------
+Using locks, conditions and semaphores in the :keyword:`async with` statement
+-----------------------------------------------------------------------------
 
 :class:`Lock`, :class:`Condition`, :class:`Semaphore`, and
 :class:`BoundedSemaphore` objects can be used in :keyword:`async with`

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -3,6 +3,7 @@
 __all__ = ['Lock', 'Event', 'Condition', 'Semaphore', 'BoundedSemaphore']
 
 import collections
+import warnings
 
 from . import events
 from . import futures
@@ -63,6 +64,9 @@ class _ContextManagerMixin:
         #         <block>
         #     finally:
         #         lock.release()
+        warnings.warn("'with (yield from lock):' is deprecated "
+                      "use 'async with lock:' instead",
+                      DeprecationWarning, stacklevel=2)
         yield from self.acquire()
         return _ContextManager(self)
 

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -64,8 +64,8 @@ class _ContextManagerMixin:
         #         <block>
         #     finally:
         #         lock.release()
-        warnings.warn("'with (yield from lock):' is deprecated "
-                      "use 'async with lock:' instead",
+        warnings.warn("'with (yield from lock)' is deprecated "
+                      "use 'async with lock' instead",
                       DeprecationWarning, stacklevel=2)
         yield from self.acquire()
         return _ContextManager(self)
@@ -75,6 +75,9 @@ class _ContextManagerMixin:
         return _ContextManager(self)
 
     def __await__(self):
+        warnings.warn("'with await lock' is deprecated "
+                      "use 'async with lock' instead",
+                      DeprecationWarning, stacklevel=2)
         # To make "with await lock" work.
         return self.__acquire_ctx().__await__()
 

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -42,7 +42,8 @@ class LockTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def acquire_lock():
-            yield from lock
+            with self.assertWarns(DeprecationWarning):
+                yield from lock
 
         self.loop.run_until_complete(acquire_lock())
         self.assertTrue(repr(lock).endswith('[locked]>'))
@@ -53,7 +54,8 @@ class LockTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def acquire_lock():
-            return (yield from lock)
+            with self.assertWarns(DeprecationWarning):
+                return (yield from lock)
 
         res = self.loop.run_until_complete(acquire_lock())
 
@@ -77,12 +79,13 @@ class LockTests(test_utils.TestCase):
         def test(lock):
             yield from asyncio.sleep(0.01, loop=loop)
             self.assertFalse(lock.locked())
-            with (yield from lock) as _lock:
-                self.assertIs(_lock, None)
-                self.assertTrue(lock.locked())
-                yield from asyncio.sleep(0.01, loop=loop)
-                self.assertTrue(lock.locked())
-            self.assertFalse(lock.locked())
+            with self.assertWarns(DeprecationWarning):
+                with (yield from lock) as _lock:
+                    self.assertIs(_lock, None)
+                    self.assertTrue(lock.locked())
+                    yield from asyncio.sleep(0.01, loop=loop)
+                    self.assertTrue(lock.locked())
+                self.assertFalse(lock.locked())
 
         for primitive in primitives:
             loop.run_until_complete(test(primitive))
@@ -237,7 +240,8 @@ class LockTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def acquire_lock():
-            return (yield from lock)
+            with self.assertWarns(DeprecationWarning):
+                return (yield from lock)
 
         with self.loop.run_until_complete(acquire_lock()):
             self.assertTrue(lock.locked())
@@ -249,7 +253,8 @@ class LockTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def acquire_lock():
-            return (yield from lock)
+            with self.assertWarns(DeprecationWarning):
+                return (yield from lock)
 
         # This spells "yield from lock" outside a generator.
         cm = self.loop.run_until_complete(acquire_lock())
@@ -693,7 +698,8 @@ class ConditionTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def acquire_cond():
-            return (yield from cond)
+            with self.assertWarns(DeprecationWarning):
+                return (yield from cond)
 
         with self.loop.run_until_complete(acquire_cond()):
             self.assertTrue(cond.locked())
@@ -776,7 +782,8 @@ class SemaphoreTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def acquire_lock():
-            return (yield from sem)
+            with self.assertWarns(DeprecationWarning):
+                return (yield from sem)
 
         res = self.loop.run_until_complete(acquire_lock())
 
@@ -918,7 +925,8 @@ class SemaphoreTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def acquire_lock():
-            return (yield from sem)
+            with self.assertWarns(DeprecationWarning):
+                return (yield from sem)
 
         with self.loop.run_until_complete(acquire_lock()):
             self.assertFalse(sem.locked())

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -59,12 +59,13 @@ class LockTests(BaseTest):
         async def test(lock):
             await asyncio.sleep(0.01, loop=self.loop)
             self.assertFalse(lock.locked())
-            with await lock as _lock:
-                self.assertIs(_lock, None)
-                self.assertTrue(lock.locked())
-                await asyncio.sleep(0.01, loop=self.loop)
-                self.assertTrue(lock.locked())
-            self.assertFalse(lock.locked())
+            with self.assertWarns(DeprecationWarning):
+                with await lock as _lock:
+                    self.assertIs(_lock, None)
+                    self.assertTrue(lock.locked())
+                    await asyncio.sleep(0.01, loop=self.loop)
+                    self.assertTrue(lock.locked())
+                self.assertFalse(lock.locked())
 
         for primitive in primitives:
             self.loop.run_until_complete(test(primitive))

--- a/Misc/NEWS.d/next/Library/2017-12-09-11-30-35.bpo-32253.TQHSYF.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-09-11-30-35.bpo-32253.TQHSYF.rst
@@ -1,0 +1,2 @@
+Deprecate ``yield from lock``, ``await lock``, ``with (yield from lock)``
+and ``with await lock`` for asyncio synchronization primitives.


### PR DESCRIPTION


<!-- issue-number: bpo-32253 -->
https://bugs.python.org/issue32253
<!-- /issue-number -->
