### PR TITLE
bpo-32255: Fix inconsistent behavior when csv.writer writes None

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -211,6 +211,25 @@ class Test_Csv(unittest.TestCase):
             fileobj.seek(0)
             self.assertEqual(fileobj.read(), "a,b\r\nc,d\r\n")
 
+    def test_writerows_with_none(self):
+        with TemporaryFile("w+", newline='') as fileobj:
+            writer = csv.writer(fileobj)
+            writer.writerows([['a',None],[None,'d']])
+            fileobj.seek(0)
+            self.assertEqual(fileobj.read(), "a,\r\n,d\r\n")
+
+        with TemporaryFile("w+", newline='') as fileobj:
+            writer = csv.writer(fileobj)
+            writer.writerows([[None],['a']])
+            fileobj.seek(0)
+            self.assertEqual(fileobj.read(), '""\r\na\r\n')
+
+        with TemporaryFile("w+", newline='') as fileobj:
+            writer = csv.writer(fileobj)
+            writer.writerows([['a'],[None]])
+            fileobj.seek(0)
+            self.assertEqual(fileobj.read(), 'a\r\n""\r\n')
+
     @support.cpython_only
     def test_writerows_legacy_strings(self):
         import _testcapi

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -207,26 +207,26 @@ class Test_Csv(unittest.TestCase):
         with TemporaryFile("w+", newline='') as fileobj:
             writer = csv.writer(fileobj)
             self.assertRaises(TypeError, writer.writerows, None)
-            writer.writerows([['a','b'],['c','d']])
+            writer.writerows([['a', 'b'], ['c', 'd']])
             fileobj.seek(0)
             self.assertEqual(fileobj.read(), "a,b\r\nc,d\r\n")
 
     def test_writerows_with_none(self):
         with TemporaryFile("w+", newline='') as fileobj:
             writer = csv.writer(fileobj)
-            writer.writerows([['a',None],[None,'d']])
+            writer.writerows([['a', None], [None, 'd']])
             fileobj.seek(0)
             self.assertEqual(fileobj.read(), "a,\r\n,d\r\n")
 
         with TemporaryFile("w+", newline='') as fileobj:
             writer = csv.writer(fileobj)
-            writer.writerows([[None],['a']])
+            writer.writerows([[None], ['a']])
             fileobj.seek(0)
             self.assertEqual(fileobj.read(), '""\r\na\r\n')
 
         with TemporaryFile("w+", newline='') as fileobj:
             writer = csv.writer(fileobj)
-            writer.writerows([['a'],[None]])
+            writer.writerows([['a'], [None]])
             fileobj.seek(0)
             self.assertEqual(fileobj.read(), 'a\r\n""\r\n')
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1554,6 +1554,7 @@ Joel Taddei
 Arfrever Frehtes Taifersar Arahesis
 Hideaki Takahashi
 Takase Arihiro
+Licht Takeuchi
 Indra Talip
 Neil Tallim
 Geoff Talvola

--- a/Misc/NEWS.d/next/Library/2017-12-12-07-29-06.bpo-32255.2bfNmM.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-12-07-29-06.bpo-32255.2bfNmM.rst
@@ -1,0 +1,2 @@
+Fix inconsistent ``csv.writer`` behavior when it handles ``None``.
+Patch by Licht Takeuchi.

--- a/Misc/NEWS.d/next/Library/2017-12-12-07-29-06.bpo-32255.2bfNmM.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-12-07-29-06.bpo-32255.2bfNmM.rst
@@ -1,2 +1,3 @@
-Fix inconsistent ``csv.writer`` behavior when it handles ``None``.
+A single empty field is now always quoted when written into a CSV file.
+This allows to distinguish an empty row from a row consisting of a single empty field.
 Patch by Licht Takeuchi.

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1238,7 +1238,7 @@ csv_writerow(WriterObj *self, PyObject *seq)
     if (PyErr_Occurred())
         return NULL;
 
-    if (self->num_fields > 0 && self->rec_size == 0) {
+    if (self->num_fields > 0 && self->rec_len == 0) {
         if (dialect->quoting == QUOTE_NONE) {
             PyErr_Format(_csvstate_global->error_obj,
                 "single empty field record must be quoted");


### PR DESCRIPTION
See this.
https://github.com/pandas-dev/pandas/issues/18676
https://bugs.python.org/issue32255

I am waiting for the CLA response.

<!-- issue-number: bpo-32255 -->
https://bugs.python.org/issue32255
<!-- /issue-number -->
