### PR TITLE
bpo-32260: don't byte swap siphash keys

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-09-11-03-51.bpo-32260.1DAO-p.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-09-11-03-51.bpo-32260.1DAO-p.rst
@@ -1,0 +1,3 @@
+Don't byte swap the input keys to the SipHash algorithm on big-endian
+platforms. This should ensure siphash gives consistent results across
+platforms.

--- a/Python/pyhash.c
+++ b/Python/pyhash.c
@@ -364,9 +364,7 @@ static PyHash_FuncDef PyHash_Func = {fnv, "fnv", 8 * SIZEOF_PY_HASH_T,
 
 
 static uint64_t
-siphash24(uint64_t key0, uint64_t key1, const void *src, Py_ssize_t src_sz) {
-    uint64_t k0 = _le64toh(key0);
-    uint64_t k1 = _le64toh(key1);
+siphash24(uint64_t k0, uint64_t k1, const void *src, Py_ssize_t src_sz) {
     uint64_t b = (uint64_t)src_sz << 56;
     const uint64_t *in = (uint64_t*)src;
 


### PR DESCRIPTION
Reference siphash takes the keys as a bytes, so it makes sense to byte swap
when reifying the keys as 64-bit integers. However, Python's siphash takes host
integers in to start with.

<!-- issue-number: bpo-32260 -->
https://bugs.python.org/issue32260
<!-- /issue-number -->
