### PR TITLE
Skip KqueueEventLoopTests.test_read_pty_output test on MacOS.

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1486,9 +1486,7 @@ class EventLoopTestsMixin:
 
     @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
-    # select, poll and kqueue don't support character devices (PTY) on Mac OS X
-    # older than 10.6 (Snow Leopard)
-    @support.requires_mac_ver(10, 6)
+    @unittest.skipIf(sys.platform == 'darwin', 'test hangs on MacOS')
     # Issue #20495: The test hangs on FreeBSD 7.2 but pass on FreeBSD 9
     @support.requires_freebsd_version(8)
     def test_read_pty_output(self):


### PR DESCRIPTION
Starting with 10.13.2 the test hangs forever.  Since its already masked on OpenBSD, it seems that the problem is known and common.