### PR TITLE
bpo-31940: Reject faulty lchmod implementations

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-12-10-11-35-57.bpo-31940.Mhw94T.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-10-11-35-57.bpo-31940.Mhw94T.rst
@@ -1,0 +1,2 @@
+Detect faulty ``lchmod`` implementation to fix ``shutil.copystat`` on musl
+libc.  Patch by Anthony Sottile.


### PR DESCRIPTION
This is a runtime attempt at implementing https://github.com/python/cpython/pull/4267

A few notes:
- During review it was suggested to _cache_ the failed `lchmod` attempts, however I don't think this is doable:
    - `lchmod` is used for both symlinks and not symlinks if `follow_symlinks=False` -- it works fine for normal files
    - detecting whether something is a symlink up front throws away all benefits of caching whether it fails as you still make a syscall
    - the code for `fchmodat` adjacent to the `lchmod` code serves as precedent for both of these decisions

<!-- issue-number: bpo-31940 -->
https://bugs.python.org/issue31940
<!-- /issue-number -->
