### PR TITLE
bpo-32272: Remove asyncio.async() function.

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -235,9 +235,6 @@ Tasks
    interoperability. In this case, the result type is a subclass of
    :class:`Task`.
 
-   This method was added in Python 3.4.2. Use the :func:`async` function to
-   support also older Python versions.
-
    .. versionadded:: 3.4.2
 
 .. method:: AbstractEventLoop.set_task_factory(factory)

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -538,12 +538,6 @@ Task functions
 
       The :meth:`AbstractEventLoop.create_task` method.
 
-.. function:: async(coro_or_future, \*, loop=None)
-
-   A deprecated alias to :func:`ensure_future`.
-
-   .. deprecated:: 3.4.4
-
 .. function:: wrap_future(future, \*, loop=None)
 
    Wrap a :class:`concurrent.futures.Future` object in a :class:`Future`

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -3,7 +3,7 @@
 __all__ = (
     'Task',
     'FIRST_COMPLETED', 'FIRST_EXCEPTION', 'ALL_COMPLETED',
-    'wait', 'wait_for', 'as_completed', 'sleep', 'async',
+    'wait', 'wait_for', 'as_completed', 'sleep',
     'gather', 'shield', 'ensure_future', 'run_coroutine_threadsafe',
 )
 
@@ -487,26 +487,6 @@ async def sleep(delay, result=None, *, loop=None):
         return await future
     finally:
         h.cancel()
-
-
-def async_(coro_or_future, *, loop=None):
-    """Wrap a coroutine in a future.
-
-    If the argument is a Future, it is returned directly.
-
-    This function is deprecated in 3.5. Use asyncio.ensure_future() instead.
-    """
-
-    warnings.warn("asyncio.async() function is deprecated, use ensure_future()",
-                  DeprecationWarning,
-                  stacklevel=2)
-
-    return ensure_future(coro_or_future, loop=loop)
-
-# Silence DeprecationWarning:
-globals()['async'] = async_
-async_.__name__ = 'async'
-del async_
 
 
 def ensure_future(coro_or_future, *, loop=None):

--- a/Misc/NEWS.d/next/Library/2017-12-10-18-59-13.bpo-32272.Mu84Am.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-10-18-59-13.bpo-32272.Mu84Am.rst
@@ -1,0 +1,1 @@
+Remove asyncio.async() function.


### PR DESCRIPTION


<!-- issue-number: bpo-32272 -->
https://bugs.python.org/issue32272
<!-- /issue-number -->
