### PR TITLE
bpo-30050: Allow disabling full buffer warnings in signal.set_wakeup_fd

### DIFF
--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -322,13 +322,13 @@ The :mod:`signal` module defines the following functions:
    arrived.
 
    In the first approach, we read the data out of the fd's buffer, and
-   the byte values give you the signal numbers. This is simple, but it
-   can run into a problem: generally the fd will have a limited amount
-   of buffer space, and if too many signals arrive too quickly, the
-   buffer may become full, and some signals may be lost. If you use
-   this approach, then you should set ``warn_on_full_buffer=True``,
-   which will at least cause a warning to be printed to stderr when
-   signals are lost.
+   the byte values give you the signal numbers. This is simple, but in
+   rare cases it can run into a problem: generally the fd will have a
+   limited amount of buffer space, and if too many signals arrive too
+   quickly, then the buffer may become full, and some signals may be
+   lost. If you use this approach, then you should set
+   ``warn_on_full_buffer=True``, which will at least cause a warning
+   to be printed to stderr when signals are lost.
 
    In the second approach, we use the wakeup fd *only* for wakeups,
    and ignore the actual byte values. In this case, all we care about

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -300,7 +300,7 @@ The :mod:`signal` module defines the following functions:
    Availability: Unix.
 
 
-.. function:: set_wakeup_fd(fd)
+.. function:: set_wakeup_fd(fd, *, warn_on_full_buffer=True)
 
    Set the wakeup file descriptor to *fd*.  When a signal is received, the
    signal number is written as a single byte into the fd.  This can be used by
@@ -312,16 +312,36 @@ The :mod:`signal` module defines the following functions:
    If not -1, *fd* must be non-blocking.  It is up to the library to remove
    any bytes from *fd* before calling poll or select again.
 
-   Use for example ``struct.unpack('%uB' % len(data), data)`` to decode the
-   signal numbers list.
-
    When threads are enabled, this function can only be called from the main thread;
    attempting to call it from other threads will cause a :exc:`ValueError`
    exception to be raised.
 
+   There are two common ways to use this function. In both approaches,
+   you use the fd to wake up when a signal arrives, but then they
+   differ in how they determine *which* signal or signals have
+   arrived.
+
+   In the first approach, we read the data out of the fd's buffer, and
+   the byte values give you the signal numbers. This is simple, but it
+   can run into a problem: generally the fd will have a limited amount
+   of buffer space, and if too many signals arrive too quickly, the
+   buffer may become full, and some signals may be lost. If you use
+   this approach, then you should set ``warn_on_full_buffer=True``,
+   which will at least cause a warning to be printed to stderr when
+   signals are lost.
+
+   In the second approach, we use the wakeup fd *only* for wakeups,
+   and ignore the actual byte values. In this case, all we care about
+   is whether the fd's buffer is empty or non-empty; a full buffer
+   doesn't indicate a problem at all. If you use this approach, then
+   you should set ``warn_on_full_buffer=False``, so that your users
+   are not confused by spurious warning messages.
+
    .. versionchanged:: 3.5
       On Windows, the function now also supports socket handles.
 
+   .. versionchanged:: 3.7
+      Added ``warn_on_full_buffer``.
 
 .. function:: siginterrupt(signalnum, flag)
 

--- a/Doc/library/signal.rst
+++ b/Doc/library/signal.rst
@@ -341,7 +341,7 @@ The :mod:`signal` module defines the following functions:
       On Windows, the function now also supports socket handles.
 
    .. versionchanged:: 3.7
-      Added ``warn_on_full_buffer``.
+      Added ``warn_on_full_buffer`` parameter.
 
 .. function:: siginterrupt(signalnum, flag)
 

--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -92,9 +92,11 @@ class WindowsSignalTests(unittest.TestCase):
 class WakeupFDTests(unittest.TestCase):
 
     def test_invalid_call(self):
+        # First parameter is positional-only
         with self.assertRaises(TypeError):
             signal.set_wakeup_fd(signum=signal.SIGINT)
 
+        # warn_on_full_buffer is a keyword-only parameter
         with self.assertRaises(TypeError):
             signal.set_wakeup_fd(signal.SIGINT, False)
 

--- a/Misc/NEWS.d/next/Library/2017-12-10-23-44-56.bpo-30050.4SZ3lY.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-10-23-44-56.bpo-30050.4SZ3lY.rst
@@ -1,0 +1,3 @@
+New argument warn_on_full_buffer to signal.set_wakeup_fd lets you control
+whether Python prints a warning on stderr when the wakeup fd buffer
+overflows.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -216,7 +216,7 @@ report_wakeup_send_error(void* data)
     /* PyErr_SetExcFromWindowsErr() invokes FormatMessage() which
        recognizes the error codes used by both GetLastError() and
        WSAGetLastError */
-    res = PyErr_SetExcFromWindowsErr(PyExc_OSError, (int) (intptr_t) data);
+    PyErr_SetExcFromWindowsErr(PyExc_OSError, (int) (intptr_t) data);
     PySys_WriteStderr("Exception ignored when trying to send to the "
                       "signal wakeup fd:\n");
     PyErr_WriteUnraisable(NULL);

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -100,13 +100,15 @@ static volatile struct {
 
 static volatile struct {
     SOCKET_T fd;
+    int warn_on_full_buffer;
     int use_send;
-} wakeup = {INVALID_FD, 0};
+} wakeup = {INVALID_FD, 1, 0};
 #else
 #define INVALID_FD (-1)
 static volatile struct {
     sig_atomic_t fd;
-} wakeup = {INVALID_FD};
+    int warn_on_full_buffer;
+} wakeup = {INVALID_FD, 1};
 #endif
 
 /* Speed up sigcheck() when none tripped */
@@ -271,10 +273,13 @@ trip_signal(int sig_num)
 
             if (rc < 0) {
                 int last_error = GetLastError();
-                /* Py_AddPendingCall() isn't signal-safe, but we
-                   still use it for this exceptional case. */
-                Py_AddPendingCall(report_wakeup_send_error,
-                                  (void *)(intptr_t) last_error);
+                if (wakeup.warn_on_full_buffer ||
+                    last_error != WSAEWOULDBLOCK) {
+                    /* Py_AddPendingCall() isn't signal-safe, but we
+                       still use it for this exceptional case. */
+                    Py_AddPendingCall(report_wakeup_send_error,
+                                      (void *)(intptr_t) last_error);
+                }
             }
         }
         else
@@ -285,10 +290,13 @@ trip_signal(int sig_num)
             rc = _Py_write_noraise(fd, &byte, 1);
 
             if (rc < 0) {
-                /* Py_AddPendingCall() isn't signal-safe, but we
-                   still use it for this exceptional case. */
-                Py_AddPendingCall(report_wakeup_write_error,
-                                  (void *)(intptr_t)errno);
+                if (wakeup.warn_on_full_buffer ||
+                    (errno != EWOULDBLOCK && errno != EAGAIN)) {
+                    /* Py_AddPendingCall() isn't signal-safe, but we
+                       still use it for this exceptional case. */
+                    Py_AddPendingCall(report_wakeup_write_error,
+                                      (void *)(intptr_t)errno);
+                }
             }
         }
     }
@@ -529,9 +537,13 @@ signal_siginterrupt_impl(PyObject *module, int signalnum, int flag)
 
 
 static PyObject*
-signal_set_wakeup_fd(PyObject *self, PyObject *args)
+signal_set_wakeup_fd(PyObject *self, PyObject *args, PyObject *kwds)
 {
     struct _Py_stat_struct status;
+    static char *kwlist[] = {
+        "", "warn_on_full_buffer", NULL,
+    };
+    int warn_on_full_buffer = 1;
 #ifdef MS_WINDOWS
     PyObject *fdobj;
     SOCKET_T sockfd, old_sockfd;
@@ -540,7 +552,8 @@ signal_set_wakeup_fd(PyObject *self, PyObject *args)
     PyObject *mod;
     int is_socket;
 
-    if (!PyArg_ParseTuple(args, "O:set_wakeup_fd", &fdobj))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|$p:set_wakeup_fd", kwlist,
+                                     &fdobj, &warn_on_full_buffer))
         return NULL;
 
     sockfd = PyLong_AsSocket_t(fdobj);
@@ -549,7 +562,8 @@ signal_set_wakeup_fd(PyObject *self, PyObject *args)
 #else
     int fd, old_fd;
 
-    if (!PyArg_ParseTuple(args, "i:set_wakeup_fd", &fd))
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "i|$p:set_wakeup_fd", kwlist,
+                                     &fd, &warn_on_full_buffer))
         return NULL;
 #endif
 
@@ -600,6 +614,7 @@ signal_set_wakeup_fd(PyObject *self, PyObject *args)
 
     old_sockfd = wakeup.fd;
     wakeup.fd = sockfd;
+    wakeup.warn_on_full_buffer = warn_on_full_buffer;
     wakeup.use_send = is_socket;
 
     if (old_sockfd != INVALID_FD)
@@ -626,13 +641,14 @@ signal_set_wakeup_fd(PyObject *self, PyObject *args)
 
     old_fd = wakeup.fd;
     wakeup.fd = fd;
+    wakeup.warn_on_full_buffer = warn_on_full_buffer;
 
     return PyLong_FromLong(old_fd);
 #endif
 }
 
 PyDoc_STRVAR(set_wakeup_fd_doc,
-"set_wakeup_fd(fd) -> fd\n\
+"set_wakeup_fd(fd, *, warn_on_full_buffer=True) -> fd\n\
 \n\
 Sets the fd to be written to (with the signal number) when a signal\n\
 comes in.  A library can use this to wakeup select or poll.\n\
@@ -654,6 +670,7 @@ PySignal_SetWakeupFd(int fd)
     old_fd = wakeup.fd;
 #endif
     wakeup.fd = fd;
+    wakeup.warn_on_full_buffer = 1;
     return old_fd;
 }
 
@@ -1134,7 +1151,7 @@ static PyMethodDef signal_methods[] = {
     SIGNAL_GETITIMER_METHODDEF
     SIGNAL_SIGNAL_METHODDEF
     SIGNAL_GETSIGNAL_METHODDEF
-    {"set_wakeup_fd",           signal_set_wakeup_fd, METH_VARARGS, set_wakeup_fd_doc},
+    {"set_wakeup_fd", (PyCFunction)signal_set_wakeup_fd, METH_VARARGS | METH_KEYWORDS, set_wakeup_fd_doc},
     SIGNAL_SIGINTERRUPT_METHODDEF
     SIGNAL_PAUSE_METHODDEF
     SIGNAL_PTHREAD_KILL_METHODDEF

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -300,8 +300,6 @@ trip_signal(int sig_num)
         else
 #endif
         {
-            byte = (unsigned char)sig_num;
-
             /* _Py_write_noraise() retries write() if write() is interrupted by
                a signal (fails with EINTR). */
             rc = _Py_write_noraise(fd, &byte, 1);

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -102,13 +102,13 @@ static volatile struct {
     SOCKET_T fd;
     int warn_on_full_buffer;
     int use_send;
-} wakeup = {INVALID_FD, 1, 0};
+} wakeup = {.fd = INVALID_FD, .warn_on_full_buffer = 1, .use_send = 0};
 #else
 #define INVALID_FD (-1)
 static volatile struct {
     sig_atomic_t fd;
     int warn_on_full_buffer;
-} wakeup = {INVALID_FD, 1};
+} wakeup = {.fd = INVALID_FD, .warn_on_full_buffer = 1};
 #endif
 
 /* Speed up sigcheck() when none tripped */
@@ -274,7 +274,8 @@ trip_signal(int sig_num)
             if (rc < 0) {
                 int last_error = GetLastError();
                 if (wakeup.warn_on_full_buffer ||
-                    last_error != WSAEWOULDBLOCK) {
+                    last_error != WSAEWOULDBLOCK)
+                {
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
                     Py_AddPendingCall(report_wakeup_send_error,
@@ -291,7 +292,8 @@ trip_signal(int sig_num)
 
             if (rc < 0) {
                 if (wakeup.warn_on_full_buffer ||
-                    (errno != EWOULDBLOCK && errno != EAGAIN)) {
+                    (errno != EWOULDBLOCK && errno != EAGAIN))
+                {
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
                     Py_AddPendingCall(report_wakeup_write_error,


### PR DESCRIPTION
Previously, if the wakeup fd's buffer overflowed, Python would
unconditionally print a warning on stderr. But for many of
set_wakeup_fd's users (e.g. Twisted, Tornado, and Trio), this is
incorrect: the way they use set_wakeup_fd, a full buffer is a totally
normal and unexceptional condition. On the other hand, for asyncio and
curio, a full buffer causes signals to be lost, so they really want to
issue a warning (at the least!).

This change lets the caller of set_wakeup_fd choose whether they would
like this warning to be printed or not.

<!-- issue-number: bpo-30050 -->
https://bugs.python.org/issue30050
<!-- /issue-number -->
