### PR TITLE
bpo-32252: Fix faulthandler_suppress_crash_report()

### DIFF
--- a/Misc/NEWS.d/next/Tests/2017-12-11-13-31-33.bpo-32252.YnFw7J.rst
+++ b/Misc/NEWS.d/next/Tests/2017-12-11-13-31-33.bpo-32252.YnFw7J.rst
@@ -1,0 +1,2 @@
+Fix faulthandler_suppress_crash_report() used to prevent core dump files
+when testing crashes. getrlimit() returns zero on success.

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -932,7 +932,7 @@ faulthandler_suppress_crash_report(void)
     struct rlimit rl;
 
     /* Disable creation of core dump */
-    if (getrlimit(RLIMIT_CORE, &rl) != 0) {
+    if (getrlimit(RLIMIT_CORE, &rl) == 0) {
         rl.rlim_cur = 0;
         setrlimit(RLIMIT_CORE, &rl);
     }


### PR DESCRIPTION
Fix faulthandler_suppress_crash_report() used to prevent core dump files
when testing crashes. getrlimit() returns zero on success.

<!-- issue-number: bpo-32252 -->
https://bugs.python.org/issue32252
<!-- /issue-number -->
