### PR TITLE
bpo-29620: iterate over a copy of sys.modules

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -251,7 +251,7 @@ class _AssertWarnsContext(_AssertRaisesBaseContext):
     def __enter__(self):
         # The __warningregistry__'s need to be in a pristine state for tests
         # to work properly.
-        for v in sys.modules.values():
+        for v in list(sys.modules.values()):
             if getattr(v, '__warningregistry__', None):
                 v.__warningregistry__ = {}
         self.warnings_manager = warnings.catch_warnings(record=True)

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -1350,9 +1350,11 @@ test case
                 sys.modules['@bar@'] = 'bar'
 
         sys.modules['@foo@'] = Foo('foo')
-        self.assertWarns(UserWarning, warnings.warn, 'expected')
-        del sys.modules['@foo@']
-        del sys.modules['@bar@']
+        try:
+            self.assertWarns(UserWarning, warnings.warn, 'expected')
+        finally:
+            del sys.modules['@foo@']
+            del sys.modules['@bar@']
 
     def testAssertRaisesRegexMismatch(self):
         def Stub():

--- a/Misc/NEWS.d/next/Library/2018-08-21-16-20-33.bpo-29620.xxx666.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-21-16-20-33.bpo-29620.xxx666.rst
@@ -1,0 +1,3 @@
+:func:`~unittest.TestCase.assertWarns` no longer raises a ``RuntimeException``
+when accessing a module's ``__warningregistry__`` causes importation of a new
+module, or when a new module is imported in another thread. Patch by Kernc.


### PR DESCRIPTION
Fixes https://bugs.python.org/issue29620 by wrapping `sys.modules.values()` into a tuple before iteration.

<!-- issue-number: [bpo-29620](https://bugs.python.org/issue29620) -->
https://bugs.python.org/issue29620
<!-- /issue-number -->
