### PR TITLE
bpo-32282: Remove incorrect gate for `VersionHelpers.h` in `socketmodule.c` on Windows

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-12-14-02-28.bpo-32282.xFVMTn.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-12-14-02-28.bpo-32282.xFVMTn.rst
@@ -1,0 +1,2 @@
+Fix an unnecessary ifdef in the include of VersionHelpers.h in socketmodule
+on Windows.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -297,11 +297,8 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
 #  include <fcntl.h>
 # endif
 
-/* `VersionHelpers.h` is not necessarily available based on `_MSC_VER`. */
-#if defined(_MSC_VER) && _MSC_VER >= 1800 && !defined(_USING_V110_SDK71_)
-  /* Provides the IsWindows7SP1OrGreater() function */
-  #include <VersionHelpers.h>
-#endif
+/* Provides the IsWindows7SP1OrGreater() function */
+#include <VersionHelpers.h>
 
 #endif
 
@@ -6544,9 +6541,7 @@ PyInit__socket(void)
 
 #ifdef MS_WINDOWS
     if (support_wsa_no_inherit == -1) {
-#if defined(_MSC_VER) && _MSC_VER >= 1800 && !defined(_USING_V110_SDK71_)
         support_wsa_no_inherit = IsWindows7SP1OrGreater();
-#else
         DWORD version = GetVersion();
         DWORD major = (DWORD)LOBYTE(LOWORD(version));
         DWORD minor = (DWORD)HIBYTE(LOWORD(version));

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -297,9 +297,10 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
 #  include <fcntl.h>
 # endif
 
-#if defined(_MSC_VER) && _MSC_VER >= 1800
-/* Provides the IsWindows7SP1OrGreater() function */
-#include <VersionHelpers.h>
+/* `VersionHelpers.h` is not necessarily available based on `_MSC_VER`. */
+#if defined(_MSC_VER) && _MSC_VER >= 1800 && !defined(_USING_V110_SDK71_)
+  /* Provides the IsWindows7SP1OrGreater() function */
+  #include <VersionHelpers.h>
 #endif
 
 #endif
@@ -6543,7 +6544,7 @@ PyInit__socket(void)
 
 #ifdef MS_WINDOWS
     if (support_wsa_no_inherit == -1) {
-#if defined(_MSC_VER) && _MSC_VER >= 1800
+#if defined(_MSC_VER) && _MSC_VER >= 1800 && !defined(_USING_V110_SDK71_)
         support_wsa_no_inherit = IsWindows7SP1OrGreater();
 #else
         DWORD version = GetVersion();

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -6542,12 +6542,6 @@ PyInit__socket(void)
 #ifdef MS_WINDOWS
     if (support_wsa_no_inherit == -1) {
         support_wsa_no_inherit = IsWindows7SP1OrGreater();
-        DWORD version = GetVersion();
-        DWORD major = (DWORD)LOBYTE(LOWORD(version));
-        DWORD minor = (DWORD)HIBYTE(LOWORD(version));
-        /* need Windows 7 SP1, 2008 R2 SP1 or later */
-        support_wsa_no_inherit = major > 6 || (major == 6 && minor >= 1);
-#endif
     }
 #endif
 


### PR DESCRIPTION
`_MSC_VER` is insufficient to detect this header's presence, it's also important to ensure the XP-compatible toolset is not in use.

<!-- issue-number: bpo-32282 -->
https://bugs.python.org/issue32282
<!-- /issue-number -->
