### PR TITLE
[3.6] bpo-32137: The repr of deeply nested dict now raises a RecursionError (GH-4570)

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -53,10 +53,11 @@ class CommonTest(seq_tests.CommonTest):
         self.assertEqual(str(a2), "[0, 1, 2, [...], 3]")
         self.assertEqual(repr(a2), "[0, 1, 2, [...], 3]")
 
-        l0 = []
+    def test_repr_deep(self):
+        a = self.type2test([])
         for i in range(sys.getrecursionlimit() + 100):
-            l0 = [l0]
-        self.assertRaises(RecursionError, repr, l0)
+            a = self.type2test([a])
+        self.assertRaises(RecursionError, repr, a)
 
     def test_print(self):
         d = self.type2test(range(200))

--- a/Lib/test/mapping_tests.py
+++ b/Lib/test/mapping_tests.py
@@ -1,6 +1,7 @@
 # tests common to dict and UserDict
 import unittest
 import collections
+import sys
 
 
 class BasicTestMappingProtocol(unittest.TestCase):
@@ -618,6 +619,14 @@ class TestHashMappingProtocol(TestMappingProtocol):
 
         d = self._full_mapping({1: BadRepr()})
         self.assertRaises(Exc, repr, d)
+
+    def test_repr_deep(self):
+        d = self._empty_mapping()
+        for i in range(sys.getrecursionlimit() + 100):
+            d0 = d
+            d = self._empty_mapping()
+            d[1] = d0
+        self.assertRaises(RecursionError, repr, d)
 
     def test_eq(self):
         self.assertEqual(self._empty_mapping(), self._empty_mapping())

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -468,6 +468,12 @@ class DictTest(unittest.TestCase):
         d = {1: BadRepr()}
         self.assertRaises(Exc, repr, d)
 
+    def test_repr_deep(self):
+        d = {}
+        for i in range(sys.getrecursionlimit() + 100):
+            d = {1: d}
+        self.assertRaises(RecursionError, repr, d)
+
     def test_eq(self):
         self.assertEqual({}, {})
         self.assertEqual({1: 2}, {1: 2})

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-26-14-36-30.bpo-32137.Stj5nL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-26-14-36-30.bpo-32137.Stj5nL.rst
@@ -1,0 +1,2 @@
+The repr of deeply nested dict now raises a RecursionError instead of
+crashing due to a stack overflow.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2075,7 +2075,10 @@ dict_repr(PyDictObject *mp)
         }
         first = 0;
 
+        if (Py_EnterRecursiveCall(" while getting the repr of a dict"))
+            goto error;
         s = PyObject_Repr(key);
+        Py_LeaveRecursiveCall();
         if (s == NULL)
             goto error;
         res = _PyUnicodeWriter_WriteStr(&writer, s);
@@ -2086,7 +2089,10 @@ dict_repr(PyDictObject *mp)
         if (_PyUnicodeWriter_WriteASCIIString(&writer, ": ", 2) < 0)
             goto error;
 
+        if (Py_EnterRecursiveCall(" while getting the repr of a dict"))
+            goto error;
         s = PyObject_Repr(value);
+        Py_LeaveRecursiveCall();
         if (s == NULL)
             goto error;
         res = _PyUnicodeWriter_WriteStr(&writer, s);


### PR DESCRIPTION
instead of crashing due to a stack overflow.

This doesn't touch reprs of other extension types.
(cherry picked from commit 1fb72d2)


<!-- issue-number: bpo-32137 -->
https://bugs.python.org/issue32137
<!-- /issue-number -->
