### PR TITLE
bpo-30256: pass all BaseProxy arguments through AutoProxy

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -958,7 +958,7 @@ def MakeProxyType(name, exposed, _cache={}):
 
 
 def AutoProxy(token, serializer, manager=None, authkey=None,
-              exposed=None, incref=True):
+              exposed=None, incref=True, manager_owned=False):
     '''
     Return an auto-proxy for `token`
     '''
@@ -978,7 +978,7 @@ def AutoProxy(token, serializer, manager=None, authkey=None,
 
     ProxyType = MakeProxyType('AutoProxy[%s]' % token.typeid, exposed)
     proxy = ProxyType(token, serializer, manager=manager, authkey=authkey,
-                      incref=incref)
+                      incref=incref, manager_owned=manager_owned)
     proxy._isauto = True
     return proxy
 

--- a/Misc/NEWS.d/next/Library/2019-09-25-13-54-41.bpo-30256.wBkzox.rst
+++ b/Misc/NEWS.d/next/Library/2019-09-25-13-54-41.bpo-30256.wBkzox.rst
@@ -1,0 +1,1 @@
+Pass multiprocessing BaseProxy argument `manager_owned` through AutoProxy


### PR DESCRIPTION
The AutoProxy method did not accept the "manager_owned" keyword argument which broke when nested AutoProxy objects were created.

<!-- issue-number: bpo-30256 -->
https://bugs.python.org/issue30256
<!-- /issue-number -->
