### PR TITLE
import.c: Fix a GCC warning

### DIFF
--- a/Python/import.c
+++ b/Python/import.c
@@ -2308,7 +2308,7 @@ PyImport_ExtendInittab(struct _inittab *newtab)
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
 
     /* Allocate new memory for the combined table */
-    if ((i + n + 1) <= PY_SSIZE_T_MAX / sizeof(struct _inittab)) {
+    if ((i + n + 1) <= PY_SSIZE_T_MAX / (Py_ssize_t)sizeof(struct _inittab)) {
         size_t size = sizeof(struct _inittab) * (i + n + 1);
         p = PyMem_RawRealloc(inittab_copy, size);
     }


### PR DESCRIPTION
Fix the warning:

Python/import.c: warning: comparison between signed and unsigned integer expressions
     if ((i + n + 1) <= PY_SSIZE_T_MAX / sizeof(struct _inittab)) {