### PR TITLE
bpo-32295: User friendly message when invoking bdist_wheel sans wheel package

### DIFF
--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -840,6 +840,13 @@ Common commands: (see '--help-commands' for more)
             self.cmdclass[command] = klass
             return klass
 
+        if command == "bdist_wheel":
+            help_url = "https://packaging.python.org/tutorials/distributing-packages/#wheels"
+            raise DistutilsModuleError("invalid command '%s'\nnote: The wheel "
+                                       "package provides this command. See "
+                                       "%s for information on packaging wheels"
+                                       % (command, help_url))
+
         raise DistutilsModuleError("invalid command '%s'" % command)
 
     def get_command_obj(self, command, create=1):


### PR DESCRIPTION
Wheels are a well-known part of the Python packaging ecosystem at this point!

Many tutorials, gists, and other tools suggest to build wheels using setuptools and distutils, but may not remind users to install the wheel package.

Given that this does not interfere with experienced users implementing their own bdist_wheel command, it should be a welcome addition to help guide novice packagers in the right direction.

Result for a Python environment without the `wheel` package installed:

```shell
$ python3 setup.py bdist_wheel
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'bdist_wheel'
note: The wheel package provides this command. See https://packaging.python.org/tutorials/distributing-packages/#wheels for information on packaging wheels
```

<!-- issue-number: bpo-32295 -->
https://bugs.python.org/issue32295
<!-- /issue-number -->
