### PR TITLE
bpo-17852: Revert incorrect fix based on misunderstanding of _Py_PyAtExit() semantics

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1182,7 +1182,6 @@ class BufferedWriter(_BufferedIOMixin):
         self.buffer_size = buffer_size
         self._write_buf = bytearray()
         self._write_lock = Lock()
-        _register_writer(self)
 
     def writable(self):
         return self.raw.writable()
@@ -2587,26 +2586,3 @@ class StringIO(TextIOWrapper):
     def detach(self):
         # This doesn't make sense on StringIO.
         self._unsupported("detach")
-
-
-# ____________________________________________________________
-
-import atexit, weakref
-
-_all_writers = weakref.WeakSet()
-
-def _register_writer(w):
-    # keep weak-ref to buffered writer
-    _all_writers.add(w)
-
-def _flush_all_writers():
-    # Ensure all buffered writers are flushed before proceeding with
-    # normal shutdown.  Otherwise, if the underlying file objects get
-    # finalized before the buffered writer wrapping it then any buffered
-    # data will be lost.
-    for w in _all_writers:
-        try:
-            w.flush()
-        except:
-            pass
-atexit.register(_flush_all_writers)

--- a/Misc/NEWS.d/next/Library/2017-12-13-00-00-37.bpo-17852.Q8BP8N.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-13-00-00-37.bpo-17852.Q8BP8N.rst
@@ -1,0 +1,1 @@
+Revert incorrect fix based on misunderstanding of _Py_PyAtExit() semantics.

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -766,8 +766,6 @@ PyInit__io(void)
         !(_PyIO_empty_bytes = PyBytes_FromStringAndSize(NULL, 0)))
         goto fail;
 
-    _Py_PyAtExit(_PyIO_atexit_flush);
-
     state->initialized = 1;
 
     return m;

--- a/Modules/_io/_iomodule.h
+++ b/Modules/_io/_iomodule.h
@@ -183,5 +183,3 @@ extern PyObject *_PyIO_empty_str;
 extern PyObject *_PyIO_empty_bytes;
 
 extern PyTypeObject _PyBytesIOBuffer_Type;
-
-extern void _PyIO_atexit_flush(void);


### PR DESCRIPTION
The fix committed in https://github.com/python/cpython/pull/3372 uses `_Py_PyAtExit`. Unfortunately this function does not *add* a new callback, it merely replaces the current one. In other words, `_Py_PyAtExit` is only meant to be called by the `atexit` module and nothing else.

https://bugs.python.org/issue17852