### PR TITLE
bpo-32284: Fix documentation of BinaryIO and TextIO

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -774,9 +774,9 @@ The module defines the following classes, functions and decorators:
 
    Wrapper namespace for I/O stream types.
 
-   This defines the generic type ``IO[AnyStr]`` and aliases ``TextIO``
-   and ``BinaryIO`` for respectively ``IO[str]`` and ``IO[bytes]``.
-   These represent the types of I/O streams such as returned by
+   This defines the generic type ``IO[AnyStr]`` and subclasses ``TextIO``
+   and ``BinaryIO``, deriving from ``IO[str]`` and ``IO[bytes]``,
+   respectively. These represent the types of I/O streams such as returned by
    :func:`open`.
 
    These types are also accessible directly as ``typing.IO``,


### PR DESCRIPTION


<!-- issue-number: bpo-32284 -->
https://bugs.python.org/issue32284
<!-- /issue-number -->
