### PR TITLE
bpo-32299: unittest.mock.patch.dict now returns patched dict when used as context manager

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1275,15 +1275,17 @@ patch.dict
 
     :func:`patch.dict` can be used as a context manager, decorator or class
     decorator. When used as a class decorator :func:`patch.dict` honours
-    ``patch.TEST_PREFIX`` for choosing which methods to wrap.
+    ``patch.TEST_PREFIX`` for choosing which methods to wrap. When used as a
+    context manager it returns patched *in_dict*.
 
 :func:`patch.dict` can be used to add members to a dictionary, or simply let a test
 change a dictionary, and ensure the dictionary is restored when the test
 ends.
 
     >>> foo = {}
-    >>> with patch.dict(foo, {'newkey': 'newvalue'}):
+    >>> with patch.dict(foo, {'newkey': 'newvalue'}) as patched_foo:
     ...     assert foo == {'newkey': 'newvalue'}
+    ...     assert patched_foo == {'newkey': 'newvalue'}
     ...
     >>> assert foo == {}
 

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1275,8 +1275,7 @@ patch.dict
 
     :func:`patch.dict` can be used as a context manager, decorator or class
     decorator. When used as a class decorator :func:`patch.dict` honours
-    ``patch.TEST_PREFIX`` for choosing which methods to wrap. When used as a
-    context manager it returns patched *in_dict*.
+    ``patch.TEST_PREFIX`` for choosing which methods to wrap.
 
 :func:`patch.dict` can be used to add members to a dictionary, or simply let a test
 change a dictionary, and ensure the dictionary is restored when the test
@@ -1332,6 +1331,8 @@ magic methods :meth:`__getitem__`, :meth:`__setitem__`, :meth:`__delitem__` and 
     ...
     >>> assert thing['one'] == 1
     >>> assert list(thing) == ['one']
+
+:func:`patch.dict` returns a patched dictionary when used as context manager.
 
 
 patch.multiple

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1628,6 +1628,7 @@ class _patch_dict(object):
     def __enter__(self):
         """Patch the dict."""
         self._patch_dict()
+        return self.in_dict
 
 
     def _patch_dict(self):

--- a/Lib/unittest/test/testmock/testpatch.py
+++ b/Lib/unittest/test/testmock/testpatch.py
@@ -626,6 +626,13 @@ class PatchTest(unittest.TestCase):
         self.assertEqual(foo.values, original)
 
 
+    def test_patch_dict_as_context_manager(self):
+        foo = {'a': 'b'}
+        with patch.dict(foo, a='c') as patched:
+            self.assertDictEqual(patched, {'a': 'c'})
+        self.assertDictEqual(foo, {'a': 'b'})
+
+
     def test_name_preserved(self):
         foo = {}
 

--- a/Misc/NEWS.d/next/Library/2017-12-13-17-49-56.bpo-32299.eqAPWs.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-13-17-49-56.bpo-32299.eqAPWs.rst
@@ -1,0 +1,1 @@
+Changed patch.dict to return patched dictionary when used as context manager

--- a/Misc/NEWS.d/next/Library/2017-12-13-17-49-56.bpo-32299.eqAPWs.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-13-17-49-56.bpo-32299.eqAPWs.rst
@@ -1,1 +1,1 @@
-Changed patch.dict to return patched dictionary when used as context manager
+Changed ``mock.patch.dict`` to return patched dictionary when used as context manager


### PR DESCRIPTION
example:
```python
>>> from unittest.mock import patch
>>> with patch.dict(a, a=2) as patched:
...     print(patched)
... 
{'a': 2}
>>> print(a)
{'a': '1'}
```

<!-- issue-number: bpo-32299 -->
https://bugs.python.org/issue32299
<!-- /issue-number -->
