### PR TITLE
bpo-29240, bpo-32030: pymain_set_sys_argv() now copies argv

### DIFF
--- a/Include/sysmodule.h
+++ b/Include/sysmodule.h
@@ -16,6 +16,12 @@ PyAPI_FUNC(int) _PySys_SetObjectId(_Py_Identifier *key, PyObject *);
 
 PyAPI_FUNC(void) PySys_SetArgv(int, wchar_t **);
 PyAPI_FUNC(void) PySys_SetArgvEx(int, wchar_t **, int);
+#ifdef Py_BUILD_CORE
+PyAPI_FUNC(_PyInitError) _PySys_SetArgvWithError(
+    int argc,
+    wchar_t **argv,
+    int updatepath);
+#endif
 PyAPI_FUNC(void) PySys_SetPath(const wchar_t *);
 
 PyAPI_FUNC(void) PySys_WriteStdout(const char *format, ...)


### PR DESCRIPTION
* Rename pymain_set_argv() to pymain_set_sys_argv()
* pymain_set_sys_argv() now creates of copy of argv and modify the
  copy, rather than modifying pymain->argv
* Call pymain_set_sys_argv() earlier: before pymain_run_python(), but
  after pymain_get_importer().
* Add _PySys_SetArgvWithError() to handle errors

<!-- issue-number: bpo-29240 -->
https://bugs.python.org/issue29240
<!-- /issue-number -->
