### PR TITLE
bpo-15873: add '.fromisoformat' for date, time and datetime

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -428,6 +428,19 @@ Other constructors, all class methods:
       :exc:`ValueError` on :c:func:`localtime` failure.
 
 
+.. classmethod:: date.fromisoformat(date_string)
+
+   Return a date object corresponding to *date_string*, according to RFC 3339,
+   a stricter, simpler subset of ISO 8601, and such as is returned by
+   :func:`date.isoformat`. Microseconds are rounded to 6 digits.
+   :exc:`ValueError` is raised if *date_string* is not a valid RFC 3339
+   date string.
+
+   .. `RFC 3339`: https://www.ietf.org/rfc/rfc3339.txt
+
+   .. versionadded:: 3.7
+
+
 .. classmethod:: date.fromordinal(ordinal)
 
    Return the date corresponding to the proleptic Gregorian ordinal, where January
@@ -791,6 +804,19 @@ Other constructors, all class methods:
       is out of the range of values supported by the platform C
       :c:func:`gmtime` function. Raise :exc:`OSError` instead of
       :exc:`ValueError` on :c:func:`gmtime` failure.
+
+
+.. classmethod:: datetime.fromisoformat(datetime_string)
+
+   Return a datetime object corresponding to *datetime_string*, according to RFC 3339,
+   a stricter, simpler subset of ISO 8601, and such as is returned by
+   :func:`datetime.isoformat`. Microseconds are rounded to 6 digits.
+   :exc:`ValueError` is raised if *datetime_string* is not a valid RFC 3339
+   datetime string.
+
+   .. `RFC 3339`: https://www.ietf.org/rfc/rfc3339.txt
+
+   .. versionadded:: 3.7
 
 
 .. classmethod:: datetime.fromordinal(ordinal)
@@ -1393,6 +1419,22 @@ day, and subject to adjustment via a :class:`tzinfo` object.
 
    If an argument outside those ranges is given, :exc:`ValueError` is raised.  All
    default to ``0`` except *tzinfo*, which defaults to :const:`None`.
+
+
+Other constructor:
+
+.. classmethod:: time.fromisoformat(string)
+
+   Return a time object corresponding to *time_string*, according to RFC 3339,
+   a stricter, simpler subset of ISO 8601, and such as is returned by
+   :func:`time.isoformat`. Microseconds are rounded to 6 digits.
+   :exc:`ValueError` is raised if *time_string* is not a valid RFC 3339
+   time string..
+
+   .. `RFC 3339`: https://www.ietf.org/rfc/rfc3339.txt
+
+   .. versionadded:: 3.7
+
 
 Class attributes:
 

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -732,6 +732,15 @@ class date:
         y, m, d = _ord2ymd(n)
         return cls(y, m, d)
 
+    @classmethod
+    def fromisoformat(cls, date_string):
+        """Constructs a date from an RFC 3339 string, a strict subset of ISO 8601.
+
+        Raises ValueError in case of ill-formatted or invalid string.
+        """
+        import _strptime
+        return _strptime._parse_isodate(cls, date_string)
+
     # Conversions to string
 
     def __repr__(self):
@@ -1074,6 +1083,16 @@ class time:
         self._hashcode = -1
         self._fold = fold
         return self
+
+    @classmethod
+    def fromisoformat(cls, time_string):
+        """Constructs a time from an RFC 3339 string, a strict subset of ISO 8601.
+        Microseconds are rounded to 6 digits.
+
+        Raises ValueError in case of ill-formatted or invalid string.
+        """
+        import _strptime
+        return _strptime._parse_isotime(cls, time_string)
 
     # Read-only field accessors
     @property
@@ -1471,6 +1490,16 @@ class datetime(date):
     def utcfromtimestamp(cls, t):
         """Construct a naive UTC datetime from a POSIX timestamp."""
         return cls._fromtimestamp(t, True, None)
+
+    @classmethod
+    def fromisoformat(cls, datetime_string):
+        """Constructs a datetime from an RFC 3339 string, a strict subset of ISO 8601.
+        Microseconds are rounded to 6 digits.
+
+        Raises ValueError in case of ill-formatted or invalid string.
+        """
+        import _strptime
+        return _strptime._parse_isodatetime(cls, datetime_string)
 
     @classmethod
     def now(cls, tz=None):

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2607,6 +2607,25 @@ date_fromtimestamp(PyObject *cls, PyObject *args)
     return result;
 }
 
+/* Return new date from given date string, using _strptime._parse_isodate(). */
+static PyObject *
+date_fromisoformat(PyObject *cls, PyObject *args)
+{
+    static PyObject *module = NULL;
+    PyObject *string;
+
+    if (!PyArg_ParseTuple(args, "U:fromisoformat", &string))
+        return NULL;
+
+    if (module == NULL) {
+        module = PyImport_ImportModule("_strptime");
+        if (module == NULL)
+            return NULL;
+    }
+
+    return PyObject_CallMethod(module, "_parse_isodate", "OO", cls, string);
+}
+
 /* Return new date from proleptic Gregorian ordinal.  Raises ValueError if
  * the ordinal is out of range.
  */
@@ -2919,6 +2938,11 @@ static PyMethodDef date_methods[] = {
                                                        METH_CLASS,
      PyDoc_STR("timestamp -> local date from a POSIX timestamp (like "
                "time.time()).")},
+
+    {"fromisoformat", (PyCFunction)date_fromisoformat,
+     METH_VARARGS | METH_CLASS,
+     PyDoc_STR("Construct a date from an RFC 3339 string, a strict subset of ISO 8601.\n"
+               "Raises ValueError in case of ill-formatted or invalid string.\n")},
 
     {"fromordinal", (PyCFunction)date_fromordinal,      METH_VARARGS |
                                                     METH_CLASS,
@@ -3711,6 +3735,26 @@ time_str(PyDateTime_Time *self)
     return _PyObject_CallMethodId((PyObject *)self, &PyId_isoformat, NULL);
 }
 
+/* Return new time from time string, using _strptime._parse_isotime(). */
+static PyObject *
+time_fromisoformat(PyObject *cls, PyObject *args)
+{
+    static PyObject *module = NULL;
+    PyObject *string;
+
+    if (!PyArg_ParseTuple(args, "U:fromisoformat", &string))
+        return NULL;
+
+
+    if (module == NULL) {
+        module = PyImport_ImportModule("_strptime");
+        if (module == NULL)
+            return NULL;
+        }
+
+    return PyObject_CallMethod(module, "_parse_isotime", "OO", cls, string);
+}
+
 static PyObject *
 time_isoformat(PyDateTime_Time *self, PyObject *args, PyObject *kw)
 {
@@ -4017,6 +4061,13 @@ time_reduce(PyDateTime_Time *self, PyObject *arg)
 }
 
 static PyMethodDef time_methods[] = {
+
+    {"fromisoformat", (PyCFunction)time_fromisoformat,
+     METH_VARARGS | METH_CLASS,
+     PyDoc_STR("Construct a time from an RFC 3339 string, a strict subset "
+               "of ISO 8601.\n"
+               "Microseconds are rounded to 6 digits.\n"
+               "Raises ValueError in case of ill-formatted or invalid string.\n")},
 
     {"isoformat",   (PyCFunction)time_isoformat,        METH_VARARGS | METH_KEYWORDS,
      PyDoc_STR("Return string in ISO 8601 format, [HH[:MM[:SS[.mmm[uuu]]]]]"
@@ -4724,6 +4775,25 @@ static PyObject *
 datetime_str(PyDateTime_DateTime *self)
 {
     return _PyObject_CallMethodId((PyObject *)self, &PyId_isoformat, "s", " ");
+}
+
+/* Return new datetime from _strptime._parse_isodatetime(). */
+static PyObject *
+datetime_fromisoformat(PyObject *cls, PyObject *args)
+{
+    static PyObject *module = NULL;
+    PyObject *string;
+
+    if (!PyArg_ParseTuple(args, "U:fromisoformat", &string))
+        return NULL;
+
+    if (module == NULL) {
+        module = PyImport_ImportModule("_strptime");
+        if (module == NULL)
+            return NULL;
+    }
+
+    return PyObject_CallMethod(module, "_parse_isodatetime", "OO", cls, string);
 }
 
 static PyObject *
@@ -5505,6 +5575,12 @@ static PyMethodDef datetime_methods[] = {
     {"fromtimestamp", (PyCFunction)datetime_fromtimestamp,
      METH_VARARGS | METH_KEYWORDS | METH_CLASS,
      PyDoc_STR("timestamp[, tz] -> tz's local time from POSIX timestamp.")},
+
+    {"fromisoformat", (PyCFunction)datetime_fromisoformat,
+     METH_VARARGS | METH_CLASS,
+     PyDoc_STR("Construct a datetime from an RFC 3339 string, a strict subset of ISO 8601.\n"
+               "Microseconds are rounded to 6 digits.\n"
+               "Raises ValueError in case of ill-formatted or invalid string.\n")},
 
     {"utcfromtimestamp", (PyCFunction)datetime_utcfromtimestamp,
      METH_VARARGS | METH_CLASS,


### PR DESCRIPTION
adding method 'fromisoformat' to date, time and datetime classes 


<!-- issue-number: bpo-15873 -->
https://bugs.python.org/issue15873
<!-- /issue-number -->
