### PR TITLE
bpo-32236: Issue RuntimeWarning if buffering=1 for open() in binary mode

### DIFF
--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -174,7 +174,7 @@ recommended approach for working with encoded text files, this module
 provides additional utility functions and classes that allow the use of a
 wider range of codecs when working with binary files:
 
-.. function:: open(filename, mode='r', encoding=None, errors='strict', buffering=1)
+.. function:: open(filename, mode='r', encoding=None, errors='strict', buffering=-1)
 
    Open an encoded file using the given *mode* and return an instance of
    :class:`StreamReaderWriter`, providing transparent encoding/decoding.
@@ -194,8 +194,8 @@ wider range of codecs when working with binary files:
    *errors* may be given to define the error handling. It defaults to ``'strict'``
    which causes a :exc:`ValueError` to be raised in case an encoding error occurs.
 
-   *buffering* has the same meaning as for the built-in :func:`open` function.  It
-   defaults to line buffered.
+   *buffering* has the same meaning as for the built-in :func:`open` function.
+   It defaults to -1 which means that the default buffer size will be used.
 
 
 .. function:: EncodedFile(file, data_encoding, file_encoding=None, errors='strict')

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -200,8 +200,8 @@ def open(file, mode="r", buffering=-1, encoding=None, errors=None,
         raise ValueError("binary mode doesn't take a newline argument")
     if binary and buffering == 1:
         import warnings
-        warnings.warn("line buffering is not supported in binary mode",
-                      RuntimeWarning, 2)
+        warnings.warn("line buffering (buffering=1) isn't supported in binary "
+                      "mode, file will be fully buffered", RuntimeWarning, 2)
     raw = FileIO(file,
                  (creating and "x" or "") +
                  (reading and "r" or "") +

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -201,7 +201,8 @@ def open(file, mode="r", buffering=-1, encoding=None, errors=None,
     if binary and buffering == 1:
         import warnings
         warnings.warn("line buffering (buffering=1) isn't supported in binary "
-                      "mode, file will be fully buffered", RuntimeWarning, 2)
+                      "mode, the default buffer size will be used",
+                      RuntimeWarning, 2)
     raw = FileIO(file,
                  (creating and "x" or "") +
                  (reading and "r" or "") +

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -198,6 +198,8 @@ def open(file, mode="r", buffering=-1, encoding=None, errors=None,
         raise ValueError("binary mode doesn't take an errors argument")
     if binary and newline is not None:
         raise ValueError("binary mode doesn't take a newline argument")
+    if binary and buffering == 1:
+        raise ValueError("line buffering is not supported in binary mode")
     raw = FileIO(file,
                  (creating and "x" or "") +
                  (reading and "r" or "") +

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -199,7 +199,9 @@ def open(file, mode="r", buffering=-1, encoding=None, errors=None,
     if binary and newline is not None:
         raise ValueError("binary mode doesn't take a newline argument")
     if binary and buffering == 1:
-        raise ValueError("line buffering is not supported in binary mode")
+        import warnings
+        warnings.warn("line buffering is not supported in binary mode",
+                      RuntimeWarning, 2)
     raw = FileIO(file,
                  (creating and "x" or "") +
                  (reading and "r" or "") +

--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -883,7 +883,8 @@ def open(filename, mode='r', encoding=None, errors='strict', buffering=-1):
         encoding error occurs.
 
         buffering has the same meaning as for the builtin open() API.
-        It defaults to line buffered.
+        It defaults to -1 which means that the default buffer size will
+        be used.
 
         The returned wrapped file object provides an extra attribute
         .encoding which allows querying the used encoding. This

--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -862,7 +862,7 @@ class StreamRecoder:
 
 ### Shortcuts
 
-def open(filename, mode='r', encoding=None, errors='strict', buffering=1):
+def open(filename, mode='r', encoding=None, errors='strict', buffering=-1):
 
     """ Open an encoded file using the given mode and return
         a wrapped version providing transparent encoding/decoding.

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -724,7 +724,8 @@ class Popen(object):
         if self.text_mode:
             if bufsize == 1:
                 line_buffering = True
-                # line buffering is not supported in binary mode
+                # Use the default buffer size for the underlying binary streams
+                # since they don't support line buffering.
                 bufsize = -1
             else:
                 line_buffering = False

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -721,12 +721,20 @@ class Popen(object):
 
         self._closed_child_pipe_fds = False
 
+        if self.text_mode:
+            if bufsize == 1:
+                line_buffering = True
+                # line buffering is not supported in binary mode
+                bufsize = -1
+            else:
+                line_buffering = False
+
         try:
             if p2cwrite != -1:
                 self.stdin = io.open(p2cwrite, 'wb', bufsize)
                 if self.text_mode:
                     self.stdin = io.TextIOWrapper(self.stdin, write_through=True,
-                            line_buffering=(bufsize == 1),
+                            line_buffering=line_buffering,
                             encoding=encoding, errors=errors)
             if c2pread != -1:
                 self.stdout = io.open(c2pread, 'rb', bufsize)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -101,7 +101,8 @@ __all__ = [
     # threads
     "threading_setup", "threading_cleanup", "reap_threads", "start_threads",
     # miscellaneous
-    "check_warnings", "check_no_resource_warning", "EnvironmentVarGuard",
+    "check_warnings", "check_no_resource_warning", "check_no_warnings",
+    "EnvironmentVarGuard",
     "run_with_locale", "swap_item",
     "swap_attr", "Matcher", "set_memlimit", "SuppressCrashReport", "sortdict",
     "run_with_tz", "PGO", "missing_compiler_executable", "fd_count",
@@ -1209,10 +1210,14 @@ def check_warnings(*filters, **kwargs):
 
 
 @contextlib.contextmanager
-def check_no_warning(testcase, message='', category=Warning, force_gc=False):
-    """Context manager to check that no matching warning is emitted.
+def check_no_warnings(testcase, message='', category=Warning, force_gc=False):
+    """Context manager to check that no warnings are emitted.
 
-    If force_gc is True, attempt a garbage collection before checking
+    This context manager enables a given warning within its scope
+    and checks that no warnings are emitted even with that warning
+    enabled.
+
+    If force_gc is True, a garbage collection is attempted before checking
     for warnings. This may help to catch warnings emitted when objects
     are deleted, such as ResourceWarning.
 
@@ -1242,7 +1247,7 @@ def check_no_resource_warning(testcase):
     You must remove the object which may emit ResourceWarning before
     the end of the context manager.
     """
-    with check_no_warning(testcase, category=ResourceWarning, force_gc=True):
+    with check_no_warnings(testcase, category=ResourceWarning, force_gc=True):
         yield
 
 

--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -177,10 +177,10 @@ class CmdLineTest(unittest.TestCase):
     @contextlib.contextmanager
     def interactive_python(self, separate_stderr=False):
         if separate_stderr:
-            p = spawn_python('-i', bufsize=1, stderr=subprocess.PIPE)
+            p = spawn_python('-i', stderr=subprocess.PIPE)
             stderr = p.stderr
         else:
-            p = spawn_python('-i', bufsize=1, stderr=subprocess.STDOUT)
+            p = spawn_python('-i', stderr=subprocess.STDOUT)
             stderr = p.stdout
         try:
             # Drain stderr until prompt

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -182,7 +182,10 @@ class OtherFileTests:
         # make sure that explicitly setting the buffer size doesn't cause
         # misbehaviour especially with repeated close() calls
         for s in (-1, 0, 512):
-            self._checkBufferSize(s)
+            with support.check_no_warning(self,
+                                          message='line buffering',
+                                          category=RuntimeWarning):
+                self._checkBufferSize(s)
 
         # test that attempts to use line buffering in binary mode cause
         # a warning

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -182,9 +182,9 @@ class OtherFileTests:
         # make sure that explicitly setting the buffer size doesn't cause
         # misbehaviour especially with repeated close() calls
         for s in (-1, 0, 512):
-            with support.check_no_warning(self,
-                                          message='line buffering',
-                                          category=RuntimeWarning):
+            with support.check_no_warnings(self,
+                                           message='line buffering',
+                                           category=RuntimeWarning):
                 self._checkBufferSize(s)
 
         # test that attempts to use line buffering in binary mode cause

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -186,8 +186,7 @@ class OtherFileTests:
 
         # test that attempts to use line buffering in binary mode cause
         # a warning
-        warn_msg = 'line buffering is not supported in binary mode'
-        with self.assertWarns(RuntimeWarning, msg=warn_msg):
+        with self.assertWarnsRegex(RuntimeWarning, 'line buffering'):
             self._checkBufferSize(1)
 
     def testTruncateOnWindows(self):

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -167,7 +167,7 @@ class OtherFileTests:
     def testSetBufferSize(self):
         # make sure that explicitly setting the buffer size doesn't cause
         # misbehaviour especially with repeated close() calls
-        for s in (-1, 0, 1, 512):
+        for s in (-1, 0, 512):
             try:
                 f = self.open(TESTFN, 'wb', s)
                 f.write(str(s).encode("ascii"))
@@ -180,6 +180,10 @@ class OtherFileTests:
             except OSError as msg:
                 self.fail('error setting buffer size %d: %s' % (s, str(msg)))
             self.assertEqual(d, s)
+
+        # test that attempts to use line buffering in binary mode are rejected
+        self.assertRaises(ValueError, self.open, TESTFN, 'wb', 1)
+        self.assertRaises(ValueError, self.open, TESTFN, 'rb', 1)
 
     def testTruncateOnWindows(self):
         # SF bug <http://www.python.org/sf/801631>

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -591,23 +591,15 @@ class IOTest(unittest.TestCase):
         with self.open(support.TESTFN, "w+b") as f:
             self.large_file_ops(f)
 
-    def _checked_open(self, path, mode, bufsize, under_check=False):
-        if not under_check and bufsize == 1:
-            warn_msg = 'line buffering is not supported in binary mode'
-            with self.assertWarns(RuntimeWarning, msg=warn_msg):
-                return self._checked_open(path, mode, 1, True)
-        else:
-            return self.open(path, mode, bufsize)
-
     def test_with_open(self):
-        for bufsize in (0, 1, 100):
+        for bufsize in (0, 100):
             f = None
-            with self._checked_open(support.TESTFN, "wb", bufsize) as f:
+            with self.open(support.TESTFN, "wb", bufsize) as f:
                 f.write(b"xxx")
             self.assertEqual(f.closed, True)
             f = None
             try:
-                with self._checked_open(support.TESTFN, "wb", bufsize) as f:
+                with self.open(support.TESTFN, "wb", bufsize) as f:
                     1/0
             except ZeroDivisionError:
                 self.assertEqual(f.closed, True)

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -591,15 +591,23 @@ class IOTest(unittest.TestCase):
         with self.open(support.TESTFN, "w+b") as f:
             self.large_file_ops(f)
 
+    def _checked_open(self, path, mode, bufsize, under_check=False):
+        if not under_check and bufsize == 1:
+            warn_msg = 'line buffering is not supported in binary mode'
+            with self.assertWarns(RuntimeWarning, msg=warn_msg):
+                return self._checked_open(path, mode, 1, True)
+        else:
+            return self.open(path, mode, bufsize)
+
     def test_with_open(self):
-        for bufsize in (0, 100):
+        for bufsize in (0, 1, 100):
             f = None
-            with self.open(support.TESTFN, "wb", bufsize) as f:
+            with self._checked_open(support.TESTFN, "wb", bufsize) as f:
                 f.write(b"xxx")
             self.assertEqual(f.closed, True)
             f = None
             try:
-                with self.open(support.TESTFN, "wb", bufsize) as f:
+                with self._checked_open(support.TESTFN, "wb", bufsize) as f:
                     1/0
             except ZeroDivisionError:
                 self.assertEqual(f.closed, True)

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -592,7 +592,7 @@ class IOTest(unittest.TestCase):
             self.large_file_ops(f)
 
     def test_with_open(self):
-        for bufsize in (0, 1, 100):
+        for bufsize in (0, 100):
             f = None
             with self.open(support.TESTFN, "wb", bufsize) as f:
                 f.write(b"xxx")

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1137,8 +1137,7 @@ class ProcessTestCase(BaseTestCase):
         # line is not flushed in binary mode with bufsize=1.
         # we should get empty response
         line = b'line' + os.linesep.encode() # assume ascii-based locale
-        warn_msg = 'line buffering is not supported in binary mode'
-        with self.assertWarns(RuntimeWarning, msg=warn_msg):
+        with self.assertWarnsRegex(RuntimeWarning, 'line buffering'):
             self._test_bufsize_equal_one(line, b'', universal_newlines=False)
 
     def test_leaking_fds_on_error(self):

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1134,10 +1134,9 @@ class ProcessTestCase(BaseTestCase):
         self._test_bufsize_equal_one(line, line, universal_newlines=True)
 
     def test_bufsize_equal_one_binary_mode(self):
-        # line is not flushed in binary mode with bufsize=1.
-        # we should get empty response
-        line = b'line' + os.linesep.encode() # assume ascii-based locale
-        self._test_bufsize_equal_one(line, b'', universal_newlines=False)
+        # bufsize=1 should not be accepted in binary mode.
+        self.assertRaises(ValueError, self._test_bufsize_equal_one,
+            b'', b'', universal_newlines=False)
 
     def test_leaking_fds_on_error(self):
         # see bug #5179: Popen leaks file descriptors to PIPEs if

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1134,9 +1134,12 @@ class ProcessTestCase(BaseTestCase):
         self._test_bufsize_equal_one(line, line, universal_newlines=True)
 
     def test_bufsize_equal_one_binary_mode(self):
-        # bufsize=1 should not be accepted in binary mode.
-        self.assertRaises(ValueError, self._test_bufsize_equal_one,
-            b'', b'', universal_newlines=False)
+        # line is not flushed in binary mode with bufsize=1.
+        # we should get empty response
+        line = b'line' + os.linesep.encode() # assume ascii-based locale
+        warn_msg = 'line buffering is not supported in binary mode'
+        with self.assertWarns(RuntimeWarning, msg=warn_msg):
+            self._test_bufsize_equal_one(line, b'', universal_newlines=False)
 
     def test_leaking_fds_on_error(self):
         # see bug #5179: Popen leaks file descriptors to PIPEs if

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-11-23-50-40.bpo-32236.3RupnN.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-11-23-50-40.bpo-32236.3RupnN.rst
@@ -1,0 +1,2 @@
+Warn that line buffering is not supported if :func:`open` is called with
+binary mode and ``buffering=1``.

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -364,8 +364,8 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
 
     if (binary && buffering == 1) {
         if (PyErr_WarnEx(PyExc_RuntimeWarning,
-                         "line buffering is not supported in binary mode",
-                         1) < 0)
+                         "line buffering (buffering=1) isn't supported in "
+                         "binary mode, file will be fully buffered", 1) < 0)
            goto error;
     }
 

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -365,8 +365,10 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
     if (binary && buffering == 1) {
         if (PyErr_WarnEx(PyExc_RuntimeWarning,
                          "line buffering (buffering=1) isn't supported in "
-                         "binary mode, file will be fully buffered", 1) < 0)
+                         "binary mode, the default buffer size will be used",
+                         1) < 0) {
            goto error;
+        }
     }
 
     /* Create the Raw file stream */

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -363,9 +363,10 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
     }
 
     if (binary && buffering == 1) {
-        PyErr_SetString(PyExc_ValueError,
-                        "line buffering is not supported in binary mode");
-        goto error;
+        if (PyErr_WarnEx(PyExc_RuntimeWarning,
+                         "line buffering is not supported in binary mode",
+                         1) < 0)
+           goto error;
     }
 
     /* Create the Raw file stream */

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -362,6 +362,12 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
         goto error;
     }
 
+    if (binary && buffering == 1) {
+        PyErr_SetString(PyExc_ValueError,
+                        "line buffering is not supported in binary mode");
+        goto error;
+    }
+
     /* Create the Raw file stream */
     {
         PyObject *RawIO_class = (PyObject *)&PyFileIO_Type;


### PR DESCRIPTION
If buffering=1 is specified for open() in binary mode, it is silently
treated as buffering=-1 (i.e., the default buffer size).
Coupled with the fact that line buffering is always supported in Python 2,
such behavior caused several issues (e.g., bpo-10344, bpo-21332).

Raise ValueError on attempts to use line buffering in binary mode to prevent
possible bugs and expose existing buggy code.

<!-- issue-number: bpo-32236 -->
https://bugs.python.org/issue32236
<!-- /issue-number -->
