### PR TITLE
bpo-32310: Remove _Py_PyAtExit from Python.h.

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -77,12 +77,13 @@ PyAPI_FUNC(PyThreadState *) Py_NewInterpreter(void);
 PyAPI_FUNC(void) Py_EndInterpreter(PyThreadState *);
 
 
-/* Py_PyAtExit is for the atexit module, Py_AtExit is for low-level
- * exit functions.
+/* Py_AtExit is for low-level exit functions.  Note that registered
+ * functions are called late in the interpreter shutdown procedure and so
+ * the actions those functions can take are limited.  There is also a
+ * limited number of functions that can be registered, defined by
+ * NEXITFUNCS.  Currently the limit is 32 and a few of those are already
+ * used by the interpreter internals.
  */
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _Py_PyAtExit(void (*func)(void));
-#endif
 PyAPI_FUNC(int) Py_AtExit(void (*func)(void));
 
 PyAPI_FUNC(void) Py_Exit(int) _Py_NO_RETURN;

--- a/Misc/NEWS.d/next/C API/2017-12-13-12-25-47.bpo-32310.JMLVDg.rst
+++ b/Misc/NEWS.d/next/C API/2017-12-13-12-25-47.bpo-32310.JMLVDg.rst
@@ -1,0 +1,2 @@
+Remove _Py_PyAtExit from Python.h.  It is only to be used by the atexit
+module and should not be available for other uses.

--- a/Modules/atexitmodule.c
+++ b/Modules/atexitmodule.c
@@ -323,6 +323,9 @@ static struct PyModuleDef atexitmodule = {
     (freefunc)atexit_free
 };
 
+
+extern void _Py_PyAtExit(void (*func)(void));
+
 PyMODINIT_FUNC
 PyInit_atexit(void)
 {


### PR DESCRIPTION
The _Py_PyAtExit() should only be used by the atexit module.  Having it available is an invitation
for misuse.  Add some extra comments for the Py_AtExit() API.


<!-- issue-number: bpo-32310 -->
https://bugs.python.org/issue32310
<!-- /issue-number -->
