### PR TITLE
bpo-32302: Fix distutils bdist_wininst for CRT v142

### DIFF
--- a/Lib/distutils/command/bdist_wininst.py
+++ b/Lib/distutils/command/bdist_wininst.py
@@ -338,8 +338,8 @@ class bdist_wininst(Command):
                 bv = '14.0'
             else:
                 bv = '.'.join(CRT_ASSEMBLY_VERSION.split('.', 2)[:2])
-                if bv == '14.11':
-                    # v141 and v140 are binary compatible,
+                if bv in ('14.11', '14.12'):
+                    # v142, v141 and v140 are binary compatible,
                     # so keep using the 14.0 stub.
                     bv = '14.0'
 

--- a/Misc/NEWS.d/next/Library/2017-12-13-22-38-08.bpo-32302.othtTr.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-13-22-38-08.bpo-32302.othtTr.rst
@@ -1,0 +1,2 @@
+Fix bdist_wininst of distutils for CRT v142: it binary compatible with CRT
+v140.


### PR DESCRIPTION
CRT v142 is binary compatible with CRT v140.

<!-- issue-number: bpo-32302 -->
https://bugs.python.org/issue32302
<!-- /issue-number -->
