### PR TITLE
bpo-32323: urllib.parse.urlsplit() must not lowercase() IPv6 scope value

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -520,6 +520,15 @@ class UrlParseTestCase(unittest.TestCase):
             self.assertEqual(result.url, defrag)
             self.assertEqual(result.fragment, frag)
 
+    def test_urlsplit_scoped_IPv6(self):
+        p = urllib.parse.urlsplit('http://[FE80::822a:a8ff:fe49:470c%tESt]:1234')
+        self.assertEqual(p.hostname, "fe80::822a:a8ff:fe49:470c%tESt")
+        self.assertEqual(p.netloc, '[FE80::822a:a8ff:fe49:470c%tESt]:1234')
+
+        p = urllib.parse.urlsplit(b'http://[FE80::822a:a8ff:fe49:470c%tESt]:1234')
+        self.assertEqual(p.hostname, b"fe80::822a:a8ff:fe49:470c%tESt")
+        self.assertEqual(p.netloc, b'[FE80::822a:a8ff:fe49:470c%tESt]:1234')
+
     def test_urlsplit_attributes(self):
         url = "HTTP://WWW.PYTHON.ORG/doc/#frag"
         p = urllib.parse.urlsplit(url)

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -155,10 +155,12 @@ class _NetlocResultMixinBase(object):
     def hostname(self):
         hostname = self._hostinfo[0]
         if not hostname:
-            hostname = None
-        elif hostname is not None:
-            hostname = hostname.lower()
-        return hostname
+            return None
+        # Scoped IPv6 address may have zone info, which must not be lowercased
+        # like http://[fe80::822a:a8ff:fe49:470c%tESt]:1234/keys
+        separator = '%' if isinstance(hostname, str) else b'%'
+        hostname, percent, zone = hostname.partition(separator)
+        return hostname.lower() + percent + zone
 
     @property
     def port(self):

--- a/Misc/NEWS.d/next/Library/2017-12-14-10-10-10.bpo-32323.ideco.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-14-10-10-10.bpo-32323.ideco.rst
@@ -1,0 +1,2 @@
+:func:`urllib.parse.urlsplit()` does not convert zone-id (scope) to lower case
+for scoped IPv6 addresses in hostnames now.


### PR DESCRIPTION


<!-- issue-number: bpo-32323 -->
https://bugs.python.org/issue32323
<!-- /issue-number -->
