### PR TITLE
bpo-32327: Convert asyncio functions documented as coroutines to coroutines.

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -269,9 +269,8 @@ Creating connections
    socket type :py:data:`~socket.SOCK_STREAM`.  *protocol_factory* must be a
    callable returning a :ref:`protocol <asyncio-protocol>` instance.
 
-   This method is a :ref:`coroutine <coroutine>` which will try to
-   establish the connection in the background.  When successful, the
-   coroutine returns a ``(transport, protocol)`` pair.
+   This method will try to establish the connection in the background.
+   When successful, it returns a ``(transport, protocol)`` pair.
 
    The chronological synopsis of the underlying operation is as follows:
 
@@ -344,9 +343,8 @@ Creating connections
    :py:data:`~socket.SOCK_DGRAM`. *protocol_factory* must be a
    callable returning a :ref:`protocol <asyncio-protocol>` instance.
 
-   This method is a :ref:`coroutine <coroutine>` which will try to
-   establish the connection in the background.  When successful, the
-   coroutine returns a ``(transport, protocol)`` pair.
+   This method will try to establish the connection in the background.
+   When successful, the it returns a ``(transport, protocol)`` pair.
 
    Options changing how the connection is created:
 
@@ -395,9 +393,8 @@ Creating connections
    family is used to communicate between processes on the same machine
    efficiently.
 
-   This method is a :ref:`coroutine <coroutine>` which will try to
-   establish the connection in the background.  When successful, the
-   coroutine returns a ``(transport, protocol)`` pair.
+   This method will try to establish the connection in the background.
+   When successful, the it returns a ``(transport, protocol)`` pair.
 
    *path* is the name of a UNIX domain socket, and is required unless a *sock*
    parameter is specified.  Abstract UNIX sockets, :class:`str`,
@@ -459,8 +456,6 @@ Creating listening connections
      set this flag when being created. This option is not supported on
      Windows.
 
-   This method is a :ref:`coroutine <coroutine>`.
-
    .. versionchanged:: 3.5
 
       On Windows with :class:`ProactorEventLoop`, SSL/TLS is now supported.
@@ -484,8 +479,6 @@ Creating listening connections
    parameter is specified.  Abstract UNIX sockets, :class:`str`,
    :class:`bytes`, and :class:`~pathlib.Path` paths are supported.
 
-   This method is a :ref:`coroutine <coroutine>`.
-
    Availability: UNIX.
 
    .. versionchanged:: 3.7
@@ -507,8 +500,7 @@ Creating listening connections
    * *ssl* can be set to an :class:`~ssl.SSLContext` to enable SSL over the
      accepted connections.
 
-   This method is a :ref:`coroutine <coroutine>`.  When completed, the
-   coroutine returns a ``(transport, protocol)`` pair.
+   When completed it returns a ``(transport, protocol)`` pair.
 
    .. versionadded:: 3.5.3
 
@@ -565,7 +557,10 @@ Low-level socket operations
    With :class:`SelectorEventLoop` event loop, the socket *sock* must be
    non-blocking.
 
-   This method is a :ref:`coroutine <coroutine>`.
+   .. versionchanged:: 3.7
+      Even though the method was always documented as a coroutine
+      method, before Python 3.7 it returned a :class:`Future`.
+      Since Python 3.7, this is an ``async def`` method.
 
 .. coroutinemethod:: AbstractEventLoop.sock_recv_into(sock, buf)
 
@@ -577,8 +572,6 @@ Low-level socket operations
 
    With :class:`SelectorEventLoop` event loop, the socket *sock* must be
    non-blocking.
-
-   This method is a :ref:`coroutine <coroutine>`.
 
    .. versionadded:: 3.7
 
@@ -596,7 +589,10 @@ Low-level socket operations
    With :class:`SelectorEventLoop` event loop, the socket *sock* must be
    non-blocking.
 
-   This method is a :ref:`coroutine <coroutine>`.
+   .. versionchanged:: 3.7
+      Even though the method was always documented as a coroutine
+      method, before Python 3.7 it returned an :class:`Future`.
+      Since Python 3.7, this is an ``async def`` method.
 
 .. coroutinemethod:: AbstractEventLoop.sock_connect(sock, address)
 
@@ -605,8 +601,6 @@ Low-level socket operations
 
    With :class:`SelectorEventLoop` event loop, the socket *sock* must be
    non-blocking.
-
-   This method is a :ref:`coroutine <coroutine>`.
 
    .. versionchanged:: 3.5.2
       ``address`` no longer needs to be resolved.  ``sock_connect``
@@ -634,7 +628,10 @@ Low-level socket operations
 
    The socket *sock* must be non-blocking.
 
-   This method is a :ref:`coroutine <coroutine>`.
+   .. versionchanged:: 3.7
+      Even though the method was always documented as a coroutine
+      method, before Python 3.7 it returned a :class:`Future`.
+      Since Python 3.7, this is an ``async def`` method.
 
    .. seealso::
 
@@ -673,8 +670,6 @@ Use :class:`ProactorEventLoop` to support pipes on Windows.
    With :class:`SelectorEventLoop` event loop, the *pipe* is set to
    non-blocking mode.
 
-   This method is a :ref:`coroutine <coroutine>`.
-
 .. coroutinemethod:: AbstractEventLoop.connect_write_pipe(protocol_factory, pipe)
 
    Register write pipe in eventloop.
@@ -686,8 +681,6 @@ Use :class:`ProactorEventLoop` to support pipes on Windows.
 
    With :class:`SelectorEventLoop` event loop, the *pipe* is set to
    non-blocking mode.
-
-   This method is a :ref:`coroutine <coroutine>`.
 
 .. seealso::
 
@@ -738,14 +731,17 @@ pool of processes). By default, an event loop uses a thread pool executor
    :ref:`Use functools.partial to pass keywords to the *func*
    <asyncio-pass-keywords>`.
 
-   This method is a :ref:`coroutine <coroutine>`.
-
    .. versionchanged:: 3.5.3
       :meth:`BaseEventLoop.run_in_executor` no longer configures the
       ``max_workers`` of the thread pool executor it creates, instead
       leaving it up to the thread pool executor
       (:class:`~concurrent.futures.ThreadPoolExecutor`) to set the
       default.
+
+   .. versionchanged:: 3.7
+      Even though the method was always documented as a coroutine
+      method, before Python 3.7 it returned a :class:`Future`.
+      Since Python 3.7, this is an ``async def`` method.
 
 .. method:: AbstractEventLoop.set_default_executor(executor)
 
@@ -856,8 +852,6 @@ Server
    .. coroutinemethod:: wait_closed()
 
       Wait until the :meth:`close` method completes.
-
-      This method is a :ref:`coroutine <coroutine>`.
 
    .. attribute:: sockets
 

--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -432,20 +432,20 @@ class BaseProactorEventLoop(base_events.BaseEventLoop):
         # Close the event loop
         super().close()
 
-    def sock_recv(self, sock, n):
-        return self._proactor.recv(sock, n)
+    async def sock_recv(self, sock, n):
+        return await self._proactor.recv(sock, n)
 
-    def sock_recv_into(self, sock, buf):
-        return self._proactor.recv_into(sock, buf)
+    async def sock_recv_into(self, sock, buf):
+        return await self._proactor.recv_into(sock, buf)
 
-    def sock_sendall(self, sock, data):
-        return self._proactor.send(sock, data)
+    async def sock_sendall(self, sock, data):
+        return await self._proactor.send(sock, data)
 
-    def sock_connect(self, sock, address):
-        return self._proactor.connect(sock, address)
+    async def sock_connect(self, sock, address):
+        return await self._proactor.connect(sock, address)
 
-    def sock_accept(self, sock):
-        return self._proactor.accept(sock)
+    async def sock_accept(self, sock):
+        return await self._proactor.accept(sock)
 
     def _close_self_pipe(self):
         if self._self_reading_future is not None:

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -217,14 +217,6 @@ class BaseEventLoopTests(test_utils.TestCase):
         self.loop.set_default_executor(executor)
         self.assertIs(executor, self.loop._default_executor)
 
-    def test_getnameinfo(self):
-        sockaddr = mock.Mock()
-        self.loop.run_in_executor = mock.Mock()
-        self.loop.getnameinfo(sockaddr)
-        self.assertEqual(
-            (None, socket.getnameinfo, sockaddr, 0),
-            self.loop.run_in_executor.call_args[0])
-
     def test_call_soon(self):
         def cb():
             pass
@@ -344,26 +336,6 @@ class BaseEventLoopTests(test_utils.TestCase):
 
         # check disabled if debug mode is disabled
         test_thread(self.loop, False, create_loop=True)
-
-    def test_run_once_in_executor_plain(self):
-        def cb():
-            pass
-        f = asyncio.Future(loop=self.loop)
-        executor = mock.Mock()
-        executor.submit.return_value = f
-
-        self.loop.set_default_executor(executor)
-
-        res = self.loop.run_in_executor(None, cb)
-        self.assertIs(f, res)
-
-        executor = mock.Mock()
-        executor.submit.return_value = f
-        res = self.loop.run_in_executor(executor, cb)
-        self.assertIs(f, res)
-        self.assertTrue(executor.submit.called)
-
-        f.cancel()  # Don't complain about abandoned Future.
 
     def test__run_once(self):
         h1 = asyncio.TimerHandle(time.monotonic() + 5.0, lambda: True, (),
@@ -1007,6 +979,12 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.loop = asyncio.new_event_loop()
         self.set_event_loop(self.loop)
 
+    @mock.patch('socket.getnameinfo')
+    def test_getnameinfo(self, m_gai):
+        m_gai.side_effect = lambda *args: 42
+        r = self.loop.run_until_complete(self.loop.getnameinfo(('abc', 123)))
+        self.assertEqual(r, 42)
+
     @patch_socket
     def test_create_connection_multiple_errors(self, m_socket):
 
@@ -1119,9 +1097,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             OSError, self.loop.run_until_complete, coro)
 
     def test_create_connection_connect_err(self):
-        @asyncio.coroutine
-        def getaddrinfo(*args, **kw):
-            yield from []
+        async def getaddrinfo(*args, **kw):
             return [(2, 1, 6, '', ('107.6.106.82', 80))]
 
         def getaddrinfo_task(*args, **kwds):
@@ -1714,10 +1690,11 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
         self.assertTrue(m_log.error.called)
         self.assertFalse(sock.close.called)
         self.loop._remove_reader.assert_called_with(10)
-        self.loop.call_later.assert_called_with(constants.ACCEPT_RETRY_DELAY,
-                                                # self.loop._start_serving
-                                                mock.ANY,
-                                                MyProto, sock, None, None, mock.ANY)
+        self.loop.call_later.assert_called_with(
+            constants.ACCEPT_RETRY_DELAY,
+            # self.loop._start_serving
+            mock.ANY,
+            MyProto, sock, None, None, mock.ANY)
 
     def test_call_coroutine(self):
         @asyncio.coroutine
@@ -1738,7 +1715,8 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
             with self.assertRaises(TypeError):
                 self.loop.call_at(self.loop.time() + 60, func)
             with self.assertRaises(TypeError):
-                self.loop.run_in_executor(None, func)
+                self.loop.run_until_complete(
+                    self.loop.run_in_executor(None, func))
 
     @mock.patch('asyncio.base_events.logger')
     def test_log_slow_callbacks(self, m_logger):

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1702,7 +1702,7 @@ class EventLoopTestsMixin:
     def test_prompt_cancellation(self):
         r, w = socket.socketpair()
         r.setblocking(False)
-        f = self.loop.sock_recv(r, 1)
+        f = self.loop.create_task(self.loop.sock_recv(r, 1))
         ov = getattr(f, 'ov', None)
         if ov is not None:
             self.assertTrue(ov.pending)
@@ -1819,7 +1819,8 @@ class EventLoopTestsMixin:
         with self.assertRaises(RuntimeError):
             self.loop.call_at(self.loop.time() + .0, func)
         with self.assertRaises(RuntimeError):
-            self.loop.run_in_executor(None, func)
+            self.loop.run_until_complete(
+                self.loop.run_in_executor(None, func))
         with self.assertRaises(RuntimeError):
             self.loop.create_task(coro)
         with self.assertRaises(RuntimeError):

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -483,27 +483,6 @@ class BaseProactorEventLoopTests(test_utils.TestCase):
         self.loop.close()
         self.assertFalse(self.loop._close_self_pipe.called)
 
-    def test_sock_recv(self):
-        self.loop.sock_recv(self.sock, 1024)
-        self.proactor.recv.assert_called_with(self.sock, 1024)
-
-    def test_sock_recv_into(self):
-        buf = bytearray(10)
-        self.loop.sock_recv_into(self.sock, buf)
-        self.proactor.recv_into.assert_called_with(self.sock, buf)
-
-    def test_sock_sendall(self):
-        self.loop.sock_sendall(self.sock, b'data')
-        self.proactor.send.assert_called_with(self.sock, b'data')
-
-    def test_sock_connect(self):
-        self.loop.sock_connect(self.sock, ('1.2.3.4', 123))
-        self.proactor.connect.assert_called_with(self.sock, ('1.2.3.4', 123))
-
-    def test_sock_accept(self):
-        self.loop.sock_accept(self.sock)
-        self.proactor.accept.assert_called_with(self.sock)
-
     def test_make_socket_transport(self):
         tr = self.loop._make_socket_transport(self.sock, asyncio.Protocol())
         self.assertIsInstance(tr, _ProactorSocketTransport)

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -176,9 +176,15 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock = test_utils.mock_nonblocking_socket()
         self.loop._sock_recv = mock.Mock()
 
-        f = self.loop.sock_recv(sock, 1024)
-        self.assertIsInstance(f, asyncio.Future)
-        self.loop._sock_recv.assert_called_with(f, None, sock, 1024)
+        f = self.loop.create_task(self.loop.sock_recv(sock, 1024))
+        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+
+        self.assertEqual(self.loop._sock_recv.call_args[0][1:],
+                         (None, sock, 1024))
+
+        f.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            self.loop.run_until_complete(f)
 
     def test_sock_recv_reconnection(self):
         sock = mock.Mock()
@@ -188,7 +194,11 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
 
         self.loop.add_reader = mock.Mock()
         self.loop.remove_reader = mock.Mock()
-        fut = self.loop.sock_recv(sock, 1024)
+        fut = self.loop.create_task(
+            self.loop.sock_recv(sock, 1024))
+
+        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+
         callback = self.loop.add_reader.call_args[0][1]
         params = self.loop.add_reader.call_args[0][2:]
 
@@ -197,6 +207,8 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock.fileno.return_value = -1
         sock.recv.side_effect = OSError(9)
         callback(*params)
+
+        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
 
         self.assertIsInstance(fut.exception(), OSError)
         self.assertEqual((10,), self.loop.remove_reader.call_args[0])
@@ -245,18 +257,26 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock = test_utils.mock_nonblocking_socket()
         self.loop._sock_sendall = mock.Mock()
 
-        f = self.loop.sock_sendall(sock, b'data')
-        self.assertIsInstance(f, asyncio.Future)
+        f = self.loop.create_task(
+            self.loop.sock_sendall(sock, b'data'))
+
+        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+
         self.assertEqual(
-            (f, None, sock, b'data'),
-            self.loop._sock_sendall.call_args[0])
+            (None, sock, b'data'),
+            self.loop._sock_sendall.call_args[0][1:])
+
+        f.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            self.loop.run_until_complete(f)
 
     def test_sock_sendall_nodata(self):
         sock = test_utils.mock_nonblocking_socket()
         self.loop._sock_sendall = mock.Mock()
 
-        f = self.loop.sock_sendall(sock, b'')
-        self.assertIsInstance(f, asyncio.Future)
+        f = self.loop.create_task(self.loop.sock_sendall(sock, b''))
+        self.loop.run_until_complete(asyncio.sleep(0, loop=self.loop))
+
         self.assertTrue(f.done())
         self.assertIsNone(f.result())
         self.assertFalse(self.loop._sock_sendall.called)
@@ -269,7 +289,10 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
 
         self.loop.add_writer = mock.Mock()
         self.loop.remove_writer = mock.Mock()
-        fut = self.loop.sock_sendall(sock, b'data')
+        fut = self.loop.create_task(self.loop.sock_sendall(sock, b'data'))
+
+        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+
         callback = self.loop.add_writer.call_args[0][1]
         params = self.loop.add_writer.call_args[0][2:]
 
@@ -278,6 +301,8 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock.fileno.return_value = -1
         sock.send.side_effect = OSError(9)
         callback(*params)
+
+        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
 
         self.assertIsInstance(fut.exception(), OSError)
         self.assertEqual((10,), self.loop.remove_writer.call_args[0])
@@ -402,17 +427,17 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
     def test_sock_connect_resolve_using_socket_params(self, m_gai):
         addr = ('need-resolution.com', 8080)
         sock = test_utils.mock_nonblocking_socket()
-        m_gai.side_effect = (None, None, None, None, ('127.0.0.1', 0))
-        m_gai._is_coroutine = False
+
+        m_gai.side_effect = \
+            lambda *args: [(None, None, None, None, ('127.0.0.1', 0))]
+
         con = self.loop.create_task(self.loop.sock_connect(sock, addr))
-        while not m_gai.called:
-            self.loop._run_once()
+        self.loop.run_until_complete(con)
         m_gai.assert_called_with(
             addr[0], addr[1], sock.family, sock.type, sock.proto, 0)
 
-        con.cancel()
-        with self.assertRaises(asyncio.CancelledError):
-            self.loop.run_until_complete(con)
+        self.loop.run_until_complete(con)
+        sock.connect.assert_called_with(('127.0.0.1', 0))
 
     def test__sock_connect(self):
         f = asyncio.Future(loop=self.loop)
@@ -487,10 +512,15 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock = test_utils.mock_nonblocking_socket()
         self.loop._sock_accept = mock.Mock()
 
-        f = self.loop.sock_accept(sock)
-        self.assertIsInstance(f, asyncio.Future)
-        self.assertEqual(
-            (f, False, sock), self.loop._sock_accept.call_args[0])
+        f = self.loop.create_task(self.loop.sock_accept(sock))
+        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+
+        self.assertFalse(self.loop._sock_accept.call_args[0][1])
+        self.assertIs(self.loop._sock_accept.call_args[0][2], sock)
+
+        f.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            self.loop.run_until_complete(f)
 
     def test__sock_accept(self):
         f = asyncio.Future(loop=self.loop)

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -39,7 +39,7 @@ class ProactorTests(test_utils.TestCase):
     def test_close(self):
         a, b = socket.socketpair()
         trans = self.loop._make_socket_transport(a, asyncio.Protocol())
-        f = asyncio.ensure_future(self.loop.sock_recv(b, 100))
+        f = asyncio.ensure_future(self.loop.sock_recv(b, 100), loop=self.loop)
         trans.close()
         self.loop.run_until_complete(f)
         self.assertEqual(f.result(), b'')

--- a/Misc/NEWS.d/next/Library/2017-12-14-16-00-25.bpo-32327.bbkSxA.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-14-16-00-25.bpo-32327.bbkSxA.rst
@@ -1,0 +1,3 @@
+Convert asyncio functions that were documented as coroutines to coroutines.
+Affected functions: loop.sock_sendall, loop.sock_recv, loop.sock_accept,
+loop.run_in_executor, loop.getaddrinfo, loop.getnameinfo.


### PR DESCRIPTION


<!-- issue-number: bpo-32327 -->
https://bugs.python.org/issue32327
<!-- /issue-number -->
