### PR TITLE
[3.6] bpo-32329: Fix sys.flags.hash_randomization

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -426,9 +426,14 @@ class CmdLineTest(unittest.TestCase):
 
         # Verify that sys.flags contains hash_randomization
         code = 'import sys; print("random is", sys.flags.hash_randomization)'
-        rc, out, err = assert_python_ok('-c', code)
-        self.assertEqual(rc, 0)
+        rc, out, err = assert_python_ok('-c', code, PYTHONHASHSEED='')
         self.assertIn(b'random is 1', out)
+
+        rc, out, err = assert_python_ok('-c', code, PYTHONHASHSEED='random')
+        self.assertIn(b'random is 1', out)
+
+        rc, out, err = assert_python_ok('-c', code, PYTHONHASHSEED='0')
+        self.assertIn(b'random is 0', out)
 
     def test_del___main__(self):
         # Issue #15001: PyRun_SimpleFileExFlags() did crash because it kept a

--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-15-00-55-35.bpo-32329.XL1O99.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-15-00-55-35.bpo-32329.XL1O99.rst
@@ -1,0 +1,2 @@
+``sys.flags.hash_randomization`` is now properly set to 0 when hash
+randomization is turned off by ``PYTHONHASHSEED=0``.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -394,7 +394,6 @@ Py_Main(int argc, wchar_t **argv)
         exit(1);
     }
 
-    Py_HashRandomizationFlag = 1;
     _PyRandom_Init();
 
     PySys_ResetWarnOptions();

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -330,10 +330,6 @@ _Py_InitializeEx_Private(int install_sigs, int install_importlib)
         Py_OptimizeFlag = add_flag(Py_OptimizeFlag, p);
     if ((p = Py_GETENV("PYTHONDONTWRITEBYTECODE")) && *p != '\0')
         Py_DontWriteBytecodeFlag = add_flag(Py_DontWriteBytecodeFlag, p);
-    /* The variable is only tested for existence here; _PyRandom_Init will
-       check its value further. */
-    if ((p = Py_GETENV("PYTHONHASHSEED")) && *p != '\0')
-        Py_HashRandomizationFlag = add_flag(Py_HashRandomizationFlag, p);
 #ifdef MS_WINDOWS
     if ((p = Py_GETENV("PYTHONLEGACYWINDOWSFSENCODING")) && *p != '\0')
         Py_LegacyWindowsFSEncodingFlag = add_flag(Py_LegacyWindowsFSEncodingFlag, p);

--- a/Python/random.c
+++ b/Python/random.c
@@ -565,9 +565,11 @@ _PyRandom_Init(void)
         if (seed == 0) {
             /* disable the randomized hash */
             memset(secret, 0, secret_size);
+            Py_HashRandomizationFlag = 0;
         }
         else {
             lcg_urandom(seed, secret, secret_size);
+            Py_HashRandomizationFlag = 1;
         }
     }
     else {
@@ -582,6 +584,7 @@ _PyRandom_Init(void)
         if (res < 0) {
             Py_FatalError("failed to get random numbers to initialize Python");
         }
+        Py_HashRandomizationFlag = 1;
     }
 }
 


### PR DESCRIPTION
sys.flags.hash_randomization is now properly set to 0 when hash
randomization is turned off by PYTHONHASHSEED=0.

<!-- issue-number: bpo-32329 -->
https://bugs.python.org/issue32329
<!-- /issue-number -->
