### PR TITLE
bpo-32331: Fix socket.type on Linux; expose SOCK_TYPE_MASK.

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -482,6 +482,11 @@ The following functions all create :ref:`socket objects <socket-objects>`.
    .. versionchanged:: 3.7
        The CAN_ISOTP protocol was added.
 
+   .. versionchanged:: 3.7
+      On Linux: when :const:`SOCK_NONBLOCK` or :const:`SOCK_CLOEXEC` bit
+      flags are applied to *type* they are cleared, and :attr:`socket.type`
+      will not reflect them.
+
 .. function:: socketpair([family[, type[, proto]]])
 
    Build a pair of connected socket objects using the given address family, socket
@@ -1417,6 +1422,10 @@ to sockets.
 
    * ``sock.setblocking(False)`` is equivalent to ``sock.settimeout(0.0)``
 
+   .. versionchanged:: 3.7
+      The method no longer applies :const:`SOCK_NONBLOCK` flag on
+      :attr:`socket.type` on Linux.
+
 
 .. method:: socket.settimeout(value)
 
@@ -1428,6 +1437,10 @@ to sockets.
    non-blocking mode. If ``None`` is given, the socket is put in blocking mode.
 
    For further information, please consult the :ref:`notes on socket timeouts <socket-timeouts>`.
+
+   .. versionchanged:: 3.7
+      The method no longer toggles :const:`SOCK_NONBLOCK` flag on
+      :attr:`socket.type` on Linux.
 
 
 .. method:: socket.setsockopt(level, optname, value: int)

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -483,9 +483,17 @@ The following functions all create :ref:`socket objects <socket-objects>`.
        The CAN_ISOTP protocol was added.
 
    .. versionchanged:: 3.7
-      On Linux: when :const:`SOCK_NONBLOCK` or :const:`SOCK_CLOEXEC` bit
-      flags are applied to *type* they are cleared, and :attr:`socket.type`
-      will not reflect them.
+      Linux-specific: when :const:`SOCK_NONBLOCK` or :const:`SOCK_CLOEXEC`
+      bit flags are applied to *type* they are cleared, and
+      :attr:`socket.type` will not reflect them.  They are still passed
+      to the underlying Linux' `socket()` call, therefore::
+
+          sock = socket.socket(
+              socket.AF_INET,
+              socket.SOCK_STREAM | socket.SOCK_NONBLOCK)
+
+      will still create a non-blocking socket on Linux, but
+      ``sock.type`` will be set to ``socket.SOCK_STREAM``.
 
 .. function:: socketpair([family[, type[, proto]]])
 

--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -483,17 +483,18 @@ The following functions all create :ref:`socket objects <socket-objects>`.
        The CAN_ISOTP protocol was added.
 
    .. versionchanged:: 3.7
-      Linux-specific: when :const:`SOCK_NONBLOCK` or :const:`SOCK_CLOEXEC`
+      When :const:`SOCK_NONBLOCK` or :const:`SOCK_CLOEXEC`
       bit flags are applied to *type* they are cleared, and
       :attr:`socket.type` will not reflect them.  They are still passed
-      to the underlying Linux' `socket()` call, therefore::
+      to the underlying system `socket()` call.  Therefore::
 
           sock = socket.socket(
               socket.AF_INET,
               socket.SOCK_STREAM | socket.SOCK_NONBLOCK)
 
-      will still create a non-blocking socket on Linux, but
-      ``sock.type`` will be set to ``socket.SOCK_STREAM``.
+      will still create a non-blocking socket on OSes that support
+      ``SOCK_NONBLOCK``, but ``sock.type`` will be set to
+      ``socket.SOCK_STREAM``.
 
 .. function:: socketpair([family[, type[, proto]]])
 
@@ -1432,7 +1433,7 @@ to sockets.
 
    .. versionchanged:: 3.7
       The method no longer applies :const:`SOCK_NONBLOCK` flag on
-      :attr:`socket.type` on Linux.
+      :attr:`socket.type`.
 
 
 .. method:: socket.settimeout(value)
@@ -1448,7 +1449,7 @@ to sockets.
 
    .. versionchanged:: 3.7
       The method no longer toggles :const:`SOCK_NONBLOCK` flag on
-      :attr:`socket.type` on Linux.
+      :attr:`socket.type`.
 
 
 .. method:: socket.setsockopt(level, optname, value: int)

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -881,6 +881,12 @@ Changes in the Python API
   recent to be more consistent with :mod:`traceback`.
   (Contributed by Jesse Bakker in :issue:`32121`.)
 
+* On Linux, the :attr:`socket.type <socket.socket.type>` attribute no
+  longer has :const:`socket.SOCK_NONBLOCK` flag applied, so checks like
+  ``if sock.type == socket.SOCK_STREAM`` work as expected on all
+  platforms.
+  (Contributed by Yury Selivanov in :issue:`32331`.)
+
 .. _Unicode Technical Standard #18: https://unicode.org/reports/tr18/
 
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -881,9 +881,10 @@ Changes in the Python API
   recent to be more consistent with :mod:`traceback`.
   (Contributed by Jesse Bakker in :issue:`32121`.)
 
-* On Linux, the :attr:`socket.type <socket.socket.type>` attribute no
-  longer has :const:`socket.SOCK_NONBLOCK` or :const:`socket.SOCK_CLOEXEC`
-  flags applied, so checks like ``if sock.type == socket.SOCK_STREAM``
+* On OSes that support :const:`socket.SOCK_NONBLOCK` or
+  :const:`socket.SOCK_CLOEXEC` bit flags, the
+  :attr:`socket.type <socket.socket.type>` no longer has them applied.
+  Therefore, checks like ``if sock.type == socket.SOCK_STREAM``
   work as expected on all platforms.
   (Contributed by Yury Selivanov in :issue:`32331`.)
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -882,9 +882,9 @@ Changes in the Python API
   (Contributed by Jesse Bakker in :issue:`32121`.)
 
 * On Linux, the :attr:`socket.type <socket.socket.type>` attribute no
-  longer has :const:`socket.SOCK_NONBLOCK` flag applied, so checks like
-  ``if sock.type == socket.SOCK_STREAM`` work as expected on all
-  platforms.
+  longer has :const:`socket.SOCK_NONBLOCK` or :const:`socket.SOCK_CLOEXEC`
+  flags applied, so checks like ``if sock.type == socket.SOCK_STREAM``
+  work as expected on all platforms.
   (Contributed by Yury Selivanov in :issue:`32331`.)
 
 .. _Unicode Technical Standard #18: https://unicode.org/reports/tr18/

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -80,6 +80,8 @@ IntEnum._convert(
         __name__,
         lambda C: (C.isupper() and
                    C.startswith('SOCK_') and
+                   # SOCK_NONBLOCK and SOCK_CLOEXEC are not socket types,
+                   # they are Linux-specific bit flags.
                    C not in {'SOCK_NONBLOCK', 'SOCK_CLOEXEC'}))
 
 IntFlag._convert(

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -78,7 +78,9 @@ IntEnum._convert(
 IntEnum._convert(
         'SocketKind',
         __name__,
-        lambda C: C.isupper() and C.startswith('SOCK_'))
+        lambda C: (C.isupper() and
+                   C.startswith('SOCK_') and
+                   C not in {'SOCK_NONBLOCK', 'SOCK_CLOEXEC'}))
 
 IntFlag._convert(
         'MsgFlag',
@@ -203,11 +205,7 @@ class socket(_socket.socket):
         For IP sockets, the address info is a pair (hostaddr, port).
         """
         fd, addr = self._accept()
-        # If our type has the SOCK_NONBLOCK flag, we shouldn't pass it onto the
-        # new socket. We do not currently allow passing SOCK_NONBLOCK to
-        # accept4, so the returned socket is always blocking.
-        type = self.type & ~globals().get("SOCK_NONBLOCK", 0)
-        sock = socket(self.family, type, self.proto, fileno=fd)
+        sock = socket(self.family, self.type, self.proto, fileno=fd)
         # Issue #7995: if no default timeout is set and the listening
         # socket had a (non-zero) timeout, force the new socket in blocking
         # mode to override platform-specific socket flags inheritance.

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -78,11 +78,7 @@ IntEnum._convert(
 IntEnum._convert(
         'SocketKind',
         __name__,
-        lambda C: (C.isupper() and
-                   C.startswith('SOCK_') and
-                   # SOCK_NONBLOCK and SOCK_CLOEXEC are not socket types,
-                   # they are Linux-specific bit flags.
-                   C not in {'SOCK_NONBLOCK', 'SOCK_CLOEXEC'}))
+        lambda C: C.isupper() and C.startswith('SOCK_'))
 
 IntFlag._convert(
         'MsgFlag',

--- a/Lib/test/test_asyncore.py
+++ b/Lib/test/test_asyncore.py
@@ -726,14 +726,10 @@ class BaseTestAPI:
     def test_create_socket(self):
         s = asyncore.dispatcher()
         s.create_socket(self.family)
+        self.assertEqual(s.socket.type, socket.SOCK_STREAM)
         self.assertEqual(s.socket.family, self.family)
-        SOCK_NONBLOCK = getattr(socket, 'SOCK_NONBLOCK', 0)
-        sock_type = socket.SOCK_STREAM | SOCK_NONBLOCK
-        if hasattr(socket, 'SOCK_CLOEXEC'):
-            self.assertIn(s.socket.type,
-                          (sock_type | socket.SOCK_CLOEXEC, sock_type))
-        else:
-            self.assertEqual(s.socket.type, sock_type)
+        self.assertEqual(s.socket.gettimeout(), 0)
+        self.assertFalse(s.socket.get_inheritable())
 
     def test_bind(self):
         if HAS_UNIX_SOCKETS and self.family == socket.AF_UNIX:

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1606,7 +1606,13 @@ class GeneralModuleTests(unittest.TestCase):
         fd, path = tempfile.mkstemp()
         self.addCleanup(os.unlink, path)
         unknown_family = max(socket.AddressFamily.__members__.values()) + 1
-        unknown_type = max(socket.SocketKind.__members__.values()) + 1
+
+        unknown_type = max(
+            kind
+            for name, kind in socket.SocketKind.__members__.items()
+            if name not in {'SOCK_NONBLOCK', 'SOCK_CLOEXEC'}
+        ) + 1
+
         with socket.socket(
                 family=unknown_family, type=unknown_type, fileno=fd) as s:
             self.assertEqual(s.family, unknown_family)

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1577,6 +1577,22 @@ class GeneralModuleTests(unittest.TestCase):
             self.assertEqual(str(s.family), 'AddressFamily.AF_INET')
             self.assertEqual(str(s.type), 'SocketKind.SOCK_STREAM')
 
+    def test_socket_consistent_sock_type(self):
+        SOCK_NONBLOCK = getattr(socket, 'SOCK_NONBLOCK', 0)
+        SOCK_CLOEXEC = getattr(socket, 'SOCK_CLOEXEC', 0)
+        sock_type = socket.SOCK_STREAM | SOCK_NONBLOCK | SOCK_CLOEXEC
+
+        with socket.socket(socket.AF_INET, sock_type) as s:
+            self.assertEqual(s.type, socket.SOCK_STREAM)
+            s.settimeout(1)
+            self.assertEqual(s.type, socket.SOCK_STREAM)
+            s.settimeout(0)
+            self.assertEqual(s.type, socket.SOCK_STREAM)
+            s.setblocking(True)
+            self.assertEqual(s.type, socket.SOCK_STREAM)
+            s.setblocking(False)
+            self.assertEqual(s.type, socket.SOCK_STREAM)
+
     @unittest.skipIf(os.name == 'nt', 'Will not work on Windows')
     def test_uknown_socket_family_repr(self):
         # Test that when created with a family that's not one of the known
@@ -1589,9 +1605,12 @@ class GeneralModuleTests(unittest.TestCase):
         # On Windows this trick won't work, so the test is skipped.
         fd, path = tempfile.mkstemp()
         self.addCleanup(os.unlink, path)
-        with socket.socket(family=42424, type=13331, fileno=fd) as s:
-            self.assertEqual(s.family, 42424)
-            self.assertEqual(s.type, 13331)
+        unknown_family = max(socket.AddressFamily.__members__.values()) + 1
+        unknown_type = max(socket.SocketKind.__members__.values()) + 1
+        with socket.socket(
+                family=unknown_family, type=unknown_type, fileno=fd) as s:
+            self.assertEqual(s.family, unknown_family)
+            self.assertEqual(s.type, unknown_type)
 
     @unittest.skipUnless(hasattr(os, 'sendfile'), 'test needs os.sendfile()')
     def test__sendfile_use_sendfile(self):
@@ -5084,7 +5103,7 @@ class InheritanceTest(unittest.TestCase):
     def test_SOCK_CLOEXEC(self):
         with socket.socket(socket.AF_INET,
                            socket.SOCK_STREAM | socket.SOCK_CLOEXEC) as s:
-            self.assertTrue(s.type & socket.SOCK_CLOEXEC)
+            self.assertEqual(s.type, socket.SOCK_STREAM)
             self.assertFalse(s.get_inheritable())
 
     def test_default_inheritable(self):
@@ -5149,11 +5168,15 @@ class InheritanceTest(unittest.TestCase):
 class NonblockConstantTest(unittest.TestCase):
     def checkNonblock(self, s, nonblock=True, timeout=0.0):
         if nonblock:
-            self.assertTrue(s.type & socket.SOCK_NONBLOCK)
+            self.assertEqual(s.type, socket.SOCK_STREAM)
             self.assertEqual(s.gettimeout(), timeout)
+            self.assertTrue(
+                fcntl.fcntl(s, fcntl.F_GETFL, os.O_NONBLOCK) & os.O_NONBLOCK)
         else:
-            self.assertFalse(s.type & socket.SOCK_NONBLOCK)
+            self.assertEqual(s.type, socket.SOCK_STREAM)
             self.assertEqual(s.gettimeout(), None)
+            self.assertFalse(
+                fcntl.fcntl(s, fcntl.F_GETFL, os.O_NONBLOCK) & os.O_NONBLOCK)
 
     @support.requires_linux_version(2, 6, 28)
     def test_SOCK_NONBLOCK(self):

--- a/Misc/NEWS.d/next/Library/2017-12-15-23-48-43.bpo-32331.fIg1Uc.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-15-23-48-43.bpo-32331.fIg1Uc.rst
@@ -1,0 +1,3 @@
+Fix socket.settimeout() and socket.setblocking() to not change socket.type
+on Linux.  Fix socket.socket() constructor to reset any bit flags applied to
+socket's type.  This change only affects Linux.

--- a/Misc/NEWS.d/next/Library/2017-12-15-23-48-43.bpo-32331.fIg1Uc.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-15-23-48-43.bpo-32331.fIg1Uc.rst
@@ -1,3 +1,4 @@
-Fix socket.settimeout() and socket.setblocking() to not change socket.type
-on Linux.  Fix socket.socket() constructor to reset any bit flags applied to
-socket's type.  This change only affects Linux.
+Fix socket.settimeout() and socket.setblocking() to keep socket.type
+as is. Fix socket.socket() constructor to reset any bit flags applied to
+socket's type.  This change only affects OSes that have SOCK_NONBLOCK
+and/or SOCK_CLOEXEC.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -881,7 +881,7 @@ init_sockobject(PySocketSockObject *s,
        0xF is SOCK_TYPE_MASK in include/linux/net.h which on Linux
        is used to mask off SOCK_NONBLOCK and SOCK_CLOEXEC.
     */
-    s->sock_type = type & 0xF;
+    s->sock_type = type & ~(SOCK_NONBLOCK | SOCK_CLOEXEC);
 #else
     s->sock_type = type;
 #endif

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -871,7 +871,8 @@ init_sockobject(PySocketSockObject *s,
     s->sock_fd = fd;
     s->sock_family = family;
 
-#ifdef __linux__
+    s->sock_type = type;
+
     /* It's possible to pass SOCK_NONBLOCK and SOCK_CLOEXEC bit flags
        on Linux as part of socket.type.  We want to reset them here,
        to make socket.type be set to the same value on all platforms.
@@ -881,9 +882,11 @@ init_sockobject(PySocketSockObject *s,
        0xF is SOCK_TYPE_MASK in include/linux/net.h which on Linux
        is used to mask off SOCK_NONBLOCK and SOCK_CLOEXEC.
     */
-    s->sock_type = type & ~(SOCK_NONBLOCK | SOCK_CLOEXEC);
-#else
-    s->sock_type = type;
+#ifdef SOCK_NONBLOCK
+    s->sock_type = s->sock_type & ~SOCK_NONBLOCK;
+#endif
+#ifdef SOCK_CLOEXEC
+    s->sock_type = s->sock_type & ~SOCK_CLOEXEC;
 #endif
 
     s->sock_proto = proto;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -874,13 +874,10 @@ init_sockobject(PySocketSockObject *s,
     s->sock_type = type;
 
     /* It's possible to pass SOCK_NONBLOCK and SOCK_CLOEXEC bit flags
-       on Linux as part of socket.type.  We want to reset them here,
+       on some OSes as part of socket.type.  We want to reset them here,
        to make socket.type be set to the same value on all platforms.
        Otherwise, simple code like 'if sock.type == SOCK_STREAM' is
        not portable.
-
-       0xF is SOCK_TYPE_MASK in include/linux/net.h which on Linux
-       is used to mask off SOCK_NONBLOCK and SOCK_CLOEXEC.
     */
 #ifdef SOCK_NONBLOCK
     s->sock_type = s->sock_type & ~SOCK_NONBLOCK;


### PR DESCRIPTION


<!-- issue-number: bpo-32331 -->
https://bugs.python.org/issue32331
<!-- /issue-number -->
