### PR TITLE
bpo-27169: The __debug__ constant is now optimized out at compile time.

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -337,16 +337,16 @@ class BuiltinTest(unittest.TestCase):
         try:
             assert False
         except AssertionError:
-            return (True, f.__doc__, debug_enabled)
+            return (True, f.__doc__, debug_enabled, __debug__)
         else:
-            return (False, f.__doc__, debug_enabled)
+            return (False, f.__doc__, debug_enabled, __debug__)
         '''
         def f(): """doc"""
-        values = [(-1, __debug__, f.__doc__, __debug__),
-                  (0, True, 'doc', True),
-                  (1, False, 'doc', False),
-                  (2, False, None, False)]
-        for optval, assertval, docstring, debugval in values:
+        values = [(-1, __debug__, f.__doc__, __debug__, __debug__),
+                  (0, True, 'doc', True, True),
+                  (1, False, 'doc', False, False),
+                  (2, False, None, False, False)]
+        for optval, *expected in values:
             # test both direct compilation and compilation via AST
             codeobjs = []
             codeobjs.append(compile(codestr, "<test>", "exec", optimize=optval))
@@ -356,7 +356,7 @@ class BuiltinTest(unittest.TestCase):
                 ns = {}
                 exec(code, ns)
                 rv = ns['f']()
-                self.assertEqual(rv, (assertval, docstring, debugval))
+                self.assertEqual(rv, tuple(expected))
 
     def test_delattr(self):
         sys.spam = 1

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -35,6 +35,7 @@ class TestSpecifics(unittest.TestCase):
         import builtins
         prev = builtins.__debug__
         setattr(builtins, '__debug__', 'sure')
+        self.assertEqual(__debug__, prev)
         setattr(builtins, '__debug__', prev)
 
     def test_argument_handling(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-15-11-50-06.bpo-27169.VO84fQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-15-11-50-06.bpo-27169.VO84fQ.rst
@@ -1,0 +1,2 @@
+The ``__debug__`` constant is now optimized out at compile time. This fixes also
+bpo-22091.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -1332,13 +1332,15 @@ is_const(expr_ty e)
     case Ellipsis_kind:
     case NameConstant_kind:
         return 1;
+    case Name_kind:
+        return _PyUnicode_EqualToASCIIString(e->v.Name.id, "__debug__");
     default:
         return 0;
     }
 }
 
 static PyObject *
-get_const_value(expr_ty e)
+get_const_value(struct compiler *c, expr_ty e)
 {
     switch (e->kind) {
     case Constant_kind:
@@ -1353,6 +1355,9 @@ get_const_value(expr_ty e)
         return Py_Ellipsis;
     case NameConstant_kind:
         return e->v.NameConstant.value;
+    case Name_kind:
+        assert(_PyUnicode_EqualToASCIIString(e->v.Name.id, "__debug__"));
+        return c->c_optimize ? Py_False : Py_True;
     default:
         Py_UNREACHABLE();
     }
@@ -3097,6 +3102,11 @@ compiler_nameop(struct compiler *c, identifier name, expr_context_ty ctx)
            !_PyUnicode_EqualToASCIIString(name, "True") &&
            !_PyUnicode_EqualToASCIIString(name, "False"));
 
+    if (ctx == Load && _PyUnicode_EqualToASCIIString(name, "__debug__")) {
+        ADDOP_O(c, LOAD_CONST, c->c_optimize ? Py_False : Py_True, consts);
+        return 1;
+    }
+
     op = 0;
     optype = OP_NAME;
     scope = PyST_GetScope(c->u->u_ste, mangled);
@@ -3360,7 +3370,7 @@ compiler_subdict(struct compiler *c, expr_ty e, Py_ssize_t begin, Py_ssize_t end
             return 0;
         }
         for (i = begin; i < end; i++) {
-            key = get_const_value((expr_ty)asdl_seq_GET(e->v.Dict.keys, i));
+            key = get_const_value(c, (expr_ty)asdl_seq_GET(e->v.Dict.keys, i));
             Py_INCREF(key);
             PyTuple_SET_ITEM(keys, i - begin, key);
         }
@@ -4132,35 +4142,10 @@ compiler_visit_keyword(struct compiler *c, keyword_ty k)
 static int
 expr_constant(struct compiler *c, expr_ty e)
 {
-    const char *id;
-    switch (e->kind) {
-    case Ellipsis_kind:
-        return 1;
-    case Constant_kind:
-        return PyObject_IsTrue(e->v.Constant.value);
-    case Num_kind:
-        return PyObject_IsTrue(e->v.Num.n);
-    case Str_kind:
-        return PyObject_IsTrue(e->v.Str.s);
-    case Name_kind:
-        /* optimize away names that can't be reassigned */
-        id = PyUnicode_AsUTF8(e->v.Name.id);
-        if (id && strcmp(id, "__debug__") == 0)
-            return !c->c_optimize;
-        return -1;
-    case NameConstant_kind: {
-        PyObject *o = e->v.NameConstant.value;
-        if (o == Py_None)
-            return 0;
-        else if (o == Py_True)
-            return 1;
-        else if (o == Py_False)
-            return 0;
+    if (is_const(e)) {
+        return PyObject_IsTrue(get_const_value(c, e));
     }
-    /* fall through */
-    default:
-        return -1;
-    }
+    return -1;
 }
 
 


### PR DESCRIPTION
This fixes also bpo-22091.


<!-- issue-number: bpo-27169 -->
https://bugs.python.org/issue27169
<!-- /issue-number -->
