### PR TITLE
bpo-32294: Fix multiprocessing test_semaphore_tracker()

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4365,7 +4365,7 @@ class TestSemaphoreTracker(unittest.TestCase):
         '''
         r, w = os.pipe()
         p = subprocess.Popen([sys.executable,
-                             '-c', cmd % (w, w)],
+                             '-E', '-c', cmd % (w, w)],
                              pass_fds=[w],
                              stderr=subprocess.PIPE)
         os.close(w)


### PR DESCRIPTION
Run the child process with -E option to ignore the PYTHONWARNINGS
environment variable.

<!-- issue-number: bpo-32294 -->
https://bugs.python.org/issue32294
<!-- /issue-number -->
