### PR TITLE
[3.6] compile.c: Remove unused varible

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5155,7 +5155,6 @@ compute_code_flags(struct compiler *c)
 {
     PySTEntryObject *ste = c->u->u_ste;
     int flags = 0;
-    Py_ssize_t n;
     if (ste->ste_type == FunctionBlock) {
         flags |= CO_NEWLOCALS | CO_OPTIMIZED;
         if (ste->ste_nested)


### PR DESCRIPTION
Fix a compiler warning.
