### PR TITLE
F-strings docs: link to Format Specifiers

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -656,7 +656,8 @@ the final value of the whole string.
 
 Top-level format specifiers may include nested replacement fields.
 These nested fields may include their own conversion fields and
-format specifiers, but may not include more deeply-nested replacement fields.
+:ref:`format specifiers <formatspec>`, but may not include more
+deeply-nested replacement fields.
 
 Formatted string literals may be concatenated, but replacement fields
 cannot be split across literals.


### PR DESCRIPTION
Link to the Format Specification Mini Language section from f-strings' documentation.
