### PR TITLE
bpo-32336: OrderedDict import is no longer needed in argparse

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -83,7 +83,6 @@ __all__ = [
 ]
 
 
-import collections as _collections
 import os as _os
 import re as _re
 import sys as _sys
@@ -1084,7 +1083,7 @@ class _SubParsersAction(Action):
 
         self._prog_prefix = prog
         self._parser_class = parser_class
-        self._name_parser_map = _collections.OrderedDict()
+        self._name_parser_map = {}
         self._choices_actions = []
 
         super(_SubParsersAction, self).__init__(


### PR DESCRIPTION



<!-- issue-number: bpo-32336 -->
https://bugs.python.org/issue32336
<!-- /issue-number -->
