### PR TITLE
bpo-29240: Don't define decode_locale() on macOS

### DIFF
--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -249,6 +249,7 @@ decode_ascii_surrogateescape(const char *arg, size_t *size)
 }
 #endif
 
+#if !defined(__APPLE__) && !defined(__ANDROID__)
 static wchar_t*
 decode_locale(const char* arg, size_t *size)
 {
@@ -364,6 +365,7 @@ oom:
     }
     return NULL;
 }
+#endif
 
 
 /* Decode a byte string from the locale encoding with the
@@ -453,6 +455,7 @@ _Py_EncodeLocaleUTF8(const wchar_t *text, size_t *error_pos)
     return cpath;
 }
 
+#if !defined(__APPLE__) && !defined(__ANDROID__)
 static char*
 encode_locale(const wchar_t *text, size_t *error_pos)
 {
@@ -516,6 +519,7 @@ encode_locale(const wchar_t *text, size_t *error_pos)
     }
     return result;
 }
+#endif
 
 /* Encode a wide character string to the locale encoding with the
    surrogateescape error handler: surrogate characters in the range


### PR DESCRIPTION
Don't define decode_locale() nor encode_locale() on macOS or Android.

<!-- issue-number: bpo-29240 -->
https://bugs.python.org/issue29240
<!-- /issue-number -->
