### PR TITLE
[2.7] bpo-30416: Protect the optimizer during constant folding. (GH-4865)

### DIFF
--- a/Include/intobject.h
+++ b/Include/intobject.h
@@ -28,7 +28,10 @@ typedef struct {
 PyAPI_DATA(PyTypeObject) PyInt_Type;
 
 #define PyInt_Check(op) \
-		 PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_INT_SUBCLASS)
+                 PyType_FastSubclass(Py_TYPE(op), Py_TPFLAGS_INT_SUBCLASS)
+#define _PyAnyInt_Check(op) \
+                 PyType_FastSubclass(Py_TYPE(op), \
+                    Py_TPFLAGS_INT_SUBCLASS|Py_TPFLAGS_LONG_SUBCLASS)
 #define PyInt_CheckExact(op) (Py_TYPE(op) == &PyInt_Type)
 
 PyAPI_FUNC(PyObject *) PyInt_FromString(char*, char**, int);

--- a/Lib/test/test_peepholer.py
+++ b/Lib/test/test_peepholer.py
@@ -125,7 +125,7 @@ class TestTranforms(unittest.TestCase):
             ('a = 13 | 7', '(15)'),                 # binary or
             ):
             asm = dis_single(line)
-            self.assertIn(elem, asm, asm)
+            self.assertIn(elem, asm, (elem, asm))
             self.assertNotIn('BINARY_', asm)
 
         # Verify that unfoldables are skipped
@@ -134,8 +134,24 @@ class TestTranforms(unittest.TestCase):
         self.assertIn("('b')", asm)
 
         # Verify that large sequences do not result from folding
-        asm = dis_single('a="x"*1000')
+        asm = dis_single('a="x"*10000')
+        self.assertIn('(10000)', asm)
+        self.assertNotIn('(%r)' % ("x"*10000), asm)
+        asm = dis_single('a="x"*10000L')
+        self.assertIn('(10000L)', asm)
+        self.assertNotIn('(%r)' % ("x"*10000L), asm)
+        asm = dis_single('a=1<<1000')
         self.assertIn('(1000)', asm)
+        self.assertNotIn('(%r)' % (1<<1000), asm)
+        asm = dis_single('a=1<<1000L')
+        self.assertIn('(1000L)', asm)
+        self.assertNotIn('(%r)' % (1<<1000L), asm)
+        asm = dis_single('a=2**1000')
+        self.assertIn('(1000)', asm)
+        self.assertNotIn('(%r)' % (2**1000), asm)
+        asm = dis_single('a=2**1000L')
+        self.assertIn('(1000L)', asm)
+        self.assertNotIn('(%r)' % (2**1000L), asm)
 
     def test_binary_subscr_on_unicode(self):
         # unicode strings don't get optimized

--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-14-11-48-19.bpo-30416.hlHo_9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-14-11-48-19.bpo-30416.hlHo_9.rst
@@ -1,0 +1,3 @@
+The optimizer is now protected from spending much time doing complex
+calculations and consuming much memory for creating large constants in
+constant folding.


### PR DESCRIPTION
It no longer spends much time doing complex calculations and no longer consumes much memory for creating large constants that will be dropped later.

This fixes also bpo-21074.
(cherry picked from commit b580f4f2bf49fd3b11f2a046911993560c02492a)


<!-- issue-number: bpo-30416 -->
https://bugs.python.org/issue30416
<!-- /issue-number -->
