### PR TITLE
bpo-29084: Exclude C API for OrderedDict from the limited C API.

### DIFF
--- a/Include/odictobject.h
+++ b/Include/odictobject.h
@@ -6,6 +6,7 @@ extern "C" {
 
 
 /* OrderedDict */
+/* This API is optional and mostly redundant. */
 
 #ifndef Py_LIMITED_API
 
@@ -20,10 +21,6 @@ PyAPI_DATA(PyTypeObject) PyODictValues_Type;
 #define PyODict_Check(op) PyObject_TypeCheck(op, &PyODict_Type)
 #define PyODict_CheckExact(op) (Py_TYPE(op) == &PyODict_Type)
 #define PyODict_SIZE(op) PyDict_GET_SIZE((op))
-
-#endif /* Py_LIMITED_API */
-
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03050000
 
 PyAPI_FUNC(PyObject *) PyODict_New(void);
 PyAPI_FUNC(int) PyODict_SetItem(PyObject *od, PyObject *key, PyObject *item);

--- a/Misc/NEWS.d/next/C API/2017-12-16-09-59-35.bpo-29084.ZGJ-LJ.rst
+++ b/Misc/NEWS.d/next/C API/2017-12-16-09-59-35.bpo-29084.ZGJ-LJ.rst
@@ -1,0 +1,2 @@
+Undocumented C API for OrderedDict has been excluded from the limited C API.
+It was added by mistake and actually never worked in the limited C API.


### PR DESCRIPTION


<!-- issue-number: bpo-29084 -->
https://bugs.python.org/issue29084
<!-- /issue-number -->
