### PR TITLE
gh-76135: Reuse oldkeys if oldkeys->dk_size == newsize. (alt)

### DIFF
--- a/Include/dictobject.h
+++ b/Include/dictobject.h
@@ -26,6 +26,9 @@ typedef struct {
     /* Number of items in the dictionary */
     Py_ssize_t ma_used;
 
+    /* Whether OrderedDict's cache is synchronized with dict table */
+    unsigned int ma_clean: 1;
+
     /* Dictionary version: globally unique, value change each time
        the dictionary is modified */
     uint64_t ma_version_tag;

--- a/Include/dictobject.h
+++ b/Include/dictobject.h
@@ -26,9 +26,6 @@ typedef struct {
     /* Number of items in the dictionary */
     Py_ssize_t ma_used;
 
-    /* Whether OrderedDict's cache is synchronized with dict table */
-    unsigned int ma_clean: 1;
-
     /* Dictionary version: globally unique, value change each time
        the dictionary is modified */
     uint64_t ma_version_tag;

--- a/Include/dictobject.h
+++ b/Include/dictobject.h
@@ -120,7 +120,7 @@ PyAPI_FUNC(PyObject *) _PyDict_Pop(PyObject *, PyObject *, PyObject *);
 PyObject *_PyDict_Pop_KnownHash(PyObject *, PyObject *, Py_hash_t, PyObject *);
 PyObject *_PyDict_FromKeys(PyObject *, PyObject *, PyObject *);
 #define _PyDict_HasSplitTable(d) ((d)->ma_values != NULL)
-
+PyAPI_FUNC(Py_ssize_t) _PyDict_GetIndex(PyDictObject *, PyObject *, Py_hash_t);
 PyAPI_FUNC(int) PyDict_ClearFreeList(void);
 #endif
 

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -676,7 +676,7 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
         size = support.calcobjsize
         check = self.check_sizeof
 
-        basicsize = size('nQ2P' + '3Pn2P') + calcsize('2nP2nI0P')
+        basicsize = size('nQ2P' + '3Pn2P') + calcsize('4nI0P')
 
         entrysize = calcsize('n2P')
         p = calcsize('P')

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -676,7 +676,7 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
         size = support.calcobjsize
         check = self.check_sizeof
 
-        basicsize = size('nQ2P' + '3Pn2P') + calcsize('2nP2ni0P')
+        basicsize = size('nQ2P' + '3Pn2P') + calcsize('2nP2nI0P')
 
         entrysize = calcsize('n2P')
         p = calcsize('P')

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -676,7 +676,7 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
         size = support.calcobjsize
         check = self.check_sizeof
 
-        basicsize = size('niQ2P' + '3Pn2P') + calcsize('2nP2n')
+        basicsize = size('nQ2P' + '3Pn2P') + calcsize('2nP2ni0P')
 
         entrysize = calcsize('n2P')
         p = calcsize('P')

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -676,7 +676,7 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
         size = support.calcobjsize
         check = self.check_sizeof
 
-        basicsize = size('nQ2P' + '3PnPn2P') + calcsize('2nP2n')
+        basicsize = size('niQ2P' + '3Pn2P') + calcsize('2nP2n')
 
         entrysize = calcsize('n2P')
         p = calcsize('P')

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -965,9 +965,9 @@ class SizeofTest(unittest.TestCase):
         # method-wrapper (descriptor object)
         check({}.__iter__, size('2P'))
         # dict
-        check({}, size('nQ2P') + calcsize('2nP2ni0P') + 8 + (8*2//3)*calcsize('n2P'))
+        check({}, size('nQ2P') + calcsize('2nP2nI0P') + 8 + (8*2//3)*calcsize('n2P'))
         longdict = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8}
-        check(longdict, size('nQ2P') + calcsize('2nP2ni0P') + 16 + (16*2//3)*calcsize('n2P'))
+        check(longdict, size('nQ2P') + calcsize('2nP2nI0P') + 16 + (16*2//3)*calcsize('n2P'))
         # dictionary-keyview
         check({}.keys(), size('P'))
         # dictionary-valueview
@@ -1128,13 +1128,13 @@ class SizeofTest(unittest.TestCase):
                   '4P')
         class newstyleclass(object): pass
         # Separate block for PyDictKeysObject with 8 keys and 5 entries
-        check(newstyleclass, s + calcsize("2nP2ni0P") + 8 + 5*calcsize("n2P"))
+        check(newstyleclass, s + calcsize("2nP2nI0P") + 8 + 5*calcsize("n2P"))
         # dict with shared keys
         check(newstyleclass().__dict__, size('nQ2P') + 5*self.P)
         o = newstyleclass()
         o.a = o.b = o.c = o.d = o.e = o.f = o.g = o.h = 1
         # Separate block for PyDictKeysObject with 16 keys and 10 entries
-        check(newstyleclass, s + calcsize("2nP2ni0P") + 16 + 10*calcsize("n2P"))
+        check(newstyleclass, s + calcsize("2nP2nI0P") + 16 + 10*calcsize("n2P"))
         # dict with shared keys
         check(newstyleclass().__dict__, size('nQ2P') + 10*self.P)
         # unicode

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -965,9 +965,9 @@ class SizeofTest(unittest.TestCase):
         # method-wrapper (descriptor object)
         check({}.__iter__, size('2P'))
         # dict
-        check({}, size('nQ2P') + calcsize('2nP2nI0P') + 8 + (8*2//3)*calcsize('n2P'))
+        check({}, size('nQ2P') + calcsize('4nI0P') + 8 + (8*2//3)*calcsize('n2P'))
         longdict = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8}
-        check(longdict, size('nQ2P') + calcsize('2nP2nI0P') + 16 + (16*2//3)*calcsize('n2P'))
+        check(longdict, size('nQ2P') + calcsize('4nI0P') + 16 + (16*2//3)*calcsize('n2P'))
         # dictionary-keyview
         check({}.keys(), size('P'))
         # dictionary-valueview
@@ -1128,13 +1128,13 @@ class SizeofTest(unittest.TestCase):
                   '4P')
         class newstyleclass(object): pass
         # Separate block for PyDictKeysObject with 8 keys and 5 entries
-        check(newstyleclass, s + calcsize("2nP2nI0P") + 8 + 5*calcsize("n2P"))
+        check(newstyleclass, s + calcsize("4nI0P") + 8 + 5*calcsize("n2P"))
         # dict with shared keys
         check(newstyleclass().__dict__, size('nQ2P') + 5*self.P)
         o = newstyleclass()
         o.a = o.b = o.c = o.d = o.e = o.f = o.g = o.h = 1
         # Separate block for PyDictKeysObject with 16 keys and 10 entries
-        check(newstyleclass, s + calcsize("2nP2nI0P") + 16 + 10*calcsize("n2P"))
+        check(newstyleclass, s + calcsize("4nI0P") + 16 + 10*calcsize("n2P"))
         # dict with shared keys
         check(newstyleclass().__dict__, size('nQ2P') + 10*self.P)
         # unicode

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -965,9 +965,9 @@ class SizeofTest(unittest.TestCase):
         # method-wrapper (descriptor object)
         check({}.__iter__, size('2P'))
         # dict
-        check({}, size('niQ2P') + calcsize('2nP2n') + 8 + (8*2//3)*calcsize('n2P'))
+        check({}, size('nQ2P') + calcsize('2nP2ni0P') + 8 + (8*2//3)*calcsize('n2P'))
         longdict = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8}
-        check(longdict, size('niQ2P') + calcsize('2nP2n') + 16 + (16*2//3)*calcsize('n2P'))
+        check(longdict, size('nQ2P') + calcsize('2nP2ni0P') + 16 + (16*2//3)*calcsize('n2P'))
         # dictionary-keyview
         check({}.keys(), size('P'))
         # dictionary-valueview
@@ -1128,15 +1128,15 @@ class SizeofTest(unittest.TestCase):
                   '4P')
         class newstyleclass(object): pass
         # Separate block for PyDictKeysObject with 8 keys and 5 entries
-        check(newstyleclass, s + calcsize("2nP2n0P") + 8 + 5*calcsize("n2P"))
+        check(newstyleclass, s + calcsize("2nP2ni0P") + 8 + 5*calcsize("n2P"))
         # dict with shared keys
-        check(newstyleclass().__dict__, size('niQ2P') + 5*self.P)
+        check(newstyleclass().__dict__, size('nQ2P') + 5*self.P)
         o = newstyleclass()
         o.a = o.b = o.c = o.d = o.e = o.f = o.g = o.h = 1
         # Separate block for PyDictKeysObject with 16 keys and 10 entries
-        check(newstyleclass, s + calcsize("2nP2n0P") + 16 + 10*calcsize("n2P"))
+        check(newstyleclass, s + calcsize("2nP2ni0P") + 16 + 10*calcsize("n2P"))
         # dict with shared keys
-        check(newstyleclass().__dict__, size('niQ2P') + 10*self.P)
+        check(newstyleclass().__dict__, size('nQ2P') + 10*self.P)
         # unicode
         # each tuple contains a string and its expected character size
         # don't put any static strings here, as they may contain

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -965,9 +965,9 @@ class SizeofTest(unittest.TestCase):
         # method-wrapper (descriptor object)
         check({}.__iter__, size('2P'))
         # dict
-        check({}, size('nQ2P') + calcsize('2nP2n') + 8 + (8*2//3)*calcsize('n2P'))
+        check({}, size('niQ2P') + calcsize('2nP2n') + 8 + (8*2//3)*calcsize('n2P'))
         longdict = {1:1, 2:2, 3:3, 4:4, 5:5, 6:6, 7:7, 8:8}
-        check(longdict, size('nQ2P') + calcsize('2nP2n') + 16 + (16*2//3)*calcsize('n2P'))
+        check(longdict, size('niQ2P') + calcsize('2nP2n') + 16 + (16*2//3)*calcsize('n2P'))
         # dictionary-keyview
         check({}.keys(), size('P'))
         # dictionary-valueview
@@ -1130,13 +1130,13 @@ class SizeofTest(unittest.TestCase):
         # Separate block for PyDictKeysObject with 8 keys and 5 entries
         check(newstyleclass, s + calcsize("2nP2n0P") + 8 + 5*calcsize("n2P"))
         # dict with shared keys
-        check(newstyleclass().__dict__, size('nQ2P') + 5*self.P)
+        check(newstyleclass().__dict__, size('niQ2P') + 5*self.P)
         o = newstyleclass()
         o.a = o.b = o.c = o.d = o.e = o.f = o.g = o.h = 1
         # Separate block for PyDictKeysObject with 16 keys and 10 entries
         check(newstyleclass, s + calcsize("2nP2n0P") + 16 + 10*calcsize("n2P"))
         # dict with shared keys
-        check(newstyleclass().__dict__, size('nQ2P') + 10*self.P)
+        check(newstyleclass().__dict__, size('niQ2P') + 10*self.P)
         # unicode
         # each tuple contains a string and its expected character size
         # don't put any static strings here, as they may contain

--- a/Objects/dict-common.h
+++ b/Objects/dict-common.h
@@ -8,12 +8,6 @@ typedef struct {
     PyObject *me_value; /* This field is only meaningful for combined tables */
 } PyDictKeyEntry;
 
-/* dict_lookup_func() returns index of entry which can be used like DK_ENTRIES(dk)[index].
- * -1 when no entry found, -3 when compare raises error.
- */
-typedef Py_ssize_t (*dict_lookup_func)
-    (PyDictObject *mp, PyObject *key, Py_hash_t hash, PyObject **value_addr);
-
 #define DKIX_EMPTY (-1)
 #define DKIX_DUMMY (-2)  /* Used internally */
 #define DKIX_ERROR (-3)
@@ -24,6 +18,12 @@ struct _dictkeysobject {
 
     /* Size of the hash table (dk_indices). It must be a power of 2. */
     Py_ssize_t dk_size;
+
+    /* Number of usable entries in dk_entries. */
+    Py_ssize_t dk_usable;
+
+    /* Number of used entries in dk_entries. */
+    Py_ssize_t dk_nentries;
 
     /* Function to lookup in the hash table (dk_indices):
 
@@ -38,16 +38,10 @@ struct _dictkeysobject {
          specialized for Unicode string keys that cannot be the <dummy> value.
 
        - lookdict_split(): Version of lookdict() for split tables. */
-    dict_lookup_func dk_lookup;
-
-    /* Number of usable entries in dk_entries. */
-    Py_ssize_t dk_usable;
-
-    /* Number of used entries in dk_entries. */
-    Py_ssize_t dk_nentries;
+    unsigned int dk_lookup: 8;
 
     /* Whether OrderedDict's cache is synchronized with dict table */
-    unsigned int dk_clean;
+    unsigned int dk_clean: 1;
 
     /* Actual hash table of dk_size entries. It holds indices in dk_entries,
        or DKIX_EMPTY(-1) or DKIX_DUMMY(-2).

--- a/Objects/dict-common.h
+++ b/Objects/dict-common.h
@@ -46,6 +46,9 @@ struct _dictkeysobject {
     /* Number of used entries in dk_entries. */
     Py_ssize_t dk_nentries;
 
+    /* Whether OrderedDict's cache is synchronized with dict table */
+    unsigned int dk_clean;
+
     /* Actual hash table of dk_size entries. It holds indices in dk_entries,
        or DKIX_EMPTY(-1) or DKIX_DUMMY(-2).
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -417,11 +417,12 @@ dk_set_index(PyDictKeysObject *keys, Py_ssize_t i, Py_ssize_t ix)
  * (which cannot fail and thus can do no allocation).
  */
 static PyDictKeysObject empty_keys_struct = {
-        1, /* dk_refcnt */
-        1, /* dk_size */
-        lookdict_split, /* dk_lookup */
-        0, /* dk_usable (immutable) */
-        0, /* dk_nentries */
+        .dk_refcnt = 1,
+        .dk_size = 1,
+        .dk_lookup = lookdict_split,
+        .dk_usable = 0,
+        .dk_nentries = 0,
+        .dk_clean = 0,
         .dk_indices = { .as_1 = {DKIX_EMPTY, DKIX_EMPTY, DKIX_EMPTY, DKIX_EMPTY,
                                  DKIX_EMPTY, DKIX_EMPTY, DKIX_EMPTY, DKIX_EMPTY}},
 };

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -490,12 +490,9 @@ struct _odictobject {
     PyDictObject od_dict;        /* the underlying dict */
     _ODictNode *od_first;        /* first node in the linked list, if any */
     _ODictNode *od_last;         /* last node in the linked list, if any */
-    /* od_fast_nodes, od_fast_nodes_size and od_resize_sentinel are managed
-     * by _odict_resize().
-     * Note that we rely on implementation details of dict for both. */
-    _ODictNode **od_fast_nodes;  /* hash table that mirrors the dict table */
-    Py_ssize_t od_fast_nodes_size;
-    void *od_resize_sentinel;    /* changes if odict should be resized */
+    /* od_fast_nodes is managed by _odict_resize().
+     * Note that we rely on implementation details of dict for it. */
+    _ODictNode **od_fast_nodes;  /* table that mirrors the dict table */
 
     size_t od_state;             /* incremented whenever the LL changes */
     PyObject *od_inst_dict;      /* OrderedDict().__dict__ */
@@ -587,8 +584,7 @@ _odict_resize(PyODictObject *od) {
     /* Replace the old fast nodes table. */
     _odict_free_fast_nodes(od);
     od->od_fast_nodes = fast_nodes;
-    od->od_fast_nodes_size = size;
-    od->od_resize_sentinel = ((PyDictObject *)od)->ma_keys;
+    ((PyDictObject *)od)->ma_clean = 1;
     return 0;
 }
 
@@ -596,14 +592,8 @@ _odict_resize(PyODictObject *od) {
 static Py_ssize_t
 _odict_get_index(PyODictObject *od, PyObject *key, Py_hash_t hash)
 {
-    PyDictKeysObject *keys;
-
-    assert(key != NULL);
-    keys = ((PyDictObject *)od)->ma_keys;
-
     /* Ensure od_fast_nodes and dk_entries are in sync. */
-    if (od->od_resize_sentinel != keys ||
-        od->od_fast_nodes_size != keys->dk_size) {
+    if (!((PyDictObject *)od)->ma_clean) {
         int resize_res = _odict_resize(od);
         if (resize_res < 0)
             return -1;

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -584,7 +584,7 @@ _odict_resize(PyODictObject *od) {
     /* Replace the old fast nodes table. */
     _odict_free_fast_nodes(od);
     od->od_fast_nodes = fast_nodes;
-    ((PyDictObject *)od)->ma_clean = 1;
+    ((PyDictObject *)od)->ma_keys->dk_clean = 1;
     return 0;
 }
 
@@ -593,7 +593,7 @@ static Py_ssize_t
 _odict_get_index(PyODictObject *od, PyObject *key, Py_hash_t hash)
 {
     /* Ensure od_fast_nodes and dk_entries are in sync. */
-    if (!((PyDictObject *)od)->ma_clean) {
+    if (!((PyDictObject *)od)->ma_keys->dk_clean) {
         int resize_res = _odict_resize(od);
         if (resize_res < 0)
             return -1;


### PR DESCRIPTION
This is an alternate to #4292. It makes `dk_lookup` an index instead of a function pointer.

<!-- issue-number: bpo-31954 -->
https://bugs.python.org/issue31954
<!-- /issue-number -->

<!-- gh-issue-number: gh-76135 -->
* Issue: gh-76135
<!-- /gh-issue-number -->
