### PR TITLE
bpo-32339: Make csv.DictReader returning regular dict instead of OrderedDict.

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -149,14 +149,14 @@ The :mod:`csv` module defines the following classes:
 .. class:: DictReader(f, fieldnames=None, restkey=None, restval=None, \
                       dialect='excel', *args, **kwds)
 
-   Create an object that operates like a regular reader but maps the
-   information in each row to an :mod:`OrderedDict <collections.OrderedDict>`
-   whose keys are given by the optional *fieldnames* parameter.
+   Create an object which operates like a regular reader but maps the
+   information read into a dict whose keys are given by the optional
+   *fieldnames* parameter.
 
    The *fieldnames* parameter is a :term:`sequence`.  If *fieldnames* is
    omitted, the values in the first row of file *f* will be used as the
-   fieldnames.  Regardless of how the fieldnames are determined, the ordered
-   dictionary preserves their original ordering.
+   fieldnames.  Regardless of how the fieldnames are determined, the dictionary
+   preserves their original ordering.
 
    If a row has more fields than fieldnames, the remaining data is put in a
    list and stored with the fieldname specified by *restkey* (which defaults
@@ -166,8 +166,9 @@ The :mod:`csv` module defines the following classes:
    All other optional or keyword arguments are passed to the underlying
    :class:`reader` instance.
 
-   .. versionchanged:: 3.6
-      Returned rows are now of type :class:`OrderedDict`.
+   .. versionchanged:: 3.7
+      Returned rows are now of type :class:`dict`, which guaranteed to retain
+      insertion order in Python3.7.
 
    A short usage example::
 
@@ -181,7 +182,7 @@ The :mod:`csv` module defines the following classes:
        John Cleese
 
        >>> print(row)
-       OrderedDict([('first_name', 'John'), ('last_name', 'Cleese')])
+       {'first_name': 'John', 'last_name': 'Cleese'}
 
 
 .. class:: DictWriter(f, fieldnames, restval='', extrasaction='raise', \

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -11,7 +11,6 @@ from _csv import Error, __version__, writer, reader, register_dialect, \
                  __doc__
 from _csv import Dialect as _Dialect
 
-from collections import OrderedDict
 from io import StringIO
 
 __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
@@ -117,7 +116,7 @@ class DictReader:
         # values
         while row == []:
             row = next(self.reader)
-        d = OrderedDict(zip(self.fieldnames, row))
+        d = dict(zip(self.fieldnames, row))
         lf = len(self.fieldnames)
         lr = len(row)
         if lf < lr:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1788,3 +1788,4 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
+Shang Hui

--- a/Misc/NEWS.d/next/Library/2017-12-16-21-50-03.bpo-32339.JQHdWv.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-16-21-50-03.bpo-32339.JQHdWv.rst
@@ -1,0 +1,2 @@
+Make ``csv.DictReader`` returning regular ``dict`` instead of
+``OrderedDict``.


### PR DESCRIPTION
<!-- issue-number: bpo-32339 -->
https://bugs.python.org/issue32339
<!-- /issue-number -->
