### PR TITLE
bpo-32351: Use fastpath in asyncio.sleep if delay<0

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -503,7 +503,7 @@ def __sleep0():
 
 async def sleep(delay, result=None, *, loop=None):
     """Coroutine that completes after a given time (in seconds)."""
-    if delay == 0:
+    if delay <= 0:
         await __sleep0()
         return result
 

--- a/Misc/NEWS.d/next/Library/2017-12-17-14-23-23.bpo-32351.95fh2K.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-17-14-23-23.bpo-32351.95fh2K.rst
@@ -1,0 +1,1 @@
+Use fastpath in asyncio.sleep if delay<0 (2x boost)


### PR DESCRIPTION
Currently asyncio.sleep schedules a callback execution by `loop.call_later()` call, which has the same behavior but 2x slower.

<!-- issue-number: bpo-32351 -->
https://bugs.python.org/issue32351
<!-- /issue-number -->
