### PR TITLE
bpo-32365: Fix a reference leak when compile __debug__.

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3094,10 +3094,6 @@ compiler_nameop(struct compiler *c, identifier name, expr_context_ty ctx)
     PyObject *mangled;
     /* XXX AugStore isn't used anywhere! */
 
-    mangled = _Py_Mangle(c->u->u_private, name);
-    if (!mangled)
-        return 0;
-
     assert(!_PyUnicode_EqualToASCIIString(name, "None") &&
            !_PyUnicode_EqualToASCIIString(name, "True") &&
            !_PyUnicode_EqualToASCIIString(name, "False"));
@@ -3106,6 +3102,10 @@ compiler_nameop(struct compiler *c, identifier name, expr_context_ty ctx)
         ADDOP_O(c, LOAD_CONST, c->c_optimize ? Py_False : Py_True, consts);
         return 1;
     }
+
+    mangled = _Py_Mangle(c->u->u_private, name);
+    if (!mangled)
+        return 0;
 
     op = 0;
     optype = OP_NAME;


### PR DESCRIPTION
It was introduced in bpo-27169.


<!-- issue-number: bpo-32365 -->
https://bugs.python.org/issue32365
<!-- /issue-number -->
