### PR TITLE
bpo-32030: Fix compilation on FreeBSD, #include <fenv.h>

### DIFF
--- a/Modules/main.c
+++ b/Modules/main.c
@@ -9,23 +9,27 @@
 #include <locale.h>
 
 #if defined(MS_WINDOWS) || defined(__CYGWIN__)
-#include <windows.h>
-#ifdef HAVE_IO_H
-#include <io.h>
-#endif
-#ifdef HAVE_FCNTL_H
-#include <fcntl.h>
-#endif
+#  include <windows.h>
+#  ifdef HAVE_IO_H
+#    include <io.h>
+#  endif
+#  ifdef HAVE_FCNTL_H
+#    include <fcntl.h>
+#  endif
 #endif
 
 #ifdef _MSC_VER
-#include <crtdbg.h>
+#  include <crtdbg.h>
+#endif
+
+#ifdef __FreeBSD__
+#  include <fenv.h>
 #endif
 
 #if defined(MS_WINDOWS)
-#define PYTHONHOMEHELP "<prefix>\\python{major}{minor}"
+#  define PYTHONHOMEHELP "<prefix>\\python{major}{minor}"
 #else
-#define PYTHONHOMEHELP "<prefix>/lib/pythonX.X"
+#  define PYTHONHOMEHELP "<prefix>/lib/pythonX.X"
 #endif
 
 #define COPYRIGHT \

--- a/Programs/python.c
+++ b/Programs/python.c
@@ -1,12 +1,6 @@
 /* Minimal main program -- everything is loaded from the library */
 
 #include "Python.h"
-#include "internal/pystate.h"
-#include <locale.h>
-
-#ifdef __FreeBSD__
-#include <fenv.h>
-#endif
 
 #ifdef MS_WINDOWS
 int
@@ -15,8 +9,6 @@ wmain(int argc, wchar_t **argv)
     return Py_Main(argc, argv);
 }
 #else
-
-
 int
 main(int argc, char **argv)
 {


### PR DESCRIPTION
* main.c: add missing #include <fenv.h> on FreeBSD
* indent also other #ifdef in main.c
* cleanup Programs/python.c

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
