### PR TITLE
bpo-32030: Fix compiler warnings

### DIFF
--- a/Include/warnings.h
+++ b/Include/warnings.h
@@ -7,9 +7,6 @@ extern "C" {
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject*) _PyWarnings_Init(void);
 #endif
-#ifdef Py_BUILD_CORE
-PyAPI_FUNC(PyObject*) _PyWarnings_InitWithConfig(const _PyCoreConfig *config);
-#endif
 
 PyAPI_FUNC(int) PyErr_WarnEx(
     PyObject *category,

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1151,27 +1151,6 @@ pymain_get_program_name(_PyMain *pymain)
 }
 
 
-/* Initialize the main interpreter.
- *
- * Replaces previous call to Py_Initialize()
- *
- * Return 0 on success.
- * Set pymain->err and return -1 on error.
- */
-static int
-pymain_init_main_interpreter(_PyMain *pymain)
-{
-    _PyInitError err;
-
-    err = _Py_InitializeMainInterpreter(&pymain->config);
-    if (_Py_INIT_FAILED(err)) {
-        pymain->err = err;
-        return -1;
-    }
-    return 0;
-}
-
-
 static void
 pymain_header(_PyMain *pymain)
 {
@@ -2357,7 +2336,9 @@ pymain_init_python_main(_PyMain *pymain)
         return -1;
     }
 
-    if (pymain_init_main_interpreter(pymain)) {
+    err = _Py_InitializeMainInterpreter(&pymain->config);
+    if (_Py_INIT_FAILED(err)) {
+        pymain->err = err;
         return -1;
     }
 

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1173,7 +1173,7 @@ create_filter(PyObject *category, _Py_Identifier *id)
 
 
 static PyObject *
-init_filters(const _PyCoreConfig *config)
+init_filters(void)
 {
 #ifdef Py_DEBUG
     /* Py_DEBUG builds show all warnings by default */
@@ -1218,8 +1218,8 @@ static struct PyModuleDef warningsmodule = {
 };
 
 
-PyObject*
-_PyWarnings_InitWithConfig(const _PyCoreConfig *config)
+PyMODINIT_FUNC
+_PyWarnings_Init(void)
 {
     PyObject *m;
 
@@ -1228,7 +1228,7 @@ _PyWarnings_InitWithConfig(const _PyCoreConfig *config)
         return NULL;
 
     if (_PyRuntime.warnings.filters == NULL) {
-        _PyRuntime.warnings.filters = init_filters(config);
+        _PyRuntime.warnings.filters = init_filters();
         if (_PyRuntime.warnings.filters == NULL)
             return NULL;
     }
@@ -1258,13 +1258,4 @@ _PyWarnings_InitWithConfig(const _PyCoreConfig *config)
 
     _PyRuntime.warnings.filters_version = 0;
     return m;
-}
-
-
-PyMODINIT_FUNC
-_PyWarnings_Init(void)
-{
-    PyInterpreterState *interp = PyThreadState_GET()->interp;
-    const _PyCoreConfig *config = &interp->core_config;
-    return _PyWarnings_InitWithConfig(config);
 }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -737,7 +737,7 @@ _Py_InitializeCore(const _PyCoreConfig *core_config)
     }
 
     /* Initialize _warnings. */
-    if (_PyWarnings_InitWithConfig(&interp->core_config) == NULL) {
+    if (_PyWarnings_Init() == NULL) {
         return _Py_INIT_ERR("can't initialize warnings");
     }
 
@@ -847,7 +847,9 @@ _Py_InitializeMainInterpreter(const _PyMainInterpreterConfig *config)
     }
 
     /* Initialize warnings. */
-    if (PySys_HasWarnOptions()) {
+    if (interp->config.warnoptions != NULL &&
+        PyList_Size(interp->config.warnoptions) > 0)
+    {
         PyObject *warnings_module = PyImport_ImportModule("warnings");
         if (warnings_module == NULL) {
             fprintf(stderr, "'import warnings' failed; traceback:\n");
@@ -1021,9 +1023,15 @@ Py_FinalizeEx(void)
 
     /* Copy the core config, PyInterpreterState_Delete() free
        the core config memory */
+#ifdef Py_REF_DEBUG
     int show_ref_count = interp->core_config.show_ref_count;
+#endif
+#ifdef Py_TRACE_REFS
     int dump_refs = interp->core_config.dump_refs;
+#endif
+#ifdef WITH_PYMALLOC
     int malloc_stats = interp->core_config.malloc_stats;
+#endif
 
     /* Remaining threads (e.g. daemon threads) will automatically exit
        after taking the GIL (in PyEval_RestoreThread()). */


### PR DESCRIPTION
Fix compiler warnings in Py_FinalizeEx(): only define variables if
they are needed, add #ifdef.

Other cleanup changes:

* _PyWarnings_InitWithConfig() is no more needed: call
  _PyWarnings_Init() instead.
* Inline pymain_init_main_interpreter() in its caller. This
  subfunction is no more justifed.

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
