### PR TITLE
Fix GCC warning in _asynciomodule.c

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -3023,7 +3023,7 @@ _asyncio__leave_task_impl(PyObject *module, PyObject *loop, PyObject *task)
 
 
 static void
-module_free_freelists()
+module_free_freelists(void)
 {
     PyObject *next;
     PyObject *current;


### PR DESCRIPTION
`_asynciomodule.c:3026:1: warning: function declaration isn’t a prototype [-Wstrict-prototypes]
 module_free_freelists()`