### PR TITLE
bpo-32378: Skip NPN tests with LibreSSL 2.6.1+

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -29,6 +29,12 @@ ssl = support.import_module("ssl")
 PROTOCOLS = sorted(ssl._PROTOCOL_NAMES)
 HOST = support.HOST
 IS_LIBRESSL = ssl.OPENSSL_VERSION.startswith('LibreSSL')
+if IS_LIBRESSL:
+    LIBRESSL_VERSION = tuple(
+        int(s) for s in ssl.OPENSSL_VERSION.rsplit(' ')[-1].split('.')
+    )
+else:
+    LIBRESSL_VERSION = ()
 IS_OPENSSL_1_1 = not IS_LIBRESSL and ssl.OPENSSL_VERSION_INFO >= (1, 1, 0)
 
 
@@ -3392,6 +3398,8 @@ class ThreadedTests(unittest.TestCase):
                                    sni_name=hostname)
         self.assertIs(stats['client_npn_protocol'], None)
 
+    @unittest.skipIf(IS_LIBRESSL and LIBRESSL_VERSION >= (2, 6, 1),
+                     "LibreSSL 2.6.1+ has broken NPN support")
     @unittest.skipUnless(ssl.HAS_NPN, "NPN support needed for this test")
     def test_npn_protocols(self):
         server_protocols = ['http/1.1', 'spdy/2']

--- a/Misc/NEWS.d/next/Tests/2017-12-19-20-04-23.bpo-32378.oDT53f.rst
+++ b/Misc/NEWS.d/next/Tests/2017-12-19-20-04-23.bpo-32378.oDT53f.rst
@@ -1,0 +1,1 @@
+LibreSSL 2.6.1+ has broken NPN support, skip tests for now.

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -47,7 +47,7 @@ OPENSSL_OLD_VERSIONS = [
 
 OPENSSL_RECENT_VERSIONS = [
      "1.0.2",
-     "1.0.2m",
+     "1.0.2n",
      "1.1.0g",
 ]
 
@@ -57,8 +57,8 @@ LIBRESSL_OLD_VERSIONS = [
 ]
 
 LIBRESSL_RECENT_VERSIONS = [
-    "2.5.3",
     "2.5.5",
+    "2.6.4",
 ]
 
 # store files in ../multissl


### PR DESCRIPTION
LibreSSL 2.6.1 broke NPN support. We can more or less safely skip the
tests. NPN is deprecated and no longer used anyways.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-32378 -->
https://bugs.python.org/issue32378
<!-- /issue-number -->
