### PR TITLE
bpo-32379: Faster MRO computation for single inheritance

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -1783,6 +1783,12 @@ order (MRO) for bases """
             def f(self): return "C"
         class D(B, C):
             pass
+        self.assertEqual(A.mro(), [A, object])
+        self.assertEqual(A.__mro__, (A, object))
+        self.assertEqual(B.mro(), [B, A, object])
+        self.assertEqual(B.__mro__, (B, A, object))
+        self.assertEqual(C.mro(), [C, A, object])
+        self.assertEqual(C.__mro__, (C, A, object))
         self.assertEqual(D.mro(), [D, B, C, A, object])
         self.assertEqual(D.__mro__, (D, B, C, A, object))
         self.assertEqual(D().f(), "C")

--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-19-21-14-41.bpo-32379.B7mOmI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-19-21-14-41.bpo-32379.B7mOmI.rst
@@ -1,0 +1,1 @@
+Make MRO computation faster when a class inherits from a single base.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2015,6 +2015,7 @@ mro_internal(PyTypeObject *type, PyObject **p_old_mro)
     return 1;
 }
 
+
 /* Calculate the best base amongst multiple base classes.
    This is the first one that's on the path to the "solid base". */
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1859,14 +1859,10 @@ type_mro_impl(PyTypeObject *self)
 {
     PyObject *seq;
     seq = mro_implementation(self);
-    if (seq != NULL && PyTuple_CheckExact(seq)) {
-        PyObject *lst = PySequence_List(seq);
-        Py_DECREF(seq);
-        return lst;
+    if (seq != NULL && !PyList_Check(seq)) {
+        Py_SETREF(seq, PySequence_List(seq));
     }
-    else {
-        return seq;
-    }
+    return seq;
 }
 
 static int

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1857,7 +1857,16 @@ static PyObject *
 type_mro_impl(PyTypeObject *self)
 /*[clinic end generated code: output=bffc4a39b5b57027 input=28414f4e156db28d]*/
 {
-    return mro_implementation(self);
+    PyObject *seq;
+    seq = mro_implementation(self);
+    if (seq != NULL && PyTuple_CheckExact(seq)) {
+        PyObject *lst = PySequence_List(seq);
+        Py_DECREF(seq);
+        return lst;
+    }
+    else {
+        return seq;
+    }
 }
 
 static int


### PR DESCRIPTION


<!-- issue-number: bpo-32379 -->
https://bugs.python.org/issue32379
<!-- /issue-number -->
