### PR TITLE
bpo-32030: Cleanup pymain_main()

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -2003,13 +2003,13 @@ exit:
     }
 }
 
-void
+void _Py_NO_RETURN
 Py_FatalError(const char *msg)
 {
     fatal_error(NULL, msg, -1);
 }
 
-void
+void _Py_NO_RETURN
 _Py_FatalInitError(_PyInitError err)
 {
     /* On "user" error: exit with status 1.


### PR DESCRIPTION
* Reorganize pymain_main() to make the code more flat
* Clear configurations before pymain_update_sys_path()
* Mark Py_FatalError() and _Py_FatalInitError() with _Py_NO_RETURN
* Replace _PyMain.run_code variable with a new RUN_CODE() macro

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
