### PR TITLE
bpo-32030: Add _PyCoreConfig.warn_opts

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -54,7 +54,6 @@ PyAPI_FUNC(int) Py_SetStandardStreamEncoding(const char *encoding,
 PyAPI_FUNC(_PyInitError) _Py_InitializeCore(const _PyCoreConfig *);
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
 
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_ReadEnv(_PyCoreConfig *);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *);
 PyAPI_FUNC(void) _PyCoreConfig_Clear(_PyCoreConfig *);
 PyAPI_FUNC(int) _PyCoreConfig_Copy(

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -50,7 +50,14 @@ typedef struct {
 
     int argc;               /* Number of command line arguments,
                                -1 means unset */
-    wchar_t **argv;         /* sys.argv, ignored if argc is negative */
+    wchar_t **argv;         /* Command line arguments */
+    wchar_t *program;       /* argv[0] or "" */
+
+    int nxoption;           /* Number of -X options */
+    wchar_t **xoptions;     /* -X options */
+
+    int nwarnoption;        /* Number of warnings options */
+    wchar_t **warnoptions;  /* Warnings options */
 } _PyCoreConfig;
 
 #define _PyCoreConfig_INIT \

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -107,11 +107,6 @@ pathconfig_global_init(void)
     _PyInitError err;
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    err = _PyCoreConfig_ReadEnv(&config);
-    if (_Py_INIT_FAILED(err)) {
-        goto error;
-    }
-
     err = _PyCoreConfig_Read(&config);
     if (_Py_INIT_FAILED(err)) {
         goto error;

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -882,7 +882,7 @@ _Py_InitializeEx_Private(int install_sigs, int install_importlib)
     core_config._disable_importlib = !install_importlib;
     config.install_signal_handlers = install_sigs;
 
-    err = _PyCoreConfig_ReadEnv(&core_config);
+    err = _PyCoreConfig_Read(&core_config);
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }
@@ -2030,7 +2030,7 @@ void _Py_PyAtExit(void (*func)(PyObject *), PyObject *module)
 {
     PyThreadState *ts;
     PyInterpreterState *is;
-    
+
     ts = PyThreadState_GET();
     is = ts->interp;
 


### PR DESCRIPTION
* Add nxoption, xoptions, nwarn_opt and warn_opts to _PyCoreConfig
* Move filename, command and module from _Py_CommandLineDetails to
  _PyMain
* Remove xoptions from _Py_CommandLineDetails
* Add pymain_cmdline() function
* Add _PyMain.program: argv[0] or ""
* Rename copy_argv() to copy_wstrlist()
* Rename clear_argv() to clear_wstrlist()
* Rename pymain_set_flag_from_env() to pymain_get_env_flag()
* Rename pymain_set_flags_from_env() to pymain_get_env_flags()
* _PyMainInterpreterConfig_Read() now creates the warnoptions from
  _PyCoreConfig.warnoptions

_Py_CommandLineDetails usage is now restricted to pymain_cmdline().

<!-- issue-number: bpo-32030 -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
