### PR TITLE
bpo-32384 fix test.test_generators for other implementations

### DIFF
--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -18,8 +18,8 @@ except ImportError:
 # This tests to make sure that if a SIGINT arrives just before we send into a
 # yield from chain, the KeyboardInterrupt is raised in the innermost
 # generator (see bpo-30039).
-@unittest.skipUnless(_testcapi is not None and hasattr(_testcapi,
-                     "raise_SIGINT_then_send_None"),
+@unittest.skipUnless(_testcapi is not None and
+                     hasattr(_testcapi, "raise_SIGINT_then_send_None"),
                      "needs _testcapi.raise_SIGINT_then_send_None")
 class SignalAndYieldFromTest(unittest.TestCase):
 

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -9,12 +9,18 @@ import inspect
 
 from test import support
 
-_testcapi = support.import_module('_testcapi')
+try:
+    import _testcapi
+except ImportError:
+    _testcapi = None
 
 
 # This tests to make sure that if a SIGINT arrives just before we send into a
 # yield from chain, the KeyboardInterrupt is raised in the innermost
 # generator (see bpo-30039).
+@unittest.skipUnless(_testcapi is not None and hasattr(_testcapi,
+                     "raise_SIGINT_then_send_None"),
+                     "needs _testcapi.raise_SIGINT_then_send_None")
 class SignalAndYieldFromTest(unittest.TestCase):
 
     def generator1(self):


### PR DESCRIPTION
Added guard to the `test.test_generators.SignalAndYieldFromTest` to check the existence of `_testcapi.raise_SIGINT_then_send_None`


<!-- issue-number: bpo-32384 -->
https://bugs.python.org/issue32384
<!-- /issue-number -->
