### PR TITLE
bpo-32326: Update Build projects to version 10.0.16299.0 of the Windows 10 SDK.

### DIFF
--- a/Misc/NEWS.d/next/Windows/2017-12-20-12-48-15.bpo-32326.hIm_oK.rst
+++ b/Misc/NEWS.d/next/Windows/2017-12-20-12-48-15.bpo-32326.hIm_oK.rst
@@ -1,0 +1,1 @@
+Compile with latest Windows 10 SDK on Windows if installed.

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -47,11 +47,10 @@
     <sqlite3Dir>$(ExternalsDir)sqlite-3.21.0.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.0f\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.0f\$(ArchName)\</opensslOutDir>
-    <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
+    <opensslDir>$(ExternalsDir)openssl-1.0.2k\</opensslDir>
+    <opensslIncludeDir>$(opensslDir)include32</opensslIncludeDir>
+    <opensslIncludeDir Condition="'$(ArchName)' == 'amd64'">$(opensslDir)include64</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
-    <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>
     
     <!-- Suffix for all binaries when building for debug -->
     <PyDebugExt Condition="'$(PyDebugExt)' == '' and $(Configuration) == 'Debug'">_d</PyDebugExt>

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -32,13 +32,13 @@
     <PySourcePath Condition="!HasTrailingSlash($(PySourcePath))">$(PySourcePath)\</PySourcePath>
     
     <!-- Directory where build outputs are put -->
-    <BuildPath32 Condition="'$(Py_OutDir)' == ''">$(PySourcePath)PCBuild\win32\</BuildPath32>
+    <BuildPath32 Condition="'$(Py_OutDir)' == ''">$(PySourcePath)PCbuild\win32\</BuildPath32>
     <BuildPath32 Condition="'$(Py_OutDir)' != ''">$(Py_OutDir)\win32\</BuildPath32>
-    <BuildPath64 Condition="'$(Py_OutDir)' == ''">$(PySourcePath)PCBuild\amd64\</BuildPath64>
+    <BuildPath64 Condition="'$(Py_OutDir)' == ''">$(PySourcePath)PCbuild\amd64\</BuildPath64>
     <BuildPath64 Condition="'$(Py_OutDir)' != ''">$(Py_OutDir)\amd64\</BuildPath64>
     <BuildPath Condition="'$(ArchName)' == 'win32'">$(BuildPath32)</BuildPath>
     <BuildPath Condition="'$(ArchName)' == 'amd64'">$(BuildPath64)</BuildPath>
-    <BuildPath Condition="'$(BuildPath)' == ''">$(PySourcePath)PCBuild\$(ArchName)\</BuildPath>
+    <BuildPath Condition="'$(BuildPath)' == ''">$(PySourcePath)PCbuild\$(ArchName)\</BuildPath>
     <BuildPath Condition="!HasTrailingSlash($(BuildPath))">$(BuildPath)\</BuildPath>
     <BuildPath Condition="$(Configuration) == 'PGInstrument'">$(BuildPath)instrumented\</BuildPath>
     
@@ -47,10 +47,11 @@
     <sqlite3Dir>$(ExternalsDir)sqlite-3.21.0.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-    <opensslDir>$(ExternalsDir)openssl-1.0.2k\</opensslDir>
-    <opensslIncludeDir>$(opensslDir)include32</opensslIncludeDir>
-    <opensslIncludeDir Condition="'$(ArchName)' == 'amd64'">$(opensslDir)include64</opensslIncludeDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.0f\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.0f\$(ArchName)\</opensslOutDir>
+    <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
+    <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>
     
     <!-- Suffix for all binaries when building for debug -->
     <PyDebugExt Condition="'$(PyDebugExt)' == '' and $(Configuration) == 'Debug'">_d</PyDebugExt>
@@ -64,7 +65,7 @@
     <!-- Full path of the resulting python.exe binary -->
     <PythonExe Condition="'$(PythonExe)' == ''">$(BuildPath)python$(PyDebugExt).exe</PythonExe>
   </PropertyGroup>
-
+  
   <PropertyGroup Condition="$(DefaultWindowsSDKVersion) == ''">
     <!--
     Attempt to select the latest installed WinSDK. If we don't find any, then we will
@@ -74,12 +75,13 @@
     -->
     <_RegistryVersion>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</_RegistryVersion>
     <_RegistryVersion Condition="$(_RegistryVersion) == ''">$(Registry:HKEY_LOCAL_MACHINE\WOW6432Node\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</_RegistryVersion>
-    <DefaultWindowsSDKVersion>10.0.15063.0</DefaultWindowsSDKVersion>
+    <DefaultWindowsSDKVersion>10.0.16299.0</DefaultWindowsSDKVersion>
+    <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.15063'">10.0.15063.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.14393'">10.0.14393.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.10586'">10.0.10586.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.10240'">10.0.10240.0</DefaultWindowsSDKVersion>
   </PropertyGroup>
-
+  
   <PropertyGroup Condition="'$(OverrideVersion)' == ''">
     <!--
     Read version information from Include\patchlevel.h. The following properties are set:
@@ -115,11 +117,11 @@
     Override the version number when building by specifying OverrideVersion.
     For example:
     
-        PCBuild\build.bat "/p:OverrideVersion=3.5.2a1"
+        PCbuild\build.bat "/p:OverrideVersion=3.5.2a1"
     
     Use the -V option to check your version is valid:
     
-        PCBuild\build.bat -V "/p:OverrideVersion=3.5.2a1"
+        PCbuild\build.bat -V "/p:OverrideVersion=3.5.2a1"
           PythonVersionNumber: 3.5.2
           PythonVersion:       3.5.2a1
           PythonVersionHex:    0x030502A1


### PR DESCRIPTION
This will make python 3.6.x compile when only having the latest version
of the Windows 10 SDK installed.
<!-- issue-number: bpo-32326 -->
https://bugs.python.org/issue32326
<!-- /issue-number -->
