### PR TITLE
bpo-26133: Dont unsubscribe signals in UNIX even loop on interpreter shutdown

### DIFF
--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -56,7 +56,8 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
                 self.remove_signal_handler(sig)
         else:
             warinigs.warn(f"Closing the loop {self} on interpreter shutdown "
-                          f"stage, signal unsubsription is disabled")
+                          f"stage, signal unsubsription is disabled",
+                          stacklevel=2)
 
     def _process_self_data(self, data):
         for signum in data:

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -55,9 +55,9 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
             for sig in list(self._signal_handlers):
                 self.remove_signal_handler(sig)
         else:
-            warinigs.warn(f"Closing the loop {self} on interpreter shutdown "
+            warinigs.warn(f"Closing the loop {self!r} on interpreter shutdown "
                           f"stage, signal unsubsription is disabled",
-                          stacklevel=2)
+                          ResourceWarning)
 
     def _process_self_data(self, data):
         for signum in data:

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -57,7 +57,8 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
         else:
             warinigs.warn(f"Closing the loop {self!r} on interpreter shutdown "
                           f"stage, signal unsubsription is disabled",
-                          ResourceWarning)
+                          ResourceWarning,
+                          source=self)
 
     def _process_self_data(self, data):
         for signum in data:

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -51,8 +51,12 @@ class _UnixSelectorEventLoop(selector_events.BaseSelectorEventLoop):
 
     def close(self):
         super().close()
-        for sig in list(self._signal_handlers):
-            self.remove_signal_handler(sig)
+        if not sys.is_finalizing():
+            for sig in list(self._signal_handlers):
+                self.remove_signal_handler(sig)
+        else:
+            warinigs.warn(f"Closing the loop {self} on interpreter shutdown "
+                          f"stage, signal unsubsription is disabled")
 
     def _process_self_data(self, data):
         for signum in data:

--- a/Misc/NEWS.d/next/Library/2017-12-21-11-08-42.bpo-26133.mt81QV.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-21-11-08-42.bpo-26133.mt81QV.rst
@@ -1,0 +1,1 @@
+Dont unsubscribe signals in asyncio UNIX event loop on interpreter shutdown.

--- a/Misc/NEWS.d/next/Library/2017-12-21-11-08-42.bpo-26133.mt81QV.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-21-11-08-42.bpo-26133.mt81QV.rst
@@ -1,1 +1,1 @@
-Dont unsubscribe signals in asyncio UNIX event loop on interpreter shutdown.
+Don't unsubscribe signals in asyncio UNIX event loop on interpreter shutdown.


### PR DESCRIPTION


<!-- issue-number: bpo-26133 -->
https://bugs.python.org/issue26133
<!-- /issue-number -->
