### PR TITLE
bpo-32243: Use monotonic clock for thread timeouts; more flexibility for very small switch intervals

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -939,7 +939,7 @@ regen-opcode-targets:
 		$(srcdir)/Python/opcode_targets.h.new
 	$(UPDATE_FILE) $(srcdir)/Python/opcode_targets.h $(srcdir)/Python/opcode_targets.h.new
 
-Python/ceval.o: $(srcdir)/Python/opcode_targets.h $(srcdir)/Python/ceval_gil.h
+Python/ceval.o: $(srcdir)/Python/opcode_targets.h $(srcdir)/Python/ceval_gil.h $(srcdir)/Python/condvar.h
 
 Python/frozen.o: $(srcdir)/Python/importlib.h $(srcdir)/Python/importlib_external.h \
 		$(srcdir)/Python/importlib_zipimport.h
@@ -1838,7 +1838,7 @@ patchcheck: @DEF_MAKE_RULE@
 
 # Dependencies
 
-Python/thread.o: @THREADHEADERS@
+Python/thread.o: @THREADHEADERS@ $(srcdir)/Python/condvar.h
 
 # Declare targets that aren't real files
 .PHONY: all build_all sharedmods check-clean-src oldsharedmods test quicktest

--- a/Python/condvar.h
+++ b/Python/condvar.h
@@ -62,7 +62,11 @@
 #define PyCOND_BROADCAST(cond)  pthread_cond_broadcast(cond)
 #define PyCOND_WAIT(cond, mut)  pthread_cond_wait((cond), (mut))
 
+#if HAVE_PTHREAD_CONDATTR_SETCLOCK
 #define MONOTONIC
+#else
+#undef MONOTONIC
+#endif
 
 Py_LOCAL_INLINE(int)
 PyCOND_INIT(PyCOND_T *cond)

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -74,8 +74,12 @@
      defined(HAVE_SEM_TIMEDWAIT))
 #  define USE_SEMAPHORES
 #else
-#  define MONOTONIC
 #  undef USE_SEMAPHORES
+#  if HAVE_PTHREAD_CONDATTR_SETCLOCK
+#    define MONOTONIC
+#  else
+#    undef MONOTONIC
+#  endif
 #endif
 
 

--- a/configure
+++ b/configure
@@ -10878,12 +10878,13 @@ $as_echo "#define HAVE_BROKEN_PTHREAD_SIGMASK 1" >>confdefs.h
 fi
 done
 
-      for ac_func in pthread_getcpuclockid
+      for ac_func in pthread_getcpuclockid pthread_condattr_setclock
 do :
-  ac_fn_c_check_func "$LINENO" "pthread_getcpuclockid" "ac_cv_func_pthread_getcpuclockid"
-if test "x$ac_cv_func_pthread_getcpuclockid" = xyes; then :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
   cat >>confdefs.h <<_ACEOF
-#define HAVE_PTHREAD_GETCPUCLOCKID 1
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
 _ACEOF
 
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -3157,7 +3157,7 @@ if test "$posix_threads" = "yes"; then
             [Define if pthread_sigmask() does not work on your system.])
             ;;
         esac])
-      AC_CHECK_FUNCS(pthread_getcpuclockid)
+      AC_CHECK_FUNCS([pthread_getcpuclockid pthread_condattr_setclock])
 fi
 
 


### PR DESCRIPTION
This is the work I did toward fixing [bpo-32243](https://bugs.python.org/issue32243) (and might be better broken into separate PRs--we'll see).

This updates @vstinner's patch from [bpo-23428](https://bugs.python.org/issue23428), and on top of it adds a fix to `PyCOND_TIMEDWAIT` that makes small adjustments, if needed, to the timeout (in microseconds) if it's so short that the deadline is always in the past.

My experience in profiling the latter fix (just with some print statements) was that on a slow VM, with setting `sys.setswitchinterval(1e-6)` on a slow system, this would typically go through the while loop I added to `PyCOND_TIMEDWAIT` twice (i.e. it would increase the timeout once).  On rarer occasions it would go through three times.  With `sys.setswitchinterval(1e-5)` it would sometimes go through the loop twice--usually just once.  And for longer switch intervals than that it would always go through the loop only once.

This does all unfortunately come at the cost of an unconditional extra call `GETTIME()`.

<!-- issue-number: bpo-32243 -->
https://bugs.python.org/issue32243
<!-- /issue-number -->
