### PR TITLE
bpo-32398: Remove OSX c++ linking workaround in distutils.

### DIFF
--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -177,18 +177,6 @@ class UnixCCompiler(CCompiler):
                     linker = self.linker_exe[:]
                 else:
                     linker = self.linker_so[:]
-                if target_lang == "c++" and self.compiler_cxx:
-                    # skip over environment variable settings if /usr/bin/env
-                    # is used to set up the linker's environment.
-                    # This is needed on OSX. Note: this assumes that the
-                    # normal and C++ compiler have the same environment
-                    # settings.
-                    i = 0
-                    if os.path.basename(linker[0]) == "env":
-                        i = 1
-                        while '=' in linker[i]:
-                            i += 1
-                    linker[i] = self.compiler_cxx[i]
 
                 if sys.platform == 'darwin':
                     linker = _osx_support.compiler_fixup(linker, ld_args)

--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-21-17-34-40.bpo-32398.XxESJr.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-21-17-34-40.bpo-32398.XxESJr.rst
@@ -1,0 +1,1 @@
+Remove ancient OSX C++ linking workaround in distutils.


### PR DESCRIPTION
When compiling GDAL with python support, before the removed code we have

```
self.compiler_cxx = ['/bin/sh', '/usr/x86_64-pc-linux-gnu/bin/libtool', '--mode=compile', '--tag=CXX', 'x86_64-pc-linux-gnu-c++']
linker = ['x86_64-pc-linux-gnu-cc', '-pthread', '-shared', '-march=native', '-pipe', '-O2', '-Wall', '-Wdeclaration-after-statement', '-Wextra', '-Winit-self', '-Wunused-parameter', '-Wmissing-prototypes', '-Wmissing-declarations', '-Wformat', '-Werror=format-security', '-Wno-format-nonliteral', '-Wlogical-op', '-Wshadow', '-Werror=vla', '-Wdeclaration-after-statement', '-Wnull-dereference', '-Wduplicated-cond', '-DOGR_ENABLED', '-march=native', '-pipe', '-O2', '-I/var/tmp/paludis/build/sci-libs-gdal-2.1.1/work/gdal-2.1.1/port', '-DGDAL_COMPILATION']
```

and after the removed code

```
linker = ['/bin/sh', '-pthread', '-shared', '-march=native', '-pipe', '-O2', '-Wall', '-Wdeclaration-after-statement', '-Wextra', '-Winit-self', '-Wunused-parameter', '-Wmissing-prototypes', '-Wmissing-declarations', '-Wformat', '-Werror=format-security', '-Wno-format-nonliteral', '-Wlogical-op', '-Wshadow', '-Werror=vla', '-Wdeclaration-after-statement', '-Wnull-dereference', '-Wduplicated-cond', '-DOGR_ENABLED', '-march=native', '-pipe', '-O2', '-I/var/tmp/paludis/build/sci-libs-gdal-2.1.1/work/gdal-2.1.1/port', '-DGDAL_COMPILATION']
```

which leads to next [error](https://www.mail-archive.com/freebsd-ports@freebsd.org/msg41030.html):

```
/bin/sh: -d: invalid option
```

Some [workarounds](https://www.michael-joost.de/gdal_install.html) have been found, but anyway the code removed:

1. ...is a hack about OSX but there is no platform checking,

2. ...assumes linker and compiler commands have similar structure and
environment settings (no documentation reference found about that), and

3. ...assumes `env`, if used, does not come with any modifier.

<!-- issue-number: bpo-32398 -->
https://bugs.python.org/issue32398
<!-- /issue-number -->
