### PR TITLE
bpo-22908: Add seek and tell functionality to ZipExtFile

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -230,9 +230,9 @@ ZipFile Objects
    With *mode* ``'r'`` the file-like object
    (``ZipExtFile``) is read-only and provides the following methods:
    :meth:`~io.BufferedIOBase.read`, :meth:`~io.IOBase.readline`,
-   :meth:`~io.IOBase.readlines`, :meth:`__iter__`,
-   :meth:`~iterator.__next__`.  These objects can operate independently of
-   the ZipFile.
+   :meth:`~io.IOBase.readlines`, :meth:`~io.IOBase.seek`, 
+   :meth:`~io.IOBase.tell`, :meth:`__iter__`, :meth:`~iterator.__next__`.
+   These objects can operate independently of the ZipFile.
 
    With ``mode='w'``, a writable file handle is returned, which supports the
    :meth:`~io.BufferedIOBase.write` method.  While a writable file handle is open,

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -230,7 +230,7 @@ ZipFile Objects
    With *mode* ``'r'`` the file-like object
    (``ZipExtFile``) is read-only and provides the following methods:
    :meth:`~io.BufferedIOBase.read`, :meth:`~io.IOBase.readline`,
-   :meth:`~io.IOBase.readlines`, :meth:`~io.IOBase.seek`, 
+   :meth:`~io.IOBase.readlines`, :meth:`~io.IOBase.seek`,
    :meth:`~io.IOBase.tell`, :meth:`__iter__`, :meth:`~iterator.__next__`.
    These objects can operate independently of the ZipFile.
 

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1596,6 +1596,40 @@ class OtherTests(unittest.TestCase):
             self.assertEqual(zipf.read('baz'), msg3)
             self.assertEqual(zipf.namelist(), ['foo', 'bar', 'baz'])
 
+    def test_seek_tell(self):
+        # Test seek functionality
+        txt = b"Where's Bruce?"
+        bloc = txt.find(b"Bruce")
+        # Check seek on a file
+        with zipfile.ZipFile(TESTFN, "w") as zipf:
+            zipf.writestr("foo.txt", txt)
+        with zipfile.ZipFile(TESTFN, "r") as zipf:
+            with zipf.open("foo.txt", "r") as fp:
+                fp.seek(bloc, os.SEEK_SET)
+                self.assertEqual(fp.tell(), bloc)
+                fp.seek(-bloc, os.SEEK_CUR)
+                self.assertEqual(fp.tell(), 0)
+                fp.seek(bloc, os.SEEK_CUR)
+                self.assertEqual(fp.tell(), bloc)
+                self.assertEqual(fp.read(5), txt[bloc:bloc+5])
+                fp.seek(0, os.SEEK_END)
+                self.assertEqual(fp.tell(), len(txt))
+        # Check seek on memory file
+        data = io.BytesIO()
+        with zipfile.ZipFile(data, mode="w") as zipf:
+            zipf.writestr("foo.txt", txt)
+        with zipfile.ZipFile(data, mode="r") as zipf:
+            with zipf.open("foo.txt", "r") as fp:
+                fp.seek(bloc, os.SEEK_SET)
+                self.assertEqual(fp.tell(), bloc)
+                fp.seek(-bloc, os.SEEK_CUR)
+                self.assertEqual(fp.tell(), 0)
+                fp.seek(bloc, os.SEEK_CUR)
+                self.assertEqual(fp.tell(), bloc)
+                self.assertEqual(fp.read(5), txt[bloc:bloc+5])
+                fp.seek(0, os.SEEK_END)
+                self.assertEqual(fp.tell(), len(txt))
+
     def tearDown(self):
         unlink(TESTFN)
         unlink(TESTFN2)

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -974,14 +974,14 @@ class ZipExtFile(io.BufferedIOBase):
     def seekable(self):
         return self._seekable
 
-    def seek(self, offset, from_what = 0):
+    def seek(self, offset, whence = 0):
         if not self._seekable:
             raise io.UnsupportedOperation("underlying stream is not seekable")
         curr_pos = self.tell()
         new_pos = offset # Default seek from start of file
-        if from_what == 1: # Seek from current position
+        if whence == 1: # Seek from current position
             new_pos = curr_pos + offset
-        elif from_what == 2: # Seek from EOF
+        elif whence == 2: # Seek from EOF
             new_pos = self._orig_file_size + offset
 
         if new_pos > self._orig_file_size:

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -990,16 +990,20 @@ class ZipExtFile(io.BufferedIOBase):
         if new_pos > curr_pos:
             self.read(new_pos - curr_pos)
         elif new_pos < curr_pos:
-            self._fileobj.seek(self._orig_compress_start)
-            self._running_crc = self._orig_start_crc
-            self._compress_left = self._orig_compress_size
-            self._left = self._orig_file_size
-            self._readbuffer = b''
-            self._offset = 0
-            self._decompressor = zipfile._get_decompressor(self._compress_type)
-            self._eof = False
-            if new_pos > 0:
-                self.read(new_pos)
+            if self._offset >= curr_pos - new_pos:
+                # No need to reset if the new position is within the read buffer
+                self._offset -= curr_pos - new_pos
+            else:
+                self._fileobj.seek(self._orig_compress_start)
+                self._running_crc = self._orig_start_crc
+                self._compress_left = self._orig_compress_size
+                self._left = self._orig_file_size
+                self._readbuffer = b''
+                self._offset = 0
+                self._decompressor = zipfile._get_decompressor(self._compress_type)
+                self._eof = False
+                if new_pos > 0:
+                    self.read(new_pos)
 
         return self.tell()
 

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -990,11 +990,15 @@ class ZipExtFile(io.BufferedIOBase):
         if not self._seekable:
             raise io.UnsupportedOperation("underlying stream is not seekable")
         curr_pos = self.tell()
-        new_pos = offset # Default seek from start of file
-        if whence == 1: # Seek from current position
+        if whence == 0: # Seek from start of file
+            new_pos = offset
+        elif whence == 1: # Seek from current position
             new_pos = curr_pos + offset
         elif whence == 2: # Seek from EOF
             new_pos = self._orig_file_size + offset
+        else:
+            raise ValueError("whence must be os.SEEK_SET (0), "
+                             "os.SEEK_CUR (1), or os.SEEK_END (2)")
 
         if new_pos > self._orig_file_size:
             new_pos = self._orig_file_size

--- a/Misc/NEWS.d/next/Library/2017-12-21-22-00-11.bpo-22908.cVm89I.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-21-22-00-11.bpo-22908.cVm89I.rst
@@ -1,4 +1,2 @@
-Added seek and rest to the ZipExtFile class. This only works if the file
-object used to open the zipfile is seekable. This change is the first
-iteration of this feature and can easily be optimized by considering the
-_readbuffer.
+Added seek and tell to the ZipExtFile class. This only works if the file
+object used to open the zipfile is seekable.

--- a/Misc/NEWS.d/next/Library/2017-12-21-22-00-11.bpo-22908.cVm89I.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-21-22-00-11.bpo-22908.cVm89I.rst
@@ -1,0 +1,4 @@
+Added seek and rest to the ZipExtFile class. This only works if the file
+object used to open the zipfile is seekable. This change is the first
+iteration of this feature and can easily be optimized by considering the
+_readbuffer.


### PR DESCRIPTION
- Added seek, tell, and seekable functions to ZipExtFile
  - Added internal variables to ZipExtFile that preserves original
    values in order to reset the zipfile to it's initial state
  - Raises io.UnsupportedOperation when accessed without a seekable file
    object
  - Could be optimized to seek within the _readbuffer

<!-- issue-number: bpo-22908 -->
https://bugs.python.org/issue22908
<!-- /issue-number -->
