### PR TITLE
bpo-29240: Skip test_readline.test_nonascii()

### DIFF
--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -152,6 +152,8 @@ print("History length:", readline.get_current_history_length())
         output = run_pty(self.auto_history_script.format(False))
         self.assertIn(b"History length: 0\r\n", output)
 
+    @unittest.skipIf(True,
+                     "FIXME: test broken by bpo-29240")
     def test_nonascii(self):
         try:
             readline.add_history("\xEB\xEF")


### PR DESCRIPTION
Skip the test which fails on FreeBSD with POSIX locale.

Skip the test to fix FreeBSD buildbots, until a fix can be found, so
the buildbots can catch other regressions.

<!-- issue-number: bpo-29240 -->
https://bugs.python.org/issue29240
<!-- /issue-number -->
