### PR TITLE
[3.6] bpo-20891: Skip test_embed.test_bpo20891() (#4967)

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -494,6 +494,9 @@ class EmbeddingTests(unittest.TestCase):
         self.assertEqual(out, '')
         self.assertEqual(err, '')
 
+    @unittest.skipIf(True,
+                     "FIXME: test fails randomly because of a race conditon, "
+                     "see bpo-20891")
     def test_bpo20891(self):
         """
         bpo-20891: Calling PyGILState_Ensure in a non-Python thread before


### PR DESCRIPTION
Skip the test failing randomly because of known race condition.

Skip the test to fix macOS buildbots until a decision is made on the
proper fix for the race condition.

(cherry picked from commit 550ee051d605b909dd75ef686d8e1244a0994394)

<!-- issue-number: bpo-20891 -->
https://bugs.python.org/issue20891
<!-- /issue-number -->
