### PR TITLE
More warnings

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2493,12 +2493,12 @@ task_step_impl(TaskObj *task, PyObject *exc)
                 tb = NULL;
                 goto set_exception;
             }
-            PyObject *res = future_set_result((FutureObj*)task, o);
+            PyObject *set_res = future_set_result((FutureObj*)task, o);
             Py_DECREF(o);
-            if (res == NULL) {
+            if (set_res == NULL) {
                 return NULL;
             }
-            Py_DECREF(res);
+            Py_DECREF(set_res);
             Py_RETURN_NONE;
         }
 
@@ -2551,7 +2551,7 @@ set_exception:
     /* Check if `result` is FutureObj or TaskObj (and not a subclass) */
     if (Future_CheckExact(result) || Task_CheckExact(result)) {
         PyObject *wrapper;
-        PyObject *res;
+        PyObject *add_res;
         FutureObj *fut = (FutureObj*)result;
 
         /* Check if `result` future is attached to a different loop */
@@ -2567,12 +2567,12 @@ set_exception:
             if (wrapper == NULL) {
                 goto fail;
             }
-            res = future_add_done_callback((FutureObj*)result, wrapper);
+            add_res = future_add_done_callback((FutureObj*)result, wrapper);
             Py_DECREF(wrapper);
-            if (res == NULL) {
+            if (add_res == NULL) {
                 goto fail;
             }
-            Py_DECREF(res);
+            Py_DECREF(add_res);
 
             /* task._fut_waiter = result */
             task->task_fut_waiter = result;  /* no incref is necessary */
@@ -2613,7 +2613,7 @@ set_exception:
         else {
             /* `result` is a Future-compatible object */
             PyObject *wrapper;
-            PyObject *res;
+            PyObject *method_res;
 
             int blocking = PyObject_IsTrue(o);
             Py_DECREF(o);
@@ -2646,14 +2646,14 @@ set_exception:
                 if (wrapper == NULL) {
                     goto fail;
                 }
-                res = _PyObject_CallMethodIdObjArgs(result,
-                                                    &PyId_add_done_callback,
-                                                    wrapper, NULL);
+                method_res = _PyObject_CallMethodIdObjArgs(result,
+                                                           &PyId_add_done_callback,
+                                                           wrapper, NULL);
                 Py_DECREF(wrapper);
-                if (res == NULL) {
+                if (method_res == NULL) {
                     goto fail;
                 }
-                Py_DECREF(res);
+                Py_DECREF(method_res);
 
                 /* task._fut_waiter = result */
                 task->task_fut_waiter = result;  /* no incref is necessary */

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -4512,12 +4512,12 @@ Array_ass_subscript(PyObject *myself, PyObject *item, PyObject *value)
             return -1;
         }
         for (cur = start, i = 0; i < otherlen; cur += step, i++) {
-            PyObject *item = PySequence_GetItem(value, i);
+            PyObject *curr_item = PySequence_GetItem(value, i);
             int result;
-            if (item == NULL)
+            if (curr_item == NULL)
                 return -1;
-            result = Array_ass_item(myself, cur, item);
-            Py_DECREF(item);
+            result = Array_ass_item(myself, cur, curr_item);
+            Py_DECREF(curr_item);
             if (result == -1)
                 return -1;
         }

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -519,7 +519,7 @@ PyCStructUnionType_update_stgdict(PyObject *type, PyObject *fields, int isStruct
             const char *fieldfmt = dict->format ? dict->format : "B";
             const char *fieldname = PyUnicode_AsUTF8(name);
             char *ptr;
-            Py_ssize_t len;
+            Py_ssize_t str_len;
             char *buf;
 
             if (fieldname == NULL)
@@ -528,9 +528,9 @@ PyCStructUnionType_update_stgdict(PyObject *type, PyObject *fields, int isStruct
                 return -1;
             }
 
-            len = strlen(fieldname) + strlen(fieldfmt);
+            str_len = strlen(fieldname) + strlen(fieldfmt);
 
-            buf = PyMem_Malloc(len + 2 + 1);
+            buf = PyMem_Malloc(str_len + 2 + 1);
             if (buf == NULL) {
                 Py_DECREF(pair);
                 PyErr_NoMemory();

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1536,16 +1536,16 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     if (_PyBytes_Resize(&newfmt, usednew) < 0)
         goto Done;
     {
-        PyObject *format;
+        PyObject *new_format;
         PyObject *time = PyImport_ImportModuleNoBlock("time");
 
         if (time == NULL)
             goto Done;
-        format = PyUnicode_FromString(PyBytes_AS_STRING(newfmt));
-        if (format != NULL) {
+        new_format = PyUnicode_FromString(PyBytes_AS_STRING(newfmt));
+        if (new_format != NULL) {
             result = _PyObject_CallMethodIdObjArgs(time, &PyId_strftime,
-                                                   format, timetuple, NULL);
-            Py_DECREF(format);
+                                                   new_format, timetuple, NULL);
+            Py_DECREF(new_format);
         }
         Py_DECREF(time);
     }

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -1753,9 +1753,9 @@ element_subscr(PyObject* self_, PyObject* item)
 
             for (cur = start, i = 0; i < slicelen;
                  cur += step, i++) {
-                PyObject* item = self->extra->children[cur];
-                Py_INCREF(item);
-                PyList_SET_ITEM(list, i, item);
+                PyObject* curr_item = self->extra->children[cur];
+                Py_INCREF(curr_item);
+                PyList_SET_ITEM(list, i, curr_item);
             }
 
             return list;
@@ -1802,9 +1802,6 @@ element_ass_subscr(PyObject* self_, PyObject* item, PyObject* value)
 
         if (value == NULL) {
             /* Delete slice */
-            size_t cur;
-            Py_ssize_t i;
-
             if (slicelen <= 0)
                 return 0;
 
@@ -1834,12 +1831,12 @@ element_ass_subscr(PyObject* self_, PyObject* item, PyObject* value)
              * Note that in the ith iteration, shifting is done i+i places down
              * because i children were already removed.
             */
-            for (cur = start, i = 0; cur < (size_t)stop; cur += step, ++i) {
+            for (cur = start, i = 0; cur < stop; cur += step, ++i) {
                 /* Compute how many children have to be moved, clipping at the
                  * list end.
                 */
                 Py_ssize_t num_moved = step - 1;
-                if (cur + step >= (size_t)self->extra->length) {
+                if (cur + step >= self->extra->length) {
                     num_moved = self->extra->length - cur - 1;
                 }
 
@@ -1853,7 +1850,7 @@ element_ass_subscr(PyObject* self_, PyObject* item, PyObject* value)
 
             /* Leftover "tail" after the last removed child */
             cur = start + (size_t)slicelen * step;
-            if (cur < (size_t)self->extra->length) {
+            if (cur < self->extra->length) {
                 memmove(
                     self->extra->children + cur - slicelen,
                     self->extra->children + cur,

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -504,9 +504,9 @@ buffered_close(buffered *self, PyObject *args)
     }
 
     if (self->finalizing) {
-        PyObject *r = buffered_dealloc_warn(self, (PyObject *) self);
-        if (r)
-            Py_DECREF(r);
+        PyObject *obj = buffered_dealloc_warn(self, (PyObject *) self);
+        if (obj)
+            Py_DECREF(obj);
         else
             PyErr_Clear();
     }

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -447,8 +447,6 @@ _PyIncrementalNewlineDecoder_decode(PyObject *myself,
         }
         else {
             void *translated;
-            int kind = PyUnicode_KIND(output);
-            void *in_str = PyUnicode_DATA(output);
             Py_ssize_t in, out;
             /* XXX: Previous in-place translation here is disabled as
                resizing is not possible anymore */
@@ -1975,7 +1973,7 @@ _PyIO_find_line_ending(
                 e = s;
             while (s < e) {
                 Py_ssize_t i;
-                const char *pos = find_control_char(kind, s, end, nl[0]);
+                pos = find_control_char(kind, s, end, nl[0]);
                 if (pos == NULL || pos >= e)
                     break;
                 for (i = 1; i < readnl_len; i++) {

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -518,7 +518,7 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 PyUnicode_READ(kind, buf, next++) == 'u') {
                 Py_UCS4 c2 = 0;
                 end += 6;
-                /* Decode 4 hex curr_digs */
+                /* Decode 4 hex digits */
                 for (; next < end; next++) {
                     Py_UCS4 curr_dig = PyUnicode_READ(kind, buf, next);
                     c2 <<= 4;

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -495,18 +495,18 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
             }
             /* Decode 4 hex digits */
             for (; next < end; next++) {
-                Py_UCS4 digit = PyUnicode_READ(kind, buf, next);
+                Py_UCS4 curr_dig = PyUnicode_READ(kind, buf, next);
                 c <<= 4;
-                switch (digit) {
+                switch (curr_dig) {
                     case '0': case '1': case '2': case '3': case '4':
                     case '5': case '6': case '7': case '8': case '9':
-                        c |= (digit - '0'); break;
+                        c |= (curr_dig - '0'); break;
                     case 'a': case 'b': case 'c': case 'd': case 'e':
                     case 'f':
-                        c |= (digit - 'a' + 10); break;
+                        c |= (curr_dig - 'a' + 10); break;
                     case 'A': case 'B': case 'C': case 'D': case 'E':
                     case 'F':
-                        c |= (digit - 'A' + 10); break;
+                        c |= (curr_dig - 'A' + 10); break;
                     default:
                         raise_errmsg("Invalid \\uXXXX escape", pystr, end - 5);
                         goto bail;
@@ -518,20 +518,20 @@ scanstring_unicode(PyObject *pystr, Py_ssize_t end, int strict, Py_ssize_t *next
                 PyUnicode_READ(kind, buf, next++) == 'u') {
                 Py_UCS4 c2 = 0;
                 end += 6;
-                /* Decode 4 hex digits */
+                /* Decode 4 hex curr_digs */
                 for (; next < end; next++) {
-                    Py_UCS4 digit = PyUnicode_READ(kind, buf, next);
+                    Py_UCS4 curr_dig = PyUnicode_READ(kind, buf, next);
                     c2 <<= 4;
-                    switch (digit) {
+                    switch (curr_dig) {
                         case '0': case '1': case '2': case '3': case '4':
                         case '5': case '6': case '7': case '8': case '9':
-                            c2 |= (digit - '0'); break;
+                            c2 |= (curr_dig- '0'); break;
                         case 'a': case 'b': case 'c': case 'd': case 'e':
                         case 'f':
-                            c2 |= (digit - 'a' + 10); break;
+                            c2 |= (curr_dig - 'a' + 10); break;
                         case 'A': case 'B': case 'C': case 'D': case 'E':
                         case 'F':
-                            c2 |= (digit - 'A' + 10); break;
+                            c2 |= (curr_dig - 'A' + 10); break;
                         default:
                             raise_errmsg("Invalid \\uXXXX escape", pystr, end - 5);
                             goto bail;

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -1617,11 +1617,10 @@ done:
 static PyObject *
 methodcaller_reduce(methodcallerobject *mc)
 {
-    PyObject *newargs;
     if (!mc->kwds || PyDict_GET_SIZE(mc->kwds) == 0) {
         Py_ssize_t i;
         Py_ssize_t callargcount = PyTuple_GET_SIZE(mc->args);
-        newargs = PyTuple_New(1 + callargcount);
+        PyObject *newargs = PyTuple_New(1 + callargcount);
         if (newargs == NULL)
             return NULL;
         Py_INCREF(mc->name);

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3718,7 +3718,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
             Py_ssize_t i;
             _Py_IDENTIFIER(__new__);
 
-            newargs = PyTuple_New(PyTuple_GET_SIZE(args) + 2);
+            newargs = PyTuple_New(PyTuple_GET_SIZE(tup_args) + 2);
             if (newargs == NULL)
                 return -1;
 
@@ -3730,8 +3730,8 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
             PyTuple_SET_ITEM(newargs, 0, cls_new);
             Py_INCREF(cls);
             PyTuple_SET_ITEM(newargs, 1, cls);
-            for (i = 0; i < PyTuple_GET_SIZE(args); i++) {
-                PyObject *item = PyTuple_GET_ITEM(args, i);
+            for (i = 0; i < PyTuple_GET_SIZE(tup_args); i++) {
+                PyObject *item = PyTuple_GET_ITEM(tup_args, i);
                 Py_INCREF(item);
                 PyTuple_SET_ITEM(newargs, i + 2, item);
             }

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -230,8 +230,8 @@ static PyThreadState *tcl_tstate = NULL;
 #endif
 
 #define ENTER_TCL \
-    { PyThreadState *tstate = PyThreadState_Get(); Py_BEGIN_ALLOW_THREADS \
-        if(tcl_lock)PyThread_acquire_lock(tcl_lock, 1); tcl_tstate = tstate;
+    { PyThreadState *t_state = PyThreadState_Get(); Py_BEGIN_ALLOW_THREADS \
+        if(tcl_lock)PyThread_acquire_lock(tcl_lock, 1); tcl_tstate = t_state;
 
 #define LEAVE_TCL \
     tcl_tstate = NULL; \

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -706,7 +706,7 @@ array_richcompare(PyObject *v, PyObject *w, int op)
         case Py_GE: cmp = result >= 0; break;
         default: return NULL; /* cannot happen */
         }
-        PyObject *res = cmp ? Py_True : Py_False;
+        res = cmp ? Py_True : Py_False;
         Py_INCREF(res);
         return res;
     }
@@ -2107,7 +2107,6 @@ array__array_reconstructor_impl(PyObject *module, PyTypeObject *arraytype,
         Py_ssize_t itemcount = Py_SIZE(items) / mf_descr.size;
         const unsigned char *memstr =
             (unsigned char *)PyBytes_AS_STRING(items);
-        const struct arraydescr *descr;
 
         /* If possible, try to pack array's items using a data type
          * that fits better. This may result in an array with narrower
@@ -2354,7 +2353,7 @@ array_subscr(arrayobject* self, PyObject* item)
             return newarrayobject(&Arraytype, 0, self->ob_descr);
         }
         else if (step == 1) {
-            PyObject *result = newarrayobject(&Arraytype,
+            result = newarrayobject(&Arraytype,
                                     slicelength, self->ob_descr);
             if (result == NULL)
                 return NULL;

--- a/Modules/expat/xmlparse.c
+++ b/Modules/expat/xmlparse.c
@@ -2175,14 +2175,14 @@ XML_GetBuffer(XML_Parser parser, int len)
       bufferLim = newBuf + bufferSize;
 #ifdef XML_CONTEXT_BYTES
       if (bufferPtr) {
-        int keep = (int)(bufferPtr - buffer);
-        if (keep > XML_CONTEXT_BYTES)
-          keep = XML_CONTEXT_BYTES;
-        memcpy(newBuf, &bufferPtr[-keep], bufferEnd - bufferPtr + keep);
+        int to_keep = (int)(bufferPtr - buffer);
+        if (to_keep > XML_CONTEXT_BYTES)
+          to_keep = XML_CONTEXT_BYTES;
+        memcpy(newBuf, &bufferPtr[-to_keep], bufferEnd - bufferPtr + to_keep);
         FREE(buffer);
         buffer = newBuf;
-        bufferEnd = buffer + (bufferEnd - bufferPtr) + keep;
-        bufferPtr = buffer + keep;
+        bufferEnd = buffer + (bufferEnd - bufferPtr) + to_keep;
+        bufferPtr = buffer + to_keep;
       }
       else {
         bufferEnd = newBuf + (bufferEnd - bufferPtr);
@@ -5017,11 +5017,11 @@ doProlog(XML_Parser parser,
           }
           groupConnector = temp;
           if (dtd->scaffIndex) {
-            int *temp = (int *)REALLOC(dtd->scaffIndex,
+            int *temp1 = (int *)REALLOC(dtd->scaffIndex,
                           groupSize * sizeof(int));
-            if (temp == NULL)
+            if (temp1 == NULL)
               return XML_ERROR_NO_MEMORY;
-            dtd->scaffIndex = temp;
+            dtd->scaffIndex = temp1;
           }
         }
         else {

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -1021,7 +1021,7 @@ faulthandler_fatal_error_thread(void *plock)
 static PyObject *
 faulthandler_fatal_error_c_thread(PyObject *self, PyObject *args)
 {
-    long thread;
+    long thread_id;
     PyThread_type_lock lock;
 
     faulthandler_suppress_crash_report();
@@ -1032,8 +1032,8 @@ faulthandler_fatal_error_c_thread(PyObject *self, PyObject *args)
 
     PyThread_acquire_lock(lock, WAIT_LOCK);
 
-    thread = PyThread_start_new_thread(faulthandler_fatal_error_thread, lock);
-    if (thread == -1) {
+    thread_id = PyThread_start_new_thread(faulthandler_fatal_error_thread, lock);
+    if (thread_id == -1) {
         PyThread_free_lock(lock);
         PyErr_SetString(PyExc_RuntimeError, "unable to start the thread");
         return NULL;

--- a/Modules/fcntlmodule.c
+++ b/Modules/fcntlmodule.c
@@ -170,7 +170,7 @@ fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
 
     if (ob_arg != NULL) {
         if (PyArg_Parse(ob_arg, "w*:ioctl", &pstr)) {
-            char *arg;
+            char *buf_arg;
             str = pstr.buf;
             len = pstr.len;
 
@@ -178,10 +178,10 @@ fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
                 if (len <= IOCTL_BUFSZ) {
                     memcpy(buf, str, len);
                     buf[len] = '\0';
-                    arg = buf;
+                    buf_arg = buf;
                 }
                 else {
-                    arg = str;
+                    buf_arg = str;
                 }
             }
             else {
@@ -194,16 +194,16 @@ fcntl_ioctl_impl(PyObject *module, int fd, unsigned int code,
                 else {
                     memcpy(buf, str, len);
                     buf[len] = '\0';
-                    arg = buf;
+                    buf_arg = buf;
                 }
             }
-            if (buf == arg) {
+            if (buf == buf_arg) {
                 Py_BEGIN_ALLOW_THREADS /* think array.resize() */
-                ret = ioctl(fd, code, arg);
+                ret = ioctl(fd, code, buf_arg);
                 Py_END_ALLOW_THREADS
             }
             else {
-                ret = ioctl(fd, code, arg);
+                ret = ioctl(fd, code, buf_arg);
             }
             if (mutate_arg && (len <= IOCTL_BUFSZ)) {
                 memcpy(str, buf, len);

--- a/Modules/unicodedata.c
+++ b/Modules/unicodedata.c
@@ -639,7 +639,7 @@ nfc_nfkc(PyObject *self, PyObject *input, int k)
     void *data;
     Py_UCS4 *output;
     Py_ssize_t i, i1, o, len;
-    int f,l,index,index1,comb;
+    int f,l,index,index_1,comb;
     Py_UCS4 code;
     Py_ssize_t skipped[20];
     int cskipped = 0;
@@ -734,8 +734,8 @@ nfc_nfkc(PyObject *self, PyObject *input, int k)
               continue;
           }
           index = f*TOTAL_LAST + l;
-          index1 = comp_index[index >> COMP_SHIFT];
-          code = comp_data[(index1<<COMP_SHIFT)+
+          index_1 = comp_index[index >> COMP_SHIFT];
+          code = comp_data[(index_1<<COMP_SHIFT)+
                            (index&((1<<COMP_SHIFT)-1))];
           if (code == 0)
               goto not_combinable;

--- a/Objects/capsule.c
+++ b/Objects/capsule.c
@@ -41,7 +41,7 @@ name_matches(const char *name1, const char *name2) {
 
 
 PyObject *
-PyCapsule_New(void *pointer, const char *name, PyCapsule_Destructor destructor)
+PyCapsule_New(void *pointer, const char *name, PyCapsule_Destructor dtor)
 {
     PyCapsule *capsule;
 
@@ -58,7 +58,7 @@ PyCapsule_New(void *pointer, const char *name, PyCapsule_Destructor destructor)
     capsule->pointer = pointer;
     capsule->name = name;
     capsule->context = NULL;
-    capsule->destructor = destructor;
+    capsule->destructor = dtor;
 
     return (PyObject *)capsule;
 }
@@ -164,7 +164,7 @@ PyCapsule_SetName(PyObject *o, const char *name)
 
 
 int
-PyCapsule_SetDestructor(PyObject *o, PyCapsule_Destructor destructor)
+PyCapsule_SetDestructor(PyObject *o, PyCapsule_Destructor dtor)
 {
     PyCapsule *capsule = (PyCapsule *)o;
 
@@ -172,7 +172,7 @@ PyCapsule_SetDestructor(PyObject *o, PyCapsule_Destructor destructor)
         return -1;
     }
 
-    capsule->destructor = destructor;
+    capsule->destructor = dtor;
     return 0;
 }
 

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1284,9 +1284,9 @@ PyDoc_STRVAR(getter_doc,
              "Descriptor to change the getter on a property.");
 
 static PyObject *
-property_getter(PyObject *self, PyObject *getter)
+property_getter(PyObject *self, PyObject *get)
 {
-    return property_copy(self, getter, NULL, NULL);
+    return property_copy(self, get, NULL, NULL);
 }
 
 
@@ -1294,9 +1294,9 @@ PyDoc_STRVAR(setter_doc,
              "Descriptor to change the setter on a property.");
 
 static PyObject *
-property_setter(PyObject *self, PyObject *setter)
+property_setter(PyObject *self, PyObject *set)
 {
-    return property_copy(self, NULL, setter, NULL);
+    return property_copy(self, NULL, set, NULL);
 }
 
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1764,7 +1764,6 @@ _PyDict_FromKeys(PyObject *cls, PyObject *iterable, PyObject *value)
             PyDictObject *mp = (PyDictObject *)d;
             PyObject *oldvalue;
             Py_ssize_t pos = 0;
-            PyObject *key;
             Py_hash_t hash;
 
             if (dictresize(mp, ESTIMATE_SIZE(PyDict_GET_SIZE(iterable)))) {
@@ -1783,7 +1782,6 @@ _PyDict_FromKeys(PyObject *cls, PyObject *iterable, PyObject *value)
         if (PyAnySet_CheckExact(iterable)) {
             PyDictObject *mp = (PyDictObject *)d;
             Py_ssize_t pos = 0;
-            PyObject *key;
             Py_hash_t hash;
 
             if (dictresize(mp, ESTIMATE_SIZE(PySet_GET_SIZE(iterable)))) {

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -1280,7 +1280,7 @@ float_fromhex(PyTypeObject *type, PyObject *string)
     double x;
     long exp, top_exp, lsb, key_digit;
     const char *s, *coeff_start, *s_store, *coeff_end, *exp_start, *s_end;
-    int half_eps, digit, round_up, negate=0;
+    int half_eps, curr_dig, round_up, negate=0;
     Py_ssize_t length, ndigits, fdigits, i;
 
     /*
@@ -1429,7 +1429,7 @@ float_fromhex(PyTypeObject *type, PyObject *string)
 
     /* top_exp = 1 more than exponent of most sig. bit of coefficient */
     top_exp = exp + 4*((long)ndigits - 1);
-    for (digit = HEX_DIGIT(ndigits-1); digit != 0; digit /= 2)
+    for (curr_dig = HEX_DIGIT(ndigits-1); curr_dig != 0; curr_dig /= 2)
         top_exp++;
 
     /* catch almost all nonextreme cases of overflow and underflow here */
@@ -1458,14 +1458,14 @@ float_fromhex(PyTypeObject *type, PyObject *string)
     key_digit = (lsb - exp - 1) / 4;
     for (i = ndigits-1; i > key_digit; i--)
         x = 16.0*x + HEX_DIGIT(i);
-    digit = HEX_DIGIT(key_digit);
-    x = 16.0*x + (double)(digit & (16-2*half_eps));
+    curr_dig = HEX_DIGIT(key_digit);
+    x = 16.0*x + (double)(curr_dig & (16-2*half_eps));
 
     /* round-half-even: round up if bit lsb-1 is 1 and at least one of
        bits lsb, lsb-2, lsb-3, lsb-4, ... is 1. */
-    if ((digit & half_eps) != 0) {
+    if ((curr_dig & half_eps) != 0) {
         round_up = 0;
-        if ((digit & (3*half_eps-1)) != 0 ||
+        if ((curr_dig & (3*half_eps-1)) != 0 ||
             (half_eps == 8 && (HEX_DIGIT(key_digit+1) & 1) != 0))
             round_up = 1;
         else

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -457,7 +457,7 @@ func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
               PyObject *name, PyObject *defaults, PyObject *closure)
 /*[clinic end generated code: output=99c6d9da3a24e3be input=93611752fc2daf11]*/
 {
-    PyFunctionObject *newfunc;
+    PyFunctionObject *new_func_obj;
     Py_ssize_t nfree, nclosure;
 
     if (name != Py_None && !PyUnicode_Check(name)) {
@@ -502,25 +502,25 @@ func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
         }
     }
 
-    newfunc = (PyFunctionObject *)PyFunction_New((PyObject *)code,
-                                                 globals);
-    if (newfunc == NULL)
+    new_func_obj = (PyFunctionObject *)PyFunction_New((PyObject *)code,
+                                                      globals);
+    if (new_func_obj == NULL)
         return NULL;
 
     if (name != Py_None) {
         Py_INCREF(name);
-        Py_SETREF(newfunc->func_name, name);
+        Py_SETREF(new_func_obj->func_name, name);
     }
     if (defaults != Py_None) {
         Py_INCREF(defaults);
-        newfunc->func_defaults  = defaults;
+        new_func_obj->func_defaults  = defaults;
     }
     if (closure != Py_None) {
         Py_INCREF(closure);
-        newfunc->func_closure = closure;
+        new_func_obj->func_closure = closure;
     }
 
-    return (PyObject *)newfunc;
+    return (PyObject *)new_func_obj;
 }
 
 static void

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -2282,7 +2282,7 @@ digit beyond the first.
 
         if (log_base_BASE[base] == 0.0) {
             twodigits convmax = base;
-            int i = 1;
+            int k = 1;
 
             log_base_BASE[base] = (log((double)base) /
                                    log((double)PyLong_BASE));
@@ -2292,11 +2292,11 @@ digit beyond the first.
                     break;
                 }
                 convmax = next;
-                ++i;
+                ++k;
             }
             convmultmax_base[base] = convmax;
-            assert(i > 0);
-            convwidth_base[base] = i;
+            assert(k > 0);
+            convwidth_base[base] = k;
         }
 
         /* Find length of the string of numeric characters. */

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -2492,16 +2492,16 @@ memory_ass_sub(PyMemoryViewObject *self, PyObject *key, PyObject *value)
         return ret;
     }
     if (is_multiindex(key)) {
-        char *ptr;
+        char *p;
         if (PyTuple_GET_SIZE(key) < view->ndim) {
             PyErr_SetString(PyExc_NotImplementedError,
                             "sub-views are not implemented");
             return -1;
         }
-        ptr = ptr_from_tuple(view, key);
-        if (ptr == NULL)
+        p = ptr_from_tuple(view, key);
+        if (p == NULL)
             return -1;
-        return pack_single(ptr, value, fmt);
+        return pack_single(p, value, fmt);
     }
     if (PySlice_Check(key) || is_multislice(key)) {
         /* Call memory_subscript() to produce a sliced lvalue, then copy

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -2409,9 +2409,9 @@ printone(FILE *out, const char* msg, size_t value)
     k = 3;
     do {
         size_t nextvalue = value / 10;
-        unsigned int digit = (unsigned int)(value - nextvalue * 10);
+        unsigned int curr_dig = (unsigned int)(value - nextvalue * 10);
         value = nextvalue;
-        buf[i--] = (char)(digit + '0');
+        buf[i--] = (char)(curr_dig + '0');
         --k;
         if (k == 0 && value && i >= 0) {
             k = 3;

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -1154,14 +1154,14 @@ fieldnameiter_dealloc(fieldnameiterobject *it)
 static PyObject *
 fieldnameiter_next(fieldnameiterobject *it)
 {
-    int result;
+    int iter_res;
     int is_attr;
     Py_ssize_t idx;
     SubString name;
 
-    result = FieldNameIterator_next(&it->it_field, &is_attr,
-                                    &idx, &name);
-    if (result == 0 || result == 1)
+    iter_res = FieldNameIterator_next(&it->it_field, &is_attr,
+                                      &idx, &name);
+    if (iter_res == 0 || iter_res == 1)
         /* if 0, error has already been set, if 1, iterator is empty */
         return NULL;
     else {

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2483,7 +2483,7 @@ type_new(PyTypeObject *metatype, PyObject *args, PyObject *kwds)
 
         /* Check for valid slot names and two special cases */
         for (i = 0; i < nslots; i++) {
-            PyObject *tmp = PyTuple_GET_ITEM(slots, i);
+            tmp = PyTuple_GET_ITEM(slots, i);
             if (!valid_identifier(tmp))
                 goto error;
             assert(PyUnicode_Check(tmp));

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8270,7 +8270,7 @@ PyUnicode_BuildEncodingMap(PyObject* string)
         need_dict = 1;
 
     if (need_dict) {
-        PyObject *result = PyDict_New();
+        result = PyDict_New();
         PyObject *key, *value;
         if (!result)
             return NULL;
@@ -8310,7 +8310,7 @@ PyUnicode_BuildEncodingMap(PyObject* string)
     count3 = 0;
     for (i = 1; i < length; i++) {
         int o1, o2, o3, i2, i3;
-        Py_UCS4 ch = PyUnicode_READ(kind, data, i);
+        ch = PyUnicode_READ(kind, data, i);
         if (ch == 0xFFFE)
             /* unmapped character */
             continue;
@@ -8883,10 +8883,10 @@ charmaptranslate_output(Py_UCS4 ch, PyObject *mapping,
     }
 
     if (PyLong_Check(item)) {
-        long ch = (Py_UCS4)PyLong_AS_LONG(item);
+        long long_ch = (Py_UCS4)PyLong_AS_LONG(item);
         /* PyLong_AS_LONG() cannot fail, charmaptranslate_lookup() already
            used it */
-        if (_PyUnicodeWriter_WriteCharInline(writer, ch) < 0) {
+        if (_PyUnicodeWriter_WriteCharInline(writer, long_ch) < 0) {
             Py_DECREF(item);
             return -1;
         }
@@ -9225,9 +9225,9 @@ PyUnicode_TransformDecimalToASCII(Py_UNICODE *s,
     for (i = 0; i < length; i++) {
         Py_UCS4 ch = s[i];
         if (ch > 127) {
-            int decimal = Py_UNICODE_TODECIMAL(ch);
-            if (decimal >= 0)
-                ch = '0' + decimal;
+            const int dec_int = Py_UNICODE_TODECIMAL(ch);
+            if (dec_int >= 0)
+                ch = '0' + dec_int;
             maxchar = Py_MAX(maxchar, ch);
         }
     }
@@ -9242,9 +9242,9 @@ PyUnicode_TransformDecimalToASCII(Py_UNICODE *s,
     for (i = 0; i < length; i++) {
         Py_UCS4 ch = s[i];
         if (ch > 127) {
-            int decimal = Py_UNICODE_TODECIMAL(ch);
-            if (decimal >= 0)
-                ch = '0' + decimal;
+            const int dec_int = Py_UNICODE_TODECIMAL(ch);
+            if (dec_int >= 0)
+                ch = '0' + dec_int;
         }
         PyUnicode_WRITE(kind, data, i, ch);
     }
@@ -14051,7 +14051,7 @@ unicode_subscript(PyObject* self, PyObject* item)
         dest_data = PyUnicode_DATA(result);
 
         for (cur = start, i = 0; i < slicelength; cur += step, i++) {
-            Py_UCS4 ch = PyUnicode_READ(src_kind, src_data, cur);
+            ch = PyUnicode_READ(src_kind, src_data, cur);
             PyUnicode_WRITE(dest_kind, dest_data, i, ch);
         }
         assert(_PyUnicode_CheckConsistency(result, 1));

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -157,7 +157,7 @@ get_filter(PyObject *category, PyObject *text, Py_ssize_t lineno,
 
     /* _PyRuntime.warnings.filters could change while we are iterating over it. */
     for (i = 0; i < PyList_GET_SIZE(filters); i++) {
-        PyObject *tmp_item, *action, *msg, *cat, *mod, *ln_obj;
+        PyObject *tmp_item, *msg, *cat, *mod, *ln_obj;
         Py_ssize_t ln;
         int is_subclass, good_msg, good_mod;
 

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -883,11 +883,11 @@ PyObject *PyCodec_BackslashReplaceErrors(PyObject *exc)
         }
         outp = PyUnicode_1BYTE_DATA(res);
         for (i = start; i < end; i++, outp += 4) {
-            unsigned char c = p[i];
+            unsigned char curr_ch = p[i];
             outp[0] = '\\';
             outp[1] = 'x';
-            outp[2] = Py_hexdigits[(c>>4)&0xf];
-            outp[3] = Py_hexdigits[c&0xf];
+            outp[2] = Py_hexdigits[(curr_ch>>4)&0xf];
+            outp[3] = Py_hexdigits[curr_ch&0xf];
         }
 
         assert(_PyUnicode_CheckConsistency(res, 1));

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -217,7 +217,7 @@ cleanup_buffer(PyObject *self, void *ptr)
 }
 
 static int
-addcleanup(void *ptr, freelist_t *freelist, destr_t destructor)
+addcleanup(void *ptr, freelist_t *freelist, destr_t dtor)
 {
     int index;
 
@@ -225,7 +225,7 @@ addcleanup(void *ptr, freelist_t *freelist, destr_t destructor)
     freelist->first_available += 1;
 
     freelist->entries[index].item = ptr;
-    freelist->entries[index].destructor = destructor;
+    freelist->entries[index].destructor = dtor;
 
     return 0;
 }

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -936,11 +936,11 @@ r_object(RFILE *p)
     PyObject *v, *v2;
     Py_ssize_t idx = 0;
     long i, n;
-    int type, code = r_byte(p);
+    int type, obj_code = r_byte(p);
     int flag, is_interned = 0;
     PyObject *retval = NULL;
 
-    if (code == EOF) {
+    if (obj_code == EOF) {
         PyErr_SetString(PyExc_EOFError,
                         "EOF read where object expected");
         return NULL;
@@ -954,8 +954,8 @@ r_object(RFILE *p)
         return NULL;
     }
 
-    flag = code & FLAG_REF;
-    type = code & ~FLAG_REF;
+    flag = obj_code & FLAG_REF;
+    type = obj_code & ~FLAG_REF;
 
 #define R_REF(O) do{\
     if (flag) \

--- a/Python/peephole.c
+++ b/Python/peephole.c
@@ -146,9 +146,9 @@ fold_tuple_on_constants(_Py_CODEUNIT *codestr, Py_ssize_t c_start,
         assert(_Py_OPCODE(codestr[pos]) == LOAD_CONST);
 
         unsigned int arg = get_arg(codestr, pos);
-        PyObject *constant = PyList_GET_ITEM(consts, arg);
-        Py_INCREF(constant);
-        PyTuple_SET_ITEM(newconst, i, constant);
+        PyObject *curr_const = PyList_GET_ITEM(consts, arg);
+        Py_INCREF(curr_const);
+        PyTuple_SET_ITEM(newconst, i, curr_const);
     }
 
     /* Append folded constant onto consts */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1476,8 +1476,8 @@ add_main_module(PyInterpreterState *interp)
      */
     loader = PyDict_GetItemString(d, "__loader__");
     if (loader == NULL || loader == Py_None) {
-        PyObject *loader = PyObject_GetAttrString(interp->importlib,
-                                                  "BuiltinImporter");
+        loader = PyObject_GetAttrString(interp->importlib,
+                                        "BuiltinImporter");
         if (loader == NULL) {
             return _Py_INIT_ERR("Failed to retrieve BuiltinImporter");
         }

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1055,8 +1055,8 @@ error:
     int i; \
     asdl_seq *seq = (SEQ); /* avoid variable capture */ \
     for (i = 0; i < asdl_seq_LEN(seq); i++) { \
-        TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
-        if (!symtable_visit_ ## TYPE((ST), elt)) \
+        TYPE ## _ty _elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
+        if (!symtable_visit_ ## TYPE((ST), _elt)) \
             VISIT_QUIT((ST), 0);                 \
     } \
 }
@@ -1065,8 +1065,8 @@ error:
     int i; \
     asdl_seq *seq = (SEQ); /* avoid variable capture */ \
     for (i = (START); i < asdl_seq_LEN(seq); i++) { \
-        TYPE ## _ty elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
-        if (!symtable_visit_ ## TYPE((ST), elt)) \
+        TYPE ## _ty _elt = (TYPE ## _ty)asdl_seq_GET(seq, i); \
+        if (!symtable_visit_ ## TYPE((ST), _elt)) \
             VISIT_QUIT((ST), 0);                 \
     } \
 }

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -894,11 +894,11 @@ get_hash_info(void)
 {
     PyObject *hash_info;
     int field = 0;
-    PyHash_FuncDef *hashfunc;
+    PyHash_FuncDef *hash_func;
     hash_info = PyStructSequence_New(&Hash_InfoType);
     if (hash_info == NULL)
         return NULL;
-    hashfunc = PyHash_GetFuncDef();
+    hash_func = PyHash_GetFuncDef();
     PyStructSequence_SET_ITEM(hash_info, field++,
                               PyLong_FromLong(8*sizeof(Py_hash_t)));
     PyStructSequence_SET_ITEM(hash_info, field++,
@@ -910,11 +910,11 @@ get_hash_info(void)
     PyStructSequence_SET_ITEM(hash_info, field++,
                               PyLong_FromLong(_PyHASH_IMAG));
     PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyUnicode_FromString(hashfunc->name));
+                              PyUnicode_FromString(hash_func->name));
     PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromLong(hashfunc->hash_bits));
+                              PyLong_FromLong(hash_func->hash_bits));
     PyStructSequence_SET_ITEM(hash_info, field++,
-                              PyLong_FromLong(hashfunc->seed_bits));
+                              PyLong_FromLong(hash_func->seed_bits));
     PyStructSequence_SET_ITEM(hash_info, field++,
                               PyLong_FromLong(Py_HASH_CUTOFF));
     if (PyErr_Occurred()) {

--- a/configure
+++ b/configure
@@ -6780,13 +6780,33 @@ UNIVERSAL_ARCH_FLAGS=
 # tweak BASECFLAGS based on compiler and platform
 case $GCC in
 yes)
-    CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for -Wextra" >&5
-$as_echo_n "checking for -Wextra... " >&6; }
+
+# $1 = [Output] The name of the variable to concat the given flag
+#        (e.g. CFLAGS_NODIST, BASECFLAGS..)
+# $2 = The warning to add (Including the '-W' prefix)
+# $3 = The message to display for the check
+#
+# NOTE: DO NOT USE THIS FUCNTION DIRECTRY.
+#       Please use the below functions instead.
+function _try_add_warnings_helper() {
+    # Remove the '-W' prefix. Substituted for e.g. "ac_cv_extra_warning"
+    ac_cv_var="ac_cv_${2:2}_warning"
+
+    # Handle warnings with multiple words: e.g. "-Wcast-align"
+    # Turn it into "cast_align"
+    ac_cv_var="${ac_cv_var//-/_}"
+
+    # Handle cases where we want to turn specific warnings into errors.
+    # In this case, we get e.g. "-Werror=logical-op".
+    # Turn it into "error_logical_op"
+    ac_cv_var="${ac_cv_var//=/_}"
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking $3" >&5
+$as_echo_n "checking $3... " >&6; }
      ac_save_cc="$CC"
-     CC="$CC -Wextra -Werror"
-     if ${ac_cv_extra_warnings+:} false; then :
+     CC="$CC $2 -Werror"
+
+     if { as_var=!ac_cv_var; eval \${$as_var+:} false; }; then :
   $as_echo_n "(cached) " >&6
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
@@ -6804,25 +6824,68 @@ main ()
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
 
-           ac_cv_extra_warnings=yes
+           eval ${ac_cv_var}=yes
 
 else
 
-           ac_cv_extra_warnings=no
+           eval ${ac_cv_var}=no
 
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
      CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_extra_warnings" >&5
-$as_echo "$ac_cv_extra_warnings" >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: ${!ac_cv_var}" >&5
+$as_echo "${!ac_cv_var}" >&6; }
 
-    if test $ac_cv_extra_warnings = yes
+    if test ${!ac_cv_var} = yes
     then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
+      eval ${1}="\"${!1} $2\""
+    fi
+}
+
+# $1 = The warning to add (Including the '-W' prefix)
+# $2 = The message to display for the check
+function try_add_nodist_warnings() {
+    _try_add_warnings_helper "CFLAGS_NODIST" "$1" "$2"
+}
+function try_add_base_warnings() {
+    _try_add_warnings_helper "BASECFLAGS" "$1" "$2"
+}
+
+    CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
+
+    ################################
+    ## *!*! ENABLED WARNINGS *!*! ##
+    ################################
+    try_add_base_warnings "-Wsign-compare" "if we can turn on $CC mixed sign comparison warning"
+
+    try_add_nodist_warnings "-Wextra" "for -Wextra"
+    try_add_nodist_warnings "-Wc99-c11-compat" "if we can turn on $CC c99/c11 compatibility warnings"
+    try_add_nodist_warnings "-Wlogical-op" "if we can turn on $CC logical-op warning"
+    try_add_nodist_warnings "-Wformat=2" "if we can turn on $CC format=2 warning"
+    try_add_nodist_warnings "-Wvarargs" "if we can turn on $CC varargs warning"
+    try_add_nodist_warnings "-Wuninitialized" "if we can turn on $CC uninitialized warning"
+    try_add_nodist_warnings "-Wcast-align" "if we can turn on $CC cast-align warning"
+    try_add_nodist_warnings "-Wshadow" "if we can turn on $CC shadow warning"
+    try_add_nodist_warnings "-Werror=implicit-function-declaration" "if we can make implicit function declaration an error in $CC"
+
+    # Don't enable unreachable code warning in debug mode, since it usually
+    # results in non-standard code paths.
+    # Issue #24324: Unfortunately, the unreachable code warning does not work
+    # correctly on gcc and has been silently removed from the compiler.
+    # It is supported on clang but on OS X systems gcc may be an alias
+    # for clang.  Try to determine if the compiler is not really gcc and,
+    # if so, only then enable the warning.
+    if test "$Py_DEBUG" != "true" && \
+        test -z "`$CC --version 2>/dev/null | grep 'Free Software Foundation'`"
+    then
+        try_add_base_warnings "-Wunreachable-code" "if we can turn on $CC unreachable code warning"
     fi
 
+    #################################
+    ## *!*! DISABLED WARNINGS *!*! ##
+    #################################
     # Python doesn't violate C99 aliasing rules, but older versions of
     # GCC produce warnings for legal Python code.  Enable
     # -fno-strict-aliasing on versions of GCC that support but produce
@@ -6897,274 +6960,17 @@ $as_echo "$ac_cv_no_strict_aliasing" >&6; }
     ## XXX does it emit an unused result warning and can it be disabled?
     case "$CC" in
     *icc*)
-    ac_cv_disable_unused_result_warning=no
     ;;
     *)
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn off $CC unused result warning" >&5
-$as_echo_n "checking if we can turn off $CC unused result warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wunused-result -Werror"
-     save_CFLAGS="$CFLAGS"
-     if ${ac_cv_disable_unused_result_warning+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_disable_unused_result_warning=yes
-
-else
-
-           ac_cv_disable_unused_result_warning=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_result_warning" >&5
-$as_echo "$ac_cv_disable_unused_result_warning" >&6; }
+    try_add_base_warnings "-Wno-unused-result" "if we can turn off $CC unused result warning"
+    try_add_nodist_warnings "-Wno-unused-result" "if we can turn off $CC unused result warning"
     ;;
     esac
 
-    if test $ac_cv_disable_unused_result_warning = yes
-    then
-      BASECFLAGS="$BASECFLAGS -Wno-unused-result"
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"
-    fi
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn off $CC unused parameter warning" >&5
-$as_echo_n "checking if we can turn off $CC unused parameter warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wunused-parameter -Werror"
-     if ${ac_cv_disable_unused_parameter_warning+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
+    try_add_nodist_warnings "-Wno-unused-parameter" "if we can turn off $CC unused parameter warning"
+    try_add_nodist_warnings "-Wno-missing-field-initializers" "if we can turn off $CC missing field initializers warning"
 
 
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_disable_unused_parameter_warning=yes
-
-else
-
-           ac_cv_disable_unused_parameter_warning=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_unused_parameter_warning" >&5
-$as_echo "$ac_cv_disable_unused_parameter_warning" >&6; }
-
-    if test $ac_cv_disable_unused_parameter_warning = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"
-    fi
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn off $CC missing field initializers warning" >&5
-$as_echo_n "checking if we can turn off $CC missing field initializers warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wmissing-field-initializers -Werror"
-     if ${ac_cv_disable_missing_field_initializers+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_disable_missing_field_initializers=yes
-
-else
-
-           ac_cv_disable_missing_field_initializers=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_disable_missing_field_initializers" >&5
-$as_echo "$ac_cv_disable_missing_field_initializers" >&6; }
-
-    if test $ac_cv_disable_missing_field_initializers = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"
-    fi
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn on $CC mixed sign comparison warning" >&5
-$as_echo_n "checking if we can turn on $CC mixed sign comparison warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wsign-compare"
-     save_CFLAGS="$CFLAGS"
-     if ${ac_cv_enable_sign_compare_warning+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_enable_sign_compare_warning=yes
-
-else
-
-           ac_cv_enable_sign_compare_warning=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_sign_compare_warning" >&5
-$as_echo "$ac_cv_enable_sign_compare_warning" >&6; }
-
-    if test $ac_cv_enable_sign_compare_warning = yes
-    then
-      BASECFLAGS="$BASECFLAGS -Wsign-compare"
-    fi
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can turn on $CC unreachable code warning" >&5
-$as_echo_n "checking if we can turn on $CC unreachable code warning... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Wunreachable-code"
-     save_CFLAGS="$CFLAGS"
-     if ${ac_cv_enable_unreachable_code_warning+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_enable_unreachable_code_warning=yes
-
-else
-
-           ac_cv_enable_unreachable_code_warning=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-
-    # Don't enable unreachable code warning in debug mode, since it usually
-    # results in non-standard code paths.
-    # Issue #24324: Unfortunately, the unreachable code warning does not work
-    # correctly on gcc and has been silently removed from the compiler.
-    # It is supported on clang but on OS X systems gcc may be an alias
-    # for clang.  Try to determine if the compiler is not really gcc and,
-    # if so, only then enable the warning.
-    if test $ac_cv_enable_unreachable_code_warning = yes && \
-        test "$Py_DEBUG" != "true" && \
-        test -z "`$CC --version 2>/dev/null | grep 'Free Software Foundation'`"
-    then
-      BASECFLAGS="$BASECFLAGS -Wunreachable-code"
-    else
-      ac_cv_enable_unreachable_code_warning=no
-    fi
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_unreachable_code_warning" >&5
-$as_echo "$ac_cv_enable_unreachable_code_warning" >&6; }
-
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if we can make implicit function declaration an error in $CC" >&5
-$as_echo_n "checking if we can make implicit function declaration an error in $CC... " >&6; }
-     ac_save_cc="$CC"
-     CC="$CC -Werror=implicit-function-declaration"
-     if ${ac_cv_enable_implicit_function_declaration_error+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
-
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-
-           ac_cv_enable_implicit_function_declaration_error=yes
-
-else
-
-           ac_cv_enable_implicit_function_declaration_error=no
-
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-
-     CC="$ac_save_cc"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_enable_implicit_function_declaration_error" >&5
-$as_echo "$ac_cv_enable_implicit_function_declaration_error" >&6; }
-
-    if test $ac_cv_enable_implicit_function_declaration_error = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"
-    fi
 
     # if using gcc on alpha, use -mieee to get (near) full IEEE 754
     # support.  Without this, treatment of subnormals doesn't follow

--- a/configure.ac
+++ b/configure.ac
@@ -1562,16 +1562,17 @@ function try_add_base_warnings() {
     ################################
     ## *!*! ENABLED WARNINGS *!*! ##
     ################################
-    try_add_nodist_warnings "-Wextra" "for -Wextra"
-
-    try_add_base_warnings "-Wc99-c11-compat" "if we can turn on $CC c99/c11 compatibility warnings"
     try_add_base_warnings "-Wsign-compare" "if we can turn on $CC mixed sign comparison warning"
-    try_add_base_warnings "-Wlogical-op" "if we can turn on $CC logical-op warning"
-    try_add_base_warnings "-Wformat=2" "if we can turn on $CC format=2 warning"
-    try_add_base_warnings "-Wvarargs" "if we can turn on $CC varargs warning"
-    try_add_base_warnings "-Wuninitialized" "if we can turn on $CC uninitialized warning"
-    try_add_base_warnings "-Wcast-align" "if we can turn on $CC cast-align warning"
 
+    try_add_nodist_warnings "-Wextra" "for -Wextra"
+    try_add_nodist_warnings "-Wc99-c11-compat" "if we can turn on $CC c99/c11 compatibility warnings"
+    try_add_nodist_warnings "-Wlogical-op" "if we can turn on $CC logical-op warning"
+    try_add_nodist_warnings "-Wformat=2" "if we can turn on $CC format=2 warning"
+    try_add_nodist_warnings "-Wvarargs" "if we can turn on $CC varargs warning"
+    try_add_nodist_warnings "-Wuninitialized" "if we can turn on $CC uninitialized warning"
+    try_add_nodist_warnings "-Wcast-align" "if we can turn on $CC cast-align warning"
+
+    try_add_nodist_warnings "-Werror=implicit-function-declaration" "if we can make implicit function declaration an error in $CC"
     # Don't enable unreachable code warning in debug mode, since it usually
     # results in non-standard code paths.
     # Issue #24324: Unfortunately, the unreachable code warning does not work
@@ -1584,8 +1585,6 @@ function try_add_base_warnings() {
     then
         try_add_base_warnings "-Wunreachable-code" "if we can turn on $CC unreachable code warning"
     fi
-
-    try_add_base_warnings "-Werror=implicit-function-declaration" "if we can make implicit function declaration an error in $CC"
 
     #################################
     ## *!*! DISABLED WARNINGS *!*! ##

--- a/configure.ac
+++ b/configure.ac
@@ -1559,8 +1559,37 @@ function try_add_base_warnings() {
 
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
+    ################################
+    ## *!*! ENABLED WARNINGS *!*! ##
+    ################################
     try_add_nodist_warnings "-Wextra" "for -Wextra"
 
+    try_add_base_warnings "-Wsign-compare" "if we can turn on $CC mixed sign comparison warning"
+    try_add_base_warnings "-Wlogical-op" "if we can turn on $CC logical-op warning"
+    try_add_base_warnings "-Wformat=2" "if we can turn on $CC format=2 warning"
+    try_add_base_warnings "-Wvarargs" "if we can turn on $CC varargs warning"
+    try_add_base_warnings "-Wuninitialized" "if we can turn on $CC uninitialized warning"
+    try_add_base_warnings "-Wcast-align" "if we can turn on $CC cast-align warning"
+    try_add_base_warnings "-Wstrict-prototypes" "if we can turn on $CC strict-prototypes warning"
+
+    # Don't enable unreachable code warning in debug mode, since it usually
+    # results in non-standard code paths.
+    # Issue #24324: Unfortunately, the unreachable code warning does not work
+    # correctly on gcc and has been silently removed from the compiler.
+    # It is supported on clang but on OS X systems gcc may be an alias
+    # for clang.  Try to determine if the compiler is not really gcc and,
+    # if so, only then enable the warning.
+    if test "$Py_DEBUG" != "true" && \
+        test -z "`$CC --version 2>/dev/null | grep 'Free Software Foundation'`"
+    then
+        try_add_base_warnings "-Wunreachable-code" "if we can turn on $CC unreachable code warning"
+    fi
+
+    try_add_base_warnings "-Werror=implicit-function-declaration" "if we can make implicit function declaration an error in $CC"
+
+    #################################
+    ## *!*! DISABLED WARNINGS *!*! ##
+    #################################
     # Python doesn't violate C99 aliasing rules, but older versions of
     # GCC produce warnings for legal Python code.  Enable
     # -fno-strict-aliasing on versions of GCC that support but produce
@@ -1608,25 +1637,9 @@ function try_add_base_warnings() {
     esac
 
     try_add_nodist_warnings "-Wno-unused-parameter" "if we can turn off $CC unused parameter warning"
-
     try_add_nodist_warnings "-Wno-missing-field-initializers" "if we can turn off $CC missing field initializers warning"
 
-    try_add_base_warnings "-Wsign-compare" "if we can turn on $CC mixed sign comparison warning"
 
-    # Don't enable unreachable code warning in debug mode, since it usually
-    # results in non-standard code paths.
-    # Issue #24324: Unfortunately, the unreachable code warning does not work
-    # correctly on gcc and has been silently removed from the compiler.
-    # It is supported on clang but on OS X systems gcc may be an alias
-    # for clang.  Try to determine if the compiler is not really gcc and,
-    # if so, only then enable the warning.
-    if test "$Py_DEBUG" != "true" && \
-        test -z "`$CC --version 2>/dev/null | grep 'Free Software Foundation'`"
-    then
-        try_add_base_warnings "-Wunreachable-code" "if we can turn on $CC unreachable code warning"
-    fi
-
-    try_add_base_warnings "-Werror=implicit-function-declaration" "if we can make implicit function declaration an error in $CC"
 
     # if using gcc on alpha, use -mieee to get (near) full IEEE 754
     # support.  Without this, treatment of subnormals doesn't follow

--- a/configure.ac
+++ b/configure.ac
@@ -1571,8 +1571,9 @@ function try_add_base_warnings() {
     try_add_nodist_warnings "-Wvarargs" "if we can turn on $CC varargs warning"
     try_add_nodist_warnings "-Wuninitialized" "if we can turn on $CC uninitialized warning"
     try_add_nodist_warnings "-Wcast-align" "if we can turn on $CC cast-align warning"
-
+    try_add_nodist_warnings "-Wshadow" "if we can turn on $CC shadow warning"
     try_add_nodist_warnings "-Werror=implicit-function-declaration" "if we can make implicit function declaration an error in $CC"
+
     # Don't enable unreachable code warning in debug mode, since it usually
     # results in non-standard code paths.
     # Issue #24324: Unfortunately, the unreachable code warning does not work

--- a/configure.ac
+++ b/configure.ac
@@ -1514,7 +1514,7 @@ yes)
 #
 # NOTE: DO NOT USE THIS FUCNTION DIRECTRY.
 #       Please use the below functions instead.
-function _add_flags_helper() {
+function _try_add_warnings_helper() {
     # Remove the '-W' prefix. Substituted for e.g. "ac_cv_extra_warning"
     ac_cv_var="ac_cv_${2:2}_warning"
 
@@ -1529,6 +1529,7 @@ function _add_flags_helper() {
     AC_MSG_CHECKING($3)
      ac_save_cc="$CC"
      CC="$CC $2 -Werror"
+
      AC_CACHE_VAL(!ac_cv_var,
        AC_COMPILE_IFELSE(
          [
@@ -1549,16 +1550,16 @@ function _add_flags_helper() {
 
 # $1 = The warning to add (Including the '-W' prefix)
 # $2 = The message to display for the check
-function add_nodist_flags() {
-	_add_flags_helper "CFLAGS_NODIST" $1 $2
+function try_add_nodist_warnings() {
+    _try_add_warnings_helper "CFLAGS_NODIST" $1 $2
 }
-function add_base_flags() {
-	_add_flags_helper "BASECFLAGS" $1 $2
+function try_add_base_warnings() {
+    _try_add_warnings_helper "BASECFLAGS" $1 $2
 }
 
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
-    add_nodist_flags "-Wextra" "for -Wextra"
+    try_add_nodist_warnings "-Wextra" "for -Wextra"
 
     # Python doesn't violate C99 aliasing rules, but older versions of
     # GCC produce warnings for legal Python code.  Enable
@@ -1599,75 +1600,18 @@ function add_base_flags() {
     ## XXX does it emit an unused result warning and can it be disabled?
     case "$CC" in
     *icc*)
-    ac_cv_disable_unused_result_warning=no
     ;;
     *)
-    AC_MSG_CHECKING(if we can turn off $CC unused result warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wunused-result -Werror"
-     save_CFLAGS="$CFLAGS"
-     AC_CACHE_VAL(ac_cv_disable_unused_result_warning,
-       AC_COMPILE_IFELSE(
-         [
-	   AC_LANG_PROGRAM([[]], [[]])
-	 ],[
-           ac_cv_disable_unused_result_warning=yes
-	 ],[
-           ac_cv_disable_unused_result_warning=no
-	 ]))
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_disable_unused_result_warning)
+    try_add_base_warnings "-Wno-unused-result" "if we can turn off $CC unused result warning"
+    try_add_nodist_warnings "-Wno-unused-result" "if we can turn off $CC unused result warning"
     ;;
     esac
 
-    if test $ac_cv_disable_unused_result_warning = yes
-    then
-      BASECFLAGS="$BASECFLAGS -Wno-unused-result"
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-result"
-    fi
+    try_add_nodist_warnings "-Wno-unused-parameter" "if we can turn off $CC unused parameter warning"
 
-    AC_MSG_CHECKING(if we can turn off $CC unused parameter warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wunused-parameter -Werror"
-     AC_CACHE_VAL(ac_cv_disable_unused_parameter_warning,
-       AC_COMPILE_IFELSE(
-         [
-           AC_LANG_PROGRAM([[]], [[]])
-         ],[
-           ac_cv_disable_unused_parameter_warning=yes
-         ],[
-           ac_cv_disable_unused_parameter_warning=no
-         ]))
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_disable_unused_parameter_warning)
+    try_add_nodist_warnings "-Wno-missing-field-initializers" "if we can turn off $CC missing field initializers warning"
 
-    if test $ac_cv_disable_unused_parameter_warning = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-unused-parameter"
-    fi
-
-    AC_MSG_CHECKING(if we can turn off $CC missing field initializers warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wmissing-field-initializers -Werror"
-     AC_CACHE_VAL(ac_cv_disable_missing_field_initializers,
-       AC_COMPILE_IFELSE(
-         [
-           AC_LANG_PROGRAM([[]], [[]])
-         ],[
-           ac_cv_disable_missing_field_initializers=yes
-         ],[
-           ac_cv_disable_missing_field_initializers=no
-         ]))
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_disable_missing_field_initializers)
-
-    if test $ac_cv_disable_missing_field_initializers = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"
-    fi
-
-    add_base_flags "-Wsign-compare" "if we can turn on $CC mixed sign comparison warning"
+    try_add_base_warnings "-Wsign-compare" "if we can turn on $CC mixed sign comparison warning"
 
     # Don't enable unreachable code warning in debug mode, since it usually
     # results in non-standard code paths.
@@ -1679,10 +1623,10 @@ function add_base_flags() {
     if test "$Py_DEBUG" != "true" && \
         test -z "`$CC --version 2>/dev/null | grep 'Free Software Foundation'`"
     then
-        add_base_flags "-Wunreachable-code" "if we can turn on $CC unreachable code warning"
+        try_add_base_warnings "-Wunreachable-code" "if we can turn on $CC unreachable code warning"
     fi
 
-    add_base_flags "-Werror=implicit-function-declaration" "if we can make implicit function declaration an error in $CC"
+    try_add_base_warnings "-Werror=implicit-function-declaration" "if we can make implicit function declaration an error in $CC"
 
     # if using gcc on alpha, use -mieee to get (near) full IEEE 754
     # support.  Without this, treatment of subnormals doesn't follow

--- a/configure.ac
+++ b/configure.ac
@@ -1505,27 +1505,60 @@ AC_SUBST(UNIVERSAL_ARCH_FLAGS)
 # tweak BASECFLAGS based on compiler and platform
 case $GCC in
 yes)
-    CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
 
-    AC_MSG_CHECKING(for -Wextra)
+
+# $1 = [Output] The name of the variable to concat the given flag
+#        (e.g. CFLAGS_NODIST, BASECFLAGS..)
+# $2 = The warning to add (Including the '-W' prefix)
+# $3 = The message to display for the check
+#
+# NOTE: DO NOT USE THIS FUCNTION DIRECTRY.
+#       Please use the below functions instead.
+function _add_flags_helper() {
+    # Remove the '-W' prefix. Substituted for e.g. "ac_cv_extra_warning"
+    ac_cv_var="ac_cv_${2:2}_warning"
+
+    # Handle warnings with multiple words: e.g. "-Wcast-align"
+    # Turn it into "cast_align"
+    ac_cv_var="${ac_cv_var//-/_}"
+
+    # Handle cases where we want to turn specific warnings into errors.
+    # In this case, we get e.g. "-Werror=logical-op".
+    # Turn it into "error_logical_op"
+    ac_cv_var="${ac_cv_var//=/_}"
+    AC_MSG_CHECKING($3)
      ac_save_cc="$CC"
-     CC="$CC -Wextra -Werror"
-     AC_CACHE_VAL(ac_cv_extra_warnings,
+     CC="$CC $2 -Werror"
+     AC_CACHE_VAL(!ac_cv_var,
        AC_COMPILE_IFELSE(
          [
            AC_LANG_PROGRAM([[]], [[]])
          ],[
-           ac_cv_extra_warnings=yes
+           eval ${ac_cv_var}=yes
          ],[
-           ac_cv_extra_warnings=no
+           eval ${ac_cv_var}=no
          ]))
      CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_extra_warnings)
+    AC_MSG_RESULT(${!ac_cv_var})
 
-    if test $ac_cv_extra_warnings = yes
+    if test ${!ac_cv_var} = yes
     then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Wextra"
+      eval ${1}="\"${!1} $2\""
     fi
+}
+
+# $1 = The warning to add (Including the '-W' prefix)
+# $2 = The message to display for the check
+function add_nodist_flags() {
+	_add_flags_helper "CFLAGS_NODIST" $1 $2
+}
+function add_base_flags() {
+	_add_flags_helper "BASECFLAGS" $1 $2
+}
+
+    CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
+
+    add_nodist_flags "-Wextra" "for -Wextra"
 
     # Python doesn't violate C99 aliasing rules, but older versions of
     # GCC produce warnings for legal Python code.  Enable
@@ -1634,43 +1667,7 @@ yes)
       CFLAGS_NODIST="$CFLAGS_NODIST -Wno-missing-field-initializers"
     fi
 
-    AC_MSG_CHECKING(if we can turn on $CC mixed sign comparison warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wsign-compare"
-     save_CFLAGS="$CFLAGS"
-     AC_CACHE_VAL(ac_cv_enable_sign_compare_warning,
-       AC_COMPILE_IFELSE(
-         [
-	   AC_LANG_PROGRAM([[]], [[]])
-	 ],[
-           ac_cv_enable_sign_compare_warning=yes
-	 ],[
-           ac_cv_enable_sign_compare_warning=no
-	 ]))
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_enable_sign_compare_warning)
-
-    if test $ac_cv_enable_sign_compare_warning = yes
-    then
-      BASECFLAGS="$BASECFLAGS -Wsign-compare"
-    fi
-
-    AC_MSG_CHECKING(if we can turn on $CC unreachable code warning)
-     ac_save_cc="$CC"
-     CC="$CC -Wunreachable-code"
-     save_CFLAGS="$CFLAGS"
-     AC_CACHE_VAL(ac_cv_enable_unreachable_code_warning,
-       AC_COMPILE_IFELSE(
-         [
-	   AC_LANG_PROGRAM([[]], [[]])
-	 ],[
-           ac_cv_enable_unreachable_code_warning=yes
-	 ],[
-           ac_cv_enable_unreachable_code_warning=no
-	 ]))
-     CFLAGS="$save_CFLAGS"
-     CC="$ac_save_cc"
+    add_base_flags "-Wsign-compare" "if we can turn on $CC mixed sign comparison warning"
 
     # Don't enable unreachable code warning in debug mode, since it usually
     # results in non-standard code paths.
@@ -1679,35 +1676,13 @@ yes)
     # It is supported on clang but on OS X systems gcc may be an alias
     # for clang.  Try to determine if the compiler is not really gcc and,
     # if so, only then enable the warning.
-    if test $ac_cv_enable_unreachable_code_warning = yes && \
-        test "$Py_DEBUG" != "true" && \
+    if test "$Py_DEBUG" != "true" && \
         test -z "`$CC --version 2>/dev/null | grep 'Free Software Foundation'`"
     then
-      BASECFLAGS="$BASECFLAGS -Wunreachable-code"
-    else
-      ac_cv_enable_unreachable_code_warning=no
+        add_base_flags "-Wunreachable-code" "if we can turn on $CC unreachable code warning"
     fi
-    AC_MSG_RESULT($ac_cv_enable_unreachable_code_warning)
 
-    AC_MSG_CHECKING(if we can make implicit function declaration an error in $CC)
-     ac_save_cc="$CC"
-     CC="$CC -Werror=implicit-function-declaration"
-     AC_CACHE_VAL(ac_cv_enable_implicit_function_declaration_error,
-       AC_COMPILE_IFELSE(
-         [
-	   AC_LANG_PROGRAM([[]], [[]])
-	 ],[
-           ac_cv_enable_implicit_function_declaration_error=yes
-	 ],[
-           ac_cv_enable_implicit_function_declaration_error=no
-	 ]))
-     CC="$ac_save_cc"
-    AC_MSG_RESULT($ac_cv_enable_implicit_function_declaration_error)
-
-    if test $ac_cv_enable_implicit_function_declaration_error = yes
-    then
-      CFLAGS_NODIST="$CFLAGS_NODIST -Werror=implicit-function-declaration"
-    fi
+    add_base_flags "-Werror=implicit-function-declaration" "if we can make implicit function declaration an error in $CC"
 
     # if using gcc on alpha, use -mieee to get (near) full IEEE 754
     # support.  Without this, treatment of subnormals doesn't follow

--- a/configure.ac
+++ b/configure.ac
@@ -1551,10 +1551,10 @@ function _try_add_warnings_helper() {
 # $1 = The warning to add (Including the '-W' prefix)
 # $2 = The message to display for the check
 function try_add_nodist_warnings() {
-    _try_add_warnings_helper "CFLAGS_NODIST" $1 $2
+    _try_add_warnings_helper "CFLAGS_NODIST" "$1" "$2"
 }
 function try_add_base_warnings() {
-    _try_add_warnings_helper "BASECFLAGS" $1 $2
+    _try_add_warnings_helper "BASECFLAGS" "$1" "$2"
 }
 
     CFLAGS_NODIST="$CFLAGS_NODIST -std=c99"
@@ -1564,13 +1564,13 @@ function try_add_base_warnings() {
     ################################
     try_add_nodist_warnings "-Wextra" "for -Wextra"
 
+    try_add_base_warnings "-Wc99-c11-compat" "if we can turn on $CC c99/c11 compatibility warnings"
     try_add_base_warnings "-Wsign-compare" "if we can turn on $CC mixed sign comparison warning"
     try_add_base_warnings "-Wlogical-op" "if we can turn on $CC logical-op warning"
     try_add_base_warnings "-Wformat=2" "if we can turn on $CC format=2 warning"
     try_add_base_warnings "-Wvarargs" "if we can turn on $CC varargs warning"
     try_add_base_warnings "-Wuninitialized" "if we can turn on $CC uninitialized warning"
     try_add_base_warnings "-Wcast-align" "if we can turn on $CC cast-align warning"
-    try_add_base_warnings "-Wstrict-prototypes" "if we can turn on $CC strict-prototypes warning"
 
     # Don't enable unreachable code warning in debug mode, since it usually
     # results in non-standard code paths.


### PR DESCRIPTION
Added the following new warnings when compiling with gcc:
-Wc99-c11-compat
-Wlogical-op
-Wformat=2
-Wvarargs
-Wuninitialized
-Wcast-align
-Wshadow
And fixed the warnings (-Wshadow being the most annoying).

Also, organized a bit the "test & add"ing of warnings in configure.ac, so it should be clearer now to see the warnings in use (And nicer to add new ones)

It's my first pull request, so I hope I didn't forget anything :)