### PR TITLE
bpo-32278: Add dataclasses.Data as an alias for typing.Any

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -3,8 +3,10 @@ import types
 from copy import deepcopy
 import collections
 import inspect
+import typing
 
-__all__ = ['dataclass',
+__all__ = ('dataclass',
+           'Data',
            'field',
            'FrozenInstanceError',
            'InitVar',
@@ -15,7 +17,9 @@ __all__ = ['dataclass',
            'astuple',
            'make_dataclass',
            'replace',
-           ]
+           )
+
+Data = typing.Any
 
 # Raised when an attempt is made to modify a frozen class.
 class FrozenInstanceError(AttributeError): pass

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1,5 +1,5 @@
 from dataclasses import (
-    dataclass, field, FrozenInstanceError, fields, asdict, astuple,
+    dataclass, Data, field, FrozenInstanceError, fields, asdict, astuple,
     make_dataclass, replace, InitVar, Field
 )
 
@@ -7,7 +7,7 @@ import pickle
 import inspect
 import unittest
 from unittest.mock import Mock
-from typing import ClassVar, Any, List, Union, Tuple, Dict, Generic, TypeVar
+from typing import ClassVar, List, Union, Tuple, Dict, Generic, TypeVar
 from collections import deque, OrderedDict, namedtuple
 
 # Just any custom exception we can catch.
@@ -200,7 +200,7 @@ class TestCase(unittest.TestCase):
         #  the same as defined in Base.
         @dataclass
         class Base:
-            x: Any = 15.0
+            x: Data = 15.0
             y: int = 0
 
         @dataclass


### PR DESCRIPTION
As suggested in a recent python-dev discussion:
 https://groups.google.com/d/msg/dev-python/DIFX5Gf85Gs/eg53gekFDAAJ

For people who do not want to use or promote the typing module.  It
allows for the following readable idiom when one does not care to
declare types.

```python
from dataclasses import dataclass, Data

@dataclass
class Swallow:
    weight_in_oz: Data = 5
    laden: Data = False
```

<!-- issue-number: bpo-32278 -->
https://bugs.python.org/issue32278
<!-- /issue-number -->
