### PR TITLE
bpo-32357: Use PySet_GET_SIZE macro in _is_coroutine() from _asynciomodule.c 

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -142,7 +142,11 @@ _is_coroutine(PyObject *coro)
         return is_res_true;
     }
 
-    if (PySet_Size(iscoroutine_typecache) < 100) {
+    Py_ssize_t size = PySet_Size(iscoroutine_typecache);
+    if (size < 0) {
+	return -1;
+    }
+    if (size < 100) {
         /* Just in case we don't want to cache more than 100
            positive types.  That shouldn't ever happen, unless
            someone stressing the system on purpose.
@@ -3023,7 +3027,7 @@ _asyncio__leave_task_impl(PyObject *module, PyObject *loop, PyObject *task)
 
 
 static void
-module_free_freelists()
+module_free_freelists(void)
 {
     PyObject *next;
     PyObject *current;

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -142,11 +142,7 @@ _is_coroutine(PyObject *coro)
         return is_res_true;
     }
 
-    Py_ssize_t size = PySet_Size(iscoroutine_typecache);
-    if (size < 0) {
-        return -1;
-    }
-    if (size < 100) {
+    if (PySet_GET_SIZE(iscoroutine_typecache) < 100) {
         /* Just in case we don't want to cache more than 100
            positive types.  That shouldn't ever happen, unless
            someone stressing the system on purpose.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -144,7 +144,7 @@ _is_coroutine(PyObject *coro)
 
     Py_ssize_t size = PySet_Size(iscoroutine_typecache);
     if (size < 0) {
-	return -1;
+        return -1;
     }
     if (size < 100) {
         /* Just in case we don't want to cache more than 100


### PR DESCRIPTION
PySet_Size can fail if passed object is not a set.
It's not the case, pretty sure -- but let's add a check for better code readability.

<!-- issue-number: bpo-32357 -->
https://bugs.python.org/issue32357
<!-- /issue-number -->
