### PR TITLE
bpo-32403: Faster date and datetime constructors

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1552,6 +1552,54 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         self.assertEqual(dt1.toordinal(), dt2.toordinal())
         self.assertEqual(dt2.newmeth(-7), dt1.year + dt1.month - 7)
 
+    def test_subclass_alternate_constructors(self):
+        # Test that alternate constructors call the constructor
+        class DateSubclass(self.theclass):
+            def __new__(cls, *args, **kwargs):
+                result = self.theclass.__new__(cls, *args, **kwargs)
+                result.extra = 7
+
+                return result
+
+        args = (2003, 4, 14)
+        ts = 1050292800.0           # Equivalent timestamp
+        d_ord = 731319              # Equivalent ordinal date
+        d_isoformat = '2003-04-14'  # Equivalent isoformat()
+
+        base_d = DateSubclass(*args)
+        self.assertIsInstance(base_d, DateSubclass)
+        self.assertEqual(base_d.extra, 7)
+
+        test_cases = [
+            ('fromordinal', (d_ord,)),
+            ('fromtimestamp', (ts,)),
+            ('fromisoformat', (d_isoformat,)),
+        ]
+
+        for constr_name, constr_args in test_cases:
+            if (issubclass(self.theclass, datetime) and
+                    constr_name == 'fromtimestamp'):
+                # Known failure for datetime.fromtimestamp
+                # See bpo-32404
+                continue
+
+            for base_obj in (DateSubclass, base_d):
+                # Test both the classmethod and method
+                with self.subTest(base_obj_type=type(base_obj),
+                                  constr_name=constr_name):
+                    constr = getattr(base_obj, constr_name)
+
+                    dt = constr(*constr_args)
+
+                    # Test that it creates the right subclass
+                    self.assertIsInstance(dt, DateSubclass)
+
+                    # Test that it's equal to the base object
+                    self.assertEqual(dt, base_d)
+
+                    # Test that it called the constructor
+                    self.assertEqual(dt.extra, 7)
+
     def test_pickling_subclass_date(self):
 
         args = 6, 7, 23

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1562,13 +1562,15 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
                 return result
 
         args = (2003, 4, 14)
-        ts = 1050292800.0           # Equivalent timestamp
         d_ord = 731319              # Equivalent ordinal date
         d_isoformat = '2003-04-14'  # Equivalent isoformat()
 
         base_d = DateSubclass(*args)
         self.assertIsInstance(base_d, DateSubclass)
         self.assertEqual(base_d.extra, 7)
+
+        # Timestamp depends on time zone, so we'll calculate the equivalent here
+        ts = datetime.combine(base_d, time(0)).timestamp()
 
         test_cases = [
             ('fromordinal', (d_ord,)),
@@ -1577,12 +1579,6 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         ]
 
         for constr_name, constr_args in test_cases:
-            if (issubclass(self.theclass, datetime) and
-                    constr_name == 'fromtimestamp'):
-                # Known failure for datetime.fromtimestamp
-                # See bpo-32404
-                continue
-
             for base_obj in (DateSubclass, base_d):
                 # Test both the classmethod and method
                 with self.subTest(base_obj_type=type(base_obj),
@@ -2467,6 +2463,54 @@ class TestDateTime(TestDate):
         self.assertEqual(dt1.toordinal(), dt2.toordinal())
         self.assertEqual(dt2.newmeth(-7), dt1.year + dt1.month +
                                           dt1.second - 7)
+
+    def test_subclass_alternate_constructors_datetime(self):
+        # Test that alternate constructors call the constructor
+        class DateTimeSubclass(self.theclass):
+            def __new__(cls, *args, **kwargs):
+                result = self.theclass.__new__(cls, *args, **kwargs)
+                result.extra = 7
+
+                return result
+
+        args = (2003, 4, 14, 12, 30, 15, 123456)
+        d_isoformat = '2003-04-14T12:30:15.123456'      # Equivalent isoformat()
+        utc_ts = 1050323415.123456                      # UTC timestamp
+
+        base_d = DateTimeSubclass(*args)
+        self.assertIsInstance(base_d, DateTimeSubclass)
+        self.assertEqual(base_d.extra, 7)
+
+        # Timestamp depends on time zone, so we'll calculate the equivalent here
+        ts = base_d.timestamp()
+
+        test_cases = [
+            ('fromtimestamp', (ts,)),
+            # See https://bugs.python.org/issue32417
+            # ('fromtimestamp', (ts, timezone.utc)),
+            ('utcfromtimestamp', (utc_ts,)),
+            ('fromisoformat', (d_isoformat,)),
+            ('strptime', (d_isoformat, '%Y-%m-%dT%H:%M:%S.%f')),
+            ('combine', (date(*args[0:3]), time(*args[3:]))),
+        ]
+
+        for constr_name, constr_args in test_cases:
+            for base_obj in (DateTimeSubclass, base_d):
+                # Test both the classmethod and method
+                with self.subTest(base_obj_type=type(base_obj),
+                                  constr_name=constr_name):
+                    constr = getattr(base_obj, constr_name)
+
+                    dt = constr(*constr_args)
+
+                    # Test that it creates the right subclass
+                    self.assertIsInstance(dt, DateTimeSubclass)
+
+                    # Test that it's equal to the base object
+                    self.assertEqual(dt, base_d.replace(tzinfo=None))
+
+                    # Test that it called the constructor
+                    self.assertEqual(dt.extra, 7)
 
     def test_fromisoformat_datetime(self):
         # Test that isoformat() is reversible

--- a/Misc/NEWS.d/next/Library/2017-12-23-14-51-46.bpo-32403.CVFapH.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-23-14-51-46.bpo-32403.CVFapH.rst
@@ -1,0 +1,2 @@
+Improved speed of :class:`datetime.date` and :class:`datetime.datetime`
+alternate constructors.

--- a/Misc/NEWS.d/next/Library/2017-12-23-14-54-05.bpo-32404.yJqtlJ.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-23-14-54-05.bpo-32404.yJqtlJ.rst
@@ -1,0 +1,2 @@
+Fix bug where :meth:`datetime.datetime.fromtimestamp` did not call __new__
+in :class:`datetime.datetime` subclasses.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -844,21 +844,29 @@ new_date_ex(int year, int month, int day, PyTypeObject *type)
     return (PyObject *) self;
 }
 
+#define new_date(year, month, day) \
+    new_date_ex(year, month, day, &PyDateTime_DateType)
+
+// Forward declaration
+static PyObject * new_datetime_ex(int, int, int, int, int, int, int,
+                                  PyObject*, PyTypeObject*);
+
 /* Create date instance with no range checking, or call subclass constructor */
 static PyObject *
 new_date_subclass_ex(int year, int month, int day, PyObject *cls) {
     PyObject *result;
+    // We have "fast path" constructors for two subclasses: date and datetime
     if ((PyTypeObject *)cls == &PyDateTime_DateType) {
         result = new_date_ex(year, month, day, (PyTypeObject *)cls);
+    } else if ((PyTypeObject *)cls == &PyDateTime_DateTimeType) {
+        result = new_datetime_ex(year, month, day, 0, 0, 0, 0, Py_None,
+                                 (PyTypeObject *)cls);
     } else {
         result = PyObject_CallFunction(cls, "iii", year, month, day);
     }
 
     return result;
 }
-
-#define new_date(year, month, day) \
-    new_date_ex(year, month, day, &PyDateTime_DateType)
 
 /* Create a datetime instance with no range checking. */
 static PyObject *

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4810,18 +4810,16 @@ datetime_combine(PyObject *cls, PyObject *args, PyObject *kw)
             else
                 tzinfo = Py_None;
         }
-        result = new_datetime_subclass_ex(GET_YEAR(date),
-                                          GET_MONTH(date),
-                                          GET_DAY(date),
-                                          TIME_GET_HOUR(time),
-                                          TIME_GET_MINUTE(time),
-                                          TIME_GET_SECOND(time),
-                                          TIME_GET_MICROSECOND(time),
-                                          tzinfo,
-                                          cls);
-
-        if (result)
-            DATE_SET_FOLD(result, TIME_GET_FOLD(time));
+        result = new_datetime_subclass_fold_ex(GET_YEAR(date),
+                                               GET_MONTH(date),
+                                               GET_DAY(date),
+                                               TIME_GET_HOUR(time),
+                                               TIME_GET_MINUTE(time),
+                                               TIME_GET_SECOND(time),
+                                               TIME_GET_MICROSECOND(time),
+                                               tzinfo,
+                                               TIME_GET_FOLD(time),
+                                               cls);
     }
     return result;
 }


### PR DESCRIPTION
This fixes [bpo-32403](https://bugs.python.org/issue32403) and [bpo-32404](https://bugs.python.org/issue32404). The first one is a performance enhancement, the second is a bugfix.

Using [this script to benchmark the alternate constructors](https://gist.github.com/pganssle/15875840f31be893e7c98958730657bb), I see significant improvements in speed across the board (note that since the subclasses don't take the fast path, they are a reasonable proxy for the speed from *before* this patch). You can see the results on my laptop (using the debug build, not the profiling optimized build) below:

```
Running with N = 10000, k=20
                   |           datetime           |       DateTimeSubclass       
=================================================================================
constructor        |  1416.5  [1463.9 (±71) ns]   |  1494.8  [1569.2 (±119) ns]  
fromordinal        |  1081.5  [1117.2 (±24) ns]   |  2180.7  [2357.3 (±279) ns]  
fromisoformat      |   928.8   [962.5 (±34) ns]   |  2834.8  [3179.7 (±281) ns]  
fromtimestamp      |  1504.3  [1600.9 (±63) ns]   |  3625.1  [3869.6 (±280) ns]  
utcfromtimestamp   |  1178.6  [1281.2 (±172) ns]  |  3242.6  [3445.0 (±205) ns]  
combine            |  1060.1  [1111.0 (±73) ns]   |  2808.7  [3013.0 (±236) ns]  
now                |  1219.3  [1325.0 (±216) ns]  |  3625.5  [3892.7 (±300) ns]  
today              |  4868.5  [5261.0 (±565) ns]  |  7189.5  [7663.0 (±436) ns]  
=================================================================================
                   |             date             |         DateSubclass         
=================================================================================
constructor        |  974.5   [1010.1 (±39) ns]   |  1114.7  [1298.8 (±229) ns]  
fromordinal        |  1059.7  [1109.4 (±59) ns]   |  1923.1  [2258.8 (±375) ns]  
fromisoformat      |  817.5   [905.1 (±123) ns]   |  1734.1  [2160.8 (±542) ns]  
fromtimestamp      |  1285.4  [1484.7 (±378) ns]  |  2363.6  [3038.6 (±783) ns]  
today              |  4551.7  [4976.6 (±584) ns]  |  5828.9  [6883.9 (±934) ns]  
=================================================================================
```

For comparision, here is the same script run against master:
```
Running with N = 10000, k=20
                   |           datetime           |       DateTimeSubclass       
=================================================================================
constructor        |  1335.9  [1350.3 (±24) ns]   |  1406.0  [1426.9 (±15) ns]   
fromordinal        |  1905.0  [1948.3 (±42) ns]   |  2011.5  [2055.4 (±32) ns]   
fromisoformat      |   918.1   [929.3 (±6) ns]    |  2660.8  [2707.7 (±25) ns]   
fromtimestamp      |  1570.1  [1611.8 (±28) ns]   |  1732.1  [1766.3 (±30) ns]   
utcfromtimestamp   |  1202.7  [1234.5 (±18) ns]   |  1334.9  [1371.7 (±26) ns]   
combine            |  2584.9  [2626.3 (±22) ns]   |  2722.8  [2759.8 (±25) ns]   
now                |   1317.2  [1338.2 (±9) ns]   |  1509.7  [1563.7 (±24) ns]   
today              |  5027.1  [5096.9 (±71) ns]   |  5237.6  [5334.9 (±73) ns]   
=================================================================================
                   |             date             |         DateSubclass         
=================================================================================
constructor        |   912.8   [928.8 (±15) ns]   |   996.4   [1003.9 (±7) ns]   
fromordinal        |  1662.9  [1706.4 (±40) ns]   |  1773.6  [1820.7 (±41) ns]   
fromisoformat      |   818.5   [829.0 (±9) ns]    |  1630.0  [1743.3 (±289) ns]  
fromtimestamp      |  2155.2  [2213.4 (±41) ns]   |  2321.9  [2486.9 (±590) ns]  
today              |  5502.0  [5624.6 (±76) ns]   |  5679.8  [5845.4 (±445) ns]  
=================================================================================
```

<!-- issue-number: bpo-32403 -->
https://bugs.python.org/issue32403
<!-- /issue-number -->
