### PR TITLE
bpo-32360: Remove OrderedDict reference as dicts are ordered now

### DIFF
--- a/Lib/unittest/util.py
+++ b/Lib/unittest/util.py
@@ -1,6 +1,6 @@
 """Various utility functions."""
 
-from collections import namedtuple, OrderedDict
+from collections import namedtuple
 from os.path import commonprefix
 
 __unittest = True
@@ -155,7 +155,7 @@ def _count_diff_all_purpose(actual, expected):
 
 def _ordered_count(iterable):
     'Return dict of element counts, in the order they were first seen'
-    c = OrderedDict()
+    c = {}
     for elem in iterable:
         c[elem] = c.get(elem, 0) + 1
     return c

--- a/Lib/unittest/util.py
+++ b/Lib/unittest/util.py
@@ -1,6 +1,6 @@
 """Various utility functions."""
 
-from collections import namedtuple
+from collections import namedtuple, Counter
 from os.path import commonprefix
 
 __unittest = True
@@ -153,17 +153,10 @@ def _count_diff_all_purpose(actual, expected):
         result.append(diff)
     return result
 
-def _ordered_count(iterable):
-    'Return dict of element counts, in the order they were first seen'
-    c = {}
-    for elem in iterable:
-        c[elem] = c.get(elem, 0) + 1
-    return c
-
 def _count_diff_hashable(actual, expected):
     'Returns list of (cnt_act, cnt_exp, elem) triples where the counts differ'
     # elements must be hashable
-    s, t = _ordered_count(actual), _ordered_count(expected)
+    s, t = Counter(actual), Counter(expected)
     result = []
     for elem, cnt_s in s.items():
         cnt_t = t.get(elem, 0)


### PR DESCRIPTION


<!-- issue-number: bpo-32360 -->
https://bugs.python.org/issue32360
<!-- /issue-number -->
