### PR TITLE
bpo-32360: Remove object_pairs_hook=OrderedDict examples

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -230,8 +230,8 @@ Basic Usage
    *object_pairs_hook* is an optional function that will be called with the
    result of any object literal decoded with an ordered list of pairs.  The
    return value of *object_pairs_hook* will be used instead of the
-   :class:`dict`.  This feature can be used to implement custom decoders that
-   rely on the order that the key and value pairs are decoded. If *object_hook*
+   :class:`dict`.  This feature can be used to implement custom decoders (for
+   example, sort keys before creating dict).  If *object_hook*
    is also defined, the *object_pairs_hook* takes priority.
 
    .. versionchanged:: 3.1
@@ -324,9 +324,9 @@ Encoders and Decoders
    *object_pairs_hook*, if specified will be called with the result of every
    JSON object decoded with an ordered list of pairs.  The return value of
    *object_pairs_hook* will be used instead of the :class:`dict`.  This
-   feature can be used to implement custom decoders that rely on the order
-   that the key and value pairs are decoded. If *object_hook* is also defined,
-   the *object_pairs_hook* takes priority.
+   feature can be used to implement custom decoders (for example, sort keys
+   before creating dict).  If *object_hook* is also defined, the
+   *object_pairs_hook* takes priority.
 
    .. versionchanged:: 3.1
       Added support for *object_pairs_hook*.

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -231,9 +231,8 @@ Basic Usage
    result of any object literal decoded with an ordered list of pairs.  The
    return value of *object_pairs_hook* will be used instead of the
    :class:`dict`.  This feature can be used to implement custom decoders that
-   rely on the order that the key and value pairs are decoded (for example,
-   :func:`collections.OrderedDict` will remember the order of insertion). If
-   *object_hook* is also defined, the *object_pairs_hook* takes priority.
+   rely on the order that the key and value pairs are decoded. If *object_hook*
+   is also defined, the *object_pairs_hook* takes priority.
 
    .. versionchanged:: 3.1
       Added support for *object_pairs_hook*.
@@ -326,9 +325,8 @@ Encoders and Decoders
    JSON object decoded with an ordered list of pairs.  The return value of
    *object_pairs_hook* will be used instead of the :class:`dict`.  This
    feature can be used to implement custom decoders that rely on the order
-   that the key and value pairs are decoded (for example,
-   :func:`collections.OrderedDict` will remember the order of insertion). If
-   *object_hook* is also defined, the *object_pairs_hook* takes priority.
+   that the key and value pairs are decoded. If *object_hook* is also defined,
+   the *object_pairs_hook* takes priority.
 
    .. versionchanged:: 3.1
       Added support for *object_pairs_hook*.

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -230,9 +230,8 @@ Basic Usage
    *object_pairs_hook* is an optional function that will be called with the
    result of any object literal decoded with an ordered list of pairs.  The
    return value of *object_pairs_hook* will be used instead of the
-   :class:`dict`.  This feature can be used to implement custom decoders (for
-   example, sort keys before creating dict).  If *object_hook*
-   is also defined, the *object_pairs_hook* takes priority.
+   :class:`dict`.  This feature can be used to implement custom decoders.
+   If *object_hook* is also defined, the *object_pairs_hook* takes priority.
 
    .. versionchanged:: 3.1
       Added support for *object_pairs_hook*.
@@ -324,9 +323,8 @@ Encoders and Decoders
    *object_pairs_hook*, if specified will be called with the result of every
    JSON object decoded with an ordered list of pairs.  The return value of
    *object_pairs_hook* will be used instead of the :class:`dict`.  This
-   feature can be used to implement custom decoders (for example, sort keys
-   before creating dict).  If *object_hook* is also defined, the
-   *object_pairs_hook* takes priority.
+   feature can be used to implement custom decoders.  If *object_hook* is also
+   defined, the *object_pairs_hook* takes priority.
 
    .. versionchanged:: 3.1
       Added support for *object_pairs_hook*.

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -284,9 +284,9 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
     ``object_pairs_hook`` is an optional function that will be called with the
     result of any object literal decoded with an ordered list of pairs.  The
     return value of ``object_pairs_hook`` will be used instead of the ``dict``.
-    This feature can be used to implement custom decoders that rely on the
-    order that the key and value pairs are decoded. If ``object_hook`` is also
-    defined, the ``object_pairs_hook`` takes priority.
+    This feature can be used to implement custom decoders (e.g. sort by keys
+    before creating dict).  If ``object_hook`` is also defined, the
+    ``object_pairs_hook`` takes priority.
 
     To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
     kwarg; otherwise ``JSONDecoder`` is used.
@@ -311,9 +311,9 @@ def loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None,
     ``object_pairs_hook`` is an optional function that will be called with the
     result of any object literal decoded with an ordered list of pairs.  The
     return value of ``object_pairs_hook`` will be used instead of the ``dict``.
-    This feature can be used to implement custom decoders that rely on the
-    order that the key and value pairs are decoded. If ``object_hook`` is also
-    defined, the ``object_pairs_hook`` takes priority.
+    This feature can be used to implement custom decoders (e.g. sort by keys
+    before creating dict).  If ``object_hook`` is also defined, the
+    ``object_pairs_hook`` takes priority.
 
     ``parse_float``, if specified, will be called with the string
     of every JSON float to be decoded. By default this is equivalent to

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -28,8 +28,7 @@ Encoding basic Python object hierarchies::
 Compact encoding::
 
     >>> import json
-    >>> from collections import OrderedDict
-    >>> mydict = OrderedDict([('4', 5), ('6', 7)])
+    >>> mydict = {'4': 5, '6': 7}
     >>> json.dumps([1,2,3,mydict], separators=(',', ':'))
     '[1,2,3,{"4":5,"6":7}]'
 
@@ -286,9 +285,8 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
     result of any object literal decoded with an ordered list of pairs.  The
     return value of ``object_pairs_hook`` will be used instead of the ``dict``.
     This feature can be used to implement custom decoders that rely on the
-    order that the key and value pairs are decoded (for example,
-    collections.OrderedDict will remember the order of insertion). If
-    ``object_hook`` is also defined, the ``object_pairs_hook`` takes priority.
+    order that the key and value pairs are decoded. If ``object_hook`` is also
+    defined, the ``object_pairs_hook`` takes priority.
 
     To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
     kwarg; otherwise ``JSONDecoder`` is used.
@@ -314,9 +312,8 @@ def loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None,
     result of any object literal decoded with an ordered list of pairs.  The
     return value of ``object_pairs_hook`` will be used instead of the ``dict``.
     This feature can be used to implement custom decoders that rely on the
-    order that the key and value pairs are decoded (for example,
-    collections.OrderedDict will remember the order of insertion). If
-    ``object_hook`` is also defined, the ``object_pairs_hook`` takes priority.
+    order that the key and value pairs are decoded. If ``object_hook`` is also
+    defined, the ``object_pairs_hook`` takes priority.
 
     ``parse_float``, if specified, will be called with the string
     of every JSON float to be decoded. By default this is equivalent to

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -284,13 +284,11 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
     ``object_pairs_hook`` is an optional function that will be called with the
     result of any object literal decoded with an ordered list of pairs.  The
     return value of ``object_pairs_hook`` will be used instead of the ``dict``.
-    This feature can be used to implement custom decoders (e.g. sort by keys
-    before creating dict).  If ``object_hook`` is also defined, the
-    ``object_pairs_hook`` takes priority.
+    This feature can be used to implement custom decoders.  If ``object_hook``
+    is also defined, the ``object_pairs_hook`` takes priority.
 
     To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
     kwarg; otherwise ``JSONDecoder`` is used.
-
     """
     return loads(fp.read(),
         cls=cls, object_hook=object_hook,
@@ -311,9 +309,8 @@ def loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None,
     ``object_pairs_hook`` is an optional function that will be called with the
     result of any object literal decoded with an ordered list of pairs.  The
     return value of ``object_pairs_hook`` will be used instead of the ``dict``.
-    This feature can be used to implement custom decoders (e.g. sort by keys
-    before creating dict).  If ``object_hook`` is also defined, the
-    ``object_pairs_hook`` takes priority.
+    This feature can be used to implement custom decoders.  If ``object_hook``
+    is also defined, the ``object_pairs_hook`` takes priority.
 
     ``parse_float``, if specified, will be called with the string
     of every JSON float to be decoded. By default this is equivalent to
@@ -334,7 +331,6 @@ def loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None,
     kwarg; otherwise ``JSONDecoder`` is used.
 
     The ``encoding`` argument is ignored and deprecated.
-
     """
     if isinstance(s, str):
         if s.startswith('\ufeff'):

--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -292,9 +292,9 @@ class JSONDecoder(object):
         ``object_pairs_hook``, if specified will be called with the result of
         every JSON object decoded with an ordered list of pairs.  The return
         value of ``object_pairs_hook`` will be used instead of the ``dict``.
-        This feature can be used to implement custom decoders that rely on the
-        order that the key and value pairs are decoded. If ``object_hook``
-        is also defined, the ``object_pairs_hook`` takes priority.
+        This feature can be used to implement custom decoders (e.g. sort by
+        keys before creating dict).  If ``object_hook`` is also defined, the
+        ``object_pairs_hook`` takes priority.
 
         ``parse_float``, if specified, will be called with the string
         of every JSON float to be decoded. By default this is equivalent to

--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -293,10 +293,8 @@ class JSONDecoder(object):
         every JSON object decoded with an ordered list of pairs.  The return
         value of ``object_pairs_hook`` will be used instead of the ``dict``.
         This feature can be used to implement custom decoders that rely on the
-        order that the key and value pairs are decoded (for example,
-        collections.OrderedDict will remember the order of insertion). If
-        ``object_hook`` is also defined, the ``object_pairs_hook`` takes
-        priority.
+        order that the key and value pairs are decoded. If ``object_hook``
+        is also defined, the ``object_pairs_hook`` takes priority.
 
         ``parse_float``, if specified, will be called with the string
         of every JSON float to be decoded. By default this is equivalent to

--- a/Lib/json/decoder.py
+++ b/Lib/json/decoder.py
@@ -292,9 +292,9 @@ class JSONDecoder(object):
         ``object_pairs_hook``, if specified will be called with the result of
         every JSON object decoded with an ordered list of pairs.  The return
         value of ``object_pairs_hook`` will be used instead of the ``dict``.
-        This feature can be used to implement custom decoders (e.g. sort by
-        keys before creating dict).  If ``object_hook`` is also defined, the
-        ``object_pairs_hook`` takes priority.
+        This feature can be used to implement custom decoders.
+        If ``object_hook`` is also defined, the ``object_pairs_hook`` takes
+        priority.
 
         ``parse_float``, if specified, will be called with the string
         of every JSON float to be decoded. By default this is equivalent to
@@ -315,7 +315,6 @@ class JSONDecoder(object):
         characters will be allowed inside strings.  Control characters in
         this context are those with character codes in the 0-31 range,
         including ``'\\t'`` (tab), ``'\\n'``, ``'\\r'`` and ``'\\0'``.
-
         """
         self.object_hook = object_hook
         self.parse_float = parse_float or float


### PR DESCRIPTION
Remove OrederedDict from document (including docstring) and json.tool.

<!-- issue-number: bpo-32360 -->
https://bugs.python.org/issue32360
<!-- /issue-number -->
