### PR TITLE
bpo-32413: Add documentation that at the module level, locals(), globals() are the  same dictionary

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -820,7 +820,8 @@ are always available.  They are listed here in alphabetical order.
 
    Update and return a dictionary representing the current local symbol table.
    Free variables are returned by :func:`locals` when it is called in function
-   blocks, but not in class blocks.
+   blocks, but not in class blocks. Remember that at the module level, :func:`locals`
+   and :func:`globals` are the same dictionary.
 
    .. note::
       The contents of this dictionary should not be modified; changes may not

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -820,7 +820,7 @@ are always available.  They are listed here in alphabetical order.
 
    Update and return a dictionary representing the current local symbol table.
    Free variables are returned by :func:`locals` when it is called in function
-   blocks, but not in class blocks. Remember that at the module level, :func:`locals`
+   blocks, but not in class blocks. Note that at the module level, :func:`locals`
    and :func:`globals` are the same dictionary.
 
    .. note::

--- a/Misc/NEWS.d/next/Documentation/2017-12-24-22-29-37.bpo-32413.eZe-ID.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-12-24-22-29-37.bpo-32413.eZe-ID.rst
@@ -1,0 +1,1 @@
+Add documentation that at module level, locals() and globals() are the same dictionary

--- a/Misc/NEWS.d/next/Documentation/2017-12-24-22-29-37.bpo-32413.eZe-ID.rst
+++ b/Misc/NEWS.d/next/Documentation/2017-12-24-22-29-37.bpo-32413.eZe-ID.rst
@@ -1,1 +1,0 @@
-Add documentation that at module level, locals() and globals() are the same dictionary


### PR DESCRIPTION


<!-- issue-number: bpo-32413 -->
https://bugs.python.org/issue32413
<!-- /issue-number -->
