### PR TITLE
bpo-32360: Remove OrderedDict from re module

### DIFF
--- a/Lib/re.py
+++ b/Lib/re.py
@@ -128,12 +128,6 @@ try:
 except ImportError:
     _locale = None
 
-# try _collections first to reduce startup cost
-try:
-    from _collections import OrderedDict
-except ImportError:
-    from collections import OrderedDict
-
 
 # public symbols
 __all__ = [
@@ -271,7 +265,7 @@ Match = type(sre_compile.compile('', 0).match(''))
 # --------------------------------------------------------------------
 # internals
 
-_cache = OrderedDict()
+_cache = {}
 
 _MAXCACHE = 512
 def _compile(pattern, flags):
@@ -293,7 +287,7 @@ def _compile(pattern, flags):
     if not (flags & DEBUG):
         if len(_cache) >= _MAXCACHE:
             try:
-                _cache.popitem(last=False)
+                _cache.pop(list(_cache.keys())[0])
             except KeyError:
                 pass
         _cache[type(pattern), pattern, flags] = p

--- a/Misc/NEWS.d/next/Library/2017-12-26-10-06-23.bpo-32360.BseRtQ.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-26-10-06-23.bpo-32360.BseRtQ.rst
@@ -1,0 +1,1 @@
+Remove `OrderedDict` from `re` module.


### PR DESCRIPTION


<!-- issue-number: bpo-32360 -->
https://bugs.python.org/issue32360
<!-- /issue-number -->
