### PR TITLE
bpo-32429: Abort compilation on outdated Modules/Setup file.

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -692,7 +692,10 @@ Modules/Setup: $(srcdir)/Modules/Setup.dist
 		echo "check to make sure you have all the updates you"; \
 		echo "need in your Modules/Setup file."; \
 		echo "Usually, copying Modules/Setup.dist to Modules/Setup will work."; \
+		echo "Or if you want to keep your modifications, touch Modules/Setup"; \
+		echo "to skip this warning."; \
 		echo "-----------------------------------------------"; \
+		false; \
 	fi
 
 Programs/_testembed: Programs/_testembed.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)

--- a/Misc/NEWS.d/next/Build/2017-12-26-23-22-37.bpo-32429.yfKLwE.rst
+++ b/Misc/NEWS.d/next/Build/2017-12-26-23-22-37.bpo-32429.yfKLwE.rst
@@ -1,0 +1,3 @@
+Build will now fail when Module/Setup is out of date. Previously a warning
+was displayed but was invisible due to make verbosity, sometimes giving a
+non-working Python as a result, like in https://bugs.python.org/issue32335.


### PR DESCRIPTION
<!-- issue-number: bpo-32429 -->
https://bugs.python.org/issue32429
<!-- /issue-number -->
