### PR TITLE
bpo-31639: Use threads in http.server

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -33,9 +33,16 @@ handler.  Code to create and run the server looks like this::
    :attr:`server_port`. The server is accessible by the handler, typically
    through the handler's :attr:`server` instance variable.
 
+.. class:: ThreadedHTTPServer(server_address, RequestHandlerClass)
 
-The :class:`HTTPServer` must be given a *RequestHandlerClass* on instantiation,
-of which this module provides three different variants:
+   This class is identical to HTTPServer but uses threads to handle
+   requests by using the :class:`~socketserver.ThreadingMixin`. This
+   is usefull to handle web browsers pre-opening sockets, on which
+   :class:`HTTPServer` would wait indefinitly.
+
+The :class:`HTTPServer` and :class:`ThreadedHTTPServer` must be given
+a *RequestHandlerClass* on instantiation, of which this module
+provides three different variants:
 
 .. class:: BaseHTTPRequestHandler(request, client_address, server)
 

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -83,7 +83,7 @@ XXX To do:
 __version__ = "0.6"
 
 __all__ = [
-    "HTTPServer", "BaseHTTPRequestHandler",
+    "HTTPServer", "ThreadedHTTPServer", "BaseHTTPRequestHandler",
     "SimpleHTTPRequestHandler", "CGIHTTPRequestHandler",
 ]
 
@@ -138,6 +138,10 @@ class HTTPServer(socketserver.TCPServer):
         host, port = self.server_address[:2]
         self.server_name = socket.getfqdn(host)
         self.server_port = port
+
+
+class ThreadedHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
+    daemon_threads = True
 
 
 class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
@@ -1213,7 +1217,8 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
 
 
 def test(HandlerClass=BaseHTTPRequestHandler,
-         ServerClass=HTTPServer, protocol="HTTP/1.0", port=8000, bind=""):
+         ServerClass=ThreadedHTTPServer,
+         protocol="HTTP/1.0", port=8000, bind=""):
     """Test the HTTP request handler class.
 
     This runs an HTTP server on port 8000 (or the port argument).

--- a/Misc/NEWS.d/next/Library/2017-12-27-21-55-19.bpo-31639.l3avDJ.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-27-21-55-19.bpo-31639.l3avDJ.rst
@@ -1,0 +1,2 @@
+http.server now exposes a ThreadedHTTPServer class and uses it when the
+module is invoked to cope with web browsers pre-opening sockets.


### PR DESCRIPTION
As modern browser will use multiple sockets, see https://bugs.python.org/issue31639



<!-- issue-number: bpo-31639 -->
https://bugs.python.org/issue31639
<!-- /issue-number -->
