### PR TITLE
Adding necessary import in email.message.rst

### DIFF
--- a/Doc/library/email.message.rst
+++ b/Doc/library/email.message.rst
@@ -519,6 +519,7 @@ message objects.
          False False
          False True
          False False
+         >>> from email.iterators import _structure
          >>> _structure(msg)
          multipart/report
              text/plain


### PR DESCRIPTION
Adding the necessary import for the `_structure` function to make it more clear where that function comes from.

The import is missing from the [3.6 documentation](https://docs.python.org/3.6/library/email.message.html?highlight=_structure#email.message.EmailMessage.walk) and the [3.7 docs](https://docs.python.org/3.7/library/email.message.html?highlight=_structure#email.message.EmailMessage.walk) (as well as some older versions too).

I didn't raise an issue for this as it is a relatively minor edit, but I would be happy to do so if you would like. Also, I'm not sure which branch this PR should be made against, so feel free to change it as needed.
