### PR TITLE
bpo-32431: Ensure two bytes objects of zero length compare equal 

### DIFF
--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1561,7 +1561,7 @@ bytes_compare_eq(PyBytesObject *a, PyBytesObject *b)
     if (a->ob_sval[0] != b->ob_sval[0])
         return 0;
 
-    cmp = memcmp(a->ob_sval, b->ob_sval, len);
+    cmp = memcmp(a->ob_sval, b->ob_sval, lena);
     return (cmp == 0);
 }
 

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1547,11 +1547,16 @@ static int
 bytes_compare_eq(PyBytesObject *a, PyBytesObject *b)
 {
     int cmp;
-    Py_ssize_t len;
+    Py_ssize_t lena, lenb;
 
-    len = Py_SIZE(a);
-    if (Py_SIZE(b) != len)
+    lena = Py_SIZE(a);
+    lenb = Py_SIZE(b);
+
+    if (lena != lenb)
         return 0;
+
+    if (lena == 0 && lenb == 0)
+        return 1;
 
     if (a->ob_sval[0] != b->ob_sval[0])
         return 0;


### PR DESCRIPTION
With the current logic in `Objects/bytesobject.c` in the function `bytes_compare_eq` can be the case that zero length bytes object object created in an extension module like this:

```c
val = PyBytes_FromStringAndSize (NULL, 20);
Py_SIZE(val) = 0;
```

won't compare equal to `b''` because the memory is not initialized, so the first two bytes won't be equal. Nonetheless, the Python interpreter does return `b''` for `print(repr(val))`, so this behaviour is very confusing. To get the correct behaviour, one would have to initialize the memory:

```c
val = PyBytes_FromStringAndSize (NULL, 20);
c = PyBytes_AS_STRING (val);
c[0] = '\0';
Py_SIZE(val) = 0;
```

This PR ensures that two zero length byte objects always compare equal irrespecitve of whether the memory has been initialized for either object.



<!-- issue-number: bpo-32431 -->
https://bugs.python.org/issue32431
<!-- /issue-number -->
