### PR TITLE
bpo-32424: Rename copy() to __copy__() in Python version of xml.etree.ElementTree.

### DIFF
--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -189,7 +189,7 @@ class Element:
         """
         return self.__class__(tag, attrib)
 
-    def copy(self):
+    def __copy__(self):
         """Return copy of current element.
 
         This creates a shallow copy. Subelements will be shared with the


### PR DESCRIPTION
The C version defines `__copy__()` and `__deepcopy__()` while the Python
version defines `copy()`. The documentation does not mention `copy()`, so
it is presumed to be in error. This unifies the definition of `__copy__()`
between the Python and C version, making the proper way to copy an
`Element be copy.copy(ET.Element("foo"))`.

<!-- issue-number: bpo-32424 -->
https://bugs.python.org/issue32424
<!-- /issue-number -->
