### PR TITLE
bpo-25942: make subprocess more graceful on ^C

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -304,7 +304,7 @@ def call(*popenargs, timeout=None, **kwargs):
     with Popen(*popenargs, **kwargs) as p:
         try:
             return p.wait(timeout=timeout)
-        except:
+        except Exception:  # Ignore KeyboardInterrupt and SystemExit.
             p.kill()
             p.wait()
             raise
@@ -450,7 +450,7 @@ def run(*popenargs, input=None, timeout=None, check=False, **kwargs):
             stdout, stderr = process.communicate()
             raise TimeoutExpired(process.args, timeout, output=stdout,
                                  stderr=stderr)
-        except:
+        except Exception:  # Ignore KeyboardInterrupt and SystemExit.
             process.kill()
             process.wait()
             raise

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -725,6 +725,8 @@ class Popen(object):
         self.text_mode = encoding or errors or text or universal_newlines
 
         # How long to resume waiting on a child after the first ^C.
+        # There is no right value for this.  The purpose is to be polite
+        # yet remain good for interactive users trying to exit a tool.
         self._sigint_wait_secs = 0.125  # 1/xkcd221.getRandomNumber()/2
 
         self._closed_child_pipe_fds = False

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -717,7 +717,7 @@ class Popen(object):
         # How long to resume waiting on a child after the first ^C.
         # There is no right value for this.  The purpose is to be polite
         # yet remain good for interactive users trying to exit a tool.
-        self._sigint_wait_secs = 0.125  # 1/xkcd221.getRandomNumber()/2
+        self._sigint_wait_secs = 0.25  # 1/xkcd221.getRandomNumber()
 
         self._closed_child_pipe_fds = False
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -447,8 +447,6 @@ def run(*popenargs, input=None, timeout=None, check=False, **kwargs):
         kwargs['stdin'] = PIPE
 
     with Popen(*popenargs, **kwargs) as process:
-        if timeout is not None:
-            endtime = _time() + timeout
         try:
             stdout, stderr = process.communicate(input, timeout=timeout)
         except TimeoutExpired:

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -306,7 +306,7 @@ def call(*popenargs, timeout=None, **kwargs):
             return p.wait(timeout=timeout)
         except:  # Including KeyboardInterrupt, wait handled that.
             p.kill()
-            # We don't call p.wait() as p.__exit__ does that for us.
+            # We don't call p.wait() again as p.__exit__ does that for us.
             raise
 
 
@@ -965,9 +965,7 @@ class Popen(object):
             # https://bugs.python.org/issue25942
             # The first keyboard interrupt waits briefly for the child to
             # exit under the common assumption that it also received the ^C
-            # generated SIGINT and will exit rapidly.  A second ^C will
-            # abort this immediately.  Matching user patterns of hitting
-            # ^C more than once before resorting to ^\ (SIGKILL).
+            # generated SIGINT and will exit rapidly.
             if timeout is not None:
                 sigint_timeout = min(self._sigint_wait_secs,
                                      self._remaining_time(endtime))

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -460,7 +460,7 @@ def run(*popenargs, input=None, timeout=None, check=False, **kwargs):
             raise
         except KeyboardInterrupt:
             # https://bugs.python.org/issue25942
-            process.kill()  # It already got a chance within wait.
+            process.kill()  # It already got a chance within communicate.
             raise
         retcode = process.poll()
         if check and retcode:

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2922,6 +2922,71 @@ class Win32ProcessTestCase(BaseTestCase):
         self._kill_dead_process('terminate')
 
 class MiscTests(unittest.TestCase):
+
+    class RecordingPopen(subprocess.Popen):
+        """A Popen that saves a reference to each instance for testing."""
+        instances_created = []
+
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            self.instances_created.append(self)
+
+    @mock.patch.object(subprocess.Popen, "_communicate")
+    def _test_keyboardinterrupt_no_kill(self, popener, mock__communicate,
+                                        **kwargs):
+        """Fake a SIGINT happening during Popen._communicate() and ._wait().
+
+        This avoids the need to actually try and get test environments to send
+        and receive signals reliably across platforms.  The net effect of a ^C
+        happening during a blocking subprocess execution which we want to clean
+        up from is a KeyboardInterrupt coming out of communicate() or wait().
+        """
+
+        mock__communicate.side_effect = KeyboardInterrupt
+        try:
+            with mock.patch.object(subprocess.Popen, "_wait") as mock__wait:
+                # We patch out _wait() as no signal was involved so the
+                # child process isn't actually going to exit rapidly.
+                mock__wait.side_effect = KeyboardInterrupt
+                with mock.patch.object(subprocess, "Popen",
+                                       self.RecordingPopen):
+                    with self.assertRaises(KeyboardInterrupt):
+                        popener([sys.executable, "-c",
+                                 "import time\ntime.sleep(9)\nimport sys\n"
+                                 "sys.stderr.write('\\n!runaway child!\\n')"],
+                                stdout=subprocess.DEVNULL, **kwargs)
+                for call in mock__wait.call_args_list[1:]:
+                    self.assertNotEqual(
+                            call, mock.call(timeout=None),
+                            "no open-ended wait() after the first allowed: "
+                            f"{mock__wait.call_args_list}")
+                sigint_calls = []
+                for call in mock__wait.call_args_list:
+                    if call == mock.call(timeout=0.125):  # from Popen.__init__
+                        sigint_calls.append(call)
+                self.assertLessEqual(mock__wait.call_count, 2,
+                                     msg=mock__wait.call_args_list)
+                self.assertEqual(len(sigint_calls), 1,
+                                 msg=mock__wait.call_args_list)
+        finally:
+            # cleanup the forgotten (due to our mocks) child process
+            process = self.RecordingPopen.instances_created.pop()
+            process.kill()
+            process.wait()
+            self.assertEqual([], self.RecordingPopen.instances_created)
+
+    def test_call_keyboardinterrupt_no_kill(self):
+        self._test_keyboardinterrupt_no_kill(subprocess.call, timeout=6.282)
+
+    def test_run_keyboardinterrupt_no_kill(self):
+        self._test_keyboardinterrupt_no_kill(subprocess.run, timeout=6.282)
+
+    def test_context_manager_keyboardinterrupt_no_kill(self):
+        def popen_via_context_manager(*args, **kwargs):
+            with subprocess.Popen(*args, **kwargs) as unused_process:
+                raise KeyboardInterrupt  # Test how __exit__ handles ^C.
+        self._test_keyboardinterrupt_no_kill(popen_via_context_manager)
+
     def test_getoutput(self):
         self.assertEqual(subprocess.getoutput('echo xyzzy'), 'xyzzy')
         self.assertEqual(subprocess.getstatusoutput('echo xyzzy'),

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2962,7 +2962,7 @@ class MiscTests(unittest.TestCase):
                             f"{mock__wait.call_args_list}")
                 sigint_calls = []
                 for call in mock__wait.call_args_list:
-                    if call == mock.call(timeout=0.125):  # from Popen.__init__
+                    if call == mock.call(timeout=0.25):  # from Popen.__init__
                         sigint_calls.append(call)
                 self.assertLessEqual(mock__wait.call_count, 2,
                                      msg=mock__wait.call_args_list)

--- a/Misc/NEWS.d/next/Library/2017-12-27-20-15-51.bpo-25942.Giyr8v.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-27-20-15-51.bpo-25942.Giyr8v.rst
@@ -1,0 +1,6 @@
+The subprocess module is now more graceful when handling a Ctrl-C
+KeyboardInterrupt during subprocess.call, subprocess.run, or a Popen context
+manager.  It now waits a short amount of time for the child (presumed to
+have also gotten the SIGINT) to exit, before continuing the
+KeyboardInterrupt exception handling.  This still includes a SIGKILL in the
+call() and run() APIs, but at least the child had a chance first.


### PR DESCRIPTION
In Python 3.3-3.6 `subprocess.call` and `subprocess.run` would immediately
`SIGKILL` the child process upon receiving a `SIGINT` (which raises a
`KeyboardInterrupt`).  We now give the child a small amount of time to
exit gracefully before resorting to a `SIGKILL`.

This is also the case for `subprocess.Popen.__exit__` which would
previously block indefinitely waiting for the child to die.  This was
hidden from many users by virtue of `subprocess.call` and `subprocess.run`
sending the signal immediately.

*Behavior change:* `subprocess.Popen.__exit__` will not block indefinitely
when the exiting exception is a KeyboardInterrupt.  This is done for
user friendliness as people expect their ^C to actually happen.  This
could cause occasional orphaned Popen objects when not using `call` or
`run` with a child process that hasn't exited.

*Internal refactoring:* The Popen.wait method deals with the
KeyboardInterrupt. The existing platform specific internal
methods have been renamed to `_wait()` which it calls.

<!-- issue-number: bpo-25942 -->
https://bugs.python.org/issue25942
<!-- /issue-number -->
