### PR TITLE
Update __init__.py

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -860,6 +860,7 @@ class Handler(Filterer):
         Set the formatter for this handler.
         """
         self.formatter = fmt
+        return self
 
     def flush(self):
         """


### PR DESCRIPTION
Returns the Handler from `setFormatter`. Makes it possible to add a formatted handler:

    logging.getLogger().addHandler(logging.StreamHandler().setFormatter(logging.Formatter(LOGFMT)))

or

    sh = logging.StreamHandler().setFormatter(LOGFMT)
    logging.getLogger.addHandler(sh)

This does not alter the method itself, and should conform to [PEP 282][1]. 

Even better, but not implemented:

        logging.getLogger().addHandler(logging.StreamHandler(format=LOGFMT))

(If you don't like this change, feel free to not accept the pull request. It's just a minor change that could make stuff simpler.)

[1]: https://www.python.org/dev/peps/pep-0282/

!!! If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

PLEASE: Remove this headline!!!
