### PR TITLE
[2.7] bpo-18035: telnetlib: select.error doesn't have an errno attribute

### DIFF
--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -317,7 +317,7 @@ class Telnet:
                     ready = poller.poll(None if timeout is None
                                         else 1000 * call_timeout)
                 except select.error as e:
-                    if e.errno == errno.EINTR:
+                    if e[0] == errno.EINTR:
                         if timeout is not None:
                             elapsed = time() - time_start
                             call_timeout = timeout-elapsed
@@ -688,7 +688,7 @@ class Telnet:
                     ready = poller.poll(None if timeout is None
                                         else 1000 * call_timeout)
                 except select.error as e:
-                    if e.errno == errno.EINTR:
+                    if e[0] == errno.EINTR:
                         if timeout is not None:
                             elapsed = time() - time_start
                             call_timeout = timeout-elapsed

--- a/Misc/NEWS.d/next/Library/2017-12-29-15-16-56.bpo-18035.c6rdCt.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-29-15-16-56.bpo-18035.c6rdCt.rst
@@ -1,0 +1,2 @@
+``telnetlib``: ``select.error`` doesn't have an ``errno`` attribute. Patch
+by Segev Finer.


### PR DESCRIPTION
`select.error` doesn't have an `errno` attribute so access the `errno` by indexing instead.

<!-- issue-number: bpo-18035 -->
https://bugs.python.org/issue18035
<!-- /issue-number -->
