### PR TITLE
bpo-32424: Synchronize xml.etree.ElementTree.Element copy methods.

### DIFF
--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -94,6 +94,7 @@ VERSION = "1.3.0"
 import sys
 import re
 import warnings
+import copy
 import io
 import collections
 import collections.abc
@@ -194,10 +195,33 @@ class Element:
         original tree.
 
         """
+        warnings.warn(
+            "elem.copy() is deprecated. Use copy.copy(elem) instead.",
+            DeprecationWarning
+            )
+        return self.__copy__()
+
+    def __copy__(self):
         elem = self.makeelement(self.tag, self.attrib)
         elem.text = self.text
         elem.tail = self.tail
         elem[:] = self
+        return elem
+
+    def __deepcopy__(self, memo):
+        tag = copy.deepcopy(self.tag, memo)
+        attrib = copy.deepcopy(self.attrib, memo)
+
+        elem = self.makeelement(tag, attrib)
+
+        elem.text = copy.deepcopy(self.text, memo)
+        elem.tail = copy.deepcopy(self.tail, memo)
+
+        for child in self:
+            elem.append(copy.deepcopy(child, memo))
+
+        memo[id(self)] = elem
+
         return elem
 
     def __len__(self):

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -295,10 +295,12 @@ create_new_element(PyObject* tag, PyObject* attrib)
     PyObject_GC_Track(self);
 
     if (attrib != Py_None && !is_empty_dict(attrib)) {
+        attrib = PyDict_Copy(attrib);
         if (create_extra(self, attrib) < 0) {
             Py_DECREF(self);
             return NULL;
         }
+        Py_DECREF(attrib);
     }
 
     return (PyObject*) self;
@@ -757,6 +759,24 @@ _elementtree_Element___copy___impl(ElementObject *self)
     }
 
     return (PyObject*) element;
+}
+
+/*[clinic input]
+_elementtree.Element.copy
+
+[clinic start generated code]*/
+
+static PyObject *
+_elementtree_Element_copy_impl(ElementObject *self)
+/*[clinic end generated code: output=84660e8524276b22 input=1f8134305a7719a3]*/
+{
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "elem.copy() is deprecated. Use copy.copy(elem) instead.",
+                     1) < 0) {
+        return NULL;
+    }
+
+    return _elementtree_Element___copy___impl(self);
 }
 
 /* Helper for a deep copy. */
@@ -3801,6 +3821,7 @@ static PyMethodDef element_methods[] = {
 
     _ELEMENTTREE_ELEMENT_MAKEELEMENT_METHODDEF
 
+    _ELEMENTTREE_ELEMENT_COPY_METHODDEF
     _ELEMENTTREE_ELEMENT___COPY___METHODDEF
     _ELEMENTTREE_ELEMENT___DEEPCOPY___METHODDEF
     _ELEMENTTREE_ELEMENT___SIZEOF___METHODDEF

--- a/Modules/clinic/_elementtree.c.h
+++ b/Modules/clinic/_elementtree.c.h
@@ -64,6 +64,23 @@ _elementtree_Element___copy__(ElementObject *self, PyObject *Py_UNUSED(ignored))
     return _elementtree_Element___copy___impl(self);
 }
 
+PyDoc_STRVAR(_elementtree_Element_copy__doc__,
+"copy($self, /)\n"
+"--\n"
+"\n");
+
+#define _ELEMENTTREE_ELEMENT_COPY_METHODDEF    \
+    {"copy", (PyCFunction)_elementtree_Element_copy, METH_NOARGS, _elementtree_Element_copy__doc__},
+
+static PyObject *
+_elementtree_Element_copy_impl(ElementObject *self);
+
+static PyObject *
+_elementtree_Element_copy(ElementObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return _elementtree_Element_copy_impl(self);
+}
+
 PyDoc_STRVAR(_elementtree_Element___deepcopy____doc__,
 "__deepcopy__($self, memo, /)\n"
 "--\n"
@@ -853,4 +870,4 @@ skip_optional:
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=440b5d90a4b86590 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=dfe73768e94a9bc3 input=a9049054013a1b77]*/


### PR DESCRIPTION
The Python implementation had `Element.copy()` while the C
implementation had `Element.__copy__()` and `Element.__deepcopy__()`.

This synchronizes the two implementations and deprecates
`elem.copy()` in favor of `copy.copy(elem)`.


<!-- issue-number: bpo-32424 -->
https://bugs.python.org/issue32424
<!-- /issue-number -->
