### PR TITLE
bpo-32454: socket closefd

### DIFF
--- a/Doc/library/socket.rst
+++ b/Doc/library/socket.rst
@@ -578,6 +578,14 @@ Other functions
 The :mod:`socket` module also offers various network-related services:
 
 
+.. function:: close(fd)
+
+   Close a socket file descriptor. This is like :func:`os.close`, but for
+   sockets. On some platforms (most noticeable Windows) :func:`os.close`
+   does not work for socket file descriptors.
+
+   .. versionadded:: 3.7
+
 .. function:: getaddrinfo(host, port, family=0, type=0, proto=0, flags=0)
 
    Translate the *host*/*port* argument into a sequence of 5-tuples that contain

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1519,6 +1519,22 @@ class GeneralModuleTests(unittest.TestCase):
             self.assertRaises(ValueError, fp.writable)
             self.assertRaises(ValueError, fp.seekable)
 
+    def test_socket_close(self):
+        sock = socket.socket()
+        try:
+            sock.bind((HOST, 0))
+            socket.close(sock.fileno())
+            with self.assertRaises(OSError):
+                sock.listen(1)
+        finally:
+            with self.assertRaises(OSError):
+                # sock.close() fails with EBADF
+                sock.close()
+        with self.assertRaises(TypeError):
+            socket.close(None)
+        with self.assertRaises(OSError):
+            socket.close(-1)
+
     def test_makefile_mode(self):
         for mode in 'r', 'rb', 'rw', 'w', 'wb':
             with self.subTest(mode=mode):

--- a/Misc/NEWS.d/next/Library/2017-12-30-10-38-05.bpo-32454.wsZnl-.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-30-10-38-05.bpo-32454.wsZnl-.rst
@@ -1,0 +1,1 @@
+Add close(fd) function to the socket module.


### PR DESCRIPTION
Add close(fd) function to the socket module

Signed-off-by: Christian Heimes <christian@python.org>

**NOTE** The PR also documents the previously undocumented ``socket.close`` function.

<!-- issue-number: bpo-32454 -->
https://bugs.python.org/issue32454
<!-- /issue-number -->
