### PR TITLE
bpo-19678: Pass channel parameter to process_message

### DIFF
--- a/Lib/smtpd.py
+++ b/Lib/smtpd.py
@@ -86,6 +86,7 @@ import socket
 import asyncore
 import asynchat
 import collections
+from inspect import signature
 from warnings import warn
 from email._header_value_parser import get_addr_spec, get_angle_addr
 
@@ -383,6 +384,9 @@ class SMTPChannel(asynchat.async_chat):
                     'mail_options': self.mail_options,
                     'rcpt_options': self.rcpt_options,
                 }
+            process_msg_sig = signature(self.smtp_server.process_message)
+            if process_msg_sig.parameters.get('kwargs'):
+                kwargs['channel'] = self
             status = self.smtp_server.process_message(*args, **kwargs)
             self._set_post_data_state()
             if not status:

--- a/Misc/NEWS.d/next/Library/2017-12-30-21-58-14.bpo-19678.hFWoTx.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-30-21-58-14.bpo-19678.hFWoTx.rst
@@ -1,0 +1,2 @@
+smtpd.py: `channel` state is passed to `process_message` method for child
+classes of SMTPServer class. Patch by Sanyam Khurana.


### PR DESCRIPTION
Uses `inspect.signature` to know if the `process_message` method in base class accepts `kwargs`. If so, we also pass the `channel` to it.

https://bugs.python.org/issue19678

<!-- issue-number: bpo-19678 -->
https://bugs.python.org/issue19678
<!-- /issue-number -->
