### PR TITLE
bpo-32418: Postfix, raise NotImplementdError and close resources in tests

### DIFF
--- a/Lib/asyncio/events.py
+++ b/Lib/asyncio/events.py
@@ -149,15 +149,15 @@ class AbstractServer:
 
     def close(self):
         """Stop serving.  This leaves existing connections open."""
-        return NotImplemented
+        raise NotImplementedError
 
     async def wait_closed(self):
         """Coroutine to wait until service is closed."""
-        return NotImplemented
+        raise NotImplementedError
 
     def get_loop(self):
         """ Get the event loop the Server object is attached to."""
-        return NotImplemented
+        raise NotImplementedError
 
 
 class AbstractEventLoop:

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2826,19 +2826,36 @@ else:
         get_running_loop_impl = events._c_get_running_loop
         get_event_loop_impl = events._c_get_event_loop
 
+
 class TestServer(unittest.TestCase):
 
     def test_get_loop(self):
         loop = asyncio.new_event_loop()
+        self.addCleanup(loop.close)
         proto = MyProto(loop)
         server = loop.run_until_complete(loop.create_server(lambda: proto, '0.0.0.0', 0))
         self.assertEqual(server.get_loop(), loop)
-        loop.close()
+        server.close()
+        loop.run_until_complete(server.wait_closed())
+
 
 class TestAbstractServer(unittest.TestCase):
 
+    def test_close(self):
+        with self.assertRaises(NotImplementedError):
+            events.AbstractServer().close()
+
+    def test_wait_closed(self):
+        loop = asyncio.new_event_loop()
+        self.addCleanup(loop.close)
+
+        with self.assertRaises(NotImplementedError):
+            loop.run_until_complete(events.AbstractServer().wait_closed())
+
     def test_get_loop(self):
-        self.assertEqual(events.AbstractServer().get_loop(), NotImplemented)
+        with self.assertRaises(NotImplementedError):
+            events.AbstractServer().get_loop()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Discussed in #4997 

`AbstractServer.close()` and `.wait_closed()` returned `NotImplemented` which is obviously wrong and should be replaced by raising `NotImplementedError`.

<!-- issue-number: bpo-32418 -->
https://bugs.python.org/issue32418
<!-- /issue-number -->
