### PR TITLE
Add missing backslashes in PCbuild bat files

### DIFF
--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -39,7 +39,7 @@ if "%DO_FETCH%"=="false" goto end
 :fetch
 
 if "%ORG%"=="" (set ORG=python)
-call "%PCBUILD%find_python.bat" "%PYTHON%"
+call "%PCBUILD%\find_python.bat" "%PYTHON%"
 
 if "%PYTHON%"=="" (
     where /Q git || echo Python 3.6 could not be found or installed, and git.exe is not on your PATH && exit /B 1
@@ -65,7 +65,7 @@ for %%e in (%libraries%) do (
         git clone --depth 1 https://github.com/%ORG%/cpython-source-deps --branch %%e "%EXTERNALS_DIR%\%%e"
     ) else (
         echo.Fetching %%e...
-        %PYTHON% "%PCBUILD%get_external.py" -O %ORG% %%e
+        %PYTHON% "%PCBUILD%\get_external.py" -O %ORG% %%e
     )
 )
 
@@ -84,7 +84,7 @@ for %%b in (%binaries%) do (
         git clone --depth 1 https://github.com/%ORG%/cpython-bin-deps --branch %%b "%EXTERNALS_DIR%\%%b"
     ) else (
         echo.Fetching %%b...
-        %PYTHON% "%PCBUILD%get_external.py" -b -O %ORG% %%b
+        %PYTHON% "%PCBUILD%\get_external.py" -b -O %ORG% %%b
     )
 )
 

--- a/PCbuild/prepare_ssl.bat
+++ b/PCbuild/prepare_ssl.bat
@@ -45,19 +45,19 @@ goto Usage
 if not defined SRC (echo --in directory is required & exit /b 1)
 if not defined OUT (echo --out directory is required & exit /b 1)
 
-call "%PCBUILD%find_msbuild.bat" %MSBUILD%
+call "%PCBUILD%\find_msbuild.bat" %MSBUILD%
 if ERRORLEVEL 1 (echo Cannot locate MSBuild.exe on PATH or as MSBUILD variable & exit /b 2)
 
-call "%PCBUILD%find_python.bat" "%PYTHON%"
+call "%PCBUILD%\find_python.bat" "%PYTHON%"
 if ERRORLEVEL 1 (echo Cannot locate python.exe on PATH or as PYTHON variable & exit /b 3)
 
-call "%PCBUILD%get_externals.bat" --openssl-src %ORG_SETTING%
+call "%PCBUILD%\get_externals.bat" --openssl-src %ORG_SETTING%
 
 if "%PERL%" == "" where perl > "%TEMP%\perl.loc" 2> nul && set /P PERL= <"%TEMP%\perl.loc" & del "%TEMP%\perl.loc"
 if "%PERL%" == "" (echo Cannot locate perl.exe on PATH or as PERL variable & exit /b 4)
 
-%MSBUILD% "%PCBUILD%openssl.vcxproj" /p:Configuration=Release /p:Platform=Win32
+%MSBUILD% "%PCBUILD%\openssl.vcxproj" /p:Configuration=Release /p:Platform=Win32
 if errorlevel 1 exit /b
-%MSBUILD% "%PCBUILD%openssl.vcxproj" /p:Configuration=Release /p:Platform=x64
+%MSBUILD% "%PCBUILD%\openssl.vcxproj" /p:Configuration=Release /p:Platform=x64
 if errorlevel 1 exit /b
 

--- a/PCbuild/prepare_tcltk.bat
+++ b/PCbuild/prepare_tcltk.bat
@@ -38,18 +38,18 @@ echo Unrecognized option: %1
 goto Usage
 
 :Build
-call "%PCBUILD%find_msbuild.bat" %MSBUILD%
+call "%PCBUILD%\find_msbuild.bat" %MSBUILD%
 if ERRORLEVEL 1 (echo Cannot locate MSBuild.exe on PATH or as MSBUILD variable & exit /b 2)
 
-rem call "%PCBUILD%find_python.bat" "%PYTHON%"
+rem call "%PCBUILD%\find_python.bat" "%PYTHON%"
 rem if ERRORLEVEL 1 (echo Cannot locate python.exe on PATH or as PYTHON variable & exit /b 3)
 
-call "%PCBUILD%get_externals.bat" --tkinter-src %ORG_SETTING%
+call "%PCBUILD%\get_externals.bat" --tkinter-src %ORG_SETTING%
 
-%MSBUILD% "%PCBUILD%tcl.vcxproj" /p:Configuration=Release /p:Platform=Win32
-%MSBUILD% "%PCBUILD%tk.vcxproj" /p:Configuration=Release /p:Platform=Win32
-%MSBUILD% "%PCBUILD%tix.vcxproj" /p:Configuration=Release /p:Platform=Win32
+%MSBUILD% "%PCBUILD%\tcl.vcxproj" /p:Configuration=Release /p:Platform=Win32
+%MSBUILD% "%PCBUILD%\tk.vcxproj" /p:Configuration=Release /p:Platform=Win32
+%MSBUILD% "%PCBUILD%\tix.vcxproj" /p:Configuration=Release /p:Platform=Win32
 
-%MSBUILD% "%PCBUILD%tcl.vcxproj" /p:Configuration=Release /p:Platform=x64
-%MSBUILD% "%PCBUILD%tk.vcxproj" /p:Configuration=Release /p:Platform=x64
-%MSBUILD% "%PCBUILD%tix.vcxproj" /p:Configuration=Release /p:Platform=x64
+%MSBUILD% "%PCBUILD%\tcl.vcxproj" /p:Configuration=Release /p:Platform=x64
+%MSBUILD% "%PCBUILD%\tk.vcxproj" /p:Configuration=Release /p:Platform=x64
+%MSBUILD% "%PCBUILD%\tix.vcxproj" /p:Configuration=Release /p:Platform=x64


### PR DESCRIPTION
At least on my Windows 8.1 build worker, `%~dp0` doesn't contain a trailing backslash, so uses of `%PCBUILD%` must add it.