### PR TITLE
coalesce GILless sections in new_buffersize

### DIFF
--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -1016,10 +1016,10 @@ new_buffersize(PyFileObject *f, size_t currentsize)
     off_t pos, end;
     struct stat st;
     int res;
+    size_t bufsize = 0;
 
-    Py_BEGIN_ALLOW_THREADS
+    FILE_BEGIN_ALLOW_THREADS(f)
     res = fstat(fileno(f->f_fp), &st);
-    Py_END_ALLOW_THREADS
 
     if (res == 0) {
         end = st.st_size;
@@ -1033,9 +1033,7 @@ new_buffersize(PyFileObject *f, size_t currentsize)
            need to take the amount of buffered data into account.
            (Yet another reason why stdio stinks. :-) */
 
-        Py_BEGIN_ALLOW_THREADS
         pos = lseek(fileno(f->f_fp), 0L, SEEK_CUR);
-        Py_END_ALLOW_THREADS
 
         if (pos >= 0) {
             pos = ftell(f->f_fp);
@@ -1043,9 +1041,12 @@ new_buffersize(PyFileObject *f, size_t currentsize)
         if (pos < 0)
             clearerr(f->f_fp);
         if (end > pos && pos >= 0)
-            return currentsize + end - pos + 1;
+            bufsize = currentsize + end - pos + 1;
         /* Add 1 so if the file were to grow we'd notice. */
     }
+    FILE_END_ALLOW_THREADS(f)
+    if (bufsize != 0)
+        return bufsize;
 #endif
     /* Expand the buffer by an amount proportional to the current size,
        giving us amortized linear-time behavior. Use a less-than-double


### PR DESCRIPTION
830daae1c82ed33deef0086b7b6323e5be0b0cc8 added some new GIL-releasing to new_buffersize. This is fine, but it's better to avoid reacquiring the GIL for as long as possible. Also, it should use FILE_(BEGIN|END)_ALLOW_THREADS to avoid having the file closed from under it.
