### PR TITLE
Add support for string type nargs

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2234,7 +2234,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # all others should be integers
         else:
-            nargs_pattern = '(-*%s-*)' % '-*'.join('A' * nargs)
+            nargs_pattern = '(-*%s-*)' % '-*'.join('A' * int(nargs))
 
         # if this is an optional action, -- is not allowed
         if action.option_strings:


### PR DESCRIPTION
Integers wrapped in integers should also be supported. For eg. "2", "8", etc.
It will remove any arbitrariness since other options are also str type for nargs (eg. "*", "+", etc.).
