### PR TITLE
bpo-32469: Improve representation of the coroutines

### DIFF
--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -226,10 +226,10 @@ class CoroutineTests(BaseTest):
                 t.cancel()
 
         self.loop.set_debug(True)
-        with self.assertRaisesRegex(
-            RuntimeError,
-            r'Cannot await.*test_double_await.*\bafunc\b.*while.*\bsleep\b'):
-
+        afunc_first_line = afunc.__code__.co_firstlineno
+        error = (r"Cannot await .*{}.*{}.*\b afunc\b.* "
+                 r"while.*\bsleep\b".format(repr(__file__), afunc_first_line))
+        with self.assertRaisesRegex(RuntimeError, error):
             self.loop.run_until_complete(runner())
 
 

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -519,7 +519,7 @@ class CoroutineTest(unittest.TestCase):
             raise StopIteration
 
         with silence_coro_gc():
-            self.assertRegex(repr(foo()), '^<coroutine object.* at 0x.*>$')
+            self.assertRegex(repr(foo()), '^<coroutine at 0x.*>$')
 
     def test_func_4(self):
         async def foo():
@@ -890,7 +890,11 @@ class CoroutineTest(unittest.TestCase):
 
         async def f(): pass
         c = f()
-        self.assertIn('coroutine object', repr(c))
+        self.assertEqual("<coroutine at %s, %s, file %s, line %s, code f>" % (
+                          hex(id(c)),
+                          "closed",
+                          repr(__file__),
+                          f.__code__.co_firstlineno), repr(c))
         c.close()
 
     def test_await_1(self):

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -156,6 +156,17 @@ class GeneratorTest(unittest.TestCase):
             with self.assertRaises((TypeError, pickle.PicklingError)):
                 pickle.dumps(g, proto)
 
+    def test_repr(self):
+        def f():
+            yield 1
+        g = f()
+        gen_repr = repr(g)
+        self.assertEqual("<generator at %s, %s, file %s, line %s, code f>" % (
+            hex(id(g)),
+            "closed",
+            repr(__file__),
+            f.__code__.co_firstlineno), gen_repr)
+
 
 class ExceptionTest(unittest.TestCase):
     # Tests for the issue #23353: check that the currently handled exception
@@ -1225,7 +1236,7 @@ StopIteration
 True
 
 
-Test the __name__ attribute and the repr()
+Test the __name__ attribute
 
 >>> def f():
 ...    yield 5
@@ -1233,8 +1244,6 @@ Test the __name__ attribute and the repr()
 >>> g = f()
 >>> g.__name__
 'f'
->>> repr(g)  # doctest: +ELLIPSIS
-'<generator object f at ...>'
 
 Lambdas shouldn't have their usual return behavior.
 

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -1236,7 +1236,7 @@ StopIteration
 True
 
 
-Test the __name__ attribute
+Test the __name__ attribute and the repr()
 
 >>> def f():
 ...    yield 5
@@ -1244,6 +1244,8 @@ Test the __name__ attribute
 >>> g = f()
 >>> g.__name__
 'f'
+>>> repr(g)  # doctest: +ELLIPSIS
+"<generator at ..., closed, file ..., code f>"
 
 Lambdas shouldn't have their usual return behavior.
 

--- a/Lib/test/test_genexps.py
+++ b/Lib/test/test_genexps.py
@@ -92,7 +92,7 @@ Verify that parenthesis are required when used as a keyword argument value
 Verify that parenthesis are required when used as a keyword argument value
 
     >>> dict(a = (i for i in range(10))) #doctest: +ELLIPSIS
-    {'a': <generator object <genexpr> at ...>}
+    {'a': <generator at ..., closed, file ..., code <genexpr>>}
 
 Verify early binding for the outermost for-expression
 

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1644,7 +1644,11 @@ class CoroutineTests(unittest.TestCase):
             return gen()
 
         wrapper = coro()
-        self.assertIn('GeneratorWrapper', repr(wrapper))
+        wrapper_repr = repr(wrapper)
+        self.assertIn('coroutine-like-object', wrapper_repr)
+        self.assertIn(hex(id(wrapper)), wrapper_repr)
+        self.assertIn(gen.__code__.co_filename, wrapper_repr)
+        self.assertIn(str(gen.__code__.co_firstlineno), wrapper_repr)
         self.assertEqual(repr(wrapper), str(wrapper))
         self.assertTrue(set(dir(wrapper)).issuperset({
             '__await__', '__iter__', '__next__', 'cr_code', 'cr_running',

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -233,6 +233,15 @@ class _GeneratorWrapper:
             return self.__wrapped
         return self
     __await__ = __iter__
+    def __repr__(self):
+        return ('<coroutine-like-object at %s, %s, file %s, line %s, '
+                'code %s>') % (
+            hex(id(self)),
+            'running' if self.gi_running else 'closed',
+            self.gi_frame.f_code.co_filename,
+            self.gi_frame.f_code.co_firstlineno,
+            self.gi_frame.f_code.co_name)
+
 
 def coroutine(func):
     """Convert regular generator function to a coroutine."""

--- a/Misc/NEWS.d/next/Library/2018-01-01-13-31-58.bpo-32469.YBs__1.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-01-13-31-58.bpo-32469.YBs__1.rst
@@ -1,0 +1,1 @@
+Improve generators, coroutines and coroutine-like objects repr() to mention filename, running status, code name and current line number.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -680,8 +680,20 @@ _PyGen_FetchStopIterationValue(PyObject **pvalue)
 static PyObject *
 gen_repr(PyGenObject *gen)
 {
-    return PyUnicode_FromFormat("<generator object %S at %p>",
-                                gen->gi_qualname, gen);
+    const char *msg;
+    if (gen->gi_running) {
+        msg = "running";
+    } else {
+        msg = "closed";
+    }
+
+    return PyUnicode_FromFormat(
+        "<generator at %p, %s, file %R, line %d, code %S>",
+        gen,
+        msg,
+        gen->gi_frame->f_code->co_filename,
+        gen->gi_frame->f_lineno,
+        gen->gi_name);
 }
 
 static PyObject *
@@ -950,8 +962,20 @@ _PyCoro_GetAwaitableIter(PyObject *o)
 static PyObject *
 coro_repr(PyCoroObject *coro)
 {
-    return PyUnicode_FromFormat("<coroutine object %S at %p>",
-                                coro->cr_qualname, coro);
+    const char *msg;
+    if (coro->cr_running) {
+        msg = "running";
+    } else {
+        msg = "closed";
+    }
+
+    return PyUnicode_FromFormat(
+        "<coroutine at %p, %s, file %R, line %d, code %S>",
+        coro,
+        msg,
+        coro->cr_frame->f_code->co_filename,
+        coro->cr_frame->f_lineno,
+        coro->cr_name);
 }
 
 static PyObject *


### PR DESCRIPTION
Current representation:
<coroutine object f at 0x7f86c9733790>

A goal is to display more information:
<coroutine at 0x7f86c9733790, running, file "/home/antoine/cpython/default/Lib/logging/__init__.py", line 123, code getLogger>


<!-- issue-number: bpo-32469 -->
https://bugs.python.org/issue32469
<!-- /issue-number -->
