### PR TITLE
bpo-32474: nargs enhancement

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -2234,7 +2234,7 @@ class ArgumentParser(_AttributeHolder, _ActionsContainer):
 
         # all others should be integers
         else:
-            nargs_pattern = '(-*%s-*)' % '-*'.join('A' * nargs)
+            nargs_pattern = '(-*%s-*)' % '-*'.join('A' * int(nargs))
 
         # if this is an optional action, -- is not allowed
         if action.option_strings:


### PR DESCRIPTION
```
bpo-32474: argparse nargs should support string wrapped integers too (GH-5073)
```
* Added support for numeric values in nargs to be string (for eg. "2", "3")


<!-- issue-number: bpo-32474 -->
https://bugs.python.org/issue32474
<!-- /issue-number -->
