### PR TITLE
bpo-32452: Fixes issue - Brackets and Parentheses used in an ambiguous way

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -876,9 +876,9 @@ Generator Expressions
 =====================
 
 Some simple generators can be coded succinctly as expressions using a syntax
-similar to list comprehensions but with parentheses instead of brackets.  These
-expressions are designed for situations where the generator is used right away
-by an enclosing function.  Generator expressions are more compact but less
+similar to list comprehensions but with parentheses instead of square brackets.
+These expressions are designed for situations where the generator is used right
+away by an enclosing function.  Generator expressions are more compact but less
 versatile than full generator definitions and tend to be more memory friendly
 than equivalent list comprehensions.
 


### PR DESCRIPTION
Updates documentation for generator expressions in classes tutorial: Clarify usage of ambiguous term "brackets" by replacing with "square brackets". Updated subsequent lines to respect line breaks.

<!-- issue-number: bpo-32452 -->
https://bugs.python.org/issue32452
<!-- /issue-number -->
