### PR TITLE
Ignore importlib.h for automatic review requests from the import team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,8 +14,13 @@
 **/*hashlib*                  @python/crypto-team
 **/*pyhash*                   @python/crypto-team
 
-# Import (including importlib)
-**/*import*                   @python/import-team
+# Import (including importlib).
+# Ignoring importlib.h so as to not get flagged on
+# all pull requests that change the the emitted
+# bytecode.
+**/*import*.c                 @python/import-team
+**/*import*.py                @python/import-team
+
 
 # SSL
 **/*ssl*                      @python/crypto-team


### PR DESCRIPTION
Otherwise the import team gets flagged for reviews any time the bytecode for
importlib.h changes (e.g new bytecode, optimizations, etc.).