### PR TITLE
bpo-15450: Allow subclassing of dircmp

### DIFF
--- a/Lib/filecmp.py
+++ b/Lib/filecmp.py
@@ -191,7 +191,7 @@ class dircmp:
         for x in self.common_dirs:
             a_x = os.path.join(self.left, x)
             b_x = os.path.join(self.right, x)
-            self.subdirs[x]  = dircmp(a_x, b_x, self.ignore, self.hide)
+            self.subdirs[x] = type(self)(a_x, b_x, self.ignore, self.hide)
 
     def phase4_closure(self): # Recursively call phase4() on subdirectories
         self.phase4()


### PR DESCRIPTION
Current implementation of dircmp does not really allow subclassing because it calls itself recursively.

<!-- issue-number: bpo-15450 -->
https://bugs.python.org/issue15450
<!-- /issue-number -->
