### PR TITLE
Fix outdated comment in typeobject.c

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2372,7 +2372,7 @@ type_new(PyTypeObject *metatype, PyObject *args, PyObject *kwds)
         }
 
         /* SF bug 475327 -- if that didn't trigger, we need 3
-           arguments. but PyArg_ParseTupleAndKeywords below may give
+           arguments. but PyArg_ParseTuple below may give
            a msg saying type() needs exactly 3. */
         if (nargs != 3) {
             PyErr_SetString(PyExc_TypeError,


### PR DESCRIPTION
The comment was added in 3abca127fe1565ec80f6b0a1ae48d65186ad887d.
In d78448e912126410117723c7d240bbdfff06df16, it was changed to
use PyArg_ParseTuple instead.
