### PR TITLE
[2.7] bpo-32211: Document the existing bug in re.findall() and re.finditer(). (GH-4695).

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -611,14 +611,21 @@ form.
       Added the optional flags argument.
 
 
+
 .. function:: findall(pattern, string, flags=0)
 
    Return all non-overlapping matches of *pattern* in *string*, as a list of
    strings.  The *string* is scanned left-to-right, and matches are returned in
    the order found.  If one or more groups are present in the pattern, return a
    list of groups; this will be a list of tuples if the pattern has more than
-   one group.  Empty matches are included in the result unless they touch the
-   beginning of another match.
+   one group.  Empty matches are included in the result.
+
+   .. note::
+
+      Due to the limitation of the current implementation the character
+      following an empty match is not included in a next match, so
+      ``findall(r'^|\w+', 'two words')`` returns ``['', 'wo', 'words']``
+      (note missed "t").  This is changed in Python 3.7.
 
    .. versionadded:: 1.5.2
 
@@ -631,8 +638,7 @@ form.
    Return an :term:`iterator` yielding :class:`MatchObject` instances over all
    non-overlapping matches for the RE *pattern* in *string*.  The *string* is
    scanned left-to-right, and matches are returned in the order found.  Empty
-   matches are included in the result unless they touch the beginning of another
-   match.
+   matches are included in the result.  See also the note about :func:`findall`.
 
    .. versionadded:: 2.2
 


### PR DESCRIPTION
(cherry picked from commit 1e6d8525f9dd3dcdc83adb93b164082c8b95d17a)


<!-- issue-number: bpo-32211 -->
https://bugs.python.org/issue32211
<!-- /issue-number -->
