### PR TITLE
Fixing typo in dataclasses astuple docstring.

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -670,7 +670,7 @@ def astuple(obj, *, tuple_factory=tuple):
           y: int
 
     c = C(1, 2)
-    assert asdtuple(c) == (1, 2)
+    assert astuple(c) == (1, 2)
 
     If given, 'tuple_factory' will be used instead of built-in tuple.
     The function applies recursively to field values that are


### PR DESCRIPTION
Fixing a small typo in  docstring of `dataclasses.astuple` function. After looking through the file, I found the following discrepancies (maybe I'm wrong), if necessary I will add these changes to PR:

1. In docstring of [`fields`](https://github.com/python/cpython/blob/87be28f4a1c5b76926c71a3d9f92503f9eb82d51/Lib/dataclasses.py#L122):

``` python
def field(*, default=MISSING, default_factory=MISSING, init=True, repr=True,
          hash=None, compare=True, metadata=None):
    """Return an object to identify dataclass fields.

    default is the default value of the field. default_factory is a
    0-argument function called to initialize a field's value. If init
    ...
```

`default is the default value of the field` should be `MISSING is the default value of the field`.

2. Although the comments are comments, there are some problems with the alignment, through the entire file.
