### PR TITLE
bpo-31993: Do not create frames for large bytes and str objects

### DIFF
--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2097,11 +2097,14 @@ class AbstractPickleTests(unittest.TestCase):
         N = 1024 * 1024
         obj = [b'x' * N, b'y' * N, 'z' * N]
         for proto in range(4, pickle.HIGHEST_PROTOCOL + 1):
-            for fast in [True, False, None]:
+            for fast in [False, True]:
                 with self.subTest(proto=proto, fast=fast):
-                    if fast is None:
+                    if not fast:
+                        # fast=False by default.
+                        # This covers in-memory pickling with pickle.dumps().
                         pickled = self.dumps(obj, proto)
                     else:
+                        # Pickler is required when fast=True.
                         if not hasattr(self, 'pickler'):
                             continue
                         buf = io.BytesIO()

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -2097,20 +2097,18 @@ class AbstractPickleTests(unittest.TestCase):
         N = 1024 * 1024
         obj = [b'x' * N, b'y' * N, 'z' * N]
         for proto in range(4, pickle.HIGHEST_PROTOCOL + 1):
-            for fast in [True, False]:
+            for fast in [True, False, None]:
                 with self.subTest(proto=proto, fast=fast):
-                    if hasattr(self, 'pickler'):
+                    if fast is None:
+                        pickled = self.dumps(obj, proto)
+                    else:
+                        if not hasattr(self, 'pickler'):
+                            continue
                         buf = io.BytesIO()
                         pickler = self.pickler(buf, protocol=proto)
                         pickler.fast = fast
                         pickler.dump(obj)
                         pickled = buf.getvalue()
-                    elif fast:
-                        continue
-                    else:
-                        # Fallback to self.dumps when fast=False and
-                        # self.pickler is not available.
-                        pickled = self.dumps(obj, proto)
                     unpickled = self.loads(pickled)
                     # More informative error message in case of failure.
                     self.assertEqual([len(x) for x in obj],

--- a/Lib/test/test_pickle.py
+++ b/Lib/test/test_pickle.py
@@ -71,8 +71,6 @@ class PyPicklerTests(AbstractPickleTests):
 class InMemoryPickleTests(AbstractPickleTests, AbstractUnpickleTests,
                           BigmemPickleTests):
 
-    pickler = pickle._Pickler
-    unpickler = pickle._Unpickler
     bad_stack_errors = (pickle.UnpicklingError, IndexError)
     truncated_errors = (pickle.UnpicklingError, EOFError,
                         AttributeError, ValueError,
@@ -83,6 +81,8 @@ class InMemoryPickleTests(AbstractPickleTests, AbstractUnpickleTests,
 
     def loads(self, buf, **kwds):
         return pickle.loads(buf, **kwds)
+
+    test_framed_write_sizes_with_delayed_writer = None
 
 
 class PersistentPicklerUnpicklerMixin(object):

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -2184,7 +2184,8 @@ _Pickler_write_bytes(PicklerObject *self,
         /* Stream write the payload into the file without going through the
            output buffer. */
         if (payload == NULL) {
-            payload = mem = PyBytes_FromStringAndSize(data, data_size);
+            payload = mem = PyMemoryView_FromMemory((char *) data, data_size,
+                                                    PyBUF_READ);
             if (payload == NULL) {
                 return -1;
             }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -2164,7 +2164,7 @@ _Pickler_write_bytes(PicklerObject *self,
         if (_Pickler_CommitFrame(self)) {
             return -1;
         }
-        /* Disable frameing temporarily */
+        /* Disable framing temporarily */
         self->framing = 0;
     }
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -2408,7 +2408,7 @@ write_utf8(PicklerObject *self, const char *data, Py_ssize_t size)
         return -1;
     }
 
-    if (size < FRAME_SIZE_TARGET || self->write == NULL) {
+    if (size < FRAME_SIZE_TARGET) {
         if (_Pickler_Write(self, header, len) < 0) {
             return -1;
         }


### PR DESCRIPTION
when serialize into memory buffer with C pickle implementations.

This optimization already is performed when serialize into memory with Python pickle implementations or into a file with both implementations.


<!-- issue-number: bpo-31993 -->
https://bugs.python.org/issue31993
<!-- /issue-number -->
