### PR TITLE
Kill the AppVeyor file whitelist

### DIFF
--- a/.github/appveyor.yml
+++ b/.github/appveyor.yml
@@ -16,20 +16,3 @@ environment:
   HOST_PYTHON: C:\Python36\python.exe
 image:
 - Visual Studio 2017
-
-# Only trigger AppVeyor if actual code or its configuration changes
-only_commits:
-  files:
-    - .github/appveyor.yml
-    - .gitattributes
-    - Grammar/
-    - Include/
-    - Lib/
-    - Modules/
-    - Objects/
-    - PC/
-    - PCbuild/
-    - Parser/
-    - Programs/
-    - Python/
-    - Tools/


### PR DESCRIPTION
It's more trouble than it's worth, since it only checks the HEAD commit of a PR rather than the full diff against the base branch for changed files.