### PR TITLE
[2.7] Kill the AppVeyor file whitelist (GH-5121)

### DIFF
--- a/.github/appveyor.yml
+++ b/.github/appveyor.yml
@@ -14,20 +14,3 @@ test_script:
 - cmd: PCbuild\rt.bat -q -uall -u-cpu -rwW --slowest -j2
 environment:
   HOST_PYTHON: C:\Python36\python.exe
-
-# Only trigger AppVeyor if actual code or its configuration changes
-only_commits:
-  files:
-    - .github/appveyor.yml
-    - .gitattributes
-    - Grammar/
-    - Include/
-    - Lib/
-    - Modules/
-    - Objects/
-    - PC/
-    - PCBuild/
-    - Parser/
-    - Programs/
-    - Python/
-    - Tools/


### PR DESCRIPTION
It's more trouble than it's worth, since AppVeyor only checks the HEAD commit of a PR rather than the full diff against the base branch to decide which files changed.
(cherry picked from commit 7f7de371f947dc38e67505601927e9bc58fa268a)