### PR TITLE
bpo-32506: Change dataclasses from OrderedDict to plain dict.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-01-07-11-32-42.bpo-32506.MaT-zU.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-07-11-32-42.bpo-32506.MaT-zU.rst
@@ -1,0 +1,2 @@
+Now that dict is defined as keeping insertion order, drop OrderedDict and
+just use plain dict.


### PR DESCRIPTION
Now that dicts are are defined as maintaining insertion order, switch to using dicts.

<!-- issue-number: bpo-32506 -->
https://bugs.python.org/issue32506
<!-- /issue-number -->
