### PR TITLE
bpo-32515: Add an option to trace to run module as a script

### DIFF
--- a/Doc/library/trace.rst
+++ b/Doc/library/trace.rst
@@ -42,6 +42,9 @@ all Python modules imported during the execution into the current directory.
 
    Display the version of the module and exit.
 
+.. versionadded:: 3.8
+    Added ``--module`` option that allows to run an executable module.
+
 Main options
 ^^^^^^^^^^^^
 

--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -474,7 +474,7 @@ class TestCommandLine(unittest.TestCase):
 
     def test_failures(self):
         _errors = (
-            (b'filename is missing: required with the main options', '-l', '-T'),
+            (b'progname is missing: required with the main options', '-l', '-T'),
             (b'cannot specify both --listfuncs and (--trace or --count)', '-lc'),
             (b'argument -R/--no-report: not allowed with argument -r/--report', '-rR'),
             (b'must specify one of --trace, --count, --report, --listfuncs, or --trackcalls', '-g'),
@@ -523,6 +523,11 @@ class TestCommandLine(unittest.TestCase):
         self.assertEqual(status, 0)
         self.assertIn('lines   cov%   module   (path)', stdout)
         self.assertIn(f'6   100%   {TESTFN}   ({filename})', stdout)
+
+    def test_run_as_module(self):
+        assert_python_ok('-m', 'trace', '-l', '--module', 'timeit', '-n', '1')
+        assert_python_failure('-m', 'trace', '-l', '--module', 'not_a_module_zzz')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-01-07-21-04-50.bpo-32515.D8_Wcb.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-07-21-04-50.bpo-32515.D8_Wcb.rst
@@ -1,0 +1,1 @@
+trace.py can now run modules via python3 -m trace -t --module module_name


### PR DESCRIPTION
Adds a new option in `trace` that allows tracing runnable modules.

If you find it appropriate I can add some further tests that verify things like:

- that only the lines of the modules are covered
- The args are passed properly

<!-- issue-number: bpo-32515 -->
https://bugs.python.org/issue32515
<!-- /issue-number -->
