### PR TITLE
bpo-32521: nis libtirpc

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-01-08-18-02-33.bpo-32521.Kh-KoN.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-08-18-02-33.bpo-32521.Kh-KoN.rst
@@ -1,0 +1,2 @@
+glibc has removed Sun RPC. Use replacement libtirpc headers and library in
+nis module.

--- a/setup.py
+++ b/setup.py
@@ -1373,12 +1373,19 @@ class PyBuildExt(build_ext):
             # Sun yellow pages. Some systems have the functions in libc.
             if (host_platform not in ['cygwin', 'qnx6'] and
                 find_file('rpcsvc/yp_prot.h', inc_dirs, []) is not None):
-                if (self.compiler.find_library_file(lib_dirs, 'nsl')):
-                    libs = ['nsl']
-                else:
-                    libs = []
+                nis_libs = []
+                nis_includes = []
+                if self.compiler.find_library_file(lib_dirs, 'nsl'):
+                    nis_libs.append('nsl')
+                if self.compiler.find_library_file(lib_dirs, 'tirpc'):
+                    # Sun RPC has been moved from glibc to libtirpc
+                    # rpcsvc/yp_prot.h is still in /usr/include, but
+                    # rpc/rpc.h has been moved into tirpc/ subdir.
+                    nis_libs.append('tirpc')
+                    nis_includes.append('/usr/include/tirpc')
                 exts.append( Extension('nis', ['nismodule.c'],
-                                       libraries = libs) )
+                                       libraries = nis_libs,
+                                       include_dirs=nis_includes) )
             else:
                 missing.append('nis')
         else:


### PR DESCRIPTION
glibc has removed Sun RPC. Use replacement libtirpc headers and library in
nis module

Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: bpo-32521 -->
https://bugs.python.org/issue32521
<!-- /issue-number -->
