### PR TITLE
[WIP] bpo-29640 for pthread: Use native thread-local storage to avoid locking issues

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-09-23-26-01.bpo-29640.hovoCF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-09-23-26-01.bpo-29640.hovoCF.rst
@@ -1,0 +1,1 @@
+Use native thread-local storage on pthread systems to avoid locking issues around fork()

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -530,7 +530,7 @@ _pythread_pthread_set_stacksize(size_t size)
  * The difference here is that instead of using NATIVE_TSS_KEY_T
  * (i.e. pthread_key_t) directly, the Python 2 API uses int for keys.
  * (On many systems, pthread_key_t *is* int, but on some it isn't.)
- * So, we keep an array to mapping these ints to pthread_key_t*.
+ * So, we keep an array mapping these ints to pthread_key_t.
  */
 
 struct _Py_tss_t {
@@ -552,12 +552,11 @@ int
 PyThread_create_key(void)
 {
     unsigned int i;
-    /* Find first unused entry */
     if (next_key == keys_allocated) {
         /* grow array */
         keys_allocated = keys_allocated * 2 + 1;
         /* XXX: this array is never freed.
-        /* The common implementation leaks some memory as well
+         * The common implementation leaks some memory as well
          * (see PyThread_delete_key in thread.c),
          * so let's assume programs don't create/destroy TLS keys en masse
          */


### PR DESCRIPTION
Making `fork()` work correctly with thread-local storage is, so far, a game of whack-a-mole -- see [issue 29640](https://bugs.python.org/issue29640) and PR https://github.com/python/cpython/pull/783. The more general discussion in [6721](https://bugs.python.org/issue6721#msg135857) suggests making this “posixly correct” is impossible.

This implements native thread-local storage for pthread. That should fix bug 29640 -- although, sadly, only for pthread platforms.

<!-- issue-number: bpo-29640 -->
https://bugs.python.org/issue29640
<!-- /issue-number -->
