### PR TITLE
[2.7] bpo-32524: Don't leak a package's __init__.py module object in sys.modules on SyntaxError

### DIFF
--- a/Lib/test/test_import.py
+++ b/Lib/test/test_import.py
@@ -422,6 +422,21 @@ class ImportTests(unittest.TestCase):
             __import__('encodings', fromlist=[1])
         self.assertIn('must be str, not int', str(cm.exception))
 
+    def test_package_init_with_syntax_error(self):
+        dir_name = os.path.abspath(TESTFN)
+        os.mkdir(dir_name)
+        self.addCleanup(rmtree, dir_name)
+        pkg_dir = os.path.join(dir_name, 'syntax_error')
+        os.mkdir(pkg_dir)
+        with open(os.path.join(pkg_dir, '__init__.py'), 'w') as init_file:
+            init_file.write("spam()spam()")
+        sys.path.insert(0, dir_name)
+        self.addCleanup(sys.path.pop, 0)
+        def do_import():
+            import syntax_error
+        self.assertRaises(SyntaxError, do_import)
+        self.assertRaises(SyntaxError, do_import)
+
 
 class PycRewritingTests(unittest.TestCase):
     # Test that the `co_filename` attribute on code objects always points

--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-09-23-16-08.bpo-32524.GK9BTS.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-09-23-16-08.bpo-32524.GK9BTS.rst
@@ -1,0 +1,2 @@
+Don't leak a package's \_\_init__.py module object in ``sys.modules`` on
+``SyntaxError``.  Patch by Segev Finer.

--- a/Python/import.c
+++ b/Python/import.c
@@ -1193,6 +1193,8 @@ load_package(char *name, char *pathname)
   error:
     m = NULL;
   cleanup:
+    if (!m)
+        remove_module(name);
     if (buf)
         PyMem_FREE(buf);
     Py_XDECREF(path);


### PR DESCRIPTION
With the file hello/\_\_init__.py:

```py
ham = 123
spam()spam()
```

I get the following:

```py
Python 2.7.14 (v2.7.14:84471935ed, Sep 16 2017, 20:19:30) [MSC v.1500 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import hello
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "hello\__init__.py", line 2
    spam()spam()
             ^
SyntaxError: invalid syntax
>>> import hello
>>> print hello
<module 'hello' from 'hello'>
>>> print dir(hello)
['__doc__', '__file__', '__name__', '__package__', '__path__']
>>>
```

I'd expect to get the `SyntaxError` twice, which is indeed what happens on at least Python 3.6 (Possibly earlier Python 3 versions).

Originally found here https://github.com/pallets/flask/issues/2423 & https://github.com/pallets/flask/pull/2588

cc @davidism @mitsuhiko

<!-- issue-number: bpo-32524 -->
https://bugs.python.org/issue32524
<!-- /issue-number -->
