### PR TITLE
bpo-29240: Ignore UTF-8 Mode in time module

### DIFF
--- a/Include/unicodeobject.h
+++ b/Include/unicodeobject.h
@@ -1811,6 +1811,10 @@ PyAPI_FUNC(PyObject*) PyUnicode_EncodeLocale(
     const char *errors
     );
 
+PyAPI_FUNC(PyObject*) _PyUnicode_DecodeCurrentLocale(
+    const char *str,
+    const char *errors);
+
 PyAPI_FUNC(PyObject*) _PyUnicode_DecodeCurrentLocaleAndSize(
     const char *str,
     Py_ssize_t len,

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -138,8 +138,7 @@ encode(PyObject *b)
 static PyObject *
 decode(const char *s)
 {
-    return _PyUnicode_DecodeCurrentLocaleAndSize(s, strlen(s),
-                                                 "surrogateescape");
+    return _PyUnicode_DecodeCurrentLocale(s, "surrogateescape");
 }
 
 

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -418,11 +418,11 @@ tmtotuple(struct tm *p
     SET(8, p->tm_isdst);
 #ifdef HAVE_STRUCT_TM_TM_ZONE
     PyStructSequence_SET_ITEM(v, 9,
-        PyUnicode_DecodeLocale(p->tm_zone, "surrogateescape"));
+        _PyUnicode_DecodeCurrentLocale(p->tm_zone, "surrogateescape"));
     SET(10, p->tm_gmtoff);
 #else
     PyStructSequence_SET_ITEM(v, 9,
-        PyUnicode_DecodeLocale(zone, "surrogateescape"));
+        _PyUnicode_DecodeCurrentLocale(zone, "surrogateescape"));
     PyStructSequence_SET_ITEM(v, 10, _PyLong_FromTime_t(gmtoff));
 #endif /* HAVE_STRUCT_TM_TM_ZONE */
 #undef SET
@@ -809,8 +809,8 @@ time_strftime(PyObject *self, PyObject *args)
 #ifdef HAVE_WCSFTIME
             ret = PyUnicode_FromWideChar(outbuf, buflen);
 #else
-            ret = PyUnicode_DecodeLocaleAndSize(outbuf, buflen,
-                                                "surrogateescape");
+            ret = _PyUnicode_DecodeCurrentLocaleAndSize(outbuf, buflen,
+                                                        "surrogateescape");
 #endif
             PyMem_Free(outbuf);
             break;
@@ -1541,8 +1541,8 @@ PyInit_timezone(PyObject *m) {
     PyModule_AddIntConstant(m, "altzone", timezone-3600);
 #endif
     PyModule_AddIntConstant(m, "daylight", daylight);
-    otz0 = PyUnicode_DecodeLocale(tzname[0], "surrogateescape");
-    otz1 = PyUnicode_DecodeLocale(tzname[1], "surrogateescape");
+    otz0 = _PyUnicode_DecodeCurrentLocale(tzname[0], "surrogateescape");
+    otz1 = _PyUnicode_DecodeCurrentLocale(tzname[1], "surrogateescape");
     PyModule_AddObject(m, "tzname", Py_BuildValue("(NN)", otz0, otz1));
 #else /* !HAVE_TZNAME || __GLIBC__ || __CYGWIN__*/
     {

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3837,6 +3837,12 @@ _PyUnicode_DecodeCurrentLocaleAndSize(const char *str, Py_ssize_t len,
 }
 
 PyObject*
+_PyUnicode_DecodeCurrentLocale(const char *str, const char *errors)
+{
+    return unicode_decode_locale(str, (Py_ssize_t)strlen(str), errors, 1);
+}
+
+PyObject*
 PyUnicode_DecodeLocale(const char *str, const char *errors)
 {
     Py_ssize_t size = (Py_ssize_t)strlen(str);


### PR DESCRIPTION
time.strftime() must use the current LC_CTYPE encoding, not UTF-8
if the UTF-8 mode is enabled.

Add _PyUnicode_DecodeCurrentLocale() function.

<!-- issue-number: bpo-29240 -->
https://bugs.python.org/issue29240
<!-- /issue-number -->
