### PR TITLE
bpo-28429 Fix ctypes import under grsec TPE

### DIFF
--- a/Lib/ctypes/__init__.py
+++ b/Lib/ctypes/__init__.py
@@ -270,7 +270,8 @@ def _reset_cache():
     # function is needed for the unittests on Win64 to succeed.  This MAY
     # be a compiler bug, since the problem occurs only when _ctypes is
     # compiled with the MS SDK compiler.  Or an uninitialized variable?
-    CFUNCTYPE(c_int)(lambda: None)
+    if _os.name == "nt":
+        CFUNCTYPE(c_int)(lambda: None)
 
 def create_unicode_buffer(init, size=None):
     """create_unicode_buffer(aString) -> character array

--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-11-12-32-26.bpo-28429.GKMfVW.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-11-12-32-26.bpo-28429.GKMfVW.rst
@@ -1,0 +1,3 @@
+Added a check that only runs dummy function init in ctypes on windows, where
+it's needed. This solves the problem with GRsecurity/SELinux complaining
+about that and treating it as a memory violation.


### PR DESCRIPTION
We've hit that issue in production recently, and are planning to hotfix this in a similar way. Since there are no signs of a better fix (or demand for one), I think that this change should be good enough - which should resolve both GRsec and potential SELinux problems.

<!-- issue-number: bpo-28429 -->
https://bugs.python.org/issue28429
<!-- /issue-number -->
