### PR TITLE
bpo-32529: imporved shutil.copyfileobj

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -75,11 +75,18 @@ class RegistryError(Exception):
 
 def copyfileobj(fsrc, fdst, length=16*1024):
     """copy data from file-like object fsrc to file-like object fdst"""
+    buf = memoryview(bytearray(length))
+    # localize
+    readinto = fsrc.readinto
+    write = fdst.write
+    # run loop
     while 1:
-        buf = fsrc.read(length)
-        if not buf:
+        recv_len = readinto(buf)
+        if recv_len < length:
+            # write remaining content if any.
+            write(buf[:recv_len])
             break
-        fdst.write(buf)
+        write(buf)
 
 def _samefile(src, dst):
     # Macintosh, Unix.

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -79,7 +79,7 @@ class EncodingMismatchError(UnicodeError):
 def copyfileobj(fsrc, fdst, length=16*1024):
     """copy data from file-like object fsrc to file-like object fdst"""
     write = fdst.write
-    if hasattr(fsrc, 'readinto') and length > 0:  # Bytes IO
+    if hasattr(fsrc, 'readinto') and length > 0:
         buf = memoryview(bytearray(length))
         readinto = fsrc.readinto
         while 1:
@@ -89,7 +89,7 @@ def copyfileobj(fsrc, fdst, length=16*1024):
                 write(buf[:recv_len])
                 break
             write(buf)
-    else:  # Text IO
+    else:
         if hasattr(fsrc, 'encoding') and hasattr(fdst, 'encoding'):
             # check fsrc & fdst encoding matches
             if fsrc.encoding != fdst.encoding:

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -72,14 +72,14 @@ class RegistryError(Exception):
     """Raised when a registry operation with the archiving
     and unpacking registries fails"""
 
-class EncodingMissmatchError(UnicodeError):
+class EncodingMismatchError(UnicodeError):
     """Raised when source and destination encoding are not the same."""
 
 
 def copyfileobj(fsrc, fdst, length=16*1024):
     """copy data from file-like object fsrc to file-like object fdst"""
     write = fdst.write
-    if hasattr(fsrc, 'readinto') and length > 0:
+    if hasattr(fsrc, 'readinto') and length > 0:  # Bytes IO
         buf = memoryview(bytearray(length))
         readinto = fsrc.readinto
         while 1:
@@ -89,12 +89,11 @@ def copyfileobj(fsrc, fdst, length=16*1024):
                 write(buf[:recv_len])
                 break
             write(buf)
-    else:
-        # TextIOBase
+    else:  # Text IO
         if hasattr(fsrc, 'encoding') and hasattr(fdst, 'encoding'):
             # check fsrc & fdst encoding matches
             if fsrc.encoding != fdst.encoding:
-                raise EncodingMissmatchError(
+                raise EncodingMismatchError(
                     'fsrc.encoding={!r} and fdst.encoding={!r}'.format(fsrc.encoding, fdst.encoding)
                 )
         read = fsrc.read

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -72,9 +72,6 @@ class RegistryError(Exception):
     """Raised when a registry operation with the archiving
     and unpacking registries fails"""
 
-class EncodingMismatchError(UnicodeError):
-    """Raised when source and destination encoding are not the same."""
-
 
 def copyfileobj(fsrc, fdst, length=16*1024):
     """copy data from file-like object fsrc to file-like object fdst"""
@@ -90,12 +87,6 @@ def copyfileobj(fsrc, fdst, length=16*1024):
                 break
             write(buf)
     else:
-        if hasattr(fsrc, 'encoding') and hasattr(fdst, 'encoding'):
-            # check fsrc & fdst encoding matches
-            if fsrc.encoding != fdst.encoding:
-                raise EncodingMismatchError(
-                    'fsrc.encoding={!r} and fdst.encoding={!r}'.format(fsrc.encoding, fdst.encoding)
-                )
         read = fsrc.read
         while 1:
             buf = read(length)

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -125,7 +125,7 @@ def copyfile(src, dst, *, follow_symlinks=True):
     if _samefile(src, dst):
         raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
 
-    for fn in {src, dst}:
+    for fn in [src, dst]:
         try:
             st = os.stat(fn)
         except OSError:


### PR DESCRIPTION
Improved "copyfileobj" function to use less memory if provided Bytes IO and fixed potential encoding mismatch corruption in Text IO

<!-- issue-number: bpo-32529 -->
https://bugs.python.org/issue32529
<!-- /issue-number -->
