### PR TITLE
bpo-27643 - fix test_ctypes test_bitfields with XLC compiler.

### DIFF
--- a/Lib/ctypes/test/test_bitfields.py
+++ b/Lib/ctypes/test/test_bitfields.py
@@ -40,6 +40,10 @@ class C_Test(unittest.TestCase):
                 self.assertEqual(getattr(b, name), func(byref(b), name.encode('ascii')))
 
     def test_shorts(self):
+        b = BITS()
+        name = "M"
+        if func(byref(b), name.encode('ascii')) == 999:
+            self.skipTest("Compiler does not support signed short bitfields")
         for i in range(256):
             for name in "MNOPQRS":
                 b = BITS()

--- a/Misc/NEWS.d/next/Tests/2018-01-12-09-05-19.bpo-27643._6z49y.rst
+++ b/Misc/NEWS.d/next/Tests/2018-01-12-09-05-19.bpo-27643._6z49y.rst
@@ -1,0 +1,5 @@
+Test_C test case needs "signed short" bitfields, but the
+IBM XLC compiler (on AIX) does not support this
+Skip the code and test when AIX and XLC are used
+
+Applicable to Python2-2.7 and later

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -416,17 +416,12 @@ EXPORT(unsigned long long) last_tf_arg_u = 0;
 struct BITS {
     signed int A: 1, B:2, C:3, D:4, E: 5, F: 6, G: 7, H: 8, I: 9;
 /*
- * The test case needs "signed short" bitfields, but the
+ * The test case needs/uses "signed short" bitfields, but the
  * IBM XLC compiler does not support this
  */
-#ifndef _AIX
+#ifndef __xlc__
 #define SIGNED_SHORT_BITFIELDS
      short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
-#else
-#ifdef __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 /* Something to distinguish GCC and XLC */
-#define SIGNED_SHORT_BITFIELDS
-     short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
-#endif
 #endif
 };
 

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -414,8 +414,20 @@ EXPORT(long long) last_tf_arg_s = 0;
 EXPORT(unsigned long long) last_tf_arg_u = 0;
 
 struct BITS {
-    int A: 1, B:2, C:3, D:4, E: 5, F: 6, G: 7, H: 8, I: 9;
-    short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
+    signed int A: 1, B:2, C:3, D:4, E: 5, F: 6, G: 7, H: 8, I: 9;
+/*
+ * The test case needs "signed short" bitfields, but the
+ * IBM XLC compiler does not support this
+ */
+#ifndef _AIX
+#define SIGNED_SHORT_BITFIELDS
+     short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
+#else
+#ifdef __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 /* Something to distinguish GCC and XLC */
+#define SIGNED_SHORT_BITFIELDS
+     short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
+#endif
+#endif
 };
 
 EXPORT(void) set_bitfields(struct BITS *bits, char name, int value)
@@ -430,7 +442,7 @@ EXPORT(void) set_bitfields(struct BITS *bits, char name, int value)
     case 'G': bits->G = value; break;
     case 'H': bits->H = value; break;
     case 'I': bits->I = value; break;
-
+#ifdef SIGNED_SHORT_BITFIELDS
     case 'M': bits->M = value; break;
     case 'N': bits->N = value; break;
     case 'O': bits->O = value; break;
@@ -438,6 +450,7 @@ EXPORT(void) set_bitfields(struct BITS *bits, char name, int value)
     case 'Q': bits->Q = value; break;
     case 'R': bits->R = value; break;
     case 'S': bits->S = value; break;
+#endif
     }
 }
 
@@ -454,6 +467,7 @@ EXPORT(int) unpack_bitfields(struct BITS *bits, char name)
     case 'H': return bits->H;
     case 'I': return bits->I;
 
+#ifdef SIGNED_SHORT_BITFIELDS
     case 'M': return bits->M;
     case 'N': return bits->N;
     case 'O': return bits->O;
@@ -461,8 +475,9 @@ EXPORT(int) unpack_bitfields(struct BITS *bits, char name)
     case 'Q': return bits->Q;
     case 'R': return bits->R;
     case 'S': return bits->S;
+#endif
     }
-    return 0;
+    return 999;
 }
 
 static PyMethodDef module_methods[] = {


### PR DESCRIPTION
This PR skips the "signed short" bitfield test when the compiler is XLC
It also removes the failing code (signed short declaration) in test_bitfields.py and _ctypes_test.c)

<!-- issue-number: [bpo-27643](https://www.bugs.python.org/issue27643) -->
https://bugs.python.org/issue27643
<!-- /issue-number -->
