### PR TITLE
bpo-36668: FIX reuse semaphore tracker for child processes

### DIFF
--- a/Lib/multiprocessing/semaphore_tracker.py
+++ b/Lib/multiprocessing/semaphore_tracker.py
@@ -44,18 +44,11 @@ class SemaphoreTracker(object):
         This can be run from any process.  Usually a child process will use
         the semaphore created by its parent.'''
         with self._lock:
-            if self._pid is not None:
+            if self._fd is not None:
                 # semaphore tracker was launched before, is it still running?
-                try:
-                    pid, _ = os.waitpid(self._pid, os.WNOHANG)
-                except ChildProcessError:
-                    # The process terminated
-                    pass
-                else:
-                    if not pid:
-                        # => still alive
-                        return
-
+                if self._check_alive():
+                    # => still alive
+                    return
                 # => dead, launch it again
                 os.close(self._fd)
                 self._fd = None
@@ -98,6 +91,15 @@ class SemaphoreTracker(object):
                 self._pid = pid
             finally:
                 os.close(r)
+
+    def _check_alive(self):
+        '''Check for that the pipe has not been closed by sending a probe.'''
+        try:
+            os.write(self._fd, b'PROBE:0\n')
+        except BrokenPipeError:
+            return False
+        else:
+            return True
 
     def register(self, name):
         '''Register name of semaphore with semaphore tracker.'''
@@ -150,6 +152,8 @@ def main(fd):
                         cache.add(name)
                     elif cmd == b'UNREGISTER':
                         cache.remove(name)
+                    elif cmd == b'PROBE':
+                        pass
                     else:
                         raise RuntimeError('unrecognized command %r' % cmd)
                 except Exception:

--- a/Lib/multiprocessing/semaphore_tracker.py
+++ b/Lib/multiprocessing/semaphore_tracker.py
@@ -59,7 +59,7 @@ class SemaphoreTracker(object):
                     if self._pid is not None:
                         os.waitpid(self._pid, 0)
                 except ChildProcessError:
-                    # The semaphore_tracker is already terminated.
+                    # The semaphore_tracker has already been terminated.
                     pass
                 self._fd = None
                 self._pid = None

--- a/Lib/multiprocessing/semaphore_tracker.py
+++ b/Lib/multiprocessing/semaphore_tracker.py
@@ -100,7 +100,7 @@ class SemaphoreTracker(object):
                 os.close(r)
 
     def _check_alive(self):
-        '''Check for that the pipe has not been closed by sending a probe.'''
+        '''Check that the pipe has not been closed by sending a probe.'''
         try:
             # We cannot use send here as it calls ensure_running, creating
             # a cycle.

--- a/Lib/multiprocessing/semaphore_tracker.py
+++ b/Lib/multiprocessing/semaphore_tracker.py
@@ -108,7 +108,7 @@ class SemaphoreTracker(object):
             # We cannot use send here as it calls ensure_running, creating
             # a cycle.
             os.write(self._fd, b'PROBE:0\n')
-        except BrokenPipeError:
+        except OSError:
             return False
         else:
             return True

--- a/Lib/multiprocessing/semaphore_tracker.py
+++ b/Lib/multiprocessing/semaphore_tracker.py
@@ -51,6 +51,13 @@ class SemaphoreTracker(object):
                     return
                 # => dead, launch it again
                 os.close(self._fd)
+                try:
+                    # Clean-up to avoid dangling processes.
+                    os.waitpid(self._pid, 0)
+                except ChildProcessError:
+                    # The process terminated or is a child from an ancestor of
+                    # the current process.
+                    pass
                 self._fd = None
                 self._pid = None
 

--- a/Lib/multiprocessing/semaphore_tracker.py
+++ b/Lib/multiprocessing/semaphore_tracker.py
@@ -95,6 +95,8 @@ class SemaphoreTracker(object):
     def _check_alive(self):
         '''Check for that the pipe has not been closed by sending a probe.'''
         try:
+            # We cannot use send here as it calls ensure_running, creating
+            # a cycle.
             os.write(self._fd, b'PROBE:0\n')
         except BrokenPipeError:
             return False

--- a/Lib/multiprocessing/semaphore_tracker.py
+++ b/Lib/multiprocessing/semaphore_tracker.py
@@ -51,12 +51,15 @@ class SemaphoreTracker(object):
                     return
                 # => dead, launch it again
                 os.close(self._fd)
+
+                # Clean-up to avoid dangling processes.
                 try:
-                    # Clean-up to avoid dangling processes.
-                    os.waitpid(self._pid, 0)
+                    # _pid can be None if this process is a child from another
+                    # python process, which has started the semaphore_tracker.
+                    if self._pid is not None:
+                        os.waitpid(self._pid, 0)
                 except ChildProcessError:
-                    # The process terminated or is a child from an ancestor of
-                    # the current process.
+                    # The semaphore_tracker is already terminated.
                     pass
                 self._fd = None
                 self._pid = None

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -237,7 +237,7 @@ def prepare(data):
     if 'start_method' in data:
         set_start_method(data['start_method'], force=True)
 
-    if 'tacker_pid' in data:
+    if 'tracker_pid' in data:
         from . import semaphore_tracker
         semaphore_tracker._semaphore_tracker._pid = data["tracker_pid"]
 

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -178,12 +178,6 @@ def get_preparation_data(name):
         start_method=get_start_method(),
         )
 
-    if sys.platform != "win32":
-        # Pass the semaphore_tracker pid to avoid re-spawning it in every child
-        from . import semaphore_tracker
-        semaphore_tracker.ensure_running()
-        d['tracker_pid'] = semaphore_tracker._semaphore_tracker._pid
-
     # Figure out whether to initialise main in the subprocess as a module
     # or through direct execution (or to leave it alone entirely)
     main_module = sys.modules['__main__']
@@ -236,10 +230,6 @@ def prepare(data):
 
     if 'start_method' in data:
         set_start_method(data['start_method'], force=True)
-
-    if 'tracker_pid' in data:
-        from . import semaphore_tracker
-        semaphore_tracker._semaphore_tracker._pid = data["tracker_pid"]
 
     if 'init_main_from_name' in data:
         _fixup_main_from_name(data['init_main_from_name'])

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -178,6 +178,12 @@ def get_preparation_data(name):
         start_method=get_start_method(),
         )
 
+    if sys.platform != "win32":
+        # Pass the semaphore_tracker pid to avoid re-spawning it in every child
+        from . import semaphore_tracker
+        semaphore_tracker.ensure_running()
+        d['tracker_pid'] = semaphore_tracker._semaphore_tracker._pid
+
     # Figure out whether to initialise main in the subprocess as a module
     # or through direct execution (or to leave it alone entirely)
     main_module = sys.modules['__main__']
@@ -230,6 +236,10 @@ def prepare(data):
 
     if 'start_method' in data:
         set_start_method(data['start_method'], force=True)
+
+    if 'tacker_pid' in data:
+        from . import semaphore_tracker
+        semaphore_tracker._semaphore_tracker._pid = data["tracker_pid"]
 
     if 'init_main_from_name' in data:
         _fixup_main_from_name(data['init_main_from_name'])

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -169,6 +169,11 @@ def get_preparation_data(name):
     else:
         sys_path[i] = process.ORIGINAL_DIR
 
+    if sys.platform != "win32":
+        from .semaphore_tracker import _semaphore_tracker
+        _semaphore_tracker.ensure_running()
+        d['semaphore_tracker_pid'] = _semaphore_tracker._pid
+
     d.update(
         name=name,
         sys_path=sys_path,
@@ -230,6 +235,10 @@ def prepare(data):
 
     if 'start_method' in data:
         set_start_method(data['start_method'], force=True)
+
+    if 'semaphore_tracker_pid' in data:
+        from .semaphore_tracker import _semaphore_tracker
+        _semaphore_tracker._pid = data['semaphore_tracker_pid']
 
     if 'init_main_from_name' in data:
         _fixup_main_from_name(data['init_main_from_name'])

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -169,11 +169,6 @@ def get_preparation_data(name):
     else:
         sys_path[i] = process.ORIGINAL_DIR
 
-    if sys.platform != "win32":
-        from .semaphore_tracker import _semaphore_tracker
-        _semaphore_tracker.ensure_running()
-        d['semaphore_tracker_pid'] = _semaphore_tracker._pid
-
     d.update(
         name=name,
         sys_path=sys_path,
@@ -235,10 +230,6 @@ def prepare(data):
 
     if 'start_method' in data:
         set_start_method(data['start_method'], force=True)
-
-    if 'semaphore_tracker_pid' in data:
-        from .semaphore_tracker import _semaphore_tracker
-        _semaphore_tracker._pid = data['semaphore_tracker_pid']
 
     if 'init_main_from_name' in data:
         _fixup_main_from_name(data['init_main_from_name'])

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4883,11 +4883,6 @@ class TestSemaphoreTracker(unittest.TestCase):
             else:
                 self.assertEqual(len(all_warn), 0)
 
-        # make sure to clean-up the killed semaphore_tracker to avoid dangling
-        # processes.
-        if signum == signal.SIGKILL:
-            os.waitpid(pid, 0)
-
     def test_semaphore_tracker_sigint(self):
         # Catchable signal (ignored by semaphore tracker)
         self.check_semaphore_tracker_death(signal.SIGINT, False)

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4896,10 +4896,10 @@ class TestSemaphoreTracker(unittest.TestCase):
         self.check_semaphore_tracker_death(signal.SIGKILL, True)
 
     @staticmethod
-    def _is_semaphore_tracker_reused(conn):
+    def _is_semaphore_tracker_reused(conn, pid):
         from multiprocessing.semaphore_tracker import _semaphore_tracker
         _semaphore_tracker.ensure_running()
-        reused = _semaphore_tracker._pid is None
+        reused = _semaphore_tracker._pid  == pid
         reused &= _semaphore_tracker._check_alive()
         conn.send(reused)
 
@@ -4911,7 +4911,7 @@ class TestSemaphoreTracker(unittest.TestCase):
         ctx = multiprocessing.get_context("spawn")
         r, w = ctx.Pipe(duplex=False)
         p = ctx.Process(target=self._is_semaphore_tracker_reused,
-                        args=(w,))
+                        args=(w, pid))
         p.start()
         is_semaphore_tracker_reused = r.recv()
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4899,7 +4899,7 @@ class TestSemaphoreTracker(unittest.TestCase):
     def _is_semaphore_tracker_reused(conn, pid):
         from multiprocessing.semaphore_tracker import _semaphore_tracker
         _semaphore_tracker.ensure_running()
-        reused = _semaphore_tracker._pid  == pid
+        reused = _semaphore_tracker._pid is None
         reused &= _semaphore_tracker._check_alive()
         conn.send(reused)
 
@@ -4908,10 +4908,9 @@ class TestSemaphoreTracker(unittest.TestCase):
         _semaphore_tracker.ensure_running()
         pid = _semaphore_tracker._pid
 
-        ctx = multiprocessing.get_context("spawn")
-        r, w = ctx.Pipe(duplex=False)
-        p = ctx.Process(target=self._is_semaphore_tracker_reused,
-                        args=(w, pid))
+        r, w = multiprocessing.Pipe(duplex=False)
+        p = multiprocessing.Process(target=self._is_semaphore_tracker_reused,
+                                    args=(w, pid))
         p.start()
         is_semaphore_tracker_reused = r.recv()
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4899,7 +4899,9 @@ class TestSemaphoreTracker(unittest.TestCase):
     def _is_semaphore_tracker_reused(conn, pid):
         from multiprocessing.semaphore_tracker import _semaphore_tracker
         _semaphore_tracker.ensure_running()
-        reused = _semaphore_tracker._pid is None
+        # The pid should be None in the child process, expect for the fork
+        # context. It should not be a new value.
+        reused = _semaphore_tracker._pid in (None, pid)
         reused &= _semaphore_tracker._check_alive()
         conn.send(reused)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4883,6 +4883,11 @@ class TestSemaphoreTracker(unittest.TestCase):
             else:
                 self.assertEqual(len(all_warn), 0)
 
+        # make sure to clean-up the killed semaphore_tracker to avoid dangling
+        # processes.
+        if signum == signal.SIGKILL:
+            os.waitpid(pid, 0)
+
     def test_semaphore_tracker_sigint(self):
         # Catchable signal (ignored by semaphore tracker)
         self.check_semaphore_tracker_death(signal.SIGINT, False)

--- a/Misc/NEWS.d/next/Library/2018-04-06-11-06-23.bpo-31310.eq9ky0.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-06-11-06-23.bpo-31310.eq9ky0.rst
@@ -1,0 +1,1 @@
+Fix the multiprocessing.semaphore_tracker so it is reused by child processes


### PR DESCRIPTION
The current implementation of the `semaphore_tracker` creates a new process for each children.
This PR intends to fix this behavior.

The easy fix would be to pass the `_pid` to the children but the current mechanism to check if the `semaphore_tracker` is alive relies on `waitpid` which cannot be used in child processes (the `semaphore_tracker` is only a sibling of these processes). The main issue is to have a reliable check that either:
- The pipe is open. This is what is done here by sending a message. I don't know if there is a more efficient way to check it.
- Check that a given pid is alive. As we cannot rely on `waitpid`, I don't see an efficient mechanism.

I took the approach of adding a `PROBE` command in the semaphore tracker. When the pipe is closed, the send command fails and this means the semaphore tracker is down.

<!-- issue-number: [bpo-36668](https://bugs.python.org/issue36668) -->
https://bugs.python.org/issue36668
<!-- /issue-number -->
