### PR TITLE
bpo-32544: Speed up hasattr() and getattr()

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -536,6 +536,8 @@ PyAPI_FUNC(int) PyObject_SetAttr(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(int) PyObject_HasAttr(PyObject *, PyObject *);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyObject_IsAbstract(PyObject *);
+/* Same to PyObject_GetAttr(), but don't raise AttributeError. */
+PyAPI_FUNC(PyObject *) _PyObject_GetAttrWithoutError(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) _PyObject_GetAttrId(PyObject *, struct _Py_Identifier *);
 PyAPI_FUNC(int) _PyObject_SetAttrId(PyObject *, struct _Py_Identifier *, PyObject *);
 PyAPI_FUNC(int) _PyObject_HasAttrId(PyObject *, struct _Py_Identifier *);
@@ -567,7 +569,7 @@ PyAPI_FUNC(int) PyObject_CallFinalizerFromDealloc(PyObject *);
 /* Same as PyObject_Generic{Get,Set}Attr, but passing the attributes
    dict as the last parameter. */
 PyAPI_FUNC(PyObject *)
-_PyObject_GenericGetAttrWithDict(PyObject *, PyObject *, PyObject *);
+_PyObject_GenericGetAttrWithDict(PyObject *, PyObject *, PyObject *, int);
 PyAPI_FUNC(int)
 _PyObject_GenericSetAttrWithDict(PyObject *, PyObject *,
                                  PyObject *, PyObject *);

--- a/Include/object.h
+++ b/Include/object.h
@@ -536,7 +536,7 @@ PyAPI_FUNC(int) PyObject_SetAttr(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(int) PyObject_HasAttr(PyObject *, PyObject *);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyObject_IsAbstract(PyObject *);
-/* Same to PyObject_GetAttr(), but don't raise AttributeError. */
+/* Same as PyObject_GetAttr(), but don't raise AttributeError. */
 PyAPI_FUNC(PyObject *) _PyObject_GetAttrWithoutError(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) _PyObject_GetAttrId(PyObject *, struct _Py_Identifier *);
 PyAPI_FUNC(int) _PyObject_SetAttrId(PyObject *, struct _Py_Identifier *, PyObject *);

--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-16-18-51-58.bpo-32544.ga-cFE.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-16-18-51-58.bpo-32544.ga-cFE.rst
@@ -1,0 +1,3 @@
+``hasattr(obj, name)`` and ``getattr(obj, name, default)`` is about 4 times
+faster than before when ``name`` is not found and ``obj`` doesn't override
+``__getattr__`` or ``__getattribute__``.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-16-18-51-58.bpo-32544.ga-cFE.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-16-18-51-58.bpo-32544.ga-cFE.rst
@@ -1,3 +1,3 @@
-``hasattr(obj, name)`` and ``getattr(obj, name, default)`` is about 4 times
+``hasattr(obj, name)`` and ``getattr(obj, name, default)`` are about 4 times
 faster than before when ``name`` is not found and ``obj`` doesn't override
 ``__getattr__`` or ``__getattribute__``.

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -925,13 +925,15 @@ local_getattro(localobject *self, PyObject *name)
 
     if (Py_TYPE(self) != &localtype)
         /* use generic lookup for subtypes */
-        return _PyObject_GenericGetAttrWithDict((PyObject *)self, name, ldict);
+        return _PyObject_GenericGetAttrWithDict(
+            (PyObject *)self, name, ldict, 0);
 
     /* Optimization: just look in dict ourselves */
     value = PyDict_GetItem(ldict, name);
     if (value == NULL)
         /* Fall back on generic to get __class__ and __dict__ */
-        return _PyObject_GenericGetAttrWithDict((PyObject *)self, name, ldict);
+        return _PyObject_GenericGetAttrWithDict(
+            (PyObject *)self, name, ldict, 0);
 
     Py_INCREF(value);
     return value;

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -900,11 +900,12 @@ _PyObject_GetAttrWithoutError(PyObject *v, PyObject *name)
         return NULL;
     }
     if (tp->tp_getattro != NULL) {
-        // Fast path, skip raising AttributeError
         if (tp->tp_getattro == PyObject_GenericGetAttr) {
-            return _PyObject_GenericGetAttrWithDict(v, name, NULL, 1);
+            ret = _PyObject_GenericGetAttrWithDict(v, name, NULL, 1);
         }
-        ret = (*tp->tp_getattro)(v, name);
+        else {
+            ret = (*tp->tp_getattro)(v, name);
+        }
     }
     else if (tp->tp_getattr != NULL) {
         const char *name_str = PyUnicode_AsUTF8(name);
@@ -1134,6 +1135,9 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
 {
     /* Make sure the logic of _PyObject_GetMethod is in sync with
        this method.
+
+       When suppress=1, this function doesn't raise AttributeError.
+       But descriptors may raise it.
     */
 
     PyTypeObject *tp = Py_TYPE(obj);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -922,7 +922,7 @@ _PyObject_GetAttrWithoutError(PyObject *v, PyObject *name)
 int
 PyObject_HasAttr(PyObject *v, PyObject *name)
 {
-    PyObject *res = PyObject_GetAttr(v, name);
+    PyObject *res = _PyObject_GetAttrWithoutError(v, name);
     if (res != NULL) {
         Py_DECREF(res);
         return 1;


### PR DESCRIPTION
Skip raising AttributeError when tp_getattro == PyObject_GenericGetAttr

<!-- issue-number: bpo-32544 -->
https://bugs.python.org/issue32544
<!-- /issue-number -->
