### PR TITLE
gh-73065: Add Date header if missing in smtplib send_message

### DIFF
--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -522,12 +522,17 @@ An :class:`SMTP` instance has the following methods:
    specified in :rfc:`5322`\: *from_addr* is set to the :mailheader:`Sender`
    field if it is present, and otherwise to the :mailheader:`From` field.
    *to_addrs* combines the values (if any) of the :mailheader:`To`,
-   :mailheader:`Cc`, and :mailheader:`Bcc` fields from *msg*.  If exactly one
-   set of :mailheader:`Resent-*` headers appear in the message, the regular
-   headers are ignored and the :mailheader:`Resent-*` headers are used instead.
-   If the message contains more than one set of :mailheader:`Resent-*` headers,
-   a :exc:`ValueError` is raised, since there is no way to unambiguously detect
-   the most recent set of :mailheader:`Resent-` headers.
+   :mailheader:`Cc`, and :mailheader:`Bcc` fields from *msg*.  If there's no
+   :mailheader:`Date` header inside the message, ``send_message`` will add one to the data.
+   If exactly one set of :mailheader:`Resent-*` headers appear in the message,
+   the regular headers are ignored and the :mailheader:`Resent-*` headers are
+   used instead.  If the message contains more than one set of
+   :mailheader:`Resent-*` headers, a :exc:`ValueError` is raised, since there
+   is no way to unambiguously detect the most recent set of
+   :mailheader:`Resent-` headers.
+
+   .. versionchanged:: 3.2
+      Support to add :mailheader:`Date` header to the message if one does not exist.
 
    ``send_message`` serializes *msg* using
    :class:`~email.generator.BytesGenerator` with ``\r\n`` as the *linesep*, and

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -932,6 +932,10 @@ class SMTP:
             header_prefix = 'Resent-'
         else:
             raise ValueError("message has more than one 'Resent-' header block")
+
+        # RFC 5322 section 3.6, 4th Paragraph
+        if msg.get('Date', None) is None:
+            msg['Date'] = email.utils.formatdate()
         if from_addr is None:
             # Prefer the sender field per RFC 2822:3.6.2.
             from_addr = (msg[header_prefix + 'Sender']

--- a/Misc/NEWS.d/next/Library/2018-01-13-15-52-00.bpo-28879.aW2gj0.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-13-15-52-00.bpo-28879.aW2gj0.rst
@@ -1,0 +1,2 @@
+Fix ``smtplib.send_message`` to add a ``Date`` header if it is missing as per
+RFC5322.


### PR DESCRIPTION


<!-- issue-number: bpo-28879 -->
https://bugs.python.org/issue28879
<!-- /issue-number -->

<!-- gh-issue-number: gh-73065 -->
* Issue: gh-73065
<!-- /gh-issue-number -->
