### PR TITLE
bpo-8243: Doc patch for curses.window.addstr and curses.window.addch

### DIFF
--- a/Doc/library/curses.rst
+++ b/Doc/library/curses.rst
@@ -685,6 +685,12 @@ the following methods and attributes:
    character previously painter at that location.  By default, the character
    position and attributes are the current settings for the window object.
 
+   .. note::
+
+      Writing outside the window, subwindow, or pad raises a :exc:`curses.error`.
+      Attempting to write to the lower right corner of a window, subwindow,
+      or pad will cause an exception to be raised after the character is printed.
+
 
 .. method:: window.addnstr(str, n[, attr])
             window.addnstr(y, x, str, n[, attr])
@@ -699,6 +705,12 @@ the following methods and attributes:
 
    Paint the character string *str* at ``(y, x)`` with attributes
    *attr*, overwriting anything previously on the display.
+
+   .. note::
+
+      Writing outside the window, subwindow, or pad raises :exc:`curses.error`.
+      Attempting to write to the lower right corner of a window, subwindow,
+      or pad will cause an exception to be raised after the string is printed.
 
 
 .. method:: window.attroff(attr)

--- a/Misc/NEWS.d/next/Documentation/2018-01-13-20-30-53.bpo-8243.s98r28.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-13-20-30-53.bpo-8243.s98r28.rst
@@ -1,0 +1,2 @@
+Add a note about curses.addch and curses.addstr exception behavior when
+writing outside a window, or pad.


### PR DESCRIPTION
bpo-8243: Doc patch for curses.window.addstr and curses.window.addch

Added documentation notes for two functions in curses.window . 
This is my first pr, please let me know what else I need to do.


<!-- issue-number: bpo-8243 -->
https://bugs.python.org/issue8243
<!-- /issue-number -->
