### PR TITLE
bpo-32526: Closing async generator while it is running does not raise an exception

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -696,6 +696,28 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         self.loop.run_until_complete(run())
         self.assertEqual(DONE, 10)
 
+    def test_async_gen_asyncio_aclose_12(self):
+        DONE = 0
+
+        async def gen():
+            nonlocal DONE
+            await asyncio.sleep(0.1)
+            yield
+            DONE += 2
+
+        async def run():
+            nonlocal DONE
+            ag = gen()
+            asend_coro = ag.asend(None)
+            fut = asend_coro.send(None)
+            self.assertTrue(ag.ag_running)
+            with self.assertRaises(ValueError):
+                await ag.asend(None)
+            DONE += 10
+
+        self.loop.run_until_complete(run())
+        self.assertEqual(DONE, 12)
+
     def test_async_gen_asyncio_asend_01(self):
         DONE = 0
 

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -701,7 +701,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
 
         async def gen():
             nonlocal DONE
-            await asyncio.sleep(0.1)
+            await asyncio.sleep(1)
             yield
             DONE += 2
 
@@ -709,6 +709,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
             nonlocal DONE
             ag = gen()
             asend_coro = ag.asend(None)
+            self.assertFalse(ag.ag_running)
             fut = asend_coro.send(None)
             self.assertTrue(ag.ag_running)
             with self.assertRaises(ValueError):
@@ -716,7 +717,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
             DONE += 10
 
         self.loop.run_until_complete(run())
-        self.assertEqual(DONE, 12)
+        self.assertEqual(DONE, 10)
 
     def test_async_gen_asyncio_asend_01(self):
         DONE = 0

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1534,9 +1534,11 @@ async_gen_asend_send(PyAsyncGenASend *o, PyObject *arg)
 
     result = gen_send_ex((PyGenObject*)o->ags_gen, arg, 0, 0);
     result = async_gen_unwrap_value(o->ags_gen, result);
+    ((PyGenObject*)o->ags_gen)->gi_running = 1;
 
     if (result == NULL) {
         o->ags_state = AWAITABLE_STATE_CLOSED;
+        ((PyGenObject*)o->ags_gen)->gi_running = 0;
     }
 
     return result;
@@ -1562,9 +1564,11 @@ async_gen_asend_throw(PyAsyncGenASend *o, PyObject *args)
 
     result = gen_throw((PyGenObject*)o->ags_gen, args);
     result = async_gen_unwrap_value(o->ags_gen, result);
+    ((PyGenObject*)o->ags_gen)->gi_running = 1;
 
     if (result == NULL) {
         o->ags_state = AWAITABLE_STATE_CLOSED;
+        ((PyGenObject*)o->ags_gen)->gi_running = 0;
     }
 
     return result;
@@ -1575,6 +1579,7 @@ static PyObject *
 async_gen_asend_close(PyAsyncGenASend *o, PyObject *args)
 {
     o->ags_state = AWAITABLE_STATE_CLOSED;
+    ((PyGenObject*)o->ags_gen)->gi_running = 0;
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
Here are my first draft PR to pass the `async_generator` test case provided by @njsmith.
I have reset `gi_running` value to 1 after `gen_send_ex()` and `_gen_throw()` calls in async generators and clear it to 0 when they close.
This PR obviously requires more test cases regarding `athrow()` calls, but I submit at this stage to check if my approach is correct first.

<!-- issue-number: bpo-32526 -->
https://bugs.python.org/issue32526
<!-- /issue-number -->
