### PR TITLE
bpo-28009: for AIX correct uuid.getnode() and add ctypes() based uuid._generate_time_safe

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -4,6 +4,7 @@ import builtins
 import contextlib
 import io
 import os
+import sys
 import shutil
 import subprocess
 
@@ -490,10 +491,19 @@ class BaseTestInternals:
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_find_mac(self):
-        data = '''
+        # issue28009 - AIX netstat -ai has specific layout,
+        # e.g., '.' rather than ':' tsas format character  
+        if not sys.platform.startswith("aix"):
+            data = '''
 fake hwaddr
 cscotun0  Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
 eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
+'''
+        else:
+            data = '''
+fake hwaddr
+cscotun0  Link encap:UNSPEC  HWaddr 00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00
+eth0      Link encap:Ethernet  HWaddr 12.34.56.78.90.ab
 '''
 
         popen = unittest.mock.MagicMock()
@@ -523,6 +533,8 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_ifconfig_getnode(self):
+        if sys.platform.startswith("aix"):
+            self.skipTest('AIX ifconfig does not provide MAC addr')
         node = self.uuid._ifconfig_getnode()
         self.check_node(node, 'ifconfig')
 
@@ -533,6 +545,8 @@ eth0      Link encap:Ethernet  HWaddr 12:34:56:78:90:ab
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_arp_getnode(self):
+        if sys.platform.startswith("aix"):
+            self.skipTest('AIX arp does not provide MAC addr')
         node = self.uuid._arp_getnode()
         self.check_node(node, 'arp')
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -491,8 +491,8 @@ class BaseTestInternals:
 
     @unittest.skipUnless(os.name == 'posix', 'requires Posix')
     def test_find_mac(self):
-        # issue28009 - AIX netstat -ai has specific layout,
-        # e.g., '.' rather than ':' tsas format character  
+        # issue28009 - AIX netstat -i(a) has specific formatting,
+        # i.e., '.' rather than ':' as format character
         if not sys.platform.startswith("aix"):
             data = '''
 fake hwaddr

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -713,6 +713,13 @@ def _random_getnode():
 
 _node = None
 
+_NODE_GETTERS_WIN32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
+
+_NODE_GETTERS_UNIX = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
+                      _arp_getnode, _lanscan_getnode, _netstat_getnode]
+
+_NODE_GETTERS_AIX = [_unix_getnode, _netstat_getnode]
+
 def getnode():
     """Get the hardware address as a 48-bit positive integer.
 
@@ -726,12 +733,11 @@ def getnode():
         return _node
 
     if sys.platform == 'win32':
-        getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
+        getters = _NODE_GETTERS_WIN32
     elif sys.platform.startswith("aix"):
-        getters = [_unix_getnode, _netstat_getnode]
+        getters = _NODE_GETTERS_AIX
     else:
-        getters = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
-                   _arp_getnode, _lanscan_getnode, _netstat_getnode]
+        getters = _NODE_GETTERS_UNIX
 
     for getter in getters + [_random_getnode]:
         try:

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -708,8 +708,6 @@ _NODE_GETTERS_WIN32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
 _NODE_GETTERS_UNIX = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
                       _arp_getnode, _lanscan_getnode, _netstat_getnode]
 
-_NODE_GETTERS_AIX  = [_unix_getnode, _netstat_getnode]
-
 def getnode(*, getters=None):
     """Get the hardware address as a 48-bit positive integer.
 
@@ -724,8 +722,6 @@ def getnode(*, getters=None):
 
     if sys.platform == 'win32':
         getters = _NODE_GETTERS_WIN32
-    elif sys.platform.startswith("aix"):
-        getters = _NODE_GETTERS_AIX
     else:
         getters = _NODE_GETTERS_UNIX
 

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -720,7 +720,7 @@ _NODE_GETTERS_UNIX = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
 
 _NODE_GETTERS_AIX = [_unix_getnode, _netstat_getnode]
 
-def getnode():
+def getnode(*, getters=None):
     """Get the hardware address as a 48-bit positive integer.
 
     The first time this runs, it may launch a separate program, which could

--- a/Misc/NEWS.d/next/Tests/2018-01-14-15-17-10.bpo-28009.bLNd9y.rst
+++ b/Misc/NEWS.d/next/Tests/2018-01-14-15-17-10.bpo-28009.bLNd9y.rst
@@ -1,4 +1,5 @@
 * AIX uses the character '.' rather than ':' to seperate the MAC ADDR values
- returned by 'netstat -i' command.
-* The commands arp and ifconfig doe not return a local MAC address 
-* define util._generate_time_safe based on lib.uuid_create (for when _uuid is not available)
+  returned by 'netstat -i' command.
+* The commands 'arp' and 'ifconfig' do not return a local MAC address 
+* define uuid._generate_time_safe in uuid.py based on ctypes()
+  lib.uuid_create (for when _uuid is not available)

--- a/Misc/NEWS.d/next/Tests/2018-01-14-15-17-10.bpo-28009.bLNd9y.rst
+++ b/Misc/NEWS.d/next/Tests/2018-01-14-15-17-10.bpo-28009.bLNd9y.rst
@@ -1,0 +1,4 @@
+* AIX uses the character '.' rather than ':' to seperate the MAC ADDR values
+ returned by 'netstat -i' command.
+* The commands arp and ifconfig doe not return a local MAC address 
+* define util._generate_time_safe based on lib.uuid_create (for when _uuid is not available)


### PR DESCRIPTION
* Add uuid._generate_time_safe using ctypes() from libc.uuid_create (for when _uuid is not available)
* use the character '.' rather than ':' to separate the MAC ADDR values
  returned by 'netstat -i' command (AIX specific)
* The commands arp and ifconfig do not return a local MAC address

<!-- issue-number: bpo-28009 -->
https://bugs.python.org/issue28009
<!-- /issue-number -->
