### PR TITLE
bpo-26330: Document accepted values for shutil.disk_usage()

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -318,7 +318,8 @@ Directory and files operations
 
    Return disk usage statistics about the given path as a :term:`named tuple`
    with the attributes *total*, *used* and *free*, which are the amount of
-   total, used and free space, in bytes.
+   total, used and free space, in bytes.  On Windows, *path* must be a
+   directory; on Unix, it can be a file or directory.
 
    .. versionadded:: 3.3
 


### PR DESCRIPTION


<!-- issue-number: bpo-26330 -->
https://bugs.python.org/issue26330
<!-- /issue-number -->
