### PR TITLE
bpo-32521: nis libnsl

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-01-15-12-53-13.bpo-32521.IxX4Ba.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-15-12-53-13.bpo-32521.IxX4Ba.rst
@@ -1,0 +1,1 @@
+The nis module is now compatible with new libnsl and headers location.

--- a/setup.py
+++ b/setup.py
@@ -1315,27 +1315,14 @@ class PyBuildExt(build_ext):
             exts.append( Extension('termios', ['termios.c']) )
             # Jeremy Hylton's rlimit interface
             exts.append( Extension('resource', ['resource.c']) )
-
-            # Sun yellow pages. Some systems have the functions in libc.
-            if (host_platform not in ['cygwin', 'qnx6'] and
-                find_file('rpcsvc/yp_prot.h', inc_dirs, []) is not None):
-                nis_libs = []
-                nis_includes = []
-                if self.compiler.find_library_file(lib_dirs, 'nsl'):
-                    nis_libs.append('nsl')
-                if self.compiler.find_library_file(lib_dirs, 'tirpc'):
-                    # Sun RPC has been moved from glibc to libtirpc
-                    # rpcsvc/yp_prot.h is still in /usr/include, but
-                    # rpc/rpc.h has been moved into tirpc/ subdir.
-                    nis_libs.append('tirpc')
-                    nis_includes.append('/usr/include/tirpc')
-                exts.append( Extension('nis', ['nismodule.c'],
-                                       libraries = nis_libs,
-                                       include_dirs=nis_includes) )
-            else:
-                missing.append('nis')
         else:
-            missing.extend(['nis', 'resource', 'termios'])
+            missing.extend(['resource', 'termios'])
+
+        nis = self._detect_nis(inc_dirs, lib_dirs)
+        if nis is not None:
+            exts.append(nis)
+        else:
+            missing.append('nis')
 
         # Curses support, requiring the System V version of curses, often
         # provided by the ncurses library.
@@ -2174,6 +2161,51 @@ class PyBuildExt(build_ext):
         )
 
         return ssl_ext, hashlib_ext
+
+    def _detect_nis(self, inc_dirs, lib_dirs):
+        if host_platform in {'win32', 'cygwin', 'qnx6'}:
+            return None
+
+        libs = []
+        library_dirs = []
+        includes_dirs = []
+
+        # bpo-32521: glibc has deprecated Sun RPC for some time. Fedora 28
+        # moved headers and libraries to libtirpc and libnsl. The headers
+        # are in tircp and nsl sub directories.
+        rpcsvc_inc = find_file(
+            'rpcsvc/yp_prot.h', inc_dirs,
+            [os.path.join(inc_dir, 'nsl') for inc_dir in inc_dirs]
+        )
+        rpc_inc = find_file(
+            'rpc/rpc.h', inc_dirs,
+            [os.path.join(inc_dir, 'tirpc') for inc_dir in inc_dirs]
+        )
+        if rpcsvc_inc is None or rpc_inc is None:
+            # not found
+            return None
+        includes_dirs.extend(rpcsvc_inc)
+        includes_dirs.extend(rpc_inc)
+
+        if self.compiler.find_library_file(lib_dirs, 'nsl'):
+            libs.append('nsl')
+        else:
+            # libnsl-devel: check for libnsl in nsl/ subdirectory
+            nsl_dirs = [os.path.join(lib_dir, 'nsl') for lib_dir in lib_dirs]
+            libnsl = self.compiler.find_library_file(nsl_dirs, 'nsl')
+            if libnsl is not None:
+                library_dirs.append(os.path.dirname(libnsl))
+                libs.append('nsl')
+
+        if self.compiler.find_library_file(lib_dirs, 'tirpc'):
+            libs.append('tirpc')
+
+        return Extension(
+            'nis', ['nismodule.c'],
+            libraries=libs,
+            library_dirs=library_dirs,
+            include_dirs=includes_dirs
+        )
 
 
 class PyBuildInstall(install):


### PR DESCRIPTION
The nismodule is now compatible with new libnsl and headers location

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-32521 -->
https://bugs.python.org/issue32521
<!-- /issue-number -->
