### PR TITLE
bpo-31900: Fix decimal for LC_NUMERIC != LC_CTYPE

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1600,8 +1600,8 @@ expression support in the :mod:`re` module).
    that can be specified in format strings.
 
    .. note::
-      When formatting a number (:class:`int`, :class:`float`, :class:`float`
-      and subclasses) with the ``n`` type (ex: ``'{:n}'.format(1234)``), the
+      When formatting a number (:class:`int`, :class:`float`, :class:`float`,
+      :class:`decimal.Decimal` and subclasses) with the ``n`` type (ex: ``'{:n}'.format(1234)``), the
       function sets temporarily the ``LC_CTYPE`` locale to the ``LC_NUMERIC``
       locale to decode ``decimal_point`` and ``thousands_sep`` fields of
       :c:func:`localeconv` if they are non-ASCII or longer than 1 byte, and the

--- a/Misc/NEWS.d/next/Library/2017-10-30-15-55-32.bpo-31900.-S9xc4.rst
+++ b/Misc/NEWS.d/next/Library/2017-10-30-15-55-32.bpo-31900.-S9xc4.rst
@@ -5,5 +5,5 @@ the ``LC_NUMERIC`` locale is different than the ``LC_CTYPE`` locale.  This
 temporary change affects other threads.
 
 Same change for the :meth:`str.format` method when formatting a number
-(:class:`int`, :class:`float`, :class:`float` and subclasses) with the ``n``
+(:class:`int`, :class:`float`, :class:`complex`, :class:`decimal.Decimal` and subclasses) with the ``n``
 type (ex: ``'{:n}'.format(1234)``).

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -3076,32 +3076,6 @@ dec_replace_fillchar(char *dest)
      }
 }
 
-/* Convert decimal_point or thousands_sep, which may be multibyte or in
-   the range [128, 255], to a UTF8 string. */
-static PyObject *
-dotsep_as_utf8(const char *s)
-{
-    PyObject *utf8;
-    PyObject *tmp;
-    wchar_t buf[2];
-    size_t n;
-
-    n = mbstowcs(buf, s, 2);
-    if (n != 1) { /* Issue #7442 */
-        PyErr_SetString(PyExc_ValueError,
-            "invalid decimal point or unsupported "
-            "combination of LC_CTYPE and LC_NUMERIC");
-        return NULL;
-    }
-    tmp = PyUnicode_FromWideChar(buf, n);
-    if (tmp == NULL) {
-        return NULL;
-    }
-    utf8 = PyUnicode_AsUTF8String(tmp);
-    Py_DECREF(tmp);
-    return utf8;
-}
-
 /* Formatted representation of a PyDecObject. */
 static PyObject *
 dec_format(PyObject *dec, PyObject *args)
@@ -3196,24 +3170,25 @@ dec_format(PyObject *dec, PyObject *args)
             goto finish;
         }
     }
-    else {
-        size_t n = strlen(spec.dot);
-        if (n > 1 || (n == 1 && !isascii((uchar)spec.dot[0]))) {
-            /* fix locale dependent non-ascii characters */
-            dot = dotsep_as_utf8(spec.dot);
-            if (dot == NULL) {
-                goto finish;
-            }
-            spec.dot = PyBytes_AS_STRING(dot);
+    else if (spec.locale) {
+        if (_Py_GetLocaleconvNumeric(&dot, &sep, &spec.grouping) < 0) {
+            goto finish;
         }
-        n = strlen(spec.sep);
-        if (n > 1 || (n == 1 && !isascii((uchar)spec.sep[0]))) {
-            /* fix locale dependent non-ascii characters */
-            sep = dotsep_as_utf8(spec.sep);
-            if (sep == NULL) {
-                goto finish;
-            }
-            spec.sep = PyBytes_AS_STRING(sep);
+
+        spec.dot = PyUnicode_AsUTF8(dot);
+        if (spec.dot == NULL) {
+            goto finish;
+        }
+
+        spec.sep = PyUnicode_AsUTF8(sep);
+        if (spec.sep == NULL) {
+            goto finish;
+        }
+
+        if (mpd_validate_lconv(&spec) < 0) {
+            PyErr_SetString(PyExc_ValueError,
+                "invalid localeconv()");
+            goto finish;
         }
     }
 

--- a/Modules/_decimal/libmpdec/io.c
+++ b/Modules/_decimal/libmpdec/io.c
@@ -784,6 +784,7 @@ mpd_parse_fmt_str(mpd_spec_t *spec, const char *fmt, int caps)
     spec->dot = "";
     spec->sep = "";
     spec->grouping = "";
+    spec->locale = 0;
 
 
     /* presume that the first character is a UTF-8 fill character */
@@ -871,6 +872,7 @@ mpd_parse_fmt_str(mpd_spec_t *spec, const char *fmt, int caps)
         if (*spec->sep) {
             return 0;
         }
+        spec->locale = 1;
         spec->type = *cp++;
         spec->type = (spec->type == 'N') ? 'G' : 'g';
         lc = localeconv();

--- a/Modules/_decimal/libmpdec/mpdecimal.h
+++ b/Modules/_decimal/libmpdec/mpdecimal.h
@@ -397,6 +397,7 @@ typedef struct mpd_spec_t {
     const char *dot;       /* decimal point */
     const char *sep;       /* thousands separator */
     const char *grouping;  /* grouping of digits */
+    int locale;            /* use localeconv() */
 } mpd_spec_t;
 
 /* output to a string */


### PR DESCRIPTION
Fix decimal.Decimal formatter when the LC_NUMERIC locale encoding is
different than the LC_CTYPE encoding: reuse
_Py_GetLocaleconvNumeric() to decode localeconv() correctly, set
tempoarily setlocale() if needed.

<!-- issue-number: bpo-31900 -->
https://bugs.python.org/issue31900
<!-- /issue-number -->
