### PR TITLE
bpo-29240: Skip test_readline.test_nonascii() on C locale

### DIFF
--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -3,6 +3,7 @@ Very minimal unittests for parts of the readline module.
 """
 from contextlib import ExitStack
 from errno import EIO
+import locale
 import os
 import selectors
 import subprocess
@@ -153,6 +154,13 @@ print("History length:", readline.get_current_history_length())
         self.assertIn(b"History length: 0\r\n", output)
 
     def test_nonascii(self):
+        loc = locale.setlocale(locale.LC_CTYPE, None)
+        if loc in ('C', 'POSIX'):
+            # bpo-29240: On FreeBSD, if the LC_CTYPE locale is C or POSIX,
+            # writing and reading non-ASCII bytes into/from a TTY works, but
+            # readline or ncurses ignores non-ASCII bytes on read.
+            self.skipTest(f"the LC_CTYPE locale is {loc!r}")
+
         try:
             readline.add_history("\xEB\xEF")
         except UnicodeEncodeError as err:


### PR DESCRIPTION
bpo-29240: If the LC_CTYPE locale is the C locale, skip
test_readline.test_nonascii(). On FreeBSD, writing non-ASCII bytes
into TTY works, reading from stdin returns non-ASCII bytes. But
readline or ncurses ignores non-ASCII bytes on read.

<!-- issue-number: bpo-29240 -->
https://bugs.python.org/issue29240
<!-- /issue-number -->
