### PR TITLE
bpo-32571: Avoid raising unneeded AttributeError and silencing it C code.

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -539,6 +539,7 @@ PyAPI_FUNC(int) _PyObject_IsAbstract(PyObject *);
 /* Same as PyObject_GetAttr(), but don't raise AttributeError. */
 PyAPI_FUNC(PyObject *) _PyObject_GetAttrWithoutError(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) _PyObject_GetAttrId(PyObject *, struct _Py_Identifier *);
+PyAPI_FUNC(PyObject *) _PyObject_GetAttrIdWithoutError(PyObject *, struct _Py_Identifier *);
 PyAPI_FUNC(int) _PyObject_SetAttrId(PyObject *, struct _Py_Identifier *, PyObject *);
 PyAPI_FUNC(int) _PyObject_HasAttrId(PyObject *, struct _Py_Identifier *);
 PyAPI_FUNC(PyObject **) _PyObject_GetDictPtr(PyObject *);

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1339,12 +1339,11 @@ deque_reduce(dequeobject *deque)
     PyObject *dict, *it;
     _Py_IDENTIFIER(__dict__);
 
-    dict = _PyObject_GetAttrId((PyObject *)deque, &PyId___dict__);
+    dict = _PyObject_GetAttrIdWithoutError((PyObject *)deque, &PyId___dict__);
     if (dict == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        if (PyErr_Occurred()) {
             return NULL;
         }
-        PyErr_Clear();
         dict = Py_None;
         Py_INCREF(dict);
     }

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -1073,11 +1073,9 @@ fileio_repr(fileio *self)
     if (self->fd < 0)
         return PyUnicode_FromFormat("<_io.FileIO [closed]>");
 
-    nameobj = _PyObject_GetAttrId((PyObject *) self, &PyId_name);
+    nameobj = _PyObject_GetAttrIdWithoutError((PyObject *) self, &PyId_name);
     if (nameobj == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError))
-            PyErr_Clear();
-        else
+        if (PyErr_Occurred())
             return NULL;
         res = PyUnicode_FromFormat(
             "<_io.FileIO fd=%d mode='%s' closefd=%s>",

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -135,12 +135,11 @@ iobase_is_closed(PyObject *self)
     PyObject *res;
     /* This gets the derived attribute, which is *not* __IOBase_closed
        in most cases! */
-    res = _PyObject_GetAttrId(self, &PyId___IOBase_closed);
+    res = _PyObject_GetAttrIdWithoutError(self, &PyId___IOBase_closed);
     if (res == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        if (PyErr_Occurred()) {
             return -1;
         }
-        PyErr_Clear();
         return 0;
     }
     Py_DECREF(res);

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -924,11 +924,9 @@ _textiowrapper_set_encoder(textio *self, PyObject *codec_info,
         return -1;
 
     /* Get the normalized named of the codec */
-    res = _PyObject_GetAttrId(codec_info, &PyId_name);
+    res = _PyObject_GetAttrIdWithoutError(codec_info, &PyId_name);
     if (res == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError))
-            PyErr_Clear();
-        else
+        if (PyErr_Occurred())
             return -1;
     }
     else if (PyUnicode_Check(res)) {
@@ -1178,12 +1176,10 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     if (Py_TYPE(buffer) == &PyBufferedReader_Type ||
         Py_TYPE(buffer) == &PyBufferedWriter_Type ||
         Py_TYPE(buffer) == &PyBufferedRandom_Type) {
-        raw = _PyObject_GetAttrId(buffer, &PyId_raw);
+        raw = _PyObject_GetAttrIdWithoutError(buffer, &PyId_raw);
         /* Cache the raw FileIO object to speed up 'closed' checks */
         if (raw == NULL) {
-            if (PyErr_ExceptionMatches(PyExc_AttributeError))
-                PyErr_Clear();
-            else
+            if (PyErr_Occurred())
                 goto error;
         }
         else if (Py_TYPE(raw) == &PyFileIO_Type)

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2203,11 +2203,10 @@ array_array___reduce_ex__(arrayobject *self, PyObject *value)
     if (protocol == -1 && PyErr_Occurred())
         return NULL;
 
-    dict = _PyObject_GetAttrId((PyObject *)self, &PyId___dict__);
+    dict = _PyObject_GetAttrIdWithoutError((PyObject *)self, &PyId___dict__);
     if (dict == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_Occurred())
             return NULL;
-        PyErr_Clear();
         dict = Py_None;
         Py_INCREF(dict);
     }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -830,17 +830,16 @@ tee(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    copyfunc = _PyObject_GetAttrId(it, &PyId___copy__);
+    copyfunc = _PyObject_GetAttrIdWithoutError(it, &PyId___copy__);
     if (copyfunc != NULL) {
         copyable = it;
     }
-    else if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+    else if (PyErr_Occurred()) {
         Py_DECREF(it);
         Py_DECREF(result);
         return NULL;
     }
     else {
-        PyErr_Clear();
         copyable = tee_fromiterable(it);
         Py_DECREF(it);
         if (copyable == NULL) {

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -249,17 +249,14 @@ method_repr(PyMethodObject *a)
     PyObject *funcname = NULL, *result = NULL;
     const char *defname = "?";
 
-    funcname = _PyObject_GetAttrId(func, &PyId___qualname__);
+    funcname = _PyObject_GetAttrIdWithoutError(func, &PyId___qualname__);
     if (funcname == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_Occurred())
             return NULL;
-        PyErr_Clear();
 
-        funcname = _PyObject_GetAttrId(func, &PyId___name__);
-        if (funcname == NULL) {
-            if (!PyErr_ExceptionMatches(PyExc_AttributeError))
-                return NULL;
-            PyErr_Clear();
+        funcname = _PyObject_GetAttrIdWithoutError(func, &PyId___name__);
+        if (funcname == NULL && PyErr_Occurred()) {
+            return NULL;
         }
     }
 
@@ -550,11 +547,10 @@ instancemethod_repr(PyObject *self)
         return NULL;
     }
 
-    funcname = _PyObject_GetAttrId(func, &PyId___name__);
+    funcname = _PyObject_GetAttrIdWithoutError(func, &PyId___name__);
     if (funcname == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_Occurred())
             return NULL;
-        PyErr_Clear();
     }
     else if (!PyUnicode_Check(funcname)) {
         Py_DECREF(funcname);

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2188,13 +2188,12 @@ dict_update_common(PyObject *self, PyObject *args, PyObject *kwds,
     }
     else if (arg != NULL) {
         _Py_IDENTIFIER(keys);
-        PyObject *func = _PyObject_GetAttrId(arg, &PyId_keys);
+        PyObject *func = _PyObject_GetAttrIdWithoutError(arg, &PyId_keys);
         if (func != NULL) {
             Py_DECREF(func);
             result = PyDict_Merge(self, arg, 1);
         }
-        else if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
+        else if (!PyErr_Occurred()) {
             result = PyDict_MergeFromSeq2(self, arg, 1);
         }
         else {

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -349,11 +349,10 @@ gen_close_iter(PyObject *yf)
             return -1;
     }
     else {
-        PyObject *meth = _PyObject_GetAttrId(yf, &PyId_close);
+        PyObject *meth = _PyObject_GetAttrIdWithoutError(yf, &PyId_close);
         if (meth == NULL) {
-            if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+            if (PyErr_Occurred())
                 PyErr_WriteUnraisable(yf);
-            PyErr_Clear();
         }
         else {
             retval = _PyObject_CallNoArg(meth);
@@ -468,13 +467,12 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
             gen->gi_running = 0;
         } else {
             /* `yf` is an iterator or a coroutine-like object. */
-            PyObject *meth = _PyObject_GetAttrId(yf, &PyId_throw);
+            PyObject *meth = _PyObject_GetAttrIdWithoutError(yf, &PyId_throw);
             if (meth == NULL) {
-                if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+                if (PyErr_Occurred()) {
                     Py_DECREF(yf);
                     return NULL;
                 }
-                PyErr_Clear();
                 Py_DECREF(yf);
                 goto throw_here;
             }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -816,13 +816,12 @@ _PyObject_IsAbstract(PyObject *obj)
     if (obj == NULL)
         return 0;
 
-    isabstract = _PyObject_GetAttrId(obj, &PyId___isabstractmethod__);
+    isabstract = _PyObject_GetAttrIdWithoutError(obj, &PyId___isabstractmethod__);
     if (isabstract == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
-            return 0;
+        if (PyErr_Occurred()) {
+            return -1;
         }
-        return -1;
+        return 0;
     }
     res = PyObject_IsTrue(isabstract);
     Py_DECREF(isabstract);
@@ -916,6 +915,17 @@ _PyObject_GetAttrWithoutError(PyObject *v, PyObject *name)
         PyErr_Clear();
     }
     return ret;
+}
+
+PyObject *
+_PyObject_GetAttrIdWithoutError(PyObject *v, _Py_Identifier *name)
+{
+    PyObject *result;
+    PyObject *oname = _PyUnicode_FromId(name); /* borrowed */
+    if (!oname)
+        return NULL;
+    result = _PyObject_GetAttrWithoutError(v, oname);
+    return result;
 }
 
 int

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -2359,7 +2359,7 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
             goto handle_kwargs;
         }
 
-        func = _PyObject_GetAttrId(other, &PyId_keys);
+        func = _PyObject_GetAttrIdWithoutError(other, &PyId_keys);
         if (func != NULL) {
             PyObject *keys, *iterator, *key;
             keys = _PyObject_CallNoArg(func);
@@ -2391,15 +2391,12 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
                 return NULL;
             goto handle_kwargs;
         }
-        else if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        else if (PyErr_Occurred()) {
             Py_DECREF(other);
             return NULL;
         }
-        else {
-            PyErr_Clear();
-        }
 
-        func = _PyObject_GetAttrId(other, &PyId_items);
+        func = _PyObject_GetAttrIdWithoutError(other, &PyId_items);
         if (func != NULL) {
             PyObject *items;
             Py_DECREF(other);
@@ -2413,12 +2410,9 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
                 return NULL;
             goto handle_kwargs;
         }
-        else if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        else if (PyErr_Occurred()) {
             Py_DECREF(other);
             return NULL;
-        }
-        else {
-            PyErr_Clear();
         }
 
         res = mutablemapping_add_pairs(self, other);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -80,11 +80,8 @@ get_warnings_attr(_Py_Identifier *attr_id, int try_import)
             return NULL;
     }
 
-    obj = _PyObject_GetAttrId(warnings_module, attr_id);
+    obj = _PyObject_GetAttrIdWithoutError(warnings_module, attr_id);
     Py_DECREF(warnings_module);
-    if (obj == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-        PyErr_Clear();
-    }
     return obj;
 }
 
@@ -893,13 +890,10 @@ get_source_line(PyObject *module_globals, int lineno)
     Py_INCREF(module_name);
 
     /* Make sure the loader implements the optional get_source() method. */
-    get_source = _PyObject_GetAttrId(loader, &PyId_get_source);
+    get_source = _PyObject_GetAttrIdWithoutError(loader, &PyId_get_source);
     Py_DECREF(loader);
     if (!get_source) {
         Py_DECREF(module_name);
-        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
-        }
         return NULL;
     }
     /* Call get_source() to get the source code. */

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -71,12 +71,11 @@ update_bases(PyObject *bases, PyObject *const *args, int nargs)
             }
             continue;
         }
-        meth = _PyObject_GetAttrId(base, &PyId___mro_entries__);
+        meth = _PyObject_GetAttrIdWithoutError(base, &PyId___mro_entries__);
         if (!meth) {
-            if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            if (PyErr_Occurred()) {
                 goto error;
             }
-            PyErr_Clear();
             if (new_bases) {
                 if (PyList_Append(new_bases, base) < 0) {
                     goto error;
@@ -218,17 +217,13 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
     }
     /* else: meta is not a class, so we cannot do the metaclass
        calculation, so we will use the explicitly given object as it is */
-    prep = _PyObject_GetAttrId(meta, &PyId___prepare__);
+    prep = _PyObject_GetAttrIdWithoutError(meta, &PyId___prepare__);
     if (prep == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
-            ns = PyDict_New();
+        if (PyErr_Occurred()) {
+            ns = NULL;
         }
         else {
-            Py_DECREF(meta);
-            Py_XDECREF(mkw);
-            Py_DECREF(bases);
-            return NULL;
+            ns = PyDict_New();
         }
     }
     else {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4798,13 +4798,12 @@ import_from(PyObject *v, PyObject *name)
     _Py_IDENTIFIER(__name__);
     PyObject *fullmodname, *pkgname, *pkgpath, *pkgname_or_unknown, *errmsg;
 
-    x = PyObject_GetAttr(v, name);
-    if (x != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError))
+    x = _PyObject_GetAttrWithoutError(v, name);
+    if (x != NULL || PyErr_Occurred())
         return x;
     /* Issue #17636: in case this failed because of a circular relative
        import, try to fallback on reading the module directly from
        sys.modules. */
-    PyErr_Clear();
     pkgname = _PyObject_GetAttrId(v, &PyId___name__);
     if (pkgname == NULL) {
         goto error;
@@ -4866,21 +4865,20 @@ import_all_from(PyObject *locals, PyObject *v)
 {
     _Py_IDENTIFIER(__all__);
     _Py_IDENTIFIER(__dict__);
-    PyObject *all = _PyObject_GetAttrId(v, &PyId___all__);
+    PyObject *all = _PyObject_GetAttrIdWithoutError(v, &PyId___all__);
     PyObject *dict, *name, *value;
     int skip_leading_underscores = 0;
     int pos, err;
 
     if (all == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_Occurred())
             return -1; /* Unexpected error */
-        PyErr_Clear();
-        dict = _PyObject_GetAttrId(v, &PyId___dict__);
+        dict = _PyObject_GetAttrIdWithoutError(v, &PyId___dict__);
         if (dict == NULL) {
-            if (!PyErr_ExceptionMatches(PyExc_AttributeError))
-                return -1;
-            PyErr_SetString(PyExc_ImportError,
-            "from-import-* object has no __dict__ and no __all__");
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_ImportError,
+                    "from-import-* object has no __dict__ and no __all__");
+            }
             return -1;
         }
         all = PyMapping_Keys(dict);

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -540,11 +540,9 @@ PyObject * _PyCodec_LookupTextEncoding(const char *encoding,
      * attribute.
      */
     if (!PyTuple_CheckExact(codec)) {
-        attr = _PyObject_GetAttrId(codec, &PyId__is_text_encoding);
+        attr = _PyObject_GetAttrIdWithoutError(codec, &PyId__is_text_encoding);
         if (attr == NULL) {
-            if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-                PyErr_Clear();
-            } else {
+            if (PyErr_Occurred()) {
                 Py_DECREF(codec);
                 return NULL;
             }


### PR DESCRIPTION
Added `_PyObject_GetAttrIdWithoutError()` and used in appropriate cases.


<!-- issue-number: bpo-32571 -->
https://bugs.python.org/issue32571
<!-- /issue-number -->
