### PR TITLE
bpo-32248: Fix Git attributes of test_importlib data files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -26,6 +26,7 @@ Lib/test/decimaltestdata/*.decTest -text
 Lib/test/test_email/data/*.txt -text
 Lib/test/xmltestdata/* -text
 Lib/test/coding20731.py -text
+Lib/test/test_importlib/data01/* -text
 
 # CRLF files
 *.bat text eol=crlf


### PR DESCRIPTION
Make sure that Git checks out data files with Unix line
ending on Windows as well.

<!-- issue-number: bpo-32248 -->
https://bugs.python.org/issue32248
<!-- /issue-number -->
