### PR TITLE
bpo-32226: Fix memory leak in generic_alias_dealloc()

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -5064,6 +5064,7 @@ static void
 generic_alias_dealloc(PyGenericAliasObject *self)
 {
     Py_CLEAR(self->item);
+    Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 static PyObject *


### PR DESCRIPTION


<!-- issue-number: bpo-32226 -->
https://bugs.python.org/issue32226
<!-- /issue-number -->
