### PR TITLE
bpo-32576: use queue.SimpleQueue in critical places

### DIFF
--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -128,7 +128,7 @@ class ThreadPoolExecutor(_base.Executor):
             raise TypeError("initializer must be a callable")
 
         self._max_workers = max_workers
-        self._work_queue = queue.Queue()
+        self._work_queue = queue.SimpleQueue()
         self._threads = set()
         self._broken = False
         self._shutdown = False

--- a/Misc/NEWS.d/next/Library/2018-01-17-13-04-16.bpo-32576.iDL09t.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-17-13-04-16.bpo-32576.iDL09t.rst
@@ -1,0 +1,2 @@
+Use queue.SimpleQueue() in places where it can be invoked from a weakref
+callback.


### PR DESCRIPTION
Where a queue may be invoked from a weakref callback, we need to use the reentrant SimpleQueue.

<!-- issue-number: bpo-32576 -->
https://bugs.python.org/issue32576
<!-- /issue-number -->
