### PR TITLE
bpo-32582: chr() doesn't raise OverflowError anymore

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -304,7 +304,8 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(chr(0x0010FFFF), "\U0010FFFF")
         self.assertRaises(ValueError, chr, -1)
         self.assertRaises(ValueError, chr, 0x00110000)
-        self.assertRaises((OverflowError, ValueError), chr, 2**32)
+        self.assertRaises(ValueError, chr, -2**100)
+        self.assertRaises(ValueError, chr, 2**100)
 
     def test_cmp(self):
         self.assertTrue(not hasattr(builtins, "cmp"))

--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-17-15-42-56.bpo-32582.kSu6Yj.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-17-15-42-56.bpo-32582.kSu6Yj.rst
@@ -1,0 +1,2 @@
+The :func:`chr` builtin function now catchs :exc:`OverflowError` and raises
+a :exc:`ValueError` exception instead.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -731,7 +731,6 @@ builtin_chr(PyObject *module, PyObject *i)
             return NULL;
         }
         PyErr_Clear();
-        ch = -1;
     }
     return PyUnicode_FromOrdinal(ch);
 }

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -715,17 +715,25 @@ builtin_format_impl(PyObject *module, PyObject *value, PyObject *format_spec)
 /*[clinic input]
 chr as builtin_chr
 
-    i: int
+    i: object
     /
 
 Return a Unicode string of one character with ordinal i; 0 <= i <= 0x10ffff.
 [clinic start generated code]*/
 
 static PyObject *
-builtin_chr_impl(PyObject *module, int i)
-/*[clinic end generated code: output=c733afcd200afcb7 input=3f604ef45a70750d]*/
+builtin_chr(PyObject *module, PyObject *i)
+/*[clinic end generated code: output=d34f25b8035a9b10 input=f919867f0ba2f496]*/
 {
-    return PyUnicode_FromOrdinal(i);
+    int ch = _PyLong_AsInt(i);
+    if (ch == -1 && PyErr_Occurred()) {
+        if (!PyErr_ExceptionMatches(PyExc_OverflowError)) {
+            return NULL;
+        }
+        PyErr_Clear();
+        ch = -1;
+    }
+    return PyUnicode_FromOrdinal(ch);
 }
 
 

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -113,24 +113,6 @@ PyDoc_STRVAR(builtin_chr__doc__,
 #define BUILTIN_CHR_METHODDEF    \
     {"chr", (PyCFunction)builtin_chr, METH_O, builtin_chr__doc__},
 
-static PyObject *
-builtin_chr_impl(PyObject *module, int i);
-
-static PyObject *
-builtin_chr(PyObject *module, PyObject *arg)
-{
-    PyObject *return_value = NULL;
-    int i;
-
-    if (!PyArg_Parse(arg, "i:chr", &i)) {
-        goto exit;
-    }
-    return_value = builtin_chr_impl(module, i);
-
-exit:
-    return return_value;
-}
-
 PyDoc_STRVAR(builtin_compile__doc__,
 "compile($module, /, source, filename, mode, flags=0,\n"
 "        dont_inherit=False, optimize=-1)\n"
@@ -710,4 +692,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9f17c7a87d740374 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=2ff748273b78b0ac input=a9049054013a1b77]*/


### PR DESCRIPTION
chr() now catchs OverflowError and raises a ValueError exception
instead.

<!-- issue-number: bpo-32582 -->
https://bugs.python.org/issue32582
<!-- /issue-number -->
