### PR TITLE
 bpo-32571: Avoid raising unneeded AttributeError and silencing it in C code (alt).

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -539,6 +539,7 @@ PyAPI_FUNC(int) _PyObject_IsAbstract(PyObject *);
 /* Same as PyObject_GetAttr(), but don't raise AttributeError. */
 PyAPI_FUNC(PyObject *) _PyObject_GetAttrWithoutError(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) _PyObject_GetAttrId(PyObject *, struct _Py_Identifier *);
+PyAPI_FUNC(PyObject *) _PyObject_GetAttrIdWithoutError(PyObject *, struct _Py_Identifier *);
 PyAPI_FUNC(int) _PyObject_SetAttrId(PyObject *, struct _Py_Identifier *, PyObject *);
 PyAPI_FUNC(int) _PyObject_HasAttrId(PyObject *, struct _Py_Identifier *);
 PyAPI_FUNC(PyObject **) _PyObject_GetDictPtr(PyObject *);

--- a/Include/object.h
+++ b/Include/object.h
@@ -536,12 +536,20 @@ PyAPI_FUNC(int) PyObject_SetAttr(PyObject *, PyObject *, PyObject *);
 PyAPI_FUNC(int) PyObject_HasAttr(PyObject *, PyObject *);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyObject_IsAbstract(PyObject *);
-/* Same as PyObject_GetAttr(), but don't raise AttributeError. */
-PyAPI_FUNC(PyObject *) _PyObject_GetAttrWithoutError(PyObject *, PyObject *);
 PyAPI_FUNC(PyObject *) _PyObject_GetAttrId(PyObject *, struct _Py_Identifier *);
-PyAPI_FUNC(PyObject *) _PyObject_GetAttrIdWithoutError(PyObject *, struct _Py_Identifier *);
 PyAPI_FUNC(int) _PyObject_SetAttrId(PyObject *, struct _Py_Identifier *, PyObject *);
 PyAPI_FUNC(int) _PyObject_HasAttrId(PyObject *, struct _Py_Identifier *);
+/* Replacements of PyObject_GetAttr() and _PyObject_GetAttrId() which
+   don't raise AttributeError.
+
+   Return 1 and set *result != NULL if an attribute is found.
+   Return 0 and set *result == NULL if an attribute is not found;
+   an AttributeError is silenced.
+   Return -1 and set *result == NULL if an error other than AttributeError
+   is raised.
+*/
+PyAPI_FUNC(int) _PyObject_LookupAttr(PyObject *, PyObject *, PyObject **);
+PyAPI_FUNC(int) _PyObject_LookupAttrId(PyObject *, struct _Py_Identifier *, PyObject **);
 PyAPI_FUNC(PyObject **) _PyObject_GetDictPtr(PyObject *);
 #endif
 PyAPI_FUNC(PyObject *) PyObject_SelfIter(PyObject *);

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1339,12 +1339,11 @@ deque_reduce(dequeobject *deque)
     PyObject *dict, *it;
     _Py_IDENTIFIER(__dict__);
 
-    dict = _PyObject_GetAttrId((PyObject *)deque, &PyId___dict__);
+    dict = _PyObject_GetAttrIdWithoutError((PyObject *)deque, &PyId___dict__);
     if (dict == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        if (PyErr_Occurred()) {
             return NULL;
         }
-        PyErr_Clear();
         dict = Py_None;
         Py_INCREF(dict);
     }

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1339,11 +1339,10 @@ deque_reduce(dequeobject *deque)
     PyObject *dict, *it;
     _Py_IDENTIFIER(__dict__);
 
-    dict = _PyObject_GetAttrIdWithoutError((PyObject *)deque, &PyId___dict__);
+    if (_PyObject_LookupAttrId((PyObject *)deque, &PyId___dict__, &dict) < 0) {
+        return NULL;
+    }
     if (dict == NULL) {
-        if (PyErr_Occurred()) {
-            return NULL;
-        }
         dict = Py_None;
         Py_INCREF(dict);
     }

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1541,7 +1541,9 @@ _bufferedreader_read_all(buffered *self)
     }
     _bufferedreader_reset_buf(self);
 
-    readall = _PyObject_GetAttrWithoutError(self->raw, _PyIO_str_readall);
+    if (_PyObject_LookupAttr(self->raw, _PyIO_str_readall, &readall) < 0) {
+        goto cleanup;
+    }
     if (readall) {
         tmp = _PyObject_CallNoArg(readall);
         Py_DECREF(readall);
@@ -1559,9 +1561,6 @@ _bufferedreader_read_all(buffered *self)
             }
             res = data;
         }
-        goto cleanup;
-    }
-    else if (PyErr_Occurred()) {
         goto cleanup;
     }
 

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -1073,10 +1073,10 @@ fileio_repr(fileio *self)
     if (self->fd < 0)
         return PyUnicode_FromFormat("<_io.FileIO [closed]>");
 
-    nameobj = _PyObject_GetAttrIdWithoutError((PyObject *) self, &PyId_name);
+    if (_PyObject_LookupAttrId((PyObject *) self, &PyId_name, &nameobj) < 0) {
+        return NULL;
+    }
     if (nameobj == NULL) {
-        if (PyErr_Occurred())
-            return NULL;
         res = PyUnicode_FromFormat(
             "<_io.FileIO fd=%d mode='%s' closefd=%s>",
             self->fd, mode_string(self), self->closefd ? "True" : "False");

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -1073,11 +1073,9 @@ fileio_repr(fileio *self)
     if (self->fd < 0)
         return PyUnicode_FromFormat("<_io.FileIO [closed]>");
 
-    nameobj = _PyObject_GetAttrId((PyObject *) self, &PyId_name);
+    nameobj = _PyObject_GetAttrIdWithoutError((PyObject *) self, &PyId_name);
     if (nameobj == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError))
-            PyErr_Clear();
-        else
+        if (PyErr_Occurred())
             return NULL;
         res = PyUnicode_FromFormat(
             "<_io.FileIO fd=%d mode='%s' closefd=%s>",

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -135,12 +135,11 @@ iobase_is_closed(PyObject *self)
     PyObject *res;
     /* This gets the derived attribute, which is *not* __IOBase_closed
        in most cases! */
-    res = _PyObject_GetAttrId(self, &PyId___IOBase_closed);
+    res = _PyObject_GetAttrIdWithoutError(self, &PyId___IOBase_closed);
     if (res == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        if (PyErr_Occurred()) {
             return -1;
         }
-        PyErr_Clear();
         return 0;
     }
     Py_DECREF(res);

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -133,17 +133,12 @@ static int
 iobase_is_closed(PyObject *self)
 {
     PyObject *res;
+    int ret;
     /* This gets the derived attribute, which is *not* __IOBase_closed
        in most cases! */
-    res = _PyObject_GetAttrIdWithoutError(self, &PyId___IOBase_closed);
-    if (res == NULL) {
-        if (PyErr_Occurred()) {
-            return -1;
-        }
-        return 0;
-    }
-    Py_DECREF(res);
-    return 1;
+    ret = _PyObject_LookupAttrId(self, &PyId___IOBase_closed, &res);
+    Py_XDECREF(res);
+    return ret;
 }
 
 /* Flush and close methods */
@@ -189,20 +184,16 @@ iobase_check_closed(PyObject *self)
     int closed;
     /* This gets the derived attribute, which is *not* __IOBase_closed
        in most cases! */
-    res = _PyObject_GetAttrWithoutError(self, _PyIO_str_closed);
-    if (res == NULL) {
-        if (PyErr_Occurred()) {
+    closed = _PyObject_LookupAttr(self, _PyIO_str_closed, &res);
+    if (closed > 0) {
+        closed = PyObject_IsTrue(res);
+        Py_DECREF(res);
+        if (closed > 0) {
+            PyErr_SetString(PyExc_ValueError, "I/O operation on closed file.");
             return -1;
         }
-        return 0;
     }
-    closed = PyObject_IsTrue(res);
-    Py_DECREF(res);
-    if (closed <= 0) {
-        return closed;
-    }
-    PyErr_SetString(PyExc_ValueError, "I/O operation on closed file.");
-    return -1;
+    return closed;
 }
 
 PyObject *
@@ -272,8 +263,7 @@ iobase_finalize(PyObject *self)
 
     /* If `closed` doesn't exist or can't be evaluated as bool, then the
        object is probably in an unusable state, so ignore. */
-    res = _PyObject_GetAttrWithoutError(self, _PyIO_str_closed);
-    if (res == NULL) {
+    if (_PyObject_LookupAttr(self, _PyIO_str_closed, &res) <= 0) {
         PyErr_Clear();
         closed = -1;
     }
@@ -537,8 +527,7 @@ _io__IOBase_readline_impl(PyObject *self, Py_ssize_t limit)
     PyObject *peek, *buffer, *result;
     Py_ssize_t old_size = -1;
 
-    peek = _PyObject_GetAttrWithoutError(self, _PyIO_str_peek);
-    if (peek == NULL && PyErr_Occurred()) {
+    if (_PyObject_LookupAttr(self, _PyIO_str_peek, &peek) < 0) {
         return NULL;
     }
 

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -924,12 +924,10 @@ _textiowrapper_set_encoder(textio *self, PyObject *codec_info,
         return -1;
 
     /* Get the normalized named of the codec */
-    res = _PyObject_GetAttrIdWithoutError(codec_info, &PyId_name);
-    if (res == NULL) {
-        if (PyErr_Occurred())
-            return -1;
+    if (_PyObject_LookupAttrId(codec_info, &PyId_name, &res) < 0) {
+        return -1;
     }
-    else if (PyUnicode_Check(res)) {
+    if (res != NULL && PyUnicode_Check(res)) {
         const encodefuncentry *e = encodefuncs;
         while (e->name != NULL) {
             if (_PyUnicode_EqualToASCIIString(res, e->name)) {
@@ -1175,17 +1173,17 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
 
     if (Py_TYPE(buffer) == &PyBufferedReader_Type ||
         Py_TYPE(buffer) == &PyBufferedWriter_Type ||
-        Py_TYPE(buffer) == &PyBufferedRandom_Type) {
-        raw = _PyObject_GetAttrIdWithoutError(buffer, &PyId_raw);
+        Py_TYPE(buffer) == &PyBufferedRandom_Type)
+    {
+        if (_PyObject_LookupAttrId(buffer, &PyId_raw, &raw) < 0)
+            goto error;
         /* Cache the raw FileIO object to speed up 'closed' checks */
-        if (raw == NULL) {
-            if (PyErr_Occurred())
-                goto error;
+        if (raw != NULL) {
+            if (Py_TYPE(raw) == &PyFileIO_Type)
+                self->raw = raw;
+            else
+                Py_DECREF(raw);
         }
-        else if (Py_TYPE(raw) == &PyFileIO_Type)
-            self->raw = raw;
-        else
-            Py_DECREF(raw);
     }
 
     res = _PyObject_CallMethodId(buffer, &PyId_seekable, NULL);
@@ -1197,17 +1195,12 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
         goto error;
     self->seekable = self->telling = r;
 
-    res = _PyObject_GetAttrWithoutError(buffer, _PyIO_str_read1);
-    if (res != NULL) {
-        Py_DECREF(res);
-        self->has_read1 = 1;
-    }
-    else if (!PyErr_Occurred()) {
-        self->has_read1 = 0;
-    }
-    else {
+    r = _PyObject_LookupAttr(buffer, _PyIO_str_read1, &res);
+    if (r < 0) {
         goto error;
     }
+    Py_XDECREF(res);
+    self->has_read1 = r;
 
     self->encoding_start_of_stream = 0;
     if (_textiowrapper_fix_encoder_state(self) < 0) {
@@ -3016,10 +3009,9 @@ textiowrapper_newlines_get(textio *self, void *context)
 {
     PyObject *res;
     CHECK_ATTACHED(self);
-    if (self->decoder == NULL)
-        Py_RETURN_NONE;
-    res = _PyObject_GetAttrWithoutError(self->decoder, _PyIO_str_newlines);
-    if (res == NULL && !PyErr_Occurred()) {
+    if (self->decoder == NULL ||
+        _PyObject_LookupAttr(self->decoder, _PyIO_str_newlines, &res) == 0)
+    {
         Py_RETURN_NONE;
     }
     return res;

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -924,11 +924,9 @@ _textiowrapper_set_encoder(textio *self, PyObject *codec_info,
         return -1;
 
     /* Get the normalized named of the codec */
-    res = _PyObject_GetAttrId(codec_info, &PyId_name);
+    res = _PyObject_GetAttrIdWithoutError(codec_info, &PyId_name);
     if (res == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError))
-            PyErr_Clear();
-        else
+        if (PyErr_Occurred())
             return -1;
     }
     else if (PyUnicode_Check(res)) {
@@ -1178,12 +1176,10 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
     if (Py_TYPE(buffer) == &PyBufferedReader_Type ||
         Py_TYPE(buffer) == &PyBufferedWriter_Type ||
         Py_TYPE(buffer) == &PyBufferedRandom_Type) {
-        raw = _PyObject_GetAttrId(buffer, &PyId_raw);
+        raw = _PyObject_GetAttrIdWithoutError(buffer, &PyId_raw);
         /* Cache the raw FileIO object to speed up 'closed' checks */
         if (raw == NULL) {
-            if (PyErr_ExceptionMatches(PyExc_AttributeError))
-                PyErr_Clear();
-            else
+            if (PyErr_Occurred())
                 goto error;
         }
         else if (Py_TYPE(raw) == &PyFileIO_Type)

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2203,10 +2203,10 @@ array_array___reduce_ex__(arrayobject *self, PyObject *value)
     if (protocol == -1 && PyErr_Occurred())
         return NULL;
 
-    dict = _PyObject_GetAttrIdWithoutError((PyObject *)self, &PyId___dict__);
+    if (_PyObject_LookupAttrId((PyObject *)self, &PyId___dict__, &dict) < 0) {
+        return NULL;
+    }
     if (dict == NULL) {
-        if (PyErr_Occurred())
-            return NULL;
         dict = Py_None;
         Py_INCREF(dict);
     }

--- a/Modules/arraymodule.c
+++ b/Modules/arraymodule.c
@@ -2203,11 +2203,10 @@ array_array___reduce_ex__(arrayobject *self, PyObject *value)
     if (protocol == -1 && PyErr_Occurred())
         return NULL;
 
-    dict = _PyObject_GetAttrId((PyObject *)self, &PyId___dict__);
+    dict = _PyObject_GetAttrIdWithoutError((PyObject *)self, &PyId___dict__);
     if (dict == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_Occurred())
             return NULL;
-        PyErr_Clear();
         dict = Py_None;
         Py_INCREF(dict);
     }

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -830,17 +830,16 @@ tee(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    copyfunc = _PyObject_GetAttrId(it, &PyId___copy__);
+    copyfunc = _PyObject_GetAttrIdWithoutError(it, &PyId___copy__);
     if (copyfunc != NULL) {
         copyable = it;
     }
-    else if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+    else if (PyErr_Occurred()) {
         Py_DECREF(it);
         Py_DECREF(result);
         return NULL;
     }
     else {
-        PyErr_Clear();
         copyable = tee_fromiterable(it);
         Py_DECREF(it);
         if (copyable == NULL) {

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -830,14 +830,13 @@ tee(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    copyfunc = _PyObject_GetAttrIdWithoutError(it, &PyId___copy__);
-    if (copyfunc != NULL) {
-        copyable = it;
-    }
-    else if (PyErr_Occurred()) {
+    if (_PyObject_LookupAttrId(it, &PyId___copy__, &copyfunc) < 0) {
         Py_DECREF(it);
         Py_DECREF(result);
         return NULL;
+    }
+    if (copyfunc != NULL) {
+        copyable = it;
     }
     else {
         copyable = tee_fromiterable(it);

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -171,14 +171,13 @@ PyObject_GetItem(PyObject *o, PyObject *key)
     if (PyType_Check(o)) {
         PyObject *meth, *result, *stack[1] = {key};
         _Py_IDENTIFIER(__class_getitem__);
-        meth = _PyObject_GetAttrIdWithoutError(o, &PyId___class_getitem__);
+        if (_PyObject_LookupAttrId(o, &PyId___class_getitem__, &meth) < 0) {
+            return NULL;
+        }
         if (meth) {
             result = _PyObject_FastCall(meth, stack, 1);
             Py_DECREF(meth);
             return result;
-        }
-        else if (PyErr_Occurred()) {
-            return NULL;
         }
     }
 
@@ -2267,12 +2266,9 @@ abstract_get_bases(PyObject *cls)
     PyObject *bases;
 
     Py_ALLOW_RECURSION
-    bases = _PyObject_GetAttrIdWithoutError(cls, &PyId___bases__);
+    (void)_PyObject_LookupAttrId(cls, &PyId___bases__, &bases);
     Py_END_ALLOW_RECURSION
-    if (bases == NULL) {
-        return NULL;
-    }
-    if (!PyTuple_Check(bases)) {
+    if (bases != NULL && !PyTuple_Check(bases)) {
         Py_DECREF(bases);
         return NULL;
     }
@@ -2335,23 +2331,23 @@ static int
 recursive_isinstance(PyObject *inst, PyObject *cls)
 {
     PyObject *icls;
-    int retval = 0;
+    int retval;
     _Py_IDENTIFIER(__class__);
 
     if (PyType_Check(cls)) {
         retval = PyObject_TypeCheck(inst, (PyTypeObject *)cls);
         if (retval == 0) {
-            PyObject *c = _PyObject_GetAttrIdWithoutError(inst, &PyId___class__);
-            if (c != NULL) {
-                if (c != (PyObject *)(inst->ob_type) && PyType_Check(c)) {
+            retval = _PyObject_LookupAttrId(inst, &PyId___class__, &icls);
+            if (icls != NULL) {
+                if (icls != (PyObject *)(inst->ob_type) && PyType_Check(icls)) {
                     retval = PyType_IsSubtype(
-                        (PyTypeObject *)c,
+                        (PyTypeObject *)icls,
                         (PyTypeObject *)cls);
                 }
-                Py_DECREF(c);
-            }
-            else if (PyErr_Occurred()) {
-                retval = -1;
+                else {
+                    retval = 0;
+                }
+                Py_DECREF(icls);
             }
         }
     }
@@ -2359,13 +2355,10 @@ recursive_isinstance(PyObject *inst, PyObject *cls)
         if (!check_class(cls,
             "isinstance() arg 2 must be a type or tuple of types"))
             return -1;
-        icls = _PyObject_GetAttrIdWithoutError(inst, &PyId___class__);
+        retval = _PyObject_LookupAttrId(inst, &PyId___class__, &icls);
         if (icls != NULL) {
             retval = abstract_issubclass(icls, cls);
             Py_DECREF(icls);
-        }
-        else if (PyErr_Occurred()) {
-            retval = -1;
         }
     }
 

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -249,17 +249,14 @@ method_repr(PyMethodObject *a)
     PyObject *funcname = NULL, *result = NULL;
     const char *defname = "?";
 
-    funcname = _PyObject_GetAttrId(func, &PyId___qualname__);
+    funcname = _PyObject_GetAttrIdWithoutError(func, &PyId___qualname__);
     if (funcname == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_Occurred())
             return NULL;
-        PyErr_Clear();
 
-        funcname = _PyObject_GetAttrId(func, &PyId___name__);
-        if (funcname == NULL) {
-            if (!PyErr_ExceptionMatches(PyExc_AttributeError))
-                return NULL;
-            PyErr_Clear();
+        funcname = _PyObject_GetAttrIdWithoutError(func, &PyId___name__);
+        if (funcname == NULL && PyErr_Occurred()) {
+            return NULL;
         }
     }
 
@@ -550,11 +547,10 @@ instancemethod_repr(PyObject *self)
         return NULL;
     }
 
-    funcname = _PyObject_GetAttrId(func, &PyId___name__);
+    funcname = _PyObject_GetAttrIdWithoutError(func, &PyId___name__);
     if (funcname == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_Occurred())
             return NULL;
-        PyErr_Clear();
     }
     else if (!PyUnicode_Check(funcname)) {
         Py_DECREF(funcname);

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -246,18 +246,14 @@ method_repr(PyMethodObject *a)
 {
     PyObject *self = a->im_self;
     PyObject *func = a->im_func;
-    PyObject *funcname = NULL, *result = NULL;
+    PyObject *funcname, *result;
     const char *defname = "?";
 
-    funcname = _PyObject_GetAttrIdWithoutError(func, &PyId___qualname__);
-    if (funcname == NULL) {
-        if (PyErr_Occurred())
-            return NULL;
-
-        funcname = _PyObject_GetAttrIdWithoutError(func, &PyId___name__);
-        if (funcname == NULL && PyErr_Occurred()) {
-            return NULL;
-        }
+    if (_PyObject_LookupAttrId(func, &PyId___qualname__, &funcname) < 0 ||
+        (funcname == NULL &&
+         _PyObject_LookupAttrId(func, &PyId___name__, &funcname) < 0))
+    {
+        return NULL;
     }
 
     if (funcname != NULL && !PyUnicode_Check(funcname)) {
@@ -539,7 +535,7 @@ static PyObject *
 instancemethod_repr(PyObject *self)
 {
     PyObject *func = PyInstanceMethod_Function(self);
-    PyObject *funcname = NULL , *result = NULL;
+    PyObject *funcname, *result;
     const char *defname = "?";
 
     if (func == NULL) {
@@ -547,12 +543,10 @@ instancemethod_repr(PyObject *self)
         return NULL;
     }
 
-    funcname = _PyObject_GetAttrIdWithoutError(func, &PyId___name__);
-    if (funcname == NULL) {
-        if (PyErr_Occurred())
-            return NULL;
+    if (_PyObject_LookupAttrId(func, &PyId___name__, &funcname) < 0) {
+        return NULL;
     }
-    else if (!PyUnicode_Check(funcname)) {
+    if (funcname != NULL && !PyUnicode_Check(funcname)) {
         Py_DECREF(funcname);
         funcname = NULL;
     }

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2188,13 +2188,12 @@ dict_update_common(PyObject *self, PyObject *args, PyObject *kwds,
     }
     else if (arg != NULL) {
         _Py_IDENTIFIER(keys);
-        PyObject *func = _PyObject_GetAttrId(arg, &PyId_keys);
+        PyObject *func = _PyObject_GetAttrIdWithoutError(arg, &PyId_keys);
         if (func != NULL) {
             Py_DECREF(func);
             result = PyDict_Merge(self, arg, 1);
         }
-        else if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
+        else if (!PyErr_Occurred()) {
             result = PyDict_MergeFromSeq2(self, arg, 1);
         }
         else {

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2188,16 +2188,16 @@ dict_update_common(PyObject *self, PyObject *args, PyObject *kwds,
     }
     else if (arg != NULL) {
         _Py_IDENTIFIER(keys);
-        PyObject *func = _PyObject_GetAttrIdWithoutError(arg, &PyId_keys);
-        if (func != NULL) {
+        PyObject *func;
+        if (_PyObject_LookupAttrId(arg, &PyId_keys, &func) < 0) {
+            result = -1;
+        }
+        else if (func != NULL) {
             Py_DECREF(func);
             result = PyDict_Merge(self, arg, 1);
         }
-        else if (!PyErr_Occurred()) {
-            result = PyDict_MergeFromSeq2(self, arg, 1);
-        }
         else {
-            result = -1;
+            result = PyDict_MergeFromSeq2(self, arg, 1);
         }
     }
 

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -349,12 +349,11 @@ gen_close_iter(PyObject *yf)
             return -1;
     }
     else {
-        PyObject *meth = _PyObject_GetAttrIdWithoutError(yf, &PyId_close);
-        if (meth == NULL) {
-            if (PyErr_Occurred())
-                PyErr_WriteUnraisable(yf);
+        PyObject *meth;
+        if (_PyObject_LookupAttrId(yf, &PyId_close, &meth) < 0) {
+            PyErr_WriteUnraisable(yf);
         }
-        else {
+        if (meth) {
             retval = _PyObject_CallNoArg(meth);
             Py_DECREF(meth);
             if (retval == NULL)
@@ -467,12 +466,12 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
             gen->gi_running = 0;
         } else {
             /* `yf` is an iterator or a coroutine-like object. */
-            PyObject *meth = _PyObject_GetAttrIdWithoutError(yf, &PyId_throw);
+            PyObject *meth;
+            if (_PyObject_LookupAttrId(yf, &PyId_throw, &meth) < 0) {
+                Py_DECREF(yf);
+                return NULL;
+            }
             if (meth == NULL) {
-                if (PyErr_Occurred()) {
-                    Py_DECREF(yf);
-                    return NULL;
-                }
                 Py_DECREF(yf);
                 goto throw_here;
             }

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -349,11 +349,10 @@ gen_close_iter(PyObject *yf)
             return -1;
     }
     else {
-        PyObject *meth = _PyObject_GetAttrId(yf, &PyId_close);
+        PyObject *meth = _PyObject_GetAttrIdWithoutError(yf, &PyId_close);
         if (meth == NULL) {
-            if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+            if (PyErr_Occurred())
                 PyErr_WriteUnraisable(yf);
-            PyErr_Clear();
         }
         else {
             retval = _PyObject_CallNoArg(meth);
@@ -468,13 +467,12 @@ _gen_throw(PyGenObject *gen, int close_on_genexit,
             gen->gi_running = 0;
         } else {
             /* `yf` is an iterator or a coroutine-like object. */
-            PyObject *meth = _PyObject_GetAttrId(yf, &PyId_throw);
+            PyObject *meth = _PyObject_GetAttrIdWithoutError(yf, &PyId_throw);
             if (meth == NULL) {
-                if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+                if (PyErr_Occurred()) {
                     Py_DECREF(yf);
                     return NULL;
                 }
-                PyErr_Clear();
                 Py_DECREF(yf);
                 goto throw_here;
             }

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -816,13 +816,12 @@ _PyObject_IsAbstract(PyObject *obj)
     if (obj == NULL)
         return 0;
 
-    isabstract = _PyObject_GetAttrId(obj, &PyId___isabstractmethod__);
+    isabstract = _PyObject_GetAttrIdWithoutError(obj, &PyId___isabstractmethod__);
     if (isabstract == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
-            return 0;
+        if (PyErr_Occurred()) {
+            return -1;
         }
-        return -1;
+        return 0;
     }
     res = PyObject_IsTrue(isabstract);
     Py_DECREF(isabstract);
@@ -916,6 +915,17 @@ _PyObject_GetAttrWithoutError(PyObject *v, PyObject *name)
         PyErr_Clear();
     }
     return ret;
+}
+
+PyObject *
+_PyObject_GetAttrIdWithoutError(PyObject *v, _Py_Identifier *name)
+{
+    PyObject *result;
+    PyObject *oname = _PyUnicode_FromId(name); /* borrowed */
+    if (!oname)
+        return NULL;
+    result = _PyObject_GetAttrWithoutError(v, oname);
+    return result;
 }
 
 int

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -816,15 +816,11 @@ _PyObject_IsAbstract(PyObject *obj)
     if (obj == NULL)
         return 0;
 
-    isabstract = _PyObject_GetAttrIdWithoutError(obj, &PyId___isabstractmethod__);
-    if (isabstract == NULL) {
-        if (PyErr_Occurred()) {
-            return -1;
-        }
-        return 0;
+    res = _PyObject_LookupAttrId(obj, &PyId___isabstractmethod__, &isabstract);
+    if (res > 0) {
+        res = PyObject_IsTrue(isabstract);
+        Py_DECREF(isabstract);
     }
-    res = PyObject_IsTrue(isabstract);
-    Py_DECREF(isabstract);
     return res;
 }
 
@@ -886,58 +882,74 @@ PyObject_GetAttr(PyObject *v, PyObject *name)
     return NULL;
 }
 
-PyObject *
-_PyObject_GetAttrWithoutError(PyObject *v, PyObject *name)
+int
+_PyObject_LookupAttr(PyObject *v, PyObject *name, PyObject **result)
 {
     PyTypeObject *tp = Py_TYPE(v);
-    PyObject *ret = NULL;
 
     if (!PyUnicode_Check(name)) {
         PyErr_Format(PyExc_TypeError,
                      "attribute name must be string, not '%.200s'",
                      name->ob_type->tp_name);
-        return NULL;
+        *result = NULL;
+        return -1;
     }
 
     if (tp->tp_getattro == PyObject_GenericGetAttr) {
-        return _PyObject_GenericGetAttrWithDict(v, name, NULL, 1);
+        *result = _PyObject_GenericGetAttrWithDict(v, name, NULL, 1);
+        if (*result != NULL) {
+            return 1;
+        }
+        if (PyErr_Occurred()) {
+            return -1;
+        }
+        return 0;
     }
     if (tp->tp_getattro != NULL) {
-        ret = (*tp->tp_getattro)(v, name);
+        *result = (*tp->tp_getattro)(v, name);
     }
     else if (tp->tp_getattr != NULL) {
         const char *name_str = PyUnicode_AsUTF8(name);
-        if (name_str == NULL)
-            return NULL;
-        ret = (*tp->tp_getattr)(v, (char *)name_str);
+        if (name_str == NULL) {
+            *result = NULL;
+            return -1;
+        }
+        *result = (*tp->tp_getattr)(v, (char *)name_str);
     }
-    if (ret == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-        PyErr_Clear();
+    if (*result != NULL) {
+        return 1;
     }
-    return ret;
+    if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        return -1;
+    }
+    PyErr_Clear();
+    return 0;
 }
 
-PyObject *
-_PyObject_GetAttrIdWithoutError(PyObject *v, _Py_Identifier *name)
+int
+_PyObject_LookupAttrId(PyObject *v, _Py_Identifier *name, PyObject **result)
 {
-    PyObject *result;
     PyObject *oname = _PyUnicode_FromId(name); /* borrowed */
-    if (!oname)
-        return NULL;
-    result = _PyObject_GetAttrWithoutError(v, oname);
-    return result;
+    if (!oname) {
+        *result = NULL;
+        return -1;
+    }
+    return  _PyObject_LookupAttr(v, oname, result);
 }
 
 int
 PyObject_HasAttr(PyObject *v, PyObject *name)
 {
-    PyObject *res = _PyObject_GetAttrWithoutError(v, name);
-    if (res != NULL) {
-        Py_DECREF(res);
-        return 1;
+    PyObject *res;
+    if (_PyObject_LookupAttr(v, name, &res) < 0) {
+        PyErr_Clear();
+        return 0;
     }
-    PyErr_Clear();
-    return 0;
+    if (res == NULL) {
+        return 0;
+    }
+    Py_DECREF(res);
+    return 1;
 }
 
 int

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -2359,7 +2359,7 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
             goto handle_kwargs;
         }
 
-        func = _PyObject_GetAttrId(other, &PyId_keys);
+        func = _PyObject_GetAttrIdWithoutError(other, &PyId_keys);
         if (func != NULL) {
             PyObject *keys, *iterator, *key;
             keys = _PyObject_CallNoArg(func);
@@ -2391,15 +2391,12 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
                 return NULL;
             goto handle_kwargs;
         }
-        else if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        else if (PyErr_Occurred()) {
             Py_DECREF(other);
             return NULL;
         }
-        else {
-            PyErr_Clear();
-        }
 
-        func = _PyObject_GetAttrId(other, &PyId_items);
+        func = _PyObject_GetAttrIdWithoutError(other, &PyId_items);
         if (func != NULL) {
             PyObject *items;
             Py_DECREF(other);
@@ -2413,12 +2410,9 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
                 return NULL;
             goto handle_kwargs;
         }
-        else if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+        else if (PyErr_Occurred()) {
             Py_DECREF(other);
             return NULL;
-        }
-        else {
-            PyErr_Clear();
         }
 
         res = mutablemapping_add_pairs(self, other);

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -2359,7 +2359,10 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
             goto handle_kwargs;
         }
 
-        func = _PyObject_GetAttrIdWithoutError(other, &PyId_keys);
+        if (_PyObject_LookupAttrId(other, &PyId_keys, &func) < 0) {
+            Py_DECREF(other);
+            return NULL;
+        }
         if (func != NULL) {
             PyObject *keys, *iterator, *key;
             keys = _PyObject_CallNoArg(func);
@@ -2391,12 +2394,11 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
                 return NULL;
             goto handle_kwargs;
         }
-        else if (PyErr_Occurred()) {
+
+        if (_PyObject_LookupAttrId(other, &PyId_items, &func) < 0) {
             Py_DECREF(other);
             return NULL;
         }
-
-        func = _PyObject_GetAttrIdWithoutError(other, &PyId_items);
         if (func != NULL) {
             PyObject *items;
             Py_DECREF(other);
@@ -2409,10 +2411,6 @@ mutablemapping_update(PyObject *self, PyObject *args, PyObject *kwargs)
             if (res == -1)
                 return NULL;
             goto handle_kwargs;
-        }
-        else if (PyErr_Occurred()) {
-            Py_DECREF(other);
-            return NULL;
         }
 
         res = mutablemapping_add_pairs(self, other);

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -497,11 +497,27 @@ class Obj2ModVisitor(PickleVisitor):
 
     def visitField(self, field, name, sum=None, prod=None, depth=0):
         ctype = get_c_type(field.type)
+        self.emit("if (_PyObject_LookupAttrId(obj, &PyId_%s, &tmp) < 0) {" % field.name, depth)
+        self.emit("return 1;", depth+1)
+        self.emit("}", depth)
         if not field.opt:
-            self.emit("tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_%s);" % field.name, depth)
+            self.emit("if (tmp == NULL) {", depth)
+            message = "required field \\\"%s\\\" missing from %s" % (field.name, name)
+            format = "PyErr_SetString(PyExc_TypeError, \"%s\");"
+            self.emit(format % message, depth+1, reflow=False)
+            self.emit("return 1;", depth+1)
         else:
-            self.emit("tmp = get_not_none(obj, &PyId_%s);" % field.name, depth)
-        self.emit("if (tmp != NULL) {", depth)
+            self.emit("if (tmp == NULL || tmp == Py_None) {", depth)
+            self.emit("Py_CLEAR(tmp);", depth+1)
+            if self.isNumeric(field):
+                self.emit("%s = 0;" % field.name, depth+1)
+            elif not self.isSimpleType(field):
+                self.emit("%s = NULL;" % field.name, depth+1)
+            else:
+                raise TypeError("could not determine the default value for %s" % field.name)
+        self.emit("}", depth)
+        self.emit("else {", depth)
+
         self.emit("int res;", depth+1)
         if field.seq:
             self.emit("Py_ssize_t len;", depth+1)
@@ -539,25 +555,6 @@ class Obj2ModVisitor(PickleVisitor):
             self.emit("if (res != 0) goto failed;", depth+1)
 
         self.emit("Py_CLEAR(tmp);", depth+1)
-        if not field.opt:
-            self.emit("} else {", depth)
-            self.emit("if (!PyErr_Occurred()) {", depth+1)
-            message = "required field \\\"%s\\\" missing from %s" % (field.name, name)
-            format = "PyErr_SetString(PyExc_TypeError, \"%s\");"
-            self.emit(format % message, depth+2, reflow=False)
-            self.emit("}", depth+1)
-            self.emit("return 1;", depth+1)
-        else:
-            self.emit("} else if (PyErr_Occurred()) {", depth)
-            self.emit("return 1;", depth+1)
-            self.emit("} else {", depth)
-
-            if self.isNumeric(field):
-                self.emit("%s = 0;" % field.name, depth+1)
-            elif not self.isSimpleType(field):
-                self.emit("%s = NULL;" % field.name, depth+1)
-            else:
-                raise TypeError("could not determine the default value for %s" % field.name)
         self.emit("}", depth)
 
 
@@ -662,14 +659,13 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields;
-    fields = _PyObject_GetAttrIdWithoutError((PyObject*)Py_TYPE(self), &PyId__fields);
+    if (_PyObject_LookupAttrId((PyObject*)Py_TYPE(self), &PyId__fields, &fields) < 0) {
+        goto cleanup;
+    }
     if (fields) {
         numfields = PySequence_Size(fields);
         if (numfields == -1)
             goto cleanup;
-    }
-    else if (PyErr_Occurred()) {
-        goto cleanup;
     }
 
     res = 0; /* if no error occurs, this stays 0 to the end */
@@ -711,12 +707,12 @@ static PyObject *
 ast_type_reduce(PyObject *self, PyObject *unused)
 {
     _Py_IDENTIFIER(__dict__);
-    PyObject *dict = _PyObject_GetAttrIdWithoutError(self, &PyId___dict__);
+    PyObject *dict;
+    if (_PyObject_LookupAttrId(self, &PyId___dict__, &dict) < 0) {
+        return NULL;
+    }
     if (dict) {
         return Py_BuildValue("O()N", Py_TYPE(self), dict);
-    }
-    if (PyErr_Occurred()) {
-        return NULL;
     }
     return Py_BuildValue("O()", Py_TYPE(self));
 }
@@ -954,19 +950,6 @@ static int add_ast_fields(void)
     }
     Py_DECREF(empty_tuple);
     return 0;
-}
-
-static PyObject *get_not_none(PyObject *obj, _Py_Identifier *id)
-{
-    PyObject *attr = _PyObject_GetAttrIdWithoutError(obj, id);
-    if (!attr) {
-        return NULL;
-    }
-    else if (attr == Py_None) {
-        Py_DECREF(attr);
-        return NULL;
-    }
-    return attr;
 }
 
 """, 0, reflow=False)

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -545,14 +545,13 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
     Py_ssize_t i, numfields = 0;
     int res = -1;
     PyObject *key, *value, *fields;
-    fields = _PyObject_GetAttrIdWithoutError((PyObject*)Py_TYPE(self), &PyId__fields);
+    if (_PyObject_LookupAttrId((PyObject*)Py_TYPE(self), &PyId__fields, &fields) < 0) {
+        goto cleanup;
+    }
     if (fields) {
         numfields = PySequence_Size(fields);
         if (numfields == -1)
             goto cleanup;
-    }
-    else if (PyErr_Occurred()) {
-        goto cleanup;
     }
 
     res = 0; /* if no error occurs, this stays 0 to the end */
@@ -594,12 +593,12 @@ static PyObject *
 ast_type_reduce(PyObject *self, PyObject *unused)
 {
     _Py_IDENTIFIER(__dict__);
-    PyObject *dict = _PyObject_GetAttrIdWithoutError(self, &PyId___dict__);
+    PyObject *dict;
+    if (_PyObject_LookupAttrId(self, &PyId___dict__, &dict) < 0) {
+        return NULL;
+    }
     if (dict) {
         return Py_BuildValue("O()N", Py_TYPE(self), dict);
-    }
-    if (PyErr_Occurred()) {
-        return NULL;
     }
     return Py_BuildValue("O()", Py_TYPE(self));
 }
@@ -837,19 +836,6 @@ static int add_ast_fields(void)
     }
     Py_DECREF(empty_tuple);
     return 0;
-}
-
-static PyObject *get_not_none(PyObject *obj, _Py_Identifier *id)
-{
-    PyObject *attr = _PyObject_GetAttrIdWithoutError(obj, id);
-    if (!attr) {
-        return NULL;
-    }
-    else if (attr == Py_None) {
-        Py_DECREF(attr);
-        return NULL;
-    }
-    return attr;
 }
 
 
@@ -4000,8 +3986,14 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
         asdl_seq* body;
         string docstring;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Module");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4023,22 +4015,19 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Module");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_docstring, &tmp) < 0) {
             return 1;
         }
-        tmp = get_not_none(obj, &PyId_docstring);
-        if (tmp != NULL) {
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            docstring = NULL;
+        }
+        else {
             int res;
             res = obj2ast_string(tmp, &docstring, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            docstring = NULL;
         }
         *out = Module(body, docstring, arena);
         if (*out == NULL) goto failed;
@@ -4051,8 +4040,14 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* body;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Interactive");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4074,11 +4069,6 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Interactive");
-            }
-            return 1;
         }
         *out = Interactive(body, arena);
         if (*out == NULL) goto failed;
@@ -4091,17 +4081,18 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty body;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Expression");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &body, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Expression");
-            }
-            return 1;
         }
         *out = Expression(body, arena);
         if (*out == NULL) goto failed;
@@ -4114,8 +4105,14 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* body;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Suite");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4137,11 +4134,6 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Suite");
-            }
-            return 1;
         }
         *out = Suite(body, arena);
         if (*out == NULL) goto failed;
@@ -4167,29 +4159,31 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_lineno);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_lineno, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"lineno\" missing from stmt");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_int(tmp, &lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"lineno\" missing from stmt");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_col_offset, &tmp) < 0) {
         return 1;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_col_offset);
-    if (tmp != NULL) {
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"col_offset\" missing from stmt");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_int(tmp, &col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"col_offset\" missing from stmt");
-        }
-        return 1;
     }
     isinstance = PyObject_IsInstance(obj, (PyObject*)FunctionDef_type);
     if (isinstance == -1) {
@@ -4203,32 +4197,40 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty returns;
         string docstring;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_name);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from FunctionDef");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_identifier(tmp, &name, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from FunctionDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_args);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from FunctionDef");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_arguments(tmp, &args, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from FunctionDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from FunctionDef");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4250,14 +4252,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from FunctionDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_decorator_list, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_decorator_list);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"decorator_list\" missing from FunctionDef");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4279,33 +4282,32 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(decorator_list, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"decorator_list\" missing from FunctionDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_returns, &tmp) < 0) {
             return 1;
         }
-        tmp = get_not_none(obj, &PyId_returns);
-        if (tmp != NULL) {
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            returns = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &returns, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            returns = NULL;
         }
-        tmp = get_not_none(obj, &PyId_docstring);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_docstring, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            docstring = NULL;
+        }
+        else {
             int res;
             res = obj2ast_string(tmp, &docstring, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            docstring = NULL;
         }
         *out = FunctionDef(name, args, body, decorator_list, returns,
                            docstring, lineno, col_offset, arena);
@@ -4324,32 +4326,40 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty returns;
         string docstring;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_name);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from AsyncFunctionDef");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_identifier(tmp, &name, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from AsyncFunctionDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_args);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from AsyncFunctionDef");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_arguments(tmp, &args, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from AsyncFunctionDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from AsyncFunctionDef");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4371,14 +4381,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from AsyncFunctionDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_decorator_list, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_decorator_list);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"decorator_list\" missing from AsyncFunctionDef");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4400,33 +4411,32 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(decorator_list, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"decorator_list\" missing from AsyncFunctionDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_returns, &tmp) < 0) {
             return 1;
         }
-        tmp = get_not_none(obj, &PyId_returns);
-        if (tmp != NULL) {
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            returns = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &returns, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            returns = NULL;
         }
-        tmp = get_not_none(obj, &PyId_docstring);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_docstring, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            docstring = NULL;
+        }
+        else {
             int res;
             res = obj2ast_string(tmp, &docstring, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            docstring = NULL;
         }
         *out = AsyncFunctionDef(name, args, body, decorator_list, returns,
                                 docstring, lineno, col_offset, arena);
@@ -4445,20 +4455,27 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* decorator_list;
         string docstring;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_name);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from ClassDef");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_identifier(tmp, &name, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from ClassDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_bases, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_bases);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"bases\" missing from ClassDef");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4480,14 +4497,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(bases, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"bases\" missing from ClassDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_keywords, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_keywords);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"keywords\" missing from ClassDef");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4509,14 +4527,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(keywords, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"keywords\" missing from ClassDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from ClassDef");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4538,14 +4557,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from ClassDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_decorator_list, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_decorator_list);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"decorator_list\" missing from ClassDef");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4567,22 +4587,19 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(decorator_list, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"decorator_list\" missing from ClassDef");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_docstring, &tmp) < 0) {
             return 1;
         }
-        tmp = get_not_none(obj, &PyId_docstring);
-        if (tmp != NULL) {
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            docstring = NULL;
+        }
+        else {
             int res;
             res = obj2ast_string(tmp, &docstring, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            docstring = NULL;
         }
         *out = ClassDef(name, bases, keywords, body, decorator_list, docstring,
                         lineno, col_offset, arena);
@@ -4596,16 +4613,18 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        tmp = get_not_none(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            value = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            value = NULL;
         }
         *out = Return(value, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -4618,8 +4637,14 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* targets;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_targets);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_targets, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"targets\" missing from Delete");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4641,11 +4666,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(targets, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"targets\" missing from Delete");
-            }
-            return 1;
         }
         *out = Delete(targets, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -4659,8 +4679,14 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* targets;
         expr_ty value;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_targets);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_targets, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"targets\" missing from Assign");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4682,23 +4708,19 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(targets, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"targets\" missing from Assign");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Assign");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Assign");
-            }
-            return 1;
         }
         *out = Assign(targets, value, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -4713,41 +4735,44 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         operator_ty op;
         expr_ty value;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_target);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from AugAssign");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &target, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from AugAssign");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_op, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_op);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"op\" missing from AugAssign");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_operator(tmp, &op, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"op\" missing from AugAssign");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from AugAssign");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from AugAssign");
-            }
-            return 1;
         }
         *out = AugAssign(target, op, value, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -4763,52 +4788,57 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty value;
         int simple;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_target);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from AnnAssign");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &target, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from AnnAssign");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_annotation, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_annotation);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"annotation\" missing from AnnAssign");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &annotation, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"annotation\" missing from AnnAssign");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
             return 1;
         }
-        tmp = get_not_none(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            value = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            value = NULL;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_simple);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_simple, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"simple\" missing from AnnAssign");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_int(tmp, &simple, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"simple\" missing from AnnAssign");
-            }
-            return 1;
         }
         *out = AnnAssign(target, annotation, value, simple, lineno, col_offset,
                          arena);
@@ -4825,32 +4855,40 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* orelse;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_target);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from For");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &target, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from For");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_iter, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_iter);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"iter\" missing from For");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &iter, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"iter\" missing from For");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from For");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4872,14 +4910,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from For");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_orelse);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from For");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4901,11 +4940,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(orelse, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from For");
-            }
-            return 1;
         }
         *out = For(target, iter, body, orelse, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -4921,32 +4955,40 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* orelse;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_target);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from AsyncFor");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &target, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from AsyncFor");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_iter, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_iter);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"iter\" missing from AsyncFor");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &iter, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"iter\" missing from AsyncFor");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from AsyncFor");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4968,14 +5010,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from AsyncFor");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_orelse);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from AsyncFor");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -4997,11 +5040,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(orelse, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from AsyncFor");
-            }
-            return 1;
         }
         *out = AsyncFor(target, iter, body, orelse, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5016,20 +5054,27 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* orelse;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_test);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_test, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"test\" missing from While");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &test, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"test\" missing from While");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from While");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5051,14 +5096,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from While");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_orelse);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from While");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5080,11 +5126,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(orelse, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from While");
-            }
-            return 1;
         }
         *out = While(test, body, orelse, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5099,20 +5140,27 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* body;
         asdl_seq* orelse;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_test);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_test, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"test\" missing from If");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &test, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"test\" missing from If");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from If");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5134,14 +5182,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from If");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_orelse);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from If");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5163,11 +5212,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(orelse, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from If");
-            }
-            return 1;
         }
         *out = If(test, body, orelse, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5181,8 +5225,14 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* items;
         asdl_seq* body;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_items);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_items, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"items\" missing from With");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5204,14 +5254,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(items, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"items\" missing from With");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from With");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5233,11 +5284,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from With");
-            }
-            return 1;
         }
         *out = With(items, body, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5251,8 +5297,14 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* items;
         asdl_seq* body;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_items);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_items, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"items\" missing from AsyncWith");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5274,14 +5326,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(items, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"items\" missing from AsyncWith");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from AsyncWith");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5303,11 +5356,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from AsyncWith");
-            }
-            return 1;
         }
         *out = AsyncWith(items, body, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5321,27 +5369,31 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty exc;
         expr_ty cause;
 
-        tmp = get_not_none(obj, &PyId_exc);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_exc, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            exc = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &exc, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            exc = NULL;
         }
-        tmp = get_not_none(obj, &PyId_cause);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_cause, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            cause = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &cause, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            cause = NULL;
         }
         *out = Raise(exc, cause, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5357,8 +5409,14 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* orelse;
         asdl_seq* finalbody;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Try");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5380,14 +5438,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Try");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_handlers, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_handlers);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"handlers\" missing from Try");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5409,14 +5468,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(handlers, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"handlers\" missing from Try");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_orelse);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from Try");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5438,14 +5498,15 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(orelse, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from Try");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_finalbody, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_finalbody);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"finalbody\" missing from Try");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5467,11 +5528,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(finalbody, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"finalbody\" missing from Try");
-            }
-            return 1;
         }
         *out = Try(body, handlers, orelse, finalbody, lineno, col_offset,
                    arena);
@@ -5486,28 +5542,31 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         expr_ty test;
         expr_ty msg;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_test);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_test, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"test\" missing from Assert");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &test, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"test\" missing from Assert");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_msg, &tmp) < 0) {
             return 1;
         }
-        tmp = get_not_none(obj, &PyId_msg);
-        if (tmp != NULL) {
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            msg = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &msg, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            msg = NULL;
         }
         *out = Assert(test, msg, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5520,8 +5579,14 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* names;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_names);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_names, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"names\" missing from Import");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5543,11 +5608,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(names, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"names\" missing from Import");
-            }
-            return 1;
         }
         *out = Import(names, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5562,19 +5622,27 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
         asdl_seq* names;
         int level;
 
-        tmp = get_not_none(obj, &PyId_module);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_module, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            module = NULL;
+        }
+        else {
             int res;
             res = obj2ast_identifier(tmp, &module, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            module = NULL;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_names);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_names, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"names\" missing from ImportFrom");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5596,22 +5664,19 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(names, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"names\" missing from ImportFrom");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_level, &tmp) < 0) {
             return 1;
         }
-        tmp = get_not_none(obj, &PyId_level);
-        if (tmp != NULL) {
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            level = 0;
+        }
+        else {
             int res;
             res = obj2ast_int(tmp, &level, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            level = 0;
         }
         *out = ImportFrom(module, names, level, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5624,8 +5689,14 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* names;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_names);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_names, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"names\" missing from Global");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5647,11 +5718,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(names, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"names\" missing from Global");
-            }
-            return 1;
         }
         *out = Global(names, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5664,8 +5730,14 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* names;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_names);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_names, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"names\" missing from Nonlocal");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5687,11 +5759,6 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
                 asdl_seq_SET(names, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"names\" missing from Nonlocal");
-            }
-            return 1;
         }
         *out = Nonlocal(names, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5704,17 +5771,18 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Expr");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Expr");
-            }
-            return 1;
         }
         *out = Expr(value, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5770,29 +5838,31 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_lineno);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_lineno, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"lineno\" missing from expr");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_int(tmp, &lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"lineno\" missing from expr");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_col_offset, &tmp) < 0) {
         return 1;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_col_offset);
-    if (tmp != NULL) {
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"col_offset\" missing from expr");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_int(tmp, &col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"col_offset\" missing from expr");
-        }
-        return 1;
     }
     isinstance = PyObject_IsInstance(obj, (PyObject*)BoolOp_type);
     if (isinstance == -1) {
@@ -5802,20 +5872,27 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         boolop_ty op;
         asdl_seq* values;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_op);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_op, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"op\" missing from BoolOp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_boolop(tmp, &op, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"op\" missing from BoolOp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_values, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_values);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"values\" missing from BoolOp");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -5837,11 +5914,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(values, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"values\" missing from BoolOp");
-            }
-            return 1;
         }
         *out = BoolOp(op, values, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5856,41 +5928,44 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         operator_ty op;
         expr_ty right;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_left);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_left, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"left\" missing from BinOp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &left, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"left\" missing from BinOp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_op, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_op);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"op\" missing from BinOp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_operator(tmp, &op, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"op\" missing from BinOp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_right, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_right);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"right\" missing from BinOp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &right, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"right\" missing from BinOp");
-            }
-            return 1;
         }
         *out = BinOp(left, op, right, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5904,29 +5979,31 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         unaryop_ty op;
         expr_ty operand;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_op);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_op, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"op\" missing from UnaryOp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_unaryop(tmp, &op, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"op\" missing from UnaryOp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_operand, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_operand);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"operand\" missing from UnaryOp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &operand, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"operand\" missing from UnaryOp");
-            }
-            return 1;
         }
         *out = UnaryOp(op, operand, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5940,29 +6017,31 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         arguments_ty args;
         expr_ty body;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_args);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from Lambda");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_arguments(tmp, &args, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from Lambda");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Lambda");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &body, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from Lambda");
-            }
-            return 1;
         }
         *out = Lambda(args, body, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -5977,41 +6056,44 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty body;
         expr_ty orelse;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_test);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_test, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"test\" missing from IfExp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &test, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"test\" missing from IfExp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from IfExp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &body, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from IfExp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_orelse, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_orelse);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from IfExp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &orelse, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"orelse\" missing from IfExp");
-            }
-            return 1;
         }
         *out = IfExp(test, body, orelse, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6025,8 +6107,14 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* keys;
         asdl_seq* values;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_keys);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_keys, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"keys\" missing from Dict");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6048,14 +6136,15 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(keys, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"keys\" missing from Dict");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_values, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_values);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"values\" missing from Dict");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6077,11 +6166,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(values, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"values\" missing from Dict");
-            }
-            return 1;
         }
         *out = Dict(keys, values, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6094,8 +6178,14 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* elts;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_elts);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_elts, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"elts\" missing from Set");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6117,11 +6207,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(elts, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"elts\" missing from Set");
-            }
-            return 1;
         }
         *out = Set(elts, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6135,20 +6220,27 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty elt;
         asdl_seq* generators;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_elt);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_elt, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"elt\" missing from ListComp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &elt, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"elt\" missing from ListComp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_generators, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_generators);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"generators\" missing from ListComp");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6170,11 +6262,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(generators, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"generators\" missing from ListComp");
-            }
-            return 1;
         }
         *out = ListComp(elt, generators, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6188,20 +6275,27 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty elt;
         asdl_seq* generators;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_elt);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_elt, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"elt\" missing from SetComp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &elt, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"elt\" missing from SetComp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_generators, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_generators);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"generators\" missing from SetComp");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6223,11 +6317,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(generators, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"generators\" missing from SetComp");
-            }
-            return 1;
         }
         *out = SetComp(elt, generators, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6242,32 +6331,40 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty value;
         asdl_seq* generators;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_key);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_key, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"key\" missing from DictComp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &key, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"key\" missing from DictComp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from DictComp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from DictComp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_generators, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_generators);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"generators\" missing from DictComp");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6289,11 +6386,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(generators, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"generators\" missing from DictComp");
-            }
-            return 1;
         }
         *out = DictComp(key, value, generators, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6307,20 +6399,27 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty elt;
         asdl_seq* generators;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_elt);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_elt, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"elt\" missing from GeneratorExp");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &elt, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"elt\" missing from GeneratorExp");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_generators, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_generators);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"generators\" missing from GeneratorExp");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6342,11 +6441,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(generators, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"generators\" missing from GeneratorExp");
-            }
-            return 1;
         }
         *out = GeneratorExp(elt, generators, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6359,17 +6453,18 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Await");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Await");
-            }
-            return 1;
         }
         *out = Await(value, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6382,16 +6477,18 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        tmp = get_not_none(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            value = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            value = NULL;
         }
         *out = Yield(value, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6404,17 +6501,18 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from YieldFrom");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from YieldFrom");
-            }
-            return 1;
         }
         *out = YieldFrom(value, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6429,20 +6527,27 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_int_seq* ops;
         asdl_seq* comparators;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_left);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_left, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"left\" missing from Compare");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &left, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"left\" missing from Compare");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_ops, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_ops);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"ops\" missing from Compare");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6464,14 +6569,15 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(ops, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"ops\" missing from Compare");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_comparators, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_comparators);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"comparators\" missing from Compare");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6493,11 +6599,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(comparators, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"comparators\" missing from Compare");
-            }
-            return 1;
         }
         *out = Compare(left, ops, comparators, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6512,20 +6613,27 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* args;
         asdl_seq* keywords;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_func);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_func, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"func\" missing from Call");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &func, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"func\" missing from Call");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_args);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from Call");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6547,14 +6655,15 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(args, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from Call");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_keywords, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_keywords);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"keywords\" missing from Call");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6576,11 +6685,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(keywords, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"keywords\" missing from Call");
-            }
-            return 1;
         }
         *out = Call(func, args, keywords, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6593,17 +6697,18 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         object n;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_n);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_n, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"n\" missing from Num");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_object(tmp, &n, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"n\" missing from Num");
-            }
-            return 1;
         }
         *out = Num(n, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6616,17 +6721,18 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         string s;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_s);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_s, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"s\" missing from Str");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_string(tmp, &s, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"s\" missing from Str");
-            }
-            return 1;
         }
         *out = Str(s, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6641,39 +6747,44 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         int conversion;
         expr_ty format_spec;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from FormattedValue");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from FormattedValue");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_conversion, &tmp) < 0) {
             return 1;
         }
-        tmp = get_not_none(obj, &PyId_conversion);
-        if (tmp != NULL) {
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            conversion = 0;
+        }
+        else {
             int res;
             res = obj2ast_int(tmp, &conversion, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            conversion = 0;
         }
-        tmp = get_not_none(obj, &PyId_format_spec);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_format_spec, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            format_spec = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &format_spec, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            format_spec = NULL;
         }
         *out = FormattedValue(value, conversion, format_spec, lineno,
                               col_offset, arena);
@@ -6687,8 +6798,14 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* values;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_values);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_values, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"values\" missing from JoinedStr");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -6710,11 +6827,6 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(values, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"values\" missing from JoinedStr");
-            }
-            return 1;
         }
         *out = JoinedStr(values, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6727,17 +6839,18 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         bytes s;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_s);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_s, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"s\" missing from Bytes");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_bytes(tmp, &s, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"s\" missing from Bytes");
-            }
-            return 1;
         }
         *out = Bytes(s, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6750,17 +6863,18 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         singleton value;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from NameConstant");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_singleton(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from NameConstant");
-            }
-            return 1;
         }
         *out = NameConstant(value, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6783,17 +6897,18 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
     if (isinstance) {
         constant value;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Constant");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_constant(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Constant");
-            }
-            return 1;
         }
         *out = Constant(value, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6808,41 +6923,44 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         identifier attr;
         expr_context_ty ctx;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Attribute");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Attribute");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_attr, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_attr);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"attr\" missing from Attribute");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_identifier(tmp, &attr, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"attr\" missing from Attribute");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_ctx);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Attribute");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr_context(tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Attribute");
-            }
-            return 1;
         }
         *out = Attribute(value, attr, ctx, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6857,41 +6975,44 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         slice_ty slice;
         expr_context_ty ctx;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Subscript");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Subscript");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_slice, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_slice);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"slice\" missing from Subscript");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_slice(tmp, &slice, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"slice\" missing from Subscript");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_ctx);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Subscript");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr_context(tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Subscript");
-            }
-            return 1;
         }
         *out = Subscript(value, slice, ctx, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6905,29 +7026,31 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         expr_ty value;
         expr_context_ty ctx;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Starred");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Starred");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_ctx);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Starred");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr_context(tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Starred");
-            }
-            return 1;
         }
         *out = Starred(value, ctx, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6941,29 +7064,31 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         identifier id;
         expr_context_ty ctx;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_id);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_id, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"id\" missing from Name");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_identifier(tmp, &id, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"id\" missing from Name");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_ctx);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Name");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr_context(tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Name");
-            }
-            return 1;
         }
         *out = Name(id, ctx, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -6977,8 +7102,14 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* elts;
         expr_context_ty ctx;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_elts);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_elts, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"elts\" missing from List");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -7000,23 +7131,19 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(elts, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"elts\" missing from List");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_ctx);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from List");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr_context(tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from List");
-            }
-            return 1;
         }
         *out = List(elts, ctx, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -7030,8 +7157,14 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
         asdl_seq* elts;
         expr_context_ty ctx;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_elts);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_elts, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"elts\" missing from Tuple");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -7053,23 +7186,19 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
                 asdl_seq_SET(elts, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"elts\" missing from Tuple");
-            }
+        }
+        if (_PyObject_LookupAttrId(obj, &PyId_ctx, &tmp) < 0) {
             return 1;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_ctx);
-        if (tmp != NULL) {
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Tuple");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr_context(tmp, &ctx, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"ctx\" missing from Tuple");
-            }
-            return 1;
         }
         *out = Tuple(elts, ctx, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -7160,38 +7289,44 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
         expr_ty upper;
         expr_ty step;
 
-        tmp = get_not_none(obj, &PyId_lower);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_lower, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            lower = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &lower, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            lower = NULL;
         }
-        tmp = get_not_none(obj, &PyId_upper);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_upper, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            upper = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &upper, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            upper = NULL;
         }
-        tmp = get_not_none(obj, &PyId_step);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_step, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            step = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &step, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            step = NULL;
         }
         *out = Slice(lower, upper, step, arena);
         if (*out == NULL) goto failed;
@@ -7204,8 +7339,14 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
     if (isinstance) {
         asdl_seq* dims;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_dims);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_dims, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"dims\" missing from ExtSlice");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -7227,11 +7368,6 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
                 asdl_seq_SET(dims, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"dims\" missing from ExtSlice");
-            }
-            return 1;
         }
         *out = ExtSlice(dims, arena);
         if (*out == NULL) goto failed;
@@ -7244,17 +7380,18 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
     if (isinstance) {
         expr_ty value;
 
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Index");
+            return 1;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &value, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from Index");
-            }
-            return 1;
         }
         *out = Index(value, arena);
         if (*out == NULL) goto failed;
@@ -7548,32 +7685,40 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
     asdl_seq* ifs;
     int is_async;
 
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_target);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_target, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from comprehension");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_expr(tmp, &target, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"target\" missing from comprehension");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_iter, &tmp) < 0) {
         return 1;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_iter);
-    if (tmp != NULL) {
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"iter\" missing from comprehension");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_expr(tmp, &iter, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"iter\" missing from comprehension");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_ifs, &tmp) < 0) {
         return 1;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_ifs);
-    if (tmp != NULL) {
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"ifs\" missing from comprehension");
+        return 1;
+    }
+    else {
         int res;
         Py_ssize_t len;
         Py_ssize_t i;
@@ -7595,23 +7740,19 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
             asdl_seq_SET(ifs, i, val);
         }
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"ifs\" missing from comprehension");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_is_async, &tmp) < 0) {
         return 1;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_is_async);
-    if (tmp != NULL) {
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"is_async\" missing from comprehension");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_int(tmp, &is_async, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"is_async\" missing from comprehension");
-        }
-        return 1;
     }
     *out = comprehension(target, iter, ifs, is_async, arena);
     return 0;
@@ -7633,29 +7774,31 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         *out = NULL;
         return 0;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_lineno);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_lineno, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"lineno\" missing from excepthandler");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_int(tmp, &lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"lineno\" missing from excepthandler");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_col_offset, &tmp) < 0) {
         return 1;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_col_offset);
-    if (tmp != NULL) {
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"col_offset\" missing from excepthandler");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_int(tmp, &col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"col_offset\" missing from excepthandler");
-        }
-        return 1;
     }
     isinstance = PyObject_IsInstance(obj, (PyObject*)ExceptHandler_type);
     if (isinstance == -1) {
@@ -7666,30 +7809,40 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
         identifier name;
         asdl_seq* body;
 
-        tmp = get_not_none(obj, &PyId_type);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_type, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            type = NULL;
+        }
+        else {
             int res;
             res = obj2ast_expr(tmp, &type, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            type = NULL;
         }
-        tmp = get_not_none(obj, &PyId_name);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL || tmp == Py_None) {
+            Py_CLEAR(tmp);
+            name = NULL;
+        }
+        else {
             int res;
             res = obj2ast_identifier(tmp, &name, arena);
             if (res != 0) goto failed;
             Py_CLEAR(tmp);
-        } else if (PyErr_Occurred()) {
-            return 1;
-        } else {
-            name = NULL;
         }
-        tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_body);
-        if (tmp != NULL) {
+        if (_PyObject_LookupAttrId(obj, &PyId_body, &tmp) < 0) {
+            return 1;
+        }
+        if (tmp == NULL) {
+            PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from ExceptHandler");
+            return 1;
+        }
+        else {
             int res;
             Py_ssize_t len;
             Py_ssize_t i;
@@ -7711,11 +7864,6 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
                 asdl_seq_SET(body, i, val);
             }
             Py_CLEAR(tmp);
-        } else {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, "required field \"body\" missing from ExceptHandler");
-            }
-            return 1;
         }
         *out = ExceptHandler(type, name, body, lineno, col_offset, arena);
         if (*out == NULL) goto failed;
@@ -7739,8 +7887,14 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
     arg_ty kwarg;
     asdl_seq* defaults;
 
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_args);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_args, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from arguments");
+        return 1;
+    }
+    else {
         int res;
         Py_ssize_t len;
         Py_ssize_t i;
@@ -7762,25 +7916,28 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
             asdl_seq_SET(args, i, val);
         }
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"args\" missing from arguments");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_vararg, &tmp) < 0) {
         return 1;
     }
-    tmp = get_not_none(obj, &PyId_vararg);
-    if (tmp != NULL) {
+    if (tmp == NULL || tmp == Py_None) {
+        Py_CLEAR(tmp);
+        vararg = NULL;
+    }
+    else {
         int res;
         res = obj2ast_arg(tmp, &vararg, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else if (PyErr_Occurred()) {
-        return 1;
-    } else {
-        vararg = NULL;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_kwonlyargs);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_kwonlyargs, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"kwonlyargs\" missing from arguments");
+        return 1;
+    }
+    else {
         int res;
         Py_ssize_t len;
         Py_ssize_t i;
@@ -7802,14 +7959,15 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
             asdl_seq_SET(kwonlyargs, i, val);
         }
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"kwonlyargs\" missing from arguments");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_kw_defaults, &tmp) < 0) {
         return 1;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_kw_defaults);
-    if (tmp != NULL) {
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"kw_defaults\" missing from arguments");
+        return 1;
+    }
+    else {
         int res;
         Py_ssize_t len;
         Py_ssize_t i;
@@ -7831,25 +7989,28 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
             asdl_seq_SET(kw_defaults, i, val);
         }
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"kw_defaults\" missing from arguments");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_kwarg, &tmp) < 0) {
         return 1;
     }
-    tmp = get_not_none(obj, &PyId_kwarg);
-    if (tmp != NULL) {
+    if (tmp == NULL || tmp == Py_None) {
+        Py_CLEAR(tmp);
+        kwarg = NULL;
+    }
+    else {
         int res;
         res = obj2ast_arg(tmp, &kwarg, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else if (PyErr_Occurred()) {
-        return 1;
-    } else {
-        kwarg = NULL;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_defaults);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_defaults, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"defaults\" missing from arguments");
+        return 1;
+    }
+    else {
         int res;
         Py_ssize_t len;
         Py_ssize_t i;
@@ -7871,11 +8032,6 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
             asdl_seq_SET(defaults, i, val);
         }
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"defaults\" missing from arguments");
-        }
-        return 1;
     }
     *out = arguments(args, vararg, kwonlyargs, kw_defaults, kwarg, defaults,
                      arena);
@@ -7894,52 +8050,57 @@ obj2ast_arg(PyObject* obj, arg_ty* out, PyArena* arena)
     int lineno;
     int col_offset;
 
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_arg);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_arg, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"arg\" missing from arg");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_identifier(tmp, &arg, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"arg\" missing from arg");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_annotation, &tmp) < 0) {
         return 1;
     }
-    tmp = get_not_none(obj, &PyId_annotation);
-    if (tmp != NULL) {
+    if (tmp == NULL || tmp == Py_None) {
+        Py_CLEAR(tmp);
+        annotation = NULL;
+    }
+    else {
         int res;
         res = obj2ast_expr(tmp, &annotation, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else if (PyErr_Occurred()) {
-        return 1;
-    } else {
-        annotation = NULL;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_lineno);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_lineno, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"lineno\" missing from arg");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_int(tmp, &lineno, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"lineno\" missing from arg");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_col_offset, &tmp) < 0) {
         return 1;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_col_offset);
-    if (tmp != NULL) {
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"col_offset\" missing from arg");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_int(tmp, &col_offset, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"col_offset\" missing from arg");
-        }
-        return 1;
     }
     *out = arg(arg, annotation, lineno, col_offset, arena);
     return 0;
@@ -7955,28 +8116,31 @@ obj2ast_keyword(PyObject* obj, keyword_ty* out, PyArena* arena)
     identifier arg;
     expr_ty value;
 
-    tmp = get_not_none(obj, &PyId_arg);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_arg, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL || tmp == Py_None) {
+        Py_CLEAR(tmp);
+        arg = NULL;
+    }
+    else {
         int res;
         res = obj2ast_identifier(tmp, &arg, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else if (PyErr_Occurred()) {
-        return 1;
-    } else {
-        arg = NULL;
     }
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_value);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_value, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from keyword");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_expr(tmp, &value, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"value\" missing from keyword");
-        }
-        return 1;
     }
     *out = keyword(arg, value, arena);
     return 0;
@@ -7992,28 +8156,31 @@ obj2ast_alias(PyObject* obj, alias_ty* out, PyArena* arena)
     identifier name;
     identifier asname;
 
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_name);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_name, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from alias");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_identifier(tmp, &name, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"name\" missing from alias");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_asname, &tmp) < 0) {
         return 1;
     }
-    tmp = get_not_none(obj, &PyId_asname);
-    if (tmp != NULL) {
+    if (tmp == NULL || tmp == Py_None) {
+        Py_CLEAR(tmp);
+        asname = NULL;
+    }
+    else {
         int res;
         res = obj2ast_identifier(tmp, &asname, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else if (PyErr_Occurred()) {
-        return 1;
-    } else {
-        asname = NULL;
     }
     *out = alias(name, asname, arena);
     return 0;
@@ -8029,28 +8196,31 @@ obj2ast_withitem(PyObject* obj, withitem_ty* out, PyArena* arena)
     expr_ty context_expr;
     expr_ty optional_vars;
 
-    tmp = _PyObject_GetAttrIdWithoutError(obj, &PyId_context_expr);
-    if (tmp != NULL) {
+    if (_PyObject_LookupAttrId(obj, &PyId_context_expr, &tmp) < 0) {
+        return 1;
+    }
+    if (tmp == NULL) {
+        PyErr_SetString(PyExc_TypeError, "required field \"context_expr\" missing from withitem");
+        return 1;
+    }
+    else {
         int res;
         res = obj2ast_expr(tmp, &context_expr, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else {
-        if (!PyErr_Occurred()) {
-            PyErr_SetString(PyExc_TypeError, "required field \"context_expr\" missing from withitem");
-        }
+    }
+    if (_PyObject_LookupAttrId(obj, &PyId_optional_vars, &tmp) < 0) {
         return 1;
     }
-    tmp = get_not_none(obj, &PyId_optional_vars);
-    if (tmp != NULL) {
+    if (tmp == NULL || tmp == Py_None) {
+        Py_CLEAR(tmp);
+        optional_vars = NULL;
+    }
+    else {
         int res;
         res = obj2ast_expr(tmp, &optional_vars, arena);
         if (res != 0) goto failed;
         Py_CLEAR(tmp);
-    } else if (PyErr_Occurred()) {
-        return 1;
-    } else {
-        optional_vars = NULL;
     }
     *out = withitem(context_expr, optional_vars, arena);
     return 0;

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -80,11 +80,8 @@ get_warnings_attr(_Py_Identifier *attr_id, int try_import)
             return NULL;
     }
 
-    obj = _PyObject_GetAttrId(warnings_module, attr_id);
+    obj = _PyObject_GetAttrIdWithoutError(warnings_module, attr_id);
     Py_DECREF(warnings_module);
-    if (obj == NULL && PyErr_ExceptionMatches(PyExc_AttributeError)) {
-        PyErr_Clear();
-    }
     return obj;
 }
 
@@ -893,13 +890,10 @@ get_source_line(PyObject *module_globals, int lineno)
     Py_INCREF(module_name);
 
     /* Make sure the loader implements the optional get_source() method. */
-    get_source = _PyObject_GetAttrId(loader, &PyId_get_source);
+    get_source = _PyObject_GetAttrIdWithoutError(loader, &PyId_get_source);
     Py_DECREF(loader);
     if (!get_source) {
         Py_DECREF(module_name);
-        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
-        }
         return NULL;
     }
     /* Call get_source() to get the source code. */

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -80,7 +80,7 @@ get_warnings_attr(_Py_Identifier *attr_id, int try_import)
             return NULL;
     }
 
-    obj = _PyObject_GetAttrIdWithoutError(warnings_module, attr_id);
+    (void)_PyObject_LookupAttrId(warnings_module, attr_id, &obj);
     Py_DECREF(warnings_module);
     return obj;
 }
@@ -890,7 +890,7 @@ get_source_line(PyObject *module_globals, int lineno)
     Py_INCREF(module_name);
 
     /* Make sure the loader implements the optional get_source() method. */
-    get_source = _PyObject_GetAttrIdWithoutError(loader, &PyId_get_source);
+    (void)_PyObject_LookupAttrId(loader, &PyId_get_source, &get_source);
     Py_DECREF(loader);
     if (!get_source) {
         Py_DECREF(module_name);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -71,12 +71,11 @@ update_bases(PyObject *bases, PyObject *const *args, int nargs)
             }
             continue;
         }
-        meth = _PyObject_GetAttrId(base, &PyId___mro_entries__);
+        meth = _PyObject_GetAttrIdWithoutError(base, &PyId___mro_entries__);
         if (!meth) {
-            if (!PyErr_ExceptionMatches(PyExc_AttributeError)) {
+            if (PyErr_Occurred()) {
                 goto error;
             }
-            PyErr_Clear();
             if (new_bases) {
                 if (PyList_Append(new_bases, base) < 0) {
                     goto error;
@@ -218,17 +217,13 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
     }
     /* else: meta is not a class, so we cannot do the metaclass
        calculation, so we will use the explicitly given object as it is */
-    prep = _PyObject_GetAttrId(meta, &PyId___prepare__);
+    prep = _PyObject_GetAttrIdWithoutError(meta, &PyId___prepare__);
     if (prep == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-            PyErr_Clear();
-            ns = PyDict_New();
+        if (PyErr_Occurred()) {
+            ns = NULL;
         }
         else {
-            Py_DECREF(meta);
-            Py_XDECREF(mkw);
-            Py_DECREF(bases);
-            return NULL;
+            ns = PyDict_New();
         }
     }
     else {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -71,11 +71,10 @@ update_bases(PyObject *bases, PyObject *const *args, int nargs)
             }
             continue;
         }
-        meth = _PyObject_GetAttrIdWithoutError(base, &PyId___mro_entries__);
+        if (_PyObject_LookupAttrId(base, &PyId___mro_entries__, &meth) < 0) {
+            goto error;
+        }
         if (!meth) {
-            if (PyErr_Occurred()) {
-                goto error;
-            }
             if (new_bases) {
                 if (PyList_Append(new_bases, base) < 0) {
                     goto error;
@@ -217,14 +216,11 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
     }
     /* else: meta is not a class, so we cannot do the metaclass
        calculation, so we will use the explicitly given object as it is */
-    prep = _PyObject_GetAttrIdWithoutError(meta, &PyId___prepare__);
-    if (prep == NULL) {
-        if (PyErr_Occurred()) {
-            ns = NULL;
-        }
-        else {
-            ns = PyDict_New();
-        }
+    if (_PyObject_LookupAttrId(meta, &PyId___prepare__, &prep) < 0) {
+        ns = NULL;
+    }
+    else if (prep == NULL) {
+        ns = PyDict_New();
     }
     else {
         PyObject *pargs[2] = {name, bases};
@@ -1122,8 +1118,7 @@ builtin_getattr(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
         return NULL;
     }
     if (dflt != NULL) {
-        result = _PyObject_GetAttrWithoutError(v, name);
-        if (result == NULL && !PyErr_Occurred()) {
+        if (_PyObject_LookupAttr(v, name, &result) == 0) {
             Py_INCREF(dflt);
             return dflt;
         }
@@ -1186,12 +1181,11 @@ builtin_hasattr_impl(PyObject *module, PyObject *obj, PyObject *name)
                         "hasattr(): attribute name must be string");
         return NULL;
     }
-    v = _PyObject_GetAttrWithoutError(obj, name);
-    if (v == NULL) {
-        if (!PyErr_Occurred()) {
-            Py_RETURN_FALSE;
-        }
+    if (_PyObject_LookupAttr(obj, name, &v) < 0) {
         return NULL;
+    }
+    if (v == NULL) {
+        Py_RETURN_FALSE;
     }
     Py_DECREF(v);
     Py_RETURN_TRUE;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4798,13 +4798,12 @@ import_from(PyObject *v, PyObject *name)
     _Py_IDENTIFIER(__name__);
     PyObject *fullmodname, *pkgname, *pkgpath, *pkgname_or_unknown, *errmsg;
 
-    x = PyObject_GetAttr(v, name);
-    if (x != NULL || !PyErr_ExceptionMatches(PyExc_AttributeError))
+    x = _PyObject_GetAttrWithoutError(v, name);
+    if (x != NULL || PyErr_Occurred())
         return x;
     /* Issue #17636: in case this failed because of a circular relative
        import, try to fallback on reading the module directly from
        sys.modules. */
-    PyErr_Clear();
     pkgname = _PyObject_GetAttrId(v, &PyId___name__);
     if (pkgname == NULL) {
         goto error;
@@ -4866,21 +4865,20 @@ import_all_from(PyObject *locals, PyObject *v)
 {
     _Py_IDENTIFIER(__all__);
     _Py_IDENTIFIER(__dict__);
-    PyObject *all = _PyObject_GetAttrId(v, &PyId___all__);
+    PyObject *all = _PyObject_GetAttrIdWithoutError(v, &PyId___all__);
     PyObject *dict, *name, *value;
     int skip_leading_underscores = 0;
     int pos, err;
 
     if (all == NULL) {
-        if (!PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_Occurred())
             return -1; /* Unexpected error */
-        PyErr_Clear();
-        dict = _PyObject_GetAttrId(v, &PyId___dict__);
+        dict = _PyObject_GetAttrIdWithoutError(v, &PyId___dict__);
         if (dict == NULL) {
-            if (!PyErr_ExceptionMatches(PyExc_AttributeError))
-                return -1;
-            PyErr_SetString(PyExc_ImportError,
-            "from-import-* object has no __dict__ and no __all__");
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_ImportError,
+                    "from-import-* object has no __dict__ and no __all__");
+            }
             return -1;
         }
         all = PyMapping_Keys(dict);

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -540,13 +540,11 @@ PyObject * _PyCodec_LookupTextEncoding(const char *encoding,
      * attribute.
      */
     if (!PyTuple_CheckExact(codec)) {
-        attr = _PyObject_GetAttrIdWithoutError(codec, &PyId__is_text_encoding);
-        if (attr == NULL) {
-            if (PyErr_Occurred()) {
-                Py_DECREF(codec);
-                return NULL;
-            }
-        } else {
+        if (_PyObject_LookupAttrId(codec, &PyId__is_text_encoding, &attr) < 0) {
+            Py_DECREF(codec);
+            return NULL;
+        }
+        if (attr != NULL) {
             is_text_codec = PyObject_IsTrue(attr);
             Py_DECREF(attr);
             if (is_text_codec <= 0) {

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -540,11 +540,9 @@ PyObject * _PyCodec_LookupTextEncoding(const char *encoding,
      * attribute.
      */
     if (!PyTuple_CheckExact(codec)) {
-        attr = _PyObject_GetAttrId(codec, &PyId__is_text_encoding);
+        attr = _PyObject_GetAttrIdWithoutError(codec, &PyId__is_text_encoding);
         if (attr == NULL) {
-            if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
-                PyErr_Clear();
-            } else {
+            if (PyErr_Occurred()) {
                 Py_DECREF(codec);
                 return NULL;
             }


### PR DESCRIPTION
Add `_PyObject_LookupAttr()` and `_PyObject_LookupAttrId()` and use them in appropriate cases instead of `PyObject_GetAttr()`, `_PyObject_GetAttrId()` and `_PyObject_GetAttrIdWithoutError()`.

<!-- issue-number: bpo-32571 -->
https://bugs.python.org/issue32571
<!-- /issue-number -->
