### PR TITLE
bpo-32589: Statistics as a result from timeit

### DIFF
--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -172,7 +172,7 @@ class Timer:
         to one million.  The main statement, the setup statement and
         the timer function to be used are passed to the constructor.
 
-        If 'stats' is True a dictionary is with more information is 
+        If 'stats' is True a dictionary is with more information is
         returned. The keys are 'mean', 'median', 'stdev'
         (statistics.pstdev), 'variance' (statistics.pvariance) and
         total.
@@ -198,7 +198,7 @@ class Timer:
         else:
             return sum(timing)
 
-    def repeat(self, repeat=default_repeat, number=default_number, 
+    def repeat(self, repeat=default_repeat, number=default_number,
                stats=default_statistics):
         """Call timeit() a few times.
 
@@ -252,7 +252,7 @@ def timeit(stmt="pass", setup="pass", timer=default_timer,
     return Timer(stmt, setup, timer, globals).timeit(number, stats)
 
 def repeat(stmt="pass", setup="pass", timer=default_timer,
-           repeat=default_repeat, number=default_number, globals=None, 
+           repeat=default_repeat, number=default_number, globals=None,
            stats=default_statistics):
     """Convenience function to create Timer object and call repeat method."""
     return Timer(stmt, setup, timer, globals).repeat(repeat, number, stats)

--- a/Lib/timeit.py
+++ b/Lib/timeit.py
@@ -189,8 +189,10 @@ class Timer:
             import statistics
             result = {'mean': statistics.mean(timing),
                       'median': statistics.median(timing),
-                      'stdev': statistics.pstdev(timing),
-                      'variance': statistics.pvariance(timing),
+                      'stdev': statistics.stdev(timing),
+                      'variance': statistics.variance(timing),
+                      'pstdev': statistics.pstdev(timing),
+                      'pvariance': statistics.pvariance(timing),
                       'total': sum(timing)}
             return result
         else:

--- a/Misc/NEWS.d/next/Library/2018-01-19-11-52-46.bpo-32589.dD0x7A.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-19-11-52-46.bpo-32589.dD0x7A.rst
@@ -1,0 +1,1 @@
+Added statistics output to timeit module


### PR DESCRIPTION
Add stats flag in timeit function. This should
return a dictionary with additional statistics
information.

Resolves [bpo 32589](https://bugs.python.org/issue32589)

<!-- issue-number: bpo-32589 -->
https://bugs.python.org/issue32589
<!-- /issue-number -->
