### PR TITLE
bpo-9566: Fix size_t=>int downcast warnings

### DIFF
--- a/Modules/clinic/gcmodule.c.h
+++ b/Modules/clinic/gcmodule.c.h
@@ -307,22 +307,22 @@ PyDoc_STRVAR(gc_get_freeze_count__doc__,
 #define GC_GET_FREEZE_COUNT_METHODDEF    \
     {"get_freeze_count", (PyCFunction)gc_get_freeze_count, METH_NOARGS, gc_get_freeze_count__doc__},
 
-static int
+static Py_ssize_t
 gc_get_freeze_count_impl(PyObject *module);
 
 static PyObject *
 gc_get_freeze_count(PyObject *module, PyObject *Py_UNUSED(ignored))
 {
     PyObject *return_value = NULL;
-    int _return_value;
+    Py_ssize_t _return_value;
 
     _return_value = gc_get_freeze_count_impl(module);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
-    return_value = PyLong_FromLong((long)_return_value);
+    return_value = PyLong_FromSsize_t(_return_value);
 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6f9ee4d8dd1f36c1 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=21dc9270b10b7891 input=a9049054013a1b77]*/

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1449,14 +1449,14 @@ gc_unfreeze_impl(PyObject *module)
 }
 
 /*[clinic input]
-gc.get_freeze_count -> int
+gc.get_freeze_count -> Py_ssize_t
 
 Return the number of objects in the permanent generation.
 [clinic start generated code]*/
 
-static int
+static Py_ssize_t
 gc_get_freeze_count_impl(PyObject *module)
-/*[clinic end generated code: output=e4e2ebcc77e5cbf3 input=4b759db880a3c6e4]*/
+/*[clinic end generated code: output=61cbd9f43aa032e1 input=45ffbc65cfe2a6ed]*/
 {
     return gc_list_size(&_PyRuntime.gc.permanent_generation.head);
 }

--- a/Python/ast_opt.c
+++ b/Python/ast_opt.c
@@ -397,7 +397,7 @@ fold_compare(expr_ty node, PyArena *arena, int optimize)
 {
     asdl_int_seq *ops;
     asdl_seq *args;
-    int i;
+    Py_ssize_t i;
 
     ops = node->v.Compare.ops;
     args = node->v.Compare.comparators;

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -52,9 +52,9 @@ _Py_IDENTIFIER(stderr);
 #include "clinic/bltinmodule.c.h"
 
 static PyObject*
-update_bases(PyObject *bases, PyObject *const *args, int nargs)
+update_bases(PyObject *bases, PyObject *const *args, Py_ssize_t nargs)
 {
-    int i, j;
+    Py_ssize_t i, j;
     PyObject *base, *meth, *new_base, *result, *new_bases = NULL;
     PyObject *stack[1] = {bases};
     assert(PyTuple_Check(bases));

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -367,13 +367,12 @@ _Py_FindEnvConfigValue(FILE *env_file, const wchar_t *key,
     fseek(env_file, 0, SEEK_SET);
     while (!feof(env_file)) {
         char * p = fgets(buffer, MAXPATHLEN*2, env_file);
-        wchar_t *tmpbuffer;
-        int n;
 
         if (p == NULL) {
             break;
         }
-        n = strlen(p);
+
+        size_t n = strlen(p);
         if (p[n - 1] != '\n') {
             /* line has overflowed - bail */
             break;
@@ -382,7 +381,8 @@ _Py_FindEnvConfigValue(FILE *env_file, const wchar_t *key,
             /* Comment - skip */
             continue;
         }
-        tmpbuffer = _Py_DecodeUTF8_surrogateescape(buffer, n);
+
+        wchar_t *tmpbuffer = _Py_DecodeUTF8_surrogateescape(buffer, n);
         if (tmpbuffer) {
             wchar_t * state;
             wchar_t * tok = wcstok(tmpbuffer, L" \t\r\n", &state);


### PR DESCRIPTION
Use wider types (int => Py_ssize_t) to avoid integer overflows.

<!-- issue-number: bpo-9566 -->
https://bugs.python.org/issue9566
<!-- /issue-number -->
