### PR TITLE
bpo-32593: distutils UnixCCompiler: remove FreeBSD special case

### DIFF
--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -227,8 +227,6 @@ class UnixCCompiler(CCompiler):
         if sys.platform[:6] == "darwin":
             # MacOSX's linker doesn't understand the -R flag at all
             return "-L" + dir
-        elif sys.platform[:7] == "freebsd":
-            return "-Wl,-rpath=" + dir
         elif sys.platform[:5] == "hp-ux":
             if self._is_gcc(compiler):
                 return ["-Wl,+s", "-L" + dir]


### PR DESCRIPTION
There is no need to have a special case for FreeBSD.
FreeBSD can share the same code than Linux.

<!-- issue-number: bpo-32593 -->
https://bugs.python.org/issue32593
<!-- /issue-number -->
