### PR TITLE
bpo-26163: Frozenset hash improvement

### DIFF
--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -795,7 +795,7 @@ frozenset_hash(PyObject *self)
     hash ^= ((Py_uhash_t)PySet_GET_SIZE(self) + 1) * 1927868237UL;
 
     /* Disperse patterns arising in nested frozensets */
-    hash ^= (hash >> 11) ^ (~hash >> 25);
+    hash ^= (hash >> 11) ^ (hash >> 25);
     hash = hash * 69069U + 907133923UL;
 
     /* -1 is reserved as an error code */


### PR DESCRIPTION
The bit inversion didn't improve the dispersion statistics, so it is unnecessary and can be removed.

<!-- issue-number: bpo-26163 -->
https://bugs.python.org/issue26163
<!-- /issue-number -->
