### PR TITLE
[2.7] bpo-32586: Fix fully qualified exception in Docs for urllib2 HOWTO

### DIFF
--- a/Doc/howto/urllib2.rst
+++ b/Doc/howto/urllib2.rst
@@ -203,7 +203,7 @@ e.g. ::
 
     >>> req = urllib2.Request('http://www.pretend_server.org')
     >>> try: urllib2.urlopen(req)
-    ... except URLError as e:
+    ... except urllib2.URLError as e:
     ...    print e.reason   #doctest: +SKIP
     ...
     (4, 'getaddrinfo failed')


### PR DESCRIPTION


<!-- issue-number: bpo-32586 -->
https://bugs.python.org/issue32586
<!-- /issue-number -->
