### PR TITLE
bpo-31848: Fix broken error handling in Aifc_read.initfp() when the SSND chunk is not found

### DIFF
--- a/Lib/aifc.py
+++ b/Lib/aifc.py
@@ -322,6 +322,7 @@ class Aifc_read:
         else:
             raise Error('not an AIFF or AIFF-C file')
         self._comm_chunk_read = 0
+        self._ssnd_chunk = None
         while 1:
             self._ssnd_seek_needed = 1
             try:

--- a/Lib/test/test_aifc.py
+++ b/Lib/test/test_aifc.py
@@ -266,6 +266,14 @@ class AIFCLowLevelTest(unittest.TestCase):
         b = io.BytesIO(b'FORM' + struct.pack('>L', 4) + b'AIFF')
         self.assertRaises(aifc.Error, aifc.open, b)
 
+    def test_read_no_ssnd_chunk(self):
+        b = b'FORM' + struct.pack('>L', 4) + b'AIFC'
+        b += b'COMM' + struct.pack('>LhlhhLL', 38, 0, 0, 0, 0, 0, 0)
+        b += b'NONE' + struct.pack('B', 14) + b'not compressed' + b'\x00'
+        with self.assertRaisesRegex(aifc.Error, 'COMM chunk and/or SSND chunk'
+                                                ' missing'):
+            aifc.open(io.BytesIO(b))
+
     def test_read_wrong_compression_type(self):
         b = b'FORM' + struct.pack('>L', 4) + b'AIFC'
         b += b'COMM' + struct.pack('>LhlhhLL', 23, 0, 0, 0, 0, 0, 0)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1505,6 +1505,7 @@ Nicholas Spies
 Per Spilling
 Joshua Spoerri
 Noah Spurrier
+Zackery Spytz
 Nathan Srebro
 RajGopal Srinivasan
 Tage Stabell-Kulo

--- a/Misc/NEWS.d/next/Library/2018-01-18-23-34-17.bpo-31848.M2cldy.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-18-23-34-17.bpo-31848.M2cldy.rst
@@ -1,0 +1,1 @@
+Fix error handling in Aifc_read.initfp() when the SSND chunk is not found.

--- a/Misc/NEWS.d/next/Library/2018-01-18-23-34-17.bpo-31848.M2cldy.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-18-23-34-17.bpo-31848.M2cldy.rst
@@ -1,1 +1,2 @@
-Fix error handling in Aifc_read.initfp() when the SSND chunk is not found.
+Fix the error handling in Aifc_read.initfp() when the SSND chunk is not found.
+Patch by Zackery Spytz.


### PR DESCRIPTION
Initialize self._ssnd_chunk so that aifc.Error is raised as intended,
not AttributeError.

This mirrors what is done in [Wave_read.initfp()](https://github.com/python/cpython/blob/9f914a01affc55abe799afc521ce71612bb495a5/Lib/wave.py#L135) for self._data_chunk.


<!-- issue-number: bpo-31848 -->
https://bugs.python.org/issue31848
<!-- /issue-number -->
