### PR TITLE
bpo-32311: Drop asyncio.create_task

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -377,17 +377,6 @@ with the result.
 Task
 ----
 
-.. function:: create_task(coro)
-
-   Wrap a :ref:`coroutine <coroutine>` *coro* into a task and schedule
-   its execution.  Return the task object.
-
-   The task is executed in :func:`get_running_loop` context,
-   :exc:`RuntimeError` is raised if there is no running loop in
-   current thread.
-
-   .. versionadded:: 3.7
-
 .. class:: Task(coro, \*, loop=None)
 
    A unit for concurrent running of :ref:`coroutines <coroutine>`,
@@ -416,7 +405,7 @@ Task
    <coroutine>` did not complete. It is probably a bug and a warning is
    logged: see :ref:`Pending task destroyed <asyncio-pending-task-destroyed>`.
 
-   Don't directly create :class:`Task` instances: use the :func:`create_task`
+   Don't directly create :class:`Task` instances: use the :func:`ensure_future`
    function or the :meth:`AbstractEventLoop.create_task` method.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
@@ -586,15 +575,9 @@ Task functions
    .. versionchanged:: 3.5.1
       The function accepts any :term:`awaitable` object.
 
-   .. note::
-
-      :func:`create_task` (added in Python 3.7) is the preferable way
-      for spawning new tasks.
-
    .. seealso::
 
-      The :func:`create_task` function and
-      :meth:`AbstractEventLoop.create_task` method.
+      The :meth:`AbstractEventLoop.create_task` method.
 
 .. function:: wrap_future(future, \*, loop=None)
 

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -1,7 +1,7 @@
 """Support for tasks, coroutines and the scheduler."""
 
 __all__ = (
-    'Task', 'create_task',
+    'Task',
     'FIRST_COMPLETED', 'FIRST_EXCEPTION', 'ALL_COMPLETED',
     'wait', 'wait_for', 'as_completed', 'sleep',
     'gather', 'shield', 'ensure_future', 'run_coroutine_threadsafe',
@@ -292,15 +292,6 @@ except ImportError:
 else:
     # _CTask is needed for tests.
     Task = _CTask = _asyncio.Task
-
-
-def create_task(coro):
-    """Schedule the execution of a coroutine object in a spawn task.
-
-    Return a Task object.
-    """
-    loop = events.get_running_loop()
-    return loop.create_task(coro)
 
 
 # wait() and as_completed() similar to those in PEP 3148.

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2163,19 +2163,6 @@ class BaseTaskTests:
         self.assertIsInstance(task, self.Task)
         self.assertEqual(self.loop.run_until_complete(task), 42)
 
-    def test_bare_create_task(self):
-
-        async def inner():
-            return 1
-
-        async def coro():
-            task = asyncio.create_task(inner())
-            self.assertIsInstance(task, self.Task)
-            ret = await task
-            self.assertEqual(1, ret)
-
-        self.loop.run_until_complete(coro())
-
 
 def add_subclass_tests(cls):
     BaseTask = cls.Task

--- a/Misc/NEWS.d/3.7.0a4.rst
+++ b/Misc/NEWS.d/3.7.0a4.rst
@@ -410,15 +410,6 @@ unified API for reading resources contained within packages.  Also add
 
 ..
 
-.. bpo: 32311
-.. date: 2017-12-14-17-28-54
-.. nonce: DL5Ytn
-.. section: Library
-
-Implement asyncio.create_task(coro) shortcut
-
-..
-
 .. bpo: 32327
 .. date: 2017-12-14-16-00-25
 .. nonce: bbkSxA


### PR DESCRIPTION
As discussed with @1st1 `asyncio.create_task` should not be exposed.

<!-- issue-number: bpo-32311 -->
https://bugs.python.org/issue32311
<!-- /issue-number -->
