### PR TITLE
bpo-32601: Skip PosixPathTest.test_expanduser if no other user is found

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2145,6 +2145,9 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
             otherhome = pwdent.pw_dir.rstrip('/')
             if othername != username and otherhome:
                 break
+        else:
+            othername = username
+            otherhome = userhome
 
         p1 = P('~/Documents')
         p2 = P('~' + username + '/Documents')


### PR DESCRIPTION
This happens in the NixOS build sandbox, for example, where the only other user is nobody with home directory /.

<!-- issue-number: bpo-32601 -->
https://bugs.python.org/issue32601
<!-- /issue-number -->
