### PR TITLE
bpo-32591: Add native coroutine origin tracking

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -215,6 +215,10 @@ attributes:
 +-----------+-------------------+---------------------------+
 |           | cr_code           | code                      |
 +-----------+-------------------+---------------------------+
+|           | cr_origin         | where coroutine was       |
+|           |                   | created, if coroutine     |
+|           |                   | origin tracking is enabled|
++-----------+-------------------+---------------------------+
 | builtin   | __doc__           | documentation string      |
 +-----------+-------------------+---------------------------+
 |           | __name__          | original name of this     |
@@ -234,6 +238,9 @@ attributes:
    The ``__name__`` attribute of generators is now set from the function
    name, instead of the code name, and it can now be modified.
 
+.. versionchanged:: 3.7
+
+   Add ``cr_origin`` attribute to coroutines.
 
 .. function:: getmembers(object[, predicate])
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -34,6 +34,9 @@ provided as convenient choices for the second argument to :func:`getmembers`.
 They also help you determine when you can expect to find the following special
 attributes:
 
+.. this function name is too big to fit in the ascii-art table below
+.. |coroutine-origin-link| replace:: :func:`sys.set_coroutine_origin_tracking_depth`
+
 +-----------+-------------------+---------------------------+
 | Type      | Attribute         | Description               |
 +===========+===================+===========================+
@@ -216,8 +219,8 @@ attributes:
 |           | cr_code           | code                      |
 +-----------+-------------------+---------------------------+
 |           | cr_origin         | where coroutine was       |
-|           |                   | created, if coroutine     |
-|           |                   | origin tracking is enabled|
+|           |                   | created, or ``None``. See |
+|           |                   | |coroutine-origin-link|   |
 +-----------+-------------------+---------------------------+
 | builtin   | __doc__           | documentation string      |
 +-----------+-------------------+---------------------------+

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -675,6 +675,18 @@ always available.
       for details.)
 
 
+.. function:: get_coroutine_origin_tracking_depth()
+
+   Get the current coroutine origin tracking depth, as set by
+   func:`set_coroutine_origin_tracking_depth`.
+
+   .. versionadded:: 3.7
+
+   .. note::
+      This function has been added on a provisional basis (see :pep:`411`
+      for details.)  Use it only for debugging purposes.
+
+
 .. function:: get_coroutine_wrapper()
 
    Returns ``None``, or a wrapper set by :func:`set_coroutine_wrapper`.
@@ -1228,8 +1240,6 @@ always available.
    To enable, pass a *depth* value greater than zero; this sets the
    number of frames whose information will be captured. To disable,
    pass set *depth* to zero.
-
-   Returns the old value of *depth*.
 
    This setting is thread-specific.
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -686,6 +686,10 @@ always available.
       This function has been added on a provisional basis (see :pep:`411`
       for details.)  Use it only for debugging purposes.
 
+   .. deprecated:: 3.7
+      The coroutine wrapper functionality has been deprecated, and
+      will be removed in 3.8. See :issue:`32591` for details.
+
 
 .. data:: hash_info
 
@@ -1217,8 +1221,9 @@ always available.
    Allows enabling or disabling coroutine origin tracking. When
    enabled, the ``cr_origin`` attribute on coroutine objects will
    contain a list of (filename, line number, function name) tuples
-   describing the traceback where the coroutine object was created.
-   When disabled, ``cr_origin`` will be None.
+   describing the traceback where the coroutine object was created,
+   with the most recent call first. When disabled, ``cr_origin`` will
+   be None.
 
    To enable, pass a *depth* value greater than zero; this sets the
    number of frames whose information will be captured. To disable,
@@ -1226,7 +1231,7 @@ always available.
 
    Returns the old value of *depth*.
 
-   This setting is thread-local.
+   This setting is thread-specific.
 
    .. versionadded:: 3.7
 
@@ -1272,6 +1277,10 @@ always available.
    .. note::
       This function has been added on a provisional basis (see :pep:`411`
       for details.)  Use it only for debugging purposes.
+
+   .. deprecated:: 3.7
+      The coroutine wrapper functionality has been deprecated, and
+      will be removed in 3.8. See :issue:`32591` for details.
 
 .. function:: _enablelegacywindowsfsencoding()
 

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1232,7 +1232,7 @@ always available.
 
    Allows enabling or disabling coroutine origin tracking. When
    enabled, the ``cr_origin`` attribute on coroutine objects will
-   contain a list of (filename, line number, function name) tuples
+   contain a tuple of (filename, line number, function name) tuples
    describing the traceback where the coroutine object was created,
    with the most recent call first. When disabled, ``cr_origin`` will
    be None.

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1212,6 +1212,27 @@ always available.
       This function has been added on a provisional basis (see :pep:`411`
       for details.)
 
+.. function:: set_coroutine_origin_tracking_depth(depth)
+
+   Allows enabling or disabling coroutine origin tracking. When
+   enabled, the ``cr_origin`` attribute on coroutine objects will
+   contain a list of (filename, line number, function name) tuples
+   describing the traceback where the coroutine object was created.
+   When disabled, ``cr_origin`` will be None.
+
+   To enable, pass a *depth* value greater than zero; this sets the
+   number of frames whose information will be captured. To disable,
+   pass set *depth* to zero.
+
+   Returns the old value of *depth*.
+
+   This setting is thread-local.
+
+   .. versionadded:: 3.7
+
+   .. note::
+      This function has been added on a provisional basis (see :pep:`411`
+      for details.)  Use it only for debugging purposes.
 
 .. function:: set_coroutine_wrapper(wrapper)
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -510,6 +510,9 @@ sys
 
 Added :attr:`sys.flags.dev_mode` flag for the new development mode.
 
+Deprecated :func:`sys.set_coroutine_wrapper` and
+:func:`sys.get_coroutine_wrapper`.
+
 time
 ----
 

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -31,6 +31,7 @@ PyAPI_FUNC(PyObject *) PyEval_CallMethod(PyObject *obj,
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(void) PyEval_SetProfile(Py_tracefunc, PyObject *);
 PyAPI_FUNC(void) PyEval_SetTrace(Py_tracefunc, PyObject *);
+PyAPI_FUNC(int) _PyEval_SetCoroutineOriginTrackingDepth(int new_depth);
 PyAPI_FUNC(void) _PyEval_SetCoroutineWrapper(PyObject *);
 PyAPI_FUNC(PyObject *) _PyEval_GetCoroutineWrapper(void);
 PyAPI_FUNC(void) _PyEval_SetAsyncGenFirstiter(PyObject *);

--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -31,7 +31,8 @@ PyAPI_FUNC(PyObject *) PyEval_CallMethod(PyObject *obj,
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(void) PyEval_SetProfile(Py_tracefunc, PyObject *);
 PyAPI_FUNC(void) PyEval_SetTrace(Py_tracefunc, PyObject *);
-PyAPI_FUNC(int) _PyEval_SetCoroutineOriginTrackingDepth(int new_depth);
+PyAPI_FUNC(void) _PyEval_SetCoroutineOriginTrackingDepth(int new_depth);
+PyAPI_FUNC(int) _PyEval_GetCoroutineOriginTrackingDepth(void);
 PyAPI_FUNC(void) _PyEval_SetCoroutineWrapper(PyObject *);
 PyAPI_FUNC(PyObject *) _PyEval_GetCoroutineWrapper(void);
 PyAPI_FUNC(void) _PyEval_SetAsyncGenFirstiter(PyObject *);

--- a/Include/genobject.h
+++ b/Include/genobject.h
@@ -51,6 +51,7 @@ PyAPI_FUNC(void) _PyGen_Finalize(PyObject *self);
 #ifndef Py_LIMITED_API
 typedef struct {
     _PyGenObject_HEAD(cr)
+    PyObject *cr_origin;
 } PyCoroObject;
 
 PyAPI_DATA(PyTypeObject) PyCoro_Type;

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -262,6 +262,8 @@ typedef struct _ts {
     void (*on_delete)(void *);
     void *on_delete_data;
 
+    int coroutine_origin_tracking_depth;
+
     PyObject *coroutine_wrapper;
     int in_coroutine_wrapper;
 

--- a/Include/warnings.h
+++ b/Include/warnings.h
@@ -56,6 +56,10 @@ PyErr_WarnExplicitFormat(PyObject *category,
 #define PyErr_Warn(category, msg) PyErr_WarnEx(category, msg, 1)
 #endif
 
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(void) _PyErr_WarnUnawaitedCoroutine(PyObject *coro);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Include/warnings.h
+++ b/Include/warnings.h
@@ -57,7 +57,7 @@ PyErr_WarnExplicitFormat(PyObject *category,
 #endif
 
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(void) _PyErr_WarnUnawaitedCoroutine(PyObject *coro);
+void _PyErr_WarnUnawaitedCoroutine(PyObject *coro);
 #endif
 
 #ifdef __cplusplus

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1539,8 +1539,9 @@ class BaseEventLoop(events.AbstractEventLoop):
 
         if enabled:
             self._coroutine_origin_tracking_saved_depth = (
-                sys.set_coroutine_origin_tracking_depth(
-                    constants.DEBUG_STACK_DEPTH))
+                sys.get_coroutine_origin_tracking_depth())
+            sys.set_coroutine_origin_tracking_depth(
+                constants.DEBUG_STACK_DEPTH)
         else:
             sys.set_coroutine_origin_tracking_depth(
                 self._coroutine_origin_tracking_saved_depth)

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -1555,4 +1555,4 @@ class BaseEventLoop(events.AbstractEventLoop):
         self._debug = enabled
 
         if self.is_running():
-            self._set_coroutine_wrapper(enabled)
+            self.call_soon_threadsafe(self._set_coroutine_origin_tracking, enabled)

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -40,6 +40,7 @@ from . import futures
 from . import sslproto
 from . import tasks
 from .log import logger
+from .constants import DEBUG_STACK_DEPTH
 
 
 __all__ = 'BaseEventLoop',
@@ -224,7 +225,8 @@ class BaseEventLoop(events.AbstractEventLoop):
         self.slow_callback_duration = 0.1
         self._current_handle = None
         self._task_factory = None
-        self._coroutine_wrapper_set = False
+        self._coroutine_origin_tracking_enabled = False
+        self._coroutine_origin_tracking_saved_depth = None
 
         if hasattr(sys, 'get_asyncgen_hooks'):
             # Python >= 3.6
@@ -382,7 +384,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         if events._get_running_loop() is not None:
             raise RuntimeError(
                 'Cannot run the event loop while another loop is running')
-        self._set_coroutine_wrapper(self._debug)
+        self._set_coroutine_origin_tracking(self._debug)
         self._thread_id = threading.get_ident()
         if self._asyncgens is not None:
             old_agen_hooks = sys.get_asyncgen_hooks()
@@ -398,7 +400,7 @@ class BaseEventLoop(events.AbstractEventLoop):
             self._stopping = False
             self._thread_id = None
             events._set_running_loop(None)
-            self._set_coroutine_wrapper(False)
+            self._set_coroutine_origin_tracking(False)
             if self._asyncgens is not None:
                 sys.set_asyncgen_hooks(*old_agen_hooks)
 
@@ -1531,39 +1533,20 @@ class BaseEventLoop(events.AbstractEventLoop):
                 handle._run()
         handle = None  # Needed to break cycles when an exception occurs.
 
-    def _set_coroutine_wrapper(self, enabled):
-        try:
-            set_wrapper = sys.set_coroutine_wrapper
-            get_wrapper = sys.get_coroutine_wrapper
-        except AttributeError:
+    def _set_coroutine_origin_tracking(self, enabled):
+        if enabled == self._coroutine_origin_tracking_enabled:
             return
-
-        enabled = bool(enabled)
-        if self._coroutine_wrapper_set == enabled:
-            return
-
-        wrapper = coroutines.debug_wrapper
-        current_wrapper = get_wrapper()
 
         if enabled:
-            if current_wrapper not in (None, wrapper):
-                warnings.warn(
-                    f"loop.set_debug(True): cannot set debug coroutine "
-                    f"wrapper; another wrapper is already set "
-                    f"{current_wrapper!r}",
-                    RuntimeWarning)
-            else:
-                set_wrapper(wrapper)
-                self._coroutine_wrapper_set = True
+            self._coroutine_origin_tracking_saved_depth = (
+                sys.set_coroutine_origin_tracking_depth(DEBUG_STACK_DEPTH)
+            )
         else:
-            if current_wrapper not in (None, wrapper):
-                warnings.warn(
-                    f"loop.set_debug(False): cannot unset debug coroutine "
-                    f"wrapper; another wrapper was set {current_wrapper!r}",
-                    RuntimeWarning)
-            else:
-                set_wrapper(None)
-                self._coroutine_wrapper_set = False
+            sys.set_coroutine_origin_tracking_depth(
+                self._coroutine_origin_tracking_saved_depth
+            )
+
+        self._coroutine_origin_tracking_enabled = enabled
 
     def get_debug(self):
         return self._debug

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -34,13 +34,13 @@ try:
 except ImportError:  # pragma: no cover
     ssl = None
 
+from . import constants
 from . import coroutines
 from . import events
 from . import futures
 from . import sslproto
 from . import tasks
 from .log import logger
-from .constants import DEBUG_STACK_DEPTH
 
 
 __all__ = 'BaseEventLoop',
@@ -1534,17 +1534,16 @@ class BaseEventLoop(events.AbstractEventLoop):
         handle = None  # Needed to break cycles when an exception occurs.
 
     def _set_coroutine_origin_tracking(self, enabled):
-        if enabled == self._coroutine_origin_tracking_enabled:
+        if bool(enabled) == bool(self._coroutine_origin_tracking_enabled):
             return
 
         if enabled:
             self._coroutine_origin_tracking_saved_depth = (
-                sys.set_coroutine_origin_tracking_depth(DEBUG_STACK_DEPTH)
-            )
+                sys.set_coroutine_origin_tracking_depth(
+                    constants.DEBUG_STACK_DEPTH))
         else:
             sys.set_coroutine_origin_tracking_depth(
-                self._coroutine_origin_tracking_saved_depth
-            )
+                self._coroutine_origin_tracking_saved_depth)
 
         self._coroutine_origin_tracking_enabled = enabled
 

--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -79,39 +79,16 @@ class CoroWrapper:
         return self.gen.gi_code
 
     def __await__(self):
-        cr_await = getattr(self.gen, 'cr_await', None)
-        if cr_await is not None:
-            raise RuntimeError(
-                f"Cannot await on coroutine {self.gen!r} while it's "
-                f"awaiting for {cr_await!r}")
         return self
 
     @property
     def gi_yieldfrom(self):
         return self.gen.gi_yieldfrom
 
-    @property
-    def cr_await(self):
-        return self.gen.cr_await
-
-    @property
-    def cr_running(self):
-        return self.gen.cr_running
-
-    @property
-    def cr_code(self):
-        return self.gen.cr_code
-
-    @property
-    def cr_frame(self):
-        return self.gen.cr_frame
-
     def __del__(self):
         # Be careful accessing self.gen.frame -- self.gen might not exist.
         gen = getattr(self, 'gen', None)
         frame = getattr(gen, 'gi_frame', None)
-        if frame is None:
-            frame = getattr(gen, 'cr_frame', None)
         if frame is not None and frame.f_lasti == -1:
             msg = f'{self!r} was never yielded from'
             tb = getattr(self, '_source_traceback', ())

--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -32,14 +32,6 @@ def _is_debug_mode():
 _DEBUG = _is_debug_mode()
 
 
-def debug_wrapper(gen):
-    # This function is called from 'sys.set_coroutine_wrapper'.
-    # We only wrap here coroutines defined via 'async def' syntax.
-    # Generator-based coroutines are wrapped in @coroutine
-    # decorator.
-    return CoroWrapper(gen, None)
-
-
 class CoroWrapper:
     # Wrapper for coroutine object in _DEBUG mode.
 
@@ -141,8 +133,6 @@ def coroutine(func):
     if inspect.iscoroutinefunction(func):
         # In Python 3.5 that's all we need to do for coroutines
         # defined with "async def".
-        # Wrapping in CoroWrapper will happen via
-        # 'sys.set_coroutine_wrapper' function.
         return func
 
     if inspect.isgeneratorfunction(func):

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -1,5 +1,6 @@
 """Tests support for new syntax introduced by PEP 492."""
 
+import sys
 import types
 import unittest
 
@@ -148,35 +149,19 @@ class CoroutineTests(BaseTest):
         data = self.loop.run_until_complete(foo())
         self.assertEqual(data, 'spam')
 
-    @mock.patch('asyncio.coroutines.logger')
-    def test_async_def_wrapped(self, m_log):
-        async def foo():
-            pass
-        async def start():
-            foo_coro = foo()
-            self.assertRegex(
-                repr(foo_coro),
-                r'<CoroWrapper .*\.foo\(\) running at .*pep492.*>')
+    def test_debug_mode_manages_coroutine_origin_tracking(self):
+        def get_depth():
+            depth = sys.set_coroutine_origin_tracking_depth(0)
+            sys.set_coroutine_origin_tracking_depth(depth)
+            return depth
 
-            with support.check_warnings((r'.*foo.*was never',
-                                         RuntimeWarning)):
-                foo_coro = None
-                support.gc_collect()
-                self.assertTrue(m_log.error.called)
-                message = m_log.error.call_args[0][0]
-                self.assertRegex(message,
-                                 r'CoroWrapper.*foo.*was never')
+        async def start():
+            self.assertTrue(get_depth() > 0)
 
         self.loop.set_debug(True)
         self.loop.run_until_complete(start())
 
-        async def start():
-            foo_coro = foo()
-            task = asyncio.ensure_future(foo_coro, loop=self.loop)
-            self.assertRegex(repr(task), r'Task.*foo.*running')
-
-        self.loop.run_until_complete(start())
-
+        self.assertEqual(get_depth(), 0)
 
     def test_types_coroutine(self):
         def gen():
@@ -226,9 +211,9 @@ class CoroutineTests(BaseTest):
                 t.cancel()
 
         self.loop.set_debug(True)
-        with self.assertRaisesRegex(
-            RuntimeError,
-            r'Cannot await.*test_double_await.*\bafunc\b.*while.*\bsleep\b'):
+        with self.assertRaises(
+                RuntimeError,
+                msg='coroutine is being awaited already'):
 
             self.loop.run_until_complete(runner())
 

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -150,18 +150,13 @@ class CoroutineTests(BaseTest):
         self.assertEqual(data, 'spam')
 
     def test_debug_mode_manages_coroutine_origin_tracking(self):
-        def get_depth():
-            depth = sys.set_coroutine_origin_tracking_depth(0)
-            sys.set_coroutine_origin_tracking_depth(depth)
-            return depth
-
         async def start():
-            self.assertTrue(get_depth() > 0)
+            self.assertTrue(sys.get_coroutine_origin_tracking_depth() > 0)
 
+        self.assertEqual(sys.get_coroutine_origin_tracking_depth(), 0)
         self.loop.set_debug(True)
         self.loop.run_until_complete(start())
-
-        self.assertEqual(get_depth(), 0)
+        self.assertEqual(sys.get_coroutine_origin_tracking_depth(), 0)
 
     def test_types_coroutine(self):
         def gen():

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2067,7 +2067,7 @@ class OriginTrackingTest(unittest.TestCase):
             fname, lineno = self.here()
             with contextlib.closing(corofn()) as coro:
                 self.assertEqual(coro.cr_origin,
-                                 [(fname, lineno + 1, "test_origin_tracking")])
+                                 ((fname, lineno + 1, "test_origin_tracking"),))
 
             sys.set_coroutine_origin_tracking_depth(2)
             self.assertEqual(sys.get_coroutine_origin_tracking_depth(), 2)
@@ -2078,8 +2078,8 @@ class OriginTrackingTest(unittest.TestCase):
             ((nested_fname, nested_lineno), coro) = nested()
             with contextlib.closing(coro):
                 self.assertEqual(coro.cr_origin,
-                                 [(nested_fname, nested_lineno, "nested"),
-                                  (fname, lineno + 1, "test_origin_tracking")])
+                                 ((nested_fname, nested_lineno, "nested"),
+                                  (fname, lineno + 1, "test_origin_tracking")))
 
             # Check we handle running out of frames correctly
             sys.set_coroutine_origin_tracking_depth(1000)

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2050,22 +2050,28 @@ class OriginTrackingTest(unittest.TestCase):
         return (info.filename, info.lineno)
 
     def test_origin_tracking(self):
-        orig_depth = sys.set_coroutine_origin_tracking_depth(0)
+        orig_depth = sys.get_coroutine_origin_tracking_depth()
         try:
             async def corofn():
                 pass
 
+            sys.set_coroutine_origin_tracking_depth(0)
+            self.assertEqual(sys.get_coroutine_origin_tracking_depth(), 0)
+
             with contextlib.closing(corofn()) as coro:
                 self.assertIsNone(coro.cr_origin)
 
-            self.assertEqual(sys.set_coroutine_origin_tracking_depth(1), 0)
+            sys.set_coroutine_origin_tracking_depth(1)
+            self.assertEqual(sys.get_coroutine_origin_tracking_depth(), 1)
 
             fname, lineno = self.here()
             with contextlib.closing(corofn()) as coro:
                 self.assertEqual(coro.cr_origin,
                                  [(fname, lineno + 1, "test_origin_tracking")])
 
-            self.assertEqual(sys.set_coroutine_origin_tracking_depth(2), 1)
+            sys.set_coroutine_origin_tracking_depth(2)
+            self.assertEqual(sys.get_coroutine_origin_tracking_depth(), 2)
+
             def nested():
                 return (self.here(), corofn())
             fname, lineno = self.here()
@@ -2084,7 +2090,7 @@ class OriginTrackingTest(unittest.TestCase):
             with self.assertRaises(ValueError):
                 sys.set_coroutine_origin_tracking_depth(-1)
             # And trying leaves it unchanged
-            self.assertEqual(sys.set_coroutine_origin_tracking_depth(0), 1000)
+            self.assertEqual(sys.get_coroutine_origin_tracking_depth(), 1000)
 
         finally:
             sys.set_coroutine_origin_tracking_depth(orig_depth)
@@ -2115,7 +2121,7 @@ class OriginTrackingTest(unittest.TestCase):
             self.assertIs(wlist[0].category, RuntimeWarning)
             self.assertEqual(msg, str(wlist[0].message))
 
-        orig_depth = sys.set_coroutine_origin_tracking_depth(0)
+        orig_depth = sys.get_coroutine_origin_tracking_depth()
         try:
             msg = check(0, f"coroutine '{corofn.__qualname__}' was never awaited")
             check(1, "".join([

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -502,6 +502,12 @@ def _warn_unawaited_coroutine(coro):
         msg_lines.append("Coroutine created at (most recent call last)\n")
         msg_lines += traceback.format_list(list(extract()))
     msg = "".join(msg_lines).rstrip("\n")
+    # Passing source= here means that if the user happens to have tracemalloc
+    # enabled and tracking where the coroutine was created, the warning will
+    # contain that traceback. This does mean that if they have *both*
+    # coroutine origin tracking *and* tracemalloc enabled, they'll get two
+    # partially-redundant tracebacks. If we wanted to be clever we could
+    # probably detect this case and avoid it, but for now we don't bother.
     warn(msg, category=RuntimeWarning, stacklevel=2, source=coro)
 
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1486,6 +1486,7 @@ Christopher Smith
 Eric V. Smith
 Gregory P. Smith
 Mark Smith
+Nathaniel J. Smith
 Roy Smith
 Ryan Smith-Roberts
 Rafal Smotrzyk

--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-20-00-50-33.bpo-32591.666kl6.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-20-00-50-33.bpo-32591.666kl6.rst
@@ -1,0 +1,4 @@
+Added built-in support for tracking the origin of coroutine objects; see
+sys.set_coroutine_origin_tracking_depth and CoroutineType.cr_origin. This
+replaces the asyncio debug mode's use of coroutine wrapping for native
+coroutine objects.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -76,11 +76,8 @@ _PyGen_Finalize(PyObject *self)
     if (gen->gi_code != NULL &&
         ((PyCodeObject *)gen->gi_code)->co_flags & CO_COROUTINE &&
         gen->gi_frame->f_lasti == -1) {
-        if (!error_value) {
-            PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
-                             "coroutine '%.50S' was never awaited",
-                             gen->gi_qualname);
-        }
+        if (!error_value)
+            _PyErr_WarnUnawaitedCoroutine((PyObject *)gen);
     }
     else {
         res = gen_close(gen, NULL);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -1153,6 +1153,52 @@ exit:
     return ret;
 }
 
+void
+_PyErr_WarnUnawaitedCoroutine(PyObject *coro)
+{
+    _Py_IDENTIFIER(_warn_unawaited_coroutine);
+    PyObject *fn = NULL, *res = NULL;
+    int warned = 0;
+
+    /* First, we attempt to funnel the warning through
+       warnings._warn_unawaited_coroutine.
+
+       This could raise an exception, due to:
+       - a bug
+       - some kind of shutdown-related brokenness
+       - succeeding, but with an "error" warning filter installed, so the
+         warning is converted into a RuntimeWarning exception
+
+       In the first two cases, we want to print the error (so we know what it
+       is!), and then print a warning directly as a fallback. In the last
+       case, we want to print the error (since it's the warning!), but *not*
+       do a fallback. And after we print the error we can't check for what
+       type of error it was (because PyErr_WriteUnraisable clears it), so we
+       need a flag to keep track.
+
+       Since this is called from __del__ context, it's careful to never raise
+       an exception.
+    */
+    fn = get_warnings_attr(&PyId__warn_unawaited_coroutine, 1);
+    if (fn) {
+        res = PyObject_CallFunctionObjArgs(fn, coro, NULL);
+        if (res || PyErr_ExceptionMatches(PyExc_RuntimeWarning))
+            warned = 1;
+    }
+    Py_XDECREF(fn);
+    Py_XDECREF(res);
+
+    if (PyErr_Occurred())
+        PyErr_WriteUnraisable(coro);
+    if (!warned) {
+        PyErr_WarnFormat(PyExc_RuntimeWarning, 1,
+                         "coroutine '%.50S' was never awaited",
+                         ((PyCoroObject *)coro)->cr_qualname);
+        /* Maybe *that* got converted into an exception */
+        if (PyErr_Occurred())
+            PyErr_WriteUnraisable(coro);
+    }
+}
 
 PyDoc_STRVAR(warn_explicit_doc,
 "Low-level inferface to warnings functionality.");

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4387,14 +4387,19 @@ PyEval_SetTrace(Py_tracefunc func, PyObject *arg)
                            || (tstate->c_profilefunc != NULL));
 }
 
-int
+void
 _PyEval_SetCoroutineOriginTrackingDepth(int new_depth)
 {
     assert(new_depth >= 0);
     PyThreadState *tstate = PyThreadState_GET();
-    int old_depth = tstate->coroutine_origin_tracking_depth;
     tstate->coroutine_origin_tracking_depth = new_depth;
-    return old_depth;
+}
+
+int
+_PyEval_GetCoroutineOriginTrackingDepth(void)
+{
+    PyThreadState *tstate = PyThreadState_GET();
+    return tstate->coroutine_origin_tracking_depth;
 }
 
 void

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4387,6 +4387,15 @@ PyEval_SetTrace(Py_tracefunc func, PyObject *arg)
                            || (tstate->c_profilefunc != NULL));
 }
 
+int
+_PyEval_SetCoroutineOriginTrackingDepth(int new_depth)
+{
+    PyThreadState *tstate = PyThreadState_GET();
+    int old_depth = tstate->coroutine_origin_tracking_depth;
+    tstate->coroutine_origin_tracking_depth = new_depth;
+    return old_depth;
+}
+
 void
 _PyEval_SetCoroutineWrapper(PyObject *wrapper)
 {

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4390,6 +4390,7 @@ PyEval_SetTrace(Py_tracefunc func, PyObject *arg)
 int
 _PyEval_SetCoroutineOriginTrackingDepth(int new_depth)
 {
+    assert(new_depth >= 0);
     PyThreadState *tstate = PyThreadState_GET();
     int old_depth = tstate->coroutine_origin_tracking_depth;
     tstate->coroutine_origin_tracking_depth = new_depth;

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -1,0 +1,43 @@
+/*[clinic input]
+preserve
+[clinic start generated code]*/
+
+PyDoc_STRVAR(sys_set_coroutine_origin_tracking_depth__doc__,
+"set_coroutine_origin_tracking_depth($module, /, depth)\n"
+"--\n"
+"\n"
+"Enable or disable origin tracking for coroutine objects in this thread.\n"
+"\n"
+"Coroutine objects will track \'depth\' frames of traceback information about\n"
+"where they came from, available in their cr_origin attribute. Set depth of 0\n"
+"to disable. Returns old value.");
+
+#define SYS_SET_COROUTINE_ORIGIN_TRACKING_DEPTH_METHODDEF    \
+    {"set_coroutine_origin_tracking_depth", (PyCFunction)sys_set_coroutine_origin_tracking_depth, METH_FASTCALL|METH_KEYWORDS, sys_set_coroutine_origin_tracking_depth__doc__},
+
+static int
+sys_set_coroutine_origin_tracking_depth_impl(PyObject *module, int depth);
+
+static PyObject *
+sys_set_coroutine_origin_tracking_depth(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"depth", NULL};
+    static _PyArg_Parser _parser = {"i:set_coroutine_origin_tracking_depth", _keywords, 0};
+    int depth;
+    int _return_value;
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &depth)) {
+        goto exit;
+    }
+    _return_value = sys_set_coroutine_origin_tracking_depth_impl(module, depth);
+    if ((_return_value == -1) && PyErr_Occurred()) {
+        goto exit;
+    }
+    return_value = PyLong_FromLong((long)_return_value);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=9448b0765e4d5bf0 input=a9049054013a1b77]*/

--- a/Python/clinic/sysmodule.c.h
+++ b/Python/clinic/sysmodule.c.h
@@ -10,12 +10,12 @@ PyDoc_STRVAR(sys_set_coroutine_origin_tracking_depth__doc__,
 "\n"
 "Coroutine objects will track \'depth\' frames of traceback information about\n"
 "where they came from, available in their cr_origin attribute. Set depth of 0\n"
-"to disable. Returns old value.");
+"to disable.");
 
 #define SYS_SET_COROUTINE_ORIGIN_TRACKING_DEPTH_METHODDEF    \
     {"set_coroutine_origin_tracking_depth", (PyCFunction)sys_set_coroutine_origin_tracking_depth, METH_FASTCALL|METH_KEYWORDS, sys_set_coroutine_origin_tracking_depth__doc__},
 
-static int
+static PyObject *
 sys_set_coroutine_origin_tracking_depth_impl(PyObject *module, int depth);
 
 static PyObject *
@@ -25,13 +25,36 @@ sys_set_coroutine_origin_tracking_depth(PyObject *module, PyObject *const *args,
     static const char * const _keywords[] = {"depth", NULL};
     static _PyArg_Parser _parser = {"i:set_coroutine_origin_tracking_depth", _keywords, 0};
     int depth;
-    int _return_value;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &depth)) {
         goto exit;
     }
-    _return_value = sys_set_coroutine_origin_tracking_depth_impl(module, depth);
+    return_value = sys_set_coroutine_origin_tracking_depth_impl(module, depth);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(sys_get_coroutine_origin_tracking_depth__doc__,
+"get_coroutine_origin_tracking_depth($module, /)\n"
+"--\n"
+"\n"
+"Check status of origin tracking for coroutine objects in this thread.");
+
+#define SYS_GET_COROUTINE_ORIGIN_TRACKING_DEPTH_METHODDEF    \
+    {"get_coroutine_origin_tracking_depth", (PyCFunction)sys_get_coroutine_origin_tracking_depth, METH_NOARGS, sys_get_coroutine_origin_tracking_depth__doc__},
+
+static int
+sys_get_coroutine_origin_tracking_depth_impl(PyObject *module);
+
+static PyObject *
+sys_get_coroutine_origin_tracking_depth(PyObject *module, PyObject *Py_UNUSED(ignored))
+{
+    PyObject *return_value = NULL;
+    int _return_value;
+
+    _return_value = sys_get_coroutine_origin_tracking_depth_impl(module);
     if ((_return_value == -1) && PyErr_Occurred()) {
         goto exit;
     }
@@ -40,4 +63,4 @@ sys_set_coroutine_origin_tracking_depth(PyObject *module, PyObject *const *args,
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9448b0765e4d5bf0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4a3ac42b97d710ff input=a9049054013a1b77]*/

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -305,6 +305,8 @@ new_threadstate(PyInterpreterState *interp, int init)
         tstate->on_delete = NULL;
         tstate->on_delete_data = NULL;
 
+        tstate->coroutine_origin_tracking_depth = 0;
+
         tstate->coroutine_wrapper = NULL;
         tstate->in_coroutine_wrapper = 0;
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -34,6 +34,13 @@ extern void *PyWin_DLLhModule;
 extern const char *PyWin_DLLVersionString;
 #endif
 
+/*[clinic input]
+module sys
+[clinic start generated code]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=3726b388feee8cea]*/
+
+#include "clinic/sysmodule.c.h"
+
 _Py_IDENTIFIER(_);
 _Py_IDENTIFIER(__sizeof__);
 _Py_IDENTIFIER(_xoptions);
@@ -708,6 +715,29 @@ sys_setrecursionlimit(PyObject *self, PyObject *args)
 
     Py_SetRecursionLimit(new_limit);
     Py_RETURN_NONE;
+}
+
+/*[clinic input]
+sys.set_coroutine_origin_tracking_depth -> int
+
+  depth: int
+
+Enable or disable origin tracking for coroutine objects in this thread.
+
+Coroutine objects will track 'depth' frames of traceback information about
+where they came from, available in their cr_origin attribute. Set depth of 0
+to disable. Returns old value.
+[clinic start generated code]*/
+
+static int
+sys_set_coroutine_origin_tracking_depth_impl(PyObject *module, int depth)
+/*[clinic end generated code: output=1d421106d83a2fce input=f0a48609fc463a5c]*/
+{
+    if (depth < 0) {
+        PyErr_SetString(PyExc_ValueError, "depth must be >= 0");
+        return -1;
+    }
+    return _PyEval_SetCoroutineOriginTrackingDepth(depth);
 }
 
 static PyObject *
@@ -1512,6 +1542,7 @@ static PyMethodDef sys_methods[] = {
     {"call_tracing", sys_call_tracing, METH_VARARGS, call_tracing_doc},
     {"_debugmallocstats", sys_debugmallocstats, METH_NOARGS,
      debugmallocstats_doc},
+    SYS_SET_COROUTINE_ORIGIN_TRACKING_DEPTH_METHODDEF
     {"set_coroutine_wrapper", sys_set_coroutine_wrapper, METH_O,
      set_coroutine_wrapper_doc},
     {"get_coroutine_wrapper", sys_get_coroutine_wrapper, METH_NOARGS,

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -743,6 +743,11 @@ sys_set_coroutine_origin_tracking_depth_impl(PyObject *module, int depth)
 static PyObject *
 sys_set_coroutine_wrapper(PyObject *self, PyObject *wrapper)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "set_coroutine_wrapper is deprecated", 1) < 0) {
+        return NULL;
+    }
+
     if (wrapper != Py_None) {
         if (!PyCallable_Check(wrapper)) {
             PyErr_Format(PyExc_TypeError,
@@ -767,6 +772,10 @@ Set a wrapper for coroutine objects."
 static PyObject *
 sys_get_coroutine_wrapper(PyObject *self, PyObject *args)
 {
+    if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                     "get_coroutine_wrapper is deprecated", 1) < 0) {
+        return NULL;
+    }
     PyObject *wrapper = _PyEval_GetCoroutineWrapper();
     if (wrapper == NULL) {
         wrapper = Py_None;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -718,7 +718,7 @@ sys_setrecursionlimit(PyObject *self, PyObject *args)
 }
 
 /*[clinic input]
-sys.set_coroutine_origin_tracking_depth -> int
+sys.set_coroutine_origin_tracking_depth
 
   depth: int
 
@@ -726,18 +726,32 @@ Enable or disable origin tracking for coroutine objects in this thread.
 
 Coroutine objects will track 'depth' frames of traceback information about
 where they came from, available in their cr_origin attribute. Set depth of 0
-to disable. Returns old value.
+to disable.
 [clinic start generated code]*/
 
-static int
+static PyObject *
 sys_set_coroutine_origin_tracking_depth_impl(PyObject *module, int depth)
-/*[clinic end generated code: output=1d421106d83a2fce input=f0a48609fc463a5c]*/
+/*[clinic end generated code: output=0a2123c1cc6759c5 input=9083112cccc1bdcb]*/
 {
     if (depth < 0) {
         PyErr_SetString(PyExc_ValueError, "depth must be >= 0");
-        return -1;
+        return NULL;
     }
-    return _PyEval_SetCoroutineOriginTrackingDepth(depth);
+    _PyEval_SetCoroutineOriginTrackingDepth(depth);
+    Py_RETURN_NONE;
+}
+
+/*[clinic input]
+sys.get_coroutine_origin_tracking_depth -> int
+
+Check status of origin tracking for coroutine objects in this thread.
+[clinic start generated code]*/
+
+static int
+sys_get_coroutine_origin_tracking_depth_impl(PyObject *module)
+/*[clinic end generated code: output=3699f7be95a3afb8 input=335266a71205b61a]*/
+{
+    return _PyEval_GetCoroutineOriginTrackingDepth();
 }
 
 static PyObject *
@@ -1552,6 +1566,7 @@ static PyMethodDef sys_methods[] = {
     {"_debugmallocstats", sys_debugmallocstats, METH_NOARGS,
      debugmallocstats_doc},
     SYS_SET_COROUTINE_ORIGIN_TRACKING_DEPTH_METHODDEF
+    SYS_GET_COROUTINE_ORIGIN_TRACKING_DEPTH_METHODDEF
     {"set_coroutine_wrapper", sys_set_coroutine_wrapper, METH_O,
      set_coroutine_wrapper_doc},
     {"get_coroutine_wrapper", sys_get_coroutine_wrapper, METH_NOARGS,


### PR DESCRIPTION
After this PR, asyncio no longer uses sys.set_coroutine_wrapper.

There is one non-trivial semantic change: before in asycnio debug
mode, unawaited coroutine warnings were logged using
logger.error(...). Now they generate a regular warnings-module
warning.

This is best reviewed one commit at a time.

Note that there's also a fix for a very subtle bug in
BaseEventLoop.set_debug; see the 4th commit. (It's the one where the
commit message is 4x longer than the diff.)

Not done here, could be added here or in followups:

- Support for enabling coroutine origin tracking via envvar or -X flag
- Actually deprecating/removing sys.set_coroutine_wrapper

<!-- issue-number: bpo-32591 -->
https://bugs.python.org/issue32591
<!-- /issue-number -->
