### PR TITLE
bpo-32476 : Add concat function for ElementTree find

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -410,61 +410,69 @@ Supported XPath syntax
 
 .. tabularcolumns:: |l|L|
 
-+-----------------------+------------------------------------------------------+
-| Syntax                | Meaning                                              |
-+=======================+======================================================+
-| ``tag``               | Selects all child elements with the given tag.       |
-|                       | For example, ``spam`` selects all child elements     |
-|                       | named ``spam``, and ``spam/egg`` selects all         |
-|                       | grandchildren named ``egg`` in all children named    |
-|                       | ``spam``.  ``{namespace}*`` selects all tags in the  |
-|                       | given namespace, ``{*}spam`` selects tags named      |
-|                       | ``spam`` in any (or no) namespace, and ``{}*``       |
-|                       | only selects tags that are not in a namespace.       |
-|                       |                                                      |
-|                       | .. versionchanged:: 3.8                              |
-|                       |    Support for star-wildcards was added.             |
-+-----------------------+------------------------------------------------------+
-| ``*``                 | Selects all child elements, including comments and   |
-|                       | processing instructions.  For example, ``*/egg``     |
-|                       | selects all grandchildren named ``egg``.             |
-+-----------------------+------------------------------------------------------+
-| ``.``                 | Selects the current node.  This is mostly useful     |
-|                       | at the beginning of the path, to indicate that it's  |
-|                       | a relative path.                                     |
-+-----------------------+------------------------------------------------------+
-| ``//``                | Selects all subelements, on all levels beneath the   |
-|                       | current  element.  For example, ``.//egg`` selects   |
-|                       | all ``egg`` elements in the entire tree.             |
-+-----------------------+------------------------------------------------------+
-| ``..``                | Selects the parent element.  Returns ``None`` if the |
-|                       | path attempts to reach the ancestors of the start    |
-|                       | element (the element ``find`` was called on).        |
-+-----------------------+------------------------------------------------------+
-| ``[@attrib]``         | Selects all elements that have the given attribute.  |
-+-----------------------+------------------------------------------------------+
-| ``[@attrib='value']`` | Selects all elements for which the given attribute   |
-|                       | has the given value.  The value cannot contain       |
-|                       | quotes.                                              |
-+-----------------------+------------------------------------------------------+
-| ``[tag]``             | Selects all elements that have a child named         |
-|                       | ``tag``.  Only immediate children are supported.     |
-+-----------------------+------------------------------------------------------+
-| ``[.='text']``        | Selects all elements whose complete text content,    |
-|                       | including descendants, equals the given ``text``.    |
-|                       |                                                      |
-|                       | .. versionadded:: 3.7                                |
-+-----------------------+------------------------------------------------------+
-| ``[tag='text']``      | Selects all elements that have a child named         |
-|                       | ``tag`` whose complete text content, including       |
-|                       | descendants, equals the given ``text``.              |
-+-----------------------+------------------------------------------------------+
-| ``[position]``        | Selects all elements that are located at the given   |
-|                       | position.  The position can be either an integer     |
-|                       | (1 is the first position), the expression ``last()`` |
-|                       | (for the last position), or a position relative to   |
-|                       | the last position (e.g. ``last()-1``).               |
-+-----------------------+------------------------------------------------------+
++------------------------------------+------------------------------------------------------+
+| Syntax                             | Meaning                                              |
++====================================+======================================================+
+| ``tag``                            | Selects all child elements with the given tag.       |
+|                                    | For example, ``spam`` selects all child elements     |
+|                                    | named ``spam``, and ``spam/egg`` selects all         |
+|                                    | grandchildren named ``egg`` in all children named    |
+|                                    | ``spam``.  ``{namespace}*`` selects all tags in the  |
+|                                    | given namespace, ``{*}spam`` selects tags named      |
+|                                    | ``spam`` in any (or no) namespace, and ``{}*``       |
+|                                    | only selects tags that are not in a namespace.       |
+|                                    |                                                      |
+|                                    | .. versionchanged:: 3.8                              |
+|                                    |    Support for star-wildcards was added.             |
++------------------------------------+------------------------------------------------------+
+| ``*``                              | Selects all child elements, including comments and   |
+|                                    | processing instructions.  For example, ``*/egg``     |
+|                                    | selects all grandchildren named ``egg``.             |
++------------------------------------+------------------------------------------------------+
+| ``.``                              | Selects the current node.  This is mostly useful     |
+|                                    | at the beginning of the path, to indicate that it's  |
+|                                    | a relative path.                                     |
++------------------------------------+------------------------------------------------------+
+| ``//``                             | Selects all subelements, on all levels beneath the   |
+|                                    | current  element.  For example, ``.//egg`` selects   |
+|                                    | all ``egg`` elements in the entire tree.             |
++------------------------------------+------------------------------------------------------+
+| ``..``                             | Selects the parent element.  Returns ``None`` if the |
+|                                    | path attempts to reach the ancestors of the start    |
+|                                    | element (the element ``find`` was called on).        |
++------------------------------------+------------------------------------------------------+
+| ``[@attrib]``                      | Selects all elements that have the given attribute.  |
++------------------------------------+------------------------------------------------------+
+| ``[@attrib='value']``              | Selects all elements for which the given attribute   |
+|                                    | has the given value.  The value cannot contain       |
+|                                    | quotes.                                              |
++------------------------------------+------------------------------------------------------+
+| ``[@attrib=concat('value', ...)]`` | Concatenates one or more strings together and        |
+|                                    | selects all elements for which the given attribute   |
+|                                    | has the given value.  The various strings my have    |
+|                                    | either quotes (if surrounded by apostrophe quotes),  |
+|                                    | or apostrophes (if surrounded by standard quotes).   |
+|                                    |                                                      |
+|                                    | .. versionadded:: 3.7                                |
++------------------------------------+------------------------------------------------------+
+| ``[tag]``                          | Selects all elements that have a child named         |
+|                                    | ``tag``.  Only immediate children are supported.     |
++------------------------------------+------------------------------------------------------+
+| ``[.='text']``                     | Selects all elements whose complete text content,    |
+|                                    | including descendants, equals the given ``text``.    |
+|                                    |                                                      |
+|                                    | .. versionadded:: 3.7                                |
++------------------------------------+------------------------------------------------------+
+| ``[tag='text']``                   | Selects all elements that have a child named         |
+|                                    | ``tag`` whose complete text content, including       |
+|                                    | descendants, equals the given ``text``.              |
++------------------------------------+------------------------------------------------------+
+| ``[position]``                     | Selects all elements that are located at the given   |
+|                                    | position.  The position can be either an integer     |
+|                                    | (1 is the first position), the expression ``last()`` |
+|                                    | (for the last position), or a position relative to   |
+|                                    | the last position (e.g. ``last()-1``).               |
++------------------------------------+------------------------------------------------------+
 
 Predicates (expressions within square brackets) must be preceded by a tag
 name, an asterisk, or another predicate.  ``position`` predicates must be

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2601,9 +2601,12 @@ class ElementFindTest(unittest.TestCase):
         self.assertEqual(e.find('./concat[@class=concat("x")]').attrib['class'], 'x')
 
         self.assertRaisesRegex(SyntaxError, 'invalid predicate', e.find, './tag[@class=concat"d"]')
-        self.assertRaisesRegex(SyntaxError, 'concat missing opening paranthese', e.find, './tag[@class=concat()]')
-        self.assertRaisesRegex(SyntaxError, 'invalid close paranthese for concat', e.find, './tag[@class=concat("d",)]')
-        self.assertRaisesRegex(SyntaxError, 'incomplete concat', e.find, './tag[@class=concat("d"')
+        self.assertRaisesRegex(SyntaxError, 'concat missing opening paranthesis', e.find, './tag[@class=concat "d"]')
+        self.assertRaisesRegex(SyntaxError, 'concat with no parameters not allowed', e.find, './tag[@class=concat()]')
+        self.assertRaisesRegex(SyntaxError, 'incomplete parameter list for concat', e.find, './tag[@class=concat( )]')
+        self.assertRaisesRegex(SyntaxError, 'incomplete parameter list for concat', e.find, './tag[@class=concat("d",)]')
+        self.assertRaisesRegex(SyntaxError, 'comma separator in concat without preceding string', e.find, './tag[@class=concat(,"d")]')
+        self.assertRaisesRegex(SyntaxError, 'missing closing parathesis for concat', e.find, './tag[@class=concat("d"')
         self.assertRaisesRegex(SyntaxError, "invalid string '.' in concat", e.find, './tag[@class=concat("d". "e"]')
 
     def test_findall(self):

--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -253,7 +253,7 @@ def prepare_predicate_concat(next):
             constr += token[0][1:-1]
             needstr = False
         else:
-            raise SyntaxError("invalid string ({}) in concat".format(token[0] or token[1]))
+            raise SyntaxError("invalid string '{}' in concat".format(token[0] or token[1]))
 
 def prepare_predicate(next, token):
     # FIXME: replace with real parser!!! refs:

--- a/Lib/xml/etree/ElementPath.py
+++ b/Lib/xml/etree/ElementPath.py
@@ -231,22 +231,24 @@ def prepare_predicate_concat(next):
         try:
             token = next()
         except StopIteration:
-            raise SyntaxError("incomplete concat")
+            raise SyntaxError("missing closing parathesis for concat")
         if token == ('', ''):
             continue
         if not started:
-            if token[0] == '(':
+            if token[0] and token[0][0] == '(':
                 started = True
+                if len(token[0]) > 1 and token[0][1] == ')':
+                    raise SyntaxError("concat with no parameters not allowed")
                 continue
             else:
-                raise SyntaxError("concat missing opening paranthese")
+                raise SyntaxError("concat missing opening paranthesis")
         if token[0] == ')':
             if needstr:
-                raise SyntaxError("invalid close paranthese for concat")
+                raise SyntaxError("incomplete parameter list for concat")
             return constr
         if token[0] == ',':
             if needstr:
-                raise SyntaxError("comma separator in concat without string")
+                raise SyntaxError("comma separator in concat without preceding string")
             needstr = True
             continue
         if token[0] and token[0][0] in "'\"" and token[0][0] == token[0][-1]:

--- a/Misc/NEWS.d/next/Library/2018-01-18-15-19-31.bpo-32476.jwIvo6.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-18-15-19-31.bpo-32476.jwIvo6.rst
@@ -1,0 +1,1 @@
+Added xpath ``concat`` support to ElementTree ``find``


### PR DESCRIPTION
Problem: Using apostrophes and quotes in a search string is impossible. Currently escaping quotes in the search string is not implemented.
Example:
```
>>> import xml.etree.ElementTree as et
>>> e = et.Element("root")
>>> c = et.SubElement(e, "branch")
>>> c.set("name", "main")
>>> gc = et.SubElement(c, "leaf")
>>> gc.set("name", "\"quote\" 'apostrophe'")
>>> et.tostring(e)
b'<root><branch name="main"><leaf name="&quot;quote&quot; \'apostrophe\'" /></branch></root>'
>>> r.findall(".//*[@name=\"&quot;quote&quot; 'apostrophe'\"]")
[]
```
Solution: This patch implements the XPath `concat()` function within an attribute search.
Result:
```
>>> r.findall(".//*[@name=concat('\"quote\"', ' ', \"'apostrophe'\")]")
[<Element 'leaf' at 0x7f8f9778cae8>]
```


<!-- issue-number: bpo-32476 -->
https://bugs.python.org/issue32476
<!-- /issue-number -->
