### PR TITLE
bpo-24334: Cleanup SSLSocket

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -455,6 +455,8 @@ class BasicSocketTests(unittest.TestCase):
             self.assertRaises(OSError, ss.recvfrom_into, bytearray(b'x'), 1)
             self.assertRaises(OSError, ss.send, b'x')
             self.assertRaises(OSError, ss.sendto, b'x', ('0.0.0.0', 0))
+            self.assertRaises(NotImplementedError, ss.sendmsg,
+                              [b'x'], (), 0, ('0.0.0.0', 0))
 
     def test_timeout(self):
         # Issue #8524: when creating an SSL socket, the timeout of the
@@ -3381,11 +3383,13 @@ class ThreadedTests(unittest.TestCase):
                                 chatty=False) as server:
             with context.wrap_socket(socket.socket()) as s:
                 self.assertIs(s.version(), None)
+                self.assertIs(s._sslobj, None)
                 s.connect((HOST, server.port))
                 if ssl.OPENSSL_VERSION_INFO >= (1, 0, 2):
                     self.assertEqual(s.version(), 'TLSv1.2')
                 else:  # 0.9.8 to 1.0.1
                     self.assertIn(s.version(), ('TLSv1', 'TLSv1.2'))
+            self.assertIs(s._sslobj, None)
             self.assertIs(s.version(), None)
 
     @unittest.skipUnless(ssl.HAS_TLSv1_3,

--- a/Misc/NEWS.d/next/Library/2018-01-20-23-17-25.bpo-24334.GZuQLv.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-20-23-17-25.bpo-24334.GZuQLv.rst
@@ -1,0 +1,4 @@
+Internal implementation details of ssl module were cleaned up. The SSLSocket
+has one less layer of indirection. Owner and session information are now
+handled by the SSLSocket and SSLObject constructor. Channel binding
+implementation has been simplified.

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -45,8 +45,8 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(_ssl__SSLSocket_peer_certificate__doc__,
-"peer_certificate($self, der=False, /)\n"
+PyDoc_STRVAR(_ssl__SSLSocket_getpeercert__doc__,
+"getpeercert($self, der=False, /)\n"
 "--\n"
 "\n"
 "Returns the certificate for the peer.\n"
@@ -59,23 +59,23 @@ PyDoc_STRVAR(_ssl__SSLSocket_peer_certificate__doc__,
 "peer certificate, or None if no certificate was provided.  This will\n"
 "return the certificate even if it wasn\'t validated.");
 
-#define _SSL__SSLSOCKET_PEER_CERTIFICATE_METHODDEF    \
-    {"peer_certificate", (PyCFunction)_ssl__SSLSocket_peer_certificate, METH_FASTCALL, _ssl__SSLSocket_peer_certificate__doc__},
+#define _SSL__SSLSOCKET_GETPEERCERT_METHODDEF    \
+    {"getpeercert", (PyCFunction)_ssl__SSLSocket_getpeercert, METH_FASTCALL, _ssl__SSLSocket_getpeercert__doc__},
 
 static PyObject *
-_ssl__SSLSocket_peer_certificate_impl(PySSLSocket *self, int binary_mode);
+_ssl__SSLSocket_getpeercert_impl(PySSLSocket *self, int binary_mode);
 
 static PyObject *
-_ssl__SSLSocket_peer_certificate(PySSLSocket *self, PyObject *const *args, Py_ssize_t nargs)
+_ssl__SSLSocket_getpeercert(PySSLSocket *self, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *return_value = NULL;
     int binary_mode = 0;
 
-    if (!_PyArg_ParseStack(args, nargs, "|p:peer_certificate",
+    if (!_PyArg_ParseStack(args, nargs, "|p:getpeercert",
         &binary_mode)) {
         goto exit;
     }
-    return_value = _ssl__SSLSocket_peer_certificate_impl(self, binary_mode);
+    return_value = _ssl__SSLSocket_getpeercert_impl(self, binary_mode);
 
 exit:
     return return_value;
@@ -293,9 +293,7 @@ PyDoc_STRVAR(_ssl__SSLSocket_shutdown__doc__,
 "shutdown($self, /)\n"
 "--\n"
 "\n"
-"Does the SSL shutdown handshake with the remote end.\n"
-"\n"
-"Returns the underlying socket object.");
+"Does the SSL shutdown handshake with the remote end.");
 
 #define _SSL__SSLSOCKET_SHUTDOWN_METHODDEF    \
     {"shutdown", (PyCFunction)_ssl__SSLSocket_shutdown, METH_NOARGS, _ssl__SSLSocket_shutdown__doc__},
@@ -309,24 +307,39 @@ _ssl__SSLSocket_shutdown(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_shutdown_impl(self);
 }
 
-PyDoc_STRVAR(_ssl__SSLSocket_tls_unique_cb__doc__,
-"tls_unique_cb($self, /)\n"
+PyDoc_STRVAR(_ssl__SSLSocket_get_channel_binding__doc__,
+"get_channel_binding($self, /, cb_type=\'tls-unique\')\n"
 "--\n"
 "\n"
-"Returns the \'tls-unique\' channel binding data, as defined by RFC 5929.\n"
+"Get channel binding data for current connection.\n"
 "\n"
-"If the TLS handshake is not yet complete, None is returned.");
+"Raise ValueError if the requested `cb_type` is not supported.  Return bytes\n"
+"of the data or None if the data is not available (e.g. before the handshake).\n"
+"Only \'tls-unique\' channel binding data from RFC 5929 is supported.");
 
-#define _SSL__SSLSOCKET_TLS_UNIQUE_CB_METHODDEF    \
-    {"tls_unique_cb", (PyCFunction)_ssl__SSLSocket_tls_unique_cb, METH_NOARGS, _ssl__SSLSocket_tls_unique_cb__doc__},
+#define _SSL__SSLSOCKET_GET_CHANNEL_BINDING_METHODDEF    \
+    {"get_channel_binding", (PyCFunction)_ssl__SSLSocket_get_channel_binding, METH_FASTCALL|METH_KEYWORDS, _ssl__SSLSocket_get_channel_binding__doc__},
 
 static PyObject *
-_ssl__SSLSocket_tls_unique_cb_impl(PySSLSocket *self);
+_ssl__SSLSocket_get_channel_binding_impl(PySSLSocket *self,
+                                         const char *cb_type);
 
 static PyObject *
-_ssl__SSLSocket_tls_unique_cb(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
+_ssl__SSLSocket_get_channel_binding(PySSLSocket *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
-    return _ssl__SSLSocket_tls_unique_cb_impl(self);
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"cb_type", NULL};
+    static _PyArg_Parser _parser = {"|s:get_channel_binding", _keywords, 0};
+    const char *cb_type = "tls-unique";
+
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
+        &cb_type)) {
+        goto exit;
+    }
+    return_value = _ssl__SSLSocket_get_channel_binding_impl(self, cb_type);
+
+exit:
+    return return_value;
 }
 
 static PyObject *
@@ -538,7 +551,8 @@ PyDoc_STRVAR(_ssl__SSLContext_load_dh_params__doc__,
     {"load_dh_params", (PyCFunction)_ssl__SSLContext_load_dh_params, METH_O, _ssl__SSLContext_load_dh_params__doc__},
 
 PyDoc_STRVAR(_ssl__SSLContext__wrap_socket__doc__,
-"_wrap_socket($self, /, sock, server_side, server_hostname=None)\n"
+"_wrap_socket($self, /, sock, server_side, server_hostname=None, *,\n"
+"             owner=None, session=None)\n"
 "--\n"
 "\n");
 
@@ -547,23 +561,26 @@ PyDoc_STRVAR(_ssl__SSLContext__wrap_socket__doc__,
 
 static PyObject *
 _ssl__SSLContext__wrap_socket_impl(PySSLContext *self, PyObject *sock,
-                                   int server_side, PyObject *hostname_obj);
+                                   int server_side, PyObject *hostname_obj,
+                                   PyObject *owner, PyObject *session);
 
 static PyObject *
 _ssl__SSLContext__wrap_socket(PySSLContext *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"sock", "server_side", "server_hostname", NULL};
-    static _PyArg_Parser _parser = {"O!i|O:_wrap_socket", _keywords, 0};
+    static const char * const _keywords[] = {"sock", "server_side", "server_hostname", "owner", "session", NULL};
+    static _PyArg_Parser _parser = {"O!i|O$OO:_wrap_socket", _keywords, 0};
     PyObject *sock;
     int server_side;
     PyObject *hostname_obj = Py_None;
+    PyObject *owner = Py_None;
+    PyObject *session = Py_None;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
-        PySocketModule.Sock_Type, &sock, &server_side, &hostname_obj)) {
+        PySocketModule.Sock_Type, &sock, &server_side, &hostname_obj, &owner, &session)) {
         goto exit;
     }
-    return_value = _ssl__SSLContext__wrap_socket_impl(self, sock, server_side, hostname_obj);
+    return_value = _ssl__SSLContext__wrap_socket_impl(self, sock, server_side, hostname_obj, owner, session);
 
 exit:
     return return_value;
@@ -571,7 +588,7 @@ exit:
 
 PyDoc_STRVAR(_ssl__SSLContext__wrap_bio__doc__,
 "_wrap_bio($self, /, incoming, outgoing, server_side,\n"
-"          server_hostname=None)\n"
+"          server_hostname=None, *, owner=None, session=None)\n"
 "--\n"
 "\n");
 
@@ -581,24 +598,27 @@ PyDoc_STRVAR(_ssl__SSLContext__wrap_bio__doc__,
 static PyObject *
 _ssl__SSLContext__wrap_bio_impl(PySSLContext *self, PySSLMemoryBIO *incoming,
                                 PySSLMemoryBIO *outgoing, int server_side,
-                                PyObject *hostname_obj);
+                                PyObject *hostname_obj, PyObject *owner,
+                                PyObject *session);
 
 static PyObject *
 _ssl__SSLContext__wrap_bio(PySSLContext *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"incoming", "outgoing", "server_side", "server_hostname", NULL};
-    static _PyArg_Parser _parser = {"O!O!i|O:_wrap_bio", _keywords, 0};
+    static const char * const _keywords[] = {"incoming", "outgoing", "server_side", "server_hostname", "owner", "session", NULL};
+    static _PyArg_Parser _parser = {"O!O!i|O$OO:_wrap_bio", _keywords, 0};
     PySSLMemoryBIO *incoming;
     PySSLMemoryBIO *outgoing;
     int server_side;
     PyObject *hostname_obj = Py_None;
+    PyObject *owner = Py_None;
+    PyObject *session = Py_None;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
-        &PySSLMemoryBIO_Type, &incoming, &PySSLMemoryBIO_Type, &outgoing, &server_side, &hostname_obj)) {
+        &PySSLMemoryBIO_Type, &incoming, &PySSLMemoryBIO_Type, &outgoing, &server_side, &hostname_obj, &owner, &session)) {
         goto exit;
     }
-    return_value = _ssl__SSLContext__wrap_bio_impl(self, incoming, outgoing, server_side, hostname_obj);
+    return_value = _ssl__SSLContext__wrap_bio_impl(self, incoming, outgoing, server_side, hostname_obj, owner, session);
 
 exit:
     return return_value;
@@ -1155,4 +1175,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=84e1fd89aff9b0f7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d987411caeb106e7 input=a9049054013a1b77]*/


### PR DESCRIPTION
* The SSLSocket is no longer implemented on top of SSLObject to
  avoid an extra level of indirection.
* Owner and session are now handled in the internal constructor.
* _ssl._SSLSocket now uses the same method names as SSLSocket and
  SSLObject.
* Channel binding type check is now handled in C code. Channel binding
  is always available.

The patch also changes the signature of SSLObject.__init__(). In my
opinion it's fine. A SSLObject is not a user-constructable object.
SSLContext.wrap_bio() is the only valid factory.


<!-- issue-number: bpo-24334 -->
https://bugs.python.org/issue24334
<!-- /issue-number -->
