### PR TITLE
bpo-32378: LibreSSL NPN workaround

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -2381,6 +2381,23 @@ successful call of :func:`~ssl.RAND_add`, :func:`~ssl.RAND_bytes` or
 :func:`~ssl.RAND_pseudo_bytes` is sufficient.
 
 
+.. ssl-libressl:
+
+LibreSSL support
+----------------
+
+LibreSSL is a fork of OpenSSL 1.0.1. The ssl module has limited support for
+LibreSSL. Some features are not available when the ssl module is compiled
+with LibreSSL.
+
+* LibreSSL >= 2.6.1 no longer supports NPN. The methods
+  :meth:`SSLContext.set_npn_protocols` and
+  :meth:`SSLSocket.selected_npn_protocol` are not available.
+* :meth:`SSLContext.set_default_verify_paths` ignores the env vars
+  :envvar:`SSL_CERT_FILE` and :envvar:`SSL_CERT_PATH` although
+  :func:`get_default_verify_paths` still reports them.
+
+
 .. seealso::
 
    Class :class:`socket.socket`

--- a/Misc/NEWS.d/next/Library/2018-01-21-00-01-19.bpo-32378.-TXPA3.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-21-00-01-19.bpo-32378.-TXPA3.rst
@@ -1,0 +1,2 @@
+The ssl module now contains a workaround for missing NPN support in LibreSSL
+2.6.1. Upstream has removed NPN without setting OPENSSL_NO_NEXTPROTONEG.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -135,6 +135,18 @@ static void _PySSLFixErrno(void) {
 #  define OPENSSL_VERSION_1_1 1
 #endif
 
+/* LibreSSL quirks
+ *
+ * LibreSSL 2.6.1 no longer provides NPN support but does not set the
+ * designated OPENSSL_NO_NEXTPROTONEG feature flag. See upstream issue
+ * https://github.com/libressl-portable/portable/issues/368
+ */
+#if defined(LIBRESSL_VERSION_NUMBER) && !defined(TLSEXT_TYPE_next_proto_neg)
+#  ifndef OPENSSL_NO_NEXTPROTONEG
+#    define OPENSSL_NO_NEXTPROTONEG 1
+#  endif
+#endif
+
 /* Openssl comes with TLSv1.1 and TLSv1.2 between 1.0.0h and 1.0.1
     http://www.openssl.org/news/changelog.html
  */


### PR DESCRIPTION
The ssl module now contains a workaround for missing NPN support in LibreSSL
2.6.1. Upstream has removed NPN without setting OPENSSL_NO_NEXTPROTONEG.

Obsoletes PR #4930 
See https://github.com/libressl-portable/portable/issues/368

<!-- issue-number: bpo-32378 -->
https://bugs.python.org/issue32378
<!-- /issue-number -->
