### PR TITLE
bpo-32502: Discard 64-bit (and other invalid) hardware addresses

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -319,9 +319,9 @@ class BaseTestUUID:
 
         # Confirm that uuid.getnode ignores hardware addresses larger than 48
         # bits. Mock out each platform's *_getnode helper functions to return
-        # something just larger than 2^48 to test. This will cause uuid.getnode
-        # to fall back on uuid._random_getnode, which will generate a valid
-        # value.
+        # something just larger than 48 bits to test. This will cause
+        # uuid.getnode to fall back on uuid._random_getnode, which will
+        # generate a valid value.
         too_large_getter = lambda: 1 << 48
         with unittest.mock.patch.multiple(
             self.uuid,

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -314,7 +314,6 @@ class BaseTestUUID:
     # bpo-32502: UUID1 requires a 48-bit identifier, but hardware identifiers
     # need not necessarily be 48 bits (e.g., EUI-64).
     def test_uuid1_eui64(self):
-        # Reset any cached node value.
         self.uuid._node = None
 
         # Confirm that uuid.getnode ignores hardware addresses larger than 48
@@ -325,8 +324,9 @@ class BaseTestUUID:
         too_large_getter = lambda: 1 << 48
         with unittest.mock.patch.multiple(
             self.uuid,
-            _node_getters_win32=[too_large_getter],
-            _node_getters_unix=[too_large_getter],
+            _node=None,  # Ignore any cached node value.
+            _NODE_GETTERS_WIN32=[too_large_getter],
+            _NODE_GETTERS_UNIX=[too_large_getter],
         ):
             node = self.uuid.getnode()
         self.assertTrue(0 < node < (1 << 48), '%012x' % node)

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -311,6 +311,26 @@ class BaseTestUUID:
         node2 = self.uuid.getnode()
         self.assertEqual(node1, node2, '%012x != %012x' % (node1, node2))
 
+    # bpo-32502: UUID1 requires a 48-bit identifier, but hardware identifiers
+    # need not necessarily be 48 bits (e.g., EUI-64).
+    def test_uuid1_eui64(self):
+        # Reset any cached node value
+        self.uuid._node = None
+
+        # Confirm that uuid.getnode ignores hardware addresses larger than 48
+        # bits
+        bad_getter = lambda: 1 << 48
+        node = self.uuid.getnode(getters=[bad_getter])
+        self.assertTrue(0 < node < (1 << 48), '%012x' % node)
+
+        # Confirm that uuid1 doesn't fail when there's only a 64-bit hardware
+        # address
+        try:
+            self.uuid.uuid1(node=node)
+        except ValueError as e:
+            self.fail('uuid1 was given an invalid node ID')
+
+
     def test_uuid1(self):
         equal = self.assertEqual
 

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -314,8 +314,6 @@ class BaseTestUUID:
     # bpo-32502: UUID1 requires a 48-bit identifier, but hardware identifiers
     # need not necessarily be 48 bits (e.g., EUI-64).
     def test_uuid1_eui64(self):
-        self.uuid._node = None
-
         # Confirm that uuid.getnode ignores hardware addresses larger than 48
         # bits. Mock out each platform's *_getnode helper functions to return
         # something just larger than 48 bits to test. This will cause

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -656,7 +656,7 @@ def _random_getnode():
 
 _node = None
 
-def getnode():
+def getnode(*, getters=None):
     """Get the hardware address as a 48-bit positive integer.
 
     The first time this runs, it may launch a separate program, which could
@@ -668,20 +668,21 @@ def getnode():
     if _node is not None:
         return _node
 
-    if sys.platform == 'win32':
-        getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
-    else:
-        getters = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
-                   _arp_getnode, _lanscan_getnode, _netstat_getnode]
+    if getters is None:
+        if sys.platform == 'win32':
+            getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
+        else:
+            getters = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
+                       _arp_getnode, _lanscan_getnode, _netstat_getnode]
 
     for getter in getters + [_random_getnode]:
         try:
             _node = getter()
         except:
             continue
-        if _node is not None:
+        if (_node is not None) and (0 <= _node < (1 << 48)):
             return _node
-    assert False, '_random_getnode() returned None'
+    assert False, '_random_getnode() returned an invalid value'
 
 
 _last_timestamp = None

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -656,9 +656,9 @@ def _random_getnode():
 
 _node = None
 
-_node_getters_win32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
+_NODE_GETTERS_WIN32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
 
-_node_getters_unix = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
+_NODE_GETTERS_UNIX = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
                       _arp_getnode, _lanscan_getnode, _netstat_getnode]
 
 def getnode(*, getters=None):
@@ -674,9 +674,9 @@ def getnode(*, getters=None):
         return _node
 
     if sys.platform == 'win32':
-        getters = _node_getters_win32
+        getters = _NODE_GETTERS_WIN32
     else:
-        getters = _node_getters_unix
+        getters = _NODE_GETTERS_UNIX
 
     for getter in getters + [_random_getnode]:
         try:
@@ -685,7 +685,6 @@ def getnode(*, getters=None):
             continue
         if (_node is not None) and (0 <= _node < (1 << 48)):
             return _node
-
     assert False, '_random_getnode() returned invalid value: {}'.format(_node)
 
 

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -656,6 +656,11 @@ def _random_getnode():
 
 _node = None
 
+_node_getters_win32 = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
+
+_node_getters_unix = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
+                      _arp_getnode, _lanscan_getnode, _netstat_getnode]
+
 def getnode(*, getters=None):
     """Get the hardware address as a 48-bit positive integer.
 
@@ -668,12 +673,10 @@ def getnode(*, getters=None):
     if _node is not None:
         return _node
 
-    if getters is None:
-        if sys.platform == 'win32':
-            getters = [_windll_getnode, _netbios_getnode, _ipconfig_getnode]
-        else:
-            getters = [_unix_getnode, _ifconfig_getnode, _ip_getnode,
-                       _arp_getnode, _lanscan_getnode, _netstat_getnode]
+    if sys.platform == 'win32':
+        getters = _node_getters_win32
+    else:
+        getters = _node_getters_unix
 
     for getter in getters + [_random_getnode]:
         try:
@@ -682,7 +685,8 @@ def getnode(*, getters=None):
             continue
         if (_node is not None) and (0 <= _node < (1 << 48)):
             return _node
-    assert False, '_random_getnode() returned an invalid value'
+
+    assert False, '_random_getnode() returned invalid value: {}'.format(_node)
 
 
 _last_timestamp = None

--- a/Misc/NEWS.d/next/Library/2018-01-20-17-15-34.bpo-32502.OXJfn7.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-20-17-15-34.bpo-32502.OXJfn7.rst
@@ -1,0 +1,2 @@
+uuid.uuid1 no longer raises an exception if a 64-bit hardware address is
+encountered.


### PR DESCRIPTION
This PR adds a fix for bug 32502, which causes `uuid.uuid1` to fail when [`uuid.getnode`](https://github.com/bbayles/cpython/blob/67c3a720ba15582ea8b8d6aa97473cd7d7c02eed/Lib/uuid.py#L659) finds a hardware address that's not 48 bits (e.g., a 64-bit FireWire hardware address).

In this fix I'm simply discarding MAC addresses that appear to be outside of [0, 2^48). This means in principle that an EUI-64 address that doesn't have any high bits set could be accepted, but I think that's (a) OK, and (b) better than the status quo.

I'm also not modifying each of the platform-specific `*_getnode` functions - just the one that organizes them. If I should patch each of the existing ones I can, but in that case it might make sense to enforce that the `*_getnode` functions check for 48-bits.

<!-- issue-number: bpo-32502 -->
https://bugs.python.org/issue32502
<!-- /issue-number -->
