### PR TITLE
bpo-32603: Deprecation warning on strings used in re module

### DIFF
--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -28,7 +28,10 @@ character for the same purpose in string literals; for example, to match
 a literal backslash, one might have to write ``'\\\\'`` as the pattern
 string, because the regular expression must be ``\\``, and each
 backslash must be expressed as ``\\`` inside a regular Python string
-literal.
+literal. Also, please note that any invalid escape sequences in Python's
+usage of the backslash in string literals now generate a :exc:`DeprecationWarning`
+and in the future this will become a :exc:`SyntaxError`. This behaviour
+will happen even if it is a valid escape sequence for a regular expression.
 
 The solution is to use Python's raw string notation for regular expression
 patterns; backslashes are not handled in any special way in a string literal


### PR DESCRIPTION


<!-- issue-number: bpo-32603 -->
https://bugs.python.org/issue32603
<!-- /issue-number -->
