### PR TITLE
bpo-32232: Fix "building extensions as builtins is broken in 3.7"

### DIFF
--- a/Include/internal/pystate.h
+++ b/Include/internal/pystate.h
@@ -7,6 +7,8 @@ extern "C" {
 #include "pystate.h"
 #include "pyatomic.h"
 #include "pythread.h"
+#include "pyerrors.h"
+#include "pylifecycle.h"
 
 #include "internal/mem.h"
 #include "internal/ceval.h"

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -327,11 +327,26 @@ PyAPI_FUNC(PyObject *) PyThreadState_GetDict(void);
 PyAPI_FUNC(int) PyThreadState_SetAsyncExc(unsigned long, PyObject *);
 
 
+/* Routines for advanced debuggers, requested by David Beazley.
+   Don't use unless you know what you are doing! */
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_Main(void);
+PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_Head(void);
+PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_Next(PyInterpreterState *);
+PyAPI_FUNC(PyThreadState *) PyInterpreterState_ThreadHead(PyInterpreterState *);
+PyAPI_FUNC(PyThreadState *) PyThreadState_Next(PyThreadState *);
+
+typedef struct _frame *(*PyThreadFrameGetter)(PyThreadState *self_);
+#endif
+
 /* Variable and macro for in-line access to current thread state */
 
 /* Assuming the current thread holds the GIL, this is the
    PyThreadState for the current thread. */
 #ifdef Py_BUILD_CORE
+#ifndef MS_WINDOWS
+#  include "internal/pystate.h"
+#endif
 #  define _PyThreadState_Current _PyRuntime.gilstate.tstate_current
 #  define PyThreadState_GET() \
              ((PyThreadState*)_Py_atomic_load_relaxed(&_PyThreadState_Current))
@@ -406,18 +421,6 @@ PyAPI_FUNC(PyInterpreterState *) _PyGILState_GetInterpreterStateUnsafe(void);
 */
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _PyThread_CurrentFrames(void);
-#endif
-
-/* Routines for advanced debuggers, requested by David Beazley.
-   Don't use unless you know what you are doing! */
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_Main(void);
-PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_Head(void);
-PyAPI_FUNC(PyInterpreterState *) PyInterpreterState_Next(PyInterpreterState *);
-PyAPI_FUNC(PyThreadState *) PyInterpreterState_ThreadHead(PyInterpreterState *);
-PyAPI_FUNC(PyThreadState *) PyThreadState_Next(PyThreadState *);
-
-typedef struct _frame *(*PyThreadFrameGetter)(PyThreadState *self_);
 #endif
 
 #ifdef __cplusplus

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import time
 import unittest
+from distutils.ccompiler import new_compiler, gen_lib_options
 from test import support
 
 TESTFN = support.TESTFN
@@ -539,6 +540,46 @@ class TestSupport(unittest.TestCase):
             support.set_match_tests(['test_access', 'DONTMATCH'])
             self.assertTrue(support.match_test(test_access))
             self.assertFalse(support.match_test(test_chdir))
+
+    @unittest.skipIf(os.name == "nt", "Test cannot run on Windows")
+    def test_build_extensions_as_builtins(self):
+        # https://bugs.python.org/issue32232
+
+
+        compiler = new_compiler()
+        base_dir = os.path.realpath(os.path.join(os.path.abspath(__file__),
+                                   "../../.."))
+
+        for _dir in ["./Python", "./Include", "./Objects", "."]:
+            compiler.add_include_dir(os.path.join(base_dir,_dir))
+
+        compiler.define_macro(name="Py_BUILD_CORE", value=1)
+
+
+        targets = [
+            "Modules/_stat.c", "Modules/_bisectmodule.c",
+            "Modules/_datetimemodule.c", "Modules/_lsprof.c",
+            "Modules/_opcode.c", "Modules/_localemodule.c",
+            "Modules/_heapqmodule.c", "Modules/_tracemalloc.c",
+            "Modules/_elementtree.c", "Modules/_hashopenssl.c",
+            "Modules/_weakref.c", "Modules/_operator.c",
+            "Modules/_cursesmodule.c", "Modules/_math.c",
+            "Modules/_asynciomodule.c", "Modules/_functoolsmodule.c",
+            "Modules/_randommodule.c", "Modules/_queuemodule.c",
+            "Modules/_uuidmodule.c", "Modules/_bz2module.c",
+            "Modules/_testimportmultiple.c", "Modules/_testbuffer.c",
+            "Modules/_collectionsmodule.c", "Modules/_posixsubprocess.c",
+            "Modules/_json.c", "Modules/_testmultiphase.c",
+            "Modules/_gdbmmodule.c", "Modules/_struct.c",
+            "Modules/_threadmodule.c", "Modules/_cryptmodule.c",
+            "Modules/_lzmamodule.c", "Modules/_sre.c",
+            "Modules/_csv.c", "Modules/_curses_panel.c", "Modules/_ssl.c",
+            "Modules/_codecsmodule.c", "Modules/_pickle.c"
+        ]
+
+        for target in targets:
+            object_file, = compiler.compile([os.path.join(base_dir,target)])
+            os.unlink(object_file)
 
 
     # XXX -follows a list of untested API


### PR DESCRIPTION
The [patch](https://bugs.python.org/file47325/ext-as-builtins.diff) involvin `Include/internal/pystate.h` and `Include/pystate.h` is by @doko42.

<!-- issue-number: bpo-32232 -->
https://bugs.python.org/issue32232
<!-- /issue-number -->
