### PR TITLE
cryptmodule: Include <crypt.h> for declaration of crypt() if needed

### DIFF
--- a/Modules/_cryptmodule.c
+++ b/Modules/_cryptmodule.c
@@ -5,6 +5,10 @@
 
 #include <sys/types.h>
 
+#ifndef _XOPEN_CRYPT
+#include <crypt.h>
+#endif
+
 /* Module crypt */
 
 /*[clinic input]


### PR DESCRIPTION
Not every target system may provide a crypt() function in its stdlibc
and may use an external or replacement library, like libxcrypt, for
providing such functions.