### PR TITLE
bpo-32304: Fix distutils upload for tar files ending with b'\r'

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -409,6 +409,11 @@ therefore included in source distributions.
 and ``platforms`` fields are not specified as a list or a string.
 (Contributed by Berker Peksag in :issue:`19610`.)
 
+The ``upload`` command now longer tries to change CR end-of-line characters
+to CRLF.  This fixes a corruption issue with sdists that ended with a byte
+equivalent to CR.
+(Contributed by Bo Bayles in :issue:`32304`.)
+
 http.client
 -----------
 

--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -159,7 +159,7 @@ class upload(PyPIRCCommand):
                 body.write(title.encode('utf-8'))
                 body.write(b"\r\n\r\n")
                 body.write(value)
-                if value and value[-1:] == b'\r':
+                if value and (value[-1:] == b'\r') and (key != 'content'):
                     body.write(b'\n')  # write an extra newline (lurve Macs)
         body.write(end_boundary)
         body = body.getvalue()

--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -159,8 +159,6 @@ class upload(PyPIRCCommand):
                 body.write(title.encode('utf-8'))
                 body.write(b"\r\n\r\n")
                 body.write(value)
-                if value and (value[-1:] == b'\r') and (key != 'content'):
-                    body.write(b'\n')  # write an extra newline (lurve Macs)
         body.write(end_boundary)
         body = body.getvalue()
 

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -154,7 +154,8 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
         dist_files = [(command, pyversion, filename)]
         self.write_file(self.rc, PYPIRC_LONG_PASSWORD)
 
-        # other fields that end with \r should not be modified.
+        # other fields that ended with \r used to be modified, now are
+        # preserved.
         pkg_dir, dist = self.create_dist(
             dist_files=dist_files,
             description='long description\r'
@@ -164,8 +165,6 @@ class uploadTestCase(BasePyPIRCCommandTestCase):
         cmd.ensure_finalized()
         cmd.run()
 
-        # an extra character should have been added to the description,
-        # but not to the content
         headers = dict(self.last_open.req.headers)
         self.assertEqual(headers['Content-length'], '2172')
         self.assertIn(b'long description\r', self.last_open.req.data)

--- a/Misc/NEWS.d/next/Library/2018-01-21-16-33-53.bpo-32304.TItrNv.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-21-16-33-53.bpo-32304.TItrNv.rst
@@ -1,0 +1,1 @@
+distutils no longer corrupts tar files ending with b'\x0d'

--- a/Misc/NEWS.d/next/Library/2018-01-21-16-33-53.bpo-32304.TItrNv.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-21-16-33-53.bpo-32304.TItrNv.rst
@@ -1,1 +1,2 @@
-distutils no longer corrupts tar files ending with b'\x0d'
+distutils' upload command no longer corrupts tar files ending with a CR byte,
+and no longer tries to convert CR to CRLF in any of the upload text fields.


### PR DESCRIPTION
This PR fixes issue 32304, in which `distutils`'s upload command corrupts tar files that end with `b'\r'` by appending `b'\n'` to them ([here](https://github.com/python/cpython/blob/56fe4749fb79609de7a6ab83f7d444d271f64e38/Lib/distutils/command/upload.py#L162-L163)).

[The original report](https://bugs.python.org/issue32304#msg308205) describes a simple fix, which is [endorsed](https://bugs.python.org/issue32304#msg308691). I've provided that fix here, plus a test that ensures that (1) the "content" doesn't get the newline appended, (2) the other keys do.

Of course, one wonders if fixing `'\r'` without `'\n'` is so important now that no major OSs use it?



<!-- issue-number: bpo-32304 -->
https://bugs.python.org/issue32304
<!-- /issue-number -->
