### PR TITLE
gh-72002: Make SSL suppress_ragged_eofs default more secure

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -400,11 +400,14 @@ class SSLContext(_SSLContext):
 
     def __init__(self, protocol=PROTOCOL_TLS):
         self.protocol = protocol
+        self.suppress_ragged_eofs = False
 
     def wrap_socket(self, sock, server_side=False,
                     do_handshake_on_connect=True,
-                    suppress_ragged_eofs=True,
+                    suppress_ragged_eofs=None,
                     server_hostname=None, session=None):
+        if suppress_ragged_eofs is None:
+            suppress_ragged_eofs = self.suppress_ragged_eofs
         return self.sslsocket_class(
             sock=sock,
             server_side=server_side,
@@ -737,7 +740,7 @@ class SSLSocket(socket):
                  ssl_version=PROTOCOL_TLS, ca_certs=None,
                  do_handshake_on_connect=True,
                  family=AF_INET, type=SOCK_STREAM, proto=0, fileno=None,
-                 suppress_ragged_eofs=True, npn_protocols=None, ciphers=None,
+                 suppress_ragged_eofs=False, npn_protocols=None, ciphers=None,
                  server_hostname=None,
                  _context=None, _session=None):
 
@@ -1156,7 +1159,7 @@ def wrap_socket(sock, keyfile=None, certfile=None,
                 server_side=False, cert_reqs=CERT_NONE,
                 ssl_version=PROTOCOL_TLS, ca_certs=None,
                 do_handshake_on_connect=True,
-                suppress_ragged_eofs=True,
+                suppress_ragged_eofs=False,
                 ciphers=None):
     return SSLSocket(sock=sock, keyfile=keyfile, certfile=certfile,
                      server_side=server_side, cert_reqs=cert_reqs,

--- a/Lib/test/test_imaplib.py
+++ b/Lib/test/test_imaplib.py
@@ -635,7 +635,11 @@ class ThreadedNetworkedTests(unittest.TestCase):
                 self.wfile.write(b'* OK')
 
         with self.reaped_server(EOFHandler) as server:
-            self.assertRaises(imaplib.IMAP4.abort,
+            if isinstance(server, SecureTCPServer):
+                exception = ssl.SSLEOFError
+            else:
+                exception = imaplib.IMAP4.abort
+            self.assertRaises(exception,
                               self.imap_class, *server.server_address)
 
     @reap_threads

--- a/Misc/NEWS.d/next/Library/2018-01-21-18-44-09.bpo-27815.nF1zEi.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-21-18-44-09.bpo-27815.nF1zEi.rst
@@ -1,0 +1,9 @@
+SSL
+
+The *suppress_ragged_eofs* setting is now disabled by default. This means
+that by default a TCP shutdown, which may not be secure, raises
+:exc:`~ssl.SSLEOFError`, and applications can distinguish a secure SSL
+shutdown from a truncation attack.  There is a new
+:attr:`SSLContext.suppress_ragged_eofs
+<ssl.SSLContext.suppress_ragged_eofs>` attribute, which can be used to re-
+enable the setting via a context object.

--- a/Misc/NEWS.d/next/Library/2018-01-21-18-44-09.bpo-27815.nF1zEi.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-21-18-44-09.bpo-27815.nF1zEi.rst
@@ -6,4 +6,4 @@ that by default a TCP shutdown, which may not be secure, raises
 shutdown from a truncation attack.  There is a new
 :attr:`SSLContext.suppress_ragged_eofs
 <ssl.SSLContext.suppress_ragged_eofs>` attribute, which can be used to re-
-enable the setting via a context object.
+enable the setting via a context object.  Patch by Martin Panter.


### PR DESCRIPTION
Patch by Martin Panter.

<!-- issue-number: bpo-27815 -->
https://bugs.python.org/issue27815
<!-- /issue-number -->

<!-- gh-issue-number: gh-72002 -->
* Issue: gh-72002
<!-- /gh-issue-number -->
