### PR TITLE
urllib.request: Remove unused import

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -1792,7 +1792,6 @@ class URLopener:
             if filename:
                 tfp = open(filename, 'wb')
             else:
-                import tempfile
                 garbage, path = splittype(url)
                 garbage, path = splithost(path or "")
                 path, garbage = splitquery(path or "")


### PR DESCRIPTION
urllib.request imports tempfile at top of the module.
`import tempfile` in function is not needed.