### PR TITLE
bpo-32618: Fix test_mutatingdecodehandler not testing test.mutating

### DIFF
--- a/Lib/test/test_codeccallbacks.py
+++ b/Lib/test/test_codeccallbacks.py
@@ -1043,7 +1043,7 @@ class CodecCallbackTest(unittest.TestCase):
             # unicode-internal has been deprecated
             for (encoding, data) in baddata:
                 with self.assertRaises(TypeError):
-                    data.decode(encoding, "test.replacing")
+                    data.decode(encoding, "test.mutating")
 
     def test_fake_error_class(self):
         handlers = [

--- a/Lib/test/test_codeccallbacks.py
+++ b/Lib/test/test_codeccallbacks.py
@@ -1032,7 +1032,7 @@ class CodecCallbackTest(unittest.TestCase):
 
         def mutating(exc):
             if isinstance(exc, UnicodeDecodeError):
-                exc.object[:] = b""
+                exc.object = b""
                 return ("\u4242", 0)
             else:
                 raise TypeError("don't know how to handle %r" % exc)
@@ -1042,8 +1042,7 @@ class CodecCallbackTest(unittest.TestCase):
         with test.support.check_warnings():
             # unicode-internal has been deprecated
             for (encoding, data) in baddata:
-                with self.assertRaises(TypeError):
-                    data.decode(encoding, "test.mutating")
+                self.assertEqual(data.decode(encoding, "test.mutating"), "\u4242")
 
     def test_fake_error_class(self):
         handlers = [


### PR DESCRIPTION
It should test both test.replacing and test.mutating instead of test test.replacing twice.

<!-- issue-number: bpo-32618 -->
https://bugs.python.org/issue32618
<!-- /issue-number -->
