### PR TITLE
[3.5] bpo-32620: Remove failing pyenv call from CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ matrix:
       # compiler here and the other to run the coverage build. Clang is preferred
       # in this instance for its better error messages.
       env: TESTING=cpython
-      before_install:
-        # work around https://github.com/travis-ci/travis-ci/issues/8363
-        - pyenv global system 3.5
     - os: osx
       language: c
       compiler: clang

--- a/Lib/test/test_xmlrpc_net.py
+++ b/Lib/test/test_xmlrpc_net.py
@@ -7,6 +7,7 @@ from test import support
 
 import xmlrpc.client as xmlrpclib
 
+@unittest.skip('XXX: buildbot.python.org/all/xmlrpc/ is gone')
 class PythonBuildersTest(unittest.TestCase):
 
     def test_python_builders(self):


### PR DESCRIPTION
This workaround for bpo-31568 is now itself causing CI failures.

Drop it entirely so CI can start running on the 3.5 branch again.

<!-- issue-number: bpo-32620 -->
https://bugs.python.org/issue32620
<!-- /issue-number -->
