### PR TITLE
bpo-32593: Run autoconf

### DIFF
--- a/configure
+++ b/configure
@@ -3355,10 +3355,6 @@ $as_echo "#define _BSD_SOURCE 1" >>confdefs.h
   # but used in struct sockaddr.sa_family. Reported by Tim Rice.
   SCO_SV/3.2)
     define_xopen_source=no;;
-  # On FreeBSD 4, the math functions C89 does not cover are never defined
-  # with _XOPEN_SOURCE and __BSD_VISIBLE does not re-enable them.
-  FreeBSD/4.*)
-    define_xopen_source=no;;
   # On MacOS X 10.2, a bug in ncurses.h means that it craps out if
   # _XOPEN_EXTENDED_SOURCE is defined. Apparently, this is fixed in 10.3, which
   # identifies itself as Darwin/7.*


### PR DESCRIPTION
Update configure since configure.ac was modified to drop support for
FreeBSD 4.

<!-- issue-number: bpo-32593 -->
https://bugs.python.org/issue32593
<!-- /issue-number -->
