### PR TITLE
bpo-20361: Remove workaround for a now fixed bug

### DIFF
--- a/Tools/scripts/run_tests.py
+++ b/Tools/scripts/run_tests.py
@@ -30,9 +30,6 @@ def main(regrtest_args):
     # Allow user-specified interpreter options to override our defaults.
     args.extend(test.support.args_from_interpreter_flags())
 
-    # Workaround for issue #20361
-    args.extend(['-W', 'error::BytesWarning'])
-
     args.extend(['-m', 'test',    # Run the test suite
                  '-r',            # Randomize test order
                  '-w',            # Re-run failed tests in verbose mode


### PR DESCRIPTION
"python3 -bb -Wd" now works as expected:
"python3 -bb -Wd -Werror::BytesWarning" is no more needed.

<!-- issue-number: bpo-20361 -->
https://bugs.python.org/issue20361
<!-- /issue-number -->
