### PR TITLE
bpo-32635: Fix a segfault when importing the crypt module with libxcrypt.

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -35,6 +35,9 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+#ifdef HAVE_CRYPT_H
+#include <crypt.h>
+#endif
 
 /* For size_t? */
 #ifdef HAVE_STDDEF_H

--- a/Misc/NEWS.d/next/Build/2018-01-23-15-33-40.bpo-32635.qHwIZy.rst
+++ b/Misc/NEWS.d/next/Build/2018-01-23-15-33-40.bpo-32635.qHwIZy.rst
@@ -1,0 +1,2 @@
+Fix segfault of the crypt module when libxcrypt is provided instead of
+libcrypt at the system.

--- a/configure
+++ b/configure
@@ -7682,7 +7682,7 @@ $as_echo "#define STDC_HEADERS 1" >>confdefs.h
 
 fi
 
-for ac_header in asm/types.h conio.h direct.h dlfcn.h errno.h \
+for ac_header in asm/types.h crypt.h conio.h direct.h dlfcn.h errno.h \
 fcntl.h grp.h \
 ieeefp.h io.h langinfo.h libintl.h process.h pthread.h \
 sched.h shadow.h signal.h stropts.h termios.h \

--- a/configure.ac
+++ b/configure.ac
@@ -2041,7 +2041,7 @@ dnl AC_MSG_RESULT($cpp_type)
 
 # checks for header files
 AC_HEADER_STDC
-AC_CHECK_HEADERS(asm/types.h conio.h direct.h dlfcn.h errno.h \
+AC_CHECK_HEADERS(asm/types.h crypt.h conio.h direct.h dlfcn.h errno.h \
 fcntl.h grp.h \
 ieeefp.h io.h langinfo.h libintl.h process.h pthread.h \
 sched.h shadow.h signal.h stropts.h termios.h \

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -140,6 +140,9 @@
 /* Define to 1 if you have the `copysign' function. */
 #undef HAVE_COPYSIGN
 
+/* Define to 1 if you have the <crypt.h> header file. */
+#undef HAVE_CRYPT_H
+
 /* Define to 1 if you have the `ctermid' function. */
 #undef HAVE_CTERMID
 


### PR DESCRIPTION
glibc is deprecating libcrypt in favor of libxcrypt, however python assumes
that crypt.h will always be included. This change makes the header inclusion
explicit when libxcrypt is present on the system.


<!-- issue-number: bpo-32635 -->
https://bugs.python.org/issue32635
<!-- /issue-number -->
