### PR TITLE
bpo-32637: Set sys.platform to "android" on Android

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -999,7 +999,12 @@ always available.
    Windows          ``'win32'``
    Windows/Cygwin   ``'cygwin'``
    Mac OS X         ``'darwin'``
+   Android          ``'android'``
    ================ ===========================
+
+   .. versionchanged:: 3.7
+      On Android, :attr:`sys.platform` is now equal to ``"android"`` rather
+      than ``'linux'``.
 
    .. versionchanged:: 3.3
       On Linux, :attr:`sys.platform` doesn't contain the major version anymore.

--- a/Misc/NEWS.d/next/Library/2018-01-24-00-52-55.bpo-32637.ntAPTa.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-24-00-52-55.bpo-32637.ntAPTa.rst
@@ -1,0 +1,1 @@
+Set sys.platform to "android" on Android.

--- a/Python/getplatform.c
+++ b/Python/getplatform.c
@@ -5,6 +5,12 @@
 #define PLATFORM "unknown"
 #endif
 
+/* bpo-32637: Force sys.platform == "android" on Android */
+#ifdef __ANDROID__
+#  undef PLATFORM
+#  define "android"
+#endif
+
 const char *
 Py_GetPlatform(void)
 {

--- a/Python/getplatform.c
+++ b/Python/getplatform.c
@@ -8,7 +8,7 @@
 /* bpo-32637: Force sys.platform == "android" on Android */
 #ifdef __ANDROID__
 #  undef PLATFORM
-#  define "android"
+#  define PLATFORM "android"
 #endif
 
 const char *


### PR DESCRIPTION


<!-- issue-number: bpo-32637 -->
https://bugs.python.org/issue32637
<!-- /issue-number -->
