### PR TITLE
bpo-28046: Remove MACHDEPPATH from Modules/Setup.dist

### DIFF
--- a/Modules/Setup.dist
+++ b/Modules/Setup.dist
@@ -93,11 +93,7 @@ SITEPATH=
 # Standard path components for test modules
 TESTPATH=
 
-# Path components for machine- or system-dependent modules and shared libraries
-MACHDEPPATH=:$(PLATDIR)
-EXTRAMACHDEPPATH=
-
-COREPYTHONPATH=$(DESTPATH)$(SITEPATH)$(TESTPATH)$(MACHDEPPATH)$(EXTRAMACHDEPPATH)
+COREPYTHONPATH=$(DESTPATH)$(SITEPATH)$(TESTPATH)
 PYTHONPATH=$(COREPYTHONPATH)
 
 


### PR DESCRIPTION
Makefile $MACHDEPPATH uses $PLATDIR, but this variable was removed.
So remove also $MACHDEPPATH.

Remove also $EXTRAMACHDEPPATH.

<!-- issue-number: bpo-28046 -->
https://bugs.python.org/issue28046
<!-- /issue-number -->
