### PR TITLE
bpo-32643: Drop support for a few private Task and Future APIs.

### DIFF
--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -131,10 +131,10 @@ class Future:
         if self._state != _PENDING:
             return False
         self._state = _CANCELLED
-        self._schedule_callbacks()
+        self.__schedule_callbacks()
         return True
 
-    def _schedule_callbacks(self):
+    def __schedule_callbacks(self):
         """Internal: Ask the event loop to call all callbacks.
 
         The callbacks are scheduled to be called as soon as possible. Also
@@ -234,7 +234,7 @@ class Future:
             raise InvalidStateError('{}: {!r}'.format(self._state, self))
         self._result = result
         self._state = _FINISHED
-        self._schedule_callbacks()
+        self.__schedule_callbacks()
 
     def set_exception(self, exception):
         """Mark the future done and set an exception.
@@ -251,7 +251,7 @@ class Future:
                             "and cannot be raised into a Future")
         self._exception = exception
         self._state = _FINISHED
-        self._schedule_callbacks()
+        self.__schedule_callbacks()
         self.__log_traceback = True
 
     def __await__(self):

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -176,10 +176,6 @@ class BaseFutureTests:
             fut.remove_done_callback(lambda f: None)
 
         fut = self.cls.__new__(self.cls, loop=self.loop)
-        with self.assertRaises((RuntimeError, AttributeError)):
-            fut._schedule_callbacks()
-
-        fut = self.cls.__new__(self.cls, loop=self.loop)
         try:
             repr(fut)
         except (RuntimeError, AttributeError):

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1401,17 +1401,6 @@ class BaseTaskTests:
         self.assertTrue(t.done())
         self.assertIsNone(t.result())
 
-    def test_step_with_baseexception(self):
-        @asyncio.coroutine
-        def notmutch():
-            raise BaseException()
-
-        task = self.new_task(self.loop, notmutch())
-        self.assertRaises(BaseException, task._step)
-
-        self.assertTrue(task.done())
-        self.assertIsInstance(task.exception(), BaseException)
-
     def test_baseexception_during_cancel(self):
 
         def gen():
@@ -2275,22 +2264,12 @@ def add_subclass_tests(cls):
             self.calls = collections.defaultdict(lambda: 0)
             super().__init__(*args, **kwargs)
 
-        def _schedule_callbacks(self):
-            self.calls['_schedule_callbacks'] += 1
-            return super()._schedule_callbacks()
-
         def add_done_callback(self, *args, **kwargs):
             self.calls['add_done_callback'] += 1
             return super().add_done_callback(*args, **kwargs)
 
     class Task(CommonFuture, BaseTask):
-        def _step(self, *args):
-            self.calls['_step'] += 1
-            return super()._step(*args)
-
-        def _wakeup(self, *args):
-            self.calls['_wakeup'] += 1
-            return super()._wakeup(*args)
+        pass
 
     class Future(CommonFuture, BaseFuture):
         pass
@@ -2310,12 +2289,11 @@ def add_subclass_tests(cls):
 
         self.assertEqual(
             dict(task.calls),
-            {'_step': 2, '_wakeup': 1, 'add_done_callback': 1,
-             '_schedule_callbacks': 1})
+            {'add_done_callback': 1})
 
         self.assertEqual(
             dict(fut.calls),
-            {'add_done_callback': 1, '_schedule_callbacks': 1})
+            {'add_done_callback': 1})
 
     # Add patched Task & Future back to the test case
     cls.Task = Task

--- a/Misc/NEWS.d/next/Library/2018-01-24-00-32-58.bpo-32643.VWipsW.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-24-00-32-58.bpo-32643.VWipsW.rst
@@ -1,0 +1,2 @@
+Make Task._step, Task._wakeup and Future._schedule_callbacks methods
+private.

--- a/Modules/clinic/_asynciomodule.c.h
+++ b/Modules/clinic/_asynciomodule.c.h
@@ -252,23 +252,6 @@ _asyncio_Future__repr_info(FutureObj *self, PyObject *Py_UNUSED(ignored))
     return _asyncio_Future__repr_info_impl(self);
 }
 
-PyDoc_STRVAR(_asyncio_Future__schedule_callbacks__doc__,
-"_schedule_callbacks($self, /)\n"
-"--\n"
-"\n");
-
-#define _ASYNCIO_FUTURE__SCHEDULE_CALLBACKS_METHODDEF    \
-    {"_schedule_callbacks", (PyCFunction)_asyncio_Future__schedule_callbacks, METH_NOARGS, _asyncio_Future__schedule_callbacks__doc__},
-
-static PyObject *
-_asyncio_Future__schedule_callbacks_impl(FutureObj *self);
-
-static PyObject *
-_asyncio_Future__schedule_callbacks(FutureObj *self, PyObject *Py_UNUSED(ignored))
-{
-    return _asyncio_Future__schedule_callbacks_impl(self);
-}
-
 PyDoc_STRVAR(_asyncio_Task___init____doc__,
 "Task(coro, *, loop=None)\n"
 "--\n"
@@ -501,64 +484,6 @@ exit:
     return return_value;
 }
 
-PyDoc_STRVAR(_asyncio_Task__step__doc__,
-"_step($self, /, exc=None)\n"
-"--\n"
-"\n");
-
-#define _ASYNCIO_TASK__STEP_METHODDEF    \
-    {"_step", (PyCFunction)_asyncio_Task__step, METH_FASTCALL|METH_KEYWORDS, _asyncio_Task__step__doc__},
-
-static PyObject *
-_asyncio_Task__step_impl(TaskObj *self, PyObject *exc);
-
-static PyObject *
-_asyncio_Task__step(TaskObj *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
-{
-    PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"exc", NULL};
-    static _PyArg_Parser _parser = {"|O:_step", _keywords, 0};
-    PyObject *exc = Py_None;
-
-    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
-        &exc)) {
-        goto exit;
-    }
-    return_value = _asyncio_Task__step_impl(self, exc);
-
-exit:
-    return return_value;
-}
-
-PyDoc_STRVAR(_asyncio_Task__wakeup__doc__,
-"_wakeup($self, /, fut)\n"
-"--\n"
-"\n");
-
-#define _ASYNCIO_TASK__WAKEUP_METHODDEF    \
-    {"_wakeup", (PyCFunction)_asyncio_Task__wakeup, METH_FASTCALL|METH_KEYWORDS, _asyncio_Task__wakeup__doc__},
-
-static PyObject *
-_asyncio_Task__wakeup_impl(TaskObj *self, PyObject *fut);
-
-static PyObject *
-_asyncio_Task__wakeup(TaskObj *self, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
-{
-    PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"fut", NULL};
-    static _PyArg_Parser _parser = {"O:_wakeup", _keywords, 0};
-    PyObject *fut;
-
-    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
-        &fut)) {
-        goto exit;
-    }
-    return_value = _asyncio_Task__wakeup_impl(self, fut);
-
-exit:
-    return return_value;
-}
-
 PyDoc_STRVAR(_asyncio_Task_set_result__doc__,
 "set_result($self, result, /)\n"
 "--\n"
@@ -786,4 +711,4 @@ _asyncio__leave_task(PyObject *module, PyObject *const *args, Py_ssize_t nargs, 
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=bcbaf1b2480f4aa9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=b6148b0134e7a819 input=a9049054013a1b77]*/


### PR DESCRIPTION
Specifically, it's not possible to subclass Task/Future classes
and override the following methods:

* Future._schedule_callbacks
* Task._step
* Task._wakeup



<!-- issue-number: bpo-32643 -->
https://bugs.python.org/issue32643
<!-- /issue-number -->
