### PR TITLE
bpo-32652: Defer pymain_set_global_config() call

### DIFF
--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -223,6 +223,21 @@ class UTF8ModeTests(unittest.TestCase):
             c_arg = arg_ascii
         check('utf8=0', [c_arg], LC_ALL='C')
 
+    def test_optim_level(self):
+        # CPython: check that Py_Main() doesn't increment Py_OptimizeFlag
+        # twice when -X utf8 requires to parse the configuration twice (when
+        # the encoding changes after reading the configuration, the
+        # configuration is read again with the new encoding).
+        code = 'import sys; print(sys.flags.optimize)'
+        out = self.get_output('-X', 'utf8', '-O', '-c', code)
+        self.assertEqual(out, '1')
+        out = self.get_output('-X', 'utf8', '-OO', '-c', code)
+        self.assertEqual(out, '2')
+
+        code = 'import sys; print(sys.flags.ignore_environment)'
+        out = self.get_output('-X', 'utf8', '-E', '-c', code)
+        self.assertEqual(out, '1')
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In Py_Main(), don't call pymain_set_global_config() early: only call
it when the whole configuration has been read.

Add an unit test to prevent future regression.

<!-- issue-number: bpo-32652 -->
https://bugs.python.org/issue32652
<!-- /issue-number -->
