### PR TITLE
bpo-32659: Solaris "stat" should support "st_fstype"

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2390,6 +2390,14 @@ features:
 
       Time of file creation.
 
+   On Solaris and derivatives, the following attributes may also be
+   available:
+
+   .. attribute:: st_fstype
+
+      String that uniquely identifies the type of the filesystem that
+      contains the file.
+
    On Mac OS systems, the following attributes may also be available:
 
    .. attribute:: st_rsize

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2441,6 +2441,8 @@ features:
    .. versionadded:: 3.5
       Added the :attr:`st_file_attributes` member on Windows.
 
+   .. versionadded:: 3.7
+      Added the :attr:`st_fstype` member to Solaris/derivatives.
 
 .. function:: statvfs(path)
 

--- a/Misc/NEWS.d/next/Library/2018-01-25-03-46-00.bpo-32659.VHYoON.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-25-03-46-00.bpo-32659.VHYoON.rst
@@ -1,0 +1,1 @@
+Under Solaris and derivatives, :class:`os.stat_result` provides a st_fstype attribute.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -394,6 +394,10 @@ static int win32_can_symlink = 0;
 #define MODNAME "posix"
 #endif
 
+#if defined(__sun)
+/* Something to implement in autoconf, not present in autoconf 2.69 */
+#define HAVE_STRUCT_STAT_ST_FSTYPE 1
+#endif
 
 #ifdef HAVE_FORK
 static void
@@ -1789,6 +1793,9 @@ static PyStructSequence_Field stat_result_fields[] = {
 #ifdef HAVE_STRUCT_STAT_ST_FILE_ATTRIBUTES
     {"st_file_attributes", "Windows file attribute bits"},
 #endif
+#ifdef HAVE_STRUCT_STAT_ST_FSTYPE
+    {"st_fstype",  "Type of filesystem"},
+#endif
     {0}
 };
 
@@ -1832,6 +1839,12 @@ static PyStructSequence_Field stat_result_fields[] = {
 #define ST_FILE_ATTRIBUTES_IDX (ST_BIRTHTIME_IDX+1)
 #else
 #define ST_FILE_ATTRIBUTES_IDX ST_BIRTHTIME_IDX
+#endif
+
+#ifdef HAVE_STRUCT_STAT_ST_FSTYPE
+#define ST_FSTYPE_IDX (ST_FILE_ATTRIBUTES_IDX+1)
+#else
+#define ST_FSTYPE_IDX ST_FILE_ATTRIBUTES_IDX
 #endif
 
 static PyStructSequence_Desc stat_result_desc = {
@@ -2056,6 +2069,10 @@ _pystat_fromstructstat(STRUCT_STAT *st)
 #ifdef HAVE_STRUCT_STAT_ST_FILE_ATTRIBUTES
     PyStructSequence_SET_ITEM(v, ST_FILE_ATTRIBUTES_IDX,
                               PyLong_FromUnsignedLong(st->st_file_attributes));
+#endif
+#ifdef HAVE_STRUCT_STAT_ST_FSTYPE
+   PyStructSequence_SET_ITEM(v, ST_FSTYPE_IDX,
+                              PyUnicode_FromString(st->st_fstype));
 #endif
 
     if (PyErr_Occurred()) {


### PR DESCRIPTION
Trivial patch. The only questionable thing is the `__sun` define use. This is needed because autoconf doesn't test `st_fstype`. This would be something to patch in autoconf.

Example:

```
$ LD_LIBRARY_PATH=/home/cpython/cpython-bpo-32659 ./python
Python 3.7.0a4+ (default, Jan 25 2018, 03:34:04) 
[GCC 4.9.4] on sunos5
Type "help", "copyright", "credits" or "license" for more information.
>>> os.stat('/etc/passwd').st_fstype
'zfs'
```

<!-- issue-number: bpo-32659 -->
https://bugs.python.org/issue32659
<!-- /issue-number -->
