### PR TITLE
gh-76809: support DirectoryIndex for http server

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -328,6 +328,14 @@ of which this module provides three different variants:
 
       If not specified, the directory to serve is the current working directory.
 
+   .. attribute:: directory_index
+
+      A list of files to potentially serve for a request for a directory,
+      rather than the set of files in the directory. The default list
+      is ``index.html`` and ``index.htm``.
+
+      .. versionadded:: 3.7
+
    The :class:`SimpleHTTPRequestHandler` class defines the following methods:
 
    .. method:: do_HEAD()

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -680,7 +680,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                 self.send_header("Location", new_url)
                 self.end_headers()
                 return None
-            for index in "index.html", "index.htm":
+            for index in self.directory_index:
                 index = os.path.join(path, index)
                 if os.path.exists(index):
                     path = index
@@ -872,6 +872,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
         '.c': 'text/plain',
         '.h': 'text/plain',
         })
+    directory_index = ["index.html", "index.htm"]
 
 
 # Utilities for CGIHTTPRequestHandler

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1189,6 +1189,7 @@ Gaël Pasgrimaud
 Feanil Patel
 Ashish Nitin Patil
 Alecsandru Patrascu
+Erik Paulson
 Randy Pausch
 Samuele Pedroni
 Justin Peel

--- a/Misc/NEWS.d/next/Library/2018-01-25-03-55-28.bpo-32628.ize0Jq.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-25-03-55-28.bpo-32628.ize0Jq.rst
@@ -1,0 +1,2 @@
+Add directory_index list to SimpleHTTPRequestHandler to support more than
+index.html and index.htm


### PR DESCRIPTION
SimpleHTTPRequestHandler is hard-coded to only use index.html or index.htm
as files to serve for a request for a directory. With this change, this list
can be modified, ala the DirectoryIndex directive of an Apache web server.


<!-- issue-number: bpo-32628 -->
https://bugs.python.org/issue32628
<!-- /issue-number -->

<!-- gh-issue-number: gh-76809 -->
* Issue: gh-76809
<!-- /gh-issue-number -->
