### PR TITLE
gh-56915: timeout sentinel in ftplib and poplib documentation

### DIFF
--- a/Doc/library/ftplib.rst
+++ b/Doc/library/ftplib.rst
@@ -40,7 +40,7 @@ Here's a sample session using the :mod:`ftplib` module::
 
 The module defines the following items:
 
-.. class:: FTP(host='', user='', passwd='', acct='', timeout=None, source_address=None)
+.. class:: FTP(host='', user='', passwd='', acct='', timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None)
 
    Return a new instance of the :class:`FTP` class.  When *host* is given, the
    method call ``connect(host)`` is made.  When *user* is given, additionally
@@ -72,7 +72,7 @@ The module defines the following items:
       *source_address* parameter was added.
 
 
-.. class:: FTP_TLS(host='', user='', passwd='', acct='', keyfile=None, certfile=None, context=None, timeout=None, source_address=None)
+.. class:: FTP_TLS(host='', user='', passwd='', acct='', keyfile=None, certfile=None, context=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT source_address=None)
 
    A :class:`FTP` subclass which adds TLS support to FTP as described in
    :rfc:`4217`.
@@ -176,7 +176,7 @@ followed by ``lines`` for the text version or ``binary`` for the binary version.
    debugging output, logging each line sent and received on the control connection.
 
 
-.. method:: FTP.connect(host='', port=0, timeout=None, source_address=None)
+.. method:: FTP.connect(host='', port=0, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, source_address=None)
 
    Connect to the given host and port.  The default port number is ``21``, as
    specified by the FTP protocol specification.  It is rarely needed to specify a

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -31,7 +31,7 @@ mailserver supports IMAP, you would be better off using the
 The :mod:`poplib` module provides two classes:
 
 
-.. class:: POP3(host, port=POP3_PORT[, timeout])
+.. class:: POP3(host, port=POP3_PORT, timeout=socket._GLOBAL_DEFAULT_TIMEOUT)
 
    This class implements the actual POP3 protocol.  The connection is created when
    the instance is initialized. If *port* is omitted, the standard POP3 port (110)
@@ -40,7 +40,7 @@ The :mod:`poplib` module provides two classes:
    be used).
 
 
-.. class:: POP3_SSL(host, port=POP3_SSL_PORT, keyfile=None, certfile=None, timeout=None, context=None)
+.. class:: POP3_SSL(host, port=POP3_SSL_PORT, keyfile=None, certfile=None, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, context=None)
 
    This is a subclass of :class:`POP3` that connects to the server over an SSL
    encrypted socket.  If *port* is not specified, 995, the standard POP3-over-SSL

--- a/Doc/library/poplib.rst
+++ b/Doc/library/poplib.rst
@@ -31,7 +31,7 @@ mailserver supports IMAP, you would be better off using the
 The :mod:`poplib` module provides two classes:
 
 
-.. class:: POP3(host, port=POP3_PORT, timeout=socket._GLOBAL_DEFAULT_TIMEOUT)
+.. class:: POP3(host, port=POP3_PORT[, timeout])
 
    This class implements the actual POP3 protocol.  The connection is created when
    the instance is initialized. If *port* is omitted, the standard POP3 port (110)

--- a/Lib/ftplib.py
+++ b/Lib/ftplib.py
@@ -132,7 +132,7 @@ class FTP:
                 if self.sock is not None:
                     self.close()
 
-    def connect(self, host='', port=0, timeout=-999, source_address=None):
+    def connect(self, host='', port=0, timeout=_GLOBAL_DEFAULT_TIMEOUT, source_address=None):
         '''Connect to host.  Arguments are:
          - host: hostname to connect to (string, default previous host)
          - port: port to connect to (integer, default previous port)
@@ -144,7 +144,7 @@ class FTP:
             self.host = host
         if port > 0:
             self.port = port
-        if timeout != -999:
+        if timeout is not _GLOBAL_DEFAULT_TIMEOUT:
             self.timeout = timeout
         if source_address is not None:
             self.source_address = source_address

--- a/Misc/NEWS.d/next/Documentation/2018-01-24-20-50-49.bpo-12706.x8hX4N.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-24-20-50-49.bpo-12706.x8hX4N.rst
@@ -1,0 +1,1 @@
+Update on ftplib and poplib documentation timeout value

--- a/Misc/NEWS.d/next/Documentation/2018-01-24-20-50-49.bpo-12706.x8hX4N.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-24-20-50-49.bpo-12706.x8hX4N.rst
@@ -1,1 +1,0 @@
-Update on ftplib and poplib documentation timeout value


### PR DESCRIPTION
Original patch by Greg (εσχατοκυριος)


<!-- issue-number: bpo-12706 -->
https://bugs.python.org/issue12706
<!-- /issue-number -->

<!-- gh-issue-number: gh-56915 -->
* Issue: gh-56915
<!-- /gh-issue-number -->
