### PR TITLE
bpo-31972: Improve docstrings for pathlib classes

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -939,11 +939,17 @@ os.PathLike.register(PurePath)
 
 
 class PurePosixPath(PurePath):
+    """On a POSIX system, instantiating a PurePath should return this object.
+    However, you can also instantiate it directly on any system.
+    """
     _flavour = _posix_flavour
     __slots__ = ()
 
 
 class PureWindowsPath(PurePath):
+    """On a Windows system, instantiating a PurePath should return this object.
+    However, you can also instantiate it directly on any system.
+    """
     _flavour = _windows_flavour
     __slots__ = ()
 
@@ -952,6 +958,12 @@ class PureWindowsPath(PurePath):
 
 
 class Path(PurePath):
+    """Path represents a filesystem path but unlike PurePath, also offers
+    methods to do system calls on path objects. Depending on your system,
+    instantiating a Path will return either a PosixPath or a WindowsPath
+    object. You can also instantiate a PosixPath or WindowsPath directly,
+    but cannot instantiate a WindowsPath on a POSIX system or vice versa.
+    """
     __slots__ = (
         '_accessor',
         '_closed',
@@ -1427,9 +1439,15 @@ class Path(PurePath):
 
 
 class PosixPath(Path, PurePosixPath):
+    """
+    On a POSIX system, instantiating a Path should return this object.
+    """
     __slots__ = ()
 
 class WindowsPath(Path, PureWindowsPath):
+    """
+    On a Windows system, instantiating a Path should return this object.
+    """
     __slots__ = ()
 
     def owner(self):

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -584,7 +584,9 @@ class _PathParents(Sequence):
 
 
 class PurePath(object):
-    """PurePath represents a filesystem path and offers operations which
+    """Deal with paths without any filesystem I/O.
+
+    PurePath represents a filesystem path and offers operations which
     don't imply any actual filesystem I/O.  Depending on your system,
     instantiating a PurePath will return either a PurePosixPath or a
     PureWindowsPath object.  You can also instantiate either of these classes
@@ -939,7 +941,9 @@ os.PathLike.register(PurePath)
 
 
 class PurePosixPath(PurePath):
-    """On a POSIX system, instantiating a PurePath should return this object.
+    """PurePath subclass for non-Windows systems.
+
+    On a POSIX system, instantiating a PurePath should return this object.
     However, you can also instantiate it directly on any system.
     """
     _flavour = _posix_flavour
@@ -947,7 +951,9 @@ class PurePosixPath(PurePath):
 
 
 class PureWindowsPath(PurePath):
-    """On a Windows system, instantiating a PurePath should return this object.
+    """PurePath subclass for Windows systems.
+
+    On a Windows system, instantiating a PurePath should return this object.
     However, you can also instantiate it directly on any system.
     """
     _flavour = _windows_flavour
@@ -958,7 +964,9 @@ class PureWindowsPath(PurePath):
 
 
 class Path(PurePath):
-    """Path represents a filesystem path but unlike PurePath, also offers
+    """PurePath subclass that can make system calls.
+
+    Path represents a filesystem path but unlike PurePath, also offers
     methods to do system calls on path objects. Depending on your system,
     instantiating a Path will return either a PosixPath or a WindowsPath
     object. You can also instantiate a PosixPath or WindowsPath directly,
@@ -1439,13 +1447,15 @@ class Path(PurePath):
 
 
 class PosixPath(Path, PurePosixPath):
-    """
+    """Path subclass for non-Windows systems.
+
     On a POSIX system, instantiating a Path should return this object.
     """
     __slots__ = ()
 
 class WindowsPath(Path, PureWindowsPath):
-    """
+    """Path subclass for Windows systems.
+
     On a Windows system, instantiating a Path should return this object.
     """
     __slots__ = ()

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -584,7 +584,7 @@ class _PathParents(Sequence):
 
 
 class PurePath(object):
-    """Deal with paths without any filesystem I/O.
+    """Base class for manipulating paths without I/O.
 
     PurePath represents a filesystem path and offers operations which
     don't imply any actual filesystem I/O.  Depending on your system,

--- a/Misc/NEWS.d/next/Documentation/2018-01-25-14-23-12.bpo-31972.w1m_8r.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-25-14-23-12.bpo-31972.w1m_8r.rst
@@ -1,0 +1,1 @@
+Improve docstrings for `pathlib.PurePath` subclasses.


### PR DESCRIPTION
The classes that inherit from PurePath do not have docstrings,
and therefore inherit the docstrings from PurePath. This is confusing
because a developer may assume that Path works similarly to PurePath,
which of course it doesn't. This adds a docstring to Path as well as
to the other PurePath children that is more indicative of their role.

<!-- issue-number: bpo-31972 -->
https://bugs.python.org/issue31972
<!-- /issue-number -->
