### PR TITLE
bpo-29708: support SOURCE_DATE_EPOCH for build info

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -737,6 +737,16 @@ regen-all: regen-opcode regen-opcode-targets regen-typeslots regen-grammar regen
 ############################################################################
 # Special rules for object files
 
+DATE_FMT = %b %d %Y
+TIME_FMT = %H:%M:%S
+ifdef SOURCE_DATE_EPOCH
+	BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)"  2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+	BUILD_TIME ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(TIME_FMT)"  2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(TIME_FMT)" 2>/dev/null || date -u "+$(TIME_FMT)")
+else
+	BUILD_DATE ?= $(shell date "+$(DATE_FMT)")
+	BUILD_TIME ?= $(shell date "+$(TIME_FMT)")
+endif
+
 Modules/getbuildinfo.o: $(PARSER_OBJS) \
 		$(OBJECT_OBJS) \
 		$(PYTHON_OBJS) \
@@ -744,6 +754,8 @@ Modules/getbuildinfo.o: $(PARSER_OBJS) \
 		$(MODOBJS) \
 		$(srcdir)/Modules/getbuildinfo.c
 	$(CC) -c $(PY_CORE_CFLAGS) \
+	      -DDATE="\"$(BUILD_DATE)\"" \
+	      -DTIME="\"$(BUILD_TIME)\"" \
 	      -DGITVERSION="\"`LC_ALL=C $(GITVERSION)`\"" \
 	      -DGITTAG="\"`LC_ALL=C $(GITTAG)`\"" \
 	      -DGITBRANCH="\"`LC_ALL=C $(GITBRANCH)`\"" \

--- a/Misc/NEWS.d/next/Build/2018-01-25-10-35-49.bpo-29708.d97BIE.rst
+++ b/Misc/NEWS.d/next/Build/2018-01-25-10-35-49.bpo-29708.d97BIE.rst
@@ -1,0 +1,4 @@
+Honor the SOURCE_DATE_EPOCH environment variable during build to produce
+reproducible binaries. This means using the SOURCE_DATE_EPOCH value to
+compute values for the DATE and TIME variables, that will be used in
+Modules/getbuildinfo.c


### PR DESCRIPTION
The `Modules/getbuildinfo.c` file allows the use of
DATE and TIME macros to be defined via CFLAGS.

These vars, control the build date & time when the
interpreter is opened, and can be read via the
`platform._sys_version()` function.

So, a conversion from SOURCE_DATE_EPOCH to DATE & TIME
is required at build-time.

This is especially needed for `platform._sys_version()`
to work.
The installation of pip seems to rely on this.

The logic has been adapted from:
 https://wiki.debian.org/ReproducibleBuilds/TimestampsProposal#Makefile

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>

<!-- issue-number: bpo-29708 -->
https://bugs.python.org/issue29708
<!-- /issue-number -->
