### PR TITLE
bpo-32360: Remove OrderedDict usage from json.tool

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -11,7 +11,6 @@ Usage::
 
 """
 import argparse
-import collections
 import json
 import sys
 
@@ -34,11 +33,7 @@ def main():
     sort_keys = options.sort_keys
     with infile:
         try:
-            if sort_keys:
-                obj = json.load(infile)
-            else:
-                obj = json.load(infile,
-                                object_pairs_hook=collections.OrderedDict)
+            obj = json.load(infile)
         except ValueError as e:
             raise SystemExit(e)
     with outfile:


### PR DESCRIPTION
This pull request is part of #5001.  This focus on code and #5001 will focus on doc.

<!-- issue-number: bpo-32360 -->
https://bugs.python.org/issue32360
<!-- /issue-number -->
