### PR TITLE
bpo-10381: Cleanup dangling reference in get_timezone_utc_capi

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2300,8 +2300,10 @@ get_timezone_utc_capi(PyObject* self, PyObject *args) {
         return NULL;
     }
     if (macro) {
+        Py_INCREF(PyDateTime_TimeZone_UTC);
         return PyDateTime_TimeZone_UTC;
     } else {
+        Py_INCREF(PyDateTimeAPI->TimeZone_UTC);
         return PyDateTimeAPI->TimeZone_UTC;
     }
 }


### PR DESCRIPTION
Per @vstinner's comment, the C API test was erroneously not increasing the refcount on the UTC singleton.

This is a bugfix to unreleased changes, so news is unnecessary.

<!-- issue-number: bpo-10381 -->
https://bugs.python.org/issue10381
<!-- /issue-number -->
