### PR TITLE
bpo-32667: Fix tests when $PATH contains a file

### DIFF
--- a/Lib/test/test_dtrace.py
+++ b/Lib/test/test_dtrace.py
@@ -79,7 +79,7 @@ class TraceBackend:
         try:
             output = self.trace(abspath("assert_usable" + self.EXTENSION))
             output = output.strip()
-        except (FileNotFoundError, PermissionError) as fnfe:
+        except (FileNotFoundError, NotADirectoryError, PermissionError) as fnfe:
             output = str(fnfe)
         if output != "probe: success":
             raise unittest.SkipTest(


### PR DESCRIPTION
Some tests failed when the PATH environment variable contained a path
to an existing file. Fix tests to ignore also NotADirectoryError, not
only FileNotFoundError and PermissionError.

<!-- issue-number: bpo-32667 -->
https://bugs.python.org/issue32667
<!-- /issue-number -->
