### PR TITLE
[2.7] bpo-32667: Fix tests when $PATH contains a file

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -697,7 +697,7 @@ class ProcessTestCase(BaseTestCase):
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
             # ignore errors that indicate the command was not found
-            if c.exception.errno not in (errno.ENOENT, errno.EACCES):
+            if c.exception.errno not in (errno.ENOENT, errno.ENOTDIR, errno.EACCES):
                 raise c.exception
 
     @unittest.skipIf(threading is None, "threading required")


### PR DESCRIPTION
test_subprocess.test_leaking_fds_on_error() failed when the PATH
environment variable contains a path to an existing file. Fix the
test: ignore also ENOTDIR, not only ENOENT and EACCES.

<!-- issue-number: bpo-32667 -->
https://bugs.python.org/issue32667
<!-- /issue-number -->
