### PR TITLE
bpo-32436: Fix a refleak and a GCC warning

### DIFF
--- a/Python/context.c
+++ b/Python/context.c
@@ -134,7 +134,9 @@ PyContextVar_New(const char *name, PyObject *def)
     if (pyname == NULL) {
         return NULL;
     }
-    return contextvar_new(pyname, def);
+    PyContextVar *var = contextvar_new(pyname, def);
+    Py_DECREF(pyname);
+    return var;
 }
 
 
@@ -741,8 +743,8 @@ contextvar_new(PyObject *name, PyObject *def)
     var->var_cached_tsid = 0;
     var->var_cached_tsver = 0;
 
-    if (_PyObject_GC_IS_TRACKED(name) ||
-            (def != NULL && _PyObject_GC_IS_TRACKED(def)))
+    if (_PyObject_GC_MAY_BE_TRACKED(name) ||
+            (def != NULL && _PyObject_GC_MAY_BE_TRACKED(def)))
     {
         PyObject_GC_Track(var);
     }

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -449,7 +449,7 @@ hamt_bitcount(uint32_t i)
     */
     i = i - ((i >> 1) & 0x55555555);
     i = (i & 0x33333333) + ((i >> 2) & 0x33333333);
-    return ((i + (i >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
+    return (((i + (i >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
 }
 
 static inline uint32_t


### PR DESCRIPTION
The refleak in question wasn't really important, as context vars
are usually created at the toplevel and live as long as the interpreter
lives, so the context var name isn't ever GCed anyways.


<!-- issue-number: bpo-32436 -->
https://bugs.python.org/issue32436
<!-- /issue-number -->
