### PR TITLE
bpo-32660: Solaris should support constants like termios' FIONREAD

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-01-26-01-26-00.bpo-32660.tVJIWV.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-26-01-26-00.bpo-32660.tVJIWV.rst
@@ -1,0 +1,2 @@
+:mod:`termios` makes available ``FIONREAD``, ``FIONCLEX``, ``FIOCLEX``,
+``FIOASYNC`` and ``FIONBIO`` also under Solaris/derivatives.

--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -8,6 +8,12 @@
 #define CTRL(c) ((c)&037)
 #endif
 
+#if defined(__sun)
+/* We could do better. Check issue-32660 */
+#include <sys/filio.h>
+#include <sys/sockio.h>
+#endif
+
 #include <termios.h>
 #include <sys/ioctl.h>
 


### PR DESCRIPTION


<!-- issue-number: bpo-32660 -->
https://bugs.python.org/issue32660
<!-- /issue-number -->
