### PR TITLE
[3.6] bpo-32304: Fix distutils upload for tar files ending with b'\r' (GH-5264)

### DIFF
--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -1016,6 +1016,11 @@ attribute defaults to ``['gztar']``. Although not anticipated,
 any code relying on the presence of ``default_format`` may
 need to be adapted. See :issue:`27819` for more details.
 
+The ``upload`` command now longer tries to change CR end-of-line characters
+to CRLF.  This fixes a corruption issue with sdists that ended with a byte
+equivalent to CR.
+(Contributed by Bo Bayles in :issue:`32304`.)
+
 
 email
 -----

--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -159,8 +159,6 @@ class upload(PyPIRCCommand):
                 body.write(title.encode('utf-8'))
                 body.write(b"\r\n\r\n")
                 body.write(value)
-                if value and value[-1:] == b'\r':
-                    body.write(b'\n')  # write an extra newline (lurve Macs)
         body.write(end_boundary)
         body = body.getvalue()
 

--- a/Misc/NEWS.d/next/Library/2018-01-21-16-33-53.bpo-32304.TItrNv.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-21-16-33-53.bpo-32304.TItrNv.rst
@@ -1,0 +1,2 @@
+distutils' upload command no longer corrupts tar files ending with a CR byte,
+and no longer tries to convert CR to CRLF in any of the upload text fields.


### PR DESCRIPTION
This PR brings #5264, which @merwok merged, to version 3.6.

<!-- issue-number: bpo-32304 -->
https://bugs.python.org/issue32304
<!-- /issue-number -->
