### PR TITLE
[2.7] bpo-32304: Fix distutils upload for tar files ending with b'\r' (GH-5264)

### DIFF
--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -1218,6 +1218,11 @@ changes, or look through the Subversion logs for all the details.
   created some new files that should be included.
   (Fixed by Tarek Ziadé; :issue:`8688`.)
 
+  The ``upload`` command now longer tries to change CR end-of-line characters
+  to CRLF.  This fixes a corruption issue with sdists that ended with a byte
+  equivalent to CR.
+  (Contributed by Bo Bayles in :issue:`32304`.)
+
 * The :mod:`doctest` module's :const:`IGNORE_EXCEPTION_DETAIL` flag
   will now ignore the name of the module containing the exception
   being tested.  (Patch by Lennart Regebro; :issue:`7490`.)

--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -155,8 +155,6 @@ class upload(PyPIRCCommand):
                 body.write(fn)
                 body.write("\r\n\r\n")
                 body.write(value)
-                if value and value[-1] == '\r':
-                    body.write('\n')  # write an extra newline (lurve Macs)
         body.write(end_boundary)
         body = body.getvalue()
 

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -128,6 +128,32 @@ class uploadTestCase(PyPIRCCommandTestCase):
         auth = self.last_open.req.headers['Authorization']
         self.assertNotIn('\n', auth)
 
+    # bpo-32304: archives whose last byte was b'\r' were corrupted due to
+    # normalization intended for Mac OS 9.
+    def test_upload_correct_cr(self):
+        # content that ends with \r should not be modified.
+        tmp = self.mkdtemp()
+        path = os.path.join(tmp, 'xxx')
+        self.write_file(path, content='yy\r')
+        command, pyversion, filename = 'xxx', '2.6', path
+        dist_files = [(command, pyversion, filename)]
+        self.write_file(self.rc, PYPIRC_LONG_PASSWORD)
+
+        # other fields that ended with \r used to be modified, now are
+        # preserved.
+        pkg_dir, dist = self.create_dist(
+            dist_files=dist_files,
+            description='long description\r'
+        )
+        cmd = upload(dist)
+        cmd.show_response = 1
+        cmd.ensure_finalized()
+        cmd.run()
+
+        headers = dict(self.last_open.req.headers)
+        self.assertEqual(headers['Content-length'], '2172')
+        self.assertIn(b'long description\r', self.last_open.req.data)
+
     def test_upload_fails(self):
         self.next_msg = "Not Found"
         self.next_code = 404

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -152,6 +152,7 @@ class uploadTestCase(PyPIRCCommandTestCase):
         headers = dict(self.last_open.req.headers)
         self.assertEqual(headers['Content-length'], '2170')
         self.assertIn(b'long description\r', self.last_open.req.data)
+        self.assertNotIn(b'long description\r\n', self.last_open.req.data)
 
     def test_upload_fails(self):
         self.next_msg = "Not Found"

--- a/Lib/distutils/tests/test_upload.py
+++ b/Lib/distutils/tests/test_upload.py
@@ -146,12 +146,11 @@ class uploadTestCase(PyPIRCCommandTestCase):
             description='long description\r'
         )
         cmd = upload(dist)
-        cmd.show_response = 1
         cmd.ensure_finalized()
         cmd.run()
 
         headers = dict(self.last_open.req.headers)
-        self.assertEqual(headers['Content-length'], '2172')
+        self.assertEqual(headers['Content-length'], '2170')
         self.assertIn(b'long description\r', self.last_open.req.data)
 
     def test_upload_fails(self):

--- a/Misc/NEWS.d/next/Library/2018-01-21-16-33-53.bpo-32304.TItrNv.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-21-16-33-53.bpo-32304.TItrNv.rst
@@ -1,0 +1,2 @@
+distutils' upload command no longer corrupts tar files ending with a CR byte,
+and no longer tries to convert CR to CRLF in any of the upload text fields.


### PR DESCRIPTION
This PR brings #5264, which @merwok merged, to version 2.7.

<!-- issue-number: bpo-32304 -->
https://bugs.python.org/issue32304
<!-- /issue-number -->
