### PR TITLE
bpo-32571: Fix reading uninitialized memory.

### DIFF
--- a/Objects/object.c
+++ b/Objects/object.c
@@ -917,6 +917,11 @@ _PyObject_LookupAttr(PyObject *v, PyObject *name, PyObject **result)
         }
         *result = (*tp->tp_getattr)(v, (char *)name_str);
     }
+    else {
+        *result = NULL;
+        return 0;
+    }
+
     if (*result != NULL) {
         return 1;
     }


### PR DESCRIPTION
Thanks to Coverity.

<!-- issue-number: bpo-32571 -->
https://bugs.python.org/issue32571
<!-- /issue-number -->
