### PR TITLE
[2.7] bpo-32640: Clarify the behavior of str.join and unicode object

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1071,9 +1071,10 @@ string functions based on regular expressions.
 .. method:: str.join(iterable)
 
    Return a string which is the concatenation of the strings in *iterable*.
-   A :exc:`TypeError` will be raised if there are any non-string values in
-   *iterable*, including :class:`bytes` objects.  The separator between
-   elements is the string providing this method.
+   If there is any Unicode object in *iterable*, return a Unicode instead.
+   A :exc:`TypeError` will be raised if there are any non-string or non Unicode
+   object values in *iterable*.  The separator between elements is the string
+   providing this method.
 
 
 .. method:: str.ljust(width[, fillchar])


### PR DESCRIPTION
In str.join, if any of the iterable contains a Unicode object,
str.join will return a Unicode object.

A Type error will be raised if iterable contains values other
than a string or Unicode object.


<!-- issue-number: bpo-32640 -->
https://bugs.python.org/issue32640
<!-- /issue-number -->
