### PR TITLE
bpo-32657 Removing mutable entry from send_message

### DIFF
--- a/Doc/library/smtplib.rst
+++ b/Doc/library/smtplib.rst
@@ -484,7 +484,7 @@ An :class:`SMTP` instance has the following methods:
 
 
 .. method:: SMTP.send_message(msg, from_addr=None, to_addrs=None, \
-                              mail_options=[], rcpt_options=[])
+                              mail_options=None, rcpt_options=None)
 
    This is a convenience method for calling :meth:`sendmail` with the message
    represented by an :class:`email.message.Message` object.  The arguments have

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -890,7 +890,7 @@ class SMTP:
         return senderrs
 
     def send_message(self, msg, from_addr=None, to_addrs=None,
-                mail_options=[], rcpt_options={}):
+                mail_options=None, rcpt_options=None):
         """Converts message to a bytestring and passes it to sendmail.
 
         The arguments are as for sendmail, except that msg is an
@@ -939,6 +939,10 @@ class SMTP:
                                        msg[header_prefix + 'Cc'])
                            if f is not None]
             to_addrs = [a[1] for a in email.utils.getaddresses(addr_fields)]
+        if mail_options is None:
+            mail_options = []
+        if rcpt_options is None:
+            rcpt_options = []
         # Make a local copy so we can delete the bcc headers.
         msg_copy = copy.copy(msg)
         del msg_copy['Bcc']

--- a/Misc/NEWS.d/next/Library/2018-01-26-12-34-01.bpo-32657.gYp2Zz.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-26-12-34-01.bpo-32657.gYp2Zz.rst
@@ -1,2 +1,2 @@
-Removing mutable defaults for mail_options and rcpt_options from
+Removed mutable defaults for mail_options and rcpt_options from
 `SMTP.send_message`

--- a/Misc/NEWS.d/next/Library/2018-01-26-12-34-01.bpo-32657.gYp2Zz.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-26-12-34-01.bpo-32657.gYp2Zz.rst
@@ -1,0 +1,2 @@
+Removing mutable defaults for mail_options and rcpt_options from
+`SMTP.send_message`


### PR DESCRIPTION
The signature for send_message included mutable defaults for two sets of
options, mail_options and rcpt_options. Additionally, the default for
rcpt_options was a dictionary, not a list. These have now been changed
to have a default of None, which is set to a dictionary during function
execution.

<!-- issue-number: bpo-32657 -->
https://bugs.python.org/issue32657
<!-- /issue-number -->
