### PR TITLE
bpo-32674: minor documentation fix for '__import__'

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -327,7 +327,7 @@ empty list to emulate ``import name''.\n\
 When importing a module from a package, note that __import__('A.B', ...)\n\
 returns package A when fromlist is empty, but its submodule B when\n\
 fromlist is not empty.  The level argument is used to determine whether to\n\
-perform absolute or relative imports, 0 is absolute while a positive number\n\
+perform absolute or relative imports: 0 is absolute while a positive number\n\
 is the number of parent directories to search relative to the current module.");
 
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -317,7 +317,7 @@ PyDoc_STRVAR(import_doc,
 "__import__(name, globals=None, locals=None, fromlist=(), level=0) -> module\n\
 \n\
 Import a module. Because this function is meant for use by the Python\n\
-interpreter and not for general use it is better to use\n\
+interpreter and not for general use, it is better to use\n\
 importlib.import_module() to programmatically import a module.\n\
 \n\
 The globals argument is only used to determine the context;\n\
@@ -326,8 +326,8 @@ should be a list of names to emulate ``from name import ...'', or an\n\
 empty list to emulate ``import name''.\n\
 When importing a module from a package, note that __import__('A.B', ...)\n\
 returns package A when fromlist is empty, but its submodule B when\n\
-fromlist is not empty.  Level is used to determine whether to perform \n\
-absolute or relative imports. 0 is absolute while a positive number\n\
+fromlist is not empty.  The level argument is used to determine whether to\n\
+perform absolute or relative imports, 0 is absolute while a positive number\n\
 is the number of parent directories to search relative to the current module.");
 
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -327,7 +327,7 @@ empty list to emulate ``import name''.\n\
 When importing a module from a package, note that __import__('A.B', ...)\n\
 returns package A when fromlist is empty, but its submodule B when\n\
 fromlist is not empty.  The level argument is used to determine whether to\n\
-perform absolute or relative imports: 0 is absolute while a positive number\n\
+perform absolute or relative imports: 0 is absolute, while a positive number\n\
 is the number of parent directories to search relative to the current module.");
 
 


### PR DESCRIPTION
https://bugs.python.org/issue32674

This is a minor documentation fix for builtin function `__import__`.


<!-- issue-number: bpo-32674 -->
https://bugs.python.org/issue32674
<!-- /issue-number -->
