### PR TITLE
[2.7] bpo-30622: Change NPN detection: (GH-2079)

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2048,7 +2048,7 @@ static PyMethodDef PySSLMethods[] = {
      PySSL_peercert_doc},
     {"cipher", (PyCFunction)PySSL_cipher, METH_NOARGS},
     {"version", (PyCFunction)PySSL_version, METH_NOARGS},
-#ifdef OPENSSL_NPN_NEGOTIATED
+#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
     {"selected_npn_protocol", (PyCFunction)PySSL_selected_npn_protocol, METH_NOARGS},
 #endif
 #ifdef HAVE_ALPN


### PR DESCRIPTION
Fix build with OpenSSL 1.1 without NPN
Small omission in original backport/cherry-pick


<!-- issue-number: bpo-30622 -->
https://bugs.python.org/issue30622
<!-- /issue-number -->
