### PR TITLE
bpo-32680 add default "sock" on SMTP objects

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -216,6 +216,8 @@ class SMTP:
         method called 'sendmail' that will do an entire mail transaction.
         """
     debuglevel = 0
+
+    sock = None
     file = None
     helo_resp = None
     ehlo_msg = "ehlo"
@@ -344,7 +346,7 @@ class SMTP:
         """Send `s' to the server."""
         if self.debuglevel > 0:
             self._print_debug('send:', repr(s))
-        if hasattr(self, 'sock') and self.sock:
+        if self.sock:
             if isinstance(s, str):
                 # send is used by the 'data' command, where command_encoding
                 # should not be used, but 'data' needs to convert the string to

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -602,6 +602,13 @@ class NonConnectingTests(unittest.TestCase):
         self.assertRaises(OSError, smtplib.SMTP,
                           "localhost:bogus")
 
+    def testSockAttributeExists(self):
+        # check that sock attribute is present outside of a connect() call
+        # (regression test, the previous behavior raised an
+        #  AttributeError: 'SMTP' object has no attribute 'sock')
+        with smtplib.SMTP() as smtp:
+            self.assertIsNone(smtp.sock)
+
 
 class DefaultArgumentsTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2018-10-09-14-25-36.bpo-32680.z2FbOp.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-09-14-25-36.bpo-32680.z2FbOp.rst
@@ -1,0 +1,1 @@
+:class:`smtplib.SMTP` objects now always have a `sock` attribute present


### PR DESCRIPTION
By default the smtplib.SMTP objects did not have a sock attribute, it
was only created during connect()

<!-- issue-number: bpo-32680 -->
https://bugs.python.org/issue32680
<!-- /issue-number -->
