### PR TITLE
bpo-32681: Fix an uninitialized variable in the C imp of os.dup2

### DIFF
--- a/Misc/NEWS.d/next/C API/2018-01-26-17-29-29.bpo-32681.N1ruWa.rst
+++ b/Misc/NEWS.d/next/C API/2018-01-26-17-29-29.bpo-32681.N1ruWa.rst
@@ -1,0 +1,2 @@
+Fix uninitialized variable 'res' in the C implementation of os.dup2. Patch
+by Stéphane Wirtel

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7782,7 +7782,7 @@ static int
 os_dup2_impl(PyObject *module, int fd, int fd2, int inheritable)
 /*[clinic end generated code: output=bc059d34a73404d1 input=c3cddda8922b038d]*/
 {
-    int res;
+    int res = 0;
 #if defined(HAVE_DUP3) && \
     !(defined(HAVE_FCNTL_H) && defined(F_DUP2FD_CLOEXEC))
     /* dup3() is available on Linux 2.6.27+ and glibc 2.9 */


### PR DESCRIPTION
<!-- issue-number: bpo-32681 -->
https://bugs.python.org/issue32681
<!-- /issue-number -->
