### PR TITLE
bpo-32682: test_zlib improve version parsing

### DIFF
--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -750,17 +750,19 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
 
     def test_wbits(self):
         # wbits=0 only supported since zlib v1.2.3.5
-        # Register "1.2.3" as "1.2.3.0"
-        v = zlib.ZLIB_RUNTIME_VERSION
-        if '-' in v:
-            v = v.split('-',1)[0].split('.')[:3] 
+        # Register "1.2.3" as "1.2.3.0" or "1.2.0-linux","1.2.0.f","1.2.0.f-linux"
+        v = zlib.ZLIB_RUNTIME_VERSION.split('-',1)[0].split('.')
+        if len(v)<4:
             v.append('0')
-        else:
-            v = (v + ".0").split(".", 4)
-        supports_wbits_0 = int(v[0]) > 1 or int(v[0]) == 1 \
-            and (int(v[1]) > 2 or int(v[1]) == 2
-            and (int(v[2]) > 3 or int(v[2]) == 3 and int(v[3]) >= 5))
+        elif not v[-1].isnumeric():
+            v[-1]='0'
 
+        v = tuple( map( int, v ) )
+        supports_wbits_0 = (v[0]> 1) or ( v[0] == 1 ) \
+            and ( v[1] > 2 ) or ( v[1] == 2 ) \
+            and ( v[2] > 3 ) or ( v[2] == 3)  \
+            and ( v[3] >= 5)
+        
         co = zlib.compressobj(level=1, wbits=15)
         zlib15 = co.compress(HAMLET_SCENE) + co.flush()
         self.assertEqual(zlib.decompress(zlib15, 15), HAMLET_SCENE)

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -751,12 +751,11 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
     def test_wbits(self):
         # wbits=0 only supported since zlib v1.2.3.5
         # Register "1.2.3" as "1.2.3.0"
-        if zlib.ZLIB_RUNTIME_VERSION.find('-')>=0:
-            #  zlib can report "1.2.8-linuxfoundation-mods-v1 or "1.2.8.f-linuxfoundation-mods-v1"
-            v = list(map( int , zlib.ZLIB_RUNTIME_VERSION.split('-',1)[0].split('.')[:3] ))
+        v = zlib.ZLIB_RUNTIME_VERSION.split('-',1)[0]
+        if '-' in v:
+            v = list(map( int , v.split('.')[:3] ))
             v.append(0)
-        else:
-            v = (zlib.ZLIB_RUNTIME_VERSION + ".0").split(".", 4)
+
         supports_wbits_0 = int(v[0]) > 1 or int(v[0]) == 1 \
             and (int(v[1]) > 2 or int(v[1]) == 2
             and (int(v[2]) > 3 or int(v[2]) == 3 and int(v[3]) >= 5))

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -750,7 +750,8 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
 
     def test_wbits(self):
         # wbits=0 only supported since zlib v1.2.3.5
-        # Register "1.2.3" as "1.2.3.0" or "1.2.0-linux","1.2.0.f","1.2.0.f-linux"
+        # Register "1.2.3" as "1.2.3.0"
+        # or "1.2.0-linux","1.2.0.f","1.2.0.f-linux"
         v = zlib.ZLIB_RUNTIME_VERSION.split('-',1)[0].split('.')
         if len(v)<4:
             v.append('0')
@@ -762,6 +763,7 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
             and ( v[1] > 2 ) or ( v[1] == 2 ) \
             and ( v[2] > 3 ) or ( v[2] == 3)  \
             and ( v[3] >= 5)
+        del v
         
         co = zlib.compressobj(level=1, wbits=15)
         zlib15 = co.compress(HAMLET_SCENE) + co.flush()

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -752,19 +752,19 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         # wbits=0 only supported since zlib v1.2.3.5
         # Register "1.2.3" as "1.2.3.0"
         # or "1.2.0-linux","1.2.0.f","1.2.0.f-linux"
-        v = zlib.ZLIB_RUNTIME_VERSION.split('-',1)[0].split('.')
-        if len(v)<4:
+        v = zlib.ZLIB_RUNTIME_VERSION.split('-', 1)[0].split('.')
+        if len(v) < 4:
             v.append('0')
         elif not v[-1].isnumeric():
-            v[-1]='0'
+            v[-1] = '0'
 
         v = tuple( map( int, v ) )
-        supports_wbits_0 = (v[0]> 1) or ( v[0] == 1 ) \
-            and ( v[1] > 2 ) or ( v[1] == 2 ) \
-            and ( v[2] > 3 ) or ( v[2] == 3)  \
-            and ( v[3] >= 5)
+        supports_wbits_0 = ( v[0] > 1 ) or ( v[0] == 1 ) \
+                and ( v[1] > 2 ) or ( v[1] == 2 ) \
+                and ( v[2] > 3 ) or ( v[2] == 3 ) \
+                and ( v[3] >= 5 )
         del v
-        
+
         co = zlib.compressobj(level=1, wbits=15)
         zlib15 = co.compress(HAMLET_SCENE) + co.flush()
         self.assertEqual(zlib.decompress(zlib15, 15), HAMLET_SCENE)

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -751,7 +751,12 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
     def test_wbits(self):
         # wbits=0 only supported since zlib v1.2.3.5
         # Register "1.2.3" as "1.2.3.0"
-        v = (zlib.ZLIB_RUNTIME_VERSION + ".0").split(".", 4)
+        if zlib.ZLIB_RUNTIME_VERSION.find('-')>=0:
+            #  zlib can report "1.2.8-linuxfoundation-mods-v1 or "1.2.8.f-linuxfoundation-mods-v1"
+            v = list(map( int , zlib.ZLIB_RUNTIME_VERSION.split('-',1)[0].split('.')[:3] ))
+            v.append(0)
+        else:
+            v = (zlib.ZLIB_RUNTIME_VERSION + ".0").split(".", 4)
         supports_wbits_0 = int(v[0]) > 1 or int(v[0]) == 1 \
             and (int(v[1]) > 2 or int(v[1]) == 2
             and (int(v[2]) > 3 or int(v[2]) == 3 and int(v[3]) >= 5))

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -751,11 +751,12 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
     def test_wbits(self):
         # wbits=0 only supported since zlib v1.2.3.5
         # Register "1.2.3" as "1.2.3.0"
-        v = zlib.ZLIB_RUNTIME_VERSION.split('-',1)[0]
+        v = zlib.ZLIB_RUNTIME_VERSION
         if '-' in v:
-            v = list(map( int , v.split('.')[:3] ))
-            v.append(0)
-
+            v = v.split('-',1)[0].split('.')[:3] 
+            v.append('0')
+        else:
+            v = (v + ".0").split(".", 4)
         supports_wbits_0 = int(v[0]) > 1 or int(v[0]) == 1 \
             and (int(v[1]) > 2 or int(v[1]) == 2
             and (int(v[2]) > 3 or int(v[2]) == 3 and int(v[3]) >= 5))

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -759,7 +759,7 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
             v[-1] = '0'
 
         v = tuple(map(int, v))
-        supports_wbits_0 = v >= (1, 2, 3, 5)        
+        supports_wbits_0 = v >= (1, 2, 3, 5)
 
         co = zlib.compressobj(level=1, wbits=15)
         zlib15 = co.compress(HAMLET_SCENE) + co.flush()

--- a/Lib/test/test_zlib.py
+++ b/Lib/test/test_zlib.py
@@ -758,12 +758,8 @@ class CompressObjectTestCase(BaseCompressTestCase, unittest.TestCase):
         elif not v[-1].isnumeric():
             v[-1] = '0'
 
-        v = tuple( map( int, v ) )
-        supports_wbits_0 = ( v[0] > 1 ) or ( v[0] == 1 ) \
-                and ( v[1] > 2 ) or ( v[1] == 2 ) \
-                and ( v[2] > 3 ) or ( v[2] == 3 ) \
-                and ( v[3] >= 5 )
-        del v
+        v = tuple(map(int, v))
+        supports_wbits_0 = v >= (1, 2, 3, 5)        
 
         co = zlib.compressobj(level=1, wbits=15)
         zlib15 = co.compress(HAMLET_SCENE) + co.flush()


### PR DESCRIPTION
fix odd version number parsing of zlib found at least on some android versions.

https://bugs.python.org/issue32682


<!-- issue-number: bpo-32682 -->
https://bugs.python.org/issue32682
<!-- /issue-number -->
