### PR TITLE
bpo-32436: Make PyContextVar_Get a little bit faster

### DIFF
--- a/Python/context.c
+++ b/Python/context.c
@@ -145,7 +145,8 @@ PyContextVar_Get(PyContextVar *var, PyObject *def, PyObject **val)
 {
     assert(PyContextVar_CheckExact(var));
 
-    PyThreadState *ts = PyThreadState_Get();
+    PyThreadState *ts = PyThreadState_GET();
+    assert(ts != NULL);
     if (ts->context == NULL) {
         goto not_found;
     }


### PR DESCRIPTION
Since context.c is compiled with Py_BUILD_CORE, using a macro
will result in a slightly more optimal code.


<!-- issue-number: bpo-32436 -->
https://bugs.python.org/issue32436
<!-- /issue-number -->
