### PR TITLE
bpo-15115: Document deprecation of email.encoders in Python 3

### DIFF
--- a/Doc/library/email.encoders.rst
+++ b/Doc/library/email.encoders.rst
@@ -12,6 +12,12 @@ This module is part of the legacy (``Compat32``) email API.  In the
 new API the functionality is provided by the *cte* parameter of
 the :meth:`~email.message.EmailMessage.set_content` method.
 
+This module is also deprecated in Python 3.  The functions provided here
+never need to be called explicitly and any calls should be removed before
+porting to Python 3.  The reason is that the :class:`email.mime.text.MIMEText`
+class sets the content type and CTE header using the *_subtype* and *_charset*
+values passed during the instaniation of that class.
+
 The remaining text in this section is the original documentation of the module.
 
 When creating :class:`~email.message.Message` objects from scratch, you often

--- a/Doc/library/email.encoders.rst
+++ b/Doc/library/email.encoders.rst
@@ -12,9 +12,8 @@ This module is part of the legacy (``Compat32``) email API.  In the
 new API the functionality is provided by the *cte* parameter of
 the :meth:`~email.message.EmailMessage.set_content` method.
 
-This module is also deprecated in Python 3.  The functions provided here
-never need to be called explicitly and any calls should be removed before
-porting to Python 3.  The reason is that the :class:`email.mime.text.MIMEText`
+This module is deprecated in Python 3.  The functions provided here
+should not be called explicitly since the :class:`~email.mime.text.MIMEText`
 class sets the content type and CTE header using the *_subtype* and *_charset*
 values passed during the instaniation of that class.
 


### PR DESCRIPTION


<!-- issue-number: bpo-15115 -->
https://bugs.python.org/issue15115
<!-- /issue-number -->
