### PR TITLE
[2.7] bpo-18533: Avoid RuntimeError from repr() of recursive dictview [GH-4823]

### DIFF
--- a/Lib/test/test_dictviews.py
+++ b/Lib/test/test_dictviews.py
@@ -1,5 +1,6 @@
 import copy
 import pickle
+import sys
 import unittest
 import collections
 from test import test_support
@@ -169,6 +170,20 @@ class DictSetTest(unittest.TestCase):
     def test_recursive_repr(self):
         d = {}
         d[42] = d.viewvalues()
+        r = repr(d)
+        # Cannot perform a stronger test, as the contents of the repr
+        # are implementation-dependent.  All we can say is that we
+        # want a str result, not an exception of any sort.
+        self.assertIsInstance(r, str)
+        d[42] = d.viewitems()
+        r = repr(d)
+        # Again.
+        self.assertIsInstance(r, str)
+
+    def test_deeply_nested_repr(self):
+        d = {}
+        for i in range(sys.getrecursionlimit() + 100):
+            d = {42: d.viewvalues()}
         self.assertRaises(RuntimeError, repr, d)
 
     def test_abc_registry(self):

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -220,6 +220,19 @@ class TestOrderedDict(unittest.TestCase):
         self.assertEqual(repr(od),
             "OrderedDict([('a', None), ('b', None), ('c', None), ('x', ...)])")
 
+    def test_repr_recursive_values(self):
+        od = OrderedDict()
+        od[42] = od.viewvalues()
+        r = repr(od)
+        # Cannot perform a stronger test, as the contents of the repr
+        # are implementation-dependent.  All we can say is that we
+        # want a str result, not an exception of any sort.
+        self.assertIsInstance(r, str)
+        od[42] = od.viewitems()
+        r = repr(od)
+        # Again.
+        self.assertIsInstance(r, str)
+
     def test_setdefault(self):
         pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
         shuffle(pairs)

--- a/Misc/NEWS.d/next/Core and Builtins/2017-12-13-16-46-23.bpo-18533.Dlk8d7.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-12-13-16-46-23.bpo-18533.Dlk8d7.rst
@@ -1,0 +1,3 @@
+``repr()`` on a dict containing its own ``viewvalues()`` or
+``viewitems()`` no longer raises ``RuntimeError``.  Instead, use
+``...``, as for other recursive structures.  Patch by Ben North.

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3005,21 +3005,29 @@ dictview_repr(dictviewobject *dv)
 {
     PyObject *seq;
     PyObject *seq_str;
-    PyObject *result;
+    PyObject *result = NULL;
+    Py_ssize_t rc;
 
+    rc = Py_ReprEnter((PyObject *)dv);
+    if (rc != 0) {
+        return rc > 0 ? PyString_FromString("...") : NULL;
+    }
     seq = PySequence_List((PyObject *)dv);
-    if (seq == NULL)
-        return NULL;
-
+    if (seq == NULL) {
+        goto Done;
+    }
     seq_str = PyObject_Repr(seq);
+    Py_DECREF(seq);
+
     if (seq_str == NULL) {
-        Py_DECREF(seq);
-        return NULL;
+        goto Done;
     }
     result = PyString_FromFormat("%s(%s)", Py_TYPE(dv)->tp_name,
                                  PyString_AS_STRING(seq_str));
     Py_DECREF(seq_str);
-    Py_DECREF(seq);
+
+Done:
+    Py_ReprLeave((PyObject *)dv);
     return result;
 }
 


### PR DESCRIPTION
As suggested in [a message on BPO](https://bugs.python.org/issue18533#msg310785), this is a backport of #4823 to the 2.7 branch.  Compared to the changes introduced in #4823, this PR:

* Works with the existing explicit `seq_str` in `dictview_repr()`.
* Uses `PyString...` (instead of `PyUnicode...`).
* Sets up the test-case dictionaries to contain `viewvalues()` and `viewitems()` (instead of `values()` and `items()`).
* Checks for `RuntimeError` (instead of `RecursionError`).
* Updates the news entry accordingly.

I kept the test on `OrderedDict` even though 2.7 behaves correctly already; please let me know if it would be cleaner to omit this part.

<!-- issue-number: bpo-18533 -->
https://bugs.python.org/issue18533
<!-- /issue-number -->
