### PR TITLE
bpo-32532: Improve documentation of settrace and setprofile

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1089,8 +1089,8 @@ always available.
    but the return event is reported even when an exception has been set). The function is
    thread-specific, but there is no way for the profiler to know about context switches between
    threads, so it does not make sense to use this in the presence of multiple threads. Also,
-   its return value is not used, so it can simply return ``None``.  Error in profile function
-   will cause itself unset.
+   its return value is not used, so it can simply return ``None``.  Error in the profile
+   function will cause itself unset.
 
    Profile functions should have three arguments: *frame*, *event*, and
    *arg*. *frame* is the current stack frame.  *event* is a string: ``'call'``,

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1089,7 +1089,8 @@ always available.
    but the return event is reported even when an exception has been set). The function is
    thread-specific, but there is no way for the profiler to know about context switches between
    threads, so it does not make sense to use this in the presence of multiple threads. Also,
-   its return value is not used, so it can simply return ``None``.
+   its return value is not used, so it can simply return ``None``.  Error in profile function
+   will cause itself unset.
 
    Profile functions should have three arguments: *frame*, *event*, and
    *arg*. *frame* is the current stack frame.  *event* is a string: ``'call'``,

--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -1173,6 +1173,9 @@ always available.
    function for further tracing in that scope), or ``None`` to turn off tracing
    in that scope.
 
+   If there is any error occurred in the trace function, it will be unset, just
+   like ``settrace(None)`` is called.
+
    The events have the following meaning:
 
    ``'call'``


### PR DESCRIPTION
Mention in the documentation of settrace and setprofile that errors in the registered handlers will cause themselves unset.

<!-- issue-number: bpo-32532 -->
https://bugs.python.org/issue32532
<!-- /issue-number -->
