### PR TITLE
bpo-32687: Fix wrong meaning of args for PyTrace_LINE/CALL in documentation

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1283,12 +1283,12 @@ Python-level trace functions in previous versions.
    +------------------------------+--------------------------------------+
    | Value of *what*              | Meaning of *arg*                     |
    +==============================+======================================+
-   | :const:`PyTrace_CALL`        | Always *NULL*.                       |
+   | :const:`PyTrace_CALL`        | Always :c:data:`Py_None`.            |
    +------------------------------+--------------------------------------+
    | :const:`PyTrace_EXCEPTION`   | Exception information as returned by |
    |                              | :func:`sys.exc_info`.                |
    +------------------------------+--------------------------------------+
-   | :const:`PyTrace_LINE`        | Always *NULL*.                       |
+   | :const:`PyTrace_LINE`        | Always :c:data:`Py_None`.            |
    +------------------------------+--------------------------------------+
    | :const:`PyTrace_RETURN`      | Value being returned to the caller,  |
    |                              | or *NULL* if caused by an exception. |

--- a/Misc/NEWS.d/next/Documentation/2018-01-28-00-25-14.bpo-32687.T_2dJN.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-28-00-25-14.bpo-32687.T_2dJN.rst
@@ -1,0 +1,1 @@
+Fix wrong meaning of args for PyTrace_LINE and PyTrace_CALL.

--- a/Misc/NEWS.d/next/Documentation/2018-01-28-00-25-14.bpo-32687.T_2dJN.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-28-00-25-14.bpo-32687.T_2dJN.rst
@@ -1,1 +1,0 @@
-Fix wrong meaning of args for PyTrace_LINE and PyTrace_CALL.


### PR DESCRIPTION


<!-- issue-number: bpo-32687 -->
https://bugs.python.org/issue32687
<!-- /issue-number -->
