### PR TITLE
bpo-32622: Fix AbstractEventLoop.sendfile signature in documentation.

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -546,7 +546,7 @@ Creating listening connections
 File Transferring
 -----------------
 
-.. coroutinemethod:: AbstractEventLoop.sendfile(sock, transport, \
+.. coroutinemethod:: AbstractEventLoop.sendfile(transport, file, \
                                                 offset=0, count=None, \
                                                 *, fallback=True)
 


### PR DESCRIPTION



<!-- issue-number: bpo-32622 -->
https://bugs.python.org/issue32622
<!-- /issue-number -->
