### PR TITLE
bpo-32436: Add a default switch branch in _PyHamt_Eq

### DIFF
--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -2445,6 +2445,9 @@ _PyHamt_Eq(PyHamtObject *v, PyHamtObject *w)
                         return 0;
                     }
                 }
+
+                default:
+                    Py_UNREACHABLE();
             }
         }
     } while (iter_res != I_END);


### PR DESCRIPTION
This is a minor nit-fix.

<!-- issue-number: bpo-32436 -->
https://bugs.python.org/issue32436
<!-- /issue-number -->
