### PR TITLE
bpo-30306: Add missing NEWS entry

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-01-28-14-10-51.bpo-30306.TmKMXi.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-28-14-10-51.bpo-30306.TmKMXi.rst
@@ -1,0 +1,4 @@
+contextlib.contextmanager now releases the arguments passed to the
+underlying generator as soon as the context manager is entered. Previously
+it would keep them alive for as long as the context manager was alive, even
+when not being used as a function decorator. Patch by Martin Teichmann.


### PR DESCRIPTION
The initial PR for bpo-30306 was missing a NEWS entry, but
also had maintainer branch editing disabled, so this is a
follow-up commit to add one.

<!-- issue-number: bpo-30306 -->
https://bugs.python.org/issue30306
<!-- /issue-number -->
