### PR TITLE
bpo-32690: Preserve order of locals()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-28-09-26-07.bpo-32690.8i9g5P.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-28-09-26-07.bpo-32690.8i9g5P.rst
@@ -1,0 +1,2 @@
+The locals() dictionary now displays in the lexical order that variables
+were defined.  Previously, the order was reversed.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -791,7 +791,7 @@ map_to_dict(PyObject *map, Py_ssize_t nmap, PyObject *dict, PyObject **values,
     assert(PyTuple_Check(map));
     assert(PyDict_Check(dict));
     assert(PyTuple_Size(map) >= nmap);
-    for (j = nmap; --j >= 0; ) {
+    for (j=0; j < nmap; j++) {
         PyObject *key = PyTuple_GET_ITEM(map, j);
         PyObject *value = values[j];
         assert(PyUnicode_Check(key));
@@ -844,7 +844,7 @@ dict_to_map(PyObject *map, Py_ssize_t nmap, PyObject *dict, PyObject **values,
     assert(PyTuple_Check(map));
     assert(PyDict_Check(dict));
     assert(PyTuple_Size(map) >= nmap);
-    for (j = nmap; --j >= 0; ) {
+    for (j=0; j < nmap; j++) {
         PyObject *key = PyTuple_GET_ITEM(map, j);
         PyObject *value = PyObject_GetItem(dict, key);
         assert(PyUnicode_Check(key));


### PR DESCRIPTION


<!-- issue-number: bpo-32690 -->
https://bugs.python.org/issue32690
<!-- /issue-number -->
