### PR TITLE
update on ac_cv_dtrace_link enabled on solaris os

### DIFF
--- a/configure
+++ b/configure
@@ -11096,7 +11096,7 @@ $as_echo "#define WITH_DTRACE 1" >>confdefs.h
     # On OS X, DTrace providers do not need to be explicitly compiled and
     # linked into the binary. Correspondingly, dtrace(1) is missing the ELF
     # generation flag '-G'. We check for presence of this flag, rather than
-    # hardcoding support by OS, in the interest of robustness.
+    # hardcoding support by OS, in the interest of robustness.   
     { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether DTrace probes require linking" >&5
 $as_echo_n "checking whether DTrace probes require linking... " >&6; }
 if ${ac_cv_dtrace_link+:} false; then :
@@ -11104,6 +11104,12 @@ if ${ac_cv_dtrace_link+:} false; then :
 else
               ac_cv_dtrace_link=no
             echo 'BEGIN' > conftest.d
+	    #  on solaris, above script will fail target "Python/pydtrace.o"
+            #  change to BEGIN{} to w/r
+	    #  verified on i386-pc-solaris2.11
+            if test "`uname -s`" = "SunOS"; then
+                echo 'BEGIN{}' > conftest.d
+            fi 
             "$DTRACE" -G -s conftest.d -o conftest.o > /dev/null 2>&1 && \
                 ac_cv_dtrace_link=yes
 


### PR DESCRIPTION
change 'BEGIN{}' on solaris to avoid --with-dtrace compile failed

