### PR TITLE
update Modules/gcmodule.o to DTRACE_DEPS

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -443,6 +443,7 @@ LIBRARY_OBJS=	\
 # in-place by dtrace(1).
 DTRACE_DEPS = \
 	Python/ceval.o
+	Modules/gcmodule.o
 # XXX: should gcmodule, etc. be here, too?
 
 #########################################################################


### PR DESCRIPTION
on solaris need to add Modules/gcmodule.o to DTRACE_DEPS
otherwise compile failed

verified: i386-pc-solaris2.11
