### PR TITLE
Fix PyTrace_RETURN documentation

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -1332,7 +1332,7 @@ Python-level trace functions in previous versions.
 .. c:var:: int PyTrace_RETURN
 
    The value for the *what* parameter to :c:type:`Py_tracefunc` functions when a
-   call is returning without propagating an exception.
+   call is about to return.
 
 
 .. c:var:: int PyTrace_C_CALL


### PR DESCRIPTION
It will be triggered when propagating an exception.
