### PR TITLE
bpo-21417: Compression level for zipfile

### DIFF
--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -130,10 +130,12 @@ ZipFile Objects
 ---------------
 
 
-.. class:: ZipFile(file, mode='r', compression=ZIP_STORED, allowZip64=True)
+.. class:: ZipFile(file, mode='r', compression=ZIP_STORED, allowZip64=True, \
+                   compresslevel=None)
 
    Open a ZIP file, where *file* can be a path to a file (a string), a
    file-like object or a :term:`path-like object`.
+
    The *mode* parameter should be ``'r'`` to read an existing
    file, ``'w'`` to truncate and write a new file, ``'a'`` to append to an
    existing file, or ``'x'`` to exclusively create and write a new file.
@@ -145,16 +147,25 @@ ZipFile Objects
    adding a ZIP archive to another file (such as :file:`python.exe`).  If
    *mode* is ``'a'`` and the file does not exist at all, it is created.
    If *mode* is ``'r'`` or ``'a'``, the file should be seekable.
+
    *compression* is the ZIP compression method to use when writing the archive,
    and should be :const:`ZIP_STORED`, :const:`ZIP_DEFLATED`,
    :const:`ZIP_BZIP2` or :const:`ZIP_LZMA`; unrecognized
-   values will cause :exc:`NotImplementedError` to be raised.  If :const:`ZIP_DEFLATED`,
-   :const:`ZIP_BZIP2` or :const:`ZIP_LZMA` is specified but the corresponding module
-   (:mod:`zlib`, :mod:`bz2` or :mod:`lzma`) is not available, :exc:`RuntimeError`
-   is raised. The default is :const:`ZIP_STORED`.  If *allowZip64* is
-   ``True`` (the default) zipfile will create ZIP files that use the ZIP64
-   extensions when the zipfile is larger than 4 GiB. If it is  false :mod:`zipfile`
-   will raise an exception when the ZIP file would require ZIP64 extensions.
+   values will cause :exc:`NotImplementedError` to be raised.  If
+   :const:`ZIP_DEFLATED`, :const:`ZIP_BZIP2` or :const:`ZIP_LZMA` is specified
+   but the corresponding module (:mod:`zlib`, :mod:`bz2` or :mod:`lzma`) is not
+   available, :exc:`RuntimeError` is raised. The default is :const:`ZIP_STORED`.
+
+   If *allowZip64* is ``True`` (the default) zipfile will create ZIP files that
+   use the ZIP64 extensions when the zipfile is larger than 4 GiB. If it is
+   ``false`` :mod:`zipfile` will raise an exception when the ZIP file would
+   require ZIP64 extensions.
+
+   The *compresslevel* parameter controls the compression level to use when
+   writing files to the archive. When using :const:`ZIP_STORED` or
+   :const:`ZIP_LZMA` it has no effect. When using :const:`ZIP_DEFLATED`
+   integers ``0`` through ``9`` are accepted. When using :const:`ZIP_BZIP2`
+   integers ``1`` through ``9`` are accepted.
 
    If the file is created with mode ``'w'``, ``'x'`` or ``'a'`` and then
    :meth:`closed <close>` without adding any files to the archive, the appropriate
@@ -186,6 +197,9 @@ ZipFile Objects
 
    .. versionchanged:: 3.6.2
       The *file* parameter accepts a :term:`path-like object`.
+
+   .. versionchanged:: 3.7
+      Add the *compresslevel* parameter.
 
 
 .. method:: ZipFile.close()
@@ -351,13 +365,15 @@ ZipFile Objects
       :exc:`ValueError`.  Previously, a :exc:`RuntimeError` was raised.
 
 
-.. method:: ZipFile.write(filename, arcname=None, compress_type=None)
+.. method:: ZipFile.write(filename, arcname=None, compress_type=None, \
+                          compress_level=None)
 
    Write the file named *filename* to the archive, giving it the archive name
    *arcname* (by default, this will be the same as *filename*, but without a drive
    letter and with leading path separators removed).  If given, *compress_type*
    overrides the value given for the *compression* parameter to the constructor for
-   the new entry.
+   the new entry. Similarly, if given, *compress_level* overrides the *compresslevel*
+   parameter.
    The archive must be open with mode ``'w'``, ``'x'`` or ``'a'``.
 
    .. note::
@@ -383,7 +399,8 @@ ZipFile Objects
       a :exc:`RuntimeError` was raised.
 
 
-.. method:: ZipFile.writestr(zinfo_or_arcname, data[, compress_type])
+.. method:: ZipFile.writestr(zinfo_or_arcname, data, compress_type=None, \
+                             compress_level=None)
 
    Write the string *data* to the archive; *zinfo_or_arcname* is either the file
    name it will be given in the archive, or a :class:`ZipInfo` instance.  If it's
@@ -393,7 +410,8 @@ ZipFile Objects
 
    If given, *compress_type* overrides the value given for the *compression*
    parameter to the constructor for the new entry, or in the *zinfo_or_arcname*
-   (if that is a :class:`ZipInfo` instance).
+   (if that is a :class:`ZipInfo` instance). Similarly, *compress_level* will
+   override the *compresslevel* parameter.
 
    .. note::
 

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -165,9 +165,9 @@ ZipFile Objects
    writing files to the archive.
    When using :const:`ZIP_STORED` or :const:`ZIP_LZMA` it has no effect.
    When using :const:`ZIP_DEFLATED` integers ``0`` through ``9`` are accepted
-   (see :class:`gzip.GzipFile`).
+   (see :class:`zlib <zlib.compressobj>` for more information).
    When using :const:`ZIP_BZIP2` integers ``1`` through ``9`` are accepted
-   (see :class:`bz2.BZ2File`).
+   (see :class:`bz2 <bz2.BZ2File>` for more information).
 
    If the file is created with mode ``'w'``, ``'x'`` or ``'a'`` and then
    :meth:`closed <close>` without adding any files to the archive, the appropriate

--- a/Doc/library/zipfile.rst
+++ b/Doc/library/zipfile.rst
@@ -162,10 +162,12 @@ ZipFile Objects
    require ZIP64 extensions.
 
    The *compresslevel* parameter controls the compression level to use when
-   writing files to the archive. When using :const:`ZIP_STORED` or
-   :const:`ZIP_LZMA` it has no effect. When using :const:`ZIP_DEFLATED`
-   integers ``0`` through ``9`` are accepted. When using :const:`ZIP_BZIP2`
-   integers ``1`` through ``9`` are accepted.
+   writing files to the archive.
+   When using :const:`ZIP_STORED` or :const:`ZIP_LZMA` it has no effect.
+   When using :const:`ZIP_DEFLATED` integers ``0`` through ``9`` are accepted
+   (see :class:`gzip.GzipFile`).
+   When using :const:`ZIP_BZIP2` integers ``1`` through ``9`` are accepted
+   (see :class:`bz2.BZ2File`).
 
    If the file is created with mode ``'w'``, ``'x'`` or ``'a'`` and then
    :meth:`closed <close>` without adding any files to the archive, the appropriate
@@ -366,14 +368,14 @@ ZipFile Objects
 
 
 .. method:: ZipFile.write(filename, arcname=None, compress_type=None, \
-                          compress_level=None)
+                          compresslevel=None)
 
    Write the file named *filename* to the archive, giving it the archive name
    *arcname* (by default, this will be the same as *filename*, but without a drive
    letter and with leading path separators removed).  If given, *compress_type*
    overrides the value given for the *compression* parameter to the constructor for
-   the new entry. Similarly, if given, *compress_level* overrides the *compresslevel*
-   parameter.
+   the new entry. Similarly, *compresslevel* will override the constructor if
+   given.
    The archive must be open with mode ``'w'``, ``'x'`` or ``'a'``.
 
    .. note::
@@ -400,7 +402,7 @@ ZipFile Objects
 
 
 .. method:: ZipFile.writestr(zinfo_or_arcname, data, compress_type=None, \
-                             compress_level=None)
+                             compresslevel=None)
 
    Write the string *data* to the archive; *zinfo_or_arcname* is either the file
    name it will be given in the archive, or a :class:`ZipInfo` instance.  If it's
@@ -410,8 +412,8 @@ ZipFile Objects
 
    If given, *compress_type* overrides the value given for the *compression*
    parameter to the constructor for the new entry, or in the *zinfo_or_arcname*
-   (if that is a :class:`ZipInfo` instance). Similarly, *compress_level* will
-   override the *compresslevel* parameter.
+   (if that is a :class:`ZipInfo` instance). Similarly, *compresslevel* will
+   override the constructor if given.
 
    .. note::
 

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -309,7 +309,7 @@ class AbstractTestsWithSourceFile:
         self.assertEqual(a_info.compress_type, self.compression)
         self.assertEqual(a_info._compress_level, 1)
 
-        # Compression level is overriden.
+        # Compression level is overridden.
         b_info = zipfp.getinfo('b.txt')
         self.assertEqual(b_info.compress_type, self.compression)
         self.assertEqual(b_info._compress_level, 2)

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -384,14 +384,14 @@ class AbstractTestsWithSourceFile:
 
     def test_per_file_compresslevel(self):
         """Check that files within a Zip archive can have different
-        compression options."""
+        compression levels."""
         with zipfile.ZipFile(TESTFN2, "w") as zipfp:
             zipfp.write(TESTFN, 'compress_1', compress_level=1)
             zipfp.write(TESTFN, 'compress_9', compress_level=9)
             one_info = zipfp.getinfo('compress_1')
             nine_info = zipfp.getinfo('compress_9')
-            self.assertEqual(one_info.compress_level, 1)
-            self.assertEqual(nine_info.compress_level, 9)
+            self.assertEqual(one_info._compress_level, 1)
+            self.assertEqual(nine_info._compress_level, 9)
 
     def tearDown(self):
         unlink(TESTFN)

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -299,11 +299,20 @@ class AbstractTestsWithSourceFile:
         self.assertEqual(info.compress_type, self.compression)
 
     def test_writestr_compresslevel(self):
-        zipfp = zipfile.ZipFile(TESTFN2, "w")
+        zipfp = zipfile.ZipFile(TESTFN2, "w", compresslevel=1)
+        zipfp.writestr("a.txt", "hello world", compress_type=self.compression)
         zipfp.writestr("b.txt", "hello world", compress_type=self.compression,
-                       compress_level=1)
-        info = zipfp.getinfo('b.txt')
-        self.assertEqual(info.compress_type, self.compression)
+                       compress_level=2)
+
+        # Compression level follows the constructor.
+        a_info = zipfp.getinfo('a.txt')
+        self.assertEqual(a_info.compress_type, self.compression)
+        self.assertEqual(a_info._compress_level, 1)
+
+        # Compression level is overriden.
+        b_info = zipfp.getinfo('b.txt')
+        self.assertEqual(b_info.compress_type, self.compression)
+        self.assertEqual(b_info._compress_level, 2)
 
     def test_read_return_size(self):
         # Issue #9837: ZipExtFile.read() shouldn't return more bytes
@@ -385,8 +394,8 @@ class AbstractTestsWithSourceFile:
     def test_per_file_compresslevel(self):
         """Check that files within a Zip archive can have different
         compression levels."""
-        with zipfile.ZipFile(TESTFN2, "w") as zipfp:
-            zipfp.write(TESTFN, 'compress_1', compress_level=1)
+        with zipfile.ZipFile(TESTFN2, "w", compresslevel=1) as zipfp:
+            zipfp.write(TESTFN, 'compress_1')
             zipfp.write(TESTFN, 'compress_9', compress_level=9)
             one_info = zipfp.getinfo('compress_1')
             nine_info = zipfp.getinfo('compress_9')

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -302,17 +302,17 @@ class AbstractTestsWithSourceFile:
         zipfp = zipfile.ZipFile(TESTFN2, "w", compresslevel=1)
         zipfp.writestr("a.txt", "hello world", compress_type=self.compression)
         zipfp.writestr("b.txt", "hello world", compress_type=self.compression,
-                       compress_level=2)
+                       compresslevel=2)
 
         # Compression level follows the constructor.
         a_info = zipfp.getinfo('a.txt')
         self.assertEqual(a_info.compress_type, self.compression)
-        self.assertEqual(a_info._compress_level, 1)
+        self.assertEqual(a_info._compresslevel, 1)
 
         # Compression level is overridden.
         b_info = zipfp.getinfo('b.txt')
         self.assertEqual(b_info.compress_type, self.compression)
-        self.assertEqual(b_info._compress_level, 2)
+        self.assertEqual(b_info._compresslevel, 2)
 
     def test_read_return_size(self):
         # Issue #9837: ZipExtFile.read() shouldn't return more bytes
@@ -396,11 +396,11 @@ class AbstractTestsWithSourceFile:
         compression levels."""
         with zipfile.ZipFile(TESTFN2, "w", compresslevel=1) as zipfp:
             zipfp.write(TESTFN, 'compress_1')
-            zipfp.write(TESTFN, 'compress_9', compress_level=9)
+            zipfp.write(TESTFN, 'compress_9', compresslevel=9)
             one_info = zipfp.getinfo('compress_1')
             nine_info = zipfp.getinfo('compress_9')
-            self.assertEqual(one_info._compress_level, 1)
-            self.assertEqual(nine_info._compress_level, 9)
+            self.assertEqual(one_info._compresslevel, 1)
+            self.assertEqual(nine_info._compresslevel, 9)
 
     def tearDown(self):
         unlink(TESTFN)

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -753,7 +753,6 @@ class ZipExtFile(io.BufferedIOBase):
         self._close_fileobj = close_fileobj
 
         self._compress_type = zipinfo.compress_type
-        self._compress_level = zipinfo.compress_level  # XXX: Is this needed?
         self._compress_left = zipinfo.compress_size
         self._left = zipinfo.file_size
 

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -295,7 +295,7 @@ class ZipInfo (object):
         'filename',
         'date_time',
         'compress_type',
-        'compress_level',
+        '_compress_level',
         'comment',
         'extra',
         'create_system',
@@ -335,7 +335,7 @@ class ZipInfo (object):
 
         # Standard values:
         self.compress_type = ZIP_STORED # Type of compression for the file
-        self.compress_level = None      # Level for the compressor
+        self._compress_level = None      # Level for the compressor
         self.comment = b""              # Comment for each file
         self.extra = b""                # ZIP extra data
         if sys.platform == 'win32':
@@ -970,7 +970,7 @@ class _ZipWriteFile(io.BufferedIOBase):
         self._zip64 = zip64
         self._zipfile = zf
         self._compressor = _get_compressor(zinfo.compress_type,
-                                           zinfo.compress_level)
+                                           zinfo._compress_level)
         self._file_size = 0
         self._compress_size = 0
         self._crc = 0
@@ -1357,7 +1357,7 @@ class ZipFile:
         elif mode == 'w':
             zinfo = ZipInfo(name)
             zinfo.compress_type = self.compression
-            zinfo.compress_level = self.compresslevel
+            zinfo._compress_level = self.compresslevel
         else:
             # Get info object for name
             zinfo = self.getinfo(name)
@@ -1615,9 +1615,9 @@ class ZipFile:
                 zinfo.compress_type = self.compression
 
             if compress_level is not None:
-                zinfo.compress_level = compress_level
+                zinfo._compress_level = compress_level
             else:
-                zinfo.compress_level = self.compresslevel
+                zinfo._compress_level = self.compresslevel
 
         if zinfo.is_dir():
             with self._lock:
@@ -1652,7 +1652,7 @@ class ZipFile:
             zinfo = ZipInfo(filename=zinfo_or_arcname,
                             date_time=time.localtime(time.time())[:6])
             zinfo.compress_type = self.compression
-            zinfo.compress_level = self.compresslevel
+            zinfo._compress_level = self.compresslevel
             if zinfo.filename[-1] == '/':
                 zinfo.external_attr = 0o40775 << 16   # drwxrwxr-x
                 zinfo.external_attr |= 0x10           # MS-DOS directory flag
@@ -1673,7 +1673,7 @@ class ZipFile:
             zinfo.compress_type = compress_type
 
         if compress_level is not None:
-            zinfo.compress_level = compress_level
+            zinfo._compress_level = compress_level
 
         zinfo.file_size = len(data)            # Uncompressed size
         with self._lock:

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -295,7 +295,7 @@ class ZipInfo (object):
         'filename',
         'date_time',
         'compress_type',
-        '_compress_level',
+        '_compresslevel',
         'comment',
         'extra',
         'create_system',
@@ -335,7 +335,7 @@ class ZipInfo (object):
 
         # Standard values:
         self.compress_type = ZIP_STORED # Type of compression for the file
-        self._compress_level = None      # Level for the compressor
+        self._compresslevel = None      # Level for the compressor
         self.comment = b""              # Comment for each file
         self.extra = b""                # ZIP extra data
         if sys.platform == 'win32':
@@ -656,16 +656,16 @@ def _check_compression(compression):
         raise NotImplementedError("That compression method is not supported")
 
 
-def _get_compressor(compress_type, compress_level=None):
+def _get_compressor(compress_type, compresslevel=None):
     if compress_type == ZIP_DEFLATED:
-        if compress_level is not None:
-            return zlib.compressobj(compress_level, zlib.DEFLATED, -15)
+        if compresslevel is not None:
+            return zlib.compressobj(compresslevel, zlib.DEFLATED, -15)
         return zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
     elif compress_type == ZIP_BZIP2:
-        if compress_level is not None:
-            return bz2.BZ2Compressor(compress_level)
+        if compresslevel is not None:
+            return bz2.BZ2Compressor(compresslevel)
         return bz2.BZ2Compressor()
-    # compress_level is ignored for ZIP_LZMA
+    # compresslevel is ignored for ZIP_LZMA
     elif compress_type == ZIP_LZMA:
         return LZMACompressor()
     else:
@@ -970,7 +970,7 @@ class _ZipWriteFile(io.BufferedIOBase):
         self._zip64 = zip64
         self._zipfile = zf
         self._compressor = _get_compressor(zinfo.compress_type,
-                                           zinfo._compress_level)
+                                           zinfo._compresslevel)
         self._file_size = 0
         self._compress_size = 0
         self._crc = 0
@@ -1357,7 +1357,7 @@ class ZipFile:
         elif mode == 'w':
             zinfo = ZipInfo(name)
             zinfo.compress_type = self.compression
-            zinfo._compress_level = self.compresslevel
+            zinfo._compresslevel = self.compresslevel
         else:
             # Get info object for name
             zinfo = self.getinfo(name)
@@ -1592,7 +1592,7 @@ class ZipFile:
                                    " would require ZIP64 extensions")
 
     def write(self, filename, arcname=None,
-              compress_type=None, compress_level=None):
+              compress_type=None, compresslevel=None):
         """Put the bytes from filename into the archive under the name
         arcname."""
         if not self.fp:
@@ -1614,10 +1614,10 @@ class ZipFile:
             else:
                 zinfo.compress_type = self.compression
 
-            if compress_level is not None:
-                zinfo._compress_level = compress_level
+            if compresslevel is not None:
+                zinfo._compresslevel = compresslevel
             else:
-                zinfo._compress_level = self.compresslevel
+                zinfo._compresslevel = self.compresslevel
 
         if zinfo.is_dir():
             with self._lock:
@@ -1640,7 +1640,7 @@ class ZipFile:
                 shutil.copyfileobj(src, dest, 1024*8)
 
     def writestr(self, zinfo_or_arcname, data,
-                 compress_type=None, compress_level=None):
+                 compress_type=None, compresslevel=None):
         """Write a file into the archive.  The contents is 'data', which
         may be either a 'str' or a 'bytes' instance; if it is a 'str',
         it is encoded as UTF-8 first.
@@ -1652,7 +1652,7 @@ class ZipFile:
             zinfo = ZipInfo(filename=zinfo_or_arcname,
                             date_time=time.localtime(time.time())[:6])
             zinfo.compress_type = self.compression
-            zinfo._compress_level = self.compresslevel
+            zinfo._compresslevel = self.compresslevel
             if zinfo.filename[-1] == '/':
                 zinfo.external_attr = 0o40775 << 16   # drwxrwxr-x
                 zinfo.external_attr |= 0x10           # MS-DOS directory flag
@@ -1672,8 +1672,8 @@ class ZipFile:
         if compress_type is not None:
             zinfo.compress_type = compress_type
 
-        if compress_level is not None:
-            zinfo._compress_level = compress_level
+        if compresslevel is not None:
+            zinfo._compresslevel = compresslevel
 
         zinfo.file_size = len(data)            # Uncompressed size
         with self._lock:

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1818,9 +1818,9 @@ class PyZipFile(ZipFile):
     """Class to create ZIP archives with Python library files and packages."""
 
     def __init__(self, file, mode="r", compression=ZIP_STORED,
-                 allowZip64=True, optimize=-1, compresslevel=None):
+                 allowZip64=True, optimize=-1):
         ZipFile.__init__(self, file, mode=mode, compression=compression,
-                         allowZip64=allowZip64, compresslevel=compresslevel)
+                         allowZip64=allowZip64)
         self._optimize = optimize
 
     def writepy(self, pathname, basename="", filterfunc=None):

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -335,7 +335,7 @@ class ZipInfo (object):
 
         # Standard values:
         self.compress_type = ZIP_STORED # Type of compression for the file
-        self.compress_level = None      # Level or preset for the compressor
+        self.compress_level = None      # Level for the compressor
         self.comment = b""              # Comment for each file
         self.extra = b""                # ZIP extra data
         if sys.platform == 'win32':
@@ -657,20 +657,15 @@ def _check_compression(compression):
 
 
 def _get_compressor(compress_type, compress_level=None):
-    # zlib.compressobj defaults to zlib.Z_DEFAULT_COMPRESSION if the level
-    # isn't given.
     if compress_type == ZIP_DEFLATED:
         if compress_level is not None:
             return zlib.compressobj(compress_level, zlib.DEFLATED, -15)
         return zlib.compressobj(zlib.Z_DEFAULT_COMPRESSION, zlib.DEFLATED, -15)
-    # bz2.BZ2Compressor defaults to compresslevel=9 if the level isn't given.
-    # compresslevel=0 is not valid.
     elif compress_type == ZIP_BZIP2:
         if compress_level is not None:
             return bz2.BZ2Compressor(compress_level)
         return bz2.BZ2Compressor()
-    # LZMACompressor (defined below) doesn't allow setting a preset (i.e.,
-    # compression level)
+    # compress_level is ignored for ZIP_LZMA
     elif compress_type == ZIP_LZMA:
         return LZMACompressor()
     else:

--- a/Misc/NEWS.d/next/Library/2018-01-28-07-55-10.bpo-21417.JFnV99.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-28-07-55-10.bpo-21417.JFnV99.rst
@@ -1,0 +1,1 @@
+Added support for setting the compression level for zipfile.ZipFile.


### PR DESCRIPTION
This PR adds a `compresslevel` parameter to `zipfile.ZipFile()`, similar to the
one that exists for `tarfile.open()`.

A few things to point out:

1. The default compression type and level remain unchanged. In [the issue](https://bugs.python.org/issue21417#msg272646) someone thought `compresslevel=None` might make it look like no compression is being done - this is in fact the case with the default `ZIP_STORED`.
2. The `ZIP_DEFLATED` and `ZIP_BZIP2` compression types support different levels - `0` through `9` for the former; `1` through `9` for the latter. Specifying `mode='w:bz2'` in `tarfile.open()` leads to a `ValueError`; the same thing happens here.
3. You can set `compresslevel` on `mode='r'`, but it doesn't do anything. This matches `tarfile.open()`'s behavior - there you can do stuff like `compresslevel=9000` and `compresslevel='kittens'` with no error.
4. The `ZIP_LZMA` compression type doesn't support "levels." It has a similar concept called a [preset](https://docs.python.org/3.6/library/lzma.html#compressing-and-decompressing-data-in-memory), however we can't set that here because we're using [custom filters](https://github.com/python/cpython/blob/a6a4dc816d68df04a7d592e0b6af8c7ecc4d4344/Lib/zipfile.py#L573-L577). These are [mutually exclusive](https://github.com/python/cpython/blob/a6a4dc816d68df04a7d592e0b6af8c7ecc4d4344/Lib/lzma.py#L78-L80).
    * Because of this, if you try to set `mode='w:xz'` and `compresslevel=9` (or whatever) in `tarfile.open`, you get an obscure `TypeError`. I will file a new bug for that.
    * Because of this, I've made `compresslevel` for `ZIP_LZMA` and `ZIP_STORED` have no effect for `zipfile.ZipFile`. I could raise an exception instead, but given that `tarfile.open()` ignores parameters that don't make sense (e.g. `mode='r:gz'` and `compresslevel=9000`) I thought this was appropriate.
5. I've added tests to exercise this new functionality to the `test_zipfile` module. In my own testing I used [this script](https://gist.github.com/bbayles/4ab8158ecd88a746191658ba8a40b512), which shows things in action.
6. I did not touch `PyZipFile()` for simplicity's sake; I can be persuaded to try it out.

I will add a few more notes inline.

<!-- issue-number: bpo-21417 -->
https://bugs.python.org/issue21417
<!-- /issue-number -->
