### PR TITLE
bpo-32694: macos/configure: Discover OpenSSL when installed with Macports

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-01-28-10-14-36.bpo-32694.v_PDG1.rst
+++ b/Misc/NEWS.d/next/Build/2018-01-28-10-14-36.bpo-32694.v_PDG1.rst
@@ -1,0 +1,1 @@
+macos/configure; discover OpenSSL when installed with MacPorts

--- a/configure
+++ b/configure
@@ -16794,7 +16794,7 @@ fi
 
             # no such luck; use some default ssldirs
             if ! $found; then
-                ssldirs="/usr/local/ssl /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /usr"
+                ssldirs="/usr/local/ssl /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /opt/local /usr"
             fi
 
 

--- a/m4/ax_check_openssl.m4
+++ b/m4/ax_check_openssl.m4
@@ -63,7 +63,7 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
 
             # no such luck; use some default ssldirs
             if ! $found; then
-                ssldirs="/usr/local/ssl /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /usr"
+                ssldirs="/usr/local/ssl /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /opt/local /usr"
             fi
         ]
         )


### PR DESCRIPTION


<!-- issue-number: bpo-32694 -->
https://bugs.python.org/issue32694
<!-- /issue-number -->
