### PR TITLE
[3.6] bpo-32228: Reset raw_pos after unwinding the raw stream (GH-4858)

### DIFF
--- a/Misc/NEWS.d/next/Library/2017-12-22-16-47-41.bpo-32228.waPx3q.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-22-16-47-41.bpo-32228.waPx3q.rst
@@ -1,0 +1,1 @@
+Ensure that ``truncate()`` preserves the file position (as reported by ``tell()``) after writes longer than the buffer size.


### PR DESCRIPTION
Ensure that ``truncate()`` preserves the file position (as reported by ``tell()``) after writes longer than the buffer size.. 
(cherry picked from commit 059f58ce938d9c3f0286412a4efb1b9131339421)


<!-- issue-number: bpo-32228 -->
https://bugs.python.org/issue32228
<!-- /issue-number -->
