### PR TITLE
bpo-32695: Add docs and tests for compresslevel and preset in tarfile

### DIFF
--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -100,7 +100,10 @@ Some facts and figures:
 
    For modes ``'w:gz'``, ``'r:gz'``, ``'w:bz2'``, ``'r:bz2'``, ``'x:gz'``,
    ``'x:bz2'``, :func:`tarfile.open` accepts the keyword argument
-   *compresslevel* (default ``9``) to specify the compression level of the file.
+   *compresslevel* to specify the compression level of the file.
+   This defaults to ``9`` for gzip and bz2 compression and to
+   :class:`PRESET_DEFAULT <lzma.LZMACompressor>`.
+   *compresslevel* is ignored for other modes.
 
    For special purposes, there is a second format for *mode*:
    ``'filemode|[compression]'``.  :func:`tarfile.open` will return a :class:`TarFile`

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -102,7 +102,7 @@ Some facts and figures:
    ``'x:bz2'``, :func:`tarfile.open` accepts the keyword argument
    *compresslevel* to specify the compression level of the file.
    This defaults to ``9`` for gzip and bz2 compression and to
-   :class:`PRESET_DEFAULT <lzma.LZMACompressor>`.
+   :class:`PRESET_DEFAULT <lzma.LZMACompressor>` for lzma compression.
    *compresslevel* is ignored for other modes.
 
    For special purposes, there is a second format for *mode*:

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -103,6 +103,7 @@ Some facts and figures:
    *compresslevel* to specify the compression level of the file.
    The default levels are: ``9`` for gzip, ``9`` for bzip2, and
    :class:`PRESET_DEFAULT <lzma.LZMACompressor>` for lzma.
+   *compresslevel* is ignored for other modes.
 
    For special purposes, there is a second format for *mode*:
    ``'filemode|[compression]'``.  :func:`tarfile.open` will return a :class:`TarFile`

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -101,9 +101,8 @@ Some facts and figures:
    For modes ``'w:gz'``, ``'r:gz'``, ``'w:bz2'``, ``'r:bz2'``, ``'x:gz'``,
    ``'x:bz2'``, :func:`tarfile.open` accepts the keyword argument
    *compresslevel* to specify the compression level of the file.
-   This defaults to ``9`` for gzip and bz2 compression and to
-   :class:`PRESET_DEFAULT <lzma.LZMACompressor>` for lzma compression.
-   *compresslevel* is ignored for other modes.
+   The default levels are: ``9`` for gzip, ``9`` for bzip2, and
+   :class:`PRESET_DEFAULT <lzma.LZMACompressor>` for lzma.
 
    For special purposes, there is a second format for *mode*:
    ``'filemode|[compression]'``.  :func:`tarfile.open` will return a :class:`TarFile`

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -104,7 +104,7 @@ Some facts and figures:
 
    For modes ``w:xz``, ``r:xz``,``x:xz``, :func:`tarfile.open` accepts the
    keyword argument *preset* to specify the compression level of the file.
-   The default is :class:`PRESET_DEFAULT <lzma.LZMACompressor>` for lzma.
+   The default is :class:`PRESET_DEFAULT <lzma.LZMACompressor>`.
 
    For special purposes, there is a second format for *mode*:
    ``'filemode|[compression]'``.  :func:`tarfile.open` will return a :class:`TarFile`

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -102,9 +102,9 @@ Some facts and figures:
    ``'x:bz2'``, :func:`tarfile.open` accepts the keyword argument
    *compresslevel* (default ``9``) to specify the compression level of the file.
 
-   For modes ``w:xz``, ``r:xz``,``x:xz``, :func:`tarfile.open` accepts the
-   keyword argument *preset* to specify the compression level of the file.
-   The default is :class:`PRESET_DEFAULT <lzma.LZMACompressor>`.
+   For modes ``'w:xz'``, ``'x:xz'``, :func:`tarfile.open` accepts the keyword
+   argument *preset* to specify the compression level of the file. The default
+   is :class:`PRESET_DEFAULT <lzma.LZMACompressor>`.
 
    For special purposes, there is a second format for *mode*:
    ``'filemode|[compression]'``.  :func:`tarfile.open` will return a :class:`TarFile`

--- a/Doc/library/tarfile.rst
+++ b/Doc/library/tarfile.rst
@@ -100,10 +100,11 @@ Some facts and figures:
 
    For modes ``'w:gz'``, ``'r:gz'``, ``'w:bz2'``, ``'r:bz2'``, ``'x:gz'``,
    ``'x:bz2'``, :func:`tarfile.open` accepts the keyword argument
-   *compresslevel* to specify the compression level of the file.
-   The default levels are: ``9`` for gzip, ``9`` for bzip2, and
-   :class:`PRESET_DEFAULT <lzma.LZMACompressor>` for lzma.
-   *compresslevel* is ignored for other modes.
+   *compresslevel* (default ``9``) to specify the compression level of the file.
+
+   For modes ``w:xz``, ``r:xz``,``x:xz``, :func:`tarfile.open` accepts the
+   keyword argument *preset* to specify the compression level of the file.
+   The default is :class:`PRESET_DEFAULT <lzma.LZMACompressor>` for lzma.
 
    For special purposes, there is a second format for *mode*:
    ``'filemode|[compression]'``.  :func:`tarfile.open` will return a :class:`TarFile`

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1610,7 +1610,8 @@ class TarFile(object):
         raise ValueError("undiscernible mode")
 
     @classmethod
-    def taropen(cls, name, mode="r", fileobj=None, **kwargs):
+    def taropen(cls, name, mode="r", fileobj=None, compresslevel=None,
+                **kwargs):
         """Open uncompressed tar archive name for reading or writing.
         """
         if mode not in ("r", "a", "w", "x"):
@@ -1681,7 +1682,8 @@ class TarFile(object):
         return t
 
     @classmethod
-    def xzopen(cls, name, mode="r", fileobj=None, preset=None, **kwargs):
+    def xzopen(cls, name, mode="r", fileobj=None, compresslevel=None,
+               **kwargs):
         """Open lzma compressed tar archive name for reading or writing.
            Appending is not allowed.
         """
@@ -1693,7 +1695,7 @@ class TarFile(object):
         except ImportError:
             raise CompressionError("lzma module is not available")
 
-        fileobj = lzma.LZMAFile(fileobj or name, mode, preset=preset)
+        fileobj = lzma.LZMAFile(fileobj or name, mode, preset=compresslevel)
 
         try:
             t = cls.taropen(name, mode, fileobj, **kwargs)

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1410,7 +1410,7 @@ class TarFile(object):
     def __init__(self, name=None, mode="r", fileobj=None, format=None,
             tarinfo=None, dereference=None, ignore_zeros=None, encoding=None,
             errors="surrogateescape", pax_headers=None, debug=None,
-            errorlevel=None, copybufsize=None):
+            errorlevel=None, copybufsize=None, compresslevel=None):
         """Open an (uncompressed) tar archive `name'. `mode' is either 'r' to
            read from an existing archive, 'a' to append data to an existing
            file or 'w' to create a new file overwriting an existing one. `mode'

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -1410,7 +1410,7 @@ class TarFile(object):
     def __init__(self, name=None, mode="r", fileobj=None, format=None,
             tarinfo=None, dereference=None, ignore_zeros=None, encoding=None,
             errors="surrogateescape", pax_headers=None, debug=None,
-            errorlevel=None, copybufsize=None, compresslevel=None):
+            errorlevel=None, copybufsize=None):
         """Open an (uncompressed) tar archive `name'. `mode' is either 'r' to
            read from an existing archive, 'a' to append data to an existing
            file or 'w' to create a new file overwriting an existing one. `mode'
@@ -1610,8 +1610,7 @@ class TarFile(object):
         raise ValueError("undiscernible mode")
 
     @classmethod
-    def taropen(cls, name, mode="r", fileobj=None, compresslevel=None,
-                **kwargs):
+    def taropen(cls, name, mode="r", fileobj=None, **kwargs):
         """Open uncompressed tar archive name for reading or writing.
         """
         if mode not in ("r", "a", "w", "x"):
@@ -1682,8 +1681,7 @@ class TarFile(object):
         return t
 
     @classmethod
-    def xzopen(cls, name, mode="r", fileobj=None, compresslevel=None,
-               **kwargs):
+    def xzopen(cls, name, mode="r", fileobj=None, preset=None, **kwargs):
         """Open lzma compressed tar archive name for reading or writing.
            Appending is not allowed.
         """
@@ -1695,7 +1693,7 @@ class TarFile(object):
         except ImportError:
             raise CompressionError("lzma module is not available")
 
-        fileobj = lzma.LZMAFile(fileobj or name, mode, preset=compresslevel)
+        fileobj = lzma.LZMAFile(fileobj or name, mode, preset=preset)
 
         try:
             t = cls.taropen(name, mode, fileobj, **kwargs)

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1580,7 +1580,7 @@ class CreateTest(WriteTestBase, unittest.TestCase):
         self.assertEqual(len(names), 1)
         self.assertIn('spameggs42', names[0])
 
-    # Test for issue #32695: compresslevel parameter raises TypError when
+    # Test for issue #32695: compresslevel parameter raises TypeError when
     # the mode involves xz.
     def test_create_with_compresslevel(self):
         with tarfile.open(tmpname, self.mode, compresslevel=1) as tobj:

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1580,26 +1580,31 @@ class CreateTest(WriteTestBase, unittest.TestCase):
         self.assertEqual(len(names), 1)
         self.assertIn('spameggs42', names[0])
 
-    # Test for issue #32695: compresslevel parameter raises TypeError when
-    # the mode involves xz.
+
+class GzipCreateTest(GzipTest, CreateTest):
     def test_create_with_compresslevel(self):
         with tarfile.open(tmpname, self.mode, compresslevel=1) as tobj:
             tobj.add(self.file_path)
 
-        with self.taropen(tmpname, 'w', compresslevel=1) as tobj:
-            tobj.add(self.file_path)
-
-
-class GzipCreateTest(GzipTest, CreateTest):
-    pass
+        with tarfile.open(tmpname, 'r:gz', compresslevel=1) as tobj:
+            pass
 
 
 class Bz2CreateTest(Bz2Test, CreateTest):
-    pass
+    def test_create_with_compresslevel(self):
+        with tarfile.open(tmpname, self.mode, compresslevel=1) as tobj:
+            tobj.add(self.file_path)
+
+        with tarfile.open(tmpname, 'r:bz2', compresslevel=1) as tobj:
+            pass
 
 
 class LzmaCreateTest(LzmaTest, CreateTest):
-    pass
+    # Unlike gz and bz2, xz uses the preset keyword instead of compresslevel.
+    # It does not allow for preset to be specified when reading.
+    def test_create_with_preset(self):
+        with tarfile.open(tmpname, self.mode, preset=1) as tobj:
+            tobj.add(self.file_path)
 
 
 class CreateWithXModeTest(CreateTest):

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1580,6 +1580,15 @@ class CreateTest(WriteTestBase, unittest.TestCase):
         self.assertEqual(len(names), 1)
         self.assertIn('spameggs42', names[0])
 
+    # Test for issue #32695: compresslevel parameter raises TypError when
+    # the mode involves xz.
+    def test_create_with_compresslevel(self):
+        with tarfile.open(tmpname, self.mode, compresslevel=1) as tobj:
+            tobj.add(self.file_path)
+
+        with self.taropen(tmpname, 'w', compresslevel=1) as tobj:
+            tobj.add(self.file_path)
+
 
 class GzipCreateTest(GzipTest, CreateTest):
     pass

--- a/Misc/NEWS.d/next/Library/2018-01-28-12-27-26.bpo-32695.85YqWW.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-28-12-27-26.bpo-32695.85YqWW.rst
@@ -1,0 +1,1 @@
+tarfile.open now properly passes on compression presets for LZMA modes.

--- a/Misc/NEWS.d/next/Library/2018-01-28-12-27-26.bpo-32695.85YqWW.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-28-12-27-26.bpo-32695.85YqWW.rst
@@ -1,1 +1,2 @@
-tarfile.open now properly passes on compression presets for LZMA modes.
+The compresslevel and preset keywords for tarfile.open are now both documented
+and tested.


### PR DESCRIPTION
I've changed almost all of this - this PR now adds tests for `compresslevel` (these were lacking before) and documents `preset` (this was undocumented before).

---

~This PR fixes `tarfile.open()` when using the `w:xz` mode and a `compresslevel` parameter.~

~`TarFile.xzopen()` seems to want to do what `TarFile.gzopen()` and `TarFile.bzopen()` do (see [here](https://github.com/python/cpython/compare/master...bbayles:tarfile-fails-compresslevel?expand=1#diff-ef64d8b610dda67977a63a9837f46349L1696)), but it uses the keyword `preset` instead of `compresslevel`.~

~This means the preset never gets passed to `lzma.LZMAFile()`, the `compresslevel` keyword is thus picked up by `**kwargs` and passed to `TarFile.__init__()`, which doesn't recognize it.~

```python
>>> import tarfile
>>> good = tarfile.open('/tmp/dummy.tar.gz', 'w:gz', compresslevel=1)
>>> bad = tarfile.open('/tmp/dummy.tar.xz', 'w:xz', compresslevel=1)
Traceback (most recent call last):
  File "<pyshell#3>", line 1, in <module>
    bad = tarfile.open('/tmp/dummy.tar.xz', 'w:xz', compresslevel=1)
  File "/home/bo/Code/cpython/Lib/tarfile.py", line 1588, in open
    return func(name, filemode, fileobj, **kwargs)
  File "/home/bo/Code/cpython/Lib/tarfile.py", line 1699, in xzopen
    t = cls.taropen(name, mode, fileobj, **kwargs)
  File "/home/bo/Code/cpython/Lib/tarfile.py", line 1618, in taropen
    return cls(name, mode, fileobj, **kwargs)
TypeError: __init__() got an unexpected keyword argument 'compresslevel'
```

~In this PR I change the signature of `TarFile.xzopen()` to match its neighbors. I also change `TarFile.taropen()` and document that `compresslevel` is meaningless when not using one of the `w:<some compression>` modes. (`compresslevel` is already ignored when using a read mode; you can do `tarfile.open('/tmp/dummy.tar.gz', 'r:gz', compresslevel='kittens')` and not get an exception).~

~I also add tests for `compresslevel` with the various modes; these were lacking previously.~

---

<!-- issue-number: bpo-32695 -->
https://bugs.python.org/issue32695
<!-- /issue-number -->
