### PR TITLE
bpo-32702: Fix minor markup typo

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1423,7 +1423,7 @@ are always available.  They are listed here in alphabetical order.
    a regular function and do something with its result.  This is needed
    in some cases where you need a reference to a function from a class
    body and you want to avoid the automatic transformation to instance
-   method.  For these cases, use this idiom:
+   method.  For these cases, use this idiom::
 
       class C:
           builtin_open = staticmethod(open)


### PR DESCRIPTION
see. [bpo-32702](https://bugs.python.org/issue32702)


<!-- issue-number: bpo-32702 -->
https://bugs.python.org/issue32702
<!-- /issue-number -->
