### PR TITLE
bpo-25988: Deprecate exposing collections.abc in collections

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -35,8 +35,8 @@ Python's general purpose built-in containers, :class:`dict`, :class:`list`,
 
 .. versionchanged:: 3.3
     Moved :ref:`collections-abstract-base-classes` to the :mod:`collections.abc` module.
-    For backwards compatibility, they continue to be visible in this module
-    as well.
+    For backwards compatibility, they continue to be visible in this module through
+    Python 3.7.  Subsequently, they will be removed entirely.
 
 
 :class:`ChainMap` objects

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -874,6 +874,11 @@ Other CPython Implementation Changes
 Deprecated
 ==========
 
+* In Python 3.8, the abstract base classes in :mod:`collections.abc` will no
+  longer be exposed in the regular :mod:`collections` module.  This will help
+  create a clearer distinction between the concrete classes and the abstract
+  base classes.
+
 * Yield expressions (both ``yield`` and ``yield from`` clauses) are now deprecated
   in comprehensions and generator expressions (aside from the iterable expression
   in the leftmost :keyword:`for` clause). This ensures that comprehensions

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -18,10 +18,14 @@ __all__ = ['deque', 'defaultdict', 'namedtuple', 'UserDict', 'UserList',
             'UserString', 'Counter', 'OrderedDict', 'ChainMap']
 
 # For backwards compatibility, continue to make the collections ABCs
-# available through the collections module.
-from _collections_abc import *
+# through Python 3.6 available through the collections module.
+# Note, no new collections ABCs were added in Python 3.7
 import _collections_abc
-__all__ += _collections_abc.__all__
+from _collections_abc import (AsyncGenerator, AsyncIterable, AsyncIterator,
+    Awaitable, ByteString, Callable, Collection, Container, Coroutine,
+    Generator, Hashable, ItemsView, Iterable, Iterator, KeysView, Mapping,
+    MappingView, MutableMapping, MutableSequence, MutableSet, Reversible,
+    Sequence, Set, Sized, ValuesView)
 
 from operator import itemgetter as _itemgetter, eq as _eq
 from keyword import iskeyword as _iskeyword

--- a/Misc/NEWS.d/next/Library/2018-01-28-23-48-45.bpo-25988.I9uBct.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-28-23-48-45.bpo-25988.I9uBct.rst
@@ -1,0 +1,2 @@
+Deprecate exposing the contents of collections.abc in the regular
+collections module.


### PR DESCRIPTION


<!-- issue-number: bpo-25988 -->
https://bugs.python.org/issue25988
<!-- /issue-number -->
