### PR TITLE
bpo-31233, bpo-31151: Document socketserver changes

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -115,6 +115,21 @@ server classes.
    :class:`ForkingMixIn` and the Forking classes mentioned below are
    only available on POSIX platforms that support :func:`~os.fork`.
 
+   :meth:`socketserver.ForkingMixIn.server_close` waits until all child
+   processes complete.
+
+   :meth:`socketserver.ThreadingMixIn.server_close` waits until all non-daemon
+   threads complete. Use daemonic threads by setting
+   :data:`ThreadingMixIn.daemon_threads` to ``True`` to not wait until threads
+   complete.
+
+   .. versionchanged:: 3.7
+
+      :meth:`socketserver.ForkingMixIn.server_close` and
+      :meth:`socketserver.ThreadingMixIn.server_close` now waits until all
+      child processes and non-daemonic threads complete.
+
+
 .. class:: ForkingTCPServer
            ForkingUDPServer
            ThreadingTCPServer

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1021,6 +1021,14 @@ Changes in Python behavior
 Changes in the Python API
 -------------------------
 
+* :meth:`socketserver.ThreadingMixIn.server_close` now waits until all
+  non-daemon threads complete. Use daemonic threads by setting
+  :data:`ThreadingMixIn.daemon_threads` to ``True`` to not wait until threads
+  complete. (Contributed by Victor Stinner in :issue:`31233`.)
+
+* :meth:`socketserver.ForkingMixIn.server_close` now waits until all
+  child processes complete. (Contributed by Victor Stinner in :issue:`31151`.)
+
 * The :func:`locale.localeconv` function now sets temporarily the ``LC_CTYPE``
   locale to the ``LC_NUMERIC`` locale in some cases.
 


### PR DESCRIPTION
socketserver.ForkingMixIn.server_close() and
socketserver.ThreadingMixIn.server_close() now waits until all child
processes and non-daemonic threads complete.

<!-- issue-number: bpo-31233 -->
https://bugs.python.org/issue31233
<!-- /issue-number -->
