### PR TITLE
bpo-32709: the iterable for itertools.groupby must be sorted

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -366,8 +366,7 @@ loops that truncate the stream.
    Make an iterator that returns consecutive keys and groups from the *iterable*.
    The *key* is a function computing a key value for each element.  If not
    specified or is ``None``, *key* defaults to an identity function and returns
-   the element unchanged.  Generally, the iterable needs to already be sorted on
-   the same key function.
+   the element unchanged.  The iterable must be sorted on the same key function.
 
    The operation of :func:`groupby` is similar to the ``uniq`` filter in Unix.  It
    generates a break or new group every time the value of the key function changes

--- a/Misc/NEWS.d/next/Documentation/2018-01-29-13-45-59.bpo-32709.ygEKVM.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-29-13-45-59.bpo-32709.ygEKVM.rst
@@ -1,0 +1,2 @@
+The iterable for the itertools.groupby function must be sorted. Patch by
+Stéphane Wirtel


### PR DESCRIPTION
Just change the documentation because we need to have a sorted itebable
for the itertools.groupby function.

<!-- issue-number: bpo-32709 -->
https://bugs.python.org/issue32709
<!-- /issue-number -->
