### PR TITLE
[3.6] bpo-20891: Remove test_capi.test_bpo20891()

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -494,19 +494,6 @@ class EmbeddingTests(unittest.TestCase):
         self.assertEqual(out, '')
         self.assertEqual(err, '')
 
-    @unittest.skipIf(True,
-                     "FIXME: test fails randomly because of a race conditon, "
-                     "see bpo-20891")
-    def test_bpo20891(self):
-        """
-        bpo-20891: Calling PyGILState_Ensure in a non-Python thread before
-        calling PyEval_InitThreads() must not crash. PyGILState_Ensure() must
-        call PyEval_InitThreads() for us in this case.
-        """
-        out, err = self.run_embedded_interpreter("bpo20891")
-        self.assertEqual(out, '')
-        self.assertEqual(err, '')
-
 
 class SkipitemTest(unittest.TestCase):
 

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -149,53 +149,6 @@ static int test_pre_initialization_api(void)
     return 0;
 }
 
-static void bpo20891_thread(void *lockp)
-{
-    PyThread_type_lock lock = *((PyThread_type_lock*)lockp);
-
-    PyGILState_STATE state = PyGILState_Ensure();
-    if (!PyGILState_Check()) {
-        fprintf(stderr, "PyGILState_Check failed!");
-        abort();
-    }
-
-    PyGILState_Release(state);
-
-    PyThread_release_lock(lock);
-
-    PyThread_exit_thread();
-}
-
-static int test_bpo20891(void)
-{
-    /* bpo-20891: Calling PyGILState_Ensure in a non-Python thread before
-       calling PyEval_InitThreads() must not crash. PyGILState_Ensure() must
-       call PyEval_InitThreads() for us in this case. */
-    PyThread_type_lock lock = PyThread_allocate_lock();
-    if (!lock) {
-        fprintf(stderr, "PyThread_allocate_lock failed!");
-        return 1;
-    }
-
-    _testembed_Py_Initialize();
-
-    long thrd = PyThread_start_new_thread(bpo20891_thread, &lock);
-    if (thrd == -1) {
-        fprintf(stderr, "PyThread_start_new_thread failed!");
-        return 1;
-    }
-    PyThread_acquire_lock(lock, WAIT_LOCK);
-
-    Py_BEGIN_ALLOW_THREADS
-    /* wait until the thread exit */
-    PyThread_acquire_lock(lock, WAIT_LOCK);
-    Py_END_ALLOW_THREADS
-
-    PyThread_free_lock(lock);
-
-    return 0;
-}
-
 
 /* *********************************************************
  * List of test cases and the function that implements it.
@@ -219,7 +172,6 @@ static struct TestCase TestCases[] = {
     { "forced_io_encoding", test_forced_io_encoding },
     { "repeated_init_and_subinterpreters", test_repeated_init_and_subinterpreters },
     { "pre_initialization_api", test_pre_initialization_api },
-    { "bpo20891", test_bpo20891 },
     { NULL, NULL }
 };
 


### PR DESCRIPTION
My first fix is not enough to make test_bpo20891() reliable. A second
fix is needed and it was decided to not backport it, so remove the
test instead.

For Python 3.6, the workaround is to call PyEval_InitThreads() before
spawning the first C thread.

Python 3.7 will have both fixes.

<!-- issue-number: bpo-20891 -->
https://bugs.python.org/issue20891
<!-- /issue-number -->
