### PR TITLE
bpo-32711: Fix warnings for Python/ast_unparse.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-29-14-36-37.bpo-32711.8hQFJP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-29-14-36-37.bpo-32711.8hQFJP.rst
@@ -1,0 +1,1 @@
+Fix the warning messages for Python/ast_unparse.c. Patch by Stéphane Wirtel

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -101,9 +101,7 @@ append_ast_binop(_PyUnicodeWriter *writer, expr_ty e, bool omit_parens)
     case FloorDiv: op = " // "; break;
     case Pow: op = " ** "; break;
     default:
-        PyErr_SetString(PyExc_SystemError,
-                        "unknown operator inside f-string");
-        return -1;
+        Py_UNREACHABLE();
     }
 
     if (-1 == append_charp(writer, op)) {
@@ -132,9 +130,7 @@ append_ast_unaryop(_PyUnicodeWriter *writer, expr_ty e, bool omit_parens)
     case UAdd: op = "+"; break;
     case USub: op = "-"; break;
     default:
-        PyErr_SetString(PyExc_SystemError,
-                        "unknown operator inside f-string");
-        return -1;
+        Py_UNREACHABLE();
     }
 
     if (-1 == append_charp(writer, op)) {

--- a/Python/ast_unparse.c
+++ b/Python/ast_unparse.c
@@ -20,7 +20,7 @@ append_formattedvalue(_PyUnicodeWriter *writer, expr_ty e, bool is_format_spec);
 static int
 append_charp(_PyUnicodeWriter *writer, const char *charp)
 {
-        return _PyUnicodeWriter_WriteASCIIString(writer, charp, -1);
+    return _PyUnicodeWriter_WriteASCIIString(writer, charp, -1);
 }
 
 static int
@@ -100,6 +100,10 @@ append_ast_binop(_PyUnicodeWriter *writer, expr_ty e, bool omit_parens)
     case BitAnd: op = " & "; break;
     case FloorDiv: op = " // "; break;
     case Pow: op = " ** "; break;
+    default:
+        PyErr_SetString(PyExc_SystemError,
+                        "unknown operator inside f-string");
+        return -1;
     }
 
     if (-1 == append_charp(writer, op)) {
@@ -127,6 +131,10 @@ append_ast_unaryop(_PyUnicodeWriter *writer, expr_ty e, bool omit_parens)
     case Not: op = "not "; break;
     case UAdd: op = "+"; break;
     case USub: op = "-"; break;
+    default:
+        PyErr_SetString(PyExc_SystemError,
+                        "unknown operator inside f-string");
+        return -1;
     }
 
     if (-1 == append_charp(writer, op)) {
@@ -856,7 +864,7 @@ append_formattedvalue(_PyUnicodeWriter *writer, expr_ty e, bool is_format_spec)
             return -1;
         }
     }
-    if (e->v.FormattedValue.format_spec > 0) {
+    if (e->v.FormattedValue.format_spec) {
         if (-1 == _PyUnicodeWriter_WriteASCIIString(writer, ":", 1) ||
             -1 == append_fstring_element(writer,
                                          e->v.FormattedValue.format_spec,
@@ -1119,7 +1127,7 @@ append_ast_expr(_PyUnicodeWriter *writer, expr_ty e, bool omit_parens)
 }
 
 static int
-maybe_init_static_strings()
+maybe_init_static_strings(void)
 {
     if (!_str_open_br &&
         !(_str_open_br = PyUnicode_InternFromString("{"))) {


### PR DESCRIPTION
Fix the warnings in the new Python/ast_unparse.c file

<!-- issue-number: bpo-32711 -->
https://bugs.python.org/issue32711
<!-- /issue-number -->
