### PR TITLE
[2.7] bpo-30595: Increase test_queue_feeder_donot_stop_onexc() timeout (#2148)

### DIFF
--- a/Lib/test/test_multiprocessing.py
+++ b/Lib/test/test_multiprocessing.py
@@ -671,7 +671,8 @@ class _TestQueue(BaseTestCase):
             q = self.Queue()
             q.put(NotSerializable())
             q.put(True)
-            self.assertTrue(q.get(timeout=0.1))
+            # bpo-30595: use a timeout of 1 second for slow buildbots
+            self.assertTrue(q.get(timeout=1.0))
 
 
 #


### PR DESCRIPTION
_test_multiprocessing.test_queue_feeder_donot_stop_onexc() now uses a
timeout of 1 second on Queue.get(), instead of 0.1 second, for slow
buildbots.

(cherry picked from commit 8f6eeaf21cdf4aea25fdefeec814a1ce07453fe9)

<!-- issue-number: bpo-30595 -->
https://bugs.python.org/issue30595
<!-- /issue-number -->
