### PR TITLE
rename _imp initialization function to follow conventions

### DIFF
--- a/Include/import.h
+++ b/Include/import.h
@@ -10,7 +10,7 @@ extern "C" {
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(_PyInitError) _PyImportZip_Init(void);
 
-PyMODINIT_FUNC PyInit_imp(void);
+PyMODINIT_FUNC PyInit__imp(void);
 #endif /* !Py_LIMITED_API */
 PyAPI_FUNC(long) PyImport_GetMagicNumber(void);
 PyAPI_FUNC(const char *) PyImport_GetMagicTag(void);

--- a/Modules/config.c.in
+++ b/Modules/config.c.in
@@ -25,7 +25,7 @@ extern "C" {
 /* -- ADDMODULE MARKER 1 -- */
 
 extern PyObject* PyMarshal_Init(void);
-extern PyObject* PyInit_imp(void);
+extern PyObject* PyInit__imp(void);
 extern PyObject* PyInit_gc(void);
 extern PyObject* PyInit__ast(void);
 extern PyObject* _PyWarnings_Init(void);
@@ -39,7 +39,7 @@ struct _inittab _PyImport_Inittab[] = {
     {"marshal", PyMarshal_Init},
 
     /* This lives in import.c */
-    {"_imp", PyInit_imp},
+    {"_imp", PyInit__imp},
 
     /* This lives in Python/Python-ast.c */
     {"_ast", PyInit__ast},

--- a/PC/config.c
+++ b/PC/config.c
@@ -74,7 +74,7 @@ extern PyObject* PyInit__opcode(void);
 /* -- ADDMODULE MARKER 1 -- */
 
 extern PyObject* PyMarshal_Init(void);
-extern PyObject* PyInit_imp(void);
+extern PyObject* PyInit__imp(void);
 
 struct _inittab _PyImport_Inittab[] = {
 
@@ -147,7 +147,7 @@ struct _inittab _PyImport_Inittab[] = {
     {"marshal", PyMarshal_Init},
 
     /* This lives it with import.c */
-    {"_imp", PyInit_imp},
+    {"_imp", PyInit__imp},
 
     /* These entries are here for sys.builtin_module_names */
     {"builtins", NULL},

--- a/Python/import.c
+++ b/Python/import.c
@@ -1,4 +1,3 @@
-
 /* Module definition and import implementation */
 
 #include "Python.h"
@@ -2253,7 +2252,7 @@ static struct PyModuleDef impmodule = {
 const char *_Py_CheckHashBasedPycsMode = "default";
 
 PyMODINIT_FUNC
-PyInit_imp(void)
+PyInit__imp(void)
 {
     PyObject *m, *d;
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -312,7 +312,7 @@ initimport(PyInterpreterState *interp, PyObject *sysmod)
     Py_INCREF(interp->import_func);
 
     /* Import the _imp module */
-    impmod = PyInit_imp();
+    impmod = PyInit__imp();
     if (impmod == NULL) {
         return _Py_INIT_ERR("can't import _imp");
     }


### PR DESCRIPTION
When the C imp module became _imp in 6f44d66bc491bad5b8d897a68da68e009e27829d, the initialization function should have been renamed from PyInit_imp to PyInit__imp.