### PR TITLE
bpo-32713: Fix tarfile.itn for large/negative float values

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -200,8 +200,9 @@ def itn(n, digits=8, format=DEFAULT_FORMAT):
     # base-256 representation. This allows values up to (256**(digits-1))-1.
     # A 0o200 byte indicates a positive number, a 0o377 byte a negative
     # number.
+    n = int(n)
     if 0 <= n < 8 ** (digits - 1):
-        s = bytes("%0*o" % (digits - 1, int(n)), "ascii") + NUL
+        s = bytes("%0*o" % (digits - 1, n), "ascii") + NUL
     elif format == GNU_FORMAT and -256 ** (digits - 1) <= n < 256 ** (digits - 1):
         if n >= 0:
             s = bytearray([0o200])

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -2149,6 +2149,14 @@ class MiscTest(unittest.TestCase):
         self.assertEqual(tarfile.itn(-0x100000000000000),
                          b"\xff\x00\x00\x00\x00\x00\x00\x00")
 
+        # Issue 32713: Test if itn() supports float values outside the
+        # non-GNU format range
+        self.assertEqual(tarfile.itn(-100.0, format=tarfile.GNU_FORMAT),
+                         b"\xff\xff\xff\xff\xff\xff\xff\x9c")
+        self.assertEqual(tarfile.itn(8 ** 12 + 0.0, format=tarfile.GNU_FORMAT),
+                         b"\x80\x00\x00\x10\x00\x00\x00\x00")
+        self.assertEqual(tarfile.nti(tarfile.itn(-0.1, format=tarfile.GNU_FORMAT)), 0)
+
     def test_number_field_limits(self):
         with self.assertRaises(ValueError):
             tarfile.itn(-1, 8, tarfile.USTAR_FORMAT)

--- a/Misc/NEWS.d/next/Library/2018-02-26-13-16-36.bpo-32713.55yegW.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-26-13-16-36.bpo-32713.55yegW.rst
@@ -1,0 +1,1 @@
+Fixed tarfile.itn handling of out-of-bounds float values. Patch by Joffrey Fuhrer.


### PR DESCRIPTION
This PR changes the behavior of `tarfile.itn` to cast the input argument `n` to an integer for bitwise operations. 

<!-- issue-number: bpo-32713 -->
https://bugs.python.org/issue32713
<!-- /issue-number -->
