### PR TITLE
bpo-32604: Add the _xxsubinterpreters extension module under Windows.

### DIFF
--- a/PCbuild/_xxsubinterpreters.vcxproj
+++ b/PCbuild/_xxsubinterpreters.vcxproj
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="PGInstrument|Win32">
+      <Configuration>PGInstrument</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="PGInstrument|x64">
+      <Configuration>PGInstrument</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="PGUpdate|Win32">
+      <Configuration>PGUpdate</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="PGUpdate|x64">
+      <Configuration>PGUpdate</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}</ProjectGuid>
+    <RootNamespace>_xxsubinterpreters</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+  </PropertyGroup>
+  <Import Project="python.props" />
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Label="Configuration">
+    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <CharacterSet>NotSet</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <PropertyGroup>
+    <TargetExt>.pyd</TargetExt>
+  </PropertyGroup>
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="pyproject.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup>
+    <_ProjectFileVersion>10.0.30319.1</_ProjectFileVersion>
+  </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>Py_BUILD_CORE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\Modules\_xxsubinterpretersmodule.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <ResourceCompile Include="..\PC\python_nt.rc" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="pythoncore.vcxproj">
+      <Project>{cf7ac3d1-e2df-41d2-bea6-1e2556cdea26}</Project>
+      <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/PCbuild/_xxsubinterpreters.vcxproj.filters
+++ b/PCbuild/_xxsubinterpreters.vcxproj.filters
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{YYYYYYYY-YYYY-YYYY-YYYY-YYYYYYYYYYYY}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\Modules\_xxsubinterpreters.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/PCbuild/pcbuild.proj
+++ b/PCbuild/pcbuild.proj
@@ -59,7 +59,7 @@
     <ExtensionModules Include="@(ExternalModules->'%(Identity)')" Condition="$(IncludeExternals)" />
     <Projects Include="@(ExtensionModules->'%(Identity).vcxproj')" Condition="$(IncludeExtensions)" />
     <!-- Test modules -->
-    <TestModules Include="_ctypes_test;_testbuffer;_testcapi;_testembed;_testimportmultiple;_testmultiphase;_testconsole" />
+    <TestModules Include="_ctypes_test;_testbuffer;_testcapi;_testembed;_testimportmultiple;_testmultiphase;_testconsole;_xxsubinterpreters" />
     <TestModules Include="xxlimited" Condition="'$(Configuration)' == 'Release'" />
     <Projects Include="@(TestModules->'%(Identity).vcxproj')" Condition="$(IncludeTests)">
       <!-- Disable parallel build for test modules -->

--- a/PCbuild/pcbuild.sln
+++ b/PCbuild/pcbuild.sln
@@ -95,6 +95,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "liblzma", "liblzma.vcxproj"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_distutils_findvs", "_distutils_findvs.vcxproj", "{41ADEDF9-11D8-474E-B4D7-BB82332C878E}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_xxsubinterpreters", "_xxsubinterpreters.vcxproj", "{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Win32 = Debug|Win32
@@ -711,6 +713,22 @@ Global
 		{41ADEDF9-11D8-474E-B4D7-BB82332C878E}.Release|Win32.Build.0 = Release|Win32
 		{41ADEDF9-11D8-474E-B4D7-BB82332C878E}.Release|x64.ActiveCfg = Release|x64
 		{41ADEDF9-11D8-474E-B4D7-BB82332C878E}.Release|x64.Build.0 = Release|x64
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.Debug|Win32.ActiveCfg = Debug|Win32
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.Debug|Win32.Build.0 = Debug|Win32
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.Debug|x64.ActiveCfg = Debug|x64
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.Debug|x64.Build.0 = Debug|x64
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.PGInstrument|Win32.ActiveCfg = PGInstrument|Win32
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.PGInstrument|Win32.Build.0 = PGInstrument|Win32
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.PGInstrument|x64.ActiveCfg = PGInstrument|x64
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.PGInstrument|x64.Build.0 = PGInstrument|x64
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.PGUpdate|Win32.ActiveCfg = PGUpdate|Win32
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.PGUpdate|Win32.Build.0 = PGUpdate|Win32
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.PGUpdate|x64.ActiveCfg = PGUpdate|x64
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.PGUpdate|x64.Build.0 = PGUpdate|x64
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.Release|Win32.ActiveCfg = Release|Win32
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.Release|Win32.Build.0 = Release|Win32
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.Release|x64.ActiveCfg = Release|x64
+		{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/PCbuild/readme.txt
+++ b/PCbuild/readme.txt
@@ -145,6 +145,7 @@ _testconsole
 _testimportmultiple
 _testmultiphase
 _tkinter
+_xxsubinterpreters
 pyexpat
 select
 unicodedata


### PR DESCRIPTION
I removed the Windows extension module metadata from #1748 and am addressing it separately here.

As it currently stands, this PR is still running into link-time problems.  I suspect my problem is with Py_BUILD_CORE. When I don't set it I don't get the symbols out of Include/internal. When I do set it I end up missing stuff from python37.lib at link time. I tried adding a "Link" directive right below where I set Py_BUILD_CORE, but that did not help.

<!-- issue-number: bpo-32604 -->
https://bugs.python.org/issue32604
<!-- /issue-number -->
