### PR TITLE
bpo-32604: NULL-terminate kwlist in channel_drop_interpreter().

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1916,7 +1916,7 @@ static PyObject *
 channel_drop_interpreter(PyObject *self, PyObject *args, PyObject *kwds)
 {
     // Note that only the current interpreter is affected.
-    static char *kwlist[] = {"id", "send", "recv"};
+    static char *kwlist[] = {"id", "send", "recv", NULL};
     PyObject *id;
     int send = -1;
     int recv = -1;


### PR DESCRIPTION


<!-- issue-number: bpo-32604 -->
https://bugs.python.org/issue32604
<!-- /issue-number -->
