### PR TITLE
[3.6] Revert "bpo-32690: Preserve order of locals() (GH-5379)"

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-28-09-26-07.bpo-32690.8i9g5P.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-28-09-26-07.bpo-32690.8i9g5P.rst
@@ -1,2 +1,0 @@
-The locals() dictionary now displays in the lexical order that variables
-were defined.  Previously, the order was reversed.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -776,7 +776,7 @@ map_to_dict(PyObject *map, Py_ssize_t nmap, PyObject *dict, PyObject **values,
     assert(PyTuple_Check(map));
     assert(PyDict_Check(dict));
     assert(PyTuple_Size(map) >= nmap);
-    for (j=0; j < nmap; j++) {
+    for (j = nmap; --j >= 0; ) {
         PyObject *key = PyTuple_GET_ITEM(map, j);
         PyObject *value = values[j];
         assert(PyUnicode_Check(key));
@@ -829,7 +829,7 @@ dict_to_map(PyObject *map, Py_ssize_t nmap, PyObject *dict, PyObject **values,
     assert(PyTuple_Check(map));
     assert(PyDict_Check(dict));
     assert(PyTuple_Size(map) >= nmap);
-    for (j=0; j < nmap; j++) {
+    for (j = nmap; --j >= 0; ) {
         PyObject *key = PyTuple_GET_ITEM(map, j);
         PyObject *value = PyObject_GetItem(dict, key);
         assert(PyUnicode_Check(key));


### PR DESCRIPTION
This reverts commit 9105879bfd7133ecbac67f3e9c0bacf6e477de5a
in order to keep the behaviour of locals() consistent between
3.6.4 and 3.6.5+.


<!-- issue-number: bpo-32690 -->
https://bugs.python.org/issue32690
<!-- /issue-number -->
