### PR TITLE
bpo-32721: do not fail test_hashlib if _md5 isn't available

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -193,7 +193,7 @@ class HashLibTestCase(unittest.TestCase):
         try:
             import _md5
         except ImportError:
-            pass
+            self.skipTest("_md5 module not available")
         # This forces an ImportError for "import _md5" statements
         sys.modules['_md5'] = None
         # clear the cache

--- a/Misc/NEWS.d/next/Tests/2018-01-29-21-30-44.bpo-32721.2Bebm1.rst
+++ b/Misc/NEWS.d/next/Tests/2018-01-29-21-30-44.bpo-32721.2Bebm1.rst
@@ -1,0 +1,1 @@
+Fix test_hashlib to not fail if the _md5 module is not built.


### PR DESCRIPTION


<!-- issue-number: bpo-32721 -->
https://bugs.python.org/issue32721
<!-- /issue-number -->
