### PR TITLE
bpo-32724: Fix references to commands in Doc/pdb.rst

### DIFF
--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -338,10 +338,13 @@ by the local file.
    With no *bpnumber* argument, ``commands`` refers to the last breakpoint set.
 
    You can use breakpoint commands to start your program up again.  Simply use
-   the :pdbcmd:`continue` command, or :pdbcmd:`step`, or any other command that resumes execution.
+   the :pdbcmd:`continue` command, or :pdbcmd:`step`,
+   or any other command that resumes execution.
 
-   Specifying any command resuming execution (currently :pdbcmd:`continue`, :pdbcmd:`step`, :pdbcmd:`next`,
-   :pdbcmd:`return`, :pdbcmd:`jump`, :pdbcmd:`quit` and their abbreviations) terminates the command :pdbcmd:`list` (as if
+   Specifying any command resuming execution 
+   (currently :pdbcmd:`continue`, :pdbcmd:`step`, :pdbcmd:`next`,
+   :pdbcmd:`return`, :pdbcmd:`jump`, :pdbcmd:`quit` and their abbreviations)
+   terminates the command :pdbcmd:`list` (as if
    that command was immediately followed by end). This is because any time you
    resume execution (even with a simple next or step), you may encounter another
    breakpoint—which could have its own command list, leading to ambiguities about

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -332,16 +332,16 @@ by the local file.
       (com) end
       (Pdb)
 
-   To remove all commands from a breakpoint, type commands and follow it
+   To remove all commands from a breakpoint, type ``commands`` and follow it
    immediately with ``end``; that is, give no commands.
 
-   With no *bpnumber* argument, commands refers to the last breakpoint set.
+   With no *bpnumber* argument, ``commands`` refers to the last breakpoint set.
 
    You can use breakpoint commands to start your program up again.  Simply use
-   the continue command, or step, or any other command that resumes execution.
+   the :pdbcmd:`continue` command, or :pdbcmd:`step`, or any other command that resumes execution.
 
-   Specifying any command resuming execution (currently continue, step, next,
-   return, jump, quit and their abbreviations) terminates the command list (as if
+   Specifying any command resuming execution (currently :pdbcmd:`continue`, :pdbcmd:`step`, :pdbcmd:`next`,
+   :pdbcmd:`return`, :pdbcmd:`jump`, :pdbcmd:`quit` and their abbreviations) terminates the command :pdbcmd:`list` (as if
    that command was immediately followed by end). This is because any time you
    resume execution (even with a simple next or step), you may encounter another
    breakpoint—which could have its own command list, leading to ambiguities about

--- a/Doc/library/pdb.rst
+++ b/Doc/library/pdb.rst
@@ -341,7 +341,7 @@ by the local file.
    the :pdbcmd:`continue` command, or :pdbcmd:`step`,
    or any other command that resumes execution.
 
-   Specifying any command resuming execution 
+   Specifying any command resuming execution
    (currently :pdbcmd:`continue`, :pdbcmd:`step`, :pdbcmd:`next`,
    :pdbcmd:`return`, :pdbcmd:`jump`, :pdbcmd:`quit` and their abbreviations)
    terminates the command :pdbcmd:`list` (as if

--- a/Misc/NEWS.d/next/Documentation/2018-01-30-09-00-19.bpo-32724.qPIaM-.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-30-09-00-19.bpo-32724.qPIaM-.rst
@@ -1,0 +1,2 @@
+Add references to some commands in the documentation of Pdb. Patch by
+Stéphane Wirtel


### PR DESCRIPTION
Some commands are specified in the documentation, but there is no direct
references.


<!-- issue-number: bpo-32724 -->
https://bugs.python.org/issue32724
<!-- /issue-number -->
