### PR TITLE
bpo-28440: Don't add /Library/Python/3.x/site-packages to sys.path

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -340,11 +340,6 @@ def getsitepackages(prefixes=None):
         else:
             sitepackages.append(prefix)
             sitepackages.append(os.path.join(prefix, "lib", "site-packages"))
-        # for framework builds *only* we add the standard Apple locations.
-        if sys.platform == "darwin" and sys._framework:
-            sitepackages.append(
-                os.path.join("/Library", sys._framework,
-                             '%d.%d' % sys.version_info[:2], "site-packages"))
     return sitepackages
 
 def addsitepackages(known_paths, prefixes=None):

--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -261,20 +261,8 @@ class HelperFunctionsTests(unittest.TestCase):
     def test_getsitepackages(self):
         site.PREFIXES = ['xoxo']
         dirs = site.getsitepackages()
-
-        if (sys.platform == "darwin" and
-            sysconfig.get_config_var("PYTHONFRAMEWORK")):
-            # OS X framework builds
-            site.PREFIXES = ['Python.framework']
-            dirs = site.getsitepackages()
-            self.assertEqual(len(dirs), 2)
-            wanted = os.path.join('/Library',
-                                  sysconfig.get_config_var("PYTHONFRAMEWORK"),
-                                  '%d.%d' % sys.version_info[:2],
-                                  'site-packages')
-            self.assertEqual(dirs[1], wanted)
-        elif os.sep == '/':
-            # OS X non-framework builds, Linux, FreeBSD, etc
+        if os.sep == '/':
+            # OS X, Linux, FreeBSD, etc
             self.assertEqual(len(dirs), 1)
             wanted = os.path.join('xoxo', 'lib',
                                   'python%d.%d' % sys.version_info[:2],

--- a/Misc/NEWS.d/next/macOS/2018-01-30-04-40-12.bpo-28440.W_BUWU.rst
+++ b/Misc/NEWS.d/next/macOS/2018-01-30-04-40-12.bpo-28440.W_BUWU.rst
@@ -1,0 +1,2 @@
+No longer add /Library/Python/3.x/site-packages to sys.path for macOS
+framework builds to avoid future conflicts.


### PR DESCRIPTION
No longer add /Library/Python/3.x/site-packages, the Apple-supplied
system Python site-packages directory, to sys.path for macOS framework
builds in case Apple ships a version of Python 3. A similar change
was made earlier to Python 2.7 where it was found that the coupling
between the system Python and a user-installed framework Python often
caused confusion or pip install failures.


<!-- issue-number: bpo-28440 -->
https://bugs.python.org/issue28440
<!-- /issue-number -->
