### PR TITLE
bpo-32722: Remove useless example in the Classes tutorial

### DIFF
--- a/Doc/tutorial/classes.rst
+++ b/Doc/tutorial/classes.rst
@@ -892,10 +892,7 @@ Examples::
    >>> sum(x*y for x,y in zip(xvec, yvec))         # dot product
    260
 
-   >>> from math import pi, sin
-   >>> sine_table = {x: sin(x*pi/180) for x in range(0, 91)}
-
-   >>> unique_words = set(word  for line in page  for word in line.split())
+   >>> unique_words = set(word for line in page  for word in line.split())
 
    >>> valedictorian = max((student.gpa, student.name) for student in graduates)
 

--- a/Misc/NEWS.d/next/Documentation/2018-01-30-11-28-27.bpo-32722.frdp6A.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-01-30-11-28-27.bpo-32722.frdp6A.rst
@@ -1,0 +1,2 @@
+Remove the bad example in the tutorial of the Generator Expression. Patch by
+Stéphane Wirtel


### PR DESCRIPTION
In the tutorial about the Generator expression, there is an example with
a dict comprehension and not with a generator expression, just removed
the code.


<!-- issue-number: bpo-32722 -->
https://bugs.python.org/issue32722
<!-- /issue-number -->
