### PR TITLE
bpo-28914: Fix compilation of select on Android

### DIFF
--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1307,10 +1307,13 @@ pyepoll_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         PyErr_SetString(PyExc_ValueError, "negative sizehint");
         return NULL;
     }
+
+#ifdef HAVE_EPOLL_CREATE1
     if (flags && flags != EPOLL_CLOEXEC) {
         PyErr_SetString(PyExc_OSError, "invalid flags");
         return NULL;
     }
+#endif
 
     return newPyEpoll_Object(type, sizehint, -1);
 }


### PR DESCRIPTION
EPOLL_CLOEXEC is not defined on Android.

Co-Authored-By: Wataru Matsumoto <sxsns243@gmail.com>

<!-- issue-number: bpo-28914 -->
https://bugs.python.org/issue28914
<!-- /issue-number -->
