### PR TITLE
bpo-32727: smtplib's SMTP.send_message behaves differently with from_addr and to_addrs

### DIFF
--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -933,6 +933,7 @@ class SMTP:
             from_addr = (msg[header_prefix + 'Sender']
                            if (header_prefix + 'Sender') in msg
                            else msg[header_prefix + 'From'])
+            from_addr = email.utils.getaddresses([from_addr])[0][1]
         if to_addrs is None:
             addr_fields = [f for f in (msg[header_prefix + 'To'],
                                        msg[header_prefix + 'Bcc'],

--- a/Misc/NEWS.d/next/Library/2018-01-30-17-46-18.bpo-32727.aHVsRC.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-30-17-46-18.bpo-32727.aHVsRC.rst
@@ -1,0 +1,1 @@
+Do not include name field in SMTP envelope from address. Patch by Stéphane Wirtel


### PR DESCRIPTION
Avoid to set the SMTPUTF8 flag when the sender name contains a non-ascii
character. Patch by Stéphane Wirtel

<!-- issue-number: bpo-32727 -->
https://bugs.python.org/issue32727
<!-- /issue-number -->
