### PR TITLE
Mark job as done

### DIFF
--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -69,6 +69,7 @@ def _worker(executor_reference, work_queue):
                 work_item.run()
                 # Delete references to object. See issue16284
                 del work_item
+                work_queue.task_done()
                 continue
             executor = executor_reference()
             # Exit if:


### PR DESCRIPTION
In order to know how many jobs are running `ThreadPoolExecutor()._work_queue.unfinished_tasks`