### PR TITLE
[3.6] bpo-32583: Fix possible crashing in builtin Unicode decoders (GH-5325)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-01-26-21-20-21.bpo-32583.Fh3fau.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-01-26-21-20-21.bpo-32583.Fh3fau.rst
@@ -1,0 +1,2 @@
+Fix possible crashing in builtin Unicode decoders caused by write
+out-of-bound errors when using customized decode error handlers.


### PR DESCRIPTION
When using customized decode error handlers, it is possible for builtin decoders
to write out-of-bounds and then crash..
(cherry picked from commit 2c7fd46e11333ef5e5cce34212f7d087694f3658)



<!-- issue-number: bpo-32583 -->
https://bugs.python.org/issue32583
<!-- /issue-number -->
