### PR TITLE
Make site documentation more clear

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -97,12 +97,12 @@ not mentioned in either path configuration file.
 After these path manipulations, an attempt is made to import a module named
 :mod:`sitecustomize`, which can perform arbitrary site-specific customizations.
 It is typically created by a system administrator in the site-packages
-directory.  If this import fails with an :exc:`ImportError` exception, it is
-silently ignored.  If Python is started without output streams available, as
+directory.  If this import fails with an :exc:`ImportError` or its subclass
+exception, and the exception's :attr:`name` attribute equals to ``'sitecustomize'``,
+it is silently ignored.  If Python is started without output streams available, as
 with :file:`pythonw.exe` on Windows (which is used by default to start IDLE),
-attempted output from :mod:`sitecustomize` is ignored. Any exception other
-than :exc:`ImportError` causes a silent and perhaps mysterious failure of the
-process.
+attempted output from :mod:`sitecustomize` is ignored.  Any other exception
+causes a silent and perhaps mysterious failure of the process.
 
 .. index:: module: usercustomize
 
@@ -110,7 +110,9 @@ After this, an attempt is made to import a module named :mod:`usercustomize`,
 which can perform arbitrary user-specific customizations, if
 :data:`ENABLE_USER_SITE` is true.  This file is intended to be created in the
 user site-packages directory (see below), which is part of ``sys.path`` unless
-disabled by :option:`-s`.  An :exc:`ImportError` will be silently ignored.
+disabled by :option:`-s`.  If this import fails with an :exc:`ImportError` or
+its subclass exception, and the exception's :attr:`name` attribute equals to
+``'usercustomize'``, it is silently ignored.
 
 Note that for some non-Unix systems, ``sys.prefix`` and ``sys.exec_prefix`` are
 empty, and the path manipulations are skipped; however the import of


### PR DESCRIPTION
Mention only ImportError caused by importing sitecustomize.py/usercustomize.py
themselves will be silently ignored.
