### PR TITLE
bpo-32732 Extra kwargs of log() are ignored by LoggerAdapter

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1647,7 +1647,7 @@ class LoggerAdapter(object):
         adapter = LoggerAdapter(someLogger, dict(p1=v1, p2="v2"))
         """
         self.logger = logger
-        self.extra = extra
+        self.extra = extra or {}
 
     def process(self, msg, kwargs):
         """
@@ -1659,7 +1659,7 @@ class LoggerAdapter(object):
         Normally, you'll only need to override this one method in a
         LoggerAdapter subclass for your specific needs.
         """
-        kwargs["extra"] = self.extra
+        kwargs["extra"] = { **self.extra, **(kwargs.get("extra", {})) }
         return msg, kwargs
 
     #

--- a/Misc/NEWS.d/next/Library/2018-01-31-19-56-00.bpo-32732.mcOOli.rst
+++ b/Misc/NEWS.d/next/Library/2018-01-31-19-56-00.bpo-32732.mcOOli.rst
@@ -1,0 +1,1 @@
+Do not ignore extra in logging method when a LoggerAdapter is configured. Patch by Cyril Martin


### PR DESCRIPTION
- LoggerAdapter processes only extra kwargs given during its __init__. So extra kwargs, given to Logger#log are ignored when we configure a LoggerAdapter (same for: debug, info, warning etc).
- I expect extras are merged. More precisely, I expect local extra override the ones given in __init__.

<!-- issue-number: bpo-32732 -->
https://bugs.python.org/issue32732
<!-- /issue-number -->
