### PR TITLE
bpo-20709: os.utime(path_to_directory): wrong documentation for Windows.

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2756,14 +2756,12 @@ features:
 
    It is an error to specify tuples for both *times* and *ns*.
 
-   Whether a directory can be given for *path*
-   depends on whether the operating system implements directories as files
-   (for example, Windows does not).  Note that the exact times you set here may
-   not be returned by a subsequent :func:`~os.stat` call, depending on the
-   resolution with which your operating system records access and modification
-   times; see :func:`~os.stat`.  The best way to preserve exact times is to
-   use the *st_atime_ns* and *st_mtime_ns* fields from the :func:`os.stat`
-   result object with the *ns* parameter to `utime`.
+   Note that the exact times you set here may not be returned by a subsequent
+   :func:`~os.stat` call, depending on the resolution with which your operating
+   system records access and modification times; see :func:`~os.stat`. The best
+   way to preserve exact times is to use the *st_atime_ns* and *st_mtime_ns*
+   fields from the :func:`os.stat` result object with the *ns* parameter to
+   `utime`.
 
    This function can support :ref:`specifying a file descriptor <path_fd>`,
    :ref:`paths relative to directory descriptors <dir_fd>` and :ref:`not

--- a/Misc/NEWS.d/next/Documentation/2018-02-01-10-57-24.bpo-20709.1flcnc.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-02-01-10-57-24.bpo-20709.1flcnc.rst
@@ -1,0 +1,2 @@
+Remove the paragraph where we explain that os.utime() does not support a
+directory as path under Windows. Patch by Jan-Philip Gehrcke


### PR DESCRIPTION
Remove the paragrah where we explain that os.utime() does not support a
directory as path under Windows.

Co-authored-by: Jan-Philip Gehrcke <jgehrcke@gmail.com>

<!-- issue-number: bpo-20709 -->
https://bugs.python.org/issue20709
<!-- /issue-number -->
