### PR TITLE
bpo-32691: Use mod_spec.parent when running modules with pdb

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1532,7 +1532,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         __main__.__dict__.update({
             "__name__": "__main__",
             "__file__": self.mainpyfile,
-            "__package__": module_name,
+            "__package__": mod_spec.parent,
             "__loader__": mod_spec.loader,
             "__spec__": mod_spec,
             "__builtins__": __builtins__,

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1417,7 +1417,7 @@ class PdbTestCase(unittest.TestCase):
     def test_relative_imports(self):
         self.module_name = 't_main'
         support.rmtree(self.module_name)
-        main_file = self.module_name + '/__main__.py'
+        main_file = self.module_name + '/runme.py'
         init_file = self.module_name + '/__init__.py'
         module_file = self.module_name + '/module.py'
         self.addCleanup(support.rmtree, self.module_name)
@@ -1446,8 +1446,8 @@ class PdbTestCase(unittest.TestCase):
             p module.var2
             quit
         """
-        stdout, _ = self._run_pdb(['-m', self.module_name], commands)
-        self.assertTrue(any("VAR from module" in l for l in stdout.splitlines()))
+        stdout, _ = self._run_pdb(['-m', self.module_name + '.runme'], commands)
+        self.assertTrue(any("VAR from module" in l for l in stdout.splitlines()), stdout)
         self.assertTrue(any("VAR from top" in l for l in stdout.splitlines()))
         self.assertTrue(any("second var" in l for l in stdout.splitlines()))
 

--- a/Misc/NEWS.d/next/Library/2018-02-01-15-53-35.bpo-32691.VLWVTq.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-01-15-53-35.bpo-32691.VLWVTq.rst
@@ -1,0 +1,1 @@
+Use mod_spec.parent when running modules with pdb


### PR DESCRIPTION
At the moment the module name is used, which breaks relative imports when pdb is run against a plain module or submodule.

Fixes running `python3 -m pdb -m plain.module` when plain_module has a relative import

I've changed the relative import test to use the plain module to cover it. If prefered I can split into two test cases (just felt there are too many test cases for the run as module functionality).

Reported by @jaraco

<!-- issue-number: bpo-32206 -->
https://bugs.python.org/issue32691
<!-- /issue-number -->
