### PR TITLE
bpo-32743: Fix typo in hamt.c comments

### DIFF
--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -1476,7 +1476,7 @@ hamt_node_collision_without(PyHamtNode_Collision *self,
             if (new_count == 1) {
                 /* The node has two keys, and after deletion the
                    new Collision node would have one.  Collision nodes
-                   with one key shouldn't exist, co convert it to a
+                   with one key shouldn't exist, so convert it to a
                    Bitmap node.
                 */
                 PyHamtNode_Bitmap *node = (PyHamtNode_Bitmap *)


### PR DESCRIPTION
<!-- issue-number: bpo-32743 -->
https://bugs.python.org/issue32743
<!-- /issue-number -->
