### PR TITLE
[3.7] bpo-32734: Fix asyncio.Lock multiple acquire safety issue (GH-5466)

### DIFF
--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -206,9 +206,12 @@ class LockTests(test_utils.TestCase):
         # and 2 locks are taken at once.
         lock = asyncio.Lock(loop=self.loop)
         lock_count = 0
+        call_count = 0
 
         async def lockit():
             nonlocal lock_count
+            nonlocal call_count
+            call_count += 1
             await lock.acquire()
             lock_count += 1
   
@@ -220,13 +223,15 @@ class LockTests(test_utils.TestCase):
             t1.cancel()
             lock.release()
 
-        asyncio.Task(lockandtrigger(), loop=self.loop)
-        t1 = asyncio.Task(lockit(), loop=self.loop)
-        t2 = asyncio.Task(lockit(), loop=self.loop)
-        t3 = asyncio.Task(lockit(), loop=self.loop)
+        t0 = self.loop.create_task(lockandtrigger())
+        t1 = self.loop.create_task(lockit())
+        t2 = self.loop.create_task(lockit())
+        t3 = self.loop.create_task(lockit())
 
         # First loop acquires all
         test_utils.run_briefly(self.loop)
+        self.assertTrue(t0.done())
+
         # Second loop calls trigger
         test_utils.run_briefly(self.loop)
         # Third loop calls cancellation
@@ -234,6 +239,15 @@ class LockTests(test_utils.TestCase):
 
         # Make sure only one lock was taken
         self.assertEqual(lock_count, 1)
+        # While 3 calls were made to lockit()
+        self.assertEqual(call_count, 3)
+        self.assertTrue(t1.cancelled() and t2.done())
+
+        # Cleanup the task that is stuck on acquire.
+        t3.cancel()
+        test_utils.run_briefly(self.loop)
+        self.assertTrue(t3.cancelled())
+
 
 
     def test_finished_waiter_cancelled(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -602,6 +602,7 @@ Milton L. Hankins
 Stephen Hansen
 Barry Hantman
 Lynda Hardman
+Bar Harel
 Derek Harland
 Jason Harper
 David Harrigan

--- a/Misc/NEWS.d/next/Library/2018-02-01-01-34-47.bpo-32734.gCV9AD.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-01-01-34-47.bpo-32734.gCV9AD.rst
@@ -1,2 +1,2 @@
 Fixed ``asyncio.Lock()`` safety issue which allowed acquiring and locking
-the same lock multiple times. Patch by Bar Harel.
+the same lock multiple times, without it being free. Patch by Bar Harel.

--- a/Misc/NEWS.d/next/Library/2018-02-01-01-34-47.bpo-32734.gCV9AD.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-01-01-34-47.bpo-32734.gCV9AD.rst
@@ -1,0 +1,2 @@
+Fixed ``asyncio.Lock()`` safety issue which allowed acquiring and locking
+the same lock multiple times. Patch by Bar Harel.


### PR DESCRIPTION
<!-- issue-number: bpo-32734 -->
https://bugs.python.org/issue32734
<!-- /issue-number -->
