### PR TITLE
bpo-32720: Fixed incorrect definition in format mini-language doc

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -304,9 +304,9 @@ The general form of a *standard format specifier* is:
    fill: <any character>
    align: "<" | ">" | "=" | "^"
    sign: "+" | "-" | " "
-   width: `integer`
+   width: `digit`+
    grouping_option: "_" | ","
-   precision: `integer`
+   precision: `digit`+
    type: "b" | "c" | "d" | "e" | "E" | "f" | "F" | "g" | "G" | "n" | "o" | "s" | "x" | "X" | "%"
 
 If a valid *align* value is specified, it can be preceded by a *fill*


### PR DESCRIPTION
* Changed definition of width and precision from "integer" to "digit+" to reflect actual behavior

<!-- issue-number: bpo-32720 -->
https://bugs.python.org/issue32720
<!-- /issue-number -->
