### PR TITLE
bpo-32436: Fix compiler warning

### DIFF
--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -2358,6 +2358,8 @@ _PyHamt_Without(PyHamtObject *o, PyObject *key)
             Py_INCREF(o);
             return o;
         case W_NEWNODE: {
+            assert(new_root != NULL);
+
             PyHamtObject *new_o = hamt_alloc();
             if (new_o == NULL) {
                 Py_DECREF(new_root);


### PR DESCRIPTION


<!-- issue-number: bpo-32436 -->
https://bugs.python.org/issue32436
<!-- /issue-number -->
