### PR TITLE
bpo-31804: multiprocessing calls flush on sys.stdout at exit even if …

### DIFF
--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -314,8 +314,10 @@ class BaseProcess(object):
         finally:
             threading._shutdown()
             util.info('process exiting with exitcode %d' % exitcode)
-            sys.stdout.flush()
-            sys.stderr.flush()
+            if sys.stdout is not None and not sys.stdout.closed:
+                sys.stdout.flush()
+            if sys.stderr is not None and not sys.stderr.closed:
+                sys.stderr.flush()
 
         return exitcode
 

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -314,10 +314,14 @@ class BaseProcess(object):
         finally:
             threading._shutdown()
             util.info('process exiting with exitcode %d' % exitcode)
-            if sys.stdout is not None and not sys.stdout.closed:
+            try:
                 sys.stdout.flush()
-            if sys.stderr is not None and not sys.stderr.closed:
+            except (AttributeError, ValueError):
+                pass
+            try:
                 sys.stderr.flush()
+            except (AttributeError, ValueError):
+                pass
 
         return exitcode
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -588,7 +588,7 @@ class _TestProcess(BaseTestCase):
         if type_ == 'threads':
             # it is safe to close std streams in another process, but if thread
             # are used, we must not close the original std streams
-            closed_stream = io.StringIO()
+            closed_stream = _file_like(io.StringIO())
             closed_stream.close()
             setattr(sys, stream_name, closed_stream)
         else:
@@ -3873,6 +3873,9 @@ class _file_like(object):
     def flush(self):
         self._delegate.write(''.join(self.cache))
         self._cache = []
+
+    def close(self):
+        self._delegate.close()
 
 class TestStdinBadfiledescriptor(unittest.TestCase):
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -653,6 +653,47 @@ class _TestProcess(BaseTestCase):
             self.check_forkserver_death(signal.SIGKILL)
 
 
+class TestStdOutAndErr(unittest.TestCase):
+    @staticmethod
+    def closeIO(stream_name):
+        getattr(sys, stream_name).close()
+
+    @staticmethod
+    def removeIO(stream_name):
+        setattr(sys, stream_name, None)
+
+    def test_closed_stdio(self):
+        """
+        bpo-28326: multiprocessing.Process depends on sys.stdout being open
+        """
+        self.run_process(self.closeIO)
+
+    def test_no_stdio(self):
+        """
+        bpo-31804: If you start Python by pythonw then sys.stdout and
+        sys.stderr are set to None. If you also use multiprocessing
+        then when the child process finishes BaseProcess._bootstrap
+        calls sys.stdout.flush() and sys.stderr.flush() finally.
+        This causes the process return code to be not zero (it is 1).
+
+        This unit test sets sys.stdio and sys.stderr to None, instead of
+        changing the Python interpreter to use when starting a child process
+        to pythonw.exe because that is Windows specific. This method
+        cannot test if there is an error (because of stdout or stderr is None)
+        before the target function is called. However the errors have occurred
+        in the multiprocessing outro so this can test the previously mentioned
+        bug. Also this way the feature can be tested on other operating
+        systems too.
+        """
+        self.run_process(self.removeIO)
+
+    def run_process(self, target):
+        for stream_name in ('stdout', 'stderr'):
+            proc = multiprocessing.Process(target=target, args=(stream_name,))
+            proc.start()
+            proc.join()
+            self.assertEqual(proc.exitcode, 0)
+
 #
 #
 #

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -670,20 +670,8 @@ class TestStdOutAndErr(unittest.TestCase):
 
     def test_no_stdio(self):
         """
-        bpo-31804: If you start Python by pythonw then sys.stdout and
-        sys.stderr are set to None. If you also use multiprocessing
-        then when the child process finishes BaseProcess._bootstrap
-        calls sys.stdout.flush() and sys.stderr.flush() finally.
-        This causes the process return code to be not zero (it is 1).
-
-        This unit test sets sys.stdio and sys.stderr to None, instead of
-        changing the Python interpreter to use when starting a child process
-        to pythonw.exe because that is Windows specific. This method
-        cannot test if there is an error (because of stdout or stderr is None)
-        before the target function is called. However the errors have occurred
-        in the multiprocessing outro so this can test the previously mentioned
-        bug. Also this way the feature can be tested on other operating
-        systems too.
+        bpo-31804: set sys.stdio and sys.stderr to None, instead of
+        changing the Python interpreter to pythonw.exe. (OS independence)
         """
         self.run_process(self.removeIO)
 

--- a/Misc/NEWS.d/next/Library/2018-02-12-11-04-46.bpo-31804.9mWA5i.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-12-11-04-46.bpo-31804.9mWA5i.rst
@@ -1,0 +1,3 @@
+bugfix: Process return value is 0 when multiprocessing is used with closed
+stdout or stderr streams, or if stdout or stderr is None (e.g. using
+pythonw.exe on windows)


### PR DESCRIPTION
…it is None (pythonw)

If you start Python by pythonw.exe on Windows platform then sys.stdout and sys.stderr are set to None. If you also use multiprocessing then when the child process finishes BaseProcess._bootstrap calls sys.stdout.flush() and sys.stderr.flush() finally. This causes the process return code to be not zero (it is 1).


<!-- issue-number: bpo-31804 -->
https://bugs.python.org/issue31804
<!-- /issue-number -->
