### PR TITLE
[2.7] bpo-32137: The repr of deeply nested dict now raises a RuntimeError (GH-4570)

### DIFF
--- a/Lib/test/list_tests.py
+++ b/Lib/test/list_tests.py
@@ -45,10 +45,11 @@ class CommonTest(seq_tests.CommonTest):
         self.assertEqual(str(a2), "[0, 1, 2, [...], 3]")
         self.assertEqual(repr(a2), "[0, 1, 2, [...], 3]")
 
-        l0 = []
-        for i in xrange(sys.getrecursionlimit() + 100):
-            l0 = [l0]
-        self.assertRaises(RuntimeError, repr, l0)
+    def test_repr_deep(self):
+        a = self.type2test([])
+        for i in range(sys.getrecursionlimit() + 100):
+            a = self.type2test([a])
+        self.assertRaises(RuntimeError, repr, a)
 
     def test_print(self):
         d = self.type2test(xrange(200))

--- a/Lib/test/mapping_tests.py
+++ b/Lib/test/mapping_tests.py
@@ -2,6 +2,7 @@
 import unittest
 import UserDict
 import test_support
+import sys
 
 
 class BasicTestMappingProtocol(unittest.TestCase):
@@ -644,6 +645,14 @@ class TestHashMappingProtocol(TestMappingProtocol):
 
         d = self._full_mapping({1: BadRepr()})
         self.assertRaises(Exc, repr, d)
+
+    def test_repr_deep(self):
+        d = self._empty_mapping()
+        for i in range(sys.getrecursionlimit() + 100):
+            d0 = d
+            d = self._empty_mapping()
+            d[1] = d0
+        self.assertRaises(RuntimeError, repr, d)
 
     def test_le(self):
         self.assertTrue(not (self._empty_mapping() < self._empty_mapping()))

--- a/Lib/test/test_dict.py
+++ b/Lib/test/test_dict.py
@@ -3,6 +3,7 @@ from test import test_support
 
 import UserDict, random, string
 import gc, weakref
+import sys
 
 
 class DictTest(unittest.TestCase):
@@ -421,6 +422,12 @@ class DictTest(unittest.TestCase):
 
         d = {1: BadRepr()}
         self.assertRaises(Exc, repr, d)
+
+    def test_repr_deep(self):
+        d = {}
+        for i in range(sys.getrecursionlimit() + 100):
+            d = {1: d}
+        self.assertRaises(RuntimeError, repr, d)
 
     def test_le(self):
         self.assertFalse({} < {})

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-26-14-36-30.bpo-32137.Stj5nL.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-26-14-36-30.bpo-32137.Stj5nL.rst
@@ -1,0 +1,2 @@
+The repr of deeply nested dict now raises a RecursionError instead of
+crashing due to a stack overflow.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -383,10 +383,7 @@ list_repr(PyListObject *v)
        so must refetch the list size on each iteration. */
     for (i = 0; i < Py_SIZE(v); ++i) {
         int status;
-        if (Py_EnterRecursiveCall(" while getting the repr of a list"))
-            goto Done;
         s = PyObject_Repr(v->ob_item[i]);
-        Py_LeaveRecursiveCall();
         if (s == NULL)
             goto Done;
         status = PyList_Append(pieces, s);

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -378,7 +378,12 @@ PyObject_Repr(PyObject *v)
                                    Py_TYPE(v)->tp_name, v);
     else {
         PyObject *res;
+        /* It is possible for a type to have a tp_repr representation that
+           loops infinitely. */
+        if (Py_EnterRecursiveCall(" while getting the repr of an object"))
+            return NULL;
         res = (*Py_TYPE(v)->tp_repr)(v);
+        Py_LeaveRecursiveCall();
         if (res == NULL)
             return NULL;
 #ifdef Py_USING_UNICODE

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -288,10 +288,7 @@ tuplerepr(PyTupleObject *v)
 
     /* Do repr() on each element. */
     for (i = 0; i < n; ++i) {
-        if (Py_EnterRecursiveCall(" while getting the repr of a tuple"))
-            goto Done;
         s = PyObject_Repr(v->ob_item[i]);
-        Py_LeaveRecursiveCall();
         if (s == NULL)
             goto Done;
         PyTuple_SET_ITEM(pieces, i, s);


### PR DESCRIPTION
instead of crashing due to a stack overflow.

This perhaps will fix similar problems in other extension types..
(cherry picked from commit 1fb72d2ad243c965d4432b4e93884064001a2607)


<!-- issue-number: bpo-32137 -->
https://bugs.python.org/issue32137
<!-- /issue-number -->
