### PR TITLE
[2.7] bpo-32674: Improve the docstring for __import__ (GH-5339)

### DIFF
--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -54,7 +54,7 @@ PyDoc_STRVAR(import_doc,
 "__import__(name, globals={}, locals={}, fromlist=[], level=-1) -> module\n\
 \n\
 Import a module. Because this function is meant for use by the Python\n\
-interpreter and not for general use it is better to use\n\
+interpreter and not for general use, it is better to use\n\
 importlib.import_module() to programmatically import a module.\n\
 \n\
 The globals argument is only used to determine the context;\n\
@@ -63,9 +63,8 @@ should be a list of names to emulate ``from name import ...'', or an\n\
 empty list to emulate ``import name''.\n\
 When importing a module from a package, note that __import__('A.B', ...)\n\
 returns package A when fromlist is empty, but its submodule B when\n\
-fromlist is not empty.  Level is used to determine whether to perform \n\
-absolute or relative imports.  -1 is the original strategy of attempting\n\
-both absolute and relative imports, 0 is absolute, a positive number\n\
+fromlist is not empty.  The level argument is used to determine whether to\n\
+perform absolute or relative imports: 0 is absolute, while a positive number\n\
 is the number of parent directories to search relative to the current module.");
 
 


### PR DESCRIPTION
Clarify that the level argument is used to determine whether to
perform absolute or relative imports: 0 is absolute, while a positive number
is the number of parent directories to search relative to the current module..
(cherry picked from commit 461d225b195eec5269f317323b41115516144c41)

Co-authored-by: oldk <oldk1331@users.noreply.github.com>

<!-- issue-number: bpo-32674 -->
https://bugs.python.org/issue32674
<!-- /issue-number -->
