### PR TITLE
[3.6] bpo-32734: Fix asyncio.Lock multiple acquire safety issue (GH-5466)

### DIFF
--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -170,14 +170,17 @@ class Lock(_ContextManagerMixin):
             self._locked = True
             return True
 
-        _waiters = self._waiters
         fut = self._loop.create_future()
-        _waiters.append(fut)
+        self._waiters.append(fut)
+
+        # Finally block should be called before the CancelledError
+        # handling as we don't want CancelledError to call
+        # _wake_up_first() and attempt to wake up itself.
         try:
             try:
                 yield from fut
             finally:
-                _waiters.remove(fut)
+                self._waiters.remove(fut)
         except futures.CancelledError:
             if not self._locked:
                 self._wake_up_first()
@@ -185,7 +188,6 @@ class Lock(_ContextManagerMixin):
 
         self._locked = True
         return True
-        
 
     def release(self):
         """Release a lock.
@@ -210,10 +212,9 @@ class Lock(_ContextManagerMixin):
             fut = next(iter(self._waiters))
         except StopIteration:
             return
-        
+
         if not fut.done():
             fut.set_result(True)
-
 
 
 class Event:

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -170,18 +170,22 @@ class Lock(_ContextManagerMixin):
             self._locked = True
             return True
 
+        _waiters = self._waiters
         fut = self._loop.create_future()
-        self._waiters.append(fut)
+        _waiters.append(fut)
         try:
-            yield from fut
-            self._locked = True
-            return True
+            try:
+                yield from fut
+            finally:
+                _waiters.remove(fut)
         except futures.CancelledError:
             if not self._locked:
                 self._wake_up_first()
             raise
-        finally:
-            self._waiters.remove(fut)
+
+        self._locked = True
+        return True
+        
 
     def release(self):
         """Release a lock.
@@ -201,11 +205,15 @@ class Lock(_ContextManagerMixin):
             raise RuntimeError('Lock is not acquired.')
 
     def _wake_up_first(self):
-        """Wake up the first waiter who isn't cancelled."""
-        for fut in self._waiters:
-            if not fut.done():
-                fut.set_result(True)
-                break
+        """Wake up the first waiter if it isn't done."""
+        try:
+            fut = next(iter(self._waiters))
+        except StopIteration:
+            return
+        
+        if not fut.done():
+            fut.set_result(True)
+
 
 
 class Event:

--- a/Lib/asyncio/locks.py
+++ b/Lib/asyncio/locks.py
@@ -213,6 +213,9 @@ class Lock(_ContextManagerMixin):
         except StopIteration:
             return
 
+        # .done() necessarily means that a waiter will wake up later on and
+        # either take the lock, or, if it was cancelled and lock wasn't
+        # taken already, will hit this again and wake up a new waiter.
         if not fut.done():
             fut.set_result(True)
 

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -176,6 +176,42 @@ class LockTests(test_utils.TestCase):
         self.assertTrue(tb.cancelled())
         self.assertTrue(tc.done())
 
+    def test_cancel_release_race(self):
+        # Issue 32734
+        # Acquire 4 locks, cancel second, release first
+        # and 2 locks are taken at once.
+        lock = asyncio.Lock(loop=self.loop)
+        lock_count = 0
+
+        async def lockit():
+            nonlocal lock_count
+            await lock.acquire()
+            lock_count += 1
+  
+        async def lockandtrigger():
+            await lock.acquire()
+            self.loop.call_soon(trigger)
+          
+        def trigger():
+            t1.cancel()
+            lock.release()
+
+        asyncio.Task(lockandtrigger(), loop=self.loop)
+        t1 = asyncio.Task(lockit(), loop=self.loop)
+        t2 = asyncio.Task(lockit(), loop=self.loop)
+        t3 = asyncio.Task(lockit(), loop=self.loop)
+
+        # First loop acquires all
+        test_utils.run_briefly(self.loop)
+        # Second loop calls trigger
+        test_utils.run_briefly(self.loop)
+        # Third loop calls cancellation
+        test_utils.run_briefly(self.loop)
+
+        # Make sure only one lock was taken
+        self.assertEqual(lock_count, 1)
+
+
     def test_finished_waiter_cancelled(self):
         lock = asyncio.Lock(loop=self.loop)
 

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -182,9 +182,12 @@ class LockTests(test_utils.TestCase):
         # and 2 locks are taken at once.
         lock = asyncio.Lock(loop=self.loop)
         lock_count = 0
+        call_count = 0
 
         async def lockit():
             nonlocal lock_count
+            nonlocal call_count
+            call_count += 1
             await lock.acquire()
             lock_count += 1
   
@@ -196,13 +199,15 @@ class LockTests(test_utils.TestCase):
             t1.cancel()
             lock.release()
 
-        asyncio.Task(lockandtrigger(), loop=self.loop)
-        t1 = asyncio.Task(lockit(), loop=self.loop)
-        t2 = asyncio.Task(lockit(), loop=self.loop)
-        t3 = asyncio.Task(lockit(), loop=self.loop)
+        t0 = self.loop.create_task(lockandtrigger())
+        t1 = self.loop.create_task(lockit())
+        t2 = self.loop.create_task(lockit())
+        t3 = self.loop.create_task(lockit())
 
         # First loop acquires all
         test_utils.run_briefly(self.loop)
+        self.assertTrue(t0.done())
+
         # Second loop calls trigger
         test_utils.run_briefly(self.loop)
         # Third loop calls cancellation
@@ -210,6 +215,15 @@ class LockTests(test_utils.TestCase):
 
         # Make sure only one lock was taken
         self.assertEqual(lock_count, 1)
+        # While 3 calls were made to lockit()
+        self.assertEqual(call_count, 3)
+        self.assertTrue(t1.cancelled() and t2.done())
+
+        # Cleanup the task that is stuck on acquire.
+        t3.cancel()
+        test_utils.run_briefly(self.loop)
+        self.assertTrue(t3.cancelled())
+
 
 
     def test_finished_waiter_cancelled(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -589,6 +589,7 @@ Milton L. Hankins
 Stephen Hansen
 Barry Hantman
 Lynda Hardman
+Bar Harel
 Derek Harland
 Jason Harper
 David Harrigan

--- a/Misc/NEWS.d/next/Library/2018-02-01-01-34-47.bpo-32734.gCV9AD.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-01-01-34-47.bpo-32734.gCV9AD.rst
@@ -1,2 +1,2 @@
 Fixed ``asyncio.Lock()`` safety issue which allowed acquiring and locking
-the same lock multiple times. Patch by Bar Harel.
+the same lock multiple times, without it being free. Patch by Bar Harel.

--- a/Misc/NEWS.d/next/Library/2018-02-01-01-34-47.bpo-32734.gCV9AD.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-01-01-34-47.bpo-32734.gCV9AD.rst
@@ -1,0 +1,2 @@
+Fixed ``asyncio.Lock()`` safety issue which allowed acquiring and locking
+the same lock multiple times. Patch by Bar Harel.


### PR DESCRIPTION
<!-- issue-number: bpo-32734 -->
https://bugs.python.org/issue32734
<!-- /issue-number -->
