### PR TITLE
[3.6] bpo-30928: prepare idlelib/NEWS.txt for 3.6.5 entries.

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -1,7 +1,12 @@
-What's New in IDLE 3.6.3
-Released on 2017-09-25?
+What's New in IDLE 3.6.5
+Released on 2017-03-26?
 ========================
 
+
+
+What's New in IDLE 3.6.4
+Released on 2017-12-19
+========================
 
 bpo-32207: Improve tk event exception tracebacks in IDLE.
 When tk event handling is driven by IDLE's run loop, a confusing
@@ -9,6 +14,11 @@ and distracting queue.EMPTY traceback context is no longer added
 to tk event exception tracebacks.  The traceback is now the same
 as when event handling is driven by user code.  Patch based on
 a suggestion by Serhiy Storchaka.
+
+
+What's New in IDLE 3.6.3
+Released on 2017-10-03
+========================
 
 bpo-32164: Delete unused file idlelib/tabbedpages.py.
 Use of TabbedPageSet in configdialog was replaced by ttk.Notebook.
@@ -268,7 +278,7 @@ bpo-24813: Add icon to help_about and make other changes.
 
 
 What's New in IDLE 3.6.2
-Released on 2017-07-11
+Released on 2017-07-17
 ========================
 
 bpo-15786: Fix several problems with IDLE's autocompletion box.

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -15,11 +15,6 @@ to tk event exception tracebacks.  The traceback is now the same
 as when event handling is driven by user code.  Patch based on
 a suggestion by Serhiy Storchaka.
 
-
-What's New in IDLE 3.6.3
-Released on 2017-10-03
-========================
-
 bpo-32164: Delete unused file idlelib/tabbedpages.py.
 Use of TabbedPageSet in configdialog was replaced by ttk.Notebook.
 
@@ -49,6 +44,11 @@ a better idea of what they might see in the shell and editors.
 To make room for the expanded sample, frames on the Font tab are
 re-arranged.  The Font/Tabs help explains a bit about the additions.
 Patch by Terry Jan Reedy
+
+
+What's New in IDLE 3.6.3
+Released on 2017-10-03
+========================
 
 bpo-31460: Simplify the API of IDLE's Module Browser.
 Passing a widget instead of an flist with a root widget opens the


### PR DESCRIPTION
Add 3.6.4 and 3.6.5 headers, move 3.6.4 item from 3.6.3 section.


<!-- issue-number: bpo-30968 -->
https://bugs.python.org/issue30968
<!-- /issue-number -->
