### PR TITLE
fix error message when hashlib.scrypt function returns 0

### DIFF
--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -820,7 +820,8 @@ _hashlib_scrypt_impl(PyObject *module, Py_buffer *password, Py_buffer *salt,
     if (!retval) {
         /* sorry, can't do much better */
         PyErr_SetString(PyExc_ValueError,
-                        "Invalid paramemter combination for n, r, p, maxmem.");
+                        "Invalid parameter combination for n, r, p, maxmem. "
+                        "Make sure maxmem is high enough.");
         return NULL;
    }
 


### PR DESCRIPTION
This commit fixes a typo and adds a tip in the error message returned by the hashlib scrypt function. 

The documentation specifies the default memory limit of 32MB in OpenSSL (https://docs.python.org/3/library/hashlib.html#hashlib.scrypt), but if this limit causes any error in the low-level openssl function, the generic error message returned by the code doesn't provide helpful information. 