### PR TITLE
[3.6] bpo-32746: Fix multiple typos (GH-5144)

### DIFF
--- a/Doc/library/optparse.rst
+++ b/Doc/library/optparse.rst
@@ -567,7 +567,7 @@ An option group is obtained using the class :class:`OptionGroup`:
 
    where
 
-   * parser is the :class:`OptionParser` instance the group will be insterted in
+   * parser is the :class:`OptionParser` instance the group will be inserted in
      to
    * title is the group title
    * description, optional, is a long description of the group

--- a/Doc/library/ossaudiodev.rst
+++ b/Doc/library/ossaudiodev.rst
@@ -14,7 +14,7 @@ the standard audio interface for Linux and recent versions of FreeBSD.
 .. Things will get more complicated for future Linux versions, since
    ALSA is in the standard kernel as of 2.5.x.  Presumably if you
    use ALSA, you'll have to make sure its OSS compatibility layer
-   is active to use ossaudiodev, but you're gonna need it for the vast
+   is active to use ossaudiodev, but you're going to need it for the vast
    majority of Linux audio apps anyway.
 
    Sounds like things are also complicated for other BSDs.  In response
@@ -447,4 +447,3 @@ The remaining methods are specific to audio mixing:
    microphone input::
 
       mixer.setrecsrc (1 << ossaudiodev.SOUND_MIXER_MIC)
-

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2746,8 +2746,8 @@ def _fold_mime_parameters(part, lines, maxlen, encoding):
 
     Using the decoded list of parameters and values, format them according to
     the RFC rules, including using RFC2231 encoding if the value cannot be
-    expressed in 'encoding' and/or the paramter+value is too long to fit within
-    'maxlen'.
+    expressed in 'encoding' and/or the parameter+value is too long to fit
+    within 'maxlen'.
 
     """
     # Special case for RFC2231 encoding: start from decoded values and use

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -495,7 +495,7 @@ class FontPage(Frame):
         Changing any of the font vars invokes var_changed_font, which
         adds all 3 font options to changes and calls set_samples.
         Set_samples applies a new font constructed from the font vars to
-        font_sample and to highlight_sample on the hightlight page.
+        font_sample and to highlight_sample on the highlight page.
 
         Tabs: Enable users to change spaces entered for indent tabs.
         Changing indent_scale value with the mouse sets Var space_num,
@@ -646,7 +646,7 @@ class FontPage(Frame):
 
         Called on font initialization and change events.
         Accesses font_name, font_size, and font_bold Variables.
-        Updates font_sample and hightlight page highlight_sample.
+        Updates font_sample and highlight page highlight_sample.
         """
         font_name = self.font_name.get()
         font_weight = tkFont.BOLD if self.font_bold.get() else tkFont.NORMAL

--- a/Lib/opcode.py
+++ b/Lib/opcode.py
@@ -142,7 +142,7 @@ name_op('LOAD_NAME', 101)       # Index in name list
 def_op('BUILD_TUPLE', 102)      # Number of tuple items
 def_op('BUILD_LIST', 103)       # Number of list items
 def_op('BUILD_SET', 104)        # Number of set items
-def_op('BUILD_MAP', 105)        # Number of dict entries (upto 255)
+def_op('BUILD_MAP', 105)        # Number of dict entries
 name_op('LOAD_ATTR', 106)       # Index in name list
 def_op('COMPARE_OP', 107)       # Comparison operator
 hascompare.append(107)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1709,7 +1709,7 @@ class TestDateTime(TestDate):
 
         # Make sure comparison doesn't forget microseconds, and isn't done
         # via comparing a float timestamp (an IEEE double doesn't have enough
-        # precision to span microsecond resolution across years 1 thru 9999,
+        # precision to span microsecond resolution across years 1 through 9999,
         # so comparing via timestamp necessarily calls some distinct values
         # equal).
         dt1 = self.theclass(MAXYEAR, 12, 31, 23, 59, 59, 999998)

--- a/Lib/test/test_cmd.py
+++ b/Lib/test/test_cmd.py
@@ -52,7 +52,7 @@ class samplecmdclass(cmd.Cmd):
 
     Test for the function completedefault():
     >>> mycmd.completedefault()
-    This is the completedefault methode
+    This is the completedefault method
     >>> mycmd.completenames("a")
     ['add']
 
@@ -141,7 +141,7 @@ class samplecmdclass(cmd.Cmd):
         print("Hello from postloop")
 
     def completedefault(self, *ignored):
-        print("This is the completedefault methode")
+        print("This is the completedefault method")
 
     def complete_command(self):
         print("complete command")

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -1517,7 +1517,7 @@ class Knights:
                 succs[final].remove(corner)
                 add_to_successors(this)
 
-        # Generate moves 3 thru m*n-1.
+        # Generate moves 3 through m*n-1.
         def advance(len=len):
             # If some successor has only one exit, must take it.
             # Else favor successors with fewer exits.
@@ -1539,7 +1539,7 @@ class Knights:
                         yield i
                     add_to_successors(i)
 
-        # Generate moves 3 thru m*n-1.  Alternative version using a
+        # Generate moves 3 through m*n-1.  Alternative version using a
         # stronger (but more expensive) heuristic to order successors.
         # Since the # of backtracking levels is m*n, a poor move early on
         # can take eons to undo.  Smallest square board for which this

--- a/Lib/test/test_weakref.py
+++ b/Lib/test/test_weakref.py
@@ -1637,7 +1637,7 @@ class MappingTestCase(TestBase):
         # has to keep looping to find the first object we delete.
         objs.reverse()
 
-        # Turn on mutation in C.__eq__.  The first time thru the loop,
+        # Turn on mutation in C.__eq__.  The first time through the loop,
         # under the iterkeys() business the first comparison will delete
         # the last item iterkeys() would see, and that causes a
         #     RuntimeError: dictionary changed size during iteration

--- a/Lib/unittest/test/test_discovery.py
+++ b/Lib/unittest/test/test_discovery.py
@@ -199,8 +199,8 @@ class TestDiscovery(unittest.TestCase):
                          ['a_directory', 'test_directory', 'test_directory2'])
 
         # load_tests should have been called once with loader, tests and pattern
-        # (but there are no tests in our stub module itself, so thats [] at the
-        # time of call.
+        # (but there are no tests in our stub module itself, so that is [] at
+        # the time of call).
         self.assertEqual(Module.load_tests_args,
                          [(loader, [], 'test*')])
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3157,7 +3157,7 @@ Inconsistent:
     PyErr_SetString(PyExc_ValueError, "fromutc: tz.dst() gave"
                     "inconsistent results; cannot convert");
 
-    /* fall thru to failure */
+    /* fall through to failure */
 Fail:
     Py_XDECREF(off);
     Py_XDECREF(dst);

--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -918,7 +918,7 @@ generate_hash_name_list(void)
  *  This macro generates constructor function definitions for specific
  *  hash algorithms.  These constructors are much faster than calling
  *  the generic one passing it a python string and are noticeably
- *  faster than calling a python new() wrapper.  Thats important for
+ *  faster than calling a python new() wrapper.  That is important for
  *  code that wants to make hashes of a bunch of small strings.
  *  The first call will lazy-initialize, which reports an exception
  *  if initialization fails.

--- a/Modules/md5module.c
+++ b/Modules/md5module.c
@@ -293,7 +293,7 @@ md5_done(struct md5_state *md5, unsigned char *out)
         md5->curlen = 0;
     }
 
-    /* pad upto 56 bytes of zeroes */
+    /* pad up to 56 bytes of zeroes */
     while (md5->curlen < 56) {
         md5->buf[md5->curlen++] = (unsigned char)0;
     }

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -5977,7 +5977,7 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
     }
 #if defined(__APPLE__) && defined(AI_NUMERICSERV)
     if ((flags & AI_NUMERICSERV) && (pptr == NULL || (pptr[0] == '0' && pptr[1] == 0))) {
-        /* On OSX upto at least OSX 10.8 getaddrinfo crashes
+        /* On OSX up to at least OSX 10.8 getaddrinfo crashes
          * if AI_NUMERICSERV is set and the servname is NULL or "0".
          * This workaround avoids a segfault in libsystem.
          */

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -332,7 +332,7 @@ error:
 
 /* The addend 82520, was selected from the range(0, 1000000) for
    generating the greatest number of prime multipliers for tuples
-   upto length eight:
+   up to length eight:
 
      1082527, 1165049, 1082531, 1165057, 1247581, 1330103, 1082533,
      1330111, 1412633, 1165069, 1247599, 1495177, 1577699

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -4929,7 +4929,7 @@ PyType_Ready(PyTypeObject *type)
     /* PyType_Ready is the closest thing we have to a choke point
      * for type objects, so is the best place I can think of to try
      * to get type objects into the doubly-linked list of all objects.
-     * Still, not all type objects go thru PyType_Ready.
+     * Still, not all type objects go through PyType_Ready.
      */
     _Py_AddToAllObjects((PyObject *)type, 0);
 #endif

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -1771,7 +1771,7 @@ vgetargskeywords(PyObject *args, PyObject *keywords, const char *format,
             }
         }
 
-        /* We are into optional args, skip thru to any remaining
+        /* We are into optional args, skip through to any remaining
          * keyword args */
         msg = skipitem(&format, p_va, flags);
         if (msg) {
@@ -2130,7 +2130,7 @@ vgetargskeywordsfast_impl(PyObject **args, Py_ssize_t nargs,
             return cleanreturn(1, &freelist);
         }
 
-        /* We are into optional args, skip thru to any remaining
+        /* We are into optional args, skip through to any remaining
          * keyword args */
         msg = skipitem(&format, p_va, flags);
         assert(msg == NULL);


### PR DESCRIPTION
Fixes for the following files were in post-3.6 code and not backported:
Lib/ctypes/_aix.py (new), Lib/test/test_concurrent_futures.py,
Modules/_asynciomodule.c, Modules/_pickle.c, Objects/obmalloc.c.

(cherry picked from commit c3d9508)

<!-- issue-number: bpo-32746 -->
https://bugs.python.org/issue32746
<!-- /issue-number -->
