### PR TITLE
[3.4] [3.5] bpo-32620: Remove failing pyenv call from CI config (GH-5…

### DIFF
--- a/Lib/test/test_xmlrpc_net.py
+++ b/Lib/test/test_xmlrpc_net.py
@@ -7,6 +7,7 @@ from test import support
 
 import xmlrpc.client as xmlrpclib
 
+@unittest.skip('XXX: buildbot.python.org/all/xmlrpc/ is gone')
 class PythonBuildersTest(unittest.TestCase):
 
     def test_python_builders(self):


### PR DESCRIPTION
…274)

* [3.5] Remove failing pyenv call from CI config

* Backport XML RPC test skip to 3.5

The buildbot service upgrade removed the XML-RPC
interface, so this test no longer works (through no
fault of the standard library).
(cherry picked from commit 4a4c2743133e195cc3725b78a895d85d69e50089)

Co-authored-by: Nick Coghlan <ncoghlan@gmail.com>

!!! If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

PLEASE: Remove this headline!!!


<!-- issue-number: bpo-32620 -->
https://bugs.python.org/issue32620
<!-- /issue-number -->
