### PR TITLE
bpo-32720: Fixed the replacement field grammar documentation.

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -202,9 +202,9 @@ The grammar for a replacement field is as follows:
    .. productionlist:: sf
       replacement_field: "{" [`field_name`] ["!" `conversion`] [":" `format_spec`] "}"
       field_name: arg_name ("." `attribute_name` | "[" `element_index` "]")*
-      arg_name: [`identifier` | `digit`]
+      arg_name: [`identifier` | `digit`+]
       attribute_name: `identifier`
-      element_index: `digit` | `index_string`
+      element_index: `digit`+ | `index_string`
       index_string: <any source character except "]"> +
       conversion: "r" | "s" | "a"
       format_spec: <described in the next section>

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -202,9 +202,9 @@ The grammar for a replacement field is as follows:
    .. productionlist:: sf
       replacement_field: "{" [`field_name`] ["!" `conversion`] [":" `format_spec`] "}"
       field_name: arg_name ("." `attribute_name` | "[" `element_index` "]")*
-      arg_name: [`identifier` | `integer`]
+      arg_name: [`identifier` | `digit`]
       attribute_name: `identifier`
-      element_index: `integer` | `index_string`
+      element_index: `digit` | `index_string`
       index_string: <any source character except "]"> +
       conversion: "r" | "s" | "a"
       format_spec: <described in the next section>


### PR DESCRIPTION
`arg_name` and `element_index` are defined as `digit` instead of `integer`.

<!-- issue-number: bpo-32720 -->
https://bugs.python.org/issue32720
<!-- /issue-number -->
