### PR TITLE
[3.6] bpo-30928: IDLE - update NEWS.txt (GH-5539)

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -1,7 +1,10 @@
 What's New in IDLE 3.6.5
 Released on 2017-03-26?
-========================
+======================================
 
+
+bpo-32765: Update configdialog General tab create page docstring.
+Add new widgets to the widget list.
 
 
 What's New in IDLE 3.6.4
@@ -314,9 +317,9 @@ Issue #28572: Add 10% to coverage of IDLE's test_configdialog.
 Update and augment description of the configuration system.
 
 
-What's New in IDLE 3.6.0
+What's New in IDLE 3.6.0 (since 3.5.0)
 Released on 2016-12-23
-========================
+======================================
 
 - Issue #15308: Add 'interrupt execution' (^C) to Shell menu.
   Patch by Roger Serwy, updated by Bayard Randel.


### PR DESCRIPTION
Add entry for uniform lower context; add 'since' to be explicit.
(cherry picked from commit 05e8067)

<!-- issue-number: bpo-30928 -->
https://bugs.python.org/issue30928
<!-- /issue-number -->
