### PR TITLE
bpo-32647: Link ctypes extension with libdl.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-02-05-13-31-42.bpo-32647.ktmfR_.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-05-13-31-42.bpo-32647.ktmfR_.rst
@@ -1,0 +1,2 @@
+The ctypes module used to depend on indirect linking for dlopen. The shared
+extension is now explicitly linked against libdl on platforms with dl.

--- a/setup.py
+++ b/setup.py
@@ -2005,6 +2005,10 @@ class PyBuildExt(build_ext):
             ext.libraries.append(ffi_lib)
             self.use_system_libffi = True
 
+        if sysconfig.get_config_var('HAVE_LIBDL'):
+            # for dlopen, see bpo-32647
+            ext.libraries.append('dl')
+
     def _decimal_ext(self):
         extra_compile_args = []
         undef_macros = []


### PR DESCRIPTION
The ctypes module used to depend on indirect linking for dlopen. The shared
extension is now explicitly linked against libdl on platforms with dl.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-32647 -->
https://bugs.python.org/issue32647
<!-- /issue-number -->
