### PR TITLE
Fix typo in whatsnew/3.7.rst

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -496,7 +496,7 @@ therefore included in source distributions.
 and ``platforms`` fields are not specified as a list or a string.
 (Contributed by Berker Peksag in :issue:`19610`.)
 
-The ``upload`` command now longer tries to change CR end-of-line characters
+The ``upload`` command no longer tries to change CR end-of-line characters
 to CRLF.  This fixes a corruption issue with sdists that ended with a byte
 equivalent to CR.
 (Contributed by Bo Bayles in :issue:`32304`.)


### PR DESCRIPTION
now longer -> no longer
