### PR TITLE
2.7 bpo-27643 - Test_C test case needs "signed short" bitfields, but the IBM XLC compiler (on AIX) does not support this (GH-5164)

### DIFF
--- a/Lib/ctypes/test/test_bitfields.py
+++ b/Lib/ctypes/test/test_bitfields.py
@@ -41,6 +41,9 @@ class C_Test(unittest.TestCase):
                 self.assertEqual((name, i, getattr(b, name)), (name, i, func(byref(b), name)))
 
     def test_shorts(self):
+        b = BITS()
+        if func(byref(b), "M") == 999:
+            self.skipTest("Compiler does not support signed short bitfields")
         for i in range(256):
             for name in "MNOPQRS":
                 b = BITS()

--- a/Misc/NEWS.d/next/Tests/2018-02-05-11-58-04.bpo-27643.57BTU3.rst
+++ b/Misc/NEWS.d/next/Tests/2018-02-05-11-58-04.bpo-27643.57BTU3.rst
@@ -1,0 +1,1 @@
+Fix Lib/ctypes/test/test_bitfields.py following a suggestion by martin.panter

--- a/Modules/_ctypes/_ctypes_test.c
+++ b/Modules/_ctypes/_ctypes_test.c
@@ -396,8 +396,20 @@ EXPORT(PY_LONG_LONG) last_tf_arg_s;
 EXPORT(unsigned PY_LONG_LONG) last_tf_arg_u;
 
 struct BITS {
-    int A: 1, B:2, C:3, D:4, E: 5, F: 6, G: 7, H: 8, I: 9;
-    short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
+    signed int A: 1, B:2, C:3, D:4, E: 5, F: 6, G: 7, H: 8, I: 9;
+/*
+ * The test case needs "signed short" bitfields, but the
+ * IBM XLC compiler does not support this
+ */
+#ifndef _AIX
+#define SIGNED_SHORT_BITFIELDS
+     short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
+#else
+#ifdef __GCC_HAVE_SYNC_COMPARE_AND_SWAP_1 /* Something to distinguish GCC and XLC */
+#define SIGNED_SHORT_BITFIELDS
+     short M: 1, N: 2, O: 3, P: 4, Q: 5, R: 6, S: 7;
+#endif
+#endif
 };
 
 DL_EXPORT(void) set_bitfields(struct BITS *bits, char name, int value)
@@ -413,6 +425,7 @@ DL_EXPORT(void) set_bitfields(struct BITS *bits, char name, int value)
     case 'H': bits->H = value; break;
     case 'I': bits->I = value; break;
 
+#ifdef SIGNED_SHORT_BITFIELDS
     case 'M': bits->M = value; break;
     case 'N': bits->N = value; break;
     case 'O': bits->O = value; break;
@@ -420,6 +433,7 @@ DL_EXPORT(void) set_bitfields(struct BITS *bits, char name, int value)
     case 'Q': bits->Q = value; break;
     case 'R': bits->R = value; break;
     case 'S': bits->S = value; break;
+#endif
     }
 }
 
@@ -436,6 +450,7 @@ DL_EXPORT(int) unpack_bitfields(struct BITS *bits, char name)
     case 'H': return bits->H;
     case 'I': return bits->I;
 
+#ifdef SIGNED_SHORT_BITFIELDS
     case 'M': return bits->M;
     case 'N': return bits->N;
     case 'O': return bits->O;
@@ -443,8 +458,9 @@ DL_EXPORT(int) unpack_bitfields(struct BITS *bits, char name)
     case 'Q': return bits->Q;
     case 'R': return bits->R;
     case 'S': return bits->S;
+#endif
     }
-    return 0;
+    return 999;
 }
 
 static PyMethodDef module_methods[] = {


### PR DESCRIPTION
Following a suggestion by martin.panther - the backport to v2.7, just to be sure it also works there.

xlc does not support "unsigned short" bitfields

<!-- issue-number: bpo-27643 -->
https://bugs.python.org/issue27643
<!-- /issue-number -->
