### PR TITLE
bpo-6135: Fix `subprocess.check_output()` doc to mention changes in 3.6

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -955,6 +955,9 @@ calls these functions.
    .. versionchanged:: 3.4
       Support for the *input* keyword argument was added.
 
+   .. versionchanged:: 3.6
+      *encoding*, *errors* added
+
 .. _subprocess-replacements:
 
 Replacing Older Functions with the :mod:`subprocess` Module

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -956,7 +956,7 @@ calls these functions.
       Support for the *input* keyword argument was added.
 
    .. versionchanged:: 3.6
-      *encoding*, *errors* added
+      *encoding* and *errors* were added.  See :func:`run` for details.
 
 .. _subprocess-replacements:
 


### PR DESCRIPTION
More parameters were supported by `subprocess.check_output()` in python 3.6
See:
- https://bugs.python.org/issue6135
- https://hg.python.org/cpython/rev/720f0cf580e2

Now the doc mentions these changes allowing users targeting multiple python 3 versions to be aware not to use these parameters.


<!-- issue-number: bpo-6135 -->
https://bugs.python.org/issue6135
<!-- /issue-number -->
