### PR TITLE
allow the test suite to pass if the strop module doesn't exist

### DIFF
--- a/Lib/test/test_strop.py
+++ b/Lib/test/test_strop.py
@@ -2,10 +2,11 @@ import warnings
 warnings.filterwarnings("ignore", "strop functions are obsolete;",
                         DeprecationWarning,
                         r'test.test_strop|unittest')
-import strop
 import unittest
 import sys
 from test import test_support
+
+strop = test_support.import_module("strop")
 
 
 class StropFunctionTestCase(unittest.TestCase):


### PR DESCRIPTION
strop is highly legacy and can be safely compiled out in most installations. Let's not fail the test suite for its absence.
