### PR TITLE
[2.7] bpo-32616: Disable computed gotos by default for clang < 5

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-02-07-11-24-38.bpo-32616.o7mFJ3.rst
+++ b/Misc/NEWS.d/next/Build/2018-02-07-11-24-38.bpo-32616.o7mFJ3.rst
@@ -1,0 +1,2 @@
+Disable computed gotos by default for clang < 5.0. It caused significant
+performance regression.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -689,11 +689,19 @@ PyObject *
 PyEval_EvalFrameEx(PyFrameObject *f, int throwflag)
 {
 #ifdef DYNAMIC_EXECUTION_PROFILE
-  #undef USE_COMPUTED_GOTOS
+    #undef USE_COMPUTED_GOTOS
 #endif
 #ifdef HAVE_COMPUTED_GOTOS
     #ifndef USE_COMPUTED_GOTOS
-    #define USE_COMPUTED_GOTOS 1
+        #if defined(__clang__) && (__clang_major__ < 5)
+            /* Computed gotos caused significant performance regression
+             * with clang < 5.0.
+             * https://bugs.python.org/issue32616
+             */
+            #define USE_COMPUTED_GOTOS 0
+        #else
+            #define USE_COMPUTED_GOTOS 1
+        #endif
     #endif
 #else
     #if defined(USE_COMPUTED_GOTOS) && USE_COMPUTED_GOTOS


### PR DESCRIPTION


<!-- issue-number: bpo-32616 -->
https://bugs.python.org/issue32616
<!-- /issue-number -->
