### PR TITLE
[2.7] bpo-32784: Wrong argument name for csv.DictReader in documentation

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -165,7 +165,7 @@ The :mod:`csv` module defines the following functions:
 The :mod:`csv` module defines the following classes:
 
 
-.. class:: DictReader(csvfile, fieldnames=None, restkey=None, restval=None, \
+.. class:: DictReader(f, fieldnames=None, restkey=None, restval=None, \
                       dialect='excel', *args, **kwds)
 
    Create an object which operates like a regular reader but maps the
@@ -174,7 +174,7 @@ The :mod:`csv` module defines the following classes:
    <collections-abstract-base-classes>` whose elements are associated with the
    fields of the input data in order. These elements become the keys of the
    resulting dictionary.  If the *fieldnames* parameter is omitted, the values
-   in the first row of the *csvfile* will be used as the fieldnames.  If the
+   in the first row of the file *f* will be used as the fieldnames.  If the
    row read has more fields than the fieldnames sequence, the remaining data is
    added as a sequence keyed by the value of *restkey*.  If the row read has
    fewer fields than the fieldnames sequence, the remaining keys take the value
@@ -194,14 +194,14 @@ The :mod:`csv` module defines the following classes:
        Wonderful Spam
 
 
-.. class:: DictWriter(csvfile, fieldnames, restval='', extrasaction='raise', \
+.. class:: DictWriter(f, fieldnames, restval='', extrasaction='raise', \
                       dialect='excel', *args, **kwds)
 
    Create an object which operates like a regular writer but maps dictionaries
    onto output rows.  The *fieldnames* parameter is a :ref:`sequence
    <collections-abstract-base-classes>` of keys that identify the order in
    which values in the dictionary passed to the :meth:`writerow` method are
-   written to the *csvfile*.  The optional *restval* parameter specifies the
+   written to the file *f*.  The optional *restval* parameter specifies the
    value to be written if the dictionary is missing a key in *fieldnames*.  If
    the dictionary passed to the :meth:`writerow` method contains a key not
    found in *fieldnames*, the optional *extrasaction* parameter indicates what
@@ -213,7 +213,7 @@ The :mod:`csv` module defines the following classes:
    Note that unlike the :class:`DictReader` class, the *fieldnames* parameter
    of the :class:`DictWriter` is not optional.  Since Python's :class:`dict`
    objects are not ordered, there is not enough information available to deduce
-   the order in which the row should be written to the *csvfile*.
+   the order in which the row should be written to the file *f*.
 
    A short usage example::
 


### PR DESCRIPTION
Fix the documentation of csv.DictReader, csv.DictWriter, the name of the parameter for the file object does  not match the declared name in the __init__ method.

<!-- issue-number: bpo-32784 -->
https://bugs.python.org/issue32784
<!-- /issue-number -->
