### PR TITLE
bpo-32792: Preserve mapping order in ChainMap()

### DIFF
--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -920,13 +920,10 @@ class ChainMap(_collections_abc.MutableMapping):
         return len(set().union(*self.maps))     # reuses stored hash values if possible
 
     def __iter__(self):
-        seen = set()
-        seen_add = seen.add
-        for mapping in self.maps:
-            for k in mapping:
-                if k not in seen:
-                    seen_add(k)
-                    yield k
+        d = {}
+        for mapping in reversed(self.maps):
+            d.update(mapping)                   # reuses stored hash values if possible
+        return iter(d)
 
     def __contains__(self, key):
         return any(key in m for m in self.maps)

--- a/Lib/collections/__init__.py
+++ b/Lib/collections/__init__.py
@@ -920,7 +920,13 @@ class ChainMap(_collections_abc.MutableMapping):
         return len(set().union(*self.maps))     # reuses stored hash values if possible
 
     def __iter__(self):
-        return iter(set().union(*self.maps))
+        seen = set()
+        seen_add = seen.add
+        for mapping in self.maps:
+            for k in mapping:
+                if k not in seen:
+                    seen_add(k)
+                    yield k
 
     def __contains__(self, key):
         return any(key in m for m in self.maps)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -142,13 +142,21 @@ class TestChainMap(unittest.TestCase):
             d.popitem()
 
     def test_order_preservation(self):
-        OD = OrderedDict
-        d = ChainMap(OD(a=1, b=2), OD(b=3, c=4), OD(c=5, d=6),
-                     OD(d=7, e=8), OD(e=9, f=10, g=11, h=12))
-        self.assertEqual(list(d), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'])
-        self.assertEqual(list(d.items()), [('a', 1), ('b', 2), ('c', 4),
-                                           ('d', 6), ('e', 8), ('f', 10),
-                                           ('g', 11), ('h', 12)])
+        d = ChainMap(
+                OrderedDict(j=0, h=88888),
+                OrderedDict(),
+                OrderedDict(i=9999, d=4444, c=3333),
+                OrderedDict(f=666, b=222, g=777, c=333, h=888),
+                OrderedDict(),
+                OrderedDict(e=55, b=22),
+                OrderedDict(a=1, b=2, c=3, d=4, e=5),
+                OrderedDict(),
+            )
+        self.assertEqual(''.join(d), 'abcdefghij')
+        self.assertEqual(list(d.items()),
+            [('a', 1), ('b', 222), ('c', 3333), ('d', 4444),
+             ('e', 55), ('f', 666), ('g', 777), ('h', 88888),
+             ('i', 9999), ('j', 0)])
 
     def test_dict_coercion(self):
         d = ChainMap(dict(a=1, b=2), dict(b=20, c=30))

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -141,6 +141,11 @@ class TestChainMap(unittest.TestCase):
         with self.assertRaises(KeyError):
             d.popitem()
 
+    def test_order_preservation(self):
+        d = ChainMap(dict(a=1, b=2), dict(b=3, c=4), dict(c=5, d=6),
+                     dict(d=7, e=8), dict(e=9, f=10, g=11))
+        self.assertEqual(list(d), ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+
     def test_dict_coercion(self):
         d = ChainMap(dict(a=1, b=2), dict(b=20, c=30))
         self.assertEqual(dict(d), dict(a=1, b=2, c=30))

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -142,9 +142,10 @@ class TestChainMap(unittest.TestCase):
             d.popitem()
 
     def test_order_preservation(self):
-        d = ChainMap(dict(a=1, b=2), dict(b=3, c=4), dict(c=5, d=6),
-                     dict(d=7, e=8), dict(e=9, f=10, g=11))
-        self.assertEqual(list(d), ['a', 'b', 'c', 'd', 'e', 'f', 'g'])
+        OD = OrderedDict
+        d = ChainMap(OD(a=1, b=2), OD(b=3, c=4), OD(c=5, d=6),
+                     OD(d=7, e=8), OD(e=9, f=10, g=11, h=12))
+        self.assertEqual(list(d), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'])
 
     def test_dict_coercion(self):
         d = ChainMap(dict(a=1, b=2), dict(b=20, c=30))

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -146,6 +146,9 @@ class TestChainMap(unittest.TestCase):
         d = ChainMap(OD(a=1, b=2), OD(b=3, c=4), OD(c=5, d=6),
                      OD(d=7, e=8), OD(e=9, f=10, g=11, h=12))
         self.assertEqual(list(d), ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'])
+        self.assertEqual(list(d.items()), [('a', 1), ('b', 2), ('c', 4),
+                                           ('d', 6), ('e', 8), ('f', 10),
+                                           ('g', 11), ('h', 12)])
 
     def test_dict_coercion(self):
         d = ChainMap(dict(a=1, b=2), dict(b=20, c=30))

--- a/Misc/NEWS.d/next/Library/2018-02-08-00-47-07.bpo-32792.NtyDb4.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-08-00-47-07.bpo-32792.NtyDb4.rst
@@ -1,0 +1,1 @@
+collections.ChainMap() preserves the order of the underlying mappings.


### PR DESCRIPTION


<!-- issue-number: bpo-32792 -->
https://bugs.python.org/issue32792
<!-- /issue-number -->
