### PR TITLE
Make formatting of some return codes conforming to the general style.

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -273,8 +273,8 @@ Initializing and finalizing the interpreter
    the last call to :c:func:`Py_Initialize`.  Ideally, this frees all memory
    allocated by the Python interpreter.  This is a no-op when called for a second
    time (without calling :c:func:`Py_Initialize` again first).  Normally the
-   return value is 0.  If there were errors during finalization
-   (flushing buffered data), -1 is returned.
+   return value is ``0``.  If there were errors during finalization
+   (flushing buffered data), ``-1`` is returned.
 
    This function is provided for a number of reasons.  An embedding application
    might want to restart Python without having to restart the application itself.
@@ -1018,7 +1018,7 @@ All of the following functions must be called after :c:func:`Py_Initialize`.
 .. c:function:: PY_INT64_T PyInterpreterState_GetID(PyInterpreterState *interp)
 
    Return the interpreter's unique ID.  If there was any error in doing
-   so then -1 is returned and an error is set.
+   so then ``-1`` is returned and an error is set.
 
    .. versionadded:: 3.7
 

--- a/Doc/c-api/long.rst
+++ b/Doc/c-api/long.rst
@@ -137,7 +137,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    Raise :exc:`OverflowError` if the value of *obj* is out of range for a
    :c:type:`long`.
 
-   Returns -1 on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+   Returns ``-1`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
 
 .. c:function:: long PyLong_AsLongAndOverflow(PyObject *obj, int *overflow)
@@ -151,7 +151,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    return ``-1``; otherwise, set *\*overflow* to ``0``.  If any other exception
    occurs set *\*overflow* to ``0`` and return ``-1`` as usual.
 
-   Returns -1 on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+   Returns ``-1`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
 
 .. c:function:: long long PyLong_AsLongLong(PyObject *obj)
@@ -166,7 +166,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    Raise :exc:`OverflowError` if the value of *obj* is out of range for a
    :c:type:`long`.
 
-   Returns -1 on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+   Returns ``-1`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
 
 .. c:function:: long long PyLong_AsLongLongAndOverflow(PyObject *obj, int *overflow)
@@ -180,7 +180,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    and return ``-1``; otherwise, set *\*overflow* to ``0``.  If any other
    exception occurs set *\*overflow* to ``0`` and return ``-1`` as usual.
 
-   Returns -1 on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+   Returns ``-1`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
    .. versionadded:: 3.2
 
@@ -197,7 +197,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    Raise :exc:`OverflowError` if the value of *pylong* is out of range for a
    :c:type:`Py_ssize_t`.
 
-   Returns -1 on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+   Returns ``-1`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
 
 .. c:function:: unsigned long PyLong_AsUnsignedLong(PyObject *pylong)
@@ -259,7 +259,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    If the value of *obj* is out of range for an :c:type:`unsigned long`,
    return the reduction of that value modulo ``ULONG_MAX + 1``.
 
-   Returns -1 on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+   Returns ``-1`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
 
 .. c:function:: unsigned long long PyLong_AsUnsignedLongLongMask(PyObject *obj)
@@ -271,7 +271,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    If the value of *obj* is out of range for an :c:type:`unsigned long long`,
    return the reduction of that value modulo ``PY_ULLONG_MAX + 1``.
 
-   Returns -1 on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+   Returns ``-1`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
 
 .. c:function:: double PyLong_AsDouble(PyObject *pylong)
@@ -282,7 +282,7 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    Raise :exc:`OverflowError` if the value of *pylong* is out of range for a
    :c:type:`double`.
 
-   Returns -1.0 on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+   Returns ``-1.0`` on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
 
 
 .. c:function:: void* PyLong_AsVoidPtr(PyObject *pylong)
@@ -292,4 +292,4 @@ distinguished from a number.  Use :c:func:`PyErr_Occurred` to disambiguate.
    is only assured to produce a usable :c:type:`void` pointer for values created
    with :c:func:`PyLong_FromVoidPtr`.
 
-   Returns NULL on error.  Use :c:func:`PyErr_Occurred` to disambiguate.
+   Returns *NULL* on error.  Use :c:func:`PyErr_Occurred` to disambiguate.

--- a/Doc/c-api/memory.rst
+++ b/Doc/c-api/memory.rst
@@ -530,7 +530,7 @@ tracemalloc C API
 
    Track an allocated memory block in the :mod:`tracemalloc` module.
 
-   Return 0 on success, return ``-1`` on error (failed to allocate memory to
+   Return ``0`` on success, return ``-1`` on error (failed to allocate memory to
    store the trace). Return ``-2`` if tracemalloc is disabled.
 
    If memory block is already tracked, update the existing trace.

--- a/Doc/extending/newtypes.rst
+++ b/Doc/extending/newtypes.rst
@@ -384,8 +384,8 @@ is used to initialize an object after it's created. Unlike the new method, we
 can't guarantee that the initializer is called.  The initializer isn't called
 when unpickling objects and it can be overridden.  Our initializer accepts
 arguments to provide initial values for our instance. Initializers always accept
-positional and keyword arguments. Initializers should return either 0 on
-success or -1 on error.
+positional and keyword arguments. Initializers should return either ``0`` on
+success or ``-1`` on error.
 
 Initializers can be called multiple times.  Anyone can call the :meth:`__init__`
 method on our objects.  For this reason, we have to be extra careful when

--- a/Doc/faq/extending.rst
+++ b/Doc/faq/extending.rst
@@ -62,7 +62,7 @@ How can I execute arbitrary Python statements from C?
 
 The highest-level function to do this is :c:func:`PyRun_SimpleString` which takes
 a single string argument to be executed in the context of the module
-``__main__`` and returns 0 for success and -1 when an exception occurred
+``__main__`` and returns ``0`` for success and ``-1`` when an exception occurred
 (including ``SyntaxError``).  If you want more control, use
 :c:func:`PyRun_String`; see the source for :c:func:`PyRun_SimpleString` in
 ``Python/pythonrun.c``.

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -2480,12 +2480,12 @@ Porting C code
   :c:func:`PyUnicode_FromFormat()`, your code will automatically take
   advantage of the new unicode representations.
 
-* :c:func:`PyImport_GetMagicNumber` now returns -1 upon failure.
+* :c:func:`PyImport_GetMagicNumber` now returns ``-1`` upon failure.
 
 * As a negative value for the *level* argument to :func:`__import__` is no
   longer valid, the same now holds for :c:func:`PyImport_ImportModuleLevel`.
   This also means that the value of *level* used by
-  :c:func:`PyImport_ImportModuleEx` is now 0 instead of -1.
+  :c:func:`PyImport_ImportModuleEx` is now ``0`` instead of ``-1``.
 
 
 Building C extensions


### PR DESCRIPTION
Fixes formatting of #5396.
