### PR TITLE
bpo-32802: Travis does not compile Python if there is one change in the documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,7 +97,7 @@ before_script:
       echo "Files changed: "
       echo $files_changed
 
-      if ! echo $files_changed | grep -qvE '(\.rst$)|(^Doc)|(^Misc)'
+      if ! echo "$files_changed" | grep -qvE '(\.rst$)|(^Doc)|(^Misc)'
       then
         echo "Only docs were updated, stopping build process."
         exit


### PR DESCRIPTION
bpo-32802: Travis does not compile Python if there is one change in the Documentation

Fix the detection of the modified files in Travis

<!-- issue-number: bpo-32802 -->
https://bugs.python.org/issue32802
<!-- /issue-number -->
