### PR TITLE
Add str property to PurePath

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -9,7 +9,7 @@ import sys
 from collections import Sequence
 from contextlib import contextmanager
 from errno import EINVAL, ENOENT, ENOTDIR
-from operator import attrgetter
+from operator import attrgetter, methodcaller
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
 
@@ -765,6 +765,8 @@ class PurePath(object):
 
     root = property(attrgetter('_root'),
                     doc="""The root of the path, if any.""")
+    
+    str = property(methodcaller('__str__', doc="Return the string representation of the path, suitable for passing to system calls."))
 
     @property
     def anchor(self):


### PR DESCRIPTION
Path.str returns the string representation of the path, which is easier than using str(Path).