### PR TITLE
[2.7] bpo-30157: Fix csv.Sniffer.sniff() regex pattern. (GH-5601)

### DIFF
--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -217,7 +217,7 @@ class Sniffer:
         matches = []
         for restr in ('(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?P=delim)', # ,".*?",
                       '(?:^|\n)(?P<quote>["\']).*?(?P=quote)(?P<delim>[^\w\n"\'])(?P<space> ?)',   #  ".*?",
-                      '(?P<delim>>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?:$|\n)',  # ,".*?"
+                      '(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?:$|\n)',   # ,".*?"
                       '(?:^|\n)(?P<quote>["\']).*?(?P=quote)(?:$|\n)'):                            #  ".*?" (no delim, no space)
             regexp = re.compile(restr, re.DOTALL | re.MULTILINE)
             matches = regexp.findall(data)

--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -1036,6 +1036,15 @@ Stonecutters Seafood and Chop House+ Lemont+ IL+ 12/19/02+ Week Back
         self.assertEqual(sniffer.has_header(self.header2 + self.sample8),
                          True)
 
+    def test_guess_quote_and_delimiter(self):
+        sniffer = csv.Sniffer()
+        for header in (";'123;4';", "'123;4';", ";'123;4'", "'123;4'"):
+            dialect = sniffer.sniff(header, ",;")
+            self.assertEqual(dialect.delimiter, ';')
+            self.assertEqual(dialect.quotechar, "'")
+            self.assertIs(dialect.doublequote, False)
+            self.assertIs(dialect.skipinitialspace, False)
+
     def test_sniff(self):
         sniffer = csv.Sniffer()
         dialect = sniffer.sniff(self.sample1)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -317,6 +317,7 @@ Kushal Das
 Jonathan Dasteel
 Pierre-Yves David
 A. Jesse Jiryu Davis
+Jake Davis
 Merlijn van Deen
 John DeGood
 Ned Deily

--- a/Misc/NEWS.d/next/Library/2018-02-09-14-44-43.bpo-30157.lEiiAK.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-09-14-44-43.bpo-30157.lEiiAK.rst
@@ -1,0 +1,2 @@
+Fixed guessing quote and delimiter in csv.Sniffer.sniff() when only the last
+field is quoted.  Patch by Jake Davis.


### PR DESCRIPTION
Co-authored-by: Jake Davis <jcdavis@awedge.net>.
(cherry picked from commit 2411292ba8155327125d8a1da8a4c9fa003d5909)


<!-- issue-number: bpo-30157 -->
https://bugs.python.org/issue30157
<!-- /issue-number -->
