### PR TITLE
bpo-30688: Import unicodedata only when needed

### DIFF
--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -13,7 +13,6 @@
 # XXX: show string offset and offending character for all errors
 
 from sre_constants import *
-import unicodedata
 
 SPECIAL_CHARS = ".\\[{()*+?^$|"
 REPEAT_CHARS = "*+?{"
@@ -324,6 +323,7 @@ def _class_escape(source, escape):
             chr(c) # raise ValueError for invalid code
             return LITERAL, c
         elif c == "N" and source.istext:
+            import unicodedata
             # named unicode escape e.g. \N{EM DASH}
             if not source.match('{'):
                 raise source.error("missing {")
@@ -383,6 +383,7 @@ def _escape(source, escape, state):
             chr(c) # raise ValueError for invalid code
             return LITERAL, c
         elif c == "N" and source.istext:
+            import unicodedata
             # named unicode escape e.g. \N{EM DASH}
             if not source.match('{'):
                 raise source.error("missing {")


### PR DESCRIPTION
Importing unicodedata in this module leads to failure in compilation.
unicodedata is unused during compilation, and is not compiled when this
file is imported. The error occurs when generating posix variables,
pprint is required. The dependency chain goes on like this:

sysconfig -> pprint -> re -> sre_compile -> sre_parse (this file)

This commits fixes compilation issues introduced by
2272cec13b53c405d86c45d404f035f201c0baef.
(Issue 30688, PR #5588)

<!-- issue-number: bpo-30688 -->
https://bugs.python.org/issue30688
<!-- /issue-number -->
