### PR TITLE
bpo-32370: Use the correct encoding for ipconfig output in the uuid module

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -468,7 +468,7 @@ def _netstat_getnode():
 
 def _ipconfig_getnode():
     """Get the hardware address on Windows by running ipconfig.exe."""
-    import os, re
+    import os, re, subprocess
     first_local_mac = None
     dirs = ['', r'c:\windows\system32', r'c:\winnt\system32']
     try:
@@ -480,11 +480,13 @@ def _ipconfig_getnode():
         pass
     for dir in dirs:
         try:
-            pipe = os.popen(os.path.join(dir, 'ipconfig') + ' /all')
+            proc = subprocess.Popen([os.path.join(dir, 'ipconfig'), '/all'],
+                                    stdout=subprocess.PIPE,
+                                    encoding="oem")
         except OSError:
             continue
-        with pipe:
-            for line in pipe:
+        with proc:
+            for line in proc.stdout:
                 value = line.split(':')[-1].strip().lower()
                 if re.match('([0-9a-f][0-9a-f]-){5}[0-9a-f][0-9a-f]', value):
                     mac = int(value.replace('-', ''), 16)

--- a/Misc/NEWS.d/next/Windows/2018-02-10-15-38-19.bpo-32370.kcKuct.rst
+++ b/Misc/NEWS.d/next/Windows/2018-02-10-15-38-19.bpo-32370.kcKuct.rst
@@ -1,1 +1,2 @@
 Use the correct encoding for ipconfig output in the uuid module.
+Patch by Segev Finer.

--- a/Misc/NEWS.d/next/Windows/2018-02-10-15-38-19.bpo-32370.kcKuct.rst
+++ b/Misc/NEWS.d/next/Windows/2018-02-10-15-38-19.bpo-32370.kcKuct.rst
@@ -1,0 +1,1 @@
+Use the correct encoding for ipconfig output in the uuid module.


### PR DESCRIPTION


<!-- issue-number: bpo-32370 -->
https://bugs.python.org/issue32370
<!-- /issue-number -->
