### PR TITLE
bpo-32800: Update link to w3c doc for xml default namespaces

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -297,7 +297,7 @@ If the XML input has `namespaces
 with prefixes in the form ``prefix:sometag`` get expanded to
 ``{uri}sometag`` where the *prefix* is replaced by the full *URI*.
 Also, if there is a `default namespace
-<https://www.w3.org/TR/2006/REC-xml-names-20060816/#defaulting>`__,
+<https://www.w3.org/TR/xml-names/#defaulting>`__,
 that full URI gets prepended to all of the non-prefixed tags.
 
 Here is an XML example that incorporates two namespaces, one with the

--- a/Misc/NEWS.d/next/Documentation/2018-02-10-15-16-04.bpo-32800.FyrqCk.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-02-10-15-16-04.bpo-32800.FyrqCk.rst
@@ -1,0 +1,1 @@
+Update link to lastest w3c documentation

--- a/Misc/NEWS.d/next/Documentation/2018-02-10-15-16-04.bpo-32800.FyrqCk.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-02-10-15-16-04.bpo-32800.FyrqCk.rst
@@ -1,1 +1,1 @@
-Update link to lastest w3c documentation
+Update link to w3c doc for xml default namespaces.


### PR DESCRIPTION
This PR updates the URL to the last w3c documentation about namespace. It includes a blurb too.

It is linked to bpo 32800.


<!-- issue-number: bpo-32800 -->
https://bugs.python.org/issue32800
<!-- /issue-number -->
