### PR TITLE
bpo-32731: Specify Exception type of getpass.getuser

### DIFF
--- a/Doc/library/getpass.rst
+++ b/Doc/library/getpass.rst
@@ -43,9 +43,10 @@ The :mod:`getpass` module provides two functions:
 
    This function checks the environment variables :envvar:`LOGNAME`,
    :envvar:`USER`, :envvar:`LNAME` and :envvar:`USERNAME`, in order, and
-   returns the value of the first one which is set to a non-empty string.  If
-   none are set, the login name from the password database is returned on
-   systems which support the :mod:`pwd` module, otherwise, an exception is
-   raised.
+   returns the value of the first one which is set to a non-empty string.
+   If none are set, the function attempts to retrieve the login name from the
+   password database. On systems which the :mod:`pwd` module is not supported,
+   an :exc:`ImportError` is raised. If no login name is found, an
+   :exc:`KeyError` is raised :func:`pwd.getpwuid`.
 
    In general, this function should be preferred over :func:`os.getlogin()`.

--- a/Misc/NEWS.d/next/Documentation/2018-02-11-03-23-36.bpo-32731.eHIUEe.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-02-11-03-23-36.bpo-32731.eHIUEe.rst
@@ -1,0 +1,1 @@
+Improve documentation of exception raised in :func:`getpass.getuser()`


### PR DESCRIPTION


<!-- issue-number: bpo-32731 -->
https://bugs.python.org/issue32731
<!-- /issue-number -->
