### PR TITLE
bpo-32819: Simplify and improve ssl.match_hostname

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-02-11-15-54-41.bpo-32819.ZTRX2Q.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-11-15-54-41.bpo-32819.ZTRX2Q.rst
@@ -1,0 +1,3 @@
+ssl.match_hostname() has been simplified and no longer depends on re and
+ipaddress module for wildcard and IP addresses. Error reporting for invalid
+wildcards has been improved.


### PR DESCRIPTION
ssl.match_hostname() has been simplified and no longer depends on re and
ipaddress module for wildcard and IP addresses. Error reporting for invalid
wildcards has been improved.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-32819 -->
https://bugs.python.org/issue32819
<!-- /issue-number -->
