### PR TITLE
bpo-32798: Add restriction on the offset parameter for mmap.flush in the docs

### DIFF
--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -94,7 +94,8 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
    *offset* may be specified as a non-negative integer offset. mmap references
    will be relative to the offset from the beginning of the file. *offset*
-   defaults to 0.  *offset* must be a multiple of :const:`PAGESIZE`.
+   defaults to 0. *offset* must be a multiple of :const:`ALLOCATIONGRANULARITY`
+   which is equal to :const:`PAGESIZE` on Unix systems.
 
    To ensure validity of the created memory mapping the file specified
    by the descriptor *fileno* is internally automatically synchronized

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -65,7 +65,7 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
    *offset* may be specified as a non-negative integer offset. mmap references
    will be relative to the offset from the beginning of the file. *offset*
-   defaults to 0.  *offset* must be a multiple of the ALLOCATIONGRANULARITY.
+   defaults to 0.  *offset* must be a multiple of the :const:`ALLOCATIONGRANULARITY`.
 
 
 .. class:: mmap(fileno, length, flags=MAP_SHARED, prot=PROT_WRITE|PROT_READ, access=ACCESS_DEFAULT[, offset])

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -94,8 +94,7 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
    *offset* may be specified as a non-negative integer offset. mmap references
    will be relative to the offset from the beginning of the file. *offset*
-   defaults to 0.  *offset* must be a multiple of the :const:`PAGESIZE` or
-   :const:`ALLOCATIONGRANULARITY`.
+   defaults to 0.  *offset* must be a multiple of :const:`PAGESIZE`.
 
    To ensure validity of the created memory mapping the file specified
    by the descriptor *fileno* is internally automatically synchronized

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -189,7 +189,8 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
       use of this call there is no guarantee that changes are written back before
       the object is destroyed.  If *offset* and *size* are specified, only
       changes to the given range of bytes will be flushed to disk; otherwise, the
-      whole extent of the mapping is flushed.
+      whole extent of the mapping is flushed. *offset* must be a multiple of the
+      PAGESIZE.
 
       **(Windows version)** A nonzero value returned indicates success; zero
       indicates failure.

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -94,8 +94,8 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
    *offset* may be specified as a non-negative integer offset. mmap references
    will be relative to the offset from the beginning of the file. *offset*
-   defaults to 0.  *offset* must be a multiple of the PAGESIZE or
-   ALLOCATIONGRANULARITY.
+   defaults to 0.  *offset* must be a multiple of the :const:`PAGESIZE` or
+   :const:`ALLOCATIONGRANULARITY`.
 
    To ensure validity of the created memory mapping the file specified
    by the descriptor *fileno* is internally automatically synchronized
@@ -189,8 +189,8 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
       use of this call there is no guarantee that changes are written back before
       the object is destroyed.  If *offset* and *size* are specified, only
       changes to the given range of bytes will be flushed to disk; otherwise, the
-      whole extent of the mapping is flushed. *offset* must be a multiple of the
-      PAGESIZE.
+      whole extent of the mapping is flushed.  *offset* must be a multiple of the
+      :const:`PAGESIZE` or :const:`ALLOCATIONGRANULARITY`.
 
       **(Windows version)** A nonzero value returned indicates success; zero
       indicates failure.


### PR DESCRIPTION


<!-- issue-number: bpo-32798 -->
https://bugs.python.org/issue32798
<!-- /issue-number -->
