### PR TITLE
bpo-32821: Add console logging cookbook recipe

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -2549,7 +2549,7 @@ This can be achieved with a filter as shown below::
     logger.setLevel(logging.DEBUG)
     stdout = logging.StreamHandler(sys.stdout)
     stdout.setLevel("DEBUG")
-    stdout.addFilter(MaxLevelFilter("INFO"))
+    stdout.addFilter(MaxLevelFilter(logging.INFO))
     stderr = logging.StreamHandler(sys.stderr)
     stderr.setLevel(logging.WARNING)
     logger.addHandler(stdout)

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -2534,29 +2534,29 @@ pointing to the two streams, but we want all messages **above** INFO to not
 go to ``stderr``, as otherwise ``ERROR`` messages will appear twice in the console.
 This can be achieved with a filter as shown below::
 
-	import logging
+    import logging
 
-	class MaxLevelFilter:
-		def __init__(self, max_level=None):
-			self.max_level = max_level
+    class MaxLevelFilter:
+        def __init__(self, max_level=None):
+            self.max_level = max_level
 
-		def filter(self, record):
-			return record.levelno <= self.max_level
+        def filter(self, record):
+            return record.levelno <= self.max_level
 
 
-	import sys
-	logger = logging.getLogger()
-	logger.setLevel(logging.DEBUG)
-	stdout = logging.StreamHandler(sys.stdout)
-	stdout.setLevel("DEBUG")
-	stdout.addFilter(MaxLevelFilter("INFO"))
-	stderr = logging.StreamHandler(sys.stderr)
-	stderr.setLevel(logging.WARNING)
-	logger.addHandler(stdout)
-	logger.addHandler(stderr)
+    import sys
+    logger = logging.getLogger()
+    logger.setLevel(logging.DEBUG)
+    stdout = logging.StreamHandler(sys.stdout)
+    stdout.setLevel("DEBUG")
+    stdout.addFilter(MaxLevelFilter("INFO"))
+    stderr = logging.StreamHandler(sys.stderr)
+    stderr.setLevel(logging.WARNING)
+    logger.addHandler(stdout)
+    logger.addHandler(stderr)
 
-	logger.info('INFO')
-	logger.error('ERROR')
+    logger.info('INFO')
+    logger.error('ERROR')
 
 This will create an app that logs ``INFO`` and below to ``stdout`` and
 ``WARN`` and above to ``stderr``.

--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -2523,3 +2523,40 @@ In this case, the message #5 printed to ``stdout`` doesn't appear, as expected.
 Of course, the approach described here can be generalised, for example to attach
 logging filters temporarily. Note that the above code works in Python 2 as well
 as Python 3.
+
+
+Logging to console stderr and stdout
+------------------------------------
+
+Some applications want to log to ``stdout`` and ``stderr`` based on the level
+of the ``LogRecord``. To be able to do so we need two ``StreamHandler``
+pointing to the two streams, but we want all messages **above** INFO to not
+go to ``stderr``, as otherwise ``ERROR`` messages will appear twice in the console.
+This can be achieved with a filter as shown below::
+
+	import logging
+
+	class MaxLevelFilter:
+		def __init__(self, max_level=None):
+			self.max_level = max_level
+
+		def filter(self, record):
+			return record.levelno <= self.max_level
+
+
+	import sys
+	logger = logging.getLogger()
+	logger.setLevel(logging.DEBUG)
+	stdout = logging.StreamHandler(sys.stdout)
+	stdout.setLevel("DEBUG")
+	stdout.addFilter(MaxLevelFilter("INFO"))
+	stderr = logging.StreamHandler(sys.stderr)
+	stderr.setLevel(logging.WARNING)
+	logger.addHandler(stdout)
+	logger.addHandler(stderr)
+
+	logger.info('INFO')
+	logger.error('ERROR')
+
+This will create an app that logs ``INFO`` and below to ``stdout`` and
+``WARN`` and above to ``stderr``.

--- a/Misc/NEWS.d/next/Documentation/2018-02-11-17-13-04.bpo-32821.Up7EGI.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-02-11-17-13-04.bpo-32821.Up7EGI.rst
@@ -1,0 +1,1 @@
+Add recipe in logging cookbook on configuring a "Console" handler.


### PR DESCRIPTION
Add a short recipe on how to configure the logging stack to be able to perform the split many unix tools do, sending INFO and below to stdout and WARN and above to stderr.

<!-- issue-number: bpo-32821 -->
https://bugs.python.org/issue32821
<!-- /issue-number -->
