### PR TITLE
[2.7] bpo-30109: Fix reindent.py for non-ASCII files. (GH-1207)

### DIFF
--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -213,7 +213,7 @@ def parsedate_tz(data):
 def parseaddr(addr):
     """
     Parse addr into its constituent realname and email address parts.
-    
+
     Return a tuple of realname and email address, unless the parse fails, in
     which case return a 2-tuple of ('', '').
     """

--- a/Misc/NEWS.d/next/Tools-Demos/2018-02-12-14-27-01.bpo-30109.lIYlaf.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2018-02-12-14-27-01.bpo-30109.lIYlaf.rst
@@ -1,0 +1,2 @@
+Fixed Tools/scripts/reindent.py for non-ASCII files. It now processes files
+as binary streams. This also fixes "make reindent".


### PR DESCRIPTION
It now processes files as binary streams.

This also fixes "make reindent".


<!-- issue-number: bpo-30109 -->
https://bugs.python.org/issue30109
<!-- /issue-number -->
