### PR TITLE
bpo-32837: IDLE - require encoding argument for textview.view_file.

### DIFF
--- a/Lib/idlelib/idle_test/test_textview.py
+++ b/Lib/idlelib/idle_test/test_textview.py
@@ -112,7 +112,7 @@ class ViewFunctionTest(unittest.TestCase):
         view.ok()
 
     def test_view_file(self):
-        view = tv.view_file(root, 'Title', __file__, modal=False)
+        view = tv.view_file(root, 'Title', __file__, 'ascii', modal=False)
         self.assertIsInstance(view, tv.ViewWindow)
         self.assertIsInstance(view.viewframe, tv.ViewFrame)
         get = view.viewframe.textframe.text.get
@@ -121,7 +121,7 @@ class ViewFunctionTest(unittest.TestCase):
 
     def test_bad_file(self):
         # Mock showerror will be used; view_file will return None.
-        view = tv.view_file(root, 'Title', 'abc.xyz', modal=False)
+        view = tv.view_file(root, 'Title', 'abc.xyz', 'ascii', modal=False)
         self.assertIsNone(view)
         self.assertEqual(tv.showerror.title, 'File Load Error')
 
@@ -161,7 +161,8 @@ class ButtonClickTest(unittest.TestCase):
     def test_view_file_bind_with_button(self):
         def _command():
             self.called = True
-            self.view = tv.view_file(root, 'TITLE_FILE', __file__, _utest=True)
+            self.view = tv.view_file(root, 'TITLE_FILE', __file__,
+                                     encoding='ascii', _utest=True)
         button = Button(root, text='BUTTON', command=_command)
         button.invoke()
         self.addCleanup(button.destroy)

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -107,7 +107,7 @@ def view_text(parent, title, text, modal=True, _utest=False):
     return ViewWindow(parent, title, text, modal, _utest=_utest)
 
 
-def view_file(parent, title, filename, encoding=None, modal=True, _utest=False):
+def view_file(parent, title, filename, encoding, modal=True, _utest=False):
     """Create text viewer for text in filename.
 
     Return error message if file cannot be read.  Otherwise calls view_text

--- a/Misc/NEWS.d/next/IDLE/2018-02-12-17-22-48.bpo-32837.-33QPl.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-02-12-17-22-48.bpo-32837.-33QPl.rst
@@ -1,0 +1,2 @@
+Using the system and place-dependent default encoding for open() is a bad
+idea for IDLE's system and location-independent files.


### PR DESCRIPTION
Using the system and place-dependent default encoding for open()
is a bad idea for IDLE's system and location-independent files.


<!-- issue-number: bpo-32837 -->
https://bugs.python.org/issue32837
<!-- /issue-number -->
