### PR TITLE
bpo-24665: Add CJK support in textwrap by default.

### DIFF
--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -435,6 +435,9 @@ What a mess!
         text = "Whatever, it doesn't matter."
         self.assertRaises(ValueError, wrap, text, 0)
         self.assertRaises(ValueError, wrap, text, -1)
+        # Ensure that we raise while trying to split wide characters.
+        text = 'Did you say "いろはにほへとちりぬるをいろはにほ?"'
+        self.assertRaises(ValueError, wrap, text, 1)
 
     def test_no_split_at_umlaut(self):
         text = "Die Empf\xe4nger-Auswahl"
@@ -578,7 +581,10 @@ class LongWordTestCase (BaseTestCase):
 Did you say "supercalifragilisticexpialidocious?"
 How *do* you spell that odd word, anyways?
 '''
-
+        self.text_cjk = '''\
+Did you say "いろはにほへとちりぬるをいろはにほ?"
+How りぬ るをいろはにほり ぬるは, anyways?
+'''
     def test_break_long(self):
         # Wrap text with long words and lots of punctuation
 
@@ -590,7 +596,14 @@ How *do* you spell that odd word, anyways?
         self.check_wrap(self.text, 50,
                         ['Did you say "supercalifragilisticexpialidocious?"',
                          'How *do* you spell that odd word, anyways?'])
-
+        self.check_wrap(self.text_cjk, 30,
+                        ['Did you say "いろはにほへとち',
+                         'りぬるをいろはにほ?" How りぬ',
+                         'るをいろはにほり ぬるは,',
+                         'anyways?'])
+        self.check_wrap(self.text_cjk, 50,
+                        ['Did you say "いろはにほへとちりぬるをいろはにほ?"',
+                         'How りぬ るをいろはにほり ぬるは, anyways?'])
         # SF bug 797650.  Prevent an infinite loop by making sure that at
         # least one character gets split off on every pass.
         self.check_wrap('-'*10+'hello', 10,

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -514,6 +514,7 @@ Lele Gaifax
 Santiago Gala
 Yitzchak Gale
 Matthew Gallagher
+Florent Gallaire
 Quentin Gallet-Gilles
 Riccardo Attilio Galli
 Raymund Galvin

--- a/Misc/NEWS.d/next/Library/2018-02-13-02-06-24.bpo-24665.re7KqM.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-13-02-06-24.bpo-24665.re7KqM.rst
@@ -1,0 +1,2 @@
+Textwrap now take into account CJK double characters while measuring line
+width.


### PR DESCRIPTION
Related to:

- [Patch: new method get_wch for ncurses bindings: accept wide characters (unicode)](https://bugs.python.org/issue6755)
- [textwrap.wrap: new argument for more pleasing output](https://bugs.python.org/issue12485)
- [textwrap.wrap: add control for fonts with different character widths](https://bugs.python.org/issue12499)
- [Add functions to get the width in columns of a character](https://bugs.python.org/issue12568)
- [CJK support for textwrap](https://bugs.python.org/issue24665)
- https://github.com/python/cpython/pull/89

<!-- issue-number: bpo-24665 -->
https://bugs.python.org/issue24665
<!-- /issue-number -->
