### PR TITLE
[3.6] bpo-32370: Use the correct encoding for ipconfig output in the uuid module. (GH-5608).

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -419,7 +419,7 @@ def _netstat_getnode():
 
 def _ipconfig_getnode():
     """Get the hardware address on Windows by running ipconfig.exe."""
-    import os, re
+    import os, re, subprocess
     dirs = ['', r'c:\windows\system32', r'c:\winnt\system32']
     try:
         import ctypes
@@ -430,11 +430,13 @@ def _ipconfig_getnode():
         pass
     for dir in dirs:
         try:
-            pipe = os.popen(os.path.join(dir, 'ipconfig') + ' /all')
+            proc = subprocess.Popen([os.path.join(dir, 'ipconfig'), '/all'],
+                                    stdout=subprocess.PIPE,
+                                    encoding="oem")
         except OSError:
             continue
-        with pipe:
-            for line in pipe:
+        with proc:
+            for line in proc.stdout:
                 value = line.split(':')[-1].strip().lower()
                 if re.match('([0-9a-f][0-9a-f]-){5}[0-9a-f][0-9a-f]', value):
                     return int(value.replace('-', ''), 16)

--- a/Misc/NEWS.d/next/Windows/2018-02-10-15-38-19.bpo-32370.kcKuct.rst
+++ b/Misc/NEWS.d/next/Windows/2018-02-10-15-38-19.bpo-32370.kcKuct.rst
@@ -1,0 +1,2 @@
+Use the correct encoding for ipconfig output in the uuid module.
+Patch by Segev Finer.


### PR DESCRIPTION
(cherry picked from commit da6c3da6c33c6bf794f741e348b9c6d86cc43ec5)

Co-authored-by: Segev Finer <segev208@gmail.com>


<!-- issue-number: bpo-32370 -->
https://bugs.python.org/issue32370
<!-- /issue-number -->
