### PR TITLE
bpo-31787: Skip refleak check when _hashlib is not available

### DIFF
--- a/Lib/test/test_hashlib.py
+++ b/Lib/test/test_hashlib.py
@@ -163,6 +163,7 @@ class HashLibTestCase(unittest.TestCase):
         return itertools.chain.from_iterable(constructors)
 
     @support.refcount_test
+    @unittest.skipIf(c_hashlib is None, 'Require _hashlib module')
     def test_refleaks_in_hash___init__(self):
         gettotalrefcount = support.get_attribute(sys, 'gettotalrefcount')
         sha1_hash = c_hashlib.new('sha1')


### PR DESCRIPTION


<!-- issue-number: bpo-31787 -->
https://bugs.python.org/issue31787
<!-- /issue-number -->
