### PR TITLE
bpo-27846: Fix an incorrect note in the base64 documentation

### DIFF
--- a/Doc/library/base64.rst
+++ b/Doc/library/base64.rst
@@ -218,14 +218,6 @@ The modern interface provides:
    .. versionadded:: 3.4
 
 
-.. note::
-   Both Base85 and Ascii85 have an expansion factor of 5 to 4 (5 Base85 or
-   Ascii85 characters can encode 4 binary bytes), while the better-known
-   Base64 has an expansion factor of 6 to 4.  They are therefore more
-   efficient when space expensive.  They differ by details such as the
-   character map used for encoding.
-
-
 The legacy interface:
 
 .. function:: decode(input, output)


### PR DESCRIPTION
This note incorrectly stated that "Base64 has an expansion factor of 6
to 4" (it is actually 4 to 3). It was decided to remove the note.


<!-- issue-number: bpo-27846 -->
https://bugs.python.org/issue27846
<!-- /issue-number -->
