### PR TITLE
bpo-32842: Fixing epoll timeout logics

### DIFF
--- a/Lib/selectors.py
+++ b/Lib/selectors.py
@@ -451,7 +451,7 @@ if hasattr(select, 'epoll'):
         def select(self, timeout=None):
             if timeout is None:
                 timeout = -1
-            elif timeout <= 0:
+            elif timeout < -1:
                 timeout = 0
             else:
                 # epoll_wait() has a resolution of 1 millisecond, round away


### PR DESCRIPTION
# current
if timeout is None:
    timeout = -1
elif timeout <= 0:
    timeout = 0

# changed
if timeout is None:
    timeout = -1
elif timeout < -1:
    timeout = 0

what if "timeout=-1" ?
- currently it would result in being timeout=0

<!-- issue-number: bpo-32842 -->
https://bugs.python.org/issue32842
<!-- /issue-number -->
