### PR TITLE
bpo-32844: subprocess: Fix a potential misredirection of a low fd to stderr

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2201,9 +2201,14 @@ class POSIXProcessTestCase(BaseTestCase):
 
             for from_fd, to_fd in zip(from_fds, to_fds):
                 os.lseek(from_fd, 0, os.SEEK_SET)
-                exp_bytes = str(to_fd).encode('ascii')
                 read_bytes = os.read(from_fd, 1024)
-                self.assertEqual(read_bytes, exp_bytes)
+                read_fds = list(map(int, read_bytes.decode('ascii')))
+                msg = textwrap.dedent(f"""
+                    When testing {from_fds} to {to_fds} redirection,
+                    parent descriptor {from_fd} got redirected
+                    to descriptor(s) {read_fds} instead of descriptor {to_fd}.
+                """)
+                self.assertEqual([to_fd], read_fds, msg)
         finally:
             self._restore_fds(saved_fds)
 

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -2177,10 +2177,8 @@ class POSIXProcessTestCase(BaseTestCase):
                 with tempfile.TemporaryFile() as f:
                     os.dup2(f.fileno(), from_fd)
 
-            for fd in range(3):
-                if fd not in from_fds:
-                    os.close(fd)
-                    break
+            fd_to_close = (set(range(3)) - set(from_fds)).pop()
+            os.close(fd_to_close)
 
             arg_names = ['stdin', 'stdout', 'stderr']
             kwargs = {}
@@ -2195,7 +2193,7 @@ class POSIXProcessTestCase(BaseTestCase):
                         os.write(fd, str(fd).encode('ascii'))
             ''')
 
-            skipped_fd = next(fd for fd in range(3) if fd not in to_fds)
+            skipped_fd = (set(range(3)) - set(to_fds)).pop()
 
             rc = subprocess.call([sys.executable, '-c', code, str(skipped_fd)],
                                  **kwargs)

--- a/Misc/NEWS.d/next/Library/2018-02-28-13-08-00.bpo-32844.u8tnAe.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-28-13-08-00.bpo-32844.u8tnAe.rst
@@ -1,0 +1,2 @@
+Fix wrong redirection of a low descriptor (0 or 1) to stderr in subprocess
+if another low descriptor is closed.

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -424,7 +424,7 @@ child_exec(char *const exec_array[],
        either 0, 1 or 2, it is possible that it is overwritten (#12607). */
     if (c2pwrite == 0)
         POSIX_CALL(c2pwrite = dup(c2pwrite));
-    if (errwrite == 0 || errwrite == 1)
+    while (errwrite == 0 || errwrite == 1)
         POSIX_CALL(errwrite = dup(errwrite));
 
     /* Dup fds for child.


### PR DESCRIPTION
When redirecting, subprocess attempts to achieve the following state:
each fd to be redirected to is less than or equal to the fd
it is redirected from, which is necessary because redirection
occurs in the ascending order of destination descriptors.
It fails to do so in a couple of corner cases,
for example, if 1 is redirected to 2 and 0 is closed in the parent.


<!-- issue-number: bpo-32844 -->
https://bugs.python.org/issue32844
<!-- /issue-number -->
