### PR TITLE
#32858: Add OpenSSL ECDH functionality

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1180,6 +1180,12 @@ SSL sockets also have the following additional methods and attributes:
 
    .. versionadded:: 3.5
 
+.. method:: SSLSocket.kxinfo()
+
+   Returns a two-tuple containing the key exchange method and the key length
+   used for the exchange. If no connection has been established or neither ECDH
+   nor DH is used at all, the method returns ``None``.
+
 .. method:: SSLSocket.compression()
 
    Return the compression algorithm being used as a string, or ``None``

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -653,6 +653,10 @@ class SSLObject:
         ssl_version, secret_bits)``."""
         return self._sslobj.cipher()
 
+    def kxinfo(self):
+        """Return the negotiated key exchange method as string"""
+        return self._sslobj.kxinfo()
+
     def shared_ciphers(self):
         """Return a list of ciphers shared by the client during the handshake or
         None if this is not a valid server connection.
@@ -895,6 +899,13 @@ class SSLSocket(socket):
             return None
         else:
             return self._sslobj.cipher()
+
+    def kxinfo(self):
+        self._checkClosed()
+        if not self._sslobj:
+            return None
+        else:
+            return self._sslobj.kxinfo()
 
     def shared_ciphers(self):
         self._checkClosed()

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1237,8 +1237,15 @@ class ContextTests(unittest.TestCase):
     @unittest.skipUnless(ssl.HAS_ECDH, "ECDH disabled on this OpenSSL build")
     def test_set_ecdh_curve(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        if support.verbose:
+            sys.stdout.write("\n... Trying curves\n")
+            sys.stdout.write("... prime256v1\n")
         ctx.set_ecdh_curve("prime256v1")
         ctx.set_ecdh_curve(b"prime256v1")
+        if support.verbose:
+            sys.stdout.write("... X25519\n")
+        ctx.set_ecdh_curve("X25519")
+        ctx.set_ecdh_curve(b"X25519")
         self.assertRaises(TypeError, ctx.set_ecdh_curve)
         self.assertRaises(TypeError, ctx.set_ecdh_curve, None)
         self.assertRaises(ValueError, ctx.set_ecdh_curve, "foo")
@@ -3014,6 +3021,7 @@ class ThreadedTests(unittest.TestCase):
         finally:
             f.close()
         self.assertEqual(d1, d2)
+        pass
 
     def test_asyncore_server(self):
         """Check the example asyncore integration."""

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1362,6 +1362,7 @@ Craig Rowland
 Clinton Roy
 Paul Rubin
 Sam Ruby
+Stefan Rüster
 Demur Rumed
 Audun S. Runde
 Eran Rundstein

--- a/Misc/NEWS.d/next/Library/2018-02-16-17-36-00.bpo-32858.LiZ3J9.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-16-17-36-00.bpo-32858.LiZ3J9.rst
@@ -1,0 +1,2 @@
+Added support for selecting X25519 in SSLContext.set_ecdh_curve(). Added
+method SSLSocket.kxinfo() to provide information about key exchange

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -132,6 +132,23 @@ _ssl__SSLSocket_version(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_version_impl(self);
 }
 
+PyDoc_STRVAR(_ssl__SSLSocket_kxinfo__doc__,
+"kxinfo($self, /)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLSOCKET_KXINFO_METHODDEF    \
+    {"kxinfo", (PyCFunction)_ssl__SSLSocket_kxinfo, METH_NOARGS, _ssl__SSLSocket_kxinfo__doc__},
+
+static PyObject *
+_ssl__SSLSocket_kxinfo_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_kxinfo(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
+{
+    return _ssl__SSLSocket_kxinfo_impl(self);
+}
+
 #if (defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG))
 
 PyDoc_STRVAR(_ssl__SSLSocket_selected_npn_protocol__doc__,
@@ -1168,4 +1185,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=3d42305ed0ad162a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=38dd8b1e72a7c5df input=a9049054013a1b77]*/


### PR DESCRIPTION
Added support for selecting "X25519" in SSLContext.set_ecdh_curve(). Added method SSLSocket.kxinfo() to provide information about key exchange. Changed set_ecdh_curve() to use SSL_CTX_set1_curves_list which is available since OpenSSL 1.0.2.