### PR TITLE
3.7 bpo-32852: Fix trace changing sys.argv to tuple GH-5692

### DIFF
--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -387,5 +387,15 @@ class TestCommandLine(unittest.TestCase):
             status, stdout, stderr = assert_python_ok('-m', 'trace', '-l', TESTFN)
             self.assertIn(b'functions called:', stdout)
 
+    def test_sys_argv_list(self):
+        with open(TESTFN, 'w') as fd:
+            self.addCleanup(unlink, TESTFN)
+            fd.write("import sys\n")
+            fd.write("print(type(sys.argv))\n")
+
+        status, direct_stdout, stderr = assert_python_ok(TESTFN)
+        status, trace_stdout, stderr = assert_python_ok('-m', 'trace', '-l', TESTFN)
+        self.assertIn(direct_stdout.strip(), trace_stdout)
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -705,7 +705,7 @@ def main():
     if opts.filename is None:
         parser.error('filename is missing: required with the main options')
 
-    sys.argv = opts.filename, *opts.arguments
+    sys.argv = [opts.filename, *opts.arguments]
     sys.path[0] = os.path.dirname(opts.filename)
 
     t = Trace(opts.count, opts.trace, countfuncs=opts.listfuncs,

--- a/Misc/NEWS.d/next/Library/2018-02-15-12-04-29.bpo-32852.HDqIxM.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-15-12-04-29.bpo-32852.HDqIxM.rst
@@ -1,0 +1,1 @@
+Make sure sys.argv remains as a list when running trace.


### PR DESCRIPTION


<!-- issue-number: bpo-32852 -->
https://bugs.python.org/issue32852
<!-- /issue-number -->
