### PR TITLE
bpo-32858: Add method kxinfo to SSLObject

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1180,6 +1180,13 @@ SSL sockets also have the following additional methods and attributes:
 
    .. versionadded:: 3.5
 
+.. method:: SSLSocket.kxinfo()
+
+   Returns a two-tuple containing the key exchange method and the key length
+   used for the exchange. If no connection has been established or neither ECDH
+   nor DH is used at all, the method returns ``None``. When using OpenSSL <
+   v1.0.2 this method always returns ``None``.
+
 .. method:: SSLSocket.compression()
 
    Return the compression algorithm being used as a string, or ``None``

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -653,6 +653,12 @@ class SSLObject:
         ssl_version, secret_bits)``."""
         return self._sslobj.cipher()
 
+    def kxinfo(self):
+        """Return a two-tuple containing the key exchange method and the key length
+        used for the exchange or ``None`` if not connected or not using DHE or
+        ECDHE"""
+        return self._sslobj.kxinfo()
+
     def shared_ciphers(self):
         """Return a list of ciphers shared by the client during the handshake or
         None if this is not a valid server connection.
@@ -895,6 +901,13 @@ class SSLSocket(socket):
             return None
         else:
             return self._sslobj.cipher()
+
+    def kxinfo(self):
+        self._checkClosed()
+        if not self._sslobj:
+            return None
+        else:
+            return self._sslobj.kxinfo()
 
     def shared_ciphers(self):
         self._checkClosed()

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1362,6 +1362,7 @@ Craig Rowland
 Clinton Roy
 Paul Rubin
 Sam Ruby
+Stefan Rüster
 Demur Rumed
 Audun S. Runde
 Eran Rundstein

--- a/Misc/NEWS.d/next/Library/2018-02-16-20-31-00.bpo-32858.Rst3k4.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-16-20-31-00.bpo-32858.Rst3k4.rst
@@ -1,0 +1,1 @@
+Added method SSLSocket.kxinfo() to provide information about key exchange

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -138,6 +138,11 @@ static void _PySSLFixErrno(void) {
 #  define OPENSSL_VERSION_1_1 1
 #endif
 
+/* SSL_get_server_tmp_key() appeared in OpenSSL 1.0.2 */
+#if (OPENSSL_VERSION_NUMBER >= 0x10002000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#  define OPENSSL_VERSION_1_0_2 1
+#endif
+
 /* Openssl comes with TLSv1.1 and TLSv1.2 between 1.0.0h and 1.0.1
     http://www.openssl.org/news/changelog.html
  */
@@ -1895,6 +1900,93 @@ _ssl__SSLSocket_version_impl(PySSLSocket *self)
     return PyUnicode_FromString(version);
 }
 
+/*[clinic input]
+_ssl._SSLSocket.kxinfo
+[clinic start generated code]*/
+
+static PyObject *
+_ssl__SSLSocket_kxinfo_impl(PySSLSocket *self)
+/*[clinic end generated code: output=1b696880c75827d1 input=38d59706e6823f52]*/
+{
+#if !defined(OPENSSL_VERSION_1_0_2)
+    Py_RETURN_NONE;
+#else
+    if (self->ssl == NULL)
+        Py_RETURN_NONE;
+
+    if (!SSL_is_init_finished(self->ssl)) {
+        /* handshake not finished */
+        Py_RETURN_NONE;
+    }
+
+    EVP_PKEY *key;
+    if (!SSL_get_server_tmp_key(self->ssl, &key))
+        Py_RETURN_NONE;
+
+    int bits = EVP_PKEY_bits(key);
+
+    const char *kxinfo = NULL;
+
+    switch (EVP_PKEY_id(key)) {
+    case EVP_PKEY_RSA:
+        kxinfo = "RSA";
+        break;
+
+    case EVP_PKEY_DH:
+        kxinfo = "DH";
+        break;
+
+#ifndef OPENSSL_NO_EC
+    case EVP_PKEY_EC:
+        {
+            EC_KEY *ec = EVP_PKEY_get1_EC_KEY(key);
+            if(ec != NULL)
+            {
+                int nid = EC_GROUP_get_curve_name(EC_KEY_get0_group(ec));
+                if(nid != 0)
+                {
+                    kxinfo = EC_curve_nid2nist(nid);
+                    if (!kxinfo)
+                        kxinfo = OBJ_nid2sn(nid);
+                }
+                EC_KEY_free(ec);
+            }
+        }
+        break;
+#endif
+    default:
+        kxinfo = OBJ_nid2sn(EVP_PKEY_id(key));
+    }
+    EVP_PKEY_free(key);
+
+
+    if(kxinfo == NULL)
+        kxinfo = "unknown";
+
+    PyObject *v, *retval = PyTuple_New(2);
+    if (retval == NULL)
+        return NULL;
+
+    v = PyUnicode_FromString(kxinfo);
+    if (v == NULL) {
+        Py_DECREF(retval);
+        return NULL;
+    }
+
+    PyTuple_SET_ITEM(retval, 0, v);
+
+    v = PyLong_FromLong(bits);
+    if (v == NULL){
+        Py_DECREF(retval);
+        return NULL;
+    }
+    PyTuple_SET_ITEM(retval, 1, v);
+
+    return retval;
+
+#endif
+}
+
 #if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
 /*[clinic input]
 _ssl._SSLSocket.selected_npn_protocol
@@ -2711,6 +2803,7 @@ static PyMethodDef PySSLMethods[] = {
     _SSL__SSLSOCKET_CIPHER_METHODDEF
     _SSL__SSLSOCKET_SHARED_CIPHERS_METHODDEF
     _SSL__SSLSOCKET_VERSION_METHODDEF
+    _SSL__SSLSOCKET_KXINFO_METHODDEF
     _SSL__SSLSOCKET_SELECTED_NPN_PROTOCOL_METHODDEF
     _SSL__SSLSOCKET_SELECTED_ALPN_PROTOCOL_METHODDEF
     _SSL__SSLSOCKET_COMPRESSION_METHODDEF

--- a/Modules/clinic/_ssl.c.h
+++ b/Modules/clinic/_ssl.c.h
@@ -132,6 +132,23 @@ _ssl__SSLSocket_version(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
     return _ssl__SSLSocket_version_impl(self);
 }
 
+PyDoc_STRVAR(_ssl__SSLSocket_kxinfo__doc__,
+"kxinfo($self, /)\n"
+"--\n"
+"\n");
+
+#define _SSL__SSLSOCKET_KXINFO_METHODDEF    \
+    {"kxinfo", (PyCFunction)_ssl__SSLSocket_kxinfo, METH_NOARGS, _ssl__SSLSocket_kxinfo__doc__},
+
+static PyObject *
+_ssl__SSLSocket_kxinfo_impl(PySSLSocket *self);
+
+static PyObject *
+_ssl__SSLSocket_kxinfo(PySSLSocket *self, PyObject *Py_UNUSED(ignored))
+{
+    return _ssl__SSLSocket_kxinfo_impl(self);
+}
+
 #if (defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG))
 
 PyDoc_STRVAR(_ssl__SSLSocket_selected_npn_protocol__doc__,
@@ -1168,4 +1185,4 @@ exit:
 #ifndef _SSL_ENUM_CRLS_METHODDEF
     #define _SSL_ENUM_CRLS_METHODDEF
 #endif /* !defined(_SSL_ENUM_CRLS_METHODDEF) */
-/*[clinic end generated code: output=3d42305ed0ad162a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=38dd8b1e72a7c5df input=a9049054013a1b77]*/


### PR DESCRIPTION
kxinfo provides information about the SSL key exchange (chosen algorithm, curve, bit length) which was not accessible before.

This is the "kxinfo" part of the issue https://bugs.python.org/issue32858

<!-- issue-number: bpo-32858 -->
https://bugs.python.org/issue32858
<!-- /issue-number -->
