### PR TITLE
bpo-32859: Don't retry dup3() if it is not available at runtime

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-02-19-17-46-31.bpo-32859.kAT-Xp.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-19-17-46-31.bpo-32859.kAT-Xp.rst
@@ -1,0 +1,2 @@
+In ``os.dup2``, don't check every call whether the ``dup3`` syscall exists
+or not.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8016,7 +8016,7 @@ os_dup2_impl(PyObject *module, int fd, int fd2, int inheritable)
 #if defined(HAVE_DUP3) && \
     !(defined(HAVE_FCNTL_H) && defined(F_DUP2FD_CLOEXEC))
     /* dup3() is available on Linux 2.6.27+ and glibc 2.9 */
-    int dup3_works = -1;
+    static int dup3_works = -1;
 #endif
 
     if (fd < 0 || fd2 < 0) {


### PR DESCRIPTION
os.dup2() tests for dup3() system call availability at runtime,
but doesn't remember the result across calls, repeating
the test on each call with inheritable=False.

Since the caller of os.dup2() is expected to hold the GIL,
fix this by making the variable holding the test result static.



<!-- issue-number: bpo-32859 -->
https://bugs.python.org/issue32859
<!-- /issue-number -->
