### PR TITLE
bpo-32861: urllib.robotparser fix incomplete __str__ methods.

### DIFF
--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -246,6 +246,32 @@ Disallow: /cyberworld/map/
     bad = ['/cyberworld/map/index.html']
 
 
+class StringFormattingTest(BaseRobotTest, unittest.TestCase):
+    robots_txt = """\
+User-agent: *
+Crawl-delay: 1
+Request-rate: 3/15
+Disallow: /cyberworld/map/ # This is an infinite virtual URL space
+
+# Cybermapper knows where to go.
+User-agent: cybermapper
+Disallow: /some/path
+    """
+
+    expected_output = """\
+User-agent: cybermapper
+Disallow: /some/path
+
+User-agent: *
+Crawl-delay: 1
+Request-rate: 3/15
+Disallow: /cyberworld/map/\
+"""
+
+    def test_string_formatting(self):
+        self.assertEqual(str(self.parser), self.expected_output)
+
+
 class RobotHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):

--- a/Lib/urllib/robotparser.py
+++ b/Lib/urllib/robotparser.py
@@ -190,10 +190,10 @@ class RobotFileParser:
         return self.default_entry.req_rate
 
     def __str__(self):
-        ret = [str(entry) for entry in self.entries]
+        entries = self.entries
         if self.default_entry is not None:
-            ret.append(str(self.default_entry))
-        return '\n\n'.join(ret)
+            entries = entries + [self.default_entry]
+        return '\n\n'.join(map(str, entries))
 
 
 class RuleLine:
@@ -225,13 +225,13 @@ class Entry:
     def __str__(self):
         ret = []
         for agent in self.useragents:
-            ret.append("User-agent: {0}".format(agent))
+            ret.append(f"User-agent: {agent}")
         if self.delay is not None:
-            ret.append("Crawl-delay: {0}".format(self.delay))
+            ret.append(f"Crawl-delay: {self.delay}")
         if self.req_rate is not None:
-            ret.append("Request-rate: {0.requests}/{0.seconds}".format(self.req_rate))
-        for line in self.rulelines:
-            ret.append(str(line))
+            rate = self.req_rate
+            ret.append(f"Request-rate: {rate.requests}/{rate.seconds}")
+        ret.extend(map(str, self.rulelines))
         return '\n'.join(ret)
 
     def applies_to(self, useragent):

--- a/Lib/urllib/robotparser.py
+++ b/Lib/urllib/robotparser.py
@@ -190,7 +190,10 @@ class RobotFileParser:
         return self.default_entry.req_rate
 
     def __str__(self):
-        return ''.join([str(entry) + "\n" for entry in self.entries])
+        ret = [str(entry) for entry in self.entries]
+        if self.default_entry is not None:
+            ret.append(str(self.default_entry))
+        return '\n\n'.join(ret)
 
 
 class RuleLine:
@@ -222,10 +225,14 @@ class Entry:
     def __str__(self):
         ret = []
         for agent in self.useragents:
-            ret.extend(["User-agent: ", agent, "\n"])
+            ret.append("User-agent: {0}".format(agent))
+        if self.delay is not None:
+            ret.append("Crawl-delay: {0}".format(self.delay))
+        if self.req_rate is not None:
+            ret.append("Request-rate: {0.requests}/{0.seconds}".format(self.req_rate))
         for line in self.rulelines:
-            ret.extend([str(line), "\n"])
-        return ''.join(ret)
+            ret.append(str(line))
+        return '\n'.join(ret)
 
     def applies_to(self, useragent):
         """check if this entry applies to the specified agent"""

--- a/Misc/NEWS.d/next/Library/2018-04-02-20-44-54.bpo-32861.HeBjzN.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-02-20-44-54.bpo-32861.HeBjzN.rst
@@ -1,0 +1,3 @@
+The urllib.robotparser's ``__str__`` representation now includes wildcard
+entries and the "Crawl-delay" and "Request-rate" fields. Also removes extra
+newlines that were being appended to the end of the string.

--- a/Misc/NEWS.d/next/Library/2018-04-02-20-44-54.bpo-32861.HeBjzN.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-02-20-44-54.bpo-32861.HeBjzN.rst
@@ -1,3 +1,4 @@
 The urllib.robotparser's ``__str__`` representation now includes wildcard
 entries and the "Crawl-delay" and "Request-rate" fields. Also removes extra
-newlines that were being appended to the end of the string.
+newlines that were being appended to the end of the string. Patch by
+Michael Lazar.


### PR DESCRIPTION
The RobotFileParser's string representation was incomplete and missing some valid rule lines.

https://bugs.python.org/issue32861

<!-- issue-number: bpo-32861 -->
https://bugs.python.org/issue32861
<!-- /issue-number -->
