### PR TITLE
bpo-32860: Fix a missing asterisk in the documentation for glob.iglob()

### DIFF
--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -48,7 +48,7 @@ For example, ``'[?]'`` matches the character ``'?'``.
       Support for recursive globs using "``**``".
 
 
-.. function:: iglob(pathname, recursive=False)
+.. function:: iglob(pathname, *, recursive=False)
 
    Return an :term:`iterator` which yields the same values as :func:`glob`
    without actually storing them all simultaneously.


### PR DESCRIPTION


<!-- issue-number: bpo-32860 -->
https://bugs.python.org/issue32860
<!-- /issue-number -->
