### PR TITLE
[3.6] bpo-30638: Add clinic to `make regen-all` (GH-5671)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,7 @@ before_script:
       fi
       # Build in debug mode
       ./configure --with-pydebug PYTHON_FOR_REGEN=python3
-      make -j4
-      make -j4 regen-all clinic
+      make -j4 regen-all
       changes=`git status --porcelain`
       if ! test -z "$changes"
       then
@@ -96,6 +95,7 @@ before_script:
         echo "$changes"
         exit 1
       fi
+      make -j4
       make pythoninfo
 
 script:

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -538,10 +538,9 @@ coverage-report: regen-grammar regen-importlib
 	$(MAKE) coverage-lcov
 
 # Run "Argument Clinic" over all source files
-# (depends on python having already been built)
 .PHONY=clinic
-clinic: check-clean-src $(BUILDPYTHON) $(srcdir)/Modules/_blake2/blake2s_impl.c
-	$(RUNSHARED) $(PYTHON_FOR_BUILD) ./Tools/clinic/clinic.py --make
+clinic: check-clean-src $(srcdir)/Modules/_blake2/blake2s_impl.c
+	$(PYTHON_FOR_REGEN) ./Tools/clinic/clinic.py --make
 
 # Build the interpreter
 $(BUILDPYTHON):	Programs/python.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
@@ -571,9 +570,9 @@ Modules/_math.o: Modules/_math.c Modules/_math.h
 	$(CC) -c $(CCSHARED) $(PY_CORE_CFLAGS) -o $@ $<
 
 # blake2s is auto-generated from blake2b
-$(srcdir)/Modules/_blake2/blake2s_impl.c: $(BUILDPYTHON) $(srcdir)/Modules/_blake2/blake2b_impl.c $(srcdir)/Modules/_blake2/blake2b2s.py
-	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(srcdir)/Modules/_blake2/blake2b2s.py
-	$(RUNSHARED) $(PYTHON_FOR_BUILD) $(srcdir)/Tools/clinic/clinic.py -f $@
+$(srcdir)/Modules/_blake2/blake2s_impl.c: $(srcdir)/Modules/_blake2/blake2b_impl.c $(srcdir)/Modules/_blake2/blake2b2s.py
+	$(PYTHON_FOR_REGEN) $(srcdir)/Modules/_blake2/blake2b2s.py
+	$(PYTHON_FOR_REGEN) $(srcdir)/Tools/clinic/clinic.py -f $@
 
 # Build the shared modules
 # Under GNU make, MAKEFLAGS are sorted and normalized; the 's' for
@@ -720,7 +719,8 @@ regen-importlib: Programs/_freeze_importlib
 ############################################################################
 # Regenerate all generated files
 
-regen-all: regen-opcode regen-opcode-targets regen-typeslots regen-grammar regen-ast regen-importlib
+regen-all: regen-opcode regen-opcode-targets regen-typeslots regen-grammar \
+	regen-ast regen-importlib clinic
 
 ############################################################################
 # Special rules for object files


### PR DESCRIPTION
Also, use PYTHON_FOR_REGEN for clinic and blake2s_impl.c rather than PYTHON_FOR_BUILD, and update .travis.yml to make use of the change.
(cherry picked from commit d6ff8a7037903497eff95fa32bdac2b6adf71505)

<!-- issue-number: bpo-30638 -->
https://bugs.python.org/issue30638
<!-- /issue-number -->
