### PR TITLE
bpo-21060: improve error message for "setup.py upload" without dist files

### DIFF
--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -57,7 +57,8 @@ class upload(PyPIRCCommand):
 
     def run(self):
         if not self.distribution.dist_files:
-            msg = "No dist file created in earlier command"
+            msg = ("Must create and upload files in one command "
+                   "(e.g. setup.py sdist upload)")
             raise DistutilsOptionError(msg)
         for command, pyversion, filename in self.distribution.dist_files:
             self.upload_file(command, pyversion, filename)

--- a/Misc/NEWS.d/next/Library/2018-02-17-19-20-19.bpo-21060.S1Z-x6.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-17-19-20-19.bpo-21060.S1Z-x6.rst
@@ -1,0 +1,3 @@
+Rewrite confusing message from setup.py upload from
+"No dist file created in earlier command" to the more helpful
+"Must create and upload files in one command".


### PR DESCRIPTION
I put the old message in the news file in hope of catching search engines to direct people to our docs.

<!-- issue-number: bpo-21060 -->
https://bugs.python.org/issue21060
<!-- /issue-number -->
