### PR TITLE
bpo-28956: Return list of modes for a multimodal distribution.

### DIFF
--- a/Lib/statistics.py
+++ b/Lib/statistics.py
@@ -502,9 +502,13 @@ def mode(data):
     if len(table) == 1:
         return table[0][0]
     elif table:
-        raise StatisticsError(
-                'no unique mode; found %d equally common values' % len(table)
-                )
+        _data = list(value for value, frequency in table)
+        if _data == list(data):
+            raise StatisticsError(
+                    'no unique mode; found %d equally common values' % len(table)
+                    )
+        else:
+            return _data
     else:
         raise StatisticsError('no mode for empty data')
 

--- a/Lib/test/test_statistics.py
+++ b/Lib/test/test_statistics.py
@@ -1788,8 +1788,8 @@ class TestMode(NumericTestCase, AverageMixin, UnivariateTypeMixin):
         # Test mode with bimodal data.
         data = [1, 1, 2, 2, 2, 2, 3, 4, 5, 6, 6, 6, 6, 7, 8, 9, 9]
         assert data.count(2) == data.count(6) == 4
-        # Check for an exception.
-        self.assertRaises(statistics.StatisticsError, self.func, data)
+        # Check for a list of modes.
+        self.assertEqual(self.func(data), [2, 6])
 
     def test_unique_data_failure(self):
         # Test mode exception when data points are all unique.


### PR DESCRIPTION
Return list of modes for a multimodal distribution instead of raising a `StatisticsError`.

<!-- issue-number: bpo-28956 -->
https://bugs.python.org/issue28956
<!-- /issue-number -->
