### PR TITLE
bpo-31333: Fix typo in whatsnew/3.7.rst

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -853,7 +853,7 @@ Optimizations
 * Constant folding is moved from peephole optimizer to new AST optimizer.
   (Contributed by Eugene Toder and INADA Naoki in :issue:`29469`)
 
-* Most functions and methods in :mod:`abc` have been rewrittent in C.
+* Most functions and methods in :mod:`abc` have been rewritten in C.
   This makes creation of abstract base classes, and calling :func:`isinstance`
   and :func:`issubclass` on them 1.5x faster.  This also reduces Python
   start-up time by up to 10%. (Contributed by Ivan Levkivskyi and INADA Naoki


### PR DESCRIPTION


<!-- issue-number: bpo-31333 -->
https://bugs.python.org/issue31333
<!-- /issue-number -->
