### PR TITLE
[2.7] bpo-21060 Improve error message for "setup.py upload" without dist files (GH-5726).

### DIFF
--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -55,7 +55,9 @@ class upload(PyPIRCCommand):
 
     def run(self):
         if not self.distribution.dist_files:
-            raise DistutilsOptionError("No dist file created in earlier command")
+            msg = ("Must create and upload files in one command "
+                   "(e.g. setup.py sdist upload)")
+            raise DistutilsOptionError(msg)
         for command, pyversion, filename in self.distribution.dist_files:
             self.upload_file(command, pyversion, filename)
 

--- a/Misc/NEWS.d/next/Library/2018-02-17-19-20-19.bpo-21060.S1Z-x6.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-17-19-20-19.bpo-21060.S1Z-x6.rst
@@ -1,0 +1,3 @@
+Rewrite confusing message from setup.py upload from
+"No dist file created in earlier command" to the more helpful
+"Must create and upload files in one command".


### PR DESCRIPTION
(cherry picked from commit 08a6926b2584040fe3c3f06263b0b5f1fbbdc24c)

Co-authored-by: Éric Araujo <merwok@netwok.org>

<!-- issue-number: bpo-21060 -->
https://bugs.python.org/issue21060
<!-- /issue-number -->
