### PR TITLE
bpo-31966: Fixed WindowsConsoleIO.write() for writing empty data.

### DIFF
--- a/Lib/test/test_winconsoleio.py
+++ b/Lib/test/test_winconsoleio.py
@@ -121,6 +121,10 @@ class WindowsConsoleIOTests(unittest.TestCase):
             else:
                 self.assertNotIsInstance(f, ConIO)
 
+    def test_write_empty_data(self):
+        with ConIO('CONOUT$', 'w') as f:
+            self.assertEqual(f.write(b''), 0)
+
     def assertStdinRoundTrip(self, text):
         stdin = open('CONIN$', 'r')
         old_stdin = sys.stdin

--- a/Misc/NEWS.d/next/Windows/2018-02-19-13-54-42.bpo-31966._Q3HPb.rst
+++ b/Misc/NEWS.d/next/Windows/2018-02-19-13-54-42.bpo-31966._Q3HPb.rst
@@ -1,0 +1,1 @@
+Fixed WindowsConsoleIO.write() for writing empty data.

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -964,6 +964,9 @@ _io__WindowsConsoleIO_write_impl(winconsoleio *self, Py_buffer *b)
     if (!self->writable)
         return err_mode("writing");
 
+    if (!b->len) {
+        return PyLong_FromLong(0);
+    }
     if (b->len > BUFMAX)
         len = BUFMAX;
     else


### PR DESCRIPTION


<!-- issue-number: bpo-31966 -->
https://bugs.python.org/issue31966
<!-- /issue-number -->
