### PR TITLE
bpo-32457: Improves handling of denormalized executable path when launching Python

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -701,6 +701,17 @@ class CmdLineTest(unittest.TestCase):
         self.assertEqual(proc.stdout.rstrip(), 'True')
         self.assertEqual(proc.returncode, 0, proc)
 
+    @unittest.skipUnless(sys.platform == 'win32',
+                         'bpo-32457 only applies on Windows')
+    def test_argv0_normalization(self):
+        args = sys.executable, '-c', 'print(0)'
+        prefix, exe = os.path.split(sys.executable)
+        executable = prefix + '\\.\\.\\.\\' + exe
+        
+        proc = subprocess.run(args, stdout=subprocess.PIPE,
+                              executable=executable)
+        self.assertEqual(proc.returncode, 0, proc)
+        self.assertEqual(proc.stdout.strip(), b'0')
 
 @unittest.skipIf(interpreter_requires_environment(),
                  'Cannot run -I tests when PYTHON env vars are required.')

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -707,7 +707,7 @@ class CmdLineTest(unittest.TestCase):
         args = sys.executable, '-c', 'print(0)'
         prefix, exe = os.path.split(sys.executable)
         executable = prefix + '\\.\\.\\.\\' + exe
-        
+
         proc = subprocess.run(args, stdout=subprocess.PIPE,
                               executable=executable)
         self.assertEqual(proc.returncode, 0, proc)

--- a/Misc/NEWS.d/next/Windows/2018-02-19-08-54-06.bpo-32457.vVP0Iz.rst
+++ b/Misc/NEWS.d/next/Windows/2018-02-19-08-54-06.bpo-32457.vVP0Iz.rst
@@ -1,0 +1,1 @@
+Improves handling of denormalized executable path when launching Python.


### PR DESCRIPTION


<!-- issue-number: bpo-32457 -->
https://bugs.python.org/issue32457
<!-- /issue-number -->
