### PR TITLE
bpo-32409: Ensures activate.bat can handle Unicode contents

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -281,6 +281,24 @@ class BasicTest(BaseTest):
         out, err = p.communicate()
         self.assertEqual(out.strip(), envpy.encode())
 
+    @unittest.skipUnless(os.name == 'nt', 'only relevant on Windows')
+    def test_unicode_in_batch_file(self):
+        """
+        Test isolation from system site-packages
+        """
+        rmtree(self.env_dir)
+        env_dir = os.path.join(os.path.realpath(self.env_dir), 'ϼўТλФЙ')
+        builder = venv.EnvBuilder(clear=True)
+        builder.create(env_dir)
+        activate = os.path.join(env_dir, self.bindir, 'activate.bat')
+        envpy = os.path.join(env_dir, self.bindir, self.exe)
+        cmd = [activate, '&', self.exe, '-c', 'print(0)']
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE, encoding='oem',
+                             shell=True)
+        out, err = p.communicate()
+        print(err)
+        self.assertEqual(out.strip(), '0')
 
 @skipInVenv
 class EnsurePipTest(BaseTest):

--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -41,5 +41,5 @@ set "PATH=%VIRTUAL_ENV%\__VENV_BIN_NAME__;%PATH%"
 :END
 if defined _OLD_CODEPAGE (
     "%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE% > nul
-    set _OLD_CODEPAGE=
+    set "_OLD_CODEPAGE="
 )

--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -1,4 +1,13 @@
 @echo off
+
+rem This file is UTF-8 encoded, so we need to update the current code page while executing it
+for /f "tokens=2 delims=:" %%a in ('"%SystemRoot%\System32\chcp.com"') do (
+    set "_OLD_CODEPAGE=%%a"
+)
+if defined _OLD_CODEPAGE (
+    "%SystemRoot%\System32\chcp.com" 65001 > nul
+)
+
 set "VIRTUAL_ENV=__VENV_DIR__"
 
 if not defined PROMPT (
@@ -30,3 +39,7 @@ if defined _OLD_VIRTUAL_PATH (
 set "PATH=%VIRTUAL_ENV%\__VENV_BIN_NAME__;%PATH%"
 
 :END
+if defined _OLD_CODEPAGE (
+    "%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE% > nul
+    set _OLD_CODEPAGE=
+)

--- a/Misc/NEWS.d/next/Windows/2018-02-19-10-00-57.bpo-32409.nocuDg.rst
+++ b/Misc/NEWS.d/next/Windows/2018-02-19-10-00-57.bpo-32409.nocuDg.rst
@@ -1,0 +1,1 @@
+Ensures activate.bat can handle Unicode contents.


### PR DESCRIPTION


<!-- issue-number: bpo-32409 -->
https://bugs.python.org/issue32409
<!-- /issue-number -->
