### PR TITLE
bpo-30121: Fix test_subprocess for Windows Debug builds

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1179,7 +1179,7 @@ class ProcessTestCase(BaseTestCase):
                 msvcrt.CrtSetReportFile(report_type, msvcrt.CRTDBG_FILE_STDERR)
 
             try:
-                subprocess.Popen([cmd],
+                subprocess.Popen(cmd,
                                  stdout=subprocess.PIPE,
                                  stderr=subprocess.PIPE)
             except OSError:


### PR DESCRIPTION


<!-- issue-number: bpo-30121 -->
https://bugs.python.org/issue30121
<!-- /issue-number -->
