### PR TITLE
bpo-32764: Fixes test_nonexisting_with_pipes using incorrect test value

### DIFF
--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1170,7 +1170,7 @@ class ProcessTestCase(BaseTestCase):
             import msvcrt
             import subprocess
 
-            cmd = {NONEXISTING_CMD!r}
+            cmd = {NONEXISTING_CMD[0]!r}
 
             for report_type in [msvcrt.CRT_WARN,
                                 msvcrt.CRT_ERROR,

--- a/Misc/NEWS.d/next/Tests/2018-02-19-15-20-12.bpo-32764.zjzT3P.rst
+++ b/Misc/NEWS.d/next/Tests/2018-02-19-15-20-12.bpo-32764.zjzT3P.rst
@@ -1,0 +1,1 @@
+Fixes test_nonexisting_with_pipes using incorrect test value.


### PR DESCRIPTION


<!-- issue-number: bpo-32764 -->
https://bugs.python.org/issue32764
<!-- /issue-number -->
