### PR TITLE
bpo-32885: Tools/scripts/pathfix.py: Add -n option for no backup~

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -684,6 +684,7 @@ Ken Howard
 Brad Howes
 Mike Hoy
 Ben Hoyt
+Miro Hrončok
 Chiu-Hsiang Hsu
 Chih-Hao Huang
 Christian Hudon

--- a/Misc/NEWS.d/next/Tools-Demos/2018-02-20-12-16-47.bpo-32885.dL5x7C.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2018-02-20-12-16-47.bpo-32885.dL5x7C.rst
@@ -1,0 +1,2 @@
+Add an ``-n`` flag for ``Tools/scripts/pathfix.py`` to disbale automatic
+backup creation (files with ``~`` suffix).


### PR DESCRIPTION
Creating backup files with `~` suffix can be undesirable in some environment, such as when building RPM packages. Instead of requiring the user to remove those files manually, option `-n` was added, that simply disables this feature.

`-n` was selected because 2to3 has the same option with this behavior.


<!-- issue-number: bpo-32885 -->
https://bugs.python.org/issue32885
<!-- /issue-number -->
