### PR TITLE
bpo-32849: Always use fstat() to validate fds on POSIX

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-02-28-11-55-55.bpo-32849.SNQo56.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-28-11-55-55.bpo-32849.SNQo56.rst
@@ -1,0 +1,2 @@
+Use fstat() instead of dup() to validate fds on POSIX to avoid failure if
+dup() succeeds but fstat() fails afterwards.


### PR DESCRIPTION
A previous approach was to usually prefer dup() for that, but
there are various circumstances under which dup() succeeds
for a descriptor unusable for I/O but fstat() fails with EBADF
causing a fatal failure in standard streams initialization.


<!-- issue-number: bpo-32849 -->
https://bugs.python.org/issue32849
<!-- /issue-number -->
