### PR TITLE
bpo-32889: update valgrind suppressions

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-02-20-21-53-48.bpo-32889.J6eWy5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-02-20-21-53-48.bpo-32889.J6eWy5.rst
@@ -1,0 +1,2 @@
+Update Valgrind suppression list to account for the rename of
+``Py_ADDRESS_IN_RANG`` to ``address_in_range``.

--- a/Misc/valgrind-python.supp
+++ b/Misc/valgrind-python.supp
@@ -8,7 +8,7 @@
 #		./python -E ./Lib/test/regrtest.py -u gui,network
 #
 # You must edit Objects/obmalloc.c and uncomment Py_USING_MEMORY_DEBUGGER
-# to use the preferred suppressions with Py_ADDRESS_IN_RANGE.
+# to use the preferred suppressions with address_in_range.
 #
 # If you do not want to recompile Python, you can uncomment
 # suppressions for PyObject_Free and PyObject_Realloc.
@@ -19,25 +19,25 @@
 {
    ADDRESS_IN_RANGE/Invalid read of size 4
    Memcheck:Addr4
-   fun:Py_ADDRESS_IN_RANGE
+   fun:address_in_range
 }
 
 {
    ADDRESS_IN_RANGE/Invalid read of size 4
    Memcheck:Value4
-   fun:Py_ADDRESS_IN_RANGE
+   fun:address_in_range
 }
 
 {
    ADDRESS_IN_RANGE/Invalid read of size 8 (x86_64 aka amd64)
    Memcheck:Value8
-   fun:Py_ADDRESS_IN_RANGE
+   fun:address_in_range
 }
 
 {
    ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
    Memcheck:Cond
-   fun:Py_ADDRESS_IN_RANGE
+   fun:address_in_range
 }
 
 #


### PR DESCRIPTION
Py_ADDRESS_IN_RANGE was renamed address_in_range in 3.6
(commit 3924f93794fd740c547b44884f73303196475cd5).

bpo-32889

<!-- issue-number: bpo-32889 -->
https://bugs.python.org/issue32889
<!-- /issue-number -->
