### PR TITLE
[2.7] bpo-32008: don't use PROTOCOL_TLSv1 in example (GH-5789)

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1330,7 +1330,7 @@ to speed up repeated connections from the same clients.
 
       import socket, ssl
 
-      context = ssl.SSLContext(ssl.PROTOCOL_TLSv1)
+      context = ssl.SSLContext(ssl.PROTOCOL_TLS)
       context.verify_mode = ssl.CERT_REQUIRED
       context.check_hostname = True
       context.load_default_certs()
@@ -1536,7 +1536,7 @@ If you prefer to tune security settings yourself, you might create
 a context from scratch (but beware that you might not get the settings
 right)::
 
-   >>> context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
+   >>> context = ssl.SSLContext(ssl.PROTOCOL_TLS)
    >>> context.verify_mode = ssl.CERT_REQUIRED
    >>> context.check_hostname = True
    >>> context.load_verify_locations("/etc/ssl/certs/ca-bundle.crt")


### PR DESCRIPTION
It's bad form to pin to an old version of TLS.
(cherry picked from commit e9edee0b65650c4f9db90cefc2e9a8125bad762c)

<!-- issue-number: bpo-32008 -->
https://bugs.python.org/issue32008
<!-- /issue-number -->
