### PR TITLE
[master] Add gmon.out to ignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ Tools/ssl/amd64
 Tools/ssl/win32
 .vs/
 .vscode/
+gmon.out


### PR DESCRIPTION
gmon.out is generated during build when configured using
--enable-profiling
