### PR TITLE
[master] Gitignore gmon.out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ Tools/ssl/amd64
 Tools/ssl/win32
 .vs/
 .vscode/
+gmon.out


### PR DESCRIPTION
gmon.out is generated when profiling turned on

Full Configuration:
./configure --prefix=$PWD/install --enable-profiling  --enable-big-digits=30
--with-pydebug --with-assertions  --with-valgrind