### PR TITLE
bpo-32898: Fix debug build crash with COUNT_ALLOCS

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -425,6 +425,7 @@ Tal Einat
 Eric Eisner
 Andrew Eland
 Julien Élie
+Eduardo Elizondo
 Lance Ellinghaus
 Daniel Ellis
 Phil Elson

--- a/Misc/NEWS.d/next/Build/2018-02-21-12-46-00.bpo-32898.M15bZh.rst
+++ b/Misc/NEWS.d/next/Build/2018-02-21-12-46-00.bpo-32898.M15bZh.rst
@@ -1,1 +1,1 @@
-Fix the python debug build when using COUNT_ALLOCS
+Fix the python debug build when using COUNT_ALLOCS.

--- a/Misc/NEWS.d/next/Build/2018-02-21-12-46-00.bpo-32898.M15bZh.rst
+++ b/Misc/NEWS.d/next/Build/2018-02-21-12-46-00.bpo-32898.M15bZh.rst
@@ -1,1 +1,1 @@
-Fix the debug python build when using COUNT_ALLOCS
+Fix the python debug build when using COUNT_ALLOCS

--- a/Misc/NEWS.d/next/Build/2018-02-21-12-46-00.bpo-32898.M15bZh.rst
+++ b/Misc/NEWS.d/next/Build/2018-02-21-12-46-00.bpo-32898.M15bZh.rst
@@ -1,0 +1,1 @@
+Fix the debug python build when using COUNT_ALLOCS

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -86,7 +86,7 @@ static void
 show_alloc(void)
 {
     PyInterpreterState *interp = PyThreadState_GET()->interp;
-    if (!inter->core_config.show_alloc_count) {
+    if (!interp->core_config.show_alloc_count) {
         return;
     }
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -97,10 +97,11 @@ void
 dump_counts(FILE* f)
 {
     PyInterpreterState *interp = PyThreadState_GET()->interp;
-    if (!inter->core_config.show_alloc_count) {
+    if (!interp->core_config.show_alloc_count) {
         return;
     }
 
+    PyTypeObject *tp;
     for (tp = type_list; tp; tp = tp->tp_next)
         fprintf(f, "%s alloc'd: %" PY_FORMAT_SIZE_T "d, "
             "freed: %" PY_FORMAT_SIZE_T "d, "

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -45,7 +45,7 @@ static void
 show_track(void)
 {
     PyInterpreterState *interp = PyThreadState_GET()->interp;
-    if (!inter->core_config.show_alloc_count) {
+    if (!interp->core_config.show_alloc_count) {
         return;
     }
 


### PR DESCRIPTION
The following build crashed:
mkdir debug && cd debug
../configure --with-pydebug
make EXTRA_CFLAGS="-DCOUNT_ALLOCS"

The bug was introduced in: https://github.com/python/cpython/commit/25420fe290b98171e6d30edf9350292c21ef700e

Fix:
1) s/inter/interp/
2) Declare PyTypeObject

<!-- issue-number: bpo-32898 -->
https://bugs.python.org/issue32898
<!-- /issue-number -->
