### PR TITLE
bpo-32903: Fix a memory leak in os.chdir() on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-02-28-11-03-24.bpo-32903.1SXY4t.rst
+++ b/Misc/NEWS.d/next/Windows/2018-02-28-11-03-24.bpo-32903.1SXY4t.rst
@@ -1,0 +1,2 @@
+Fix a memory leak in os.chdir() on Windows if the current directory is set
+to a UNC path.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1529,8 +1529,9 @@ win32_wchdir(LPCWSTR path)
             return FALSE;
         }
     }
-    int has_drive = (new_path[0] && new_path[1] == L':');
-    if (has_drive) {
+    int is_unc_like_path = (wcsncmp(new_path, L"\\\\", 2) == 0 ||
+                            wcsncmp(new_path, L"//", 2) == 0);
+    if (!is_unc_like_path) {
         env[1] = new_path[0];
         result = SetEnvironmentVariableW(env, new_path);
     }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1529,9 +1529,7 @@ win32_wchdir(LPCWSTR path)
             return FALSE;
         }
     }
-    int is_unc_path = (wcsncmp(new_path, L"\\\\", 2) == 0 ||
-                       wcsncmp(new_path, L"//", 2) == 0);
-    if (!is_unc_path) {
+    if (wcsncmp(new_path, L"\\\\", 2) != 0) {
         env[1] = new_path[0];
         result = SetEnvironmentVariableW(env, new_path);
     }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1529,14 +1529,12 @@ win32_wchdir(LPCWSTR path)
             return FALSE;
         }
     }
-
     int is_unc_path = (wcsncmp(new_path, L"\\\\", 2) == 0 ||
                        wcsncmp(new_path, L"//", 2) == 0);
     if (!is_unc_path) {
         env[1] = new_path[0];
         result = SetEnvironmentVariableW(env, new_path);
     }
-
     if (new_path != path_buf)
         PyMem_RawFree(new_path);
     return result;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1529,7 +1529,8 @@ win32_wchdir(LPCWSTR path)
             return FALSE;
         }
     }
-    if (wcsncmp(new_path, L"\\\\", 2) != 0) {
+    int has_drive = (new_path[0] && new_path[1] == L':');
+    if (has_drive) {
         env[1] = new_path[0];
         result = SetEnvironmentVariableW(env, new_path);
     }

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1505,7 +1505,7 @@ posix_fildes_fd(int fd, int (*func)(int))
    chdir is essentially a wrapper around SetCurrentDirectory; however,
    it also needs to set "magic" environment variables indicating
    the per-drive current directory, which are of the form =<drive>: */
-static BOOL __stdcall
+static int
 win32_wchdir(LPCWSTR path)
 {
     wchar_t path_buf[MAX_PATH], *new_path = path_buf;
@@ -1513,20 +1513,20 @@ win32_wchdir(LPCWSTR path)
     wchar_t env[4] = L"=x:";
 
     if(!SetCurrentDirectoryW(path))
-        return FALSE;
+        return 0;
     result = GetCurrentDirectoryW(Py_ARRAY_LENGTH(path_buf), new_path);
     if (!result)
-        return FALSE;
+        return 0;
     if (result > Py_ARRAY_LENGTH(path_buf)) {
         new_path = PyMem_RawMalloc(result * sizeof(wchar_t));
         if (!new_path) {
             SetLastError(ERROR_OUTOFMEMORY);
-            return FALSE;
+            return 0;
         }
         result = GetCurrentDirectoryW(result, new_path);
         if (!result) {
             PyMem_RawFree(new_path);
-            return FALSE;
+            return 0;
         }
     }
     if (wcsncmp(new_path, L"\\\\", 2) != 0) {

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1529,12 +1529,14 @@ win32_wchdir(LPCWSTR path)
             return FALSE;
         }
     }
-    if (wcsncmp(new_path, L"\\\\", 2) == 0 ||
-        wcsncmp(new_path, L"//", 2) == 0)
-        /* UNC path, nothing to do. */
-        return TRUE;
-    env[1] = new_path[0];
-    result = SetEnvironmentVariableW(env, new_path);
+
+    int is_unc_path = (wcsncmp(new_path, L"\\\\", 2) == 0 ||
+                       wcsncmp(new_path, L"//", 2) == 0);
+    if (!is_unc_path) {
+        env[1] = new_path[0];
+        result = SetEnvironmentVariableW(env, new_path);
+    }
+
     if (new_path != path_buf)
         PyMem_RawFree(new_path);
     return result;

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1535,7 +1535,7 @@ win32_wchdir(LPCWSTR path)
     }
     if (new_path != path_buf)
         PyMem_RawFree(new_path);
-    return result;
+    return result ? TRUE : FALSE;
 }
 #endif
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1505,7 +1505,7 @@ posix_fildes_fd(int fd, int (*func)(int))
    chdir is essentially a wrapper around SetCurrentDirectory; however,
    it also needs to set "magic" environment variables indicating
    the per-drive current directory, which are of the form =<drive>: */
-static int
+static BOOL __stdcall
 win32_wchdir(LPCWSTR path)
 {
     wchar_t path_buf[MAX_PATH], *new_path = path_buf;
@@ -1513,20 +1513,20 @@ win32_wchdir(LPCWSTR path)
     wchar_t env[4] = L"=x:";
 
     if(!SetCurrentDirectoryW(path))
-        return 0;
+        return FALSE;
     result = GetCurrentDirectoryW(Py_ARRAY_LENGTH(path_buf), new_path);
     if (!result)
-        return 0;
+        return FALSE;
     if (result > Py_ARRAY_LENGTH(path_buf)) {
         new_path = PyMem_RawMalloc(result * sizeof(wchar_t));
         if (!new_path) {
             SetLastError(ERROR_OUTOFMEMORY);
-            return 0;
+            return FALSE;
         }
         result = GetCurrentDirectoryW(result, new_path);
         if (!result) {
             PyMem_RawFree(new_path);
-            return 0;
+            return FALSE;
         }
     }
     if (wcsncmp(new_path, L"\\\\", 2) != 0) {


### PR DESCRIPTION


<!-- issue-number: bpo-32903 -->
https://bugs.python.org/issue32903
<!-- /issue-number -->
