### PR TITLE
bpo-32905: IDLE - remove unused code in pyparse module

### DIFF
--- a/Lib/idlelib/idle_test/test_pyparse.py
+++ b/Lib/idlelib/idle_test/test_pyparse.py
@@ -1,4 +1,7 @@
-"""Unittest for idlelib.pyparse.py."""
+"""Unittest for idlelib.pyparse.py.
+
+Coverage: 97%
+"""
 
 from collections import namedtuple
 import unittest
@@ -272,8 +275,6 @@ class PyParseTest(unittest.TestCase):
             )
 
         for test in tests:
-            # There is a bug where this is carried forward from last item.
-            p.lastopenbracketpos = None
             with self.subTest(string=test.string):
                 setstr(test.string)
                 study()
@@ -463,33 +464,6 @@ class PyParseTest(unittest.TestCase):
             with self.subTest(string=test.string):
                 setstr(test.string)
                 test.assert_(closer())
-
-    def test_get_last_open_bracket_pos(self):
-        eq = self.assertEqual
-        p = self.parser
-        setstr = p.set_str
-        openbracket = p.get_last_open_bracket_pos
-
-        TestInfo = namedtuple('TestInfo', ['string', 'position'])
-        tests = (
-            TestInfo('', None),
-            TestInfo('a\n', None),
-            TestInfo('# (\n', None),
-            TestInfo('""" (\n', None),
-            TestInfo('a = (1 + 2) - 5 *\\\n', None),
-            TestInfo('\n   def function1(self, a,\n', 17),
-            TestInfo('\n   def function1(self, a,  # End of line comment.\n', 17),
-            TestInfo('{)(]\n', None),
-            TestInfo('(((((((((()))))))\n', 2),
-            TestInfo('(((((((((())\n)))\n))\n', 2),
-            )
-
-        for test in tests:
-            # There is a bug where the value is carried forward from last item.
-            p.lastopenbracketpos = None
-            with self.subTest(string=test.string):
-                setstr(test.string)
-                eq(openbracket(), test.position)
 
     def test_get_last_stmt_bracketing(self):
         eq = self.assertEqual

--- a/Lib/idlelib/pyparse.py
+++ b/Lib/idlelib/pyparse.py
@@ -18,10 +18,6 @@ import sys
 (C_NONE, C_BACKSLASH, C_STRING_FIRST_LINE,
  C_STRING_NEXT_LINES, C_BRACKET) = range(5)
 
-if 0:   # for throwaway debugging output
-    def dump(*stuff):
-        sys.__stdout__.write(" ".join(map(str, stuff)) + "\n")
-
 # Find what looks like the start of a popular statement.
 
 _synchre = re.compile(r"""

--- a/Lib/idlelib/pyparse.py
+++ b/Lib/idlelib/pyparse.py
@@ -496,8 +496,7 @@ class Parser:
         # end while p < q:
 
         self.lastch = lastch
-        if stack:
-            self.lastopenbracketpos = stack[-1]
+        self.lastopenbracketpos = stack[-1] if stack else None
         self.stmt_bracketing = tuple(bracketing)
 
     def compute_bracket_indent(self):
@@ -620,22 +619,10 @@ class Parser:
         self._study2()
         return _closere(self.str, self.stmt_start) is not None
 
-    # XXX - is this used?
-    lastopenbracketpos = None
-
-    def get_last_open_bracket_pos(self):
-        "Return index of last open bracket or None."
-        self._study2()
-        return self.lastopenbracketpos
-
-    # XXX - is this used?
-    stmt_bracketing = None
-
     def get_last_stmt_bracketing(self):
-        """Return a tuple of the structure of the bracketing of the last
-        interesting statement.
+        """Return bracketing structure of the last interesting statement.
 
-        Tuple is in the format defined in _study2().
+        The returned tuple is in the format defined in _study2().
         """
         self._study2()
         return self.stmt_bracketing

--- a/Misc/NEWS.d/next/IDLE/2018-02-22-00-09-27.bpo-32905.VlXj0x.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-02-22-00-09-27.bpo-32905.VlXj0x.rst
@@ -1,0 +1,1 @@
+Pyparse: fix bad initializations and removed unused code.

--- a/Misc/NEWS.d/next/IDLE/2018-02-22-00-09-27.bpo-32905.VlXj0x.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-02-22-00-09-27.bpo-32905.VlXj0x.rst
@@ -1,1 +1,1 @@
-Pyparse: fix bad initializations and removed unused code.
+Remove unused code in pyparse module.


### PR DESCRIPTION


<!-- issue-number: bpo-32905 -->
https://bugs.python.org/issue32905
<!-- /issue-number -->
