### PR TITLE
bpo-32907: pathlib: Fix test_resolve_common failure on Windows

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1520,6 +1520,11 @@ class _BasePathTest(object):
             self._check_resolve_relative(p, P(BASE, 'foo', 'in', 'spam'), False)
         # Now create absolute symlinks
         d = tempfile.mkdtemp(suffix='-dirD')
+        # bpo-32907: Canonicalize the temporary directory path since
+        # it is used in comparisons with other canonicalized paths below.
+        # Use Path.resolve() instead of os.path.realpath() to ensure that
+        # symlinks and "short" (8.3) filenames are resolved on Windows.
+        d = str(P(d).resolve())
         self.addCleanup(support.rmtree, d)
         os.symlink(os.path.join(d), join('dirA', 'linkX'))
         os.symlink(join('dirB'), os.path.join(d, 'linkY'))

--- a/Misc/NEWS.d/next/Tests/2018-02-23-02-01-40.bpo-32907.kno5Ua.rst
+++ b/Misc/NEWS.d/next/Tests/2018-02-23-02-01-40.bpo-32907.kno5Ua.rst
@@ -1,0 +1,2 @@
+Fix test_pathlib to not fail if tempfile.mkdtemp() returns a non-canonical
+path.


### PR DESCRIPTION
Canonicalize the temporary directory path since it is used in comparisons with other canonicalized paths.

Use Path.resolve() instead of os.path.realpath() to ensure that symlinks and "short" (8.3) filenames are resolved on Windows.

<!-- issue-number: bpo-32907 -->
https://bugs.python.org/issue32907
<!-- /issue-number -->
