### PR TITLE
bpo-10381, bpo-32403: What's new entries for changes to datetime

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -909,6 +909,11 @@ Build and C API Changes
 * Support for building ``--without-threads`` is removed.
   (Contributed by Antoine Pitrou in :issue:`31370`.).
 
+* Added C API support for timezones with timezone constructors
+  :c:func:`PyTimeZone_FromOffset` and :c:func:`PyTimeZone_FromOffsetAndName`,
+  and access to the UTC singleton with :c:data:`PyDateTime_TimeZone_UTC`.
+  Contributed by Paul Ganssle in :issue:`10381`.
+
 
 Other CPython Implementation Changes
 ====================================

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -859,6 +859,11 @@ Optimizations
   start-up time by up to 10%. (Contributed by Ivan Levkivskyi and INADA Naoki
   in :issue:`31333`)
 
+* Significant speed improvements to alternate constructors for
+  :class:`datetime.date` and :class:`datetime.datetime` by using fast-path
+  constructors when not constructing subclasses. (Contributed by Paul Ganssle
+  in :issue:`32403`)
+
 Build and C API Changes
 =======================
 


### PR DESCRIPTION
This adds "What's New" entries for two datetime-related improvements I made in #4993 (bpo-32403) and #5032 (bpo-10381).

For the "optimizations" one, I was not sure how best to measure the improvement in speed but I just put "significant". My initial benchmarks suggest that some of the constructors have as much as 100% speed improvement, but none of that was done against an optimized build.

<!-- issue-number: bpo-10381 -->
https://bugs.python.org/issue10381
<!-- /issue-number -->
