### PR TITLE
bpo-32901: Update Tcl and Tk versions to 8.6.8

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-02-23-00-47-13.bpo-32901.mGKz5_.rst
+++ b/Misc/NEWS.d/next/Windows/2018-02-23-00-47-13.bpo-32901.mGKz5_.rst
@@ -1,0 +1,1 @@
+Update Tcl and Tk versions to 8.6.8

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -51,8 +51,8 @@ set libraries=
 set libraries=%libraries%                                       bzip2-1.0.6
 if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.0f
 set libraries=%libraries%                                       sqlite-3.21.0.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.6.0
-if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.6.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.8.0
+if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.8.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tix-8.4.3.6
 set libraries=%libraries%                                       xz-5.2.2
 set libraries=%libraries%                                       zlib-1.2.11
@@ -73,7 +73,7 @@ echo.Fetching external binaries...
 
 set binaries=
 if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.0f
-if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.6.0
+if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.8.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 
 for %%b in (%binaries%) do (

--- a/PCbuild/tcltk.props
+++ b/PCbuild/tcltk.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <TclMajorVersion>8</TclMajorVersion>
     <TclMinorVersion>6</TclMinorVersion>
-    <TclPatchLevel>6</TclPatchLevel>
+    <TclPatchLevel>8</TclPatchLevel>
     <TclRevision>0</TclRevision>
     <TkMajorVersion>$(TclMajorVersion)</TkMajorVersion>
     <TkMinorVersion>$(TclMinorVersion)</TkMinorVersion>


### PR DESCRIPTION
The new binaries are already published on the bin repo, but the sources are not there yet. The builds should still succeed for 3.7 and master.

<!-- issue-number: bpo-32901 -->
https://bugs.python.org/issue32901
<!-- /issue-number -->
