### PR TITLE
[2.7] bpo-30028: make test.support.temp_cwd() fork-safe (GH-1066)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -753,10 +753,14 @@ def temp_dir(path=None, quiet=False):
                 raise
             warnings.warn('tests may fail, unable to create temp dir: ' + path,
                           RuntimeWarning, stacklevel=3)
+    if dir_created:
+        pid = os.getpid()
     try:
         yield path
     finally:
-        if dir_created:
+        # In case the process forks, let only the parent remove the
+        # directory. The child has a diffent process id. (bpo-30028)
+        if dir_created and pid == os.getpid():
             rmtree(path)
 
 @contextlib.contextmanager

--- a/Lib/test/test_test_support.py
+++ b/Lib/test/test_test_support.py
@@ -6,8 +6,10 @@ import os
 import unittest
 import socket
 import tempfile
+import textwrap
 import errno
 from test import support
+from test.support import script_helper
 
 TESTFN = support.TESTFN
 
@@ -175,6 +177,34 @@ class TestSupport(unittest.TestCase):
 
         expected = ['tests may fail, unable to create temp dir: ' + path]
         self.assertEqual(warnings, expected)
+
+    @unittest.skipUnless(hasattr(os, "fork"), "test requires os.fork")
+    def test_temp_dir__forked_child(self):
+        """Test that a forked child process does not remove the directory."""
+        # See bpo-30028 for details.
+        # Run the test as an external script, because it uses fork.
+        script_helper.assert_python_ok("-c", textwrap.dedent("""
+            import os
+            from test import support
+            with support.temp_cwd() as temp_path:
+                pid = os.fork()
+                if pid != 0:
+                    # parent process (child has pid == 0)
+
+                    # wait for the child to terminate
+                    (pid, status) = os.waitpid(pid, 0)
+                    if status != 0:
+                        raise AssertionError("Child process failed with exit "
+                                             "status indication "
+                                             "0x{:x}.".format(status))
+
+                    # Make sure that temp_path is still present. When the child
+                    # process leaves the 'temp_cwd'-context, the __exit__()-
+                    # method of the context must not remove the temporary
+                    # directory.
+                    if not os.path.isdir(temp_path):
+                        raise AssertionError("Child removed temp_path.")
+        """))
 
     # Tests for change_cwd()
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -774,6 +774,7 @@ Pedro Kroger
 Hannu Krosing
 Andrej Krpic
 Ivan Krstić
+Anselm Kruis
 Steven Kryskalla
 Andrew Kuchling
 Dave Kuhlman


### PR DESCRIPTION
Make test.support.temp_cwd() fork-safe. The context manager test.support.temp_cwd() no longer removes the temporary directory when executing in a process other than the parent it entered from.
If a forked child exits the context manager it won't do the cleanup..
(cherry picked from commit 33dddac00ba8d9b72cf21b8698504077eb3c23ad)


<!-- issue-number: bpo-30028 -->
https://bugs.python.org/issue30028
<!-- /issue-number -->
