### PR TITLE
bpo-32923: Unittest doc: replace `whilst` with `while`

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -2316,7 +2316,7 @@ handling functionality within test frameworks.
 
    When called without arguments this function removes the control-c handler
    if it has been installed. This function can also be used as a test decorator
-   to temporarily remove the handler whilst the test is being executed::
+   to temporarily remove the handler while the test is being executed::
 
       @unittest.removeHandler
       def test_signal_handling(self):


### PR DESCRIPTION
`whilst` and `while` are both english words, `whilst` is not as commonly used.
This can be confusing to readers whose primary language is not english.


<!-- issue-number: bpo-32923 -->
https://bugs.python.org/issue32923
<!-- /issue-number -->
