### PR TITLE
Silence strncpy warning for gcc 8

### DIFF
--- a/Python/pystrtod.c
+++ b/Python/pystrtod.c
@@ -1060,8 +1060,8 @@ format_float_short(double d, char format_code,
         else {
             /* shouldn't get here: Gay's code should always return
                something starting with a digit, an 'I',  or 'N' */
-            strncpy(p, "ERR", 3);
-            /* p += 3; */
+            /* strncpy(p, "ERR", 3);
+               p += 3; */
             Py_UNREACHABLE();
         }
         goto exit;


### PR DESCRIPTION
The length in strncpy is one char too short and as a result it leads
to a build warning with gcc 8.  bump up the length by one to copy the
NULL char.