### PR TITLE
bpo-32912: Upgrade warning for invalid escape sequences from silent to non-silent

### DIFF
--- a/Lib/test/test_codecs.py
+++ b/Lib/test/test_codecs.py
@@ -1210,15 +1210,15 @@ class EscapeDecodeTest(unittest.TestCase):
         for i in range(97, 123):
             b = bytes([i])
             if b not in b'abfnrtvx':
-                with self.assertWarns(DeprecationWarning):
+                with self.assertWarns(SyntaxWarning):
                     check(b"\\" + b, b"\\" + b)
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarns(SyntaxWarning):
                 check(b"\\" + b.upper(), b"\\" + b.upper())
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(SyntaxWarning):
             check(br"\8", b"\\8")
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(SyntaxWarning):
             check(br"\9", b"\\9")
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(SyntaxWarning):
             check(b"\\\xfa", b"\\\xfa")
 
     def test_errors(self):
@@ -2482,16 +2482,16 @@ class UnicodeEscapeTest(unittest.TestCase):
         for i in range(97, 123):
             b = bytes([i])
             if b not in b'abfnrtuvx':
-                with self.assertWarns(DeprecationWarning):
+                with self.assertWarns(SyntaxWarning):
                     check(b"\\" + b, "\\" + chr(i))
             if b.upper() not in b'UN':
-                with self.assertWarns(DeprecationWarning):
+                with self.assertWarns(SyntaxWarning):
                     check(b"\\" + b.upper(), "\\" + chr(i-32))
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(SyntaxWarning):
             check(br"\8", "\\8")
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(SyntaxWarning):
             check(br"\9", "\\9")
-        with self.assertWarns(DeprecationWarning):
+        with self.assertWarns(SyntaxWarning):
             check(b"\\\xfa", "\\\xfa")
 
     def test_decode_errors(self):

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -618,7 +618,7 @@ non-important content
         self.assertEqual(f'2\x203', '2 3')
         self.assertEqual(f'\x203', ' 3')
 
-        with self.assertWarns(DeprecationWarning):  # invalid escape sequence
+        with self.assertWarns(SyntaxWarning):  # invalid escape sequence
             value = eval(r"f'\{6*7}'")
         self.assertEqual(value, '\\42')
         self.assertEqual(f'\\{6*7}', '\\42')

--- a/Lib/test/test_string_literals.py
+++ b/Lib/test/test_string_literals.py
@@ -109,18 +109,18 @@ class TestLiterals(unittest.TestCase):
         for b in range(1, 128):
             if b in b"""\n\r"'01234567NU\\abfnrtuvx""":
                 continue
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarns(SyntaxWarning):
                 self.assertEqual(eval(r"'\%c'" % b), '\\' + chr(b))
 
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+            warnings.simplefilter('always', category=SyntaxWarning)
             eval("'''\n\\z'''")
         self.assertEqual(len(w), 1)
         self.assertEqual(w[0].filename, '<string>')
         self.assertEqual(w[0].lineno, 2)
 
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('error', category=DeprecationWarning)
+            warnings.simplefilter('error', category=SyntaxWarning)
             with self.assertRaises(SyntaxError) as cm:
                 eval("'''\n\\z'''")
             exc = cm.exception
@@ -158,18 +158,18 @@ class TestLiterals(unittest.TestCase):
         for b in range(1, 128):
             if b in b"""\n\r"'01234567\\abfnrtvx""":
                 continue
-            with self.assertWarns(DeprecationWarning):
+            with self.assertWarns(SyntaxWarning):
                 self.assertEqual(eval(r"b'\%c'" % b), b'\\' + bytes([b]))
 
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('always', category=DeprecationWarning)
+            warnings.simplefilter('always', category=SyntaxWarning)
             eval("b'''\n\\z'''")
         self.assertEqual(len(w), 1)
         self.assertEqual(w[0].filename, '<string>')
         self.assertEqual(w[0].lineno, 2)
 
         with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter('error', category=DeprecationWarning)
+            warnings.simplefilter('error', category=SyntaxWarning)
             with self.assertRaises(SyntaxError) as cm:
                 eval("b'''\n\\z'''")
             exc = cm.exception

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1255,7 +1255,7 @@ PyObject *PyBytes_DecodeEscape(const char *s,
     if (result == NULL)
         return NULL;
     if (first_invalid_escape != NULL) {
-        if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+        if (PyErr_WarnFormat(PyExc_SyntaxWarning, 1,
                              "invalid escape sequence '\\%c'",
                              (unsigned char)*first_invalid_escape) < 0) {
             Py_DECREF(result);

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -6109,7 +6109,7 @@ PyUnicode_DecodeUnicodeEscape(const char *s,
     if (result == NULL)
         return NULL;
     if (first_invalid_escape != NULL) {
-        if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
+        if (PyErr_WarnFormat(PyExc_SyntaxWarning, 1,
                              "invalid escape sequence '\\%c'",
                              (unsigned char)*first_invalid_escape) < 0) {
             Py_DECREF(result);

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4158,11 +4158,11 @@ warn_invalid_escape_sequence(struct compiling *c, const node *n,
     if (msg == NULL) {
         return -1;
     }
-    if (PyErr_WarnExplicitObject(PyExc_DeprecationWarning, msg,
+    if (PyErr_WarnExplicitObject(PyExc_SyntaxWarning, msg,
                                    c->c_filename, LINENO(n),
                                    NULL, NULL) < 0)
     {
-        if (PyErr_ExceptionMatches(PyExc_DeprecationWarning)) {
+        if (PyErr_ExceptionMatches(PyExc_SyntaxWarning)) {
             const char *s;
 
             /* Replace the DeprecationWarning exception with a SyntaxError


### PR DESCRIPTION
What the title says. Properly tested and ready for 3.8!

<!-- issue-number: bpo-32912 -->
https://bugs.python.org/issue32912
<!-- /issue-number -->

:EDIT:

I don't know how to add a NEWS entry, but I have to go for now. I'll look into that tomorrow.
