### PR TITLE
bpo-32146: Add documentation about frozen executables on Unix

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -186,6 +186,13 @@ A library which wants to use a particular start method should probably
 use :func:`get_context` to avoid interfering with the choice of the
 library user.
 
+.. warning::
+
+   The ``'spawn'`` and ``'forkserver'`` start methods cannot currently
+   be used with "frozen" executables (i.e., binaries produced by
+   packages like **PyInstaller** and **cx_Freeze**) on Unix.
+   The ``'fork'`` start method does work.
+
 
 Exchanging objects between processes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Misc/NEWS.d/next/Library/2018-02-25-10-17-23.bpo-32146.xOzUFW.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-25-10-17-23.bpo-32146.xOzUFW.rst
@@ -1,0 +1,2 @@
+Document the interaction between frozen executables and the spawn and
+forkserver start methods in multiprocessing.


### PR DESCRIPTION
This PR adds a note to the `multiprocessing` module's documentation about using "frozen" executables with the `'spawn'` and `'forkserver'`start methods.

This patch simply documents that this should be avoided. I hope it can be applied to the docs for previous Python versions as well (at least 3.7?), as all versions since 3.4 suffer from the issue?

I previously proposed a patch for the problem in PR #5195, but I imagine that will need to be revised and updated for 3.8. 

<!-- issue-number: bpo-32146 -->
https://bugs.python.org/issue32146
<!-- /issue-number -->
