### PR TITLE
bpo-32931: fix macOS 10.9+ installer c++ compiler name

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -161,7 +161,7 @@ def getTargetCompilers():
         '10.5': ('gcc', 'g++'),
         '10.6': ('gcc', 'g++'),
     }
-    return target_cc_map.get(DEPTARGET, ('gcc', 'gcc++') )
+    return target_cc_map.get(DEPTARGET, ('gcc', 'g++') )
 
 CC, CXX = getTargetCompilers()
 


### PR DESCRIPTION


<!-- issue-number: bpo-32931 -->
https://bugs.python.org/issue32931
<!-- /issue-number -->
