### PR TITLE
bpo-31355: Travis-CI: re-enable macOS job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,15 @@ matrix:
         - python -m pip install sphinx~=1.6.1 blurb
       script:
         - make check suspicious html SPHINXOPTS="-q -W -j4"
+    - os: osx
+      language: c
+      compiler: clang
+      # Testing under macOS is optional until testing stability has been demonstrated.
+      env: OPTIONAL=true
+      before_install:
+        # Python 3 is needed for Argument Clinic and multissl
+        - brew install xz python3
+        - export PATH=$(brew --prefix)/bin:$(brew --prefix)/sbin:$PATH
     - os: linux
       language: c
       compiler: gcc
@@ -76,9 +85,9 @@ before_install:
   - set -e
   - |
       # Check short-circuit conditions
-      if [ "${TESTING}" != "docs" ]
+      if [[ "${TESTING}" != "docs" ]]
       then
-        if [ "$TRAVIS_PULL_REQUEST" = "false" ]
+        if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]
         then
           echo "Not a PR, doing full build."
         else
@@ -101,7 +110,7 @@ before_install:
 install:
   - |
       # Install OpenSSL as necessary
-      if [ "${TESTING}" != "docs" ]
+      if [[ "${TESTING}" != "docs" ]]
       then
         # clang complains about unused-parameter a lot, redirect stderr
         python3 Tools/ssl/multissltests.py --steps=library \

--- a/Tools/scripts/smelly.py
+++ b/Tools/scripts/smelly.py
@@ -27,6 +27,11 @@ def get_exported_symbols():
 def get_smelly_symbols(stdout):
     symbols = []
     ignored_symtypes = set()
+
+    allowed_prefixes = ('Py', '_Py')
+    if sys.platform == 'darwin':
+        allowed_prefixes += ('__Py',)
+
     for line in stdout.splitlines():
         # Split line '0000000000001b80 D PyTextIOWrapper_Type'
         if not line:
@@ -47,7 +52,7 @@ def get_smelly_symbols(stdout):
             continue
 
         symbol = parts[-1]
-        if symbol.startswith(('Py', '_Py')):
+        if symbol.startswith(allowed_prefixes):
             continue
         symbol = '%s (type: %s)' % (symbol, symtype)
         symbols.append(symbol)


### PR DESCRIPTION
The long build queues that plagued macOS builds on Travis seem to be a thing of the past now.


<!-- issue-number: bpo-31355 -->
https://bugs.python.org/issue31355
<!-- /issue-number -->
