### PR TITLE
[2.7] bpo-30622: Improve NPN support detection (GH-5859)

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1808,6 +1808,23 @@ successful call of :func:`~ssl.RAND_add`, :func:`~ssl.RAND_bytes` or
 :func:`~ssl.RAND_pseudo_bytes` is sufficient.
 
 
+.. ssl-libressl:
+
+LibreSSL support
+----------------
+
+LibreSSL is a fork of OpenSSL 1.0.1. The ssl module has limited support for
+LibreSSL. Some features are not available when the ssl module is compiled
+with LibreSSL.
+
+* LibreSSL >= 2.6.1 no longer supports NPN. The methods
+  :meth:`SSLContext.set_npn_protocols` and
+  :meth:`SSLSocket.selected_npn_protocol` are not available.
+* :meth:`SSLContext.set_default_verify_paths` ignores the env vars
+  :envvar:`SSL_CERT_FILE` and :envvar:`SSL_CERT_PATH` although
+  :func:`get_default_verify_paths` still reports them.
+
+
 .. seealso::
 
    Class :class:`socket.socket`

--- a/Misc/NEWS.d/next/Library/2018-02-24-21-40-42.bpo-30622.dQjxSe.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-24-21-40-42.bpo-30622.dQjxSe.rst
@@ -1,0 +1,1 @@
+The ssl module now detects missing NPN support in LibreSSL.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -122,6 +122,19 @@ struct py_ssl_library_code {
 # define HAVE_ALPN
 #endif
 
+/* We cannot rely on OPENSSL_NO_NEXTPROTONEG because LibreSSL 2.6.1 dropped
+ * NPN support but did not set OPENSSL_NO_NEXTPROTONEG for compatibility
+ * reasons. The check for TLSEXT_TYPE_next_proto_neg works with
+ * OpenSSL 1.0.1+ and LibreSSL.
+ */
+#ifdef OPENSSL_NO_NEXTPROTONEG
+#  define HAVE_NPN 0
+#elif defined(TLSEXT_TYPE_next_proto_neg)
+#  define HAVE_NPN 1
+#else
+#  define HAVE_NPN 0
+# endif
+
 #ifndef INVALID_SOCKET /* MS defines this */
 #define INVALID_SOCKET (-1)
 #endif
@@ -280,7 +293,7 @@ static unsigned int _ssl_locks_count = 0;
 typedef struct {
     PyObject_HEAD
     SSL_CTX *ctx;
-#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
+#ifdef HAVE_NPN
     unsigned char *npn_protocols;
     int npn_protocols_len;
 #endif
@@ -2157,7 +2170,7 @@ context_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
     self->ctx = ctx;
-#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
+#ifdef HAVE_NPN
     self->npn_protocols = NULL;
 #endif
 #ifdef HAVE_ALPN
@@ -2235,7 +2248,7 @@ context_dealloc(PySSLContext *self)
     PyObject_GC_UnTrack(self);
     context_clear(self);
     SSL_CTX_free(self->ctx);
-#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
+#ifdef HAVE_NPN
     PyMem_FREE(self->npn_protocols);
 #endif
 #ifdef HAVE_ALPN
@@ -2265,7 +2278,7 @@ set_ciphers(PySSLContext *self, PyObject *args)
     Py_RETURN_NONE;
 }
 
-#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG) || defined(HAVE_ALPN)
+#if defined(HAVE_NPN) || defined(HAVE_ALPN)
 static int
 do_protocol_selection(int alpn, unsigned char **out, unsigned char *outlen,
                       const unsigned char *server_protocols, unsigned int server_protocols_len,
@@ -2291,7 +2304,7 @@ do_protocol_selection(int alpn, unsigned char **out, unsigned char *outlen,
 }
 #endif
 
-#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
+#ifdef HAVE_NPN
 /* this callback gets passed to SSL_CTX_set_next_protos_advertise_cb */
 static int
 _advertiseNPN_cb(SSL *s,
@@ -2326,7 +2339,7 @@ _selectNPN_cb(SSL *s,
 static PyObject *
 _set_npn_protocols(PySSLContext *self, PyObject *args)
 {
-#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
+#ifdef HAVE_NPN
     Py_buffer protos;
 
     if (!PyArg_ParseTuple(args, "s*:set_npn_protocols", &protos))
@@ -4322,7 +4335,7 @@ init_ssl(void)
     Py_INCREF(r);
     PyModule_AddObject(m, "HAS_ECDH", r);
 
-#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
+#ifdef HAVE_NPN
     r = Py_True;
 #else
     r = Py_False;


### PR DESCRIPTION
The ssl module now detects missing NPN support in LibreSSL.

Co-Authored-By: Bernard Spil <brnrd@FreeBSD.org>
Signed-off-by: Christian Heimes <christian@python.org>.
(cherry picked from commit 6cdb7954b0a578d899e4b78b868ea59eef08480a)

Co-authored-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-30622 -->
https://bugs.python.org/issue30622
<!-- /issue-number -->
