### PR TITLE
[2.7] bpo-32647: Link ctypes extension with libdl. (GH-5550)

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-02-05-13-31-42.bpo-32647.ktmfR_.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-05-13-31-42.bpo-32647.ktmfR_.rst
@@ -1,0 +1,2 @@
+The ctypes module used to depend on indirect linking for dlopen. The shared
+extension is now explicitly linked against libdl on platforms with dl.

--- a/setup.py
+++ b/setup.py
@@ -2149,6 +2149,10 @@ class PyBuildExt(build_ext):
             ext.libraries.append(ffi_lib)
             self.use_system_libffi = True
 
+        if sysconfig.get_config_var('HAVE_LIBDL'):
+            # for dlopen, see bpo-32647
+            ext.libraries.append('dl')
+
     def _detect_nis(self, inc_dirs, lib_dirs):
         if host_platform in {'win32', 'cygwin', 'qnx6'}:
             return None


### PR DESCRIPTION
The ctypes module used to depend on indirect linking for dlopen. The shared
extension is now explicitly linked against libdl on platforms with dl.

Signed-off-by: Christian Heimes <christian@python.org>.
(cherry picked from commit 5bb9692575f10f4a7c7f1c2c0c70956baf6d5c23)

Co-authored-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.
If your PR is for issue 12345 in the bug tracker, then the bpo number is bpo-12345.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-32647 -->
https://bugs.python.org/issue32647
<!-- /issue-number -->
