### PR TITLE
Fix ssl module, Python 2.7 doesn't have Py_MAX

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -610,7 +610,8 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
         }
 #elif defined(HAVE_INET_PTON)
 #ifdef ENABLE_IPV6
-        char packed[Py_MAX(sizeof(struct in_addr), sizeof(struct in6_addr))];
+	#define PySSL_MAX(x, y) (((x) > (y)) ? (x) : (y))
+        char packed[PySSL_MAX(sizeof(struct in_addr), sizeof(struct in6_addr))];
 #else
         char packed[sizeof(struct in_addr)];
 #endif /* ENABLE_IPV6 */


### PR DESCRIPTION
a5c9112300ecd492ed6cc9759dc8028766401f61 broke _ssl module. I didn't notice the change because the test suite was still passing.

Signed-off-by: Christian Heimes <christian@python.org>
