### PR TITLE
bpo-28124: deprecate ssl.wrap_socket()

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -673,6 +673,11 @@ The ssl module has preliminary and experimental support for TLS 1.3 and
 OpenSSL 1.1.1. (Contributed by Christian Heimes in :issue:`32947`,
 :issue:`20995`, :issue:`29136`, and :issue:`30622`)
 
+:func:`~ssl.wrap_socket` is deprecated. Documentation has been updated to
+recommend :meth:`~ssl.SSLContext.wrap_socket` instead.
+(Contributed by Christian Heimes in :issue:`28124`.)
+
+
 string
 ------
 

--- a/Misc/NEWS.d/next/Documentation/2018-02-25-16-33-35.bpo-28124._uzkgq.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-02-25-16-33-35.bpo-28124._uzkgq.rst
@@ -1,0 +1,3 @@
+The ssl module function ssl.wrap_socket() has been de-emphasized
+and deprecated in favor of the more secure and efficient
+SSLContext.wrap_socket() method.


### PR DESCRIPTION
The ssl module function ssl.wrap_socket() has been de-emphasized
and deprecated in favor of the more secure and efficient
SSLContext.wrap_socket() method.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-28124 -->
https://bugs.python.org/issue28124
<!-- /issue-number -->
