### PR TITLE
[2.7] bpo-25059: Clarify the print separator usage in tutorial (GH-5879)

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -101,7 +101,7 @@ Here are two ways to write a table of squares and cubes::
    10 100 1000
 
 (Note that in the first example, one space between each column was added by the
-way :keyword:`print` works: it always adds spaces between its arguments.)
+way :keyword:`print` works: by default it adds spaces between its arguments.)
 
 This example demonstrates the :meth:`str.rjust` method of string
 objects, which right-justifies a string in a field of a given width by padding


### PR DESCRIPTION
By default `print` adds spaces between its arguments.

(cherry picked from commit 84c4b0cc67ceb4b70842b78c718b6e8214874d6a)




<!-- issue-number: bpo-25059 -->
https://bugs.python.org/issue25059
<!-- /issue-number -->
