### PR TITLE
bpo-32257: Add ssl.OP_NO_RENEGOTIATION

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -803,6 +803,15 @@ Constants
       The option is deprecated since OpenSSL 1.1.0. It was added to 2.7.15,
       3.6.3 and 3.7.0 for backwards compatibility with OpenSSL 1.0.2.
 
+.. data:: OP_NO_RENEGOTIATION
+
+   Disable all renegotiation in TLSv1.2 and earlier. Do not send
+   HelloRequest messages, and ignore renegotiation requests via ClientHello.
+
+   This option is only available with OpenSSL 1.1.0h and later.
+
+   .. versionadded:: 3.7
+
 .. data:: OP_CIPHER_SERVER_PREFERENCE
 
    Use the server's cipher ordering preference, rather than the client's.

--- a/Misc/NEWS.d/next/Library/2018-02-26-09-08-07.bpo-32257.6ElnUt.rst
+++ b/Misc/NEWS.d/next/Library/2018-02-26-09-08-07.bpo-32257.6ElnUt.rst
@@ -1,0 +1,2 @@
+The ssl module now contains OP_NO_RENEGOTIATION constant, available with
+OpenSSL 1.1.0h or 1.1.1.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5849,6 +5849,10 @@ PyInit__ssl(void)
     PyModule_AddIntConstant(m, "OP_ENABLE_MIDDLEBOX_COMPAT",
                             SSL_OP_ENABLE_MIDDLEBOX_COMPAT);
 #endif
+#ifdef SSL_OP_NO_RENEGOTIATION
+    PyModule_AddIntConstant(m, "OP_NO_RENEGOTIATION",
+                            SSL_OP_NO_RENEGOTIATION);
+#endif
 
 #ifdef X509_CHECK_FLAG_ALWAYS_CHECK_SUBJECT
     PyModule_AddIntConstant(m, "HOSTFLAG_ALWAYS_CHECK_SUBJECT",


### PR DESCRIPTION
The ssl module now contains OP_NO_RENEGOTIATION constant, available with
OpenSSL 1.1.0h or 1.1.1.

Note, OpenSSL 1.1.0h hasn't been released yet.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-32257 -->
https://bugs.python.org/issue32257
<!-- /issue-number -->
