### PR TITLE
bpo-26707: make plistlib read UID Key-Archive data

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -175,6 +175,21 @@ class Data:
 #
 
 
+class UID:
+    def __init__(self, data):
+        if not isinstance(data, int):
+            raise TypeError("data must be an int")
+        self.data = data
+
+    def __index__(self):
+        return self.data
+
+    def __repr__(self):
+        return "%s(%s)" % (self.__class__.__name__, repr(self.data))
+
+    def __reduce__(self):
+        return (self.__class__, (self.data, ))
+
 #
 # XML support
 #

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -202,6 +202,10 @@ PLISTHEADER = b"""\
 """
 
 
+# XML key for reading UID data
+_PLISTUIDKEY = 'CF$UID'
+
+
 # Regex to find any control chars, except for \t \n and \r
 _controlCharPat = re.compile(
     r"[\x00\x01\x02\x03\x04\x05\x06\x07\x08\x0b\x0c\x0e\x0f"
@@ -324,8 +328,8 @@ class _PlistParser:
             raise ValueError("missing value for key '%s' at line %d" %
                              (self.current_key,self.parser.CurrentLineNumber))
         last_dict = self.stack.pop()
-        if len(last_dict.keys()) == 1 and list(last_dict.keys())[0] == 'CF$UID':
-            uid = UID(last_dict['CF$UID'])
+        if len(last_dict.keys()) == 1 and list(last_dict.keys())[0] == _PLISTUIDKEY:
+            uid = UID(last_dict[_PLISTUIDKEY])
             if isinstance(self.stack[-1], type([])):
                 self.stack[-1][-1] = uid
             elif isinstance(self.stack[-1], type({})):
@@ -452,7 +456,7 @@ class _PlistWriter(_DumbXMLWriter):
             self.write_data(value)
 
         elif isinstance(value, UID):
-            self.write_dict({"CF$UID": value.data})
+            self.write_dict({_PLISTUIDKEY: value.data})
 
         elif isinstance(value, (bytes, bytearray)):
             self.write_bytes(value)

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -649,8 +649,9 @@ class _BinaryPlistParser:
             s = self._get_size(tokenL)
             result = self._fp.read(s * 2).decode('utf-16be')
 
-        # tokenH == 0x80 is documented as 'UID' and appears to be used for
-        # keyed-archiving, not in plists.
+        elif tokenH == 0x80:  # UID
+            # used by Key-Archiver plist files
+            result = int.from_bytes(self._fp.read(1 + tokenL), 'big')
 
         elif tokenH == 0xA0:  # array
             s = self._get_size(tokenL)

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -48,7 +48,7 @@ Parse Plist example:
 __all__ = [
     "readPlist", "writePlist", "readPlistFromBytes", "writePlistToBytes",
     "Data", "InvalidFileException", "FMT_XML", "FMT_BINARY",
-    "load", "dump", "loads", "dumps"
+    "load", "dump", "loads", "dumps", "UID"
 ]
 
 import binascii
@@ -666,7 +666,7 @@ class _BinaryPlistParser:
 
         elif tokenH == 0x80:  # UID
             # used by Key-Archiver plist files
-            result = int.from_bytes(self._fp.read(1 + tokenL), 'big')
+            result = UID(int.from_bytes(self._fp.read(1 + tokenL), 'big'))
 
         elif tokenH == 0xA0:  # array
             s = self._get_size(tokenL)

--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -442,6 +442,9 @@ class _PlistWriter(_DumbXMLWriter):
         elif isinstance(value, Data):
             self.write_data(value)
 
+        elif isinstance(value, UID):
+            self.write_dict({"CF$UID": value.data})
+
         elif isinstance(value, (bytes, bytearray)):
             self.write_bytes(value)
 
@@ -889,6 +892,9 @@ class _BinaryPlistWriter (object):
                 self._write_size(0x60, len(t) // 2)
 
             self._fp.write(t)
+
+        elif isinstance(value, UID):
+            self._fp.write(struct.pack('>BB', 0x80, value))
 
         elif isinstance(value, (list, tuple)):
             refs = [self._getrefnum(o) for o in value]

--- a/Misc/NEWS.d/next/Library/2018-03-03-11-35-07.bpo-26707.3bkRXz.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-03-11-35-07.bpo-26707.3bkRXz.rst
@@ -1,0 +1,3 @@
+Allow plistlib to read binary plist files that were created as a Key-Archive
+file. Specifically, this allows the binary reader to process 0x80 (UID)
+elements as integers.


### PR DESCRIPTION
Plistlib currently throws an exception when asked to decode a valid
.plist file that was generated by Apple's Key-Archiver. Specifically,
this is caused by a byte 0x80 (signifying a UID) not being read as an
integer.

<!-- issue-number: bpo-26707 -->
https://bugs.python.org/issue26707
<!-- /issue-number -->
