### PR TITLE
[3.7] bpo-17288: Prevent jumps from 'return' and 'exception' trace events

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -568,6 +568,10 @@ class JumpTracer:
     def trace(self, frame, event, arg):
         if self.done:
             return
+        # frame.f_code.co_firstlineno is the first line of the decorator when
+        # 'function' is decorated and the decorator may be written using
+        # multiple physical lines when it is too long. Use the first line
+        # trace event in 'function' to find the first line of 'function'.
         if (self.firstLine is None and frame.f_code == self.code and
                 event == 'line'):
             self.firstLine = frame.f_lineno - 1
@@ -577,6 +581,8 @@ class JumpTracer:
             while f is not None and f.f_code != self.code:
                 f = f.f_back
             if f is not None:
+                # Cope with non-integer self.jumpTo (because of
+                # no_jump_to_non_integers below).
                 try:
                     frame.f_lineno = self.firstLine + self.jumpTo
                 except TypeError:

--- a/Misc/NEWS.d/next/Core and Builtins/2018-02-27-13-36-21.bpo-17288.Gdj24S.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-02-27-13-36-21.bpo-17288.Gdj24S.rst
@@ -1,0 +1,1 @@
+Prevent jumps from 'return' and 'exception' trace events.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -59,6 +59,9 @@ frame_getlineno(PyFrameObject *f, void *closure)
  *  o 'try'/'for'/'while' blocks can't be jumped into because the blockstack
  *    needs to be set up before their code runs, and for 'for' loops the
  *    iterator needs to be on the stack.
+ *  o Jumps cannot be made from within a trace function invoked with a
+ *    'return' or 'exception' event since the eval loop has been exited at
+ *    that time.
  */
 static int
 frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno)
@@ -94,13 +97,34 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno)
         return -1;
     }
 
+    /* Upon the 'call' trace event of a new frame, f->f_lasti is -1 and
+     * f->f_trace is NULL, check first on the first condition.
+     * Forbidding jumps from the 'call' event of a new frame is a side effect
+     * of allowing to set f_lineno only from trace functions. */
+    if (f->f_lasti == -1)
+    {
+        PyErr_Format(PyExc_ValueError,
+                     "can't jump from the 'call' trace event of a new frame");
+        return -1;
+    }
+
     /* You can only do this from within a trace function, not via
      * _getframe or similar hackery. */
     if (!f->f_trace)
     {
         PyErr_Format(PyExc_ValueError,
-                     "f_lineno can only be set by a"
-                     " line trace function");
+                     "f_lineno can only be set by a trace function");
+        return -1;
+    }
+
+    /* Forbid jumps upon a 'return' trace event (except after executing a
+     * YIELD_VALUE or YIELD_FROM opcode, f_stacktop is not NULL in that case)
+     * and upon an 'exception' trace event.
+     * Jumps from 'call' trace events have already been forbidden above for new
+     * frames, so this check does not change anything for 'call' events. */
+    if (f->f_stacktop == NULL) {
+        PyErr_SetString(PyExc_ValueError,
+                "can only jump from a 'line' trace event");
         return -1;
     }
 
@@ -159,6 +183,16 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno)
 
     /* We're now ready to look at the bytecode. */
     PyBytes_AsStringAndSize(f->f_code->co_code, (char **)&code, &code_len);
+
+    /* The trace function is called with a 'return' trace event after the
+     * execution of a yield statement. */
+    assert(f->f_lasti != -1);
+    if (code[f->f_lasti] == YIELD_VALUE || code[f->f_lasti] == YIELD_FROM) {
+        PyErr_SetString(PyExc_ValueError,
+                "can't jump from a yield statement");
+        return -1;
+    }
+
     min_addr = Py_MIN(new_lasti, f->f_lasti);
     max_addr = Py_MAX(new_lasti, f->f_lasti);
 

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -101,8 +101,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno)
      * f->f_trace is NULL, check first on the first condition.
      * Forbidding jumps from the 'call' event of a new frame is a side effect
      * of allowing to set f_lineno only from trace functions. */
-    if (f->f_lasti == -1)
-    {
+    if (f->f_lasti == -1) {
         PyErr_Format(PyExc_ValueError,
                      "can't jump from the 'call' trace event of a new frame");
         return -1;
@@ -110,8 +109,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno)
 
     /* You can only do this from within a trace function, not via
      * _getframe or similar hackery. */
-    if (!f->f_trace)
-    {
+    if (!f->f_trace) {
         PyErr_Format(PyExc_ValueError,
                      "f_lineno can only be set by a trace function");
         return -1;


### PR DESCRIPTION


<!-- issue-number: bpo-17288 -->
https://bugs.python.org/issue17288
<!-- /issue-number -->
