### PR TITLE
Fixed logging library doc typo

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -328,7 +328,7 @@ is the module's name in the Python package namespace.
       .. versionadded:: 3.2
 
    .. versionchanged:: 3.7
-      Loggers can now be picked and unpickled.
+      Loggers can now be pickled and unpickled.
 
 .. _levels:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
On line 331 of the documentation for the logging library, the typo "picked" has been changed to "pickled".