### PR TITLE
[2.7] bpo-32903: Fix a memory leak in os.chdir() on Windows (GH-5801).

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-02-28-11-03-24.bpo-32903.1SXY4t.rst
+++ b/Misc/NEWS.d/next/Windows/2018-02-28-11-03-24.bpo-32903.1SXY4t.rst
@@ -1,0 +1,2 @@
+Fix a memory leak in os.chdir() on Windows if the current directory is set
+to a UNC path.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -1002,15 +1002,15 @@ win32_wchdir(LPCWSTR path)
             return FALSE;
         }
     }
-    if (wcsncmp(new_path, L"\\\\", 2) == 0 ||
-        wcsncmp(new_path, L"//", 2) == 0)
-        /* UNC path, nothing to do. */
-        return TRUE;
-    env[1] = new_path[0];
-    result = SetEnvironmentVariableW(env, new_path);
+    int is_unc_like_path = (wcsncmp(new_path, L"\\\\", 2) == 0 ||
+                            wcsncmp(new_path, L"//", 2) == 0);
+    if (!is_unc_like_path) {
+        env[1] = new_path[0];
+        result = SetEnvironmentVariableW(env, new_path);
+    }
     if (new_path != _new_path)
         free(new_path);
-    return result;
+    return result ? TRUE : FALSE;
 }
 #endif
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -984,6 +984,7 @@ win32_wchdir(LPCWSTR path)
     wchar_t _new_path[MAX_PATH+1], *new_path = _new_path;
     int result;
     wchar_t env[4] = L"=x:";
+    int is_unc_like_path;
 
     if(!SetCurrentDirectoryW(path))
         return FALSE;
@@ -1002,8 +1003,8 @@ win32_wchdir(LPCWSTR path)
             return FALSE;
         }
     }
-    int is_unc_like_path = (wcsncmp(new_path, L"\\\\", 2) == 0 ||
-                            wcsncmp(new_path, L"//", 2) == 0);
+    is_unc_like_path = (wcsncmp(new_path, L"\\\\", 2) == 0 ||
+                        wcsncmp(new_path, L"//", 2) == 0);
     if (!is_unc_like_path) {
         env[1] = new_path[0];
         result = SetEnvironmentVariableW(env, new_path);


### PR DESCRIPTION
(cherry picked from commit 3e197c7a6740d564ad52fb7901c07d5ff49460f5)

Co-authored-by: Alexey Izbyshev <izbyshev@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-32903 -->
https://bugs.python.org/issue32903
<!-- /issue-number -->
