### PR TITLE
bpo-32978: Fix reading huge floats in AIFC files.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-03-01-18-51-58.bpo-32978.3puyyP.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-01-18-51-58.bpo-32978.3puyyP.rst
@@ -1,1 +1,3 @@
-Fixed reading huge floats in AIFC files.
+Fixed reading huge floats in AIFC files. :func:`aifc.open` no longer raises
+OverflowError.
+

--- a/Misc/NEWS.d/next/Library/2018-03-01-18-51-58.bpo-32978.3puyyP.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-01-18-51-58.bpo-32978.3puyyP.rst
@@ -1,0 +1,1 @@
+Fixed reading huge floats in AIFC files.


### PR DESCRIPTION


<!-- issue-number: bpo-32978 -->
https://bugs.python.org/issue32978
<!-- /issue-number -->
