### PR TITLE
bpo-32981: Fix catastrophic backtracking vulns

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1083,7 +1083,7 @@ class Differ:
 
 import re
 
-def IS_LINE_JUNK(line, pat=re.compile(r"\s*#?\s*$").match):
+def IS_LINE_JUNK(line, pat=re.compile(r"\s*(?:#\s*)?$").match):
     r"""
     Return 1 for ignorable line: iff `line` is blank or contains a single '#'.
 

--- a/Lib/poplib.py
+++ b/Lib/poplib.py
@@ -308,7 +308,7 @@ class POP3:
         return self._shortcmd('RPOP %s' % user)
 
 
-    timestamp = re.compile(br'\+OK.*(<[^>]+>)')
+    timestamp = re.compile(br'\+OK.[^<]*(<.*>)')
 
     def apop(self, user, password):
         """Authorisation

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -466,13 +466,33 @@ class TestBytes(unittest.TestCase):
             list(generator(*args))
         self.assertEqual(msg, str(ctx.exception))
 
+class TestJunkAPIs(unittest.TestCase):
+    def test_is_line_junk_true(self):
+        for line in ['#', '  ', ' #', '# ', ' # ', '']:
+            self.assertTrue(difflib.IS_LINE_JUNK(line), 'should be junk: {}'.format(line))
+
+    def test_is_line_junk_false(self):
+        for line in ['##', ' ##', '## ', 'abc ', 'abc #', 'abc # ', 'Mr. Moose is up!']:
+            self.assertFalse(difflib.IS_LINE_JUNK(line), 'should not be junk: {}'.format(line))
+
+    def test_is_line_junk_REDOS(self):
+        evil_input = ('\t' * 1000000) + '##'
+        self.assertFalse(difflib.IS_LINE_JUNK(evil_input))
+
+    def test_is_character_junk_true(self):
+        for char in [' ', '\t']:
+            self.assertTrue(difflib.IS_CHARACTER_JUNK(char), 'should be junk: {}'.format(char))
+
+    def test_is_character_junk_false(self):
+        for char in ['a', '#', '\n', '\f', '\r', '\v']:
+            self.assertFalse(difflib.IS_CHARACTER_JUNK(char), 'should not be junk: {}'.format(char))
 
 def test_main():
     difflib.HtmlDiff._default_prefix = 0
     Doctests = doctest.DocTestSuite(difflib)
     run_unittest(
         TestWithAscii, TestAutojunk, TestSFpatches, TestSFbugs,
-        TestOutputFormat, TestBytes, Doctests)
+        TestOutputFormat, TestBytes, TestJunkAPIs, Doctests)
 
 if __name__ == '__main__':
     test_main()

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -469,11 +469,11 @@ class TestBytes(unittest.TestCase):
 class TestJunkAPIs(unittest.TestCase):
     def test_is_line_junk_true(self):
         for line in ['#', '  ', ' #', '# ', ' # ', '']:
-            self.assertTrue(difflib.IS_LINE_JUNK(line), 'should be junk: {}'.format(line))
+            self.assertTrue(difflib.IS_LINE_JUNK(line), repr(line))
 
     def test_is_line_junk_false(self):
-        for line in ['##', ' ##', '## ', 'abc ', 'abc #', 'abc # ', 'Mr. Moose is up!']:
-            self.assertFalse(difflib.IS_LINE_JUNK(line), 'should not be junk: {}'.format(line))
+        for line in ['##', ' ##', '## ', 'abc ', 'abc #', 'Mr. Moose is up!']:
+            self.assertFalse(difflib.IS_LINE_JUNK(line), repr(line))
 
     def test_is_line_junk_REDOS(self):
         evil_input = ('\t' * 1000000) + '##'
@@ -481,11 +481,11 @@ class TestJunkAPIs(unittest.TestCase):
 
     def test_is_character_junk_true(self):
         for char in [' ', '\t']:
-            self.assertTrue(difflib.IS_CHARACTER_JUNK(char), 'should be junk: {}'.format(char))
+            self.assertTrue(difflib.IS_CHARACTER_JUNK(char), repr(char))
 
     def test_is_character_junk_false(self):
         for char in ['a', '#', '\n', '\f', '\r', '\v']:
-            self.assertFalse(difflib.IS_CHARACTER_JUNK(char), 'should not be junk: {}'.format(char))
+            self.assertFalse(difflib.IS_CHARACTER_JUNK(char), repr(char))
 
 def test_main():
     difflib.HtmlDiff._default_prefix = 0

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -306,8 +306,18 @@ class TestPOP3Class(TestCase):
     def test_rpop(self):
         self.assertOK(self.client.rpop('foo'))
 
-    def test_apop(self):
+    def test_apop_normal(self):
         self.assertOK(self.client.apop('foo', 'dummypassword'))
+
+    def test_apop_REDOS(self):
+        # Replace welcome with very long evil welcome.
+        # NB The upper bound on welcome length is currently 2048.
+        # At this length, evil input makes each apop call take
+        # on the order of milliseconds instead of microseconds.
+        evil_welcome = b'+OK' + (b'<' * 1000000)
+        with test_support.swap_attr(self.client, 'welcome', evil_welcome):
+            # The evil welcome is invalid, so apop should throw.
+            self.assertRaises(poplib.error_proto, self.client.apop, 'arthur', 'kingofbritons')
 
     def test_top(self):
         expected =  (b'+OK 116 bytes',

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -317,7 +317,7 @@ class TestPOP3Class(TestCase):
         evil_welcome = b'+OK' + (b'<' * 1000000)
         with test_support.swap_attr(self.client, 'welcome', evil_welcome):
             # The evil welcome is invalid, so apop should throw.
-            self.assertRaises(poplib.error_proto, self.client.apop, 'arthur', 'kingofbritons')
+            self.assertRaises(poplib.error_proto, self.client.apop, 'a', 'kb')
 
     def test_top(self):
         expected =  (b'+OK 116 bytes',

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -356,6 +356,7 @@ Jonathan Dasteel
 Pierre-Yves David
 A. Jesse Jiryu Davis
 Jake Davis
+Jamie (James C.) Davis
 Ratnadeep Debnath
 Merlijn van Deen
 John DeGood

--- a/Misc/NEWS.d/next/Security/2018-03-02-10-24-52.bpo-32981.O_qDyj.rst
+++ b/Misc/NEWS.d/next/Security/2018-03-02-10-24-52.bpo-32981.O_qDyj.rst
@@ -1,0 +1,4 @@
+Regexes in difflib and poplib were vulnerable to catastrophic backtracking.
+These regexes formed potential DOS vectors (REDOS). They have been
+refactored. This resolves CVE-2018-1060 and CVE-2018-1061.
+Patch by Jamie Davis.


### PR DESCRIPTION
Fix catastrophic backtracking vulns disclosed by email.
- CVE-2018-1060
- CVE-2018-1061

<!-- issue-number: bpo-32981 -->
https://bugs.python.org/issue32981
<!-- /issue-number -->
