### PR TITLE
bpo-32986: multiprocessing: change default pool size to look for NCPUS envvar be…

### DIFF
--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -164,7 +164,10 @@ class Pool(object):
         self._initargs = initargs
 
         if processes is None:
-            processes = os.cpu_count() or 1
+            try:
+                processes = int(os.environ["NCPUS"])
+            except:
+                processes = os.cpu_count() or 1
         if processes < 1:
             raise ValueError("Number of processes must be at least 1")
 

--- a/Misc/NEWS.d/next/Library/2018-03-05-14-00-00.bpo-32986.gRq6Ht.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-05-14-00-00.bpo-32986.gRq6Ht.rst
@@ -1,0 +1,2 @@
+Multiprocessing now looks to the environment variable NCPUS for default
+pool size, before falling-back to os.cpu_count()


### PR DESCRIPTION
bpo-32986  multiprocessing: change default pool size determination 

bpo-32986 : change multiprocessing's default Pool size determination to check for value of "NCPUS" environment variable before falling back to os.cpu_count()


<!-- issue-number: bpo-32986 -->
https://bugs.python.org/issue32986
<!-- /issue-number -->
