### PR TITLE
bpo-32963: Fix the tutorial to state source has a default encoding of ASCII

### DIFF
--- a/Doc/tutorial/interpreter.rst
+++ b/Doc/tutorial/interpreter.rst
@@ -126,14 +126,7 @@ The Interpreter and Its Environment
 Source Code Encoding
 --------------------
 
-By default, Python source files are treated as encoded in UTF-8.  In that
-encoding, characters of most languages in the world can be used simultaneously
-in string literals, identifiers and comments --- although the standard library
-only uses ASCII characters for identifiers, a convention that any portable code
-should follow.  To display all these characters properly, your editor must
-recognize that the file is UTF-8, and it must use a font that supports all the
-characters in the file.
-
+By default, Python source files are treated as encoded in ASCII.
 To declare an encoding other than the default one, a special comment line
 should be added as the *first* line of the file.  The syntax is as follows::
 


### PR DESCRIPTION


<!-- issue-number: bpo-32963 -->
https://bugs.python.org/issue32963
<!-- /issue-number -->
