### PR TITLE
bpo-28124: clarify the two wrap_socket() are different

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -673,8 +673,8 @@ The ssl module has preliminary and experimental support for TLS 1.3 and
 OpenSSL 1.1.1. (Contributed by Christian Heimes in :issue:`32947`,
 :issue:`20995`, :issue:`29136`, and :issue:`30622`)
 
-:func:`~ssl.wrap_socket` is deprecated. Documentation has been updated to
-recommend :meth:`~ssl.SSLContext.wrap_socket` instead.
+:func:`ssl.wrap_socket` is deprecated. Documentation has been updated to
+recommend :meth:`ssl.SSLContext.wrap_socket` instead.
 (Contributed by Christian Heimes in :issue:`28124`.)
 
 :class:`~ssl.SSLSocket` and :class:`~ssl.SSLObject` no longer have a public


### PR DESCRIPTION
It looks confusing to say "wrap_socket() is deprecated. Documentation has been updated to recommend wrap_socket() instead." I removed "~" to show the full name of function/method.

Note that I didn't create an issue for this but refer to the original issue number. 

<!-- issue-number: bpo-28124 -->
https://bugs.python.org/issue28124
<!-- /issue-number -->
