### PR TITLE
Fix missing coroutine declaration in the asyncio documentation.

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -682,7 +682,7 @@ Task functions
 
    This function is a :ref:`coroutine <coroutine>`.
 
-.. function:: shield(arg, \*, loop=None)
+.. coroutinefunction:: shield(arg, \*, loop=None)
 
    Wait for a future, shielding it from cancellation.
 


### PR DESCRIPTION
It's a simple fix to add a missing "coroutine" function descriptor in the asyncio docs.

