### PR TITLE
bpo-32933: Implement dunder iter method on mock_open

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2136,7 +2136,6 @@ And for reading files:
     >>> assert result == 'bibble'
 
 
-
 .. _auto-speccing:
 
 Autospeccing

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2095,6 +2095,10 @@ mock_open
    .. versionchanged:: 3.5
       *read_data* is now reset on each call to the *mock*.
 
+   .. versionchanged:: 3.8
+      Added :meth:`__iter__` to implementation so that iteration (such as in for
+      loops) correctly consumes *read_data*.
+
 Using :func:`open` as a context manager is a great way to ensure your file handles
 are closed properly and is becoming common::
 
@@ -2130,6 +2134,7 @@ And for reading files:
     ...
     >>> m.assert_called_once_with('foo')
     >>> assert result == 'bibble'
+
 
 
 .. _auto-speccing:

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2387,6 +2387,7 @@ def mock_open(mock=None, read_data=''):
     _state[1] = _readline_side_effect()
     handle.readline.side_effect = _state[1]
     handle.readlines.side_effect = _readlines_side_effect
+    handle.__iter__.side_effect = _readline_side_effect
 
     def reset_data(*args, **kwargs):
         _state[0] = _iterate_read_data(read_data)

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2364,6 +2364,12 @@ def mock_open(mock=None, read_data=''):
         while True:
             yield type(read_data)()
 
+    def _iter_side_effect():
+        if handle.readline.return_value is not None:
+            while True:
+                yield handle.readline.return_value
+        for line in _state[0]:
+            yield line
 
     global file_spec
     if file_spec is None:
@@ -2387,7 +2393,7 @@ def mock_open(mock=None, read_data=''):
     _state[1] = _readline_side_effect()
     handle.readline.side_effect = _state[1]
     handle.readlines.side_effect = _readlines_side_effect
-    handle.__iter__.side_effect = _readline_side_effect
+    handle.__iter__.side_effect = _iter_side_effect
 
     def reset_data(*args, **kwargs):
         _state[0] = _iterate_read_data(read_data)

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -2356,11 +2356,7 @@ def mock_open(mock=None, read_data=''):
         return type(read_data)().join(_state[0])
 
     def _readline_side_effect():
-        if handle.readline.return_value is not None:
-            while True:
-                yield handle.readline.return_value
-        for line in _state[0]:
-            yield line
+        yield from _iter_side_effect()
         while True:
             yield type(read_data)()
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1455,7 +1455,7 @@ class MockTest(unittest.TestCase):
         f1 = mocked_open('a-name')
         lines = [line for line in f1]
         self.assertEqual(lines[0], 'Remarkable\n')
-        self.assertEqual(lines[1], 'Norwegian Blue\n')
+        self.assertEqual(lines[1], 'Norwegian Blue')
 
     def test_mock_open_write(self):
         # Test exception in file writing write()

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1450,7 +1450,8 @@ class MockTest(unittest.TestCase):
         f2_data = f2.read()
         self.assertEqual(f1_data, f2_data)
 
-    def test_mock_open_dunder_iter_issue_32933(self):
+    def test_mock_open_dunder_iter_issue(self):
+        """Test dunder_iter method generates the expected result and consumes the iterator"""
         mocked_open = mock.mock_open(read_data='Remarkable\nNorwegian Blue')
         f1 = mocked_open('a-name')
         lines = [line for line in f1]

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1451,12 +1451,14 @@ class MockTest(unittest.TestCase):
         self.assertEqual(f1_data, f2_data)
 
     def test_mock_open_dunder_iter_issue(self):
-        """Test dunder_iter method generates the expected result and consumes the iterator"""
+        # Test dunder_iter method generates the expected result and
+        # consumes the iterator.
         mocked_open = mock.mock_open(read_data='Remarkable\nNorwegian Blue')
         f1 = mocked_open('a-name')
         lines = [line for line in f1]
         self.assertEqual(lines[0], 'Remarkable\n')
         self.assertEqual(lines[1], 'Norwegian Blue')
+        self.assertEqual(list(f1), [])
 
     def test_mock_open_write(self):
         # Test exception in file writing write()

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1454,8 +1454,8 @@ class MockTest(unittest.TestCase):
         mocked_open = mock.mock_open(read_data='Remarkable Bird\nThe Norwegian Blue\nBeautiful Plumage')
         f1 = mocked_open('a-name')
         lines = [line for line in f1]
-        self.assertEqual(lines[0], 'Remarkable Bird')
-        self.assertEqual(lines[1], 'The Norwegian Blue')
+        self.assertEqual(lines[0], 'Remarkable Bird\n')
+        self.assertEqual(lines[1], 'The Norwegian Blue\n')
         self.assertEqual(lines[2], 'Beautiful Plumage')
 
     def test_mock_open_write(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1451,12 +1451,11 @@ class MockTest(unittest.TestCase):
         self.assertEqual(f1_data, f2_data)
 
     def test_mock_open_dunder_iter_issue_32933(self):
-        mocked_open = mock.mock_open(read_data='Remarkable Bird\nThe Norwegian Blue\nBeautiful Plumage')
+        mocked_open = mock.mock_open(read_data='Remarkable\nNorwegian Blue')
         f1 = mocked_open('a-name')
         lines = [line for line in f1]
-        self.assertEqual(lines[0], 'Remarkable Bird\n')
-        self.assertEqual(lines[1], 'The Norwegian Blue\n')
-        self.assertEqual(lines[2], 'Beautiful Plumage')
+        self.assertEqual(lines[0], 'Remarkable\n')
+        self.assertEqual(lines[1], 'Norwegian Blue\n')
 
     def test_mock_open_write(self):
         # Test exception in file writing write()

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1450,6 +1450,14 @@ class MockTest(unittest.TestCase):
         f2_data = f2.read()
         self.assertEqual(f1_data, f2_data)
 
+    def test_mock_open_dunder_iter_issue_32933(self):
+        mocked_open = mock.mock_open(read_data='Remarkable Bird\nThe Norwegian Blue\nBeautiful Plumage')
+        f1 = mocked_open('a-name')
+        lines = [line for line in f1]
+        self.assertEqual(lines[0], 'Remarkable Bird')
+        self.assertEqual(lines[1], 'The Norwegian Blue')
+        self.assertEqual(lines[2], 'Beautiful Plumage')
+
     def test_mock_open_write(self):
         # Test exception in file writing write()
         mock_namedtemp = mock.mock_open(mock.MagicMock(name='JLV'))

--- a/Lib/unittest/test/testmock/testwith.py
+++ b/Lib/unittest/test/testmock/testwith.py
@@ -188,6 +188,7 @@ class TestMockOpen(unittest.TestCase):
 
     def test_readline_data(self):
         # Check that readline will return all the lines from the fake file
+        # And that once fully consumed, readline will return an empty string.
         mock = mock_open(read_data='foo\nbar\nbaz\n')
         with patch('%s.open' % __name__, mock, create=True):
             h = open('bar')
@@ -197,6 +198,7 @@ class TestMockOpen(unittest.TestCase):
         self.assertEqual(line1, 'foo\n')
         self.assertEqual(line2, 'bar\n')
         self.assertEqual(line3, 'baz\n')
+        self.assertEqual(h.readline(),'')
 
         # Check that we properly emulate a file that doesn't end in a newline
         mock = mock_open(read_data='foo')
@@ -204,10 +206,11 @@ class TestMockOpen(unittest.TestCase):
             h = open('bar')
             result = h.readline()
         self.assertEqual(result, 'foo')
-
+        self.assertEqual(h.readline(),'')
+      
+    
     def test_dunder_iter_data(self):
         # Check that dunder_iter will return all the lines from the fake file
-        # Added to test Issue 32933
         mock = mock_open(read_data='foo\nbar\nbaz\n')
         with patch('%s.open' % __name__, mock, create=True):
             h = open('bar')
@@ -215,13 +218,7 @@ class TestMockOpen(unittest.TestCase):
         self.assertEqual(lines[0], 'foo\n')
         self.assertEqual(lines[1], 'bar\n')
         self.assertEqual(lines[2], 'baz\n')
-
-        # Check that we properly emulate a file that doesn't end in a newline
-        mock = mock_open(read_data='foo')
-        with patch('%s.open' % __name__, mock, create=True):
-            h = open('bar')
-            result = h.readline()
-        self.assertEqual(result, 'foo')
+        self.assertEqual(h.readline(),'')
 
 
     def test_readlines_data(self):

--- a/Lib/unittest/test/testmock/testwith.py
+++ b/Lib/unittest/test/testmock/testwith.py
@@ -198,7 +198,7 @@ class TestMockOpen(unittest.TestCase):
         self.assertEqual(line1, 'foo\n')
         self.assertEqual(line2, 'bar\n')
         self.assertEqual(line3, 'baz\n')
-        self.assertEqual(h.readline(),'')
+        self.assertEqual(h.readline(), '')
 
         # Check that we properly emulate a file that doesn't end in a newline
         mock = mock_open(read_data='foo')
@@ -206,11 +206,11 @@ class TestMockOpen(unittest.TestCase):
             h = open('bar')
             result = h.readline()
         self.assertEqual(result, 'foo')
-        self.assertEqual(h.readline(),'')
+        self.assertEqual(h.readline(), '')
       
     
     def test_dunder_iter_data(self):
-        # Check that dunder_iter will return all the lines from the fake file
+        # Check that __iter__ will return all the lines from the fake file.
         mock = mock_open(read_data='foo\nbar\nbaz\n')
         with patch('%s.open' % __name__, mock, create=True):
             h = open('bar')
@@ -218,7 +218,7 @@ class TestMockOpen(unittest.TestCase):
         self.assertEqual(lines[0], 'foo\n')
         self.assertEqual(lines[1], 'bar\n')
         self.assertEqual(lines[2], 'baz\n')
-        self.assertEqual(h.readline(),'')
+        self.assertEqual(h.readline(), '')
 
 
     def test_readlines_data(self):

--- a/Lib/unittest/test/testmock/testwith.py
+++ b/Lib/unittest/test/testmock/testwith.py
@@ -207,10 +207,10 @@ class TestMockOpen(unittest.TestCase):
             result = h.readline()
         self.assertEqual(result, 'foo')
         self.assertEqual(h.readline(), '')
-      
-    
+
+
     def test_dunder_iter_data(self):
-        # Check that __iter__ will return all the lines from the fake file.
+        # Check that dunder_iter will return all the lines from the fake file.
         mock = mock_open(read_data='foo\nbar\nbaz\n')
         with patch('%s.open' % __name__, mock, create=True):
             h = open('bar')

--- a/Lib/unittest/test/testmock/testwith.py
+++ b/Lib/unittest/test/testmock/testwith.py
@@ -205,6 +205,24 @@ class TestMockOpen(unittest.TestCase):
             result = h.readline()
         self.assertEqual(result, 'foo')
 
+    def test_dunder_iter_data(self):
+        # Check that dunder_iter will return all the lines from the fake file
+        # Added to test Issue 32933
+        mock = mock_open(read_data='foo\nbar\nbaz\n')
+        with patch('%s.open' % __name__, mock, create=True):
+            h = open('bar')
+            lines = [l for l in h]
+        self.assertEqual(lines[0], 'foo\n')
+        self.assertEqual(lines[1], 'bar\n')
+        self.assertEqual(lines[2], 'baz\n')
+
+        # Check that we properly emulate a file that doesn't end in a newline
+        mock = mock_open(read_data='foo')
+        with patch('%s.open' % __name__, mock, create=True):
+            h = open('bar')
+            result = h.readline()
+        self.assertEqual(result, 'foo')
+
 
     def test_readlines_data(self):
         # Test that emulating a file that ends in a newline character works

--- a/Misc/NEWS.d/next/Library/2018-04-30-22-43-31.bpo-32933.M3iI_y.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-30-22-43-31.bpo-32933.M3iI_y.rst
@@ -1,1 +1,2 @@
-func:`unittest.mock.mock_open` now supports iteration over the file contents. Patch by Tony Flury
+:func:`unittest.mock.mock_open` now supports iteration over the file
+contents. Patch by Tony Flury.

--- a/Misc/NEWS.d/next/Library/2018-04-30-22-43-31.bpo-32933.M3iI_y.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-30-22-43-31.bpo-32933.M3iI_y.rst
@@ -1,1 +1,1 @@
-unittest.mock.mock_open now supports iteration over the file contents.
+func:`unittest.mock.mock_open` now supports iteration over the file contents. Patch by Tony Flury

--- a/Misc/NEWS.d/next/Library/2018-04-30-22-43-31.bpo-32933.M3iI_y.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-30-22-43-31.bpo-32933.M3iI_y.rst
@@ -1,0 +1,1 @@
+unittest.mock.mock_open now supports iteration over the file contents.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-32933 -->
https://bugs.python.org/issue32933
<!-- /issue-number -->
