### PR TITLE
bpo-32991: Restore expectation that inspect.getfile raises TypeError on namespace package

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -642,13 +642,13 @@ def cleandoc(doc):
 def getfile(object):
     """Work out which source or compiled file an object was defined in."""
     if ismodule(object):
-        if hasattr(object, '__file__'):
+        if getattr(object, '__file__', None):
             return object.__file__
         raise TypeError('{!r} is a built-in module'.format(object))
     if isclass(object):
         if hasattr(object, '__module__'):
             object = sys.modules.get(object.__module__)
-            if hasattr(object, '__file__'):
+            if getattr(object, '__file__', None):
                 return object.__file__
         raise TypeError('{!r} is a built-in class'.format(object))
     if ismethod(object):

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -7,6 +7,8 @@ import doctest
 import functools
 import os
 import sys
+import importlib
+import unittest
 
 
 # NOTE: There are some additional tests relating to interaction with
@@ -435,7 +437,7 @@ We'll simulate a __file__ attr that ends in pyc:
     >>> tests = finder.find(sample_func)
 
     >>> print(tests)  # doctest: +ELLIPSIS
-    [<DocTest sample_func from ...:19 (1 example)>]
+    [<DocTest sample_func from ...:21 (1 example)>]
 
 The exact name depends on how test_doctest was invoked, so allow for
 leading path components.
@@ -680,6 +682,17 @@ Note here that 'bin', 'oct', and 'hex' are functions; 'float.as_integer_ratio',
 'float.hex', and 'int.bit_length' are methods; 'float.fromhex' is a classmethod,
 and 'int' is a type.
 """
+
+
+class TestDocTestFinder(unittest.TestCase):
+
+    def test_empty_namespace_package(self):
+        pkg_name = 'doctest_empty_pkg'
+        os.mkdir(pkg_name)
+        mod = importlib.import_module(pkg_name)
+        assert doctest.DocTestFinder().find(mod) == []
+        os.rmdir(pkg_name)
+
 
 def test_DocTestParser(): r"""
 Unit tests for the `DocTestParser` class.
@@ -2944,6 +2957,10 @@ def test_main():
     # Check the doctest cases defined here:
     from test import test_doctest
     support.run_doctest(test_doctest, verbosity=True)
+
+    # Run unittests
+    support.run_unittest(__name__)
+
 
 def test_coverage(coverdir):
     trace = support.import_module('trace')


### PR DESCRIPTION
In the ticket, I've made some assumptions about decisions about how to best handle the offending issue and the underlying error. The offending issue is that DocTestFinder.find crashes on a namespace package. The underlying issue is that inspect.getfile no longer raises a TypeError for namespace packages (where it did previously). This patch addresses both issues by once again raising a TypeError for those packages.

Following principles of TDD, in the first commit, I demonstrate the failed expectation, replicating the reported error. In the second commit, I apply the fix. I suspect these commits will get squashed and the intermediate failing state will remain only in this PR.

<!-- issue-number: bpo-32991 -->
https://bugs.python.org/issue32991
<!-- /issue-number -->
