### PR TITLE
[2.7] bpo-32997: Fix REDOS in fpformat

### DIFF
--- a/Lib/fpformat.py
+++ b/Lib/fpformat.py
@@ -19,7 +19,7 @@ import re
 __all__ = ["fix","sci","NotANumber"]
 
 # Compiled regular expression to "decode" a number
-decoder = re.compile(r'^([-+]?)0*(\d*)((?:\.\d*)?)(([eE][-+]?\d+)?)$')
+decoder = re.compile(r'^([-+]?)0*([1-9]\d*)?((?:\.\d*)?)(([eE][-+]?\d+)?)$')
 # \0 the whole thing
 # \1 leading sign or empty
 # \2 digits left of decimal point
@@ -41,6 +41,8 @@ def extract(s):
     res = decoder.match(s)
     if res is None: raise NotANumber, s
     sign, intpart, fraction, exppart = res.group(1,2,3,4)
+    if intpart is None: # ([1-9]\d*)? may match nothing
+        intpart = ''
     if sign == '+': sign = ''
     if fraction: fraction = fraction[1:]
     if exppart: expo = int(exppart[1:])

--- a/Lib/fpformat.py
+++ b/Lib/fpformat.py
@@ -19,7 +19,7 @@ import re
 __all__ = ["fix","sci","NotANumber"]
 
 # Compiled regular expression to "decode" a number
-decoder = re.compile(r'^([-+]?)0*([1-9]\d*)?((?:\.\d*)?)(([eE][-+]?\d+)?)$')
+decoder = re.compile(r'^([-+]?)(\d*)?((?:\.\d*)?)(([eE][-+]?\d+)?)$')
 # \0 the whole thing
 # \1 leading sign or empty
 # \2 digits left of decimal point
@@ -41,8 +41,7 @@ def extract(s):
     res = decoder.match(s)
     if res is None: raise NotANumber, s
     sign, intpart, fraction, exppart = res.group(1,2,3,4)
-    if intpart is None: # ([1-9]\d*)? may match nothing
-        intpart = ''
+    intpart = intpart.lstrip('0');
     if sign == '+': sign = ''
     if fraction: fraction = fraction[1:]
     if exppart: expo = int(exppart[1:])

--- a/Lib/fpformat.py
+++ b/Lib/fpformat.py
@@ -19,7 +19,7 @@ import re
 __all__ = ["fix","sci","NotANumber"]
 
 # Compiled regular expression to "decode" a number
-decoder = re.compile(r'^([-+]?)(\d*)?((?:\.\d*)?)(([eE][-+]?\d+)?)$')
+decoder = re.compile(r'^([-+]?)(\d*)((?:\.\d*)?)(([eE][-+]?\d+)?)$')
 # \0 the whole thing
 # \1 leading sign or empty
 # \2 digits left of decimal point

--- a/Lib/test/test_fpformat.py
+++ b/Lib/test/test_fpformat.py
@@ -67,6 +67,16 @@ class FpformatTest(unittest.TestCase):
         else:
             self.fail("No exception on non-numeric sci")
 
+    def test_REDOS(self):
+        # This attack string will hang on the old decoder pattern.
+        attack = '+0' + ('0' * 1000000) + '++'
+        digs = 5 # irrelevant
+
+        # fix returns input if it does not decode
+        self.assertEqual(fpformat.fix(attack, digs), attack)
+        # sci raises NotANumber
+        with self.assertRaises(NotANumber):
+            fpformat.sci(attack, digs)
 
 def test_main():
     run_unittest(FpformatTest)

--- a/Misc/NEWS.d/next/Security/2018-03-05-10-14-42.bpo-32997.hp2s8n.rst
+++ b/Misc/NEWS.d/next/Security/2018-03-05-10-14-42.bpo-32997.hp2s8n.rst
@@ -1,0 +1,4 @@
+A regex in fpformat was vulnerable to catastrophic backtracking. This regex
+was a potential DOS vector (REDOS). Based on typical uses of fpformat the
+risk seems low. The regex has been refactored and is now safe. Patch by
+Jamie Davis.


### PR DESCRIPTION
The regex to decode a number in fpformat is susceptible to
catastrophic backtracking.
This is a potential DOS vector if a server is using fpformat on
untrusted number strings.

Replace it with an equivalent non-vulnerable regex.

The match behavior of the new regex is slightly different.
This difference is addressed with a follow-up check.

<!-- issue-number: bpo-32997 -->
https://bugs.python.org/issue32997
<!-- /issue-number -->
