### PR TITLE
bpo-33001: Minimal fix to prevent buffer overrun in os.symlink

### DIFF
--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2164,6 +2164,42 @@ class Win32SymlinkTests(unittest.TestCase):
         target = os.readlink(r'C:\Users\All Users')
         self.assertTrue(os.path.samefile(target, r'C:\ProgramData'))
 
+    def test_buffer_overflow(self):
+        # Older versions would have a buffer overflow when detecting
+        # whether a link source was a directory. This test ensures we
+        # no longer crash, but does not otherwise validate the behavior
+        segment = 'X' * 27
+        path = os.path.join(*[segment] * 10)
+        test_cases = [
+            # overflow with absolute src
+            ('\\' + path, segment),
+            # overflow dest with relative src
+            (segment, path),
+            # overflow dest when appending '\\' for join
+            (segment, path[:261]),
+            # overflow when joining src
+            (path[:180], path[:180]),
+        ]
+        for src, dest in test_cases:
+            try:
+                os.symlink(src, dest)
+            except FileNotFoundError:
+                pass
+            else:
+                try:
+                    os.remove(dest)
+                except OSError:
+                    pass
+            # Also test with bytes, since that is a separate code path.
+            try:
+                os.symlink(os.fsencode(src), os.fsencode(dest))
+            except FileNotFoundError:
+                pass
+            else:
+                try:
+                    os.remove(dest)
+                except OSError:
+                    pass
 
 @unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
 class Win32JunctionTests(unittest.TestCase):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2175,8 +2175,6 @@ class Win32SymlinkTests(unittest.TestCase):
             ('\\' + path, segment),
             # overflow dest with relative src
             (segment, path),
-            # overflow dest when appending '\\' for join
-            (segment, path[:261]),
             # overflow when joining src
             (path[:180], path[:180]),
         ]

--- a/Misc/NEWS.d/next/Security/2018-03-05-10-09-51.bpo-33001.elj4Aa.rst
+++ b/Misc/NEWS.d/next/Security/2018-03-05-10-09-51.bpo-33001.elj4Aa.rst
@@ -1,0 +1,1 @@
+Minimal fix to prevent buffer overrun in os.symlink on Windows


### PR DESCRIPTION


<!-- issue-number: bpo-33001 -->
https://bugs.python.org/issue33001
<!-- /issue-number -->
