### PR TITLE
bpo-28788: configparser.write() accepts also str as a filename to write to

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -1134,7 +1134,8 @@ ConfigParser Objects
 
    .. method:: write(fileobject, space_around_delimiters=True)
 
-      Write a representation of the configuration to the specified :term:`file
+      Write a representation of the configuration to the specified *file*.
+      That could be either file name or :term:`file
       object`, which must be opened in text mode (accepting strings).  This
       representation can be parsed by a future :meth:`read` call.  If
       *space_around_delimiters* is true, delimiters between

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -900,7 +900,14 @@ class RawConfigParser(MutableMapping):
                 raise NoSectionError(section) from None
         sectdict[self.optionxform(option)] = value
 
-    def write(self, fp, space_around_delimiters=True):
+    def write(self, file, space_around_delimiters=True):
+        if isinstance(file, str):
+            with io.open(filename, 'w') as f:
+                self._write(f, space_around_delimiters)
+        else:
+            self._write(file, space_around_delimiters)
+
+    def _write(self, fp, space_around_delimiters=True):
         """Write an .ini-format representation of the configuration state.
 
         If `space_around_delimiters' is True (the default), delimiters

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -900,12 +900,12 @@ class RawConfigParser(MutableMapping):
                 raise NoSectionError(section) from None
         sectdict[self.optionxform(option)] = value
 
-    def write(self, file, space_around_delimiters=True):
-        if isinstance(file, str):
-            with io.open(filename, 'w') as f:
+    def write(self, fp, space_around_delimiters=True):
+        if isinstance(fp, str):
+            with io.open(fp, 'w') as f:
                 self._write(f, space_around_delimiters)
         else:
-            self._write(file, space_around_delimiters)
+            self._write(fp, space_around_delimiters)
 
     def _write(self, fp, space_around_delimiters=True):
         """Write an .ini-format representation of the configuration state.

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -658,8 +658,8 @@ boolean {0[0]} NO
             )
         if self.allow_no_value:
             config_string += (
-            "[Valueless]\n"
-            "option-without-value\n"
+                "[Valueless]\n"
+                "option-without-value\n"
             )
 
         cf = self.fromstring(config_string)
@@ -667,13 +667,9 @@ boolean {0[0]} NO
             if testfile is None:
                 output = io.StringIO()
             else:
-                output = open(testfile, 'w')
-            try:
-                cf.write(output,
-                         space_around_delimiters=space_around_delimiters)
-            finally:
-                if testfile is not None:
-                    output.close()
+                output = testfile
+            cf.write(output,
+                     space_around_delimiters=space_around_delimiters)
             delimiter = self.delimiters[0]
             if space_around_delimiters:
                 delimiter = " {} ".format(delimiter)
@@ -711,10 +707,8 @@ boolean {0[0]} NO
         f = tempfile.NamedTemporaryFile(delete=False)
         try:
             self.test_write(testfile=f.name)
-        except:
-            raise
         finally:
-            os.unlink(f.name)
+            support.unlink(f.name)
 
     def test_set_string_types(self):
         cf = self.fromstring("[sect]\n"

--- a/Misc/NEWS.d/next/Library/2018-03-06-01-20-19.bpo-28788.iMieW_.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-06-01-20-19.bpo-28788.iMieW_.rst
@@ -1,0 +1,3 @@
+``Configparser.write()`` can now accept filename as its parameters instead
+of just file handler. If the file with such name already exists its  content
+will be removed first.


### PR DESCRIPTION
Fix #28788

<!-- issue-number: bpo-28788 -->
https://bugs.python.org/issue28788
<!-- /issue-number -->
