### PR TITLE
bpo-33005: Fix _PyGILState_Reinit()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-03-06-12-19-19.bpo-33005.LP-V2U.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-03-06-12-19-19.bpo-33005.LP-V2U.rst
@@ -1,0 +1,4 @@
+Fix a crash on fork when using a custom memory allocator (ex: using
+PYTHONMALLOC env var). _PyGILState_Reinit() and _PyInterpreterState_Enable()
+now use the default RAW memory allocator to allocate a new interpreters mutex
+on fork.


### PR DESCRIPTION
Fix crash on fork when using a custom memory allocator (ex: using
PYTHONMALLOC env var). _PyGILState_Reinit() now uses the default RAW
memory allocator to allocate a new interpreters mutex on fork.

Simplify _PyInterpreterState_Enable(): the mutex is already
initialized by _PyRuntimeState_Init().

<!-- issue-number: bpo-33005 -->
https://bugs.python.org/issue33005
<!-- /issue-number -->
