### PR TITLE
bpo-32999: Fix ABC.__subclasscheck__ crash

### DIFF
--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -395,9 +395,20 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
         def test_issubclass(self):
             class A(metaclass=abc_ABCMeta):
                 pass
-            with self.assertRaises(TypeError):
-                issubclass(42, A)
 
+            with self.assertRaises(TypeError):
+                issubclass({}, A)  # unhashable
+
+            with self.assertRaises(TypeError):
+                issubclass(42, A)  # No __mro__
+
+            # Python version supports any iterable as __mro__.
+            # But it's implementation detail and don't emulate it in C version.
+            class C:
+                __mro__ = 42  # __mro__ is not tuple
+
+            with self.assertRaises(TypeError):
+                self.assertTrue(issubclass(C(), A))
 
         def test_all_new_methods_are_called(self):
             class A(metaclass=abc_ABCMeta):

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -392,6 +392,13 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             self.assertIsInstance(42, A)
             self.assertIsInstance(42, (A,))
 
+        def test_issubclass(self):
+            class A(metaclass=abc_ABCMeta):
+                pass
+            with self.assertRaises(TypeError):
+                issubclass(42, A)
+
+
         def test_all_new_methods_are_called(self):
             class A(metaclass=abc_ABCMeta):
                 pass

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -408,7 +408,7 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
                 __mro__ = 42  # __mro__ is not tuple
 
             with self.assertRaises(TypeError):
-                self.assertTrue(issubclass(C(), A))
+                issubclass(C(), A)
 
         def test_all_new_methods_are_called(self):
             class A(metaclass=abc_ABCMeta):

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -392,7 +392,7 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             self.assertIsInstance(42, A)
             self.assertIsInstance(42, (A,))
 
-        def test_issubclass(self):
+        def test_issubclass_bad_arguments(self):
             class A(metaclass=abc_ABCMeta):
                 pass
 

--- a/Misc/NEWS.d/next/Library/2018-03-06-20-30-20.bpo-32999.lgFXWl.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-06-20-30-20.bpo-32999.lgFXWl.rst
@@ -1,0 +1,2 @@
+Fix C implemetation of ``ABC.__subclasscheck__(cls, subclass)`` crashed when
+``subclass`` is not a type object.

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -647,7 +647,13 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
     if (_PyObject_LookupAttrId(subclass, &PyId___mro__, &mro) < 0) {
         goto end;
     }
-    if (mro != NULL && PyTuple_Check(mro)) {
+    if (mro != NULL) {
+        if (!PyTuple_Check(mro)) {
+            // Python version supports non-tuple iterable.  Keep it as
+            // implementation detail.
+            PyErr_SetString(PyExc_TypeError, "__mro__ is not a tuple");
+            goto end;
+        }
         for (pos = 0; pos < PyTuple_GET_SIZE(mro); pos++) {
             PyObject *mro_item = PyTuple_GET_ITEM(mro, pos);
             if (mro_item == NULL) {

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -16,6 +16,7 @@ _Py_IDENTIFIER(__abstractmethods__);
 _Py_IDENTIFIER(__class__);
 _Py_IDENTIFIER(__dict__);
 _Py_IDENTIFIER(__bases__);
+_Py_IDENTIFIER(__mro__);
 _Py_IDENTIFIER(_abc_impl);
 _Py_IDENTIFIER(__subclasscheck__);
 _Py_IDENTIFIER(__subclasshook__);
@@ -643,7 +644,6 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
      *     cls._abc_cache.add(subclass)
      *     return True
      */
-    _Py_IDENTIFIER(__mro__);
     if (_PyObject_LookupAttrId(subclass, &PyId___mro__, &mro) < 0) {
         goto end;
     }

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -705,8 +705,8 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
     result = Py_False;
 
 end:
+    Py_DECREF(impl);
     Py_XDECREF(mro);
-    Py_XDECREF(impl);
     Py_XDECREF(subclasses);
     Py_XINCREF(result);
     return result;

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -12,13 +12,7 @@ module _abc
 PyDoc_STRVAR(_abc__doc__,
 "Module contains faster C implementation of abc.ABCMeta");
 
-_Py_IDENTIFIER(__abstractmethods__);
-_Py_IDENTIFIER(__class__);
-_Py_IDENTIFIER(__dict__);
-_Py_IDENTIFIER(__bases__);
 _Py_IDENTIFIER(_abc_impl);
-_Py_IDENTIFIER(__subclasscheck__);
-_Py_IDENTIFIER(__subclasshook__);
 
 /* A global counter that is incremented each time a class is
    registered as a virtual subclass of anything.  It forces the
@@ -258,6 +252,7 @@ _abc__get_dump(PyObject *module, PyObject *self)
 static int
 compute_abstract_methods(PyObject *self)
 {
+    _Py_IDENTIFIER(__abstractmethods__);
     int ret = -1;
     PyObject *abstracts = PyFrozenSet_New(NULL);
     if (abstracts == NULL) {
@@ -267,6 +262,7 @@ compute_abstract_methods(PyObject *self)
     PyObject *ns = NULL, *items = NULL, *bases = NULL;  // Py_XDECREF()ed on error.
 
     /* Stage 1: direct abstract methods. */
+    _Py_IDENTIFIER(__dict__);
     ns = _PyObject_GetAttrId(self, &PyId___dict__);
     if (!ns) {
         goto error;
@@ -311,6 +307,7 @@ compute_abstract_methods(PyObject *self)
     }
 
     /* Stage 2: inherited abstract methods. */
+    _Py_IDENTIFIER(__bases__);
     bases = _PyObject_GetAttrId(self, &PyId___bases__);
     if (!bases) {
         goto error;
@@ -479,12 +476,14 @@ _abc__abc_instancecheck_impl(PyObject *module, PyObject *self,
                              PyObject *instance)
 /*[clinic end generated code: output=b8b5148f63b6b56f input=a4f4525679261084]*/
 {
+    _Py_IDENTIFIER(__subclasscheck__);
     PyObject *subtype, *result = NULL, *subclass = NULL;
     _abc_data *impl = _get_impl(self);
     if (impl == NULL) {
         return NULL;
     }
 
+    _Py_IDENTIFIER(__class__);
     subclass = _PyObject_GetAttrId(instance, &PyId___class__);
     if (subclass == NULL) {
         Py_DECREF(impl);
@@ -608,6 +607,7 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
     }
 
     /* 3. Check the subclass hook. */
+    _Py_IDENTIFIER(__subclasshook__);
     ok = _PyObject_CallMethodIdObjArgs((PyObject *)self, &PyId___subclasshook__,
                                        subclass, NULL);
     if (ok == NULL) {

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -567,7 +567,7 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
                              PyObject *subclass)
 /*[clinic end generated code: output=b56c9e4a530e3894 input=1d947243409d10b8]*/
 {
-    PyObject *ok, *mro, *subclasses = NULL, *result = NULL;
+    PyObject *ok, *mro = NULL, *subclasses = NULL, *result = NULL;
     Py_ssize_t pos;
     int incache;
     _abc_data *impl = _get_impl(self);
@@ -645,7 +645,7 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
      */
     _Py_IDENTIFIER(__mro__);
     if (_PyObject_LookupAttrId(subclass, &PyId___mro__, &mro) < 0) {
-        return NULL;
+        goto end;
     }
     if (mro != NULL && PyTuple_Check(mro)) {
         for (pos = 0; pos < PyTuple_GET_SIZE(mro); pos++) {
@@ -699,6 +699,7 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
     result = Py_False;
 
 end:
+    Py_XDECREF(mro);
     Py_XDECREF(impl);
     Py_XDECREF(subclasses);
     Py_XINCREF(result);

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -12,7 +12,13 @@ module _abc
 PyDoc_STRVAR(_abc__doc__,
 "Module contains faster C implementation of abc.ABCMeta");
 
+_Py_IDENTIFIER(__abstractmethods__);
+_Py_IDENTIFIER(__class__);
+_Py_IDENTIFIER(__dict__);
+_Py_IDENTIFIER(__bases__);
 _Py_IDENTIFIER(_abc_impl);
+_Py_IDENTIFIER(__subclasscheck__);
+_Py_IDENTIFIER(__subclasshook__);
 
 /* A global counter that is incremented each time a class is
    registered as a virtual subclass of anything.  It forces the
@@ -252,7 +258,6 @@ _abc__get_dump(PyObject *module, PyObject *self)
 static int
 compute_abstract_methods(PyObject *self)
 {
-    _Py_IDENTIFIER(__abstractmethods__);
     int ret = -1;
     PyObject *abstracts = PyFrozenSet_New(NULL);
     if (abstracts == NULL) {
@@ -262,7 +267,6 @@ compute_abstract_methods(PyObject *self)
     PyObject *ns = NULL, *items = NULL, *bases = NULL;  // Py_XDECREF()ed on error.
 
     /* Stage 1: direct abstract methods. */
-    _Py_IDENTIFIER(__dict__);
     ns = _PyObject_GetAttrId(self, &PyId___dict__);
     if (!ns) {
         goto error;
@@ -307,7 +311,6 @@ compute_abstract_methods(PyObject *self)
     }
 
     /* Stage 2: inherited abstract methods. */
-    _Py_IDENTIFIER(__bases__);
     bases = _PyObject_GetAttrId(self, &PyId___bases__);
     if (!bases) {
         goto error;
@@ -476,14 +479,12 @@ _abc__abc_instancecheck_impl(PyObject *module, PyObject *self,
                              PyObject *instance)
 /*[clinic end generated code: output=b8b5148f63b6b56f input=a4f4525679261084]*/
 {
-    _Py_IDENTIFIER(__subclasscheck__);
     PyObject *subtype, *result = NULL, *subclass = NULL;
     _abc_data *impl = _get_impl(self);
     if (impl == NULL) {
         return NULL;
     }
 
-    _Py_IDENTIFIER(__class__);
     subclass = _PyObject_GetAttrId(instance, &PyId___class__);
     if (subclass == NULL) {
         Py_DECREF(impl);
@@ -607,7 +608,6 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
     }
 
     /* 3. Check the subclass hook. */
-    _Py_IDENTIFIER(__subclasshook__);
     ok = _PyObject_CallMethodIdObjArgs((PyObject *)self, &PyId___subclasshook__,
                                        subclass, NULL);
     if (ok == NULL) {

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -656,9 +656,6 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
         }
         for (pos = 0; pos < PyTuple_GET_SIZE(mro); pos++) {
             PyObject *mro_item = PyTuple_GET_ITEM(mro, pos);
-            if (mro_item == NULL) {
-                goto end;
-            }
             if ((PyObject *)self == mro_item) {
                 if (_add_to_weak_set(&impl->_abc_cache, subclass) < 0) {
                     goto end;


### PR DESCRIPTION
C implementation of ``ABC.__subclasscheck__(cls, subclass)`` crashed when ``subclass`` is not type object.

This commit makes C implementation more similar to Python implementation.

<!-- issue-number: bpo-32999 -->
https://bugs.python.org/issue32999
<!-- /issue-number -->
