### PR TITLE
bpo-33009: Fix inspect.signature() for single-parameter partialmethods.

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -2254,7 +2254,8 @@ def _signature_from_callable(obj, *,
                 return sig
             else:
                 sig_params = tuple(sig.parameters.values())
-                assert first_wrapped_param is not sig_params[0]
+                assert (not sig_params or
+                        first_wrapped_param is not sig_params[0])
                 new_params = (first_wrapped_param,) + sig_params
                 return sig.replace(parameters=new_params)
 

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -2580,6 +2580,16 @@ class TestSignatureObject(unittest.TestCase):
                            ('c', 1, ..., 'keyword_only')),
                           'spam'))
 
+        class Spam:
+            def test(self: 'anno', x):
+                pass
+
+            g = partialmethod(test, 1)
+
+        self.assertEqual(self.signature(Spam.g),
+                         ((('self', ..., 'anno', 'positional_or_keyword'),),
+                          ...))
+
     def test_signature_on_fake_partialmethod(self):
         def foo(a): pass
         foo._partialmethod = 'spam'

--- a/Misc/NEWS.d/next/Library/2018-03-06-11-54-59.bpo-33009.-Ekysb.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-06-11-54-59.bpo-33009.-Ekysb.rst
@@ -1,0 +1,1 @@
+Fix inspect.signature() for single-parameter partialmethods.


### PR DESCRIPTION


<!-- issue-number: bpo-33009 -->
https://bugs.python.org/issue33009
<!-- /issue-number -->
