### PR TITLE
bpo-32992: Unittest: Automatically run coroutines in a loop.

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -693,6 +693,11 @@ Test cases
    and report failures, and some inquiry methods allowing information about the
    test itself to be gathered.
 
+   .. versionchanged:: 3.8
+         Any test method, along with :meth:`setUp` and :meth:`tearDown` can
+         optionally be coroutine functions. In this case, they will be executed
+         on the default loop when running the test.
+
    Methods in the first group (running the test) are:
 
    .. method:: setUp()
@@ -701,6 +706,9 @@ Test cases
       before calling the test method; other than :exc:`AssertionError` or :exc:`SkipTest`,
       any exception raised by this method will be considered an error rather than
       a test failure. The default implementation does nothing.
+
+      .. versionchanged:: 3.8
+         This method can optionally be a coroutine function.
 
 
    .. method:: tearDown()
@@ -714,6 +722,9 @@ Test cases
       the total number of reported errors). This method will only be called if
       the :meth:`setUp` succeeds, regardless of the outcome of the test method.
       The default implementation does nothing.
+
+      .. versionchanged:: 3.8
+         This method can optionally be a coroutine function.
 
 
    .. method:: setUpClass()

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import difflib
 import pprint
@@ -1827,6 +1828,36 @@ test case
             testcase = TestCase(method_name)
             testcase.run()
             self.assertEqual(MyException.ninstance, 0)
+
+    def test_coroutines(self):
+        # Test that test methods, setUp and tearDown can
+        # be coroutines.
+        class TestCase(unittest.TestCase):
+            def __init__(self, method_name):
+                super().__init__(method_name)
+                self.setUp_called = False
+                self.tearDown_called = False
+                self.test1_called = False
+
+            async def setUp(self):
+                # Await 0 seconds to prevent the entire function
+                # from executing immediately.
+                await asyncio.sleep(0.0)
+                self.setUp_called = True
+
+            async def tearDown(self):
+                await asyncio.sleep(0.0)
+                self.tearDown_called = True
+
+            async def test1(self):
+                await asyncio.sleep(0.0)
+                self.test1_called = True
+
+        testcase = TestCase('test1')
+        testcase.run()
+        self.assertTrue(testcase.setUp_called)
+        self.assertTrue(testcase.tearDown_called)
+        self.assertTrue(testcase.test1_called)
 
 
 if __name__ == "__main__":

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1540,6 +1540,7 @@ Daniel Stokes
 Michael Stone
 Serhiy Storchaka
 Ken Stox
+Petter Strandmark
 Charalampos Stratakis
 Dan Stromberg
 Donald Stufft

--- a/Misc/NEWS.d/next/Library/2018-03-05-20-01-47.bpo-32992.gfeea.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-05-20-01-47.bpo-32992.gfeea.rst
@@ -1,0 +1,3 @@
+Test methods,  ``setUp`` and ``tearDown`` in ``unittest.TestCase`` may now be
+coroutine functions and will be excuted in the default ``asyncio`` loop.
+Patch by Petter Strandmark.


### PR DESCRIPTION
If test methods, setUp, or tearDown are coroutine functions, they will be
executed in the default loop.


<!-- issue-number: bpo-32992 -->
https://bugs.python.org/issue32992
<!-- /issue-number -->
