### PR TITLE
bpo-33015: Add a wrapper for thread function in PyThread_start_new_thread

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-08-24-09-48-25.bpo-33015.s21y74.rst
+++ b/Misc/NEWS.d/next/Build/2018-08-24-09-48-25.bpo-33015.s21y74.rst
@@ -1,3 +1,3 @@
-Add a wrapper for the thread function argument in
-`PyThread_start_new_thread` to avoid an incompatible cast warning with gcc
-8.
+Fix an undefined behaviour in the pthread implementation of
+:c:func:`PyThread_start_new_thread`: add a function wrapper to always return
+``NULL`.

--- a/Misc/NEWS.d/next/Build/2018-08-24-09-48-25.bpo-33015.s21y74.rst
+++ b/Misc/NEWS.d/next/Build/2018-08-24-09-48-25.bpo-33015.s21y74.rst
@@ -1,3 +1,3 @@
 Fix an undefined behaviour in the pthread implementation of
 :c:func:`PyThread_start_new_thread`: add a function wrapper to always return
-``NULL`.
+``NULL``.

--- a/Misc/NEWS.d/next/Build/2018-08-24-09-48-25.bpo-33015.s21y74.rst
+++ b/Misc/NEWS.d/next/Build/2018-08-24-09-48-25.bpo-33015.s21y74.rst
@@ -1,0 +1,3 @@
+Add a wrapper for the thread function argument in
+`PyThread_start_new_thread` to avoid an incompatible cast warning with gcc
+8.

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -210,13 +210,14 @@ PyThread_start_new_thread(void (*func)(void *), void *arg)
     pthread_attr_setscope(&attrs, PTHREAD_SCOPE_SYSTEM);
 #endif
 
-    pythread_callback *fn = PyMem_RawMalloc(sizeof(pythread_callback));
+    pythread_callback *callback = PyMem_RawMalloc(sizeof(pythread_callback));
 
-    if (fn == NULL)
+    if (callback == NULL) {
       return PYTHREAD_INVALID_THREAD_ID;
+    }
 
-    fn->func = func;
-    fn->arg = arg;
+    callback->func = func;
+    callback->arg = arg;
 
     status = pthread_create(&th,
 #if defined(THREAD_STACK_SIZE) || defined(PTHREAD_SYSTEM_SCHED_SUPPORTED)
@@ -224,14 +225,14 @@ PyThread_start_new_thread(void (*func)(void *), void *arg)
 #else
                              (pthread_attr_t*)NULL,
 #endif
-                             pythread_wrapper, fn);
+                             pythread_wrapper, callback);
 
 #if defined(THREAD_STACK_SIZE) || defined(PTHREAD_SYSTEM_SCHED_SUPPORTED)
     pthread_attr_destroy(&attrs);
 #endif
 
     if (status != 0) {
-        PyMem_RawFree((void *)fn);
+        PyMem_RawFree(callback);
         return PYTHREAD_INVALID_THREAD_ID;
     }
 

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -152,29 +152,26 @@ PyThread__init_thread(void)
  * Thread support.
  */
 
-/* The thread function argument passed to PyThread_start_new_thread has a
- * different type compared to the thread function passed to the POSIX
- * pthread_create function and the result of forcibly casting it to the latter
- * type is undefined.  The pythread_fn struct and the pythread_helper_fn below
- * help work around this in a conforming manner by wrapping around the thread
- * function.
- */
+/* bpo-33015: pythread_callback struct and pythread_wrapper() cast
+   "void func(void *)" to "void* func(void *)": always return NULL.
+
+   PyThread_start_new_thread() uses "void func(void *)" type, whereas
+   pthread_create() requires a void* return value. */
 typedef struct {
     void (*func) (void *);
     void *arg;
-} pythread_fn;
+} pythread_callback;
 
 static void *
-pythread_helper_fn(void *fn)
+pythread_wrapper(void *arg)
 {
-    pythread_fn *pfn = fn;
+    /* copy func and func_arg and free the temporary structure */
+    pythread_callback *callback = arg;
+    void (*func)(void *) = callback->func;
+    void *func_arg = callback->arg;
+    PyMem_RawFree(arg);
 
-    void (*func)(void *) = pfn->func;
-    void *arg = pfn->arg;
-
-    PyMem_RawFree((void *)fn);
-    func(arg);
-
+    func(func_arg);
     return NULL;
 }
 
@@ -213,7 +210,7 @@ PyThread_start_new_thread(void (*func)(void *), void *arg)
     pthread_attr_setscope(&attrs, PTHREAD_SCOPE_SYSTEM);
 #endif
 
-    pythread_fn *fn = (pythread_fn *)PyMem_RawMalloc(sizeof (pythread_fn));
+    pythread_callback *fn = PyMem_RawMalloc(sizeof(pythread_callback));
 
     if (fn == NULL)
       return PYTHREAD_INVALID_THREAD_ID;
@@ -227,9 +224,7 @@ PyThread_start_new_thread(void (*func)(void *), void *arg)
 #else
                              (pthread_attr_t*)NULL,
 #endif
-                             pythread_helper_fn,
-                             fn
-                             );
+                             pythread_wrapper, fn);
 
 #if defined(THREAD_STACK_SIZE) || defined(PTHREAD_SYSTEM_SCHED_SUPPORTED)
     pthread_attr_destroy(&attrs);


### PR DESCRIPTION
PyThread_start_new_thread accepts a function of type `void (*) (void *)`, which does not match with the pthread_create function callback prototype `void *(*) (void *)`.  This results in an invalid function cast warning with gcc8.  Fix this by wrapping the function in an internal pthread function callback that returns NULL.

<!-- issue-number: bpo-33015 -->
https://bugs.python.org/issue33015
<!-- /issue-number -->
