### PR TITLE
bpo-30235: Support Path-like in shutil.copytree

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -231,6 +231,9 @@ Directory and files operations
    as arguments. By default, :func:`shutil.copy2` is used, but any function
    that supports the same signature (like :func:`shutil.copy`) can be used.
 
+   .. versionchanged:: 3.8
+      Accepts a :term:`path-like object` for *src* and *dst*.
+
    .. versionchanged:: 3.3
       Copy metadata when *symlinks* is false.
       Now returns *dst*.

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -306,6 +306,9 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
     function that supports the same signature (like copy()) can be used.
 
     """
+    src = os.fspath(src)
+    dst = os.fspath(dst)
+
     names = os.listdir(src)
     if ignore is not None:
         ignored_names = ignore(src, names)

--- a/Misc/NEWS.d/next/Library/2018-03-06-16-37-49.bpo-30235.gelRH0.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-06-16-37-49.bpo-30235.gelRH0.rst
@@ -1,0 +1,1 @@
+Support Path-like in shutil.copytree


### PR DESCRIPTION
I updated `shutil.copytree` to support Path-like objects. The issue [30235](https://bugs.python.org/issue30235) describes other functions that should be checked/updated too, but also recommended separate PRs for them. If this is right, I would be happy to check the other ones.

<!-- issue-number: bpo-30235 -->
https://bugs.python.org/issue30235
<!-- /issue-number -->
