### PR TITLE
[2.7] bpo-33021: Release the GIL during fstat() calls (GH-6019)

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-03-12-00-36-37.bpo-33021.fBmBwP.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-12-00-36-37.bpo-33021.fBmBwP.rst
@@ -1,0 +1,4 @@
+Release the GIL during fstat() calls, avoiding hang of all threads when
+calling imp.load_dynamic(), imp.load_source(), mmap.mmap(),
+mmapobject.size(), os.fdopen(), os.urandom(), and random.seed().  Patch by
+Nir Soffer.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6920,7 +6920,13 @@ posix_fdopen(PyObject *self, PyObject *args)
         struct stat buf;
         const char *msg;
         PyObject *exc;
-        if (fstat(fd, &buf) == 0 && S_ISDIR(buf.st_mode)) {
+        int res;
+
+        Py_BEGIN_ALLOW_THREADS
+        res = fstat(fd, &buf);
+        Py_END_ALLOW_THREADS
+
+        if (res == 0 && S_ISDIR(buf.st_mode)) {
             PyMem_FREE(mode);
             msg = strerror(EISDIR);
             exc = PyObject_CallFunction(PyExc_IOError, "(iss)",

--- a/Python/dynload_shlib.c
+++ b/Python/dynload_shlib.c
@@ -87,7 +87,11 @@ dl_funcptr _PyImport_GetDynLoadFunc(const char *fqname, const char *shortname,
     if (fp != NULL) {
         int i;
         struct stat statb;
+
+        Py_BEGIN_ALLOW_THREADS
         fstat(fileno(fp), &statb);
+        Py_END_ALLOW_THREADS
+
         for (i = 0; i < nhandles; i++) {
             if (statb.st_dev == handles[i].dev &&
                 statb.st_ino == handles[i].ino) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -1054,6 +1054,7 @@ static PyObject *
 load_source_module(char *name, char *pathname, FILE *fp)
 {
     struct stat st;
+    int fstat_result;
     FILE *fpc;
     char *buf;
     char *cpathname;
@@ -1061,7 +1062,11 @@ load_source_module(char *name, char *pathname, FILE *fp)
     PyObject *m;
     time_t mtime;
 
-    if (fstat(fileno(fp), &st) != 0) {
+    Py_BEGIN_ALLOW_THREADS
+    fstat_result = fstat(fileno(fp), &st);
+    Py_END_ALLOW_THREADS
+
+    if (fstat_result != 0) {
         PyErr_Format(PyExc_RuntimeError,
                      "unable to get file status from '%s'",
                      pathname);


### PR DESCRIPTION
If the file descriptor is on a non-responsive NFS server, calling
fstat() can block for long time, hanging all threads. Most of the calls
release the GIL around the call, but some calls seems to be forgotten.

This patch fixes the last calls, affecting users of:
- imp.load_dynamic()
- imp.load_source()
- mmap.mmap()
- mmapobject.size()
- os.fdopen()
- os.urandom()
- random.seed()

<!-- issue-number: bpo-33021 -->
https://bugs.python.org/issue33021
<!-- /issue-number -->
