### PR TITLE
bpo-26701: Add documentation for __trunc__

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -713,7 +713,7 @@ are always available.  They are listed here in alphabetical order.
    ``0`` if no arguments are given.  If *x* is a number, return
    :meth:`x.__int__() <object.__int__>`. If *x* defines
    :meth:`x.__trunc__() <object.__trunc__>` but not
-   :meth:`x.__int__() <object.__int__>`, then return 
+   :meth:`x.__int__() <object.__int__>`, then return
    if :meth:`x.__trunc__() <object.__trunc__>`.  For floating point numbers,
    this truncates towards zero.
 

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -711,8 +711,11 @@ are always available.  They are listed here in alphabetical order.
 
    Return an integer object constructed from a number or string *x*, or return
    ``0`` if no arguments are given.  If *x* is a number, return
-   :meth:`x.__int__() <object.__int__>`.  For floating point numbers, this
-   truncates towards zero.
+   :meth:`x.__int__() <object.__int__>`. If *x* defines
+   :meth:`x.__trunc__() <object.__trunc__>` but not
+   :meth:`x.__int__() <object.__int__>`, then return 
+   if :meth:`x.__trunc__() <object.__trunc__>`.  For floating point numbers,
+   this truncates towards zero.
 
    If *x* is not a number or if *base* is given, then *x* must be a string,
    :class:`bytes`, or :class:`bytearray` instance representing an :ref:`integer

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -203,7 +203,7 @@ Number-theoretic and representation functions
 
    Return the :class:`~numbers.Real` value *x* truncated to an
    :class:`~numbers.Integral` (usually an integer). Delegates to
-   ``x.__trunc__()``.
+   :meth:`__trunc__`.
 
 
 Note that :func:`frexp` and :func:`modf` have a different call/return pattern

--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -203,7 +203,7 @@ Number-theoretic and representation functions
 
    Return the :class:`~numbers.Real` value *x* truncated to an
    :class:`~numbers.Integral` (usually an integer). Delegates to
-   :meth:`__trunc__`.
+   :meth:`x.__trunc__() <object.__trunc__>`.
 
 
 Note that :func:`frexp` and :func:`modf` have a different call/return pattern

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2289,6 +2289,15 @@ left undefined.
    of the appropriate type.
 
 
+.. method:: object.__trunc__(self)
+
+   Called to implement :meth:`math.trunc`. Should return the value of the
+   object truncated to a :class:`numbers.Integral` (typically an
+   :class:`int`).  If a class defines :meth:`__trunc__` but not
+   :meth:`__int__`, then :meth:`__trunc__` is called to implement the
+   built-in function :func:`int`.
+
+
 .. method:: object.__index__(self)
 
    Called to implement :func:`operator.index`, and whenever Python needs to

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -2291,7 +2291,7 @@ left undefined.
 
 .. method:: object.__trunc__(self)
 
-   Called to implement :meth:`math.trunc`. Should return the value of the
+   Called to implement :meth:`math.trunc`.  Should return the value of the
    object truncated to a :class:`numbers.Integral` (typically an
    :class:`int`).  If a class defines :meth:`__trunc__` but not
    :meth:`__int__`, then :meth:`__trunc__` is called to implement the


### PR DESCRIPTION
Add explicit documentation of the `__trunc__` method beyond the single mention in the math module.

Place the documentation for this method near to `__int__`, and explain that there is a fallback to `x.__trunc__()` if `x.__int__()` is not available.

<!-- issue-number: bpo-26701 -->
https://bugs.python.org/issue26701
<!-- /issue-number -->
