### PR TITLE
bpo-33012: Fix invalid function cast warnings with gcc 8 for METH_NOARGS

### DIFF
--- a/Doc/extending/newtypes_tutorial.rst
+++ b/Doc/extending/newtypes_tutorial.rst
@@ -457,7 +457,7 @@ We define a single method, :meth:`Custom.name()`, that outputs the objects name 
 concatenation of the first and last names. ::
 
    static PyObject *
-   Custom_name(CustomObject *self)
+   Custom_name(CustomObject *self, PyObject *Py_UNUSED(ignored))
    {
        if (self->first == NULL) {
            PyErr_SetString(PyExc_AttributeError, "first");

--- a/Misc/NEWS.d/next/Build/2018-03-08-20-25-29.bpo-33012.k9Fe1q.rst
+++ b/Misc/NEWS.d/next/Build/2018-03-08-20-25-29.bpo-33012.k9Fe1q.rst
@@ -1,0 +1,5 @@
+gcc 8 has added a new warning heuristic to detect invalid function casts and
+a stock python build seems to hit that warning quite often.  The most common
+is the cast of a METH_NOARGS function (that uses just one argument) to a
+PyCFunction. Fix this by adding a dummy argument to all functions that
+implement METH_NOARGS.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -512,7 +512,7 @@ deque_inplace_concat(dequeobject *deque, PyObject *other)
 }
 
 static PyObject *
-deque_copy(PyObject *deque)
+deque_copy(PyObject *deque, PyObject *Py_UNUSED(ignored))
 {
     dequeobject *old_deque = (dequeobject *)deque;
     if (Py_TYPE(deque) == &deque_type) {
@@ -563,7 +563,7 @@ deque_concat(dequeobject *deque, PyObject *other)
         return NULL;
     }
 
-    new_deque = deque_copy((PyObject *)deque);
+    new_deque = deque_copy((PyObject *)deque, NULL);
     if (new_deque == NULL)
         return NULL;
     result = deque_extend((dequeobject *)new_deque, other);
@@ -659,7 +659,7 @@ deque_clear(dequeobject *deque)
 }
 
 static PyObject *
-deque_clearmethod(dequeobject *deque)
+deque_clearmethod(dequeobject *deque, PyObject *Py_UNUSED(ignored))
 {
     deque_clear(deque);
     Py_RETURN_NONE;
@@ -754,7 +754,7 @@ deque_repeat(dequeobject *deque, Py_ssize_t n)
     dequeobject *new_deque;
     PyObject *rv;
 
-    new_deque = (dequeobject *)deque_copy((PyObject *) deque);
+    new_deque = (dequeobject *)deque_copy((PyObject *) deque, NULL);
     if (new_deque == NULL)
         return NULL;
     rv = deque_inplace_repeat(new_deque, n);
@@ -1576,7 +1576,7 @@ static PyNumberMethods deque_as_number = {
  };
 
 static PyObject *deque_iter(dequeobject *deque);
-static PyObject *deque_reviter(dequeobject *deque);
+static PyObject *deque_reviter(dequeobject *deque, PyObject *Py_UNUSED(ignored));
 PyDoc_STRVAR(reversed_doc,
     "D.__reversed__() -- return a reverse iterator over the deque");
 
@@ -1587,9 +1587,9 @@ static PyMethodDef deque_methods[] = {
         METH_O,                  appendleft_doc},
     {"clear",                   (PyCFunction)deque_clearmethod,
         METH_NOARGS,             clear_doc},
-    {"__copy__",                (PyCFunction)deque_copy,
+    {"__copy__",                deque_copy,
         METH_NOARGS,             copy_doc},
-    {"copy",                    (PyCFunction)deque_copy,
+    {"copy",                    deque_copy,
         METH_NOARGS,             copy_doc},
     {"count",                   (PyCFunction)deque_count,
         METH_O,                  count_doc},
@@ -1774,7 +1774,7 @@ dequeiter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 }
 
 static PyObject *
-dequeiter_len(dequeiterobject *it)
+dequeiter_len(dequeiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromSsize_t(it->counter);
 }
@@ -1782,7 +1782,7 @@ dequeiter_len(dequeiterobject *it)
 PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-dequeiter_reduce(dequeiterobject *it)
+dequeiter_reduce(dequeiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("O(On)", Py_TYPE(it), it->deque, Py_SIZE(it->deque) - it->counter);
 }
@@ -1841,7 +1841,7 @@ static PyTypeObject dequeiter_type = {
 static PyTypeObject dequereviter_type;
 
 static PyObject *
-deque_reviter(dequeobject *deque)
+deque_reviter(dequeobject *deque, PyObject *Py_UNUSED(ignored))
 {
     dequeiterobject *it;
 
@@ -1896,7 +1896,7 @@ dequereviter_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     assert(type == &dequereviter_type);
 
-    it = (dequeiterobject*)deque_reviter((dequeobject *)deque);
+    it = (dequeiterobject*)deque_reviter((dequeobject *)deque, NULL);
     if (!it)
         return NULL;
     /* consume items from the queue */
@@ -2001,7 +2001,7 @@ defdict_missing(defdictobject *dd, PyObject *key)
 PyDoc_STRVAR(defdict_copy_doc, "D.copy() -> a shallow copy of D.");
 
 static PyObject *
-defdict_copy(defdictobject *dd)
+defdict_copy(defdictobject *dd, PyObject *Py_UNUSED(ignored))
 {
     /* This calls the object's class.  That only works for subclasses
        whose class constructor has the same signature.  Subclasses that
@@ -2015,7 +2015,7 @@ defdict_copy(defdictobject *dd)
 }
 
 static PyObject *
-defdict_reduce(defdictobject *dd)
+defdict_reduce(defdictobject *dd, PyObject *Py_UNUSED(ignored))
 {
     /* __reduce__ must return a 5-tuple as follows:
 

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2590,7 +2590,7 @@ delta_getstate(PyDateTime_Delta *self)
 }
 
 static PyObject *
-delta_total_seconds(PyObject *self)
+delta_total_seconds(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *total_seconds;
     PyObject *total_microseconds;
@@ -2606,7 +2606,7 @@ delta_total_seconds(PyObject *self)
 }
 
 static PyObject *
-delta_reduce(PyDateTime_Delta* self)
+delta_reduce(PyDateTime_Delta* self, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("ON", Py_TYPE(self), delta_getstate(self));
 }
@@ -2627,7 +2627,7 @@ static PyMemberDef delta_members[] = {
 };
 
 static PyMethodDef delta_methods[] = {
-    {"total_seconds", (PyCFunction)delta_total_seconds, METH_NOARGS,
+    {"total_seconds", delta_total_seconds, METH_NOARGS,
      PyDoc_STR("Total seconds in the duration.")},
 
     {"__reduce__", (PyCFunction)delta_reduce, METH_NOARGS,
@@ -2991,7 +2991,7 @@ date_repr(PyDateTime_Date *self)
 }
 
 static PyObject *
-date_isoformat(PyDateTime_Date *self)
+date_isoformat(PyDateTime_Date *self, PyObject *Py_UNUSED(ignored))
 {
     return PyUnicode_FromFormat("%04d-%02d-%02d",
                                 GET_YEAR(self), GET_MONTH(self), GET_DAY(self));
@@ -3006,7 +3006,7 @@ date_str(PyDateTime_Date *self)
 
 
 static PyObject *
-date_ctime(PyDateTime_Date *self)
+date_ctime(PyDateTime_Date *self, PyObject *Py_UNUSED(ignored))
 {
     return format_ctime(self, 0, 0, 0);
 }
@@ -3055,7 +3055,7 @@ date_format(PyDateTime_Date *self, PyObject *args)
 /* ISO methods. */
 
 static PyObject *
-date_isoweekday(PyDateTime_Date *self)
+date_isoweekday(PyDateTime_Date *self, PyObject *Py_UNUSED(ignored))
 {
     int dow = weekday(GET_YEAR(self), GET_MONTH(self), GET_DAY(self));
 
@@ -3063,7 +3063,7 @@ date_isoweekday(PyDateTime_Date *self)
 }
 
 static PyObject *
-date_isocalendar(PyDateTime_Date *self)
+date_isocalendar(PyDateTime_Date *self, PyObject *Py_UNUSED(ignored))
 {
     int  year         = GET_YEAR(self);
     int  week1_monday = iso_week1_monday(year);
@@ -3100,7 +3100,7 @@ date_richcompare(PyObject *self, PyObject *other, int op)
 }
 
 static PyObject *
-date_timetuple(PyDateTime_Date *self)
+date_timetuple(PyDateTime_Date *self, PyObject *Py_UNUSED(ignored))
 {
     return build_struct_time(GET_YEAR(self),
                              GET_MONTH(self),
@@ -3149,14 +3149,14 @@ date_hash(PyDateTime_Date *self)
 }
 
 static PyObject *
-date_toordinal(PyDateTime_Date *self)
+date_toordinal(PyDateTime_Date *self, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromLong(ymd_to_ord(GET_YEAR(self), GET_MONTH(self),
                                      GET_DAY(self)));
 }
 
 static PyObject *
-date_weekday(PyDateTime_Date *self)
+date_weekday(PyDateTime_Date *self, PyObject *Py_UNUSED(ignored))
 {
     int dow = weekday(GET_YEAR(self), GET_MONTH(self), GET_DAY(self));
 
@@ -3435,7 +3435,7 @@ Fail:
  */
 
 static PyObject *
-tzinfo_reduce(PyObject *self)
+tzinfo_reduce(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *args, *state;
     PyObject *getinitargs, *getstate;
@@ -3502,7 +3502,7 @@ static PyMethodDef tzinfo_methods[] = {
     {"fromutc",         (PyCFunction)tzinfo_fromutc,            METH_O,
      PyDoc_STR("datetime in UTC -> datetime in local time.")},
 
-    {"__reduce__",  (PyCFunction)tzinfo_reduce,             METH_NOARGS,
+    {"__reduce__",  tzinfo_reduce,             METH_NOARGS,
      PyDoc_STR("-> (cls, state)")},
 
     {NULL, NULL}
@@ -3720,7 +3720,7 @@ timezone_fromutc(PyDateTime_TimeZone *self, PyDateTime_DateTime *dt)
 }
 
 static PyObject *
-timezone_getinitargs(PyDateTime_TimeZone *self)
+timezone_getinitargs(PyDateTime_TimeZone *self, PyObject *Py_UNUSED(ignored))
 {
     if (self->name == NULL)
         return Py_BuildValue("(O)", self->offset);
@@ -5173,7 +5173,7 @@ datetime_isoformat(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
 }
 
 static PyObject *
-datetime_ctime(PyDateTime_DateTime *self)
+datetime_ctime(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
     return format_ctime((PyDateTime_Date *)self,
                         DATE_GET_HOUR(self),
@@ -5652,7 +5652,7 @@ datetime_astimezone(PyDateTime_DateTime *self, PyObject *args, PyObject *kw)
 }
 
 static PyObject *
-datetime_timetuple(PyDateTime_DateTime *self)
+datetime_timetuple(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
     int dstflag = -1;
 
@@ -5727,7 +5727,7 @@ local_to_seconds(int year, int month, int day,
 #define EPOCH_SECONDS (719163LL * 24 * 60 * 60)
 
 static PyObject *
-datetime_timestamp(PyDateTime_DateTime *self)
+datetime_timestamp(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *result;
 
@@ -5736,7 +5736,7 @@ datetime_timestamp(PyDateTime_DateTime *self)
         delta = datetime_subtract((PyObject *)self, PyDateTime_Epoch);
         if (delta == NULL)
             return NULL;
-        result = delta_total_seconds(delta);
+        result = delta_total_seconds(delta, NULL);
         Py_DECREF(delta);
     }
     else {
@@ -5757,7 +5757,7 @@ datetime_timestamp(PyDateTime_DateTime *self)
 }
 
 static PyObject *
-datetime_getdate(PyDateTime_DateTime *self)
+datetime_getdate(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
     return new_date(GET_YEAR(self),
                     GET_MONTH(self),
@@ -5765,7 +5765,7 @@ datetime_getdate(PyDateTime_DateTime *self)
 }
 
 static PyObject *
-datetime_gettime(PyDateTime_DateTime *self)
+datetime_gettime(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
     return new_time(DATE_GET_HOUR(self),
                     DATE_GET_MINUTE(self),
@@ -5776,7 +5776,7 @@ datetime_gettime(PyDateTime_DateTime *self)
 }
 
 static PyObject *
-datetime_gettimetz(PyDateTime_DateTime *self)
+datetime_gettimetz(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
     return new_time(DATE_GET_HOUR(self),
                     DATE_GET_MINUTE(self),
@@ -5787,7 +5787,7 @@ datetime_gettimetz(PyDateTime_DateTime *self)
 }
 
 static PyObject *
-datetime_utctimetuple(PyDateTime_DateTime *self)
+datetime_utctimetuple(PyDateTime_DateTime *self, PyObject *Py_UNUSED(ignored))
 {
     int y, m, d, hh, mm, ss;
     PyObject *tzinfo;

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -758,7 +758,7 @@ _io_BytesIO_close_impl(bytesio *self)
  */
 
 static PyObject *
-bytesio_getstate(bytesio *self)
+bytesio_getstate(bytesio *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *initvalue = _io_BytesIO_getvalue_impl(self);
     PyObject *dict;

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -1123,7 +1123,7 @@ _io_FileIO_isatty_impl(fileio *self)
 }
 
 static PyObject *
-fileio_getstate(fileio *self)
+fileio_getstate(fileio *self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_Format(PyExc_TypeError,
                  "cannot serialize '%s' object", Py_TYPE(self)->tp_name);

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -812,7 +812,7 @@ _io_StringIO_seekable_impl(stringio *self)
 */
 
 static PyObject *
-stringio_getstate(stringio *self)
+stringio_getstate(stringio *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *initvalue = _io_StringIO_getvalue_impl(self);
     PyObject *dict;

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -66,7 +66,7 @@ PyDoc_STRVAR(textiobase_detach_doc,
     );
 
 static PyObject *
-textiobase_detach(PyObject *self)
+textiobase_detach(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _unsupported("detach");
 }
@@ -148,7 +148,7 @@ textiobase_errors_get(PyObject *self, void *context)
 
 
 static PyMethodDef textiobase_methods[] = {
-    {"detach", (PyCFunction)textiobase_detach, METH_NOARGS, textiobase_detach_doc},
+    {"detach", textiobase_detach, METH_NOARGS, textiobase_detach_doc},
     {"read", textiobase_read, METH_VARARGS, textiobase_read_doc},
     {"readline", textiobase_readline, METH_VARARGS, textiobase_readline_doc},
     {"write", textiobase_write, METH_VARARGS, textiobase_write_doc},

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -1057,7 +1057,7 @@ _io__WindowsConsoleIO_isatty_impl(winconsoleio *self)
 }
 
 static PyObject *
-winconsoleio_getstate(winconsoleio *self)
+winconsoleio_getstate(winconsoleio *self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_Format(PyExc_TypeError,
                  "cannot serialize '%s' object", Py_TYPE(self)->tp_name);

--- a/Modules/_localemodule.c
+++ b/Modules/_localemodule.c
@@ -132,7 +132,7 @@ PyDoc_STRVAR(localeconv__doc__,
 "() -> dict. Returns numeric and monetary locale-specific parameters.");
 
 static PyObject*
-PyLocale_localeconv(PyObject* self)
+PyLocale_localeconv(PyObject* self, PyObject *Py_UNUSED(ignored))
 {
     PyObject* result;
     struct lconv *l;
@@ -317,7 +317,7 @@ exit:
 
 #if defined(MS_WINDOWS)
 static PyObject*
-PyLocale_getdefaultlocale(PyObject* self)
+PyLocale_getdefaultlocale(PyObject* self, PyObject *Py_UNUSED(ignored))
 {
     char encoding[100];
     char locale[100];
@@ -605,8 +605,7 @@ PyIntl_bind_textdomain_codeset(PyObject* self,PyObject*args)
 static struct PyMethodDef PyLocale_Methods[] = {
   {"setlocale", (PyCFunction) PyLocale_setlocale,
    METH_VARARGS, setlocale__doc__},
-  {"localeconv", (PyCFunction) PyLocale_localeconv,
-   METH_NOARGS, localeconv__doc__},
+  {"localeconv", PyLocale_localeconv, METH_NOARGS, localeconv__doc__},
 #ifdef HAVE_WCSCOLL
   {"strcoll", (PyCFunction) PyLocale_strcoll,
    METH_VARARGS, strcoll__doc__},
@@ -616,7 +615,7 @@ static struct PyMethodDef PyLocale_Methods[] = {
    METH_VARARGS, strxfrm__doc__},
 #endif
 #if defined(MS_WINDOWS)
-  {"_getdefaultlocale", (PyCFunction) PyLocale_getdefaultlocale, METH_NOARGS},
+  {"_getdefaultlocale", PyLocale_getdefaultlocale, METH_NOARGS},
 #endif
 #ifdef HAVE_LANGINFO_H
   {"nl_langinfo", (PyCFunction) PyLocale_nl_langinfo,

--- a/Modules/_multiprocessing/semaphore.c
+++ b/Modules/_multiprocessing/semaphore.c
@@ -518,20 +518,20 @@ semlock_dealloc(SemLockObject* self)
 }
 
 static PyObject *
-semlock_count(SemLockObject *self)
+semlock_count(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromLong((long)self->count);
 }
 
 static PyObject *
-semlock_ismine(SemLockObject *self)
+semlock_ismine(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
     /* only makes sense for a lock */
     return PyBool_FromLong(ISMINE(self));
 }
 
 static PyObject *
-semlock_getvalue(SemLockObject *self)
+semlock_getvalue(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
 #ifdef HAVE_BROKEN_SEM_GETVALUE
     PyErr_SetNone(PyExc_NotImplementedError);
@@ -549,7 +549,7 @@ semlock_getvalue(SemLockObject *self)
 }
 
 static PyObject *
-semlock_iszero(SemLockObject *self)
+semlock_iszero(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
 #ifdef HAVE_BROKEN_SEM_GETVALUE
     if (sem_trywait(self->handle) < 0) {
@@ -570,7 +570,7 @@ semlock_iszero(SemLockObject *self)
 }
 
 static PyObject *
-semlock_afterfork(SemLockObject *self)
+semlock_afterfork(SemLockObject *self, PyObject *Py_UNUSED(ignored))
 {
     self->count = 0;
     Py_RETURN_NONE;

--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -1040,7 +1040,7 @@ itemgetter_repr(itemgetterobject *ig)
 }
 
 static PyObject *
-itemgetter_reduce(itemgetterobject *ig)
+itemgetter_reduce(itemgetterobject *ig, PyObject *Py_UNUSED(ignored))
 {
     if (ig->nitems == 1)
         return Py_BuildValue("O(O)", Py_TYPE(ig), ig->item);
@@ -1382,7 +1382,7 @@ attrgetter_repr(attrgetterobject *ag)
 }
 
 static PyObject *
-attrgetter_reduce(attrgetterobject *ag)
+attrgetter_reduce(attrgetterobject *ag, PyObject *Py_UNUSED(ignored))
 {
     PyObject *attrstrings = attrgetter_args(ag);
     if (attrstrings == NULL)
@@ -1615,7 +1615,7 @@ done:
 }
 
 static PyObject *
-methodcaller_reduce(methodcallerobject *mc)
+methodcaller_reduce(methodcallerobject *mc, PyObject *Py_UNUSED(ignored))
 {
     PyObject *newargs;
     if (!mc->kwds || PyDict_GET_SIZE(mc->kwds) == 0) {

--- a/Modules/_randommodule.c
+++ b/Modules/_randommodule.c
@@ -138,7 +138,7 @@ genrand_int32(RandomObject *self)
  * The original code credited Isaku Wada for this algorithm, 2002/01/09.
  */
 static PyObject *
-random_random(RandomObject *self)
+random_random(RandomObject *self, PyObject *Py_UNUSED(ignored))
 {
     uint32_t a=genrand_int32(self)>>5, b=genrand_int32(self)>>6;
     return PyFloat_FromDouble((a*67108864.0+b)*(1.0/9007199254740992.0));
@@ -319,7 +319,7 @@ Done:
 }
 
 static PyObject *
-random_getstate(RandomObject *self)
+random_getstate(RandomObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *state;
     PyObject *element;

--- a/Modules/_scproxy.c
+++ b/Modules/_scproxy.c
@@ -53,7 +53,7 @@ cfstring_to_pystring(CFStringRef ref)
 
 
 static PyObject*
-get_proxy_settings(PyObject* mod __attribute__((__unused__)))
+get_proxy_settings(PyObject* Py_UNUSED(mod), PyObject *Py_UNUSED(ignored))
 {
     CFDictionaryRef proxyDict = NULL;
     CFNumberRef aNum = NULL;
@@ -166,7 +166,7 @@ set_proxy(PyObject* proxies, const char* proto, CFDictionaryRef proxyDict,
 
 
 static PyObject*
-get_proxies(PyObject* mod __attribute__((__unused__)))
+get_proxies(PyObject* Py_UNUSED(mod), PyObject *Py_UNUSED(ignored))
 {
     PyObject* result = NULL;
     int r;
@@ -212,13 +212,13 @@ error:
 static PyMethodDef mod_methods[] = {
     {
         "_get_proxy_settings",
-        (PyCFunction)get_proxy_settings,
+        get_proxy_settings,
         METH_NOARGS,
         NULL,
     },
     {
         "_get_proxies",
-        (PyCFunction)get_proxies,
+        get_proxies,
         METH_NOARGS,
         NULL,
     },

--- a/Modules/_sqlite/row.c
+++ b/Modules/_sqlite/row.c
@@ -155,7 +155,7 @@ Py_ssize_t pysqlite_row_length(pysqlite_Row* self, PyObject* args, PyObject* kwa
     return PyTuple_GET_SIZE(self->data);
 }
 
-PyObject* pysqlite_row_keys(pysqlite_Row* self, PyObject* args, PyObject* kwargs)
+PyObject* pysqlite_row_keys(pysqlite_Row* self, PyObject *Py_UNUSED(ignored))
 {
     PyObject* list;
     Py_ssize_t nitems, i;

--- a/Modules/_struct.c
+++ b/Modules/_struct.c
@@ -1629,7 +1629,7 @@ unpackiter_traverse(unpackiterobject *self, visitproc visit, void *arg)
 }
 
 static PyObject *
-unpackiter_len(unpackiterobject *self)
+unpackiter_len(unpackiterobject *self, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t len;
     if (self->so == NULL)

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -2354,7 +2354,7 @@ out:
 }
 
 static PyObject *
-get_sizeof_void_p(PyObject *self)
+get_sizeof_void_p(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromSize_t(sizeof(void *));
 }
@@ -2807,7 +2807,7 @@ static PyTypeObject StaticArray_Type = {
 static struct PyMethodDef _testbuffer_functions[] = {
     {"slice_indices", slice_indices, METH_VARARGS, NULL},
     {"get_pointer", get_pointer, METH_VARARGS, NULL},
-    {"get_sizeof_void_p", (PyCFunction)get_sizeof_void_p, METH_NOARGS, NULL},
+    {"get_sizeof_void_p", get_sizeof_void_p, METH_NOARGS, NULL},
     {"get_contiguous", get_contiguous, METH_VARARGS, NULL},
     {"py_buffer_to_contiguous", py_buffer_to_contiguous, METH_VARARGS, NULL},
     {"is_contiguous", is_contiguous, METH_VARARGS, NULL},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -51,7 +51,7 @@ sizeof_error(const char* fatname, const char* typname,
 }
 
 static PyObject*
-test_config(PyObject *self)
+test_config(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
 #define CHECK_SIZEOF(FATNAME, TYPE) \
             if (FATNAME != sizeof(TYPE)) \
@@ -70,7 +70,7 @@ test_config(PyObject *self)
 }
 
 static PyObject*
-test_sizeof_c_types(PyObject *self)
+test_sizeof_c_types(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
 #if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ > 5)))
 #pragma GCC diagnostic push
@@ -131,7 +131,7 @@ test_sizeof_c_types(PyObject *self)
 
 
 static PyObject*
-test_list_api(PyObject *self)
+test_list_api(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject* list;
     int i;
@@ -223,7 +223,7 @@ test_dict_inner(int count)
 }
 
 static PyObject*
-test_dict_iteration(PyObject* self)
+test_dict_iteration(PyObject* self, PyObject *Py_UNUSED(ignored))
 {
     int i;
 
@@ -315,7 +315,7 @@ static PyTypeObject _HashInheritanceTester_Type = {
 };
 
 static PyObject*
-test_lazy_hash_inheritance(PyObject* self)
+test_lazy_hash_inheritance(PyObject* self, PyObject *Py_UNUSED(ignored))
 {
     PyTypeObject *type;
     PyObject *obj;
@@ -411,7 +411,7 @@ raise_test_long_error(const char* msg)
 #include "testcapi_long.h"
 
 static PyObject *
-test_long_api(PyObject* self)
+test_long_api(PyObject* self, PyObject *Py_UNUSED(ignored))
 {
     return TESTNAME(raise_test_long_error);
 }
@@ -457,7 +457,7 @@ test_longlong_api(PyObject* self, PyObject *args)
 */
 
 static PyObject *
-test_long_and_overflow(PyObject *self)
+test_long_and_overflow(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *num, *one, *temp;
     long value;
@@ -621,7 +621,7 @@ test_long_and_overflow(PyObject *self)
 */
 
 static PyObject *
-test_long_long_and_overflow(PyObject *self)
+test_long_long_and_overflow(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *num, *one, *temp;
     long long value;
@@ -785,7 +785,7 @@ test_long_long_and_overflow(PyObject *self)
  */
 
 static PyObject *
-test_long_as_size_t(PyObject *self)
+test_long_as_size_t(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     size_t out_u;
     Py_ssize_t out_s;
@@ -821,7 +821,7 @@ test_long_as_size_t(PyObject *self)
  */
 
 static PyObject *
-test_long_as_double(PyObject *self)
+test_long_as_double(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     double out;
 
@@ -846,7 +846,7 @@ test_long_as_double(PyObject *self)
    it fails.
 */
 static PyObject *
-test_L_code(PyObject *self)
+test_L_code(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *tuple, *num;
     long long value;
@@ -1173,7 +1173,7 @@ getargs_K(PyObject *self, PyObject *args)
 /* This function not only tests the 'k' getargs code, but also the
    PyLong_AsUnsignedLongMask() function. */
 static PyObject *
-test_k_code(PyObject *self)
+test_k_code(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *tuple, *num;
     unsigned long value;
@@ -1531,7 +1531,7 @@ getargs_et_hash(PyObject *self, PyObject *args)
 /* Test the s and z codes for PyArg_ParseTuple.
 */
 static PyObject *
-test_s_code(PyObject *self)
+test_s_code(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     /* Unicode strings should be accepted */
     PyObject *tuple, *obj;
@@ -1637,7 +1637,7 @@ static volatile int x;
    of an error.
 */
 static PyObject *
-test_u_code(PyObject *self)
+test_u_code(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *tuple, *obj;
     Py_UNICODE *value;
@@ -1680,7 +1680,7 @@ test_u_code(PyObject *self)
 
 /* Test Z and Z# codes for PyArg_ParseTuple */
 static PyObject *
-test_Z_code(PyObject *self)
+test_Z_code(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *tuple, *obj;
     const Py_UNICODE *value1, *value2;
@@ -1735,7 +1735,7 @@ test_Z_code(PyObject *self)
 }
 
 static PyObject *
-test_widechar(PyObject *self)
+test_widechar(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
 #if defined(SIZEOF_WCHAR_T) && (SIZEOF_WCHAR_T == 4)
     const wchar_t wtext[2] = {(wchar_t)0x10ABCDu};
@@ -2033,7 +2033,7 @@ getargs_w_star(PyObject *self, PyObject *args)
 
 
 static PyObject *
-test_empty_argparse(PyObject *self)
+test_empty_argparse(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     /* Test that formats can begin with '|'. See issue #4720. */
     PyObject *tuple, *dict = NULL;
@@ -2083,7 +2083,7 @@ codec_incrementaldecoder(PyObject *self, PyObject *args)
 
 /* Simple test of _PyLong_NumBits and _PyLong_Sign. */
 static PyObject *
-test_long_numbits(PyObject *self)
+test_long_numbits(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     struct triple {
         long input;
@@ -2131,7 +2131,7 @@ test_long_numbits(PyObject *self)
 /* Example passing NULLs to PyObject_Str(NULL). */
 
 static PyObject *
-test_null_strings(PyObject *self)
+test_null_strings(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *o1 = PyObject_Str(NULL), *o2 = PyObject_Str(NULL);
     PyObject *tuple = PyTuple_Pack(2, o1, o2);
@@ -2492,7 +2492,7 @@ test_string_from_format(PyObject *self, PyObject *args)
 
 
 static PyObject *
-test_unicode_compare_with_ascii(PyObject *self) {
+test_unicode_compare_with_ascii(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     PyObject *py_s = PyUnicode_FromStringAndSize("str\0", 4);
     int result;
     if (py_s == NULL)
@@ -2509,14 +2509,14 @@ test_unicode_compare_with_ascii(PyObject *self) {
 
 /* This is here to provide a docstring for test_descr. */
 static PyObject *
-test_with_docstring(PyObject *self)
+test_with_docstring(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     Py_RETURN_NONE;
 }
 
 /* Test PyOS_string_to_double. */
 static PyObject *
-test_string_to_double(PyObject *self) {
+test_string_to_double(PyObject *self, PyObject *Py_UNUSED(ignored)) {
     double result;
     const char *msg;
 
@@ -2881,7 +2881,7 @@ exception_print(PyObject *self, PyObject *args)
 
 /* reliably raise a MemoryError */
 static PyObject *
-raise_memoryerror(PyObject *self)
+raise_memoryerror(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_NoMemory();
     return NULL;
@@ -2954,7 +2954,7 @@ make_exception_with_doc(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 static PyObject *
-make_memoryview_from_NULL_pointer(PyObject *self)
+make_memoryview_from_NULL_pointer(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     Py_buffer info;
     if (PyBuffer_FillInfo(&info, NULL, NULL, 1, 1, PyBUF_FULL_RO) < 0)
@@ -3067,7 +3067,7 @@ getbuffer_with_null_view(PyObject* self, PyObject *obj)
 /* Test that the fatal error from not having a current thread doesn't
    cause an infinite loop.  Run via Lib/test/test_capi.py */
 static PyObject *
-crash_no_current_thread(PyObject *self)
+crash_no_current_thread(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     Py_BEGIN_ALLOW_THREADS
     /* Using PyThreadState_Get() directly allows the test to pass in
@@ -3274,7 +3274,7 @@ _test_incref(PyObject *ob)
 }
 
 static PyObject *
-test_xincref_doesnt_leak(PyObject *ob)
+test_xincref_doesnt_leak(PyObject *ob, PyObject *Py_UNUSED(ignored))
 {
     PyObject *obj = PyLong_FromLong(0);
     Py_XINCREF(_test_incref(obj));
@@ -3285,7 +3285,7 @@ test_xincref_doesnt_leak(PyObject *ob)
 }
 
 static PyObject *
-test_incref_doesnt_leak(PyObject *ob)
+test_incref_doesnt_leak(PyObject *ob, PyObject *Py_UNUSED(ignored))
 {
     PyObject *obj = PyLong_FromLong(0);
     Py_INCREF(_test_incref(obj));
@@ -3296,21 +3296,21 @@ test_incref_doesnt_leak(PyObject *ob)
 }
 
 static PyObject *
-test_xdecref_doesnt_leak(PyObject *ob)
+test_xdecref_doesnt_leak(PyObject *ob, PyObject *Py_UNUSED(ignored))
 {
     Py_XDECREF(PyLong_FromLong(0));
     Py_RETURN_NONE;
 }
 
 static PyObject *
-test_decref_doesnt_leak(PyObject *ob)
+test_decref_doesnt_leak(PyObject *ob, PyObject *Py_UNUSED(ignored))
 {
     Py_DECREF(PyLong_FromLong(0));
     Py_RETURN_NONE;
 }
 
 static PyObject *
-test_incref_decref_API(PyObject *ob)
+test_incref_decref_API(PyObject *ob, PyObject *Py_UNUSED(ignored))
 {
     PyObject *obj = PyLong_FromLong(0);
     Py_IncRef(obj);
@@ -3320,7 +3320,7 @@ test_incref_decref_API(PyObject *ob)
 }
 
 static PyObject *
-test_pymem_alloc0(PyObject *self)
+test_pymem_alloc0(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     void *ptr;
 
@@ -3546,19 +3546,19 @@ finally:
 }
 
 static PyObject *
-test_pymem_setrawallocators(PyObject *self)
+test_pymem_setrawallocators(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return test_setallocators(PYMEM_DOMAIN_RAW);
 }
 
 static PyObject *
-test_pymem_setallocators(PyObject *self)
+test_pymem_setallocators(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return test_setallocators(PYMEM_DOMAIN_MEM);
 }
 
 static PyObject *
-test_pyobject_setallocators(PyObject *self)
+test_pyobject_setallocators(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return test_setallocators(PYMEM_DOMAIN_OBJ);
 }
@@ -3681,7 +3681,7 @@ set_nomemory(PyObject *self, PyObject *args)
 }
 
 static PyObject*
-remove_mem_hooks(PyObject *self)
+remove_mem_hooks(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     fm_remove_hooks();
     Py_RETURN_NONE;
@@ -4552,10 +4552,10 @@ new_hamt(PyObject *self, PyObject *args)
 
 static PyMethodDef TestMethods[] = {
     {"raise_exception",         raise_exception,                 METH_VARARGS},
-    {"raise_memoryerror",   (PyCFunction)raise_memoryerror,  METH_NOARGS},
+    {"raise_memoryerror",       raise_memoryerror,               METH_NOARGS},
     {"set_errno",               set_errno,                       METH_VARARGS},
-    {"test_config",             (PyCFunction)test_config,        METH_NOARGS},
-    {"test_sizeof_c_types",     (PyCFunction)test_sizeof_c_types, METH_NOARGS},
+    {"test_config",             test_config,                     METH_NOARGS},
+    {"test_sizeof_c_types",     test_sizeof_c_types,             METH_NOARGS},
     {"test_datetime_capi",  test_datetime_capi,              METH_NOARGS},
     {"datetime_check_date",     datetime_check_date,             METH_VARARGS},
     {"datetime_check_time",     datetime_check_time,             METH_VARARGS},
@@ -4565,31 +4565,31 @@ static PyMethodDef TestMethods[] = {
     {"make_timezones_capi",     make_timezones_capi,             METH_NOARGS},
     {"get_timezones_offset_zero",   get_timezones_offset_zero,   METH_NOARGS},
     {"get_timezone_utc_capi",    get_timezone_utc_capi,            METH_VARARGS},
-    {"test_list_api",           (PyCFunction)test_list_api,      METH_NOARGS},
-    {"test_dict_iteration",     (PyCFunction)test_dict_iteration,METH_NOARGS},
+    {"test_list_api",           test_list_api,                   METH_NOARGS},
+    {"test_dict_iteration",     test_dict_iteration,             METH_NOARGS},
     {"dict_getitem_knownhash",  dict_getitem_knownhash,          METH_VARARGS},
     {"dict_hassplittable",      dict_hassplittable,              METH_O},
-    {"test_lazy_hash_inheritance",      (PyCFunction)test_lazy_hash_inheritance,METH_NOARGS},
-    {"test_long_api",           (PyCFunction)test_long_api,      METH_NOARGS},
-    {"test_xincref_doesnt_leak",(PyCFunction)test_xincref_doesnt_leak,      METH_NOARGS},
-    {"test_incref_doesnt_leak", (PyCFunction)test_incref_doesnt_leak,      METH_NOARGS},
-    {"test_xdecref_doesnt_leak",(PyCFunction)test_xdecref_doesnt_leak,      METH_NOARGS},
-    {"test_decref_doesnt_leak", (PyCFunction)test_decref_doesnt_leak,      METH_NOARGS},
-    {"test_incref_decref_API",  (PyCFunction)test_incref_decref_API,       METH_NOARGS},
-    {"test_long_and_overflow", (PyCFunction)test_long_and_overflow,
-     METH_NOARGS},
-    {"test_long_as_double",     (PyCFunction)test_long_as_double,METH_NOARGS},
-    {"test_long_as_size_t",     (PyCFunction)test_long_as_size_t,METH_NOARGS},
-    {"test_long_numbits",       (PyCFunction)test_long_numbits,  METH_NOARGS},
-    {"test_k_code",             (PyCFunction)test_k_code,        METH_NOARGS},
-    {"test_empty_argparse", (PyCFunction)test_empty_argparse,METH_NOARGS},
+    {"test_lazy_hash_inheritance",      test_lazy_hash_inheritance,METH_NOARGS},
+    {"test_long_api",           test_long_api,                   METH_NOARGS},
+    {"test_xincref_doesnt_leak",test_xincref_doesnt_leak,        METH_NOARGS},
+    {"test_incref_doesnt_leak", test_incref_doesnt_leak,         METH_NOARGS},
+    {"test_xdecref_doesnt_leak",test_xdecref_doesnt_leak,        METH_NOARGS},
+    {"test_decref_doesnt_leak", test_decref_doesnt_leak,         METH_NOARGS},
+    {"test_incref_decref_API",  test_incref_decref_API,          METH_NOARGS},
+    {"test_long_and_overflow",  test_long_and_overflow,          METH_NOARGS},
+    {"test_long_as_double",     test_long_as_double,             METH_NOARGS},
+    {"test_long_as_size_t",     test_long_as_size_t,             METH_NOARGS},
+    {"test_long_numbits",       test_long_numbits,               METH_NOARGS},
+    {"test_k_code",             test_k_code,                     METH_NOARGS},
+    {"test_empty_argparse",     test_empty_argparse,             METH_NOARGS},
     {"parse_tuple_and_keywords", parse_tuple_and_keywords, METH_VARARGS},
-    {"test_null_strings",       (PyCFunction)test_null_strings,  METH_NOARGS},
+    {"test_null_strings",       test_null_strings,               METH_NOARGS},
     {"test_string_from_format", (PyCFunction)test_string_from_format, METH_NOARGS},
-    {"test_with_docstring", (PyCFunction)test_with_docstring, METH_NOARGS,
+    {"test_with_docstring",     test_with_docstring,             METH_NOARGS,
      PyDoc_STR("This is a pretty normal docstring.")},
-    {"test_string_to_double", (PyCFunction)test_string_to_double, METH_NOARGS},
-    {"test_unicode_compare_with_ascii", (PyCFunction)test_unicode_compare_with_ascii, METH_NOARGS},
+    {"test_string_to_double",   test_string_to_double,           METH_NOARGS},
+    {"test_unicode_compare_with_ascii", test_unicode_compare_with_ascii,
+     METH_NOARGS},
     {"test_capsule", (PyCFunction)test_capsule, METH_NOARGS},
     {"test_from_contiguous", (PyCFunction)test_from_contiguous, METH_NOARGS},
 #if (defined(__linux__) || defined(__FreeBSD__)) && defined(__GNUC__)
@@ -4620,9 +4620,8 @@ static PyMethodDef TestMethods[] = {
     {"getargs_L",               getargs_L,                       METH_VARARGS},
     {"getargs_K",               getargs_K,                       METH_VARARGS},
     {"test_longlong_api",       test_longlong_api,               METH_NOARGS},
-    {"test_long_long_and_overflow",
-        (PyCFunction)test_long_long_and_overflow, METH_NOARGS},
-    {"test_L_code",             (PyCFunction)test_L_code,        METH_NOARGS},
+    {"test_long_long_and_overflow",test_long_long_and_overflow,  METH_NOARGS},
+    {"test_L_code",             test_L_code,                     METH_NOARGS},
     {"getargs_f",               getargs_f,                       METH_VARARGS},
     {"getargs_d",               getargs_d,                       METH_VARARGS},
     {"getargs_D",               getargs_D,                       METH_VARARGS},
@@ -4653,10 +4652,10 @@ static PyMethodDef TestMethods[] = {
      (PyCFunction)codec_incrementalencoder,                      METH_VARARGS},
     {"codec_incrementaldecoder",
      (PyCFunction)codec_incrementaldecoder,                      METH_VARARGS},
-    {"test_s_code",             (PyCFunction)test_s_code,        METH_NOARGS},
-    {"test_u_code",             (PyCFunction)test_u_code,        METH_NOARGS},
-    {"test_Z_code",             (PyCFunction)test_Z_code,        METH_NOARGS},
-    {"test_widechar",           (PyCFunction)test_widechar,      METH_NOARGS},
+    {"test_s_code",             test_s_code,                     METH_NOARGS},
+    {"test_u_code",             test_u_code,                     METH_NOARGS},
+    {"test_Z_code",             test_Z_code,                     METH_NOARGS},
+    {"test_widechar",           test_widechar,                   METH_NOARGS},
     {"unicode_aswidechar",      unicode_aswidechar,              METH_VARARGS},
     {"unicode_aswidecharstring",unicode_aswidecharstring,        METH_VARARGS},
     {"unicode_asucs4",          unicode_asucs4,                  METH_VARARGS},
@@ -4677,26 +4676,22 @@ static PyMethodDef TestMethods[] = {
     {"code_newempty",           code_newempty,                   METH_VARARGS},
     {"make_exception_with_doc", (PyCFunction)make_exception_with_doc,
      METH_VARARGS | METH_KEYWORDS},
-    {"make_memoryview_from_NULL_pointer", (PyCFunction)make_memoryview_from_NULL_pointer,
+    {"make_memoryview_from_NULL_pointer", make_memoryview_from_NULL_pointer,
      METH_NOARGS},
-    {"crash_no_current_thread", (PyCFunction)crash_no_current_thread, METH_NOARGS},
+    {"crash_no_current_thread", crash_no_current_thread,         METH_NOARGS},
     {"run_in_subinterp",        run_in_subinterp,                METH_VARARGS},
     {"pytime_object_to_time_t", test_pytime_object_to_time_t,  METH_VARARGS},
     {"pytime_object_to_timeval", test_pytime_object_to_timeval,  METH_VARARGS},
     {"pytime_object_to_timespec", test_pytime_object_to_timespec,  METH_VARARGS},
     {"with_tp_del",             with_tp_del,                     METH_VARARGS},
     {"create_cfunction",        create_cfunction,                METH_NOARGS},
-    {"test_pymem_alloc0",
-     (PyCFunction)test_pymem_alloc0, METH_NOARGS},
-    {"test_pymem_setrawallocators",
-     (PyCFunction)test_pymem_setrawallocators, METH_NOARGS},
-    {"test_pymem_setallocators",
-     (PyCFunction)test_pymem_setallocators, METH_NOARGS},
-    {"test_pyobject_setallocators",
-     (PyCFunction)test_pyobject_setallocators, METH_NOARGS},
+    {"test_pymem_alloc0",       test_pymem_alloc0,               METH_NOARGS},
+    {"test_pymem_setrawallocators",test_pymem_setrawallocators,  METH_NOARGS},
+    {"test_pymem_setallocators",test_pymem_setallocators,        METH_NOARGS},
+    {"test_pyobject_setallocators",test_pyobject_setallocators,  METH_NOARGS},
     {"set_nomemory", (PyCFunction)set_nomemory, METH_VARARGS,
      PyDoc_STR("set_nomemory(start:int, stop:int = 0)")},
-    {"remove_mem_hooks", (PyCFunction)remove_mem_hooks, METH_NOARGS,
+    {"remove_mem_hooks",        remove_mem_hooks,                METH_NOARGS,
      PyDoc_STR("Remove memory hooks.")},
     {"no_docstring",
         (PyCFunction)test_with_docstring, METH_NOARGS},

--- a/Modules/_threadmodule.c
+++ b/Modules/_threadmodule.c
@@ -163,7 +163,7 @@ and the return value reflects whether the lock is acquired.\n\
 The blocking operation is interruptible.");
 
 static PyObject *
-lock_PyThread_release_lock(lockobject *self)
+lock_PyThread_release_lock(lockobject *self, PyObject *Py_UNUSED(ignored))
 {
     /* Sanity check: the lock must be locked */
     if (!self->locked) {
@@ -185,7 +185,7 @@ the lock to acquire the lock.  The lock must be in the locked state,\n\
 but it needn't be locked by the same thread that unlocks it.");
 
 static PyObject *
-lock_locked_lock(lockobject *self)
+lock_locked_lock(lockobject *self, PyObject *Py_UNUSED(ignored))
 {
     return PyBool_FromLong((long)self->locked);
 }
@@ -333,7 +333,7 @@ internal counter is simply incremented. If nobody holds the lock,\n\
 the lock is taken and its internal counter initialized to 1.");
 
 static PyObject *
-rlock_release(rlockobject *self)
+rlock_release(rlockobject *self, PyObject *Py_UNUSED(ignored))
 {
     unsigned long tid = PyThread_get_thread_ident();
 
@@ -392,7 +392,7 @@ PyDoc_STRVAR(rlock_acquire_restore_doc,
 For internal use by `threading.Condition`.");
 
 static PyObject *
-rlock_release_save(rlockobject *self)
+rlock_release_save(rlockobject *self, PyObject *Py_UNUSED(ignored))
 {
     unsigned long owner;
     unsigned long count;
@@ -418,7 +418,7 @@ For internal use by `threading.Condition`.");
 
 
 static PyObject *
-rlock_is_owned(rlockobject *self)
+rlock_is_owned(rlockobject *self, PyObject *Py_UNUSED(ignored))
 {
     unsigned long tid = PyThread_get_thread_ident();
 
@@ -1087,7 +1087,7 @@ when the function raises an unhandled exception; a stack trace will be\n\
 printed unless the exception is SystemExit.\n");
 
 static PyObject *
-thread_PyThread_exit_thread(PyObject *self)
+thread_PyThread_exit_thread(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_SetNone(PyExc_SystemExit);
     return NULL;
@@ -1101,7 +1101,7 @@ This is synonymous to ``raise SystemExit''.  It will cause the current\n\
 thread to exit silently unless the exception is caught.");
 
 static PyObject *
-thread_PyThread_interrupt_main(PyObject * self)
+thread_PyThread_interrupt_main(PyObject * self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_SetInterrupt();
     Py_RETURN_NONE;
@@ -1117,7 +1117,7 @@ A subthread can use this function to interrupt the main thread."
 static lockobject *newlockobject(void);
 
 static PyObject *
-thread_PyThread_allocate_lock(PyObject *self)
+thread_PyThread_allocate_lock(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return (PyObject *) newlockobject();
 }
@@ -1130,7 +1130,7 @@ Create a new lock object. See help(type(threading.Lock())) for\n\
 information about locks.");
 
 static PyObject *
-thread_get_ident(PyObject *self)
+thread_get_ident(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     unsigned long ident = PyThread_get_thread_ident();
     if (ident == PYTHREAD_INVALID_THREAD_ID) {
@@ -1152,7 +1152,7 @@ be relied upon, and the number should be seen purely as a magic cookie.\n\
 A thread's identity may be reused for another thread after it exits.");
 
 static PyObject *
-thread__count(PyObject *self)
+thread__count(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyThreadState *tstate = PyThreadState_Get();
     return PyLong_FromLong(tstate->interp->num_threads);
@@ -1192,7 +1192,7 @@ release_sentinel(void *wr)
 }
 
 static PyObject *
-thread__set_sentinel(PyObject *self)
+thread__set_sentinel(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *wr;
     PyThreadState *tstate = PyThreadState_Get();
@@ -1289,23 +1289,23 @@ static PyMethodDef thread_methods[] = {
      METH_VARARGS, start_new_doc},
     {"start_new",               (PyCFunction)thread_PyThread_start_new_thread,
      METH_VARARGS, start_new_doc},
-    {"allocate_lock",           (PyCFunction)thread_PyThread_allocate_lock,
+    {"allocate_lock",           thread_PyThread_allocate_lock,
      METH_NOARGS, allocate_doc},
-    {"allocate",                (PyCFunction)thread_PyThread_allocate_lock,
+    {"allocate",                thread_PyThread_allocate_lock,
      METH_NOARGS, allocate_doc},
-    {"exit_thread",             (PyCFunction)thread_PyThread_exit_thread,
+    {"exit_thread",             thread_PyThread_exit_thread,
      METH_NOARGS, exit_doc},
-    {"exit",                    (PyCFunction)thread_PyThread_exit_thread,
+    {"exit",                    thread_PyThread_exit_thread,
      METH_NOARGS, exit_doc},
-    {"interrupt_main",          (PyCFunction)thread_PyThread_interrupt_main,
+    {"interrupt_main",          thread_PyThread_interrupt_main,
      METH_NOARGS, interrupt_doc},
-    {"get_ident",               (PyCFunction)thread_get_ident,
+    {"get_ident",               thread_get_ident,
      METH_NOARGS, get_ident_doc},
-    {"_count",                  (PyCFunction)thread__count,
+    {"_count",                  thread__count,
      METH_NOARGS, _count_doc},
     {"stack_size",              (PyCFunction)thread_stack_size,
      METH_VARARGS, stack_size_doc},
-    {"_set_sentinel",           (PyCFunction)thread__set_sentinel,
+    {"_set_sentinel",           thread__set_sentinel,
      METH_NOARGS, _set_sentinel_doc},
     {NULL,                      NULL}           /* sentinel */
 };

--- a/Modules/_uuidmodule.c
+++ b/Modules/_uuidmodule.c
@@ -10,7 +10,8 @@
 
 
 static PyObject *
-py_uuid_generate_time_safe(void)
+py_uuid_generate_time_safe(PyObject *Py_UNUSED(context),
+                           PyObject *Py_UNUSED(ignored))
 {
     uuid_t uuid;
 #ifdef HAVE_UUID_GENERATE_TIME_SAFE
@@ -30,7 +31,7 @@ py_uuid_generate_time_safe(void)
 
 
 static PyMethodDef uuid_methods[] = {
-    {"generate_time_safe", (PyCFunction) py_uuid_generate_time_safe, METH_NOARGS, NULL},
+    {"generate_time_safe", py_uuid_generate_time_safe, METH_NOARGS, NULL},
     {NULL, NULL, 0, NULL}           /* sentinel */
 };
 

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2171,7 +2171,7 @@ So does an unrecognized ID.");
 
 
 static PyObject *
-interp_list_all(PyObject *self)
+interp_list_all(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *ids, *id;
     PyInterpreterState *interp;
@@ -2209,7 +2209,7 @@ Return a list containing the ID of every existing interpreter.");
 
 
 static PyObject *
-interp_get_current(PyObject *self)
+interp_get_current(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyInterpreterState *interp =_get_current();
     if (interp == NULL) {
@@ -2225,7 +2225,7 @@ Return the ID of current interpreter.");
 
 
 static PyObject *
-interp_get_main(PyObject *self)
+interp_get_main(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     // Currently, 0 is always the main interpreter.
     return PyLong_FromLongLong(0);
@@ -2341,7 +2341,7 @@ PyDoc_STRVAR(is_running_doc,
 Return whether or not the identified interpreter is running.");
 
 static PyObject *
-channel_create(PyObject *self)
+channel_create(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     int64_t cid = _channel_create(&_globals.channels);
     if (cid < 0) {
@@ -2389,7 +2389,7 @@ Close and finalize the channel.  Afterward attempts to use the channel\n\
 will behave as though it never existed.");
 
 static PyObject *
-channel_list_all(PyObject *self)
+channel_list_all(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     int64_t count = 0;
     int64_t *cids = _channels_list_all(&_globals.channels, &count);
@@ -2546,11 +2546,11 @@ static PyMethodDef module_functions[] = {
      METH_VARARGS, create_doc},
     {"destroy",                   (PyCFunction)interp_destroy,
      METH_VARARGS, destroy_doc},
-    {"list_all",                  (PyCFunction)interp_list_all,
+    {"list_all",                  interp_list_all,
      METH_NOARGS, list_all_doc},
-    {"get_current",               (PyCFunction)interp_get_current,
+    {"get_current",               interp_get_current,
      METH_NOARGS, get_current_doc},
-    {"get_main",                  (PyCFunction)interp_get_main,
+    {"get_main",                  interp_get_main,
      METH_NOARGS, get_main_doc},
     {"is_running",                (PyCFunction)interp_is_running,
      METH_VARARGS, is_running_doc},
@@ -2560,11 +2560,11 @@ static PyMethodDef module_functions[] = {
     {"is_shareable",              (PyCFunction)object_is_shareable,
      METH_VARARGS, is_shareable_doc},
 
-    {"channel_create",            (PyCFunction)channel_create,
+    {"channel_create",            channel_create,
      METH_NOARGS, channel_create_doc},
     {"channel_destroy",           (PyCFunction)channel_destroy,
      METH_VARARGS, channel_destroy_doc},
-    {"channel_list_all",          (PyCFunction)channel_list_all,
+    {"channel_list_all",          channel_list_all,
      METH_NOARGS, channel_list_all_doc},
     {"channel_send",              (PyCFunction)channel_send,
      METH_VARARGS, channel_send_doc},

--- a/Modules/faulthandler.c
+++ b/Modules/faulthandler.c
@@ -533,7 +533,7 @@ faulthandler_disable(void)
 }
 
 static PyObject*
-faulthandler_disable_py(PyObject *self)
+faulthandler_disable_py(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (!fatal_error.enabled) {
         Py_RETURN_FALSE;
@@ -543,7 +543,7 @@ faulthandler_disable_py(PyObject *self)
 }
 
 static PyObject*
-faulthandler_is_enabled(PyObject *self)
+faulthandler_is_enabled(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return PyBool_FromLong(fatal_error.enabled);
 }
@@ -718,7 +718,8 @@ faulthandler_dump_traceback_later(PyObject *self,
 }
 
 static PyObject*
-faulthandler_cancel_dump_traceback_later_py(PyObject *self)
+faulthandler_cancel_dump_traceback_later_py(PyObject *self,
+                                            PyObject *Py_UNUSED(ignored))
 {
     cancel_dump_traceback_later();
     Py_RETURN_NONE;
@@ -1116,7 +1117,7 @@ stack_overflow(uintptr_t min_sp, uintptr_t max_sp, size_t *depth)
 }
 
 static PyObject *
-faulthandler_stack_overflow(PyObject *self)
+faulthandler_stack_overflow(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     size_t depth, size;
     uintptr_t sp = (uintptr_t)&depth;
@@ -1177,9 +1178,9 @@ static PyMethodDef module_methods[] = {
      (PyCFunction)faulthandler_py_enable, METH_VARARGS|METH_KEYWORDS,
      PyDoc_STR("enable(file=sys.stderr, all_threads=True): "
                "enable the fault handler")},
-    {"disable", (PyCFunction)faulthandler_disable_py, METH_NOARGS,
+    {"disable", faulthandler_disable_py, METH_NOARGS,
      PyDoc_STR("disable(): disable the fault handler")},
-    {"is_enabled", (PyCFunction)faulthandler_is_enabled, METH_NOARGS,
+    {"is_enabled", faulthandler_is_enabled, METH_NOARGS,
      PyDoc_STR("is_enabled()->bool: check if the handler is enabled")},
     {"dump_traceback",
      (PyCFunction)faulthandler_dump_traceback_py, METH_VARARGS|METH_KEYWORDS,
@@ -1194,7 +1195,7 @@ static PyMethodDef module_methods[] = {
                "or each timeout seconds if repeat is True. If exit is True, "
                "call _exit(1) which is not safe.")},
     {"cancel_dump_traceback_later",
-     (PyCFunction)faulthandler_cancel_dump_traceback_later_py, METH_NOARGS,
+     faulthandler_cancel_dump_traceback_later_py, METH_NOARGS,
      PyDoc_STR("cancel_dump_traceback_later():\ncancel the previous call "
                "to dump_traceback_later().")},
 #endif
@@ -1227,7 +1228,7 @@ static PyMethodDef module_methods[] = {
     {"_fatal_error", faulthandler_fatal_error_py, METH_VARARGS,
      PyDoc_STR("_fatal_error(message): call Py_FatalError(message)")},
 #ifdef FAULTHANDLER_STACK_OVERFLOW
-    {"_stack_overflow", (PyCFunction)faulthandler_stack_overflow, METH_NOARGS,
+    {"_stack_overflow", faulthandler_stack_overflow, METH_NOARGS,
      PyDoc_STR("_stack_overflow(): recursive call to raise a stack overflow")},
 #endif
 #ifdef MS_WINDOWS

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -138,7 +138,7 @@ groupby_next(groupbyobject *gbo)
 }
 
 static PyObject *
-groupby_reduce(groupbyobject *lz)
+groupby_reduce(groupbyobject *lz, PyObject *Py_UNUSED(ignored))
 {
     /* reduce as a 'new' call with an optional 'setstate' if groupby
      * has started
@@ -320,7 +320,7 @@ _grouper_next(_grouperobject *igo)
 }
 
 static PyObject *
-_grouper_reduce(_grouperobject *lz)
+_grouper_reduce(_grouperobject *lz, PyObject *Py_UNUSED(ignored))
 {
     if (((groupbyobject *)lz->parent)->currgrouper != lz) {
         return Py_BuildValue("N(())", _PyObject_GetBuiltin("iter"));
@@ -504,7 +504,7 @@ teedataobject_dealloc(teedataobject *tdo)
 }
 
 static PyObject *
-teedataobject_reduce(teedataobject *tdo)
+teedataobject_reduce(teedataobject *tdo, PyObject *Py_UNUSED(ignored))
 {
     int i;
     /* create a temporary list of already iterated values */
@@ -649,7 +649,7 @@ tee_traverse(teeobject *to, visitproc visit, void *arg)
 }
 
 static PyObject *
-tee_copy(teeobject *to)
+tee_copy(teeobject *to, PyObject *Py_UNUSED(ignored))
 {
     teeobject *newto;
 
@@ -676,7 +676,7 @@ tee_fromiterable(PyObject *iterable)
     if (it == NULL)
         return NULL;
     if (PyObject_TypeCheck(it, &tee_type)) {
-        to = (teeobject *)tee_copy((teeobject *)it);
+        to = (teeobject *)tee_copy((teeobject *)it, NULL);
         goto done;
     }
 
@@ -726,7 +726,7 @@ tee_dealloc(teeobject *to)
 }
 
 static PyObject *
-tee_reduce(teeobject *to)
+tee_reduce(teeobject *to, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("O(())(Oi)", Py_TYPE(to), to->dataobj, to->index);
 }
@@ -973,7 +973,7 @@ cycle_next(cycleobject *lz)
 }
 
 static PyObject *
-cycle_reduce(cycleobject *lz)
+cycle_reduce(cycleobject *lz, PyObject *Py_UNUSED(ignored))
 {
     /* Create a new cycle with the iterator tuple, then set the saved state */
     if (lz->it == NULL) {
@@ -1168,7 +1168,7 @@ dropwhile_next(dropwhileobject *lz)
 }
 
 static PyObject *
-dropwhile_reduce(dropwhileobject *lz)
+dropwhile_reduce(dropwhileobject *lz, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("O(OO)l", Py_TYPE(lz), lz->func, lz->it, lz->start);
 }
@@ -1332,7 +1332,7 @@ takewhile_next(takewhileobject *lz)
 }
 
 static PyObject *
-takewhile_reduce(takewhileobject *lz)
+takewhile_reduce(takewhileobject *lz, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("O(OO)l", Py_TYPE(lz), lz->func, lz->it, lz->stop);
 }
@@ -1558,7 +1558,7 @@ empty:
 }
 
 static PyObject *
-islice_reduce(isliceobject *lz)
+islice_reduce(isliceobject *lz, PyObject *Py_UNUSED(ignored))
 {
     /* When unpickled, generate a new object with the same bounds,
      * then 'setstate' with the next and count
@@ -1746,7 +1746,7 @@ starmap_next(starmapobject *lz)
 }
 
 static PyObject *
-starmap_reduce(starmapobject *lz)
+starmap_reduce(starmapobject *lz, PyObject *Py_UNUSED(ignored))
 {
     /* Just pickle the iterator */
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
@@ -1918,7 +1918,7 @@ chain_next(chainobject *lz)
 }
 
 static PyObject *
-chain_reduce(chainobject *lz)
+chain_reduce(chainobject *lz, PyObject *Py_UNUSED(ignored))
 {
     if (lz->source) {
         /* we can't pickle function objects (itertools.from_iterable) so
@@ -2242,7 +2242,7 @@ empty:
 }
 
 static PyObject *
-product_reduce(productobject *lz)
+product_reduce(productobject *lz, PyObject *Py_UNUSED(ignored))
 {
     if (lz->stopped) {
         return Py_BuildValue("O(())", Py_TYPE(lz));
@@ -2569,7 +2569,7 @@ empty:
 }
 
 static PyObject *
-combinations_reduce(combinationsobject *lz)
+combinations_reduce(combinationsobject *lz, PyObject *Py_UNUSED(ignored))
 {
     if (lz->result == NULL) {
         return Py_BuildValue("O(On)", Py_TYPE(lz), lz->pool, lz->r);
@@ -2903,7 +2903,7 @@ empty:
 }
 
 static PyObject *
-cwr_reduce(cwrobject *lz)
+cwr_reduce(cwrobject *lz, PyObject *Py_UNUSED(ignored))
 {
     if (lz->result == NULL) {
         return Py_BuildValue("O(On)", Py_TYPE(lz), lz->pool, lz->r);
@@ -3262,7 +3262,7 @@ empty:
 }
 
 static PyObject *
-permutations_reduce(permutationsobject *po)
+permutations_reduce(permutationsobject *po, PyObject *Py_UNUSED(ignored))
 {
     if (po->result == NULL) {
         return Py_BuildValue("O(On)", Py_TYPE(po), po->pool, po->r);
@@ -3514,7 +3514,7 @@ accumulate_next(accumulateobject *lz)
 }
 
 static PyObject *
-accumulate_reduce(accumulateobject *lz)
+accumulate_reduce(accumulateobject *lz, PyObject *Py_UNUSED(ignored))
 {
     if (lz->total == Py_None) {
         PyObject *it;
@@ -3707,7 +3707,7 @@ compress_next(compressobject *lz)
 }
 
 static PyObject *
-compress_reduce(compressobject *lz)
+compress_reduce(compressobject *lz, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("O(OO)", Py_TYPE(lz),
         lz->data, lz->selectors);
@@ -3865,7 +3865,7 @@ filterfalse_next(filterfalseobject *lz)
 }
 
 static PyObject *
-filterfalse_reduce(filterfalseobject *lz)
+filterfalse_reduce(filterfalseobject *lz, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
 }
@@ -4108,7 +4108,7 @@ count_repr(countobject *lz)
 }
 
 static PyObject *
-count_reduce(countobject *lz)
+count_reduce(countobject *lz, PyObject *Py_UNUSED(ignored))
 {
     if (lz->cnt == PY_SSIZE_T_MAX)
         return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->long_cnt, lz->long_step);
@@ -4253,7 +4253,7 @@ repeat_repr(repeatobject *ro)
 }
 
 static PyObject *
-repeat_len(repeatobject *ro)
+repeat_len(repeatobject *ro, PyObject *Py_UNUSED(ignored))
 {
     if (ro->cnt == -1) {
         PyErr_SetString(PyExc_TypeError, "len() of unsized object");
@@ -4265,7 +4265,7 @@ repeat_len(repeatobject *ro)
 PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-repeat_reduce(repeatobject *ro)
+repeat_reduce(repeatobject *ro, PyObject *Py_UNUSED(ignored))
 {
     /* unpickle this so that a new repeat iterator is constructed with an
      * object, then call __setstate__ on it to set cnt
@@ -4504,7 +4504,7 @@ zip_longest_next(ziplongestobject *lz)
 }
 
 static PyObject *
-zip_longest_reduce(ziplongestobject *lz)
+zip_longest_reduce(ziplongestobject *lz, PyObject *Py_UNUSED(ignored))
 {
 
     /* Create a new tuple with empty sequences where appropriate to pickle.

--- a/Modules/nismodule.c
+++ b/Modules/nismodule.c
@@ -137,7 +137,7 @@ nis_foreach (int instatus, char *inkey, int inkeylen, char *inval,
 }
 
 static PyObject *
-nis_get_default_domain (PyObject *self)
+nis_get_default_domain (PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     char *domain;
     int err;
@@ -432,7 +432,7 @@ static PyMethodDef nis_methods[] = {
     {"maps",                    (PyCFunction)nis_maps,
                                     METH_VARARGS | METH_KEYWORDS,
                                     maps__doc__},
-    {"get_default_domain",      (PyCFunction)nis_get_default_domain,
+    {"get_default_domain",      nis_get_default_domain,
                                     METH_NOARGS,
                                     get_default_domain__doc__},
     {NULL,                      NULL}            /* Sentinel */

--- a/Modules/overlapped.c
+++ b/Modules/overlapped.c
@@ -618,7 +618,7 @@ PyDoc_STRVAR(
     "Cancel overlapped operation");
 
 static PyObject *
-Overlapped_cancel(OverlappedObject *self)
+Overlapped_cancel(OverlappedObject *self, PyObject *Py_UNUSED(ignored))
 {
     BOOL ret = TRUE;
 

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1006,7 +1006,7 @@ devpoll_internal_close(devpollObject *self)
 }
 
 static PyObject*
-devpoll_close(devpollObject *self)
+devpoll_close(devpollObject *self, PyObject *Py_UNUSED(ignored))
 {
     errno = devpoll_internal_close(self);
     if (errno < 0) {
@@ -1032,7 +1032,7 @@ devpoll_get_closed(devpollObject *self)
 }
 
 static PyObject*
-devpoll_fileno(devpollObject *self)
+devpoll_fileno(devpollObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (self->fd_devpoll < 0)
         return devpoll_err_closed();
@@ -1327,7 +1327,7 @@ pyepoll_dealloc(pyEpoll_Object *self)
 }
 
 static PyObject*
-pyepoll_close(pyEpoll_Object *self)
+pyepoll_close(pyEpoll_Object *self, PyObject *Py_UNUSED(ignored))
 {
     errno = pyepoll_internal_close(self);
     if (errno < 0) {
@@ -1353,7 +1353,7 @@ pyepoll_get_closed(pyEpoll_Object *self)
 }
 
 static PyObject*
-pyepoll_fileno(pyEpoll_Object *self)
+pyepoll_fileno(pyEpoll_Object *self, PyObject *Py_UNUSED(ignored))
 {
     if (self->epfd < 0)
         return pyepoll_err_closed();
@@ -2053,7 +2053,7 @@ kqueue_queue_dealloc(kqueue_queue_Object *self)
 }
 
 static PyObject*
-kqueue_queue_close(kqueue_queue_Object *self)
+kqueue_queue_close(kqueue_queue_Object *self, PyObject *Py_UNUSED(ignored))
 {
     errno = kqueue_queue_internal_close(self);
     if (errno < 0) {
@@ -2079,7 +2079,7 @@ kqueue_queue_get_closed(kqueue_queue_Object *self)
 }
 
 static PyObject*
-kqueue_queue_fileno(kqueue_queue_Object *self)
+kqueue_queue_fileno(kqueue_queue_Object *self, PyObject *Py_UNUSED(ignored))
 {
     if (self->kqfd < 0)
         return kqueue_queue_err_closed();

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2504,7 +2504,7 @@ sock_accept_impl(PySocketSockObject *s, void *data)
 /* s._accept() -> (fd, address) */
 
 static PyObject *
-sock_accept(PySocketSockObject *s)
+sock_accept(PySocketSockObject *s, PyObject *Py_UNUSED(ignored))
 {
     sock_addr_t addrbuf;
     SOCKET_T newfd;
@@ -2605,7 +2605,7 @@ setblocking(False) is equivalent to settimeout(0.0).");
    False if it is in non-blocking mode.
 */
 static PyObject *
-sock_getblocking(PySocketSockObject *s)
+sock_getblocking(PySocketSockObject *s, PyObject *Py_UNUSED(ignored))
 {
     if (s->sock_timeout) {
         Py_RETURN_TRUE;
@@ -2717,7 +2717,7 @@ Setting a timeout of zero is the same as setblocking(0).");
 /* s.gettimeout() method.
    Returns the timeout associated with a socket. */
 static PyObject *
-sock_gettimeout(PySocketSockObject *s)
+sock_gettimeout(PySocketSockObject *s, PyObject *Py_UNUSED(ignored))
 {
     if (s->sock_timeout < 0) {
         Py_RETURN_NONE;
@@ -2930,7 +2930,7 @@ sockets the address is a tuple (ifname, proto [,pkttype [,hatype]])");
    will surely fail. */
 
 static PyObject *
-sock_close(PySocketSockObject *s)
+sock_close(PySocketSockObject *s, PyObject *Py_UNUSED(ignored))
 {
     SOCKET_T fd;
     int res;
@@ -2961,7 +2961,7 @@ PyDoc_STRVAR(sock_close_doc,
 Close the socket.  It cannot be used after this call.");
 
 static PyObject *
-sock_detach(PySocketSockObject *s)
+sock_detach(PySocketSockObject *s, PyObject *Py_UNUSED(ignored))
 {
     SOCKET_T fd = s->sock_fd;
     s->sock_fd = INVALID_SOCKET;
@@ -3117,7 +3117,7 @@ instead of raising an exception when an error occurs.");
 /* s.fileno() method */
 
 static PyObject *
-sock_fileno(PySocketSockObject *s)
+sock_fileno(PySocketSockObject *s, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromSocket_t(s->sock_fd);
 }
@@ -3131,7 +3131,7 @@ Return the integer file descriptor of the socket.");
 /* s.getsockname() method */
 
 static PyObject *
-sock_getsockname(PySocketSockObject *s)
+sock_getsockname(PySocketSockObject *s, PyObject *Py_UNUSED(ignored))
 {
     sock_addr_t addrbuf;
     int res;
@@ -3160,7 +3160,7 @@ info is a pair (hostaddr, port).");
 /* s.getpeername() method */
 
 static PyObject *
-sock_getpeername(PySocketSockObject *s)
+sock_getpeername(PySocketSockObject *s, PyObject *Py_UNUSED(ignored))
 {
     sock_addr_t addrbuf;
     int res;
@@ -6390,7 +6390,7 @@ Get host and port for a sockaddr.");
 /* Python API to getting and setting the default timeout value. */
 
 static PyObject *
-socket_getdefaulttimeout(PyObject *self)
+socket_getdefaulttimeout(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (defaulttimeout < 0) {
         Py_RETURN_NONE;
@@ -6639,7 +6639,7 @@ static PyMethodDef socket_methods[] = {
      METH_VARARGS | METH_KEYWORDS, getaddrinfo_doc},
     {"getnameinfo",             socket_getnameinfo,
      METH_VARARGS, getnameinfo_doc},
-    {"getdefaulttimeout",       (PyCFunction)socket_getdefaulttimeout,
+    {"getdefaulttimeout",       socket_getdefaulttimeout,
      METH_NOARGS, getdefaulttimeout_doc},
     {"setdefaulttimeout",       socket_setdefaulttimeout,
      METH_O, setdefaulttimeout_doc},

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -1940,7 +1940,7 @@ PyDoc_STRVAR(alloc_doc,
 Return the number of bytes actually allocated.");
 
 static PyObject *
-bytearray_alloc(PyByteArrayObject *self)
+bytearray_alloc(PyByteArrayObject *self, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromSsize_t(self->ob_alloc);
 }
@@ -2018,7 +2018,7 @@ Create a string of hexadecimal numbers from a bytearray object.\n\
 Example: bytearray([0xb9, 0x01, 0xef]).hex() -> 'b901ef'.");
 
 static PyObject *
-bytearray_hex(PyBytesObject *self)
+bytearray_hex(PyBytesObject *self, PyObject *Py_UNUSED(ignored))
 {
     char* argbuf = PyByteArray_AS_STRING(self);
     Py_ssize_t arglen = PyByteArray_GET_SIZE(self);
@@ -2136,7 +2136,7 @@ bytearray_methods[] = {
     BYTEARRAY_REDUCE_EX_METHODDEF
     BYTEARRAY_SIZEOF_METHODDEF
     BYTEARRAY_APPEND_METHODDEF
-    {"capitalize", (PyCFunction)stringlib_capitalize, METH_NOARGS,
+    {"capitalize", stringlib_capitalize, METH_NOARGS,
      _Py_capitalize__doc__},
     {"center", (PyCFunction)stringlib_center, METH_VARARGS, _Py_center__doc__},
     BYTEARRAY_CLEAR_METHODDEF
@@ -2155,25 +2155,25 @@ bytearray_methods[] = {
     {"hex", (PyCFunction)bytearray_hex, METH_NOARGS, hex__doc__},
     {"index", (PyCFunction)bytearray_index, METH_VARARGS, _Py_index__doc__},
     BYTEARRAY_INSERT_METHODDEF
-    {"isalnum", (PyCFunction)stringlib_isalnum, METH_NOARGS,
+    {"isalnum", stringlib_isalnum, METH_NOARGS,
      _Py_isalnum__doc__},
-    {"isalpha", (PyCFunction)stringlib_isalpha, METH_NOARGS,
+    {"isalpha", stringlib_isalpha, METH_NOARGS,
      _Py_isalpha__doc__},
-    {"isascii", (PyCFunction)stringlib_isascii, METH_NOARGS,
+    {"isascii", stringlib_isascii, METH_NOARGS,
      _Py_isascii__doc__},
-    {"isdigit", (PyCFunction)stringlib_isdigit, METH_NOARGS,
+    {"isdigit", stringlib_isdigit, METH_NOARGS,
      _Py_isdigit__doc__},
-    {"islower", (PyCFunction)stringlib_islower, METH_NOARGS,
+    {"islower", stringlib_islower, METH_NOARGS,
      _Py_islower__doc__},
-    {"isspace", (PyCFunction)stringlib_isspace, METH_NOARGS,
+    {"isspace", stringlib_isspace, METH_NOARGS,
      _Py_isspace__doc__},
-    {"istitle", (PyCFunction)stringlib_istitle, METH_NOARGS,
+    {"istitle", stringlib_istitle, METH_NOARGS,
      _Py_istitle__doc__},
-    {"isupper", (PyCFunction)stringlib_isupper, METH_NOARGS,
+    {"isupper", stringlib_isupper, METH_NOARGS,
      _Py_isupper__doc__},
     BYTEARRAY_JOIN_METHODDEF
     {"ljust", (PyCFunction)stringlib_ljust, METH_VARARGS, _Py_ljust__doc__},
-    {"lower", (PyCFunction)stringlib_lower, METH_NOARGS, _Py_lower__doc__},
+    {"lower", stringlib_lower, METH_NOARGS, _Py_lower__doc__},
     BYTEARRAY_LSTRIP_METHODDEF
     BYTEARRAY_MAKETRANS_METHODDEF
     BYTEARRAY_PARTITION_METHODDEF
@@ -2192,11 +2192,11 @@ bytearray_methods[] = {
     {"startswith", (PyCFunction)bytearray_startswith, METH_VARARGS ,
      _Py_startswith__doc__},
     BYTEARRAY_STRIP_METHODDEF
-    {"swapcase", (PyCFunction)stringlib_swapcase, METH_NOARGS,
+    {"swapcase", stringlib_swapcase, METH_NOARGS,
      _Py_swapcase__doc__},
-    {"title", (PyCFunction)stringlib_title, METH_NOARGS, _Py_title__doc__},
+    {"title", stringlib_title, METH_NOARGS, _Py_title__doc__},
     BYTEARRAY_TRANSLATE_METHODDEF
-    {"upper", (PyCFunction)stringlib_upper, METH_NOARGS, _Py_upper__doc__},
+    {"upper", stringlib_upper, METH_NOARGS, _Py_upper__doc__},
     {"zfill", (PyCFunction)stringlib_zfill, METH_VARARGS, _Py_zfill__doc__},
     {NULL}
 };
@@ -2324,7 +2324,7 @@ bytearrayiter_next(bytesiterobject *it)
 }
 
 static PyObject *
-bytearrayiter_length_hint(bytesiterobject *it)
+bytearrayiter_length_hint(bytesiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t len = 0;
     if (it->it_seq) {
@@ -2340,7 +2340,7 @@ PyDoc_STRVAR(length_hint_doc,
     "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-bytearrayiter_reduce(bytesiterobject *it)
+bytearrayiter_reduce(bytesiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     if (it->it_seq != NULL) {
         return Py_BuildValue("N(O)n", _PyObject_GetBuiltin("iter"),

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2422,7 +2422,7 @@ Create a string of hexadecimal numbers from a bytes object.\n\
 Example: b'\\xb9\\x01\\xef'.hex() -> 'b901ef'.");
 
 static PyObject *
-bytes_hex(PyBytesObject *self)
+bytes_hex(PyBytesObject *self, PyObject *Py_UNUSED(ignored))
 {
     char* argbuf = PyBytes_AS_STRING(self);
     Py_ssize_t arglen = PyBytes_GET_SIZE(self);
@@ -2430,7 +2430,7 @@ bytes_hex(PyBytesObject *self)
 }
 
 static PyObject *
-bytes_getnewargs(PyBytesObject *v)
+bytes_getnewargs(PyBytesObject *v, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("(y#)", v->ob_sval, Py_SIZE(v));
 }
@@ -2439,7 +2439,7 @@ bytes_getnewargs(PyBytesObject *v)
 static PyMethodDef
 bytes_methods[] = {
     {"__getnewargs__",          (PyCFunction)bytes_getnewargs,  METH_NOARGS},
-    {"capitalize", (PyCFunction)stringlib_capitalize, METH_NOARGS,
+    {"capitalize", stringlib_capitalize, METH_NOARGS,
      _Py_capitalize__doc__},
     {"center", (PyCFunction)stringlib_center, METH_VARARGS,
      _Py_center__doc__},
@@ -2455,25 +2455,25 @@ bytes_methods[] = {
     BYTES_FROMHEX_METHODDEF
     {"hex", (PyCFunction)bytes_hex, METH_NOARGS, hex__doc__},
     {"index", (PyCFunction)bytes_index, METH_VARARGS, _Py_index__doc__},
-    {"isalnum", (PyCFunction)stringlib_isalnum, METH_NOARGS,
+    {"isalnum", stringlib_isalnum, METH_NOARGS,
      _Py_isalnum__doc__},
-    {"isalpha", (PyCFunction)stringlib_isalpha, METH_NOARGS,
+    {"isalpha", stringlib_isalpha, METH_NOARGS,
      _Py_isalpha__doc__},
-    {"isascii", (PyCFunction)stringlib_isascii, METH_NOARGS,
+    {"isascii", stringlib_isascii, METH_NOARGS,
      _Py_isascii__doc__},
-    {"isdigit", (PyCFunction)stringlib_isdigit, METH_NOARGS,
+    {"isdigit", stringlib_isdigit, METH_NOARGS,
      _Py_isdigit__doc__},
-    {"islower", (PyCFunction)stringlib_islower, METH_NOARGS,
+    {"islower", stringlib_islower, METH_NOARGS,
      _Py_islower__doc__},
-    {"isspace", (PyCFunction)stringlib_isspace, METH_NOARGS,
+    {"isspace", stringlib_isspace, METH_NOARGS,
      _Py_isspace__doc__},
-    {"istitle", (PyCFunction)stringlib_istitle, METH_NOARGS,
+    {"istitle", stringlib_istitle, METH_NOARGS,
      _Py_istitle__doc__},
-    {"isupper", (PyCFunction)stringlib_isupper, METH_NOARGS,
+    {"isupper", stringlib_isupper, METH_NOARGS,
      _Py_isupper__doc__},
     BYTES_JOIN_METHODDEF
     {"ljust", (PyCFunction)stringlib_ljust, METH_VARARGS, _Py_ljust__doc__},
-    {"lower", (PyCFunction)stringlib_lower, METH_NOARGS, _Py_lower__doc__},
+    {"lower", stringlib_lower, METH_NOARGS, _Py_lower__doc__},
     BYTES_LSTRIP_METHODDEF
     BYTES_MAKETRANS_METHODDEF
     BYTES_PARTITION_METHODDEF
@@ -2489,11 +2489,11 @@ bytes_methods[] = {
     {"startswith", (PyCFunction)bytes_startswith, METH_VARARGS,
      _Py_startswith__doc__},
     BYTES_STRIP_METHODDEF
-    {"swapcase", (PyCFunction)stringlib_swapcase, METH_NOARGS,
+    {"swapcase", stringlib_swapcase, METH_NOARGS,
      _Py_swapcase__doc__},
-    {"title", (PyCFunction)stringlib_title, METH_NOARGS, _Py_title__doc__},
+    {"title", stringlib_title, METH_NOARGS, _Py_title__doc__},
     BYTES_TRANSLATE_METHODDEF
-    {"upper", (PyCFunction)stringlib_upper, METH_NOARGS, _Py_upper__doc__},
+    {"upper", stringlib_upper, METH_NOARGS, _Py_upper__doc__},
     {"zfill", (PyCFunction)stringlib_zfill, METH_VARARGS, _Py_zfill__doc__},
     {NULL,     NULL}                         /* sentinel */
 };
@@ -3037,7 +3037,7 @@ striter_next(striterobject *it)
 }
 
 static PyObject *
-striter_len(striterobject *it)
+striter_len(striterobject *it, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t len = 0;
     if (it->it_seq)
@@ -3049,7 +3049,7 @@ PyDoc_STRVAR(length_hint_doc,
              "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-striter_reduce(striterobject *it)
+striter_reduce(striterobject *it, PyObject *Py_UNUSED(ignored))
 {
     if (it->it_seq != NULL) {
         return Py_BuildValue("N(O)n", _PyObject_GetBuiltin("iter"),

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -73,7 +73,7 @@ PyMethod_New(PyObject *func, PyObject *self)
 }
 
 static PyObject *
-method_reduce(PyMethodObject *im)
+method_reduce(PyMethodObject *im, PyObject *Py_UNUSED(ignored))
 {
     PyObject *self = PyMethod_GET_SELF(im);
     PyObject *func = PyMethod_GET_FUNCTION(im);

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -695,7 +695,7 @@ complex_float(PyObject *v)
 }
 
 static PyObject *
-complex_conjugate(PyObject *self)
+complex_conjugate(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     Py_complex c;
     c = ((PyComplexObject *)self)->cval;
@@ -709,7 +709,7 @@ PyDoc_STRVAR(complex_conjugate_doc,
 "Return the complex conjugate of its argument. (3-4j).conjugate() == 3+4j.");
 
 static PyObject *
-complex_getnewargs(PyComplexObject *v)
+complex_getnewargs(PyComplexObject *v, PyObject *Py_UNUSED(ignored))
 {
     Py_complex c = v->cval;
     return Py_BuildValue("(dd)", c.real, c.imag);

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -448,7 +448,7 @@ descr_get_qualname(PyDescrObject *descr)
 }
 
 static PyObject *
-descr_reduce(PyDescrObject *descr)
+descr_reduce(PyDescrObject *descr, PyObject *Py_UNUSED(ignored))
 {
     PyObject *builtins;
     PyObject *getattr;
@@ -868,28 +868,28 @@ mappingproxy_get(mappingproxyobject *pp, PyObject *args)
 }
 
 static PyObject *
-mappingproxy_keys(mappingproxyobject *pp)
+mappingproxy_keys(mappingproxyobject *pp, PyObject *Py_UNUSED(ignored))
 {
     _Py_IDENTIFIER(keys);
     return _PyObject_CallMethodId(pp->mapping, &PyId_keys, NULL);
 }
 
 static PyObject *
-mappingproxy_values(mappingproxyobject *pp)
+mappingproxy_values(mappingproxyobject *pp, PyObject *Py_UNUSED(ignored))
 {
     _Py_IDENTIFIER(values);
     return _PyObject_CallMethodId(pp->mapping, &PyId_values, NULL);
 }
 
 static PyObject *
-mappingproxy_items(mappingproxyobject *pp)
+mappingproxy_items(mappingproxyobject *pp, PyObject *Py_UNUSED(ignored))
 {
     _Py_IDENTIFIER(items);
     return _PyObject_CallMethodId(pp->mapping, &PyId_items, NULL);
 }
 
 static PyObject *
-mappingproxy_copy(mappingproxyobject *pp)
+mappingproxy_copy(mappingproxyobject *pp, PyObject *Py_UNUSED(ignored))
 {
     _Py_IDENTIFIER(copy);
     return _PyObject_CallMethodId(pp->mapping, &PyId_copy, NULL);
@@ -1086,7 +1086,7 @@ wrapper_repr(wrapperobject *wp)
 }
 
 static PyObject *
-wrapper_reduce(wrapperobject *wp)
+wrapper_reduce(wrapperobject *wp, PyObject *Py_UNUSED(ignored))
 {
     PyObject *builtins;
     PyObject *getattr;

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -2511,7 +2511,7 @@ _PyDict_MergeEx(PyObject *a, PyObject *b, int override)
 }
 
 static PyObject *
-dict_copy(PyDictObject *mp)
+dict_copy(PyDictObject *mp, PyObject *Py_UNUSED(ignored))
 {
     return PyDict_Copy((PyObject*)mp);
 }
@@ -2874,7 +2874,7 @@ dict_setdefault_impl(PyDictObject *self, PyObject *key,
 }
 
 static PyObject *
-dict_clear(PyDictObject *mp)
+dict_clear(PyDictObject *mp, PyObject *Py_UNUSED(ignored))
 {
     PyDict_Clear((PyObject *)mp);
     Py_RETURN_NONE;
@@ -2892,7 +2892,7 @@ dict_pop(PyDictObject *mp, PyObject *args)
 }
 
 static PyObject *
-dict_popitem(PyDictObject *mp)
+dict_popitem(PyDictObject *mp, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t i, j;
     PyDictKeyEntry *ep0, *ep;
@@ -3020,7 +3020,7 @@ _PyDict_KeysSize(PyDictKeysObject *keys)
 }
 
 static PyObject *
-dict_sizeof(PyDictObject *mp)
+dict_sizeof(PyDictObject *mp, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromSsize_t(_PyDict_SizeOf(mp));
 }
@@ -3051,9 +3051,9 @@ PyDoc_STRVAR(copy__doc__,
 "D.copy() -> a shallow copy of D");
 
 /* Forward */
-static PyObject *dictkeys_new(PyObject *);
-static PyObject *dictitems_new(PyObject *);
-static PyObject *dictvalues_new(PyObject *);
+static PyObject *dictkeys_new(PyObject *, PyObject *);
+static PyObject *dictitems_new(PyObject *, PyObject *);
+static PyObject *dictvalues_new(PyObject *, PyObject *);
 
 PyDoc_STRVAR(keys__doc__,
              "D.keys() -> a set-like object providing a view on D's keys");
@@ -3074,11 +3074,11 @@ static PyMethodDef mapp_methods[] = {
      pop__doc__},
     {"popitem",         (PyCFunction)dict_popitem,      METH_NOARGS,
      popitem__doc__},
-    {"keys",            (PyCFunction)dictkeys_new,      METH_NOARGS,
+    {"keys",            dictkeys_new,                   METH_NOARGS,
     keys__doc__},
-    {"items",           (PyCFunction)dictitems_new,     METH_NOARGS,
+    {"items",           dictitems_new,                  METH_NOARGS,
     items__doc__},
-    {"values",          (PyCFunction)dictvalues_new,    METH_NOARGS,
+    {"values",          dictvalues_new,                 METH_NOARGS,
     values__doc__},
     {"update",          (PyCFunction)dict_update,       METH_VARARGS | METH_KEYWORDS,
      update__doc__},
@@ -3361,7 +3361,7 @@ dictiter_traverse(dictiterobject *di, visitproc visit, void *arg)
 }
 
 static PyObject *
-dictiter_len(dictiterobject *di)
+dictiter_len(dictiterobject *di, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t len = 0;
     if (di->di_dict != NULL && di->di_used == di->di_dict->ma_used)
@@ -3373,7 +3373,7 @@ PyDoc_STRVAR(length_hint_doc,
              "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-dictiter_reduce(dictiterobject *di);
+dictiter_reduce(dictiterobject *di, PyObject *Py_UNUSED(ignored));
 
 PyDoc_STRVAR(reduce_doc, "Return state information for pickling.");
 
@@ -3652,7 +3652,7 @@ PyTypeObject PyDictIterItem_Type = {
 
 
 static PyObject *
-dictiter_reduce(dictiterobject *di)
+dictiter_reduce(dictiterobject *di, PyObject *Py_UNUSED(ignored))
 {
     PyObject *list;
     dictiterobject tmp;
@@ -4092,7 +4092,7 @@ PyTypeObject PyDictKeys_Type = {
 };
 
 static PyObject *
-dictkeys_new(PyObject *dict)
+dictkeys_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
 {
     return _PyDictView_New(dict, &PyDictKeys_Type);
 }
@@ -4182,7 +4182,7 @@ PyTypeObject PyDictItems_Type = {
 };
 
 static PyObject *
-dictitems_new(PyObject *dict)
+dictitems_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
 {
     return _PyDictView_New(dict, &PyDictItems_Type);
 }
@@ -4247,7 +4247,7 @@ PyTypeObject PyDictValues_Type = {
 };
 
 static PyObject *
-dictvalues_new(PyObject *dict)
+dictvalues_new(PyObject *dict, PyObject *Py_UNUSED(ignored))
 {
     return _PyDictView_New(dict, &PyDictValues_Type);
 }

--- a/Objects/enumobject.c
+++ b/Objects/enumobject.c
@@ -189,7 +189,7 @@ enum_next(enumobject *en)
 }
 
 static PyObject *
-enum_reduce(enumobject *en)
+enum_reduce(enumobject *en, PyObject *Py_UNUSED(ignored))
 {
     if (en->en_longindex != NULL)
         return Py_BuildValue("O(OO)", Py_TYPE(en), en->en_sit, en->en_longindex);
@@ -349,7 +349,7 @@ reversed_next(reversedobject *ro)
 }
 
 static PyObject *
-reversed_len(reversedobject *ro)
+reversed_len(reversedobject *ro, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t position, seqsize;
 
@@ -365,7 +365,7 @@ reversed_len(reversedobject *ro)
 PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-reversed_reduce(reversedobject *ro)
+reversed_reduce(reversedobject *ro, PyObject *Py_UNUSED(ignored))
 {
     if (ro->seq)
         return Py_BuildValue("O(O)n", Py_TYPE(ro), ro->seq, ro->index);

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -126,7 +126,7 @@ BaseException_repr(PyBaseExceptionObject *self)
 
 /* Pickling support */
 static PyObject *
-BaseException_reduce(PyBaseExceptionObject *self)
+BaseException_reduce(PyBaseExceptionObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (self->args && self->dict)
         return PyTuple_Pack(3, Py_TYPE(self), self->args, self->dict);
@@ -713,7 +713,7 @@ ImportError_getstate(PyImportErrorObject *self)
 
 /* Pickling support */
 static PyObject *
-ImportError_reduce(PyImportErrorObject *self)
+ImportError_reduce(PyImportErrorObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *res;
     PyObject *args;
@@ -1123,7 +1123,7 @@ OSError_str(PyOSErrorObject *self)
 }
 
 static PyObject *
-OSError_reduce(PyOSErrorObject *self)
+OSError_reduce(PyOSErrorObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *args = self->args;
     PyObject *res = NULL, *tmp;

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -398,7 +398,7 @@ stdprinter_write(PyStdPrinter_Object *self, PyObject *args)
 }
 
 static PyObject *
-stdprinter_fileno(PyStdPrinter_Object *self)
+stdprinter_fileno(PyStdPrinter_Object *self, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromLong((long) self->fd);
 }
@@ -411,13 +411,13 @@ stdprinter_repr(PyStdPrinter_Object *self)
 }
 
 static PyObject *
-stdprinter_noop(PyStdPrinter_Object *self)
+stdprinter_noop(PyStdPrinter_Object *self, PyObject *Py_UNUSED(ignored))
 {
     Py_RETURN_NONE;
 }
 
 static PyObject *
-stdprinter_isatty(PyStdPrinter_Object *self)
+stdprinter_isatty(PyStdPrinter_Object *self, PyObject *Py_UNUSED(ignored))
 {
     long res;
     if (self->fd < 0) {

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -500,7 +500,7 @@ frame_tp_clear(PyFrameObject *f)
 }
 
 static PyObject *
-frame_clear(PyFrameObject *f)
+frame_clear(PyFrameObject *f, PyObject *Py_UNUSED(ignored))
 {
     if (f->f_executing) {
         PyErr_SetString(PyExc_RuntimeError,
@@ -519,7 +519,7 @@ PyDoc_STRVAR(clear__doc__,
 "F.clear(): clear most references held by the frame");
 
 static PyObject *
-frame_sizeof(PyFrameObject *f)
+frame_sizeof(PyFrameObject *f, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t res, extras, ncells, nfrees;
 

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -78,7 +78,7 @@ iter_iternext(PyObject *iterator)
 }
 
 static PyObject *
-iter_len(seqiterobject *it)
+iter_len(seqiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t seqsize, len;
 
@@ -101,7 +101,7 @@ iter_len(seqiterobject *it)
 PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-iter_reduce(seqiterobject *it)
+iter_reduce(seqiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     if (it->it_seq != NULL)
         return Py_BuildValue("N(O)n", _PyObject_GetBuiltin("iter"),
@@ -240,7 +240,7 @@ calliter_iternext(calliterobject *it)
 }
 
 static PyObject *
-calliter_reduce(calliterobject *it)
+calliter_reduce(calliterobject *it, PyObject *Py_UNUSED(ignored))
 {
     if (it->it_callable != NULL && it->it_sentinel != NULL)
         return Py_BuildValue("N(OO)", _PyObject_GetBuiltin("iter"),

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2983,9 +2983,9 @@ typedef struct {
 static void listiter_dealloc(listiterobject *);
 static int listiter_traverse(listiterobject *, visitproc, void *);
 static PyObject *listiter_next(listiterobject *);
-static PyObject *listiter_len(listiterobject *);
+static PyObject *listiter_len(listiterobject *, PyObject *);
 static PyObject *listiter_reduce_general(void *_it, int forward);
-static PyObject *listiter_reduce(listiterobject *);
+static PyObject *listiter_reduce(listiterobject *, PyObject *);
 static PyObject *listiter_setstate(listiterobject *, PyObject *state);
 
 PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(it)).");
@@ -3092,7 +3092,7 @@ listiter_next(listiterobject *it)
 }
 
 static PyObject *
-listiter_len(listiterobject *it)
+listiter_len(listiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t len;
     if (it->it_seq) {
@@ -3104,7 +3104,7 @@ listiter_len(listiterobject *it)
 }
 
 static PyObject *
-listiter_reduce(listiterobject *it)
+listiter_reduce(listiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     return listiter_reduce_general(it, 1);
 }
@@ -3136,8 +3136,8 @@ typedef struct {
 static void listreviter_dealloc(listreviterobject *);
 static int listreviter_traverse(listreviterobject *, visitproc, void *);
 static PyObject *listreviter_next(listreviterobject *);
-static PyObject *listreviter_len(listreviterobject *);
-static PyObject *listreviter_reduce(listreviterobject *);
+static PyObject *listreviter_len(listreviterobject *, PyObject *);
+static PyObject *listreviter_reduce(listreviterobject *, PyObject *);
 static PyObject *listreviter_setstate(listreviterobject *, PyObject *);
 
 static PyMethodDef listreviter_methods[] = {
@@ -3246,7 +3246,7 @@ listreviter_next(listreviterobject *it)
 }
 
 static PyObject *
-listreviter_len(listreviterobject *it)
+listreviter_len(listreviterobject *it, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t len = it->it_index + 1;
     if (it->it_seq == NULL || PyList_GET_SIZE(it->it_seq) < len)
@@ -3255,7 +3255,7 @@ listreviter_len(listreviterobject *it)
 }
 
 static PyObject *
-listreviter_reduce(listreviterobject *it)
+listreviter_reduce(listreviterobject *it, PyObject *Py_UNUSED(ignored))
 {
     return listiter_reduce_general(it, 0);
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -2537,7 +2537,7 @@ PyLong_FromUnicodeObject(PyObject *u, int base)
 /* forward */
 static PyLongObject *x_divrem
     (PyLongObject *, PyLongObject *, PyLongObject **);
-static PyObject *long_long(PyObject *v);
+static PyObject *long_long(PyObject *v, PyObject *Py_UNUSED(ignored));
 
 /* Int division with remainder, top-level routine */
 
@@ -2557,7 +2557,7 @@ long_divrem(PyLongObject *a, PyLongObject *b,
         (size_a == size_b &&
          a->ob_digit[size_a-1] < b->ob_digit[size_b-1])) {
         /* |a| < |b|. */
-        *prem = (PyLongObject *)long_long((PyObject *)a);
+        *prem = (PyLongObject *)long_long((PyObject *)a, NULL);
         if (*prem == NULL) {
             return -1;
         }
@@ -4242,7 +4242,7 @@ long_abs(PyLongObject *v)
     if (Py_SIZE(v) < 0)
         return long_neg(v);
     else
-        return long_long((PyObject *)v);
+        return long_long((PyObject *)v, NULL);
 }
 
 static int
@@ -4554,7 +4554,7 @@ long_or(PyObject *a, PyObject *b)
 }
 
 static PyObject *
-long_long(PyObject *v)
+long_long(PyObject *v, PyObject *Py_UNUSED(ignored))
 {
     if (PyLong_CheckExact(v))
         Py_INCREF(v);
@@ -5028,7 +5028,7 @@ long_round(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "|O", &o_ndigits))
         return NULL;
     if (o_ndigits == NULL)
-        return long_long(self);
+        return long_long(self, NULL);
 
     ndigits = PyNumber_Index(o_ndigits);
     if (ndigits == NULL)
@@ -5037,7 +5037,7 @@ long_round(PyObject *self, PyObject *args)
     /* if ndigits >= 0 then no rounding is necessary; return self unchanged */
     if (Py_SIZE(ndigits) >= 0) {
         Py_DECREF(ndigits);
-        return long_long(self);
+        return long_long(self, NULL);
     }
 
     /* result = self - divmod_near(self, 10 ** -ndigits)[1] */
@@ -5279,7 +5279,7 @@ int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
 }
 
 static PyMethodDef long_methods[] = {
-    {"conjugate",       (PyCFunction)long_long, METH_NOARGS,
+    {"conjugate",       long_long, METH_NOARGS,
      "Returns self, the complex conjugate of any int."},
     INT_BIT_LENGTH_METHODDEF
 #if 0
@@ -5288,11 +5288,11 @@ static PyMethodDef long_methods[] = {
 #endif
     INT_TO_BYTES_METHODDEF
     INT_FROM_BYTES_METHODDEF
-    {"__trunc__",       (PyCFunction)long_long, METH_NOARGS,
+    {"__trunc__",       long_long, METH_NOARGS,
      "Truncating an Integral returns itself."},
-    {"__floor__",       (PyCFunction)long_long, METH_NOARGS,
+    {"__floor__",       long_long, METH_NOARGS,
      "Flooring an Integral returns itself."},
-    {"__ceil__",        (PyCFunction)long_long, METH_NOARGS,
+    {"__ceil__",        long_long, METH_NOARGS,
      "Ceiling of an Integral returns itself."},
     {"__round__",       (PyCFunction)long_round, METH_VARARGS,
      "Rounding an Integral returns itself.\n"

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -101,7 +101,7 @@ meth_dealloc(PyCFunctionObject *m)
 }
 
 static PyObject *
-meth_reduce(PyCFunctionObject *m)
+meth_reduce(PyCFunctionObject *m, PyObject *Py_UNUSED(ignored))
 {
     PyObject *builtins;
     PyObject *getattr;

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -173,7 +173,7 @@ namespace_richcompare(PyObject *self, PyObject *other, int op)
 PyDoc_STRVAR(namespace_reduce__doc__, "Return state information for pickling");
 
 static PyObject *
-namespace_reduce(_PyNamespaceObject *ns)
+namespace_reduce(_PyNamespaceObject *ns, PyObject *Py_UNUSED(ignored))
 {
     PyObject *result, *args = PyTuple_New(0);
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -1619,13 +1619,13 @@ NotImplemented_repr(PyObject *op)
 }
 
 static PyObject *
-NotImplemented_reduce(PyObject *op)
+NotImplemented_reduce(PyObject *op, PyObject *Py_UNUSED(ignored))
 {
     return PyUnicode_FromString("NotImplemented");
 }
 
 static PyMethodDef notimplemented_methods[] = {
-    {"__reduce__", (PyCFunction)NotImplemented_reduce, METH_NOARGS, NULL},
+    {"__reduce__", NotImplemented_reduce, METH_NOARGS, NULL},
     {NULL, NULL}
 };
 

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -884,7 +884,7 @@ OrderedDict_fromkeys_impl(PyTypeObject *type, PyObject *seq, PyObject *value)
 PyDoc_STRVAR(odict_sizeof__doc__, "");
 
 static PyObject *
-odict_sizeof(PyODictObject *od)
+odict_sizeof(PyODictObject *od, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t res = _PyDict_SizeOf((PyDictObject *)od);
     res += sizeof(_ODictNode *) * _odict_FAST_SIZE(od);  /* od_fast_nodes */
@@ -899,7 +899,7 @@ odict_sizeof(PyODictObject *od)
 PyDoc_STRVAR(odict_reduce__doc__, "Return state information for pickling");
 
 static PyObject *
-odict_reduce(register PyODictObject *od)
+odict_reduce(register PyODictObject *od, PyObject *Py_UNUSED(ignored))
 {
     _Py_IDENTIFIER(__dict__);
     _Py_IDENTIFIER(items);
@@ -1143,21 +1143,21 @@ OrderedDict_popitem_impl(PyODictObject *self, int last)
 /* MutableMapping.keys() does not have a docstring. */
 PyDoc_STRVAR(odict_keys__doc__, "");
 
-static PyObject * odictkeys_new(PyObject *od);  /* forward */
+static PyObject * odictkeys_new(PyObject *od, PyObject *Py_UNUSED(ignored));  /* forward */
 
 /* values() */
 
 /* MutableMapping.values() does not have a docstring. */
 PyDoc_STRVAR(odict_values__doc__, "");
 
-static PyObject * odictvalues_new(PyObject *od);  /* forward */
+static PyObject * odictvalues_new(PyObject *od, PyObject *Py_UNUSED(ignored));  /* forward */
 
 /* items() */
 
 /* MutableMapping.items() does not have a docstring. */
 PyDoc_STRVAR(odict_items__doc__, "");
 
-static PyObject * odictitems_new(PyObject *od);  /* forward */
+static PyObject * odictitems_new(PyObject *od, PyObject *Py_UNUSED(ignored));  /* forward */
 
 /* update() */
 
@@ -1175,7 +1175,7 @@ PyDoc_STRVAR(odict_clear__doc__,
              "od.clear() -> None.  Remove all items from od.");
 
 static PyObject *
-odict_clear(register PyODictObject *od)
+odict_clear(register PyODictObject *od, PyObject *Py_UNUSED(ignored))
 {
     PyDict_Clear((PyObject *)od);
     _odict_clear_nodes(od);
@@ -1193,7 +1193,7 @@ static int _PyODict_SetItem_KnownHash(PyObject *, PyObject *, PyObject *,
 PyDoc_STRVAR(odict_copy__doc__, "od.copy() -> a shallow copy of od");
 
 static PyObject *
-odict_copy(register PyODictObject *od)
+odict_copy(register PyODictObject *od, PyObject *Py_UNUSED(ignored))
 {
     _ODictNode *node;
     PyObject *od_copy;
@@ -1252,7 +1252,7 @@ PyDoc_STRVAR(odict_reversed__doc__, "od.__reversed__() <==> reversed(od)");
 static PyObject * odictiter_new(PyODictObject *, int);
 
 static PyObject *
-odict_reversed(PyODictObject *od)
+odict_reversed(PyODictObject *od, PyObject *Py_UNUSED(ignored))
 {
     return odictiter_new(od, _odict_ITER_KEYS|_odict_ITER_REVERSED);
 }
@@ -1322,11 +1322,11 @@ static PyMethodDef odict_methods[] = {
     {"pop",             (PyCFunction)odict_pop,
      METH_VARARGS | METH_KEYWORDS, odict_pop__doc__},
     ORDEREDDICT_POPITEM_METHODDEF
-    {"keys",            (PyCFunction)odictkeys_new,     METH_NOARGS,
+    {"keys",            odictkeys_new,                  METH_NOARGS,
      odict_keys__doc__},
-    {"values",          (PyCFunction)odictvalues_new,   METH_NOARGS,
+    {"values",          odictvalues_new,                METH_NOARGS,
      odict_values__doc__},
-    {"items",           (PyCFunction)odictitems_new,    METH_NOARGS,
+    {"items",           odictitems_new,                 METH_NOARGS,
      odict_items__doc__},
     {"update",          (PyCFunction)odict_update, METH_VARARGS | METH_KEYWORDS,
      odict_update__doc__},
@@ -1487,7 +1487,7 @@ odict_tp_clear(PyODictObject *od)
     PyObject *res;
     Py_CLEAR(od->od_inst_dict);
     Py_CLEAR(od->od_weakreflist);
-    res = odict_clear(od);
+    res = odict_clear(od, NULL);
     if (res == NULL)
         return -1;
     Py_DECREF(res);
@@ -1956,7 +1956,7 @@ odictkeys_iter(_PyDictViewObject *dv)
 }
 
 static PyObject *
-odictkeys_reversed(_PyDictViewObject *dv)
+odictkeys_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
 {
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
@@ -2005,7 +2005,7 @@ PyTypeObject PyODictKeys_Type = {
 };
 
 static PyObject *
-odictkeys_new(PyObject *od)
+odictkeys_new(PyObject *od, PyObject *Py_UNUSED(ignored))
 {
     return _PyDictView_New(od, &PyODictKeys_Type);
 }
@@ -2023,7 +2023,7 @@ odictitems_iter(_PyDictViewObject *dv)
 }
 
 static PyObject *
-odictitems_reversed(_PyDictViewObject *dv)
+odictitems_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
 {
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
@@ -2072,7 +2072,7 @@ PyTypeObject PyODictItems_Type = {
 };
 
 static PyObject *
-odictitems_new(PyObject *od)
+odictitems_new(PyObject *od, PyObject *Py_UNUSED(ignored))
 {
     return _PyDictView_New(od, &PyODictItems_Type);
 }
@@ -2090,7 +2090,7 @@ odictvalues_iter(_PyDictViewObject *dv)
 }
 
 static PyObject *
-odictvalues_reversed(_PyDictViewObject *dv)
+odictvalues_reversed(_PyDictViewObject *dv, PyObject *Py_UNUSED(ignored))
 {
     if (dv->dv_dict == NULL) {
         Py_RETURN_NONE;
@@ -2139,7 +2139,7 @@ PyTypeObject PyODictValues_Type = {
 };
 
 static PyObject *
-odictvalues_new(PyObject *od)
+odictvalues_new(PyObject *od, PyObject *Py_UNUSED(ignored))
 {
     return _PyDictView_New(od, &PyODictValues_Type);
 }

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -636,7 +636,7 @@ static PyNumberMethods range_as_number = {
 };
 
 static PyObject * range_iter(PyObject *seq);
-static PyObject * range_reverse(PyObject *seq);
+static PyObject * range_reverse(PyObject *seq, PyObject *Py_UNUSED(ignored));
 
 PyDoc_STRVAR(reverse_doc,
 "Return a reverse iterator.");
@@ -649,7 +649,7 @@ PyDoc_STRVAR(index_doc,
 "Raise ValueError if the value is not present.");
 
 static PyMethodDef range_methods[] = {
-    {"__reversed__",    (PyCFunction)range_reverse, METH_NOARGS, reverse_doc},
+    {"__reversed__",    range_reverse,              METH_NOARGS, reverse_doc},
     {"__reduce__",      (PyCFunction)range_reduce,  METH_VARARGS},
     {"count",           (PyCFunction)range_count,   METH_O,      count_doc},
     {"index",           (PyCFunction)range_index,   METH_O,      index_doc},
@@ -731,7 +731,7 @@ rangeiter_next(rangeiterobject *r)
 }
 
 static PyObject *
-rangeiter_len(rangeiterobject *r)
+rangeiter_len(rangeiterobject *r, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromLong(r->len - r->index);
 }
@@ -740,7 +740,7 @@ PyDoc_STRVAR(length_hint_doc,
              "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-rangeiter_reduce(rangeiterobject *r)
+rangeiter_reduce(rangeiterobject *r, PyObject *Py_UNUSED(ignored))
 {
     PyObject *start=NULL, *stop=NULL, *step=NULL;
     PyObject *range;
@@ -896,7 +896,7 @@ longrangeiter_len(longrangeiterobject *r, PyObject *no_args)
 }
 
 static PyObject *
-longrangeiter_reduce(longrangeiterobject *r)
+longrangeiter_reduce(longrangeiterobject *r, PyObject *Py_UNUSED(ignored))
 {
     PyObject *product, *stop=NULL;
     PyObject *range;
@@ -1081,7 +1081,7 @@ range_iter(PyObject *seq)
 }
 
 static PyObject *
-range_reverse(PyObject *seq)
+range_reverse(PyObject *seq, PyObject *Py_UNUSED(ignored))
 {
     rangeobject *range = (rangeobject*) seq;
     longrangeiterobject *it;

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -703,7 +703,7 @@ set_merge(PySetObject *so, PyObject *otherset)
 }
 
 static PyObject *
-set_pop(PySetObject *so)
+set_pop(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     /* Make sure the search finger is in bounds */
     Py_ssize_t i = so->finger & so->mask;
@@ -833,7 +833,7 @@ setiter_traverse(setiterobject *si, visitproc visit, void *arg)
 }
 
 static PyObject *
-setiter_len(setiterobject *si)
+setiter_len(setiterobject *si, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t len = 0;
     if (si->si_set != NULL && si->si_used == si->si_set->used)
@@ -846,7 +846,7 @@ PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(
 static PyObject *setiter_iternext(setiterobject *si);
 
 static PyObject *
-setiter_reduce(setiterobject *si)
+setiter_reduce(setiterobject *si, PyObject *Py_UNUSED(ignored))
 {
     PyObject *list;
     setiterobject tmp;
@@ -1175,25 +1175,25 @@ set_swap_bodies(PySetObject *a, PySetObject *b)
 }
 
 static PyObject *
-set_copy(PySetObject *so)
+set_copy(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     return make_new_set_basetype(Py_TYPE(so), (PyObject *)so);
 }
 
 static PyObject *
-frozenset_copy(PySetObject *so)
+frozenset_copy(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     if (PyFrozenSet_CheckExact(so)) {
         Py_INCREF(so);
         return (PyObject *)so;
     }
-    return set_copy(so);
+    return set_copy(so, NULL);
 }
 
 PyDoc_STRVAR(copy_doc, "Return a shallow copy of a set.");
 
 static PyObject *
-set_clear(PySetObject *so)
+set_clear(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     set_clear_internal(so);
     Py_RETURN_NONE;
@@ -1208,7 +1208,7 @@ set_union(PySetObject *so, PyObject *args)
     PyObject *other;
     Py_ssize_t i;
 
-    result = (PySetObject *)set_copy(so);
+    result = (PySetObject *)set_copy(so, NULL);
     if (result == NULL)
         return NULL;
 
@@ -1237,7 +1237,7 @@ set_or(PySetObject *so, PyObject *other)
     if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
         Py_RETURN_NOTIMPLEMENTED;
 
-    result = (PySetObject *)set_copy(so);
+    result = (PySetObject *)set_copy(so, NULL);
     if (result == NULL)
         return NULL;
     if ((PyObject *)so == other)
@@ -1270,7 +1270,7 @@ set_intersection(PySetObject *so, PyObject *other)
     int rv;
 
     if ((PyObject *)so == other)
-        return set_copy(so);
+        return set_copy(so, NULL);
 
     result = (PySetObject *)make_new_set_basetype(Py_TYPE(so), NULL);
     if (result == NULL)
@@ -1343,7 +1343,7 @@ set_intersection_multi(PySetObject *so, PyObject *args)
     PyObject *result = (PyObject *)so;
 
     if (PyTuple_GET_SIZE(args) == 0)
-        return set_copy(so);
+        return set_copy(so, NULL);
 
     Py_INCREF(so);
     for (i=0 ; i<PyTuple_GET_SIZE(args) ; i++) {
@@ -1542,7 +1542,7 @@ set_copy_and_difference(PySetObject *so, PyObject *other)
 {
     PyObject *result;
 
-    result = set_copy(so);
+    result = set_copy(so, NULL);
     if (result == NULL)
         return NULL;
     if (set_difference_update_internal((PySetObject *) result, other) == 0)
@@ -1562,7 +1562,7 @@ set_difference(PySetObject *so, PyObject *other)
     int rv;
 
     if (PySet_GET_SIZE(so) == 0) {
-        return set_copy(so);
+        return set_copy(so, NULL);
     }
 
     if (PyAnySet_Check(other)) {
@@ -1630,7 +1630,7 @@ set_difference_multi(PySetObject *so, PyObject *args)
     PyObject *result, *other;
 
     if (PyTuple_GET_SIZE(args) == 0)
-        return set_copy(so);
+        return set_copy(so, NULL);
 
     other = PyTuple_GET_ITEM(args, 0);
     result = set_difference(so, other);
@@ -1681,7 +1681,7 @@ set_symmetric_difference_update(PySetObject *so, PyObject *other)
     int rv;
 
     if ((PyObject *)so == other)
-        return set_clear(so);
+        return set_clear(so, NULL);
 
     if (PyDict_CheckExact(other)) {
         PyObject *value;
@@ -1976,7 +1976,7 @@ PyDoc_STRVAR(discard_doc,
 If the element is not a member, do nothing.");
 
 static PyObject *
-set_reduce(PySetObject *so)
+set_reduce(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     PyObject *keys=NULL, *args=NULL, *result=NULL, *dict=NULL;
     _Py_IDENTIFIER(__dict__);
@@ -2002,7 +2002,7 @@ done:
 }
 
 static PyObject *
-set_sizeof(PySetObject *so)
+set_sizeof(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t res;
 
@@ -2044,7 +2044,7 @@ static PySequenceMethods set_as_sequence = {
 /* set object ********************************************************/
 
 #ifdef Py_DEBUG
-static PyObject *test_c_api(PySetObject *so);
+static PyObject *test_c_api(PySetObject *so, PyObject *Py_UNUSED(ignored));
 
 PyDoc_STRVAR(test_c_api_doc, "Exercises C API.  Returns True.\n\
 All is well if assertions don't fail.");
@@ -2379,7 +2379,7 @@ PySet_Pop(PyObject *set)
         PyErr_BadInternalCall();
         return NULL;
     }
-    return set_pop((PySetObject *)set);
+    return set_pop((PySetObject *)set, NULL);
 }
 
 int
@@ -2408,7 +2408,7 @@ PyObject *_PySet_Dummy = dummy;
     } while(0)
 
 static PyObject *
-test_c_api(PySetObject *so)
+test_c_api(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t count;
     const char *s;

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -36,13 +36,13 @@ ellipsis_repr(PyObject *op)
 }
 
 static PyObject *
-ellipsis_reduce(PyObject *op)
+ellipsis_reduce(PyObject *op, PyObject *Py_UNUSED(ignored))
 {
     return PyUnicode_FromString("Ellipsis");
 }
 
 static PyMethodDef ellipsis_methods[] = {
-    {"__reduce__", (PyCFunction)ellipsis_reduce, METH_NOARGS, NULL},
+    {"__reduce__", ellipsis_reduce, METH_NOARGS, NULL},
     {NULL, NULL}
 };
 
@@ -546,7 +546,7 @@ S. Out of bounds indices are clipped in a manner consistent with the\n\
 handling of normal slices.");
 
 static PyObject *
-slice_reduce(PySliceObject* self)
+slice_reduce(PySliceObject* self, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("O(OOO)", Py_TYPE(self), self->start, self->stop, self->step);
 }

--- a/Objects/stringlib/ctype.h
+++ b/Objects/stringlib/ctype.h
@@ -5,49 +5,49 @@
 #include "bytes_methods.h"
 
 static PyObject*
-stringlib_isspace(PyObject *self)
+stringlib_isspace(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _Py_bytes_isspace(STRINGLIB_STR(self), STRINGLIB_LEN(self));
 }
 
 static PyObject*
-stringlib_isalpha(PyObject *self)
+stringlib_isalpha(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _Py_bytes_isalpha(STRINGLIB_STR(self), STRINGLIB_LEN(self));
 }
 
 static PyObject*
-stringlib_isalnum(PyObject *self)
+stringlib_isalnum(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _Py_bytes_isalnum(STRINGLIB_STR(self), STRINGLIB_LEN(self));
 }
 
 static PyObject*
-stringlib_isascii(PyObject *self)
+stringlib_isascii(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _Py_bytes_isascii(STRINGLIB_STR(self), STRINGLIB_LEN(self));
 }
 
 static PyObject*
-stringlib_isdigit(PyObject *self)
+stringlib_isdigit(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _Py_bytes_isdigit(STRINGLIB_STR(self), STRINGLIB_LEN(self));
 }
 
 static PyObject*
-stringlib_islower(PyObject *self)
+stringlib_islower(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _Py_bytes_islower(STRINGLIB_STR(self), STRINGLIB_LEN(self));
 }
 
 static PyObject*
-stringlib_isupper(PyObject *self)
+stringlib_isupper(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _Py_bytes_isupper(STRINGLIB_STR(self), STRINGLIB_LEN(self));
 }
 
 static PyObject*
-stringlib_istitle(PyObject *self)
+stringlib_istitle(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return _Py_bytes_istitle(STRINGLIB_STR(self), STRINGLIB_LEN(self));
 }
@@ -56,7 +56,7 @@ stringlib_istitle(PyObject *self)
 /* functions that return a new object partially translated by ctype funcs: */
 
 static PyObject*
-stringlib_lower(PyObject *self)
+stringlib_lower(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject* newobj;
     newobj = STRINGLIB_NEW(NULL, STRINGLIB_LEN(self));
@@ -68,7 +68,7 @@ stringlib_lower(PyObject *self)
 }
 
 static PyObject*
-stringlib_upper(PyObject *self)
+stringlib_upper(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject* newobj;
     newobj = STRINGLIB_NEW(NULL, STRINGLIB_LEN(self));
@@ -80,7 +80,7 @@ stringlib_upper(PyObject *self)
 }
 
 static PyObject*
-stringlib_title(PyObject *self)
+stringlib_title(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject* newobj;
     newobj = STRINGLIB_NEW(NULL, STRINGLIB_LEN(self));
@@ -92,7 +92,7 @@ stringlib_title(PyObject *self)
 }
 
 static PyObject*
-stringlib_capitalize(PyObject *self)
+stringlib_capitalize(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject* newobj;
     newobj = STRINGLIB_NEW(NULL, STRINGLIB_LEN(self));
@@ -104,7 +104,7 @@ stringlib_capitalize(PyObject *self)
 }
 
 static PyObject*
-stringlib_swapcase(PyObject *self)
+stringlib_swapcase(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject* newobj;
     newobj = STRINGLIB_NEW(NULL, STRINGLIB_LEN(self));

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -240,7 +240,7 @@ structseq_repr(PyStructSequence *obj)
 }
 
 static PyObject *
-structseq_reduce(PyStructSequence* self)
+structseq_reduce(PyStructSequence* self, PyObject *Py_UNUSED(ignored))
 {
     PyObject* tup = NULL;
     PyObject* dict = NULL;

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -989,7 +989,7 @@ tupleiter_next(tupleiterobject *it)
 }
 
 static PyObject *
-tupleiter_len(tupleiterobject *it)
+tupleiter_len(tupleiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t len = 0;
     if (it->it_seq)
@@ -1000,7 +1000,7 @@ tupleiter_len(tupleiterobject *it)
 PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-tupleiter_reduce(tupleiterobject *it)
+tupleiter_reduce(tupleiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     if (it->it_seq)
         return Py_BuildValue("N(O)n", _PyObject_GetBuiltin("iter"),

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13792,7 +13792,7 @@ unicode_sizeof_impl(PyObject *self)
 }
 
 static PyObject *
-unicode_getnewargs(PyObject *v)
+unicode_getnewargs(PyObject *v, PyObject *Py_UNUSED(ignored))
 {
     PyObject *copy = _PyUnicode_Copy(v);
     if (!copy)
@@ -13853,7 +13853,7 @@ static PyMethodDef unicode_methods[] = {
     {"_decimal2ascii", (PyCFunction) unicode__decimal2ascii, METH_NOARGS},
 #endif
 
-    {"__getnewargs__",  (PyCFunction)unicode_getnewargs, METH_NOARGS},
+    {"__getnewargs__",  unicode_getnewargs, METH_NOARGS},
     {NULL, NULL}
 };
 
@@ -15334,7 +15334,7 @@ unicodeiter_next(unicodeiterobject *it)
 }
 
 static PyObject *
-unicodeiter_len(unicodeiterobject *it)
+unicodeiter_len(unicodeiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t len = 0;
     if (it->it_seq)
@@ -15345,7 +15345,7 @@ unicodeiter_len(unicodeiterobject *it)
 PyDoc_STRVAR(length_hint_doc, "Private method returning an estimate of len(list(it)).");
 
 static PyObject *
-unicodeiter_reduce(unicodeiterobject *it)
+unicodeiter_reduce(unicodeiterobject *it, PyObject *Py_UNUSED(ignored))
 {
     if (it->it_seq != NULL) {
         return Py_BuildValue("N(O)n", _PyObject_GetBuiltin("iter"),

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -452,7 +452,7 @@ proxy_checkref(PyWeakReference *proxy)
 
 #define WRAP_METHOD(method, special) \
     static PyObject * \
-    method(PyObject *proxy) { \
+    method(PyObject *proxy, PyObject *Py_UNUSED(ignored)) { \
             _Py_IDENTIFIER(special); \
             UNWRAP(proxy); \
                 return _PyObject_CallMethodId(proxy, &PyId_##special, NULL); \
@@ -602,7 +602,7 @@ WRAP_METHOD(proxy_bytes, __bytes__)
 
 
 static PyMethodDef proxy_methods[] = {
-        {"__bytes__", (PyCFunction)proxy_bytes, METH_NOARGS},
+        {"__bytes__", proxy_bytes, METH_NOARGS},
         {NULL, NULL}
 };
 

--- a/PC/bdist_wininst/install.c
+++ b/PC/bdist_wininst/install.c
@@ -631,19 +631,18 @@ static PyObject *PyMessageBox(PyObject *self, PyObject *args)
     return g_Py_BuildValue("i", rc);
 }
 
-static PyObject *GetRootHKey(PyObject *self)
+static PyObject *GetRootHKey(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return g_PyLong_FromVoidPtr(hkey_root);
 }
 
 #define METH_VARARGS 0x0001
 #define METH_NOARGS   0x0004
-typedef PyObject *(*PyCFunction)(PyObject *, PyObject *);
 
 PyMethodDef meth[] = {
     {"create_shortcut", CreateShortcut, METH_VARARGS, NULL},
     {"get_special_folder_path", GetSpecialFolderPath, METH_VARARGS, NULL},
-    {"get_root_hkey", (PyCFunction)GetRootHKey, METH_NOARGS, NULL},
+    {"get_root_hkey", GetRootHKey, METH_NOARGS, NULL},
     {"file_created", FileCreated, METH_VARARGS, NULL},
     {"directory_created", DirectoryCreated, METH_VARARGS, NULL},
     {"message_box", PyMessageBox, METH_VARARGS, NULL},

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -619,7 +619,7 @@ filter_next(filterobject *lz)
 }
 
 static PyObject *
-filter_reduce(filterobject *lz)
+filter_reduce(filterobject *lz, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("O(OO)", Py_TYPE(lz), lz->func, lz->it);
 }
@@ -1331,7 +1331,7 @@ exit:
 }
 
 static PyObject *
-map_reduce(mapobject *lz)
+map_reduce(mapobject *lz, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t numargs = PyTuple_GET_SIZE(lz->iters);
     PyObject *args = PyTuple_New(numargs+1);
@@ -2656,7 +2656,7 @@ zip_next(zipobject *lz)
 }
 
 static PyObject *
-zip_reduce(zipobject *lz)
+zip_reduce(zipobject *lz, PyObject *Py_UNUSED(ignored))
 {
     /* Just recreate the zip with the internal iterator tuple */
     return Py_BuildValue("OO", Py_TYPE(lz), lz->ittuple);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -357,7 +357,7 @@ exit status will be one (i.e., failure)."
 
 
 static PyObject *
-sys_getdefaultencoding(PyObject *self)
+sys_getdefaultencoding(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return PyUnicode_FromString(PyUnicode_GetDefaultEncoding());
 }
@@ -370,7 +370,7 @@ implementation."
 );
 
 static PyObject *
-sys_getfilesystemencoding(PyObject *self)
+sys_getfilesystemencoding(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (Py_FileSystemDefaultEncoding)
         return PyUnicode_FromString(Py_FileSystemDefaultEncoding);
@@ -387,7 +387,7 @@ operating system filenames."
 );
 
 static PyObject *
-sys_getfilesystemencodeerrors(PyObject *self)
+sys_getfilesystemencodeerrors(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (Py_FileSystemDefaultEncodeErrors)
         return PyUnicode_FromString(Py_FileSystemDefaultEncodeErrors);
@@ -988,7 +988,7 @@ dependent."
 );
 
 static PyObject *
-sys_getrecursionlimit(PyObject *self)
+sys_getrecursionlimit(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromLong(Py_GetRecursionLimit());
 }
@@ -1274,7 +1274,7 @@ sys_getrefcount(PyObject *self, PyObject *arg)
 
 #ifdef Py_REF_DEBUG
 static PyObject *
-sys_gettotalrefcount(PyObject *self)
+sys_gettotalrefcount(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromSsize_t(_Py_GetRefTotal());
 }
@@ -1289,7 +1289,7 @@ reference as an argument to getrefcount()."
 );
 
 static PyObject *
-sys_getallocatedblocks(PyObject *self)
+sys_getallocatedblocks(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return PyLong_FromSsize_t(_Py_GetAllocatedBlocks());
 }
@@ -1401,7 +1401,7 @@ a 11-tuple where the entries in the tuple are counts of:\n\
 );
 
 static PyObject *
-sys_callstats(PyObject *self)
+sys_callstats(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     if (PyErr_WarnEx(PyExc_DeprecationWarning,
                       "sys.callstats() has been deprecated in Python 3.7 "
@@ -1493,7 +1493,7 @@ static PyMethodDef sys_methods[] = {
     /* Might as well keep this in alphabetic order */
     {"breakpointhook",  (PyCFunction)sys_breakpointhook,
      METH_FASTCALL | METH_KEYWORDS, breakpointhook_doc},
-    {"callstats", (PyCFunction)sys_callstats, METH_NOARGS,
+    {"callstats", sys_callstats, METH_NOARGS,
      callstats_doc},
     {"_clear_type_cache",       sys_clear_type_cache,     METH_NOARGS,
      sys_clear_type_cache__doc__},
@@ -1503,13 +1503,13 @@ static PyMethodDef sys_methods[] = {
     {"exc_info",        sys_exc_info, METH_NOARGS, exc_info_doc},
     {"excepthook",      sys_excepthook, METH_VARARGS, excepthook_doc},
     {"exit",            sys_exit, METH_VARARGS, exit_doc},
-    {"getdefaultencoding", (PyCFunction)sys_getdefaultencoding,
+    {"getdefaultencoding", sys_getdefaultencoding,
      METH_NOARGS, getdefaultencoding_doc},
 #ifdef HAVE_DLOPEN
     {"getdlopenflags", (PyCFunction)sys_getdlopenflags, METH_NOARGS,
      getdlopenflags_doc},
 #endif
-    {"getallocatedblocks", (PyCFunction)sys_getallocatedblocks, METH_NOARGS,
+    {"getallocatedblocks", sys_getallocatedblocks, METH_NOARGS,
       getallocatedblocks_doc},
 #ifdef COUNT_ALLOCS
     {"getcounts",       (PyCFunction)sys_getcounts, METH_NOARGS},
@@ -1517,18 +1517,18 @@ static PyMethodDef sys_methods[] = {
 #ifdef DYNAMIC_EXECUTION_PROFILE
     {"getdxp",          _Py_GetDXProfile, METH_VARARGS},
 #endif
-    {"getfilesystemencoding", (PyCFunction)sys_getfilesystemencoding,
+    {"getfilesystemencoding", sys_getfilesystemencoding,
      METH_NOARGS, getfilesystemencoding_doc},
-    { "getfilesystemencodeerrors", (PyCFunction)sys_getfilesystemencodeerrors,
+    { "getfilesystemencodeerrors", sys_getfilesystemencodeerrors,
      METH_NOARGS, getfilesystemencodeerrors_doc },
 #ifdef Py_TRACE_REFS
     {"getobjects",      _Py_GetObjects, METH_VARARGS},
 #endif
 #ifdef Py_REF_DEBUG
-    {"gettotalrefcount", (PyCFunction)sys_gettotalrefcount, METH_NOARGS},
+    {"gettotalrefcount", sys_gettotalrefcount, METH_NOARGS},
 #endif
     {"getrefcount",     (PyCFunction)sys_getrefcount, METH_O, getrefcount_doc},
-    {"getrecursionlimit", (PyCFunction)sys_getrecursionlimit, METH_NOARGS,
+    {"getrecursionlimit", sys_getrecursionlimit, METH_NOARGS,
      getrecursionlimit_doc},
     {"getsizeof",   (PyCFunction)sys_getsizeof,
      METH_VARARGS | METH_KEYWORDS, getsizeof_doc},

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -87,7 +87,7 @@ tb_new_impl(PyTypeObject *type, PyObject *tb_next, PyFrameObject *tb_frame,
 }
 
 static PyObject *
-tb_dir(PyTracebackObject *self)
+tb_dir(PyTracebackObject *self, PyObject *Py_UNUSED(ignored))
 {
     return Py_BuildValue("[ssss]", "tb_frame", "tb_next",
                                    "tb_lasti", "tb_lineno");


### PR DESCRIPTION
gcc 8 has added a new warning heuristic to detect invalid function casts and a stock python build seems to hit that warning quite often.  The most common is the cast of a METH_NOARGS function (that uses just one argument) to a PyCFunction.  Fix this by adding a dummy argument to all the affected callback functions.

I have split the changes by directory and also made a separate commit where the change was not just a trivial dummy argument addition, as is the case in a4ee3ad and 58eaf31.

<!-- issue-number: bpo-33012 -->
https://bugs.python.org/issue33012
<!-- /issue-number -->
