### PR TITLE
[3.6] bpo-33016: Fix potential use of uninitialized memory in nt._getfinalpathname (GH-6010)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-03-07-01-33-33.bpo-33016.Z_Med0.rst
+++ b/Misc/NEWS.d/next/Windows/2018-03-07-01-33-33.bpo-33016.Z_Med0.rst
@@ -1,0 +1,1 @@
+Fix potential use of uninitialized memory in nt._getfinalpathname


### PR DESCRIPTION


<!-- issue-number: bpo-33016 -->
https://bugs.python.org/issue33016
<!-- /issue-number -->
