### PR TITLE
bpo-32517: fix test_read_pty_output() hangs on macOS 10.13.2+

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1533,6 +1533,7 @@ class EventLoopTestsMixin:
         self.assertEqual(5, proto.nbytes)
 
         os.close(slave)
+        proto.transport.close()
         self.loop.run_until_complete(proto.done)
         self.assertEqual(
             ['INITIAL', 'CONNECTED', 'EOF', 'CLOSED'], proto.state)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -614,6 +614,7 @@ Thomas Heller
 Malte Helmert
 Lance Finn Helsten
 Jonathan Hendry
+Nathan Henrie
 Michael Henry
 James Henstridge
 Kasun Herath

--- a/Misc/NEWS.d/next/Tests/2018-03-09-07-05-12.bpo-32517.ugc1iW.rst
+++ b/Misc/NEWS.d/next/Tests/2018-03-09-07-05-12.bpo-32517.ugc1iW.rst
@@ -1,0 +1,2 @@
+Fix failing ``test_asyncio`` on macOS 10.12.2+ due to transport of
+``KqueueSelector`` loop was not being closed.


### PR DESCRIPTION
test_asyncio hangs indefinitely on macOS 10.13.2+ on `read_pty_output()`
using the KqueueSelector. Closing `proto.transport` (as is done in
`write_pty_output()`) seems to fix it.

<!-- issue-number: bpo-32517 -->
https://bugs.python.org/issue32517
<!-- /issue-number -->
