### PR TITLE
bpo-33037: Skip sending/receiving after SSL transport closing

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -504,6 +504,10 @@ class SSLProtocol(protocols.Protocol):
 
         The argument is a bytes object.
         """
+        if self._sslpipe is None:
+            # transport closing, sslpipe is destroyed
+            return
+
         try:
             ssldata, appdata = self._sslpipe.feed_ssldata(data)
         except ssl.SSLError as e:
@@ -636,7 +640,7 @@ class SSLProtocol(protocols.Protocol):
 
     def _process_write_backlog(self):
         # Try to make progress on the write backlog.
-        if self._transport is None:
+        if self._transport is None or self._sslpipe is None:
             return
 
         try:

--- a/Misc/NEWS.d/next/Library/2018-03-09-23-07-07.bpo-33037.nAJ3at.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-09-23-07-07.bpo-33037.nAJ3at.rst
@@ -1,0 +1,1 @@
+Skip sending/receiving data after SSL transport closing.


### PR DESCRIPTION


<!-- issue-number: bpo-33037 -->
https://bugs.python.org/issue33037
<!-- /issue-number -->
