### PR TITLE
bpo-32758: Warn that dbm.dumb.open() can crash Python

### DIFF
--- a/Doc/library/dbm.rst
+++ b/Doc/library/dbm.rst
@@ -361,6 +361,11 @@ The module defines the following:
    database has to be created.  It defaults to octal ``0o666`` (and will be modified
    by the prevailing umask).
 
+   .. warning::
+      It is possible to crash the Python interpreter when loading a database
+      with a sufficiently large/complex entry due to stack depth limitations in
+      Python's AST compiler.
+
    .. versionchanged:: 3.5
       :func:`.open` always creates a new database when the flag has the value
       ``'n'``.


### PR DESCRIPTION
This is  due to the use of `ast.literal_eval()`.

<!-- issue-number: bpo-32758 -->
https://bugs.python.org/issue32758
<!-- /issue-number -->
