### PR TITLE
bpo-32972: Unittest: Add a runTestMethod to TestCase (don't merge)

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -790,6 +790,14 @@ Test cases
       by the test to be propagated to the caller, and can be used to support
       running tests under a debugger.
 
+   .. method:: runTestMethod(method)
+
+      Calls *method* and returns its result. This function is used to execute
+      all test methods and exists so that subclasses may override it to e.g.
+      await any possible coroutine returned by the test method.
+
+      .. versionadded:: 3.8
+
    .. _assert-methods:
 
    The :class:`TestCase` class provides several assert methods to check for and

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -612,7 +612,7 @@ class TestCase(object):
             if outcome.success:
                 outcome.expecting_failure = expecting_failure
                 with outcome.testPartExecutor(self, isTest=True):
-                    testMethod()
+                    self._runTestMethod(testMethod)
                 outcome.expecting_failure = False
                 with outcome.testPartExecutor(self):
                     self.tearDown()
@@ -1329,6 +1329,13 @@ class TestCase(object):
             msg = self._formatMessage(msg, standardMsg)
             raise self.failureException(msg)
 
+    def _runTestMethod(self, method):
+        """Execute the test method.
+
+        This method can be overridden in subclasses to (e.g.) run coroutines
+        in an event loop.
+        """
+        return method()
 
     def _deprecate(original_func):
         def deprecated_func(*args, **kwargs):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -612,7 +612,7 @@ class TestCase(object):
             if outcome.success:
                 outcome.expecting_failure = expecting_failure
                 with outcome.testPartExecutor(self, isTest=True):
-                    self._runTestMethod(testMethod)
+                    self.runTestMethod(testMethod)
                 outcome.expecting_failure = False
                 with outcome.testPartExecutor(self):
                     self.tearDown()
@@ -1329,7 +1329,7 @@ class TestCase(object):
             msg = self._formatMessage(msg, standardMsg)
             raise self.failureException(msg)
 
-    def _runTestMethod(self, method):
+    def runTestMethod(self, method):
         """Execute the test method.
 
         This method can be overridden in subclasses to (e.g.) run coroutines

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -1836,7 +1836,7 @@ test case
                 super().__init__(method_name)
                 self.test1_called = False
 
-            def _runTestMethod(self, method):
+            def runTestMethod(self, method):
                 result = method()
                 if asyncio.iscoroutine(result):
                     return asyncio.run(result)

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import difflib
 import pprint
@@ -1827,6 +1828,28 @@ test case
             testcase = TestCase(method_name)
             testcase.run()
             self.assertEqual(MyException.ninstance, 0)
+
+    def test_runTestMethod(self):
+        # Test that _runTestMethod runs the test method and can be overridden.
+        class AsyncTestCase(unittest.TestCase):
+            def __init__(self, method_name):
+                super().__init__(method_name)
+                self.test1_called = False
+
+            def _runTestMethod(self, method):
+                result = method()
+                if asyncio.iscoroutine(result):
+                    return asyncio.run(result)
+                else:
+                    return result
+
+            async def test1(self):
+                await asyncio.sleep(0.0)
+                self.test1_called = True
+
+        testcase = AsyncTestCase('test1')
+        testcase.run()
+        self.assertTrue(testcase.test1_called)
 
 
 if __name__ == "__main__":

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1540,6 +1540,7 @@ Daniel Stokes
 Michael Stone
 Serhiy Storchaka
 Ken Stox
+Petter Strandmark
 Charalampos Stratakis
 Dan Stromberg
 Donald Stufft

--- a/Misc/NEWS.d/next/Library/2018-03-10-11-56-01.bpo-32972.gfeea.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-10-11-56-01.bpo-32972.gfeea.rst
@@ -1,0 +1,2 @@
+``unittest.TestCase`` now has a private method that can be overridden in
+subclasses to run coroutine test cases. Patch by Petter Strandmark.

--- a/Misc/NEWS.d/next/Library/2018-03-10-11-56-01.bpo-32972.gfeea.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-10-11-56-01.bpo-32972.gfeea.rst
@@ -1,2 +1,3 @@
-``unittest.TestCase`` now has a private method that can be overridden in
-subclasses to run coroutine test cases. Patch by Petter Strandmark.
+``unittest.TestCase`` now has a method ``runTestMethod`` that can be
+overridden in subclasses to run coroutine test cases. Patch by Petter
+Strandmark.


### PR DESCRIPTION
This allows a future subclass to customize how the test method is run. For
example, this is required in order to create an "AsyncTestCase" that runs
coroutines in an event loop.

This pull request only provides the neccessary change in unittest. Any future class like "AsyncTestCase" will probably live in asyncio.

<!-- issue-number: [bpo-32972](https://bugs.python.org/issue32972) -->
https://bugs.python.org/issue32972
<!-- /issue-number -->
