### PR TITLE
bpo-33041: Fixed bytecode generation for "async for" with a complex target.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-03-10-15-16-40.bpo-33041.-ak5Fk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-03-10-15-16-40.bpo-33041.-ak5Fk.rst
@@ -1,0 +1,3 @@
+Fixed bytecode generation for "async for" with a complex target. A
+StopAsyncIteration raised on assigning or unpacking will be now propagated
+instead of stopping the iteration.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2473,8 +2473,8 @@ compiler_async_for(struct compiler *c, stmt_ty s)
     ADDOP(c, GET_ANEXT);
     ADDOP_O(c, LOAD_CONST, Py_None, consts);
     ADDOP(c, YIELD_FROM);
-    VISIT(c, expr, s->v.AsyncFor.target);
     ADDOP(c, POP_BLOCK);  /* for SETUP_FINALLY */
+    VISIT(c, expr, s->v.AsyncFor.target);
     compiler_pop_fblock(c, EXCEPT, try);
     ADDOP_JREL(c, JUMP_FORWARD, after_try);
 
@@ -4060,8 +4060,8 @@ compiler_async_comprehension_generator(struct compiler *c,
     ADDOP(c, GET_ANEXT);
     ADDOP_O(c, LOAD_CONST, Py_None, consts);
     ADDOP(c, YIELD_FROM);
-    VISIT(c, expr, gen->target);
     ADDOP(c, POP_BLOCK);
+    VISIT(c, expr, gen->target);
     compiler_pop_fblock(c, EXCEPT, try);
     ADDOP_JREL(c, JUMP_FORWARD, after_try);
 


### PR DESCRIPTION
A StopAsyncIteration raised on assigning or unpacking will be now propagated instead of stopping the iteration.


<!-- issue-number: bpo-33041 -->
https://bugs.python.org/issue33041
<!-- /issue-number -->
