### PR TITLE
[3.6] bpo-33037: Skip sending/receiving after SSL transport closing (GH-6044)

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -497,6 +497,10 @@ class SSLProtocol(protocols.Protocol):
 
         The argument is a bytes object.
         """
+        if self._sslpipe is None:
+            # transport closing, sslpipe is destroyed
+            return
+
         try:
             ssldata, appdata = self._sslpipe.feed_ssldata(data)
         except ssl.SSLError as e:
@@ -626,7 +630,7 @@ class SSLProtocol(protocols.Protocol):
 
     def _process_write_backlog(self):
         # Try to make progress on the write backlog.
-        if self._transport is None:
+        if self._transport is None or self._sslpipe is None:
             return
 
         try:

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -22,15 +22,16 @@ class SslProtoHandshakeTests(test_utils.TestCase):
         self.loop = asyncio.new_event_loop()
         self.set_event_loop(self.loop)
 
-    def ssl_protocol(self, waiter=None):
+    def ssl_protocol(self, *, waiter=None, proto=None):
         sslcontext = test_utils.dummy_ssl_context()
-        app_proto = asyncio.Protocol()
-        proto = sslproto.SSLProtocol(self.loop, app_proto, sslcontext, waiter)
-        self.assertIs(proto._app_transport.get_protocol(), app_proto)
-        self.addCleanup(proto._app_transport.close)
-        return proto
+        if proto is None:  # app protocol
+            proto = asyncio.Protocol()
+        ssl_proto = sslproto.SSLProtocol(self.loop, proto, sslcontext, waiter)
+        self.assertIs(ssl_proto._app_transport.get_protocol(), proto)
+        self.addCleanup(ssl_proto._app_transport.close)
+        return ssl_proto
 
-    def connection_made(self, ssl_proto, do_handshake=None):
+    def connection_made(self, ssl_proto, *, do_handshake=None):
         transport = mock.Mock()
         sslpipe = mock.Mock()
         sslpipe.shutdown.return_value = b''
@@ -48,7 +49,7 @@ class SslProtoHandshakeTests(test_utils.TestCase):
         # Python issue #23197: cancelling a handshake must not raise an
         # exception or log an error, even if the handshake failed
         waiter = asyncio.Future(loop=self.loop)
-        ssl_proto = self.ssl_protocol(waiter)
+        ssl_proto = self.ssl_protocol(waiter=waiter)
         handshake_fut = asyncio.Future(loop=self.loop)
 
         def do_handshake(callback):
@@ -58,14 +59,14 @@ class SslProtoHandshakeTests(test_utils.TestCase):
             return []
 
         waiter.cancel()
-        self.connection_made(ssl_proto, do_handshake)
+        self.connection_made(ssl_proto, do_handshake=do_handshake)
 
         with test_utils.disable_logger():
             self.loop.run_until_complete(handshake_fut)
 
     def test_eof_received_waiter(self):
         waiter = asyncio.Future(loop=self.loop)
-        ssl_proto = self.ssl_protocol(waiter)
+        ssl_proto = self.ssl_protocol(waiter=waiter)
         self.connection_made(ssl_proto)
         ssl_proto.eof_received()
         test_utils.run_briefly(self.loop)
@@ -76,7 +77,7 @@ class SslProtoHandshakeTests(test_utils.TestCase):
         # _fatal_error() generates a NameError if sslproto.py
         # does not import base_events.
         waiter = asyncio.Future(loop=self.loop)
-        ssl_proto = self.ssl_protocol(waiter)
+        ssl_proto = self.ssl_protocol(waiter=waiter)
         # Temporarily turn off error logging so as not to spoil test output.
         log_level = log.logger.getEffectiveLevel()
         log.logger.setLevel(logging.FATAL)
@@ -90,7 +91,7 @@ class SslProtoHandshakeTests(test_utils.TestCase):
         # From issue #472.
         # yield from waiter hang if lost_connection was called.
         waiter = asyncio.Future(loop=self.loop)
-        ssl_proto = self.ssl_protocol(waiter)
+        ssl_proto = self.ssl_protocol(waiter=waiter)
         self.connection_made(ssl_proto)
         ssl_proto.connection_lost(ConnectionAbortedError)
         test_utils.run_briefly(self.loop)
@@ -99,10 +100,7 @@ class SslProtoHandshakeTests(test_utils.TestCase):
     def test_close_during_handshake(self):
         # bpo-29743 Closing transport during handshake process leaks socket
         waiter = asyncio.Future(loop=self.loop)
-        ssl_proto = self.ssl_protocol(waiter)
-
-        def do_handshake(callback):
-            return []
+        ssl_proto = self.ssl_protocol(waiter=waiter)
 
         transport = self.connection_made(ssl_proto)
         test_utils.run_briefly(self.loop)
@@ -112,7 +110,7 @@ class SslProtoHandshakeTests(test_utils.TestCase):
 
     def test_get_extra_info_on_closed_connection(self):
         waiter = asyncio.Future(loop=self.loop)
-        ssl_proto = self.ssl_protocol(waiter)
+        ssl_proto = self.ssl_protocol(waiter=waiter)
         self.assertIsNone(ssl_proto._get_extra_info('socket'))
         default = object()
         self.assertIs(ssl_proto._get_extra_info('socket', default), default)
@@ -123,11 +121,30 @@ class SslProtoHandshakeTests(test_utils.TestCase):
 
     def test_set_new_app_protocol(self):
         waiter = asyncio.Future(loop=self.loop)
-        ssl_proto = self.ssl_protocol(waiter)
+        ssl_proto = self.ssl_protocol(waiter=waiter)
         new_app_proto = asyncio.Protocol()
         ssl_proto._app_transport.set_protocol(new_app_proto)
         self.assertIs(ssl_proto._app_transport.get_protocol(), new_app_proto)
         self.assertIs(ssl_proto._app_protocol, new_app_proto)
+
+    def test_data_received_after_closing(self):
+        ssl_proto = self.ssl_protocol()
+        self.connection_made(ssl_proto)
+        transp = ssl_proto._app_transport
+
+        transp.close()
+
+        # should not raise
+        self.assertIsNone(ssl_proto.data_received(b'data'))
+
+    def test_write_after_closing(self):
+        ssl_proto = self.ssl_protocol()
+        self.connection_made(ssl_proto)
+        transp = ssl_proto._app_transport
+        transp.close()
+
+        # should not raise
+        self.assertIsNone(transp.write(b'data'))
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2018-03-09-23-07-07.bpo-33037.nAJ3at.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-09-23-07-07.bpo-33037.nAJ3at.rst
@@ -1,0 +1,1 @@
+Skip sending/receiving data after SSL transport closing.


### PR DESCRIPTION
* Skip write()/data_received() if sslpipe is destroyed.
(cherry picked from commit 5e80a71ab67045fecec46573a1892e240b569ace)


<!-- issue-number: bpo-33037 -->
https://bugs.python.org/issue33037
<!-- /issue-number -->
