### PR TITLE
[3.7] bpo-33041: Add missed error checks when compile "async for" (GH-6053)

### DIFF
--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2337,7 +2337,7 @@ compiler_async_for(struct compiler *c, stmt_ty s)
     _Py_IDENTIFIER(StopAsyncIteration);
 
     basicblock *try, *except, *end, *after_try, *try_cleanup,
-               *after_loop, *after_loop_else;
+               *after_loop_else;
 
     PyObject *stop_aiter_error = _PyUnicode_FromId(&PyId_StopAsyncIteration);
     if (stop_aiter_error == NULL) {
@@ -2349,14 +2349,14 @@ compiler_async_for(struct compiler *c, stmt_ty s)
     end = compiler_new_block(c);
     after_try = compiler_new_block(c);
     try_cleanup = compiler_new_block(c);
-    after_loop = compiler_new_block(c);
     after_loop_else = compiler_new_block(c);
 
     if (try == NULL || except == NULL || end == NULL
-            || after_try == NULL || try_cleanup == NULL)
+            || after_try == NULL || try_cleanup == NULL
+            || after_loop_else == NULL)
         return 0;
 
-    ADDOP_JREL(c, SETUP_LOOP, after_loop);
+    ADDOP_JREL(c, SETUP_LOOP, end);
     if (!compiler_push_fblock(c, LOOP, try))
         return 0;
 
@@ -2403,9 +2403,6 @@ compiler_async_for(struct compiler *c, stmt_ty s)
 
     ADDOP(c, POP_BLOCK); /* for SETUP_LOOP */
     compiler_pop_fblock(c, LOOP, try);
-
-    compiler_use_next_block(c, after_loop);
-    ADDOP_JABS(c, JUMP_ABSOLUTE, end);
 
     compiler_use_next_block(c, after_loop_else);
     VISIT_SEQ(c, stmt, s->v.For.orelse);
@@ -3893,7 +3890,7 @@ compiler_async_comprehension_generator(struct compiler *c,
     _Py_IDENTIFIER(StopAsyncIteration);
 
     comprehension_ty gen;
-    basicblock *anchor, *skip, *if_cleanup, *try,
+    basicblock *anchor, *if_cleanup, *try,
                *after_try, *except, *try_cleanup;
     Py_ssize_t i, n;
 
@@ -3906,13 +3903,12 @@ compiler_async_comprehension_generator(struct compiler *c,
     after_try = compiler_new_block(c);
     try_cleanup = compiler_new_block(c);
     except = compiler_new_block(c);
-    skip = compiler_new_block(c);
     if_cleanup = compiler_new_block(c);
     anchor = compiler_new_block(c);
 
-    if (skip == NULL || if_cleanup == NULL || anchor == NULL ||
+    if (if_cleanup == NULL || anchor == NULL ||
             try == NULL || after_try == NULL ||
-            except == NULL || after_try == NULL) {
+            except == NULL || try_cleanup == NULL) {
         return 0;
     }
 
@@ -4004,8 +4000,6 @@ compiler_async_comprehension_generator(struct compiler *c,
         default:
             return 0;
         }
-
-        compiler_use_next_block(c, skip);
     }
     compiler_use_next_block(c, if_cleanup);
     ADDOP_JABS(c, JUMP_ABSOLUTE, try);


### PR DESCRIPTION
and remove redundant code.
(cherry picked from commit 67ee07795bcd84b679c000780212d4d81a1490a3)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>


<!-- issue-number: bpo-33041 -->
https://bugs.python.org/issue33041
<!-- /issue-number -->
