### PR TITLE
bpo-27428: Fix WindowsRegistryFinder documentation

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1030,7 +1030,7 @@ find and load modules.
 .. class:: WindowsRegistryFinder
 
    :term:`Finder` for modules declared in the Windows registry.  This class
-   implements the :class:`importlib.abc.Finder` ABC.
+   implements the :class:`importlib.abc.MetaPathFinder` ABC.
 
    Only class methods are defined by this class to alleviate the need for
    instantiation.

--- a/Misc/NEWS.d/next/Documentation/2018-03-11-00-16-56.bpo-27428.B7A8FT.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-03-11-00-16-56.bpo-27428.B7A8FT.rst
@@ -1,0 +1,2 @@
+Update documentation to clarify that ``WindowsRegistryFinder`` implement
+``MetaPathFinder``. Patch by Himanshu Lakhara

--- a/Misc/NEWS.d/next/Documentation/2018-03-11-00-16-56.bpo-27428.B7A8FT.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-03-11-00-16-56.bpo-27428.B7A8FT.rst
@@ -1,2 +1,2 @@
-Update documentation to clarify that ``WindowsRegistryFinder`` implement
-``MetaPathFinder``. Patch by Himanshu Lakhara
+Update documentation to clarify that ``WindowsRegistryFinder`` implements
+``MetaPathFinder``. (Patch by Himanshu Lakhara)


### PR DESCRIPTION
Update documentation to clarify WindowsRegistryFinder
implement MetaPathFinder

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-27428 -->
https://bugs.python.org/issue27428
<!-- /issue-number -->
