### PR TITLE
Drop confusing commented out strncpy in pystrtod.c

### DIFF
--- a/Python/pystrtod.c
+++ b/Python/pystrtod.c
@@ -1060,8 +1060,6 @@ format_float_short(double d, char format_code,
         else {
             /* shouldn't get here: Gay's code should always return
                something starting with a digit, an 'I',  or 'N' */
-            /* strncpy(p, "ERR", 3);
-               p += 3; */
             Py_UNREACHABLE();
         }
         goto exit;


### PR DESCRIPTION
Commit efd2bac1 commented out strncpy to fix a gcc 8 warning.  Remove
the commented out code to avoid confusion[1].

[1] https://mail.python.org/pipermail/python-dev/2018-March/152342.html