### PR TITLE
[3.7] bpo-33026: Fix jumping out of "with" block by setting f_lineno. (GH-6026).

### DIFF
--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -797,6 +797,34 @@ class JumpTestCase(unittest.TestCase):
         with tracecontext(output, 4):
             output.append(5)
 
+    @jump_test(4, 5, [1, 3, 5, 6])
+    def test_jump_out_of_with_block_within_for_block(output):
+        output.append(1)
+        for i in [1]:
+            with tracecontext(output, 3):
+                output.append(4)
+            output.append(5)
+        output.append(6)
+
+    @jump_test(4, 5, [1, 2, 3, 5, -2, 6])
+    def test_jump_out_of_with_block_within_with_block(output):
+        output.append(1)
+        with tracecontext(output, 2):
+            with tracecontext(output, 3):
+                output.append(4)
+            output.append(5)
+        output.append(6)
+
+    @jump_test(5, 6, [2, 4, 6, 7])
+    def test_jump_out_of_with_block_within_finally_block(output):
+        try:
+            output.append(2)
+        finally:
+            with tracecontext(output, 4):
+                output.append(5)
+            output.append(6)
+        output.append(7)
+
     @jump_test(8, 11, [1, 3, 5, 11, 12])
     def test_jump_out_of_complex_nested_blocks(output):
         output.append(1)

--- a/Misc/NEWS.d/next/Core and Builtins/2018-03-08-09-48-38.bpo-33026.QZA3Ba.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-03-08-09-48-38.bpo-33026.QZA3Ba.rst
@@ -1,0 +1,1 @@
+Fixed jumping out of "with" block by setting f_lineno.

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -320,6 +320,13 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno)
             PyObject *v = (*--f->f_stacktop);
             Py_DECREF(v);
         }
+        if (b->b_type == SETUP_FINALLY &&
+            code[b->b_handler] == WITH_CLEANUP_START)
+        {
+            /* Pop the exit function. */
+            PyObject *v = (*--f->f_stacktop);
+            Py_DECREF(v);
+        }
     }
 
     /* Finally set the new f_lineno and f_lasti and return OK. */


### PR DESCRIPTION
(cherry picked from commit 26c9f565d016db21257a60d29ab2c99383dd5ac7)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>


<!-- issue-number: bpo-33026 -->
https://bugs.python.org/issue33026
<!-- /issue-number -->
