### PR TITLE
bpo-33034: Added explicit exception message when cast fails

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -936,6 +936,16 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(p2.scheme, 'tel')
         self.assertEqual(p2.path, '+31641044153')
 
+    def test_issue33034(self):
+        # Test case to asset a valid port as an integer
+        p1 = urllib.parse.urlparse('https://www.python.org:80')
+        self.assertEqual(p1.port, 80)
+
+        # Test case to assert ValueError when a string is parsed as a port
+        p2 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
+        with self.assertRaises(ValueError):
+            p2.port
+
     def test_telurl_params(self):
         p1 = urllib.parse.urlparse('tel:123-4;phone-context=+1-650-516')
         self.assertEqual(p1.scheme, 'tel')

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -936,15 +936,14 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(p2.scheme, 'tel')
         self.assertEqual(p2.path, '+31641044153')
 
-    def test_issue33034(self):
-        # Test case to asset a valid port as an integer
-        p1 = urllib.parse.urlparse('https://www.python.org:80')
-        self.assertEqual(p1.port, 80)
-
-        # Test case to assert ValueError when a string is parsed as a port
-        p2 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
-        with self.assertRaises(ValueError):
-            p2.port
+    def test_port_casting_failure_message(self):
+        # Assert ValueError when int(string) is parsed as a port value
+        # Asset that the error message is Port could not be cast to integer value
+        p1 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
+        with self.assertRaises(ValueError) as valueError:
+            p1.port
+        self.assertEqual(str(valueError.exception), 
+            'Port could not be cast to integer value')
 
     def test_telurl_params(self):
         p1 = urllib.parse.urlparse('tel:123-4;phone-context=+1-650-516')

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -937,14 +937,20 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(p2.path, '+31641044153')
 
     def test_port_casting_failure_message(self):
-        # Assert ValueError when int(string) is parsed as a port value
-        # Asset that the error message is:
-        # port oracle could not be cast to integer value
+        # Assert ValueError when int(string/object) for port is set and used.
+        # Asset error message when port is used with urlparse:
+        # Port could not be cast to integer value as 'valueError'
+        message = "Port could not be cast to integer value as 'oracle'"
         p1 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
-        with self.assertRaisesRegex(ValueError, "Port could not be " \
-                                                "cast to integer value " \
-                                                "as: 'oracle'"):
+        with self.assertRaisesRegex(ValueError, message):
             p1.port
+
+        # Asset error message when port is used with urlsplit:
+        # Port could not be cast to integer value as 'valueError'
+        p2 = urllib.parse.urlsplit('http://Server=sde; Service=sde:oracle')
+        with self.assertRaisesRegex(ValueError, message):
+            p2.port
+
 
     def test_telurl_params(self):
         p1 = urllib.parse.urlparse('tel:123-4;phone-context=+1-650-516')

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -937,16 +937,11 @@ class UrlParseTestCase(unittest.TestCase):
         self.assertEqual(p2.path, '+31641044153')
 
     def test_port_casting_failure_message(self):
-        # Assert ValueError when int(string/object) for port is set and used.
-        # Asset error message when port is used with urlparse:
-        # Port could not be cast to integer value as 'valueError'
         message = "Port could not be cast to integer value as 'oracle'"
         p1 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
         with self.assertRaisesRegex(ValueError, message):
             p1.port
 
-        # Asset error message when port is used with urlsplit:
-        # Port could not be cast to integer value as 'valueError'
         p2 = urllib.parse.urlsplit('http://Server=sde; Service=sde:oracle')
         with self.assertRaisesRegex(ValueError, message):
             p2.port

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -940,9 +940,9 @@ class UrlParseTestCase(unittest.TestCase):
         # Assert ValueError when int(string) is parsed as a port value
         # Asset that the error message is port could not be cast to integer value
         p1 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
-        with self.assertRaises(ValueError) as valueError:
+        with self.assertRaises(ValueError) as cm:
             p1.port
-        self.assertEqual(str(valueError.exception), 'Port could not be cast to integer value')
+        self.assertEqual(str(cm.exception), 'Port could not be cast to integer value')
 
     def test_telurl_params(self):
         p1 = urllib.parse.urlparse('tel:123-4;phone-context=+1-650-516')

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -941,8 +941,8 @@ class UrlParseTestCase(unittest.TestCase):
         # Asset that the error message is:
         # port oracle could not be cast to integer value
         p1 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
-        with self.assertRaisesRegex(ValueError, 
-                                    "Port oracle could not be cast to integer value"):
+        with self.assertRaisesRegex(ValueError, "Port oracle could not be " \
+                                                "cast to integer value"):
             p1.port
 
     def test_telurl_params(self):

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -942,8 +942,7 @@ class UrlParseTestCase(unittest.TestCase):
         p1 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
         with self.assertRaises(ValueError) as valueError:
             p1.port
-        self.assertEqual(str(valueError.exception), 
-                        'Port could not be cast to integer value')
+        self.assertEqual(str(valueError.exception), 'Port could not be cast to integer value')
 
     def test_telurl_params(self):
         p1 = urllib.parse.urlparse('tel:123-4;phone-context=+1-650-516')

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -946,7 +946,6 @@ class UrlParseTestCase(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, message):
             p2.port
 
-
     def test_telurl_params(self):
         p1 = urllib.parse.urlparse('tel:123-4;phone-context=+1-650-516')
         self.assertEqual(p1.scheme, 'tel')

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -938,7 +938,7 @@ class UrlParseTestCase(unittest.TestCase):
 
     def test_port_casting_failure_message(self):
         # Assert ValueError when int(string) is parsed as a port value
-        # Asset that the error message is Port could not be cast to integer value
+        # Asset that the error message is port could not be cast to integer value
         p1 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
         with self.assertRaises(ValueError) as valueError:
             p1.port

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -943,7 +943,7 @@ class UrlParseTestCase(unittest.TestCase):
         with self.assertRaises(ValueError) as valueError:
             p1.port
         self.assertEqual(str(valueError.exception), 
-            'Port could not be cast to integer value')
+                        'Port could not be cast to integer value')
 
     def test_telurl_params(self):
         p1 = urllib.parse.urlparse('tel:123-4;phone-context=+1-650-516')

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -941,8 +941,9 @@ class UrlParseTestCase(unittest.TestCase):
         # Asset that the error message is:
         # port oracle could not be cast to integer value
         p1 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
-        with self.assertRaisesRegex(ValueError, "Port oracle could not be " \
-                                                "cast to integer value"):
+        with self.assertRaisesRegex(ValueError, "Port could not be " \
+                                                "cast to integer value " \
+                                                "as: 'oracle'"):
             p1.port
 
     def test_telurl_params(self):

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -938,11 +938,12 @@ class UrlParseTestCase(unittest.TestCase):
 
     def test_port_casting_failure_message(self):
         # Assert ValueError when int(string) is parsed as a port value
-        # Asset that the error message is port could not be cast to integer value
+        # Asset that the error message is:
+        # port oracle could not be cast to integer value
         p1 = urllib.parse.urlparse('http://Server=sde; Service=sde:oracle')
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaisesRegex(ValueError, 
+                                    "Port oracle could not be cast to integer value"):
             p1.port
-        self.assertEqual(str(cm.exception), 'Port could not be cast to integer value')
 
     def test_telurl_params(self):
         p1 = urllib.parse.urlparse('tel:123-4;phone-context=+1-650-516')

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -169,7 +169,8 @@ class _NetlocResultMixinBase(object):
             try:
                 port = int(port, 10)
             except ValueError:
-                raise ValueError("Port could not be cast to integer value") from None
+                raise ValueError("Port %s could not be cast to integer value" % 
+                                (port)) from None
             if not ( 0 <= port <= 65535):
                 raise ValueError("Port out of range 0-65535")
         return port

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -169,8 +169,8 @@ class _NetlocResultMixinBase(object):
             try:
                 port = int(port, 10)
             except ValueError:
-                raise ValueError("Port %s could not be cast " \
-                                 "to integer value" % (port)) from None
+                raise ValueError("Port could not be cast " \
+                                 "to integer value as: %r" % (port)) from None
             if not ( 0 <= port <= 65535):
                 raise ValueError("Port out of range 0-65535")
         return port

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -168,10 +168,10 @@ class _NetlocResultMixinBase(object):
         if port is not None:
             try:
                 port = int(port, 10)
-                if not ( 0 <= port <= 65535):
-                    raise ValueError("Port out of range 0-65535")
             except ValueError:
-                print("Port could not be cast to integer value")
+                raise ValueError("Port could not be cast to integer value") from None
+            if not ( 0 <= port <= 65535):
+                raise ValueError("Port out of range 0-65535")
         return port
 
 

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -166,9 +166,12 @@ class _NetlocResultMixinBase(object):
     def port(self):
         port = self._hostinfo[1]
         if port is not None:
-            port = int(port, 10)
-            if not ( 0 <= port <= 65535):
-                raise ValueError("Port out of range 0-65535")
+            try:
+                port = int(port, 10)
+                if not ( 0 <= port <= 65535):
+                    raise ValueError("Port out of range 0-65535")
+            except ValueError:
+                print("Port could not be cast to integer value")
         return port
 
 

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -169,8 +169,8 @@ class _NetlocResultMixinBase(object):
             try:
                 port = int(port, 10)
             except ValueError:
-                raise ValueError("Port could not be cast " \
-                                 "to integer value as: %r" % (port)) from None
+                message = f'Port could not be cast to integer value as {port!r}'
+                raise ValueError(message) from None
             if not ( 0 <= port <= 65535):
                 raise ValueError("Port out of range 0-65535")
         return port

--- a/Lib/urllib/parse.py
+++ b/Lib/urllib/parse.py
@@ -169,8 +169,8 @@ class _NetlocResultMixinBase(object):
             try:
                 port = int(port, 10)
             except ValueError:
-                raise ValueError("Port %s could not be cast to integer value" % 
-                                (port)) from None
+                raise ValueError("Port %s could not be cast " \
+                                 "to integer value" % (port)) from None
             if not ( 0 <= port <= 65535):
                 raise ValueError("Port out of range 0-65535")
         return port

--- a/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
@@ -1,3 +1,3 @@
 Providing an explicit error message when casting the port property to anything 
-that is not and integer value using ``urlparse()`` and ``urlsplit()``.  Port 
+that is not an integer value using ``urlparse()`` and ``urlsplit()``.  Port 
 could not be cast to integer value as 'valueError'. Patch by Matt Eaton.

--- a/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
@@ -1,3 +1,3 @@
 Providing an explicit error message when casting the port property to anything 
-that is not an integer value using ``urlparse()`` and ``urlsplit()``.  Port 
-could not be cast to integer value as 'valueError'. Patch by Matt Eaton.
+that is not an integer value using ``urlparse()`` and ``urlsplit()``.
+Patch by Matt Eaton.

--- a/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
@@ -1,0 +1,1 @@
+Providing an explicit message when casting a port that is a string instead of an integer.  Port could not be cast to integer value.

--- a/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
@@ -1,3 +1,3 @@
-Providing an explicit message when casting a port that is a string instead of 
-an integer using ``urlparse()``.  Port could not be cast to integer value. 
-Patch by Matt Eaton.
+Providing an explicit error message when casting the port property to anything 
+that is not and integer value using ``urlparse()`` and ``urlsplit()``.  Port 
+could not be cast to integer value as 'valueError'. Patch by Matt Eaton.

--- a/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-11-08-44-12.bpo-33034.bpb23d.rst
@@ -1,1 +1,3 @@
-Providing an explicit message when casting a port that is a string instead of an integer.  Port could not be cast to integer value.
+Providing an explicit message when casting a port that is a string instead of 
+an integer using ``urlparse()``.  Port could not be cast to integer value. 
+Patch by Matt Eaton.


### PR DESCRIPTION
bpo-33034: Added explicit exception message when cast fails to parse.py.

BPO Issue: https://bugs.python.org/issue33034


<!-- issue-number: bpo-33034 -->
https://bugs.python.org/issue33034
<!-- /issue-number -->
