### PR TITLE
bpo-31804: Fix multiprocessing.Process with broken standard streams

### DIFF
--- a/Lib/multiprocessing/popen_fork.py
+++ b/Lib/multiprocessing/popen_fork.py
@@ -14,14 +14,7 @@ class Popen(object):
     method = 'fork'
 
     def __init__(self, process_obj):
-        try:
-            sys.stdout.flush()
-        except (AttributeError, ValueError):
-            pass
-        try:
-            sys.stderr.flush()
-        except (AttributeError, ValueError):
-            pass
+        util._flush_std_streams()
         self.returncode = None
         self.finalizer = None
         self._launch(process_obj)

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -314,8 +314,7 @@ class BaseProcess(object):
         finally:
             threading._shutdown()
             util.info('process exiting with exitcode %d' % exitcode)
-            sys.stdout.flush()
-            sys.stderr.flush()
+            util._flush_std_streams()
 
         return exitcode
 

--- a/Lib/multiprocessing/util.py
+++ b/Lib/multiprocessing/util.py
@@ -392,6 +392,20 @@ def _close_stdin():
         pass
 
 #
+# Flush standard streams, if any
+#
+
+def _flush_std_streams():
+    try:
+        sys.stdout.flush()
+    except (AttributeError, ValueError):
+        pass
+    try:
+        sys.stderr.flush()
+    except (AttributeError, ValueError):
+        pass
+
+#
 # Start a program with only specified fds kept open
 #
 

--- a/Misc/NEWS.d/next/Library/2018-03-11-19-03-52.bpo-31804.i8KUMp.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-11-19-03-52.bpo-31804.i8KUMp.rst
@@ -1,0 +1,2 @@
+Avoid failing in multiprocessing.Process if the standard streams are closed
+or None at exit.


### PR DESCRIPTION
In some conditions the standard streams will be None or closed in the child process (for example if using "pythonw" instead of "python" on Windows).  Avoid failing with a non-0 exit code in those conditions.

Report and initial patch by @poxthegreat.

<!-- issue-number: bpo-31804 -->
https://bugs.python.org/issue31804
<!-- /issue-number -->
