### PR TITLE
[3.6] bpo-31804: Fix multiprocessing.Process with broken standard streams (GH-6079)

### DIFF
--- a/Lib/multiprocessing/popen_fork.py
+++ b/Lib/multiprocessing/popen_fork.py
@@ -14,14 +14,7 @@ class Popen(object):
     method = 'fork'
 
     def __init__(self, process_obj):
-        try:
-            sys.stdout.flush()
-        except (AttributeError, ValueError):
-            pass
-        try:
-            sys.stderr.flush()
-        except (AttributeError, ValueError):
-            pass
+        util._flush_std_streams()
         self.returncode = None
         self._launch(process_obj)
 

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -274,8 +274,7 @@ class BaseProcess(object):
             traceback.print_exc()
         finally:
             util.info('process exiting with exitcode %d' % exitcode)
-            sys.stdout.flush()
-            sys.stderr.flush()
+            util._flush_std_streams()
 
         return exitcode
 

--- a/Lib/multiprocessing/util.py
+++ b/Lib/multiprocessing/util.py
@@ -389,6 +389,20 @@ def _close_stdin():
         pass
 
 #
+# Flush standard streams, if any
+#
+
+def _flush_std_streams():
+    try:
+        sys.stdout.flush()
+    except (AttributeError, ValueError):
+        pass
+    try:
+        sys.stderr.flush()
+    except (AttributeError, ValueError):
+        pass
+
+#
 # Start a program with only specified fds kept open
 #
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -427,10 +427,19 @@ class _TestProcess(BaseTestCase):
         close_queue(q)
 
     @classmethod
-    def _test_error_on_stdio_flush(self, evt):
+    def _test_error_on_stdio_flush(self, evt, break_std_streams={}):
+        for stream_name, action in break_std_streams.items():
+            if action == 'close':
+                stream = io.StringIO()
+                stream.close()
+            else:
+                assert action == 'remove'
+                stream = None
+            setattr(sys, stream_name, None)
         evt.set()
 
-    def test_error_on_stdio_flush(self):
+    def test_error_on_stdio_flush_1(self):
+        # Check that Process works with broken standard streams
         streams = [io.StringIO(), None]
         streams[0].close()
         for stream_name in ('stdout', 'stderr'):
@@ -444,6 +453,24 @@ class _TestProcess(BaseTestCase):
                     proc.start()
                     proc.join()
                     self.assertTrue(evt.is_set())
+                    self.assertEqual(proc.exitcode, 0)
+                finally:
+                    setattr(sys, stream_name, old_stream)
+
+    def test_error_on_stdio_flush_2(self):
+        # Same as test_error_on_stdio_flush_1(), but standard streams are
+        # broken by the child process
+        for stream_name in ('stdout', 'stderr'):
+            for action in ('close', 'remove'):
+                old_stream = getattr(sys, stream_name)
+                try:
+                    evt = self.Event()
+                    proc = self.Process(target=self._test_error_on_stdio_flush,
+                                        args=(evt, {stream_name: action}))
+                    proc.start()
+                    proc.join()
+                    self.assertTrue(evt.is_set())
+                    self.assertEqual(proc.exitcode, 0)
                 finally:
                     setattr(sys, stream_name, old_stream)
 

--- a/Misc/NEWS.d/next/Library/2018-03-11-19-03-52.bpo-31804.i8KUMp.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-11-19-03-52.bpo-31804.i8KUMp.rst
@@ -1,0 +1,2 @@
+Avoid failing in multiprocessing.Process if the standard streams are closed
+or None at exit.


### PR DESCRIPTION
In some conditions the standard streams will be None or closed in the child process (for example if using "pythonw" instead of "python" on Windows).  Avoid failing with a non-0 exit code in those conditions.

Report and initial patch by poxthegreat..
(cherry picked from commit e756f66c83786ee82f5f7d45931ae50a6931dd7f)


<!-- issue-number: bpo-31804 -->
https://bugs.python.org/issue31804
<!-- /issue-number -->
