### PR TITLE
bpo-33051: IDLE: Separate editor options from the general tab in config

### DIFF
--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -41,6 +41,14 @@ reloadables = (AutoComplete, CodeContext, ParenMatch, FormatParagraph,
                Squeezer)
 
 
+def init_validators(page):
+    digits_or_empty_re = re.compile(r'[0-9]*')
+    def is_digits_or_empty(s):
+        "Return 's is blank or contains only digits'"
+        return digits_or_empty_re.fullmatch(s) is not None
+    return (page.register(is_digits_or_empty), '%P',)
+
+
 class ConfigDialog(Toplevel):
     """Config dialog for IDLE.
     """
@@ -120,7 +128,7 @@ class ConfigDialog(Toplevel):
         note.add(self.fontpage, text='Fonts/Tabs')
         note.add(self.highpage, text='Highlights')
         note.add(self.keyspage, text=' Keys ')
-        note.add(self.editpage, text=' Editor ')
+        note.add(self.editpage, text=' Editor/Shell ')
         note.add(self.genpage, text=' General ')
         note.add(self.extpage, text='Extensions')
         note.enable_traversal()
@@ -1781,6 +1789,7 @@ class EditPage(Frame):
 
     def __init__(self, master):
         super().__init__(master)
+        self.digits_only = init_validators(self)
         self.create_page_editor()
         self.load_editor_cfg()
 
@@ -1926,17 +1935,9 @@ class GenPage(Frame):
 
     def __init__(self, master):
         super().__init__(master)
-
-        self.init_validators()
+        self.digits_only = init_validators(self)
         self.create_page_general()
         self.load_general_cfg()
-
-    def init_validators(self):
-        digits_or_empty_re = re.compile(r'[0-9]*')
-        def is_digits_or_empty(s):
-            "Return 's is blank or contains only digits'"
-            return digits_or_empty_re.fullmatch(s) is not None
-        self.digits_only = (self.register(is_digits_or_empty), '%P',)
 
     def create_page_general(self):
         """Return frame of widgets for General tab.

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -1203,6 +1203,54 @@ class KeysPageTest(unittest.TestCase):
         del d.askyesno
 
 
+class EditPageTest(unittest.TestCase):
+    """Test that edtior tab widgets enable users to make changes.
+
+    Test that widget actions set vars, that var changes add
+    options to changes and that helplist works correctly.
+    """
+    @classmethod
+    def setUpClass(cls):
+        page = cls.page = dialog.editpage
+        dialog.note.select(page)
+
+    @classmethod
+    def tearDownClass(cls):
+        page = cls.page
+
+    def setUp(self):
+        changes.clear()
+
+    def test_load_editor_cfg(self):
+        # Set to wrong values, load, check right values.
+        eq = self.assertEqual
+        d = self.page
+        d.autosave.set(1)
+        d.format_width.set(1)
+        d.context_lines.set(1)
+        d.load_editor_cfg()
+        eq(d.autosave.get(), 0)
+        eq(d.format_width.get(), '72')
+        eq(d.context_lines.get(), '15')
+
+    def test_autosave(self):
+        d = self.page
+        d.save_auto_on.invoke()
+        self.assertEqual(mainpage, {'General': {'autosave': '1'}})
+        d.save_ask_on.invoke()
+        self.assertEqual(mainpage, {'General': {'autosave': '0'}})
+
+    def test_paragraph(self):
+        self.page.format_width_int.delete(0, 'end')
+        self.page.format_width_int.insert(0, '11')
+        self.assertEqual(extpage, {'FormatParagraph': {'max-width': '11'}})
+
+    def test_context(self):
+        self.page.context_int.delete(0, 'end')
+        self.page.context_int.insert(0, '1')
+        self.assertEqual(extpage, {'CodeContext': {'maxlines': '1'}})
+
+
 class GenPageTest(unittest.TestCase):
     """Test that general tab widgets enable users to make changes.
 
@@ -1233,7 +1281,6 @@ class GenPageTest(unittest.TestCase):
         eq = self.assertEqual
         d = self.page
         d.startup_edit.set(1)
-        d.autosave.set(1)
         d.win_width.set(1)
         d.win_height.set(1)
         d.helplist.insert('end', 'bad')
@@ -1241,7 +1288,6 @@ class GenPageTest(unittest.TestCase):
         idleConf.SetOption('main', 'HelpFiles', '1', 'name;file')
         d.load_general_cfg()
         eq(d.startup_edit.get(), 0)
-        eq(d.autosave.get(), 0)
         eq(d.win_width.get(), '80')
         eq(d.win_height.get(), '40')
         eq(d.helplist.get(0, 'end'), ('name',))
@@ -1288,23 +1334,6 @@ class GenPageTest(unittest.TestCase):
         changes.clear()
         d.bell_on.invoke()
         eq(extpage, {'ParenMatch': {'bell': 'False'}})
-
-    def test_autosave(self):
-        d = self.page
-        d.save_auto_on.invoke()
-        self.assertEqual(mainpage, {'General': {'autosave': '1'}})
-        d.save_ask_on.invoke()
-        self.assertEqual(mainpage, {'General': {'autosave': '0'}})
-
-    def test_paragraph(self):
-        self.page.format_width_int.delete(0, 'end')
-        self.page.format_width_int.insert(0, '11')
-        self.assertEqual(extpage, {'FormatParagraph': {'max-width': '11'}})
-
-    def test_context(self):
-        self.page.context_int.delete(0, 'end')
-        self.page.context_int.insert(0, '1')
-        self.assertEqual(extpage, {'CodeContext': {'maxlines': '1'}})
 
     def test_source_selected(self):
         d = self.page

--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -1228,10 +1228,14 @@ class EditPageTest(unittest.TestCase):
         d.autosave.set(1)
         d.format_width.set(1)
         d.context_lines.set(1)
+        d.line_numbers_default.set(True)
+        d.auto_squeeze_min_lines.set(1)
         d.load_editor_cfg()
         eq(d.autosave.get(), 0)
         eq(d.format_width.get(), '72')
         eq(d.context_lines.get(), '15')
+        eq(d.line_numbers_default.get(), False)
+        eq(d.auto_squeeze_min_lines.get(), '50')
 
     def test_autosave(self):
         d = self.page
@@ -1249,6 +1253,19 @@ class EditPageTest(unittest.TestCase):
         self.page.context_int.delete(0, 'end')
         self.page.context_int.insert(0, '1')
         self.assertEqual(extpage, {'CodeContext': {'maxlines': '1'}})
+
+    def test_line_numbers(self):
+        d = self.page
+        d.line_numbers_default.set(True)
+        d.line_numbers_default_bool.invoke()
+        self.assertEqual(mainpage, {'EditorWindow': {'line-numbers-default': 'False'}})
+        d.line_numbers_default_bool.invoke()
+        self.assertEqual(mainpage, {'EditorWindow': {'line-numbers-default': 'True'}})
+
+    def test_auto_squeeze(self):
+        self.page.auto_squeeze_min_lines_int.delete(0, 'end')
+        self.page.auto_squeeze_min_lines_int.insert(0, '99')
+        self.assertEqual(mainpage, {'PyShell': {'auto-squeeze-min-lines': '99'}})
 
 
 class GenPageTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/IDLE/2018-03-11-15-29-02.bpo-33051.4tKnde.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-03-11-15-29-02.bpo-33051.4tKnde.rst
@@ -1,0 +1,1 @@
+Separate editor options from the general tab in config dialog.


### PR DESCRIPTION
Split the 'Editor Preferences' section of the General tab in configdialog into its own tab.




<!-- issue-number: bpo-33051 -->
https://bugs.python.org/issue33051
<!-- /issue-number -->
