### PR TITLE
bpo-33056 FIX leaking fd in concurrent.futures.ProcessPoolExecutor

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -78,10 +78,12 @@ _global_shutdown = False
 
 
 class _ThreadWakeup:
-    __slot__ = ["_state"]
-
     def __init__(self):
         self._reader, self._writer = mp.Pipe(duplex=False)
+
+    def close(self):
+        self._writer.close()
+        self._reader.close()
 
     def wakeup(self):
         self._writer.send_bytes(b"")
@@ -654,6 +656,11 @@ class ProcessPoolExecutor(_base.Executor):
             self._call_queue = None
         self._result_queue = None
         self._processes = None
+
+        if self._queue_management_thread_wakeup:
+            self._queue_management_thread_wakeup.close()
+            self._queue_management_thread_wakeup = None
+
     shutdown.__doc__ = _base.Executor.shutdown.__doc__
 
 atexit.register(_python_exit)

--- a/Misc/NEWS.d/next/Library/2018-03-12-16-40-00.bpo-33056.lNN9Eh.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-12-16-40-00.bpo-33056.lNN9Eh.rst
@@ -1,0 +1,1 @@
+FIX properly close leaking fds in concurrent.futures.ProcessPoolExecutor.


### PR DESCRIPTION
The recent changes introduced by #3895 leaks some file descriptors (the Pipe open in _ThreadWakeup, see [here](https://github.com/python/cpython/blob/master/Lib/concurrent/futures/process.py#L84)).
They should be properly closed at shutdown.

<!-- issue-number: bpo-33056 -->
https://bugs.python.org/issue33056
<!-- /issue-number -->
