### PR TITLE
bpo-22674: fix test_strsignal on OSX

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -58,8 +58,8 @@ class PosixTests(unittest.TestCase):
         self.assertEqual(signal.getsignal(signal.SIGHUP), hup)
 
     def test_strsignal(self):
-        self.assertEqual(signal.strsignal(signal.SIGINT), "Interrupt")
-        self.assertEqual(signal.strsignal(signal.SIGTERM), "Terminated")
+        self.assertIn("Interrupt", signal.strsignal(signal.SIGINT))
+        self.assertIn("Terminated", signal.strsignal(signal.SIGTERM))
 
     # Issue 3864, unknown if this affects earlier versions of freebsd also
     def test_interprocess_signal(self):


### PR DESCRIPTION
We changed the behavior to remove OSX specific handling and forgot to update the tests. This *should* fix it, but I don't have an OSX machine so I can't test it myself... If the CI is still down for OSX, I'll need someone else to test it first :/

<!-- issue-number: bpo-22674 -->
https://bugs.python.org/issue22674
<!-- /issue-number -->
