### PR TITLE
bpo-33057: Fix call to logRecordFactory in managed loggers

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1432,8 +1432,13 @@ class Logger(Filterer):
         A factory method which can be overridden in subclasses to create
         specialized LogRecords.
         """
-        rv = _logRecordFactory(name, level, fn, lno, msg, args, exc_info, func,
-                             sinfo)
+        try:  # See issue #33057.
+            logRecordFactory = self.manager.logRecordFactory or _logRecordFactory
+        except AttributeError:
+            logRecordFactory = _logRecordFactory
+
+        rv = logRecordFactory(name, level, fn, lno, msg, args, exc_info, func,
+                              sinfo)
         if extra is not None:
             for key in extra:
                 if (key in ["message", "asctime"]) or (key in rv.__dict__):

--- a/Misc/NEWS.d/next/Library/2018-03-12-21-26-08.bpo-33057.KE3kmO.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-12-21-26-08.bpo-33057.KE3kmO.rst
@@ -1,0 +1,3 @@
+Fix `Logger.makeRecord()` when a manager is assigned to the logger. It will
+use the manager's `logRecordFactory` when exist, instead of the global
+`_logRecordFactory`.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

If a logger has a manager (`self.manager` exists), try to use its `logRecordFactory` before falling-back to the global `_logRecordFactory`.

<!-- issue-number: bpo-33057 -->
https://bugs.python.org/issue33057
<!-- /issue-number -->
