### PR TITLE
bpo-33058: Enhanced COUNT_ALLOCS to be ABI Compatible

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -423,16 +423,16 @@ typedef struct _typeobject {
     unsigned int tp_version_tag;
 
     destructor tp_finalize;
-
+} PyTypeObject;
 #ifdef COUNT_ALLOCS
-    /* these must be last and never explicitly initialized */
+typedef struct _typeobject_ext {
+    const char *tp_name; /* To match with PyTypeObject */
     Py_ssize_t tp_allocs;
     Py_ssize_t tp_frees;
     Py_ssize_t tp_maxalloc;
-    struct _typeobject *tp_prev;
-    struct _typeobject *tp_next;
+    struct _typeobject_ext *tp_next;
+} PyTypeObjectExt;
 #endif
-} PyTypeObject;
 #endif
 
 typedef struct{
@@ -752,12 +752,10 @@ PyAPI_FUNC(void) inc_count(PyTypeObject *);
 PyAPI_FUNC(void) dec_count(PyTypeObject *);
 #define _Py_INC_TPALLOCS(OP)    inc_count(Py_TYPE(OP))
 #define _Py_INC_TPFREES(OP)     dec_count(Py_TYPE(OP))
-#define _Py_DEC_TPFREES(OP)     Py_TYPE(OP)->tp_frees--
 #define _Py_COUNT_ALLOCS_COMMA  ,
 #else
 #define _Py_INC_TPALLOCS(OP)
 #define _Py_INC_TPFREES(OP)
-#define _Py_DEC_TPFREES(OP)
 #define _Py_COUNT_ALLOCS_COMMA
 #endif /* COUNT_ALLOCS */
 

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -3222,14 +3222,7 @@ slot_tp_del(PyObject *self)
     _Py_DEC_REFTOTAL;
     /* If Py_TRACE_REFS, _Py_NewReference re-added self to the object
      * chain, so no more to do there.
-     * If COUNT_ALLOCS, the original decref bumped tp_frees, and
-     * _Py_NewReference bumped tp_allocs:  both of those need to be
-     * undone.
      */
-#ifdef COUNT_ALLOCS
-    --Py_TYPE(self)->tp_frees;
-    --Py_TYPE(self)->tp_allocs;
-#endif
 }
 
 static PyObject *
@@ -4563,7 +4556,6 @@ static PyMethodDef TestMethods[] = {
     {"datetime_check_delta",     datetime_check_delta,           METH_VARARGS},
     {"datetime_check_tzinfo",     datetime_check_tzinfo,         METH_VARARGS},
     {"make_timezones_capi",     make_timezones_capi,             METH_NOARGS},
-    {"get_timezones_offset_zero",   get_timezones_offset_zero,   METH_NOARGS},
     {"get_timezone_utc_capi",    get_timezone_utc_capi,            METH_VARARGS},
     {"test_list_api",           (PyCFunction)test_list_api,      METH_NOARGS},
     {"test_dict_iteration",     (PyCFunction)test_dict_iteration,METH_NOARGS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4556,6 +4556,7 @@ static PyMethodDef TestMethods[] = {
     {"datetime_check_delta",     datetime_check_delta,           METH_VARARGS},
     {"datetime_check_tzinfo",     datetime_check_tzinfo,         METH_VARARGS},
     {"make_timezones_capi",     make_timezones_capi,             METH_NOARGS},
+    {"get_timezones_offset_zero",   get_timezones_offset_zero,   METH_NOARGS},
     {"get_timezone_utc_capi",    get_timezone_utc_capi,            METH_VARARGS},
     {"test_list_api",           (PyCFunction)test_list_api,      METH_NOARGS},
     {"test_dict_iteration",     (PyCFunction)test_dict_iteration,METH_NOARGS},

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -92,34 +92,34 @@ extern Py_ssize_t null_strings, one_strings;
 
 PyTypeObjectExt *
 PyTypeObjectExt_New(PyTypeObject* tp_orig) {
-  PyTypeObjectExt *tp;
-  tp = PyMem_MALLOC(sizeof(*tp));
-  tp->tp_name = strdup(tp_orig->tp_name);
-  tp->tp_allocs = 0;
-  tp->tp_frees = 0;
-  tp->tp_maxalloc = 0;
-  tp->tp_next = NULL;
-  return tp;
+    PyTypeObjectExt *tp;
+    tp = PyMem_MALLOC(sizeof(*tp));
+    tp->tp_name = strdup(tp_orig->tp_name);
+    tp->tp_allocs = 0;
+    tp->tp_frees = 0;
+    tp->tp_maxalloc = 0;
+    tp->tp_next = NULL;
+    return tp;
 }
 
 PyTypeObjectExt *
 find_ext(PyTypeObject *tp_orig) {
-  // Base case
-  if (type_list == NULL) {
-    type_list = PyTypeObjectExt_New(tp_orig);
-  }
+    // Base case
+    if (type_list == NULL) {
+        type_list = PyTypeObjectExt_New(tp_orig);
+    }
 
-  PyTypeObjectExt *tp = type_list;
-  while (strcmp(tp->tp_name, tp_orig->tp_name) != 0 && tp->tp_next) {
-    tp = tp->tp_next;
-  }
+    PyTypeObjectExt *tp = type_list;
+    while (strcmp(tp->tp_name, tp_orig->tp_name) != 0 && tp->tp_next) {
+        tp = tp->tp_next;
+    }
 
-  if (strcmp(tp->tp_name, tp_orig->tp_name) == 0) {
-    return tp; // Type Found
-  }
-  tp->tp_next = PyTypeObjectExt_New(tp_orig);
-
-  return tp->tp_next;
+    // Type not found
+    if (strcmp(tp->tp_name, tp_orig->tp_name) != 0) {
+        tp->tp_next = PyTypeObjectExt_New(tp_orig);
+        tp = tp->tp_next;
+    }
+    return tp;
 }
 
 void


### PR DESCRIPTION
This modifies the COUNT_ALLOCS build to be ABI Compatible. This means that there's no need to rebuild all extensions to be able to use this feature.

To make this ABI Compatible, I had to pull out the extra members from PyTypeObject and create another object - called "PyTypeObjectExt". Now, on every alloc/free, given a PyTypeObject we find/create the correct PyTypeObejctExt.

The only drawback is that on every alloc/free increase, this will now do an O(n) linked list traversal where n is the total number of different types seen so far. However, COUNT_ALLOCS is not meant to be a production build, thus the runtime perf hit won't matter as much - granted that this will allow us to gather object allocation data.

Furthermore, we don't expect the memory footprint to be that big as well, as this only allocates an object in memory once per every type.

Note: This also gets rid of a couple of places with extra bookkeeping as this doesn't modify the ref counts of the object themselves.

To test:
test.py:
```
import sys
import pprint
pprint.pprint(counts)
```
// On a vanilla cpython:
> make EXTRA_CFLAGS=-DCOUNT_ALLOCS
> ./python test.py > a.diff
> git patch change.diff
> make EXTRA_CFLAGS=-DCOUNT_ALLOCS
> ./python test.py > b.diff
> diff a.diff b.diff

<!-- issue-number: bpo-33058 -->
https://bugs.python.org/issue33058
<!-- /issue-number -->
