### PR TITLE
bpo-33023: SSL pickle error message

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -388,6 +388,10 @@ class SSLContext(_SSLContext):
         self = _SSLContext.__new__(cls, protocol)
         return self
 
+    def __getstate__(self):
+        raise TypeError("cannot serialize {} object".format(
+            self.__class__.__name__))
+
     def _encode_hostname(self, hostname):
         if hostname is None:
             return None
@@ -695,6 +699,10 @@ class SSLObject:
         server hostame is set."""
         return self._sslobj.server_hostname
 
+    def __getstate__(self):
+        raise TypeError("cannot serialize {} object".format(
+            self.__class__.__name__))
+
     def read(self, len=1024, buffer=None):
         """Read up to 'len' bytes from the SSL object and return them.
 
@@ -880,9 +888,13 @@ class SSLSocket(socket):
         if self._sslobj is not None:
             return self._sslobj.session_reused
 
+    def __getstate__(self):
+        raise TypeError("cannot serialize {} object".format(
+            self.__class__.__name__))
+
     def dup(self):
-        raise NotImplemented("Can't dup() %s instances" %
-                             self.__class__.__name__)
+        raise NotImplementedError("Can't dup() {} instances".format(
+            self.__class__.__name__))
 
     def _checkClosed(self, msg=None):
         # raise an exception here if you wish to check for spurious closes

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -19,6 +19,8 @@ import weakref
 import platform
 import functools
 import sysconfig
+import copy
+import pickle
 try:
     import ctypes
 except ImportError:
@@ -972,6 +974,17 @@ class BasicSocketTests(unittest.TestCase):
         )
         self.assertIn(rc, errors)
 
+    def test_copy_pickle(self):
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        with ctx.wrap_socket(socket.socket(),
+                             server_hostname='localhost') as s:
+            with self.assertRaises(TypeError):
+                copy.copy(s)
+            with self.assertRaises(TypeError):
+                copy.deepcopy(s)
+            with self.assertRaises(TypeError):
+                pickle.dumps(s)
+
 
 class ContextTests(unittest.TestCase):
 
@@ -1607,6 +1620,15 @@ class ContextTests(unittest.TestCase):
             self.assertIsInstance(sock, MySSLSocket)
         obj = ctx.wrap_bio(ssl.MemoryBIO(), ssl.MemoryBIO())
         self.assertIsInstance(obj, MySSLObject)
+
+    def test_copy_pickle(self):
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        with self.assertRaises(TypeError):
+            copy.copy(ctx)
+        with self.assertRaises(TypeError):
+            copy.deepcopy(ctx)
+        with self.assertRaises(TypeError):
+            pickle.dumps(ctx)
 
 
 class SSLErrorTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-03-13-09-48-02.bpo-33023.Zlszr2.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-13-09-48-02.bpo-33023.Zlszr2.rst
@@ -1,0 +1,3 @@
+Improve error message when trying to serialize SSLContext, SSLObject, and
+SSLSocket objects. The classes can't be pickled or copied by the copy
+module.


### PR DESCRIPTION
Improve error message when trying to serialize SSLContext, SSLObject, and
SSLSocket objects. The classes can't be pickled or copied by the copy
module.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-33023 -->
https://bugs.python.org/issue33023
<!-- /issue-number -->
