### PR TITLE
bpo-30622: Fix backport of NPN fix

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2747,7 +2747,7 @@ _ssl__SSLContext_impl(PyTypeObject *type, int proto_version)
         return NULL;
     }
     self->ctx = ctx;
-#ifdef HAVE_NPN
+#if HAVE_NPN
     self->npn_protocols = NULL;
 #endif
 #if HAVE_ALPN


### PR DESCRIPTION
Fix backport a79591cf of bpo-30622 to 3.6 branch.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-30622 -->
https://bugs.python.org/issue30622
<!-- /issue-number -->
