### PR TITLE
bpo-33070: Add platform triplet for RISC-V

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-03-13-14-35-47.bpo-33070.33070.rst
+++ b/Misc/NEWS.d/next/Build/2018-03-13-14-35-47.bpo-33070.33070.rst
@@ -1,0 +1,1 @@
+Add platform triplet for RISC-V

--- a/configure.ac
+++ b/configure.ac
@@ -823,6 +823,12 @@ cat >> conftest.c <<EOF
         sparc64-linux-gnu
 # elif defined(__sparc__)
         sparc-linux-gnu
+# elif defined(__riscv)
+#  if __riscv_xlen == 64
+        riscv64-linux-gnu
+#  else
+        riscv32-linux-gnu
+#  endif
 # else
 #   error unknown platform triplet
 # endif


### PR DESCRIPTION


<!-- issue-number: bpo-33070 -->
https://bugs.python.org/issue33070
<!-- /issue-number -->
