### PR TITLE
bpo-32517: re-enable test_read_pty_output on macOS

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1475,7 +1475,6 @@ class EventLoopTestsMixin:
 
     @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
-    @unittest.skipIf(sys.platform == 'darwin', 'test hangs on MacOS')
     def test_read_pty_output(self):
         proto = MyReadPipeProto(loop=self.loop)
 


### PR DESCRIPTION


<!-- issue-number: bpo-32517 -->
https://bugs.python.org/issue32517
<!-- /issue-number -->
