### PR TITLE
bpo-32517: fix test_read_pty_output() hangs on macOS 10.13.2+ (GH-6037)

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1475,7 +1475,6 @@ class EventLoopTestsMixin:
 
     @unittest.skipUnless(sys.platform != 'win32',
                          "Don't support pipes for Windows")
-    @unittest.skipIf(sys.platform == 'darwin', 'test hangs on MacOS')
     def test_read_pty_output(self):
         proto = MyReadPipeProto(loop=self.loop)
 
@@ -1502,6 +1501,7 @@ class EventLoopTestsMixin:
         self.assertEqual(5, proto.nbytes)
 
         os.close(slave)
+        proto.transport.close()
         self.loop.run_until_complete(proto.done)
         self.assertEqual(
             ['INITIAL', 'CONNECTED', 'EOF', 'CLOSED'], proto.state)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -630,6 +630,7 @@ Thomas Heller
 Malte Helmert
 Lance Finn Helsten
 Jonathan Hendry
+Nathan Henrie
 Michael Henry
 James Henstridge
 Kasun Herath

--- a/Misc/NEWS.d/next/Tests/2018-03-09-07-05-12.bpo-32517.ugc1iW.rst
+++ b/Misc/NEWS.d/next/Tests/2018-03-09-07-05-12.bpo-32517.ugc1iW.rst
@@ -1,0 +1,2 @@
+Fix failing ``test_asyncio`` on macOS 10.12.2+ due to transport of
+``KqueueSelector`` loop was not being closed.


### PR DESCRIPTION
test_asyncio hangs indefinitely on macOS 10.13.2+ on `read_pty_output()`
using the KqueueSelector. Closing `proto.transport` (as is done in
`write_pty_output()`) seems to fix it.
(cherry picked from commit 12f74d8608c15cacd9d5786524e2be9ca36f007e)

Co-authored-by: Nathan Henrie <n8henrie@users.noreply.github.com>

Also, re-enable test_read_pty_output on macOS.


<!-- issue-number: bpo-32517 -->
https://bugs.python.org/issue32517
<!-- /issue-number -->
