### PR TITLE
[3.6] bpo-27984: Limit the cls argument of singledispatch.register and

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -769,6 +769,9 @@ def singledispatch(func):
 
         """
         nonlocal cache_token
+        if not isinstance(cls, type):
+            raise TypeError("dispatch() argument must be a type: {!r}"
+                            .format(cls))
         if cache_token is not None:
             current_token = get_cache_token()
             if cache_token != current_token:
@@ -791,6 +794,9 @@ def singledispatch(func):
 
         """
         nonlocal cache_token
+        if not isinstance(cls, type):
+            raise TypeError("register() argument must be a type: {!r}"
+                            .format(cls))
         if func is None:
             return lambda f: register(cls, f)
         registry[cls] = func

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2078,6 +2078,18 @@ class TestSingleDispatch(unittest.TestCase):
         self.assertEqual(len(td), 0)
         functools.WeakKeyDictionary = _orig_wkd
 
+    def test_invalid_arguments(self):
+        # issue27984
+        from enum import Enum
+        IS = Enum("IS", "a, b")
+        @functools.singledispatch
+        def g(obj):
+            return "base"
+        with self.assertRaisesRegex(TypeError, "argument must be a type"):
+            g.register(IS.a)
+        with self.assertRaisesRegex(TypeError, "argument must be a type"):
+            g.dispatch(IS.b)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-03-14-21-14-01.bpo-27984.9uyg-9.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-14-21-14-01.bpo-27984.9uyg-9.rst
@@ -1,0 +1,2 @@
+Non-type cls argument to singledispatch.register and singledispatch.dispatch
+will raise a TypeError.


### PR DESCRIPTION
singledispatch.dispatch to type only.



<!-- issue-number: bpo-27984 -->
https://bugs.python.org/issue27984
<!-- /issue-number -->
