### PR TITLE
bpo-33021: Fix GCC 7 warning (-Wmaybe-uninitialized) in mmapmodule.c

### DIFF
--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -1050,7 +1050,7 @@ static PyObject *
 new_mmap_object(PyTypeObject *type, PyObject *args, PyObject *kwdict)
 {
     struct _Py_stat_struct status;
-    int fstat_result;
+    int fstat_result = -1;
     mmap_object *m_obj;
     Py_ssize_t map_size;
     off_t offset = 0;


### PR DESCRIPTION
Introduced in 4484f9d:

cpython/Modules/mmapmodule.c: In function ‘new_mmap_object’:
cpython/Modules/mmapmodule.c:1126:18: warning: ‘fstat_result’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     if (fd != -1 && fstat_result == 0 && S_ISREG(status.st_mode)) {

<!-- issue-number: bpo-33021 -->
https://bugs.python.org/issue33021
<!-- /issue-number -->
