### PR TITLE
bpo-28055: fix unaligned accesses in siphash24()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-25-20-44-42.bpo-28055.f49kfC.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-25-20-44-42.bpo-28055.f49kfC.rst
@@ -1,0 +1,1 @@
+Fix unaligned accesses in siphash24(). Patch by Rolf Eike Beer.


### PR DESCRIPTION
The hash implementation casts the input pointer to uint64_t* and directly reads from this, which may cause unaligned accesses. Use memcpy() instead so this code will not crash with SIGBUS on sparc.

https://bugs.gentoo.org/show_bug.cgi?id=636400


<!-- issue-number: bpo-28055 -->
https://bugs.python.org/issue28055
<!-- /issue-number -->
