### PR TITLE
bpo-27645: Fix sqlite backup check if database in transaction to be up to 3.8.7 (inclusive)

### DIFF
--- a/Lib/sqlite3/test/backup.py
+++ b/Lib/sqlite3/test/backup.py
@@ -37,14 +37,12 @@ class BackupTests(unittest.TestCase):
             self.cx.backup(bck)
 
     def test_bad_target_in_transaction(self):
-        if sqlite.sqlite_version_info == (3, 8, 7, 1):
-            self.skipTest('skip until we debug https://bugs.python.org/issue27645#msg313562')
         bck = sqlite.connect(':memory:')
         bck.execute('CREATE TABLE bar (key INTEGER)')
         bck.executemany('INSERT INTO bar (key) VALUES (?)', [(3,), (4,)])
         with self.assertRaises(sqlite.OperationalError) as cm:
             self.cx.backup(bck)
-        if sqlite.sqlite_version_info < (3, 8, 7):
+        if sqlite.sqlite_version_info < (3, 8, 8):
             self.assertEqual(str(cm.exception), 'target is in transaction')
 
     def test_keyword_only_args(self):

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -1481,8 +1481,8 @@ pysqlite_connection_backup(pysqlite_Connection *self, PyObject *args, PyObject *
         return NULL;
     }
 
-#if SQLITE_VERSION_NUMBER < 3008007
-    /* Since 3.8.7 this is already done, per commit
+#if SQLITE_VERSION_NUMBER < 3008008
+    /* Since 3.8.8 this is already done, per commit
        https://www.sqlite.org/src/info/169b5505498c0a7e */
     if (!sqlite3_get_autocommit(((pysqlite_Connection *)target)->db)) {
         PyErr_SetString(pysqlite_OperationalError, "target is in transaction");


### PR DESCRIPTION
This PR come to fix the issue in https://bugs.python.org/issue27645#msg313562.


<!-- issue-number: bpo-27645 -->
https://bugs.python.org/issue27645
<!-- /issue-number -->
