### PR TITLE
bpo-33097: Fix submit accepting callable after executor shutdown by interpreter exit

### DIFF
--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -591,7 +591,7 @@ class ProcessPoolExecutor(_base.Executor):
         with self._shutdown_lock:
             if self._broken:
                 raise BrokenProcessPool(self._broken)
-            if self._shutdown_thread:
+            if _global_shutdown or self._shutdown_thread:
                 raise RuntimeError('cannot schedule new futures after shutdown')
 
             f = _base.Future()

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -421,6 +421,10 @@ def _queue_management_worker(executor_reference,
         #   - The executor that owns this worker has been shutdown.
         if shutting_down():
             try:
+                # Flag the executor as shutting down as early as possible if it
+                # is not gc-ed yet.
+                if executor is not None:
+                    executor._shutdown_thread = True
                 # Since no new work items can be added, it is safe to shutdown
                 # this thread if there are no pending work items.
                 if not pending_work_items:

--- a/Lib/concurrent/futures/process.py
+++ b/Lib/concurrent/futures/process.py
@@ -591,8 +591,11 @@ class ProcessPoolExecutor(_base.Executor):
         with self._shutdown_lock:
             if self._broken:
                 raise BrokenProcessPool(self._broken)
-            if _global_shutdown or self._shutdown_thread:
+            if self._shutdown_thread:
                 raise RuntimeError('cannot schedule new futures after shutdown')
+            if _global_shutdown:
+                raise RuntimeError('cannot schedule new futures after '
+                                   'interpreter shutdown')
 
             f = _base.Future()
             w = _WorkItem(f, fn, args, kwargs)

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -87,6 +87,10 @@ def _worker(executor_reference, work_queue, initializer, initargs):
             #   - The executor that owns the worker has been collected OR
             #   - The executor that owns the worker has been shutdown.
             if _shutdown or executor is None or executor._shutdown:
+                # Flag the executor as shutting down as early as possible if it
+                # is not gc-ed yet.
+                if executor is not None:
+                    executor._shutdown = True
                 # Notice other workers
                 work_queue.put(None)
                 return

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -143,7 +143,7 @@ class ThreadPoolExecutor(_base.Executor):
             if self._broken:
                 raise BrokenThreadPool(self._broken)
 
-            if self._shutdown:
+            if _shutdown or self._shutdown:
                 raise RuntimeError('cannot schedule new futures after shutdown')
 
             f = _base.Future()

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -143,8 +143,11 @@ class ThreadPoolExecutor(_base.Executor):
             if self._broken:
                 raise BrokenThreadPool(self._broken)
 
-            if _shutdown or self._shutdown:
+            if self._shutdown:
                 raise RuntimeError('cannot schedule new futures after shutdown')
+            if _shutdown:
+                raise RuntimeError('cannot schedule new futures after'
+                                   'interpreter shutdown')
 
             f = _base.Future()
             w = _WorkItem(f, fn, args, kwargs)

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -328,7 +328,7 @@ class ExecutorShutdownTest:
                        context=getattr(self, "ctx", "")))
         # Errors in atexit hooks don't change the process exit code, check
         # stderr manually.
-        self.assertTrue(err)
+        self.assertIn("RuntimeError: cannot schedule new futures", err.decode())
         self.assertEqual(out.strip(), b"runtime-error")
 
     def test_hang_issue12364(self):

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -317,7 +317,7 @@ class ExecutorShutdownTest:
             from concurrent.futures import {executor_type}
             if __name__ == "__main__":
                 context = '{context}'
-                if context == "":
+                if not context:
                     t = {executor_type}(5)
                 else:
                     from multiprocessing import get_context

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -323,6 +323,7 @@ class ExecutorShutdownTest:
                     from multiprocessing import get_context
                     context = get_context(context)
                     t = {executor_type}(5, mp_context=context)
+                    t.submit(id, 42).result()
             """.format(executor_type=self.executor_type.__name__,
                        context=getattr(self, "ctx", "")))
         # Errors in atexit hooks don't change the process exit code, check

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -303,6 +303,33 @@ class ExecutorShutdownTest:
         self.assertFalse(err)
         self.assertEqual(out.strip(), b"apple")
 
+    def test_submit_after_interpreter_shutdown(self):
+        # Test the atexit hook for shutdown of worker threads and processes
+        rc, out, err = assert_python_ok('-c', """if 1:
+            import atexit
+            @atexit.register
+            def run_last():
+                try:
+                    t.submit(lambda: None)
+                except RuntimeError:
+                    print("runtime-error")
+                    raise
+            from concurrent.futures import {executor_type}
+            if __name__ == "__main__":
+                context = '{context}'
+                if context == "":
+                    t = {executor_type}(5)
+                else:
+                    from multiprocessing import get_context
+                    context = get_context(context)
+                    t = {executor_type}(5, mp_context=context)
+            """.format(executor_type=self.executor_type.__name__,
+                       context=getattr(self, "ctx", "")))
+        # Errors in atexit hooks don't change the process exit code, check
+        # stderr manually.
+        self.assertTrue(err)
+        self.assertEqual(out.strip(), b"runtime-error")
+
     def test_hang_issue12364(self):
         fs = [self.executor.submit(time.sleep, 0.1) for _ in range(50)]
         self.executor.shutdown()

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -310,7 +310,7 @@ class ExecutorShutdownTest:
             @atexit.register
             def run_last():
                 try:
-                    t.submit(lambda: None)
+                    t.submit(id, None)
                 except RuntimeError:
                     print("runtime-error")
                     raise

--- a/Misc/NEWS.d/next/Library/2018-03-18-16-48-23.bpo-33097.Yl4gI2.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-18-16-48-23.bpo-33097.Yl4gI2.rst
@@ -1,0 +1,2 @@
+Raise RuntimeError when ``executor.submit`` is called during interpreter
+shutdown.


### PR DESCRIPTION


<!-- issue-number: bpo-33097 -->
https://bugs.python.org/issue33097
<!-- /issue-number -->
