### PR TITLE
bpo-33083 - math.factorial accepts non-integral Decimal instances

### DIFF
--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -5,6 +5,7 @@ from test.support import run_unittest, verbose, requires_IEEE_754
 from test import support
 import unittest
 import itertools
+import decimal
 import math
 import os
 import platform
@@ -497,18 +498,24 @@ class MathTests(unittest.TestCase):
 
     def testFactorial(self):
         self.assertEqual(math.factorial(0), 1)
-        self.assertEqual(math.factorial(0.0), 1)
-        total = 1
-        for i in range(1, 1000):
-            total *= i
-            self.assertEqual(math.factorial(i), total)
-            self.assertEqual(math.factorial(float(i)), total)
-            self.assertEqual(math.factorial(i), py_factorial(i))
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(math.factorial(0.0), 1)
+            total = 1
+            for i in range(1, 1000):
+                total *= i
+                self.assertEqual(math.factorial(i), total)
+                self.assertEqual(math.factorial(float(i)), total)
+                self.assertEqual(math.factorial(i), py_factorial(i))
         self.assertRaises(ValueError, math.factorial, -1)
-        self.assertRaises(ValueError, math.factorial, -1.0)
-        self.assertRaises(ValueError, math.factorial, -10**100)
-        self.assertRaises(ValueError, math.factorial, -1e100)
-        self.assertRaises(ValueError, math.factorial, math.pi)
+        with self.assertWarns(DeprecationWarning):
+            self.assertRaises(ValueError, math.factorial, -1.0)
+            self.assertRaises(ValueError, math.factorial, -10**100)
+            self.assertRaises(ValueError, math.factorial, -1e100)
+            self.assertRaises(ValueError, math.factorial, math.pi)
+
+    def testFactorialNonIntegers(self):
+        self.assertRaises(TypeError, math.factorial, decimal.Decimal(5.2))
+        self.assertRaises(TypeError, math.factorial, "5")
 
     # Other implementations may place different upper bounds.
     @support.cpython_only
@@ -516,7 +523,8 @@ class MathTests(unittest.TestCase):
         # Currently raises ValueError for inputs that are too large
         # to fit into a C long.
         self.assertRaises(OverflowError, math.factorial, 10**100)
-        self.assertRaises(OverflowError, math.factorial, 1e100)
+        with self.assertWarns(DeprecationWarning):
+            self.assertRaises(OverflowError, math.factorial, 1e100)
 
     def testFloor(self):
         self.assertRaises(TypeError, math.floor)

--- a/Lib/test/test_math.py
+++ b/Lib/test/test_math.py
@@ -498,20 +498,18 @@ class MathTests(unittest.TestCase):
 
     def testFactorial(self):
         self.assertEqual(math.factorial(0), 1)
-        with self.assertWarns(DeprecationWarning):
-            self.assertEqual(math.factorial(0.0), 1)
-            total = 1
-            for i in range(1, 1000):
-                total *= i
-                self.assertEqual(math.factorial(i), total)
-                self.assertEqual(math.factorial(float(i)), total)
-                self.assertEqual(math.factorial(i), py_factorial(i))
+        self.assertEqual(math.factorial(0.0), 1)
+        total = 1
+        for i in range(1, 1000):
+            total *= i
+            self.assertEqual(math.factorial(i), total)
+            self.assertEqual(math.factorial(float(i)), total)
+            self.assertEqual(math.factorial(i), py_factorial(i))
         self.assertRaises(ValueError, math.factorial, -1)
-        with self.assertWarns(DeprecationWarning):
-            self.assertRaises(ValueError, math.factorial, -1.0)
-            self.assertRaises(ValueError, math.factorial, -10**100)
-            self.assertRaises(ValueError, math.factorial, -1e100)
-            self.assertRaises(ValueError, math.factorial, math.pi)
+        self.assertRaises(ValueError, math.factorial, -1.0)
+        self.assertRaises(ValueError, math.factorial, -10**100)
+        self.assertRaises(ValueError, math.factorial, -1e100)
+        self.assertRaises(ValueError, math.factorial, math.pi)
 
     def testFactorialNonIntegers(self):
         self.assertRaises(TypeError, math.factorial, decimal.Decimal(5.2))
@@ -523,8 +521,7 @@ class MathTests(unittest.TestCase):
         # Currently raises ValueError for inputs that are too large
         # to fit into a C long.
         self.assertRaises(OverflowError, math.factorial, 10**100)
-        with self.assertWarns(DeprecationWarning):
-            self.assertRaises(OverflowError, math.factorial, 1e100)
+        self.assertRaises(OverflowError, math.factorial, 1e100)
 
     def testFloor(self):
         self.assertRaises(TypeError, math.floor)

--- a/Misc/NEWS.d/next/Core and Builtins/2018-03-19-00-59-20.bpo-33083.Htztjl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-03-19-00-59-20.bpo-33083.Htztjl.rst
@@ -1,3 +1,2 @@
-math.factorial no longer accepts arguments that are not int-like. A
-DeprecationWarning is emitted if the argument is a float. Patch by Pablo
-Galindo.
+``math.factorial`` no longer accepts arguments that are not int-like.
+Patch by Pablo Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-03-19-00-59-20.bpo-33083.Htztjl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-03-19-00-59-20.bpo-33083.Htztjl.rst
@@ -1,3 +1,3 @@
-math.factorial no longer accept arguments that are not int-like. A
-DeprecationWarning is emmited if the argument is a float. Patch by Pablo
+math.factorial no longer accepts arguments that are not int-like. A
+DeprecationWarning is emitted if the argument is a float. Patch by Pablo
 Galindo.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-03-19-00-59-20.bpo-33083.Htztjl.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-03-19-00-59-20.bpo-33083.Htztjl.rst
@@ -1,0 +1,3 @@
+math.factorial no longer accept arguments that are not int-like. A
+DeprecationWarning is emmited if the argument is a float. Patch by Pablo
+Galindo.

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1671,16 +1671,10 @@ math_factorial(PyObject *module, PyObject *arg)
             return NULL;
         x = PyLong_AsLongAndOverflow(lx, &overflow);
         Py_DECREF(lx);
-        if (PyErr_WarnEx(PyExc_DeprecationWarning,
-                "Passing float instances to math.factorial will be "
-                "removed in future versions.", 1) < 0) {
-            return NULL;
-        }
-
     }
     else{
         pyint_form = PyNumber_Index(arg);
-        if( pyint_form == NULL){
+        if(pyint_form == NULL){
             return NULL;
         }
         x = PyLong_AsLongAndOverflow(pyint_form, &overflow);

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1672,9 +1672,9 @@ math_factorial(PyObject *module, PyObject *arg)
         x = PyLong_AsLongAndOverflow(lx, &overflow);
         Py_DECREF(lx);
     }
-    else{
+    else {
         pyint_form = PyNumber_Index(arg);
-        if(pyint_form == NULL){
+        if (pyint_form == NULL) {
             return NULL;
         }
         x = PyLong_AsLongAndOverflow(pyint_form, &overflow);

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -1656,7 +1656,7 @@ math_factorial(PyObject *module, PyObject *arg)
 {
     long x;
     int overflow;
-    PyObject *result, *odd_part, *two_valuation;
+    PyObject *result, *odd_part, *two_valuation, *pyint_form;
 
     if (PyFloat_Check(arg)) {
         PyObject *lx;
@@ -1671,9 +1671,21 @@ math_factorial(PyObject *module, PyObject *arg)
             return NULL;
         x = PyLong_AsLongAndOverflow(lx, &overflow);
         Py_DECREF(lx);
+        if (PyErr_WarnEx(PyExc_DeprecationWarning,
+                "Passing float instances to math.factorial will be "
+                "removed in future versions.", 1) < 0) {
+            return NULL;
+        }
+
     }
-    else
-        x = PyLong_AsLongAndOverflow(arg, &overflow);
+    else{
+        pyint_form = PyNumber_Index(arg);
+        if( pyint_form == NULL){
+            return NULL;
+        }
+        x = PyLong_AsLongAndOverflow(pyint_form, &overflow);
+        Py_DECREF(pyint_form);
+    }
 
     if (x == -1 && PyErr_Occurred()) {
         return NULL;


### PR DESCRIPTION


<!-- issue-number: bpo-33083 -->
https://bugs.python.org/issue33083
<!-- /issue-number -->
