### PR TITLE
[2.7] bpo-31550: Revert "Make an error message more understandable and consistent with other error messages."

### DIFF
--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -156,7 +156,7 @@ PyObject_GetItem(PyObject *o, PyObject *key)
                               "be integer, not '%.200s'", key);
     }
 
-    return type_error("'%.200s' object has no attribute '__getitem__'", o);
+    return type_error("'%.200s' object is not subscriptable", o);
 }
 
 int


### PR DESCRIPTION

This reverts commit 7d1483cbadbe48620964348a2039690624e7dc8e.

<!-- issue-number: bpo-31550 -->
https://bugs.python.org/issue31550
<!-- /issue-number -->
