### PR TITLE
bpo-33100: Dataclasses now handles __slots__ and default values correctly.

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -519,6 +519,9 @@ def _get_field(cls, a_name, a_type):
     if isinstance(default, Field):
         f = default
     else:
+        if isinstance(default, types.MemberDescriptorType):
+            # This is a field in __slots__, so it has no default value.
+            default = MISSING
         f = field(default=default)
 
     # Assume it's a normal field until proven otherwise.

--- a/Misc/NEWS.d/next/Library/2018-03-19-20-47-00.bpo-33100.chyIO4.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-19-20-47-00.bpo-33100.chyIO4.rst
@@ -1,0 +1,2 @@
+Dataclasses: If a field has a default value that's a MemberDescriptorType,
+then it's from that field being in __slots__, not an actual default value.


### PR DESCRIPTION
If the class has a member that's a `MemberDescriptorType`, it's not a default value, it's from that member being in `__slots__`.


<!-- issue-number: bpo-33100 -->
https://bugs.python.org/issue33100
<!-- /issue-number -->
