### PR TITLE
Fix typos (.:: should typically just be ::).

### DIFF
--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -60,7 +60,7 @@ program. So, how do you arrange for the interpreter to handle your Python?
 First, you need to make sure that your command window recognises the word
 "python" as an instruction to start the interpreter.  If you have opened a
 command window, you should try entering the command ``python`` and hitting
-return.::
+return::
 
    C:\Users\YourName> python
 

--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -981,7 +981,7 @@ is used when no command-line argument was present::
 
 
 Providing ``default=argparse.SUPPRESS`` causes no attribute to be added if the
-command-line argument was not present.::
+command-line argument was not present::
 
    >>> parser = argparse.ArgumentParser()
    >>> parser.add_argument('--foo', default=argparse.SUPPRESS)

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -127,7 +127,7 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
 
    :class:`~mmap.mmap` can also be used as a context manager in a :keyword:`with`
-   statement.::
+   statement::
 
       import mmap
 


### PR DESCRIPTION
Found them using:

    git grep "\.::" Doc/ | grep -v 'e\.g\.::'
