### PR TITLE
bpo-32896: Fix error when subclassing a dataclass with a field that uses a default_factory

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -318,6 +318,11 @@ def _create_fn(name, args, body, *, globals=None, locals=None,
     # Compute the text of the entire function.
     txt = f'def {name}({args}){return_annotation}:\n{body}'
 
+    if name == '__init__':
+        print(txt)
+        print(globals)
+        print(locals)
+        print()
     exec(txt, globals, locals)
     return locals[name]
 
@@ -661,10 +666,14 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen):
             if getattr(b, _PARAMS).frozen:
                 any_frozen_base = True
 
+    print(f'found fields in {cls.__name__}: {fields}')
+    print('annotations', cls.__annotations__)
+    print('dict', cls.__dict__.keys())
     # Now find fields in our class.  While doing so, validate some
     #  things, and set the default values (as class attributes)
     #  where we can.
     for f in _find_fields(cls):
+        print('adding field', f)
         fields[f.name] = f
 
         # If the class attribute (which is the default value for

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -582,11 +582,9 @@ def _find_fields(cls):
     #  Pseudo-fields ClassVars and InitVars are included, despite the
     #  fact that they're not real fields.  That's dealt with later.
 
-    try:
-        annotations = cls.__dict__['__annotations__']
-    except KeyError:
-        # This class defines no additional annotations.
-        annotations = {}
+    # If __annotations__ isn't present, then this class adds no new
+    #  annotations.
+    annotations = cls.__dict__.get('__annotations__', {})
     return [_get_field(cls, name, type) for name, type in annotations.items()]
 
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -585,7 +585,7 @@ def _find_fields(cls):
     try:
         annotations = cls.__dict__['__annotations__']
     except KeyError:
-        # This class defines no annotations.
+        # This class defines no additional annotations.
         annotations = {}
     return [_get_field(cls, name, type) for name, type in annotations.items()]
 

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1159,11 +1159,12 @@ class TestCase(unittest.TestCase):
 
         self.assertEqual(Foo().x, {})
         self.assertEqual(Bar().x, {})
+        self.assertEqual(Bar().y, 1)
 
         @dataclass
         class Baz(Foo):
             pass
-        Baz()
+        self.assertEqual(Baz().x, {})
 
     def test_intermediate_non_dataclass(self):
         # Test that an intermediate class that defines

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1165,6 +1165,36 @@ class TestCase(unittest.TestCase):
             pass
         Baz()
 
+    def test_intermediate_non_dataclass(self):
+        # Test that an intermediate class that defines
+        #  annotations does not define fields.
+
+        @dataclass
+        class A:
+            x: int
+
+        class B(A):
+            y: int
+
+        @dataclass
+        class C(B):
+            z: int
+
+        c = C(1, 3)
+        self.assertEqual((c.x, c.z), (1, 3))
+
+        # .y was not initialized.
+        with self.assertRaisesRegex(AttributeError,
+                                    'object has no attribute'):
+            c.y
+
+        # And if we again derive a non-dataclass, no fields are added.
+        class D(C):
+            t: int
+        d = D(4, 5)
+        self.assertEqual((d.x, d.z), (4, 5))
+
+
     def x_test_classvar_default_factory(self):
         # XXX: it's an error for a ClassVar to have a factory function
         @dataclass

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1147,6 +1147,24 @@ class TestCase(unittest.TestCase):
         C().x
         self.assertEqual(factory.call_count, 2)
 
+    def test_default_factory_derived(self):
+        # See bpo-32896.
+        @dataclass
+        class Foo:
+            x: dict = field(default_factory=dict)
+
+        @dataclass
+        class Bar(Foo):
+            y: int = 1
+
+        self.assertEqual(Foo().x, {})
+        self.assertEqual(Bar().x, {})
+
+        @dataclass
+        class Baz(Foo):
+            pass
+        Baz()
+
     def x_test_classvar_default_factory(self):
         # XXX: it's an error for a ClassVar to have a factory function
         @dataclass

--- a/Misc/NEWS.d/next/Library/2018-03-20-20-53-21.bpo-32896.ewW3Ln.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-20-20-53-21.bpo-32896.ewW3Ln.rst
@@ -1,0 +1,2 @@
+Fix an error where subclassing a dataclass with a field that uses a
+default_factory would generate an incorrect class.


### PR DESCRIPTION


<!-- issue-number: bpo-32896 -->
https://bugs.python.org/issue32896
<!-- /issue-number -->
