### PR TITLE
bpo-33078 FIX failure on OSX sem_getvalue

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1062,11 +1062,16 @@ class _TestQueue(BaseTestCase):
             q = self.Queue(maxsize=1)
             q.put(NotSerializable())
             q.put(True)
-            self.assertEqual(q.qsize(), 1)
+            try:
+                self.assertEqual(q.qsize(), 1)
+            except NotImplementedError:
+                # qsize is not available on all platform as it
+                # relies on sem_getvalue
+                pass
             # bpo-30595: use a timeout of 1 second for slow buildbots
             self.assertTrue(q.get(timeout=1.0))
             # Check that the size of the queue is correct
-            self.assertEqual(q.qsize(), 0)
+            self.assertTrue(q.empty())
             close_queue(q)
 
     def test_queue_feeder_on_queue_feeder_error(self):

--- a/Misc/NEWS.d/next/Library/2018-03-21-17-59-39.bpo-33078.PQOniT.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-21-17-59-39.bpo-33078.PQOniT.rst
@@ -1,0 +1,1 @@
+Fix the failure on OSX caused by the tests relying on sem_getvalue


### PR DESCRIPTION
Fixes the failure in the build bots reported by @ned-deily 


http://buildbot.python.org/all/#/builders/14/builds/804/steps/4/logs/stdio
http://buildbot.python.org/all/#/builders/93/builds/459/steps/4/logs/stdio

<!-- issue-number: bpo-33078 -->
https://bugs.python.org/issue33078
<!-- /issue-number -->
