### PR TITLE
bpo-33116: Add 'Field' to dataclasses.__all__.

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -5,6 +5,7 @@ import inspect
 
 __all__ = ['dataclass',
            'field',
+           'Field',
            'FrozenInstanceError',
            'InitVar',
            'MISSING',
@@ -513,7 +514,7 @@ def _get_field(cls, a_name, a_type):
     #  and InitVars are also returned, but marked as such (see
     #  f._field_type).
 
-    # If the default value isn't derived from field, then it's
+    # If the default value isn't derived from Field, then it's
     #  only a normal default value.  Convert it to a Field().
     default = getattr(cls, a_name, MISSING)
     if isinstance(default, Field):

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1,7 +1,8 @@
-from dataclasses import (
-    dataclass, field, FrozenInstanceError, fields, asdict, astuple,
-    make_dataclass, replace, InitVar, Field, MISSING, is_dataclass,
-)
+# Deliberately use "from dataclasses import *".  Every name in __all__
+# is tested, so they all must be present.  This is a way to catch
+# missing ones.
+
+from dataclasses import *
 
 import pickle
 import inspect

--- a/Misc/NEWS.d/next/Library/2018-03-21-16-52-26.bpo-33116.Tvzerj.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-21-16-52-26.bpo-33116.Tvzerj.rst
@@ -1,0 +1,1 @@
+Add 'Field' to dataclasses.__all__.


### PR DESCRIPTION
Field is documented, but was missing from __all__.

<!-- issue-number: bpo-33116 -->
https://bugs.python.org/issue33116
<!-- /issue-number -->
