### PR TITLE
bpo-33123: pathlib: Add missing_ok parameter to Path.unlink

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1033,10 +1033,19 @@ call fails (for example because the path doesn't exist):
    otherwise :exc:`FileExistsError` is raised.
 
 
-.. method:: Path.unlink()
+.. method:: Path.unlink(missing_ok=False)
 
    Remove this file or symbolic link.  If the path points to a directory,
    use :func:`Path.rmdir` instead.
+
+   If *missing_ok* is false (the default), :exc:`FileNotFoundError` is
+   raised if the path does not exist.
+
+   If *missing_ok* is true, :exc:`FileNotFoundError` exceptions will be
+   ignored (same behavior as the POSIX ``rm -f`` command).
+
+   .. versionchanged:: 3.8
+      The *missing_ok* parameter was added.
 
 
 .. method:: Path.write_bytes(data)

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1256,14 +1256,18 @@ class Path(PurePath):
             self._raise_closed()
         self._accessor.lchmod(self, mode)
 
-    def unlink(self):
+    def unlink(self, missing_ok=False):
         """
         Remove this file or link.
         If the path is a directory, use rmdir() instead.
         """
         if self._closed:
             self._raise_closed()
-        self._accessor.unlink(self)
+        try:
+            self._accessor.unlink(self)
+        except FileNotFoundError:
+            if not missing_ok:
+                raise
 
     def rmdir(self):
         """

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1627,6 +1627,11 @@ class _BasePathTest(object):
         self.assertFileNotFound(p.stat)
         self.assertFileNotFound(p.unlink)
 
+    def test_unlink_missing_ok(self):
+        p = self.cls(BASE) / 'fileAAA'
+        self.assertFileNotFound(p.unlink)
+        p.unlink(missing_ok=True)
+
     def test_rmdir(self):
         p = self.cls(BASE) / 'dirA'
         for q in p.iterdir():

--- a/Misc/NEWS.d/next/Library/2018-03-22-19-13-19.bpo-33123._Y5ooE.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-22-19-13-19.bpo-33123._Y5ooE.rst
@@ -1,2 +1,2 @@
-:class:`pathlib.Path.unlink` now accepts a +missing_ok* parameter to avoid a
+:class:`pathlib.Path.unlink` now accepts a *missing_ok* parameter to avoid a
 :exc:`FileNotFoundError` from being raised. Patch by Robert Buchholz.

--- a/Misc/NEWS.d/next/Library/2018-03-22-19-13-19.bpo-33123._Y5ooE.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-22-19-13-19.bpo-33123._Y5ooE.rst
@@ -1,0 +1,2 @@
+:class:`pathlib.Path.unlink` now accepts a +missing_ok* parameter to avoid a
+:exc:`FileNotFoundError` from being raised. Patch by Robert Buchholz.


### PR DESCRIPTION

Similarly to how several pathlib file creation functions have an "exists_ok" parameter, we should introduce "missing_ok" that makes removal functions not raise an exception when a file or directory is already absent.  IMHO, this should cover Path.unlink and Path.rmdir.  Note, Path.resolve() has a "strict" parameter since 3.6 that does the same thing. Naming this of this new parameter tries to be consistent with the "exists_ok" parameter as that is more explicit about what it does (as opposed to "strict").

<!-- issue-number: bpo-33123 -->
https://bugs.python.org/issue33123
<!-- /issue-number -->
