### PR TITLE
bpo-27212: Modify islice recipe to consume initial values preceding start

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -454,7 +454,6 @@ loops that truncate the stream.
               # Consume to *stop*.
               for i, element in zip(range(i + 1, stop), iterable):
                   pass
-              return
 
    If *start* is ``None``, then iteration starts at zero. If *step* is ``None``,
    then the step defaults to one.

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -445,16 +445,16 @@ loops that truncate the stream.
               for i, element in zip(range(start), iterable):
                   pass
               return
-          for i, element in enumerate(iterable):
-              if i == nexti:
-                  yield element
-                  try:
+          try:
+              for i, element in enumerate(iterable):
+                  if i == nexti:
+                      yield element
                       nexti = next(it)
-                  except StopIteration:
-                      # Consume to *stop*.
-                      for i, element in zip(range(i + 1, stop), iterable):
-                          pass
-                      return
+          except StopIteration:
+              # Consume to *stop*.
+              for i, element in zip(range(i + 1, stop), iterable):
+                  pass
+              return
 
    If *start* is ``None``, then iteration starts at zero. If *step* is ``None``,
    then the step defaults to one.

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -435,21 +435,26 @@ loops that truncate the stream.
           # islice('ABCDEFG', 2, 4) --> C D
           # islice('ABCDEFG', 2, None) --> C D E F G
           # islice('ABCDEFG', 0, None, 2) --> A C E G
-          # it = iter('abcdefghi')
-          # list(islice(it, 4, 4)) --> []
-          # list(it) --> ['e', 'f', 'g', 'h', 'i']
           s = slice(*args)
-          it = iter(range(0, s.stop or sys.maxsize, s.step or 1))
-          for i in zip(range(0, s.start or 0), iterable):
-              nexti = next(it)
+          start, stop, step = s.start or 0, s.stop or sys.maxsize, s.step or 1
+          it = iter(range(start, stop, step))
           try:
               nexti = next(it)
           except StopIteration:
+              # Consume *iterable* up to the *start* position.
+              for i, element in zip(range(start), iterable):
+                  pass
               return
           for i, element in enumerate(iterable):
               if i == nexti:
                   yield element
-                  nexti = next(it)
+                  try:
+                      nexti = next(it)
+                  except StopIteration:
+                      # Consume to *stop*.
+                      for i, element in zip(range(i + 1, stop), iterable):
+                          pass
+                      return
 
    If *start* is ``None``, then iteration starts at zero. If *step* is ``None``,
    then the step defaults to one.
@@ -693,8 +698,8 @@ which incur interpreter overhead.
        # tail(3, 'ABCDEFG') --> E F G
        return iter(collections.deque(iterable, maxlen=n))
 
-   def consume(iterator, n):
-       "Advance the iterator n-steps ahead. If n is none, consume entirely."
+   def consume(iterator, n=None):
+       "Advance the iterator n-steps ahead. If n is None, consume entirely."
        # Use functions that consume iterators at C speed.
        if n is None:
            # feed the entire iterator into a zero-length deque

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -435,8 +435,13 @@ loops that truncate the stream.
           # islice('ABCDEFG', 2, 4) --> C D
           # islice('ABCDEFG', 2, None) --> C D E F G
           # islice('ABCDEFG', 0, None, 2) --> A C E G
+          # it = iter('abcdefghi')
+          # list(islice(it, 4, 4)) --> []
+          # list(it) --> ['e', 'f', 'g', 'h', 'i']
           s = slice(*args)
-          it = iter(range(s.start or 0, s.stop or sys.maxsize, s.step or 1))
+          it = iter(range(0, s.stop or sys.maxsize, s.step or 1))
+          for i in zip(range(0, s.start or 0), iterable):
+              nexti = next(it)
           try:
               nexti = next(it)
           except StopIteration:

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1192,6 +1192,7 @@ class TestBasicOps(unittest.TestCase):
                 (10, 20, 3),
                 (10, 3, 20),
                 (10, 20),
+                (10, 10),
                 (10, 3),
                 (20,)
                 ]:
@@ -1216,6 +1217,10 @@ class TestBasicOps(unittest.TestCase):
         # Test number of items consumed     SF #1171417
         it = iter(range(10))
         self.assertEqual(list(islice(it, 3)), list(range(3)))
+        self.assertEqual(list(it), list(range(3, 10)))
+
+        it = iter(range(10))
+        self.assertEqual(list(islice(it, 3, 3)), [])
         self.assertEqual(list(it), list(range(3, 10)))
 
         # Test invalid arguments
@@ -1602,6 +1607,49 @@ class TestExamples(unittest.TestCase):
 
     def test_takewhile(self):
         self.assertEqual(list(takewhile(lambda x: x<5, [1,4,6,4,1])), [1,4])
+
+
+class TestPurePythonRoughEquivalents(unittest.TestCase):
+
+    @staticmethod
+    def islice(iterable, *args):
+        s = slice(*args)
+        start, stop, step = s.start or 0, s.stop or sys.maxsize, s.step or 1
+        it = iter(range(start, stop, step))
+        try:
+            nexti = next(it)
+        except StopIteration:
+            # Consume *iterable* up to the *start* position.
+            for i, element in zip(range(start), iterable):
+                pass
+            return
+        for i, element in enumerate(iterable):
+            if i == nexti:
+                yield element
+                try:
+                    nexti = next(it)
+                except StopIteration:
+                    # Consume to *stop*.
+                    for i, element in zip(range(i + 1, stop), iterable):
+                        pass
+                    return
+
+    def test_islice_recipe(self):
+        self.assertEqual(list(self.islice('ABCDEFG', 2)), list('AB'))
+        self.assertEqual(list(self.islice('ABCDEFG', 2, 4)), list('CD'))
+        self.assertEqual(list(self.islice('ABCDEFG', 2, None)), list('CDEFG'))
+        self.assertEqual(list(self.islice('ABCDEFG', 0, None, 2)), list('ACEG'))
+        # Test items consumed.
+        it = iter(range(10))
+        self.assertEqual(list(self.islice(it, 3)), list(range(3)))
+        self.assertEqual(list(it), list(range(3, 10)))
+        it = iter(range(10))
+        self.assertEqual(list(self.islice(it, 3, 3)), [])
+        self.assertEqual(list(it), list(range(3, 10)))
+        # Test that slice finishes in predictable state.
+        c = count()
+        self.assertEqual(list(self.islice(c, 1, 3, 50)), [1])
+        self.assertEqual(next(c), 3)
 
 
 class TestGC(unittest.TestCase):
@@ -2158,6 +2206,17 @@ Samuele
 ...     "Return function(0), function(1), ..."
 ...     return map(function, count(start))
 
+>>> import collections
+>>> def consume(iterator, n=None):
+...     "Advance the iterator n-steps ahead. If n is None, consume entirely."
+...     # Use functions that consume iterators at C speed.
+...     if n is None:
+...         # feed the entire iterator into a zero-length deque
+...         collections.deque(iterator, maxlen=0)
+...     else:
+...         # advance to the empty slice starting at position n
+...         next(islice(iterator, n, n), None)
+
 >>> def nth(iterable, n, default=None):
 ...     "Returns the nth item or a default value"
 ...     return next(islice(iterable, n, None), default)
@@ -2298,6 +2357,14 @@ perform as purported.
 >>> list(islice(tabulate(lambda x: 2*x), 4))
 [0, 2, 4, 6]
 
+>>> it = iter(range(10))
+>>> consume(it, 3)
+>>> next(it)
+3
+>>> consume(it)
+>>> next(it, 'Done')
+'Done'
+
 >>> nth('abcde', 3)
 'd'
 
@@ -2386,6 +2453,7 @@ def test_main(verbose=None):
     test_classes = (TestBasicOps, TestVariousIteratorArgs, TestGC,
                     RegressionTests, LengthTransparency,
                     SubclassWithKwargsTest, TestExamples,
+                    TestPurePythonRoughEquivalents,
                     SizeofTest)
     support.run_unittest(*test_classes)
 

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1623,16 +1623,16 @@ class TestPurePythonRoughEquivalents(unittest.TestCase):
             for i, element in zip(range(start), iterable):
                 pass
             return
-        for i, element in enumerate(iterable):
-            if i == nexti:
-                yield element
-                try:
+        try:
+            for i, element in enumerate(iterable):
+                if i == nexti:
+                    yield element
                     nexti = next(it)
-                except StopIteration:
-                    # Consume to *stop*.
-                    for i, element in zip(range(i + 1, stop), iterable):
-                        pass
-                    return
+        except StopIteration:
+            # Consume to *stop*.
+            for i, element in zip(range(i + 1, stop), iterable):
+                pass
+            return
 
     def test_islice_recipe(self):
         self.assertEqual(list(self.islice('ABCDEFG', 2)), list('AB'))

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1632,7 +1632,6 @@ class TestPurePythonRoughEquivalents(unittest.TestCase):
             # Consume to *stop*.
             for i, element in zip(range(i + 1, stop), iterable):
                 pass
-            return
 
     def test_islice_recipe(self):
         self.assertEqual(list(self.islice('ABCDEFG', 2)), list('AB'))

--- a/Misc/NEWS.d/next/Documentation/2018-03-22-19-23-04.bpo-27212.wrE5KR.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-03-22-19-23-04.bpo-27212.wrE5KR.rst
@@ -1,0 +1,2 @@
+Modify documentation for the :func:`islice` recipe to consume initial values
+up to start.

--- a/Misc/NEWS.d/next/Documentation/2018-03-22-19-23-04.bpo-27212.wrE5KR.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-03-22-19-23-04.bpo-27212.wrE5KR.rst
@@ -1,2 +1,2 @@
 Modify documentation for the :func:`islice` recipe to consume initial values
-up to start.
+up to the start index.


### PR DESCRIPTION


<!-- issue-number: bpo-27212 -->
https://bugs.python.org/issue27212
<!-- /issue-number -->
