### PR TITLE
bpo-24334: Remove inaccurate match_hostname call

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -1106,11 +1106,6 @@ class SSLSocket(socket):
             if timeout == 0.0 and block:
                 self.settimeout(None)
             self._sslobj.do_handshake()
-            if self.context.check_hostname:
-                if not self.server_hostname:
-                    raise ValueError("check_hostname needs server_hostname "
-                                     "argument")
-                match_hostname(self.getpeercert(), self.server_hostname)
         finally:
             self.settimeout(timeout)
 


### PR DESCRIPTION
Commit 141c5e8c re-added match_hostname() call. The resurrection of the
function call was never intended and was solely a merge mistake.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-24334 -->
https://bugs.python.org/issue24334
<!-- /issue-number -->
