### PR TITLE
[3.6] bpo-33127: Compatibility patch for LibreSSL 2.7.0 (GH-6210)

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1687,6 +1687,7 @@ class SimpleBackgroundTests(unittest.TestCase):
         self.assertEqual(len(ctx.get_ca_certs()), 1)
 
     @needs_sni
+    @unittest.skipUnless(hasattr(ssl, "PROTOCOL_TLSv1_2"), "needs TLS 1.2")
     def test_context_setget(self):
         # Check that the context of a connected socket can be replaced.
         ctx1 = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)

--- a/Misc/NEWS.d/next/Library/2018-03-24-15-08-24.bpo-33127.olJmHv.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-24-15-08-24.bpo-33127.olJmHv.rst
@@ -1,0 +1,1 @@
+The ssl module now compiles with LibreSSL 2.7.1.

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -57,8 +57,9 @@ LIBRESSL_OLD_VERSIONS = [
 ]
 
 LIBRESSL_RECENT_VERSIONS = [
-    "2.5.3",
     "2.5.5",
+    "2.6.4",
+    "2.7.1",
 ]
 
 # store files in ../multissl


### PR DESCRIPTION
LibreSSL 2.7 introduced OpenSSL 1.1.0 API. The ssl module now detects
LibreSSL 2.7 and only provides API shims for OpenSSL < 1.1.0 and
LibreSSL < 2.7.

Documentation updates and fixes for failing tests will be provided in
another patch set.

Signed-off-by: Christian Heimes <christian@python.org>.
(cherry picked from commit 4ca0739c9d97ac7cd45499e0d31be68dc659d0e1)

Co-authored-by: Christian Heimes <christian@python.org>


<!-- issue-number: bpo-33127 -->
https://bugs.python.org/issue33127
<!-- /issue-number -->
