### PR TITLE
[2.7] bpo-33127: Compatibility patch for LibreSSL 2.7.0 (GH-6210)

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-03-24-15-08-24.bpo-33127.olJmHv.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-24-15-08-24.bpo-33127.olJmHv.rst
@@ -1,0 +1,1 @@
+The ssl module now compiles with LibreSSL 2.7.1.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -102,6 +102,12 @@ struct py_ssl_library_code {
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
 #  define OPENSSL_VERSION_1_1 1
+#  define PY_OPENSSL_1_1_API 1
+#endif
+
+/* LibreSSL 2.7.0 provides necessary OpenSSL 1.1.0 APIs */
+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x2070000fL
+#  define PY_OPENSSL_1_1_API 1
 #endif
 
 /* Openssl comes with TLSv1.1 and TLSv1.2 between 1.0.0h and 1.0.1
@@ -149,15 +155,17 @@ struct py_ssl_library_code {
 #define INVALID_SOCKET (-1)
 #endif
 
-#ifdef OPENSSL_VERSION_1_1
-/* OpenSSL 1.1.0+ */
-#ifndef OPENSSL_NO_SSL2
-#define OPENSSL_NO_SSL2
-#endif
-#else /* OpenSSL < 1.1.0 */
-#if defined(WITH_THREAD)
+/* OpenSSL 1.0.2 and LibreSSL needs extra code for locking */
+#if !defined(OPENSSL_VERSION_1_1) && defined(WITH_THREAD)
 #define HAVE_OPENSSL_CRYPTO_LOCK
 #endif
+
+#if defined(OPENSSL_VERSION_1_1) && !defined(OPENSSL_NO_SSL2)
+#define OPENSSL_NO_SSL2
+#endif
+
+#ifndef PY_OPENSSL_1_1_API
+/* OpenSSL 1.1 API shims for OpenSSL < 1.1.0 and LibreSSL < 2.7.0 */
 
 #define TLS_method SSLv23_method
 
@@ -201,7 +209,7 @@ static X509_VERIFY_PARAM *X509_STORE_get0_param(X509_STORE *store)
 {
     return store->param;
 }
-#endif /* OpenSSL < 1.1.0 or LibreSSL */
+#endif /* OpenSSL < 1.1.0 or LibreSSL < 2.7.0 */
 
 
 enum py_ssl_error {

--- a/Tools/ssl/multissltests.py
+++ b/Tools/ssl/multissltests.py
@@ -58,8 +58,9 @@ LIBRESSL_OLD_VERSIONS = [
 ]
 
 LIBRESSL_RECENT_VERSIONS = [
-    "2.5.3",
     "2.5.5",
+    "2.6.4",
+    "2.7.1",
 ]
 
 # store files in ../multissl


### PR DESCRIPTION
LibreSSL 2.7 introduced OpenSSL 1.1.0 API. The ssl module now detects
LibreSSL 2.7 and only provides API shims for OpenSSL < 1.1.0 and
LibreSSL < 2.7.

Documentation updates and fixes for failing tests will be provided in
another patch set.

Signed-off-by: Christian Heimes <christian@python.org>.
(cherry picked from commit 4ca0739c9d97ac7cd45499e0d31be68dc659d0e1)

Co-authored-by: Christian Heimes <christian@python.org>

<!-- issue-number: bpo-33127 -->
https://bugs.python.org/issue33127
<!-- /issue-number -->
