### PR TITLE
Implement `MutableMapping`'s `popitem` using `pop`

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -809,8 +809,7 @@ class MutableMapping(Mapping):
             key = next(iter(self))
         except StopIteration:
             raise KeyError from None
-        value = self[key]
-        del self[key]
+        value = self.pop(key)
         return key, value
 
     def clear(self):


### PR DESCRIPTION
Current `popitem` is implemented by separate `__getitem__` and `__delitem__` calls. However it is really just `pop` for the first key returned from iterating. So it seems better to just reuse `pop` in this case.