### PR TITLE
Use `__delitem__` in `clear` with each key

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -815,11 +815,13 @@ class MutableMapping(Mapping):
 
     def clear(self):
         'D.clear() -> None.  Remove all items from D.'
-        try:
-            while True:
-                self.popitem()
-        except KeyError:
-            pass
+        while True:
+            try:
+                key = next(iter(self))
+            except StopIteration:
+                break
+            else:
+                del self[key]
 
     def update(*args, **kwds):
         ''' D.update([E, ]**F) -> None.  Update D from mapping/iterable E and F.


### PR DESCRIPTION
Instead of using `popitem` to delete each value from a `MutableMapping`, just grab each key and delete it from the `MutableMapping`. Once we are unable to grab a key, terminate the loop. As `popitem` reads values, which are unused, for a potentially non-trivial cost, it is better to not read the values in `clear` and merely delete each value corresponding to the next key. Thus avoiding any cost associated with reading the value.