### PR TITLE
bpo-32362: Fix references to non-existent multiprocessing.Connection()

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1027,7 +1027,8 @@ Connection Objects
 Connection objects allow the sending and receiving of picklable objects or
 strings.  They can be thought of as message oriented connected sockets.
 
-Connection objects are usually created using :func:`Pipe` -- see also
+Connection objects are usually created using
+:func:`Pipe <multiprocessing.Pipe>` -- see also
 :ref:`multiprocessing-listeners-clients`.
 
 .. class:: Connection
@@ -2274,7 +2275,7 @@ Listeners and Clients
    :synopsis: API for dealing with sockets.
 
 Usually message passing between processes is done using queues or by using
-:class:`~multiprocessing.connection.Connection` objects returned by
+:class:`~Connection` objects returned by
 :func:`~multiprocessing.Pipe`.
 
 However, the :mod:`multiprocessing.connection` module allows some extra
@@ -2304,7 +2305,7 @@ multiple connections at the same time.
 .. function:: Client(address[, family[, authkey]])
 
    Attempt to set up a connection to the listener which is using address
-   *address*, returning a :class:`~multiprocessing.connection.Connection`.
+   *address*, returning a :class:`~Connection`.
 
    The type of the connection is determined by *family* argument, but this can
    generally be omitted since it can usually be inferred from the format of
@@ -2354,7 +2355,7 @@ multiple connections at the same time.
    .. method:: accept()
 
       Accept a connection on the bound socket or named pipe of the listener
-      object and return a :class:`~multiprocessing.connection.Connection` object.
+      object and return a :class:`~Connection` object.
       If authentication is attempted and fails, then
       :exc:`~multiprocessing.AuthenticationError` is raised.
 
@@ -2514,10 +2515,10 @@ an ``'AF_PIPE'`` address rather than an ``'AF_UNIX'`` address.
 Authentication keys
 ~~~~~~~~~~~~~~~~~~~
 
-When one uses :meth:`Connection.recv <multiprocessing.connection.Connection.recv>`,
-the data received is automatically
-unpickled.  Unfortunately unpickling data from an untrusted source is a security
-risk.  Therefore :class:`Listener` and :func:`Client` use the :mod:`hmac` module
+When one uses :meth:`Connection.recv <Connection.recv>`, the
+data received is automatically
+unpickled. Unfortunately unpickling data from an untrusted source is a security
+risk. Therefore :class:`Listener` and :func:`Client` use the :mod:`hmac` module
 to provide digest authentication.
 
 An authentication key is a byte string which can be thought of as a

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1022,8 +1022,7 @@ Miscellaneous
 Connection Objects
 ~~~~~~~~~~~~~~~~~~
 
-.. module:: multiprocessing.connection
-   :noindex:
+.. currentmodule:: multiprocessing.connection
 
 Connection objects allow the sending and receiving of picklable objects or
 strings.  They can be thought of as message oriented connected sockets.
@@ -1162,6 +1161,8 @@ For example:
 
 Synchronization primitives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: multiprocessing
 
 Generally synchronization primitives are not as necessary in a multiprocess
 program as they are in a multithreaded program.  See the documentation for

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -735,8 +735,9 @@ For an example of the usage of queues for interprocess communication see
 
 .. function:: Pipe([duplex])
 
-   Returns a pair ``(conn1, conn2)`` of :class:`Connection` objects representing
-   the ends of a pipe.
+   Returns a pair ``(conn1, conn2)`` of
+   :class:`~multiprocessing.connection.Connection` objects representing the
+   ends of a pipe.
 
    If *duplex* is ``True`` (the default) then the pipe is bidirectional.  If
    *duplex* is ``False`` then the pipe is unidirectional: ``conn1`` can only be
@@ -1020,6 +1021,9 @@ Miscellaneous
 
 Connection Objects
 ~~~~~~~~~~~~~~~~~~
+
+.. module:: multiprocessing.connection
+   :noindex:
 
 Connection objects allow the sending and receiving of picklable objects or
 strings.  They can be thought of as message oriented connected sockets.
@@ -2269,7 +2273,7 @@ Listeners and Clients
    :synopsis: API for dealing with sockets.
 
 Usually message passing between processes is done using queues or by using
-:class:`~multiprocessing.Connection` objects returned by
+:class:`~multiprocessing.connection.Connection` objects returned by
 :func:`~multiprocessing.Pipe`.
 
 However, the :mod:`multiprocessing.connection` module allows some extra
@@ -2299,7 +2303,7 @@ multiple connections at the same time.
 .. function:: Client(address[, family[, authkey]])
 
    Attempt to set up a connection to the listener which is using address
-   *address*, returning a :class:`~multiprocessing.Connection`.
+   *address*, returning a :class:`~multiprocessing.connection.Connection`.
 
    The type of the connection is determined by *family* argument, but this can
    generally be omitted since it can usually be inferred from the format of
@@ -2349,8 +2353,8 @@ multiple connections at the same time.
    .. method:: accept()
 
       Accept a connection on the bound socket or named pipe of the listener
-      object and return a :class:`~multiprocessing.Connection` object.  If
-      authentication is attempted and fails, then
+      object and return a :class:`~multiprocessing.connection.Connection` object.
+      If authentication is attempted and fails, then
       :exc:`~multiprocessing.AuthenticationError` is raised.
 
    .. method:: close()
@@ -2386,7 +2390,7 @@ multiple connections at the same time.
    For both Unix and Windows, an object can appear in *object_list* if
    it is
 
-   * a readable :class:`~multiprocessing.Connection` object;
+   * a readable :class:`~multiprocessing.connection.Connection` object;
    * a connected and readable :class:`socket.socket` object; or
    * the :attr:`~multiprocessing.Process.sentinel` attribute of a
      :class:`~multiprocessing.Process` object.
@@ -2509,8 +2513,8 @@ an ``'AF_PIPE'`` address rather than an ``'AF_UNIX'`` address.
 Authentication keys
 ~~~~~~~~~~~~~~~~~~~
 
-When one uses :meth:`Connection.recv <multiprocessing.Connection.recv>`, the
-data received is automatically
+When one uses :meth:`Connection.recv <multiprocessing.connection.Connection.recv>`,
+the data received is automatically
 unpickled.  Unfortunately unpickling data from an untrusted source is a security
 risk.  Therefore :class:`Listener` and :func:`Client` use the :mod:`hmac` module
 to provide digest authentication.

--- a/Misc/NEWS.d/next/Documentation/2018-03-24-20-31-56.bpo-32362.CeGpEt.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-03-24-20-31-56.bpo-32362.CeGpEt.rst
@@ -1,0 +1,2 @@
+Fix multiprocessing doc references to
+``multiprocessing.connection.Connection``.

--- a/Misc/NEWS.d/next/Documentation/2018-03-24-20-31-56.bpo-32362.CeGpEt.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-03-24-20-31-56.bpo-32362.CeGpEt.rst
@@ -1,2 +1,0 @@
-Fix multiprocessing doc references to
-``multiprocessing.connection.Connection``.


### PR DESCRIPTION
This PR fixes references to `multiprocessing.Connection()` in the `multiprocessing` docs - they should be `multiprocessing.connection.Connection()`.

We set the ~`module`~ `currentmodule` directive such that Sphinx renders the class name correctly ([here](https://github.com/python/cpython/compare/master...bbayles:mp-connection-docs-32362?expand=1#diff-a8cfc8ad76a3734ec269179e28217c60R1025)), ~but~ since `module:: multiprocessing.connection` is already used once ([here](https://github.com/python/cpython/compare/master...bbayles:mp-connection-docs-32362?expand=1#diff-a8cfc8ad76a3734ec269179e28217c60R2272)) ~, we also set `noindex` to avoid messing with the document structure~.

<!-- issue-number: bpo-32362 -->
https://bugs.python.org/issue32362
<!-- /issue-number -->
