### PR TITLE
bpo-33136: Harden ssl module against CVE-2018-8970

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1660,6 +1660,9 @@ class SSLErrorTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             ctx.wrap_bio(ssl.MemoryBIO(), ssl.MemoryBIO(),
                          server_hostname=".example.org")
+        with self.assertRaises(TypeError):
+            ctx.wrap_bio(ssl.MemoryBIO(), ssl.MemoryBIO(),
+                         server_hostname="example.org\x00evil.com")
 
 
 class MemoryBIOTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Security/2018-03-25-12-05-43.bpo-33136.TzSN4x.rst
+++ b/Misc/NEWS.d/next/Security/2018-03-25-12-05-43.bpo-33136.TzSN4x.rst
@@ -1,0 +1,3 @@
+Harden ssl module against LibreSSL CVE-2018-8970.
+X509_VERIFY_PARAM_set1_host() is called with an explicit namelen. A new test
+ensures that NULL bytes are not allowed.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -852,7 +852,8 @@ _ssl_configure_hostname(PySSLSocket *self, const char* server_hostname)
     if (self->ctx->check_hostname) {
         X509_VERIFY_PARAM *param = SSL_get0_param(self->ssl);
         if (ip == NULL) {
-            if (!X509_VERIFY_PARAM_set1_host(param, server_hostname, 0)) {
+            if (!X509_VERIFY_PARAM_set1_host(param, server_hostname,
+                                             strlen(server_hostname))) {
                 _setSSLError(NULL, 0, __FILE__, __LINE__);
                 goto error;
             }
@@ -4025,7 +4026,7 @@ _ssl__SSLContext__wrap_socket_impl(PySSLContext *self, PyObject *sock,
     PyObject *res;
 
     /* server_hostname is either None (or absent), or to be encoded
-       as IDN A-label (ASCII str). */
+       as IDN A-label (ASCII str) without NULL bytes. */
     if (hostname_obj != Py_None) {
         if (!PyArg_Parse(hostname_obj, "es", "ascii", &hostname))
             return NULL;
@@ -4063,7 +4064,7 @@ _ssl__SSLContext__wrap_bio_impl(PySSLContext *self, PySSLMemoryBIO *incoming,
     PyObject *res;
 
     /* server_hostname is either None (or absent), or to be encoded
-       as IDN A-label (ASCII str). */
+       as IDN A-label (ASCII str) without NULL bytes. */
     if (hostname_obj != Py_None) {
         if (!PyArg_Parse(hostname_obj, "es", "ascii", &hostname))
             return NULL;


### PR DESCRIPTION
Harden ssl module against LibreSSL CVE-2018-8970.
X509_VERIFY_PARAM_set1_host() is called with an explicit namelen. A new test
ensures that NULL bytes are not allowed.

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33136 -->
https://bugs.python.org/issue33136
<!-- /issue-number -->
