### PR TITLE
bpo-24565: f->f_lineno is now -1 when tracing is not set

### DIFF
--- a/Include/frameobject.h
+++ b/Include/frameobject.h
@@ -35,10 +35,9 @@ typedef struct _frame {
 
     int f_lasti;                /* Last instruction if called */
     /* Call PyFrame_GetLineNumber() instead of reading this field
-       directly.  As of 2.3 f_lineno is only valid when tracing is
-       active (i.e. when f_trace is set).  At other times we use
-       PyCode_Addr2Line to calculate the line from the current
-       bytecode index. */
+       directly.  As of 2.3 f_lineno is valid when tracing is active.  At
+       other times we use PyCode_Addr2Line to calculate the line from the
+       current bytecode index and f->f_lineno is -1. */
     int f_lineno;               /* Current line number */
     int f_iblock;               /* index in f_blockstack */
     char f_executing;           /* whether the frame is still executing */

--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -341,10 +341,6 @@ class Bdb:
         if not self.breaks:
             # no breakpoints; run without debugger overhead
             sys.settrace(None)
-            frame = sys._getframe().f_back
-            while frame and frame is not self.botframe:
-                del frame.f_trace
-                frame = frame.f_back
 
     def set_quit(self):
         """Set quitting attribute to True.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-03-23-18-31-12.bpo-24565.8eJzyI.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-03-23-18-31-12.bpo-24565.8eJzyI.rst
@@ -1,0 +1,4 @@
+`f->f_lineno` is now `-1` when tracing is not set. When tracing is
+set, `f->f_lineno` is valid for all the frames on the stack except
+upon starting or resuming a frame where it is -1 until the first
+call to :c:func:`maybe_call_line_trace()`.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -5094,7 +5094,7 @@ static void
 maybe_dtrace_line(PyFrameObject *frame,
                   int *instr_lb, int *instr_ub, int *instr_prev)
 {
-    int line;
+    int line = -1;
     const char *co_filename, *co_name;
 
     /* If the last instruction executed isn't in the current
@@ -5106,14 +5106,14 @@ maybe_dtrace_line(PyFrameObject *frame,
                                        &bounds);
         *instr_lb = bounds.ap_lower;
         *instr_ub = bounds.ap_upper;
-    } else {
-        line = PyFrame_GetLineNumber(frame);
     }
-
     /* If the last instruction falls at the start of a line or if
        it represents a jump backwards, update the frame's line
        number and call the trace function. */
     if (frame->f_lasti == *instr_lb || frame->f_lasti < *instr_prev) {
+        if (line == -1) {
+            line = PyFrame_GetLineNumber(frame);
+        }
         co_filename = PyUnicode_AsUTF8(frame->f_code->co_filename);
         if (!co_filename)
             co_filename = "?";


### PR DESCRIPTION
When tracing is set, f->f_lineno is valid for all the frames of the
stack except upon starting or resuming a frame where it is -1 until
the first call to maybe_call_line_trace().

Fix issues [7238](https://bugs.python.org/issue7238), [16482](https://bugs.python.org/issue16482), [17277](https://bugs.python.org/issue17277) and [17697](https://bugs.python.org/issue17697).


<!-- issue-number: bpo-24565 -->
https://bugs.python.org/issue24565
<!-- /issue-number -->
