### PR TITLE
bpo-33053: Remove test_cmd_line_script debugging print

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -125,8 +125,6 @@ class CmdLineTest(unittest.TestCase):
             script_exec_args = [script_exec_args]
         run_args = [*support.optim_args_from_interpreter_flags(),
                     *cmd_line_switches, *script_exec_args, *example_args]
-        if env_vars:
-            print(env_vars)
         rc, out, err = assert_python_ok(
             *run_args, __isolated=False, __cwd=cwd, **env_vars
         )


### PR DESCRIPTION
I noticed this had slipped into the original commit when
resolving a merge conflict for the backport to 3.7.


<!-- issue-number: bpo-33053 -->
https://bugs.python.org/issue33053
<!-- /issue-number -->
