### PR TITLE
bpo-24132: refactor pathlib to allow easy subclassing

### DIFF
--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -22,9 +22,9 @@ except ImportError:
 class _BaseFlavourTest(object):
 
     def _check_parse_parts(self, arg, expected):
-        f = self.flavour.parse_parts
-        sep = self.flavour.sep
-        altsep = self.flavour.altsep
+        f = self._parse_parts
+        sep = self.sep
+        altsep = self.altsep
         actual = f([x.replace('/', sep) for x in arg])
         self.assertEqual(actual, expected)
         if altsep:
@@ -33,7 +33,7 @@ class _BaseFlavourTest(object):
 
     def test_parse_parts_common(self):
         check = self._check_parse_parts
-        sep = self.flavour.sep
+        sep = self.sep
         # Unanchored parts
         check([],                   ('', '', []))
         check(['a'],                ('', '', ['a']))
@@ -60,8 +60,7 @@ class _BaseFlavourTest(object):
         check(['a', '/b', '/c'],    ('', sep, [sep, 'c']))
 
 
-class PosixFlavourTest(_BaseFlavourTest, unittest.TestCase):
-    flavour = pathlib._posix_flavour
+class PosixFlavourTest(_BaseFlavourTest, unittest.TestCase, pathlib.PurePosixPath):
 
     def test_parse_parts(self):
         check = self._check_parse_parts
@@ -76,7 +75,7 @@ class PosixFlavourTest(_BaseFlavourTest, unittest.TestCase):
         check(['\\a'],                  ('', '', ['\\a']))
 
     def test_splitroot(self):
-        f = self.flavour.splitroot
+        f = self._splitroot
         self.assertEqual(f(''), ('', '', ''))
         self.assertEqual(f('a'), ('', '', 'a'))
         self.assertEqual(f('a/b'), ('', '', 'a/b'))
@@ -96,8 +95,7 @@ class PosixFlavourTest(_BaseFlavourTest, unittest.TestCase):
         self.assertEqual(f('\\a\\b'), ('', '', '\\a\\b'))
 
 
-class NTFlavourTest(_BaseFlavourTest, unittest.TestCase):
-    flavour = pathlib._windows_flavour
+class NTFlavourTest(_BaseFlavourTest, unittest.TestCase, pathlib.PureWindowsPath):
 
     def test_parse_parts(self):
         check = self._check_parse_parts
@@ -134,7 +132,7 @@ class NTFlavourTest(_BaseFlavourTest, unittest.TestCase):
         check(['//?/Z:/a', '/b', 'c'],  ('\\\\?\\Z:', '\\', ['\\\\?\\Z:\\', 'b', 'c']))
 
     def test_splitroot(self):
-        f = self.flavour.splitroot
+        f = self._splitroot
         self.assertEqual(f(''), ('', '', ''))
         self.assertEqual(f('a'), ('', '', 'a'))
         self.assertEqual(f('a\\b'), ('', '', 'a\\b'))
@@ -182,10 +180,8 @@ class _BasePurePathTest(object):
     }
 
     def setUp(self):
-        p = self.cls('a')
-        self.flavour = p._flavour
-        self.sep = self.flavour.sep
-        self.altsep = self.flavour.altsep
+        self.sep = self.cls.sep
+        self.altsep = self.cls.altsep
 
     def test_constructor_common(self):
         P = self.cls


### PR DESCRIPTION
`PurePath` and `Path` are now just variables pointing at the
corresponding classes (resp. PurePosixPath or PureWindowsPath, and
PosixPath or WindowsPath) depending on the platform running the code.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-24132 -->
https://bugs.python.org/issue24132
<!-- /issue-number -->
