### PR TITLE
bpo-31920: Fixed handling directories as arguments in the pygettext script.

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -852,6 +852,7 @@ Maksim Kozyarchuk
 Stefan Krah
 Rolf Krahl
 Bob Kras
+Oleg Krasnikov
 Sebastian Kreft
 Holger Krekel
 Michael Kremer

--- a/Misc/NEWS.d/next/Tools-Demos/2018-03-26-18-54-24.bpo-31920.u_WKsT.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2018-03-26-18-54-24.bpo-31920.u_WKsT.rst
@@ -1,0 +1,2 @@
+Fixed handling directories as arguments in the ``pygettext`` script. Based
+on patch by Oleg Krasnikov.

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -259,24 +259,6 @@ def containsAny(str, set):
     return 1 in [c in str for c in set]
 
 
-def _visit_pyfiles(list, dirname, names):
-    """Helper for getFilesForName()."""
-    # get extension for python source files
-    if '_py_ext' not in globals():
-        global _py_ext
-        _py_ext = importlib.machinery.SOURCE_SUFFIXES[0]
-
-    # don't recurse into CVS directories
-    if 'CVS' in names:
-        names.remove('CVS')
-
-    # add all *.py files to list
-    list.extend(
-        [os.path.join(dirname, file) for file in names
-         if os.path.splitext(file)[1] == _py_ext]
-        )
-
-
 def getFilesForName(name):
     """Get a list of module files for a filename, a module or package name,
     or a directory.
@@ -302,7 +284,17 @@ def getFilesForName(name):
     if os.path.isdir(name):
         # find all python files in directory
         list = []
-        os.walk(name, _visit_pyfiles, list)
+        # get extension for python source files
+        _py_ext = importlib.machinery.SOURCE_SUFFIXES[0]
+        for root, dirs, files in os.walk(name):
+            # don't recurse into CVS directories
+            if 'CVS' in dirs:
+                dirs.remove('CVS')
+            # add all *.py files to list
+            list.extend(
+                [os.path.join(root, file) for file in files
+                 if os.path.splitext(file)[1] == _py_ext]
+                )
         return list
     elif os.path.exists(name):
         # a single file


### PR DESCRIPTION
Based on patch by Oleg Krasnikov (#4225).


<!-- issue-number: bpo-31920 -->
https://bugs.python.org/issue31920
<!-- /issue-number -->
