### PR TITLE
bpo-33141: Have dataclasses.Field pass through __set_name__ to any default descriptor.

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -248,12 +248,11 @@ class Field:
     #  the default value, so the end result is a descriptor that had
     #  __set_name__ called on it at the right time.
     def __set_name__(self, owner, name):
-        if inspect.ismethoddescriptor(self.default):
-            func = getattr(self.default, '__set_name__', None)
-            if func:
-                # There is a __set_name__ method on the descriptor,
-                #  call it.
-                func(owner, name)
+        func = getattr(self.default, '__set_name__', None)
+        if func:
+            # There is a __set_name__ method on the descriptor,
+            #  call it.
+            func(owner, name)
 
 
 class _DataclassParams:

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -710,18 +710,6 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen):
                 #  all in the post-processed class.
                 delattr(cls, f.name)
             else:
-                # Because this class was initially initialized with a
-                #  Field object, if we're overwriting that with a
-                #  method descriptor then the descriptor's
-                #  .__set_name__ method will not have been called at
-                #  class creation time.  Manually call __set_name__
-                #  here, if it exists.
-                ## if inspect.ismethoddescriptor(f.default):
-                ##     func = getattr(f.default, '__set_name__', None)
-                ##     if func:
-                ##         # There is a __set_name__ method on the
-                ##         #  descriptor, call it.
-                ##         func(cls, f.name)
                 setattr(cls, f.name, f.default)
 
     # Do we have any Field members that don't also have annotations?

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -695,6 +695,8 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen):
                 #  all in the post-processed class.
                 delattr(cls, f.name)
             else:
+                if inspect.ismethoddescriptor(f.default):
+                    print('setting method descriptor')
                 setattr(cls, f.name, f.default)
 
     # Do we have any Field members that don't also have annotations?

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2698,6 +2698,35 @@ class TestSlots(unittest.TestCase):
         # We can add a new field to the derived instance.
         d.z = 10
 
+class TestDescriptors(unittest.TestCase):
+    def test_set_name(self):
+        # See bpo-33141.
+
+        # Create a descriptor.
+        class D:
+            def __set_name__(self, owner, name):
+                self.name = name
+            def __get__(self, instance, owner):
+                if instance is not None:
+                    return 1
+                return self
+
+        # This is the case of just normal descriptor behavior, no
+        #  dataclass code is involved in initializing the descriptor.
+        @dataclass
+        class C:
+            c: int=D()
+        self.assertEqual(C.c.name, 'c')
+
+        # Now test with a default value and init=False, which is the
+        #  only time this is really meaningful.  If not using
+        #  init=False, then the descriptor will be overwritten, anyway.
+        @dataclass
+        class C:
+            c: int=field(default=D(), init=False)
+        self.assertEqual(C.c.name, 'c')
+        self.assertEqual(C().c, 1)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -2727,6 +2727,19 @@ class TestDescriptors(unittest.TestCase):
         self.assertEqual(C.c.name, 'c')
         self.assertEqual(C().c, 1)
 
+    def test_non_descriptor(self):
+        # PEP 487 says __set_name__ should work on non-descriptors.
+        # Create a descriptor.
+
+        class D:
+            def __set_name__(self, owner, name):
+                self.name = name
+
+        @dataclass
+        class C:
+            c: int=field(default=D(), init=False)
+        self.assertEqual(C.c.name, 'c')
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-03-26-12-33-13.bpo-33141.23wlxf.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-26-12-33-13.bpo-33141.23wlxf.rst
@@ -1,0 +1,2 @@
+Have Field objects pass through __set_name__ to their default values, if
+they have their own __set_name__.


### PR DESCRIPTION


<!-- issue-number: bpo-33141 -->
https://bugs.python.org/issue33141
<!-- /issue-number -->
