### PR TITLE
bpo-33159: Add name attribute to NameError

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -80,6 +80,9 @@ Other Language Changes
 * Added support of ``\N{name}`` escapes in :mod:`regular expressions <re>`.
   (Contributed by Jonathan Eunice and Serhiy Storchaka in :issue:`30688`.)
 
+* PEP 473 Support: the error ``NameError`` has now an optional ``name``
+  attribute.
+
 
 New Modules
 ===========

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -65,6 +65,12 @@ typedef struct {
     PyObject *value;
 } PyStopIterationObject;
 
+typedef struct {
+    PyException_HEAD
+    PyObject *msg;
+    PyObject *name;
+} PyNameErrorObject;
+
 /* Compatibility typedefs */
 typedef PyOSErrorObject PyEnvironmentErrorObject;
 #ifdef MS_WINDOWS
@@ -313,6 +319,14 @@ PyAPI_FUNC(PyObject *) PyErr_SetImportErrorSubclass(PyObject *, PyObject *,
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
 PyAPI_FUNC(PyObject *) PyErr_SetImportError(PyObject *, PyObject *,
     PyObject *);
+#endif
+
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03060000
+PyAPI_FUNC(PyObject *) PyErr_SetNameErrorSubclass(PyObject *, PyObject *,
+    PyObject *);
+#endif
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03030000
+PyAPI_FUNC(PyObject *) PyErr_SetNameError(PyObject *, PyObject *);
 #endif
 
 /* Export the old function so that the existing API remains available: */

--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-08-18-30-36.bpo-33159.C2FXjN.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-08-18-30-36.bpo-33159.C2FXjN.rst
@@ -1,0 +1,1 @@
+PEP 473 Support: ``NameError`` has now an optional ``name`` attribue.


### PR DESCRIPTION
This is the first change to implement PEP 473.

The plan is to add the attributes described in the PEP one exeption at a time, adjusting the most common places where the exceptions are raised to also include the structured data.
Once the exceptions have been updated, the next step would be to update the Python code and the remaining places where exceptions are raised in the C code.

Note: This is my first PR to cpython, so if anything is amiss I would be happy to fix it.

See https://github.com/python/cpython/issues/81978, https://bugs.python.org/issue37797 and https://bugs.python.org/issue33159 for extra context.

<!-- issue-number: [bpo-33159](https://bugs.python.org/issue33159) -->
https://bugs.python.org/issue33159
<!-- /issue-number -->
