### PR TITLE
Correct note about default behavior of logging.handlers.DatagramHandler

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -524,7 +524,7 @@ over UDP sockets.
 
    .. versionchanged:: 3.4
       If ``port`` is specified as ``None``, a Unix domain socket is created
-      using the value in ``host`` - otherwise, a TCP socket is created.
+      using the value in ``host`` - otherwise, a UDP socket is created.
 
    .. method:: emit()
 


### PR DESCRIPTION
This trivial fix changes `TCP` to `UDP` in what appeared to be a copy-paste error.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
