### PR TITLE
bpo-33128 Fix duplicated call to importlib._install_external_importers 

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -852,6 +852,9 @@ class SysModuleTest(unittest.TestCase):
         check(-1<<1000, [traceback[-1]])
         check(None, traceback)
 
+    def test_no_duplicates_in_meta_path(self):
+        self.assertEqual(len(sys.meta_path), len(set(sys.meta_path)))
+
 
 @test.support.cpython_only
 class SizeofTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-24-22-31-04.bpo-33128.g2yLuf.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-24-22-31-04.bpo-33128.g2yLuf.rst
@@ -1,0 +1,2 @@
+Fix a bug that causes PathFinder to appear twice on sys.meta_path. Patch by
+Pablo Galindo Salgado.

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -325,11 +325,6 @@ initimport(PyInterpreterState *interp, PyObject *sysmod)
 
     /* Install importlib as the implementation of import */
     value = PyObject_CallMethod(importlib, "_install", "OO", sysmod, impmod);
-    if (value != NULL) {
-        Py_DECREF(value);
-        value = PyObject_CallMethod(importlib,
-                                    "_install_external_importers", "");
-    }
     if (value == NULL) {
         PyErr_Print();
         return _Py_INIT_ERR("importlib install failed");


### PR DESCRIPTION

<!-- issue-number: bpo-33128 -->
https://bugs.python.org/issue33128
<!-- /issue-number -->

It seems that in 1abcf6700b4da6207fe859de40c6c1bada6b4fec `_Py_InitializeEx_Private` calls  `_Py_InitializeCore` and `_Py_InitializeMainInterpreter`. The first one calls at the end `initimport` that in turns calls `importlib._install_external_importers` that sets the `PathFinder` in  `sys.meta_path`. Then, `_Py_InitializeMainInterpreter` calls  `initexternalimport` that in turns calls again `importlib._install_external_importers` and therefore we end with two `PathFinders` in `sys.meta_path`.

This PR eliminates duplicated calls to `importlib._install_external_importers`.