### PR TITLE
bpo-33161: pathlib is refactored.

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -242,10 +242,7 @@ class _WindowsFlavour(_Flavour):
         elif 'USERPROFILE' in os.environ:
             userhome = os.environ['USERPROFILE']
         elif 'HOMEPATH' in os.environ:
-            try:
-                drv = os.environ['HOMEDRIVE']
-            except KeyError:
-                drv = ''
+            drv = os.environ.get('HOMEDRIVE', '')
             userhome = drv + os.environ['HOMEPATH']
         else:
             raise RuntimeError("Can't determine home directory")

--- a/Misc/NEWS.d/next/Library/2018-03-28-04-13-59.bpo-33161.vTXVGK.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-28-04-13-59.bpo-33161.vTXVGK.rst
@@ -1,0 +1,2 @@
+pathlib's _WindowsBehavior.gethomedir method is refactored to use dict's get
+method rather than using KeyError handling.


### PR DESCRIPTION
pathlib's _WindowsBehavior.gethomedir method is refactored to use dict's get method rather than using KeyError handling.

<!-- issue-number: bpo-33161 -->
https://bugs.python.org/issue33161
<!-- /issue-number -->
