### PR TITLE
bpo-32872: Avoid regrtest compatibility issue with namespace packages.

### DIFF
--- a/Lib/test/libregrtest/setup.py
+++ b/Lib/test/libregrtest/setup.py
@@ -57,7 +57,7 @@ def setup_tests(ns):
         if hasattr(module, '__path__'):
             for index, path in enumerate(module.__path__):
                 module.__path__[index] = os.path.abspath(path)
-        if hasattr(module, '__file__'):
+        if getattr(module, '__file__', None):
             module.__file__ = os.path.abspath(module.__file__)
 
     # MacOSX (a.k.a. Darwin) has a default stack size that is too small

--- a/Misc/NEWS.d/next/Tests/2018-03-28-01-35-02.bpo-32872.J5NDUj.rst
+++ b/Misc/NEWS.d/next/Tests/2018-03-28-01-35-02.bpo-32872.J5NDUj.rst
@@ -1,0 +1,1 @@
+Avoid regrtest compatibility issue with namespace packages.


### PR DESCRIPTION


<!-- issue-number: bpo-32872 -->
https://bugs.python.org/issue32872
<!-- /issue-number -->
