### PR TITLE
bpo-32726: Do not force IDLE.app to launch in 32-bit mode.

### DIFF
--- a/Mac/Makefile.in
+++ b/Mac/Makefile.in
@@ -221,10 +221,6 @@ install_IDLE:
 	-test -d "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app" && rm -rf "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app"
 	/bin/cp -PR "$(srcdir)/IDLE/IDLE.app" "$(DESTDIR)$(PYTHONAPPSDIR)"
 	ln -sf "$(INSTALLED_PYTHONAPP)" "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/Python"
-ifneq ($(LIPO_32BIT_FLAGS),)
-	rm "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/Python"
-	lipo $(LIPO_32BIT_FLAGS) -output "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/Python" "$(BUILDPYTHON)"
-endif
 	sed -e "s!%prefix%!$(prefix)!g" -e 's!%exe%!$(PYTHONFRAMEWORK)!g' < "$(srcdir)/IDLE/IDLE.app/Contents/MacOS/IDLE" > "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/MacOS/IDLE"
 	sed "s!%version%!`$(RUNSHARED) $(BUILDPYTHON) -c 'import platform; print(platform.python_version())'`!g" < "$(srcdir)/IDLE/IDLE.app/Contents/Info.plist" > "$(DESTDIR)$(PYTHONAPPSDIR)/IDLE.app/Contents/Info.plist"
 	if [ -f "$(DESTDIR)$(LIBDEST)/idlelib/config-main.def" ]; then \


### PR DESCRIPTION
Forcing the macOS IDLE.app gui process to launch in 32-mode was
a necessary hack for old versions of Tk (Aqua Carbon as in Tk 8.4
and early versions of 8.5); it is not needed for current versions
of Tk.  Since 32-bit launching will no longer be supported on
future releases of macOS, allow IDLE.app to launch in 64-bit mode.


<!-- issue-number: bpo-32726 -->
https://bugs.python.org/issue32726
<!-- /issue-number -->
