### PR TITLE
bpo-33163: Upgrade pip to 9.0.3 and setuptools to v39.0.1.

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-03-28-04-15-03.bpo-33163.hfpWuU.rst
+++ b/Misc/NEWS.d/next/Build/2018-03-28-04-15-03.bpo-33163.hfpWuU.rst
@@ -1,0 +1,1 @@
+Upgrade pip to 9.0.3 and setuptools to v39.0.1.


### PR DESCRIPTION


<!-- issue-number: bpo-33163 -->
https://bugs.python.org/issue33163
<!-- /issue-number -->
