### PR TITLE
bpo-33144: random.Random and subclasses: split _randbelow implementation

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -38,7 +38,6 @@ General notes on the underlying Mersenne Twister core generator:
 """
 
 from warnings import warn as _warn
-from types import FunctionType as _FunctionType
 from math import log as _log, exp as _exp, pi as _pi, e as _e, ceil as _ceil
 from math import sqrt as _sqrt, acos as _acos, cos as _cos, sin as _sin
 from os import urandom as _urandom
@@ -95,16 +94,26 @@ class Random(_random.Random):
         self.gauss_next = None
 
     def __init_subclass__(cls, **kwargs):
-        # Only call self.getrandbits if the original random() builtin method
-        # has not been overridden or if a new getrandbits() was supplied.
-        if type(cls.__dict__.get('getrandbits')) is _FunctionType:
+        """Control how subclasses generate random integers.
+
+        The algorithm a subclass can use depends on the random() and/or
+        getrandbits() implementation available to it and determines
+        whether it can generate random integers from arbitrarily large
+        ranges.
+        """
+
+        if (cls.random is _random.Random.random) or (
+            cls.getrandbits is not _random.Random.getrandbits):
+            # The original random() builtin method has not been overridden
+            # or a new getrandbits() was supplied.
+            # The subclass can use the getrandbits-dependent implementation
+            # of _randbelow().
             cls._randbelow = cls._randbelow_with_getrandbits
-        elif 'random' in cls.__dict__:
-            # There's an overridden random() method but no new getrandbits() method,
-            # so we can only use random() from here.
-            cls._randbelow = cls._randbelow_without_getrandbits
         else:
-            cls._randbelow = getattr(cls, cls._randbelow.__name__)
+            # There's an overridden random() method but no new getrandbits(),
+            # so the subclass can only use the getrandbits-independent
+            # implementation of _randbelow().
+            cls._randbelow = cls._randbelow_without_getrandbits
 
     def seed(self, a=None, version=2):
         """Initialize internal state from hashable object.

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -249,9 +249,6 @@ class Random(_random.Random):
         The implementation does not use getrandbits, but only random.
         """
 
-        if n == 0:
-            raise ValueError("Upper boundary cannot be zero")
-
         random = self.random
         if n >= maxsize:
             _warn("Underlying random() generator does not supply \n"

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -640,21 +640,22 @@ class MersenneTwister_TestBasicOps(TestBasicOps, unittest.TestCase):
             self.assertEqual(k, numbits)        # note the stronger assertion
             self.assertTrue(2**k > n > 2**(k-1))   # note the stronger assertion
 
-    @unittest.mock.patch('random.Random.random')
-    def test_randbelow_overridden_random(self, random_mock):
+    def test_randbelow_without_getrandbits(self):
         # Random._randbelow() can only use random() when the built-in one
         # has been overridden but no new getrandbits() method was supplied.
-        random_mock.side_effect = random.SystemRandom().random
         maxsize = 1<<random.BPF
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)
             # Population range too large (n >= maxsize)
-            self.gen._randbelow(maxsize+1, maxsize = maxsize)
-        self.gen._randbelow(5640, maxsize = maxsize)
+            self.gen._randbelow_without_getrandbits(
+                maxsize+1, maxsize=maxsize
+            )
+        self.gen._randbelow_without_getrandbits(5640, maxsize=maxsize)
         # issue 33203: test that _randbelow raises ValueError on
         # n == 0 also in its getrandbits-independent branch.
         with self.assertRaises(ValueError):
-            self.gen._randbelow(0, maxsize=maxsize)
+            self.gen._randbelow_without_getrandbits(0, maxsize=maxsize)
+
         # This might be going too far to test a single line, but because of our
         # noble aim of achieving 100% test coverage we need to write a case in
         # which the following line in Random._randbelow() gets executed:
@@ -672,8 +673,10 @@ class MersenneTwister_TestBasicOps(TestBasicOps, unittest.TestCase):
         n = 42
         epsilon = 0.01
         limit = (maxsize - (maxsize % n)) / maxsize
-        random_mock.side_effect = [limit + epsilon, limit - epsilon]
-        self.gen._randbelow(n, maxsize = maxsize)
+        with unittest.mock.patch.object(random.Random, 'random') as random_mock:
+            random_mock.side_effect = [limit + epsilon, limit - epsilon]
+            self.gen._randbelow_without_getrandbits(n, maxsize=maxsize)
+            self.assertEqual(random_mock.call_count, 2)
 
     def test_randrange_bug_1590891(self):
         start = 1000000000000
@@ -926,6 +929,81 @@ class TestDistributions(unittest.TestCase):
         gammavariate_mock.return_value = 0.0
         self.assertEqual(0.0, random.betavariate(2.71828, 3.14159))
 
+class TestRandomSubclassing(unittest.TestCase):
+    def test_random_subclass_with_kwargs(self):
+        # SF bug #1486663 -- this used to erroneously raise a TypeError
+        class Subclass(random.Random):
+            def __init__(self, newarg=None):
+                random.Random.__init__(self)
+        Subclass(newarg=1)
+
+    def test_overriding_random(self):
+        # First, let's assert our base class gets the selection of its
+        # _randbelow implementation right.
+        self.assertIs(
+            random.Random._randbelow, random.Random._randbelow_with_getrandbits
+        )
+
+        # Subclasses with a random method that got more recently defined than
+        # their getrandbits method should not rely on getrandbits in
+        # _randbelow, but select the getrandbits-independent implementation
+        # of _randbelow instead.
+
+        # Subclass doesn't override any of the methods => keep using
+        # original getrandbits-dependent version of _randbelow
+        class SubClass1(random.Random):
+            pass
+        self.assertIs(
+            SubClass1._randbelow, random.Random._randbelow_with_getrandbits
+        )
+        # subclass providing its own random **and** getrandbits methods
+        # like random.SystemRandom does => keep relying on getrandbits for
+        # _randbelow
+        class SubClass2(random.Random):
+            def random(self):
+                pass
+
+            def getrandbits(self):
+                pass
+        self.assertIs(
+            SubClass2._randbelow, random.Random._randbelow_with_getrandbits
+        )
+        # subclass providing only random => switch to getrandbits-independent
+        # version of _randbelow
+        class SubClass3(random.Random):
+            def random(self):
+                pass
+        self.assertIs(
+            SubClass3._randbelow, random.Random._randbelow_without_getrandbits
+        )
+        # subclass defining getrandbits to complement its inherited random
+        # => can now rely on getrandbits for _randbelow again
+        class SubClass4(SubClass3):
+            def getrandbits(self):
+                pass
+        self.assertIs(
+            SubClass4._randbelow, random.Random._randbelow_with_getrandbits
+        )
+        # subclass overriding the getrandbits-dependent implementation of
+        # _randbelow => make sure it is used
+        class SubClass5(SubClass4):
+            def _randbelow_with_getrandbits(self):
+                pass
+        self.assertIs(
+            SubClass5._randbelow, SubClass5._randbelow_with_getrandbits
+        )
+        self.assertIsNot(
+            SubClass5._randbelow, random.Random._randbelow_with_getrandbits
+        )
+        # subclass defining random making it more recent than its inherited
+        # getrandbits => switch back to getrandbits-independent implementaion
+        class SubClass6(SubClass5):
+            def random(self):
+                pass
+        self.assertIs(
+            SubClass6._randbelow, random.Random._randbelow_without_getrandbits
+        )
+
 class TestModule(unittest.TestCase):
     def testMagicConstants(self):
         self.assertAlmostEqual(random.NV_MAGICCONST, 1.71552776992141)
@@ -936,13 +1014,6 @@ class TestModule(unittest.TestCase):
     def test__all__(self):
         # tests validity but not completeness of the __all__ list
         self.assertTrue(set(random.__all__) <= set(dir(random)))
-
-    def test_random_subclass_with_kwargs(self):
-        # SF bug #1486663 -- this used to erroneously raise a TypeError
-        class Subclass(random.Random):
-            def __init__(self, newarg=None):
-                random.Random.__init__(self)
-        Subclass(newarg=1)
 
     @unittest.skipUnless(hasattr(os, "fork"), "fork() required")
     def test_after_fork(self):

--- a/Misc/NEWS.d/next/Library/2018-04-10-14-50-30.bpo-33144.iZr4et.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-10-14-50-30.bpo-33144.iZr4et.rst
@@ -1,0 +1,4 @@
+``random.Random()`` and its subclassing mechanism got optimized to check only
+once at class/subclass instantiation time whether its ``getrandbits()`` method
+can be relied on by other methods, including ``randrange()``, for the
+generation of arbitrarily large random integers.  Patch by Wolfgang Maier.


### PR DESCRIPTION
Splits the getrandbits-dependent and -independent branches of
random.Random._randbelow into separate methods and selects the
implementation to be used by Random and its subclasses at class
creation time for increased performance.



<!-- issue-number: bpo-33144 -->
https://bugs.python.org/issue33144
<!-- /issue-number -->
