### PR TITLE
bpo-33173: Return Underlying fileobj's Seekability in GzipFile.seekable

### DIFF
--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -347,7 +347,7 @@ class GzipFile(_compression.BaseStream):
         return self.mode == WRITE
 
     def seekable(self):
-        return True
+        return self.fileobj.seekable()
 
     def seek(self, offset, whence=io.SEEK_SET):
         if self.mode == WRITE:

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -530,6 +530,14 @@ class TestGzip(BaseTest):
         with gzip.open(self.filename, "rb") as f:
             f._buffer.raw._fp.prepend()
 
+    def test_seekable(self):
+        seekable = gzip.GzipFile(fileobj=io.BytesIO())
+        not_seekable = gzip.GzipFile(fileobj=UnseekableIO())
+
+        self.assertTrue(seekable.seekable())
+        self.assertFalse(not_seekable.seekable())
+
+
 class TestOpen(BaseTest):
     def test_binary_modes(self):
         uncompressed = data1 * 50

--- a/Misc/NEWS.d/next/Library/2018-03-29-12-33-07.bpo-33173.pV0Y1o.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-29-12-33-07.bpo-33173.pV0Y1o.rst
@@ -1,0 +1,2 @@
+gzip.GzipFile's seekable() method returns the seek-ability of its underlying
+file object


### PR DESCRIPTION
Does something along these lines seem reasonable? 
I ran into an issue where the seekable() method was returning true despite the underlying fileobj not being seekable, which lead to errors when a consumer of the GzipFile used the results of the seekable() method as evidence it was safe to call seek.

<!-- issue-number: bpo-33173 -->
https://bugs.python.org/issue33173
<!-- /issue-number -->
