### PR TITLE
bpo-33175: dataclasses should look up __set_name__ on class, not instance

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -248,11 +248,11 @@ class Field:
     #  the default value, so the end result is a descriptor that had
     #  __set_name__ called on it at the right time.
     def __set_name__(self, owner, name):
-        func = getattr(self.default, '__set_name__', None)
+        func = getattr(type(self.default), '__set_name__', None)
         if func:
             # There is a __set_name__ method on the descriptor,
             #  call it.
-            func(owner, name)
+            func(self.default, owner, name)
 
 
 class _DataclassParams:

--- a/Misc/NEWS.d/next/Library/2018-03-29-04-32-25.bpo-33175._zs1yM.rst
+++ b/Misc/NEWS.d/next/Library/2018-03-29-04-32-25.bpo-33175._zs1yM.rst
@@ -1,0 +1,2 @@
+In dataclasses, Field.__set_name__ now looks up the __set_name__ special
+method on the class, not the instance, of the default value.


### PR DESCRIPTION


<!-- issue-number: bpo-33175 -->
https://bugs.python.org/issue33175
<!-- /issue-number -->
