### PR TITLE
bpo-32726: macOS 10.6+ installer now builds Tcl/TK 8.6

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -4,7 +4,7 @@ This script is used to build "official" universal installers on macOS.
 
 NEW for 3.7.0:
 - support Intel 64-bit-only () and 32-bit-only installer builds
-- use external Tcl/Tk 8.6 for 10.9+ builds
+- build and use internal Tcl/Tk 8.6 for 10.6+ builds
 - deprecate use of explicit SDK (--sdk-path=) since all but the oldest
   versions of Xcode support implicit setting of an SDK via environment
   variables (SDKROOT and friends, see the xcrun man page for more info).
@@ -24,7 +24,9 @@ Sphinx and dependencies are installed into a venv using the python3's pip
 so will fetch them from PyPI if necessary.  Since python3 is now used for
 Sphinx, build-installer.py should also be converted to use python3!
 
-build-installer currently requires an installed third-party version of
+For 3.7.0, when building for a 10.6 or higher deployment target,
+build-installer builds and links with its own copy of Tcl/Tk 8.6.
+Otherwise, it requires an installed third-party version of
 Tcl/Tk 8.4 (for OS X 10.4 and 10.5 deployment targets), Tcl/TK 8.5
 (for 10.6 or later), or Tcl/TK 8.6 (for 10.9 or later)
 installed in /Library/Frameworks.  When installed,
@@ -190,9 +192,9 @@ USAGE = textwrap.dedent("""\
 EXPECTED_SHARED_LIBS = {}
 
 # Are we building and linking with our own copy of Tcl/TK?
-#   For now, do so if deployment target is 10.9+.
+#   For now, do so if deployment target is 10.6+.
 def internalTk():
-    return getDeptargetTuple() >= (10, 9)
+    return getDeptargetTuple() >= (10, 6)
 
 # List of names of third party software built with this installer.
 # The names will be inserted into the rtf version of the License.

--- a/Mac/BuildScript/resources/ReadMe.rtf
+++ b/Mac/BuildScript/resources/ReadMe.rtf
@@ -53,16 +53,10 @@ The bundled
 \f0  included with this installer has its own default certificate store for verifying download connections.\
 \
 
-\b \ul Using IDLE or other Tk applications [NEW/CHANGED in 3.7.0b1] 
+\b \ul Using IDLE or other Tk applications [NEW/CHANGED in 3.7.0b3] 
 \b0 \ulnone \
 \
-The 10.9+ installer variant comes with its own private version of Tcl/Tk 8.6. It does not use system-supplied or third-party supplied versions of Tcl/Tk.\
-\
-For the 10.6+ variant, you continue to need to install a newer third-party version of the 
-\i Tcl/Tk
-\i0  8.5 (not 8.6) frameworks to use IDLE or other programs that use the Tkinter graphical user interface toolkit.  Visit {\field{\*\fldinst{HYPERLINK "https://www.python.org/download/mac/tcltk/"}}{\fldrslt https://www.python.org/download/mac/tcltk/}} for current information about supported and recommended versions of 
-\i Tcl/Tk
-\i0  for this version of Python and of macOS.\
+Both installer variants come with their own private version of Tcl/Tk 8.6. They no longer use system-supplied or third-party supplied versions of Tcl/Tk.\
 
 \b \ul \
 Other changes\

--- a/Mac/BuildScript/resources/Welcome.rtf
+++ b/Mac/BuildScript/resources/Welcome.rtf
@@ -23,5 +23,5 @@
 \
 
 \b NEW in 3.7.0b1: 
-\b0 two installer variants (10.9+ 64-bit-only, 10.6+ 64-/32-bit), built-in Tcl/Tk 8.6 support in the 10.9+ variant (no additional third-party downloads!), OpenSSL 1.1.0g, and more!\
+\b0 two installer variants (10.9+ 64-bit-only, 10.6+ 64-/32-bit), built-in Tcl/Tk 8.6 support (no additional third-party downloads!), OpenSSL 1.1.0g, and more!\
 }

--- a/Misc/NEWS.d/next/macOS/2018-03-29-06-56-12.bpo-32726.urS9uX.rst
+++ b/Misc/NEWS.d/next/macOS/2018-03-29-06-56-12.bpo-32726.urS9uX.rst
@@ -1,0 +1,5 @@
+Build and link with private copy of Tcl/Tk 8.6 for the macOS 10.6+
+installer. The 10.9+ installer variant already does this.  This means that
+the Python 3.7 provided by the python.org macOS installers no longer need or
+use any external versions of Tcl/Tk, either system-provided or user-
+installed, such as ActiveTcl.


### PR DESCRIPTION
Build and link with private copy of Tcl/Tk 8.6 for the macOS 10.6+
installer. The 10.9+ installer variant already does this.  This means that
the Python 3.7 provided by the python.org macOS installers no longer need or
use any external versions of Tcl/Tk, either system-provided or user-
installed, such as ActiveTcl.


<!-- issue-number: bpo-32726 -->
https://bugs.python.org/issue32726
<!-- /issue-number -->
