### PR TITLE
bpo-23495: Correct the documentation for writerows() of csv Writer objects

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -452,8 +452,9 @@ read CSV files (assuming they support complex numbers at all).
 
 .. method:: csvwriter.writerows(rows)
 
-   Write all the *rows* parameters (a list of *row* objects as described above) to
-   the writer's file object, formatted according to the current dialect.
+   Write all elements in *rows* (an iterable of *row* objects as described
+   above) to the writer's file object, formatted according to the current
+   dialect.
 
 Writer objects have the following public attribute:
 


### PR DESCRIPTION
`writerows()` takes an iterable.

<!-- issue-number: bpo-23495 -->
https://bugs.python.org/issue23495
<!-- /issue-number -->
