### PR TITLE
bpo-33188: Allow dynamic creation of generic dataclasses

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1004,7 +1004,9 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
         anns[name] = tp
 
     namespace['__annotations__'] = anns
-    cls = type(cls_name, bases, namespace)
+    # We use `types.new_class()` instead of simply `type()` to allow dynamic creation
+    # of generic dataclassses.
+    cls = types.new_class(cls_name, bases, {}, lambda ns: ns.update(namespace))
     return dataclass(cls, init=init, repr=repr, eq=eq, order=order,
                      unsafe_hash=unsafe_hash, frozen=frozen)
 


### PR DESCRIPTION
As per PEP 560 the only way to dynamically create generic classes is by calling `types.new_class`. It turns out that some users are interested in dynamic creation of generic dataclasses. I propose to allow this, by using `types.new_class()` instead of `type()` in `make_dataclass()`. I propose to don't change the signature of the latter because of this rare use case (but it is not a strong opinion).

<!-- issue-number: bpo-33188 -->
https://bugs.python.org/issue33188
<!-- /issue-number -->
