### PR TITLE
[2.7] Gitignore gmon.out (GH-5796)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ TAGS
 coverage/
 externals/
 htmlcov/
+gmon.out


### PR DESCRIPTION
gmon.out is generated when profiling turned on

Full Configuration:
./configure --prefix=$PWD/install --enable-profiling  --enable-big-digits=30
--with-pydebug --with-assertions  --with-valgrind.
(cherry picked from commit 95ad3822a2b6287772bd752b6ab493c6d4198d4b)

Co-authored-by: Neeraj Badlani <neerajbadlani@gmail.com>
