### PR TITLE
bpo-33203: Ensure random.choice always raises IndexError on empty sequence

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -242,6 +242,8 @@ class Random(_random.Random):
                 "enough bits to choose from a population range this large.\n"
                 "To remove the range limitation, add a getrandbits() method.")
             return int(random() * n)
+        if n == 0:
+            raise ValueError("Boundary cannot be zero")
         rem = maxsize % n
         limit = (maxsize - rem) / maxsize   # int(limit * maxsize) % n == 0
         r = random()

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -651,7 +651,10 @@ class MersenneTwister_TestBasicOps(TestBasicOps, unittest.TestCase):
             # Population range too large (n >= maxsize)
             self.gen._randbelow(maxsize+1, maxsize = maxsize)
         self.gen._randbelow(5640, maxsize = maxsize)
-
+        # issue 33203: test that _randbelow raises ValueError on
+        # n == 0 also in its getrandbits-independent branch.
+        with self.assertRaises(ValueError):
+            self.gen._randbelow(0, maxsize=maxsize)
         # This might be going too far to test a single line, but because of our
         # noble aim of achieving 100% test coverage we need to write a case in
         # which the following line in Random._randbelow() gets executed:

--- a/Misc/NEWS.d/next/Library/2018-04-05-11-09-45.bpo-33203.Hje9Py.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-05-11-09-45.bpo-33203.Hje9Py.rst
@@ -1,0 +1,3 @@
+``random.Random.choice()`` now raises ``IndexError`` for empty sequences
+consistently even when called from subclasses without a ``getrandbits()``
+implementation.


### PR DESCRIPTION
Without this patch a ZeroDivisionError was leaked for Random
subclasses overriding the random, but not the getrandbits method.



<!-- issue-number: bpo-33203 -->
https://bugs.python.org/issue33203
<!-- /issue-number -->
