### PR TITLE
[2.7] bpo-27212: Modify islice recipe to consume initial values prece…

### DIFF
--- a/Misc/NEWS.d/next/Documentation/2018-03-22-19-23-04.bpo-27212.wrE5KR.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-03-22-19-23-04.bpo-27212.wrE5KR.rst
@@ -1,0 +1,2 @@
+Modify documentation for the :func:`islice` recipe to consume initial values
+up to the start index.


### PR DESCRIPTION
…ding start (GH-6195)

(cherry picked from commit da1734c58d2f97387ccc9676074717d38b044128)




<!-- issue-number: bpo-27212 -->
https://bugs.python.org/issue27212
<!-- /issue-number -->
