### PR TITLE
bpo-30940: Updating round() docs.

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1331,7 +1331,8 @@ are always available.  They are listed here in alphabetical order.
    equally close, rounding is done toward the even choice (so, for example,
    both ``round(0.5)`` and ``round(-0.5)`` are ``0``, and ``round(1.5)`` is
    ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
-   negative).  The return value is an integer if *ndigits* is omitted or *None*.
+   negative).  The return value is an integer if *ndigits* is omitted or
+   ``None``.
    Otherwise the return value has the same type as *number*.
 
    For a general Python object ``number``, ``round`` delegates to

--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1331,11 +1331,11 @@ are always available.  They are listed here in alphabetical order.
    equally close, rounding is done toward the even choice (so, for example,
    both ``round(0.5)`` and ``round(-0.5)`` are ``0``, and ``round(1.5)`` is
    ``2``).  Any integer value is valid for *ndigits* (positive, zero, or
-   negative).  The return value is an integer if called with one argument,
-   otherwise of the same type as *number*.
+   negative).  The return value is an integer if *ndigits* is omitted or *None*.
+   Otherwise the return value has the same type as *number*.
 
-   For a general Python object ``number``, ``round(number, ndigits)`` delegates to
-   ``number.__round__(ndigits)``.
+   For a general Python object ``number``, ``round`` delegates to
+   ``number.__round__``.
 
    .. note::
 


### PR DESCRIPTION
Updating the round docs to make it more clear what happens when None is the second argument to round().


<!-- issue-number: bpo-30940 -->
https://bugs.python.org/issue30940
<!-- /issue-number -->
