### PR TITLE
I think it's better to not imply false statements

### DIFF
--- a/Doc/tutorial/interpreter.rst
+++ b/Doc/tutorial/interpreter.rst
@@ -109,11 +109,11 @@ before printing the first prompt:
 Continuation lines are needed when entering a multi-line construct. As an
 example, take a look at this :keyword:`if` statement::
 
-   >>> the_world_is_flat = True
-   >>> if the_world_is_flat:
-   ...     print("Be careful not to fall off!")
+   >>> the_world_is_flat = False
+   >>> if the_world_is_flat == False:
+   ...     print("You won't fall off!")
    ...
-   Be careful not to fall off!
+   You won't fall off!
 
 
 For more on interactive mode, see :ref:`tut-interac`.


### PR DESCRIPTION
My arguments on webmaster@python.org:
A program operates in its own Universe?
- First, the program is operating on a computer, which is based on physical laws, same ones that require enormous masses to be round.

- Second, It's not adding any knowledge. Purpose of a lesson is to impart knowledge, implying obviously false statements is contradictory to purpose of a lesson.

- Third, I think the person who contributed the lesson was just trying to be edgy or sarcastic, which should be corrected out. A tutorial should be properly vetted. At the expense of making the joke, you(not you, but you are not helping resolve it) are lengthening the lesson.

So, I insist.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
