### PR TITLE
bpo-33207: Call super in Generic.__init_subclass__

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1232,6 +1232,25 @@ class GenericTests(BaseTestCase):
         class C(List[int], B): ...
         self.assertEqual(C.__mro__, (C, list, B, Generic, object))
 
+    def test_init_subclass_super_called(self):
+        class FinalException(Exception):
+            pass
+
+        class Final:
+            def __init_subclass__(cls, **kwargs) -> None:
+                for base in cls.__bases__:
+                    if base is not Final and issubclass(base, Final):
+                        raise FinalException(base)
+                super().__init_subclass__(**kwargs)
+        class Test(Generic[T], Final):
+            pass
+        with self.assertRaises(FinalException):
+            class Subclass(Test):
+                pass
+        with self.assertRaises(FinalException):
+            class Subclass(Test[int]):
+                pass
+
     def test_nested(self):
 
         G = Generic

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -850,6 +850,7 @@ class Generic:
         return _GenericAlias(cls, params)
 
     def __init_subclass__(cls, *args, **kwargs):
+        super().__init_subclass__(*args, **kwargs)
         tvars = []
         if '__orig_bases__' in cls.__dict__:
             error = Generic in cls.__orig_bases__


### PR DESCRIPTION
The fix is straightforward -- this just makes `Generic` cooperative by calling `super()`
in `Generic.__init_subclass__`.

<!-- issue-number: bpo-33207 -->
https://bugs.python.org/issue33207
<!-- /issue-number -->
