### PR TITLE
Changed a line where it said "the_world_is_flat"

### DIFF
--- a/Doc/tutorial/interpreter.rst
+++ b/Doc/tutorial/interpreter.rst
@@ -109,11 +109,11 @@ before printing the first prompt:
 Continuation lines are needed when entering a multi-line construct. As an
 example, take a look at this :keyword:`if` statement::
 
-   >>> the_world_is_flat = True
-   >>> if the_world_is_flat:
-   ...     print("Be careful not to fall off!")
+   >>> the_Earth_is_round = True
+   >>> if the_Earth_is_round :
+   ...     print("You won't fall off!")
    ...
-   Be careful not to fall off!
+   You won't fall off!
 
 
 For more on interactive mode, see :ref:`tut-interac`.


### PR DESCRIPTION
# Changed a line where it said "the_world_is_flat"

This was in there since 3rd April, 2000. Science has progressed since and we know better now. This is a duplicate pull request, created because serhiy-storchaka pointed out some errors in #6343.

> You have to create a pull request to the master branch.

I think it's correct now. Base fork: python/cpython base: master

> `the_world_is_flat == False` is an example of extremely bad style.

I went through the [styling guidelines][1]

> Python is full of jokes.

Ok, thanks for stating your observation. But this doesn't make any sense for the PR. Is it a requirement that every line of program in Python be a joke?

Overall, this meets all the suggestions made by serhiy-storchaka. I am not very funny but maybe someone else can come up with a good joke that doesn't imply false statements which are debated _passionately_ to this day.

[1]: https://www.python.org/dev/peps/pep-0008/


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
