### PR TITLE
[3.5] bpo-33216: Correct the doc of CALL_FUNCTION_VAR and CALL_FUNCTION_VAR_KW.

### DIFF
--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1020,9 +1020,10 @@ the more significant byte last.
 
 .. opcode:: CALL_FUNCTION_VAR (argc)
 
-   Calls a function. *argc* is interpreted as in :opcode:`CALL_FUNCTION`. The
-   top elements on the stack are the keyword arguments, followed by the
-   variable argument list, and then the positional arguments.
+   Calls a function. *argc* is interpreted as in :opcode:`CALL_FUNCTION`.  The
+   difference with :opcode:`CALL_FUNCTION`, is that ``CALL_FUNCTION_VAR``
+   finds the var-positional argument below all the keyword parameters, but
+   above all positional parameters.
 
    .. versionchanged:: 3.5
       The order of elements in the stack was changed.
@@ -1037,9 +1038,8 @@ the more significant byte last.
 .. opcode:: CALL_FUNCTION_VAR_KW (argc)
 
    Calls a function. *argc* is interpreted as in :opcode:`CALL_FUNCTION`.  The
-   top element on the stack contains the keyword arguments dictionary,
-   followed by explicit keyword arguments, then the variable-arguments tuple,
-   and finally by the positional arguments.
+   opcode finds the var-keyword argument at the top of the stack; and below,
+   the opcode finds the same items :opcode:`CALL_FUNCTION_VAR` does.
 
    .. versionchanged:: 3.5
       The order of elements in the stack was changed.

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1024,6 +1024,8 @@ the more significant byte last.
    top elements on the stack are the keyword arguments, followed by the
    variable argument list, and then the positional arguments.
 
+   .. versionchanged:: 3.5
+      The order of elements in the stack was changed.
 
 .. opcode:: CALL_FUNCTION_KW (argc)
 
@@ -1039,6 +1041,8 @@ the more significant byte last.
    followed by explicit keyword arguments, then the variable-arguments tuple,
    and finally by the positional arguments.
 
+   .. versionchanged:: 3.5
+      The order of elements in the stack was changed.
 
 .. opcode:: HAVE_ARGUMENT
 

--- a/Doc/library/dis.rst
+++ b/Doc/library/dis.rst
@@ -1021,8 +1021,8 @@ the more significant byte last.
 .. opcode:: CALL_FUNCTION_VAR (argc)
 
    Calls a function. *argc* is interpreted as in :opcode:`CALL_FUNCTION`. The
-   top element on the stack contains the variable argument list, followed by
-   keyword and positional arguments.
+   top elements on the stack are the keyword arguments, followed by the
+   variable argument list, and then the positional arguments.
 
 
 .. opcode:: CALL_FUNCTION_KW (argc)
@@ -1035,9 +1035,9 @@ the more significant byte last.
 .. opcode:: CALL_FUNCTION_VAR_KW (argc)
 
    Calls a function. *argc* is interpreted as in :opcode:`CALL_FUNCTION`.  The
-   top element on the stack contains the keyword arguments dictionary, followed
-   by the variable-arguments tuple, followed by explicit keyword and positional
-   arguments.
+   top element on the stack contains the keyword arguments dictionary,
+   followed by explicit keyword arguments, then the variable-arguments tuple,
+   and finally by the positional arguments.
 
 
 .. opcode:: HAVE_ARGUMENT


### PR DESCRIPTION
The order of the elements in the stack was incorrect.  It seems that, in general (for all CALL_FUNCTION opcodes), the correct order is (from bottom to top):

     function
     positional arguments
     [star arg tuple]
     keyword arguments
     [keyword dictionary]
     CALL_FUNCTION[_..]

Fixes [bug 33216](https://bugs.python.org/issue33216).


<!-- issue-number: bpo-33216 -->
https://bugs.python.org/issue33216
<!-- /issue-number -->
