### PR TITLE
bpo-24882: Let ThreadPoolExecutor reuse idle threads before creating new thread

### DIFF
--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -186,7 +186,7 @@ class ThreadPoolExecutor(_base.Executor):
     submit.__doc__ = _base.Executor.submit.__doc__
 
     def _adjust_thread_count(self):
-        #if idle threads are available, don't spin new threads
+        # if idle threads are available, don't spin new threads
         if self._idle_semaphore.acquire(timeout=0):
             return
 

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -346,10 +346,10 @@ class ThreadPoolShutdownTest(ThreadPoolMixin, ExecutorShutdownTest, BaseTestCase
         pass
 
     def test_threads_terminate(self):
-        self.executor.submit(mul, 21, 2)
-        self.executor.submit(mul, 6, 7)
-        self.executor.submit(mul, 3, 14)
-        self.assertTrue(len(self.executor._threads) < 3)
+        self.executor.submit(mul, 21, 2).result()
+        self.executor.submit(mul, 6, 7).result()
+        self.executor.submit(mul, 3, 14).result()
+        self.assertTrue(len(self.executor._threads) == 1)
         self.executor.shutdown()
         for t in self.executor._threads:
             t.join()
@@ -752,6 +752,10 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
         executor = self.executor_type()
         self.assertEqual(executor._max_workers,
                          (os.cpu_count() or 1) * 5)
+
+    def test_saturation(self):
+        list(self.executor.map(lambda x: mul(0, x), range(100 * self.executor._max_workers)))
+        self.assertEqual(len(self.executor._threads), self.executor._max_workers)
 
 
 class ProcessPoolExecutorTest(ExecutorTest):

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -349,7 +349,7 @@ class ThreadPoolShutdownTest(ThreadPoolMixin, ExecutorShutdownTest, BaseTestCase
         self.executor.submit(mul, 21, 2)
         self.executor.submit(mul, 6, 7)
         self.executor.submit(mul, 3, 14)
-        self.assertEqual(len(self.executor._threads), 3)
+        self.assertTrue(len(self.executor._threads) < 3)
         self.executor.shutdown()
         for t in self.executor._threads:
             t.join()

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -770,7 +770,7 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
         for i in range(100 * executor._max_workers):
             sem.release()
         executor.shutdown(wait=True)
-         
+
     def test_idle_thread_reuse(self):
         executor = self.executor_type()
         executor.submit(mul, 21, 2).result()

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -759,15 +759,15 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
                          (os.cpu_count() or 1) * 5)
 
     def test_saturation(self):
-        executor = self.executor_type()
+        executor = self.executor_type(4)
         def acquire_lock(lock):
             lock.acquire()
 
         sem = threading.Semaphore(0)
-        for i in range(100 * executor._max_workers):
+        for i in range(15 * executor._max_workers):
             executor.submit(acquire_lock, sem)
         self.assertEqual(len(executor._threads), executor._max_workers)
-        for i in range(100 * executor._max_workers):
+        for i in range(15 * executor._max_workers):
             sem.release()
         executor.shutdown(wait=True)
 

--- a/Misc/NEWS.d/next/Library/2018-04-04-14-54-30.bpo-24882.urybpa.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-04-14-54-30.bpo-24882.urybpa.rst
@@ -1,0 +1,1 @@
+Change ThreadPoolExecutor to use existing idle threads before spinning up new ones.


### PR DESCRIPTION
The change fixes an issue where ThreadPoolExecutor doesn't check if existing threads are idle before spinning up new ones. To do this, we use a simple counter within the Executor to track how many threads are idle, and atomically increment and decrement the count as needed. 

One question - the previous code to spin up a new thread in `_adjust_thread_count` does not appear thread safe - if two threads are both submitting items to the executor at the same time, the call to check the number of threads could be invalid. Is this something that should also be fixed, or is this not an issue because of the global interpreter lock?


<!-- issue-number: [bpo-24882](https://bugs.python.org/issue24882) -->
https://bugs.python.org/issue24882
<!-- /issue-number -->
