### PR TITLE
bpo-32873: Remove a name hack for generic aliases in typing module

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1058,14 +1058,15 @@ class GenericTests(BaseTestCase):
             self.assertEqual(x.bar, 'abc')
             self.assertEqual(x.__dict__, {'foo': 42, 'bar': 'abc'})
         samples = [Any, Union, Tuple, Callable, ClassVar,
-                   Union[int, str], ClassVar[List], Tuple[int, ...], Callable[[str], bytes]]
+                   Union[int, str], ClassVar[List], Tuple[int, ...], Callable[[str], bytes],
+                   typing.DefaultDict, typing.FrozenSet[int]]
         for s in samples:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 z = pickle.dumps(s, proto)
                 x = pickle.loads(z)
                 self.assertEqual(s, x)
         more_samples = [List, typing.Iterable, typing.Type, List[int],
-                        typing.Type[typing.Mapping]]
+                        typing.Type[typing.Mapping], typing.AbstractSet[Tuple[int, str]]]
         for s in more_samples:
             for proto in range(pickle.HIGHEST_PROTOCOL + 1):
                 z = pickle.dumps(s, proto)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -611,6 +611,19 @@ class TypeVar(_Final, _Immutable, _root=True):
 # * __args__ is a tuple of all arguments used in subscripting,
 #   e.g., Dict[T, int].__args__ == (T, int).
 
+
+# Mapping from non-generic type names that have a generic alias in typing
+# but with a different name.
+_normalize_alias = {'list': 'List',
+                    'tuple': 'Tuple',
+                    'dict': 'Dict',
+                    'set': 'Set',
+                    'frozenset': 'FrozenSet',
+                    'deque': 'Deque',
+                    'defaultdict': 'DefaultDict',
+                    'type': 'Type',
+                    'Set': 'AbstractSet'}
+
 def _is_dunder(attr):
     return attr.startswith('__') and attr.endswith('__')
 
@@ -629,7 +642,10 @@ class _GenericAlias(_Final, _root=True):
         self._special = special
         if special and name is None:
             orig_name = origin.__name__
-            name = orig_name[0].title() + orig_name[1:]
+            if orig_name in _normalize_alias:
+                name = _normalize_alias[orig_name]
+            else:
+                name = orig_name
         self._name = name
         if not isinstance(params, tuple):
             params = (params,)

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -642,10 +642,7 @@ class _GenericAlias(_Final, _root=True):
         self._special = special
         if special and name is None:
             orig_name = origin.__name__
-            if orig_name in _normalize_alias:
-                name = _normalize_alias[orig_name]
-            else:
-                name = orig_name
+            name = _normalize_alias.get(orig_name, orig_name)
         self._name = name
         if not isinstance(params, tuple):
             params = (params,)


### PR DESCRIPTION
This removes a hack and replaces it with a proper mapping `{'list': 'List', 'dict': 'Dict', ...}`.

<!-- issue-number: bpo-32873 -->
https://bugs.python.org/issue32873
<!-- /issue-number -->
