### PR TITLE
bpo-33226: Fix unicode error in formatwarning

### DIFF
--- a/Lib/test/test_warnings.py
+++ b/Lib/test/test_warnings.py
@@ -637,7 +637,7 @@ class WarningsDisplayTests(unittest.TestCase):
         line_num = 3
         file_line = 'spam'
         format = u"%s:%s: %s: %s\n  %s\n"
-        expect = format % (file_name, line_num, category.__name__, str(message),
+        expect = format % (file_name, line_num, category.__name__, message,
                             file_line)
         self.assertEqual(expect, self.module.formatwarning(message,
                                     category, file_name, line_num, file_line))
@@ -655,7 +655,7 @@ class WarningsDisplayTests(unittest.TestCase):
         line_num = 3
         file_line = 'sp\xe4m'
         format = u"%s:%s: %s: %s\n  %s\n"
-        expect = format % (file_name, line_num, category.__name__, str(message),
+        expect = format % (file_name, line_num, category.__name__, message,
                             file_line)
         self.assertEqual(expect, self.module.formatwarning(message,
                                     category, file_name, line_num, file_line))

--- a/Lib/test/test_warnings.py
+++ b/Lib/test/test_warnings.py
@@ -596,7 +596,7 @@ class WarningsDisplayTests(unittest.TestCase):
         file_name = os.path.splitext(warning_tests.__file__)[0] + '.py'
         line_num = 3
         file_line = linecache.getline(file_name, line_num).strip()
-        format = "%s:%s: %s: %s\n  %s\n"
+        format = u"%s:%s: %s: %s\n  %s\n"
         expect = format % (file_name, line_num, category.__name__, message,
                             file_line)
         self.assertEqual(expect, self.module.formatwarning(message,
@@ -615,7 +615,7 @@ class WarningsDisplayTests(unittest.TestCase):
         file_name = os.path.splitext(warning_tests.__file__)[0] + '.py'
         line_num = 3
         file_line = linecache.getline(file_name, line_num).strip()
-        format = "%s:%s: %s: %s\n  %s\n"
+        format = u"%s:%s: %s: %s\n  %s\n"
         expect = format % (file_name, line_num, category.__name__, message,
                             file_line)
         self.assertEqual(expect, self.module.formatwarning(message,
@@ -636,7 +636,7 @@ class WarningsDisplayTests(unittest.TestCase):
         file_name = unicode_file_name.encode(sys.getfilesystemencoding())
         line_num = 3
         file_line = 'spam'
-        format = "%s:%s: %s: %s\n  %s\n"
+        format = u"%s:%s: %s: %s\n  %s\n"
         expect = format % (file_name, line_num, category.__name__, str(message),
                             file_line)
         self.assertEqual(expect, self.module.formatwarning(message,
@@ -654,7 +654,7 @@ class WarningsDisplayTests(unittest.TestCase):
         file_name = 'file.py'
         line_num = 3
         file_line = 'sp\xe4m'
-        format = "%s:%s: %s: %s\n  %s\n"
+        format = u"%s:%s: %s: %s\n  %s\n"
         expect = format % (file_name, line_num, category.__name__, str(message),
                             file_line)
         self.assertEqual(expect, self.module.formatwarning(message,

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -47,7 +47,7 @@ def formatwarning(message, category, filename, lineno, line=None):
         message = str(message)
     except UnicodeEncodeError:
         pass
-    s =  "%s: %s: %s\n" % (lineno, category.__name__, message)
+    s =  u"%s: %s: %s\n" % (lineno, category.__name__, message)
     line = linecache.getline(filename, lineno) if line is None else line
     if line:
         line = line.strip()


### PR DESCRIPTION
Adding u prefix to "%s: %s: %s\n" % (lineno, category.__name__, message)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33226 -->
https://bugs.python.org/issue33226
<!-- /issue-number -->
