### PR TITLE
bpo-33224: PEP 479 fix for difflib.mdiff()

### DIFF
--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1645,6 +1645,7 @@ def _mdiff(fromlines, tolines, context=None, linejunk=None,
                     yield from_line, to_line, found_diff
             except StopIteration:
                 # Catch exception from next() and return normally
+                return
 
 
 _file_template = """

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -1634,14 +1634,17 @@ def _mdiff(fromlines, tolines, context=None, linejunk=None,
                 lines_to_write -= 1
             # Now yield the context lines after the change
             lines_to_write = context-1
-            while(lines_to_write):
-                from_line, to_line, found_diff = next(line_pair_iterator)
-                # If another change within the context, extend the context
-                if found_diff:
-                    lines_to_write = context-1
-                else:
-                    lines_to_write -= 1
-                yield from_line, to_line, found_diff
+            try:
+                while(lines_to_write):
+                    from_line, to_line, found_diff = next(line_pair_iterator)
+                    # If another change within the context, extend the context
+                    if found_diff:
+                        lines_to_write = context-1
+                    else:
+                        lines_to_write -= 1
+                    yield from_line, to_line, found_diff
+            except StopIteration:
+                # Catch exception from next() and return normally
 
 
 _file_template = """

--- a/Lib/test/test_difflib.py
+++ b/Lib/test/test_difflib.py
@@ -93,6 +93,14 @@ class TestSFbugs(unittest.TestCase):
         self.assertEqual("+ \t\tI am a bug", diff[2])
         self.assertEqual("? +\n", diff[3])
 
+    def test_mdiff_catch_stop_iteration(self):
+        # Issue #33224
+        self.assertEqual(
+            list(difflib._mdiff(["2"], ["3"], 1)),
+            [((1, '\x00-2\x01'), (1, '\x00+3\x01'), True)],
+        )
+
+
 patch914575_from1 = """
    1. Beautiful is beTTer than ugly.
    2. Explicit is better than implicit.

--- a/Misc/NEWS.d/next/Library/2018-04-04-23-41-30.bpo-33224.pyR0jB.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-04-23-41-30.bpo-33224.pyR0jB.rst
@@ -1,0 +1,2 @@
+Update difflib.mdiff() for PEP 479.  Convert an uncaught StopIteration in a
+generator into a return-statement.


### PR DESCRIPTION


<!-- issue-number: bpo-33224 -->
https://bugs.python.org/issue33224
<!-- /issue-number -->
