### PR TITLE
bpo-33231: Fix potential leak in normalizestring()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-05-22-20-44.bpo-33231.3Jmo0q.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-05-22-20-44.bpo-33231.3Jmo0q.rst
@@ -1,0 +1,1 @@
+Fix potential memory leak in ``normalizestring()``.

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -78,8 +78,6 @@ PyObject *normalizestring(const char *string)
     }
     p[i] = '\0';
     v = PyUnicode_FromString(p);
-    if (v == NULL)
-        return NULL;
     PyMem_Free(p);
     return v;
 }


### PR DESCRIPTION


<!-- issue-number: bpo-33231 -->
https://bugs.python.org/issue33231
<!-- /issue-number -->
