### PR TITLE
bpo-33184: Update macOS installer build to use OpenSSL 1.1.0h.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -215,9 +215,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.1.0g",
-              url="https://www.openssl.org/source/openssl-1.1.0g.tar.gz",
-              checksum='ba5f1b8b835b88cadbce9b35ed9531a6',
+              name="OpenSSL 1.1.0h",
+              url="https://www.openssl.org/source/openssl-1.1.0h.tar.gz",
+              checksum='5271477e4d93f4ea032b665ef095ff24',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2018-04-07-00-51-34.bpo-33184.3j208P.rst
+++ b/Misc/NEWS.d/next/macOS/2018-04-07-00-51-34.bpo-33184.3j208P.rst
@@ -1,0 +1,1 @@
+Update macOS installer build to use OpenSSL 1.1.0h.


### PR DESCRIPTION


<!-- issue-number: bpo-33184 -->
https://bugs.python.org/issue33184
<!-- /issue-number -->
