### PR TITLE
[3.6] bpo-33184: Update macOS installer build to use OpenSSL 1.0.2o.

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -210,9 +210,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.0.2n",
-              url="https://www.openssl.org/source/openssl-1.0.2n.tar.gz",
-              checksum='13bdc1b1d1ff39b6fd42a255e74676a4',
+              name="OpenSSL 1.0.2o",
+              url="https://www.openssl.org/source/openssl-1.0.2o.tar.gz",
+              checksum='44279b8557c3247cbe324e2322ecd114',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2018-04-07-00-58-50.bpo-33184.rMTiqu.rst
+++ b/Misc/NEWS.d/next/macOS/2018-04-07-00-58-50.bpo-33184.rMTiqu.rst
@@ -1,0 +1,1 @@
+Update macOS installer build to use OpenSSL 1.0.2o.


### PR DESCRIPTION


<!-- issue-number: bpo-33184 -->
https://bugs.python.org/issue33184
<!-- /issue-number -->
