### PR TITLE
Update docstring of tempfile._RandomNameSequence

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -132,7 +132,7 @@ def _sanitize_params(prefix, suffix, dir):
 class _RandomNameSequence:
     """An instance of _RandomNameSequence generates an endless
     sequence of unpredictable strings which can safely be incorporated
-    into file names.  Each string is six characters long.  Multiple
+    into file names.  Each string is eight characters long.  Multiple
     threads can safely use the same instance at the same time.
 
     _RandomNameSequence is an iterator."""


### PR DESCRIPTION
When issue 12015 got resolved by increasing the length of the
random string generated by _RandomNameSequence from six to eight
characters, the docstring of the class was not adjusted
accordingly.