### PR TITLE
bpo-25735: math.factorial doc should mention integer return type

### DIFF
--- a/Doc/library/math.rst
+++ b/Doc/library/math.rst
@@ -50,7 +50,7 @@ Number-theoretic and representation functions
 
 .. function:: factorial(x)
 
-   Return *x* factorial.  Raises :exc:`ValueError` if *x* is not integral or
+   Return *x* factorial as an integer.  Raises :exc:`ValueError` if *x* is not integral or
    is negative.
 
 

--- a/Misc/NEWS.d/next/Documentation/2018-04-08-19-09-22.bpo-25735.idVQBD.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-04-08-19-09-22.bpo-25735.idVQBD.rst
@@ -1,1 +1,1 @@
-Added documentations for :func:`fabs`, to take only integer input values.
+Added documentation for func factorial to indicate that returns integer values

--- a/Misc/NEWS.d/next/Documentation/2018-04-08-19-09-22.bpo-25735.idVQBD.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-04-08-19-09-22.bpo-25735.idVQBD.rst
@@ -1,0 +1,1 @@
+Added documentations for :func:`fabs`, to take only integer input values.


### PR DESCRIPTION
Issue link: [math.factorial doc should mention integer return type](https://bugs.python.org/issue25735)

<!-- issue-number: bpo-25735 -->
https://bugs.python.org/issue25735
<!-- /issue-number -->
