### PR TITLE
bpo-33099: Fix test_poplib hangs after error

### DIFF
--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -221,12 +221,15 @@ class DummyPOP3Server(asyncore.dispatcher, threading.Thread):
         self.__flag.wait()
 
     def run(self):
-        self.active = True
-        self.__flag.set()
-        while self.active and asyncore.socket_map:
-            self.active_lock.acquire()
-            asyncore.loop(timeout=0.1, count=1)
-            self.active_lock.release()
+        try:
+            self.active = True
+            self.__flag.set()
+            while self.active and asyncore.socket_map:
+                self.active_lock.acquire()
+                asyncore.loop(timeout=0.1, count=1)
+                self.active_lock.release()
+        finally:
+            self.close()
 
     def stop(self):
         assert self.active

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -255,21 +255,24 @@ class TestPOP3Class(TestCase):
     def assertOK(self, resp):
         self.assertTrue(resp.startswith(b"+OK"))
 
-    def setUp(self):
+    def setup_server(self, handler_class=None):
         self.server = DummyPOP3Server((HOST, PORT))
+        if handler_class is not None:
+            self.server.handler = handler_class
         self.server.start()
-        try:
-            self.client = poplib.POP3(self.server.host, self.server.port, timeout=3)
-        except:
+
+        @self.addCleanup
+        def close_server():
             self.server.stop()
+            # Explicitly clear the attribute to prevent dangling thread
             self.server = None
-            raise
+
+    def setUp(self):
+        self.setup_server()
+        self.client = poplib.POP3(self.server.host, self.server.port, timeout=3)
 
     def tearDown(self):
         self.client.close()
-        self.server.stop()
-        # Explicitly clear the attribute to prevent dangling thread
-        self.server = None
 
     def test_getwelcome(self):
         self.assertEqual(self.client.getwelcome(),
@@ -409,15 +412,8 @@ class TestPOP3_SSLClass(TestPOP3Class):
     # repeat previous tests by using poplib.POP3_SSL
 
     def setUp(self):
-        self.server = DummyPOP3Server((HOST, PORT))
-        self.server.handler = DummyPOP3_SSLHandler
-        self.server.start()
-        try:
-            self.client = poplib.POP3_SSL(self.server.host, self.server.port)
-        except:
-            self.server.stop()
-            self.server = None
-            raise
+        self.setup_server(DummyPOP3_SSLHandler)
+        self.client = poplib.POP3_SSL(self.server.host, self.server.port)
 
     def test__all__(self):
         self.assertIn('POP3_SSL', poplib.__all__)
@@ -458,15 +454,9 @@ class TestPOP3_TLSClass(TestPOP3Class):
     # repeat previous tests by using poplib.POP3.stls()
 
     def setUp(self):
-        self.server = DummyPOP3Server((HOST, PORT))
-        self.server.start()
-        try:
-            self.client = poplib.POP3(self.server.host, self.server.port, timeout=3)
-            self.client.stls()
-        except:
-            self.server.stop()
-            self.server = None
-            raise
+        self.setup_server()
+        self.client = poplib.POP3(self.server.host, self.server.port, timeout=3)
+        self.client.stls()
 
     def tearDown(self):
         if self.client.file is not None and self.client.sock is not None:
@@ -477,9 +467,6 @@ class TestPOP3_TLSClass(TestPOP3Class):
                 # response will be treated as response to QUIT and raise
                 # this exception
                 self.client.close()
-        self.server.stop()
-        # Explicitly clear the attribute to prevent dangling thread
-        self.server = None
 
     def test_stls(self):
         self.assertRaises(poplib.error_proto, self.client.stls)

--- a/Lib/test/test_poplib.py
+++ b/Lib/test/test_poplib.py
@@ -261,7 +261,6 @@ class TestPOP3Class(TestCase):
         try:
             self.client = poplib.POP3(self.server.host, self.server.port, timeout=3)
         except:
-            traceback.print_exc()
             self.server.stop()
             self.server = None
             raise
@@ -416,7 +415,6 @@ class TestPOP3_SSLClass(TestPOP3Class):
         try:
             self.client = poplib.POP3_SSL(self.server.host, self.server.port)
         except:
-            traceback.print_exc()
             self.server.stop()
             self.server = None
             raise
@@ -466,7 +464,6 @@ class TestPOP3_TLSClass(TestPOP3Class):
             self.client = poplib.POP3(self.server.host, self.server.port, timeout=3)
             self.client.stls()
         except:
-            traceback.print_exc()
             self.server.stop()
             self.server = None
             raise

--- a/Misc/NEWS.d/next/Library/2018-04-09-19-02-34.bpo-33099.Bgn7Kc.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-09-19-02-34.bpo-33099.Bgn7Kc.rst
@@ -1,0 +1,2 @@
+Fix test_poplib hangs when an error occured in ``setUp()`` method or
+``DummyPOP3Server.run()``.


### PR DESCRIPTION
This fixes resource leaks in the test and reveals real errors.

<!-- issue-number: bpo-33099 -->
https://bugs.python.org/issue33099
<!-- /issue-number -->
