### PR TITLE
[3.7] bpo-33031: Remove dead code in C implementation of OrderedDict. (GH-6120)

### DIFF
--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -859,64 +859,6 @@ static PyMappingMethods odict_as_mapping = {
  * OrderedDict methods
  */
 
-/* __delitem__() */
-
-PyDoc_STRVAR(odict_delitem__doc__, "od.__delitem__(y) <==> del od[y]");
-
-/* __eq__() */
-
-PyDoc_STRVAR(odict_eq__doc__,
-"od.__eq__(y) <==> od==y.  Comparison to another OD is order-sensitive \n\
-        while comparison to a regular mapping is order-insensitive.\n\
-        ");
-
-/* forward */
-static PyObject * odict_richcompare(PyObject *v, PyObject *w, int op);
-
-static PyObject *
-odict_eq(PyObject *a, PyObject *b)
-{
-    return odict_richcompare(a, b, Py_EQ);
-}
-
-/* __init__() */
-
-PyDoc_STRVAR(odict_init__doc__,
-"Initialize an ordered dictionary.  The signature is the same as\n\
-        regular dictionaries.  Keyword argument order is preserved.\n\
-\n\
-        ");
-
-/* forward */
-static int odict_init(PyObject *self, PyObject *args, PyObject *kwds);
-
-/* __iter__() */
-
-PyDoc_STRVAR(odict_iter__doc__, "od.__iter__() <==> iter(od)");
-
-static PyObject * odict_iter(PyODictObject *self);  /* forward */
-
-/* __ne__() */
-
-/* Mapping.__ne__() does not have a docstring. */
-PyDoc_STRVAR(odict_ne__doc__, "");
-
-static PyObject *
-odict_ne(PyObject *a, PyObject *b)
-{
-    return odict_richcompare(a, b, Py_NE);
-}
-
-/* __repr__() */
-
-PyDoc_STRVAR(odict_repr__doc__, "od.__repr__() <==> repr(od)");
-
-static PyObject * odict_repr(PyODictObject *self);  /* forward */
-
-/* __setitem__() */
-
-PyDoc_STRVAR(odict_setitem__doc__, "od.__setitem__(i, y) <==> od[i]=y");
-
 /* fromkeys() */
 
 /*[clinic input]
@@ -1370,25 +1312,8 @@ OrderedDict_move_to_end_impl(PyODictObject *self, PyObject *key, int last)
 
 static PyMethodDef odict_methods[] = {
 
-    /* explicitly defined so we can align docstrings with
-     * collections.OrderedDict */
-    {"__delitem__",     (PyCFunction)odict_mp_ass_sub,  METH_NOARGS,
-     odict_delitem__doc__},
-    {"__eq__",          (PyCFunction)odict_eq,          METH_NOARGS,
-     odict_eq__doc__},
-    {"__init__",        (PyCFunction)odict_init,        METH_NOARGS,
-     odict_init__doc__},
-    {"__iter__",        (PyCFunction)odict_iter,        METH_NOARGS,
-     odict_iter__doc__},
-    {"__ne__",          (PyCFunction)odict_ne,          METH_NOARGS,
-     odict_ne__doc__},
-    {"__repr__",        (PyCFunction)odict_repr,        METH_NOARGS,
-     odict_repr__doc__},
-    {"__setitem__",     (PyCFunction)odict_mp_ass_sub,  METH_NOARGS,
-     odict_setitem__doc__},
-    ORDEREDDICT_FROMKEYS_METHODDEF
-
     /* overridden dict methods */
+    ORDEREDDICT_FROMKEYS_METHODDEF
     {"__sizeof__",      (PyCFunction)odict_sizeof,      METH_NOARGS,
      odict_sizeof__doc__},
     {"__reduce__",      (PyCFunction)odict_reduce,      METH_NOARGS,


### PR DESCRIPTION
This code doesn't have effect on the final result, but causes GCC 8 warnings and can have an undefined behavior.
(cherry picked from commit 827d49f3cf0296f1e267eae6834a977cf312cc1e)
