### PR TITLE
[2.7] bpo-31920: Fixed handling directories as arguments in the ``pygettext`` script. (GH-6259)

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -767,6 +767,7 @@ Jerzy Kozera
 Maksim Kozyarchuk
 Stefan Krah
 Bob Kras
+Oleg Krasnikov
 Sebastian Kreft
 Holger Krekel
 Michael Kremer

--- a/Misc/NEWS.d/next/Tools-Demos/2018-03-26-18-54-24.bpo-31920.u_WKsT.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2018-03-26-18-54-24.bpo-31920.u_WKsT.rst
@@ -1,0 +1,2 @@
+Fixed handling directories as arguments in the ``pygettext`` script. Based
+on patch by Oleg Krasnikov.

--- a/Tools/i18n/pygettext.py
+++ b/Tools/i18n/pygettext.py
@@ -261,25 +261,6 @@ def containsAny(str, set):
     return 1 in [c in str for c in set]
 
 
-def _visit_pyfiles(list, dirname, names):
-    """Helper for getFilesForName()."""
-    # get extension for python source files
-    if not globals().has_key('_py_ext'):
-        global _py_ext
-        _py_ext = [triple[0] for triple in imp.get_suffixes()
-                   if triple[2] == imp.PY_SOURCE][0]
-
-    # don't recurse into CVS directories
-    if 'CVS' in names:
-        names.remove('CVS')
-
-    # add all *.py files to list
-    list.extend(
-        [os.path.join(dirname, file) for file in names
-         if os.path.splitext(file)[1] == _py_ext]
-        )
-
-
 def _get_modpkg_path(dotted_name, pathlist=None):
     """Get the filesystem path for a module or a package.
 
@@ -340,7 +321,20 @@ def getFilesForName(name):
     if os.path.isdir(name):
         # find all python files in directory
         list = []
-        os.path.walk(name, _visit_pyfiles, list)
+        # get extension for python source files
+        if '_py_ext' not in globals():
+            global _py_ext
+            _py_ext = [triple[0] for triple in imp.get_suffixes()
+                       if triple[2] == imp.PY_SOURCE][0]
+        for root, dirs, files in os.walk(name):
+            # don't recurse into CVS directories
+            if 'CVS' in dirs:
+                dirs.remove('CVS')
+            # add all *.py files to list
+            list.extend(
+                [os.path.join(root, file) for file in files
+                 if os.path.splitext(file)[1] == _py_ext]
+                )
         return list
     elif os.path.exists(name):
         # a single file


### PR DESCRIPTION
Based on patch by Oleg Krasnikov.
(cherry picked from commit c93938b5beea4c3f592119ebee6d4029558db8de)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>


<!-- issue-number: bpo-31920 -->
https://bugs.python.org/issue31920
<!-- /issue-number -->
