### PR TITLE
bpo-33253: Fix xxsubtype.bench to accept correct string signature

### DIFF
--- a/Modules/xxsubtype.c
+++ b/Modules/xxsubtype.c
@@ -239,7 +239,7 @@ spam_bench(PyObject *self, PyObject *args)
     int n = 1000;
     time_t t0, t1;
 
-    if (!PyArg_ParseTuple(args, "OS|i", &obj, &name, &n))
+    if (!PyArg_ParseTuple(args, "OU|i", &obj, &name, &n))
         return NULL;
     t0 = clock();
     while (--n >= 0) {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
This fixes the issue as explained on the [tracker](https://bugs.python.org/issue33253) where `xxsubtype.bench` can never run without raising an exception due to the old Python 2 string signature still being in use.

Old behavior:
![image](https://user-images.githubusercontent.com/8049998/38527724-4aa7ebbe-3c97-11e8-8e05-2bfe01968d2b.png)

New behavior:
![image](https://user-images.githubusercontent.com/8049998/38527751-72025a8c-3c97-11e8-8348-4699454cab48.png)


<!-- issue-number: bpo-33253 -->
https://bugs.python.org/issue33253
<!-- /issue-number -->
