### PR TITLE
bpo-33256: Replace square brackets around python object repr to display it in html

### DIFF
--- a/Lib/cgitb.py
+++ b/Lib/cgitb.py
@@ -124,7 +124,7 @@ function calls leading up to the error, in the order they occurred.</p>'''
         args, varargs, varkw, locals = inspect.getargvalues(frame)
         call = ''
         if func != '?':
-            call = 'in ' + strong(func.replace("<", "&lt;").replace(">", "&gt;")) + \
+            call = 'in ' + strong(pydoc.html.escape(func)) + \
                 inspect.formatargvalues(args, varargs, varkw, locals,
                     formatvalue=lambda value: '=' + pydoc.html.repr(value))
 

--- a/Lib/cgitb.py
+++ b/Lib/cgitb.py
@@ -282,7 +282,7 @@ class Hook:
 
         if self.display:
             if plain:
-                doc = doc.replace('&', '&amp;').replace('<', '&lt;')
+                doc = pydoc.html.escape(doc)
                 self.file.write('<pre>' + doc + '</pre>\n')
             else:
                 self.file.write(doc + '\n')

--- a/Lib/cgitb.py
+++ b/Lib/cgitb.py
@@ -124,7 +124,7 @@ function calls leading up to the error, in the order they occurred.</p>'''
         args, varargs, varkw, locals = inspect.getargvalues(frame)
         call = ''
         if func != '?':
-            call = 'in ' + strong(func) + \
+            call = 'in ' + strong(func.replace("<", "&lt;").replace(">", "&gt;")) + \
                 inspect.formatargvalues(args, varargs, varkw, locals,
                     formatvalue=lambda value: '=' + pydoc.html.repr(value))
 

--- a/Lib/test/test_cgitb.py
+++ b/Lib/test/test_cgitb.py
@@ -45,6 +45,7 @@ class TestCgitb(unittest.TestCase):
         out = out.decode(sys.getfilesystemencoding())
         self.assertIn("ValueError", out)
         self.assertIn("Hello World", out)
+        self.assertIn("<strong>&lt;module&gt;</strong>", out)
         # By default we emit HTML markup.
         self.assertIn('<p>', out)
         self.assertIn('</p>', out)

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -158,6 +158,7 @@ Mike Bland
 Martin Bless
 Pablo Bleyer
 Erik van Blokland
+Stéphane Blondon
 Eric Blossom
 Sergey Bobrov
 Finn Bock

--- a/Misc/NEWS.d/next/Library/2018-04-10-20-57-14.bpo-33256.ndHkqu.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-10-20-57-14.bpo-33256.ndHkqu.rst
@@ -1,0 +1,1 @@
+Fix display of ``<module>`` call in the html produced by ``cgitb.html()``.

--- a/Misc/NEWS.d/next/Library/2018-04-10-20-57-14.bpo-33256.ndHkqu.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-10-20-57-14.bpo-33256.ndHkqu.rst
@@ -1,1 +1,1 @@
-Fix display of ``<module>`` call in the html produced by ``cgitb.html()``. Patch by Stéphane Blondon
+Fix display of ``<module>`` call in the html produced by ``cgitb.html()``. Patch by Stéphane Blondon.

--- a/Misc/NEWS.d/next/Library/2018-04-10-20-57-14.bpo-33256.ndHkqu.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-10-20-57-14.bpo-33256.ndHkqu.rst
@@ -1,1 +1,1 @@
-Fix display of ``<module>`` call in the html produced by ``cgitb.html()``.
+Fix display of ``<module>`` call in the html produced by ``cgitb.html()``. Patch by Stéphane Blondon


### PR DESCRIPTION
This PR replace '<' and '>' in ```func``` so an representation of an object will be displayed. It will not change the display of functions.


<!-- issue-number: bpo-33256 -->
https://bugs.python.org/issue33256
<!-- /issue-number -->
