### PR TITLE
bpo-33251: Prevent ConfigParser.items returning items present in vars.

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -846,19 +846,16 @@ class RawConfigParser(MutableMapping):
         except KeyError:
             if section != self.default_section:
                 raise NoSectionError(section)
+        orig_keys = list(d.keys())
         # Update with the entry specific variables
         if vars:
             for key, value in vars.items():
                 d[self.optionxform(key)] = value
-        # Change `vars` from None to a dict to avoid TypeError on return.
-        else:
-            vars = {}
         value_getter = lambda option: self._interpolation.before_get(self,
             section, option, d[option], d)
         if raw:
             value_getter = lambda option: d[option]
-        return [(option, value_getter(option)) for option in d.keys()
-                if option not in vars]
+        return [(option, value_getter(option)) for option in orig_keys]
 
     def popitem(self):
         """Remove a section from the parser and return it as

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -850,11 +850,15 @@ class RawConfigParser(MutableMapping):
         if vars:
             for key, value in vars.items():
                 d[self.optionxform(key)] = value
+        # Change `vars` from None to a dict to avoid TypeError on return.
+        else:
+            vars = {}
         value_getter = lambda option: self._interpolation.before_get(self,
             section, option, d[option], d)
         if raw:
             value_getter = lambda option: d[option]
-        return [(option, value_getter(option)) for option in d.keys()]
+        return [(option, value_getter(option)) for option in d.keys()
+                if option not in vars]
 
     def popitem(self):
         """Remove a section from the parser and return it as

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -915,8 +915,7 @@ class ConfigParserTestCase(BasicTestCase, unittest.TestCase):
         self.check_items_config([('default', '<default>'),
                                  ('getdefault', '|<default>|'),
                                  ('key', '|value|'),
-                                 ('name', 'value'),
-                                 ('value', 'value')])
+                                 ('name', 'value')])
 
     def test_safe_interpolation(self):
         # See http://www.python.org/sf/511737
@@ -1093,8 +1092,7 @@ class RawConfigParserTestCase(BasicTestCase, unittest.TestCase):
         self.check_items_config([('default', '<default>'),
                                  ('getdefault', '|%(default)s|'),
                                  ('key', '|%(name)s|'),
-                                 ('name', '%(value)s'),
-                                 ('value', 'value')])
+                                 ('name', '%(value)s')])
 
     def test_set_nonstring_types(self):
         cf = self.newconfig()

--- a/Misc/NEWS.d/next/Library/2018-04-23-18-25-36.bpo-33251.C_K-J9.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-23-18-25-36.bpo-33251.C_K-J9.rst
@@ -1,2 +1,2 @@
-`ConfigParser.items` amended so any values passed in using the `vars`
-argument are not included in the resulting output.
+`ConfigParser.items()` was fixed so that key-value pairs passed in via `vars`
+are not included in the resulting output.

--- a/Misc/NEWS.d/next/Library/2018-04-23-18-25-36.bpo-33251.C_K-J9.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-23-18-25-36.bpo-33251.C_K-J9.rst
@@ -1,0 +1,2 @@
+`ConfigParser.items` amended so any values passed in using the `vars`
+argument are not included in the resulting output.


### PR DESCRIPTION
Documentation for `ConfigParser.items()` states:
'Items present in vars no longer appear in the result.'

This fix aligns behaviour to that specified in the documentation.

<!-- issue-number: bpo-33251 -->
https://bugs.python.org/issue33251
<!-- /issue-number -->
