### PR TITLE
bpo-1634034: Show "expected" token on syntax error.

### DIFF
--- a/Include/token.h
+++ b/Include/token.h
@@ -62,7 +62,8 @@ extern "C" {
 #define ATEQUAL         50
 #define RARROW          51
 #define ELLIPSIS        52
-/* Don't forget to update the table _PyParser_TokenNames in tokenizer.c! */
+/* Don't forget to update the tables _PyParser_TokenNames and
+ * _PyParser_TokenDescs in tokenizer.c! */
 #define OP              53
 #define ERRORTOKEN      54
 /* These aren't used by the C tokenizer but are needed for tokenize.py */
@@ -80,7 +81,8 @@ extern "C" {
 #define ISEOF(x)                ((x) == ENDMARKER)
 
 
-PyAPI_DATA(const char *) _PyParser_TokenNames[]; /* Token names */
+PyAPI_DATA(const char * const) _PyParser_TokenNames[]; /* Token names */
+PyAPI_DATA(const char * const) _PyParser_TokenDescs[]; /* Token descriptions */
 PyAPI_FUNC(int) PyToken_OneChar(int);
 PyAPI_FUNC(int) PyToken_TwoChars(int, int);
 PyAPI_FUNC(int) PyToken_ThreeChars(int, int, int);

--- a/Lib/test/test_genexps.py
+++ b/Lib/test/test_genexps.py
@@ -87,7 +87,7 @@ Verify that parenthesis are required when used as a keyword argument value
     >>> dict(a = i for i in range(10))
     Traceback (most recent call last):
        ...
-    SyntaxError: invalid syntax
+    SyntaxError: invalid syntax - ')' expected
 
 Verify that parenthesis are required when used as a keyword argument value
 

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -29,7 +29,7 @@ Errors from set_context():
 
 >>> obj.None = 1
 Traceback (most recent call last):
-SyntaxError: invalid syntax
+SyntaxError: invalid syntax - name expected
 
 >>> None = 1
 Traceback (most recent call last):
@@ -102,17 +102,17 @@ SyntaxError: non-default argument follows default argument
 >>> def f(x, None):
 ...     pass
 Traceback (most recent call last):
-SyntaxError: invalid syntax
+SyntaxError: invalid syntax - ')' expected
 
 >>> def f(*None):
 ...     pass
 Traceback (most recent call last):
-SyntaxError: invalid syntax
+SyntaxError: invalid syntax - ')' expected
 
 >>> def f(**None):
 ...     pass
 Traceback (most recent call last):
-SyntaxError: invalid syntax
+SyntaxError: invalid syntax - name expected
 
 
 From ast_for_funcdef():
@@ -120,7 +120,7 @@ From ast_for_funcdef():
 >>> def None(x):
 ...     pass
 Traceback (most recent call last):
-SyntaxError: invalid syntax
+SyntaxError: invalid syntax - name expected
 
 
 From ast_for_call():

--- a/Lib/test/test_unpack_ex.py
+++ b/Lib/test/test_unpack_ex.py
@@ -165,14 +165,14 @@ Generator expression in function arguments
     ...
         list(*x for x in (range(5) for i in range(3)))
                   ^
-    SyntaxError: invalid syntax
+    SyntaxError: invalid syntax - ')' expected
 
     >>> dict(**x for x in [{1:2}])
     Traceback (most recent call last):
     ...
         dict(**x for x in [{1:2}])
                    ^
-    SyntaxError: invalid syntax
+    SyntaxError: invalid syntax - ')' expected
 
 Iterable argument unpacking
 

--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-11-21-57-44.bpo-1634034.BbCpxd.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-11-21-57-44.bpo-1634034.BbCpxd.rst
@@ -1,0 +1,2 @@
+"Expected" token is now shown on syntax error.  Based on patch by Oliver
+Gramberg and Dave Malcolm.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -50,7 +50,7 @@ static void tok_backup(struct tok_state *tok, int c);
 
 /* Token names */
 
-const char *_PyParser_TokenNames[] = {
+const char * const _PyParser_TokenNames[] = {
     "ENDMARKER",
     "NAME",
     "NUMBER",
@@ -113,6 +113,74 @@ const char *_PyParser_TokenNames[] = {
     "<N_TOKENS>"
 };
 
+static const int _update_PyParser_TokenNames = Py_BUILD_ASSERT_EXPR(
+    Py_ARRAY_LENGTH(_PyParser_TokenNames) == N_TOKENS + 1);
+
+const char * const _PyParser_TokenDescs[] = {
+    "end marker", /* ENDMARKER */
+    "name", /* "NAME", */
+    "number", /* NUMBER */
+    "string",  /* STRING" */
+    "newline", /* NEWLINE */
+    "indent", /* INDENT */
+    "dedent", /* DEDENT */
+    "'('", /* LPAR */
+    "')'", /* RPAR */
+    "'['", /* LSQB */
+    "']'", /* RSQB */
+    "':'", /* COLON */
+    "','", /* COMMA */
+    "';'", /* SEMI */
+    "'+'", /* PLUS */
+    "'-'", /* MINUS */
+    "'*'", /* STAR */
+    "'/'", /* SLASH */
+    "'|'", /* VBAR */
+    "'&'", /* AMPER */
+    "'<'", /* LESS */
+    "'>'", /* GREATER */
+    "'='", /* EQUAL */
+    "'.'", /* DOT */
+    "'%'", /* PERCENT */
+    "'{'", /* LBRACE */
+    "'}'", /* RBRACE */
+    "'=='", /* EQEQUAL */
+    "'!='", /* NOTEQUAL */
+    "'<='", /* LESSEQUAL */
+    "'>='", /* GREATEREQUAL */
+    "'~'", /* TILDE */
+    "'^'", /* CIRCUMFLEX */
+    "'<<'", /* LEFTSHIFT */
+    "'>>'", /* RIGHTSHIFT */
+    "'**'", /* DOUBLESTAR */
+    "'+='", /* PLUSEQUAL */
+    "'-='", /* MINEQUAL */
+    "'*='", /* STAREQUAL */
+    "'/='", /* SLASHEQUAL */
+    "'%='", /* PERCENTEQUAL */
+    "'&='", /* AMPEREQUAL */
+    "'|='", /* VBAREQUAL */
+    "'^='", /* CIRCUMFLEXEQUAL */
+    "'<<='", /* LEFTSHIFTEQUAL */
+    "'>>='", /* RIGHTSHIFTEQUAL */
+    "'**='", /* DOUBLESTAREQUAL */
+    "'//'", /* DOUBLESLASH */
+    "'//='", /* DOUBLESLASHEQUAL */
+    "'@'", /* AT */
+    "'@='", /* ATEQUAL */
+    "'->'", /* RARROW */
+    "'...'", /* ELLIPSIS */
+    /* This table must match the #defines in token.h! */
+    "OP", /* OP */
+    "<ERRORTOKEN>", /* <ERRORTOKEN> */
+    "comment", /* COMMENT */
+    "new line", /* NL */
+    "encoding cookie", /* ENCODING */
+    "<N_TOKENS>" /* <N_TOKENS */
+};
+
+static const int _update_PyParser_TokenDescs = Py_BUILD_ASSERT_EXPR(
+    Py_ARRAY_LENGTH(_PyParser_TokenDescs) == N_TOKENS + 1);
 
 /* Create and initialize a new tok_state structure */
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1347,6 +1347,10 @@ err_input(perrdetail *err)
         else {
             errtype = PyExc_SyntaxError;
             msg = "invalid syntax";
+            if (err->expected != -1)
+                msg_obj = PyUnicode_FromFormat(
+                        "invalid syntax - %s expected",
+                        _PyParser_TokenDescs[err->expected]);
         }
         break;
     case E_TOKEN:


### PR DESCRIPTION
Based on patch by Oliver Gramberg and Dave Malcolm.


<!-- issue-number: bpo-1634034 -->
https://bugs.python.org/issue1634034
<!-- /issue-number -->
