### PR TITLE
bpo-33082: Include multiprocessing Pool callback in example & docstrings

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -367,6 +367,15 @@ For example::
    from multiprocessing import Pool, TimeoutError
    import time
    import os
+   import random
+
+   def random_sleep():
+       duration = random() * 5.0
+       time.sleep(duration)
+       return duration
+
+   def report_slept_duration(duration):
+       print("Slept for %0.2f seconds." % duration)
 
    def f(x):
        return x*x
@@ -402,6 +411,10 @@ For example::
                print("We lacked patience and got a multiprocessing.TimeoutError")
 
            print("For the moment, the pool remains available for more work")
+
+           for i in range(10):
+               pool.apply_async(random_sleep, callback=report_slept_duration)
+           print("Finished adding to pool. Waiting for jobs to finish.")
 
        # exiting the 'with'-block has stopped the pool
        print("Now the pool is closed and no longer available")
@@ -2114,17 +2127,16 @@ with the :class:`Pool` class.
 
       A variant of the :meth:`apply` method which returns a result object.
 
-      If *callback* is specified then it should be a callable which accepts a
-      single argument.  When the result becomes ready *callback* is applied to
-      it, that is unless the call failed, in which case the *error_callback*
-      is applied instead.
+      The *callback*, if specified, must be a callable taking a single argument.
+      When *func* successfully finishes, *callback* is applied to its return value,
+      back in the main process.
 
       If *error_callback* is specified then it should be a callable which
-      accepts a single argument.  If the target function fails, then
+      accepts a single argument.  If *func* raises an exception, then
       the *error_callback* is called with the exception instance.
 
-      Callbacks should complete immediately since otherwise the thread which
-      handles the results will get blocked.
+      During the time callbacks run, they impede further pool maintenance, so
+      they should be designed to complete immediately.
 
    .. method:: map(func, iterable[, chunksize])
 
@@ -2139,17 +2151,16 @@ with the :class:`Pool` class.
 
       A variant of the :meth:`.map` method which returns a result object.
 
-      If *callback* is specified then it should be a callable which accepts a
-      single argument.  When the result becomes ready *callback* is applied to
-      it, that is unless the call failed, in which case the *error_callback*
-      is applied instead.
+      The *callback*, if specified, must be a callable taking a single argument.
+      When *func* successfully finishes, *callback* is applied to its return value,
+      back in the main process.
 
       If *error_callback* is specified then it should be a callable which
-      accepts a single argument.  If the target function fails, then
+      accepts a single argument.  If *func* raises an exception, then
       the *error_callback* is called with the exception instance.
 
-      Callbacks should complete immediately since otherwise the thread which
-      handles the results will get blocked.
+      During the time callbacks run, they impede further pool maintenance, so
+      they should be designed to complete immediately.
 
    .. method:: imap(func, iterable[, chunksize])
 

--- a/Lib/multiprocessing/pool.py
+++ b/Lib/multiprocessing/pool.py
@@ -356,7 +356,9 @@ class Pool(object):
     def apply_async(self, func, args=(), kwds={}, callback=None,
             error_callback=None):
         '''
-        Asynchronous version of `apply()` method.
+        Asynchronous version of `apply()` method. If supplied,
+        `callback(return_value)`, or `error_callback(exception_instance)`
+        is run from pool process.
         '''
         if self._state != RUN:
             raise ValueError("Pool not running")
@@ -367,7 +369,9 @@ class Pool(object):
     def map_async(self, func, iterable, chunksize=None, callback=None,
             error_callback=None):
         '''
-        Asynchronous version of `map()` method.
+        Asynchronous version of `map()` method. If supplied,
+        `callback(return_value)`, or `error_callback(exception_instance)`
+        is run from pool process.
         '''
         return self._map_async(func, iterable, mapstar, chunksize, callback,
             error_callback)


### PR DESCRIPTION
Also make the callback docs more clear as to how data flows.

Callbacks are executed in the main process. The callback input values are the
return values of the called function, when that function exits, or an exception
instance in error_callbacks if it is raised.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33082 -->
https://bugs.python.org/issue33082
<!-- /issue-number -->
