### PR TITLE
bpo-33266: Add support for all string literals to lib2to3

### DIFF
--- a/Lib/lib2to3/tests/data/py3_test_grammar.py
+++ b/Lib/lib2to3/tests/data/py3_test_grammar.py
@@ -147,6 +147,8 @@ jumps over\n\
 the \'lazy\' dog.\n\
 '
         self.assertEquals(x, y)
+        x = rf"hello \{True}"; y = f"hello \\{True}"
+        self.assertEquals(x, y)
 
     def testEllipsis(self):
         x = ...


### PR DESCRIPTION


<!-- issue-number: bpo-33266 -->
https://bugs.python.org/issue33266
<!-- /issue-number -->
