### PR TITLE
bpo-12029: Exception handling should match subclasses

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -8,11 +8,11 @@ Built-in Exceptions
    statement: except
 
 In Python, all exceptions must be instances of a class that derives from
-:class:`BaseException`.  In a :keyword:`try` statement with an :keyword:`except`
-clause that mentions a particular class, that clause also handles any exception
-classes derived from that class (but not exception classes from which *it* is
-derived).  Two exception classes that are not related via subclassing are never
-equivalent, even if they have the same name.
+:class:`BaseException`.  A :keyword:`try` statement with an :keyword:`except`
+clause that mentions a class handles exceptions of that class and its
+subclasses (as defined by :func:`issubclass`). Two exception classes that
+are not related via subclassing are never equivalent, even if they have the
+same name.
 
 .. index:: statement: raise
 

--- a/Lib/unittest/test/test_assertions.py
+++ b/Lib/unittest/test/test_assertions.py
@@ -1,3 +1,4 @@
+import abc
 import datetime
 import warnings
 import weakref
@@ -369,6 +370,16 @@ class TestLongMessage(unittest.TestCase):
                               ['^TypeError not raised$', '^oops$',
                                '^TypeError not raised$',
                                '^TypeError not raised : oops$'])
+
+    def testAssertRaisesWithMetaClass(self):
+        # See issue33271
+        class A(Exception, metaclass=abc.ABCMeta):
+            pass
+        class B(Exception):
+            pass
+        A.register(B)
+        with self.assertRaises(A, msg="Exception B should be interpreted as A"):
+            raise B
 
     def testAssertRaisesRegex(self):
         # test error not raised

--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-13-10-38-00.bpo-12029.851NV8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-13-10-38-00.bpo-12029.851NV8.rst
@@ -1,0 +1,3 @@
+Fix bug where exception matching fails to match virtual subclasses because
+``PyErr_GivenExceptionMatches`` used ``PyType_IsSubtype`` instead of
+``PyObject_IsSubclass``.


### PR DESCRIPTION
Exception handling should match subclasses, not subtypes


# Example


    from abc import ABC
    
    class MyException(Exception, ABC):
        pass
    
    class OtherException(Exception):
        pass
    
    MyException.register(OtherException)
    
    try:
        raise OtherException
    except MyException:
        print("Correct: Caught MyException")
    except Exception:
        print("Wrong: Caught something else")
        
    # "Wrong: Caught something else"


# Background and evidence of bug-ness

Issue 2534 [1] (10 years ago!) introduced the behavior, but only in the Python 3 patch [2]. During code review, the correct function call was used [3], but the function's name got switched in the final python3 patch without any comment.

The current Python 2 code uses `PyObject_IsSubclass`, and produces the correct behavior in the example above (using `__metaclass__ = ABCMeta`, of course). This leads me to strongly suspect that this is a bug, not a feature. The note below regarding unittest for further evidence that this code has eight legs.

Given the ancient nature of this bug, it affects all versions of python3.

[1] https://bugs.python.org/issue2534
[2] https://bugs.python.org/file11257/isinstance3k-2.patch
[3] https://codereview.appspot.com/483/diff/1/21#newcode114
[4] https://github.com/python/cpython/blob/2.7/Python/errors.c#L119


# Solution

Coming very soon in a PR on Github, but in short, we do the following:

  1. Switch `PyType_IsSubtype` to  `PyObject_IsSubclass`.
  2. Revert the changes made to remove “dead code” in https://bugs.python.org/issue31091. The code was dead because the wrong function was used—the PR left only the bug.
  3. Add tests. Note that `unittest`’s `self.assertRaises` function uses `issubclass` and does not alert to this bug. (Different symptom, same cause.)


-Mike


<!-- issue-number: bpo-33271 -->
https://bugs.python.org/issue33271
<!-- /issue-number -->
<!-- issue-number: bpo-12029 -->
https://bugs.python.org/issue12029
<!-- /issue-number -->
