### PR TITLE
bpo-33294: Support complex expressions for py-print command.

### DIFF
--- a/Misc/NEWS.d/next/Tools-Demos/2018-04-17-09-16-40.bpo-33294.J7sTti.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2018-04-17-09-16-40.bpo-33294.J7sTti.rst
@@ -1,0 +1,7 @@
+Purpose of the patch is to support more complex expressions for py-print
+command. Small example:
+
+(gdb) py-print t
+local 't' = <Test(t=[1, 2, 3, 4, {'a': 'b', 'c': 'd'}], x=123) at remote 0x7ffff6f15780>
+(gdb) py-print t.t[4]["a"]
+local 't.t[4]["a"]' = 'b'


### PR DESCRIPTION
The patch is based on a blog post: http://kouk.surukle.me/2014/09/25/debugging-python-objects-and-fields-with-gdb/.
Adding him: @kouk

Purpose of the pull request is to support more complex expressions for py-print command.
Small example:

```
(gdb) py-print self
local 'self' = <OptimizationLevel(level='', options=[<MarchFlag(name='-mtune=', options={'x86_64': ('native', 'i386', 'i486', 'i586', 'pentium', 'lakemont', 'pentium-mmx', 'pentiumpro', 'i686', 'pentium2', 'pentium3', 'pentium3m', 'pentium-m', 'pentium4', 'pentium4m', 'prescott', 'nocona', 'core2', 'nehalem', 'westmere', 'sandybridge', 'ivybridge', 'haswell', 'broadwell', 'skylake', 'bonnell', 'silvermont', 'knl', 'skylake-avx512', 'k6', 'k6-2', 'k6-3', 'athlon', 'athlon-tbird', 'athlon-4', 'athlon-xp', 'athlon-mp', 'k8', 'opteron', 'athlon64', 'athlon-fx', 'k8-sse3', 'opteron-sse3', 'athlon64-sse3', 'amdfam10', 'barcelona', 'bdver1', 'bdver2', 'bdver3', 'bdver4', 'znver1', 'btver1', 'btver2', 'winchip-c6', 'winchip2', 'c3', 'c3-2', 'geode'), 'ppc64': ['401', '403', '405', '405fp', '440', '440fp', '464', '464fp', '476', '476fp', '505', '601', '602', '603', '603e', '604', '604e', '620', '630', '740', '7400', '7450', '750', '801', '821', '823', '860', '970', '8540', 'a2', 'e300c2', 'e300c3', 'e500mc', 'e500mc64', 'e5500', 'e6...(truncated)

(gdb) py-print self.options.0.options.x86_64.3
local 'self.options.0.options.x86_64.3' = 'i586'
```

I consider it very handy. For now I support objects, dictionary, tuple and list types of objects.
I guess a test-case and a documentation entry will be needed. But I would first like to get a feedback about the intention of the change.

Thanks

<!-- issue-number: bpo-33294 -->
https://bugs.python.org/issue33294
<!-- /issue-number -->
