### PR TITLE
Removed a confusing line from a docstring in http.cookies

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -256,8 +256,7 @@ class Morsel(dict):
     In a cookie, each such pair may have several attributes, so this class is
     used to keep the attributes associated with the appropriate key,value pair.
     This class also includes a coded_value attribute, which is used to hold
-    the network representation of the value.  This is most useful when Python
-    objects are pickled for network transit.
+    the network representation of the value.
     """
     # RFC 2109 lists these attributes as reserved:
     #   path       comment         domain


### PR DESCRIPTION
There's no reason a cookie should _ever_ contain pickled data. That's just asking for a critical security vulnerability. Back in Python2 there were helpers for doing that, but they're no more in Python3. Now coded_value is used when the value needs to be encoded for any reason.

