### PR TITLE
bpo-32232: by default, Setup modules are no longer built with -DPy_BUILD_CORE

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -106,8 +106,8 @@ ARFLAGS=	@ARFLAGS@
 # Extra C flags added for building the interpreter object files.
 CFLAGSFORSHARED=@CFLAGSFORSHARED@
 # C flags used for building the interpreter object files
-PY_NO_CORE_CFLAGS= $(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED)
-PY_CORE_CFLAGS=	$(PY_NO_CORE_CFLAGS) -DPy_BUILD_CORE
+PY_STDMODULE_CFLAGS= $(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED)
+PY_CORE_CFLAGS=	$(PY_STDMODULE_CFLAGS) -DPy_BUILD_CORE
 # Strict or non-strict aliasing flags used to compile dtoa.c, see above
 CFLAGS_ALIASING=@CFLAGS_ALIASING@
 

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -106,7 +106,8 @@ ARFLAGS=	@ARFLAGS@
 # Extra C flags added for building the interpreter object files.
 CFLAGSFORSHARED=@CFLAGSFORSHARED@
 # C flags used for building the interpreter object files
-PY_CORE_CFLAGS=	$(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED) -DPy_BUILD_CORE
+PY_NO_CORE_CFLAGS= $(PY_CFLAGS) $(PY_CFLAGS_NODIST) $(PY_CPPFLAGS) $(CFLAGSFORSHARED)
+PY_CORE_CFLAGS=	$(PY_NO_CORE_CFLAGS) -DPy_BUILD_CORE
 # Strict or non-strict aliasing flags used to compile dtoa.c, see above
 CFLAGS_ALIASING=@CFLAGS_ALIASING@
 

--- a/Misc/NEWS.d/next/Build/2018-04-17-00-38-19.bpo-32232.o7G_UO.rst
+++ b/Misc/NEWS.d/next/Build/2018-04-17-00-38-19.bpo-32232.o7G_UO.rst
@@ -1,0 +1,2 @@
+Some modules configured in Modules/Setup are not anymore built with
+-DPy_BUILD_CORE.

--- a/Misc/NEWS.d/next/Build/2018-04-17-00-38-19.bpo-32232.o7G_UO.rst
+++ b/Misc/NEWS.d/next/Build/2018-04-17-00-38-19.bpo-32232.o7G_UO.rst
@@ -1,2 +1,3 @@
-Some modules configured in Modules/Setup are not anymore built with
--DPy_BUILD_CORE.
+By default, modules configured in `Modules/Setup` are no longer built with
+`-DPy_BUILD_CORE`. Instead, modules that specifically need that preprocessor
+definition include it in their individual entries.

--- a/Modules/Setup.dist
+++ b/Modules/Setup.dist
@@ -104,33 +104,33 @@ PYTHONPATH=$(COREPYTHONPATH)
 # This only contains the minimal set of modules required to run the
 # setup.py script in the root of the Python source tree.
 
-posix posixmodule.c		# posix (UNIX) system calls
-errno errnomodule.c		# posix (UNIX) errno values
-pwd pwdmodule.c			# this is needed to find out the user's home dir
-				# if $HOME is not set
-_sre _sre.c			# Fredrik Lundh's new regular expressions
-_codecs _codecsmodule.c		# access to the builtin codecs and codec registry
-_weakref _weakref.c		# weak references
-_functools _functoolsmodule.c   # Tools for working with functions and callable objects
-_operator _operator.c	        # operator.add() and similar goodies
-_collections _collectionsmodule.c # Container types
-_abc _abc.c                     # Abstract base classes
-itertools itertoolsmodule.c    # Functions creating iterators for efficient looping
-atexit atexitmodule.c      # Register functions to be run at interpreter-shutdown
-_signal signalmodule.c
-_stat _stat.c			# stat.h interface
-time timemodule.c	# -lm # time operations and variables
-_thread _threadmodule.c         # low-level threading interface
+posix -DPy_BUILD_CORE posixmodule.c	# posix (UNIX) system calls
+errno errnomodule.c			# posix (UNIX) errno values
+pwd pwdmodule.c				# this is needed to find out the user's home dir
+					# if $HOME is not set
+_sre _sre.c				# Fredrik Lundh's new regular expressions
+_codecs _codecsmodule.c			# access to the builtin codecs and codec registry
+_weakref _weakref.c			# weak references
+_functools -DPy_BUILD_CORE _functoolsmodule.c   # Tools for working with functions and callable objects
+_operator _operator.c	        	# operator.add() and similar goodies
+_collections _collectionsmodule.c	# Container types
+_abc _abc.c				# Abstract base classes
+itertools itertoolsmodule.c		# Functions creating iterators for efficient looping
+atexit atexitmodule.c			# Register functions to be run at interpreter-shutdown
+_signal -DPy_BUILD_CORE signalmodule.c
+_stat _stat.c				# stat.h interface
+time -DPy_BUILD_CORE timemodule.c	# -lm # time operations and variables
+_thread -DPy_BUILD_CORE _threadmodule.c	# low-level threading interface
 
 # access to ISO C locale support
 _locale _localemodule.c  # -lintl
 
 # Standard I/O baseline
-_io -I$(srcdir)/Modules/_io _io/_iomodule.c _io/iobase.c _io/fileio.c _io/bytesio.c _io/bufferedio.c _io/textio.c _io/stringio.c
+_io -DPy_BUILD_CORE -I$(srcdir)/Modules/_io _io/_iomodule.c _io/iobase.c _io/fileio.c _io/bytesio.c _io/bufferedio.c _io/textio.c _io/stringio.c
 
 # The zipimport module is always imported at startup. Having it as a
 # builtin module avoids some bootstrapping problems and reduces overhead.
-zipimport zipimport.c
+zipimport -DPy_BUILD_CORE zipimport.c
 
 # faulthandler module
 faulthandler faulthandler.c

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -233,7 +233,7 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 			case $doconfig in
 			no)	cc="$cc \$(CCSHARED) \$(PY_CFLAGS) \$(PY_CPPFLAGS)";;
 			*)
-				cc="$cc \$(PY_NO_CORE_CFLAGS)";;
+				cc="$cc \$(PY_STDMODULE_CFLAGS)";;
 			esac
 			rule="$obj: $src; $cc $cpps -c $src -o $obj"
 			echo "$rule" >>$rulesf

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -233,7 +233,7 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 			case $doconfig in
 			no)	cc="$cc \$(CCSHARED) \$(PY_CFLAGS) \$(PY_CPPFLAGS)";;
 			*)
-				cc="$cc \$(PY_CORE_CFLAGS)";;
+				cc="$cc \$(PY_NO_CORE_CFLAGS)";;
 			esac
 			rule="$obj: $src; $cc $cpps -c $src -o $obj"
 			echo "$rule" >>$rulesf


### PR DESCRIPTION


<!-- issue-number: bpo-32232 -->
https://bugs.python.org/issue32232
<!-- /issue-number -->
