### PR TITLE
bpo-33234 Improve list() pre-sizing for inputs with known lengths

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -2028,7 +2028,7 @@ order (MRO) for bases """
                 setattr(X, attr, obj)
             setattr(X, name, SpecialDescr(meth_impl))
             runner(X())
-            self.assertEqual(record, [1], name)
+            self.assertGreaterEqual(record.count(1), 1, name)
 
             class X(Checker):
                 pass

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -1,5 +1,6 @@
 import sys
 from test import list_tests
+from test.support import cpython_only
 import pickle
 import unittest
 
@@ -156,6 +157,14 @@ class ListTest(list_tests.CommonTest):
         class L(list): pass
         with self.assertRaises(TypeError):
             (3,) + L([1,2])
+
+    @cpython_only
+    def test_preallocation(self):
+        iterable = [0] * 10
+        iter_size = sys.getsizeof(iterable)
+
+        self.assertEqual(iter_size, sys.getsizeof(list([0] * 10)))
+        self.assertEqual(iter_size, sys.getsizeof(list(range(10))))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-17-01-24-51.bpo-33234.l9IDtp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-17-01-24-51.bpo-33234.l9IDtp.rst
@@ -1,0 +1,2 @@
+The list constructor will pre-size and not over-allocate when the input size
+is known or can be reasonably estimated.


### PR DESCRIPTION
The list() constructor isn't taking full advantage of known input
lengths or length hints. This commit makes the constructor
pre-size and not over-allocate when the input size is known or
can be reasonably estimated.

A new test is added to `test_list.py` and a test needed to be modified
in `test_descr.py` as it assumed that there is only one call to
`__length_hint__()` in the list constructor.

<!-- issue-number: [bpo-33234](https://www.bugs.python.org/issue33234) -->
https://bugs.python.org/issue33234
<!-- /issue-number -->
