### PR TITLE
bpo-33251: Revert 725476222a3c1f2f93162d75a540e6bcdeaa36fd

### DIFF
--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -1120,10 +1120,6 @@ ConfigParser Objects
       given *section*.  Optional arguments have the same meaning as for the
       :meth:`get` method.
 
-      .. versionchanged:: 3.2
-         Items present in *vars* no longer appear in the result.  The previous
-         behaviour mixed actual parser options with variables provided for
-         interpolation.
 
    .. method:: set(section, option, value)
 


### PR DESCRIPTION
This note in documentation was never true.

<!-- issue-number: bpo-33251 -->
https://bugs.python.org/issue33251
<!-- /issue-number -->
