### PR TITLE
bpo-33292: Fix secrets.randbelow docstring

### DIFF
--- a/Lib/secrets.py
+++ b/Lib/secrets.py
@@ -25,7 +25,7 @@ randbits = _sysrand.getrandbits
 choice = _sysrand.choice
 
 def randbelow(exclusive_upper_bound):
-    """Return a random int in the range [0, n)."""
+    """Return a random int in the range(0, n)."""
     if exclusive_upper_bound <= 0:
         raise ValueError("Upper bound must be positive.")
     return _sysrand._randbelow(exclusive_upper_bound)

--- a/Lib/secrets.py
+++ b/Lib/secrets.py
@@ -25,7 +25,7 @@ randbits = _sysrand.getrandbits
 choice = _sysrand.choice
 
 def randbelow(exclusive_upper_bound):
-    """Return a random int in the range(0, n)."""
+    """Return a random integer x satisfying 0 <= x < n."""
     if exclusive_upper_bound <= 0:
         raise ValueError("Upper bound must be positive.")
     return _sysrand._randbelow(exclusive_upper_bound)

--- a/Misc/NEWS.d/next/Library/2018-04-16-10-13-00.bpo-33292.hellonixawk.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-16-10-13-00.bpo-33292.hellonixawk.rst
@@ -1,0 +1,1 @@
+Fix randbelow docstring description in secrets module.


### PR DESCRIPTION
- https://github.com/python/cpython/blob/master/Lib/secrets.py#L28

Please fix

```
"""Return a random int in the range [0, n)."""
```

to

```
"""Return a random integer x satisfying 0 <= x < n."""
```

<!-- issue-number: bpo-33292 -->
https://bugs.python.org/issue33292
<!-- /issue-number -->
