### PR TITLE
bpo-33295: Skip test using missing external site

### DIFF
--- a/Lib/test/test_urllib2net.py
+++ b/Lib/test/test_urllib2net.py
@@ -177,6 +177,7 @@ class OtherNetworkTests(unittest.TestCase):
             opener.open(request)
             self.assertEqual(request.get_header('User-agent'),'Test-Agent')
 
+    @unittest.skip('XXX: http://www.imdb.com is gone')
     def test_sites_no_connection_close(self):
         # Some sites do not send Connection: close header.
         # Verify that those work properly. (#issue12576)


### PR DESCRIPTION
`test_urllib2net.OtherNetworkTests.test_sites_no_connection_close`
used `http://www.imdb.com/` but it is moved to https so the test is
not valid anymore.

<!-- issue-number: bpo-33295 -->
https://bugs.python.org/issue33295
<!-- /issue-number -->
