### PR TITLE
[RFC] pdb.do_debug: handle any exceptions

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -1096,7 +1096,10 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         p = Pdb(self.completekey, self.stdin, self.stdout)
         p.prompt = "(%s) " % self.prompt.strip()
         self.message("ENTERING RECURSIVE DEBUGGER")
-        sys.call_tracing(p.run, (arg, globals, locals))
+        try:
+            sys.call_tracing(p.run, (arg, globals, locals))
+        except Exception as exc:
+            print('Failed to run cmd: %r' % exc)
         self.message("LEAVING RECURSIVE DEBUGGER")
         sys.settrace(self.trace_dispatch)
         self.lastcmd = p.lastcmd


### PR DESCRIPTION
This avoids crashing with e.g. `debug foo(` (which causes a
SyntaxError).

This PR is mostly to request feedback and check if existing tests are failing (to see where a new test should go eventually).