### PR TITLE
bpo-33299: Return an object itself for some types in _PyCode_ConstantKey().

### DIFF
--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -488,14 +488,21 @@ _PyCode_ConstantKey(PyObject *op)
 {
     PyObject *key;
 
-    /* Py_None and Py_Ellipsis are singleton */
+    /* Py_None and Py_Ellipsis are singletons. */
     if (op == Py_None || op == Py_Ellipsis
        || PyLong_CheckExact(op)
-       || PyBool_Check(op)
-       || PyBytes_CheckExact(op)
        || PyUnicode_CheckExact(op)
           /* code_richcompare() uses _PyCode_ConstantKey() internally */
-       || PyCode_Check(op)) {
+       || PyCode_Check(op))
+    {
+        /* Objects of these types are always different from object of other
+         * type and from tuples. */
+        Py_INCREF(op);
+        key = op;
+    }
+    else if (PyBool_Check(op) || PyBytes_CheckExact(op)) {
+        /* Make booleans different from integers 0 and 1.
+         * Avoid BytesWarning from comparing bytes with strings. */
         key = PyTuple_Pack(2, Py_TYPE(op), op);
     }
     else if (PyFloat_CheckExact(op)) {

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -5299,10 +5299,12 @@ dict_keys_inorder(PyObject *dict, Py_ssize_t offset)
         return NULL;
     while (PyDict_Next(dict, &pos, &k, &v)) {
         i = PyLong_AS_LONG(v);
-        /* The keys of the dictionary are tuples. (see compiler_add_o
-         * and _PyCode_ConstantKey). The object we want is always second,
-         * though. */
-        k = PyTuple_GET_ITEM(k, 1);
+        /* The keys of the dictionary can be tuples wrapping a contant.
+         * (see compiler_add_o and _PyCode_ConstantKey). In that case
+         * the object we want is always second. */
+        if (PyTuple_CheckExact(k)) {
+            k = PyTuple_GET_ITEM(k, 1);
+        }
         Py_INCREF(k);
         assert((i - offset) < size);
         assert((i - offset) >= 0);


### PR DESCRIPTION


<!-- issue-number: bpo-33299 -->
https://bugs.python.org/issue33299
<!-- /issue-number -->
