### PR TITLE
bpo-26153: Fix a rare crash when issuing warnings during interpreter shutdown

### DIFF
--- a/Misc/NEWS.d/next/C API/2018-04-18-16-31-22.bpo-26153.yhg1sx.rst
+++ b/Misc/NEWS.d/next/C API/2018-04-18-16-31-22.bpo-26153.yhg1sx.rst
@@ -1,0 +1,1 @@
+Fix a rare crash when issuing warnings during interpreter shutdown.

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -62,6 +62,11 @@ get_warnings_attr(const char *attr, int try_import)
             return NULL;
         }
     }
+    else if (_Py_Finalizing != NULL) {
+        /* PyImport_GetModuleDict() isn't safe during interpreter shutdown,
+         * so like above, fall back to the C implementation. */
+        return NULL;
+    }
     else {
         all_modules = PyImport_GetModuleDict();
 


### PR DESCRIPTION
Fix a rare crash when using the 'warnings' module during interpreter shutdown: if interp->modules is deleted at the wrong time, PyImport_GetModulesDict() will abort.

<!-- issue-number: bpo-26153 -->
https://bugs.python.org/issue26153
<!-- /issue-number -->
