### PR TITLE
[2.7] bpo-33255: Treats 'utf-8' and aliases equally.

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -1,5 +1,6 @@
 """Implementation of JSONEncoder
 """
+import codecs
 import re
 
 try:
@@ -160,7 +161,7 @@ class JSONEncoder(object):
             self.item_separator, self.key_separator = separators
         if default is not None:
             self.default = default
-        self.encoding = encoding
+        self.encoding = codecs.lookup(encoding).name
 
     def default(self, o):
         """Implement this method in a subclass such that it returns

--- a/Lib/json/tests/test_unicode.py
+++ b/Lib/json/tests/test_unicode.py
@@ -84,6 +84,19 @@ class TestUnicode(object):
         self.assertRaises(UnicodeEncodeError, self.loads, '"a"', u"rat\xe9")
         self.assertRaises(TypeError, self.loads, '"a"', 1)
 
+    def test_aliases(self):
+        self.assertEqual(type(self.dumps({"u": "t"}, ensure_ascii=False)), str)
+        self.assertEqual(type(self.dumps({"u": "t"}, ensure_ascii=False, encoding='u8')), str)
+        self.assertEqual(type(self.dumps({"u": "t"}, ensure_ascii=False, encoding='latin1')), unicode)
+
+    def test_mixed_types(self):
+        s = {u"u": "a", "t": "\xe2\x82\xac"}
+        self.assertRaises(UnicodeError, self.dumps, s, ensure_ascii=False)
+        self.assertRaises(UnicodeError, self.dumps, s, ensure_ascii=False, encoding='utf8')
+
+    def test_invalid_encoding(self):
+        self.assertRaises(LookupError, self.dumps, [1, 2, 3], encoding='spam')
+
 
 class TestPyUnicode(TestUnicode, PyTest): pass
 class TestCUnicode(TestUnicode, CTest): pass

--- a/Lib/json/tests/test_unicode.py
+++ b/Lib/json/tests/test_unicode.py
@@ -85,10 +85,10 @@ class TestUnicode(object):
         self.assertRaises(TypeError, self.loads, '"a"', 1)
 
     def test_aliases(self):
-        t1 = type(self.dumps({"u": "t"}, ensure_ascii=False, encoding='u8'))
-        t2 = type(self.dumps({"u": "t"}, ensure_ascii=False))
-        self.assertEqual(t1, t2)
-
+        s1 = self.dumps({"u": "t"}, ensure_ascii=False, encoding='utf-8')
+        s2 = self.dumps({"u": "t"}, ensure_ascii=False, encoding='u8')
+        self.assertEqual(type(s1), type(s2))
+        self.assertEqual(s1, s2)
 
 
 class TestPyUnicode(TestUnicode, PyTest): pass

--- a/Lib/json/tests/test_unicode.py
+++ b/Lib/json/tests/test_unicode.py
@@ -85,17 +85,10 @@ class TestUnicode(object):
         self.assertRaises(TypeError, self.loads, '"a"', 1)
 
     def test_aliases(self):
-        self.assertEqual(type(self.dumps({"u": "t"}, ensure_ascii=False)), str)
-        self.assertEqual(type(self.dumps({"u": "t"}, ensure_ascii=False, encoding='u8')), str)
-        self.assertEqual(type(self.dumps({"u": "t"}, ensure_ascii=False, encoding='latin1')), unicode)
+        t1 = type(self.dumps({"u": "t"}, ensure_ascii=False, encoding='u8'))
+        t2 = type(self.dumps({"u": "t"}, ensure_ascii=False))
+        self.assertEqual(t1, t2)
 
-    def test_mixed_types(self):
-        s = {u"u": "a", "t": "\xe2\x82\xac"}
-        self.assertRaises(UnicodeError, self.dumps, s, ensure_ascii=False)
-        self.assertRaises(UnicodeError, self.dumps, s, ensure_ascii=False, encoding='utf8')
-
-    def test_invalid_encoding(self):
-        self.assertRaises(LookupError, self.dumps, [1, 2, 3], encoding='spam')
 
 
 class TestPyUnicode(TestUnicode, PyTest): pass

--- a/Misc/NEWS.d/next/Library/2018-04-18-23-21-14.bpo-33255.Yah0FJ.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-18-23-21-14.bpo-33255.Yah0FJ.rst
@@ -1,0 +1,2 @@
+Treats ``utf-8`` and all it's aliases (``utf8``, ``u8``, ...) in the same
+maner in ``json.dumps(o, ensure_ascii=Flase, encoding='u8')``


### PR DESCRIPTION
This ensures that

```python
import json
o = {u"greeting": "hi", "currency": "€"}
json.dumps(o, ensure_ascii=False, encoding="utf8")
json.dumps(o, ensure_ascii=False)
```

behave in the same way. They now both throw an exception (`UnicodeDecodeError`)
It would probably be slightly better return `u'{"currency": "\u20ac", "greeting": "hi"}'` in both cases, but that might break peoples codes.
Note that after this change

```python
import json
s = json.dumps([1, 2, 3], encoding='spam')
```

will throw `LookupError: unknown encoding: spam`. Of course many more variations are possible.

Thank you for your attention. I hope I followed the instructions correctly.

<!-- issue-number: bpo-33255 -->
https://bugs.python.org/issue33255
<!-- /issue-number -->
