### PR TITLE
bpo-24882: eagerly spawn threads in ThreadPoolExecutor

### DIFF
--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -346,7 +346,7 @@ class ThreadPoolShutdownTest(ThreadPoolMixin, ExecutorShutdownTest, BaseTestCase
         self.executor.submit(mul, 21, 2)
         self.executor.submit(mul, 6, 7)
         self.executor.submit(mul, 3, 14)
-        self.assertEqual(len(self.executor._threads), 3)
+        self.assertEqual(len(self.executor._threads), self.worker_count)
         self.executor.shutdown()
         for t in self.executor._threads:
             t.join()
@@ -742,6 +742,7 @@ class ThreadPoolExecutorTest(ThreadPoolMixin, ExecutorTest, BaseTestCase):
         executor = self.executor_type()
         self.assertEqual(executor._max_workers,
                          (os.cpu_count() or 1) * 5)
+        executor.shutdown()
 
 
 class ProcessPoolExecutorTest(ExecutorTest):

--- a/Misc/NEWS.d/next/Library/2018-04-18-17-23-46.bpo-24882.3JXIwK.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-18-17-23-46.bpo-24882.3JXIwK.rst
@@ -1,0 +1,2 @@
+Modify ThreadPoolExecutor to spawn worker threads on creation, instead of on
+work submission.


### PR DESCRIPTION
This is an alternate solution to issue 24882 (and a replacement for PR #6375). At the suggestion
of @pitrou , instead of implementing idle thread handling logic, this change modifies ThreadPoolExecutor to spawn all worker threads on creation - removing all the logic entirely. 

Also updates relevant test cases. 


<!-- issue-number: bpo-24882 -->
https://bugs.python.org/issue24882
<!-- /issue-number -->
