### PR TITLE
[2.7] bpo-33308: Fix a crash in the parser module when convert an ST object. (GH-6519)

### DIFF
--- a/Lib/test/test_parser.py
+++ b/Lib/test/test_parser.py
@@ -263,21 +263,19 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
         # An absolutely minimal test of position information.  Better
         # tests would be a big project.
         code = "def f(x):\n    return x + 1"
-        st1 = parser.suite(code)
-        st2 = st1.totuple(line_info=1, col_info=1)
+        st = parser.suite(code)
 
         def walk(tree):
             node_type = tree[0]
             next = tree[1]
-            if isinstance(next, tuple):
+            if isinstance(next, (tuple, list)):
                 for elt in tree[1:]:
                     for x in walk(elt):
                         yield x
             else:
                 yield tree
 
-        terminals = list(walk(st2))
-        self.assertEqual([
+        expected = [
             (1, 'def', 1, 0),
             (1, 'f', 1, 4),
             (7, '(', 1, 5),
@@ -293,8 +291,25 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
             (4, '', 2, 16),
             (6, '', 2, -1),
             (4, '', 2, -1),
-            (0, '', 2, -1)],
-                         terminals)
+            (0, '', 2, -1),
+        ]
+
+        self.assertEqual(list(walk(st.totuple(line_info=True, col_info=True))),
+                         expected)
+        self.assertEqual(list(walk(st.totuple())),
+                         [(t, n) for t, n, l, c in expected])
+        self.assertEqual(list(walk(st.totuple(line_info=True))),
+                         [(t, n, l) for t, n, l, c in expected])
+        self.assertEqual(list(walk(st.totuple(col_info=True))),
+                         [(t, n, c) for t, n, l, c in expected])
+        self.assertEqual(list(walk(st.tolist(line_info=True, col_info=True))),
+                         [list(x) for x in expected])
+        self.assertEqual(list(walk(parser.st2tuple(st, line_info=True,
+                                                   col_info=True))),
+                         expected)
+        self.assertEqual(list(walk(parser.st2list(st, line_info=True,
+                                                  col_info=True))),
+                         [list(x) for x in expected])
 
 
 #

--- a/Misc/NEWS.d/next/Library/2018-04-18-19-12-25.bpo-33308.fW75xi.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-18-19-12-25.bpo-33308.fW75xi.rst
@@ -1,0 +1,2 @@
+Fixed a crash in the :mod:`parser` module when converting an ST object to a
+tree of tuples or lists with ``line_info=False`` and ``col_info=True``.

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -121,10 +121,10 @@ node2tuple(node *n,                     /* node to convert               */
         if (result != NULL) {
             (void) addelem(result, 0, PyInt_FromLong(TYPE(n)));
             (void) addelem(result, 1, PyString_FromString(STR(n)));
-            if (lineno == 1)
+            if (lineno)
                 (void) addelem(result, 2, PyInt_FromLong(n->n_lineno));
-            if (col_offset == 1)
-                (void) addelem(result, 3, PyInt_FromLong(n->n_col_offset));
+            if (col_offset)
+                (void) addelem(result, 2 + lineno, PyInt_FromLong(n->n_col_offset));
         }
         return (result);
     }


### PR DESCRIPTION
Converting with line_info=False and col_info=True crashed before.
(cherry picked from commit e5362eaa75a154c6e91c5b1c47719d0a0f5ca48b)


<!-- issue-number: bpo-33308 -->
https://bugs.python.org/issue33308
<!-- /issue-number -->
