### PR TITLE
bpo-33316: PyThread_release_lock always fails

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-04-20-03-24-07.bpo-33316.9IiJ8J.rst
+++ b/Misc/NEWS.d/next/Windows/2018-04-20-03-24-07.bpo-33316.9IiJ8J.rst
@@ -1,0 +1,1 @@
+PyThread_release_lock always fails

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -104,7 +104,8 @@ LeaveNonRecursiveMutex(PNRMUTEX mutex)
     if (PyMUTEX_LOCK(&mutex->cs))
         return FALSE;
     mutex->locked = 0;
-    result = PyCOND_SIGNAL(&mutex->cv);
+    /* condvar APIs return 0 on success. We need to return TRUE on success. */
+    result = !PyCOND_SIGNAL(&mutex->cv);
     PyMUTEX_UNLOCK(&mutex->cs);
     return result;
 }

--- a/Python/thread_nt.h
+++ b/Python/thread_nt.h
@@ -105,7 +105,7 @@ LeaveNonRecursiveMutex(PNRMUTEX mutex)
         return FALSE;
     mutex->locked = 0;
     result = PyCOND_SIGNAL(&mutex->cv);
-    result &= PyMUTEX_UNLOCK(&mutex->cs);
+    PyMUTEX_UNLOCK(&mutex->cs);
     return result;
 }
 


### PR DESCRIPTION


<!-- issue-number: bpo-33316 -->
https://bugs.python.org/issue33316
<!-- /issue-number -->
