### PR TITLE
bpo-33312: update Tools/gdb/libpython.py to match.

### DIFF
--- a/Tools/gdb/libpython.py
+++ b/Tools/gdb/libpython.py
@@ -730,7 +730,7 @@ class PyDictObjectPtr(PyObjectPtr):
         else:
             offset = 8 * dk_size
 
-        ent_addr = keys['dk_indices']['as_1'].address
+        ent_addr = keys['dk_indices'].address
         ent_addr = ent_addr.cast(_type_unsigned_char_ptr()) + offset
         ent_ptr_t = gdb.lookup_type('PyDictKeyEntry').pointer()
         ent_addr = ent_addr.cast(ent_ptr_t)


### PR DESCRIPTION
Attempt to fix test_gdb failing on some platforms possibly due to the changes in 397f1b28c4a12e3b3ed59a89599eabc457412649.

The test passes for me either way.