### PR TITLE
bpo-991266: Fix quoting of the Comment attribute of SimpleCookie

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -408,6 +408,8 @@ class Morsel(dict):
                 append("%s=%s" % (self._reserved[key], _getdate(value)))
             elif key == "max-age" and isinstance(value, int):
                 append("%s=%d" % (self._reserved[key], value))
+            elif key == "comment" and isinstance(value, str):
+                append("%s=%s" % (self._reserved[key], _quote(value)))
             elif key in self._flags:
                 if value:
                     append(str(self._reserved[key]))

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -220,6 +220,16 @@ class CookieTests(unittest.TestCase):
         with self.assertRaises(cookies.CookieError):
             C.load(rawdata)
 
+    def test_comment_quoting(self):
+        c = cookies.SimpleCookie()
+        c['foo'] = '\N{COPYRIGHT SIGN}'
+        self.assertEqual(str(c['foo']), 'Set-Cookie: foo="\\251"')
+        c['foo']['comment'] = 'comment \N{COPYRIGHT SIGN}'
+        self.assertEqual(
+            str(c['foo']),
+            'Set-Cookie: foo="\\251"; Comment="comment \\251"'
+        )
+
 
 class MorselTests(unittest.TestCase):
     """Tests for the Morsel object."""

--- a/Misc/NEWS.d/next/Library/2018-04-21-00-24-08.bpo-991266.h93TP_.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-21-00-24-08.bpo-991266.h93TP_.rst
@@ -1,0 +1,1 @@
+Fix quoting of the ``Comment`` attribute of :class:`http.cookies.SimpleCookie`.


### PR DESCRIPTION


<!-- issue-number: bpo-991266 -->
https://bugs.python.org/issue991266
<!-- /issue-number -->
