### PR TITLE
[3.6] Spelling fixes to docs, docstrings, and comments (GH-6374)

### DIFF
--- a/Doc/library/email.generator.rst
+++ b/Doc/library/email.generator.rst
@@ -185,7 +185,7 @@ to be using :class:`BytesGenerator`, and not :class:`Generator`.
       Convert any bytes with the high bit set as needed using an
       ASCII-compatible :mailheader:`Content-Transfer-Encoding`.  That is,
       transform parts with non-ASCII :mailheader:`Cotnent-Transfer-Encoding`
-      (:mailheader:`Content-Transfer-Encoding: 8bit`) to an ASCII compatibile
+      (:mailheader:`Content-Transfer-Encoding: 8bit`) to an ASCII compatible
       :mailheader:`Content-Transfer-Encoding`, and encode RFC-invalid non-ASCII
       bytes in headers using the MIME ``unknown-8bit`` character set, thus
       rendering them RFC-compliant.

--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -44,7 +44,7 @@ bpo-31860: The font sample in the settings dialog is now editable.
 Edits persist while IDLE remains open.
 Patch by Serhiy Storchake and Terry Jan Reedy.
 
-bpo-31858: Restrict shell prompt manipulaton to the shell.
+bpo-31858: Restrict shell prompt manipulation to the shell.
 Editor and output windows only see an empty last prompt line.  This
 simplifies the code and fixes a minor bug when newline is inserted.
 Sys.ps1, if present, is read on Shell start-up, but is not set or changed.

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -5586,7 +5586,7 @@ class LinuxKernelCryptoAPI(unittest.TestCase):
 @unittest.skipUnless(sys.platform.startswith("win"), "requires Windows")
 class TestMSWindowsTCPFlags(unittest.TestCase):
     knownTCPFlags = {
-                       # avaliable since long time ago
+                       # available since long time ago
                        'TCP_MAXSEG',
                        'TCP_NODELAY',
                        # available starting with Windows 10 1607


### PR DESCRIPTION
(cherry picked from commit 61f82e0e337f971da57f8f513abfe693edf95aa5)
