### PR TITLE
bpo-33334: Support NOP and EXTENDED_ARG in dis.stack_effect().

### DIFF
--- a/Lib/test/test__opcode.py
+++ b/Lib/test/test__opcode.py
@@ -15,6 +15,21 @@ class OpcodeTests(unittest.TestCase):
         self.assertRaises(ValueError, _opcode.stack_effect, 30000)
         self.assertRaises(ValueError, _opcode.stack_effect, dis.opmap['BUILD_SLICE'])
         self.assertRaises(ValueError, _opcode.stack_effect, dis.opmap['POP_TOP'], 0)
+        # All defined opcodes
+        for name, code in dis.opmap.items():
+            with self.subTest(opname=name):
+                if code < dis.HAVE_ARGUMENT:
+                    _opcode.stack_effect(code)
+                    self.assertRaises(ValueError, _opcode.stack_effect, code, 0)
+                else:
+                    _opcode.stack_effect(code, 0)
+                    self.assertRaises(ValueError, _opcode.stack_effect, code)
+        # All not defined opcodes
+        for code in set(range(256)) - set(dis.opmap.values()):
+            with self.subTest(opcode=code):
+                self.assertRaises(ValueError, _opcode.stack_effect, code)
+                self.assertRaises(ValueError, _opcode.stack_effect, code, 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-04-22-20-13-21.bpo-33334.19UMOC.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-22-20-13-21.bpo-33334.19UMOC.rst
@@ -1,0 +1,2 @@
+:func:`dis.stack_effect` now supports all defined opcodes including NOP and
+EXTENDED_ARG.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -859,6 +859,10 @@ static int
 stack_effect(int opcode, int oparg, int jump)
 {
     switch (opcode) {
+        case NOP:
+        case EXTENDED_ARG:
+            return 0;
+
         /* Stack manipulation */
         case POP_TOP:
             return -1;


### PR DESCRIPTION
Added tests to ensure that all defined opcodes are supported.


<!-- issue-number: bpo-33334 -->
https://bugs.python.org/issue33334
<!-- /issue-number -->
