### PR TITLE
bpo-33333

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -843,9 +843,11 @@ class RawConfigParser(MutableMapping):
         d = self._defaults.copy()
         try:
             d.update(self._sections[section])
+            section_keys = list(self._sections[section])
         except KeyError:
             if section != self.default_section:
                 raise NoSectionError(section)
+            section_keys = list(d)
         # Update with the entry specific variables
         if vars:
             for key, value in vars.items():
@@ -854,7 +856,8 @@ class RawConfigParser(MutableMapping):
             section, option, d[option], d)
         if raw:
             value_getter = lambda option: d[option]
-        return [(option, value_getter(option)) for option in d.keys()]
+        return [(option, value_getter(option)) for option in d.keys()
+                if option in section_keys]
 
     def popitem(self):
         """Remove a section from the parser and return it as

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -489,10 +489,11 @@ class ExtendedInterpolation(Interpolation):
                 path = m.group(1).split(':')
                 rest = rest[m.end():]
                 sect = section
-                opt = option
                 try:
                     if len(path) == 1:
                         opt = parser.optionxform(path[0])
+                        if opt not in map:
+                            map.update(parser.items(parser.default_section))
                         v = map[opt]
                     elif len(path) == 2:
                         sect = path[0]

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -912,11 +912,9 @@ class ConfigParserTestCase(BasicTestCase, unittest.TestCase):
                                     '%(reference)s', 'reference'))
 
     def test_items(self):
-        self.check_items_config([('default', '<default>'),
-                                 ('getdefault', '|<default>|'),
+        self.check_items_config([('getdefault', '|<default>|'),
                                  ('key', '|value|'),
-                                 ('name', 'value'),
-                                 ('value', 'value')])
+                                 ('name', 'value')])
 
     def test_safe_interpolation(self):
         # See http://www.python.org/sf/511737
@@ -1090,11 +1088,9 @@ class RawConfigParserTestCase(BasicTestCase, unittest.TestCase):
            "something %(with11)s lots of interpolation (11 steps)")
 
     def test_items(self):
-        self.check_items_config([('default', '<default>'),
-                                 ('getdefault', '|%(default)s|'),
+        self.check_items_config([('getdefault', '|%(default)s|'),
                                  ('key', '|%(name)s|'),
-                                 ('name', '%(value)s'),
-                                 ('value', 'value')])
+                                 ('name', '%(value)s')])
 
     def test_set_nonstring_types(self):
         cf = self.newconfig()
@@ -1356,10 +1352,7 @@ class ConfigParserTestCaseTrickyFile(CfgParserTestCaseClass, unittest.TestCase):
         longname = 'yeah, sections can be indented as well'
         self.assertFalse(cf.getboolean(longname, 'are they subsections'))
         self.assertEqual(cf.get(longname, 'lets use some Unicode'), '片仮名')
-        self.assertEqual(len(cf.items('another one!')), 5) # 4 in section and
-                                                           # `go` from DEFAULT
-        with self.assertRaises(configparser.InterpolationMissingOptionError):
-            cf.items('no values here')
+        self.assertEqual(len(cf.items('another one!')), 4)
         self.assertEqual(cf.get('tricky interpolation', 'lets'), 'do this')
         self.assertEqual(cf.get('tricky interpolation', 'lets'),
                          cf.get('tricky interpolation', 'go'))


### PR DESCRIPTION
Documentation for [ConfigParser.items()](
https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.items) states:

> When section is not given, return a list of section_name, section_proxy pairs, including DEFAULTSECT.
>
> Otherwise, return a list of name, value pairs for the options in the given section. Optional arguments have the same meaning as for the get() method.

This fix aligns behaviour to that specified in the documentation.

As well as fixing [bpo-33333](https://bugs.python.org/issue33333) this also resolves [bpo-33251](https://bugs.python.org/issue33251) (related PR #6446).
