### PR TITLE
bpo-33329: Fix multiprocessing regression on newer glibcs

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-04-23-13-21-39.bpo-33329.lQ-Eod.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-23-13-21-39.bpo-33329.lQ-Eod.rst
@@ -1,0 +1,1 @@
+Fix multiprocessing regression on newer glibcs

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -819,7 +819,6 @@ iterable_to_sigset(PyObject *iterable, sigset_t *mask)
     int result = -1;
     PyObject *iterator, *item;
     long signum;
-    int err;
 
     sigemptyset(mask);
 
@@ -841,11 +840,14 @@ iterable_to_sigset(PyObject *iterable, sigset_t *mask)
         Py_DECREF(item);
         if (signum == -1 && PyErr_Occurred())
             goto error;
-        if (0 < signum && signum < NSIG)
-            err = sigaddset(mask, (int)signum);
-        else
-            err = 1;
-        if (err) {
+        if (0 < signum && signum < NSIG) {
+            /* bpo-33329: ignore sigaddset() return value as it can fail
+             * for some reserved signals, but we want the `range(1, NSIG)`
+             * idiom to allow selecting all valid signals.
+             */
+            (void) sigaddset(mask, (int)signum);
+        }
+        else {
             PyErr_Format(PyExc_ValueError,
                          "signal number %ld out of range", signum);
             goto error;


### PR DESCRIPTION
Starting with glibc 2.27.9000-xxx, sigaddset() can return EINVAL for some reserved signal numbers between 1 and NSIG.  The `range(1, NSIG)` idiom is commonly used to select all signals for blocking with `pthread_sigmask`. So we ignore the sigaddset() return value until we expose sigfillset() to provide a better idiom.


<!-- issue-number: bpo-33329 -->
https://bugs.python.org/issue33329
<!-- /issue-number -->
