### PR TITLE
[3.6] bpo-33329: Fix multiprocessing regression on newer glibcs (GH-6575)

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-04-23-13-21-39.bpo-33329.lQ-Eod.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-23-13-21-39.bpo-33329.lQ-Eod.rst
@@ -1,0 +1,1 @@
+Fix multiprocessing regression on newer glibcs


### PR DESCRIPTION
Starting with glibc 2.27.9000-xxx, sigaddset() can return EINVAL for some
reserved signal numbers between 1 and NSIG.  The `range(1, NSIG)` idiom
is commonly used to select all signals for blocking with `pthread_sigmask`.
So we ignore the sigaddset() return value until we expose sigfillset()
to provide a better idiom.
(cherry picked from commit 25038ecfb665bef641abf8cb61afff7505b0e008)


<!-- issue-number: bpo-33329 -->
https://bugs.python.org/issue33329
<!-- /issue-number -->
