### PR TITLE
bpo-33348: parse expressions after * and ** in lib2to3

### DIFF
--- a/Lib/lib2to3/Grammar.txt
+++ b/Lib/lib2to3/Grammar.txt
@@ -138,8 +138,8 @@ arglist: argument (',' argument)* [',']
 # that precede iterable unpackings are blocked; etc.
 argument: ( test [comp_for] |
             test '=' test |
-	    '**' expr |
-	    star_expr )
+            '**' test |
+	        '*' test )
 
 comp_iter: comp_for | comp_if
 comp_for: [ASYNC] 'for' exprlist 'in' or_test [comp_iter]

--- a/Lib/lib2to3/fixes/fix_apply.py
+++ b/Lib/lib2to3/fixes/fix_apply.py
@@ -37,10 +37,8 @@ class FixApply(fixer_base.BaseFix):
         # I feel like we should be able to express this logic in the
         # PATTERN above but I don't know how to do it so...
         if args:
-            if args.type == self.syms.star_expr:
-                return  # Make no change.
             if (args.type == self.syms.argument and
-                args.children[0].value == '**'):
+                args.children[0].value in {'**', '*'}):
                 return  # Make no change.
         if kwds and (kwds.type == self.syms.argument and
                      kwds.children[0].value == '**'):

--- a/Lib/lib2to3/fixes/fix_intern.py
+++ b/Lib/lib2to3/fixes/fix_intern.py
@@ -30,10 +30,8 @@ class FixIntern(fixer_base.BaseFix):
             # PATTERN above but I don't know how to do it so...
             obj = results['obj']
             if obj:
-                if obj.type == self.syms.star_expr:
-                    return  # Make no change.
                 if (obj.type == self.syms.argument and
-                    obj.children[0].value == '**'):
+                    obj.children[0].value in {'**', '*'}):
                     return  # Make no change.
         names = ('sys', 'intern')
         new = ImportAndCall(node, results, names)

--- a/Lib/lib2to3/fixes/fix_reload.py
+++ b/Lib/lib2to3/fixes/fix_reload.py
@@ -27,10 +27,8 @@ class FixReload(fixer_base.BaseFix):
             # PATTERN above but I don't know how to do it so...
             obj = results['obj']
             if obj:
-                if obj.type == self.syms.star_expr:
-                    return  # Make no change.
                 if (obj.type == self.syms.argument and
-                    obj.children[0].value == '**'):
+                    obj.children[0].value in {'**', '*'}):
                     return  # Make no change.
         names = ('imp', 'reload')
         new = ImportAndCall(node, results, names)

--- a/Lib/lib2to3/tests/test_parser.py
+++ b/Lib/lib2to3/tests/test_parser.py
@@ -253,6 +253,13 @@ class TestUnpackingGeneralizations(GrammarTest):
     def test_double_star_dict_literal_after_keywords(self):
         self.validate("""func(spam='fried', **{'eggs':'scrambled'})""")
 
+    def test_double_star_expression(self):
+        self.validate("""func(**{'a':2} or {})""")
+        self.validate("""func(**() or {})""")
+
+    def test_star_expression(self):
+        self.validate("""func(*[] or [2])""")
+
     def test_list_display(self):
         self.validate("""[*{2}, 3, *[4]]""")
 

--- a/Misc/NEWS.d/next/Library/2018-04-24-13-18-48.bpo-33348.XaJDei.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-24-13-18-48.bpo-33348.XaJDei.rst
@@ -1,0 +1,2 @@
+lib2to3 now recognizes expressions after ``*`` and `**` like in ``f(*[] or
+[])``.


### PR DESCRIPTION
These are valid even in python 2.7

<!-- issue-number: [bpo-33348](https://bugs.python.org/issue33348) -->
https://bugs.python.org/issue33348
<!-- /issue-number -->


Automerge-Triggered-By: @gpshead