### PR TITLE
[3.6] travis: Use -O3 option (GH-5599)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,11 @@ cache:
   - pip
   - ccache
 
+env:
+  global:
+    # Use -O3 because we don't use debugger on Travis-CI
+    - CFLAGS="-O3"
+
 branches:
   only:
     - master


### PR DESCRIPTION
We don't use debugger on Travis.
(cherry picked from commit 8ff53564730f7ba503f5ad94418c309c48e8516d)