### PR TITLE
bpo-30465: Fix C downcast warning on Windows in ast.c

### DIFF
--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4313,7 +4313,7 @@ fstring_fix_node_location(const node *parent, node *n, char *expr_str)
                     break;
                 start--;
             }
-            cols += substr - start;
+            cols += (int)(substr - start);
             /* Fix lineno in mulitline strings. */
             while ((substr = strchr(substr + 1, '\n')))
                 lines--;


### PR DESCRIPTION
ast.c: fstring_fix_node_location() downcasts a pointer difference to
a C int. Replace int with Py_ssize_t to fix the compiler warning.

<!-- issue-number: bpo-30465 -->
https://bugs.python.org/issue30465
<!-- /issue-number -->
