### PR TITLE
bpo-33041: Fix downcast warning on Windows

### DIFF
--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -297,7 +297,7 @@ frame_setlineno(PyFrameObject *f, PyObject* p_new_lineno)
     if (delta_iblock > 0) {
         f->f_iblock -= delta_iblock;
         PyTryBlock *b = &f->f_blockstack[f->f_iblock];
-        delta += (f->f_stacktop - f->f_valuestack) - b->b_level;
+        delta += (int)(f->f_stacktop - f->f_valuestack) - b->b_level;
         if (b->b_type == SETUP_FINALLY &&
             code[b->b_handler] == WITH_CLEANUP_START)
         {


### PR DESCRIPTION
Cast pointer difference from ssize_t to int: a frame is very unlikely
larger than 2 GB.

<!-- issue-number: bpo-33041 -->
https://bugs.python.org/issue33041
<!-- /issue-number -->
