### PR TITLE
bpo-30613: Fix that the distutils register command generates invalid HTTP multipart data

### DIFF
--- a/Lib/distutils/command/register.py
+++ b/Lib/distutils/command/register.py
@@ -255,7 +255,7 @@ Your selection [default 1]: ''', log.INFO)
                                                     log.INFO)
         # Build up the MIME payload for the urllib2 POST data
         boundary = '--------------GHSKFJDLGDS7543FJKLFHRE75642756743254'
-        sep_boundary = '\n--' + boundary
+        sep_boundary = '\r\n--' + boundary
         end_boundary = sep_boundary + '--'
         body = io.StringIO()
         for key, value in data.items():
@@ -265,8 +265,8 @@ Your selection [default 1]: ''', log.INFO)
             for value in value:
                 value = str(value)
                 body.write(sep_boundary)
-                body.write('\nContent-Disposition: form-data; name="%s"'%key)
-                body.write("\n\n")
+                body.write('\r\nContent-Disposition: form-data; name="%s"'%key)
+                body.write("\r\n\r\n")
                 body.write(value)
                 if value and value[-1] == '\r':
                     body.write('\n')  # write an extra newline (lurve Macs)

--- a/Lib/distutils/tests/test_register.py
+++ b/Lib/distutils/tests/test_register.py
@@ -152,8 +152,8 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         req1 = dict(self.conn.reqs[0].headers)
         req2 = dict(self.conn.reqs[1].headers)
 
-        self.assertEqual(req1['Content-length'], '1374')
-        self.assertEqual(req2['Content-length'], '1374')
+        self.assertEqual(req1['Content-length'], '1423')
+        self.assertEqual(req2['Content-length'], '1423')
         self.assertIn(b'xxx', self.conn.reqs[1].data)
 
     def test_password_not_in_file(self):
@@ -183,7 +183,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         self.assertEqual(len(self.conn.reqs), 1)
         req = self.conn.reqs[0]
         headers = dict(req.headers)
-        self.assertEqual(headers['Content-length'], '608')
+        self.assertEqual(headers['Content-length'], '629')
         self.assertIn(b'tarek', req.data)
 
     def test_password_reset(self):
@@ -201,7 +201,7 @@ class RegisterTestCase(BasePyPIRCCommandTestCase):
         self.assertEqual(len(self.conn.reqs), 1)
         req = self.conn.reqs[0]
         headers = dict(req.headers)
-        self.assertEqual(headers['Content-length'], '290')
+        self.assertEqual(headers['Content-length'], '299')
         self.assertIn(b'tarek', req.data)
 
     @unittest.skipUnless(docutils is not None, 'needs docutils')


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-30613 -->
https://bugs.python.org/issue30613
<!-- /issue-number -->
