### PR TITLE
fix running the curses.has_key module (closes bpo-33359)

### DIFF
--- a/Lib/curses/has_key.py
+++ b/Lib/curses/has_key.py
@@ -182,7 +182,7 @@ if __name__ == '__main__':
         L = []
         _curses.initscr()
         for key in _capability_names.keys():
-            system = key in _curses
+            system = _curses.has_key(key)
             python = has_key(key)
             if system != python:
                 L.append( 'Mismatch for key %s, system=%i, Python=%i'

--- a/Misc/NEWS.d/next/Library/2018-04-25-22-41-04.bpo-33359.Nr4CzK.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-25-22-41-04.bpo-33359.Nr4CzK.rst
@@ -1,0 +1,1 @@
+Fix running ``python -m curses.has_key``.


### PR DESCRIPTION
This was broken by poor automated translation back in 6e3dbbdf39f3b4eb6f18c0165e446df17218b7dc.


<!-- issue-number: bpo-33359 -->
https://bugs.python.org/issue33359
<!-- /issue-number -->
