### PR TITLE
bpo-33365: print the header values besides the keys

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -321,7 +321,7 @@ class HTTPResponse(io.BufferedIOBase):
 
         if self.debuglevel > 0:
             for hdr in self.headers:
-                print("header:", hdr, end=" ")
+                print("header:", hdr + ":", self.headers.get(hdr))
 
         # are we using the chunked-style of transfer encoding?
         tr_enc = self.headers.get("transfer-encoding")

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -344,6 +344,21 @@ class HeaderTests(TestCase):
                 with self.assertRaisesRegex(ValueError, 'Invalid header'):
                     conn.putheader(name, value)
 
+    def test_headers_debuglevel(self):
+        body = (
+            b'HTTP/1.1 200 OK\r\n'
+            b'First: val\r\n'
+            b'Second: val\r\n'
+        )
+        sock = FakeSocket(body)
+        resp = client.HTTPResponse(sock, debuglevel=1)
+        with support.captured_stdout() as output:
+            resp.begin()
+        lines = output.getvalue().splitlines()
+        self.assertEqual(lines[0], "reply: 'HTTP/1.1 200 OK\\r\\n'")
+        self.assertEqual(lines[1], "header: First: val")
+        self.assertEqual(lines[2], "header: Second: val")
+
 
 class TransferEncodingTest(TestCase):
     expected_body = b"It's just a flesh wound"

--- a/Misc/NEWS.d/next/Library/2018-05-08-15-01-10.bpo-33365.SicsAd.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-08-15-01-10.bpo-33365.SicsAd.rst
@@ -1,0 +1,1 @@
+Print the header values besides the header keys instead just the header keys if *debuglevel* is set to >0 in :mod:`http.client`. Patch by Marco Strigl.


### PR DESCRIPTION
With `debuglevel=1 `only the header keys got printed. With this change the header values get printed as well and the single header entries get '\n' as a separator.

<!-- issue-number: bpo-33365 -->
https://bugs.python.org/issue33365
<!-- /issue-number -->
