### PR TITLE
bpo-33358 Fix test_pre_initialization_sys_options when building with --enable-shared

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -208,7 +208,7 @@ class EmbeddingTests(unittest.TestCase):
         Checks that sys.warnoptions and sys._xoptions can be set before the
         runtime is initialized (otherwise they won't be effective).
         """
-        env = dict(PYTHONPATH=os.pathsep.join(sys.path))
+        env = dict(os.environ, PYTHONPATH=os.pathsep.join(sys.path))
         out, err = self.run_embedded_interpreter(
                         "pre_initialization_sys_options", env=env)
         expected_output = (

--- a/Misc/NEWS.d/next/Tests/2018-04-27-11-46-35.bpo-33358._OcR59.rst
+++ b/Misc/NEWS.d/next/Tests/2018-04-27-11-46-35.bpo-33358._OcR59.rst
@@ -1,0 +1,2 @@
+Fix ``test_embed.test_pre_initialization_sys_options()`` when the interpreter
+is built with ``--enable-shared``.


### PR DESCRIPTION


<!-- issue-number: bpo-33358 -->
https://bugs.python.org/issue33358
<!-- /issue-number -->
