### PR TITLE
bpo-33370: Add mypy cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ Tools/ssl/win32
 .vs/
 .vscode/
 gmon.out
+.mypy_cache/


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Since Python developers started to use mypy, I think we should add .mypy_cache directories to .gitignore.


<!-- issue-number: bpo-33370 -->
https://bugs.python.org/issue33370
<!-- /issue-number -->
