### PR TITLE
bpo-33371: Clarify the inspect.getmembers predicate parameter

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -247,9 +247,10 @@ attributes:
 
 .. function:: getmembers(object[, predicate])
 
-   Return all the members of an object in a list of (name, value) pairs sorted by
-   name.  If the optional *predicate* argument is supplied, only members for which
-   the predicate returns a true value are included.
+   Return all the members of an object in a list of ``(name, value)``
+   pairs sorted by name. If the optional *predicate* argument—which will be
+   called with the ``value`` object of each member—is supplied, only members
+   for which the predicate returns a true value are included.
 
    .. note::
 


### PR DESCRIPTION
Previously, the *predicate* parameter was mentioned, but what it was to be called with was not documented and required either trial-and-error or looking into the source to find that it is called with the `value`, or second item, of the full members list. This change addresses what the *predicate* callable will receive, as well as does some light formatting to make this clear.


<!-- issue-number: bpo-33371 -->
https://bugs.python.org/issue33371
<!-- /issue-number -->
