### PR TITLE
[3.7] bpo-33363: raise SyntaxError for async for/with outside async functions (GH-6616).

### DIFF
--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -362,7 +362,22 @@ class AsyncBadSyntaxTest(unittest.TestCase):
             """def foo():
                    async def bar():
                         pass\nawait a
-            """]
+            """,
+            """def foo():
+                   async for i in arange(2):
+                       pass
+            """,
+            """def foo():
+                   async with resource:
+                       pass
+            """,
+            """async with resource:
+                   pass
+            """,
+            """async for i in arange(2):
+                   pass
+            """,
+            ]
 
         for code in samples:
             with self.subTest(code=code), self.assertRaises(SyntaxError):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-26-22-48-28.bpo-33363.8RCnN2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-26-22-48-28.bpo-33363.8RCnN2.rst
@@ -1,0 +1,2 @@
+Raise a SyntaxError for ``async with`` and ``async for`` statements outside
+of async functions.

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -2339,6 +2339,10 @@ compiler_async_for(struct compiler *c, stmt_ty s)
     basicblock *try, *except, *end, *after_try, *try_cleanup,
                *after_loop_else;
 
+    if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION) {
+        return compiler_error(c, "'async for' outside async function");
+    }
+
     PyObject *stop_aiter_error = _PyUnicode_FromId(&PyId_StopAsyncIteration);
     if (stop_aiter_error == NULL) {
         return 0;
@@ -4204,6 +4208,9 @@ compiler_async_with(struct compiler *c, stmt_ty s, int pos)
     withitem_ty item = asdl_seq_GET(s->v.AsyncWith.items, pos);
 
     assert(s->kind == AsyncWith_kind);
+    if (c->u->u_scope_type != COMPILER_SCOPE_ASYNC_FUNCTION) {
+        return compiler_error(c, "'async with' outside async function");
+    }
 
     block = compiler_new_block(c);
     finally = compiler_new_block(c);


### PR DESCRIPTION


<!-- issue-number: bpo-33363 -->
https://bugs.python.org/issue33363
<!-- /issue-number -->
