### PR TITLE
bpo-32790: Added info about alt format using # for 'g' in chart

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -483,6 +483,11 @@ The available presentation types for floating point and decimal values are:
    |         | from the significand, and the decimal point is also      |
    |         | removed if there are no remaining digits following it.   |
    |         |                                                          |
+   |         | Also, The ``'#'`` option causes the "alternate form" to  |
+   |         | be used for the conversion. The alternate form is defined|
+   |         | differently for different types. For ``'g'`` conversion, |
+   |         | trailing zeros are not removed from the result.          |
+   |         |                                                          |
    |         | Positive and negative infinity, positive and negative    |
    |         | zero, and nans, are formatted as ``inf``, ``-inf``,      |
    |         | ``0``, ``-0`` and ``nan`` respectively, regardless of    |

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -481,12 +481,8 @@ The available presentation types for floating point and decimal values are:
    |         | with presentation type ``'e'`` and precision ``p-1``.    |
    |         | In both cases insignificant trailing zeros are removed   |
    |         | from the significand, and the decimal point is also      |
-   |         | removed if there are no remaining digits following it.   |
-   |         |                                                          |
-   |         | Also, The ``'#'`` option causes the "alternate form" to  |
-   |         | be used for the conversion. The alternate form is defined|
-   |         | differently for different types. For ``'g'`` conversion, |
-   |         | trailing zeros are not removed from the result.          |
+   |         | removed if there are no remaining digits following it,   |
+   |         | unless the ``'#'`` option is used.                       |
    |         |                                                          |
    |         | Positive and negative infinity, positive and negative    |
    |         | zero, and nans, are formatted as ``inf``, ``-inf``,      |


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Added additional information in the chart for format parameter 'g'. @CuriousLearner 


<!-- issue-number: bpo-32790 -->
https://bugs.python.org/issue32790
<!-- /issue-number -->
