### PR TITLE
bpo-19213: Adding support for Oracle OS distribution in platform.py

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -265,7 +265,7 @@ _release_version = re.compile(r'([^0-9]+)'
 # and http://www.die.net/doc/linux/man/man1/lsb_release.1.html
 
 _supported_dists = (
-    'SuSE', 'debian', 'fedora', 'redhat', 'centos',
+    'SuSE', 'debian', 'fedora', 'redhat', 'centos', 'oracle'
     'mandrake', 'mandriva', 'rocks', 'slackware', 'yellowdog', 'gentoo',
     'UnitedLinux', 'turbolinux', 'arch', 'mageia')
 

--- a/Misc/NEWS.d/next/Library/2018-04-28-11-30-33.bpo-19213.UV50t3.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-28-11-30-33.bpo-19213.UV50t3.rst
@@ -1,0 +1,2 @@
++Return Oracle OS information in ``platform.linux_distibution()``
++instead of RedHat. Patch by Komail Kanjee.


### PR DESCRIPTION
Presently when running Oracle OS which matches the RedHat OS, platform.linux_distribution returns the RedHat release information.

Adding oracle to the list so when oracle-release is available it will return that

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-19213 -->
https://bugs.python.org/issue19213
<!-- /issue-number -->
