### PR TITLE
bpo-33378: Add Korean to the language switcher.

### DIFF
--- a/Doc/tools/static/switchers.js
+++ b/Doc/tools/static/switchers.js
@@ -21,6 +21,7 @@
       'en': 'English',
       'fr': 'French',
       'ja': 'Japanese',
+      'ko': 'Korean',
   };
 
   function build_version_select(current_version, current_release) {

--- a/Misc/NEWS.d/next/Documentation/2018-04-29-04-02-18.bpo-33378.-anAHN.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-04-29-04-02-18.bpo-33378.-anAHN.rst
@@ -1,0 +1,1 @@
+Add Korean language switcher for https://docs.python.org/3/


### PR DESCRIPTION
bpo-33378: Add Korean to the language switcher.

<!-- issue-number: bpo-33378 -->
https://bugs.python.org/issue33378
<!-- /issue-number -->
