### PR TITLE
bpo-33388: Add variables to distutils/dist.py support PEP 566 metadata

### DIFF
--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -1056,6 +1056,9 @@ class DistributionMetadata:
             self.provides = None
             self.requires = None
             self.obsoletes = None
+            # PEP 566
+            self.long_description_content_type = None
+            self.provides_extras = None
 
     def read_pkg_file(self, file):
         """Reads the metadata values from a file object."""

--- a/Misc/NEWS.d/next/Build/2018-04-30-10-15-08.bpo-33388._MRe-V.rst
+++ b/Misc/NEWS.d/next/Build/2018-04-30-10-15-08.bpo-33388._MRe-V.rst
@@ -1,0 +1,1 @@
+Preliminary support for new fields from PEP 566 in distutils.


### PR DESCRIPTION
These variables are used in setuptools to support PEP 566 'Description-Content-Type' and 'Provides-Extra':

https://www.python.org/dev/peps/pep-0566/
http://setuptools.readthedocs.io/en/latest/setuptools.html#metadata

Currently dist.py in CPython will warn if they are set, e.g.:

`dist.py:261: UserWarning: Unknown distribution option: 'long_description_content_type'`

The warnings seem spurious, but looked a bit scary to me as a new user. By declaring these variables, the warnings are no longer displayed. long_description_content_type, at least, is being used in the wild since:

https://github.com/pypa/sampleproject/commit/5be097071c83c935777bde117fa85cd1f64c690a

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33388 -->
https://bugs.python.org/issue33388
<!-- /issue-number -->
