### PR TITLE
bpo-21474: Update IDLE word/identifier definition from ascii to unicode.

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -1658,12 +1658,12 @@ def get_accelerator(keydefs, eventname):
 
 
 def fixwordbreaks(root):
-    # Make sure that Tk's double-click and next/previous word
-    # operations use our definition of a word (i.e. an identifier)
+    # On Windows, tcl/tk breaks 'words' only on spaces, as in Command Prompt.
+    # We want Motif style everywhere. See #21474, msg218992 and followup.
     tk = root.tk
     tk.call('tcl_wordBreakAfter', 'a b', 0) # make sure word.tcl is loaded
-    tk.call('set', 'tcl_wordchars', '[a-zA-Z0-9_]')
-    tk.call('set', 'tcl_nonwordchars', '[^a-zA-Z0-9_]')
+    tk.call('set', 'tcl_wordchars', r'\w')
+    tk.call('set', 'tcl_nonwordchars', r'\W')
 
 
 def _editor_window(parent):  # htest #

--- a/Misc/NEWS.d/next/IDLE/2018-04-29-16-13-02.bpo-21474.bglg-F.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-04-29-16-13-02.bpo-21474.bglg-F.rst
@@ -1,0 +1,3 @@
+Update word/identifier definition from ascii to unicode. In text and entry
+boxes, this affects selection by double-click, movement left/right by
+control-left/right, and deletion left/right by control-BACKSPACE/DEL.


### PR DESCRIPTION
In text and entry boxes, this affects selection by double-click,
movement left/right by control-left/right, and deletion left/right
by control-BACKSPACE/DEL.


<!-- issue-number: bpo-21474 -->
https://bugs.python.org/issue21474
<!-- /issue-number -->
