### PR TITLE
[2.7] bpo-32362: Fix references to non-existent multiprocessing.Connection() (GH-6223)

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -574,9 +574,8 @@ For an example of the usage of queues for interprocess communication see
 
 .. function:: Pipe([duplex])
 
-   Returns a pair ``(conn1, conn2)`` of
-   :class:`~multiprocessing.connection.Connection` objects representing the
-   ends of a pipe.
+   Returns a pair ``(conn1, conn2)`` of :class:`Connection` objects
+   representing the ends of a pipe.
 
    If *duplex* is ``True`` (the default) then the pipe is bidirectional.  If
    *duplex* is ``False`` then the pipe is unidirectional: ``conn1`` can only be
@@ -804,7 +803,7 @@ Miscellaneous
 Connection Objects
 ~~~~~~~~~~~~~~~~~~
 
-.. currentmodule:: multiprocessing.connection
+.. currentmodule:: None
 
 Connection objects allow the sending and receiving of picklable objects or
 strings.  They can be thought of as message oriented connected sockets.

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -813,7 +813,6 @@ Connection objects are usually created using
 :ref:`multiprocessing-listeners-clients`.
 
 .. class:: Connection
-   :noindex:
 
    .. method:: send(obj)
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -574,7 +574,7 @@ For an example of the usage of queues for interprocess communication see
 
 .. function:: Pipe([duplex])
 
-   Returns a pair ``(conn1, conn2)`` of :class:`Connection` object representing
+   Returns a pair ``(conn1, conn2)`` of :class:`Connection` objects representing
    the ends of a pipe.
 
    If *duplex* is ``True`` (the default) then the pipe is bidirectional.  If

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -574,8 +574,9 @@ For an example of the usage of queues for interprocess communication see
 
 .. function:: Pipe([duplex])
 
-   Returns a pair ``(conn1, conn2)`` of :class:`Connection` objects representing
-   the ends of a pipe.
+   Returns a pair ``(conn1, conn2)`` of
+   :class:`~multiprocessing.connection.Connection` objects representing the
+   ends of a pipe.
 
    If *duplex* is ``True`` (the default) then the pipe is bidirectional.  If
    *duplex* is ``False`` then the pipe is unidirectional: ``conn1`` can only be
@@ -803,10 +804,13 @@ Miscellaneous
 Connection Objects
 ~~~~~~~~~~~~~~~~~~
 
+.. currentmodule:: multiprocessing.connection
+
 Connection objects allow the sending and receiving of picklable objects or
 strings.  They can be thought of as message oriented connected sockets.
 
-Connection objects are usually created using :func:`Pipe` -- see also
+Connection objects are usually created using
+:func:`Pipe <multiprocessing.Pipe>` -- see also
 :ref:`multiprocessing-listeners-clients`.
 
 .. class:: Connection
@@ -925,6 +929,8 @@ For example:
 
 Synchronization primitives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: multiprocessing
 
 Generally synchronization primitives are not as necessary in a multiprocess
 program as they are in a multithreaded program.  See the documentation for
@@ -1943,7 +1949,7 @@ Listeners and Clients
    :synopsis: API for dealing with sockets.
 
 Usually message passing between processes is done using queues or by using
-:class:`~multiprocessing.Connection` objects returned by
+:class:`~Connection` objects returned by
 :func:`~multiprocessing.Pipe`.
 
 However, the :mod:`multiprocessing.connection` module allows some extra
@@ -1972,7 +1978,7 @@ authentication* using the :mod:`hmac` module.
 .. function:: Client(address[, family[, authenticate[, authkey]]])
 
    Attempt to set up a connection to the listener which is using address
-   *address*, returning a :class:`~multiprocessing.Connection`.
+   *address*, returning a :class:`~Connection`.
 
    The type of the connection is determined by *family* argument, but this can
    generally be omitted since it can usually be inferred from the format of
@@ -2028,8 +2034,8 @@ authentication* using the :mod:`hmac` module.
    .. method:: accept()
 
       Accept a connection on the bound socket or named pipe of the listener
-      object and return a :class:`~multiprocessing.Connection` object.  If
-      authentication is attempted and fails, then
+      object and return a :class:`~Connection` object.
+      If authentication is attempted and fails, then
       :exc:`~multiprocessing.AuthenticationError` is raised.
 
    .. method:: close()
@@ -2126,10 +2132,10 @@ an ``'AF_PIPE'`` address rather than an ``'AF_UNIX'`` address.
 Authentication keys
 ~~~~~~~~~~~~~~~~~~~
 
-When one uses :meth:`Connection.recv <multiprocessing.Connection.recv>`, the
+When one uses :meth:`Connection.recv <Connection.recv>`, the
 data received is automatically
-unpickled.  Unfortunately unpickling data from an untrusted source is a security
-risk.  Therefore :class:`Listener` and :func:`Client` use the :mod:`hmac` module
+unpickled. Unfortunately unpickling data from an untrusted source is a security
+risk. Therefore :class:`Listener` and :func:`Client` use the :mod:`hmac` module
 to provide digest authentication.
 
 An authentication key is a string which can be thought of as a password: once a

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1977,7 +1977,7 @@ authentication* using the :mod:`hmac` module.
 .. function:: Client(address[, family[, authenticate[, authkey]]])
 
    Attempt to set up a connection to the listener which is using address
-   *address*, returning a :class:`~Connection`.
+   *address*, returning a :class:`Connection`.
 
    The type of the connection is determined by *family* argument, but this can
    generally be omitted since it can usually be inferred from the format of
@@ -2033,7 +2033,7 @@ authentication* using the :mod:`hmac` module.
    .. method:: accept()
 
       Accept a connection on the bound socket or named pipe of the listener
-      object and return a :class:`~Connection` object.
+      object and return a :class:`Connection` object.
       If authentication is attempted and fails, then
       :exc:`~multiprocessing.AuthenticationError` is raised.
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -804,7 +804,6 @@ Connection Objects
 ~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: None
-   :noindex:
 
 Connection objects allow the sending and receiving of picklable objects or
 strings.  They can be thought of as message oriented connected sockets.
@@ -814,6 +813,7 @@ Connection objects are usually created using
 :ref:`multiprocessing-listeners-clients`.
 
 .. class:: Connection
+   :noindex:
 
    .. method:: send(obj)
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -574,8 +574,8 @@ For an example of the usage of queues for interprocess communication see
 
 .. function:: Pipe([duplex])
 
-   Returns a pair ``(conn1, conn2)`` of :class:`Connection` objects
-   representing the ends of a pipe.
+   Returns a pair ``(conn1, conn2)`` of :class:`Connection` object representing
+   the ends of a pipe.
 
    If *duplex* is ``True`` (the default) then the pipe is bidirectional.  If
    *duplex* is ``False`` then the pipe is unidirectional: ``conn1`` can only be
@@ -804,6 +804,7 @@ Connection Objects
 ~~~~~~~~~~~~~~~~~~
 
 .. currentmodule:: None
+   :noindex:
 
 Connection objects allow the sending and receiving of picklable objects or
 strings.  They can be thought of as message oriented connected sockets.
@@ -1948,8 +1949,7 @@ Listeners and Clients
    :synopsis: API for dealing with sockets.
 
 Usually message passing between processes is done using queues or by using
-:class:`~Connection` objects returned by
-:func:`~multiprocessing.Pipe`.
+:class:`Connection` objects returned by :func:`~multiprocessing.Pipe`.
 
 However, the :mod:`multiprocessing.connection` module allows some extra
 flexibility.  It basically gives a high level message oriented API for dealing
@@ -2144,10 +2144,10 @@ an ``'AF_PIPE'`` address rather than an ``'AF_UNIX'`` address.
 Authentication keys
 ~~~~~~~~~~~~~~~~~~~
 
-When one uses :meth:`Connection.recv <Connection.recv>`, the
+When one uses :meth:`Connection.recv`, the
 data received is automatically
-unpickled. Unfortunately unpickling data from an untrusted source is a security
-risk. Therefore :class:`Listener` and :func:`Client` use the :mod:`hmac` module
+unpickled.  Unfortunately unpickling data from an untrusted source is a security
+risk.  Therefore :class:`Listener` and :func:`Client` use the :mod:`hmac` module
 to provide digest authentication.
 
 An authentication key is a string which can be thought of as a password: once a


### PR DESCRIPTION
This PR is a backport of #6223 to 2.7. 

While fixing the conflict, I noticed a mistake in the 2.7 docs. [This section](https://github.com/python/cpython/blame/2.7/Doc/library/multiprocessing.rst#L2053-L2057) states there are "two" exceptions, but then goes on to define only one. I will make a separate PR for that.

CC: @serhiy-storchaka 

<!-- issue-number: bpo-32362 -->
https://bugs.python.org/issue32362
<!-- /issue-number -->
