### PR TITLE
[2.7] Fix multiprocessing docs' list of exceptions

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -2050,11 +2050,24 @@ authentication* using the :mod:`hmac` module.
       unavailable then it is ``None``.
 
 
-The module defines two exceptions:
+The module defines the following exceptions:
+
+.. exception:: ProcessError
+
+   The base class of all :mod:`multiprocessing` exceptions.
+
+.. exception:: BufferTooShort
+
+   Exception raised by :meth:`Connection.recv_bytes_into()` when the supplied
+   buffer object is too small for the message read.
 
 .. exception:: AuthenticationError
 
-   Exception raised when there is an authentication error.
+   Raised when there is an authentication error.
+
+.. exception:: TimeoutError
+
+   Raised by methods with a timeout when the timeout expires.
 
 
 **Examples**


### PR DESCRIPTION
The docs for Python 2.7's `multiprocessing` module say:

```
The module defines two exceptions:

.. exception:: AuthenticationError

   Exception raised when there is an authentication error.
```

It's a bit odd to say there are two, and then write about one. It's even more odd when you look at the module and find there are [four](https://github.com/python/cpython/blob/2.7/Lib/multiprocessing/__init__.py#L71-L81).

This PR adds definitions for `ProcessError`, `BufferTooShort`, and `TimeoutError`, which come from the 3.x docs. AFAICT they apply, modulo the detail about `BufferTooShot` returning a `bytes` string. I've left that clause out.

I believe this PR should be tagged with `skip news` and `type-documentation`?

Ref: #6223 and #6646 