### PR TITLE
[2.7] bpo-33256: Replace angle brackets around python object repr to display it in html (GH-6442).

### DIFF
--- a/Lib/cgitb.py
+++ b/Lib/cgitb.py
@@ -125,7 +125,7 @@ function calls leading up to the error, in the order they occurred.</p>'''
         args, varargs, varkw, locals = inspect.getargvalues(frame)
         call = ''
         if func != '?':
-            call = 'in ' + strong(func) + \
+            call = 'in ' + strong(pydoc.html.escape(func)) + \
                 inspect.formatargvalues(args, varargs, varkw, locals,
                     formatvalue=lambda value: '=' + pydoc.html.repr(value))
 
@@ -285,7 +285,7 @@ class Hook:
 
         if self.display:
             if plain:
-                doc = doc.replace('&', '&amp;').replace('<', '&lt;')
+                doc = pydoc.html.escape(doc)
                 self.file.write('<pre>' + doc + '</pre>\n')
             else:
                 self.file.write(doc + '\n')

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -138,6 +138,7 @@ Mike Bland
 Martin Bless
 Pablo Bleyer
 Erik van Blokland
+Stéphane Blondon
 Eric Blossom
 Sergey Bobrov
 Finn Bock

--- a/Misc/NEWS.d/next/Library/2018-04-10-20-57-14.bpo-33256.ndHkqu.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-10-20-57-14.bpo-33256.ndHkqu.rst
@@ -1,0 +1,1 @@
+Fix display of ``<module>`` call in the html produced by ``cgitb.html()``. Patch by Stéphane Blondon.


### PR DESCRIPTION
(cherry picked from commit 7d68bfa82654ba01d860b8a772ff63bf0bd183ee)

Co-authored-by: sblondon <sblondon@users.noreply.github.com>


<!-- issue-number: bpo-33256 -->
https://bugs.python.org/issue33256
<!-- /issue-number -->
