### PR TITLE
bpo-33394: Enable the verbose build for extension modules with GNU make

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -601,11 +601,15 @@ $(srcdir)/Modules/_blake2/blake2s_impl.c: $(srcdir)/Modules/_blake2/blake2b_impl
 # Under GNU make, MAKEFLAGS are sorted and normalized; the 's' for
 # -s, --silent or --quiet is always the first char.
 # Under BSD make, MAKEFLAGS might be " -s -v x=y".
+# Ignore macros passed by GNU make, passed after --
 sharedmods: $(BUILDPYTHON) pybuilddir.txt Modules/_math.o
-	@case "$$MAKEFLAGS" in \
+	@case "`echo X $$MAKEFLAGS | sed 's/^X //;s/ -- .*//'`" in \
 	    *\ -s*|s*) quiet="-q";; \
 	    *) quiet="";; \
 	esac; \
+	echo "$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
+		_TCLTK_INCLUDES='$(TCLTK_INCLUDES)' _TCLTK_LIBS='$(TCLTK_LIBS)' \
+		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build"; \
 	$(RUNSHARED) CC='$(CC)' LDSHARED='$(BLDSHARED)' OPT='$(OPT)' \
 		_TCLTK_INCLUDES='$(TCLTK_INCLUDES)' _TCLTK_LIBS='$(TCLTK_LIBS)' \
 		$(PYTHON_FOR_BUILD) $(srcdir)/setup.py $$quiet build

--- a/Misc/NEWS.d/next/Build/2018-04-30-17-36-46.bpo-33394._Vdi4t.rst
+++ b/Misc/NEWS.d/next/Build/2018-04-30-17-36-46.bpo-33394._Vdi4t.rst
@@ -1,0 +1,2 @@
+Enable the verbose build for extension modules, when GNU make is passed
+macros on the command line.


### PR DESCRIPTION


<!-- issue-number: bpo-33394 -->
https://bugs.python.org/issue33394
<!-- /issue-number -->
