### PR TITLE
bpo-28167: bump Deprecated function removal to 3.8

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -248,7 +248,8 @@ Unix Platforms
 
    This is another name for :func:`linux_distribution`.
 
-   .. deprecated-removed:: 3.5 3.7
+   .. deprecated-removed:: 3.5 3.8
+      See alternative like the `distro <https://pypi.org/project/distro>`_ package.
 
 .. function:: linux_distribution(distname='', version='', id='', supported_dists=('SuSE','debian','redhat','mandrake',...), full_distribution_name=1)
 
@@ -266,7 +267,8 @@ Unix Platforms
    parameters.  ``id`` is the item in parentheses after the version number.  It
    is usually the version codename.
 
-   .. deprecated-removed:: 3.5 3.7
+   .. deprecated-removed:: 3.5 3.8
+      See alternative like the `distro <https://pypi.org/project/distro>`_ package.
 
 .. function:: libc_ver(executable=sys.executable, lib='', version='', chunksize=2048)
 

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -302,7 +302,7 @@ def linux_distribution(distname='', version='', id='',
                        full_distribution_name=1):
     import warnings
     warnings.warn("dist() and linux_distribution() functions are deprecated "
-                  "in Python 3.5", PendingDeprecationWarning, stacklevel=2)
+                  "in Python 3.5", DeprecationWarning, stacklevel=2)
     return _linux_distribution(distname, version, id, supported_dists,
                                full_distribution_name)
 
@@ -376,7 +376,7 @@ def dist(distname='', version='', id='',
     """
     import warnings
     warnings.warn("dist() and linux_distribution() functions are deprecated "
-                  "in Python 3.5", PendingDeprecationWarning, stacklevel=2)
+                  "in Python 3.5", DeprecationWarning, stacklevel=2)
     return _linux_distribution(distname, version, id,
                                supported_dists=supported_dists,
                                full_distribution_name=0)
@@ -1345,7 +1345,7 @@ def platform(aliased=0, terse=0):
                 'ignore',
                 r'dist\(\) and linux_distribution\(\) '
                 'functions are deprecated .*',
-                PendingDeprecationWarning,
+                DeprecationWarning,
             )
             distname, distversion, distid = dist('')
         if distname and not terse:

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -353,14 +353,14 @@ class PlatformTest(unittest.TestCase):
 class DeprecationTest(unittest.TestCase):
 
     def test_dist_deprecation(self):
-        with self.assertWarns(PendingDeprecationWarning) as cm:
+        with self.assertWarns(DeprecationWarning) as cm:
             platform.dist()
         self.assertEqual(str(cm.warning),
                          'dist() and linux_distribution() functions are '
                          'deprecated in Python 3.5')
 
     def test_linux_distribution_deprecation(self):
-        with self.assertWarns(PendingDeprecationWarning) as cm:
+        with self.assertWarns(DeprecationWarning) as cm:
             platform.linux_distribution()
         self.assertEqual(str(cm.warning),
                          'dist() and linux_distribution() functions are '

--- a/Misc/NEWS.d/next/Library/2018-05-02-07-26-29.bpo-28167.7FwDfN.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-02-07-26-29.bpo-28167.7FwDfN.rst
@@ -1,0 +1,3 @@
+The function ``platform.linux_ditribution`` and ``platform.dist`` now
+trigger a ``DeprecationWarning`` and have been marked for removal in Python
+3.8


### PR DESCRIPTION
Also bump PendingDeprecationWarning to DeprecationWarning.
-- 
I'm guessing we are far enough in the cycle that it's too late for removal...

<!-- issue-number: bpo-28167 -->
https://bugs.python.org/issue28167
<!-- /issue-number -->
