### PR TITLE
bpo-33391: fix leak in set_symmetric_difference

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-05-02-08-36-03.bpo-33391.z4a7rb.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-05-02-08-36-03.bpo-33391.z4a7rb.rst
@@ -1,0 +1,1 @@
+Fix a leak in set_symmetric_difference().

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1744,8 +1744,10 @@ set_symmetric_difference(PySetObject *so, PyObject *other)
     if (otherset == NULL)
         return NULL;
     rv = set_symmetric_difference_update(otherset, (PyObject *)so);
-    if (rv == NULL)
+    if (rv == NULL) {
+        Py_DECREF(otherset);
         return NULL;
+    }
     Py_DECREF(rv);
     return (PyObject *)otherset;
 }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33391 -->
https://bugs.python.org/issue33391
<!-- /issue-number -->
