### PR TITLE
bpo-33399: Handle when module __cache__ is None in site.abs_path()

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -108,7 +108,7 @@ def abs_paths():
             pass
         try:
             m.__cached__ = os.path.abspath(m.__cached__)
-        except (AttributeError, OSError):
+        except (AttributeError, OSError, TypeError):
             pass
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

I'll look at adding tests if this approach isn't just wrong. https://bugs.python.org/issue33399

<!-- issue-number: bpo-33399 -->
https://bugs.python.org/issue33399
<!-- /issue-number -->
