### PR TITLE
Fix documentation for Decimal's divmod function

### DIFF
--- a/Doc/library/decimal.rst
+++ b/Doc/library/decimal.rst
@@ -1187,7 +1187,10 @@ In addition to the three supplied contexts, new contexts can be created with the
 
    .. method:: divmod(x, y)
 
-      Divides two numbers and returns the integer part of the result.
+      Divides two numbers and returns a pair of numbers consisting of their quotient 
+      and remainder when using integer division.
+      
+      The result is always equal to *(divide_int(x,y), remainder(x,y))*.
 
 
    .. method:: exp(x)


### PR DESCRIPTION
The documentation was just wrong (it looks like it was perhaps copy/pasted from the docs for some kind of integer-part function).

Note: I didn't create an issue on python.org for this, it seemed small enough. I'm also not interested in creating an account there just to sign a contributor agreement for this, so take it or leave it :)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
