### PR TITLE
bpo-33403: Added return_on parameter to asyncio.tasks.wait coro

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-05-02-03-02-42.bpo-33403.jG08q2.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-02-03-02-42.bpo-33403.jG08q2.rst
@@ -1,0 +1,2 @@
+Parameter return_on has been added to asyncio.tasks.wait coroutine in order
+to allow defining a custom exception or tuple of exceptions to return on.


### PR DESCRIPTION
Added return_on parameter to asyncio.tasks.wait coroutine in order to be able to set a custom exception or tuple of exceptions to return when return_when parameter is set to FIRST_EXCEPTION. 

Uses Exception as default value in order to keep maintaining the actual behaviour of returning when any exception is raised when FIRST_EXCEPTION is used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33403 -->
https://bugs.python.org/issue33403
<!-- /issue-number -->
