### PR TITLE
bpo-33290: Have macOS installer remove "pip" alias

### DIFF
--- a/Mac/BuildScript/scripts/postflight.ensurepip
+++ b/Mac/BuildScript/scripts/postflight.ensurepip
@@ -12,6 +12,11 @@ umask 022
 
 "${FWK}/bin/python${PYVER}" -E -s -m ensurepip --upgrade
 
+# bpo-33290: An earlier "pip3 install --upgrade pip" may have installed
+#     a "pip" in the fw bin directory.  For a py3 install, remove it.
+
+rm -f "${FWK}/bin/pip"
+
 "${FWK}/bin/python${PYVER}" -E -s -Wi \
     "${FWK}/lib/python${PYVER}/compileall.py" -q -j0 \
     -f -x badsyntax \


### PR DESCRIPTION
Currently, "pip3 install --upgrade pip" unconditionally installs a
"pip" alias even for Python 3.  If a user has an existing Python 3.x
installed from a python.org macOS installer and then subsequently
manually updates to a new version of pip, there may now be a stray
"pip" alias in the Python 3.x framework bin directory which can cause
confusion if the user has both a Python 2.7 and 3.x installed;
if the Python 3.x fw bin directory appears early on $PATH, "pip"
might invoke the pip3 for the Python 3.x rather than the pip for
Python 2.7.  To try to mitigate this, the macOS installer script
for the ensurepip option will unconditionally remove "pip" from
the 3.x framework bin directory being updated / installed.  (The
ambiguity can be avoided by using "pythonx.y -m pip".)

<!-- issue-number: bpo-33290 -->
https://bugs.python.org/issue33290
<!-- /issue-number -->
