### PR TITLE
bpo-33413: asyncio.gather without a special Future

### DIFF
--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1714,8 +1714,8 @@ class BaseTaskTests:
         test_utils.run_briefly(self.loop)
         parent.cancel()
         # This should cancel inner1 and inner2 but bot child1 and child2.
-        test_utils.run_briefly(self.loop)
-        self.assertIsInstance(parent.exception(), asyncio.CancelledError)
+        with self.assertRaises(asyncio.CancelledError):
+            self.loop.run_until_complete(parent)
         self.assertTrue(inner1.cancelled())
         self.assertTrue(inner2.cancelled())
         child1.set_result(1)


### PR DESCRIPTION
This re-implements asyncio.gather without the need of a special inherited Future.

Futures nowadays are created using loop.create_future(), so having a special-case Future is actually weird. This changes gather() to simply return a Task.

This patch goes at great length to stay backwards compatible. It splits the function gather() in two parts: a backwards-compatible gather() that wraps the coroutine _gather() into an ensure_future(). IMHO the _gather() is everything one would need.

<!-- issue-number: bpo-33413 -->
https://bugs.python.org/issue33413
<!-- /issue-number -->
