### PR TITLE
bpo-27300: Add missing error= argument to tempfile classes

### DIFF
--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -31,7 +31,7 @@ is recommended to use keyword arguments for clarity.
 
 The module defines the following user-callable items:
 
-.. function:: TemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None)
+.. function:: TemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, errors=None)
 
    Return a :term:`file-like object` that can be used as a temporary storage area.
    The file is created securely, using the same rules as :func:`mkstemp`. It will be destroyed as soon
@@ -49,7 +49,7 @@ The module defines the following user-callable items:
    The *mode* parameter defaults to ``'w+b'`` so that the file created can
    be read and written without being closed.  Binary mode is used so that it
    behaves consistently on all platforms without regard for the data that is
-   stored.  *buffering*, *encoding* and *newline* are interpreted as for
+   stored.  *buffering*, *encoding*, *errors* and *newline* are interpreted as for
    :func:`open`.
 
    The *dir*, *prefix* and *suffix* parameters have the same meaning and
@@ -66,8 +66,11 @@ The module defines the following user-callable items:
 
       The :py:data:`os.O_TMPFILE` flag is now used if available.
 
+   .. versionchanged:: 3.8
+      Added *errors* parameter.
 
-.. function:: NamedTemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, delete=True)
+
+.. function:: NamedTemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, delete=True, errors=None)
 
    This function operates exactly as :func:`TemporaryFile` does, except that
    the file is guaranteed to have a visible name in the file system (on
@@ -82,8 +85,11 @@ The module defines the following user-callable items:
    attribute is the underlying true file object. This file-like object can
    be used in a :keyword:`with` statement, just like a normal file.
 
+   .. versionchanged:: 3.8
+      Added *errors* parameter.
 
-.. function:: SpooledTemporaryFile(max_size=0, mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None)
+
+.. function:: SpooledTemporaryFile(max_size=0, mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, errors=None)
 
    This function operates exactly as :func:`TemporaryFile` does, except that
    data is spooled in memory until the file size exceeds *max_size*, or
@@ -103,6 +109,9 @@ The module defines the following user-callable items:
 
    .. versionchanged:: 3.3
       the truncate method now accepts a ``size`` argument.
+
+   .. versionchanged:: 3.8
+      Added *errors* parameter.
 
 
 .. function:: TemporaryDirectory(suffix=None, prefix=None, dir=None)

--- a/Doc/library/tempfile.rst
+++ b/Doc/library/tempfile.rst
@@ -31,7 +31,7 @@ is recommended to use keyword arguments for clarity.
 
 The module defines the following user-callable items:
 
-.. function:: TemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, errors=None)
+.. function:: TemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, *, errors=None)
 
    Return a :term:`file-like object` that can be used as a temporary storage area.
    The file is created securely, using the same rules as :func:`mkstemp`. It will be destroyed as soon
@@ -70,7 +70,7 @@ The module defines the following user-callable items:
       Added *errors* parameter.
 
 
-.. function:: NamedTemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, delete=True, errors=None)
+.. function:: NamedTemporaryFile(mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, delete=True, *, errors=None)
 
    This function operates exactly as :func:`TemporaryFile` does, except that
    the file is guaranteed to have a visible name in the file system (on
@@ -89,7 +89,7 @@ The module defines the following user-callable items:
       Added *errors* parameter.
 
 
-.. function:: SpooledTemporaryFile(max_size=0, mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, errors=None)
+.. function:: SpooledTemporaryFile(max_size=0, mode='w+b', buffering=None, encoding=None, newline=None, suffix=None, prefix=None, dir=None, *, errors=None)
 
    This function operates exactly as :func:`TemporaryFile` does, except that
    data is spooled in memory until the file size exceeds *max_size*, or

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -693,12 +693,7 @@ class SpooledTemporaryFile:
 
     @property
     def encoding(self):
-        try:
-            return self._file.encoding
-        except AttributeError:
-            if 'b' in self._TemporaryFileArgs['mode']:
-                raise
-            return self._TemporaryFileArgs['encoding']
+        return self._file.encoding
 
     @property
     def errors(self):
@@ -730,12 +725,7 @@ class SpooledTemporaryFile:
 
     @property
     def newlines(self):
-        try:
-            return self._file.newlines
-        except AttributeError:
-            if 'b' in self._TemporaryFileArgs['mode']:
-                raise
-            return self._TemporaryFileArgs['newline']
+        return self._file.newlines
 
     def read(self, *args):
         return self._file.read(*args)

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -702,12 +702,7 @@ class SpooledTemporaryFile:
 
     @property
     def errors(self):
-        try:
-            return self._file.errors
-        except AttributeError:
-            if 'b' in self._TemporaryFileArgs['mode']:
-                raise
-            return self._TemporaryFileArgs['errors']
+        return self._file.errors
 
     def fileno(self):
         self.rollover()

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -609,7 +609,8 @@ else:
             else:
                 try:
                     return _io.open(fd, mode, buffering=buffering,
-                                    newline=newline, encoding=encoding, errors=errors)
+                                    newline=newline, encoding=encoding,
+                                    errors=errors)
                 except:
                     _os.close(fd)
                     raise

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -517,7 +517,7 @@ class _TemporaryFileWrapper:
 
 def NamedTemporaryFile(mode='w+b', buffering=-1, encoding=None,
                        newline=None, suffix=None, prefix=None,
-                       dir=None, delete=True, errors=None):
+                       dir=None, delete=True, *, errors=None):
     """Create and return a temporary file.
     Arguments:
     'prefix', 'suffix', 'dir' -- as for mkstemp.
@@ -567,7 +567,7 @@ else:
 
     def TemporaryFile(mode='w+b', buffering=-1, encoding=None,
                       newline=None, suffix=None, prefix=None,
-                      dir=None, errors=None):
+                      dir=None, *, errors=None):
         """Create and return a temporary file.
         Arguments:
         'prefix', 'suffix', 'dir' -- as for mkstemp.
@@ -633,7 +633,7 @@ class SpooledTemporaryFile:
 
     def __init__(self, max_size=0, mode='w+b', buffering=-1,
                  encoding=None, newline=None,
-                 suffix=None, prefix=None, dir=None, errors=None):
+                 suffix=None, prefix=None, dir=None, *, errors=None):
         if 'b' in mode:
             self._file = _io.BytesIO()
         else:

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -1094,6 +1094,8 @@ class TestSpooledTemporaryFile(BaseTestCase):
             f.newlines
         with self.assertRaises(AttributeError):
             f.encoding
+        with self.assertRaises(AttributeError):
+            f.errors
 
         f.write(b'x')
         self.assertTrue(f._rolled)
@@ -1103,6 +1105,8 @@ class TestSpooledTemporaryFile(BaseTestCase):
             f.newlines
         with self.assertRaises(AttributeError):
             f.encoding
+        with self.assertRaises(AttributeError):
+            f.errors
 
     def test_text_mode(self):
         # Creating a SpooledTemporaryFile with a text mode should produce
@@ -1119,6 +1123,7 @@ class TestSpooledTemporaryFile(BaseTestCase):
         self.assertIsNone(f.name)
         self.assertIsNone(f.newlines)
         self.assertIsNone(f.encoding)
+        self.assertIsNone(f.errors)
 
         f.write("xyzzy\n")
         f.seek(0)
@@ -1132,10 +1137,12 @@ class TestSpooledTemporaryFile(BaseTestCase):
         self.assertIsNotNone(f.name)
         self.assertEqual(f.newlines, os.linesep)
         self.assertIsNotNone(f.encoding)
+        self.assertIsNotNone(f.errors)
 
     def test_text_newline_and_encoding(self):
         f = tempfile.SpooledTemporaryFile(mode='w+', max_size=10,
-                                          newline='', encoding='utf-8')
+                                          newline='', encoding='utf-8',
+                                          errors='ignore')
         f.write("\u039B\r\n")
         f.seek(0)
         self.assertEqual(f.read(), "\u039B\r\n")
@@ -1144,6 +1151,7 @@ class TestSpooledTemporaryFile(BaseTestCase):
         self.assertIsNone(f.name)
         self.assertIsNone(f.newlines)
         self.assertIsNone(f.encoding)
+        self.assertIsNone(f.errors)
 
         f.write("\u039B" * 20 + "\r\n")
         f.seek(0)
@@ -1153,6 +1161,7 @@ class TestSpooledTemporaryFile(BaseTestCase):
         self.assertIsNotNone(f.name)
         self.assertIsNotNone(f.newlines)
         self.assertEqual(f.encoding, 'utf-8')
+        self.assertEqual(f.errors, 'ignore')
 
     def test_context_manager_before_rollover(self):
         # A SpooledTemporaryFile can be used as a context manager

--- a/Misc/NEWS.d/next/Library/2018-05-01-02-24-44.bpo-27300.LdIXvK.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-01-02-24-44.bpo-27300.LdIXvK.rst
@@ -1,2 +1,2 @@
 The file classes in *tempfile* now accept an *errors* parameter that
-complements the already existing *encoding*.
+complements the already existing *encoding*.  Patch by Stephan Hohe.

--- a/Misc/NEWS.d/next/Library/2018-05-01-02-24-44.bpo-27300.LdIXvK.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-01-02-24-44.bpo-27300.LdIXvK.rst
@@ -1,0 +1,2 @@
+The file classes in *tempfile* now accept an *errors* parameter that
+complements the already existing *encoding*.


### PR DESCRIPTION
The classes for temporary files in `tempfile` have an `encoding` parameter to specify the file encoding. They don't have an `error` parameter to specify what should happen on encoding errors. This is unusual, normally things with `encoding` also have `errors`.

This pull request adds the missing `errors` parameter. It is treated the same as the already existing `encoding` parameter: the parameter is simply handed through to the underlying `io` class.


<!-- issue-number: bpo-27300 -->
https://bugs.python.org/issue27300
<!-- /issue-number -->
