### PR TITLE
Create documentation page for 'antigravity'

### DIFF
--- a/Doc/library/antigravity.rst
+++ b/Doc/library/antigravity.rst
@@ -1,0 +1,15 @@
+:mod:`antigravity` --- Easter Egg for XKCD
+====================================
+
+.. module:: antigravity
+   :synopsis: An easter egg for XKCD #353.
+
+**Source code:** :source:`Lib/antigravity.py`
+
+--------------
+
+When imported, this module will open https://xkcd.com/353/ in the default web browser.
+
+.. method:: antigravity.geohash(lattitude, longitude, datedow)
+
+   Compute geohash() using the Munroe algorithm.


### PR DESCRIPTION
Adds a simple documentation page for the antigravity module.

(See http://python-history.blogspot.com/2010/06/import-antigravity.html)