### PR TITLE
bpo-33427: Update "The Python Standard Library" page link

### DIFF
--- a/Doc/library/index.rst
+++ b/Doc/library/index.rst
@@ -30,7 +30,7 @@ optional components.
 In addition to the standard library, there is a growing collection of
 several thousand components (from individual programs and modules to
 packages and entire application development frameworks), available from
-the `Python Package Index <https://pypi.python.org/pypi>`_.
+the `Python Package Index <https://pypi.org>`_.
 
 
 .. toctree::

--- a/Misc/NEWS.d/next/Documentation/2018-05-06-01-43-26.bpo-33427.mVz1bu.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-06-01-43-26.bpo-33427.mVz1bu.rst
@@ -1,0 +1,1 @@
+Update "The Python Standard Library" link


### PR DESCRIPTION
Needs backport patch for 2.7, 3.4, 3.5, 3.6, 3.7


<!-- issue-number: bpo-33427 -->
https://bugs.python.org/issue33427
<!-- /issue-number -->
