### PR TITLE
bpo-33435: Fixed incorrect version detection of linux in some distributions (platform.py)

### DIFF
--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -374,7 +374,7 @@ def _linux_distribution(distname, version, id, supported_dists,
             return distname, version, id
 
         except IOError:
-            return linux_dist_origin()
+            return linux_dist_origin(distname, version, id)
     else:
         return linux_dist_origin(distname, version, id)
 


### PR DESCRIPTION
In some linux distributions, the information about the distribution is incorrectly determined when the linux_distribution() method is called from the platform class. Since the information file os-release becomes a certain standard, I propose first of all to check its availability and if it is in the system, then parse the information from it. I apply the patch. It will work well with version 2.7.

<!-- issue-number: bpo-33435 -->
https://bugs.python.org/issue33435
<!-- /issue-number -->
