### PR TITLE
bpo-33435: Fixed incorrect version detection of linux in some distrib…

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-05-08-13-08-29.bpo-33435.vE6dMZ.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-08-13-08-29.bpo-33435.vE6dMZ.rst
@@ -1,0 +1,2 @@
+Fixed incorrect version detection of linux in some distributions (platform.py linux_distribution()).
+Now checked file os-release and if it is in the system then parse the information from it.

--- a/Misc/NEWS.d/next/Library/2018-05-08-13-08-29.bpo-33435.vE6dMZ.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-08-13-08-29.bpo-33435.vE6dMZ.rst
@@ -1,2 +1,2 @@
-Fixed incorrect version detection of linux in some distributions (platform.py linux_distribution()).
-Now checked file os-release and if it is in the system then parse the information from it.
+Fixed incorrect version detection of linux in some distributions (Lib/platform.py method: linux_distribution()).
+Now checked file os-release and if the file exists - parse the information from it, else used old method.


### PR DESCRIPTION
In some linux distributions, the information about the distribution is incorrectly determined when the linux_distribution() method is called from the platform class. Since the information file os-release becomes a certain standard, I propose first of all to check its availability and if it is in the system, then parse the information from it. I apply the patch. It will work well with version 2.7.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33435 -->
https://bugs.python.org/issue33435
<!-- /issue-number -->
