### PR TITLE
bpo-33443: Fix typo in Python/import.c

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-05-07-15-22-29.bpo-33443.51ea8e.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-07-15-22-29.bpo-33443.51ea8e.rst
@@ -1,0 +1,3 @@
+n the method, "_PyImportZip_Init(void)", of Python/import.c, the variable, "PyObject *path_hooks, *zimpimport;", seems to be typo, which can be "zipimport".
+
+Modified "zimpimport" to "zipimport" in L. 95, 107, 108, 115, 117 of Python/import.c.

--- a/Python/import.c
+++ b/Python/import.c
@@ -92,7 +92,7 @@ _PyImportHooks_Init(void)
 _PyInitError
 _PyImportZip_Init(void)
 {
-    PyObject *path_hooks, *zimpimport;
+    PyObject *path_hooks, *zipimport;
     int err = 0;
 
     path_hooks = PySys_GetObject("path_hooks");
@@ -104,17 +104,17 @@ _PyImportZip_Init(void)
     if (Py_VerboseFlag)
         PySys_WriteStderr("# installing zipimport hook\n");
 
-    zimpimport = PyImport_ImportModule("zipimport");
-    if (zimpimport == NULL) {
+    zipimport = PyImport_ImportModule("zipimport");
+    if (zipimport == NULL) {
         PyErr_Clear(); /* No zip import module -- okay */
         if (Py_VerboseFlag)
             PySys_WriteStderr("# can't import zipimport\n");
     }
     else {
         _Py_IDENTIFIER(zipimporter);
-        PyObject *zipimporter = _PyObject_GetAttrId(zimpimport,
+        PyObject *zipimporter = _PyObject_GetAttrId(zipimport,
                                                     &PyId_zipimporter);
-        Py_DECREF(zimpimport);
+        Py_DECREF(zipimport);
         if (zipimporter == NULL) {
             PyErr_Clear(); /* No zipimporter object -- okay */
             if (Py_VerboseFlag)


### PR DESCRIPTION
In the method, "_PyImportZip_Init(void)", of Python/import.c, the variable, "PyObject *path_hooks, *zimpimport;", seems to be typo, which can be "zipimport".

I modified "zimpimport" to "zipimport" in L. 95, 107, 108, 115, 117 of Python/import.c.

<!-- issue-number: bpo-33443 -->
https://bugs.python.org/issue33443
<!-- /issue-number -->
