### PR TITLE
README: Use range of years for copyright

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,7 @@ This is Python version 3.8.0 alpha 0
    :alt: CPython code coverage on Codecov
    :target: https://codecov.io/gh/python/cpython
 
-Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
-2012, 2013, 2014, 2015, 2016, 2017, 2018 Python Software Foundation.  All rights
+Copyright (c) 2001-2018 Python Software Foundation.  All rights
 reserved.
 
 See the end of this file for further copyright and license information.
@@ -234,8 +233,7 @@ See :pep:`569` for Python 3.8 release details.
 Copyright and License Information
 ---------------------------------
 
-Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
-2012, 2013, 2014, 2015, 2016, 2017, 2018 Python Software Foundation.  All rights
+Copyright (c) 2001-2018 Python Software Foundation.  All rights
 reserved.
 
 Copyright (c) 2000 BeOpen.com.  All rights reserved.


### PR DESCRIPTION
Uses a range of years for Python's copyright rather than listing each year individually.

('2001-2018' vs '2001, 2002, 2003, ...')