### PR TITLE
bpo-33445: fail properly in test_cprofile()

### DIFF
--- a/Lib/test/test_profile.py
+++ b/Lib/test/test_profile.py
@@ -51,13 +51,18 @@ class ProfileTest(unittest.TestCase):
         results = self.do_profiling()
         expected = self.get_expected_output()
         self.assertEqual(results[0], 1000)
+        fail = []
         for i, method in enumerate(self.methodnames):
-            if results[i+1] != expected[method]:
-                print("Stats.%s output for %s doesn't fit expectation!" %
-                      (method, self.profilerclass.__name__))
-                print('\n'.join(unified_diff(
-                                  results[i+1].split('\n'),
-                                  expected[method].split('\n'))))
+            a = expected[method]
+            b = results[i+1]
+            if a != b:
+                fail.append(f"\nStats.{method} output for "
+                            f"{self.profilerclass.__name__} "
+                             "does not fit expectation:")
+                fail.extend(unified_diff(a.split('\n'), b.split('\n'),
+                            lineterm=""))
+        if fail:
+            self.fail("\n".join(fail))
 
     def test_calling_conventions(self):
         # Issue #5330: profile and cProfile wouldn't report C functions called


### PR DESCRIPTION
No news because this doesn't change CPython, just the test suite.