### PR TITLE
bpo-33446: destructors of local variables are now traced

### DIFF
--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -201,6 +201,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         self.stack = []
         self.curindex = 0
         self.curframe = None
+        self.curframe_locals = None
         self.tb_lineno.clear()
 
     def setup(self, f, tb):

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1140,6 +1140,39 @@ def test_pdb_issue_20766():
     pdb 2: <built-in function default_int_handler>
     """
 
+def test_pdb_issue_33446():
+    """Test that the destructor of a local variable is traced.
+
+    >>> def test_function():
+    ...     class C:
+    ...         def __del__(self):
+    ...             within_destructor = True
+    ...
+    ...     a = C()
+    ...     import pdb; pdb.Pdb(nosigint=True, readrc=False).set_trace()
+    ...     pass
+
+    >>> with PdbTestInput(['step',
+    ...                    'step',
+    ...                    'step',
+    ...                    'continue']):
+    ...     test_function()
+    > <doctest test.test_pdb.test_pdb_issue_33446[0]>(8)test_function()
+    -> pass
+    (Pdb) step
+    --Return--
+    > <doctest test.test_pdb.test_pdb_issue_33446[0]>(8)test_function()->None
+    -> pass
+    (Pdb) step
+    --Call--
+    > <doctest test.test_pdb.test_pdb_issue_33446[0]>(3)__del__()
+    -> def __del__(self):
+    (Pdb) step
+    > <doctest test.test_pdb.test_pdb_issue_33446[0]>(4)__del__()
+    -> within_destructor = True
+    (Pdb) continue
+    """
+
 
 class PdbTestCase(unittest.TestCase):
     def tearDown(self):

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -447,6 +447,32 @@ class TraceTestCase(unittest.TestCase):
             [(0, 'call'),
              (1, 'line')])
 
+    def test_18_trace_locals_destructors(self):
+        # Issue bpo-33446: destructors of local variables are now traced.
+        def func():
+            class C:
+                def __del__(self):
+                    lineno = 3
+
+            a = C()
+            a = 1
+            lineno = 7
+
+        self.run_and_compare(func,
+           [(0, 'call'),
+            (1, 'line'),
+            (1, 'call'),
+            (1, 'line'),
+            (2, 'line'),
+            (2, 'return'),
+            (5, 'line'),
+            (6, 'line'),
+            (2, 'call'),
+            (3, 'line'),
+            (3, 'return'),
+            (7, 'line'),
+            (7, 'return')])
+
 
 class SkipLineEventsTraceTestCase(TraceTestCase):
     """Repeat the trace tests, but with per-line events skipped"""

--- a/Misc/NEWS.d/next/Core and Builtins/2018-05-08-20-37-16.bpo-33446.GQUaqN.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-05-08-20-37-16.bpo-33446.GQUaqN.rst
@@ -1,0 +1,1 @@
+Destructors of local variables are now traced.


### PR DESCRIPTION


<!-- issue-number: bpo-33446 -->
https://bugs.python.org/issue33446
<!-- /issue-number -->
