### PR TITLE
bpo-30167: site: Ignore TypeError in abs_paths()

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -104,7 +104,7 @@ def abs_paths():
             continue   # don't mess with a PEP 302-supplied __file__
         try:
             m.__file__ = os.path.abspath(m.__file__)
-        except (AttributeError, OSError):
+        except (AttributeError, OSError, TypeError):
             pass
         try:
             m.__cached__ = os.path.abspath(m.__cached__)

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -108,7 +108,7 @@ def abs_paths():
             pass
         try:
             m.__cached__ = os.path.abspath(m.__cached__)
-        except (AttributeError, OSError):
+        except (AttributeError, OSError, TypeError):
             pass
 
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1714,6 +1714,7 @@ David Watson
 Aaron Watters
 Henrik Weber
 Leon Weber
+Steve Weber
 Corran Webster
 Glyn Webster
 Phil Webster

--- a/Misc/NEWS.d/next/Library/2018-06-10-19-29-17.bpo-30167.G5EgC5.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-10-19-29-17.bpo-30167.G5EgC5.rst
@@ -1,0 +1,1 @@
+Prevent site.main() exception if PYTHONSTARTUP is set. Patch by Steve Weber.


### PR DESCRIPTION
Behavior of "os.path.abspath(None)" was changed.

Before Python 3.6, used to report an AttributeError which is properly caught inside "site.abs_paths", making it ignore `__main__`, one of sys.modules, which has `__file__` and `__cached__` set to None.

perhaps best to find what sets `__cache__` as None and /fix/ that instead of this proposed fix.

<!-- issue-number: bpo-30167 -->
https://bugs.python.org/issue30167
<!-- /issue-number -->
