### PR TITLE
[2.7] bpo-13525: Fix incorrect encoding name in the tutorial example. (GH-6738).

### DIFF
--- a/Doc/tutorial/interpreter.rst
+++ b/Doc/tutorial/interpreter.rst
@@ -137,12 +137,12 @@ where *encoding* is one of the valid :mod:`codecs` supported by Python.
 For example, to declare that Windows-1252 encoding is to be used, the first
 line of your source code file should be::
 
-   # -*- coding: cp-1252 -*-
+   # -*- coding: cp1252 -*-
 
 One exception to the *first line* rule is when the source code starts with a
 :ref:`UNIX "shebang" line <tut-scripts>`.  In this case, the encoding
 declaration should be added as the second line of the file.  For example::
 
    #!/usr/bin/env python
-   # -*- coding: cp-1252 -*-
+   # -*- coding: cp1252 -*-
 


### PR DESCRIPTION
(cherry picked from commit ddb6215a55b0218b621d5cb755e9dfac8dab231a)


<!-- issue-number: bpo-13525 -->
https://bugs.python.org/issue13525
<!-- /issue-number -->
