### PR TITLE
fcntl.lockf() is more powerful than written

### DIFF
--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -116,7 +116,7 @@ The module defines the following functions:
 .. function:: lockf(fd, cmd, len=0, start=0, whence=0)
 
    This is essentially a wrapper around the :func:`~fcntl.fcntl` locking calls.
-   *fd* is a file-like object with a `fileno()` method that returns a file
+   *fd* is a file-like object with a :func:`fileno` method that returns a file
    descriptor, or is directly the file descriptor of the file to lock or unlock,
    and *cmd* is one of the following values:
 

--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -116,8 +116,9 @@ The module defines the following functions:
 .. function:: lockf(fd, cmd, len=0, start=0, whence=0)
 
    This is essentially a wrapper around the :func:`~fcntl.fcntl` locking calls.
-   *fd* is the file descriptor of the file to lock or unlock, and *cmd*
-   is one of the following values:
+   *fd* is a file-like object with a `fileno()` method that returns a file
+   descriptor, or is directly the file descriptor of the file to lock or unlock,
+   and *cmd* is one of the following values:
 
    * :const:`LOCK_UN` -- unlock
    * :const:`LOCK_SH` -- acquire a shared lock

--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -116,8 +116,8 @@ The module defines the following functions:
 .. function:: lockf(fd, cmd, len=0, start=0, whence=0)
 
    This is essentially a wrapper around the :func:`~fcntl.fcntl` locking calls.
-   *fd* is a file-like object with a :func:`fileno` method that returns a file
-   descriptor, or is directly the file descriptor of the file to lock or unlock,
+   *fd* is the file descriptor (file objects providing a :meth:`~io.IOBase.fileno`
+   method are accepted as well) of the file to lock or unlock,
    and *cmd* is one of the following values:
 
    * :const:`LOCK_UN` -- unlock

--- a/Doc/library/fcntl.rst
+++ b/Doc/library/fcntl.rst
@@ -117,8 +117,8 @@ The module defines the following functions:
 
    This is essentially a wrapper around the :func:`~fcntl.fcntl` locking calls.
    *fd* is the file descriptor (file objects providing a :meth:`~io.IOBase.fileno`
-   method are accepted as well) of the file to lock or unlock,
-   and *cmd* is one of the following values:
+   method are accepted as well) of the file to lock or unlock, and *cmd*
+   is one of the following values:
 
    * :const:`LOCK_UN` -- unlock
    * :const:`LOCK_SH` -- acquire a shared lock
@@ -168,4 +168,3 @@ using the :func:`flock` call may be better.
       present in the :mod:`os` module (on BSD only), the :func:`os.open`
       function provides an alternative to the :func:`lockf` and :func:`flock`
       functions.
-


### PR DESCRIPTION
The fcntl.lockf() function is more powerful than written: it accepts more than only file descriptors, as indicated in the proposed change, which is consistent with the error message one gets from using an incorrect fd argument.

(The fcntl.flock() function already mentions the more general usage.)