### PR TITLE
bpo-33455: Pass os.environ in test_posix::test_specify_environment

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1462,7 +1462,7 @@ class TestPosixSpawn(unittest.TestCase):
         """
         pid = posix.posix_spawn(sys.executable,
                                 [sys.executable, '-c', script],
-                                {'foo': 'bar'})
+                                {**os.environ, 'foo': 'bar'})
         self.assertEqual(os.waitpid(pid, 0), (pid, 0))
         with open(envfile) as f:
             self.assertEqual(f.read(), 'bar')


### PR DESCRIPTION
Pass `os.environ`'s copy to new process created at `test_posix::test_specify_environment`. Otherwise important variables such as `LD_LIBRARY_PATH` are not set and the child process might not work at all
in an environment where such variables are required for Python to function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33455 -->
https://bugs.python.org/issue33455
<!-- /issue-number -->
