### PR TITLE
bpo-33456: site.py: fix wrong default for key in pyvenv.cfg

### DIFF
--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -45,9 +45,9 @@ sys.prefix and sys.exec_prefix are set to that directory and
 it is also checked for site-packages (sys.base_prefix and
 sys.base_exec_prefix will always be the "real" prefixes of the Python
 installation). If "pyvenv.cfg" (a bootstrap configuration file) contains
-the key "include-system-site-packages" set to anything other than "false"
-(case-insensitive), the system-level prefixes will still also be
-searched for site-packages; otherwise they won't.
+the key "include-system-site-packages" set to anything other than "true"
+(case-insensitive), the system-level prefixes will not be
+searched for site-packages; otherwise they will.
 
 A path configuration file is a file whose name has the form :file:`{name}.pth`
 and exists in one of the four directories mentioned above; its contents are

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -465,7 +465,7 @@ def venv(known_paths):
 
     if candidate_confs:
         virtual_conf = candidate_confs[0]
-        system_site = "false"
+        system_site = "true"
         # Issue 25185: Use UTF-8, as that's what the venv module uses when
         # writing the file.
         with open(virtual_conf, encoding='utf-8') as f:
@@ -486,7 +486,7 @@ def venv(known_paths):
 
         # addsitepackages will process site_prefix again if its in PREFIXES,
         # but that's ok; known_paths will prevent anything being added twice
-        if system_site != "false":
+        if system_site == "true":
             PREFIXES.insert(0, sys.prefix)
         else:
             PREFIXES = [sys.prefix]

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -465,7 +465,7 @@ def venv(known_paths):
 
     if candidate_confs:
         virtual_conf = candidate_confs[0]
-        system_site = "true"
+        system_site = "false"
         # Issue 25185: Use UTF-8, as that's what the venv module uses when
         # writing the file.
         with open(virtual_conf, encoding='utf-8') as f:
@@ -486,7 +486,7 @@ def venv(known_paths):
 
         # addsitepackages will process site_prefix again if its in PREFIXES,
         # but that's ok; known_paths will prevent anything being added twice
-        if system_site == "true":
+        if system_site != "false":
             PREFIXES.insert(0, sys.prefix)
         else:
             PREFIXES = [sys.prefix]


### PR DESCRIPTION
[PEP 405](https://www.python.org/dev/peps/pep-0405/) says this:

> By default, a virtual environment is entirely isolated from the system-level site-packages directories.
>
> If the `pyvenv.cfg` file also contains a key `include-system-site-packages` with a value of `true` (not case sensitive), the `site` module will also add the system site directories to `sys.path` after the virtual environment site directories.

The [documentation of the `site` module](https://docs.python.org/3/library/site.html) says (emphasis added):

> If "pyvenv.cfg" […] contains the key "include-system-site-packages" set to anything other than "false" (case-insensitive), the system-level prefixes will still also be searched for site-packages; *otherwise they won’t*.

However, what actually happens in `site.py` is different: see <https://github.com/python/cpython/blob/3.6/Lib/site.py#L447>.  The `system_site` variable is initialized to `"true"` and doesn't change unless the key `include-system-site-packages` exists in `pyvenv.cfg`.

I think `system_site` should be initialized to `"false"` so the actual behavior matches the documented behavior.

<!-- issue-number: bpo-33456 -->
https://bugs.python.org/issue33456
<!-- /issue-number -->
