### PR TITLE
Fix check CC compiler variable in configure

### DIFF
--- a/configure
+++ b/configure
@@ -6471,7 +6471,7 @@ $as_echo "no" >&6; }
 fi
 
 if test "$Py_LTO" = 'true' ; then
-  case $CC in
+  case ${CC##*/} in
     *clang*)
       case $ac_sys_system in
         Darwin*)
@@ -6674,7 +6674,7 @@ $as_echo "$as_me: llvm-profdata found via xcrun: ${LLVM_PROFDATA}" >&6;}
   fi
 fi
 LLVM_PROF_ERR=no
-case $CC in
+case ${CC##*/} in
   *clang*)
     # Any changes made here should be reflected in the GCC+Darwin case below
     PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
@@ -6751,7 +6751,7 @@ then
            WRAP="-fwrapv"
         fi
 
-        case $CC in
+        case ${CC##*/} in
             *clang*)
                 cc_is_clang=1
                 ;;
@@ -6931,7 +6931,7 @@ $as_echo "$ac_cv_no_strict_aliasing" >&6; }
 
     # ICC doesn't recognize the option, but only emits a warning
     ## XXX does it emit an unused result warning and can it be disabled?
-    case "$CC" in
+    case "${CC##*/}" in
     *icc*)
     ac_cv_disable_unused_result_warning=no
     ;;
@@ -7363,7 +7363,7 @@ $as_echo "$MACOSX_DEPLOYMENT_TARGET" >&6; }
 esac
 
 # ICC needs -fp-model strict or floats behave badly
-case "$CC" in
+case "${CC##*/}" in
 *icc*)
     CFLAGS_NODIST="$CFLAGS_NODIST -fp-model strict"
     ;;
@@ -9362,7 +9362,7 @@ then
 		then
 			LINKFORSHARED="-Wl,--export-dynamic"
 		fi;;
-	SunOS/5*) case $CC in
+	SunOS/5*) case ${CC##*/} in
 		  *gcc*)
 		    if $CC -Xlinker --help 2>&1 | grep export-dynamic >/dev/null
 		    then
@@ -16479,7 +16479,7 @@ if test "$have_gcc_asm_for_x87" = yes; then
     # Some versions of gcc miscompile inline asm:
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46491
     # http://gcc.gnu.org/ml/gcc/2010-11/msg00366.html
-    case $CC in
+    case ${CC##*/} in
         *gcc*)
             { $as_echo "$as_me:${as_lineno-$LINENO}: checking for gcc ipa-pure-const bug" >&5
 $as_echo_n "checking for gcc ipa-pure-const bug... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -1316,7 +1316,7 @@ else
 fi],
 [AC_MSG_RESULT(no)])
 if test "$Py_LTO" = 'true' ; then
-  case $CC in
+  case ${CC##*/} in
     *clang*)
       case $ac_sys_system in
         Darwin*)
@@ -1389,7 +1389,7 @@ then
   fi
 fi
 LLVM_PROF_ERR=no
-case $CC in
+case ${CC##*/} in
   *clang*)
     # Any changes made here should be reflected in the GCC+Darwin case below
     PGO_PROF_GEN_FLAG="-fprofile-instr-generate"
@@ -1466,7 +1466,7 @@ then
            WRAP="-fwrapv"
         fi
 
-        case $CC in
+        case ${CC##*/} in
             *clang*)
                 cc_is_clang=1
                 ;;
@@ -1590,7 +1590,7 @@ yes)
 
     # ICC doesn't recognize the option, but only emits a warning
     ## XXX does it emit an unused result warning and can it be disabled?
-    case "$CC" in
+    case "${CC##*/}" in
     *icc*)
     ac_cv_disable_unused_result_warning=no
     ;;
@@ -1892,7 +1892,7 @@ yes)
 esac
 
 # ICC needs -fp-model strict or floats behave badly
-case "$CC" in
+case "${CC##*/}" in
 *icc*)
     CFLAGS_NODIST="$CFLAGS_NODIST -fp-model strict"
     ;;
@@ -2654,7 +2654,7 @@ then
 		then
 			LINKFORSHARED="-Wl,--export-dynamic"
 		fi;;
-	SunOS/5*) case $CC in
+	SunOS/5*) case ${CC##*/} in
 		  *gcc*)
 		    if $CC -Xlinker --help 2>&1 | grep export-dynamic >/dev/null
 		    then
@@ -5332,7 +5332,7 @@ if test "$have_gcc_asm_for_x87" = yes; then
     # Some versions of gcc miscompile inline asm:
     # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46491
     # http://gcc.gnu.org/ml/gcc/2010-11/msg00366.html
-    case $CC in
+    case ${CC##*/} in
         *gcc*)
             AC_MSG_CHECKING(for gcc ipa-pure-const bug)
             saved_cflags="$CFLAGS"


### PR DESCRIPTION
If you use a compiler with abs path there are some issues, e.g. if my path contains the word "piccolo" the script enable some flags of icc compiler because "piccolo" contains "icc".
