### PR TITLE
bpo-33461: Emit DeprecationWarning when json.loads(encoding=...) is used

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -265,17 +265,20 @@ Basic Usage
       *fp* can now be a :term:`binary file`. The input encoding should be
       UTF-8, UTF-16 or UTF-32.
 
-.. function:: loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None, parse_int=None, parse_constant=None, object_pairs_hook=None, **kw)
+.. function:: loads(s, *, cls=None, object_hook=None, parse_float=None, parse_int=None, parse_constant=None, object_pairs_hook=None, **kw)
 
    Deserialize *s* (a :class:`str`, :class:`bytes` or :class:`bytearray`
    instance containing a JSON document) to a Python object using this
    :ref:`conversion table <json-to-py-table>`.
 
    The other arguments have the same meaning as in :func:`load`, except
-   *encoding* which is ignored and deprecated.
+   *encoding* which is ignored and deprecated since Python 3.1.
 
    If the data being deserialized is not a valid JSON document, a
    :exc:`JSONDecodeError` will be raised.
+
+   .. deprecated:: 3.1
+      The *encoding* keyword argument has been deprecated and will be ignored.
 
    .. versionchanged:: 3.6
       *s* can now be of type :class:`bytes` or :class:`bytearray`. The

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -277,8 +277,8 @@ Basic Usage
    If the data being deserialized is not a valid JSON document, a
    :exc:`JSONDecodeError` will be raised.
 
-   .. deprecated:: 3.1
-      The *encoding* keyword argument has been deprecated and will be ignored.
+   .. deprecated-removed:: 3.1 3.9
+      *encoding* keyword argument.
 
    .. versionchanged:: 3.6
       *s* can now be of type :class:`bytes` or :class:`bytearray`. The

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -296,7 +296,7 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
         parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
 
 
-def loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None,
+def loads(s, *, cls=None, object_hook=None, parse_float=None,
         parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
     """Deserialize ``s`` (a ``str``, ``bytes`` or ``bytearray`` instance
     containing a JSON document) to a Python object.
@@ -330,7 +330,7 @@ def loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None,
     To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
     kwarg; otherwise ``JSONDecoder`` is used.
 
-    The ``encoding`` argument is ignored and deprecated.
+    The ``encoding`` argument is ignored and deprecated since Python 3.1.
     """
     if isinstance(s, str):
         if s.startswith('\ufeff'):
@@ -341,6 +341,15 @@ def loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None,
             raise TypeError(f'the JSON object must be str, bytes or bytearray, '
                             f'not {s.__class__.__name__}')
         s = s.decode(detect_encoding(s), 'surrogatepass')
+
+    if "encoding" is not kw:
+        import warnings
+        warnings.warn(
+            "passing 'encoding' as a keyword argument is deprecated since"
+            " Python 3.1, is ignored and will be removed in Python 3.9.",
+            DeprecationWarning,
+            stacklevel=2
+        )
 
     if (cls is None and object_hook is None and
             parse_int is None and parse_float is None and

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -345,11 +345,11 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
     if "encoding" not in kw:
         import warnings
         warnings.warn(
-            "passing 'encoding' as a keyword argument is deprecated since"
-            " Python 3.1, is ignored and will be removed in Python 3.9.",
+            "'encoding' is ignored and deprecated. It will be removed in Python 3.9",
             DeprecationWarning,
             stacklevel=2
         )
+        del kw['encoding']
 
     if (cls is None and object_hook is None and
             parse_int is None and parse_float is None and

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -342,7 +342,7 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
                             f'not {s.__class__.__name__}')
         s = s.decode(detect_encoding(s), 'surrogatepass')
 
-    if "encoding" is not kw:
+    if "encoding" not in kw:
         import warnings
         warnings.warn(
             "passing 'encoding' as a keyword argument is deprecated since"

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -342,7 +342,7 @@ def loads(s, *, cls=None, object_hook=None, parse_float=None,
                             f'not {s.__class__.__name__}')
         s = s.decode(detect_encoding(s), 'surrogatepass')
 
-    if "encoding" not in kw:
+    if "encoding" in kw:
         import warnings
         warnings.warn(
             "'encoding' is ignored and deprecated. It will be removed in Python 3.9",

--- a/Lib/test/test_json/test_decode.py
+++ b/Lib/test/test_json/test_decode.py
@@ -95,5 +95,9 @@ class TestDecode:
         d = self.json.JSONDecoder()
         self.assertRaises(ValueError, d.raw_decode, 'a'*42, -50000)
 
+    def test_deprecated_encode(self):
+        with self.assertWarns(DeprecationWarning):
+            self.loads('{}', encoding='fake')
+
 class TestPyDecode(TestDecode, PyTest): pass
 class TestCDecode(TestDecode, CTest): pass

--- a/Misc/NEWS.d/next/Library/2019-04-09-14-46-28.bpo-33461.SYJM-E.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-09-14-46-28.bpo-33461.SYJM-E.rst
@@ -1,0 +1,2 @@
+``json.loads`` now emits ``DeprecationWarning`` when ``encoding`` option is
+specified.  Patch by Matthias Bussonnier.


### PR DESCRIPTION
I also move in the docs the `encoding=...` keyword to the end of the
signature, as it is kw only. Having the first argument in the doc being
the deprecated one does not seem to be the most efficient way to make
people forget about it.

This does not, of course emit warnings if you pass `None` explicitly,
this could be further refined by using a sentinel value, but I'm unsure
this would be useful.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:
```
[X.Y] <title from the original PR> (GH-NNNN)
```
Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33461 -->
https://bugs.python.org/issue33461
<!-- /issue-number -->
