### PR TITLE
bpo-33466: Support compiling Objective-C++ (“.mm”) files

### DIFF
--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -71,7 +71,7 @@ class UnixCCompiler(CCompiler):
     # reasonable common default here, but it's not necessarily used on all
     # Unices!
 
-    src_extensions = [".c",".C",".cc",".cxx",".cpp",".m"]
+    src_extensions = [".c",".C",".cc",".cxx",".cpp",".m",".mm"]
     obj_extension = ".o"
     static_lib_extension = ".a"
     shared_lib_extension = ".so"

--- a/Misc/NEWS.d/next/Library/2018-05-11-13-12-09.bpo-33466.TjaDNz.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-11-13-12-09.bpo-33466.TjaDNz.rst
@@ -1,0 +1,2 @@
+Support compiling Objective-C++ (“.mm”) files within Distutils. Patch by
+Alexander Böhn.


### PR DESCRIPTION
At the moment, Objective-C++ files suffixed with `.mm` are unrecognized; however, other parts of `distutils` suggest support for compiling these files – e.g. the suffix list found in `extension.py`: https://github.com/python/cpython/blob/7ec8f28656ea9d84048e9b5655375c6a74a59f53/Lib/distutils/extension.py#L193

Adding the `".mm"` string to the `src_extensions` list fixes this inequity.


<!-- issue-number: bpo-33466 -->
https://bugs.python.org/issue33466
<!-- /issue-number -->
