### PR TITLE
bpo-33473: Be slightly better about CFLAGS, LDFLAGS, and related

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-05-12-15-58-15.bpo-33473.BEm_Wt.rst
+++ b/Misc/NEWS.d/next/Build/2018-05-12-15-58-15.bpo-33473.BEm_Wt.rst
@@ -1,0 +1,1 @@
+configure.ac was fixed to correctly report CC, CFLAGS, and LDFLAGS

--- a/configure
+++ b/configure
@@ -7529,11 +7529,9 @@ if ${ac_cv_pthread+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_save_cc="$CC"
-CC="$CC -pthread"
-if test "$cross_compiling" = yes; then :
-  ac_cv_pthread=no
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+CC="$CC"
+CFLAGS="-pthread"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <stdio.h>
@@ -7550,15 +7548,13 @@ int main(){
 }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_pthread=yes
 else
   ac_cv_pthread=no
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
 CC="$ac_save_cc"
 fi
 
@@ -7585,7 +7581,8 @@ then
   ac_cv_cxx_thread=yes
 elif test "$ac_cv_pthread" = "yes"
 then
-  CXX="$CXX -pthread"
+  CXX="$CXX"
+  CXXFLAGS="-pthread"
   ac_cv_cxx_thread=yes
 fi
 
@@ -8865,7 +8862,7 @@ then CC="$CC -Kpthread"
 elif test "$ac_cv_kthread" = "yes"
 then CC="$CC -Kthread"
 elif test "$ac_cv_pthread" = "yes"
-then CC="$CC -pthread"
+then CC="$CC"; BASECFLAGS="$BASECFLAGS -pthread"; BASECXXFLAGS="$BASECXXFLAGS -pthread"
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for pthread_t" >&5
@@ -10298,9 +10295,11 @@ then
     posix_threads=yes
 elif test "$ac_cv_pthread" = "yes"
 then
-    CC="$CC -pthread"
+    CC="$CC"
+    BASECFLAGS="$BASECFLAGS -pthread"
     if test "$ac_cv_cxx_thread" = "yes"; then
-        CXX="$CXX -pthread"
+        CXX="$CXX"
+	BASECXXFLAGS="$BASECFLAGS -pthread"
     fi
     posix_threads=yes
 else

--- a/configure.ac
+++ b/configure.ac
@@ -1993,8 +1993,9 @@ then
 AC_MSG_CHECKING(whether $CC accepts -pthread)
 AC_CACHE_VAL(ac_cv_pthread,
 [ac_save_cc="$CC"
-CC="$CC -pthread"
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
+CC="$CC"
+LDFLAGS="-pthread"
+AC_LINK_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
 
@@ -2030,7 +2031,8 @@ then
   ac_cv_cxx_thread=yes
 elif test "$ac_cv_pthread" = "yes"
 then
-  CXX="$CXX -pthread"
+  CXX="$CXX"
+  CXXFLAGS="-pthread"
   ac_cv_cxx_thread=yes
 fi
 
@@ -2261,7 +2263,7 @@ then CC="$CC -Kpthread"
 elif test "$ac_cv_kthread" = "yes"
 then CC="$CC -Kthread"
 elif test "$ac_cv_pthread" = "yes"
-then CC="$CC -pthread"
+then CC="$CC"; BASECFLAGS="-pthread"; BASECXXFLAGS="-pthread"
 fi
 
 AC_MSG_CHECKING(for pthread_t)
@@ -2973,9 +2975,11 @@ then
     posix_threads=yes
 elif test "$ac_cv_pthread" = "yes"
 then
-    CC="$CC -pthread"
+    CC="$CC"
+    BASECFLAGS="-pthread"
     if test "$ac_cv_cxx_thread" = "yes"; then
-        CXX="$CXX -pthread"
+        CXX="$CXX"
+	BASECXXFLAGS="-pthread"
     fi
     posix_threads=yes
 else

--- a/configure.ac
+++ b/configure.ac
@@ -1994,7 +1994,7 @@ AC_MSG_CHECKING(whether $CC accepts -pthread)
 AC_CACHE_VAL(ac_cv_pthread,
 [ac_save_cc="$CC"
 CC="$CC"
-LDFLAGS="-pthread"
+CFLAGS="-pthread"
 AC_LINK_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
@@ -2263,7 +2263,7 @@ then CC="$CC -Kpthread"
 elif test "$ac_cv_kthread" = "yes"
 then CC="$CC -Kthread"
 elif test "$ac_cv_pthread" = "yes"
-then CC="$CC"; BASECFLAGS="-pthread"; BASECXXFLAGS="-pthread"
+then CC="$CC"; BASECFLAGS="$BASECFLAGS -pthread"; BASECXXFLAGS="$BASECXXFLAGS -pthread"
 fi
 
 AC_MSG_CHECKING(for pthread_t)
@@ -2976,10 +2976,10 @@ then
 elif test "$ac_cv_pthread" = "yes"
 then
     CC="$CC"
-    BASECFLAGS="-pthread"
+    BASECFLAGS="$BASECFLAGS -pthread"
     if test "$ac_cv_cxx_thread" = "yes"; then
         CXX="$CXX"
-	BASECXXFLAGS="-pthread"
+	BASECXXFLAGS="$BASECFLAGS -pthread"
     fi
     posix_threads=yes
 else


### PR DESCRIPTION
- "-pthread" is a part of the C compiler and linker flags. It is not
part of the compiler. In particular 'make CC=clang' ought to work
- checking for pthreads support is a link time issue, not run time

Not done in this patch:
- convert from "gcc" to "cc" to more correctly infer the current
compiler
- regenerate generated code such as "configure" or "aclocal.m4"

<!-- issue-number: bpo-33473 -->
https://bugs.python.org/issue33473
<!-- /issue-number -->
