### PR TITLE
fix error message in ast.c

### DIFF
--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4063,7 +4063,7 @@ ast_for_stmt(struct compiling *c, const node *n)
                 return ast_for_async_stmt(c, ch);
             default:
                 PyErr_Format(PyExc_SystemError,
-                             "unhandled small_stmt: TYPE=%d NCH=%d\n",
+                             "unhandled compound_stmt: TYPE=%d NCH=%d\n",
                              TYPE(n), NCH(n));
                 return NULL;
         }


### PR DESCRIPTION
This was probably copied from the PyErr_Format one block up, but this block handles compound_stmt, not small_stmt.

This confused me for a while when I was messing with the grammar and got an inexplicable error about small_stmt.

I don't think this requires an issue or a NEWS entry (this error should basically only appear when you make changes to the grammar), but I can add one if needed.