### PR TITLE
bpo-33484: Link instead of run certain test programs

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-05-13-17-32-17.bpo-33484.OqDvEb.rst
+++ b/Misc/NEWS.d/next/Build/2018-05-13-17-32-17.bpo-33484.OqDvEb.rst
@@ -1,0 +1,1 @@
+Avoid running test applications when linking will do.

--- a/configure
+++ b/configure
@@ -7374,9 +7374,6 @@ $as_echo_n "checking whether pthreads are available without options... " >&6; }
 if ${ac_cv_pthread_is_default+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  if test "$cross_compiling" = yes; then :
-  ac_cv_pthread_is_default=no
-else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -7394,7 +7391,7 @@ int main(){
 }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+if ac_fn_c_try_link "$LINENO"; then :
 
   ac_cv_pthread_is_default=yes
   ac_cv_kthread=no
@@ -7403,10 +7400,8 @@ if ac_fn_c_try_run "$LINENO"; then :
 else
   ac_cv_pthread_is_default=no
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
 
 fi
 
@@ -7421,7 +7416,7 @@ else
 # -Kpthread, if available, provides the right #defines
 # and linker options to make pthread_create available
 # Some compilers won't report that they do not support -Kpthread,
-# so we need to run a program to see whether it really made the
+# so we need to link a program to see whether it really made the
 # function available.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -Kpthread" >&5
 $as_echo_n "checking whether $CC accepts -Kpthread... " >&6; }
@@ -7430,10 +7425,7 @@ if ${ac_cv_kpthread+:} false; then :
 else
   ac_save_cc="$CC"
 CC="$CC -Kpthread"
-if test "$cross_compiling" = yes; then :
-  ac_cv_kpthread=no
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <stdio.h>
@@ -7450,15 +7442,13 @@ int main(){
 }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_kpthread=yes
 else
   ac_cv_kpthread=no
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
 CC="$ac_save_cc"
 fi
 
@@ -7471,7 +7461,7 @@ then
 # -Kthread, if available, provides the right #defines
 # and linker options to make pthread_create available
 # Some compilers won't report that they do not support -Kthread,
-# so we need to run a program to see whether it really made the
+# so we need to link a program to see whether it really made the
 # function available.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -Kthread" >&5
 $as_echo_n "checking whether $CC accepts -Kthread... " >&6; }
@@ -7480,10 +7470,7 @@ if ${ac_cv_kthread+:} false; then :
 else
   ac_save_cc="$CC"
 CC="$CC -Kthread"
-if test "$cross_compiling" = yes; then :
-  ac_cv_kthread=no
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <stdio.h>
@@ -7500,15 +7487,13 @@ int main(){
 }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_kthread=yes
 else
   ac_cv_kthread=no
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
 CC="$ac_save_cc"
 fi
 
@@ -7521,7 +7506,7 @@ then
 # -pthread, if available, provides the right #defines
 # and linker options to make pthread_create available
 # Some compilers won't report that they do not support -pthread,
-# so we need to run a program to see whether it really made the
+# so we need to link a program to see whether it really made the
 # function available.
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether $CC accepts -pthread" >&5
 $as_echo_n "checking whether $CC accepts -pthread... " >&6; }
@@ -7530,10 +7515,7 @@ if ${ac_cv_pthread+:} false; then :
 else
   ac_save_cc="$CC"
 CC="$CC -pthread"
-if test "$cross_compiling" = yes; then :
-  ac_cv_pthread=no
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
 #include <stdio.h>
@@ -7550,15 +7532,13 @@ int main(){
 }
 
 _ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
+if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_pthread=yes
 else
   ac_cv_pthread=no
 fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
 CC="$ac_save_cc"
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -1901,7 +1901,7 @@ fi
 # options before we can check whether -Kpthread improves anything.
 AC_MSG_CHECKING(whether pthreads are available without options)
 AC_CACHE_VAL(ac_cv_pthread_is_default,
-[AC_RUN_IFELSE([AC_LANG_SOURCE([[
+[AC_LINK_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
 
@@ -1930,13 +1930,13 @@ else
 # -Kpthread, if available, provides the right #defines
 # and linker options to make pthread_create available
 # Some compilers won't report that they do not support -Kpthread,
-# so we need to run a program to see whether it really made the
+# so we need to link a program to see whether it really made the
 # function available.
 AC_MSG_CHECKING(whether $CC accepts -Kpthread)
 AC_CACHE_VAL(ac_cv_kpthread,
 [ac_save_cc="$CC"
 CC="$CC -Kpthread"
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
+AC_LINK_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
 
@@ -1959,13 +1959,13 @@ then
 # -Kthread, if available, provides the right #defines
 # and linker options to make pthread_create available
 # Some compilers won't report that they do not support -Kthread,
-# so we need to run a program to see whether it really made the
+# so we need to link a program to see whether it really made the
 # function available.
 AC_MSG_CHECKING(whether $CC accepts -Kthread)
 AC_CACHE_VAL(ac_cv_kthread,
 [ac_save_cc="$CC"
 CC="$CC -Kthread"
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
+AC_LINK_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
 
@@ -1988,13 +1988,13 @@ then
 # -pthread, if available, provides the right #defines
 # and linker options to make pthread_create available
 # Some compilers won't report that they do not support -pthread,
-# so we need to run a program to see whether it really made the
+# so we need to link a program to see whether it really made the
 # function available.
 AC_MSG_CHECKING(whether $CC accepts -pthread)
 AC_CACHE_VAL(ac_cv_pthread,
 [ac_save_cc="$CC"
 CC="$CC -pthread"
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
+AC_LINK_IFELSE([AC_LANG_SOURCE([[
 #include <stdio.h>
 #include <pthread.h>
 


### PR DESCRIPTION
The build system attempts to run certain test code when it can actually
just link the code. This is a minor performance optimization but is really
a semantic correctness issue.

<!-- issue-number: bpo-33484 -->
https://bugs.python.org/issue33484
<!-- /issue-number -->
