### PR TITLE
bpo-33461: remove json.loads encoding kwarg

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -262,14 +262,13 @@ Basic Usage
    .. versionchanged:: 3.6
       All optional parameters are now :ref:`keyword-only <keyword-only_parameter>`.
 
-.. function:: loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None, parse_int=None, parse_constant=None, object_pairs_hook=None, **kw)
+.. function:: loads(s, *, cls=None, object_hook=None, parse_float=None, parse_int=None, parse_constant=None, object_pairs_hook=None, **kw)
 
    Deserialize *s* (a :class:`str`, :class:`bytes` or :class:`bytearray`
    instance containing a JSON document) to a Python object using this
    :ref:`conversion table <json-to-py-table>`.
 
-   The other arguments have the same meaning as in :func:`load`, except
-   *encoding* which is ignored and deprecated.
+   The other arguments have the same meaning as in :func:`load`.
 
    If the data being deserialized is not a valid JSON document, a
    :exc:`JSONDecodeError` will be raised.

--- a/Lib/json/__init__.py
+++ b/Lib/json/__init__.py
@@ -296,7 +296,7 @@ def load(fp, *, cls=None, object_hook=None, parse_float=None,
         parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
 
 
-def loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None,
+def loads(s, *, cls=None, object_hook=None, parse_float=None,
         parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
     """Deserialize ``s`` (a ``str``, ``bytes`` or ``bytearray`` instance
     containing a JSON document) to a Python object.
@@ -330,7 +330,6 @@ def loads(s, *, encoding=None, cls=None, object_hook=None, parse_float=None,
     To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
     kwarg; otherwise ``JSONDecoder`` is used.
 
-    The ``encoding`` argument is ignored and deprecated.
     """
     if isinstance(s, str):
         if s.startswith('\ufeff'):

--- a/Misc/NEWS.d/next/Library/2018-05-13-14-19-13.bpo-33461.uteyf-.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-13-14-19-13.bpo-33461.uteyf-.rst
@@ -1,0 +1,2 @@
+json.loads *encoding* keyword which was deprecated and ignored since Python
+3.1 has been removed


### PR DESCRIPTION
The keyword argument was deprecated in 3.1, and can now be removed.

Alternative to gh-6762 that just raise a DeprecationWarning and delay the removal.

<!-- issue-number: bpo-33461 -->
https://bugs.python.org/issue33461
<!-- /issue-number -->
