### PR TITLE
bpo-33488: Satisfy markdownlint for pull request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,11 @@ Please read this comment in its entirety. It's quite important.
 # Pull Request title
 
 It should be in the following format:
+
 ```
 bpo-NNNN: Summary of the changes made
 ```
+
 Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.
 
 Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.
@@ -16,9 +18,11 @@ Most PRs will require an issue number. Trivial changes, like fixing a typo, do n
 
 If this is a backport PR (PR made against branches other than `master`),
 please ensure that the PR title is in the following format:
+
 ```
 [X.Y] <title from the original PR> (GH-NNNN)
 ```
+
 Where: [X.Y] is the branch name, e.g. [3.6].
 
 GH-NNNN refers to the PR number from `master`.


### PR DESCRIPTION
skip news
markdownlint is, as the name implies, a tool for linting markdown files. The current template has several warnings. Fix them.
<!-- issue-number: bpo-33488 -->
https://bugs.python.org/issue33488
<!-- /issue-number -->
