### PR TITLE
trivial: rely on AC_USE_SYSTEM_EXTENSIONS

### DIFF
--- a/configure
+++ b/configure
@@ -2967,12 +2967,6 @@ VERSION=3.8
 
 SOVERSION=1.0
 
-# The later defininition of _XOPEN_SOURCE disables certain features
-# on Linux, so we need _GNU_SOURCE to re-enable them (makedev, tm_zone).
-
-$as_echo "#define _GNU_SOURCE 1" >>confdefs.h
-
-
 # The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on NetBSD, so we need _NETBSD_SOURCE to re-enable
 # them.

--- a/configure.ac
+++ b/configure.ac
@@ -121,10 +121,6 @@ VERSION=PYTHON_VERSION
 AC_SUBST(SOVERSION)
 SOVERSION=1.0
 
-# The later defininition of _XOPEN_SOURCE disables certain features
-# on Linux, so we need _GNU_SOURCE to re-enable them (makedev, tm_zone).
-AC_DEFINE(_GNU_SOURCE, 1, [Define on Linux to activate all library features])
-
 # The later defininition of _XOPEN_SOURCE and _POSIX_C_SOURCE disables
 # certain features on NetBSD, so we need _NETBSD_SOURCE to re-enable
 # them.

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1495,9 +1495,6 @@
 /* This must be set to 64 on some systems to enable large file support. */
 #undef _FILE_OFFSET_BITS
 
-/* Define on Linux to activate all library features */
-#undef _GNU_SOURCE
-
 /* Define to include mbstate_t for mbrtowc */
 #undef _INCLUDE__STDC_A1_SOURCE
 


### PR DESCRIPTION
Instead of manually defining GNU_SOURCE, rely on
AC_USE_SYSTEM_EXTENSIONS as it already defines _GNU_SOURCE as required.