### PR TITLE
bpo-31849: Fix warning in pyhash.c.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-05-14-11-00-00.bpo-31849.EmHaH4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-05-14-11-00-00.bpo-31849.EmHaH4.rst
@@ -1,0 +1,1 @@
+Fix signed/unsigned comparison warning in pyhash.c.

--- a/Python/pyhash.c
+++ b/Python/pyhash.c
@@ -272,8 +272,8 @@ fnv(const void *src, Py_ssize_t len)
         x = (_PyHASH_MULTIPLIER * x) ^ (Py_uhash_t) *p++;
     x ^= (Py_uhash_t) len;
     x ^= (Py_uhash_t) _Py_HashSecret.fnv.suffix;
-    if (x == -1) {
-        x = -2;
+    if (x == (Py_uhash_t) -1) {
+        x = (Py_uhash_t) -2;
     }
     return x;
 }


### PR DESCRIPTION
Fix a warning about signed/unsigned comparison.

<!-- issue-number: bpo-31849 -->
https://bugs.python.org/issue31849
<!-- /issue-number -->
