### PR TITLE
[2.7] bpo-32861: urllib.robotparser fix incomplete __str__ methods. (GH-5711) (GH-6795)

### DIFF
--- a/Lib/robotparser.py
+++ b/Lib/robotparser.py
@@ -160,7 +160,10 @@ class RobotFileParser:
 
 
     def __str__(self):
-        return ''.join([str(entry) + "\n" for entry in self.entries])
+        entries = self.entries
+        if self.default_entry is not None:
+            entries = entries + [self.default_entry]
+        return '\n'.join(map(str, entries)) + '\n'
 
 
 class RuleLine:

--- a/Lib/test/test_robotparser.py
+++ b/Lib/test/test_robotparser.py
@@ -136,6 +136,31 @@ Disallow: /cyberworld/map/
     bad = ['/cyberworld/map/index.html']
 
 
+class StringFormattingTest(BaseRobotTest, unittest.TestCase):
+    robots_txt = """\
+User-agent: *
+Crawl-delay: 1
+Request-rate: 3/15
+Disallow: /cyberworld/map/ # This is an infinite virtual URL space
+
+# Cybermapper knows where to go.
+User-agent: cybermapper
+Disallow: /some/path
+    """
+
+    expected_output = """\
+User-agent: cybermapper
+Disallow: /some/path
+
+User-agent: *
+Disallow: /cyberworld/map/
+
+"""
+
+    def test_string_formatting(self):
+        self.assertEqual(str(self.parser), self.expected_output)
+
+
 class RobotHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
@@ -226,6 +251,7 @@ def test_main():
         UseFirstUserAgentWildcardTest,
         EmptyQueryStringTest,
         DefaultEntryTest,
+        StringFormattingTest,
         PasswordProtectedSiteTestCase,
         NetworkTestCase)
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -807,6 +807,7 @@ Ben Laurie
 Simon Law
 Julia Lawall
 Chris Lawrence
+Michael Lazar
 Brian Leair
 Mathieu Leduc-Hamel
 Amandine Lee

--- a/Misc/NEWS.d/next/Library/2018-04-02-20-44-54.bpo-32861.HeBjzN.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-02-20-44-54.bpo-32861.HeBjzN.rst
@@ -1,0 +1,3 @@
+The urllib.robotparser's ``__str__`` representation now includes wildcard
+entries and the "Crawl-delay" and "Request-rate" fields. Patch by
+Michael Lazar.


### PR DESCRIPTION
The robotparser's `__str__` representation now includes wildcard entries.
(cherry picked from commit c3fa1f2b93fa4bf96a8aadc74ee196384cefa31e)

Co-authored-by: Michael Lazar <lazar.michael22@gmail.com>.


<!-- issue-number: bpo-32861 -->
https://bugs.python.org/issue32861
<!-- /issue-number -->
