### PR TITLE
bpo-33421: Add AsyncContextManager to typing module documentation (Python 3.7+).

### DIFF
--- a/Doc/library/typing.rst
+++ b/Doc/library/typing.rst
@@ -666,6 +666,12 @@ The module defines the following classes, functions and decorators:
 
    .. versionadded:: 3.6
 
+.. class:: AsyncContextManager(Generic[T_co])
+
+   A generic version of :class:`contextlib.AbstractAsyncContextManager`.
+
+   .. versionadded:: 3.6
+
 .. class:: Dict(dict, MutableMapping[KT, VT])
 
    A generic version of :class:`dict`.

--- a/Misc/NEWS.d/next/Documentation/2018-05-14-15-15-41.bpo-33421.3GU_QO.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-14-15-15-41.bpo-33421.3GU_QO.rst
@@ -1,0 +1,1 @@
+Add missing documentation for ``typing.AsyncContextManager``.


### PR DESCRIPTION
Adds documention for  `typing.AsyncContextManager` referencing `contextlib.AbstractAsyncContextManager` (which was added in 3.7).
See #6700.

@ilevkivskyi 

<!-- issue-number: bpo-33421 -->
https://bugs.python.org/issue33421
<!-- /issue-number -->
