### PR TITLE
Fix ClassVar as string fails when getting type hints

### DIFF
--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1553,6 +1553,14 @@ class ForwardRefTests(BaseTestCase):
         with self.assertRaises(SyntaxError):
             get_type_hints(foo)
 
+    def test_type_error(self):
+
+        def foo(a: Tuple['42']):
+            pass
+
+        with self.assertRaises(TypeError):
+            get_type_hints(foo)
+
     def test_name_error(self):
 
         def foo(a: 'Noode[T]'):

--- a/Lib/test/test_typing.py
+++ b/Lib/test/test_typing.py
@@ -1553,14 +1553,6 @@ class ForwardRefTests(BaseTestCase):
         with self.assertRaises(SyntaxError):
             get_type_hints(foo)
 
-    def test_type_error(self):
-
-        def foo(a: Tuple['42']):
-            pass
-
-        with self.assertRaises(TypeError):
-            get_type_hints(foo)
-
     def test_name_error(self):
 
         def foo(a: 'Noode[T]'):
@@ -1589,6 +1581,20 @@ class ForwardRefTests(BaseTestCase):
         self.assertEqual(cth, {})
         ith = get_type_hints(C().foo)
         self.assertEqual(ith, {})
+
+    def test_no_type_check_forward_ref_as_string(self):
+        class C:
+            foo: typing.ClassVar[int] = 7
+        class D:
+            foo: ClassVar[int] = 7
+        class E:
+            foo: 'typing.ClassVar[int]' = 7
+        class F:
+            foo: 'ClassVar[int]' = 7
+
+        expected_result = {'foo': typing.ClassVar[int]}
+        for clazz in [C, D, E, F]:
+            self.assertEqual(get_type_hints(clazz), expected_result)
 
     def test_no_type_check_no_bases(self):
         class C:

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -486,9 +486,7 @@ class ForwardRef(_Final, _root=True):
                 globalns = localns
             elif localns is None:
                 localns = globalns
-            self.__forward_value__ = _type_check(
-                eval(self.__forward_code__, globalns, localns),
-                "Forward references must evaluate to types.")
+            self.__forward_value__ = eval(self.__forward_code__, globalns, localns)
             self.__forward_evaluated__ = True
         return self.__forward_value__
 

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -106,7 +106,7 @@ __all__ = [
 # legitimate imports of those modules.
 
 
-def _type_check(arg, msg):
+def _type_check(arg, msg, is_argument=False):
     """Check that the argument is a type, and return it (internal helper).
 
     As a special case, accept None and return type(None) instead. Also wrap strings
@@ -118,12 +118,16 @@ def _type_check(arg, msg):
 
     We append the repr() of the actual value (truncated to 100 chars).
     """
+    invalid_generic_forms = (Generic, _Protocol)
+    if not is_argument:
+        invalid_generic_forms = invalid_generic_forms + (ClassVar, )
+
     if arg is None:
         return type(None)
     if isinstance(arg, str):
         return ForwardRef(arg)
     if (isinstance(arg, _GenericAlias) and
-            arg.__origin__ in (Generic, _Protocol, ClassVar)):
+            arg.__origin__ in invalid_generic_forms):
         raise TypeError(f"{arg} is not valid as type argument")
     if (isinstance(arg, _SpecialForm) and arg is not Any or
             arg in (Generic, _Protocol)):
@@ -464,9 +468,10 @@ class ForwardRef(_Final, _root=True):
     """Internal wrapper to hold a forward reference."""
 
     __slots__ = ('__forward_arg__', '__forward_code__',
-                 '__forward_evaluated__', '__forward_value__')
+                 '__forward_evaluated__', '__forward_value__',
+                 '__forward_is_argument__')
 
-    def __init__(self, arg):
+    def __init__(self, arg, is_argument=False):
         if not isinstance(arg, str):
             raise TypeError(f"Forward reference must be a string -- got {arg!r}")
         try:
@@ -477,6 +482,7 @@ class ForwardRef(_Final, _root=True):
         self.__forward_code__ = code
         self.__forward_evaluated__ = False
         self.__forward_value__ = None
+        self.__forward_is_argument__ = is_argument
 
     def _evaluate(self, globalns, localns):
         if not self.__forward_evaluated__ or localns is not globalns:
@@ -486,7 +492,10 @@ class ForwardRef(_Final, _root=True):
                 globalns = localns
             elif localns is None:
                 localns = globalns
-            self.__forward_value__ = eval(self.__forward_code__, globalns, localns)
+            self.__forward_value__ = _type_check(
+                eval(self.__forward_code__, globalns, localns),
+                "Forward references must evaluate to types.",
+                is_argument=self.__forward_is_argument__)
             self.__forward_evaluated__ = True
         return self.__forward_value__
 
@@ -996,7 +1005,7 @@ def get_type_hints(obj, globalns=None, localns=None):
                 if value is None:
                     value = type(None)
                 if isinstance(value, str):
-                    value = ForwardRef(value)
+                    value = ForwardRef(value, is_argument=True)
                 value = _eval_type(value, base_globals, localns)
                 hints[name] = value
         return hints

--- a/Misc/NEWS.d/next/Library/2018-05-15-18-02-03.bpo-0.pj2Mbb.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-15-18-02-03.bpo-0.pj2Mbb.rst
@@ -1,1 +1,1 @@
-Fix ClassVar as string failure when getting type hints
+Fix failure in `typing.get_type_hints()` when ClassVar was provided as a string forward reference.

--- a/Misc/NEWS.d/next/Library/2018-05-15-18-02-03.bpo-0.pj2Mbb.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-15-18-02-03.bpo-0.pj2Mbb.rst
@@ -1,0 +1,1 @@
+Fix ClassVar as string failure when getting type hints


### PR DESCRIPTION
Closes python/typing#505
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
