### PR TITLE
bpo-31445: Added two lines to avoid 

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1815,6 +1815,8 @@ def get_mailbox_list(value):
         if value and value[0] == ',':
             mailbox_list.append(ListSeparator)
             value = value[1:]
+    if not value:
+        value = ';'
     return mailbox_list, value
 
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

fix-issue-31455:  Changed by adding two lines in the module "email/_header_value_parser.py" into the function "get_mailbox_list(value)" before return mailbox_list, value to avoid IndexError.


<!-- issue-number: bpo-31445 -->
https://bugs.python.org/issue31445
<!-- /issue-number -->
