### PR TITLE
issue 29412 fixed empty string exception in get_word of email library module

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1336,15 +1336,21 @@ def get_word(value):
         leader, value = get_cfws(value)
     else:
         leader = None
-    if value[0]=='"':
-        token, value = get_quoted_string(value)
-    elif value[0] in SPECIALS:
-        raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
-                                      "but found '{}'".format(value))
+    if value:
+        if value[0] == '"':
+            token, value = get_quoted_string(value)
+        elif value[0] in SPECIALS:
+            raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
+                                          "but found '{}'".format(value))
+        else:
+            token, value = get_atom(value)
+        if leader is not None:
+            token[:0] = [leader]
     else:
         token, value = get_atom(value)
     if leader is not None:
         token[:0] = [leader]
+
     return token, value
 
 def get_phrase(value):


### PR DESCRIPTION

# Issue 29412 Pull Request

```
bpo-29412: Fixed string-index out of range error in get_word by checking value for empty string
```

# Backport Pull Request title

If this is a backport PR

```
[fix-issue-29412] <Issue 29412> (GH-29412)
```
