### PR TITLE
bpo-31445: String index out of range in get_group(), email/_header_value_parser.py

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1854,7 +1854,6 @@ def get_group_list(value):
         token[:0] = [leader]
     group_list.append(token)
     return group_list, value
-
 def get_group(value):
     """ group = display-name ":" [group-list] ";" [CFWS]
 
@@ -1875,7 +1874,7 @@ def get_group(value):
     if not value:
         group.defects.append(errors.InvalidHeaderDefect(
             "end of header in group"))
-    if value[0] != ';':
+    elif value[0] != ';':
         raise errors.HeaderParseError(
             "expected ';' at end of group but found {}".format(value))
     group.append(ValueTerminal(';', 'group-terminator'))

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2048,6 +2048,20 @@ class TestParser(TestParserMixin, TestEmailBase):
                          group_list.all_mailboxes)
 
     # get_group
+    def test_get_group_empty_missing_semi(self):
+        group = self._test_get_x(parser.get_group,
+                                 'Monty Python:',
+                                 'Monty Python:;',
+                                 'Monty Python:;',
+                                 [errors.InvalidHeaderDefect,
+                                  errors.InvalidHeaderDefect],
+                                 '')
+        self.assertEqual(group.token_type, 'group')
+        self.assertEqual(group.display_name, 'Monty Python')
+        self.assertEqual(len(group.mailboxes), 0)
+        self.assertEqual(group.mailboxes,
+                         group.all_mailboxes)
+    
 
     def test_get_group_empty(self):
         group = self._test_get_x(parser.get_group,


### PR DESCRIPTION
<!--
fixed the index error bug
-->


<!-- issue-number: [bpo-31445](https://bugs.python.org/issue31445) -->
https://bugs.python.org/issue31445
<!-- /issue-number -->
