### PR TITLE
trivial: remove unused argument to AC_CHECK_SIZEOF

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -18,6 +18,7 @@ David Abrahams
 Marc Abramowitz
 Eldar Abusalimov
 Ron Adam
+Eitan Adler
 Anton Afanasyev
 Ali Afshar
 Nitika Agarwal

--- a/configure
+++ b/configure
@@ -779,7 +779,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -887,7 +886,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1140,15 +1138,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1286,7 +1275,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1439,7 +1428,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -11057,11 +11045,16 @@ $as_echo "$MACHDEP_OBJS" >&6; }
 fi
 
 # checks for library functions
-for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
+AC_CHECK_CHOWN
+AC_CHECK_FSEEKO
+AC_CHECK_GETGROUPS
+
+
+for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset \
  clock confstr ctermid dup3 execv faccessat fchmod fchmodat fchown fchownat \
  fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
  futimens futimes gai_strerror getentropy \
- getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \
+ getgrouplist getlogin getloadavg getpeername getpgid getpid \
  getpriority getresuid getresgid getpwent getspnam getspent getsid getwd \
  if_nameindex \
  initgroups kill killpg lchmod lchown lockf linkat lstat lutimes mmap \
@@ -12152,7 +12145,7 @@ done
 
 
 # check for long file support functions
-for ac_func in fseek64 fseeko fstatvfs ftell64 ftello statvfs
+for ac_func in fseek64 fstatvfs ftell64 statvfs
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -3419,11 +3419,16 @@ else
 fi
 
 # checks for library functions
-AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
+AC_CHECK_CHOWN
+AC_CHECK_FSEEKO
+AC_CHECK_GETGROUPS
+
+
+AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset \
  clock confstr ctermid dup3 execv faccessat fchmod fchmodat fchown fchownat \
  fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
  futimens futimes gai_strerror getentropy \
- getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \
+ getgrouplist getlogin getloadavg getpeername getpgid getpid \
  getpriority getresuid getresgid getpwent getspnam getspent getsid getwd \
  if_nameindex \
  initgroups kill killpg lchmod lchown lockf linkat lstat lutimes mmap \
@@ -3712,7 +3717,7 @@ AC_CHECK_FUNCS(forkpty,,
 )
 
 # check for long file support functions
-AC_CHECK_FUNCS(fseek64 fseeko fstatvfs ftell64 ftello statvfs)
+AC_CHECK_FUNCS(fseek64 fstatvfs ftell64 statvfs)
 
 AC_REPLACE_FUNCS(dup2 strdup)
 AC_CHECK_FUNCS(getpgrp,

--- a/configure.ac
+++ b/configure.ac
@@ -2186,16 +2186,16 @@ AC_CHECK_TYPE(__uint128_t,
 
 # Sizes of various common basic types
 # ANSI C requires sizeof(char) == 1, so no need to check it
-AC_CHECK_SIZEOF(int, 4)
-AC_CHECK_SIZEOF(long, 4)
-AC_CHECK_SIZEOF(long long, 8)
-AC_CHECK_SIZEOF(void *, 4)
-AC_CHECK_SIZEOF(short, 2)
-AC_CHECK_SIZEOF(float, 4)
-AC_CHECK_SIZEOF(double, 8)
-AC_CHECK_SIZEOF(fpos_t, 4)
-AC_CHECK_SIZEOF(size_t, 4)
-AC_CHECK_SIZEOF(pid_t, 4)
+AC_CHECK_SIZEOF(int)
+AC_CHECK_SIZEOF(long)
+AC_CHECK_SIZEOF(long long)
+AC_CHECK_SIZEOF(void *)
+AC_CHECK_SIZEOF(short)
+AC_CHECK_SIZEOF(float)
+AC_CHECK_SIZEOF(double)
+AC_CHECK_SIZEOF(fpos_t)
+AC_CHECK_SIZEOF(size_t)
+AC_CHECK_SIZEOF(pid_t)
 AC_CHECK_SIZEOF(uintptr_t)
 
 AC_MSG_CHECKING(for long double support)
@@ -2206,10 +2206,10 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[]], [[long double x; x = (long double)0;]])
 ],[])
 AC_MSG_RESULT($have_long_double)
 if test "$have_long_double" = yes ; then
-AC_CHECK_SIZEOF(long double, 16)
+AC_CHECK_SIZEOF(long double)
 fi
 
-AC_CHECK_SIZEOF(_Bool, 1)
+AC_CHECK_SIZEOF(_Bool)
 
 AC_CHECK_SIZEOF(off_t, [], [
 #ifdef HAVE_SYS_TYPES_H
@@ -4509,7 +4509,7 @@ wchar_h="no"
 # determine wchar_t size
 if test "$wchar_h" = yes
 then
-  AC_CHECK_SIZEOF(wchar_t, 4, [#include <wchar.h>])
+  AC_CHECK_SIZEOF(wchar_t, [], [#include <wchar.h>])
 fi
 
 AC_MSG_CHECKING(for UCS-4 tcl)


### PR DESCRIPTION
The middle argument to AC_CHECK_SIZEOF does nothing now. See
https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Generic-Compiler-Characteristics.html

Instead of setting it, remove it.