### PR TITLE
[skip issue]Small changes in importing process of multiprocessing package

### DIFF
--- a/Lib/multiprocessing/__init__.py
+++ b/Lib/multiprocessing/__init__.py
@@ -19,7 +19,7 @@ from . import context
 # Copy stuff from default context
 #
 
-__all__ = [x for x in dir(context._default_context) if not x[0].startswith('_')]
+__all__ = [x for x in dir(context._default_context) if not x.startswith('_')]
 globals().update((name, getattr(context._default_context, name)) for name in __all__)
 
 #

--- a/Lib/multiprocessing/__init__.py
+++ b/Lib/multiprocessing/__init__.py
@@ -19,9 +19,8 @@ from . import context
 # Copy stuff from default context
 #
 
-globals().update((name, getattr(context._default_context, name))
-                 for name in context._default_context.__all__)
-__all__ = context._default_context.__all__
+__all__ = [x for x in dir(context._default_context) if not x[0].startswith('_')]
+globals().update((name, getattr(context._default_context, name)) for name in __all__)
 
 #
 # XXX These should not really be documented or public.

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -5,7 +5,7 @@ import threading
 from . import process
 from . import reduction
 
-__all__ = []
+__all__ = ()
 
 #
 # Exceptions

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -5,7 +5,7 @@ import threading
 from . import process
 from . import reduction
 
-__all__ = []            # things are copied from here to __init__.py
+__all__ = []
 
 #
 # Exceptions

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -24,7 +24,7 @@ class AuthenticationError(ProcessError):
     pass
 
 #
-# Base type for contexts
+# Base type for contexts. Bound methods of an instance of this type are included in __all__ of __init__.py
 #
 
 class BaseContext(object):
@@ -260,8 +260,6 @@ class DefaultContext(BaseContext):
                 return ['fork', 'spawn', 'forkserver']
             else:
                 return ['fork', 'spawn']
-
-DefaultContext.__all__ = [x for x in dir(DefaultContext) if x[0] != '_']
 
 #
 # Context types for fixed start method

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4573,6 +4573,12 @@ class TestSimpleQueue(unittest.TestCase):
 
         proc.join()
 
+
+class MiscTestCase(unittest.TestCase):
+    def test__all__(self):
+        # Just make sure names in blacklist are excluded
+        support.check__all__(self, multiprocessing, extra=multiprocessing.__all__,
+                             blacklist=['SUBDEBUG', 'SUBWARNING'])
 #
 # Mixins
 #


### PR DESCRIPTION
It seems that the way multiprocessing package set `__all__` is overly complex. And `__all__` in context.py is not used in `__init__.py` so I guess the comment there is misleading.