### PR TITLE
bpo-33514: Document PEP 492 changes in 3.7 changelog

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -684,6 +684,8 @@ can be used to create instance variables with different implementation details.
    :pep:`3129` - Class Decorators
 
 
+.. _async:
+
 Coroutines
 ==========
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1157,6 +1157,16 @@ Changes in Python behavior
   exceptions.
   (Contributed by Yury Selivanov in :issue:`32670`.)
 
+* :pep:`492` is fully implemented in Python 3.7, meaning that the old
+  :meth:`__aiter__` protocol is no longer supported: a
+  :exc:`RuntimeError` will be raised if :meth:`__aiter__` returns anything
+  but an asynchronous iterator.
+
+  Since Python 3.7, :keyword:`async` and :keyword:`await` names are proper
+  keywords. If you use them for variable names, you need to rename them in
+  order to make the code work on Python 3.7. Trying to use a keyword as
+  a variable name will raise a :exc:`SyntaxError`.
+
 * Due to an oversight, earlier Python versions erroneously accepted the
   following syntax::
 


### PR DESCRIPTION
Based on PEP 492, old \_\_aiter\_\_ protocol is no longer supported
and async and await are now keywords.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33514 -->
https://bugs.python.org/issue33514
<!-- /issue-number -->
