### PR TITLE
bpo-33471: Fix invalid numeric formatting with UCS2 separator

### DIFF
--- a/Lib/test/test_format.py
+++ b/Lib/test/test_format.py
@@ -436,6 +436,34 @@ class FormatTest(unittest.TestCase):
             self.assertIn(sep, text)
             self.assertIn(point, text)
             self.assertEqual(text.replace(sep, ''), '1234' + point + '5')
+
+            text = format(12, "n")
+            self.assertEqual(text, '12')
+        finally:
+            locale.setlocale(locale.LC_ALL, oldloc)
+
+    def test_locale_ucs2_sep(self):
+        try:
+            oldloc = locale.setlocale(locale.LC_ALL)
+            locale.setlocale(locale.LC_ALL, 'fr_FR.UTF-8')
+        except locale.Error as err:
+            self.skipTest("Cannot set locale: {}".format(err))
+        try:
+            localeconv = locale.localeconv()
+            sep = localeconv['thousands_sep']
+            point = localeconv['decimal_point']
+
+            text = format(123456789, "n")
+            self.assertIn(sep, text)
+            self.assertEqual(text.replace(sep, ''), '123456789')
+
+            text = format(1234.5, "n")
+            self.assertIn(sep, text)
+            self.assertIn(point, text)
+            self.assertEqual(text.replace(sep, ''), '1234' + point + '5')
+
+            text = format(12, "n")
+            self.assertEqual(text, '12')
         finally:
             locale.setlocale(locale.LC_ALL, oldloc)
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -9316,11 +9316,9 @@ _PyUnicode_InsertThousandsGrouping(
             if (!thousands_sep_data)
                 return -1;
         }
-        else {
-            data = _PyUnicode_AsKind(unicode, thousands_sep_kind);
-            if (!data)
-                return -1;
-        }
+        /* when thousands_sep_kind > kind, trust
+         * the writer setting by _PyUnicodeWriter_Prepare.
+         */
     }
 
     switch (kind) {
@@ -9354,8 +9352,6 @@ _PyUnicode_InsertThousandsGrouping(
     if (unicode != NULL && thousands_sep_kind != kind) {
         if (thousands_sep_kind < kind)
             PyMem_Free(thousands_sep_data);
-        else
-            PyMem_Free(data);
     }
     if (unicode == NULL) {
         *maxchar = 127;


### PR DESCRIPTION
This fixes [bpo-33471](https://bugs.python.org/issue33471).
#### Repro. code
```python
import locale

print('{:n}'.format(int(1200000)))
locale.setlocale(locale.LC_ALL, 'fr_FR.UTF-8')
print('{:n}'.format(int(1200000)))
print('{:n}'.format(int(12)))
```

<!-- issue-number: bpo-33471 -->
https://bugs.python.org/issue33471
<!-- /issue-number -->
