### PR TITLE
bpo-28167: Remove platform.linux_distribution

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -243,33 +243,6 @@ Mac OS Platform
 Unix Platforms
 --------------
 
-
-.. function:: dist(distname='', version='', id='', supported_dists=('SuSE','debian','redhat','mandrake',...))
-
-   This is another name for :func:`linux_distribution`.
-
-   .. deprecated-removed:: 3.5 3.8
-      See alternative like the `distro <https://pypi.org/project/distro>`_ package.
-
-.. function:: linux_distribution(distname='', version='', id='', supported_dists=('SuSE','debian','redhat','mandrake',...), full_distribution_name=1)
-
-   Tries to determine the name of the Linux OS distribution name.
-
-   ``supported_dists`` may be given to define the set of Linux distributions to
-   look for. It defaults to a list of currently supported Linux distributions
-   identified by their release file name.
-
-   If ``full_distribution_name`` is true (default), the full distribution read
-   from the OS is returned. Otherwise the short name taken from
-   ``supported_dists`` is used.
-
-   Returns a tuple ``(distname,version,id)`` which defaults to the args given as
-   parameters.  ``id`` is the item in parentheses after the version number.  It
-   is usually the version codename.
-
-   .. deprecated-removed:: 3.5 3.8
-      See alternative like the `distro <https://pypi.org/project/distro>`_ package.
-
 .. function:: libc_ver(executable=sys.executable, lib='', version='', chunksize=2048)
 
    Tries to determine the libc version against which the file executable (defaults

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -259,16 +259,6 @@ class PlatformTest(unittest.TestCase):
             self.assertEqual(cpid, pid)
             self.assertEqual(sts, 0)
 
-    def test_dist(self):
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore',
-                r'dist\(\) and linux_distribution\(\) '
-                'functions are deprecated .*',
-                PendingDeprecationWarning,
-            )
-            res = platform.dist()
-
     def test_libc_ver(self):
         import os
         if os.path.isdir(sys.executable) and \
@@ -278,23 +268,6 @@ class PlatformTest(unittest.TestCase):
         else:
             executable = sys.executable
         res = platform.libc_ver(executable)
-
-    def test_parse_release_file(self):
-
-        for input, output in (
-            # Examples of release file contents:
-            ('SuSE Linux 9.3 (x86-64)', ('SuSE Linux ', '9.3', 'x86-64')),
-            ('SUSE LINUX 10.1 (X86-64)', ('SUSE LINUX ', '10.1', 'X86-64')),
-            ('SUSE LINUX 10.1 (i586)', ('SUSE LINUX ', '10.1', 'i586')),
-            ('Fedora Core release 5 (Bordeaux)', ('Fedora Core', '5', 'Bordeaux')),
-            ('Red Hat Linux release 8.0 (Psyche)', ('Red Hat Linux', '8.0', 'Psyche')),
-            ('Red Hat Linux release 9 (Shrike)', ('Red Hat Linux', '9', 'Shrike')),
-            ('Red Hat Enterprise Linux release 4 (Nahant)', ('Red Hat Enterprise Linux', '4', 'Nahant')),
-            ('CentOS release 4', ('CentOS', '4', None)),
-            ('Rocks release 4.2.1 (Cydonia)', ('Rocks', '4.2.1', 'Cydonia')),
-            ('', ('', '', '')), # If there's nothing there.
-            ):
-            self.assertEqual(platform._parse_release_file(input), output)
 
     def test_popen(self):
         mswindows = (sys.platform == "win32")
@@ -327,44 +300,6 @@ class PlatformTest(unittest.TestCase):
                 else:
                     returncode = ret >> 8
                 self.assertEqual(returncode, len(data))
-
-    def test_linux_distribution_encoding(self):
-        # Issue #17429
-        with tempfile.TemporaryDirectory() as tempdir:
-            filename = os.path.join(tempdir, 'fedora-release')
-            with open(filename, 'w', encoding='utf-8') as f:
-                f.write('Fedora release 19 (Schr\xf6dinger\u2019s Cat)\n')
-
-            with mock.patch('platform._UNIXCONFDIR', tempdir):
-                with warnings.catch_warnings():
-                    warnings.filterwarnings(
-                        'ignore',
-                        r'dist\(\) and linux_distribution\(\) '
-                        'functions are deprecated .*',
-                        PendingDeprecationWarning,
-                    )
-                    distname, version, distid = platform.linux_distribution()
-
-                self.assertEqual(distname, 'Fedora')
-            self.assertEqual(version, '19')
-            self.assertEqual(distid, 'Schr\xf6dinger\u2019s Cat')
-
-
-class DeprecationTest(unittest.TestCase):
-
-    def test_dist_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            platform.dist()
-        self.assertEqual(str(cm.warning),
-                         'dist() and linux_distribution() functions are '
-                         'deprecated in Python 3.5')
-
-    def test_linux_distribution_deprecation(self):
-        with self.assertWarns(DeprecationWarning) as cm:
-            platform.linux_distribution()
-        self.assertEqual(str(cm.warning),
-                         'dist() and linux_distribution() functions are '
-                         'deprecated in Python 3.5')
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4060,24 +4060,16 @@ def test_main(verbose=False):
     if support.verbose:
         import warnings
         plats = {
-            'Linux': platform.linux_distribution,
             'Mac': platform.mac_ver,
             'Windows': platform.win32_ver,
         }
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                'ignore',
-                r'dist\(\) and linux_distribution\(\) '
-                'functions are deprecated .*',
-                PendingDeprecationWarning,
-            )
-            for name, func in plats.items():
-                plat = func()
-                if plat and plat[0]:
-                    plat = '%s %r' % (name, plat)
-                    break
-            else:
-                plat = repr(platform.platform())
+        for name, func in plats.items():
+            plat = func()
+            if plat and plat[0]:
+                plat = '%s %r' % (name, plat)
+                break
+        else:
+            plat = repr(platform.platform())
         print("test_ssl: testing with %r %r" %
             (ssl.OPENSSL_VERSION, ssl.OPENSSL_VERSION_INFO))
         print("          under %s" % plat)

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -181,22 +181,6 @@ def asn1time(cert_time):
 
     return cert_time
 
-# Issue #9415: Ubuntu hijacks their OpenSSL and forcefully disables SSLv2
-def skip_if_broken_ubuntu_ssl(func):
-    if hasattr(ssl, 'PROTOCOL_SSLv2'):
-        @functools.wraps(func)
-        def f(*args, **kwargs):
-            try:
-                ssl.SSLContext(ssl.PROTOCOL_SSLv2)
-            except ssl.SSLError:
-                if (ssl.OPENSSL_VERSION_INFO == (0, 9, 8, 15, 15) and
-                    platform.linux_distribution() == ('debian', 'squeeze/sid', '')):
-                    raise unittest.SkipTest("Patched Ubuntu OpenSSL breaks behaviour")
-            return func(*args, **kwargs)
-        return f
-    else:
-        return func
-
 needs_sni = unittest.skipUnless(ssl.HAS_SNI, "SNI support needed for this test")
 
 
@@ -975,7 +959,6 @@ class BasicSocketTests(unittest.TestCase):
 
 class ContextTests(unittest.TestCase):
 
-    @skip_if_broken_ubuntu_ssl
     def test_constructor(self):
         for protocol in PROTOCOLS:
             ssl.SSLContext(protocol)
@@ -984,7 +967,6 @@ class ContextTests(unittest.TestCase):
         self.assertRaises(ValueError, ssl.SSLContext, -1)
         self.assertRaises(ValueError, ssl.SSLContext, 42)
 
-    @skip_if_broken_ubuntu_ssl
     def test_protocol(self):
         for proto in PROTOCOLS:
             ctx = ssl.SSLContext(proto)
@@ -1018,7 +1000,6 @@ class ContextTests(unittest.TestCase):
         self.assertIn('AES256-GCM-SHA384', names)
         self.assertIn('AES128-GCM-SHA256', names)
 
-    @skip_if_broken_ubuntu_ssl
     def test_options(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         # OP_ALL | OP_NO_SSLv2 | OP_NO_SSLv3 is the default value
@@ -1333,7 +1314,6 @@ class ContextTests(unittest.TestCase):
         with self.assertRaises(ssl.SSLError) as cm:
             ctx.load_dh_params(CERTFILE)
 
-    @skip_if_broken_ubuntu_ssl
     def test_session_stats(self):
         for proto in PROTOCOLS:
             ctx = ssl.SSLContext(proto)
@@ -2554,7 +2534,6 @@ def try_protocol_combo(server_protocol, client_protocol, expect_success,
 
 class ThreadedTests(unittest.TestCase):
 
-    @skip_if_broken_ubuntu_ssl
     def test_echo(self):
         """Basic test of an SSL client connecting to a server"""
         if support.verbose:
@@ -2923,7 +2902,6 @@ class ThreadedTests(unittest.TestCase):
                     self.assertIn(msg, repr(e))
                     self.assertIn('certificate verify failed', repr(e))
 
-    @skip_if_broken_ubuntu_ssl
     @unittest.skipUnless(hasattr(ssl, 'PROTOCOL_SSLv2'),
                          "OpenSSL is compiled without SSLv2 support")
     def test_protocol_sslv2(self):
@@ -2947,7 +2925,6 @@ class ThreadedTests(unittest.TestCase):
         try_protocol_combo(ssl.PROTOCOL_SSLv2, ssl.PROTOCOL_TLS, False,
                            client_options=ssl.OP_NO_TLSv1)
 
-    @skip_if_broken_ubuntu_ssl
     def test_PROTOCOL_TLS(self):
         """Connecting to an SSLv23 server with various client options"""
         if support.verbose:
@@ -2987,7 +2964,6 @@ class ThreadedTests(unittest.TestCase):
                            server_options=ssl.OP_NO_TLSv1)
 
 
-    @skip_if_broken_ubuntu_ssl
     @unittest.skipUnless(hasattr(ssl, 'PROTOCOL_SSLv3'),
                          "OpenSSL is compiled without SSLv3 support")
     def test_protocol_sslv3(self):
@@ -3007,7 +2983,6 @@ class ThreadedTests(unittest.TestCase):
             try_protocol_combo(ssl.PROTOCOL_SSLv3, ssl.PROTOCOL_TLS,
                                False, client_options=ssl.OP_NO_SSLv2)
 
-    @skip_if_broken_ubuntu_ssl
     def test_protocol_tlsv1(self):
         """Connecting to a TLSv1 server with various client options"""
         if support.verbose:
@@ -3022,7 +2997,6 @@ class ThreadedTests(unittest.TestCase):
         try_protocol_combo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLS, False,
                            client_options=ssl.OP_NO_TLSv1)
 
-    @skip_if_broken_ubuntu_ssl
     @unittest.skipUnless(hasattr(ssl, "PROTOCOL_TLSv1_1"),
                          "TLS version 1.1 not supported.")
     def test_protocol_tlsv1_1(self):
@@ -3042,7 +3016,6 @@ class ThreadedTests(unittest.TestCase):
         try_protocol_combo(ssl.PROTOCOL_TLSv1_1, ssl.PROTOCOL_TLSv1, False)
         try_protocol_combo(ssl.PROTOCOL_TLSv1, ssl.PROTOCOL_TLSv1_1, False)
 
-    @skip_if_broken_ubuntu_ssl
     @unittest.skipUnless(hasattr(ssl, "PROTOCOL_TLSv1_2"),
                          "TLS version 1.2 not supported.")
     def test_protocol_tlsv1_2(self):

--- a/Misc/NEWS.d/next/Library/2018-05-15-13-49-13.bpo-28167.p4RdQt.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-15-13-49-13.bpo-28167.p4RdQt.rst
@@ -1,0 +1,1 @@
+Remove platform.linux_distribution, which was deprecated since 3.5.


### PR DESCRIPTION
The function `platform.linux_distribution` was scheduled for removal in 3.7, but didn't make it. But it can be removed it in 3.8.
Also remove some test_ssl infrastructure that depends on it (@tiran knows about the `skip_if_broken_ubuntu_ssl` removal).

<!-- issue-number: bpo-28167 -->
https://bugs.python.org/issue28167
<!-- /issue-number -->
