### PR TITLE
Fix Windows build of Python for latest WinSDK.

### DIFF
--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -21,7 +21,7 @@
 #endif /* HAVE_SYS_STAT_H */
 
 #ifdef MS_WINDOWS
-#include <consoleapi.h>
+#include <Windows.h>
 #endif
 
 /* Various interned strings */

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -77,7 +77,8 @@
     -->
     <_RegistryVersion>$(Registry:HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</_RegistryVersion>
     <_RegistryVersion Condition="$(_RegistryVersion) == ''">$(Registry:HKEY_LOCAL_MACHINE\WOW6432Node\SOFTWARE\Microsoft\Microsoft SDKs\Windows\v10.0@ProductVersion)</_RegistryVersion>
-    <DefaultWindowsSDKVersion>10.0.16299.0</DefaultWindowsSDKVersion>
+    <DefaultWindowsSDKVersion>10.0.17134.0</DefaultWindowsSDKVersion>
+    <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.16299'">10.0.16299.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.15063'">10.0.15063.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.14393'">10.0.14393.0</DefaultWindowsSDKVersion>
     <DefaultWindowsSDKVersion Condition="$(_RegistryVersion) == '10.0.10586'">10.0.10586.0</DefaultWindowsSDKVersion>


### PR DESCRIPTION
Python would not build on a fresh Windows machine with a fresh Visual Studio install. Per @zooba this is because there is a new version of the Windows SDK bundled with latest VS. This issue would not affect anyone upgrading earlier VS versions, only a fresh install.

Confirmed that this fix allows `PCBuild/build.bat` to complete instead of failing to find the Win SDK. 