### PR TITLE
[3.6] bpo-29706: IDLE now colors async and await as keywords in 3.6.

### DIFF
--- a/Lib/idlelib/colorizer.py
+++ b/Lib/idlelib/colorizer.py
@@ -13,7 +13,7 @@ def any(name, alternates):
     return "(?P<%s>" % name + "|".join(alternates) + ")"
 
 def make_pat():
-    kw = r"\b" + any("KEYWORD", keyword.kwlist) + r"\b"
+    kw = r"\b" + any("KEYWORD", keyword.kwlist + ['async', 'await']) + r"\b"
     builtinlist = [str(name) for name in dir(builtins)
                                         if not name.startswith('_') and \
                                         name not in keyword.kwlist]

--- a/Misc/NEWS.d/next/IDLE/2018-05-15-17-01-10.bpo-29706.id4H5i.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-05-15-17-01-10.bpo-29706.id4H5i.rst
@@ -1,0 +1,2 @@
+IDLE now colors async and await as keywords in 3.6. They become full
+keywords in 3.7.


### PR DESCRIPTION
They become full keywords in 3.7, so this patch is only needed for 3.6.


<!-- issue-number: bpo-29706 -->
https://bugs.python.org/issue29706
<!-- /issue-number -->
