### PR TITLE
bpo-33516: Add support for __round__ to MagicMock

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1660,7 +1660,7 @@ The full list of supported magic methods is:
 
 * ``__hash__``, ``__sizeof__``, ``__repr__`` and ``__str__``
 * ``__dir__``, ``__format__`` and ``__subclasses__``
-* ``__floor__``, ``__trunc__`` and ``__ceil__``
+* ``__round__``, ``__floor__``, ``__trunc__`` and ``__ceil__``
 * Comparisons: ``__lt__``, ``__gt__``, ``__le__``, ``__ge__``,
   ``__eq__`` and ``__ne__``
 * Container methods: ``__getitem__``, ``__setitem__``, ``__delitem__``,

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1709,7 +1709,7 @@ magic_methods = (
     # because there is no idivmod
     "divmod rdivmod neg pos abs invert "
     "complex int float index "
-    "trunc floor ceil "
+    "round trunc floor ceil "
     "bool next "
 )
 

--- a/Lib/unittest/test/testmock/testmagicmethods.py
+++ b/Lib/unittest/test/testmock/testmagicmethods.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 import sys
 from unittest.mock import Mock, MagicMock, _magics
@@ -280,6 +281,10 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(hash(mock), object.__hash__(mock))
         self.assertEqual(str(mock), object.__str__(mock))
         self.assertTrue(bool(mock))
+        self.assertEqual(round(mock), mock.__round__())
+        self.assertEqual(math.trunc(mock), mock.__trunc__())
+        self.assertEqual(math.floor(mock), mock.__floor__())
+        self.assertEqual(math.ceil(mock), mock.__ceil__())
 
         # in Python 3 oct and hex use __index__
         # so these tests are for __index__ in py3k

--- a/Misc/NEWS.d/next/Library/2018-05-15-17-06-42.bpo-33516.ZzARe4.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-15-17-06-42.bpo-33516.ZzARe4.rst
@@ -1,0 +1,1 @@
+:class:`unittest.mock.MagicMock` now supports the ``__round__`` magic method.


### PR DESCRIPTION
Adds support for `__round__` to MagicMock.


<!-- issue-number: bpo-33516 -->
https://bugs.python.org/issue33516
<!-- /issue-number -->
