### PR TITLE
Remove an unneeded call into OpenSSL

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -901,7 +901,6 @@ newPySSLSocket(PySSLContext *sslctx, PySocketSockObject *sock,
 #endif
 
     /* Make sure the SSL error state is initialized */
-    (void) ERR_get_state();
     ERR_clear_error();
 
     PySSL_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
This call doesn't do anything, on every version of OpenSSL going back to forever the call to `ERR_clear_error()` calls `ERR_get_state()`, so it's always been a no-op.