### PR TITLE
[3.6] Fix typos '.::' should typically just be '::'. (GH-6165).

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -981,7 +981,7 @@ is used when no command-line argument was present::
 
 
 Providing ``default=argparse.SUPPRESS`` causes no attribute to be added if the
-command-line argument was not present.::
+command-line argument was not present::
 
    >>> parser = argparse.ArgumentParser()
    >>> parser.add_argument('--foo', default=argparse.SUPPRESS)

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -123,7 +123,7 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
 
 
    :class:`~mmap.mmap` can also be used as a context manager in a :keyword:`with`
-   statement.::
+   statement::
 
       import mmap
 


### PR DESCRIPTION
(cherry picked from commit 78553138be3b38d361bded8e641a2a4fd65a9d16)
