### PR TITLE
bpo-13474 - add reference to -m usage in execution model

### DIFF
--- a/Doc/reference/executionmodel.rst
+++ b/Doc/reference/executionmodel.rst
@@ -22,9 +22,10 @@ The following are blocks: a module, a function body, and a class definition.
 Each command typed interactively is a block.  A script file (a file given as
 standard input to the interpreter or specified as a command line argument to the
 interpreter) is a code block.  A script command (a command specified on the
-interpreter command line with the '**-c**' option) is a code block.  The string
-argument passed to the built-in functions :func:`eval` and :func:`exec` is a
-code block.
+interpreter command line with the '**-c**' option) is a code block. A module run 
+as a top level script (as module `__main__`) from the command line using a 
+'**-m**' argument is also a code block.  The string argument passed to the 
+built-in functions :func:`eval` and :func:`exec` is a code block.
 
 .. index:: pair: execution; frame
 


### PR DESCRIPTION
Add small reference to -m usage from the command line and tie it to context of the paragraph on code blocks.




<!-- issue-number: bpo-13474 -->
https://bugs.python.org/issue13474
<!-- /issue-number -->
