### PR TITLE
[2.7] bpo-33503: Fix the broken pypi link in the source and the documentation

### DIFF
--- a/Doc/README.txt
+++ b/Doc/README.txt
@@ -15,7 +15,7 @@ Building the docs
 
 You need to have Sphinx <http://sphinx-doc.org/> installed; it is the toolset
 used to build the docs.  It is not included in this tree, but maintained
-separately and available from PyPI <https://pypi.python.org/pypi/Sphinx>.
+separately and available from PyPI <https://pypi.org/project/Sphinx>.
 
 
 Using make

--- a/Doc/distributing/index.rst
+++ b/Doc/distributing/index.rst
@@ -31,7 +31,7 @@ installing other Python projects, refer to the
 Key terms
 =========
 
-* the `Python Packaging Index <https://pypi.python.org/pypi>`__ is a public
+* the `Python Packaging Index <https://pypi.org>`__ is a public
   repository of open source licensed packages made available for use by
   other Python users
 * the `Python Packaging Authority

--- a/Doc/distutils/apiref.rst
+++ b/Doc/distutils/apiref.rst
@@ -78,7 +78,7 @@ setup script). Indirectly provides the  :class:`distutils.dist.Distribution` and
    |                    | be built                       | :class:`distutils.core.Extension`                           |
    +--------------------+--------------------------------+-------------------------------------------------------------+
    | *classifiers*      | A list of categories for the   | a list of strings; valid classifiers are listed on `PyPI    |
-   |                    | package                        | <https://pypi.python.org/pypi?:action=list_classifiers>`_.  |
+   |                    | package                        | <https://pypi.org/classifiers>`_.                           |
    +--------------------+--------------------------------+-------------------------------------------------------------+
    | *distclass*        | the :class:`Distribution`      | a subclass of                                               |
    |                    | class to use                   | :class:`distutils.core.Distribution`                        |

--- a/Doc/distutils/packageindex.rst
+++ b/Doc/distutils/packageindex.rst
@@ -248,4 +248,4 @@ without warnings does not guarantee that PyPI will convert the content
 successfully.
 
 
-.. _Python Package Index (PyPI): https://pypi.python.org/pypi
+.. _Python Package Index (PyPI): https://pypi.org

--- a/Doc/distutils/setupscript.rst
+++ b/Doc/distutils/setupscript.rst
@@ -606,7 +606,7 @@ Notes:
 (4)
     These fields should not be used if your package is to be compatible with Python
     versions prior to 2.2.3 or 2.3.  The list is available from the `PyPI website
-    <https://pypi.python.org/pypi>`_.
+    <https://pypi.org>`_.
 
 (5)
     The ``long_description`` field is used by PyPI when you are

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -117,7 +117,7 @@ programming), software engineering (unit testing, logging, profiling, parsing
 Python code), and operating system interfaces (system calls, filesystems, TCP/IP
 sockets).  Look at the table of contents for :ref:`library-index` to get an idea
 of what's available.  A wide variety of third-party extensions are also
-available.  Consult `the Python Package Index <https://pypi.python.org/pypi>`_ to
+available.  Consult `the Python Package Index <https://pypi.org>`_ to
 find packages of interest to you.
 
 

--- a/Doc/faq/library.rst
+++ b/Doc/faq/library.rst
@@ -19,7 +19,7 @@ standard library module.  (Eventually you'll learn what's in the standard
 library and will be able to skip this step.)
 
 For third-party packages, search the `Python Package Index
-<https://pypi.python.org/pypi>`_ or try `Google <https://www.google.com>`_ or
+<https://pypi.org>`_ or try `Google <https://www.google.com>`_ or
 another Web search engine.  Searching for "Python" plus a keyword or two for
 your topic of interest will usually find something helpful.
 
@@ -585,7 +585,7 @@ substituted for standard input and output.  You will have to use pseudo ttys
 ("ptys") instead of pipes. Or you can use a Python interface to Don Libes'
 "expect" library.  A Python extension that interfaces to expect is called "expy"
 and available from http://expectpy.sourceforge.net.  A pure Python solution that
-works like expect is `pexpect <https://pypi.python.org/pypi/pexpect/>`_.
+works like expect is `pexpect <https://pypi.org/project/pexpect/>`_.
 
 
 How do I access the serial (RS232) port?

--- a/Doc/howto/pyporting.rst
+++ b/Doc/howto/pyporting.rst
@@ -427,25 +427,25 @@ to make sure everything functions as expected in both versions of Python.
 
 
 .. _2to3: https://docs.python.org/3/library/2to3.html
-.. _caniusepython3: https://pypi.python.org/pypi/caniusepython3
+.. _caniusepython3: https://pypi.org/project/caniusepython3
 .. _cheat sheet: http://python-future.org/compatible_idioms.html
-.. _coverage.py: https://pypi.python.org/pypi/coverage
+.. _coverage.py: https://pypi.org/project/coverage
 .. _Futurize: http://python-future.org/automatic_conversion.html
 .. _importlib: https://docs.python.org/3/library/importlib.html#module-importlib
-.. _importlib2: https://pypi.python.org/pypi/importlib2
+.. _importlib2: https://pypi.org/project/importlib2
 .. _Modernize: https://python-modernize.readthedocs.org/en/latest/
 .. _mypy: http://mypy-lang.org/
 .. _Porting to Python 3: http://python3porting.com/
-.. _Pylint: https://pypi.python.org/pypi/pylint
+.. _Pylint: https://pypi.org/project/pylint
 
 .. _Python 3 Q & A: https://ncoghlan-devs-python-notes.readthedocs.org/en/latest/python3/questions_and_answers.html
 
 .. _pytype: https://github.com/google/pytype
 .. _python-future: http://python-future.org/
 .. _python-porting: https://mail.python.org/mailman/listinfo/python-porting
-.. _six: https://pypi.python.org/pypi/six
-.. _tox: https://pypi.python.org/pypi/tox
-.. _trove classifier: https://pypi.python.org/pypi?%3Aaction=list_classifiers
+.. _six: https://pypi.org/project/six
+.. _tox: https://pypi.org/project/tox
+.. _trove classifier: https://pypi.org/classifiers
 
 .. _"What's New": https://docs.python.org/3/whatsnew/index.html
 

--- a/Doc/howto/webservers.rst
+++ b/Doc/howto/webservers.rst
@@ -301,7 +301,7 @@ following WSGI-application::
     WSGIServer(app).run()
 
 This is a simple WSGI application, but you need to install `flup
-<https://pypi.python.org/pypi/flup/1.0>`_ first, as flup handles the low level
+<https://pypi.org/project/flup/1.0>`_ first, as flup handles the low level
 FastCGI access.
 
 .. seealso::
@@ -583,7 +583,7 @@ alternate storage mechanism.
      helps with choosing a method for saving data
 
    * `SQLAlchemy <http://www.sqlalchemy.org/>`_, the most powerful OR-Mapper
-     for Python, and `Elixir <https://pypi.python.org/pypi/Elixir>`_, which makes
+     for Python, and `Elixir <https://pypi.org/project/Elixir>`_, which makes
      SQLAlchemy easier to use
 
    * `SQLObject <http://www.sqlobject.org/>`_, another popular OR-Mapper

--- a/Doc/installing/index.rst
+++ b/Doc/installing/index.rst
@@ -39,9 +39,8 @@ Key terms
   being installed system wide
 * ``virtualenv`` is a third party tools for creating virtual environments, it
   is defaults to installing ``pip`` into all created virtual environments.
-* the `Python Packaging Index <https://pypi.python.org/pypi>`__ is a public
-  repository of open source licensed packages made available for use by
-  other Python users
+* the `Python Packaging Index <https://pypi.org>`__ is a public repository of
+  open source licensed packages made available for use by other Python users
 * the `Python Packaging Authority
   <https://www.pypa.io/en/latest/>`__ are the group of
   developers and documentation authors responsible for the maintenance and

--- a/Doc/library/bz2.rst
+++ b/Doc/library/bz2.rst
@@ -74,7 +74,7 @@ Handling of compressed files is offered by the :class:`BZ2File` class.
       input file, only the first stream will be accessible. If you require
       support for multi-stream files, consider using the third-party
       :mod:`bz2file` module (available from
-      `PyPI <https://pypi.python.org/pypi/bz2file>`_). This module provides a
+      `PyPI <https://pypi.org/project/bz2file>`_). This module provides a
       backport of Python 3.3's :class:`BZ2File` class, which does support
       multi-stream files.
 

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1566,7 +1566,7 @@ EST (fixed offset -5 hours), or only EDT (fixed offset -4 hours)).
 
 .. seealso::
 
-   `pytz <https://pypi.python.org/pypi/pytz/>`_
+   `pytz <https://pypi.org/project/pytz/>`_
       The standard library has no :class:`tzinfo` instances, but
       there exists a third-party library which brings the *IANA timezone
       database* (also known as the Olson database) to Python: *pytz*.

--- a/Doc/library/distribution.rst
+++ b/Doc/library/distribution.rst
@@ -4,7 +4,7 @@ Software Packaging and Distribution
 
 These libraries help you with publishing and installing Python software.
 While these modules are designed to work in conjunction with the
-`Python Package Index <https://pypi.python.org>`__, they can also be used
+`Python Package Index <https://pypi.org>`__, they can also be used
 with a local index server, or without any index server at all.
 
 .. toctree::

--- a/Doc/library/index.rst
+++ b/Doc/library/index.rst
@@ -30,7 +30,7 @@ optional components.
 In addition to the standard library, there is a growing collection of
 several thousand components (from individual programs and modules to
 packages and entire application development frameworks), available from
-the `Python Package Index <https://pypi.python.org/pypi>`_.
+the `Python Package Index <https://pypi.org>`_.
 
 
 .. toctree::

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -234,4 +234,3 @@ parameters.
     ['aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
      'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'],
     ['cccccccccccccccccccc', 'dddddddddddddddddddd']]
-

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -35,7 +35,7 @@ fine-tuning parameters.
 
 .. seealso::
 
-   The third-party `regex <https://pypi.python.org/pypi/regex/>`_ module,
+   The third-party `regex <https://pypi.org/project/regex/>`_ module,
    which has an API compatible with the standard library :mod:`re` module,
    but offers additional functionality and a more thorough Unicode support.
 

--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -1586,7 +1586,7 @@ Visual inspection shows that the certificate does identify the desired service
                 (('commonName', 'www.python.org'),)),
     'subjectAltName': (('DNS', 'www.python.org'),
                        ('DNS', 'python.org'),
-                       ('DNS', 'pypi.python.org'),
+                       ('DNS', 'pypi.org'),
                        ('DNS', 'docs.python.org'),
                        ('DNS', 'testpypi.python.org'),
                        ('DNS', 'bugs.python.org'),

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -32,7 +32,7 @@ functions can be found in the subprocess-replacements_ section.
 
    :pep:`324` -- PEP proposing the subprocess module
 
-.. _subprocess32: https://pypi.python.org/pypi/subprocess32/
+.. _subprocess32: https://pypi.org/project/subprocess32/
 
 Using the :mod:`subprocess` Module
 ----------------------------------

--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -78,7 +78,7 @@ need to derive from a specific class.
    Module :mod:`doctest`
       Another test-support module with a very different flavor.
 
-   `unittest2: A backport of new unittest features for Python 2.4-2.6 <https://pypi.python.org/pypi/unittest2>`_
+   `unittest2: A backport of new unittest features for Python 2.4-2.6 <https://pypi.org/project/unittest2>`_
       Many new features were added to unittest in Python 2.7, including test
       discovery. unittest2 allows you to use these features with earlier
       versions of Python.

--- a/Doc/library/xml.rst
+++ b/Doc/library/xml.rst
@@ -129,8 +129,8 @@ break backward compatibility. After all inline DTD and entity expansion are
 well-defined XML features.
 
 
-.. _defusedxml: https://pypi.python.org/pypi/defusedxml/
-.. _defusedexpat: https://pypi.python.org/pypi/defusedexpat/
+.. _defusedxml: https://pypi.org/project/defusedxml/
+.. _defusedexpat: https://pypi.org/project/defusedexpat/
 .. _Billion Laughs: https://en.wikipedia.org/wiki/Billion_laughs
 .. _ZIP bomb: https://en.wikipedia.org/wiki/Zip_bomb
 .. _DTD: https://en.wikipedia.org/wiki/Document_type_definition

--- a/Doc/tutorial/whatnow.rst
+++ b/Doc/tutorial/whatnow.rst
@@ -38,7 +38,7 @@ More Python resources:
 
 * https://docs.python.org:  Fast access to Python's  documentation.
 
-* https://pypi.python.org/pypi: The Python Package Index, previously also nicknamed
+* https://pypi.org: The Python Package Index, previously also nicknamed
   the Cheese Shop, is an index of user-created Python modules that are available
   for download.  Once you begin releasing code, you can register it here so that
   others can find it.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -242,7 +242,7 @@ The Windows-specific standard modules are documented in
 PyWin32
 -------
 
-The `PyWin32 <https://pypi.python.org/pypi/pywin32>`_ module by Mark Hammond
+The `PyWin32 <https://pypi.org/project/pywin32>`_ module by Mark Hammond
 is a collection of modules for advanced Windows-specific support.  This includes
 utilities for:
 

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -659,7 +659,7 @@ The heart of the catalog is the new Distutils :command:`register` command.
 Running ``python setup.py register`` will collect the metadata describing a
 package, such as its name, version, maintainer, description, &c., and send it to
 a central catalog server.  The resulting catalog is available from
-https://pypi.python.org/pypi.
+https://pypi.org.
 
 To make the catalog a bit more useful, a new optional *classifiers* keyword
 argument has been added to the Distutils :func:`setup` function.  A list of

--- a/Doc/whatsnew/2.5.rst
+++ b/Doc/whatsnew/2.5.rst
@@ -229,7 +229,7 @@ required packages. ::
         )
 
 Another new enhancement to the Python package index at
-https://pypi.python.org is storing source and binary archives for a
+https://pypi.org is storing source and binary archives for a
 package.  The new :command:`upload` Distutils command will upload a package to
 the repository.
 

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -1809,7 +1809,7 @@ new features were added.  Most of these features were implemented
 by Michael Foord, unless otherwise noted.  The enhanced version of
 the module is downloadable separately for use with Python versions 2.4 to 2.6,
 packaged as the :mod:`unittest2` package, from
-https://pypi.python.org/pypi/unittest2.
+https://pypi.org/project/unittest2.
 
 When used from the command line, the module can automatically discover
 tests.  It's not as fancy as `py.test <http://pytest.org>`__ or

--- a/Misc/NEWS.d/next/Documentation/2018-05-14-20-08-58.bpo-33503.Wvt0qg.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-14-20-08-58.bpo-33503.Wvt0qg.rst
@@ -1,0 +1,1 @@
+Fix broken pypi link


### PR DESCRIPTION
Fix the broken pypi link in the source and the documentation (GH-6814).

(cherry picked from commit 19177fbd5d6d9b29ccc302d65f9d9417ece082ce)

Co-authored-by: Stéphane Wirtel <stephane@wirtel.be>



<!-- issue-number: bpo-33503 -->
https://bugs.python.org/issue33503
<!-- /issue-number -->
