### PR TITLE
bpo-29412: patched string index out of range error in get_word function of _head…

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1336,15 +1336,21 @@ def get_word(value):
         leader, value = get_cfws(value)
     else:
         leader = None
-    if value[0]=='"':
-        token, value = get_quoted_string(value)
-    elif value[0] in SPECIALS:
-        raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
-                                      "but found '{}'".format(value))
+    if value:
+        if value[0]=='"':
+            token, value = get_quoted_string(value)
+        elif value[0] in SPECIALS:
+            raise errors.HeaderParseError("Expected 'atom' or 'quoted-string' "
+                                          "but found '{}'".format(value))
+        else:
+            token, value = get_atom(value)
+        if leader is not None:
+            token[:0] = [leader]
     else:
         token, value = get_atom(value)
     if leader is not None:
         token[:0] = [leader]
+
     return token, value
 
 def get_phrase(value):

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -901,6 +901,20 @@ class TestParser(TestParserMixin, TestEmailBase):
         self.assertEqual(word.token_type, 'atom')
         self.assertEqual(word[0].token_type, 'cfws')
 
+    def test_get_word_all_CFWS(self):
+        word = self._test_get_x(parser.get_word,
+                                '(Recipients list suppressed',
+                                str(parser.CFWSList([parser.Comment([
+                                    parser.WhiteSpaceTerminal('Recipients', 'ptext'),
+                                    parser.WhiteSpaceTerminal(' ', 'fws'),
+                                    parser.WhiteSpaceTerminal('list', 'ptext'),
+                                    parser.WhiteSpaceTerminal(' ', 'fws'),
+                                    parser.WhiteSpaceTerminal('suppressed', 'ptext')
+                                    ])])),
+                                    ' ', [], ''
+                                )
+        self.assertEqual(word.token_type, 'cfws')
+
     def test_get_word_qs_yields_qs(self):
         word = self._test_get_x(parser.get_word,
             '"bar " (bang) ah', '"bar " (bang) ', 'bar  ', [], 'ah')
@@ -2288,6 +2302,17 @@ class TestParser(TestParserMixin, TestEmailBase):
 
 
     # get_address_list
+
+    def test_get_address_list_CFWS(self):
+        address_list = self._test_get_x(parser.get_address_list,
+                                        '(Recipient list suppressed)',
+                                        '(Recipient list suppressed)',
+                                        ' ',
+                                        [errors.ObsoleteHeaderDefect],  # no content in address list
+                                        '')
+        self.assertEqual(address_list.token_type, 'address-list')
+        self.assertEqual(len(address_list.mailboxes), 0)
+        self.assertEqual(address_list.mailboxes, address_list.all_mailboxes)
 
     def test_get_address_list_mailboxes_simple(self):
         address_list = self._test_get_x(parser.get_address_list,


### PR DESCRIPTION
…er_value_parser.py and created tests in test__header_value_parser.py for empty string.

```
bpo-29412: patched string index out of range error in get_word function of _header_value_parser.py by checking for empty string.  Empty string is returned by get_cfws(value)[1] when everything is CFWS.
```

# Backport Pull Request title

Changes suggested to be applied to python 3.5 , 3.6 , and 3.7

<!-- issue-number: bpo-29412 -->
https://bugs.python.org/issue29412
<!-- /issue-number -->
