### PR TITLE
bpo-33525: Add env type checking when spawn called

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -23,6 +23,7 @@ and opendir), and leave all pathname manipulation to os.path
 
 #'
 import abc
+import inspect
 import sys
 import stat as st
 
@@ -658,7 +659,7 @@ def get_exec_path(env=None):
 
 
 # Change environ to automatically call putenv(), unsetenv if they exist.
-from _collections_abc import MutableMapping
+from _collections_abc import MutableMapping, Mapping
 
 class _Environ(MutableMapping):
     def __init__(self, data, encodekey, decodekey, encodevalue, decodevalue, putenv, unsetenv):
@@ -847,6 +848,14 @@ if _exists("fork") and not _exists("spawnv") and _exists("execv"):
             raise TypeError('argv must be a tuple or a list')
         if not args or not args[0]:
             raise ValueError('argv first element cannot be empty')
+
+        sig = inspect.signature(func)
+        if len(sig.parameters) == 3:
+            if env is None:
+                raise TypeError('env must not be None')
+            elif not isinstance(env, Mapping):
+                raise TypeError('env must be a mapping object')
+
         pid = fork()
         if not pid:
             # Child

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2439,6 +2439,14 @@ class SpawnTests(unittest.TestCase):
     def _test_invalid_env(self, spawn):
         args = [sys.executable, '-c', 'pass']
 
+        # env is None
+        env = None
+        self.assertRaises(TypeError, spawn, os.P_WAIT, args[0], args, env)
+
+        # env is not a mapping object
+        env = 1
+        self.assertRaises(TypeError, spawn, os.P_WAIT, args[0], args, env)
+
         # null character in the environment variable name
         newenv = os.environ.copy()
         newenv["FRUIT\0VEGETABLE"] = "cabbage"


### PR DESCRIPTION
This fixes [bpo-33525](https://bugs.python.org/issue33525).

<!-- issue-number: bpo-33525 -->
https://bugs.python.org/issue33525
<!-- /issue-number -->
