### PR TITLE
bpo-33540: Add block_on_close attr to socketserver

### DIFF
--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -116,10 +116,13 @@ server classes.
    only available on POSIX platforms that support :func:`~os.fork`.
 
    :meth:`socketserver.ForkingMixIn.server_close` waits until all child
-   processes complete.
+   processes complete, except if
+   :attr:`socketserver.ForkingMixIn.block_on_close` attribute if false.
 
    :meth:`socketserver.ThreadingMixIn.server_close` waits until all non-daemon
-   threads complete. Use daemonic threads by setting
+   threads complete, except if
+   :attr:`socketserver.ThreadingMixIn.block_on_close` attribute if false. Use
+   daemonic threads by setting
    :data:`ThreadingMixIn.daemon_threads` to ``True`` to not wait until threads
    complete.
 
@@ -128,6 +131,9 @@ server classes.
       :meth:`socketserver.ForkingMixIn.server_close` and
       :meth:`socketserver.ThreadingMixIn.server_close` now waits until all
       child processes and non-daemonic threads complete.
+
+      Add a new :attr:`socketserver.ForkingMixIn.block_on_close` class
+      attribute to opt-in for the old behaviour.
 
 
 .. class:: ForkingTCPServer

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -131,9 +131,8 @@ server classes.
       :meth:`socketserver.ForkingMixIn.server_close` and
       :meth:`socketserver.ThreadingMixIn.server_close` now waits until all
       child processes and non-daemonic threads complete.
-
       Add a new :attr:`socketserver.ForkingMixIn.block_on_close` class
-      attribute to opt-in for the old behaviour.
+      attribute to opt-in for the pre-3.7 behaviour.
 
 
 .. class:: ForkingTCPServer

--- a/Doc/library/socketserver.rst
+++ b/Doc/library/socketserver.rst
@@ -117,11 +117,11 @@ server classes.
 
    :meth:`socketserver.ForkingMixIn.server_close` waits until all child
    processes complete, except if
-   :attr:`socketserver.ForkingMixIn.block_on_close` attribute if false.
+   :attr:`socketserver.ForkingMixIn.block_on_close` attribute is false.
 
    :meth:`socketserver.ThreadingMixIn.server_close` waits until all non-daemon
    threads complete, except if
-   :attr:`socketserver.ThreadingMixIn.block_on_close` attribute if false. Use
+   :attr:`socketserver.ThreadingMixIn.block_on_close` attribute is false. Use
    daemonic threads by setting
    :data:`ThreadingMixIn.daemon_threads` to ``True`` to not wait until threads
    complete.

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1225,7 +1225,7 @@ until all child processes complete.
 
 Add a new :attr:`socketserver.ForkingMixIn.block_on_close` class attribute to
 :class:`socketserver.ForkingMixIn` and :class:`socketserver.ThreadingMixIn`
-classes. Set the class attribute to ``False`` to get the old behaviour.
+classes. Set the class attribute to ``False`` to get the pre-3.7 behaviour.
 
 
 sqlite3
@@ -2171,13 +2171,13 @@ Changes in the Python API
 * :meth:`socketserver.ThreadingMixIn.server_close` now waits until all
   non-daemon threads complete.  Set the new
   :attr:`socketserver.ThreadingMixIn.block_on_close` class attribute to
-  ``False`` to get the old behaviour.
+  ``False`` to get the pre-3.7 behaviour.
   (Contributed by Victor Stinner in :issue:`31233` and :issue:`33540`.)
 
 * :meth:`socketserver.ForkingMixIn.server_close` now waits until all
   child processes complete. Set the new
   :attr:`socketserver.ForkingMixIn.block_on_close` class attribute to ``False``
-  to get the old behaviour.
+  to get the pre-3.7 behaviour.
   (Contributed by Victor Stinner in :issue:`31151` and :issue:`33540`.)
 
 * The :func:`locale.localeconv` function now temporarily sets the ``LC_CTYPE``

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1205,6 +1205,18 @@ by default.
 (Contributed by Christian Heimes in :issue:`28134`.)
 
 
+socketserver
+------------
+
+:meth:`socketserver.ThreadingMixIn.server_close` now waits until all non-daemon
+threads complete. :meth:`socketserver.ForkingMixIn.server_close` now waits
+until all child processes complete.
+
+Add a new :attr:`socketserver.ForkingMixIn.block_on_close` class attribute to
+:class:`socketserver.ForkingMixIn` and :class:`socketserver.ThreadingMixIn`
+classes. Set the class attribute to ``False`` to get the old behaviour.
+
+
 sqlite3
 -------
 
@@ -2141,10 +2153,17 @@ Changes in the Python API
   and module are affected by this change. (Contributed by INADA Naoki and
   Eugene Toder in :issue:`29463`.)
 
-* :meth:`~socketserver.BaseServer.server_close` in
-  :class:`socketserver.ThreadingMixIn` and :class:`socketserver.ForkingMixIn`
-  now waits until all non-daemon threads complete.
-  (Contributed by Victor Stinner in :issue:`31233` and :issue:`31151`.)
+* :meth:`socketserver.ThreadingMixIn.server_close` now waits until all
+  non-daemon threads complete.  Set the new
+  :attr:`socketserver.ThreadingMixIn.block_on_close` class attribute to
+  ``False`` to get the old behaviour.
+  (Contributed by Victor Stinner in :issue:`31233` and :issue:`33540`.)
+
+* :meth:`socketserver.ForkingMixIn.server_close` now waits until all
+  child processes complete. Set the new
+  :attr:`socketserver.ForkingMixIn.block_on_close` class attribute to ``False``
+  to get the old behaviour.
+  (Contributed by Victor Stinner in :issue:`31151` and :issue:`33540`.)
 
 * The :func:`locale.localeconv` function now temporarily sets the ``LC_CTYPE``
   locale to the value of ``LC_NUMERIC`` in some cases.

--- a/Misc/NEWS.d/next/Library/2018-05-16-18-10-38.bpo-33540.wy9LRV.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-16-18-10-38.bpo-33540.wy9LRV.rst
@@ -1,0 +1,2 @@
+Add a new ``block_on_close`` class attribute to ``ForkingMixIn`` and
+``ThreadingMixIn`` classes of :mod:`socketserver`.


### PR DESCRIPTION
Add a new block_on_close class attribute to ForkingMixIn and
ThreadingMixIn classes of socketserver.

<!-- issue-number: bpo-33540 -->
https://bugs.python.org/issue33540
<!-- /issue-number -->
