### PR TITLE
bpo-32604: Improve subinterpreter tests.

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -156,13 +156,16 @@ class GetCurrentTests(TestBase):
         main = interpreters.get_main()
         cur = interpreters.get_current()
         self.assertEqual(cur, main)
+        self.assertIsInstance(cur, interpreters.InterpreterID)
 
     def test_subinterpreter(self):
         main = interpreters.get_main()
         interp = interpreters.create()
         out = _run_output(interp, dedent("""
             import _xxsubinterpreters as _interpreters
-            print(_interpreters.get_current())
+            cur = _interpreters.get_current()
+            print(cur)
+            assert isinstance(cur, _interpreters.InterpreterID)
             """))
         cur = int(out.strip())
         _, expected = interpreters.list_all()
@@ -176,13 +179,16 @@ class GetMainTests(TestBase):
         [expected] = interpreters.list_all()
         main = interpreters.get_main()
         self.assertEqual(main, expected)
+        self.assertIsInstance(main, interpreters.InterpreterID)
 
     def test_from_subinterpreter(self):
         [expected] = interpreters.list_all()
         interp = interpreters.create()
         out = _run_output(interp, dedent("""
             import _xxsubinterpreters as _interpreters
-            print(_interpreters.get_main())
+            main = _interpreters.get_main()
+            print(main)
+            assert isinstance(main, _interpreters.InterpreterID)
             """))
         main = int(out.strip())
         self.assertEqual(main, expected)
@@ -293,6 +299,7 @@ class CreateTests(TestBase):
 
     def test_in_main(self):
         id = interpreters.create()
+        self.assertIsInstance(id, interpreters.InterpreterID)
 
         self.assertIn(id, interpreters.list_all())
 
@@ -328,6 +335,7 @@ class CreateTests(TestBase):
             import _xxsubinterpreters as _interpreters
             id = _interpreters.create()
             print(id)
+            assert isinstance(id, _interpreters.InterpreterID)
             """))
         id2 = int(out.strip())
 
@@ -891,6 +899,10 @@ class ChannelIDTests(TestBase):
 
 
 class ChannelTests(TestBase):
+
+    def test_create_cid(self):
+        cid = interpreters.channel_create()
+        self.assertIsInstance(cid, interpreters.ChannelID)
 
     def test_sequential_ids(self):
         before = interpreters.channel_list_all()

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -255,17 +255,18 @@ def _run_action(cid, action, end, state):
         else:
             raise ValueError(end)
     elif action == 'close':
-        if end == 'boyh':
-            interpreters.channel_close(cid)
-        else:
-            interpreters.channel_close(cid)
-            #interpreters.channel_close(cid, end)
+        kwargs = {}
+        if end in ('recv', 'send'):
+            kwargs[end] = True
+        interpreters.channel_close(cid, **kwargs)
         return state.close()
     elif action == 'force-close':
-        if end == 'both':
-            interpreters.channel_close(cid, force=True)
-        else:
-            interpreters.channel_close(cid, end, force=True)
+        kwargs = {
+            'force': True,
+            }
+        if end in ('recv', 'send'):
+            kwargs[end] = True
+        interpreters.channel_close(cid, **kwargs)
         return state.close(force=True)
     else:
         raise ValueError(action)

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -162,7 +162,7 @@ class GetCurrentTests(TestBase):
         interp = interpreters.create()
         out = _run_output(interp, dedent("""
             import _xxsubinterpreters as _interpreters
-            print(int(_interpreters.get_current()))
+            print(_interpreters.get_current())
             """))
         cur = int(out.strip())
         _, expected = interpreters.list_all()
@@ -182,7 +182,7 @@ class GetMainTests(TestBase):
         interp = interpreters.create()
         out = _run_output(interp, dedent("""
             import _xxsubinterpreters as _interpreters
-            print(int(_interpreters.get_main()))
+            print(_interpreters.get_main())
             """))
         main = int(out.strip())
         self.assertEqual(main, expected)
@@ -206,7 +206,7 @@ class IsRunningTests(TestBase):
         interp = interpreters.create()
         out = _run_output(interp, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            if _interpreters.is_running({int(interp)}):
+            if _interpreters.is_running({interp}):
                 print(True)
             else:
                 print(False)
@@ -266,6 +266,10 @@ class InterpreterIDTests(TestBase):
         with self.assertRaises(RuntimeError):
             interpreters.InterpreterID(int(id) + 1)  # unforced
 
+    def test_str(self):
+        id = interpreters.InterpreterID(10, force=True)
+        self.assertEqual(str(id), '10')
+
     def test_repr(self):
         id = interpreters.InterpreterID(10, force=True)
         self.assertEqual(repr(id), 'InterpreterID(10)')
@@ -323,7 +327,7 @@ class CreateTests(TestBase):
         out = _run_output(id1, dedent("""
             import _xxsubinterpreters as _interpreters
             id = _interpreters.create()
-            print(int(id))
+            print(id)
             """))
         id2 = int(out.strip())
 
@@ -338,7 +342,7 @@ class CreateTests(TestBase):
             out = _run_output(id1, dedent("""
                 import _xxsubinterpreters as _interpreters
                 id = _interpreters.create()
-                print(int(id))
+                print(id)
                 """))
             id2 = int(out.strip())
 
@@ -432,7 +436,7 @@ class DestroyTests(TestBase):
         script = dedent(f"""
             import _xxsubinterpreters as _interpreters
             try:
-                _interpreters.destroy({int(id)})
+                _interpreters.destroy({id})
             except RuntimeError:
                 pass
             """)
@@ -446,7 +450,7 @@ class DestroyTests(TestBase):
         id2 = interpreters.create()
         script = dedent(f"""
             import _xxsubinterpreters as _interpreters
-            _interpreters.destroy({int(id2)})
+            _interpreters.destroy({id2})
             """)
         interpreters.run_string(id1, script)
 
@@ -854,6 +858,10 @@ class ChannelIDTests(TestBase):
         with self.assertRaises(interpreters.ChannelNotFoundError):
             interpreters._channel_id(int(cid) + 1)  # unforced
 
+    def test_str(self):
+        cid = interpreters._channel_id(10, force=True)
+        self.assertEqual(str(cid), '10')
+
     def test_repr(self):
         cid = interpreters._channel_id(10, force=True)
         self.assertEqual(repr(cid), 'ChannelID(10)')
@@ -900,7 +908,7 @@ class ChannelTests(TestBase):
         out = _run_output(id1, dedent("""
             import _xxsubinterpreters as _interpreters
             cid = _interpreters.channel_create()
-            print(int(cid))
+            print(cid)
             """))
         cid1 = int(out.strip())
 
@@ -908,7 +916,7 @@ class ChannelTests(TestBase):
         out = _run_output(id2, dedent("""
             import _xxsubinterpreters as _interpreters
             cid = _interpreters.channel_create()
-            print(int(cid))
+            print(cid)
             """))
         cid2 = int(out.strip())
 
@@ -942,7 +950,7 @@ class ChannelTests(TestBase):
         id1 = interpreters.create()
         out = _run_output(id1, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            _interpreters.channel_send({int(cid)}, b'spam')
+            _interpreters.channel_send({cid}, b'spam')
             """))
         obj = interpreters.channel_recv(cid)
 
@@ -980,12 +988,12 @@ class ChannelTests(TestBase):
                 import _xxsubinterpreters as _interpreters
                 while True:
                     try:
-                        obj = _interpreters.channel_recv({int(cid)})
+                        obj = _interpreters.channel_recv({cid})
                         break
                     except _interpreters.ChannelEmptyError:
                         time.sleep(0.1)
                 assert(obj == b'spam')
-                _interpreters.channel_send({int(cid)}, b'eggs')
+                _interpreters.channel_send({cid}, b'eggs')
                 """))
         t = threading.Thread(target=f)
         t.start()
@@ -1103,16 +1111,16 @@ class ChannelReleaseTests(TestBase):
         id2 = interpreters.create()
         interpreters.run_string(id1, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            _interpreters.channel_send({int(cid)}, b'spam')
+            _interpreters.channel_send({cid}, b'spam')
             """))
         out = _run_output(id2, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            obj = _interpreters.channel_recv({int(cid)})
-            _interpreters.channel_release({int(cid)})
+            obj = _interpreters.channel_recv({cid})
+            _interpreters.channel_release({cid})
             print(repr(obj))
             """))
         interpreters.run_string(id1, dedent(f"""
-            _interpreters.channel_release({int(cid)})
+            _interpreters.channel_release({cid})
             """))
 
         self.assertEqual(out.strip(), "b'spam'")
@@ -1161,7 +1169,7 @@ class ChannelReleaseTests(TestBase):
         interp = interpreters.create()
         interpreters.run_string(interp, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            _interpreters.channel_release({int(cid)})
+            _interpreters.channel_release({cid})
             """))
         obj = interpreters.channel_recv(cid)
         interpreters.channel_release(cid)
@@ -1175,8 +1183,8 @@ class ChannelReleaseTests(TestBase):
         interp = interpreters.create()
         interpreters.run_string(interp, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            obj = _interpreters.channel_send({int(cid)}, b'spam')
-            _interpreters.channel_release({int(cid)})
+            obj = _interpreters.channel_send({cid}, b'spam')
+            _interpreters.channel_release({cid})
             """))
 
         with self.assertRaises(interpreters.ChannelClosedError):
@@ -1264,21 +1272,21 @@ class ChannelCloseTests(TestBase):
         id2 = interpreters.create()
         interpreters.run_string(id1, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            _interpreters.channel_send({int(cid)}, b'spam')
+            _interpreters.channel_send({cid}, b'spam')
             """))
         interpreters.run_string(id2, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            _interpreters.channel_recv({int(cid)})
+            _interpreters.channel_recv({cid})
             """))
         interpreters.channel_close(cid)
         with self.assertRaises(interpreters.RunFailedError) as cm:
             interpreters.run_string(id1, dedent(f"""
-                _interpreters.channel_send({int(cid)}, b'spam')
+                _interpreters.channel_send({cid}, b'spam')
                 """))
         self.assertIn('ChannelClosedError', str(cm.exception))
         with self.assertRaises(interpreters.RunFailedError) as cm:
             interpreters.run_string(id2, dedent(f"""
-                _interpreters.channel_send({int(cid)}, b'spam')
+                _interpreters.channel_send({cid}, b'spam')
                 """))
         self.assertIn('ChannelClosedError', str(cm.exception))
 
@@ -1315,7 +1323,7 @@ class ChannelCloseTests(TestBase):
         interp = interpreters.create()
         interpreters.run_string(interp, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            _interpreters.channel_close({int(cid)})
+            _interpreters.channel_close({cid})
             """))
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_recv(cid)

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -1702,6 +1702,7 @@ class ChannelCloseFixture(namedtuple('ChannelCloseFixture',
             """)
 
 
+@unittest.skip('these tests take several hours to run')
 class ExhaustiveChannelTests(TestBase):
 
     """

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -162,6 +162,10 @@ class ShareableTypeTests(unittest.TestCase):
             self.cid,
             ])
 
+    def test_bytes(self):
+        self._assert_values(i.to_bytes(2, 'little', signed=True)
+                            for i in range(-1, 258))
+
     def test_int(self):
         self._assert_values(range(-1, 258))
 

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -308,6 +308,7 @@ class IsShareableTests(unittest.TestCase):
                 None,
                 # builtin objects
                 b'spam',
+                'spam',
                 10,
                 -10,
                 ]
@@ -338,14 +339,13 @@ class IsShareableTests(unittest.TestCase):
                 object(),
                 Exception(),
                 100.0,
-                'spam',
                 # user-defined types and objects
                 Cheese,
                 Cheese('Wensleydale'),
                 SubBytes(b'spam'),
                 ]
         for obj in not_shareables:
-            with self.subTest(obj):
+            with self.subTest(repr(obj)):
                 self.assertFalse(
                     interpreters.is_shareable(obj))
 

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -904,18 +904,20 @@ class ChannelTests(TestBase):
 
     ####################
 
-    def test_drop_single_user(self):
+    # XXX Add more tests for channel_release().
+
+    def test_release_single_user(self):
         cid = interpreters.channel_create()
         interpreters.channel_send(cid, b'spam')
         interpreters.channel_recv(cid)
-        interpreters.channel_drop_interpreter(cid, send=True, recv=True)
+        interpreters.channel_release(cid, send=True, recv=True)
 
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_send(cid, b'eggs')
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_recv(cid)
 
-    def test_drop_multiple_users(self):
+    def test_release_multiple_users(self):
         cid = interpreters.channel_create()
         id1 = interpreters.create()
         id2 = interpreters.create()
@@ -926,98 +928,98 @@ class ChannelTests(TestBase):
         out = _run_output(id2, dedent(f"""
             import _xxsubinterpreters as _interpreters
             obj = _interpreters.channel_recv({int(cid)})
-            _interpreters.channel_drop_interpreter({int(cid)})
+            _interpreters.channel_release({int(cid)})
             print(repr(obj))
             """))
         interpreters.run_string(id1, dedent(f"""
-            _interpreters.channel_drop_interpreter({int(cid)})
+            _interpreters.channel_release({int(cid)})
             """))
 
         self.assertEqual(out.strip(), "b'spam'")
 
-    def test_drop_no_kwargs(self):
+    def test_release_no_kwargs(self):
         cid = interpreters.channel_create()
         interpreters.channel_send(cid, b'spam')
         interpreters.channel_recv(cid)
-        interpreters.channel_drop_interpreter(cid)
+        interpreters.channel_release(cid)
 
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_send(cid, b'eggs')
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_recv(cid)
 
-    def test_drop_multiple_times(self):
+    def test_release_multiple_times(self):
         cid = interpreters.channel_create()
         interpreters.channel_send(cid, b'spam')
         interpreters.channel_recv(cid)
-        interpreters.channel_drop_interpreter(cid, send=True, recv=True)
+        interpreters.channel_release(cid, send=True, recv=True)
 
         with self.assertRaises(interpreters.ChannelClosedError):
-            interpreters.channel_drop_interpreter(cid, send=True, recv=True)
+            interpreters.channel_release(cid, send=True, recv=True)
 
-    def test_drop_with_unused_items(self):
+    def test_release_with_unused_items(self):
         cid = interpreters.channel_create()
         interpreters.channel_send(cid, b'spam')
         interpreters.channel_send(cid, b'ham')
-        interpreters.channel_drop_interpreter(cid, send=True, recv=True)
+        interpreters.channel_release(cid, send=True, recv=True)
 
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_recv(cid)
 
-    def test_drop_never_used(self):
+    def test_release_never_used(self):
         cid = interpreters.channel_create()
-        interpreters.channel_drop_interpreter(cid)
+        interpreters.channel_release(cid)
 
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_send(cid, b'spam')
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_recv(cid)
 
-    def test_drop_by_unassociated_interp(self):
+    def test_release_by_unassociated_interp(self):
         cid = interpreters.channel_create()
         interpreters.channel_send(cid, b'spam')
         interp = interpreters.create()
         interpreters.run_string(interp, dedent(f"""
             import _xxsubinterpreters as _interpreters
-            _interpreters.channel_drop_interpreter({int(cid)})
+            _interpreters.channel_release({int(cid)})
             """))
         obj = interpreters.channel_recv(cid)
-        interpreters.channel_drop_interpreter(cid)
+        interpreters.channel_release(cid)
 
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_send(cid, b'eggs')
         self.assertEqual(obj, b'spam')
 
-    def test_drop_close_if_unassociated(self):
+    def test_release_close_if_unassociated(self):
         cid = interpreters.channel_create()
         interp = interpreters.create()
         interpreters.run_string(interp, dedent(f"""
             import _xxsubinterpreters as _interpreters
             obj = _interpreters.channel_send({int(cid)}, b'spam')
-            _interpreters.channel_drop_interpreter({int(cid)})
+            _interpreters.channel_release({int(cid)})
             """))
 
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_recv(cid)
 
-    def test_drop_partially(self):
+    def test_release_partially(self):
         # XXX Is partial close too weird/confusing?
         cid = interpreters.channel_create()
         interpreters.channel_send(cid, None)
         interpreters.channel_recv(cid)
         interpreters.channel_send(cid, b'spam')
-        interpreters.channel_drop_interpreter(cid, send=True)
+        interpreters.channel_release(cid, send=True)
         obj = interpreters.channel_recv(cid)
 
         self.assertEqual(obj, b'spam')
 
-    def test_drop_used_multiple_times_by_single_user(self):
+    def test_release_used_multiple_times_by_single_user(self):
         cid = interpreters.channel_create()
         interpreters.channel_send(cid, b'spam')
         interpreters.channel_send(cid, b'spam')
         interpreters.channel_send(cid, b'spam')
         interpreters.channel_recv(cid)
-        interpreters.channel_drop_interpreter(cid, send=True, recv=True)
+        interpreters.channel_release(cid, send=True, recv=True)
 
         with self.assertRaises(interpreters.ChannelClosedError):
             interpreters.channel_send(cid, b'eggs')

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1413,6 +1413,13 @@ channelid_repr(PyObject *self)
     return PyUnicode_FromFormat(fmt, name, cid->id);
 }
 
+static PyObject *
+channelid_str(PyObject *self)
+{
+    channelid *cid = (channelid *)self;
+    return PyUnicode_FromFormat("%d", cid->id);
+}
+
 PyObject *
 channelid_int(PyObject *self)
 {
@@ -1637,7 +1644,7 @@ static PyTypeObject ChannelIDtype = {
     0,                              /* tp_as_mapping */
     channelid_hash,                 /* tp_hash */
     0,                              /* tp_call */
-    0,                              /* tp_str */
+    (reprfunc)channelid_str,        /* tp_str */
     0,                              /* tp_getattro */
     0,                              /* tp_setattro */
     0,                              /* tp_as_buffer */
@@ -1918,6 +1925,13 @@ interpid_repr(PyObject *self)
     return PyUnicode_FromFormat("%s(%d)", name, id->id);
 }
 
+static PyObject *
+interpid_str(PyObject *self)
+{
+    interpid *id = (interpid *)self;
+    return PyUnicode_FromFormat("%d", id->id);
+}
+
 PyObject *
 interpid_int(PyObject *self)
 {
@@ -2039,7 +2053,7 @@ static PyTypeObject InterpreterIDtype = {
     0,                              /* tp_as_mapping */
     interpid_hash,                  /* tp_hash */
     0,                              /* tp_call */
-    0,                              /* tp_str */
+    (reprfunc)interpid_str,         /* tp_str */
     0,                              /* tp_getattro */
     0,                              /* tp_setattro */
     0,                              /* tp_as_buffer */

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2545,7 +2545,7 @@ channel_close(PyObject *self, PyObject *args, PyObject *kwds)
     int recv = 0;
     int force = 0;
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                                     "O|$ppp:channel_release", kwlist,
+                                     "O|$ppp:channel_close", kwlist,
                                      &id, &send, &recv, &force)) {
         return NULL;
     }

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2285,7 +2285,8 @@ static PyObject *
 interp_get_main(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     // Currently, 0 is always the main interpreter.
-    return PyLong_FromLongLong(0);
+    PY_INT64_T id = 0;
+    return (PyObject *)newinterpid(&InterpreterIDtype, id, 0);
 }
 
 PyDoc_STRVAR(get_main_doc,

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2530,7 +2530,7 @@ Close the channel for all interpreters.  Once the channel's ID has\n\
 no more ref counts the channel will be destroyed.");
 
 static PyObject *
-channel_drop_interpreter(PyObject *self, PyObject *args, PyObject *kwds)
+channel_release(PyObject *self, PyObject *args, PyObject *kwds)
 {
     // Note that only the current interpreter is affected.
     static char *kwlist[] = {"id", "send", "recv", NULL};
@@ -2538,7 +2538,7 @@ channel_drop_interpreter(PyObject *self, PyObject *args, PyObject *kwds)
     int send = -1;
     int recv = -1;
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                                     "O|$pp:channel_drop_interpreter", kwlist,
+                                     "O|$pp:channel_release", kwlist,
                                      &id, &send, &recv))
         return NULL;
 
@@ -2564,8 +2564,8 @@ channel_drop_interpreter(PyObject *self, PyObject *args, PyObject *kwds)
     Py_RETURN_NONE;
 }
 
-PyDoc_STRVAR(channel_drop_interpreter_doc,
-"channel_drop_interpreter(ID, *, send=None, recv=None)\n\
+PyDoc_STRVAR(channel_release_doc,
+"channel_release(ID, *, send=None, recv=None)\n\
 \n\
 Close the channel for the current interpreter.  'send' and 'recv'\n\
 (bool) may be used to indicate the ends to close.  By default both\n\
@@ -2608,8 +2608,8 @@ static PyMethodDef module_functions[] = {
      METH_VARARGS, channel_recv_doc},
     {"channel_close",             channel_close,
      METH_O, channel_close_doc},
-    {"channel_drop_interpreter",  (PyCFunction)channel_drop_interpreter,
-     METH_VARARGS | METH_KEYWORDS, channel_drop_interpreter_doc},
+    {"channel_release",           (PyCFunction)channel_release,
+     METH_VARARGS | METH_KEYWORDS, channel_release_doc},
     {"_channel_id",               (PyCFunction)channel__channel_id,
      METH_VARARGS | METH_KEYWORDS, NULL},
 

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -2155,10 +2155,13 @@ Create a new interpreter and return a unique generated ID.");
 
 
 static PyObject *
-interp_destroy(PyObject *self, PyObject *args)
+interp_destroy(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static char *kwlist[] = {"id", NULL};
     PyObject *id;
-    if (!PyArg_UnpackTuple(args, "destroy", 1, 1, &id)) {
+    // XXX Use "L" for id?
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "O:destroy", kwlist, &id)) {
         return NULL;
     }
     if (!PyLong_Check(id)) {
@@ -2202,7 +2205,7 @@ interp_destroy(PyObject *self, PyObject *args)
 }
 
 PyDoc_STRVAR(destroy_doc,
-"destroy(ID)\n\
+"destroy(id)\n\
 \n\
 Destroy the identified interpreter.\n\
 \n\
@@ -2278,20 +2281,18 @@ Return the ID of main interpreter.");
 
 
 static PyObject *
-interp_run_string(PyObject *self, PyObject *args)
+interp_run_string(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static char *kwlist[] = {"id", "script", "shared", NULL};
     PyObject *id, *code;
     PyObject *shared = NULL;
-    if (!PyArg_UnpackTuple(args, "run_string", 2, 3, &id, &code, &shared)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "OU|O:run_string", kwlist,
+                                     &id, &code, &shared)) {
         return NULL;
     }
     if (!PyLong_Check(id)) {
         PyErr_SetString(PyExc_TypeError, "first arg (ID) must be an int");
-        return NULL;
-    }
-    if (!PyUnicode_Check(code)) {
-        PyErr_SetString(PyExc_TypeError,
-                        "second arg (code) must be a string");
         return NULL;
     }
 
@@ -2321,7 +2322,7 @@ interp_run_string(PyObject *self, PyObject *args)
 }
 
 PyDoc_STRVAR(run_string_doc,
-"run_string(ID, sourcetext)\n\
+"run_string(id, script, shared)\n\
 \n\
 Execute the provided string in the identified interpreter.\n\
 \n\
@@ -2329,12 +2330,15 @@ See PyRun_SimpleStrings.");
 
 
 static PyObject *
-object_is_shareable(PyObject *self, PyObject *args)
+object_is_shareable(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static char *kwlist[] = {"obj", NULL};
     PyObject *obj;
-    if (!PyArg_UnpackTuple(args, "is_shareable", 1, 1, &obj)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "O:is_shareable", kwlist, &obj)) {
         return NULL;
     }
+
     if (_PyObject_CheckCrossInterpreterData(obj) == 0) {
         Py_RETURN_TRUE;
     }
@@ -2350,10 +2354,12 @@ False otherwise.");
 
 
 static PyObject *
-interp_is_running(PyObject *self, PyObject *args)
+interp_is_running(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static char *kwlist[] = {"id", NULL};
     PyObject *id;
-    if (!PyArg_UnpackTuple(args, "is_running", 1, 1, &id)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "O:is_running", kwlist, &id)) {
         return NULL;
     }
     if (!PyLong_Check(id)) {
@@ -2400,15 +2406,17 @@ channel_create(PyObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(channel_create_doc,
-"channel_create() -> ID\n\
+"channel_create() -> cid\n\
 \n\
 Create a new cross-interpreter channel and return a unique generated ID.");
 
 static PyObject *
-channel_destroy(PyObject *self, PyObject *args)
+channel_destroy(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static char *kwlist[] = {"cid", NULL};
     PyObject *id;
-    if (!PyArg_UnpackTuple(args, "channel_destroy", 1, 1, &id)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "O:channel_destroy", kwlist, &id)) {
         return NULL;
     }
     int64_t cid = _coerce_id(id);
@@ -2423,7 +2431,7 @@ channel_destroy(PyObject *self, PyObject *args)
 }
 
 PyDoc_STRVAR(channel_destroy_doc,
-"channel_destroy(ID)\n\
+"channel_destroy(cid)\n\
 \n\
 Close and finalize the channel.  Afterward attempts to use the channel\n\
 will behave as though it never existed.");
@@ -2461,16 +2469,18 @@ finally:
 }
 
 PyDoc_STRVAR(channel_list_all_doc,
-"channel_list_all() -> [ID]\n\
+"channel_list_all() -> [cid]\n\
 \n\
 Return the list of all IDs for active channels.");
 
 static PyObject *
-channel_send(PyObject *self, PyObject *args)
+channel_send(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static char *kwlist[] = {"cid", "obj", NULL};
     PyObject *id;
     PyObject *obj;
-    if (!PyArg_UnpackTuple(args, "channel_send", 2, 2, &id, &obj)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "OO:channel_send", kwlist, &id, &obj)) {
         return NULL;
     }
     int64_t cid = _coerce_id(id);
@@ -2485,15 +2495,17 @@ channel_send(PyObject *self, PyObject *args)
 }
 
 PyDoc_STRVAR(channel_send_doc,
-"channel_send(ID, obj)\n\
+"channel_send(cid, obj)\n\
 \n\
 Add the object's data to the channel's queue.");
 
 static PyObject *
-channel_recv(PyObject *self, PyObject *args)
+channel_recv(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static char *kwlist[] = {"cid", NULL};
     PyObject *id;
-    if (!PyArg_UnpackTuple(args, "channel_recv", 1, 1, &id)) {
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "O:channel_recv", kwlist, &id)) {
         return NULL;
     }
     int64_t cid = _coerce_id(id);
@@ -2505,17 +2517,34 @@ channel_recv(PyObject *self, PyObject *args)
 }
 
 PyDoc_STRVAR(channel_recv_doc,
-"channel_recv(ID) -> obj\n\
+"channel_recv(cid) -> obj\n\
 \n\
 Return a new object from the data at the from of the channel's queue.");
 
 static PyObject *
-channel_close(PyObject *self, PyObject *id)
+channel_close(PyObject *self, PyObject *args, PyObject *kwds)
 {
+    static char *kwlist[] = {"cid", "send", "recv", "force", NULL};
+    PyObject *id;
+    int send = 0;
+    int recv = 0;
+    int force = 0;
+    if (!PyArg_ParseTupleAndKeywords(args, kwds,
+                                     "O|$ppp:channel_release", kwlist,
+                                     &id, &send, &recv, &force)) {
+        return NULL;
+    }
     int64_t cid = _coerce_id(id);
     if (cid < 0) {
         return NULL;
     }
+    if (send == 0 && recv == 0) {
+        send = 1;
+        recv = 1;
+    }
+
+    // XXX Handle the ends.
+    // XXX Handle force is True.
 
     if (_channel_close(&_globals.channels, cid) != 0) {
         return NULL;
@@ -2524,40 +2553,58 @@ channel_close(PyObject *self, PyObject *id)
 }
 
 PyDoc_STRVAR(channel_close_doc,
-"channel_close(ID)\n\
+"channel_close(cid, *, send=None, recv=None, force=False)\n\
 \n\
-Close the channel for all interpreters.  Once the channel's ID has\n\
-no more ref counts the channel will be destroyed.");
+Close the channel for all interpreters.\n\
+\n\
+If the channel is empty then the keyword args are ignored and both\n\
+ends are immediately closed.  Otherwise, if 'force' is True then\n\
+all queued items are released and both ends are immediately\n\
+closed.\n\
+\n\
+If the channel is not empty *and* 'force' is False then following\n\
+happens:\n\
+\n\
+ * recv is True (regardless of send):\n\
+   - raise ChannelNotEmptyError\n\
+ * recv is None and send is None:\n\
+   - raise ChannelNotEmptyError\n\
+ * send is True and recv is not True:\n\
+   - fully close the 'send' end\n\
+   - close the 'recv' end to interpreters not already receiving\n\
+   - fully close it once empty\n\
+\n\
+Closing an already closed channel results in a ChannelClosedError.\n\
+\n\
+Once the channel's ID has no more ref counts in any interpreter\n\
+the channel will be destroyed.");
 
 static PyObject *
 channel_release(PyObject *self, PyObject *args, PyObject *kwds)
 {
     // Note that only the current interpreter is affected.
-    static char *kwlist[] = {"id", "send", "recv", NULL};
+    static char *kwlist[] = {"cid", "send", "recv", "force", NULL};
     PyObject *id;
-    int send = -1;
-    int recv = -1;
+    int send = 0;
+    int recv = 0;
+    int force = 0;
     if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                                     "O|$pp:channel_release", kwlist,
-                                     &id, &send, &recv))
+                                     "O|$ppp:channel_release", kwlist,
+                                     &id, &send, &recv, &force)) {
         return NULL;
-
+    }
     int64_t cid = _coerce_id(id);
     if (cid < 0) {
         return NULL;
     }
-    if (send < 0 && recv < 0) {
+    if (send == 0 && recv == 0) {
         send = 1;
         recv = 1;
     }
-    else {
-        if (send < 0) {
-            send = 0;
-        }
-        if (recv < 0) {
-            recv = 0;
-        }
-    }
+
+    // XXX Handle force is True.
+    // XXX Fix implicit release.
+
     if (_channel_drop(&_globals.channels, cid, send, recv) != 0) {
         return NULL;
     }
@@ -2565,7 +2612,7 @@ channel_release(PyObject *self, PyObject *args, PyObject *kwds)
 }
 
 PyDoc_STRVAR(channel_release_doc,
-"channel_release(ID, *, send=None, recv=None)\n\
+"channel_release(cid, *, send=None, recv=None, force=True)\n\
 \n\
 Close the channel for the current interpreter.  'send' and 'recv'\n\
 (bool) may be used to indicate the ends to close.  By default both\n\
@@ -2581,7 +2628,7 @@ static PyMethodDef module_functions[] = {
     {"create",                    (PyCFunction)interp_create,
      METH_VARARGS, create_doc},
     {"destroy",                   (PyCFunction)interp_destroy,
-     METH_VARARGS, destroy_doc},
+     METH_VARARGS | METH_KEYWORDS, destroy_doc},
     {"list_all",                  interp_list_all,
      METH_NOARGS, list_all_doc},
     {"get_current",               interp_get_current,
@@ -2589,25 +2636,25 @@ static PyMethodDef module_functions[] = {
     {"get_main",                  interp_get_main,
      METH_NOARGS, get_main_doc},
     {"is_running",                (PyCFunction)interp_is_running,
-     METH_VARARGS, is_running_doc},
+     METH_VARARGS | METH_KEYWORDS, is_running_doc},
     {"run_string",                (PyCFunction)interp_run_string,
-     METH_VARARGS, run_string_doc},
+     METH_VARARGS | METH_KEYWORDS, run_string_doc},
 
     {"is_shareable",              (PyCFunction)object_is_shareable,
-     METH_VARARGS, is_shareable_doc},
+     METH_VARARGS | METH_KEYWORDS, is_shareable_doc},
 
     {"channel_create",            channel_create,
      METH_NOARGS, channel_create_doc},
     {"channel_destroy",           (PyCFunction)channel_destroy,
-     METH_VARARGS, channel_destroy_doc},
+     METH_VARARGS | METH_KEYWORDS, channel_destroy_doc},
     {"channel_list_all",          channel_list_all,
      METH_NOARGS, channel_list_all_doc},
     {"channel_send",              (PyCFunction)channel_send,
-     METH_VARARGS, channel_send_doc},
+     METH_VARARGS | METH_KEYWORDS, channel_send_doc},
     {"channel_recv",              (PyCFunction)channel_recv,
-     METH_VARARGS, channel_recv_doc},
-    {"channel_close",             channel_close,
-     METH_O, channel_close_doc},
+     METH_VARARGS | METH_KEYWORDS, channel_recv_doc},
+    {"channel_close",             (PyCFunction)channel_close,
+     METH_VARARGS | METH_KEYWORDS, channel_close_doc},
     {"channel_release",           (PyCFunction)channel_release,
      METH_VARARGS | METH_KEYWORDS, channel_release_doc},
     {"_channel_id",               (PyCFunction)channel__channel_id,

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1250,7 +1250,9 @@ _channel_recv(_channels *channels, int64_t id)
     _PyCrossInterpreterData *data = _channel_next(chan, interp->id);
     PyThread_release_lock(mutex);
     if (data == NULL) {
-        PyErr_Format(ChannelEmptyError, "channel %d is empty", id);
+        if (!PyErr_Occurred()) {
+            PyErr_Format(ChannelEmptyError, "channel %d is empty", id);
+        }
         return NULL;
     }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1362,6 +1362,33 @@ _bytes_shared(PyObject *obj, _PyCrossInterpreterData *data)
     return 0;
 }
 
+struct _shared_str_data {
+    int kind;
+    const void *buffer;
+    Py_ssize_t len;
+};
+
+static PyObject *
+_new_str_object(_PyCrossInterpreterData *data)
+{
+    struct _shared_str_data *shared = (struct _shared_str_data *)(data->data);
+    return PyUnicode_FromKindAndData(shared->kind, shared->buffer, shared->len);
+}
+
+static int
+_str_shared(PyObject *obj, _PyCrossInterpreterData *data)
+{
+    struct _shared_str_data *shared = PyMem_NEW(struct _shared_str_data, 1);
+    shared->kind = PyUnicode_KIND(obj);
+    shared->buffer = PyUnicode_DATA(obj);
+    shared->len = PyUnicode_GET_LENGTH(obj) - 1;
+    data->data = (void *)shared;
+    data->obj = obj;  // Will be "released" (decref'ed) when data released.
+    data->new_object = _new_str_object;
+    data->free = PyMem_Free;
+    return 0;
+}
+
 static PyObject *
 _new_long_object(_PyCrossInterpreterData *data)
 {
@@ -1419,6 +1446,11 @@ _register_builtins_for_crossinterpreter_data(void)
     // bytes
     if (_register_xidata(&PyBytes_Type, _bytes_shared) != 0) {
         Py_FatalError("could not register bytes for cross-interpreter sharing");
+    }
+
+    // str
+    if (_register_xidata(&PyUnicode_Type, _str_shared) != 0) {
+        Py_FatalError("could not register str for cross-interpreter sharing");
     }
 }
 

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1308,6 +1308,10 @@ _PyCrossInterpreterData_Register_Class(PyTypeObject *cls,
     return res;
 }
 
+/* Cross-interpreter objects are looked up by exact match on the class.
+   We can reassess this policy when we move from a global registry to a
+   tp_* slot. */
+
 crossinterpdatafunc
 _PyCrossInterpreterData_Lookup(PyObject *obj)
 {


### PR DESCRIPTION
Add more tests for subinterpreters.  This patch also fixes a few small defects in the channel implementation.

<!-- issue-number: bpo-32604 -->
https://bugs.python.org/issue32604
<!-- /issue-number -->
