### PR TITLE
bpo-13631: Fix the order of initialization for readline/editline.

### DIFF
--- a/Doc/library/readline.rst
+++ b/Doc/library/readline.rst
@@ -17,11 +17,18 @@ made using  this module affect the behaviour of both the interpreter's
 interactive prompt  and the prompts offered by the built-in :func:`input`
 function.
 
+Readline keybindings may be configured via an initialization file, typically
+``.inputrc`` in your home directory.  See `Readline Init File
+<https://cnswww.cns.cwru.edu/php/chet/readline/rluserman.html#SEC9>`_
+in the GNU Readline manual for information about the format and
+allowable constructs of that file, and the capabilities of the
+Readline library in general.
+
 .. note::
 
   The underlying Readline library API may be implemented by
   the ``libedit`` library instead of GNU readline.
-  On MacOS X the :mod:`readline` module detects which library is being used
+  On macOS the :mod:`readline` module detects which library is being used
   at run time.
 
   The configuration file for ``libedit`` is different from that
@@ -29,12 +36,13 @@ function.
   you can check for the text "libedit" in :const:`readline.__doc__`
   to differentiate between GNU readline and libedit.
 
-Readline keybindings may be configured via an initialization file, typically
-``.inputrc`` in your home directory.  See `Readline Init File
-<https://cnswww.cns.cwru.edu/php/chet/readline/rluserman.html#SEC9>`_
-in the GNU Readline manual for information about the format and
-allowable constructs of that file, and the capabilities of the
-Readline library in general.
+  If you use *editline*/``libedit`` readline emulation on macOS, the
+  initialization file located in your home directory is named
+  ``.editrc``. For example, the following content in ``~/.editrc`` will
+  turn ON *vi* keybindings and TAB completion::
+
+    python:bind -v
+    python:bind ^I rl_complete
 
 
 Init file

--- a/Doc/tools/susp-ignored.csv
+++ b/Doc/tools/susp-ignored.csv
@@ -187,6 +187,8 @@ library/profile,,:lineno,filename:lineno(function)
 library/pyexpat,,:elem1,<py:elem1 />
 library/pyexpat,,:py,"xmlns:py = ""http://www.python.org/ns/"">"
 library/random,,:len,new_diff = mean(combined[:len(drug)]) - mean(combined[len(drug):])
+library/readline,,:bind,"python:bind -v"
+library/readline,,:bind,"python:bind ^I rl_complete"
 library/smtplib,,:port,method must support that as well as a regular host:port
 library/socket,,::,'5aef:2b::8'
 library/socket,,:can,"return (can_id, can_dlc, data[:can_dlc])"

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1229,6 +1229,7 @@ Gabriel de Perthuis
 Tim Peters
 Benjamin Peterson
 Joe Peterson
+Zvezdan Petkovic
 Ulrich Petri
 Chris Petrilli
 Roumen Petrov

--- a/Misc/NEWS.d/next/macOS/2018-05-16-13-25-58.bpo-13631.UIjDyY.rst
+++ b/Misc/NEWS.d/next/macOS/2018-05-16-13-25-58.bpo-13631.UIjDyY.rst
@@ -1,0 +1,2 @@
+The .editrc file in user's home directory is now processed correctly during
+the readline initialization through editline emulation on macOS.

--- a/Modules/readline.c
+++ b/Modules/readline.c
@@ -1078,6 +1078,9 @@ setup_readline(readlinestate *mod_state)
         Py_FatalError("not enough memory to save locale");
 #endif
 
+    /* The name must be defined before initialization */
+    rl_readline_name = "python";
+
 #ifdef __APPLE__
     /* the libedit readline emulation resets key bindings etc
      * when calling rl_initialize.  So call it upfront
@@ -1099,7 +1102,6 @@ setup_readline(readlinestate *mod_state)
 
     using_history();
 
-    rl_readline_name = "python";
     /* Force rebind of TAB to insert-tab */
     rl_bind_key('\t', rl_insert);
     /* Bind both ESC-TAB and ESC-ESC to the completion function */


### PR DESCRIPTION
The editline emulation needs to be initialized *after* the name is
defined. This fixes the long open issue.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-13631 -->
https://bugs.python.org/issue13631
<!-- /issue-number -->
