### PR TITLE
bpo-33544: make asyncio.Event awaitable

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-05-16-13-32-08.bpo-33544.3TIXkL.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-16-13-32-08.bpo-33544.3TIXkL.rst
@@ -1,0 +1,1 @@
+asyncio Conditional and Event are now awaitable


### PR DESCRIPTION
Inconsistency in asyncio.Event.  It was were never made awaitable.  This is a hold over from before async/wait, and its surprising.  The awaitable pattern is much cleaner

``
  await event
``
instead of 

``
  await event.wait()
``

<!-- issue-number: bpo-33544 -->
https://bugs.python.org/issue33544
<!-- /issue-number -->
