### PR TITLE
bpo-1025395: Fix email.utils.parseaddr to handle multiple hops

### DIFF
--- a/Lib/email/_parseaddr.py
+++ b/Lib/email/_parseaddr.py
@@ -338,6 +338,8 @@ class AddrlistClass:
             elif self.field[self.pos] == '@':
                 self.pos += 1
                 expectroute = True
+            elif self.field[self.pos] == ',':
+                self.pos += 1
             elif self.field[self.pos] == ':':
                 self.pos += 1
             else:

--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3141,6 +3141,12 @@ class TestMiscellaneous(TestEmailBase):
         self.assertEqual(('', 'merwok.wok.wok@xample.com'),
             utils.parseaddr('merwok. wok .  wok@xample.com'))
 
+    def test_parseaddr_handles_obsolete_addressing(self):
+        self.assertEqual(('foobar', 'foo@bar.com'),
+            utils.parseaddr('"foobar" <@hop.org:foo@bar.com>'))
+        self.assertEqual(('foobar', 'foo@bar.com'),
+            utils.parseaddr('"foobar" <@hop1.org,@hop2.org:foo@bar.com>'))
+
     def test_formataddr_does_not_quote_parens_in_quoted_string(self):
         addr = ("'foo@example.com' (foo@example.com)",
                 'foo@example.com')

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1578,6 +1578,7 @@ Piotr Szczepaniak
 Amir Szekely
 Maciej Szulik
 Joel Taddei
+Ioana Tagirta
 Arfrever Frehtes Taifersar Arahesis
 Hideaki Takahashi
 Takase Arihiro

--- a/Misc/NEWS.d/next/Library/2018-05-16-20-31-05.bpo-1025395.pQFcKj.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-16-20-31-05.bpo-1025395.pQFcKj.rst
@@ -1,0 +1,1 @@
+Fix email.utils.parseaddr to handle multiple hops


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

This fixes a very old [issue](https://bugs.python.org/issue1025395) with `email.utils.parseaddr`.
Right now `email.utils.parseaddr` will fail to parse the input correctly when the address contains a route with multiple hops. However it does not have an issue with single hop routes.

[RFC5322](https://www.ietf.org/rfc/rfc5322.txt) states that including route hops is obsolete and that the route part should be ignored (Section 4.4). It also states that this syntax is valid and it must be accepted and parsed (Section 4).

<!-- issue-number: bpo-1025395 -->
https://bugs.python.org/issue1025395
<!-- /issue-number -->

This is a duplicate of #142 , the Travis build failing because of changes unrelated to the PR. I have rebased my old branch on latest master, but that still does not seem to help. :thinking: :cat: . @Mariatta 

