### PR TITLE
bpo-33109: argparse subparsers are once again not required by default

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1577,7 +1577,7 @@ Sub-commands
      stored; by default ``None`` and no value is stored
 
    * required_ - Whether or not a subcommand must be provided, by default
-     ``True``.
+     ``False``.
 
    * help_ - help for sub-parser group in help output, by default ``None``
 

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1077,7 +1077,7 @@ class _SubParsersAction(Action):
                  prog,
                  parser_class,
                  dest=SUPPRESS,
-                 required=True,
+                 required=False,
                  help=None,
                  metavar=None):
 

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -1932,7 +1932,9 @@ class TestAddSubparsers(TestCase):
         parser = ErrorRaisingArgumentParser()
         subparsers = parser.add_subparsers(dest='command')
         subparsers.add_parser('run')
-        self._test_required_subparsers(parser)
+        # No error here
+        ret = parser.parse_args(())
+        self.assertIsNone(ret.command)
 
     def test_optional_subparsers(self):
         parser = ErrorRaisingArgumentParser()

--- a/Misc/NEWS.d/3.7.0a2.rst
+++ b/Misc/NEWS.d/3.7.0a2.rst
@@ -477,6 +477,8 @@ module now requires sqlite version at least 3.3.9.
 argparse subparsers are now required by default.  This matches behaviour in
 Python 2. For optional subparsers, use the new parameter
 ``add_subparsers(required=False)``. Patch by Anthony Sottile.
+(As of 3.7.0rc1, the default was changed to not required as had been the case
+since Python 3.3.)
 
 ..
 

--- a/Misc/NEWS.d/next/Library/2018-05-16-14-57-58.bpo-33109.nPLL_S.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-16-14-57-58.bpo-33109.nPLL_S.rst
@@ -1,0 +1,2 @@
+argparse subparsers are once again not required by default, reverting the
+change in behavior introduced by bpo-26510 in 3.7.0a2.


### PR DESCRIPTION
bpo-26510 in 3.7.0a2 changed the behavior of argparse to make
subparsers required by default, returning to the behavior of 2.7
and 3.2. The behavior was changed in 3.3 to be no longer required.
While it might make more sense to have the default to required,
compatibility with 3.3 through 3.6 is probably less disruptive
than trying to reintroduce compatibility with 2.7 at this point.
This change restores the 3.6 behavior.

<!-- issue-number: bpo-33109 -->
https://bugs.python.org/issue33109
<!-- /issue-number -->
