### PR TITLE
bpo-33542: Ignore DUID in uuid.get_node on Windows

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -488,7 +488,7 @@ def _ipconfig_getnode():
         with proc:
             for line in proc.stdout:
                 value = line.split(':')[-1].strip().lower()
-                if re.match('([0-9a-f][0-9a-f]-){5}[0-9a-f][0-9a-f]', value):
+                if re.fullmatch('(?:[0-9a-f][0-9a-f]-){5}[0-9a-f][0-9a-f]', value):
                     mac = int(value.replace('-', ''), 16)
                     if _is_universal(mac):
                         return mac

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -428,6 +428,7 @@ Ulrich Eckhardt
 David Edelsohn
 John Edmonds
 Grant Edwards
+Zvi Effron
 John Ehresman
 Tal Einat
 Eric Eisner

--- a/Misc/NEWS.d/next/Library/2018-05-16-09-30-27.bpo-33542.idNAcs.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-16-09-30-27.bpo-33542.idNAcs.rst
@@ -1,0 +1,2 @@
+Prevent ``uuid.get_node`` from using a DUID instead of a MAC on Windows.
+Patch by Zvi Effron


### PR DESCRIPTION
uuid._ipconfig_getnode did not validate the maximum length of the value,
so long as the value had the same type of formatting as a MAC address.
This let it select DUIDs as MAC addresses. It now requires an exact
length match.

<!-- issue-number: bpo-33542 -->
https://bugs.python.org/issue33542
<!-- /issue-number -->
