### PR TITLE
bpo-33549: Remove shim and DeprecationWarning to access DocumentLS.async

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -60,17 +60,7 @@ class MinidomTest(unittest.TestCase):
     def testDocumentAsyncAttr(self):
         doc = Document()
         self.assertFalse(doc.async_)
-        with self.assertWarns(DeprecationWarning):
-            self.assertFalse(getattr(doc, 'async', True))
-        with self.assertWarns(DeprecationWarning):
-            setattr(doc, 'async', True)
-        with self.assertWarns(DeprecationWarning):
-            self.assertTrue(getattr(doc, 'async', False))
-        self.assertTrue(doc.async_)
-
         self.assertFalse(Document.async_)
-        with self.assertWarns(DeprecationWarning):
-            self.assertFalse(getattr(Document, 'async', True))
 
     def testParseFromBinaryFile(self):
         with open(tstfile, 'rb') as file:

--- a/Lib/xml/dom/xmlbuilder.py
+++ b/Lib/xml/dom/xmlbuilder.py
@@ -332,29 +332,10 @@ class DOMBuilderFilter:
 del NodeFilter
 
 
-class _AsyncDeprecatedProperty:
-    def warn(self, cls):
-        clsname = cls.__name__
-        warnings.warn(
-            "{cls}.async is deprecated; use {cls}.async_".format(cls=clsname),
-            DeprecationWarning)
-
-    def __get__(self, instance, cls):
-        self.warn(cls)
-        if instance is not None:
-            return instance.async_
-        return False
-
-    def __set__(self, instance, value):
-        self.warn(type(instance))
-        setattr(instance, 'async_', value)
-
-
 class DocumentLS:
     """Mixin to create documents that conform to the load/save spec."""
 
     async_ = False
-    locals()['async'] = _AsyncDeprecatedProperty()  # Avoid DeprecationWarning
 
     def _get_async(self):
         return False
@@ -382,9 +363,6 @@ class DocumentLS:
         elif snode.ownerDocument is not self:
             raise xml.dom.WrongDocumentErr()
         return snode.toxml()
-
-
-del _AsyncDeprecatedProperty
 
 
 class DOMImplementationLS:


### PR DESCRIPTION
`obj.async` is now a syntax error, so the warning/shim is
quasi-unnecessary.

<!-- issue-number: bpo-33549 -->
https://bugs.python.org/issue33549
<!-- /issue-number -->
