### PR TITLE
bpo-33554: make_keys_shared reusing oldkeys memory

### DIFF
--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1217,7 +1217,7 @@ clear_dummy_keys(PyDictObject *mp)
     second = entries + 1;
     end = entries + numentries;
 
-    for( ;; ) {
+    for (;;) {
         if (first >= end || second >= end) break;
 
         if (first->me_value != NULL) {
@@ -1237,7 +1237,7 @@ clear_dummy_keys(PyDictObject *mp)
     build_indices(mp->ma_keys, entries, numentries);
     mp->ma_keys->dk_usable = USABLE_FRACTION(mp->ma_keys->dk_size) - numentries;
     mp->ma_keys->dk_nentries = numentries;
-
+    mp->ma_keys->dk_lookup = lookdict_unicode_nodummy;
 }
 
 /* Returns NULL if unable to split table.
@@ -1259,7 +1259,7 @@ make_keys_shared(PyObject *op)
             return NULL;
         }
         else if (mp->ma_keys->dk_lookup == lookdict_unicode) {
-	        clear_dummy_keys(mp);
+            clear_dummy_keys(mp);
         }
         assert(mp->ma_keys->dk_lookup == lookdict_unicode_nodummy);
         /* Copy values into a new array */

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -1195,6 +1195,51 @@ dictresize(PyDictObject *mp, Py_ssize_t minsize)
     return 0;
 }
 
+/*
+ * clear dummy keys and reusing keys
+ */
+static void
+clear_dummy_keys(PyDictObject *mp)
+{
+    PyDictKeyEntry *first, *second, *end;
+    Py_ssize_t numentries;
+    PyDictKeyEntry *entries;
+
+    /* No DUMMY */
+    if (mp->ma_keys->dk_nentries == mp->ma_used) {
+        return;
+    }
+
+    numentries = mp->ma_used;
+    entries = DK_ENTRIES(mp->ma_keys);
+
+    first = entries;
+    second = entries + 1;
+    end = entries + numentries;
+
+    for( ;; ) {
+        if (first >= end || second >= end) break;
+
+        if (first->me_value != NULL) {
+            first++;
+            continue;
+        }
+
+        if (second->me_value == NULL || second < first) {
+            second++;
+            continue;
+        }
+
+        first->me_value = second->me_value;
+        second->me_value = NULL;
+    }
+
+    build_indices(mp->ma_keys, entries, numentries);
+    mp->ma_keys->dk_usable = USABLE_FRACTION(mp->ma_keys->dk_size) - numentries;
+    mp->ma_keys->dk_nentries = numentries;
+
+}
+
 /* Returns NULL if unable to split table.
  * A NULL return does not necessarily indicate an error */
 static PyDictKeysObject *
@@ -1214,9 +1259,7 @@ make_keys_shared(PyObject *op)
             return NULL;
         }
         else if (mp->ma_keys->dk_lookup == lookdict_unicode) {
-            /* Remove dummy keys */
-            if (dictresize(mp, DK_SIZE(mp->ma_keys)))
-                return NULL;
+	        clear_dummy_keys(mp);
         }
         assert(mp->ma_keys->dk_lookup == lookdict_unicode_nodummy);
         /* Copy values into a new array */


### PR DESCRIPTION
bpo-33554: make_keys_shared reusing oldkeys memory

<!-- issue-number: bpo-33554 -->
https://bugs.python.org/issue33554
<!-- /issue-number -->
