### PR TITLE
bpo-33560: improve the error message returned by tuple.index

### DIFF
--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -561,7 +561,7 @@ tuple_index_impl(PyTupleObject *self, PyObject *value, Py_ssize_t start,
         else if (cmp < 0)
             return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "tuple.index(x): x not in tuple");
+    PyErr_Format(PyExc_ValueError, "%R is not in tuple", value);
     return NULL;
 }
 


### PR DESCRIPTION
The tuple.index function now shows what element was being looked for in the
tuple, similarly to what list.index does.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33560 -->
https://bugs.python.org/issue33560
<!-- /issue-number -->
