### PR TITLE
bpo-33559: Attribute changed repr of exceptions

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1240,6 +1240,7 @@ Changes in the Python API
 
 * ``repr`` for :exc:`BaseException` has changed not to include trailing comma
   in the output. Mind that most exceptions are affected by this change.
+  (Contributed by Serhiy Storchaka in :issue:`30399`.)
 
 * ``repr`` for :class:`datetime.timedelta` has changed to include keyword arguments
   in the output. (Contributed by Utkarsh Upadhyay in :issue:`30302`.)


### PR DESCRIPTION
Skip news, please.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33559 -->
https://bugs.python.org/issue33559
<!-- /issue-number -->
