### PR TITLE
Disable multissltests.py

### DIFF
--- a/.vsts/linux-buildbot.yml
+++ b/.vsts/linux-buildbot.yml
@@ -17,10 +17,7 @@ trigger:
     - Doc/*
     - Tools/*
 
-variables:
-  # Copy-pasted from linux-deps.yml until template support arrives
-  OPENSSL: 1.1.0g
-  OPENSSL_DIR: "$(build.sourcesDirectory)/multissl/openssl/$(OPENSSL)"
+#variables:
 
 
 steps:
@@ -35,8 +32,6 @@ steps:
 - script: echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial main" > /etc/apt/sources.list.d/python.list && sudo apt-get update
   displayName: 'Update apt-get lists'
 
-- script: echo ##vso[task.prependpath]$(OPENSSL_DIR)
-  displayName: 'Add $(OPENSSL_DIR) to PATH'
 - script: >
     sudo apt-get -yq install
     build-essential
@@ -55,8 +50,6 @@ steps:
     libffi-dev
     uuid-dev
   displayName: 'Install dependencies'
-- script: python3 Tools/ssl/multissltests.py --steps=library --base-directory $(build.sourcesDirectory)/multissl --openssl $(OPENSSL) --system Linux
-  displayName: 'python multissltests.py'
 
 - script: ./configure --with-pydebug
   displayName: 'Configure CPython (debug)'

--- a/.vsts/linux-coverage.yml
+++ b/.vsts/linux-coverage.yml
@@ -17,10 +17,7 @@ trigger:
     - Doc/*
     - Tools/*
 
-variables:
-  # Copy-pasted from linux-deps.yml until template support arrives
-  OPENSSL: 1.1.0g
-  OPENSSL_DIR: "$(build.sourcesDirectory)/multissl/openssl/$(OPENSSL)"
+#variables:
 
 steps:
 - checkout: self
@@ -34,8 +31,6 @@ steps:
 - script: echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial main" > /etc/apt/sources.list.d/python.list && sudo apt-get update
   displayName: 'Update apt-get lists'
 
-- script: echo ##vso[task.prependpath]$(OPENSSL_DIR)
-  displayName: 'Add $(OPENSSL_DIR) to PATH'
 - script: >
     sudo apt-get -yq install
     build-essential
@@ -54,8 +49,6 @@ steps:
     libffi-dev
     uuid-dev
   displayName: 'Install dependencies'
-- script: python3 Tools/ssl/multissltests.py --steps=library --base-directory $(build.sourcesDirectory)/multissl --openssl $(OPENSSL) --system Linux
-  displayName: 'python multissltests.py'
 
 
 - script: ./configure --with-pydebug

--- a/.vsts/linux-deps.yml
+++ b/.vsts/linux-deps.yml
@@ -4,16 +4,12 @@
 # Current docs for the syntax of this file are at:
 #  https://github.com/Microsoft/vsts-agent/blob/master/docs/preview/yamlgettingstarted.md
 
-parameters:
-  OPENSSL: 1.1.0g
-  OPENSSL_DIR: "$(build.sourcesDirectory)/multissl/openssl/$(OPENSSL)"
+#parameters:
 
 steps:
 - script: echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial main" > /etc/apt/sources.list.d/python.list && sudo apt-get update
   displayName: 'Update apt-get lists'
 
-- script: echo ##vso[task.prependpath]$(OPENSSL_DIR)
-  displayName: 'Add $(OPENSSL_DIR) to PATH'
 - script: >
     sudo apt-get -yq install
     build-essential
@@ -32,5 +28,3 @@ steps:
     libffi-dev
     uuid-dev
   displayName: 'Install dependencies'
-- script: python3 Tools/ssl/multissltests.py --steps=library --base-directory $(build.sourcesDirectory)/multissl --openssl $(OPENSSL) --system Linux
-  displayName: 'python multissltests.py'

--- a/.vsts/linux-pr.yml
+++ b/.vsts/linux-pr.yml
@@ -17,10 +17,7 @@ trigger:
     - Doc/*
     - Tools/*
 
-variables:
-  # Copy-pasted from linux-deps.yml until template support arrives
-  OPENSSL: 1.1.0g
-  OPENSSL_DIR: "$(build.sourcesDirectory)/multissl/openssl/$(OPENSSL)"
+#variables:
 
 steps:
 - checkout: self
@@ -34,8 +31,6 @@ steps:
 - script: echo "deb-src http://archive.ubuntu.com/ubuntu/ xenial main" > /etc/apt/sources.list.d/python.list && sudo apt-get update
   displayName: 'Update apt-get lists'
 
-- script: echo ##vso[task.prependpath]$(OPENSSL_DIR)
-  displayName: 'Add $(OPENSSL_DIR) to PATH'
 - script: >
     sudo apt-get -yq install
     build-essential
@@ -54,8 +49,6 @@ steps:
     libffi-dev
     uuid-dev
   displayName: 'Install dependencies'
-- script: python3 Tools/ssl/multissltests.py --steps=library --base-directory $(build.sourcesDirectory)/multissl --openssl $(OPENSSL) --system Linux
-  displayName: 'python multissltests.py'
 
 
 - script: ./configure --with-pydebug


### PR DESCRIPTION
We don't run `multissltests.py` on Travis, so this also disables it on VSTS