### PR TITLE
bpo-33564: Add async to IDLE's code context block openers.

### DIFF
--- a/Lib/idlelib/codecontext.py
+++ b/Lib/idlelib/codecontext.py
@@ -18,7 +18,7 @@ from tkinter.constants import TOP, LEFT, X, W, SUNKEN
 from idlelib.config import idleConf
 
 BLOCKOPENERS = {"class", "def", "elif", "else", "except", "finally", "for",
-                    "if", "try", "while", "with"}
+                "if", "try", "while", "with", "async"}
 UPDATEINTERVAL = 100 # millisec
 FONTUPDATEINTERVAL = 1000 # millisec
 

--- a/Misc/NEWS.d/next/IDLE/2018-05-17-19-41-12.bpo-33564.XzHZJe.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-05-17-19-41-12.bpo-33564.XzHZJe.rst
@@ -1,0 +1,1 @@
+IDLE's code context now recognizes async as a block opener.


### PR DESCRIPTION


<!-- issue-number: bpo-33564 -->
https://bugs.python.org/issue33564
<!-- /issue-number -->
