### PR TITLE
bpo-33519: clarify that .copy() is not part of the MutableSequence ABC

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1108,7 +1108,9 @@ Notes:
 (5)
    :meth:`clear` and :meth:`!copy` are included for consistency with the
    interfaces of mutable containers that don't support slicing operations
-   (such as :class:`dict` and :class:`set`)
+   (such as :class:`dict` and :class:`set`). :meth:`!copy` is not part of the
+   :class:`collections.abc.MutableSequence` ABC, but most concrete
+   mutable sequence classes provide it.
 
    .. versionadded:: 3.3
       :meth:`clear` and :meth:`!copy` methods.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1098,7 +1098,7 @@ Notes:
    item is removed and returned.
 
 (3)
-   ``remove`` raises :exc:`ValueError` when *x* is not found in *s*.
+   :meth:`remove` raises :exc:`ValueError` when *x* is not found in *s*.
 
 (4)
    The :meth:`reverse` method modifies the sequence in place for economy of

--- a/Misc/NEWS.d/next/Documentation/2018-05-17-21-02-00.bpo-33519.Q7s2FB.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-17-21-02-00.bpo-33519.Q7s2FB.rst
@@ -1,0 +1,1 @@
+Clarify that `copy()` is not part of the `MutableSequence` ABC.


### PR DESCRIPTION


<!-- issue-number: bpo-33519 -->
https://bugs.python.org/issue33519
<!-- /issue-number -->
