### PR TITLE
[2.7] bpo-16055: Fixes incorrect error text for int('1', base=1000)

### DIFF
--- a/Objects/intobject.c
+++ b/Objects/intobject.c
@@ -358,7 +358,7 @@ PyInt_FromString(char *s, char **pend, int base)
 
     if ((base != 0 && base < 2) || base > 36) {
         PyErr_SetString(PyExc_ValueError,
-                        "int() base must be >= 2 and <= 36");
+                        "int() base must be >= 2 and <= 36, or 0");
         return NULL;
     }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -1722,7 +1722,7 @@ PyLong_FromString(char *str, char **pend, int base)
 
     if ((base != 0 && base < 2) || base > 36) {
         PyErr_SetString(PyExc_ValueError,
-                        "long() arg 2 must be >= 2 and <= 36");
+                        "long() base must be >= 2 and <= 36, or 0");
         return NULL;
     }
     while (*str != '\0' && isspace(Py_CHARMASK(*str)))


### PR DESCRIPTION
Fixes incorrect error text for int('1', base=1000)
and long('1', base=1000).

<!-- issue-number: bpo-16055 -->
https://bugs.python.org/issue16055
<!-- /issue-number -->
