### PR TITLE
bpo-33479: Remove unqualified tkinter threadsafe claim.

### DIFF
--- a/Doc/library/tk.rst
+++ b/Doc/library/tk.rst
@@ -19,8 +19,7 @@ The :mod:`tkinter` package is a thin object-oriented layer on top of Tcl/Tk. To
 use :mod:`tkinter`, you don't need to write Tcl code, but you will need to
 consult the Tk documentation, and occasionally the Tcl documentation.
 :mod:`tkinter` is a set of wrappers that implement the Tk widgets as Python
-classes.  In addition, the internal module :mod:`_tkinter` provides a threadsafe
-mechanism which allows Python and Tcl to interact.
+classes.
 
 :mod:`tkinter`'s chief virtues are that it is fast, and that it usually comes
 bundled with Python. Although its standard documentation is weak, good

--- a/Misc/NEWS.d/next/Documentation/2018-05-19-15-59-29.bpo-33479.4cLlxo.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-19-15-59-29.bpo-33479.4cLlxo.rst
@@ -1,0 +1,4 @@
+Remove the unqualified claim that tkinter is threadsafe. It has not been
+true for several years and likely never was. An explanation of what is true
+may be added later, after more discussion, and possibly after patching
+_tkinter.c,


### PR DESCRIPTION
It has not been true for several years and likely never was.
An explanation of what is true may be added later, after discussion,
and possibly after patching, but not before the coming 3.7.0rc1 release.


<!-- issue-number: bpo-33479 -->
https://bugs.python.org/issue33479
<!-- /issue-number -->
