### PR TITLE
bpo-17972: Document `findsource` in inspect.rst

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -511,9 +511,24 @@ Retrieving source code
    returned as a single string.  An :exc:`OSError` is raised if the source code
    cannot be retrieved.
 
+   If *object* is a wrapper function (that is to say has a :attr:`__wrapped__`
+   field, :func:`getsource` will follows the chain of :attr:`__wrapped__`
+   attributes returning the last object in the chain using :func:`unwrap`
+
    .. versionchanged:: 3.3
       :exc:`OSError` is raised instead of :exc:`IOError`, now an alias of the
       former.
+
+.. function:: findsource(object)
+
+   Return the entire source file and starting line number for an object.
+
+   The argument may be a module, class, method, function, traceback, frame,
+   or code object.  The source code is returned as a list of all the lines
+   in the file and the line number indexes a line in that list.  An OSError
+   is raised if the source code cannot be retrieved.
+
+   Prefer the use of :func:`getsource` if possible.
 
 
 .. function:: cleandoc(doc)

--- a/Misc/NEWS.d/next/Documentation/2018-05-19-15-26-25.bpo-17972.eBXOAY.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-19-15-26-25.bpo-17972.eBXOAY.rst
@@ -1,0 +1,1 @@
+Document :func:`inspect.findsource`


### PR DESCRIPTION
From the discussion in bpo-1792, it seem that findsource is mostly low
level, while getsource is higher level.

This does not completely fix bpo-17972 as many methonds need to be
marked either private, or documented

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-17972 -->
https://bugs.python.org/issue17972
<!-- /issue-number -->
