### PR TITLE
bpo-33582: Emit deprecation warning for `formatargspec`

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -18,7 +18,7 @@ Here are some of the useful functions provided by this module:
 
     getargvalues(), getcallargs() - get info about function arguments
     getfullargspec() - same, with support for Python 3 features
-    formatargspec(), formatargvalues() - format an argument spec
+    formatargvalues() - format an argument spec
     getouterframes(), getinnerframes() - get info about frames
     currentframe() - get the current stack frame
     stack(), trace() - get info about frames on the stack or in a traceback
@@ -1211,7 +1211,19 @@ def formatargspec(args, varargs=None, varkw=None, defaults=None,
     kwonlyargs, kwonlydefaults, annotations).  The other five arguments
     are the corresponding optional formatting functions that are called to
     turn names and values into strings.  The last argument is an optional
-    function to format the sequence of arguments."""
+    function to format the sequence of arguments.
+
+    Deprecated since Python 3.5 use, the `signature` function and `Signature`
+    objects.
+    """
+
+    from warnings import warn
+
+    warn("`formatargspec` is deprecated since Python 3.5. Use `signature` and "
+         " the `Signature` object directly",
+         DeprecationWarning,
+         stacklevel=2)
+
     def formatargandannotation(arg):
         result = formatarg(arg)
         if arg in annotations:

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1213,7 +1213,7 @@ def formatargspec(args, varargs=None, varkw=None, defaults=None,
     turn names and values into strings.  The last argument is an optional
     function to format the sequence of arguments.
 
-    Deprecated since Python 3.5 use, the `signature` function and `Signature`
+    Deprecated since Python 3.5 : use the `signature` function and `Signature`
     objects.
     """
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1213,7 +1213,7 @@ def formatargspec(args, varargs=None, varkw=None, defaults=None,
     turn names and values into strings.  The last argument is an optional
     function to format the sequence of arguments.
 
-    Deprecated since Python 3.5 : use the `signature` function and `Signature`
+    Deprecated since Python 3.5: use the `signature` function and `Signature`
     objects.
     """
 

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -712,7 +712,8 @@ class TestClassesAndFunctions(unittest.TestCase):
         self.assertEqual(varkw, varkw_e)
         self.assertEqual(defaults, defaults_e)
         if formatted is not None:
-            self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults),
+            with self.assertWarns(DeprecationWarning):
+                self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults),
                              formatted)
 
     def assertFullArgSpecEquals(self, routine, args_e, varargs_e=None,
@@ -729,7 +730,8 @@ class TestClassesAndFunctions(unittest.TestCase):
         self.assertEqual(kwonlydefaults, kwonlydefaults_e)
         self.assertEqual(ann, ann_e)
         if formatted is not None:
-            self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults,
+            with self.assertWarns(DeprecationWarning):
+                self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults,
                                                     kwonlyargs, kwonlydefaults, ann),
                              formatted)
 

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -714,7 +714,7 @@ class TestClassesAndFunctions(unittest.TestCase):
         if formatted is not None:
             with self.assertWarns(DeprecationWarning):
                 self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults),
-                             formatted)
+                                 formatted)
 
     def assertFullArgSpecEquals(self, routine, args_e, varargs_e=None,
                                     varkw_e=None, defaults_e=None,
@@ -732,7 +732,7 @@ class TestClassesAndFunctions(unittest.TestCase):
         if formatted is not None:
             with self.assertWarns(DeprecationWarning):
                 self.assertEqual(inspect.formatargspec(args, varargs, varkw, defaults,
-                                                    kwonlyargs, kwonlydefaults, ann),
+                                                       kwonlyargs, kwonlydefaults, ann),
                              formatted)
 
     def test_getargspec(self):

--- a/Misc/NEWS.d/next/Library/2018-05-19-15-58-14.bpo-33582.qBZPmF.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-19-15-58-14.bpo-33582.qBZPmF.rst
@@ -1,0 +1,1 @@
+Emit a deprecation warning for inspect.formatargspec


### PR DESCRIPTION
Also assert it emits deprecation warnings in corresponding test, and add that into the docstring. 

<!-- issue-number: bpo-33582 -->
https://bugs.python.org/issue33582
<!-- /issue-number -->
