### PR TITLE
[3.6] bpo-30928: Update idlelib/NEWS.txt. (GH-6995)

### DIFF
--- a/Lib/idlelib/NEWS.txt
+++ b/Lib/idlelib/NEWS.txt
@@ -3,6 +3,11 @@ Released on 2018-06-15?
 ======================================
 
 
+bpo-32831: Add docstrings and tests for codecontext.py.
+Coverage is 100%.  Patch by Cheryl Sabella.
+
+bpo-33564: Code context now recognizes async as a block opener.
+
 bpo-29706: IDLE now colors async and await as keywords in 3.6.
 They become full keywords in 3.7.
 


### PR DESCRIPTION
(cherry picked from commit 6b0d09b)


<!-- issue-number: bpo-30928 -->
https://bugs.python.org/issue30928
<!-- /issue-number -->
