### PR TITLE
[3.6] bpo-33584: Fix several minor bugs in asyncio. (GH-7003)

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -233,7 +233,7 @@ class Task(futures.Future):
                     self._step,
                     RuntimeError(
                         'yield was used instead of yield from for '
-                        'generator in task {!r} with {}'.format(
+                        'generator in task {!r} with {!r}'.format(
                             self, result)))
             else:
                 # Yielding something else is an error.

--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2248,19 +2248,19 @@ set_exception:
     }
     if (res == 1) {
         /* `result` is a generator */
-        PyObject *ret;
-        ret = task_set_error_soon(
+        o = task_set_error_soon(
             task, PyExc_RuntimeError,
             "yield was used instead of yield from for "
-            "generator in task %R with %S", task, result);
+            "generator in task %R with %R", task, result);
         Py_DECREF(result);
-        return ret;
+        return o;
     }
 
     /* The `result` is none of the above */
-    Py_DECREF(result);
-    return task_set_error_soon(
+    o = task_set_error_soon(
         task, PyExc_RuntimeError, "Task got bad yield: %R", result);
+    Py_DECREF(result);
+    return o;
 
 self_await:
     o = task_set_error_soon(


### PR DESCRIPTION
* repr() was called for a borrowed link.
* str() was used instead of repr() in formatting one error message.
(cherry picked from commit 6655354afcd116c27486bb5ba1dfa50b369d8d85)


<!-- issue-number: bpo-33584 -->
https://bugs.python.org/issue33584
<!-- /issue-number -->
