### PR TITLE
[3.6] bpo-33542: Ignore DUID in uuid.get_node on Windows. (GH-6922)

### DIFF
--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -438,7 +438,7 @@ def _ipconfig_getnode():
         with proc:
             for line in proc.stdout:
                 value = line.split(':')[-1].strip().lower()
-                if re.match('([0-9a-f][0-9a-f]-){5}[0-9a-f][0-9a-f]', value):
+                if re.fullmatch('(?:[0-9a-f][0-9a-f]-){5}[0-9a-f][0-9a-f]', value):
                     return int(value.replace('-', ''), 16)
 
 def _netbios_getnode():

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -415,6 +415,7 @@ Ulrich Eckhardt
 David Edelsohn
 John Edmonds
 Grant Edwards
+Zvi Effron
 John Ehresman
 Tal Einat
 Eric Eisner

--- a/Misc/NEWS.d/next/Library/2018-05-16-09-30-27.bpo-33542.idNAcs.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-16-09-30-27.bpo-33542.idNAcs.rst
@@ -1,0 +1,2 @@
+Prevent ``uuid.get_node`` from using a DUID instead of a MAC on Windows.
+Patch by Zvi Effron


### PR DESCRIPTION
uuid._ipconfig_getnode did not validate the maximum length of the value,
so long as the value had the same type of formatting as a MAC address.
This let it select DUIDs as MAC addresses. It now requires an exact
length match..
(cherry picked from commit c66c342cb42ab8a88884527ddfe3a5086bc06316)

Co-authored-by: CtrlZvi <viz+github@flippedperspective.com>


<!-- issue-number: bpo-33542 -->
https://bugs.python.org/issue33542
<!-- /issue-number -->
