### PR TITLE
bpo-32262: Fix typo in f-string

### DIFF
--- a/Lib/asyncio/base_subprocess.py
+++ b/Lib/asyncio/base_subprocess.py
@@ -57,7 +57,7 @@ class BaseSubprocessTransport(transports.SubprocessTransport):
         if self._closed:
             info.append('closed')
         if self._pid is not None:
-            info.append(f'pid={self.pid}')
+            info.append(f'pid={self._pid}')
         if self._returncode is not None:
             info.append(f'returncode={self._returncode}')
         elif self._pid is not None:

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -29,6 +29,7 @@ class TestSubprocessTransport(base_subprocess.BaseSubprocessTransport):
         self._proc.stdin = None
         self._proc.stdout = None
         self._proc.stderr = None
+        self._proc.pid = -1
 
 
 class SubprocessTransportTests(test_utils.TestCase):
@@ -71,6 +72,29 @@ class SubprocessTransportTests(test_utils.TestCase):
         self.assertRaises(ProcessLookupError, transport.terminate)
         self.assertRaises(ProcessLookupError, transport.kill)
 
+        transport.close()
+
+    def test_subprocess_repr(self):
+        waiter = asyncio.Future(loop=self.loop)
+        transport, protocol = self.create_transport(waiter)
+        transport._process_exited(6)
+        self.loop.run_until_complete(waiter)
+
+        self.assertEqual(
+            repr(transport),
+            "<TestSubprocessTransport pid=-1 returncode=6>"
+        )
+        transport._returncode = None
+        self.assertEqual(
+            repr(transport),
+            "<TestSubprocessTransport pid=-1 running>"
+        )
+        transport._pid = None
+        transport._returncode = None
+        self.assertEqual(
+            repr(transport),
+            "<TestSubprocessTransport not started>"
+        )
         transport.close()
 
 


### PR DESCRIPTION
Fix typo from commit 6370f345e1d5829e1fba59cd695c8b82c5a8c620

Signed-off-by: Christian Heimes <christian@python.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-32262 -->
https://bugs.python.org/issue32262
<!-- /issue-number -->
