### PR TITLE
Fix asyncio flaky tests

### DIFF
--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1855,9 +1855,10 @@ class BaseLoopSockSendfileTests(test_utils.TestCase):
 
         for _ in range(10):
             try:
-                self.run_loop(self.loop.sock_connect(sock, (support.HOST, port)))
+                self.run_loop(self.loop.sock_connect(sock,
+                                                     (support.HOST, port)))
             except OSError:
-                time.sleep(0.5)
+                self.run_loop(asyncio.sleep(0.5))
                 continue
             else:
                 break


### PR DESCRIPTION
Use `asyncio.sleep()` instead of `time.sleep()` to wait for socket connection