### PR TITLE
Add missed details of the C API introduced in 3.7.

### DIFF
--- a/Doc/data/refcounts.dat
+++ b/Doc/data/refcounts.dat
@@ -152,6 +152,47 @@ PyComplex_ImagAsDouble:PyObject*:op:0:
 PyComplex_RealAsDouble:double:::
 PyComplex_RealAsDouble:PyObject*:op:0:
 
+PyContext_CheckExact:int:::
+PyContext_CheckExact:PyObject*:o:0:
+
+PyContext_ClearFreeList:int:::
+
+PyContext_Copy:PyObject*::+1:
+PyContext_Copy:PyObject*:ctx:0:
+
+PyContext_CopyCurrent:PyObject*::+1:
+
+PyContext_Enter:int:::
+PyContext_Enter:PyObject*:ctx:+1:
+
+PyContext_Exit:int:::
+PyContext_Exit:PyObject*:ctx:-1:
+
+PyContext_New:PyObject*::+1:
+
+PyContextToken_CheckExact:int:::
+PyContextToken_CheckExact:PyObject*:o:0:
+
+PyContextVar_CheckExact:int:::
+PyContextVar_CheckExact:PyObject*:o:0:
+
+PyContextVar_Get:int:::
+PyContextVar_Get:PyObject*:var:0:
+PyContextVar_Get:PyObject*:default_value:0:
+PyContextVar_Get:PyObject**:value:+1:???
+
+PyContextVar_New:PyObject*::+1:
+PyContextVar_New:const char*:name::
+PyContextVar_New:PyObject*:def:+1:
+
+PyContextVar_Set:PyObject*::+1:
+PyContextVar_Set:PyObject*:var:0:
+PyContextVar_Set:PyObject*:value:+1:
+
+PyContextVar_Reset:int:::
+PyContextVar_Reset:PyObject*:var:0:
+PyContextVar_Reset:PyObject*:token:-1:
+
 PyDate_FromDate:PyObject*::+1:
 PyDate_FromDate:int:year::
 PyDate_FromDate:int:month::
@@ -541,6 +582,9 @@ PyImport_ExecCodeModuleEx:const char*:pathname::
 
 PyImport_GetMagicNumber:long:::
 
+PyImport_GetModule:PyObject*::+1:
+PyImport_GetModule:PyObject*:name:0:
+
 PyImport_GetModuleDict:PyObject*::0:
 
 PyImport_Import:PyObject*::+1:
@@ -604,6 +648,9 @@ PyInterpreterState_Clear:PyInterpreterState*:interp::
 
 PyInterpreterState_Delete:void:::
 PyInterpreterState_Delete:PyInterpreterState*:interp::
+
+PyInterpreterState_GetID:int64_t:::
+PyInterpreterState_GetID:PyInterpreterState*:interp::
 
 PyInterpreterState_New:PyInterpreterState*:::
 
@@ -933,6 +980,14 @@ PyNumber_Xor:PyObject*:o2:0:
 PyObject_AsFileDescriptor:int:::
 PyObject_AsFileDescriptor:PyObject*:o:0:
 
+PyOS_AfterFork:void:::
+
+PyOS_AfterFork_Child:void:::
+
+PyOS_AfterFork_Parent:void:::
+
+PyOS_BeforeFork:void:::
+
 PyOS_FSPath:PyObject*::+1:
 PyOS_FSPath:PyObject*:path:0:
 
@@ -1252,6 +1307,12 @@ PySet_Pop:PyObject*:set:0:
 PySet_Size:int:::
 PySet_Size:PyObject*:anyset:0:
 
+PySlice_AdjustIndices:Py_ssize_t:::
+PySlice_AdjustIndices:Py_ssize_t:length::
+PySlice_AdjustIndices:Py_ssize_t*:start::
+PySlice_AdjustIndices:Py_ssize_t*:stop::
+PySlice_AdjustIndices:Py_ssize_t*:step::
+
 PySlice_Check:int:::
 PySlice_Check:PyObject*:ob:0:
 
@@ -1259,6 +1320,12 @@ PySlice_New:PyObject*::+1:
 PySlice_New:PyObject*:start:0:
 PySlice_New:PyObject*:stop:0:
 PySlice_New:PyObject*:step:0:
+
+PySlice_Unpack:int:::
+PySlice_Unpack:PyObject*:slice:0:
+PySlice_Unpack:Py_ssize_t*:start::
+PySlice_Unpack:Py_ssize_t*:stop::
+PySlice_Unpack:Py_ssize_t*:step::
 
 PyString_AS_STRING:const char*:::
 PyString_AS_STRING:PyObject*:string:0:
@@ -1388,6 +1455,15 @@ PyTime_FromTime:int:hour::
 PyTime_FromTime:int:minute::
 PyTime_FromTime:int:second::
 PyTime_FromTime:int:usecond::
+
+PyTraceMalloc_Track:int:::
+PyTraceMalloc_Track:unsigned int:domain::
+PyTraceMalloc_Track:uintptr_t:ptr::
+PyTraceMalloc_Track:size_t:size::
+
+PyTraceMalloc_Untrack:int:::
+PyTraceMalloc_Untrack:unsigned int:domain::
+PyTraceMalloc_Untrack:uintptr_t:ptr::
 
 PyTuple_Check:int:::
 PyTuple_Check:PyObject*:p:0:

--- a/Include/import.h
+++ b/Include/import.h
@@ -38,7 +38,9 @@ PyAPI_FUNC(PyObject *) PyImport_ExecCodeModuleObject(
     );
 #endif
 PyAPI_FUNC(PyObject *) PyImport_GetModuleDict(void);
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
 PyAPI_FUNC(PyObject *) PyImport_GetModule(PyObject *name);
+#endif
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyImport_IsInitialized(PyInterpreterState *);
 PyAPI_FUNC(PyObject *) _PyImport_GetModuleId(struct _Py_Identifier *name);

--- a/Include/intrcheck.h
+++ b/Include/intrcheck.h
@@ -8,9 +8,11 @@ extern "C" {
 PyAPI_FUNC(int) PyOS_InterruptOccurred(void);
 PyAPI_FUNC(void) PyOS_InitInterrupts(void);
 #ifdef HAVE_FORK
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
 PyAPI_FUNC(void) PyOS_BeforeFork(void);
 PyAPI_FUNC(void) PyOS_AfterFork_Parent(void);
 PyAPI_FUNC(void) PyOS_AfterFork_Child(void);
+#endif
 #endif
 /* Deprecated, please use PyOS_AfterFork_Child() instead */
 PyAPI_FUNC(void) PyOS_AfterFork(void) Py_DEPRECATED(3.7);

--- a/PC/python3.def
+++ b/PC/python3.def
@@ -284,6 +284,7 @@ EXPORTS
   PyImport_GetImporter=python38.PyImport_GetImporter
   PyImport_GetMagicNumber=python38.PyImport_GetMagicNumber
   PyImport_GetMagicTag=python38.PyImport_GetMagicTag
+  PyImport_GetModule=python38.PyImport_GetModule
   PyImport_GetModuleDict=python38.PyImport_GetModuleDict
   PyImport_Import=python38.PyImport_Import
   PyImport_ImportFrozenModule=python38.PyImport_ImportFrozenModule
@@ -757,6 +758,7 @@ EXPORTS
   Py_SetPythonHome=python38.Py_SetPythonHome
   Py_SetRecursionLimit=python38.Py_SetRecursionLimit
   Py_SymtableString=python38.Py_SymtableString
+  Py_UTF8Mode=python38.Py_UTF8Mode DATA
   Py_VaBuildValue=python38.Py_VaBuildValue
   _PyArg_ParseTupleAndKeywords_SizeT=python38._PyArg_ParseTupleAndKeywords_SizeT
   _PyArg_ParseTuple_SizeT=python38._PyArg_ParseTuple_SizeT


### PR DESCRIPTION
* Set the limited API version for `PyImport_GetModule` and `PyOS_*Fork` functions.
* Add `PyImport_GetModule` and `Py_UTF8Mode` in `PC/python3.def`.
* Add several functions in `Doc/data/refcounts.dat`.
