### PR TITLE
[3.6] Fix line breaks added after hyphens by blurb. (GH-7002)

### DIFF
--- a/Misc/NEWS.d/3.5.0a1.rst
+++ b/Misc/NEWS.d/3.5.0a1.rst
@@ -2706,8 +2706,8 @@ Added support for the "xztar" format in the shutil module.
 .. nonce: ZLsRil
 .. section: Library
 
-Don't force 3rd party C extensions to be built with -Werror=declaration-
-after-statement.
+Don't force 3rd party C extensions to be built with
+``-Werror=declaration-after-statement``.
 
 ..
 
@@ -4464,8 +4464,8 @@ Improve repr of inspect.Signature and inspect.Parameter.
 .. nonce: DFMEgN
 .. section: Library
 
-Fix inspect.getcallargs() to raise correct TypeError for missing keyword-
-only arguments. Patch by Jeremiah Lowin.
+Fix inspect.getcallargs() to raise correct TypeError for missing
+keyword-only arguments. Patch by Jeremiah Lowin.
 
 ..
 
@@ -5059,8 +5059,8 @@ Anticipated fixes to support OS X versions > 10.9.
 .. nonce: KAl7aO
 .. section: Build
 
-Prevent possible segfaults and other random failures of python --generate-
-posix-vars in pybuilddir.txt build target.
+Prevent possible segfaults and other random failures of python
+``--generate-posix-vars`` in pybuilddir.txt build target.
 
 ..
 

--- a/Misc/NEWS.d/3.5.0a3.rst
+++ b/Misc/NEWS.d/3.5.0a3.rst
@@ -62,8 +62,8 @@ Fix the default __sizeof__ implementation for variable-sized objects.
 .. nonce: b5M04V
 .. section: Library
 
-The groupindex attribute of regular expression pattern object now is non-
-modifiable mapping.
+The groupindex attribute of regular expression pattern object now is
+non-modifiable mapping.
 
 ..
 

--- a/Misc/NEWS.d/3.5.0b3.rst
+++ b/Misc/NEWS.d/3.5.0b3.rst
@@ -110,8 +110,8 @@ by Martin Panter.
 .. nonce: aAbWbQ
 .. section: Library
 
-Restore semantic round-trip correctness in tokenize/untokenize for tab-
-indented blocks.
+Restore semantic round-trip correctness in tokenize/untokenize for
+tab-indented blocks.
 
 ..
 

--- a/Misc/NEWS.d/3.5.0b4.rst
+++ b/Misc/NEWS.d/3.5.0b4.rst
@@ -224,8 +224,8 @@ segment.
 .. nonce: hwXwCH
 .. section: Library
 
-SMTP.auth() and SMTP.login() now support RFC 4954's optional initial-
-response argument to the SMTP AUTH command.
+SMTP.auth() and SMTP.login() now support RFC 4954's optional
+initial-response argument to the SMTP AUTH command.
 
 ..
 

--- a/Misc/NEWS.d/3.5.1rc1.rst
+++ b/Misc/NEWS.d/3.5.1rc1.rst
@@ -159,8 +159,8 @@ twice.
 
 On Solaris 11.3 or newer, os.urandom() now uses the getrandom() function
 instead of the getentropy() function. The getentropy() function is blocking
-to generate very good quality entropy, os.urandom() doesn't need such high-
-quality entropy.
+to generate very good quality entropy, os.urandom() doesn't need such
+high-quality entropy.
 
 ..
 
@@ -1083,10 +1083,10 @@ them a 'sheet'.  Patch by Mark Roseman.
 .. nonce: -j_BV7
 .. section: IDLE
 
-Enhance the initial html viewer now used for Idle Help. * Properly indent
-fixed-pitch text (patch by Mark Roseman). * Give code snippet a very Sphinx-
-like light blueish-gray background. * Re-use initial width and height set by
-users for shell and editor. * When the Table of Contents (TOC) menu is used,
+Enhance the initial html viewer now used for Idle Help. Properly indent
+fixed-pitch text (patch by Mark Roseman). Give code snippet a very
+Sphinx-like light blueish-gray background. Re-use initial width and height set by
+users for shell and editor. When the Table of Contents (TOC) menu is used,
 put the section header at the top of the screen.
 
 ..

--- a/Misc/NEWS.d/3.5.2rc1.rst
+++ b/Misc/NEWS.d/3.5.2rc1.rst
@@ -568,9 +568,9 @@ string.  Original fix by Ján Janech.
 .. section: Library
 
 The "urllib.request" module now percent-encodes non-ASCII bytes found in
-redirect target URLs.  Some servers send Location header fields with non-
-ASCII bytes, but "http.client" requires the request target to be ASCII-
-encodable, otherwise a UnicodeEncodeError is raised.  Based on patch by
+redirect target URLs.  Some servers send Location header fields with
+non-ASCII bytes, but "http.client" requires the request target to be
+ASCII-encodable, otherwise a UnicodeEncodeError is raised.  Based on patch by
 Christian Heimes.
 
 ..
@@ -1952,8 +1952,8 @@ Fix linking extension modules for cross builds. Patch by Xavier de Gaye.
 .. nonce: HDjM4s
 .. section: Build
 
-Disable the rules for running _freeze_importlib and pgen when cross-
-compiling.  The output of these programs is normally saved with the source
+Disable the rules for running _freeze_importlib and pgen when
+cross-compiling.  The output of these programs is normally saved with the source
 code anyway, and is still regenerated when doing a native build. Patch by
 Xavier de Gaye.
 

--- a/Misc/NEWS.d/3.5.3rc1.rst
+++ b/Misc/NEWS.d/3.5.3rc1.rst
@@ -81,8 +81,8 @@ astral characters.  Patch by Xiang Zhang.
 .. nonce: RYbEGH
 .. section: Core and Builtins
 
-Extra slash no longer added to sys.path components in case of empty compile-
-time PYTHONPATH components.
+Extra slash no longer added to sys.path components in case of empty
+compile-time PYTHONPATH components.
 
 ..
 
@@ -349,8 +349,8 @@ Patch written by Xiang Zhang.
 .. section: Core and Builtins
 
 Standard __import__() no longer look up "__import__" in globals or builtins
-for importing submodules or "from import".  Fixed handling an error of non-
-string package name.
+for importing submodules or "from import".  Fixed handling an error of
+non-string package name.
 
 ..
 
@@ -2070,9 +2070,9 @@ Update message in validate_ucrtbase.py
 .. section: Build
 
 Cause lack of llvm-profdata tool when using clang as required for PGO
-linking to be a configure time error rather than make time when --with-
-optimizations is enabled.  Also improve our ability to find the llvm-
-profdata tool on MacOS and some Linuxes.
+linking to be a configure time error rather than make time when
+``--with-optimizations`` is enabled.  Also improve our ability to find the
+llvm-profdata tool on MacOS and some Linuxes.
 
 ..
 

--- a/Misc/NEWS.d/3.6.0a1.rst
+++ b/Misc/NEWS.d/3.6.0a1.rst
@@ -728,8 +728,8 @@ Fixed a number of bugs in UTF-7 decoding of misformed data.
 .. section: Core and Builtins
 
 The UTF-8 encoder is now up to 75 times as fast for error handlers:
-``ignore``, ``replace``, ``surrogateescape``, ``surrogatepass``. Patch co-
-written with Serhiy Storchaka.
+``ignore``, ``replace``, ``surrogateescape``, ``surrogatepass``. Patch
+co-written with Serhiy Storchaka.
 
 ..
 
@@ -761,8 +761,8 @@ by Serhiy Storchaka.
 
 On Solaris 11.3 or newer, os.urandom() now uses the getrandom() function
 instead of the getentropy() function. The getentropy() function is blocking
-to generate very good quality entropy, os.urandom() doesn't need such high-
-quality entropy.
+to generate very good quality entropy, os.urandom() doesn't need such
+high-quality entropy.
 
 ..
 
@@ -891,9 +891,9 @@ string.  Original fix by Ján Janech.
 .. section: Library
 
 The "urllib.request" module now percent-encodes non-ASCII bytes found in
-redirect target URLs.  Some servers send Location header fields with non-
-ASCII bytes, but "http.client" requires the request target to be ASCII-
-encodable, otherwise a UnicodeEncodeError is raised.  Based on patch by
+redirect target URLs.  Some servers send Location header fields with
+non-ASCII bytes, but "http.client" requires the request target to be
+ASCII-encodable, otherwise a UnicodeEncodeError is raised.  Based on patch by
 Christian Heimes.
 
 ..
@@ -3328,10 +3328,10 @@ them a 'sheet'.  Patch by Mark Roseman.
 .. nonce: -j_BV7
 .. section: IDLE
 
-Enhance the initial html viewer now used for Idle Help. * Properly indent
-fixed-pitch text (patch by Mark Roseman). * Give code snippet a very Sphinx-
-like light blueish-gray background. * Re-use initial width and height set by
-users for shell and editor. * When the Table of Contents (TOC) menu is used,
+Enhance the initial html viewer now used for Idle Help. Properly indent
+fixed-pitch text (patch by Mark Roseman). Give code snippet a very
+Sphinx-like light blueish-gray background. Re-use initial width and height set by
+users for shell and editor. When the Table of Contents (TOC) menu is used,
 put the section header at the top of the screen.
 
 ..
@@ -3651,8 +3651,8 @@ particular on Android).  Patch by Chi Hsuan Yen.
 .. nonce: HDjM4s
 .. section: Build
 
-Disable the rules for running _freeze_importlib and pgen when cross-
-compiling.  The output of these programs is normally saved with the source
+Disable the rules for running _freeze_importlib and pgen when
+cross-compiling.  The output of these programs is normally saved with the source
 code anyway, and is still regenerated when doing a native build. Patch by
 Xavier de Gaye.
 

--- a/Misc/NEWS.d/3.6.0b1.rst
+++ b/Misc/NEWS.d/3.6.0b1.rst
@@ -507,8 +507,8 @@ expression.
 .. nonce: TJ779X
 .. section: Library
 
-xmlrpc now supports unmarshalling additional data types used by Apache XML-
-RPC implementation for numerics and None.
+xmlrpc now supports unmarshalling additional data types used by Apache
+XML-RPC implementation for numerics and None.
 
 ..
 
@@ -1416,9 +1416,9 @@ platforms.
 .. section: Build
 
 Cause lack of llvm-profdata tool when using clang as required for PGO
-linking to be a configure time error rather than make time when --with-
-optimizations is enabled.  Also improve our ability to find the llvm-
-profdata tool on MacOS and some Linuxes.
+linking to be a configure time error rather than make time when
+``--with-optimizations`` is enabled.  Also improve our ability to find the
+llvm-profdata tool on MacOS and some Linuxes.
 
 ..
 

--- a/Misc/NEWS.d/3.6.0b4.rst
+++ b/Misc/NEWS.d/3.6.0b4.rst
@@ -54,8 +54,8 @@ astral characters.  Patch by Xiang Zhang.
 .. nonce: RYbEGH
 .. section: Core and Builtins
 
-Extra slash no longer added to sys.path components in case of empty compile-
-time PYTHONPATH components.
+Extra slash no longer added to sys.path components in case of empty
+compile-time PYTHONPATH components.
 
 ..
 

--- a/Misc/NEWS.d/3.6.2rc1.rst
+++ b/Misc/NEWS.d/3.6.2rc1.rst
@@ -492,8 +492,8 @@ is received.
 .. section: Library
 
 Various updates to typing module: add typing.NoReturn type, use
-WrapperDescriptorType, minor bug-fixes.  Original PRs by Jim Fasarakis-
-Hilliard and Ivan Levkivskyi.
+WrapperDescriptorType, minor bug-fixes.  Original PRs by Jim
+Fasarakis-Hilliard and Ivan Levkivskyi.
 
 ..
 
@@ -830,8 +830,8 @@ Fix out-of-tree builds of Python when configured with ``--with--dtrace``.
 .. section: Build
 
 Prevent unnecessary rebuilding of Python during ``make test``, ``make
-install`` and some other make targets when configured with ``--enable-
-optimizations``.
+install`` and some other make targets when configured with
+``--enable-optimizations``.
 
 ..
 

--- a/Misc/NEWS.d/3.6.2rc2.rst
+++ b/Misc/NEWS.d/3.6.2rc2.rst
@@ -20,9 +20,9 @@ Upgrade expat copy from 2.2.0 to 2.2.1 to get fixes of multiple security
 vulnerabilities including: CVE-2017-9233 (External entity infinite loop
 DoS), CVE-2016-9063 (Integer overflow, re-fix), CVE-2016-0718 (Fix
 regression bugs from 2.2.0's fix to CVE-2016-0718) and CVE-2012-0876
-(Counter hash flooding with SipHash). Note: the CVE-2016-5300 (Use os-
-specific entropy sources like getrandom) doesn't impact Python, since Python
-already gets entropy from the OS to set the expat secret using
+(Counter hash flooding with SipHash). Note: the CVE-2016-5300 (Use
+os-specific entropy sources like getrandom) doesn't impact Python, since
+Python already gets entropy from the OS to set the expat secret using
 ``XML_SetHashSalt()``.
 
 ..

--- a/Misc/NEWS.d/3.6.3rc1.rst
+++ b/Misc/NEWS.d/3.6.3rc1.rst
@@ -197,10 +197,10 @@ ImportError rather than SystemError.
 
 Improve signal delivery.
 
-Avoid using Py_AddPendingCall from signal handler, to avoid calling signal-
-unsafe functions. The tests I'm adding here fail without the rest of the
-patch, on Linux and OS X. This means our signal delivery logic had defects
-(some signals could be lost).
+Avoid using Py_AddPendingCall from signal handler, to avoid calling
+signal-unsafe functions. The tests I'm adding here fail without the rest of
+the patch, on Linux and OS X. This means our signal delivery logic had
+defects (some signals could be lost).
 
 ..
 
@@ -516,9 +516,9 @@ LF. Patch by Dong-hee Na.
 .. nonce: -zJ7d8
 .. section: Library
 
-multiprocessing.Queue.get() with a timeout now polls its reader in non-
-blocking mode if it succeeded to aquire the lock but the acquire took longer
-than the timeout.
+multiprocessing.Queue.get() with a timeout now polls its reader in
+non-blocking mode if it succeeded to aquire the lock but the acquire took
+longer than the timeout.
 
 ..
 
@@ -627,8 +627,8 @@ Fix email header value parser dropping folding white space in certain cases.
 .. nonce: N3KI-o
 .. section: Library
 
-os.listdir() and os.scandir() now emit bytes names when called with bytes-
-like argument.
+os.listdir() and os.scandir() now emit bytes names when called with
+bytes-like argument.
 
 ..
 
@@ -881,8 +881,8 @@ All custom keysets are saved as a whole in config- extension.cfg.  All take
 effect as soon as one clicks Apply or Ok.
 
 The affected events are '<<force-open-completions>>', '<<expand-word>>',
-'<<force-open-calltip>>', '<<flash-paren>>', '<<format-paragraph>>', '<<run-
-module>>', '<<check-module>>', and '<<zoom-height>>'.  Any (global)
+'<<force-open-calltip>>', '<<flash-paren>>', '<<format-paragraph>>',
+'<<run-module>>', '<<check-module>>', and '<<zoom-height>>'.  Any (global)
 customizations made before 3.6.3 will not affect their keyset- specific
 customization after 3.6.3. and vice versa.
 

--- a/Misc/NEWS.d/3.6.5rc1.rst
+++ b/Misc/NEWS.d/3.6.5rc1.rst
@@ -74,8 +74,8 @@ terminated by a semi-colon instead of a newline. Patch by Nitish Chandra.
 .. nonce: Fh3fau
 .. section: Core and Builtins
 
-Fix possible crashing in builtin Unicode decoders caused by write out-of-
-bound errors when using customized decode error handlers.
+Fix possible crashing in builtin Unicode decoders caused by write
+out-of-bound errors when using customized decode error handlers.
 
 ..
 


### PR DESCRIPTION
Also remove bullet asterisks from IDLE entries.
(cherry picked from commit aef639f62677f8a342af24e9c19f0503b0d1e36e)
