### PR TITLE
bpo-33604: Bump removal notice from 3.6 to 3.8

### DIFF
--- a/Doc/library/hmac.rst
+++ b/Doc/library/hmac.rst
@@ -27,7 +27,7 @@ This module implements the HMAC algorithm as described by :rfc:`2104`.
       Parameter *msg* can be of any type supported by :mod:`hashlib`.
       Parameter *digestmod* can be the name of a hash algorithm.
 
-   .. deprecated:: 3.4
+   .. deprecated-removed:: 3.4 3.8
       MD5 as implicit default digest for *digestmod* is deprecated.
 
 

--- a/Lib/hmac.py
+++ b/Lib/hmac.py
@@ -39,8 +39,8 @@ class HMAC:
                    A hashlib constructor returning a new hash object. *OR*
                    A hash name suitable for hashlib.new().
                    Defaults to hashlib.md5.
-                   Implicit default to hashlib.md5 is deprecated and will be
-                   removed in Python 3.6.
+                   Implicit default to hashlib.md5 is deprecated since Python
+                   3.4 and will be removed in Python 3.8.
 
         Note: key and msg must be a bytes or bytearray objects.
         """
@@ -50,7 +50,9 @@ class HMAC:
 
         if digestmod is None:
             _warnings.warn("HMAC() without an explicit digestmod argument "
-                           "is deprecated.", PendingDeprecationWarning, 2)
+                           "is deprecated since Python 3.4, and will be removed "
+                           "in 3.8",
+                           DeprecationWarning, 2)
             digestmod = _hashlib.md5
 
         if callable(digestmod):

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -12,7 +12,7 @@ def ignore_warning(func):
     def wrapper(*args, **kwargs):
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore",
-                                    category=PendingDeprecationWarning)
+                                    category=DeprecationWarning)
             return func(*args, **kwargs)
     return wrapper
 
@@ -303,7 +303,7 @@ class TestVectorsTestCase(unittest.TestCase):
                 self.fail('Expected warning about small block_size')
 
     def test_with_digestmod_warning(self):
-        with self.assertWarns(PendingDeprecationWarning):
+        with self.assertWarns(DeprecationWarning):
             key = b"\x0b" * 16
             data = b"Hi There"
             digest = "9294727A3638BB1C13F48EF8158BFC9D"

--- a/Misc/NEWS.d/next/Documentation/2018-05-22-11-47-14.bpo-33604.5YHTpz.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-22-11-47-14.bpo-33604.5YHTpz.rst
@@ -1,0 +1,1 @@
+Update HMAC DeprecationWarning, bump removal to 3.8

--- a/Misc/NEWS.d/next/Documentation/2018-05-22-11-47-14.bpo-33604.5YHTpz.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-22-11-47-14.bpo-33604.5YHTpz.rst
@@ -1,1 +1,1 @@
-Update HMAC DeprecationWarning, bump removal to 3.8
+Update HMAC md5 default to a DeprecationWarning, bump removal to 3.8.


### PR DESCRIPTION
Also change from PendingDeprecationWarning to DeprecationWarning.

<!-- issue-number: bpo-33604 -->
https://bugs.python.org/issue33604
<!-- /issue-number -->
