### PR TITLE
bpo-33604: Remove deprecated HMAC default value marked for removal in 3.8

### DIFF
--- a/Doc/library/hmac.rst
+++ b/Doc/library/hmac.rst
@@ -19,8 +19,7 @@ This module implements the HMAC algorithm as described by :rfc:`2104`.
    Return a new hmac object.  *key* is a bytes or bytearray object giving the
    secret key.  If *msg* is present, the method call ``update(msg)`` is made.
    *digestmod* is the digest name, digest constructor or module for the HMAC
-   object to use. It supports any name suitable to :func:`hashlib.new` and
-   defaults to the :data:`hashlib.md5` constructor.
+   object to use. It supports any name suitable to :func:`hashlib.new`.
 
    .. versionchanged:: 3.4
       Parameter *key* can be a bytes or bytearray object.

--- a/Lib/hmac.py
+++ b/Lib/hmac.py
@@ -35,10 +35,9 @@ class HMAC:
 
         key:       key for the keyed hash object.
         msg:       Initial input for the hash, if provided.
-        digestmod: A module supporting PEP 247.  *OR*
-                   A hashlib constructor returning a new hash object. *OR*
+        digestmod: Required.  A module supporting PEP 247.  *OR*
+                   A hashlib constructor returning a new hash object.  *OR*
                    A hash name suitable for hashlib.new().
-                   Implicit default to hashlib.md5 has been removed in Python 3.8
 
         Note: key and msg must be a bytes or bytearray objects.
         """
@@ -47,7 +46,7 @@ class HMAC:
             raise TypeError("key: expected bytes or bytearray, but got %r" % type(key).__name__)
 
         if digestmod is None:
-            raise ValueError('`digestmode` should be explicitly given.')
+            raise ValueError('`digestmod` is required.')
 
         if callable(digestmod):
             self.digest_cons = digestmod

--- a/Lib/hmac.py
+++ b/Lib/hmac.py
@@ -38,9 +38,7 @@ class HMAC:
         digestmod: A module supporting PEP 247.  *OR*
                    A hashlib constructor returning a new hash object. *OR*
                    A hash name suitable for hashlib.new().
-                   Defaults to hashlib.md5.
-                   Implicit default to hashlib.md5 is deprecated since Python
-                   3.4 and will be removed in Python 3.8.
+                   Implicit default to hashlib.md5 has been removed in Python 3.8
 
         Note: key and msg must be a bytes or bytearray objects.
         """
@@ -49,11 +47,7 @@ class HMAC:
             raise TypeError("key: expected bytes or bytearray, but got %r" % type(key).__name__)
 
         if digestmod is None:
-            _warnings.warn("HMAC() without an explicit digestmod argument "
-                           "is deprecated since Python 3.4, and will be removed "
-                           "in 3.8",
-                           DeprecationWarning, 2)
-            digestmod = _hashlib.md5
+            raise ValueError('`digestmode` should be explicitly given.')
 
         if callable(digestmod):
             self.digest_cons = digestmod

--- a/Lib/test/test_hmac.py
+++ b/Lib/test/test_hmac.py
@@ -302,45 +302,38 @@ class TestVectorsTestCase(unittest.TestCase):
                 hmac.HMAC(b'a', b'b', digestmod=MockCrazyHash)
                 self.fail('Expected warning about small block_size')
 
-    def test_with_digestmod_warning(self):
-        with self.assertWarns(DeprecationWarning):
+    def test_with_digestmod_no_default(self):
+        with self.assertRaises(ValueError):
             key = b"\x0b" * 16
             data = b"Hi There"
-            digest = "9294727A3638BB1C13F48EF8158BFC9D"
-            h = hmac.HMAC(key, data)
-            self.assertEqual(h.hexdigest().upper(), digest)
-
+            hmac.HMAC(key, data, digestmod=None)
 
 class ConstructorTestCase(unittest.TestCase):
 
-    @ignore_warning
     def test_normal(self):
         # Standard constructor call.
         failed = 0
         try:
-            h = hmac.HMAC(b"key")
+            h = hmac.HMAC(b"key", digestmod='md5')
         except Exception:
             self.fail("Standard constructor call raised exception.")
 
-    @ignore_warning
     def test_with_str_key(self):
         # Pass a key of type str, which is an error, because it expects a key
         # of type bytes
         with self.assertRaises(TypeError):
-            h = hmac.HMAC("key")
+            h = hmac.HMAC("key", digestmod='md5')
 
-    @ignore_warning
     def test_dot_new_with_str_key(self):
         # Pass a key of type str, which is an error, because it expects a key
         # of type bytes
         with self.assertRaises(TypeError):
-            h = hmac.new("key")
+            h = hmac.new("key", digestmod='md5')
 
-    @ignore_warning
     def test_withtext(self):
         # Constructor call with text.
         try:
-            h = hmac.HMAC(b"key", b"hash this!")
+            h = hmac.HMAC(b"key", b"hash this!", digestmod='md5')
         except Exception:
             self.fail("Constructor call with text argument raised exception.")
         self.assertEqual(h.hexdigest(), '34325b639da4cfd95735b381e28cb864')
@@ -368,13 +361,6 @@ class ConstructorTestCase(unittest.TestCase):
             self.fail("Constructor call with hashlib.sha1 raised exception.")
 
 class SanityTestCase(unittest.TestCase):
-
-    @ignore_warning
-    def test_default_is_md5(self):
-        # Testing if HMAC defaults to MD5 algorithm.
-        # NOTE: this whitebox test depends on the hmac class internals
-        h = hmac.HMAC(b"key")
-        self.assertEqual(h.digest_cons, hashlib.md5)
 
     def test_exercise_all_methods(self):
         # Exercising all methods once.

--- a/Misc/NEWS.d/next/Library/2018-05-22-11-55-33.bpo-33604.6V4JcO.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-22-11-55-33.bpo-33604.6V4JcO.rst
@@ -1,0 +1,2 @@
+Remove HMAC default to md5 marked for removal in 3.8 (removal originally
+planned in 3.6, bump to 3.8 in gh-7062).


### PR DESCRIPTION
HMAC's digestmod was deprecated marked for removal in 3.6, then to 3.8 (in #7062).

This is on top of #7062, which fix the deprecation notice to use the correct Python version. 

<!-- issue-number: bpo-33604 -->
https://bugs.python.org/issue33604
<!-- /issue-number -->
