### PR TITLE
Add patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ installp/
 # Ignore ./python binary on Unix but still look into ./Python/ directory.
 /python
 !/Python/
+*.bak
 *.cover
 *.iml
 *.o
@@ -24,6 +25,7 @@ installp/
 *.profraw
 *.dyn
 .gdb_history
+C.tom
 Doc/build/
 Doc/venv/
 Doc/.venv/


### PR DESCRIPTION
In my environment I need to ignore `*.bak` files and file `C.tom`.  So this just adds those patterns.  I have a hard time believing this needs a report on bugs.python.org., or a NEWS entry, but - if so - let me know.