### PR TITLE
bpo-33330: PyImport_Cleanup check for exc leaks

### DIFF
--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -1595,6 +1595,7 @@ _PyGC_CollectNoFail(void)
        during interpreter shutdown (and then never finish it).
        See http://bugs.python.org/issue8713#msg195178 for an example.
        */
+    assert(!PyErr_Occurred());
     if (_PyRuntime.gc.collecting)
         n = 0;
     else {
@@ -1602,6 +1603,7 @@ _PyGC_CollectNoFail(void)
         n = collect(NUM_GENERATIONS - 1, NULL, NULL, 1);
         _PyRuntime.gc.collecting = 0;
     }
+    assert(!PyErr_Occurred());
     return n;
 }
 


### PR DESCRIPTION
* Add "assert(!PyErr_Occurred());" assertions to PyImport_Cleanup()
  and _PyGC_CollectNoFail() to make sure that these functions don't
  leak exceptions.
* Replace also PyImport_GetModuleDict() call with interp->modules to
  prevent a fatal error if modules is already NULL.

<!-- issue-number: bpo-33330 -->
https://bugs.python.org/issue33330
<!-- /issue-number -->
