### PR TITLE
bpo-33612: Remove PyThreadState_Clear() assertion

### DIFF
--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -586,7 +586,6 @@ PyThreadState_Clear(PyThreadState *tstate)
     Py_CLEAR(tstate->exc_state.exc_traceback);
 
     /* The stack of exception states should contain just this thread. */
-    assert(tstate->exc_info->previous_item == NULL);
     if (Py_VerboseFlag && tstate->exc_info != &tstate->exc_state) {
         fprintf(stderr,
           "PyThreadState_Clear: warning: thread still has a generator\n");


### PR DESCRIPTION
bpo-25612, bpo-33612: Remove an assertion from PyThreadState_Clear()
which failed at Python shutdown or on fork if a thread was running a
generator.

<!-- issue-number: bpo-33612 -->
https://bugs.python.org/issue33612
<!-- /issue-number -->
