### PR TITLE
bpo-27485: Change urlparse tests to use private methods

### DIFF
--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -994,7 +994,7 @@ class Utility_Tests(unittest.TestCase):
     # In Python 2 this test class was in test_urllib.
 
     def test_splittype(self):
-        splittype = urllib.parse.splittype
+        splittype = urllib.parse._splittype
         self.assertEqual(splittype('type:opaquestring'), ('type', 'opaquestring'))
         self.assertEqual(splittype('opaquestring'), (None, 'opaquestring'))
         self.assertEqual(splittype(':opaquestring'), (None, ':opaquestring'))
@@ -1002,7 +1002,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splittype('type:opaque:string'), ('type', 'opaque:string'))
 
     def test_splithost(self):
-        splithost = urllib.parse.splithost
+        splithost = urllib.parse._splithost
         self.assertEqual(splithost('//www.example.org:80/foo/bar/baz.html'),
                          ('www.example.org:80', '/foo/bar/baz.html'))
         self.assertEqual(splithost('//www.example.org:80'),
@@ -1031,7 +1031,7 @@ class Utility_Tests(unittest.TestCase):
                          ('example.net', '/file#'))
 
     def test_splituser(self):
-        splituser = urllib.parse.splituser
+        splituser = urllib.parse._splituser
         self.assertEqual(splituser('User:Pass@www.python.org:080'),
                          ('User:Pass', 'www.python.org:080'))
         self.assertEqual(splituser('@www.python.org:080'),
@@ -1046,7 +1046,7 @@ class Utility_Tests(unittest.TestCase):
     def test_splitpasswd(self):
         # Some of the password examples are not sensible, but it is added to
         # confirming to RFC2617 and addressing issue4675.
-        splitpasswd = urllib.parse.splitpasswd
+        splitpasswd = urllib.parse._splitpasswd
         self.assertEqual(splitpasswd('user:ab'), ('user', 'ab'))
         self.assertEqual(splitpasswd('user:a\nb'), ('user', 'a\nb'))
         self.assertEqual(splitpasswd('user:a\tb'), ('user', 'a\tb'))
@@ -1062,7 +1062,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitpasswd(':ab'), ('', 'ab'))
 
     def test_splitport(self):
-        splitport = urllib.parse.splitport
+        splitport = urllib.parse._splitport
         self.assertEqual(splitport('parrot:88'), ('parrot', '88'))
         self.assertEqual(splitport('parrot'), ('parrot', None))
         self.assertEqual(splitport('parrot:'), ('parrot', None))
@@ -1073,7 +1073,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitport(':88'), ('', '88'))
 
     def test_splitnport(self):
-        splitnport = urllib.parse.splitnport
+        splitnport = urllib.parse._splitnport
         self.assertEqual(splitnport('parrot:88'), ('parrot', 88))
         self.assertEqual(splitnport('parrot'), ('parrot', -1))
         self.assertEqual(splitnport('parrot', 55), ('parrot', 55))
@@ -1087,7 +1087,7 @@ class Utility_Tests(unittest.TestCase):
     def test_splitquery(self):
         # Normal cases are exercised by other tests; ensure that we also
         # catch cases with no port specified (testcase ensuring coverage)
-        splitquery = urllib.parse.splitquery
+        splitquery = urllib.parse._splitquery
         self.assertEqual(splitquery('http://python.org/fake?foo=bar'),
                          ('http://python.org/fake', 'foo=bar'))
         self.assertEqual(splitquery('http://python.org/fake?foo=bar?'),
@@ -1097,7 +1097,7 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitquery('?foo=bar'), ('', 'foo=bar'))
 
     def test_splittag(self):
-        splittag = urllib.parse.splittag
+        splittag = urllib.parse._splittag
         self.assertEqual(splittag('http://example.com?foo=bar#baz'),
                          ('http://example.com?foo=bar', 'baz'))
         self.assertEqual(splittag('http://example.com?foo=bar#'),
@@ -1109,7 +1109,7 @@ class Utility_Tests(unittest.TestCase):
                          ('http://example.com?foo=bar#baz', 'boo'))
 
     def test_splitattr(self):
-        splitattr = urllib.parse.splitattr
+        splitattr = urllib.parse._splitattr
         self.assertEqual(splitattr('/path;attr1=value1;attr2=value2'),
                          ('/path', ['attr1=value1', 'attr2=value2']))
         self.assertEqual(splitattr('/path;'), ('/path', ['']))
@@ -1120,7 +1120,7 @@ class Utility_Tests(unittest.TestCase):
     def test_splitvalue(self):
         # Normal cases are exercised by other tests; test pathological cases
         # with no key/value pairs. (testcase ensuring coverage)
-        splitvalue = urllib.parse.splitvalue
+        splitvalue = urllib.parse._splitvalue
         self.assertEqual(splitvalue('foo=bar'), ('foo', 'bar'))
         self.assertEqual(splitvalue('foo='), ('foo', ''))
         self.assertEqual(splitvalue('=bar'), ('', 'bar'))
@@ -1128,13 +1128,13 @@ class Utility_Tests(unittest.TestCase):
         self.assertEqual(splitvalue('foo=bar=baz'), ('foo', 'bar=baz'))
 
     def test_to_bytes(self):
-        result = urllib.parse.to_bytes('http://www.python.org')
+        result = urllib.parse._to_bytes('http://www.python.org')
         self.assertEqual(result, 'http://www.python.org')
         self.assertRaises(UnicodeError, urllib.parse._to_bytes,
                           'http://www.python.org/medi\u00e6val')
 
     def test_unwrap(self):
-        url = urllib.parse.unwrap('<URL:type://host/path>')
+        url = urllib.parse._unwrap('<URL:type://host/path>')
         self.assertEqual(url, 'type://host/path')
 
 


### PR DESCRIPTION
The original change for bpo-27485 deprecated undocumented methods in urlparse and changed them to private methods.  This is to fix the tests so they don't get the Deprecation Warning.

<!-- issue-number: bpo-27485 -->
https://bugs.python.org/issue27485
<!-- /issue-number -->
