### PR TITLE
bpo-33617: Use os.fspath() for subprocess sequences on Windows

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -502,6 +502,7 @@ def list2cmdline(seq):
     result = []
     needquote = False
     for arg in seq:
+        arg = os.fspath(arg)
         bs_buf = []
 
         # Add a space to separate this argument from the others

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -18,6 +18,7 @@ import shutil
 import threading
 import gc
 import textwrap
+import pathlib
 from test.support import FakePath
 
 try:
@@ -117,6 +118,19 @@ class ProcessTestCase(BaseTestCase):
             p.stdout.close()
             p.stderr.close()
             p.wait()
+
+    def test_pathlib_executable(self):
+        p = subprocess.Popen([pathlib.Path(sys.executable), "-c",
+                              "import sys; sys.exit(47)"])
+        p.wait()
+        self.assertEqual(p.returncode, 47)
+
+    def test_pathlib_argument(self):
+        path = pathlib.Path(sys.executable)
+        output = subprocess.check_output([path, "-c",
+                                         "import sys; sys.stdout.write(sys.argv[1])",
+                                          path])
+        self.assertEqual(output, os.fspath(path).encode())
 
     def test_call_seq(self):
         # call() function with sequence argument

--- a/Misc/NEWS.d/next/Library/2018-05-23-15-27-00.bpo-33617.dj349j.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-23-15-27-00.bpo-33617.dj349j.rst
@@ -1,0 +1,1 @@
+Use os.fspath() on elements of sequences passed to subprocess.Popen() on Windows.


### PR DESCRIPTION


<!-- issue-number: bpo-33617 -->
https://bugs.python.org/issue33617
<!-- /issue-number -->
