### PR TITLE
bpo-33625: Release GIL for grp.getgr{nam,gid} and pwd.getpw{nam,uid}

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-05-23-17-07-54.bpo-33625.nzQgD8.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-23-17-07-54.bpo-33625.nzQgD8.rst
@@ -1,0 +1,2 @@
+Release GIL on `grp.getgrnam`, `grp.getgrgid`, `pwd.getpwnam` and
+`pwd.getpwuid`. Patch by William Grzybowski.

--- a/Misc/NEWS.d/next/Library/2018-05-23-17-07-54.bpo-33625.nzQgD8.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-23-17-07-54.bpo-33625.nzQgD8.rst
@@ -1,2 +1,3 @@
 Release GIL on `grp.getgrnam`, `grp.getgrgid`, `pwd.getpwnam` and
-`pwd.getpwuid`. Patch by William Grzybowski.
+`pwd.getpwuid` if reentrant variants of these functions are available.
+Patch by William Grzybowski.

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -139,15 +139,12 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
             break;
         }
         if (bufsize > (PY_SSIZE_T_MAX >> 1)) {
-            PyErr_NoMemory();
             nomem = 1;
-            status = ERANGE;
             break;
         }
         bufsize <<= 1;
         p = PyMem_RawRealloc(buf, bufsize);
         if (p == NULL) {
-            PyErr_NoMemory();
             nomem = 1;
             break;
         }
@@ -166,9 +163,7 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
             PyMem_RawFree(buf);
         }
         if (nomem == 1) {
-            PyErr_Format(PyExc_RuntimeError,
-                         "getgrgid(): cannot allocate memory: %d", gid);
-            return NULL;
+            return PyErr_NoMemory();
         }
         PyObject *gid_obj = _PyLong_FromGid(gid);
         if (gid_obj == NULL)
@@ -226,15 +221,12 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
             break;
         }
         if (bufsize > (PY_SSIZE_T_MAX >> 1)) {
-            PyErr_NoMemory();
             nomem = 1;
-            status = ERANGE;
             break;
         }
         bufsize <<= 1;
         p = PyMem_RawRealloc(buf, bufsize);
         if (p == NULL) {
-            PyErr_NoMemory();
             nomem = 1;
             break;
         }
@@ -250,7 +242,7 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
 #endif
     if (p == NULL) {
         if (nomem == 1) {
-            PyErr_Format(PyExc_RuntimeError, "getgrnam(): cannot allocate memory: %s", name_chars);
+            PyErr_NoMemory();
         } else {
             PyErr_Format(PyExc_KeyError, "getgrnam(): name not found: %s", name_chars);
         }

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -96,7 +96,8 @@ static PyObject *
 grp_getgrgid_impl(PyObject *module, PyObject *id)
 /*[clinic end generated code: output=30797c289504a1ba input=15fa0e2ccf5cda25]*/
 {
-    PyObject *py_int_id;
+    PyObject *py_int_id, *retval = NULL;
+    char *buf;
     gid_t gid;
     struct group *p;
 
@@ -119,8 +120,38 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
         }
         Py_DECREF(py_int_id);
     }
+#ifdef HAVE_GETGRGID_R
+    Py_BEGIN_ALLOW_THREADS
+    int status, bufsize = NSS_BUFLEN_GROUP;
+    struct group *grpbuf = NULL;
 
-    if ((p = getgrgid(gid)) == NULL) {
+    p = malloc(sizeof(struct group));
+    buf = malloc(bufsize);
+
+    do {
+        status = getgrgid_r(gid, p, buf, bufsize, &grpbuf);
+        if(grpbuf == NULL && status == ERANGE) {
+            free(buf);
+            if((bufsize << 1) > (NSS_BUFLEN_GROUP << 10)) {
+                errno = ERANGE;
+                break;
+            }
+            bufsize <<= 1;
+            buf = malloc(bufsize);
+
+        }
+    } while (grpbuf == NULL && status == ERANGE);
+
+    if (status != 0 || grpbuf == NULL) {
+        free(buf);
+        free(p);
+        p = NULL;
+    }
+    Py_END_ALLOW_THREADS
+#else
+    p = getgrgid(gid);
+#endif
+    if (p == NULL) {
         PyObject *gid_obj = _PyLong_FromGid(gid);
         if (gid_obj == NULL)
             return NULL;
@@ -128,7 +159,12 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
         Py_DECREF(gid_obj);
         return NULL;
     }
-    return mkgrent(p);
+    retval = mkgrent(p);
+#ifdef HAVE_GETGRGID_R
+    free(buf);
+    free(p);
+#endif
+    return retval;
 }
 
 /*[clinic input]
@@ -145,7 +181,7 @@ static PyObject *
 grp_getgrnam_impl(PyObject *module, PyObject *name)
 /*[clinic end generated code: output=67905086f403c21c input=08ded29affa3c863]*/
 {
-    char *name_chars;
+    char *buf, *name_chars;
     struct group *p;
     PyObject *bytes, *retval = NULL;
 
@@ -154,12 +190,46 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
     /* check for embedded null bytes */
     if (PyBytes_AsStringAndSize(bytes, &name_chars, NULL) == -1)
         goto out;
+#ifdef HAVE_GETGRNAM_R
+    Py_BEGIN_ALLOW_THREADS
+    int status, bufsize = NSS_BUFLEN_GROUP;
+    struct group *grpbuf = NULL;
 
-    if ((p = getgrnam(name_chars)) == NULL) {
+    p = malloc(sizeof(struct group));
+    buf = malloc(bufsize);
+
+    do {
+        status = getgrnam_r(name_chars, p, buf, bufsize, &grpbuf);
+        if(grpbuf == NULL && status == ERANGE) {
+            free(buf);
+            if((bufsize << 1) > (NSS_BUFLEN_GROUP << 10)) {
+                errno = ERANGE;
+                break;
+            }
+            bufsize <<= 1;
+            buf = malloc(bufsize);
+
+        }
+    } while (grpbuf == NULL && status == ERANGE);
+
+    if (status != 0 || grpbuf == NULL) {
+        free(buf);
+        free(p);
+        p = NULL;
+    }
+    Py_END_ALLOW_THREADS
+#else
+    p = getgrnam(name_chars);
+#endif
+    if (p == NULL) {
         PyErr_Format(PyExc_KeyError, "getgrnam(): name not found: %s", name_chars);
         goto out;
     }
     retval = mkgrent(p);
+#ifdef HAVE_GETGRNAM_R
+    free(buf);
+    free(p);
+#endif
 out:
     Py_DECREF(bytes);
     return retval;

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -133,9 +133,15 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
     if (bufsize == -1) {
         bufsize = DEFAULT_BUFFER_SIZE;
     }
-    buf = PyMem_RawMalloc(bufsize);
 
     while (1) {
+        buf2 = PyMem_RawRealloc(buf, bufsize);
+        if (buf2 == NULL) {
+            p = NULL;
+            nomem = 1;
+            break;
+        }
+        buf = buf2;
         status = getgrgid_r(gid, &grp, buf, bufsize, &p);
         if (status != 0) {
             p = NULL;
@@ -148,12 +154,6 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
             break;
         }
         bufsize <<= 1;
-        buf2 = PyMem_RawRealloc(buf, bufsize);
-        if (buf2 == NULL) {
-            nomem = 1;
-            break;
-        }
-        buf = buf2;
     }
 
     Py_END_ALLOW_THREADS
@@ -213,9 +213,15 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
     if (bufsize == -1) {
         bufsize = DEFAULT_BUFFER_SIZE;
     }
-    buf = PyMem_RawMalloc(bufsize);
 
     while(1) {
+        buf2 = PyMem_RawRealloc(buf, bufsize);
+        if (buf2 == NULL) {
+            p = NULL;
+            nomem = 1;
+            break;
+        }
+        buf = buf2;
         status = getgrnam_r(name_chars, &grp, buf, bufsize, &p);
         if (status != 0) {
             p = NULL;
@@ -228,12 +234,6 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
             break;
         }
         bufsize <<= 1;
-        buf2 = PyMem_RawRealloc(buf, bufsize);
-        if (p == NULL) {
-            nomem = 1;
-            break;
-        }
-        buf = (char *) buf2;
     }
 
     Py_END_ALLOW_THREADS

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -140,7 +140,7 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
     }
     buf = PyMem_RawMalloc(bufsize);
 
-    do {
+    while(1) {
         status = getpwuid_r(uid, &pwd, buf, bufsize, &p);
         if (p != NULL || status != ERANGE) {
             break;
@@ -156,7 +156,7 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
             break;
         }
         buf = (char *) p;
-    } while (1);
+    }
 
     if (status != 0) {
         p = NULL;
@@ -224,7 +224,7 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
     }
     buf = PyMem_RawMalloc(bufsize);
 
-    do {
+    while(1) {
         status = getpwnam_r(name, &pwd, buf, bufsize, &p);
         if (p != NULL || status != ERANGE) {
             break;
@@ -240,7 +240,7 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
             break;
         }
         buf = (char *) p;
-    } while (1);
+    }
 
     if (status != 0) {
         p = NULL;

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -116,8 +116,10 @@ static PyObject *
 pwd_getpwuid(PyObject *module, PyObject *uidobj)
 /*[clinic end generated code: output=c4ee1d4d429b86c4 input=ae64d507a1c6d3e8]*/
 {
+    PyObject *retval = NULL;
     uid_t uid;
     struct passwd *p;
+    char *buf;
 
     if (!_Py_Uid_Converter(uidobj, &uid)) {
         if (PyErr_ExceptionMatches(PyExc_OverflowError))
@@ -125,7 +127,38 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
                          "getpwuid(): uid not found");
         return NULL;
     }
-    if ((p = getpwuid(uid)) == NULL) {
+#ifdef HAVE_GETPWUID_R
+    Py_BEGIN_ALLOW_THREADS
+    int status, bufsize = NSS_BUFLEN_PASSWD;
+    struct passwd *pwdbuf = NULL;
+
+    p = malloc(sizeof(struct passwd));
+    buf = malloc(bufsize);
+
+    do {
+        status = getpwuid_r(uid, p, buf, bufsize, &pwdbuf);
+        if(pwdbuf == NULL && status == ERANGE) {
+            free(buf);
+            if((bufsize << 1) > (NSS_BUFLEN_PASSWD << 10)) {
+                errno = ERANGE;
+                break;
+            }
+            bufsize <<= 1;
+            buf = malloc(bufsize);
+
+        }
+    } while (pwdbuf == NULL && status == ERANGE);
+
+    if (status != 0 || pwdbuf == NULL) {
+        free(buf);
+        free(p);
+        p = NULL;
+    }
+    Py_END_ALLOW_THREADS
+#else
+    p = getpwuid(uid);
+#endif
+    if (p == NULL) {
         PyObject *uid_obj = _PyLong_FromUid(uid);
         if (uid_obj == NULL)
             return NULL;
@@ -134,7 +167,12 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
         Py_DECREF(uid_obj);
         return NULL;
     }
-    return mkpwent(p);
+    retval = mkpwent(p);
+#ifdef HAVE_GETPWUID_R
+    free(buf);
+    free(p);
+#endif
+    return retval;
 }
 
 /*[clinic input]
@@ -152,7 +190,7 @@ static PyObject *
 pwd_getpwnam_impl(PyObject *module, PyObject *arg)
 /*[clinic end generated code: output=6abeee92430e43d2 input=d5f7e700919b02d3]*/
 {
-    char *name;
+    char *buf, *name;
     struct passwd *p;
     PyObject *bytes, *retval = NULL;
 
@@ -161,12 +199,46 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
     /* check for embedded null bytes */
     if (PyBytes_AsStringAndSize(bytes, &name, NULL) == -1)
         goto out;
-    if ((p = getpwnam(name)) == NULL) {
+#ifdef HAVE_GETPWNAM_R
+    Py_BEGIN_ALLOW_THREADS
+    int status, bufsize = NSS_BUFLEN_PASSWD;
+    struct passwd *pwdbuf = NULL;
+
+    p = malloc(sizeof(struct passwd));
+    buf = malloc(bufsize);
+
+    do {
+        status = getpwnam_r(name, p, buf, bufsize, &pwdbuf);
+        if(pwdbuf == NULL && status == ERANGE) {
+            free(buf);
+            if((bufsize << 1) > (NSS_BUFLEN_PASSWD << 10)) {
+                errno = ERANGE;
+                break;
+            }
+            bufsize <<= 1;
+            buf = malloc(bufsize);
+
+        }
+    } while (pwdbuf == NULL && status == ERANGE);
+
+    if(status != 0 || pwdbuf == NULL) {
+        free(p);
+        p = NULL;
+    }
+    Py_END_ALLOW_THREADS
+#else
+    p = getpwnam(name);
+#endif
+    if (p == NULL) {
         PyErr_Format(PyExc_KeyError,
                      "getpwnam(): name not found: %s", name);
         goto out;
     }
     retval = mkpwent(p);
+#ifdef HAVE_GETPWNAM_R
+    free(buf);
+    free(p);
+#endif
 out:
     Py_DECREF(bytes);
     return retval;

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -146,15 +146,12 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
             break;
         }
         if (bufsize > (PY_SSIZE_T_MAX >> 1)) {
-            PyErr_NoMemory();
             nomem = 1;
-            status = ERANGE;
             break;
         }
         bufsize <<= 1;
         p = PyMem_RawRealloc(buf, bufsize);
         if (p == NULL) {
-            PyErr_NoMemory();
             nomem = 1;
             break;
         }
@@ -173,9 +170,7 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
             PyMem_RawFree(buf);
         }
         if (nomem == 1) {
-            PyErr_Format(PyExc_RuntimeError,
-                         "getpwuid(): cannot allocate memory: %d", uid);
-            return NULL;
+            return PyErr_NoMemory();
         }
         PyObject *uid_obj = _PyLong_FromUid(uid);
         if (uid_obj == NULL)
@@ -235,15 +230,12 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
             break;
         }
         if (bufsize > (PY_SSIZE_T_MAX >> 1)) {
-            PyErr_NoMemory();
             nomem = 1;
-            status = ERANGE;
             break;
         }
         bufsize <<= 1;
         p = PyMem_RawRealloc(buf, bufsize);
         if (p == NULL) {
-            PyErr_NoMemory();
             nomem = 1;
             break;
         }
@@ -259,8 +251,7 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
 #endif
     if (p == NULL) {
         if (nomem == 1) {
-            PyErr_Format(PyExc_RuntimeError,
-                         "getpwnam(): cannot allocate memory: %s", name);
+            PyErr_NoMemory();
         } else {
             PyErr_Format(PyExc_KeyError,
                          "getpwnam(): name not found: %s", name);

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -140,9 +140,14 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
     if (bufsize == -1) {
         bufsize = DEFAULT_BUFFER_SIZE;
     }
-    buf = PyMem_RawMalloc(bufsize);
 
     while(1) {
+        buf2 = PyMem_RawRealloc(buf, bufsize);
+        if (buf2 == NULL) {
+            nomem = 1;
+            break;
+        }
+        buf = buf2;
         status = getpwuid_r(uid, &pwd, buf, bufsize, &p);
         if (status != 0) {
             p = NULL;
@@ -155,12 +160,6 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
             break;
         }
         bufsize <<= 1;
-        buf2 = PyMem_RawRealloc(buf, bufsize);
-        if (p == NULL) {
-            nomem = 1;
-            break;
-        }
-        buf = buf2;
     }
 
     Py_END_ALLOW_THREADS
@@ -222,9 +221,14 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
     if (bufsize == -1) {
         bufsize = DEFAULT_BUFFER_SIZE;
     }
-    buf = PyMem_RawMalloc(bufsize);
 
     while(1) {
+        buf2 = PyMem_RawRealloc(buf, bufsize);
+        if (buf2 == NULL) {
+            nomem = 1;
+            break;
+        }
+        buf = buf2;
         status = getpwnam_r(name, &pwd, buf, bufsize, &p);
         if (status != 0) {
             p = NULL;
@@ -237,12 +241,6 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
             break;
         }
         bufsize <<= 1;
-        buf2 = PyMem_RawRealloc(buf, bufsize);
-        if (p == NULL) {
-            nomem = 1;
-            break;
-        }
-        buf = buf2;
     }
 
     Py_END_ALLOW_THREADS

--- a/configure
+++ b/configure
@@ -11275,8 +11275,9 @@ for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  clock confstr ctermid dup3 execv faccessat fchmod fchmodat fchown fchownat \
  fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
  futimens futimes gai_strerror getentropy \
+ getgrgid_r getgrnam_r \
  getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \
- getpriority getresuid getresgid getpwent getspnam getspent getsid getwd \
+ getpriority getresuid getresgid getpwent getpwnam_r getpwuid_r getspnam getspent getsid getwd \
  if_nameindex \
  initgroups kill killpg lchmod lchown lockf linkat lstat lutimes mmap \
  memrchr mbrtowc mkdirat mkfifo \
@@ -13706,139 +13707,6 @@ fi
 
 
 
-
-
-# checks for re-entrant nss functions
-for ac_func in getpwnam_r
-do :
-  ac_fn_c_check_func "$LINENO" "getpwnam_r" "ac_cv_func_getpwnam_r"
-if test "x$ac_cv_func_getpwnam_r" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_GETPWNAM_R 1
-_ACEOF
-
-
-$as_echo "#define HAVE_GETPWNAM_R 1" >>confdefs.h
-
-
-
-fi
-done
-
-
-for ac_func in getpwuid_r
-do :
-  ac_fn_c_check_func "$LINENO" "getpwuid_r" "ac_cv_func_getpwuid_r"
-if test "x$ac_cv_func_getpwuid_r" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_GETPWUID_R 1
-_ACEOF
-
-
-$as_echo "#define HAVE_GETPWUID_R 1" >>confdefs.h
-
-
-
-fi
-done
-
-
-for ac_func in getgrnam_r
-do :
-  ac_fn_c_check_func "$LINENO" "getgrnam_r" "ac_cv_func_getgrnam_r"
-if test "x$ac_cv_func_getgrnam_r" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_GETGRNAM_R 1
-_ACEOF
-
-
-$as_echo "#define HAVE_GETGRNAM_R 1" >>confdefs.h
-
-
-
-fi
-done
-
-
-for ac_func in getgrgid_r
-do :
-  ac_fn_c_check_func "$LINENO" "getgrgid_r" "ac_cv_func_getgrgid_r"
-if test "x$ac_cv_func_getgrgid_r" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_GETGRGID_R 1
-_ACEOF
-
-
-$as_echo "#define HAVE_GETGRGID_R 1" >>confdefs.h
-
-
-
-fi
-done
-
-
-if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <pwd.h>
-int main(int argc, char*argv[])
-{
-#ifdef NSS_BUFLEN_PASSWD
-    return 0;
-#else
-    return 1;
-#endif
-}
-
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
-
-else
-
-$as_echo "#define NSS_BUFLEN_PASSWD 1024" >>confdefs.h
-
-fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
-
-
-if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <grp.h>
-int main(int argc, char*argv[])
-{
-#ifdef NSS_BUFLEN_GROUP
-    return 0;
-#else
-    return 1;
-#endif
-}
-
-_ACEOF
-if ac_fn_c_try_run "$LINENO"; then :
-
-else
-
-$as_echo "#define NSS_BUFLEN_GROUP 1024" >>confdefs.h
-
-fi
-rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
-  conftest.$ac_objext conftest.beam conftest.$ac_ext
-fi
 
 
 

--- a/configure
+++ b/configure
@@ -781,6 +781,7 @@ infodir
 docdir
 oldincludedir
 includedir
+runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -891,6 +892,7 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
+runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE_TARNAME}'
@@ -1143,6 +1145,15 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
+  -runstatedir | --runstatedir | --runstatedi | --runstated \
+  | --runstate | --runstat | --runsta | --runst | --runs \
+  | --run | --ru | --r)
+    ac_prev=runstatedir ;;
+  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
+  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
+  | --run=* | --ru=* | --r=*)
+    runstatedir=$ac_optarg ;;
+
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1280,7 +1291,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir runstatedir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1433,6 +1444,7 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
+  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -13693,6 +13705,140 @@ fi
 
 
 
+
+
+
+# checks for re-entrant nss functions
+for ac_func in getpwnam_r
+do :
+  ac_fn_c_check_func "$LINENO" "getpwnam_r" "ac_cv_func_getpwnam_r"
+if test "x$ac_cv_func_getpwnam_r" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_GETPWNAM_R 1
+_ACEOF
+
+
+$as_echo "#define HAVE_GETPWNAM_R 1" >>confdefs.h
+
+
+
+fi
+done
+
+
+for ac_func in getpwuid_r
+do :
+  ac_fn_c_check_func "$LINENO" "getpwuid_r" "ac_cv_func_getpwuid_r"
+if test "x$ac_cv_func_getpwuid_r" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_GETPWUID_R 1
+_ACEOF
+
+
+$as_echo "#define HAVE_GETPWUID_R 1" >>confdefs.h
+
+
+
+fi
+done
+
+
+for ac_func in getgrnam_r
+do :
+  ac_fn_c_check_func "$LINENO" "getgrnam_r" "ac_cv_func_getgrnam_r"
+if test "x$ac_cv_func_getgrnam_r" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_GETGRNAM_R 1
+_ACEOF
+
+
+$as_echo "#define HAVE_GETGRNAM_R 1" >>confdefs.h
+
+
+
+fi
+done
+
+
+for ac_func in getgrgid_r
+do :
+  ac_fn_c_check_func "$LINENO" "getgrgid_r" "ac_cv_func_getgrgid_r"
+if test "x$ac_cv_func_getgrgid_r" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_GETGRGID_R 1
+_ACEOF
+
+
+$as_echo "#define HAVE_GETGRGID_R 1" >>confdefs.h
+
+
+
+fi
+done
+
+
+if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <pwd.h>
+int main(int argc, char*argv[])
+{
+#ifdef NSS_BUFLEN_PASSWD
+    return 0;
+#else
+    return 1;
+#endif
+}
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+
+else
+
+$as_echo "#define NSS_BUFLEN_PASSWD 1024" >>confdefs.h
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
+
+
+if test "$cross_compiling" = yes; then :
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "cannot run test program while cross compiling
+See \`config.log' for more details" "$LINENO" 5; }
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+#include <grp.h>
+int main(int argc, char*argv[])
+{
+#ifdef NSS_BUFLEN_GROUP
+    return 0;
+#else
+    return 1;
+#endif
+}
+
+_ACEOF
+if ac_fn_c_try_run "$LINENO"; then :
+
+else
+
+$as_echo "#define NSS_BUFLEN_GROUP 1024" >>confdefs.h
+
+fi
+rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
+  conftest.$ac_objext conftest.beam conftest.$ac_ext
+fi
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -4145,6 +4145,60 @@ AC_SUBST(HAVE_GETHOSTBYNAME_R_3_ARG)
 AC_SUBST(HAVE_GETHOSTBYNAME_R)
 AC_SUBST(HAVE_GETHOSTBYNAME)
 
+# checks for re-entrant nss functions
+AC_CHECK_FUNCS(getpwnam_r,
+  [
+    AC_DEFINE(HAVE_GETPWNAM_R, 1,
+    [Define to 1 if your system has getpwnam_r.])
+  ]
+)
+
+AC_CHECK_FUNCS(getpwuid_r,
+  [
+    AC_DEFINE(HAVE_GETPWUID_R, 1,
+    [Define to 1 if your system has getpwuid_r.])
+  ]
+)
+
+AC_CHECK_FUNCS(getgrnam_r,
+  [
+    AC_DEFINE(HAVE_GETGRNAM_R, 1,
+    [Define to 1 if your system has getgrnam_r.])
+  ]
+)
+
+AC_CHECK_FUNCS(getgrgid_r,
+  [
+    AC_DEFINE(HAVE_GETGRGID_R, 1,
+    [Define to 1 if your system has getgrgid_r.])
+  ]
+)
+
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <pwd.h>
+int main(int argc, char*argv[])
+{
+#ifdef NSS_BUFLEN_PASSWD
+    return 0;
+#else
+    return 1;
+#endif
+}
+]])], [], [AC_DEFINE(NSS_BUFLEN_PASSWD, 1024, [Define default buflen for reentrant pwd functions])])
+
+AC_RUN_IFELSE([AC_LANG_SOURCE([[
+#include <grp.h>
+int main(int argc, char*argv[])
+{
+#ifdef NSS_BUFLEN_GROUP
+    return 0;
+#else
+    return 1;
+#endif
+}
+]])], [], [AC_DEFINE(NSS_BUFLEN_GROUP, 1024, [Define default buflen for reentrant grp functions])])
+
+
 # checks for system services
 # (none yet)
 

--- a/configure.ac
+++ b/configure.ac
@@ -3445,8 +3445,9 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  clock confstr ctermid dup3 execv faccessat fchmod fchmodat fchown fchownat \
  fexecve fdopendir fork fpathconf fstatat ftime ftruncate futimesat \
  futimens futimes gai_strerror getentropy \
+ getgrgid_r getgrnam_r \
  getgrouplist getgroups getlogin getloadavg getpeername getpgid getpid \
- getpriority getresuid getresgid getpwent getspnam getspent getsid getwd \
+ getpriority getresuid getresgid getpwent getpwnam_r getpwuid_r getspnam getspent getsid getwd \
  if_nameindex \
  initgroups kill killpg lchmod lchown lockf linkat lstat lutimes mmap \
  memrchr mbrtowc mkdirat mkfifo \
@@ -4144,60 +4145,6 @@ AC_SUBST(HAVE_GETHOSTBYNAME_R_5_ARG)
 AC_SUBST(HAVE_GETHOSTBYNAME_R_3_ARG)
 AC_SUBST(HAVE_GETHOSTBYNAME_R)
 AC_SUBST(HAVE_GETHOSTBYNAME)
-
-# checks for re-entrant nss functions
-AC_CHECK_FUNCS(getpwnam_r,
-  [
-    AC_DEFINE(HAVE_GETPWNAM_R, 1,
-    [Define to 1 if your system has getpwnam_r.])
-  ]
-)
-
-AC_CHECK_FUNCS(getpwuid_r,
-  [
-    AC_DEFINE(HAVE_GETPWUID_R, 1,
-    [Define to 1 if your system has getpwuid_r.])
-  ]
-)
-
-AC_CHECK_FUNCS(getgrnam_r,
-  [
-    AC_DEFINE(HAVE_GETGRNAM_R, 1,
-    [Define to 1 if your system has getgrnam_r.])
-  ]
-)
-
-AC_CHECK_FUNCS(getgrgid_r,
-  [
-    AC_DEFINE(HAVE_GETGRGID_R, 1,
-    [Define to 1 if your system has getgrgid_r.])
-  ]
-)
-
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <pwd.h>
-int main(int argc, char*argv[])
-{
-#ifdef NSS_BUFLEN_PASSWD
-    return 0;
-#else
-    return 1;
-#endif
-}
-]])], [], [AC_DEFINE(NSS_BUFLEN_PASSWD, 1024, [Define default buflen for reentrant pwd functions])])
-
-AC_RUN_IFELSE([AC_LANG_SOURCE([[
-#include <grp.h>
-int main(int argc, char*argv[])
-{
-#ifdef NSS_BUFLEN_GROUP
-    return 0;
-#else
-    return 1;
-#endif
-}
-]])], [], [AC_DEFINE(NSS_BUFLEN_GROUP, 1024, [Define default buflen for reentrant grp functions])])
-
 
 # checks for system services
 # (none yet)

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -403,10 +403,10 @@
 /* Define to 1 if you have the `getentropy' function. */
 #undef HAVE_GETENTROPY
 
-/* Define to 1 if your system has getgrgid_r. */
+/* Define to 1 if you have the `getgrgid_r' function. */
 #undef HAVE_GETGRGID_R
 
-/* Define to 1 if your system has getgrnam_r. */
+/* Define to 1 if you have the `getgrnam_r' function. */
 #undef HAVE_GETGRNAM_R
 
 /* Define to 1 if you have the `getgrouplist' function. */
@@ -463,10 +463,10 @@
 /* Define to 1 if you have the `getpwent' function. */
 #undef HAVE_GETPWENT
 
-/* Define to 1 if your system has getpwnam_r. */
+/* Define to 1 if you have the `getpwnam_r' function. */
 #undef HAVE_GETPWNAM_R
 
-/* Define to 1 if your system has getpwuid_r. */
+/* Define to 1 if you have the `getpwuid_r' function. */
 #undef HAVE_GETPWUID_R
 
 /* Define to 1 if the getrandom() function is available */
@@ -1295,12 +1295,6 @@
 
 /* Define if mvwdelch in curses.h is an expression. */
 #undef MVWDELCH_IS_EXPRESSION
-
-/* Define default buflen for reentrant grp functions */
-#undef NSS_BUFLEN_GROUP
-
-/* Define default buflen for reentrant pwd functions */
-#undef NSS_BUFLEN_PASSWD
 
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -403,6 +403,12 @@
 /* Define to 1 if you have the `getentropy' function. */
 #undef HAVE_GETENTROPY
 
+/* Define to 1 if your system has getgrgid_r. */
+#undef HAVE_GETGRGID_R
+
+/* Define to 1 if your system has getgrnam_r. */
+#undef HAVE_GETGRNAM_R
+
 /* Define to 1 if you have the `getgrouplist' function. */
 #undef HAVE_GETGROUPLIST
 
@@ -456,6 +462,12 @@
 
 /* Define to 1 if you have the `getpwent' function. */
 #undef HAVE_GETPWENT
+
+/* Define to 1 if your system has getpwnam_r. */
+#undef HAVE_GETPWNAM_R
+
+/* Define to 1 if your system has getpwuid_r. */
+#undef HAVE_GETPWUID_R
 
 /* Define to 1 if the getrandom() function is available */
 #undef HAVE_GETRANDOM
@@ -1283,6 +1295,12 @@
 
 /* Define if mvwdelch in curses.h is an expression. */
 #undef MVWDELCH_IS_EXPRESSION
+
+/* Define default buflen for reentrant grp functions */
+#undef NSS_BUFLEN_GROUP
+
+/* Define default buflen for reentrant pwd functions */
+#undef NSS_BUFLEN_PASSWD
 
 /* Define to the address where bug reports for this package should be sent. */
 #undef PACKAGE_BUGREPORT


### PR DESCRIPTION
Especially when using more complex nss modules the call might that an
unknown amount of time depending on the service in question.
This makes sures others threads are not blocked waiting the call to
finish.

<!-- issue-number: bpo-33625 -->
https://bugs.python.org/issue33625
<!-- /issue-number -->
