### PR TITLE
[3.7] bpo-33353: Fix test_asyncio on FreeBSD

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2095,7 +2095,7 @@ class SubprocessTestsMixin:
 
 class SendfileBase:
 
-    DATA = b"12345abcde" * 160 * 1024  # 160 KiB
+    DATA = b"12345abcde" * 16 * 1024  # 160 KiB
 
     @classmethod
     def setUpClass(cls):
@@ -2208,7 +2208,7 @@ class SockSendfileMixin(SendfileBase):
         self.assertEqual(self.file.tell(), 0)
 
     def test_sock_sendfile_mix_with_regular_send(self):
-        buf = b'1234567890' * 1024 * 1024  # 10 MB
+        buf = b"X" * 160 * 1024  # 160 KiB
         sock, proto = self.prepare_socksendfile()
         self.run_loop(self.loop.sock_sendall(sock, buf))
         ret = self.run_loop(self.loop.sock_sendfile(sock, self.file))


### PR DESCRIPTION
* bpo-33353: test_asyncio uses smaller sendfile data (#7083)
* bpo-33353: test_asyncio set SO_SNDBUF after connect (GH-7086)


<!-- issue-number: bpo-33353 -->
https://bugs.python.org/issue33353
<!-- /issue-number -->
