### PR TITLE
bpo-33629: Prevent coredump in test_importlib

### DIFF
--- a/Lib/test/test_importlib/extension/test_loader.py
+++ b/Lib/test/test_importlib/extension/test_loader.py
@@ -275,10 +275,13 @@ class MultiPhaseExtensionModuleTests(abc.LoaderTests):
             (Multiphase initialization modules only)
         '''
         script = """if True:
+                from test import support
                 import importlib.util as util
                 spec = util.find_spec('_testmultiphase')
                 spec.name = '_testmultiphase_with_bad_traverse'
-                m = spec.loader.create_module(spec)"""
+
+                with support.SuppressCrashReport():
+                    m = spec.loader.create_module(spec)"""
         assert_python_failure("-c", script)
 
 


### PR DESCRIPTION
bpo-32374, bpo-33629: Use support.SuppressCrashReport() in
test_bad_traverse() of MultiPhaseExtensionModuleTests to prevent
leaking a core dump file.

<!-- issue-number: bpo-33629 -->
https://bugs.python.org/issue33629
<!-- /issue-number -->
