### PR TITLE
[2.7] bpo-33622: Fix issues with handling errors in the GC. (GH-7078)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-05-23-20-46-14.bpo-33622.xPucO9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-05-23-20-46-14.bpo-33622.xPucO9.rst
@@ -1,0 +1,4 @@
+Fixed a leak when the garbage collector fails to add an object with the
+``__del__`` method or referenced by it into the :data:`gc.garbage` list.
+:c:func:`PyGC_Collect` can now be called when an exception is set and
+preserves it.


### PR DESCRIPTION
* Fixed a leak when the GC fails to add an object with `__del__` into the `gc.garbage` list.
* `PyGC_Collect()` can now be called when an exception is set and preserves it.
(cherry picked from commit 301e3cc8a5bc68c5347ab6ac6f83428000d31ab2)


<!-- issue-number: bpo-33622 -->
https://bugs.python.org/issue33622
<!-- /issue-number -->
