### PR TITLE
bpo-32493: Fix uuid.uuid1() on FreeBSD.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-05-24-17-41-36.bpo-32493.5tAoAu.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-24-17-41-36.bpo-32493.5tAoAu.rst
@@ -1,0 +1,1 @@
+Fixed :func:`uuid.uuid1` on FreeBSD.


### PR DESCRIPTION


<!-- issue-number: bpo-32493 -->
https://bugs.python.org/issue32493
<!-- /issue-number -->
