### PR TITLE
bpo-32493: Fix uuid.uuid1() on FreeBSD.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-05-24-17-41-36.bpo-32493.5tAoAu.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-24-17-41-36.bpo-32493.5tAoAu.rst
@@ -1,0 +1,1 @@
+Fixed :func:`uuid.uuid1` on FreeBSD.

--- a/Modules/_uuidmodule.c
+++ b/Modules/_uuidmodule.c
@@ -19,10 +19,16 @@ py_uuid_generate_time_safe(PyObject *Py_UNUSED(context),
 
     res = uuid_generate_time_safe(uuid);
     return Py_BuildValue("y#i", (const char *) uuid, sizeof(uuid), res);
-#elif HAVE_UUID_CREATE
+#elif defined(HAVE_UUID_CREATE)
     uint32_t status;
     uuid_create(&uuid, &status);
+# if defined(HAVE_UUID_ENC_BE)
+    unsigned char buf[sizeof(uuid)];
+    uuid_enc_be(buf, &uuid);
+    return Py_BuildValue("y#i", buf, sizeof(uuid), (int) status);
+# else
     return Py_BuildValue("y#i", (const char *) &uuid, sizeof(uuid), (int) status);
+# endif
 #else
     uuid_generate_time(uuid);
     return Py_BuildValue("y#O", (const char *) uuid, sizeof(uuid), Py_None);
@@ -58,6 +64,7 @@ PyInit__uuid(void)
     }
     if (PyModule_AddIntConstant(mod, "has_uuid_generate_time_safe",
                                 has_uuid_generate_time_safe) < 0) {
+        Py_DECREF(mod);
         return NULL;
     }
 

--- a/configure
+++ b/configure
@@ -9584,6 +9584,40 @@ $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+# Little-endian FreeBSD, OpenBSD and NetBSD needs encoding into an octet
+# stream in big-endian byte-order
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for uuid_enc_be" >&5
+$as_echo_n "checking for uuid_enc_be... " >&6; }
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#include <uuid.h>
+int
+main ()
+{
+
+#ifndef uuid_enc_be
+uuid_t uuid;
+unsigned char buf[sizeof(uuid)];
+uuid_enc_be(buf, &uuid);
+#endif
+
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+$as_echo "#define HAVE_UUID_ENC_BE 1" >>confdefs.h
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 # 'Real Time' functions on Solaris
 # posix4 on Solaris 2.6
 # pthread (first!) on Linux

--- a/configure.ac
+++ b/configure.ac
@@ -2696,6 +2696,21 @@ void *x = uuid_create
   [AC_MSG_RESULT(no)]
 )
 
+# Little-endian FreeBSD, OpenBSD and NetBSD needs encoding into an octet
+# stream in big-endian byte-order
+AC_MSG_CHECKING(for uuid_enc_be)
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <uuid.h>]], [[
+#ifndef uuid_enc_be
+uuid_t uuid;
+unsigned char buf[sizeof(uuid)];
+uuid_enc_be(buf, &uuid);
+#endif
+]])],
+  [AC_DEFINE(HAVE_UUID_ENC_BE, 1, Define if uuid_enc_be() exists.)
+   AC_MSG_RESULT(yes)],
+  [AC_MSG_RESULT(no)]
+)
+
 # 'Real Time' functions on Solaris
 # posix4 on Solaris 2.6
 # pthread (first!) on Linux

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -1215,6 +1215,9 @@
 /* Define if uuid_create() exists. */
 #undef HAVE_UUID_CREATE
 
+/* Define if uuid_enc_be() exists. */
+#undef HAVE_UUID_ENC_BE
+
 /* Define if uuid_generate_time_safe() exists. */
 #undef HAVE_UUID_GENERATE_TIME_SAFE
 


### PR DESCRIPTION
An alternate solution using `uuid_enc_be()`.

<!-- issue-number: bpo-32493 -->
https://bugs.python.org/issue32493
<!-- /issue-number -->
