### PR TITLE
bpo-33644: Fix signatures of tp_finalize handlers in testing code.

### DIFF
--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -23,11 +23,10 @@ Example_traverse(ExampleObject *self, visitproc visit, void *arg)
     return 0;
 }
 
-static int
+static void
 Example_finalize(ExampleObject *self)
 {
     Py_CLEAR(self->x_attr);
-    return 0;
 }
 
 static PyObject *

--- a/Modules/xxlimited.c
+++ b/Modules/xxlimited.c
@@ -47,11 +47,10 @@ Xxo_traverse(XxoObject *self, visitproc visit, void *arg)
     return 0;
 }
 
-static int
+static void
 Xxo_finalize(XxoObject *self)
 {
     Py_CLEAR(self->x_attr);
-    return 0;
 }
 
 static PyObject *


### PR DESCRIPTION


<!-- issue-number: bpo-33644 -->
https://bugs.python.org/issue33644
<!-- /issue-number -->
