### PR TITLE
[2.7] bpo-33645: Fix an "unknown parsing error" in the parser.

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -5,6 +5,7 @@ from test.test_support import run_unittest, check_syntax_error, \
                               check_py3k_warnings
 import unittest
 import sys
+import warnings
 # testing import *
 from sys import *
 
@@ -628,7 +629,6 @@ hello world
             with check_py3k_warnings((warntext, DeprecationWarning)):
                 compile(code, '<test string>', 'exec')
             if sys.py3kwarning:
-                import warnings
                 with warnings.catch_warnings():
                     warnings.filterwarnings('error', category=DeprecationWarning)
                     with self.assertRaises(SyntaxError) as cm:
@@ -883,6 +883,13 @@ hello world
         with check_py3k_warnings(('<> not supported in 3.x; use !=',
                                   DeprecationWarning)):
             if eval('1 < 1 > 1 == 1 >= 1 <= 1 <> 1 != 1 in 1 not in 1 is 1 is not 1'): pass
+        if sys.py3kwarning:
+            with warnings.catch_warnings():
+                warnings.filterwarnings('error', category=DeprecationWarning)
+                with self.assertRaises(DeprecationWarning) as cm:
+                    compile('1 <> 1', '<test string>', 'eval')
+                self.assertIn('<> not supported in 3.x; use !=',
+                              str(cm.exception))
 
     def test_binary_mask_ops(self):
         x = 1 & 1

--- a/Misc/NEWS.d/next/Core and Builtins/2018-05-25-18-20-04.bpo-33645.GYGIPH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-05-25-18-20-04.bpo-33645.GYGIPH.rst
@@ -1,0 +1,2 @@
+Fixed an "unknown parsing error" on parsing the "<>" operator when run
+Python with both options ``-3`` and ``-We``.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1636,6 +1636,8 @@ tok_get(register struct tok_state *tok, char **p_start, char **p_end)
                                    "<> not supported in 3.x; use !=",
                                    tok->filename, tok->lineno,
                                    NULL, NULL)) {
+                tok->done = E_ERROR;
+                tok->cur = tok->inp;
                 return ERRORTOKEN;
             }
         }


### PR DESCRIPTION
It is reproduced when parse the "<>" operator and run
Python with both options -3 and -We.


<!-- issue-number: bpo-33645 -->
https://bugs.python.org/issue33645
<!-- /issue-number -->
