### PR TITLE
[2.7] bpo-33595: Fix lambda parameters being refered as arguments (GH…

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -457,7 +457,7 @@ Glossary
    lambda
       An anonymous inline function consisting of a single :term:`expression`
       which is evaluated when the function is called.  The syntax to create
-      a lambda function is ``lambda [arguments]: expression``
+      a lambda function is ``lambda [parameters]: expression``
 
    LBYL
       Look before you leap.  This coding style explicitly tests for

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -1390,10 +1390,10 @@ Lambdas
 
 Lambda expressions (sometimes called lambda forms) have the same syntactic position as
 expressions.  They are a shorthand to create anonymous functions; the expression
-``lambda arguments: expression`` yields a function object.  The unnamed object
+``lambda parameters: expression`` yields a function object.  The unnamed object
 behaves like a function object defined with ::
 
-   def name(arguments):
+   def <lambda>(parameters):
        return expression
 
 See section :ref:`function` for the syntax of parameter lists.  Note that


### PR DESCRIPTION
…-7037)

(cherry picked from commit 268cc7c)

Co-authored-by: Andrés Delfino adelfino@gmail.com

<!-- issue-number: bpo-33595 -->
https://bugs.python.org/issue33595
<!-- /issue-number -->
