### PR TITLE
bpo-13886: Fix test_builtin.PtyTests tests when readline is loaded

### DIFF
--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1710,16 +1710,19 @@ class PtyTests(unittest.TestCase):
             'if result != {expected!a}:\n'
             '    raise AssertionError("unexpected input " + ascii(result))\n'
         )
+        sentinel = 'Hé, this is before calling input()'
         if stdio_encoding:
             expected = terminal_input.decode(stdio_encoding, 'surrogateescape')
+            exp_sentinel = sentinel.encode(stdio_encoding, errors='replace')
         else:
             expected = terminal_input.decode(sys.stdin.encoding)  # what else?
+            exp_sentinel = sentinel.encode(sys.stdout.encoding)
         code = template.format(
             stdio_encoding=stdio_encoding, prompt=prompt, expected=expected,
-            sentinel='sentinel')
+            sentinel=sentinel)
 
         # Without Readline module
-        self.assert_script(code, terminal_input, b'sentinel')
+        self.assert_script(code, terminal_input, exp_sentinel)
 
         readline_encoding = locale.getpreferredencoding()
         try:
@@ -1730,7 +1733,7 @@ class PtyTests(unittest.TestCase):
             pass
         else:
             self.assert_script('import readline\n' + code, terminal_input,
-                               b'sentinel')
+                               exp_sentinel)
 
     def assert_script(self, code, terminal_input, expected):
         cmd = (sys.executable, '-c', code)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1729,7 +1729,7 @@ class PtyTests(unittest.TestCase):
             self.assert_script('import readline\n' + code, terminal_input)
 
     def assert_script(self, code, terminal_input):
-        cmd = (sys.executable, '-s', '-c', code)
+        cmd = (sys.executable, '-c', code)
         [master, slave] = pty.openpty()
         proc = subprocess.Popen(cmd, stdin=slave, stdout=slave, stderr=slave)
         os.close(slave)
@@ -1748,7 +1748,7 @@ class PtyTests(unittest.TestCase):
 
     def test_input_tty_non_ascii_unicode_errors(self):
         # Check stdin/stdout error handler used when invoking PyOS_Readline()
-        self.check_input_tty("prompté", b"quux\xe9", "ascii")
+        self.check_input_tty("prompté", "quuxé".encode("utf-8"), "ascii")
 
     def test_input_no_stdout_fileno(self):
         # Issue #24402: If stdin is the original terminal but stdout.fileno()

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1710,7 +1710,7 @@ class PtyTests(unittest.TestCase):
             'if result != {expected!a}:\n'
             '    raise AssertionError("unexpected input " + ascii(result))\n'
         )
-        sentinel = 'Hé, this is before calling input()'
+        sentinel = '123'
         if stdio_encoding:
             expected = terminal_input.decode(stdio_encoding, 'surrogateescape')
             exp_sentinel = sentinel.encode(stdio_encoding, errors='replace')
@@ -1740,7 +1740,6 @@ class PtyTests(unittest.TestCase):
         [master, slave] = pty.openpty()
         proc = subprocess.Popen(cmd, stdin=slave, stdout=slave, stderr=slave)
         os.close(slave)
-        output = "could not read process output"
         with proc, os.fdopen(master, "wb", closefd=False) as writer:
             # Wait for the process to be fully started.
             sentinel = os.read(master, len(expected))

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1737,14 +1737,17 @@ class PtyTests(unittest.TestCase):
         [master, slave] = pty.openpty()
         proc = subprocess.Popen(cmd, stdin=slave, stdout=slave, stderr=slave)
         os.close(slave)
+        output = "could not read process output"
         with proc, os.fdopen(master, "wb", closefd=False) as writer:
             # Wait for the process to be fully started.
             sentinel = os.read(master, len(expected))
             writer.write(terminal_input + b"\r\n")
+            writer.flush()
             # Assert after writing to the process to avoid a deadlock if the
             # assertion fails.
             self.assertEqual(sentinel, expected)
-        self.assertEqual(proc.returncode, 0, self.final_output(master))
+            output = self.final_output(master)
+        self.assertEqual(proc.returncode, 0, output)
 
     def test_input_tty(self):
         # Test input() functionality when wired to a tty (the code path

--- a/Misc/NEWS.d/next/Tests/2018-05-26-18-09-39.bpo-13886.QdOme0.rst
+++ b/Misc/NEWS.d/next/Tests/2018-05-26-18-09-39.bpo-13886.QdOme0.rst
@@ -1,0 +1,1 @@
+Fix test_builtin.PtyTests tests when readline is loaded.


### PR DESCRIPTION


<!-- issue-number: bpo-13886 -->
https://bugs.python.org/issue13886
<!-- /issue-number -->
