### PR TITLE
bpo-33655: Also ignore test_posix_fallocate failures on BSD platforms

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -343,7 +343,12 @@ class PosixTester(unittest.TestCase):
         except OSError as inst:
             # issue10812, ZFS doesn't appear to support posix_fallocate,
             # so skip Solaris-based since they are likely to have ZFS.
-            if inst.errno != errno.EINVAL or not sys.platform.startswith("sunos"):
+            # issue33655: Also ignore EINVAL on *BSD since ZFS is also
+            # often used there.
+            if inst.errno == errno.EINVAL and sys.platform.startswith(
+                ('sunos', 'freebsd', 'netbsd', 'openbsd', 'gnukfreebsd')):
+                raise unittest.SkipTest("test may fail on ZFS filesystems")
+            else:
                 raise
         finally:
             os.close(fd)

--- a/Misc/NEWS.d/next/Tests/2018-05-26-16-01-40.bpo-33655.Frb4LA.rst
+++ b/Misc/NEWS.d/next/Tests/2018-05-26-16-01-40.bpo-33655.Frb4LA.rst
@@ -1,0 +1,2 @@
+Ignore test_posix_fallocate failures on BSD platforms that might be due to
+running on ZFS.


### PR DESCRIPTION
The failure may be due to the use oF ZFS, a case we already ignore
for Solaris-based systems where ZFS is frequently used.


<!-- issue-number: bpo-33655 -->
https://bugs.python.org/issue33655
<!-- /issue-number -->
