### PR TITLE
bpo-30654: Do not reset SIGINT handler to SIG_DFL in finisignal

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-05-28-12-28-53.bpo-30654.9fDJye.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-05-28-12-28-53.bpo-30654.9fDJye.rst
@@ -1,0 +1,2 @@
+Fixed reset of the SIGINT handler to SIG_DFL on interpreter shutdown even
+when there was a custom handler set previously. Patch by Philipp Kerling.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -126,13 +126,6 @@ static PyObject *DefaultHandler;
 static PyObject *IgnoreHandler;
 static PyObject *IntHandler;
 
-/* On Solaris 8, gcc will produce a warning that the function
-   declaration is not a prototype. This is caused by the definition of
-   SIG_DFL as (void (*)())0; the correct declaration would have been
-   (void (*)(int))0. */
-
-static PyOS_sighandler_t old_siginthandler = SIG_DFL;
-
 #ifdef MS_WINDOWS
 static HANDLE sigint_event = NULL;
 #endif
@@ -1336,7 +1329,7 @@ PyInit__signal(void)
         /* Install default int handler */
         Py_INCREF(IntHandler);
         Py_SETREF(Handlers[SIGINT].func, IntHandler);
-        old_siginthandler = PyOS_setsig(SIGINT, signal_handler);
+        PyOS_setsig(SIGINT, signal_handler);
     }
 
 #ifdef SIGHUP
@@ -1542,14 +1535,11 @@ finisignal(void)
     int i;
     PyObject *func;
 
-    PyOS_setsig(SIGINT, old_siginthandler);
-    old_siginthandler = SIG_DFL;
-
     for (i = 1; i < NSIG; i++) {
         func = Handlers[i].func;
         _Py_atomic_store_relaxed(&Handlers[i].tripped, 0);
         Handlers[i].func = NULL;
-        if (i != SIGINT && func != NULL && func != Py_None &&
+        if (func != NULL && func != Py_None &&
             func != DefaultHandler && func != IgnoreHandler)
             PyOS_setsig(i, SIG_DFL);
         Py_XDECREF(func);


### PR DESCRIPTION
Instead of saving old_siginthandler which will always be SIG_DFL, just use the normal reset code. This means that SIGINT will *not* be reset to SIG_DFL if it had a custom C handler during initialization, since `func` will be `Py_None` then.

I'm not sure if this is the intended behavior. But the prior behavior was broken, so it's an improvement.

https://bugs.python.org/issue30654

Supersedes #2162 (now for master branch)

<!-- issue-number: bpo-30654 -->
https://bugs.python.org/issue30654
<!-- /issue-number -->
