### PR TITLE
bpo-32374: Enhance test_importlib.test_bad_traverse()

### DIFF
--- a/Lib/test/test_importlib/extension/test_loader.py
+++ b/Lib/test/test_importlib/extension/test_loader.py
@@ -3,13 +3,12 @@ from .. import util
 
 machinery = util.import_importlib('importlib.machinery')
 
+import importlib.util
 import os.path
+import subprocess
 import sys
 import types
 import unittest
-import importlib.util
-import importlib
-from test.support.script_helper import assert_python_failure
 
 class LoaderTests(abc.LoaderTests):
 
@@ -282,7 +281,11 @@ class MultiPhaseExtensionModuleTests(abc.LoaderTests):
 
                 with support.SuppressCrashReport():
                     m = spec.loader.create_module(spec)"""
-        assert_python_failure("-c", script)
+
+        proc = subprocess.run([sys.executable, "-c", script])
+        # Expect a crash: exit code different than 0 (success)
+        # and 1 (generic Python error).
+        self.assertNotIn(proc.returncode, [0, 1])
 
 
 (Frozen_MultiPhaseExtensionModuleTests,


### PR DESCRIPTION
Make test_bad_traverse() fails if the script raises a Python
exception: generic exit code 1. The test expects a crash which means
an exit code different than 0 and 1.

<!-- issue-number: bpo-32374 -->
https://bugs.python.org/issue32374
<!-- /issue-number -->
