### PR TITLE
bpo-33614: Ensures module definition files for the stable ABI on Windows are correctly regenerated

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-05-28-11-40-22.bpo-33614.28e0sE.rst
+++ b/Misc/NEWS.d/next/Build/2018-05-28-11-40-22.bpo-33614.28e0sE.rst
@@ -1,0 +1,2 @@
+Ensures module definition files for the stable ABI on Windows are correctly
+regenerated.

--- a/PCbuild/find_msbuild.bat
+++ b/PCbuild/find_msbuild.bat
@@ -47,5 +47,13 @@
 @exit /b 1
 
 :found
-@echo Using %MSBUILD% (found in the %_Py_MSBuild_Source%)
+@pushd %MSBUILD% >nul 2>nul
+@if not ERRORLEVEL 1 @(
+  @if exist msbuild.exe @(set MSBUILD="%CD%\msbuild.exe") else @(set MSBUILD=)
+  @popd
+)
+
+@if defined MSBUILD @echo Using %MSBUILD% (found in the %_Py_MSBuild_Source%)
+@if not defined MSBUILD @echo Failed to find MSBuild
 @set _Py_MSBuild_Source=
+@if not defined MSBUILD @exit /b 1

--- a/PCbuild/python3dll.vcxproj
+++ b/PCbuild/python3dll.vcxproj
@@ -89,13 +89,17 @@
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
   
-  <Target Name="BuildPython3_dDef" BeforeTargets="BuildStubDef" Inputs="..\PC\python3.def" Outputs="$(IntDir)python3_d.def" Condition="$(Configuration) == 'Debug'">
+  <Target Name="BuildPython3_dDef" BeforeTargets="BuildStubDef" Condition="$(Configuration) == 'Debug'">
     <ItemGroup>
       <_DefLines Remove="@(_DefLines)" />
       <_Lines Remove="@(_Lines)" />
+      <_OriginalLines Remove="@(_OriginalLines)" />
     </ItemGroup>
     <ReadLinesFromFile File="..\PC\python3.def">
       <Output TaskParameter="Lines" ItemName="_DefLines" />
+    </ReadLinesFromFile>
+    <ReadLinesFromFile File="$(IntDir)python3_d.def" Condition="Exists('$(IntDir)python3_d.def')">
+      <Output TaskParameter="Lines" ItemName="_OriginalLines" />
     </ReadLinesFromFile>
     <PropertyGroup>
       <_Pattern1>(=python$(MajorVersionNumber)$(MinorVersionNumber))\.</_Pattern1>
@@ -109,16 +113,22 @@
       </_Lines>
     </ItemGroup>
     <MakeDir Directories="$(IntDir)" />
-    <WriteLinesToFile File="$(IntDir)python3_d.def" Lines="@(_Lines->'%(New)')" Overwrite="true" />
+    <Message Text="Updating python3_d.def" Condition="@(_Lines->'%(New)') != @(_OriginalLines)" Importance="high" />
+    <WriteLinesToFile File="$(IntDir)python3_d.def" Lines="@(_Lines->'%(New)')" Overwrite="true"
+                      Condition="@(_Lines->'%(New)') != @(_OriginalLines)" />
   </Target>
   
-  <Target Name="BuildStubDef" BeforeTargets="PreLinkEvent" Inputs="..\PC\python3.def" Outputs="$(IntDir)python3stub.def">
+  <Target Name="BuildStubDef" BeforeTargets="PreLinkEvent">
     <ItemGroup>
       <_DefLines Remove="@(_DefLines)" />
       <_Lines Remove="@(_Lines)" />
+      <_OriginalLines Remove="@(_OriginalLines)" />
     </ItemGroup>
     <ReadLinesFromFile File="..\PC\python3.def">
       <Output TaskParameter="Lines" ItemName="_DefLines" />
+    </ReadLinesFromFile>
+    <ReadLinesFromFile File="$(IntDir)python3stub.def" Condition="Exists('$(IntDir)python3stub.def')">
+      <Output TaskParameter="Lines" ItemName="_OriginalLines" />
     </ReadLinesFromFile>
     <PropertyGroup>
       <_Pattern>^[\w.]+=.+?\.([^ ]+).*$</_Pattern>
@@ -132,6 +142,8 @@
       <_Lines Include="@(_Symbols->'%(Symbol)')" />
     </ItemGroup>
     <MakeDir Directories="$(IntDir)" />
-    <WriteLinesToFile File="$(IntDir)python3stub.def" Lines="@(_Lines)" Overwrite="true" />
+    <Message Text="Updating python3stub.def" Condition="@(_OriginalLines) != @(_Lines)" Importance="high" />
+    <WriteLinesToFile File="$(IntDir)python3stub.def" Lines="@(_Lines)" Overwrite="true"
+                      Condition="@(_DefLines) != @(_Lines)" />
   </Target>
 </Project>


### PR DESCRIPTION
Also includes a minor improvement to `find_MSBuild.bat` to handle the case where `%MSBUILD%` is set to the directory rather than the executable.