### PR TITLE
bpo-33614: Override exit code in find_msbuild.bat

### DIFF
--- a/PCbuild/find_msbuild.bat
+++ b/PCbuild/find_msbuild.bat
@@ -57,3 +57,4 @@
 @if not defined MSBUILD @echo Failed to find MSBuild
 @set _Py_MSBuild_Source=
 @if not defined MSBUILD @exit /b 1
+@exit /b 0

--- a/PCbuild/python3dll.vcxproj
+++ b/PCbuild/python3dll.vcxproj
@@ -142,8 +142,8 @@
       <_Lines Include="@(_Symbols->'%(Symbol)')" />
     </ItemGroup>
     <MakeDir Directories="$(IntDir)" />
-    <Message Text="Updating python3stub.def" Condition="@(_OriginalLines) != @(_Lines)" Importance="high" />
+    <Message Text="Updating python3stub.def" Condition="@(_Lines) != @(_OriginalLines)" Importance="high" />
     <WriteLinesToFile File="$(IntDir)python3stub.def" Lines="@(_Lines)" Overwrite="true"
-                      Condition="@(_DefLines) != @(_Lines)" />
+                      Condition="@(_Lines) != @(_OriginalLines)" />
   </Target>
 </Project>


### PR DESCRIPTION


<!-- issue-number: bpo-33614 -->
https://bugs.python.org/issue33614
<!-- /issue-number -->
