### PR TITLE
bpo-33674: asyncio: Fix SSLProtocol race

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -592,7 +592,7 @@ class SSLProtocol(protocols.Protocol):
         # (b'', 1) is a special value in _process_write_backlog() to do
         # the SSL handshake
         self._write_backlog.append((b'', 1))
-        self._loop.call_soon(self._process_write_backlog)
+        self._process_write_backlog()
         self._handshake_timeout_handle = \
             self._loop.call_later(self._ssl_handshake_timeout,
                                   self._check_handshake_timeout)

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -592,10 +592,10 @@ class SSLProtocol(protocols.Protocol):
         # (b'', 1) is a special value in _process_write_backlog() to do
         # the SSL handshake
         self._write_backlog.append((b'', 1))
-        self._process_write_backlog()
         self._handshake_timeout_handle = \
             self._loop.call_later(self._ssl_handshake_timeout,
                                   self._check_handshake_timeout)
+        self._process_write_backlog()
 
     def _check_handshake_timeout(self):
         if self._in_handshake is True:

--- a/Misc/NEWS.d/next/Library/2018-05-28-22-49-59.bpo-33674.6LFFj7.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-28-22-49-59.bpo-33674.6LFFj7.rst
@@ -1,0 +1,4 @@
+Fix a race condition in SSLProtocol.connection_made() of asyncio.sslproto:
+start immediately the handshake instead of using call_soon(). Previously,
+data_received() could be called before the handshake started, causing the
+handshake to hang or fail.


### PR DESCRIPTION
Fix a race condition in SSLProtocol.connection_made() of
asyncio.sslproto: start immediately the handshake instead of using
call_soon(). Previously, data_received() could be called before the
handshake started, causing the handshake to hang or fail.

<!-- issue-number: bpo-33674 -->
https://bugs.python.org/issue33674
<!-- /issue-number -->
