### PR TITLE
[3.6] bpo-33674: asyncio: Fix SSLProtocol race (GH-7175)

### DIFF
--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -574,7 +574,7 @@ class SSLProtocol(protocols.Protocol):
         # (b'', 1) is a special value in _process_write_backlog() to do
         # the SSL handshake
         self._write_backlog.append((b'', 1))
-        self._loop.call_soon(self._process_write_backlog)
+        self._process_write_backlog()
 
     def _on_handshake_complete(self, handshake_exc):
         self._in_handshake = False

--- a/Misc/NEWS.d/next/Library/2018-05-28-22-49-59.bpo-33674.6LFFj7.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-28-22-49-59.bpo-33674.6LFFj7.rst
@@ -1,0 +1,4 @@
+Fix a race condition in SSLProtocol.connection_made() of asyncio.sslproto:
+start immediately the handshake instead of using call_soon(). Previously,
+data_received() could be called before the handshake started, causing the
+handshake to hang or fail.


### PR DESCRIPTION
Fix a race condition in SSLProtocol.connection_made() of
asyncio.sslproto: start immediately the handshake instead of using
call_soon(). Previously, data_received() could be called before the
handshake started, causing the handshake to hang or fail.

(cherry picked from commit be00a5583a2cb696335c527b921d1868266a42c6)

<!-- issue-number: bpo-33674 -->
https://bugs.python.org/issue33674
<!-- /issue-number -->
