### PR TITLE
[3.6] bpo-32878: Adds documentation for st_ino on Windows (GH-5764)

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2263,7 +2263,13 @@ features:
 
    .. attribute:: st_ino
 
-      Inode number.
+      Platform dependent, but if non-zero, uniquely identifies the
+      file for a given value of ``st_dev``. Typically:
+
+      * the inode number on Unix,
+      * the `file index
+        <https://msdn.microsoft.com/en-us/library/aa363788>`_ on
+        Windows
 
    .. attribute:: st_dev
 
@@ -2415,6 +2421,10 @@ features:
 
    .. versionadded:: 3.5
       Added the :attr:`st_file_attributes` member on Windows.
+
+   .. versionchanged:: 3.5
+      Windows now returns the file index as :attr:`st_ino` when
+      available.
 
 
 .. function:: stat_float_times([newvalue])


### PR DESCRIPTION


<!-- issue-number: bpo-32878 -->
https://bugs.python.org/issue32878
<!-- /issue-number -->
