### PR TITLE
bpo-31639: Change ThreadedHTTPServer to ThreadingHTTPServer class name

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -33,7 +33,7 @@ handler.  Code to create and run the server looks like this::
    :attr:`server_port`. The server is accessible by the handler, typically
    through the handler's :attr:`server` instance variable.
 
-.. class:: ThreadedHTTPServer(server_address, RequestHandlerClass)
+.. class:: ThreadingHTTPServer(server_address, RequestHandlerClass)
 
    This class is identical to HTTPServer but uses threads to handle
    requests by using the :class:`~socketserver.ThreadingMixIn`. This
@@ -43,7 +43,7 @@ handler.  Code to create and run the server looks like this::
    .. versionadded:: 3.7
 
 
-The :class:`HTTPServer` and :class:`ThreadedHTTPServer` must be given
+The :class:`HTTPServer` and :class:`ThreadingHTTPServer` must be given
 a *RequestHandlerClass* on instantiation, of which this module
 provides three different variants:
 

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -83,7 +83,7 @@ XXX To do:
 __version__ = "0.6"
 
 __all__ = [
-    "HTTPServer", "ThreadedHTTPServer", "BaseHTTPRequestHandler",
+    "HTTPServer", "ThreadingHTTPServer", "BaseHTTPRequestHandler",
     "SimpleHTTPRequestHandler", "CGIHTTPRequestHandler",
 ]
 
@@ -140,7 +140,7 @@ class HTTPServer(socketserver.TCPServer):
         self.server_port = port
 
 
-class ThreadedHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
     daemon_threads = True
 
 
@@ -1217,7 +1217,7 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
 
 
 def test(HandlerClass=BaseHTTPRequestHandler,
-         ServerClass=ThreadedHTTPServer,
+         ServerClass=ThreadingHTTPServer,
          protocol="HTTP/1.0", port=8000, bind=""):
     """Test the HTTP request handler class.
 

--- a/Misc/NEWS.d/next/Library/2017-12-27-21-55-19.bpo-31639.l3avDJ.rst
+++ b/Misc/NEWS.d/next/Library/2017-12-27-21-55-19.bpo-31639.l3avDJ.rst
@@ -1,2 +1,2 @@
-http.server now exposes a ThreadedHTTPServer class and uses it when the
+http.server now exposes a ThreadingHTTPServer class and uses it when the
 module is run with ``-m`` to cope with web browsers pre-opening sockets.


### PR DESCRIPTION
Changes the class name `http.server.ThreadedHTTPServer` to `http.server.ThreadingHTTPServer` [introduced](https://github.com/python/cpython/commit/8bcfa02e4b1b65634e526e197588bc600674c80b#diff-f12bea18c24702e0866a5e97d970d865) by @JulienPalard on 23 March 2018 for Python 3.7, in order to be consistent with the already [existing classes](https://docs.python.org/3/library/socketserver.html#socketserver.ForkingTCPServer):

- `socketserver.ForkingTCPServer`;
- `socketserver.ForkingUDPServer`;
- `socketserver.ThreadingTCPServer`;
- `socketserver.ThreadingUDPServer`.

<!-- issue-number: bpo-31639 -->
https://bugs.python.org/issue31639
<!-- /issue-number -->
