### PR TITLE
gh-75128: Fix create_server to handle the case when iface isn't IPv6 enabled.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-05-29-11-38-34.bpo-30945.zYP6IH.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-29-11-38-34.bpo-30945.zYP6IH.rst
@@ -1,0 +1,1 @@
+Fix create_server() to handle the case when interface is not IPv6 enabled


### PR DESCRIPTION
Patch by Antoine Pitrou.

https://bugs.python.org/issue30945

<!-- issue-number: bpo-30945 -->
https://bugs.python.org/issue30945
<!-- /issue-number -->


<!-- gh-issue-number: gh-75128 -->
* Issue: gh-75128
<!-- /gh-issue-number -->
