### PR TITLE
bpo-23859: Document that asyncio.wait() does not cancel its futures

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -764,6 +764,9 @@ Task functions
    |                             | futures finish or are cancelled.       |
    +-----------------------------+----------------------------------------+
 
+   Unlike :func:`~asyncio.wait_for`, ``wait()`` will not cancel the futures
+   when a timeout accurs.
+
    This function is a :ref:`coroutine <coroutine>`.
 
    Usage::

--- a/Misc/NEWS.d/next/Documentation/2018-05-29-16-02-31.bpo-23859.E5gba1.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-05-29-16-02-31.bpo-23859.E5gba1.rst
@@ -1,0 +1,1 @@
+Document that `asyncio.wait()` does not cancel its futures on timeout.


### PR DESCRIPTION
Unlike `asyncio.wait_for()`, `asyncio.wait()` does not cancel the passed
futures when a timeout accurs.

<!-- issue-number: bpo-23859 -->
https://bugs.python.org/issue23859
<!-- /issue-number -->
