### PR TITLE
[3.7] bpo-31639: Change ThreadedHTTPServer to ThreadingHTTPServer class name (GH-7195)

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -33,7 +33,7 @@ handler.  Code to create and run the server looks like this::
    :attr:`server_port`. The server is accessible by the handler, typically
    through the handler's :attr:`server` instance variable.
 
-.. class:: ThreadedHTTPServer(server_address, RequestHandlerClass)
+.. class:: ThreadingHTTPServer(server_address, RequestHandlerClass)
 
    This class is identical to HTTPServer but uses threads to handle
    requests by using the :class:`~socketserver.ThreadingMixIn`. This
@@ -43,7 +43,7 @@ handler.  Code to create and run the server looks like this::
    .. versionadded:: 3.7
 
 
-The :class:`HTTPServer` and :class:`ThreadedHTTPServer` must be given
+The :class:`HTTPServer` and :class:`ThreadingHTTPServer` must be given
 a *RequestHandlerClass* on instantiation, of which this module
 provides three different variants:
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -929,7 +929,7 @@ With this parameter, the server serves the specified directory, by default it
 uses the current working directory.
 (Contributed by Stéphane Wirtel and Julien Palard in :issue:`28707`.)
 
-The new :class:`ThreadedHTTPServer <http.server.ThreadedHTTPServer>` class
+The new :class:`ThreadingHTTPServer <http.server.ThreadingHTTPServer>` class
 uses threads to handle requests using :class:`~socketserver.ThreadingMixin`.
 It is used when ``http.server`` is run with ``-m``.
 (Contributed by Julien Palard in :issue:`31639`.)

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -83,7 +83,7 @@ XXX To do:
 __version__ = "0.6"
 
 __all__ = [
-    "HTTPServer", "ThreadedHTTPServer", "BaseHTTPRequestHandler",
+    "HTTPServer", "ThreadingHTTPServer", "BaseHTTPRequestHandler",
     "SimpleHTTPRequestHandler", "CGIHTTPRequestHandler",
 ]
 
@@ -140,7 +140,7 @@ class HTTPServer(socketserver.TCPServer):
         self.server_port = port
 
 
-class ThreadedHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
+class ThreadingHTTPServer(socketserver.ThreadingMixIn, HTTPServer):
     daemon_threads = True
 
 
@@ -1217,7 +1217,7 @@ class CGIHTTPRequestHandler(SimpleHTTPRequestHandler):
 
 
 def test(HandlerClass=BaseHTTPRequestHandler,
-         ServerClass=ThreadedHTTPServer,
+         ServerClass=ThreadingHTTPServer,
          protocol="HTTP/1.0", port=8000, bind=""):
     """Test the HTTP request handler class.
 


### PR DESCRIPTION
(cherry picked from commit 1cee216cf383eade641aed22f4ec7d4cb565ecff)


<!-- issue-number: bpo-31639 -->
https://bugs.python.org/issue31639
<!-- /issue-number -->
