### PR TITLE
Fix whatsnew entry about ThreadedHTTPServer.

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -929,7 +929,7 @@ With this parameter, the server serves the specified directory, by default it
 uses the current working directory.
 (Contributed by Stéphane Wirtel and Julien Palard in :issue:`28707`.)
 
-The new :class:`ThreadedHTTPServer <http.server.ThreadedHTTPServer>` class
+The new :class:`ThreadingHTTPServer <http.server.ThreadingHTTPServer>` class
 uses threads to handle requests using :class:`~socketserver.ThreadingMixin`.
 It is used when ``http.server`` is run with ``-m``.
 (Contributed by Julien Palard in :issue:`31639`.)


### PR DESCRIPTION
Fixing the 3.7 whatsnews entry about https://github.com/python/cpython/pull/7195.