### PR TITLE
[2.7] Improve ensurepip's --help (GH-4686)

### DIFF
--- a/Lib/ensurepip/__init__.py
+++ b/Lib/ensurepip/__init__.py
@@ -190,8 +190,8 @@ def _main(argv=None):
         "--altinstall",
         action="store_true",
         default=False,
-        help=("Make an alternate install, installing only the X.Y versioned"
-              "scripts (Default: pipX, pipX.Y, easy_install-X.Y)"),
+        help=("Make an alternate install, installing only the X.Y versioned "
+              "scripts (Default: pipX, pipX.Y, easy_install-X.Y)."),
     )
     parser.add_argument(
         "--default-pip",


### PR DESCRIPTION
* Add a space to ensurepip's --altinstall option
* Add period to the --altinstall argument of ensurepip

This makes --help for all optional arguments consistent and also makes it
consistent with pip --help..
(cherry picked from commit e9537ad6a128924dd610bea2268065500c174181)

Co-authored-by: Wieland Hoffmann <mineo@users.noreply.github.com>
