### PR TITLE
bpo-33711: Fix license generation error in msi.py

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-06-24-12-09-23.bpo-33711.LpO0s1.rst
+++ b/Misc/NEWS.d/next/Windows/2018-06-24-12-09-23.bpo-33711.LpO0s1.rst
@@ -1,0 +1,1 @@
+Fixed licence generation error when building the installer.

--- a/Tools/msi/msi.py
+++ b/Tools/msi/msi.py
@@ -917,7 +917,7 @@ def generate_license():
     shutil.copyfileobj(open(os.path.join(srcdir, "LICENSE")), out)
     shutil.copyfileobj(open("crtlicense.txt"), out)
     for name, pat, file in (("bzip2","bzip2-*", "LICENSE"),
-                      ("Berkeley DB", "db-*", "LICENSE"),
+                      ("Berkeley DB", "bsddb-*", "LICENSE"),
                       ("openssl", "openssl-*", "LICENSE"),
                       ("Tcl", "tcl-8*", "license.terms"),
                       ("Tk", "tk-8*", "license.terms"),


### PR DESCRIPTION
```
c:\Users\Sasha\Documents\cpython\Tools\msi>python msi.py
Traceback (most recent call last):
  File "msi.py", line 1372, in <module>
    add_files(db)
  File "msi.py", line 956, in add_files
    generate_license()
  File "msi.py", line 928, in generate_license
    raise ValueError, "Could not find "+srcdir+"/externals/"+pat
ValueError: Could not find c:\Users\Sasha\Documents\cpython/externals/db-*
```
The dir in externals is actually called `bsddb-<version>`.
Bug caused by https://github.com/python/cpython/commit/986b7ffc650919b3022ccaa458a843bb8a95d2bd .
Doesn't affect 3.x 'cuz the `bsddb` module has been dropped.

<!-- issue-number: bpo-33711 -->
https://bugs.python.org/issue33711
<!-- /issue-number -->
