### PR TITLE
bpo-33698: Fixed skipping of empty paths while reading `pth` [WIP].

### DIFF
--- a/Lib/test/test_site.py
+++ b/Lib/test/test_site.py
@@ -521,9 +521,12 @@ class _pthFileTests(unittest.TestCase):
     def _calc_sys_path_for_underpth_nosite(self, sys_prefix, lines):
         sys_path = []
         for line in lines:
-            if not line or line[0] == '#':
-                continue
-            abs_path = os.path.abspath(os.path.join(sys_prefix, line))
+            if line:
+                if line[0] == '#':
+                    continue
+                abs_path = os.path.abspath(os.path.join(sys_prefix, line))
+            else:
+                abs_path = ''
             sys_path.append(abs_path)
         return sys_path
 
@@ -535,6 +538,7 @@ class _pthFileTests(unittest.TestCase):
             *[libpath for _ in range(200)],
             '',
             '# comment',
+            '#import site',
         ]
         exe_file = self._create_underpth_exe(pth_lines)
         sys_path = self._calc_sys_path_for_underpth_nosite(
@@ -545,9 +549,9 @@ class _pthFileTests(unittest.TestCase):
         env['PYTHONPATH'] = 'from-env'
         env['PATH'] = '{};{}'.format(exe_prefix, os.getenv('PATH'))
         output = subprocess.check_output([exe_file, '-c',
-            'import sys; print("\\n".join(sys.path) if sys.flags.no_site else "")'
+            'import sys; print(";".join(sys.path) if sys.flags.no_site else "")'
         ], env=env, encoding='ansi')
-        actual_sys_path = output.rstrip().split('\n')
+        actual_sys_path = output.rstrip().split(';')
         self.assertTrue(actual_sys_path, "sys.flags.no_site was False")
         self.assertEqual(
             actual_sys_path,

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -283,6 +283,7 @@ Matt Chisholm
 Lita Cho
 Sayan Chowdhury
 Yuan-Chao Chou
+Vladimir Chebotarev
 Anders Chrigström
 Tom Christiansen
 Renee Chu

--- a/Misc/NEWS.d/next/Windows/2018-05-30-18-11-48.bpo-29326.RderYr.rst
+++ b/Misc/NEWS.d/next/Windows/2018-05-30-18-11-48.bpo-29326.RderYr.rst
@@ -1,0 +1,1 @@
+Fixed an issue with empty path in sys.path not coming from `_pth`.

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -578,14 +578,15 @@ read_pth_file(_PyPathConfig *config, wchar_t *prefix, const wchar_t *path,
         if (!p) {
             break;
         }
-        if (*p == '\0' || *p == '\r' || *p == '\n' || *p == '#') {
+        if (*p == '\0' || *p == '#') {
             continue;
         }
-        while (*++p) {
+        while (*p) {
             if (*p == '\r' || *p == '\n') {
                 *p = '\0';
                 break;
             }
+            ++p;
         }
 
         if (strcmp(line, "import site") == 0) {
@@ -615,17 +616,19 @@ read_pth_file(_PyPathConfig *config, wchar_t *prefix, const wchar_t *path,
             usedsiz += 1;
         }
 
-        errno_t result;
-        _Py_BEGIN_SUPPRESS_IPH
-        result = wcscat_s(buf, bufsiz, prefix);
-        _Py_END_SUPPRESS_IPH
-        if (result == EINVAL) {
-            Py_FatalError("invalid argument during ._pth processing");
-        } else if (result == ERANGE) {
-            Py_FatalError("buffer overflow during ._pth processing");
+        if (line[0] != '\0') {
+            errno_t result;
+            _Py_BEGIN_SUPPRESS_IPH
+            result = wcscat_s(buf, bufsiz, prefix);
+            _Py_END_SUPPRESS_IPH
+            if (result == EINVAL) {
+                Py_FatalError("invalid argument during ._pth processing");
+            } else if (result == ERANGE) {
+                Py_FatalError("buffer overflow during ._pth processing");
+            }
+            wchar_t *b = &buf[usedsiz];
+            join(b, wline);
         }
-        wchar_t *b = &buf[usedsiz];
-        join(b, wline);
 
         PyMem_RawFree(wline);
     }


### PR DESCRIPTION
This patch fixes possibility to use imports from script directory.

--Follow up to Issue 29326.

Alexey erroneously broke adding empty paths to `sys.path` along with his fix of `'\n'` in `sys.path`.--

Official embeddable Python distributions do contain a blank line in its `._pth`, and that previously allowed users to import modules from script directory.


<!-- issue-number: bpo-29326 -->
https://bugs.python.org/issue29326
<!-- /issue-number -->
