### PR TITLE
bpo-33615: avoid extra decref

### DIFF
--- a/Include/internal/pystate.h
+++ b/Include/internal/pystate.h
@@ -80,7 +80,7 @@ struct _xid;
 
 // _PyCrossInterpreterData is similar to Py_buffer as an effectively
 // opaque struct that holds data outside the object machinery.  This
-// is necessary to pass between interpreters in the same process.
+// is necessary to pass safely between interpreters in the same process.
 typedef struct _xid {
     // data is the cross-interpreter-safe derivation of a Python object
     // (see _PyObject_GetCrossInterpreterData).  It will be NULL if the
@@ -89,8 +89,9 @@ typedef struct _xid {
     // obj is the Python object from which the data was derived.  This
     // is non-NULL only if the data remains bound to the object in some
     // way, such that the object must be "released" (via a decref) when
-    // the data is released.  In that case it is automatically
-    // incref'ed (to match the automatic decref when releaed).
+    // the data is released.  In that case the code that sets the field,
+    // likely a registered "crossinterpdatafunc", is responsible for
+    // ensuring it owns the reference (i.e. incref).
     PyObject *obj;
     // interp is the ID of the owning interpreter of the original
     // object.  It corresponds to the active interpreter when

--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -1315,8 +1315,6 @@ class ChannelTests(TestBase):
         self.assertEqual(obj, b'spam')
         self.assertEqual(out.strip(), 'send')
 
-    # XXX Fix the crashes.
-    @unittest.skip('bpo-33615: triggering crashes so temporarily disabled')
     def test_run_string_arg_resolved(self):
         cid = interpreters.channel_create()
         cid = interpreters._channel_id(cid, _resolve=True)

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1712,6 +1712,7 @@ _channelid_shared(PyObject *obj, _PyCrossInterpreterData *data)
     xid->resolve = ((channelid *)obj)->resolve;
 
     data->data = xid;
+    Py_INCREF(obj);
     data->obj = obj;
     data->new_object = _channelid_from_xid;
     data->free = PyMem_Free;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1205,7 +1205,6 @@ _PyObject_GetCrossInterpreterData(PyObject *obj, _PyCrossInterpreterData *data)
     }
 
     // Fill in the blanks and validate the result.
-    Py_XINCREF(data->obj);
     data->interp = interp->id;
     if (_check_xidata(data) != 0) {
         _PyCrossInterpreterData_Release(data);
@@ -1355,6 +1354,7 @@ _bytes_shared(PyObject *obj, _PyCrossInterpreterData *data)
         return -1;
     }
     data->data = (void *)shared;
+    Py_INCREF(obj);
     data->obj = obj;  // Will be "released" (decref'ed) when data released.
     data->new_object = _new_bytes_object;
     data->free = PyMem_Free;
@@ -1382,6 +1382,7 @@ _str_shared(PyObject *obj, _PyCrossInterpreterData *data)
     shared->buffer = PyUnicode_DATA(obj);
     shared->len = PyUnicode_GET_LENGTH(obj) - 1;
     data->data = (void *)shared;
+    Py_INCREF(obj);
     data->obj = obj;  // Will be "released" (decref'ed) when data released.
     data->new_object = _new_str_object;
     data->free = PyMem_Free;


### PR DESCRIPTION
For [bpo-32604](https://bugs.python.org/issue32604) I added extra subinterpreter-related tests (see #6914), which caused a few buildbots to fail.  This patch ensures that refcounts in channels are handled properly.

WIP: I'll be iterating against the failing buildbots (particularly ["x86 Gentoo Refleaks 3.x"](http://buildbot.python.org/all/#/builders/1)) until this is resolved.  The problem may have already existed before #6914 (and only surfaced with the new tests).  However, I'm going to start from #6914 and then dive deeper.  My first stab at the problem involves preventing a race (albeit an unlikely one) in _PyObject_GetCrossInterpreterData().

<!-- issue-number: bpo-33615 -->
https://bugs.python.org/issue33615
<!-- /issue-number -->
