### PR TITLE
bpo-33532: Fix multiprocessing test_ignore()

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -4338,7 +4338,7 @@ class TestIgnoreEINTR(unittest.TestCase):
         conn.send('ready')
         x = conn.recv()
         conn.send(x)
-        conn.send_bytes(b'x' * (1024 * 1024))   # sending 1 MiB should block
+        conn.send_bytes(b'x' * support.PIPE_MAX_SIZE)
 
     @unittest.skipUnless(hasattr(signal, 'SIGUSR1'), 'requires SIGUSR1')
     def test_ignore(self):
@@ -4357,7 +4357,7 @@ class TestIgnoreEINTR(unittest.TestCase):
             self.assertEqual(conn.recv(), 1234)
             time.sleep(0.1)
             os.kill(p.pid, signal.SIGUSR1)
-            self.assertEqual(conn.recv_bytes(), b'x'*(1024*1024))
+            self.assertEqual(conn.recv_bytes(), b'x' * support.PIPE_MAX_SIZE)
             time.sleep(0.1)
             p.join()
         finally:


### PR DESCRIPTION
Fix test_ignore() of multiprocessing tests like
test_multiprocessing_forkserver: use support.PIPE_MAX_SIZE to make
sure that send_bytes() blocks.

<!-- issue-number: bpo-33532 -->
https://bugs.python.org/issue33532
<!-- /issue-number -->
