### PR TITLE
[2.7] bpo-33532: Fix multiprocessing test_ignore()

### DIFF
--- a/Lib/test/test_multiprocessing.py
+++ b/Lib/test/test_multiprocessing.py
@@ -2689,7 +2689,7 @@ class TestIgnoreEINTR(unittest.TestCase):
         conn.send('ready')
         x = conn.recv()
         conn.send(x)
-        conn.send_bytes(b'x'*(1024*1024))   # sending 1 MB should block
+        conn.send_bytes(b'x' * test_support.PIPE_MAX_SIZE)
 
     @unittest.skipUnless(hasattr(signal, 'SIGUSR1'), 'requires SIGUSR1')
     def test_ignore(self):
@@ -2708,7 +2708,8 @@ class TestIgnoreEINTR(unittest.TestCase):
             self.assertEqual(conn.recv(), 1234)
             time.sleep(0.1)
             os.kill(p.pid, signal.SIGUSR1)
-            self.assertEqual(conn.recv_bytes(), b'x'*(1024*1024))
+            self.assertEqual(conn.recv_bytes(),
+                             b'x' * test_support.PIPE_MAX_SIZE)
             time.sleep(0.1)
             p.join()
         finally:


### PR DESCRIPTION
Fix test_multiprocessing.test_ignore(): use support.PIPE_MAX_SIZE
to make sure that send_bytes() blocks.

<!-- issue-number: bpo-33532 -->
https://bugs.python.org/issue33532
<!-- /issue-number -->
