### PR TITLE
bpo-31014: Fix the webbrowser module.

### DIFF
--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -302,7 +302,7 @@ class ImportTest(unittest.TestCase):
         webbrowser = support.import_fresh_module('webbrowser')
         try:
             browser = webbrowser.get().name
-        except webbrowser.Error as err:
+        except (webbrowser.Error, AttributeError) as err:
             self.skipTest(str(err))
         with support.EnvironmentVarGuard() as env:
             env["BROWSER"] = browser

--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -1,5 +1,7 @@
 import webbrowser
 import unittest
+import os
+import sys
 import subprocess
 from unittest import mock
 from test import support
@@ -289,6 +291,23 @@ class ImportTest(unittest.TestCase):
         with self.assertRaises(webbrowser.Error):
             webbrowser.get('fakebrowser')
         self.assertIsNotNone(webbrowser._tryorder)
+
+    def test_synthesize(self):
+        webbrowser = support.import_fresh_module('webbrowser')
+        name = os.path.basename(sys.executable).lower()
+        webbrowser.register(name, None, webbrowser.GenericBrowser(name))
+        webbrowser.get(sys.executable)
+
+    def test_environment(self):
+        webbrowser = support.import_fresh_module('webbrowser')
+        try:
+            browser = webbrowser.get().name
+        except webbrowser.Error as err:
+            self.skipTest(str(err))
+        with support.EnvironmentVarGuard() as env:
+            env["BROWSER"] = browser
+            webbrowser = support.import_fresh_module('webbrowser')
+            webbrowser.get()
 
 
 if __name__=='__main__':

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -86,7 +86,7 @@ def open_new_tab(url):
     return open(url, 2)
 
 
-def _synthesize(browser, update_tryorder=1):
+def _synthesize(browser, *, preferred=True):
     """Attempt to synthesize a controller base on existing controllers.
 
     This is useful to create a controller when a user specifies a path to
@@ -113,7 +113,7 @@ def _synthesize(browser, update_tryorder=1):
         controller = copy.copy(controller)
         controller.name = browser
         controller.basename = os.path.basename(browser)
-        register(browser, None, controller, update_tryorder)
+        register(browser, None, instance=controller, preferred=preferred)
         return [None, controller]
     return [None, None]
 
@@ -564,7 +564,7 @@ def register_standard_browsers():
         # and prepend to _tryorder
         for cmdline in userchoices:
             if cmdline != '':
-                cmd = _synthesize(cmdline, -1)
+                cmd = _synthesize(cmdline, preferred=False)
                 if cmd[1] is None:
                     register(cmdline, None, GenericBrowser(cmdline), preferred=True)
 

--- a/Misc/NEWS.d/next/Library/2018-05-31-06-48-55.bpo-31014.SNY681.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-31-06-48-55.bpo-31014.SNY681.rst
@@ -1,0 +1,3 @@
+Fixed creating a controller for :mod:`webbrowser` when a user specifies a
+path to an entry in the BROWSER environment variable.  Based on patch by
+John Still.


### PR DESCRIPTION
`webbrowser._synthesize()` called `webbrowser.register()` with outdated signature.

Based on patch by John Still (#2689).


<!-- issue-number: bpo-31014 -->
https://bugs.python.org/issue31014
<!-- /issue-number -->
