### PR TITLE
[2.7] bpo-33709: test_ntpath and test_posixpath fail in Windows with ACP!=1252 (GH-7278)

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -654,8 +654,10 @@ if have_unicode:
         unichr(0x20AC),
     ):
         try:
-            character.encode(sys.getfilesystemencoding())\
-                     .decode(sys.getfilesystemencoding())
+            if character.encode(sys.getfilesystemencoding())\
+                        .decode(sys.getfilesystemencoding())\
+                    != character:
+                raise UnicodeError
         except UnicodeError:
             pass
         else:

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -654,6 +654,8 @@ if have_unicode:
         unichr(0x20AC),
     ):
         try:
+            # In Windows, 'mbcs' is used, and encode() returns '?'
+            # for characters missing in the ANSI codepage
             if character.encode(sys.getfilesystemencoding())\
                         .decode(sys.getfilesystemencoding())\
                     != character:

--- a/Lib/test/test_posixpath.py
+++ b/Lib/test/test_posixpath.py
@@ -474,12 +474,10 @@ class PosixPathTest(unittest.TestCase):
         finally:
             os.getcwd = real_getcwd
 
-    @test_support.requires_unicode
+    @unittest.skipUnless(test_support.FS_NONASCII, 'need test_support.FS_NONASCII')
     def test_expandvars_nonascii_word(self):
         encoding = sys.getfilesystemencoding()
-        # Non-ASCII word characters
-        letters = test_support.u(r'\xe6\u0130\u0141\u03c6\u041a\u05d0\u062a\u0e01')
-        uwnonascii = letters.encode(encoding, 'ignore').decode(encoding)[:3]
+        uwnonascii = test_support.FS_NONASCII
         swnonascii = uwnonascii.encode(encoding)
         if not swnonascii:
             self.skipTest('Needs non-ASCII word characters')


### PR DESCRIPTION


<!-- issue-number: bpo-33709 -->
https://bugs.python.org/issue33709
<!-- /issue-number -->
