### PR TITLE
bpo-33708: Fix method reference links in asyncio.Event and asyncio.Condition docs

### DIFF
--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -164,8 +164,8 @@ Condition
 
       .. note::
 
-         An awakened coroutine does not actually return from its :meth:`wait`
-         call until it can reacquire the lock. Since :meth:`notify` does not
+         An awakened coroutine does not actually return from its :meth:`.wait`
+         call until it can reacquire the lock. Since :meth:`.notify` does not
          release the lock, its caller should.
 
    .. method:: locked()

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -36,7 +36,7 @@ Lock
    'locked' or 'unlocked'.
 
    The lock is created in the unlocked state.
-   It has two basic methods, :meth:`acquire` and :meth:`release`.
+   It has two basic methods, :meth:`.acquire` and :meth:`.release`.
    When the state is unlocked, acquire() changes the state to
    locked and returns immediately.  When the state is locked, acquire() blocks
    until a call to release() in another coroutine changes it to unlocked, then
@@ -50,7 +50,7 @@ Lock
    resets the state to unlocked; first coroutine which is blocked in acquire()
    is being processed.
 
-   :meth:`acquire` is a coroutine and should be called with ``await``.
+   :meth:`.acquire` is a coroutine and should be called with ``await``.
 
    Locks support the :ref:`context management protocol <async-with-locks>`.
 
@@ -175,9 +175,9 @@ Condition
    .. method:: notify_all()
 
       Wake up all coroutines waiting on this condition. This method acts like
-      :meth:`notify`, but wakes up all waiting coroutines instead of one. If the
-      calling coroutine has not acquired the lock when this method is called, a
-      :exc:`RuntimeError` is raised.
+      :meth:`.notify`, but wakes up all waiting coroutines instead of one. If
+      the calling coroutine has not acquired the lock when this method is
+      called, a :exc:`RuntimeError` is raised.
 
    .. method:: release()
 
@@ -199,7 +199,7 @@ Condition
       called, a :exc:`RuntimeError` is raised.
 
       This method releases the underlying lock, and then blocks until it is
-      awakened by a :meth:`notify` or :meth:`notify_all` call for the same
+      awakened by a :meth:`.notify` or :meth:`.notify_all` call for the same
       condition variable in another coroutine.  Once awakened, it re-acquires
       the lock and returns ``True``.
 
@@ -223,9 +223,9 @@ Semaphore
    A Semaphore implementation.
 
    A semaphore manages an internal counter which is decremented by each
-   :meth:`acquire` call and incremented by each :meth:`release` call. The
-   counter can never go below zero; when :meth:`acquire` finds that it is zero,
-   it blocks, waiting until some other coroutine calls :meth:`release`.
+   :meth:`.acquire` call and incremented by each :meth:`.release` call. The
+   counter can never go below zero; when :meth:`.acquire` finds that it is zero,
+   it blocks, waiting until some other coroutine calls :meth:`.release`.
 
    The optional argument gives the initial value for the internal counter; it
    defaults to ``1``. If the value given is less than ``0``, :exc:`ValueError`
@@ -242,7 +242,7 @@ Semaphore
 
       If the internal counter is larger than zero on entry, decrement it by one
       and return ``True`` immediately.  If it is zero on entry, block, waiting
-      until some other coroutine has called :meth:`release` to make it larger
+      until some other coroutine has called :meth:`.release` to make it larger
       than ``0``, and then return ``True``.
 
       This method is a :ref:`coroutine <coroutine>`.

--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -90,8 +90,8 @@ Event
    An Event implementation, asynchronous equivalent to :class:`threading.Event`.
 
    Class implementing event objects. An event manages a flag that can be set to
-   true with the :meth:`set` method and reset to false with the :meth:`clear`
-   method.  The :meth:`wait` method blocks until the flag is true. The flag is
+   true with the :meth:`.set` method and reset to false with the :meth:`.clear`
+   method.  The :meth:`.wait` method blocks until the flag is true. The flag is
    initially false.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
@@ -99,7 +99,7 @@ Event
    .. method:: clear()
 
       Reset the internal flag to false. Subsequently, coroutines calling
-      :meth:`wait` will block until :meth:`set` is called to set the internal
+      :meth:`.wait` will block until :meth:`.set` is called to set the internal
       flag to true again.
 
    .. method:: is_set()
@@ -109,7 +109,7 @@ Event
    .. method:: set()
 
       Set the internal flag to true. All coroutines waiting for it to become
-      true are awakened. Coroutine that call :meth:`wait` once the flag is true
+      true are awakened. Coroutine that call :meth:`.wait` once the flag is true
       will not block at all.
 
    .. coroutinemethod:: wait()
@@ -117,7 +117,7 @@ Event
       Block until the internal flag is true.
 
       If the internal flag is true on entry, return ``True`` immediately.
-      Otherwise, block until another coroutine calls :meth:`set` to set the
+      Otherwise, block until another coroutine calls :meth:`.set` to set the
       flag to true, then return ``True``.
 
       This method is a :ref:`coroutine <coroutine>`.


### PR DESCRIPTION
This patch addresses the linking problem reported in [Issue #33708](https://bugs.python.org/issue33708).

<!-- issue-number: bpo-33708 -->
https://bugs.python.org/issue33708
<!-- /issue-number -->
