### PR TITLE
[2.7] bpo-33600: document that platform.linux_distribution() has been removed

### DIFF
--- a/Doc/library/platform.rst
+++ b/Doc/library/platform.rst
@@ -270,6 +270,10 @@ Unix Platforms
    parameters.  ``id`` is the item in parentheses after the version number.  It
    is usually the version codename.
 
+   .. note::
+      This function is deprecated since Python 3.5 and removed in Python 3.8.
+      See alternative like the `distro <https://pypi.org/project/distro>`_ package.
+
    .. versionadded:: 2.6
 
 .. function:: libc_ver(executable=sys.executable, lib='', version='', chunksize=2048)


### PR DESCRIPTION
This change addresses the issue here: https://bugs.python.org/issue33600

Is there a better marker than `.. versionchanged::` for this? I tried to find similar situations, but couldn't find any. Maybe someone could point me to one?

<!-- issue-number: bpo-33600 -->
https://bugs.python.org/issue33600
<!-- /issue-number -->
