### PR TITLE
bpo-33706: Fix pymain_parse_cmdline_impl()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-05-31-14-50-04.bpo-33706.ztlH04.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-05-31-14-50-04.bpo-33706.ztlH04.rst
@@ -1,0 +1,2 @@
+Fix a crash in Python initialization when parsing the command line options.
+Thanks Christoph Gohlke for the bug report and the fix!

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -761,7 +761,7 @@ pymain_parse_cmdline_impl(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
                 pymain->err = _Py_INIT_NO_MEMORY();
                 return -1;
             }
-            memcpy(command, _PyOS_optarg, len * sizeof(wchar_t));
+            memcpy(command, _PyOS_optarg, (len - 2) * sizeof(wchar_t));
             command[len - 2] = '\n';
             command[len - 1] = 0;
             pymain->command = command;


### PR DESCRIPTION
Fix a crash in Python initialization when parsing the command line
options.

Fix memcpy() size parameter: previously, we read one wchar_t after
the end of _PyOS_optarg. Moreover, don't copy the trailingg NUL
character: we write it manually anyway.

Thanks Christoph Gohlke for the bug report and the fix!

<!-- issue-number: bpo-33706 -->
https://bugs.python.org/issue33706
<!-- /issue-number -->
