### PR TITLE
bpo-33606: improve logging performance when logger is disabled

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1569,6 +1569,9 @@ class Logger(Filterer):
         """
         Is this logger enabled for level 'level'?
         """
+        if self.disabled:
+            return False
+
         try:
             return self._cache[level]
         except KeyError:

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -4097,6 +4097,18 @@ class LoggerTest(BaseTest):
         self.addCleanup(setattr, self.logger.manager, 'disable', old_disable)
         self.assertFalse(self.logger.isEnabledFor(22))
 
+    def test_is_enabled_for_disabled_logger(self):
+        old_disabled = self.logger.disabled
+        old_disable = self.logger.manager.disable
+
+        self.logger.disabled = True
+        self.logger.manager.disable = 21
+
+        self.addCleanup(setattr, self.logger, 'disabled', old_disabled)
+        self.addCleanup(setattr, self.logger.manager, 'disable', old_disable)
+
+        self.assertFalse(self.logger.isEnabledFor(22))
+
     def test_root_logger_aliases(self):
         root = logging.getLogger()
         self.assertIs(root, logging.root)


### PR DESCRIPTION
There is a check in `Logger.handle` to check whether the logger is disabled or not. However, for normal logging via `Logger.debug`, `Logger.info`, etc it could already be checked in `Logger.isEnabledFor()` to improve the performance when the logger is disabled.



<!-- issue-number: bpo-33606 -->
https://bugs.python.org/issue33606
<!-- /issue-number -->
