### PR TITLE
bpo-33684:parse failed for mutibytes characters, encode will show in \xxx

### DIFF
--- a/Lib/json/tool.py
+++ b/Lib/json/tool.py
@@ -22,7 +22,7 @@ def main():
     parser = argparse.ArgumentParser(prog=prog, description=description)
     parser.add_argument('infile', nargs='?', type=argparse.FileType(),
                         help='a JSON file to be validated or pretty-printed')
-    parser.add_argument('outfile', nargs='?', type=argparse.FileType('w'),
+    parser.add_argument('outfile', nargs='?', type=argparse.FileType('w', encoding='utf-8'),
                         help='write the output of infile to outfile')
     parser.add_argument('--sort-keys', action='store_true', default=False,
                         help='sort the output of dictionaries alphabetically by key')
@@ -37,7 +37,7 @@ def main():
         except ValueError as e:
             raise SystemExit(e)
     with outfile:
-        json.dump(obj, outfile, sort_keys=sort_keys, indent=4)
+        outfile.write(json.dumps(obj,ensure_ascii=False,sort_keys=sort_keys, indent=4))
         outfile.write('\n')
 
 

--- a/Misc/NEWS.d/next/Library/2018-05-31-22-34-24.bpo-33684.8iz5m6.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-31-22-34-24.bpo-33684.8iz5m6.rst
@@ -1,0 +1,2 @@
+when strings or files are encode with utf8 without bom, auto detect encoding
+will fail. set default decoded type with utf-8 for most time


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
when type this command in windows(xp or win7, all the same):
python -m json.tool xxx.txt xxx.json
if xxx.txt contains Chinese(or other multibytes characters):
if xxx.txt is encoded in ansi, xxx.json will encode Chinese as \xxx, very bad to see what they are;
if xxx.txt is encoded in utf8(without bom for most of the time), because with no bom, json.tool will think it is encoded in ansi, and decode fail.

as now, utf8 is widely use, set default to utf8 for most of the time when auto detect encoding failed

<!-- issue-number: bpo-33684 -->
https://bugs.python.org/issue33684
<!-- /issue-number -->
