### PR TITLE
bpo-33615: Temporarily disable a test that is triggering crashes on a few buildbots.

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -1315,6 +1315,8 @@ class ChannelTests(TestBase):
         self.assertEqual(obj, b'spam')
         self.assertEqual(out.strip(), 'send')
 
+    # XXX Fix the crashes.
+    @unittest.skip('bpo-33615: triggering crashes so temporarily disabled')
     def test_run_string_arg_resolved(self):
         cid = interpreters.channel_create()
         cid = interpreters._channel_id(cid, _resolve=True)


### PR DESCRIPTION
For [bpo-32604](https://bugs.python.org/issue33615) I added some subinterpreter-related tests (see #6914) that are causing crashes on a few buildbots.  I'm working on fixing the crashes (see #7251).

In the meantime, this patch will disable the test that is triggering the crashes.  This should keep the subinterpreter code from causing failures on the relevant buildbots.  This should be okay as a *temporary* solution (as I work on the actual fix) because the crashing code is currently only used in the subinterpreter-related tests.  I'm hopeful that I'll have the crash properly fixed in the next few days (and by 8 June at the latest).

<!-- issue-number: bpo-33615 -->
https://bugs.python.org/issue33615
<!-- /issue-number -->
