### PR TITLE
bpo-33726: Add short descriptions to PEP references in seealso

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -680,8 +680,13 @@ can be used to create instance variables with different implementation details.
 
 .. seealso::
 
-   :pep:`3115` - Metaclasses in Python 3
+   :pep:`3115` - Metaclasses in Python 3000
+      The proposal that introduced the current syntax for declaring metaclasses,
+      and the semantics for how classes with metaclasses are constructed.
+
    :pep:`3129` - Class Decorators
+      The proposal that added syntax for class decorators, as an extension to
+      the function and method decorators introduced in :pep:`318`.
 
 
 .. _async:
@@ -807,6 +812,8 @@ It is a :exc:`SyntaxError` to use ``async with`` statement outside of an
 .. seealso::
 
    :pep:`492` - Coroutines with async and await syntax
+      The proposal that made coroutines a proper standalone concept in Python,
+      adding supporting syntax.
 
 
 .. rubric:: Footnotes

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -685,7 +685,7 @@ can be used to create instance variables with different implementation details.
       and the semantics for how classes with metaclasses are constructed.
 
    :pep:`3129` - Class Decorators
-      The proposal that added syntax for class decorators, as an extension to
+      The proposal that added class decorators, as an extension to
       the function and method decorators introduced in :pep:`318`.
 
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -681,12 +681,13 @@ can be used to create instance variables with different implementation details.
 .. seealso::
 
    :pep:`3115` - Metaclasses in Python 3000
-      The proposal that introduced the current syntax for declaring metaclasses,
-      and the semantics for how classes with metaclasses are constructed.
+      The proposal that changed the declaration of metaclasses to the current
+      syntax, and the semantics for how classes with metaclasses are
+      constructed.
 
    :pep:`3129` - Class Decorators
-      The proposal that added class decorators, as an extension to
-      the function and method decorators introduced in :pep:`318`.
+      The proposal that added class decorators.  Function and method decorators
+      were introduced in :pep:`318`.
 
 
 .. _async:
@@ -813,7 +814,7 @@ It is a :exc:`SyntaxError` to use ``async with`` statement outside of an
 
    :pep:`492` - Coroutines with async and await syntax
       The proposal that made coroutines a proper standalone concept in Python,
-      adding supporting syntax.
+      and added supporting syntax.
 
 
 .. rubric:: Footnotes

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -354,12 +354,14 @@ target, then the interpreter evaluates the target except for the last
 .. seealso::
 
    :pep:`526` - Syntax for Variable Annotations
-      The proposal that added syntax for annotating variables and class
-      attributes.
+      The proposal that added syntax for annotating the types of variables
+      (including class variables and instance variables), instead of expressing
+      them through comments.
 
    :pep:`484` - Type hints
-      The proposal that added the :mod:`typing` module to ease the use of
-      annotations as type hints for static type analysis tools and IDEs.
+      The proposal that added the :mod:`typing` module to provide a standard
+      syntax for type annotations that can be used in static analysis tools and
+      IDEs.
 
 
 .. _assert:

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -353,8 +353,13 @@ target, then the interpreter evaluates the target except for the last
 
 .. seealso::
 
-   :pep:`526` - Variable and attribute annotation syntax
+   :pep:`526` - Syntax for Variable Annotations
+      The proposal that added syntax for annotating variables and class
+      attributes.
+
    :pep:`484` - Type hints
+      The proposal that added the :mod:`typing` module to ease the use of
+      annotations as type hints for static type analysis tools.
 
 
 .. _assert:

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -359,7 +359,7 @@ target, then the interpreter evaluates the target except for the last
 
    :pep:`484` - Type hints
       The proposal that added the :mod:`typing` module to ease the use of
-      annotations as type hints for static type analysis tools.
+      annotations as type hints for static type analysis tools and IDEs.
 
 
 .. _assert:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33726 -->
https://bugs.python.org/issue33726
<!-- /issue-number -->
