### PR TITLE
bpo-27902: Add compatibility note to Profile docs

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -317,11 +317,12 @@ Analysis of the profiler data is done using the :class:`~pstats.Stats` class.
    corresponding version of :mod:`profile` or :mod:`cProfile`.  To be specific,
    there is *no* file compatibility guaranteed with future versions of this
    profiler, and there is no compatibility with files produced by other
-   profilers.  If several files are provided, all the statistics for identical
-   functions will be coalesced, so that an overall view of several processes can
-   be considered in a single report.  If additional files need to be combined
-   with data in an existing :class:`~pstats.Stats` object, the
-   :meth:`~pstats.Stats.add` method can be used.
+   profilers, or the same profiler run on a different operating system.  If
+   several files are provided, all the statistics for identical functions will
+   be coalesced, so that an overall view of several processes can be considered
+   in a single report.  If additional files need to be combined with data in an
+   existing :class:`~pstats.Stats` object, the :meth:`~pstats.Stats.add` method
+   can be used.
 
    Instead of reading the profile data from a file, a :class:`cProfile.Profile`
    or :class:`profile.Profile` object can be used as the profile data source.


### PR DESCRIPTION
As per [bpo-27902](https://bugs.python.org/issue27902), I added a note that compatibility of `Stats` files between operating systems can't be guaranteed (due to different path formats).

<!-- issue-number: bpo-27902 -->
https://bugs.python.org/issue27902
<!-- /issue-number -->
