### PR TITLE
bpo-32519: Removed misleading sentence from EnvBuilder documentation.

### DIFF
--- a/Doc/library/venv.rst
+++ b/Doc/library/venv.rst
@@ -105,8 +105,7 @@ creation according to their needs, the :class:`EnvBuilder` class.
 
     * ``symlinks`` -- a Boolean value indicating whether to attempt to symlink the
       Python binary (and any necessary DLLs or other binaries,
-      e.g. ``pythonw.exe``), rather than copying. Defaults to ``True`` on Linux and
-      Unix systems, but ``False`` on Windows.
+      e.g. ``pythonw.exe``), rather than copying.
 
     * ``upgrade`` -- a Boolean value which, if true, will upgrade an existing
       environment with the running Python - for use when that Python has been


### PR DESCRIPTION


<!-- issue-number: bpo-32519 -->
https://bugs.python.org/issue32519
<!-- /issue-number -->
