### PR TITLE
bpo-33400: Removed references to RFC3339 and ISO8601 from the logging…

### DIFF
--- a/Doc/library/logging.config.rst
+++ b/Doc/library/logging.config.rst
@@ -790,11 +790,10 @@ Sections which specify formatter configuration are typified by the following.
 
 The ``format`` entry is the overall format string, and the ``datefmt`` entry is
 the :func:`strftime`\ -compatible date/time format string.  If empty, the
-package substitutes ISO8601-style format date/times, which is almost equivalent to
-specifying the date format string ``'%Y-%m-%d %H:%M:%S'``.  This format also
-specifies milliseconds, which are appended to the result of using the above
-format string, with a comma separator.  An example time in this format is
-``2003-01-23 00:29:50,411``.
+package substitutes something which is almost equivalent to specifying the date
+format string ``'%Y-%m-%d %H:%M:%S'``.  This format also specifies milliseconds,
+which are appended to the result of using the above format string, with a comma
+separator.  An example time in this format is ``2003-01-23 00:29:50,411``.
 
 The ``class`` entry is optional.  It indicates the name of the formatter's class
 (as a dotted module and class name.)  This option is useful for instantiating a

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -515,9 +515,8 @@ The useful mapping keys in a :class:`LogRecord` are given in the section on
    Returns a new instance of the :class:`Formatter` class.  The instance is
    initialized with a format string for the message as a whole, as well as a
    format string for the date/time portion of a message.  If no *fmt* is
-   specified, ``'%(message)s'`` is used.  If no *datefmt* is specified, an
-   ISO8601-like (or :rfc:`3339`-like) date format is used. See the
-   :meth:`formatTime` documentation for more details.
+   specified, ``'%(message)s'`` is used.  If no *datefmt* is specified, a format
+   is used which is described in the :meth:`formatTime` documentation.
 
    The *style* parameter can be one of '%', '{' or '$' and determines how
    the format string will be merged with its data: using one of %-formatting,
@@ -557,8 +556,10 @@ The useful mapping keys in a :class:`LogRecord` are given in the section on
       formatters to provide for any specific requirement, but the basic behavior
       is as follows: if *datefmt* (a string) is specified, it is used with
       :func:`time.strftime` to format the creation time of the
-      record. Otherwise, an ISO8601-like (or RDC 3339-like) format is used.  The
-      resulting string is returned.
+      record. Otherwise, the format '%Y-%m-%d %H:%M:%S,uuu' is used, where the
+      uuu part is a millisecond value and the other letters are as per the
+      :func:`time.strftime` documentation.  An example time in this format is
+      ``2003-01-23 00:29:50,411``.  The resulting string is returned.
 
       This function uses a user-configurable function to convert the creation
       time to a tuple. By default, :func:`time.localtime` is used; to change
@@ -569,8 +570,8 @@ The useful mapping keys in a :class:`LogRecord` are given in the section on
       attribute in the ``Formatter`` class.
 
       .. versionchanged:: 3.3
-         Previously, the default ISO8601-like format was hard-coded as in this
-         example: ``2010-09-06 22:38:15,292`` where the part before the comma is
+         Previously, the default format was hard-coded as in this example:
+         ``2010-09-06 22:38:15,292`` where the part before the comma is
          handled by a strptime format string (``'%Y-%m-%d %H:%M:%S'``), and the
          part after the comma is a millisecond value. Because strptime does not
          have a format placeholder for milliseconds, the millisecond value is


### PR DESCRIPTION
… documentation.

<!-- issue-number: bpo-33400 -->
https://bugs.python.org/issue33400
<!-- /issue-number -->
