### PR TITLE
bpo-33540: Fix socketserver.ThreadingMixIn if block_on_close=False

### DIFF
--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -655,7 +655,7 @@ class ThreadingMixIn:
         t = threading.Thread(target = self.process_request_thread,
                              args = (request, client_address))
         t.daemon = self.daemon_threads
-        if not t.daemon:
+        if not t.daemon and self.block_on_close:
             if self._threads is None:
                 self._threads = []
             self._threads.append(t)


### PR DESCRIPTION
socketserver.ThreadingMixIn no longer tracks active threads if
block_on_close is false.

<!-- issue-number: bpo-33540 -->
https://bugs.python.org/issue33540
<!-- /issue-number -->
