### PR TITLE
[3.6] bpo-31238: pydoc ServerThread.stop() now joins itself (GH-3151)

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2273,6 +2273,10 @@ def _start_server(urlhandler, port):
         def stop(self):
             """Stop the server and this thread nicely"""
             self.docserver.quit = True
+            self.join()
+            # explicitly break a reference cycle: DocServer.callback
+            # has indirectly a reference to ServerThread.
+            self.docserver = None
             self.serving = False
             self.url = None
 

--- a/Misc/NEWS.d/next/Library/2017-08-21-12-31-53.bpo-31238.Gg0LRH.rst
+++ b/Misc/NEWS.d/next/Library/2017-08-21-12-31-53.bpo-31238.Gg0LRH.rst
@@ -1,0 +1,3 @@
+pydoc: the stop() method of the private ServerThread class now waits until
+DocServer.serve_until_quit() completes and then explicitly sets its
+docserver attribute to None to break a reference cycle.


### PR DESCRIPTION
ServerThread.stop() now joins itself to wait until
DocServer.serve_until_quit() completes and then explicitly sets
its docserver attribute to None to break a reference cycle.

(cherry picked from commit 4cab2cd0c05fcda5fcb128c9eb230253fff88c21)

<!-- issue-number: bpo-31238 -->
https://bugs.python.org/issue31238
<!-- /issue-number -->
