### PR TITLE
bpo-33562: Check the global asyncio event loop policy isn't set after any tests

### DIFF
--- a/Lib/test/libregrtest/save_env.py
+++ b/Lib/test/libregrtest/save_env.py
@@ -1,3 +1,4 @@
+import asyncio
 import builtins
 import locale
 import logging
@@ -65,7 +66,13 @@ class saved_test_environment:
                  'sysconfig._CONFIG_VARS', 'sysconfig._INSTALL_SCHEMES',
                  'files', 'locale', 'warnings.showwarning',
                  'shutil_archive_formats', 'shutil_unpack_formats',
+                 'asyncio.events._event_loop_policy',
                 )
+
+    def get_asyncio_events__event_loop_policy(self):
+        return support.maybe_get_event_loop_policy()
+    def restore_asyncio_events__event_loop_policy(self, policy):
+        asyncio.set_event_loop_policy(policy)
 
     def get_sys_argv(self):
         return id(sys.argv), sys.argv, sys.argv[:]

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -3,6 +3,7 @@
 if __name__ != 'test.support':
     raise ImportError('support must be imported from the test package')
 
+import asyncio.events
 import collections.abc
 import contextlib
 import errno
@@ -2878,3 +2879,8 @@ class FakePath:
             raise self.path
         else:
             return self.path
+
+
+def maybe_get_event_loop_policy():
+    """Return the global event loop policy if one is set, else return None."""
+    return asyncio.events._event_loop_policy

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -328,6 +328,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
     def tearDown(self):
         self.loop.close()
         self.loop = None
+        asyncio.set_event_loop_policy(None)
 
     async def to_list(self, gen):
         res = []

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -24,6 +24,10 @@ MOCK_ANY = mock.ANY
 PY34 = sys.version_info >= (3, 4)
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 def mock_socket_module():
     m_socket = mock.MagicMock(spec=socket)
     for name in (

--- a/Lib/test/test_asyncio/test_buffered_proto.py
+++ b/Lib/test/test_asyncio/test_buffered_proto.py
@@ -4,6 +4,10 @@ import unittest
 from test.test_asyncio import functional as func_tests
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class ReceiveStuffProto(asyncio.BufferedProtocol):
     def __init__(self, cb, con_lost_fut):
         self.cb = cb

--- a/Lib/test/test_asyncio/test_context.py
+++ b/Lib/test/test_asyncio/test_context.py
@@ -3,6 +3,10 @@ import decimal
 import unittest
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class DecimalContextTest(unittest.TestCase):
 
     def test_asyncio_task_decimal_context(self):

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -37,6 +37,10 @@ from test.test_asyncio import utils as test_utils
 from test import support
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 def osx_tiger():
     """Return True if the platform is Mac OS 10.4 or older."""
     if sys.platform != 'darwin':

--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -14,6 +14,10 @@ from test.test_asyncio import utils as test_utils
 from test import support
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 def _fakefunc(f):
     return f
 

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -16,6 +16,10 @@ STR_RGX_REPR = (
 RGX_REPR = re.compile(STR_RGX_REPR)
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class LockTests(test_utils.TestCase):
 
     def setUp(self):

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -11,6 +11,10 @@ import asyncio
 from test.test_asyncio import utils as test_utils
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 # Test that asyncio.iscoroutine() uses collections.abc.Coroutine
 class FakeCoro:
     def send(self, value):

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -16,6 +16,10 @@ from test import support
 from test.test_asyncio import utils as test_utils
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 def close_transport(transport):
     # Don't call transport.close() because the event loop and the IOCP proactor
     # are mocked

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -7,6 +7,10 @@ import asyncio
 from test.test_asyncio import utils as test_utils
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class _QueueTestBase(test_utils.TestCase):
 
     def setUp(self):

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -22,6 +22,10 @@ from test.test_asyncio import utils as test_utils
 MOCK_ANY = mock.ANY
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class TestBaseSelectorEventLoop(BaseSelectorEventLoop):
 
     def _make_self_pipe(self):

--- a/Lib/test/test_asyncio/test_server.py
+++ b/Lib/test/test_asyncio/test_server.py
@@ -9,6 +9,10 @@ from test.test_asyncio import utils as test_utils
 from test.test_asyncio import functional as func_tests
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class BaseStartServer(func_tests.FunctionalTestCaseMixin):
 
     def new_loop(self):

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -17,6 +17,10 @@ from test.test_asyncio import utils as test_utils
 from test.test_asyncio import functional as func_tests
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 @unittest.skipIf(ssl is None, 'No ssl module')
 class SslProtoHandshakeTests(test_utils.TestCase):
 

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -19,6 +19,10 @@ import asyncio
 from test.test_asyncio import utils as test_utils
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class StreamTests(test_utils.TestCase):
 
     DATA = b'line1\nline2\nline3\n'

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -23,6 +23,11 @@ PROGRAM_CAT = [
               'data = sys.stdin.buffer.read()',
               'sys.stdout.buffer.write(data)'))]
 
+
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class TestSubprocessTransport(base_subprocess.BaseSubprocessTransport):
     def _start(self, *args, **kwargs):
         self._proc = mock.Mock()

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -24,6 +24,10 @@ from test import support
 from test.support.script_helper import assert_python_ok
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 @asyncio.coroutine
 def coroutine_function():
     pass

--- a/Lib/test/test_asyncio/test_unix_events.py
+++ b/Lib/test/test_asyncio/test_unix_events.py
@@ -31,6 +31,10 @@ from test.test_asyncio import utils as test_utils
 MOCK_ANY = mock.ANY
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 def close_pipe_transport(transport):
     # Don't call transport.close() because the event loop and the selector
     # are mocked

--- a/Lib/test/test_asyncio/test_windows_events.py
+++ b/Lib/test/test_asyncio/test_windows_events.py
@@ -15,6 +15,10 @@ from asyncio import windows_events
 from test.test_asyncio import utils as test_utils
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class UpperProto(asyncio.Protocol):
     def __init__(self):
         self.buf = []

--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -14,6 +14,10 @@ from asyncio import windows_utils
 from test import support
 
 
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
 class PipeTests(unittest.TestCase):
 
     def test_pipe_overlapped(self):

--- a/Lib/test/test_asyncio/test_windows_utils.py
+++ b/Lib/test/test_asyncio/test_windows_utils.py
@@ -10,6 +10,7 @@ if sys.platform != 'win32':
 import _overlapped
 import _winapi
 
+import asyncio
 from asyncio import windows_utils
 from test import support
 

--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -18,7 +18,7 @@ def _async_test(func):
             return loop.run_until_complete(coro)
         finally:
             loop.close()
-            asyncio.set_event_loop(None)
+            asyncio.set_event_loop_policy(None)
     return wrapper
 
 
@@ -295,6 +295,7 @@ class TestAsyncExitStack(TestBaseExitStack, unittest.TestCase):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
         self.addCleanup(self.loop.close)
+        self.addCleanup(asyncio.set_event_loop_policy, None)
 
     @_async_test
     async def test_async_callback(self):

--- a/Lib/test/test_coroutines.py
+++ b/Lib/test/test_coroutines.py
@@ -2142,7 +2142,7 @@ class CoroAsyncIOCompatTest(unittest.TestCase):
             pass
         finally:
             loop.close()
-            asyncio.set_event_loop(None)
+            asyncio.set_event_loop_policy(None)
 
         self.assertEqual(buffer, [1, 2, 'MyException'])
 

--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -745,6 +745,7 @@ def test_pdb_next_command_for_coroutine():
     ...     loop = asyncio.new_event_loop()
     ...     loop.run_until_complete(test_main())
     ...     loop.close()
+    ...     asyncio.set_event_loop_policy(None)
     ...     print("finished")
 
     >>> with PdbTestInput(['step',
@@ -804,6 +805,7 @@ def test_pdb_next_command_for_asyncgen():
     ...     loop = asyncio.new_event_loop()
     ...     loop.run_until_complete(test_main())
     ...     loop.close()
+    ...     asyncio.set_event_loop_policy(None)
     ...     print("finished")
 
     >>> with PdbTestInput(['step',
@@ -915,6 +917,7 @@ def test_pdb_return_command_for_coroutine():
     ...     loop = asyncio.new_event_loop()
     ...     loop.run_until_complete(test_main())
     ...     loop.close()
+    ...     asyncio.set_event_loop_policy(None)
     ...     print("finished")
 
     >>> with PdbTestInput(['step',
@@ -1005,6 +1008,7 @@ def test_pdb_until_command_for_coroutine():
     ...     loop = asyncio.new_event_loop()
     ...     loop.run_until_complete(test_main())
     ...     loop.close()
+    ...     asyncio.set_event_loop_policy(None)
     ...     print("finished")
 
     >>> with PdbTestInput(['step',

--- a/Lib/test/test_sys_settrace.py
+++ b/Lib/test/test_sys_settrace.py
@@ -667,6 +667,7 @@ class JumpTestCase(unittest.TestCase):
             with self.assertRaisesRegex(*error):
                 asyncio.run(func(output))
         sys.settrace(None)
+        asyncio.set_event_loop_policy(None)
         self.compare_jump_output(expected, output)
 
     def jump_test(jumpFrom, jumpTo, expected, error=None, event='line'):

--- a/Misc/NEWS.d/next/Tests/2018-06-01-14-25-31.bpo-33562.GutEHf.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-01-14-25-31.bpo-33562.GutEHf.rst
@@ -1,0 +1,2 @@
+Check that a global asyncio event loop policy is not left behind by any
+tests.


### PR DESCRIPTION


<!-- issue-number: bpo-33562 -->
https://bugs.python.org/issue33562
<!-- /issue-number -->
