### PR TITLE
bpo-33724: Use the right format code for int64_t in subinterpreters code.

### DIFF
--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -33,35 +33,35 @@ _get_current(void)
 }
 
 static int64_t
-_coerce_id(PyObject *id)
+_coerce_id(PyObject *orig)
 {
-    id = PyNumber_Long(id);
-    if (id == NULL) {
+    PyObject *pyid = PyNumber_Long(orig);
+    if (pyid == NULL) {
         if (PyErr_ExceptionMatches(PyExc_TypeError)) {
-            PyErr_SetString(PyExc_TypeError,
-                            "'id' must be a non-negative int");
+            PyErr_Format(PyExc_TypeError,
+                         "'id' must be a non-negative int, got %R", orig);
         }
         else {
-            PyErr_SetString(PyExc_ValueError,
-                            "'id' must be a non-negative int");
+            PyErr_Format(PyExc_ValueError,
+                         "'id' must be a non-negative int, got %R", orig);
         }
         return -1;
     }
-    int64_t cid = PyLong_AsLongLong(id);
-    Py_DECREF(id);
-    if (cid == -1 && PyErr_Occurred() != NULL) {
+    int64_t id = PyLong_AsLongLong(pyid);
+    Py_DECREF(pyid);
+    if (id == -1 && PyErr_Occurred() != NULL) {
         if (!PyErr_ExceptionMatches(PyExc_OverflowError)) {
-            PyErr_SetString(PyExc_ValueError,
-                            "'id' must be a non-negative int");
+            PyErr_Format(PyExc_ValueError,
+                         "'id' must be a non-negative int, got %R", orig);
         }
         return -1;
     }
-    if (cid < 0) {
-        PyErr_SetString(PyExc_ValueError,
-                        "'id' must be a non-negative int");
+    if (id < 0) {
+        PyErr_Format(PyExc_ValueError,
+                     "'id' must be a non-negative int, got %R", orig);
         return -1;
     }
-    return cid;
+    return id;
 }
 
 

--- a/Modules/_xxsubinterpretersmodule.c
+++ b/Modules/_xxsubinterpretersmodule.c
@@ -1000,11 +1000,11 @@ _channels_lookup(_channels *channels, int64_t id, PyThread_type_lock *pmutex)
 
     _channelref *ref = _channelref_find(channels->head, id, NULL);
     if (ref == NULL) {
-        PyErr_Format(ChannelNotFoundError, "channel %d not found", id);
+        PyErr_Format(ChannelNotFoundError, "channel %lld not found", id);
         goto done;
     }
     if (ref->chan == NULL || !ref->chan->open) {
-        PyErr_Format(ChannelClosedError, "channel %d closed", id);
+        PyErr_Format(ChannelClosedError, "channel %lld closed", id);
         goto done;
     }
 
@@ -1064,16 +1064,16 @@ _channels_close(_channels *channels, int64_t cid, _PyChannelState **pchan,
 
     _channelref *ref = _channelref_find(channels->head, cid, NULL);
     if (ref == NULL) {
-        PyErr_Format(ChannelNotFoundError, "channel %d not found", cid);
+        PyErr_Format(ChannelNotFoundError, "channel %lld not found", cid);
         goto done;
     }
 
     if (ref->chan == NULL) {
-        PyErr_Format(ChannelClosedError, "channel %d closed", cid);
+        PyErr_Format(ChannelClosedError, "channel %lld closed", cid);
         goto done;
     }
     else if (!force && end == CHANNEL_SEND && ref->chan->closing != NULL) {
-        PyErr_Format(ChannelClosedError, "channel %d closed", cid);
+        PyErr_Format(ChannelClosedError, "channel %lld closed", cid);
         goto done;
     }
     else {
@@ -1081,7 +1081,8 @@ _channels_close(_channels *channels, int64_t cid, _PyChannelState **pchan,
             if (end == CHANNEL_SEND &&
                     PyErr_ExceptionMatches(ChannelNotEmptyError)) {
                 if (ref->chan->closing != NULL) {
-                    PyErr_Format(ChannelClosedError, "channel %d closed", cid);
+                    PyErr_Format(ChannelClosedError,
+                                 "channel %lld closed", cid);
                     goto done;
                 }
                 // Mark the channel as closing and return.  The channel
@@ -1143,7 +1144,7 @@ _channels_remove(_channels *channels, int64_t id, _PyChannelState **pchan)
     _channelref *prev = NULL;
     _channelref *ref = _channelref_find(channels->head, id, &prev);
     if (ref == NULL) {
-        PyErr_Format(ChannelNotFoundError, "channel %d not found", id);
+        PyErr_Format(ChannelNotFoundError, "channel %lld not found", id);
         goto done;
     }
 
@@ -1163,7 +1164,7 @@ _channels_add_id_object(_channels *channels, int64_t id)
 
     _channelref *ref = _channelref_find(channels->head, id, NULL);
     if (ref == NULL) {
-        PyErr_Format(ChannelNotFoundError, "channel %d not found", id);
+        PyErr_Format(ChannelNotFoundError, "channel %lld not found", id);
         goto done;
     }
     ref->objcount += 1;
@@ -1327,7 +1328,7 @@ _channel_send(_channels *channels, int64_t id, PyObject *obj)
     // Past this point we are responsible for releasing the mutex.
 
     if (chan->closing != NULL) {
-        PyErr_Format(ChannelClosedError, "channel %d closed", id);
+        PyErr_Format(ChannelClosedError, "channel %lld closed", id);
         PyThread_release_lock(mutex);
         return -1;
     }
@@ -1376,7 +1377,7 @@ _channel_recv(_channels *channels, int64_t id)
     PyThread_release_lock(mutex);
     if (data == NULL) {
         if (!PyErr_Occurred()) {
-            PyErr_Format(ChannelEmptyError, "channel %d is empty", id);
+            PyErr_Format(ChannelEmptyError, "channel %lld is empty", id);
         }
         return NULL;
     }
@@ -1526,13 +1527,13 @@ channelid_repr(PyObject *self)
     channelid *cid = (channelid *)self;
     const char *fmt;
     if (cid->end == CHANNEL_SEND) {
-        fmt = "%s(%d, send=True)";
+        fmt = "%s(%lld, send=True)";
     }
     else if (cid->end == CHANNEL_RECV) {
-        fmt = "%s(%d, recv=True)";
+        fmt = "%s(%lld, recv=True)";
     }
     else {
-        fmt = "%s(%d)";
+        fmt = "%s(%lld)";
     }
     return PyUnicode_FromFormat(fmt, name, cid->id);
 }
@@ -1541,7 +1542,7 @@ static PyObject *
 channelid_str(PyObject *self)
 {
     channelid *cid = (channelid *)self;
-    return PyUnicode_FromFormat("%d", cid->id);
+    return PyUnicode_FromFormat("%lld", cid->id);
 }
 
 PyObject *
@@ -2046,14 +2047,14 @@ interpid_repr(PyObject *self)
     PyTypeObject *type = Py_TYPE(self);
     const char *name = _PyType_Name(type);
     interpid *id = (interpid *)self;
-    return PyUnicode_FromFormat("%s(%d)", name, id->id);
+    return PyUnicode_FromFormat("%s(%lld)", name, id->id);
 }
 
 static PyObject *
 interpid_str(PyObject *self)
 {
     interpid *id = (interpid *)self;
-    return PyUnicode_FromFormat("%d", id->id);
+    return PyUnicode_FromFormat("%lld", id->id);
 }
 
 PyObject *


### PR DESCRIPTION
For bpo-32604 I added some subinterpreter-related tests (see #6914) that surfaced some problems in the _xxsubinterpreters module (but only on some platforms: ARMv7 & PPC64).  This patch addresses the failures by using ``%lld`` as the format code for ``int64_t`` instead of ``%d``.

<!-- issue-number: bpo-33724 -->
https://bugs.python.org/issue33724
<!-- /issue-number -->
