### PR TITLE
bpo-29235: Update document for Profiler's context manager

### DIFF
--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -272,6 +272,8 @@ functions:
 
       pr.print_stats()
 
+   .. versionadded:: 3.8
+
    .. method:: enable()
 
       Start collecting profiling data.

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -274,7 +274,7 @@ functions:
 
    .. versionchanged:: 3.8
       Added context manager support.
-   
+
    .. method:: enable()
 
       Start collecting profiling data.

--- a/Doc/library/profile.rst
+++ b/Doc/library/profile.rst
@@ -272,8 +272,9 @@ functions:
 
       pr.print_stats()
 
-   .. versionadded:: 3.8
-
+   .. versionchanged:: 3.8
+      Added context manager support.
+   
    .. method:: enable()
 
       Start collecting profiling data.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -151,6 +151,8 @@ Changes in the Python API
   ``type.__new__``.  A :exc:`DeprecationWarning` was emitted in Python
   3.6--3.7.  (Contributed by Serhiy Storchaka in :issue:`23722`.)
 
+* The :class:`cProfile.Profile` class can now be used as a context
+  manager. (Contributed by Scott Sanderson :issue:`29235`.)
 
 CPython bytecode changes
 ------------------------

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -152,7 +152,7 @@ Changes in the Python API
   3.6--3.7.  (Contributed by Serhiy Storchaka in :issue:`23722`.)
 
 * The :class:`cProfile.Profile` class can now be used as a context
-  manager. (Contributed by Scott Sanderson :issue:`29235`.)
+  manager. (Contributed by Scott Sanderson in :issue:`29235`.)
 
 CPython bytecode changes
 ------------------------

--- a/Misc/NEWS.d/next/Library/2018-05-14-15-01-55.bpo-29235.47Fzwt.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-14-15-01-55.bpo-29235.47Fzwt.rst
@@ -1,8 +1,2 @@
-The :class:`cProfile.Profile` class can now be used as a context manager.
-You can profile a block of code by running::
-
-  import cProfile
-  with cProfile.Profile() as profiler:
-      # ... code to be profiled ...
-
-Patch by Scott Sanderson.
+The :class:`cProfile.Profile` class can now be used as a context manager. Patch
+by Scott Sanderson.


### PR DESCRIPTION
- Add a versionadded directive to the note about Profile being a context manager.
- Remove extra paragraph from NEWS entry.
- Add an entry to whatsnew for 3.8.

cc @serhiy-storchaka, xref: https://bugs.python.org/issue29235#msg318460



<!-- issue-number: bpo-29235 -->
https://bugs.python.org/issue29235
<!-- /issue-number -->
