### PR TITLE
bpo-30974: fix os.path.samefile docstring with docs

### DIFF
--- a/Lib/genericpath.py
+++ b/Lib/genericpath.py
@@ -92,7 +92,11 @@ def samestat(s1, s2):
 
 # Are two filenames really pointing to the same file?
 def samefile(f1, f2):
-    """Test whether two pathnames reference the same actual file"""
+    """Test whether two pathnames reference the same actual file or directory
+
+    This is determined by the device number and i-node number and
+    raises an exception if an os.stat() call on either pathname fails.
+    """
     s1 = os.stat(f1)
     s2 = os.stat(f2)
     return samestat(s1, s2)


### PR DESCRIPTION
As proposed in [bpo-30974](https://bugs.python.org/issue30974) I've copied the docs of `os.path.samefile` into it's docstring to prevent confusion about what `samefile` should do.

<!-- issue-number: bpo-30974 -->
https://bugs.python.org/issue30974
<!-- /issue-number -->
