### PR TITLE
doc: Fix typo in asyncio-eventloop.rst

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -376,7 +376,7 @@ Creating connections
    callable returning a :ref:`protocol <asyncio-protocol>` instance.
 
    This method will try to establish the connection in the background.
-   When successful, the it returns a ``(transport, protocol)`` pair.
+   When successful, it returns a ``(transport, protocol)`` pair.
 
    Options changing how the connection is created:
 
@@ -429,7 +429,7 @@ Creating connections
    efficiently.
 
    This method will try to establish the connection in the background.
-   When successful, the it returns a ``(transport, protocol)`` pair.
+   When successful, it returns a ``(transport, protocol)`` pair.
 
    *path* is the name of a UNIX domain socket, and is required unless a *sock*
    parameter is specified.  Abstract UNIX sockets, :class:`str`,


### PR DESCRIPTION
This is a fixup to 19a44f63c738388ef3c8515348b4ffc061dfd627

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
