### PR TITLE
[2.7] bpo-30654: Do not reset SIGINT handler to SIG_DFL in finisignal (GH-7146)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-05-28-12-28-53.bpo-30654.9fDJye.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-05-28-12-28-53.bpo-30654.9fDJye.rst
@@ -1,0 +1,2 @@
+Fixed reset of the SIGINT handler to SIG_DFL on interpreter shutdown even
+when there was a custom handler set previously. Patch by Philipp Kerling.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -95,13 +95,6 @@ static PyObject *DefaultHandler;
 static PyObject *IgnoreHandler;
 static PyObject *IntHandler;
 
-/* On Solaris 8, gcc will produce a warning that the function
-   declaration is not a prototype. This is caused by the definition of
-   SIG_DFL as (void (*)())0; the correct declaration would have been
-   (void (*)(int))0. */
-
-static PyOS_sighandler_t old_siginthandler = SIG_DFL;
-
 #ifdef HAVE_GETITIMER
 static PyObject *ItimerError;
 
@@ -629,7 +622,7 @@ initsignal(void)
         /* Install default int handler */
         Py_INCREF(IntHandler);
         Py_SETREF(Handlers[SIGINT].func, IntHandler);
-        old_siginthandler = PyOS_setsig(SIGINT, signal_handler);
+        PyOS_setsig(SIGINT, signal_handler);
     }
 
 #ifdef SIGHUP
@@ -872,14 +865,11 @@ finisignal(void)
     int i;
     PyObject *func;
 
-    PyOS_setsig(SIGINT, old_siginthandler);
-    old_siginthandler = SIG_DFL;
-
     for (i = 1; i < NSIG; i++) {
         func = Handlers[i].func;
         Handlers[i].tripped = 0;
         Handlers[i].func = NULL;
-        if (i != SIGINT && func != NULL && func != Py_None &&
+        if (func != NULL && func != Py_None &&
             func != DefaultHandler && func != IgnoreHandler)
             PyOS_setsig(i, SIG_DFL);
         Py_XDECREF(func);


### PR DESCRIPTION
(cherry picked from commit e905c84)

<!-- issue-number: bpo-30654 -->
https://bugs.python.org/issue30654
<!-- /issue-number -->
