### PR TITLE
bpo-33509: Fix test_warnings for python3 -Werror

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -221,6 +221,8 @@ class FilterTests(BaseTest):
     def test_module_globals(self):
         with original_warnings.catch_warnings(record=True,
                 module=self.module) as w:
+            self.module.simplefilter("always", UserWarning)
+
             # bpo-33509: module_globals=None must not crash
             self.module.warn_explicit('msg', UserWarning, "filename", 42,
                                       module_globals=None)


### PR DESCRIPTION
Fix test_warnings.test_module_globals() when python3 is run with
-Werror.

<!-- issue-number: bpo-33509 -->
https://bugs.python.org/issue33509
<!-- /issue-number -->
