### PR TITLE
bpo-33764: Disable largefile on AppVeyor

### DIFF
--- a/.github/appveyor.yml
+++ b/.github/appveyor.yml
@@ -30,7 +30,7 @@ build_script:
   - cmd: PCbuild\build.bat -e
   - cmd: PCbuild\win32\python.exe -m test.pythoninfo
 test_script:
-  - cmd: PCbuild\rt.bat -q -uall -u-cpu -rwW --slowest --timeout=1200 --fail-env-changed -j0
+  - cmd: PCbuild\rt.bat -q -uall -u-cpu -u-largefile -rwW --slowest --timeout=1200 --fail-env-changed -j0
 environment:
   HOST_PYTHON: C:\Python36\python.exe
 image:


### PR DESCRIPTION
AppVeyor started to fail with:

"Build exceeded allowed resource quotas. Fix your build to consume
less resources or contact AppVeyor support to request quotas
increase."

Disable largefile tests to try to workaround this error.

<!-- issue-number: bpo-33764 -->
https://bugs.python.org/issue33764
<!-- /issue-number -->
