### PR TITLE
[2.7] bpo-33759: Fix test.test_xmlrpc.ServerProxyTestCase. (GH-7362)

### DIFF
--- a/Lib/test/test_xmlrpc.py
+++ b/Lib/test/test_xmlrpc.py
@@ -854,13 +854,9 @@ class GzipServerTestCase(BaseServerTestCase):
 class ServerProxyTestCase(unittest.TestCase):
     def setUp(self):
         unittest.TestCase.setUp(self)
-        if threading:
-            self.url = URL
-        else:
-            # Without threading, http_server() and http_multi_server() will not
-            # be executed and URL is still equal to None. 'http://' is a just
-            # enough to choose the scheme (HTTP)
-            self.url = 'http://'
+        # Actual value of the URL doesn't matter if it is a string in
+        # the correct format.
+        self.url = 'http://fake.localhost'
 
     def test_close(self):
         p = xmlrpclib.ServerProxy(self.url)


### PR DESCRIPTION
It depended on a global variable set by other tests.
(cherry picked from commit 7cfd8c6a1b53a7dbdea14b6f414f2629dcd130a2)


<!-- issue-number: bpo-33759 -->
https://bugs.python.org/issue33759
<!-- /issue-number -->
