### PR TITLE
bpo-33767: Fix improper use of SystemError by mmap.mmap objects

### DIFF
--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -735,7 +735,6 @@ class MmapTests(unittest.TestCase):
         self.assertRaises(ValueError, m.write, b'abc')
 
     def test_concat_repeat_exception(self):
-        # A SystemError was raised on two unsupported sequence operations.
         m = mmap.mmap(-1, 16)
         with self.assertRaises(TypeError):
             m + m

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -734,6 +734,14 @@ class MmapTests(unittest.TestCase):
         self.assertRaises(ValueError, m.write_byte, 42)
         self.assertRaises(ValueError, m.write, b'abc')
 
+    def test_concat_repeat_exception(self):
+        # A SystemError was raised on two unsupported sequence operations.
+        m = mmap.mmap(-1, 16)
+        with self.assertRaises(TypeError):
+            m + m
+        with self.assertRaises(TypeError):
+            m * 2
+
 
 class LargeMmapTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2018-06-03-22-41-59.bpo-33767.2e82g3.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-03-22-41-59.bpo-33767.2e82g3.rst
@@ -1,2 +1,3 @@
-Fix improper use of :exc:`SystemError` by :class:`mmap.mmap` objects.  Patch
-by Zackery Spytz.
+The concatenation (``+``) and repetition (``*``) sequence operations now
+raise :exc:`TypeError` instead of :exc:`SystemError` when performed on
+:class:`mmap.mmap` objects.  Patch by Zackery Spytz.

--- a/Misc/NEWS.d/next/Library/2018-06-03-22-41-59.bpo-33767.2e82g3.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-03-22-41-59.bpo-33767.2e82g3.rst
@@ -1,0 +1,2 @@
+Fix improper use of :exc:`SystemError` by :class:`mmap.mmap` objects.  Patch
+by Zackery Spytz.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -816,7 +816,7 @@ static PyObject *
 mmap_concat(mmap_object *self, PyObject *bb)
 {
     CHECK_VALID(NULL);
-    PyErr_SetString(PyExc_SystemError,
+    PyErr_SetString(PyExc_TypeError,
                     "mmaps don't support concatenation");
     return NULL;
 }
@@ -825,7 +825,7 @@ static PyObject *
 mmap_repeat(mmap_object *self, Py_ssize_t n)
 {
     CHECK_VALID(NULL);
-    PyErr_SetString(PyExc_SystemError,
+    PyErr_SetString(PyExc_TypeError,
                     "mmaps don't support repeat operation");
     return NULL;
 }

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -812,24 +812,6 @@ mmap_subscript(mmap_object *self, PyObject *item)
     }
 }
 
-static PyObject *
-mmap_concat(mmap_object *self, PyObject *bb)
-{
-    CHECK_VALID(NULL);
-    PyErr_SetString(PyExc_TypeError,
-                    "mmaps don't support concatenation");
-    return NULL;
-}
-
-static PyObject *
-mmap_repeat(mmap_object *self, Py_ssize_t n)
-{
-    CHECK_VALID(NULL);
-    PyErr_SetString(PyExc_TypeError,
-                    "mmaps don't support repeat operation");
-    return NULL;
-}
-
 static int
 mmap_ass_item(mmap_object *self, Py_ssize_t i, PyObject *v)
 {
@@ -949,8 +931,8 @@ mmap_ass_subscript(mmap_object *self, PyObject *item, PyObject *value)
 
 static PySequenceMethods mmap_as_sequence = {
     (lenfunc)mmap_length,            /*sq_length*/
-    (binaryfunc)mmap_concat,         /*sq_concat*/
-    (ssizeargfunc)mmap_repeat,       /*sq_repeat*/
+    0,                               /*sq_concat*/
+    0,                               /*sq_repeat*/
     (ssizeargfunc)mmap_item,         /*sq_item*/
     0,                               /*sq_slice*/
     (ssizeobjargproc)mmap_ass_item,  /*sq_ass_item*/


### PR DESCRIPTION
An alternative would be to remove `mmap_concat()` and `mmap_repeat()` to rely on the default TypeError. 

<!-- issue-number: bpo-33767 -->
https://bugs.python.org/issue33767
<!-- /issue-number -->
