### PR TITLE
bpo-33766: Document that end of file or string is a newline 

### DIFF
--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -53,6 +53,9 @@ form using the ASCII sequence CR LF (return followed by linefeed), or the old
 Macintosh form using the ASCII CR (return) character.  All of these forms can be
 used equally, regardless of platform.
 
+The end of a file may also serve as a terminator for a physical line. This is
+relevant when a file does not end with an end-of-line sequence.
+
 When embedding Python, source code strings should be passed to Python APIs using
 the standard C conventions for newline characters (the ``\n`` character,
 representing ASCII LF, is the line terminator).

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -47,14 +47,12 @@ Physical lines
 --------------
 
 A physical line is a sequence of characters terminated by an end-of-line
-sequence.  In source files, any of the standard platform line termination
-sequences can be used - the Unix form using ASCII LF (linefeed), the Windows
-form using the ASCII sequence CR LF (return followed by linefeed), or the old
-Macintosh form using the ASCII CR (return) character.  All of these forms can be
-used equally, regardless of platform.
-
-The end of a file may also serve as a terminator for a physical line. This is
-relevant when a file does not end with an end-of-line sequence.
+sequence.  In source files and strings, any of the standard platform line
+termination sequences can be used - the Unix form using ASCII LF (linefeed),
+the Windows form using the ASCII sequence CR LF (return followed by linefeed),
+or the old Macintosh form using the ASCII CR (return) character.  All of these
+forms can be used equally, regardless of platform. The end of input also serves
+as an implicit terminator for the final physical line.
 
 When embedding Python, source code strings should be passed to Python APIs using
 the standard C conventions for newline characters (the ``\n`` character,


### PR DESCRIPTION
Tried to cover the technical side and the relevant use case in the wording.

<!-- issue-number: bpo-33766 -->
https://bugs.python.org/issue33766
<!-- /issue-number -->
