### PR TITLE
bpo-30436: Add missing space in importlib.util.find_spec() error message

### DIFF
--- a/Lib/importlib/util.py
+++ b/Lib/importlib/util.py
@@ -96,7 +96,7 @@ def find_spec(name, package=None):
                 parent_path = parent.__path__
             except AttributeError as e:
                 raise ModuleNotFoundError(
-                    f"__path__ attribute not found on {parent_name!r}"
+                    f"__path__ attribute not found on {parent_name!r} "
                     f"while trying to find {fullname!r}", name=fullname) from e
         else:
             parent_path = None


### PR DESCRIPTION


<!-- issue-number: bpo-30436 -->
https://bugs.python.org/issue30436
<!-- /issue-number -->
