### PR TITLE
[2.7] bpo-33718: regrtest keeps filters to re-run fails

### DIFF
--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -276,7 +276,11 @@ def format_duration(seconds):
         return '%.0f sec' % seconds
 
     minutes, seconds = divmod(seconds, 60.0)
-    return '%.0f min %.0f sec' % (minutes, seconds)
+    hours, minutes = divmod(minutes, 60.0)
+    if hours:
+        return '%.0f hour %.0f min' % (hours, minutes)
+    else:
+        return '%.0f min %.0f sec' % (minutes, seconds)
 
 
 _FORMAT_TEST_RESULT = {
@@ -770,7 +774,7 @@ def main(tests=None, testdir=None, verbose=0, quiet=False,
                     continue
                 dt = time.time() - worker.start_time
                 if dt >= PROGRESS_MIN_TIME:
-                    running.append('%s (%.0f sec)' % (current_test, dt))
+                    running.append('%s (%s)' % (current_test, format_duration(dt)))
             return running
 
         finished = 0

--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -638,8 +638,9 @@ def main(tests=None, testdir=None, verbose=0, quiet=False,
     def display_progress(test_index, test):
         # "[ 51/405/1] test_tcl"
         line = "{1:{0}}{2}".format(test_count_width, test_index, test_count)
-        if bad and not pgo:
-            line = '{}/{}'.format(line, len(bad))
+        fails = len(bad) + len(environment_changed)
+        if fails and not pgo:
+            line = '{}/{}'.format(line, fails)
         line = '[{}]'.format(line)
 
         # add the system load prefix: "load avg: 1.80 "

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1671,6 +1671,14 @@ def run_doctest(module, verbosity=None):
 #=======================================================================
 # Threading support to prevent reporting refleaks when running regrtest.py -R
 
+# Flag used by saved_test_environment of test.libregrtest.save_env,
+# to check if a test modified the environment. The flag should be set to False
+# before running a new test.
+#
+# For example, threading_cleanup() sets the flag is the function fails
+# to cleanup threads.
+environment_altered = False
+
 # NOTE: we use thread._count() rather than threading.enumerate() (or the
 # moral equivalent thereof) because a threading.Thread object is still alive
 # until its __bootstrap() method has returned, even after it has been


### PR DESCRIPTION
* No longer clear filters, like --match, to re-run failed tests in
  verbose mode (-w option).
* Tests result: always indicate if tests have been interrupted.
* Enhance tests summary
* After failing tests are re-run, display again the summary.

<!-- issue-number: bpo-33718 -->
https://bugs.python.org/issue33718
<!-- /issue-number -->
