### PR TITLE
[2.7] bpo-18174: Fix file descriptor leaks in tests

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -199,6 +199,7 @@ class PosixTester(unittest.TestCase):
     def test_fdopen_directory(self):
         try:
             fd = os.open('.', os.O_RDONLY)
+            self.addCleanup(os.close, fd)
         except OSError as e:
             self.assertEqual(e.errno, errno.EACCES)
             self.skipTest("system cannot open directories")

--- a/Lib/test/test_tempfile.py
+++ b/Lib/test/test_tempfile.py
@@ -821,6 +821,7 @@ class test_NamedTemporaryFile(TC):
         old_fdopen = os.fdopen
         closed = []
         def close(fd):
+            old_close(fd)
             closed.append(fd)
         def fdopen(*args):
             raise ValueError()


### PR DESCRIPTION
* test_tempfile.test_no_leak_fd() mocks os.close() but it doesn't
  call the original os.close() method and so leaks an open file
  descriptor. Fix the test by calling the original os.close()
  function.
* test_posix.test_fdopen_directory(): close the directory file
  descriptor when the test completes.

<!-- issue-number: bpo-18174 -->
https://bugs.python.org/issue18174
<!-- /issue-number -->
