### PR TITLE
bpo-33755: Fix importlib.resources isolation tests

### DIFF
--- a/Lib/test/test_importlib/test_resource.py
+++ b/Lib/test/test_importlib/test_resource.py
@@ -2,7 +2,7 @@ import sys
 import unittest
 
 from . import data01
-from . import zipdata02
+from . import zipdata01, zipdata02
 from . import util
 from importlib import resources, import_module
 
@@ -108,6 +108,10 @@ class ResourceFromZipsTest(util.ZipSetupBase, unittest.TestCase):
         self.assertEqual(
             set(resources.contents('ziptestdata.two')),
             {'__init__.py', 'resource2.txt'})
+
+
+class SubdirectoryResourceFromZipsTest(util.ZipSetupBase, unittest.TestCase):
+    ZIP_MODULE = zipdata01                          # type: ignore
 
     def test_is_submodule_resource(self):
         submodule = import_module('ziptestdata.subdirectory')

--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -549,6 +549,10 @@ class ZipSetupBase:
         except AttributeError:
             pass
 
+    def setUp(self):
+        modules = support.modules_setup()
+        self.addCleanup(support.modules_cleanup, *modules)
+
 
 class ZipSetup(ZipSetupBase):
     ZIP_MODULE = zipdata01                          # type: ignore


### PR DESCRIPTION


<!-- issue-number: bpo-33755 -->
https://bugs.python.org/issue33755
<!-- /issue-number -->
