### PR TITLE
[2.7] bpo-18174: Fix fd_count() on FreeBSD

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2069,8 +2069,9 @@ def fd_count():
         try:
             names = os.listdir("/proc/self/fd")
             return len(names)
-        except FileNotFoundError:
-            pass
+        except OSError as exc:
+            if exc.errno != errno.ENOENT:
+                raise
 
     old_modes = None
     if sys.platform == 'win32':


### PR DESCRIPTION
Python 2.7 doesn't have FileNotFoundError exception: use OSError and
errno.ENOENT.

<!-- issue-number: bpo-18174 -->
https://bugs.python.org/issue18174
<!-- /issue-number -->
