### PR TITLE
bpo-33773: Fix test.support.fd_count() on Linux/FreBSD

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2768,7 +2768,9 @@ def fd_count():
     if sys.platform.startswith(('linux', 'freebsd')):
         try:
             names = os.listdir("/proc/self/fd")
-            return len(names)
+            # Substract one because listdir() opens internally a file
+            # descriptor to list the content of the /proc/self/fd/ directory.
+            return len(names) - 1
         except FileNotFoundError:
             pass
 

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2774,6 +2774,13 @@ def fd_count():
         except FileNotFoundError:
             pass
 
+    MAXFD = 256
+    if hasattr(os, 'sysconf'):
+        try:
+            MAXFD = os.sysconf("SC_OPEN_MAX")
+        except OSError:
+            pass
+
     old_modes = None
     if sys.platform == 'win32':
         # bpo-25306, bpo-31009: Call CrtSetReportMode() to not kill the process
@@ -2790,13 +2797,6 @@ def fd_count():
                                 msvcrt.CRT_ERROR,
                                 msvcrt.CRT_ASSERT):
                 old_modes[report_type] = msvcrt.CrtSetReportMode(report_type, 0)
-
-    MAXFD = 256
-    if hasattr(os, 'sysconf'):
-        try:
-            MAXFD = os.sysconf("SC_OPEN_MAX")
-        except OSError:
-            pass
 
     try:
         count = 0

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -569,6 +569,18 @@ class TestSupport(unittest.TestCase):
             self.assertTrue(support.match_test(test_access))
             self.assertFalse(support.match_test(test_chdir))
 
+    def test_fd_count(self):
+        code = "from test.support import fd_count; print(fd_count())"
+        proc = script_helper.assert_python_ok("-c", code)
+        out = proc.out.decode("ascii", "replace").strip()
+        # A fresh Python process should have exactly 3 open file descriptors
+        # (stdin, stdout, stderr) even if these standard streams have been
+        # closed in the parent process. assert_python_ok() opens one pipe
+        # per stream, so 3 pipes in total (stdin, stdout, stderr).
+        #
+        # subprocess.Popen(close_fds=True) and PEP 446 ensure that the child
+        # process don't inherit file descriptors from its parent.
+        self.assertEqual(out, "3")
 
     # XXX -follows a list of untested API
     # make_legacy_pyc


### PR DESCRIPTION
Substract one because listdir() opens internally a file
descriptor to list the content of the /proc/self/fd/ directory.

<!-- issue-number: bpo-33773 -->
https://bugs.python.org/issue33773
<!-- /issue-number -->
