### PR TITLE
[2.7] bpo-33767: Fix improper use of SystemError by mmap.mmap objects (GH-7381)

### DIFF
--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -666,6 +666,13 @@ class MmapTests(unittest.TestCase):
         self.assertRaises(ValueError, m.write_byte, 'b')
         self.assertRaises(ValueError, m.write, 'abc')
 
+    def test_concat_repeat_exception(self):
+        m = mmap.mmap(-1, 16)
+        with self.assertRaises(TypeError):
+            m + m
+        with self.assertRaises(TypeError):
+            m * 2
+
 
 class LargeMmapTests(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2018-06-03-22-41-59.bpo-33767.2e82g3.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-03-22-41-59.bpo-33767.2e82g3.rst
@@ -1,0 +1,3 @@
+The concatenation (``+``) and repetition (``*``) sequence operations now
+raise :exc:`TypeError` instead of :exc:`SystemError` when performed on
+:class:`mmap.mmap` objects.  Patch by Zackery Spytz.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -818,24 +818,6 @@ mmap_subscript(mmap_object *self, PyObject *item)
     }
 }
 
-static PyObject *
-mmap_concat(mmap_object *self, PyObject *bb)
-{
-    CHECK_VALID(NULL);
-    PyErr_SetString(PyExc_SystemError,
-                    "mmaps don't support concatenation");
-    return NULL;
-}
-
-static PyObject *
-mmap_repeat(mmap_object *self, Py_ssize_t n)
-{
-    CHECK_VALID(NULL);
-    PyErr_SetString(PyExc_SystemError,
-                    "mmaps don't support repeat operation");
-    return NULL;
-}
-
 static int
 mmap_ass_slice(mmap_object *self, Py_ssize_t ilow, Py_ssize_t ihigh, PyObject *v)
 {
@@ -993,9 +975,9 @@ mmap_ass_subscript(mmap_object *self, PyObject *item, PyObject *value)
 
 static PySequenceMethods mmap_as_sequence = {
     (lenfunc)mmap_length,                      /*sq_length*/
-    (binaryfunc)mmap_concat,                   /*sq_concat*/
-    (ssizeargfunc)mmap_repeat,                 /*sq_repeat*/
-    (ssizeargfunc)mmap_item,                           /*sq_item*/
+    0,                                         /*sq_concat*/
+    0,                                         /*sq_repeat*/
+    (ssizeargfunc)mmap_item,                   /*sq_item*/
     (ssizessizeargfunc)mmap_slice,             /*sq_slice*/
     (ssizeobjargproc)mmap_ass_item,            /*sq_ass_item*/
     (ssizessizeobjargproc)mmap_ass_slice,      /*sq_ass_slice*/


### PR DESCRIPTION
Raise TypeError instead of SystemError for unsupported operations..
(cherry picked from commit e9e397605789b2a67b67558fbbe756b7b88934f5)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>


<!-- issue-number: bpo-33767 -->
https://bugs.python.org/issue33767
<!-- /issue-number -->
