### PR TITLE
[2.7] PC/_subprocess.c: Fix signed/unsigned comparison

### DIFF
--- a/PC/_subprocess.c
+++ b/PC/_subprocess.c
@@ -381,7 +381,7 @@ getenvironment(PyObject* environment)
         }
         totalsize = (p - PyString_AS_STRING(out)) + ksize + 1 +
                                                      vsize + 1 + 1;
-        if (totalsize > PyString_GET_SIZE(out)) {
+        if (totalsize > (size_t)PyString_GET_SIZE(out)) {
             size_t offset = p - PyString_AS_STRING(out);
             if (_PyString_Resize(&out, totalsize + 1024))
                 goto exit;


### PR DESCRIPTION
Fix the following compiler warning on Windows:
..\PC\_subprocess.c(384): warning C4018: '>' : signed/unsigned mismatch