### PR TITLE
bpo-31044, test_posix: Reenable makedev() tests on FreeBSD

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -615,11 +615,6 @@ class PosixTester(unittest.TestCase):
         self.assertRaises(TypeError, posix.minor)
         self.assertRaises((ValueError, OverflowError), posix.minor, -1)
 
-        # FIXME: reenable these tests on FreeBSD with the kernel fix
-        if sys.platform.startswith('freebsd') and dev >= 0x1_0000_0000:
-            self.skipTest("bpo-31044: on FreeBSD CURRENT, minor() truncates "
-                          "64-bit dev to 32-bit")
-
         self.assertEqual(posix.makedev(major, minor), dev)
         self.assertRaises(TypeError, posix.makedev, float(major), minor)
         self.assertRaises(TypeError, posix.makedev, major, float(minor))


### PR DESCRIPTION
The bug has been fixed 10 months ago:

* https://svnweb.freebsd.org/base?view=revision&revision=321920
* https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=221048

<!-- issue-number: bpo-31044 -->
https://bugs.python.org/issue31044
<!-- /issue-number -->
