### PR TITLE
[2.7] bpo-19418: audioop.c: Fix warnings on -0x80000000

### DIFF
--- a/Modules/audioop.c
+++ b/Modules/audioop.c
@@ -25,7 +25,8 @@ typedef short PyInt16;
 #endif
 
 static const int maxvals[] = {0, 0x7F, 0x7FFF, 0x7FFFFF, 0x7FFFFFFF};
-static const int minvals[] = {0, -0x80, -0x8000, -0x800000, -0x80000000};
+/* -1 trick is needed on Windows to support -0x80000000 without a warning */
+static const int minvals[] = {0, -0x80, -0x8000, -0x800000, -0x7FFFFFFF-1};
 static const unsigned int masks[] = {0, 0xFF, 0xFFFF, 0xFFFFFF, 0xFFFFFFFF};
 
 static int
@@ -393,7 +394,9 @@ audioop_minmax(PyObject *self, PyObject *args)
     signed char *cp;
     int len, size, val = 0;
     int i;
-    int min = 0x7fffffff, max = -0x80000000;
+    /* -1 trick below is needed on Windows to support -0x80000000 without
+    a warning */
+    int min = 0x7fffffff, max = -0x7FFFFFFF-1;
 
     if (!PyArg_ParseTuple(args, "s#i:minmax", &cp, &len, &size))
         return NULL;


### PR DESCRIPTION
bpo-19418, bpo-33781: Fix the following warnings on Windows:

Modules\audioop.c(28): warning C4146: unary minus operator applied
    to unsigned type, result still unsigned
Modules\audioop.c(396): warning C4146: unary minus operator applied
    to unsigned type, result still unsigned

<!-- issue-number: bpo-19418 -->
https://bugs.python.org/issue19418
<!-- /issue-number -->
