### PR TITLE
[2.7] bpo-33773: Fix test.support.fd_count() on Linux/FreBSD (GH-7421)

### DIFF
--- a/Lib/test/test_test_support.py
+++ b/Lib/test/test_test_support.py
@@ -417,6 +417,17 @@ class TestSupport(unittest.TestCase):
             self.assertTrue(support.match_test(test_access))
             self.assertFalse(support.match_test(test_chdir))
 
+    def test_fd_count(self):
+        # We cannot test the absolute value of fd_count(): on old Linux
+        # kernel or glibc versions, os.urandom() keeps a FD open on
+        # /dev/urandom device and Python has 4 FD opens instead of 3.
+        start = support.fd_count()
+        fd = os.open(__file__, os.O_RDONLY)
+        try:
+            more = support.fd_count()
+        finally:
+            os.close(fd)
+        self.assertEqual(more - start, 1)
 
     # XXX -follows a list of untested API
     # make_legacy_pyc


### PR DESCRIPTION
Substract one because listdir() opens internally a file
descriptor to list the content of the /proc/self/fd/ directory.

Add test_support.test_fd_count().

Move also MAXFD code before msvcrt.CrtSetReportMode(), to make sure
that the report mode is always restored on failure.

(cherry picked from commit 492d6424a7ca907c8ec1df21e51062e8f3d88e32)

<!-- issue-number: bpo-33773 -->
https://bugs.python.org/issue33773
<!-- /issue-number -->
