### PR TITLE
Added more to docstring of datetime.timedelta

### DIFF
--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2637,7 +2637,11 @@ static PyMethodDef delta_methods[] = {
 };
 
 static const char delta_doc[] =
-PyDoc_STR("Difference between two datetime values.");
+PyDoc_STR("Difference between two datetime values.\n\n"
+          "timedelta(days=0, seconds=0, microseconds=0, milliseconds=0, "
+          "minutes=0, hours=0, weeks=0)\n\n"
+          "All arguments are optional and default to 0.\n"
+          "Arguments may be integers or floats, and may be positive or negative.");
 
 static PyNumberMethods delta_as_number = {
     delta_add,                                  /* nb_add */


### PR DESCRIPTION
Addition of signature and a bit more text to the class docstring for datetime.datetime, as discussed on python-dev 5 June, 2018.

https://mail.python.org/pipermail/python-dev/2018-June/153813.html

NOTE: it would be nice to get this back-ported to all actively maintained versions, but I have no idea how to trigger that.

But if this is approved, and someone lets me know how to do it, I'll be happy to do so.

Also -- I couldn't find clear guidance in PEP 257 for docstrings for C classes, so I hope this is close.
