### PR TITLE
bpo-33789: test_asyncio: Fix ResourceWarning

### DIFF
--- a/Lib/test/test_asyncio/functional.py
+++ b/Lib/test/test_asyncio/functional.py
@@ -150,9 +150,14 @@ class TestSocketWrapper:
             server_hostname=server_hostname,
             do_handshake_on_connect=False)
 
-        ssl_sock.do_handshake()
+        try:
+            ssl_sock.do_handshake()
+        except:
+            ssl_sock.close()
+            raise
+        finally:
+            self.__sock.close()
 
-        self.__sock.close()
         self.__sock = ssl_sock
 
     def __getattr__(self, name):

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -604,6 +604,8 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                     server_side=True)
             except ssl.SSLError:
                 pass
+            except OSError:
+                pass
             finally:
                 sock.close()
 
@@ -640,6 +642,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
             except ssl.SSLError:
                 pass
             finally:
+                orig_sock.close()
                 sock.close()
 
         async def client(addr):
@@ -653,6 +656,8 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
             writer.write(b'B')
             with self.assertRaises(ssl.SSLError):
                 await reader.readline()
+
+            writer.close()
             return 'OK'
 
         with self.tcp_server(server,


### PR DESCRIPTION
* Close sockets and streams to fix ResourceWarning warnings
* Catch also OSError to hide a traceback on an expected handshake
  error

<!-- issue-number: bpo-33789 -->
https://bugs.python.org/issue33789
<!-- /issue-number -->
