### PR TITLE
bpo-33789, test_asyncio: Hide PendingDeprecationWarning

### DIFF
--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2613,7 +2613,8 @@ class BaseTaskIntrospectionTests:
         self.assertEqual(asyncio.all_tasks(loop), set())
         self._register_task(task)
         self.assertEqual(asyncio.all_tasks(loop), set())
-        self.assertEqual(asyncio.Task.all_tasks(loop), {task})
+        with self.assertWarns(PendingDeprecationWarning):
+            self.assertEqual(asyncio.Task.all_tasks(loop), {task})
         self._unregister_task(task)
 
     def test__enter_task(self):


### PR DESCRIPTION
Hide PendingDeprecationWarning in test__register_task_3().

<!-- issue-number: bpo-33789 -->
https://bugs.python.org/issue33789
<!-- /issue-number -->
