### PR TITLE
bpo-32676, test_asyncio: Fix warning in test_error_in_call_soon()

### DIFF
--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2182,7 +2182,11 @@ class BaseTaskTests:
         self.assertFalse(m_log.error.called)
 
         with self.assertRaises(ValueError):
-            self.new_task(self.loop, coro())
+            gen = coro()
+            try:
+                self.new_task(self.loop, gen)
+            finally:
+                gen.close()
 
         self.assertTrue(m_log.error.called)
         message = m_log.error.call_args[0][0]


### PR DESCRIPTION
Fix "<CoroWrapper ...> was never yielded from" warning in
PyTask_PyFuture_Tests.test_error_in_call_soon() of
test_asyncio.test_tasks.

Close manually the coroutine on error.

<!-- issue-number: bpo-32676 -->
https://bugs.python.org/issue32676
<!-- /issue-number -->
