### PR TITLE
bpo-33274: Compliance with DOM L1: return removed attribute

### DIFF
--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -325,7 +325,7 @@ class MinidomTest(unittest.TestCase):
         node = child.getAttributeNode("spam")
         self.assertRaises(xml.dom.NotFoundErr, child.removeAttributeNode,
             None)
-        child.removeAttributeNode(node)
+        self.assertIs(node, child.removeAttributeNode(node))
         self.confirm(len(child.attributes) == 0
                 and child.getAttributeNode("spam") is None)
         dom2 = Document()

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -823,6 +823,7 @@ class Element(Node):
         # Restore this since the node is still useful and otherwise
         # unlinked
         node.ownerDocument = self.ownerDocument
+        return node
 
     removeAttributeNodeNS = removeAttributeNode
 

--- a/Misc/NEWS.d/next/Library/2018-06-06-22-01-33.bpo-33274.teYqv8.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-06-22-01-33.bpo-33274.teYqv8.rst
@@ -1,3 +1,3 @@
 W3C DOM Level 1 specifies return value of Element.removeAttributeNode() as
 "The Attr node that was removed." xml.dom.minidom now complies with this
-requirement
+requirement.

--- a/Misc/NEWS.d/next/Library/2018-06-06-22-01-33.bpo-33274.teYqv8.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-06-22-01-33.bpo-33274.teYqv8.rst
@@ -1,0 +1,3 @@
+W3C DOM Level 1 specifies return value of Element.removeAttributeNode() as
+"The Attr node that was removed." xml.dom.minidom now complies with this
+requirement


### PR DESCRIPTION
W3C DOM Level 1[1] requires `removeAttributeNode()` to return the removed node:

removeAttributeNode: Removes the specified attribute.
Return Value: The Attr node that was removed.

Current implementation returns `None`.

[1]https://www.w3.org/TR/1998/REC-DOM-Level-1-19981001/level-one-core.html#method-removeAttributeNode

<!-- issue-number: bpo-33274 -->
https://bugs.python.org/issue33274
<!-- /issue-number -->
