### PR TITLE
bpo-33791: Changed README for Mac users

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,9 @@ to find out more.  On macOS and Cygwin, the executable is called ``python.exe``;
 elsewhere it's just ``python``.
 
 If you are running on Mac with the latest updates installed, make sure to install
-openSSL or some other SSL software along with Homebrew.
+openSSL or some other SSL software along with Homebrew or another package manager.
+If issues persist, see https://devguide.python.org/setup/#macos-and-os-x for more 
+information. 
 
 On macOS, if you have configured Python with ``--enable-framework``, you
 should use ``make frameworkinstall`` to do the installation.  Note that this

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ You can pass many options to the configure script; run ``./configure --help``
 to find out more.  On macOS and Cygwin, the executable is called ``python.exe``;
 elsewhere it's just ``python``.
 
-If you are running on Mac with the latest updates installed, make sure to install
+If you are running on MacOS with the latest updates installed, make sure to install
 openSSL or some other SSL software along with Homebrew or another package manager.
 If issues persist, see https://devguide.python.org/setup/#macos-and-os-x for more 
 information. 

--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,7 @@ You can pass many options to the configure script; run ``./configure --help``
 to find out more.  On macOS and Cygwin, the executable is called ``python.exe``;
 elsewhere it's just ``python``.
 
-If you are running on MacOS with the latest updates installed, make sure to install
+If you are running on macOS with the latest updates installed, make sure to install
 openSSL or some other SSL software along with Homebrew or another package manager.
 If issues persist, see https://devguide.python.org/setup/#macos-and-os-x for more 
 information. 

--- a/README.rst
+++ b/README.rst
@@ -62,6 +62,9 @@ You can pass many options to the configure script; run ``./configure --help``
 to find out more.  On macOS and Cygwin, the executable is called ``python.exe``;
 elsewhere it's just ``python``.
 
+If you are running on Mac with the latest updates installed, make sure to install
+openSSL or some other SSL software along with Homebrew.
+
 On macOS, if you have configured Python with ``--enable-framework``, you
 should use ``make frameworkinstall`` to do the installation.  Note that this
 installs the Python executable in a place that is not normally on your PATH,


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# README change for Mac users

It should be in the following format:

```
I tried to run this on my MacBook Pro running OSX 10.13.5 (17F77). I could not get it to install, and found out you need to download some SSL to install because the default one that comes with Mac OS does not do the job. I changed the build instructions to include instructions for SSL for Mac users. 
```

Where: No Issue. 

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: bpo-33791 -->
https://bugs.python.org/issue33791
<!-- /issue-number -->
