### PR TITLE
gh-75044: Return StreamReeader remaining buffer before raise an exception

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -575,6 +575,11 @@ class StreamReader:
                         'Separator is not found, and chunk exceed the limit',
                         offset)
 
+            # All data that was in the buffer has been returned, if there is
+            # an exception dont wait and just raise the exception.
+            if self._exception is not None:
+                raise self._exception
+
             # Complete message (with full separator) may be present in buffer
             # even when EOF flag is set. This may happen when the last chunk
             # adds data which makes separator be found. That's why we check for
@@ -583,11 +588,6 @@ class StreamReader:
                 chunk = bytes(self._buffer)
                 self._buffer.clear()
                 raise IncompleteReadError(chunk, None)
-
-            # All data that was in the buffer has been returned, if there is
-            # an exception dont wait and just raise the exception.
-            if self._exception is not None:
-                raise self._exception
 
             # _wait_for_data() will resume reading if stream was paused.
             await self._wait_for_data('readuntil')
@@ -678,12 +678,23 @@ class StreamReader:
             raise ValueError('readexactly size can not be less than zero')
 
         if self._exception is not None:
+            # if there is pending data in the buffer and the
+            # n asked meets that size, return the data before
+            # raise the exception.
+            if n != 0 and len(self._buffer) >= n:
+                data = bytes(self._buffer[:n])
+                del self._buffer[:n]
+                return data
             raise self._exception
 
         if n == 0:
             return b''
 
         while len(self._buffer) < n:
+
+            if self._exception is not None:
+                raise self._exception
+
             if self._eof:
                 incomplete = bytes(self._buffer)
                 self._buffer.clear()

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -692,9 +692,6 @@ class StreamReader:
 
         while len(self._buffer) < n:
 
-            if self._exception is not None:
-                raise self._exception
-
             if self._eof:
                 incomplete = bytes(self._buffer)
                 self._buffer.clear()

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -201,12 +201,23 @@ class StreamTests(test_utils.TestCase):
 
     def test_read_exception(self):
         stream = asyncio.StreamReader(loop=self.loop)
+
+        stream.set_exception(ValueError())
+        self.assertRaises(
+            ValueError, self.loop.run_until_complete, stream.read(2))
+
+    def test_read_remains_buffer_before_exception(self):
+        stream = asyncio.StreamReader(loop=self.loop)
+
         stream.feed_data(b'line\n')
+        stream.set_exception(ValueError())
 
         data = self.loop.run_until_complete(stream.read(2))
         self.assertEqual(b'li', data)
 
-        stream.set_exception(ValueError())
+        data = self.loop.run_until_complete(stream.read(3))
+        self.assertEqual(b'ne\n', data)
+
         self.assertRaises(
             ValueError, self.loop.run_until_complete, stream.read(2))
 
@@ -465,6 +476,24 @@ class StreamTests(test_utils.TestCase):
             self.loop.run_until_complete(stream.readuntil(b'AAA'))
 
         self.assertEqual(b'some dataAAA', stream._buffer)
+
+    def test_readuntil_exception(self):
+        stream = asyncio.StreamReader(loop=self.loop)
+        stream.set_exception(ValueError())
+        self.assertRaises(
+            ValueError, self.loop.run_until_complete, stream.readuntil(b'\n'))
+
+    def test_readuntil_remains_buffer_before_exception(self):
+        stream = asyncio.StreamReader(loop=self.loop)
+
+        stream.feed_data(b'line\n')
+        stream.set_exception(ValueError())
+
+        data = self.loop.run_until_complete(stream.readuntil(b'\n'))
+        self.assertEqual(b'line\n', data)
+
+        self.assertRaises(
+            ValueError, self.loop.run_until_complete, stream.readuntil(b'\n'))
 
     def test_readexactly_zero_or_less(self):
         # Read exact number of bytes (zero or less).

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -553,14 +553,30 @@ class StreamTests(test_utils.TestCase):
 
     def test_readexactly_exception(self):
         stream = asyncio.StreamReader(loop=self.loop)
+        stream.set_exception(ValueError())
+        self.assertRaises(
+            ValueError, self.loop.run_until_complete, stream.readexactly(2))
+
+    def test_readexactly_remains_buffer_before_exception(self):
+        stream = asyncio.StreamReader(loop=self.loop)
         stream.feed_data(b'line\n')
+        stream.set_exception(ValueError())
 
         data = self.loop.run_until_complete(stream.readexactly(2))
         self.assertEqual(b'li', data)
 
+        data = self.loop.run_until_complete(stream.readexactly(3))
+        self.assertEqual(b'ne\n', data)
+
+        self.assertRaises(
+            ValueError, self.loop.run_until_complete, stream.readexactly(3))
+
+    def test_readexactly_N_0_exception(self):
+        stream = asyncio.StreamReader(loop=self.loop)
+        stream.feed_data(b'line\n')
         stream.set_exception(ValueError())
         self.assertRaises(
-            ValueError, self.loop.run_until_complete, stream.readexactly(2))
+            ValueError, self.loop.run_until_complete, stream.readexactly(0))
 
     def test_exception(self):
         stream = asyncio.StreamReader(loop=self.loop)

--- a/Misc/NEWS.d/next/Library/2018-06-07-11-18-00.bpo-30861.eQ23fa.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-07-11-18-00.bpo-30861.eQ23fa.rst
@@ -1,0 +1,1 @@
+Return StreamReeader remaining buffer before raise an exception.


### PR DESCRIPTION
The current implementation of StreamReader does not take care of the status of the buffer, once an exception has been set via set_exception any call to the read methods won't be able to get the missing data still pending to be processed.

From the point of view of the developer, if there is no scheduled task for waiting for data into the Streamreader between a network data gets into the buffer socket and a closing connection by the other peer arrives, the developer won't be able to gather the previous data.

This PR take care first of the remaining buffer and try to return first to the user, and only when the buffer has run out raises the proper exception

<!-- issue-number: bpo-30861 -->
https://bugs.python.org/issue30861
<!-- /issue-number -->

<!-- gh-issue-number: gh-75044 -->
* Issue: gh-75044
<!-- /gh-issue-number -->
