### PR TITLE
[2.7] bpo-5755: don't use compiler flag -Wstrict-prototypes (GH-7395)

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-05-14-11-57-56.bpo-5755.kpNUx-.rst
+++ b/Misc/NEWS.d/next/Build/2018-05-14-11-57-56.bpo-5755.kpNUx-.rst
@@ -1,0 +1,3 @@
+No longer use the ``-Wstrict-prototypes`` compiler flag.
+This avoids a compiler warning when compiling C++ extension modules
+with distutils.

--- a/configure
+++ b/configure
@@ -6011,9 +6011,6 @@ if test "${OPT-unset}" = "unset"
 then
     case $GCC in
     yes)
-        if test "$CC" != 'g++' ; then
-	    STRICT_PROTO="-Wstrict-prototypes"
-	fi
         # For gcc 4.x we need to use -fwrapv so lets check if its supported
         if "$CC" -v --help 2>/dev/null |grep -- -fwrapv > /dev/null; then
            WRAP="-fwrapv"
@@ -6030,13 +6027,13 @@ then
 	    if test "$Py_DEBUG" = 'true' ; then
 		# Optimization messes up debuggers, so turn it off for
 		# debug builds.
-		OPT="-g -O0 -Wall $STRICT_PROTO"
+		OPT="-g -O0 -Wall"
 	    else
-		OPT="-g $WRAP -O3 -Wall $STRICT_PROTO"
+		OPT="-g $WRAP -O3 -Wall"
 	    fi
 	    ;;
 	*)
-	    OPT="-O3 -Wall $STRICT_PROTO"
+	    OPT="-O3 -Wall"
 	    ;;
 	esac
 	case $ac_sys_system in

--- a/configure.ac
+++ b/configure.ac
@@ -1071,9 +1071,6 @@ if test "${OPT-unset}" = "unset"
 then
     case $GCC in
     yes)
-        if test "$CC" != 'g++' ; then
-	    STRICT_PROTO="-Wstrict-prototypes"
-	fi
         # For gcc 4.x we need to use -fwrapv so lets check if its supported
         if "$CC" -v --help 2>/dev/null |grep -- -fwrapv > /dev/null; then
            WRAP="-fwrapv"
@@ -1090,13 +1087,13 @@ then
 	    if test "$Py_DEBUG" = 'true' ; then
 		# Optimization messes up debuggers, so turn it off for
 		# debug builds.
-		OPT="-g -O0 -Wall $STRICT_PROTO"
+		OPT="-g -O0 -Wall"
 	    else
-		OPT="-g $WRAP -O3 -Wall $STRICT_PROTO"
+		OPT="-g $WRAP -O3 -Wall"
 	    fi
 	    ;;
 	*)
-	    OPT="-O3 -Wall $STRICT_PROTO"
+	    OPT="-O3 -Wall"
 	    ;;
 	esac
 	case $ac_sys_system in


### PR DESCRIPTION


<!-- issue-number: bpo-5755 -->
https://bugs.python.org/issue5755
<!-- /issue-number -->
