### PR TITLE
[3.7] bpo-33789: Backport test_asyncio fixes from master

### DIFF
--- a/Lib/test/test_asyncio/functional.py
+++ b/Lib/test/test_asyncio/functional.py
@@ -150,9 +150,14 @@ class TestSocketWrapper:
             server_hostname=server_hostname,
             do_handshake_on_connect=False)
 
-        ssl_sock.do_handshake()
+        try:
+            ssl_sock.do_handshake()
+        except:
+            ssl_sock.close()
+            raise
+        finally:
+            self.__sock.close()
 
-        self.__sock.close()
         self.__sock = ssl_sock
 
     def __getattr__(self, name):

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -600,6 +600,8 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                     server_side=True)
             except ssl.SSLError:
                 pass
+            except OSError:
+                pass
             finally:
                 sock.close()
 
@@ -636,6 +638,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
             except ssl.SSLError:
                 pass
             finally:
+                orig_sock.close()
                 sock.close()
 
         async def client(addr):
@@ -649,6 +652,8 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
             writer.write(b'B')
             with self.assertRaises(ssl.SSLError):
                 await reader.readline()
+
+            writer.close()
             return 'OK'
 
         with self.tcp_server(server,

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2609,7 +2609,8 @@ class BaseTaskIntrospectionTests:
         self.assertEqual(asyncio.all_tasks(loop), set())
         self._register_task(task)
         self.assertEqual(asyncio.all_tasks(loop), set())
-        self.assertEqual(asyncio.Task.all_tasks(loop), {task})
+        with self.assertWarns(PendingDeprecationWarning):
+            self.assertEqual(asyncio.Task.all_tasks(loop), {task})
         self._unregister_task(task)
 
     def test__enter_task(self):

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2178,7 +2178,11 @@ class BaseTaskTests:
         self.assertFalse(m_log.error.called)
 
         with self.assertRaises(ValueError):
-            self.new_task(self.loop, coro())
+            gen = coro()
+            try:
+                self.new_task(self.loop, gen)
+            finally:
+                gen.close()
 
         self.assertTrue(m_log.error.called)
         message = m_log.error.call_args[0][0]


### PR DESCRIPTION
* bpo-33789: test_asyncio: Fix ResourceWarning (GH-7460)
* bpo-33789, test_asyncio: Hide PendingDeprecationWarning (GH-7461)
* bpo-32676, test_asyncio: Fix warning in test_error_in_call_soon() (GH-7462)


<!-- issue-number: bpo-33789 -->
https://bugs.python.org/issue33789
<!-- /issue-number -->
