### PR TITLE
[3.7] bpo-33743: Mask deprecation warning in asyncio tests

### DIFF
--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -2609,7 +2609,8 @@ class BaseTaskIntrospectionTests:
         self.assertEqual(asyncio.all_tasks(loop), set())
         self._register_task(task)
         self.assertEqual(asyncio.all_tasks(loop), set())
-        self.assertEqual(asyncio.Task.all_tasks(loop), {task})
+        with self.assertWarns(PendingDeprecationWarning):
+            self.assertEqual(asyncio.Task.all_tasks(loop), {task})
         self._unregister_task(task)
 
     def test__enter_task(self):


### PR DESCRIPTION
`asyncio.Task.all_tasks()` is the deprecated function.

Master already has the fix.

<!-- issue-number: bpo-33743 -->
https://bugs.python.org/issue33743
<!-- /issue-number -->
