### PR TITLE
bpo-33476: Fix _header_value_parser.py when address group is missing final ';'

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -1875,7 +1875,7 @@ def get_group(value):
     if not value:
         group.defects.append(errors.InvalidHeaderDefect(
             "end of header in group"))
-    if value[0] != ';':
+    elif value[0] != ';':
         raise errors.HeaderParseError(
             "expected ';' at end of group but found {}".format(value))
     group.append(ValueTerminal(';', 'group-terminator'))

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2143,6 +2143,31 @@ class TestParser(TestParserMixin, TestEmailBase):
         self.assertEqual(group.mailboxes[1].local_part, 'x')
         self.assertIsNone(group.all_mailboxes[1].display_name)
 
+    def test_get_group_missing_final_semicol(self):
+        group = self._test_get_x(parser.get_group,
+            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>,'
+             'eric@where.test,John <jdoe@test>'),
+            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>,'
+             'eric@where.test,John <jdoe@test>;'),
+            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>,'
+             'eric@where.test,John <jdoe@test>;'),
+            [errors.InvalidHeaderDefect],
+            '')
+        self.assertEqual(group.token_type, 'group')
+        self.assertEqual(group.display_name, 'Monty Python')
+        self.assertEqual(len(group.mailboxes), 3)
+        self.assertEqual(group.mailboxes,
+                         group.all_mailboxes)
+        self.assertEqual(group.mailboxes[0].addr_spec,
+                         'dinsdale@example.com')
+        self.assertEqual(group.mailboxes[0].display_name,
+                         'Fred A. Bear')
+        self.assertEqual(group.mailboxes[1].addr_spec,
+                         'eric@where.test')
+        self.assertEqual(group.mailboxes[2].display_name,
+                         'John')
+        self.assertEqual(group.mailboxes[2].addr_spec,
+                         'jdoe@test')
     # get_address
 
     def test_get_address_simple(self):

--- a/Misc/NEWS.d/next/Library/2018-06-08-00-29-40.bpo-33476.R0Bhlj.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-08-00-29-40.bpo-33476.R0Bhlj.rst
@@ -1,0 +1,2 @@
+Fix _header_value_parser.py when address group is missing final ';'.
+Contributed by Enrique Perez-Terron


### PR DESCRIPTION
Fix _header_value_parser.py when address group is missing final ';'

Need to backport patch for 3.7, 3.6.

<!-- issue-number: bpo-33476 -->
https://bugs.python.org/issue33476
<!-- /issue-number -->
