### PR TITLE
bpo-33694: asyncio: Fix race in Proactor's Transport.set_protocol()

### DIFF
--- a/Lib/asyncio/protocols.py
+++ b/Lib/asyncio/protocols.py
@@ -189,3 +189,22 @@ class SubprocessProtocol(BaseProtocol):
 
     def process_exited(self):
         """Called when subprocess has exited."""
+
+
+def _feed_data_to_bufferred_proto(proto, data):
+    data_len = len(data)
+    while data_len:
+        buf = proto.get_buffer(data_len)
+        buf_len = len(buf)
+        if not buf_len:
+            raise RuntimeError('get_buffer() returned an empty buffer')
+
+        if buf_len >= data_len:
+            buf[:data_len] = data
+            proto.buffer_updated(data_len)
+            return
+        else:
+            buf[:buf_len] = data[:buf_len]
+            proto.buffer_updated(buf_len)
+            data = data[buf_len:]
+            data_len = len(data)

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -535,7 +535,7 @@ class SSLProtocol(protocols.Protocol):
             if chunk:
                 try:
                     if self._app_protocol_is_buffer:
-                        _feed_data_to_bufferred_proto(
+                        protocols._feed_data_to_bufferred_proto(
                             self._app_protocol, chunk)
                     else:
                         self._app_protocol.data_received(chunk)
@@ -721,22 +721,3 @@ class SSLProtocol(protocols.Protocol):
                 self._transport.abort()
         finally:
             self._finalize()
-
-
-def _feed_data_to_bufferred_proto(proto, data):
-    data_len = len(data)
-    while data_len:
-        buf = proto.get_buffer(data_len)
-        buf_len = len(buf)
-        if not buf_len:
-            raise RuntimeError('get_buffer() returned an empty buffer')
-
-        if buf_len >= data_len:
-            buf[:data_len] = data
-            proto.buffer_updated(data_len)
-            return
-        else:
-            buf[:buf_len] = data[:buf_len]
-            proto.buffer_updated(buf_len)
-            data = data[buf_len:]
-            data_len = len(data)

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -2504,10 +2504,12 @@ class SendfileMixin(SendfileBase):
                 self.loop.sendfile(cli_proto.transport, self.file))
         self.run_loop(srv_proto.done)
 
-        self.assertTrue(1024 <= srv_proto.nbytes < len(self.DATA),
-                        srv_proto.nbytes)
-        self.assertTrue(1024 <= self.file.tell() < len(self.DATA),
-                        self.file.tell())
+        self.assertLessEqual(1024, srv_proto.nbytes)
+        self.assertLessEqual(srv_proto.nbytes, len(self.DATA))
+
+        self.assertLessEqual(1024, self.file.tell())
+        self.assertLessEqual(self.file.tell(), len(self.DATA))
+
         self.assertTrue(cli_proto.transport.is_closing())
 
     def test_sendfile_fallback_close_peer_in_the_middle_of_receiving(self):

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -12,7 +12,7 @@ except ImportError:
 import asyncio
 from asyncio import log
 from asyncio import sslproto
-from asyncio import tasks
+from asyncio import protocols
 from test.test_asyncio import utils as test_utils
 from test.test_asyncio import functional as func_tests
 
@@ -189,28 +189,28 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
 
         for usemv in [False, True]:
             proto = Proto(1, usemv)
-            sslproto._feed_data_to_bufferred_proto(proto, b'12345')
+            protocols._feed_data_to_bufferred_proto(proto, b'12345')
             self.assertEqual(proto.data, b'12345')
 
             proto = Proto(2, usemv)
-            sslproto._feed_data_to_bufferred_proto(proto, b'12345')
+            protocols._feed_data_to_bufferred_proto(proto, b'12345')
             self.assertEqual(proto.data, b'12345')
 
             proto = Proto(2, usemv)
-            sslproto._feed_data_to_bufferred_proto(proto, b'1234')
+            protocols._feed_data_to_bufferred_proto(proto, b'1234')
             self.assertEqual(proto.data, b'1234')
 
             proto = Proto(4, usemv)
-            sslproto._feed_data_to_bufferred_proto(proto, b'1234')
+            protocols._feed_data_to_bufferred_proto(proto, b'1234')
             self.assertEqual(proto.data, b'1234')
 
             proto = Proto(100, usemv)
-            sslproto._feed_data_to_bufferred_proto(proto, b'12345')
+            protocols._feed_data_to_bufferred_proto(proto, b'12345')
             self.assertEqual(proto.data, b'12345')
 
             proto = Proto(0, usemv)
             with self.assertRaisesRegex(RuntimeError, 'empty buffer'):
-                sslproto._feed_data_to_bufferred_proto(proto, b'12345')
+                protocols._feed_data_to_bufferred_proto(proto, b'12345')
 
     def test_start_tls_client_reg_proto_1(self):
         HELLO_MSG = b'1' * self.PAYLOAD_SIZE

--- a/Misc/NEWS.d/next/Library/2018-06-07-12-24-11.bpo-33694.NjSAqI.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-07-12-24-11.bpo-33694.NjSAqI.rst
@@ -1,0 +1,4 @@
+Refactor Proactor's data receiving code path.  The idea is to always use
+recv_into() and to emulate the old Protocol.data_received() path. This way
+there is no read cancellation race or data loss in set_protocol() and
+there's no performance degradation for both Protocol and BufferedProtocol.


### PR DESCRIPTION
Refactor Proactor's data receiving code path.  The idea is to always use
`recv_into()` and to emulate the old `Protocol.data_received()` path. This way
there is no read cancellation race or data loss in set_protocol() and
there's no performance degradation for both `Protocol` and `BufferedProtocol`.

This PR removes some outdated and now irrelevant proactor mock tests
(most of the removed mocked tests have an alternative working test
for BufferedProtocol).

<!-- issue-number: bpo-33694 -->
https://bugs.python.org/issue33694
<!-- /issue-number -->
