### PR TITLE
[3.6] bpo-32392: Document env keyword argument of subprocess.run() (GH-7289)

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -38,8 +38,8 @@ compatibility with older versions, see the :ref:`call-function-trio` section.
 
 
 .. function:: run(args, *, stdin=None, input=None, stdout=None, stderr=None,\
-                  shell=False, cwd=None, timeout=None, check=False, \
-                  encoding=None, errors=None)
+                  shell=False, timeout=None, check=False, \
+                  encoding=None, errors=None, env=None)
 
    Run the command described by *args*.  Wait for command to complete, then
    return a :class:`CompletedProcess` instance.
@@ -74,6 +74,11 @@ compatibility with older versions, see the :ref:`call-function-trio` section.
    file objects for stdin, stdout and stderr are opened in text mode using the
    specified *encoding* and *errors* or the :class:`io.TextIOWrapper` default.
    Otherwise, file objects are opened in binary mode.
+
+   If *env* is not ``None``, it must be a mapping that defines the environment
+   variables for the new process; these are used instead of the default
+   behavior of inheriting the current process' environment. It is passed directly
+   to :class:`Popen`.
 
    Examples::
 

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -38,7 +38,7 @@ compatibility with older versions, see the :ref:`call-function-trio` section.
 
 
 .. function:: run(args, *, stdin=None, input=None, stdout=None, stderr=None,\
-                  shell=False, timeout=None, check=False, \
+                  shell=False, cwd=None, timeout=None, check=False, \
                   encoding=None, errors=None, env=None)
 
    Run the command described by *args*.  Wait for command to complete, then


### PR DESCRIPTION


<!-- issue-number: bpo-32392 -->
https://bugs.python.org/issue32392
<!-- /issue-number -->
