### PR TITLE
bpo-33801: Remove non-ordered dict comment from plistlib

### DIFF
--- a/Doc/library/plistlib.rst
+++ b/Doc/library/plistlib.rst
@@ -63,9 +63,7 @@ This module defines the following functions:
    :class:`Data`.
 
    The *dict_type* is the type used for dictionaries that are read from the
-   plist file. The exact structure of the plist can be recovered by using
-   :class:`collections.OrderedDict` (although the order of keys shouldn't be
-   important in plist files).
+   plist file.
 
    XML data for the :data:`FMT_XML` format is parsed using the Expat parser
    from :mod:`xml.parsers.expat` -- see its documentation for possible


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33801 -->
https://bugs.python.org/issue33801
<!-- /issue-number -->
