### PR TITLE
bpo-33615: Skip test__xxsubinterpreters

### DIFF
--- a/Lib/test/test__xxsubinterpreters.py
+++ b/Lib/test/test__xxsubinterpreters.py
@@ -12,6 +12,8 @@ import unittest
 from test import support
 from test.support import script_helper
 
+raise unittest.SkipTest("FIXME: bpo-33615: test crash on some CIs")
+
 interpreters = support.import_module('_xxsubinterpreters')
 
 


### PR DESCRIPTION
The test does crash on multiple CIs causing many troubles. For
example, the test prevents to get results of the two Refleak 3.x
buildbot.

<!-- issue-number: bpo-33615 -->
https://bugs.python.org/issue33615
<!-- /issue-number -->
