### PR TITLE
bpo-33802 - Fix regression in logging configuration

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -636,7 +636,13 @@ class RawConfigParser(MutableMapping):
         if converters is not _UNSET:
             self._converters.update(converters)
         if defaults:
-            self._read_defaults(defaults)
+            # For backward compatibility, defaults should do no interpolation.
+            try:
+                interpolation = self._interpolation
+                self._interpolation = Interpolation()
+                self._read_defaults(defaults)
+            finally:
+                self._interpolation = interpolation
 
     def defaults(self):
         return self._defaults

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1451,6 +1451,43 @@ class ConfigFileTest(BaseTest):
         self.apply_config(self.disable_test, disable_existing_loggers=False)
         self.assertFalse(logger.disabled)
 
+    def test_defaults_do_no_interpolation(self):
+        """bpo-33802 defaults should not get interpolated"""
+        ini = textwrap.dedent("""
+            [formatters]
+            keys=default
+
+            [formatter_default]
+
+            [handlers]
+            keys=console
+
+            [handler_console]
+            class=logging.StreamHandler
+            args=tuple()
+
+            [loggers]
+            keys=root
+
+            [logger_root]
+            formatter=default
+            handlers=console
+            """).strip()
+        with tempfile.NamedTemporaryFile(mode='w+t', encoding='utf-8') as fp:
+            fp.write(ini)
+            fp.flush()
+            logging.config.fileConfig(fp.name, defaults=dict(
+                version=1,
+                disable_existing_loggers=False,
+                formatters={
+                    "generic": {
+                        "format": "%(asctime)s [%(process)d] [%(levelname)s] %(message)s",
+                        "datefmt": "[%Y-%m-%d %H:%M:%S %z]",
+                        "class": "logging.Formatter"
+                        },
+                    },
+                ))
+
 
 class SocketHandlerTest(BaseTest):
 


### PR DESCRIPTION
In Python 3.6, defaults were not interpolated.   Interpolating defaults in 3.8 and 3.7 causes a regression.  I don't love this fix, but it seemed like the simplest thing possible to restore the old behavior.

<!-- issue-number: bpo-33802 -->
https://bugs.python.org/issue33802
<!-- /issue-number -->
