### PR TITLE
bpo-32493: Fix the detection of uuid_enc_be() function of libuuid in configure.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-06-07-18-55-35.bpo-32493.1Bte62.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-07-18-55-35.bpo-32493.1Bte62.rst
@@ -1,1 +1,2 @@
-correct logic in configure.ac so that HAVE_UUID_ENC_BE is not always defined
+Correct test for ``uuid_enc_be availability`` in ``configure.ac``.
+Patch by Michael Felt.

--- a/Misc/NEWS.d/next/Library/2018-06-07-18-55-35.bpo-32493.1Bte62.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-07-18-55-35.bpo-32493.1Bte62.rst
@@ -1,2 +1,2 @@
-Correct test for ``uuid_enc_be availability`` in ``configure.ac``.
+Correct test for ``uuid_enc_be`` availability in ``configure.ac``.
 Patch by Michael Felt.

--- a/Misc/NEWS.d/next/Library/2018-06-07-18-55-35.bpo-32493.1Bte62.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-07-18-55-35.bpo-32493.1Bte62.rst
@@ -1,0 +1,1 @@
+correct logic in configure.ac so that HAVE_UUID_ENC_BE is not always defined

--- a/configure
+++ b/configure
@@ -10072,6 +10072,7 @@ fi
 
 
 
+
 if test "x$ac_cv_env_PKG_CONFIG_set" != "xset"; then
 	if test -n "$ac_tool_prefix"; then
   # Extract the first word of "${ac_tool_prefix}pkg-config", so it can be a program name with args.

--- a/configure
+++ b/configure
@@ -9714,9 +9714,7 @@ main ()
 {
 
 #ifndef uuid_enc_be
-uuid_t uuid;
-unsigned char buf[sizeof(uuid)];
-uuid_enc_be(buf, &uuid);
+void *x = uuid_enc_be
 #endif
 
   ;
@@ -10066,7 +10064,6 @@ else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 fi
-
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -2782,9 +2782,7 @@ void *x = uuid_create
 AC_MSG_CHECKING(for uuid_enc_be)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <uuid.h>]], [[
 #ifndef uuid_enc_be
-uuid_t uuid;
-unsigned char buf[sizeof(uuid)];
-uuid_enc_be(buf, &uuid);
+void *x = uuid_enc_be
 #endif
 ]])],
   [AC_DEFINE(HAVE_UUID_ENC_BE, 1, Define if uuid_enc_be() exists.)


### PR DESCRIPTION
Using git bisect - I found the issue that prevents _uuid from building on AIX.

Short explanation: the logic in configure is always true, so HAVE_UUID_ENC_BE gets defined and the link of the module fails.

5734f41a9b46b4fd65b6ba90240b108f8a0b7c57 is the first bad commit
commit 5734f41a9b46b4fd65b6ba90240b108f8a0b7c57
Author: Miss Islington (bot) <31488909+miss-islington@users.noreply.github.com>
Date:   Thu May 24 16:22:59 2018 -0700

    bpo-32493: Fix uuid.uuid1() on FreeBSD. (GH-7099)


    Use uuid_enc_be() if available to encode UUID to bytes as big endian.
    (cherry picked from commit 17d8830312d82e7de42ab89739b0771f712645ff)

    Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>

:040000 040000 6983052a6c16a7fda20a50595a25b8bd28b3e5d6 4c011f4015cbdc47ebfd003fa111b869227235cd M      Misc
:040000 040000 9bd35582651acc82fdb7be7100d33843a39fb0b4 5c71739d2798ecf74076e172ddfaf0478f4b92de M      Modules
:100755 100755 f1f01df4a80e4262d0c849aa467dfb7afec7df66 b1cd944ac562ea363eb8af040d280e1ec59c03c0 M      configure
:100644 100644 2535969642042f38ad4a4a7ef485f9aef94f7b5a 59489047fc24eb1b0fe2dc2d642bd097226235c5 M      configure.ac
:100644 100644 a0efff9777d27d53086971543e81abf4604a1bf6 e561a7c07cca7896f35faaa1f2dc9d07823ca42a M      pyconfig.h.in


<!-- issue-number: bpo-32493 -->
https://bugs.python.org/issue32493
<!-- /issue-number -->
