### PR TITLE
bpo-33718: regrtest: use "xxx then yyy" result if re-run

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -79,6 +79,7 @@ class Regrtest:
         self.resource_denieds = []
         self.environment_changed = []
         self.rerun = []
+        self.first_result = None
         self.interrupted = False
 
         # used by --slow
@@ -273,6 +274,8 @@ class Regrtest:
         self.ns.failfast = False
         self.ns.verbose3 = False
 
+        self.first_result = self.get_tests_result()
+
         print()
         print("Re-running failed tests in verbose mode")
         self.rerun = self.bad[:]
@@ -447,7 +450,10 @@ class Regrtest:
         if not result:
             result.append("SUCCESS")
 
-        return ', '.join(result)
+        result = ', '.join(result)
+        if self.first_result:
+            result = '%s then %s' % (self.first_result, result)
+        return result
 
     def run_tests(self):
         # For a partial run, we do not need to clutter the output.


### PR DESCRIPTION
If tests are re-run, use "xxx then yyy" result format (ex: "FAILURE
then SUCCESS") to show that some failing tests have been re-run.

Add also test_regrtest.test_rerun_fail() test.

<!-- issue-number: bpo-33718 -->
https://bugs.python.org/issue33718
<!-- /issue-number -->
