### PR TITLE
bpo-33694: Fix typo in asyncio helper function name

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -234,7 +234,7 @@ class _ProactorReadPipeTransport(_ProactorBasePipeTransport,
 
         if isinstance(self._protocol, protocols.BufferedProtocol):
             try:
-                protocols._feed_data_to_bufferred_proto(self._protocol, data)
+                protocols._feed_data_to_buffered_proto(self._protocol, data)
             except Exception as exc:
                 self._fatal_error(exc,
                                   'Fatal error: protocol.buffer_updated() '

--- a/Lib/asyncio/protocols.py
+++ b/Lib/asyncio/protocols.py
@@ -191,7 +191,7 @@ class SubprocessProtocol(BaseProtocol):
         """Called when subprocess has exited."""
 
 
-def _feed_data_to_bufferred_proto(proto, data):
+def _feed_data_to_buffered_proto(proto, data):
     data_len = len(data)
     while data_len:
         buf = proto.get_buffer(data_len)

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -535,7 +535,7 @@ class SSLProtocol(protocols.Protocol):
             if chunk:
                 try:
                     if self._app_protocol_is_buffer:
-                        protocols._feed_data_to_bufferred_proto(
+                        protocols._feed_data_to_buffered_proto(
                             self._app_protocol, chunk)
                     else:
                         self._app_protocol.data_received(chunk)

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -190,28 +190,28 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
 
         for usemv in [False, True]:
             proto = Proto(1, usemv)
-            protocols._feed_data_to_bufferred_proto(proto, b'12345')
+            protocols._feed_data_to_buffered_proto(proto, b'12345')
             self.assertEqual(proto.data, b'12345')
 
             proto = Proto(2, usemv)
-            protocols._feed_data_to_bufferred_proto(proto, b'12345')
+            protocols._feed_data_to_buffered_proto(proto, b'12345')
             self.assertEqual(proto.data, b'12345')
 
             proto = Proto(2, usemv)
-            protocols._feed_data_to_bufferred_proto(proto, b'1234')
+            protocols._feed_data_to_buffered_proto(proto, b'1234')
             self.assertEqual(proto.data, b'1234')
 
             proto = Proto(4, usemv)
-            protocols._feed_data_to_bufferred_proto(proto, b'1234')
+            protocols._feed_data_to_buffered_proto(proto, b'1234')
             self.assertEqual(proto.data, b'1234')
 
             proto = Proto(100, usemv)
-            protocols._feed_data_to_bufferred_proto(proto, b'12345')
+            protocols._feed_data_to_buffered_proto(proto, b'12345')
             self.assertEqual(proto.data, b'12345')
 
             proto = Proto(0, usemv)
             with self.assertRaisesRegex(RuntimeError, 'empty buffer'):
-                protocols._feed_data_to_bufferred_proto(proto, b'12345')
+                protocols._feed_data_to_buffered_proto(proto, b'12345')
 
     def test_start_tls_client_reg_proto_1(self):
         HELLO_MSG = b'1' * self.PAYLOAD_SIZE


### PR DESCRIPTION
_feed_data_to_bufferred_proto() renamed to
_feed_data_to_buffered_proto() ("bufferred" => "buffered").

Typo spotted by Nathaniel J. Smith.

<!-- issue-number: bpo-33694 -->
https://bugs.python.org/issue33694
<!-- /issue-number -->
