### PR TITLE
bpo-33802: Do not interpolate in ConfigParser while reading defaults

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -1208,8 +1208,16 @@ class ConfigParser(RawConfigParser):
 
     def _read_defaults(self, defaults):
         """Reads the defaults passed in the initializer, implicitly converting
-        values to strings like the rest of the API."""
-        self.read_dict({self.default_section: defaults})
+        values to strings like the rest of the API.
+
+        Does not perform interpolation for backwards compatibility.
+        """
+        try:
+            hold_interpolation = self._interpolation
+            self._interpolation = Interpolation()
+            self.read_dict({self.default_section: defaults})
+        finally:
+            self._interpolation = hold_interpolation
 
 
 class SafeConfigParser(ConfigParser):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1451,6 +1451,43 @@ class ConfigFileTest(BaseTest):
         self.apply_config(self.disable_test, disable_existing_loggers=False)
         self.assertFalse(logger.disabled)
 
+    def test_defaults_do_no_interpolation(self):
+        """bpo-33802 defaults should not get interpolated"""
+        ini = textwrap.dedent("""
+            [formatters]
+            keys=default
+
+            [formatter_default]
+
+            [handlers]
+            keys=console
+
+            [handler_console]
+            class=logging.StreamHandler
+            args=tuple()
+
+            [loggers]
+            keys=root
+
+            [logger_root]
+            formatter=default
+            handlers=console
+            """).strip()
+        with tempfile.NamedTemporaryFile(mode='w+t', encoding='utf-8') as fp:
+            fp.write(ini)
+            fp.flush()
+            logging.config.fileConfig(fp.name, defaults=dict(
+                version=1,
+                disable_existing_loggers=False,
+                formatters={
+                    "generic": {
+                        "format": "%(asctime)s [%(process)d] [%(levelname)s] %(message)s",
+                        "datefmt": "[%Y-%m-%d %H:%M:%S %z]",
+                        "class": "logging.Formatter"
+                        },
+                    },
+                ))
+
 
 class SocketHandlerTest(BaseTest):
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1473,13 +1473,12 @@ class ConfigFileTest(BaseTest):
             formatter=default
             handlers=console
             """).strip()
+        fd, fn = tempfile.mkstemp(prefix='test_logging_', suffix='.ini')
         try:
-            with tempfile.NamedTemporaryFile(
-                mode='w+t', encoding='utf-8', delete='False'
-            ) as ntf:
-                ntf.write(ini)
+            os.write(fd, ini.encode('ascii'))
+            os.close(fd)
             logging.config.fileConfig(
-                ntf.name,
+                fn,
                 defaults=dict(
                     version=1,
                     disable_existing_loggers=False,
@@ -1493,7 +1492,7 @@ class ConfigFileTest(BaseTest):
                 )
             )
         finally:
-            os.unlink(ntf.name)
+            os.unlink(fn)
 
 
 class SocketHandlerTest(BaseTest):

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1473,20 +1473,27 @@ class ConfigFileTest(BaseTest):
             formatter=default
             handlers=console
             """).strip()
-        with tempfile.NamedTemporaryFile(mode='w+t', encoding='utf-8') as fp:
-            fp.write(ini)
-            fp.flush()
-            logging.config.fileConfig(fp.name, defaults=dict(
-                version=1,
-                disable_existing_loggers=False,
-                formatters={
-                    "generic": {
-                        "format": "%(asctime)s [%(process)d] [%(levelname)s] %(message)s",
-                        "datefmt": "[%Y-%m-%d %H:%M:%S %z]",
-                        "class": "logging.Formatter"
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode='w+t', encoding='utf-8', delete='False'
+            ) as ntf:
+                ntf.write(ini)
+            logging.config.fileConfig(
+                ntf.name,
+                defaults=dict(
+                    version=1,
+                    disable_existing_loggers=False,
+                    formatters={
+                        "generic": {
+                            "format": "%(asctime)s [%(process)d] [%(levelname)s] %(message)s",
+                            "datefmt": "[%Y-%m-%d %H:%M:%S %z]",
+                            "class": "logging.Formatter"
                         },
                     },
-                ))
+                )
+            )
+        finally:
+            os.unlink(ntf.name)
 
 
 class SocketHandlerTest(BaseTest):


### PR DESCRIPTION
This solves a regression in logging config due to changes in BPO-23835.

<!-- issue-number: bpo-33802 -->
https://bugs.python.org/issue33802
<!-- /issue-number -->
