### PR TITLE
Prefer OrderedDict over ordered dictionary

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -155,8 +155,9 @@ The :mod:`csv` module defines the following classes:
 
    The *fieldnames* parameter is a :term:`sequence`.  If *fieldnames* is
    omitted, the values in the first row of file *f* will be used as the
-   fieldnames.  Regardless of how the fieldnames are determined, the ordered
-   dictionary preserves their original ordering.
+   fieldnames.  Regardless of how the fieldnames are determined, the
+   :mod:`OrderedDict <collections.OrderedDict>` preserves their original
+   ordering.
 
    If a row has more fields than fieldnames, the remaining data is put in a
    list and stored with the fieldname specified by *restkey* (which defaults


### PR DESCRIPTION
Prefer "OrderedDict" over "ordered dictionary" now that dict objects preserve insertion order.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
