### PR TITLE
[2.7] bpo-31215: Add version change notes for OpenSSL 1.1.0 compatibility

### DIFF
--- a/Doc/library/ssl.rst
+++ b/Doc/library/ssl.rst
@@ -24,6 +24,9 @@ sockets, both client-side and server-side.  This module uses the OpenSSL
 library. It is available on all modern Unix systems, Windows, Mac OS X, and
 probably additional platforms, as long as OpenSSL is installed on that platform.
 
+.. versionchanged:: 2.7.13
+   Updated to support linking with OpenSSL 1.1.0
+
 .. note::
 
    Some behavior may be platform dependent, since calls are made to the


### PR DESCRIPTION
Hey, I added the version change notes, as discussed in [this issue](https://bugs.python.org/issue31215) and in [this PR](https://github.com/python/cpython/pull/7346) with @ncoghlan .
I've added the note, just before the Note and the Warning. Do tell me if you would like to place it somewhere else in the documentation. 
Thanks!

<!-- issue-number: bpo-31215 -->
https://bugs.python.org/issue31215
<!-- /issue-number -->
