### PR TITLE
bpo-33375: Fix GCC warning in Python/_warnings.c

### DIFF
--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -9,7 +9,6 @@ PyDoc_STRVAR(warnings__doc__,
 MODULE_NAME " provides basic warning filtering support.\n"
 "It is a helper module to speed up interpreter start-up.");
 
-_Py_IDENTIFIER(argv);
 _Py_IDENTIFIER(stderr);
 #ifndef Py_DEBUG
 _Py_IDENTIFIER(default);


### PR DESCRIPTION
_Py_IDENTIFIER(argv) is now unused.

This should have been removed as part of #6622.

<!-- issue-number: bpo-33375 -->
https://bugs.python.org/issue33375
<!-- /issue-number -->
