### PR TITLE
[Skip Issue] Remove unneeded PyErr_Occurred() check in os_lseek_impl()

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8238,9 +8238,6 @@ os_lseek_impl(PyObject *module, int fd, Py_off_t position, int how)
     }
 #endif /* SEEK_END */
 
-    if (PyErr_Occurred())
-        return -1;
-
     Py_BEGIN_ALLOW_THREADS
     _Py_BEGIN_SUPPRESS_IPH
 #ifdef MS_WINDOWS


### PR DESCRIPTION
This call became unneeded after the posix module was converted to the
Argument Clinic in 2f93635d342a500053e97c9c7c30f1eaf11fc3ac and should
have been removed as part of that change.
