### PR TITLE
bpo-31711: Fix for calling SSLSocket.send with empty input.

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2578,7 +2578,7 @@ class ThreadedTests(unittest.TestCase):
                                chatty=True, connectionchatty=True,
                                sni_name=hostname)
 
-        ## Testing that SSLSopcet can handle empty input
+        ## Testing that SSLSocket can handle empty input
         with self.subTest(client=ssl.PROTOCOL_TLS_CLIENT, server=ssl.PROTOCOL_TLS_SERVER):
             server_params_test(client_context=client_context,
                                server_context=server_context,

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2466,7 +2466,7 @@ def server_params_test(client_context, server_context, indata=b"FOO\n",
                         sys.stdout.write(
                             " client:  sending %r...\n" % indata)
                 s.write(arg)
-                outdata = s.read()
+                outdata = s.read() if len(arg) > 0 else b''
                 if connectionchatty:
                     if support.verbose:
                         sys.stdout.write(" client:  read %r\n" % outdata)
@@ -2575,6 +2575,14 @@ class ThreadedTests(unittest.TestCase):
         with self.subTest(client=ssl.PROTOCOL_TLS_CLIENT, server=ssl.PROTOCOL_TLS_SERVER):
             server_params_test(client_context=client_context,
                                server_context=server_context,
+                               chatty=True, connectionchatty=True,
+                               sni_name=hostname)
+
+        ## Testing that SSLSopcet can handle empty input
+        with self.subTest(client=ssl.PROTOCOL_TLS_CLIENT, server=ssl.PROTOCOL_TLS_SERVER):
+            server_params_test(client_context=client_context,
+                               server_context=server_context,
+                               indata = b'',
                                chatty=True, connectionchatty=True,
                                sni_name=hostname)
 

--- a/Misc/NEWS.d/next/Library/2018-06-09-17-15-35.bpo-31711.sOj9dl.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-09-17-15-35.bpo-31711.sOj9dl.rst
@@ -1,0 +1,2 @@
+Avoiding triggering undefined behaviour from SSL_write when calling
+SSLSocket.send() with empty input.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2248,7 +2248,7 @@ _ssl__SSLSocket_write_impl(PySSLSocket *self, Py_buffer *b)
         goto error;
     }
     if (b->len == 0) {
-        /*Sending 0 bytes to SSL_write is undefined behaviour per OpenSSL documentation.
+        /* Sending 0 bytes to SSL_write is undefined behaviour per OpenSSL documentation.
         * SSLSocket imitates normal socket in Python.
         * We have to guard against empty input here. */
         Py_XDECREF(sock);


### PR DESCRIPTION
SSLSocket in Python wraps ordinary sockets and provides SSLSocket.send with same behaviour (except for nonblocking differences mentiond in the documentation). Internally cPython uses OpenSSL as SSL library.
SSLSocket.send() calls to SSL_write() with data to send. However calling SSL_write() with zero-length buffer is undefined behaviour. To emulate ordinary socket behaviour in this case and not to trigger 
 undefined behaviour from OpenSSL we explicitly check for zero-length buffer before calling SSL_write().


<!-- issue-number: bpo-31711 -->
https://bugs.python.org/issue31711
<!-- /issue-number -->
