### PR TITLE
[2.7] bpo-33718: regrtest: use "xxx then yyy" result if re-run (GH-7521)

### DIFF
--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -530,6 +530,7 @@ def main(tests=None, testdir=None, verbose=0, quiet=False,
     resource_denieds = []
     environment_changed = []
     rerun = []
+    first_result = None
     interrupted = False
 
     if findleaks:
@@ -907,7 +908,10 @@ def main(tests=None, testdir=None, verbose=0, quiet=False,
         if not result:
             result.append("SUCCESS")
 
-        return ', '.join(result)
+        result = ', '.join(result)
+        if first_result:
+            result = '%s then %s' % (first_result, result)
+        return result
 
 
     def display_result():
@@ -974,6 +978,8 @@ def main(tests=None, testdir=None, verbose=0, quiet=False,
     display_result()
 
     if verbose2 and bad:
+        first_result = get_tests_result()
+
         print
         print "Re-running failed tests in verbose mode"
         rerun = bad[:]

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -92,6 +92,7 @@ class BaseTestCase(unittest.TestCase):
 
     def check_executed_tests(self, output, tests, skipped=(), failed=(),
                              env_changed=(), omitted=(),
+                             rerun=(),
                              randomize=False, interrupted=False,
                              fail_env_changed=False):
         if isinstance(tests, str):
@@ -104,6 +105,8 @@ class BaseTestCase(unittest.TestCase):
             env_changed = [env_changed]
         if isinstance(omitted, str):
             omitted = [omitted]
+        if isinstance(rerun, str):
+            rerun = [rerun]
 
         executed = self.parse_executed_tests(output)
         if randomize:
@@ -138,6 +141,14 @@ class BaseTestCase(unittest.TestCase):
             regex = list_regex('%s test%s omitted', omitted)
             self.check_line(output, regex)
 
+        if rerun:
+            regex = list_regex('%s re-run test%s', rerun)
+            self.check_line(output, regex)
+            self.check_line(output, "Re-running failed tests in verbose mode")
+            for name in rerun:
+                regex = "Re-running test %r in verbose mode" % name
+                self.check_line(output, regex)
+
         good = (len(tests) - len(skipped) - len(failed)
                 - len(omitted) - len(env_changed))
         if good:
@@ -149,14 +160,19 @@ class BaseTestCase(unittest.TestCase):
         if interrupted:
             self.check_line(output, 'Test suite interrupted by signal SIGINT.')
 
+        result = []
         if failed:
-            result = 'FAILURE'
-        elif interrupted:
-            result = 'INTERRUPTED'
+            result.append('FAILURE')
         elif fail_env_changed and env_changed:
-            result = 'ENV CHANGED'
-        else:
-            result = 'SUCCESS'
+            result.append('ENV CHANGED')
+        if interrupted:
+            result.append('INTERRUPTED')
+        if not result:
+            result.append('SUCCESS')
+        result = ', '.join(result)
+        if rerun:
+            self.check_line(output, 'Tests result: %s' % result)
+            result = 'FAILURE then %s' % result
         self.check_line(output, 'Tests result: %s' % result)
 
     def parse_random_seed(self, output):
@@ -647,6 +663,24 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("--fail-env-changed", testname, exitcode=3)
         self.check_executed_tests(output, [testname], env_changed=testname,
                                   fail_env_changed=True)
+
+    def test_rerun_fail(self):
+        code = textwrap.dedent("""
+            import unittest
+
+            class Tests(unittest.TestCase):
+                def test_bug(self):
+                    # test always fail
+                    self.fail("bug")
+
+            def test_main():
+                support.run_unittest(Tests)
+        """)
+        testname = self.create_test(code=code)
+
+        output = self.run_tests("-w", testname, exitcode=2)
+        self.check_executed_tests(output, [testname],
+                                  failed=testname, rerun=testname)
 
 
 def test_main():


### PR DESCRIPTION
If tests are re-run, use "xxx then yyy" result format (ex: "FAILURE
then SUCCESS") to show that some failing tests have been re-run.

Add also test_regrtest.test_rerun_fail() test.

(cherry picked from commit c45fc7673e23f911639d10d3771ffef7be870c7a)

<!-- issue-number: bpo-33718 -->
https://bugs.python.org/issue33718
<!-- /issue-number -->
