### PR TITLE
bpo-33757: Fix separate test_pdb_next_command_in_generator_for_loop

### DIFF
--- a/Lib/test/test_pdb.py
+++ b/Lib/test/test_pdb.py
@@ -1045,7 +1045,7 @@ def test_pdb_next_command_in_generator_for_loop():
     ...         print('value', i)
     ...     x = 123
 
-    >>> with PdbTestInput(['break test_gen',
+    >>> with PdbTestInput(['break test_gen', # doctest: +ELLIPSIS
     ...                    'continue',
     ...                    'next',
     ...                    'next',
@@ -1055,7 +1055,7 @@ def test_pdb_next_command_in_generator_for_loop():
     > <doctest test.test_pdb.test_pdb_next_command_in_generator_for_loop[1]>(3)test_function()
     -> for i in test_gen():
     (Pdb) break test_gen
-    Breakpoint 6 at <doctest test.test_pdb.test_pdb_next_command_in_generator_for_loop[0]>:1
+    Breakpoint ... at <doctest test.test_pdb.test_pdb_next_command_in_generator_for_loop[0]>:1
     (Pdb) continue
     > <doctest test.test_pdb.test_pdb_next_command_in_generator_for_loop[0]>(2)test_gen()
     -> yield 0

--- a/Misc/NEWS.d/next/Tests/2018-06-09-18-17-51.bpo-33757.xDqphp.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-09-18-17-51.bpo-33757.xDqphp.rst
@@ -1,0 +1,1 @@
+Fix separate test_pdb_next_command_in_generator_for_loop in test_pdb


### PR DESCRIPTION
in test_pdb

<!-- issue-number: bpo-33757 -->
https://bugs.python.org/issue33757
<!-- /issue-number -->
