### PR TITLE
cgi.py - convert data to string before writing

### DIFF
--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -684,7 +684,7 @@ class FieldStorage:
                 if not data:
                     self.done = -1
                     break
-                self.file.write(data)
+                self.file.write(str(data))
                 todo = todo - len(data)
 
     def read_lines(self):


### PR DESCRIPTION
When using web.py, I get the following failure:
```
  File "/usr/local/lib/python3.5/dist-packages/web/webapi.py", line 364, in input
    out = rawinput(_method)
  File "/usr/local/lib/python3.5/dist-packages/web/webapi.py", line 341, in rawinput
    a = cgi.FieldStorage(fp=fp, environ=e, keep_blank_values=1)
  File "/usr/lib/python3.5/cgi.py", line 561, in __init__
    self.read_single()
  File "/usr/lib/python3.5/cgi.py", line 740, in read_single
    self.read_binary()
  File "/usr/lib/python3.5/cgi.py", line 762, in read_binary
    self.file.write(data)
TypeError: write() argument must be str, not bytes
```
Converting data to a string using the str() function fixes the problem.  There may be a better way to accomplish this, but it seems to need to happen one way or another.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
