### PR TITLE
bpo-32493: Correct test for uuid_enc_be availability in configure.ac.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-06-07-18-55-35.bpo-32493.1Bte62.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-07-18-55-35.bpo-32493.1Bte62.rst
@@ -1,0 +1,2 @@
+Correct test for ``uuid_enc_be`` availability in ``configure.ac``.
+Patch by Michael Felt.

--- a/configure
+++ b/configure
@@ -9632,9 +9632,7 @@ main ()
 {
 
 #ifndef uuid_enc_be
-uuid_t uuid;
-unsigned char buf[sizeof(uuid)];
-uuid_enc_be(buf, &uuid);
+void *x = uuid_enc_be
 #endif
 
   ;

--- a/configure.ac
+++ b/configure.ac
@@ -2716,9 +2716,7 @@ void *x = uuid_create
 AC_MSG_CHECKING(for uuid_enc_be)
 AC_COMPILE_IFELSE([AC_LANG_PROGRAM([[#include <uuid.h>]], [[
 #ifndef uuid_enc_be
-uuid_t uuid;
-unsigned char buf[sizeof(uuid)];
-uuid_enc_be(buf, &uuid);
+void *x = uuid_enc_be
 #endif
 ]])],
   [AC_DEFINE(HAVE_UUID_ENC_BE, 1, Define if uuid_enc_be() exists.)


### PR DESCRIPTION


<!-- issue-number: bpo-32493 -->
https://bugs.python.org/issue32493
<!-- /issue-number -->
