### PR TITLE
[2.7] Remove hyphens from phrase "picks up where it left off" (GH-7410).

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -296,7 +296,7 @@ Glossary
       the :func:`next` function. Each :keyword:`yield` temporarily suspends
       processing, remembering the location execution state (including local
       variables and pending try-statements).  When the generator resumes, it
-      picks-up where it left-off (in contrast to functions which start fresh on
+      picks up where it left off (in contrast to functions which start fresh on
       every invocation).
 
       .. index:: single: generator expression


### PR DESCRIPTION
(cherry picked from commit d689f976199d2e211a97d526b57cfa9871cc578d)

Co-authored-by: Andrés Delfino <adelfino@gmail.com>
