### PR TITLE
bpo-33818: PyExceptionClass_Name() will now return "const char *".

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1625,11 +1625,11 @@ The fields :c:member:`name` and :c:member:`doc` of structures
 :c:type:`PyMemberDef`, :c:type:`PyGetSetDef`,
 :c:type:`PyStructSequence_Field`, :c:type:`PyStructSequence_Desc`,
 and :c:type:`wrapperbase` are now of type ``const char *`` rather of
-``char *``.  (Contributed by Serhiy Storchaka in :issue:`28761`.)
-
-The result of :c:func:`PyUnicode_AsUTF8AndSize` and :c:func:`PyUnicode_AsUTF8`
-is now of type ``const char *`` rather of ``char *``. (Contributed by Serhiy
-Storchaka in :issue:`28769`.)
+``char *``.  The result of :c:func:`PyUnicode_AsUTF8AndSize`,
+:c:func:`PyUnicode_AsUTF8` and :c:func:`PyExceptionClass_Name`
+is now of type ``const char *`` rather of ``char *``.
+(Contributed by Serhiy Storchaka in :issue:`28761`, :issue:`28769` and
+:issue:`33818`.)
 
 The result of :c:func:`PyMapping_Keys`, :c:func:`PyMapping_Values` and
 :c:func:`PyMapping_Items` is now always a list, rather than a list or a

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1633,11 +1633,11 @@ The fields :c:member:`name` and :c:member:`doc` of structures
 :c:type:`PyMemberDef`, :c:type:`PyGetSetDef`,
 :c:type:`PyStructSequence_Field`, :c:type:`PyStructSequence_Desc`,
 and :c:type:`wrapperbase` are now of type ``const char *`` rather of
-``char *``.  The result of :c:func:`PyUnicode_AsUTF8AndSize`,
-:c:func:`PyUnicode_AsUTF8` and :c:func:`PyExceptionClass_Name`
-is now of type ``const char *`` rather of ``char *``.
-(Contributed by Serhiy Storchaka in :issue:`28761`, :issue:`28769` and
-:issue:`33818`.)
+``char *``.  (Contributed by Serhiy Storchaka in :issue:`28761`.)
+
+The result of :c:func:`PyUnicode_AsUTF8AndSize` and :c:func:`PyUnicode_AsUTF8`
+is now of type ``const char *`` rather of ``char *``. (Contributed by Serhiy
+Storchaka in :issue:`28769`.)
 
 The result of :c:func:`PyMapping_Keys`, :c:func:`PyMapping_Values` and
 :c:func:`PyMapping_Items` is now always a list, rather than a list or a

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -98,9 +98,13 @@ Optimizations
   first introduced in Python 3.4.  It offers better performance and smaller
   size compared to Protocol 3 available since Python 3.0.
 
+
 Build and C API Changes
 =======================
 
+* The result of :c:func:`PyExceptionClass_Name` is now of type
+  ``const char *`` rather of ``char *``.
+  (Contributed by Serhiy Storchaka in :issue:`33818`.)
 
 
 Deprecated

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -142,9 +142,9 @@ PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
 
 #ifndef Py_LIMITED_API
 #define PyExceptionClass_Name(x) \
-     ((char *)(((PyTypeObject*)(x))->tp_name))
+     (((PyTypeObject*)(x))->tp_name)
 #else
-     PyAPI_FUNC(char *) PyExceptionClass_Name(PyObject*);
+PyAPI_FUNC(const char *) PyExceptionClass_Name(PyObject *);
 #endif
 
 #define PyExceptionInstance_Class(x) ((PyObject*)((x)->ob_type))

--- a/Misc/NEWS.d/next/C API/2018-06-10-09-42-31.bpo-33818.50nlf3.rst
+++ b/Misc/NEWS.d/next/C API/2018-06-10-09-42-31.bpo-33818.50nlf3.rst
@@ -1,0 +1,2 @@
+:c:func`PyExceptionClass_Name` will now return ``const char *`` instead of
+``char *``.

--- a/Misc/NEWS.d/next/C API/2018-06-10-09-42-31.bpo-33818.50nlf3.rst
+++ b/Misc/NEWS.d/next/C API/2018-06-10-09-42-31.bpo-33818.50nlf3.rst
@@ -1,2 +1,2 @@
-:c:func`PyExceptionClass_Name` will now return ``const char *`` instead of
+:c:func:`PyExceptionClass_Name` will now return ``const char *`` instead of
 ``char *``.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -343,7 +343,8 @@ PyException_SetContext(PyObject *self, PyObject *context)
 }
 
 #undef PyExceptionClass_Name
-char *
+
+const char *
 PyExceptionClass_Name(PyObject *ob)
 {
     return ((PyTypeObject*)ob)->tp_name;

--- a/Python/errors.c
+++ b/Python/errors.c
@@ -947,7 +947,7 @@ PyErr_WriteUnraisable(PyObject *obj)
     _Py_IDENTIFIER(__module__);
     PyObject *f, *t, *v, *tb;
     PyObject *moduleName = NULL;
-    char* className;
+    const char *className;
 
     PyErr_Fetch(&t, &v, &tb);
 
@@ -977,7 +977,7 @@ PyErr_WriteUnraisable(PyObject *obj)
     assert(PyExceptionClass_Check(t));
     className = PyExceptionClass_Name(t);
     if (className != NULL) {
-        char *dot = strrchr(className, '.');
+        const char *dot = strrchr(className, '.');
         if (dot != NULL)
             className = dot+1;
     }

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -774,12 +774,12 @@ print_exception(PyObject *f, PyObject *value)
     }
     else {
         PyObject* moduleName;
-        char* className;
+        const char *className;
         _Py_IDENTIFIER(__module__);
         assert(PyExceptionClass_Check(type));
         className = PyExceptionClass_Name(type);
         if (className != NULL) {
-            char *dot = strrchr(className, '.');
+            const char *dot = strrchr(className, '.');
             if (dot != NULL)
                 className = dot+1;
         }


### PR DESCRIPTION
This PR is purposed for backporting in 3.7. If this change will not be applied to 3.7, What's New will need to be changed.

<!-- issue-number: bpo-33818 -->
https://bugs.python.org/issue33818
<!-- /issue-number -->
