### PR TITLE
[3.6] Fix spaces added after hyphens in news entries. (GH-7579)

### DIFF
--- a/Misc/NEWS.d/3.5.3rc1.rst
+++ b/Misc/NEWS.d/3.5.3rc1.rst
@@ -2131,7 +2131,7 @@ CPP invocation in configure must use CPPFLAGS. Patch by Chi Hsuan Yen.
 .. section: Build
 
 The configure script now inserts comments into the makefile to prevent the
-pgen and _freeze_importlib executables from being cross- compiled.
+pgen and _freeze_importlib executables from being cross-compiled.
 
 ..
 

--- a/Misc/NEWS.d/3.6.0a4.rst
+++ b/Misc/NEWS.d/3.6.0a4.rst
@@ -662,7 +662,7 @@ CPP invocation in configure must use CPPFLAGS. Patch by Chi Hsuan Yen.
 .. section: Build
 
 The configure script now inserts comments into the makefile to prevent the
-pgen and _freeze_importlib executables from being cross- compiled.
+pgen and _freeze_importlib executables from being cross-compiled.
 
 ..
 

--- a/Misc/NEWS.d/3.6.0b1.rst
+++ b/Misc/NEWS.d/3.6.0b1.rst
@@ -1127,7 +1127,7 @@ Chunked transfer encoding support added to http.client.HTTPConnection
 requests.  The urllib.request.AbstractHTTPHandler class does not enforce a
 Content-Length header any more.  If a HTTP request has a file or iterable
 body, but no Content-Length header, the library now falls back to use
-chunked transfer- encoding.
+chunked transfer-encoding.
 
 ..
 

--- a/Misc/NEWS.d/3.6.3rc1.rst
+++ b/Misc/NEWS.d/3.6.3rc1.rst
@@ -876,14 +876,14 @@ for maintenance.  Hence the conversion.
 The main difference for users is that user configurable key bindings for
 builtin features are now handled uniformly.  Now, editing a binding in a
 keyset only affects its value in the keyset.  All bindings are defined
-together in the system-specific default keysets in config- extensions.def.
-All custom keysets are saved as a whole in config- extension.cfg.  All take
+together in the system-specific default keysets in config-extensions.def.
+All custom keysets are saved as a whole in config-extension.cfg.  All take
 effect as soon as one clicks Apply or Ok.
 
 The affected events are '<<force-open-completions>>', '<<expand-word>>',
 '<<force-open-calltip>>', '<<flash-paren>>', '<<format-paragraph>>',
 '<<run-module>>', '<<check-module>>', and '<<zoom-height>>'.  Any (global)
-customizations made before 3.6.3 will not affect their keyset- specific
+customizations made before 3.6.3 will not affect their keyset-specific
 customization after 3.6.3. and vice versa.
 
 Inital patch by Charles Wohlganger.

--- a/Misc/NEWS.d/3.6.4rc1.rst
+++ b/Misc/NEWS.d/3.6.4rc1.rst
@@ -1068,7 +1068,7 @@ Remove test order dependence in idle_test.test_browser.
 Rename IDLE's module browser from Class Browser to Module Browser. The
 original module-level class and method browser became a module browser, with
 the addition of module-level functions, years ago. Nested classes and
-functions were added yesterday.  For back- compatibility, the virtual event
+functions were added yesterday.  For back-compatibility, the virtual event
 <<open-class-browser>>, which appears on the Keys tab of the Settings
 dialog, is not changed. Patch by Cheryl Sabella.
 


### PR DESCRIPTION
Seems they were added by double applying blurb.
(cherry picked from commit 98a0e466cd94d4635769cfdfd397c43c07384595)
