### PR TITLE
bpo-33738: Fix macros which contradict PEP 384

### DIFF
--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -598,7 +598,7 @@ PyAPI_FUNC(PyObject *) PyObject_GetIter(PyObject *);
     ((obj)->ob_type->tp_iternext != NULL && \
      (obj)->ob_type->tp_iternext != &_PyObject_NextNotImplemented)
 #else
-PyAPI_FUNC(int) PyIter_Check(PyObject*);
+PyAPI_FUNC(int) PyIter_Check(PyObject *);
 #endif
 
 /* Takes an iterator object and calls its tp_iternext slot,

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -142,9 +142,9 @@ PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
 
 #ifndef Py_LIMITED_API
 #define PyExceptionClass_Name(x) \
-     ((char *)(((PyTypeObject*)(x))->tp_name))
+     ((char *)(((PyTypeObject *)(x))->tp_name))
 #else
-     PyAPI_FUNC(char *) PyExceptionClass_Name(PyObject*);
+     PyAPI_FUNC(const char *) PyExceptionClass_Name(PyObject *);
 #endif
 
 #define PyExceptionInstance_Class(x) ((PyObject*)((x)->ob_type))

--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-07-18-34-19.bpo-33738.ODZS7a.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-07-18-34-19.bpo-33738.ODZS7a.rst
@@ -1,4 +1,4 @@
 Seven macro incompatibilities with the Limited API were fixed, and the
 macros PyIter_Check, PyIndex_Check and PyExceptionClass_Name were added as
-functions. The return type of PyExceptionClass_Name is "const char *".
+functions. The return type of PyExceptionClass_Name is "const char \*".
 A script for automatic macro checks was added.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-07-18-34-19.bpo-33738.ODZS7a.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-07-18-34-19.bpo-33738.ODZS7a.rst
@@ -1,3 +1,4 @@
 Seven macro incompatibilities with the Limited API were fixed, and the
 macros PyIter_Check, PyIndex_Check and PyExceptionClass_Name were added as
-functions. A script for automatic macro checks was added.
+functions. The return type of PyExceptionClass_Name is "const char *".
+A script for automatic macro checks was added.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -1245,6 +1245,7 @@ PyNumber_Absolute(PyObject *o)
 }
 
 #undef PyIndex_Check
+
 int
 PyIndex_Check(PyObject *obj)
 {
@@ -2544,6 +2545,7 @@ PyObject_GetIter(PyObject *o)
 }
 
 #undef PyIter_Check
+
 int PyIter_Check(PyObject *obj)
 {
     return obj->ob_type->tp_iternext != NULL &&

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -343,6 +343,7 @@ PyException_SetContext(PyObject *self, PyObject *context)
 }
 
 #undef PyExceptionClass_Name
+
 char *
 PyExceptionClass_Name(PyObject *ob)
 {


### PR DESCRIPTION
During development of the limited API support for PySide,
we saw an error in a macro that accessed a type field.

This patch fixes the 7 errors in the Python headers.
Macros which were not written as capitals were implemented
as function.

To do the necessary analysis again, a script was included that
parses all headers and looks for "->tp_" in sections which can
be reached with active limited API.

It is easily possible to call this script as a test.

Error listing:

../../Include/objimpl.h:243
    (Py_TYPE(o)->tp_is_gc == NULL || Py_TYPE(o)->tp_is_gc(o)))
Action: commented only

../../Include/objimpl.h:362
Action: commented only

../../Include/objimpl.h:364
    ((PyObject **) (((char *) (o)) + Py_TYPE(o)->tp_weaklistoffset))
Action: commented only

../../Include/pyerrors.h:143
     ((char *)(((PyTypeObject*)(x))->tp_name))
Action: implemented function

../../Include/abstract.h:593
    ((obj)->ob_type->tp_iternext != NULL && \
     (obj)->ob_type->tp_iternext != &_PyObject_NextNotImplemented)
Action: implemented function

../../Include/abstract.h:713
    ((obj)->ob_type->tp_as_number != NULL &&            \
     (obj)->ob_type->tp_as_number->nb_index != NULL)
Action: implemented function

../../Include/abstract.h:924
    ( Py_TYPE(o)->tp_as_sequence->sq_item(o, i) )
Action: commented only

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33738 -->
https://bugs.python.org/issue33738
<!-- /issue-number -->
