### PR TITLE
bpo-32108: Don't clear configparser values if key is assigned to itself

### DIFF
--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -966,9 +966,9 @@ class RawConfigParser(MutableMapping):
 
         # XXX this is not atomic if read_dict fails at any point. Then again,
         # no update method in configparser is atomic in this implementation.
-        if key == self.default_section:
+        if key == self.default_section and self._defaults != value:
             self._defaults.clear()
-        elif key in self._sections:
+        elif key in self._sections and self._sections[key] != value:
             self._sections[key].clear()
         self.read_dict({key: value})
 

--- a/Lib/configparser.py
+++ b/Lib/configparser.py
@@ -963,12 +963,13 @@ class RawConfigParser(MutableMapping):
     def __setitem__(self, key, value):
         # To conform with the mapping protocol, overwrites existing values in
         # the section.
-
+        if key in self and self[key] is value:
+            return
         # XXX this is not atomic if read_dict fails at any point. Then again,
         # no update method in configparser is atomic in this implementation.
-        if key == self.default_section and self._defaults != value:
+        if key == self.default_section:
             self._defaults.clear()
-        elif key in self._sections and self._sections[key] != value:
+        elif key in self._sections:
             self._sections[key].clear()
         self.read_dict({key: value})
 

--- a/Lib/test/test_configparser.py
+++ b/Lib/test/test_configparser.py
@@ -850,12 +850,18 @@ boolean {0[0]} NO
         self.assertEqual(set(cf['section3'].keys()), {'named'})
         self.assertNotIn('name3', cf['section3'])
         self.assertEqual(cf.sections(), ['section1', 'section2', 'section3'])
+        # For bpo-32108, assigning default_section to itself.
+        cf[self.default_section] = cf[self.default_section]
+        self.assertNotEqual(set(cf[self.default_section].keys()), set())
         cf[self.default_section] = {}
         self.assertEqual(set(cf[self.default_section].keys()), set())
         self.assertEqual(set(cf['section1'].keys()), {'name1'})
         self.assertEqual(set(cf['section2'].keys()), {'name22'})
         self.assertEqual(set(cf['section3'].keys()), set())
         self.assertEqual(cf.sections(), ['section1', 'section2', 'section3'])
+        # For bpo-32108, assigning section to itself.
+        cf['section2'] = cf['section2']
+        self.assertEqual(set(cf['section2'].keys()), {'name22'})
 
     def test_invalid_multiline_value(self):
         if self.allow_no_value:

--- a/Misc/NEWS.d/next/Library/2018-06-10-12-15-26.bpo-32108.iEkvh0.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-10-12-15-26.bpo-32108.iEkvh0.rst
@@ -1,0 +1,1 @@
+In configparser, don't clear section when it is assigned to itself.


### PR DESCRIPTION


<!-- issue-number: bpo-32108 -->
https://bugs.python.org/issue32108
<!-- /issue-number -->
