### PR TITLE
Fix GCC warning in Python/hamt.c

### DIFF
--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -2348,7 +2348,7 @@ _PyHamt_Without(PyHamtObject *o, PyObject *key)
         return NULL;
     }
 
-    PyHamtNode *new_root;
+    PyHamtNode *new_root = NULL;
 
     hamt_without_t res = hamt_node_without(
         (PyHamtNode *)(o->h_root),


### PR DESCRIPTION
This warning is present in the Travis builds for master and 3.7.

> Python/hamt.c: In function ‘_PyHamt_Without’:
Python/hamt.c:2371:76: warning: ‘new_root’ may be used uninitialized in this function [-Wmaybe-uninitialized]
Py_DECREF(new_root);
^
Python/hamt.c: In function ‘hamt_py_delete’:
Python/hamt.c:2371:76: warning: ‘new_root’ may be used uninitialized in this function [-Wmaybe-uninitialized]
Python/hamt.c:2351:17: note: ‘new_root’ was declared here
PyHamtNode *new_root;
> 