### PR TITLE
Mark importlib and clinic headers as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -40,9 +40,17 @@ PC/readme.txt text eol=crlf
 
 # Generated files
 # https://github.com/github/linguist#generated-code
-Modules/clinic/*.h linguist-generated=true
-Objects/clinic/*.h linguist-generated=true
-PC/clinic/*.h linguist-generated=true
-Python/clinic/*.h linguist-generated=true
-Python/importlib.h linguist-generated=true
+Include/graminit.h          linguist-generated=true
+Python/graminit.h           linguist-generated=true
+Modules/clinic/*.h          linguist-generated=true
+Objects/clinic/*.h          linguist-generated=true
+PC/clinic/*.h               linguist-generated=true
+Python/clinic/*.h           linguist-generated=true
+Python/importlib.h          linguist-generated=true
 Python/importlib_external.h linguist-generated=true
+Include/Python-ast.h        linguist-generated=true
+Python/Python-ast.c         linguist-generated=true
+Include/opcode.h            linguist-generated=true
+Python/opcode_targets.h     linguist-generated=true
+Objects/typeslots.inc       linguist-generated=true
+Modules/unicodedata_db.h    linguist-generated=true

--- a/.gitattributes
+++ b/.gitattributes
@@ -37,3 +37,12 @@ Lib/test/test_importlib/data01/* -text
 *.proj text eol=crlf
 PCbuild/readme.txt text eol=crlf
 PC/readme.txt text eol=crlf
+
+# Generated files
+# https://github.com/github/linguist#generated-code
+Modules/clinic/*.h linguist-generated=true
+Objects/clinic/*.h linguist-generated=true
+PC/clinic/*.h linguist-generated=true
+Python/clinic/*.h linguist-generated=true
+Python/importlib.h linguist-generated=true
+Python/importlib_external.h linguist-generated=true


### PR DESCRIPTION
We can specify generated files in `.gitattributes`.
Github doesn't render diff for generated files by default.

[Sample pull request](https://github.com/methane/cpython/pull/13/files)