### PR TITLE
bpo-33829: provide new object protocol helper for C API

### DIFF
--- a/Doc/c-api/object.rst
+++ b/Doc/c-api/object.rst
@@ -305,6 +305,18 @@ Object Protocol
       The types of *name* and *format* were changed from ``char *``.
 
 
+.. c:function:: PyObject* PyObject_CallMethodArgs(PyObject *obj, const char *name, PyObject *args, PyObject *kwargs)
+
+   Call the method named *name* of object *obj* with arguments given by the
+   tuple *args* and keywords arguments given by the dictionary *kwargs*.
+
+   *args* must not be *NULL*, use an empty tuple if no arguments are
+   needed. If no named arguments are needed, *kwargs* can be *NULL*.
+
+   This is the equivalent of the Python expression:
+   ``obj.name(*args, **kwargs)``.
+
+
 .. c:function:: PyObject* PyObject_CallFunctionObjArgs(PyObject *callable, ..., NULL)
 
    Call a callable Python object *callable*, with a variable number of

--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -309,6 +309,19 @@ PyAPI_FUNC(PyObject *) PyObject_CallMethod(PyObject *obj,
                                            const char *name,
                                            const char *format, ...);
 
+/* Call the method named 'name' of object 'obj' with arguments given by the
+   tuple 'args' and keywords arguments given by the dictionary 'kwargs'.
+
+   'args' must not be *NULL*, use an empty tuple if no arguments are
+   needed. If no named arguments are needed, 'kwargs' can be NULL.
+
+   This is the equivalent of the Python expression:
+   obj.name(*args, **kwargs). */
+PyAPI_FUNC(PyObject *) PyObject_CallMethodArgs(PyObject *obj,
+                                               const char *name,
+                                               PyObject *args,
+                                               PyObject *kwargs);
+
 #ifndef Py_LIMITED_API
 /* Like PyObject_CallMethod(), but expect a _Py_Identifier*
    as the method name. */

--- a/Misc/NEWS.d/next/C API/2018-06-11-12-03-51.bpo-33829.QioE4z.rst
+++ b/Misc/NEWS.d/next/C API/2018-06-11-12-03-51.bpo-33829.QioE4z.rst
@@ -1,0 +1,2 @@
+Add a new helper for calling object methods with args and kwargs tuples passed
+unchanged as parameters.

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1051,6 +1051,27 @@ PyObject_CallMethod(PyObject *obj, const char *name, const char *format, ...)
 }
 
 
+PyAPI_FUNC(PyObject *) PyObject_CallMethodArgs(PyObject *obj,
+                                               const char *name,
+                                               PyObject *args,
+                                               PyObject *kwargs)
+{
+    PyObject *callable, *retval;
+
+    if (obj ==  NULL)
+        return null_error();
+
+    callable = PyObject_GetAttrString(obj, name);
+    if (callable == NULL)
+        return NULL;
+
+    retval = PyObject_Call(callable, args, kwargs);
+    Py_DECREF(callable);
+
+    return retval;
+}
+
+
 /* PyEval_CallMethod is exact copy of PyObject_CallMethod.
  * This function is kept for backward compatibility.
  */


### PR DESCRIPTION
If we want to call an object's method from C code and pass it the args
and kwargs tuples unchanged, we need to first retrieve the callable
object using PyObject_GetAttrString(), then call it using
PyObject_Call().

This patch proposes to wrap the two calls in a new helper.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33829 -->
https://bugs.python.org/issue33829
<!-- /issue-number -->
