### PR TITLE
Clean up after bpo-33738.

### DIFF
--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -593,12 +593,11 @@ PyAPI_FUNC(PyObject *) PyObject_GetIter(PyObject *);
 /* Returns 1 if the object 'obj' provides iterator protocols, and 0 otherwise.
 
    This function always succeeds. */
+PyAPI_FUNC(int) PyIter_Check(PyObject *);
 #ifndef Py_LIMITED_API
 #define PyIter_Check(obj) \
     ((obj)->ob_type->tp_iternext != NULL && \
      (obj)->ob_type->tp_iternext != &_PyObject_NextNotImplemented)
-#else
-PyAPI_FUNC(int) PyIter_Check(PyObject *);
 #endif
 
 /* Takes an iterator object and calls its tp_iternext slot,
@@ -719,12 +718,11 @@ PyAPI_FUNC(PyObject *) PyNumber_Or(PyObject *o1, PyObject *o2);
 
 /* Returns 1 if obj is an index integer (has the nb_index slot of the
    tp_as_number structure filled in), and 0 otherwise. */
+PyAPI_FUNC(int) PyIndex_Check(PyObject *);
 #ifndef Py_LIMITED_API
 #define PyIndex_Check(obj)                              \
     ((obj)->ob_type->tp_as_number != NULL &&            \
      (obj)->ob_type->tp_as_number->nb_index != NULL)
-#else
-PyAPI_FUNC(int) PyIndex_Check(PyObject *);
 #endif
 
 /* Returns the object 'o' converted to a Python int, or NULL with an exception

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -140,11 +140,10 @@ PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
 #define PyExceptionInstance_Check(x)                    \
     PyType_FastSubclass((x)->ob_type, Py_TPFLAGS_BASE_EXC_SUBCLASS)
 
+PyAPI_FUNC(char *) PyExceptionClass_Name(PyObject *);
 #ifndef Py_LIMITED_API
 #define PyExceptionClass_Name(x) \
      ((char *)(((PyTypeObject *)(x))->tp_name))
-#else
-     PyAPI_FUNC(const char *) PyExceptionClass_Name(PyObject *);
 #endif
 
 #define PyExceptionInstance_Class(x) ((PyObject*)((x)->ob_type))

--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-07-18-34-19.bpo-33738.ODZS7a.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-07-18-34-19.bpo-33738.ODZS7a.rst
@@ -1,4 +1,4 @@
 Seven macro incompatibilities with the Limited API were fixed, and the
-macros PyIter_Check, PyIndex_Check and PyExceptionClass_Name were added as
-functions. The return type of PyExceptionClass_Name is "const char \*".
+macros :c:func:`PyIter_Check`, :c:func:`PyIndex_Check` and
+:c:func:`PyExceptionClass_Name` were added as functions.
 A script for automatic macro checks was added.

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -347,7 +347,7 @@ PyException_SetContext(PyObject *self, PyObject *context)
 char *
 PyExceptionClass_Name(PyObject *ob)
 {
-    return ((PyTypeObject*)ob)->tp_name;
+    return (char *)((PyTypeObject*)ob)->tp_name;
 }
 
 static struct PyMemberDef BaseException_members[] = {


### PR DESCRIPTION
* Add declarations even if they are overridden by macros.
* Make the declaration and the definition of PyExceptionClass_Name
  consistent.


<!-- issue-number: bpo-33738 -->
https://bugs.python.org/issue33738
<!-- /issue-number -->
