### PR TITLE
bpo-30820: Remove incorrect docs for email.contentmanager.raw_data_manager

### DIFF
--- a/Doc/library/email.contentmanager.rst
+++ b/Doc/library/email.contentmanager.rst
@@ -126,9 +126,6 @@ Currently the email package provides only one concrete content manager,
                set_content(msg, <'EmailMessage'>, cte=None, \
                            disposition=None, filename=None, cid=None, \
                            params=None, headers=None)
-               set_content(msg, <'list'>, subtype='mixed', \
-                           disposition=None, filename=None, cid=None, \
-                           params=None, headers=None)
 
        Add headers and payload to *msg*:
 
@@ -144,12 +141,6 @@ Currently the email package provides only one concrete content manager,
              specified or ``rfc822`` if it is not.  If *subtype* is
              ``partial``, raise an error (``bytes`` objects must be used to
              construct ``message/partial`` parts).
-           * For *<'list'>*, which should be a list of
-             :class:`~email.message.EmailMessage` objects, set the ``maintype``
-             to ``multipart``, and the ``subtype`` to *subtype* if it is
-             specified, and ``mixed`` if it is not.  If the message parts in
-             the *<'list'>* have :mailheader:`MIME-Version` headers, remove
-             them.
 
        If *charset* is provided (which is valid only for ``str``), encode the
        string to bytes using the specified character set.  The default is


### PR DESCRIPTION
The docs falsely claimed that a list of EmailMessage objects could be
passed to set_content().

<!-- issue-number: bpo-30820 -->
https://bugs.python.org/issue30820
<!-- /issue-number -->
