### PR TITLE
bpo-33833: Fix ProactorSocketTransport AssertionError

### DIFF
--- a/Lib/asyncio/proactor_events.py
+++ b/Lib/asyncio/proactor_events.py
@@ -343,6 +343,10 @@ class _ProactorBaseWritePipeTransport(_ProactorBasePipeTransport,
 
     def _loop_writing(self, f=None, data=None):
         try:
+            if f is not None and self._write_fut is None and self._closing:
+                # XXX most likely self._force_close() has been called, and
+                # it has set self._write_fut to None.
+                return
             assert f is self._write_fut
             self._write_fut = None
             self._pending_write = 0

--- a/Lib/test/test_asyncio/test_proactor_events.py
+++ b/Lib/test/test_asyncio/test_proactor_events.py
@@ -257,6 +257,19 @@ class ProactorSocketTransportTests(test_utils.TestCase):
         self.assertEqual(None, tr._buffer)
         self.assertEqual(tr._conn_lost, 1)
 
+    def test_loop_writing_force_close(self):
+        exc_handler = mock.Mock()
+        self.loop.set_exception_handler(exc_handler)
+        fut = asyncio.Future(loop=self.loop)
+        fut.set_result(1)
+        self.proactor.send.return_value = fut
+
+        tr = self.socket_transport()
+        tr.write(b'data')
+        tr._force_close(None)
+        test_utils.run_briefly(self.loop)
+        exc_handler.assert_not_called()
+
     def test_force_close_idempotent(self):
         tr = self.socket_transport()
         tr._closing = True

--- a/Misc/NEWS.d/next/Library/2018-06-17-11-46-20.bpo-33833.RnEqvM.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-17-11-46-20.bpo-33833.RnEqvM.rst
@@ -1,0 +1,2 @@
+Fixed bug in asyncio where ProactorSocketTransport logs AssertionError if
+force closed during write.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33833 -->
https://bugs.python.org/issue33833
<!-- /issue-number -->
