### PR TITLE
bpo-33656: Add enum name for argument of Windows call.

### DIFF
--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -9,10 +9,13 @@ except ImportError:
           "Your Python may not be configured for Tk. **", file=sys.__stderr__)
     raise SystemExit(1)
 
+# Valid arguments for the ...Awareness call below are defined in the following.
+# https://msdn.microsoft.com/en-us/library/windows/desktop/dn280512(v=vs.85).aspx
 if sys.platform == 'win32':
     import ctypes
+    PROCESS_SYSTEM_DPI_AWARE = 1
     try:
-        ctypes.OleDLL('shcore').SetProcessDpiAwareness(1)
+        ctypes.OleDLL('shcore').SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE)
     except (AttributeError, OSError):
         pass
 


### PR DESCRIPTION
Change suggested by Eryk Sun in a comment on PR 7137 after it was merged.


<!-- issue-number: bpo-33656 -->
https://bugs.python.org/issue33656
<!-- /issue-number -->
