### PR TITLE
bpo-31432: Revert unrelated code changes to _ssl.c and test_ssl

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4074,9 +4074,7 @@ class ThreadedTests(unittest.TestCase):
                 self.assertTrue(session)
                 with self.assertRaises(TypeError) as e:
                     s.session = object
-                self.assertEqual(
-                    str(e.exception), 'Value is not an SSLSession.'
-                )
+                self.assertEqual(str(e.exception), 'Value is not a SSLSession.')
 
             with client_context.wrap_socket(socket.socket(),
                                             server_hostname=hostname) as s:

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2066,7 +2066,7 @@ static int PySSL_set_context(PySSLSocket *self, PyObject *value,
         SSL_set_SSL_CTX(self->ssl, self->ctx->ctx);
 #endif
     } else {
-        PyErr_SetString(PyExc_TypeError, "The value must be an SSLContext.");
+        PyErr_SetString(PyExc_TypeError, "The value must be a SSLContext");
         return -1;
     }
 
@@ -2725,7 +2725,7 @@ static int PySSL_set_session(PySSLSocket *self, PyObject *value,
     int result;
 
     if (!PySSLSession_Check(value)) {
-        PyErr_SetString(PyExc_TypeError, "Value is not an SSLSession.");
+        PyErr_SetString(PyExc_TypeError, "Value is not a SSLSession.");
         return -1;
     }
     pysess = (PySSLSession *)value;


### PR DESCRIPTION
Revert code changes inadvertently committed with previous doc update as they change user-facing messages.  They can be reconsidered in a separate PR.

<!-- issue-number: bpo-31432 -->
https://bugs.python.org/issue31432
<!-- /issue-number -->
