### PR TITLE
bpo-33582: Remove duplicate space in inspect.formatargspec() deprecation warning

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -1220,7 +1220,7 @@ def formatargspec(args, varargs=None, varkw=None, defaults=None,
     from warnings import warn
 
     warn("`formatargspec` is deprecated since Python 3.5. Use `signature` and "
-         " the `Signature` object directly",
+         "the `Signature` object directly",
          DeprecationWarning,
          stacklevel=2)
 


### PR DESCRIPTION


<!-- issue-number: bpo-33582 -->
https://bugs.python.org/issue33582
<!-- /issue-number -->
