### PR TITLE
bpo-33630: Fix race condition in `TestPosixSpawn.test_open`

### DIFF
--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1529,6 +1529,7 @@ class TestPosixSpawn(unittest.TestCase):
         script = """if 1:
             import sys
             sys.stdout.write("hello")
+            sys.stdout.flush()
             """
         file_actions = [
             (os.POSIX_SPAWN_OPEN, 1, outfile,
@@ -1539,6 +1540,12 @@ class TestPosixSpawn(unittest.TestCase):
                                 [sys.executable, '-c', script],
                                 os.environ, file_actions)
         self.assertEqual(os.waitpid(pid, 0), (pid, 0))
+
+        max_tries = 3
+        while not os.path.exists(outfile) and max_tries:
+            max_tries -= 1
+            time.sleep(0.1)
+
         with open(outfile) as f:
             self.assertEqual(f.read(), 'hello')
 

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1541,9 +1541,10 @@ class TestPosixSpawn(unittest.TestCase):
                                 os.environ, file_actions)
         self.assertEqual(os.waitpid(pid, 0), (pid, 0))
 
-        max_tries = 3
-        while not os.path.exists(outfile) and max_tries:
-            max_tries -= 1
+        deadline = time.monotonic() + 0.3
+        while not os.path.exists(outfile):
+            if time.monotonic() > deadline:
+                break
             time.sleep(0.1)
 
         with open(outfile) as f:

--- a/Lib/test/test_posix.py
+++ b/Lib/test/test_posix.py
@@ -1544,11 +1544,19 @@ class TestPosixSpawn(unittest.TestCase):
         deadline = time.monotonic() + 0.3
         while not os.path.exists(outfile):
             if time.monotonic() > deadline:
-                break
+                raise TimeoutError
             time.sleep(0.1)
 
+        deadline = time.monotonic() + 0.3
         with open(outfile) as f:
-            self.assertEqual(f.read(), 'hello')
+            while True:
+                if time.monotonic() > deadline:
+                    raise TimeoutError
+                f.seek(0)
+                data = f.read()
+                if data:
+                    break
+            self.assertEqual(data, 'hello')
 
     def test_close_file(self):
         closefile = support.TESTFN


### PR DESCRIPTION

<!-- issue-number: bpo-33630 -->
https://bugs.python.org/issue33630
<!-- /issue-number -->

This PR is triying to fix this error (more info in the bpo):

```exception
test_no_such_executable (test.test_posix.TestPosixSpawn) ... ok
test_open_file (test.test_posix.TestPosixSpawn) ... ERROR
test_returns_pid (test.test_posix.TestPosixSpawn) ... ok
Warning -- files was modified by test_posix
  Before: []
  After:  ['\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb\udcdb'] 
test test_posix failed
test_specify_environment (test.test_posix.TestPosixSpawn) ... ok

======================================================================
ERROR: test_open_file (test.test_posix.TestPosixSpawn)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/shager/cpython-buildarea/3.x.edelsohn-fedora-ppc64/build/Lib/test/test_posix.py", line 1542, in test_open_file
    with open(outfile) as f:
FileNotFoundError: [Errno 2] No such file or directory: '@test_42482_tmp'
```
