### PR TITLE
bpo-33660: Fix PosixPath to resolve a relative path on root

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -325,7 +325,10 @@ class _PosixFlavour(_Flavour):
                     # parent dir
                     path, _, _ = path.rpartition(sep)
                     continue
-                newpath = path + sep + name
+                if path.endswith(sep):
+                    newpath = path + name
+                else:
+                    newpath = path + sep + name
                 if newpath in seen:
                     # Already seen this path
                     path = seen[newpath]

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2223,6 +2223,15 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
         st = os.stat(join('other_new_file'))
         self.assertEqual(stat.S_IMODE(st.st_mode), 0o644)
 
+    def test_resolve_root(self):
+        current_directory = os.getcwd()
+        try:
+            os.chdir('/')
+            p = self.cls('spam')
+            self.assertEqual(str(p.resolve()), '/spam')
+        finally:
+            os.chdir(current_directory)
+
     def test_touch_mode(self):
         old_mask = os.umask(0)
         self.addCleanup(os.umask, old_mask)

--- a/Misc/NEWS.d/next/Library/2018-06-12-23-30-41.bpo-33660.AdDn5Z.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-12-23-30-41.bpo-33660.AdDn5Z.rst
@@ -1,0 +1,2 @@
+Fix pathlib.PosixPath to resolve a relative path located on the root
+directory properly.


### PR DESCRIPTION

<!-- issue-number: bpo-33660 -->
https://bugs.python.org/issue33660
<!-- /issue-number -->

Needs backport to 3.7 3.6
