### PR TITLE
bpo-33828: Add missing versionchanged note for string.Formatter.

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -231,11 +231,11 @@ attribute using :func:`getattr`, while an expression of the form ``'[index]'``
 does an index lookup using :func:`__getitem__`.
 
 .. versionchanged:: 3.1
-   The positional argument specifiers can be omitted, for :meth:`str.format`,
-   so ``'{} {}'`` is equivalent to ``'{0} {1}'``.
+   The positional argument specifiers can be omitted for :meth:`str.format`,
+   so ``'{} {}'.format(a, b)`` is equivalent to ``'{0} {1}'.format(a, b)``.
 
 .. versionchanged:: 3.4
-   The positional argument specifiers can be omitted, for :class:`Formatter`.
+   The positional argument specifiers can be omitted for :class:`Formatter`.
 
 Some simple format string examples::
 

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -231,8 +231,11 @@ attribute using :func:`getattr`, while an expression of the form ``'[index]'``
 does an index lookup using :func:`__getitem__`.
 
 .. versionchanged:: 3.1
-   The positional argument specifiers can be omitted, so ``'{} {}'`` is
-   equivalent to ``'{0} {1}'``.
+   The positional argument specifiers can be omitted, for :meth:`str.format`,
+   so ``'{} {}'`` is equivalent to ``'{0} {1}'``.
+
+.. versionchanged:: 3.4
+   The positional argument specifiers can be omitted, for :class:`Formatter`.
 
 Some simple format string examples::
 


### PR DESCRIPTION
string.Formatter auto-numbering feature was added in 3.4 and there
is no versionchanged not in its documentation, making the documentation
ambiguous about which version the feature is available.

<!-- issue-number: bpo-33828 -->
https://bugs.python.org/issue33828
<!-- /issue-number -->
