### PR TITLE
[2.7] bpo-33828: Add missing versionchanged note for string.Formatter. (GH-7668)

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -257,8 +257,9 @@ attribute using :func:`getattr`, while an expression of the form ``'[index]'``
 does an index lookup using :func:`__getitem__`.
 
 .. versionchanged:: 2.7
-   The positional argument specifiers can be omitted, so ``'{} {}'`` is
-   equivalent to ``'{0} {1}'``.
+   The positional argument specifiers can be omitted for :meth:`str.format` and
+   :meth:`unicode.format`, so ``'{} {}'`` is equivalent to ``'{0} {1}'``,
+   ``u'{} {}'`` is equivalent to ``u'{0} {1}'``.
 
 Some simple format string examples::
 


### PR DESCRIPTION
string.Formatter auto-numbering feature was added in 3.4 and not
available in 2.7.  Make the documentation unambiguous.


<!-- issue-number: bpo-33828 -->
https://bugs.python.org/issue33828
<!-- /issue-number -->
