### PR TITLE
bpo-31378: Add missing docs for sqlite3.OperationalError

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -821,6 +821,13 @@ Exceptions
    exists, syntax error in the SQL statement, wrong number of parameters
    specified, etc.  It is a subclass of :exc:`DatabaseError`.
 
+.. exception:: OperationalError
+
+   Exception raised for errors that are related to the database's operation
+   and not necessarily under the control of the programmer, e.g. an unexpected
+   disconnect occurs, the data source name is not found, a transaction could
+   not be processed, etc.  It is a subclass of :exc:`DatabaseError`.
+
 
 .. _sqlite3-types:
 


### PR DESCRIPTION
The wording is taken from PEP 249.

<!-- issue-number: bpo-31378 -->
https://bugs.python.org/issue31378
<!-- /issue-number -->
