### PR TITLE
bpo-33351: (WIP) Patches to build on clang-cl

### DIFF
--- a/Include/pytime.h
+++ b/Include/pytime.h
@@ -14,9 +14,9 @@ extern "C" {
 #endif
 
 #if defined(_MSC_VER)
-	/* Forward declare struct timeval so that clang-cl doesn't complain about it
-	being a local declaration later on  in _PyTime_AsTimeval.*/
-	struct timeval;
+        /* Forward declare struct timeval so that clang-cl doesn't complain about it
+        being a local declaration later on  in _PyTime_AsTimeval.*/
+        struct timeval;
 #endif /* _MSC_VER */
 
 /* _PyTime_t: Python timestamp with subsecond precision. It can be used to

--- a/Include/pytime.h
+++ b/Include/pytime.h
@@ -13,6 +13,12 @@ functions and constants
 extern "C" {
 #endif
 
+#if defined(_MSC_VER)
+	/* Forward declare struct timeval so that clang-cl doesn't complain about it
+	being a local declaration later on  in _PyTime_AsTimeval.*/
+	struct timeval;
+#endif /* _MSC_VER */
+
 /* _PyTime_t: Python timestamp with subsecond precision. It can be used to
    store a duration, and so indirectly a date (related to another date, like
    UNIX epoch). */

--- a/Misc/NEWS.d/next/Build/2018-06-13-03-08-13.bpo-33351.fn4g9Z.rst
+++ b/Misc/NEWS.d/next/Build/2018-06-13-03-08-13.bpo-33351.fn4g9Z.rst
@@ -1,0 +1,3 @@
+Port CPython to build with clang-cl on Windows.
+
+Patch by Ethan Smith

--- a/Modules/_tracemalloc.c
+++ b/Modules/_tracemalloc.c
@@ -67,7 +67,10 @@ static PyThread_type_lock tables_lock;
 
 #define DEFAULT_DOMAIN 0
 
-/* Pack the frame_t structure to reduce the memory footprint. */
+/* Pack the pointer_t structure to reduce the memory footprint. */
+#if defined(_MSC_VER)
+#pragma pack(push, 4)
+#endif
 typedef struct
 #ifdef __GNUC__
 __attribute__((packed))
@@ -76,14 +79,18 @@ __attribute__((packed))
     uintptr_t ptr;
     unsigned int domain;
 } pointer_t;
+#ifdef _MSC_VER
+#pragma pack(pop)
+#endif
 
 /* Pack the frame_t structure to reduce the memory footprint on 64-bit
-   architectures: 12 bytes instead of 16. */
+architectures: 12 bytes instead of 16. */
+#if defined(_MSC_VER)
+#pragma pack(push, 4)
+#endif
 typedef struct
 #ifdef __GNUC__
 __attribute__((packed))
-#elif defined(_MSC_VER)
-#pragma pack(push, 4)
 #endif
 {
     /* filename cannot be NULL: "<unknown>" is used if the Python frame

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -117,7 +117,7 @@ WIN32 is still required for the locale module.
 #if defined(__INTEL_COMPILER)
 #define COMPILER ("[ICC v." _Py_STRINGIZE(__INTEL_COMPILER) " 64 bit (amd64) with MSC v." _Py_STRINGIZE(_MSC_VER) " CRT]")
 #elif defined(__clang__)
-#define COMPILER ("[clang v." _Py_STRINGIZE(__clang_version__) "64 bit (amd64) with MSC v." _Py_STRINGIZE(_MSC_VER) " CRT]")
+#define COMPILER ("[clang v." _Py_STRINGIZE(__clang_version__) " 64 bit (amd64) with MSC v." _Py_STRINGIZE(_MSC_VER) " CRT]")
 #else
 #define COMPILER _Py_PASTE_VERSION("64 bit (AMD64)")
 #endif /* __INTEL_COMPILER */

--- a/PC/pyconfig.h
+++ b/PC/pyconfig.h
@@ -94,15 +94,9 @@ WIN32 is still required for the locale module.
 /* e.g., this produces, after compile-time string catenation,
  *      ("[MSC v.1200 32 bit (Intel)]")
  *
- * _Py_STRINGIZE(_MSC_VER) expands to
- * _Py_STRINGIZE1((_MSC_VER)) expands to
- * _Py_STRINGIZE2(_MSC_VER) but as this call is the result of token-pasting
- *      it's scanned again for macros and so further expands to (under MSVC 6)
- * _Py_STRINGIZE2(1200) which then expands to
- * "1200"
+ * The double-stringize hack, a method to get the string version of _MSC_VER
  */
-#define _Py_STRINGIZE(X) _Py_STRINGIZE1((X))
-#define _Py_STRINGIZE1(X) _Py_STRINGIZE2 ## X
+#define _Py_STRINGIZE(X) _Py_STRINGIZE2(X)
 #define _Py_STRINGIZE2(X) #X
 
 /* MSVC defines _WINxx to differentiate the windows platform types
@@ -122,6 +116,8 @@ WIN32 is still required for the locale module.
 #if defined(_M_X64) || defined(_M_AMD64)
 #if defined(__INTEL_COMPILER)
 #define COMPILER ("[ICC v." _Py_STRINGIZE(__INTEL_COMPILER) " 64 bit (amd64) with MSC v." _Py_STRINGIZE(_MSC_VER) " CRT]")
+#elif defined(__clang__)
+#define COMPILER ("[clang v." _Py_STRINGIZE(__clang_version__) "64 bit (amd64) with MSC v." _Py_STRINGIZE(_MSC_VER) " CRT]")
 #else
 #define COMPILER _Py_PASTE_VERSION("64 bit (AMD64)")
 #endif /* __INTEL_COMPILER */
@@ -172,6 +168,8 @@ typedef _W64 int ssize_t;
 #if defined(_M_IX86)
 #if defined(__INTEL_COMPILER)
 #define COMPILER ("[ICC v." _Py_STRINGIZE(__INTEL_COMPILER) " 32 bit (Intel) with MSC v." _Py_STRINGIZE(_MSC_VER) " CRT]")
+#elif defined(__clang__)
+#define COMPILER ("[clang v." _Py_STRINGIZE(__clang_version__) "32 bit (Intel) with MSC v." _Py_STRINGIZE(_MSC_VER) " CRT]")
 #else
 #define COMPILER _Py_PASTE_VERSION("32 bit (Intel)")
 #endif /* __INTEL_COMPILER */


### PR DESCRIPTION
I've been a bit busy so I haven't had time to prepare this, but I wanted to post something people can try, so here's something.

So far I have made changes to:
- forward declare struct timeval in pytime (it should have been anyway)
- move some struct packing in the correct place
- Using a more portable stringize macro
- defining compiler names

This builds and passes tests with MSVC, and clang-cl on x64.

If you would like to test this:

- Grab a Windows snapshot build of clang trunk from here: http://llvm.org/builds/ or build clang from source (not recommended, this is quite time, processor, and memory intensive).
then
- Change project files to build with the LLVM-2014 toolset (I haven't figured out a good way to do this automatically yet).

Everything builds except:

- _decimal (clang-cl doesn't like linking mpd it seems)
- _distutils_findvs (unsurprisingly)
- pyshellext (it doesn't like the idl file)

The good news is that clang generates MSVC ABI compatible binaries, so linking clang/msvc binaries together is fine.

The following tests fail under clang-cl:

test_compile test_compileall test_ctypes test_exceptions
    test_fileio test_io test_json test_os test_pickle test_pickletools
    test_richcmp test_runpy test_script_helper test_sys test_traceback
    test_userdict test_userlist test_xml_etree

It seems many of them are failing with a stack overflow, so it seems clang is miscompiling something.

There is however a subset that can compile under clang while still passing the tests.

<!-- issue-number: bpo-33351 -->
https://bugs.python.org/issue33351
<!-- /issue-number -->
