### PR TITLE
bpo-33671 / shutil.copyfile: use memoryview() with dynamic size on Windows

### DIFF
--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -413,8 +413,8 @@ On Linux, Solaris and other POSIX platforms where :func:`os.sendfile` supports
 copies between 2 regular file descriptors :func:`os.sendfile` is used.
 
 On Windows :func:`shutil.copyfile` uses a bigger default buffer size (1 MiB
-instead of 16 KiB) and if file size >= 128 MiB a :func:`memoryview`-based
-variant of :func:`shutil.copyfileobj` is used.
+instead of 16 KiB) and a :func:`memoryview`-based variant of
+:func:`shutil.copyfileobj` is used.
 
 If the fast-copy operation fails and no data was written in the destination
 file then shutil will silently fallback on using less efficient

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -412,6 +412,10 @@ On macOS `fcopyfile`_ is used to copy the file content (not metadata).
 On Linux, Solaris and other POSIX platforms where :func:`os.sendfile` supports
 copies between 2 regular file descriptors :func:`os.sendfile` is used.
 
+On Windows :func:`shutil.copyfile` uses a bigger default buffer size (1 MiB
+instead of 16 KiB) and if file size >= 128 MiB a :func:`memoryview`-based
+variant of :func:`shutil.copyfileobj` is used.
+
 If the fast-copy operation fails and no data was written in the destination
 file then shutil will silently fallback on using less efficient
 :func:`copyfileobj` function internally.

--- a/Doc/library/shutil.rst
+++ b/Doc/library/shutil.rst
@@ -407,7 +407,7 @@ efficiently (see :issue:`33671`).
 "fast-copy" means that the copying operation occurs within the kernel, avoiding
 the use of userspace buffers in Python as in "``outfd.write(infd.read())``".
 
-On OSX `fcopyfile`_ is used to copy the file content (not metadata).
+On macOS `fcopyfile`_ is used to copy the file content (not metadata).
 
 On Linux, Solaris and other POSIX platforms where :func:`os.sendfile` supports
 copies between 2 regular file descriptors :func:`os.sendfile` is used.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -167,6 +167,9 @@ Changes in the Python API
 * The :class:`cProfile.Profile` class can now be used as a context
   manager. (Contributed by Scott Sanderson in :issue:`29235`.)
 
+* :func:`shutil.copyfile` default buffer size on Windows was changed from
+  16 KiB to 1 MiB.
+
 CPython bytecode changes
 ------------------------
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -100,15 +100,11 @@ Optimizations
   "fast-copy" means that the copying operation occurs within the kernel,
   avoiding the use of userspace buffers in Python as in
   "``outfd.write(infd.read())``".
-  All other platforms not using such technique will rely on a faster
-  :func:`shutil.copyfile` implementation using :func:`memoryview`,
-  :class:`bytearray` and
-  :meth:`BufferedIOBase.readinto() <io.BufferedIOBase.readinto>`.
-  Finally, :func:`shutil.copyfile` default buffer size on Windows was increased
-  from 16KB to 1MB.
-  The speedup for copying a 512MB file within the same partition is about +26%
-  on Linux, +50% on macOS and +38% on Windows. Also, much less CPU cycles are
-  consumed.
+  Also, :func:`shutil.copyfile` default buffer size on Windows was increased
+  from 16 KiB to 1 MiB.
+  The speedup for copying a 512 MiB file within the same partition is about
+  +26% on Linux, +50% on macOS and +40% on Windows. Also, much less CPU cycles
+  are consumed.
   (Contributed by Giampaolo Rodola' in :issue:`25427`.)
 
 * The default protocol in the :mod:`pickle` module is now Protocol 4,

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -95,8 +95,8 @@ Optimizations
 
 * :func:`shutil.copyfile`, :func:`shutil.copy`, :func:`shutil.copy2`,
   :func:`shutil.copytree` and :func:`shutil.move` use platform-specific
-  "fast-copy" syscalls on Linux, OSX and Solaris in order to copy the file more
-  efficiently.
+  "fast-copy" syscalls on Linux, macOS and Solaris in order to copy the file
+  more efficiently.
   "fast-copy" means that the copying operation occurs within the kernel,
   avoiding the use of userspace buffers in Python as in
   "``outfd.write(infd.read())``".
@@ -107,7 +107,7 @@ Optimizations
   Finally, :func:`shutil.copyfile` default buffer size on Windows was increased
   from 16KB to 1MB.
   The speedup for copying a 512MB file within the same partition is about +26%
-  on Linux, +50% on OSX and +38% on Windows. Also, much less CPU cycles are
+  on Linux, +50% on macOS and +38% on Windows. Also, much less CPU cycles are
   consumed.
   (Contributed by Giampaolo Rodola' in :issue:`25427`.)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -100,9 +100,9 @@ Optimizations
   "fast-copy" means that the copying operation occurs within the kernel,
   avoiding the use of userspace buffers in Python as in
   "``outfd.write(infd.read())``".
-  On Windows :func:`shutil.copyfile` default buffer size was increased
-  from 16 KiB to 1 MiB and a faster implementation of :func:`shutil.copyfileobj`
-  is used for files bigger than 128 MiB.
+  On Windows :func:`shutil.copyfile` uses a bigger default buffer size (1 MiB
+  instead of 16 KiB) and a :func:`memoryview`-based variant of
+  :func:`shutil.copyfileobj` is used.
   The speedup for copying a 512 MiB file within the same partition is about
   +26% on Linux, +50% on macOS and +40% on Windows. Also, much less CPU cycles
   are consumed.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -105,6 +105,7 @@ Optimizations
   The speedup for copying a 512 MiB file within the same partition is about
   +26% on Linux, +50% on macOS and +40% on Windows. Also, much less CPU cycles
   are consumed.
+  See :ref:`shutil-platform-dependent-efficient-copy-operations` section.
   (Contributed by Giampaolo Rodola' in :issue:`25427`.)
 
 * The default protocol in the :mod:`pickle` module is now Protocol 4,

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -100,8 +100,9 @@ Optimizations
   "fast-copy" means that the copying operation occurs within the kernel,
   avoiding the use of userspace buffers in Python as in
   "``outfd.write(infd.read())``".
-  Also, :func:`shutil.copyfile` default buffer size on Windows was increased
-  from 16 KiB to 1 MiB.
+  On Windows :func:`shutil.copyfile` default buffer size was increased
+  from 16 KiB to 1 MiB and a faster implementation of :func:`shutil.copyfileobj`
+  is used for files bigger than 128 MiB.
   The speedup for copying a 512 MiB file within the same partition is about
   +26% on Linux, +50% on macOS and +40% on Windows. Also, much less CPU cycles
   are consumed.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -167,6 +167,11 @@ Changes in the Python API
 * The :class:`cProfile.Profile` class can now be used as a context
   manager. (Contributed by Scott Sanderson in :issue:`29235`.)
 
+* :func:`shutil.copyfile`, :func:`shutil.copy`, :func:`shutil.copy2`,
+  :func:`shutil.copytree` and :func:`shutil.move` use platform-specific
+  "fast-copy" syscalls (see
+  :ref:`shutil-platform-dependent-efficient-copy-operations` section).
+
 * :func:`shutil.copyfile` default buffer size on Windows was changed from
   16 KiB to 1 MiB.
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -218,7 +218,7 @@ def copyfile(src, dst, *, follow_symlinks=True):
     if _samefile(src, dst):
         raise SameFileError("{!r} and {!r} are the same file".format(src, dst))
 
-    filesize = 0
+    file_size = 0
     for i, fn in enumerate([src, dst]):
         try:
             st = os.stat(fn)
@@ -230,7 +230,7 @@ def copyfile(src, dst, *, follow_symlinks=True):
             if stat.S_ISFIFO(st.st_mode):
                 raise SpecialFileError("`%s` is a named pipe" % fn)
             if _WINDOWS and i == 0:
-                filesize = st.st_size
+                file_size = st.st_size
 
     if not follow_symlinks and os.path.islink(src):
         os.symlink(os.readlink(src), dst)
@@ -254,7 +254,7 @@ def copyfile(src, dst, *, follow_symlinks=True):
             # considerable speedup by using a readinto()/memoryview()
             # variant of copyfileobj(), see:
             # https://github.com/python/cpython/pull/7160#discussion_r195162475
-            elif _WINDOWS and filesize >= 128 * 1024 * 1024:
+            elif _WINDOWS and file_size >= 128 * 1024 * 1024:
                 _copybinfileobj(fsrc, fdst)
                 return dst
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -184,20 +184,25 @@ def _copybinfileobj(fsrc, fdst, length=COPY_BUFSIZE):
             else:
                 fdst_write(mv)
 
-def _is_binary_files_pair(fsrc, fdst):
-    return hasattr(fsrc, 'readinto') and \
-        isinstance(fsrc, io.BytesIO) or 'b' in getattr(fsrc, 'mode', '') and \
-        isinstance(fdst, io.BytesIO) or 'b' in getattr(fdst, 'mode', '')
+def _do_bincopy(fsrc, fdst, length):
+    if length <= 0:
+        return False
+    if not hasattr(fsrc, 'readinto'):
+        return False
+    if isinstance(fsrc, io.BytesIO) or 'b' in getattr(fsrc, 'mode', ''):
+        if isinstance(fdst, io.BytesIO) or 'b' in getattr(fdst, 'mode', ''):
+            return True
+    return False
 
 def copyfileobj(fsrc, fdst, length=COPY_BUFSIZE):
     """copy data from file-like object fsrc to file-like object fdst"""
-    if _is_binary_files_pair(fsrc, fdst):
+    if _do_bincopy(fsrc, fdst, length):
         _copybinfileobj(fsrc, fdst, length=length)
     else:
         # Localize variable access to minimize overhead.
         fsrc_read = fsrc.read
         fdst_write = fdst.write
-        while 1:
+        while True:
             buf = fsrc_read(length)
             if not buf:
                 break

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -179,7 +179,8 @@ def _copybinfileobj(fsrc, fdst, length=COPY_BUFSIZE):
             if not n:
                 break
             elif n < length:
-                fdst_write(mv[:n])
+                with mv[:n] as smv:
+                    fdst.write(smv)
             else:
                 fdst_write(mv)
 

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -239,17 +239,17 @@ def copyfile(src, dst, *, follow_symlinks=True):
         os.symlink(os.readlink(src), dst)
     else:
         with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
-            # Linux / Solaris
-            if _HAS_SENDFILE:
+            # macOS
+            if _HAS_FCOPYFILE:
                 try:
-                    _fastcopy_sendfile(fsrc, fdst)
+                    _fastcopy_fcopyfile(fsrc, fdst, posix._COPYFILE_DATA)
                     return dst
                 except _GiveupOnFastCopy:
                     pass
-            # macOS
-            elif _HAS_FCOPYFILE:
+            # Linux / Solaris
+            elif _HAS_SENDFILE:
                 try:
-                    _fastcopy_fcopyfile(fsrc, fdst, posix._COPYFILE_DATA)
+                    _fastcopy_sendfile(fsrc, fdst)
                     return dst
                 except _GiveupOnFastCopy:
                     pass

--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -51,7 +51,7 @@ elif os.name == 'nt':
 
 COPY_BUFSIZE = 1024 * 1024 if os.name == 'nt' else 16 * 1024
 _HAS_SENDFILE = posix and hasattr(os, "sendfile")
-_HAS_FCOPYFILE = posix and hasattr(posix, "_fcopyfile")  # OSX
+_HAS_FCOPYFILE = posix and hasattr(posix, "_fcopyfile")  # macOS
 
 __all__ = ["copyfileobj", "copyfile", "copymode", "copystat", "copy", "copy2",
            "copytree", "move", "rmtree", "Error", "SpecialFileError",
@@ -88,9 +88,9 @@ class _GiveupOnFastCopy(Exception):
     file copy when fast-copy functions fail to do so.
     """
 
-def _fastcopy_osx(fsrc, fdst, flags):
+def _fastcopy_fcopyfile(fsrc, fdst, flags):
     """Copy a regular file content or metadata by using high-performance
-    fcopyfile(3) syscall (OSX).
+    fcopyfile(3) syscall (macOS).
     """
     try:
         infd = fsrc.fileno()
@@ -249,7 +249,7 @@ def copyfile(src, dst, *, follow_symlinks=True):
 
             if _HAS_FCOPYFILE:
                 try:
-                    _fastcopy_osx(fsrc, fdst, posix._COPYFILE_DATA)
+                    _fastcopy_fcopyfile(fsrc, fdst, posix._COPYFILE_DATA)
                     return dst
                 except _GiveupOnFastCopy:
                     pass

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -33,7 +33,7 @@ from test import support
 from test.support import TESTFN, FakePath
 
 TESTFN2 = TESTFN + "2"
-OSX = sys.platform.startswith("darwin")
+MACOS = sys.platform.startswith("darwin")
 try:
     import grp
     import pwd
@@ -1808,7 +1808,7 @@ class TestCopyFile(unittest.TestCase):
 
         self.assertRaises(OSError, shutil.copyfile, 'srcfile', 'destfile')
 
-    @unittest.skipIf(OSX, "skipped on OSX")
+    @unittest.skipIf(MACOS, "skipped on macOS")
     def test_w_dest_open_fails(self):
 
         srcfile = self.Faux()
@@ -1828,7 +1828,7 @@ class TestCopyFile(unittest.TestCase):
         self.assertEqual(srcfile._exited_with[1].args,
                          ('Cannot open "destfile"',))
 
-    @unittest.skipIf(OSX, "skipped on OSX")
+    @unittest.skipIf(MACOS, "skipped on macOS")
     def test_w_dest_close_fails(self):
 
         srcfile = self.Faux()
@@ -1851,7 +1851,7 @@ class TestCopyFile(unittest.TestCase):
         self.assertEqual(srcfile._exited_with[1].args,
                          ('Cannot close',))
 
-    @unittest.skipIf(OSX, "skipped on OSX")
+    @unittest.skipIf(MACOS, "skipped on macOS")
     def test_w_source_close_fails(self):
 
         srcfile = self.Faux(True)
@@ -2111,12 +2111,12 @@ class TestZeroCopySendfile(_ZeroCopyFileTest, unittest.TestCase):
             shutil._HAS_SENDFILE = True
 
 
-@unittest.skipIf(not OSX, 'OSX only')
-class TestZeroCopyOSX(_ZeroCopyFileTest, unittest.TestCase):
+@unittest.skipIf(not MACOS, 'macOS only')
+class TestZeroCopyMACOS(_ZeroCopyFileTest, unittest.TestCase):
     PATCHPOINT = "posix._fcopyfile"
 
     def zerocopy_fun(self, src, dst):
-        return shutil._fastcopy_osx(src, dst, posix._COPYFILE_DATA)
+        return shutil._fastcopy_fcopyfile(src, dst, posix._COPYFILE_DATA)
 
 
 class TermsizeTests(unittest.TestCase):

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -1918,47 +1918,22 @@ class TestCopyFileObj(unittest.TestCase):
             with open(dst, 'rb') as fdst:
                 self.assertEqual(fsrc.read(), fdst.read())
 
-    # ---
-
     def test_content(self):
         with self.get_files() as (src, dst):
             shutil.copyfileobj(src, dst)
         self.assert_files_eq(TESTFN, TESTFN2)
 
-    def test_not_closed(self):
+    def test_file_not_closed(self):
         with self.get_files() as (src, dst):
             shutil.copyfileobj(src, dst)
             assert not src.closed
             assert not dst.closed
 
-    def test_offset(self):
+    def test_file_offset(self):
         with self.get_files() as (src, dst):
             shutil.copyfileobj(src, dst)
             self.assertEqual(src.tell(), self.FILESIZE)
             self.assertEqual(dst.tell(), self.FILESIZE)
-
-    def test_bincopy(self):
-        with unittest.mock.patch('shutil._copybinfileobj') as m:
-            with self.get_files() as (src, dst):
-                shutil.copyfileobj(src, dst)
-                assert m.called
-
-    def test_bincopy_neg_length(self):
-        with unittest.mock.patch('shutil._copybinfileobj') as m:
-            with self.get_files() as (src, dst):
-                shutil.copyfileobj(src, dst, length=-1)
-                assert not m.called
-        self.assert_files_eq(TESTFN, TESTFN2)
-
-    def test_bincopy_text_file(self):
-        src = open(TESTFN, "rt")
-        dst = open(TESTFN2, "wt")
-        self.addCleanup(src.close)
-        self.addCleanup(dst.close)
-        with unittest.mock.patch('shutil._copybinfileobj') as m:
-            shutil.copyfileobj(src, dst)
-            assert not m.called
-        self.assert_files_eq(TESTFN, TESTFN2)
 
 
 class _ZeroCopyFileTest(object):

--- a/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
@@ -1,11 +1,8 @@
 :func:`shutil.copyfile`, :func:`shutil.copy`, :func:`shutil.copy2`,
 :func:`shutil.copytree` and :func:`shutil.move` use platform-specific
 fast-copy syscalls on Linux, Solaris and macOS in order to copy the file
-more efficiently. All other platforms not using such technique will rely on a
-faster :func:`shutil.copyfile` implementation using :func:`memoryview`,
-:class:`bytearray` and
-:meth:`BufferedIOBase.readinto() <io.BufferedIOBase.readinto>`.
-Finally, :func:`shutil.copyfile` default buffer size on Windows was increased
-from 16KB to 1MB. The speedup for copying a 512MB file is about +26% on Linux,
-+50% on macOS and +38% on Windows. Also, much less CPU cycles are consumed
-(Contributed by Giampaolo Rodola' in :issue:`25427`.)
+more efficiently.
+Also, :func:`shutil.copyfile` default buffer size on Windows was increased
+from 16KiB to 1MiB. The speedup for copying a 512MB file is about +26% on
+Linux, +50% on macOS and +40% on Windows. Also, much less CPU cycles are
+consumed (Contributed by Giampaolo Rodola' in :issue:`25427`.)

--- a/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
@@ -3,8 +3,8 @@
 fast-copy syscalls on Linux, Solaris and macOS in order to copy the file
 more efficiently.
 On Windows :func:`shutil.copyfile` uses a bigger default buffer size (1 MiB
-instead of 16 KiB) and if file size >= 128 MiB a :func:`memoryview`-based
-variant of :func:`shutil.copyfileobj` is used.
+instead of 16 KiB) and a :func:`memoryview`-based variant of
+:func:`shutil.copyfileobj` is used.
 The speedup for copying a 512MiB file is about +26% on Linux, +50% on macOS and
 +40% on Windows. Also, much less CPU cycles are consumed.
 (Contributed by Giampaolo Rodola' in :issue:`25427`.)

--- a/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
@@ -2,7 +2,9 @@
 :func:`shutil.copytree` and :func:`shutil.move` use platform-specific
 fast-copy syscalls on Linux, Solaris and macOS in order to copy the file
 more efficiently.
-Also, :func:`shutil.copyfile` default buffer size on Windows was increased
-from 16KiB to 1MiB. The speedup for copying a 512MiB file is about +26% on
-Linux, +50% on macOS and +40% on Windows. Also, much less CPU cycles are
-consumed (Contributed by Giampaolo Rodola' in :issue:`25427`.)
+On Windows :func:`shutil.copyfile` uses a bigger default buffer size (1 MiB
+instead of 16 KiB) and if file size >= 128 MiB a :func:`memoryview`-based
+variant of :func:`shutil.copyfileobj` is used.
+The speedup for copying a 512MiB file is about +26% on Linux, +50% on macOS and
++40% on Windows. Also, much less CPU cycles are consumed.
+(Contributed by Giampaolo Rodola' in :issue:`25427`.)

--- a/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
@@ -1,11 +1,11 @@
 :func:`shutil.copyfile`, :func:`shutil.copy`, :func:`shutil.copy2`,
 :func:`shutil.copytree` and :func:`shutil.move` use platform-specific
-fast-copy syscalls on Linux, Solaris and OSX in order to copy the file
+fast-copy syscalls on Linux, Solaris and macOS in order to copy the file
 more efficiently. All other platforms not using such technique will rely on a
 faster :func:`shutil.copyfile` implementation using :func:`memoryview`,
 :class:`bytearray` and
 :meth:`BufferedIOBase.readinto() <io.BufferedIOBase.readinto>`.
 Finally, :func:`shutil.copyfile` default buffer size on Windows was increased
 from 16KB to 1MB. The speedup for copying a 512MB file is about +26% on Linux,
-+50% on OSX and +38% on Windows. Also, much less CPU cycles are consumed
++50% on macOS and +38% on Windows. Also, much less CPU cycles are consumed
 (Contributed by Giampaolo Rodola' in :issue:`25427`.)

--- a/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
+++ b/Misc/NEWS.d/next/Library/2018-05-28-23-25-17.bpo-33671.GIdKKi.rst
@@ -3,6 +3,6 @@
 fast-copy syscalls on Linux, Solaris and macOS in order to copy the file
 more efficiently.
 Also, :func:`shutil.copyfile` default buffer size on Windows was increased
-from 16KiB to 1MiB. The speedup for copying a 512MB file is about +26% on
+from 16KiB to 1MiB. The speedup for copying a 512MiB file is about +26% on
 Linux, +50% on macOS and +40% on Windows. Also, much less CPU cycles are
 consumed (Contributed by Giampaolo Rodola' in :issue:`25427`.)

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -3859,7 +3859,7 @@ PyDoc_STRVAR(os__fcopyfile__doc__,
 "_fcopyfile($module, infd, outfd, flags, /)\n"
 "--\n"
 "\n"
-"Efficiently copy content or metadata of 2 regular file descriptors (OSX).");
+"Efficiently copy content or metadata of 2 regular file descriptors (macOS).");
 
 #define OS__FCOPYFILE_METHODDEF    \
     {"_fcopyfile", (PyCFunction)os__fcopyfile, METH_FASTCALL, os__fcopyfile__doc__},
@@ -6627,4 +6627,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=b5d1ec71bc6f0651 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=47fb6a3e88cba6d9 input=a9049054013a1b77]*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8755,12 +8755,12 @@ os._fcopyfile
     flags: int
     /
 
-Efficiently copy content or metadata of 2 regular file descriptors (OSX).
+Efficiently copy content or metadata of 2 regular file descriptors (macOS).
 [clinic start generated code]*/
 
 static PyObject *
 os__fcopyfile_impl(PyObject *module, int infd, int outfd, int flags)
-/*[clinic end generated code: output=8e8885c721ec38e3 input=aeb9456804eec879]*/
+/*[clinic end generated code: output=8e8885c721ec38e3 input=69e0770e600cb44f]*/
 {
     int ret;
 


### PR DESCRIPTION
This is a follow up of https://github.com/python/cpython/pull/7160.
Changes:
- use `memoryview()` with size == file size, see https://github.com/python/cpython/pull/7160#discussion_r195405230
- release intermediate (sliced) `memoryview` immediately
- replace "OSX" occurrences with "macOS"
- add some unittests for copyfileobj()
- update doc

<!-- issue-number: bpo-33671 -->
https://bugs.python.org/issue33671
<!-- /issue-number -->
