### PR TITLE
bpo-33851: Fix ast.get_docstring() for a node that lacks a docstring.

### DIFF
--- a/Lib/ast.py
+++ b/Lib/ast.py
@@ -206,7 +206,7 @@ def get_docstring(node, clean=True):
     """
     if not isinstance(node, (AsyncFunctionDef, FunctionDef, ClassDef, Module)):
         raise TypeError("%r can't have docstrings" % node.__class__.__name__)
-    if not node.body:
+    if not(node.body and isinstance(node.body[0], Expr)):
         return None
     node = node.body[0].value
     if isinstance(node, Str):
@@ -215,7 +215,7 @@ def get_docstring(node, clean=True):
         text = node.value
     else:
         return None
-    if clean and text:
+    if clean:
         import inspect
         text = inspect.cleandoc(text)
     return text

--- a/Lib/test/test_ast.py
+++ b/Lib/test/test_ast.py
@@ -521,13 +521,44 @@ class ASTHelpers_Test(unittest.TestCase):
         )
 
     def test_get_docstring(self):
+        node = ast.parse('"""line one\n  line two"""')
+        self.assertEqual(ast.get_docstring(node),
+                         'line one\nline two')
+
+        node = ast.parse('class foo:\n  """line one\n  line two"""')
+        self.assertEqual(ast.get_docstring(node.body[0]),
+                         'line one\nline two')
+
         node = ast.parse('def foo():\n  """line one\n  line two"""')
         self.assertEqual(ast.get_docstring(node.body[0]),
                          'line one\nline two')
 
         node = ast.parse('async def foo():\n  """spam\n  ham"""')
         self.assertEqual(ast.get_docstring(node.body[0]), 'spam\nham')
+
+    def test_get_docstring_none(self):
         self.assertIsNone(ast.get_docstring(ast.parse('')))
+        node = ast.parse('x = "not docstring"')
+        self.assertIsNone(ast.get_docstring(node))
+        node = ast.parse('def foo():\n  pass')
+        self.assertIsNone(ast.get_docstring(node))
+
+        node = ast.parse('class foo:\n  pass')
+        self.assertIsNone(ast.get_docstring(node.body[0]))
+        node = ast.parse('class foo:\n  x = "not docstring"')
+        self.assertIsNone(ast.get_docstring(node.body[0]))
+        node = ast.parse('class foo:\n  def bar(self): pass')
+        self.assertIsNone(ast.get_docstring(node.body[0]))
+
+        node = ast.parse('def foo():\n  pass')
+        self.assertIsNone(ast.get_docstring(node.body[0]))
+        node = ast.parse('def foo():\n  x = "not docstring"')
+        self.assertIsNone(ast.get_docstring(node.body[0]))
+
+        node = ast.parse('async def foo():\n  pass')
+        self.assertIsNone(ast.get_docstring(node.body[0]))
+        node = ast.parse('async def foo():\n  x = "not docstring"')
+        self.assertIsNone(ast.get_docstring(node.body[0]))
 
     def test_literal_eval(self):
         self.assertEqual(ast.literal_eval('[1, 2, 3]'), [1, 2, 3])

--- a/Misc/NEWS.d/next/Library/2018-06-13-15-12-25.bpo-33851.SVbqlz.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-13-15-12-25.bpo-33851.SVbqlz.rst
@@ -1,0 +1,1 @@
+Fix :func:`ast.get_docstring` for a node that lacks a docstring.


### PR DESCRIPTION


<!-- issue-number: bpo-33851 -->
https://bugs.python.org/issue33851
<!-- /issue-number -->
