### PR TITLE
bpo-33630: Fix memory leak in old versions of glicb for `posix_spawn`.

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5359,9 +5359,7 @@ os_posix_spawn_impl(PyObject *module, path_t *path, PyObject *argv,
          * buffers. The use of `temp_buffer` here is a workaround that keeps the
          * python objects that own the buffers alive until posix_spawn gets called.
          * posix_spawn_file_actions_addopen copies the value of **path** except for
-         * some old * versions of * glibc (<2.20). The usage of temp_buffer is
-         * a workaround * to keep this temporary objects alive until posix_spawn
-         * gets called.
+         * some old versions of glibc (<2.20).
          * Check https://bugs.python.org/issue33630 and
          * https://sourceware.org/bugzilla/show_bug.cgi?id=17048 for more info.*/
         temp_buffer = PyList_New(0);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5179,7 +5179,8 @@ enum posix_spawn_file_actions_identifier {
 
 static int
 parse_file_actions(PyObject *file_actions,
-                   posix_spawn_file_actions_t *file_actionsp)
+                   posix_spawn_file_actions_t *file_actionsp,
+                   PyObject* temp_buffer)
 {
     PyObject *seq;
     PyObject *file_action = NULL;
@@ -5224,9 +5225,14 @@ parse_file_actions(PyObject *file_actions,
                 {
                     goto fail;
                 }
+                PyList_Append(temp_buffer, path);
                 errno = posix_spawn_file_actions_addopen(file_actionsp,
                         fd, PyBytes_AS_STRING(path), oflag, (mode_t)mode);
-                Py_DECREF(path);  /* addopen copied it. */
+                /* addopen copies the value except for some old versions of
+                 * glibc (<2.26). The usage of temp_buffer is a workaround
+                 * to keep this temporary objects alive until posix_spawn
+                 * gets called.*/
+                Py_DECREF(path);
                 if (errno) {
                     posix_error();
                     goto fail;
@@ -5309,6 +5315,7 @@ os_posix_spawn_impl(PyObject *module, path_t *path, PyObject *argv,
     posix_spawn_file_actions_t *file_actionsp = NULL;
     Py_ssize_t argc, envc;
     PyObject *result = NULL;
+    PyObject *temp_buffer = NULL;
     pid_t pid;
     int err_code;
 
@@ -5349,7 +5356,19 @@ os_posix_spawn_impl(PyObject *module, path_t *path, PyObject *argv,
     }
 
     if (file_actions != Py_None) {
-        if (parse_file_actions(file_actions, &file_actions_buf)) {
+
+        /* There is a bug in old versions of glibc that makes some of the
+         * helper functions for manipulating file actions not copy the provided
+         * buffers. The use of `temp_buffer` here is a workaround that keeps the
+         * python objects that own the buffers alive until posix_spawn gets called.
+         * Check https://bugs.python.org/issue33630 for more info. */
+
+        temp_buffer = PyList_New(0);
+
+        if (!temp_buffer) {
+            goto exit;
+        }
+        if (parse_file_actions(file_actions, &file_actions_buf, temp_buffer)) {
             goto exit;
         }
         file_actionsp = &file_actions_buf;
@@ -5376,6 +5395,9 @@ exit:
     if (argvlist) {
         free_string_array(argvlist, argc);
     }
+
+    Py_XDECREF(temp_buffer);
+
     return result;
 }
 #endif /* HAVE_POSIX_SPAWN */

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5226,6 +5226,7 @@ parse_file_actions(PyObject *file_actions,
                     goto fail;
                 }
                 if (PyList_Append(temp_buffer, path)) {
+                    Py_DECREF(path);
                     goto fail;
                 }
                 errno = posix_spawn_file_actions_addopen(file_actionsp,

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5356,9 +5356,9 @@ os_posix_spawn_impl(PyObject *module, path_t *path, PyObject *argv,
     if (file_actions != Py_None) {
         /* There is a bug in old versions of glibc that makes some of the
          * helper functions for manipulating file actions not copy the provided
-         * buffers. The problem is that posix_spawn_file_actions_addopen copies
-         * the value of **path** except for some old versions of glibc (<2.20).
-         * The use of `temp_buffer` here is a workaround that keeps the
+         * buffers. The problem is that posix_spawn_file_actions_addopen does not
+         * copy the value of path for some old versions of glibc (<2.20).
+         * The use of temp_buffer here is a workaround that keeps the
          * python objects that own the buffers alive until posix_spawn gets called.
          * Check https://bugs.python.org/issue33630 and
          * https://sourceware.org/bugzilla/show_bug.cgi?id=17048 for more info.*/

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5181,7 +5181,7 @@ enum posix_spawn_file_actions_identifier {
 static int
 parse_file_actions(PyObject *file_actions,
                    posix_spawn_file_actions_t *file_actionsp,
-                   PyObject* temp_buffer)
+                   PyObject *temp_buffer)
 #else
     static int
     parse_file_actions(PyObject *file_actions,
@@ -5232,7 +5232,10 @@ parse_file_actions(PyObject *file_actions,
                     goto fail;
                 }
 #if defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ < 20))
-                PyList_Append(temp_buffer, path);
+                int error = PyList_Append(temp_buffer, path);
+                if (error) {
+                    goto fail;
+                }
 #endif
                 errno = posix_spawn_file_actions_addopen(file_actionsp,
                         fd, PyBytes_AS_STRING(path), oflag, (mode_t)mode);

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5177,16 +5177,10 @@ enum posix_spawn_file_actions_identifier {
     POSIX_SPAWN_DUP2
 };
 
-#if defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ < 20))
 static int
 parse_file_actions(PyObject *file_actions,
                    posix_spawn_file_actions_t *file_actionsp,
                    PyObject *temp_buffer)
-#else
-    static int
-    parse_file_actions(PyObject *file_actions,
-                       posix_spawn_file_actions_t *file_actionsp)
-#endif
 {
     PyObject *seq;
     PyObject *file_action = NULL;
@@ -5231,12 +5225,10 @@ parse_file_actions(PyObject *file_actions,
                 {
                     goto fail;
                 }
-#if defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ < 20))
                 int error = PyList_Append(temp_buffer, path);
                 if (error) {
                     goto fail;
                 }
-#endif
                 errno = posix_spawn_file_actions_addopen(file_actionsp,
                         fd, PyBytes_AS_STRING(path), oflag, (mode_t)mode);
                 /* addopen copies the value except for some old versions of
@@ -5375,7 +5367,6 @@ os_posix_spawn_impl(PyObject *module, path_t *path, PyObject *argv,
          * Check https://bugs.python.org/issue33630 and
          * https://sourceware.org/bugzilla/show_bug.cgi?id=17048 for more info. */
 
-#if defined(__GLIBC__) && ((__GLIBC__ == 2 && __GLIBC_MINOR__ < 20))
         temp_buffer = PyList_New(0);
 
         if (!temp_buffer) {
@@ -5384,11 +5375,6 @@ os_posix_spawn_impl(PyObject *module, path_t *path, PyObject *argv,
         if (parse_file_actions(file_actions, &file_actions_buf, temp_buffer)) {
             goto exit;
         }
-#else
-        if (parse_file_actions(file_actions, &file_actions_buf)) {
-            goto exit;
-        }
-#endif
         file_actionsp = &file_actions_buf;
     }
 

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -5356,10 +5356,10 @@ os_posix_spawn_impl(PyObject *module, path_t *path, PyObject *argv,
     if (file_actions != Py_None) {
         /* There is a bug in old versions of glibc that makes some of the
          * helper functions for manipulating file actions not copy the provided
-         * buffers. The use of `temp_buffer` here is a workaround that keeps the
+         * buffers. The problem is that posix_spawn_file_actions_addopen copies
+         * the value of **path** except for some old versions of glibc (<2.20).
+         * The use of `temp_buffer` here is a workaround that keeps the
          * python objects that own the buffers alive until posix_spawn gets called.
-         * posix_spawn_file_actions_addopen copies the value of **path** except for
-         * some old versions of glibc (<2.20).
          * Check https://bugs.python.org/issue33630 and
          * https://sourceware.org/bugzilla/show_bug.cgi?id=17048 for more info.*/
         temp_buffer = PyList_New(0);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33630 -->
https://bugs.python.org/issue33630
<!-- /issue-number -->
