### PR TITLE
bpo-33718: regrtest: use format_duration() to display failed tests

### DIFF
--- a/Lib/test/libregrtest/runtest_mp.py
+++ b/Lib/test/libregrtest/runtest_mp.py
@@ -200,7 +200,7 @@ def run_tests_multiprocess(regrtest):
             if (ok not in (CHILD_ERROR, INTERRUPTED)
                 and test_time >= PROGRESS_MIN_TIME
                 and not regrtest.ns.pgo):
-                text += ' (%.0f sec)' % test_time
+                text += ' (%s)' % format_duration(test_time)
             elif ok == CHILD_ERROR:
                 text = '%s (%s)' % (text, test_time)
             running = get_running(workers)

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -4,12 +4,11 @@ import textwrap
 
 
 def format_duration(seconds):
-    ms, seconds = math.modf(seconds)
-    seconds = math.ceil(seconds)
-    ms = math.ceil(ms * 1e3)
-
+    ms = math.ceil(seconds * 1e3)
+    seconds, ms = divmod(ms, 1000)
     minutes, seconds = divmod(seconds, 60)
     hours, minutes = divmod(minutes, 60)
+
     parts = []
     if hours:
         parts.append('%s hour' % hours)
@@ -17,8 +16,11 @@ def format_duration(seconds):
         parts.append('%s min' % minutes)
     if seconds:
         parts.append('%s sec' % seconds)
-    if ms or (not parts):
+    if ms:
         parts.append('%s ms' % ms)
+    if not parts:
+        return '0 ms'
+
     parts = parts[:2]
     return ' '.join(parts)
 

--- a/Lib/test/libregrtest/utils.py
+++ b/Lib/test/libregrtest/utils.py
@@ -1,19 +1,26 @@
 import os.path
+import math
 import textwrap
 
 
 def format_duration(seconds):
-    if seconds < 1.0:
-        return '%.0f ms' % (seconds * 1e3)
-    if seconds < 60.0:
-        return '%.0f sec' % seconds
+    ms, seconds = math.modf(seconds)
+    seconds = math.ceil(seconds)
+    ms = math.ceil(ms * 1e3)
 
-    minutes, seconds = divmod(seconds, 60.0)
-    hours, minutes = divmod(minutes, 60.0)
+    minutes, seconds = divmod(seconds, 60)
+    hours, minutes = divmod(minutes, 60)
+    parts = []
     if hours:
-        return '%.0f hour %.0f min' % (hours, minutes)
-    else:
-        return '%.0f min %.0f sec' % (minutes, seconds)
+        parts.append('%s hour' % hours)
+    if minutes:
+        parts.append('%s min' % minutes)
+    if seconds:
+        parts.append('%s sec' % seconds)
+    if ms or (not parts):
+        parts.append('%s ms' % ms)
+    parts = parts[:2]
+    return ' '.join(parts)
 
 
 def removepy(names):

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -19,6 +19,7 @@ import threading
 import unittest
 from test import libregrtest
 from test import support
+from test.libregrtest import utils
 
 
 Py_DEBUG = hasattr(sys, 'getobjects')
@@ -978,6 +979,30 @@ class ArgsTestCase(BaseTestCase):
         output = self.run_tests("-w", testname, exitcode=2)
         self.check_executed_tests(output, [testname],
                                   failed=testname, rerun=testname)
+
+
+class TestUtils(unittest.TestCase):
+    def test_format_duration(self):
+        self.assertEqual(utils.format_duration(0),
+                         '0 ms')
+        self.assertEqual(utils.format_duration(1e-9),
+                         '1 ms')
+        self.assertEqual(utils.format_duration(10e-3),
+                         '10 ms')
+        self.assertEqual(utils.format_duration(1.5),
+                         '1 sec 500 ms')
+        self.assertEqual(utils.format_duration(1),
+                         '1 sec')
+        self.assertEqual(utils.format_duration(2 * 60),
+                         '2 min')
+        self.assertEqual(utils.format_duration(2 * 60 + 1),
+                         '2 min 1 sec')
+        self.assertEqual(utils.format_duration(3 * 3600),
+                         '3 hour')
+        self.assertEqual(utils.format_duration(3 * 3600  + 2 * 60 + 1),
+                         '3 hour 2 min')
+        self.assertEqual(utils.format_duration(3 * 3600 + 1),
+                         '3 hour 1 sec')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Enhance also format_duration(): work on integers and rounds towards
  infinity (math.ceil).
* Write unit tests on format_duration()

<!-- issue-number: bpo-33718 -->
https://bugs.python.org/issue33718
<!-- /issue-number -->
