### PR TITLE
bpo-33866: enum: Stop using OrderedDict

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -281,7 +281,7 @@ Iterating over the members of an enum does not provide the aliases::
     >>> list(Shape)
     [<Shape.SQUARE: 2>, <Shape.DIAMOND: 1>, <Shape.CIRCLE: 3>]
 
-The special attribute ``__members__`` is a dictionary mapping names
+The special attribute ``__members__`` is a read-only ordered dictionary mapping names
 to members.  It includes all names defined in the enumeration, including the
 aliases::
 
@@ -998,7 +998,7 @@ Finer Points
 Supported ``__dunder__`` names
 """"""""""""""""""""""""""""""
 
-:attr:`__members__` is a dictionary ``member_name``:``member``
+:attr:`__members__` is a read-only ordered dictionary ``member_name``:``member``
 items.  It is only available on the class.
 
 :meth:`__new__`, if specified, must create and return the enum members; it is
@@ -1008,7 +1008,7 @@ all the members are created it is no longer used.
 .. versionchanged:: 3.8
    :attr:`__members__` is changed from :class:`collections.OrderedDict` to
    :class:`dict`, because ``dict`` is guaranteed to preserve insertion order
-   since Python 3.7.
+   starting with Python 3.7.
 
 
 Supported ``_sunder_`` names

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -281,7 +281,7 @@ Iterating over the members of an enum does not provide the aliases::
     >>> list(Shape)
     [<Shape.SQUARE: 2>, <Shape.DIAMOND: 1>, <Shape.CIRCLE: 3>]
 
-The special attribute ``__members__`` is a read-only ordered dictionary mapping names
+The special attribute ``__members__`` is a read-only ordered mapping of names
 to members.  It includes all names defined in the enumeration, including the
 aliases::
 
@@ -998,17 +998,12 @@ Finer Points
 Supported ``__dunder__`` names
 """"""""""""""""""""""""""""""
 
-:attr:`__members__` is a read-only ordered dictionary ``member_name``:``member``
+:attr:`__members__` is a read-only ordered mapping of ``member_name``:``member``
 items.  It is only available on the class.
 
 :meth:`__new__`, if specified, must create and return the enum members; it is
 also a very good idea to set the member's :attr:`_value_` appropriately.  Once
 all the members are created it is no longer used.
-
-.. versionchanged:: 3.8
-   :attr:`__members__` is changed from :class:`collections.OrderedDict` to
-   :class:`dict`, because ``dict`` is guaranteed to preserve insertion order
-   starting with Python 3.7.
 
 
 Supported ``_sunder_`` names

--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -281,7 +281,7 @@ Iterating over the members of an enum does not provide the aliases::
     >>> list(Shape)
     [<Shape.SQUARE: 2>, <Shape.DIAMOND: 1>, <Shape.CIRCLE: 3>]
 
-The special attribute ``__members__`` is an ordered dictionary mapping names
+The special attribute ``__members__`` is a dictionary mapping names
 to members.  It includes all names defined in the enumeration, including the
 aliases::
 
@@ -998,12 +998,17 @@ Finer Points
 Supported ``__dunder__`` names
 """"""""""""""""""""""""""""""
 
-:attr:`__members__` is an :class:`OrderedDict` of ``member_name``:``member``
+:attr:`__members__` is a dictionary ``member_name``:``member``
 items.  It is only available on the class.
 
 :meth:`__new__`, if specified, must create and return the enum members; it is
 also a very good idea to set the member's :attr:`_value_` appropriately.  Once
 all the members are created it is no longer used.
+
+.. versionchanged:: 3.8
+   :attr:`__members__` is changed from :class:`collections.OrderedDict` to
+   :class:`dict`, because ``dict`` is guaranteed to preserve insertion order
+   since Python 3.7.
 
 
 Supported ``_sunder_`` names

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -627,7 +627,10 @@ class Enum(metaclass=EnumMeta):
         # _value2member_map_ is populated in the same order every time
         # for a consistent reverse mapping of number to name when there
         # are multiple names for the same number.
-        members = [(name, source[name]) for name in source if filter(name)]
+        members = [
+                (name, value)
+                for name, value in source.items()
+                if filter(name)]
         try:
             # sort by value
             members.sort(key=lambda t: (t[1], t[0]))

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -1,12 +1,6 @@
 import sys
 from types import MappingProxyType, DynamicClassAttribute
 
-# try _collections first to reduce startup cost
-try:
-    from _collections import OrderedDict
-except ImportError:
-    from collections import OrderedDict
-
 
 __all__ = [
         'EnumMeta',
@@ -168,7 +162,7 @@ class EnumMeta(type):
         # create our new Enum type
         enum_class = super().__new__(metacls, cls, bases, classdict)
         enum_class._member_names_ = []               # names in definition order
-        enum_class._member_map_ = OrderedDict()      # name->value map
+        enum_class._member_map_ = {}                 # name->value map
         enum_class._member_type_ = member_type
 
         # save attributes from super classes so we know if we can take
@@ -630,15 +624,10 @@ class Enum(metaclass=EnumMeta):
             source = vars(source)
         else:
             source = module_globals
-        # We use an OrderedDict of sorted source keys so that the
-        # _value2member_map is populated in the same order every time
+        # _value2member_map_ is populated in the same order every time
         # for a consistent reverse mapping of number to name when there
-        # are multiple names for the same number rather than varying
-        # between runs due to hash randomization of the module dictionary.
-        members = [
-                (name, source[name])
-                for name in source.keys()
-                if filter(name)]
+        # are multiple names for the same number.
+        members = [(name, source[name]) for name in source if filter(name)]
         try:
             # sort by value
             members.sort(key=lambda t: (t[1], t[0]))

--- a/Misc/NEWS.d/next/Library/2018-06-15-11-48-05.bpo-33866.-hQ4hq.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-15-11-48-05.bpo-33866.-hQ4hq.rst
@@ -1,1 +1,0 @@
-Changed ``Enum._member_map_`` from ``OrderedDict`` to ``dict``.

--- a/Misc/NEWS.d/next/Library/2018-06-15-11-48-05.bpo-33866.-hQ4hq.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-15-11-48-05.bpo-33866.-hQ4hq.rst
@@ -1,0 +1,1 @@
+Changed ``Enum._member_map_`` from ``OrderedDict`` to ``dict``.


### PR DESCRIPTION
Since dict is ordered now.

<!-- issue-number: bpo-33866 -->
https://bugs.python.org/issue33866
<!-- /issue-number -->
