### PR TITLE
bpo-33032: Mention the implicit cache in struct.Struct() docs

### DIFF
--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -408,9 +408,9 @@ The :mod:`struct` module also defines the following type:
    .. note::
 
       The compiled versions of the most-recent format strings passed to
-      :class:`Struct` objects and the module-level functions are cached, so
-      programs that use only a few format strings needn't worry about reusing
-      a single :class:`Struct` instance.
+      :class:`Struct` and the module-level functions are cached, so programs
+      that use only a few format strings needn't worry about reusing a single
+      :class:`Struct` instance.
 
    Compiled Struct objects support the following methods and attributes:
 

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -405,6 +405,12 @@ The :mod:`struct` module also defines the following type:
    methods is more efficient than calling the :mod:`struct` functions with the
    same format since the format string only needs to be compiled once.
 
+   .. note::
+
+      The compiled versions of the most-recent format strings passed to
+      :class:`Struct` objects and the module-level functions are cached, so
+      programs that use only a few format strings needn't worry about reusing
+      a single :class:`Struct` instance.
 
    Compiled Struct objects support the following methods and attributes:
 

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -407,7 +407,7 @@ The :mod:`struct` module also defines the following type:
 
    .. note::
 
-      The compiled versions of the most-recent format strings passed to
+      The compiled versions of the most recent format strings passed to
       :class:`Struct` and the module-level functions are cached, so programs
       that use only a few format strings needn't worry about reusing a single
       :class:`Struct` instance.


### PR DESCRIPTION
The wording is based on the note in the documentation for `re.compile()`.

<!-- issue-number: bpo-33032 -->
https://bugs.python.org/issue33032
<!-- /issue-number -->
