### PR TITLE
bpo-33824, bpo-32030: Fix pymain_read_conf()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-15-19-39-06.bpo-33824.DfWHT3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-15-19-39-06.bpo-33824.DfWHT3.rst
@@ -1,0 +1,2 @@
+Fix "LC_ALL=C python3.7 -V": reset properly the command line parser when the
+encoding changes after reading the Python configuration.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -2015,6 +2015,7 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
         Py_IgnoreEnvironmentFlag = init_ignore_env;
         _PyCoreConfig_Clear(&pymain->config);
         pymain_clear_cmdline(pymain, cmdline);
+        memset(cmdline, 0, sizeof(*cmdline));
         pymain_get_global_config(pymain, cmdline);
 
         /* The encoding changed: read again the configuration


### PR DESCRIPTION
Fix "LC_ALL=C python3.7 -V": fix code parsing command line arguments when
the encoding changes when reading the Python configuration.

Fix pymain_read_conf(): use memset(0) to reset properly cmdline.

<!-- issue-number: bpo-33824 -->
https://bugs.python.org/issue33824
<!-- /issue-number -->
