### PR TITLE
[2.7] bpo-33852: Remove misplaced parentheses around 'list'. (GH-7672)

### DIFF
--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -581,7 +581,7 @@ whose value is one of the keys of the mapping, and the subscription selects the
 value in the mapping that corresponds to that key.  (The expression list is a
 tuple except if it has exactly one item.)
 
-If the primary is a sequence, the expression (list) must evaluate to a plain
+If the primary is a sequence, the expression list must evaluate to a plain
 integer.  If this value is negative, the length of the sequence is added to it
 (so that, e.g., ``x[-1]`` selects the last item of ``x``.)  The resulting value
 must be a nonnegative integer less than the number of items in the sequence, and


### PR DESCRIPTION
'expresson list' refers to the grammar term 'expression_list' in the subscription production..
(cherry picked from commit 4fddd4e4069aad9efad999d8d9ce3cd9fb523a5c)

Co-authored-by: Andrés Delfino <adelfino@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33852 -->
https://bugs.python.org/issue33852
<!-- /issue-number -->
