### PR TITLE
[3.7] Revert "bpo-32962: Fix test_gdb failure in debug build with -mcet -fcf-protection -O0 (GH-6754)"

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -162,11 +162,7 @@ class DebuggerTests(unittest.TestCase):
             commands += ['set print entry-values no']
 
         if cmds_after_breakpoint:
-            # bpo-32962: When Python is compiled with -mcet -fcf-protection,
-            # arguments are unusable before running the first instruction
-            # of the function entry point. The 'next' command makes the
-            # required first step.
-            commands += ['next'] + cmds_after_breakpoint
+            commands += cmds_after_breakpoint
         else:
             commands += ['backtrace']
 
@@ -851,12 +847,9 @@ id(42)
             id("first break point")
             l = MyList()
         ''')
-        # bpo-32962: same case as in get_stack_trace():
-        # we need an additional 'next' command in order to read
-        # arguments of the innermost function of the call stack.
         # Verify with "py-bt":
         gdb_output = self.get_stack_trace(cmd,
-                                          cmds_after_breakpoint=['break wrapper_call', 'continue', 'next', 'py-bt'])
+                                          cmds_after_breakpoint=['break wrapper_call', 'continue', 'py-bt'])
         self.assertRegex(gdb_output,
                          r"<method-wrapper u?'__init__' of MyList object at ")
 

--- a/Misc/NEWS.d/next/Tests/2018-05-10-16-59-15.bpo-32962.S-rcIN.rst
+++ b/Misc/NEWS.d/next/Tests/2018-05-10-16-59-15.bpo-32962.S-rcIN.rst
@@ -1,1 +1,0 @@
-Fixed test_gdb when Python is compiled with flags -mcet -fcf-protection -O0.


### PR DESCRIPTION
This reverts commit 9b7c74ca32d1bec7128d550a9ab1b2ddc7046287.

<!-- issue-number: bpo-32962 -->
https://bugs.python.org/issue32962
<!-- /issue-number -->
