### PR TITLE
bpo-33873: Fix bug in `runtest.py` and add checks for invalid `-R` parameters

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -529,8 +529,10 @@ class Regrtest:
         if self.ns.huntrleaks:
             warmup, repetitions, _ = self.ns.huntrleaks
             if warmup < 1 or repetitions < 1:
-                print("Invalid values for the --huntrleaks/-R parameters",
-                      file=sys.stderr, flush=True)
+                msg = ("Invalid values for the --huntrleaks/-R parameters. The "
+                       "number of warmups and repetitions must be at least 1 "
+                       "each (1:1).")
+                print(msg, file=sys.stderr, flush=True)
                 sys.exit(2)
 
         if self.ns.slaveargs is not None:

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -526,6 +526,13 @@ class Regrtest:
     def _main(self, tests, kwargs):
         self.ns = self.parse_args(kwargs)
 
+        if self.ns.huntrleaks:
+            warmup, repetitions, _ = self.ns.huntrleaks
+            if warmup < 1 or repetitions < 1:
+                print("Invalid values for the --huntrleaks/-R parameters",
+                      file=sys.stderr, flush=True)
+                sys.exit(2)
+
         if self.ns.slaveargs is not None:
             from test.libregrtest.runtest_mp import run_tests_slave
             run_tests_slave(self.ns.slaveargs)

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -173,9 +173,10 @@ def runtest_inner(ns, test, display_failure=True):
                     if loader.errors:
                         raise Exception("errors while loading tests")
                     support.run_unittest(tests)
-            test_runner()
             if ns.huntrleaks:
                 refleak = dash_R(the_module, test, test_runner, ns.huntrleaks)
+            else:
+                test_runner()
             test_time = time.time() - start_time
         post_test_cleanup()
     except support.ResourceDenied as msg:

--- a/Misc/NEWS.d/next/Tests/2018-06-16-01-37-31.bpo-33873.d86vab.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-16-01-37-31.bpo-33873.d86vab.rst
@@ -1,0 +1,4 @@
+Fix a bug in ``regrtest`` that caused an extra test to run if
+--huntrleaks/-R was used. Exit with error in case that invalid
+parameters are specified to --huntrleaks/-R (at least one warmup
+run and one repetition must be used).


### PR DESCRIPTION


<!-- issue-number: bpo-33873 -->
https://bugs.python.org/issue33873
<!-- /issue-number -->
