### PR TITLE
bpo-33873: Add warning when using less than 3 warmup runs in `runtest.py`.

### DIFF
--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -465,7 +465,7 @@ class Regrtest:
         if self.ns.huntrleaks:
             warmup, repetitions, _ = self.ns.huntrleaks
             if warmup < 3:
-                msg = ("WARNING: Runing tests with --huntrleaks/-R and less than "
+                msg = ("WARNING: Running tests with --huntrleaks/-R and less than "
                         "3 warmup repetitions can give false positives!")
                 print(msg, file=sys.stdout, flush=True)
 

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -462,6 +462,13 @@ class Regrtest:
                    or self.tests or self.ns.args)):
             self.display_header()
 
+        if self.ns.huntrleaks:
+            warmup, repetitions, _ = self.ns.huntrleaks
+            if warmup < 3:
+                msg = ("WARNING: Using less than 3 warmup repetitions can "
+                   "give false positives!")
+                print(msg, file=sys.stdout, flush=True)
+
         if self.ns.randomize:
             print("Using random seed", self.ns.random_seed)
 

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -465,8 +465,8 @@ class Regrtest:
         if self.ns.huntrleaks:
             warmup, repetitions, _ = self.ns.huntrleaks
             if warmup < 3:
-                msg = ("WARNING: Using less than 3 warmup repetitions can "
-                   "give false positives!")
+                msg = ("WARNING: Runing tests with --huntrleaks/-R and less than "
+                        "3 warmup repetitions can give false positives!")
                 print(msg, file=sys.stdout, flush=True)
 
         if self.ns.randomize:

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -98,6 +98,13 @@ def runtest(ns, test):
 
     output_on_failure = ns.verbose3
 
+    if ns.huntrleaks:
+        warmup, repetitions, _ = ns.huntrleaks
+        if warmup < 3:
+            msg = ("WARNING: Using less than 3 warmup repetitions can "
+                   "give false positives!")
+            print(msg, file=sys.stdout, flush=True)
+
     use_timeout = (ns.timeout is not None)
     if use_timeout:
         faulthandler.dump_traceback_later(ns.timeout, exit=True)

--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -98,13 +98,6 @@ def runtest(ns, test):
 
     output_on_failure = ns.verbose3
 
-    if ns.huntrleaks:
-        warmup, repetitions, _ = ns.huntrleaks
-        if warmup < 3:
-            msg = ("WARNING: Using less than 3 warmup repetitions can "
-                   "give false positives!")
-            print(msg, file=sys.stdout, flush=True)
-
     use_timeout = (ns.timeout is not None)
     if use_timeout:
         faulthandler.dump_traceback_later(ns.timeout, exit=True)


### PR DESCRIPTION


<!-- issue-number: bpo-33873 -->
https://bugs.python.org/issue33873
<!-- /issue-number -->
