### PR TITLE
bpo-33875: Add optional passwordeval field for pypirc server configuration.

### DIFF
--- a/Lib/distutils/config.py
+++ b/Lib/distutils/config.py
@@ -5,7 +5,6 @@ that uses .pypirc in the distutils.command package.
 """
 import os
 from configparser import RawConfigParser
-import subprocess
 import shlex
 
 from distutils.cmd import Command
@@ -49,6 +48,11 @@ class PyPIRCCommand(Command):
 
     def _read_pypirc(self):
         """Reads the .pypirc file."""
+
+        # Subprocess is not available during distutils build of Python, thus
+        # the method-local import.
+        import subprocess
+
         rc = self._get_rc_file()
         if os.path.exists(rc):
             self.announce('Using PyPI login from %s' % rc)

--- a/Lib/distutils/config.py
+++ b/Lib/distutils/config.py
@@ -5,6 +5,8 @@ that uses .pypirc in the distutils.command package.
 """
 import os
 from configparser import RawConfigParser
+import subprocess
+import shlex
 
 from distutils.cmd import Command
 
@@ -82,6 +84,12 @@ class PyPIRCCommand(Command):
                             current[key] = config.get(server, key)
                         else:
                             current[key] = default
+
+                    # Handle password eval separately, and override any static
+                    # password provided.
+                    if config.has_option(server, 'passwordeval'):
+                        cmd = shlex.split(config.get(server, 'passwordeval'))
+                        current['password'] = subprocess.check_output(cmd, shell=True).decode().rstrip('\n')
 
                     # work around people having "repository" for the "pypi"
                     # section of their config set to the HTTP (rather than

--- a/Lib/distutils/tests/test_config.py
+++ b/Lib/distutils/tests/test_config.py
@@ -17,6 +17,7 @@ index-servers =
     server1
     server2
     server3
+    server4
 
 [server1]
 username:me
@@ -31,6 +32,10 @@ repository:http://another.pypi/
 [server3]
 username:cbiggles
 password:yh^%#rest-of-my-password
+
+[server4]
+username:mufasa
+passwordeval:"echo 'hello'"
 """
 
 PYPIRC_OLD = """\
@@ -132,9 +137,23 @@ class PyPIRCCommandTestCase(BasePyPIRCCommandTestCase):
                   ('server', 'server3'), ('username', 'cbiggles')]
         self.assertEqual(config, waited)
 
+    def test_password_eval(self):
+        # If passwordeval is specified, use its return value.
+        self.write_file(self.rc, PYPIRC)
+        cmd = self._cmd(self.dist)
+        cmd.repository = 'server4'
+        config = cmd._read_pypirc()
+
+        config = list(sorted(config.items()))
+        waited = [('password', 'hello'), ('realm', 'pypi'),
+                  ('repository', 'https://upload.pypi.org/legacy/'),
+                  ('server', 'server4'), ('username', 'mufasa')]
+        self.assertEqual(config, waited)
+
 
 def test_suite():
     return unittest.makeSuite(PyPIRCCommandTestCase)
+
 
 if __name__ == "__main__":
     run_unittest(test_suite())


### PR DESCRIPTION
Allows for calling an arbitrary external program, e.g. `gpg`, so that a cleartext password is not necessary in the distutils `.pypirc` server configuration file sections.

https://bugs.python.org/issue33875?

<!-- issue-number: bpo-33875 -->
https://bugs.python.org/issue33875
<!-- /issue-number -->
