### PR TITLE
[3.6] bpo-33859: Fix spelling mistakes in docs. (GH-7691).

### DIFF
--- a/Doc/library/email.rst
+++ b/Doc/library/email.rst
@@ -133,7 +133,7 @@ Legacy API:
 .. seealso::
 
    Module :mod:`smtplib`
-      SMTP (Simple Mail Transport Protcol) client
+      SMTP (Simple Mail Transport Protocol) client
 
    Module :mod:`poplib`
       POP (Post Office Protocol) client

--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -243,7 +243,7 @@ ABC hierarchy::
 
    .. abstractmethod:: find_module(fullname, path=None)
 
-      An abstact method for finding a :term:`loader` for the specified
+      An abstract method for finding a :term:`loader` for the specified
       module.  Originally specified in :pep:`302`, this method was meant
       for use in :data:`sys.meta_path` and in the path-based import subsystem.
 

--- a/Doc/library/xmlrpc.client.rst
+++ b/Doc/library/xmlrpc.client.rst
@@ -145,7 +145,7 @@ between conformable Python objects and XML on the wire.
 
    .. versionchanged:: 3.6
       Added support of type tags with prefixes (e.g. ``ex:nil``).
-      Added support of unmarsalling additional types used by Apache XML-RPC
+      Added support of unmarshalling additional types used by Apache XML-RPC
       implementation for numerics: ``i1``, ``i2``, ``i8``, ``biginteger``,
       ``float`` and ``bigdecimal``.
       See http://ws.apache.org/xmlrpc/types.html for a description.

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -1414,7 +1414,7 @@ http
 :class:`http.server.BaseHTTPRequestHandler` now buffers the headers and writes
 them all at once when :meth:`~http.server.BaseHTTPRequestHandler.end_headers` is
 called.  A new method :meth:`~http.server.BaseHTTPRequestHandler.flush_headers`
-can be used to directly manage when the accumlated headers are sent.
+can be used to directly manage when the accumulated headers are sent.
 (Contributed by Andrew Schaaf in :issue:`3709`.)
 
 :class:`http.server` now produces valid ``HTML 4.01 strict`` output.

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -1855,7 +1855,7 @@ Build and C API Changes
   For more information, see :pep:`7` and :issue:`17884`.
 
 * Cross-compiling CPython with the Android NDK and the Android API level set to
-  21 (Android 5.0 Lollilop) or greater runs successfully. While Android is not
+  21 (Android 5.0 Lollipop) or greater runs successfully. While Android is not
   yet a supported platform, the Python test suite runs on the Android emulator
   with only about 16 tests failures. See the Android meta-issue :issue:`26865`.
 


### PR DESCRIPTION
(cherry picked from commit c151f7846d6d900c22edaaa77f5f7771b529099e)

Co-authored-by: Xtreak <tirkarthi@users.noreply.github.com>

<!-- issue-number: bpo-33859 -->
https://bugs.python.org/issue33859
<!-- /issue-number -->
