### PR TITLE
[2.7] Fix typos in docs

### DIFF
--- a/Doc/howto/doanddont.rst
+++ b/Doc/howto/doanddont.rst
@@ -285,7 +285,7 @@ There are also many useful built-in functions people seem not to be aware of
 for some reason: :func:`min` and :func:`max` can find the minimum/maximum of
 any sequence with comparable semantics, for example, yet many people write
 their own :func:`max`/:func:`min`. Another highly useful function is
-:func:`reduce` which can be used to repeatly apply a binary operation to a
+:func:`reduce` which can be used to repeatedly apply a binary operation to a
 sequence, reducing it to a single value.  For example, compute a factorial
 with a series of multiply operations::
 

--- a/Doc/library/idle.rst
+++ b/Doc/library/idle.rst
@@ -442,7 +442,7 @@ longer or disable the extension.
 Calltips
 ^^^^^^^^
 
-A calltip is shown when one types :kbd:`(` after the name of an *acccessible*
+A calltip is shown when one types :kbd:`(` after the name of an *accessible*
 function.  A name expression may include dots and subscripts.  A calltip
 remains until it is clicked, the cursor is moved out of the argument area,
 or :kbd:`)` is typed.  When the cursor is in the argument part of a definition,

--- a/Doc/library/sysconfig.rst
+++ b/Doc/library/sysconfig.rst
@@ -83,7 +83,7 @@ Python currently supports seven schemes:
 - *nt*: scheme for NT platforms like Windows.
 - *nt_user*: scheme for NT platforms, when the *user* option is used.
 - *os2*: scheme for OS/2 platforms.
-- *os2_home*: scheme for OS/2 patforms, when the *user* option is used.
+- *os2_home*: scheme for OS/2 platforms, when the *user* option is used.
 
 Each scheme is itself composed of a series of paths and each path has a unique
 identifier.  Python currently uses eight paths:

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -236,7 +236,7 @@ The module defines the following functions and data items:
    argument.  If *t* is not provided, the current time as returned by
    :func:`localtime` is used.  *format* must be a string.  :exc:`ValueError` is
    raised if any field in *t* is outside of the allowed range. :func:`strftime`
-   returns a locale depedent byte string; the result may be converted to unicode
+   returns a locale dependent byte string; the result may be converted to unicode
    by doing ``strftime(<myformat>).decode(locale.getlocale()[1])``.
 
    .. versionchanged:: 2.1


### PR DESCRIPTION
This is similar to #7691 where I ran aspell and fixed some typos in docs. Since this is trivial I have not created an issue. Changes are as below : 

* repeatly -> repeatedly
* acccessible -> accessible
* patforms -> platforms
* depedent -> dependent

Please add skip-issue and skip-news labels.

Thanks.