### PR TITLE
[2.7] bpo-33856: Add "help" to the welcome message of IDLE (GH-7755)

### DIFF
--- a/Lib/idlelib/PyShell.py
+++ b/Lib/idlelib/PyShell.py
@@ -1040,7 +1040,7 @@ class PyShell(OutputWindow):
         return self.shell_title
 
     COPYRIGHT = \
-          'Type "copyright", "credits" or "license()" for more information.'
+          'Type "help", "copyright", "credits" or "license()" for more information.'
 
     def begin(self):
         self.resetoutput()

--- a/Misc/NEWS.d/next/IDLE/2018-06-16-21-54-45.bpo-33856.TH8WHU.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-06-16-21-54-45.bpo-33856.TH8WHU.rst
@@ -1,0 +1,1 @@
+Add "help" in the welcome message of IDLE


### PR DESCRIPTION
Make it the same as when one runs 'python'.
(cherry picked from commit 9d49f85064c388e2dddb9f8cb4ae1f486bc8d357)

Co-authored-by: Stéphane Wirtel <stephane@wirtel.be>


<!-- issue-number: bpo-33856 -->
https://bugs.python.org/issue33856
<!-- /issue-number -->
