### PR TITLE
bpo-33529: Fix Infinite loop on folding email if headers has non_ascii

### DIFF
--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2727,13 +2727,14 @@ def _fold_as_ew(to_encode, lines, maxlen, last_ew, ew_combine_allowed, charset):
         first_part = to_encode[:text_space]
         ew = _ew.encode(first_part, charset=encode_as)
         excess = len(ew) - remaining_space
+        encoded_first_part = ew.split('?')[3]
         if excess > 0:
             # encode always chooses the shortest encoding, so this
             # is guaranteed to fit at this point.
-            first_part = first_part[:-excess]
+            encoded_first_part = encoded_first_part[:-excess]
             ew = _ew.encode(first_part)
         lines[-1] += ew
-        to_encode = to_encode[len(first_part):]
+        to_encode = to_encode[len(encoded_first_part):]
         if to_encode:
             lines.append(' ')
             new_last_ew = len(lines[-1])

--- a/Lib/test/test_email/test_policy.py
+++ b/Lib/test/test_email/test_policy.py
@@ -237,6 +237,12 @@ class PolicyAPITests(unittest.TestCase):
                          email.policy.EmailPolicy.header_factory)
         self.assertEqual(newpolicy.__dict__, {'raise_on_defect': True})
 
+    def test_non_ascii_policy(self):
+        policy = email.policy.default
+        msg = email.message.EmailMessage()
+        msg["Subject"] = "á"*100
+        res = policy.fold("Subject", msg["Subject"])
+        self.assertEqual(len(res), 304)
     # XXX: Need subclassing tests.
     # For adding subclassed objects, make sure the usual rules apply (subclass
     # wins), but that the order still works (right overrides left).

--- a/Misc/NEWS.d/next/Library/2018-06-17-20-28-27.bpo-33529.uoCjry.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-17-20-28-27.bpo-33529.uoCjry.rst
@@ -1,0 +1,2 @@
+Fix infinite loop on folding email if headers has no spaces with non-ascii 
+characters and a size of value is over 78


### PR DESCRIPTION


<!-- issue-number: bpo-33529 -->
https://bugs.python.org/issue33529
<!-- /issue-number -->
