### PR TITLE
bpo-33095: Add reference to isolated mode in -m and script option

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -101,6 +101,11 @@ source.
    first element will be set to ``"-m"``). As with the :option:`-c` option,
    the current directory will be added to the start of :data:`sys.path`.
 
+   :option:`-I` option can  be used to run the script in isolated mode where
+   :data:`sys.path` contains neither the script's directory nor the user's
+   site-packages directory. All :envvar:`PYTHON*` environment variables are
+   ignored, too.
+
    Many standard library modules contain code that is invoked on their execution
    as a script.  An example is the :mod:`timeit` module::
 
@@ -121,6 +126,7 @@ source.
    .. versionchanged:: 3.4
       namespace packages are also supported
 
+.. _cmdarg-dash:
 
 .. describe:: -
 
@@ -132,6 +138,8 @@ source.
    :data:`sys.path`.
 
    .. audit-event:: cpython.run_stdin "" ""
+
+.. _cmdarg-script:
 
 .. describe:: <script>
 
@@ -150,6 +158,11 @@ source.
    If the script name refers to a directory or zipfile, the script name is
    added to the start of :data:`sys.path` and the ``__main__.py`` file in
    that location is executed as the :mod:`__main__` module.
+
+   :option:`-I` option can  be used to run the script in isolated mode where
+   :data:`sys.path` contains neither the script's directory nor the user's
+   site-packages directory. All :envvar:`PYTHON*` environment variables are
+   ignored, too.
 
    .. audit-event:: cpython.run_file filename
 

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -102,7 +102,7 @@ source.
    the current directory will be added to the start of :data:`sys.path`.
 
    :option:`-I` option can  be used to run the script in isolated mode where
-   :data:`sys.path` contains neither the script's directory nor the user's
+   :data:`sys.path` contains neither the current directory nor the user's
    site-packages directory. All :envvar:`PYTHON*` environment variables are
    ignored, too.
 


### PR DESCRIPTION
* Add reference to isolated mode in `-m` and `<script>` option
* Make `-` and `<script>` hyperlinkable. I couldn't get this working using label definitions in markdown. I read through [cross-linking markup](https://devguide.python.org/documenting/#cross-linking-markup) but it seems that adding it increases the font and makes the section as 1.2 . Maybe I am missing something here due to my limited knowledge

Ref for hyperlinking : https://bugs.python.org/msg319812

https://bugs.python.org/issue33095

Thanks

<!-- issue-number: bpo-33095 -->
https://bugs.python.org/issue33095
<!-- /issue-number -->
