### PR TITLE
WIP: bpo-23395: Raise an exception if the SIGINT signal is ignored or not handled

### DIFF
--- a/Doc/c-api/exceptions.rst
+++ b/Doc/c-api/exceptions.rst
@@ -494,18 +494,26 @@ Signal Handling
    cleared if it was previously set.
 
 
-.. c:function:: void PyErr_SetInterrupt()
+.. c:function:: int PyErr_SetInterruptWithErr()
 
    .. index::
       single: SIGINT
-      single: KeyboardInterrupt (built-in exception)
 
-   This function simulates the effect of a :const:`SIGINT` signal arriving --- the
-   next time :c:func:`PyErr_CheckSignals` is called,  :exc:`KeyboardInterrupt` will
-   be raised.  It may be called without holding the interpreter lock.
+   Simulate the effect of a :data:`signal.SIGINT` signal arriving. The next
+   time :c:func:`PyErr_CheckSignals` is called,  the Python
+   :data:`signal.SIGINT` signal handler will be raised.
 
-   .. % XXX This was described as obsolete, but is used in
-   .. % _thread.interrupt_main() (used from IDLE), so it's still needed.
+   The :data:`signal.SIGINT` signal must be handled by Python, otherwise an
+   exception is raised and return ``-1`` on error. Return ``0`` on success.
+
+   The GIL doesn't need to be hold to call this function.
+
+   .. versionadded:: 3.6
+
+
+.. c:function:: void PyErr_SetInterrupt()
+
+   Deprecated version :c:func:`PyErr_SetInterruptWithErr` which ignores errors.
 
 
 .. c:function:: int PySignal_SetWakeupFd(int fd)

--- a/Doc/library/_thread.rst
+++ b/Doc/library/_thread.rst
@@ -53,8 +53,15 @@ This module defines the following constants and functions:
 
 .. function:: interrupt_main()
 
-   Raise a :exc:`KeyboardInterrupt` exception in the main thread.  A subthread can
-   use this function to interrupt the main thread.
+   Simulate the effect of a :data:`signal.SIGINT` signal arriving in the main
+   thread. A thread can use this function to interrupt the main thread.
+
+   The :data:`signal.SIGINT` signal must be handled by Python, otherwise
+   an exception is raised.
+
+   .. versionchanged:: 3.6
+      The function now raises an exception if the signal is ignored or not
+      handled by Python.
 
 
 .. function:: exit()

--- a/Misc/NEWS.d/next/Library/2016-07-27-11-06-43.bpo-23395.MuCEX9.rst
+++ b/Misc/NEWS.d/next/Library/2016-07-27-11-06-43.bpo-23395.MuCEX9.rst
@@ -1,0 +1,3 @@
+``_thread.interrupt_main()`` now raises an exception if the 
+``SIGINT`` signal is ignored or not handled by Python.
+Patch by Viktor Stinner

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -1607,9 +1607,39 @@ PyErr_CheckSignals(void)
 }
 
 
-/* Replacements for intrcheck.c functionality
- * Declared in pyerrors.h
- */
+/* Simulate the effect of a SIGINT signal arriving. The next time
+   PyErr_CheckSignals() is called,  the Python SIGINT signal handler will be
+   raised.
+
+   The SIGINT signal must be handled by Python, otherwise an exception is
+   raised and return -1. Return 0 on success.
+
+   The GIL doesn't need to be hold to call this function. */
+int
+PyErr_SetInterruptWithErr(void)
+{
+    if (Handlers[SIGINT].func == IgnoreHandler) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "the SIGINT signal is ignored");
+        return -1;
+    }
+
+    if (Handlers[SIGINT].func == DefaultHandler) {
+        PyErr_SetString(PyExc_RuntimeError,
+                        "the SIGINT signal is not handled by Python");
+        return -1;
+    }
+
+    trip_signal(SIGINT);
+    return 0;
+}
+
+
+/* Simulate the effect of a SIGINT signal arriving. The next time
+   PyErr_CheckSignals() is called,  the Python SIGINT signal handler will be
+   raised.
+
+   The GIL doesn't need to be hold to call this function. */
 void
 PyErr_SetInterrupt(void)
 {


### PR DESCRIPTION
Attached interrupt_main.patch fixes for ``_thread.interrupt_main()``. Raise an exception if the ``SIGINT`` signal is ignored (``SIG_IGN``) or not handled by Python (``SIG_DFL``).

The patch updates the documentation and adds unit tests.

<!-- issue-number: bpo-23395 -->
https://bugs.python.org/issue23395
<!-- /issue-number -->
