### PR TITLE
bpo-33830: Fix http.client 404 docs

### DIFF
--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -497,8 +497,8 @@ Here is an example session that uses the ``GET`` method::
    b'<!doctype html>\n<!--[if"...
    ...
    >>> # Example of an invalid request
-   >>> conn = http.client.HTTPSConnection("httpbin.org")
-   >>> conn.request("GET", "/status/404")
+   >>> conn = http.client.HTTPSConnection("docs.python.org")
+   >>> conn.request("GET", "/parrot.spam")
    >>> r2 = conn.getresponse()
    >>> print(r2.status, r2.reason)
    404 Not Found

--- a/Doc/library/http.client.rst
+++ b/Doc/library/http.client.rst
@@ -497,7 +497,8 @@ Here is an example session that uses the ``GET`` method::
    b'<!doctype html>\n<!--[if"...
    ...
    >>> # Example of an invalid request
-   >>> conn.request("GET", "/parrot.spam")
+   >>> conn = http.client.HTTPSConnection("httpbin.org")
+   >>> conn.request("GET", "/status/404")
    >>> r2 = conn.getresponse()
    >>> print(r2.status, r2.reason)
    404 Not Found


### PR DESCRIPTION
Fix invalid request in docs to return 404 NOT FOUND which currently returns 404 OK. I think using an example with 404 OK is misleading and couldn't find an endpoint that returns 404 NOT FOUND in python.org . pythontest.net used for test suite doesn't have https in it. 

This needs to fixed in 2.7 where '/' instead of '/parrot.spam' which is also incorrect.

Please add skip-news label for this

Thanks

<!-- issue-number: bpo-33830 -->
https://bugs.python.org/issue33830
<!-- /issue-number -->
