### PR TITLE
"copytree" insists that dest-dir doesn't exist.

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -446,7 +446,7 @@ def copytree(src, dst, symlinks=False, ignore=None, copy_function=copy2,
     else:
         ignored_names = set()
 
-    os.makedirs(dst)
+    if not os.path.isdir(dst): os.makedirs(dst)
     errors = []
     for name in names:
         if name in ignored_names:


### PR DESCRIPTION
"copytree" insists that the destination directory does not exist. This causes problems in a number of scenarios and people have been resorting to - subprocess.call["cp","-a"...]) - which is silly, as such a small change fixes the issue

Scenario-1 - the destination directory is a mount point (e.g. copying to a USB stick)
Scenario-2 - you wish to run two tree copies, from two different sources, to the same destination to merge the contents

The insistence that the end destination directory doesn't exist is also illogical as any/all of the parents of that end directory may or may not exist, so why apply only different rules to the last one?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
