### PR TITLE
bpo-33901: Fix test_dbm_gnu for gdbm 1.15

### DIFF
--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -74,7 +74,7 @@ class TestGdbm(unittest.TestCase):
 
         self.g['x'] = 'x' * 10000
         size1 = os.path.getsize(filename)
-        self.assertGreater(size1, size0)
+        self.assertGreaterEqual(size1, size0)
 
         del self.g['x']
         # 'size' is supposed to be the same even after deleting an entry.
@@ -82,7 +82,7 @@ class TestGdbm(unittest.TestCase):
 
         self.g.reorganize()
         size2 = os.path.getsize(filename)
-        self.assertLess(size2, size1)
+        self.assertLessEqual(size2, size1)
         self.assertGreaterEqual(size2, size0)
 
     def test_context_manager(self):

--- a/Misc/NEWS.d/next/Tests/2018-06-19-14-04-21.bpo-33901.OFW1Sr.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-19-14-04-21.bpo-33901.OFW1Sr.rst
@@ -1,0 +1,4 @@
+Fix test_dbm_gnu for gdbm 1.15. Using gdbm 1.15, creating a database creates
+a file of 16 MiB. Adding a small entry and then modifying the small entry
+doesn't change the file size. Modify test_dbm_gnu to be less strict: allow
+that the file size doesn't change.


### PR DESCRIPTION
Using gdbm 1.15, creating a database creates a file of 16 MiB. Adding
a small entry and then modifying the small entry doesn't change the
file size. Modify test_dbm_gnu to be less strict: allow that the file
size doesn't change.

<!-- issue-number: bpo-33901 -->
https://bugs.python.org/issue33901
<!-- /issue-number -->
