### PR TITLE
bpo-33901: Better test_dbm_gnu.test_reorganize() fix

### DIFF
--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -74,8 +74,8 @@ class TestGdbm(unittest.TestCase):
 
         # bpo-33901: on macOS with gdbm 1.15, an empty database uses 16 MiB
         # and adding an entry of 10,000 B has no effect on the file size.
-        # Add size0//2 bytes to make sure that the file size changes.
-        value_size = max(size0 // 2, 10000)
+        # Add size0 bytes to make sure that the file size changes.
+        value_size = max(size0, 10000)
         self.g['x'] = 'x' * value_size
         size1 = os.path.getsize(filename)
         self.assertGreater(size1, size0)

--- a/Misc/NEWS.d/next/Tests/2018-06-19-14-04-21.bpo-33901.OFW1Sr.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-19-14-04-21.bpo-33901.OFW1Sr.rst
@@ -1,4 +1,2 @@
-Fix test_dbm_gnu for gdbm 1.15. Using gdbm 1.15, creating a database creates
-a file of 16 MiB. Adding a small entry and then modifying the small entry
-doesn't change the file size. Modify test_dbm_gnu to be less strict: allow
-that the file size doesn't change.
+Fix test_dbm_gnu on macOS with gdbm 1.15: add a larger value to make sure that
+the file size changes.


### PR DESCRIPTION
Fix test_dbm_gnu.test_reorganize() on macOS with gdbm 1.15: add a
larger value to make sure that the file size changes.

<!-- issue-number: bpo-33901 -->
https://bugs.python.org/issue33901
<!-- /issue-number -->
