### PR TITLE
bpo-33717: set terse=True in pythoninfo.collect_platform

### DIFF
--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -142,7 +142,7 @@ def collect_platform(info_add):
     info_add('platform.python_implementation',
              platform.python_implementation())
     info_add('platform.platform',
-             platform.platform(aliased=True))
+             platform.platform(aliased=True, terse=True))
 
 
 def collect_locale(info_add):


### PR DESCRIPTION
I suggest using `platform.platform(aliased=True, terse=True)` in test.pythoninfo in < 3.8. This makes it more consistent with 3.8. `platform.platform` is largely changed in 3.8. More specially, I want libc version to be included in pythoninfo. Although libc version is wrong now but I think it will be fixed soon.

<!-- issue-number: bpo-33717 -->
https://bugs.python.org/issue33717
<!-- /issue-number -->
