### PR TITLE
bpo-33746: Fix test_unittest when run in verbose mode

### DIFF
--- a/Lib/unittest/test/test_break.py
+++ b/Lib/unittest/test/test_break.py
@@ -39,6 +39,8 @@ class TestBreak(unittest.TestCase):
 
     def testRegisterResult(self):
         result = unittest.TestResult()
+        self.assertNotIn(result, unittest.signals._results)
+
         unittest.registerResult(result)
         try:
             self.assertIn(result, unittest.signals._results)

--- a/Lib/unittest/test/test_break.py
+++ b/Lib/unittest/test/test_break.py
@@ -40,15 +40,10 @@ class TestBreak(unittest.TestCase):
     def testRegisterResult(self):
         result = unittest.TestResult()
         unittest.registerResult(result)
-
-        for ref in unittest.signals._results:
-            if ref is result:
-                break
-            elif ref is not result:
-                self.fail("odd object in result set")
-        else:
-            self.fail("result not found")
-
+        try:
+            self.assertIn(result, unittest.signals._results)
+        finally:
+            unittest.removeResult(result)
 
     def testInterruptCaught(self):
         default_handler = signal.getsignal(signal.SIGINT)

--- a/Misc/NEWS.d/next/Tests/2018-06-19-17-55-46.bpo-33746.Sz7avn.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-19-17-55-46.bpo-33746.Sz7avn.rst
@@ -1,0 +1,1 @@
+Fix test_unittest when run in verbose mode.


### PR DESCRIPTION
Only make sure that the result is in unittest.signals._results, don't
check the full content of unittest.signals._results.

support._run_suite() uses TextTestRunner in verbose mode, but
TextTestRunner.run() calls registerResult(result) which made the test
fail with "odd object in result set".

Call also removeResult() to restore unittest.signals._results to
avoid side effect of the test.

<!-- issue-number: bpo-33746 -->
https://bugs.python.org/issue33746
<!-- /issue-number -->
