### PR TITLE
bpo-33671: Add support.MS_WINDOWS and support.MACOS

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -103,8 +103,6 @@ else:
 HAVE_GETVALUE = not getattr(_multiprocessing,
                             'HAVE_BROKEN_SEM_GETVALUE', False)
 
-WIN32 = (sys.platform == "win32")
-
 from multiprocessing.connection import wait
 
 def wait_for_handle(handle, timeout):
@@ -3806,7 +3804,7 @@ class _TestPollEintr(BaseTestCase):
 
 class TestInvalidHandle(unittest.TestCase):
 
-    @unittest.skipIf(WIN32, "skipped on Windows")
+    @unittest.skipIf(support.MS_WINDOWS, "skipped on Windows")
     def test_invalid_handles(self):
         conn = multiprocessing.connection.Connection(44977608)
         # check that poll() doesn't crash
@@ -4134,12 +4132,12 @@ class TestWait(unittest.TestCase):
 
 class TestInvalidFamily(unittest.TestCase):
 
-    @unittest.skipIf(WIN32, "skipped on Windows")
+    @unittest.skipIf(support.MS_WINDOWS, "skipped on Windows")
     def test_invalid_family(self):
         with self.assertRaises(ValueError):
             multiprocessing.connection.Listener(r'\\.\test')
 
-    @unittest.skipUnless(WIN32, "skipped on non-Windows platforms")
+    @unittest.skipUnless(support.MS_WINDOWS, "skipped on non-Windows platforms")
     def test_invalid_family_win32(self):
         with self.assertRaises(ValueError):
             multiprocessing.connection.Listener('/var/test.pipe')
@@ -4265,7 +4263,7 @@ class TestForkAwareThreadLock(unittest.TestCase):
 class TestCloseFds(unittest.TestCase):
 
     def get_high_socket_fd(self):
-        if WIN32:
+        if support.MS_WINDOWS:
             # The child process will not have any socket handles, so
             # calling socket.fromfd() should produce WSAENOTSOCK even
             # if there is a handle of the same number.
@@ -4283,7 +4281,7 @@ class TestCloseFds(unittest.TestCase):
             return fd
 
     def close(self, fd):
-        if WIN32:
+        if support.MS_WINDOWS:
             socket.socket(socket.AF_INET, socket.SOCK_STREAM, fileno=fd).close()
         else:
             os.close(fd)

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -803,10 +803,12 @@ requires_bz2 = unittest.skipUnless(bz2, 'requires bz2')
 
 requires_lzma = unittest.skipUnless(lzma, 'requires lzma')
 
-if not MS_WINDOWS:
-    unix_shell = '/system/bin/sh' if ANDROID else '/bin/sh'
-else:
+if MS_WINDOWS:
     unix_shell = None
+elif ANDROID:
+    unix_shell = '/system/bin/sh'
+else:
+    unix_shell = '/bin/sh'
 
 # Filename used for testing
 if os.name == 'java':

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -90,7 +90,7 @@ __all__ = [
     "anticipate_failure", "load_package_tests", "detect_api_mismatch",
     "check__all__", "skip_unless_bind_unix_socket",
     # sys
-    "is_jython", "ANDROID", "check_impl_detail", "unix_shell",
+    "JYTHON", "ANDROID", "check_impl_detail", "unix_shell",
     "setswitchinterval", "MS_WINDOWS", "MACOS",
     # network
     "HOST", "IPV6_ENABLED", "find_unused_port", "bind_port", "open_urlresource",
@@ -115,8 +115,11 @@ MS_WINDOWS = (sys.platform == 'win32')
 # True if Python is running on Apple macOS.
 MACOS = (sys.platform == 'darwin')
 
-is_jython = sys.platform.startswith('java')
+# True if Python runs on Jython
+# (Python implemented in Java running in a Java VM)
+JYTHON = sys.platform.startswith('java')
 
+# True if Python runs on Android
 ANDROID = hasattr(sys, 'getandroidapilevel')
 
 
@@ -1531,7 +1534,7 @@ def gc_collect():
     objects to disappear.
     """
     gc.collect()
-    if is_jython:
+    if JYTHON:
         time.sleep(0.1)
     gc.collect()
     gc.collect()

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -90,7 +90,7 @@ __all__ = [
     "anticipate_failure", "load_package_tests", "detect_api_mismatch",
     "check__all__", "skip_unless_bind_unix_socket",
     # sys
-    "is_jython", "is_android", "check_impl_detail", "unix_shell",
+    "is_jython", "ANDROID", "check_impl_detail", "unix_shell",
     "setswitchinterval", "MS_WINDOWS", "MACOS",
     # network
     "HOST", "IPV6_ENABLED", "find_unused_port", "bind_port", "open_urlresource",
@@ -117,7 +117,7 @@ MACOS = (sys.platform == 'darwin')
 
 is_jython = sys.platform.startswith('java')
 
-is_android = hasattr(sys, 'getandroidapilevel')
+ANDROID = hasattr(sys, 'getandroidapilevel')
 
 
 class Error(Exception):
@@ -801,7 +801,7 @@ requires_bz2 = unittest.skipUnless(bz2, 'requires bz2')
 requires_lzma = unittest.skipUnless(lzma, 'requires lzma')
 
 if not MS_WINDOWS:
-    unix_shell = '/system/bin/sh' if is_android else '/bin/sh'
+    unix_shell = '/system/bin/sh' if ANDROID else '/bin/sh'
 else:
     unix_shell = None
 
@@ -2744,7 +2744,7 @@ def setswitchinterval(interval):
     # Setting a very low gil interval on the Android emulator causes python
     # to hang (issue #26939).
     minimum_interval = 1e-5
-    if is_android and interval < minimum_interval:
+    if ANDROID and interval < minimum_interval:
         global _is_android_emulator
         if _is_android_emulator is None:
             _is_android_emulator = (subprocess.check_output(

--- a/Lib/test/test_c_locale_coercion.py
+++ b/Lib/test/test_c_locale_coercion.py
@@ -27,7 +27,7 @@ EXPECT_COERCION_IN_DEFAULT_LOCALE = True
 
 # Apply some platform dependent overrides
 if sys.platform.startswith("linux"):
-    if test.support.is_android:
+    if test.support.ANDROID:
         # Android defaults to using UTF-8 for all system interfaces
         EXPECTED_C_LOCALE_STREAM_ENCODING = "utf-8"
         EXPECTED_C_LOCALE_FS_ENCODING = "utf-8"
@@ -335,7 +335,7 @@ class LocaleCoercionTests(_LocaleHandlingTestCase):
             # locale environment variables are undefined or empty. When
             # this code path is run with environ['LC_ALL'] == 'C', then
             # LEGACY_LOCALE_WARNING is printed.
-            if (test.support.is_android and
+            if (test.support.ANDROID and
                     _expected_warnings == [CLI_COERCION_WARNING]):
                 _expected_warnings = None
             self._check_child_encoding_details(base_var_dict,

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -187,8 +187,8 @@ class CmdLineTest(unittest.TestCase):
         if not stdout.startswith(pattern):
             raise AssertionError("%a doesn't start with %a" % (stdout, pattern))
 
-    @unittest.skipUnless((sys.platform == 'darwin' or
-                support.is_android), 'test specific to Mac OS X and Android')
+    @unittest.skipUnless((support.MACOS or support.ANDROID),
+                         'test specific to macOS and Android')
     def test_osx_android_utf8(self):
         def check_output(text):
             decoded = text.decode('utf-8', 'surrogateescape')

--- a/Lib/test/test_codeop.py
+++ b/Lib/test/test_codeop.py
@@ -3,12 +3,12 @@
    Nick Mathewson
 """
 import unittest
-from test.support import is_jython
+from test import support
 
 from codeop import compile_command, PyCF_DONT_IMPLY_DEDENT
 import io
 
-if is_jython:
+if support.JYTHON:
     import sys
 
     def unify_callables(d):
@@ -21,7 +21,7 @@ class CodeopTests(unittest.TestCase):
 
     def assertValid(self, str, symbol='single'):
         '''succeed iff str is a valid piece of code'''
-        if is_jython:
+        if support.JYTHON:
             code = compile_command(str, "<input>", symbol)
             self.assertTrue(code)
             if symbol == "single":
@@ -60,7 +60,7 @@ class CodeopTests(unittest.TestCase):
         av = self.assertValid
 
         # special case
-        if not is_jython:
+        if not support.JYTHON:
             self.assertEqual(compile_command(""),
                              compile("pass", "<input>", 'single',
                                      PyCF_DONT_IMPLY_DEDENT))

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -6,7 +6,7 @@ import signal
 import subprocess
 import sys
 from test import support
-from test.support import script_helper, is_android
+from test.support import script_helper
 import tempfile
 import threading
 import unittest
@@ -30,7 +30,7 @@ def expected_traceback(lineno1, lineno2, header, min_count=1):
 
 def skip_segfault_on_android(test):
     # Issue #32138: Raising SIGSEGV on Android may not cause a crash.
-    return unittest.skipIf(is_android,
+    return unittest.skipIf(support.ANDROID,
                            'raising SIGSEGV on Android is unreliable')(test)
 
 @contextmanager

--- a/Lib/test/test_faulthandler.py
+++ b/Lib/test/test_faulthandler.py
@@ -18,7 +18,6 @@ except ImportError:
     _testcapi = None
 
 TIMEOUT = 0.5
-MS_WINDOWS = (os.name == 'nt')
 
 def expected_traceback(lineno1, lineno2, header, min_count=1):
     regex = header
@@ -121,7 +120,7 @@ class FaultHandlerTests(unittest.TestCase):
     @unittest.skipIf(sys.platform.startswith('aix'),
                      "the first page of memory is a mapped read-only on AIX")
     def test_read_null(self):
-        if not MS_WINDOWS:
+        if not support.MS_WINDOWS:
             self.check_fatal_error("""
                 import faulthandler
                 faulthandler.enable()
@@ -732,7 +731,7 @@ class FaultHandlerTests(unittest.TestCase):
             with self.check_stderr_none():
                 faulthandler.register(signal.SIGUSR1)
 
-    @unittest.skipUnless(MS_WINDOWS, 'specific to Windows')
+    @unittest.skipUnless(support.MS_WINDOWS, 'specific to Windows')
     def test_raise_exception(self):
         for exc, name in (
             ('EXCEPTION_ACCESS_VIOLATION', 'access violation'),
@@ -747,7 +746,7 @@ class FaultHandlerTests(unittest.TestCase):
                 3,
                 name)
 
-    @unittest.skipUnless(MS_WINDOWS, 'specific to Windows')
+    @unittest.skipUnless(support.MS_WINDOWS, 'specific to Windows')
     def test_ignore_exception(self):
         for exc_code in (
             0xE06D7363,   # MSC exception ("Emsc")
@@ -763,7 +762,7 @@ class FaultHandlerTests(unittest.TestCase):
             self.assertEqual(output, [])
             self.assertEqual(exitcode, exc_code)
 
-    @unittest.skipUnless(MS_WINDOWS, 'specific to Windows')
+    @unittest.skipUnless(support.MS_WINDOWS, 'specific to Windows')
     def test_raise_nonfatal_exception(self):
         # These exceptions are not strictly errors. Letting
         # faulthandler display the traceback when they are
@@ -791,7 +790,7 @@ class FaultHandlerTests(unittest.TestCase):
             self.assertIn(exitcode,
                           (exc, exc & ~0x10000000))
 
-    @unittest.skipUnless(MS_WINDOWS, 'specific to Windows')
+    @unittest.skipUnless(support.MS_WINDOWS, 'specific to Windows')
     def test_disable_windows_exc_handler(self):
         code = dedent("""
             import faulthandler

--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -20,7 +20,7 @@ import contextlib
 
 import test.support
 from test.support import (
-    EnvironmentVarGuard, TESTFN, check_warnings, forget, is_jython,
+    EnvironmentVarGuard, TESTFN, check_warnings, forget, JYTHON,
     make_legacy_pyc, rmtree, run_unittest, swap_attr, swap_item, temp_umask,
     unlink, unload, create_empty_file, cpython_only, TESTFN_UNENCODABLE,
     temp_dir, DirsOnSysPath)
@@ -148,7 +148,7 @@ class ImportTests(unittest.TestCase):
         def test_with_extension(ext):
             # The extension is normally ".py", perhaps ".pyw".
             source = TESTFN + ext
-            if is_jython:
+            if JYTHON:
                 pyc = TESTFN + "$py.class"
             else:
                 pyc = TESTFN + ".pyc"

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -583,7 +583,7 @@ class IOTest(unittest.TestCase):
         # On Windows and Mac OSX this test consumes large resources; It takes
         # a long time to build the >2 GiB file and takes >2 GiB of disk space
         # therefore the resource must be enabled to run this test.
-        if sys.platform[:3] == 'win' or sys.platform == 'darwin':
+        if support.MS_WINDOWS or support.MACOS:
             support.requires(
                 'largefile',
                 'test requires %s bytes and a long time to run' % self.LARGE)

--- a/Lib/test/test_largefile.py
+++ b/Lib/test/test_largefile.py
@@ -5,6 +5,7 @@ import os
 import stat
 import sys
 import unittest
+from test import support
 from test.support import TESTFN, requires, unlink
 import io  # C implementation of io
 import _pyio as pyio # Python implementation of io
@@ -145,7 +146,7 @@ def setUpModule():
     # takes a long time to build the >2 GiB file and takes >2 GiB of disk
     # space therefore the resource must be enabled to run this test.
     # If not, nothing after this line stanza will be executed.
-    if sys.platform[:3] == 'win' or sys.platform == 'darwin':
+    if support.MS_WINDOWS or support.MACOS:
         requires('largefile',
                  'test requires %s bytes and a long time to run' % str(size))
     else:

--- a/Lib/test/test_locale.py
+++ b/Lib/test/test_locale.py
@@ -1,9 +1,10 @@
-from test.support import verbose, is_android, check_warnings
-import unittest
+import codecs
 import locale
 import sys
-import codecs
+import unittest
 import warnings
+from test import support
+
 
 class BaseLocalizedTest(unittest.TestCase):
     #
@@ -12,7 +13,7 @@ class BaseLocalizedTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        if sys.platform == 'darwin':
+        if support.MACOS:
             import os
             tlocs = ("en_US.UTF-8", "en_US.ISO8859-1", "en_US")
             if int(os.uname().release.split('.')[0]) < 10:
@@ -44,7 +45,7 @@ class BaseLocalizedTest(unittest.TestCase):
         oldlocale = locale.setlocale(self.locale_type)
         self.addCleanup(locale.setlocale, self.locale_type, oldlocale)
         locale.setlocale(self.locale_type, self.enUS_locale)
-        if verbose:
+        if support.verbose:
             print("testing with %r..." % self.enUS_locale, end=' ', flush=True)
 
 
@@ -144,7 +145,7 @@ class BaseFormattingTest(object):
             func(format, value, **format_opts), out)
 
     def _test_format(self, format, value, out, **format_opts):
-        with check_warnings(('', DeprecationWarning)):
+        with support.check_warnings(('', DeprecationWarning)):
             self._test_formatfunc(format, value, out,
                 func=locale.format, **format_opts)
 
@@ -233,7 +234,7 @@ class TestFormatPatternArg(unittest.TestCase):
     # Test handling of pattern argument of format
 
     def test_onlyOnePattern(self):
-        with check_warnings(('', DeprecationWarning)):
+        with support.check_warnings(('', DeprecationWarning)):
             # Issue 2522: accept exactly one % pattern, and no extra chars.
             self.assertRaises(ValueError, locale.format, "%f\n", 'foo')
             self.assertRaises(ValueError, locale.format, "%f\r", 'foo')
@@ -365,7 +366,7 @@ class TestEnUSCollation(BaseLocalizedTest, TestCollation):
         enc = codecs.lookup(locale.getpreferredencoding(False) or 'ascii').name
         if enc not in ('utf-8', 'iso8859-1', 'cp1252'):
             raise unittest.SkipTest('encoding not suitable')
-        if enc != 'iso8859-1' and (sys.platform == 'darwin' or is_android or
+        if enc != 'iso8859-1' and (support.MACOS or support.ANDROID or
                                    sys.platform.startswith('freebsd')):
             raise unittest.SkipTest('wcscoll/wcsxfrm have known bugs')
         BaseLocalizedTest.setUp(self)
@@ -526,7 +527,7 @@ class TestMiscellaneous(unittest.TestCase):
             # Unsupported locale on this system
             self.skipTest('test needs Turkish locale')
         loc = locale.getlocale(locale.LC_CTYPE)
-        if verbose:
+        if support.verbose:
             print('testing with %a' % (loc,), end=' ', flush=True)
         locale.setlocale(locale.LC_CTYPE, loc)
         self.assertEqual(loc, locale.getlocale(locale.LC_CTYPE))

--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -270,9 +270,7 @@ class PlatformTest(unittest.TestCase):
         res = platform.libc_ver(executable)
 
     def test_popen(self):
-        mswindows = (sys.platform == "win32")
-
-        if mswindows:
+        if support.MS_WINDOWS:
             command = '"{}" -c "print(\'Hello\')"'.format(sys.executable)
         else:
             command = "'{}' -c 'print(\"Hello\")'".format(sys.executable)
@@ -284,7 +282,7 @@ class PlatformTest(unittest.TestCase):
                 self.assertEqual(hello, "Hello")
 
         data = 'plop'
-        if mswindows:
+        if support.MS_WINDOWS:
             command = '"{}" -c "import sys; data=sys.stdin.read(); exit(len(data))"'
         else:
             command = "'{}' -c 'import sys; data=sys.stdin.read(); exit(len(data))'"

--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -33,7 +33,6 @@ from test import support
 from test.support import TESTFN, FakePath
 
 TESTFN2 = TESTFN + "2"
-MACOS = sys.platform.startswith("darwin")
 try:
     import grp
     import pwd
@@ -1808,7 +1807,7 @@ class TestCopyFile(unittest.TestCase):
 
         self.assertRaises(OSError, shutil.copyfile, 'srcfile', 'destfile')
 
-    @unittest.skipIf(MACOS, "skipped on macOS")
+    @unittest.skipIf(support.MACOS, "skipped on macOS")
     def test_w_dest_open_fails(self):
 
         srcfile = self.Faux()
@@ -1828,7 +1827,7 @@ class TestCopyFile(unittest.TestCase):
         self.assertEqual(srcfile._exited_with[1].args,
                          ('Cannot open "destfile"',))
 
-    @unittest.skipIf(MACOS, "skipped on macOS")
+    @unittest.skipIf(support.MACOS, "skipped on macOS")
     def test_w_dest_close_fails(self):
 
         srcfile = self.Faux()
@@ -1851,7 +1850,7 @@ class TestCopyFile(unittest.TestCase):
         self.assertEqual(srcfile._exited_with[1].args,
                          ('Cannot close',))
 
-    @unittest.skipIf(MACOS, "skipped on macOS")
+    @unittest.skipIf(support.MACOS, "skipped on macOS")
     def test_w_source_close_fails(self):
 
         srcfile = self.Faux(True)
@@ -2185,7 +2184,7 @@ class TestZeroCopySendfile(_ZeroCopyFileTest, unittest.TestCase):
             shutil._HAS_SENDFILE = True
 
 
-@unittest.skipIf(not MACOS, 'macOS only')
+@unittest.skipIf(not support.MACOS, 'macOS only')
 class TestZeroCopyMACOS(_ZeroCopyFileTest, unittest.TestCase):
     PATCHPOINT = "posix._fcopyfile"
 

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -1038,7 +1038,7 @@ class GeneralModuleTests(unittest.TestCase):
             eq(udpport, port)
         # Now make sure the lookup by port returns the same service name
         # Issue #26936: Android getservbyport() is broken.
-        if not support.is_android:
+        if not support.ANDROID:
             eq(socket.getservbyport(port2), service)
         eq(socket.getservbyport(port, 'tcp'), service)
         if udpport is not None:

--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -521,7 +521,7 @@ class CalculationTests(unittest.TestCase):
                         "Calculation of day of the week failed;"
                          "%s != %s" % (result.tm_wday, self.time_tuple.tm_wday))
 
-    if support.is_android:
+    if support.ANDROID:
         # Issue #26929: strftime() on Android incorrectly formats %V or %G for
         # the last or the first incomplete week in a year.
         _ymd_excluded = ((1905, 1, 1), (1906, 12, 31), (2008, 12, 29),

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -35,13 +35,11 @@ except ImportError:
 if support.PGO:
     raise unittest.SkipTest("test is not helpful for PGO")
 
-mswindows = (sys.platform == "win32")
-
 #
 # Depends on the following external programs: Python
 #
 
-if mswindows:
+if support.MS_WINDOWS:
     SETBINARY = ('import msvcrt; msvcrt.setmode(sys.stdout.fileno(), '
                                                 'os.O_BINARY);')
 else:
@@ -314,7 +312,7 @@ class ProcessTestCase(BaseTestCase):
                           self._assert_python, pre_args,
                           executable=NONEXISTING_CMD[0])
 
-    @unittest.skipIf(mswindows, "executable argument replaces shell")
+    @unittest.skipIf(support.MS_WINDOWS, "executable argument replaces shell")
     def test_executable_replaces_shell(self):
         # Check that the executable argument replaces the default shell
         # when shell=True.
@@ -363,7 +361,7 @@ class ProcessTestCase(BaseTestCase):
         temp_dir = self._normalize_cwd(temp_dir)
         self._assert_cwd(temp_dir, sys.executable, cwd=FakePath(temp_dir))
 
-    @unittest.skipIf(mswindows, "pending resolution of issue #15533")
+    @unittest.skipIf(support.MS_WINDOWS, "pending resolution of issue #15533")
     def test_cwd_with_relative_arg(self):
         # Check that Popen looks for args[0] relative to cwd if args[0]
         # is relative.
@@ -379,7 +377,7 @@ class ProcessTestCase(BaseTestCase):
             python_dir = self._normalize_cwd(python_dir)
             self._assert_cwd(python_dir, rel_python, cwd=python_dir)
 
-    @unittest.skipIf(mswindows, "pending resolution of issue #15533")
+    @unittest.skipIf(support.MS_WINDOWS, "pending resolution of issue #15533")
     def test_cwd_with_relative_executable(self):
         # Check that Popen looks for executable relative to cwd if executable
         # is relative (and that executable takes precedence over args[0]).
@@ -1008,7 +1006,7 @@ class ProcessTestCase(BaseTestCase):
 
     def test_no_leaking(self):
         # Make sure we leak no resources
-        if not mswindows:
+        if not support.MS_WINDOWS:
             max_handles = 1026 # too much for most UNIX systems
         else:
             max_handles = 2050 # too much for (at least some) Windows setups
@@ -1244,7 +1242,7 @@ class ProcessTestCase(BaseTestCase):
         t = threading.Timer(0.2, kill_proc_timer_thread)
         t.start()
 
-        if mswindows:
+        if support.MS_WINDOWS:
             expected_errorcode = 1
         else:
             # Should be -9 because of the proc.kill() from the thread.
@@ -1365,13 +1363,13 @@ class ProcessTestCase(BaseTestCase):
         fds_after_exception = os.listdir(fd_directory)
         self.assertEqual(fds_before_popen, fds_after_exception)
 
-    @unittest.skipIf(mswindows, "behavior currently not supported on Windows")
+    @unittest.skipIf(support.MS_WINDOWS, "behavior currently not supported on Windows")
     def test_file_not_found_includes_filename(self):
         with self.assertRaises(FileNotFoundError) as c:
             subprocess.call(['/opt/nonexistent_binary', 'with', 'some', 'args'])
         self.assertEqual(c.exception.filename, '/opt/nonexistent_binary')
 
-    @unittest.skipIf(mswindows, "behavior currently not supported on Windows")
+    @unittest.skipIf(support.MS_WINDOWS, "behavior currently not supported on Windows")
     def test_file_not_found_with_bad_cwd(self):
         with self.assertRaises(FileNotFoundError) as c:
             subprocess.Popen(['exit', '0'], cwd='/some/nonexistent/directory')
@@ -1505,7 +1503,7 @@ class RunFuncTestCase(BaseTestCase):
         self.assertIn('capture_output', c.exception.args[0])
 
 
-@unittest.skipIf(mswindows, "POSIX specific tests")
+@unittest.skipIf(support.MS_WINDOWS, "POSIX specific tests")
 class POSIXProcessTestCase(BaseTestCase):
 
     def setUp(self):
@@ -2788,7 +2786,7 @@ class POSIXProcessTestCase(BaseTestCase):
         self.assertEqual(returncode, -3)
 
 
-@unittest.skipUnless(mswindows, "Windows specific tests")
+@unittest.skipUnless(support.MS_WINDOWS, "Windows specific tests")
 class Win32ProcessTestCase(BaseTestCase):
 
     def test_startupinfo(self):
@@ -3093,7 +3091,7 @@ class MiscTests(unittest.TestCase):
             dir = tempfile.mkdtemp()
             name = os.path.join(dir, "foo")
             status, output = subprocess.getstatusoutput(
-                ("type " if mswindows else "cat ") + name)
+                ("type " if support.MS_WINDOWS else "cat ") + name)
             self.assertNotEqual(status, 0)
         finally:
             if dir is not None:
@@ -3127,7 +3125,7 @@ class ProcessTestCaseNoPoll(ProcessTestCase):
         ProcessTestCase.tearDown(self)
 
 
-@unittest.skipUnless(mswindows, "Windows-specific tests")
+@unittest.skipUnless(support.MS_WINDOWS, "Windows-specific tests")
 class CommandsWithSpaces (BaseTestCase):
 
     def setUp(self):

--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -214,7 +214,7 @@ class UTF8ModeTests(unittest.TestCase):
             self.assertEqual(args, ascii(expected), out)
 
         check('utf8', [arg_utf8])
-        if sys.platform == 'darwin' or support.is_android:
+        if support.MACOS or support.ANDROID:
             c_arg = arg_utf8
         else:
             c_arg = arg_ascii

--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -11,9 +11,6 @@ from test import support
 from test.support.script_helper import assert_python_ok, assert_python_failure
 
 
-MS_WINDOWS = (sys.platform == 'win32')
-
-
 class UTF8ModeTests(unittest.TestCase):
     DEFAULT_ENV = {
         'PYTHONUTF8': '',
@@ -35,7 +32,7 @@ class UTF8ModeTests(unittest.TestCase):
             out = out[1]
         return out.decode().rstrip("\n\r")
 
-    @unittest.skipIf(MS_WINDOWS, 'Windows has no POSIX locale')
+    @unittest.skipIf(support.MS_WINDOWS, 'Windows has no POSIX locale')
     def test_posix_locale(self):
         code = 'import sys; print(sys.flags.utf8_mode)'
 
@@ -55,7 +52,7 @@ class UTF8ModeTests(unittest.TestCase):
         out = self.get_output('-X', 'utf8=0', '-c', code)
         self.assertEqual(out, '0')
 
-        if MS_WINDOWS:
+        if support.MS_WINDOWS:
             # PYTHONLEGACYWINDOWSFSENCODING disables the UTF-8 Mode
             # and has the priority over -X utf8
             out = self.get_output('-X', 'utf8', '-c', code,
@@ -75,7 +72,7 @@ class UTF8ModeTests(unittest.TestCase):
         out = self.get_output('-X', 'utf8=0', '-c', code, PYTHONUTF8='1')
         self.assertEqual(out, '0')
 
-        if MS_WINDOWS:
+        if support.MS_WINDOWS:
             # PYTHONLEGACYWINDOWSFSENCODING disables the UTF-8 mode
             # and has the priority over PYTHONUTF8
             out = self.get_output('-X', 'utf8', '-c', code, PYTHONUTF8='1',
@@ -101,7 +98,7 @@ class UTF8ModeTests(unittest.TestCase):
                                  sys.getfilesystemencodeerrors()))
         ''')
 
-        if MS_WINDOWS:
+        if support.MS_WINDOWS:
             expected = 'utf-8/surrogatepass'
         else:
             expected = 'utf-8/surrogateescape'
@@ -109,7 +106,7 @@ class UTF8ModeTests(unittest.TestCase):
         out = self.get_output('-X', 'utf8', '-c', code)
         self.assertEqual(out, expected)
 
-        if MS_WINDOWS:
+        if support.MS_WINDOWS:
             # PYTHONLEGACYWINDOWSFSENCODING disables the UTF-8 mode
             # and has the priority over -X utf8 and PYTHONUTF8
             out = self.get_output('-X', 'utf8', '-c', code,
@@ -204,7 +201,7 @@ class UTF8ModeTests(unittest.TestCase):
         out = self.get_output('-X', 'utf8', '-c', code, LC_ALL='C')
         self.assertEqual(out, 'UTF-8 UTF-8')
 
-    @unittest.skipIf(MS_WINDOWS, 'test specific to Unix')
+    @unittest.skipIf(support.MS_WINDOWS, 'test specific to Unix')
     def test_cmd_line(self):
         arg = 'h\xe9\u20ac'.encode('utf-8')
         arg_utf8 = arg.decode('utf-8')


### PR DESCRIPTION
* MS_WINDOWS: True if Python is running on Microsoft Windows.
* MACOS: True if Python is running on Apple macOS.
* Rename support.is_android to support.ANDROID
* Rename support.is_jython to support.JYTHON

<!-- issue-number: bpo-33671 -->
https://bugs.python.org/issue33671
<!-- /issue-number -->
