### PR TITLE
 [3.6] bpo-33907: Rename an IDLE module and class. (GH-7807) 

### DIFF
--- a/Lib/idlelib/calltip.py
+++ b/Lib/idlelib/calltip.py
@@ -15,7 +15,7 @@ from idlelib.hyperparser import HyperParser
 import __main__
 
 
-class CallTips:
+class Calltip:
 
     def __init__(self, editwin=None):
         if editwin is None:  # subprocess and test
@@ -31,7 +31,7 @@ class CallTips:
 
     def _make_tk_calltip_window(self):
         # See __init__ for usage
-        return calltip_w.CallTip(self.text)
+        return calltip_w.Calltip(self.text)
 
     def _remove_calltip_window(self, event=None):
         if self.active_calltip:
@@ -44,7 +44,7 @@ class CallTips:
         return "break"
 
     def try_open_calltip_event(self, event):
-        """Happens when it would be nice to open a CallTip, but not really
+        """Happens when it would be nice to open a Calltip, but not really
         necessary, for example after an opening bracket, so function calls
         won't be made.
         """
@@ -175,4 +175,4 @@ def get_argspec(ob):
 
 if __name__ == '__main__':
     from unittest import main
-    main('idlelib.idle_test.test_calltips', verbosity=2)
+    main('idlelib.idle_test.test_calltip', verbosity=2)

--- a/Lib/idlelib/calltip_w.py
+++ b/Lib/idlelib/calltip_w.py
@@ -1,7 +1,7 @@
-"""A CallTip window class for Tkinter/IDLE.
+"""A Calltip window class for Tkinter/IDLE.
 
 After tooltip.py, which uses ideas gleaned from PySol
-Used by the calltips IDLE extension.
+Used by calltip.
 """
 from tkinter import Toplevel, Label, LEFT, SOLID, TclError
 
@@ -13,7 +13,7 @@ CHECKHIDE_TIME = 100 # milliseconds
 
 MARK_RIGHT = "calltipwindowregion_right"
 
-class CallTip:
+class Calltip:
 
     def __init__(self, widget):
         self.widget = widget
@@ -47,7 +47,7 @@ class CallTip:
     def showtip(self, text, parenleft, parenright):
         """Show the calltip, bind events which will close it and reposition it.
         """
-        # Only called in CallTips, where lines are truncated
+        # Only called in Calltip, where lines are truncated
         self.text = text
         if self.tipwindow or not self.text:
             return
@@ -147,7 +147,7 @@ def _calltip_window(parent):  # htest #
     text.pack(side=LEFT, fill=BOTH, expand=1)
     text.insert("insert", "string.split")
     top.update()
-    calltip = CallTip(text)
+    calltip = Calltip(text)
 
     def calltip_show(event):
         calltip.showtip("(s=Hello world)", "insert", "end")
@@ -161,7 +161,7 @@ def _calltip_window(parent):  # htest #
 
 if __name__ == '__main__':
     from unittest import main
-    main('idlelib.idle_test.test_calltips', verbosity=2, exit=False)
+    main('idlelib.idle_test.test_calltip_w', verbosity=2, exit=False)
 
     from idlelib.idle_test.htest import run
     run(_calltip_window)

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -54,7 +54,7 @@ class EditorWindow(object):
     from idlelib.statusbar import MultiStatusBar
     from idlelib.autocomplete import AutoComplete
     from idlelib.autoexpand import AutoExpand
-    from idlelib.calltips import CallTips
+    from idlelib.calltip import Calltip
     from idlelib.codecontext import CodeContext
     from idlelib.paragraph import FormatParagraph
     from idlelib.parenmatch import ParenMatch
@@ -311,11 +311,11 @@ class EditorWindow(object):
         text.bind("<<check-module>>", scriptbinding.check_module_event)
         text.bind("<<run-module>>", scriptbinding.run_module_event)
         text.bind("<<do-rstrip>>", self.RstripExtension(self).do_rstrip)
-        calltips = self.CallTips(self)
-        text.bind("<<try-open-calltip>>", calltips.try_open_calltip_event)
-        #refresh-calltips must come after paren-closed to work right
-        text.bind("<<refresh-calltip>>", calltips.refresh_calltip_event)
-        text.bind("<<force-open-calltip>>", calltips.force_open_calltip_event)
+        ctip = self.Calltip(self)
+        text.bind("<<try-open-calltip>>", ctip.try_open_calltip_event)
+        #refresh-calltip must come after paren-closed to work right
+        text.bind("<<refresh-calltip>>", ctip.refresh_calltip_event)
+        text.bind("<<force-open-calltip>>", ctip.force_open_calltip_event)
         text.bind("<<zoom-height>>", self.ZoomHeight(self).zoom_height_event)
         text.bind("<<toggle-code-context>>",
                   self.CodeContext(self).toggle_code_context_event)

--- a/Lib/idlelib/idle_test/test_calltip.py
+++ b/Lib/idlelib/idle_test/test_calltip.py
@@ -1,11 +1,11 @@
-"Test calltips, coverage 60%"
+"Test calltip, coverage 60%"
 
-from idlelib import calltips
+from idlelib import calltip
 import unittest
 import textwrap
 import types
 
-default_tip = calltips._default_callable_argspec
+default_tip = calltip._default_callable_argspec
 
 
 # Test Class TC is used in multiple get_argspec test methods
@@ -36,7 +36,7 @@ class TC():
 
 
 tc = TC()
-signature = calltips.get_argspec  # 2.7 and 3.x use different functions
+signature = calltip.get_argspec  # 2.7 and 3.x use different functions
 
 
 class Get_signatureTest(unittest.TestCase):
@@ -66,7 +66,7 @@ class Get_signatureTest(unittest.TestCase):
               '  See help(type) for accurate signature.')
         gtest(list.__init__,
               '(self, /, *args, **kwargs)'
-              + calltips._argument_positional + '\n' +
+              + calltip._argument_positional + '\n' +
               'Initialize self.  See help(type(self)) for accurate signature.')
         append_doc =  "L.append(object) -> None -- append object to end"
         gtest(list.append, append_doc)
@@ -100,7 +100,7 @@ non-overlapping occurrences o...''')
     def test_docline_truncation(self):
         def f(): pass
         f.__doc__ = 'a'*300
-        self.assertEqual(signature(f), '()\n' + 'a' * (calltips._MAX_COLS-3) + '...')
+        self.assertEqual(signature(f), '()\n' + 'a' * (calltip._MAX_COLS-3) + '...')
 
     def test_multiline_docstring(self):
         # Test fewer lines than max.
@@ -119,7 +119,7 @@ bytes() -> empty bytes object''')
         # Test more than max lines
         def f(): pass
         f.__doc__ = 'a\n' * 15
-        self.assertEqual(signature(f), '()' + '\na' * calltips._MAX_LINES)
+        self.assertEqual(signature(f), '()' + '\na' * calltip._MAX_LINES)
 
     def test_functions(self):
         def t1(): 'doc'
@@ -166,7 +166,7 @@ bytes() -> empty bytes object''')
         class Test:
             def __call__(*, a): pass
 
-        mtip = calltips._invalid_method
+        mtip = calltip._invalid_method
         self.assertEqual(signature(C().m2), mtip)
         self.assertEqual(signature(Test()), mtip)
 
@@ -174,7 +174,7 @@ bytes() -> empty bytes object''')
         # test that re works to delete a first parameter name that
         # includes non-ascii chars, such as various forms of A.
         uni = "(A\u0391\u0410\u05d0\u0627\u0905\u1e00\u3042, a)"
-        assert calltips._first_param.sub('', uni) == '(a)'
+        assert calltip._first_param.sub('', uni) == '(a)'
 
     def test_no_docstring(self):
         def nd(s):
@@ -207,9 +207,9 @@ bytes() -> empty bytes object''')
 
 class Get_entityTest(unittest.TestCase):
     def test_bad_entity(self):
-        self.assertIsNone(calltips.get_entity('1/0'))
+        self.assertIsNone(calltip.get_entity('1/0'))
     def test_good_entity(self):
-        self.assertIs(calltips.get_entity('int'), int)
+        self.assertIs(calltip.get_entity('int'), int)
 
 
 if __name__ == '__main__':

--- a/Lib/idlelib/idle_test/test_calltip_w.py
+++ b/Lib/idlelib/idle_test/test_calltip_w.py
@@ -14,7 +14,7 @@ class CallTipTest(unittest.TestCase):
         cls.root = Tk()
         cls.root.withdraw()
         cls.text = Text(cls.root)
-        cls.calltip = calltip_w.CallTip(cls.text)
+        cls.calltip = calltip_w.Calltip(cls.text)
 
     @classmethod
     def tearDownClass(cls):

--- a/Lib/idlelib/run.py
+++ b/Lib/idlelib/run.py
@@ -11,7 +11,7 @@ import warnings
 import tkinter  # Tcl, deletions, messagebox if startup fails
 
 from idlelib import autocomplete  # AutoComplete, fetch_encodings
-from idlelib import calltips  # CallTips
+from idlelib import calltip  # Calltip
 from idlelib import debugger_r  # start_debugger
 from idlelib import debugobj_r  # remote_object_tree_item
 from idlelib import iomenu  # encoding
@@ -462,7 +462,7 @@ class Executive(object):
     def __init__(self, rpchandler):
         self.rpchandler = rpchandler
         self.locals = __main__.__dict__
-        self.calltip = calltips.CallTips()
+        self.calltip = calltip.Calltip()
         self.autocomplete = autocomplete.AutoComplete()
 
     def runcode(self, code):

--- a/Misc/NEWS.d/next/IDLE/2018-06-19-22-21-27.bpo-33907.z-_B3N.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-06-19-22-21-27.bpo-33907.z-_B3N.rst
@@ -1,0 +1,3 @@
+For consistency and appearance, rename an IDLE module and class. Module
+idlelib.calltips is now calltip.  Class idlelib.calltip_w.CallTip is now
+Calltip.


### PR DESCRIPTION
Improve consistency and appearance. Module idlelib.calltips is now calltip.
Class idlelib.calltip_w.CallTip is now Calltip..
(cherry picked from commit 06e2029)

Co-authored-by: Terry Jan Reedy <tjreedy@udel.edu>

<!-- issue-number: bpo-33907 -->
https://bugs.python.org/issue33907
<!-- /issue-number -->
