### PR TITLE
bpo-33907: Rename an IDLE module and classes.

### DIFF
--- a/Lib/idlelib/calltip.py
+++ b/Lib/idlelib/calltip.py
@@ -31,7 +31,7 @@ class Calltip:
 
     def _make_tk_calltip_window(self):
         # See __init__ for usage
-        return calltip_w.Calltip(self.text)
+        return calltip_w.CalltipWindow(self.text)
 
     def _remove_calltip_window(self, event=None):
         if self.active_calltip:
@@ -44,7 +44,7 @@ class Calltip:
         return "break"
 
     def try_open_calltip_event(self, event):
-        """Happens when it would be nice to open a Calltip, but not really
+        """Happens when it would be nice to open a calltip, but not really
         necessary, for example after an opening bracket, so function calls
         won't be made.
         """

--- a/Lib/idlelib/calltip_w.py
+++ b/Lib/idlelib/calltip_w.py
@@ -1,4 +1,4 @@
-"""A Calltip window class for Tkinter/IDLE.
+"""A calltip window class for Tkinter/IDLE.
 
 After tooltip.py, which uses ideas gleaned from PySol
 Used by calltip.
@@ -13,7 +13,7 @@ CHECKHIDE_TIME = 100 # milliseconds
 
 MARK_RIGHT = "calltipwindowregion_right"
 
-class Calltip:
+class CalltipWindow:
 
     def __init__(self, widget):
         self.widget = widget
@@ -47,7 +47,7 @@ class Calltip:
     def showtip(self, text, parenleft, parenright):
         """Show the calltip, bind events which will close it and reposition it.
         """
-        # Only called in Calltip, where lines are truncated
+        # Only called in calltip.Calltip, where lines are truncated
         self.text = text
         if self.tipwindow or not self.text:
             return
@@ -147,7 +147,7 @@ def _calltip_window(parent):  # htest #
     text.pack(side=LEFT, fill=BOTH, expand=1)
     text.insert("insert", "string.split")
     top.update()
-    calltip = Calltip(text)
+    calltip = CalltipWindow(text)
 
     def calltip_show(event):
         calltip.showtip("(s=Hello world)", "insert", "end")

--- a/Lib/idlelib/idle_test/test_calltip_w.py
+++ b/Lib/idlelib/idle_test/test_calltip_w.py
@@ -6,7 +6,7 @@ from test.support import requires
 from tkinter import Tk, Text
 
 
-class CallTipTest(unittest.TestCase):
+class CallTipWindowTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -14,7 +14,7 @@ class CallTipTest(unittest.TestCase):
         cls.root = Tk()
         cls.root.withdraw()
         cls.text = Text(cls.root)
-        cls.calltip = calltip_w.Calltip(cls.text)
+        cls.calltip = calltip_w.CalltipWindow(cls.text)
 
     @classmethod
     def tearDownClass(cls):

--- a/Misc/NEWS.d/next/IDLE/2018-06-19-22-21-27.bpo-33907.z-_B3N.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-06-19-22-21-27.bpo-33907.z-_B3N.rst
@@ -1,3 +1,4 @@
-For consistency and appearance, rename an IDLE module and class. Module
-idlelib.calltips is now calltip.  Class idlelib.calltip_w.CallTip is now
-Calltip.
+For consistency and appearance, rename an IDLE module and classes.
+Module calltips and class calltips.Calltips are now calltip and calltip.Calltip.
+Class calltip_w.CallTip is now calltip_w.CalltipWindow.
+

--- a/Misc/NEWS.d/next/IDLE/2018-06-19-22-21-27.bpo-33907.z-_B3N.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-06-19-22-21-27.bpo-33907.z-_B3N.rst
@@ -1,4 +1,3 @@
-For consistency and appearance, rename an IDLE module and classes.
-Module calltips and class calltips.Calltips are now calltip and calltip.Calltip.
-Class calltip_w.CallTip is now calltip_w.CalltipWindow.
-
+For consistency and clarity, rename an IDLE module and classes.
+Module calltips and its class CallTips are now calltip and Calltip.
+In module calltip_w, class CallTip is now CalltipWindow.


### PR DESCRIPTION
Fix-up class name duplication in PR #7807.  Combined effect is that
module calltips and its class CallTips are now calltip and Calltip.
In module calltip_w class CallTip is now CalltipWindow.


<!-- issue-number: bpo-33907 -->
https://bugs.python.org/issue33907
<!-- /issue-number -->
