### PR TITLE
bpo-33904:  IDLE: In rstrip, rename class RstripExtension as Rstrip

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -58,7 +58,7 @@ class EditorWindow(object):
     from idlelib.codecontext import CodeContext
     from idlelib.paragraph import FormatParagraph
     from idlelib.parenmatch import ParenMatch
-    from idlelib.rstrip import RstripExtension
+    from idlelib.rstrip import Rstrip
     from idlelib.zoomheight import ZoomHeight
 
     filesystemencoding = sys.getfilesystemencoding()  # for file names
@@ -310,7 +310,7 @@ class EditorWindow(object):
         scriptbinding = ScriptBinding(self)
         text.bind("<<check-module>>", scriptbinding.check_module_event)
         text.bind("<<run-module>>", scriptbinding.run_module_event)
-        text.bind("<<do-rstrip>>", self.RstripExtension(self).do_rstrip)
+        text.bind("<<do-rstrip>>", self.Rstrip(self).do_rstrip)
         ctip = self.Calltip(self)
         text.bind("<<try-open-calltip>>", ctip.try_open_calltip_event)
         #refresh-calltip must come after paren-closed to work right

--- a/Lib/idlelib/idle_test/test_rstrip.py
+++ b/Lib/idlelib/idle_test/test_rstrip.py
@@ -9,7 +9,7 @@ class rstripTest(unittest.TestCase):
     def test_rstrip_line(self):
         editor = Editor()
         text = editor.text
-        do_rstrip = rstrip.RstripExtension(editor).do_rstrip
+        do_rstrip = rstrip.Rstrip(editor).do_rstrip
 
         do_rstrip()
         self.assertEqual(text.get('1.0', 'insert'), '')
@@ -27,7 +27,7 @@ class rstripTest(unittest.TestCase):
         #from tkinter import Tk
         #editor = Editor(root=Tk())
         text = editor.text
-        do_rstrip = rstrip.RstripExtension(editor).do_rstrip
+        do_rstrip = rstrip.Rstrip(editor).do_rstrip
 
         original = (
             "Line with an ending tab    \n"

--- a/Lib/idlelib/rstrip.py
+++ b/Lib/idlelib/rstrip.py
@@ -1,6 +1,6 @@
 'Provides "Strip trailing whitespace" under the "Format" menu.'
 
-class RstripExtension:
+class Rstrip:
 
     def __init__(self, editwin):
         self.editwin = editwin

--- a/Misc/NEWS.d/next/IDLE/2018-06-20-12-40-54.bpo-33904.qm0eCu.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-06-20-12-40-54.bpo-33904.qm0eCu.rst
@@ -1,0 +1,1 @@
+IDLE: In rstrip, rename class RstripExtension as Rstrip


### PR DESCRIPTION
https://bugs.python.org/issue33904

<!-- issue-number: bpo-33904 -->
https://bugs.python.org/issue33904
<!-- /issue-number -->
