### PR TITLE
bpo-33783: Use proper class markup for random.Random docs

### DIFF
--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -312,7 +312,7 @@ Alternative Generator
 
 .. class:: Random([seed])
 
-   This class implement the default pseudo-random number generator used by the
+   Class that implements the default pseudo-random number generator used by the
    :mod:`random` module.
 
 .. class:: SystemRandom([seed])

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -33,12 +33,6 @@ The functions supplied by this module are actually bound methods of a hidden
 instance of the :class:`random.Random` class.  You can instantiate your own
 instances of :class:`Random` to get generators that don't share state.
 
-Class :class:`Random` can also be subclassed if you want to use a different
-basic generator of your own devising: in that case, override the :meth:`~Random.random`,
-:meth:`~Random.seed`, :meth:`~Random.getstate`, and :meth:`~Random.setstate` methods.
-Optionally, a new generator can supply a :meth:`~Random.getrandbits` method --- this
-allows :meth:`randrange` to produce selections over an arbitrarily large range.
-
 The :mod:`random` module also provides the :class:`SystemRandom` class which
 uses the system function :func:`os.urandom` to generate random numbers
 from sources provided by the operating system.
@@ -309,6 +303,15 @@ be found in any statistics text.
 
 Alternative Generator
 ---------------------
+
+.. class:: Random([seed])
+
+   Class to be subclassed if you want to use a different basic generator of your
+   own devising: in that case, override the :meth:`random`,
+   :meth:`seed`, :meth:`getstate`, and :meth:`setstate`
+   methods. Optionally, a new generator can supply a
+   :meth:`getrandbits` method --- this allows :meth:`randrange` to
+   produce selections over an arbitrarily large range.
 
 .. class:: SystemRandom([seed])
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -306,12 +306,17 @@ Alternative Generator
 
 .. class:: Random([seed])
 
-   Class to be subclassed if you want to use a different basic generator of your
-   own devising: in that case, override the :meth:`random`,
-   :meth:`seed`, :meth:`getstate`, and :meth:`setstate`
-   methods. Optionally, a new generator can supply a
-   :meth:`getrandbits` method --- this allows :meth:`randrange` to
-   produce selections over an arbitrarily large range.
+   This class can be subclassed if you want to use a different basic generator
+   of your own devising: in that case, override the :meth:`random`,
+   :meth:`seed`, :meth:`getstate`, and :meth:`setstate` methods. Optionally, a
+   new generator can supply a :meth:`getrandbits` method --- this allows
+   :meth:`randrange` to produce selections over an arbitrarily large range.
+
+   Additionally, you can instantiate your own instances of the
+   :class:`Random` class to get generators that don't share state. The
+   functions supplied by the :mod:`random` module are actually bound methods of
+   a hidden instance of the :class:`Random` class.
+
 
 .. class:: SystemRandom([seed])
 

--- a/Doc/library/random.rst
+++ b/Doc/library/random.rst
@@ -33,6 +33,12 @@ The functions supplied by this module are actually bound methods of a hidden
 instance of the :class:`random.Random` class.  You can instantiate your own
 instances of :class:`Random` to get generators that don't share state.
 
+Class :class:`Random` can also be subclassed if you want to use a different
+basic generator of your own devising: in that case, override the :meth:`~Random.random`,
+:meth:`~Random.seed`, :meth:`~Random.getstate`, and :meth:`~Random.setstate` methods.
+Optionally, a new generator can supply a :meth:`~Random.getrandbits` method --- this
+allows :meth:`randrange` to produce selections over an arbitrarily large range.
+
 The :mod:`random` module also provides the :class:`SystemRandom` class which
 uses the system function :func:`os.urandom` to generate random numbers
 from sources provided by the operating system.
@@ -306,17 +312,8 @@ Alternative Generator
 
 .. class:: Random([seed])
 
-   This class can be subclassed if you want to use a different basic generator
-   of your own devising: in that case, override the :meth:`random`,
-   :meth:`seed`, :meth:`getstate`, and :meth:`setstate` methods. Optionally, a
-   new generator can supply a :meth:`getrandbits` method --- this allows
-   :meth:`randrange` to produce selections over an arbitrarily large range.
-
-   Additionally, you can instantiate your own instances of the
-   :class:`Random` class to get generators that don't share state. The
-   functions supplied by the :mod:`random` module are actually bound methods of
-   a hidden instance of the :class:`Random` class.
-
+   This class implement the default pseudo-random number generator used by the
+   :mod:`random` module.
 
 .. class:: SystemRandom([seed])
 


### PR DESCRIPTION
This should make it easier to spot the existence of this class

<!-- issue-number: bpo-33783 -->
https://bugs.python.org/issue33783
<!-- /issue-number -->
