### PR TITLE
[2.7] bpo-33901: Fix test_gdbm for gdbm 1.15 (GH-7798)

### DIFF
--- a/Lib/test/test_gdbm.py
+++ b/Lib/test/test_gdbm.py
@@ -62,9 +62,13 @@ class TestGdbm(unittest.TestCase):
         self.g = gdbm.open(filename, 'c')
         size0 = os.path.getsize(filename)
 
-        self.g['x'] = 'x' * 10000
+        # bpo-33901: on macOS with gdbm 1.15, an empty database uses 16 MiB
+        # and adding an entry of 10,000 B has no effect on the file size.
+        # Add size0 bytes to make sure that the file size changes.
+        value_size = max(size0, 10000)
+        self.g['x'] = 'x' * value_size
         size1 = os.path.getsize(filename)
-        self.assertTrue(size0 < size1)
+        self.assertGreater(size1, size0)
 
         del self.g['x']
         # 'size' is supposed to be the same even after deleting an entry.
@@ -72,7 +76,8 @@ class TestGdbm(unittest.TestCase):
 
         self.g.reorganize()
         size2 = os.path.getsize(filename)
-        self.assertTrue(size1 > size2 >= size0)
+        self.assertLess(size2, size1)
+        self.assertGreaterEqual(size2, size0)
 
 
 def test_main():

--- a/Misc/NEWS.d/next/Tests/2018-06-19-14-04-21.bpo-33901.OFW1Sr.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-19-14-04-21.bpo-33901.OFW1Sr.rst
@@ -1,0 +1,2 @@
+Fix test_gdbm on macOS with gdbm 1.15: add a larger value to make sure that
+the file size changes.


### PR DESCRIPTION
Fix test_gdbm.test_reorganize() on macOS with gdbm 1.15: add a
larger value to make sure that the file size changes.

(cherry picked from commit 13c79c677f9ec9437c82eda72fa1c2d288d8fceb)

<!-- issue-number: bpo-33901 -->
https://bugs.python.org/issue33901
<!-- /issue-number -->
