### PR TITLE
[2.7] bpo-30345: Add -g to LDFLAGS for LTO (GH-7709)

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-06-15-18-18-16.bpo-30345.j-xRE1.rst
+++ b/Misc/NEWS.d/next/Build/2018-06-15-18-18-16.bpo-30345.j-xRE1.rst
@@ -1,0 +1,1 @@
+Add -g to LDFLAGS when compiling with LTO to get debug symbols.

--- a/configure
+++ b/configure
@@ -6481,6 +6481,13 @@ if test "$Py_LTO" = 'true' ; then
       esac
       ;;
   esac
+
+  if test "$ac_cv_prog_cc_g" = "yes"
+  then
+      # bpo-30345: Add -g to LDFLAGS when compiling with LTO
+      # to get debug symbols.
+      LTOFLAGS="$LTOFLAGS -g"
+  fi
 fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -1455,6 +1455,13 @@ if test "$Py_LTO" = 'true' ; then
       esac
       ;;
   esac
+
+  if test "$ac_cv_prog_cc_g" = "yes"
+  then
+      # bpo-30345: Add -g to LDFLAGS when compiling with LTO
+      # to get debug symbols.
+      LTOFLAGS="$LTOFLAGS -g"
+  fi
 fi
 
 


### PR DESCRIPTION
Add -g to LDFLAGS when compiling with LTO to get debug symbols.

<!-- issue-number: bpo-30345 -->
https://bugs.python.org/issue30345
<!-- /issue-number -->
