### PR TITLE
bpo-18174: regrtest -R 3:3 checks for handle leak

### DIFF
--- a/Lib/test/libregrtest/refleak.py
+++ b/Lib/test/libregrtest/refleak.py
@@ -112,7 +112,7 @@ def dash_R(the_module, test, indirect_test, huntrleaks):
         (rc_deltas, 'references', check_rc_deltas),
         (alloc_deltas, 'memory blocks', check_rc_deltas),
         (fd_deltas, 'file descriptors', check_fd_deltas),
-        (handle_deltas, 'handles', check_fd_deltas),
+        (handle_deltas, 'handles', check_rc_deltas),
     ]:
         # ignore warmup runs
         deltas = deltas[nwarmup:]

--- a/Misc/NEWS.d/next/Tests/2018-06-20-16-55-12.bpo-18174.343gmT.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-20-16-55-12.bpo-18174.343gmT.rst
@@ -1,0 +1,2 @@
+regrtest now also checks for leak of Windows handles. Initial patch written
+by Richard Oudkerk.

--- a/Modules/_winapi.c
+++ b/Modules/_winapi.c
@@ -1230,6 +1230,33 @@ _winapi_GetModuleFileName_impl(PyObject *module, HMODULE module_handle)
 }
 
 /*[clinic input]
+_winapi.GetProcessHandleCount
+
+    ProcessHandle: HANDLE(c_default="GetCurrentProcess()") = NULL
+    /
+
+Return the number of open handles for the specified process.
+
+Return the number of open handles for the process specified
+by ProcessHandle.  If ProcessHandle is not given then the
+handle count for the current process is given.
+
+[clinic start generated code]*/
+
+static PyObject *
+_winapi_GetProcessHandleCount_impl(PyObject *module, HANDLE ProcessHandle)
+/*[clinic end generated code: output=af58910c23922016 input=089cb7546e598a2d]*/
+{
+    DWORD HandleCount;
+
+    if (!GetProcessHandleCount(ProcessHandle, &HandleCount))
+        return PyErr_SetFromWindowsErr(0);
+
+    return PyLong_FromUnsignedLong(HandleCount);
+}
+
+
+/*[clinic input]
 _winapi.GetStdHandle -> HANDLE
 
     std_handle: DWORD
@@ -1714,6 +1741,7 @@ static PyMethodDef winapi_functions[] = {
     _WINAPI_GETEXITCODEPROCESS_METHODDEF
     _WINAPI_GETLASTERROR_METHODDEF
     _WINAPI_GETMODULEFILENAME_METHODDEF
+    _WINAPI_GETPROCESSHANDLECOUNT_METHODDEF
     _WINAPI_GETSTDHANDLE_METHODDEF
     _WINAPI_GETVERSION_METHODDEF
     _WINAPI_OPENPROCESS_METHODDEF

--- a/Modules/clinic/_winapi.c.h
+++ b/Modules/clinic/_winapi.c.h
@@ -530,6 +530,38 @@ exit:
     return return_value;
 }
 
+PyDoc_STRVAR(_winapi_GetProcessHandleCount__doc__,
+"GetProcessHandleCount($module, ProcessHandle=None, /)\n"
+"--\n"
+"\n"
+"Return the number of open handles for the specified process.\n"
+"\n"
+"Return the number of open handles for the process specified\n"
+"by ProcessHandle.  If ProcessHandle is not given then the\n"
+"handle count for the current process is given.");
+
+#define _WINAPI_GETPROCESSHANDLECOUNT_METHODDEF    \
+    {"GetProcessHandleCount", (PyCFunction)_winapi_GetProcessHandleCount, METH_FASTCALL, _winapi_GetProcessHandleCount__doc__},
+
+static PyObject *
+_winapi_GetProcessHandleCount_impl(PyObject *module, HANDLE ProcessHandle);
+
+static PyObject *
+_winapi_GetProcessHandleCount(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    HANDLE ProcessHandle = GetCurrentProcess();
+
+    if (!_PyArg_ParseStack(args, nargs, "|" F_HANDLE ":GetProcessHandleCount",
+        &ProcessHandle)) {
+        goto exit;
+    }
+    return_value = _winapi_GetProcessHandleCount_impl(module, ProcessHandle);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(_winapi_GetStdHandle__doc__,
 "GetStdHandle($module, std_handle, /)\n"
 "--\n"
@@ -941,4 +973,4 @@ _winapi_GetFileType(PyObject *module, PyObject *const *args, Py_ssize_t nargs, P
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=ec7f36eb7efc9d00 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=5f1f0b2da6249e90 input=a9049054013a1b77]*/


### PR DESCRIPTION
* Add _winapi.GetProcessHandleCount()
* regrtest now also checks for leak of Windows handles
* Add an unit test in test_regrtest

Co-Authored-By: Richard Oudkerk <shibturn@gmail.com>

<!-- issue-number: bpo-18174 -->
https://bugs.python.org/issue18174
<!-- /issue-number -->
