### PR TITLE
bpo-33912: Add missing warning filter to test_exec_filename()

### DIFF
--- a/Lib/test/test_warnings/__init__.py
+++ b/Lib/test/test_warnings/__init__.py
@@ -447,6 +447,7 @@ class WarnTests(BaseTest):
                            "warnings.warn('hello', UserWarning)"),
                           filename, "exec")
         with original_warnings.catch_warnings(record=True) as w:
+            self.module.simplefilter("always", category=UserWarning)
             exec(codeobj)
         self.assertEqual(w[0].filename, filename)
 


### PR DESCRIPTION
Added the missing warning filter to test_exec_filename() as mentioned in this issue: https://bugs.python.org/issue33912

First pull request here so let me know if there are any issues (signed the CLA, but it has not been processed yet).

<!-- issue-number: bpo-33912 -->
https://bugs.python.org/issue33912
<!-- /issue-number -->
