### PR TITLE
bpo-32568: make select.epoll() and its docs consistent

### DIFF
--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -57,7 +57,8 @@ The module defines the following:
 
    (Only supported on Linux 2.5.44 and newer.) Return an edge polling object,
    which can be used as Edge or Level Triggered interface for I/O
-   events. *sizehint* and *flags* are deprecated and completely ignored.
+   events.  *sizehint* is only used on systems where :c:func:`epoll_create1`
+   is not available.  *flags* is deprecated and completely ignored.
 
    See the :ref:`epoll-objects` section below for the methods supported by
    epolling objects.

--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -57,8 +57,16 @@ The module defines the following:
 
    (Only supported on Linux 2.5.44 and newer.) Return an edge polling object,
    which can be used as Edge or Level Triggered interface for I/O
-   events.  *sizehint* is only used on systems where :c:func:`epoll_create1`
-   is not available.  *flags* is deprecated and completely ignored.
+   events.
+
+   *sizehint* informs epoll about the expected number of events to be
+   registered.  It must be positive, or `-1` to use the default. It is only
+   used on older systems where :c:func:`epoll_create1` is not available;
+   otherwise it has no effect (though its value is still checked).
+
+   *flags* is deprecated and completely ignored.  However, when supplied, its
+   value must be ``0`` or ``select.EPOLL_CLOEXEC``, otherwise ``OSError`` is
+   raised.
 
    See the :ref:`epoll-objects` section below for the methods supported by
    epolling objects.

--- a/Lib/test/test_epoll.py
+++ b/Lib/test/test_epoll.py
@@ -74,12 +74,11 @@ class TestEPoll(unittest.TestCase):
         ep.close()
         self.assertTrue(ep.closed)
         self.assertRaises(ValueError, ep.fileno)
+
         if hasattr(select, "EPOLL_CLOEXEC"):
-            select.epoll(select.EPOLL_CLOEXEC).close()
+            select.epoll(-1, select.EPOLL_CLOEXEC).close()
             select.epoll(flags=select.EPOLL_CLOEXEC).close()
-        select.epoll(flags=0).close()
-        # the flags parameter is now ignored
-        select.epoll(flags=12356).close()
+            select.epoll(flags=0).close()
 
     def test_badcreate(self):
         self.assertRaises(TypeError, select.epoll, 1, 2, 3)
@@ -88,6 +87,13 @@ class TestEPoll(unittest.TestCase):
         self.assertRaises(TypeError, select.epoll, ())
         self.assertRaises(TypeError, select.epoll, ['foo'])
         self.assertRaises(TypeError, select.epoll, {})
+
+        self.assertRaises(ValueError, select.epoll, 0)
+        self.assertRaises(ValueError, select.epoll, -2)
+        self.assertRaises(ValueError, select.epoll, sizehint=-2)
+
+        if hasattr(select, "EPOLL_CLOEXEC"):
+            self.assertRaises(OSError, select.epoll, flags=12356)
 
     def test_context_manager(self):
         with select.epoll(16) as ep:
@@ -118,19 +124,19 @@ class TestEPoll(unittest.TestCase):
         try:
             # TypeError: argument must be an int, or have a fileno() method.
             self.assertRaises(TypeError, ep.register, object(),
-                select.EPOLLIN | select.EPOLLOUT)
+                              select.EPOLLIN | select.EPOLLOUT)
             self.assertRaises(TypeError, ep.register, None,
-                select.EPOLLIN | select.EPOLLOUT)
+                              select.EPOLLIN | select.EPOLLOUT)
             # ValueError: file descriptor cannot be a negative integer (-1)
             self.assertRaises(ValueError, ep.register, -1,
-                select.EPOLLIN | select.EPOLLOUT)
+                              select.EPOLLIN | select.EPOLLOUT)
             # OSError: [Errno 9] Bad file descriptor
             self.assertRaises(OSError, ep.register, 10000,
-                select.EPOLLIN | select.EPOLLOUT)
+                              select.EPOLLIN | select.EPOLLOUT)
             # registering twice also raises an exception
             ep.register(server, select.EPOLLIN | select.EPOLLOUT)
             self.assertRaises(OSError, ep.register, server,
-                select.EPOLLIN | select.EPOLLOUT)
+                              select.EPOLLIN | select.EPOLLOUT)
         finally:
             ep.close()
 
@@ -161,9 +167,9 @@ class TestEPoll(unittest.TestCase):
 
         ep = select.epoll(16)
         ep.register(server.fileno(),
-                   select.EPOLLIN | select.EPOLLOUT | select.EPOLLET)
+                    select.EPOLLIN | select.EPOLLOUT | select.EPOLLET)
         ep.register(client.fileno(),
-                   select.EPOLLIN | select.EPOLLOUT | select.EPOLLET)
+                    select.EPOLLIN | select.EPOLLOUT | select.EPOLLET)
 
         now = time.monotonic()
         events = ep.poll(1, 4)

--- a/Lib/test/test_epoll.py
+++ b/Lib/test/test_epoll.py
@@ -77,8 +77,9 @@ class TestEPoll(unittest.TestCase):
         if hasattr(select, "EPOLL_CLOEXEC"):
             select.epoll(select.EPOLL_CLOEXEC).close()
             select.epoll(flags=select.EPOLL_CLOEXEC).close()
-            select.epoll(flags=0).close()
-            self.assertRaises(OSError, select.epoll, flags=12356)
+        select.epoll(flags=0).close()
+        # the flags parameter is now ignored
+        select.epoll(flags=12356).close()
 
     def test_badcreate(self):
         self.assertRaises(TypeError, select.epoll, 1, 2, 3)

--- a/Misc/NEWS.d/next/Library/2018-06-21-09-33-02.bpo-32568.f_meGY.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-21-09-33-02.bpo-32568.f_meGY.rst
@@ -1,1 +1,2 @@
-make select.epoll() and its docs consistent re. *sizehint* and *flags*
+Make select.epoll() and its documentation consistent regarding *sizehint* and
+*flags*.

--- a/Misc/NEWS.d/next/Library/2018-06-21-09-33-02.bpo-32568.f_meGY.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-21-09-33-02.bpo-32568.f_meGY.rst
@@ -1,0 +1,1 @@
+make select.epoll() and its docs consistent re. *sizehint* and *flags*

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1317,7 +1317,7 @@ pyepoll_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
         return NULL;
     }
 #endif
-     return newPyEpoll_Object(type, sizehint, -1);
+    return newPyEpoll_Object(type, sizehint, -1);
 }
 
 

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1306,12 +1306,18 @@ pyepoll_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (sizehint == -1) {
         sizehint = FD_SETSIZE - 1;
     }
-    else if (sizehint < -1) {
-        PyErr_SetString(PyExc_ValueError, "sizehint must be positive, 0 or -1");
+    else if (sizehint <= 0) {
+        PyErr_SetString(PyExc_ValueError, "sizehint must be positive or -1");
         return NULL;
     }
 
-    return newPyEpoll_Object(type, sizehint, -1);
+#ifdef HAVE_EPOLL_CREATE1
+    if (flags && flags != EPOLL_CLOEXEC) {
+        PyErr_SetString(PyExc_OSError, "invalid flags");
+        return NULL;
+    }
+#endif
+     return newPyEpoll_Object(type, sizehint, -1);
 }
 
 

--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -1297,23 +1297,19 @@ newPyEpoll_Object(PyTypeObject *type, int sizehint, SOCKET fd)
 static PyObject *
 pyepoll_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
-    int flags = 0, sizehint = FD_SETSIZE - 1;
+    int flags = 0, sizehint = -1;
     static char *kwlist[] = {"sizehint", "flags", NULL};
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "|ii:epoll", kwlist,
                                      &sizehint, &flags))
         return NULL;
-    if (sizehint < 0) {
-        PyErr_SetString(PyExc_ValueError, "negative sizehint");
+    if (sizehint == -1) {
+        sizehint = FD_SETSIZE - 1;
+    }
+    else if (sizehint < -1) {
+        PyErr_SetString(PyExc_ValueError, "sizehint must be positive, 0 or -1");
         return NULL;
     }
-
-#ifdef HAVE_EPOLL_CREATE1
-    if (flags && flags != EPOLL_CLOEXEC) {
-        PyErr_SetString(PyExc_OSError, "invalid flags");
-        return NULL;
-    }
-#endif
 
     return newPyEpoll_Object(type, sizehint, -1);
 }


### PR DESCRIPTION
The docs for `select.epoll()` are currently out of sync with the implementation with regard to the `sizehint` and `flags` parameters.

* `flags` is indeed deprecated, but there was a validation on its value, contrary to the docs saying it is "completely ignored".  This removes that check.
* `sizehint` is still used when `epoll_create1()` is unavailable, so this adds mention of this in the docs.
* Make `sizehint` accept `-1` again, which is replaced with `FD_SETSIZE-1`.  This is needed to have a default value available at the Python level  allowing to set this, since `FD_SETSIZE` is not exposed to Python.  (see: [bpo-31938](https://bugs.python.org/issue31938))

<!-- issue-number: bpo-32568 -->
https://bugs.python.org/issue32568
<!-- /issue-number -->
