### PR TITLE
bpo-33916: Fix bz2 and lzma init when called twice

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-06-21-11-35-47.bpo-33916.cZgPCD.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-21-11-35-47.bpo-33916.cZgPCD.rst
@@ -1,0 +1,2 @@
+bz2 and lzma: When Decompressor.__init__() is called twice, free the old
+lock to not leak memory.

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -634,11 +634,15 @@ _bz2_BZ2Decompressor___init___impl(BZ2Decompressor *self)
 {
     int bzerror;
 
-    self->lock = PyThread_allocate_lock();
-    if (self->lock == NULL) {
+    PyThread_type_lock lock = PyThread_allocate_lock();
+    if (lock == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Unable to allocate lock");
         return -1;
     }
+    if (self->lock != NULL) {
+        PyThread_free_lock(self->lock);
+    }
+    self->lock = lock;
 
     self->needs_input = 1;
     self->bzs_avail_in_real = 0;

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -1163,11 +1163,15 @@ _lzma_LZMADecompressor___init___impl(Decompressor *self, int format,
     self->lzs.allocator = &self->alloc;
     self->lzs.next_in = NULL;
 
-    self->lock = PyThread_allocate_lock();
-    if (self->lock == NULL) {
+    PyThread_type_lock lock = PyThread_allocate_lock();
+    if (lock == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Unable to allocate lock");
         return -1;
     }
+    if (self->lock != NULL) {
+        PyThread_free_lock(self->lock);
+    }
+    self->lock = lock;
 
     self->check = LZMA_CHECK_UNKNOWN;
     self->needs_input = 1;


### PR DESCRIPTION
bz2, lzma: When Decompressor.__init__() is called twice, free the old
lock to not leak memory.

<!-- issue-number: bpo-33916 -->
https://bugs.python.org/issue33916
<!-- /issue-number -->
