### PR TITLE
bpo-33931: fix building 2.7 on Windows using PC\VS9.0\build.bat -e

### DIFF
--- a/PC/VS9.0/build.bat
+++ b/PC/VS9.0/build.bat
@@ -76,9 +76,10 @@ if '%build_tkinter%'=='true' (
 )
 if '%build_tkinter%'=='true' (
     if not exist "%tcltkdir%\bin\tcl85%tcl_dbg_ext%.dll" (
-        @rem all and install need to be separate invocations, otherwise nmakehlp is not found on install
+        @rem clean, all and install need to be separate invocations, otherwise nmakehlp is not found on install
         pushd "%tcldir%\win"
-        nmake -f makefile.vc MACHINE=%machine% DEBUG=%debug_flag% INSTALLDIR="%tcltkdir%" clean all
+        nmake -f makefile.vc MACHINE=%machine% DEBUG=%debug_flag% INSTALLDIR="%tcltkdir%" clean
+        nmake -f makefile.vc MACHINE=%machine% DEBUG=%debug_flag% INSTALLDIR="%tcltkdir%" all
         nmake -f makefile.vc MACHINE=%machine% DEBUG=%debug_flag% INSTALLDIR="%tcltkdir%" install
         popd
     )

--- a/PC/VS9.0/pyproject.vsprops
+++ b/PC/VS9.0/pyproject.vsprops
@@ -82,7 +82,7 @@
 	/>
 	<UserMacro
 		Name="opensslDir"
-		Value="$(externalsDir)\openssl-1.0.2k"
+		Value="$(externalsDir)\openssl-1.0.2o"
 	/>
 	<UserMacro
 		Name="tcltkDir"

--- a/PC/VS9.0/readme.txt
+++ b/PC/VS9.0/readme.txt
@@ -132,7 +132,7 @@ _ssl
 
     Get the source code through
 
-    svn export http://svn.python.org/projects/external/openssl-1.0.2k
+    svn export http://svn.python.org/projects/external/openssl-1.0.2o
 
     ** NOTE: if you use the PCbuild\get_externals.bat approach for
     obtaining external sources then you don't need to manually get the source


### PR DESCRIPTION
Set the openssl version to 1.0.2o (same as in PCbuild/get_externals.bat) and fix compiling tcl.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33931 -->
https://bugs.python.org/issue33931
<!-- /issue-number -->
