### PR TITLE
bpo-33932: Calling Py_Initialize() twice does nothing

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -229,6 +229,15 @@ class EmbeddingTests(unittest.TestCase):
         self.assertEqual(out, '')
         self.assertEqual(err, '')
 
+    def test_initialize_twice(self):
+        """
+        bpo-33932: Calling Py_Initialize() twice should do nothing (and not
+        crash!).
+        """
+        out, err = self.run_embedded_interpreter("initialize_twice")
+        self.assertEqual(out, '')
+        self.assertEqual(err, '')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/C API/2018-06-21-15-29-59.bpo-33932.VSlXyS.rst
+++ b/Misc/NEWS.d/next/C API/2018-06-21-15-29-59.bpo-33932.VSlXyS.rst
@@ -1,0 +1,2 @@
+Calling Py_Initialize() twice does nothing, instead of failing with a fatal
+error: restore the Python 3.6 behaviour.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -263,6 +263,19 @@ static int test_bpo20891(void)
     return 0;
 }
 
+static int test_initialize_twice(void)
+{
+    _testembed_Py_Initialize();
+
+    /* bpo-33932: Calling Py_Initialize() twice should do nothing
+     * (and not crash!). */
+    Py_Initialize();
+
+    Py_Finalize();
+
+    return 0;
+}
+
 
 /* *********************************************************
  * List of test cases and the function that implements it.
@@ -288,6 +301,7 @@ static struct TestCase TestCases[] = {
     { "pre_initialization_api", test_pre_initialization_api },
     { "pre_initialization_sys_options", test_pre_initialization_sys_options },
     { "bpo20891", test_bpo20891 },
+    { "initialize_twice", test_initialize_twice },
     { NULL, NULL }
 };
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -616,7 +616,8 @@ _Py_InitializeCore(const _PyCoreConfig *core_config)
     }
 
     if (_PyRuntime.initialized) {
-        return _Py_INIT_ERR("main interpreter already initialized");
+        /* bpo-33932: Calling Py_Initialize() twice does nothing. */
+        return _Py_INIT_OK();
     }
     if (_PyRuntime.core_initialized) {
         return _Py_INIT_ERR("runtime core already initialized");

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -616,8 +616,7 @@ _Py_InitializeCore(const _PyCoreConfig *core_config)
     }
 
     if (_PyRuntime.initialized) {
-        /* bpo-33932: Calling Py_Initialize() twice does nothing. */
-        return _Py_INIT_OK();
+        return _Py_INIT_ERR("main interpreter already initialized");
     }
     if (_PyRuntime.core_initialized) {
         return _Py_INIT_ERR("runtime core already initialized");
@@ -893,6 +892,11 @@ _Py_InitializeMainInterpreter(const _PyMainInterpreterConfig *config)
 _PyInitError
 _Py_InitializeEx_Private(int install_sigs, int install_importlib)
 {
+    if (_PyRuntime.initialized) {
+        /* bpo-33932: Calling Py_Initialize() twice does nothing. */
+        return _Py_INIT_OK();
+    }
+
     _PyCoreConfig config = _PyCoreConfig_INIT;
     _PyInitError err;
 


### PR DESCRIPTION
Calling Py_Initialize() twice does nothing, instead of failing with a
fatal error: restore the Python 3.6 behaviour.

<!-- issue-number: bpo-33932 -->
https://bugs.python.org/issue33932
<!-- /issue-number -->
