### PR TITLE
bpo-32500: Fix error messages for sequence and mapping C API.

### DIFF
--- a/Misc/NEWS.d/next/C API/2018-06-21-17-19-31.bpo-32500.WGCNad.rst
+++ b/Misc/NEWS.d/next/C API/2018-06-21-17-19-31.bpo-32500.WGCNad.rst
@@ -1,0 +1,4 @@
+Fixed error messages for :c:func:`PySequence_Size`,
+:c:func:`PySequence_GetItem`, :c:func:`PySequence_SetItem` and
+:c:func:`PySequence_DelItem` called with a mapping and
+:c:func:`PyMapping_Size` called with a sequence.

--- a/Objects/abstract.c
+++ b/Objects/abstract.c
@@ -1531,6 +1531,10 @@ PySequence_Size(PyObject *s)
         return len;
     }
 
+    if (s->ob_type->tp_as_mapping && s->ob_type->tp_as_mapping->mp_length) {
+        type_error("%.200s is not a sequence", s);
+        return -1;
+    }
     type_error("object of type '%.200s' has no len()", s);
     return -1;
 }
@@ -1677,6 +1681,9 @@ PySequence_GetItem(PyObject *s, Py_ssize_t i)
         return m->sq_item(s, i);
     }
 
+    if (s->ob_type->tp_as_mapping && s->ob_type->tp_as_mapping->mp_subscript) {
+        return type_error("%.200s is not a sequence", s);
+    }
     return type_error("'%.200s' object does not support indexing", s);
 }
 
@@ -1728,6 +1735,10 @@ PySequence_SetItem(PyObject *s, Py_ssize_t i, PyObject *o)
         return m->sq_ass_item(s, i, o);
     }
 
+    if (s->ob_type->tp_as_mapping && s->ob_type->tp_as_mapping->mp_ass_subscript) {
+        type_error("%.200s is not a sequence", s);
+        return -1;
+    }
     type_error("'%.200s' object does not support item assignment", s);
     return -1;
 }
@@ -1757,6 +1768,10 @@ PySequence_DelItem(PyObject *s, Py_ssize_t i)
         return m->sq_ass_item(s, i, (PyObject *)NULL);
     }
 
+    if (s->ob_type->tp_as_mapping && s->ob_type->tp_as_mapping->mp_ass_subscript) {
+        type_error("%.200s is not a sequence", s);
+        return -1;
+    }
     type_error("'%.200s' object doesn't support item deletion", s);
     return -1;
 }
@@ -2093,6 +2108,11 @@ PyMapping_Size(PyObject *o)
         return len;
     }
 
+    if (o->ob_type->tp_as_sequence && o->ob_type->tp_as_sequence->sq_length) {
+        type_error("%.200s is not a mapping", o);
+        return -1;
+    }
+    /* PyMapping_Size() can be called from PyObject_Size(). */
     type_error("object of type '%.200s' has no len()", o);
     return -1;
 }


### PR DESCRIPTION
Fix error messages for PySequence_Size(), PySequence_GetItem(),
PySequence_SetItem() and PySequence_DelItem() called with a mapping
and PyMapping_Size() called with a sequence.


<!-- issue-number: bpo-32500 -->
https://bugs.python.org/issue32500
<!-- /issue-number -->
