### PR TITLE
bpo-33936: Actually define OPENSSL_VERSION_1_1

### DIFF
--- a/Modules/_hashopenssl.c
+++ b/Modules/_hashopenssl.c
@@ -38,7 +38,11 @@ module _hashlib
 #define HASH_OBJ_CONSTRUCTOR 0
 #endif
 
-#if (OPENSSL_VERSION_NUMBER < 0x10100000L) || defined(LIBRESSL_VERSION_NUMBER)
+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && !defined(LIBRESSL_VERSION_NUMBER)
+#  define OPENSSL_VERSION_1_1 1
+#endif
+
+#ifndef OPENSSL_VERSION_1_1
 /* OpenSSL < 1.1.0 */
 #define EVP_MD_CTX_new EVP_MD_CTX_create
 #define EVP_MD_CTX_free EVP_MD_CTX_destroy


### PR DESCRIPTION
In <i>Modules/_hashopenssl.c</i>, the `OPENSSL_VERSION_1_1` macro is checked for in `PyInit__hashlib()`, but never defined.

This causes build failures with some OpenSSL 1.1.

Define it when appropriate, using the logic from <i>Modules/_ssl.c</i>.

<!-- issue-number: bpo-33936 -->
https://bugs.python.org/issue33936
<!-- /issue-number -->
