### PR TITLE
[2.7] bpo-31677: Backport regex used to match encoded-word strings

### DIFF
--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -35,12 +35,11 @@ ecre = re.compile(r'''
   =\?                   # literal =?
   (?P<charset>[^?]*?)   # non-greedy up to the next ? is the charset
   \?                    # literal ?
-  (?P<encoding>[qb])    # either a "q" or a "b", case insensitive
+  (?P<encoding>[qQbB])  # either a "q" or a "b", case insensitive
   \?                    # literal ?
   (?P<encoded>.*?)      # non-greedy up to the next ?= is the encoded string
   \?=                   # literal ?=
-  (?=[ \t]|$)           # whitespace or the end of the string
-  ''', re.VERBOSE | re.IGNORECASE | re.MULTILINE)
+  ''', re.VERBOSE | re.MULTILINE)
 
 # Field name regexp, including trailing colon, but not separating whitespace,
 # according to RFC 2822.  Character range is from tilde to exclamation mark.

--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -35,11 +35,11 @@ ecre = re.compile(r'''
   =\?                   # literal =?
   (?P<charset>[^?]*?)   # non-greedy up to the next ? is the charset
   \?                    # literal ?
-  (?P<encoding>[qQbB])  # either a "q" or a "b", case insensitive
+  (?P<encoding>[qb])  # either a "q" or a "b", case insensitive
   \?                    # literal ?
   (?P<encoded>.*?)      # non-greedy up to the next ?= is the encoded string
   \?=                   # literal ?=
-  ''', re.VERBOSE | re.MULTILINE)
+  ''', re.VERBOSE | re.IGNORECASE | re.MULTILINE)
 
 # Field name regexp, including trailing colon, but not separating whitespace,
 # according to RFC 2822.  Character range is from tilde to exclamation mark.

--- a/Lib/email/header.py
+++ b/Lib/email/header.py
@@ -35,7 +35,7 @@ ecre = re.compile(r'''
   =\?                   # literal =?
   (?P<charset>[^?]*?)   # non-greedy up to the next ? is the charset
   \?                    # literal ?
-  (?P<encoding>[qb])  # either a "q" or a "b", case insensitive
+  (?P<encoding>[qb])    # either a "q" or a "b", case insensitive
   \?                    # literal ?
   (?P<encoded>.*?)      # non-greedy up to the next ?= is the encoded string
   \?=                   # literal ?=

--- a/Lib/email/test/test_email.py
+++ b/Lib/email/test/test_email.py
@@ -1649,10 +1649,12 @@ class TestRFC2047(unittest.TestCase):
         hu = make_header(dh).__unicode__()
         eq(hu, u'The quick brown fox jumped over the lazy dog')
 
-    def test_rfc2047_without_whitespace(self):
+    def test_rfc2047_missing_whitespace(self):
         s = 'Sm=?ISO-8859-1?B?9g==?=rg=?ISO-8859-1?B?5Q==?=sbord'
         dh = decode_header(s)
-        self.assertEqual(dh, [(s, None)])
+        self.assertEqual(dh, [(b'Sm', None), (b'\xf6', 'iso-8859-1'),
+                              (b'rg', None), (b'\xe5', 'iso-8859-1'),
+                              (b'sbord', None)])
 
     def test_rfc2047_with_whitespace(self):
         s = 'Sm =?ISO-8859-1?B?9g==?= rg =?ISO-8859-1?B?5Q==?= sbord'

--- a/Lib/email/test/test_email_renamed.py
+++ b/Lib/email/test/test_email_renamed.py
@@ -1586,7 +1586,9 @@ class TestRFC2047(unittest.TestCase):
     def test_rfc2047_missing_whitespace(self):
         s = 'Sm=?ISO-8859-1?B?9g==?=rg=?ISO-8859-1?B?5Q==?=sbord'
         dh = decode_header(s)
-        self.assertEqual(dh, [(s, None)])
+        self.assertEqual(dh, [(b'Sm', None), (b'\xf6', 'iso-8859-1'),
+                              (b'rg', None), (b'\xe5', 'iso-8859-1'),
+                              (b'sbord', None)])
 
     def test_rfc2047_with_whitespace(self):
         s = 'Sm =?ISO-8859-1?B?9g==?= rg =?ISO-8859-1?B?5Q==?= sbord'


### PR DESCRIPTION
The current regex used in 2.7 doesn't really handle encoded strings with multiple parts. This backports the regex in Python 3.7 which does a better job.

Example string:

> =?gb2312?B?UmU6ILTwuLQ6IFtTdGVsbGEtVFBFXSC08Li0OiBbSFAtU3RlbGxhXSBTa3ly?==?gb2312?Q?ay_related_issue?=

With the curret regex:

`Python 2.7.14 (default, Sep 23 2017, 22:06:14)`
`>>> import re`
`>>> line = "=?gb2312?B?UmU6ILTwuLQ6IFtTdGVsbGEtVFBFXSC08Li0OiBbSFAtU3RlbGxhXSBTa3ly?==?gb2312?Q?ay_related_issue?="`
`>>> # Match encoded-word strings in the form =?charset?q?Hello_World?=`
`... ecre = re.compile(r'''`
`...   =\?                   # literal =?`
`...   (?P<charset>[^?]*?)   # non-greedy up to the next ? is the charset`
`...   \?                    # literal ?`
`...   (?P<encoding>[qb])    # either a "q" or a "b", case insensitive`
`...   \?                    # literal ?`
`...   (?P<encoded>.*?)      # non-greedy up to the next ?= is the encoded string`
`...   \?=                   # literal ?=`
`...   (?=[ \t]|$)           # whitespace or the end of the string`
`...   ''', re.VERBOSE | re.IGNORECASE | re.MULTILINE)`
`>>> print(ecre.split(line))`
`['', 'gb2312', 'B', 'UmU6ILTwuLQ6IFtTdGVsbGEtVFBFXSC08Li0OiBbSFAtU3RlbGxhXSBTa3ly?==?gb2312?Q?ay_related_issue', '']`

decode_header() then fails because it's unable to email.base64mime.decode() 'UmU6ILTwuLQ6IFtTdGVsbGEtVFBFXSC08Li0OiBbSFAtU3RlbGxhXSBTa3ly?==?gb2312?Q?ay_related_issue'

With the regex from Python 3.7:

`Python 2.7.14 (default, Sep 23 2017, 22:06:14)`
`>>> import re`
`>>> line = "=?gb2312?B?UmU6ILTwuLQ6IFtTdGVsbGEtVFBFXSC08Li0OiBbSFAtU3RlbGxhXSBTa3ly?==?gb2312?Q?ay_related_issue?="`
`>>> # Match encoded-word strings in the form =?charset?q?Hello_World?=`
`... ecre = re.compile(r'''`
`...   =\?                   # literal =?`
`...   (?P<charset>[^?]*?)   # non-greedy up to the next ? is the charset`
`...   \?                    # literal ?`
`...   (?P<encoding>[qQbB])  # either a "q" or a "b", case insensitive`
`...   \?                    # literal ?`
`...   (?P<encoded>.*?)      # non-greedy up to the next ?= is the encoded string`
`...   \?=                   # literal ?=`
`...   ''', re.VERBOSE | re.MULTILINE)`
`>>> print(ecre.split(line))`
`['', 'gb2312', 'B', 'UmU6ILTwuLQ6IFtTdGVsbGEtVFBFXSC08Li0OiBbSFAtU3RlbGxhXSBTa3ly', '', 'gb2312', 'Q', 'ay_related_issue', '']`

It's correctly broken into a base64 part, email.base64mime.decode(), as well as a quoted-printable part for email.quoprimime().

<!-- issue-number: [bpo-31677](https://bugs.python.org/issue31677) -->
https://bugs.python.org/issue31677
<!-- /issue-number -->
