### PR TITLE
chg: Make argparse.Namespace unpackable/iterable.

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -85,6 +85,7 @@ __all__ = [
 
 import os as _os
 import re as _re
+import six as _six
 import sys as _sys
 
 from gettext import gettext as _, ngettext
@@ -1227,6 +1228,9 @@ class Namespace(_AttributeHolder):
         for name in kwargs:
             setattr(self, name, kwargs[name])
 
+    def __iter__(self):
+        return _six.iteritems(self.__dict__)
+
     def __eq__(self, other):
         if not isinstance(other, Namespace):
             return NotImplemented
@@ -1234,6 +1238,12 @@ class Namespace(_AttributeHolder):
 
     def __contains__(self, key):
         return key in self.__dict__
+
+    def __getitem__(self, key):
+        return self.__dict__.get(key)
+
+    def keys(self):
+        return list(self.__dict__.keys())
 
 
 class _ActionsContainer(object):


### PR DESCRIPTION
Currently you cant use an argparse namespace iteratively or unpack
the values in the **args syntax.  These slight changes allow iter
methods and unpacking for easier use in instantiating objects
based on the Namespace.

Example use:

    class NewClass(object):
        def __init__(self, arg1, arg2, arg3):
            do_something(arg1, arg2, arg3)


    thing = NewClass(**args)
              

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
