### PR TITLE
[2.7] bpo-33877: Remove UNIX qualification for running complete programs (GH-7744)

### DIFF
--- a/Doc/reference/toplevel_components.rst
+++ b/Doc/reference/toplevel_components.rst
@@ -51,11 +51,11 @@ a complete program; each statement is executed in the namespace of
    single: command line
    single: standard input
 
-Under Unix, a complete program can be passed to the interpreter in three forms:
-with the :option:`-c` *string* command line option, as a file passed as the
-first command line argument, or as standard input. If the file or standard input
-is a tty device, the interpreter enters interactive mode; otherwise, it executes
-the file as a complete program.
+A complete program can be passed to the interpreter
+in three forms: with the :option:`-c` *string* command line option, as a file
+passed as the first command line argument, or as standard input. If the file
+or standard input is a tty device, the interpreter enters interactive mode;
+otherwise, it executes the file as a complete program.
 
 
 .. _file-input:


### PR DESCRIPTION
…ams (GH-7744)

The statement is true for Windows (and macOS) also..
(cherry picked from commit c9d43c702a53804c23ecb22a0dbf6a47c804d2b1)

Co-authored-by: Andrés Delfino <adelfino@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33877 -->
https://bugs.python.org/issue33877
<!-- /issue-number -->
