### PR TITLE
[2.7] properly free memory in pgen. (closes bpo-27780)

### DIFF
--- a/Include/grammar.h
+++ b/Include/grammar.h
@@ -69,6 +69,7 @@ typedef struct {
 /* FUNCTIONS */
 
 grammar *newgrammar(int start);
+void freegrammar(grammar *g);
 dfa *adddfa(grammar *g, int type, char *name);
 int addstate(dfa *d);
 void addarc(dfa *d, int from, int to, int lbl);

--- a/Parser/grammar.c
+++ b/Parser/grammar.c
@@ -32,6 +32,24 @@ newgrammar(int start)
     return g;
 }
 
+void
+freegrammar(grammar *g)
+{
+    int i;
+    for (i = 0; i < g->g_ndfas; i++) {
+        int j;
+        free(g->g_dfa[i].d_name);
+        for (j = 0; j < g->g_dfa[i].d_nstates; j++)
+            PyObject_FREE(g->g_dfa[i].d_state[j].s_arc);
+        PyObject_FREE(g->g_dfa[i].d_state);
+    }
+    PyObject_FREE(g->g_dfa);
+    for (i = 0; i < g->g_ll.ll_nlabels; i++)
+        free(g->g_ll.ll_label[i].lb_str);
+    PyObject_FREE(g->g_ll.ll_label);
+    PyObject_FREE(g);
+}
+
 dfa *
 adddfa(grammar *g, int type, char *name)
 {

--- a/Parser/pgen.c
+++ b/Parser/pgen.c
@@ -117,6 +117,16 @@ newnfagrammar(void)
     return gr;
 }
 
+static void
+freenfagrammar(nfagrammar *gr)
+{
+    for (int i = 0; i < gr->gr_nnfas; i++) {
+        PyObject_FREE(gr->gr_nfa[i]->nf_state);
+    }
+    PyObject_FREE(gr->gr_nfa);
+    PyObject_FREE(gr);
+}
+
 static nfa *
 addnfa(nfagrammar *gr, char *name)
 {
@@ -488,7 +498,11 @@ makedfa(nfagrammar *gr, nfa *nf, dfa *d)
 
     convert(d, xx_nstates, xx_state);
 
-    /* XXX cleanup */
+    for (int i = 0; i < xx_nstates; i++) {
+        for (int j = 0; j < xx_state[i].ss_narcs; j++)
+            delbitset(xx_state[i].ss_arc[j].sa_bitset);
+        PyObject_FREE(xx_state[i].ss_arc);
+    }
     PyObject_FREE(xx_state);
 }
 
@@ -669,7 +683,7 @@ pgen(node *n)
     g = maketables(gr);
     translatelabels(g);
     addfirstsets(g);
-    PyObject_FREE(gr);
+    freenfagrammar(gr);
     return g;
 }
 

--- a/Parser/pgenmain.c
+++ b/Parser/pgenmain.c
@@ -67,6 +67,7 @@ main(int argc, char **argv)
         printf("Writing %s ...\n", graminit_h);
     printnonterminals(g, fp);
     fclose(fp);
+    freegrammar(g);
     Py_Exit(0);
     return 0; /* Make gcc -Wall happy */
 }


### PR DESCRIPTION
(cherry picked from commit 9ac11a752a19c3b8607582a3d5ccb615c467124b)


<!-- issue-number: bpo-27780 -->
https://bugs.python.org/issue27780
<!-- /issue-number -->
