### PR TITLE
[3.6] bpo-33916: Fix bz2 and lzma init when called twice (GH-7843)

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-06-21-11-35-47.bpo-33916.cZgPCD.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-21-11-35-47.bpo-33916.cZgPCD.rst
@@ -1,0 +1,2 @@
+bz2 and lzma: When Decompressor.__init__() is called twice, free the old
+lock to not leak memory.

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -652,11 +652,15 @@ _bz2_BZ2Decompressor___init___impl(BZ2Decompressor *self)
     int bzerror;
 
 #ifdef WITH_THREAD
-    self->lock = PyThread_allocate_lock();
-    if (self->lock == NULL) {
+    PyThread_type_lock lock = PyThread_allocate_lock();
+    if (lock == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Unable to allocate lock");
         return -1;
     }
+    if (self->lock != NULL) {
+        PyThread_free_lock(self->lock);
+    }
+    self->lock = lock;
 #endif
 
     self->needs_input = 1;

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -1181,11 +1181,15 @@ _lzma_LZMADecompressor___init___impl(Decompressor *self, int format,
     self->lzs.next_in = NULL;
 
 #ifdef WITH_THREAD
-    self->lock = PyThread_allocate_lock();
-    if (self->lock == NULL) {
+    PyThread_type_lock lock = PyThread_allocate_lock();
+    if (lock == NULL) {
         PyErr_SetString(PyExc_MemoryError, "Unable to allocate lock");
         return -1;
     }
+    if (self->lock != NULL) {
+        PyThread_free_lock(self->lock);
+    }
+    self->lock = lock;
 #endif
 
     self->check = LZMA_CHECK_UNKNOWN;


### PR DESCRIPTION
bz2, lzma: When Decompressor.__init__() is called twice, free the old
lock to not leak memory.

(cherry picked from commit 9b7cf757213cf4d7ae1d436d86ad53f5ba362d55)

<!-- issue-number: bpo-33916 -->
https://bugs.python.org/issue33916
<!-- /issue-number -->
