### PR TITLE
bpo-33950: Remove IDLE htest spec for a deleted file.

### DIFF
--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -296,16 +296,6 @@ _stack_viewer_spec = {
            "Check that exc_value, exc_tb, and exc_type are correct.\n"
     }
 
-_tabbed_pages_spec = {
-    'file': 'tabbedpages',
-    'kwds': {},
-    'msg': "Toggle between the two tabs 'foo' and 'bar'\n"
-           "Add a tab by entering a suitable name for it.\n"
-           "Remove an existing tab by entering its name.\n"
-           "Remove all existing tabs.\n"
-           "<nothing> is an invalid add page and remove page name.\n"
-    }
-
 _tooltip_spec = {
     'file': 'tooltip',
     'kwds': {},


### PR DESCRIPTION
In configdialog, the custom tabbedpages widget was replaced
by ttk.notebook several months ago.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33950 -->
https://bugs.python.org/issue33950
<!-- /issue-number -->
