### PR TITLE
bpo-33451: Close .pyc files before calling PyEval_EvalCode()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-23-15-32-02.bpo-33451.sWN-1l.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-23-15-32-02.bpo-33451.sWN-1l.rst
@@ -1,0 +1,1 @@
+Close .pyc files before calling PyEval_EvalCode().

--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-23-15-32-02.bpo-33451.sWN-1l.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-23-15-32-02.bpo-33451.sWN-1l.rst
@@ -1,1 +1,1 @@
-Close .pyc files before calling PyEval_EvalCode().
+Close directly executed pyc files before calling ``PyEval_EvalCode()``.


### PR DESCRIPTION
.pyc files were kept open longer than necessary.


<!-- issue-number: bpo-33451 -->
https://bugs.python.org/issue33451
<!-- /issue-number -->
