### PR TITLE
bpo-33899: Make tokenize module mirror end-of-file is end-of-line behavior

### DIFF
--- a/Lib/test/test_tokenize.py
+++ b/Lib/test/test_tokenize.py
@@ -36,6 +36,14 @@ class TokenizeTest(TestCase):
                          ["    ENCODING   'utf-8'       (0, 0) (0, 0)"] +
                          expected.rstrip().splitlines())
 
+    def test_implicit_newline(self):
+        # Make sure that the tokenizer puts in an implicit NEWLINE
+        # when the input lacks a trailing new line.
+        f = BytesIO("x".encode('utf-8'))
+        tokens = list(tokenize(f.readline))
+        self.assertEqual(tokens[-2].type, NEWLINE)
+        self.assertEqual(tokens[-1].type, ENDMARKER)
+
     def test_basic(self):
         self.check_tokenize("1 + 1", """\
     NUMBER     '1'           (1, 0) (1, 1)

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -496,7 +496,7 @@ def _tokenize(readline, encoding):
     line = b''
     while True:                                # loop over lines in stream
         try:
-            # We capture the value of the line variable here because 
+            # We capture the value of the line variable here because
             # readline uses the empty string '' to signal end of input,
             # hence `line` itself will always be overwritten at the end
             # of this loop.

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -496,6 +496,9 @@ def _tokenize(readline, encoding):
     line = b''
     while True:                                # loop over lines in stream
         try:
+            # This loop has multiple points where it can break out so we
+            # pick up the value for the last_line here, at one unified
+            # point to keep things simple.
             last_line = line
             line = readline()
         except StopIteration:

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -656,7 +656,7 @@ def _tokenize(readline, encoding):
                 pos += 1
 
     # Add an implicit NEWLINE if the input doesn't end in one
-    if len(last_line) > 0 and last_line[-1] not in '\r\n':
+    if last_line and last_line[-1] not in '\r\n':
         yield TokenInfo(NEWLINE, '', (lnum - 1, len(last_line)), (lnum - 1, len(last_line) + 1), '')
     for indent in indents[1:]:                 # pop remaining indent levels
         yield TokenInfo(DEDENT, '', (lnum, 0), (lnum, 0), '')

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -492,8 +492,11 @@ def _tokenize(readline, encoding):
             # BOM will already have been stripped.
             encoding = "utf-8"
         yield TokenInfo(ENCODING, encoding, (0, 0), (0, 0), '')
+    last_line = b''
+    line = b''
     while True:                                # loop over lines in stream
         try:
+            last_line = line
             line = readline()
         except StopIteration:
             line = b''
@@ -648,6 +651,9 @@ def _tokenize(readline, encoding):
                            (lnum, pos), (lnum, pos+1), line)
                 pos += 1
 
+    # Add an implicit NEWLINE if the input doesn't end in one
+    if len(last_line) > 0 and last_line[-1] not in '\r\n':
+        yield TokenInfo(NEWLINE, '', (lnum - 1, len(last_line)), (lnum - 1, len(last_line) + 1), '')
     for indent in indents[1:]:                 # pop remaining indent levels
         yield TokenInfo(DEDENT, '', (lnum, 0), (lnum, 0), '')
     yield TokenInfo(ENDMARKER, '', (lnum, 0), (lnum, 0), '')

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -496,9 +496,10 @@ def _tokenize(readline, encoding):
     line = b''
     while True:                                # loop over lines in stream
         try:
-            # This loop has multiple points where it can break out so we
-            # pick up the value for the last_line here, at one unified
-            # point to keep things simple.
+            # We capture the value of the line variable here because 
+            # readline uses the empty string '' to signal end of input,
+            # hence `line` itself will always be overwritten at the end
+            # of this loop.
             last_line = line
             line = readline()
         except StopIteration:

--- a/Misc/NEWS.d/next/Library/2018-06-24-01-57-14.bpo-33899.IaOcAr.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-24-01-57-14.bpo-33899.IaOcAr.rst
@@ -1,0 +1,3 @@
+Tokenize module now implicitly emits a NEWLINE when provided with input that
+does not have a trailing new line. This behavior now matches what the C
+tokenizer does internally.

--- a/Misc/NEWS.d/next/Library/2018-06-24-01-57-14.bpo-33899.IaOcAr.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-24-01-57-14.bpo-33899.IaOcAr.rst
@@ -1,3 +1,3 @@
 Tokenize module now implicitly emits a NEWLINE when provided with input that
-does not have a trailing new line. This behavior now matches what the C
-tokenizer does internally.
+does not have a trailing new line.  This behavior now matches what the C
+tokenizer does internally.  Contributed by Ammar Askar.


### PR DESCRIPTION
Most of the change involves fixing up the test suite, which previously made the assumption that there wouldn't be a new line if the input didn't end in one.

<!-- issue-number: bpo-33899 -->
https://bugs.python.org/issue33899
<!-- /issue-number -->
