### PR TITLE
bpo-33951: IDLE test_configdialog: call page.update() in setUpClass

### DIFF
--- a/Lib/idlelib/idle_test/test_configdialog.py
+++ b/Lib/idlelib/idle_test/test_configdialog.py
@@ -60,6 +60,7 @@ class FontPageTest(unittest.TestCase):
         page = cls.page = dialog.fontpage
         dialog.note.select(page)
         page.set_samples = Func()  # Mask instance method.
+        page.update()
 
     @classmethod
     def tearDownClass(cls):
@@ -210,6 +211,7 @@ class IndentTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.page = dialog.fontpage
+        cls.page.update()
 
     def test_load_tab_cfg(self):
         d = self.page
@@ -240,6 +242,7 @@ class HighPageTest(unittest.TestCase):
         page.paint_theme_sample = Func()
         page.set_highlight_target = Func()
         page.set_color_sample = Func()
+        page.update()
 
     @classmethod
     def tearDownClass(cls):
@@ -1085,6 +1088,7 @@ class GenPageTest(unittest.TestCase):
         dialog.note.select(page)
         page.set = page.set_add_delete_state = Func()
         page.upc = page.update_help_changes = Func()
+        page.update()
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
This avoids a consistent failure in at least one case when running only a single test method rather than all tests in the module.

The issue came up when running the following on Windows 10 Pro 64-bit:
`python -m test -ugui -m test_highlight_target_text_mouse test_idle`

(This test failed for perhaps an unrelated reason on Travis CI for GH-7887.   I encountered the issue while investigating that failure.)

<!-- issue-number: bpo-33951 -->
https://bugs.python.org/issue33951
<!-- /issue-number -->
