### PR TITLE
[2.7] bpo-33952: Fix typo in str.upper() documentation (GH-7898).

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -1381,7 +1381,7 @@ string functions based on regular expressions.
 .. method:: str.upper()
 
    Return a copy of the string with all the cased characters [4]_ converted to
-   uppercase.  Note that ``str.upper().isupper()`` might be ``False`` if ``s``
+   uppercase.  Note that ``s.upper().isupper()`` might be ``False`` if ``s``
    contains uncased characters or if the Unicode category of the resulting
    character(s) is not "Lu" (Letter, uppercase), but e.g. "Lt" (Letter, titlecase).
 


### PR DESCRIPTION
(cherry picked from commit 4a6e746079441d18c30e3c4d014f106faaf7792f)

Co-authored-by: Andrés Delfino <adelfino@gmail.com>

<!-- issue-number: bpo-33952 -->
https://bugs.python.org/issue33952
<!-- /issue-number -->
