### PR TITLE
bpo-24935: derive LDSHARED from CC for OSX and Linux

### DIFF
--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -176,10 +176,10 @@ def customize_compiler(compiler):
 
         if 'CC' in os.environ:
             newcc = os.environ['CC']
-            if (sys.platform == 'darwin'
+            if ((sys.platform == 'darwin' or sys.platform.startswith('linux'))
                     and 'LDSHARED' not in os.environ
                     and ldshared.startswith(cc)):
-                # On OS X, if CC is overridden, use that as the default
+                # On OS X and linux, if CC is overridden, use that as the default
                 #       command for LDSHARED as well
                 ldshared = newcc + ldshared[len(cc):]
             cc = newcc

--- a/Misc/NEWS.d/next/Library/2018-06-26-12-13-01.bpo-24935.Nokb5W.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-26-12-13-01.bpo-24935.Nokb5W.rst
@@ -1,0 +1,4 @@
+Derive LDSHARED from CC for OSX and Linux
+
+If the CC environmental variable is set, but LDSHARED is unset, sysconfig
+used to derive LDSHARED from CC, but only for OSX.


### PR DESCRIPTION
bpo-24935: derive LDSHARED from CC for OSX and Linux

If the CC environmental variable is set, but LDSHARED is unset,
sysconfig used to derive LDSHARED from CC, but only for OSX.

There is no good reason not to do it on Linux as well.

<!-- issue-number: bpo-24935 -->
https://bugs.python.org/issue24935
<!-- /issue-number -->
