### PR TITLE
bpo-27780: Make pgen.c C89 compliant

### DIFF
--- a/Parser/pgen.c
+++ b/Parser/pgen.c
@@ -405,6 +405,7 @@ makedfa(nfagrammar *gr, nfa *nf, dfa *d)
     int istate, jstate, iarc, jarc, ibit;
     nfastate *st;
     nfaarc *ar;
+    int i, j;
 
     ss = newbitset(nbits);
     addclosure(ss, nf, nf->nf_start);
@@ -499,8 +500,8 @@ makedfa(nfagrammar *gr, nfa *nf, dfa *d)
 
     convert(d, xx_nstates, xx_state);
 
-    for (int i = 0; i < xx_nstates; i++) {
-        for (int j = 0; j < xx_state[i].ss_narcs; j++)
+    for (i = 0; i < xx_nstates; i++) {
+        for (j = 0; j < xx_state[i].ss_narcs; j++)
             delbitset(xx_state[i].ss_arc[j].sa_bitset);
         PyObject_FREE(xx_state[i].ss_arc);
     }


### PR DESCRIPTION
We still have some failing buildbots even after one C89 fix:

http://buildbot.python.org/all/#/builders/81/builds/178

<!-- issue-number: bpo-27780 -->
https://bugs.python.org/issue27780
<!-- /issue-number -->
