### PR TITLE
bpo-33881: Use NFKC to find duplicate members in make_dataclass

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1109,7 +1109,6 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
     for item in fields:
         if isinstance(item, str):
             name = item
-            normalized_name = unicodedata.normalize('NFKC', name)
             tp = 'typing.Any'
         elif len(item) == 2:
             name, tp, = item
@@ -1123,6 +1122,7 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
             raise TypeError(f'Field names must be valid identifers: {name!r}')
         if keyword.iskeyword(name):
             raise TypeError(f'Field names must not be keywords: {name!r}')
+        normalized_name = unicodedata.normalize('NFKC', name)
         if normalized_name in seen:
             raise TypeError(f'Field name duplicated: {normalized_name!r}')
 

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1124,7 +1124,7 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
         if keyword.iskeyword(name):
             raise TypeError(f'Field names must not be keywords: {name!r}')
         if normalized_name in seen:
-            raise TypeError(f'Field name duplicated: {name!r}')
+            raise TypeError(f'Field name duplicated: {normalized_name!r}')
 
         seen.add(normalized_name)
         anns[name] = tp

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -4,6 +4,7 @@ import copy
 import types
 import inspect
 import keyword
+import unicodedata
 
 __all__ = ['dataclass',
            'field',
@@ -1108,6 +1109,7 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
     for item in fields:
         if isinstance(item, str):
             name = item
+            normalized_name = unicodedata.normalize('NFKC', name)
             tp = 'typing.Any'
         elif len(item) == 2:
             name, tp, = item
@@ -1121,10 +1123,10 @@ def make_dataclass(cls_name, fields, *, bases=(), namespace=None, init=True,
             raise TypeError(f'Field names must be valid identifers: {name!r}')
         if keyword.iskeyword(name):
             raise TypeError(f'Field names must not be keywords: {name!r}')
-        if name in seen:
+        if normalized_name in seen:
             raise TypeError(f'Field name duplicated: {name!r}')
 
-        seen.add(name)
+        seen.add(normalized_name)
         anns[name] = tp
 
     namespace['__annotations__'] = anns

--- a/Misc/NEWS.d/next/Library/2018-06-25-14-18-43.bpo-33881.jBUamq.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-25-14-18-43.bpo-33881.jBUamq.rst
@@ -1,0 +1,1 @@
+Use NFKC to find duplicate members in make_dataclass.


### PR DESCRIPTION
I measured how it affected the performance by creating a dataclass with 10000 members.
python.bat -m timeit -s "from dataclasses import make_dataclass" -s "arg_list = [chr(k) * i for k in range(97, 123) for i in range(1, 500)]" "make_dataclass('a', arg_list)" 
The performance didn't change, both before and after the changes it takes around 14.5s.

<!-- issue-number: bpo-33881 -->
https://bugs.python.org/issue33881
<!-- /issue-number -->
