### PR TITLE
bpo-24596: Decref module in PyRun_SimpleFileExFlags() on SystemExit

### DIFF
--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -453,24 +453,6 @@ class CmdLineTest(unittest.TestCase):
             print("del sys.modules['__main__']", file=script)
         assert_python_ok(filename)
 
-    def test_global_del_SystemExit(self):
-        code = '''if 1:
-            class ClassWithDel:
-                def __del__(self):
-                    print('__del__ called')
-            a = ClassWithDel()
-            a.link = a
-            raise SystemExit(0)'''
-        filename = support.TESTFN
-        self.addCleanup(support.unlink, filename)
-        with open(filename, "w") as script:
-            script.write(code)
-        p = subprocess.run((sys.executable, filename),
-                           stdout=subprocess.PIPE,
-                           stderr=subprocess.PIPE,
-                           universal_newlines=True)
-        self.assertEqual(p.stdout.rstrip(), '__del__ called')
-
     def test_unknown_options(self):
         rc, out, err = assert_python_failure('-E', '-z')
         self.assertIn(b'Unknown option: -z', err)

--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-25-16-54-05.bpo-24596.Rkwova.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-25-16-54-05.bpo-24596.Rkwova.rst
@@ -1,0 +1,3 @@
+When a :exc:`SystemExit` exception occurs in
+:c:func:`PyRun_SimpleFileExFlags`, decref the module object before calling
+:c:func:`PyErr_Print()`.  Patch by Zackery Spytz.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-25-16-54-05.bpo-24596.Rkwova.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-25-16-54-05.bpo-24596.Rkwova.rst
@@ -1,3 +1,2 @@
-When a :exc:`SystemExit` exception occurs in
-:c:func:`PyRun_SimpleFileExFlags`, decref the module object before calling
+Decref the module object in :c:func:`PyRun_SimpleFileExFlags` before calling
 :c:func:`PyErr_Print()`.  Patch by Zackery Spytz.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -431,9 +431,7 @@ PyRun_SimpleFileExFlags(FILE *fp, const char *filename, int closeit,
     }
     flush_io();
     if (v == NULL) {
-        if (PyErr_ExceptionMatches(PyExc_SystemExit)) {
-            Py_DECREF(m);
-        }
+        Py_CLEAR(m);
         PyErr_Print();
         goto done;
     }
@@ -442,7 +440,7 @@ PyRun_SimpleFileExFlags(FILE *fp, const char *filename, int closeit,
   done:
     if (set_file_name && PyDict_DelItemString(d, "__file__"))
         PyErr_Clear();
-    Py_DECREF(m);
+    Py_XDECREF(m);
     return ret;
 }
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -431,6 +431,9 @@ PyRun_SimpleFileExFlags(FILE *fp, const char *filename, int closeit,
     }
     flush_io();
     if (v == NULL) {
+        if (PyErr_ExceptionMatches(PyExc_SystemExit)) {
+            Py_DECREF(m);
+        }
         PyErr_Print();
         goto done;
     }


### PR DESCRIPTION
PyErr_Print() will not return when the exception is a SystemExit, so
decref the __main__ module object in that case.

<!-- issue-number: bpo-24596 -->
https://bugs.python.org/issue24596
<!-- /issue-number -->
