### PR TITLE
bpo-33924: original missed mac-specific menudef 'windows' to 'window'…

### DIFF
--- a/Lib/idlelib/macosx.py
+++ b/Lib/idlelib/macosx.py
@@ -158,8 +158,8 @@ def overrideRootMenu(root, flist):
 
         if end > 0:
             menu.delete(0, end)
-        windows.add_windows_to_menu(menu)
-    windows.register_callback(postwindowsmenu)
+        window.add_windows_to_menu(menu)
+    window.register_callback(postwindowsmenu)
 
     def about_dialog(event=None):
         "Handle Help 'About IDLE' event."


### PR DESCRIPTION
Two missed instances of 'windows' to 'window' conversion in the recent commit, specific to macOS. Prevents IDLE from starting.


<!-- issue-number: bpo-33924 -->
https://bugs.python.org/issue33924
<!-- /issue-number -->
