### PR TITLE
bpo-4260: Document that ctypes.xFUNCTYPE are decorators

### DIFF
--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1025,6 +1025,23 @@ As we can easily check, our array is sorted now::
    1 5 7 33 99
    >>>
 
+The function factories can be used as decorator factories, so we may as well
+write::
+
+   >>> @CFUNCTYPE(c_int, POINTER(c_int), POINTER(c_int))
+   ... def py_cmp_func(*args):
+   ...    (a, b,) = (t[0] for t in args)
+   ...    print("py_cmp_func", a, b)
+   ...    return a - b
+   ...
+   >>> qsort(ia, len(ia), sizeof(c_int), py_cmp_func)
+   py_cmp_func 5 1
+   py_cmp_func 33 99
+   py_cmp_func 7 33
+   py_cmp_func 1 7
+   py_cmp_func 5 7
+   >>>
+
 .. note::
 
    Make sure you keep references to :func:`CFUNCTYPE` objects as long as they
@@ -1582,7 +1599,7 @@ type and the argument types of the function.
 
 .. function:: CFUNCTYPE(restype, *argtypes, use_errno=False, use_last_error=False)
 
-   The returned function prototype creates functions that use the standard C
+   Returns a function prototype which creates functions that use the standard C
    calling convention.  The function will release the GIL during the call.  If
    *use_errno* is set to true, the ctypes private copy of the system
    :data:`errno` variable is exchanged with the real :data:`errno` value before
@@ -1592,7 +1609,7 @@ type and the argument types of the function.
 
 .. function:: WINFUNCTYPE(restype, *argtypes, use_errno=False, use_last_error=False)
 
-   Windows only: The returned function prototype creates functions that use the
+   Windows only: Returns a function prototype which creates functions that use the
    ``stdcall`` calling convention, except on Windows CE where
    :func:`WINFUNCTYPE` is the same as :func:`CFUNCTYPE`.  The function will
    release the GIL during the call.  *use_errno* and *use_last_error* have the
@@ -1601,8 +1618,11 @@ type and the argument types of the function.
 
 .. function:: PYFUNCTYPE(restype, *argtypes)
 
-   The returned function prototype creates functions that use the Python calling
+   Returns a function prototype which creates functions that use the Python calling
    convention.  The function will *not* release the GIL during the call.
+
+These factory functions can be used as decorator factories, and as such, be applied
+to functions through the ``@wrapper`` syntax.
 
 Function prototypes created by these factory functions can be instantiated in
 different ways, depending on the type and number of the parameters in the call:

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1030,9 +1030,9 @@ write::
 
    >>> @CFUNCTYPE(c_int, POINTER(c_int), POINTER(c_int))
    ... def py_cmp_func(*args):
-   ...    (a, b,) = (t[0] for t in args)
-   ...    print("py_cmp_func", a, b)
-   ...    return a - b
+   ...     (a, b,) = (t[0] for t in args)
+   ...     print("py_cmp_func", a, b)
+   ...     return a - b
    ...
    >>> qsort(ia, len(ia), sizeof(c_int), py_cmp_func)
    py_cmp_func 5 1

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1598,7 +1598,6 @@ factories, and as such, be applied to functions through the ``@wrapper`` syntax.
 See :ref:`ctypes-callback-functions` for examples.
 
 
-
 .. function:: CFUNCTYPE(restype, *argtypes, use_errno=False, use_last_error=False)
 
    The returned function prototype creates functions that use the standard C

--- a/Doc/library/ctypes.rst
+++ b/Doc/library/ctypes.rst
@@ -1029,10 +1029,9 @@ The function factories can be used as decorator factories, so we may as well
 write::
 
    >>> @CFUNCTYPE(c_int, POINTER(c_int), POINTER(c_int))
-   ... def py_cmp_func(*args):
-   ...     (a, b,) = (t[0] for t in args)
-   ...     print("py_cmp_func", a, b)
-   ...     return a - b
+   ... def py_cmp_func(a, b):
+   ...     print("py_cmp_func", a[0], b[0])
+   ...     return a[0] - b[0]
    ...
    >>> qsort(ia, len(ia), sizeof(c_int), py_cmp_func)
    py_cmp_func 5 1
@@ -1594,12 +1593,15 @@ Foreign functions can also be created by instantiating function prototypes.
 Function prototypes are similar to function prototypes in C; they describe a
 function (return type, argument types, calling convention) without defining an
 implementation.  The factory functions must be called with the desired result
-type and the argument types of the function.
+type and the argument types of the function, and can be used as decorator
+factories, and as such, be applied to functions through the ``@wrapper`` syntax.
+See :ref:`ctypes-callback-functions` for examples.
+
 
 
 .. function:: CFUNCTYPE(restype, *argtypes, use_errno=False, use_last_error=False)
 
-   Returns a function prototype which creates functions that use the standard C
+   The returned function prototype creates functions that use the standard C
    calling convention.  The function will release the GIL during the call.  If
    *use_errno* is set to true, the ctypes private copy of the system
    :data:`errno` variable is exchanged with the real :data:`errno` value before
@@ -1609,7 +1611,7 @@ type and the argument types of the function.
 
 .. function:: WINFUNCTYPE(restype, *argtypes, use_errno=False, use_last_error=False)
 
-   Windows only: Returns a function prototype which creates functions that use the
+   Windows only: The returned function prototype creates functions that use the
    ``stdcall`` calling convention, except on Windows CE where
    :func:`WINFUNCTYPE` is the same as :func:`CFUNCTYPE`.  The function will
    release the GIL during the call.  *use_errno* and *use_last_error* have the
@@ -1618,11 +1620,8 @@ type and the argument types of the function.
 
 .. function:: PYFUNCTYPE(restype, *argtypes)
 
-   Returns a function prototype which creates functions that use the Python calling
+   The returned function prototype creates functions that use the Python calling
    convention.  The function will *not* release the GIL during the call.
-
-These factory functions can be used as decorator factories, and as such, be applied
-to functions through the ``@wrapper`` syntax.
 
 Function prototypes created by these factory functions can be instantiated in
 different ways, depending on the type and number of the parameters in the call:


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-4260 -->
https://bugs.python.org/issue4260
<!-- /issue-number -->
