### PR TITLE
DOC: In `reduce`, refer to `accumulate`

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -263,6 +263,8 @@ The :mod:`functools` module defines the following functions:
               value = function(value, element)
           return value
 
+   See :func:`itertools.accumulate` for an iterator that yields all intermediate
+   values.
 
 .. decorator:: singledispatch
 


### PR DESCRIPTION
In the documentation for `functools.reduce`, refer to `itertools.accumulate`.  The two perform similar tasks.  In the opposite direction, there is already a linked reference.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
