### PR TITLE
bpo-33871: Fix os.sendfile(), os.writev(), os.readv(), etc.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-06-26-19-03-56.bpo-33871.XhlrGU.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-26-19-03-56.bpo-33871.XhlrGU.rst
@@ -1,0 +1,4 @@
+Fixed integer overflow in :func:`os.readv`, :func:`os.writev`,
+:func:`os.preadv` and :func:`os.pwritev` and in :func:`os.sendfile` with
+*headers* or *trailers* arguments (on BSD-based OSes and MacOS).
+Thanks Ned Deily for testing on 32-bit MacOS.

--- a/Misc/NEWS.d/next/Library/2018-06-26-19-03-56.bpo-33871.XhlrGU.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-26-19-03-56.bpo-33871.XhlrGU.rst
@@ -1,4 +1,3 @@
 Fixed integer overflow in :func:`os.readv`, :func:`os.writev`,
 :func:`os.preadv` and :func:`os.pwritev` and in :func:`os.sendfile` with
-*headers* or *trailers* arguments (on BSD-based OSes and MacOS).
-Thanks Ned Deily for testing on 32-bit MacOS.
+*headers* or *trailers* arguments (on BSD-based OSes and macOS).

--- a/Misc/NEWS.d/next/Security/2018-06-26-19-35-33.bpo-33871.S4HR9n.rst
+++ b/Misc/NEWS.d/next/Security/2018-06-26-19-35-33.bpo-33871.S4HR9n.rst
@@ -1,0 +1,3 @@
+Fixed sending the part of the file in :func:`os.sendfile` on MacOS.  Using
+the *trailers* argument could cause sending more bytes from the input file
+than was specified.  Thanks Ned Deily for testing on 32-bit MacOS.

--- a/Misc/NEWS.d/next/Security/2018-06-26-19-35-33.bpo-33871.S4HR9n.rst
+++ b/Misc/NEWS.d/next/Security/2018-06-26-19-35-33.bpo-33871.S4HR9n.rst
@@ -1,3 +1,3 @@
-Fixed sending the part of the file in :func:`os.sendfile` on MacOS.  Using
+Fixed sending the part of the file in :func:`os.sendfile` on macOS.  Using
 the *trailers* argument could cause sending more bytes from the input file
-than was specified.  Thanks Ned Deily for testing on 32-bit MacOS.
+than was specified.


### PR DESCRIPTION
* Fix integer overflow in os.readv(), os.writev(), os.preadv()
  and os.pwritev() and in os.sendfile() with headers or trailers
  arguments (on BSD-based OSes and MacOS).

* Fix sending the part of the file in os.sendfile() on MacOS.
  Using the trailers argument could cause sending more bytes from
  the input file than was specified.

Thanks Ned Deily for testing on 32-bit MacOS.


<!-- issue-number: bpo-33871 -->
https://bugs.python.org/issue33871
<!-- /issue-number -->
