### PR TITLE
gh-78154: Only split request lines on b'\x20'

### DIFF
--- a/Lib/http/client.py
+++ b/Lib/http/client.py
@@ -1174,7 +1174,11 @@ class HTTPConnection:
         url = url or '/'
         self._validate_path(url)
 
-        request = '%s %s %s' % (method, url, self._http_vsn_str)
+        if self._http_vsn_str:
+            request = f'{method} {url} {self._http_vsn_str}'
+        else:
+            # For HTTP 0.9 support
+            request = f'{method} {url}'
 
         self._output(self._encode_request(request))
 

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -281,7 +281,7 @@ class BaseHTTPRequestHandler(socketserver.StreamRequestHandler):
         requestline = str(self.raw_requestline, 'iso-8859-1')
         requestline = requestline.rstrip('\r\n')
         self.requestline = requestline
-        words = requestline.split()
+        words = requestline.split(' ')
         if len(words) == 0:
             return False
 

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -1093,6 +1093,20 @@ class BaseHTTPRequestHandlerTestCase(unittest.TestCase):
         self.verify_expected_headers(result[1:result.index(b'\r\n')])
         self.assertFalse(self.handler.get_called)
 
+    def test_unicode_space(self):
+        # HTTP defines SP as *only* b'\x20' -- other space characters
+        # (such as this Latin-1 encoded non-breaking space) should not
+        # be used to delimit method, request-target, and HTTP-version.
+        result = self.send_typical_request(
+            b'GET /spaced\xa0out HTTP/1.1\r\n'
+            b'Host: dummy\r\n'
+            b'\r\n'
+        )
+        expected = b'HTTP/1.1 200 '
+        self.assertEqual(expected, result[0][:len(expected)])
+        self.verify_expected_headers(result[1:result.index(b'\r\n')])
+        self.assertTrue(self.handler.get_called)
+
     def test_with_continue_1_0(self):
         result = self.send_typical_request(b'GET / HTTP/1.0\r\nExpect: 100-continue\r\n\r\n')
         self.verify_http_server_response(result[0])

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -260,6 +260,7 @@ Artem Bulgakov
 Dick Bulterman
 Bill Bumgarner
 Jimmy Burgett
+Tim Burke
 Charles Burkland
 Edmond Burnett
 Tommy Burnette

--- a/Misc/NEWS.d/next/Library/2018-06-27-11-35-53.bpo-33973.s2lZLT.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-27-11-35-53.bpo-33973.s2lZLT.rst
@@ -1,0 +1,1 @@
+:mod:`http.server` request-line parsing now only splits on ``b'\x20'``.


### PR DESCRIPTION
Otherwise, upgrading a Python 2 server to Python 3 would break
previously working (if misbehaving) clients that send unquoted
UTF-8 request lines. While a client would be out of spec for
sending a request-line that includes bytes outside of the ASCII
range, this was previously allowed and worked as expected under
Python 2.7.


<!-- issue-number: bpo-33973 -->
https://bugs.python.org/issue33973
<!-- /issue-number -->


<!-- gh-issue-number: gh-78154 -->
* Issue: gh-78154
<!-- /gh-issue-number -->
