### PR TITLE
[2.7] bpo-33873: Backport regrtest from master

### DIFF
--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -516,6 +516,15 @@ def main(tests=None, testdir=None, verbose=0, quiet=False,
         except ValueError:
             pass
 
+    if huntrleaks:
+        warmup, repetitions, _ = huntrleaks
+        if warmup < 1 or repetitions < 1:
+            msg = ("Invalid values for the --huntrleaks/-R parameters. The "
+                   "number of warmups and repetitions must be at least 1 "
+                   "each (1:1).")
+            print >>sys.stderr, msg
+            sys.exit(2)
+
     if slaveargs is not None:
         args, kwargs = json.loads(slaveargs)
         if kwargs['huntrleaks']:
@@ -1308,11 +1317,12 @@ def runtest_inner(test, verbose, quiet, huntrleaks=False, pgo=False, testdir=Non
                 # being imported.  For tests based on unittest or doctest,
                 # explicitly invoke their test_main() function (if it exists).
                 indirect_test = getattr(the_module, "test_main", None)
-                if indirect_test is not None:
-                    indirect_test()
                 if huntrleaks:
                     refleak = dash_R(the_module, test, indirect_test,
                         huntrleaks)
+                else:
+                    if indirect_test is not None:
+                        indirect_test()
                 test_time = time.time() - start_time
             post_test_cleanup()
         finally:

--- a/Lib/test/regrtest.py
+++ b/Lib/test/regrtest.py
@@ -691,6 +691,12 @@ def main(tests=None, testdir=None, verbose=0, quiet=False,
         if ncpu:
             print "== CPU count:", ncpu
 
+    if huntrleaks:
+        warmup, repetitions, _ = huntrleaks
+        if warmup < 3:
+            print("WARNING: Running tests with --huntrleaks/-R and less than "
+                  "3 warmup repetitions can give false positives!")
+
     if randomize:
         random.seed(random_seed)
         print "Using random seed", random_seed

--- a/Lib/test/test_regrtest.py
+++ b/Lib/test/test_regrtest.py
@@ -17,6 +17,8 @@ import tempfile
 import textwrap
 import unittest
 from test import support
+# Use utils alias to use the same code for TestUtils in master and 2.7 branches
+import regrtest as utils
 
 
 Py_DEBUG = hasattr(sys, 'getobjects')
@@ -683,8 +685,32 @@ class ArgsTestCase(BaseTestCase):
                                   failed=testname, rerun=testname)
 
 
+class TestUtils(unittest.TestCase):
+    def test_format_duration(self):
+        self.assertEqual(utils.format_duration(0),
+                         '0 ms')
+        self.assertEqual(utils.format_duration(1e-9),
+                         '1 ms')
+        self.assertEqual(utils.format_duration(10e-3),
+                         '10 ms')
+        self.assertEqual(utils.format_duration(1.5),
+                         '1 sec 500 ms')
+        self.assertEqual(utils.format_duration(1),
+                         '1 sec')
+        self.assertEqual(utils.format_duration(2 * 60),
+                         '2 min')
+        self.assertEqual(utils.format_duration(2 * 60 + 1),
+                         '2 min 1 sec')
+        self.assertEqual(utils.format_duration(3 * 3600),
+                         '3 hour')
+        self.assertEqual(utils.format_duration(3 * 3600  + 2 * 60 + 1),
+                         '3 hour 2 min')
+        self.assertEqual(utils.format_duration(3 * 3600 + 1),
+                         '3 hour 1 sec')
+
+
 def test_main():
-    support.run_unittest(ProgramsTestCase, ArgsTestCase)
+    support.run_unittest(ProgramsTestCase, ArgsTestCase, TestUtils)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Tests/2018-06-16-01-37-31.bpo-33873.d86vab.rst
+++ b/Misc/NEWS.d/next/Tests/2018-06-16-01-37-31.bpo-33873.d86vab.rst
@@ -1,0 +1,4 @@
+Fix a bug in ``regrtest`` that caused an extra test to run if
+--huntrleaks/-R was used. Exit with error in case that invalid
+parameters are specified to --huntrleaks/-R (at least one warmup
+run and one repetition must be used).


### PR DESCRIPTION
* bpo-33718: regrtest: use format_duration() to display failed tests (GH-7686)
* bpo-33873: regrtest: Add warning on -R 1:3 (GH-7736)
* bpo-33873: Fix bug in `runtest.py` and add checks for invalid `-R` parameters (GH-7735)


<!-- issue-number: bpo-33873 -->
https://bugs.python.org/issue33873
<!-- /issue-number -->
