### PR TITLE
bpo-33975: Avoid small type when running IDLE's htests.

### DIFF
--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -65,6 +65,7 @@ autocomplete_w.AutoCompleteWindow
 outwin.OutputWindow (indirectly being tested with grep test)
 '''
 
+import idlelib.pyshell  # Set Windows DPI awareness before Tk().
 from importlib import import_module
 import tkinter as tk
 from tkinter.ttk import Scrollbar

--- a/Misc/NEWS.d/next/IDLE/2018-06-26-22-53-14.bpo-33975.Ow7alv.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-06-26-22-53-14.bpo-33975.Ow7alv.rst
@@ -1,0 +1,3 @@
+Avoid small type when running htests. Since part of the purpose of human-
+viewed tests is to determine that widgets look right, it is important that
+they look the same for testing as when running IDLE.


### PR DESCRIPTION
Import pyshell first in htest to call SetProcessDpiAwareness on Windows
before tkinter.Tk() is called for the htest.  Apparently, 'root.destroy()'
undoes a previous 'root = Tk()'.  Since IDLE unittests always destroy roots,
a unittest before an htest does not require anything more to work right.
Since part of the purpose of human-viewed tests is to determine that
widgets look right, it is important that they look the same for testing
as when running IDLE.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33975 -->
https://bugs.python.org/issue33975
<!-- /issue-number -->
