### PR TITLE
bpo-33976: support nested classes in Enum

### DIFF
--- a/Doc/library/enum.rst
+++ b/Doc/library/enum.rst
@@ -207,7 +207,7 @@ return A::
 .. note::
 
     Attempting to create a member with the same name as an already
-    defined attribute (another member, a method, etc.) or attempting to create
+    defined attribute (another member, a method, a class, etc.) or attempting to create
     an attribute with the same name as a member is not allowed.
 
 

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -156,7 +156,7 @@ class EnumMeta(type):
         # accessible in _EnumDict.__setitem__().
         for key, member in classdict.items():
             if isinstance(member, type):
-                if member.__qualname__.startswith(enum_class_qualname):
+                if member.__qualname__.startswith(enum_class_qualname + "."):
                     classdict.remove_member(key)
 
         # remove any keys listed in _ignore_

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -401,6 +401,44 @@ class TestEnum(unittest.TestCase):
                 green = 2
                 blue = 3
 
+    def test_enum_of_types(self):
+        """Support using Enum to refer to types deliberately."""
+        class MyTypes(Enum):
+            i = int
+            f = float
+            s = str
+        self.assertEqual(MyTypes.i.value, int)
+        self.assertEqual(MyTypes.f.value, float)
+        self.assertEqual(MyTypes.s.value, str)
+        class Foo:
+            pass
+        class Bar:
+            pass
+        class MyTypes2(Enum):
+            a = Foo
+            b = Bar
+        self.assertEqual(MyTypes2.a.value, Foo)
+        self.assertEqual(MyTypes2.b.value, Bar)
+
+    def test_nested_classes_in_enum(self):
+        """Support locally-defined nested classes."""
+        class Outer(Enum):
+            a = 1
+            b = 2
+            class Inner(Enum):
+                foo = 10
+                bar = 11
+        self.assertTrue(isinstance(Outer.Inner, type))
+        self.assertEqual(Outer.a.value, 1)
+        self.assertEqual(Outer.Inner.foo.value, 10)
+        self.assertEqual(
+            list(Outer.Inner),
+            [Outer.Inner.foo, Outer.Inner.bar],
+            )
+        self.assertEqual(
+            list(Outer),
+            [Outer.a, Outer.b],
+            )
 
     def test_enum_with_value_name(self):
         class Huh(Enum):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -419,6 +419,11 @@ class TestEnum(unittest.TestCase):
             b = Bar
         self.assertEqual(MyTypes2.a.value, Foo)
         self.assertEqual(MyTypes2.b.value, Bar)
+        class SpamEnumNotInner:
+            pass
+        class SpamEnum(Enum):
+            spam = SpamEnumNotInner
+        self.assertEqual(SpamEnum.spam.value, SpamEnumNotInner)
 
     def test_nested_classes_in_enum(self):
         """Support locally-defined nested classes."""

--- a/Misc/NEWS.d/next/Library/2018-06-28-11-04-10.bpo-33976.wahmah.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-28-11-04-10.bpo-33976.wahmah.rst
@@ -1,0 +1,1 @@
+Support nested classes in Enum. Patch by Edward Wang.


### PR DESCRIPTION
Methods defined in Enums behave 'normally' but classes defined in Enums get mistaken for regular values and can't be used as classes out of the box. In the example code below, the nested class `Outer.Inner` gets mistakenly identified as an Enum value. This PR changes it so that nested classes are treated in the same way as methods, fixing this bug.

Sample code:
```python
from enum import Enum

class Outer(Enum):
    a = 1
    b = 2
    class Inner(Enum):
        foo = 10
        bar = 11
```

Demonstration of bug:
```
>>> type(Outer)
<class 'enum.EnumMeta'>
>>> type(Outer.Inner)
<enum 'Outer'>
>>> print(Outer.Inner.foo)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'Outer' object has no attribute 'foo'
>>> 
```

<!-- issue-number: bpo-33976 -->
https://bugs.python.org/issue33976
<!-- /issue-number -->
