### PR TITLE
bpo-24567: Random subnormal.diff

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -383,7 +383,9 @@ class Random(_random.Random):
             raise ValueError('The number of weights does not match the population')
         bisect = _bisect.bisect
         total = cum_weights[-1]
-        return [population[bisect(cum_weights, random() * total)] for i in range(k)]
+        hi = len(cum_weights) - 1
+        return [population[bisect(cum_weights, random() * total, 0, hi)]
+                for i in range(k)]
 
 ## -------------------- real-valued distributions  -------------------
 

--- a/Lib/test/test_random.py
+++ b/Lib/test/test_random.py
@@ -227,6 +227,14 @@ class TestBasicOps:
         with self.assertRaises(IndexError):
             choices([], cum_weights=[], k=5)
 
+    def test_choices_subnormal(self):
+        # Subnormal weights would occassionally trigger an IndexError
+        # in choices() when the value returned by random() was large
+        # enough to make `random() * total` round up to the total.
+        # See https://bugs.python.org/msg275594 for more detail.
+        choices = self.gen.choices
+        choices(population=[1, 2], weights=[1e-323, 1e-323], k=5000)
+
     def test_gauss(self):
         # Ensure that the seed() method initializes all the hidden state.  In
         # particular, through 2.2.1 it failed to reset a piece of state used

--- a/Misc/NEWS.d/next/Library/2018-06-27-00-31-30.bpo-24567.FuePyY.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-27-00-31-30.bpo-24567.FuePyY.rst
@@ -1,0 +1,2 @@
+Improve random.choices() to handle subnormal input weights that could
+occasionally trigger an IndexError.


### PR DESCRIPTION
Make random.choices() handle subnormal input weights.

<!-- issue-number: bpo-24567 -->
https://bugs.python.org/issue24567
<!-- /issue-number -->
