### PR TITLE
bpo-30317, test_multiprocessing: fix test_timeout()

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1035,9 +1035,9 @@ class _TestQueue(BaseTestCase):
         start = time.time()
         self.assertRaises(pyqueue.Empty, q.get, True, 0.200)
         delta = time.time() - start
-        # Tolerate a delta of 30 ms because of the bad clock resolution on
+        # Tolerate a delta of 50 ms because of the bad clock resolution on
         # Windows (usually 15.6 ms)
-        self.assertGreaterEqual(delta, 0.170)
+        self.assertGreaterEqual(delta, 0.150)
         close_queue(q)
 
     def test_queue_feeder_donot_stop_onexc(self):


### PR DESCRIPTION
Tolerate a different of 50 ms, instead of just 30 ms, in
test_timeout() of multiprocessing tests. This change should fix such
test failure on Windows:

```
======================================================================
FAIL: test_timeout (test.test_multiprocessing_spawn.WithProcessesTestQueue)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "lib\test\_test_multiprocessing.py", line 753, in test_timeout
    self.assertGreaterEqual(delta, 0.170)
AssertionError: 0.16138982772827148 not greater than or equal to 0.17
```

<!-- issue-number: bpo-30317 -->
https://bugs.python.org/issue30317
<!-- /issue-number -->
