### PR TITLE
bpo-33966, multiprocessing: Pool wait for worker start

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-06-27-14-26-32.bpo-33966.aLZJuF.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-27-14-26-32.bpo-33966.aLZJuF.rst
@@ -1,0 +1,4 @@
+multiprocess: On Windows, if a worker is terminated too quickly, handles
+created by DupHandle() on reduction.dump() remain open in the parent process,
+causing a handles leak. Pool now waits using events until all new workers
+started  to make sure that the workers closed handles inherited by DupHandle.


### PR DESCRIPTION
On Windows, if a worker is terminated too quickly, handles created by
DupHandle() on reduction.dump() remain open in the parent process,
causing a handles leak. Pool now waits using events until all new
workers started to make sure that the workers closed handles
inherited by DupHandle.

<!-- issue-number: bpo-33966 -->
https://bugs.python.org/issue33966
<!-- /issue-number -->
