### PR TITLE
bpo-30356: Fix test_mymanager_context() of multiprocessing

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2666,7 +2666,9 @@ class _TestMyManager(BaseTestCase):
     def test_mymanager_context(self):
         with MyManager() as manager:
             self.common(manager)
-        self.assertEqual(manager._process.exitcode, 0)
+        # bpo-30356: BaseManager._finalize_manager() sends SIGTERM
+        # to the manager process if it takes longer than 1 second to stop.
+        self.assertIn(manager._process.exitcode, (0, -signal.SIGTERM))
 
     def test_mymanager_context_prestarted(self):
         manager = MyManager()


### PR DESCRIPTION
test_mymanager_context() now also accepts -SIGTERM as an expected
exitcode for the manager process. The process is killed with SIGTERM
if it takes longer than 1 second to stop.

<!-- issue-number: bpo-30356 -->
https://bugs.python.org/issue30356
<!-- /issue-number -->
