### PR TITLE
bpo-33715: Fix multiprocessing test_wait_result()

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1482,9 +1482,9 @@ class _TestCondition(BaseTestCase):
             p = self.Process(target=self._test_wait_result, args=(c, pid))
             p.start()
 
-            self.assertTrue(c.wait(10))
+            self.assertTrue(c.wait(60))
             if pid is not None:
-                self.assertRaises(KeyboardInterrupt, c.wait, 10)
+                self.assertRaises(KeyboardInterrupt, c.wait, 60)
 
             p.join()
 


### PR DESCRIPTION
Increase timeouts from 10 seconds to 1 minute.

<!-- issue-number: bpo-33715 -->
https://bugs.python.org/issue33715
<!-- /issue-number -->
