### PR TITLE
[3.6] bpo-33913: Fix test_multiprocessing_main_handling (GH-7972)

### DIFF
--- a/Lib/test/test_multiprocessing_main_handling.py
+++ b/Lib/test/test_multiprocessing_main_handling.py
@@ -58,11 +58,13 @@ if __name__ == '__main__':
     p = Pool(5)
     results = []
     p.map_async(f, [1, 2, 3], callback=results.extend)
-    deadline = time.time() + 10 # up to 10 s to report the results
+    start_time = time.monotonic()
     while not results:
         time.sleep(0.05)
-        if time.time() > deadline:
-            raise RuntimeError("Timed out waiting for results")
+        # up to 1 min to report the results
+        dt = time.monotonic() - start_time
+        if dt > 60.0:
+            raise RuntimeError("Timed out waiting for results (%.1f sec)" % dt)
     results.sort()
     print(start_method, "->", results)
 """
@@ -86,11 +88,13 @@ set_start_method(start_method)
 p = Pool(5)
 results = []
 p.map_async(int, [1, 4, 9], callback=results.extend)
-deadline = time.time() + 10 # up to 10 s to report the results
+start_time = time.monotonic()
 while not results:
     time.sleep(0.05)
-    if time.time() > deadline:
-        raise RuntimeError("Timed out waiting for results")
+    # up to 1 min to report the results
+    dt = time.monotonic() - start_time
+    if dt > 60.0:
+        raise RuntimeError("Timed out waiting for results (%.1f sec)" % dt)
 results.sort()
 print(start_method, "->", results)
 """


### PR DESCRIPTION
bpo-30339, bpo-33913:

* Increase timeout from 10 seconds to 1 minute in
  test_source_main_skipped_in_children source of
  test_multiprocessing_main_handling.
* Replace time.time() with time.monotonic().
* On timeout, include the duration in the error message.

(cherry picked from commit 64737e9ae2081e529935ecf07f44e89f362d1c4b)

<!-- issue-number: bpo-33913 -->
https://bugs.python.org/issue33913
<!-- /issue-number -->
