### PR TITLE
bpo-33983: Make lib2to3.pytree.Base.children a list

### DIFF
--- a/Lib/lib2to3/pytree.py
+++ b/Lib/lib2to3/pytree.py
@@ -42,7 +42,7 @@ class Base(object):
     # Default values for instance variables
     type = None    # int: token number (< 256) or symbol number (>= 256)
     parent = None  # Parent node pointer, or None
-    children = ()  # Tuple of subnodes
+    children = []  # List of subnodes
     was_changed = False
     was_checked = False
 

--- a/Misc/NEWS.d/next/Library/2018-06-27-13-55-05.bpo-33983.MRbonR.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-27-13-55-05.bpo-33983.MRbonR.rst
@@ -1,0 +1,2 @@
+:class:`lib2to3.pytree.Base` sets the `children` attribute to an empty
+list to be more consistent with :class:`lib2to3.pytree.Node`.


### PR DESCRIPTION
The type difference between Base/Leaf (a tuple) and Node (a list)
makes it difficult to type check functions that take both, because
lists can be used in ways that tuples can't.

<!-- issue-number: bpo-33983 -->
https://bugs.python.org/issue33983
<!-- /issue-number -->
