### PR TITLE
bpo-31546: fix input hook integration on windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-06-27-23-33-54.bpo-31546.zJlap-.rst
+++ b/Misc/NEWS.d/next/Windows/2018-06-27-23-33-54.bpo-31546.zJlap-.rst
@@ -1,0 +1,3 @@
+Restore running PyOS_InputHook while waiting for user input at the prompt.
+The restores integration of interactive GUI windows (such as Matplotlib
+figures) with the prompt on Windows.

--- a/Parser/myreadline.c
+++ b/Parser/myreadline.c
@@ -114,6 +114,9 @@ _PyOS_WindowsConsoleReadline(HANDLE hStdIn)
     wbuf = wbuf_local;
     wbuflen = sizeof(wbuf_local) / sizeof(wbuf_local[0]) - 1;
     while (1) {
+        if (PyOS_InputHook != NULL) {
+            (void)(PyOS_InputHook)();
+        }
         if (!ReadConsoleW(hStdIn, &wbuf[total_read], wbuflen - total_read, &n_read, NULL)) {
             err = GetLastError();
             goto exit;


### PR DESCRIPTION
This change was suggested by Steve Dower.  I do not have a windows development set up to test this.

If this could make it in for the 3.7 and the next 3.6 patch release that would be great!  This bug breaks interactive matplotlib windows for windows users in the standard python prompt.

attn @zooba 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-31546 -->
https://bugs.python.org/issue31546
<!-- /issue-number -->
