### PR TITLE
[3.7] bpo-33988: Use DeprecationWarning instead of PendingDeprecationWarning

### DIFF
--- a/Lib/test/test_platform.py
+++ b/Lib/test/test_platform.py
@@ -265,7 +265,7 @@ class PlatformTest(unittest.TestCase):
                 'ignore',
                 r'dist\(\) and linux_distribution\(\) '
                 'functions are deprecated .*',
-                PendingDeprecationWarning,
+                DeprecationWarning,
             )
             res = platform.dist()
 
@@ -341,7 +341,7 @@ class PlatformTest(unittest.TestCase):
                         'ignore',
                         r'dist\(\) and linux_distribution\(\) '
                         'functions are deprecated .*',
-                        PendingDeprecationWarning,
+                        DeprecationWarning,
                     )
                     distname, version, distid = platform.linux_distribution()
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -4145,7 +4145,7 @@ def test_main(verbose=False):
                 'ignore',
                 r'dist\(\) and linux_distribution\(\) '
                 'functions are deprecated .*',
-                PendingDeprecationWarning,
+                DeprecationWarning,
             )
             for name, func in plats.items():
                 plat = func()


### PR DESCRIPTION
* Use DeprecationWarning instead of PendingDeprecationWarning in test_platform and test_ssl.
* `dist` and `linux_distribution` were removed along with tests in master (Python 3.8) as part of https://github.com/python/cpython/commit/8b94b41ab7b12f745dea744e8940631318816935.

Since the changes are trivial I don't know if this requires a NEWS entry.

Thanks

<!-- issue-number: bpo-33988 -->
https://bugs.python.org/issue33988
<!-- /issue-number -->
