### PR TITLE
bpo-28411: Fix redundant declaration of _PyImport_AddModuleObject

### DIFF
--- a/Include/import.h
+++ b/Include/import.h
@@ -54,9 +54,6 @@ PyAPI_FUNC(PyObject *) PyImport_AddModuleObject(
     PyObject *name
     );
 #endif
-#ifndef Py_LIMITED_API
-PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *, PyObject *);
-#endif
 PyAPI_FUNC(PyObject *) PyImport_AddModule(
     const char *name            /* UTF-8 encoded string */
     );


### PR DESCRIPTION
Commit 3f9eee6eb4b2 ("bpo-28411: Support other mappings in
PyInterpreterState.modules.") introduced a new warning when building a C
extension with GCC and Python 3.7:

    In file included from /usr/include/python3.7m/Python.h:126,
                     from /home/me/linux/packaging/tools/perf/util/python.c:2:
    /usr/include/python3.7m/import.h:58:24: error: redundant redeclaration of
        ‘_PyImport_AddModuleObject’ [-Werror=redundant-decls]
     PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *, PyObject *);
                            ^~~~~~~~~~~~~~~~~~~~~~~~~
    /usr/include/python3.7m/import.h:47:24: note: previous declaration of
        ‘_PyImport_AddModuleObject’ was here
     PyAPI_FUNC(PyObject *) _PyImport_AddModuleObject(PyObject *name,
                            ^~~~~~~~~~~~~~~~~~~~~~~~~
    cc1: all warnings being treated as errors
    error: command 'gcc' failed with exit status 1

Both _PyImport_AddModuleObject declarations are within #ifndef Py_LIMITED_API
conditional block so drop one of them.

Signed-off-by: Jeremy Cline <jeremy@jcline.org>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-28411 -->
https://bugs.python.org/issue28411
<!-- /issue-number -->
