### PR TITLE
bpo-33990: Add CPPFLAGS during ./configure when customizing the compiler in distutils

### DIFF
--- a/Lib/distutils/sysconfig.py
+++ b/Lib/distutils/sysconfig.py
@@ -170,8 +170,8 @@ def customize_compiler(compiler):
                 _osx_support.customize_compiler(_config_vars)
                 _config_vars['CUSTOMIZED_OSX_COMPILER'] = 'True'
 
-        (cc, cxx, opt, cflags, ccshared, ldshared, shlib_suffix, ar, ar_flags) = \
-            get_config_vars('CC', 'CXX', 'OPT', 'CFLAGS',
+        (cc, cxx, opt, cppflags, cflags, ccshared, ldshared, shlib_suffix, ar, ar_flags) = \
+            get_config_vars('CC', 'CXX', 'OPT', 'CPPFLAGS', 'CFLAGS',
                             'CCSHARED', 'LDSHARED', 'SHLIB_SUFFIX', 'AR', 'ARFLAGS')
 
         if 'CC' in os.environ:
@@ -197,9 +197,7 @@ def customize_compiler(compiler):
             cflags = opt + ' ' + os.environ['CFLAGS']
             ldshared = ldshared + ' ' + os.environ['CFLAGS']
         if 'CPPFLAGS' in os.environ:
-            cpp = cpp + ' ' + os.environ['CPPFLAGS']
-            cflags = cflags + ' ' + os.environ['CPPFLAGS']
-            ldshared = ldshared + ' ' + os.environ['CPPFLAGS']
+            cppflags = os.environ['CPPFLAGS']
         if 'AR' in os.environ:
             ar = os.environ['AR']
         if 'ARFLAGS' in os.environ:
@@ -207,7 +205,9 @@ def customize_compiler(compiler):
         else:
             archiver = ar + ' ' + ar_flags
 
-        cc_cmd = cc + ' ' + cflags
+        cpp = cpp + ' ' + cppflags
+        ldshared = ldshared + ' ' + cppflags
+        cc_cmd = cc + ' ' + cppflags + ' ' + cflags
         compiler.set_executables(
             preprocessor=cpp,
             compiler=cc_cmd,

--- a/Misc/NEWS.d/next/Library/2018-06-28-12-30-44.bpo-33990.yWzTZp.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-28-12-30-44.bpo-33990.yWzTZp.rst
@@ -1,0 +1,3 @@
+Add the captured ``CPPFLAGS`` passed during ``./configure`` to the
+executables when customizing the compiler command in
+``sysconfig.cusomize_compiler`` for building C/C++ Python extensions.


### PR DESCRIPTION


<!-- issue-number: bpo-33990 -->
https://bugs.python.org/issue33990
<!-- /issue-number -->
