### PR TITLE
bpo-33978: close resources before deletion of logging handlers

### DIFF
--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -74,6 +74,10 @@ def fileConfig(fname, defaults=None, disable_existing_loggers=True):
     logging._acquireLock()
     try:
         logging._handlers.clear()
+
+        # Try to close the handlers before deleting the handler list
+        logging.shutdown(logging._handlerList[:])
+
         del logging._handlerList[:]
         # Handlers add themselves to logging._handlers
         handlers = _install_handlers(cp, formatters)
@@ -525,6 +529,10 @@ class DictConfigurator(BaseConfigurator):
                 disable_existing = config.pop('disable_existing_loggers', True)
 
                 logging._handlers.clear()
+
+                # Try to close the handlers before deleting the handler list
+                logging.shutdown(logging._handlerList[:])
+
                 del logging._handlerList[:]
 
                 # Do formatters first - they don't refer to anything else

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -73,12 +73,8 @@ def fileConfig(fname, defaults=None, disable_existing_loggers=True):
     # critical section
     logging._acquireLock()
     try:
-        logging._handlers.clear()
+        _clearExistingHandlers()
 
-        # Try to close the handlers before deleting the handler list
-        logging.shutdown(logging._handlerList[:])
-
-        del logging._handlerList[:]
         # Handlers add themselves to logging._handlers
         handlers = _install_handlers(cp, formatters)
         _install_loggers(cp, handlers, disable_existing_loggers)
@@ -268,6 +264,14 @@ def _install_loggers(cp, handlers, disable_existing):
     #    elif disable_existing_loggers:
     #        logger.disabled = 1
     _handle_existing_loggers(existing, child_loggers, disable_existing)
+
+
+def _clearExistingHandlers():
+    """Clear and close existing handlers"""
+    logging._handlers.clear()
+    logging.shutdown(logging._handlerList[:])
+    del logging._handlerList[:]
+
 
 IDENTIFIER = re.compile('^[a-z_][a-z0-9_]*$', re.I)
 
@@ -528,12 +532,7 @@ class DictConfigurator(BaseConfigurator):
             else:
                 disable_existing = config.pop('disable_existing_loggers', True)
 
-                logging._handlers.clear()
-
-                # Try to close the handlers before deleting the handler list
-                logging.shutdown(logging._handlerList[:])
-
-                del logging._handlerList[:]
+                _clearExistingHandlers()
 
                 # Do formatters first - they don't refer to anything else
                 formatters = config.get('formatters', EMPTY_DICT)

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1304,16 +1304,16 @@ class ConfigFileTest(BaseTest):
     keys=root
 
     [handlers]
-    keys=file_handler
+    keys=file
 
     [formatters]
     keys=
 
     [logger_root]
     level=DEBUG
-    handlers=file_handler
+    handlers=file
 
-    [handler_file_handler]
+    [handler_file]
     class=FileHandler
     level=DEBUG
     args=("{tempfile}",)
@@ -1466,9 +1466,14 @@ class ConfigFileTest(BaseTest):
 
     def test_config8_ok(self):
         with self.check_no_resource_warning():
-            with tempfile.NamedTemporaryFile() as f:
-                self.apply_config(self.config8.format(tempfile=f.name))
-                self.apply_config(self.config8.format(tempfile=f.name))
+            fd, fn = tempfile.mkstemp(".log", "test_logging-X-")
+            os.close(fd)
+            config8 = self.config8.format(tempfile=fn)
+
+            self.apply_config(config8)
+            self.apply_config(config8)
+
+            os.unlink(fn)
 
     def test_logger_disabling(self):
         self.apply_config(self.disable_test)
@@ -2926,13 +2931,16 @@ class ConfigDictTest(BaseTest):
             self.assertTrue(output.getvalue().endswith('Exclamation!\n'))
 
     def test_config15_ok(self):
-        with tempfile.NamedTemporaryFile() as f:
+        with self.check_no_resource_warning():
+            fd, fn = tempfile.mkstemp(".log", "test_logging-X-")
+            os.close(fd)
+
             config = {
                 "version": 1,
                 "handlers": {
                     "file": {
                         "class": "logging.FileHandler",
-                        "filename": f.name
+                        "filename": fn
                     }
                 },
                 "root": {
@@ -2940,9 +2948,10 @@ class ConfigDictTest(BaseTest):
                 }
             }
 
-            with self.check_no_resource_warning():
-                self.apply_config(config)
-                self.apply_config(config)
+            self.apply_config(config)
+            self.apply_config(config)
+
+            os.unlink(fn)
 
     def setup_via_listener(self, text, verify=None):
         text = text.encode("utf-8")

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1299,7 +1299,7 @@ class ConfigFileTest(BaseTest):
     """
 
     # config 8, check for resource warning
-    config8 = """
+    config8 = r"""
     [loggers]
     keys=root
 

--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -1465,15 +1465,27 @@ class ConfigFileTest(BaseTest):
             self.assert_log_lines([])
 
     def test_config8_ok(self):
+
+        def cleanup(h1, fn):
+            h1.close()
+            os.remove(fn)
+
         with self.check_no_resource_warning():
             fd, fn = tempfile.mkstemp(".log", "test_logging-X-")
             os.close(fd)
+
+            # Replace single backslash with double backslash in windows
+            # to avoid unicode error during string formatting
+            if os.name == "nt":
+                fn = fn.replace("\\", "\\\\")
+
             config8 = self.config8.format(tempfile=fn)
 
             self.apply_config(config8)
             self.apply_config(config8)
 
-            os.unlink(fn)
+        handler = logging.root.handlers[0]
+        self.addCleanup(cleanup, handler, fn)
 
     def test_logger_disabling(self):
         self.apply_config(self.disable_test)
@@ -2931,6 +2943,11 @@ class ConfigDictTest(BaseTest):
             self.assertTrue(output.getvalue().endswith('Exclamation!\n'))
 
     def test_config15_ok(self):
+
+        def cleanup(h1, fn):
+            h1.close()
+            os.remove(fn)
+
         with self.check_no_resource_warning():
             fd, fn = tempfile.mkstemp(".log", "test_logging-X-")
             os.close(fd)
@@ -2951,7 +2968,8 @@ class ConfigDictTest(BaseTest):
             self.apply_config(config)
             self.apply_config(config)
 
-            os.unlink(fn)
+        handler = logging.root.handlers[0]
+        self.addCleanup(cleanup, handler, fn)
 
     def setup_via_listener(self, text, verify=None):
         text = text.encode("utf-8")

--- a/Misc/NEWS.d/next/Library/2018-06-29-12-23-34.bpo-33978.y4csIw.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-29-12-23-34.bpo-33978.y4csIw.rst
@@ -1,0 +1,2 @@
+Close resources before deleting logging handlers. Patch by Karthikeyan
+Singaravelan.

--- a/Misc/NEWS.d/next/Library/2018-06-29-12-23-34.bpo-33978.y4csIw.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-29-12-23-34.bpo-33978.y4csIw.rst
@@ -1,2 +1,2 @@
-Close resources before deleting logging handlers. Patch by Karthikeyan
-Singaravelan.
+Closed existing logging handlers before reconfiguration via fileConfig
+and dictConfig. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
Close the file handlers before deleting the logging handlers so that there is no resource warning. Since the handlers are a weakreference I tried to close them by calling `self.close` on `__del__` but not all handlers have the `lock` attribute which resulted in `AttributeError`. `shutdown` handles the `AttributeError` and other scenarios but it will be a much cleaner if we close the handlers during weakref deletion instead of calling shudown which might miss some places.

Additionally shutdown is also registered at exit which should clean up the current handlers I hope but doesn't handle the ones that were deleted.

Attached tests and a NEWS entry. Kindly correct me if I am wrong on the approach since this is my first non-easy PR and I would like some help on this fix hoping the fix will not be much complex.

Thanks

<!-- issue-number: bpo-33978 -->
https://bugs.python.org/issue33978
<!-- /issue-number -->
