### PR TITLE
[2.7] bpo-25862: Fix assertion failures in io.TextIOWrapper.tell(). (GH-3918)

### DIFF
--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1619,6 +1619,7 @@ class TextIOWrapper(TextIOBase):
         self.buffer.write(b)
         if self._line_buffering and (haslf or "\r" in s):
             self.flush()
+        self._set_decoded_chars('')
         self._snapshot = None
         if self._decoder:
             self._decoder.reset()

--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -2741,6 +2741,17 @@ class TextIOWrapperTest(unittest.TestCase):
         with self.maybeRaises(TypeError):
             t.read(42)
 
+    def test_issue25862(self):
+        # Assertion failures occurred in tell() after read() and write().
+        t = self.TextIOWrapper(self.BytesIO(b'test'), encoding='ascii')
+        t.read(1)
+        t.read()
+        t.tell()
+        t = self.TextIOWrapper(self.BytesIO(b'test'), encoding='ascii')
+        t.read(1)
+        t.write('x')
+        t.tell()
+
 
 class CTextIOWrapperTest(TextIOWrapperTest):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-10-07-10-13-15.bpo-25862.FPYBA5.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-10-07-10-13-15.bpo-25862.FPYBA5.rst
@@ -1,0 +1,2 @@
+Fix assertion failures in the ``tell()`` method of ``io.TextIOWrapper``.
+Patch by Zackery Spytz.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -707,6 +707,8 @@ typedef struct
     PyObject *dict;
 } textio;
 
+static void
+textiowrapper_set_decoded_chars(textio *self, PyObject *chars);
 
 /* A couple of specialized cases in order to bypass the slow incremental
    encoding methods for the most popular encodings. */
@@ -1329,6 +1331,7 @@ textiowrapper_write(textio *self, PyObject *args)
         Py_DECREF(ret);
     }
 
+    textiowrapper_set_decoded_chars(self, NULL);
     Py_CLEAR(self->snapshot);
 
     if (self->decoder) {
@@ -1534,6 +1537,7 @@ textiowrapper_read(textio *self, PyObject *args)
         if (final == NULL)
             goto fail;
 
+        textiowrapper_set_decoded_chars(self, NULL);
         Py_CLEAR(self->snapshot);
         return final;
     }


### PR DESCRIPTION
(cherry picked from commit 23db935bcf258657682e66464bf8512def8af830)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>

<!-- issue-number: bpo-25862 -->
https://bugs.python.org/issue25862
<!-- /issue-number -->
