### PR TITLE
bpo-34003: Use dict instead of OrderedDict in csv.DictReader

### DIFF
--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -150,8 +150,8 @@ The :mod:`csv` module defines the following classes:
                       dialect='excel', *args, **kwds)
 
    Create an object that operates like a regular reader but maps the
-   information in each row to a ``dict`` whose keys are given by the optional
-   *fieldnames* parameter.
+   information in each row to a :class:`dict` whose keys are given by the
+   optional *fieldnames* parameter.
 
    The *fieldnames* parameter is a :term:`sequence`.  If *fieldnames* is
    omitted, the values in the first row of file *f* will be used as the

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -150,12 +150,12 @@ The :mod:`csv` module defines the following classes:
                       dialect='excel', *args, **kwds)
 
    Create an object that operates like a regular reader but maps the
-   information in each row to an :mod:`OrderedDict <collections.OrderedDict>`
-   whose keys are given by the optional *fieldnames* parameter.
+   information in each row to a ``dict`` whose keys are given by the optional
+   *fieldnames* parameter.
 
    The *fieldnames* parameter is a :term:`sequence`.  If *fieldnames* is
    omitted, the values in the first row of file *f* will be used as the
-   fieldnames.  Regardless of how the fieldnames are determined, the ordered
+   fieldnames.  Regardless of how the fieldnames are determined, the
    dictionary preserves their original ordering.
 
    If a row has more fields than fieldnames, the remaining data is put in a
@@ -166,8 +166,8 @@ The :mod:`csv` module defines the following classes:
    All other optional or keyword arguments are passed to the underlying
    :class:`reader` instance.
 
-   .. versionchanged:: 3.6
-      Returned rows are now of type :class:`OrderedDict`.
+   .. versionchanged:: 3.8
+      Returned rows are now of type :class:`dict`.
 
    A short usage example::
 
@@ -181,7 +181,7 @@ The :mod:`csv` module defines the following classes:
        John Cleese
 
        >>> print(row)
-       OrderedDict([('first_name', 'John'), ('last_name', 'Cleese')])
+       {'first_name': 'John', 'last_name': 'Cleese'}
 
 
 .. class:: DictWriter(f, fieldnames, restval='', extrasaction='raise', \

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -147,7 +147,7 @@ class DictWriter:
             wrong_fields = rowdict.keys() - self.fieldnames
             if wrong_fields:
                 raise ValueError("dict contains fields not in fieldnames: "
-                                 + ", ".join(repr(x) for x in wrong_fields))
+                                 + ", ".join([repr(x) for x in wrong_fields]))
         return (rowdict.get(key, self.restval) for key in self.fieldnames)
 
     def writerow(self, rowdict):

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -11,7 +11,6 @@ from _csv import Error, __version__, writer, reader, register_dialect, \
                  __doc__
 from _csv import Dialect as _Dialect
 
-from collections import OrderedDict
 from io import StringIO
 
 __all__ = ["QUOTE_MINIMAL", "QUOTE_ALL", "QUOTE_NONNUMERIC", "QUOTE_NONE",
@@ -117,7 +116,7 @@ class DictReader:
         # values
         while row == []:
             row = next(self.reader)
-        d = OrderedDict(zip(self.fieldnames, row))
+        d = dict(zip(self.fieldnames, row))
         lf = len(self.fieldnames)
         lr = len(row)
         if lf < lr:
@@ -148,7 +147,7 @@ class DictWriter:
             wrong_fields = rowdict.keys() - self.fieldnames
             if wrong_fields:
                 raise ValueError("dict contains fields not in fieldnames: "
-                                 + ", ".join([repr(x) for x in wrong_fields]))
+                                 + ", ".join(repr(x) for x in wrong_fields))
         return (rowdict.get(key, self.restval) for key in self.fieldnames)
 
     def writerow(self, rowdict):

--- a/Misc/NEWS.d/next/Library/2018-06-29-13-05-01.bpo-34003.Iu831h.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-29-13-05-01.bpo-34003.Iu831h.rst
@@ -1,0 +1,2 @@
+csv.DictReader now creates dicts instead of OrderedDicts. Patch by Michael
+Selik.


### PR DESCRIPTION
DictReader can now use basic dicts instead of OrderedDict, as of version
3.7's change to specify that dict maintains keys in insertion order.
This will be more efficient and more pleasant to read at the interactive
prompt.

I also changed a list comprehension to a generator expression inside of
a ``", ".join()`` to avoid the unnecessary list construction.

<!-- issue-number: bpo-34003 -->
https://bugs.python.org/issue34003
<!-- /issue-number -->
