### PR TITLE
[2.7] bpo-33974: Fix passing special characters to ttk widgets. (GH-7986)

### DIFF
--- a/Lib/lib-tk/Tkinter.py
+++ b/Lib/lib-tk/Tkinter.py
@@ -71,7 +71,7 @@ def _stringify(value):
     if isinstance(value, (list, tuple)):
         if len(value) == 1:
             value = _stringify(value[0])
-            if value[0] == '{':
+            if _magic_re.search(value):
                 value = '{%s}' % value
         else:
             value = '{%s}' % _join(value)
@@ -85,7 +85,10 @@ def _stringify(value):
         elif _magic_re.search(value):
             # add '\' before special characters and spaces
             value = _magic_re.sub(r'\\\1', value)
+            value = value.replace('\n', r'\n')
             value = _space_re.sub(r'\\\1', value)
+            if value[0] == '"':
+                value = '\\' + value
         elif value[0] == '"' or _space_re.search(value):
             value = '{%s}' % value
     return value

--- a/Lib/test/test_tcl.py
+++ b/Lib/test/test_tcl.py
@@ -661,6 +661,43 @@ class TclTest(unittest.TestCase):
                 expected = {'a': (1, 2, 3), 'something': 'foo', 'status': ''}
             self.assertEqual(splitdict(tcl, arg), expected)
 
+    def test_join(self):
+        join = tkinter._join
+        tcl = self.interp.tk
+        def unpack(s):
+            return tcl.call('lindex', s, 0)
+        def check(value):
+            self.assertEqual(unpack(join([value])), value)
+            self.assertEqual(unpack(join([value, 0])), value)
+            self.assertEqual(unpack(unpack(join([[value]]))), value)
+            self.assertEqual(unpack(unpack(join([[value, 0]]))), value)
+            self.assertEqual(unpack(unpack(join([[value], 0]))), value)
+            self.assertEqual(unpack(unpack(join([[value, 0], 0]))), value)
+        check('')
+        check('spam')
+        check('sp am')
+        check('sp\tam')
+        check('sp\nam')
+        check(' \t\n')
+        check('{spam}')
+        check('{sp am}')
+        check('"spam"')
+        check('"sp am"')
+        check('{"spam"}')
+        check('"{spam}"')
+        check('sp\\am')
+        check('"sp\\am"')
+        check('"{}" "{}"')
+        check('"\\')
+        check('"{')
+        check('"}')
+        check('\n\\')
+        check('\n{')
+        check('\n}')
+        check('\\\n')
+        check('{\n')
+        check('}\n')
+
 
 character_size = 4 if sys.maxunicode > 0xFFFF else 2
 

--- a/Misc/NEWS.d/next/Library/2018-06-28-14-56-44.bpo-33974.SA8nNP.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-28-14-56-44.bpo-33974.SA8nNP.rst
@@ -1,0 +1,3 @@
+Fixed passing lists and tuples of strings containing special characters
+``"``, ``\``, ``{``, ``}`` and ``\n`` as options to :mod:`~tkinter.ttk`
+widgets.


### PR DESCRIPTION
Fix passing lists and tuples of strings containing special characters
'"', '\\', '{', '}' and '\n' as options to tkinter.ttk widgets.
(cherry picked from commit 5bb5bbfca847524bab5f2368bdb48eedf5dba74f)


<!-- issue-number: bpo-33974 -->
https://bugs.python.org/issue33974
<!-- /issue-number -->
