### PR TITLE
bpo-34014: Added support of contextvars for BaseEventLoop.run_in_executor

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -744,12 +744,10 @@ class BaseEventLoop(events.AbstractEventLoop):
             context = contextvars.copy_context()
 
         if args:
-            fn = functools.partial(func, *args)
-        else:
-            fn = func
+            func = functools.partial(func, *args)
 
         return futures.wrap_future(
-            executor.submit(context.run, fn), loop=self)
+            executor.submit(context.run, func), loop=self)
 
     def set_default_executor(self, executor):
         self._default_executor = executor

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -16,6 +16,8 @@ to modify the meaning of the API call itself.
 import collections
 import collections.abc
 import concurrent.futures
+import contextvars
+import functools
 import heapq
 import itertools
 import logging
@@ -728,7 +730,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         self._write_to_self()
         return handle
 
-    def run_in_executor(self, executor, func, *args):
+    def run_in_executor(self, executor, func, *args, context=None):
         self._check_closed()
         if self._debug:
             self._check_callback(func, 'run_in_executor')
@@ -737,8 +739,17 @@ class BaseEventLoop(events.AbstractEventLoop):
             if executor is None:
                 executor = concurrent.futures.ThreadPoolExecutor()
                 self._default_executor = executor
+
+        if context is None:
+            context = contextvars.copy_context()
+
+        if args:
+            fn = functools.partial(func, *args)
+        else:
+            fn = func
+
         return futures.wrap_future(
-            executor.submit(func, *args), loop=self)
+            executor.submit(context.run, fn), loop=self)
 
     def set_default_executor(self, executor):
         self._default_executor = executor

--- a/Misc/NEWS.d/next/Library/2018-07-01-02-37-05.bpo-34014.RfrJGJ.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-01-02-37-05.bpo-34014.RfrJGJ.rst
@@ -1,0 +1,1 @@
+Added support of contextvars for BaseEventLoop.run_in_executor


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

`BaseEventLoop.run_in_executor` accept new keyword-only parameter `context`, which will be propagated to the executor

Added 4 tests for `test_asyncio.test_events.EventLoopTestsMixin` related for `contextvars` module

<!-- issue-number: bpo-34014 -->
https://bugs.python.org/issue34014
<!-- /issue-number -->
