### PR TITLE
Doc: fix ProcessPoolExecutor description

### DIFF
--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -223,7 +223,7 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
    *initializer* is an optional callable that is called at the start of
    each worker process; *initargs* is a tuple of arguments passed to the
    initializer.  Should *initializer* raise an exception, all currently
-   pending jobs will raise a :exc:`~concurrent.futures.thread.BrokenThreadPool`,
+   pending jobs will raise a :exc:`~concurrent.futures.process.BrokenProcessPool`,
    as well any attempt to submit more jobs to the pool.
 
    .. versionchanged:: 3.3

--- a/Doc/library/concurrent.futures.rst
+++ b/Doc/library/concurrent.futures.rst
@@ -139,9 +139,9 @@ And::
 
    *initializer* is an optional callable that is called at the start of
    each worker thread; *initargs* is a tuple of arguments passed to the
-   initializer.  Should *initializer* raise an exception, all currently
-   pending jobs will raise a :exc:`~concurrent.futures.thread.BrokenThreadPool`,
-   as well any attempt to submit more jobs to the pool.
+   initializer.  If *initializer* raises an exception, all currently pending
+   jobs will raise a :exc:`~concurrent.futures.thread.BrokenThreadPool`,
+   as will any attempt to submit more jobs to the pool.
 
    .. versionchanged:: 3.5
       If *max_workers* is ``None`` or
@@ -222,9 +222,9 @@ to a :class:`ProcessPoolExecutor` will result in deadlock.
 
    *initializer* is an optional callable that is called at the start of
    each worker process; *initargs* is a tuple of arguments passed to the
-   initializer.  Should *initializer* raise an exception, all currently
-   pending jobs will raise a :exc:`~concurrent.futures.process.BrokenProcessPool`,
-   as well any attempt to submit more jobs to the pool.
+   initializer.  If *initializer* raises an exception, all currently pending
+   jobs will raise a :exc:`~concurrent.futures.process.BrokenProcessPool`,
+   as will any attempt to submit more jobs to the pool.
 
    .. versionchanged:: 3.3
       When one of the worker processes terminates abruptly, a


### PR DESCRIPTION
This paragraph apparently was copied from `ThreadPoolExecutor` description so it references `BrokenThreadPool` exception instead of `BrokenProcessPool` which is actually being raised in the described situation.

No need to backport because `initializer` for `ProcessPoolExecutor` was added only in Python 3.7.

The CLA has just been signed, the approval is pending.