### PR TITLE
Dataclasses: Fix example on 30.6.8, add method should receive a list rather than an integer.

### DIFF
--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -536,8 +536,8 @@ Mutable default values
 
      o1 = C()
      o2 = C()
-     o1.add(1)
-     o2.add(2)
+     o1.add([1])
+     o2.add([2])
      assert o1.x == [1, 2]
      assert o1.x is o2.x
 

--- a/Doc/library/dataclasses.rst
+++ b/Doc/library/dataclasses.rst
@@ -532,12 +532,12 @@ Mutable default values
      class C:
          x = []
          def add(self, element):
-             self.x += element
+             self.x.append(element)
 
      o1 = C()
      o2 = C()
-     o1.add([1])
-     o2.add([2])
+     o1.add(1)
+     o2.add(2)
      assert o1.x == [1, 2]
      assert o1.x is o2.x
 


### PR DESCRIPTION
Fix example on 30.6.8, add method should receive a list rather than an integer.

Current example gives a TypeError.
```
Traceback (most recent call last):
  File "<input>", line 1, in <module>
    l += 1
TypeError: 'int' object is not iterable
```
