### PR TITLE
bpo-34008: Allow to call Py_Main() after Py_Initialize()

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -238,6 +238,14 @@ class EmbeddingTests(unittest.TestCase):
         self.assertEqual(out, '')
         self.assertEqual(err, '')
 
+    def test_initialize_pymain(self):
+        """
+        bpo-34008: Calling Py_Main() after Py_Initialize() must not fail.
+        """
+        out, err = self.run_embedded_interpreter("initialize_pymain")
+        self.assertEqual(out.rstrip(), "Py_Main() after Py_Initialize: sys.argv=['-c', 'arg2']")
+        self.assertEqual(err, '')
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/C API/2018-07-02-10-58-11.bpo-34008.COewz-.rst
+++ b/Misc/NEWS.d/next/C API/2018-07-02-10-58-11.bpo-34008.COewz-.rst
@@ -1,0 +1,1 @@
+Py_Main() can again be called after Py_Initialize(), as in Python 3.6.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -2144,7 +2144,6 @@ config_init_module_search_paths(_PyCoreConfig *config)
 static _PyInitError
 config_init_path_config(_PyCoreConfig *config)
 {
-    /* FIXME: this method has side effect: modify _Py_path_config */
     _PyInitError err = _PyPathConfig_Init(config);
     if (_Py_INIT_FAILED(err)) {
         return err;

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -279,7 +279,7 @@ static int test_initialize_twice(void)
 static int test_initialize_pymain(void)
 {
     wchar_t *argv[] = {L"PYTHON", L"-c",
-                           L"import sys; print(f'Py_Main() after Py_Initialize: sys.argv={sys.argv}')",
+                       L"import sys; print(f'Py_Main() after Py_Initialize: sys.argv={sys.argv}')",
                        L"arg2"};
     _testembed_Py_Initialize();
 

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -276,6 +276,21 @@ static int test_initialize_twice(void)
     return 0;
 }
 
+static int test_initialize_pymain(void)
+{
+    wchar_t *argv[] = {L"PYTHON", L"-c",
+                           L"import sys; print(f'Py_Main() after Py_Initialize: sys.argv={sys.argv}')",
+                       L"arg2"};
+    _testembed_Py_Initialize();
+
+    /* bpo-34008: Calling Py_Main() after Py_Initialize() must not crash */
+    Py_Main(Py_ARRAY_LENGTH(argv), argv);
+
+    Py_Finalize();
+
+    return 0;
+}
+
 
 /* *********************************************************
  * List of test cases and the function that implements it.
@@ -302,6 +317,7 @@ static struct TestCase TestCases[] = {
     { "pre_initialization_sys_options", test_pre_initialization_sys_options },
     { "bpo20891", test_bpo20891 },
     { "initialize_twice", test_initialize_twice },
+    { "initialize_pymain", test_initialize_pymain },
     { NULL, NULL }
 };
 


### PR DESCRIPTION
Py_Main() can again be called after Py_Initialize(), as in Python 3.6. The new configuration is ignored, except of _PyMainInterpreterConfig.argv which is used to update sys.argv.

<!-- issue-number: bpo-34008 -->
https://bugs.python.org/issue34008
<!-- /issue-number -->
