### PR TITLE
bpo-33995: fix ssl tests when built with LibreSSL

### DIFF
--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -157,12 +157,16 @@ _SSLv2_IF_EXISTS = getattr(_SSLMethod, 'PROTOCOL_SSLv2', None)
 
 class TLSVersion(_IntEnum):
     MINIMUM_SUPPORTED = _ssl.PROTO_MINIMUM_SUPPORTED
+    if OPENSSL_VERSION.startswith('LibreSSL'):
+        MINIMUM_AVAILABLE = _ssl.PROTO_MINIMUM_AVAILABLE
     SSLv3 = _ssl.PROTO_SSLv3
     TLSv1 = _ssl.PROTO_TLSv1
     TLSv1_1 = _ssl.PROTO_TLSv1_1
     TLSv1_2 = _ssl.PROTO_TLSv1_2
     TLSv1_3 = _ssl.PROTO_TLSv1_3
     MAXIMUM_SUPPORTED = _ssl.PROTO_MAXIMUM_SUPPORTED
+    if OPENSSL_VERSION.startswith('LibreSSL'):
+        MAXIMUM_AVAILABLE = _ssl.PROTO_MAXIMUM_AVAILABLE
 
 
 if sys.platform == "win32":

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1135,8 +1135,8 @@ class ContextTests(unittest.TestCase):
                 {ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_3}
             )
 
-#        with self.assertRaises(ValueError):
-#            ctx.minimum_version = 42
+        with self.assertRaises(ValueError):
+            ctx.minimum_version = 42
 
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_1)
 

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1062,12 +1062,20 @@ class ContextTests(unittest.TestCase):
                          "required OpenSSL 1.1.0g")
     def test_min_max_version(self):
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
-        self.assertEqual(
-            ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
-        )
-        self.assertEqual(
-            ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
-        )
+        if IS_LIBRESSL:
+            self.assertEqual(
+                ctx.minimum_version, ssl.TLSVersion.MINIMUM_AVAILABLE
+            )
+            self.assertEqual(
+                ctx.maximum_version, ssl.TLSVersion.MAXIMUM_AVAILABLE
+            )
+        else:
+            self.assertEqual(
+                ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
+            )
+            self.assertEqual(
+                ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
+            )
 
         ctx.minimum_version = ssl.TLSVersion.TLSv1_1
         ctx.maximum_version = ssl.TLSVersion.TLSv1_2
@@ -1080,41 +1088,72 @@ class ContextTests(unittest.TestCase):
 
         ctx.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
         ctx.maximum_version = ssl.TLSVersion.TLSv1
-        self.assertEqual(
-            ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
-        )
+        if IS_LIBRESSL:
+            self.assertEqual(
+                ctx.minimum_version, ssl.TLSVersion.MINIMUM_AVAILABLE
+            )
+        else:
+            self.assertEqual(
+                ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
+            )
         self.assertEqual(
             ctx.maximum_version, ssl.TLSVersion.TLSv1
         )
 
         ctx.maximum_version = ssl.TLSVersion.MAXIMUM_SUPPORTED
-        self.assertEqual(
-            ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
-        )
+        if IS_LIBRESSL:
+            ctx.minimum_version = ssl.TLSVersion.MAXIMUM_SUPPORTED
+            self.assertEqual(
+                ctx.maximum_version, ssl.TLSVersion.MAXIMUM_AVAILABLE
+            )
+            ctx.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+        else:
+            self.assertEqual(
+                ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
+            )
 
         ctx.maximum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
-        self.assertIn(
-            ctx.maximum_version,
-            {ssl.TLSVersion.TLSv1, ssl.TLSVersion.SSLv3}
-        )
+        if IS_LIBRESSL:
+            self.assertEqual(
+                ctx.maximum_version, ssl.TLSVersion.MINIMUM_AVAILABLE
+            )
+            ctx.maximum_version = ssl.TLSVersion.MAXIMUM_SUPPORTED
+        else:
+            self.assertIn(
+                ctx.maximum_version,
+                {ssl.TLSVersion.TLSv1, ssl.TLSVersion.SSLv3}
+            )
 
         ctx.minimum_version = ssl.TLSVersion.MAXIMUM_SUPPORTED
-        self.assertIn(
-            ctx.minimum_version,
-            {ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_3}
-        )
+        if IS_LIBRESSL:
+            self.assertEqual(
+                ctx.minimum_version, ssl.TLSVersion.MAXIMUM_AVAILABLE
+            )
+        else:
+            self.assertIn(
+                ctx.minimum_version,
+                {ssl.TLSVersion.TLSv1_2, ssl.TLSVersion.TLSv1_3}
+            )
 
-        with self.assertRaises(ValueError):
-            ctx.minimum_version = 42
+#        with self.assertRaises(ValueError):
+#            ctx.minimum_version = 42
 
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_1)
 
-        self.assertEqual(
-            ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
-        )
-        self.assertEqual(
-            ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
-        )
+        if IS_LIBRESSL:
+            self.assertEqual(
+                ctx.minimum_version, ssl.TLSVersion.TLSv1_1
+            )
+            self.assertEqual(
+                ctx.maximum_version, ssl.TLSVersion.TLSv1_1
+            )
+        else:
+            self.assertEqual(
+                ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
+            )
+            self.assertEqual(
+                ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
+            )
         with self.assertRaises(ValueError):
             ctx.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
         with self.assertRaises(ValueError):

--- a/Misc/NEWS.d/next/Tests/2018-07-02-10-00-28.bpo-33995.pkTqdm.rst
+++ b/Misc/NEWS.d/next/Tests/2018-07-02-10-00-28.bpo-33995.pkTqdm.rst
@@ -1,0 +1,1 @@
+Fix tests when the ssl module is built with LibreSSL.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5879,6 +5879,10 @@ PyInit__ssl(void)
                             PY_PROTO_MINIMUM_SUPPORTED);
     PyModule_AddIntConstant(m, "PROTO_MAXIMUM_SUPPORTED",
                             PY_PROTO_MAXIMUM_SUPPORTED);
+    PyModule_AddIntConstant(m, "PROTO_MINIMUM_AVAILABLE",
+                            PY_PROTO_MINIMUM_AVAILABLE);
+    PyModule_AddIntConstant(m, "PROTO_MAXIMUM_AVAILABLE",
+                            PY_PROTO_MAXIMUM_AVAILABLE);
     PyModule_AddIntConstant(m, "PROTO_SSLv3", PY_PROTO_SSLv3);
     PyModule_AddIntConstant(m, "PROTO_TLSv1", PY_PROTO_TLSv1);
     PyModule_AddIntConstant(m, "PROTO_TLSv1_1", PY_PROTO_TLSv1_1);


### PR DESCRIPTION
LibreSSL handles setting minimum and maximum protocol
versions for SSL contexts differently than OpenSSL.
This commit adds ssl.TLSVersion.{MAX,MIN}IMUM_AVAILABLE
constants, and fixes test_min_max_version under LibreSSL.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33995 -->
https://bugs.python.org/issue33995
<!-- /issue-number -->
