### PR TITLE
bpo-31516: Skip test_main_thread_during_shutdown() with COUNT_ALLOCS builds

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -546,6 +546,7 @@ class ThreadTests(BaseTestCase):
         self.assertEqual(err, b"")
         self.assertEqual(data, "Thread-1\nTrue\nTrue\n")
 
+    @requires_type_collecting
     def test_main_thread_during_shutdown(self):
         # bpo-31516: current_thread() should still point to the main thread
         # at shutdown


### PR DESCRIPTION
`test_main_thread_during_shutdown()` (in test_threading) fails when CPython is built with `COUNT_ALLOCS`. This test should have the `requires_type_collecting` decorator.

<!-- issue-number: bpo-31516 -->
https://bugs.python.org/issue31516
<!-- /issue-number -->
