### PR TITLE
bpo-34001: Change handling of SSL protocol bounds with LibreSSL

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1097,6 +1097,7 @@ class ContextTests(unittest.TestCase):
             ctx.maximum_version,
             {ssl.TLSVersion.TLSv1, ssl.TLSVersion.SSLv3}
         )
+        ctx.maximum_version = ssl.TLSVersion.MAXIMUM_SUPPORTED
 
         ctx.minimum_version = ssl.TLSVersion.MAXIMUM_SUPPORTED
         self.assertIn(
@@ -3572,8 +3573,8 @@ class ThreadedTests(unittest.TestCase):
                 self.assertEqual(s.version(), 'TLSv1.1')
 
         # client 1.0, server 1.2 (mismatch)
-        server_context.minimum_version = ssl.TLSVersion.TLSv1_2
         server_context.maximum_version = ssl.TLSVersion.TLSv1_2
+        server_context.minimum_version = ssl.TLSVersion.TLSv1_2
         client_context.minimum_version = ssl.TLSVersion.TLSv1
         client_context.maximum_version = ssl.TLSVersion.TLSv1
         with ThreadedEchoServer(context=server_context) as server:

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -1106,6 +1106,23 @@ class ContextTests(unittest.TestCase):
         )
 
         with self.assertRaises(ValueError):
+            ctx.maximum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+
+        self.assertEqual(
+            ctx.maximum_version, ssl.TLSVersion.MAXIMUM_SUPPORTED
+        )
+
+        ctx.minimum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+        ctx.maximum_version = ssl.TLSVersion.MINIMUM_SUPPORTED
+
+        with self.assertRaises(ValueError):
+            ctx.minimum_version = ssl.TLSVersion.MAXIMUM_SUPPORTED
+
+        self.assertEqual(
+            ctx.minimum_version, ssl.TLSVersion.MINIMUM_SUPPORTED
+        )
+
+        with self.assertRaises(ValueError):
             ctx.minimum_version = 42
 
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLSv1_1)

--- a/Misc/NEWS.d/next/Library/2018-07-02-18-22-19.bpo-34001.e5KBtP.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-02-18-22-19.bpo-34001.e5KBtP.rst
@@ -1,0 +1,2 @@
+Add checks for protocol version bounds when the ssl module is built using
+LibreSSL.


### PR DESCRIPTION
There are two substantial changes made in this pull request:

1. Under LibreSSL, bounds cannot be set such that minimum_version > maximum_version. 4254483 changes the behavior of `set_min_max_proto_version` on **all** builds to reflect that behavior, and introduces a new error message to indicate the issue.
2. LibreSSL is more permissive than OpenSSL with regard to unknown protocol versions. Namely, LibreSSL allows the setting of unknown protocol versions, rounding to the nearest known protocol version (e.g., 42 -> 769 [TLSv1]), whereas OpenSSL does not. 8352fd3 implements a check to ensure that the result of a set operation is the expected value, and forbids/undoes the change otherwise.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title
It should be in the following format:
```
bpo-NNNN: Summary of the changes made
```
Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.
Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.
-->


<!-- issue-number: bpo-34001 -->
https://bugs.python.org/issue34001
<!-- /issue-number -->
