### PR TITLE
bpo-34027: Only use util.h on macOS, fixes build errors for openpty/forkpty

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6176,20 +6176,22 @@ error:
 #endif
 
 #if defined(HAVE_OPENPTY) || defined(HAVE_FORKPTY) || defined(HAVE_DEV_PTMX)
+#ifdef __APPLE__
+#ifdef HAVE_UTIL_H
+#include <util.h>
+#endif /* HAVE_UTIL_H */
+#else
 #ifdef HAVE_PTY_H
 #include <pty.h>
 #else
 #ifdef HAVE_LIBUTIL_H
 #include <libutil.h>
-#else
-#ifdef HAVE_UTIL_H
-#include <util.h>
-#endif /* HAVE_UTIL_H */
 #endif /* HAVE_LIBUTIL_H */
 #endif /* HAVE_PTY_H */
 #ifdef HAVE_STROPTS_H
 #include <stropts.h>
 #endif
+#endif /* __APPLE__ */
 #endif /* defined(HAVE_OPENPTY) || defined(HAVE_FORKPTY) || defined(HAVE_DEV_PTMX) */
 
 


### PR DESCRIPTION
This changes the condition to only use <util.h> on macOS, instead of going down an else chain based on other things not being available.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-34027: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: bpo-34027 -->
https://bugs.python.org/issue34027
<!-- /issue-number -->
