### PR TITLE
bpo-34033: distutils: byte_compile() sort files

### DIFF
--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -416,7 +416,7 @@ byte_compile(files, optimize=%r, force=%r,
     else:
         from py_compile import compile
 
-        for file in py_files:
+        for file in sorted(py_files):
             if file[-3:] != ".py":
                 # This lets us be lazy and not filter filenames in
                 # the "install_lib" command.

--- a/Misc/NEWS.d/next/Library/2018-07-03-09-40-44.bpo-29708.vs6fdO.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-03-09-40-44.bpo-29708.vs6fdO.rst
@@ -1,0 +1,2 @@
+distutils: To get reproducible builds, byte_compile() of distutils.util now
+sorts filenames. Patch from OpenSUSE by Bernhard M. Wiedemann.


### PR DESCRIPTION
To get reproducible builds, byte_compile() of distutils.util now
sorts filenames.

Patch coming from OpenSUSE: distutils-reproducible-compile.patch.

<!-- issue-number: bpo-34033 -->
https://bugs.python.org/issue34033
<!-- /issue-number -->
