### PR TITLE
bpo-33735: Fix test_multiprocessing random failure

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2351,10 +2351,10 @@ class _TestPool(BaseTestCase):
         self.assertRaises(SayWhenError, it.__next__)
 
     def test_imap_unordered(self):
-        it = self.pool.imap_unordered(sqr, list(range(1000)))
-        self.assertEqual(sorted(it), list(map(sqr, list(range(1000)))))
+        it = self.pool.imap_unordered(sqr, list(range(10)))
+        self.assertEqual(sorted(it), list(map(sqr, list(range(10)))))
 
-        it = self.pool.imap_unordered(sqr, list(range(1000)), chunksize=53)
+        it = self.pool.imap_unordered(sqr, list(range(1000)), chunksize=100)
         self.assertEqual(sorted(it), list(map(sqr, list(range(1000)))))
 
     def test_imap_unordered_handle_iterable_exception(self):


### PR DESCRIPTION
When hunting for memory leaks using -R 3:3, test_imap_unordered() of
test_multiprocessing leaks randomly a few memory blocks. It is a
false alarm: when testing using -R 3:20 for example, no leak is
detected.

Modify test_imap_unordered() to be closer to test_imap():

* Only test 10 numbers instead of 100: it's a pool of 4 processes, so
  10 is enough to test at least one number per process
* Use chunksize=100 instead of chunksize=53 to mimick test_imap()

<!-- issue-number: bpo-33735 -->
https://bugs.python.org/issue33735
<!-- /issue-number -->
