### PR TITLE
[2.7] bpo-33735: Fix test_multiprocessing random failure (GH-8059)

### DIFF
--- a/Lib/test/test_multiprocessing.py
+++ b/Lib/test/test_multiprocessing.py
@@ -1260,10 +1260,10 @@ class _TestPool(BaseTestCase):
         self.assertRaises(SayWhenError, it.next)
 
     def test_imap_unordered(self):
-        it = self.pool.imap_unordered(sqr, range(1000))
-        self.assertEqual(sorted(it), map(sqr, range(1000)))
+        it = self.pool.imap_unordered(sqr, range(100))
+        self.assertEqual(sorted(it), map(sqr, range(100)))
 
-        it = self.pool.imap_unordered(sqr, range(1000), chunksize=53)
+        it = self.pool.imap_unordered(sqr, range(1000), chunksize=100)
         self.assertEqual(sorted(it), map(sqr, range(1000)))
 
     def test_imap_unordered_handle_iterable_exception(self):


### PR DESCRIPTION
When hunting memory leaks using -R 3:3, test_imap_unordered() of
test_multiprocessing leaks randomly a few memory blocks. It is a
false alarm: when testing using -R 3:20 for example, no leak is
detected.

Modify test_imap_unordered() to be closer to test_imap():

* Only test 10 numbers instead of 1000: it's a pool of 4 processes, so
  10 is enough to test at least one number per process
* Use chunksize=100 instead of chunksize=53 to mimick test_imap()

(cherry picked from commit 23401fb960bb94e6ea62d2999527968d53d3fc65)

<!-- issue-number: bpo-33735 -->
https://bugs.python.org/issue33735
<!-- /issue-number -->
