### PR TITLE
Doc: Stackless Python wiki moved to github.

### DIFF
--- a/Doc/faq/design.rst
+++ b/Doc/faq/design.rst
@@ -348,7 +348,7 @@ each Python stack frame.  Also, extensions can call back into Python at almost
 random moments.  Therefore, a complete threads implementation requires thread
 support for C.
 
-Answer 2: Fortunately, there is `Stackless Python <https://bitbucket.org/stackless-dev/stackless/wiki/Home>`_,
+Answer 2: Fortunately, there is `Stackless Python <https://github.com/stackless-dev/stackless/wiki>`_,
 which has a completely redesigned interpreter loop that avoids the C stack.
 
 


### PR DESCRIPTION
(backport to 3.6 not straightforward as https://github.com/python/cpython/pull/4674 has not been backported to 3.6)