### PR TITLE
DOC: add time.sleep for mulprocessing example

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -246,11 +246,13 @@ Synchronization between processes
 primitives from :mod:`threading`.  For instance one can use a lock to ensure
 that only one process prints to standard output at a time::
 
+   import time
    from multiprocessing import Process, Lock
 
    def f(l, i):
        l.acquire()
        try:
+           time.sleep(0.1)
            print('hello world', i)
        finally:
            l.release()


### PR DESCRIPTION
The original example 

```
from multiprocessing import Process, Lock

def f(l, i):
    l.acquire()
    try:
        print('hello world', i)
    finally:
        l.release()

if __name__ == '__main__':
    lock = Lock()

    for num in range(10):
        Process(target=f, args=(lock, num)).start()
```


didn't really show the different between add a lock or not. It will be much better after add time.sleep(0.1) here for reader. (I signed the CLA now)