### PR TITLE
bpo-34040, multiprocessing: Fix test_forkserver_sigkill()

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -651,13 +651,17 @@ class _TestProcess(BaseTestCase):
         from multiprocessing.forkserver import _forkserver
         _forkserver.ensure_running()
 
+        # First process sleeps 500 ms
+        delay = 0.5
+
         evt = self.Event()
-        proc = self.Process(target=self._sleep_and_set_event, args=(evt, 1.0))
+        proc = self.Process(target=self._sleep_and_set_event, args=(evt, delay))
         proc.start()
 
         pid = _forkserver._forkserver_pid
         os.kill(pid, signum)
-        time.sleep(1.0)  # give it time to die
+        # give time to the fork server to die and time to proc to complete
+        time.sleep(delay * 2.0)
 
         evt2 = self.Event()
         proc2 = self.Process(target=self._sleep_and_set_event, args=(evt2,))


### PR DESCRIPTION
Fix test_forkserver_sigkill() of test_multiprocessing_forkserver:
give more time to the first child process to complete, double of its
sleep.

Reduce also the sleep from 1000 ms to 500 ms, to not change the total
duration of the test.

<!-- issue-number: bpo-34040 -->
https://bugs.python.org/issue34040
<!-- /issue-number -->
