### PR TITLE
bpo-34041: Added *deterministic* parameter to sqlite3.Connection.create_function().

### DIFF
--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -346,13 +346,14 @@ Connection Objects
       called as the SQL function. If *deterministic* is true, the created function
       is marked as `deterministic <https://sqlite.org/deterministic.html>`_, which
       allows SQLite to perform additional optimizations. This flag is supported by
-      SQLite 3.8.3 or higher and has no effect on older versions.
+      SQLite 3.8.3 or higher, ``sqlite3.NotSupportedError`` will be raised if used
+      with older versions.
 
       The function can return any of the types supported by SQLite: bytes, str, int,
       float and ``None``.
 
       .. versionchanged:: 3.8
-        The *deterministic* parameter was added.
+         The *deterministic* parameter was added.
 
       Example:
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -337,7 +337,7 @@ Connection Objects
       :meth:`~Cursor.executescript` method with the given *sql_script*, and
       returns the cursor.
 
-   .. method:: create_function(name, num_params, func, deterministic=False)
+   .. method:: create_function(name, num_params, func, *, deterministic=False)
 
       Creates a user-defined function that you can later use from within SQL
       statements under the function name *name*. *num_params* is the number of

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -337,16 +337,23 @@ Connection Objects
       :meth:`~Cursor.executescript` method with the given *sql_script*, and
       returns the cursor.
 
-   .. method:: create_function(name, num_params, func)
+   .. method:: create_function(name, num_params, func, deterministic=False)
 
       Creates a user-defined function that you can later use from within SQL
       statements under the function name *name*. *num_params* is the number of
       parameters the function accepts (if *num_params* is -1, the function may
       take any number of arguments), and *func* is a Python callable that is
-      called as the SQL function.
+      called as the SQL function. If *deterministic* is true, the created function
+      is marked as `deterministic <https://sqlite.org/deterministic.html>`_, which
+      allows SQLite to perform additional optimizations. This flag is supported by
+      SQLite 3.8.3 or higher and has no effect on older versions.
 
       The function can return any of the types supported by SQLite: bytes, str, int,
       float and ``None``.
+
+      .. versionchanged:: 3.8
+
+        The *deterministic* parameter was added.
 
       Example:
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -352,7 +352,6 @@ Connection Objects
       float and ``None``.
 
       .. versionchanged:: 3.8
-
         The *deterministic* parameter was added.
 
       Example:

--- a/Lib/sqlite3/test/userfunctions.py
+++ b/Lib/sqlite3/test/userfunctions.py
@@ -290,6 +290,10 @@ class FunctionTests(unittest.TestCase):
         with self.assertRaises(sqlite.NotSupportedError):
             self.con.create_function("deterministic", 0, int, deterministic=True)
 
+    def CheckFuncDeterministicKwOnly(self):
+         with self.assertRaises(TypeError):
+            self.con.create_function("deterministic", 0, int, True)
+
 
 class AggregateTests(unittest.TestCase):
     def setUp(self):

--- a/Lib/sqlite3/test/userfunctions.py
+++ b/Lib/sqlite3/test/userfunctions.py
@@ -280,9 +280,15 @@ class FunctionTests(unittest.TestCase):
     def CheckFuncDeterministic(self):
         mock = unittest.mock.Mock()
         mock.return_value = None
+        query = "select deterministic() = deterministic()"
+
+        self.con.create_function("deterministic", 0, mock, deterministic=False)
+        self.con.execute(query)
+        self.assertEqual(mock.call_count, 2)
+
+        mock.reset_mock()
         self.con.create_function("deterministic", 0, mock, deterministic=True)
-        cur = self.con.cursor()
-        cur.execute("select deterministic() = deterministic()")
+        self.con.execute(query)
         self.assertEqual(mock.call_count, 1)
 
     @unittest.skipIf(sqlite.sqlite_version_info >= (3, 8, 3), "SQLite < 3.8.3 needed")

--- a/Lib/sqlite3/test/userfunctions.py
+++ b/Lib/sqlite3/test/userfunctions.py
@@ -23,6 +23,7 @@
 # 3. This notice may not be removed or altered from any source distribution.
 
 import unittest
+import unittest.mock
 import sqlite3 as sqlite
 
 def func_returntext():
@@ -274,6 +275,14 @@ class FunctionTests(unittest.TestCase):
         cur.execute("select spam(?, ?)", (1, 2))
         val = cur.fetchone()[0]
         self.assertEqual(val, 2)
+
+    def CheckFuncDeterministic(self):
+        mock = unittest.mock.Mock()
+        mock.return_value = None
+        self.con.create_function("deterministic", 0, mock, deterministic=True)
+        cur = self.con.cursor()
+        cur.execute("select deterministic(), deterministic()")
+        self.assertEqual(mock.call_count, 2 if sqlite.sqlite_version_info < (3, 8, 3) else 1)
 
 
 class AggregateTests(unittest.TestCase):

--- a/Lib/sqlite3/test/userfunctions.py
+++ b/Lib/sqlite3/test/userfunctions.py
@@ -291,7 +291,7 @@ class FunctionTests(unittest.TestCase):
             self.con.create_function("deterministic", 0, int, deterministic=True)
 
     def CheckFuncDeterministicKwOnly(self):
-         with self.assertRaises(TypeError):
+        with self.assertRaises(TypeError):
             self.con.create_function("deterministic", 0, int, True)
 
 

--- a/Lib/sqlite3/test/userfunctions.py
+++ b/Lib/sqlite3/test/userfunctions.py
@@ -281,8 +281,11 @@ class FunctionTests(unittest.TestCase):
         mock.return_value = None
         self.con.create_function("deterministic", 0, mock, deterministic=True)
         cur = self.con.cursor()
-        cur.execute("select deterministic(), deterministic()")
-        self.assertEqual(mock.call_count, 2 if sqlite.sqlite_version_info < (3, 8, 3) else 1)
+        cur.execute("select deterministic() = deterministic()")
+        self.assertEqual(
+            mock.call_count,
+            2 if sqlite.sqlite_version_info < (3, 8, 3) else 1,
+        )
 
 
 class AggregateTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-07-04-21-24-58.bpo-34041.aKk8t5.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-04-21-24-58.bpo-34041.aKk8t5.rst
@@ -1,2 +1,0 @@
-Add the parameter *deterministic* to the
-sqlite3.Connection.create_function().

--- a/Misc/NEWS.d/next/Library/2018-07-04-21-24-58.bpo-34041.aKk8t5.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-04-21-24-58.bpo-34041.aKk8t5.rst
@@ -1,0 +1,2 @@
+Add the parameter *deterministic* to the
+sqlite3.Connection.create_function().

--- a/Misc/NEWS.d/next/Library/2018-07-06-15-06-32.bpo-34041.0zrKLh.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-06-15-06-32.bpo-34041.0zrKLh.rst
@@ -1,0 +1,2 @@
+Add the parameter *deterministic* to the
+:meth:`sqlite3.Connection.create_function` method. Patch by Sergey Fedoseev.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -827,7 +827,7 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
         return NULL;
     }
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "siO|p", kwlist,
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "siO|$p", kwlist,
                                      &name, &narg, &func, &deterministic))
     {
         return NULL;

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -817,7 +817,7 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
     int narg;
     int rc;
     int deterministic = 0;
-    int eTextRep = SQLITE_UTF8;
+    int flags = SQLITE_UTF8;
 
     if (!pysqlite_check_thread(self) || !pysqlite_check_connection(self)) {
         return NULL;
@@ -841,7 +841,7 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
             return NULL;
         }
         else {
-            eTextRep |= SQLITE_DETERMINISTIC;
+            flags |= SQLITE_DETERMINISTIC;
         }
 #endif
     }
@@ -849,7 +849,7 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
     rc = sqlite3_create_function(self->db,
                                  name,
                                  narg,
-                                 eTextRep,
+                                 flags,
                                  (void*)func,
                                  _pysqlite_func_callback,
                                  NULL,

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -833,7 +833,7 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
         return NULL;
     }
 
-    if (deterministic) {
+    if (deterministic && sqlite3_libversion_number() >= 3008003) {
         eTextRep |= SQLITE_DETERMINISTIC;
     }
 

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -832,17 +832,15 @@ PyObject* pysqlite_connection_create_function(pysqlite_Connection* self, PyObjec
     if (deterministic) {
 #if SQLITE_VERSION_NUMBER < 3008003
         PyErr_SetString(pysqlite_NotSupportedError,
-                        "should be built with SQLite 3.8.3 or higher");
+                        "deterministic=True requires SQLite 3.8.3 or higher");
         return NULL;
 #else
         if (sqlite3_libversion_number() < 3008003) {
             PyErr_SetString(pysqlite_NotSupportedError,
-                            "requires SQLite 3.8.3 or higher");
+                            "deterministic=True requires SQLite 3.8.3 or higher");
             return NULL;
         }
-        else {
-            flags |= SQLITE_DETERMINISTIC;
-        }
+        flags |= SQLITE_DETERMINISTIC;
 #endif
     }
 


### PR DESCRIPTION


<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34041 -->
https://bugs.python.org/issue34041
<!-- /issue-number -->
