### PR TITLE
bpo-34043: Optimize tarfile uncompress performance

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -532,7 +532,8 @@ class _Stream:
             # Skip underlaying buffer to avoid unaligned double
             # buffering.
             if self.buf:
-                buf, self.buf = self.buf, b""
+                buf = self.buf
+                self.buf = b""
             else:
                 buf = self.fileobj.read(self.bufsize)
                 if not buf:

--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -529,8 +529,7 @@ class _Stream:
         c = len(self.dbuf)
         t = [self.dbuf]
         while c < size:
-            # Skip underlaying buffer to avoid unaligned double
-            # buffering.
+            # Skip underlying buffer to avoid unaligned double buffering.
             if self.buf:
                 buf = self.buf
                 self.buf = b""

--- a/Misc/NEWS.d/next/Library/2018-07-04-21-14-35.bpo-34043.0YJNq9.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-04-21-14-35.bpo-34043.0YJNq9.rst
@@ -1,0 +1,1 @@
+Optimize tarfile uncompress performance about 15% when gzip is used.


### PR DESCRIPTION
tarfile._Stream has two buffer for compressed and uncompressed data.
Those buffers are not aligned so unnecessary bytes slicing happens
for every reading chunks.

This commit bypass compressed buffering.

In this benchmark [1], user time become 250ms from 300ms.

[1]: https://bugs.python.org/msg320763

<!-- issue-number: bpo-34043 -->
https://bugs.python.org/issue34043
<!-- /issue-number -->
