### PR TITLE
bpo-34044: subprocess.Popen copies startupinfo

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -135,6 +135,21 @@ if _mswindows:
             self.hStdError = hStdError
             self.wShowWindow = wShowWindow
             self.lpAttributeList = lpAttributeList or {"handle_list": []}
+
+        def copy(self):
+            attribute_list = {}
+            for key, value in self.lpAttributeList.items():
+                if key == 'handle_list':
+                    value = list(value)
+                attribute_list[key] = value
+
+            return STARTUPINFO(dwFlags=self.dwFlags,
+                               hStdInput=self.hStdInput,
+                               hStdOutput=self.hStdOutput,
+                               hStdError=self.hStdError,
+                               wShowWindow=self.wShowWindow,
+                               lpAttributeList=attribute_list)
+
 else:
     import _posixsubprocess
     import select
@@ -1102,6 +1117,10 @@ class Popen(object):
             # Process startup details
             if startupinfo is None:
                 startupinfo = STARTUPINFO()
+            else:
+                # bpo-34044: Copy STARTUPINFO since it is modified above,
+                # so the caller can reuse it multiple times.
+                startupinfo = startupinfo.copy()
 
             use_std_handles = -1 not in (p2cread, c2pwrite, errwrite)
             if use_std_handles:

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -137,18 +137,16 @@ if _mswindows:
             self.lpAttributeList = lpAttributeList or {"handle_list": []}
 
         def copy(self):
-            attribute_list = {}
-            for key, value in self.lpAttributeList.items():
-                if key == 'handle_list':
-                    value = list(value)
-                attribute_list[key] = value
+            attr_list = self.lpAttributeList.copy()
+            if 'handle_list' in attr_list:
+                attr_list['handle_list'] = list(attr_list['handle_list'])
 
             return STARTUPINFO(dwFlags=self.dwFlags,
                                hStdInput=self.hStdInput,
                                hStdOutput=self.hStdOutput,
                                hStdError=self.hStdError,
                                wShowWindow=self.wShowWindow,
-                               lpAttributeList=attribute_list)
+                               lpAttributeList=attr_list)
 
 else:
     import _posixsubprocess

--- a/Misc/NEWS.d/next/Library/2018-07-04-17-14-26.bpo-34044.KWAu4y.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-04-17-14-26.bpo-34044.KWAu4y.rst
@@ -1,0 +1,3 @@
+``subprocess.Popen`` now copies the *startupinfo* argument to leave it
+unchanged: it will modify the copy, so that the same ``STARTUPINFO`` object can
+be used multiple times.


### PR DESCRIPTION
subprocess.Popen now copy the startupinfo argument to leave it
unchanged: modify the copy, so the same startupinfo object can be
used multiple times.

<!-- issue-number: bpo-34044 -->
https://bugs.python.org/issue34044
<!-- /issue-number -->
