### PR TITLE
bpo-34031: fix incorrect usage of self.fail in 2 unittests

### DIFF
--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -241,8 +241,7 @@ class OtherFileTests:
         # Test for appropriate errors mixing read* and iteration
         for methodname, args in methods:
             f = self.open(TESTFN, 'rb')
-            if next(f) != filler:
-                self.fail("Broken testfile")
+            self.assertEqual(next(f), filler)
             meth = getattr(f, methodname)
             meth(*args)  # This simply shouldn't fail
             f.close()

--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -242,7 +242,7 @@ class OtherFileTests:
         for methodname, args in methods:
             f = self.open(TESTFN, 'rb')
             if next(f) != filler:
-                self.fail, "Broken testfile"
+                self.fail("Broken testfile")
             meth = getattr(f, methodname)
             meth(*args)  # This simply shouldn't fail
             f.close()

--- a/Lib/test/test_urllib2_localnet.py
+++ b/Lib/test/test_urllib2_localnet.py
@@ -306,7 +306,7 @@ class BasicAuthTests(unittest.TestCase):
         try:
             self.assertTrue(urllib.request.urlopen(self.server_url))
         except urllib.error.HTTPError:
-            self.fail(f"Basic auth failed for the url: {self.server_url}")
+            self.fail("Basic auth failed for the url: %s" % self.server_url)
 
     def test_basic_auth_httperror(self):
         ah = urllib.request.HTTPBasicAuthHandler()

--- a/Lib/test/test_urllib2_localnet.py
+++ b/Lib/test/test_urllib2_localnet.py
@@ -306,7 +306,7 @@ class BasicAuthTests(unittest.TestCase):
         try:
             self.assertTrue(urllib.request.urlopen(self.server_url))
         except urllib.error.HTTPError:
-            self.fail("Basic auth failed for the url: %s", self.server_url)
+            self.fail(f"Basic auth failed for the url: {self.server_url}")
 
     def test_basic_auth_httperror(self):
         ah = urllib.request.HTTPBasicAuthHandler()


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34031 -->
https://bugs.python.org/issue34031
<!-- /issue-number -->
