### PR TITLE
bpo-20602: Do not clear sys.flags and sys.float_info during shutdown

### DIFF
--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -822,6 +822,22 @@ class SysModuleTest(unittest.TestCase):
         rc, stdout, stderr = assert_python_ok('-c', code)
         self.assertEqual(stdout.rstrip(), b'True')
 
+    @test.support.requires_type_collecting
+    def test_issue20602(self):
+        # sys.flags and sys.float_info were wiped during shutdown.
+        code = """if 1:
+            import sys
+            class A:
+                def __del__(self, sys=sys):
+                    print(sys.flags)
+                    print(sys.float_info)
+            a = A()
+            """
+        rc, out, err = assert_python_ok('-c', code)
+        out = out.splitlines()
+        self.assertIn(b'sys.flags', out[0])
+        self.assertIn(b'sys.float_info', out[1])
+
     @unittest.skipUnless(hasattr(sys, 'getandroidapilevel'),
                          'need sys.getandroidapilevel()')
     def test_getandroidapilevel(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-04-16-57-59.bpo-20602.sDLElw.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-04-16-57-59.bpo-20602.sDLElw.rst
@@ -1,0 +1,2 @@
+Do not clear :data:`sys.flags` and :data:`sys.float_info` during shutdown.
+Patch by Zackery Spytz.

--- a/Python/import.c
+++ b/Python/import.c
@@ -383,8 +383,6 @@ static const char * const sys_deletes[] = {
     "last_type", "last_value", "last_traceback",
     "path_hooks", "path_importer_cache", "meta_path",
     "__interactivehook__",
-    /* misc stuff */
-    "flags", "float_info",
     NULL
 };
 


### PR DESCRIPTION
There is no need to clear these immutable objects during shutdown.

<!-- issue-number: bpo-20602 -->
https://bugs.python.org/issue20602
<!-- /issue-number -->
