### PR TITLE
bpo-16968: Clean up test_concurrent_futures

### DIFF
--- a/Lib/test/libregrtest/runtest.py
+++ b/Lib/test/libregrtest/runtest.py
@@ -181,7 +181,7 @@ def runtest_inner(ns, test, display_failure=True):
             else:
                 test_runner()
             test_time = time.time() - start_time
-        post_test_cleanup()
+            post_test_cleanup()
     except support.ResourceDenied as msg:
         if not ns.quiet and not ns.pgo:
             print(test, "skipped --", msg, flush=True)

--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -1235,12 +1235,5 @@ class FutureTests(BaseTestCase):
         self.assertEqual(f.exception(), e)
 
 
-@test.support.reap_threads
-def test_main():
-    try:
-        test.support.run_unittest(__name__)
-    finally:
-        test.support.reap_children()
-
 if __name__ == "__main__":
-    test_main()
+    unittest.main()


### PR DESCRIPTION
The old test_main function would cause any dangling threads or processes
to be reaped silently rather than allowing regrtest to detect and warn
about them.  Since the shutdown methods of the module should do all of
the cleanup for us, we want to get those warnings if they don't.


<!-- issue-number: bpo-16968 -->
https://bugs.python.org/issue16968
<!-- /issue-number -->
