### PR TITLE
bpo-34049: classify abs() argument type

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -44,7 +44,8 @@ are always available.  They are listed here in alphabetical order.
 
    Return the absolute value of a number.  The argument may be an
    integer or a floating point number.  If the argument is a complex number, its
-   magnitude is returned.
+   magnitude is returned. If *x* defines :meth:`__abs__`,
+   ``abs(x)`` returns ``x.__abs__()``.
 
 
 .. function:: all(iterable)


### PR DESCRIPTION
Just like callable() method in https://docs.python.org/3/library/functions.html#callable

> ...instances are callable if their class has a __call__() method.

I think we should also mention this in abs(),

> abs(x)
> Return the absolute value of a number.  The argument may be an integer or a floating point number. If the argument is a complex number, its magnitude is returned. If x defines __abs__, abs(x) returns x.__abs__().

<!-- issue-number: bpo-34049 -->
https://bugs.python.org/issue34049
<!-- /issue-number -->
