### PR TITLE
[2.7] bpo-33720: Improve tests for the stack overflow in marshal.loads(). (GH-7336).

### DIFF
--- a/Lib/test/test_marshal.py
+++ b/Lib/test/test_marshal.py
@@ -227,8 +227,22 @@ class BugsTestCase(unittest.TestCase):
                 pass
 
     def test_loads_recursion(self):
-        s = 'c' + ('X' * 4*4) + '{' * 2**20
-        self.assertRaises(ValueError, marshal.loads, s)
+        def run_tests(N, check):
+            # (((...None...),),)
+            check(b'(\x01\x00\x00\x00' * N + b'N')
+            # [[[...None...]]]
+            check(b'[\x01\x00\x00\x00' * N + b'N')
+            # {None: {None: {None: ...None...}}}
+            check(b'{N' * N + b'N' + b'0' * N)
+            # frozenset([frozenset([frozenset([...None...])])])
+            check(b'>\x01\x00\x00\x00' * N + b'N')
+        # Check that the generated marshal data is valid and marshal.loads()
+        # works for moderately deep nesting
+        run_tests(100, marshal.loads)
+        # Very deeply nested structure shouldn't blow the stack
+        def check(s):
+            self.assertRaises(ValueError, marshal.loads, s)
+        run_tests(2**20, check)
 
     def test_recursion_limit(self):
         # Create a deeply nested structure.


### PR DESCRIPTION
(cherry picked from commit fc05e68d8fac70349b7ea17ec14e7e0cfa956121)


<!-- issue-number: bpo-33720 -->
https://bugs.python.org/issue33720
<!-- /issue-number -->
