### PR TITLE
[3.7] Update Stackless Python wiki URL (GH-8072)

### DIFF
--- a/Doc/faq/design.rst
+++ b/Doc/faq/design.rst
@@ -348,7 +348,7 @@ each Python stack frame.  Also, extensions can call back into Python at almost
 random moments.  Therefore, a complete threads implementation requires thread
 support for C.
 
-Answer 2: Fortunately, there is `Stackless Python <https://bitbucket.org/stackless-dev/stackless/wiki/Home>`_,
+Answer 2: Fortunately, there is `Stackless Python <https://github.com/stackless-dev/stackless/wiki>`_,
 which has a completely redesigned interpreter loop that avoids the C stack.
 
 


### PR DESCRIPTION
It was moved from bitbucket to GitHub.

(cherry picked from commit a6e1e41e0563c87e93085d3a7f7d96e9bbf792d7)
