### PR TITLE
Doc: Fix example in contextlib asynccontextmanager document

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -110,7 +110,7 @@ Functions and classes provided:
       async def get_connection():
           conn = await acquire_db_connection()
           try:
-              yield
+              yield conn
           finally:
               await release_db_connection(conn)
 


### PR DESCRIPTION
This fixes an example in contextlib asynccontextmanager document.