### PR TITLE
versionadded -> versionchanged for all 'X parameter was added' for uniformity.

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -232,13 +232,13 @@ is the module's name in the Python package namespace.
       above example). In such circumstances, it is likely that specialized
       :class:`Formatter`\ s would be used with particular :class:`Handler`\ s.
 
-      .. versionadded:: 3.2
+      .. versionchanged:: 3.2
          The *stack_info* parameter was added.
 
       .. versionchanged:: 3.5
          The *exc_info* parameter can now accept exception instances.
 
-      .. versionadded:: 3.8
+      .. versionchanged:: 3.8
          The *stacklevel* parameter was added.
 
 
@@ -1007,7 +1007,7 @@ functions.
    above example). In such circumstances, it is likely that specialized
    :class:`Formatter`\ s would be used with particular :class:`Handler`\ s.
 
-   .. versionadded:: 3.2
+   .. versionchanged:: 3.2
       The *stack_info* parameter was added.
 
 .. function:: info(msg, *args, **kwargs)

--- a/Doc/library/sched.rst
+++ b/Doc/library/sched.rst
@@ -81,7 +81,7 @@ Scheduler Objects
    .. versionchanged:: 3.3
       *argument* parameter is optional.
 
-   .. versionadded:: 3.3
+   .. versionchanged:: 3.3
       *kwargs* parameter was added.
 
 
@@ -94,7 +94,7 @@ Scheduler Objects
    .. versionchanged:: 3.3
       *argument* parameter is optional.
 
-   .. versionadded:: 3.3
+   .. versionchanged:: 3.3
       *kwargs* parameter was added.
 
 .. method:: scheduler.cancel(event)
@@ -128,7 +128,7 @@ Scheduler Objects
    the calling code is responsible for canceling  events which are no longer
    pertinent.
 
-   .. versionadded:: 3.3
+   .. versionchanged:: 3.3
       *blocking* parameter was added.
 
 .. attribute:: scheduler.queue

--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -485,7 +485,7 @@ functions.
    between the parent and child.  Providing any *pass_fds* forces
    *close_fds* to be :const:`True`.  (POSIX only)
 
-   .. versionadded:: 3.2
+   .. versionchanged:: 3.2
       The *pass_fds* parameter was added.
 
    If *cwd* is not ``None``, the function changes the working directory to


### PR DESCRIPTION
Per [Developer's Guide](https://devguide.python.org/documenting/#paragraph-level-markup) `versionchanged`directive should be used for new parameters.