### PR TITLE
WIP: use assign expr on if

### DIFF
--- a/Lib/_markupbase.py
+++ b/Lib/_markupbase.py
@@ -49,8 +49,7 @@ class ParserBase:
         if i >= j:
             return j
         rawdata = self.rawdata
-        nlines = rawdata.count("\n", i, j)
-        if nlines:
+        if (nlines := rawdata.count("\n", i, j)):
             self.lineno = self.lineno + nlines
             pos = rawdata.rindex("\n", i, j) # Should not fail
             self.offset = j-(pos+1)
@@ -291,8 +290,7 @@ class ParserBase:
             if not c:
                 return -1
             if c in "'\"":
-                m = _declstringlit_match(rawdata, j)
-                if m:
+                if (m := _declstringlit_match(rawdata, j)):
                     j = m.end()
                 else:
                     return -1
@@ -359,8 +357,7 @@ class ParserBase:
             if not c:
                 return -1
             if c in "'\"":
-                m = _declstringlit_match(rawdata, j)
-                if m:
+                if (m := _declstringlit_match(rawdata, j)):
                     j = m.end()
                 else:
                     return -1    # incomplete
@@ -378,8 +375,7 @@ class ParserBase:
         n = len(rawdata)
         if i == n:
             return None, -1
-        m = _declname_match(rawdata, i)
-        if m:
+        if (m := _declname_match(rawdata, i)):
             s = m.group()
             name = s.strip()
             if (i + len(s)) == n:

--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -886,8 +886,7 @@ class Decimal(object):
         self, other = _convert_for_comparison(self, other)
         if other is NotImplemented:
             return other
-        ans = self._compare_check_nans(other, context)
-        if ans:
+        if self._compare_check_nans(other, context):
             return False
         return self._cmp(other) < 0
 
@@ -895,8 +894,7 @@ class Decimal(object):
         self, other = _convert_for_comparison(self, other)
         if other is NotImplemented:
             return other
-        ans = self._compare_check_nans(other, context)
-        if ans:
+        if self._compare_check_nans(other, context):
             return False
         return self._cmp(other) <= 0
 
@@ -904,8 +902,7 @@ class Decimal(object):
         self, other = _convert_for_comparison(self, other)
         if other is NotImplemented:
             return other
-        ans = self._compare_check_nans(other, context)
-        if ans:
+        if self._compare_check_nans(other, context):
             return False
         return self._cmp(other) > 0
 
@@ -913,8 +910,7 @@ class Decimal(object):
         self, other = _convert_for_comparison(self, other)
         if other is NotImplemented:
             return other
-        ans = self._compare_check_nans(other, context)
-        if ans:
+        if self._compare_check_nans(other, context):
             return False
         return self._cmp(other) >= 0
 
@@ -930,8 +926,7 @@ class Decimal(object):
 
         # Compare(NaN, NaN) = NaN
         if (self._is_special or other and other._is_special):
-            ans = self._check_nans(other, context)
-            if ans:
+            if (ans := self._check_nans(other, context)):
                 return ans
 
         return Decimal(self._cmp(other))
@@ -1090,10 +1085,8 @@ class Decimal(object):
 
         Rounds, if it has reason.
         """
-        if self._is_special:
-            ans = self._check_nans(context=context)
-            if ans:
-                return ans
+        if self._is_special and (ans := self._check_nans(context=context)):
+            return ans
 
         if context is None:
             context = getcontext()
@@ -1112,10 +1105,8 @@ class Decimal(object):
 
         Rounds the number (if more than precision digits)
         """
-        if self._is_special:
-            ans = self._check_nans(context=context)
-            if ans:
-                return ans
+        if self._is_special and (ans := self._check_nans(context=context)):
+            return ans
 
         if context is None:
             context = getcontext()
@@ -1138,10 +1129,8 @@ class Decimal(object):
         if not round:
             return self.copy_abs()
 
-        if self._is_special:
-            ans = self._check_nans(context=context)
-            if ans:
-                return ans
+        if self._is_special and (ans := self._check_nans(context=context)):
+            return ans
 
         if self._sign:
             ans = self.__neg__(context=context)
@@ -1163,8 +1152,7 @@ class Decimal(object):
             context = getcontext()
 
         if self._is_special or other._is_special:
-            ans = self._check_nans(other, context)
-            if ans:
+            if (ans := self._check_nans(other, context)):
                 return ans
 
             if self._isinfinity():
@@ -1244,10 +1232,9 @@ class Decimal(object):
         if other is NotImplemented:
             return other
 
-        if self._is_special or other._is_special:
-            ans = self._check_nans(other, context=context)
-            if ans:
-                return ans
+        if (self._is_special or other._is_special
+           and (ans := self._check_nans(other, context=context))):
+            return ans
 
         # self - other is computed as self + other.copy_negate()
         return self.__add__(other.copy_negate(), context=context)
@@ -1275,8 +1262,7 @@ class Decimal(object):
         resultsign = self._sign ^ other._sign
 
         if self._is_special or other._is_special:
-            ans = self._check_nans(other, context)
-            if ans:
+            if (ans := self._check_nans(other, context)):
                 return ans
 
             if self._isinfinity():
@@ -1329,8 +1315,7 @@ class Decimal(object):
         sign = self._sign ^ other._sign
 
         if self._is_special or other._is_special:
-            ans = self._check_nans(other, context)
-            if ans:
+            if (ans := self._check_nans(other, context)):
                 return ans
 
             if self._isinfinity() and other._isinfinity():
@@ -1427,8 +1412,7 @@ class Decimal(object):
         if context is None:
             context = getcontext()
 
-        ans = self._check_nans(other, context)
-        if ans:
+        if (ans := self._check_nans(other, context)):
             return (ans, ans)
 
         sign = self._sign ^ other._sign
@@ -1470,8 +1454,7 @@ class Decimal(object):
         if context is None:
             context = getcontext()
 
-        ans = self._check_nans(other, context)
-        if ans:
+        if (ans := self._check_nans(other, context)):
             return ans
 
         if self._isinfinity():
@@ -1502,8 +1485,7 @@ class Decimal(object):
 
         other = _convert_other(other, raiseit=True)
 
-        ans = self._check_nans(other, context)
-        if ans:
+        if (ans := self._check_nans(other, context)):
             return ans
 
         # self == +/-infinity -> InvalidOperation
@@ -1577,8 +1559,7 @@ class Decimal(object):
         if context is None:
             context = getcontext()
 
-        ans = self._check_nans(other, context)
-        if ans:
+        if (ans := self._check_nans(other, context)):
             return ans
 
         if self._isinfinity():
@@ -2316,8 +2297,7 @@ class Decimal(object):
             context = getcontext()
 
         # either argument is a NaN => result is NaN
-        ans = self._check_nans(other, context)
-        if ans:
+        if (ans := self._check_nans(other, context)):
             return ans
 
         # 0**0 = NaN (!), x**0 = 1 for nonzero x (including +/-Infinity)
@@ -2511,8 +2491,7 @@ class Decimal(object):
             context = getcontext()
 
         if self._is_special:
-            ans = self._check_nans(context=context)
-            if ans:
+            if (ans := self._check_nans(context=context)):
                 return ans
 
         dup = self._fix(context)
@@ -2542,8 +2521,7 @@ class Decimal(object):
             rounding = context.rounding
 
         if self._is_special or exp._is_special:
-            ans = self._check_nans(exp, context)
-            if ans:
+            if (ans := self._check_nans(exp, context)):
                 return ans
 
             if exp._isinfinity() or self._isinfinity():
@@ -2673,8 +2651,7 @@ class Decimal(object):
         this method except that it doesn't raise Inexact or Rounded.
         """
         if self._is_special:
-            ans = self._check_nans(context=context)
-            if ans:
+            if (ans := self._check_nans(context=context)):
                 return ans
             return Decimal(self)
         if self._exp >= 0:
@@ -2698,8 +2675,7 @@ class Decimal(object):
         if rounding is None:
             rounding = context.rounding
         if self._is_special:
-            ans = self._check_nans(context=context)
-            if ans:
+            if (ans := self._check_nans(context=context)):
                 return ans
             return Decimal(self)
         if self._exp >= 0:
@@ -2716,8 +2692,7 @@ class Decimal(object):
             context = getcontext()
 
         if self._is_special:
-            ans = self._check_nans(context=context)
-            if ans:
+            if (ans := self._check_nans(context=context)):
                 return ans
 
             if self._isinfinity() and self._sign == 0:
@@ -2923,8 +2898,7 @@ class Decimal(object):
         NaNs taking precedence over quiet NaNs.
         """
         other = _convert_other(other, raiseit = True)
-        ans = self._compare_check_nans(other, context)
-        if ans:
+        if (ans := self._compare_check_nans(other, context)):
             return ans
         return self.compare(other, context=context)
 
@@ -3036,8 +3010,7 @@ class Decimal(object):
             context = getcontext()
 
         # exp(NaN) = NaN
-        ans = self._check_nans(context=context)
-        if ans:
+        if (ans := self._check_nans(context=context)):
             return ans
 
         # exp(-Infinity) = 0
@@ -3192,8 +3165,7 @@ class Decimal(object):
             context = getcontext()
 
         # ln(NaN) = NaN
-        ans = self._check_nans(context=context)
-        if ans:
+        if (ans := self._check_nans(context=context)):
             return ans
 
         # ln(0.0) == -Infinity
@@ -3272,8 +3244,7 @@ class Decimal(object):
             context = getcontext()
 
         # log10(NaN) = NaN
-        ans = self._check_nans(context=context)
-        if ans:
+        if (ans := self._check_nans(context=context)):
             return ans
 
         # log10(0.0) == -Infinity
@@ -3325,8 +3296,7 @@ class Decimal(object):
         without limiting the resulting exponent).
         """
         # logb(NaN) = NaN
-        ans = self._check_nans(context=context)
-        if ans:
+        if (ans := self._check_nans(context=context)):
             return ans
 
         if context is None:
@@ -3496,8 +3466,7 @@ class Decimal(object):
         if context is None:
             context = getcontext()
 
-        ans = self._check_nans(context=context)
-        if ans:
+        if (ans := self._check_nans(context=context)):
             return ans
 
         if self._isinfinity() == -1:
@@ -3519,8 +3488,7 @@ class Decimal(object):
         if context is None:
             context = getcontext()
 
-        ans = self._check_nans(context=context)
-        if ans:
+        if (ans := self._check_nans(context=context)):
             return ans
 
         if self._isinfinity() == 1:
@@ -3551,8 +3519,7 @@ class Decimal(object):
         if context is None:
             context = getcontext()
 
-        ans = self._check_nans(other, context)
-        if ans:
+        if (ans := self._check_nans(other, context)):
             return ans
 
         comparison = self._cmp(other)
@@ -3636,8 +3603,7 @@ class Decimal(object):
 
         other = _convert_other(other, raiseit=True)
 
-        ans = self._check_nans(other, context)
-        if ans:
+        if (ans := self._check_nans(other, context)):
             return ans
 
         if other._exp != 0:
@@ -3669,8 +3635,7 @@ class Decimal(object):
 
         other = _convert_other(other, raiseit=True)
 
-        ans = self._check_nans(other, context)
-        if ans:
+        if (ans := self._check_nans(other, context)):
             return ans
 
         if other._exp != 0:
@@ -3694,8 +3659,7 @@ class Decimal(object):
 
         other = _convert_other(other, raiseit=True)
 
-        ans = self._check_nans(other, context)
-        if ans:
+        if (ans := self._check_nans(other, context)):
             return ans
 
         if other._exp != 0:

--- a/Lib/_pyio.py
+++ b/Lib/_pyio.py
@@ -1080,8 +1080,7 @@ class BufferedReader(_BufferedIOMixin):
         have = len(self._read_buf) - self._read_pos
         if have < want or have <= 0:
             to_read = self.buffer_size - have
-            current = self.raw.read(to_read)
-            if current:
+            if (current := self.raw.read(to_read)):
                 self._read_buf = self._read_buf[self._read_pos:] + current
                 self._read_pos = 0
         return self._read_buf[self._read_pos:]

--- a/Lib/asyncio/format_helpers.py
+++ b/Lib/asyncio/format_helpers.py
@@ -21,8 +21,7 @@ def _get_function_source(func):
 
 def _format_callback_source(func, args):
     func_repr = _format_callback(func, args, None)
-    source = _get_function_source(func)
-    if source:
+    if (source := _get_function_source(func)):
         func_repr += f' at {source[0]}:{source[1]}'
     return func_repr
 

--- a/Lib/asyncio/selector_events.py
+++ b/Lib/asyncio/selector_events.py
@@ -618,17 +618,15 @@ class _SelectorTransport(transports._FlowControlMixin,
         info.append(f'fd={self._sock_fd}')
         # test if the transport was closed
         if self._loop is not None and not self._loop.is_closed():
-            polling = _test_selector_event(self._loop._selector,
-                                           self._sock_fd, selectors.EVENT_READ)
-            if polling:
+            if _test_selector_event(self._loop._selector,
+                                    self._sock_fd, selectors.EVENT_READ):
                 info.append('read=polling')
             else:
                 info.append('read=idle')
 
-            polling = _test_selector_event(self._loop._selector,
-                                           self._sock_fd,
-                                           selectors.EVENT_WRITE)
-            if polling:
+            if _test_selector_event(self._loop._selector,
+                                    self._sock_fd,
+                                    selectors.EVENT_WRITE):
                 state = 'polling'
             else:
                 state = 'idle'

--- a/Lib/asyncio/sslproto.py
+++ b/Lib/asyncio/sslproto.py
@@ -562,8 +562,7 @@ class SSLProtocol(protocols.Protocol):
             self._wakeup_waiter(ConnectionResetError)
 
             if not self._in_handshake:
-                keep_open = self._app_protocol.eof_received()
-                if keep_open:
+                if self._app_protocol.eof_received():
                     logger.warning('returning true from eof_received() '
                                    'has no effect when using ssl')
         finally:

--- a/Lib/asyncio/unix_events.py
+++ b/Lib/asyncio/unix_events.py
@@ -461,9 +461,8 @@ class _UnixReadPipeTransport(transports.ReadTransport):
         info.append(f'fd={self._fileno}')
         selector = getattr(self._loop, '_selector', None)
         if self._pipe is not None and selector is not None:
-            polling = selector_events._test_selector_event(
-                selector, self._fileno, selectors.EVENT_READ)
-            if polling:
+            if selector_events._test_selector_event(selector, self._fileno, 
+                                                    selectors.EVENT_READ):
                 info.append('polling')
             else:
                 info.append('idle')
@@ -594,9 +593,8 @@ class _UnixWritePipeTransport(transports._FlowControlMixin,
         info.append(f'fd={self._fileno}')
         selector = getattr(self._loop, '_selector', None)
         if self._pipe is not None and selector is not None:
-            polling = selector_events._test_selector_event(
-                selector, self._fileno, selectors.EVENT_WRITE)
-            if polling:
+            if selector_events._test_selector_event(selector, self._fileno, 
+                                                    selectors.EVENT_WRITE):
                 info.append('polling')
             else:
                 info.append('idle')

--- a/Lib/bdb.py
+++ b/Lib/bdb.py
@@ -558,8 +558,7 @@ class Bdb:
             rv = frame.f_locals['__return__']
             s += '->'
             s += reprlib.repr(rv)
-        line = linecache.getline(filename, lineno, frame.f_globals)
-        if line:
+        if (line := linecache.getline(filename, lineno, frame.f_globals)):
             s += lprefix + line.strip()
         return s
 
@@ -818,8 +817,7 @@ def effective(file, line, frame):
             # Ignore count applies only to those bpt hits where the
             # condition evaluates to true.
             try:
-                val = eval(b.cond, frame.f_globals, frame.f_locals)
-                if val:
+                if eval(b.cond, frame.f_globals, frame.f_locals):
                     if b.ignore > 0:
                         b.ignore -= 1
                         # continue

--- a/Lib/binhex.py
+++ b/Lib/binhex.py
@@ -466,8 +466,7 @@ def hexbin(inp, out):
             ofp.write(d)
     ifp.close_data()
 
-    d = ifp.read_rsrc(128000)
-    if d:
+    if (d := ifp.read_rsrc(128000)):
         ofp = openrsrc(out, 'wb')
         ofp.write(d)
         while True:

--- a/Lib/codecs.py
+++ b/Lib/codecs.py
@@ -565,8 +565,7 @@ class StreamReader(Codec):
                     data += self.read(size=1, chars=1)
 
             line += data
-            lines = line.splitlines(keepends=True)
-            if lines:
+            if (lines := line.splitlines(keepends=True)):
                 if len(lines) > 1:
                     # More than one line result; the first line is a full line
                     # to return
@@ -642,8 +641,7 @@ class StreamReader(Codec):
     def __next__(self):
 
         """ Return the next decoded line from the input stream."""
-        line = self.readline()
-        if line:
+        if (line := self.readline()):
             return line
         raise StopIteration
 
@@ -1021,11 +1019,9 @@ def iterencode(iterator, encoding, errors='strict', **kwargs):
     """
     encoder = getincrementalencoder(encoding)(errors, **kwargs)
     for input in iterator:
-        output = encoder.encode(input)
-        if output:
+        if (output := encoder.encode(input)):
             yield output
-    output = encoder.encode("", True)
-    if output:
+    if (output := encoder.encode("", True)):
         yield output
 
 def iterdecode(iterator, encoding, errors='strict', **kwargs):
@@ -1039,11 +1035,9 @@ def iterdecode(iterator, encoding, errors='strict', **kwargs):
     """
     decoder = getincrementaldecoder(encoding)(errors, **kwargs)
     for input in iterator:
-        output = decoder.decode(input)
-        if output:
+        if (output := decoder.decode(input)):
             yield output
-    output = decoder.decode(b"", True)
-    if output:
+    if (output := decoder.decode(b"", True)):
         yield output
 
 ### Helpers for charmap-based codecs
@@ -1099,8 +1093,7 @@ except LookupError:
 
 # Tell modulefinder that using codecs probably needs the encodings
 # package
-_false = 0
-if _false:
+if (_false := 0):
     import encodings
 
 ### Tests

--- a/Lib/copy.py
+++ b/Lib/copy.py
@@ -71,8 +71,7 @@ def copy(x):
 
     cls = type(x)
 
-    copier = _copy_dispatch.get(cls)
-    if copier:
+    if (copier := _copy_dispatch.get(cls)):
         return copier(x)
 
     try:
@@ -83,23 +82,17 @@ def copy(x):
         # treat it as a regular class:
         return _copy_immutable(x)
 
-    copier = getattr(cls, "__copy__", None)
-    if copier:
+    if (copier := getattr(cls, "__copy__", None)):
         return copier(x)
 
-    reductor = dispatch_table.get(cls)
-    if reductor:
+    if (reductor := dispatch_table.get(cls)):
         rv = reductor(x)
+    elif (reductor := getattr(x, "__reduce_ex__", None)):
+        rv = reductor(4)
+    elif (reductor := getattr(x, "__reduce__", None)):
+        rv = reductor()
     else:
-        reductor = getattr(x, "__reduce_ex__", None)
-        if reductor:
-            rv = reductor(4)
-        else:
-            reductor = getattr(x, "__reduce__", None)
-            if reductor:
-                rv = reductor()
-            else:
-                raise Error("un(shallow)copyable object of type %s" % cls)
+        raise Error("un(shallow)copyable object of type %s" % cls)
 
     if isinstance(rv, str):
         return x
@@ -145,8 +138,7 @@ def deepcopy(x, memo=None, _nil=[]):
 
     cls = type(x)
 
-    copier = _deepcopy_dispatch.get(cls)
-    if copier:
+    if (copier := _deepcopy_dispatch.get(cls)):
         y = copier(x, memo)
     else:
         try:
@@ -156,24 +148,18 @@ def deepcopy(x, memo=None, _nil=[]):
         if issc:
             y = _deepcopy_atomic(x, memo)
         else:
-            copier = getattr(x, "__deepcopy__", None)
-            if copier:
+            if (copier := getattr(x, "__deepcopy__", None)):
                 y = copier(memo)
             else:
-                reductor = dispatch_table.get(cls)
-                if reductor:
+                if (reductor := dispatch_table.get(cls)):
                     rv = reductor(x)
+                elif (reductor := getattr(x, "__reduce_ex__", None)):
+                    rv = reductor(4)
+                elif (reductor := getattr(x, "__reduce__", None)):
+                    rv = reductor()
                 else:
-                    reductor = getattr(x, "__reduce_ex__", None)
-                    if reductor:
-                        rv = reductor(4)
-                    else:
-                        reductor = getattr(x, "__reduce__", None)
-                        if reductor:
-                            rv = reductor()
-                        else:
-                            raise Error(
-                                "un(deep)copyable object of type %s" % cls)
+                    raise Error("un(deep)copyable object of type %s" % cls)
+
                 if isinstance(rv, str):
                     y = x
                 else:

--- a/Lib/copyreg.py
+++ b/Lib/copyreg.py
@@ -128,8 +128,7 @@ def _slotnames(cls):
                         continue
                     # mangled names
                     elif name.startswith('__') and not name.endswith('__'):
-                        stripped = c.__name__.lstrip('_')
-                        if stripped:
+                        if (stripped := c.__name__.lstrip('_')):
                             names.append('_%s%s' % (stripped, name))
                         else:
                             names.append(name)

--- a/Lib/csv.py
+++ b/Lib/csv.py
@@ -220,8 +220,7 @@ class Sniffer:
                       r'(?P<delim>[^\w\n"\'])(?P<space> ?)(?P<quote>["\']).*?(?P=quote)(?:$|\n)',   # ,".*?"
                       r'(?:^|\n)(?P<quote>["\']).*?(?P=quote)(?:$|\n)'):                            #  ".*?" (no delim, no space)
             regexp = re.compile(restr, re.DOTALL | re.MULTILINE)
-            matches = regexp.findall(data)
-            if matches:
+            if (matches := regexp.findall(data)):
                 break
 
         if not matches:
@@ -233,8 +232,7 @@ class Sniffer:
         groupindex = regexp.groupindex
         for m in matches:
             n = groupindex['quote'] - 1
-            key = m[n]
-            if key:
+            if (key := m[n]):
                 quotes[key] = quotes.get(key, 0) + 1
             try:
                 n = groupindex['delim'] - 1

--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -599,8 +599,7 @@ def _is_type(annotation, cls, a_module, a_type, is_type_predicate):
     # a eval() penalty for every single field of every dataclass
     # that's defined.  It was judged not worth it.
 
-    match = _MODULE_IDENTIFIER_RE.match(annotation)
-    if match:
+    if (match := _MODULE_IDENTIFIER_RE.match(annotation)):
         ns = None
         module_name = match.group(1)
         if not module_name:
@@ -656,8 +655,7 @@ def _get_field(cls, a_name, a_type):
     # annotation to be a ClassVar.  So, only look for ClassVar if
     # typing has been imported by any module (not necessarily cls's
     # module).
-    typing = sys.modules.get('typing')
-    if typing:
+    if (typing := sys.modules.get('typing')):
         if (_is_classvar(a_type, typing)
             or (isinstance(f.type, str)
                 and _is_type(f.type, cls, typing, typing.ClassVar,
@@ -774,8 +772,7 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen):
     for b in cls.__mro__[-1:0:-1]:
         # Only process classes that have been processed by our
         # decorator.  That is, they have a _FIELDS attribute.
-        base_fields = getattr(b, _FIELDS, None)
-        if base_fields:
+        if (base_fields := getattr(b, _FIELDS, None)):
             has_dataclass_bases = True
             for f in base_fields.values():
                 fields[f.name] = f
@@ -914,11 +911,10 @@ def _process_class(cls, init, repr, eq, order, unsafe_hash, frozen):
                                 f'in class {cls.__name__}')
 
     # Decide if/how we're going to create a hash function.
-    hash_action = _hash_action[bool(unsafe_hash),
+    if (hash_action := _hash_action[bool(unsafe_hash),
                                bool(eq),
                                bool(frozen),
-                               has_explicit_hash]
-    if hash_action:
+                               has_explicit_hash]):
         # No need to call _set_new_attribute here, since by the time
         # we're here the overwriting is unconditional.
         cls.__hash__ = hash_action(cls, field_list)

--- a/Lib/datetime.py
+++ b/Lib/datetime.py
@@ -227,8 +227,7 @@ def _wrap_strftime(object, format, timetuple):
                                 h, rest = divmod(offset, timedelta(hours=1))
                                 m, rest = divmod(rest, timedelta(minutes=1))
                                 s = rest.seconds
-                                u = offset.microseconds
-                                if u:
+                                if (u := offset.microseconds):
                                     zreplace = '%c%02d%02d%02d.%06d' % (sign, h, m, s, u)
                                 elif s:
                                     zreplace = '%c%02d%02d%02d' % (sign, h, m, s)
@@ -1131,13 +1130,11 @@ class tzinfo:
     # Pickle support.
 
     def __reduce__(self):
-        getinitargs = getattr(self, "__getinitargs__", None)
-        if getinitargs:
+        if (getinitargs := getattr(self, "__getinitargs__", None)):
             args = getinitargs()
         else:
             args = ()
-        getstate = getattr(self, "__getstate__", None)
-        if getstate:
+        if (getstate := getattr(self, "__getstate__", None)):
             state = getstate()
         else:
             state = getattr(self, "__dict__", None) or None
@@ -1352,8 +1349,7 @@ class time:
         """
         s = _format_time(self._hour, self._minute, self._second,
                           self._microsecond, timespec)
-        tz = self._tzstr()
-        if tz:
+        if (tz := self._tzstr()):
             s += tz
         return s
 
@@ -1707,8 +1703,7 @@ class datetime(date):
 
     def utctimetuple(self):
         "Return UTC time tuple compatible with time.gmtime()."
-        offset = self.utcoffset()
-        if offset:
+        if (offset := self.utcoffset()):
             self -= offset
         y, m, d = self.year, self.month, self.day
         hh, mm, ss = self.hour, self.minute, self.second
@@ -1821,8 +1816,7 @@ class datetime(date):
                           self._microsecond, timespec))
 
         off = self.utcoffset()
-        tz = _format_offset(off)
-        if tz:
+        if (tz := _format_offset(off)):
             s += tz
 
         return s
@@ -2195,8 +2189,7 @@ class timezone(tzinfo):
         hours, rest = divmod(delta, timedelta(hours=1))
         minutes, rest = divmod(rest, timedelta(minutes=1))
         seconds = rest.seconds
-        microseconds = rest.microseconds
-        if microseconds:
+        if (microseconds := rest.microseconds):
             return (f'UTC{sign}{hours:02d}:{minutes:02d}:{seconds:02d}'
                     f'.{microseconds:06d}')
         if seconds:

--- a/Lib/difflib.py
+++ b/Lib/difflib.py
@@ -314,8 +314,7 @@ class SequenceMatcher:
 
         # Purge junk elements
         self.bjunk = junk = set()
-        isjunk = self.isjunk
-        if isjunk:
+        if (isjunk := self.isjunk):
             for elt in b2j.keys():
                 if isjunk(elt):
                     junk.add(elt)

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -275,15 +275,14 @@ def _ellipsis_match(want, got):
 
     # Deal with exact matches possibly needed at one or both ends.
     startpos, endpos = 0, len(got)
-    w = ws[0]
-    if w:   # starts with exact match
+    if (w := ws[0]):   # starts with exact match
         if got.startswith(w):
             startpos = len(w)
             del ws[0]
         else:
             return False
-    w = ws[-1]
-    if w:   # ends with exact match
+
+    if (w := ws[-1]):   # ends with exact match
         if got.endswith(w):
             endpos -= len(w)
             del ws[-1]
@@ -311,8 +310,7 @@ def _ellipsis_match(want, got):
 
 def _comment_line(line):
     "Return a commented form of the given line"
-    line = line.rstrip()
-    if line:
+    if (line := line.rstrip()):
         return '# '+line
     else:
         return '#'
@@ -715,8 +713,7 @@ class DocTestParser:
         want = '\n'.join([wl[indent:] for wl in want_lines])
 
         # If `want` contains a traceback message, then extract it.
-        m = self._EXCEPTION_RE.match(want)
-        if m:
+        if (m := self._EXCEPTION_RE.match(want)):
             exc_msg = m.group('msg')
         else:
             exc_msg = None
@@ -2571,8 +2568,7 @@ def script_from_examples(s):
             # Add the example's source code (strip trailing NL)
             output.append(piece.source[:-1])
             # Add the expected output:
-            want = piece.want
-            if want:
+            if (want := piece.want):
                 output.append('# Expected:')
                 output += ['## '+l for l in want.split('\n')[:-1]]
         else:

--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -249,8 +249,7 @@ class FileInput:
 
     def __next__(self):
         while True:
-            line = self._readline()
-            if line:
+            if (line := self._readline()):
                 self._filelineno += 1
                 return line
             if not self._file:

--- a/Lib/fractions.py
+++ b/Lib/fractions.py
@@ -137,18 +137,15 @@ class Fraction(numbers.Rational):
                     raise ValueError('Invalid literal for Fraction: %r' %
                                      numerator)
                 numerator = int(m.group('num') or '0')
-                denom = m.group('denom')
-                if denom:
+                if (denom := m.group('denom')):
                     denominator = int(denom)
                 else:
                     denominator = 1
-                    decimal = m.group('decimal')
-                    if decimal:
+                    if (decimal := m.group('decimal')):
                         scale = 10**len(decimal)
                         numerator = numerator * scale + int(decimal)
                         denominator *= scale
-                    exp = m.group('exp')
-                    if exp:
+                    if (exp := m.group('exp')):
                         exp = int(exp)
                         if exp >= 0:
                             numerator *= 10**exp

--- a/Lib/getpass.py
+++ b/Lib/getpass.py
@@ -132,8 +132,7 @@ def _raw_input(prompt="", stream=None, input=None):
         stream = sys.stderr
     if not input:
         input = sys.stdin
-    prompt = str(prompt)
-    if prompt:
+    if (prompt := str(prompt)):
         try:
             stream.write(prompt)
         except UnicodeEncodeError:
@@ -160,8 +159,7 @@ def getuser():
     """
 
     for name in ('LOGNAME', 'USER', 'LNAME', 'USERNAME'):
-        user = os.environ.get(name)
-        if user:
+        if (user := os.environ.get(name)):
             return user
 
     # If this fails, the exception will "explain" why

--- a/Lib/gettext.py
+++ b/Lib/gettext.py
@@ -478,8 +478,7 @@ def find(domain, localedir=None, languages=None, all=False):
     if languages is None:
         languages = []
         for envar in ('LANGUAGE', 'LC_ALL', 'LC_MESSAGES', 'LANG'):
-            val = os.environ.get(envar)
-            if val:
+            if (val := os.environ.get(envar)):
                 languages = val.split(':')
                 break
         if 'C' not in languages:

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -313,8 +313,7 @@ class GzipFile(_compression.BaseStream):
             elif self.mode == READ:
                 self._buffer.close()
         finally:
-            myfileobj = self.myfileobj
-            if myfileobj:
+            if (myfileobj := self.myfileobj):
                 self.myfileobj = None
                 myfileobj.close()
 

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -924,8 +924,7 @@ class IMAP4:
 
 
     def _check_bye(self):
-        bye = self.untagged_responses.get('BYE')
-        if bye:
+        if (bye := self.untagged_responses.get('BYE')):
             raise self.abort(bye[-1].decode(self._encoding, 'replace'))
 
 
@@ -1389,8 +1388,7 @@ class _Authenticator:
             else:
                 t = inp
                 inp = b''
-            e = binascii.b2a_base64(t)
-            if e:
+            if (e := binascii.b2a_base64(t)):
                 oup = oup + e[:-1]
         return oup
 

--- a/Lib/imghdr.py
+++ b/Lib/imghdr.py
@@ -20,8 +20,7 @@ def what(file, h=None):
                 h = file.read(32)
                 file.seek(location)
         for tf in tests:
-            res = tf(h, f)
-            if res:
+            if (res := tf(h, f)):
                 return res
     finally:
         if f: f.close()

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -777,8 +777,7 @@ def findsource(object):
         if not (file.startswith('<') and file.endswith('>')):
             raise OSError('source code not available')
 
-    module = getmodule(object, file)
-    if module:
+    if (module := getmodule(object, file)):
         lines = linecache.getlines(file, module.__dict__)
     else:
         lines = linecache.getlines(file)
@@ -796,8 +795,7 @@ def findsource(object):
         # that's most probably not inside a function definition.
         candidates = []
         for i in range(len(lines)):
-            match = pat.match(lines[i])
-            if match:
+            if (match := pat.match(lines[i])):
                 # if it's at toplevel, it's already the best one
                 if lines[i][0] == 'c':
                     return lines, i
@@ -1978,10 +1976,8 @@ def _signature_fromstr(cls, obj, s, skip_bound_arg=True):
 
     module = None
     module_dict = {}
-    module_name = getattr(obj, '__module__', None)
-    if module_name:
-        module = sys.modules.get(module_name, None)
-        if module:
+    if (module_name := getattr(obj, '__module__', None)):
+        if (module := sys.modules.get(module_name, None)):
             module_dict = module.__dict__
     sys_module_dict = sys.modules
 

--- a/Lib/keyword.py
+++ b/Lib/keyword.py
@@ -74,8 +74,7 @@ def main():
         lines = []
         for line in fp:
             if '{1, "' in line:
-                match = strprog.search(line)
-                if match:
+                if (match := strprog.search(line)):
                     lines.append("        '" + match.group(1) + "'," + nl)
     lines.sort()
 

--- a/Lib/locale.py
+++ b/Lib/locale.py
@@ -311,13 +311,11 @@ def delocalize(string):
     conv = localeconv()
 
     #First, get rid of the grouping
-    ts = conv['thousands_sep']
-    if ts:
+    if (ts := conv['thousands_sep']):
         string = string.replace(ts, '')
 
     #next, replace the decimal point with a dot
-    dd = conv['decimal_point']
-    if dd:
+    if (dd := conv['decimal_point']):
         string = string.replace(dd, '.')
     return string
 

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1849,8 +1849,7 @@ def basicConfig(**kwargs):
     # basicConfig() from multiple threads
     _acquireLock()
     try:
-        force = kwargs.pop('force', False)
-        if force:
+        if kwargs.pop('force', False):
             for h in root.handlers[:]:
                 root.removeHandler(h)
                 h.close()
@@ -2002,8 +2001,7 @@ def shutdown(handlerList=_handlerList):
         #errors might occur, for example, if files are locked
         #we just ignore them if raiseExceptions is not set
         try:
-            h = wr()
-            if h:
+            if (h := wr()):
                 try:
                     h.acquire()
                     h.flush()

--- a/Lib/logging/config.py
+++ b/Lib/logging/config.py
@@ -113,8 +113,7 @@ def _create_formatters(cp):
         dfs = cp.get(sectname, "datefmt", raw=True, fallback=None)
         stl = cp.get(sectname, "style", raw=True, fallback='%')
         c = logging.Formatter
-        class_name = cp[sectname].get("class")
-        if class_name:
+        if (class_name := cp[sectname].get("class")):
             c = _resolve(class_name)
         f = c(fs, dfs, stl)
         formatters[form] = f
@@ -425,6 +424,7 @@ class BaseConfigurator(object):
                                 d = d[n]
                             except TypeError:
                                 d = d[idx]
+
                 if m:
                     rest = rest[m.end():]
                 else:
@@ -450,12 +450,10 @@ class BaseConfigurator(object):
             value = ConvertingTuple(value)
             value.configurator = self
         elif isinstance(value, str): # str for py3k
-            m = self.CONVERT_PATTERN.match(value)
-            if m:
+            if (m := self.CONVERT_PATTERN.match(value)):
                 d = m.groupdict()
                 prefix = d['prefix']
-                converter = self.value_converters.get(prefix, None)
-                if converter:
+                if (converter := self.value_converters.get(prefix, None)):
                     suffix = d['suffix']
                     converter = getattr(self, converter)
                     value = converter(suffix)
@@ -509,8 +507,7 @@ class DictConfigurator(BaseConfigurator):
                         try:
                             handler = logging._handlers[name]
                             handler_config = handlers[name]
-                            level = handler_config.get('level', None)
-                            if level:
+                            if (level := handler_config.get('level', None)):
                                 handler.setLevel(logging._checkLevel(level))
                         except Exception as e:
                             raise ValueError('Unable to configure handler '
@@ -522,8 +519,7 @@ class DictConfigurator(BaseConfigurator):
                     except Exception as e:
                         raise ValueError('Unable to configure logger '
                                          '%r' % name) from e
-                root = config.get('root', None)
-                if root:
+                if (root := config.get('root', None)):
                     try:
                         self.configure_root(root, True)
                     except Exception as e:
@@ -635,8 +631,7 @@ class DictConfigurator(BaseConfigurator):
                                          disable_existing)
 
                 # And finally, do the root logger
-                root = config.get('root', None)
-                if root:
+                if (root := config.get('root', None)):
                     try:
                         self.configure_root(root)
                     except Exception as e:
@@ -772,11 +767,9 @@ class DictConfigurator(BaseConfigurator):
             #Remove any existing handlers
             for h in logger.handlers[:]:
                 logger.removeHandler(h)
-            handlers = config.get('handlers', None)
-            if handlers:
+            if (handlers := config.get('handlers', None)):
                 self.add_handlers(logger, handlers)
-            filters = config.get('filters', None)
-            if filters:
+            if (filters := config.get('filters', None)):
                 self.add_filters(logger, filters)
 
     def configure_logger(self, name, config, incremental=False):

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -586,8 +586,7 @@ class SocketHandler(logging.Handler):
         Pickles the record in binary format with a length prefix, and
         returns it ready for transmission across the socket.
         """
-        ei = record.exc_info
-        if ei:
+        if record.exc_info:
             # just to get traceback text into record.exc_text ...
             dummy = self.format(record)
         # See issue #14436: If msg or args are objects, they may not be
@@ -638,8 +637,7 @@ class SocketHandler(logging.Handler):
         """
         self.acquire()
         try:
-            sock = self.sock
-            if sock:
+            if (sock := self.sock):
                 self.sock = None
                 sock.close()
             logging.Handler.close(self)

--- a/Lib/mailcap.py
+++ b/Lib/mailcap.py
@@ -250,8 +250,7 @@ def test():
             print("No viewer found for", type)
         else:
             print("Executing:", command)
-            sts = os.system(command)
-            if sts:
+            if (sts := os.system(command)):
                 print("Exit status:", sts)
 
 def show(caps):

--- a/Lib/modulefinder.py
+++ b/Lib/modulefinder.py
@@ -174,15 +174,13 @@ class ModuleFinder:
             qname = "%s.%s" % (parent.__name__, head)
         else:
             qname = head
-        q = self.import_module(head, qname, parent)
-        if q:
+        if (q := self.import_module(head, qname, parent)):
             self.msgout(4, "find_head_package ->", (q, tail))
             return q, tail
         if parent:
             qname = head
             parent = None
-            q = self.import_module(head, qname, parent)
-            if q:
+            if (q := self.import_module(head, qname, parent)):
                 self.msgout(4, "find_head_package ->", (q, tail))
                 return q, tail
         self.msgout(4, "raise ImportError: No module named", qname)
@@ -208,8 +206,7 @@ class ModuleFinder:
         for sub in fromlist:
             if sub == "*":
                 if not recursive:
-                    all = self.find_all_submodules(m)
-                    if all:
+                    if (all := self.find_all_submodules(m)):
                         self.ensure_fromlist(m, all, 1)
             elif not hasattr(m, sub):
                 subname = "%s.%s" % (m.__name__, sub)
@@ -408,8 +405,7 @@ class ModuleFinder:
 
     def load_package(self, fqname, pathname):
         self.msgin(2, "load_package", fqname, pathname)
-        newname = replacePackageMap.get(fqname)
-        if newname:
+        if (newname := replacePackageMap.get(fqname)):
             fqname = newname
         m = self.add_module(fqname)
         m.__file__ = pathname

--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -133,8 +133,7 @@ class Queue(object):
         try:
             self._reader.close()
         finally:
-            close = self._close
-            if close:
+            if (close := self._close):
                 self._close = None
                 close()
 

--- a/Lib/nntplib.py
+++ b/Lib/nntplib.py
@@ -950,8 +950,7 @@ class _NNTPBase:
             if usenetrc and not user:
                 import netrc
                 credentials = netrc.netrc()
-                auth = credentials.authenticators(self.host)
-                if auth:
+                if (auth := credentials.authenticators(self.host)):
                     user = auth[0]
                     password = auth[2]
         except OSError:

--- a/Lib/pdb.py
+++ b/Lib/pdb.py
@@ -326,8 +326,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
 
     # Called before loop, handles display expressions
     def preloop(self):
-        displaying = self.displaying.get(self.curframe)
-        if displaying:
+        if (displaying := self.displaying.get(self.curframe)):
             for expr, oldvalue in displaying.items():
                 newvalue = self._getval_except(expr)
                 # check for identity first; this prevents custom __eq__ to
@@ -674,11 +673,9 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         if not filename:
             filename = self.defaultFile()
         # Check for reasonable breakpoint
-        line = self.checkline(filename, lineno)
-        if line:
+        if (line := self.checkline(filename, lineno)):
             # now set the break point
-            err = self.set_break(filename, line, temporary, cond, funcname)
-            if err:
+            if (err := self.set_break(filename, line, temporary, cond, funcname)):
                 self.error(err)
             else:
                 bp = self.get_breaks(filename, line)[-1]
@@ -733,8 +730,7 @@ class Pdb(bdb.Bdb, cmd.Cmd):
         else:
             # More than one part.
             # First is module, second is method/class
-            f = self.lookupmodule(parts[0])
-            if f:
+            if (f := self.lookupmodule(parts[0])):
                 fname = f
             item = parts[1]
         answer = find_function(item, fname)

--- a/Lib/pickletools.py
+++ b/Lib/pickletools.py
@@ -216,8 +216,7 @@ def read_uint1(f):
     255
     """
 
-    data = f.read(1)
-    if data:
+    if (data := f.read(1)):
         return data[0]
     raise ValueError("not enough data in stream to read uint1")
 

--- a/Lib/platform.py
+++ b/Lib/platform.py
@@ -516,8 +516,7 @@ def system_alias(system, release, version):
             # These releases use the old name SunOS
             return system, release, version
         # Modify release (marketing release = SunOS release - 3)
-        l = release.split('.')
-        if l:
+        if (l := release.split('.')):
             try:
                 major = int(l[0])
             except ValueError:

--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -182,8 +182,7 @@ class PrettyPrinter:
         write('{')
         if self._indent_per_level > 1:
             write((self._indent_per_level - 1) * ' ')
-        length = len(object)
-        if length:
+        if len(object):
             items = sorted(object.items(), key=_safe_tuple)
             self._format_dict_items(items, stream, indent, allowance + 1,
                                     context, level)

--- a/Lib/py_compile.py
+++ b/Lib/py_compile.py
@@ -142,8 +142,7 @@ def compile(file, cfile=None, dfile=None, doraise=False, optimize=-1,
             sys.stderr.write(py_exc.msg + '\n')
             return
     try:
-        dirname = os.path.dirname(cfile)
-        if dirname:
+        if (dirname := os.path.dirname(cfile)):
             os.makedirs(dirname)
     except FileExistsError:
         pass

--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -1242,8 +1242,7 @@ location listed above.
             if argspec and argspec != '()':
                 push(name + argspec + '\n')
 
-        doc = getdoc(object)
-        if doc:
+        if (doc := getdoc(object)):
             push(doc + '\n')
 
         # List the mro, if non-trivial.

--- a/Lib/selectors.py
+++ b/Lib/selectors.py
@@ -332,8 +332,7 @@ class SelectSelector(_BaseSelectorImpl):
             if fd in w:
                 events |= EVENT_WRITE
 
-            key = self._key_from_fd(fd)
-            if key:
+            if (key := self._key_from_fd(fd)):
                 ready.append((key, events & key.events))
         return ready
 
@@ -422,8 +421,7 @@ class _PollLikeSelector(_BaseSelectorImpl):
             if event & ~self._EVENT_WRITE:
                 events |= EVENT_READ
 
-            key = self._key_from_fd(fd)
-            if key:
+            if (key := self._key_from_fd(fd)):
                 ready.append((key, events & key.events))
         return ready
 
@@ -475,8 +473,7 @@ if hasattr(select, 'epoll'):
                 if event & ~select.EPOLLOUT:
                     events |= EVENT_READ
 
-                key = self._key_from_fd(fd)
-                if key:
+                if (key := self._key_from_fd(fd)):
                     ready.append((key, events & key.events))
             return ready
 
@@ -567,8 +564,7 @@ if hasattr(select, 'kqueue'):
                 if flag == select.KQ_FILTER_WRITE:
                     events |= EVENT_WRITE
 
-                key = self._key_from_fd(fd)
-                if key:
+                if (key := self._key_from_fd(fd)):
                     ready.append((key, events & key.events))
             return ready
 

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -243,8 +243,7 @@ def check_enableusersite():
 
 # Copy of sysconfig._getuserbase()
 def _getuserbase():
-    env_base = os.environ.get("PYTHONUSERBASE", None)
-    if env_base:
+    if (env_base := os.environ.get("PYTHONUSERBASE", None)):
         return env_base
 
     def joinuser(*args):

--- a/Lib/smtpd.py
+++ b/Lib/smtpd.py
@@ -549,8 +549,7 @@ class SMTPChannel(asynchat.async_chat):
             elif smtputf8 is not False:
                 self.push('501 Error: SMTPUTF8 takes no arguments')
                 return
-        size = params.pop('SIZE', None)
-        if size:
+        if (size := params.pop('SIZE', None)):
             if not size.isdigit():
                 self.push(syntaxerr)
                 return

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -460,8 +460,7 @@ class SMTP:
             # 1) Else our SMTP feature parser gets confused.
             # 2) There are some servers that only advertise the auth methods we
             #    support using the old style.
-            auth_match = OLDSTYLE_AUTH.match(each)
-            if auth_match:
+            if (auth_match := OLDSTYLE_AUTH.match(each)):
                 # This doesn't remove duplicates, but that's no problem
                 self.esmtp_features["auth"] = self.esmtp_features.get("auth", "") \
                         + " " + auth_match.groups(0)[0]

--- a/Lib/sndhdr.py
+++ b/Lib/sndhdr.py
@@ -60,8 +60,7 @@ def whathdr(filename):
     with open(filename, 'rb') as f:
         h = f.read(512)
         for tf in tests:
-            res = tf(h, f)
-            if res:
+            if (res := tf(h, f)):
                 return SndHeaders(*res)
         return None
 
@@ -129,8 +128,7 @@ tests.append(test_au)
 def test_hcom(h, f):
     if h[65:69] != b'FSSD' or h[128:132] != b'HCOM':
         return None
-    divisor = get_long_be(h[144:148])
-    if divisor:
+    if (divisor := get_long_be(h[144:148])):
         rate = 22050 / divisor
     else:
         rate = 0

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -174,14 +174,12 @@ class socket(_socket.socket):
                self.proto)
         if not closed:
             try:
-                laddr = self.getsockname()
-                if laddr:
+                if (laddr := self.getsockname()):
                     s += ", laddr=%s" % str(laddr)
             except error:
                 pass
             try:
-                raddr = self.getpeername()
-                if raddr:
+                if (raddr := self.getpeername()):
                     s += ", raddr=%s" % str(raddr)
             except error:
                 pass

--- a/Lib/socketserver.py
+++ b/Lib/socketserver.py
@@ -229,8 +229,7 @@ class BaseServer:
                 selector.register(self, selectors.EVENT_READ)
 
                 while not self.__shutdown_request:
-                    ready = selector.select(poll_interval)
-                    if ready:
+                    if selector.select(poll_interval):
                         self._handle_request_noblock()
 
                     self.service_actions()
@@ -288,8 +287,7 @@ class BaseServer:
             selector.register(self, selectors.EVENT_READ)
 
             while True:
-                ready = selector.select(timeout)
-                if ready:
+                if selector.select(timeout):
                     return self._handle_request_noblock()
                 else:
                     if timeout is not None:
@@ -597,8 +595,7 @@ if hasattr(os, "fork"):
 
         def process_request(self, request, client_address):
             """Fork a new subprocess to process the request."""
-            pid = os.fork()
-            if pid:
+            if (pid := os.fork()):
                 # Parent process
                 if self.active_children is None:
                     self.active_children = set()

--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -294,11 +294,9 @@ class Tokenizer:
 
 def _class_escape(source, escape):
     # handle escape code inside character class
-    code = ESCAPES.get(escape)
-    if code:
+    if (code := ESCAPES.get(escape)):
         return code
-    code = CATEGORIES.get(escape)
-    if code and code[0] is IN:
+    if (code := CATEGORIES.get(escape)) and code[0] is IN:
         return code
     try:
         c = escape[1:2]
@@ -354,11 +352,9 @@ def _class_escape(source, escape):
 
 def _escape(source, escape, state):
     # handle escape code in expression
-    code = CATEGORIES.get(escape)
-    if code:
+    if (code := CATEGORIES.get(escape)):
         return code
-    code = ESCAPES.get(escape)
-    if code:
+    if (code := ESCAPES.get(escape)):
         return code
     try:
         c = escape[1:2]

--- a/Lib/sunau.py
+++ b/Lib/sunau.py
@@ -298,8 +298,7 @@ class Au_read:
         self._soundpos = pos
 
     def close(self):
-        file = self._file
-        if file:
+        if (file := self._file):
             self._file = None
             if self._opened:
                 file.close()

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -181,8 +181,7 @@ def _get_default_scheme():
 # NOTE: site.py has copy of this function.
 # Sync it when modify this function.
 def _getuserbase():
-    env_base = os.environ.get("PYTHONUSERBASE", None)
-    if env_base:
+    if (env_base := os.environ.get("PYTHONUSERBASE", None)):
         return env_base
 
     def joinuser(*args):
@@ -224,8 +223,7 @@ def _parse_makefile(filename, vars=None):
     for line in lines:
         if line.startswith('#') or line.strip() == '':
             continue
-        m = _variable_rx.match(line)
-        if m:
+        if (m := _variable_rx.match(line)):
             n, v = m.group(1, 2)
             v = v.strip()
             # `$$' is a literal `$' in make
@@ -449,8 +447,7 @@ def parse_config_h(fp, vars=None):
         line = fp.readline()
         if not line:
             break
-        m = define_rx.match(line)
-        if m:
+        if (m := define_rx.match(line)):
             n, v = m.group(1, 2)
             try:
                 v = int(v)
@@ -458,8 +455,7 @@ def parse_config_h(fp, vars=None):
                 pass
             vars[n] = v
         else:
-            m = undef_rx.match(line)
-            if m:
+            if (m := undef_rx.match(line)):
                 vars[m.group(1)] = 0
     return vars
 
@@ -659,8 +655,7 @@ def get_platform():
         osname = "cygwin"
         import re
         rel_re = re.compile(r'[\d.]+')
-        m = rel_re.match(release)
-        if m:
+        if (m := rel_re.match(release)):
             release = m.group()
     elif osname[:6] == "darwin":
         import _osx_support

--- a/Lib/telnetlib.py
+++ b/Lib/telnetlib.py
@@ -617,8 +617,7 @@ class Telnet:
             while not self.eof:
                 self.process_rawq()
                 for i in indices:
-                    m = list[i].search(self.cookedq)
-                    if m:
+                    if (m := list[i].search(self.cookedq)):
                         e = m.end()
                         text = self.cookedq[:e]
                         self.cookedq = self.cookedq[e:]

--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -164,8 +164,7 @@ def _candidate_tempdir_list():
 
     # First, try the environment.
     for envname in 'TMPDIR', 'TEMP', 'TMP':
-        dirname = _os.getenv(envname)
-        if dirname: dirlist.append(dirname)
+        if (dirname := _os.getenv(envname)): dirlist.append(dirname)
 
     # Failing that, try OS-specific locations.
     if _os.name == 'nt':

--- a/Lib/token.py
+++ b/Lib/token.py
@@ -115,8 +115,7 @@ def _main():
     tokens = {}
     prev_val = None
     for line in lines:
-        match = prog.match(line)
-        if match:
+        if (match := prog.match(line)):
             name, val = match.group(1, 2)
             val = int(val)
             tokens[val] = {'token': name}          # reverse so we can sort them...

--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -422,8 +422,7 @@ def detect_encoding(readline):
     if not first:
         return default, []
 
-    encoding = find_cookie(first)
-    if encoding:
+    if (encoding := find_cookie(first)):
         return encoding, [first]
     if not blank_re.match(first):
         return default, [first]
@@ -432,8 +431,7 @@ def detect_encoding(readline):
     if not second:
         return default, [first]
 
-    encoding = find_cookie(second)
-    if encoding:
+    if (encoding := find_cookie(second)):
         return encoding, [first, second]
 
     return default, [first, second]
@@ -506,8 +504,7 @@ def _tokenize(readline, encoding):
         if contstr:                            # continued string
             if not line:
                 raise TokenError("EOF in multi-line string", strstart)
-            endmatch = endprog.match(line)
-            if endmatch:
+            if (endmatch := endprog.match(line)):
                 pos = end = endmatch.end(0)
                 yield TokenInfo(STRING, contstr + line[:end],
                        strstart, (lnum, end), contline + line)
@@ -569,8 +566,7 @@ def _tokenize(readline, encoding):
             continued = 0
 
         while pos < max:
-            pseudomatch = _compile(PseudoToken).match(line, pos)
-            if pseudomatch:                                # scan for tokens
+            if (pseudomatch := _compile(PseudoToken).match(line, pos)):                                # scan for tokens
                 start, end = pseudomatch.span(1)
                 spos, epos, pos = (lnum, start), (lnum, end), end
                 if start == end:
@@ -592,8 +588,7 @@ def _tokenize(readline, encoding):
 
                 elif token in triple_quoted:
                     endprog = _compile(endpats[token])
-                    endmatch = endprog.match(line, pos)
-                    if endmatch:                           # all on one line
+                    if (endmatch := endprog.match(line, pos)):                           # all on one line
                         pos = endmatch.end(0)
                         token = line[start:pos]
                         yield TokenInfo(STRING, token, spos, (lnum, pos), line)

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -471,8 +471,7 @@ class Trace:
 
     def file_module_function_of(self, frame):
         code = frame.f_code
-        filename = code.co_filename
-        if filename:
+        if (filename := code.co_filename):
             modulename = _modname(filename)
         else:
             modulename = None
@@ -538,8 +537,7 @@ class Trace:
         """
         if why == 'call':
             code = frame.f_code
-            filename = frame.f_globals.get('__file__', None)
-            if filename:
+            if (filename := frame.f_globals.get('__file__', None)):
                 # XXX _modname() doesn't work right for packages, so
                 # the ignore support won't work right for packages
                 modulename = _modname(filename)

--- a/Lib/tracemalloc.py
+++ b/Lib/tracemalloc.py
@@ -226,8 +226,7 @@ class Traceback(Sequence):
         for frame in frame_slice:
             lines.append('  File "%s", line %s'
                          % (frame.filename, frame.lineno))
-            line = linecache.getline(frame.filename, frame.lineno).strip()
-            if line:
+            if (line := linecache.getline(frame.filename, frame.lineno).strip()):
                 lines.append('    %s' % line)
         return lines
 

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -393,16 +393,14 @@ def _ifconfig_getnode():
     # This works on Linux ('' or '-a'), Tru64 ('-av'), but not all Unixes.
     keywords = (b'hwaddr', b'ether', b'address:', b'lladdr')
     for args in ('', '-a', '-av'):
-        mac = _find_mac('ifconfig', args, keywords, lambda i: i+1)
-        if mac:
+        if (mac := _find_mac('ifconfig', args, keywords, lambda i: i+1)):
             return mac
         return None
 
 def _ip_getnode():
     """Get the hardware address on Unix by running ip."""
     # This works on Linux with iproute2.
-    mac = _find_mac('ip', 'link', [b'link/ether'], lambda i: i+1)
-    if mac:
+    if (mac := _find_mac('ip', 'link', [b'link/ether'], lambda i: i+1)):
         return mac
     return None
 

--- a/Lib/wave.py
+++ b/Lib/wave.py
@@ -188,8 +188,7 @@ class Wave_read:
 
     def close(self):
         self._file = None
-        file = self._i_opened_the_file
-        if file:
+        if (file := self._i_opened_the_file):
             self._i_opened_the_file = None
             file.close()
 
@@ -448,8 +447,7 @@ class Wave_write:
                 self._file.flush()
         finally:
             self._file = None
-            file = self._i_opened_the_file
-            if file:
+            if (file := self._i_opened_the_file):
                 self._i_opened_the_file = None
                 file.close()
 

--- a/Lib/weakref.py
+++ b/Lib/weakref.py
@@ -576,8 +576,7 @@ class finalize:
 
     @atexit.setter
     def atexit(self, value):
-        info = self._registry.get(self)
-        if info:
+        if (info := self._registry.get(self)):
             info.atexit = bool(value)
 
     def __repr__(self):

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -206,8 +206,7 @@ class UnixBrowser(BaseBrowser):
         if remote and self.raise_opts:
             # use autoraise argument only for remote invocation
             autoraise = int(autoraise)
-            opt = self.raise_opts[autoraise]
-            if opt: raise_opt = [opt]
+            if (opt := self.raise_opts[autoraise]): raise_opt = [opt]
 
         cmdline = [self.name] + raise_opt + args
 

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -898,9 +898,10 @@ class ZipExtFile(io.BufferedIOBase):
             buf = self._readbuffer[self._offset:]
             self._readbuffer = b''
             self._offset = 0
-            while not self._eof and (data := self._read1(self.MAX_N)):
-                buf += data
-                break
+            while not self._eof:
+                if (data := self._read1(self.MAX_N)):
+                    buf += data
+                    break
             return buf
 
         end = n + self._offset

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -681,12 +681,10 @@ def _get_decompressor(compress_type):
         return bz2.BZ2Decompressor()
     elif compress_type == ZIP_LZMA:
         return LZMADecompressor()
+    elif (descr := compressor_names.get(compress_type)):
+        raise NotImplementedError("compression type %d (%s)" % (compress_type, descr))
     else:
-        descr = compressor_names.get(compress_type)
-        if descr:
-            raise NotImplementedError("compression type %d (%s)" % (compress_type, descr))
-        else:
-            raise NotImplementedError("compression type %d" % (compress_type,))
+        raise NotImplementedError("compression type %d" % (compress_type,))
 
 
 class _SharedFile:
@@ -900,11 +898,9 @@ class ZipExtFile(io.BufferedIOBase):
             buf = self._readbuffer[self._offset:]
             self._readbuffer = b''
             self._offset = 0
-            while not self._eof:
-                data = self._read1(self.MAX_N)
-                if data:
-                    buf += data
-                    break
+            while not self._eof and (data := self._read1(self.MAX_N)):
+                buf += data
+                break
             return buf
 
         end = n + self._offset


### PR DESCRIPTION
Replace:

    var = expr
    if var:
        ...

with:

    if (var := expr):
        ...

Don't replace when:

* var is used after the if
* Code like ``var = regex.match(); if var: return var.group(1)``
  is left unchanged since it's covered by a dedicated PR.

Sometimes, var is only used in the condition and so has been removed
in this change. Maybe such kind of pattern should be addressed in a
different pull request.

This patch is restricted to the simplest test ``if var:``, other
conditions like ``if var > 0:`` are left unchaned to keep this change
reviewable (short enough).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
