### PR TITLE
[2.7] bpo-34019: Fix wrong arguments for Opera Browser (GH-8047)

### DIFF
--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -319,11 +319,10 @@ Chromium = Chrome
 class Opera(UnixBrowser):
     "Launcher class for Opera browser."
 
-    raise_opts = ["-noraise", ""]
-    remote_args = ['-remote', 'openURL(%s%action)']
+    remote_args = ['%action', '%s']
     remote_action = ""
-    remote_action_newwin = ",new-window"
-    remote_action_newtab = ",new-page"
+    remote_action_newwin = "--new-window"
+    remote_action_newtab = ""
     background = True
 
 

--- a/Misc/NEWS.d/next/Library/2018-07-02-05-59-11.bpo-34019.ZXJIife.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-02-05-59-11.bpo-34019.ZXJIife.rst
@@ -1,0 +1,2 @@
+webbrowser: Correct the arguments passed to Opera Browser when opening a new URL
+using the ``webbrowser`` module. Patch by Bumsik Kim.


### PR DESCRIPTION
The Opera Browser was using an outdated command line invocation that resulted in an incorrect URL being opened in the browser when requested using the webbrowser module.

* Correct the arguments passed to the Opera Browser when opening a new URL..
(cherry picked from commit 3cf1f154edb88c108877729ea09f4ac174697fea)

Co-authored-by: Bumsik Kim <k.bumsik@gmail.com>

<!-- issue-number: bpo-34019 -->
https://bugs.python.org/issue34019
<!-- /issue-number -->
