### PR TITLE
bpo-23493: json: Change sort_keys in Python encoder same to C

### DIFF
--- a/Lib/json/encoder.py
+++ b/Lib/json/encoder.py
@@ -350,7 +350,7 @@ def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
             item_separator = _item_separator
         first = True
         if _sort_keys:
-            items = sorted(dct.items(), key=lambda kv: kv[0])
+            items = sorted(dct.items())
         else:
             items = dct.items()
         for key, value in items:

--- a/Misc/NEWS.d/next/Library/2018-07-06-16-52-08.bpo-23493.xAuPmu.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-06-16-52-08.bpo-23493.xAuPmu.rst
@@ -1,1 +1,0 @@
-Optimize ``sort_keys`` option of pure Python JSON encoder.

--- a/Misc/NEWS.d/next/Library/2018-07-06-16-52-08.bpo-23493.xAuPmu.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-06-16-52-08.bpo-23493.xAuPmu.rst
@@ -1,0 +1,1 @@
+Optimize ``sort_keys`` option of pure Python JSON encoder.


### PR DESCRIPTION
Stop using key=lambda idiom.  This behavior is same to
C version encoder.

<!-- issue-number: bpo-23493 -->
https://bugs.python.org/issue23493
<!-- /issue-number -->
