### PR TITLE
[2.7] bpo-33899: Make tokenize module mirror end-of-file is end-of-li…

### DIFF
--- a/Lib/tokenize.py
+++ b/Lib/tokenize.py
@@ -306,8 +306,15 @@ def generate_tokens(readline):
     contline = None
     indents = [0]
 
+    last_line = b''
+    line = b''
     while 1:                                   # loop over lines in stream
         try:
+            # We capture the value of the line variable here because
+            # readline uses the empty string '' to signal end of input,
+            # hence `line` itself will always be overwritten at the end
+            # of this loop.
+            last_line = line
             line = readline()
         except StopIteration:
             line = ''
@@ -437,6 +444,9 @@ def generate_tokens(readline):
                            (lnum, pos), (lnum, pos+1), line)
                 pos += 1
 
+    # Add an implicit NEWLINE if the input doesn't end in one
+    if last_line and last_line[-1] not in '\r\n':
+        yield (NEWLINE, '', (lnum - 1, len(last_line)), (lnum - 1, len(last_line) + 1), '')
     for indent in indents[1:]:                 # pop remaining indent levels
         yield (DEDENT, '', (lnum, 0), (lnum, 0), '')
     yield (ENDMARKER, '', (lnum, 0), (lnum, 0), '')

--- a/Misc/NEWS.d/next/Library/2018-06-24-01-57-14.bpo-33899.IaOcAr.rst
+++ b/Misc/NEWS.d/next/Library/2018-06-24-01-57-14.bpo-33899.IaOcAr.rst
@@ -1,0 +1,3 @@
+Tokenize module now implicitly emits a NEWLINE when provided with input that
+does not have a trailing new line.  This behavior now matches what the C
+tokenizer does internally.  Contributed by Ammar Askar.


### PR DESCRIPTION


<!-- issue-number: bpo-33899 -->
https://bugs.python.org/issue33899
<!-- /issue-number -->
