### PR TITLE
bpo-34065: Fix wrongly written basicConfig document rst syntax about force

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1186,25 +1186,24 @@ functions.
    |              | with *filename* or *stream* - if both       |
    |              | are present, a ``ValueError`` is raised.    |
    +--------------+---------------------------------------------+
-   | ``force``    | If this keyword argument is specified as    |
+   | *force*      | If this keyword argument is specified as    |
    |              | true, any existing handlers attached to the |
    |              | root logger are removed and closed, before  |
    |              | carrying out the configuration as specified |
    |              | by the other arguments.                     |
    +--------------+---------------------------------------------+
 
-   .. versionchanged:: 3.8
-      The ``force`` argument was added.
-
    .. versionchanged:: 3.2
-      The ``style`` argument was added.
+      The *style* argument was added.
 
    .. versionchanged:: 3.3
-      The ``handlers`` argument was added. Additional checks were added to
+      The *handlers* argument was added. Additional checks were added to
       catch situations where incompatible arguments are specified (e.g.
-      ``handlers`` together with ``stream`` or ``filename``, or ``stream``
-      together with ``filename``).
+      *handlers* together with *stream* or *filename*, or *stream*
+      together with *filename*).
 
+   .. versionchanged:: 3.8
+      The *force* argument was added.
 
 .. function:: shutdown()
 

--- a/Misc/NEWS.d/next/Documentation/2018-07-07-20-38-41.bpo-34065.1snofM.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-07-07-20-38-41.bpo-34065.1snofM.rst
@@ -1,0 +1,1 @@
+Fix wrongly written basicConfig documentation markup syntax


### PR DESCRIPTION


<!-- issue-number: bpo-34065 -->
https://bugs.python.org/issue34065
<!-- /issue-number -->
