### PR TITLE
bpo-32523: Simplifying news entries with multiple paragraphs.

### DIFF
--- a/Misc/NEWS.d/3.5.0a2.rst
+++ b/Misc/NEWS.d/3.5.0a2.rst
@@ -112,7 +112,6 @@ Lawrence.
 .. section: Library
 
 Corrected pure python implementation of timedelta division.
-
 Eliminated OverflowError from ``timedelta * float`` for some floats;
 Corrected rounding in timedelta true division.
 

--- a/Misc/NEWS.d/3.5.2rc1.rst
+++ b/Misc/NEWS.d/3.5.2rc1.rst
@@ -678,7 +678,6 @@ Fixed the comparison of plistlib.Data with other types.
 .. section: Library
 
 Fix an uninitialized variable in `ctypes.util`.
-
 The bug only occurs on SunOS when the ctypes implementation searches for the
 `crle` program.  Patch by Xiang Zhang.  Tested on SunOS by Kees Bos.
 

--- a/Misc/NEWS.d/3.5.3rc1.rst
+++ b/Misc/NEWS.d/3.5.3rc1.rst
@@ -751,7 +751,6 @@ command.
 .. section: Library
 
 Fixed calendar functions for extreme months: 0001-01 and 9999-12.
-
 Methods itermonthdays() and itermonthdays2() are reimplemented so that they
 don't call itermonthdates() which can cause datetime.date under/overflow.
 

--- a/Misc/NEWS.d/3.5.4rc1.rst
+++ b/Misc/NEWS.d/3.5.4rc1.rst
@@ -250,7 +250,6 @@ by Nir Soffer.
 .. section: Library
 
 signal.setitimer() may disable the timer when passed a tiny value.
-
 Tiny values (such as 1e-6) are valid non-zero values for setitimer(), which
 is specified as taking microsecond-resolution intervals. However, on some
 platform, our conversion routine could convert 1e-6 into a zero interval,
@@ -1001,15 +1000,12 @@ test_zipfile64.
 .. section: Tests
 
 regrtest: Enhance regrtest and backport features from the master branch.
-
 Add options: --coverage, --testdir, --list-tests (list test files, don't run
 them), --list-cases (list test identifiers, don't run them, :issue:`30523`),
 --matchfile (load a list of test filters from a text file, :issue:`30540`),
 --slowest (alias to --slow).
-
 Enhance output: add timestamp, test result, currently running tests, "Tests
 result: xxx" summary with total duration, etc.
-
 Fix reference leak hunting in regrtest, --huntrleaks: regrtest now warms up
 caches, create explicitly all internal singletons which are created on
 demand to prevent false positives when checking for reference leaks.

--- a/Misc/NEWS.d/3.5.5rc1.rst
+++ b/Misc/NEWS.d/3.5.5rc1.rst
@@ -10,7 +10,6 @@ by revealing an inconsistency in how sys.path is initialized when executing
 considered a potential security issue, as it may lead to privileged
 processes unexpectedly loading code from user controlled directories in
 situations where that was not previously the case.
-
 The interpreter now consistently avoids ever adding the import location's
 parent directory to ``sys.path``, and ensures no other ``sys.path`` entries
 are inadvertently modified when inserting the import location named on the
@@ -56,11 +55,10 @@ Fix potential crash during GC caused by ``tp_dealloc`` which doesn't call
 .. section: Library
 
 Fixed issues with binary plists:
-
-* Fixed saving bytearrays.
-* Identical objects will be saved only once.
-* Equal references will be load as identical objects.
-* Added support for saving and loading recursive data structures.
+Fixed saving bytearrays.
+Identical objects will be saved only once.
+Equal references will be load as identical objects.
+Added support for saving and loading recursive data structures.
 
 ..
 

--- a/Misc/NEWS.d/3.6.0a1.rst
+++ b/Misc/NEWS.d/3.6.0a1.rst
@@ -1081,7 +1081,6 @@ Fixed the comparison of plistlib.Data with other types.
 .. section: Library
 
 Fix an uninitialized variable in `ctypes.util`.
-
 The bug only occurs on SunOS when the ctypes implementation searches for the
 `crle` program.  Patch by Xiang Zhang.  Tested on SunOS by Kees Bos.
 

--- a/Misc/NEWS.d/3.6.0b2.rst
+++ b/Misc/NEWS.d/3.6.0b2.rst
@@ -378,7 +378,6 @@ xml.etree.ElementTree.Element.
 .. section: Library
 
 Stop using localtime() and gmtime() in the time module.
-
 Introduced platform independent _PyTime_localtime API that is similar to
 POSIX localtime_r, but available on all platforms.  Patch by Ed Schouten.
 
@@ -390,7 +389,6 @@ POSIX localtime_r, but available on all platforms.  Patch by Ed Schouten.
 .. section: Library
 
 Fixed calendar functions for extreme months: 0001-01 and 9999-12.
-
 Methods itermonthdays() and itermonthdays2() are reimplemented so that they
 don't call itermonthdates() which can cause datetime.date under/overflow.
 

--- a/Misc/NEWS.d/3.6.2rc1.rst
+++ b/Misc/NEWS.d/3.6.2rc1.rst
@@ -872,7 +872,6 @@ the link targets for :func:`bytes` and :func:`bytearray` are now their
 respective type definitions, rather than the corresponding builtin function
 entries. Use :ref:`bytes <func-bytes>` and :ref:`bytearray <func-bytearray>`
 to reference the latter.
-
 In order to ensure this and future cross-reference updates are applied
 automatically, the daily documentation builds now disable the default output
 caching features in Sphinx.

--- a/Misc/NEWS.d/3.6.3rc1.rst
+++ b/Misc/NEWS.d/3.6.3rc1.rst
@@ -196,7 +196,6 @@ ImportError rather than SystemError.
 .. section: Core and Builtins
 
 Improve signal delivery.
-
 Avoid using Py_AddPendingCall from signal handler, to avoid calling
 signal-unsafe functions. The tests I'm adding here fail without the rest of
 the patch, on Linux and OS X. This means our signal delivery logic had
@@ -596,7 +595,6 @@ Fix out of bounds write in `asyncio.CFuture.remove_done_callback()`.
 .. section: Library
 
 signal.setitimer() may disable the timer when passed a tiny value.
-
 Tiny values (such as 1e-6) are valid non-zero values for setitimer(), which
 is specified as taking microsecond-resolution intervals. However, on some
 platform, our conversion routine could convert 1e-6 into a zero interval,
@@ -774,7 +772,6 @@ Add a missing xmlns to python.manifest so that it matches the schema.
 .. section: IDLE
 
 IDLE code context -- fix code update and font update timers.
-
 Canceling timers prevents a warning message when test_idle completes.
 
 ..
@@ -817,7 +814,6 @@ IDLE - make tests pass with zzdummy extension disabled by default.
 
 Document how IDLE runs tkinter programs. IDLE calls tcl/tk update in the
 background in order to make live
-
 interaction and experimentation with tkinter applications much easier.
 
 ..
@@ -847,7 +843,6 @@ Rearrange IDLE configdialog GenPage into Window, Editor, and Help sections.
 .. section: IDLE
 
 IDLE - Add docstrings and tests for outwin subclass of editor.
-
 Move some data and functions from the class to module level. Patch by Cheryl
 Sabella.
 
@@ -868,24 +863,20 @@ IDLE - Do not modify tkinter.message in test_configdialog.
 .. section: IDLE
 
 Convert IDLE's built-in 'extensions' to regular features.
-
 About 10 IDLE features were implemented as supposedly optional extensions.
 Their different behavior could be confusing or worse for users and not good
 for maintenance.  Hence the conversion.
-
 The main difference for users is that user configurable key bindings for
 builtin features are now handled uniformly.  Now, editing a binding in a
 keyset only affects its value in the keyset.  All bindings are defined
 together in the system-specific default keysets in config-extensions.def.
 All custom keysets are saved as a whole in config-extension.cfg.  All take
 effect as soon as one clicks Apply or Ok.
-
 The affected events are '<<force-open-completions>>', '<<expand-word>>',
 '<<force-open-calltip>>', '<<flash-paren>>', '<<format-paragraph>>',
 '<<run-module>>', '<<check-module>>', and '<<zoom-height>>'.  Any (global)
 customizations made before 3.6.3 will not affect their keyset-specific
 customization after 3.6.3. and vice versa.
-
 Inital patch by Charles Wohlganger.
 
 ..
@@ -974,7 +965,6 @@ continue to pass. Patch by Cheryl Sabella.
 .. section: IDLE
 
 IDLE - Factor FontPage(Frame) class from ConfigDialog.
-
 Slightly modified tests continue to pass. Fix General tests. Patch mostly by
 Cheryl Sabella.
 
@@ -1007,7 +997,6 @@ the tabs and will enable splitting the groups into classes.
 .. section: IDLE
 
 IDLE -- Factor a VarTrace class out of ConfigDialog.
-
 Instance tracers manages pairs consisting of a tk variable and a callback
 function.  When tracing is turned on, setting the variable calls the
 function.  Test coverage for the new class is 100%.
@@ -1029,12 +1018,10 @@ IDLE: Add more tests for General tab.
 .. section: IDLE
 
 IDLE - Improve configdialog font page and tests.
-
 In configdialog: Document causal pathways in create_font_tab docstring.
 Simplify some attribute names. Move set_samples calls to var_changed_font
 (idea from Cheryl Sabella).  Move related functions to positions after the
 create widgets function.
-
 In test_configdialog: Fix test_font_set so not order dependent.  Fix renamed
 test_indent_scale so it tests the widget.  Adjust tests for movement of
 set_samples call.  Add tests for load functions.  Put all font tests in one
@@ -1077,12 +1064,9 @@ Patch by Louie Lu.
 .. section: IDLE
 
 Document coverage details for idlelib tests.
-
-* Add section to idlelib/idle-test/README.txt.
-
-* Include check that branches are taken both ways.
-
-* Exclude IDLE-specific code that does not run during unit tests.
+Add section to idlelib/idle-test/README.txt.
+Include check that branches are taken both ways.
+Exclude IDLE-specific code that does not run during unit tests.
 
 ..
 

--- a/Misc/NEWS.d/3.6.4rc1.rst
+++ b/Misc/NEWS.d/3.6.4rc1.rst
@@ -18,14 +18,13 @@ function.
 .. section: Core and Builtins
 
 Fixed several issues in printing tracebacks (PyTraceBack_Print()).
-
-* Setting sys.tracebacklimit to 0 or less now suppresses printing tracebacks.
-* Setting sys.tracebacklimit to None now causes using the default limit.
-* Setting sys.tracebacklimit to an integer larger than LONG_MAX now means using
-  the limit LONG_MAX rather than the default limit.
-* Fixed integer overflows in the case of more than 2**31 traceback items on
-  Windows.
-* Fixed output errors handling.
+Setting sys.tracebacklimit to 0 or less now suppresses printing tracebacks.
+Setting sys.tracebacklimit to None now causes using the default limit.
+Setting sys.tracebacklimit to an integer larger than LONG_MAX now means using
+the limit LONG_MAX rather than the default limit.
+Fixed integer overflows in the case of more than 2**31 traceback items on
+Windows.
+Fixed output errors handling.
 
 ..
 
@@ -308,7 +307,6 @@ value of property is ``VT_EMPTY``.  Initial patch by Mark Mc Mahon.
 Fix wrong usage of :func:`collections.namedtuple` in the
 :meth:`RobotFileParser.parse() <urllib.robotparser.RobotFileParser.parse>`
 method.
-
 Initial patch by Robin Wellner.
 
 ..
@@ -340,11 +338,10 @@ characters/bytes for non-negative *n*. This makes it compatible with
 .. section: Library
 
 Fixed issues with binary plists:
-
-* Fixed saving bytearrays.
-* Identical objects will be saved only once.
-* Equal references will be load as identical objects.
-* Added support for saving and loading recursive data structures.
+Fixed saving bytearrays.
+Identical objects will be saved only once.
+Equal references will be load as identical objects.
+Added support for saving and loading recursive data structures.
 
 ..
 
@@ -392,10 +389,8 @@ Reduce performance overhead of asyncio debug mode.
 .. section: Library
 
 Fixed determining the MAC address in the uuid module:
-
-* Using ifconfig on NetBSD and OpenBSD.
-* Using arp on Linux, FreeBSD, NetBSD and OpenBSD.
-
+Using ifconfig on NetBSD and OpenBSD.
+Using arp on Linux, FreeBSD, NetBSD and OpenBSD.
 Based on patch by Takayuki Shimizukawa.
 
 ..
@@ -913,7 +908,6 @@ Avoid wholesale rebuild after `make regen-all` if nothing changed.
 
 Return ``None`` when ``View.Fetch()`` returns ``ERROR_NO_MORE_ITEMS``
 instead of raising ``MSIError``.
-
 Initial patch by Anthony Tuininga.
 
 ..
@@ -997,7 +991,6 @@ persist while IDLE remains open
 .. section: IDLE
 
 Test_code_module now passes if run after test_idle, which sets ps1.
-
 The code module uses sys.ps1 if present or sets it to '>>> ' if not.
 Test_code_module now properly tests both behaviors.  Ditto for ps2.
 
@@ -1034,7 +1027,6 @@ a bit about the additions.
 .. section: IDLE
 
 Simplify the API of IDLE's Module Browser.
-
 Passing a widget instead of an flist with a root widget opens the option of
 creating a browser frame that is only part of a window.  Passing a full file
 name instead of pieces assumed to come from a .py file opens the possibility
@@ -1099,10 +1091,8 @@ for code and tests by Guilherme Polo and Cheryl Sabella, respectively.
 .. section: Tools/Demos
 
 Make redemo work with Python 3.6 and newer versions.
-
 Also, remove the ``LOCALE`` option since it doesn't work with string
 patterns in Python 3.
-
 Patch by Christoph Sarnowski.
 
 ..

--- a/Misc/NEWS.d/3.6.5rc1.rst
+++ b/Misc/NEWS.d/3.6.5rc1.rst
@@ -539,7 +539,6 @@ locale to the ``LC_NUMERIC`` locale to decode ``decimal_point`` and
 ``thousands_sep`` byte strings if they are non-ASCII or longer than 1 byte,
 and the ``LC_NUMERIC`` locale is different than the ``LC_CTYPE`` locale.
 This temporary change affects other threads.
-
 Same change for the :meth:`str.format` method when formatting a number
 (:class:`int`, :class:`float`, :class:`float` and subclasses) with the ``n``
 type (ex: ``'{:n}'.format(1234)``).

--- a/Misc/NEWS.d/3.7.0a1.rst
+++ b/Misc/NEWS.d/3.7.0a1.rst
@@ -335,7 +335,6 @@ ImportError rather than SystemError.
 .. section: Core and Builtins
 
 Improve signal delivery.
-
 Avoid using Py_AddPendingCall from signal handler, to avoid calling
 signal-unsafe functions. The tests I'm adding here fail without the rest of the
 patch, on Linux and OS X. This means our signal delivery logic had defects
@@ -2051,7 +2050,6 @@ Support tzinfo objects with sub-minute offsets.
 .. section: Library
 
 Fix shared memory performance regression in multiprocessing in 3.x.
-
 Shared memory used anonymous memory mappings in 2.x, while 3.x mmaps actual
 files. Try to be careful to do as little disk I/O as possible.
 
@@ -2063,7 +2061,6 @@ files. Try to be careful to do as little disk I/O as possible.
 .. section: Library
 
 Fix too many fds in processes started with the "forkserver" method.
-
 A child process would inherit as many fds as the number of still-running
 children.
 
@@ -2181,7 +2178,6 @@ Use keywords in the ``repr`` of ``datetime.timedelta``.
 .. section: Library
 
 signal.setitimer() may disable the timer when passed a tiny value.
-
 Tiny values (such as 1e-6) are valid non-zero values for setitimer(), which
 is specified as taking microsecond-resolution intervals. However, on some
 platform, our conversion routine could convert 1e-6 into a zero interval,
@@ -2214,7 +2210,6 @@ startup is about 5% faster on Linux and 30% faster on macOS.
 .. section: Library
 
 Add missing parameter "n" on multiprocessing.Condition.notify().
-
 The doc claims multiprocessing.Condition behaves like threading.Condition,
 but its notify() method lacked the optional "n" argument (to specify the
 number of sleepers to wake up) that threading.Condition.notify() accepts.
@@ -4376,7 +4371,6 @@ xml.etree.ElementTree.Element.
 .. section: Library
 
 Stop using localtime() and gmtime() in the time module.
-
 Introduced platform independent _PyTime_localtime API that is similar to
 POSIX localtime_r, but available on all platforms.  Patch by Ed Schouten.
 
@@ -4388,7 +4382,6 @@ POSIX localtime_r, but available on all platforms.  Patch by Ed Schouten.
 .. section: Library
 
 Fixed calendar functions for extreme months: 0001-01 and 9999-12.
-
 Methods itermonthdays() and itermonthdays2() are reimplemented so that they
 don't call itermonthdates() which can cause datetime.date under/overflow.
 
@@ -4805,7 +4798,6 @@ the link targets for :func:`bytes` and :func:`bytearray` are now their
 respective type definitions, rather than the corresponding builtin function
 entries. Use :ref:`bytes <func-bytes>` and :ref:`bytearray <func-bytearray>`
 to reference the latter.
-
 In order to ensure this and future cross-reference updates are applied
 automatically, the daily documentation builds now disable the default output
 caching features in Sphinx.
@@ -5094,7 +5086,6 @@ Allow --with-lto to be used on all builds, not just `make profile-opt`.
 .. section: Build
 
 Remove support for building --without-threads.
-
 This option is not really useful anymore in the 21st century. Removing lots
 of conditional paths allows us to simplify the code base, including in
 difficult to maintain low-level internal code.
@@ -5667,7 +5658,6 @@ Windows ._pth file should allow import site
 .. section: IDLE
 
 IDLE code context -- fix code update and font update timers.
-
 Canceling timers prevents a warning message when test_idle completes.
 
 ..
@@ -5710,7 +5700,6 @@ IDLE - make tests pass with zzdummy extension disabled by default.
 
 Document how IDLE runs tkinter programs. IDLE calls tcl/tk update in the
 background in order to make live
-
 interaction and experimentation with tkinter applications much easier.
 
 ..
@@ -5740,7 +5729,6 @@ Rearrange IDLE configdialog GenPage into Window, Editor, and Help sections.
 .. section: IDLE
 
 IDLE - Add docstrings and tests for outwin subclass of editor.
-
 Move some data and functions from the class to module level. Patch by Cheryl
 Sabella.
 
@@ -5761,24 +5749,20 @@ IDLE - Do not modify tkinter.message in test_configdialog.
 .. section: IDLE
 
 Convert IDLE's built-in 'extensions' to regular features.
-
 About 10 IDLE features were implemented as supposedly optional extensions.
 Their different behavior could be confusing or worse for users and not good
 for maintenance.  Hence the conversion.
-
 The main difference for users is that user configurable key bindings for
 builtin features are now handled uniformly.  Now, editing a binding in a
 keyset only affects its value in the keyset.  All bindings are defined
 together in the system-specific default keysets in config-extensions.def.
 All custom keysets are saved as a whole in config-extension.cfg.  All take
 effect as soon as one clicks Apply or Ok.
-
 The affected events are '<<force-open-completions>>', '<<expand-word>>',
 '<<force-open-calltip>>', '<<flash-paren>>', '<<format-paragraph>>',
 '<<run-module>>', '<<check-module>>', and '<<zoom-height>>'.  Any (global)
 customizations made before 3.6.3 will not affect their keyset-specific
 customization after 3.6.3. and vice versa.
-
 Initial patch by Charles Wohlganger.
 
 ..
@@ -5867,7 +5851,6 @@ continue to pass. Patch by Cheryl Sabella.
 .. section: IDLE
 
 IDLE - Factor FontPage(Frame) class from ConfigDialog.
-
 Slightly modified tests continue to pass. Fix General tests. Patch mostly by
 Cheryl Sabella.
 
@@ -5900,7 +5883,6 @@ the tabs and will enable splitting the groups into classes.
 .. section: IDLE
 
 IDLE -- Factor a VarTrace class out of ConfigDialog.
-
 Instance tracers manages pairs consisting of a tk variable and a callback
 function.  When tracing is turned on, setting the variable calls the
 function.  Test coverage for the new class is 100%.
@@ -5922,12 +5904,10 @@ IDLE: Add more tests for General tab.
 .. section: IDLE
 
 IDLE - Improve configdialog font page and tests.
-
 In configdialog: Document causal pathways in create_font_tab docstring.
 Simplify some attribute names. Move set_samples calls to var_changed_font
 (idea from Cheryl Sabella).  Move related functions to positions after the
 create widgets function.
-
 In test_configdialog: Fix test_font_set so not order dependent.  Fix renamed
 test_indent_scale so it tests the widget.  Adjust tests for movement of
 set_samples call.  Add tests for load functions.  Put all font tests in one
@@ -5970,12 +5950,9 @@ Patch by Louie Lu.
 .. section: IDLE
 
 Document coverage details for idlelib tests.
-
-* Add section to idlelib/idle-test/README.txt.
-
-* Include check that branches are taken both ways.
-
-* Exclude IDLE-specific code that does not run during unit tests.
+Add section to idlelib/idle-test/README.txt.
+Include check that branches are taken both ways.
+Exclude IDLE-specific code that does not run during unit tests.
 
 ..
 
@@ -6311,7 +6288,6 @@ C API manual.
 .. section: C API
 
 Remove own implementation for thread-local storage.
-
 CPython has provided the own implementation for thread-local storage (TLS)
 on Python/thread.c, it's used in the case which a platform has not supplied
 native TLS.  However, currently all supported platforms (Windows and

--- a/Misc/NEWS.d/3.7.0a2.rst
+++ b/Misc/NEWS.d/3.7.0a2.rst
@@ -337,10 +337,8 @@ Fixed typo in the name of Tkinter's method adderrorinfo().
 .. section: Library
 
 Improvements to path predicates in ElementTree:
-
-* Allow whitespace around predicate parts, i.e. "[a = 'text']" instead of requiring the less readable "[a='text']".
-* Add support for text comparison of the current node, like "[.='text']".
-
+Allow whitespace around predicate parts, i.e. "[a = 'text']" instead of requiring the less readable "[a='text']".
+Add support for text comparison of the current node, like "[.='text']".
 Patch by Stefan Behnel.
 
 ..
@@ -596,7 +594,6 @@ Avoid wholesale rebuild after `make regen-all` if nothing changed.
 .. section: IDLE
 
 Simplify the API of IDLE's Module Browser.
-
 Passing a widget instead of an flist with a root widget opens the option of
 creating a browser frame that is only part of a window.  Passing a full file
 name instead of pieces assumed to come from a .py file opens the possibility

--- a/Misc/NEWS.d/3.7.0a3.rst
+++ b/Misc/NEWS.d/3.7.0a3.rst
@@ -96,14 +96,13 @@ from the environment by default).
 .. section: Core and Builtins
 
 Fixed several issues in printing tracebacks (PyTraceBack_Print()).
-
-* Setting sys.tracebacklimit to 0 or less now suppresses printing tracebacks.
-* Setting sys.tracebacklimit to None now causes using the default limit.
-* Setting sys.tracebacklimit to an integer larger than LONG_MAX now means using
-  the limit LONG_MAX rather than the default limit.
-* Fixed integer overflows in the case of more than 2**31 traceback items on
-  Windows.
-* Fixed output errors handling.
+Setting sys.tracebacklimit to 0 or less now suppresses printing tracebacks.
+Setting sys.tracebacklimit to None now causes using the default limit.
+Setting sys.tracebacklimit to an integer larger than LONG_MAX now means using
+the limit LONG_MAX rather than the default limit.
+Fixed integer overflows in the case of more than 2**31 traceback items on
+Windows.
+Fixed output errors handling.
 
 ..
 
@@ -388,7 +387,6 @@ argument to ``Traceback.format()``. (Patch by Jesse Bakker.)
 Fix wrong usage of :func:`collections.namedtuple` in the
 :meth:`RobotFileParser.parse() <urllib.robotparser.RobotFileParser.parse>`
 method.
-
 Initial patch by Robin Wellner.
 
 ..
@@ -409,7 +407,6 @@ couldn't open or create an MSI file.  Initial patch by William Tisäter.
 .. section: Library
 
 ``setup()`` now warns about invalid types for some fields.
-
 The ``distutils.dist.Distribution`` class now warns when ``classifiers``,
 ``keywords`` and ``platforms`` fields are not specified as a list or a
 string.
@@ -510,11 +507,10 @@ Added support of splitting on a pattern that could match an empty string.
 .. section: Library
 
 Fixed issues with binary plists:
-
-* Fixed saving bytearrays.
-* Identical objects will be saved only once.
-* Equal references will be load as identical objects.
-* Added support for saving and loading recursive data structures.
+Fixed saving bytearrays.
+Identical objects will be saved only once.
+Equal references will be load as identical objects.
+Added support for saving and loading recursive data structures.
 
 ..
 
@@ -697,10 +693,8 @@ Sharafutdinov.
 .. section: Library
 
 Fixed determining the MAC address in the uuid module:
-
-* Using ifconfig on NetBSD and OpenBSD.
-* Using arp on Linux, FreeBSD, NetBSD and OpenBSD.
-
+Using ifconfig on NetBSD and OpenBSD.
+Using arp on Linux, FreeBSD, NetBSD and OpenBSD.
 Based on patch by Takayuki Shimizukawa.
 
 ..
@@ -820,7 +814,6 @@ windows
 .. section: Library
 
 Remove year (1-9999) limits on the Calendar.weekday() function.
-
 Patch by Mark Gollahon.
 
 ..
@@ -1413,7 +1406,6 @@ Finish removing support for AtheOS.
 
 Return ``None`` when ``View.Fetch()`` returns ``ERROR_NO_MORE_ITEMS``
 instead of raising ``MSIError``.
-
 Initial patch by Anthony Tuininga.
 
 ..
@@ -1517,7 +1509,6 @@ persist while IDLE remains open
 .. section: IDLE
 
 Test_code_module now passes if run after test_idle, which sets ps1.
-
 The code module uses sys.ps1 if present or sets it to '>>> ' if not.
 Test_code_module now properly tests both behaviors.  Ditto for ps2.
 
@@ -1543,7 +1534,6 @@ selects a font that defines a limited subset of the unicode Basic
 Multilingual Plane, tcl/tk will use other fonts that define a character. The
 expanded example give users of non-Latin characters a better idea of what
 they might see in IDLE's shell and editors.
-
 To make room for the expanded sample, frames on the Font tab are
 re-arranged.  The Font/Tabs help explains a bit about the additions.
 
@@ -1566,10 +1556,8 @@ and Subversion are no longer used to develop CPython.
 .. section: Tools/Demos
 
 Make redemo work with Python 3.6 and newer versions.
-
 Also, remove the ``LOCALE`` option since it doesn't work with string
 patterns in Python 3.
-
 Patch by Christoph Sarnowski.
 
 ..

--- a/Misc/NEWS.d/3.7.0a4.rst
+++ b/Misc/NEWS.d/3.7.0a4.rst
@@ -343,7 +343,6 @@ AssertionError.
 
 Optimize asyncio.iscoroutine() and loop.create_task() for non-native
 coroutines (e.g. async/await compiled with Cython).
-
 'loop.create_task(python_coroutine)' used to be 20% faster than
 'loop.create_task(cython_coroutine)'.  Now, the latter is as fast.
 

--- a/Misc/NEWS.d/3.7.0b1.rst
+++ b/Misc/NEWS.d/3.7.0b1.rst
@@ -77,7 +77,6 @@ used to test that string contains only ASCII characters.
 .. section: Core and Builtins
 
 Enforce :pep:`479` for all code.
-
 This means that manually raising a StopIteration exception from a generator
 is prohibited for all code, regardless of whether 'from __future__ import
 generator_stop' was used or not.
@@ -648,7 +647,6 @@ locale to the ``LC_NUMERIC`` locale to decode ``decimal_point`` and
 ``thousands_sep`` byte strings if they are non-ASCII or longer than 1 byte,
 and the ``LC_NUMERIC`` locale is different than the ``LC_CTYPE`` locale.
 This temporary change affects other threads.
-
 Same change for the :meth:`str.format` method when formatting a number
 (:class:`int`, :class:`float`, :class:`float` and subclasses) with the ``n``
 type (ex: ``'{:n}'.format(1234)``).
@@ -747,7 +745,6 @@ Add a new "_xxsubinterpreters" extension module that exposes the existing
 subinterpreter C-API and a new cross-interpreter data sharing mechanism. The
 module is primarily intended for more thorough testing of the existing
 subinterpreter support.
-
 Note that the _xxsubinterpreters module has been removed in 3.7.0rc1.
 
 ..

--- a/Misc/NEWS.d/3.7.0b2.rst
+++ b/Misc/NEWS.d/3.7.0b2.rst
@@ -201,7 +201,6 @@ Make sure sys.argv remains as a list when running trace.
 various functions and methods in ``abc``.  Creating an ABC subclass and
 calling ``isinstance`` or ``issubclass`` with an ABC subclass are up to 1.5x
 faster. In addition, this makes Python start-up up to 10% faster.
-
 Note that the new implementation hides internal registry and caches,
 previously accessible via private attributes ``_abc_registry``,
 ``_abc_cache``, and ``_abc_negative_cache``.  There are three debugging

--- a/Misc/NEWS.d/3.7.0b4.rst
+++ b/Misc/NEWS.d/3.7.0b4.rst
@@ -174,7 +174,6 @@ Patch by Stéphane Blondon.
 
 Fixed regression when running pydoc with the :option:`-m` switch. (The
 regression was introduced in 3.7.0b3 by the resolution of :issue:`33053`)
-
 This fix also changed pydoc to add ``os.getcwd()`` to :data:`sys.path` when
 necessary, rather than adding ``"."``.
 


### PR DESCRIPTION
Also see: https://github.com/python/core-workflow/pull/274

Having multiple paragraphs in a few news entry lead to inconsistent
spacing while rendered in HTML by mixing "visually compact lists"
(when no entry of the whole list contains multiple paragraphs) and
"sparse lists" (when at least one do).

Also NEWS entries should probably stay short.


<!-- issue-number: bpo-32523 -->
https://bugs.python.org/issue32523
<!-- /issue-number -->
