### PR TITLE
[3.6] bpo-34065: Improve the markup of logging.basicConfig() arguments (GH-8153)

### DIFF
--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1170,14 +1170,13 @@ functions.
    +--------------+---------------------------------------------+
 
    .. versionchanged:: 3.2
-      The ``style`` argument was added.
+      The *style* argument was added.
 
    .. versionchanged:: 3.3
-      The ``handlers`` argument was added. Additional checks were added to
+      The *handlers* argument was added. Additional checks were added to
       catch situations where incompatible arguments are specified (e.g.
-      ``handlers`` together with ``stream`` or ``filename``, or ``stream``
-      together with ``filename``).
-
+      *handlers* together with *stream* or *filename*, or *stream*
+      together with *filename*).
 
 .. function:: shutdown()
 

--- a/Misc/NEWS.d/next/Documentation/2018-07-07-20-38-41.bpo-34065.1snofM.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-07-07-20-38-41.bpo-34065.1snofM.rst
@@ -1,0 +1,1 @@
+Fix wrongly written basicConfig documentation markup syntax


### PR DESCRIPTION
(cherry picked from commit 2800dcf656229c2ca4c90b4ddbace0717c41bb9e)

Co-authored-by: Dong-hee Na <donghee.na92@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34065 -->
https://bugs.python.org/issue34065
<!-- /issue-number -->
