### PR TITLE
bpo-34067: Include a more easily understood example for nullcontext

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -159,7 +159,7 @@ Functions and classes provided:
       def myfunction(arg, ignore_exceptions=False):
           if ignore_exceptions:
               # Use suppress to ignore all exceptions.
-              cm = contextlib.suppress(BaseException)
+              cm = contextlib.suppress(Exception)
           else:
               # Do not ignore any exceptions, cm has no effect.
               cm = contextlib.nullcontext()

--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -152,9 +152,21 @@ Functions and classes provided:
 
 .. function:: nullcontext(enter_result=None)
 
-   Return a context manager that returns enter_result from ``__enter__``, but
+   Return a context manager that returns *enter_result* from ``__enter__``, but
    otherwise does nothing. It is intended to be used as a stand-in for an
    optional context manager, for example::
+
+      def myfunction(arg, ignore_exceptions=False):
+          if ignore_exceptions:
+              # Use suppress to ignore all exceptions.
+              cm = contextlib.suppress(BaseException)
+          else:
+              # Do not ignore any exceptions, cm has no effect.
+              cm = contextlib.nullcontext()
+          with cm:
+              # Do something
+
+   An example using *enter_result*::
 
       def process_file(file_or_path):
           if isinstance(file_or_path, str):


### PR DESCRIPTION
When trying to let a few friends know about `contextlib.nullcontext`, they "didn't get it" based on the example in the docs. I feel that including examples that do and don't use `enter_result` can help new users understand the intention of `nullcontext` as a no-op context manager.

I also noticed that normally italics are used for an argument, so I fixed that up on line 155.

<!-- issue-number: bpo-34067 -->
https://bugs.python.org/issue34067
<!-- /issue-number -->
