### PR TITLE
bpo-34066: Disabled interruption before SETUP_WITH and BEFORE_ASYNC_WITH.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-07-20-15-34.bpo-34066.y9vs6s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-07-20-15-34.bpo-34066.y9vs6s.rst
@@ -1,0 +1,2 @@
+Disabled interruption by Ctrl-C between calling ``open()`` and entering a
+**with** block in ``with open()``.


### PR DESCRIPTION
This will prevent emitting a resource warning when the execution was
interrupted by Ctrl-C between calling open() and entering a 'with' block
in "with open()".


<!-- issue-number: bpo-34066 -->
https://bugs.python.org/issue34066
<!-- /issue-number -->
