### PR TITLE
[2.7] bpo-33804: Document that the argument for io.TextIOBase.read() …

### DIFF
--- a/Doc/library/io.rst
+++ b/Doc/library/io.rst
@@ -724,7 +724,7 @@ Text I/O
 
       .. versionadded:: 2.7
 
-   .. method:: read(n)
+   .. method:: read(n=-1)
 
       Read and return at most *n* characters from the stream as a single
       :class:`unicode`.  If *n* is negative or ``None``, reads until EOF.


### PR DESCRIPTION
…is optional (GH-7510).

(cherry picked from commit b6bb77c2b8e83ba6cb845c7b512ac564276e854f)

Co-authored-by: Andrés Delfino <adelfino@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33804 -->
https://bugs.python.org/issue33804
<!-- /issue-number -->
