### PR TITLE
bpo-33967: singledispatch raises TypeError when no positional arguments

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -817,8 +817,13 @@ def singledispatch(func):
         return func
 
     def wrapper(*args, **kw):
+        if not args:
+            raise TypeError(f'{funcname} requires at least '
+                            '1 positional argument')
+
         return dispatch(args[0].__class__)(*args, **kw)
 
+    funcname = getattr(func, '__name__', 'singledispatch function')
     registry[object] = func
     wrapper.register = register
     wrapper.dispatch = dispatch

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2305,6 +2305,13 @@ class TestSingleDispatch(unittest.TestCase):
         ))
         self.assertTrue(str(exc.exception).endswith(msg_suffix))
 
+    def test_invalid_positional_argument(self):
+        @functools.singledispatch
+        def f(*args):
+            pass
+        msg = 'f requires at least 1 positional argument'
+        with self.assertRaisesRegexp(TypeError, msg):
+            f()
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-07-08-18-49-41.bpo-33967.lhaAez.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-08-18-49-41.bpo-33967.lhaAez.rst
@@ -1,0 +1,2 @@
+functools.singledispatch now raises TypeError instead of IndexError when no
+positional arguments are passed.


### PR DESCRIPTION


<!-- issue-number: bpo-33967 -->
https://bugs.python.org/issue33967
<!-- /issue-number -->
