### PR TITLE
bpo-34070: only check for isatty when buffering < 0

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-07-11-20-51-20.bpo-34070.WpmFAu.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-11-20-51-20.bpo-34070.WpmFAu.rst
@@ -1,0 +1,2 @@
+Make sure to only check if the handle is a tty, when opening
+a file with ``buffering=-1``.

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -241,7 +241,7 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
 
     char rawmode[6], *m;
     int line_buffering, is_number;
-    long isatty;
+    long isatty = 0;
 
     PyObject *raw, *modeobj = NULL, *buffer, *wrapper, *result = NULL, *path_or_fd = NULL;
 
@@ -388,7 +388,7 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
         goto error;
 
     /* buffering */
-    {
+    if (buffering < 0) {
         PyObject *res = _PyObject_CallMethodId(raw, &PyId_isatty, NULL);
         if (res == NULL)
             goto error;
@@ -398,7 +398,7 @@ _io_open_impl(PyObject *module, PyObject *file, const char *mode,
             goto error;
     }
 
-    if (buffering == 1 || (buffering < 0 && isatty)) {
+    if (buffering == 1 || isatty) {
         buffering = -1;
         line_buffering = 1;
     }


### PR DESCRIPTION
https://bugs.python.org/issue34070

Only check for isatty when buffering actually requires the check (buffering < 0)

<!-- issue-number: bpo-34070 -->
https://bugs.python.org/issue34070
<!-- /issue-number -->
