### PR TITLE
bpo-23927: Make getargs.c skipitem() skipping 'w*'.

### DIFF
--- a/Misc/NEWS.d/next/C API/2018-07-09-11-39-54.bpo-23927.pDFkxb.rst
+++ b/Misc/NEWS.d/next/C API/2018-07-09-11-39-54.bpo-23927.pDFkxb.rst
@@ -1,0 +1,2 @@
+Fixed :exc:`SystemError` in :c:func:`PyArg_ParseTupleAndKeywords` when the
+``w*`` format unit is used for optional parameter.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2333,7 +2333,9 @@ skipitem(const char **p_format, va_list *p_va, int flags)
                         (void) va_arg(*p_va, int *);
                 }
                 format++;
-            } else if ((c == 's' || c == 'z' || c == 'y') && *format == '*') {
+            } else if ((c == 's' || c == 'z' || c == 'y' || c == 'w')
+                       && *format == '*')
+            {
                 format++;
             }
             break;


### PR DESCRIPTION


<!-- issue-number: bpo-23927 -->
https://bugs.python.org/issue23927
<!-- /issue-number -->
