### PR TITLE
[3.6] bpo-34066: Disabled interruption before SETUP_WITH and BEFORE_ASYNC_WITH. (GH-8159)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-07-20-15-34.bpo-34066.y9vs6s.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-07-20-15-34.bpo-34066.y9vs6s.rst
@@ -1,0 +1,2 @@
+Disabled interruption by Ctrl-C between calling ``open()`` and entering a
+**with** block in ``with open()``.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1155,11 +1155,18 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
            Py_MakePendingCalls() above. */
 
         if (_Py_atomic_load_relaxed(&eval_breaker)) {
-            if (_Py_OPCODE(*next_instr) == SETUP_FINALLY ||
-                _Py_OPCODE(*next_instr) == YIELD_FROM) {
-                /* Two cases where we skip running signal handlers and other
+            opcode = _Py_OPCODE(*next_instr);
+            if (opcode == SETUP_FINALLY ||
+                opcode == SETUP_WITH ||
+                opcode == BEFORE_ASYNC_WITH ||
+                opcode == YIELD_FROM) {
+                /* Few cases where we skip running signal handlers and other
                    pending calls:
-                   - If we're about to enter the try: of a try/finally (not
+                   - If we're about to enter the 'with:'. It will prevent
+                     emitting a resource warning in the common idiom
+                     'with open(path) as file:'.
+                   - If we're about to enter the 'async with:'.
+                   - If we're about to enter the 'try:' of a try/finally (not
                      *very* useful, but might help in some cases and it's
                      traditional)
                    - If we're resuming a chain of nested 'yield from' or


### PR DESCRIPTION
This will prevent emitting a resource warning when the execution was
interrupted by Ctrl-C between calling open() and entering a 'with' block
in "with open()".
(cherry picked from commit 3f4d90d4d72921f16babd3f52d7df804916af224)


<!-- issue-number: bpo-34066 -->
https://bugs.python.org/issue34066
<!-- /issue-number -->
