### PR TITLE
[2.7] Fixed several assertTrue() that were intended to be assertEqual(). (GH-8191)

### DIFF
--- a/Lib/ctypes/test/test_as_parameter.py
+++ b/Lib/ctypes/test/test_as_parameter.py
@@ -24,7 +24,7 @@ class BasicWrapTestCase(unittest.TestCase):
         f.argtypes = [c_byte, c_wchar, c_int, c_long, c_float, c_double]
         result = f(self.wrap(1), self.wrap(u"x"), self.wrap(3), self.wrap(4), self.wrap(5.0), self.wrap(6.0))
         self.assertEqual(result, 139)
-        self.assertTrue(type(result), int)
+        self.assertIs(type(result), int)
 
     def test_pointers(self):
         f = dll._testfunc_p_p

--- a/Lib/test/test_pkg.py
+++ b/Lib/test/test_pkg.py
@@ -134,7 +134,7 @@ class Test(unittest.TestCase):
 
         s = """
             from t2 import *
-            self.assertTrue(dir(), ['self', 'sub'])
+            self.assertEqual(dir(), ['self', 'sub'])
             """
         self.run_code(s)
 

--- a/Lib/test/test_test_support.py
+++ b/Lib/test/test_test_support.py
@@ -267,7 +267,7 @@ class TestSupport(unittest.TestCase):
         with support.temp_cwd(name=TESTFN):
             self.assertEqual(os.path.basename(os.getcwd()), TESTFN)
         self.assertFalse(os.path.exists(TESTFN))
-        self.assertTrue(os.path.basename(os.getcwd()), here)
+        self.assertEqual(os.getcwd(), here)
 
 
     def test_temp_cwd__name_none(self):

--- a/Lib/test/test_warnings.py
+++ b/Lib/test/test_warnings.py
@@ -107,10 +107,14 @@ class FilterTests(object):
             self.module.resetwarnings()
             self.module.filterwarnings("always", category=UserWarning)
             message = "FilterTests.test_always"
-            self.module.warn(message, UserWarning)
-            self.assertTrue(message, w[-1].message)
-            self.module.warn(message, UserWarning)
-            self.assertTrue(w[-1].message, message)
+            def f():
+                self.module.warn(message, UserWarning)
+            f()
+            self.assertEqual(len(w), 1)
+            self.assertEqual(w[-1].message.args[0], message)
+            f()
+            self.assertEqual(len(w), 2)
+            self.assertEqual(w[-1].message.args[0], message)
 
     def test_default(self):
         with original_warnings.catch_warnings(record=True,


### PR DESCRIPTION
Fixed also testing the "always" warning filter.
(cherry picked from commit b796e7dcdc24ff7ec53044af041254c83a8ace21)

Co-authored-by: Sergey Fedoseev <fedoseev.sergey@gmail.com>
