### PR TITLE
bpo-34077: Mention that mock_open mocks don't support __iter__

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -2131,6 +2131,28 @@ And for reading files:
     >>> m.assert_called_once_with('foo')
     >>> assert result == 'bibble'
 
+Note that, as the mock created by :func:`mock_open` does not define the
+:meth:`__iter__` method, it cannot be iterated::
+
+   >>> m = mock_open(read_data='bibble')
+   >>> with patch('__main__.open', m):
+   ...     with open('foo') as h:
+   ...         for line in h:
+   ...             print(line)
+   ...
+   >>>
+
+This can be overcomed by iterating on :meth:`~io.IOBase.readlines` instead::
+
+   >>> m = mock_open(read_data='bibble')
+   >>> with patch('__main__.open', m):
+   ...     with open('foo') as h:
+   ...         for line in h.readlines():
+   ...             print(line)
+   ...
+   bibble
+   >>>
+
 
 .. _auto-speccing:
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34077 -->
https://bugs.python.org/issue34077
<!-- /issue-number -->
