### PR TITLE
bpo-34080: Fix a memory leak in the compiler.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-10-11-24-16.bpo-34080.8t7PtO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-10-11-24-16.bpo-34080.8t7PtO.rst
@@ -1,0 +1,2 @@
+Fixed a memory leak in the compiler when it raised some uncommon errors
+during tokenizing.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1339,7 +1339,7 @@ err_input(perrdetail *err)
     errtype = PyExc_SyntaxError;
     switch (err->error) {
     case E_ERROR:
-        return;
+        goto cleanup;
     case E_SYNTAX:
         errtype = PyExc_IndentationError;
         if (err->expected == INDENT)


### PR DESCRIPTION


<!-- issue-number: bpo-34080 -->
https://bugs.python.org/issue34080
<!-- /issue-number -->
