### PR TITLE
[2.7] bpo-34031: fix incorrect usage of self.fail in two tests (GH-8091)

### DIFF
--- a/Lib/test/test_file.py
+++ b/Lib/test/test_file.py
@@ -247,8 +247,7 @@ class OtherFileTests(unittest.TestCase):
         # Test for appropriate errors mixing read* and iteration
         for methodname, args in methods:
             f = self.open(TESTFN, 'rb')
-            if next(f) != filler:
-                self.fail, "Broken testfile"
+            self.assertEqual(next(f), filler)
             meth = getattr(f, methodname)
             meth(*args)  # This simply shouldn't fail
             f.close()


### PR DESCRIPTION
Contributed by Bradley Laney.

(cherry picked from commit 6b490b5db40fc29588e8e6cc23bb89c4fed74ad5)

<!-- issue-number: bpo-34031 -->
https://bugs.python.org/issue34031
<!-- /issue-number -->
