### PR TITLE
bpo-34083: Update dict order in Functional HOWTO

### DIFF
--- a/Doc/howto/functional.rst
+++ b/Doc/howto/functional.rst
@@ -273,23 +273,24 @@ dictionary's keys::
 
     >>> m = {'Jan': 1, 'Feb': 2, 'Mar': 3, 'Apr': 4, 'May': 5, 'Jun': 6,
     ...      'Jul': 7, 'Aug': 8, 'Sep': 9, 'Oct': 10, 'Nov': 11, 'Dec': 12}
-    >>> for key in m:  #doctest: +SKIP
+    >>> for key in m:
     ...     print(key, m[key])
-    Mar 3
+    Jan 1
     Feb 2
-    Aug 8
-    Sep 9
+    Mar 3
     Apr 4
+    May 5
     Jun 6
     Jul 7
-    Jan 1
-    May 5
+    Aug 8
+    Sep 9
+    Oct 10
     Nov 11
     Dec 12
-    Oct 10
 
-Note that the order is essentially random, because it's based on the hash
-ordering of the objects in the dictionary.
+Note that starting with Python 3.7, dictionary iteration order is guaranteed
+to be the same as the insertion order. In earlier versions, the behaviour was
+unspecified and could vary between implementations.
 
 Applying :func:`iter` to a dictionary always loops over the keys, but
 dictionaries have methods that return other iterators.  If you want to iterate
@@ -301,8 +302,8 @@ The :func:`dict` constructor can accept an iterator that returns a finite stream
 of ``(key, value)`` tuples:
 
     >>> L = [('Italy', 'Rome'), ('France', 'Paris'), ('US', 'Washington DC')]
-    >>> dict(iter(L))  #doctest: +SKIP
-    {'Italy': 'Rome', 'US': 'Washington DC', 'France': 'Paris'}
+    >>> dict(iter(L))
+    {'Italy': 'Rome', 'France': 'Paris', 'US': 'Washington DC'}
 
 Files also support iteration by calling the :meth:`~io.TextIOBase.readline`
 method until there are no more lines in the file.  This means you can read each


### PR DESCRIPTION
I changed the output of the code examples and the paragraph describing iteration order. Additionally, enabled doctest for the dictionary code examples as the output order is specified.
I have run doctest on the file using the locally built Python.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34083 -->
https://bugs.python.org/issue34083
<!-- /issue-number -->
