### PR TITLE
[WIP] bpo-34089: Remove required (non-optional) modules from Modules/Setup.dist

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -719,28 +719,14 @@ $(DLLLIBRARY) libpython$(LDVERSION).dll.a: $(LIBRARY_OBJS)
 oldsharedmods: $(SHAREDMODS)
 
 
-Makefile Modules/config.c: Makefile.pre \
-				$(srcdir)/Modules/config.c.in \
-				$(MAKESETUP) \
-				Modules/Setup \
-				Modules/Setup.local
+# Generate Makefile and Modules/config.c
+makesetup:
 	$(SHELL) $(MAKESETUP) -c $(srcdir)/Modules/config.c.in \
 				-s Modules \
 				Modules/Setup.local \
 				Modules/Setup
 	@mv config.c Modules
 	@echo "The Makefile was updated, you may need to re-run make."
-
-
-Modules/Setup: $(srcdir)/Modules/Setup.dist
-	@if test -f Modules/Setup; then \
-		echo "-----------------------------------------------"; \
-		echo "Modules/Setup.dist is newer than Modules/Setup;"; \
-		echo "check to make sure you have all the updates you"; \
-		echo "need in your Modules/Setup file."; \
-		echo "Usually, copying Modules/Setup.dist to Modules/Setup will work."; \
-		echo "-----------------------------------------------"; \
-	fi
 
 Programs/_testembed: Programs/_testembed.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
 	$(LINKCC) $(PY_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/_testembed.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST)
@@ -1802,7 +1788,7 @@ Python/thread.o: @THREADHEADERS@
 .PHONY: frameworkinstallmaclib frameworkinstallapps frameworkinstallunixtools
 .PHONY: frameworkaltinstallunixtools recheck clean clobber distclean
 .PHONY: smelly funny patchcheck touch altmaninstall commoninstall
-.PHONY: gdbhooks
+.PHONY: gdbhooks makesetup
 
 # IF YOU PUT ANYTHING HERE IT WILL GO AWAY
 # Local Variables:

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -261,11 +261,6 @@ COVERAGE_REPORT_OPTIONS=--no-branch-coverage --title "CPython lcov report"
 
 ##########################################################################
 # Modules
-MODULE_OBJS=	\
-		Modules/config.o \
-		Modules/getpath.o \
-		Modules/main.o \
-		Modules/gcmodule.o
 
 IO_H=		Modules/_io/_iomodule.h
 
@@ -277,6 +272,46 @@ IO_OBJS=	\
 		Modules/_io/textio.o \
 		Modules/_io/bytesio.o \
 		Modules/_io/stringio.o
+
+# Extension modules that we always include.  These are needed in order to run
+# setup.py.  Note that to add another extension, you must also edit
+# Modules/setup.c.in.
+#
+# These extensions were previously part of the *static* section of
+# Modules/Setup.  They are now included here so that Setup.dist contains no
+# extensions that are enabled by default.
+EXTENSION_OBJS= \
+		$(IO_OBJS) \
+		Modules/_abc.o \
+		Modules/_codecsmodule.o \
+		Modules/_collectionsmodule.o \
+		Modules/_functoolsmodule.o \
+		Modules/_localemodule.o \
+		Modules/_operator.o \
+		Modules/_sre.o \
+		Modules/_stat.o \
+		Modules/_threadmodule.o \
+		Modules/_tracemalloc.o Modules/hashtable.o \
+		Modules/_weakref.o \
+		Modules/atexitmodule.o \
+		Modules/errnomodule.o \
+		Modules/faulthandler.o \
+		Modules/itertoolsmodule.o \
+		Modules/posixmodule.o \
+		Modules/pwdmodule.o \
+		Modules/signalmodule.o \
+		Modules/symtablemodule.o \
+		Modules/timemodule.o \
+		Modules/xxsubtype.o \
+		Modules/zipimport.o
+
+MODULE_OBJS=	\
+		Modules/config.o \
+		Modules/getpath.o \
+		Modules/main.o \
+		Modules/gcmodule.o \
+		$(EXTENSION_OBJS)
+
 
 ##########################################################################
 

--- a/Modules/Setup.dist
+++ b/Modules/Setup.dist
@@ -97,48 +97,7 @@ COREPYTHONPATH=$(DESTPATH)$(SITEPATH)$(TESTPATH)
 PYTHONPATH=$(COREPYTHONPATH)
 
 
-# The modules listed here can't be built as shared libraries for
-# various reasons; therefore they are listed here instead of in the
-# normal order.
-
-# This only contains the minimal set of modules required to run the
-# setup.py script in the root of the Python source tree.
-
-posix -DPy_BUILD_CORE posixmodule.c	# posix (UNIX) system calls
-errno errnomodule.c			# posix (UNIX) errno values
-pwd pwdmodule.c				# this is needed to find out the user's home dir
-					# if $HOME is not set
-_sre _sre.c				# Fredrik Lundh's new regular expressions
-_codecs _codecsmodule.c			# access to the builtin codecs and codec registry
-_weakref _weakref.c			# weak references
-_functools -DPy_BUILD_CORE _functoolsmodule.c   # Tools for working with functions and callable objects
-_operator _operator.c	        	# operator.add() and similar goodies
-_collections _collectionsmodule.c	# Container types
-_abc _abc.c				# Abstract base classes
-itertools itertoolsmodule.c		# Functions creating iterators for efficient looping
-atexit atexitmodule.c			# Register functions to be run at interpreter-shutdown
-_signal -DPy_BUILD_CORE signalmodule.c
-_stat _stat.c				# stat.h interface
-time -DPy_BUILD_CORE timemodule.c	# -lm # time operations and variables
-_thread -DPy_BUILD_CORE _threadmodule.c	# low-level threading interface
-
-# access to ISO C locale support
-_locale _localemodule.c  # -lintl
-
-# Standard I/O baseline
-_io -DPy_BUILD_CORE -I$(srcdir)/Modules/_io _io/_iomodule.c _io/iobase.c _io/fileio.c _io/bytesio.c _io/bufferedio.c _io/textio.c _io/stringio.c
-
-# The zipimport module is always imported at startup. Having it as a
-# builtin module avoids some bootstrapping problems and reduces overhead.
-zipimport -DPy_BUILD_CORE zipimport.c
-
-# faulthandler module
-faulthandler faulthandler.c
-
-# debug tool to trace memory blocks allocated by Python
-_tracemalloc _tracemalloc.c hashtable.c
-
-# The rest of the modules listed in this file are all commented out by
+# The modules listed in this file are all commented out by
 # default.  Usually they can be detected and built as dynamically
 # loaded modules by the new setup.py script added in Python 2.1.  If
 # you're on a platform that doesn't support dynamic loading, want to
@@ -147,9 +106,6 @@ _tracemalloc _tracemalloc.c hashtable.c
 # appropriate lines below.
 
 # ======================================================================
-
-# The Python symtable module depends on .h files that setup.py doesn't track
-_symtable symtablemodule.c
 
 # Uncommenting the following line tells makesetup that all following
 # modules are to be built as shared libraries (see above for more
@@ -366,7 +322,7 @@ _symtable symtablemodule.c
 # xx xxmodule.c
 
 # Another example -- the 'xxsubtype' module shows C-level subtyping in action
-xxsubtype xxsubtype.c
+#xxsubtype xxsubtype.c
 
 # Uncommenting the following line tells makesetup that all following modules
 # are not built (see above for more detail).

--- a/Modules/config.c.in
+++ b/Modules/config.c.in
@@ -31,6 +31,31 @@ extern PyObject* PyInit__ast(void);
 extern PyObject* _PyWarnings_Init(void);
 extern PyObject* PyInit__string(void);
 
+/* extension modules always included */
+extern PyObject* PyInit__abc(void);
+extern PyObject* PyInit__codecs(void);
+extern PyObject* PyInit__collections(void);
+extern PyObject* PyInit__functools(void);
+extern PyObject* PyInit__io(void);
+extern PyObject* PyInit__locale(void);
+extern PyObject* PyInit__operator(void);
+extern PyObject* PyInit__signal(void);
+extern PyObject* PyInit__sre(void);
+extern PyObject* PyInit__stat(void);
+extern PyObject* PyInit__symtable(void);
+extern PyObject* PyInit__thread(void);
+extern PyObject* PyInit__tracemalloc(void);
+extern PyObject* PyInit__weakref(void);
+extern PyObject* PyInit_atexit(void);
+extern PyObject* PyInit_errno(void);
+extern PyObject* PyInit_faulthandler(void);
+extern PyObject* PyInit_itertools(void);
+extern PyObject* PyInit_posix(void);
+extern PyObject* PyInit_pwd(void);
+extern PyObject* PyInit_time(void);
+extern PyObject* PyInit_xxsubtype(void);
+extern PyObject* PyInit_zipimport(void);
+
 struct _inittab _PyImport_Inittab[] = {
 
 /* -- ADDMODULE MARKER 2 -- */
@@ -56,6 +81,78 @@ struct _inittab _PyImport_Inittab[] = {
 
     /* This lives in Objects/unicodeobject.c */
     {"_string", PyInit__string},
+
+    /* extensions below are always included, see EXTENSION_OBJS in the
+     * Makefile */
+
+    /* abstract base classes */
+    {"_abc", PyInit__abc},
+
+    /* access to the builtin codecs and codec registry */
+    {"_codecs", PyInit__codecs},
+
+    /* container types */
+    {"_collections", PyInit__collections},
+
+    /* Tools for working with functions and callable objects */
+    {"_functools", PyInit__functools},
+
+    /* Standard I/O baseline */
+    {"_io", PyInit__io},
+
+    /* access to ISO C locale support */
+    {"_locale", PyInit__locale},
+
+    /* operator.add() and similar goodies */
+    {"_operator", PyInit__operator},
+
+    {"_signal", PyInit__signal},
+
+    /* Fredrik Lundh's new regular expressions */
+    {"_sre", PyInit__sre},
+
+    /* stat.h interface */
+    {"_stat", PyInit__stat},
+
+    /* The Python symtable module depends on .h files that setup.py
+     * doesn't track */
+    {"_symtable", PyInit__symtable},
+
+    /* low-level threading interface */
+    {"_thread", PyInit__thread},
+
+    /* debug tool to trace memory blocks allocated by Python */
+    {"_tracemalloc", PyInit__tracemalloc},
+
+    /* weak references */
+    {"_weakref", PyInit__weakref},
+
+    /* Register functions to be run at interpreter-shutdown */
+    {"atexit", PyInit_atexit},
+
+    /* posix (UNIX) errno values */
+    {"errno", PyInit_errno},
+
+    {"faulthandler", PyInit_faulthandler},
+
+    {"itertools", PyInit_itertools},
+
+    /* posix (UNIX system calls */
+    {"posix", PyInit_posix},
+
+    /* needed to find out the user's home dir if $HOME is not set */
+    {"pwd", PyInit_pwd},
+
+    /* time operations and variables */
+    {"time", PyInit_time},
+
+    /* example, shows subtyping in action */
+    {"xxsubtype", PyInit_xxsubtype},
+
+    /* The zipimport module is always imported at startup. Having it as a
+       builtin module avoids some bootstrapping problems and reduces
+       overhead. */
+    {"zipimport", PyInit_zipimport},
 
     /* Sentinel */
     {0, 0}

--- a/setup.py
+++ b/setup.py
@@ -675,9 +675,6 @@ class PyBuildExt(build_ext):
         if lib:
             time_libs.append(lib)
 
-        # time operations and variables
-        exts.append( Extension('time', ['timemodule.c'],
-                               libraries=time_libs) )
         # libm is needed by delta_new() that uses round() and by accum() that
         # uses modf().
         exts.append( Extension('_datetime', ['_datetimemodule.c'],
@@ -690,8 +687,6 @@ class PyBuildExt(build_ext):
         exts.append( Extension("_heapq", ["_heapqmodule.c"]) )
         # C-optimized pickle replacement
         exts.append( Extension("_pickle", ["_pickle.c"]) )
-        # atexit
-        exts.append( Extension("atexit", ["atexitmodule.c"]) )
         # _json speedups
         exts.append( Extension("_json", ["_json.c"]) )
         # Python C API test module
@@ -712,8 +707,6 @@ class PyBuildExt(build_ext):
         exts.append( Extension('_opcode', ['_opcode.c']) )
         # asyncio speedups
         exts.append( Extension("_asyncio", ["_asynciomodule.c"]) )
-        # _abc speedups
-        exts.append( Extension("_abc", ["_abc.c"]) )
         # _queue module
         exts.append( Extension("_queue", ["_queuemodule.c"]) )
 
@@ -727,8 +720,6 @@ class PyBuildExt(build_ext):
             # May be necessary on AIX for flock function
             libs = ['bsd']
         exts.append( Extension('fcntl', ['fcntlmodule.c'], libraries=libs) )
-        # pwd(3)
-        exts.append( Extension('pwd', ['pwdmodule.c']) )
         # grp(3)
         exts.append( Extension('grp', ['grpmodule.c']) )
         # spwd, shadow passwords


### PR DESCRIPTION
Remove non-optional extension modules from Setup.dist.  Instead, add them directly to Makefile.pre.in and Modules/config.c.in.  It is a few more lines of code to do things this way but it simplifies the build.  The Setup + makesetup system is still supported for people who want to use it.  However, I think it is better if Setup does not contain a mixture of non-optional and optional extension modules.  Instead, it should be the set of modules that the user building Python wants to explicitly include.

<!-- issue-number: bpo-34089 -->
https://bugs.python.org/issue34089
<!-- /issue-number -->
