### PR TITLE
Point to Simple statements section instead of PEP

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -241,8 +241,8 @@ are always available.  They are listed here in alphabetical order.
    interactive statement (in the latter case, expression statements that
    evaluate to something other than ``None`` will be printed).
 
-   The optional arguments *flags* and *dont_inherit* control which future
-   statements (see :pep:`236`) affect the compilation of *source*.  If neither
+   The optional arguments *flags* and *dont_inherit* control which :ref:`future
+   statements <future>` affect the compilation of *source*.  If neither
    is present (or both are zero) the code is compiled with those future
    statements that are in effect in the code that is calling :func:`compile`.  If the
    *flags* argument is given and *dont_inherit* is not (or is zero) then the


### PR DESCRIPTION
The Simple statements section provides a more concise description of the feature. There's no need to point to the PEP here.