### PR TITLE
bpo-34080: Fix memory leak on parsing error

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-11-11-20-12.bpo-34080.8t7PtO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-11-11-20-12.bpo-34080.8t7PtO.rst
@@ -1,0 +1,2 @@
+Fixed a memory leak in the compiler when it raised some uncommon errors
+during tokenizing.

--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -246,8 +246,6 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
             else if ((ps->p_flags & CO_FUTURE_BARRY_AS_BDFL) &&
                             strcmp(str, "<>")) {
                 PyObject_FREE(str);
-                err_ret->text = "with Barry as BDFL, use '<>' "
-                                "instead of '!='";
                 err_ret->error = E_SYNTAX;
                 break;
             }
@@ -322,7 +320,10 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
             assert(tok->cur - tok->buf < INT_MAX);
             err_ret->offset = (int)(tok->cur - tok->buf);
             len = tok->inp - tok->buf;
-            err_ret->text = (char *) PyObject_MALLOC(len + 1);
+            /* make sure that we don't leak memory if text has been
+               set previously */
+            assert(err_ret->text == NULL);
+            err_ret->text = (char *) PyObject_Malloc(len + 1);
             if (err_ret->text != NULL) {
                 if (len > 0)
                     strncpy(err_ret->text, tok->buf, len);

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -63,7 +63,7 @@ static PyObject *run_mod(mod_ty, PyObject *, PyObject *, PyObject *,
                           PyCompilerFlags *, PyArena *);
 static PyObject *run_pyc_file(FILE *, const char *, PyObject *, PyObject *,
                               PyCompilerFlags *);
-static void err_input(perrdetail *);
+static void err_input(const perrdetail *);
 static void err_free(perrdetail *);
 static int PyRun_InteractiveOneObjectEx(FILE *, PyObject *, PyCompilerFlags *);
 
@@ -1331,7 +1331,7 @@ err_free(perrdetail *err)
 /* Set the error appropriate to the given input error code (see errcode.h) */
 
 static void
-err_input(perrdetail *err)
+err_input(const perrdetail *err)
 {
     PyObject *v, *w, *errtype, *errtext;
     PyObject *msg_obj = NULL;
@@ -1447,10 +1447,6 @@ err_input(perrdetail *err)
     Py_XDECREF(w);
 cleanup:
     Py_XDECREF(msg_obj);
-    if (err->text != NULL) {
-        PyObject_Free(err->text);
-        err->text = NULL;
-    }
 }
 
 

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1324,6 +1324,8 @@ static void
 err_free(perrdetail *err)
 {
     Py_CLEAR(err->filename);
+    PyObject_Free(err->text);
+    err->text = NULL;
 }
 
 /* Set the error appropriate to the given input error code (see errcode.h) */
@@ -1446,7 +1448,7 @@ err_input(perrdetail *err)
 cleanup:
     Py_XDECREF(msg_obj);
     if (err->text != NULL) {
-        PyObject_FREE(err->text);
+        PyObject_Free(err->text);
         err->text = NULL;
     }
 }


### PR DESCRIPTION
* bpo-34080, bpo-34084: err_free() now always releases 'text' memory
  allocated by PyObject_Malloc() to fix a memory leak on parsing
  error.  Previously, err->text was not released (by err_input()) on
  E_ERROR error.
* Remove also "with Barry as BDFL, use '<>' instead of '!='" static
  string error message (previously set to err_ret->text) because in
  practice, err_ret->text is always set later. Add also an assertion
  to make sure that err_ret->text is only set once.
* Replace old PyObject_MALLOC() and PyObject_FREE() aliases with
  PyObject_Malloc() and PyObject_Free() function calls.

Co-Authored-By: Serhiy Storchaka <storchaka@gmail.com>
Co-Authored-By: Xiang Zhang <angwerzx@126.com>

<!-- issue-number: bpo-34080 -->
https://bugs.python.org/issue34080
<!-- /issue-number -->
