### PR TITLE
bpo-34092, test_logging: increase SMTPHandlerTest timeout

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -971,7 +971,8 @@ if hasattr(socket, "AF_UNIX"):
 # - end of server_helper section
 
 class SMTPHandlerTest(BaseTest):
-    TIMEOUT = 8.0
+    # bpo-14314, bpo-19665, bpo-34092: don't wait forever, timeout of 1 minute
+    TIMEOUT = 60.0
 
     def test_basic(self):
         sockmap = {}
@@ -986,7 +987,7 @@ class SMTPHandlerTest(BaseTest):
         r = logging.makeLogRecord({'msg': 'Hello \u2713'})
         self.handled = threading.Event()
         h.handle(r)
-        self.handled.wait(self.TIMEOUT)  # 14314: don't wait forever
+        self.handled.wait(self.TIMEOUT)
         server.stop()
         self.assertTrue(self.handled.is_set())
         self.assertEqual(len(self.messages), 1)


### PR DESCRIPTION
Change test_logging.SMTPHandlerTest timeout from 8 seconds to 1
minute. The test failed randomly on the slow x86 Gentoo Refleaks 3.7
buildbot.

<!-- issue-number: bpo-34092 -->
https://bugs.python.org/issue34092
<!-- /issue-number -->
