### PR TITLE
bpo-34081: Fix wrong example link that was linking to distutils

### DIFF
--- a/.azure-pipelines/docs-steps.yml
+++ b/.azure-pipelines/docs-steps.yml
@@ -12,7 +12,7 @@ steps:
   inputs:
     versionSpec: '>=3.6'
 
-- script: python -m pip install sphinx~=1.6.1 blurb python-docs-theme
+- script: python -m pip install sphinx==1.8.1 blurb python-docs-theme
   displayName: 'Install build dependencies'
 
 - ${{ if ne(parameters.latex, 'true') }}:

--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -12,7 +12,7 @@ PAPER        =
 SOURCES      =
 DISTVERSION  = $(shell $(PYTHON) tools/extensions/patchlevel.py)
 
-ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees -D latex_elements.papersize=$(PAPER) \
+ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees -W -D latex_elements.papersize=$(PAPER) \
                 $(SPHINXOPTS) . build/$(BUILDER) $(SOURCES)
 
 .PHONY: help build html htmlhelp latex text changes linkcheck \

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -20,7 +20,7 @@ functionality.  The fields of the type object are examined in detail in this
 section.  The fields will be described in the order in which they occur in the
 structure.
 
-In addition to the following quick reference, the :ref:`examples`
+In addition to the following quick reference, the :ref:`typeobj-examples`
 section provides at-a-glance insight into the meaning and use of
 :c:type:`PyTypeObject`.
 
@@ -2321,7 +2321,7 @@ Slot Type typedefs
 .. c:type:: int (*objobjargproc)(PyObject *, PyObject *, PyObject *)
 
 
-.. _examples:
+.. _typeobj-examples:
 
 Examples
 ========

--- a/Doc/c-api/typeobj.rst
+++ b/Doc/c-api/typeobj.rst
@@ -20,7 +20,7 @@ functionality.  The fields of the type object are examined in detail in this
 section.  The fields will be described in the order in which they occur in the
 structure.
 
-In addition to the following quick reference, the :ref:`typeobj-examples`
+In addition to the following quick reference, the :ref:`examples`
 section provides at-a-glance insight into the meaning and use of
 :c:type:`PyTypeObject`.
 
@@ -2321,7 +2321,7 @@ Slot Type typedefs
 .. c:type:: int (*objobjargproc)(PyObject *, PyObject *, PyObject *)
 
 
-.. _typeobj-examples:
+.. _examples:
 
 Examples
 ========

--- a/Misc/NEWS.d/next/Build/2018-09-06-07-15-20.bpo-34081.cuSTnH.rst
+++ b/Misc/NEWS.d/next/Build/2018-09-06-07-15-20.bpo-34081.cuSTnH.rst
@@ -1,0 +1,1 @@
+Make Sphinx warnings as errors in the Docs Makefile.


### PR DESCRIPTION
This PR fixes example link in [Type Objects](https://docs.python.org/3.8/c-api/typeobj.html) where examples was pointing to [distutils examples](https://docs.python.org/3.8/distutils/examples.html#examples) . Distutils also had the same label as `example`. This was pointed out in the docs CI with the warning but it doesn't cause any error and hence was ignored. I think it will be better to turn on warning as errors in sphinx docs configuration so that these errors are caught in the CI run.

This is present only in master introduced as part of 9e7c92193cc98fd3c2d4751c87851460a33b9118 and doesn't have to be backported.

Thanks

<!-- issue-number: bpo-34081 -->
https://bugs.python.org/issue34081
<!-- /issue-number -->
