### PR TITLE
gh-78279: multiprocessing.Server now uses ExceptionWithTraceback

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -260,7 +260,7 @@ class Server(object):
                 try:
                     res = function(*args, **kwds)
                 except Exception as e:
-                    msg = ('#ERROR', e)
+                    msg = ('#ERROR', pool.ExceptionWithTraceback(e, e.__traceback__))
                 else:
                     typeid = gettypeid and gettypeid.get(methodname, None)
                     if typeid:

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2766,6 +2766,10 @@ class _TestMyManager(BaseTestCase):
 
         self.assertEqual(foo.f(), 'f()')
         self.assertRaises(ValueError, foo.g)
+        with self.assertRaises(ValueError) as ctx:
+            foo._callmethod('g')
+        cause = ctx.exception.__cause__
+        self.assertIsInstance(cause, multiprocessing.pool.RemoteTraceback)
         self.assertEqual(foo._callmethod('f'), 'f()')
         self.assertRaises(RemoteError, foo._callmethod, '_h')
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -2701,7 +2701,7 @@ class FooBar(object):
     def f(self):
         return 'f()'
     def g(self):
-        raise ValueError
+        raise ValueError  # exception raised here
     def _h(self):
         return '_h()'
 
@@ -2767,9 +2767,10 @@ class _TestMyManager(BaseTestCase):
         self.assertEqual(foo.f(), 'f()')
         self.assertRaises(ValueError, foo.g)
         with self.assertRaises(ValueError) as ctx:
-            foo._callmethod('g')
+            foo.g()
         cause = ctx.exception.__cause__
         self.assertIsInstance(cause, multiprocessing.pool.RemoteTraceback)
+        self.assertIn('# exception raised here', str(cause))
         self.assertEqual(foo._callmethod('f'), 'f()')
         self.assertRaises(RemoteError, foo._callmethod, '_h')
 

--- a/Misc/NEWS.d/next/Library/2018-07-16-11-35-00.bpo-34098.CVjiuZ.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-16-11-35-00.bpo-34098.CVjiuZ.rst
@@ -1,2 +1,3 @@
 Embed stringification of remote traceback in local traceback when a method
 executed via ``multiprocessing.BaseManager`` raises.
+Patch by Guilherme Salgado

--- a/Misc/NEWS.d/next/Library/2018-07-16-11-35-00.bpo-34098.CVjiuZ.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-16-11-35-00.bpo-34098.CVjiuZ.rst
@@ -1,2 +1,2 @@
 Embed stringification of remote traceback in local traceback when a method
-executed via multiprocessing.BaseManager raises
+executed via ``multiprocessing.BaseManager`` raises.

--- a/Misc/NEWS.d/next/Library/2018-07-16-11-35-00.bpo-34098.CVjiuZ.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-16-11-35-00.bpo-34098.CVjiuZ.rst
@@ -1,0 +1,2 @@
+Embed stringification of remote traceback in local traceback when a method
+executed via multiprocessing.BaseManager raises

--- a/Misc/NEWS.d/next/Library/2018-07-16-11-35-00.bpo-34098.CVjiuZ.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-16-11-35-00.bpo-34098.CVjiuZ.rst
@@ -1,3 +1,3 @@
 Embed stringification of remote traceback in local traceback when a method
 executed via ``multiprocessing.BaseManager`` raises.
-Patch by Guilherme Salgado
+Patch by Guilherme Salgado.


### PR DESCRIPTION
That way we preserve the original traceback, and make debugging easier

Closes: https://bugs.python.org/issue34098

Note to self: use `./python -m unittest -v test.test_multiprocessing_fork.WithManagerTestMyManager` to run the tests

<!-- issue-number: [bpo-34098](https://bugs.python.org/issue34098) -->
https://bugs.python.org/issue34098
<!-- /issue-number -->

<!-- gh-issue-number: gh-78279 -->
* Issue: gh-78279
<!-- /gh-issue-number -->
