### PR TITLE
bpo-34084: Remove parser deadcode for Barry as BDFL

### DIFF
--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -246,8 +246,6 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
             else if ((ps->p_flags & CO_FUTURE_BARRY_AS_BDFL) &&
                             strcmp(str, "<>")) {
                 PyObject_FREE(str);
-                err_ret->text = "with Barry as BDFL, use '<>' "
-                                "instead of '!='";
                 err_ret->error = E_SYNTAX;
                 break;
             }


### PR DESCRIPTION
In practice, err_ret->text is always replaced later: setting
err_ret->text was useless, removed the code.

<!-- issue-number: bpo-34084 -->
https://bugs.python.org/issue34084
<!-- /issue-number -->
