### PR TITLE
bpo-32430: During 'configure', don't copy Setup.dist to Setup.

### DIFF
--- a/Doc/extending/extending.rst
+++ b/Doc/extending/extending.rst
@@ -450,8 +450,8 @@ of an unpacked source distribution, add a line to the file
 and rebuild the interpreter by running :program:`make` in the toplevel
 directory.  You can also run :program:`make` in the :file:`Modules/`
 subdirectory, but then you must first rebuild :file:`Makefile` there by running
-':program:`make` Makefile'.  (This is necessary each time you change the
-:file:`Setup` file.)
+':program:`make` makesetup'.  (This is necessary each time you change the
+:file:`Setup.local` file.)
 
 If your module requires additional libraries to link with, these can be listed
 on the line in the configuration file as well, for instance:

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -684,11 +684,7 @@ $(DLLLIBRARY) libpython$(LDVERSION).dll.a: $(LIBRARY_OBJS)
 oldsharedmods: $(SHAREDMODS)
 
 
-Makefile Modules/config.c: Makefile.pre \
-				$(srcdir)/Modules/config.c.in \
-				$(MAKESETUP) \
-				Modules/Setup \
-				Modules/Setup.local
+makesetup:
 	$(SHELL) $(MAKESETUP) -c $(srcdir)/Modules/config.c.in \
 				-s Modules \
 				Modules/Setup.local \
@@ -696,16 +692,6 @@ Makefile Modules/config.c: Makefile.pre \
 	@mv config.c Modules
 	@echo "The Makefile was updated, you may need to re-run make."
 
-
-Modules/Setup: $(srcdir)/Modules/Setup.dist
-	@if test -f Modules/Setup; then \
-		echo "-----------------------------------------------"; \
-		echo "Modules/Setup.dist is newer than Modules/Setup;"; \
-		echo "check to make sure you have all the updates you"; \
-		echo "need in your Modules/Setup file."; \
-		echo "Usually, copying Modules/Setup.dist to Modules/Setup will work."; \
-		echo "-----------------------------------------------"; \
-	fi
 
 Programs/_testembed: Programs/_testembed.o $(LIBRARY) $(LDLIBRARY) $(PY3LIBRARY)
 	$(LINKCC) $(PY_LDFLAGS) $(LINKFORSHARED) -o $@ Programs/_testembed.o $(BLDLIBRARY) $(LIBS) $(MODLIBS) $(SYSLIBS) $(LDLAST)
@@ -1478,7 +1464,11 @@ libainstall:	@DEF_MAKE_RULE@ python-config
 	$(INSTALL_DATA) Programs/python.o $(DESTDIR)$(LIBPL)/python.o
 	$(INSTALL_DATA) $(srcdir)/Modules/config.c.in $(DESTDIR)$(LIBPL)/config.c.in
 	$(INSTALL_DATA) Makefile $(DESTDIR)$(LIBPL)/Makefile
-	$(INSTALL_DATA) Modules/Setup $(DESTDIR)$(LIBPL)/Setup
+	@if test -e Modules/Setup; then \
+		$(INSTALL_DATA) Modules/Setup $(DESTDIR)$(LIBPL)/Setup ; \
+	else \
+		$(INSTALL_DATA) $(srcdir)/Modules/Setup.dist $(DESTDIR)$(LIBPL)/Setup ; \
+	fi
 	$(INSTALL_DATA) Modules/Setup.local $(DESTDIR)$(LIBPL)/Setup.local
 	$(INSTALL_DATA) Misc/python.pc $(DESTDIR)$(LIBPC)/python-$(VERSION).pc
 	$(INSTALL_SCRIPT) $(srcdir)/Modules/makesetup $(DESTDIR)$(LIBPL)/makesetup
@@ -1767,7 +1757,7 @@ Python/thread.o: @THREADHEADERS@
 .PHONY: frameworkinstallmaclib frameworkinstallapps frameworkinstallunixtools
 .PHONY: frameworkaltinstallunixtools recheck clean clobber distclean
 .PHONY: smelly funny patchcheck touch altmaninstall commoninstall
-.PHONY: gdbhooks
+.PHONY: gdbhooks makesetup
 
 # IF YOU PUT ANYTHING HERE IT WILL GO AWAY
 # Local Variables:

--- a/Misc/NEWS.d/next/Build/2018-07-11-17-49-25.bpo-32430.c5qJcT.rst
+++ b/Misc/NEWS.d/next/Build/2018-07-11-17-49-25.bpo-32430.c5qJcT.rst
@@ -1,0 +1,7 @@
+The 'configure' script no longer copies Modules/Setup.dist to Modules/Setup.
+If Modules/Setup exists, it will be used in preference to Modules/Setup.dist
+(this fallback logic is done by the Modules/makesetup script).  Remove the
+makefile rules to re-generate Makefile and Modules/config.c if Modules/Setup
+or Modules/config.c.in changes.  To re-generate, you must run "make
+makesetup".  Normally that is not required since 'configure' already runs
+makesetup.

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -322,7 +322,7 @@ search_for_prefix(const _PyCoreConfig *core_config,
     /* Check to see if argv[0] is in the build directory */
     wcsncpy(prefix, calculate->argv0_path, MAXPATHLEN);
     prefix[MAXPATHLEN] = L'\0';
-    joinpath(prefix, L"Modules/Setup");
+    joinpath(prefix, L"Modules/config.c");
     if (isfile(prefix)) {
         /* Check VPATH to see if argv0_path is in the build directory. */
         vpath = Py_DecodeLocale(VPATH, NULL);

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -98,11 +98,23 @@ CYGWIN*) if test $libdir = .
 esac
 
 # Main loop
-for i in ${*-Setup}
+for setupfile in ${*-Setup}
 do
-	case $i in
+	# Check if Setup file does not exist.  In that case, use
+	# Setup.dist from libdir (source) folder.  In the normal case,
+	# the user does not create or modify Setup and so Setup.dist
+	# from the source distribution is used as-is.
+	case $setupfile in
+	*/Setup)
+		if ! test -f $setupfile; then
+			setupfile=$libdir/Setup.dist
+		fi
+		;;
+	esac
+
+	case $setupfile in
 	-n)	echo '*noobjects*';;
-	*)	echo '*doconfig*'; cat "$i";;
+	*)	echo '*doconfig*'; cat "$setupfile";;
 	esac
 done |
 sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |

--- a/configure
+++ b/configure
@@ -18355,12 +18355,6 @@ $as_echo "$as_me: WARNING: unrecognized options: $ac_unrecognized_opts" >&2;}
 fi
 
 
-echo "creating Modules/Setup" >&6
-if test ! -f Modules/Setup
-then
-	cp $srcdir/Modules/Setup.dist Modules/Setup
-fi
-
 echo "creating Modules/Setup.local" >&6
 if test ! -f Modules/Setup.local
 then

--- a/configure.ac
+++ b/configure.ac
@@ -5565,12 +5565,6 @@ AC_CONFIG_FILES(Makefile.pre Misc/python.pc Misc/python-config.sh)
 AC_CONFIG_FILES([Modules/ld_so_aix], [chmod +x Modules/ld_so_aix])
 AC_OUTPUT
 
-echo "creating Modules/Setup" >&AS_MESSAGE_FD
-if test ! -f Modules/Setup
-then
-	cp $srcdir/Modules/Setup.dist Modules/Setup
-fi
-
 echo "creating Modules/Setup.local" >&AS_MESSAGE_FD
 if test ! -f Modules/Setup.local
 then


### PR DESCRIPTION
In the past, users building Python were expected to modify the
Modules/Setup file.  In that case, preserving their local
modifications on re-execution of 'configure' was useful.  Further,
to support users modifying Setup and re-runnning make, there was
dependency rules in the Makefile to re-run makesetup if needed,
which would re-generate Makefile and Modules/config.c.

For modern builds of Python, most users never touch Modules/Setup.
In that case, the behavior of preserving Modules/Setup is
counter-productive since updating Modules/Setup.dist will result in
a stale copy of Modules/Setup being used.  In that case 'make'
outputs a warning.  In the past, the warning was the last output
from 'make'.  Now we run setup.py and so that warning is buried
under a pile of build tool output.  So, the net effect is that the
build can fail and the user doesn't know how to fix it.  Running
'configure' again is not sufficient because the out-of-date
Modules/Setup file is preserved.

This change does the following:

- In 'configure', don't create Modules/Setup from
  Modules/Setup.dist.  If the user wants a customized Setup, they
  will have to copy it themselves.

- In 'makesetup', if Modules/Setup does not exist, read the config
  from Modules/Setup.dist.  Note this is a bit tricky since the
  source and build folders can be separate (i.e. $srcdir/Modules/xyx
  is not the same as Modules/xyz).  The effect of this change is
  that if Modules/Setup exists, it will be used in preference to
  Modules/Setup.dist.

- In the 'Makefile', stop checking for an out-of-date Modules/Setup
  file.  If the user is creating Setup, we will have to trust them
  to keep it up-to-date.  That should not be a problem for 3rd party
  distributions like Red Hat, Debian, etc.  They would normally
  start a build from a clean source tree and so nothing should be
  out-of-date.

- In the 'Makefile', remove the dependency rule to re-run
  'makesetup'.  Again, this should never be necessary in the normal
  case.  Running 'configure' will result in 'makesetup' getting run.
  There is also a make target 'makesetup' if someone wants to modify
  Modules/Setup and wishes to re-generate Makefile and
  Modules/config.c.  Run "make makesetup" will process
  Setup/Setup.dist.

- Change getpath.c to look for Modules/config.c as the marker for a
  source folder.  That file gets generated and so we can use it in
  the same way that Modules/Setup was previously used.  This marker
  is important in the case that separate build and source folders
  are being used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-32430 -->
https://bugs.python.org/issue32430
<!-- /issue-number -->
