### PR TITLE
bpo-33967: Remove use of deprecated assertRaisesRegexp()

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2310,7 +2310,7 @@ class TestSingleDispatch(unittest.TestCase):
         def f(*args):
             pass
         msg = 'f requires at least 1 positional argument'
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             f()
 
 if __name__ == '__main__':

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2310,7 +2310,7 @@ class TestSingleDispatch(unittest.TestCase):
         def f(*args):
             pass
         msg = 'f requires at least 1 positional argument'
-        with self.assertRaisesRegex(TypeError, msg):
+        with self.assertRaises(TypeError, msg):
             f()
 
 if __name__ == '__main__':

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2310,7 +2310,7 @@ class TestSingleDispatch(unittest.TestCase):
         def f(*args):
             pass
         msg = 'f requires at least 1 positional argument'
-        with self.assertRaises(TypeError, msg):
+        with self.assertRaises(TypeError, msg=msg):
             f()
 
 if __name__ == '__main__':


### PR DESCRIPTION
It was added in 445f1b3.


<!-- issue-number: bpo-33967 -->
https://bugs.python.org/issue33967
<!-- /issue-number -->
