### PR TITLE
[3.6] bpo-33716, test_concurrent_futures: increase timeout (GH-7828)

### DIFF
--- a/Lib/test/test_concurrent_futures.py
+++ b/Lib/test/test_concurrent_futures.py
@@ -79,7 +79,7 @@ class ExecutorMixin:
     def setUp(self):
         super().setUp()
 
-        self.t1 = time.time()
+        self.t1 = time.monotonic()
         try:
             self.executor = self.executor_type(max_workers=self.worker_count)
         except NotImplementedError as e:
@@ -90,10 +90,10 @@ class ExecutorMixin:
         self.executor.shutdown(wait=True)
         self.executor = None
 
-        dt = time.time() - self.t1
+        dt = time.monotonic() - self.t1
         if test.support.verbose:
             print("%.2fs" % dt, end=' ')
-        self.assertLess(dt, 60, "synchronization issue: test lasted too long")
+        self.assertLess(dt, 300, "synchronization issue: test lasted too long")
 
         super().tearDown()
 


### PR DESCRIPTION
Increase the timeout from 1 min to 5 min.

Replace also time.time() with time.monotonic() for timeouts.

(cherry picked from commit 3ad8decd76c736f393755537aeb19b5612c21761)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33716 -->
https://bugs.python.org/issue33716
<!-- /issue-number -->
