### PR TITLE
bpo-33723: Remove time.thread_time() functional tests

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -529,19 +529,10 @@ class TimeTestCase(unittest.TestCase):
         # on Windows
         self.assertLess(stop - start, 0.020)
 
-        # thread_time() should include CPU time spent in current thread...
-        start = time.thread_time()
-        busy_wait(0.100)
-        stop = time.thread_time()
-        self.assertGreaterEqual(stop - start, 0.020)  # machine busy?
-
-        # ...but not in other threads
-        t = threading.Thread(target=busy_wait, args=(0.100,))
-        start = time.thread_time()
-        t.start()
-        t.join()
-        stop = time.thread_time()
-        self.assertLess(stop - start, 0.020)
+        # bpo-33723: Previously, there were functional tests to make sure that
+        # time.thread_time() doesn't account time of a busy loop in a different
+        # thread, but these tests have been removed because they were too
+        # fragile.
 
         info = time.get_clock_info('thread_time')
         self.assertTrue(info.monotonic)


### PR DESCRIPTION
These functional tests were too fragile: we already tolerate to only
get a delta of 20 ms whereas the test runs a busy loop during 100 ms.
The test failed on a buildbot because the delta was only 19 ms.
Reducing the minimum delta would make the test meaningless, so remove
it instead.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-33723 -->
https://bugs.python.org/issue33723
<!-- /issue-number -->
