### PR TITLE
bpo-34102: Check if data is not None before split

### DIFF
--- a/Lib/email/feedparser.py
+++ b/Lib/email/feedparser.py
@@ -96,7 +96,10 @@ class BufferedSubFile(object):
     def push(self, data):
         """Push some new data into this object."""
         # Crack into lines, but preserve the linesep characters on the end of each
-        parts = data.splitlines(True)
+        if data is None:
+            parts = []
+        else:
+            parts = data.splitlines(True)
 
         if not parts or not parts[0].endswith(('\n', '\r')):
             # No new complete lines, so just accumulate partials


### PR DESCRIPTION
Fix error in feedparser when data is None and it's splitted.
Check if data is not None, otherwise it's emptry list.

<!-- issue-number: bpo-34102 -->
https://bugs.python.org/issue34102
<!-- /issue-number -->
