### PR TITLE
bpo-33723: Fix test_time.test_thread_time()

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -529,19 +529,24 @@ class TimeTestCase(unittest.TestCase):
         # on Windows
         self.assertLess(stop - start, 0.020)
 
+        # bpo-33723: A busy loop of 100 ms should increase thread_time()
+        # by at least 15 ms
+        min_time = 0.015
+        busy_time = 0.100
+
         # thread_time() should include CPU time spent in current thread...
         start = time.thread_time()
-        busy_wait(0.100)
+        busy_wait(busy_time)
         stop = time.thread_time()
-        self.assertGreaterEqual(stop - start, 0.020)  # machine busy?
+        self.assertGreaterEqual(stop - start, min_time)
 
         # ...but not in other threads
-        t = threading.Thread(target=busy_wait, args=(0.100,))
+        t = threading.Thread(target=busy_wait, args=(busy_time,))
         start = time.thread_time()
         t.start()
         t.join()
         stop = time.thread_time()
-        self.assertLess(stop - start, 0.020)
+        self.assertLess(stop - start, min_time)
 
         info = time.get_clock_info('thread_time')
         self.assertTrue(info.monotonic)


### PR DESCRIPTION
The test failed on AMD64 Debian root 3.x buildbot because the busy
loop of 100 ms only increased time.thread_time() by 19.9 ms which is
smaller than 20 ms. Modify the test to tolerate a delta of at least
15 ms instead of 20 ms.

<!-- issue-number: bpo-33723 -->
https://bugs.python.org/issue33723
<!-- /issue-number -->
