### PR TITLE
bpo-34108: Fix double carriage return in 2to3 on Windows

### DIFF
--- a/Lib/lib2to3/refactor.py
+++ b/Lib/lib2to3/refactor.py
@@ -514,7 +514,7 @@ class RefactoringTool(object):
         set.
         """
         try:
-            fp = io.open(filename, "w", encoding=encoding)
+            fp = io.open(filename, "w", encoding=encoding, newline='')
         except OSError as err:
             self.log_error("Can't create %s: %s", filename, err)
             return

--- a/Lib/lib2to3/tests/test_refactor.py
+++ b/Lib/lib2to3/tests/test_refactor.py
@@ -300,6 +300,7 @@ from __future__ import print_function"""
         old, new = self.refactor_file(fn)
         self.assertIn(b"\r\n", old)
         self.assertIn(b"\r\n", new)
+        self.assertNotIn(b"\r\r\n", new)
 
     def test_refactor_docstring(self):
         rt = self.rt()

--- a/Misc/NEWS.d/next/Library/2018-07-13-08-44-52.bpo-34108.RjobUC.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-13-08-44-52.bpo-34108.RjobUC.rst
@@ -1,0 +1,1 @@
+Remove extraneous CR in 2to3 refactor.


### PR DESCRIPTION
See also #6483 

<!-- issue-number: bpo-34108 -->
https://bugs.python.org/issue34108
<!-- /issue-number -->
