### PR TITLE
[2.7] bpo-34110: Fix module load problem of cPickle in case of multithreading

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-07-13-15-08-12.bpo-34110.0vn18S.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-13-15-08-12.bpo-34110.0vn18S.rst
@@ -1,0 +1,2 @@
+Fix module load problem of cPickle in case of multithreading. Patch by 
+Guoqiang Zhang.

--- a/Modules/cPickle.c
+++ b/Modules/cPickle.c
@@ -3365,7 +3365,15 @@ find_class(PyObject *py_module_name, PyObject *py_global_name, PyObject *fc)
     if (module == NULL)
         return NULL;
 
+    _PyImport_AcquireLock();
     module = PyDict_GetItem(module, py_module_name);
+    if (_PyImport_ReleaseLock() < 0) {
+        Py_XDECREF(module);
+        PyErr_SetString(PyExc_RuntimeError,
+                        "not holding the import lock");
+        return NULL;
+    }
+
     if (module == NULL) {
         module = PyImport_Import(py_module_name);
         if (!module)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
[bpo-34110](https://bugs.python.org/issue34110): Fix module load problem of cPickle in case of multithreading
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

In Python 2.7, `sys.modules` may contain a partially loaded module. This is caused by the following logic:
https://github.com/python/cpython/blob/a45fa39d85fc500d530d05d3ec7b36eb5d286f5e/Python/import.c#L721-L727

When executing the code of a module, an empty module is added into the module dict. Thus if any code in the module releases the GIL, another thread may get a partially loaded module from `sys.modules`. Unfortunately, `cPickle` checks `sys.modules` before trying to import and may get an incomplete module, leading to an `AttributeError` when trying to obtain an object of the module.

This fix acquires import lock before checking `sys.modules`, make sure there is no partially loaded module.

To reproduce, first create a `foo.py`:
```
import time
time.sleep(0.1)
class foo():
    pass
```

Then create and run `main.py`:
```
import threading
import cPickle 

threads = [threading.Thread(target=cPickle.loads, args=('cfoo\nfoo\np0\n.',)) for _ in range(2)]
[thread.start() for thread in threads]
[thread.join() for thread in threads]
```

The following error should be raised:
```
Exception in thread Thread-2:
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
AttributeError: 'module' object has no attribute 'foo'
```

<!-- issue-number: [bpo-34110](https://bugs.python.org/issue34110) -->
https://bugs.python.org/issue34110
<!-- /issue-number -->
