### PR TITLE
bpo-34068: _io__IOBase_close_impl could call _PyObject_SetAttrId with an exception set

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -968,6 +968,16 @@ class IOTest(unittest.TestCase):
                 self.assertSequenceEqual(buffer[result:], unused)
                 self.assertEqual(len(reader.avail), avail - result)
 
+    def test_close_assert(self):
+        class R(self.IOBase):
+            def __setattr__(self, name, value):
+                pass
+            def flush(self):
+                raise OSError()
+        f = R()
+        # This would cause an assertion failure.
+        self.assertRaises(OSError, f.close)
+
 
 class CIOTest(IOTest):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-14-08-58-46.bpo-34068.9xfM55.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-14-08-58-46.bpo-34068.9xfM55.rst
@@ -1,2 +1,3 @@
-In :meth:`io.IOBase.close`, ensure that ``_PyObject_SetAttrId()`` is not
-called with a live exception.  Patch by Zackery Spytz and Serhiy Storchaka.
+In :meth:`io.IOBase.close`, ensure that the :attr:`~io.IOBase.closed`
+attribute is not set with a live exception.  Patch by Zackery Spytz and Serhiy
+Storchaka.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-14-08-58-46.bpo-34068.9xfM55.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-14-08-58-46.bpo-34068.9xfM55.rst
@@ -1,0 +1,2 @@
+In :meth:`io.IOBase.close`, ensure that ``_PyObject_SetAttrId()`` is not
+called with a live exception.  Patch by Zackery Spytz and Serhiy Storchaka.

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -224,8 +224,8 @@ static PyObject *
 _io__IOBase_close_impl(PyObject *self)
 /*[clinic end generated code: output=63c6a6f57d783d6d input=f4494d5c31dbc6b7]*/
 {
-    PyObject *res;
-    int closed = iobase_is_closed(self);
+    PyObject *res, *exc, *val, *tb;
+    int rc, closed = iobase_is_closed(self);
 
     if (closed < 0) {
         return NULL;
@@ -236,9 +236,11 @@ _io__IOBase_close_impl(PyObject *self)
 
     res = PyObject_CallMethodObjArgs(self, _PyIO_str_flush, NULL);
 
-    if (_PyObject_SetAttrId(self, &PyId___IOBase_closed, Py_True) < 0) {
-        Py_XDECREF(res);
-        return NULL;
+    PyErr_Fetch(&exc, &val, &tb);
+    rc = _PyObject_SetAttrId(self, &PyId___IOBase_closed, Py_True);
+    _PyErr_ChainExceptions(exc, val, tb);
+    if (rc < 0) {
+        Py_CLEAR(res);
     }
 
     if (res == NULL)


### PR DESCRIPTION


<!-- issue-number: bpo-34068 -->
https://bugs.python.org/issue34068
<!-- /issue-number -->
