### PR TITLE
bpo-24618: Add a check in the code constructor.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-14-14-01-37.bpo-24618.iTKjD_.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-14-14-01-37.bpo-24618.iTKjD_.rst
@@ -1,0 +1,2 @@
+Fixed reading invalid memory when create the code object with too small
+varnames tuple or too large argument counts.


### PR DESCRIPTION
Check that the size of the varnames tuple is enough at least for all arguments.


<!-- issue-number: bpo-24618 -->
https://bugs.python.org/issue24618
<!-- /issue-number -->
