### PR TITLE
bpo-34124: fix message_from_binary_file typo

### DIFF
--- a/Doc/library/email.parser.rst
+++ b/Doc/library/email.parser.rst
@@ -246,7 +246,7 @@ in the top-level :mod:`email` package namespace.
       Removed the *strict* argument.  Added the *policy* keyword.
 
 
-.. function:: message_from_binary_file(fp, _class=None, *,
+.. function:: message_from_binary_file(fp, _class=None, *, \
                                        policy=policy.compat32)
 
    Return a message object structure tree from an open binary :term:`file


### PR DESCRIPTION
The documentation for `email.message_from_binary_file` is missing a line-continuation backslash at the end of the `.. function::` line which means the output formatting is mangled and it has no permalink.



<!-- issue-number: bpo-34124 -->
https://bugs.python.org/issue34124
<!-- /issue-number -->
