### PR TITLE
bpo-34126: fix crashes while profiling certain invalid calls

### DIFF
--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -334,6 +334,22 @@ class ProfileSimulatorTestCase(TestCaseBase):
                               (1, 'return', j_ident),
                               ])
 
+    # Test an invalid call (bpo-34126)
+    def test_unbound_method_no_args(self):
+        def f(p):
+            dict.get()
+        f_ident = ident(f)
+        self.check_events(f, [(1, 'call', f_ident),
+                              (1, 'return', f_ident)])
+
+    # Test an invalid call (bpo-34126)
+    def test_unbound_method_invalid_args(self):
+        def f(p):
+            dict.get(print, 42)
+        f_ident = ident(f)
+        self.check_events(f, [(1, 'call', f_ident),
+                              (1, 'return', f_ident)])
+
 
 def ident(function):
     if hasattr(function, "f_code"):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-16-20-55-29.bpo-34126.mBVmgc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-16-20-55-29.bpo-34126.mBVmgc.rst
@@ -1,0 +1,2 @@
+Fix crashes when profiling certain invalid calls of unbound methods.
+Patch by Jeroen Demeyer.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4566,10 +4566,16 @@ call_function(PyObject ***pp_stack, Py_ssize_t oparg, PyObject *kwnames)
     }
     else if (Py_TYPE(func) == &PyMethodDescr_Type) {
         PyThreadState *tstate = PyThreadState_GET();
-        if (tstate->use_tracing && tstate->c_profilefunc) {
-            // We need to create PyCFunctionObject for tracing.
-            PyMethodDescrObject *descr = (PyMethodDescrObject*)func;
-            func = PyCFunction_NewEx(descr->d_method, stack[0], NULL);
+        if (nargs > 0 && tstate->use_tracing) {
+            /* We need to create a temporary bound method as argument
+               for profiling.
+
+               If nargs == 0, then this cannot work because we have no
+               "self". In any case, the call itself would raise
+               TypeError (foo needs an argument), so we just skip
+               profiling. */
+            PyObject *self = stack[0];
+            func = Py_TYPE(func)->tp_descr_get(func, self, (PyObject*)Py_TYPE(self));
             if (func == NULL) {
                 return NULL;
             }


### PR DESCRIPTION
Needs backport to 3.7

<!-- issue-number: bpo-34126 -->
https://bugs.python.org/issue34126
<!-- /issue-number -->
