### PR TITLE
bpo-33967: Fix wrong use of assertRaises

### DIFF
--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2310,7 +2310,7 @@ class TestSingleDispatch(unittest.TestCase):
         def f(*args):
             pass
         msg = 'f requires at least 1 positional argument'
-        with self.assertRaises(TypeError, msg=msg):
+        with self.assertRaisesRegex(TypeError, msg):
             f()
 
 if __name__ == '__main__':


### PR DESCRIPTION


<!-- issue-number: bpo-33967 -->
https://bugs.python.org/issue33967
<!-- /issue-number -->
