### PR TITLE
bpo-34133: Clarify ValueError's broad applicability

### DIFF
--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -525,7 +525,7 @@ The following exceptions are the exceptions that are usually raised.
 
 .. exception:: ValueError
 
-   Raised when a built-in operation or function receives an argument that has the
+   Raised when an operation or function receives an argument that has the
    right type but an inappropriate value, and the situation is not described by a
    more precise exception such as :exc:`IndexError`.
 


### PR DESCRIPTION


<!-- issue-number: bpo-34133 -->
https://bugs.python.org/issue34133
<!-- /issue-number -->
