### PR TITLE
[2.7] bpo-34068: iobase_close could call PyObject_SetAttrString with an exception set (GH-8282). (GH-8312)

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -690,6 +690,16 @@ class IOTest(unittest.TestCase):
         self.assertEqual(stream.readinto(buffer), 5)
         self.assertEqual(buffer.tobytes(), b"12345")
 
+    def test_close_assert(self):
+        class R(self.IOBase):
+            def __setattr__(self, name, value):
+                pass
+            def flush(self):
+                raise OSError()
+        f = R()
+        # This would cause an assertion failure.
+        self.assertRaises(OSError, f.close)
+
 
 class CIOTest(IOTest):
 

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-14-08-58-46.bpo-34068.9xfM55.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-14-08-58-46.bpo-34068.9xfM55.rst
@@ -1,0 +1,3 @@
+In :meth:`io.IOBase.close`, ensure that the :attr:`~io.IOBase.closed`
+attribute is not set with a live exception.  Patch by Zackery Spytz and Serhiy
+Storchaka.

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -177,17 +177,25 @@ _PyIOBase_check_closed(PyObject *self, PyObject *args)
 static PyObject *
 iobase_close(PyObject *self, PyObject *args)
 {
-    PyObject *res;
+    PyObject *res, *exc, *val, *tb;
+    int rc;
 
     if (IS_CLOSED(self))
         Py_RETURN_NONE;
 
     res = PyObject_CallMethodObjArgs(self, _PyIO_str_flush, NULL);
-    PyObject_SetAttrString(self, "__IOBase_closed", Py_True);
+
+    PyErr_Fetch(&exc, &val, &tb);
+    rc = PyObject_SetAttrString(self, "__IOBase_closed", Py_True);
+    _PyErr_ReplaceException(exc, val, tb);
+    if (rc < 0) {
+        Py_CLEAR(res);
+    }
+
     if (res == NULL) {
         return NULL;
     }
-    Py_XDECREF(res);
+    Py_DECREF(res);
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
(cherry picked from commit 28f07364f066792ceee93231dbb80ae8ad98b2bb)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>.
(cherry picked from commit cc13016658a9ed86d0b702ab6c251ad5952a952f)


<!-- issue-number: bpo-34068 -->
https://bugs.python.org/issue34068
<!-- /issue-number -->
