### PR TITLE
bpo-34132: Fix netrc parsing regression

### DIFF
--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -35,13 +35,15 @@ class netrc:
         lexer.commenters = lexer.commenters.replace('#', '')
         while 1:
             # Look for a machine, default, or macdef top-level keyword
-            saved_lineno = lexer.lineno
+            pos = lexer.instream.tell()
             toplevel = tt = lexer.get_token()
             if not tt:
                 break
             elif tt[0] == '#':
-                if lexer.lineno == saved_lineno and len(tt) == 1:
-                    lexer.instream.readline()
+                if len(tt) != 1:
+                    pos = max(pos - 1, 0)
+                lexer.instream.seek(pos)
+                lexer.instream.readline()
                 continue
             elif tt == 'machine':
                 entryname = lexer.get_token()

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -165,6 +165,14 @@ class NetrcTestCase(unittest.TestCase):
 
         self.assertTrue(called)
 
+    def test_newline_comment_space(self):
+        nrc = self.make_nrc(
+            '\n'
+            '# Comment\n'
+            'default login anonymous password user@site\n'
+        )
+        self.assertEqual(nrc.hosts['default'], ('anonymous', None, 'user@site'))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-07-17-21-23-31.bpo-34132.FK4czq.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-17-21-23-31.bpo-34132.FK4czq.rst
@@ -1,0 +1,1 @@
+Fixed regression in netrc file newline and comment handling.


### PR DESCRIPTION
This PR adds a test and fix for the issue described in bpo-34132, a strange regression in netrc parsing that causes recent versions of Python 3 to fail to parse files like this:

```

# Comment
default login user password pass 
```

but to succesfully parse files like this:

```

#Comment
default login user password pass 
```

This fix is adapted from the [Python 2 version](https://hg.python.org/cpython/rev/cb3a77b0f8dd), which is able to parse the former file.

<!-- issue-number: bpo-34132 -->
https://bugs.python.org/issue34132
<!-- /issue-number -->
