### PR TITLE
bpo-34144: Fix of venv acvtivate.bat for win 10

### DIFF
--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -1,7 +1,7 @@
 @echo off
 
 rem This file is UTF-8 encoded, so we need to update the current code page while executing it
-for /f "tokens=2 delims=:" %%a in ('"%SystemRoot%\System32\chcp.com"') do (
+for /f "tokens=2 delims=:." %%a in ('"%SystemRoot%\System32\chcp.com"') do (
     set "_OLD_CODEPAGE=%%a"
 )
 if defined _OLD_CODEPAGE (

--- a/Misc/NEWS.d/next/Windows/2019-04-10-04-35-31.bpo-34144._KzB5z.rst
+++ b/Misc/NEWS.d/next/Windows/2019-04-10-04-35-31.bpo-34144._KzB5z.rst
@@ -1,2 +1,2 @@
-fixed codepage grep to work with win10/ 1803 (chcp.com return got trailing dot).
+Fixed activate.bat to correctly update codepage when chcp.com returns dots in output.
 Patch by Lorenz Mende.

--- a/Misc/NEWS.d/next/Windows/2019-04-10-04-35-31.bpo-34144._KzB5z.rst
+++ b/Misc/NEWS.d/next/Windows/2019-04-10-04-35-31.bpo-34144._KzB5z.rst
@@ -1,0 +1,2 @@
+fixed codepage grep to work with win10/ 1803 (chcp.com return got trailing dot).
+Patch by Lorenz Mende.


### PR DESCRIPTION
The script needs to be updated to support win 10/ 1803 chcp.com command (output has trailing dot)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34144 -->
https://bugs.python.org/issue34144
<!-- /issue-number -->
