### PR TITLE
bpo-34130: Fix test_signal.test_socket()

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -392,7 +392,6 @@ class WakeupSocketSignalTests(unittest.TestCase):
         signal.signal(signum, handler)
 
         read, write = socket.socketpair()
-        read.setblocking(False)
         write.setblocking(False)
         signal.set_wakeup_fd(write.fileno())
 


### PR DESCRIPTION
Sometimes on Windows, test_signal.test_socket() fails on recv(1) with
BlockingIOError. The C signal handler wrote the signal number using
send() which returns 1 byte as expected, but the read end of the
socket pair doesn't get "immediately" the byte.

Configure the read end of the socket pair as blocking to wait until
we get the signal number and so fix the race condition on Windows.

Use also "with" context manager to ensure that the sockets are closed
even if the test fails.

<!-- issue-number: bpo-34130 -->
https://bugs.python.org/issue34130
<!-- /issue-number -->
