### PR TITLE
bpo-34149: Behavior of the min/max with key=None

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -869,6 +869,9 @@ are always available.  They are listed here in alphabetical order.
    .. versionadded:: 3.4
       The *default* keyword-only argument.
 
+   .. versionchanged:: 3.8
+      The *key* can be ``None``.
+
 
 .. _func-memoryview:
 .. function:: memoryview(obj)
@@ -902,6 +905,9 @@ are always available.  They are listed here in alphabetical order.
 
    .. versionadded:: 3.4
       The *default* keyword-only argument.
+
+   .. versionchanged:: 3.8
+      The *key* can be ``None``.
 
 
 .. function:: next(iterator[, default])

--- a/Lib/heapq.py
+++ b/Lib/heapq.py
@@ -468,10 +468,7 @@ def nsmallest(n, iterable, key=None):
     if n == 1:
         it = iter(iterable)
         sentinel = object()
-        if key is None:
-            result = min(it, default=sentinel)
-        else:
-            result = min(it, default=sentinel, key=key)
+        result = min(it, default=sentinel, key=key)
         return [] if result is sentinel else [result]
 
     # When n>=size, it's faster to use sorted()
@@ -531,10 +528,7 @@ def nlargest(n, iterable, key=None):
     if n == 1:
         it = iter(iterable)
         sentinel = object()
-        if key is None:
-            result = max(it, default=sentinel)
-        else:
-            result = max(it, default=sentinel, key=key)
+        result = max(it, default=sentinel, key=key)
         return [] if result is sentinel else [result]
 
     # When n>=size, it's faster to use sorted()

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -905,6 +905,8 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(max((), default=1, key=neg), 1)
         self.assertEqual(max((1, 2), default=3, key=neg), 1)
 
+        self.assertEqual(max((1, 2), key=None), 2)
+
         data = [random.randrange(200) for i in range(100)]
         keys = dict((elem, random.randrange(50)) for elem in data)
         f = keys.__getitem__
@@ -956,6 +958,8 @@ class BuiltinTest(unittest.TestCase):
 
         self.assertEqual(min((), default=1, key=neg), 1)
         self.assertEqual(min((1, 2), default=1, key=neg), 2)
+
+        self.assertEqual(min((1, 2), key=None), 1)
 
         data = [random.randrange(200) for i in range(100)]
         keys = dict((elem, random.randrange(50)) for elem in data)

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-23-21-49-05.bpo-34149.WSV-_g.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-23-21-49-05.bpo-34149.WSV-_g.rst
@@ -1,0 +1,1 @@
+Fix min and max functions to get default behavior when key is None.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -1639,6 +1639,10 @@ min_max(PyObject *args, PyObject *kwds, int op)
         return NULL;
     }
 
+    if (keyfunc == Py_None) {
+        keyfunc = NULL;
+    }
+
     maxitem = NULL; /* the result */
     maxval = NULL;  /* the value associated with the result */
     while (( item = PyIter_Next(it) )) {


### PR DESCRIPTION
https://bugs.python.org/issue34149

I was faced with the fact that the behavior of the functions "min"/"max" and "sorted" is a little different.

For example, this code works fine:

    >>> sorted([3, 2, 1], key=None)
    [1, 2, 3]

But the same example for "min" and "max" doesn't work:

    >>> min([3, 2, 1], key=None)
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    TypeError: 'NoneType' object is not callable

That is why the heapq library has this code:

    ...
    def nsmallest(n, iterable, key=None):
        ...
            if key is None:
                result = min(it, default=sentinel)
            else:
                result = min(it, default=sentinel, key=key)
        ...

At the same time, there are many places where such checks are not performed for the "sorted" function. I think the behavior of the "min" / "max" / "sorted" functions should be unified. That is, they should work as if "None" is the default value for "key".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34149 -->
https://bugs.python.org/issue34149
<!-- /issue-number -->
