### PR TITLE
bpo-32692: Fix test_threading.test_set_and_clear()

### DIFF
--- a/Lib/test/lock_tests.py
+++ b/Lib/test/lock_tests.py
@@ -405,12 +405,13 @@ class EventTests(BaseTestCase):
         # cleared before the waiting thread is woken up.
         evt = self.eventtype()
         results = []
+        timeout = 0.250
         N = 5
         def f():
-            results.append(evt.wait(1))
+            results.append(evt.wait(timeout * 4))
         b = Bunch(f, N)
         b.wait_for_started()
-        time.sleep(0.5)
+        time.sleep(timeout)
         evt.set()
         evt.clear()
         b.wait_for_finished()


### PR DESCRIPTION
Increase the timeout: give timeout x 4 instead of timeout x 2 to
threads to wait until the Event is set, but reduce the sleep from 500
ms to 250 ms. So the test should be more reliable and faster!

<!-- issue-number: bpo-32692 -->
https://bugs.python.org/issue32692
<!-- /issue-number -->
