### PR TITLE
[3.6] bpo-30237: Output error when ReadConsole is canceled by CancelSynchronousIo. (GH-7911)

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-06-25-09-33-48.bpo-30237.EybiZA.rst
+++ b/Misc/NEWS.d/next/Windows/2018-06-25-09-33-48.bpo-30237.EybiZA.rst
@@ -1,0 +1,2 @@
+Output error when ReadConsole is canceled by CancelSynchronousIo instead of
+crashing.

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -573,12 +573,16 @@ read_console_w(HANDLE handle, DWORD maxlen, DWORD *readlen) {
     Py_BEGIN_ALLOW_THREADS
     DWORD off = 0;
     while (off < maxlen) {
-        DWORD n, len = min(maxlen - off, BUFSIZ);
+        DWORD n = (DWORD)-1; 
+        DWORD len = min(maxlen - off, BUFSIZ);
         SetLastError(0);
         BOOL res = ReadConsoleW(handle, &buf[off], len, &n, NULL);
 
         if (!res) {
             err = GetLastError();
+            break;
+        }
+        if (n == (DWORD)-1 && (err = GetLastError()) == ERROR_OPERATION_ABORTED) {
             break;
         }
         if (n == 0) {

--- a/Parser/myreadline.c
+++ b/Parser/myreadline.c
@@ -114,7 +114,7 @@ _PyOS_WindowsConsoleReadline(HANDLE hStdIn)
     char *buf = NULL;
     int err = 0;
 
-    n_read = 0;
+    n_read = (DWORD)-1;
     total_read = 0;
     wbuf = wbuf_local;
     wbuflen = sizeof(wbuf_local) / sizeof(wbuf_local[0]) - 1;
@@ -125,6 +125,9 @@ _PyOS_WindowsConsoleReadline(HANDLE hStdIn)
         if (!ReadConsoleW(hStdIn, &wbuf[total_read], wbuflen - total_read, &n_read, NULL)) {
             err = GetLastError();
             goto exit;
+        }
+        if (n_read == (DWORD)-1 && (err = GetLastError()) == ERROR_OPERATION_ABORTED) {
+            break;
         }
         if (n_read == 0) {
             int s;


### PR DESCRIPTION


<!-- issue-number: bpo-30237 -->
https://bugs.python.org/issue30237
<!-- /issue-number -->
