### PR TITLE
[3.7] bpo-34161 Removed additional parens (GH-8349)

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -41,8 +41,8 @@ printing space-separated values. There are several ways to format output.
   ::
 
      >>> yes_votes = 42_572_654 ; no_votes = 43_132_495
-     >>> percentage = (yes_votes/(yes_votes+no_votes)
-     >>> '{:-9} YES votes  {:2.2%}'.format(yes_votes, percentage))
+     >>> percentage = yes_votes/(yes_votes+no_votes)
+     >>> '{:-9} YES votes  {:2.2%}'.format(yes_votes, percentage)
      ' 42572654 YES votes  49.67%'
 
 * Finally, you can do all the string handling yourself by using string slicing and


### PR DESCRIPTION
https://bugs.python.org/issue34161

```
bpo-34161 removed additional parens/brackets
```



<!-- issue-number: bpo-34161 -->
https://bugs.python.org/issue34161
<!-- /issue-number -->
