### PR TITLE
bpo-34164: Fix handling of incorrect padding in base64.b32decode().

### DIFF
--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -231,21 +231,13 @@ def b32decode(s, casefold=False, map01=None):
             raise binascii.Error('Non-base32 digit found') from None
         decoded += acc.to_bytes(5, 'big')
     # Process the last, partial quanta
-    if padchars:
+    if l % 8 or padchars not in {0, 1, 3, 4, 6}:
+        raise binascii.Error('Incorrect padding')
+    if padchars and decoded:
         acc <<= 5 * padchars
         last = acc.to_bytes(5, 'big')
-        if padchars == 1:
-            decoded[-5:] = last[:-1]
-        elif padchars == 3:
-            decoded[-5:] = last[:-2]
-        elif padchars == 4:
-            decoded[-5:] = last[:-3]
-        elif padchars == 6:
-            decoded[-5:] = last[:-4]
-        else:
-            raise binascii.Error('Incorrect padding')
+        decoded[-5:] = last[:-((padchars * 5 + 4) // 8)]
     return bytes(decoded)
-
 
 
 # RFC 3548, Base 16 Alphabet specifies uppercase, but hexlify() returns

--- a/Lib/base64.py
+++ b/Lib/base64.py
@@ -236,7 +236,8 @@ def b32decode(s, casefold=False, map01=None):
     if padchars and decoded:
         acc <<= 5 * padchars
         last = acc.to_bytes(5, 'big')
-        decoded[-5:] = last[:-((padchars * 5 + 4) // 8)]
+        leftover = (43 - 5 * padchars) // 8  # 1: 4, 3: 3, 4: 2, 6: 1
+        decoded[-5:] = last[:leftover]
     return bytes(decoded)
 
 

--- a/Lib/test/test_base64.py
+++ b/Lib/test/test_base64.py
@@ -343,11 +343,20 @@ class BaseXYTestCase(unittest.TestCase):
             self.assertRaises(binascii.Error, base64.b32decode, data_str)
 
     def test_b32decode_error(self):
-        for data in [b'abc', b'ABCDEF==', b'==ABCDEF']:
-            with self.assertRaises(binascii.Error):
-                base64.b32decode(data)
-            with self.assertRaises(binascii.Error):
-                base64.b32decode(data.decode('ascii'))
+        tests = [b'abc', b'ABCDEF==', b'==ABCDEF']
+        prefixes = [b'M', b'ME', b'MFRA', b'MFRGG', b'MFRGGZA', b'MFRGGZDF']
+        for i in range(0, 17):
+            if i:
+                tests.append(b'='*i)
+            for prefix in prefixes:
+                if len(prefix) + i != 8:
+                    tests.append(prefix + b'='*i)
+        for data in tests:
+            with self.subTest(data=data):
+                with self.assertRaises(binascii.Error):
+                    base64.b32decode(data)
+                with self.assertRaises(binascii.Error):
+                    base64.b32decode(data.decode('ascii'))
 
     def test_b16encode(self):
         eq = self.assertEqual

--- a/Misc/NEWS.d/next/Library/2018-07-20-18-06-00.bpo-34164.fNfT-q.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-20-18-06-00.bpo-34164.fNfT-q.rst
@@ -1,0 +1,2 @@
+:func:`base64.b32decode` could raise UnboundLocalError or OverflowError for
+incorrect padding.  Now it always raises :exc:`base64.Error` in these cases.


### PR DESCRIPTION
Now base64.Error is always raised instead of UnboundLocalError or
OverflowError.


<!-- issue-number: bpo-34164 -->
https://bugs.python.org/issue34164
<!-- /issue-number -->
