### PR TITLE
bpo-34169: Fix itertools.repeat to get the default when times is None.

### DIFF
--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -1130,6 +1130,11 @@ class TestBasicOps(unittest.TestCase):
         self.assertEqual(repr(repeat('a', times=-1)), "repeat('a', 0)")
         self.assertEqual(repr(repeat('a', times=-2)), "repeat('a', 0)")
 
+    def test_repeat_with_none_times(self):
+        self.assertEqual(repr(repeat('a')), "repeat('a')")
+        self.assertEqual(repr(repeat('a', None)), "repeat('a')")
+        self.assertEqual(repr(repeat('a', times=None)), "repeat('a')")
+
     def test_map(self):
         self.assertEqual(list(map(operator.pow, range(3), range(1,7))),
                          [0**1, 1**2, 2**3])

--- a/Misc/NEWS.d/next/Library/2018-07-21-01-46-21.bpo-34169.Jl0Yex.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-21-01-46-21.bpo-34169.Jl0Yex.rst
@@ -1,0 +1,1 @@
+Fix itertools.repeat to get the default behavior when times is None.


### PR DESCRIPTION


<!-- issue-number: bpo-34169 -->
https://bugs.python.org/issue34169
<!-- /issue-number -->
