### PR TITLE
Fix Windows compiler warning in tokenize.c

### DIFF
--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1294,7 +1294,7 @@ syntaxerror(struct tok_state *tok, const char *format, ...)
     va_end(vargs);
     PyErr_SyntaxLocationObject(tok->filename,
                                tok->lineno,
-                               tok->cur - tok->line_start);
+                               (int)(tok->cur - tok->line_start));
     tok->done = E_ERROR;
 #else
     tok->done = E_TOKEN;


### PR DESCRIPTION
Fix the following warning on Windows 64-bit:

parser\tokenizer.c(1297): warning C4244: 'function': conversion from
'__int64' to 'int', possible loss of data.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
