### PR TITLE
bpo-34132: Fix netrc parsing regression

### DIFF
--- a/Lib/netrc.py
+++ b/Lib/netrc.py
@@ -35,13 +35,16 @@ class netrc:
         lexer.commenters = lexer.commenters.replace('#', '')
         while 1:
             # Look for a machine, default, or macdef top-level keyword
-            saved_lineno = lexer.lineno
+            saved_pos = lexer.instream.tell()
             toplevel = tt = lexer.get_token()
             if not tt:
                 break
             elif tt[0] == '#':
-                if lexer.lineno == saved_lineno and len(tt) == 1:
-                    lexer.instream.readline()
+                # seek to beginning of comment, in case reading the token put
+                # us on a new line, and then skip the rest of the line.
+                new_pos = lexer.instream.tell()
+                lexer.instream.seek(new_pos - len(tt) - 1)
+                lexer.instream.readline()
                 continue
             elif tt == 'machine':
                 entryname = lexer.get_token()

--- a/Lib/test/test_netrc.py
+++ b/Lib/test/test_netrc.py
@@ -165,6 +165,22 @@ class NetrcTestCase(unittest.TestCase):
 
         self.assertTrue(called)
 
+    def test_newline_comment_space(self):
+        nrc = self.make_nrc(
+            '\n'
+            '# Comment\n'
+            'default login anonymous password user@site\n'
+        )
+        self.assertEqual(nrc.hosts['default'], ('anonymous', None, 'user@site'))
+
+    def test_newline_comment_no_space(self):
+        nrc = self.make_nrc(
+            '\n'
+            '#Comment\n'
+            'default login anonymous password user@site\n'
+        )
+        self.assertEqual(nrc.hosts['default'], ('anonymous', None, 'user@site'))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-07-20-19-54-05.bpo-34132.FK4czq.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-20-19-54-05.bpo-34132.FK4czq.rst
@@ -1,0 +1,1 @@
+Fixed regression in netrc file newline and comment handling.


### PR DESCRIPTION
This PR adds tests and a fix for the issue described in bpo-34132, a strange regression in netrc parsing. 

Current versions of Python 3 to fail to parse files like this one:

```

# Comment
default login user password pass 
```

However, they can parse files like this one:

```

#Comment
default login user password pass 
```

Python 2 had no such problem - it used negative seeks instead of the lexer's line number counter. Negative seeks don't work in Python 3, but we can use absolute seeks almost as easily.
https://github.com/python/cpython/blob/2.7/Lib/netrc.py#L47-L51

I made another attempt this [earlier](https://github.com/python/cpython/pull/8320), but this time I think I managed to avoid introducing a different regression.

<!-- issue-number: bpo-34132 -->
https://bugs.python.org/issue34132
<!-- /issue-number -->
