### PR TITLE
AppVeyor: build Python in 64-bit mode

### DIFF
--- a/.github/appveyor.yml
+++ b/.github/appveyor.yml
@@ -28,10 +28,10 @@ before_build:
 
 
 build_script:
-  - cmd: PCbuild\build.bat -e
-  - cmd: PCbuild\win32\python.exe -m test.pythoninfo
+  - cmd: PCbuild\build.bat -e -p x64
+  - cmd: PCbuild\amd64\python.exe -m test.pythoninfo
 test_script:
-  - cmd: PCbuild\rt.bat -q -uall -u-cpu -u-largefile -rwW --slowest --timeout=1200 --fail-env-changed -j0
+  - cmd: PCbuild\rt.bat -x64 -q -uall -u-cpu -u-largefile -rwW --slowest --timeout=1200 --fail-env-changed -j0
 environment:
   HOST_PYTHON: C:\Python36\python.exe
 image:


### PR DESCRIPTION
Previously, Python was built in 32-bit mode and so issues specific to
64-bit mode like compiler warnings could be missed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
