### PR TITLE
bpo-34136: Make test_do_not_recreate_annotations more reliable.

### DIFF
--- a/Lib/test/test_opcodes.py
+++ b/Lib/test/test_opcodes.py
@@ -1,7 +1,7 @@
 # Python test set -- part 2, opcodes
 
 import unittest
-from test import ann_module
+from test import ann_module, support
 
 class OpcodeTest(unittest.TestCase):
 
@@ -42,10 +42,14 @@ class OpcodeTest(unittest.TestCase):
         self.assertEqual(ns['__annotations__'], {'x': int, 1: 2})
 
     def test_do_not_recreate_annotations(self):
-        class C:
-            del __annotations__
-            with self.assertRaises(NameError):
-                x: int
+        annotations = {}
+        # Don't rely on the existence of the '__annotations__' global.
+        with support.swap_item(globals(), '__annotations__', annotations):
+            class C:
+                del __annotations__
+                x: int  # Updates the '__annotations__' global.
+        self.assertIn('x', annotations)
+        self.assertIs(annotations['x'], int)
 
     def test_raise_class_exceptions(self):
 


### PR DESCRIPTION


<!-- issue-number: bpo-34136 -->
https://bugs.python.org/issue34136
<!-- /issue-number -->
