### PR TITLE
bpo-34166: Use tobytes instead of tostring and use with statement for file handling

### DIFF
--- a/Tools/i18n/msgfmt.py
+++ b/Tools/i18n/msgfmt.py
@@ -89,7 +89,7 @@ def generate():
                          7*4,               # start of key index
                          7*4+len(keys)*8,   # start of value index
                          0, 0)              # size and offset of hash table
-    output += array.array("i", offsets).tostring()
+    output += array.array("i", offsets).tobytes()
     output += ids
     output += strs
     return output
@@ -109,7 +109,8 @@ def make(filename, outfile):
         outfile = os.path.splitext(infile)[0] + '.mo'
 
     try:
-        lines = open(infile, 'rb').readlines()
+        with open(infile, 'rb') as f:
+            lines = f.readlines()
     except IOError as msg:
         print(msg, file=sys.stderr)
         sys.exit(1)
@@ -199,7 +200,8 @@ def make(filename, outfile):
     output = generate()
 
     try:
-        open(outfile,"wb").write(output)
+        with open(outfile,"wb") as f:
+            f.write(output)
     except IOError as msg:
         print(msg, file=sys.stderr)
 


### PR DESCRIPTION
Changes made : 

* Use `tobytes` instead of `tostring`.
* Use with statement for file handling to fix ResourceWarning.

Tested using a sample .po file as in https://bugs.python.org/msg322074

I think this needs a backport to 3.7 and 3.6. I haven't added a NEWS entry since the changes seem trivial let me know if it's needed.

Thanks

<!-- issue-number: bpo-34166 -->
https://bugs.python.org/issue34166
<!-- /issue-number -->
