### PR TITLE
[3.7] bpo-34166: Fix warnings in Tools/msgfmt.py. (GH-8367)

### DIFF
--- a/Tools/i18n/msgfmt.py
+++ b/Tools/i18n/msgfmt.py
@@ -89,7 +89,7 @@ def generate():
                          7*4,               # start of key index
                          7*4+len(keys)*8,   # start of value index
                          0, 0)              # size and offset of hash table
-    output += array.array("i", offsets).tostring()
+    output += array.array("i", offsets).tobytes()
     output += ids
     output += strs
     return output
@@ -109,7 +109,8 @@ def make(filename, outfile):
         outfile = os.path.splitext(infile)[0] + '.mo'
 
     try:
-        lines = open(infile, 'rb').readlines()
+        with open(infile, 'rb') as f:
+            lines = f.readlines()
     except IOError as msg:
         print(msg, file=sys.stderr)
         sys.exit(1)
@@ -199,7 +200,8 @@ def make(filename, outfile):
     output = generate()
 
     try:
-        open(outfile,"wb").write(output)
+        with open(outfile,"wb") as f:
+            f.write(output)
     except IOError as msg:
         print(msg, file=sys.stderr)
 


### PR DESCRIPTION
(cherry picked from commit a692efe4733f98831cb51a9683877b152f754d14)

Co-authored-by: Xtreak <tirkarthi@users.noreply.github.com>

<!-- issue-number: bpo-34166 -->
https://bugs.python.org/issue34166
<!-- /issue-number -->
