### PR TITLE
[2.7] bpo-33336: Legalize MOVE command (GH-6569)

### DIFF
--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -70,6 +70,7 @@ Commands = {
         'LOGIN':        ('NONAUTH',),
         'LOGOUT':       ('NONAUTH', 'AUTH', 'SELECTED', 'LOGOUT'),
         'LSUB':         ('AUTH', 'SELECTED'),
+        'MOVE':         ('SELECTED',),
         'NAMESPACE':    ('AUTH', 'SELECTED'),
         'NOOP':         ('NONAUTH', 'AUTH', 'SELECTED', 'LOGOUT'),
         'PARTIAL':      ('SELECTED',),                                  # NB: obsolete

--- a/Misc/NEWS.d/next/Library/2018-04-27-22-18-38.bpo-33336.T8rxn0.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-27-22-18-38.bpo-33336.T8rxn0.rst
@@ -1,0 +1,2 @@
+``imaplib`` now allows ``MOVE`` command in ``IMAP4.uid()`` and potentially
+as a name of supported method of ``IMAP4`` object.

--- a/Misc/NEWS.d/next/Library/2018-04-27-22-18-38.bpo-33336.T8rxn0.rst
+++ b/Misc/NEWS.d/next/Library/2018-04-27-22-18-38.bpo-33336.T8rxn0.rst
@@ -1,2 +1,3 @@
-``imaplib`` now allows ``MOVE`` command in ``IMAP4.uid()`` and potentially
-as a name of supported method of ``IMAP4`` object.
+``imaplib`` now allows ``MOVE`` command in ``IMAP4.uid()`` (RFC 
+6851: IMAP MOVE Extension) and potentially as a name of supported 
+method of ``IMAP4`` object.


### PR DESCRIPTION
When running
```python
    box = IMAP4_SSL(host)
    box.login(user, passw)
    msgs = somehowget_uids_of_messsages_to_move()
    box.uid('MOVE', msgs, 'target')
```
I get an error "Unknown IMAP4 UID command: MOVE". The problem is that ``imaplib`` contains a list Commands of the permitted IMAP commands, and MOVE is not included, even though it is perfectly legal (and quite widely supported) command according to [RFC-6851](https://tools.ietf.org/html/rfc6851).

@vstinner , @warsaw 

<!-- issue-number: bpo-33336 -->
https://bugs.python.org/issue33336
<!-- /issue-number -->
