### PR TITLE
Doc: Clarify that the "simple" FIFO queue is :class:`SimpleQueue`.

### DIFF
--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -28,8 +28,8 @@ competing threads; however, they are not designed to handle reentrancy
 within a thread.
 
 In addition, the module implements a "simple"
-:abbr:`FIFO (first-in, first-out)` queue type where
-specific implementations can provide additional guarantees
+:abbr:`FIFO (first-in, first-out)` queue type, :class:`SimpleQueue`, whose
+specific implementation provides additional guarantees
 in exchange for the smaller functionality.
 
 The :mod:`queue` module defines the following classes and exceptions:


### PR DESCRIPTION
I'm trying to clarify a sentence in Doc/library/queue.rst, (following a discussion here https://github.com/python/python-docs-fr/pull/203#discussion_r200082086). But my current understanding of the sentence may also be the wrong one.
