### PR TITLE
bpo-34179:  Make sure decimal context doesn't affect other tests 

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -872,19 +872,19 @@ class CPyTimeTestCase:
         ns_timestamps = self._rounding_values(use_float)
         valid_values = convert_values(ns_timestamps)
         for time_rnd, decimal_rnd in ROUNDING_MODES :
-            context = decimal.getcontext()
-            context.rounding = decimal_rnd
+            with decimal.localcontext() as context:
+                context.rounding = decimal_rnd
 
-            for value in valid_values:
-                debug_info = {'value': value, 'rounding': decimal_rnd}
-                try:
-                    result = pytime_converter(value, time_rnd)
-                    expected = expected_func(value)
-                except Exception as exc:
-                    self.fail("Error on timestamp conversion: %s" % debug_info)
-                self.assertEqual(result,
-                                 expected,
-                                 debug_info)
+                for value in valid_values:
+                    debug_info = {'value': value, 'rounding': decimal_rnd}
+                    try:
+                        result = pytime_converter(value, time_rnd)
+                        expected = expected_func(value)
+                    except Exception as exc:
+                        self.fail("Error on timestamp conversion: %s" % debug_info)
+                    self.assertEqual(result,
+                                     expected,
+                                     debug_info)
 
         # test overflow
         ns = self.OVERFLOW_SECONDS * SEC_TO_NS

--- a/Misc/NEWS.d/next/Tests/2018-07-21-09-21-23.bpo-34179.Rq9ZOc.rst
+++ b/Misc/NEWS.d/next/Tests/2018-07-21-09-21-23.bpo-34179.Rq9ZOc.rst
@@ -1,0 +1,1 @@
+Use decimal.localcontext for test_time to avoid affecting other tests

--- a/Misc/NEWS.d/next/Tests/2018-07-21-09-21-23.bpo-34179.Rq9ZOc.rst
+++ b/Misc/NEWS.d/next/Tests/2018-07-21-09-21-23.bpo-34179.Rq9ZOc.rst
@@ -1,1 +1,0 @@
-Use decimal.localcontext for test_time to avoid affecting other tests


### PR DESCRIPTION
The use of `decimal.getcontext` in `test_time.py` affects other modules that use the `decimal` module.

The PR changes the tests to use `decimal.localcontext`, which doesn't have this problem.

After

```
$ ./python -m test test_time test_statistics
Run tests sequentially
0:00:00 load avg: 2.53 [1/2] test_time
0:00:02 load avg: 2.53 [2/2] test_statistics

== Tests result: SUCCESS ==

All 2 tests OK.

Total duration: 3 sec 80 ms
Tests result: SUCCESS
```

Before
```
$ ./python -m test test_time test_statistics
Run tests sequentially
0:00:00 load avg: 2.54 [1/2] test_time
0:00:02 load avg: 2.66 [2/2] test_statistics
test test_statistics failed -- multiple errors occurred; run in verbose mode for details
test_statistics failed

== Tests result: FAILURE ==

1 test OK.

1 test failed:
    test_statistics

Total duration: 3 sec 87 ms
Tests result: FAILURE

```

<!-- issue-number: bpo-34179 -->
https://bugs.python.org/issue34179
<!-- /issue-number -->
