### PR TITLE
bpo-34183: Fix running Lib/test/test_contextlib_async.py as a script.

### DIFF
--- a/Lib/test/test_contextlib_async.py
+++ b/Lib/test/test_contextlib_async.py
@@ -4,7 +4,7 @@ import functools
 from test import support
 import unittest
 
-from .test_contextlib import TestBaseExitStack
+from test.test_contextlib import TestBaseExitStack
 
 
 def _async_test(func):


### PR DESCRIPTION


<!-- issue-number: bpo-34183 -->
https://bugs.python.org/issue34183
<!-- /issue-number -->
