### PR TITLE
bpo-34182: Fix test_pydoc running as a script

### DIFF
--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -357,8 +357,9 @@ def get_pydoc_html(module):
 
 def get_pydoc_link(module):
     "Returns a documentation web link of a module"
+    abspath = os.path.abspath
     dirname = os.path.dirname
-    basedir = dirname(dirname(__file__))
+    basedir = abspath(dirname(dirname(__file__)))
     doc = pydoc.TextDoc()
     loc = doc.getdocloc(module, basedir=basedir)
     return loc

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -359,7 +359,7 @@ def get_pydoc_link(module):
     "Returns a documentation web link of a module"
     abspath = os.path.abspath
     dirname = os.path.dirname
-    basedir = (dirname(dirname(abspath(__file__))))
+    basedir = dirname(dirname(abspath(__file__)))
     doc = pydoc.TextDoc()
     loc = doc.getdocloc(module, basedir=basedir)
     return loc

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -359,7 +359,7 @@ def get_pydoc_link(module):
     "Returns a documentation web link of a module"
     abspath = os.path.abspath
     dirname = os.path.dirname
-    basedir = abspath(dirname(dirname(__file__)))
+    basedir = (dirname(dirname(abspath(__file__))))
     doc = pydoc.TextDoc()
     loc = doc.getdocloc(module, basedir=basedir)
     return loc


### PR DESCRIPTION
This PR fixes running `test_pydoc` as a module. The issue was that [this line](https://github.com/python/cpython/compare/master...bbayles:pydoc-test-34182?expand=1#diff-5977f78166dbb87048ca6e79714cc237L361) was returning `Lib` instead of `/path/to/Lib`.

```
$ ./python Lib/test/test_pydoc.py 
...
test_mixed_case_module_names_are_lower_cased (__main__.PydocDocTest) ... ok
...

----------------------------------------------------------------------
Ran 53 tests in 3.177s

OK (skipped=3)

```

<!-- issue-number: bpo-34182 -->
https://bugs.python.org/issue34182
<!-- /issue-number -->
