### PR TITLE
bpo-940286: Fix pydoc to show cross refs correctly

### DIFF
--- a/Lib/pydoc.py
+++ b/Lib/pydoc.py
@@ -2028,14 +2028,15 @@ module "pydoc_data.topics" could not be found.
         except KeyError:
             self.output.write('no documentation found for %s\n' % repr(topic))
             return
-        pager(doc.strip() + '\n')
+        doc = doc.strip() + '\n'
         if more_xrefs:
             xrefs = (xrefs or '') + ' ' + more_xrefs
         if xrefs:
             import textwrap
             text = 'Related help topics: ' + ', '.join(xrefs.split()) + '\n'
             wrapped_text = textwrap.wrap(text, 72)
-            self.output.write('\n%s\n' % ''.join(wrapped_text))
+            doc += '\n%s\n' % '\n'.join(wrapped_text)
+        pager(doc)
 
     def _gettopic(self, topic, more_xrefs=''):
         """Return unbuffered tuple of (topic, xrefs).

--- a/Misc/NEWS.d/next/Library/2018-07-22-07-59-32.bpo-940286.NZTzyc.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-22-07-59-32.bpo-940286.NZTzyc.rst
@@ -1,0 +1,2 @@
+pydoc's ``Helper.showtopic()`` method now prints the cross references of a
+topic correctly.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-940286 -->
https://bugs.python.org/issue940286
<!-- /issue-number -->
