### PR TITLE
bpo-34127: Fix grammar in error message with respect to argument count

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -143,6 +143,22 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         msg = r"^from_bytes\(\) takes at most 2 positional arguments \(3 given\)"
         self.assertRaisesRegex(TypeError, msg, int.from_bytes, b'a', 'little', False)
 
+    def test_varargs4(self):
+        msg = r"get expected at least 1 argument, got 0"
+        self.assertRaisesRegex(TypeError, msg, {}.get)
+
+    def test_varargs5(self):
+        msg = r"getattr expected at least 2 arguments, got 0"
+        self.assertRaisesRegex(TypeError, msg, getattr)
+
+    def test_varargs6(self):
+        msg = r"input expected at most 1 argument, got 2"
+        self.assertRaisesRegex(TypeError, msg, input, 1, 2)
+
+    def test_varargs7(self):
+        msg = r"get expected at most 2 arguments, got 3"
+        self.assertRaisesRegex(TypeError, msg, {}.get, 1, 2, 3)
+
     def test_varargs1_kw(self):
         msg = r"__contains__\(\) takes no keyword arguments"
         self.assertRaisesRegex(TypeError, msg, {}.__contains__, x=2)

--- a/Misc/NEWS.d/next/C API/2018-07-22-14-58-06.bpo-34127.qkfnHO.rst
+++ b/Misc/NEWS.d/next/C API/2018-07-22-14-58-06.bpo-34127.qkfnHO.rst
@@ -1,0 +1,2 @@
+Return grammatically correct error message based on argument count.
+Patch by Karthikeyan Singaravelan.

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -2411,8 +2411,8 @@ unpack_stack(PyObject *const *args, Py_ssize_t nargs, const char *name,
         if (name != NULL)
             PyErr_Format(
                 PyExc_TypeError,
-                "%.200s expected %s%zd arguments, got %zd",
-                name, (min == max ? "" : "at least "), min, nargs);
+                "%.200s expected %s%zd argument%s, got %zd",
+                name, (min == max ? "" : "at least "), min, min == 1 ? "" : "s", nargs);
         else
             PyErr_Format(
                 PyExc_TypeError,
@@ -2430,8 +2430,8 @@ unpack_stack(PyObject *const *args, Py_ssize_t nargs, const char *name,
         if (name != NULL)
             PyErr_Format(
                 PyExc_TypeError,
-                "%.200s expected %s%zd arguments, got %zd",
-                name, (min == max ? "" : "at most "), max, nargs);
+                "%.200s expected %s%zd argument%s, got %zd",
+                name, (min == max ? "" : "at most "), max, max == 1 ? "" : "s", nargs);
         else
             PyErr_Format(
                 PyExc_TypeError,


### PR DESCRIPTION
* Modified the error message to be argument or arguments based on argument count.
* Added tests in `test_call.py` based on the changes made.
* Added a NEWS entry since the change will be seen by users.

<!-- issue-number: bpo-34127 -->
https://bugs.python.org/issue34127
<!-- /issue-number -->
