### PR TITLE
[3.6] bpo-34189: Add simple tests for new Tk widget options. (GH-8396)

### DIFF
--- a/Lib/tkinter/test/support.py
+++ b/Lib/tkinter/test/support.py
@@ -1,3 +1,4 @@
+import functools
 import re
 import tkinter
 import unittest
@@ -54,8 +55,19 @@ import _tkinter
 tcl_version = tuple(map(int, _tkinter.TCL_VERSION.split('.')))
 
 def requires_tcl(*version):
-    return unittest.skipUnless(tcl_version >= version,
+    if len(version) <= 2:
+        return unittest.skipUnless(tcl_version >= version,
             'requires Tcl version >= ' + '.'.join(map(str, version)))
+
+    def deco(test):
+        @functools.wraps(test)
+        def newtest(self):
+            if get_tk_patchlevel() < (8, 6, 5):
+                self.skipTest('requires Tcl version >= ' +
+                                '.'.join(map(str, get_tk_patchlevel())))
+            test(self)
+        return newtest
+    return deco
 
 _tk_patchlevel = None
 def get_tk_patchlevel():

--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -717,9 +717,7 @@ class ListboxTest(AbstractWidgetTest, unittest.TestCase):
         self.checkEnumParam(widget, 'activestyle',
                             'dotbox', 'none', 'underline')
 
-    @requires_tcl(8, 6, 5)
-    def test_justify(self):
-        AbstractWidgetTest.test_justify(self)
+    test_justify = requires_tcl(8, 6, 5)(StandardOptionsTests.test_justify)
 
     def test_listvariable(self):
         widget = self.create()

--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -703,7 +703,7 @@ class ListboxTest(AbstractWidgetTest, unittest.TestCase):
         'disabledforeground', 'exportselection',
         'font', 'foreground', 'height',
         'highlightbackground', 'highlightcolor', 'highlightthickness',
-        'listvariable', 'relief',
+        'justify', 'listvariable', 'relief',
         'selectbackground', 'selectborderwidth', 'selectforeground',
         'selectmode', 'setgrid', 'state',
         'takefocus', 'width', 'xscrollcommand', 'yscrollcommand',
@@ -716,6 +716,10 @@ class ListboxTest(AbstractWidgetTest, unittest.TestCase):
         widget = self.create()
         self.checkEnumParam(widget, 'activestyle',
                             'dotbox', 'none', 'underline')
+
+    @requires_tcl(8, 6, 5)
+    def test_justify(self):
+        AbstractWidgetTest.test_justify(self)
 
     def test_listvariable(self):
         widget = self.create()
@@ -951,7 +955,9 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
     OPTIONS = (
         'background', 'borderwidth', 'cursor',
         'handlepad', 'handlesize', 'height',
-        'opaqueresize', 'orient', 'relief',
+        'opaqueresize', 'orient',
+        'proxybackground', 'proxyborderwidth', 'proxyrelief',
+        'relief',
         'sashcursor', 'sashpad', 'sashrelief', 'sashwidth',
         'showhandle', 'width',
     )
@@ -977,6 +983,23 @@ class PanedWindowTest(AbstractWidgetTest, unittest.TestCase):
     def test_opaqueresize(self):
         widget = self.create()
         self.checkBooleanParam(widget, 'opaqueresize')
+
+    @requires_tcl(8, 6, 5)
+    def test_proxybackground(self):
+        widget = self.create()
+        self.checkColorParam(widget, 'proxybackground')
+
+    @requires_tcl(8, 6, 5)
+    def test_proxyborderwidth(self):
+        widget = self.create()
+        self.checkPixelsParam(widget, 'proxyborderwidth',
+                              0, 1.3, 2.9, 6, -2, '10p',
+                              conv=noconv)
+
+    @requires_tcl(8, 6, 5)
+    def test_proxyrelief(self):
+        widget = self.create()
+        self.checkReliefParam(widget, 'proxyrelief')
 
     def test_sashcursor(self):
         widget = self.create()


### PR DESCRIPTION
(cherry picked from commit e271ca78e37a502b3dc1036f824aa3999efcd56b)
(cherry picked from commit c75c1e0e8aeb720ac3fcfab119b70cabba4e8235)


<!-- issue-number: bpo-34189 -->
https://bugs.python.org/issue34189
<!-- /issue-number -->
