### PR TITLE
[2.7] bpo-34189: Add simple tests for new Tk widget options. (GH-8396)

### DIFF
--- a/Lib/lib-tk/test/test_ttk/support.py
+++ b/Lib/lib-tk/test/test_ttk/support.py
@@ -1,3 +1,4 @@
+import functools
 import re
 import unittest
 import Tkinter as tkinter
@@ -54,8 +55,19 @@ import _tkinter
 tcl_version = tuple(map(int, _tkinter.TCL_VERSION.split('.')))
 
 def requires_tcl(*version):
-    return unittest.skipUnless(tcl_version >= version,
+    if len(version) <= 2:
+        return unittest.skipUnless(tcl_version >= version,
             'requires Tcl version >= ' + '.'.join(map(str, version)))
+
+    def deco(test):
+        @functools.wraps(test)
+        def newtest(self):
+            if get_tk_patchlevel() < (8, 6, 5):
+                self.skipTest('requires Tcl version >= ' +
+                                '.'.join(map(str, get_tk_patchlevel())))
+            test(self)
+        return newtest
+    return deco
 
 _tk_patchlevel = None
 def get_tk_patchlevel():


### PR DESCRIPTION
(cherry picked from commit e271ca78e37a502b3dc1036f824aa3999efcd56b)
(cherry picked from commit c75c1e0e8aeb720ac3fcfab119b70cabba4e8235)


<!-- issue-number: bpo-34189 -->
https://bugs.python.org/issue34189
<!-- /issue-number -->
