### PR TITLE
bpo-25094: Fix test_tools.test_sundry() on Windows

### DIFF
--- a/Lib/test/test_tools/test_sundry.py
+++ b/Lib/test/test_tools/test_sundry.py
@@ -25,15 +25,25 @@ class TestSundryScripts(unittest.TestCase):
     # scripts that use windows-only modules
     windows_only = ['win_add2path']
     # blacklisted for other reasons
-    other = ['analyze_dxp']
+    other = ['analyze_dxp', '2to3']
 
     skiplist = blacklist + whitelist + windows_only + other
 
     def test_sundry(self):
-        for fn in os.listdir(scriptsdir):
-            name = fn[:-3]
-            if fn.endswith('.py') and name not in self.skiplist:
+        old_modules = support.modules_setup()
+        try:
+            for fn in os.listdir(scriptsdir):
+                if not fn.endswith('.py'):
+                    continue
+
+                name = fn[:-3]
+                if name in self.skiplist:
+                    continue
+
                 import_tool(name)
+        finally:
+            # Unload all modules loaded in this test
+            support.modules_cleanup(*old_modules)
 
     @unittest.skipIf(sys.platform != "win32", "Windows-only test")
     def test_sundry_windows(self):


### PR DESCRIPTION
When Python is installed on Windows, python -m test test_tools
failed. Fix test_sundry() test by fixing sys.argv before loading
scripts. Run 2to3 with one argument: test_tools/test_sundry.py.

Modify also the unit test to unload all modules which have been
loaded by the test. Moreover, use CleanImport() context manager to
make sure that 'name' module is not already loaded.

<!-- issue-number: bpo-25094 -->
https://bugs.python.org/issue25094
<!-- /issue-number -->
