### PR TITLE
bpo-34201: Make ndarray.readonly a bool and use stricter tests in test_buffer.

### DIFF
--- a/Lib/test/test_buffer.py
+++ b/Lib/test/test_buffer.py
@@ -761,10 +761,10 @@ class TestBufferProtocol(unittest.TestCase):
         # The suboffsets tests need sizeof(void *).
         self.sizeof_void_p = get_sizeof_void_p()
 
-    def verify(self, result, obj=-1,
-                     itemsize={1}, fmt=-1, readonly={1},
-                     ndim={1}, shape=-1, strides=-1,
-                     lst=-1, sliced=False, cast=False):
+    def verify(self, result, *, obj,
+                     itemsize, fmt, readonly,
+                     ndim, shape, strides,
+                     lst, sliced=False, cast=False):
         # Verify buffer contents against expected values. Default values
         # are deliberately initialized to invalid types.
         if shape:
@@ -800,7 +800,7 @@ class TestBufferProtocol(unittest.TestCase):
         self.assertEqual(result.nbytes, expected_len)
         self.assertEqual(result.itemsize, itemsize)
         self.assertEqual(result.format, fmt)
-        self.assertEqual(result.readonly, readonly)
+        self.assertIs(result.readonly, readonly)
         self.assertEqual(result.ndim, ndim)
         self.assertEqual(result.shape, tuple(shape))
         if not (sliced and suboffsets):
@@ -978,7 +978,7 @@ class TestBufferProtocol(unittest.TestCase):
             lst = nd.tolist()
 
         # The consumer may have requested default values or a NULL format.
-        ro = 0 if match(req, PyBUF_WRITABLE) else ex.readonly
+        ro = not match(req, PyBUF_WRITABLE) and ex.readonly
         fmt = ex.format
         itemsize = ex.itemsize
         ndim = ex.ndim
@@ -1284,7 +1284,7 @@ class TestBufferProtocol(unittest.TestCase):
             itemsize = struct.calcsize(fmt)
             nd = ndarray(scalar, shape=(), format=fmt)
             self.verify(nd, obj=None,
-                        itemsize=itemsize, fmt=fmt, readonly=1,
+                        itemsize=itemsize, fmt=fmt, readonly=True,
                         ndim=0, shape=(), strides=(),
                         lst=scalar)
 
@@ -1296,7 +1296,7 @@ class TestBufferProtocol(unittest.TestCase):
             for flags in (0, ND_PIL):
                 nd = ndarray(items, shape=[nitems], format=fmt, flags=flags)
                 self.verify(nd, obj=None,
-                            itemsize=itemsize, fmt=fmt, readonly=1,
+                            itemsize=itemsize, fmt=fmt, readonly=True,
                             ndim=1, shape=(nitems,), strides=(itemsize,),
                             lst=items)
 
@@ -1317,7 +1317,7 @@ class TestBufferProtocol(unittest.TestCase):
                     nd = ndarray(items, shape=shape, strides=strides,
                                  format=fmt, offset=offset, flags=flags)
                     self.verify(nd, obj=None,
-                                itemsize=itemsize, fmt=fmt, readonly=1,
+                                itemsize=itemsize, fmt=fmt, readonly=True,
                                 ndim=1, shape=shape, strides=strides,
                                 lst=items[::step])
 
@@ -1346,7 +1346,7 @@ class TestBufferProtocol(unittest.TestCase):
                     strides = strides_from_shape(ndim, shape, itemsize, 'C')
                     lst = carray(items, shape)
                     self.verify(nd, obj=None,
-                                itemsize=itemsize, fmt=fmt, readonly=1,
+                                itemsize=itemsize, fmt=fmt, readonly=True,
                                 ndim=ndim, shape=shape, strides=strides,
                                 lst=lst)
 
@@ -1357,7 +1357,7 @@ class TestBufferProtocol(unittest.TestCase):
                         self.assertTrue(nd.strides == ())
                         mv = nd.memoryview_from_buffer()
                         self.verify(mv, obj=None,
-                                    itemsize=itemsize, fmt=fmt, readonly=1,
+                                    itemsize=itemsize, fmt=fmt, readonly=True,
                                     ndim=ndim, shape=shape, strides=strides,
                                     lst=lst)
 
@@ -1368,7 +1368,7 @@ class TestBufferProtocol(unittest.TestCase):
                     strides = strides_from_shape(ndim, shape, itemsize, 'F')
                     lst = farray(items, shape)
                     self.verify(nd, obj=None,
-                                itemsize=itemsize, fmt=fmt, readonly=1,
+                                itemsize=itemsize, fmt=fmt, readonly=True,
                                 ndim=ndim, shape=shape, strides=strides,
                                 lst=lst)
 
@@ -1816,7 +1816,7 @@ class TestBufferProtocol(unittest.TestCase):
                             self.assertEqual(mv, nd)
                             self.assertIs(mverr, lsterr)
                             self.verify(mv, obj=ex,
-                              itemsize=nd.itemsize, fmt=fmt, readonly=0,
+                              itemsize=nd.itemsize, fmt=fmt, readonly=False,
                               ndim=nd.ndim, shape=nd.shape, strides=nd.strides,
                               lst=nd.tolist())
 
@@ -1890,7 +1890,7 @@ class TestBufferProtocol(unittest.TestCase):
                         continue # http://projects.scipy.org/numpy/ticket/1910
                     z = numpy_array_from_structure(items, fmt, t)
                     self.verify(x, obj=None,
-                                itemsize=z.itemsize, fmt=fmt, readonly=0,
+                                itemsize=z.itemsize, fmt=fmt, readonly=False,
                                 ndim=z.ndim, shape=z.shape, strides=z.strides,
                                 lst=z.tolist())
 
@@ -1975,12 +1975,12 @@ class TestBufferProtocol(unittest.TestCase):
                         # Slice assignment of overlapping structures
                         # is undefined in NumPy.
                         self.verify(xl, obj=None,
-                                    itemsize=zl.itemsize, fmt=fmt, readonly=0,
+                                    itemsize=zl.itemsize, fmt=fmt, readonly=False,
                                     ndim=zl.ndim, shape=zl.shape,
                                     strides=zl.strides, lst=zl.tolist())
 
                     self.verify(xr, obj=None,
-                                itemsize=zr.itemsize, fmt=fmt, readonly=0,
+                                itemsize=zr.itemsize, fmt=fmt, readonly=False,
                                 ndim=zr.ndim, shape=zr.shape,
                                 strides=zr.strides, lst=zr.tolist())
 
@@ -2358,14 +2358,14 @@ class TestBufferProtocol(unittest.TestCase):
             lst = carray(items, shape)
 
             self.verify(m, obj=ex,
-                        itemsize=1, fmt='B', readonly=1,
+                        itemsize=1, fmt='B', readonly=True,
                         ndim=ndim, shape=shape, strides=strides,
                         lst=lst)
 
             # From memoryview:
             m2 = memoryview(m)
             self.verify(m2, obj=ex,
-                        itemsize=1, fmt='B', readonly=1,
+                        itemsize=1, fmt='B', readonly=True,
                         ndim=ndim, shape=shape, strides=strides,
                         lst=lst)
 
@@ -2374,7 +2374,7 @@ class TestBufferProtocol(unittest.TestCase):
             self.assertEqual(nd.strides, ())
             m = nd.memoryview_from_buffer()
             self.verify(m, obj=None,
-                        itemsize=1, fmt='B', readonly=1,
+                        itemsize=1, fmt='B', readonly=True,
                         ndim=ndim, shape=shape, strides=strides,
                         lst=lst)
 
@@ -2387,7 +2387,7 @@ class TestBufferProtocol(unittest.TestCase):
 
             lst = [items] if ndim == 0 else items
             self.verify(m, obj=None,
-                        itemsize=1, fmt='B', readonly=1,
+                        itemsize=1, fmt='B', readonly=True,
                         ndim=1, shape=[ex.nbytes], strides=(1,),
                         lst=lst)
 
@@ -2405,14 +2405,14 @@ class TestBufferProtocol(unittest.TestCase):
             lst = farray(items, shape)
 
             self.verify(m, obj=ex,
-                        itemsize=1, fmt='B', readonly=1,
+                        itemsize=1, fmt='B', readonly=True,
                         ndim=ndim, shape=shape, strides=strides,
                         lst=lst)
 
             # From memoryview:
             m2 = memoryview(m)
             self.verify(m2, obj=ex,
-                        itemsize=1, fmt='B', readonly=1,
+                        itemsize=1, fmt='B', readonly=True,
                         ndim=ndim, shape=shape, strides=strides,
                         lst=lst)
 
@@ -2427,14 +2427,14 @@ class TestBufferProtocol(unittest.TestCase):
             lst = carray(items, shape)
 
             self.verify(m, obj=ex,
-                        itemsize=1, fmt='B', readonly=1,
+                        itemsize=1, fmt='B', readonly=True,
                         ndim=ndim, shape=shape, strides=ex.strides,
                         lst=lst)
 
             # From memoryview:
             m2 = memoryview(m)
             self.verify(m2, obj=ex,
-                        itemsize=1, fmt='B', readonly=1,
+                        itemsize=1, fmt='B', readonly=True,
                         ndim=ndim, shape=shape, strides=ex.strides,
                         lst=lst)
 
@@ -2684,7 +2684,7 @@ class TestBufferProtocol(unittest.TestCase):
                 m2 = m.cast(bytefmt)
                 lst = to_bytelist(ex)
                 self.verify(m2, obj=ex,
-                            itemsize=1, fmt=bytefmt, readonly=0,
+                            itemsize=1, fmt=bytefmt, readonly=False,
                             ndim=1, shape=[31*srcsize], strides=(1,),
                             lst=lst, cast=True)
 
@@ -2692,7 +2692,7 @@ class TestBufferProtocol(unittest.TestCase):
                 self.assertEqual(m3, ex)
                 lst = ex.tolist()
                 self.verify(m3, obj=ex,
-                            itemsize=srcsize, fmt=fmt, readonly=0,
+                            itemsize=srcsize, fmt=fmt, readonly=False,
                             ndim=1, shape=[31], strides=(srcsize,),
                             lst=lst, cast=True)
 
@@ -2703,7 +2703,7 @@ class TestBufferProtocol(unittest.TestCase):
         m = memoryview(ex)
         m2 = m.cast('B')
         self.verify(m2, obj=ex,
-                    itemsize=1, fmt='B', readonly=1,
+                    itemsize=1, fmt='B', readonly=True,
                     ndim=1, shape=destshape, strides=(1,),
                     lst=destitems, cast=True)
 
@@ -2714,7 +2714,7 @@ class TestBufferProtocol(unittest.TestCase):
         m = memoryview(ex)
         m2 = m.cast('I', shape=[])
         self.verify(m2, obj=ex,
-                    itemsize=destsize, fmt='I', readonly=1,
+                    itemsize=destsize, fmt='I', readonly=True,
                     ndim=0, shape=(), strides=(),
                     lst=destitems, cast=True)
 
@@ -2763,7 +2763,7 @@ class TestBufferProtocol(unittest.TestCase):
                     strides = nd.strides
                     lst = nd.tolist()
                     self.verify(m2, obj=ex,
-                                itemsize=tsize, fmt=tfmt, readonly=1,
+                                itemsize=tsize, fmt=tfmt, readonly=True,
                                 ndim=ndim, shape=tshape, strides=strides,
                                 lst=lst, cast=True)
 
@@ -2775,12 +2775,12 @@ class TestBufferProtocol(unittest.TestCase):
                     lst = ex.tolist()
 
                     self.verify(m3, obj=ex,
-                                itemsize=size, fmt=fmt, readonly=1,
+                                itemsize=size, fmt=fmt, readonly=True,
                                 ndim=ndim, shape=shape, strides=strides,
                                 lst=lst, cast=True)
 
                     self.verify(m4, obj=ex,
-                                itemsize=size, fmt=fmt, readonly=1,
+                                itemsize=size, fmt=fmt, readonly=True,
                                 ndim=ndim, shape=shape, strides=strides,
                                 lst=lst, cast=True)
 
@@ -2793,7 +2793,7 @@ class TestBufferProtocol(unittest.TestCase):
             m2 = m1.cast('B')
             self.assertEqual(m2.obj, point)
             self.assertEqual(m2.itemsize, 1)
-            self.assertEqual(m2.readonly, 0)
+            self.assertIs(m2.readonly, False)
             self.assertEqual(m2.ndim, 1)
             self.assertEqual(m2.shape, (m2.nbytes,))
             self.assertEqual(m2.strides, (1,))
@@ -2804,7 +2804,7 @@ class TestBufferProtocol(unittest.TestCase):
             m2 = m1.cast('c')
             self.assertEqual(m2.obj, x)
             self.assertEqual(m2.itemsize, 1)
-            self.assertEqual(m2.readonly, 0)
+            self.assertIs(m2.readonly, False)
             self.assertEqual(m2.ndim, 1)
             self.assertEqual(m2.shape, (m2.nbytes,))
             self.assertEqual(m2.strides, (1,))
@@ -2972,7 +2972,7 @@ class TestBufferProtocol(unittest.TestCase):
                      flags=ND_WRITABLE)
         m = memoryview(ex)
         m[1] = True
-        self.assertEqual(m[1], True)
+        self.assertIs(m[1], True)
 
         # pack_single() exceptions:
         nd = ndarray([b'x'], shape=[1], format='c', flags=ND_WRITABLE)
@@ -4306,7 +4306,7 @@ class TestBufferProtocol(unittest.TestCase):
         x = staticarray()
         y = memoryview(x)
         self.verify(y, obj=x,
-                    itemsize=1, fmt=fmt, readonly=1,
+                    itemsize=1, fmt=fmt, readonly=True,
                     ndim=1, shape=[12], strides=[1],
                     lst=lst)
         for i in range(12):
@@ -4326,7 +4326,7 @@ class TestBufferProtocol(unittest.TestCase):
         self.assertIs(y.obj, x)
         self.assertIs(m.obj, z)
         self.verify(m, obj=z,
-                    itemsize=1, fmt=fmt, readonly=1,
+                    itemsize=1, fmt=fmt, readonly=True,
                     ndim=1, shape=[12], strides=[1],
                     lst=lst)
         del x, y, z, m
@@ -4339,7 +4339,7 @@ class TestBufferProtocol(unittest.TestCase):
         self.assertIs(z.obj, x)
         self.assertIs(m.obj, x)
         self.verify(m, obj=x,
-                    itemsize=1, fmt=fmt, readonly=1,
+                    itemsize=1, fmt=fmt, readonly=True,
                     ndim=1, shape=[12], strides=[1],
                     lst=lst)
         del x, y, z, m
@@ -4348,7 +4348,7 @@ class TestBufferProtocol(unittest.TestCase):
         x = staticarray(legacy_mode=True)
         y = memoryview(x)
         self.verify(y, obj=None,
-                    itemsize=1, fmt=fmt, readonly=1,
+                    itemsize=1, fmt=fmt, readonly=True,
                     ndim=1, shape=[12], strides=[1],
                     lst=lst)
         for i in range(12):
@@ -4368,7 +4368,7 @@ class TestBufferProtocol(unittest.TestCase):
         self.assertIs(y.obj, None)
         self.assertIs(m.obj, z)
         self.verify(m, obj=z,
-                    itemsize=1, fmt=fmt, readonly=1,
+                    itemsize=1, fmt=fmt, readonly=True,
                     ndim=1, shape=[12], strides=[1],
                     lst=lst)
         del x, y, z, m
@@ -4383,7 +4383,7 @@ class TestBufferProtocol(unittest.TestCase):
         self.assertIs(z.obj, y)
         self.assertIs(m.obj, y)
         self.verify(m, obj=y,
-                    itemsize=1, fmt=fmt, readonly=1,
+                    itemsize=1, fmt=fmt, readonly=True,
                     ndim=1, shape=[12], strides=[1],
                     lst=lst)
         del x, y, z, m

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -2038,7 +2038,7 @@ static PyObject *
 ndarray_get_readonly(NDArrayObject *self, void *closure)
 {
     Py_buffer *base = &self->head->base;
-    return PyLong_FromLong(base->readonly);
+    return PyBool_FromLong(base->readonly);
 }
 
 static PyObject *


### PR DESCRIPTION


<!-- issue-number: bpo-34201 -->
https://bugs.python.org/issue34201
<!-- /issue-number -->
