### PR TITLE
[2.7] bpo-27195: Fix crashes in io.BufferedReader() and io.BufferedWriter()

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -1067,6 +1067,16 @@ class BufferedReaderTest(unittest.TestCase, CommonBufferedTests):
             self.assertEqual(rawio._extraneous_reads, 0,
                              "failed for {}: {} != 0".format(n, rawio._extraneous_reads))
 
+    def test_read_format_crash(self):
+        class R(self.MockRawIO):
+            def readable(self):
+                return True
+            def readinto(self, b):
+                b.format
+        b = self.tp(R())
+        # This would crash.
+        b.read(1)
+
 
 class CBufferedReaderTest(BufferedReaderTest, SizeofTest):
     tp = io.BufferedReader
@@ -1381,6 +1391,16 @@ class BufferedWriterTest(unittest.TestCase, CommonBufferedTests):
         b.write(b'spam')
         self.assertRaises(IOError, b.close) # exception not swallowed
         self.assertTrue(b.closed)
+
+    def test_write_format_crash(self):
+        class R(self.MockRawIO):
+            def writeable(self):
+                return True
+            def write(self, b):
+                b.format
+        b = self.tp(R())
+        # This would crash.
+        b.write(b'x')
 
 
 class CBufferedWriterTest(BufferedWriterTest, SizeofTest):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-23-08-18-07.bpo-27195.V-bmFq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-23-08-18-07.bpo-27195.V-bmFq.rst
@@ -1,2 +1,3 @@
-Fix crashes in :class:`io.BufferedReader` and :class:`io.BufferedWriter`.
+Fix crashes in :class:`io.BufferedReader` and :class:`io.BufferedWriter`
+(internal :term:`bytes-like object`s were not being properly initialized).
 Patch by Zackery Spytz.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-23-08-18-07.bpo-27195.V-bmFq.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-23-08-18-07.bpo-27195.V-bmFq.rst
@@ -1,0 +1,2 @@
+Fix crashes in :class:`io.BufferedReader` and :class:`io.BufferedWriter`.
+Patch by Zackery Spytz.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1286,8 +1286,10 @@ _bufferedreader_raw_read(buffered *self, char *start, Py_ssize_t len)
     PyObject *memobj, *res;
     Py_ssize_t n;
     /* NOTE: the buffer needn't be released as its object is NULL. */
-    if (PyBuffer_FillInfo(&buf, NULL, start, len, 0, PyBUF_RECORDS) == -1)
+    if (PyBuffer_FillInfo(&buf, NULL, start, len, 0,
+                          PyBUF_CONTIG | PyBUF_FORMAT) == -1) {
         return -1;
+    }
     memobj = PyMemoryView_FromBuffer(&buf);
     if (memobj == NULL)
         return -1;
@@ -1710,8 +1712,10 @@ _bufferedwriter_raw_write(buffered *self, char *start, Py_ssize_t len)
     Py_ssize_t n;
     int errnum;
     /* NOTE: the buffer needn't be released as its object is NULL. */
-    if (PyBuffer_FillInfo(&buf, NULL, start, len, 1, PyBUF_RECORDS_RO) == -1)
+    if (PyBuffer_FillInfo(&buf, NULL, start, len, 1,
+                          PyBUF_CONTIG_RO | PyBUF_FORMAT) == -1) {
         return -1;
+    }
     memobj = PyMemoryView_FromBuffer(&buf);
     if (memobj == NULL)
         return -1;

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -1286,7 +1286,7 @@ _bufferedreader_raw_read(buffered *self, char *start, Py_ssize_t len)
     PyObject *memobj, *res;
     Py_ssize_t n;
     /* NOTE: the buffer needn't be released as its object is NULL. */
-    if (PyBuffer_FillInfo(&buf, NULL, start, len, 0, PyBUF_CONTIG) == -1)
+    if (PyBuffer_FillInfo(&buf, NULL, start, len, 0, PyBUF_RECORDS) == -1)
         return -1;
     memobj = PyMemoryView_FromBuffer(&buf);
     if (memobj == NULL)
@@ -1710,7 +1710,7 @@ _bufferedwriter_raw_write(buffered *self, char *start, Py_ssize_t len)
     Py_ssize_t n;
     int errnum;
     /* NOTE: the buffer needn't be released as its object is NULL. */
-    if (PyBuffer_FillInfo(&buf, NULL, start, len, 1, PyBUF_CONTIG_RO) == -1)
+    if (PyBuffer_FillInfo(&buf, NULL, start, len, 1, PyBUF_RECORDS_RO) == -1)
         return -1;
     memobj = PyMemoryView_FromBuffer(&buf);
     if (memobj == NULL)


### PR DESCRIPTION
In _bufferedreader_raw_read() and _bufferedwriter_raw_write(),
PyBUF_FORMAT should be included in the flags passed to
PyBuffer_FillInfo() (unlike in Python 3, PyMemoryView_FromBuffer()
will not set the format of the memoryview's buffer if the passed
buffer's format is NULL).

<!-- issue-number: bpo-27195 -->
https://bugs.python.org/issue27195
<!-- /issue-number -->
