### PR TITLE
bpo-34125: Enable profiling of method_descriptor in all cases

### DIFF
--- a/Lib/test/test_sys_setprofile.py
+++ b/Lib/test/test_sys_setprofile.py
@@ -350,6 +350,24 @@ class ProfileSimulatorTestCase(TestCaseBase):
         self.check_events(f, [(1, 'call', f_ident),
                               (1, 'return', f_ident)])
 
+    # Test an invalid call (bpo-34125)
+    def test_unbound_method_no_args(self):
+        kwargs = {}
+        def f(p):
+            dict.get(**kwargs)
+        f_ident = ident(f)
+        self.check_events(f, [(1, 'call', f_ident),
+                              (1, 'return', f_ident)])
+
+    # Test an invalid call (bpo-34125)
+    def test_unbound_method_invalid_args(self):
+        kwargs = {}
+        def f(p):
+            dict.get(print, 42, **kwargs)
+        f_ident = ident(f)
+        self.check_events(f, [(1, 'call', f_ident),
+                              (1, 'return', f_ident)])
+
 
 def ident(function):
     if hasattr(function, "f_code"):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-23-16-34-03.bpo-34125.jCl2Q2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-23-16-34-03.bpo-34125.jCl2Q2.rst
@@ -1,0 +1,1 @@
+Profiling of unbound built-in methods now works when ``**kwargs`` is given.


### PR DESCRIPTION
`list.append([], None)` was profiled but `list.append([], None, **{})` was not profiled.
Enable profiling for later case.
<!-- issue-number: [bpo-34125](https://www.bugs.python.org/issue34125) -->
https://bugs.python.org/issue34125
<!-- /issue-number -->
