### PR TITLE
bpo-34170: Add _PyCoreConfig.isolated

### DIFF
--- a/Include/internal/pystate.h
+++ b/Include/internal/pystate.h
@@ -52,17 +52,17 @@ typedef struct _PyPathConfig {
     wchar_t *program_name;
     /* Set by Py_SetPythonHome() or PYTHONHOME environment variable */
     wchar_t *home;
-    /* isolated and no_site_import are used to set Py_IsolatedFlag and
+    /* isolated and site_import are used to set Py_IsolatedFlag and
        Py_NoSiteFlag flags on Windows in read_pth_file(). These fields
        are ignored when their value are equal to -1 (unset). */
     int isolated;
-    int no_site_import;
+    int site_import;
 } _PyPathConfig;
 
 #define _PyPathConfig_INIT \
     {.module_search_path = NULL, \
      .isolated = -1, \
-     .no_site_import = -1}
+     .site_import = -1}
 /* Note: _PyPathConfig_INIT sets other fields to 0/NULL */
 
 PyAPI_DATA(_PyPathConfig) _Py_path_config;

--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -54,20 +54,16 @@ PyAPI_FUNC(int) Py_SetStandardStreamEncoding(const char *encoding,
 PyAPI_FUNC(_PyInitError) _Py_InitializeCore(const _PyCoreConfig *);
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
 
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(
-    _PyCoreConfig *config,
-    int *isolated,
-    int *no_site_import);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config);
 PyAPI_FUNC(void) _PyCoreConfig_Clear(_PyCoreConfig *);
 PyAPI_FUNC(int) _PyCoreConfig_Copy(
     _PyCoreConfig *config,
     const _PyCoreConfig *config2);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPathConfig(
-    _PyCoreConfig *config,
-    int *isolated,
-    int *no_site_import);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPathConfig(_PyCoreConfig *config);
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetPathConfig(
     const _PyCoreConfig *config);
+PyAPI_FUNC(void) _PyCoreConfig_SetGlobalConfig(const _PyCoreConfig *config);
+
 
 PyAPI_FUNC(_PyInitError) _PyMainInterpreterConfig_Read(
     _PyMainInterpreterConfig *config,

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -28,7 +28,7 @@ typedef PyObject* (*_PyFrameEvalFunction)(struct _frame *, int);
 typedef struct {
     int install_signal_handlers;  /* Install signal handlers? -1 means unset */
 
-    int ignore_environment; /* -E, Py_IgnoreEnvironmentFlag */
+    int ignore_environment; /* -E, Py_IgnoreEnvironmentFlag, -1 means unset */
     int use_hash_seed;      /* PYTHONHASHSEED=x */
     unsigned long hash_seed;
     const char *allocator;  /* Memory allocator: _PyMem_SetupAllocators() */
@@ -75,6 +75,24 @@ typedef struct {
     wchar_t *dll_path;      /* Windows DLL path */
 #endif
 
+    /* If greater than 0, enable isolated mode sys.path contains
+       neither the script's directory nor the user's site-packages directory.
+       Ignored if set to -1.
+
+       Related to Py_IsolatedFlag global configuration variable and -I command
+       line option. */
+    int isolated;
+
+    /* If equal to zero, disable the import of the module site and the
+       site-dependent manipulations of sys.path that it entails. Also disable
+       these manipulations if site is explicitly imported later (call
+       site.main() if you want them to be triggered).
+       Ignored if set to -1.
+
+       Related to Py_NoSiteFlag global configuration variable and -S command
+       line option. */
+    int site_import;
+
     /* Private fields */
     int _disable_importlib; /* Needed by freeze_importlib */
 } _PyCoreConfig;
@@ -82,11 +100,14 @@ typedef struct {
 #define _PyCoreConfig_INIT \
     (_PyCoreConfig){ \
         .install_signal_handlers = -1, \
+        .ignore_environment = -1, \
         .use_hash_seed = -1, \
         .coerce_c_locale = -1, \
         .utf8_mode = -1, \
         .argc = -1, \
-        .nmodule_search_path = -1}
+        .nmodule_search_path = -1, \
+        .isolated = -1, \
+        .site_import = -1}
 /* Note: _PyCoreConfig_INIT sets other fields to 0/NULL */
 
 /* Placeholders while working on the new configuration API

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -75,26 +75,28 @@ typedef struct {
     wchar_t *dll_path;      /* Windows DLL path */
 #endif
 
-    /* If greater than 0, enable isolated mode sys.path contains
+    /* If greater than 0, enable isolated mode: sys.path contains
        neither the script's directory nor the user's site-packages directory.
-       Ignored if set to -1.
 
-       Related to Py_IsolatedFlag global configuration variable and -I command
-       line option. */
+       Set to 1 by the -I command line option. If set to -1 (default), inherit
+       Py_IsolatedFlag value. */
     int isolated;
 
     /* If equal to zero, disable the import of the module site and the
        site-dependent manipulations of sys.path that it entails. Also disable
        these manipulations if site is explicitly imported later (call
        site.main() if you want them to be triggered).
-       Ignored if set to -1.
 
-       Related to Py_NoSiteFlag global configuration variable and -S command
-       line option. */
+       Set to 0 by the -S command line option. If set to -1 (default), set to
+       the negative value of Py_NoSiteFlag. */
     int site_import;
 
-    /* Private fields */
-    int _disable_importlib; /* Needed by freeze_importlib */
+    /* --- Private fields -------- */
+
+    /* Install importlib? If set to 0, importlib is not initialized at all.
+       Needed by freeze_importlib: see install_importlib argument of
+       _Py_InitializeEx_Private(). */
+    int _install_importlib;
 } _PyCoreConfig;
 
 #define _PyCoreConfig_INIT \
@@ -107,7 +109,8 @@ typedef struct {
         .argc = -1, \
         .nmodule_search_path = -1, \
         .isolated = -1, \
-        .site_import = -1}
+        .site_import = -1, \
+        ._install_importlib = 1}
 /* Note: _PyCoreConfig_INIT sets other fields to 0/NULL */
 
 /* Placeholders while working on the new configuration API

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -625,6 +625,10 @@ _PyCoreConfig_SetGlobalConfig(const _PyCoreConfig *config)
     if (config->site_import != -1) {
         Py_NoSiteFlag = !config->site_import;
     }
+
+    /* Random or non-zero hash seed */
+    Py_HashRandomizationFlag = (config->use_hash_seed == 0 ||
+                                config->hash_seed != 0);
 }
 
 
@@ -649,10 +653,6 @@ pymain_set_global_config(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
     Py_LegacyWindowsFSEncodingFlag = cmdline->legacy_windows_fs_encoding;
     Py_LegacyWindowsStdioFlag = cmdline->legacy_windows_stdio;
 #endif
-
-    /* Random or non-zero hash seed */
-    Py_HashRandomizationFlag = (pymain->config.use_hash_seed == 0 ||
-                                pymain->config.hash_seed != 0);
 }
 
 
@@ -728,7 +728,7 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
     COPY_ATTR(ignore_environment);
     COPY_ATTR(use_hash_seed);
     COPY_ATTR(hash_seed);
-    COPY_ATTR(_disable_importlib);
+    COPY_ATTR(_install_importlib);
     COPY_ATTR(allocator);
     COPY_ATTR(dev_mode);
     COPY_ATTR(faulthandler);
@@ -2309,7 +2309,7 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         config->install_signal_handlers = 1;
     }
 
-    if (!config->_disable_importlib) {
+    if (config->_install_importlib) {
         err = _PyCoreConfig_InitPathConfig(config);
         if (_Py_INIT_FAILED(err)) {
             return err;
@@ -2433,7 +2433,7 @@ _PyMainInterpreterConfig_Read(_PyMainInterpreterConfig *main_config,
                       config->argc, config->argv);
     }
 
-    if (!config->_disable_importlib) {
+    if (config->_install_importlib) {
         COPY_WSTR(executable);
         COPY_WSTR(prefix);
         COPY_WSTR(base_prefix);
@@ -2540,7 +2540,6 @@ pymain_init(_PyMain *pymain)
     fedisableexcept(FE_OVERFLOW);
 #endif
 
-    pymain->config._disable_importlib = 0;
     pymain->config.install_signal_handlers = 1;
 }
 

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -563,7 +563,7 @@ read_pth_file(_PyPathConfig *config, wchar_t *prefix, const wchar_t *path)
     wcscpy_s(prefix, MAXPATHLEN+1, path);
     reduce(prefix);
     config->isolated = 1;
-    config->no_site_import = 1;
+    config->site_import = 0;
 
     size_t bufsiz = MAXPATHLEN;
     size_t prefixlen = wcslen(prefix);
@@ -588,7 +588,7 @@ read_pth_file(_PyPathConfig *config, wchar_t *prefix, const wchar_t *path)
         }
 
         if (strcmp(line, "import site") == 0) {
-            config->no_site_import = 0;
+            config->site_import = 1;
             continue;
         }
         else if (strncmp(line, "import ", 7) == 0) {

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -283,8 +283,7 @@ core_config_init_module_search_paths(_PyCoreConfig *config,
 
 
 _PyInitError
-_PyCoreConfig_InitPathConfig(_PyCoreConfig *config,
-                             int *isolated, int *no_site_import)
+_PyCoreConfig_InitPathConfig(_PyCoreConfig *config)
 {
     _PyPathConfig path_config = _PyPathConfig_INIT;
     _PyInitError err;
@@ -345,11 +344,11 @@ _PyCoreConfig_InitPathConfig(_PyCoreConfig *config,
         }
     }
 
-    if (path_config.isolated != -1 && isolated != NULL) {
-        *isolated = path_config.isolated;
+    if (path_config.isolated != -1) {
+        config->isolated = path_config.isolated;
     }
-    if (path_config.no_site_import != -1 && no_site_import != NULL) {
-        *no_site_import = path_config.no_site_import;
+    if (path_config.site_import != -1) {
+        config->site_import = path_config.site_import;
     }
 
     _PyPathConfig_Clear(&path_config);
@@ -375,10 +374,7 @@ pathconfig_global_init(void)
     _PyInitError err;
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    /* Py_IsolatedFlag and Py_NoSiteFlag are left unchanged: pass NULL.
-       _PyCoreConfig_InitPathConfig() will be called later and will set
-       these flags. */
-    err = _PyCoreConfig_Read(&config, NULL, NULL);
+    err = _PyCoreConfig_Read(&config);
     if (_Py_INIT_FAILED(err)) {
         goto error;
     }


### PR DESCRIPTION
* _PyCoreConfig: add isolated and site_import attributes
* Replace Py_IgnoreEnvironment with config->ignore_environment when
  reading the current configuration
* _PyCoreConfig_Read() now sets ignore_environment, utf8_mode,
  isolated and site_import from Py_IgnoreEnvironment, Py_UTF8Mode,
  Py_IsolatedFlag and Py_NoSiteFlag
* _Py_InitializeCore() now sets Py_xxx flags from the configuration
* pymain_read_conf() now uses _PyCoreConfig_Copy() to save/restore
  the configuration.

<!-- issue-number: bpo-34170 -->
https://bugs.python.org/issue34170
<!-- /issue-number -->
