### PR TITLE
Use bytes.hex instead of binascii.hexlify in pbkdf2_hmac example

### DIFF
--- a/Doc/library/hashlib.rst
+++ b/Doc/library/hashlib.rst
@@ -244,10 +244,10 @@ include a `salt <https://en.wikipedia.org/wiki/Salt_%28cryptography%29>`_.
    *dklen* is the length of the derived key. If *dklen* is ``None`` then the
    digest size of the hash algorithm *hash_name* is used, e.g. 64 for SHA-512.
 
-   >>> import hashlib, binascii
+   >>> import hashlib
    >>> dk = hashlib.pbkdf2_hmac('sha256', b'password', b'salt', 100000)
-   >>> binascii.hexlify(dk)
-   b'0394a2ede332c9a13eb82e9b24631604c31df978b4e2f0fbd2c549944f9d79a5'
+   >>> dk.hex()
+   '0394a2ede332c9a13eb82e9b24631604c31df978b4e2f0fbd2c549944f9d79a5'
 
    .. versionadded:: 3.4
 


### PR DESCRIPTION
Just simpler code.