### PR TITLE
bpo-34198: Additional encoding options to tkinter.filedialog

### DIFF
--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -390,15 +390,15 @@ def askopenfilenames(**options):
 
 # FIXME: are the following  perhaps a bit too convenient?
 
-def askopenfile(mode = "r", **options):
+def askopenfile(mode = "r", encoding = None, **options):
     "Ask for a filename to open, and returned the opened file"
 
     filename = Open(**options).show()
     if filename:
-        return open(filename, mode)
+        return open(filename, mode, encoding=encoding)
     return None
 
-def askopenfiles(mode = "r", **options):
+def askopenfiles(mode = "r", encoding = None, **options):
     """Ask for multiple filenames and return the open file
     objects
 
@@ -410,17 +410,17 @@ def askopenfiles(mode = "r", **options):
     if files:
         ofiles=[]
         for filename in files:
-            ofiles.append(open(filename, mode))
+            ofiles.append(open(filename, mode, encoding=encoding))
         files=ofiles
     return files
 
 
-def asksaveasfile(mode = "w", **options):
+def asksaveasfile(mode = "w", , encoding = None, **options):
     "Ask for a filename to save as, and returned the opened file"
 
     filename = SaveAs(**options).show()
     if filename:
-        return open(filename, mode)
+        return open(filename, mode, encoding=encoding)
     return None
 
 def askdirectory (**options):

--- a/Lib/tkinter/filedialog.py
+++ b/Lib/tkinter/filedialog.py
@@ -415,7 +415,7 @@ def askopenfiles(mode = "r", encoding = None, **options):
     return files
 
 
-def asksaveasfile(mode = "w", , encoding = None, **options):
+def asksaveasfile(mode = "w", encoding = None, **options):
     "Ask for a filename to save as, and returned the opened file"
 
     filename = SaveAs(**options).show()

--- a/Misc/NEWS.d/next/Library/2018-07-24-11-44-23.bpo-34198.QUQdhF.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-24-11-44-23.bpo-34198.QUQdhF.rst
@@ -1,0 +1,1 @@
+Additional `encoding` options to `tkinter.filedialog`


### PR DESCRIPTION
These call builtin `open`, but don't have encoding args.
- `askopenfile`
- `askopenfiles`
- `asksaveasfile`


In many Windows environments it will write as follows:
```
file_path = filedialog.askopenfilename()
file = open(file_path, 'r', encoding='utf-8')
print(file.read())
```

I want to write as follows:
```
file = filedialog.askopenfile('r', encoding='utf-8')
print(file.read())
```

<!-- issue-number: bpo-34198 -->
https://bugs.python.org/issue34198
<!-- /issue-number -->
