### PR TITLE
bpo-34193: Fix pluralization in getargs.c and test cases

### DIFF
--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -164,6 +164,9 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         msg = r"get expected at least 1 argument, got 0"
         self.assertRaisesRegex(TypeError, msg, {}.get)
 
+        msg = r"expected 1 argument, got 0"
+        self.assertRaisesRegex(TypeError, msg, {}.__delattr__)
+
     def test_varargs2min(self):
         msg = r"getattr expected at least 2 arguments, got 0"
         self.assertRaisesRegex(TypeError, msg, getattr)

--- a/Lib/test/test_call.py
+++ b/Lib/test/test_call.py
@@ -160,19 +160,19 @@ class CFunctionCallsErrorMessages(unittest.TestCase):
         msg = r"^from_bytes\(\) takes at most 2 positional arguments \(3 given\)"
         self.assertRaisesRegex(TypeError, msg, int.from_bytes, b'a', 'little', False)
 
-    def test_varargs4(self):
+    def test_varargs1min(self):
         msg = r"get expected at least 1 argument, got 0"
         self.assertRaisesRegex(TypeError, msg, {}.get)
 
-    def test_varargs5(self):
+    def test_varargs2min(self):
         msg = r"getattr expected at least 2 arguments, got 0"
         self.assertRaisesRegex(TypeError, msg, getattr)
 
-    def test_varargs6(self):
+    def test_varargs1max(self):
         msg = r"input expected at most 1 argument, got 2"
         self.assertRaisesRegex(TypeError, msg, input, 1, 2)
 
-    def test_varargs7(self):
+    def test_varargs2max(self):
         msg = r"get expected at most 2 arguments, got 3"
         self.assertRaisesRegex(TypeError, msg, {}.get, 1, 2, 3)
 

--- a/Lib/test/test_getargs2.py
+++ b/Lib/test/test_getargs2.py
@@ -1112,7 +1112,7 @@ class ParseTupleAndKeywords_Test(unittest.TestCase):
             parse((1,), {'a': 3}, 'OOO', ['', '', 'a'])
         parse((1,), {}, 'O|OO', ['', '', 'a'])
         with self.assertRaisesRegex(TypeError,
-               r'function takes at least 1 positional arguments \(0 given\)'):
+               r'function takes at least 1 positional argument \(0 given\)'):
             parse((), {}, 'O|OO', ['', '', 'a'])
         parse((1, 2), {'a': 3}, 'OO$O', ['', '', 'a'])
         with self.assertRaisesRegex(TypeError,
@@ -1120,7 +1120,7 @@ class ParseTupleAndKeywords_Test(unittest.TestCase):
             parse((1,), {'a': 3}, 'OO$O', ['', '', 'a'])
         parse((1,), {}, 'O|O$O', ['', '', 'a'])
         with self.assertRaisesRegex(TypeError,
-               r'function takes at least 1 positional arguments \(0 given\)'):
+               r'function takes at least 1 positional argument \(0 given\)'):
             parse((), {}, 'O|O$O', ['', '', 'a'])
         with self.assertRaisesRegex(SystemError, r'Empty parameter name after \$'):
             parse((1,), {}, 'O|$OO', ['', '', 'a'])

--- a/Lib/test/test_getargs2.py
+++ b/Lib/test/test_getargs2.py
@@ -682,11 +682,11 @@ class PositionalOnlyAndKeywords_TestCase(unittest.TestCase):
         self.assertEqual(self.getargs(1), (1, -1, -1))
         # required positional arg missing
         with self.assertRaisesRegex(TypeError,
-            r"function takes at least 1 positional arguments \(0 given\)"):
+            r"function takes at least 1 positional argument \(0 given\)"):
             self.getargs()
 
         with self.assertRaisesRegex(TypeError,
-            r"function takes at least 1 positional arguments \(0 given\)"):
+            r"function takes at least 1 positional argument \(0 given\)"):
             self.getargs(keyword=3)
 
     def test_empty_keyword(self):

--- a/Misc/NEWS.d/next/C API/2018-07-24-11-57-35.bpo-34193.M6ch1Q.rst
+++ b/Misc/NEWS.d/next/C API/2018-07-24-11-57-35.bpo-34193.M6ch1Q.rst
@@ -1,2 +1,2 @@
-Fix pluralization in TypeError messages in getargs.c: '1 argument' instead
-of '1 arguments' and '1 element' instead of '1 elements'.
+Fix pluralization in TypeError messages in getargs.c and typeobject.c:
+'1 argument' instead of '1 arguments' and '1 element' instead of '1 elements'.

--- a/Misc/NEWS.d/next/C API/2018-07-24-11-57-35.bpo-34193.M6ch1Q.rst
+++ b/Misc/NEWS.d/next/C API/2018-07-24-11-57-35.bpo-34193.M6ch1Q.rst
@@ -1,0 +1,2 @@
+Fix pluralization in TypeError messages in getargs.c: '1 argument' instead
+of '1 arguments' and '1 element' instead of '1 elements'.

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -5434,7 +5434,7 @@ check_num_args(PyObject *ob, int n)
         return 1;
     PyErr_Format(
         PyExc_TypeError,
-        "expected %d arguments, got %zd", n, PyTuple_GET_SIZE(ob));
+        "expected %d argument%s, got %zd", n, n == 1 ? "" : "s", PyTuple_GET_SIZE(ob));
     return 0;
 }
 

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -540,8 +540,10 @@ converttuple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
         levels[0] = 0;
         if (toplevel) {
             PyOS_snprintf(msgbuf, bufsize,
-                          "expected %d arguments, not %" PY_FORMAT_SIZE_T "d",
-                          n, len);
+                          "expected %d argument%s, not %" PY_FORMAT_SIZE_T "d",
+                          n,
+                          n == 1 ? "" : "s",
+                          len);
         }
         else {
             PyOS_snprintf(msgbuf, bufsize,
@@ -1718,12 +1720,14 @@ vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
                 }
                 else {
                     PyErr_Format(PyExc_TypeError,
-                                 "%.200s%s takes %s %d positional arguments"
+                                 "%.200s%s takes %s %d positional argument%s"
                                  " (%d given)",
                                  (fname == NULL) ? "function" : fname,
                                  (fname == NULL) ? "" : "()",
                                  (min != INT_MAX) ? "at most" : "exactly",
-                                 max, nargs);
+                                 max,
+                                 max == 1 ? "" : "s",
+                                 nargs);
                 }
                 return cleanreturn(0, &freelist);
             }
@@ -1797,12 +1801,14 @@ vgetargskeywords(PyObject *args, PyObject *kwargs, const char *format,
 
     if (skip) {
         PyErr_Format(PyExc_TypeError,
-                     "%.200s%s takes %s %d positional arguments"
+                     "%.200s%s takes %s %d positional argument%s"
                      " (%d given)",
                      (fname == NULL) ? "function" : fname,
                      (fname == NULL) ? "" : "()",
                      (Py_MIN(pos, min) < i) ? "at least" : "exactly",
-                     Py_MIN(pos, min), nargs);
+                     Py_MIN(pos, min),
+                     Py_MIN(pos, min) == 1 ? "" : "s",
+                     nargs);
         return cleanreturn(0, &freelist);
     }
 
@@ -2104,11 +2110,13 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
         }
         else {
             PyErr_Format(PyExc_TypeError,
-                         "%.200s%s takes %s %d positional arguments (%d given)",
+                         "%.200s%s takes %s %d positional argument%s (%d given)",
                          (parser->fname == NULL) ? "function" : parser->fname,
                          (parser->fname == NULL) ? "" : "()",
                          (parser->min != INT_MAX) ? "at most" : "exactly",
-                         parser->max, nargs);
+                         parser->max,
+                         parser->max == 1 ? "" : "s",
+                         nargs);
         }
         return cleanreturn(0, &freelist);
     }
@@ -2152,12 +2160,14 @@ vgetargskeywordsfast_impl(PyObject *const *args, Py_ssize_t nargs,
             if (i < pos) {
                 Py_ssize_t min = Py_MIN(pos, parser->min);
                 PyErr_Format(PyExc_TypeError,
-                             "%.200s%s takes %s %d positional arguments"
+                             "%.200s%s takes %s %d positional argument%s"
                              " (%d given)",
                              (parser->fname == NULL) ? "function" : parser->fname,
                              (parser->fname == NULL) ? "" : "()",
                              min < parser->max ? "at least" : "exactly",
-                             min, nargs);
+                             min,
+                             min == 1 ? "" : "s",
+                             nargs);
             }
             else {
                 keyword = PyTuple_GET_ITEM(kwtuple, i - pos);
@@ -2417,9 +2427,9 @@ unpack_stack(PyObject *const *args, Py_ssize_t nargs, const char *name,
         else
             PyErr_Format(
                 PyExc_TypeError,
-                "unpacked tuple should have %s%zd elements,"
+                "unpacked tuple should have %s%zd element%s,"
                 " but has %zd",
-                (min == max ? "" : "at least "), min, nargs);
+                (min == max ? "" : "at least "), min, min == 1 ? "" : "s", nargs);
         return 0;
     }
 
@@ -2436,9 +2446,9 @@ unpack_stack(PyObject *const *args, Py_ssize_t nargs, const char *name,
         else
             PyErr_Format(
                 PyExc_TypeError,
-                "unpacked tuple should have %s%zd elements,"
+                "unpacked tuple should have %s%zd element%s,"
                 " but has %zd",
-                (min == max ? "" : "at most "), max, nargs);
+                (min == max ? "" : "at most "), max, max == 1 ? "" : "s", nargs);
         return 0;
     }
 


### PR DESCRIPTION

> Tests: In the 3 tests before this, the suffix 0, 2, or 3 is the number of arguments given. This would suggest 0a, 0b, 2a, and 3a for the suffixes here. I like 1min, 2min, 1max, and 2max even better. You can wait a bit for other reviews before changing.

I have changed the function names but I can change as per review comments

> But if we add all the remaining fixes needed in this file (see below), we could write.
Fix pluralization in TypeError messages in getargs.c: '1 argument' instead of '1 arguments' and '1 element' instead of '1 elements'.

Added a new blurb. Let me know if the old one needs edit and can be re-used or to have the current one.

> Scope: I think we should finish the job in the file. The next line in both else clauses,
"unpacked tuple should have %s%zd elements,"
should get the same treatment. This may break existing tests. (These are the only two formatted 'elements'.
> Fixes for the following will break some test, which will then need fixing also.
542: "expected %d arguments, not %" PY_FORMAT_SIZE_T "d",
1720, "%.200s%s takes %s %d positional arguments"
1799, "%.200s%s takes %s %d positional arguments"
2106, "%200s%s takes %s %d positional arguments (%d given)",
2154: "%.200s%s takes %s %d positional arguments"

I have fixed the above ones and there were some test case failures in `test_capi` and `test_getargs` which were fixed. Changes for [1799](https://github.com/python/cpython/compare/master...tirkarthi:bpo34193?expand=1#diff-8aaf09dbd5eefbcdceb804ab2143a907R1803) line caused [test case](https://github.com/python/cpython/compare/master...tirkarthi:bpo34193?expand=1#diff-c25ce7de401ef2b5f1a26097694d65fcR569) failures that were fixed.

With respect to elements the code path is triggered only when fname is set as NULL and I couldn't find a function that passes fname as NULL. Almost all of them pass it as "" in case it's not present. I commented out the else block and tried running the test suite and had no failures. I think the code is not hit by any function. They were added as part of e4616e67525be58454db078594776c98450d8810 in 2001 and there are no test cases.

I tried looking into [argument clinic docs](https://docs.python.org/3/howto/clinic.html) to see if I can come up with a format string and function to hit the respective code paths for the patch. But understanding the format string is little difficult for me since the ones I can come up with generate error with required argument and not positional argument. I think test coverage could be improved in these and I also don't know if we have tests that hit this code but don't check for the error message. I will try my hands at `_testcapimodule.c` to see if I can come up with tests. Any guidance on testing and argument clinic format string will be highly helpful.

Thanks

<!-- issue-number: bpo-34193 -->
https://bugs.python.org/issue34193
<!-- /issue-number -->
