### PR TITLE
bpo-34197: Make _csv.Dialect attributes booleans.

### DIFF
--- a/Lib/test/test_csv.py
+++ b/Lib/test/test_csv.py
@@ -48,13 +48,13 @@ class Test_Csv(unittest.TestCase):
         obj = ctor(*args)
         # Check defaults
         self.assertEqual(obj.dialect.delimiter, ',')
-        self.assertEqual(obj.dialect.doublequote, True)
+        self.assertIs(obj.dialect.doublequote, True)
         self.assertEqual(obj.dialect.escapechar, None)
         self.assertEqual(obj.dialect.lineterminator, "\r\n")
         self.assertEqual(obj.dialect.quotechar, '"')
         self.assertEqual(obj.dialect.quoting, csv.QUOTE_MINIMAL)
-        self.assertEqual(obj.dialect.skipinitialspace, False)
-        self.assertEqual(obj.dialect.strict, False)
+        self.assertIs(obj.dialect.skipinitialspace, False)
+        self.assertIs(obj.dialect.strict, False)
         # Try deleting or changing attributes (they are read-only)
         self.assertRaises(AttributeError, delattr, obj.dialect, 'delimiter')
         self.assertRaises(AttributeError, setattr, obj.dialect, 'delimiter', ':')
@@ -76,13 +76,13 @@ class Test_Csv(unittest.TestCase):
                       strict=True)
         obj = ctor(*args, **kwargs)
         self.assertEqual(obj.dialect.delimiter, ':')
-        self.assertEqual(obj.dialect.doublequote, False)
+        self.assertIs(obj.dialect.doublequote, False)
         self.assertEqual(obj.dialect.escapechar, '\\')
         self.assertEqual(obj.dialect.lineterminator, "\r")
         self.assertEqual(obj.dialect.quotechar, '*')
         self.assertEqual(obj.dialect.quoting, csv.QUOTE_NONE)
-        self.assertEqual(obj.dialect.skipinitialspace, True)
-        self.assertEqual(obj.dialect.strict, True)
+        self.assertIs(obj.dialect.skipinitialspace, True)
+        self.assertIs(obj.dialect.strict, True)
 
     def test_reader_kw_attrs(self):
         self._test_kw_attrs(csv.reader, [])
@@ -104,13 +104,13 @@ class Test_Csv(unittest.TestCase):
         args = args + (dialect,)
         obj = ctor(*args)
         self.assertEqual(obj.dialect.delimiter, '-')
-        self.assertEqual(obj.dialect.doublequote, False)
+        self.assertIs(obj.dialect.doublequote, False)
         self.assertEqual(obj.dialect.escapechar, '^')
         self.assertEqual(obj.dialect.lineterminator, "$")
         self.assertEqual(obj.dialect.quotechar, '#')
         self.assertEqual(obj.dialect.quoting, csv.QUOTE_ALL)
-        self.assertEqual(obj.dialect.skipinitialspace, True)
-        self.assertEqual(obj.dialect.strict, False)
+        self.assertIs(obj.dialect.skipinitialspace, True)
+        self.assertIs(obj.dialect.strict, False)
 
     def test_reader_dialect_attrs(self):
         self._test_dialect_attrs(csv.reader, [])
@@ -976,15 +976,13 @@ Stonecutters Seafood and Chop House+ Lemont+ IL+ 12/19/02+ Week Back
 
     def test_has_header(self):
         sniffer = csv.Sniffer()
-        self.assertEqual(sniffer.has_header(self.sample1), False)
-        self.assertEqual(sniffer.has_header(self.header1 + self.sample1),
-                         True)
+        self.assertIs(sniffer.has_header(self.sample1), False)
+        self.assertIs(sniffer.has_header(self.header1 + self.sample1), True)
 
     def test_has_header_regex_special_delimiter(self):
         sniffer = csv.Sniffer()
-        self.assertEqual(sniffer.has_header(self.sample8), False)
-        self.assertEqual(sniffer.has_header(self.header2 + self.sample8),
-                         True)
+        self.assertIs(sniffer.has_header(self.sample8), False)
+        self.assertIs(sniffer.has_header(self.header2 + self.sample8), True)
 
     def test_guess_quote_and_delimiter(self):
         sniffer = csv.Sniffer()
@@ -1001,12 +999,12 @@ Stonecutters Seafood and Chop House+ Lemont+ IL+ 12/19/02+ Week Back
         dialect = sniffer.sniff(self.sample1)
         self.assertEqual(dialect.delimiter, ",")
         self.assertEqual(dialect.quotechar, '"')
-        self.assertEqual(dialect.skipinitialspace, True)
+        self.assertIs(dialect.skipinitialspace, True)
 
         dialect = sniffer.sniff(self.sample2)
         self.assertEqual(dialect.delimiter, ":")
         self.assertEqual(dialect.quotechar, "'")
-        self.assertEqual(dialect.skipinitialspace, False)
+        self.assertIs(dialect.skipinitialspace, False)
 
     def test_delimiters(self):
         sniffer = csv.Sniffer()
@@ -1068,7 +1066,7 @@ class TestLeaks(unittest.TestCase):
             delta = rc-lastrc
             lastrc = rc
         # if csv.reader() leaks, last delta should be 3 or more
-        self.assertEqual(delta < 3, True)
+        self.assertLess(delta, 3)
 
     def test_create_write(self):
         delta = 0
@@ -1084,7 +1082,7 @@ class TestLeaks(unittest.TestCase):
             delta = rc-lastrc
             lastrc = rc
         # if csv.writer() leaks, last delta should be 3 or more
-        self.assertEqual(delta < 3, True)
+        self.assertLess(delta, 3)
 
     def test_read(self):
         delta = 0
@@ -1100,7 +1098,7 @@ class TestLeaks(unittest.TestCase):
             delta = rc-lastrc
             lastrc = rc
         # if reader leaks during read, delta should be 5 or more
-        self.assertEqual(delta < 5, True)
+        self.assertLess(delta, 5)
 
     def test_write(self):
         delta = 0
@@ -1117,7 +1115,7 @@ class TestLeaks(unittest.TestCase):
             delta = rc-lastrc
             lastrc = rc
         # if writer leaks during write, last delta should be 5 or more
-        self.assertEqual(delta < 5, True)
+        self.assertLess(delta, 5)
 
 class TestUnicode(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2018-07-23-14-12-28.bpo-34197.7yFSP5.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-23-14-12-28.bpo-34197.7yFSP5.rst
@@ -1,0 +1,3 @@
+Attributes *skipinitialspace*, *doublequote* and *strict* of the *dialect*
+attribute of the :mod:`csv` reader are now :class:`bool` instances instead
+of integers 0 or 1.


### PR DESCRIPTION
Attributes skipinitialspace, doublequote and strict are now
booleans instead of integers 0 or 1.


<!-- issue-number: bpo-34197 -->
https://bugs.python.org/issue34197
<!-- /issue-number -->
