### PR TITLE
bpo-34212: Adds -DPy_BUILD_CORE_BUILTIN for modules statically linked into libpython

### DIFF
--- a/Modules/Setup
+++ b/Modules/Setup
@@ -102,25 +102,25 @@ PYTHONPATH=$(COREPYTHONPATH)
 # setup.py script in the root of the Python source tree.
 
 posix -DPy_BUILD_CORE posixmodule.c	# posix (UNIX) system calls
-errno errnomodule.c			# posix (UNIX) errno values
-pwd pwdmodule.c				# this is needed to find out the user's home dir
+errno -DPy_BUILD_CORE_BUILTIN errnomodule.c			# posix (UNIX) errno values
+pwd -DPy_BUILD_CORE_BUILTIN pwdmodule.c				# this is needed to find out the user's home dir
 					# if $HOME is not set
-_sre _sre.c				# Fredrik Lundh's new regular expressions
-_codecs _codecsmodule.c			# access to the builtin codecs and codec registry
-_weakref _weakref.c			# weak references
+_sre -DPy_BUILD_CORE_BUILTIN _sre.c				# Fredrik Lundh's new regular expressions
+_codecs -DPy_BUILD_CORE_BUILTIN _codecsmodule.c			# access to the builtin codecs and codec registry
+_weakref -DPy_BUILD_CORE_BUILTIN _weakref.c			# weak references
 _functools -DPy_BUILD_CORE _functoolsmodule.c   # Tools for working with functions and callable objects
-_operator _operator.c	        	# operator.add() and similar goodies
-_collections _collectionsmodule.c	# Container types
-_abc _abc.c				# Abstract base classes
-itertools itertoolsmodule.c		# Functions creating iterators for efficient looping
-atexit atexitmodule.c			# Register functions to be run at interpreter-shutdown
+_operator -DPy_BUILD_CORE_BUILTIN _operator.c	        	# operator.add() and similar goodies
+_collections -DPy_BUILD_CORE_BUILTIN _collectionsmodule.c	# Container types
+_abc -DPy_BUILD_CORE_BUILTIN _abc.c				# Abstract base classes
+itertools -DPy_BUILD_CORE_BUILTIN itertoolsmodule.c		# Functions creating iterators for efficient looping
+atexit -DPy_BUILD_CORE_BUILTIN atexitmodule.c			# Register functions to be run at interpreter-shutdown
 _signal -DPy_BUILD_CORE signalmodule.c
-_stat _stat.c				# stat.h interface
+_stat -DPy_BUILD_CORE_BUILTIN _stat.c				# stat.h interface
 time -DPy_BUILD_CORE timemodule.c	# -lm # time operations and variables
 _thread -DPy_BUILD_CORE _threadmodule.c	# low-level threading interface
 
 # access to ISO C locale support
-_locale _localemodule.c  # -lintl
+_locale -DPy_BUILD_CORE_BUILTIN _localemodule.c  # -lintl
 
 # Standard I/O baseline
 _io -DPy_BUILD_CORE -I$(srcdir)/Modules/_io _io/_iomodule.c _io/iobase.c _io/fileio.c _io/bytesio.c _io/bufferedio.c _io/textio.c _io/stringio.c
@@ -130,10 +130,10 @@ _io -DPy_BUILD_CORE -I$(srcdir)/Modules/_io _io/_iomodule.c _io/iobase.c _io/fil
 zipimport -DPy_BUILD_CORE zipimport.c
 
 # faulthandler module
-faulthandler faulthandler.c
+faulthandler -DPy_BUILD_CORE_BUILTIN faulthandler.c
 
 # debug tool to trace memory blocks allocated by Python
-_tracemalloc _tracemalloc.c hashtable.c
+_tracemalloc -DPy_BUILD_CORE_BUILTIN _tracemalloc.c hashtable.c
 
 # The rest of the modules listed in this file are all commented out by
 # default.  Usually they can be detected and built as dynamically
@@ -146,7 +146,7 @@ _tracemalloc _tracemalloc.c hashtable.c
 # ======================================================================
 
 # The Python symtable module depends on .h files that setup.py doesn't track
-_symtable symtablemodule.c
+_symtable -DPy_BUILD_CORE_BUILTIN symtablemodule.c
 
 # Uncommenting the following line tells makesetup that all following
 # modules are to be built as shared libraries (see above for more
@@ -363,7 +363,7 @@ _symtable symtablemodule.c
 # xx xxmodule.c
 
 # Another example -- the 'xxsubtype' module shows C-level subtyping in action
-xxsubtype xxsubtype.c
+xxsubtype -DPy_BUILD_CORE_BUILTIN xxsubtype.c
 
 # Uncommenting the following line tells makesetup that all following modules
 # are not built (see above for more detail).


### PR DESCRIPTION
I'm not happy with this solution since the `-DPy_BUILD_CORE_BUILTIN` is required for *every* module built into libpython that doesn't already define `-DPy_BUILD_CORE`.  So perhaps this should be done automatically, such as by `Modules/makesetup`, though I'm mildly afraid to touch that...

This along with #8445 are the minimal needed for Python 3.7+ to build on Cygwin again.

<!-- issue-number: bpo-34212 -->
https://bugs.python.org/issue34212
<!-- /issue-number -->