### PR TITLE
bpo-34170: Add _PyCoreConfig.bytes_warning

### DIFF
--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -87,9 +87,115 @@ typedef struct {
        these manipulations if site is explicitly imported later (call
        site.main() if you want them to be triggered).
 
-       Set to 0 by the -S command line option. If set to -1 (default), set to
-       the negative value of Py_NoSiteFlag. */
+       Set to 0 by the -S command line option. If set to -1 (default), it is
+       set to !Py_NoSiteFlag. */
     int site_import;
+
+    /* Bytes warnings:
+
+       * If equal to 1, issue a warning when comparing bytes or bytearray with
+         str or bytes with int.
+       * If equal or greater to 2, issue an error.
+
+       Incremented by the -b command line option. If set to -1 (default), inherit
+       Py_BytesWarningFlag value. */
+    int bytes_warning;
+
+    /* If greater than 0, enable inspect: when a script is passed as first
+       argument or the -c option is used, enter interactive mode after
+       executing the script or the command, even when sys.stdin does not appear
+       to be a terminal.
+
+       Incremented by the -i command line option. Set to 1 if the PYTHONINSPECT
+       environment variable is non-empty. If set to -1 (default), inherit
+       Py_InspectFlag value. */
+    int inspect;
+
+    /* If greater than 0: enable the interactive mode (REPL).
+
+       Incremented by the -i command line option. If set to -1 (default),
+       inherit Py_InteractiveFlag value. */
+    int interactive;
+
+    /* Optimization level.
+
+       Incremented by the -O command line option. Set by the PYTHONOPTIMIZE
+       environment variable. If set to -1 (default), inherit Py_OptimizeFlag
+       value. */
+    int optimization_level;
+
+    /* If greater than 0, enable the debug mode: turn on parser debugging
+       output (for expert only, depending on compilation options).
+
+       Incremented by the -d command line option. Set by the PYTHONDEBUG
+       environment variable. If set to -1 (default), inherit Py_DebugFlag
+       value. */
+    int debug;
+
+    /* If equal to 0, Python won't try to write ``.pyc`` files on the
+       import of source modules.
+
+       Set to 0 by the -B command line option and the PYTHONDONTWRITEBYTECODE
+       environment variable. If set to -1 (default), it is set to
+       !Py_DontWriteBytecodeFlag. */
+    int write_bytecode;
+
+    /* If greater than 0, enable the verbose mode: print a message each time a
+       module is initialized, showing the place (filename or built-in module)
+       from which it is loaded.
+
+       If greater or equal to 2, print a message for each file that is checked
+       for when searching for a module. Also provides information on module
+       cleanup at exit.
+
+       Incremented by the -v option. Set by the PYTHONVERBOSE environment
+       variable. If set to -1 (default), inherit Py_VerboseFlag value. */
+    int verbose;
+
+    /* If greater than 0, enable the quiet mode: Don't display the copyright
+       and version messages even in interactive mode.
+
+       Incremented by the -q option. If set to -1 (default), inherit
+       Py_QuietFlag value. */
+    int quiet;
+
+   /* If greater than 0, don't add the user site-packages directory to
+      sys.path.
+
+      Set to 0 by the -s and -I command line options , and the PYTHONNOUSERSITE
+      environment variable. If set to -1 (default), it is set to
+      !Py_NoUserSiteDirectory. */
+    int user_site_directory;
+
+    /* If greater than 0, enable unbuffered mode: force the stdout and stderr
+       streams to be unbuffered.
+
+       Set to 1 by the -u option. Set by the PYTHONUNBUFFERED environment
+       variable. If set to -1 (default), inherit Py_UnbufferedStdioFlag
+       value. */
+    int unbuffered_stdio;
+
+#ifdef MS_WINDOWS
+    /* If greater than 1, use the "mbcs" encoding instead of the UTF-8
+       encoding for the filesystem encoding.
+
+       Set to 1 if the PYTHONLEGACYWINDOWSFSENCODING environment variable is
+       set to a non-empty string. If set to -1 (default), inherit
+       Py_LegacyWindowsFSEncodingFlag value.
+
+       See PEP 529 for more details. */
+    int legacy_windows_fs_encoding;
+
+    /* If greater than zero, use io.FileIO instead of WindowsConsoleIO for sys
+       standard streams.
+
+       Set to 1 if the PYTHONLEGACYWINDOWSSTDIO environment variable is set to
+       a non-empty string. If set to -1 (default), inherit
+       Py_LegacyWindowsStdioFlag value.
+
+       See PEP 528 for more details. */
+    int legacy_windows_stdio;
+#endif
 
     /* --- Private fields -------- */
 
@@ -97,7 +203,30 @@ typedef struct {
        Needed by freeze_importlib: see install_importlib argument of
        _Py_InitializeEx_Private(). */
     int _install_importlib;
+
+    /* Value of the --check-hash-based-pycs configure option. Valid values:
+
+       - "default" means the 'check_source' flag in hash-based pycs
+         determines invalidation
+       - "always" causes the interpreter to hash the source file for
+         invalidation regardless of value of 'check_source' bit
+       - "never" causes the interpreter to always assume hash-based pycs are
+         valid
+
+       Set by the --check-hash-based-pycs command line option.
+       If set to NULL (default), inherit _Py_CheckHashBasedPycsMode value.
+
+       See PEP 552 "Deterministic pycs" for more details. */
+    const char *_check_hash_pycs_mode;
 } _PyCoreConfig;
+
+#ifdef MS_WINDOWS
+#  define _PyCoreConfig_WINDOWS_INIT \
+        .legacy_windows_fs_encoding = -1, \
+        .legacy_windows_stdio = -1,
+#else
+#  define _PyCoreConfig_WINDOWS_INIT
+#endif
 
 #define _PyCoreConfig_INIT \
     (_PyCoreConfig){ \
@@ -110,6 +239,17 @@ typedef struct {
         .nmodule_search_path = -1, \
         .isolated = -1, \
         .site_import = -1, \
+        .bytes_warning = -1, \
+        .inspect = -1, \
+        .interactive = -1, \
+        .optimization_level = -1, \
+        .debug= -1, \
+        .write_bytecode = -1, \
+        .verbose = -1, \
+        .quiet = -1, \
+        .user_site_directory = -1, \
+        .unbuffered_stdio = -1, \
+        _PyCoreConfig_WINDOWS_INIT \
         ._install_importlib = 1}
 /* Note: _PyCoreConfig_INIT sets other fields to 0/NULL */
 

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -507,13 +507,15 @@ class CmdLineTest(unittest.TestCase):
                 PYTHONDONTWRITEBYTECODE=value,
                 PYTHONVERBOSE=value,
             )
+            dont_write_bytecode = int(bool(value))
             code = (
                 "import sys; "
                 "sys.stderr.write(str(sys.flags)); "
                 f"""sys.exit(not (
                     sys.flags.debug == sys.flags.optimize ==
-                    sys.flags.dont_write_bytecode == sys.flags.verbose ==
+                    sys.flags.verbose ==
                     {expected}
+                    and sys.flags.dont_write_bytecode == {dont_write_bytecode}
                 ))"""
             )
             with self.subTest(envar_value=value):

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1906,7 +1906,7 @@ cmdline_get_env_flags(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
 #ifdef MS_WINDOWS
     get_env_flag(config, &config->legacy_windows_fs_encoding,
                  "PYTHONLEGACYWINDOWSFSENCODING");
-    get_env_flag(config, &onfig->legacy_windows_stdio,
+    get_env_flag(config, &config->legacy_windows_stdio,
                  "PYTHONLEGACYWINDOWSSTDIO");
 #endif
 }

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -999,12 +999,13 @@ bytearray_repr(PyByteArrayObject *self)
 static PyObject *
 bytearray_str(PyObject *op)
 {
-        if (Py_BytesWarningFlag) {
-                if (PyErr_WarnEx(PyExc_BytesWarning,
-                                 "str() on a bytearray instance", 1))
-                        return NULL;
+    if (Py_BytesWarningFlag) {
+        if (PyErr_WarnEx(PyExc_BytesWarning,
+                         "str() on a bytearray instance", 1)) {
+                return NULL;
         }
-        return bytearray_repr((PyByteArrayObject*)op);
+    }
+    return bytearray_repr((PyByteArrayObject*)op);
 }
 
 static PyObject *

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -1416,8 +1416,9 @@ bytes_str(PyObject *op)
 {
     if (Py_BytesWarningFlag) {
         if (PyErr_WarnEx(PyExc_BytesWarning,
-                         "str() on a bytes instance", 1))
+                         "str() on a bytes instance", 1)) {
             return NULL;
+        }
     }
     return bytes_repr(op);
 }

--- a/Parser/pgenmain.c
+++ b/Parser/pgenmain.c
@@ -24,9 +24,9 @@
 #include "parsetok.h"
 #include "pgen.h"
 
-int Py_DebugFlag;
-int Py_VerboseFlag;
-int Py_IgnoreEnvironmentFlag;
+int Py_DebugFlag = 0;
+int Py_VerboseFlag = 0;
+int Py_IgnoreEnvironmentFlag = 0;
 _PyRuntimeState _PyRuntime = _PyRuntimeState_INIT;
 
 /* Forward */

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -568,7 +568,9 @@ _PyState_ClearModules(void)
 void
 PyThreadState_Clear(PyThreadState *tstate)
 {
-    if (Py_VerboseFlag && tstate->frame != NULL)
+    int verbose = tstate->interp->core_config.verbose;
+
+    if (verbose && tstate->frame != NULL)
         fprintf(stderr,
           "PyThreadState_Clear: warning: thread still has a frame\n");
 
@@ -586,7 +588,7 @@ PyThreadState_Clear(PyThreadState *tstate)
     Py_CLEAR(tstate->exc_state.exc_traceback);
 
     /* The stack of exception states should contain just this thread. */
-    if (Py_VerboseFlag && tstate->exc_info != &tstate->exc_state) {
+    if (verbose && tstate->exc_info != &tstate->exc_state) {
         fprintf(stderr,
           "PyThreadState_Clear: warning: thread still has a generator\n");
     }


### PR DESCRIPTION
Add more fields to _PyCoreConfig:

* _check_hash_pycs_mode
* bytes_warning
* debug
* inspect
* interactive
* legacy_windows_fs_encoding
* legacy_windows_stdio
* optimization_level
* quiet
* unbuffered_stdio
* user_site_directory
* verbose
* write_bytecode

Changes:

* Remove pymain_get_global_config() and pymain_set_global_config()
  which became useless. These functions have been replaced by
  _PyCoreConfig_GetGlobalConfig() and
  _PyCoreConfig_SetGlobalConfig().
* sys.flags.dont_write_bytecode value is now restricted to 1 even if
  -B option is specified multiple times on the command line.
* PyThreadState_Clear() now uses the config from the current
  interpreter rather than using global Py_VerboseFlag

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34170 -->
https://bugs.python.org/issue34170
<!-- /issue-number -->
