### PR TITLE
bpo-34195: Fix case-sensitive comparison in test_nt_helpers

### DIFF
--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -423,8 +423,7 @@ class TestNtpath(unittest.TestCase):
             self.assertTrue(ntpath.ismount(b"\\\\localhost\\c$\\"))
 
     def assertEqualCI(self, s1, s2):
-        """Assert that two strings are equal ignoring case differences
-        """
+        """Assert that two strings are equal ignoring case differences"""
         self.assertEqual(s1.lower(), s2.lower())
 
     @unittest.skipUnless(nt, "OS helpers require 'nt' module")
@@ -432,11 +431,13 @@ class TestNtpath(unittest.TestCase):
         # Trivial validation that the helpers do not break, and support both
         # unicode and bytes (UTF-8) paths
 
-        drive, path = ntpath.splitdrive(sys.executable)
-        drive = drive.rstrip(ntpath.sep) + ntpath.sep
-        self.assertEqualCI(drive, nt._getvolumepathname(sys.executable))
-        self.assertEqualCI(drive.encode(),
-                         nt._getvolumepathname(sys.executable.encode()))
+        executable = nt._getfinalpathname(sys.executable)
+
+        for path in executable, os.fsencode(executable):
+            volume_path = nt._getvolumepathname(path)
+            path_drive = ntpath.splitdrive(path)[0]
+            volume_path_drive = ntpath.splitdrive(volume_path)[0]
+            self.assertEqualCI(path_drive, volume_path_drive)
 
         cap, free = nt._getdiskusage(sys.exec_prefix)
         self.assertGreater(cap, 0)

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -423,7 +423,7 @@ class TestNtpath(unittest.TestCase):
             self.assertTrue(ntpath.ismount(b"\\\\localhost\\c$\\"))
 
     def assertEqualCI(self, s1, s2):
-        """Assert that two strings are equal ignoring case differences"""
+        """Assert that two strings are equal ignoring case differences."""
         self.assertEqual(s1.lower(), s2.lower())
 
     @unittest.skipUnless(nt, "OS helpers require 'nt' module")

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -422,6 +422,11 @@ class TestNtpath(unittest.TestCase):
             self.assertTrue(ntpath.ismount(b"\\\\localhost\\c$"))
             self.assertTrue(ntpath.ismount(b"\\\\localhost\\c$\\"))
 
+    def assertEqualCI(self, s1, s2):
+        """Assert that two strings are equal ignoring case differences
+        """
+        self.assertEqual(s1.lower(), s2.lower())
+
     @unittest.skipUnless(nt, "OS helpers require 'nt' module")
     def test_nt_helpers(self):
         # Trivial validation that the helpers do not break, and support both
@@ -429,8 +434,8 @@ class TestNtpath(unittest.TestCase):
 
         drive, path = ntpath.splitdrive(sys.executable)
         drive = drive.rstrip(ntpath.sep) + ntpath.sep
-        self.assertEqual(drive, nt._getvolumepathname(sys.executable))
-        self.assertEqual(drive.encode(),
+        self.assertEqualCI(drive, nt._getvolumepathname(sys.executable))
+        self.assertEqualCI(drive.encode(),
                          nt._getvolumepathname(sys.executable.encode()))
 
         cap, free = nt._getdiskusage(sys.exec_prefix)


### PR DESCRIPTION
test_nt_helpers assumed that two versions of a Windows path could be compared case-sensitively. This is not the case, and the difference can be triggered (apparently) by running the test on a path somewhere below a Junction.

This change adds a simple method to compare without considering case and uses it in test_ntpath.TestNtpath.test_nt_helpers

<!-- issue-number: bpo-34195 -->
https://bugs.python.org/issue34195
<!-- /issue-number -->
