### PR TITLE
[2.7] bpo-25083: Python 2 can sometimes create incorrect .pyc files

### DIFF
--- a/Include/errcode.h
+++ b/Include/errcode.h
@@ -29,6 +29,7 @@ extern "C" {
 #define E_EOFS		23	/* EOF in triple-quoted string */
 #define E_EOLS		24	/* EOL in single-quoted string */
 #define E_LINECONT	25	/* Unexpected characters after a line continuation */
+#define E_IO    	26	/* I/O error */
 
 #ifdef __cplusplus
 }

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-25-22-47-19.bpo-25083.HT_hXh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-25-22-47-19.bpo-25083.HT_hXh.rst
@@ -1,0 +1,2 @@
+Adding I/O error checking when reading .py files and aborting importing on
+error.

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1681,6 +1681,11 @@ int
 PyTokenizer_Get(struct tok_state *tok, char **p_start, char **p_end)
 {
     int result = tok_get(tok, p_start, p_end);
+    if (tok->fp && ferror(tok->fp)) {
+        clearerr(tok->fp);
+        result = ERRORTOKEN;
+        tok->done = E_IO;
+    }
     if (tok->decoding_erred) {
         result = ERRORTOKEN;
         tok->done = E_DECODE;

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1654,6 +1654,9 @@ err_input(perrdetail *err)
         Py_XDECREF(tb);
         break;
     }
+    case E_IO:
+        msg = "I/O error while reading";
+        break;
     case E_LINECONT:
         msg = "unexpected character after line continuation character";
         break;


### PR DESCRIPTION
Python 2 never checked for I/O error when reading .py files and
thus could mistake an I/O error for EOF and create incorrect .pyc
files. This adds an check for this and aborts on an error.

<!-- issue-number: bpo-25083 -->
https://bugs.python.org/issue25083
<!-- /issue-number -->
