### PR TITLE
bpo-1539381: Implement SpooledTemporaryFile.readinto

### DIFF
--- a/Lib/tempfile.py
+++ b/Lib/tempfile.py
@@ -738,6 +738,12 @@ class SpooledTemporaryFile:
     def readlines(self, *args):
         return self._file.readlines(*args)
 
+    def readinto(self, *args):
+        return self._file.readinto(*args)
+
+    def readinto1(self, *args):
+        return self._file.readinto1(*args)
+
     def seek(self, *args):
         self._file.seek(*args)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-1539381: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
`SpooledTemporaryFile` have no `readinto` because of `StringIO` absence of it.

However, SpooledTemporaryFile have 3 internal "modes": BytesIO, StringIO and TemporaryFile.

This PR allows it use and expose `.readinto` of the modes that allows it. And the one that does not will raise its exception.

<!-- issue-number: bpo-1539381 -->
https://bugs.python.org/issue1539381
<!-- /issue-number -->
