### PR TITLE
bpo-34217: use lowercase header for windows includes

### DIFF
--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -28,7 +28,7 @@
  * I use SIO_GET_MULTICAST_FILTER to detect a decent SDK.
  */
 # ifdef SIO_GET_MULTICAST_FILTER
-#  include <MSTcpIP.h> /* for SIO_RCVALL */
+#  include <mstcpip.h> /* for SIO_RCVALL */
 #  define HAVE_ADDRINFO
 #  define HAVE_SOCKADDR_STORAGE
 #  define HAVE_GETADDRINFO

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -89,7 +89,7 @@
 #endif
 
 #include <windows.h>
-#include <Shlwapi.h>
+#include <shlwapi.h>
 
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>


### PR DESCRIPTION
When cross compiling python on a linux host with a case sensitive file system for a windows target.  The compilation will fail due to header
files which contain uppercases.

This commit fixes the case of 2 windows includes.


<!-- issue-number: bpo-34217 -->
https://bugs.python.org/issue34217
<!-- /issue-number -->
