### PR TITLE
bpo-34218: Fix a leak in _elementtree.c introduced in GH-6769.

### DIFF
--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -3178,6 +3178,7 @@ expat_start_doctype_handler(XMLParserObject *self,
                 "The doctype() method of XMLParser is ignored.  "
                 "Define doctype() method on the TreeBuilder target.",
                 1);
+        Py_DECREF(res);
     }
 
     Py_DECREF(doctype_name_obj);


### PR DESCRIPTION


<!-- issue-number: bpo-34218 -->
https://bugs.python.org/issue34218
<!-- /issue-number -->
