### PR TITLE
bpo-34225: Ensure INCLUDE and LIB directories do not end with a backslash

### DIFF
--- a/Lib/distutils/_msvccompiler.py
+++ b/Lib/distutils/_msvccompiler.py
@@ -252,11 +252,11 @@ class MSVCCompiler(CCompiler) :
 
         for dir in vc_env.get('include', '').split(os.pathsep):
             if dir:
-                self.add_include_dir(dir)
+                self.add_include_dir(dir.rstrip(os.sep))
 
         for dir in vc_env.get('lib', '').split(os.pathsep):
             if dir:
-                self.add_library_dir(dir)
+                self.add_library_dir(dir.rstrip(os.sep))
 
         self.preprocess_options = None
         # If vcruntime_redist is available, link against it dynamically. Otherwise,

--- a/Misc/NEWS.d/next/Windows/2018-07-25-16-13-12.bpo-34225.ngemNL.rst
+++ b/Misc/NEWS.d/next/Windows/2018-07-25-16-13-12.bpo-34225.ngemNL.rst
@@ -1,0 +1,1 @@
+Ensure INCLUDE and LIB directories do not end with a backslash.


### PR DESCRIPTION


<!-- issue-number: bpo-34225 -->
https://bugs.python.org/issue34225
<!-- /issue-number -->
