### PR TITLE
bpo-34228: Allow PYTHONTRACEMALLOC=0

### DIFF
--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -232,6 +232,7 @@ typedef struct {
         .install_signal_handlers = -1, \
         .ignore_environment = -1, \
         .use_hash_seed = -1, \
+        .tracemalloc = -1, \
         .coerce_c_locale = -1, \
         .utf8_mode = -1, \
         .argc = -1, \

--- a/Lib/test/test_tracemalloc.py
+++ b/Lib/test/test_tracemalloc.py
@@ -15,6 +15,7 @@ except ImportError:
 
 
 EMPTY_STRING_SIZE = sys.getsizeof(b'')
+INVALID_NFRAME = (-1, 2**30)
 
 
 def get_frames(nframe, lineno_delta):
@@ -833,6 +834,13 @@ class TestCommandLine(unittest.TestCase):
         stdout = stdout.rstrip()
         self.assertEqual(stdout, b'False')
 
+    def test_env_var_disabled(self):
+        # tracing at startup
+        code = 'import tracemalloc; print(tracemalloc.is_tracing())'
+        ok, stdout, stderr = assert_python_ok('-c', code, PYTHONTRACEMALLOC='0')
+        stdout = stdout.rstrip()
+        self.assertEqual(stdout, b'False')
+
     def test_env_var_enabled_at_startup(self):
         # tracing at startup
         code = 'import tracemalloc; print(tracemalloc.is_tracing())'
@@ -861,7 +869,7 @@ class TestCommandLine(unittest.TestCase):
 
 
     def test_env_var_invalid(self):
-        for nframe in (-1, 0, 2**30):
+        for nframe in INVALID_NFRAME:
             with self.subTest(nframe=nframe):
                 self.check_env_var_invalid(nframe)
 
@@ -889,7 +897,7 @@ class TestCommandLine(unittest.TestCase):
         self.fail(f"unexpeced output: {stderr!a}")
 
     def test_sys_xoptions_invalid(self):
-        for nframe in (-1, 0, 2**30):
+        for nframe in INVALID_NFRAME:
             with self.subTest(nframe=nframe):
                 self.check_sys_xoptions_invalid(nframe)
 

--- a/Misc/NEWS.d/next/Library/2018-07-25-19-02-39.bpo-34228.0Ibztw.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-25-19-02-39.bpo-34228.0Ibztw.rst
@@ -1,0 +1,3 @@
+tracemalloc: PYTHONTRACEMALLOC=0 environment variable and -X tracemalloc=0
+command line option are now allowed to disable explicitly tracemalloc at
+startup.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1726,10 +1726,14 @@ pymain_init_tracemalloc(_PyCoreConfig *config)
     int nframe;
     int valid;
 
+    if (config->tracemalloc >= 0) {
+        return _Py_INIT_OK();
+    }
+
     const char *env = config_get_env_var(config, "PYTHONTRACEMALLOC");
     if (env) {
         if (!pymain_str_to_int(env, &nframe)) {
-            valid = (nframe >= 1);
+            valid = (nframe >= 0);
         }
         else {
             valid = 0;
@@ -1746,7 +1750,7 @@ pymain_init_tracemalloc(_PyCoreConfig *config)
         const wchar_t *sep = wcschr(xoption, L'=');
         if (sep) {
             if (!pymain_wstr_to_int(sep + 1, &nframe)) {
-                valid = (nframe >= 1);
+                valid = (nframe >= 0);
             }
             else {
                 valid = 0;
@@ -2249,17 +2253,22 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
 
     config_init_locale(config);
 
-    /* Signal handlers are installed by default */
-    if (config->install_signal_handlers < 0) {
-        config->install_signal_handlers = 1;
-    }
-
     if (config->_install_importlib) {
         err = _PyCoreConfig_InitPathConfig(config);
         if (_Py_INIT_FAILED(err)) {
             return err;
         }
     }
+
+    /* default values */
+    if (config->tracemalloc < 0) {
+        config->tracemalloc = 0;
+    }
+    if (config->install_signal_handlers < 0) {
+        /* Signal handlers are installed by default */
+        config->install_signal_handlers = 1;
+    }
+
     return _Py_INIT_OK();
 }
 


### PR DESCRIPTION
PYTHONTRACEMALLOC=0 environment variable and -X tracemalloc=0 command
line option are now allowed to disable explicitly tracemalloc at
startup.

<!-- issue-number: bpo-34228 -->
https://bugs.python.org/issue34228
<!-- /issue-number -->
