### PR TITLE
bpo-34170: Enhance _PyCoreConfig_Read()

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -127,10 +127,9 @@ PyAPI_FUNC(wchar_t *) Py_GetExecPrefix(void);
 PyAPI_FUNC(wchar_t *) Py_GetPath(void);
 #ifdef Py_BUILD_CORE
 struct _PyPathConfig;
-typedef struct _PyPathConfig _PyPathConfig;
 
 PyAPI_FUNC(_PyInitError) _PyPathConfig_SetGlobal(
-    const _PyPathConfig *config);
+    const struct _PyPathConfig *config);
 PyAPI_FUNC(PyObject*) _PyPathConfig_ComputeArgv0(int argc, wchar_t **argv);
 PyAPI_FUNC(int) _Py_FindEnvConfigValue(
     FILE *env_file,

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -26,15 +26,23 @@ typedef PyObject* (*_PyFrameEvalFunction)(struct _frame *, int);
 
 
 typedef struct {
-    int install_signal_handlers;  /* Install signal handlers? -1 means unset */
+    /* Install signal handlers? Yes by default. */
+    int install_signal_handlers;
 
     int ignore_environment; /* -E, Py_IgnoreEnvironmentFlag, -1 means unset */
     int use_hash_seed;      /* PYTHONHASHSEED=x */
     unsigned long hash_seed;
-    const char *allocator;  /* Memory allocator: _PyMem_SetupAllocators() */
+    const char *allocator;  /* Memory allocator: PYTHONMALLOC */
     int dev_mode;           /* PYTHONDEVMODE, -X dev */
-    int faulthandler;       /* PYTHONFAULTHANDLER, -X faulthandler */
-    int tracemalloc;        /* PYTHONTRACEMALLOC, -X tracemalloc=N */
+
+    /* Enable faulthandler?
+       Set to 1 by -X faulthandler and PYTHONFAULTHANDLER. -1 means unset. */
+    int faulthandler;
+
+    /* Enable tracemalloc?
+       Set by -X tracemalloc=N and PYTHONTRACEMALLOC. -1 means unset */
+    int tracemalloc;
+
     int import_time;        /* PYTHONPROFILEIMPORTTIME, -X importtime */
     int show_ref_count;     /* -X showrefcount */
     int show_alloc_count;   /* -X showalloccount */
@@ -229,9 +237,10 @@ typedef struct {
 
 #define _PyCoreConfig_INIT \
     (_PyCoreConfig){ \
-        .install_signal_handlers = -1, \
+        .install_signal_handlers = 1, \
         .ignore_environment = -1, \
         .use_hash_seed = -1, \
+        .faulthandler = -1, \
         .tracemalloc = -1, \
         .coerce_c_locale = -1, \
         .utf8_mode = -1, \

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -551,9 +551,7 @@ class CmdLineTest(unittest.TestCase):
         env = dict(os.environ)
         env.pop('PYTHONWARNINGS', None)
         env.pop('PYTHONDEVMODE', None)
-        # Force malloc() to disable the debug hooks which are enabled
-        # by default for Python compiled in debug mode
-        env['PYTHONMALLOC'] = 'malloc'
+        env.pop('PYTHONMALLOC', None)
 
         if xdev:
             args = (sys.executable, '-X', 'dev', *args)

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-25-19-23-33.bpo-34170.v1h_H2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-25-19-23-33.bpo-34170.v1h_H2.rst
@@ -1,0 +1,2 @@
+-X dev: it is now possible to override the memory allocator using
+PYTHONMALLOC even if the developer mode is enabled.


### PR DESCRIPTION
* Inline cmdline_get_env_flags() into config_read_env_vars():
  _PyCoreConfig_Read() now reads much more environment variables like
  PYTHONVERBOSE.
* Allow to override faulthandler and allocator even if dev_mode=1.
  PYTHONMALLOC is now the priority over PYTHONDEVMODE.
* Fix _PyCoreConfig_Copy(): copy also install_signal_handlers,
  coerce_c_locale and coerce_c_locale_warn
* _PyCoreConfig.install_signal_handlers default is now 1: install
  signals by default
* Fix also a compiler warning: don't define _PyPathConfig type twice.

<!-- issue-number: bpo-34170 -->
https://bugs.python.org/issue34170
<!-- /issue-number -->
