### PR TITLE
bpo-34217: Fix include "Windows.h" case for cross-compiling

### DIFF
--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -21,7 +21,7 @@
 #endif /* HAVE_SYS_STAT_H */
 
 #ifdef MS_WINDOWS
-#include <Windows.h>
+#include <windows.h>
 #endif
 
 /* Various interned strings */

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -303,7 +303,7 @@ http://cvsweb.netbsd.org/bsdweb.cgi/src/lib/libc/net/getaddrinfo.c.diff?r1=1.82&
 # endif
 
 /* Provides the IsWindows7SP1OrGreater() function */
-#include <VersionHelpers.h>
+#include <versionhelpers.h>
 
 /* remove some flags on older version Windows during run-time.
    https://msdn.microsoft.com/en-us/library/windows/desktop/ms738596.aspx */

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -28,7 +28,7 @@
  * I use SIO_GET_MULTICAST_FILTER to detect a decent SDK.
  */
 # ifdef SIO_GET_MULTICAST_FILTER
-#  include <MSTcpIP.h> /* for SIO_RCVALL */
+#  include <mstcpip.h> /* for SIO_RCVALL */
 #  define HAVE_ADDRINFO
 #  define HAVE_SOCKADDR_STORAGE
 #  define HAVE_GETADDRINFO

--- a/PC/getpathp.c
+++ b/PC/getpathp.c
@@ -89,7 +89,7 @@
 #endif
 
 #include <windows.h>
-#include <Shlwapi.h>
+#include <shlwapi.h>
 
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/Tools/msi/bundle/bootstrap/pch.h
+++ b/Tools/msi/bundle/bootstrap/pch.h
@@ -15,7 +15,7 @@
 
 #include <windows.h>
 #include <gdiplus.h>
-#include <Uxtheme.h>
+#include <uxtheme.h>
 #include <msiquery.h>
 #include <objbase.h>
 #include <shlobj.h>


### PR DESCRIPTION
one more uppercase windows header found in _iomodule.c, no other occurences of "Windows.h" found


<!-- issue-number: [bpo-34217](https://www.bugs.python.org/issue34217) -->
https://bugs.python.org/issue34217
<!-- /issue-number -->
