### PR TITLE
bpo-34230: Fix crashes in pysqlite_build_row_cast_map() on memory allocation failure.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-07-26-10-38-57.bpo-34230.aSUdKF.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-26-10-38-57.bpo-34230.aSUdKF.rst
@@ -1,0 +1,2 @@
+Fix crashes in :mod:`sqlite3` on memory allocation failure. Patch by Sergey
+Fedoseev.

--- a/Modules/_sqlite/cursor.c
+++ b/Modules/_sqlite/cursor.c
@@ -132,6 +132,9 @@ int pysqlite_build_row_cast_map(pysqlite_Cursor* self)
     }
 
     Py_XSETREF(self->row_cast_map, PyList_New(0));
+    if (!self->row_cast_map) {
+        return -1;
+    }
 
     for (i = 0; i < sqlite3_column_count(self->statement->st); i++) {
         converter = NULL;
@@ -186,9 +189,6 @@ int pysqlite_build_row_cast_map(pysqlite_Cursor* self)
         }
 
         if (PyList_Append(self->row_cast_map, converter) != 0) {
-            if (converter != Py_None) {
-                Py_DECREF(converter);
-            }
             Py_CLEAR(self->row_cast_map);
 
             return -1;


### PR DESCRIPTION


<!-- issue-number: bpo-34230 -->
https://bugs.python.org/issue34230
<!-- /issue-number -->
