### PR TITLE
bpo-34231: PYTHONBREAKPOINT is not documented on python --help

### DIFF
--- a/Misc/python.man
+++ b/Misc/python.man
@@ -495,6 +495,9 @@ directory and Distutils installation paths for
 If this environment variable is set to a non-empty string, Python will
 show how long each import takes. This is exactly equivalent to setting
 \fB\-X importtime\fP on the command line.
+.IP PYTHONBREAKPOINT
+If this environment variable is set to 0, it disables the default debugger. It
+can be set to the callable of your debugger of choice.
 .SS Debug-mode variables
 Setting these variables only has an effect in a debug build of Python, that is,
 if Python was configured with the

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -144,9 +144,8 @@ static const char usage_6[] =
 "PYTHONCOERCECLOCALE: if this variable is set to 0, it disables the locale\n"
 "   coercion behavior. Use PYTHONCOERCECLOCALE=warn to request display of\n"
 "   locale coercion and locale compatibility warnings on stderr.\n"
-"PYTHONBREAKPOINT: if this variable is set to 1, it enables the default\n"
-"   debugger. if this variable is a string to a callable, then breakpoint()\n"
-"   can enter any debugger. if this variable is set to 0, disable debugging.\n"
+"PYTHONBREAKPOINT: if this variable is set to 0, it disables the default\n"
+"   debugger. It can be set to the callable of your debugger of choice.\n"
 "PYTHONDEVMODE: enable the development mode.\n"
 "PYTHONPYCACHEPREFIX: root directory for bytecode cache (pyc) files.\n";
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -144,6 +144,9 @@ static const char usage_6[] =
 "PYTHONCOERCECLOCALE: if this variable is set to 0, it disables the locale\n"
 "   coercion behavior. Use PYTHONCOERCECLOCALE=warn to request display of\n"
 "   locale coercion and locale compatibility warnings on stderr.\n"
+"PYTHONBREAKPOINT: if this variable is set to 1, it enables the default\n"
+"   debugger. if this variable is a string to a callable, then breakpoint()\n"
+"   can enter any debugger. if this variable is set to 0, disable debugging.\n"
 "PYTHONDEVMODE: enable the development mode.\n"
 "PYTHONPYCACHEPREFIX: root directory for bytecode cache (pyc) files.\n";
 


### PR DESCRIPTION
Add the documentation about PYTHONBREAKPOINT when python --help is
executed.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34231 -->
https://bugs.python.org/issue34231
<!-- /issue-number -->
