### PR TITLE
bpo-34170: Cleanup pymain_read_conf()

### DIFF
--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -29,9 +29,14 @@ typedef struct {
     /* Install signal handlers? Yes by default. */
     int install_signal_handlers;
 
-    int ignore_environment; /* -E, Py_IgnoreEnvironmentFlag, -1 means unset */
+    /* If greater than 0: use environment variables.
+       Set to 0 by -E command line option. If set to -1 (default), it is
+       set to !Py_IgnoreEnvironmentFlag. */
+    int use_environment;
+
     int use_hash_seed;      /* PYTHONHASHSEED=x */
     unsigned long hash_seed;
+
     const char *allocator;  /* Memory allocator: PYTHONMALLOC */
     int dev_mode;           /* PYTHONDEVMODE, -X dev */
 
@@ -238,7 +243,7 @@ typedef struct {
 #define _PyCoreConfig_INIT \
     (_PyCoreConfig){ \
         .install_signal_handlers = 1, \
-        .ignore_environment = -1, \
+        .use_environment = -1, \
         .use_hash_seed = -1, \
         .faulthandler = -1, \
         .tracemalloc = -1, \

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1237,10 +1237,9 @@ config_init_warnoptions(_PyCoreConfig *config, _PyCmdline *cmdline)
    Return 0 on success.
    Set pymain->err and return -1 on error. */
 static _PyInitError
-cmdline_init_env_warnoptions(_PyMain *pymain, _PyCoreConfig *config, _PyCmdline *cmdline)
+cmdline_init_env_warnoptions(_PyMain *pymain, const _PyCoreConfig *config,
+                             _PyCmdline *cmdline)
 {
-    assert(config->use_environment > 0);
-
     wchar_t *env;
     int res = config_get_env_var_dup(config, &env,
                                      L"PYTHONWARNINGS", "PYTHONWARNINGS");
@@ -2023,6 +2022,12 @@ pymain_read_conf_impl(_PyMain *pymain, _PyCoreConfig *config,
         return -1;
     }
 
+    err = _PyCoreConfig_Read(config);
+    if (_Py_INIT_FAILED(err)) {
+        pymain->err = err;
+        return -1;
+    }
+
     assert(config->use_environment >= 0);
     if (config->use_environment) {
         err = cmdline_init_env_warnoptions(pymain, config, cmdline);
@@ -2030,12 +2035,6 @@ pymain_read_conf_impl(_PyMain *pymain, _PyCoreConfig *config,
             pymain->err = err;
             return -1;
         }
-    }
-
-    err = _PyCoreConfig_Read(config);
-    if (_Py_INIT_FAILED(err)) {
-        pymain->err = err;
-        return -1;
     }
 
     err = config_init_warnoptions(config, cmdline);

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -77,7 +77,7 @@ main(int argc, char *argv[])
     _PyCoreConfig config = _PyCoreConfig_INIT;
     config.user_site_directory = 0;
     config.site_import = 0;
-    config.ignore_environment = 1;
+    config.use_environment = 0;
     config.program_name = L"./_freeze_importlib";
     /* Don't install importlib, since it could execute outdated bytecode. */
     config._install_importlib = 0;


### PR DESCRIPTION
* _PyCoreConfig: Rename ignore_environment field to use_environment.
* _PyCoreConfig_Read(): if isolated is set, use_environment and
  site_import are now always set to 0.
* Inline pymain_free_raw() into pymain_free()
* Move config_init_warnoptions() call into pymain_read_conf_impl()
* _PyCoreConfig_Read(): don't replace values if they are already set:
  faulthandler, pycache_prefix, home.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: bpo-34170 -->
https://bugs.python.org/issue34170
<!-- /issue-number -->
