### PR TITLE
bpo-34229: Check start and stop of slice object to be long when they are not int in PySlice_GetIndices

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -108,6 +108,15 @@ class Test6012(unittest.TestCase):
         self.assertEqual(_testcapi.argparsing("Hello", "World"), 1)
 
 
+class TestGetIndices(unittest.TestCase):
+
+    def test_get_indices(self):
+        self.assertEqual(_testcapi.get_indices(slice(10L, 20, 1), 100), 0)
+        self.assertEqual(_testcapi.get_indices(slice(10.1, 20, 1), 100), -1)
+        self.assertEqual(_testcapi.get_indices(slice(10, 20L, 1), 100), 0)
+        self.assertEqual(_testcapi.get_indices(slice(10, 20.1, 1), 100), -1)
+
+
 class SkipitemTest(unittest.TestCase):
 
     def test_skipitem(self):
@@ -266,7 +275,7 @@ def test_main():
                 raise support.TestFailed, sys.exc_info()[1]
 
     support.run_unittest(CAPITest, TestPendingCalls, SkipitemTest,
-                         TestThreadState)
+                         TestThreadState, TestGetIndices)
 
 if __name__ == "__main__":
     test_main()

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -111,10 +111,15 @@ class Test6012(unittest.TestCase):
 class TestGetIndices(unittest.TestCase):
 
     def test_get_indices(self):
-        self.assertEqual(_testcapi.get_indices(slice(10L, 20, 1), 100), 0)
-        self.assertEqual(_testcapi.get_indices(slice(10.1, 20, 1), 100), -1)
-        self.assertEqual(_testcapi.get_indices(slice(10, 20L, 1), 100), 0)
-        self.assertEqual(_testcapi.get_indices(slice(10, 20.1, 1), 100), -1)
+        self.assertEqual(_testcapi.get_indices(slice(10L, 20, 1), 100), (0, 10, 20, 1))
+        self.assertEqual(_testcapi.get_indices(slice(10.1, 20, 1), 100), None)
+        self.assertEqual(_testcapi.get_indices(slice(10, 20L, 1), 100), (0, 10, 20, 1))
+        self.assertEqual(_testcapi.get_indices(slice(10, 20.1, 1), 100), None)
+
+        self.assertEqual(_testcapi.get_indices(slice(10L, 20, 1L), 100), (0, 10, 20, 1))
+        self.assertEqual(_testcapi.get_indices(slice(10.1, 20, 1L), 100), None)
+        self.assertEqual(_testcapi.get_indices(slice(10, 20L, 1L), 100), (0, 10, 20, 1))
+        self.assertEqual(_testcapi.get_indices(slice(10, 20.1, 1L), 100), None)
 
 
 class SkipitemTest(unittest.TestCase):

--- a/Misc/NEWS.d/next/C API/2018-07-26-12-24-29.bpo-34229.SupCZK.rst
+++ b/Misc/NEWS.d/next/C API/2018-07-26-12-24-29.bpo-34229.SupCZK.rst
@@ -1,0 +1,2 @@
+Check start and stop of slice object to be long when they are not int in
+:c:func:`PySlice_GetIndices`.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1560,6 +1560,19 @@ getargs_et_hash(PyObject *self, PyObject *args)
 }
 
 static PyObject *
+get_indices(PyObject *self, PyObject *args)
+{
+  PySliceObject *slice;
+  Py_ssize_t length, start, stop, step;
+
+  if (!PyArg_ParseTuple(args, "On", &slice, &length))
+    return NULL;
+
+  int result = PySlice_GetIndices(slice, length, &start, &stop, &step);
+  return Py_BuildValue("i", result);
+}
+
+static PyObject *
 parse_tuple_and_keywords(PyObject *self, PyObject *args)
 {
     PyObject *sub_args;
@@ -2664,6 +2677,7 @@ static PyMethodDef TestMethods[] = {
 #ifdef Py_USING_UNICODE
     {"test_empty_argparse", (PyCFunction)test_empty_argparse,METH_NOARGS},
 #endif
+    {"get_indices", get_indices, METH_VARARGS},
     {"parse_tuple_and_keywords", parse_tuple_and_keywords, METH_VARARGS},
     {"test_null_strings",       (PyCFunction)test_null_strings,  METH_NOARGS},
     {"test_string_from_format", (PyCFunction)test_string_from_format, METH_NOARGS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1562,14 +1562,23 @@ getargs_et_hash(PyObject *self, PyObject *args)
 static PyObject *
 get_indices(PyObject *self, PyObject *args)
 {
-  PySliceObject *slice;
-  Py_ssize_t length, start, stop, step;
+    PySliceObject *slice;
+    Py_ssize_t length, start, stop, step;
 
-  if (!PyArg_ParseTuple(args, "On", &slice, &length))
-    return NULL;
+    if (!PyArg_ParseTuple(args, "On", &slice, &length))
+        return NULL;
 
-  int result = PySlice_GetIndices(slice, length, &start, &stop, &step);
-  return Py_BuildValue("i", result);
+    int result = PySlice_GetIndices(slice, length, &start, &stop, &step);
+
+    if (PyErr_Occurred()) {
+        assert(result == -1);
+        return NULL;
+    }
+
+    if (result == -1) {
+        Py_RETURN_NONE;
+    }
+    return Py_BuildValue("innn", result, start, stop, step);
 }
 
 static PyObject *
@@ -2677,7 +2686,7 @@ static PyMethodDef TestMethods[] = {
 #ifdef Py_USING_UNICODE
     {"test_empty_argparse", (PyCFunction)test_empty_argparse,METH_NOARGS},
 #endif
-    {"get_indices", get_indices, METH_VARARGS},
+    {"get_indices", (PyCFunction)get_indices, METH_VARARGS},
     {"parse_tuple_and_keywords", parse_tuple_and_keywords, METH_VARARGS},
     {"test_null_strings",       (PyCFunction)test_null_strings,  METH_NOARGS},
     {"test_string_from_format", (PyCFunction)test_string_from_format, METH_NOARGS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -1562,13 +1562,14 @@ getargs_et_hash(PyObject *self, PyObject *args)
 static PyObject *
 get_indices(PyObject *self, PyObject *args)
 {
+    int result;
     PySliceObject *slice;
     Py_ssize_t length, start, stop, step;
 
     if (!PyArg_ParseTuple(args, "On", &slice, &length))
         return NULL;
 
-    int result = PySlice_GetIndices(slice, length, &start, &stop, &step);
+    result = PySlice_GetIndices(slice, length, &start, &stop, &step);
 
     if (PyErr_Occurred()) {
         assert(result == -1);
@@ -2686,7 +2687,7 @@ static PyMethodDef TestMethods[] = {
 #ifdef Py_USING_UNICODE
     {"test_empty_argparse", (PyCFunction)test_empty_argparse,METH_NOARGS},
 #endif
-    {"get_indices", (PyCFunction)get_indices, METH_VARARGS},
+    {"get_indices", get_indices, METH_VARARGS},
     {"parse_tuple_and_keywords", parse_tuple_and_keywords, METH_VARARGS},
     {"test_null_strings",       (PyCFunction)test_null_strings,  METH_NOARGS},
     {"test_string_from_format", (PyCFunction)test_string_from_format, METH_NOARGS},

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -113,14 +113,14 @@ PySlice_GetIndices(PySliceObject *r, Py_ssize_t length,
     if (r->start == Py_None) {
         *start = *step < 0 ? length-1 : 0;
     } else {
-        if (!PyInt_Check(r->start) && !PyLong_Check(r->step)) return -1;
+        if (!PyInt_Check(r->start) && !PyLong_Check(r->start)) return -1;
         *start = PyInt_AsSsize_t(r->start);
         if (*start < 0) *start += length;
     }
     if (r->stop == Py_None) {
         *stop = *step < 0 ? -1 : length;
     } else {
-        if (!PyInt_Check(r->stop) && !PyLong_Check(r->step)) return -1;
+        if (!PyInt_Check(r->stop) && !PyLong_Check(r->stop)) return -1;
         *stop = PyInt_AsSsize_t(r->stop);
         if (*stop < 0) *stop += length;
     }


### PR DESCRIPTION
Check for slice.start and slice.stop to be Long when they are not int in `PySlice_GetIndices` instead of checking for slice.step to be of Long type.

Thanks

<!-- issue-number: bpo-34229 -->
https://bugs.python.org/issue34229
<!-- /issue-number -->
