### PR TITLE
bpo-19891: ignore error writing history with no homedir

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -439,7 +439,16 @@ def enablerlcompleter():
                 readline.read_history_file(history)
             except OSError:
                 pass
-            atexit.register(readline.write_history_file, history)
+
+            def write_history():
+                try:
+                    readline.write_history_file(history)
+                except (FileNotFoundError, PermissionError):
+                    # home directory does not exist or is not writable
+                    # https://bugs.python.org/issue19891
+                    pass
+
+            atexit.register(write_history)
 
     sys.__interactivehook__ = register_readline
 

--- a/Misc/NEWS.d/next/Library/2018-07-26-08-45-49.bpo-19891.Y-3IiB.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-26-08-45-49.bpo-19891.Y-3IiB.rst
@@ -1,0 +1,2 @@
+Ignore errors caused by missing / non-writable homedir while writing history
+during exit of an interactive session.  Patch by Anthony Sottile.


### PR DESCRIPTION


<!-- issue-number: bpo-19891 -->
https://bugs.python.org/issue19891
<!-- /issue-number -->
