### PR TITLE
bpo-34239: Convert test_bz2 to use tempfile

### DIFF
--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -79,7 +79,7 @@ class BaseTest(unittest.TestCase):
     def setUp(self):
         fd, self.filename = tempfile.mkstemp()
         os.close(fd)
-    
+
     def tearDown(self):
         try:
             os.unlink(self.filename)

--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -6,6 +6,7 @@ from io import BytesIO, DEFAULT_BUFFER_SIZE
 import os
 import pickle
 import glob
+import tempfile
 import pathlib
 import random
 import shutil
@@ -76,11 +77,14 @@ class BaseTest(unittest.TestCase):
     BIG_DATA = bz2.compress(BIG_TEXT, compresslevel=1)
 
     def setUp(self):
-        self.filename = support.TESTFN
-
+        fd, self.filename = tempfile.mkstemp()
+        os.close(fd)
+    
     def tearDown(self):
-        if os.path.isfile(self.filename):
+        try:
             os.unlink(self.filename)
+        except FileNotFoundError:
+            pass
 
 
 class BZ2FileTest(BaseTest):


### PR DESCRIPTION
[Creating tentatively to see how the non-Windows tests run]

test_bz2 currently uses the test.support.TESTFN functionality which creates a temporary file local to the test directory named around the pid.

This can give rise to race conditions where tests are competing with each other to delete and recreate the file.

This change converts the tests to use tempfile.mkstemp which gives a different file every time from the system's temp area

<!-- issue-number: bpo-34239 -->
https://bugs.python.org/issue34239
<!-- /issue-number -->
