### PR TITLE
[3.6] bpo-34177: vsts: Avoid conflict with Homebrew Python (GH-8430)

### DIFF
--- a/.vsts/macos-buildbot.yml
+++ b/.vsts/macos-buildbot.yml
@@ -24,7 +24,7 @@ steps:
   clean: true
   fetchDepth: 5
 
-- script: ./configure --with-pydebug --with-openssl=/usr/local/opt/openssl
+- script: ./configure --with-pydebug --with-openssl=/usr/local/opt/openssl --prefix=/opt/python-vsts
   displayName: 'Configure CPython (debug)'
 
 - script: make -s -j4

--- a/.vsts/macos-pr.yml
+++ b/.vsts/macos-pr.yml
@@ -24,7 +24,7 @@ steps:
   clean: true
   fetchDepth: 5
 
-- script: ./configure --with-pydebug --with-openssl=/usr/local/opt/openssl
+- script: ./configure --with-pydebug --with-openssl=/usr/local/opt/openssl --prefix=/opt/python-vsts
   displayName: 'Configure CPython (debug)'
 
 - script: make -s -j4


### PR DESCRIPTION
/usr/local/lib/pythonX.Y is used by Homebrew's Python already.
(cherry picked from commit 3e7d18a54b9243b9652c9ddab87c2b9153dc365f)

Co-authored-by: INADA Naoki <methane@users.noreply.github.com>

<!-- issue-number: [bpo-34177](https://www.bugs.python.org/issue34177) -->
https://bugs.python.org/issue34177
<!-- /issue-number -->
