### PR TITLE
bpo-34249: Full set of format codes applies to strftime only

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2024,7 +2024,8 @@ For :class:`date` objects, the format codes for hours, minutes, seconds, and
 microseconds should not be used, as :class:`date` objects have no such
 values.  If they're used anyway, ``0`` is substituted for them.
 
-The full set of format codes supported varies across platforms, because Python
+For the ``strftime(format)`` method the full set of format codes
+supported varies across platforms, because Python
 calls the platform C library's :func:`strftime` function, and platform
 variations are common.  To see the full set of format codes supported on your
 platform, consult the :manpage:`strftime(3)` documentation.


### PR DESCRIPTION
The existing paragraph about the full set of format code implies that it applies for strftime only, as it mentiones refers to C library’s strftime(). This is an effort to clarify that the full set of format codes does not apply to both strftime and strptime


<!-- issue-number: [bpo-34249](https://www.bugs.python.org/issue34249) -->
https://bugs.python.org/issue34249
<!-- /issue-number -->
