### PR TITLE
bpo-18372: Add missing PyObject_GC_Track() calls in the pickle module

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-12-08-03-40-43.bpo-18372.DT1nR0.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-12-08-03-40-43.bpo-18372.DT1nR0.rst
@@ -1,0 +1,2 @@
+Add missing :c:func:`PyObject_GC_Track` calls in the :mod:`pickle` module.
+Patch by Zackery Spytz.

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1117,6 +1117,8 @@ _Pickler_New(void)
         Py_DECREF(self);
         return NULL;
     }
+
+    PyObject_GC_Track(self);
     return self;
 }
 
@@ -1492,6 +1494,7 @@ _Unpickler_New(void)
         return NULL;
     }
 
+    PyObject_GC_Track(self);
     return self;
 }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-18372](https://www.bugs.python.org/issue18372) -->
https://bugs.python.org/issue18372
<!-- /issue-number -->
