### PR TITLE
normcase: use path for arg name, and adjust docs

### DIFF
--- a/Lib/macpath.py
+++ b/Lib/macpath.py
@@ -34,9 +34,12 @@ def _get_colon(path):
     else:
         return ':'
 
-# Normalize the case of a pathname.  Dummy in Posix, but <s>.lower() here.
 
 def normcase(path):
+    """Normalize case of pathname.
+
+    Dummy in Posix, but <s>.lower() here.
+    """
     if not isinstance(path, (bytes, str)):
         raise TypeError("normcase() argument must be str or bytes, "
                         "not '{}'".format(path.__class__.__name__))

--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -37,24 +37,25 @@ def _get_bothseps(path):
     else:
         return '\\/'
 
-# Normalize the case of a pathname and map slashes to backslashes.
-# Other normalizations (such as optimizing '../' away) are not done
-# (this is done by normpath).
 
-def normcase(s):
+def normcase(path):
     """Normalize case of pathname.
 
-    Makes all characters lowercase and all slashes into backslashes."""
-    s = os.fspath(s)
+    Makes all characters lowercase and all slashes into backslashes.
+
+    Other normalizations (such as optimizing '../' away) are not done here,
+    but by normpath.
+    """
+    path = os.fspath(path)
     try:
-        if isinstance(s, bytes):
-            return s.replace(b'/', b'\\').lower()
+        if isinstance(path, bytes):
+            return path.replace(b'/', b'\\').lower()
         else:
-            return s.replace('/', '\\').lower()
+            return path.replace('/', '\\').lower()
     except (TypeError, AttributeError):
-        if not isinstance(s, (bytes, str)):
+        if not isinstance(path, (bytes, str)):
             raise TypeError("normcase() argument must be str or bytes, "
-                            "not %r" % s.__class__.__name__) from None
+                            "not %r" % path.__class__.__name__) from None
         raise
 
 

--- a/Lib/posixpath.py
+++ b/Lib/posixpath.py
@@ -44,18 +44,14 @@ def _get_sep(path):
     else:
         return '/'
 
-# Normalize the case of a pathname.  Trivial in Posix, string.lower on Mac.
-# On MS-DOS this may also turn slashes into backslashes; however, other
-# normalizations (such as optimizing '../' away) are not allowed
-# (another function should be defined to do that).
 
-def normcase(s):
-    """Normalize case of pathname.  Has no effect under Posix"""
-    s = os.fspath(s)
-    if not isinstance(s, (bytes, str)):
+def normcase(path):
+    """Normalize case of pathname."""
+    path = os.fspath(path)
+    if not isinstance(path, (bytes, str)):
         raise TypeError("normcase() argument must be str or bytes, "
-                        "not '{}'".format(s.__class__.__name__))
-    return s
+                        "not '{}'".format(path.__class__.__name__))
+    return path
 
 
 # Return whether a path is absolute.


### PR DESCRIPTION
I've created this due to `s` being a bad variable name when using pdb(pp), where it would print `s` instead of `step`ping.

While at it I've also moved and adjusted the doc above into the docstrings.