### PR TITLE
bpo-34113: Fix SIGSEGV on negative STACKADJ when LLTRACE is on

### DIFF
--- a/Lib/test/test_lltrace.py
+++ b/Lib/test/test_lltrace.py
@@ -1,8 +1,8 @@
 import os
-import tempfile
 import textwrap
 import unittest
 
+from test import support
 from test.support.script_helper import assert_python_ok
 
 
@@ -13,9 +13,9 @@ class TestLLTrace(unittest.TestCase):
         # bpo-34113. The crash happened at the command line console of
         # debug Python builds with __ltrace__ enabled (only possible in console),
         # when the interal Python stack was negatively adjusted
-        with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp_script:
-            self.addCleanup(os.remove, tmp_script.name)
-            tmp_script.write(textwrap.dedent("""\
+        with open(support.TESTFN, 'w') as fd:
+            self.addCleanup(os.unlink, support.TESTFN)
+            fd.write(textwrap.dedent("""\
             import code
 
             console = code.InteractiveConsole()
@@ -24,9 +24,8 @@ class TestLLTrace(unittest.TestCase):
             console.push('a[0] = 1')
             print('unreachable if bug exists')
             """))
-            tmp_script.flush()
 
-            assert_python_ok(tmp_script.name)
+            assert_python_ok(support.TESTFN)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_lltrace.py
+++ b/Lib/test/test_lltrace.py
@@ -1,0 +1,43 @@
+
+import os
+import tempfile
+import textwrap
+import unittest
+
+from test import support
+from test.support.script_helper import (
+    assert_python_ok, assert_python_failure, interpreter_requires_environment,
+)
+
+
+class TestLLTrace(unittest.TestCase):
+
+    def test_lltrace_does_not_crash_on_subscript_operator(self):
+        # If this test fails, it will reproduce a crash reported as
+        # bpo-34113. The crash happened at the command line console of
+        # debug Python builds with __ltrace__ enabled (only possible in console),
+        # when the interal Python stack was negatively adjusted
+        with tempfile.NamedTemporaryFile(mode='w+', delete=False) as tmp_script:
+            self.addCleanup(os.remove, tmp_script.name)
+            tmp_script.write(textwrap.dedent("""\
+            import code
+
+            console = code.InteractiveConsole()
+            console.push('__ltrace__ = 1')
+            console.push('a = [1, 2, 3]')
+            console.push('a[0] = 1')
+            print('unreachable if bug exists')
+            """))
+            tmp_script.flush()
+
+            status, stdout, stderr = assert_python_ok(tmp_script.name)
+            self.assertEqual(status, 0)
+
+
+def test_main():
+    support.run_unittest(
+        TestLLTrace,
+    )
+
+if __name__ == "__main__":
+    test_main()

--- a/Lib/test/test_lltrace.py
+++ b/Lib/test/test_lltrace.py
@@ -1,13 +1,9 @@
-
 import os
 import tempfile
 import textwrap
 import unittest
 
-from test import support
-from test.support.script_helper import (
-    assert_python_ok, assert_python_failure, interpreter_requires_environment,
-)
+from test.support.script_helper import assert_python_ok
 
 
 class TestLLTrace(unittest.TestCase):
@@ -30,14 +26,7 @@ class TestLLTrace(unittest.TestCase):
             """))
             tmp_script.flush()
 
-            status, stdout, stderr = assert_python_ok(tmp_script.name)
-            self.assertEqual(status, 0)
-
-
-def test_main():
-    support.run_unittest(
-        TestLLTrace,
-    )
+            assert_python_ok(tmp_script.name)
 
 if __name__ == "__main__":
-    test_main()
+    unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-28-10-34-00.bpo-34113.eZ5FWV.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-28-10-34-00.bpo-34113.eZ5FWV.rst
@@ -1,0 +1,2 @@
+Fixed crash on debug builds when opcode stack was adjusted with negative
+numbers. Patch by Constantin Petrisor.

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -762,12 +762,18 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
                           assert(STACK_LEVEL() <= co->co_stacksize); }
 #define POP()           ((void)(lltrace && prtrace(TOP(), "pop")), \
                          BASIC_POP())
-#define STACKADJ_GROW(n)    { (void)(BASIC_STACKADJ(n), \
+#define STACKADJ_GROW(n)    do { \
+                              assert(n >= 0); \
+                              (void)(BASIC_STACKADJ(n), \
                               lltrace && prtrace(TOP(), "stackadj")); \
-                              assert(STACK_LEVEL() <= co->co_stacksize); }
-#define STACKADJ_SHRINK(n)  { (void)(lltrace && prtrace(TOP(), "stackadj")); \
-                              (void)(BASIC_STACKADJ(n)); \
-                              assert(STACK_LEVEL() <= co->co_stacksize); }
+                              assert(STACK_LEVEL() <= co->co_stacksize); \
+                            } while (0)
+#define STACKADJ_SHRINK(n)  do { \
+                              assert(n >= 0); \
+                              (void)(lltrace && prtrace(TOP(), "stackadj")); \
+                              (void)(BASIC_STACKADJ(-n)); \
+                              assert(STACK_LEVEL() <= co->co_stacksize); \
+                            } while (0)
 #define EXT_POP(STACK_POINTER) ((void)(lltrace && \
                                 prtrace((STACK_POINTER)[-1], "ext_pop")), \
                                 *--(STACK_POINTER))
@@ -775,7 +781,7 @@ _PyEval_EvalFrameDefault(PyFrameObject *f, int throwflag)
 #define PUSH(v)                BASIC_PUSH(v)
 #define POP()                  BASIC_POP()
 #define STACKADJ_GROW(n)       BASIC_STACKADJ(n)
-#define STACKADJ_SHRINK(n)     BASIC_STACKADJ(n)
+#define STACKADJ_SHRINK(n)     BASIC_STACKADJ(-n)
 #define EXT_POP(STACK_POINTER) (*--(STACK_POINTER))
 #endif
 
@@ -1177,7 +1183,7 @@ main_loop:
                 SET_TOP(Py_False);
                 DISPATCH();
             }
-            STACKADJ_SHRINK(-1);
+            STACKADJ_SHRINK(1);
             goto error;
         }
 
@@ -1573,7 +1579,7 @@ main_loop:
             PyObject *container = SECOND();
             PyObject *v = THIRD();
             int err;
-            STACKADJ_SHRINK(-3);
+            STACKADJ_SHRINK(3);
             /* container[sub] = v */
             err = PyObject_SetItem(container, sub, v);
             Py_DECREF(v);
@@ -1588,7 +1594,7 @@ main_loop:
             PyObject *sub = TOP();
             PyObject *container = SECOND();
             int err;
-            STACKADJ_SHRINK(-2);
+            STACKADJ_SHRINK(2);
             /* del container[sub] */
             err = PyObject_DelItem(container, sub);
             Py_DECREF(container);
@@ -2101,7 +2107,7 @@ main_loop:
             PyObject *owner = TOP();
             PyObject *v = SECOND();
             int err;
-            STACKADJ_SHRINK(-2);
+            STACKADJ_SHRINK(2);
             err = PyObject_SetAttr(owner, name, v);
             Py_DECREF(v);
             Py_DECREF(owner);
@@ -2424,7 +2430,7 @@ main_loop:
                     err = PySet_Add(set, item);
                 Py_DECREF(item);
             }
-            STACKADJ_SHRINK(-oparg);
+            STACKADJ_SHRINK(oparg);
             if (err != 0) {
                 Py_DECREF(set);
                 goto error;
@@ -2645,7 +2651,7 @@ main_loop:
             PyObject *value = SECOND();
             PyObject *map;
             int err;
-            STACKADJ_SHRINK(-2);
+            STACKADJ_SHRINK(2);
             map = PEEK(oparg);                      /* dict */
             assert(PyDict_CheckExact(map));
             err = PyDict_SetItem(map, key, value);  /* map[key] = value */
@@ -2788,7 +2794,7 @@ main_loop:
             PyObject *cond = TOP();
             int err;
             if (cond == Py_True) {
-                STACKADJ_SHRINK(-1);
+                STACKADJ_SHRINK(1);
                 Py_DECREF(cond);
                 FAST_DISPATCH();
             }
@@ -2798,7 +2804,7 @@ main_loop:
             }
             err = PyObject_IsTrue(cond);
             if (err > 0) {
-                STACKADJ_SHRINK(-1);
+                STACKADJ_SHRINK(1);
                 Py_DECREF(cond);
             }
             else if (err == 0)
@@ -2812,7 +2818,7 @@ main_loop:
             PyObject *cond = TOP();
             int err;
             if (cond == Py_False) {
-                STACKADJ_SHRINK(-1);
+                STACKADJ_SHRINK(1);
                 Py_DECREF(cond);
                 FAST_DISPATCH();
             }
@@ -2825,7 +2831,7 @@ main_loop:
                 JUMPTO(oparg);
             }
             else if (err == 0) {
-                STACKADJ_SHRINK(-1);
+                STACKADJ_SHRINK(1);
                 Py_DECREF(cond);
             }
             else
@@ -2911,7 +2917,7 @@ main_loop:
                 PyErr_Clear();
             }
             /* iterator ended normally */
-            STACKADJ_SHRINK(-1);
+            STACKADJ_SHRINK(1);
             Py_DECREF(iter);
             JUMPBY(oparg);
             PREDICT(POP_BLOCK);
@@ -3019,7 +3025,7 @@ main_loop:
             val = tb = Py_None;
             exc = TOP();
             if (exc == NULL) {
-                STACKADJ_SHRINK(-1);
+                STACKADJ_SHRINK(1);
                 exit_func = TOP();
                 SET_TOP(exc);
                 exc = Py_None;


### PR DESCRIPTION
https://bugs.python.org/issue34113

<!-- issue-number: [bpo-34113](https://www.bugs.python.org/issue34113) -->
https://bugs.python.org/issue34113
<!-- /issue-number -->
