### PR TITLE
bpo-34261: Add description to clinic.py

### DIFF
--- a/Tools/clinic/clinic.py
+++ b/Tools/clinic/clinic.py
@@ -4355,7 +4355,14 @@ def main(argv):
         sys.exit("Error: clinic.py requires Python 3.3 or greater.")
 
     import argparse
-    cmdline = argparse.ArgumentParser()
+    cmdline = argparse.ArgumentParser(
+        description="""Preprocessor for CPython C files.
+
+The purpose of the Argument Clinic is automating all the boilerplate involved
+with writing argument parsing code for builtins and providing introspection
+signatures ("docstrings") for CPython builtins.
+
+For more information see https://docs.python.org/3/howto/clinic.html""")
     cmdline.add_argument("-f", "--force", action='store_true')
     cmdline.add_argument("-o", "--output", type=str)
     cmdline.add_argument("-v", "--verbose", action='store_true')


### PR DESCRIPTION
# Add description to clinic.py

This PR adds a short description to `clinic.py` to help contributors understand what it's used for (This was something I was stumbling upon personally when trying to update a docstring of a CPython builtin). 

<!-- issue-number: [bpo-34261](https://www.bugs.python.org/issue34261) -->
https://bugs.python.org/issue34261
<!-- /issue-number -->
