### PR TITLE
bpo-34247: actually use environment variables in Py_Initialize

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -54,8 +54,9 @@ PyAPI_FUNC(int) Py_SetStandardStreamEncoding(const char *encoding,
 PyAPI_FUNC(_PyInitError) _Py_InitializeCore(const _PyCoreConfig *);
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
 
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *, int);
 PyAPI_FUNC(void) _PyCoreConfig_Clear(_PyCoreConfig *);
+PyAPI_FUNC(void) _PyCoreConfig_UpdateGlobals(_PyCoreConfig *);
 PyAPI_FUNC(int) _PyCoreConfig_Copy(
     _PyCoreConfig *config,
     const _PyCoreConfig *config2);

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -72,6 +72,12 @@ typedef struct {
     wchar_t *exec_prefix;   /* sys.exec_prefix */
     wchar_t *base_exec_prefix;  /* sys.base_exec_prefix */
 
+    int optimization_level;      /* Py_OptimizeFlag, -O, PYTHONOPTIMIZE */
+    int inspect;                 /* Py_InspectFlag, -i, PYTHONINSPECT */
+    int no_user_site_directory;  /* Py_NoUserSiteDirectory, -I, -s, PYTHONNOUSERSITE */
+    int dont_write_bytecode;     /* Py_DontWriteBytecodeFlag, -B, PYTHONDONTWRITEBYTECODE */
+    int use_unbuffered_io;       /* Py_UnbufferedStdioFlag, -u, PYTHONUNBUFFERED */
+
     /* Private fields */
     int _disable_importlib; /* Needed by freeze_importlib */
 } _PyCoreConfig;

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -219,6 +219,47 @@ class EmbeddingTests(unittest.TestCase):
         self.assertIn(expected_output, out)
         self.assertEqual(err, '')
 
+    def test_initialize_sys_flags_from_environment(self):
+        """
+        Validate that settings from environment variables affect
+        interpreter settings
+        """
+        env = { k: os.environ[k] for k in os.environ
+                if not k.startswith('PYTHON') }
+
+        out, err = self.run_embedded_interpreter(
+                "initialize_sys_flags", env=env)
+
+        expected_output = (
+            "dont_write_bytecode=0\n"
+            "hash_randomization=1\n"
+            "inspect=0\n"
+            "no_user_site=0\n"
+            "optimize=0\n"
+        )
+        self.assertIn(expected_output, out)
+        self.assertEqual(err, '')
+
+        env['PYTHONDONTWRITEBYTECODE'] = '1'
+        env['PYTHONHASHSEED'] = '0'
+        env['PYTHONINSPECT'] = '3'
+        env['PYTHONNOUSERSITE'] = '4'
+        env['PYTHONOPTIMIZE'] = '2'
+
+        out, err = self.run_embedded_interpreter(
+                "initialize_sys_flags", env=env)
+
+        expected_output = (
+            "dont_write_bytecode=1\n"
+            "hash_randomization=0\n"
+            "inspect=3\n"
+            "no_user_site=4\n"
+            "optimize=2\n"
+        )
+        self.assertEqual(expected_output, out)
+        self.assertEqual(err, '')
+
+
     def test_bpo20891(self):
         """
         bpo-20891: Calling PyGILState_Ensure in a non-Python thread before

--- a/Misc/NEWS.d/next/Core and Builtins/2018-07-28-13-08-54.bpo-34247.3J_0ge.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-07-28-13-08-54.bpo-34247.3J_0ge.rst
@@ -1,0 +1,2 @@
+Don't ignore environment variables with command-line equivalents in
+Py_Initialize.

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -291,6 +291,24 @@ static int test_initialize_pymain(void)
     return 0;
 }
 
+static int test_initialize_sys_flags(void)
+{
+    _testembed_Py_Initialize();
+
+    PyRun_SimpleString(
+        "import sys;"
+        "print(f\"dont_write_bytecode={sys.flags.dont_write_bytecode}\");"
+        "print(f\"hash_randomization={sys.flags.hash_randomization}\");"
+        "print(f\"inspect={sys.flags.inspect}\");"
+        "print(f\"no_user_site={sys.flags.no_user_site}\");"
+        "print(f\"optimize={sys.flags.optimize}\");"
+        "sys.stdout.flush()"
+    );
+
+    Py_Finalize();
+    return 0;
+}
+
 
 /* *********************************************************
  * List of test cases and the function that implements it.
@@ -318,6 +336,7 @@ static struct TestCase TestCases[] = {
     { "bpo20891", test_bpo20891 },
     { "initialize_twice", test_initialize_twice },
     { "initialize_pymain", test_initialize_pymain },
+    { "initialize_sys_flags", test_initialize_sys_flags },
     { NULL, NULL }
 };
 

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -108,7 +108,7 @@ pathconfig_global_init(void)
     _PyInitError err;
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    err = _PyCoreConfig_Read(&config);
+    err = _PyCoreConfig_Read(&config, 1);
     if (_Py_INIT_FAILED(err)) {
         goto error;
     }

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -924,10 +924,12 @@ _Py_InitializeEx_Private(int install_sigs, int install_importlib)
     config._disable_importlib = !install_importlib;
     config.install_signal_handlers = install_sigs;
 
-    err = _PyCoreConfig_Read(&config);
+    err = _PyCoreConfig_Read(&config, 0);
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }
+
+    _PyCoreConfig_UpdateGlobals(&config);
 
     err = _Py_InitializeCore(&config);
     if (_Py_INIT_FAILED(err)) {
@@ -943,6 +945,7 @@ _Py_InitializeEx_Private(int install_sigs, int install_importlib)
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }
+
 
     err = _Py_INIT_OK();
 


### PR DESCRIPTION
As mentioned in [bpo-34247](https://www.bugs.python.org/issue34247) a program embedding Python with Py_Initialize / Py_Run... (no Py_Main) cannot affect a number of interpreter options through environment variables. 

This is a pull request against the 3.7 branch, primarily because Nick Coghlan mentioned that there is related work on the master branch by Victor Stinner ([bpo-34170](https://www.bugs.python.org/issue34170)). 

The patch works for me, but I haven't dug deeply enough in the code to be sure that this is the right patch, I'm particularly unsure about the additional argument to _PyCoreConfig_Read.

<!-- issue-number: [bpo-34247](https://www.bugs.python.org/issue34247) -->
https://bugs.python.org/issue34247
<!-- /issue-number -->
