### PR TITLE
bpo-34035: Fix several AttributeError in zipfile seek() methods

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1442,6 +1442,16 @@ class OtherTests(unittest.TestCase):
 
                 self.assertEqual(f.read(), b"O, for a Muse of Fire!")
 
+    def test_seek_before_current_position(self):
+        """Check that calling seek() at a position before the current one
+        on a ZipExtFile object resets its state and still works."""
+        with zipfile.ZipFile(TESTFN, mode="w") as zipf:
+            zipf.writestr("foo.txt", "O, for a Muse of Fire!")
+            with zipf.open("foo.txt") as f:
+                f.seek(f._orig_file_size)
+                f.seek(0)
+                self.assertEqual(f.read(), b"O, for a Muse of Fire!")
+
     def test_open_non_existent_item(self):
         """Check that attempting to call open() for an item that doesn't
         exist in the archive raises a RuntimeError."""

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1442,16 +1442,6 @@ class OtherTests(unittest.TestCase):
 
                 self.assertEqual(f.read(), b"O, for a Muse of Fire!")
 
-    def test_seek_before_current_position(self):
-        """Check that calling seek() at a position before the current one
-        on a ZipExtFile object resets its state and still works."""
-        with zipfile.ZipFile(TESTFN, mode="w") as zipf:
-            zipf.writestr("foo.txt", "O, for a Muse of Fire!")
-            with zipf.open("foo.txt") as f:
-                f.read()
-                f.seek(0)
-                self.assertEqual(f.read(), b"O, for a Muse of Fire!")
-
     def test_open_non_existent_item(self):
         """Check that attempting to call open() for an item that doesn't
         exist in the archive raises a RuntimeError."""
@@ -1656,6 +1646,8 @@ class OtherTests(unittest.TestCase):
                 self.assertEqual(fp.read(5), txt[bloc:bloc+5])
                 fp.seek(0, os.SEEK_END)
                 self.assertEqual(fp.tell(), len(txt))
+                fp.seek(0, os.SEEK_SET)
+                self.assertEqual(fp.tell(), 0)
         # Check seek on memory file
         data = io.BytesIO()
         with zipfile.ZipFile(data, mode="w") as zipf:
@@ -1671,6 +1663,8 @@ class OtherTests(unittest.TestCase):
                 self.assertEqual(fp.read(5), txt[bloc:bloc+5])
                 fp.seek(0, os.SEEK_END)
                 self.assertEqual(fp.tell(), len(txt))
+                fp.seek(0, os.SEEK_SET)
+                self.assertEqual(fp.tell(), 0)
 
     def tearDown(self):
         unlink(TESTFN)

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -1448,7 +1448,7 @@ class OtherTests(unittest.TestCase):
         with zipfile.ZipFile(TESTFN, mode="w") as zipf:
             zipf.writestr("foo.txt", "O, for a Muse of Fire!")
             with zipf.open("foo.txt") as f:
-                f.seek(f._orig_file_size)
+                f.read()
                 f.seek(0)
                 self.assertEqual(f.read(), b"O, for a Muse of Fire!")
 

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -701,11 +701,11 @@ class _SharedFile:
 
     def seek(self, offset, whence=0):
         with self._lock:
-            if self.writing():
+            if self._writing():
                 raise ValueError("Can't reposition in the ZIP file while "
                         "there is an open writing handle on it. "
                         "Close the writing handle before trying to read.")
-            self._file.seek(self._pos)
+            self._file.seek(offset, whence)
             self._pos = self._file.tell()
             return self._pos
 
@@ -1021,14 +1021,13 @@ class ZipExtFile(io.BufferedIOBase):
             read_offset = 0
         elif read_offset < 0:
             # Position is before the current position. Reset the ZipExtFile
-
             self._fileobj.seek(self._orig_compress_start)
             self._running_crc = self._orig_start_crc
             self._compress_left = self._orig_compress_size
             self._left = self._orig_file_size
             self._readbuffer = b''
             self._offset = 0
-            self._decompressor = zipfile._get_decompressor(self._compress_type)
+            self._decompressor = _get_decompressor(self._compress_type)
             self._eof = False
             read_offset = new_pos
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1435,6 +1435,7 @@ Michael Schneider
 Peter Schneider-Kamp
 Arvin Schnell
 Nofar Schnider
+Mickaël Schoentgen
 Ed Schouten
 Scott Schram
 Robin Schreiber

--- a/Misc/NEWS.d/next/Library/2018-07-28-15-00-31.bpo-34035.75nW0H.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-28-15-00-31.bpo-34035.75nW0H.rst
@@ -1,0 +1,1 @@
+Fix several AttributeError in zipfile seek() methods.

--- a/Misc/NEWS.d/next/Library/2018-07-28-15-00-31.bpo-34035.75nW0H.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-28-15-00-31.bpo-34035.75nW0H.rst
@@ -1,1 +1,1 @@
-Fix several AttributeError in zipfile seek() methods.
+Fix several AttributeError in zipfile seek() methods. Patch by Mickaël Schoentgen.


### PR DESCRIPTION
The `ZipExtFile.seek()` was not tested and several errors were not spotted. I added a test to prevent any future regression.

To be checked with @vstinner.

<!-- issue-number: [bpo-34035](https://www.bugs.python.org/issue34035) -->
https://bugs.python.org/issue34035
<!-- /issue-number -->
