### PR TITLE
bpo-34255: Ensure that test.test_embed works when blddir != srcdir

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -7,12 +7,16 @@ import os
 import re
 import subprocess
 import sys
+import sysconfig
 
 
 class EmbeddingTestsMixin:
     def setUp(self):
-        here = os.path.abspath(__file__)
-        basepath = os.path.dirname(os.path.dirname(os.path.dirname(here)))
+        if not sysconfig.is_python_build():
+            self.skipTest('testing installed tree')
+
+        basepath = sysconfig._PROJECT_BASE
+
         exename = "_testembed"
         if sys.platform.startswith("win"):
             ext = ("_d" if "_d" in sys.executable else "") + ".exe"

--- a/Misc/NEWS.d/next/Tests/2018-07-28-14-48-59.bpo-34255.AKSqSY.rst
+++ b/Misc/NEWS.d/next/Tests/2018-07-28-14-48-59.bpo-34255.AKSqSY.rst
@@ -1,0 +1,1 @@
+Ensure that test.test_embed works when building outside of the source tree


### PR DESCRIPTION
The title says it all: this patch uses a different way to locate the _testembed helper for test.test_embed to ensure that this tool can be found when building outside of the source directory.

<!-- issue-number: [bpo-34255](https://www.bugs.python.org/issue34255) -->
https://bugs.python.org/issue34255
<!-- /issue-number -->
