### PR TITLE
bpo-42349: Switch to test.support.unlink

### DIFF
--- a/Lib/test/test_bz2.py
+++ b/Lib/test/test_bz2.py
@@ -81,10 +81,7 @@ class BaseTest(unittest.TestCase):
         os.close(fd)
 
     def tearDown(self):
-        try:
-            os.unlink(self.filename)
-        except FileNotFoundError:
-            pass
+        unlink(self.filename)
 
 
 class BZ2FileTest(BaseTest):


### PR DESCRIPTION
Serhiy Storchaka pointed out that using test.support.unlink was preferable

<!-- issue-number: [bpo-42349](https://www.bugs.python.org/issue42349) -->
https://bugs.python.org/issue42349
<!-- /issue-number -->
