### PR TITLE
bpo-34263 Cap timeout submitted to epoll/select etc. to one day.

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -173,10 +173,6 @@ Which clock is used depends on the (platform-specific) event loop
 implementation; ideally it is a monotonic clock.  This will generally be
 a different clock than :func:`time.time`.
 
-.. note::
-
-   Timeouts (relative *delay* or absolute *when*) should not exceed one day.
-
 
 .. method:: AbstractEventLoop.call_later(delay, callback, *args, context=None)
 

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -63,6 +63,9 @@ _FATAL_ERROR_IGNORE = (BrokenPipeError,
 
 _HAS_IPv6 = hasattr(socket, 'AF_INET6')
 
+# Maximum timeout passed to select to avoid OS limitations
+MAXIMUM_SELECT_TIMEOUT = 24 * 3600
+
 
 def _format_handle(handle):
     cb = handle._callback
@@ -1702,7 +1705,7 @@ class BaseEventLoop(events.AbstractEventLoop):
         elif self._scheduled:
             # Compute the desired timeout.
             when = self._scheduled[0]._when
-            timeout = max(0, when - self.time())
+            timeout = min(max(0, when - self.time()), MAXIMUM_SELECT_TIMEOUT)
 
         if self._debug and timeout != 0:
             t0 = self.time()

--- a/Misc/NEWS.d/next/Library/2018-07-28-17-00-36.bpo-34263.zUfRsu.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-28-17-00-36.bpo-34263.zUfRsu.rst
@@ -1,0 +1,2 @@
+asyncio's event loop will not pass timeouts longer than one day to
+epoll/select etc.


### PR DESCRIPTION
"Timeouts (relative *delay* or absolute *when*) should not exceed one day."

Shall we update the doc? With this PR there is no reason anymore to disallow timeouts greater than one day in asyncio.


<!-- issue-number: [bpo-34263](https://www.bugs.python.org/issue34263) -->
https://bugs.python.org/issue34263
<!-- /issue-number -->
