### PR TITLE
bpo-34075: Deprecate non-ThreadPoolExecutor in loop.set_default_executor()

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -906,7 +906,14 @@ pool of processes). By default, an event loop uses a thread pool executor
 
 .. method:: AbstractEventLoop.set_default_executor(executor)
 
-   Set the default executor used by :meth:`run_in_executor`.
+   Set *executor* as the default executor used by :meth:`run_in_executor`.
+   *executor* should be an instance of
+   :class:`~concurrent.futures.ThreadPoolExecutor`.
+
+   .. deprecated:: 3.8
+      Using an executor that is not an instance of
+      :class:`~concurrent.futures.ThreadPoolExecutor` is deprecated and
+      will trigger an error in Python 3.9.
 
 
 Error Handling API

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -164,6 +164,12 @@ Deprecated
   They will be removed in Python 3.9.
   (Contributed by Serhiy Storchaka in :issue:`29209`.)
 
+* Passing an object that is not an instance of
+  :class:`concurrent.futures.ThreadPoolExecutor` to
+  :meth:`asyncio.AbstractEventLoop.set_default_executor()` is
+  deprecated and will be prohibited in Python 3.9.
+  (Contributed by Elvis Pranskevichus in :issue:`34075`.)
+
 
 Removed
 =======

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -741,6 +741,12 @@ class BaseEventLoop(events.AbstractEventLoop):
             executor.submit(func, *args), loop=self)
 
     def set_default_executor(self, executor):
+        if not isinstance(executor, concurrent.futures.ThreadPoolExecutor):
+            warnings.warn(
+                'Using the default executor that is not an instance of '
+                'ThreadPoolExecutor is deprecated and will be prohibited '
+                'in Python 3.9',
+                DeprecationWarning, 2)
         self._default_executor = executor
 
     def _getaddrinfo_debug(self, host, port, family, type, proto, flags):

--- a/Misc/NEWS.d/next/Library/2018-07-28-11-49-21.bpo-34075.9u1bO-.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-28-11-49-21.bpo-34075.9u1bO-.rst
@@ -1,0 +1,2 @@
+Deprecate passing non-ThreadPoolExecutor instances to
+:meth:`AbstractEventLoop.set_default_executor`.


### PR DESCRIPTION
Various asyncio internals expect that the default executor is a
`ThreadPoolExecutor`, so deprecate passing anything else to
`loop.set_default_executor()`.

<!-- issue-number: [bpo-34075](https://www.bugs.python.org/issue34075) -->
https://bugs.python.org/issue34075
<!-- /issue-number -->
