### PR TITLE
bpo-34264: [macOS] make stack size of created threads same as on main…

### DIFF
--- a/Misc/NEWS.d/next/macOS/2018-07-28-17-04-42.bpo-34264.Pr_YdD.rst
+++ b/Misc/NEWS.d/next/macOS/2018-07-28-17-04-42.bpo-34264.Pr_YdD.rst
@@ -1,0 +1,2 @@
+Make sure that the default stack size for the main threads and threads
+created by the threading module are the same.

--- a/Python/thread_pthread.h
+++ b/Python/thread_pthread.h
@@ -28,7 +28,7 @@
  */
 #if defined(__APPLE__) && defined(THREAD_STACK_SIZE) && THREAD_STACK_SIZE == 0
 #undef  THREAD_STACK_SIZE
-#define THREAD_STACK_SIZE       0x500000
+#define THREAD_STACK_SIZE       0x1000000
 #endif
 #if defined(__FreeBSD__) && defined(THREAD_STACK_SIZE) && THREAD_STACK_SIZE == 0
 #undef  THREAD_STACK_SIZE


### PR DESCRIPTION
As mentioned in the BPO issue the default stack sizes for the main thread and secondary threads is inconsistent on macOS, even though both claim to be chosen to a minimal value that works correctly with the default recursion limit.

This pull request increases the default stack size of secondary threads to match that of the main thread.

<!-- issue-number: [bpo-34264](https://www.bugs.python.org/issue34264) -->
https://bugs.python.org/issue34264
<!-- /issue-number -->
