### PR TITLE
bpo-20177: Migrate datetime.date.fromtimestamp to Argument Clinic

### DIFF
--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -668,6 +668,7 @@ Benjamin Hodgson
 Joerg-Cyril Hoehle
 Gregor Hoffleit
 Chris Hoffman
+Tim Hoffmann
 Stefan Hoffmeister
 Albert Hofkamp
 Chris Hogan

--- a/Misc/NEWS.d/next/Documentation/2018-07-28-17-17-42.bpo-20177.cOZJWp.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-07-28-17-17-42.bpo-20177.cOZJWp.rst
@@ -1,0 +1,1 @@
+Migrate datetime.date.fromtimestamp to Argument Clinic. Patch by Tim Hoffmann.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -23,8 +23,9 @@
 /*[clinic input]
 module datetime
 class datetime.datetime "PyDateTime_DateTime *" "&PyDateTime_DateTimeType"
+class datetime.date "PyDateTime_Date *" "&PyDateTime_DateType"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=78142cb64b9e98bc]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=25138ad6a696b785]*/
 
 #include "clinic/_datetimemodule.c.h"
 
@@ -2785,9 +2786,8 @@ date_new(PyTypeObject *type, PyObject *args, PyObject *kw)
     return self;
 }
 
-/* Return new date from localtime(t). */
 static PyObject *
-date_local_from_object(PyObject *cls, PyObject *obj)
+date_fromtimestamp(PyObject *cls, PyObject *obj)
 {
     struct tm tm;
     time_t t;
@@ -2832,18 +2832,25 @@ date_today(PyObject *cls, PyObject *dummy)
     return result;
 }
 
-/* Return new date from given timestamp (Python timestamp -- a double). */
+/*[clinic input]
+@classmethod
+datetime.date.fromtimestamp
+
+    timestamp: object
+    /
+
+Create a date from a POSIX timestamp.
+
+The timestamp is a number, e.g. created via time.time(), that is interpreted
+as local time.
+[clinic start generated code]*/
+
 static PyObject *
-date_fromtimestamp(PyObject *cls, PyObject *args)
+datetime_date_fromtimestamp(PyTypeObject *type, PyObject *timestamp)
+/*[clinic end generated code: output=fd045fda58168869 input=eabb3fe7f40491fe]*/
 {
-    PyObject *timestamp;
-    PyObject *result = NULL;
-
-    if (PyArg_ParseTuple(args, "O:fromtimestamp", &timestamp))
-        result = date_local_from_object(cls, timestamp);
-    return result;
+    return date_fromtimestamp((PyObject *) type, timestamp);
 }
-
 
 /* Return new date from proleptic Gregorian ordinal.  Raises ValueError if
  * the ordinal is out of range.
@@ -3184,11 +3191,7 @@ date_reduce(PyDateTime_Date *self, PyObject *arg)
 static PyMethodDef date_methods[] = {
 
     /* Class methods: */
-
-    {"fromtimestamp", (PyCFunction)date_fromtimestamp, METH_VARARGS |
-                                                       METH_CLASS,
-     PyDoc_STR("timestamp -> local date from a POSIX timestamp (like "
-               "time.time()).")},
+    DATETIME_DATE_FROMTIMESTAMP_METHODDEF
 
     {"fromordinal", (PyCFunction)date_fromordinal,      METH_VARARGS |
                                                     METH_CLASS,

--- a/Modules/clinic/_datetimemodule.c.h
+++ b/Modules/clinic/_datetimemodule.c.h
@@ -2,6 +2,18 @@
 preserve
 [clinic start generated code]*/
 
+PyDoc_STRVAR(datetime_date_fromtimestamp__doc__,
+"fromtimestamp($type, timestamp, /)\n"
+"--\n"
+"\n"
+"Create a date from a POSIX timestamp.\n"
+"\n"
+"The timestamp is a number, e.g. created via time.time(), that is interpreted\n"
+"as local time.");
+
+#define DATETIME_DATE_FROMTIMESTAMP_METHODDEF    \
+    {"fromtimestamp", (PyCFunction)datetime_date_fromtimestamp, METH_O|METH_CLASS, datetime_date_fromtimestamp__doc__},
+
 PyDoc_STRVAR(datetime_datetime_now__doc__,
 "now($type, /, tz=None)\n"
 "--\n"
@@ -36,4 +48,4 @@ datetime_datetime_now(PyTypeObject *type, PyObject *const *args, Py_ssize_t narg
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=1fc05897ab239b3f input=a9049054013a1b77]*/
+/*[clinic end generated code: output=7fd14bd67749da23 input=a9049054013a1b77]*/


### PR DESCRIPTION
This PR migrates `datetime.date.fromtimestamp` to the Argument Clinic.

There's much more to to in [bpo-20177](https://www.bugs.python.org/issue20177), but it's a start to see how the conversion is going.

#europython2018-sprint

<!-- issue-number: [bpo-20177](https://www.bugs.python.org/issue20177) -->
https://bugs.python.org/issue20177
<!-- /issue-number -->
