### PR TITLE
bpo-34185: Fix test module collision in test_bdb when ran as script

### DIFF
--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -549,11 +549,11 @@ def create_modules(modules):
 def break_in_func(funcname, fname=__file__, temporary=False, cond=None):
     return 'break', (fname, None, temporary, cond, funcname)
 
-TEST_MODULE = 'test_module'
+TEST_MODULE = 'test_module_for_bdb'
 TEST_MODULE_FNAME = TEST_MODULE + '.py'
 def tfunc_import():
-    import test_module
-    test_module.main()
+    import test_module_for_bdb
+    test_module_for_bdb.main()
 
 def tfunc_main():
     lno = 2
@@ -971,9 +971,9 @@ class RunTestCase(BaseTestCase):
                 ('return', 3, 'main'),     ('step', ),
                 ('return', 1, '<module>'), ('quit', ),
             ]
-            import test_module
+            import test_module_for_bdb
             with TracerRun(self) as tracer:
-                tracer.runeval('test_module.main()', globals(), locals())
+                tracer.runeval('test_module_for_bdb.main()', globals(), locals())
 
 class IssuesTestCase(BaseTestCase):
     """Test fixed bdb issues."""
@@ -983,7 +983,7 @@ class IssuesTestCase(BaseTestCase):
         # Check that the tracer does step into the caller frame when the
         # trace function is not set in that frame.
         code_1 = """
-            from test_module_2 import func
+            from test_module_for_bdb_2 import func
             def main():
                 func()
                 lno = 5
@@ -994,12 +994,12 @@ class IssuesTestCase(BaseTestCase):
         """
         modules = {
             TEST_MODULE: code_1,
-            'test_module_2': code_2,
+            'test_module_for_bdb_2': code_2,
         }
         with create_modules(modules):
             self.expect_set = [
                 ('line', 2, 'tfunc_import'),
-                    break_in_func('func', 'test_module_2.py'),
+                    break_in_func('func', 'test_module_for_bdb_2.py'),
                 ('None', 2, 'tfunc_import'),      ('continue', ),
                 ('line', 3, 'func', ({1:1}, [])), ('step', ),
                 ('return', 3, 'func'),            ('step', ),


### PR DESCRIPTION
When running test_bdb.py as a script, `import test_module` would be
importing the existing Lib/test/test_modules.py instead of the
tempcwd/test_module.py module which was dynamically created by
test_bdb.py itself.

Indeed, when running `./python Lib/test/test_bdb.py` ("as a script"),
`sys.path[0]` is getting filled with the path to Lib/test.

The chosen solution here was to change the name of the temporary module
created by test_bdb.py .

<!-- issue-number: [bpo-34185](https://www.bugs.python.org/issue34185) -->
https://bugs.python.org/issue34185
<!-- /issue-number -->
