### PR TITLE
bpo-33635: Handling Bad file descriptor in Path.is_file and related.

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -7,7 +7,7 @@ import posixpath
 import re
 import sys
 from _collections_abc import Sequence
-from errno import EINVAL, ENOENT, ENOTDIR
+from errno import EINVAL, ENOENT, ENOTDIR, EBADF
 from operator import attrgetter
 from stat import S_ISDIR, S_ISLNK, S_ISREG, S_ISSOCK, S_ISBLK, S_ISCHR, S_ISFIFO
 from urllib.parse import quote_from_bytes as urlquote_from_bytes
@@ -33,6 +33,9 @@ __all__ = [
 #
 # Internals
 #
+
+# EBADF - guard agains macOS `stat` throwing EBADF
+_IGNORED_ERROS = (ENOENT, ENOTDIR, EBADF)
 
 def _is_wildcard_pattern(pat):
     # Whether this pattern needs actual matching using fnmatch, or can
@@ -528,7 +531,13 @@ class _RecursiveWildcardSelector(_Selector):
         try:
             entries = list(scandir(parent_path))
             for entry in entries:
-                if entry.is_dir() and not entry.is_symlink():
+                entry_is_dir = False
+                try:
+                    entry_is_dir = entry.is_dir()
+                except OSError as e:
+                    if e.errno not in _IGNORED_ERROS:
+                        raise
+                if entry_is_dir and not entry.is_symlink():
                     path = parent_path._make_child_relpath(entry.name)
                     for p in self._iterate_directories(path, is_dir, scandir):
                         yield p
@@ -1317,7 +1326,7 @@ class Path(PurePath):
         try:
             self.stat()
         except OSError as e:
-            if e.errno not in (ENOENT, ENOTDIR):
+            if e.errno not in _IGNORED_ERROS:
                 raise
             return False
         return True
@@ -1329,7 +1338,7 @@ class Path(PurePath):
         try:
             return S_ISDIR(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in (ENOENT, ENOTDIR):
+            if e.errno not in _IGNORED_ERROS:
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1343,7 +1352,7 @@ class Path(PurePath):
         try:
             return S_ISREG(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in (ENOENT, ENOTDIR):
+            if e.errno not in _IGNORED_ERROS:
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1377,7 +1386,7 @@ class Path(PurePath):
         try:
             return S_ISLNK(self.lstat().st_mode)
         except OSError as e:
-            if e.errno not in (ENOENT, ENOTDIR):
+            if e.errno not in _IGNORED_ERROS:
                 raise
             # Path doesn't exist
             return False
@@ -1389,7 +1398,7 @@ class Path(PurePath):
         try:
             return S_ISBLK(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in (ENOENT, ENOTDIR):
+            if e.errno not in _IGNORED_ERROS:
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1402,7 +1411,7 @@ class Path(PurePath):
         try:
             return S_ISCHR(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in (ENOENT, ENOTDIR):
+            if e.errno not in _IGNORED_ERROS:
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1415,7 +1424,7 @@ class Path(PurePath):
         try:
             return S_ISFIFO(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in (ENOENT, ENOTDIR):
+            if e.errno not in _IGNORED_ERROS:
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)
@@ -1428,7 +1437,7 @@ class Path(PurePath):
         try:
             return S_ISSOCK(self.stat().st_mode)
         except OSError as e:
-            if e.errno not in (ENOENT, ENOTDIR):
+            if e.errno not in _IGNORED_ERROS:
                 raise
             # Path doesn't exist or is a broken symlink
             # (see https://bitbucket.org/pitrou/pathlib/issue/12/)

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1,6 +1,7 @@
 import collections.abc
 import io
 import os
+import sys
 import errno
 import pathlib
 import pickle
@@ -2173,6 +2174,29 @@ class PosixPathTest(_BasePathTest, unittest.TestCase):
             self.assertEqual(p5.expanduser(), p5)
             self.assertEqual(p6.expanduser(), p6)
             self.assertRaises(RuntimeError, p7.expanduser)
+
+    @unittest.skipIf(sys.platform != "darwin",
+                     "Bad file descriptor in /dev/fd affects only macOS")
+    def test_handling_bad_descriptor(self):
+        try:
+            file_descriptors = list(pathlib.Path('/dev/fd').rglob("*"))[3:]
+            if not file_descriptors:
+                self.skipTest("no file descriptors - issue was not reproduced")
+            # Checking all file descriptors because there is no guarantee
+            # which one will fail.
+            for f in file_descriptors:
+                f.exists()
+                f.is_dir()
+                f.is_file()
+                f.is_symlink()
+                f.is_block_device()
+                f.is_char_device()
+                f.is_fifo()
+                f.is_socket()
+        except OSError as e:
+            if e.errno == errno.EBADF:
+                self.fail("Bad file descriptor not handled.")
+            raise
 
 
 @only_nt

--- a/Misc/NEWS.d/next/macOS/2018-07-31-09-51-01.bpo-33635.KiscE-.rst
+++ b/Misc/NEWS.d/next/macOS/2018-07-31-09-51-01.bpo-33635.KiscE-.rst
@@ -1,0 +1,5 @@
+In macOS stat on some file descriptors (/dev/fd/3 f.e) will result in bad
+file descriptor OSError. Guard against this exception was added in is_dir,
+is_file and similar methods. DirEntry.is_dir can also throw this exception
+so _RecursiveWildcardSelector._iterate_directories was also extended with
+the same error ignoring pattern.


### PR DESCRIPTION
In macOS `stat` on some file descriptors will result in bad file descriptor OSError. This PR is guarding agains this exception in `is_dir`, `is_file` and similar methods. `DirEntry.is_dir` can also throw this exception so I have extended `_RecursiveWildcardSelector._iterate_directories` with the same error ignoring pattern.


```
(default) ➜  cpython git:(fix-issue-33635) ls /dev/fd
0 1 2 3 4
(default) ➜  cpython git:(fix-issue-33635) stat /dev/fd/3
stat: /dev/fd/3: stat: Bad file descriptor
(default) ➜  cpython git:(fix-issue-33635) python
Python 3.6.4 (default, Jan  6 2018, 11:51:59)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import pathlib
>>> pathlib.Path('/dev/fd/3').is_file()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/pathlib.py", line 1340, in is_file
    return S_ISREG(self.stat().st_mode)
  File "/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/pathlib.py", line 1136, in stat
    return self._accessor.stat(self)
  File "/usr/local/Cellar/python3/3.6.4_2/Frameworks/Python.framework/Versions/3.6/lib/python3.6/pathlib.py", line 387, in wrapped
    return strfunc(str(pathobj), *args)
OSError: [Errno 9] Bad file descriptor: '/dev/fd/3'
```

<!-- issue-number: [bpo-33635](https://www.bugs.python.org/issue33635) -->
https://bugs.python.org/issue33635
<!-- /issue-number -->
