### PR TITLE
bpo-31047: Fix ntpath.abspath for invalid paths

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -498,7 +498,8 @@ def normpath(path):
 
 def _abspath_fallback(path):
     """Return the absolute version of a path as a fallback function in case
-    `nt._getfullpathname` is not available or raises OSError.
+    `nt._getfullpathname` is not available or raises OSError. See bpo-31047 for
+    more.
 
     """
 

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -280,6 +280,9 @@ class TestNtpath(unittest.TestCase):
     @unittest.skipUnless(nt, "abspath requires 'nt' module")
     def test_abspath(self):
         tester('ntpath.abspath("C:\\")', "C:\\")
+        with support.temp_cwd(support.TESTFN) as cwd_dir: # bpo-31047
+            tester('ntpath.abspath(" ")', os.path.join(cwd_dir, " "))
+            tester('ntpath.abspath("")', cwd_dir)
 
     def test_relpath(self):
         tester('ntpath.relpath("a")', 'a')

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -281,8 +281,9 @@ class TestNtpath(unittest.TestCase):
     def test_abspath(self):
         tester('ntpath.abspath("C:\\")', "C:\\")
         with support.temp_cwd(support.TESTFN) as cwd_dir: # bpo-31047
-            tester('ntpath.abspath(" ")', os.path.join(cwd_dir, " "))
             tester('ntpath.abspath("")', cwd_dir)
+            tester('ntpath.abspath(" ")', cwd_dir + "\\ ")
+            tester('ntpath.abspath("?")', cwd_dir + "\\?")
 
     def test_relpath(self):
         tester('ntpath.relpath("a")', 'a')

--- a/Misc/NEWS.d/next/Library/2018-07-29-14-12-23.bpo-31047.FSarLs.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-29-14-12-23.bpo-31047.FSarLs.rst
@@ -1,0 +1,2 @@
+Fix ``ntpath.abspath`` for invalid paths on windows. Patch by Franz
+Woellert.


### PR DESCRIPTION
Fixes `nt.abspath` for invalid paths to ensure `os.path.isabs(os.path.abspath(" ")) == True` to behave the same as for `""` or `"?"`.

Refers to https://bugs.python.org/issue31047

Co-authored-by: 
- Eryk Sun <eryksun@gmail.com>
- Victor Stinner <vstinner@redhat.com>

<!-- issue-number: [bpo-31047](https://www.bugs.python.org/issue31047) -->
https://bugs.python.org/issue31047
<!-- /issue-number -->
