### PR TITLE
[3.7] bpo-34231: PYTHONBREAKPOINT is not documented on python --help (GH-8475)

### DIFF
--- a/Misc/python.man
+++ b/Misc/python.man
@@ -495,6 +495,9 @@ directory and Distutils installation paths for
 If this environment variable is set to a non-empty string, Python will
 show how long each import takes. This is exactly equivalent to setting
 \fB\-X importtime\fP on the command line.
+.IP PYTHONBREAKPOINT
+If this environment variable is set to 0, it disables the default debugger. It
+can be set to the callable of your debugger of choice.
 .SS Debug-mode variables
 Setting these variables only has an effect in a debug build of Python, that is,
 if Python was configured with the

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -144,6 +144,8 @@ static const char usage_6[] =
 "PYTHONCOERCECLOCALE: if this variable is set to 0, it disables the locale\n"
 "   coercion behavior. Use PYTHONCOERCECLOCALE=warn to request display of\n"
 "   locale coercion and locale compatibility warnings on stderr.\n"
+"PYTHONBREAKPOINT: if this variable is set to 0, it disables the default\n"
+"   debugger. It can be set to the callable of your debugger of choice.\n"
 "PYTHONDEVMODE: enable the development mode.\n";
 
 static void


### PR DESCRIPTION


<!-- issue-number: [bpo-34231](https://www.bugs.python.org/issue34231) -->
https://bugs.python.org/issue34231
<!-- /issue-number -->
