### PR TITLE
[3.6] bpo-31047: Fix ntpath.abspath for invalid paths (GH-8544)

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -518,38 +518,36 @@ def normpath(path):
         comps.append(curdir)
     return prefix + sep.join(comps)
 
+def _abspath_fallback(path):
+    """Return the absolute version of a path as a fallback function in case
+    `nt._getfullpathname` is not available or raises OSError. See bpo-31047 for
+    more.
+
+    """
+
+    path = os.fspath(path)
+    if not isabs(path):
+        if isinstance(path, bytes):
+            cwd = os.getcwdb()
+        else:
+            cwd = os.getcwd()
+        path = join(cwd, path)
+    return normpath(path)
 
 # Return an absolute path.
 try:
     from nt import _getfullpathname
 
 except ImportError: # not running on Windows - mock up something sensible
-    def abspath(path):
-        """Return the absolute version of a path."""
-        path = os.fspath(path)
-        if not isabs(path):
-            if isinstance(path, bytes):
-                cwd = os.getcwdb()
-            else:
-                cwd = os.getcwd()
-            path = join(cwd, path)
-        return normpath(path)
+    abspath = _abspath_fallback
 
 else:  # use native Windows method on Windows
     def abspath(path):
         """Return the absolute version of a path."""
-
-        if path: # Empty path must return current working directory.
-            path = os.fspath(path)
-            try:
-                path = _getfullpathname(path)
-            except OSError:
-                pass # Bad path - return unchanged.
-        elif isinstance(path, bytes):
-            path = os.getcwdb()
-        else:
-            path = os.getcwd()
-        return normpath(path)
+        try:
+            return _getfullpathname(path)
+        except OSError:
+            return _abspath_fallback(path)
 
 # realpath is a no-op on systems without islink support
 realpath = abspath

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -303,6 +303,10 @@ class TestNtpath(unittest.TestCase):
         try:
             import nt
             tester('ntpath.abspath("C:\\")', "C:\\")
+            with support.temp_cwd(support.TESTFN) as cwd_dir: # bpo-31047
+                tester('ntpath.abspath("")', cwd_dir)
+                tester('ntpath.abspath(" ")', cwd_dir + "\\ ")
+                tester('ntpath.abspath("?")', cwd_dir + "\\?")
         except ImportError:
             self.skipTest('nt module not available')
 

--- a/Misc/NEWS.d/next/Library/2018-07-29-14-12-23.bpo-31047.FSarLs.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-29-14-12-23.bpo-31047.FSarLs.rst
@@ -1,0 +1,2 @@
+Fix ``ntpath.abspath`` for invalid paths on windows. Patch by Franz
+Woellert.


### PR DESCRIPTION


<!-- issue-number: [bpo-31047](https://www.bugs.python.org/issue31047) -->
https://bugs.python.org/issue31047
<!-- /issue-number -->
