### PR TITLE
bpo-26440: tarfile._FileInFile.seekable is broken in stream mode

### DIFF
--- a/Lib/tarfile.py
+++ b/Lib/tarfile.py
@@ -500,6 +500,15 @@ class _Stream:
         """
         return self.pos
 
+    def seekable(self):
+        """As negative seeking is forbidden, the returned value
+        is False and True depending what you have in mind.
+        Returning False would say that seeking is always forbidden
+        so we are returning True and it's up to the user to use it
+        wisely.
+        """
+        return True
+
     def seek(self, pos=0):
         """Set the stream's file pointer to pos. Negative seeking
            is forbidden.

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -672,6 +672,7 @@ class StreamReadTest(CommonReadTest, unittest.TestCase):
             if not tarinfo.isreg():
                 continue
             with self.tar.extractfile(tarinfo) as fobj:
+                self.assertTrue(fobj.seekable())
                 while True:
                     try:
                         buf = fobj.read(512)

--- a/Misc/NEWS.d/next/Library/2018-07-29-16-28-25.bpo-26440.HwI8QR.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-29-16-28-25.bpo-26440.HwI8QR.rst
@@ -1,0 +1,2 @@
+Fix tarfile._FileInFile.seekable in stream mode. Patch by Mickaël
+Schoentgen.


### PR DESCRIPTION


<!-- issue-number: [bpo-26440](https://www.bugs.python.org/issue26440) -->
https://bugs.python.org/issue26440
<!-- /issue-number -->
