### PR TITLE
Doc Dash vs EM dash consistency.

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -716,7 +716,7 @@ an explicit ``with`` statement.
 
 .. seealso::
 
-   :pep:`343` - The "with" statement
+   :pep:`343` -- The "with" statement
       The specification, background, and examples for the Python :keyword:`with`
       statement.
 

--- a/Doc/library/csv.rst
+++ b/Doc/library/csv.rst
@@ -38,7 +38,7 @@ using the :class:`DictReader` and :class:`DictWriter` classes.
 
 .. seealso::
 
-   :pep:`305` - CSV File API
+   :pep:`305` -- CSV File API
       The Python Enhancement Proposal which proposed this addition to Python.
 
 

--- a/Doc/library/exceptions.rst
+++ b/Doc/library/exceptions.rst
@@ -662,7 +662,7 @@ depending on the system error code.
 
 .. seealso::
 
-   :pep:`3151` - Reworking the OS and IO exception hierarchy
+   :pep:`3151` -- Reworking the OS and IO exception hierarchy
 
 
 .. _warning-categories-as-exceptions:

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -865,7 +865,7 @@ function.
 
 .. seealso::
 
-   :pep:`362` - Function Signature Object.
+   :pep:`362` -- Function Signature Object.
       The detailed specification, implementation details and examples.
 
 

--- a/Doc/library/logging.rst
+++ b/Doc/library/logging.rst
@@ -1294,7 +1294,7 @@ with the :mod:`warnings` module.
    Module :mod:`logging.handlers`
       Useful handlers included with the logging module.
 
-   :pep:`282` - A Logging System
+   :pep:`282` -- A Logging System
       The proposal which described this feature for inclusion in the Python standard
       library.
 

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -110,7 +110,7 @@ This example uses the iterator form::
    https://www.w3schools.com/sql/
       Tutorial, reference and examples for learning SQL syntax.
 
-   :pep:`249` - Database API Specification 2.0
+   :pep:`249` -- Database API Specification 2.0
       PEP written by Marc-André Lemburg.
 
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -3390,7 +3390,7 @@ Notes:
 
 .. seealso::
 
-   :pep:`461` - Adding % formatting to bytes and bytearray
+   :pep:`461` -- Adding % formatting to bytes and bytearray
 
 .. versionadded:: 3.5
 

--- a/Doc/library/types.rst
+++ b/Doc/library/types.rst
@@ -66,7 +66,7 @@ Dynamic Type Creation
    :ref:`metaclasses`
       Full details of the class creation process supported by these functions
 
-   :pep:`3115` - Metaclasses in Python 3000
+   :pep:`3115` -- Metaclasses in Python 3000
       Introduced the ``__prepare__`` namespace hook
 
 .. function:: resolve_bases(bases)
@@ -84,7 +84,7 @@ Dynamic Type Creation
 
 .. seealso::
 
-   :pep:`560` - Core support for typing module and generic types
+   :pep:`560` -- Core support for typing module and generic types
 
 
 Standard Interpreter Types

--- a/Doc/library/weakref.rst
+++ b/Doc/library/weakref.rst
@@ -330,7 +330,7 @@ objects.
 
 .. seealso::
 
-   :pep:`205` - Weak References
+   :pep:`205` -- Weak References
       The proposal and rationale for this feature, including links to earlier
       implementations and information about similar features in other languages.
 

--- a/Doc/library/zipimport.rst
+++ b/Doc/library/zipimport.rst
@@ -36,12 +36,12 @@ ZIP archives with an archive comment are currently not supported.
       Documentation on the ZIP file format by Phil Katz, the creator of the format and
       algorithms used.
 
-   :pep:`273` - Import Modules from Zip Archives
+   :pep:`273` -- Import Modules from Zip Archives
       Written by James C. Ahlstrom, who also provided an implementation. Python 2.3
       follows the specification in PEP 273, but uses an implementation written by Just
       van Rossum that uses the import hooks described in PEP 302.
 
-   :pep:`302` - New Import Hooks
+   :pep:`302` -- New Import Hooks
       The PEP to add the import hooks that help this module work.
 
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -440,7 +440,7 @@ is equivalent to ::
 
 .. seealso::
 
-   :pep:`343` - The "with" statement
+   :pep:`343` -- The "with" statement
       The specification, background, and examples for the Python :keyword:`with`
       statement.
 
@@ -588,17 +588,17 @@ access the local variables of the function containing the def.  See section
 
 .. seealso::
 
-   :pep:`3107` - Function Annotations
+   :pep:`3107` -- Function Annotations
       The original specification for function annotations.
 
-   :pep:`484` - Type Hints
+   :pep:`484` -- Type Hints
       Definition of a standard meaning for annotations: type hints.
 
-   :pep:`526` - Syntax for Variable Annotations
+   :pep:`526` -- Syntax for Variable Annotations
       Ability to type hint variable declarations, including class
       variables and instance variables
 
-   :pep:`563` - Postponed Evaluation of Annotations
+   :pep:`563` -- Postponed Evaluation of Annotations
       Support for forward references within annotations by preserving
       annotations in a string form at runtime instead of eager evaluation.
 
@@ -681,8 +681,8 @@ can be used to create instance variables with different implementation details.
 
 .. seealso::
 
-   :pep:`3115` - Metaclasses in Python 3
-   :pep:`3129` - Class Decorators
+   :pep:`3115` -- Metaclasses in Python 3
+   :pep:`3129` -- Class Decorators
 
 
 .. _async:
@@ -808,7 +808,7 @@ It is a :exc:`SyntaxError` to use ``async with`` statement outside of an
 
 .. seealso::
 
-   :pep:`492` - Coroutines with async and await syntax
+   :pep:`492` -- Coroutines with async and await syntax
 
 
 .. rubric:: Footnotes

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1596,7 +1596,7 @@ a module object to a subclass of :class:`types.ModuleType`. For example::
 
 .. seealso::
 
-   :pep:`562` - Module __getattr__ and __dir__
+   :pep:`562` -- Module __getattr__ and __dir__
       Describes the ``__getattr__`` and ``__dir__`` functions on modules.
 
 
@@ -1875,7 +1875,7 @@ the original base is ignored.
 
 .. seealso::
 
-   :pep:`560` - Core support for typing module and generic types
+   :pep:`560` -- Core support for typing module and generic types
 
 
 Determining the appropriate metaclass
@@ -1916,7 +1916,7 @@ is initialised as an empty ordered mapping.
 
 .. seealso::
 
-   :pep:`3115` - Metaclasses in Python 3000
+   :pep:`3115` -- Metaclasses in Python 3000
       Introduced the ``__prepare__`` namespace hook
 
 
@@ -1991,7 +1991,7 @@ becomes the :attr:`~object.__dict__` attribute of the class object.
 
 .. seealso::
 
-   :pep:`3135` - New super
+   :pep:`3135` -- New super
       Describes the implicit ``__class__`` closure reference
 
 
@@ -2068,7 +2068,7 @@ case the instance is itself a class.
 
 .. seealso::
 
-   :pep:`3119` - Introducing Abstract Base Classes
+   :pep:`3119` -- Introducing Abstract Base Classes
       Includes the specification for customizing :func:`isinstance` and
       :func:`issubclass` behavior through :meth:`~class.__instancecheck__` and
       :meth:`~class.__subclasscheck__`, with motivation for this functionality
@@ -2094,7 +2094,7 @@ is discouraged.
 
 .. seealso::
 
-   :pep:`560` - Core support for typing module and generic types
+   :pep:`560` -- Core support for typing module and generic types
 
 
 .. _callable-types:
@@ -2488,7 +2488,7 @@ For more information on context managers, see :ref:`typecontextmanager`.
 
 .. seealso::
 
-   :pep:`343` - The "with" statement
+   :pep:`343` -- The "with" statement
       The specification, background, and examples for the Python :keyword:`with`
       statement.
 

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -462,14 +462,14 @@ on the right hand side of an assignment statement.
 
 .. seealso::
 
-   :pep:`255` - Simple Generators
+   :pep:`255` -- Simple Generators
       The proposal for adding generators and the :keyword:`yield` statement to Python.
 
-   :pep:`342` - Coroutines via Enhanced Generators
+   :pep:`342` -- Coroutines via Enhanced Generators
       The proposal to enhance the API and syntax of generators, making them
       usable as simple coroutines.
 
-   :pep:`380` - Syntax for Delegating to a Subgenerator
+   :pep:`380` -- Syntax for Delegating to a Subgenerator
       The proposal to introduce the :token:`yield_from` syntax, making delegation
       to sub-generators easy.
 

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -250,7 +250,7 @@ the following program prints ``[0, 2]``::
 
 .. seealso::
 
-   :pep:`3132` - Extended Iterable Unpacking
+   :pep:`3132` -- Extended Iterable Unpacking
       The specification for the ``*target`` feature.
 
 
@@ -353,8 +353,8 @@ target, then the interpreter evaluates the target except for the last
 
 .. seealso::
 
-   :pep:`526` - Variable and attribute annotation syntax
-   :pep:`484` - Type hints
+   :pep:`526` -- Variable and attribute annotation syntax
+   :pep:`484` -- Type hints
 
 
 .. _assert:
@@ -899,7 +899,7 @@ after the script is executed.
 
 .. seealso::
 
-   :pep:`236` - Back to the __future__
+   :pep:`236` -- Back to the __future__
       The original proposal for the __future__ mechanism.
 
 
@@ -983,5 +983,5 @@ pre-existing bindings in the local scope.
 
 .. seealso::
 
-   :pep:`3104` - Access to Names in Outer Scopes
+   :pep:`3104` -- Access to Names in Outer Scopes
       The specification for the :keyword:`nonlocal` statement.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -1012,5 +1012,5 @@ Other resources
    `A Python for Windows Tutorial <http://www.imladris.com/Scripts/PythonForWindows.html>`_
       by Amanda Birmingham, 2004
 
-   :pep:`397` - Python launcher for Windows
+   :pep:`397` -- Python launcher for Windows
       The proposal for the launcher to be included in the Python distribution.

--- a/Doc/whatsnew/2.1.rst
+++ b/Doc/whatsnew/2.1.rst
@@ -120,7 +120,7 @@ all of 2.1's lifetime to fix any breakage resulting from their introduction.
 
 .. seealso::
 
-   :pep:`227` - Statically Nested Scopes
+   :pep:`227` -- Statically Nested Scopes
       Written and implemented by Jeremy Hylton.
 
 .. ======================================================================
@@ -150,7 +150,7 @@ precede any statement that will result in bytecodes being produced.
 
 .. seealso::
 
-   :pep:`236` - Back to the :mod:`__future__`
+   :pep:`236` -- Back to the :mod:`__future__`
       Written by Tim Peters, and primarily implemented by Jeremy Hylton.
 
 .. ======================================================================
@@ -219,7 +219,7 @@ comparison.  I won't cover the C API here, but will refer you to PEP 207, or to
 
 .. seealso::
 
-   :pep:`207` - Rich Comparisons
+   :pep:`207` -- Rich Comparisons
       Written by Guido van Rossum, heavily based on earlier work by David Ascher, and
       implemented by Guido van Rossum.
 
@@ -286,13 +286,13 @@ Functions were also added to Python's C API for issuing warnings; refer to PEP
 
 .. seealso::
 
-   :pep:`5` - Guidelines for Language Evolution
+   :pep:`5` -- Guidelines for Language Evolution
       Written by Paul Prescod, to specify procedures to be followed when removing old
       features from Python.  The policy described in this PEP hasn't been officially
       adopted, but the eventual policy probably won't be too different from Prescod's
       proposal.
 
-   :pep:`230` - Warning Framework
+   :pep:`230` -- Warning Framework
       Written and implemented by Guido van Rossum.
 
 .. ======================================================================
@@ -332,7 +332,7 @@ simpler.
 
 .. seealso::
 
-   :pep:`229` - Using Distutils to Build Python
+   :pep:`229` -- Using Distutils to Build Python
       Written and implemented by A.M. Kuchling.
 
 .. ======================================================================
@@ -413,7 +413,7 @@ exists.  If the object is deallocated, attempting to use a proxy will cause a
 
 .. seealso::
 
-   :pep:`205` - Weak References
+   :pep:`205` -- Weak References
       Written and implemented by Fred L. Drake, Jr.
 
 .. ======================================================================
@@ -451,7 +451,7 @@ that behaves like a mapping.
 
 .. seealso::
 
-   :pep:`232` - Function Attributes
+   :pep:`232` -- Function Attributes
       Written and implemented by Barry Warsaw.
 
 .. ======================================================================
@@ -499,7 +499,7 @@ pretty-printing function::
 
 .. seealso::
 
-   :pep:`217` - Display Hook for Interactive Use
+   :pep:`217` -- Display Hook for Interactive Use
       Written and implemented by Moshe Zadka.
 
 .. ======================================================================
@@ -529,7 +529,7 @@ object's numeric methods).
 
 .. seealso::
 
-   :pep:`208` - Reworking the Coercion Model
+   :pep:`208` -- Reworking the Coercion Model
       Written and implemented by Neil Schemenauer, heavily based upon earlier work by
       Marc-André Lemburg.  Read this to understand the fine points of how numeric
       operations will now be processed at the C level.
@@ -567,10 +567,10 @@ available from the Distutils SIG at https://www.python.org/community/sigs/curren
 
 .. seealso::
 
-   :pep:`241` - Metadata for Python Software Packages
+   :pep:`241` -- Metadata for Python Software Packages
       Written and implemented by A.M. Kuchling.
 
-   :pep:`243` - Module Repository Upload Mechanism
+   :pep:`243` -- Module Repository Upload Mechanism
       Written by Sean Reifschneider, this draft PEP describes a proposed mechanism for
       uploading  Python packages to a central server.
 

--- a/Doc/whatsnew/2.2.rst
+++ b/Doc/whatsnew/2.2.rst
@@ -531,7 +531,7 @@ requires a :meth:`next` method.
 
 .. seealso::
 
-   :pep:`234` - Iterators
+   :pep:`234` -- Iterators
       Written by Ka-Ping Yee and GvR; implemented  by the Python Labs crew, mostly by
       GvR and Tim Peters.
 
@@ -658,7 +658,7 @@ a data structure.
 
 .. seealso::
 
-   :pep:`255` - Simple Generators
+   :pep:`255` -- Simple Generators
       Written by Neil Schemenauer, Tim Peters, Magnus Lie Hetland.  Implemented mostly
       by Neil Schemenauer and Tim Peters, with other fixes from the Python Labs crew.
 
@@ -698,7 +698,7 @@ rarely needed.
 
 .. seealso::
 
-   :pep:`237` - Unifying Long Integers and Integers
+   :pep:`237` -- Unifying Long Integers and Integers
       Written by Moshe Zadka and Guido van Rossum.  Implemented mostly by Guido van
       Rossum.
 
@@ -767,7 +767,7 @@ Here are the changes 2.2 introduces:
 
 .. seealso::
 
-   :pep:`238` - Changing the Division Operator
+   :pep:`238` -- Changing the Division Operator
       Written by Moshe Zadka and  Guido van Rossum.  Implemented by Guido van Rossum..
 
 .. ======================================================================
@@ -829,7 +829,7 @@ implemented by Fredrik Lundh and Martin von Löwis.
 
 .. seealso::
 
-   :pep:`261` - Support for 'wide' Unicode characters
+   :pep:`261` -- Support for 'wide' Unicode characters
       Written by Paul Prescod.
 
 .. ======================================================================
@@ -924,7 +924,7 @@ anyway).
 
 .. seealso::
 
-   :pep:`227` - Statically Nested Scopes
+   :pep:`227` -- Statically Nested Scopes
       Written and implemented by Jeremy Hylton.
 
 .. ======================================================================

--- a/Doc/whatsnew/2.3.rst
+++ b/Doc/whatsnew/2.3.rst
@@ -113,7 +113,7 @@ whether one set is a subset or superset of another::
 
 .. seealso::
 
-   :pep:`218` - Adding a Built-In Set Object Type
+   :pep:`218` -- Adding a Built-In Set Object Type
       PEP written by Greg V. Wilson. Implemented by Greg V. Wilson, Alex Martelli, and
       GvR.
 
@@ -244,7 +244,7 @@ a data structure.
 
 .. seealso::
 
-   :pep:`255` - Simple Generators
+   :pep:`255` -- Simple Generators
       Written by Neil Schemenauer, Tim Peters, Magnus Lie Hetland.  Implemented mostly
       by Neil Schemenauer and Tim Peters, with other fixes from the Python Labs crew.
 
@@ -278,7 +278,7 @@ use characters outside of the usual alphanumerics.
 
 .. seealso::
 
-   :pep:`263` - Defining Python Source Code Encodings
+   :pep:`263` -- Defining Python Source Code Encodings
       Written by Marc-André Lemburg and Martin von Löwis; implemented by Suzuki Hisao
       and Martin von Löwis.
 
@@ -325,7 +325,7 @@ import from the :file:`lib/` subdirectory within the archive.
 
 .. seealso::
 
-   :pep:`273` - Import Modules from Zip Archives
+   :pep:`273` -- Import Modules from Zip Archives
       Written by James C. Ahlstrom,  who also provided an implementation. Python 2.3
       follows the specification in :pep:`273`,  but uses an implementation written by
       Just van Rossum  that uses the import hooks described in :pep:`302`. See section
@@ -361,7 +361,7 @@ Under MacOS, :func:`os.listdir` may now return Unicode filenames.
 
 .. seealso::
 
-   :pep:`277` - Unicode file name support for Windows NT
+   :pep:`277` -- Unicode file name support for Windows NT
       Written by Neil Hodgson; implemented by Neil Hodgson, Martin von Löwis, and Mark
       Hammond.
 
@@ -400,7 +400,7 @@ This feature can be disabled when compiling Python by specifying the
 
 .. seealso::
 
-   :pep:`278` - Universal Newline Support
+   :pep:`278` -- Universal Newline Support
       Written and implemented by Jack Jansen.
 
 .. ======================================================================
@@ -432,7 +432,7 @@ This can be rewritten using :func:`enumerate` as::
 
 .. seealso::
 
-   :pep:`279` - The enumerate() built-in function
+   :pep:`279` -- The enumerate() built-in function
       Written and implemented by Raymond D. Hettinger.
 
 .. ======================================================================
@@ -538,7 +538,7 @@ documentation for all of the details.  Reading :pep:`282` will also be helpful.
 
 .. seealso::
 
-   :pep:`282` - A Logging System
+   :pep:`282` -- A Logging System
       Written by Vinay Sajip and Trent Mick; implemented by Vinay Sajip.
 
 .. ======================================================================
@@ -610,7 +610,7 @@ instead of ``'1'`` and ``'0'``.
 
 .. seealso::
 
-   :pep:`285` - Adding a bool type
+   :pep:`285` -- Adding a bool type
       Written and implemented by GvR.
 
 .. ======================================================================
@@ -642,7 +642,7 @@ characters and "xmlcharrefreplace" emits XML character references.
 
 .. seealso::
 
-   :pep:`293` - Codec Error Handling Callbacks
+   :pep:`293` -- Codec Error Handling Callbacks
       Written and implemented by Walter Dörwald.
 
 .. ======================================================================
@@ -691,7 +691,7 @@ register --list-classifiers``.
 
 .. seealso::
 
-   :pep:`301` - Package Index and Metadata for Distutils
+   :pep:`301` -- Package Index and Metadata for Distutils
       Written and implemented by Richard Jones.
 
 .. ======================================================================
@@ -757,7 +757,7 @@ Pseudo-code for Python's new import logic, therefore, looks something like this
 
 .. seealso::
 
-   :pep:`302` - New Import Hooks
+   :pep:`302` -- New Import Hooks
       Written by Just van Rossum and Paul Moore. Implemented by Just van Rossum.
 
 .. ======================================================================
@@ -802,7 +802,7 @@ of tuples or lists, quoting strings that contain the delimiter.
 
 .. seealso::
 
-   :pep:`305` - CSV File API
+   :pep:`305` -- CSV File API
       Written and implemented  by Kevin Altis, Dave Cole, Andrew McNamara, Skip
       Montanaro, Cliff Wells.
 
@@ -846,7 +846,7 @@ codes for private use.  Currently no codes have been specified.
 
 .. seealso::
 
-   :pep:`307` - Extensions to the pickle protocol
+   :pep:`307` -- Extensions to the pickle protocol
       Written and implemented  by Guido van Rossum and Tim Peters.
 
 .. ======================================================================

--- a/Doc/whatsnew/2.4.rst
+++ b/Doc/whatsnew/2.4.rst
@@ -79,7 +79,7 @@ currently no plans to deprecate the module.
 
 .. seealso::
 
-   :pep:`218` - Adding a Built-In Set Object Type
+   :pep:`218` -- Adding a Built-In Set Object Type
       Originally proposed by Greg Wilson and ultimately implemented by Raymond
       Hettinger.
 
@@ -104,7 +104,7 @@ the correct answer, 8589934592.
 
 .. seealso::
 
-   :pep:`237` - Unifying Long Integers and Integers
+   :pep:`237` -- Unifying Long Integers and Integers
       Original PEP written by Moshe Zadka and GvR.  The changes for 2.4 were
       implemented by  Kalle Svensson.
 
@@ -161,7 +161,7 @@ list comprehensions match generator expressions in this respect.
 
 .. seealso::
 
-   :pep:`289` - Generator Expressions
+   :pep:`289` -- Generator Expressions
       Proposed by Raymond Hettinger and implemented by Jiwon Seo with early efforts
       steered by Hye-Shik Chang.
 
@@ -208,7 +208,7 @@ ignores missing keys::
 
 .. seealso::
 
-   :pep:`292` - Simpler String Substitutions
+   :pep:`292` -- Simpler String Substitutions
       Written and implemented  by Barry Warsaw.
 
 .. ======================================================================
@@ -332,7 +332,7 @@ returned.
 
 .. seealso::
 
-   :pep:`318` - Decorators for Functions, Methods and Classes
+   :pep:`318` -- Decorators for Functions, Methods and Classes
       Written  by Kevin D. Smith, Jim Jewett, and Skip Montanaro.  Several people
       wrote patches implementing function decorators, but the one that was actually
       checked in was patch #979728, written by Mark Russell.
@@ -373,7 +373,7 @@ you want to reverse an iterator, first convert it to  a list with :func:`list`.
 
 .. seealso::
 
-   :pep:`322` - Reverse Iteration
+   :pep:`322` -- Reverse Iteration
       Written and implemented by Raymond Hettinger.
 
 .. ======================================================================
@@ -461,7 +461,7 @@ of the PEP is highly recommended.
 
 .. seealso::
 
-   :pep:`324` - subprocess - New process module
+   :pep:`324` -- subprocess - New process module
       Written and implemented by Peter Åstrand, with assistance from Fredrik Lundh and
       others.
 
@@ -679,7 +679,7 @@ includes a quick-start tutorial and a reference.
 
 .. seealso::
 
-   :pep:`327` - Decimal Data Type
+   :pep:`327` -- Decimal Data Type
       Written by Facundo Batista and implemented by Facundo Batista, Eric Price,
       Raymond Hettinger, Aahz, and Tim Peters.
 
@@ -725,7 +725,7 @@ PEP was not implemented for Python 2.4, but was completed for Python 2.5.
 
 .. seealso::
 
-   :pep:`328` - Imports: Multi-Line and Absolute/Relative
+   :pep:`328` -- Imports: Multi-Line and Absolute/Relative
       Written by Aahz.  Multi-line imports were implemented by Dima Dorfman.
 
 .. ======================================================================
@@ -764,7 +764,7 @@ letting extensions such as GTK+  produce the correct results.
 
 .. seealso::
 
-   :pep:`331` - Locale-Independent Float/String Conversions
+   :pep:`331` -- Locale-Independent Float/String Conversions
       Written by Christian R. Reis, and implemented by Gustavo Carneiro.
 
 .. ======================================================================

--- a/Doc/whatsnew/2.5.rst
+++ b/Doc/whatsnew/2.5.rst
@@ -119,7 +119,7 @@ conditional expressions, you won't run into this case.
 
 .. seealso::
 
-   :pep:`308` - Conditional Expressions
+   :pep:`308` -- Conditional Expressions
       PEP written by Guido van Rossum and Raymond D. Hettinger; implemented by Thomas
       Wouters.
 
@@ -197,7 +197,7 @@ example would be::
 
 .. seealso::
 
-   :pep:`309` - Partial Function Application
+   :pep:`309` -- Partial Function Application
       PEP proposed and written by Peter Harris; implemented by Hye-Shik Chang and Nick
       Coghlan, with adaptations by Raymond Hettinger.
 
@@ -244,7 +244,7 @@ Package uploading was implemented by Martin von Löwis and Richard Jones.
 
 .. seealso::
 
-   :pep:`314` - Metadata for Python Software Packages v1.1
+   :pep:`314` -- Metadata for Python Software Packages v1.1
       PEP proposed and written by A.M. Kuchling, Richard Jones, and Fred Drake;
       implemented by Richard Jones and Fred Drake.
 
@@ -327,7 +327,7 @@ statement, only the ``from ... import`` form.
 
 .. seealso::
 
-   :pep:`328` - Imports: Multi-Line and Absolute/Relative
+   :pep:`328` -- Imports: Multi-Line and Absolute/Relative
       PEP written by Aahz; implemented by Thomas Wouters.
 
    https://pylib.readthedocs.io/
@@ -356,7 +356,7 @@ archive.
 
 .. seealso::
 
-   :pep:`338` - Executing modules as scripts
+   :pep:`338` -- Executing modules as scripts
       PEP written and  implemented by Nick Coghlan.
 
 .. ======================================================================
@@ -404,7 +404,7 @@ in the *final-block* is still run.
 
 .. seealso::
 
-   :pep:`341` - Unifying try-except and try-finally
+   :pep:`341` -- Unifying try-except and try-finally
       PEP written by Georg Brandl;  implementation by Thomas Lee.
 
 .. ======================================================================
@@ -540,7 +540,7 @@ exhausted.
 
 .. seealso::
 
-   :pep:`342` - Coroutines via Enhanced Generators
+   :pep:`342` -- Coroutines via Enhanced Generators
       PEP written by  Guido van Rossum and Phillip J. Eby; implemented by Phillip J.
       Eby.  Includes examples of  some fancier uses of generators as coroutines.
 
@@ -795,7 +795,7 @@ bound to a variable, and calls ``object.close`` at the end of the block. ::
 
 .. seealso::
 
-   :pep:`343` - The "with" statement
+   :pep:`343` -- The "with" statement
       PEP written by Guido van Rossum and Nick Coghlan; implemented by Mike Bland,
       Guido van Rossum, and Neal Norwitz.  The PEP shows the code generated for a
       ':keyword:`with`' statement, which can be helpful in learning how the statement
@@ -859,7 +859,7 @@ to be able to remove the string-exception feature in a few releases.
 
 .. seealso::
 
-   :pep:`352` - Required Superclass for Exceptions
+   :pep:`352` -- Required Superclass for Exceptions
       PEP written by  Brett Cannon and Guido van Rossum; implemented by Brett Cannon.
 
 .. ======================================================================
@@ -918,7 +918,7 @@ read to learn about supporting 64-bit platforms.
 
 .. seealso::
 
-   :pep:`353` - Using ssize_t as the index type
+   :pep:`353` -- Using ssize_t as the index type
       PEP written and implemented by Martin von Löwis.
 
 .. ======================================================================
@@ -961,7 +961,7 @@ A corresponding :attr:`nb_index` slot was added to the C-level
 
 .. seealso::
 
-   :pep:`357` - Allowing Any Object to be Used for Slicing
+   :pep:`357` -- Allowing Any Object to be Used for Slicing
       PEP written  and implemented by Travis Oliphant.
 
 .. ======================================================================
@@ -2027,7 +2027,7 @@ https://www.sqlite.org.
 
    The documentation  for the :mod:`sqlite3` module.
 
-   :pep:`249` - Database API Specification 2.0
+   :pep:`249` -- Database API Specification 2.0
       PEP written by Marc-André Lemburg.
 
 .. ======================================================================
@@ -2067,7 +2067,7 @@ up a server takes only a few lines of code::
    http://www.wsgi.org
       A central web site for WSGI-related resources.
 
-   :pep:`333` - Python Web Server Gateway Interface v1.0
+   :pep:`333` -- Python Web Server Gateway Interface v1.0
       PEP written by Phillip J. Eby.
 
 .. ======================================================================

--- a/Doc/whatsnew/2.6.rst
+++ b/Doc/whatsnew/2.6.rst
@@ -485,7 +485,7 @@ of the block. ::
 
 .. seealso::
 
-   :pep:`343` - The "with" statement
+   :pep:`343` -- The "with" statement
       PEP written by Guido van Rossum and Nick Coghlan; implemented by Mike Bland,
       Guido van Rossum, and Neal Norwitz.  The PEP shows the code generated for a
       ':keyword:`with`' statement, which can be helpful in learning how the statement
@@ -549,7 +549,7 @@ environment variable.
 
 .. seealso::
 
-   :pep:`370` - Per-user ``site-packages`` Directory
+   :pep:`370` -- Per-user ``site-packages`` Directory
      PEP written and implemented by Christian Heimes.
 
 
@@ -705,7 +705,7 @@ This will produce the output::
 
    The documentation for the :mod:`multiprocessing` module.
 
-   :pep:`371` - Addition of the multiprocessing package
+   :pep:`371` -- Addition of the multiprocessing package
      PEP written by Jesse Noller and Richard Oudkerk;
      implemented by Richard Oudkerk and Jesse Noller.
 
@@ -848,7 +848,7 @@ provided specifier::
    :ref:`formatstrings`
       The reference documentation for format fields.
 
-   :pep:`3101` - Advanced String Formatting
+   :pep:`3101` -- Advanced String Formatting
       PEP written by Talin. Implemented by Eric Smith.
 
 .. ======================================================================
@@ -883,7 +883,7 @@ The parameters are:
 
 .. seealso::
 
-   :pep:`3105` - Make print a function
+   :pep:`3105` -- Make print a function
       PEP written by Georg Brandl.
 
 .. ======================================================================
@@ -934,7 +934,7 @@ that will only be executed with 2.6.
 
 .. seealso::
 
-   :pep:`3110` - Catching Exceptions in Python 3000
+   :pep:`3110` -- Catching Exceptions in Python 3000
       PEP written and implemented by Collin Winter.
 
 .. ======================================================================
@@ -1018,7 +1018,7 @@ and various other functions.
 
 .. seealso::
 
-   :pep:`3112` - Bytes literals in Python 3000
+   :pep:`3112` -- Bytes literals in Python 3000
       PEP written by Jason Orendorff; backported to 2.6 by Christian Heimes.
 
 .. ======================================================================
@@ -1098,7 +1098,7 @@ their own implementations of buffering and text I/O.
 
 .. seealso::
 
-   :pep:`3116` - New I/O
+   :pep:`3116` -- New I/O
       PEP written by Daniel Stutzbach, Mike Verdone, and Guido van Rossum.
       Code by Guido van Rossum, Georg Brandl, Walter Doerwald,
       Jeremy Hylton, Martin von Löwis, Tony Lownds, and others.
@@ -1151,7 +1151,7 @@ Two new argument codes for :c:func:`PyArg_ParseTuple`,
 
 .. seealso::
 
-   :pep:`3118` - Revising the buffer protocol
+   :pep:`3118` -- Revising the buffer protocol
       PEP written by Travis Oliphant and Carl Banks; implemented by
       Travis Oliphant.
 
@@ -1298,7 +1298,7 @@ Subclasses must then define a :meth:`readonly` property.
 
 .. seealso::
 
-   :pep:`3119` - Introducing Abstract Base Classes
+   :pep:`3119` -- Introducing Abstract Base Classes
       PEP written by Guido van Rossum and Talin.
       Implemented by Guido van Rossum.
       Backported to 2.6 by Benjamin Aranguren, with Alex Martelli.
@@ -1351,7 +1351,7 @@ determined from the string)::
 
 .. seealso::
 
-   :pep:`3127` - Integer Literal Support and Syntax
+   :pep:`3127` -- Integer Literal Support and Syntax
       PEP written by Patrick Maupin; backported to 2.6 by
       Eric Smith.
 
@@ -1379,7 +1379,7 @@ This is equivalent to::
 
 .. seealso::
 
-   :pep:`3129` - Class Decorators
+   :pep:`3129` -- Class Decorators
       PEP written by Collin Winter.
 
 .. ======================================================================
@@ -1428,7 +1428,7 @@ one, :func:`math.trunc`, that's been backported to Python 2.6.
 
 .. seealso::
 
-   :pep:`3141` - A Type Hierarchy for Numbers
+   :pep:`3141` -- A Type Hierarchy for Numbers
       PEP written by Jeffrey Yasskin.
 
    `Scheme's numerical tower <https://www.gnu.org/software/guile/manual/html_node/Numerical-Tower.html#Numerical-Tower>`__, from the Guile manual.

--- a/Doc/whatsnew/2.7.rst
+++ b/Doc/whatsnew/2.7.rst
@@ -303,7 +303,7 @@ modules.
 
 .. seealso::
 
-   :pep:`372` - Adding an ordered dictionary to collections
+   :pep:`372` -- Adding an ordered dictionary to collections
      PEP written by Armin Ronacher and Raymond Hettinger;
      implemented by Raymond Hettinger.
 
@@ -342,7 +342,7 @@ module, but it's easier to use.
 
 .. seealso::
 
-   :pep:`378` - Format Specifier for Thousands Separator
+   :pep:`378` -- Format Specifier for Thousands Separator
      PEP written by Raymond Hettinger; implemented by Eric Smith.
 
 PEP 389: The argparse Module for Parsing Command Lines
@@ -441,7 +441,7 @@ standard input or output.
      Part of the Python documentation, describing how to convert
      code that uses :mod:`optparse`.
 
-   :pep:`389` - argparse - New Command Line Parsing Module
+   :pep:`389` -- argparse - New Command Line Parsing Module
      PEP written and implemented by Steven Bethard.
 
 PEP 391: Dictionary-Based Configuration For Logging
@@ -541,7 +541,7 @@ implemented by Vinay Sajip, are:
 
 .. seealso::
 
-   :pep:`391` - Dictionary-Based Configuration For Logging
+   :pep:`391` -- Dictionary-Based Configuration For Logging
      PEP written and implemented by Vinay Sajip.
 
 PEP 3106: Dictionary Views
@@ -602,7 +602,7 @@ converter will change them to the standard :meth:`~dict.keys`,
 
 .. seealso::
 
-   :pep:`3106` - Revamping dict.keys(), .values() and .items()
+   :pep:`3106` -- Revamping dict.keys(), .values() and .items()
      PEP written by Guido van Rossum.
      Backported to 2.7 by Alexandre Vassalotti; :issue:`1967`.
 
@@ -661,7 +661,7 @@ it's a mutable object.
 
 .. seealso::
 
-   :pep:`3137` - Immutable Bytes and Mutable Buffer
+   :pep:`3137` -- Immutable Bytes and Mutable Buffer
      PEP written by Guido van Rossum.
      Implemented by Travis Oliphant, Antoine Pitrou and others.
      Backported to 2.7 by Antoine Pitrou; :issue:`2396`.

--- a/Doc/whatsnew/3.1.rst
+++ b/Doc/whatsnew/3.1.rst
@@ -75,7 +75,7 @@ Support was also added for third-party tools like `PyYAML <http://pyyaml.org/>`_
 
 .. seealso::
 
-   :pep:`372` - Ordered Dictionaries
+   :pep:`372` -- Ordered Dictionaries
       PEP written by Armin Ronacher and Raymond Hettinger.  Implementation
       written by Raymond Hettinger.
 
@@ -107,7 +107,7 @@ for thousands separators.
 
 .. seealso::
 
-   :pep:`378` - Format Specifier for Thousands Separator
+   :pep:`378` -- Format Specifier for Thousands Separator
       PEP written by Raymond Hettinger and implemented by Eric Smith and
       Mark Dickinson.
 

--- a/Doc/whatsnew/3.2.rst
+++ b/Doc/whatsnew/3.2.rst
@@ -54,7 +54,7 @@ focuses on a few highlights and gives a few examples.  For full details, see the
 
 .. seealso::
 
-   :pep:`392` - Python 3.2 Release Schedule
+   :pep:`392` -- Python 3.2 Release Schedule
 
 
 PEP 384: Defining a Stable ABI
@@ -77,7 +77,7 @@ need to be recompiled for every feature release.
 
 .. seealso::
 
-   :pep:`384` - Defining a Stable ABI
+   :pep:`384` -- Defining a Stable ABI
       PEP written by Martin von Löwis.
 
 
@@ -169,7 +169,7 @@ each with their own argument patterns and help displays::
 
 .. seealso::
 
-   :pep:`389` - New Command Line Parsing Module
+   :pep:`389` -- New Command Line Parsing Module
       PEP written by Steven Bethard.
 
    :ref:`upgrading-optparse-code` for details on the differences from :mod:`optparse`.
@@ -224,7 +224,7 @@ loaded and called with code like this::
 
 .. seealso::
 
-   :pep:`391` - Dictionary Based Configuration for Logging
+   :pep:`391` -- Dictionary Based Configuration for Logging
       PEP written by Vinay Sajip.
 
 
@@ -275,7 +275,7 @@ launch of four parallel threads for copying files::
 
 .. seealso::
 
-   :pep:`3148` - Futures -- Execute Computations Asynchronously
+   :pep:`3148` -- Futures -- Execute Computations Asynchronously
       PEP written by Brian Quinlan.
 
    :ref:`Code for Threaded Parallel URL reads<threadpoolexecutor-example>`, an
@@ -347,7 +347,7 @@ aspects that are visible to the programmer:
 
 .. seealso::
 
-   :pep:`3147` - PYC Repository Directories
+   :pep:`3147` -- PYC Repository Directories
       PEP written by Barry Warsaw.
 
 
@@ -378,7 +378,7 @@ module::
 
 .. seealso::
 
-   :pep:`3149` - ABI Version Tagged .so Files
+   :pep:`3149` -- ABI Version Tagged .so Files
       PEP written by Barry Warsaw.
 
 
@@ -425,7 +425,7 @@ this gap, the :mod:`wsgiref` module has a new function,
 
 .. seealso::
 
-   :pep:`3333` - Python Web Server Gateway Interface v1.0.1
+   :pep:`3333` -- Python Web Server Gateway Interface v1.0.1
       PEP written by Phillip Eby.
 
 

--- a/Doc/whatsnew/3.3.rst
+++ b/Doc/whatsnew/3.3.rst
@@ -48,7 +48,7 @@ see the `changelog <https://docs.python.org/3.3/whatsnew/changelog.html>`_.
 
 .. seealso::
 
-    :pep:`398` - Python 3.3 Release Schedule
+    :pep:`398` -- Python 3.3 Release Schedule
 
 
 Summary -- Release highlights
@@ -115,7 +115,7 @@ tree.
 
 .. seealso::
 
-    :pep:`405` - Python Virtual Environments
+    :pep:`405` -- Python Virtual Environments
        PEP written by Carl Meyer; implementation by Carl Meyer and Vinay Sajip
 
 
@@ -129,7 +129,7 @@ various third party approaches to namespace packages, as described in
 
 .. seealso::
 
-   :pep:`420` - Implicit Namespace Packages
+   :pep:`420` -- Implicit Namespace Packages
       PEP written by Eric V. Smith; implementation by Eric V. Smith
       and Barry Warsaw
 
@@ -200,7 +200,7 @@ API changes
 
 .. seealso::
 
-   :pep:`3118` - Revising the Buffer Protocol
+   :pep:`3118` -- Revising the Buffer Protocol
 
 
 .. _pep-393:
@@ -279,7 +279,7 @@ details).
 
 .. seealso::
 
-   :pep:`393` - Flexible String Representation
+   :pep:`393` -- Flexible String Representation
       PEP written by Martin von Löwis; implementation by Torsten Becker
       and Martin von Löwis.
 
@@ -312,7 +312,7 @@ by Brian Curtin in :issue:`3561`.)
 
 .. seealso::
 
-   :pep:`397` - Python Launcher for Windows
+   :pep:`397` -- Python Launcher for Windows
       PEP written by Mark Hammond and Martin v. Löwis; implementation by
       Vinay Sajip.
 
@@ -389,7 +389,7 @@ inspection of exception attributes::
 
 .. seealso::
 
-   :pep:`3151` - Reworking the OS and IO Exception Hierarchy
+   :pep:`3151` -- Reworking the OS and IO Exception Hierarchy
       PEP written and implemented by Antoine Pitrou
 
 
@@ -459,7 +459,7 @@ multiple subfunctions.
 
 .. seealso::
 
-   :pep:`380` - Syntax for Delegating to a Subgenerator
+   :pep:`380` -- Syntax for Delegating to a Subgenerator
       PEP written by Greg Ewing; implementation by Greg Ewing, integrated into
       3.3 by Renaud Blanch, Ryan Kelly and Nick Coghlan; documentation by
       Zbigniew Jędrzejewski-Szmek and Nick Coghlan
@@ -524,7 +524,7 @@ suppressed valuable underlying details)::
 
 .. seealso::
 
-   :pep:`409` - Suppressing exception context
+   :pep:`409` -- Suppressing exception context
       PEP written by Ethan Furman; implemented by Ethan Furman and Nick
       Coghlan.
 
@@ -542,7 +542,7 @@ separation of binary and text data).
 
 .. seealso::
 
-   :pep:`414` - Explicit Unicode literals
+   :pep:`414` -- Explicit Unicode literals
       PEP written by Armin Ronacher.
 
 
@@ -603,7 +603,7 @@ new, more precise information::
 
 .. seealso::
 
-   :pep:`3155` - Qualified name for classes and functions
+   :pep:`3155` -- Qualified name for classes and functions
       PEP written and implemented by Antoine Pitrou.
 
 
@@ -619,7 +619,7 @@ consumption of programs creating many instances of non-builtin types.
 
 .. seealso::
 
-   :pep:`412` - Key-Sharing Dictionary
+   :pep:`412` -- Key-Sharing Dictionary
       PEP written and implemented by Mark Shannon.
 
 
@@ -675,7 +675,7 @@ through normal attribute access.
 
 .. seealso::
 
-   :pep:`421` - Adding sys.implementation
+   :pep:`421` -- Adding sys.implementation
       PEP written and implemented by Eric Snow.
 
 

--- a/Doc/whatsnew/3.5.rst
+++ b/Doc/whatsnew/3.5.rst
@@ -51,7 +51,7 @@ list of changes.
 
 .. seealso::
 
-    :pep:`478` - Python 3.5 Release Schedule
+    :pep:`478` -- Python 3.5 Release Schedule
 
 
 Summary -- Release highlights

--- a/Doc/whatsnew/3.6.rst
+++ b/Doc/whatsnew/3.6.rst
@@ -51,7 +51,7 @@ list of changes.
 
 .. seealso::
 
-    :pep:`494` - Python 3.6 Release Schedule
+    :pep:`494` -- Python 3.6 Release Schedule
 
 
 Summary -- Release highlights


### PR DESCRIPTION
There was a mix [1] of dash and emdash to separate a PEP and its title, I mean:

    :pep:`305` - CSV File API

vs

    :pep:`305` -- CSV File API

I think emdash fits better here, so I replaced dashes to emdashes using:

    sed -i 's/\(:pep:`[0-9]*`\) - /\1 -- /' Doc/**/*.rst

[1] the mix was:
```
$ git grep ':pep:`[0-9]*` - ' Doc/ | wc -l
    135     
$ git grep ':pep:`[0-9]*` -- ' Doc/ | wc -l
     67     
```