### PR TITLE
Remove unused variable from functools

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -558,7 +558,6 @@ def _lru_cache_wrapper(user_function, maxsize, typed, _CacheInfo):
                     # still adjusting the links.
                     root = oldroot[NEXT]
                     oldkey = root[KEY]
-                    oldresult = root[RESULT]
                     root[KEY] = root[RESULT] = None
                     # Now update the cache dictionary.
                     del cache[oldkey]


### PR DESCRIPTION
There was an unnecessary `oldresult` variable in the `_lru_cache_wrapper` method. This variable first time was committed in python3.3 and never used in the code. I removed the declaration.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
