### PR TITLE
bpo-34280: do not use second argument of METH_NOARGS functions

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -178,8 +178,8 @@ can be combined with a binding flag.
    Methods without parameters don't need to check whether arguments are given if
    they are listed with the :const:`METH_NOARGS` flag.  They need to be of type
    :c:type:`PyCFunction`.  The first parameter is typically named *self* and will
-   hold a reference to the module or object instance.  In all cases the second
-   parameter will be *NULL*.
+   hold a reference to the module or object instance.  The second parameter must
+   not be used: it is unspecified what its value is.
 
 
 .. data:: METH_O

--- a/Misc/NEWS.d/next/C API/2018-07-30-13-58-08.bpo-34280.HKr4HC.rst
+++ b/Misc/NEWS.d/next/C API/2018-07-30-13-58-08.bpo-34280.HKr4HC.rst
@@ -1,0 +1,2 @@
+The second argument of a C function with signature METH_NOARGS is no longer
+guaranteed to be NULL.

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -403,7 +403,7 @@ buffered_dealloc(buffered *self)
 }
 
 static PyObject *
-buffered_sizeof(buffered *self, void *unused)
+buffered_sizeof(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     Py_ssize_t res;
 
@@ -540,7 +540,7 @@ end:
 /* detach */
 
 static PyObject *
-buffered_detach(buffered *self, PyObject *args)
+buffered_detach(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *raw, *res;
     CHECK_INITIALIZED(self)
@@ -558,21 +558,21 @@ buffered_detach(buffered *self, PyObject *args)
 /* Inquiries */
 
 static PyObject *
-buffered_seekable(buffered *self, PyObject *args)
+buffered_seekable(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
     return PyObject_CallMethodObjArgs(self->raw, _PyIO_str_seekable, NULL);
 }
 
 static PyObject *
-buffered_readable(buffered *self, PyObject *args)
+buffered_readable(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
     return PyObject_CallMethodObjArgs(self->raw, _PyIO_str_readable, NULL);
 }
 
 static PyObject *
-buffered_writable(buffered *self, PyObject *args)
+buffered_writable(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
     return PyObject_CallMethodObjArgs(self->raw, _PyIO_str_writable, NULL);
@@ -595,14 +595,14 @@ buffered_mode_get(buffered *self, void *context)
 /* Lower-level APIs */
 
 static PyObject *
-buffered_fileno(buffered *self, PyObject *args)
+buffered_fileno(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
     return PyObject_CallMethodObjArgs(self->raw, _PyIO_str_fileno, NULL);
 }
 
 static PyObject *
-buffered_isatty(buffered *self, PyObject *args)
+buffered_isatty(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     CHECK_INITIALIZED(self)
     return PyObject_CallMethodObjArgs(self->raw, _PyIO_str_isatty, NULL);
@@ -611,7 +611,7 @@ buffered_isatty(buffered *self, PyObject *args)
 /* Serialization */
 
 static PyObject *
-buffered_getstate(buffered *self, PyObject *args)
+buffered_getstate(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     PyErr_Format(PyExc_TypeError,
                  "cannot serialize '%s' object", Py_TYPE(self)->tp_name);
@@ -1202,7 +1202,7 @@ _io__Buffered_readline_impl(buffered *self, Py_ssize_t size)
 
 
 static PyObject *
-buffered_tell(buffered *self, PyObject *args)
+buffered_tell(buffered *self, PyObject *Py_UNUSED(ignored))
 {
     Py_off_t pos;
 
@@ -2207,33 +2207,33 @@ bufferedrwpair_write(rwpair *self, PyObject *args)
 }
 
 static PyObject *
-bufferedrwpair_flush(rwpair *self, PyObject *args)
+bufferedrwpair_flush(rwpair *self, PyObject *Py_UNUSED(ignored))
 {
-    return _forward_call(self->writer, &PyId_flush, args);
+    return _forward_call(self->writer, &PyId_flush, NULL);
 }
 
 static PyObject *
-bufferedrwpair_readable(rwpair *self, PyObject *args)
+bufferedrwpair_readable(rwpair *self, PyObject *Py_UNUSED(ignored))
 {
-    return _forward_call(self->reader, &PyId_readable, args);
+    return _forward_call(self->reader, &PyId_readable, NULL);
 }
 
 static PyObject *
-bufferedrwpair_writable(rwpair *self, PyObject *args)
+bufferedrwpair_writable(rwpair *self, PyObject *Py_UNUSED(ignored))
 {
-    return _forward_call(self->writer, &PyId_writable, args);
+    return _forward_call(self->writer, &PyId_writable, NULL);
 }
 
 static PyObject *
-bufferedrwpair_close(rwpair *self, PyObject *args)
+bufferedrwpair_close(rwpair *self, PyObject *Py_UNUSED(ignored))
 {
     PyObject *exc = NULL, *val, *tb;
-    PyObject *ret = _forward_call(self->writer, &PyId_close, args);
+    PyObject *ret = _forward_call(self->writer, &PyId_close, NULL);
     if (ret == NULL)
         PyErr_Fetch(&exc, &val, &tb);
     else
         Py_DECREF(ret);
-    ret = _forward_call(self->reader, &PyId_close, args);
+    ret = _forward_call(self->reader, &PyId_close, NULL);
     if (exc != NULL) {
         _PyErr_ChainExceptions(exc, val, tb);
         Py_CLEAR(ret);
@@ -2242,9 +2242,9 @@ bufferedrwpair_close(rwpair *self, PyObject *args)
 }
 
 static PyObject *
-bufferedrwpair_isatty(rwpair *self, PyObject *args)
+bufferedrwpair_isatty(rwpair *self, PyObject *Py_UNUSED(ignored))
 {
-    PyObject *ret = _forward_call(self->writer, &PyId_isatty, args);
+    PyObject *ret = _forward_call(self->writer, &PyId_isatty, NULL);
 
     if (ret != Py_False) {
         /* either True or exception */
@@ -2252,7 +2252,7 @@ bufferedrwpair_isatty(rwpair *self, PyObject *args)
     }
     Py_DECREF(ret);
 
-    return _forward_call(self->reader, &PyId_isatty, args);
+    return _forward_call(self->reader, &PyId_isatty, NULL);
 }
 
 static PyObject *


### PR DESCRIPTION


<!-- issue-number: [bpo-34280](https://www.bugs.python.org/issue34280) -->
https://bugs.python.org/issue34280
<!-- /issue-number -->
