### PR TITLE
bpo-31658: Make xml.sax.parse accepting Path objects

### DIFF
--- a/Doc/library/xml.sax.reader.rst
+++ b/Doc/library/xml.sax.reader.rst
@@ -102,12 +102,15 @@ The :class:`XMLReader` interface supports the following methods:
 
    Process an input source, producing SAX events. The *source* object can be a
    system identifier (a string identifying the input source -- typically a file
-   name or a URL), a file-like object, or an :class:`InputSource` object. When
-   :meth:`parse` returns, the input is completely processed, and the parser object
-   can be discarded or reset.
+   name or a URL), a :class:`~pathlib.Path` object, a file-like object or an
+   :class:`InputSource` object. When :meth:`parse` returns, the input is
+   completely processed, and the parser object can be discarded or reset.
 
    .. versionchanged:: 3.5
       Added support of character streams.
+
+   .. versionchanged:: 3.8
+      Added support of :class:`~pathlib.Path` objects.
 
 
 .. method:: XMLReader.getContentHandler()

--- a/Doc/library/xml.sax.reader.rst
+++ b/Doc/library/xml.sax.reader.rst
@@ -102,8 +102,8 @@ The :class:`XMLReader` interface supports the following methods:
 
    Process an input source, producing SAX events. The *source* object can be a
    system identifier (a string identifying the input source -- typically a file
-   name or a URL), a :class:`~pathlib.Path` object, a file-like object or an
-   :class:`InputSource` object. When :meth:`parse` returns, the input is
+   name or a URL), a :class:`~pathlib.Path` object, a :term:`file-like object`
+   or an :class:`InputSource` object. When :meth:`parse` returns, the input is
    completely processed, and the parser object can be discarded or reset.
 
    .. versionchanged:: 3.5

--- a/Doc/library/xml.sax.reader.rst
+++ b/Doc/library/xml.sax.reader.rst
@@ -102,7 +102,8 @@ The :class:`XMLReader` interface supports the following methods:
 
    Process an input source, producing SAX events. The *source* object can be a
    system identifier (a string identifying the input source -- typically a file
-   name or a URL), a :class:`~pathlib.Path` object, a :term:`file-like object`
+   name or a URL), a :class:`pathlib.Path` or :term:`path-like <path-like object>`
+   object,
    or an :class:`InputSource` object. When :meth:`parse` returns, the input is
    completely processed, and the parser object can be discarded or reset.
 
@@ -110,7 +111,7 @@ The :class:`XMLReader` interface supports the following methods:
       Added support of character streams.
 
    .. versionchanged:: 3.8
-      Added support of :class:`~pathlib.Path` objects.
+      Added support of path-like objects.
 
 
 .. method:: XMLReader.getContentHandler()

--- a/Doc/library/xml.sax.reader.rst
+++ b/Doc/library/xml.sax.reader.rst
@@ -103,9 +103,9 @@ The :class:`XMLReader` interface supports the following methods:
    Process an input source, producing SAX events. The *source* object can be a
    system identifier (a string identifying the input source -- typically a file
    name or a URL), a :class:`pathlib.Path` or :term:`path-like <path-like object>`
-   object,
-   or an :class:`InputSource` object. When :meth:`parse` returns, the input is
-   completely processed, and the parser object can be discarded or reset.
+   object, or an :class:`InputSource` object. When
+   :meth:`parse` returns, the input is completely processed, and the parser object
+   can be discarded or reset.
 
    .. versionchanged:: 3.5
       Added support of character streams.

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -18,11 +18,10 @@ from xml.sax.xmlreader import InputSource, AttributesImpl, AttributesNSImpl
 from io import BytesIO, StringIO
 import codecs
 import os.path
-import pathlib
 import shutil
 from urllib.error import URLError
 from test import support
-from test.support import findfile, run_unittest, TESTFN
+from test.support import findfile, run_unittest, FakePath, TESTFN
 
 TEST_XMLFILE = findfile("test.xml", subdir="xmltestdata")
 TEST_XMLFILE_OUT = findfile("test.xml.out", subdir="xmltestdata")
@@ -185,7 +184,7 @@ class ParseTest(unittest.TestCase):
 
     def test_parse_path_object(self):
         make_xml_file(self.data, 'utf-8', None)
-        self.check_parse(pathlib.Path(TESTFN))
+        self.check_parse(FakePath(TESTFN))
 
     def test_parse_InputSource(self):
         # accept data without declared but with explicitly specified encoding
@@ -404,7 +403,7 @@ class PrepareInputSourceTest(unittest.TestCase):
 
     def test_path_objects(self):
         # If the source is a Path object, use it as a system ID and open it.
-        prep = prepare_input_source(pathlib.Path(self.file))
+        prep = prepare_input_source(FakePath(self.file))
         self.assertIsNone(prep.getCharacterStream())
         self.checkContent(prep.getByteStream(),
                           b"This was read from a file.")

--- a/Lib/test/test_sax.py
+++ b/Lib/test/test_sax.py
@@ -18,6 +18,7 @@ from xml.sax.xmlreader import InputSource, AttributesImpl, AttributesNSImpl
 from io import BytesIO, StringIO
 import codecs
 import os.path
+import pathlib
 import shutil
 from urllib.error import URLError
 from test import support
@@ -181,6 +182,10 @@ class ParseTest(unittest.TestCase):
         with open(TESTFN, 'rb') as f:
             with self.assertRaises(SAXException):
                 self.check_parse(f)
+
+    def test_parse_path_object(self):
+        make_xml_file(self.data, 'utf-8', None)
+        self.check_parse(pathlib.Path(TESTFN))
 
     def test_parse_InputSource(self):
         # accept data without declared but with explicitly specified encoding
@@ -393,6 +398,13 @@ class PrepareInputSourceTest(unittest.TestCase):
     def test_string(self):
         # If the source is a string, use it as a system ID and open it.
         prep = prepare_input_source(self.file)
+        self.assertIsNone(prep.getCharacterStream())
+        self.checkContent(prep.getByteStream(),
+                          b"This was read from a file.")
+
+    def test_path_objects(self):
+        # If the source is a Path object, use it as a system ID and open it.
+        prep = prepare_input_source(pathlib.Path(self.file))
         self.assertIsNone(prep.getCharacterStream())
         self.checkContent(prep.getByteStream(),
                           b"This was read from a file.")

--- a/Lib/xml/sax/saxutils.py
+++ b/Lib/xml/sax/saxutils.py
@@ -340,6 +340,8 @@ def prepare_input_source(source, base=""):
     """This function takes an InputSource and an optional base URL and
     returns a fully resolved InputSource object ready for reading."""
 
+    if isinstance(source, os.PathLike):
+        source = os.fspath(source)
     if isinstance(source, str):
         source = xmlreader.InputSource(source)
     elif hasattr(source, "read"):

--- a/Misc/NEWS.d/next/Library/2018-07-30-12-00-15.bpo-31658._bx7a_.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-30-12-00-15.bpo-31658._bx7a_.rst
@@ -1,1 +1,2 @@
-Make xml.sax.parse accepting Path objects. Patch by Mickaël Schoentgen.
+:func:`xml.sax.parse` now supports :term:`path-like <path-like object>`.
+Patch by Mickaël Schoentgen.

--- a/Misc/NEWS.d/next/Library/2018-07-30-12-00-15.bpo-31658._bx7a_.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-30-12-00-15.bpo-31658._bx7a_.rst
@@ -1,0 +1,1 @@
+Make xml.sax.parse accepting Path objects. Patch by Mickaël Schoentgen.


### PR DESCRIPTION


<!-- issue-number: [bpo-31658](https://www.bugs.python.org/issue31658) -->
https://bugs.python.org/issue31658
<!-- /issue-number -->
