### PR TITLE
bpo-34282: Fix Enum._convert shadowing members named _convert

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -424,7 +424,7 @@ class EnumMeta(type):
 
         return enum_class
 
-    def _convert(cls, name, module, filter, source=None):
+    def _convert_(cls, name, module, filter, source=None):
         """
         Create a new Enum subclass that replaces a collection of global constants
         """

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -165,9 +165,11 @@ class EnumMeta(type):
         enum_class._member_map_ = {}                 # name->value map
         enum_class._member_type_ = member_type
 
-        # save attributes from super classes so we know if we can take
-        # the shortcut of storing members in the class dict
-        base_attributes = {a for b in enum_class.mro() for a in b.__dict__}
+        # save DynamicClassAttribute attributes from super classes so we know
+        # if we can take the shortcut of storing members in the class dict
+        dynamic_attributes = {k for c in enum_class.mro()
+                              for k, v in c.__dict__.items()
+                              if isinstance(v, DynamicClassAttribute)}
 
         # Reverse value->name map for hashable values.
         enum_class._value2member_map_ = {}
@@ -227,7 +229,7 @@ class EnumMeta(type):
                 enum_class._member_names_.append(member_name)
             # performance boost for any member that would not shadow
             # a DynamicClassAttribute
-            if member_name not in base_attributes:
+            if member_name not in dynamic_attributes:
                 setattr(enum_class, member_name, enum_member)
             # now add to _member_map_
             enum_class._member_map_[member_name] = enum_member

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -457,11 +457,11 @@ class EnumMeta(type):
         module_globals[name] = cls
         return cls
 
-    def _convert(cls, *args):
+    def _convert(cls, *args, **kwargs):
         import warnings
         warnings.warn("_convert is deprecated and will be removed in 3.9, use "
                       "_convert_ instead.", DeprecationWarning, stacklevel=2)
-        return cls._convert_(*args)
+        return cls._convert_(*args, **kwargs)
 
     @staticmethod
     def _get_mixins_(bases):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -457,6 +457,12 @@ class EnumMeta(type):
         module_globals[name] = cls
         return cls
 
+    def _convert(cls, *args):
+        import warnings
+        warnings.warn("_convert is deprecated and will be removed in 3.9, use "
+                      "_convert_ instead.", DeprecationWarning, stacklevel=2)
+        return cls._convert_(*args)
+
     @staticmethod
     def _get_mixins_(bases):
         """Returns the type for creating enum members, and the first inherited

--- a/Lib/signal.py
+++ b/Lib/signal.py
@@ -5,19 +5,19 @@ from enum import IntEnum as _IntEnum
 
 _globals = globals()
 
-_IntEnum._convert(
+_IntEnum._convert_(
         'Signals', __name__,
         lambda name:
             name.isupper()
             and (name.startswith('SIG') and not name.startswith('SIG_'))
             or name.startswith('CTRL_'))
 
-_IntEnum._convert(
+_IntEnum._convert_(
         'Handlers', __name__,
         lambda name: name in ('SIG_DFL', 'SIG_IGN'))
 
 if 'pthread_sigmask' in _globals:
-    _IntEnum._convert(
+    _IntEnum._convert_(
             'Sigmasks', __name__,
             lambda name: name in ('SIG_BLOCK', 'SIG_UNBLOCK', 'SIG_SETMASK'))
 

--- a/Lib/socket.py
+++ b/Lib/socket.py
@@ -70,22 +70,22 @@ __all__.extend(os._get_exports_list(_socket))
 # in this module understands the enums and translates them back from integers
 # where needed (e.g. .family property of a socket object).
 
-IntEnum._convert(
+IntEnum._convert_(
         'AddressFamily',
         __name__,
         lambda C: C.isupper() and C.startswith('AF_'))
 
-IntEnum._convert(
+IntEnum._convert_(
         'SocketKind',
         __name__,
         lambda C: C.isupper() and C.startswith('SOCK_'))
 
-IntFlag._convert(
+IntFlag._convert_(
         'MsgFlag',
         __name__,
         lambda C: C.isupper() and C.startswith('MSG_'))
 
-IntFlag._convert(
+IntFlag._convert_(
         'AddressInfo',
         __name__,
         lambda C: C.isupper() and C.startswith('AI_'))

--- a/Lib/ssl.py
+++ b/Lib/ssl.py
@@ -119,32 +119,32 @@ from _ssl import (
 from _ssl import _DEFAULT_CIPHERS, _OPENSSL_API_VERSION
 
 
-_IntEnum._convert(
+_IntEnum._convert_(
     '_SSLMethod', __name__,
     lambda name: name.startswith('PROTOCOL_') and name != 'PROTOCOL_SSLv23',
     source=_ssl)
 
-_IntFlag._convert(
+_IntFlag._convert_(
     'Options', __name__,
     lambda name: name.startswith('OP_'),
     source=_ssl)
 
-_IntEnum._convert(
+_IntEnum._convert_(
     'AlertDescription', __name__,
     lambda name: name.startswith('ALERT_DESCRIPTION_'),
     source=_ssl)
 
-_IntEnum._convert(
+_IntEnum._convert_(
     'SSLErrorNumber', __name__,
     lambda name: name.startswith('SSL_ERROR_'),
     source=_ssl)
 
-_IntFlag._convert(
+_IntFlag._convert_(
     'VerifyFlags', __name__,
     lambda name: name.startswith('VERIFY_'),
     source=_ssl)
 
-_IntEnum._convert(
+_IntEnum._convert_(
     'VerifyMode', __name__,
     lambda name: name.startswith('CERT_'),
     source=_ssl)

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2619,7 +2619,7 @@ CONVERT_TEST_NAME_F = 5
 
 class TestIntEnumConvert(unittest.TestCase):
     def test_convert_value_lookup_priority(self):
-        test_type = enum.IntEnum._convert(
+        test_type = enum.IntEnum._convert_(
                 'UnittestConvert',
                 ('test.test_enum', '__main__')[__name__=='__main__'],
                 filter=lambda x: x.startswith('CONVERT_TEST_'))
@@ -2629,7 +2629,7 @@ class TestIntEnumConvert(unittest.TestCase):
         self.assertEqual(test_type(5).name, 'CONVERT_TEST_NAME_A')
 
     def test_convert(self):
-        test_type = enum.IntEnum._convert(
+        test_type = enum.IntEnum._convert_(
                 'UnittestConvert',
                 ('test.test_enum', '__main__')[__name__=='__main__'],
                 filter=lambda x: x.startswith('CONVERT_TEST_'))

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1508,6 +1508,23 @@ class TestEnum(unittest.TestCase):
             yellow = 6
         self.assertEqual(MoreColor.magenta.hex(), '5 hexlified!')
 
+    def test_subclass_duplicate_name(self):
+        class Base(Enum):
+            def test(self):
+                pass
+        class Test(Base):
+            test = 1
+        self.assertIs(type(Test.test), Test)
+
+    def test_subclass_duplicate_name_dynamic(self):
+        from types import DynamicClassAttribute
+        class Base(Enum):
+            @DynamicClassAttribute
+            def test(self):
+                return 'dynamic'
+        class Test(Base):
+            test = 1
+        self.assertEqual(Test.test.test, 'dynamic')
 
     def test_no_duplicates(self):
         class UniqueEnum(Enum):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1,6 +1,7 @@
 import enum
 import inspect
 import pydoc
+import sys
 import unittest
 import threading
 from collections import OrderedDict
@@ -2661,6 +2662,24 @@ class TestIntEnumConvert(unittest.TestCase):
         self.assertEqual([name for name in dir(test_type)
                           if name[0:2] not in ('CO', '__')],
                          [], msg='Names other than CONVERT_TEST_* found.')
+
+    @unittest.skipUnless(sys.version_info[:2] == (3, 8),
+                         '_convert was deprecated in 3.8')
+    def test_convert_warn(self):
+        with self.assertWarns(DeprecationWarning):
+            enum.IntEnum._convert(
+                'UnittestConvert',
+                ('test.test_enum', '__main__')[__name__=='__main__'],
+                filter=lambda x: x.startswith('CONVERT_TEST_'))
+
+    @unittest.skipUnless(sys.version_info >= (3, 9),
+                         '_convert was removed in 3.9')
+    def test_convert_raise(self):
+        with self.assertRaises(AttributeError):
+            enum.IntEnum._convert(
+                'UnittestConvert',
+                ('test.test_enum', '__main__')[__name__=='__main__'],
+                filter=lambda x: x.startswith('CONVERT_TEST_'))
 
 
 if __name__ == '__main__':

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1173,6 +1173,7 @@ Piet van Oostrum
 Tomas Oppelstrup
 Jason Orendorff
 Bastien Orivel
+orlnub123
 Douglas Orr
 William Orr
 Michele Orrù

--- a/Misc/NEWS.d/next/Library/2018-08-31-06-28-03.bpo-34282.ztyXH8.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-31-06-28-03.bpo-34282.ztyXH8.rst
@@ -1,0 +1,1 @@
+Fix ``Enum._convert`` shadowing members named _convert.

--- a/Misc/NEWS.d/next/Library/2018-08-31-06-28-03.bpo-34282.ztyXH8.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-31-06-28-03.bpo-34282.ztyXH8.rst
@@ -1,1 +1,2 @@
-Fix ``Enum._convert`` shadowing members named _convert.
+Move ``Enum._convert`` to ``EnumMeta._convert_`` and fix enum members getting
+shadowed by parent attributes.


### PR DESCRIPTION
I've combined the third solution with the second from the issue below, circumventing its problem.

<!-- issue-number: [bpo-34282](https://www.bugs.python.org/issue34282) -->
https://bugs.python.org/issue34282
<!-- /issue-number -->
