### PR TITLE
[2.7] Use 'for example' instead of 'in other words' in compound state…

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -185,7 +185,7 @@ effect of Pascal's ``for i := a to b do``; e.g., ``range(3)`` returns the list
       single: mutable sequence; loop over
 
    There is a subtlety when the sequence is being modified by the loop (this can
-   only occur for mutable sequences, i.e. lists). An internal counter is used to
+   only occur for mutable sequences, e.g. lists). An internal counter is used to
    keep track of which item is used next, and this is incremented on each
    iteration.  When this counter has reached the length of the sequence the loop
    terminates.  This means that if the suite deletes the current (or a previous)


### PR DESCRIPTION
…ment doc (GH-8401).

(cherry picked from commit 6921ef7bef4eab3819b3d0fda5fa3e3b2a8c0613)

Co-authored-by: Andrés Delfino <adelfino@gmail.com>
