### PR TITLE
bpo-34284: Nonsensical exception message when calling `__new__` on non-instantiable objects

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -499,7 +499,9 @@ PyAPI_FUNC(unsigned long) PyType_GetFlags(PyTypeObject*);
 PyAPI_FUNC(int) PyType_Ready(PyTypeObject *);
 PyAPI_FUNC(PyObject *) PyType_GenericAlloc(PyTypeObject *, Py_ssize_t);
 PyAPI_FUNC(PyObject *) PyType_GenericNew(PyTypeObject *,
-                                               PyObject *, PyObject *);
+                                         PyObject *, PyObject *);
+PyAPI_FUNC(PyObject *) PyType_NullNew(PyTypeObject *,
+                                      PyObject *, PyObject *);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(const char *) _PyType_Name(PyTypeObject *);
 PyAPI_FUNC(PyObject *) _PyType_Lookup(PyTypeObject *, PyObject *);

--- a/Lib/test/test_curses.py
+++ b/Lib/test/test_curses.py
@@ -14,6 +14,7 @@ import string
 import sys
 import tempfile
 import unittest
+import re
 
 from test.support import requires, import_module, verbose, SaveSignals
 
@@ -305,6 +306,21 @@ class TestCurses(unittest.TestCase):
         # just verify these don't cause errors
         curses.ungetmouse(0, 0, 0, 0, curses.BUTTON1_PRESSED)
         m = curses.getmouse()
+
+    @requires_curses_func('panel')
+    def test_panel_no_instantiation(self):
+        cant_create_message = re.escape("cannot create '_curses_panel.panel' instances")
+        object_message = re.escape(
+            'object.__new__(_curses_panel.panel) is not safe, '
+            'use _curses_panel.panel.__new__()'
+        )
+
+        with self.assertRaisesRegex(TypeError, cant_create_message):
+            curses.panel.panel()
+        with self.assertRaisesRegex(TypeError, cant_create_message):
+            curses.panel.panel.__new__(curses.panel.panel)
+        with self.assertRaisesRegex(TypeError, object_message):
+            object.__new__(curses.panel.panel)
 
     @requires_curses_func('panel')
     def test_userptr_without_set(self):

--- a/Lib/test/test_types.py
+++ b/Lib/test/test_types.py
@@ -1688,28 +1688,6 @@ class ObjectCreationTests(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, not_safe_message):
             object.__new__(C)
 
-    def test_create_sys_tuples(self):
-        C = type(sys.flags)
-
-        cant_create_message = re.escape("cannot create 'sys.flags' instances")
-        object_message = re.escape(
-            'object.__new__(sys.flags) is not safe, '
-            'use sys.flags.__new__()'
-        )
-        tuple_message = re.escape(
-            'tuple.__new__(sys.flags) is not safe, '
-            'use sys.flags.__new__()'
-        )
-
-        with self.assertRaisesRegex(TypeError, cant_create_message):
-            C()
-        with self.assertRaisesRegex(TypeError, cant_create_message):
-            C.__new__(C)
-        with self.assertRaisesRegex(TypeError, object_message):
-            object.__new__(C)
-        with self.assertRaisesRegex(TypeError, tuple_message):
-            tuple.__new__(C)
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/tkinter/test/test_tkinter/test_internals.py
+++ b/Lib/tkinter/test/test_tkinter/test_internals.py
@@ -1,0 +1,38 @@
+import unittest, test.support
+import _tkinter
+import re
+
+class InternalsTest(unittest.TestCase):
+    def assert_raise_on_new(self, tkinter_type):
+        # Users are intentionally prevented from creating new instances of
+        # _tkinter.TkappType, _tkinter.Tcl_Obj and _tkinter.TkttType
+        tkinter_type_name = f'_tkinter.{tkinter_type.__name__}'
+
+        cant_create_message = re.escape(f"cannot create '{tkinter_type_name}' instances")
+        object_message = re.escape(
+            f'object.__new__({tkinter_type_name}) is not safe, '
+            f'use {tkinter_type_name}.__new__()'
+        )
+
+        with self.assertRaisesRegex(TypeError, cant_create_message):
+            tkinter_type()
+        with self.assertRaisesRegex(TypeError, cant_create_message):
+            tkinter_type.__new__(tkinter_type)
+        with self.assertRaisesRegex(TypeError, object_message):
+            object.__new__(tkinter_type)
+
+    def test_tkapp_type_no_instantiation(self):
+        self.assert_raise_on_new(_tkinter.TkappType)
+
+    def test_tck_obj_no_instantiation(self):
+        self.assert_raise_on_new(_tkinter.Tcl_Obj)
+
+    def test_tktt_type_info_no_instantiation(self):
+        self.assert_raise_on_new(_tkinter.TkttType)
+
+
+def test_main():
+    test.support.run_unittest(InternalsTest,)
+
+if __name__ == "__main__":
+    test_main()

--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-08-20-40-46.bpo-34284.jFqKLF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-08-20-40-46.bpo-34284.jFqKLF.rst
@@ -1,0 +1,1 @@
+NullNew for old extension types instead of just null

--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-08-20-40-46.bpo-34284.jFqKLF.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-08-20-40-46.bpo-34284.jFqKLF.rst
@@ -1,1 +1,4 @@
-NullNew for old extension types instead of just null
+Types that cannot be instantiated now don't have `tp_new` equal to NULL,
+but equal to a common helper function that raises TypeError instead.
+This is applied to all old types without `tp_new` and types
+in the `sys` module that are derived from `tuple`.

--- a/Modules/_curses_panel.c
+++ b/Modules/_curses_panel.c
@@ -477,6 +477,7 @@ static PyMethodDef PyCursesPanel_Methods[] = {
 /* -------------------------------------------------------*/
 
 static PyType_Slot PyCursesPanel_Type_slots[] = {
+    {Py_tp_new,     PyType_NullNew},
     {Py_tp_dealloc, PyCursesPanel_Dealloc},
     {Py_tp_methods, PyCursesPanel_Methods},
     {0, 0},
@@ -640,7 +641,6 @@ PyInit__curses_panel(void)
     v = PyType_FromSpec(&PyCursesPanel_Type_spec);
     if (v == NULL)
         goto fail;
-    ((PyTypeObject *)v)->tp_new = NULL;
     _curses_panelstate(m)->PyCursesPanel_Type = v;
 
     import_curses();

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -906,6 +906,7 @@ static PyGetSetDef PyTclObject_getsetlist[] = {
 };
 
 static PyType_Slot PyTclObject_Type_slots[] = {
+    {Py_tp_new, PyType_NullNew},
     {Py_tp_dealloc, (destructor)PyTclObject_dealloc},
     {Py_tp_repr, (reprfunc)PyTclObject_repr},
     {Py_tp_str, (reprfunc)PyTclObject_str},
@@ -3206,6 +3207,7 @@ static PyMethodDef Tktt_methods[] =
 };
 
 static PyType_Slot Tktt_Type_slots[] = {
+    {Py_tp_new, PyType_NullNew},
     {Py_tp_dealloc, Tktt_Dealloc},
     {Py_tp_repr, Tktt_Repr},
     {Py_tp_methods, Tktt_methods},
@@ -3261,6 +3263,7 @@ static PyMethodDef Tkapp_methods[] =
 };
 
 static PyType_Slot Tkapp_Type_slots[] = {
+    {Py_tp_new, PyType_NullNew},
     {Py_tp_dealloc, Tkapp_Dealloc},
     {Py_tp_methods, Tkapp_methods},
     {0, 0}
@@ -3459,7 +3462,6 @@ PyInit__tkinter(void)
         Py_DECREF(m);
         return NULL;
     }
-    ((PyTypeObject *)o)->tp_new = NULL;
     if (PyModule_AddObject(m, "TkappType", o)) {
         Py_DECREF(o);
         Py_DECREF(m);
@@ -3472,7 +3474,6 @@ PyInit__tkinter(void)
         Py_DECREF(m);
         return NULL;
     }
-    ((PyTypeObject *)o)->tp_new = NULL;
     if (PyModule_AddObject(m, "TkttType", o)) {
         Py_DECREF(o);
         Py_DECREF(m);
@@ -3485,7 +3486,6 @@ PyInit__tkinter(void)
         Py_DECREF(m);
         return NULL;
     }
-    ((PyTypeObject *)o)->tp_new = NULL;
     if (PyModule_AddObject(m, "Tcl_Obj", o)) {
         Py_DECREF(o);
         Py_DECREF(m);


### PR DESCRIPTION
<!-- issue-number: [bpo-34284](https://www.bugs.python.org/issue34284) -->
https://bugs.python.org/issue34284
<!-- /issue-number -->
