### PR TITLE
bpo-34293: fix DOC Makefile regarding PAPER envvar

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -13,7 +13,11 @@ SOURCES      =
 DISTVERSION  = $(shell $(PYTHON) tools/extensions/patchlevel.py)
 SPHINXERRORHANDLING = -W
 
-ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees -D latex_elements.papersize=$(PAPER) \
+# Internal variables.
+PAPEROPT_a4     = -D latex_elements.papersize=a4paper
+PAPEROPT_letter = -D latex_elements.papersize=letterpaper
+
+ALLSPHINXOPTS = -b $(BUILDER) -d build/doctrees $(PAPEROPT_$(PAPER)) \
                 $(SPHINXOPTS) $(SPHINXERRORHANDLING) . build/$(BUILDER) $(SOURCES)
 
 .PHONY: help build html htmlhelp latex text changes linkcheck \

--- a/Misc/NEWS.d/next/Documentation/2018-07-31-15-38-26.bpo-34293.yHupAL.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-07-31-15-38-26.bpo-34293.yHupAL.rst
@@ -1,0 +1,1 @@
+Fix the Doc/Makefile regarding PAPER environment variable and PDF builds


### PR DESCRIPTION
The fix is modeled on https://github.com/sphinx-doc/sphinx/pull/5235

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34293](https://www.bugs.python.org/issue34293) -->
https://bugs.python.org/issue34293
<!-- /issue-number -->
