### PR TITLE
bpo-34248: add filename to DbmError at gdbm_open()

### DIFF
--- a/Lib/test/test_dbm_gnu.py
+++ b/Lib/test/test_dbm_gnu.py
@@ -144,6 +144,13 @@ class TestGdbm(unittest.TestCase):
             self.assertTrue(b'key' in db)
             self.assertEqual(db[b'key'], b'value')
 
+    def test_nonexisting_file(self):
+        nonexisting_file = 'nonexisting-file'
+        with self.assertRaises(gdbm.error) as cm:
+            gdbm.open(nonexisting_file)
+        self.assertIn(nonexisting_file, str(cm.exception))
+        self.assertEqual(cm.exception.filename, nonexisting_file)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_dbm_ndbm.py
+++ b/Lib/test/test_dbm_ndbm.py
@@ -105,6 +105,12 @@ class DbmTestCase(unittest.TestCase):
             self.assertTrue(b'key' in db)
             self.assertEqual(db[b'key'], b'value')
 
+    def test_nonexisting_file(self):
+        nonexisting_file = 'nonexisting-file'
+        with self.assertRaises(dbm.ndbm.error) as cm:
+            dbm.ndbm.open(nonexisting_file)
+        self.assertIn(nonexisting_file, str(cm.exception))
+        self.assertEqual(cm.exception.filename, nonexisting_file)
 
 
 if __name__ == '__main__':

--- a/Misc/NEWS.d/next/Library/2018-07-31-23-00-09.bpo-34248.5U6wwc.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-31-23-00-09.bpo-34248.5U6wwc.rst
@@ -1,0 +1,3 @@
+Report filename in the exception raised when the database file cannot be opened
+by :func:`dbm.gnu.open` and :func:`dbm.ndbm.open` due to OS-related error.
+Patch by Zsolt Cserna.

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -62,7 +62,7 @@ newdbmobject(const char *file, int flags, int mode)
     dp->di_size = -1;
     /* See issue #19296 */
     if ( (dp->di_dbm = dbm_open((char *)file, flags, mode)) == 0 ) {
-        PyErr_SetFromErrno(DbmError);
+        PyErr_SetFromErrnoWithFilename(DbmError, file);
         Py_DECREF(dp);
         return NULL;
     }

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -75,7 +75,7 @@ newdbmobject(const char *file, int flags, int mode)
     errno = 0;
     if ((dp->di_dbm = gdbm_open((char *)file, 0, flags, mode, NULL)) == 0) {
         if (errno != 0)
-            PyErr_SetFromErrno(DbmError);
+            PyErr_SetFromErrnoWithFilename(DbmError, file);
         else
             PyErr_SetString(DbmError, gdbm_strerror(gdbm_errno));
         Py_DECREF(dp);


### PR DESCRIPTION
Add the filename to the DbmError raised when dbm.gnu.open() is called and
errno is set.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34248](https://www.bugs.python.org/issue34248) -->
https://bugs.python.org/issue34248
<!-- /issue-number -->
