### PR TITLE
bpo-34170: _PyCoreConfig_Read() defaults to argc=0

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -272,6 +272,8 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
         'pycache_prefix': '(null)',
         'program_name': './_testembed',
+        'argc': 0,
+        'argv': '[]',
         'program': '(null)',
 
         'isolated': 0,

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -2286,6 +2286,9 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
     if (config->_frozen < 0) {
         config->_frozen = 0;
     }
+    if (config->argc < 0) {
+        config->argc = 0;
+    }
 
     return _Py_INIT_OK();
 }

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -335,7 +335,17 @@ dump_config(void)
     printf("pycache_prefix = %ls\n", config->pycache_prefix);
     printf("program_name = %ls\n", config->program_name);
     ASSERT_STR_EQUAL(config->program_name, Py_GetProgramName());
-    /* FIXME: test argc/argv */
+
+    printf("argc = %i\n", config->argc);
+    printf("argv = [");
+    for (int i=0; i < config->argc; i++) {
+        if (i) {
+            printf(", ");
+        }
+        printf("\"%ls\"", config->argv[i]);
+    }
+    printf("]\n");
+
     printf("program = %ls\n", config->program);
     /* FIXME: test xoptions */
     /* FIXME: test warnoptions */


### PR DESCRIPTION
Add unit tests for argc and argv of _PyCoreConfig.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34170](https://www.bugs.python.org/issue34170) -->
https://bugs.python.org/issue34170
<!-- /issue-number -->
