### PR TITLE
bpo-33499: Fix pymain_init_pycache_prefix()

### DIFF
--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1765,16 +1765,6 @@ pymain_init_tracemalloc(_PyCoreConfig *config)
 static _PyInitError
 pymain_init_pycache_prefix(_PyCoreConfig *config)
 {
-    wchar_t *env;
-
-    int res = config_get_env_var_dup(config, &env,
-                                     L"PYTHONPYCACHEPREFIX", "PYTHONPYCACHEPREFIX");
-    if (res < 0) {
-        return DECODE_LOCALE_ERR("PYTHONPYCACHEPREFIX", res);
-    } else if (env) {
-        config->pycache_prefix = env;
-    }
-
     const wchar_t *xoption = config_get_xoption(config, L"pycache_prefix");
     if (xoption) {
         const wchar_t *sep = wcschr(xoption, L'=');
@@ -1787,6 +1777,16 @@ pymain_init_pycache_prefix(_PyCoreConfig *config)
             // -X pycache_prefix= can cancel the env var
             config->pycache_prefix = NULL;
         }
+        return _Py_INIT_OK();
+    }
+
+    wchar_t *env;
+    int res = config_get_env_var_dup(config, &env,
+                                     L"PYTHONPYCACHEPREFIX", "PYTHONPYCACHEPREFIX");
+    if (res < 0) {
+        return DECODE_LOCALE_ERR("PYTHONPYCACHEPREFIX", res);
+    } else if (env) {
+        config->pycache_prefix = env;
     }
 
     return _Py_INIT_OK();


### PR DESCRIPTION
Fix a memory leak in pymain_init_pycache_prefix()
when PYTHONPYCACHEPREFIX and -X pycache_prefix are used.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-33499](https://www.bugs.python.org/issue33499) -->
https://bugs.python.org/issue33499
<!-- /issue-number -->
