### PR TITLE
bpo-24564: shutil.copystat(): ignore EINVAL on os.setxattr()

### DIFF
--- a/Lib/shutil.py
+++ b/Lib/shutil.py
@@ -297,7 +297,7 @@ if hasattr(os, 'listxattr'):
         try:
             names = os.listxattr(src, follow_symlinks=follow_symlinks)
         except OSError as e:
-            if e.errno not in (errno.ENOTSUP, errno.ENODATA):
+            if e.errno not in {errno.ENOTSUP, errno.ENODATA, errno.EINVAL}:
                 raise
             return
         for name in names:
@@ -305,7 +305,8 @@ if hasattr(os, 'listxattr'):
                 value = os.getxattr(src, name, follow_symlinks=follow_symlinks)
                 os.setxattr(dst, name, value, follow_symlinks=follow_symlinks)
             except OSError as e:
-                if e.errno not in (errno.EPERM, errno.ENOTSUP, errno.ENODATA):
+                if e.errno not in {errno.EPERM, errno.ENOTSUP, errno.ENODATA,
+                                   errno.EINVAL}:
                     raise
 else:
     def _copyxattr(*args, **kwargs):

--- a/Misc/NEWS.d/next/Library/2018-08-01-09-08-54.bpo-24564.LQN_RE.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-01-09-08-54.bpo-24564.LQN_RE.rst
@@ -1,0 +1,2 @@
+shutil.copystat(): ignore EINVAL on os.setxattr() which may occur when
+copying files on NFS filesystems.  (patch by Giampaolo Rodola')


### PR DESCRIPTION
https://bugs.python.org/issue24564

<!-- issue-number: [bpo-24564](https://bugs.python.org/issue24564) -->
https://bugs.python.org/issue24564
<!-- /issue-number -->
