### PR TITLE
bpo-34120: fix IDLE freezing after closing dialogs

### DIFF
--- a/Lib/idlelib/config_key.py
+++ b/Lib/idlelib/config_key.py
@@ -29,7 +29,6 @@ class GetKeysDialog(Toplevel):
         self.resizable(height=FALSE, width=FALSE)
         self.title(title)
         self.transient(parent)
-        self.grab_set()
         self.protocol("WM_DELETE_WINDOW", self.Cancel)
         self.parent = parent
         self.action=action

--- a/Lib/idlelib/config_key.py
+++ b/Lib/idlelib/config_key.py
@@ -29,6 +29,7 @@ class GetKeysDialog(Toplevel):
         self.resizable(height=FALSE, width=FALSE)
         self.title(title)
         self.transient(parent)
+        self.grab_set()
         self.protocol("WM_DELETE_WINDOW", self.Cancel)
         self.parent = parent
         self.action=action
@@ -234,10 +235,12 @@ class GetKeysDialog(Toplevel):
             return
         if (self.advanced or self.KeysOK(keys)) and self.bind_ok(keys):
             self.result = keys
+        self.grab_release()
         self.destroy()
 
     def Cancel(self, event=None):
         self.result=''
+        self.grab_release()
         self.destroy()
 
     def KeysOK(self, keys):

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -84,6 +84,7 @@ class ConfigDialog(Toplevel):
         tracers.attach()
 
         if not _utest:
+            self.grab_set()
             self.wm_deiconify()
             self.wait_window()
 
@@ -190,6 +191,7 @@ class ConfigDialog(Toplevel):
     def destroy(self):
         global font_sample_text
         font_sample_text = self.fontpage.font_sample.get('1.0', 'end')
+        self.grab_release()
         super().destroy()
 
     def help(self):

--- a/Lib/idlelib/configdialog.py
+++ b/Lib/idlelib/configdialog.py
@@ -84,7 +84,6 @@ class ConfigDialog(Toplevel):
         tracers.attach()
 
         if not _utest:
-            self.grab_set()
             self.wm_deiconify()
             self.wait_window()
 

--- a/Lib/idlelib/help_about.py
+++ b/Lib/idlelib/help_about.py
@@ -44,6 +44,7 @@ class AboutDialog(Toplevel):
         self.title(title or
                    f'About IDLE {python_version()} ({build_bits()} bit)')
         self.transient(parent)
+        self.grab_set()
         self.protocol("WM_DELETE_WINDOW", self.ok)
         self.parent = parent
         self.button_ok.focus_set()
@@ -194,6 +195,7 @@ class AboutDialog(Toplevel):
 
     def ok(self, event=None):
         "Dismiss help_about dialog."
+        self.grab_release()
         self.destroy()
 
 

--- a/Lib/idlelib/help_about.py
+++ b/Lib/idlelib/help_about.py
@@ -44,7 +44,6 @@ class AboutDialog(Toplevel):
         self.title(title or
                    f'About IDLE {python_version()} ({build_bits()} bit)')
         self.transient(parent)
-        self.grab_set()
         self.protocol("WM_DELETE_WINDOW", self.ok)
         self.parent = parent
         self.button_ok.focus_set()

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -56,6 +56,7 @@ class Query(Toplevel):
         self.text0 = text0
         self.used_names = used_names
         self.transient(parent)
+        self.grab_set()
         windowingsystem = self.tk.call('tk', 'windowingsystem')
         if windowingsystem == 'aqua':
             try:
@@ -141,6 +142,10 @@ class Query(Toplevel):
         "Set dialog result to None and destroy tk widget."
         self.result = None
         self.destroy()
+
+    def destroy(self):
+        self.grab_release()
+        super().destroy()
 
 
 class SectionName(Query):

--- a/Lib/idlelib/query.py
+++ b/Lib/idlelib/query.py
@@ -56,7 +56,6 @@ class Query(Toplevel):
         self.text0 = text0
         self.used_names = used_names
         self.transient(parent)
-        self.grab_set()
         windowingsystem = self.tk.call('tk', 'windowingsystem')
         if windowingsystem == 'aqua':
             try:

--- a/Lib/idlelib/searchbase.py
+++ b/Lib/idlelib/searchbase.py
@@ -59,12 +59,10 @@ class SearchDialogBase:
         self.ent.focus_set()
         self.ent.selection_range(0, "end")
         self.ent.icursor(0)
-        self.top.grab_set()
 
     def close(self, event=None):
         "Put dialog away for later use."
         if self.top:
-            self.top.grab_release()
             self.top.withdraw()
 
     def create_widgets(self):

--- a/Lib/idlelib/searchbase.py
+++ b/Lib/idlelib/searchbase.py
@@ -59,10 +59,12 @@ class SearchDialogBase:
         self.ent.focus_set()
         self.ent.selection_range(0, "end")
         self.ent.icursor(0)
+        self.top.grab_set()
 
     def close(self, event=None):
         "Put dialog away for later use."
         if self.top:
+            self.top.grab_release()
             self.top.withdraw()
 
     def create_widgets(self):

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -85,11 +85,13 @@ class ViewWindow(Toplevel):
 
         if modal:
             self.transient(parent)
+            self.grab_set()
             if not _utest:
                 self.wait_window()
 
     def ok(self, event=None):
         """Dismiss text viewer dialog."""
+        self.grab_release()
         self.destroy()
 
 

--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -85,7 +85,6 @@ class ViewWindow(Toplevel):
 
         if modal:
             self.transient(parent)
-            self.grab_set()
             if not _utest:
                 self.wait_window()
 

--- a/Misc/NEWS.d/next/IDLE/2018-08-01-23-25-38.bpo-34120.HgsIz-.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-08-01-23-25-38.bpo-34120.HgsIz-.rst
@@ -1,0 +1,1 @@
+Fix unresponsiveness after closing certain windows and dialogs.


### PR DESCRIPTION
Added missing `.grab_release()` calls to all places where we call `.grab_set()`. This was missing in all cases other than idlelib.searchbase.

<!-- issue-number: [bpo-34120](https://www.bugs.python.org/issue34120) -->
https://bugs.python.org/issue34120
<!-- /issue-number -->
