### PR TITLE
Misindented yaml example

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -750,9 +750,9 @@ the new dictionary-based approach:
         level: DEBUG
         handlers: [console]
         propagate: no
-    root:
-      level: DEBUG
-      handlers: [console]
+      root:
+        level: DEBUG
+        handlers: [console]
 
 For more information about logging using a dictionary, see
 :ref:`logging-config-api`.


### PR DESCRIPTION
While reading the howto, I've seen that the logger config for root was misindented.