### PR TITLE
bpo-34307: Allow any argument in NullHandler

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -2037,6 +2037,9 @@ class NullHandler(Handler):
     a NullHandler and add it to the top-level logger of the library module or
     package.
     """
+    def __init__(self, *args, **kwargs):
+        """Stub."""
+
     def handle(self, record):
         """Stub."""
 


### PR DESCRIPTION
The Nullhandler might be used as a drop-in replacement to a custom
logger, in that case the initialization would fail when the logging
configuration contains additional arguments

<!-- issue-number: [bpo-34307](https://www.bugs.python.org/issue34307) -->
https://bugs.python.org/issue34307
<!-- /issue-number -->
