### PR TITLE
bpo-31650: Remove _Py_CheckHashBasedPycsMode global config var

### DIFF
--- a/Include/coreconfig.h
+++ b/Include/coreconfig.h
@@ -241,7 +241,7 @@ typedef struct {
          valid
 
        Set by the --check-hash-based-pycs command line option.
-       If set to NULL (default), inherit _Py_CheckHashBasedPycsMode value.
+       The default value is "default".
 
        See PEP 552 "Deterministic pycs" for more details. */
     const char *_check_hash_pycs_mode;
@@ -286,6 +286,7 @@ typedef struct {
         .buffered_stdio = -1, \
         _PyCoreConfig_WINDOWS_INIT \
         ._install_importlib = 1, \
+        ._check_hash_pycs_mode = "default", \
         ._frozen = -1}
 /* Note: _PyCoreConfig_INIT sets other fields to 0/NULL */
 

--- a/Include/internal/import.h
+++ b/Include/internal/import.h
@@ -1,6 +1,0 @@
-#ifndef Py_INTERNAL_IMPORT_H
-#define Py_INTERNAL_IMPORT_H
-
-extern const char *_Py_CheckHashBasedPycsMode;
-
-#endif

--- a/Modules/zipimport.c
+++ b/Modules/zipimport.c
@@ -1,5 +1,4 @@
 #include "Python.h"
-#include "internal/import.h"
 #include "internal/pystate.h"
 #include "structmember.h"
 #include "osdefs.h"
@@ -1352,12 +1351,13 @@ unmarshal_code(PyObject *pathname, PyObject *data, time_t mtime)
 
     uint32_t flags = get_uint32(buf + 4);
     if (flags != 0) {
+        _PyCoreConfig *config = &PyThreadState_GET()->interp->core_config;
         // Hash-based pyc. We currently refuse to handle checked hash-based
         // pycs. We could validate hash-based pycs against the source, but it
         // seems likely that most people putting hash-based pycs in a zipfile
         // will use unchecked ones.
-        if (strcmp(_Py_CheckHashBasedPycsMode, "never") &&
-            (flags != 0x1 || !strcmp(_Py_CheckHashBasedPycsMode, "always")))
+        if (strcmp(config->_check_hash_pycs_mode, "never") &&
+            (flags != 0x1 || !strcmp(config->_check_hash_pycs_mode, "always")))
             Py_RETURN_NONE;
     } else if ((mtime != 0 && !eq_mtime(get_uint32(buf + 8), mtime))) {
         if (Py_VerboseFlag) {

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -436,8 +436,6 @@ static int test_init_global_config(void)
     /* FIXME: test Py_LegacyWindowsFSEncodingFlag */
     /* FIXME: test Py_LegacyWindowsStdioFlag */
 
-    /* _Py_CheckHashBasedPycsMode is not public, and so not tested */
-
     Py_Initialize();
     dump_config();
     Py_Finalize();

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -1,5 +1,4 @@
 #include "Python.h"
-#include "internal/import.h"
 #include "internal/pystate.h"
 
 
@@ -52,7 +51,6 @@ int Py_IsolatedFlag = 0; /* for -I, isolate from user's env */
 int Py_LegacyWindowsFSEncodingFlag = 0; /* Uses mbcs instead of utf-8 */
 int Py_LegacyWindowsStdioFlag = 0; /* Uses FileIO instead of WindowsConsoleIO */
 #endif
-const char *_Py_CheckHashBasedPycsMode = "default";
 
 
 void
@@ -317,10 +315,6 @@ _PyCoreConfig_GetGlobalConfig(_PyCoreConfig *config)
     COPY_NOT_FLAG(write_bytecode, Py_DontWriteBytecodeFlag);
     COPY_NOT_FLAG(user_site_directory, Py_NoUserSiteDirectory);
 
-    if (config->_check_hash_pycs_mode == NULL) {
-        config->_check_hash_pycs_mode = _Py_CheckHashBasedPycsMode;
-    }
-
 #undef COPY_FLAG
 #undef COPY_NOT_FLAG
 }
@@ -358,10 +352,6 @@ _PyCoreConfig_SetGlobalConfig(const _PyCoreConfig *config)
     COPY_NOT_FLAG(site_import, Py_NoSiteFlag);
     COPY_NOT_FLAG(write_bytecode, Py_DontWriteBytecodeFlag);
     COPY_NOT_FLAG(user_site_directory, Py_NoUserSiteDirectory);
-
-    if (config->_check_hash_pycs_mode != NULL) {
-        _Py_CheckHashBasedPycsMode = config->_check_hash_pycs_mode;
-    }
 
     /* Random or non-zero hash seed */
     Py_HashRandomizationFlag = (config->use_hash_seed == 0 ||

--- a/Python/import.c
+++ b/Python/import.c
@@ -5,7 +5,6 @@
 #include "Python-ast.h"
 #undef Yield /* undefine macro conflicting with winbase.h */
 #include "internal/hash.h"
-#include "internal/import.h"
 #include "internal/pystate.h"
 #include "errcode.h"
 #include "marshal.h"
@@ -2290,7 +2289,8 @@ PyInit__imp(void)
     d = PyModule_GetDict(m);
     if (d == NULL)
         goto failure;
-    PyObject *pyc_mode = PyUnicode_FromString(_Py_CheckHashBasedPycsMode);
+    _PyCoreConfig *config = &PyThreadState_GET()->interp->core_config;
+    PyObject *pyc_mode = PyUnicode_FromString(config->_check_hash_pycs_mode);
     if (pyc_mode == NULL) {
         goto failure;
     }


### PR DESCRIPTION
[bpo-31650](https://www.bugs.python.org/issue31650), [bpo-34170](https://www.bugs.python.org/issue34170): Replace _Py_CheckHashBasedPycsMode with
_PyCoreConfig._check_hash_pycs_mode. Modify PyInit__imp() and
zipimport to get the parameter from the current interpreter core
configuration.

Remove Include/internal/import.h file.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
