### PR TITLE
bpo-9372: Deprecate several __getitem__ methods

### DIFF
--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -170,7 +170,7 @@ available for subclassing as well:
       The *bufsize* parameter.
 
    .. deprecated:: 3.8
-      Support for :meth:`sequence protocol <object.__getitem__>` is deprecated.
+      Support for :meth:`sequence protocol <__getitem__>` is deprecated.
 
 
 **Optional in-place filtering:** if the keyword argument ``inplace=True`` is

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -170,7 +170,7 @@ available for subclassing as well:
       The *bufsize* parameter.
 
    .. deprecated:: 3.8
-      Support for :meth:`sequence protocol <__getitem__>` is deprecated.
+      Support for :meth:`__getitem__` method is deprecated.
 
 
 **Optional in-place filtering:** if the keyword argument ``inplace=True`` is

--- a/Doc/library/fileinput.rst
+++ b/Doc/library/fileinput.rst
@@ -169,6 +169,9 @@ available for subclassing as well:
    .. deprecated-removed:: 3.6 3.8
       The *bufsize* parameter.
 
+   .. deprecated:: 3.8
+      Support for :meth:`sequence protocol <object.__getitem__>` is deprecated.
+
 
 **Optional in-place filtering:** if the keyword argument ``inplace=True`` is
 passed to :func:`fileinput.input` or to the :class:`FileInput` constructor, the

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -174,7 +174,7 @@ also provides these miscellaneous utilities:
           print(chunk)
 
    .. deprecated:: 3.8
-      Support for :meth:`__getitem__` iteration style is deprecated.
+      Support for :meth:`sequence protocol <__getitem__>` is deprecated.
 
 
 :mod:`wsgiref.headers` -- WSGI response header tools

--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -173,6 +173,8 @@ also provides these miscellaneous utilities:
       for chunk in wrapper:
           print(chunk)
 
+   .. deprecated:: 3.8
+      Support for :meth:`__getitem__` iteration style is deprecated.
 
 
 :mod:`wsgiref.headers` -- WSGI response header tools

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -100,6 +100,8 @@ DOMEventStream Objects
 
 .. class:: DOMEventStream(stream, parser, bufsize)
 
+   .. deprecated:: 3.8
+      Support for :meth:`__getitem__` iteration style is deprecated.
 
    .. method:: getEvent()
 

--- a/Doc/library/xml.dom.pulldom.rst
+++ b/Doc/library/xml.dom.pulldom.rst
@@ -101,7 +101,7 @@ DOMEventStream Objects
 .. class:: DOMEventStream(stream, parser, bufsize)
 
    .. deprecated:: 3.8
-      Support for :meth:`__getitem__` iteration style is deprecated.
+      Support for :meth:`sequence protocol <__getitem__>` is deprecated.
 
    .. method:: getEvent()
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -154,6 +154,15 @@ Build and C API Changes
 
   (Contributed by Antoine Pitrou in :issue:`32430`.)
 
+* The :meth:`__getitem__` methods of :class:`xml.dom.pulldom.DOMEventStream`,
+  :class:`wsgiref.util.FileWrapper` and :class:`fileinput.FileInput` have been
+  deprecated.
+
+  Implementations of these methods have been ignoring their *index* parameter,
+  and returning the next item instead.
+
+  (Contributed by Berker Peksag in :issue:`9372`.)
+
 
 Deprecated
 ==========

--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -261,7 +261,7 @@ class FileInput:
     def __getitem__(self, i):
         import warnings
         warnings.warn(
-            "FileInput's __getitem__ method is deprecated. "
+            "Support for indexing FileInput objects is deprecated. "
             "Use iterator protocol instead.",
             DeprecationWarning,
             stacklevel=2

--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -262,7 +262,7 @@ class FileInput:
         import warnings
         warnings.warn(
             "FileInput's __getitem__ method is deprecated. "
-            "Use the iteration protocol instead.",
+            "Use iterator protocol instead.",
             DeprecationWarning,
             stacklevel=2
         )

--- a/Lib/fileinput.py
+++ b/Lib/fileinput.py
@@ -259,6 +259,13 @@ class FileInput:
             # repeat with next file
 
     def __getitem__(self, i):
+        import warnings
+        warnings.warn(
+            "FileInput's __getitem__ method is deprecated. "
+            "Use the iteration protocol instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         if i != self.lineno():
             raise RuntimeError("accessing lines out of order")
         try:

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -89,6 +89,7 @@ __all__ = [
     "requires_IEEE_754", "skip_unless_xattr", "requires_zlib",
     "anticipate_failure", "load_package_tests", "detect_api_mismatch",
     "check__all__", "skip_unless_bind_unix_socket",
+    "ignore_warnings",
     # sys
     "is_jython", "is_android", "check_impl_detail", "unix_shell",
     "setswitchinterval",
@@ -136,6 +137,22 @@ def _ignore_deprecated_imports(ignore=True):
             yield
     else:
         yield
+
+
+def ignore_warnings(*, category):
+    """Decorator to suppress deprecation warnings.
+
+    Use of context managers to hide warnings make diffs
+    more noisy and tools like 'git blame' less useful.
+    """
+    def decorator(test):
+        @functools.wraps(test)
+        def wrapper(self, *args, **kwargs):
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', category=category)
+                return test(self, *args, **kwargs)
+        return wrapper
+    return decorator
 
 
 def import_module(name, deprecated=False, *, required_on=()):

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -366,7 +366,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
     def test__getitem___deprecation(self):
         t = self.writeTmp("line1\nline2\n")
         with self.assertWarnsRegex(DeprecationWarning,
-                                   r'Use the iteration protocol instead'):
+                                   r'Use iterator protocol instead'):
             with FileInput(files=[t]) as fi:
                 with self.assertRaises(RuntimeError):
                     fi[1]

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -25,6 +25,7 @@ from fileinput import FileInput, hook_encoded
 from pathlib import Path
 
 from test.support import verbose, TESTFN, check_warnings
+from test.support import ignore_warnings
 from test.support import unlink as safe_unlink
 from test import support
 from unittest import mock
@@ -351,6 +352,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
         with FileInput(files=[]) as fi:
             self.assertEqual(fi._files, ('-',))
 
+    @ignore_warnings(category=DeprecationWarning)
     def test__getitem__(self):
         """Tests invoking FileInput.__getitem__() with the current
            line number"""
@@ -361,6 +363,15 @@ class FileInputTests(BaseTests, unittest.TestCase):
             retval2 = fi[1]
             self.assertEqual(retval2, "line2\n")
 
+    def test__getitem___deprecation(self):
+        t = self.writeTmp("line1\nline2\n")
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   r'Use the iteration protocol instead'):
+            with FileInput(files=[t]) as fi:
+                with self.assertRaises(RuntimeError):
+                    fi[1]
+
+    @ignore_warnings(category=DeprecationWarning)
     def test__getitem__invalid_key(self):
         """Tests invoking FileInput.__getitem__() with an index unequal to
            the line number"""
@@ -370,6 +381,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
                 fi[1]
         self.assertEqual(cm.exception.args, ("accessing lines out of order",))
 
+    @ignore_warnings(category=DeprecationWarning)
     def test__getitem__eof(self):
         """Tests invoking FileInput.__getitem__() with the line number but at
            end-of-input"""

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -368,8 +368,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
         with self.assertWarnsRegex(DeprecationWarning,
                                    r'Use iterator protocol instead'):
             with FileInput(files=[t]) as fi:
-                with self.assertRaises(RuntimeError):
-                    fi[1]
+                self.assertEqual(fi[0], "line1\n")
 
     @ignore_warnings(category=DeprecationWarning)
     def test__getitem__invalid_key(self):

--- a/Lib/test/test_fileinput.py
+++ b/Lib/test/test_fileinput.py
@@ -25,7 +25,6 @@ from fileinput import FileInput, hook_encoded
 from pathlib import Path
 
 from test.support import verbose, TESTFN, check_warnings
-from test.support import ignore_warnings
 from test.support import unlink as safe_unlink
 from test import support
 from unittest import mock
@@ -352,7 +351,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
         with FileInput(files=[]) as fi:
             self.assertEqual(fi._files, ('-',))
 
-    @ignore_warnings(category=DeprecationWarning)
+    @support.ignore_warnings(category=DeprecationWarning)
     def test__getitem__(self):
         """Tests invoking FileInput.__getitem__() with the current
            line number"""
@@ -370,7 +369,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
             with FileInput(files=[t]) as fi:
                 self.assertEqual(fi[0], "line1\n")
 
-    @ignore_warnings(category=DeprecationWarning)
+    @support.ignore_warnings(category=DeprecationWarning)
     def test__getitem__invalid_key(self):
         """Tests invoking FileInput.__getitem__() with an index unequal to
            the line number"""
@@ -380,7 +379,7 @@ class FileInputTests(BaseTests, unittest.TestCase):
                 fi[1]
         self.assertEqual(cm.exception.args, ("accessing lines out of order",))
 
-    @ignore_warnings(category=DeprecationWarning)
+    @support.ignore_warnings(category=DeprecationWarning)
     def test__getitem__eof(self):
         """Tests invoking FileInput.__getitem__() with the line number but at
            end-of-input"""

--- a/Lib/test/test_pulldom.py
+++ b/Lib/test/test_pulldom.py
@@ -163,9 +163,8 @@ class PullDOMTestCase(unittest.TestCase):
         parser = pulldom.parseString(SMALL_SAMPLE)
         with self.assertWarnsRegex(DeprecationWarning,
                                    r'Use iterator protocol instead'):
-            last = parser[-1]
             # This should have returned 'END_ELEMENT'.
-            self.assertEqual(last[0], pulldom.START_DOCUMENT)
+            self.assertEqual(parser[-1], pulldom.START_DOCUMENT)
 
 
 class ThoroughTestCase(unittest.TestCase):

--- a/Lib/test/test_pulldom.py
+++ b/Lib/test/test_pulldom.py
@@ -162,7 +162,7 @@ class PullDOMTestCase(unittest.TestCase):
     def test_getitem_deprecation(self):
         parser = pulldom.parseString(SMALL_SAMPLE)
         with self.assertWarnsRegex(DeprecationWarning,
-                                   r'Use the iteration protocol instead'):
+                                   r'Use iterator protocol instead'):
             last = parser[-1]
             # This should have returned 'END_ELEMENT'.
             self.assertEqual(last[0], pulldom.START_DOCUMENT)

--- a/Lib/test/test_pulldom.py
+++ b/Lib/test/test_pulldom.py
@@ -164,7 +164,7 @@ class PullDOMTestCase(unittest.TestCase):
         with self.assertWarnsRegex(DeprecationWarning,
                                    r'Use iterator protocol instead'):
             # This should have returned 'END_ELEMENT'.
-            self.assertEqual(parser[-1], pulldom.START_DOCUMENT)
+            self.assertEqual(parser[-1][0], pulldom.START_DOCUMENT)
 
 
 class ThoroughTestCase(unittest.TestCase):

--- a/Lib/test/test_pulldom.py
+++ b/Lib/test/test_pulldom.py
@@ -159,6 +159,14 @@ class PullDOMTestCase(unittest.TestCase):
             self.fail(
                 "Ran out of events, but should have received END_DOCUMENT")
 
+    def test_getitem_deprecation(self):
+        parser = pulldom.parseString(SMALL_SAMPLE)
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   r'Use the iteration protocol instead'):
+            last = parser[-1]
+            # This should have returned 'END_ELEMENT'.
+            self.assertEqual(last[0], pulldom.START_DOCUMENT)
+
 
 class ThoroughTestCase(unittest.TestCase):
     """Test the hard-to-reach parts of pulldom."""

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -361,7 +361,7 @@ class UtilityTests(TestCase):
     def test_filewrapper_getitem_deprecation(self):
         wrapper = util.FileWrapper(StringIO('foobar'), 3)
         with self.assertWarnsRegex(DeprecationWarning,
-                                   r'Use the iteration protocol instead'):
+                                   r'Use iterator protocol instead'):
             last = wrapper[1]
         # This should have returned 'bar'.
         self.assertEqual(last, 'foo')

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -20,7 +20,6 @@ import signal
 import sys
 import threading
 import unittest
-import warnings
 
 
 class MockServer(WSGIServer):
@@ -362,9 +361,8 @@ class UtilityTests(TestCase):
         wrapper = util.FileWrapper(StringIO('foobar'), 3)
         with self.assertWarnsRegex(DeprecationWarning,
                                    r'Use iterator protocol instead'):
-            last = wrapper[1]
-        # This should have returned 'bar'.
-        self.assertEqual(last, 'foo')
+            # This should have returned 'bar'.
+            self.assertEqual(wrapper[1], 'foo')
 
     def testSimpleShifts(self):
         self.checkShift('','/', '', '/', '')

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -20,6 +20,7 @@ import signal
 import sys
 import threading
 import unittest
+import warnings
 
 
 class MockServer(WSGIServer):
@@ -338,6 +339,7 @@ class UtilityTests(TestCase):
         util.setup_testing_defaults(kw)
         self.assertEqual(util.request_uri(kw,query),uri)
 
+    @support.ignore_warnings(category=DeprecationWarning)
     def checkFW(self,text,size,match):
 
         def make_it(text=text,size=size):
@@ -355,6 +357,14 @@ class UtilityTests(TestCase):
 
         it.close()
         self.assertTrue(it.filelike.closed)
+
+    def test_filewrapper_getitem_deprecation(self):
+        wrapper = util.FileWrapper(StringIO('foobar'), 3)
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   r'Use the iteration protocol instead'):
+            last = wrapper[1]
+        # This should have returned 'bar'.
+        self.assertEqual(last, 'foo')
 
     def testSimpleShifts(self):
         self.checkShift('','/', '', '/', '')

--- a/Lib/wsgiref/util.py
+++ b/Lib/wsgiref/util.py
@@ -18,6 +18,13 @@ class FileWrapper:
             self.close = filelike.close
 
     def __getitem__(self,key):
+        import warnings
+        warnings.warn(
+            "FileWrapper's __getitem__ method ignores 'key' parameter. "
+            "Use the iteration protocol instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         data = self.filelike.read(self.blksize)
         if data:
             return data

--- a/Lib/wsgiref/util.py
+++ b/Lib/wsgiref/util.py
@@ -21,7 +21,7 @@ class FileWrapper:
         import warnings
         warnings.warn(
             "FileWrapper's __getitem__ method ignores 'key' parameter. "
-            "Use the iteration protocol instead.",
+            "Use iterator protocol instead.",
             DeprecationWarning,
             stacklevel=2
         )

--- a/Lib/xml/dom/pulldom.py
+++ b/Lib/xml/dom/pulldom.py
@@ -217,6 +217,13 @@ class DOMEventStream:
         self.parser.setContentHandler(self.pulldom)
 
     def __getitem__(self, pos):
+        import warnings
+        warnings.warn(
+            "DOMEventStream's __getitem__ method ignores 'pos' parameter. "
+            "Use the iteration protocol instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         rc = self.getEvent()
         if rc:
             return rc

--- a/Lib/xml/dom/pulldom.py
+++ b/Lib/xml/dom/pulldom.py
@@ -220,7 +220,7 @@ class DOMEventStream:
         import warnings
         warnings.warn(
             "DOMEventStream's __getitem__ method ignores 'pos' parameter. "
-            "Use the iteration protocol instead.",
+            "Use iterator protocol instead.",
             DeprecationWarning,
             stacklevel=2
         )

--- a/Misc/NEWS.d/next/Library/2018-08-01-21-26-17.bpo-9372.V8Ou3K.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-01-21-26-17.bpo-9372.V8Ou3K.rst
@@ -1,0 +1,3 @@
+Deprecate :meth:`__getitem__` methods of
+:class:`xml.dom.pulldom.DOMEventStream`, :class:`wsgiref.util.FileWrapper`
+and :class:`fileinput.FileInput`.


### PR DESCRIPTION
The `__getitem__` methods of DOMEventStream, FileInput
and FileWrapper classes ignore their 'index'
parameters and return the next item instead.

<!-- issue-number: [bpo-9372](https://www.bugs.python.org/issue9372) -->
https://bugs.python.org/issue9372
<!-- /issue-number -->
