### PR TITLE
bpo-1230540: Invoke custom sys.excepthook for threads in threading

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -1106,6 +1106,29 @@ class ThreadingExceptionTests(BaseTestCase):
         # explicitly break the reference cycle to not leak a dangling thread
         thread.exc = None
 
+    def test_excepthook(self):
+        script = r"""if True:
+            import sys
+            import threading
+
+            def f():
+                raise Exception()
+
+            def hook(*args):
+                # print('thread: %r' % (threading.current_thread(),))
+                print('custom hook: %r' % (args,))
+
+            sys.excepthook = hook
+
+            threading.Thread(target=f).start()
+            """
+        rc, out, err = assert_python_ok("-c", script)
+        decoded_out = out.decode()
+        decoded_err = err.decode()
+        self.assertNotIn("Traceback", decoded_err)
+        self.assertIn("custom hook", decoded_out)
+
+
 class TimerTests(BaseTestCase):
 
     def setUp(self):


### PR DESCRIPTION
Threads created via threading.Thread didn't invoke sys.excepthook if there was an uncaught exception. Since the docs for sys.excepthook are not specific about using it from threads and, in fact, this hook works for threads created via the _thread module, it makes sense to enable it the threading module as well.


<!-- issue-number: [bpo-1230540](https://www.bugs.python.org/issue1230540) -->
https://bugs.python.org/issue1230540
<!-- /issue-number -->
