### PR TITLE
[2.7] bpo-34120: fix IDLE freezing after closing dialogs (GH-8603)

### DIFF
--- a/Lib/idlelib/aboutDialog.py
+++ b/Lib/idlelib/aboutDialog.py
@@ -141,6 +141,7 @@ class AboutDialog(Toplevel):
         textView.view_file(self, title, fn, encoding)
 
     def Ok(self, event=None):
+        self.grab_release()
         self.destroy()
 
 if __name__ == '__main__':

--- a/Lib/idlelib/configDialog.py
+++ b/Lib/idlelib/configDialog.py
@@ -1197,10 +1197,12 @@ class ConfigDialog(Toplevel):
             instance.reset_help_menu_entries()
 
     def Cancel(self):
+        self.grab_release()
         self.destroy()
 
     def Ok(self):
         self.Apply()
+        self.grab_release()
         self.destroy()
 
     def Apply(self):

--- a/Lib/idlelib/configHelpSourceEdit.py
+++ b/Lib/idlelib/configHelpSourceEdit.py
@@ -155,10 +155,12 @@ class GetHelpSourceDialog(Toplevel):
                     # Mac Safari insists on using the URI form for local files
                     self.result = list(self.result)
                     self.result[1] = "file://" + path
+            self.grab_release()
             self.destroy()
 
     def Cancel(self, event=None):
         self.result = None
+        self.grab_release()
         self.destroy()
 
 if __name__ == '__main__':

--- a/Lib/idlelib/configSectionNameDialog.py
+++ b/Lib/idlelib/configSectionNameDialog.py
@@ -80,10 +80,13 @@ class GetCfgSectionNameDialog(Toplevel):
         name = self.name_ok()
         if name:
             self.result = name
+            self.grab_release()
             self.destroy()
     def Cancel(self, event=None):
         self.result = ''
+        self.grab_release()
         self.destroy()
+
 if __name__ == '__main__':
     import unittest
     unittest.main('idlelib.idle_test.test_config_name', verbosity=2, exit=False)

--- a/Lib/idlelib/idle_test/test_config_name.py
+++ b/Lib/idlelib/idle_test/test_config_name.py
@@ -15,6 +15,8 @@ class Dummy_name_dialog(object):
     name = Var()
     result = None
     destroyed = False
+    def grab_release(self):
+        pass
     def destroy(self):
         self.destroyed = True
 

--- a/Lib/idlelib/keybindingDialog.py
+++ b/Lib/idlelib/keybindingDialog.py
@@ -217,10 +217,12 @@ class GetKeysDialog(Toplevel):
     def OK(self, event=None):
         if self.advanced or self.KeysOK():  # doesn't check advanced string yet
             self.result=self.keyString.get()
+            self.grab_release()
             self.destroy()
 
     def Cancel(self, event=None):
         self.result=''
+        self.grab_release()
         self.destroy()
 
     def KeysOK(self):

--- a/Lib/idlelib/textView.py
+++ b/Lib/idlelib/textView.py
@@ -39,7 +39,8 @@ class TextViewer(Toplevel):
         self.textView.insert(0.0, text)
         self.textView.config(state=DISABLED)
 
-        if modal:
+        self.is_modal = modal
+        if self.is_modal:
             self.transient(parent)
             self.grab_set()
             self.wait_window()
@@ -62,6 +63,8 @@ class TextViewer(Toplevel):
         frameText.pack(side=TOP,expand=TRUE,fill=BOTH)
 
     def Ok(self, event=None):
+        if self.is_modal:
+            self.grab_release()
         self.destroy()
 
 

--- a/Misc/NEWS.d/next/IDLE/2018-08-01-23-25-38.bpo-34120.HgsIz-.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-08-01-23-25-38.bpo-34120.HgsIz-.rst
@@ -1,0 +1,1 @@
+Fix unresponsiveness after closing certain windows and dialogs.


### PR DESCRIPTION
Added missing .grab_release() calls to all places where we call .grab_set().

(cherry picked from commit 10ea9409ceb5da83cb380b610750551e26561044)

<!-- issue-number: [bpo-34120](https://www.bugs.python.org/issue34120) -->
https://bugs.python.org/issue34120
<!-- /issue-number -->
