### PR TITLE
bpo-34120: fix text viewer to call grab_release() only when needed

### DIFF
--- a/Lib/idlelib/textview.py
+++ b/Lib/idlelib/textview.py
@@ -83,7 +83,8 @@ class ViewWindow(Toplevel):
                                             command=self.ok, takefocus=False)
         self.viewframe.pack(side='top', expand=True, fill='both')
 
-        if modal:
+        self.is_modal = modal
+        if self.is_modal:
             self.transient(parent)
             self.grab_set()
             if not _utest:
@@ -91,7 +92,8 @@ class ViewWindow(Toplevel):
 
     def ok(self, event=None):
         """Dismiss text viewer dialog."""
-        self.grab_release()
+        if self.is_modal:
+            self.grab_release()
         self.destroy()
 
 


### PR DESCRIPTION
Fixing a bug in my recent fix for this issue.

<!-- issue-number: [bpo-34120](https://www.bugs.python.org/issue34120) -->
https://bugs.python.org/issue34120
<!-- /issue-number -->
