### PR TITLE
[2.7] Fix compiler warnings on Windows

### DIFF
--- a/Modules/_ctypes/libffi_msvc/ffi.c
+++ b/Modules/_ctypes/libffi_msvc/ffi.c
@@ -119,7 +119,7 @@ void ffi_prep_args(char *stack, extended_cif *ecif)
       argp += z;
     }
 
-  if (argp - stack > ecif->cif->bytes) 
+  if (argp >= stack && (unsigned)(argp - stack) > ecif->cif->bytes)
     {
       Py_FatalError("FFI BUG: not enough stack space for arguments");
     }

--- a/Modules/_sqlite/util.c
+++ b/Modules/_sqlite/util.c
@@ -132,7 +132,7 @@ _pysqlite_long_from_int64(sqlite_int64 value)
     }
 # endif
 #endif
-    return PyInt_FromLong(value);
+    return PyInt_FromLong(Py_SAFE_DOWNCAST(value, sqlite_int64, long));
 }
 
 sqlite_int64

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -4222,7 +4222,7 @@ PyObject *PyUnicode_DecodeCharmap(const char *s,
                         p = PyUnicode_AS_UNICODE(v) + oldpos;
                     }
                     value -= 0x10000;
-                    *p++ = 0xD800 | (value >> 10);
+                    *p++ = 0xD800 | (Py_UNICODE)(value >> 10);
                     *p++ = 0xDC00 | (value & 0x3FF);
                     extrachars -= 2;
                 }


### PR DESCRIPTION
* Fix compilation warnings on Windows 64-bit
* Fix compilation warning in _ctypes module on Window
* Fix compiler warning in unicodeobject.c
