### PR TITLE
Trivial: Change list.remove(x) documentation to better document the error raised

### DIFF
--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -40,8 +40,8 @@ objects:
 .. method:: list.remove(x)
    :noindex:
 
-   Remove the first item from the list whose value is equal to *x*.  It is an error if
-   there is no such item.
+   Remove the first item from the list whose value is equal to *x*.  It raises a
+   ``ValueError`` if there is no such item.
 
 
 .. method:: list.pop([i])


### PR DESCRIPTION
I changed "It is an error" to "It raises a `ValueError`", as I found it more suitable and more consistent to the documentations of the other methods.