### PR TITLE
[3.6] bpo-30317: Fix multiprocessing test_timeout() (GH-8621)

### DIFF
--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -882,9 +882,10 @@ class _TestQueue(BaseTestCase):
         start = time.time()
         self.assertRaises(pyqueue.Empty, q.get, True, 0.200)
         delta = time.time() - start
-        # Tolerate a delta of 50 ms because of the bad clock resolution on
-        # Windows (usually 15.6 ms)
-        self.assertGreaterEqual(delta, 0.150)
+        # bpo-30317: Tolerate a delta of 100 ms because of the bad clock
+        # resolution on Windows (usually 15.6 ms). x86 Windows7 3.x once
+        # failed because the delta was only 135.8 ms.
+        self.assertGreaterEqual(delta, 0.100)
         close_queue(q)
 
     def test_queue_feeder_donot_stop_onexc(self):


### PR DESCRIPTION
Multiprocessing test_timeout() now accepts a delta of 100 ms instead
of just 50 ms, since the test failed with 135.8 ms instead of the
expected 200 ms.
(cherry picked from commit 5640d030e100aade54210034828b711c3b506b18)

Co-authored-by: Victor Stinner <vstinner@redhat.com>

<!-- issue-number: [bpo-30317](https://www.bugs.python.org/issue30317) -->
https://bugs.python.org/issue30317
<!-- /issue-number -->
