### PR TITLE
 bpo-34275: Make IDLE calltips always visible on Mac. 

### DIFF
--- a/Lib/idlelib/calltip_w.py
+++ b/Lib/idlelib/calltip_w.py
@@ -72,6 +72,7 @@ class CalltipWindow:
                            background="#ffffe0", relief=SOLID, borderwidth=1,
                            font = self.widget['font'])
         self.label.pack()
+        tw.update_idletasks()
         tw.lift()  # work around bug in Tk 8.5.18+ (issue #24570)
 
         self.checkhideid = self.widget.bind(CHECKHIDE_VIRTUAL_EVENT_NAME,

--- a/Misc/NEWS.d/next/IDLE/2018-08-02-22-16-42.bpo-34275.Iu0d7t.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-08-02-22-16-42.bpo-34275.Iu0d7t.rst
@@ -1,0 +1,2 @@
+Make IDLE calltips always visible on Mac. Some MacOS-tk combinations need
+.update_idletasks(). Patch by Kevin Waltzer.

--- a/Misc/NEWS.d/next/IDLE/2018-08-02-22-16-42.bpo-34275.Iu0d7t.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-08-02-22-16-42.bpo-34275.Iu0d7t.rst
@@ -1,2 +1,2 @@
 Make IDLE calltips always visible on Mac. Some MacOS-tk combinations need
-.update_idletasks(). Patch by Kevin Waltzer.
+.update_idletasks(). Patch by Kevin Walzer.


### PR DESCRIPTION
Some MacOS-tk combinations need .update_idletasks().
The call is both unneeded and innocuous on Linux and Windows.
Patch by Kevin Walzer.

<!-- issue-number: [bpo-34275](https://www.bugs.python.org/issue34275) -->
https://bugs.python.org/issue34275
<!-- /issue-number -->
