### PR TITLE
bpo-34319: Clarify file handler closure in pathlib.read_text

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -911,7 +911,8 @@ call fails (for example because the path doesn't exist):
       >>> p.read_text()
       'Text file contents'
 
-   The optional parameters have the same meaning as in :func:`open`.
+   The file is opened and then closed. The optional parameters have the same
+   meaning as in :func:`open`.
 
    .. versionadded:: 3.5
 


### PR DESCRIPTION
Made the suggested changes in pathlib.read_text to clarify file handler being closed. Feel free to suggest if the wording can be improved.

Ref : https://bugs.python.org/issue34319#msg322991

> How about if we add "The file is opened and then closed." before "The optional parameters have the same meaning as in open()."

Since this is a doc change I think this doesn't require a NEWS entry.

Thanks

<!-- issue-number: [bpo-34319](https://www.bugs.python.org/issue34319) -->
https://bugs.python.org/issue34319
<!-- /issue-number -->
