### PR TITLE
bpo-34324: Doc README wrong directory name for venv

### DIFF
--- a/Doc/README.rst
+++ b/Doc/README.rst
@@ -33,7 +33,7 @@ To get started on UNIX, you can create a virtual environment with the command ::
   make venv
 
 That will install all the tools necessary to build the documentation. Assuming
-the virtual environment was created in the ``env`` directory (the default;
+the virtual environment was created in the ``venv`` directory (the default;
 configurable with the VENVDIR variable), you can run the following command to
 build the HTML output files::
 


### PR DESCRIPTION
In the documentation, the `env` directory is specified when we execute
the `make venv` command. But in the code, `make venv` will create the
virtualenv inside the `venv` directory (defined by `VENVDIR`)

<!-- issue-number: [bpo-34324](https://www.bugs.python.org/issue34324) -->
https://bugs.python.org/issue34324
<!-- /issue-number -->
