### PR TITLE
bpo-323042: Document how to remove a suffix of a pathlib.Path

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -559,8 +559,8 @@ Pure paths provide the following methods and properties:
 .. method:: PurePath.with_suffix(suffix)
 
    Return a new path with the :attr:`suffix` changed.  If the original path
-   doesn't have a suffix, the new *suffix* is appended instead. If the
-   *suffix* is an empty string the original suffix is removed::
+   doesn't have a suffix, the new *suffix* is appended instead.  If the
+   *suffix* is an empty string, the original suffix is removed::
 
       >>> p = PureWindowsPath('c:/Downloads/pathlib.tar.gz')
       >>> p.with_suffix('.bz2')

--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -559,7 +559,8 @@ Pure paths provide the following methods and properties:
 .. method:: PurePath.with_suffix(suffix)
 
    Return a new path with the :attr:`suffix` changed.  If the original path
-   doesn't have a suffix, the new *suffix* is appended instead::
+   doesn't have a suffix, the new *suffix* is appended instead. If the
+   *suffix* is an empty string the original suffix is removed::
 
       >>> p = PureWindowsPath('c:/Downloads/pathlib.tar.gz')
       >>> p.with_suffix('.bz2')
@@ -567,6 +568,9 @@ Pure paths provide the following methods and properties:
       >>> p = PureWindowsPath('README')
       >>> p.with_suffix('.txt')
       PureWindowsPath('README.txt')
+      >>> p = PureWindowsPath('README.txt')
+      >>> p.with_suffix('')
+      PureWindowsPath('README')
 
 
 .. _concrete-paths:

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -807,8 +807,10 @@ class PurePath(object):
                                        self._parts[:-1] + [name])
 
     def with_suffix(self, suffix):
-        """Return a new path with the file suffix changed (or added, if none)."""
-        # XXX if suffix is None, should the current suffix be removed?
+        """Return a new path with the file suffix changed.  If the path
+        has no suffix, add given suffix.  If the given suffix is an empty
+        string, remove the suffix from the path.
+        """
         f = self._flavour
         if f.sep in suffix or f.altsep and f.altsep in suffix:
             raise ValueError("Invalid suffix %r" % (suffix))


### PR DESCRIPTION
# [bpo-323042](https://www.bugs.python.org/issue323042): Document how to remove a suffix of a pathlib.Path

I didn't realize that you can remove a suffix with the `with_suffix` function of the `Path` class of `pathlib` and I always used a little utility function that I wrote.

I wanted to add that functionality (removing of a suffix) and submit a PR but then I saw that `with_suffix` has you covered already. I'm just documenting this feature with this PR.

<!-- issue-number: [bpo-323042](https://www.bugs.python.org/issue323042) -->
https://bugs.python.org/issue323042
<!-- /issue-number -->
