### PR TITLE
bpo-34170: _PyCoreConfig_Read() don't replace coerce_c_locale

### DIFF
--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -373,6 +373,8 @@ dump_config(void)
     printf("quiet = %i\n", config->quiet);
     printf("user_site_directory = %i\n", config->user_site_directory);
     printf("buffered_stdio = %i\n", config->buffered_stdio);
+    ASSERT_EQUAL(config->buffered_stdio, !Py_UnbufferedStdioFlag);
+
     /* FIXME: test legacy_windows_fs_encoding */
     /* FIXME: test legacy_windows_stdio */
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -805,7 +805,6 @@ _Py_InitializeCore(PyInterpreterState **interp_p,
 {
     assert(src_config != NULL);
 
-
     PyMemAllocatorEx old_alloc;
     _PyInitError err;
 


### PR DESCRIPTION
If coerce_c_locale is already set (>= 0), use its value: don't
override it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34170](https://www.bugs.python.org/issue34170) -->
https://bugs.python.org/issue34170
<!-- /issue-number -->
