### PR TITLE
[3.7] bpo-34247: Fix Python 3.7 initialization

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -51,14 +51,26 @@ PyAPI_FUNC(int) Py_SetStandardStreamEncoding(const char *encoding,
                                              const char *errors);
 
 /* PEP 432 Multi-phase initialization API (Private while provisional!) */
-PyAPI_FUNC(_PyInitError) _Py_InitializeCore(const _PyCoreConfig *);
+PyAPI_FUNC(_PyInitError) _Py_InitializeCore(
+    PyInterpreterState **interp_p,
+    const _PyCoreConfig *config);
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
+#ifndef Py_LIMITED_API
+PyAPI_FUNC(_PyInitError) _Py_InitializeFromConfig(
+    const _PyCoreConfig *config);
+#endif
+#ifdef Py_BUILD_CORE
+PyAPI_FUNC(void) _Py_Initialize_ReadEnvVars(void);
+#endif
 
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *);
 PyAPI_FUNC(void) _PyCoreConfig_Clear(_PyCoreConfig *);
 PyAPI_FUNC(int) _PyCoreConfig_Copy(
     _PyCoreConfig *config,
     const _PyCoreConfig *config2);
+PyAPI_FUNC(void) _PyCoreConfig_SetGlobalConfig(
+    const _PyCoreConfig *config);
+
 
 PyAPI_FUNC(_PyInitError) _PyMainInterpreterConfig_Read(
     _PyMainInterpreterConfig *config,
@@ -68,7 +80,9 @@ PyAPI_FUNC(int) _PyMainInterpreterConfig_Copy(
     _PyMainInterpreterConfig *config,
     const _PyMainInterpreterConfig *config2);
 
-PyAPI_FUNC(_PyInitError) _Py_InitializeMainInterpreter(const _PyMainInterpreterConfig *);
+PyAPI_FUNC(_PyInitError) _Py_InitializeMainInterpreter(
+        PyInterpreterState *interp,
+        const _PyMainInterpreterConfig *config);
 #endif
 
 /* Initialization and finalization */

--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -55,12 +55,10 @@ PyAPI_FUNC(_PyInitError) _Py_InitializeCore(
     PyInterpreterState **interp_p,
     const _PyCoreConfig *config);
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
-#ifndef Py_LIMITED_API
 PyAPI_FUNC(_PyInitError) _Py_InitializeFromConfig(
     const _PyCoreConfig *config);
-#endif
 #ifdef Py_BUILD_CORE
-PyAPI_FUNC(void) _Py_Initialize_ReadEnvVars(void);
+PyAPI_FUNC(void) _Py_Initialize_ReadEnvVarsNoAlloc(void);
 #endif
 
 PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *);
@@ -83,7 +81,8 @@ PyAPI_FUNC(int) _PyMainInterpreterConfig_Copy(
 PyAPI_FUNC(_PyInitError) _Py_InitializeMainInterpreter(
         PyInterpreterState *interp,
         const _PyMainInterpreterConfig *config);
-#endif
+#endif   /* !defined(Py_LIMITED_API) */
+
 
 /* Initialization and finalization */
 PyAPI_FUNC(void) Py_Initialize(void);

--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -89,7 +89,6 @@ PyAPI_FUNC(_PyInitError) _Py_InitializeMainInterpreter(
 PyAPI_FUNC(void) Py_Initialize(void);
 PyAPI_FUNC(void) Py_InitializeEx(int);
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(_PyInitError) _Py_InitializeEx_Private(int, int);
 PyAPI_FUNC(void) _Py_FatalInitError(_PyInitError err) _Py_NO_RETURN;
 #endif
 PyAPI_FUNC(void) Py_Finalize(void);

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -79,8 +79,11 @@ typedef struct {
 #define _PyCoreConfig_INIT \
     (_PyCoreConfig){ \
         .install_signal_handlers = -1, \
+        .ignore_environment = -1, \
         .use_hash_seed = -1, \
         .coerce_c_locale = -1, \
+        .faulthandler = -1, \
+        .tracemalloc = -1, \
         .utf8_mode = -1, \
         .argc = -1, \
         .nmodule_search_path = -1}

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -523,9 +523,7 @@ class CmdLineTest(unittest.TestCase):
         env = dict(os.environ)
         env.pop('PYTHONWARNINGS', None)
         env.pop('PYTHONDEVMODE', None)
-        # Force malloc() to disable the debug hooks which are enabled
-        # by default for Python compiled in debug mode
-        env['PYTHONMALLOC'] = 'malloc'
+        env.pop('PYTHONMALLOC', None)
 
         if xdev:
             args = (sys.executable, '-X', 'dev', *args)

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -289,7 +289,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'Py_UnbufferedStdioFlag': 0,
 
         '_disable_importlib': 0,
-        '_Py_CheckHashBasedPycsMode': 'default',
         'Py_FrozenFlag': 0,
     }
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 
 
-class EmbeddingTests(unittest.TestCase):
+class EmbeddingTestsMixin:
     def setUp(self):
         here = os.path.abspath(__file__)
         basepath = os.path.dirname(os.path.dirname(os.path.dirname(here)))
@@ -110,6 +110,8 @@ class EmbeddingTests(unittest.TestCase):
                 yield current_run
                 current_run = []
 
+
+class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
     def test_subinterps_main(self):
         for run in self.run_repeated_init_and_subinterpreters():
             main = run[0]
@@ -245,6 +247,151 @@ class EmbeddingTests(unittest.TestCase):
         out, err = self.run_embedded_interpreter("initialize_pymain")
         self.assertEqual(out.rstrip(), "Py_Main() after Py_Initialize: sys.argv=['-c', 'arg2']")
         self.assertEqual(err, '')
+
+
+class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
+    maxDiff = 4096
+    DEFAULT_CONFIG = {
+        'install_signal_handlers': 1,
+        'Py_IgnoreEnvironmentFlag': 0,
+        'use_hash_seed': 0,
+        'hash_seed': 0,
+        'allocator': '(null)',
+        'dev_mode': 0,
+        'faulthandler': 0,
+        'tracemalloc': 0,
+        'import_time': 0,
+        'show_ref_count': 0,
+        'show_alloc_count': 0,
+        'dump_refs': 0,
+        'malloc_stats': 0,
+        'utf8_mode': 0,
+
+        'coerce_c_locale': 0,
+        'coerce_c_locale_warn': 0,
+
+        'program_name': './_testembed',
+        'argc': 0,
+        'argv': '[]',
+        'program': '(null)',
+
+        'Py_IsolatedFlag': 0,
+        'Py_NoSiteFlag': 0,
+        'Py_BytesWarningFlag': 0,
+        'Py_InspectFlag': 0,
+        'Py_InteractiveFlag': 0,
+        'Py_OptimizeFlag': 0,
+        'Py_DebugFlag': 0,
+        'Py_DontWriteBytecodeFlag': 0,
+        'Py_VerboseFlag': 0,
+        'Py_QuietFlag': 0,
+        'Py_NoUserSiteDirectory': 0,
+        'Py_UnbufferedStdioFlag': 0,
+
+        '_disable_importlib': 0,
+        '_Py_CheckHashBasedPycsMode': 'default',
+        'Py_FrozenFlag': 0,
+    }
+
+    def check_config(self, testname, expected):
+        env = dict(os.environ)
+        for key in list(env):
+            if key.startswith('PYTHON'):
+                del env[key]
+        # Disable C locale coercion and UTF-8 mode to not depend
+        # on the current locale
+        env['PYTHONCOERCECLOCALE'] = '0'
+        env['PYTHONUTF8'] = '0'
+        out, err = self.run_embedded_interpreter(testname, env=env)
+        # Ignore err
+
+        expected = dict(self.DEFAULT_CONFIG, **expected)
+        for key, value in expected.items():
+            expected[key] = str(value)
+
+        config = {}
+        for line in out.splitlines():
+            key, value = line.split(' = ', 1)
+            config[key] = value
+        self.assertEqual(config, expected)
+
+    def test_init_default_config(self):
+        self.check_config("init_default_config", {})
+
+    def test_init_global_config(self):
+        config = {
+            'program_name': './globalvar',
+            'Py_NoSiteFlag': 1,
+            'Py_BytesWarningFlag': 1,
+            'Py_InspectFlag': 1,
+            'Py_InteractiveFlag': 1,
+            'Py_OptimizeFlag': 2,
+            'Py_DontWriteBytecodeFlag': 1,
+            'Py_VerboseFlag': 1,
+            'Py_QuietFlag': 1,
+            'Py_UnbufferedStdioFlag': 1,
+            'utf8_mode': 1,
+            'Py_NoUserSiteDirectory': 1,
+            'Py_FrozenFlag': 1,
+        }
+        self.check_config("init_global_config", config)
+
+    def test_init_from_config(self):
+        config = {
+            'install_signal_handlers': 0,
+            'use_hash_seed': 1,
+            'hash_seed': 123,
+            'allocator': 'malloc_debug',
+            'tracemalloc': 2,
+            'import_time': 1,
+            'show_ref_count': 1,
+            'show_alloc_count': 1,
+            'malloc_stats': 1,
+
+            'utf8_mode': 1,
+
+            'program_name': './conf_program_name',
+            'program': 'conf_program',
+
+            'faulthandler': 1,
+        }
+        self.check_config("init_from_config", config)
+
+    def test_init_env(self):
+        config = {
+            'use_hash_seed': 1,
+            'hash_seed': 42,
+            'allocator': 'malloc_debug',
+            'tracemalloc': 2,
+            'import_time': 1,
+            'malloc_stats': 1,
+            'utf8_mode': 1,
+            'Py_InspectFlag': 1,
+            'Py_OptimizeFlag': 2,
+            'Py_DontWriteBytecodeFlag': 1,
+            'Py_VerboseFlag': 1,
+            'Py_UnbufferedStdioFlag': 1,
+            'Py_NoUserSiteDirectory': 1,
+            'faulthandler': 1,
+            'dev_mode': 1,
+        }
+        self.check_config("init_env", config)
+
+    def test_init_dev_mode(self):
+        config = {
+            'dev_mode': 1,
+            'faulthandler': 1,
+            'allocator': 'debug',
+        }
+        self.check_config("init_dev_mode", config)
+
+    def test_init_isolated(self):
+        config = {
+            'Py_IsolatedFlag': 1,
+            'Py_IgnoreEnvironmentFlag': 1,
+            'Py_NoUserSiteDirectory': 1,
+        }
+        self.check_config("init_isolated", config)
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/C API/2018-08-05-00-21-38.bpo-34247._Sn92u.rst
+++ b/Misc/NEWS.d/next/C API/2018-08-05-00-21-38.bpo-34247._Sn92u.rst
@@ -1,0 +1,2 @@
+Fix Py_Initialize() regression introduced in 3.7.0: read environment
+variables like PYTHONOPTIMIZE.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-03-21-59-06.bpo-34170.v1h_H2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-03-21-59-06.bpo-34170.v1h_H2.rst
@@ -1,0 +1,2 @@
+-X dev: it is now possible to override the memory allocator using
+PYTHONMALLOC even if the developer mode is enabled.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1364,9 +1364,24 @@ pymain_update_sys_path(_PyMain *pymain, PyObject *path0)
 }
 
 
+void
+_PyCoreConfig_GetGlobalConfig(_PyCoreConfig *config)
+{
+#define COPY_FLAG(ATTR, VALUE) \
+        if (config->ATTR == -1) { \
+            config->ATTR = VALUE; \
+        }
+
+    COPY_FLAG(ignore_environment, Py_IgnoreEnvironmentFlag);
+    COPY_FLAG(utf8_mode, Py_UTF8Mode);
+
+#undef COPY_FLAG
+}
+
+
 /* Get Py_xxx global configuration variables */
 static void
-pymain_get_global_config(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
+cmdline_get_global_config(_Py_CommandLineDetails *cmdline)
 {
     cmdline->bytes_warning = Py_BytesWarningFlag;
     cmdline->debug = Py_DebugFlag;
@@ -1385,15 +1400,24 @@ pymain_get_global_config(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
     cmdline->legacy_windows_stdio = Py_LegacyWindowsStdioFlag;
 #endif
     cmdline->check_hash_pycs_mode = _Py_CheckHashBasedPycsMode ;
+}
 
-    pymain->config.ignore_environment = Py_IgnoreEnvironmentFlag;
-    pymain->config.utf8_mode = Py_UTF8Mode;
+
+void
+_PyCoreConfig_SetGlobalConfig(const _PyCoreConfig *config)
+{
+    Py_IgnoreEnvironmentFlag = config->ignore_environment;
+    Py_UTF8Mode = config->utf8_mode;
+
+    /* Random or non-zero hash seed */
+    Py_HashRandomizationFlag = (config->use_hash_seed == 0 ||
+                                config->hash_seed != 0);
 }
 
 
 /* Set Py_xxx global configuration variables */
 static void
-pymain_set_global_config(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
+cmdline_set_global_config(_Py_CommandLineDetails *cmdline)
 {
     Py_BytesWarningFlag = cmdline->bytes_warning;
     Py_DebugFlag = cmdline->debug;
@@ -1412,13 +1436,6 @@ pymain_set_global_config(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
     Py_LegacyWindowsFSEncodingFlag = cmdline->legacy_windows_fs_encoding;
     Py_LegacyWindowsStdioFlag = cmdline->legacy_windows_stdio;
 #endif
-
-    Py_IgnoreEnvironmentFlag = pymain->config.ignore_environment;
-    Py_UTF8Mode = pymain->config.utf8_mode;
-
-    /* Random or non-zero hash seed */
-    Py_HashRandomizationFlag = (pymain->config.use_hash_seed == 0 ||
-                                pymain->config.hash_seed != 0);
 }
 
 
@@ -1632,7 +1649,7 @@ pymain_wstr_to_int(const wchar_t *wstr, int *result)
 
 
 static _PyInitError
-pymain_init_tracemalloc(_PyCoreConfig *config)
+config_init_tracemalloc(_PyCoreConfig *config)
 {
     int nframe;
     int valid;
@@ -1714,6 +1731,27 @@ cmdline_get_env_flags(_Py_CommandLineDetails *cmdline)
 }
 
 
+/* Set global variable variables from environment variables */
+void
+_Py_Initialize_ReadEnvVars(void)
+{
+    _Py_CommandLineDetails cmdline;
+    memset(&cmdline, 0, sizeof(cmdline));
+
+    cmdline_get_global_config(&cmdline);
+    if (cmdline.isolated) {
+        Py_IgnoreEnvironmentFlag = 1;
+        cmdline.no_user_site_directory = 1;
+    }
+    if (!Py_IgnoreEnvironmentFlag) {
+        cmdline_get_env_flags(&cmdline);
+    }
+    cmdline_set_global_config(&cmdline);
+
+    /* no need to call pymain_clear_cmdline(), no memory has been allocated */
+}
+
+
 static _PyInitError
 config_init_home(_PyCoreConfig *config)
 {
@@ -1741,17 +1779,15 @@ config_init_home(_PyCoreConfig *config)
 static _PyInitError
 config_init_hash_seed(_PyCoreConfig *config)
 {
-    if (config->use_hash_seed < 0) {
-        const char *seed_text = config_get_env_var("PYTHONHASHSEED");
-        int use_hash_seed;
-        unsigned long hash_seed;
-        if (_Py_ReadHashSeed(seed_text, &use_hash_seed, &hash_seed) < 0) {
-            return _Py_INIT_USER_ERR("PYTHONHASHSEED must be \"random\" "
-                                     "or an integer in range [0; 4294967295]");
-        }
-        config->use_hash_seed = use_hash_seed;
-        config->hash_seed = hash_seed;
+    const char *seed_text = config_get_env_var("PYTHONHASHSEED");
+    int use_hash_seed;
+    unsigned long hash_seed;
+    if (_Py_ReadHashSeed(seed_text, &use_hash_seed, &hash_seed) < 0) {
+        return _Py_INIT_USER_ERR("PYTHONHASHSEED must be \"random\" "
+                                 "or an integer in range [0; 4294967295]");
     }
+    config->use_hash_seed = use_hash_seed;
+    config->hash_seed = hash_seed;
     return _Py_INIT_OK();
 }
 
@@ -1759,12 +1795,6 @@ config_init_hash_seed(_PyCoreConfig *config)
 static _PyInitError
 config_init_utf8_mode(_PyCoreConfig *config)
 {
-    /* The option was already set by Py_UTF8Mode,
-       Py_LegacyWindowsFSEncodingFlag or PYTHONLEGACYWINDOWSFSENCODING. */
-    if (config->utf8_mode >= 0) {
-        return _Py_INIT_OK();
-    }
-
     const wchar_t *xopt = config_get_xoption(config, L"utf8");
     if (xopt) {
         wchar_t *sep = wcschr(xopt, L'=');
@@ -1808,7 +1838,11 @@ config_init_utf8_mode(_PyCoreConfig *config)
 static _PyInitError
 config_read_env_vars(_PyCoreConfig *config)
 {
-    config->allocator = config_get_env_var("PYTHONMALLOC");
+    assert(!config->ignore_environment);
+
+    if (config->allocator == NULL) {
+        config->allocator = config_get_env_var("PYTHONMALLOC");
+    }
 
     if (config_get_env_var("PYTHONDUMPREFS")) {
         config->dump_refs = 1;
@@ -1817,16 +1851,18 @@ config_read_env_vars(_PyCoreConfig *config)
         config->malloc_stats = 1;
     }
 
-    const char *env = config_get_env_var("PYTHONCOERCECLOCALE");
-    if (env) {
-        if (strcmp(env, "0") == 0) {
-            config->coerce_c_locale = 0;
-        }
-        else if (strcmp(env, "warn") == 0) {
-            config->coerce_c_locale_warn = 1;
-        }
-        else {
-            config->coerce_c_locale = 1;
+    if (config->coerce_c_locale < 0) {
+        const char *env = config_get_env_var("PYTHONCOERCECLOCALE");
+        if (env) {
+            if (strcmp(env, "0") == 0) {
+                config->coerce_c_locale = 0;
+            }
+            else if (strcmp(env, "warn") == 0) {
+                config->coerce_c_locale_warn = 1;
+            }
+            else {
+                config->coerce_c_locale = 1;
+            }
         }
     }
 
@@ -1837,9 +1873,11 @@ config_read_env_vars(_PyCoreConfig *config)
     }
     config->module_search_path_env = path;
 
-    _PyInitError err = config_init_hash_seed(config);
-    if (_Py_INIT_FAILED(err)) {
-        return err;
+    if (config->use_hash_seed < 0) {
+        _PyInitError err = config_init_hash_seed(config);
+        if (_Py_INIT_FAILED(err)) {
+            return err;
+        }
     }
 
     return _Py_INIT_OK();
@@ -1850,9 +1888,11 @@ static _PyInitError
 config_read_complex_options(_PyCoreConfig *config)
 {
     /* More complex options configured by env var and -X option */
-    if (config_get_env_var("PYTHONFAULTHANDLER")
-       || config_get_xoption(config, L"faulthandler")) {
-        config->faulthandler = 1;
+    if (config->faulthandler < 0) {
+        if (config_get_env_var("PYTHONFAULTHANDLER")
+           || config_get_xoption(config, L"faulthandler")) {
+            config->faulthandler = 1;
+        }
     }
     if (config_get_env_var("PYTHONPROFILEIMPORTTIME")
        || config_get_xoption(config, L"importtime")) {
@@ -1862,13 +1902,13 @@ config_read_complex_options(_PyCoreConfig *config)
         config_get_env_var("PYTHONDEVMODE"))
     {
         config->dev_mode = 1;
-        config->faulthandler = 1;
-        config->allocator = "debug";
     }
 
-    _PyInitError err = pymain_init_tracemalloc(config);
-    if (_Py_INIT_FAILED(err)) {
-        return err;
+    if (config->tracemalloc < 0) {
+        _PyInitError err = config_init_tracemalloc(config);
+        if (_Py_INIT_FAILED(err)) {
+            return err;
+        }
     }
     return _Py_INIT_OK();
 }
@@ -1892,22 +1932,18 @@ pymain_read_conf_impl(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
 
     /* Set Py_IgnoreEnvironmentFlag for Py_GETENV() */
     _PyCoreConfig *config = &pymain->config;
-    Py_IgnoreEnvironmentFlag = config->ignore_environment;
+    Py_IgnoreEnvironmentFlag = config->ignore_environment || cmdline->isolated;
 
     /* Get environment variables */
-    cmdline_get_env_flags(cmdline);
+    if (!Py_IgnoreEnvironmentFlag) {
+        cmdline_get_env_flags(cmdline);
+    }
 
     err = cmdline_init_env_warnoptions(cmdline);
     if (_Py_INIT_FAILED(err)) {
         pymain->err = err;
         return -1;
     }
-
-#ifdef MS_WINDOWS
-    if (cmdline->legacy_windows_fs_encoding) {
-        config->utf8_mode = 0;
-    }
-#endif
 
     if (pymain_init_core_argv(pymain, cmdline) < 0) {
         return -1;
@@ -1940,6 +1976,8 @@ pymain_read_conf_impl(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
 static int
 pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
 {
+    _PyCoreConfig *config = &pymain->config;
+    _PyCoreConfig save_config = _PyCoreConfig_INIT;
     int res = -1;
 
     char *oldloc = _PyMem_RawStrdup(setlocale(LC_ALL, NULL));
@@ -1953,10 +1991,15 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
 
     int locale_coerced = 0;
     int loops = 0;
-    int init_ignore_env = pymain->config.ignore_environment;
+    int init_ignore_env = config->ignore_environment;
+
+    if (_PyCoreConfig_Copy(&save_config, config) < 0) {
+        pymain->err = _Py_INIT_NO_MEMORY();
+        goto done;
+    }
 
     while (1) {
-        int utf8_mode = pymain->config.utf8_mode;
+        int init_utf8_mode = config->utf8_mode;
         int encoding_changed = 0;
 
         /* Watchdog to prevent an infinite loop */
@@ -1987,20 +2030,20 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
          * See the documentation of the PYTHONCOERCECLOCALE setting for more
          * details.
          */
-        if (pymain->config.coerce_c_locale == 1 && !locale_coerced) {
+        if (config->coerce_c_locale == 1 && !locale_coerced) {
             locale_coerced = 1;
-            _Py_CoerceLegacyLocale(&pymain->config);
+            _Py_CoerceLegacyLocale(config);
             encoding_changed = 1;
         }
 
-        if (utf8_mode == -1) {
-            if (pymain->config.utf8_mode == 1) {
+        if (init_utf8_mode == -1) {
+            if (config->utf8_mode == 1) {
                 /* UTF-8 Mode enabled */
                 encoding_changed = 1;
             }
         }
         else {
-            if (pymain->config.utf8_mode != utf8_mode) {
+            if (config->utf8_mode != init_utf8_mode) {
                 encoding_changed = 1;
             }
         }
@@ -2013,12 +2056,18 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
            Py_DecodeLocale(). Reset Py_IgnoreEnvironmentFlag, modified by
            pymain_read_conf_impl(). Reset Py_IsolatedFlag and Py_NoSiteFlag
            modified by _PyCoreConfig_Read(). */
-        Py_UTF8Mode = pymain->config.utf8_mode;
+        int new_utf8_mode = config->utf8_mode;
         Py_IgnoreEnvironmentFlag = init_ignore_env;
-        _PyCoreConfig_Clear(&pymain->config);
+        if (_PyCoreConfig_Copy(config, &save_config) < 0) {
+            pymain->err = _Py_INIT_NO_MEMORY();
+            goto done;
+        }
         pymain_clear_cmdline(pymain, cmdline);
         memset(cmdline, 0, sizeof(*cmdline));
-        pymain_get_global_config(pymain, cmdline);
+
+        cmdline_get_global_config(cmdline);
+        _PyCoreConfig_GetGlobalConfig(config);
+        config->utf8_mode = new_utf8_mode;
 
         /* The encoding changed: read again the configuration
            with the new encoding */
@@ -2026,6 +2075,7 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
     res = 0;
 
 done:
+    _PyCoreConfig_Clear(&save_config);
     if (oldloc != NULL) {
         setlocale(LC_ALL, oldloc);
         PyMem_RawFree(oldloc);
@@ -2038,10 +2088,6 @@ done:
 static void
 config_init_locale(_PyCoreConfig *config)
 {
-    if (config->utf8_mode >= 0 && config->coerce_c_locale >= 0) {
-        return;
-    }
-
     if (_Py_LegacyLocaleDetected()) {
         /* POSIX locale: enable C locale coercion and UTF-8 Mode */
         if (config->utf8_mode < 0) {
@@ -2050,15 +2096,6 @@ config_init_locale(_PyCoreConfig *config)
         if (config->coerce_c_locale < 0) {
             config->coerce_c_locale = 1;
         }
-        return;
-    }
-
-    /* By default, C locale coercion and UTF-8 Mode are disabled */
-    if (config->coerce_c_locale < 0) {
-        config->coerce_c_locale = 0;
-    }
-    if (config->utf8_mode < 0) {
-        config->utf8_mode = 0;
     }
 }
 
@@ -2175,9 +2212,20 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
 {
     _PyInitError err;
 
-    err = config_read_env_vars(config);
-    if (_Py_INIT_FAILED(err)) {
-        return err;
+    _PyCoreConfig_GetGlobalConfig(config);
+
+#ifdef MS_WINDOWS
+    if (cmdline->legacy_windows_fs_encoding) {
+        config->utf8_mode = 0;
+    }
+#endif
+
+    assert(config->ignore_environment >= 0);
+    if (!config->ignore_environment) {
+        err = config_read_env_vars(config);
+        if (_Py_INIT_FAILED(err)) {
+            return err;
+        }
     }
 
     /* -X options */
@@ -2193,26 +2241,29 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         return err;
     }
 
-    err = config_init_utf8_mode(config);
-    if (_Py_INIT_FAILED(err)) {
-        return err;
+    if (config->utf8_mode < 0) {
+        err = config_init_utf8_mode(config);
+        if (_Py_INIT_FAILED(err)) {
+            return err;
+        }
     }
 
-    err = config_init_home(config);
-    if (_Py_INIT_FAILED(err)) {
-        return err;
+    if (config->home == NULL) {
+        err = config_init_home(config);
+        if (_Py_INIT_FAILED(err)) {
+            return err;
+        }
     }
 
-    err = config_init_program_name(config);
-    if (_Py_INIT_FAILED(err)) {
-        return err;
+    if (config->program_name == NULL) {
+        err = config_init_program_name(config);
+        if (_Py_INIT_FAILED(err)) {
+            return err;
+        }
     }
 
-    config_init_locale(config);
-
-    /* Signal handlers are installed by default */
-    if (config->install_signal_handlers < 0) {
-        config->install_signal_handlers = 1;
+    if (config->utf8_mode < 0 || config->coerce_c_locale < 0) {
+        config_init_locale(config);
     }
 
     if (!config->_disable_importlib) {
@@ -2221,6 +2272,39 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
             return err;
         }
     }
+
+    /* default values */
+    if (config->dev_mode) {
+        if (config->faulthandler < 0) {
+            config->faulthandler = 1;
+        }
+        if (config->allocator == NULL) {
+            config->allocator = "debug";
+        }
+    }
+    if (config->install_signal_handlers < 0) {
+        config->install_signal_handlers = 1;
+    }
+    if (config->use_hash_seed < 0) {
+        config->use_hash_seed = 0;
+        config->hash_seed = 0;
+    }
+    if (config->faulthandler < 0) {
+        config->faulthandler = 0;
+    }
+    if (config->tracemalloc < 0) {
+        config->tracemalloc = 0;
+    }
+    if (config->coerce_c_locale < 0) {
+        config->coerce_c_locale = 0;
+    }
+    if (config->utf8_mode < 0) {
+        config->utf8_mode = 0;
+    }
+    if (config->argc < 0) {
+        config->argc = 0;
+    }
+
     return _Py_INIT_OK();
 }
 
@@ -2289,6 +2373,7 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
         config->LEN = config2->LEN; \
     } while (0)
 
+    COPY_ATTR(install_signal_handlers);
     COPY_ATTR(ignore_environment);
     COPY_ATTR(use_hash_seed);
     COPY_ATTR(hash_seed);
@@ -2302,6 +2387,9 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
     COPY_ATTR(show_alloc_count);
     COPY_ATTR(dump_refs);
     COPY_ATTR(malloc_stats);
+
+    COPY_ATTR(coerce_c_locale);
+    COPY_ATTR(coerce_c_locale_warn);
     COPY_ATTR(utf8_mode);
 
     COPY_STR_ATTR(module_search_path_env);
@@ -2457,14 +2545,14 @@ _PyMainInterpreterConfig_Read(_PyMainInterpreterConfig *main_config,
 
 
 static int
-pymain_init_python_main(_PyMain *pymain)
+pymain_init_python_main(_PyMain *pymain, PyInterpreterState *interp)
 {
     _PyInitError err;
 
     _PyMainInterpreterConfig main_config = _PyMainInterpreterConfig_INIT;
-    err = _PyMainInterpreterConfig_Read(&main_config, &pymain->config);
+    err = _PyMainInterpreterConfig_Read(&main_config, &interp->core_config);
     if (!_Py_INIT_FAILED(err)) {
-        err = _Py_InitializeMainInterpreter(&main_config);
+        err = _Py_InitializeMainInterpreter(interp, &main_config);
     }
     _PyMainInterpreterConfig_Clear(&main_config);
 
@@ -2615,11 +2703,17 @@ pymain_cmdline(_PyMain *pymain)
     _Py_CommandLineDetails cmdline;
     memset(&cmdline, 0, sizeof(cmdline));
 
-    pymain_get_global_config(pymain, &cmdline);
+    cmdline_get_global_config(&cmdline);
+    _PyCoreConfig_GetGlobalConfig(&pymain->config);
 
     int res = pymain_cmdline_impl(pymain, &cmdline);
 
-    pymain_set_global_config(pymain, &cmdline);
+    cmdline_set_global_config(&cmdline);
+    _PyCoreConfig_SetGlobalConfig(&pymain->config);
+    if (Py_IsolatedFlag) {
+        Py_IgnoreEnvironmentFlag = 1;
+        Py_NoUserSiteDirectory = 1;
+    }
 
     pymain_clear_cmdline(pymain, &cmdline);
 
@@ -2649,16 +2743,13 @@ pymain_main(_PyMain *pymain)
 
     pymain_init_stdio(pymain);
 
-    /* bpo-34008: For backward compatibility reasons, calling Py_Main() after
-       Py_Initialize() ignores the new configuration. */
-    if (!_PyRuntime.initialized) {
-        pymain->err = _Py_InitializeCore(&pymain->config);
-        if (_Py_INIT_FAILED(pymain->err)) {
-            _Py_FatalInitError(pymain->err);
-        }
+    PyInterpreterState *interp;
+    pymain->err = _Py_InitializeCore(&interp, &pymain->config);
+    if (_Py_INIT_FAILED(pymain->err)) {
+        _Py_FatalInitError(pymain->err);
     }
 
-    if (pymain_init_python_main(pymain) < 0) {
+    if (pymain_init_python_main(pymain, interp) < 0) {
         _Py_FatalInitError(pymain->err);
     }
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1733,7 +1733,7 @@ cmdline_get_env_flags(_Py_CommandLineDetails *cmdline)
 
 /* Set global variable variables from environment variables */
 void
-_Py_Initialize_ReadEnvVars(void)
+_Py_Initialize_ReadEnvVarsNoAlloc(void)
 {
     _Py_CommandLineDetails cmdline;
     memset(&cmdline, 0, sizeof(cmdline));

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1945,6 +1945,12 @@ pymain_read_conf_impl(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
         return -1;
     }
 
+#ifdef MS_WINDOWS
+    if (cmdline->legacy_windows_fs_encoding) {
+        config->utf8_mode = 0;
+    }
+#endif
+
     if (pymain_init_core_argv(pymain, cmdline) < 0) {
         return -1;
     }
@@ -2213,12 +2219,6 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
     _PyInitError err;
 
     _PyCoreConfig_GetGlobalConfig(config);
-
-#ifdef MS_WINDOWS
-    if (cmdline->legacy_windows_fs_encoding) {
-        config->utf8_mode = 0;
-    }
-#endif
 
     assert(config->ignore_environment >= 0);
     if (!config->ignore_environment) {

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -74,17 +74,24 @@ main(int argc, char *argv[])
     }
     text[text_size] = '\0';
 
+    _PyCoreConfig config = _PyCoreConfig_INIT;
+    config.program_name = L"./_freeze_importlib";
+    /* Don't install importlib, since it could execute outdated bytecode. */
+    config._disable_importlib = 1;
+
     Py_NoUserSiteDirectory++;
     Py_NoSiteFlag++;
     Py_IgnoreEnvironmentFlag++;
     Py_FrozenFlag++;
 
-    Py_SetProgramName(L"./_freeze_importlib");
-    /* Don't install importlib, since it could execute outdated bytecode. */
-    _PyInitError err = _Py_InitializeEx_Private(1, 0);
+
+    _PyInitError err = _Py_InitializeFromConfig(&config);
+    /* No need to call _PyCoreConfig_Clear() since we didn't allocate any
+       memory: program_name is a constant string. */
     if (_Py_INIT_FAILED(err)) {
         _Py_FatalInitError(err);
     }
+
 
     if (strstr(inpath, "_external") != NULL) {
         is_bootstrap = 0;

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -374,7 +374,7 @@ dump_config(void)
     /* FIXME: test legacy_windows_stdio */
 
     printf("_disable_importlib = %i\n", config->_disable_importlib);
-    printf("_Py_CheckHashBasedPycsMode = %s\n", _Py_CheckHashBasedPycsMode);
+    /* cannot test _Py_CheckHashBasedPycsMode: the symbol is not exported */
     printf("Py_FrozenFlag = %i\n", Py_FrozenFlag);
 
 #undef ASSERT_EQUAL

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -1,4 +1,5 @@
 #include <Python.h>
+#include "internal/import.h"
 #include "pythread.h"
 #include <inttypes.h>
 #include <stdio.h>
@@ -292,6 +293,293 @@ static int test_initialize_pymain(void)
 }
 
 
+static void
+dump_config(void)
+{
+#define ASSERT_EQUAL(a, b) \
+    if ((a) != (b)) { \
+        printf("ERROR: %s != %s (%i != %i)\n", #a, #b, (a), (b)); \
+        exit(1); \
+    }
+#define ASSERT_STR_EQUAL(a, b) \
+    if ((a) == NULL || (b == NULL) || wcscmp((a), (b)) != 0) { \
+        printf("ERROR: %s != %s ('%ls' != '%ls')\n", #a, #b, (a), (b)); \
+        exit(1); \
+    }
+
+    PyInterpreterState *interp = PyThreadState_Get()->interp;
+    _PyCoreConfig *config = &interp->core_config;
+
+    printf("install_signal_handlers = %i\n", config->install_signal_handlers);
+
+    printf("Py_IgnoreEnvironmentFlag = %i\n", Py_IgnoreEnvironmentFlag);
+
+    printf("use_hash_seed = %i\n", config->use_hash_seed);
+    printf("hash_seed = %lu\n", config->hash_seed);
+
+    printf("allocator = %s\n", config->allocator);
+
+    printf("dev_mode = %i\n", config->dev_mode);
+    printf("faulthandler = %i\n", config->faulthandler);
+    printf("tracemalloc = %i\n", config->tracemalloc);
+    printf("import_time = %i\n", config->import_time);
+    printf("show_ref_count = %i\n", config->show_ref_count);
+    printf("show_alloc_count = %i\n", config->show_alloc_count);
+    printf("dump_refs = %i\n", config->dump_refs);
+    printf("malloc_stats = %i\n", config->malloc_stats);
+
+    printf("coerce_c_locale = %i\n", config->coerce_c_locale);
+    printf("coerce_c_locale_warn = %i\n", config->coerce_c_locale_warn);
+    printf("utf8_mode = %i\n", config->utf8_mode);
+
+    printf("program_name = %ls\n", config->program_name);
+    ASSERT_STR_EQUAL(config->program_name, Py_GetProgramName());
+
+    printf("argc = %i\n", config->argc);
+    printf("argv = [");
+    for (int i=0; i < config->argc; i++) {
+        if (i) {
+            printf(", ");
+        }
+        printf("\"%ls\"", config->argv[i]);
+    }
+    printf("]\n");
+
+    printf("program = %ls\n", config->program);
+    /* FIXME: test xoptions */
+    /* FIXME: test warnoptions */
+    /* FIXME: test module_search_path_env */
+    /* FIXME: test home */
+    /* FIXME: test module_search_paths */
+    /* FIXME: test executable */
+    /* FIXME: test prefix */
+    /* FIXME: test base_prefix */
+    /* FIXME: test exec_prefix */
+    /* FIXME: test base_exec_prefix */
+    /* FIXME: test dll_path */
+
+    printf("Py_IsolatedFlag = %i\n", Py_IsolatedFlag);
+    printf("Py_NoSiteFlag = %i\n", Py_NoSiteFlag);
+    printf("Py_BytesWarningFlag = %i\n", Py_BytesWarningFlag);
+    printf("Py_InspectFlag = %i\n", Py_InspectFlag);
+    printf("Py_InteractiveFlag = %i\n", Py_InteractiveFlag);
+    printf("Py_OptimizeFlag = %i\n", Py_OptimizeFlag);
+    printf("Py_DebugFlag = %i\n", Py_DebugFlag);
+    printf("Py_DontWriteBytecodeFlag = %i\n", Py_DontWriteBytecodeFlag);
+    printf("Py_VerboseFlag = %i\n", Py_VerboseFlag);
+    printf("Py_QuietFlag = %i\n", Py_QuietFlag);
+    printf("Py_NoUserSiteDirectory = %i\n", Py_NoUserSiteDirectory);
+    printf("Py_UnbufferedStdioFlag = %i\n", Py_UnbufferedStdioFlag);
+    /* FIXME: test legacy_windows_fs_encoding */
+    /* FIXME: test legacy_windows_stdio */
+
+    printf("_disable_importlib = %i\n", config->_disable_importlib);
+    printf("_Py_CheckHashBasedPycsMode = %s\n", _Py_CheckHashBasedPycsMode);
+    printf("Py_FrozenFlag = %i\n", Py_FrozenFlag);
+
+#undef ASSERT_EQUAL
+#undef ASSERT_STR_EQUAL
+}
+
+
+static int test_init_default_config(void)
+{
+    _testembed_Py_Initialize();
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+
+static int test_init_global_config(void)
+{
+    /* FIXME: test Py_IgnoreEnvironmentFlag */
+
+    putenv("PYTHONUTF8=0");
+    Py_UTF8Mode = 1;
+
+    /* Test initialization from global configuration variables (Py_xxx) */
+    Py_SetProgramName(L"./globalvar");
+
+    /* Py_IsolatedFlag is not tested */
+    Py_NoSiteFlag = 1;
+    Py_BytesWarningFlag = 1;
+
+    putenv("PYTHONINSPECT=");
+    Py_InspectFlag = 1;
+
+    putenv("PYTHONOPTIMIZE=0");
+    Py_InteractiveFlag = 1;
+
+    putenv("PYTHONDEBUG=0");
+    Py_OptimizeFlag = 2;
+
+    /* Py_DebugFlag is not tested */
+
+    putenv("PYTHONDONTWRITEBYTECODE=");
+    Py_DontWriteBytecodeFlag = 1;
+
+    putenv("PYTHONVERBOSE=0");
+    Py_VerboseFlag = 1;
+
+    Py_QuietFlag = 1;
+    Py_NoUserSiteDirectory = 1;
+
+    putenv("PYTHONUNBUFFERED=");
+    Py_UnbufferedStdioFlag = 1;
+
+    Py_FrozenFlag = 1;
+
+    /* FIXME: test Py_LegacyWindowsFSEncodingFlag */
+    /* FIXME: test Py_LegacyWindowsStdioFlag */
+
+    Py_Initialize();
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+
+static int test_init_from_config(void)
+{
+    /* Test _Py_InitializeFromConfig() */
+    _PyCoreConfig config = _PyCoreConfig_INIT;
+    config.install_signal_handlers = 0;
+
+    /* FIXME: test ignore_environment */
+
+    putenv("PYTHONHASHSEED=42");
+    config.use_hash_seed = 1;
+    config.hash_seed = 123;
+
+    putenv("PYTHONMALLOC=malloc");
+    config.allocator = "malloc_debug";
+
+    /* dev_mode=1 is tested in test_init_dev_mode() */
+
+    putenv("PYTHONFAULTHANDLER=");
+    config.faulthandler = 1;
+
+    putenv("PYTHONTRACEMALLOC=0");
+    config.tracemalloc = 2;
+
+    putenv("PYTHONPROFILEIMPORTTIME=0");
+    config.import_time = 1;
+
+    config.show_ref_count = 1;
+    config.show_alloc_count = 1;
+    /* FIXME: test dump_refs: bpo-34223 */
+
+    putenv("PYTHONMALLOCSTATS=0");
+    config.malloc_stats = 1;
+
+    /* FIXME: test coerce_c_locale and coerce_c_locale_warn */
+
+    putenv("PYTHONUTF8=0");
+    Py_UTF8Mode = 0;
+    config.utf8_mode = 1;
+
+    Py_SetProgramName(L"./globalvar");
+    config.program_name = L"./conf_program_name";
+
+    /* FIXME: test argc/argv */
+    config.program = L"conf_program";
+    /* FIXME: test xoptions */
+    /* FIXME: test warnoptions */
+    /* FIXME: test module_search_path_env */
+    /* FIXME: test home */
+    /* FIXME: test path config: module_search_path .. dll_path */
+
+    _PyInitError err = _Py_InitializeFromConfig(&config);
+    /* Don't call _PyCoreConfig_Clear() since all strings are static */
+    if (_Py_INIT_FAILED(err)) {
+        _Py_FatalInitError(err);
+    }
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+
+static void test_init_env_putenvs(void)
+{
+    putenv("PYTHONHASHSEED=42");
+    putenv("PYTHONMALLOC=malloc_debug");
+    putenv("PYTHONTRACEMALLOC=2");
+    putenv("PYTHONPROFILEIMPORTTIME=1");
+    putenv("PYTHONMALLOCSTATS=1");
+    putenv("PYTHONUTF8=1");
+    putenv("PYTHONVERBOSE=1");
+    putenv("PYTHONINSPECT=1");
+    putenv("PYTHONOPTIMIZE=2");
+    putenv("PYTHONDONTWRITEBYTECODE=1");
+    putenv("PYTHONUNBUFFERED=1");
+    putenv("PYTHONNOUSERSITE=1");
+    putenv("PYTHONFAULTHANDLER=1");
+    putenv("PYTHONDEVMODE=1");
+    /* FIXME: test PYTHONWARNINGS */
+    /* FIXME: test PYTHONEXECUTABLE */
+    /* FIXME: test PYTHONHOME */
+    /* FIXME: test PYTHONDEBUG */
+    /* FIXME: test PYTHONDUMPREFS */
+    /* FIXME: test PYTHONCOERCECLOCALE */
+    /* FIXME: test PYTHONPATH */
+}
+
+
+static int test_init_env(void)
+{
+    /* Test initialization from environment variables */
+    Py_IgnoreEnvironmentFlag = 0;
+    test_init_env_putenvs();
+    _testembed_Py_Initialize();
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+
+static int test_init_isolated(void)
+{
+    /* Test _PyCoreConfig.isolated=1 */
+    _PyCoreConfig config = _PyCoreConfig_INIT;
+
+    /* Set coerce_c_locale and utf8_mode to not depend on the locale */
+    config.coerce_c_locale = 0;
+    config.utf8_mode = 0;
+    /* Use path starting with "./" avoids a search along the PATH */
+    config.program_name = L"./_testembed";
+
+    Py_IsolatedFlag = 1;
+
+    test_init_env_putenvs();
+    _PyInitError err = _Py_InitializeFromConfig(&config);
+    if (_Py_INIT_FAILED(err)) {
+        _Py_FatalInitError(err);
+    }
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+
+static int test_init_dev_mode(void)
+{
+    _PyCoreConfig config = _PyCoreConfig_INIT;
+    putenv("PYTHONFAULTHANDLER=");
+    putenv("PYTHONMALLOC=");
+    config.dev_mode = 1;
+    config.program_name = L"./_testembed";
+    _PyInitError err = _Py_InitializeFromConfig(&config);
+    if (_Py_INIT_FAILED(err)) {
+        _Py_FatalInitError(err);
+    }
+    dump_config();
+    Py_Finalize();
+    return 0;
+}
+
+
 /* *********************************************************
  * List of test cases and the function that implements it.
  *
@@ -318,6 +606,12 @@ static struct TestCase TestCases[] = {
     { "bpo20891", test_bpo20891 },
     { "initialize_twice", test_initialize_twice },
     { "initialize_pymain", test_initialize_pymain },
+    { "init_default_config", test_init_default_config },
+    { "init_global_config", test_init_global_config },
+    { "init_from_config", test_init_from_config },
+    { "init_env", test_init_env },
+    { "init_dev_mode", test_init_dev_mode },
+    { "init_isolated", test_init_isolated },
     { NULL, NULL }
 };
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -627,12 +627,12 @@ _Py_InitializeCore_impl(PyInterpreterState **interp_p,
     if (_PyRuntime.core_initialized) {
         PyThreadState *tstate = PyThreadState_GET();
         if (!tstate) {
-            return _Py_INIT_ERR("failed to read thread state");
+            return _Py_INIT_ERR("no thread state found");
         }
 
         interp = tstate->interp;
         if (interp == NULL) {
-            return _Py_INIT_ERR("can't make main interpreter");
+            return _Py_INIT_ERR("no main interpreter found");
         }
         *interp_p = interp;
 
@@ -981,7 +981,7 @@ _Py_InitializeMainInterpreter(PyInterpreterState *interp,
 _PyInitError
 _Py_InitializeFromConfig(const _PyCoreConfig *config)
 {
-    _Py_Initialize_ReadEnvVars();
+    _Py_Initialize_ReadEnvVarsNoAlloc();
 
     PyInterpreterState *interp;
     _PyInitError err;


### PR DESCRIPTION
* -X dev: it is now possible to override the memory allocator using
  PYTHONMALLOC even if the developer mode is enabled.
* Add _Py_InitializeFromConfig()
* Add _Py_Initialize_ReadEnvVars() to set global configuration
  variables from environment variables
* Fix the code to initialize Python: Py_Initialize() now also reads
  environment variables
* _Py_InitializeCore() can now be called repeatedly: the second
  and subsequent calls only replace the configuration, they don't
  recreate the main interpreter
* Write unit tests on Py_Initialize() and the different ways to
  configure Python
* The isolated mode now always sets Py_IgnoreEnvironmentFlag and
  Py_NoUserSiteDirectory to 1.
* pymain_read_conf() now saves/restores the configuration
  if the encoding changed

<!-- issue-number: [bpo-34247](https://www.bugs.python.org/issue34247) -->
https://bugs.python.org/issue34247
<!-- /issue-number -->
