### PR TITLE
bpo-34333: Fix %-formatting in Path.with_suffix()

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -813,7 +813,7 @@ class PurePath(object):
         """
         f = self._flavour
         if f.sep in suffix or f.altsep and f.altsep in suffix:
-            raise ValueError("Invalid suffix %r" % (suffix))
+            raise ValueError("Invalid suffix %r" % (suffix,))
         if suffix and not suffix.startswith('.') or suffix == '.':
             raise ValueError("Invalid suffix %r" % (suffix))
         name = self.name

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -577,6 +577,8 @@ class _BasePurePathTest(object):
         self.assertRaises(ValueError, P('a/b').with_suffix, '.c/.d')
         self.assertRaises(ValueError, P('a/b').with_suffix, './.d')
         self.assertRaises(ValueError, P('a/b').with_suffix, '.d/.')
+        self.assertRaises(ValueError, P('a/b').with_suffix,
+                          (self.flavour.sep, 'd'))
 
     def test_relative_to_common(self):
         P = self.cls

--- a/Misc/NEWS.d/next/Library/2018-08-04-00-06-28.bpo-34333.5NHG93.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-04-00-06-28.bpo-34333.5NHG93.rst
@@ -1,0 +1,1 @@
+Fix %-formatting in :meth:`pathlib.PurePath.with_suffix`.

--- a/Misc/NEWS.d/next/Library/2018-08-04-00-06-28.bpo-34333.5NHG93.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-04-00-06-28.bpo-34333.5NHG93.rst
@@ -1,1 +1,2 @@
-Fix %-formatting in :meth:`pathlib.PurePath.with_suffix`.
+Fix %-formatting in :meth:`pathlib.PurePath.with_suffix` when formatting an
+error message.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34333](https://www.bugs.python.org/issue34333) -->
https://bugs.python.org/issue34333
<!-- /issue-number -->
