### PR TITLE
bpo-34335: Do not mix @asyncio.coroutine decorator and await in asyncio docs

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -431,8 +431,7 @@ Simple example querying HTTP headers of the URL passed on the command line::
     import urllib.parse
     import sys
 
-    @asyncio.coroutine
-    def print_http_headers(url):
+    async def print_http_headers(url):
         url = urllib.parse.urlsplit(url)
         if url.scheme == 'https':
             connect = asyncio.open_connection(url.hostname, 443, ssl=True)

--- a/Doc/library/asyncio-subprocess.rst
+++ b/Doc/library/asyncio-subprocess.rst
@@ -392,8 +392,7 @@ function::
     import asyncio.subprocess
     import sys
 
-    @asyncio.coroutine
-    def get_date():
+    async def get_date():
         code = 'import datetime; print(datetime.datetime.now())'
 
         # Create the subprocess, redirect the standard output into a pipe


### PR DESCRIPTION
This is a leftover from:
[bpo-32258](https://www.bugs.python.org/issue32258): Replace 'yield from' to 'await' in asyncio docs (#4779)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34335](https://www.bugs.python.org/issue34335) -->
https://bugs.python.org/issue34335
<!-- /issue-number -->
