### PR TITLE
bpo-34047: IDLE: fix mousewheel scrolling direction on macOS

### DIFF
--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -457,12 +457,19 @@ class EditorWindow(object):
         return 'break'
 
     def mousescroll(self, event):
-        "Handle scroll wheel."
-        up = {EventType.MouseWheel: (event.delta >= 0) == darwin,
+        """Handle scrollwheel event.
+
+        For wheel up, event.delta = 120*n on Windows, -1*n on darwin,
+        where n can be > 1 if one scrolls fast.  Flicking the wheel
+        generates up to maybe 20 events with n up to 10 or more 1.
+        Macs use wheel down (delta = 1*n) to scroll up, so positive
+        delta means to scroll up on both systems.
+
+        X-11 sends Control-Button-4 event instead.
+        """
+        up = {EventType.MouseWheel: event.delta > 0,
               EventType.Button: event.num == 4}
-        lines = 5
-        if up[event.type]:
-            lines = -lines
+        lines = -5 if up[event.type] else 5
         self.text.yview_scroll(lines, 'units')
         return 'break'
 
@@ -1701,7 +1708,11 @@ def _editor_window(parent):  # htest #
         filename = None
     macosx.setupApp(root, None)
     edit = EditorWindow(root=root, filename=filename)
-    edit.text.bind("<<close-all-windows>>", edit.close_event)
+    text = edit.text
+    text['height'] = 10
+    for i in range(20):
+        text.insert('insert', '  '*i + str(i) + '\n')
+    # text.bind("<<close-all-windows>>", edit.close_event)
     # Does not stop error, neither does following
     # edit.text.bind("<<close-window>>", edit.close_event)
 

--- a/Lib/idlelib/editor.py
+++ b/Lib/idlelib/editor.py
@@ -458,7 +458,7 @@ class EditorWindow(object):
 
     def mousescroll(self, event):
         "Handle scroll wheel."
-        up = {EventType.MouseWheel: event.delta >= 0 == darwin,
+        up = {EventType.MouseWheel: (event.delta >= 0) == darwin,
               EventType.Button: event.num == 4}
         lines = 5
         if up[event.type]:

--- a/Misc/NEWS.d/next/IDLE/2018-08-05-15-49-55.bpo-34047.LGKsIm.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-08-05-15-49-55.bpo-34047.LGKsIm.rst
@@ -1,0 +1,1 @@
+Fixed mousewheel scrolling direction on macOS.


### PR DESCRIPTION
Thanks to Vlad Tudorache for discovering the cause of the bug!

<!-- issue-number: [bpo-34047](https://www.bugs.python.org/issue34047) -->
https://bugs.python.org/issue34047
<!-- /issue-number -->
