### PR TITLE
[2.7] bpo-34236: Remove mistakenly backported Test6012 in test_capi.py

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -102,12 +102,6 @@ class TestPendingCalls(unittest.TestCase):
         self.pendingcalls_wait(l, n)
 
 
-# Bug #6012
-class Test6012(unittest.TestCase):
-    def test(self):
-        self.assertEqual(_testcapi.argparsing("Hello", "World"), 1)
-
-
 class TestGetIndices(unittest.TestCase):
 
     def test_get_indices(self):


### PR DESCRIPTION
This was backported by mistake in ef19fd2.

<!-- issue-number: [bpo-34236](https://www.bugs.python.org/issue34236) -->
https://bugs.python.org/issue34236
<!-- /issue-number -->
