### PR TITLE
[2.7] bpo-34273: Change 'Fixed point' to 'Fixed-point notation'. (GH-…

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -464,10 +464,10 @@ The available presentation types for floating point and decimal values are:
    | ``'E'`` | Exponent notation. Same as ``'e'`` except it uses an     |
    |         | upper case 'E' as the separator character.               |
    +---------+----------------------------------------------------------+
-   | ``'f'`` | Fixed point. Displays the number as a fixed-point        |
-   |         | number.  The default precision is ``6``.                 |
+   | ``'f'`` | Fixed-point notation. Displays the number as a           |
+   |         | fixed-point number.  The default precision is ``6``.     |
    +---------+----------------------------------------------------------+
-   | ``'F'`` | Fixed point. Same as ``'f'``.                            |
+   | ``'F'`` | Fixed point notation. Same as ``'f'``.                   |
    +---------+----------------------------------------------------------+
    | ``'g'`` | General format.  For a given precision ``p >= 1``,       |
    |         | this rounds the number to ``p`` significant digits and   |


### PR DESCRIPTION
…8673)

The change in the mini language floating point and decimal table
is consistent with 'Exponential notation' and clarifies that we
are referring to the output notation, not an object type.

(cherry picked from commit 28c7f8c8ce34a0cb848822a252a9d0a761fb42d5)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34273](https://www.bugs.python.org/issue34273) -->
https://bugs.python.org/issue34273
<!-- /issue-number -->
