### PR TITLE
bpo-2122: Make mmap.flush() behave same on all platforms

### DIFF
--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -191,11 +191,13 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
       changes to the given range of bytes will be flushed to disk; otherwise, the
       whole extent of the mapping is flushed.
 
-      A zero value is returned to indicate success. An
-      exception is raised when the call failed.
+      ``None`` is returned to indicate success. An exception is raised when the
+      call failed.
 
       .. versionchanged:: 3.8
-         Previously, a nonzero value was returned on success under Windows.
+         Previously, a nonzero value was returned on success; zero was returned
+         on error under Windows and a zero value was returned on success; an
+         exception was raised on error under Unix.
 
 
    .. method:: move(dest, src, count)

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -191,11 +191,11 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
       changes to the given range of bytes will be flushed to disk; otherwise, the
       whole extent of the mapping is flushed.
 
-      **(Windows version)** A nonzero value returned indicates success; zero
-      indicates failure.
-
-      **(Unix version)** A zero value is returned to indicate success. An
+      A zero value is returned to indicate success. An
       exception is raised when the call failed.
+
+      .. versionchanged:: 3.8
+         Previously, a nonzero value was returned on success under Windows.
 
 
    .. method:: move(dest, src, count)

--- a/Doc/library/mmap.rst
+++ b/Doc/library/mmap.rst
@@ -191,12 +191,12 @@ To map anonymous memory, -1 should be passed as the fileno along with the length
       changes to the given range of bytes will be flushed to disk; otherwise, the
       whole extent of the mapping is flushed.
 
-      ``None`` is returned to indicate success. An exception is raised when the
+      ``None`` is returned to indicate success.  An exception is raised when the
       call failed.
 
       .. versionchanged:: 3.8
          Previously, a nonzero value was returned on success; zero was returned
-         on error under Windows and a zero value was returned on success; an
+         on error under Windows.  A zero value was returned on success; an
          exception was raised on error under Unix.
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -267,9 +267,9 @@ Changes in the Python API
 
 * The :meth:`mmap.flush() <mmap.mmap.flush>` method now returns ``None`` on
   success and raises an exception on error under all platforms.  Previously,
-  a nonzero value was returned on success; zero was returned on error under
-  Windows and a zero value was returned on success; an exception was raised on
-  error under Unix.
+  its behavior was platform-depended: a nonzero value was returned on success;
+  zero was returned on error under Windows.  A zero value was returned on
+  success; an exception was raised on error under Unix.
   (Contributed by Berker Peksag in :issue:`2122`.)
 
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -265,6 +265,13 @@ Changes in the Python API
   task name is visible in the ``repr()`` output of :class:`asyncio.Task` and
   can also be retrieved using the :meth:`~asyncio.Task.get_name` method.
 
+* The :meth:`mmap.flush() <mmap.mmap.flush>` method now returns ``None`` on
+  success and raises an exception on error under all platforms.  Previously,
+  a nonzero value was returned on success; zero was returned on error under
+  Windows and a zero value was returned on success; an exception was raised on
+  error under Unix.
+  (Contributed by Berker Peksag in :issue:`2122`.)
+
 
 CPython bytecode changes
 ------------------------

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -1,4 +1,4 @@
-from test.support import (TESTFN, run_unittest, import_module, unlink,
+from test.support import (TESTFN, import_module, unlink,
                           requires, _2G, _4G, gc_collect, cpython_only)
 import unittest
 import os
@@ -741,6 +741,15 @@ class MmapTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             m * 2
 
+    def test_flush_return_value(self):
+        # mm.flush() should return zero on success, raise an
+        # exception on error under all platforms.
+        mm = mmap.mmap(-1, 16)
+        mm.write(b"python")
+        result = mm.flush()
+        self.assertEqual(result, 0)
+        mm.close()
+
 
 class LargeMmapTests(unittest.TestCase):
 
@@ -803,8 +812,5 @@ class LargeMmapTests(unittest.TestCase):
         self._test_around_boundary(_4G)
 
 
-def test_main():
-    run_unittest(MmapTests, LargeMmapTests)
-
 if __name__ == '__main__':
-    test_main()
+    unittest.main()

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -742,12 +742,12 @@ class MmapTests(unittest.TestCase):
             m * 2
 
     def test_flush_return_value(self):
-        # mm.flush() should return zero on success, raise an
+        # mm.flush() should return None on success, raise an
         # exception on error under all platforms.
         mm = mmap.mmap(-1, 16)
-        mm.write(b"python")
+        mm.write(b'python')
         result = mm.flush()
-        self.assertEqual(result, 0)
+        self.assertIsNone(result)
         mm.close()
 
 

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -750,6 +750,7 @@ class MmapTests(unittest.TestCase):
         result = mm.flush()
         self.assertIsNone(result)
         if os.name != 'nt':
+            # 'offset' must be a multiple of mmap.PAGESIZE.
             self.assertRaises(OSError, mm.flush, 1, len(b'python'))
 
 

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -748,6 +748,7 @@ class MmapTests(unittest.TestCase):
         mm.write(b'python')
         result = mm.flush()
         self.assertIsNone(result)
+        self.assertRaises(OSError, mm.flush, 1, len(b'python'))
         mm.close()
 
 

--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -745,11 +745,12 @@ class MmapTests(unittest.TestCase):
         # mm.flush() should return None on success, raise an
         # exception on error under all platforms.
         mm = mmap.mmap(-1, 16)
+        self.addCleanup(mm.close)
         mm.write(b'python')
         result = mm.flush()
         self.assertIsNone(result)
-        self.assertRaises(OSError, mm.flush, 1, len(b'python'))
-        mm.close()
+        if os.name != 'nt':
+            self.assertRaises(OSError, mm.flush, 1, len(b'python'))
 
 
 class LargeMmapTests(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-08-06-21-47-03.bpo-2122.GWdmrm.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-06-21-47-03.bpo-2122.GWdmrm.rst
@@ -1,2 +1,2 @@
-:meth:`mmap.mmap.flush` now returns zero on success, raises :exc:`OSError`
-on error under Windows.
+The :meth:`mmap.flush() <mmap.mmap.flush>` method now returns ``None`` on
+success, raises an exception on error under all platforms.

--- a/Misc/NEWS.d/next/Library/2018-08-06-21-47-03.bpo-2122.GWdmrm.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-06-21-47-03.bpo-2122.GWdmrm.rst
@@ -1,0 +1,2 @@
+:meth:`mmap.mmap.flush` now returns zero on success, raises :exc:`OSError`
+on error under Windows.

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -572,7 +572,11 @@ mmap_flush_method(mmap_object *self, PyObject *args)
         return PyLong_FromLong(0);
 
 #ifdef MS_WINDOWS
-    return PyLong_FromLong((long) FlushViewOfFile(self->data+offset, size));
+    if (!FlushViewOfFile(self->data+offset, size)) {
+        PyErr_SetFromWindowsErr(GetLastError());
+        return NULL;
+    }
+    return PyLong_FromLong(0);
 #elif defined(UNIX)
     /* XXX semantics of return value? */
     /* XXX flags for msync? */

--- a/Modules/mmapmodule.c
+++ b/Modules/mmapmodule.c
@@ -569,22 +569,21 @@ mmap_flush_method(mmap_object *self, PyObject *args)
     }
 
     if (self->access == ACCESS_READ || self->access == ACCESS_COPY)
-        return PyLong_FromLong(0);
+        Py_RETURN_NONE;
 
 #ifdef MS_WINDOWS
     if (!FlushViewOfFile(self->data+offset, size)) {
         PyErr_SetFromWindowsErr(GetLastError());
         return NULL;
     }
-    return PyLong_FromLong(0);
+    Py_RETURN_NONE;
 #elif defined(UNIX)
-    /* XXX semantics of return value? */
     /* XXX flags for msync? */
     if (-1 == msync(self->data + offset, size, MS_SYNC)) {
         PyErr_SetFromErrno(PyExc_OSError);
         return NULL;
     }
-    return PyLong_FromLong(0);
+    Py_RETURN_NONE;
 #else
     PyErr_SetString(PyExc_ValueError, "flush not supported on this system");
     return NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-2122](https://www.bugs.python.org/issue2122) -->
https://bugs.python.org/issue2122
<!-- /issue-number -->
