### PR TITLE
bpo-34353: Added sockets to stat.filemode fallback python implementation

### DIFF
--- a/Lib/stat.py
+++ b/Lib/stat.py
@@ -111,6 +111,7 @@ SF_SNAPSHOT  = 0x00200000  # file is a snapshot file
 
 _filemode_table = (
     ((S_IFLNK,         "l"),
+     (S_IFSOCK,        "s"),  # Must appear before IFREG and IFDIR as IFSOCK == IFREG | IFDIR
      (S_IFREG,         "-"),
      (S_IFBLK,         "b"),
      (S_IFDIR,         "d"),

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import socket
 import sys
 from test.support import TESTFN, import_fresh_module
 
@@ -190,6 +191,17 @@ class TestFilemode:
                 self.assertEqual(modestr[0], 'b')
                 self.assertS_IS("BLK", st_mode)
                 break
+
+    @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), 'requires unix socket')
+    def test_socket(self):
+        s = socket.socket(socket.AF_UNIX)
+        s.bind(TESTFN)
+        try:
+            st_mode, modestr = self.get_mode()
+            self.assertEqual(modestr[0], 's')
+            self.assertS_IS("SOCK", st_mode)
+        finally:
+            s.close()
 
     def test_module_attributes(self):
         for key, value in self.stat_struct.items():

--- a/Lib/test/test_stat.py
+++ b/Lib/test/test_stat.py
@@ -194,14 +194,11 @@ class TestFilemode:
 
     @unittest.skipUnless(hasattr(socket, 'AF_UNIX'), 'requires unix socket')
     def test_socket(self):
-        s = socket.socket(socket.AF_UNIX)
-        s.bind(TESTFN)
-        try:
+        with socket.socket(socket.AF_UNIX) as s:
+            s.bind(TESTFN)
             st_mode, modestr = self.get_mode()
             self.assertEqual(modestr[0], 's')
             self.assertS_IS("SOCK", st_mode)
-        finally:
-            s.close()
 
     def test_module_attributes(self):
         for key, value in self.stat_struct.items():

--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-09-18-42-49.bpo-34353.GIOm_8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-09-18-42-49.bpo-34353.GIOm_8.rst
@@ -1,0 +1,2 @@
+Added the "socket" option in the `stat.filemode()` Python implementation to
+match the C implementation.


### PR DESCRIPTION
```
[bpo-34353](https://www.bugs.python.org/issue34353): Add sockets to stat.filemode fallback python implementation
```

<!-- issue-number: [bpo-34353](https://www.bugs.python.org/issue34353) -->
https://bugs.python.org/issue34353
<!-- /issue-number -->
