### PR TITLE
Assume the raw environ is always declared.

### DIFF
--- a/Lib/os.py
+++ b/Lib/os.py
@@ -525,12 +525,6 @@ if {open, stat} <= supports_dir_fd and {scandir, stat} <= supports_fd:
 
     __all__.append("fwalk")
 
-# Make sure os.environ exists, at least
-try:
-    environ
-except NameError:
-    environ = {}
-
 def execl(file, *args):
     """execl(file, *args)
 


### PR DESCRIPTION
posixmodule.c always declares environ, so don't bother catching a NameError in os.py.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
