### PR TITLE
bpo-33989: Ensure that ms.key_compare is always initialized in list_sort_impl()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-08-20-52-55.bpo-33989.TkLBui.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-08-20-52-55.bpo-33989.TkLBui.rst
@@ -1,0 +1,2 @@
+Ensure that ``ms.key_compare`` is always initialized in :meth:`list.sort`.
+Patch by Zackery Spytz.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-08-20-52-55.bpo-33989.TkLBui.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-08-20-52-55.bpo-33989.TkLBui.rst
@@ -1,2 +1,2 @@
-Ensure that ``ms.key_compare`` is always initialized in :meth:`list.sort`.
-Patch by Zackery Spytz.
+Fix a possible crash in :meth:`list.sort` when sorting objects with
+``ob_type->tp_richcompare == NULL``.  Patch by Zackery Spytz.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2280,6 +2280,9 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
             else if ((ms.key_richcompare = key_type->tp_richcompare) != NULL) {
                 ms.key_compare = unsafe_object_compare;
             }
+            else {
+                ms.key_compare = safe_object_compare;
+            }
         }
         else {
             ms.key_compare = safe_object_compare;


### PR DESCRIPTION


<!-- issue-number: [bpo-33989](https://www.bugs.python.org/issue33989) -->
https://bugs.python.org/issue33989
<!-- /issue-number -->
