### PR TITLE
bpo-32745: Fix a regression in the handling of ctypes' c_wchar_p type

### DIFF
--- a/Lib/ctypes/test/test_unicode.py
+++ b/Lib/ctypes/test/test_unicode.py
@@ -26,6 +26,14 @@ class UnicodeTestCase(unittest.TestCase):
         self.assertEqual(buf[::2], 'a\xe4\xfc')
         self.assertEqual(buf[6:5:-1], "")
 
+    def test_embedded_null(self):
+        class TestStruct(ctypes.Structure):
+            _fields_ = [("unicode", ctypes.c_wchar_p)]
+        t = TestStruct()
+        # This would raise a ValueError.
+        t.unicode = "foo\0bar\0\0"
+
+
 func = ctypes.CDLL(_ctypes_test.__file__)._testfunc_p_p
 
 class StringTestCase(UnicodeTestCase):

--- a/Lib/ctypes/test/test_unicode.py
+++ b/Lib/ctypes/test/test_unicode.py
@@ -30,7 +30,7 @@ class UnicodeTestCase(unittest.TestCase):
         class TestStruct(ctypes.Structure):
             _fields_ = [("unicode", ctypes.c_wchar_p)]
         t = TestStruct()
-        # This would raise a ValueError.
+        # This would raise a ValueError:
         t.unicode = "foo\0bar\0\0"
 
 

--- a/Misc/NEWS.d/next/Library/2018-08-09-23-47-10.bpo-32745.iQi9hI.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-09-23-47-10.bpo-32745.iQi9hI.rst
@@ -1,0 +1,3 @@
+Fix a regression in the handling of ctypes' :data:`ctypes.c_wchar_p` type:
+embedded null characters would cause a :exc:`ValueError` to be raised. Patch
+by Zackery Spytz.

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -1355,6 +1355,7 @@ Z_set(void *ptr, PyObject *value, Py_ssize_t size)
 {
     PyObject *keep;
     wchar_t *buffer;
+    Py_ssize_t bsize;
 
     if (value == Py_None) {
         *(wchar_t **)ptr = NULL;
@@ -1378,7 +1379,7 @@ Z_set(void *ptr, PyObject *value, Py_ssize_t size)
 
     /* We must create a wchar_t* buffer from the unicode object,
        and keep it alive */
-    buffer = PyUnicode_AsWideCharString(value, NULL);
+    buffer = PyUnicode_AsWideCharString(value, &bsize);
     if (!buffer)
         return NULL;
     keep = PyCapsule_New(buffer, CTYPES_CFIELD_CAPSULE_NAME_PYMEM, pymem_destructor);


### PR DESCRIPTION
Embedded nulls would cause a ValueError to be raised. Thanks go to
Eryk Sun for their analysis.

<!-- issue-number: [bpo-32745](https://www.bugs.python.org/issue32745) -->
https://bugs.python.org/issue32745
<!-- /issue-number -->
