### PR TITLE
bpo-34373: fix test_mktime and test_pthread_getcpuclickid tests on AIX

### DIFF
--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -438,13 +438,6 @@ class TimeTestCase(unittest.TestCase):
     def test_mktime(self):
         # Issue #1726687
         for t in (-2, -1, 0, 1):
-            if sys.platform.startswith('aix') and t == -1:
-                # Issue #11188, #19748: mktime() returns -1 on error. On Linux,
-                # the tm_wday field is used as a sentinel () to detect if -1 is
-                # really an error or a valid timestamp. On AIX, tm_wday is
-                # unchanged even on success and so cannot be used as a
-                # sentinel.
-                continue
             try:
                 tt = time.localtime(t)
             except (OverflowError, OSError):

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -124,9 +124,16 @@ class TimeTestCase(unittest.TestCase):
     @unittest.skipUnless(hasattr(time, 'clock_gettime'),
                          'need time.clock_gettime()')
     def test_pthread_getcpuclockid(self):
+        from ctypes import c_void_p, sizeof
         clk_id = time.pthread_getcpuclockid(threading.get_ident())
         self.assertTrue(type(clk_id) is int)
-        self.assertNotEqual(clk_id, time.CLOCK_THREAD_CPUTIME_ID)
+        # when in 32-bit mode AIX only returns the predefined constant
+        if not sys.platform.startswith("aix"):
+            self.assertNotEqual(clk_id, time.CLOCK_THREAD_CPUTIME_ID)
+        elif ((sizeof(c_void_p) * 8) == 64):
+            self.assertNotEqual(clk_id, time.CLOCK_THREAD_CPUTIME_ID)
+        else:
+            self.assertEqual(clk_id, time.CLOCK_THREAD_CPUTIME_ID)
         t1 = time.clock_gettime(clk_id)
         t2 = time.clock_gettime(clk_id)
         self.assertLessEqual(t1, t2)

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -124,13 +124,12 @@ class TimeTestCase(unittest.TestCase):
     @unittest.skipUnless(hasattr(time, 'clock_gettime'),
                          'need time.clock_gettime()')
     def test_pthread_getcpuclockid(self):
-        from ctypes import c_void_p, sizeof
         clk_id = time.pthread_getcpuclockid(threading.get_ident())
         self.assertTrue(type(clk_id) is int)
         # when in 32-bit mode AIX only returns the predefined constant
-        if not sys.platform.startswith("aix"):
+        if not platform.system() == "AIX":
             self.assertNotEqual(clk_id, time.CLOCK_THREAD_CPUTIME_ID)
-        elif ((sizeof(c_void_p) * 8) == 64):
+        elif (sys.maxsize.bit_length() > 32):
             self.assertNotEqual(clk_id, time.CLOCK_THREAD_CPUTIME_ID)
         else:
             self.assertEqual(clk_id, time.CLOCK_THREAD_CPUTIME_ID)

--- a/Misc/NEWS.d/next/Tests/2018-08-10-16-17-51.bpo-34373.SKdb1k.rst
+++ b/Misc/NEWS.d/next/Tests/2018-08-10-16-17-51.bpo-34373.SKdb1k.rst
@@ -1,2 +1,3 @@
-fix test_mktime and test_pthread_getcpuclickid tests
-add range checking for _PyTime_localtime (for AIX)
+Fix ``test_mktime`` and ``test_pthread_getcpuclickid`` tests for AIX
+Add range checking for ``_PyTime_localtime`` for AIX
+Patch by Michael Felt

--- a/Misc/NEWS.d/next/Tests/2018-08-10-16-17-51.bpo-34373.SKdb1k.rst
+++ b/Misc/NEWS.d/next/Tests/2018-08-10-16-17-51.bpo-34373.SKdb1k.rst
@@ -1,0 +1,2 @@
+fix test_mktime and test_pthread_getcpuclickid tests
+add range checking for _PyTime_localtime (for AIX)

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -948,7 +948,7 @@ time_mktime(PyObject *self, PyObject *tup)
 #ifdef _AIX
     time_t clk;
     int     year = buf.tm_year;
-    int     days = 0;
+    int     delta_days = 0;
 #endif
 
     if (!gettmarg(tup, &buf,
@@ -968,20 +968,21 @@ time_mktime(PyObject *self, PyObject *tup)
                         "mktime argument out of range");
         return NULL;
     }
-    /* year < 1970 */
-    if (year < 70) do {
+    year = buf.tm_year;
+    /* year < 1970 - adjust buf.tm_year into legal range */
+    while (buf.tm_year < 70) {
         buf.tm_year += 4;
-        days -= (366 + (365 * 3));
-    } while (buf.tm_year < 70);
+        delta_days -= (366 + (365 * 3));
+    }
 
     buf.tm_wday = -1;
     clk = mktime(&buf);
     buf.tm_year = year;
 
-    if (buf.tm_wday != -1 && days)
-        buf.tm_wday = (buf.tm_wday + days) % 7;
+    if (buf.tm_wday != -1 && delta_days)
+        buf.tm_wday = (buf.tm_wday + delta_days) % 7;
 
-    tt = clk + (days * (24 * 3600));
+    tt = clk + (delta_days * (24 * 3600));
 #endif
     /* Return value of -1 does not necessarily mean an error, but tm_wday
      * cannot remain set to -1 if mktime succeeded. */

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -979,7 +979,7 @@ time_mktime(PyObject *self, PyObject *tup)
     clk = mktime(&buf);
     buf.tm_year = year;
 
-    if (buf.tm_wday != -1 && delta_days)
+    if ((buf.tm_wday != -1) && delta_days)
         buf.tm_wday = (buf.tm_wday + delta_days) % 7;
 
     tt = clk + (delta_days * (24 * 3600));

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -967,8 +967,8 @@ time_mktime(PyObject *self, PyObject *tup)
         /* year < 1970 */
         if (year < 70) do
         {
-                buf.tm_year += 4;
-                days -= (366 + (365 * 3));
+            buf.tm_year += 4;
+            days -= (366 + (365 * 3));
         } while (buf.tm_year < 70);
 
         buf.tm_wday = -1;
@@ -976,9 +976,9 @@ time_mktime(PyObject *self, PyObject *tup)
         buf.tm_year = year;
 
         if (buf.tm_wday != -1 && days)
-                buf.tm_wday = (buf.tm_wday + days) % 7;
+            buf.tm_wday = (buf.tm_wday + days) % 7;
 
-	tt = clk + (days * (24 * 3600));
+        tt = clk + (days * (24 * 3600));
     }
 #else
     buf.tm_wday = -1;  /* sentinel; original value ignored */

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1062,6 +1062,22 @@ _PyTime_localtime(time_t t, struct tm *tm)
     }
     return 0;
 #else /* !MS_WINDOWS */
+#ifdef _AIX
+	/*
+	 * AIX does not return NULL on an error
+	 * so test ranges - asif!
+	 * (1902-01-01, -2145916800.0)
+	 * (2038-01-01,  2145916800.0)
+	 */
+    if (abs(t) > (time_t) 2145916800) {
+#ifdef EINVAL
+            errno = EINVAL;
+#endif
+            PyErr_SetString(PyExc_OverflowError,
+                "ctime argument out of range");
+            return -1;
+    }
+#endif
     if (localtime_r(&t, tm) == NULL) {
 #ifdef EINVAL
         if (errno == 0) {

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -1063,19 +1063,17 @@ _PyTime_localtime(time_t t, struct tm *tm)
     return 0;
 #else /* !MS_WINDOWS */
 #ifdef _AIX
-	/*
-	 * AIX does not return NULL on an error
-	 * so test ranges - asif!
-	 * (1902-01-01, -2145916800.0)
-	 * (2038-01-01,  2145916800.0)
-	 */
+    /* AIX does not return NULL on an error
+       so test ranges - asif!
+       (1902-01-01, -2145916800.0)
+       (2038-01-01,  2145916800.0) */
     if (abs(t) > (time_t) 2145916800) {
 #ifdef EINVAL
-            errno = EINVAL;
+        errno = EINVAL;
 #endif
-            PyErr_SetString(PyExc_OverflowError,
-                "ctime argument out of range");
-            return -1;
+        PyErr_SetString(PyExc_OverflowError,
+                        "ctime argument out of range");
+        return -1;
     }
 #endif
     if (localtime_r(&t, tm) == NULL) {


### PR DESCRIPTION
fix test_mktime and test_pthread_getcpuclickid tests
add range checking for _PyTime_localtime (for AIX)


<!-- issue-number: [bpo-34373](https://www.bugs.python.org/issue34373) -->
https://bugs.python.org/issue34373
<!-- /issue-number -->
