### PR TITLE
bpo-34363: Handle namedtuples fields correctly in asdict() and astuple().

### DIFF
--- a/Lib/dataclasses.py
+++ b/Lib/dataclasses.py
@@ -1020,8 +1020,14 @@ def _asdict_inner(obj, dict_factory):
             value = _asdict_inner(getattr(obj, f.name), dict_factory)
             result.append((f.name, value))
         return dict_factory(result)
-    elif isinstance(obj, (list, tuple)):
+    elif type(obj) in (list, tuple):
+        # Actual list or tuple.
         return type(obj)(_asdict_inner(v, dict_factory) for v in obj)
+    elif isinstance(obj, (list, tuple)):
+        # Subclass of list or tuple. Probably a namedtuple, whose
+        # __new__ works differently than tuple.__new__ does with
+        # respect to iterators.
+        return type(obj)(*[_asdict_inner(v, dict_factory) for v in obj])
     elif isinstance(obj, dict):
         return type(obj)((_asdict_inner(k, dict_factory), _asdict_inner(v, dict_factory))
                           for k, v in obj.items())
@@ -1060,8 +1066,14 @@ def _astuple_inner(obj, tuple_factory):
             value = _astuple_inner(getattr(obj, f.name), tuple_factory)
             result.append(value)
         return tuple_factory(result)
-    elif isinstance(obj, (list, tuple)):
+    elif type(obj) in (list, tuple):
+        # Actual list or tuple.
         return type(obj)(_astuple_inner(v, tuple_factory) for v in obj)
+    elif isinstance(obj, (list, tuple)):
+        # Subclass of list or tuple. Probably a namedtuple, whose
+        # __new__ works differently than tuple.__new__ does with
+        # respect to iterators.
+        return type(obj)(*[_astuple_inner(v, tuple_factory) for v in obj])
     elif isinstance(obj, dict):
         return type(obj)((_astuple_inner(k, tuple_factory), _astuple_inner(v, tuple_factory))
                           for k, v in obj.items())

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -1309,7 +1309,7 @@ class TestCase(unittest.TestCase):
                 # Make sure we copied these objects and aren't using the
                 # originals.
                 self.assertIsNot(d['nt1'], inst1)
-                self.assertIsNot(d['nt2'], inst1)
+                self.assertIsNot(d['nt2'], inst2)
                 # Due to the way that namedtuples compare to tuples, check
                 # that dict values can be accessed by field name (that is,
                 # they're namedtuples not tuples).
@@ -1458,7 +1458,7 @@ class TestCase(unittest.TestCase):
                 # Make sure we copied these objects and aren't using the
                 # originals.
                 self.assertIsNot(t[1], inst1)
-                self.assertIsNot(t[2], inst1)
+                self.assertIsNot(t[2], inst2)
                 # Due to the way that namedtuples compare to tuples, check
                 # that dict values can be accessed by field name (that is,
                 # they're namedtuples not tuples).

--- a/Lib/test/test_dataclasses.py
+++ b/Lib/test/test_dataclasses.py
@@ -8,7 +8,7 @@ import pickle
 import inspect
 import unittest
 from unittest.mock import Mock
-from typing import ClassVar, Any, List, Union, Tuple, Dict, Generic, TypeVar, Optional
+from typing import ClassVar, Any, List, Union, Tuple, Dict, Generic, TypeVar, Optional, NamedTuple
 from collections import deque, OrderedDict, namedtuple
 from functools import total_ordering
 
@@ -1281,6 +1281,42 @@ class TestCase(unittest.TestCase):
         self.assertEqual(asdict(c), {'x': 42, 'y': 2})
         self.assertIs(type(asdict(c)), dict)
 
+    def test_helper_asdict_namedtuple(self):
+        nt1 = namedtuple('nt1', 'f')
+        nt2 = namedtuple('nt2', 'f1 f2')
+
+        class NT1(NamedTuple):
+            f: Any
+
+        class NT2(NamedTuple):
+            f1: Any
+            f2: Any
+
+        # Test with both namedtuple and NamedTuple.
+        for type1, type2 in ((nt1, nt2), (NT1, NT2)):
+            with self.subTest(type1=type1, type2=type2):
+                @dataclass
+                class C:
+                    i1: int
+                    nt1: type1
+                    nt2: type2
+
+                inst1 = type1((1,))
+                inst2 = type2((3,), (5, 6))
+                c = C(3, inst1, inst2)
+                d = asdict(c)
+                self.assertEqual(d, {'i1': 3, 'nt1': inst1, 'nt2': inst2})
+                # Make sure we copied these objects and aren't using the
+                # originals.
+                self.assertIsNot(d['nt1'], inst1)
+                self.assertIsNot(d['nt2'], inst1)
+                # Due to the way that namedtuples compare to tuples, check
+                # that dict values can be accessed by field name (that is,
+                # they're namedtuples not tuples).
+                self.assertEqual(d['nt1'].f, (1,))
+                self.assertEqual(d['nt2'].f1, (3,))
+                self.assertEqual(d['nt2'].f2, (5, 6))
+
     def test_helper_asdict_raises_on_classes(self):
         # asdict() should raise on a class object.
         @dataclass
@@ -1393,6 +1429,42 @@ class TestCase(unittest.TestCase):
         c.y = 42
         self.assertEqual(astuple(c), (1, 42))
         self.assertIs(type(astuple(c)), tuple)
+
+    def test_helper_astuple_namedtuple(self):
+        nt1 = namedtuple('nt1', 'f')
+        nt2 = namedtuple('nt2', 'f1 f2')
+
+        class NT1(NamedTuple):
+            f: Any
+
+        class NT2(NamedTuple):
+            f1: Any
+            f2: Any
+
+        # Test with both namedtuple and NamedTuple.
+        for type1, type2 in ((nt1, nt2), (NT1, NT2)):
+            with self.subTest(type1=type1, type2=type2):
+                @dataclass
+                class C:
+                    i1: int
+                    nt1: type1
+                    nt2: type2
+
+                inst1 = type1((1,))
+                inst2 = type2((3,), (5, 6))
+                c = C(3, inst1, inst2)
+                t = astuple(c)
+                self.assertEqual(t, (3, inst1, inst2))
+                # Make sure we copied these objects and aren't using the
+                # originals.
+                self.assertIsNot(t[1], inst1)
+                self.assertIsNot(t[2], inst1)
+                # Due to the way that namedtuples compare to tuples, check
+                # that dict values can be accessed by field name (that is,
+                # they're namedtuples not tuples).
+                self.assertEqual(t[1].f, (1,))
+                self.assertEqual(t[2].f1, (3,))
+                self.assertEqual(t[2].f2, (5, 6))
 
     def test_helper_astuple_raises_on_classes(self):
         # astuple() should raise on a class object.

--- a/Misc/NEWS.d/next/Library/2018-08-10-14-22-02.bpo-34363.OLQ4w1.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-10-14-22-02.bpo-34363.OLQ4w1.rst
@@ -1,0 +1,1 @@
+Handle namedtuple fields correct in dataclasses.astuple() and .asdict().


### PR DESCRIPTION


<!-- issue-number: [bpo-34363](https://www.bugs.python.org/issue34363) -->
https://bugs.python.org/issue34363
<!-- /issue-number -->
