### PR TITLE
bpo-34377: update valgrind suppressions

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-10-15-05-00.bpo-34377.EJMMY4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-10-15-05-00.bpo-34377.EJMMY4.rst
@@ -1,0 +1,3 @@
+Update valgrind suppression list to use
+``_PyObject_Free``/``_PyObject_Realloc``
+instead of ``PyObject_Free``/``PyObject_Realloc``.

--- a/Misc/valgrind-python.supp
+++ b/Misc/valgrind-python.supp
@@ -11,7 +11,7 @@
 # to use the preferred suppressions with address_in_range.
 #
 # If you do not want to recompile Python, you can uncomment
-# suppressions for PyObject_Free and PyObject_Realloc.
+# suppressions for _PyObject_Free and _PyObject_Realloc.
 #
 # See Misc/README.valgrind for more information.
 
@@ -127,61 +127,61 @@
 ###{
 ###   ADDRESS_IN_RANGE/Invalid read of size 4
 ###   Memcheck:Addr4
-###   fun:PyObject_Free
+###   fun:_PyObject_Free
 ###}
 ###
 ###{
 ###   ADDRESS_IN_RANGE/Invalid read of size 4
 ###   Memcheck:Value4
-###   fun:PyObject_Free
+###   fun:_PyObject_Free
 ###}
 ###
 ###{
 ###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
 ###   Memcheck:Addr8
-###   fun:PyObject_Free
+###   fun:_PyObject_Free
 ###}
 ###
 ###{
 ###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
 ###   Memcheck:Value8
-###   fun:PyObject_Free
+###   fun:_PyObject_Free
 ###}
 ###
 ###{
 ###   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
 ###   Memcheck:Cond
-###   fun:PyObject_Free
+###   fun:_PyObject_Free
 ###}
 
 ###{
 ###   ADDRESS_IN_RANGE/Invalid read of size 4
 ###   Memcheck:Addr4
-###   fun:PyObject_Realloc
+###   fun:_PyObject_Realloc
 ###}
 ###
 ###{
 ###   ADDRESS_IN_RANGE/Invalid read of size 4
 ###   Memcheck:Value4
-###   fun:PyObject_Realloc
+###   fun:_PyObject_Realloc
 ###}
 ###
 ###{
 ###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
 ###   Memcheck:Addr8
-###   fun:PyObject_Realloc
+###   fun:_PyObject_Realloc
 ###}
 ###
 ###{
 ###   ADDRESS_IN_RANGE/Use of uninitialised value of size 8
 ###   Memcheck:Value8
-###   fun:PyObject_Realloc
+###   fun:_PyObject_Realloc
 ###}
 ###
 ###{
 ###   ADDRESS_IN_RANGE/Conditional jump or move depends on uninitialised value
 ###   Memcheck:Cond
-###   fun:PyObject_Realloc
+###   fun:_PyObject_Realloc
 ###}
 
 ###


### PR DESCRIPTION
valgrind isn't seeing PyObject_Free/PyObject_Realloc.
Using _PyObject_Free/_PyObject_Realloc works.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34377](https://www.bugs.python.org/issue34377) -->
https://bugs.python.org/issue34377
<!-- /issue-number -->
