### PR TITLE
bpo-34379: Move note for json.dump to function's docs

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -188,6 +188,11 @@ Basic Usage
    .. versionchanged:: 3.6
       All optional parameters are now :ref:`keyword-only <keyword-only_parameter>`.
 
+   .. note::
+
+      Unlike :mod:`pickle` and :mod:`marshal`, JSON is not a framed protocol,
+      so trying to serialize multiple objects with repeated calls to
+      :func:`dump` using the same *fp* will result in an invalid JSON file.
 
 .. function:: dumps(obj, *, skipkeys=False, ensure_ascii=True, \
                     check_circular=True, allow_nan=True, cls=None, \
@@ -197,12 +202,6 @@ Basic Usage
    Serialize *obj* to a JSON formatted :class:`str` using this :ref:`conversion
    table <py-to-json-table>`.  The arguments have the same meaning as in
    :func:`dump`.
-
-   .. note::
-
-      Unlike :mod:`pickle` and :mod:`marshal`, JSON is not a framed protocol,
-      so trying to serialize multiple objects with repeated calls to
-      :func:`dump` using the same *fp* will result in an invalid JSON file.
 
    .. note::
 


### PR DESCRIPTION
I wasn't sure whether the `versionchanged` or `note` should go first. There's an example in the docs for `datetime` where `versionchanged` is first so I went with the same order.

Thank you for reviewing and please feel free to request changes as desired.

<!-- issue-number: [bpo-34379](https://www.bugs.python.org/issue34379) -->
https://bugs.python.org/issue34379
<!-- /issue-number -->
