### PR TITLE
Remove obsolete comment about latin-1 in `normalize_encoding`

### DIFF
--- a/Lib/encodings/__init__.py
+++ b/Lib/encodings/__init__.py
@@ -49,8 +49,7 @@ def normalize_encoding(encoding):
         collapsed and replaced with a single underscore, e.g. '  -;#'
         becomes '_'. Leading and trailing underscores are removed.
 
-        Note that encoding names should be ASCII only; if they do use
-        non-ASCII characters, these must be Latin-1 compatible.
+        Note that encoding names should be ASCII only.
 
     """
     if isinstance(encoding, bytes):


### PR DESCRIPTION
This docstring has drifted since python2: https://github.com/python/cpython/blob/ca079a3ea30098aff3197c559a0e32d42dda6d84/Lib/encodings/__init__.py#L68