### PR TITLE
bpo-34384: Fix os.readlink() on Windows

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -2014,8 +2014,10 @@ features:
       The *dir_fd* argument.
 
    .. versionchanged:: 3.6
-      Accepts a :term:`path-like object`.
+      Accepts a :term:`path-like object` on Unix.
 
+   .. versionchanged:: 3.8
+      Accepts a :term:`path-like object` and a bytes object on Windows.
 
 .. function:: remove(path, *, dir_fd=None)
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2079,8 +2079,8 @@ class Win32SymlinkTests(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'readlink'), 'needs os.readlink()')
     def test_readlink_pathlike(self):
-        os.symlink(self.filelink_target, self.filelink)
         import pathlib
+        os.symlink(self.filelink_target, self.filelink)
         filelink = pathlib.Path(self.filelink)
         self.assertEqual(os.readlink(filelink), self.filelink_target)
 

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2070,6 +2070,8 @@ class ReadlinkTests(unittest.TestCase):
         self.assertEqual(os.readlink(filelink), self.filelink_target)
 
     @support.skip_unless_symlink
+    @unittest.skipIf(sys.platform == 'win32',
+                     'os.readlink() always returns str on Windows')
     def test_pathlike_bytes(self):
         os.symlink(self.filelinkb_target, self.filelinkb)
         self.addCleanup(support.unlink, self.filelinkb)
@@ -2078,6 +2080,8 @@ class ReadlinkTests(unittest.TestCase):
         self.assertIsInstance(path, bytes)
 
     @support.skip_unless_symlink
+    @unittest.skipIf(sys.platform == 'win32',
+                     'os.readlink() always returns str on Windows')
     def test_bytes(self):
         os.symlink(self.filelinkb_target, self.filelinkb)
         self.addCleanup(support.unlink, self.filelinkb)

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2039,6 +2039,53 @@ class Win32ListdirTests(unittest.TestCase):
                 [os.fsencode(path) for path in self.created_paths])
 
 
+@unittest.skipUnless(hasattr(os, 'readlink'), 'needs os.readlink()')
+class ReadlinkTests(unittest.TestCase):
+    filelink = 'readlinktest'
+    filelink_target = os.path.abspath(__file__)
+    filelinkb = os.fsencode(filelink)
+    filelinkb_target = os.fsencode(filelink_target)
+
+    def setUp(self):
+        self.assertTrue(os.path.exists(self.filelink_target))
+        self.assertTrue(os.path.exists(self.filelinkb_target))
+        self.assertFalse(os.path.exists(self.filelink))
+        self.assertFalse(os.path.exists(self.filelinkb))
+
+    def test_not_symlink(self):
+        filelink_target = FakePath(self.filelink_target)
+        self.assertRaises(OSError, os.readlink, self.filelink_target)
+        self.assertRaises(OSError, os.readlink, filelink_target)
+
+    def test_missing_link(self):
+        self.assertRaises(FileNotFoundError, os.readlink, 'missing-link')
+        self.assertRaises(FileNotFoundError, os.readlink,
+                          FakePath('missing-link'))
+
+    @support.skip_unless_symlink
+    def test_pathlike(self):
+        os.symlink(self.filelink_target, self.filelink)
+        self.addCleanup(support.unlink, self.filelink)
+        filelink = FakePath(self.filelink)
+        self.assertEqual(os.readlink(filelink), self.filelink_target)
+
+    @support.skip_unless_symlink
+    def test_pathlike_bytes(self):
+        os.symlink(self.filelinkb_target, self.filelinkb)
+        self.addCleanup(support.unlink, self.filelinkb)
+        path = os.readlink(FakePath(self.filelinkb))
+        self.assertEqual(path, self.filelinkb_target)
+        self.assertIsInstance(path, bytes)
+
+    @support.skip_unless_symlink
+    def test_bytes(self):
+        os.symlink(self.filelinkb_target, self.filelinkb)
+        self.addCleanup(support.unlink, self.filelinkb)
+        path = os.readlink(self.filelinkb)
+        self.assertEqual(path, self.filelinkb_target)
+        self.assertIsInstance(path, bytes)
+
+
 @unittest.skipUnless(sys.platform == "win32", "Win32 specific tests")
 @support.skip_unless_symlink
 class Win32SymlinkTests(unittest.TestCase):
@@ -2076,12 +2123,6 @@ class Win32SymlinkTests(unittest.TestCase):
         self.assertTrue(os.path.isfile(self.filelink))
         self.assertTrue(os.path.islink(self.filelink))
         self.check_stat(self.filelink, self.filelink_target)
-
-    @unittest.skipUnless(hasattr(os, 'readlink'), 'needs os.readlink()')
-    def test_readlink_pathlike(self):
-        os.symlink(self.filelink_target, self.filelink)
-        filelink = FakePath(self.filelink)
-        self.assertEqual(os.readlink(filelink), self.filelink_target)
 
     def _create_missing_dir_link(self):
         'Create a "directory" link to a non-existent target'

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2079,15 +2079,8 @@ class Win32SymlinkTests(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'readlink'), 'needs os.readlink()')
     def test_readlink_pathlike(self):
-        import pathlib
         os.symlink(self.filelink_target, self.filelink)
-        filelink = pathlib.Path(self.filelink)
-        print()
-        print('Debug prints:')
-        print('filelink:', filelink)
-        print('readlink:', os.readlink(filelink))
-        print('target:', self.filelink_target)
-        print()
+        filelink = FakePath(self.filelink)
         self.assertEqual(os.readlink(filelink), self.filelink_target)
 
     def _create_missing_dir_link(self):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2082,6 +2082,12 @@ class Win32SymlinkTests(unittest.TestCase):
         import pathlib
         os.symlink(self.filelink_target, self.filelink)
         filelink = pathlib.Path(self.filelink)
+        print()
+        print('Debug prints:')
+        print('filelink:', filelink)
+        print('readlink:', os.readlink(filelink))
+        print('target:', self.filelink_target)
+        print()
         self.assertEqual(os.readlink(filelink), self.filelink_target)
 
     def _create_missing_dir_link(self):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2070,8 +2070,6 @@ class ReadlinkTests(unittest.TestCase):
         self.assertEqual(os.readlink(filelink), self.filelink_target)
 
     @support.skip_unless_symlink
-    @unittest.skipIf(sys.platform == 'win32',
-                     'os.readlink() always returns str on Windows')
     def test_pathlike_bytes(self):
         os.symlink(self.filelinkb_target, self.filelinkb)
         self.addCleanup(support.unlink, self.filelinkb)
@@ -2080,8 +2078,6 @@ class ReadlinkTests(unittest.TestCase):
         self.assertIsInstance(path, bytes)
 
     @support.skip_unless_symlink
-    @unittest.skipIf(sys.platform == 'win32',
-                     'os.readlink() always returns str on Windows')
     def test_bytes(self):
         os.symlink(self.filelinkb_target, self.filelinkb)
         self.addCleanup(support.unlink, self.filelinkb)

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -2077,6 +2077,13 @@ class Win32SymlinkTests(unittest.TestCase):
         self.assertTrue(os.path.islink(self.filelink))
         self.check_stat(self.filelink, self.filelink_target)
 
+    @unittest.skipUnless(hasattr(os, 'readlink'), 'needs os.readlink()')
+    def test_readlink_pathlike(self):
+        os.symlink(self.filelink_target, self.filelink)
+        import pathlib
+        filelink = pathlib.Path(self.filelink)
+        self.assertEqual(os.readlink(filelink), self.filelink_target)
+
     def _create_missing_dir_link(self):
         'Create a "directory" link to a non-existent target'
         linkname = self.missing_link

--- a/Misc/NEWS.d/next/Library/2018-08-12-08-43-21.bpo-34384.yjofCv.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-12-08-43-21.bpo-34384.yjofCv.rst
@@ -1,0 +1,2 @@
+:func:`os.readlink` now accepts :term:`path-like objects <path-like object>`
+on Windows.

--- a/Misc/NEWS.d/next/Library/2018-08-12-08-43-21.bpo-34384.yjofCv.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-12-08-43-21.bpo-34384.yjofCv.rst
@@ -1,2 +1,2 @@
-:func:`os.readlink` now accepts :term:`path-like objects <path-like object>`
-on Windows.
+:func:`os.readlink` now accepts :term:`path-like <path-like object>` and
+:class:`bytes` objects on Windows.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7491,7 +7491,7 @@ win_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
     /* First get a handle to the reparse point */
     Py_BEGIN_ALLOW_THREADS
     reparse_point_handle = CreateFileW(
-        path,
+        path.wide,
         0,
         0,
         0,

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7419,12 +7419,11 @@ static PyObject *
 posix_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     path_t path;
-#if defined(HAVE_READLINK)
     int dir_fd = DEFAULT_DIR_FD;
+#if defined(HAVE_READLINK)
     char buffer[MAXPATHLEN+1];
     ssize_t length;
 #elif defined(MS_WINDOWS)
-    int dir_fd;
     DWORD n_bytes_returned;
     DWORD io_result;
     HANDLE reparse_point_handle;
@@ -7440,12 +7439,7 @@ posix_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
     path.function_name = "readlink";
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&|$O&:readlink", keywords,
                           path_converter, &path,
-#if defined(HAVE_READLINK)
-                          READLINKAT_DIR_FD_CONVERTER,
-#elif defined(MS_WINDOWS)
-                          dir_fd_unavailable,
-#endif
-                          &dir_fd))
+                          READLINKAT_DIR_FD_CONVERTER, &dir_fd))
         return NULL;
 
 #if defined(HAVE_READLINK)
@@ -7517,9 +7511,6 @@ posix_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
                           rdb->SymbolicLinkReparseBuffer.PrintNameLength / sizeof(wchar_t));
     if (path.narrow) {
         Py_SETREF(return_value, PyUnicode_EncodeFSDefault(return_value));
-        if (!return_value) {
-            goto exit;
-        }
     }
 #endif
 exit:

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7414,18 +7414,25 @@ If dir_fd is not None, it should be a file descriptor open to a directory,\n\
   and path should be relative; path will then be relative to that directory.\n\
 dir_fd may not be implemented on your platform.\n\
   If it is unavailable, using it will raise a NotImplementedError.");
-#endif
 
-#ifdef HAVE_READLINK
-
-/* AC 3.5: merge win32 and not together */
 static PyObject *
 posix_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
 {
     path_t path;
+#if defined(HAVE_READLINK)
     int dir_fd = DEFAULT_DIR_FD;
     char buffer[MAXPATHLEN+1];
     ssize_t length;
+#elif defined(MS_WINDOWS)
+    int dir_fd;
+    DWORD n_bytes_returned;
+    DWORD io_result;
+    HANDLE reparse_point_handle;
+
+    char target_buffer[_Py_MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
+    _Py_REPARSE_DATA_BUFFER *rdb = (_Py_REPARSE_DATA_BUFFER *)target_buffer;
+    const wchar_t *print_name;
+#endif
     PyObject *return_value = NULL;
     static char *keywords[] = {"path", "dir_fd", NULL};
 
@@ -7433,9 +7440,15 @@ posix_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
     path.function_name = "readlink";
     if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&|$O&:readlink", keywords,
                           path_converter, &path,
-                          READLINKAT_DIR_FD_CONVERTER, &dir_fd))
+#if defined(HAVE_READLINK)
+                          READLINKAT_DIR_FD_CONVERTER,
+#elif defined(MS_WINDOWS)
+                          dir_fd_unavailable,
+#endif
+                          &dir_fd))
         return NULL;
 
+#if defined(HAVE_READLINK)
     Py_BEGIN_ALLOW_THREADS
 #ifdef HAVE_READLINKAT
     if (dir_fd != DEFAULT_DIR_FD)
@@ -7455,39 +7468,7 @@ posix_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
         return_value = PyUnicode_DecodeFSDefaultAndSize(buffer, length);
     else
         return_value = PyBytes_FromStringAndSize(buffer, length);
-exit:
-    path_cleanup(&path);
-    return return_value;
-}
-
-#endif /* HAVE_READLINK */
-
-#if !defined(HAVE_READLINK) && defined(MS_WINDOWS)
-
-static PyObject *
-win_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
-{
-    path_t path;
-    DWORD n_bytes_returned;
-    DWORD io_result;
-    PyObject *result = NULL;
-    int dir_fd;
-    HANDLE reparse_point_handle;
-
-    char target_buffer[_Py_MAXIMUM_REPARSE_DATA_BUFFER_SIZE];
-    _Py_REPARSE_DATA_BUFFER *rdb = (_Py_REPARSE_DATA_BUFFER *)target_buffer;
-    const wchar_t *print_name;
-
-    static char *keywords[] = {"path", "dir_fd", NULL};
-
-    memset(&path, 0, sizeof(path));
-    path.function_name = "readlink";
-    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "O&|$O&:readlink", keywords,
-                          path_converter, &path,
-                          dir_fd_unavailable, &dir_fd
-                          ))
-        goto exit;
-
+#elif defined(MS_WINDOWS)
     /* First get a handle to the reparse point */
     Py_BEGIN_ALLOW_THREADS
     reparse_point_handle = CreateFileW(
@@ -7501,7 +7482,7 @@ win_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_END_ALLOW_THREADS
 
     if (reparse_point_handle == INVALID_HANDLE_VALUE) {
-        result = path_error(&path);
+        return_value = path_error(&path);
         goto exit;
     }
 
@@ -7519,7 +7500,7 @@ win_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
     Py_END_ALLOW_THREADS
 
     if (io_result == 0) {
-        result = path_error(&path);
+        return_value = path_error(&path);
         goto exit;
     }
 
@@ -7532,22 +7513,20 @@ win_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
     print_name = (wchar_t *)((char*)rdb->SymbolicLinkReparseBuffer.PathBuffer +
                  rdb->SymbolicLinkReparseBuffer.PrintNameOffset);
 
-    result = PyUnicode_FromWideChar(print_name,
-                    rdb->SymbolicLinkReparseBuffer.PrintNameLength / sizeof(wchar_t));
+    return_value = PyUnicode_FromWideChar(print_name,
+                          rdb->SymbolicLinkReparseBuffer.PrintNameLength / sizeof(wchar_t));
     if (path.narrow) {
-        Py_SETREF(result, PyUnicode_EncodeFSDefault(result));
-        if (!result) {
+        Py_SETREF(return_value, PyUnicode_EncodeFSDefault(return_value));
+        if (!return_value) {
             goto exit;
         }
     }
+#endif
 exit:
     path_cleanup(&path);
-    return result;
+    return return_value;
 }
-
-#endif /* !defined(HAVE_READLINK) && defined(MS_WINDOWS) */
-
-
+#endif /* defined(HAVE_READLINK) || defined(MS_WINDOWS) */
 
 #ifdef HAVE_SYMLINK
 
@@ -12960,16 +12939,11 @@ static PyMethodDef posix_methods[] = {
     OS_GETPRIORITY_METHODDEF
     OS_SETPRIORITY_METHODDEF
     OS_POSIX_SPAWN_METHODDEF
-#ifdef HAVE_READLINK
+#if defined(HAVE_READLINK) || defined(MS_WINDOWS)
     {"readlink",        (PyCFunction)posix_readlink,
                         METH_VARARGS | METH_KEYWORDS,
                         readlink__doc__},
-#endif /* HAVE_READLINK */
-#if !defined(HAVE_READLINK) && defined(MS_WINDOWS)
-    {"readlink",        (PyCFunction)win_readlink,
-                        METH_VARARGS | METH_KEYWORDS,
-                        readlink__doc__},
-#endif /* !defined(HAVE_READLINK) && defined(MS_WINDOWS) */
+#endif /* defined(HAVE_READLINK) || defined(MS_WINDOWS) */
     OS_RENAME_METHODDEF
     OS_REPLACE_METHODDEF
     OS_RMDIR_METHODDEF

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -7534,6 +7534,12 @@ win_readlink(PyObject *self, PyObject *args, PyObject *kwargs)
 
     result = PyUnicode_FromWideChar(print_name,
                     rdb->SymbolicLinkReparseBuffer.PrintNameLength / sizeof(wchar_t));
+    if (path.narrow) {
+        Py_SETREF(result, PyUnicode_EncodeFSDefault(result));
+        if (!result) {
+            goto exit;
+        }
+    }
 exit:
     path_cleanup(&path);
     return result;


### PR DESCRIPTION
os.readlink() now accepts path-like objects on Windows.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34384](https://www.bugs.python.org/issue34384) -->
https://bugs.python.org/issue34384
<!-- /issue-number -->
