### PR TITLE
bpo-33073: Adding as_integer_ratio to ints.

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -539,6 +539,12 @@ class`. In addition, it provides a few more methods:
 
     .. versionadded:: 3.2
 
+.. method:: int.as_integer_ratio()
+
+  Return a pair of integers whose ratio is exactly equal to the original integer
+  and with a positive denominator. The integer ratio of integers (whole numbers)
+  is always the integer as the numerator and 1 as the denominator.
+
 
 Additional Methods on Float
 ---------------------------
@@ -4734,4 +4740,3 @@ types, where they are relevant.  Some of these are not reported by the
 
 .. [5] To format only a tuple you should therefore provide a singleton tuple whose only
    element is the tuple to be formatted.
-

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -541,9 +541,10 @@ class`. In addition, it provides a few more methods:
 
 .. method:: int.as_integer_ratio()
 
-   Return a pair of integers whose ratio is exactly equal to the original integer
-   and with a positive denominator. The integer ratio of integers (whole numbers)
-   is always the integer as the numerator and 1 as the denominator.
+   Return a pair of integers whose ratio is exactly equal to the original
+   integer and with a positive denominator. The integer ratio of integers
+   (whole numbers) is always the integer as the numerator and 1 as the
+   denominator.
 
    .. versionadded:: 3.8
 

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -4742,3 +4742,4 @@ types, where they are relevant.  Some of these are not reported by the
 
 .. [5] To format only a tuple you should therefore provide a singleton tuple whose only
    element is the tuple to be formatted.
+

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -541,10 +541,11 @@ class`. In addition, it provides a few more methods:
 
 .. method:: int.as_integer_ratio()
 
-  Return a pair of integers whose ratio is exactly equal to the original integer
-  and with a positive denominator. The integer ratio of integers (whole numbers)
-  is always the integer as the numerator and 1 as the denominator.
+   Return a pair of integers whose ratio is exactly equal to the original integer
+   and with a positive denominator. The integer ratio of integers (whole numbers)
+   is always the integer as the numerator and 1 as the denominator.
 
+   .. versionadded:: 3.8
 
 Additional Methods on Float
 ---------------------------

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -543,7 +543,7 @@ class`. In addition, it provides a few more methods:
 
    Return a pair of integers whose ratio is exactly equal to the original
    integer and with a positive denominator. The integer ratio of integers
-   (whole numbers) is always the integer as the numerator and 1 as the
+   (whole numbers) is always the integer as the numerator and ``1`` as the
    denominator.
 
    .. versionadded:: 3.8

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -94,6 +94,10 @@ Other Language Changes
 * Added support of ``\N{name}`` escapes in :mod:`regular expressions <re>`.
   (Contributed by Jonathan Eunice and Serhiy Storchaka in :issue:`30688`.)
 
+* The ``int`` type now has a new ``as_integer_ratio`` method compatible
+  with the existing ``float.as_integer_ratio`` method.
+  (Contributed by Lisa Roach in :issue:`33073`.)
+
 
 New Modules
 ===========

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -91,12 +91,12 @@ Other Language Changes
   was lifted.
   (Contributed by Serhiy Storchaka in :issue:`32489`.)
 
-* Added support of ``\N{name}`` escapes in :mod:`regular expressions <re>`.
-  (Contributed by Jonathan Eunice and Serhiy Storchaka in :issue:`30688`.)
-
 * The ``int`` type now has a new ``as_integer_ratio`` method compatible
   with the existing ``float.as_integer_ratio`` method.
   (Contributed by Lisa Roach in :issue:`33073`.)
+
+* Added support of ``\N{name}`` escapes in :mod:`regular expressions <re>`.
+  (Contributed by Jonathan Eunice and Serhiy Storchaka in :issue:`30688`.)
 
 
 New Modules

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -675,7 +675,7 @@ plain ol' Python and is guaranteed to be available.
     2  builtins.float.hex
     1  builtins.hex
     1  builtins.int
-    4  builtins.int.as_integer_ratio
+    3  builtins.int.as_integer_ratio
     2  builtins.int.bit_length
     1  builtins.oct
 

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -665,7 +665,7 @@ plain ol' Python and is guaranteed to be available.
     True
     >>> real_tests = [t for t in tests if len(t.examples) > 0]
     >>> len(real_tests) # objects that actually have doctests
-    8
+    9
     >>> for t in real_tests:
     ...     print('{}  {}'.format(len(t.examples), t.name))
     ...

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -665,7 +665,7 @@ plain ol' Python and is guaranteed to be available.
     True
     >>> real_tests = [t for t in tests if len(t.examples) > 0]
     >>> len(real_tests) # objects that actually have doctests
-    8
+    9
     >>> for t in real_tests:
     ...     print('{}  {}'.format(len(t.examples), t.name))
     ...
@@ -675,6 +675,7 @@ plain ol' Python and is guaranteed to be available.
     2  builtins.float.hex
     1  builtins.hex
     1  builtins.int
+    4  builtins.int.as_integer_ratio
     2  builtins.int.bit_length
     1  builtins.oct
 

--- a/Lib/test/test_doctest.py
+++ b/Lib/test/test_doctest.py
@@ -675,6 +675,7 @@ plain ol' Python and is guaranteed to be available.
     2  builtins.float.hex
     1  builtins.hex
     1  builtins.int
+    4  builtins.int.as_integer_ratio
     2  builtins.int.bit_length
     1  builtins.oct
 

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -3,6 +3,7 @@ from test import support
 
 import sys
 
+import enum
 import random
 import math
 import array
@@ -1357,9 +1358,27 @@ class LongTest(unittest.TestCase):
             self.assertIsInstance(numerator, int)
             self.assertIsInstance(denominator, int)
 
+    def test_as_integer_ratio_maxint(self):
+        x = sys.maxsize + 1
+        self.assertEqual(x.as_integer_ratio()[0], x)
+
     def test_as_integer_ratio_bool(self):
         self.assertEqual(True.as_integer_ratio(), (1, 1))
         self.assertEqual(False.as_integer_ratio(), (0, 1))
+        assert(type(True.as_integer_ratio()[0]) == int)
+        assert(type(False.as_integer_ratio()[0]) == int)
+
+    def test_as_integer_ratio_int_enum(self):
+        class Foo(enum.IntEnum):
+            X = 42
+        self.assertEqual(Foo.X.as_integer_ratio(), (42, 1))
+        assert(type(Foo.X.as_integer_ratio()[0] == int))
+
+    def test_as_integer_ratio_int_flag(self):
+        class Foo(enum.IntFlag):
+            R = 1 << 2
+        self.assertEqual(Foo.R.as_integer_ratio(), (4, 1))
+        assert(type(Foo.R.as_integer_ratio()[0]) == int)
 
 
 

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1349,6 +1349,11 @@ class LongTest(unittest.TestCase):
                 self.assertEqual(type(value << shift), int)
                 self.assertEqual(type(value >> shift), int)
 
+    def test_as_integer_ratio(self):
+        tests = [10, 0, -10, 1, 3]
+        for value in tests:
+            self.assertEqual((value).as_integer_ratio(), (value, 1))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1350,9 +1350,17 @@ class LongTest(unittest.TestCase):
                 self.assertEqual(type(value >> shift), int)
 
     def test_as_integer_ratio(self):
-        tests = [10, 0, -10, 1, 3]
+        tests = [10, 0, -10, 1]
         for value in tests:
-            self.assertEqual(value.as_integer_ratio(), (value, 1))
+            numerator, denominator = value.as_integer_ratio()
+            self.assertEqual((numerator, denominator), (value, 1))
+            self.assertIsInstance(numerator, int)
+            self.assertIsInstance(denominator, int)
+
+    def test_as_integer_ratio_bool(self):
+        self.assertEqual(True.as_integer_ratio(), (1, 1))
+        self.assertEqual(False.as_integer_ratio(), (0, 1))
+
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1352,7 +1352,7 @@ class LongTest(unittest.TestCase):
     def test_as_integer_ratio(self):
         tests = [10, 0, -10, 1, 3]
         for value in tests:
-            self.assertEqual((value).as_integer_ratio(), (value, 1))
+            self.assertEqual(value.as_integer_ratio(), (value, 1))
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_long.py
+++ b/Lib/test/test_long.py
@@ -1365,20 +1365,20 @@ class LongTest(unittest.TestCase):
     def test_as_integer_ratio_bool(self):
         self.assertEqual(True.as_integer_ratio(), (1, 1))
         self.assertEqual(False.as_integer_ratio(), (0, 1))
-        assert(type(True.as_integer_ratio()[0]) == int)
-        assert(type(False.as_integer_ratio()[0]) == int)
+        self.assertEqual(type(True.as_integer_ratio()[0]), int)
+        self.assertEqual(type(False.as_integer_ratio()[0]), int)
 
     def test_as_integer_ratio_int_enum(self):
         class Foo(enum.IntEnum):
             X = 42
         self.assertEqual(Foo.X.as_integer_ratio(), (42, 1))
-        assert(type(Foo.X.as_integer_ratio()[0] == int))
+        self.assertEqual(type(Foo.X.as_integer_ratio()[0]), int)
 
     def test_as_integer_ratio_int_flag(self):
         class Foo(enum.IntFlag):
             R = 1 << 2
         self.assertEqual(Foo.R.as_integer_ratio(), (4, 1))
-        assert(type(Foo.R.as_integer_ratio()[0]) == int)
+        self.assertEqual(type(Foo.R.as_integer_ratio()[0]), int)
 
 
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1347,6 +1347,7 @@ Juan M. Bello Rivas
 Mohd Sanad Zaki Rizvi
 Davide Rizzo
 Anthony Roach
+Lisa Roach
 Carl Robben
 Ben Roberts
 Mark Roberts

--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-12-16-03-58.bpo-33073.XWu1Jh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-12-16-03-58.bpo-33073.XWu1Jh.rst
@@ -1,0 +1,1 @@
+Added as_integer_ratio to ints to make them more interoperable with floats.

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -129,12 +129,10 @@ PyDoc_STRVAR(int_as_integer_ratio__doc__,
 "\n"
 ">>> (10).as_integer_ratio()\n"
 "(10, 1)\n"
-">>> (0).as_integer_ratio()\n"
-"(0, 1)\n"
-">>> (11).as_integer_ratio()\n"
-"(11, 1)\n"
 ">>> (-10).as_integer_ratio()\n"
-"(-10, 1)");
+"(-10, 1)\n"
+">>> (0).as_integer_ratio()\n"
+"(0, 1)");
 
 #define INT_AS_INTEGER_RATIO_METHODDEF    \
     {"as_integer_ratio", (PyCFunction)int_as_integer_ratio, METH_NOARGS, int_as_integer_ratio__doc__},
@@ -241,4 +239,4 @@ int_from_bytes(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, PyOb
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=acfef50c38f681a0 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=6d5e92d7dc803751 input=a9049054013a1b77]*/

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -118,6 +118,38 @@ int_bit_length(PyObject *self, PyObject *Py_UNUSED(ignored))
     return int_bit_length_impl(self);
 }
 
+PyDoc_STRVAR(int_as_integer_ratio__doc__,
+"as_integer_ratio($self, /)\n"
+"--\n"
+"\n"
+"Return integer ratio.\n"
+"\n"
+"Return a pair of integers, whose ratio is exactly equal to the original int\n"
+"and with a positive denominator.\n"
+"\n"
+"Raise OverflowError on infinities and a ValueError on NaNs.\n"
+"\n"
+">>> (10).as_integer_ratio()\n"
+"(10, 1)\n"
+">>> (0).as_integer_ratio()\n"
+"(0, 1)\n"
+">>> (11).as_integer_ratio()\n"
+"(11, 1)\n"
+">>> (-10).as_integer_ratio()\n"
+"(-10, 1)");
+
+#define INT_AS_INTEGER_RATIO_METHODDEF    \
+    {"as_integer_ratio", (PyCFunction)int_as_integer_ratio, METH_NOARGS, int_as_integer_ratio__doc__},
+
+static PyObject *
+int_as_integer_ratio_impl(PyObject *self);
+
+static PyObject *
+int_as_integer_ratio(PyObject *self, PyObject *Py_UNUSED(ignored))
+{
+    return int_as_integer_ratio_impl(self);
+}
+
 PyDoc_STRVAR(int_to_bytes__doc__,
 "to_bytes($self, /, length, byteorder, *, signed=False)\n"
 "--\n"
@@ -211,4 +243,4 @@ int_from_bytes(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, PyOb
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=fd64beb83bd16df3 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d86862742f1a2709 input=a9049054013a1b77]*/

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -127,8 +127,6 @@ PyDoc_STRVAR(int_as_integer_ratio__doc__,
 "Return a pair of integers, whose ratio is exactly equal to the original int\n"
 "and with a positive denominator.\n"
 "\n"
-"Raise OverflowError on infinities and a ValueError on NaNs.\n"
-"\n"
 ">>> (10).as_integer_ratio()\n"
 "(10, 1)\n"
 ">>> (0).as_integer_ratio()\n"
@@ -243,4 +241,4 @@ int_from_bytes(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, PyOb
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=d86862742f1a2709 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=acfef50c38f681a0 input=a9049054013a1b77]*/

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5261,6 +5261,40 @@ long_is_finite(PyObject *v)
 #endif
 
 /*[clinic input]
+int.as_integer_ratio
+
+Return integer ratio.
+
+Return a pair of integers, whose ratio is exactly equal to the original int
+and with a positive denominator.
+
+Raise OverflowError on infinities and a ValueError on NaNs.
+
+>>> (10).as_integer_ratio()
+(10, 1)
+>>> (0).as_integer_ratio()
+(0, 1)
+>>> (11).as_integer_ratio()
+(11, 1)
+>>> (-10).as_integer_ratio()
+(-10, 1)
+[clinic start generated code]*/
+
+static PyObject *
+int_as_integer_ratio_impl(PyObject *self)
+/*[clinic end generated code: output=e60803ae1cc8621a input=ce9c7768a1287fb9]*/
+{
+    PyObject *denominator = NULL;
+    PyObject *result_pair = NULL;
+
+    denominator = PyLong_FromLong(1);
+    result_pair = PyTuple_Pack(2, self, denominator);
+
+    Py_DECREF(denominator);
+    return result_pair;
+}
+
+/*[clinic input]
 int.to_bytes
 
     length: Py_ssize_t
@@ -5392,6 +5426,7 @@ static PyMethodDef long_methods[] = {
 #endif
     INT_TO_BYTES_METHODDEF
     INT_FROM_BYTES_METHODDEF
+    INT_AS_INTEGER_RATIO_METHODDEF
     {"__trunc__",       long_long_meth, METH_NOARGS,
      "Truncating an Integral returns itself."},
     {"__floor__",       long_long_meth, METH_NOARGS,

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5280,7 +5280,7 @@ and with a positive denominator.
 
 static PyObject *
 int_as_integer_ratio_impl(PyObject *self)
-/*[clinic end generated code: output=e60803ae1cc8621a input=ce9c7768a1287fb9]*/
+/*[clinic end generated code: output=e60803ae1cc8621a input=c1aea0aa6fb85c28]*/
 {
     return PyTuple_Pack(2, self, _PyLong_One);
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5282,7 +5282,7 @@ static PyObject *
 int_as_integer_ratio_impl(PyObject *self)
 /*[clinic end generated code: output=e60803ae1cc8621a input=ce9c7768a1287fb9]*/
 {
-  return PyTuple_Pack(2, self, _PyLong_One)
+    return PyTuple_Pack(2, self, _PyLong_One);
 }
 
 /*[clinic input]

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5280,12 +5280,13 @@ static PyObject *
 int_as_integer_ratio_impl(PyObject *self)
 /*[clinic end generated code: output=e60803ae1cc8621a input=55ce3058e15de393]*/
 {
-  if PyLong_CheckExact(self)
-    return PyTuple_Pack(2, self, _PyLong_One);
-  else {
-      PyObject *temp = PyNumber_Positive(self);
-      Py_DECREF(temp);
-      return PyTuple_Pack(2, temp, _PyLong_One);
+    if PyLong_CheckExact(self) {
+        return PyTuple_Pack(2, self, _PyLong_One);
+    } else {
+        PyObject *numerator = _PyLong_Copy(self);
+        PyObject *ratio_tuple = PyTuple_Pack(2, numerator, _PyLong_One);
+        Py_DECREF(numerator);
+        return ratio_tuple;
     }
 }
 

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5282,11 +5282,13 @@ static PyObject *
 int_as_integer_ratio_impl(PyObject *self)
 /*[clinic end generated code: output=e60803ae1cc8621a input=c1aea0aa6fb85c28]*/
 {
-  if (self == Py_True)
-    return PyTuple_Pack(2, _PyLong_One, _PyLong_One);
-  if (self == Py_False)
-    return PyTuple_Pack(2, _PyLong_Zero, _PyLong_One);
-  return PyTuple_Pack(2, self, _PyLong_One);
+  if PyLong_CheckExact(self)
+    return PyTuple_Pack(2, self, _PyLong_One);
+  else {
+      PyObject *temp = PyNumber_Positive(self);
+      Py_DECREF(temp);
+      return PyTuple_Pack(2, temp, _PyLong_One);
+    }
 }
 
 /*[clinic input]

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5278,7 +5278,7 @@ and with a positive denominator.
 
 static PyObject *
 int_as_integer_ratio_impl(PyObject *self)
-/*[clinic end generated code: output=e60803ae1cc8621a input=c1aea0aa6fb85c28]*/
+/*[clinic end generated code: output=e60803ae1cc8621a input=55ce3058e15de393]*/
 {
   if PyLong_CheckExact(self)
     return PyTuple_Pack(2, self, _PyLong_One);

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5270,12 +5270,10 @@ and with a positive denominator.
 
 >>> (10).as_integer_ratio()
 (10, 1)
->>> (0).as_integer_ratio()
-(0, 1)
->>> (11).as_integer_ratio()
-(11, 1)
 >>> (-10).as_integer_ratio()
 (-10, 1)
+>>> (0).as_integer_ratio()
+(0, 1)
 [clinic start generated code]*/
 
 static PyObject *

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5280,9 +5280,13 @@ and with a positive denominator.
 
 static PyObject *
 int_as_integer_ratio_impl(PyObject *self)
-/*[clinic end generated code: output=e60803ae1cc8621a input=ce9c7768a1287fb9]*/
+/*[clinic end generated code: output=e60803ae1cc8621a input=c1aea0aa6fb85c28]*/
 {
-    return PyTuple_Pack(2, self, _PyLong_One);
+  if (self == Py_True)
+    return PyTuple_Pack(2, _PyLong_One, _PyLong_One);
+  if (self == Py_False)
+    return PyTuple_Pack(2, _PyLong_Zero, _PyLong_One);
+  return PyTuple_Pack(2, self, _PyLong_One);
 }
 
 /*[clinic input]

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5268,8 +5268,6 @@ Return integer ratio.
 Return a pair of integers, whose ratio is exactly equal to the original int
 and with a positive denominator.
 
-Raise OverflowError on infinities and a ValueError on NaNs.
-
 >>> (10).as_integer_ratio()
 (10, 1)
 >>> (0).as_integer_ratio()
@@ -5284,14 +5282,7 @@ static PyObject *
 int_as_integer_ratio_impl(PyObject *self)
 /*[clinic end generated code: output=e60803ae1cc8621a input=ce9c7768a1287fb9]*/
 {
-    PyObject *denominator = NULL;
-    PyObject *result_pair = NULL;
-
-    denominator = PyLong_FromLong(1);
-    result_pair = PyTuple_Pack(2, self, denominator);
-
-    Py_DECREF(denominator);
-    return result_pair;
+  return PyTuple_Pack(2, self, _PyLong_One)
 }
 
 /*[clinic input]


### PR DESCRIPTION
Adding as_integer_ratio to ints to make them more interoperable with floats.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-33073](https://www.bugs.python.org/issue33073) -->
https://bugs.python.org/issue33073
<!-- /issue-number -->
