### PR TITLE
bpo-34395: Fix memory leaks caused by incautious usage of PyMem_Resize().

### DIFF
--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -555,25 +555,17 @@ parse_save_field(ReaderObj *self)
 static int
 parse_grow_buff(ReaderObj *self)
 {
-    if (self->field_size == 0) {
-        self->field_size = 4096;
-        if (self->field != NULL)
-            PyMem_Free(self->field);
-        self->field = PyMem_New(Py_UCS4, self->field_size);
-    }
-    else {
-        Py_UCS4 *field = self->field;
-        if (self->field_size > PY_SSIZE_T_MAX / 2) {
-            PyErr_NoMemory();
-            return 0;
-        }
-        self->field_size *= 2;
-        self->field = PyMem_Resize(field, Py_UCS4, self->field_size);
-    }
-    if (self->field == NULL) {
+    assert((size_t)self->field_size <= PY_SSIZE_T_MAX / sizeof(Py_UCS4));
+
+    Py_ssize_t field_size_new = self->field_size ? 2 * self->field_size : 4096;
+    Py_UCS4 *field_new = self->field;
+    PyMem_Resize(field_new, Py_UCS4, field_size_new);
+    if (field_new == NULL) {
         PyErr_NoMemory();
         return 0;
     }
+    self->field = field_new;
+    self->field_size = field_size_new;
     return 1;
 }
 
@@ -1089,31 +1081,18 @@ join_append_data(WriterObj *self, unsigned int field_kind, void *field_data,
 static int
 join_check_rec_size(WriterObj *self, Py_ssize_t rec_len)
 {
-
-    if (rec_len < 0 || rec_len > PY_SSIZE_T_MAX - MEM_INCR) {
-        PyErr_NoMemory();
-        return 0;
-    }
+    assert(rec_len >= 0);
 
     if (rec_len > self->rec_size) {
-        if (self->rec_size == 0) {
-            self->rec_size = (rec_len / MEM_INCR + 1) * MEM_INCR;
-            if (self->rec != NULL)
-                PyMem_Free(self->rec);
-            self->rec = PyMem_New(Py_UCS4, self->rec_size);
-        }
-        else {
-            Py_UCS4* old_rec = self->rec;
-
-            self->rec_size = (rec_len / MEM_INCR + 1) * MEM_INCR;
-            self->rec = PyMem_Resize(old_rec, Py_UCS4, self->rec_size);
-            if (self->rec == NULL)
-                PyMem_Free(old_rec);
-        }
-        if (self->rec == NULL) {
+        size_t rec_size_new = (size_t)rec_len + MEM_INCR;
+        Py_UCS4 *rec_new = self->rec;
+        PyMem_Resize(rec_new, Py_UCS4, rec_size_new);
+        if (rec_new == NULL) {
             PyErr_NoMemory();
             return 0;
         }
+        self->rec = rec_new;
+        self->rec_size = (Py_ssize_t)rec_size_new;
     }
     return 1;
 }

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -1084,7 +1084,7 @@ join_check_rec_size(WriterObj *self, Py_ssize_t rec_len)
     assert(rec_len >= 0);
 
     if (rec_len > self->rec_size) {
-        size_t rec_size_new = (size_t)rec_len + MEM_INCR;
+        size_t rec_size_new = (size_t)(rec_len / MEM_INCR + 1) * MEM_INCR;
         Py_UCS4 *rec_new = self->rec;
         PyMem_Resize(rec_new, Py_UCS4, rec_size_new);
         if (rec_new == NULL) {

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1382,11 +1382,13 @@ _Unpickler_ResizeMemoList(UnpicklerObject *self, Py_ssize_t new_size)
 
     assert(new_size > self->memo_size);
 
-    PyMem_RESIZE(self->memo, PyObject *, new_size);
-    if (self->memo == NULL) {
+    PyObject **memo_new = self->memo;
+    PyMem_Resize(memo_new, PyObject *, new_size);
+    if (memo_new == NULL) {
         PyErr_NoMemory();
         return -1;
     }
+    self->memo = memo_new;
     for (i = self->memo_size; i < new_size; i++)
         self->memo[i] = NULL;
     self->memo_size = new_size;
@@ -6295,11 +6297,10 @@ load_mark(UnpicklerObject *self)
             return -1;
         }
 
-        if (self->marks == NULL)
-            self->marks = PyMem_NEW(Py_ssize_t, alloc);
-        else
-            PyMem_RESIZE(self->marks, Py_ssize_t, alloc);
+        Py_ssize_t *marks_old = self->marks;
+        PyMem_Resize(self->marks, Py_ssize_t, alloc);
         if (self->marks == NULL) {
+            PyMem_Free(marks_old);
             self->marks_size = 0;
             PyErr_NoMemory();
             return -1;

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1383,7 +1383,7 @@ _Unpickler_ResizeMemoList(UnpicklerObject *self, Py_ssize_t new_size)
     assert(new_size > self->memo_size);
 
     PyObject **memo_new = self->memo;
-    PyMem_Resize(memo_new, PyObject *, new_size);
+    PyMem_RESIZE(memo_new, PyObject *, new_size);
     if (memo_new == NULL) {
         PyErr_NoMemory();
         return -1;
@@ -6298,9 +6298,9 @@ load_mark(UnpicklerObject *self)
         }
 
         Py_ssize_t *marks_old = self->marks;
-        PyMem_Resize(self->marks, Py_ssize_t, alloc);
+        PyMem_RESIZE(self->marks, Py_ssize_t, alloc);
         if (self->marks == NULL) {
-            PyMem_Free(marks_old);
+            PyMem_FREE(marks_old);
             self->marks_size = 0;
             PyErr_NoMemory();
             return -1;


### PR DESCRIPTION


<!-- issue-number: [bpo-34395](https://www.bugs.python.org/issue34395) -->
https://bugs.python.org/issue34395
<!-- /issue-number -->
