### PR TITLE
bpo-34398: Allow glossary results to show up on search page

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -15,8 +15,7 @@ sys.path.append(os.path.abspath('includes'))
 
 extensions = ['sphinx.ext.coverage', 'sphinx.ext.doctest',
               'pyspecific', 'c_annotations', 'escape4chm',
-              'asdl_highlight', 'peg_highlight']
-
+              'asdl_highlight', 'peg_highlight', 'glossary_search']
 
 doctest_global_setup = '''
 try:

--- a/Doc/tools/extensions/glossary_search.py
+++ b/Doc/tools/extensions/glossary_search.py
@@ -14,6 +14,9 @@ import json
 
 
 def process_glossary_nodes(app, doctree, fromdocname):
+    if app.builder.format != 'html':
+        return
+
     terms = {}
 
     for node in doctree.traverse(glossary):

--- a/Doc/tools/extensions/glossary_search.py
+++ b/Doc/tools/extensions/glossary_search.py
@@ -9,8 +9,12 @@
 """
 from os import path
 from sphinx.addnodes import glossary
+from sphinx.util import logging
 from docutils.nodes import definition_list_item
 import json
+
+
+logger = logging.getLogger(__name__)
 
 
 def process_glossary_nodes(app, doctree, fromdocname):
@@ -25,13 +29,29 @@ def process_glossary_nodes(app, doctree, fromdocname):
             definition = glossary_item[1]
 
             rendered = app.builder.render_partial(definition)
-            terms[term] = rendered['html_body']
+            terms[term] = {
+                'title': glossary_item[0].astext(),
+                'body': rendered['html_body']
+            }
 
-    if terms:
-        with open(path.join(app.outdir, '_static', 'glossary.json'), 'w') as f:
-            json.dump(terms, f)
+    if hasattr(app.env, 'glossary_terms'):
+        app.env.glossary_terms.update(terms)
+    else:
+        app.env.glossary_terms = terms
+
+def on_build_finish(app, exc):
+    if not hasattr(app.env, 'glossary_terms'):
+        return
+    if not app.env.glossary_terms:
+        return
+
+    logger.info('Writing glossary.json', color='green')
+    with open(path.join(app.outdir, '_static', 'glossary.json'), 'w') as f:
+        json.dump(app.env.glossary_terms, f)
+
 
 def setup(app):
     app.connect('doctree-resolved', process_glossary_nodes)
+    app.connect('build-finished', on_build_finish)
 
     return {'version': '0.1', 'parallel_read_safe': True}

--- a/Doc/tools/extensions/glossary_search.py
+++ b/Doc/tools/extensions/glossary_search.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+"""
+    glossary_search.py
+    ~~~~~~~~~~~~~~~~
+
+    Feature search results for glossary items prominently.
+
+    :license: Python license.
+"""
+from os import path
+from sphinx.addnodes import glossary
+from docutils.nodes import definition_list_item
+import json
+
+
+def process_glossary_nodes(app, doctree, fromdocname):
+    terms = {}
+
+    for node in doctree.traverse(glossary):
+        for glossary_item in node.traverse(definition_list_item):
+            term = glossary_item[0].astext().lower()
+            definition = glossary_item[1]
+
+            rendered = app.builder.render_partial(definition)
+            terms[term] = rendered['html_body']
+
+    if terms:
+        with open(path.join(app.outdir, '_static', 'glossary.json'), 'w') as f:
+            json.dump(terms, f)
+
+def setup(app):
+    app.connect('doctree-resolved', process_glossary_nodes)
+
+    return {'version': '0.1', 'parallel_read_safe': True}

--- a/Doc/tools/templates/search.html
+++ b/Doc/tools/templates/search.html
@@ -2,10 +2,14 @@
 {% block extrahead %}
     {{ super() }}
     <script type="text/javascript">
+        var GLOSSARY_PAGE = 'glossary.html';
+
         jQuery(function() {
             $.getJSON("_static/glossary.json", function(glossary) {
                 var RESULT_TEMPLATE = '<div style="display: none" class="admonition seealso" id="glossary-result">' + 
-                                      '  <p class="glossary-title topic-title"></p>' +
+                                      '  <p class="topic-title">' +
+                                      '    <a class="glossary-title" href="#"></a>' +
+                                      '  </p>' +
                                       '  <div class="glossary-body"></div>' +
                                       '</div>';
                 $("#search-results").prepend(RESULT_TEMPLATE);
@@ -16,9 +20,23 @@
                     var glossary_item = glossary[search_param];
                     if (glossary_item) {
                         var resultDiv = $("#glossary-result");
+                        
+                        // set up the title text with a link to the glossary page
+                        resultDiv.find(".glossary-title").text('Glossary: ' + glossary_item.title);
+                        var link_target = search_param.replace(/ /g, '-');
+                        resultDiv.find(".glossary-title").attr(
+                            'href', GLOSSARY_PAGE + '#term-' + link_target
+                        );
+
+                        // rewrite any anchor links (to other glossary terms)
+                        // to have a full reference to the glossary page
                         var body = $(glossary_item.body).children();
+                        body.find("a[href^='#']").each(function() {
+                            var current_url = $(this).attr('href');
+                            $(this).attr('href', GLOSSARY_PAGE + current_url);
+                        });
                         resultDiv.find(".glossary-body").html(body);
-                        resultDiv.find(".glossary-title").text(glossary_item.title);
+
                         resultDiv.show();
                     } else {
                         $("#glossary-result").hide('');

--- a/Doc/tools/templates/search.html
+++ b/Doc/tools/templates/search.html
@@ -4,14 +4,22 @@
     <script type="text/javascript">
         jQuery(function() {
             $.getJSON("_static/glossary.json", function(glossary) {
-                $("#search-results").prepend('<div style="display: none" class="admonition seealso" id="glossary-result"></div>');
+                var RESULT_TEMPLATE = '<div style="display: none" class="admonition seealso" id="glossary-result">' + 
+                                      '  <p class="glossary-title topic-title"></p>' +
+                                      '  <div class="glossary-body"></div>' +
+                                      '</div>';
+                $("#search-results").prepend(RESULT_TEMPLATE);
 
                 var params = $.getQueryParameters();
                 if (params.q) {
-                    var glossary_item = glossary[params.q[0].toLowerCase()];
+                    var search_param = params.q[0].toLowerCase();
+                    var glossary_item = glossary[search_param];
                     if (glossary_item) {
-                        glossary_item = $(glossary_item).children();
-                        $("#glossary-result").html(glossary_item).show();
+                        var resultDiv = $("#glossary-result");
+                        var body = $(glossary_item.body).children();
+                        resultDiv.find(".glossary-body").html(body);
+                        resultDiv.find(".glossary-title").text(glossary_item.title);
+                        resultDiv.show();
                     } else {
                         $("#glossary-result").hide('');
                     }

--- a/Doc/tools/templates/search.html
+++ b/Doc/tools/templates/search.html
@@ -1,0 +1,22 @@
+{% extends "!search.html" %}
+{% block extrahead %}
+    {{ super() }}
+    <script type="text/javascript">
+        jQuery(function() {
+            $.getJSON("_static/glossary.json", function(glossary) {
+                $("#search-results").prepend('<div style="display: none" class="admonition seealso" id="glossary-result"></div>');
+
+                var params = $.getQueryParameters();
+                if (params.q) {
+                    var glossary_item = glossary[params.q[0].toLowerCase()];
+                    if (glossary_item) {
+                        glossary_item = $(glossary_item).children();
+                        $("#glossary-result").html(glossary_item).show();
+                    } else {
+                        $("#glossary-result").hide('');
+                    }
+                }
+            });
+        });
+    </script>
+{% endblock %}

--- a/Misc/NEWS.d/next/Documentation/2019-03-04-18-51-21.bpo-34398.YedUqW.rst
+++ b/Misc/NEWS.d/next/Documentation/2019-03-04-18-51-21.bpo-34398.YedUqW.rst
@@ -1,0 +1,2 @@
+Prominently feature listings from the glossary in documentation search
+results. Patch by Ammar Askar.


### PR DESCRIPTION
Here are some screenshots of what it looks like:

![2018-08-15-09-44-59_scrot](https://user-images.githubusercontent.com/773529/44151333-435fc984-a070-11e8-9f0f-e06f7a39c368.png)
![2018-08-15-09-46-01_scrot](https://user-images.githubusercontent.com/773529/44151343-472d1fd0-a070-11e8-9ead-14b68d325332.png)


<!-- issue-number: [bpo-34398](https://www.bugs.python.org/issue34398) -->
https://bugs.python.org/issue34398
<!-- /issue-number -->
