### PR TITLE
bpo-34405: Updated to OpenSSL 1.1.0i for Windows builds.

### DIFF
--- a/Misc/NEWS.d/next/Security/2018-08-15-12-12-47.bpo-34405.qbHTH_.rst
+++ b/Misc/NEWS.d/next/Security/2018-08-15-12-12-47.bpo-34405.qbHTH_.rst
@@ -1,0 +1,1 @@
+Updated to OpenSSL 1.1.0i for Windows builds.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -49,7 +49,7 @@ echo.Fetching external libraries...
 
 set libraries=
 set libraries=%libraries%                                       bzip2-1.0.6
-if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.0h
+if NOT "%IncludeSSLSrc%"=="false" set libraries=%libraries%     openssl-1.1.0i
 set libraries=%libraries%                                       sqlite-3.21.0.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tcl-core-8.6.8.0
 if NOT "%IncludeTkinterSrc%"=="false" set libraries=%libraries% tk-8.6.8.0
@@ -72,7 +72,7 @@ for %%e in (%libraries%) do (
 echo.Fetching external binaries...
 
 set binaries=
-if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.0h
+if NOT "%IncludeSSL%"=="false"     set binaries=%binaries% openssl-bin-1.1.0i
 if NOT "%IncludeTkinter%"=="false" set binaries=%binaries% tcltk-8.6.8.0
 if NOT "%IncludeSSLSrc%"=="false"  set binaries=%binaries% nasm-2.11.06
 

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -49,8 +49,8 @@
     <sqlite3Dir>$(ExternalsDir)sqlite-3.21.0.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-    <opensslDir>$(ExternalsDir)openssl-1.1.0h\</opensslDir>
-    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.0h\$(ArchName)\</opensslOutDir>
+    <opensslDir>$(ExternalsDir)openssl-1.1.0i\</opensslDir>
+    <opensslOutDir>$(ExternalsDir)openssl-bin-1.1.0i\$(ArchName)\</opensslOutDir>
     <opensslIncludeDir>$(opensslOutDir)include</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>
     <zlibDir>$(ExternalsDir)\zlib-1.2.11\</zlibDir>


### PR DESCRIPTION


<!-- issue-number: [bpo-34405](https://www.bugs.python.org/issue34405) -->
https://bugs.python.org/issue34405
<!-- /issue-number -->
