### PR TITLE
[3.6] bpo-34405: Updated to OpenSSL 1.0.2p for Windows builds. (GH-8775)

### DIFF
--- a/Misc/NEWS.d/next/Security/2018-08-15-12-14-03.bpo-34405.R4IZGw.rst
+++ b/Misc/NEWS.d/next/Security/2018-08-15-12-14-03.bpo-34405.R4IZGw.rst
@@ -1,0 +1,1 @@
+Updated to OpenSSL 1.0.2p for Windows builds.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -41,7 +41,7 @@ echo.Fetching external libraries...
 
 set libraries=
 set libraries=%libraries%                                    bzip2-1.0.6
-if NOT "%IncludeSSL%"=="false" set libraries=%libraries%     openssl-1.0.2o
+if NOT "%IncludeSSL%"=="false" set libraries=%libraries%     openssl-1.0.2p
 set libraries=%libraries%                                    sqlite-3.21.0.0
 if NOT "%IncludeTkinter%"=="false" set libraries=%libraries% tcl-core-8.6.6.0
 if NOT "%IncludeTkinter%"=="false" set libraries=%libraries% tk-8.6.6.0

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -49,7 +49,7 @@
     <sqlite3Dir>$(ExternalsDir)sqlite-3.21.0.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
     <lzmaDir>$(ExternalsDir)xz-5.2.2\</lzmaDir>
-    <opensslDir>$(ExternalsDir)openssl-1.0.2o\</opensslDir>
+    <opensslDir>$(ExternalsDir)openssl-1.0.2p\</opensslDir>
     <opensslIncludeDir>$(opensslDir)include32</opensslIncludeDir>
     <opensslIncludeDir Condition="'$(ArchName)' == 'amd64'">$(opensslDir)include64</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>


### PR DESCRIPTION


<!-- issue-number: [bpo-34405](https://www.bugs.python.org/issue34405) -->
https://bugs.python.org/issue34405
<!-- /issue-number -->
