### PR TITLE
bpo-34412: strsignal(3) does not exist on HP-UX

### DIFF
--- a/Lib/test/test_signal.py
+++ b/Lib/test/test_signal.py
@@ -60,6 +60,7 @@ class PosixTests(unittest.TestCase):
     def test_strsignal(self):
         self.assertIn("Interrupt", signal.strsignal(signal.SIGINT))
         self.assertIn("Terminated", signal.strsignal(signal.SIGTERM))
+        self.assertIn("Hangup", signal.strsignal(signal.SIGHUP))
 
     # Issue 3864, unknown if this affects earlier versions of freebsd also
     def test_interprocess_signal(self):

--- a/Misc/NEWS.d/next/Library/2018-08-16-19-07-05.bpo-34412.NF5Jm2.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-16-19-07-05.bpo-34412.NF5Jm2.rst
@@ -1,0 +1,1 @@
+Make :func:`signal.strsignal` work on HP-UX. Patch by Michael Osipov.

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -530,9 +530,27 @@ signal_strsignal_impl(PyObject *module, int signalnum)
         return NULL;
     }
 
-#ifdef MS_WINDOWS
-    /* Custom redefinition of POSIX signals allowed on Windows */
+#ifndef HAVE_STRSIGNAL
     switch (signalnum) {
+        /* Though being a UNIX, HP-UX does not provide strsignal(3). */
+#ifndef MS_WINDOWS
+        case SIGHUP:
+            res = "Hangup";
+            break;
+        case SIGALRM:
+            res = "Alarm clock";
+            break;
+        case SIGPIPE:
+            res = "Broken pipe";
+            break;
+        case SIGQUIT:
+            res = "Quit";
+            break;
+        case SIGCHLD:
+            res = "Child exited";
+            break;
+#endif
+        /* Custom redefinition of POSIX signals allowed on Windows. */
         case SIGINT:
             res = "Interrupt";
             break;

--- a/configure
+++ b/configure
@@ -11256,7 +11256,7 @@ for ac_func in alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  sched_get_priority_max sched_setaffinity sched_setscheduler sched_setparam \
  sched_rr_get_interval \
  sigaction sigaltstack sigfillset siginterrupt sigpending sigrelse \
- sigtimedwait sigwait sigwaitinfo snprintf strftime strlcpy symlinkat sync \
+ sigtimedwait sigwait sigwaitinfo snprintf strftime strlcpy strsignal symlinkat sync \
  sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile tmpnam tmpnam_r \
  truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \
  wcscoll wcsftime wcsxfrm wmemcmp writev _getpty

--- a/configure.ac
+++ b/configure.ac
@@ -3448,7 +3448,7 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  sched_get_priority_max sched_setaffinity sched_setscheduler sched_setparam \
  sched_rr_get_interval \
  sigaction sigaltstack sigfillset siginterrupt sigpending sigrelse \
- sigtimedwait sigwait sigwaitinfo snprintf strftime strlcpy symlinkat sync \
+ sigtimedwait sigwait sigwaitinfo snprintf strftime strlcpy strsignal symlinkat sync \
  sysconf tcgetpgrp tcsetpgrp tempnam timegm times tmpfile tmpnam tmpnam_r \
  truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \
  wcscoll wcsftime wcsxfrm wmemcmp writev _getpty)

--- a/pyconfig.h.in
+++ b/pyconfig.h.in
@@ -984,6 +984,9 @@
 /* Define to 1 if you have the <stropts.h> header file. */
 #undef HAVE_STROPTS_H
 
+/* Define to 1 if you have the `strsignal' function. */
+#undef HAVE_STRSIGNAL
+
 /* Define to 1 if `pw_gecos' is a member of `struct passwd'. */
 #undef HAVE_STRUCT_PASSWD_PW_GECOS
 


### PR DESCRIPTION
Introduce a configure check for strsignal(3) and define HAVE_STRSIGNAL for
signalmodule.c. This change applies for Windows and HP-UX.



<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34412](https://www.bugs.python.org/issue34412) -->
https://bugs.python.org/issue34412
<!-- /issue-number -->
