### PR TITLE
bpo-34395: Don't free allocated memory on realloc fail in load_mark() in _pickle.c.

### DIFF
--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6287,16 +6287,7 @@ load_mark(UnpicklerObject *self)
      */
 
     if ((self->num_marks + 1) >= self->marks_size) {
-        size_t alloc;
-
-        /* Use the size_t type to check for overflow. */
-        alloc = ((size_t)self->num_marks << 1) + 20;
-        if (alloc > (PY_SSIZE_T_MAX / sizeof(Py_ssize_t)) ||
-            alloc <= ((size_t)self->num_marks + 1)) {
-            PyErr_NoMemory();
-            return -1;
-        }
-
+        size_t alloc = ((size_t)self->num_marks << 1) + 20;
         Py_ssize_t *marks_new = self->marks;
         PyMem_RESIZE(marks_new, Py_ssize_t, alloc);
         if (marks_new == NULL) {

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6297,14 +6297,13 @@ load_mark(UnpicklerObject *self)
             return -1;
         }
 
-        Py_ssize_t *marks_old = self->marks;
-        PyMem_RESIZE(self->marks, Py_ssize_t, alloc);
-        if (self->marks == NULL) {
-            PyMem_FREE(marks_old);
-            self->marks_size = 0;
+        Py_ssize_t *marks_new = self->marks;
+        PyMem_RESIZE(marks_new, Py_ssize_t, alloc);
+        if (marks_new == NULL) {
             PyErr_NoMemory();
             return -1;
         }
+        self->marks = marks_new;
         self->marks_size = (Py_ssize_t)alloc;
     }
 


### PR DESCRIPTION


<!-- issue-number: [bpo-34395](https://www.bugs.python.org/issue34395) -->
https://bugs.python.org/issue34395
<!-- /issue-number -->
