### PR TITLE
[2.7] bpo-34391: Fix ftplib test for TLS 1.3 (GH-8787)

### DIFF
--- a/Lib/test/test_ftplib.py
+++ b/Lib/test/test_ftplib.py
@@ -675,6 +675,7 @@ class TestTLS_FTPClass(TestCase):
         # clear text
         sock = self.client.transfercmd('list')
         self.assertNotIsInstance(sock, ssl.SSLSocket)
+        self.assertEqual(sock.recv(1024), LIST_DATA.encode('ascii'))
         sock.close()
         self.assertEqual(self.client.voidresp(), "226 transfer complete")
 
@@ -682,6 +683,9 @@ class TestTLS_FTPClass(TestCase):
         self.client.prot_p()
         sock = self.client.transfercmd('list')
         self.assertIsInstance(sock, ssl.SSLSocket)
+        # consume from SSL socket to finalize handshake and avoid
+        # "SSLError [SSL] shutdown while in init"
+        self.assertEqual(sock.recv(1024), LIST_DATA.encode('ascii'))
         sock.close()
         self.assertEqual(self.client.voidresp(), "226 transfer complete")
 
@@ -689,6 +693,7 @@ class TestTLS_FTPClass(TestCase):
         self.client.prot_c()
         sock = self.client.transfercmd('list')
         self.assertNotIsInstance(sock, ssl.SSLSocket)
+        self.assertEqual(sock.recv(1024), LIST_DATA.encode('ascii'))
         sock.close()
         self.assertEqual(self.client.voidresp(), "226 transfer complete")
 

--- a/Misc/NEWS.d/next/Tests/2018-08-16-18-48-47.bpo-34391.ouNfxC.rst
+++ b/Misc/NEWS.d/next/Tests/2018-08-16-18-48-47.bpo-34391.ouNfxC.rst
@@ -1,0 +1,1 @@
+Fix ftplib test for TLS 1.3 by reading from data socket.


### PR DESCRIPTION
Read from data socket to avoid "[SSL] shutdown while in init" exception
during shutdown of the dummy server.

Signed-off-by: Christian Heimes <christian@python.org>

<!-- issue-number: [bpo-34391](https://www.bugs.python.org/issue34391) -->
https://bugs.python.org/issue34391
<!-- /issue-number -->.
(cherry picked from commit 1590c393360df059160145e7475754427bfc6680)

Co-authored-by: Christian Heimes <christian@python.org>
