### PR TITLE
bpo-34419: selectmodule.c does not compile on HP-UX due to bpo-31938

### DIFF
--- a/Modules/selectmodule.c
+++ b/Modules/selectmodule.c
@@ -846,8 +846,6 @@ static PyObject *
 select_devpoll_modify_impl(devpollObject *self, int fd,
                            unsigned short eventmask)
 /*[clinic end generated code: output=bc2e6d23aaff98b4 input=48a820fc5967165d]*/
-static PyObject *
-devpoll_modify(devpollObject *self, PyObject *args)
 {
     return internal_devpoll_register(self, fd, eventmask, 1);
 }
@@ -895,7 +893,7 @@ select_devpoll_poll_impl(devpollObject *self, PyObject *timeout_obj)
 /*[clinic end generated code: output=2654e5457cca0b3c input=fd0db698d84f0333]*/
 {
     struct dvpoll dvp;
-    PyObject *result_list = NULL, *timeout_obj = NULL;
+    PyObject *result_list = NULL;
     int poll_result, i;
     PyObject *value, *num1, *num2;
     _PyTime_t timeout, ms, deadline = 0;


### PR DESCRIPTION
Fix compile errors reported by HP aCC by changing oversights from 6dc57e2a20c
which do not cause trouble on clang or GCC.

Patch by Michael Osipov.

Please see for a detailed description the bug report.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34419](https://www.bugs.python.org/issue34419) -->
https://bugs.python.org/issue34419
<!-- /issue-number -->
