### PR TITLE
bpo-34421 Fix unicode error on Windows

### DIFF
--- a/Lib/distutils/log.py
+++ b/Lib/distutils/log.py
@@ -31,7 +31,10 @@ class Log:
                 # emulate backslashreplace error handler
                 encoding = stream.encoding
                 msg = msg.encode(encoding, "backslashreplace").decode(encoding)
-            stream.write('%s\n' % msg)
+            try:
+                stream.write('%s\n' % msg)
+            except UnicodeEncodeError:
+                stream.write('%s\n' % msg.encode('unicode-escape').decode('ascii'))
             stream.flush()
 
     def log(self, level, msg, *args):

--- a/Misc/NEWS.d/next/Library/2018-09-07-10-57-00.bpo-34421.AKJISD.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-07-10-57-00.bpo-34421.AKJISD.rst
@@ -1,0 +1,2 @@
+Fixed installation issue with setuptools distutils that crashed with 
+packages containing unicode module or package names in Windows.

--- a/Misc/NEWS.d/next/Library/2018-09-07-10-57-00.bpo-34421.AKJISD.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-07-10-57-00.bpo-34421.AKJISD.rst
@@ -1,2 +1,1 @@
-Fixed installation issue with setuptools distutils that crashed with 
-packages containing unicode module or package names in Windows.
+Fix distutils logging for non-ASCII strings.  This caused installation issues on Windows.

--- a/Misc/NEWS.d/next/Windows/Misc/NEWS.d/next/Windows/2018-09-07-10-57-00.bpo-34421.AKJISD.rst
+++ b/Misc/NEWS.d/next/Windows/Misc/NEWS.d/next/Windows/2018-09-07-10-57-00.bpo-34421.AKJISD.rst
@@ -1,0 +1,2 @@
+Fixed installation issue with setuptools setuptools that crashed with 
+packages containing unicode module or package names in Windows.

--- a/Misc/NEWS.d/next/Windows/Misc/NEWS.d/next/Windows/2018-09-07-10-57-00.bpo-34421.AKJISD.rst
+++ b/Misc/NEWS.d/next/Windows/Misc/NEWS.d/next/Windows/2018-09-07-10-57-00.bpo-34421.AKJISD.rst
@@ -1,2 +1,0 @@
-Fixed installation issue with setuptools setuptools that crashed with 
-packages containing unicode module or package names in Windows.


### PR DESCRIPTION
This fixes an issue reported to setuptools that prevents the installation of packages containing unicode module or package names in Windows:
https://github.com/pypa/setuptools/issues/1399


<!-- issue-number: [bpo-34421](https://www.bugs.python.org/issue34421) -->
https://bugs.python.org/issue34421
<!-- /issue-number -->
