### PR TITLE
bpo-34423: Fix check for overflow when casting from a double to integral types.

### DIFF
--- a/Include/pymath.h
+++ b/Include/pymath.h
@@ -221,10 +221,14 @@ PyAPI_FUNC(void) _Py_set_387controlword(unsigned short);
 #define _Py_IntegralTypeMax(type) ((_Py_IntegralTypeSigned(type)) ? (((((type)1 << (sizeof(type)*CHAR_BIT - 2)) - 1) << 1) + 1) : ~(type)0)
 /* Return the minimum value of integral type *type*. */
 #define _Py_IntegralTypeMin(type) ((_Py_IntegralTypeSigned(type)) ? -_Py_IntegralTypeMax(type) - 1 : 0)
+
 /* Check whether *v* is in the range of integral type *type*. This is most
- * useful if *v* is floating-point, since demoting a floating-point *v* to an
- * integral type that cannot represent *v*'s integral part is undefined
- * behavior. */
-#define _Py_InIntegralTypeRange(type, v) (_Py_IntegralTypeMin(type) <= v && v <= _Py_IntegralTypeMax(type))
+ * useful if *v* is floating-point, since demoting a floating-point *v* to
+ * an integral type that cannot represent *v*'s integral part is undefined
+ * behavior. If however sizeof(*v*) == sizeof(*type*) and *v* is a
+ * floating-point, maximal value of *type* cannot be represented exactly,
+ * thus the check, to be true needs to use strict less than (<).
+ */
+#define _Py_InIntegralTypeRange(type, v) (_Py_IntegralTypeMin(type) <= v && v < _Py_IntegralTypeMax(type))
 
 #endif /* Py_PYMATH_H */

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -918,8 +918,7 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
     Test the C _PyTime_t API.
     """
     # _PyTime_t is a 64-bit signed integer
-    OVERFLOW_SECONDS = math.ceil((
-        + 1) / SEC_TO_NS)
+    OVERFLOW_SECONDS = math.ceil((2**63 + 1) / SEC_TO_NS)
 
     def test_FromSeconds(self):
         from _testcapi import PyTime_FromSeconds

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -160,7 +160,7 @@ class TimeTestCase(unittest.TestCase):
     def test_sleep(self):
         self.assertRaises(ValueError, time.sleep, -2)
         self.assertRaises(ValueError, time.sleep, -1)
-        self.assertRaises(OverflowError, time.sleep(2**63 / 10**9))
+        self.assertRaises(OverflowError, time.sleep, 2**63 / SEC_TO_NS)
         time.sleep(1.2)
 
     def test_strftime(self):
@@ -918,7 +918,8 @@ class TestCPyTime(CPyTimeTestCase, unittest.TestCase):
     Test the C _PyTime_t API.
     """
     # _PyTime_t is a 64-bit signed integer
-    OVERFLOW_SECONDS = math.ceil((2**63 + 1) / SEC_TO_NS)
+    OVERFLOW_SECONDS = math.ceil((
+        + 1) / SEC_TO_NS)
 
     def test_FromSeconds(self):
         from _testcapi import PyTime_FromSeconds

--- a/Lib/test/test_time.py
+++ b/Lib/test/test_time.py
@@ -160,6 +160,7 @@ class TimeTestCase(unittest.TestCase):
     def test_sleep(self):
         self.assertRaises(ValueError, time.sleep, -2)
         self.assertRaises(ValueError, time.sleep, -1)
+        self.assertRaises(OverflowError, time.sleep(2**63 / 10**9))
         time.sleep(1.2)
 
     def test_strftime(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1830,3 +1830,4 @@ Jelle Zijlstra
 Gennadiy Zlobin
 Doug Zongker
 Peter Åstrand
+Michał Radwański

--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-18-01-39-06.bpo-34423.8rsQIk.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-18-01-39-06.bpo-34423.8rsQIk.rst
@@ -1,0 +1,2 @@
+``time.sleep(2**63 / 10**9)`` no longer eludes range checks and doesn't
+overflow.


### PR DESCRIPTION
The added comment explains the issue. This fix disallows overflow: if a double `d` passes the test, it can mean that `d == 2**63`. When casted to `int64_t`, the variable overflows to -2**63.

<!-- issue-number: [bpo-34423](https://www.bugs.python.org/issue34423) -->
https://bugs.python.org/issue34423
<!-- /issue-number -->
