### PR TITLE
bpo-34430: double chaining futures in asyncio.wrap_future

### DIFF
--- a/Lib/asyncio/futures.py
+++ b/Lib/asyncio/futures.py
@@ -375,6 +375,7 @@ def wrap_future(future, *, loop=None):
         loop = events.get_event_loop()
     new_future = loop.create_future()
     _chain_future(future, new_future)
+    _chain_future(new_future, future)
     return new_future
 
 


### PR DESCRIPTION
asyncio.future.wrap_future is used to wrap a concurrent.future.Future in a asyncio.future.Future. 

The actual implementation as the following behaviours : 

 1) When the concurrent.future.Future gets a result, the asyncio.future.Future gets the same result,
 2) When the asyncio.future.Future is cancelled, the concurrent.future.Future is cancelled

I wonder why the futures synchronisation is not symmetrical ?
I propose to add the following behaviours : 

 3) When the asyncio.future.Future gets a result, the concurrent.future.Future gets the same result,
 4) When the concurrent.future.Future is cancelled, the asyncio.future.Future is cancelled

If there is good reasons to not implement the proposed behaviours, I would be glad to know.

Thank you !

<!-- issue-number: [bpo-34430](https://www.bugs.python.org/issue34430) -->
https://bugs.python.org/issue34430
<!-- /issue-number -->
