### PR TITLE
bpo-31370: Remove references to threadless builds

### DIFF
--- a/Doc/c-api/init.rst
+++ b/Doc/c-api/init.rst
@@ -842,18 +842,18 @@ code, or when embedding the Python interpreter:
 
 .. c:function:: PyThreadState* PyEval_SaveThread()
 
-   Release the global interpreter lock (if it has been created and thread
-   support is enabled) and reset the thread state to *NULL*, returning the
-   previous thread state (which is not *NULL*).  If the lock has been created,
-   the current thread must have acquired it.
+   Release the global interpreter lock (if it has been created) and reset the
+   thread state to *NULL*, returning the previous thread state (which is not
+   *NULL*).  If the lock has been created, the current thread must have
+   acquired it.
 
 
 .. c:function:: void PyEval_RestoreThread(PyThreadState *tstate)
 
-   Acquire the global interpreter lock (if it has been created and thread
-   support is enabled) and set the thread state to *tstate*, which must not be
-   *NULL*.  If the lock has been created, the current thread must not have
-   acquired it, otherwise deadlock ensues.
+   Acquire the global interpreter lock (if it has been created) and set the
+   thread state to *tstate*, which must not be *NULL*.  If the lock has been
+   created, the current thread must not have acquired it, otherwise deadlock
+   ensues.
 
 
 .. c:function:: PyThreadState* PyThreadState_Get()

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -11,9 +11,7 @@
 The :mod:`queue` module implements multi-producer, multi-consumer queues.
 It is especially useful in threaded programming when information must be
 exchanged safely between multiple threads.  The :class:`Queue` class in this
-module implements all the required locking semantics.  It depends on the
-availability of thread support in Python; see the :mod:`threading`
-module.
+module implements all the required locking semantics.
 
 The module implements three types of queue, which differ only in the order in
 which the entries are retrieved.  In a :abbr:`FIFO (first-in, first-out)`

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -29,9 +29,6 @@ from test import support
 _multiprocessing = test.support.import_module('_multiprocessing')
 # Skip tests if sem_open implementation is broken.
 test.support.import_module('multiprocessing.synchronize')
-# import threading after _multiprocessing to raise a more relevant error
-# message: "No module named _multiprocessing". _multiprocessing is not compiled
-# without thread support.
 import threading
 
 import multiprocessing.connection

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -237,17 +237,13 @@ PyEval_ReInitThreads(void)
 }
 
 /* This function is used to signal that async exceptions are waiting to be
-   raised, therefore it is also useful in non-threaded builds. */
+   raised. */
 
 void
 _PyEval_SignalAsyncExc(void)
 {
     SIGNAL_ASYNC_EXC();
 }
-
-/* Functions save_thread and restore_thread are always defined so
-   dynamically loaded modules needn't be compiled separately for use
-   with and without threads: */
 
 PyThreadState *
 PyEval_SaveThread(void)


### PR DESCRIPTION
Support for threadless builds was removed in a6a4dc81.

<!-- issue-number: [bpo-31370](https://www.bugs.python.org/issue31370) -->
https://bugs.python.org/issue31370
<!-- /issue-number -->
