### PR TITLE
bpo-34430 Symmetrical chaining futures in asyncio.future.wrap_future

### DIFF
--- a/Lib/test/test_asyncio/test_futures.py
+++ b/Lib/test/test_asyncio/test_futures.py
@@ -480,6 +480,38 @@ class BaseFutureTests:
         self.assertEqual(f1.result(), 42)
         self.assertTrue(f2.cancelled())
 
+    def test_wrap_future_symmetry1(self):
+        f1 = concurrent.futures.Future()
+        f2 = asyncio.wrap_future(f1, loop=self.loop)
+        f1.set_result(42)
+        test_utils.run_briefly(self.loop)
+        self.assertEqual(f1.result(), 42)
+        self.assertEqual(f2.result(), 42)
+
+    def test_wrap_future_symmetry2(self):
+        f1 = concurrent.futures.Future()
+        f2 = asyncio.wrap_future(f1, loop=self.loop)
+        f2.set_result(42)
+        test_utils.run_briefly(self.loop)
+        self.assertEqual(f1.result(), 42)
+        self.assertEqual(f2.result(), 42)
+
+    def test_wrap_future_symmetry3(self):
+        f1 = concurrent.futures.Future()
+        f2 = asyncio.wrap_future(f1, loop=self.loop)
+        f2.cancel()
+        test_utils.run_briefly(self.loop)
+        self.assertTrue(f1.cancelled())
+        self.assertTrue(f2.cancelled())
+
+    def test_wrap_future_symmetry4(self):
+        f1 = concurrent.futures.Future()
+        f2 = asyncio.wrap_future(f1, loop=self.loop)
+        f1.cancel()
+        test_utils.run_briefly(self.loop)
+        self.assertTrue(f1.cancelled())
+        self.assertTrue(f2.cancelled())
+
     def test_future_source_traceback(self):
         self.loop.set_debug(True)
 

--- a/Misc/NEWS.d/next/Library/2018-08-18-16-29-56.bpo-34430.WbEvhs.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-18-16-29-56.bpo-34430.WbEvhs.rst
@@ -1,0 +1,14 @@
+The two futures chained by :func:`asyncio.future.wrap_future` are now
+symmetrical.
+
+Before, the behaviour was:
+1) When the wrapped future gets a result, the new future gets the same result,
+2) When the new future is cancelled, the wrapped future is cancelled
+
+now, these new behaviours have been implemented:
+3) When the new future gets a result, the wrapped future gets the same result,
+4) When the wrapped future is cancelled, the new future is cancelled
+
+so, the new behaviour is:
+1) When either one future is done, the other is done with the same results or exceptions,
+2) When either one future is cancelled, the other is cancelled.


### PR DESCRIPTION
The two futures chained by :func:`asyncio.future.wrap_future` are now
 symmetrical.
 
Before, the behaviour was:
 1) When the wrapped future gets a result, the new future gets the same result,
 2) When the new future is cancelled, the wrapped future is cancelled
 
now, these new behaviours have been implemented:
 3) When the new future gets a result, the wrapped future gets the same result,
 4) When the wrapped future is cancelled, the new future is cancelled
 
so, the new behaviour is:
 1) When either one future is done, the other is done with the same results or exceptions,
 2) When either one future is cancelled, the other is cancelled.

<!-- issue-number: [bpo-34430](https://www.bugs.python.org/issue34430) -->
https://bugs.python.org/issue34430
<!-- /issue-number -->
