### PR TITLE
bpo-34427: islice values when calling MutableSequence.extend on self

### DIFF
--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -7,7 +7,6 @@ Unit tests are in test_collections.
 """
 
 from abc import ABCMeta, abstractmethod
-from itertools import islice
 import sys
 
 __all__ = ["Awaitable", "Coroutine",
@@ -988,7 +987,7 @@ class MutableSequence(Sequence):
     def extend(self, values):
         'S.extend(iterable) -- extend sequence by appending elements from the iterable'
         if values is self:
-            values = islice(self, len(self))
+            values = list(values)
         for v in values:
             self.append(v)
 

--- a/Lib/_collections_abc.py
+++ b/Lib/_collections_abc.py
@@ -7,6 +7,7 @@ Unit tests are in test_collections.
 """
 
 from abc import ABCMeta, abstractmethod
+from itertools import islice
 import sys
 
 __all__ = ["Awaitable", "Coroutine",
@@ -986,6 +987,8 @@ class MutableSequence(Sequence):
 
     def extend(self, values):
         'S.extend(iterable) -- extend sequence by appending elements from the iterable'
+        if values is self:
+            values = islice(self, len(self))
         for v in values:
             self.append(v)
 

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1724,7 +1724,8 @@ class TestCollectionABCs(ABCTestCase):
         # issue 34427
         # extending self should not cause infinite loop
         items = 'ABCD'
-        mss2 = MutableSequenceSubclass(items + items)
+        mss2 = MutableSequenceSubclass()
+        mss2.extend(items + items)
         mss.clear()
         mss.extend(items)
         mss.extend(mss)

--- a/Lib/test/test_collections.py
+++ b/Lib/test/test_collections.py
@@ -1721,6 +1721,17 @@ class TestCollectionABCs(ABCTestCase):
         mss.clear()
         self.assertEqual(len(mss), 0)
 
+        # issue 34427
+        # extending self should not cause infinite loop
+        items = 'ABCD'
+        mss2 = MutableSequenceSubclass(items + items)
+        mss.clear()
+        mss.extend(items)
+        mss.extend(mss)
+        self.assertEqual(len(mss), len(mss2))
+        self.assertEqual(list(mss), list(mss2))
+
+
 ################################################################################
 ### Counter
 ################################################################################

--- a/Misc/NEWS.d/next/Library/2018-08-20-13-53-10.bpo-34427.tMRQjl.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-20-13-53-10.bpo-34427.tMRQjl.rst
@@ -1,1 +1,1 @@
-Fix ``a.extend(a)`` for ``MutableSequence`` subclasses
+Fix infinite loop in ``a.extend(a)`` for ``MutableSequence`` subclasses.

--- a/Misc/NEWS.d/next/Library/2018-08-20-13-53-10.bpo-34427.tMRQjl.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-20-13-53-10.bpo-34427.tMRQjl.rst
@@ -1,0 +1,1 @@
+Fix ``a.extend(a)`` for ``MutableSequence`` subclasses


### PR DESCRIPTION



<!-- issue-number: [bpo-34427](https://www.bugs.python.org/issue34427) -->
https://bugs.python.org/issue34427
<!-- /issue-number -->
