### PR TITLE
bpo-34433 Cancel all other pending child futures

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -701,12 +701,14 @@ def gather(*coros_or_futures, loop=None, return_exceptions=False):
                 # Check if 'fut' is cancelled first, as
                 # 'fut.exception()' will *raise* a CancelledError
                 # instead of returning it.
+                outer.cancel()
                 exc = futures.CancelledError()
                 outer.set_exception(exc)
                 return
             else:
                 exc = fut.exception()
                 if exc is not None:
+                    outer.cancel()
                     outer.set_exception(exc)
                     return
 


### PR DESCRIPTION
In `tasks.gather`, when a child future throws an exception and `return_exceptions` is False, outer future will call `set_exception` while other child futures is still running. In this case, outer future call `_GatheringFuture.cancel` first to cancel all other pending child futures for efficiency.
[https://bugs.python.org/issue34433](url)

<!-- issue-number: [bpo-34433](https://www.bugs.python.org/issue34433) -->
https://bugs.python.org/issue34433
<!-- /issue-number -->
