### PR TITLE
bpo-26901: Fix the test suite for the argument clinic (`clinic_test`)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,8 +156,6 @@ script:
   - make smelly
   # `-r -w` implicitly provided through `make buildbottest`.
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then XVFB_RUN=xvfb-run; fi; $XVFB_RUN make buildbottest TESTOPTS="-j4 -uall,-cpu"
-  # Check that the argument clinic tests work correctly
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./python Tools/clinic/clinic_test.py; fi
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,8 @@ script:
   - make smelly
   # `-r -w` implicitly provided through `make buildbottest`.
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then XVFB_RUN=xvfb-run; fi; $XVFB_RUN make buildbottest TESTOPTS="-j4 -uall,-cpu"
+  # Check that the argument clinic tests work correctly
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ./python Tools/clinic/clinic_test.py; fi
 
 notifications:
   email: false

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1077,6 +1077,7 @@ buildbottest:	build_all platform
 			pybuildbot.identify "CC='$(CC)'" "CXX='$(CXX)'"; \
 		fi
 		$(TESTRUNNER) -j 1 -u all -W --slowest --fail-env-changed --timeout=$(TESTTIMEOUT) $(TESTOPTS)
+		$(TESTPYTHON) Tools/clinic/clinic_test.py
 
 pythoninfo: build_all
 		$(RUNSHARED) ./$(BUILDPYTHON) -m test.pythoninfo

--- a/PCbuild/rt.bat
+++ b/PCbuild/rt.bat
@@ -44,6 +44,7 @@ if NOT "%1"=="" (set regrtestargs=%regrtestargs% %1) & shift & goto CheckOpts
 if not defined prefix set prefix=%pcbuild%win32
 set exe=%prefix%\python%suffix%.exe
 set cmd="%exe%" %dashO% -u -Wd -E -bb -m test %regrtestargs%
+set cmd_clinic_test="%exe%" Tools\clinic\clinic_test.py
 if defined qmode goto Qmode
 
 echo Deleting .pyc files ...
@@ -54,6 +55,7 @@ if exist %prefix%\*._pth del %prefix%\*._pth
 
 echo on
 %cmd%
+%cmd_clinic_test%
 @echo off
 
 echo About to run again without deleting .pyc first:
@@ -62,3 +64,4 @@ pause
 :Qmode
 echo on
 %cmd%
+%cmd_clinic_test%

--- a/Tools/clinic/clinic_test.py
+++ b/Tools/clinic/clinic_test.py
@@ -35,7 +35,7 @@ class FakeConvertersDict:
         return self.used_converters.setdefault(name, FakeConverterFactory(name))
 
 clinic.Clinic.presets_text = ''
-c = clinic.Clinic(language='C')
+c = clinic.Clinic(language='C', filename = "file")
 
 class FakeClinic:
     def __init__(self):
@@ -43,6 +43,7 @@ class FakeClinic:
         self.legacy_converters = FakeConvertersDict()
         self.language = clinic.CLanguage(None)
         self.filename = None
+        self.destination_buffers = {}
         self.block_parser = clinic.BlockParser('', self.language)
         self.modules = collections.OrderedDict()
         self.classes = collections.OrderedDict()
@@ -93,7 +94,7 @@ class ClinicWholeFileTest(TestCase):
         # so it would spit out an end line for you.
         # and since you really already had one,
         # the last line of the block got corrupted.
-        c = clinic.Clinic(clinic.CLanguage(None))
+        c = clinic.Clinic(clinic.CLanguage(None), filename="file")
         raw = "/*[clinic]\nfoo\n[clinic]*/"
         cooked = c.parse(raw).splitlines()
         end_line = cooked[2].rstrip()
@@ -252,7 +253,7 @@ xyz
 
     def _test_clinic(self, input, output):
         language = clinic.CLanguage(None)
-        c = clinic.Clinic(language)
+        c = clinic.Clinic(language, filename="file")
         c.parsers['inert'] = InertParser(c)
         c.parsers['copy'] = CopyParser(c)
         computed = c.parse(input)


### PR DESCRIPTION
The argument clinic now only works correctly when a filename is
provided as it relies now on `destination_buffers`.

Notice that this patch only adapts the test suite to make it work with the last
implementation of the argument clinic. I suggest that the next patch will be:

1) Run the argument clinic test suite as part of the CPython test suite so this does not
happen again.

2) Modify the argument clinic to work without providing the filename.

I prefer to have a working test suite before modifying the argument clinic itself.



<!-- issue-number: [bpo-26901](https://www.bugs.python.org/issue26901) -->
https://bugs.python.org/issue26901
<!-- /issue-number -->
