### PR TITLE
bpo-34436: Fix check that disables overallocation for the last fmt sp…

### DIFF
--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -820,7 +820,7 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
                 goto error;
 
             if (fmtcnt == 0) {
-                /* last writer: disable writer overallocation */
+                /* last write: disable writer overallocation */
                 writer.overallocate = 0;
             }
 

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -819,7 +819,7 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
             if (v == NULL)
                 goto error;
 
-            if (fmtcnt < 0) {
+            if (fmtcnt == 0) {
                 /* last writer: disable writer overallocation */
                 writer.overallocate = 0;
             }
@@ -1048,7 +1048,7 @@ _PyBytes_FormatEx(const char *format, Py_ssize_t format_len,
 
         /* If overallocation was disabled, ensure that it was the last
            write. Otherwise, we missed an optimization */
-        assert(writer.overallocate || fmtcnt < 0 || use_bytearray);
+        assert(writer.overallocate || fmtcnt == 0 || use_bytearray);
     } /* until end */
 
     if (argidx < arglen && !dict) {


### PR DESCRIPTION
…ecifier

Reported by Svace static analyzer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34436](https://www.bugs.python.org/issue34436) -->
https://bugs.python.org/issue34436
<!-- /issue-number -->
