### PR TITLE
bpo-34062: Add missing launcher argument and make behavior consistent between short and long arguments

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-08-21-19-28-23.bpo-34062.3gxsA3.rst
+++ b/Misc/NEWS.d/next/Windows/2018-08-21-19-28-23.bpo-34062.3gxsA3.rst
@@ -1,0 +1,1 @@
+Fixed the '--list' and '--list-paths' arguments for the py.exe launcher

--- a/PC/launcher.c
+++ b/PC/launcher.c
@@ -1466,7 +1466,6 @@ process(int argc, wchar_t ** argv)
     wchar_t * p;
     int rc = 0;
     size_t plen;
-    size_t slen;
     INSTALLED_PYTHON * ip;
     BOOL valid;
     DWORD size, attrs;
@@ -1602,10 +1601,11 @@ process(int argc, wchar_t ** argv)
     else {
         p = argv[1];
         plen = wcslen(p);
-        if (argc == 2) {
-            slen = wcslen(L"-0");
-            if(!wcsncmp(p, L"-0", slen)) /* Starts with -0 */
-                valid = show_python_list(argv); /* Check for -0 FIRST */
+        if ((argc == 2) && 
+            (!wcsncmp(p, L"-0", wcslen(L"-0")) || /* Starts with -0 or --list */
+            !wcsncmp(p, L"--list", wcslen(L"--list"))))
+        {
+            valid = show_python_list(argv); /* Check for -0 or --list FIRST */
         }
         valid = valid && (*p == L'-') && validate_version(&p[1]);
         if (valid) {
@@ -1638,10 +1638,13 @@ installed, use -0 for available pythons", &p[1]);
     if (!valid) {
         if ((argc == 2) && (!_wcsicmp(p, L"-h") || !_wcsicmp(p, L"--help")))
             show_help_text(argv);
-        if ((argc == 2) && (!_wcsicmp(p, L"-0") || !_wcsicmp(p, L"-0p")))
-            executable = NULL; /* Info call only */
-        else
+        if ((argc == 2) &&
+            (!_wcsicmp(p, L"-0") || !_wcsicmp(p, L"--list") ||
+            !_wcsicmp(p, L"-0p") || !_wcsicmp(p, L"--list-paths")))
         {
+            executable = NULL; /* Info call only */
+        }
+        else {
             /* Look for an active virtualenv */
             executable = find_python_by_venv();
 


### PR DESCRIPTION
Added previously missing "--list" argument.
Made "--list" and "--list-paths" behavior consistent with the corresponding "-0" and "-0p" arguments.

<!-- issue-number: [bpo-34062](https://www.bugs.python.org/issue34062) -->
https://bugs.python.org/issue34062
<!-- /issue-number -->
