### PR TITLE
bpo-14568: local libraries paths not passed to linker on HP-UX

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-08-20-11-21-33.bpo-14568.WWb7oL.rst
+++ b/Misc/NEWS.d/next/Build/2018-08-20-11-21-33.bpo-14568.WWb7oL.rst
@@ -1,0 +1,2 @@
+Add HP-UX local libraries paths to compiler library dirs. Patch by Michael
+Osipov.

--- a/setup.py
+++ b/setup.py
@@ -609,9 +609,12 @@ class PyBuildExt(build_ext):
         if host_platform in ['osf1', 'unixware7', 'openunix8']:
             lib_dirs += ['/usr/ccs/lib']
 
-        # HP-UX11iv3 keeps files in lib/hpux folders.
+        # HP-UX11iv3 keeps files in lib/hpux<bitness> directories.
         if host_platform == 'hp-ux11':
-            lib_dirs += ['/usr/lib/hpux64', '/usr/lib/hpux32']
+            lib_dirs += ['/usr/lib/hpux64', '/usr/lib/hpux32',
+                         '/usr/local/lib/hpux64', '/usr/local/lib/hpux32']
+            for lib_dir in lib_dirs:
+                add_dir_to_list(self.compiler.library_dirs, lib_dir)
 
         if host_platform == 'darwin':
             # This should work on any unixy platform ;-)


### PR DESCRIPTION
Third party libraries on HP-UX don't reside in /usr/local/lib, but in
/usr/local/lib/hpux&lt;bitness&gt;. These also need to be added to the compiler
library dirs to make linking possible, not just for module discovery.

Patch by Michael Osipov.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-14568](https://www.bugs.python.org/issue14568) -->
https://bugs.python.org/issue14568
<!-- /issue-number -->
