### PR TITLE
[master] maybe raise TypeError when name of stream isn't a string (GH-8832)

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1011,7 +1011,7 @@ class StreamHandler(Handler):
 
     def __repr__(self):
         level = getLevelName(self.level)
-        name = getattr(self.stream, 'name', '')
+        name = str(getattr(self.stream, 'name', ''))
         if name:
             name += ' '
         return '<%s %s(%s)>' % (self.__class__.__name__, name, level)


### PR DESCRIPTION
E.g,
If you run Python by uWSGI,
The name of sys.stdout will be reset to int(1) and sys.stder will be reset to int(2).
And raises TypeError: unsupported operand type(s) for +=

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
