### PR TITLE
bpo-34441: Fix ABC.__subclasscheck__ crash on a class with invalid __subclasses__

### DIFF
--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -410,7 +410,8 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             with self.assertRaises(TypeError):
                 issubclass(C(), A)
 
-            # bpo-34441: Check that issubclass() doesn't crash on bogus classes
+            # bpo-34441: Check that issubclass() doesn't crash on bogus
+            # classes.
             bogus_subclasses = [
                 None,
                 lambda x: None,
@@ -426,7 +427,7 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
                     issubclass(int, S)
 
             # Also check that issubclass() propagates exceptions raised by
-            # __subclasses__
+            # __subclasses__.
             exc_msg = "exception from __subclasses__"
 
             def raise_exc():

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -419,9 +419,9 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
                 lambda: [42],
             ]
 
-            for i, bs in enumerate(bogus_subclasses):
+            for i, func in enumerate(bogus_subclasses):
                 class S(metaclass=abc_ABCMeta):
-                    __subclasses__ = bs
+                    __subclasses__ = func
 
                 with self.subTest(i=i), \
                         self.assertRaises(TypeError):

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -410,6 +410,13 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             with self.assertRaises(TypeError):
                 issubclass(C(), A)
 
+            # bpo-34441: Check that issubclass() doesn't crash on bogus classes
+            class S(metaclass=abc_ABCMeta):
+                __subclasses__ = None
+
+            with self.assertRaises(TypeError):
+                issubclass(int, S)
+
         def test_all_new_methods_are_called(self):
             class A(metaclass=abc_ABCMeta):
                 pass

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -414,7 +414,7 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
             # classes.
             bogus_subclasses = [
                 None,
-                lambda x: None,
+                lambda x: [],
                 lambda: 42,
                 lambda: [42],
             ]

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -423,9 +423,9 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
                 class S(metaclass=abc_ABCMeta):
                     __subclasses__ = func
 
-                with self.subTest(i=i), \
-                        self.assertRaises(TypeError):
-                    issubclass(int, S)
+                with self.subTest(i=i):
+                    with self.assertRaises(TypeError):
+                        issubclass(int, S)
 
             # Also check that issubclass() propagates exceptions raised by
             # __subclasses__.

--- a/Lib/test/test_abc.py
+++ b/Lib/test/test_abc.py
@@ -419,11 +419,12 @@ def test_factory(abc_ABCMeta, abc_get_cache_token):
                 lambda: [42],
             ]
 
-            for bs in bogus_subclasses:
+            for i, bs in enumerate(bogus_subclasses):
                 class S(metaclass=abc_ABCMeta):
                     __subclasses__ = bs
 
-                with self.assertRaises(TypeError):
+                with self.subTest(i=i), \
+                        self.assertRaises(TypeError):
                     issubclass(int, S)
 
             # Also check that issubclass() propagates exceptions raised by

--- a/Misc/NEWS.d/next/Library/2018-08-20-16-48-32.bpo-34441._zx9lU.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-20-16-48-32.bpo-34441._zx9lU.rst
@@ -1,2 +1,3 @@
-Fix crash when an ``ABC``-derived class with non-callable ``__subclasses__`` is passed as the
-second argument to ``issubclass()``.
+Fix crash when an ``ABC``-derived class with non-callable ``__subclasses__``
+is passed as the second argument to :func:`issubclass()`. Patch by Alexey
+Izbyshev.

--- a/Misc/NEWS.d/next/Library/2018-08-20-16-48-32.bpo-34441._zx9lU.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-20-16-48-32.bpo-34441._zx9lU.rst
@@ -1,3 +1,3 @@
-Fix crash when an ``ABC``-derived class with non-callable ``__subclasses__``
-is passed as the second argument to :func:`issubclass()`. Patch by Alexey
+Fix crash when an ``ABC``-derived class with invalid ``__subclasses__`` is
+passed as the second argument to :func:`issubclass()`. Patch by Alexey
 Izbyshev.

--- a/Misc/NEWS.d/next/Library/2018-08-20-16-48-32.bpo-34441._zx9lU.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-20-16-48-32.bpo-34441._zx9lU.rst
@@ -1,0 +1,2 @@
+Fix crash when an ``ABC``-derived class with non-callable ``__subclasses__`` is passed as the
+second argument to ``issubclass()``.

--- a/Modules/_abc.c
+++ b/Modules/_abc.c
@@ -665,6 +665,9 @@ _abc__abc_subclasscheck_impl(PyObject *module, PyObject *self,
 
     /* 6. Check if it's a subclass of a subclass (recursive). */
     subclasses = PyObject_CallMethod(self, "__subclasses__", NULL);
+    if (subclasses == NULL) {
+        goto end;
+    }
     if (!PyList_Check(subclasses)) {
         PyErr_SetString(PyExc_TypeError, "__subclasses__() must return a list");
         goto end;


### PR DESCRIPTION
The missing NULL check was reported by Svace static analyzer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34441](https://www.bugs.python.org/issue34441) -->
https://bugs.python.org/issue34441
<!-- /issue-number -->
