### PR TITLE
bpo-34171: Prevent creating Lib/trace.cover when run the trace module.

### DIFF
--- a/Lib/test/test_trace.py
+++ b/Lib/test/test_trace.py
@@ -387,6 +387,11 @@ class TestCoverageCommandLineOutput(unittest.TestCase):
     def test_cover_files_written_no_highlight(self):
         argv = '-m trace --count'.split() + [self.codefile]
         status, stdout, stderr = assert_python_ok(*argv)
+        self.assertEqual(stderr, b'')
+        tracedir = os.path.dirname(os.path.abspath(trace.__file__))
+        tracecoverpath = os.path.join(tracedir, "trace.cover")
+        self.assertFalse(os.path.exists(tracecoverpath))
+
         self.assertTrue(os.path.exists(self.coverfile))
         with open(self.coverfile) as f:
             self.assertEqual(f.read(),

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -63,14 +63,6 @@ from time import monotonic as _time
 
 import threading
 
-def _settrace(func):
-    threading.settrace(func)
-    sys.settrace(func)
-
-def _unsettrace():
-    sys.settrace(None)
-    threading.settrace(None)
-
 PRAGMA_NOCOVER = "#pragma NO COVER"
 
 class _Ignore:
@@ -451,12 +443,14 @@ class Trace:
         if globals is None: globals = {}
         if locals is None: locals = {}
         if not self.donothing:
-            _settrace(self.globaltrace)
+            threading.settrace(self.globaltrace)
+            sys.settrace(self.globaltrace)
         try:
             exec(cmd, globals, locals)
         finally:
             if not self.donothing:
-                _unsettrace()
+                sys.settrace(None)
+                threading.settrace(None)
 
     def runfunc(self, func, *args, **kw):
         result = None

--- a/Misc/NEWS.d/next/Library/2018-08-21-00-29-01.bpo-34171.6LkWav.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-21-00-29-01.bpo-34171.6LkWav.rst
@@ -1,0 +1,1 @@
+Running the :mod:`trace` module no longer creates the ``trace.cover`` file.


### PR DESCRIPTION


<!-- issue-number: [bpo-34171](https://www.bugs.python.org/issue34171) -->
https://bugs.python.org/issue34171
<!-- /issue-number -->
