### PR TITLE
Make it more clear that setUpClass runs before each class, not "class run"

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -724,7 +724,7 @@ Test cases
 
    .. method:: setUpClass()
 
-      A class method called before tests in an individual class run.
+      A class method called before tests in an individual class are run.
       ``setUpClass`` is called with the class as the only argument
       and must be decorated as a :func:`classmethod`::
 


### PR DESCRIPTION
While not arguably strictly incorrect, the previous wording left some ambiguity at least the way I read it ("class run" ~ "test run", i.e. one complete event of running a set of tests).