### PR TITLE
[2.7] bpo-34400: Fix more undefined behavior in parsetok.c (GH-8833).

### DIFF
--- a/Parser/parsetok.c
+++ b/Parser/parsetok.c
@@ -189,10 +189,12 @@ parsetok(struct tok_state *tok, grammar *g, int start, perrdetail *err_ret,
 
 #ifdef PY_PARSER_REQUIRES_FUTURE_KEYWORD
 #endif
-        if (a >= tok->line_start)
+        if (a != NULL && a >= tok->line_start) {
             col_offset = a - tok->line_start;
-        else
+        }
+        else {
             col_offset = -1;
+        }
 
         if ((err_ret->error =
              PyParser_AddToken(ps, (int)type, str, tok->lineno, col_offset,


### PR DESCRIPTION
(cherry picked from commit 3e26e42c905852394fa136f1cc564dac98b56166)

Co-authored-by: Zackery Spytz <zspytz@gmail.com>

<!-- issue-number: [bpo-34400](https://www.bugs.python.org/issue34400) -->
https://bugs.python.org/issue34400
<!-- /issue-number -->
