### PR TITLE
bpo-34454: datetime: Fix crash on PyUnicode_AsUTF8AndSize() failure

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-08-22-00-29-35.bpo-34454.dmIlq5.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-22-00-29-35.bpo-34454.dmIlq5.rst
@@ -1,0 +1,2 @@
+Fix crash in ``fromisoformat`` method of classes from :mod:`datetime` on
+:c:func:`PyUnicode_AsUTF8AndSize()` failure. Patch by Alexey Izbyshev.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2883,6 +2883,9 @@ date_fromisoformat(PyObject *cls, PyObject *dtstr) {
     Py_ssize_t len;
 
     const char * dt_ptr = PyUnicode_AsUTF8AndSize(dtstr, &len);
+    if (dt_ptr == NULL) {
+        return NULL;
+    }
 
     int year = 0, month = 0, day = 0;
 
@@ -4257,6 +4260,9 @@ time_fromisoformat(PyObject *cls, PyObject *tstr) {
 
     Py_ssize_t len;
     const char *p = PyUnicode_AsUTF8AndSize(tstr, &len);
+    if (p == NULL) {
+        return NULL;
+    }
 
     int hour = 0, minute = 0, second = 0, microsecond = 0;
     int tzoffset, tzimicrosecond = 0;
@@ -4850,6 +4856,9 @@ datetime_fromisoformat(PyObject* cls, PyObject *dtstr) {
 
     Py_ssize_t len;
     const char * dt_ptr = PyUnicode_AsUTF8AndSize(dtstr, &len);
+    if (dt_ptr == NULL) {
+        return NULL;
+    }
     const char * p = dt_ptr;
 
     int year = 0, month = 0, day = 0;


### PR DESCRIPTION
The missing NULL check was reported by Svace static analyzer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34454](https://www.bugs.python.org/issue34454) -->
https://bugs.python.org/issue34454
<!-- /issue-number -->
