### PR TITLE
[3.7] bpo-34461: Availability of parsers in etree initializer of xml package

### DIFF
--- a/Lib/xml/etree/__init__.py
+++ b/Lib/xml/etree/__init__.py
@@ -31,3 +31,7 @@
 
 # Licensed to PSF under a Contributor Agreement.
 # See http://www.python.org/psf/license for licensing details.
+
+# Occupy all the parser files in initializer.
+
+from . import (ElementInclude, ElementPath, ElementTree, cElementTree)


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

By providing the above PR - all the parsers will be available to ***etree*** library of xml package. Now it's recommended by this solution - script can be written as 

```
from xml import *
etree.ElementTree.somemethod
```

<!-- issue-number: [bpo-34461](https://www.bugs.python.org/issue34461) -->
https://bugs.python.org/issue34461
<!-- /issue-number -->
