### PR TITLE
[2.7] bpo-34457: Python/ast.c: Add missing NULL check to alias_for_im…

### DIFF
--- a/Python/ast.c
+++ b/Python/ast.c
@@ -2520,6 +2520,8 @@ alias_for_import_name(struct compiling *c, const node *n, int store)
             break;
         case STAR:
             str = PyString_InternFromString("*");
+            if (!str)
+                return NULL;
             PyArena_AddPyObject(c->c_arena, str);
             return alias(str, NULL, c->c_arena);
         default:


### PR DESCRIPTION
…port_name(). (GH-8852)

Reported by Svace static analyzer..
(cherry picked from commit 28853a249b1d0c890b7e9ca345290bb8c1756446)

Co-authored-by: Alexey Izbyshev <izbyshev@ispras.ru>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34457](https://www.bugs.python.org/issue34457) -->
https://bugs.python.org/issue34457
<!-- /issue-number -->
