### PR TITLE
bpo-34454: fix crash in .fromisoformat() methods when given inputs with surrogate code points

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1667,6 +1667,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         # Test that fromisoformat() fails on invalid values
         bad_strs = [
             '',                 # Empty string
+            '\ud800',           # bpo-34454: Surrogate code point
             '009-03-04',        # Not 10 characters
             '123456789',        # Not a date
             '200a-12-04',       # Invalid character in year
@@ -2587,7 +2588,8 @@ class TestDateTime(TestDate):
             ' ', 'T', '\u007f',     # 1-bit widths
             '\u0080', 'ʁ',          # 2-bit widths
             'ᛇ', '時',               # 3-bit widths
-            '🐍'                     # 4-bit widths
+            '🐍',                    # 4-bit widths
+            '\ud800',               # bpo-34454: Surrogate code point
         ]
 
         for sep in separators:
@@ -2639,6 +2641,7 @@ class TestDateTime(TestDate):
         # Test that fromisoformat() fails on invalid values
         bad_strs = [
             '',                             # Empty string
+            '\ud800',                       # bpo-34454: Surrogate code point
             '2009.04-19T03',                # Wrong first separator
             '2009-04.19T03',                # Wrong second separator
             '2009-04-19T0a',                # Invalid hours

--- a/Misc/NEWS.d/next/Library/2018-08-22-21-59-08.bpo-34454.z7uG4b.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-22-21-59-08.bpo-34454.z7uG4b.rst
@@ -1,0 +1,4 @@
+Fix the .fromisoformat() methods of datetime types crashing when given
+unicode with non-UTF-8-encodable code points.  Specifically,
+datetime.fromisoformat() now accepts surrogate unicode code points used as
+the separator, to be consistent with the pure-python version.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2880,24 +2880,30 @@ date_fromisoformat(PyObject *cls, PyObject *dtstr) {
         return NULL;
     }
 
-    Py_ssize_t len = PyUnicode_GET_LENGTH(dtstr);
-    if (len != 10) {
-        goto invalid_string_error;
-    }
-
-    PyObject * bytes = PyUnicode_AsASCIIString(dtstr);
-    if (bytes == NULL) {
+    if (PyUnicode_READY(dtstr) == -1) {
         return NULL;
     }
-    const char * p = PyBytes_AS_STRING(bytes);
-    Py_DECREF(bytes);
-    if (p == NULL) {
-        goto invalid_string_error;
+
+    const PyObject *bytes = NULL;
+    const char * p;
+
+    if (PyUnicode_KIND(dtstr) == PyUnicode_1BYTE_KIND) {
+        p = (const char *) PyUnicode_1BYTE_DATA(dtstr);
+    }
+    else {
+        bytes = PyUnicode_AsASCIIString(dtstr);
+        if (bytes == NULL) {
+            goto invalid_string_error;
+        }
+        p = PyBytes_AS_STRING(bytes);
     }
 
     int year = 0, month = 0, day = 0;
-
     int rv = parse_isoformat_date(p, &year, &month, &day);
+
+    if (bytes != NULL) {
+        Py_DECREF(bytes);
+    }
 
     if (rv < 0) {
         goto invalid_string_error;
@@ -4263,8 +4269,24 @@ time_fromisoformat(PyObject *cls, PyObject *tstr) {
         return NULL;
     }
 
-    Py_ssize_t len;
-    const char *p = PyUnicode_AsUTF8AndSize(tstr, &len);
+    if (PyUnicode_READY(tstr) == -1) {
+        return NULL;
+    }
+
+    Py_ssize_t len = PyUnicode_GET_LENGTH(tstr);
+    const PyObject * bytes = NULL;
+    const char *p;
+
+    if (PyUnicode_KIND(tstr) == PyUnicode_1BYTE_KIND) {
+        p = (const char *) PyUnicode_1BYTE_DATA(tstr);
+    }
+    else {
+        bytes = PyUnicode_AsASCIIString(tstr);
+        if (bytes == NULL) {
+            goto invalid_string_error;
+        }
+        p = PyBytes_AS_STRING(bytes);
+    }
 
     int hour = 0, minute = 0, second = 0, microsecond = 0;
     int tzoffset, tzimicrosecond = 0;
@@ -4272,9 +4294,12 @@ time_fromisoformat(PyObject *cls, PyObject *tstr) {
                                   &hour, &minute, &second, &microsecond,
                                   &tzoffset, &tzimicrosecond);
 
+    if (bytes != NULL) {
+        Py_DECREF(bytes);
+    }
+
     if (rv < 0) {
-        PyErr_Format(PyExc_ValueError, "Invalid isoformat string: %s", p);
-        return NULL;
+        goto invalid_string_error;
     }
 
     PyObject *tzinfo = tzinfo_from_isoformat_results(rv, tzoffset,
@@ -4294,6 +4319,10 @@ time_fromisoformat(PyObject *cls, PyObject *tstr) {
 
     Py_DECREF(tzinfo);
     return t;
+
+  invalid_string_error:
+    PyErr_Format(PyExc_ValueError, "Invalid isoformat string: %s", p);
+    return NULL;
 }
 
 
@@ -4856,6 +4885,10 @@ datetime_fromisoformat(PyObject* cls, PyObject *dtstr) {
         return NULL;
     }
 
+    if (PyUnicode_READY(dtstr) == -1) {
+        return NULL;
+    }
+
     Py_ssize_t len = PyUnicode_GET_LENGTH(dtstr);
     if (len < 10) {
         goto invalid_string_error;
@@ -4865,32 +4898,17 @@ datetime_fromisoformat(PyObject* cls, PyObject *dtstr) {
     int hour = 0, minute = 0, second = 0, microsecond = 0;
     int tzoffset = 0, tzusec = 0;
     int rv;
-    PyObject *substr, *substr_bytes;
+    PyObject *substr, *substr_bytes = NULL;
     const char * p;
 
-    // date has a fixed length of 10
-    substr = PyUnicode_Substring(dtstr, 0, 10);
-    if (substr == NULL) {
-        return NULL;
-    }
-    substr_bytes = PyUnicode_AsASCIIString(substr);
-    Py_DECREF(substr);
-    if (substr_bytes == NULL) {
-        goto invalid_string_error;
-    }
-    p = PyBytes_AS_STRING(substr_bytes);
-    Py_DECREF(substr_bytes);
-    if (p == NULL) {
-        return NULL;
-    }
+    int is_1byte = (PyUnicode_KIND(dtstr) == PyUnicode_1BYTE_KIND);
 
-    rv = parse_isoformat_date(p, &year, &month, &day);
-    if (rv != 0) {
-        goto invalid_string_error;
+    if (is_1byte) {
+        p = (const char *) PyUnicode_1BYTE_DATA(dtstr);
     }
-
-    if (len > 10) {
-        substr = PyUnicode_Substring(dtstr, 11, len);
+    else {
+        // date has a fixed length of 10
+        substr = PyUnicode_Substring(dtstr, 0, 10);
         if (substr == NULL) {
             return NULL;
         }
@@ -4900,14 +4918,39 @@ datetime_fromisoformat(PyObject* cls, PyObject *dtstr) {
             goto invalid_string_error;
         }
         p = PyBytes_AS_STRING(substr_bytes);
+    }
+
+    rv = parse_isoformat_date(p, &year, &month, &day);
+    if (substr_bytes != NULL) {
         Py_DECREF(substr_bytes);
-        if (p == NULL) {
-            return NULL;
+    }
+    if (rv != 0) {
+        goto invalid_string_error;
+    }
+
+    if (len > 10) {
+        if (is_1byte) {
+            p += 11;
+        }
+        else {
+            substr = PyUnicode_Substring(dtstr, 11, len);
+            if (substr == NULL) {
+                return NULL;
+            }
+            substr_bytes = PyUnicode_AsASCIIString(substr);
+            Py_DECREF(substr);
+            if (substr_bytes == NULL) {
+                goto invalid_string_error;
+            }
+            p = PyBytes_AS_STRING(substr_bytes);
         }
 
         rv = parse_isoformat_time(p, len - 11,
                                   &hour, &minute, &second, &microsecond,
                                   &tzoffset, &tzusec);
+        if (substr_bytes != NULL) {
+            Py_DECREF(substr_bytes);
+        }
         if (rv < 0) {
             goto invalid_string_error;
         }


### PR DESCRIPTION
The current implementation **crashes** if the input includes a surrogate Unicode code point, which is not possible to encode in UTF-8.

It is important to note that the pure-Python implementation allows using a surrogate as the separator character when calling `datetime.fromisoformat()`.

As mentioned in [a comment on the bpo issue](https://bugs.python.org/issue34454#msg323846), there's actually no need to encode the input as UTF-8.

This implementation uses `PyUnicode_1BYTE_DATA()` when possible. In other cases (which should be extremely rare!), it creates temporary intermediate Python objects. For `date` and `time`, a single temporary `bytes` object is created. For `datetime`, up to four temporary objects are created: two `str` objects (for sub-strings) and two `bytes` objects (for converting the sub-strings to ASCII). This increases the size and complexity of the code considerably, but I couldn't find a reasonable way to avoid creating these objects entirely.

<!-- issue-number: [bpo-34454](https://www.bugs.python.org/issue34454) -->
https://bugs.python.org/issue34454
<!-- /issue-number -->
