### PR TITLE
bpo-6700: Fix inspect.getsourcelines for module level frames/tracebacks

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -954,7 +954,12 @@ def getsourcelines(object):
     object = unwrap(object)
     lines, lnum = findsource(object)
 
-    if ismodule(object):
+    if istraceback(object):
+        object = object.tb_frame
+
+    # for module or frame that correspond to module return all source lines
+    if (ismodule(object) or
+        (isframe(object) and object.f_code.co_name == "<module>")):
         return lines, 0
     else:
         return getblock(lines[lnum:]), lnum + 1

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -957,7 +957,7 @@ def getsourcelines(object):
     if istraceback(object):
         object = object.tb_frame
 
-    # for module or frame that correspond to module return all source lines
+    # for module or frame that corresponds to module, return all source lines
     if (ismodule(object) or
         (isframe(object) and object.f_code.co_name == "<module>")):
         return lines, 0

--- a/Lib/test/inspect_fodder.py
+++ b/Lib/test/inspect_fodder.py
@@ -74,3 +74,9 @@ class FesteringGob(MalodorousPervert, ParrotDroppings):
 
 async def lobbest(grenade):
     pass
+
+currentframe = inspect.currentframe()
+try:
+    raise Exception()
+except:
+    tb = sys.exc_info()[2]

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -527,6 +527,15 @@ class TestRetrievingSourceCode(GetSourceBase):
     def test_getsource_on_code_object(self):
         self.assertSourceEqual(mod.eggs.__code__, 12, 18)
 
+class TestGettingSourceOfToplevelFrames(GetSourceBase):
+    fodderModule = mod
+
+    def test_range_toplevel_frame(self):
+        self.assertSourceEqual(mod.currentframe, 1, 82)
+
+    def test_range_traceback_toplevel_frame(self):
+        self.assertSourceEqual(mod.tb, 1, 82)
+
 class TestDecorators(GetSourceBase):
     fodderModule = mod2
 
@@ -3870,7 +3879,7 @@ def test_main():
         TestBoundArguments, TestSignaturePrivateHelpers,
         TestSignatureDefinitions, TestIsDataDescriptor,
         TestGetClosureVars, TestUnwrap, TestMain, TestReload,
-        TestGetCoroutineState
+        TestGetCoroutineState, TestGettingSourceOfToplevelFrames
     )
 
 if __name__ == "__main__":

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -344,7 +344,7 @@ class GetSourceBase(unittest.TestCase):
 
     def sourcerange(self, top, bottom):
         lines = self.source.split("\n")
-        return "\n".join(lines[top-1:bottom]) + "\n"
+        return "\n".join(lines[top-1:bottom]) + ("\n" if bottom else "")
 
     def assertSourceEqual(self, obj, top, bottom):
         self.assertEqual(inspect.getsource(obj),
@@ -531,10 +531,11 @@ class TestGettingSourceOfToplevelFrames(GetSourceBase):
     fodderModule = mod
 
     def test_range_toplevel_frame(self):
-        self.assertSourceEqual(mod.currentframe, 1, 82)
+        self.maxDiff = None
+        self.assertSourceEqual(mod.currentframe, 1, None)
 
     def test_range_traceback_toplevel_frame(self):
-        self.assertSourceEqual(mod.tb, 1, 82)
+        self.assertSourceEqual(mod.tb, 1, None)
 
 class TestDecorators(GetSourceBase):
     fodderModule = mod2

--- a/Misc/NEWS.d/next/Library/2018-08-22-17-43-52.bpo-6700.hp7C4B.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-22-17-43-52.bpo-6700.hp7C4B.rst
@@ -1,0 +1,1 @@
+Fix inspect.getsourcelines for module level frames/tracebacks

--- a/Misc/NEWS.d/next/Library/2018-08-22-17-43-52.bpo-6700.hp7C4B.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-22-17-43-52.bpo-6700.hp7C4B.rst
@@ -1,1 +1,2 @@
-Fix inspect.getsourcelines for module level frames/tracebacks
+Fix inspect.getsourcelines for module level frames/tracebacks.
+Patch by Vladimir Matveev.


### PR DESCRIPTION
Fix `inspect.getsourcelines` for module level frames/tracebacks - if traceback object or frame correspond to the module - return all source lines.

<!-- issue-number: [bpo-6700](https://www.bugs.python.org/issue6700) -->
https://bugs.python.org/issue6700
<!-- /issue-number -->
