### PR TITLE
bpo-34207: Fix pymain_init_cmdline_argv()

### DIFF
--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -20,6 +20,10 @@ PyAPI_FUNC(char*) _Py_EncodeLocaleRaw(
 #endif
 
 #ifdef Py_BUILD_CORE
+PyAPI_FUNC(wchar_t *) _Py_DecodeUTF8(
+    const char *arg,
+    size_t *size);
+
 PyAPI_FUNC(int) _Py_DecodeUTF8Ex(
     const char *arg,
     Py_ssize_t arglen,

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -371,7 +371,13 @@ pymain_init_cmdline_argv(_PyMain *pymain, _PyCoreConfig *config,
 
         for (int i = 0; i < pymain->argc; i++) {
             size_t len;
-            wchar_t *arg = Py_DecodeLocale(pymain->bytes_argv[i], &len);
+            wchar_t *arg;
+            if (config->utf8_mode > 0) {
+                arg = _Py_DecodeUTF8(pymain->bytes_argv[i], &len);
+            }
+            else {
+                arg = Py_DecodeLocale(pymain->bytes_argv[i], &len);
+            }
             if (arg == NULL) {
                 _Py_wstrlist_clear(i, argv);
                 pymain->err = DECODE_LOCALE_ERR("command line arguments",

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -516,6 +516,21 @@ Py_DecodeLocale(const char* arg, size_t *wlen)
 }
 
 
+wchar_t*
+_Py_DecodeUTF8(const char* arg, size_t *wlen)
+{
+    wchar_t *wstr;
+    int res = _Py_DecodeUTF8Ex(arg, strlen(arg), &wstr, wlen, NULL, 1);
+    if (res != 0) {
+        if (wlen != NULL) {
+            *wlen = (size_t)res;
+        }
+        return NULL;
+    }
+    return wstr;
+}
+
+
 static int
 encode_current_locale(const wchar_t *text, char **str,
                       size_t *error_pos, const char **reason,


### PR DESCRIPTION
[bpo-34170](https://www.bugs.python.org/issue34170), [bpo-34207](https://www.bugs.python.org/issue34207): Fix pymain_init_cmdline_argv()

* Add _Py_DecodeUTF8()
* pymain_init_cmdline_argv() now calls directly _Py_DecodeUTF8() if
  the UTF-8 mode is enabled

Previously, pymain_init_cmdline_argv() always called
Py_DecodeLocale() which depends on Py_UTF8Mode, whereas this variable
is no longer modified when reading the current configuration.