### PR TITLE
bpo-34471: _datetime: Add missing NULL check to tzinfo_from_isoformat…

### DIFF
--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1294,7 +1294,7 @@ tzinfo_from_isoformat_results(int rv, int tzoffset, int tz_useconds) {
             return NULL;
         }
         tzinfo = new_timezone(delta, NULL);
-        Py_XDECREF(delta);
+        Py_DECREF(delta);
     } else {
         tzinfo = Py_None;
         Py_INCREF(Py_None);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1290,6 +1290,9 @@ tzinfo_from_isoformat_results(int rv, int tzoffset, int tz_useconds) {
         }
 
         PyObject *delta = new_delta(0, tzoffset, tz_useconds, 1);
+        if (delta == NULL) {
+            return NULL;
+        }
         tzinfo = new_timezone(delta, NULL);
         Py_XDECREF(delta);
     } else {


### PR DESCRIPTION
…_results()

Reported by Svace static analyzer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34471](https://www.bugs.python.org/issue34471) -->
https://bugs.python.org/issue34471
<!-- /issue-number -->
