### PR TITLE
[3.7] bpo-34207: Fix pymain_read_conf() for UTF-8 Mode (GH-8868)

### DIFF
--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1982,6 +1982,7 @@ pymain_read_conf_impl(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
 static int
 pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
 {
+    int init_utf8_mode = Py_UTF8Mode;
     _PyCoreConfig *config = &pymain->config;
     _PyCoreConfig save_config = _PyCoreConfig_INIT;
     int res = -1;
@@ -2015,6 +2016,10 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
                                        "reading the configuration");
             goto done;
         }
+
+        /* bpo-34207: Py_DecodeLocale(), Py_EncodeLocale() and similar
+           functions depend on Py_UTF8Mode. */
+        Py_UTF8Mode = config->utf8_mode;
 
         if (pymain_init_cmdline_argv(pymain, cmdline) < 0) {
             goto done;
@@ -2086,7 +2091,7 @@ done:
         setlocale(LC_ALL, oldloc);
         PyMem_RawFree(oldloc);
     }
-
+    Py_UTF8Mode = init_utf8_mode ;
     return res;
 }
 


### PR DESCRIPTION
[bpo-34170](https://www.bugs.python.org/issue34170), [bpo-34207](https://www.bugs.python.org/issue34207): pymain_read_conf() now sets Py_UTF8Mode to
config->utf8_mode. pymain_read_conf() calls indirectly
Py_DecodeLocale() and Py_EncodeLocale() which depend on Py_UTF8Mode.

(cherry picked from commit 89487f51b8d6ba8a55f5de0ed689e46fefe73cc9)

<!-- issue-number: [bpo-34207](https://www.bugs.python.org/issue34207) -->
https://bugs.python.org/issue34207
<!-- /issue-number -->
