### PR TITLE
bpo-34472: Add data descriptor signature to zipfile

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -159,6 +159,8 @@ _CD64_NUMBER_ENTRIES_TOTAL = 7
 _CD64_DIRECTORY_SIZE = 8
 _CD64_OFFSET_START_CENTDIR = 9
 
+_DD_SIGNATURE = 0x08074b50
+
 _EXTRA_FIELD_STRUCT = struct.Struct('<HH')
 
 def _strip_extra(extra, xids):
@@ -1118,8 +1120,8 @@ class _ZipWriteFile(io.BufferedIOBase):
         # Write updated header info
         if self._zinfo.flag_bits & 0x08:
             # Write CRC and file sizes after the file data
-            fmt = '<LQQ' if self._zip64 else '<LLL'
-            self._fileobj.write(struct.pack(fmt, self._zinfo.CRC,
+            fmt = '<LLQQ' if self._zip64 else '<LLLL'
+            self._fileobj.write(struct.pack(fmt, _DD_SIGNATURE, self._zinfo.CRC,
                 self._zinfo.compress_size, self._zinfo.file_size))
             self._zipfile.start_dir = self._fileobj.tell()
         else:

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1468,6 +1468,7 @@ Roger D. Serwy
 Jerry Seutter
 Pete Sevander
 Denis Severson
+Silas Sewell
 Ian Seyer
 Dmitry Shachnev
 Anish Shah

--- a/Misc/NEWS.d/next/Library/2018-08-23-09-25-08.bpo-34472.cGyYrO.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-23-09-25-08.bpo-34472.cGyYrO.rst
@@ -1,0 +1,3 @@
+Improved compatibility for streamed files in :mod:`zipfile`. Previously an
+optional signature was not being written and certain ZIP applications were
+not supported. Patch by Silas Sewell.


### PR DESCRIPTION
This makes streamed zips compatible with MacOS Archive Utility and other applications.

<!-- issue-number: [bpo-34472](https://www.bugs.python.org/issue34472) -->
https://bugs.python.org/issue34472
<!-- /issue-number -->
