### PR TITLE
bpo-26901: Fix the Argument Clinic test suite

### DIFF
--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1,8 +1,6 @@
-"""
-Test for Argument Clinic
-Copyright 2012-2013 by Larry Hastings.
-Licensed to the PSF under a contributor agreement.
-"""
+# Argument Clinic
+# Copyright 2012-2013 by Larry Hastings.
+# Licensed to the PSF under a contributor agreement.
 
 from test import support
 from unittest import TestCase

--- a/Lib/test/test_clinic.py
+++ b/Lib/test/test_clinic.py
@@ -1,16 +1,28 @@
-# Argument Clinic
-# Copyright 2012-2013 by Larry Hastings.
-# Licensed to the PSF under a contributor agreement.
-#
+"""
+Test for Argument Clinic
+Copyright 2012-2013 by Larry Hastings.
+Licensed to the PSF under a contributor agreement.
+"""
 
-import clinic
-from clinic import DSLParser
+from test import support
+from unittest import TestCase
 import collections
 import inspect
-from test import support
+import os.path
 import sys
 import unittest
-from unittest import TestCase
+
+
+clinic_path = os.path.join(os.path.dirname(__file__), '..', '..', 'Tools', 'clinic')
+clinic_path = os.path.normpath(clinic_path)
+if not os.path.exists(clinic_path):
+    raise unittest.SkipTest(f'{clinic_path!r} path does not exist')
+sys.path.append(clinic_path)
+try:
+    import clinic
+    from clinic import DSLParser
+finally:
+    del sys.path[-1]
 
 
 class FakeConverter:
@@ -35,7 +47,7 @@ class FakeConvertersDict:
         return self.used_converters.setdefault(name, FakeConverterFactory(name))
 
 clinic.Clinic.presets_text = ''
-c = clinic.Clinic(language='C')
+c = clinic.Clinic(language='C', filename = "file")
 
 class FakeClinic:
     def __init__(self):
@@ -43,6 +55,7 @@ class FakeClinic:
         self.legacy_converters = FakeConvertersDict()
         self.language = clinic.CLanguage(None)
         self.filename = None
+        self.destination_buffers = {}
         self.block_parser = clinic.BlockParser('', self.language)
         self.modules = collections.OrderedDict()
         self.classes = collections.OrderedDict()
@@ -93,7 +106,7 @@ class ClinicWholeFileTest(TestCase):
         # so it would spit out an end line for you.
         # and since you really already had one,
         # the last line of the block got corrupted.
-        c = clinic.Clinic(clinic.CLanguage(None))
+        c = clinic.Clinic(clinic.CLanguage(None), filename="file")
         raw = "/*[clinic]\nfoo\n[clinic]*/"
         cooked = c.parse(raw).splitlines()
         end_line = cooked[2].rstrip()
@@ -252,7 +265,7 @@ xyz
 
     def _test_clinic(self, input, output):
         language = clinic.CLanguage(None)
-        c = clinic.Clinic(language)
+        c = clinic.Clinic(language, filename="file")
         c.parsers['inert'] = InertParser(c)
         c.parsers['copy'] = CopyParser(c)
         computed = c.parse(input)


### PR DESCRIPTION
* Fix Tools/clinic/clinic_test.py: add missing
  FakeClinic.destination_buffers attribute and pass a file argument
  to Clinic().
* Rename Tools/clinic/clinic_test.py to Lib/test/test_clinic.py:
  add temporary Tools/clinic/ to sys.path to import the clinic
  module.

Co-Authored-By: Pablo Galindo <pablogsal@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-26901](https://www.bugs.python.org/issue26901) -->
https://bugs.python.org/issue26901
<!-- /issue-number -->
