### PR TITLE
fix typo in asyncio.BoundedSemaphore docs

### DIFF
--- a/Doc/library/asyncio-sync.rst
+++ b/Doc/library/asyncio-sync.rst
@@ -268,7 +268,7 @@ BoundedSemaphore
    This raises :exc:`ValueError` in :meth:`~Semaphore.release` if it would
    increase the value above the initial value.
 
-   Bounded semapthores support the :ref:`context management
+   Bounded semaphores support the :ref:`context management
    protocol <async-with-locks>`.
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.


### PR DESCRIPTION
here: https://docs.python.org/3/library/asyncio-sync.html#asyncio.BoundedSemaphore

I think this doesn't require an issue number.