### PR TITLE
Fix doc for `add_subparsers` arguments

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -1539,7 +1539,7 @@ Sub-commands
 
 .. method:: ArgumentParser.add_subparsers([title], [description], [prog], \
                                           [parser_class], [action], \
-                                          [option_string], [dest], [required] \
+                                          [option_string], [dest], [required], \
                                           [help], [metavar])
 
    Many programs split up their functionality into a number of sub-commands,


### PR DESCRIPTION
This is currently misrendering [here](https://docs.python.org/3/library/argparse.html#argparse.ArgumentParser.add_subparsers)