### PR TITLE
[2.7] bpo-18560: Fix potential NULL pointer dereference in sum().

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-23-21-32-27.bpo-18560.5q_c1C.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-23-21-32-27.bpo-18560.5q_c1C.rst
@@ -1,0 +1,1 @@
+Fix potential NULL pointer dereference in sum().

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2363,6 +2363,11 @@ builtin_sum(PyObject *self, PyObject *args)
             }
             /* Either overflowed or is not an int. Restore real objects and process normally */
             result = PyInt_FromLong(i_result);
+            if (result == NULL) {
+                Py_DECREF(item);
+                Py_DECREF(iter);
+                return NULL;
+            }
             temp = PyNumber_Add(result, item);
             Py_DECREF(result);
             Py_DECREF(item);


### PR DESCRIPTION
(cherry picked from commit 704e2d374f88bca83339b95d559b0abce12dc6bd)

Co-authored-by: Christian Heimes <christian@cheimes.de>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-18560](https://www.bugs.python.org/issue18560) -->
https://bugs.python.org/issue18560
<!-- /issue-number -->
