### PR TITLE
bpo-31861: Add operator.aiter and operator.anext

### DIFF
--- a/Lib/operator.py
+++ b/Lib/operator.py
@@ -10,16 +10,18 @@ for convenience.
 This is the pure Python implementation of the module.
 """
 
-__all__ = ['abs', 'add', 'and_', 'attrgetter', 'concat', 'contains', 'countOf',
-           'delitem', 'eq', 'floordiv', 'ge', 'getitem', 'gt', 'iadd', 'iand',
-           'iconcat', 'ifloordiv', 'ilshift', 'imatmul', 'imod', 'imul',
-           'index', 'indexOf', 'inv', 'invert', 'ior', 'ipow', 'irshift',
-           'is_', 'is_not', 'isub', 'itemgetter', 'itruediv', 'ixor', 'le',
-           'length_hint', 'lshift', 'lt', 'matmul', 'methodcaller', 'mod',
-           'mul', 'ne', 'neg', 'not_', 'or_', 'pos', 'pow', 'rshift',
-           'setitem', 'sub', 'truediv', 'truth', 'xor']
+__all__ = [
+    'abs', 'add', 'aiter', 'anext', 'and_', 'attrgetter', 'concat', 'contains',
+    'countOf', 'delitem', 'eq', 'floordiv', 'ge', 'getitem', 'gt', 'iadd',
+    'iand', 'iconcat', 'ifloordiv', 'ilshift', 'imatmul', 'imod', 'imul',
+    'index', 'indexOf', 'inv', 'invert', 'ior', 'ipow', 'irshift', 'is_',
+    'is_not', 'isub', 'itemgetter', 'itruediv', 'ixor', 'le', 'length_hint',
+    'lshift', 'lt', 'matmul', 'methodcaller', 'mod', 'mul', 'ne', 'neg', 'not_',
+    'or_', 'pos', 'pow', 'rshift', 'setitem', 'sub', 'truediv', 'truth', 'xor',
+]
 
 from builtins import abs as _abs
+from collections.abc import AsyncIterable, AsyncIterator
 
 
 # Comparison Operations *******************************************************#
@@ -402,6 +404,55 @@ def ixor(a, b):
     "Same as a ^= b."
     a ^= b
     return a
+
+
+# Asynchronous Iterator Operations ********************************************#
+
+async def aiter(*args):
+    """aiter(async_iterable) -> async_iterator
+    aiter(async_callable, sentinel) -> async_iterator
+
+    An async version of the iter() builtin.
+    """
+    lenargs = len(args)
+    if lenargs != 1 and lenargs != 2:
+        raise TypeError(f'aiter expected 1 or 2 arguments, got {lenargs}')
+    if lenargs == 1:
+        obj, = args
+        if not isinstance(obj, AsyncIterable):
+            raise TypeError(f'aiter expected an AsyncIterable, got {type(obj)}')
+        async for i in obj.__aiter__():
+            yield i
+        return
+    # lenargs == 2
+    async_callable, sentinel = args
+    while True:
+        value = await async_callable()
+        if value == sentinel:
+            break
+        yield value
+
+
+async def anext(*args):
+    """anext(async_iterator[, default])
+
+    Return the next item from the async iterator.
+    If default is given and the iterator is exhausted,
+    it is returned instead of raising StopAsyncIteration.
+    """
+    lenargs = len(args)
+    if lenargs != 1 and lenargs != 2:
+        raise TypeError(f'anext expected 1 or 2 arguments, got {lenargs}')
+    ait = args[0]
+    if not isinstance(ait, AsyncIterator):
+        raise TypeError(f'anext expected an AsyncIterable, got {type(ait)}')
+    anxt = ait.__anext__
+    try:
+        return await anxt()
+    except StopAsyncIteration:
+        if lenargs == 1:
+            raise
+        return args[1]  # default
 
 
 try:

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -400,6 +400,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         self.assertEqual(res, [1, 2])
 
     def test_async_gen_operator_aiter_class(self):
+        results = []
         loop = self.loop
         class Gen:
             async def __aiter__(self):
@@ -408,9 +409,14 @@ class AsyncGenAsyncioTest(unittest.TestCase):
                 yield 2
         g = Gen()
         async def consume():
-            return [i async for i in operator.aiter(g)]
-        res = self.loop.run_until_complete(consume())
-        self.assertEqual(res, [1, 2])
+            ait = operator.aiter(g)
+            while True:
+                try:
+                    results.append(await operator.anext(ait))
+                except StopAsyncIteration:
+                    break
+        self.loop.run_until_complete(consume())
+        self.assertEqual(results, [1, 2])
 
     def test_async_gen_operator_aiter_2_arg(self):
         async def gen():

--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -404,7 +404,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         class Gen:
             async def __aiter__(self):
                 yield 1
-                await asyncio.sleep(0.01, loop=loop)
+                await asyncio.sleep(0.01)
                 yield 2
         g = Gen()
         async def consume():

--- a/Misc/NEWS.d/next/Library/2018-08-24-01-08-09.bpo-31861.-q9RKJ.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-24-01-08-09.bpo-31861.-q9RKJ.rst
@@ -1,0 +1,1 @@
+Add the operator.aiter and operator.anext functions. Patch by Josh Bronson.


### PR DESCRIPTION
...along with passing tests. (I added the tests to `test_asyncgen.py` rather than to `test_operator.py` because they fit much better there.)

/cc @1st1 @njsmith @JelleZijlstra et al.

<!-- issue-number: [bpo-31861](https://www.bugs.python.org/issue31861) -->
https://bugs.python.org/issue31861
<!-- /issue-number -->
