### PR TITLE
[2.7] bpo-6700: Fix inspect.getsourcelines for module level frames/tracebacks (GH-8864)

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -688,8 +688,15 @@ def getsourcelines(object):
     raised if the source code cannot be retrieved."""
     lines, lnum = findsource(object)
 
-    if ismodule(object): return lines, 0
-    else: return getblock(lines[lnum:]), lnum + 1
+    if istraceback(object):
+        object = object.tb_frame
+
+    # for module or frame that corresponds to module, return all source lines
+    if (ismodule(object) or
+        (isframe(object) and object.f_code.co_name == "<module>")):
+        return lines, 0
+    else:
+        return getblock(lines[lnum:]), lnum + 1
 
 def getsource(object):
     """Return the text of the source code for an object.

--- a/Lib/test/inspect_fodder.py
+++ b/Lib/test/inspect_fodder.py
@@ -56,3 +56,9 @@ class ParrotDroppings:
 
 class FesteringGob(MalodorousPervert, ParrotDroppings):
     pass
+
+currentframe = inspect.currentframe()
+try:
+    raise Exception()
+except:
+    tb = sys.exc_info()[2]

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -209,7 +209,7 @@ class GetSourceBase(unittest.TestCase):
 
     def sourcerange(self, top, bottom):
         lines = self.source.split("\n")
-        return "\n".join(lines[top-1:bottom]) + "\n"
+        return "\n".join(lines[top-1:bottom]) + ("\n" if bottom else "")
 
     def assertSourceEqual(self, obj, top, bottom):
         self.assertEqual(inspect.getsource(obj),
@@ -330,6 +330,16 @@ class TestRetrievingSourceCode(GetSourceBase):
             inspect.getsource(ns["x"])
         finally:
             linecache.getlines = getlines
+
+class TestGettingSourceOfToplevelFrames(GetSourceBase):
+    fodderModule = mod
+
+    def test_range_toplevel_frame(self):
+        self.maxDiff = None
+        self.assertSourceEqual(mod.currentframe, 1, None)
+
+    def test_range_traceback_toplevel_frame(self):
+        self.assertSourceEqual(mod.tb, 1, None)
 
 class TestDecorators(GetSourceBase):
     fodderFile = mod2
@@ -896,7 +906,8 @@ def test_main():
         TestDecorators, TestRetrievingSourceCode, TestOneliners, TestBuggyCases,
         TestInterpreterStack, TestClassesAndFunctions, TestPredicates,
         TestGetcallargsFunctions, TestGetcallargsFunctionsCellVars,
-        TestGetcallargsMethods, TestGetcallargsUnboundMethods)
+        TestGetcallargsMethods, TestGetcallargsUnboundMethods,
+        TestGettingSourceOfToplevelFrames)
 
 if __name__ == "__main__":
     test_main()

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -332,7 +332,7 @@ class TestRetrievingSourceCode(GetSourceBase):
             linecache.getlines = getlines
 
 class TestGettingSourceOfToplevelFrames(GetSourceBase):
-    fodderModule = mod
+    fodderFile = mod
 
     def test_range_toplevel_frame(self):
         self.maxDiff = None

--- a/Misc/NEWS.d/next/Library/2018-08-22-17-43-52.bpo-6700.hp7C4B.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-22-17-43-52.bpo-6700.hp7C4B.rst
@@ -1,0 +1,2 @@
+Fix inspect.getsourcelines for module level frames/tracebacks.
+Patch by Vladimir Matveev.


### PR DESCRIPTION
(cherry picked from commit 91cb298f811961277fd4cc4a32211899d48bedcb)

Co-authored-by: Vladimir Matveev <v2matveev@outlook.com>

<!-- issue-number: [bpo-6700](https://www.bugs.python.org/issue6700) -->
https://bugs.python.org/issue6700
<!-- /issue-number -->
