### PR TITLE
bpo-34495: Fix falling with assertion when args == nullptr

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3634,7 +3634,7 @@ object_new(PyTypeObject *type, PyObject *args, PyObject *kwds);
 static int
 excess_args(PyObject *args, PyObject *kwds)
 {
-    return PyTuple_GET_SIZE(args) ||
+    return (args && PyTuple_GET_SIZE(args)) ||
         (kwds && PyDict_Check(kwds) && PyDict_GET_SIZE(kwds));
 }
 


### PR DESCRIPTION
Required since PyTuple_GET_SIZE performs assert(PyTuple_Check);

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34495](https://www.bugs.python.org/issue34495) -->
https://bugs.python.org/issue34495
<!-- /issue-number -->
