### PR TITLE
bpo-34489: subprocess / fixed vulnerability by execution of batch-files (.cmd/.bat) in python for windows / insufficient escape

### DIFF
--- a/Doc/library/subprocess.rst
+++ b/Doc/library/subprocess.rst
@@ -933,3 +933,27 @@ runtime):
    backslash escapes the next double quotation mark as
    described in rule 3.
 
+6. Note that some special meta-chars ``&|^<>!()%`` should be escaped,
+   additionally if arguments contain unpaired (also escaped) quotes
+   before (and another like a percent char ``%`` - always (regardless
+   paired/unpaired quotes).
+   This chars can be escaped using switching quotation process (so
+   quasy enclosed in aditional quotes, like ``1&&2`` -> ``1"&&"2``, thereby 
+   backslashes can be joined with this chars but it's important to 
+   consider the backslash before new closing quote, so although both of
+   ``1\\&&\\2`` -> ``1"\\&&"\\2`` as well as a bit longer variant
+   ``1\\&&\\2`` -> ``1"\\&&\\\\"2`` (with double escaped backslash) are correct,
+   the short (first) notation is prefered.
+
+Note that the current escape resp. quoting of arguments for windows works only
+with executables using CommandLineToArgv, CRT-library or similar, as well as
+with the windows batch files (excepting the newline, see below).
+Although it is the common escape algorithm, but, in fact, the way how the
+executable parses the command-line (resp. splits it into single arguments)
+is decisive.
+
+Unfortunately, there is currently no way to supply newline character within 
+an argument to the batch files (``.cmd`` or ``.bat``) or to the command 
+processor (``cmd.exe /c``), because this causes truncation of command-line
+(also the argument chain) on the first newline character. 
+But it works properly with an executable (using CommandLineToArgv, etc).

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -254,11 +254,12 @@ def list2cmdline(seq):
        before (and another like a percent char `%` - always (regardless
        paired/unpaired quotes).
        This chars can be escaped using switching quotation process (so
-       quasy enclosed in aditional quotes, like '1&&2' -> '1"&&"2', thereby 
+       quasy enclosed in aditional quotes, like `1&&2` -> `1"&&"2`, thereby 
        backslashes can be joined with this chars but it's important to 
-       consider the backslash before new closing quote, so both of
-       '1\\&&\\2' -> '1"\\&&"\\2' as well as a bit longer variant
-       '1\\&&\\2' -> '1"\\&&\\\\"2' (with double escaped backslash) are correct.
+       consider the backslash before new closing quote, so although both of
+       `1\\&&\\2` -> `1"\\&&"\\2` as well as a bit longer variant
+       `1\\&&\\2` -> `1"\\&&\\\\"2` (with double escaped backslash) are correct,
+       the short (first) notation is prefered.
        See under [SB-0D-001-win-exec] for more info.
     """
 

--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -284,7 +284,7 @@ def list2cmdline(seq):
         specChars = None        # within special escape, using unpaired quotes
 
         for c in arg:
-            if c in ' \t':
+            if c.isspace():
                 needquote = True
                 if bscnt: needescape = True
             elif c in specMetaChars:


### PR DESCRIPTION
<!-- issue-number: [bpo-34489](https://www.bugs.python.org/issue34489) -->
[bpo-34489](https://www.bugs.python.org/issue34489)
<!-- /issue-number -->

Closes [bpo-34489](https://www.bugs.python.org/issue34489) vulnerability "insufficient escape of special chars for quoting of arguments by exec process" for python-language, if executing windows batch-files (bat/cmd).

Fixed for 2.7, but can be easy merged (or cherry-picked) for 3.x up to master.

### What version of python is affected?
All

### Does this issue reproduce with the latest master?
Yes

### What did you do?
Execution of batch-file using `subprocess` module with arguments containing some special meta-characters.

A recipe for reproducing the error as well as more extensive PoC with additional info (and more lang's affected also) - [github/sebres/PoC/SB-0D-001-win-exec](https://github.com/sebres/PoC/blob/master/SB-0D-001-win-exec/README.md)
A complete runnable program - [test-dump-inv.py](https://github.com/sebres/PoC/blob/master/SB-0D-001-win-exec/test-dump-inv.py).

#### A simple example:
```diff
 # invoke exe-file:
 >>> import subprocess
 >>> subprocess.call(['test-dump.exe', 'test&whoami'])
+    `test-dump.exe´ `test&whoami´
 # invoke cmd-file:
 >>> subprocess.call(['test-dump.CMD', 'test&whoami'])
-    `test-dump.exe´ `test´my_domain\sebres
```
For more "broken" cases, see the result of my test-suite - [python.diff](https://github.com/sebres/PoC/blob/master/SB-0D-001-win-exec/results/python.diff)

### What did you expect to see?
Arguments are escaped/quoted properly.

### What did you see instead?
Arguments are insufficient escaped/quoted, so it is vulnerable currently.

### Solution:

- the [algorithm description](https://github.com/sebres/PoC/blob/master/SB-0D-001-win-exec/SOLUTION.md) 
- how it was fixed in TCL as [C-code](https://core.tcl-lang.org/tcl/vdiff?from=core-8-5-branch&to=0-day-21b0629c81) (see the function `BuildCommandLine`)

### Possible similar issues:
[[[bpo-33515](https://www.bugs.python.org/issue33515)]](https://bugs.python.org/issue33515)
