### PR TITLE
bpo-34490: Fix test_asyncio for AIX - do not call transport.get_extra_info('sock…

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -41,9 +41,11 @@ def tearDownModule():
     asyncio.set_event_loop_policy(None)
 
 
-def osx_tiger():
+def broken_unix_getsockname():
     """Return True if the platform is Mac OS 10.4 or older."""
-    if sys.platform != 'darwin':
+    if sys.platform.startswith("aix"):
+        return True
+    elif sys.platform != 'darwin':
         return False
     version = platform.mac_ver()[0]
     version = tuple(map(int, version.split('.')))
@@ -617,7 +619,7 @@ class EventLoopTestsMixin:
     def test_create_unix_connection(self):
         # Issue #20682: On Mac OS X Tiger, getsockname() returns a
         # zero-length address for UNIX socket.
-        check_sockname = not osx_tiger()
+        check_sockname = not broken_unix_getsockname()
 
         with test_utils.run_test_unix_server() as httpd:
             conn_fut = self.loop.create_unix_connection(
@@ -748,7 +750,7 @@ class EventLoopTestsMixin:
     def test_create_ssl_unix_connection(self):
         # Issue #20682: On Mac OS X Tiger, getsockname() returns a
         # zero-length address for UNIX socket.
-        check_sockname = not osx_tiger()
+        check_sockname = not broken_unix_getsockname()
 
         with test_utils.run_test_unix_server(use_ssl=True) as httpd:
             create_connection = functools.partial(

--- a/Misc/NEWS.d/next/Tests/2018-08-24-20-23-15.bpo-34490.vb2cx4.rst
+++ b/Misc/NEWS.d/next/Tests/2018-08-24-20-23-15.bpo-34490.vb2cx4.rst
@@ -1,0 +1,2 @@
+On AIX with AF_UNIX family sockets getsockname() does not provide 'sockname',
+so skip calls to transport.get_extra_info('sockname')


### PR DESCRIPTION
Inspired by msg211764, issue20682

<!-- issue-number: [bpo-34490](https://www.bugs.python.org/issue34490) -->
https://bugs.python.org/issue34490
<!-- /issue-number -->
