### PR TITLE
[2.7] bpo-34491: Add missing Py_DECREF() in _bsddb's DB_join()

### DIFF
--- a/Modules/_bsddb.c
+++ b/Modules/_bsddb.c
@@ -2297,6 +2297,7 @@ DB_join(DBObject* self, PyObject* args)
             PyErr_SetString(PyExc_TypeError,
                             "Sequence of DBCursor objects expected");
             free(cursors);
+            Py_DECREF(item);
             return NULL;
         }
         cursors[x] = ((DBCursorObject*)item)->dbc;


### PR DESCRIPTION


<!-- issue-number: [bpo-34491](https://www.bugs.python.org/issue34491) -->
https://bugs.python.org/issue34491
<!-- /issue-number -->
