### PR TITLE
bpo-34497 Remove needless set operator restriction

### DIFF
--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -1234,7 +1234,7 @@ set_or(PySetObject *so, PyObject *other)
 {
     PySetObject *result;
 
-    if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
+    if (!PyAnySet_Check(so))
         Py_RETURN_NOTIMPLEMENTED;
 
     result = (PySetObject *)set_copy(so, NULL);
@@ -1396,7 +1396,7 @@ PyDoc_STRVAR(intersection_update_doc,
 static PyObject *
 set_and(PySetObject *so, PyObject *other)
 {
-    if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
+    if (!PyAnySet_Check(so))
         Py_RETURN_NOTIMPLEMENTED;
     return set_intersection(so, other);
 }
@@ -1654,7 +1654,7 @@ PyDoc_STRVAR(difference_doc,
 static PyObject *
 set_sub(PySetObject *so, PyObject *other)
 {
-    if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
+    if (!PyAnySet_Check(so))
         Py_RETURN_NOTIMPLEMENTED;
     return set_difference(so, other);
 }
@@ -1760,7 +1760,7 @@ PyDoc_STRVAR(symmetric_difference_doc,
 static PyObject *
 set_xor(PySetObject *so, PyObject *other)
 {
-    if (!PyAnySet_Check(so) || !PyAnySet_Check(other))
+    if (!PyAnySet_Check(so))
         Py_RETURN_NOTIMPLEMENTED;
     return set_symmetric_difference(so, other);
 }


### PR DESCRIPTION
These set operators immediately call their non-dunder implementation upon validating the operands anyway, and since those implementations have no type restrictions for the "other" argument, why not give sets the same functionality dict_keys/dict_items have?

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34497](https://www.bugs.python.org/issue34497) -->
https://bugs.python.org/issue34497
<!-- /issue-number -->
