### PR TITLE
[3.7] bpo-34492: Modules/main.c: Fix copy_wstrlist() (GH-8910)

### DIFF
--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1236,10 +1236,13 @@ copy_wstrlist(int len, wchar_t **list)
     assert((len > 0 && list != NULL) || len == 0);
     size_t size = len * sizeof(list[0]);
     wchar_t **list_copy = PyMem_RawMalloc(size);
+    if (list_copy == NULL) {
+        return NULL;
+    }
     for (int i=0; i < len; i++) {
         wchar_t* arg = _PyMem_RawWcsdup(list[i]);
         if (arg == NULL) {
-            clear_wstrlist(i, list);
+            clear_wstrlist(i, list_copy);
             return NULL;
         }
         list_copy[i] = arg;


### PR DESCRIPTION
* Add missing NULL check reported by Svace static analyzer.
* Fix clear_wstrlist() call on a wrong list.

(cherry picked from commit eb746dbae8b320758ee08f811316d7f283435cc0)

Co-authored-by: Alexey Izbyshev <izbyshev@ispras.ru>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34492](https://www.bugs.python.org/issue34492) -->
https://bugs.python.org/issue34492
<!-- /issue-number -->
