### PR TITLE
[2.7] bpo-34500: Fix ResourceWarning in difflib.py

### DIFF
--- a/Doc/library/difflib.rst
+++ b/Doc/library/difflib.rst
@@ -757,8 +757,10 @@ It is also contained in the Python source distribution, as
        # we're passing these as arguments to the diff function
        fromdate = time.ctime(os.stat(fromfile).st_mtime)
        todate = time.ctime(os.stat(tofile).st_mtime)
-       fromlines = open(fromfile, 'U').readlines()
-       tolines = open(tofile, 'U').readlines()
+       with open(fromfile, 'U') as f:
+           fromlines = f.readlines()
+       with open(tofile, 'U') as f:
+           tolines = f.readlines()
 
        if options.u:
            diff = difflib.unified_diff(fromlines, tolines, fromfile, tofile,

--- a/Misc/NEWS.d/next/Tools-Demos/2018-08-25-17-13-24.bpo-34500.Edz41x.rst
+++ b/Misc/NEWS.d/next/Tools-Demos/2018-08-25-17-13-24.bpo-34500.Edz41x.rst
@@ -1,0 +1,1 @@
+Fix 2 ResourceWarning in difflib.py. Patch by Mickaël Schoentgen.

--- a/Tools/scripts/diff.py
+++ b/Tools/scripts/diff.py
@@ -32,8 +32,10 @@ def main():
 
     fromdate = time.ctime(os.stat(fromfile).st_mtime)
     todate = time.ctime(os.stat(tofile).st_mtime)
-    fromlines = open(fromfile, 'U').readlines()
-    tolines = open(tofile, 'U').readlines()
+    with open(fromfile, 'U') as f:
+        fromlines = f.readlines()
+    with open(tofile, 'U') as f:
+        tolines = f.readlines()
 
     if options.u:
         diff = difflib.unified_diff(fromlines, tolines, fromfile, tofile, fromdate, todate, n=n)


### PR DESCRIPTION
cc @dbieber

<!-- issue-number: [bpo-34500](https://www.bugs.python.org/issue34500) -->
https://bugs.python.org/issue34500
<!-- /issue-number -->
