### PR TITLE
bpo-34502: Remove a note about utf8_mode from sys.exit() docs

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -333,9 +333,6 @@ always available.
       has caught :exc:`SystemExit` (such as an error flushing buffered data
       in the standard streams), the exit status is changed to 120.
 
-   .. versionchanged:: 3.7
-      Added ``utf8_mode`` attribute for the new :option:`-X` ``utf8`` flag.
-
 
 .. data:: flags
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34502](https://www.bugs.python.org/issue34502) -->
https://bugs.python.org/issue34502
<!-- /issue-number -->
