### PR TITLE
bpo-14465: Provide simple prett printing for XML and ETree API

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -588,6 +588,7 @@ Functions
 
 
 .. function:: tostring(element, encoding="us-ascii", method="xml", *, \
+                       pretty_print=False, \
                        short_empty_elements=True)
 
    Generates a string representation of an XML element, including all
@@ -596,13 +597,18 @@ Functions
    generate a Unicode string (otherwise, a bytestring is generated).  *method*
    is either ``"xml"``, ``"html"`` or ``"text"`` (default is ``"xml"``).
    *short_empty_elements* has the same meaning as in :meth:`ElementTree.write`.
+   *pretty_print* enables pretty printing with default indent.
    Returns an (optionally) encoded string containing the XML data.
 
    .. versionadded:: 3.4
       The *short_empty_elements* parameter.
 
+   .. versionadded:: 3.7
+      The *pretty_print* parameter.
+
 
 .. function:: tostringlist(element, encoding="us-ascii", method="xml", *, \
+                           pretty_print=False, \
                            short_empty_elements=True)
 
    Generates a string representation of an XML element, including all
@@ -611,6 +617,7 @@ Functions
    generate a Unicode string (otherwise, a bytestring is generated).  *method*
    is either ``"xml"``, ``"html"`` or ``"text"`` (default is ``"xml"``).
    *short_empty_elements* has the same meaning as in :meth:`ElementTree.write`.
+   *pretty_print* enables pretty printing with default indent.
    Returns a list of (optionally) encoded strings containing the XML data.
    It does not guarantee any specific sequence, except that
    ``b"".join(tostringlist(element)) == tostring(element)``.
@@ -619,6 +626,9 @@ Functions
 
    .. versionadded:: 3.4
       The *short_empty_elements* parameter.
+
+   .. versionadded:: 3.7
+      The *pretty_print* parameter.
 
 
 .. function:: XML(text, parser=None)
@@ -921,6 +931,7 @@ ElementTree Objects
 
    .. method:: write(file, encoding="us-ascii", xml_declaration=None, \
                      default_namespace=None, method="xml", *, \
+                     pretty_print=False, \
                      short_empty_elements=True)
 
       Writes the element tree to a file, as XML.  *file* is a file name, or a
@@ -935,7 +946,8 @@ ElementTree Objects
       The keyword-only *short_empty_elements* parameter controls the formatting
       of elements that contain no content.  If ``True`` (the default), they are
       emitted as a single self-closed tag, otherwise they are emitted as a pair
-      of start/end tags.
+      of start/end tags. *pretty_print* enables pretty printing
+      with default indent.
 
       The output is either a string (:class:`str`) or binary (:class:`bytes`).
       This is controlled by the *encoding* argument.  If *encoding* is
@@ -946,6 +958,10 @@ ElementTree Objects
 
       .. versionadded:: 3.4
          The *short_empty_elements* parameter.
+
+      .. versionadded:: 3.7
+         The *pretty_print* parameter.
+
 
 
 This is the XML file that is going to be manipulated::

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1031,6 +1031,80 @@ class ElementTreeTest(unittest.TestCase):
                                        method='html')
                 self.assertEqual(serialized, expected)
 
+    def test_pretty_print_xml(self):
+        comment = ET.Comment('comment')
+
+        root = ET.Element(None)
+
+        child1 = ET.SubElement(root, 'child1')
+        child1.append(comment)
+        elem = ET.SubElement(child1, 'elem')
+        elem.set('a', '1')
+        elem.set('b', 'txt')
+        elem.text = 'Oh, wow, some text!'
+
+        child2 = ET.SubElement(root, 'child2')
+        elem1 = ET.SubElement(child2, 'elem1')
+        elem21 = ET.SubElement(elem1, 'elem21')
+        elem22 = ET.SubElement(elem1, 'elem22')
+        elem3 = ET.SubElement(elem21, 'elem3')
+
+        elem22.append(comment)
+
+        observed = serialize(root, method='xml', pretty_print=True)
+        expected = '\n  <child1>\n' + \
+            '    <!--comment-->\n' + \
+            '      <elem a="1" b="txt">Oh, wow, some text!</elem>\n' + \
+            '  </child1>\n' + \
+            '  <child2>\n' + \
+            '    <elem1>\n' + \
+            '      <elem21>\n' + \
+            '        <elem3 />\n' + \
+            '      </elem21>\n' + \
+            '      <elem22>\n' + \
+            '        <!--comment-->\n' + \
+            '      </elem22>\n' + \
+            '    </elem1>\n' + \
+            '  </child2>\n'
+        self.assertEqual(observed, expected)
+
+    def test_pretty_print_html(self):
+        html = ET.Element('html')
+
+        head = ET.SubElement(html, 'head')
+        body = ET.SubElement(html, 'body')
+
+        style = ET.SubElement(head, 'style')
+        style.text = '''
+        body {background-color: white;}
+        h1   {color: blue;}
+        p    {color: red;}
+        '''
+
+        p = ET.SubElement(body, 'p')
+        p.text = 'etree is awesome'
+
+        ET.SubElement(body, 'br')
+
+        script = ET.SubElement(body, 'script')
+        script.text = '   document.getElementById("some").innerHTML = "Hello JavaScript!";'
+
+        observed = serialize(html, method='html', pretty_print=True)
+        expected = '<html>\n' + \
+            '  <head>\n' + \
+            '    <style>\n' + \
+            '        body {background-color: white;}\n' + \
+            '        h1   {color: blue;}\n' + \
+            '        p    {color: red;}\n' + \
+            '        </style>\n' + \
+            '  </head>\n' + \
+            '  <body>\n' + \
+            '    <p>etree is awesome</p>\n' + \
+            '    <br>\n' + \
+            '    <script>   document.getElementById("some").innerHTML = "Hello JavaScript!";</script>\n' + \
+            '  </body>\n' + \
+            '</html>'
+        self.assertEqual(observed, expected)
 
 class XMLPullParserTest(unittest.TestCase):
 

--- a/Misc/NEWS.d/next/Library/2018-08-25-17-43-41.bpo-14465.icfJiX.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-25-17-43-41.bpo-14465.icfJiX.rst
@@ -1,0 +1,3 @@
+``ElementTree`` output methods now have ``pretty_print`` (defaulting to
+``False``) parameter which leads to output being indented for the human
+consumption.


### PR DESCRIPTION
Comparing to the solution suggested in #4016, this should bear no performance penalty when pretty_print=False (which is the default). On the other hand, it is not suitable for processing of large XML data. Then some alternative solution (e.g., lxml module) must be used.

<!-- issue-number: [bpo-14465](https://www.bugs.python.org/issue14465) -->
https://bugs.python.org/issue14465
<!-- /issue-number -->
