### PR TITLE
bpo-34503: Fix refleak in PyErr_SetObject()

### DIFF
--- a/Python/errors.c
+++ b/Python/errors.c
@@ -110,6 +110,7 @@ PyErr_SetObject(PyObject *exception, PyObject *value)
             fixed_value = _PyErr_CreateException(exception, value);
             Py_XDECREF(value);
             if (fixed_value == NULL) {
+                Py_DECREF(exc_value);
                 return;
             }
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34503](https://www.bugs.python.org/issue34503) -->
https://bugs.python.org/issue34503
<!-- /issue-number -->
