### PR TITLE
bpo-34508: allow unparenthesized star-unpacking expressions in return statements

### DIFF
--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -471,12 +471,12 @@ The :keyword:`return` statement
    pair: class; definition
 
 .. productionlist::
-   return_stmt: "return" [`expression_list`]
+   return_stmt: "return" [`starred_expression`]
 
 :keyword:`return` may only occur syntactically nested in a function definition,
 not within a nested class definition.
 
-If an expression list is present, it is evaluated, else ``None`` is substituted.
+If an expression is present, it is evaluated, else ``None`` is substituted.
 
 :keyword:`return` leaves the current function call with the expression list (or
 ``None``) as return value.

--- a/Grammar/Grammar
+++ b/Grammar/Grammar
@@ -50,7 +50,7 @@ pass_stmt: 'pass'
 flow_stmt: break_stmt | continue_stmt | return_stmt | raise_stmt | yield_stmt
 break_stmt: 'break'
 continue_stmt: 'continue'
-return_stmt: 'return' [testlist]
+return_stmt: 'return' [testlist_star_expr]
 yield_stmt: yield_expr
 raise_stmt: 'raise' [test ['from' test]]
 import_stmt: import_name | import_from

--- a/Lib/lib2to3/Grammar.txt
+++ b/Lib/lib2to3/Grammar.txt
@@ -49,7 +49,7 @@ pass_stmt: 'pass'
 flow_stmt: break_stmt | continue_stmt | return_stmt | raise_stmt | yield_stmt
 break_stmt: 'break'
 continue_stmt: 'continue'
-return_stmt: 'return' [testlist]
+return_stmt: 'return' [testlist_star_expr]
 yield_stmt: yield_expr
 raise_stmt: 'raise' [test ['from' test | ',' test [',' test]]]
 import_stmt: import_name | import_from

--- a/Lib/lib2to3/tests/data/py3_test_grammar.py
+++ b/Lib/lib2to3/tests/data/py3_test_grammar.py
@@ -473,12 +473,15 @@ class GrammarTests(unittest.TestCase):
         test_inner()
 
     def testReturn(self):
-        # 'return' [testlist]
+        # 'return' [testlist_star_expr]
         def g1(): return
         def g2(): return 1
+        def g3(): return *(1, 2), 3
         g1()
         x = g2()
+        g3()
         check_syntax_error(self, "class foo:return 1")
+        check_syntax_error(self, "def f(): return *(1, 2, 3)")
 
     def testYield(self):
         check_syntax_error(self, "class foo:yield 1")

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -824,12 +824,15 @@ class GrammarTests(unittest.TestCase):
         test_inner()
 
     def test_return(self):
-        # 'return' [testlist]
+        # 'return' [testlist_star_expr]
         def g1(): return
         def g2(): return 1
+        def g3(): return *(1, 2), 3
         g1()
         x = g2()
+        g3()
         check_syntax_error(self, "class foo:return 1")
+        check_syntax_error(self, "def f(): return *(1, 2, 3)")
 
     def test_break_in_finally(self):
         count = 0

--- a/Lib/test/test_parser.py
+++ b/Lib/test/test_parser.py
@@ -41,6 +41,9 @@ class RoundtripLegalSyntaxTestCase(unittest.TestCase):
     def check_suite(self, s):
         self.roundtrip(parser.suite, s)
 
+    def test_return_statement(self):
+        self.check_suite("def f(): return *(1, 2), 3")
+
     def test_yield_statement(self):
         self.check_suite("def f(): yield 1")
         self.check_suite("def f(): yield")

--- a/Misc/NEWS.d/next/Core and Builtins/2018-08-26-16-31-34.bpo-34508.o_gpUi.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-08-26-16-31-34.bpo-34508.o_gpUi.rst
@@ -1,0 +1,1 @@
+Allow unparenthesized star-unpacking expressions in return statements.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -3096,7 +3096,7 @@ ast_for_flow_stmt(struct compiling *c, const node *n)
                  | yield_stmt
       break_stmt: 'break'
       continue_stmt: 'continue'
-      return_stmt: 'return' [testlist]
+      return_stmt: 'return' [testlist_star_expr]
       yield_stmt: yield_expr
       yield_expr: 'yield' testlist | 'yield' 'from' test
       raise_stmt: 'raise' [test [',' test [',' test]]]

--- a/Python/graminit.c
+++ b/Python/graminit.c
@@ -613,7 +613,7 @@ static arc arcs_25_0[1] = {
     {75, 1},
 };
 static arc arcs_25_1[2] = {
-    {9, 2},
+    {47, 2},
     {0, 1},
 };
 static arc arcs_25_2[1] = {


### PR DESCRIPTION
This PR makes the following (currently illegal) syntax legal:
```python
def f():
    return *(1, 2), *(3, 4)
```
This eliminates an inconsistency between the target of a `return` and the target of a simple assignment: the following syntax is already legal:
```python
def f():
    x = *(1, 2), *(3, 4)
    return x
```


<!-- issue-number: [bpo-34508](https://www.bugs.python.org/issue34508) -->
https://bugs.python.org/issue34508
<!-- /issue-number -->
