### PR TITLE
Math hypot exactfloat fastpath

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2134,14 +2134,22 @@ math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
     }
     for (i=0 ; i<n ; i++) {
         item = PyTuple_GET_ITEM(p, i);
-        px = PyFloat_AsDouble(item);
-        if (px == -1.0 && PyErr_Occurred()) {
-            goto error_exit;
+        if (PyFloat_CheckExact(item)) {
+            px = PyFloat_AS_DOUBLE(item);
+        } else {
+            px = PyFloat_AsDouble(item);
+            if (px == -1.0 && PyErr_Occurred()) {
+                goto error_exit;
+            }
         }
         item = PyTuple_GET_ITEM(q, i);
-        qx = PyFloat_AsDouble(item);
-        if (qx == -1.0 && PyErr_Occurred()) {
-            goto error_exit;
+        if (PyFloat_CheckExact(item)) {
+            qx = PyFloat_AS_DOUBLE(item);
+        } else {
+            qx = PyFloat_AsDouble(item);
+            if (qx == -1.0 && PyErr_Occurred()) {
+                goto error_exit;
+            }
         }
         x = fabs(px - qx);
         diffs[i] = x;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2183,9 +2183,13 @@ math_hypot(PyObject *self, PyObject *args)
     }
     for (i=0 ; i<n ; i++) {
         item = PyTuple_GET_ITEM(args, i);
-        x = PyFloat_AsDouble(item);
-        if (x == -1.0 && PyErr_Occurred()) {
-            goto error_exit;
+        if (PyFloat_CheckExact(item)) {
+            x = PyFloat_AS_DOUBLE(item);
+        } else {
+            x = PyFloat_AsDouble(item);
+            if (x == -1.0 && PyErr_Occurred()) {
+                goto error_exit;
+            }
         }
         x = fabs(x);
         coordinates[i] = x;


### PR DESCRIPTION
Provide a fast path for the common case of exact float inputs.  Saves the overhead of an external function call and of the `x == 1.0` error check. Allows the inner loops to mostly use registers.

Speeds-up the overall function by approximately 25%:

    $ ------ baseline -------
    $ py -m timeit -r7 -s 'from math import dist; p=tuple(map(float, range(20))); q=tuple(reversed(p))' 'dist(p, q)'
    1000000 loops, best of 7: 297 nsec per loop

    $ ------ patched -------
    $ py -m timeit -r7 -s 'from math import dist; p=tuple(map(float, range(20))); q=tuple(reversed(p))' 'dist(p, q)'
    1000000 loops, best of 7: 215 nsec per loop

Disassembly of *math_hypot()* using GCC 8.2 shows a very tight inner loop without unnecessary register spills and reloads and without external calls that have to save and restore registers:

    L378:
	xorl	%eax, %eax
	andpd	lC5(%rip), %xmm0         # x = fabs(x);
	ucomisd	%xmm0, %xmm0
	movl	$1, %ecx
	setne	%al
	cmovp	%ecx, %eax
	orl	%eax, %ebx               # found_nan |= Py_IS_NAN(x);
    L377:
	movsd	%xmm0, (%r12,%r15,8)     # coordinates[i] = x;
	maxsd	%xmm1, %xmm0             # if (x > max) { max = x; }
	addq	$1, %r15                 # i++
	cmpq	%r15, %rbp               # i < n
	movapd	%xmm0, %xmm1
	jle	L418
    L385:
	movq	24(%r13,%r15,8), %rdi    # item = PyTuple_GET_ITEM(args, i);
	cmpq	%r14, 8(%rdi)            # if (PyFloat_CheckExact(item))
	jne	L375
	movsd	16(%rdi), %xmm0          # x = PyFloat_AS_DOUBLE(item)
	jmp	L378