### PR TITLE
bpo-34519: Add additional aliases for HP Roman 8

### DIFF
--- a/Lib/encodings/aliases.py
+++ b/Lib/encodings/aliases.py
@@ -263,9 +263,12 @@ aliases = {
     'hex'                : 'hex_codec',
 
     # hp_roman8 codec
+    'hp-roman8'          : 'hp_roman8',
     'roman8'             : 'hp_roman8',
     'r8'                 : 'hp_roman8',
     'csHPRoman8'         : 'hp_roman8',
+    'cp1051'             : 'hp_roman8',
+    'ibm1051'            : 'hp_roman8',
 
     # hz codec
     'hzgb'               : 'hz',

--- a/Lib/encodings/aliases.py
+++ b/Lib/encodings/aliases.py
@@ -263,7 +263,6 @@ aliases = {
     'hex'                : 'hex_codec',
 
     # hp_roman8 codec
-    'hp-roman8'          : 'hp_roman8',
     'roman8'             : 'hp_roman8',
     'r8'                 : 'hp_roman8',
     'csHPRoman8'         : 'hp_roman8',

--- a/Misc/NEWS.d/next/Library/2018-08-27-15-44-50.bpo-34519.cPlH1h.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-27-15-44-50.bpo-34519.cPlH1h.rst
@@ -1,0 +1,1 @@
+Add additional aliases for HP Roman 8. Patch by Michael Osipov.


### PR DESCRIPTION
HP Roman 8 is known under mode aliases than listed in aliases.py.

Patch by Michael Osipov.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34519](https://www.bugs.python.org/issue34519) -->
https://bugs.python.org/issue34519
<!-- /issue-number -->
