### PR TITLE
bpo-34524: Update comments for examples of format conversion

### DIFF
--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -259,9 +259,9 @@ on the value, ``'!r'`` which calls :func:`repr` and ``'!a'`` which calls
 
 Some examples::
 
-   "Harold's a clever {0!s}"        # Calls str() on the argument first
-   "Bring out the holy {name!r}"    # Calls repr() on the argument first
-   "More {!a}"                      # Calls ascii() on the argument first
+   "Harold's a clever {0!s}"        # Calls str() on the first argument
+   "Bring out the holy {name!r}"    # Calls repr() on a named argument 
+   "More {!a}"                      # Calls ascii() on an implicit argument 
 
 The *format_spec* field contains a specification of how the value should be
 presented, including such details as field width, alignment, padding, decimal


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
Updated the documentation section for format conversions. The example of conversion had comments that did not match the example. Small changes to wording for clarity.

https://bugs.python.org/issue34524

<!-- issue-number: [bpo-34524](https://www.bugs.python.org/issue34524) -->
https://bugs.python.org/issue34524
<!-- /issue-number -->
