### PR TITLE
bpo-34403: Skip test_utf8_mode.test_cmd_line() on HP-UX

### DIFF
--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -12,7 +12,7 @@ from test.support.script_helper import assert_python_ok, assert_python_failure
 
 
 MS_WINDOWS = (sys.platform == 'win32')
-
+HPUX = (sys.platform.startswith('hp-ux'))
 
 class UTF8ModeTests(unittest.TestCase):
     DEFAULT_ENV = {
@@ -205,6 +205,7 @@ class UTF8ModeTests(unittest.TestCase):
         self.assertEqual(out, 'UTF-8 UTF-8')
 
     @unittest.skipIf(MS_WINDOWS, 'test specific to Unix')
+    @unittest.skipIf(HPUX, 'test specific to Unix with single-byte default locale')
     def test_cmd_line(self):
         arg = 'h\xe9\u20ac'.encode('utf-8')
         arg_utf8 = arg.decode('utf-8')

--- a/Misc/NEWS.d/next/Tests/2018-08-28-09-29-00.bpo-34403.Eyek0k.rst
+++ b/Misc/NEWS.d/next/Tests/2018-08-28-09-29-00.bpo-34403.Eyek0k.rst
@@ -1,0 +1,1 @@
+Skip test_utf8_mode.test_cmd_line() on HP-UX. Patch by Michael Osipov.


### PR DESCRIPTION
Skip this test because it requires a single-byte default locale encoding like
ASCII or ISO-8859-1 to properly work with surrogate escapes. Just like CP1252
Roman 8 includes Unicode characters which are encoded in multiple bytes.
The final comparison in this test does not handle that. Disable it because
assumptions aren't met.

Patch by Michael Osipov.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34403](https://www.bugs.python.org/issue34403) -->
https://bugs.python.org/issue34403
<!-- /issue-number -->
