### PR TITLE
[3.7] bpo-34485: Fix _Py_InitializeCore() for C locale coercion (GH-8979)

### DIFF
--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1854,16 +1854,18 @@ config_read_env_vars(_PyCoreConfig *config)
         config->malloc_stats = 1;
     }
 
-    if (config->coerce_c_locale < 0) {
-        const char *env = config_get_env_var("PYTHONCOERCECLOCALE");
-        if (env) {
-            if (strcmp(env, "0") == 0) {
+    const char *env = config_get_env_var("PYTHONCOERCECLOCALE");
+    if (env) {
+        if (strcmp(env, "0") == 0) {
+            if (config->coerce_c_locale < 0) {
                 config->coerce_c_locale = 0;
             }
-            else if (strcmp(env, "warn") == 0) {
-                config->coerce_c_locale_warn = 1;
-            }
-            else {
+        }
+        else if (strcmp(env, "warn") == 0) {
+            config->coerce_c_locale_warn = 1;
+        }
+        else {
+            if (config->coerce_c_locale < 0) {
                 config->coerce_c_locale = 1;
             }
         }
@@ -2044,7 +2046,7 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
          * See the documentation of the PYTHONCOERCECLOCALE setting for more
          * details.
          */
-        if (config->coerce_c_locale == 1 && !locale_coerced) {
+        if (config->coerce_c_locale && !locale_coerced) {
             locale_coerced = 1;
             _Py_CoerceLegacyLocale(config);
             encoding_changed = 1;
@@ -2071,6 +2073,7 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
            pymain_read_conf_impl(). Reset Py_IsolatedFlag and Py_NoSiteFlag
            modified by _PyCoreConfig_Read(). */
         int new_utf8_mode = config->utf8_mode;
+        int new_coerce_c_locale = config->coerce_c_locale;
         Py_IgnoreEnvironmentFlag = init_ignore_env;
         if (_PyCoreConfig_Copy(config, &save_config) < 0) {
             pymain->err = _Py_INIT_NO_MEMORY();
@@ -2082,6 +2085,7 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
         cmdline_get_global_config(cmdline);
         _PyCoreConfig_GetGlobalConfig(config);
         config->utf8_mode = new_utf8_mode;
+        config->coerce_c_locale = new_coerce_c_locale;
 
         /* The encoding changed: read again the configuration
            with the new encoding */

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -672,10 +672,6 @@ _Py_InitializeCore_impl(PyInterpreterState **interp_p,
     _PyRuntime.finalizing = NULL;
 
 #ifndef MS_WINDOWS
-    /* Set up the LC_CTYPE locale, so we can obtain
-       the locale's charset without having to switch
-       locales. */
-    _Py_SetLocaleFromEnv(LC_CTYPE);
     _emit_stderr_warning_for_legacy_locale(core_config);
 #endif
 
@@ -828,6 +824,12 @@ _Py_InitializeCore(PyInterpreterState **interp_p,
     /* Copy the configuration, since _PyCoreConfig_Read() modifies it
        (and the input configuration is read only). */
     _PyCoreConfig config = _PyCoreConfig_INIT;
+
+#ifndef MS_WINDOWS
+    /* Set up the LC_CTYPE locale, so we can obtain the locale's charset
+       without having to switch locales. */
+    _Py_SetLocaleFromEnv(LC_CTYPE);
+#endif
 
     _PyMem_SetDefaultAllocator(PYMEM_DOMAIN_RAW, &old_alloc);
     if (_PyCoreConfig_Copy(&config, src_config) >= 0) {


### PR DESCRIPTION
* _Py_InitializeCore() now sets the LC_CTYPE locale to the user
  preferred locale before checking if the C locale should be coerced
  or not in _PyCoreConfig_Read().
* Fix pymain_read_conf(): remember if the C locale has been coerced
  when the configuration should be read again if the encoding has
  changed.

(cherry picked from commit 2c8ddcf4f14f3e4c87a6fe6678ab5ad09130c6ab)

<!-- issue-number: [bpo-34485](https://www.bugs.python.org/issue34485) -->
https://bugs.python.org/issue34485
<!-- /issue-number -->
