### PR TITLE
bpo-34481: Fix surrogate-handling in strftime

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -302,6 +302,8 @@ class TestTimeZone(unittest.TestCase):
         self.assertEqual('UTC+09:30', timezone(9.5 * HOUR).tzname(None))
         self.assertEqual('UTC-00:01', timezone(timedelta(minutes=-1)).tzname(None))
         self.assertEqual('XYZ', timezone(-5 * HOUR, 'XYZ').tzname(None))
+        # bpo-34482: Check that surrogates are handled properly.
+        self.assertEqual('\ud800', timezone(ZERO, '\ud800').tzname(None))
 
         # Sub-minute offsets:
         self.assertEqual('UTC+01:06:40', timezone(timedelta(0, 4000)).tzname(None))
@@ -1307,6 +1309,14 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
             except ValueError:
                 pass
 
+        # bpo-34482: Check that surrogates don't cause a crash.
+        # FIXME: The C datetime implementation raises an exception
+        # while the pure-Python one succeeds.
+        try:
+            t.strftime('\ud800')
+        except UnicodeEncodeError:
+            pass
+
         #check that this standard extension works
         t.strftime("%f")
 
@@ -1746,6 +1756,9 @@ class TestDateTime(TestDate):
         self.assertEqual(t.isoformat('T'), "0001-02-03T04:05:01.000123")
         self.assertEqual(t.isoformat(' '), "0001-02-03 04:05:01.000123")
         self.assertEqual(t.isoformat('\x00'), "0001-02-03\x0004:05:01.000123")
+        # bpo-34482: Check that surrogates are handled properly.
+        self.assertEqual(t.isoformat('\ud800'),
+                         "0001-02-03\ud80004:05:01.000123")
         self.assertEqual(t.isoformat(timespec='hours'), "0001-02-03T04")
         self.assertEqual(t.isoformat(timespec='minutes'), "0001-02-03T04:05")
         self.assertEqual(t.isoformat(timespec='seconds'), "0001-02-03T04:05:01")
@@ -1754,6 +1767,8 @@ class TestDateTime(TestDate):
         self.assertEqual(t.isoformat(timespec='auto'), "0001-02-03T04:05:01.000123")
         self.assertEqual(t.isoformat(sep=' ', timespec='minutes'), "0001-02-03 04:05")
         self.assertRaises(ValueError, t.isoformat, timespec='foo')
+        # bpo-34482: Check that surrogates are handled properly.
+        self.assertRaises(ValueError, t.isoformat, timespec='\ud800')
         # str is ISO format with the separator forced to a blank.
         self.assertEqual(str(t), "0001-02-03 04:05:01.000123")
 
@@ -2277,13 +2292,21 @@ class TestDateTime(TestDate):
         self.assertLessEqual(abs(from_timestamp - from_now), tolerance)
 
     def test_strptime(self):
-        string = '2004-12-01 13:02:47.197'
-        format = '%Y-%m-%d %H:%M:%S.%f'
-        expected = _strptime._strptime_datetime(self.theclass, string, format)
-        got = self.theclass.strptime(string, format)
-        self.assertEqual(expected, got)
-        self.assertIs(type(expected), self.theclass)
-        self.assertIs(type(got), self.theclass)
+        inputs = [
+            ('2004-12-01 13:02:47.197', '%Y-%m-%d %H:%M:%S.%f'),
+            # bpo-34482: Check that surrogates are handled properly.
+            ('2004-12-01\ud80013:02:47.197', '%Y-%m-%d\ud800%H:%M:%S.%f'),
+            ('2004\ud80012-01 13:02:47.197', '%Y\ud800%m-%d %H:%M:%S.%f'),
+            ('2004-12-01 13:02\ud80047.197', '%Y-%m-%d %H:%M\ud800%S.%f'),
+        ]
+        for string, format in inputs:
+            with self.subTest(string=string, format=format):
+                expected = _strptime._strptime_datetime(self.theclass, string,
+                                                        format)
+                got = self.theclass.strptime(string, format)
+                self.assertEqual(expected, got)
+                self.assertIs(type(expected), self.theclass)
+                self.assertIs(type(got), self.theclass)
 
         strptime = self.theclass.strptime
         self.assertEqual(strptime("+0002", "%z").utcoffset(), 2 * MINUTE)
@@ -2869,6 +2892,8 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         self.assertEqual(t.isoformat(timespec='microseconds'), "12:34:56.123456")
         self.assertEqual(t.isoformat(timespec='auto'), "12:34:56.123456")
         self.assertRaises(ValueError, t.isoformat, timespec='monkey')
+        # bpo-34482: Check that surrogates are handled properly.
+        self.assertRaises(ValueError, t.isoformat, timespec='\ud800')
 
         t = self.theclass(hour=12, minute=34, second=56, microsecond=999500)
         self.assertEqual(t.isoformat(timespec='milliseconds'), "12:34:56.999")
@@ -2918,6 +2943,14 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         self.assertEqual(t.strftime('%H %M %S %f'), "01 02 03 000004")
         # A naive object replaces %z and %Z with empty strings.
         self.assertEqual(t.strftime("'%z' '%Z'"), "'' ''")
+
+        # bpo-34482: Check that surrogates don't cause a crash.
+        # FIXME: The C datetime implementation raises an exception
+        # while the pure-Python one succeeds.
+        try:
+            t.strftime('\ud800')
+        except UnicodeEncodeError:
+            pass
 
     def test_format(self):
         t = self.theclass(1, 2, 3, 4)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1310,12 +1310,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
                 pass
 
         # bpo-34482: Check that surrogates don't cause a crash.
-        # FIXME: The C datetime implementation raises an exception
-        # while the pure-Python one succeeds.
-        try:
-            t.strftime('\ud800')
-        except UnicodeEncodeError:
-            pass
+        self.assertEqual(t.strftime('\ud800'), '\ud800')
 
         #check that this standard extension works
         t.strftime("%f")
@@ -2945,12 +2940,7 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         self.assertEqual(t.strftime("'%z' '%Z'"), "'' ''")
 
         # bpo-34482: Check that surrogates don't cause a crash.
-        # FIXME: The C datetime implementation raises an exception
-        # while the pure-Python one succeeds.
-        try:
-            t.strftime('\ud800')
-        except UnicodeEncodeError:
-            pass
+        self.assertEqual(t.strftime('\ud800'), '\ud800')
 
     def test_format(self):
         t = self.theclass(1, 2, 3, 4)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1310,7 +1310,10 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
                 pass
 
         # bpo-34482: Check that surrogates don't cause a crash.
-        self.assertEqual(t.strftime('\ud800'), '\ud800')
+        no_op_strs = ['\ud8888', '\ud800', '\\ud800\ud800']
+        for tstr in no_op_strs:
+            with self.subTest(f'strftime: {tstr!r}'):
+                self.assertEqual(t.strftime(tstr), tstr)
 
         #check that this standard extension works
         t.strftime("%f")

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -2942,6 +2942,10 @@ class TestTime(HarmlessMixedComparison, unittest.TestCase):
         # bpo-34482: Check that surrogates don't cause a crash.
         self.assertEqual(t.strftime('\ud800'), '\ud800')
 
+        # bpo-34482: Check that surrogates in tzinfo don't crash
+        tzinfo = timezone(timedelta(hours=1), '\ud800')
+        t.replace(tzinfo=tzinfo).strftime("%Z")
+
     def test_format(self):
         t = self.theclass(1, 2, 3, 4)
         self.assertEqual(t.__format__(''), str(t))
@@ -3346,11 +3350,6 @@ class TestTimeTZ(TestTime, TZInfoBase, unittest.TestCase):
         t = time(2, 3, 4, tzinfo=Badtzname())
         self.assertEqual(t.strftime("%H:%M:%S"), "02:03:04")
         self.assertRaises(TypeError, t.strftime, "%Z")
-
-        # Issue #6697:
-        if '_Fast' in self.__class__.__name__:
-            Badtzname.tz = '\ud800'
-            self.assertRaises(ValueError, t.strftime, "%Z")
 
     def test_hash_edge_cases(self):
         # Offsets that overflow a basic time.

--- a/Misc/NEWS.d/next/Tests/2018-08-23-20-42-14.bpo-34482.BzQYUs.rst
+++ b/Misc/NEWS.d/next/Tests/2018-08-23-20-42-14.bpo-34482.BzQYUs.rst
@@ -1,0 +1,2 @@
+Add tests for proper handling of non-UTF-8-encodable strings in
+:mod:`datetime` classes. Patch by Alexey Izbyshev.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -4939,7 +4939,12 @@ datetime_fromisoformat(PyObject* cls, PyObject *dtstr) {
     const char * dt_ptr = PyUnicode_AsUTF8AndSize(dtstr, &len);
 
     if (dt_ptr == NULL) {
-        goto invalid_string_error;
+        if (PyErr_ExceptionMatches(PyExc_UnicodeEncodeError)) {
+            // Encoding errors are invalid string errors at this point
+            goto invalid_string_error;
+        } else {
+            goto error;
+        }
     }
 
     const char *p = dt_ptr;

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -735,7 +735,7 @@ time_strftime(PyObject *self, PyObject *args)
     fmt = format;
 #else
     /* Convert the unicode string to an ascii one */
-    format = PyUnicode_EncodeLocale(format_arg, "surrogateescape");
+    format = PyUnicode_AsEncodedString(format_arg, "utf-8", "surrogateescape");
     if (format == NULL)
         return NULL;
     fmt = PyBytes_AS_STRING(format);
@@ -809,7 +809,7 @@ time_strftime(PyObject *self, PyObject *args)
 #ifdef HAVE_WCSFTIME
             ret = PyUnicode_FromWideChar(outbuf, buflen);
 #else
-            ret = PyUnicode_DecodeLocaleAndSize(outbuf, buflen, "surrogateescape");
+            ret = PyUnicode_Decode(outbuf, buflen, "utf-8", "surrogateescape");
 #endif
             PyMem_Free(outbuf);
             break;

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -639,10 +639,7 @@ checktm(struct tm* buf)
     return 1;
 }
 
-#ifdef MS_WINDOWS
-   /* wcsftime() doesn't format correctly time zones, see issue #10653 */
-#  undef HAVE_WCSFTIME
-#endif
+#undef HAVE_WCSFTIME
 #define STRFTIME_FORMAT_CODES \
 "Commonly used format codes:\n\
 \n\

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -735,7 +735,7 @@ time_strftime(PyObject *self, PyObject *args)
     fmt = format;
 #else
     /* Convert the unicode string to an ascii one */
-    format = PyUnicode_AsEncodedString(format_arg, "utf-8", "surrogateescape");
+    format = PyUnicode_EncodeLocale(format_arg, "surrogateescape");
     if (format == NULL)
         return NULL;
     fmt = PyBytes_AS_STRING(format);
@@ -809,7 +809,7 @@ time_strftime(PyObject *self, PyObject *args)
 #ifdef HAVE_WCSFTIME
             ret = PyUnicode_FromWideChar(outbuf, buflen);
 #else
-            ret = PyUnicode_Decode(outbuf, buflen, "utf-8", "surrogateescape");
+            ret = PyUnicode_DecodeLocaleAndSize(outbuf, buflen, "surrogateescape");
 #endif
             PyMem_Free(outbuf);
             break;

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -639,7 +639,10 @@ checktm(struct tm* buf)
     return 1;
 }
 
-#undef HAVE_WCSFTIME
+#ifdef MS_WINDOWS
+   /* wcsftime() doesn't format correctly time zones, see issue #10653 */
+#  undef HAVE_WCSFTIME
+#endif
 #define STRFTIME_FORMAT_CODES \
 "Commonly used format codes:\n\
 \n\


### PR DESCRIPTION
This is intended to be re-based against #8878 - that PR adds tests, this one adds the fix.

I am making this PR before that one is merged mainly because this is some crazy platform-specific behavior, and I want to test it on the full cross-platform test suite.

https://bugs.python.org/issue34481



<!-- issue-number: [bpo-34481](https://www.bugs.python.org/issue34481) -->
https://bugs.python.org/issue34481
<!-- /issue-number -->
