### PR TITLE
Improve commutativity

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2037,19 +2037,20 @@ where *max* is the largest value in the vector, compute:
 
     max * sqrt(sum((x / max) ** 2 for x in vec))
 
-When a maximum value is found, it is swapped to the end value. This
-lets us skip one loop iteration and start the accumulation from 1.0.
-
-Kahan summation is used to improve accuracy.  The *csum*
-variable tracks the cumulative sum and *frac* tracks
-fractional round-off error for the most recent addition.
-
 The value of the *max* variable must be present in *vec*
 or should equal to 0.0 when n==0.  Likewise, *max* will
 be INF if an infinity is present in the vec.
 
 The *found_nan* variable indicates whether some member of
 the *vec* is a NaN.
+
+A variant of Kahan summation is used to improve accuracy. The *csum*
+variable tracks the cumulative sum and *frac* tracks the cumulative
+fractional round-off errors at each step.  The variant assumes that
+|csum| >= |x| at each step.  We establish this precondition by
+starting the accumulation from 1.0 and skipping over one *max* entry.
+This also saves us one loop iteration.
+
 */
 
 static inline double

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2077,13 +2077,13 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
             last = max;
         }
         x /= max;
-        x = x*x - frac;
+        x = x*x;
         oldcsum = csum;
         csum += x;
-        frac = (csum - oldcsum) - x;
+        frac += (oldcsum - csum) + x;
     }
     assert(last == max);
-    return max * sqrt(csum);
+    return max * sqrt(csum + frac);
 }
 
 #define NUM_STACK_ELEMS 16

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2044,14 +2044,18 @@ be INF if an infinity is present in the vec.
 The *found_nan* variable indicates whether some member of
 the *vec* is a NaN.
 
-A variant of Kahan summation is used to improve accuracy and to
-increase the number of cases where vector_norm() is commutative.
+To improve accuracy and to increase the number of cases where
+vector_norm() is commutative, we use a variant of Neumaier
+summation specialized to exploit that we always know that
+|csum| >= |x|.
+
 The *csum* variable tracks the cumulative sum and *frac* tracks
-the cumulative fractional errors at each step.  This variant
-assumes that |csum| >= |x| at each step.  We establish the
-precondition by starting the accumulation from 1.0 which
-represents an entry equal to *max*.  This also saves us one loop
-iteration because the *max* entry is swapped with the last entry.
+the cumulative fractional errors at each step.  Since this
+variant assumes that |csum| >= |x| at each step, we establish
+the precondition by starting the accumulation from 1.0 which
+represents an entry equal to *max*.  This also provides a nice
+side benefit in that it lets us skip over a *max* entry (which
+is swapped into *last*) saving us one iteration through the loop.
 
 */
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2079,6 +2079,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         }
         x /= max;
         x = x*x;
+        assert(csum >= x);
         oldcsum = csum;
         csum += x;
         frac += (oldcsum - csum) + x;

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2037,9 +2037,8 @@ where *max* is the largest value in the vector, compute:
 
     max * sqrt(sum((x / max) ** 2 for x in vec))
 
-When a maximum value is found, it is swapped to the end.  This
-lets us skip one loop iteration and just add 1.0 at the end.
-Saving the largest value for last also helps improve accuracy.
+When a maximum value is found, it is swapped to the end value. This
+lets us skip one loop iteration and start the accumulation from 1.0.
 
 Kahan summation is used to improve accuracy.  The *csum*
 variable tracks the cumulative sum and *frac* tracks
@@ -2056,7 +2055,7 @@ the *vec* is a NaN.
 static inline double
 vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
 {
-    double x, csum = 0.0, oldcsum, frac = 0.0, last;
+    double x, csum = 1.0, oldcsum, frac = 0.0, last;
     Py_ssize_t i;
 
     if (Py_IS_INFINITY(max)) {
@@ -2084,7 +2083,6 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         frac = (csum - oldcsum) - x;
     }
     assert(last == max);
-    csum += 1.0 - frac;
     return max * sqrt(csum);
 }
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2044,12 +2044,14 @@ be INF if an infinity is present in the vec.
 The *found_nan* variable indicates whether some member of
 the *vec* is a NaN.
 
-A variant of Kahan summation is used to improve accuracy. The *csum*
-variable tracks the cumulative sum and *frac* tracks the cumulative
-fractional round-off errors at each step.  The variant assumes that
-|csum| >= |x| at each step.  We establish this precondition by
-starting the accumulation from 1.0 and skipping over one *max* entry.
-This also saves us one loop iteration.
+A variant of Kahan summation is used to improve accuracy and to
+increase the number of cases where vector_norm() is commutative.
+The *csum* variable tracks the cumulative sum and *frac* tracks
+the cumulative fractional errors at each step.  This variant
+assumes that |csum| >= |x| at each step.  We establish the
+precondition by starting the accumulation from 1.0 which
+represents an entry equal to *max*.  This also saves us one loop
+iteration because the *max* entry is swapped with the last entry.
 
 */
 


### PR DESCRIPTION
Summary
-------

Apply a variant of Kahan summation that keeps a running total for the cumulative sum and another for the cumulative fractional errors.  Start the accumulation with 1.0 to establish the invariant that ``|csum| > |x|``.  This makes sure that no information is thrown-away in the computation of the adjustment to *frac*.

The improved summation routine makes hypot() and dist() fully commutative in most cases.

Measurements
------------

$ # baseline
$ py test_hypot_commutativity.py
Counter({1: 999905, 2: 95})
$ py test_hypot_commutativity.py
Counter({1: 999916, 2: 84})
$ py test_hypot_commutativity.py
Counter({1: 999876, 2: 124})
$ py test_hypot_commutativity.py
Counter({1: 999885, 2: 115})

$ # patched
$ py test_hypot_commutativity.py
Counter({1: 1000000})
$ py test_hypot_commutativity.py
Counter({1: 1000000})
$ py test_hypot_commutativity.py
Counter({1: 1000000})
$ py test_hypot_commutativity.py
Counter({1: 1000000})


Test script
----------

<pre>
# test_hypot_commutativity.py
from math import hypot
from random import expovariate
from itertools import permutations, starmap
from collections import Counter

trials = 1_000_000
n = 5

lambdas = [1.0E-3 ** exp for exp in range(n)]
print(Counter(len(set(starmap(hypot, permutations(map(expovariate, lambdas))))) for i in range(trials)))
</pre>

Timings
-------

The patch also gives a negligible performance boost:

<pre>
$ # baseline
$ py -m timeit -r9 -s 'from math import hypot' 'hypot(15.0, 14.0, 13.0, 12.0, 11.0, 10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0)'
2000000 loops, best of 9: 181 nsec per loop
$ py -m timeit -r9 -s 'from math import hypot' 'hypot(10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0)'
2000000 loops, best of 9: 136 nsec per loop
$ py -m timeit -r9 -s 'from math import hypot' 'hypot(5.0, 4.0, 3.0, 2.0, 1.0)'
5000000 loops, best of 9: 94 nsec per loop

$ # patched
$ py -m timeit -r9 -s 'from math import hypot' 'hypot(15.0, 14.0, 13.0, 12.0, 11.0, 10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0)'
2000000 loops, best of 9: 179 nsec per loop
$ py -m timeit -r9 -s 'from math import hypot' 'hypot(10.0, 9.0, 8.0, 7.0, 6.0, 5.0, 4.0, 3.0, 2.0, 1.0)'
2000000 loops, best of 9: 134 nsec per loop
$ py -m timeit -r9 -s 'from math import hypot' 'hypot(5.0, 4.0, 3.0, 2.0, 1.0)'
5000000 loops, best of 9: 92.5 nsec per loop
</pre>