### PR TITLE
bpo-34443: return __qualname__ in enum __repr__

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -164,6 +164,11 @@ class EnumMeta(type):
         enum_class._member_names_ = []               # names in definition order
         enum_class._member_map_ = {}                 # name->value map
         enum_class._member_type_ = member_type
+        enum_class._module_qualname_ = (
+                '%s.%s' % (
+                    enum_class.__module__,
+                    enum_class.__qualname__.replace('.<locals>.','.'),
+                ))
 
         # save attributes from super classes so we know if we can take
         # the shortcut of storing members in the class dict
@@ -357,7 +362,7 @@ class EnumMeta(type):
         return MappingProxyType(cls._member_map_)
 
     def __repr__(cls):
-        return "<enum %r>" % cls.__name__
+        return "<enum %r>" % cls._module_qualname_
 
     def __reversed__(cls):
         return (cls._member_map_[name] for name in reversed(cls._member_names_))
@@ -425,6 +430,7 @@ class EnumMeta(type):
             enum_class.__module__ = module
         if qualname is not None:
             enum_class.__qualname__ = qualname
+            enum_class._module_qualname_ = '%s.%s' % (module, qualname.replace('.locals.','.'))
 
         return enum_class
 
@@ -560,8 +566,7 @@ class Enum(metaclass=EnumMeta):
         raise ValueError("%r is not a valid %s" % (value, cls.__name__))
 
     def __repr__(self):
-        return "<%s.%s: %r>" % (
-                self.__class__.__qualname__, self._name_, self._value_)
+        return "<%s.%s: %r>" % (self.__class__._module_qualname_, self._name_, self._value_)
 
     def __str__(self):
         return "%s.%s" % (self.__class__.__name__, self._name_)

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -561,7 +561,7 @@ class Enum(metaclass=EnumMeta):
 
     def __repr__(self):
         return "<%s.%s: %r>" % (
-                self.__class__.__name__, self._name_, self._value_)
+                self.__class__.__qualname__, self._name_, self._value_)
 
     def __str__(self):
         return "%s.%s" % (self.__class__.__name__, self._name_)

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -2584,9 +2584,9 @@ class TestStdLib(unittest.TestCase):
     def test_pydoc(self):
         # indirectly test __objclass__
         if StrEnum.__doc__ is None:
-            expected_text = expected_help_output_without_docs % __name__
+            expected_text = expected_help_output_without_docs % self.__class__.__qualname__
         else:
-            expected_text = expected_help_output_with_docs % __name__
+            expected_text = expected_help_output_with_docs % self.__class__.__qualname__
         output = StringIO()
         helper = pydoc.Helper(output=output)
         helper(self.Color)

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -453,7 +453,8 @@ class PydocDocTest(unittest.TestCase):
             zero = 0
             one = 1
         doc = pydoc.render_doc(BinaryInteger)
-        self.assertIn('<BinaryInteger.zero: 0>', doc)
+        # __qualname__ usage means more to check
+        self.assertIn('<test.test_pydoc.PydocDocTest.test_text_enum_memb', doc)
 
     def test_mixed_case_module_names_are_lower_cased(self):
         # issue16484


### PR DESCRIPTION
[WIP] repr of a class should return __qualname__ and
not __name__ especially in nested classes


<!-- issue-number: [bpo-34443](https://www.bugs.python.org/issue34443) -->
https://bugs.python.org/issue34443
<!-- /issue-number -->
