### PR TITLE
bpo-34222: Lib/email: Fix infinite loop when folding

### DIFF
--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2687,6 +2687,12 @@ class TestFolding(TestEmailBase):
         self._test(parser.get_unstructured("hübsch kleiner beißt"),
                    "=?utf-8?q?h=C3=BCbsch_kleiner_bei=C3=9Ft?=\n")
 
+    def test_unstructured_with_long_unicode_folded(self):
+        self._test(parser.get_unstructured("虾" * 40),
+                   "=?utf-8?b?" + "6Jm+" * 16 + "?=\n"
+                   " =?utf-8?b?" + "6Jm+" * 16 + "?=\n"
+                   " =?utf-8?b?" + "6Jm+" * 8 + "?=\n")
+
     def test_one_ew_on_each_of_two_wrapped_lines(self):
         self._test(parser.get_unstructured("Mein kleiner Kaktus ist sehr "
                                            "hübsch.  Es hat viele Stacheln "

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -1643,10 +1643,10 @@ class TestFolding(TestHeaderBase):
         self.assertEqual(
             h.fold(policy=policy.default),
             'X-Report-Abuse: =?utf-8?q?=3Chttps=3A//www=2Emailitapp=2E'
-                'com/report=5F?=\n'
-            ' =?utf-8?q?abuse=2Ephp=3Fmid=3Dxxx-xxx-xxxx'
-                'xxxxxxxxxxxxxxxxxxxx=3D=3D-xxx-?=\n'
-            ' =?utf-8?q?xx-xx=3E?=\n')
+                'com/report=5Fabuse?=\n'
+            ' =?utf-8?q?=2Ephp=3Fmid=3Dxxx-xxx-xxxx'
+                'xxxxxxxxxxxxxxxxxxxx=3D=3D-xxx-xx-xx?=\n'
+            ' =?utf-8?q?=3E?=\n')
 
 
 if __name__ == '__main__':

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1599,6 +1599,7 @@ Anish Tambe
 Musashi Tamura
 William Tanksley
 Christian Tanzer
+Pengyu Tao
 Steven Taschuk
 Amy Taylor
 Julian Taylor

--- a/Misc/NEWS.d/next/Library/2018-08-30-11-11-25.bpo-34222.yA1Rn7.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-30-11-11-25.bpo-34222.yA1Rn7.rst
@@ -1,0 +1,1 @@
+Fix infinite loop when folding non-ASCII email headers


### PR DESCRIPTION
Currently when folding headers with length > maxlen, _fold_as_ew tries
to split the to_encode into multiple parts to fulfill the maxlen limit,
in an inapropriate way.

If a long header has non-ascii characters, in some situations (e.g. a
Subject: with full of CJK chars), it will split the to_encode into
["", to_encode], entering an infinite loop.

This commit fixes this by introduce a smarter way to split.
Besides, when an header needs to be folded now, every non-last line will
try its best to reach the maxlen, in O(log N) time.
Also, apply missing charset= parameter for _ew.encode.

The bug is introduced in commit 85d5c18c9d83a1d54eecc4c2ad4dce63194107c6

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34222](https://www.bugs.python.org/issue34222) -->
https://bugs.python.org/issue34222
<!-- /issue-number -->
