### PR TITLE
bpo-34523: Fix config_init_fs_encoding()

### DIFF
--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -1344,7 +1344,7 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         config->argc = 0;
     }
 
-    if (config->filesystem_encoding == NULL && config->filesystem_errors == NULL) {
+    if (config->filesystem_encoding == NULL || config->filesystem_errors == NULL) {
         err = config_init_fs_encoding(config);
         if (_Py_INIT_FAILED(err)) {
             return err;


### PR DESCRIPTION
Call config_init_fs_encoding() if filesystem_errors is not NULL but
filesystem_encoding is NULL.

<!-- issue-number: [bpo-34523](https://www.bugs.python.org/issue34523) -->
https://bugs.python.org/issue34523
<!-- /issue-number -->
