### PR TITLE
bpo-34485: Emit C locale coercion warning later

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -301,10 +301,8 @@ static const char *_C_LOCALE_WARNING =
 static void
 _emit_stderr_warning_for_legacy_locale(const _PyCoreConfig *core_config)
 {
-    if (core_config->coerce_c_locale_warn) {
-        if (_Py_LegacyLocaleDetected()) {
-            fprintf(stderr, "%s", _C_LOCALE_WARNING);
-        }
+    if (core_config->coerce_c_locale_warn && _Py_LegacyLocaleDetected()) {
+        PySys_FormatStderr("%s", _C_LOCALE_WARNING);
     }
 }
 
@@ -566,10 +564,6 @@ _Py_InitializeCore_impl(PyInterpreterState **interp_p,
      * pair :(
      */
     _PyRuntime.finalizing = NULL;
-
-#ifndef MS_WINDOWS
-    _emit_stderr_warning_for_legacy_locale(core_config);
-#endif
 
     err = _Py_HashRandomization_Init(core_config);
     if (_Py_INIT_FAILED(err)) {
@@ -867,6 +861,11 @@ _Py_InitializeMainInterpreter(PyInterpreterState *interp,
             return err;
         }
     }
+
+#ifndef MS_WINDOWS
+    _emit_stderr_warning_for_legacy_locale(core_config);
+#endif
+
     return _Py_INIT_OK();
 }
 


### PR DESCRIPTION
PYTHONCOERCELOCALE=warn warning is now emitted later and written into
sys.stderr, rather than being written into the C stderr stream.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34485](https://www.bugs.python.org/issue34485) -->
https://bugs.python.org/issue34485
<!-- /issue-number -->
