### PR TITLE
bpo-34523: Use _PyCoreConfig instead of globals

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -123,7 +123,7 @@ PyAPI_FUNC(const char *) _Py_gitversion(void);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _PyBuiltin_Init(void);
 PyAPI_FUNC(_PyInitError) _PySys_BeginInit(PyObject **sysmod);
-PyAPI_FUNC(int) _PySys_EndInit(PyObject *sysdict, _PyMainInterpreterConfig *config);
+PyAPI_FUNC(int) _PySys_EndInit(PyObject *sysdict, PyInterpreterState *interp);
 PyAPI_FUNC(_PyInitError) _PyImport_Init(PyInterpreterState *interp);
 PyAPI_FUNC(void) _PyExc_Init(PyObject * bltinmod);
 PyAPI_FUNC(_PyInitError) _PyImportHooks_Init(void);

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -249,7 +249,9 @@ PyAPI_FUNC(void) PyInterpreterState_Delete(PyInterpreterState *);
 PyAPI_FUNC(PyInterpreterState *) _PyInterpreterState_Get(void);
 #endif
 #ifdef Py_BUILD_CORE
-   /* Macro which should only be used for performance critical code */
+   /* Macro which should only be used for performance critical code.
+      Need "#include "internal/pystate.h". See also _PyInterpreterState_Get()
+      and _PyGILState_GetInterpreterStateUnsafe(). */
 #  define _PyInterpreterState_GET_UNSAFE() (PyThreadState_GET()->interp)
 #endif
 #if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03070000
@@ -369,7 +371,9 @@ PyAPI_FUNC(int) PyGILState_Check(void);
    GILState implementation.
 
    Return NULL before _PyGILState_Init() is called and after _PyGILState_Fini()
-   is called. */
+   is called.
+
+   See also _PyInterpreterState_Get() and _PyInterpreterState_GET_UNSAFE(). */
 PyAPI_FUNC(PyInterpreterState *) _PyGILState_GetInterpreterStateUnsafe(void);
 #endif   /* !Py_LIMITED_API */
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -951,18 +951,18 @@ pymain_init_stdio(_PyMain *pymain, _PyCoreConfig *config)
 
 
 static void
-pymain_header(_PyMain *pymain)
+pymain_header(_PyMain *pymain, const _PyCoreConfig *config)
 {
-    if (Py_QuietFlag) {
+    if (config->quiet) {
         return;
     }
 
-    if (!Py_VerboseFlag && (RUN_CODE(pymain) || !pymain->stdin_is_interactive)) {
+    if (!config->verbose && (RUN_CODE(pymain) || !pymain->stdin_is_interactive)) {
         return;
     }
 
     fprintf(stderr, "Python %s on %s\n", Py_GetVersion(), Py_GetPlatform());
-    if (!Py_NoSiteFlag) {
+    if (config->site_import) {
         fprintf(stderr, "%s\n", COPYRIGHT);
     }
 }
@@ -1041,12 +1041,12 @@ wstrlist_as_pylist(int len, wchar_t **list)
 
 
 static void
-pymain_import_readline(_PyMain *pymain)
+pymain_import_readline(_PyMain *pymain, const _PyCoreConfig *config)
 {
-    if (Py_IsolatedFlag) {
+    if (config->isolated) {
         return;
     }
-    if (!Py_InspectFlag && RUN_CODE(pymain)) {
+    if (!config->inspect && RUN_CODE(pymain)) {
         return;
     }
     if (!isatty(fileno(stdin))) {
@@ -1591,8 +1591,8 @@ pymain_run_python(_PyMain *pymain, PyInterpreterState *interp)
 
     PyCompilerFlags cf = {.cf_flags = 0};
 
-    pymain_header(pymain);
-    pymain_import_readline(pymain);
+    pymain_header(pymain, config);
+    pymain_import_readline(pymain, config);
 
     if (pymain->command) {
         pymain->status = pymain_run_command(pymain->command, &cf);

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "Python-ast.h"
+#include "internal/pystate.h"
 
 #include "node.h"
 #include "code.h"
@@ -2765,6 +2766,8 @@ _PyBuiltin_Init(void)
 {
     PyObject *mod, *dict, *debug;
 
+    const _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->core_config;
+
     if (PyType_Ready(&PyFilter_Type) < 0 ||
         PyType_Ready(&PyMap_Type) < 0 ||
         PyType_Ready(&PyZip_Type) < 0)
@@ -2823,7 +2826,7 @@ _PyBuiltin_Init(void)
     SETBUILTIN("tuple",                 &PyTuple_Type);
     SETBUILTIN("type",                  &PyType_Type);
     SETBUILTIN("zip",                   &PyZip_Type);
-    debug = PyBool_FromLong(Py_OptimizeFlag == 0);
+    debug = PyBool_FromLong(config->optimization_level == 0);
     if (PyDict_SetItemString(dict, "__debug__", debug) < 0) {
         Py_DECREF(debug);
         return NULL;


### PR DESCRIPTION
Get configuratiom the core configuration of the interpreter, rather
than getting global configuration variables. For example, replace
Py_QuietFlag with core_config->quiet.

<!-- issue-number: [bpo-34523](https://www.bugs.python.org/issue34523) -->
https://bugs.python.org/issue34523
<!-- /issue-number -->
