### PR TITLE
Simplify vector_norm() main loop and eliminate branch misprediction costs

### DIFF
--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2053,11 +2053,12 @@ The *csum* variable tracks the cumulative sum and *frac* tracks
 the cumulative fractional errors at each step.  Since this
 variant assumes that |csum| >= |x| at each step, we establish
 the precondition by starting the accumulation from 1.0 which
-represents the largest possible scaled value of (x/max)**2.
+represents the largest possible value of (x/max)**2.
+
 After the loop is finished, the initial 1.0 is subtracted out
 for a net zero effect on the final sum.  Since *csum* will be
-greater than 1.0, the subtraction of 1.0 will cause additional
-loss fractional digits from *csum*.
+greater than 1.0, the subtraction of 1.0 will not cause
+fractional digits to be dropped from *csum*.
 
 */
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2032,8 +2032,8 @@ math_fmod_impl(PyObject *module, double x, double y)
 }
 
 /*
-Given an *n* length *vec* of non-negative values
-where *max* is the largest value in the vector, compute:
+Given an *n* length *vec* of values where *max* is the absolute
+value of the largest magnitude entry in the vector, compute:
 
     max * sqrt(sum((x / max) ** 2 for x in vec))
 
@@ -2053,9 +2053,7 @@ The *csum* variable tracks the cumulative sum and *frac* tracks
 the cumulative fractional errors at each step.  Since this
 variant assumes that |csum| >= |x| at each step, we establish
 the precondition by starting the accumulation from 1.0 which
-represents an entry equal to *max*.  This also provides a nice
-side benefit in that it lets us skip over a *max* entry (which
-is swapped into *last*) saving us one iteration through the loop.
+represents the largest possible scaled value of (x/max)**2.
 
 */
 
@@ -2076,7 +2074,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
     }
     for (i=0 ; i < n ; i++) {
         x = vec[i];
-        assert(Py_IS_FINITE(x) && x >= 0.0 && x <= max);
+        assert(Py_IS_FINITE(x) && fabs(x) <= max);
         x /= max;
         x = x*x;
         assert(csum >= x);

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2054,6 +2054,10 @@ the cumulative fractional errors at each step.  Since this
 variant assumes that |csum| >= |x| at each step, we establish
 the precondition by starting the accumulation from 1.0 which
 represents the largest possible scaled value of (x/max)**2.
+After the loop is finished, the initial 1.0 is subtracted out
+for a net zero effect on the final sum.  Since *csum* will be
+greater than 1.0, the subtraction of 1.0 will cause additional
+loss fractional digits from *csum*.
 
 */
 

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2071,10 +2071,9 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
     if (found_nan) {
         return Py_NAN;
     }
-    if (max == 0.0) {
-        return 0.0;
+    if (max == 0.0 || n == 1) {
+        return max;
     }
-    assert(n > 0);
     for (i=0 ; i < n ; i++) {
         x = vec[i];
         assert(Py_IS_FINITE(x) && x >= 0.0 && x <= max);

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2062,7 +2062,7 @@ is swapped into *last*) saving us one iteration through the loop.
 static inline double
 vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
 {
-    double x, csum = 1.0, oldcsum, frac = 0.0, last;
+    double x, csum = 1.0, oldcsum, frac = 0.0;
     Py_ssize_t i;
 
     if (Py_IS_INFINITY(max)) {
@@ -2075,14 +2075,9 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         return 0.0;
     }
     assert(n > 0);
-    last = vec[n-1];
-    for (i=0 ; i < n-1 ; i++) {
+    for (i=0 ; i < n ; i++) {
         x = vec[i];
         assert(Py_IS_FINITE(x) && x >= 0.0 && x <= max);
-        if (x == max) {
-            x = last;
-            last = max;
-        }
         x /= max;
         x = x*x;
         assert(csum >= x);
@@ -2090,8 +2085,7 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         csum += x;
         frac += (oldcsum - csum) + x;
     }
-    assert(last == max);
-    return max * sqrt(csum + frac);
+    return max * sqrt(csum - 1.0 + frac);
 }
 
 #define NUM_STACK_ELEMS 16

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2032,14 +2032,14 @@ math_fmod_impl(PyObject *module, double x, double y)
 }
 
 /*
-Given an *n* length *vec* of values where *max* is the absolute
-value of the largest magnitude entry in the vector, compute:
+Given an *n* length *vec* of values and a value *max*, compute:
 
     max * sqrt(sum((x / max) ** 2 for x in vec))
 
-The value of the *max* variable must be present in *vec*
-or should equal to 0.0 when n==0.  Likewise, *max* will
-be INF if an infinity is present in the vec.
+The value of the *max* variable must be non-negative and
+at least equal to the absolute value of the largest magnitude
+entry in the vector.  If n==0, then *max* should be 0.0.
+If an infinity is present in the vec, *max* should be INF.
 
 The *found_nan* variable indicates whether some member of
 the *vec* is a NaN.
@@ -2082,9 +2082,9 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
         assert(Py_IS_FINITE(x) && fabs(x) <= max);
         x /= max;
         x = x*x;
-        assert(csum >= x);
         oldcsum = csum;
         csum += x;
+        assert(csum >= x);
         frac += (oldcsum - csum) + x;
     }
     return max * sqrt(csum - 1.0 + frac);


### PR DESCRIPTION
Summary
-------

Instead of searching for and skipping over a value equal to
*max*, just start the accumlation for 1.0 and subtract it
back out in the end.

This eliminates the contortion of swapping *max* with *last*,
making loop body simpler and branchless.  Timings show
that the cost of an extra loop is more than offset by the
avoiding branch misprediction costs.

Since the loop body no longer has to search for values equal to *max*,
the vector values no longer need to be restricted to non-negative
values.

Main loop disassembly
------------------------

The main loop is much cleaner now (one memory read per loop, memory
accesses are for consecutive memory locations, and there are no branches,
register spills, or reloads).

<pre>
L379:
    movsd   (%rax), %xmm2
    addq    $8, %rax
    cmpq    %rax, %rdx
    divsd   %xmm1, %xmm2
    mulsd   %xmm2, %xmm2
    movapd  %xmm2, %xmm3
    addsd   %xmm0, %xmm3
    subsd   %xmm3, %xmm0
    addsd   %xmm0, %xmm2
    movapd  %xmm3, %xmm0
    addsd   %xmm2, %xmm4
    jne L379
</pre>

Timings
--------

Performance is the same or slightly improved for various number of arguments to *hypot()*:

<pre>
$ py time_hypot_max_location.py    # baseline 1
0.19610544399999985
$ py time_hypot_max_location.py    # baseline 2
0.2929759919999999
$ py time_hypot_max_location.py    # baseline 3
0.329982003
$ py time_hypot_max_location.py    # baseline 4
0.3638649850000002
$ py time_hypot_max_location.py    # baseline 5
0.398908402
$ py time_hypot_max_location.py    # baseline 10
0.5381930719999999
$ py time_hypot_max_location.py    # baseline 15
0.714894589
$ py time_hypot_max_location.py    # baseline 30
1.4070674050000012
$ py time_hypot_max_location.py    # baseline 60
2.381592201
$ py time_hypot_max_location.py    # baseline 120
5.435193673
$ py time_hypot_max_location.py    # baseline 240
9.103425692999991
------------------------

$ py time_hypot_max_location.py    # patched 1
0.18985156299999995
$ py time_hypot_max_location.py    # patched 2
0.2807232770000001
$ py time_hypot_max_location.py    # patched 3
0.31244054500000007
$ py time_hypot_max_location.py    # patched 4
0.34701948800000004
$ py time_hypot_max_location.py    # patched 5
0.381604936
$ py time_hypot_max_location.py    # patched 10
0.5410756759999997
$ py time_hypot_max_location.py    # patched 15
0.7458159609999999
$ py time_hypot_max_location.py    # patched 30
1.3642926619999995
$ py time_hypot_max_location.py    # patched 60
2.397398169999999
$ py time_hypot_max_location.py    # patched 120
5.419441274999997
$ py time_hypot_max_location.py    # patched 240
9.029506676999997
</pre>

Timing Code
-------------

<pre>
'Make sure branch misprediction gets included in timings'

from random import randrange
from itertools import starmap
from collections import deque
from math import hypot
from timeit import repeat

def consume(it):
    deque(it, maxlen=0)

def one_row(n, zero=0.0, one=1.0):
    'Return an n-length tuple with the max value in a rondom position'
    vec = [zero] * n
    vec[randrange(n)] = one
    return tuple(vec)

def trial(coordinates):
    consume(starmap(hypot, coordinates))

setup = '''
from __main__ import one_row, trial

trials = 10_000
n = 1
coordinates = [one_row(n) for i in range(trials)]
'''

stmts = '''
trial(coordinates)
'''

print(min(repeat(stmts, setup, repeat=9, number=1_000)))
</pre>
