### PR TITLE
bpo-34551: Remove redundant store

### DIFF
--- a/Objects/call.c
+++ b/Objects/call.c
@@ -352,7 +352,7 @@ _PyFunction_FastCallDict(PyObject *func, PyObject *const *args, Py_ssize_t nargs
             Py_INCREF(k[i+1]);
             i += 2;
         }
-        nk = i / 2;
+        assert(i / 2 == nk);
     }
     else {
         kwtuple = NULL;


### PR DESCRIPTION
The assignment of i/2 to nk is redundant because on this code path, nk is already the size of the dictionary, and i is already twice the size of the dictionary. I've replaced the store with an assertion that i/2 is equal to nk.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34551](https://www.bugs.python.org/issue34551) -->
https://bugs.python.org/issue34551
<!-- /issue-number -->
