### PR TITLE
bpo-22872: multiprocessing.Queue's put() and get() now raise ValueError if the queue is closed

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -786,6 +786,10 @@ For an example of the usage of queues for interprocess communication see
       available, else raise the :exc:`queue.Full` exception (*timeout* is
       ignored in that case).
 
+      .. versionchanged:: 3.8
+         If the queue is closed, :exc:`ValueError` is raised instead of
+         :exc:`AssertionError`.
+
    .. method:: put_nowait(obj)
 
       Equivalent to ``put(obj, False)``.
@@ -799,6 +803,10 @@ For an example of the usage of queues for interprocess communication see
       exception if no item was available within that time.  Otherwise (block is
       ``False``), return an item if one is immediately available, else raise the
       :exc:`queue.Empty` exception (*timeout* is ignored in that case).
+
+      .. versionchanged:: 3.8
+         If the queue is closed, :exc:`ValueError` is raised instead of
+         :exc:`OSError`.
 
    .. method:: get_nowait()
 

--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -78,7 +78,8 @@ class Queue(object):
         self._poll = self._reader.poll
 
     def put(self, obj, block=True, timeout=None):
-        assert not self._closed, "Queue {0!r} has been closed".format(self)
+        if self._closed:
+            raise ValueError(f"Queue {self!r} is closed")
         if not self._sem.acquire(block, timeout):
             raise Full
 
@@ -89,6 +90,8 @@ class Queue(object):
             self._notempty.notify()
 
     def get(self, block=True, timeout=None):
+        if self._closed:
+            raise ValueError(f"Queue {self!r} is closed")
         if block and timeout is None:
             with self._rlock:
                 res = self._recv_bytes()
@@ -298,7 +301,8 @@ class JoinableQueue(Queue):
         self._cond, self._unfinished_tasks = state[-2:]
 
     def put(self, obj, block=True, timeout=None):
-        assert not self._closed, "Queue {0!r} is closed".format(self)
+        if self._closed:
+            raise ValueError(f"Queue {self!r} is closed")
         if not self._sem.acquire(block, timeout):
             raise Full
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1116,6 +1116,13 @@ class _TestQueue(BaseTestCase):
         # Assert that the serialization and the hook have been called correctly
         self.assertTrue(not_serializable_obj.reduce_was_called)
         self.assertTrue(not_serializable_obj.on_queue_feeder_error_was_called)
+
+    def test_closed_queue_put_get_exceptions(self):
+        for q in multiprocessing.Queue(), multiprocessing.JoinableQueue():
+            q.close()
+            for meth, args in (q.put, ('foo',)), (q.get, ()):
+                with self.assertRaisesRegex(ValueError, 'is closed'):
+                    meth(*args)
 #
 #
 #

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -1120,9 +1120,10 @@ class _TestQueue(BaseTestCase):
     def test_closed_queue_put_get_exceptions(self):
         for q in multiprocessing.Queue(), multiprocessing.JoinableQueue():
             q.close()
-            for meth, args in (q.put, ('foo',)), (q.get, ()):
-                with self.assertRaisesRegex(ValueError, 'is closed'):
-                    meth(*args)
+            with self.assertRaisesRegex(ValueError, 'is closed'):
+                q.put('foo')
+            with self.assertRaisesRegex(ValueError, 'is closed'):
+                q.get()
 #
 #
 #

--- a/Misc/NEWS.d/next/Library/2018-08-30-14-44-11.bpo-22872.NhIaZ9.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-30-14-44-11.bpo-22872.NhIaZ9.rst
@@ -1,0 +1,3 @@
+When the queue is closed, :exc:`ValueError` is now raised by
+:meth:`multiprocessing.Queue.put` and :meth:`multiprocessing.Queue.get`
+instead of :exc:`AssertionError` and :exc:`OSError`, respectively.

--- a/Misc/NEWS.d/next/Library/2018-08-30-14-44-11.bpo-22872.NhIaZ9.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-30-14-44-11.bpo-22872.NhIaZ9.rst
@@ -1,3 +1,4 @@
 When the queue is closed, :exc:`ValueError` is now raised by
 :meth:`multiprocessing.Queue.put` and :meth:`multiprocessing.Queue.get`
 instead of :exc:`AssertionError` and :exc:`OSError`, respectively.
+Patch by Zackery Spytz.


### PR DESCRIPTION
Previously, put() and get() would raise AssertionError and OSError,
respectively.

<!-- issue-number: [bpo-22872](https://www.bugs.python.org/issue22872) -->
https://bugs.python.org/issue22872
<!-- /issue-number -->
