### PR TITLE
bpo-34443: Change enum __repr__s and __str__s to use the fully qualified name

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -353,7 +353,7 @@ class EnumMeta(type):
         return MappingProxyType(cls._member_map_)
 
     def __repr__(cls):
-        return "<enum %r>" % cls.__name__
+        return "<enum '%s.%s'>" % (cls.__module__, cls.__qualname__)
 
     def __reversed__(cls):
         return (cls._member_map_[name] for name in reversed(cls._member_names_))
@@ -556,8 +556,10 @@ class Enum(metaclass=EnumMeta):
         raise ValueError("%r is not a valid %s" % (value, cls.__name__))
 
     def __repr__(self):
-        return "<%s.%s: %r>" % (
-                self.__class__.__name__, self._name_, self._value_)
+        return "<%s.%s.%s: %r>" % (self.__class__.__module__,
+                                   self.__class__.__qualname__,
+                                   self._name_,
+                                   self._value_)
 
     def __str__(self):
         return "%s.%s" % (self.__class__.__name__, self._name_)
@@ -711,10 +713,12 @@ class Flag(Enum):
     def __repr__(self):
         cls = self.__class__
         if self._name_ is not None:
-            return '<%s.%s: %r>' % (cls.__name__, self._name_, self._value_)
+            return '<%s.%s.%s: %r>' % (
+                cls.__module__, cls.__qualname__, self._name_, self._value_)
         members, uncovered = _decompose(cls, self._value_)
-        return '<%s.%s: %r>' % (
-                cls.__name__,
+        return '<%s.%s.%s: %r>' % (
+                cls.__module__,
+                cls.__qualname__,
                 '|'.join([str(m._name_ or m._value_) for m in members]),
                 self._value_,
                 )

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -562,7 +562,9 @@ class Enum(metaclass=EnumMeta):
                                    self._value_)
 
     def __str__(self):
-        return "%s.%s" % (self.__class__.__name__, self._name_)
+        return "%s.%s.%s" % (self.__class__.__module__,
+                             self.__class__.__qualname__,
+                             self._name_)
 
     def __dir__(self):
         added_behavior = [
@@ -726,13 +728,15 @@ class Flag(Enum):
     def __str__(self):
         cls = self.__class__
         if self._name_ is not None:
-            return '%s.%s' % (cls.__name__, self._name_)
+            return '%s.%s.%s' % (cls.__module__, cls.__qualname__, self._name_)
         members, uncovered = _decompose(cls, self._value_)
         if len(members) == 1 and members[0]._name_ is None:
-            return '%s.%r' % (cls.__name__, members[0]._value_)
+            return '%s.%s.%r' % (
+                cls.__module__, cls.__qualname__, members[0]._value_)
         else:
-            return '%s.%s' % (
-                    cls.__name__,
+            return '%s.%s.%s' % (
+                    cls.__module__,
+                    cls.__qualname__,
                     '|'.join([str(m._name_ or m._value_) for m in members]),
                     )
 

--- a/Misc/NEWS.d/next/Library/2018-08-30-23-01-44.bpo-34443.faVxO4.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-30-23-01-44.bpo-34443.faVxO4.rst
@@ -1,0 +1,1 @@
+Change enum ``__repr__``s and ``__str__``s to use the fully qualified name.


### PR DESCRIPTION
The reason I've also changed the `__str__`s is to keep consistency with the `__repr__`s. ~The datetime module also follows this practice.~

<!-- issue-number: [bpo-34443](https://www.bugs.python.org/issue34443) -->
https://bugs.python.org/issue34443
<!-- /issue-number -->
