### PR TITLE
Typo in typing module docstring

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2,7 +2,7 @@
 The typing module: Support for gradual typing as defined by PEP 484.
 
 At large scale, the structure of the module is following:
-* Imports and exports, all public names should be explicitelly added to __all__.
+* Imports and exports, all public names should be explicitly added to __all__.
 * Internal helper functions: these should never be used in code outside this module.
 * _SpecialForm and its instances (special forms): Any, NoReturn, ClassVar, Union, Optional
 * Two classes whose instances can be type arguments in addition to types: ForwardRef and TypeVar


### PR DESCRIPTION
Minor fix added:

> "explicitelly" → "explicitly"

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
