### PR TITLE
Fix typo in typing.py module docstring

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -2,7 +2,7 @@
 The typing module: Support for gradual typing as defined by PEP 484.
 
 At large scale, the structure of the module is following:
-* Imports and exports, all public names should be explicitelly added to __all__.
+* Imports and exports, all public names should be explicitly added to __all__.
 * Internal helper functions: these should never be used in code outside this module.
 * _SpecialForm and its instances (special forms): Any, NoReturn, ClassVar, Union, Optional
 * Two classes whose instances can be type arguments in addition to types: ForwardRef and TypeVar


### PR DESCRIPTION
Fix spelling of explicitly:

> "explicitelly" → "explicitly"