### PR TITLE
bpo-34555: Fix incorrectly nested test for HAVE_LINUX_VM_SOCKETS_H

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-08-31-19-41-09.bpo-34555.dfQcnm.rst
+++ b/Misc/NEWS.d/next/Build/2018-08-31-19-41-09.bpo-34555.dfQcnm.rst
@@ -1,0 +1,2 @@
+Fix for case where it was not possible to have both
+``HAVE_LINUX_VM_SOCKETS_H`` and ``HAVE_SOCKADDR_ALG`` be undefined.

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -108,6 +108,7 @@ typedef int socklen_t;
 #endif
 
 #ifdef HAVE_SOCKADDR_ALG
+
 # include <linux/if_alg.h>
 # ifndef AF_ALG
 #  define AF_ALG 38

--- a/Modules/socketmodule.h
+++ b/Modules/socketmodule.h
@@ -101,39 +101,39 @@ typedef int socklen_t;
 #include <sys/kern_control.h>
 #endif
 
-#ifdef HAVE_SOCKADDR_ALG
-#include <linux/if_alg.h>
-#ifndef AF_ALG
-#define AF_ALG 38
-#endif
-#ifndef SOL_ALG
-#define SOL_ALG 279
-#endif
-
 #ifdef HAVE_LINUX_VM_SOCKETS_H
 # include <linux/vm_sockets.h>
 #else
 # undef AF_VSOCK
 #endif
 
-/* Linux 3.19 */
-#ifndef ALG_SET_AEAD_ASSOCLEN
-#define ALG_SET_AEAD_ASSOCLEN           4
-#endif
-#ifndef ALG_SET_AEAD_AUTHSIZE
-#define ALG_SET_AEAD_AUTHSIZE           5
-#endif
-/* Linux 4.8 */
-#ifndef ALG_SET_PUBKEY
-#define ALG_SET_PUBKEY                  6
-#endif
+#ifdef HAVE_SOCKADDR_ALG
+# include <linux/if_alg.h>
+# ifndef AF_ALG
+#  define AF_ALG 38
+# endif
+# ifndef SOL_ALG
+#  define SOL_ALG 279
+# endif
 
-#ifndef ALG_OP_SIGN
-#define ALG_OP_SIGN                     2
-#endif
-#ifndef ALG_OP_VERIFY
-#define ALG_OP_VERIFY                   3
-#endif
+/* Linux 3.19 */
+# ifndef ALG_SET_AEAD_ASSOCLEN
+#  define ALG_SET_AEAD_ASSOCLEN           4
+# endif
+# ifndef ALG_SET_AEAD_AUTHSIZE
+#  define ALG_SET_AEAD_AUTHSIZE           5
+# endif
+/* Linux 4.8 */
+# ifndef ALG_SET_PUBKEY
+#  define ALG_SET_PUBKEY                  6
+# endif
+
+# ifndef ALG_OP_SIGN
+#  define ALG_OP_SIGN                     2
+# endif
+# ifndef ALG_OP_VERIFY
+#  define ALG_OP_VERIFY                   3
+# endif
 
 #endif /* HAVE_SOCKADDR_ALG */
 


### PR DESCRIPTION
Unnested the check for `HAVE_LINUX_VM_SOCKETS_H`, to be independent of `HAVE_SOCKADDR_ALG`. Also added indentation to the `HAVE_SOCKADDR_ALG` block to make it clearer where it starts and ends.

<!-- issue-number: [bpo-34555](https://www.bugs.python.org/issue34555) -->
https://bugs.python.org/issue34555
<!-- /issue-number -->
