### PR TITLE
[3.6] bpo-34007: Skip traceback tests if the Program Counter is not available (GH-9018)

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -212,6 +212,15 @@ class DebuggerTests(unittest.TestCase):
         for line in errlines:
             if not line:
                 continue
+            # bpo34007: Sometimes some versions of the shared libraries that
+            # are part of the traceback are compiled in optimised mode and the
+            # Program Counter (PC) is not present, not allowing gdb to walk the
+            # frames back. When this happens, the Python bindings of gdb raise
+            # an exception, making the test impossible to succeed.
+            if "PC not saved" in line:
+                raise unittest.SkipTest("gdb cannot walk the frame object"
+                                        " because the Program Counter is"
+                                        " not present")
             if not line.startswith(ignore_patterns):
                 unexpected_errlines.append(line)
 


### PR DESCRIPTION
Sometimes some versions of the shared libraries that are part of the
traceback are compiled in optimised mode and the Program Counter (PC)
is not present, not allowing gdb to walk the frames back. When this
happens, the Python bindings of gdb raise an exception, making the
test impossible to succeed.
(cherry picked from commit f2ef51f8bec525b21e52988880c8a029642795ed)

Co-authored-by: Pablo Galindo <Pablogsal@gmail.com>

<!-- issue-number: [bpo-34007](https://www.bugs.python.org/issue34007) -->
https://bugs.python.org/issue34007
<!-- /issue-number -->
