### PR TITLE
[2.7] Fix struct sequence glossary entry grammar (GH-9030)

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -710,7 +710,7 @@ Glossary
 
    struct sequence
       A tuple with named elements. Struct sequences expose an interface similiar
-      to :term:`named tuple` in that elements can either be accessed either by
+      to :term:`named tuple` in that elements can be accessed either by
       index or as an attribute. However, they do not have any of the named tuple
       methods like :meth:`~collections.somenamedtuple._make` or
       :meth:`~collections.somenamedtuple._asdict`. Examples of struct sequences


### PR DESCRIPTION
... by removing a superfluous "either".

Reported by Никита Люшненко on docs@..
(cherry picked from commit 98b976a2f82ba5f50cf6846338f644ca6c64f47d)

Co-authored-by: Zachary Ware <zachary.ware@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
