### PR TITLE
[3.7] bpo-34282: Fix Enum._convert shadowing members named _convert

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -171,9 +171,11 @@ class EnumMeta(type):
         enum_class._member_map_ = OrderedDict()      # name->value map
         enum_class._member_type_ = member_type
 
-        # save attributes from super classes so we know if we can take
-        # the shortcut of storing members in the class dict
-        base_attributes = {a for b in enum_class.mro() for a in b.__dict__}
+        # save DynamicClassAttribute attributes from super classes so we know
+        # if we can take the shortcut of storing members in the class dict
+        dynamic_attributes = {k for c in enum_class.mro()
+                              for k, v in c.__dict__.items()
+                              if isinstance(v, DynamicClassAttribute)}
 
         # Reverse value->name map for hashable values.
         enum_class._value2member_map_ = {}
@@ -233,7 +235,7 @@ class EnumMeta(type):
                 enum_class._member_names_.append(member_name)
             # performance boost for any member that would not shadow
             # a DynamicClassAttribute
-            if member_name not in base_attributes:
+            if member_name not in dynamic_attributes:
                 setattr(enum_class, member_name, enum_member)
             # now add to _member_map_
             enum_class._member_map_[member_name] = enum_member

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -173,8 +173,7 @@ class EnumMeta(type):
 
         # save attributes from super classes so we know if we can take
         # the shortcut of storing members in the class dict
-        base_attributes = {k: v for c in reversed(enum_class.mro())
-                           for k, v in c.__dict__.items()}
+        base_attributes = {a for b in enum_class.mro() for a in b.__dict__}
 
         # Reverse value->name map for hashable values.
         enum_class._value2member_map_ = {}
@@ -236,13 +235,6 @@ class EnumMeta(type):
             # a DynamicClassAttribute
             if member_name not in base_attributes:
                 setattr(enum_class, member_name, enum_member)
-            # issue34282: Members named _convert should take precedence over
-            # the _convert method except if the enum also has a behavior named
-            # _convert. In which case, it falls back to the default
-            # behavior > member ordering where the behavior takes precedence.
-            elif (member_name == '_convert' and
-                    base_attributes['_convert'] is Enum.__dict__['_convert']):
-                enum_class._convert = enum_member
             # now add to _member_map_
             enum_class._member_map_[member_name] = enum_member
             try:

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1516,6 +1516,23 @@ class TestEnum(unittest.TestCase):
             yellow = 6
         self.assertEqual(MoreColor.magenta.hex(), '5 hexlified!')
 
+    def test_subclass_duplicate_name(self):
+        class Base(Enum):
+            def test(self):
+                pass
+        class Test(Base):
+            test = 1
+        self.assertIs(type(Test.test), Test)
+
+    def test_subclass_duplicate_name_dynamic(self):
+        from types import DynamicClassAttribute
+        class Base(Enum):
+            @DynamicClassAttribute
+            def test(self):
+                return 'dynamic'
+        class Test(Base):
+            test = 1
+        self.assertEqual(Test.test.test, 'dynamic')
 
     def test_no_duplicates(self):
         class UniqueEnum(Enum):

--- a/Misc/NEWS.d/next/Library/2018-09-02-13-33-35.bpo-34282.ztyXH8.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-02-13-33-35.bpo-34282.ztyXH8.rst
@@ -1,0 +1,1 @@
+Fix ``Enum._convert`` shadowing members named _convert.

--- a/Misc/NEWS.d/next/Library/2018-09-02-13-33-35.bpo-34282.ztyXH8.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-02-13-33-35.bpo-34282.ztyXH8.rst
@@ -1,1 +1,1 @@
-Fix ``Enum._convert`` shadowing members named _convert.
+Fix enum members getting shadowed by parent attributes.


### PR DESCRIPTION
This is the 3.7 patch for the issue below.

<!-- issue-number: [bpo-34282](https://www.bugs.python.org/issue34282) -->
https://bugs.python.org/issue34282
<!-- /issue-number -->
