### PR TITLE
bpo-23855: Add missing NULL checks for malloc() in _msi.c

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-09-02-22-29-03.bpo-23855.mdTfXN.rst
+++ b/Misc/NEWS.d/next/Windows/2018-09-02-22-29-03.bpo-23855.mdTfXN.rst
@@ -1,0 +1,1 @@
+Add missing ``NULL`` checks for ``malloc()`` in _msi.c.

--- a/Misc/NEWS.d/next/Windows/2018-09-02-22-29-03.bpo-23855.mdTfXN.rst
+++ b/Misc/NEWS.d/next/Windows/2018-09-02-22-29-03.bpo-23855.mdTfXN.rst
@@ -1,1 +1,0 @@
-Add missing ``NULL`` checks for ``malloc()`` in _msi.c.

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -330,6 +330,10 @@ msierror(int status)
     code = MsiRecordGetInteger(err, 1); /* XXX code */
     if (MsiFormatRecord(0, err, res, &size) == ERROR_MORE_DATA) {
         res = malloc(size+1);
+        if (res == NULL) {
+            MsiCloseHandle(err);
+            return PyErr_NoMemory();
+        }
         MsiFormatRecord(0, err, res, &size);
         res[size]='\0';
     }
@@ -560,6 +564,9 @@ summary_getproperty(msiobj* si, PyObject *args)
         &fval, sval, &ssize);
     if (status == ERROR_MORE_DATA) {
         sval = malloc(ssize);
+        if (sval == NULL) {
+            return PyErr_NoMemory();
+        }
         status = MsiSummaryInfoGetProperty(si->h, field, &type, &ival,
             &fval, sval, &ssize);
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-23855](https://www.bugs.python.org/issue23855) -->
https://bugs.python.org/issue23855
<!-- /issue-number -->
