### PR TITLE
bpo-34544: _Py_CoerceLegacyLocale() restores LC_CTYPE on fail

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -363,6 +363,13 @@ void
 _Py_CoerceLegacyLocale(int warn)
 {
 #ifdef PY_COERCE_C_LOCALE
+    char *oldloc = NULL;
+
+    oldloc = _PyMem_RawStrdup(setlocale(LC_CTYPE, NULL));
+    if (oldloc == NULL) {
+        return;
+    }
+
     const char *locale_override = getenv("LC_ALL");
     if (locale_override == NULL || *locale_override == '\0') {
         /* LC_ALL is also not set (or is set to an empty string) */
@@ -384,11 +391,16 @@ defined(HAVE_LANGINFO_H) && defined(CODESET)
 #endif
                 /* Successfully configured locale, so make it the default */
                 _coerce_default_locale_settings(warn, target);
-                return;
+                goto done;
             }
         }
     }
     /* No C locale warning here, as Py_Initialize will emit one later */
+
+    setlocale(LC_CTYPE, oldloc);
+
+done:
+    PyMem_RawFree(oldloc);
 #endif
 }
 


### PR DESCRIPTION
[bpo-34544](https://www.bugs.python.org/issue34544): If _Py_CoerceLegacyLocale() fails to coerce the C locale,
restore the LC_CTYPE locale to the its previous value.

<!-- issue-number: [bpo-34544](https://www.bugs.python.org/issue34544) -->
https://bugs.python.org/issue34544
<!-- /issue-number -->
