### PR TITLE
bpo-34544: pymain_read_conf() don't change LC_ALL

### DIFF
--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1291,18 +1291,7 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
     int init_legacy_encoding = Py_LegacyWindowsFSEncodingFlag;
 #endif
     _PyCoreConfig save_config = _PyCoreConfig_INIT;
-    char *oldloc = NULL;
     int res = -1;
-
-    oldloc = _PyMem_RawStrdup(setlocale(LC_ALL, NULL));
-    if (oldloc == NULL) {
-        pymain->err = _Py_INIT_NO_MEMORY();
-        goto done;
-    }
-
-    /* Reconfigure the locale to the default for this process */
-    _Py_SetLocaleFromEnv(LC_ALL);
-
     int locale_coerced = 0;
     int loops = 0;
 
@@ -1310,6 +1299,9 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
         pymain->err = _Py_INIT_NO_MEMORY();
         goto done;
     }
+
+    /* Set LC_CTYPE to the user preferred locale */
+    _Py_SetLocaleFromEnv(LC_CTYPE);
 
     while (1) {
         int utf8_mode = config->utf8_mode;
@@ -1392,10 +1384,6 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
 
 done:
     _PyCoreConfig_Clear(&save_config);
-    if (oldloc != NULL) {
-        setlocale(LC_ALL, oldloc);
-        PyMem_RawFree(oldloc);
-    }
     Py_UTF8Mode = init_utf8_mode ;
 #ifdef MS_WINDOWS
     Py_LegacyWindowsFSEncodingFlag = init_legacy_encoding;


### PR DESCRIPTION
[bpo-34485](https://www.bugs.python.org/issue34485), [bpo-34544](https://www.bugs.python.org/issue34544): Again, pymain_read_conf() leaves LC_ALL locale
unchanged: only modify LC_CTYPE.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34544](https://www.bugs.python.org/issue34544) -->
https://bugs.python.org/issue34544
<!-- /issue-number -->
