### PR TITLE
[3.7] bpo-34544: _Py_CoerceLegacyLocale() restores LC_CTYPE on fail (GH-9044)

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -475,6 +475,13 @@ void
 _Py_CoerceLegacyLocale(const _PyCoreConfig *config)
 {
 #ifdef PY_COERCE_C_LOCALE
+    char *oldloc = NULL;
+
+    oldloc = _PyMem_RawStrdup(setlocale(LC_CTYPE, NULL));
+    if (oldloc == NULL) {
+        return;
+    }
+
     const char *locale_override = getenv("LC_ALL");
     if (locale_override == NULL || *locale_override == '\0') {
         /* LC_ALL is also not set (or is set to an empty string) */
@@ -496,11 +503,16 @@ defined(HAVE_LANGINFO_H) && defined(CODESET)
 #endif
                 /* Successfully configured locale, so make it the default */
                 _coerce_default_locale_settings(config, target);
-                return;
+                goto done;
             }
         }
     }
     /* No C locale warning here, as Py_Initialize will emit one later */
+
+    setlocale(LC_CTYPE, oldloc);
+
+done:
+    PyMem_RawFree(oldloc);
 #endif
 }
 


### PR DESCRIPTION
[bpo-34544](https://www.bugs.python.org/issue34544): If _Py_CoerceLegacyLocale() fails to coerce the C locale,
restore the LC_CTYPE locale to the its previous value.

(cherry picked from commit 8ea09110d413829f71d979d8c7073008cb87fb03)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34544](https://www.bugs.python.org/issue34544) -->
https://bugs.python.org/issue34544
<!-- /issue-number -->
