### PR TITLE
bpo-34574: Prevent OrderedDict iterators from exhaustion during pickling.

### DIFF
--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -737,15 +737,10 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
         pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
         od = OrderedDict(pairs)
 
-        expected = (
-            ('keys', [k for k, v in pairs[:1]]),
-            ('values', [v for k, v in pairs[:1]]),
-            ('items', pairs[:1]),
-        )
-        for method_name, items in expected:
+        for method_name in ('keys', 'values', 'items'):
             meth = getattr(od, method_name)
-            with self.subTest(method_name=method_name):
-                for i in range(pickle.HIGHEST_PROTOCOL + 1):
+            for i in range(pickle.HIGHEST_PROTOCOL + 1):
+                with self.subTest(method_name=method_name, protocol=i):
                     it = iter(meth())
                     next(it)
                     p = pickle.dumps(it, i)

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -732,6 +732,26 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
                 del od['c']
         self.assertEqual(list(od), list('bdeaf'))
 
+    def test_iterators_pickling(self):
+        OrderedDict = self.OrderedDict
+        pairs = [('c', 1), ('b', 2), ('a', 3), ('d', 4), ('e', 5), ('f', 6)]
+        od = OrderedDict(pairs)
+
+        expected = (
+            ('keys', [k for k, v in pairs[:1]]),
+            ('values', [v for k, v in pairs[:1]]),
+            ('items', pairs[:1]),
+        )
+        for method_name, items in expected:
+            meth = getattr(od, method_name)
+            with self.subTest(method_name=method_name):
+                for i in range(pickle.HIGHEST_PROTOCOL + 1):
+                    it = iter(meth())
+                    next(it)
+                    p = pickle.dumps(it, i)
+                    unpickled = pickle.loads(p)
+                    self.assertEqual(list(it), list(unpickled))
+
 
 class PurePythonOrderedDictSubclassTests(PurePythonOrderedDictTests):
 

--- a/Lib/test/test_ordered_dict.py
+++ b/Lib/test/test_ordered_dict.py
@@ -739,13 +739,15 @@ class CPythonOrderedDictTests(OrderedDictTests, unittest.TestCase):
 
         for method_name in ('keys', 'values', 'items'):
             meth = getattr(od, method_name)
+            expected = list(meth())[1:]
             for i in range(pickle.HIGHEST_PROTOCOL + 1):
                 with self.subTest(method_name=method_name, protocol=i):
                     it = iter(meth())
                     next(it)
                     p = pickle.dumps(it, i)
                     unpickled = pickle.loads(p)
-                    self.assertEqual(list(it), list(unpickled))
+                    self.assertEqual(list(unpickled), expected)
+                    self.assertEqual(list(it), expected)
 
 
 class PurePythonOrderedDictSubclassTests(PurePythonOrderedDictTests):

--- a/Misc/NEWS.d/next/Library/2018-09-04-09-32-54.bpo-34574.X4RwYI.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-04-09-32-54.bpo-34574.X4RwYI.rst
@@ -1,0 +1,2 @@
+OrderedDict iterators are not exhausted during pickling anymore. Patch by
+Sergey Fedoseev.

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1840,10 +1840,12 @@ odictiter_reduce(odictiterobject *di)
     /* copy the iterator state */
     odictiterobject tmp = *di;
     Py_XINCREF(tmp.di_odict);
+    Py_XINCREF(tmp.di_current);
 
     /* iterate the temporary into a list */
     PyObject *list = PySequence_List((PyObject*)&tmp);
     Py_XDECREF(tmp.di_odict);
+    Py_XDECREF(tmp.di_current);
     if (list == NULL) {
         return NULL;
     }

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -1837,38 +1837,17 @@ PyDoc_STRVAR(reduce_doc, "Return state information for pickling");
 static PyObject *
 odictiter_reduce(odictiterobject *di)
 {
-    PyObject *list, *iter;
-
-    list = PyList_New(0);
-    if (!list)
-        return NULL;
+    /* copy the iterator state */
+    odictiterobject tmp = *di;
+    Py_XINCREF(tmp.di_odict);
 
     /* iterate the temporary into a list */
-    for(;;) {
-        PyObject *element = odictiter_iternext(di);
-        if (element) {
-            if (PyList_Append(list, element)) {
-                Py_DECREF(element);
-                Py_DECREF(list);
-                return NULL;
-            }
-            Py_DECREF(element);
-        }
-        else {
-            /* done iterating? */
-            break;
-        }
-    }
-    if (PyErr_Occurred()) {
-        Py_DECREF(list);
+    PyObject *list = PySequence_List((PyObject*)&tmp);
+    Py_XDECREF(tmp.di_odict);
+    if (list == NULL) {
         return NULL;
     }
-    iter = _PyObject_GetBuiltin("iter");
-    if (iter == NULL) {
-        Py_DECREF(list);
-        return NULL;
-    }
-    return Py_BuildValue("N(N)", iter, list);
+    return Py_BuildValue("N(N)", _PyObject_GetBuiltin("iter"), list);
 }
 
 static PyMethodDef odictiter_methods[] = {


### PR DESCRIPTION

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34574](https://www.bugs.python.org/issue34574) -->
https://bugs.python.org/issue34574
<!-- /issue-number -->
