### PR TITLE
bpo-34594: Fix usage of hardcoded errno values in the tests

### DIFF
--- a/Lib/test/test_spwd.py
+++ b/Lib/test/test_spwd.py
@@ -1,4 +1,3 @@
-import errno
 import os
 import unittest
 from test import support
@@ -68,9 +67,6 @@ class TestSpwdNonRoot(unittest.TestCase):
                 spwd.getspnam(name)
         except KeyError as exc:
             self.skipTest("spwd entry %r doesn't exist: %s" % (name, exc))
-        else:
-            self.assertEqual(str(cm.exception),
-                             f'[Errno {errno.EACCES}] Permission denied')
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_spwd.py
+++ b/Lib/test/test_spwd.py
@@ -1,3 +1,4 @@
+import errno
 import os
 import unittest
 from test import support
@@ -68,7 +69,8 @@ class TestSpwdNonRoot(unittest.TestCase):
         except KeyError as exc:
             self.skipTest("spwd entry %r doesn't exist: %s" % (name, exc))
         else:
-            self.assertEqual(str(cm.exception), '[Errno 13] Permission denied')
+            self.assertEqual(str(cm.exception),
+                             f'[Errno {errno.EACCES}] Permission denied')
 
 
 if __name__ == "__main__":

--- a/Lib/test/test_tabnanny.py
+++ b/Lib/test/test_tabnanny.py
@@ -5,6 +5,7 @@ Glossary:
 """
 from unittest import TestCase, mock
 from unittest import mock
+import errno
 import tabnanny
 import tokenize
 import tempfile
@@ -232,7 +233,8 @@ class TestCheck(TestCase):
     def test_when_no_file(self):
         """A python file which does not exist actually in system."""
         path = 'no_file.py'
-        err = f"{path!r}: I/O Error: [Errno 2] No such file or directory: {path!r}\n"
+        err = f"{path!r}: I/O Error: [Errno {errno.ENOENT}] " \
+              f"No such file or directory: {path!r}\n"
         self.verify_tabnanny_check(path, err=err)
 
     def test_errored_directory(self):

--- a/Misc/NEWS.d/next/Tests/2018-09-05-23-50-21.bpo-34594.tqL-GS.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-05-23-50-21.bpo-34594.tqL-GS.rst
@@ -1,0 +1,1 @@
+Fix usage of hardcoded ``errno`` values in the tests.


### PR DESCRIPTION


<!-- issue-number: [bpo-34594](https://www.bugs.python.org/issue34594) -->
https://bugs.python.org/issue34594
<!-- /issue-number -->
