### PR TITLE
bpo-30977: make uuid.UUID use __slots__ to reduce its memory footprint

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -315,6 +315,8 @@ class BaseTestUUID:
 
     def _setup_for_pickle(self):
         orig_uuid = sys.modules.get('uuid')
+        sys.modules['uuid'] = self.uuid
+
         def restore_uuid_module():
             if orig_uuid is not None:
                 sys.modules['uuid'] = orig_uuid

--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -320,17 +320,30 @@ class BaseTestUUID:
 
         # Python 2.7 protocol 0-2 pickles of u
         py27_pickles = [
-            b'ccopy_reg\n_reconstructor\np0\n(cuuid\nUUID\np1\nc__builtin__\nobject\np2\nNtp3\nRp4\n(dp5\nS\'int\'\np6\nL24197857161011715162171839636988778104L\nsb.',
-            b'ccopy_reg\n_reconstructor\nq\x00(cuuid\nUUID\nq\x01c__builtin__\nobject\nq\x02Ntq\x03Rq\x04}q\x05U\x03intq\x06L24197857161011715162171839636988778104L\nsb.',
-            b'\x80\x02cuuid\nUUID\nq\x00)\x81q\x01}q\x02U\x03intq\x03\x8a\x10xV4\x12xV4\x12xV4\x12xV4\x12sb.',
+            b'ccopy_reg\n_reconstructor\np0\n(cuuid\nUUID\np1\nc__builtin__\nob'
+            b'ject\np2\nNtp3\nRp4\n(dp5\nS\'int\'\np6\nL24197857161011715162171'
+            b'839636988778104L\nsb.',
+            b'ccopy_reg\n_reconstructor\nq\x00(cuuid\nUUID\nq\x01c__builtin__\n'
+            b'object\nq\x02Ntq\x03Rq\x04}q\x05U\x03intq\x06L2419785716101171516'
+            b'2171839636988778104L\nsb.',
+            b'\x80\x02cuuid\nUUID\nq\x00)\x81q\x01}q\x02U\x03intq\x03\x8a\x10xV'
+            b'4\x12xV4\x12xV4\x12xV4\x12sb.',
         ]
         # Python 3.6 protocol 0-4 pickles of u
         py36_pickles = [
-            b'ccopy_reg\n_reconstructor\np0\n(cuuid\nUUID\np1\nc__builtin__\nobject\np2\nNtp3\nRp4\n(dp5\nVint\np6\nL24197857161011715162171839636988778104L\nsb.',
-            b'ccopy_reg\n_reconstructor\nq\x00(cuuid\nUUID\nq\x01c__builtin__\nobject\nq\x02Ntq\x03Rq\x04}q\x05X\x03\x00\x00\x00intq\x06L24197857161011715162171839636988778104L\nsb.',
-            b'\x80\x02cuuid\nUUID\nq\x00)\x81q\x01}q\x02X\x03\x00\x00\x00intq\x03\x8a\x10xV4\x12xV4\x12xV4\x12xV4\x12sb.',
-            b'\x80\x03cuuid\nUUID\nq\x00)\x81q\x01}q\x02X\x03\x00\x00\x00intq\x03\x8a\x10xV4\x12xV4\x12xV4\x12xV4\x12sb.',
-            b'\x80\x04\x950\x00\x00\x00\x00\x00\x00\x00\x8c\x04uuid\x94\x8c\x04UUID\x94\x93\x94)\x81\x94}\x94\x8c\x03int\x94\x8a\x10xV4\x12xV4\x12xV4\x12xV4\x12sb.',
+            b'ccopy_reg\n_reconstructor\np0\n(cuuid\nUUID\np1\nc__builtin__\nob'
+            b'ject\np2\nNtp3\nRp4\n(dp5\nVint\np6\nL241978571610117151621718396'
+            b'36988778104L\nsb.',
+            b'ccopy_reg\n_reconstructor\nq\x00(cuuid\nUUID\nq\x01c__builtin__\n'
+            b'object\nq\x02Ntq\x03Rq\x04}q\x05X\x03\x00\x00\x00intq\x06L2419785'
+            b'7161011715162171839636988778104L\nsb.',
+            b'\x80\x02cuuid\nUUID\nq\x00)\x81q\x01}q\x02X\x03\x00\x00\x00intq'
+            b'\x03\x8a\x10xV4\x12xV4\x12xV4\x12xV4\x12sb.',
+            b'\x80\x03cuuid\nUUID\nq\x00)\x81q\x01}q\x02X\x03\x00\x00\x00intq'
+            b'\x03\x8a\x10xV4\x12xV4\x12xV4\x12xV4\x12sb.',
+            b'\x80\x04\x950\x00\x00\x00\x00\x00\x00\x00\x8c\x04uuid\x94\x8c\x04'
+            b'UUID\x94\x93\x94)\x81\x94}\x94\x8c\x03int\x94\x8a\x10xV4\x12xV4'
+            b'\x12xV4\x12xV4\x12sb.',
         ]
 
         for pickled in py27_pickles + py36_pickles:

--- a/Misc/NEWS.d/next/Library/2018-09-06-10-07-46.bpo-30977.bP661V.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-06-10-07-46.bpo-30977.bP661V.rst
@@ -1,0 +1,2 @@
+Make uuid.UUID use ``__slots__`` to reduce its memory footprint. Based on
+original patch by Wouter Bolsterlee.


### PR DESCRIPTION
Based on original patch by Wouter Bolsterlee. (see PR #2785)

Added pickle/unpickle logic to maintain forward and backward compatibility with other Python versions.

Manually tested that unpickling works with Python 3.6 and 2.7.

<!-- issue-number: [bpo-30977](https://www.bugs.python.org/issue30977) -->
https://bugs.python.org/issue30977
<!-- /issue-number -->
