### PR TITLE
bpo-34595: Add %T format to PyUnicode_FromFormatV()

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -519,6 +519,9 @@ APIs:
    | :attr:`%R`        | PyObject\*          | The result of calling          |
    |                   |                     | :c:func:`PyObject_Repr`.       |
    +-------------------+---------------------+--------------------------------+
+   | :attr:`%T`        | PyObject\*          | Object type name, equivalent   |
+   |                   |                     | to ``Py_TYPE(op)->tp_name``.   |
+   +-------------------+---------------------+--------------------------------+
 
    An unrecognized format character causes all the rest of the format string to be
    copied as-is to the result string, and any extra arguments discarded.
@@ -542,6 +545,9 @@ APIs:
    .. versionchanged:: 3.4
       Support width and precision formatter for ``"%s"``, ``"%A"``, ``"%U"``,
       ``"%V"``, ``"%S"``, ``"%R"`` added.
+
+   .. versionchanged:: 3.7
+      Support for ``"%T"`` (object type name) added.
 
 
 .. c:function:: PyObject* PyUnicode_FromFormatV(const char *format, va_list vargs)

--- a/Lib/test/test_unicode.py
+++ b/Lib/test/test_unicode.py
@@ -2655,6 +2655,10 @@ class CAPITest(unittest.TestCase):
         check_format(r"%A:'abc\xe9\uabcd\U0010ffff'",
                      b'%%A:%A', 'abc\xe9\uabcd\U0010ffff')
 
+        # test %T (object type name)
+        check_format(r"type name: str",
+                     b'type name: %T', 'text')
+
         # test %V
         check_format('repr=abc',
                      b'repr=%V', 'abc', b'xyz')

--- a/Misc/NEWS.d/next/C API/2018-09-06-11-17-49.bpo-34595.Hkz62y.rst
+++ b/Misc/NEWS.d/next/C API/2018-09-06-11-17-49.bpo-34595.Hkz62y.rst
@@ -1,0 +1,4 @@
+:c:func:`PyUnicode_FromFormatV`: add ``%T`` format to
+:c:func:`PyUnicode_FromFormatV`, and so to :c:func:`PyUnicode_FromFormat`
+and :c:func:`PyErr_Format`, to format an object type name: equivalent to
+"%s" with ``Py_TYPE(obj)->tp_name``.


### PR DESCRIPTION
* Add %T format to PyUnicode_FromFormatV(), and so to
  PyUnicode_FromFormat() and PyErr_Format(), to format an object type
  name: equivalent to "%s" with Py_TYPE(obj)->tp_name.
* Replace Py_TYPE(obj)->tp_name with %T format in unicodeobject.c.
* Add unit test on %T format.
* Rename unicode_fromformat_write_cstr() to
  unicode_fromformat_write_utf8(), to make the intent more explicit.

<!-- issue-number: [bpo-34595](https://www.bugs.python.org/issue34595) -->
https://bugs.python.org/issue34595
<!-- /issue-number -->
