### PR TITLE
Revert "Fix misindented yaml in logging how to example (GH-8604)"

### DIFF
--- a/Doc/howto/logging.rst
+++ b/Doc/howto/logging.rst
@@ -750,9 +750,9 @@ the new dictionary-based approach:
         level: DEBUG
         handlers: [console]
         propagate: no
-      root:
-        level: DEBUG
-        handlers: [console]
+    root:
+      level: DEBUG
+      handlers: [console]
 
 For more information about logging using a dictionary, see
 :ref:`logging-config-api`.


### PR DESCRIPTION
While reading the [logging cookbook](https://docs.python.org/3/howto/logging-cookbook.html#a-more-elaborate-multiprocessing-example), I realized my mistake.

This reverts commit 10b59f1b019cd00c940dd7f4a74c4f667a20f25f.

Revert PR #8604

This needs also to be backported to Branch 3.7 and branch 3.6