### PR TITLE
bpo-34596: Fallback to a default reason when @unittest.skip is uncalled

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -10,6 +10,7 @@ import warnings
 import collections
 import contextlib
 import traceback
+import types
 
 from . import result
 from .util import (strclass, safe_repr, _count_diff_all_purpose,
@@ -98,6 +99,10 @@ def skip(reason):
         test_item.__unittest_skip__ = True
         test_item.__unittest_skip_why__ = reason
         return test_item
+    if isinstance(reason, types.FunctionType):
+        test_item = reason
+        reason = 'unconditionally'
+        return decorator(test_item)
     return decorator
 
 def skipIf(condition, reason):

--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -101,7 +101,7 @@ def skip(reason):
         return test_item
     if isinstance(reason, types.FunctionType):
         test_item = reason
-        reason = 'unconditionally'
+        reason = ''
         return decorator(test_item)
     return decorator
 

--- a/Lib/unittest/test/test_skipping.py
+++ b/Lib/unittest/test/test_skipping.py
@@ -255,6 +255,17 @@ class Test_TestSkipping(unittest.TestCase):
         suite.run(result)
         self.assertEqual(result.skipped, [(test, "testing")])
 
+    def test_skip_without_reason(self):
+        class Foo(unittest.TestCase):
+            @unittest.skip
+            def test_1(self):
+                pass
+
+        result = unittest.TestResult()
+        test = Foo("test_1")
+        suite = unittest.TestSuite([test])
+        suite.run(result)
+        self.assertEqual(result.skipped, [(test, "unconditionally")])
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/unittest/test/test_skipping.py
+++ b/Lib/unittest/test/test_skipping.py
@@ -265,7 +265,7 @@ class Test_TestSkipping(unittest.TestCase):
         test = Foo("test_1")
         suite = unittest.TestSuite([test])
         suite.run(result)
-        self.assertEqual(result.skipped, [(test, "unconditionally")])
+        self.assertEqual(result.skipped, [(test, "")])
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Tests/2018-09-07-01-18-27.bpo-34596.r2-EGd.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-07-01-18-27.bpo-34596.r2-EGd.rst
@@ -1,2 +1,2 @@
-Fallback to a default reason when @unittest.skip is uncalled. Patch by
+Fallback to a default reason when :func:`unittest.skip` is uncalled. Patch by
 Naitree Zhu.

--- a/Misc/NEWS.d/next/Tests/2018-09-07-01-18-27.bpo-34596.r2-EGd.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-07-01-18-27.bpo-34596.r2-EGd.rst
@@ -1,0 +1,2 @@
+Fallback to a default reason when @unittest.skip is uncalled. Patch by
+Naitree Zhu.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

-   Provide a default reason string when `@unittest.skip` decorator is used in uncalled form.
-   Add a test case for this change.

<!-- issue-number: [bpo-34596](https://www.bugs.python.org/issue34596) -->
https://bugs.python.org/issue34596
<!-- /issue-number -->
