### PR TITLE
[3.6] bpo-34594: Don't hardcode errno values in the tests. (GH-9076)

### DIFF
--- a/Lib/test/test_spwd.py
+++ b/Lib/test/test_spwd.py
@@ -67,8 +67,6 @@ class TestSpwdNonRoot(unittest.TestCase):
                 spwd.getspnam(name)
         except KeyError as exc:
             self.skipTest("spwd entry %r doesn't exist: %s" % (name, exc))
-        else:
-            self.assertEqual(str(cm.exception), '[Errno 13] Permission denied')
 
 
 if __name__ == "__main__":

--- a/Misc/NEWS.d/next/Tests/2018-09-05-23-50-21.bpo-34594.tqL-GS.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-05-23-50-21.bpo-34594.tqL-GS.rst
@@ -1,0 +1,1 @@
+Fix usage of hardcoded ``errno`` values in the tests.


### PR DESCRIPTION
(cherry picked from commit b03c2c51909e3b5b5966d86a2829b5ddf2d496aa)


<!-- issue-number: [bpo-34594](https://www.bugs.python.org/issue34594) -->
https://bugs.python.org/issue34594
<!-- /issue-number -->
