### PR TITLE
bpo-34605, pty: Avoid master/slave terms

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1007,7 +1007,7 @@ or `the MSDN <https://msdn.microsoft.com/en-us/library/z0kc8e3z.aspx>`_ on Windo
    .. index:: module: pty
 
    Open a new pseudo-terminal pair. Return a pair of file descriptors
-   ``(master, slave)`` for the pty and the tty, respectively. The new file
+   ``(parent, child)`` for the pty and the tty, respectively. The new file
    descriptors are :ref:`non-inheritable <fd_inheritance>`. For a (slightly) more
    portable approach, use the :mod:`pty` module.
 
@@ -3315,7 +3315,7 @@ written in Python, such as a mail server's external command delivery program.
    Fork a child process, using a new pseudo-terminal as the child's controlling
    terminal. Return a pair of ``(pid, fd)``, where *pid* is ``0`` in the child, the
    new child's process id in the parent, and *fd* is the file descriptor of the
-   master end of the pseudo-terminal.  For a more portable approach, use the
+   parent end of the pseudo-terminal.  For a more portable approach, use the
    :mod:`pty` module.  If an error occurs :exc:`OSError` is raised.
 
    Availability: some flavors of Unix.

--- a/Doc/library/pty.rst
+++ b/Doc/library/pty.rst
@@ -36,16 +36,16 @@ The :mod:`pty` module defines the following functions:
 
    Open a new pseudo-terminal pair, using :func:`os.openpty` if possible, or
    emulation code for generic Unix systems. Return a pair of file descriptors
-   ``(master, slave)``, for the master and the slave end, respectively.
+   ``(parent, child)``, for the parent and the child end, respectively.
 
 
-.. function:: spawn(argv[, master_read[, stdin_read]])
+.. function:: spawn(argv[, parent_read[, stdin_read]])
 
    Spawn a process, and connect its controlling terminal with the current
    process's standard io. This is often used to baffle programs which insist on
    reading from the controlling terminal.
 
-   The functions *master_read* and *stdin_read* should be functions which read from
+   The functions *parent_read* and *stdin_read* should be functions which read from
    a file descriptor. The defaults try to read 1024 bytes each time they are
    called.
 

--- a/Lib/pty.py
+++ b/Lib/pty.py
@@ -19,35 +19,35 @@ STDERR_FILENO = 2
 CHILD = 0
 
 def openpty():
-    """openpty() -> (master_fd, slave_fd)
+    """openpty() -> (parent_fd, child_fd)
     Open a pty master/slave pair, using os.openpty() if possible."""
 
     try:
         return os.openpty()
     except (AttributeError, OSError):
         pass
-    master_fd, slave_name = _open_terminal()
-    slave_fd = slave_open(slave_name)
-    return master_fd, slave_fd
+    parent_fd, child_name = _open_terminal()
+    child_fd = child_open(child_name)
+    return parent_fd, child_fd
 
 def master_open():
-    """master_open() -> (master_fd, slave_name)
+    """master_open() -> (parent_fd, child_name)
     Open a pty master and return the fd, and the filename of the slave end.
     Deprecated, use openpty() instead."""
 
     try:
-        master_fd, slave_fd = os.openpty()
+        parent_fd, child_fd = os.openpty()
     except (AttributeError, OSError):
         pass
     else:
-        slave_name = os.ttyname(slave_fd)
-        os.close(slave_fd)
-        return master_fd, slave_name
+        child_name = os.ttyname(child_fd)
+        os.close(child_fd)
+        return parent_fd, child_name
 
     return _open_terminal()
 
 def _open_terminal():
-    """Open pty master and return (master_fd, tty_name)."""
+    """Open pty master and return (parent_fd, tty_name)."""
     for x in 'pqrstuvwxyzPQRST':
         for y in '0123456789abcdef':
             pty_name = '/dev/pty' + x + y
@@ -58,8 +58,8 @@ def _open_terminal():
             return (fd, '/dev/tty' + x + y)
     raise OSError('out of pty devices')
 
-def slave_open(tty_name):
-    """slave_open(tty_name) -> slave_fd
+def child_open(tty_name):
+    """child_open(tty_name) -> child_fd
     Open the pty slave and acquire the controlling terminal, returning
     opened filedescriptor.
     Deprecated, use openpty() instead."""
@@ -76,8 +76,12 @@ def slave_open(tty_name):
         pass
     return result
 
+# bpo-34605: slave_open() has been renamed to child_open(),
+# but keep slave_open alias for backward compatibility.
+slave_open = child_open
+
 def fork():
-    """fork() -> (pid, master_fd)
+    """fork() -> (pid, parent_fd)
     Fork and make the child a session leader with a controlling terminal."""
 
     try:
@@ -93,28 +97,28 @@ def fork():
                 pass
         return pid, fd
 
-    master_fd, slave_fd = openpty()
+    parent_fd, child_fd = openpty()
     pid = os.fork()
     if pid == CHILD:
         # Establish a new session.
         os.setsid()
-        os.close(master_fd)
+        os.close(parent_fd)
 
         # Slave becomes stdin/stdout/stderr of child.
-        os.dup2(slave_fd, STDIN_FILENO)
-        os.dup2(slave_fd, STDOUT_FILENO)
-        os.dup2(slave_fd, STDERR_FILENO)
-        if (slave_fd > STDERR_FILENO):
-            os.close (slave_fd)
+        os.dup2(child_fd, STDIN_FILENO)
+        os.dup2(child_fd, STDOUT_FILENO)
+        os.dup2(child_fd, STDERR_FILENO)
+        if (child_fd > STDERR_FILENO):
+            os.close (child_fd)
 
         # Explicitly open the tty to make it become a controlling tty.
         tmp_fd = os.open(os.ttyname(STDOUT_FILENO), os.O_RDWR)
         os.close(tmp_fd)
     else:
-        os.close(slave_fd)
+        os.close(child_fd)
 
     # Parent and child process.
-    return pid, master_fd
+    return pid, parent_fd
 
 def _writen(fd, data):
     """Write all the data to a descriptor."""
@@ -126,18 +130,18 @@ def _read(fd):
     """Default read function."""
     return os.read(fd, 1024)
 
-def _copy(master_fd, master_read=_read, stdin_read=_read):
+def _copy(parent_fd, master_read=_read, stdin_read=_read):
     """Parent copy loop.
     Copies
             pty master -> standard output   (master_read)
             standard input -> pty master    (stdin_read)"""
-    fds = [master_fd, STDIN_FILENO]
+    fds = [parent_fd, STDIN_FILENO]
     while True:
         rfds, wfds, xfds = select(fds, [], [])
-        if master_fd in rfds:
-            data = master_read(master_fd)
+        if parent_fd in rfds:
+            data = master_read(parent_fd)
             if not data:  # Reached EOF.
-                fds.remove(master_fd)
+                fds.remove(parent_fd)
             else:
                 os.write(STDOUT_FILENO, data)
         if STDIN_FILENO in rfds:
@@ -145,13 +149,13 @@ def _copy(master_fd, master_read=_read, stdin_read=_read):
             if not data:
                 fds.remove(STDIN_FILENO)
             else:
-                _writen(master_fd, data)
+                _writen(parent_fd, data)
 
 def spawn(argv, master_read=_read, stdin_read=_read):
     """Create a spawned process."""
     if type(argv) == type(''):
         argv = (argv,)
-    pid, master_fd = fork()
+    pid, parent_fd = fork()
     if pid == CHILD:
         os.execlp(argv[0], *argv)
     try:
@@ -161,10 +165,10 @@ def spawn(argv, master_read=_read, stdin_read=_read):
     except tty.error:    # This is the same as termios.error
         restore = 0
     try:
-        _copy(master_fd, master_read, stdin_read)
+        _copy(parent_fd, master_read, stdin_read)
     except OSError:
         if restore:
             tty.tcsetattr(STDIN_FILENO, tty.TCSAFLUSH, mode)
 
-    os.close(master_fd)
+    os.close(parent_fd)
     return os.waitpid(pid, 0)[1]

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -1500,12 +1500,12 @@ class EventLoopTestsMixin:
     def test_read_pty_output(self):
         proto = MyReadPipeProto(loop=self.loop)
 
-        master, slave = os.openpty()
-        master_read_obj = io.open(master, 'rb', 0)
+        parent, child = os.openpty()
+        parent_read_obj = io.open(parent, 'rb', 0)
 
         async def connect():
             t, p = await self.loop.connect_read_pipe(lambda: proto,
-                                                     master_read_obj)
+                                                     parent_read_obj)
             self.assertIs(p, proto)
             self.assertIs(t, proto.transport)
             self.assertEqual(['INITIAL', 'CONNECTED'], proto.state)
@@ -1513,16 +1513,16 @@ class EventLoopTestsMixin:
 
         self.loop.run_until_complete(connect())
 
-        os.write(slave, b'1')
+        os.write(child, b'1')
         test_utils.run_until(self.loop, lambda: proto.nbytes)
         self.assertEqual(1, proto.nbytes)
 
-        os.write(slave, b'2345')
+        os.write(child, b'2345')
         test_utils.run_until(self.loop, lambda: proto.nbytes >= 5)
         self.assertEqual(['INITIAL', 'CONNECTED'], proto.state)
         self.assertEqual(5, proto.nbytes)
 
-        os.close(slave)
+        os.close(child)
         proto.transport.close()
         self.loop.run_until_complete(proto.done)
         self.assertEqual(
@@ -1598,11 +1598,11 @@ class EventLoopTestsMixin:
     # older than 10.6 (Snow Leopard)
     @support.requires_mac_ver(10, 6)
     def test_write_pty(self):
-        master, slave = os.openpty()
-        slave_write_obj = io.open(slave, 'wb', 0)
+        parent, child = os.openpty()
+        child_write_obj = io.open(child, 'wb', 0)
 
         proto = MyWritePipeProto(loop=self.loop)
-        connect = self.loop.connect_write_pipe(lambda: proto, slave_write_obj)
+        connect = self.loop.connect_write_pipe(lambda: proto, child_write_obj)
         transport, p = self.loop.run_until_complete(connect)
         self.assertIs(p, proto)
         self.assertIs(transport, proto.transport)
@@ -1612,7 +1612,7 @@ class EventLoopTestsMixin:
 
         data = bytearray()
         def reader(data):
-            chunk = os.read(master, 1024)
+            chunk = os.read(parent, 1024)
             data += chunk
             return len(data)
 
@@ -1626,7 +1626,7 @@ class EventLoopTestsMixin:
         self.assertEqual(b'12345', data)
         self.assertEqual('CONNECTED', proto.state)
 
-        os.close(master)
+        os.close(parent)
 
         # extra info is available
         self.assertIsNotNone(proto.transport.get_extra_info('pipe'))
@@ -1642,14 +1642,14 @@ class EventLoopTestsMixin:
     # older than 10.6 (Snow Leopard)
     @support.requires_mac_ver(10, 6)
     def test_bidirectional_pty(self):
-        master, read_slave = os.openpty()
-        write_slave = os.dup(read_slave)
-        tty.setraw(read_slave)
+        parent, read_child = os.openpty()
+        write_child = os.dup(read_child)
+        tty.setraw(read_child)
 
-        slave_read_obj = io.open(read_slave, 'rb', 0)
+        child_read_obj = io.open(read_child, 'rb', 0)
         read_proto = MyReadPipeProto(loop=self.loop)
         read_connect = self.loop.connect_read_pipe(lambda: read_proto,
-                                                   slave_read_obj)
+                                                   child_read_obj)
         read_transport, p = self.loop.run_until_complete(read_connect)
         self.assertIs(p, read_proto)
         self.assertIs(read_transport, read_proto.transport)
@@ -1657,10 +1657,10 @@ class EventLoopTestsMixin:
         self.assertEqual(0, read_proto.nbytes)
 
 
-        slave_write_obj = io.open(write_slave, 'wb', 0)
+        child_write_obj = io.open(write_child, 'wb', 0)
         write_proto = MyWritePipeProto(loop=self.loop)
         write_connect = self.loop.connect_write_pipe(lambda: write_proto,
-                                                     slave_write_obj)
+                                                     child_write_obj)
         write_transport, p = self.loop.run_until_complete(write_connect)
         self.assertIs(p, write_proto)
         self.assertIs(write_transport, write_proto.transport)
@@ -1668,7 +1668,7 @@ class EventLoopTestsMixin:
 
         data = bytearray()
         def reader(data):
-            chunk = os.read(master, 1024)
+            chunk = os.read(parent, 1024)
             data += chunk
             return len(data)
 
@@ -1678,7 +1678,7 @@ class EventLoopTestsMixin:
         self.assertEqual(['INITIAL', 'CONNECTED'], read_proto.state)
         self.assertEqual('CONNECTED', write_proto.state)
 
-        os.write(master, b'a')
+        os.write(parent, b'a')
         test_utils.run_until(self.loop, lambda: read_proto.nbytes >= 1,
                              timeout=10)
         self.assertEqual(['INITIAL', 'CONNECTED'], read_proto.state)
@@ -1691,14 +1691,14 @@ class EventLoopTestsMixin:
         self.assertEqual(['INITIAL', 'CONNECTED'], read_proto.state)
         self.assertEqual('CONNECTED', write_proto.state)
 
-        os.write(master, b'bcde')
+        os.write(parent, b'bcde')
         test_utils.run_until(self.loop, lambda: read_proto.nbytes >= 5,
                              timeout=10)
         self.assertEqual(['INITIAL', 'CONNECTED'], read_proto.state)
         self.assertEqual(5, read_proto.nbytes)
         self.assertEqual('CONNECTED', write_proto.state)
 
-        os.close(master)
+        os.close(parent)
 
         read_transport.close()
         self.loop.run_until_complete(read_proto.done)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1669,7 +1669,7 @@ class PtyTests(unittest.TestCase):
         # Check the result was got and corresponds to the user's terminal input
         if len(lines) != 2:
             # Something went wrong, try to get at stderr
-            # Beware of Linux raising EIO when the slave is closed
+            # Beware of Linux raising EIO when the child is closed
             child_output = bytearray()
             while True:
                 try:

--- a/Lib/test/test_openpty.py
+++ b/Lib/test/test_openpty.py
@@ -8,14 +8,14 @@ if not hasattr(os, "openpty"):
 
 class OpenptyTest(unittest.TestCase):
     def test(self):
-        master, slave = os.openpty()
-        self.addCleanup(os.close, master)
-        self.addCleanup(os.close, slave)
-        if not os.isatty(slave):
-            self.fail("Slave-end of pty is not a terminal.")
+        parent, child = os.openpty()
+        self.addCleanup(os.close, parent)
+        self.addCleanup(os.close, child)
+        if not os.isatty(child):
+            self.fail("Child-end of pty is not a terminal.")
 
-        os.write(slave, b'Ping!')
-        self.assertEqual(os.read(master, 1024), b'Ping!')
+        os.write(child, b'Ping!')
+        self.assertEqual(os.read(parent, 1024), b'Ping!')
 
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -3189,11 +3189,11 @@ class FDInheritanceTests(unittest.TestCase):
 
     @unittest.skipUnless(hasattr(os, 'openpty'), "need os.openpty()")
     def test_openpty(self):
-        master_fd, slave_fd = os.openpty()
-        self.addCleanup(os.close, master_fd)
-        self.addCleanup(os.close, slave_fd)
-        self.assertEqual(os.get_inheritable(master_fd), False)
-        self.assertEqual(os.get_inheritable(slave_fd), False)
+        parent_fd, child_fd = os.openpty()
+        self.addCleanup(os.close, parent_fd)
+        self.addCleanup(os.close, child_fd)
+        self.assertEqual(os.get_inheritable(parent_fd), False)
+        self.assertEqual(os.get_inheritable(child_fd), False)
 
 
 class PathTConverterTests(unittest.TestCase):

--- a/Lib/test/test_readline.py
+++ b/Lib/test/test_readline.py
@@ -282,10 +282,10 @@ readline.write_history_file(history_file)
 def run_pty(script, input=b"dummy input\r", env=None):
     pty = import_module('pty')
     output = bytearray()
-    [master, slave] = pty.openpty()
+    [parent, child] = pty.openpty()
     args = (sys.executable, '-c', script)
-    proc = subprocess.Popen(args, stdin=slave, stdout=slave, stderr=slave, env=env)
-    os.close(slave)
+    proc = subprocess.Popen(args, stdin=child, stdout=child, stderr=child, env=env)
+    os.close(child)
     with ExitStack() as cleanup:
         cleanup.enter_context(proc)
         def terminate(proc):
@@ -295,22 +295,22 @@ def run_pty(script, input=b"dummy input\r", env=None):
                 # Workaround for Open/Net BSD bug (Issue 16762)
                 pass
         cleanup.callback(terminate, proc)
-        cleanup.callback(os.close, master)
+        cleanup.callback(os.close, parent)
         # Avoid using DefaultSelector and PollSelector. Kqueue() does not
         # work with pseudo-terminals on OS X < 10.9 (Issue 20365) and Open
         # BSD (Issue 20667). Poll() does not work with OS X 10.6 or 10.4
         # either (Issue 20472). Hopefully the file descriptor is low enough
         # to use with select().
         sel = cleanup.enter_context(selectors.SelectSelector())
-        sel.register(master, selectors.EVENT_READ | selectors.EVENT_WRITE)
-        os.set_blocking(master, False)
+        sel.register(parent, selectors.EVENT_READ | selectors.EVENT_WRITE)
+        os.set_blocking(parent, False)
         while True:
             for [_, events] in sel.select():
                 if events & selectors.EVENT_READ:
                     try:
-                        chunk = os.read(master, 0x10000)
+                        chunk = os.read(parent, 0x10000)
                     except OSError as err:
-                        # Linux raises EIO when slave is closed (Issue 5380)
+                        # Linux raises EIO when child is closed (Issue 5380)
                         if err.errno != EIO:
                             raise
                         chunk = b""
@@ -319,14 +319,14 @@ def run_pty(script, input=b"dummy input\r", env=None):
                     output.extend(chunk)
                 if events & selectors.EVENT_WRITE:
                     try:
-                        input = input[os.write(master, input):]
+                        input = input[os.write(parent, input):]
                     except OSError as err:
-                        # Apparently EIO means the slave was closed
+                        # Apparently EIO means the child was closed
                         if err.errno != EIO:
                             raise
                         input = b""  # Stop writing
                     if not input:
-                        sel.modify(master, selectors.EVENT_READ)
+                        sel.modify(parent, selectors.EVENT_READ)
 
 
 if __name__ == "__main__":

--- a/Modules/clinic/posixmodule.c.h
+++ b/Modules/clinic/posixmodule.c.h
@@ -2343,8 +2343,8 @@ PyDoc_STRVAR(os_openpty__doc__,
 "\n"
 "Open a pseudo-terminal.\n"
 "\n"
-"Return a tuple of (master_fd, slave_fd) containing open file descriptors\n"
-"for both the master and slave ends.");
+"Return a tuple of (parent_fd, child_fd) containing open file descriptors\n"
+"for both the parent and child ends.");
 
 #define OS_OPENPTY_METHODDEF    \
     {"openpty", (PyCFunction)os_openpty, METH_NOARGS, os_openpty__doc__},
@@ -2368,7 +2368,7 @@ PyDoc_STRVAR(os_forkpty__doc__,
 "\n"
 "Fork a new process with a new pseudo-terminal as controlling tty.\n"
 "\n"
-"Returns a tuple of (pid, master_fd).\n"
+"Returns a tuple of (pid, parent_fd).\n"
 "Like fork(), return pid of 0 to the child process,\n"
 "and pid of child to the parent process.\n"
 "To both, return fd of newly opened pseudo-terminal.");
@@ -3927,7 +3927,7 @@ PyDoc_STRVAR(os_isatty__doc__,
 "Return True if the fd is connected to a terminal.\n"
 "\n"
 "Return True if the file descriptor is an open file descriptor\n"
-"connected to the slave end of a terminal.");
+"connected to the child end of a terminal.");
 
 #define OS_ISATTY_METHODDEF    \
     {"isatty", (PyCFunction)os_isatty, METH_O, os_isatty__doc__},
@@ -6627,4 +6627,4 @@ exit:
 #ifndef OS_GETRANDOM_METHODDEF
     #define OS_GETRANDOM_METHODDEF
 #endif /* !defined(OS_GETRANDOM_METHODDEF) */
-/*[clinic end generated code: output=47fb6a3e88cba6d9 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d4aee56f190a791d input=a9049054013a1b77]*/


### PR DESCRIPTION
* pty.spawn(): rename master_read parameter to parent_read
* Rename pty.slave_open() to pty.child_open(), but keep an
  pty.slave_open alis to pty.child_open for backward compatibility
* os.openpty(), os.forkpty(): rename master_fd/slave_fd
  to parent_fd/child_fd
* Rename internal variables:

  * Rename master_fd/slave_fd to parent_fd/child_fd
  * Rename slave_name to child_name

<!-- issue-number: [bpo-34605](https://www.bugs.python.org/issue34605) -->
https://bugs.python.org/issue34605
<!-- /issue-number -->
