### PR TITLE
bpo-34605: Avoid master/slave terms

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -181,7 +181,7 @@ The :mod:`gc` module provides the following functions:
    fork() call to make the gc copy-on-write friendly or to speed up collection.
    Also collection before a POSIX fork() call may free pages for future
    allocation which can cause copy-on-write too so it's advised to disable gc
-   in master process and freeze before fork and enable gc in child process.
+   in parent process and freeze before fork and enable gc in child process.
 
    .. versionadded:: 3.7
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -435,7 +435,7 @@ process which created it.
 
    (If you try this it will actually output three full tracebacks
    interleaved in a semi-random fashion, and then you may have to
-   stop the master process somehow.)
+   stop the parent process somehow.)
 
 
 Reference

--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -223,7 +223,7 @@ class install(Command):
 
     def finalize_options(self):
         """Finalizes options."""
-        # This method (and its pliant slaves, like 'finalize_unix()',
+        # This method (and its pliant childs, like 'finalize_unix()',
         # 'finalize_other()', and 'select_scheme()') is where the default
         # installation directories for modules, extension modules, and
         # anything else we care to install from a Python module

--- a/Lib/optparse.py
+++ b/Lib/optparse.py
@@ -929,7 +929,7 @@ class OptionContainer:
         self.set_description(description)
 
     def _create_option_mappings(self):
-        # For use by OptionParser constructor -- create the master
+        # For use by OptionParser constructor -- create the main
         # option mappings used by this OptionParser and all
         # OptionGroups that it owns.
         self._short_opt = {}            # single letter -> Option instance

--- a/Lib/sre_parse.py
+++ b/Lib/sre_parse.py
@@ -72,7 +72,7 @@ class Verbose(Exception):
     pass
 
 class Pattern:
-    # master pattern object.  keeps track of global attributes
+    # main pattern object.  keeps track of global attributes
     def __init__(self):
         self.flags = 0
         self.groupdict = {}

--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -3494,7 +3494,7 @@ class ThreadedTests(unittest.TestCase):
         client_context, server_context, hostname = testing_context()
         # OpenSSL enables all TLS 1.3 ciphers, enforce TLS 1.2 for test
         client_context.options |= ssl.OP_NO_TLSv1_3
-        # Force different suites on client and master
+        # Force different suites on client and server
         client_context.set_ciphers("AES128")
         server_context.set_ciphers("AES256")
         with ThreadedEchoServer(context=server_context) as server:

--- a/Tools/README
+++ b/Tools/README
@@ -1,7 +1,7 @@
 This directory contains a number of Python programs that are useful
 while building or extending Python.
 
-buildbot        Batchfiles for running on Windows buildslaves.
+buildbot        Batchfiles for running on Windows buildbot workers.
 
 ccbench         A Python threads-based concurrency benchmark. (*)
 


### PR DESCRIPTION
* Replace "master process" with "parent process"
* Replace "master option mappings" with "main option mappings"
* Replace "master pattern object" with "main pattern object"
* ssl: replace "master" with "server"
* And some other similar changes

<!-- issue-number: [bpo-34605](https://www.bugs.python.org/issue34605) -->
https://bugs.python.org/issue34605
<!-- /issue-number -->
