### PR TITLE
bpo-34595: Format string using %T in Python/

### DIFF
--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -671,9 +671,9 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
 
     res = 0; /* if no error occurs, this stays 0 to the end */
     if (numfields < PyTuple_GET_SIZE(args)) {
-        PyErr_Format(PyExc_TypeError, "%.400s constructor takes at most "
+        PyErr_Format(PyExc_TypeError, "%T constructor takes at most "
                      "%zd positional argument%s",
-                     Py_TYPE(self)->tp_name,
+                     self,
                      numfields, numfields == 1 ? "" : "s");
         res = -1;
         goto cleanup;
@@ -1227,8 +1227,8 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
     if (isinstance == -1)
         return NULL;
     if (!isinstance) {
-        PyErr_Format(PyExc_TypeError, "expected %s node, got %.400s",
-                     req_name[mode], Py_TYPE(ast)->tp_name);
+        PyErr_Format(PyExc_TypeError, "expected %s node, got %T",
+                     req_name[mode], ast);
         return NULL;
     }
     if (obj2ast_mod(ast, &res, arena) != 0)

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -552,9 +552,9 @@ ast_type_init(PyObject *self, PyObject *args, PyObject *kw)
 
     res = 0; /* if no error occurs, this stays 0 to the end */
     if (numfields < PyTuple_GET_SIZE(args)) {
-        PyErr_Format(PyExc_TypeError, "%.400s constructor takes at most "
+        PyErr_Format(PyExc_TypeError, "%T constructor takes at most "
                      "%zd positional argument%s",
-                     Py_TYPE(self)->tp_name,
+                     self,
                      numfields, numfields == 1 ? "" : "s");
         res = -1;
         goto cleanup;
@@ -8383,8 +8383,8 @@ mod_ty PyAST_obj2mod(PyObject* ast, PyArena* arena, int mode)
     if (isinstance == -1)
         return NULL;
     if (!isinstance) {
-        PyErr_Format(PyExc_TypeError, "expected %s node, got %.400s",
-                     req_name[mode], Py_TYPE(ast)->tp_name);
+        PyErr_Format(PyExc_TypeError, "expected %s node, got %T",
+                     req_name[mode], ast);
         return NULL;
     }
     if (obj2ast_mod(ast, &res, arena) != 0)

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -108,8 +108,8 @@ get_once_registry(void)
     if (!PyDict_Check(registry)) {
         PyErr_Format(PyExc_TypeError,
                      MODULE_NAME ".onceregistry must be a dict, "
-                     "not '%.200s'",
-                     Py_TYPE(registry)->tp_name);
+                     "not '%T'",
+                     registry);
         Py_DECREF(registry);
         return NULL;
     }
@@ -135,8 +135,8 @@ get_default_action(void)
     if (!PyUnicode_Check(default_action)) {
         PyErr_Format(PyExc_TypeError,
                      MODULE_NAME ".defaultaction must be a string, "
-                     "not '%.200s'",
-                     Py_TYPE(default_action)->tp_name);
+                     "not '%T'",
+                     default_action);
         Py_DECREF(default_action);
         return NULL;
     }
@@ -194,8 +194,8 @@ get_filter(PyObject *category, PyObject *text, Py_ssize_t lineno,
 
         if (!PyUnicode_Check(action)) {
             PyErr_Format(PyExc_TypeError,
-                         "action must be a string, not '%.200s'",
-                         Py_TYPE(action)->tp_name);
+                         "action must be a string, not '%T'",
+                         action);
             Py_DECREF(tmp_item);
             return NULL;
         }
@@ -759,8 +759,8 @@ get_category(PyObject *message, PyObject *category)
        PyObject_IsSubclass raised an error */
     if (rc == -1 || rc == 0) {
         PyErr_Format(PyExc_TypeError,
-                     "category must be a Warning subclass, not '%s'",
-                     Py_TYPE(category)->tp_name);
+                     "category must be a Warning subclass, not '%T'",
+                     category);
         return NULL;
     }
 
@@ -891,8 +891,8 @@ warnings_warn_explicit(PyObject *self, PyObject *args, PyObject *kwds)
     if (module_globals && module_globals != Py_None) {
         if (!PyDict_Check(module_globals)) {
             PyErr_Format(PyExc_TypeError,
-                         "module_globals must be a dict, not '%.200s'",
-                         Py_TYPE(module_globals)->tp_name);
+                         "module_globals must be a dict, not '%T'",
+                         module_globals);
             return NULL;
         }
 

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -290,8 +290,8 @@ validate_expr(expr_ty exp, expr_context_ty ctx)
     case Constant_kind:
         if (!validate_constant(exp->v.Constant.value)) {
             PyErr_Format(PyExc_TypeError,
-                         "got an invalid type in Constant: %s",
-                         Py_TYPE(exp->v.Constant.value)->tp_name);
+                         "got an invalid type in Constant: %T",
+                         exp->v.Constant.value);
             return 0;
         }
         return 1;
@@ -655,9 +655,8 @@ new_identifier(const char *n, struct compiling *c)
             return NULL;
         if (!PyUnicode_Check(id2)) {
             PyErr_Format(PyExc_TypeError,
-                         "unicodedata.normalize() must return a string, not "
-                         "%.200s",
-                         Py_TYPE(id2)->tp_name);
+                         "unicodedata.normalize() must return a string, "
+                         "not %T", id2);
             Py_DECREF(id2);
             return NULL;
         }

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -213,9 +213,9 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
     }
     if (!PyMapping_Check(ns)) {
         PyErr_Format(PyExc_TypeError,
-                     "%.200s.__prepare__() must return a mapping, not %.200s",
+                     "%.200s.__prepare__() must return a mapping, not %T",
                      isclass ? ((PyTypeObject *)meta)->tp_name : "<metaclass>",
-                     Py_TYPE(ns)->tp_name);
+                     ns);
         goto error;
     }
     cell = PyEval_EvalCodeEx(PyFunction_GET_CODE(func), PyFunction_GET_GLOBALS(func), ns,
@@ -2160,8 +2160,8 @@ builtin_round_impl(PyObject *module, PyObject *number, PyObject *ndigits)
     if (round == NULL) {
         if (!PyErr_Occurred())
             PyErr_Format(PyExc_TypeError,
-                         "type %.100s doesn't define __round__ method",
-                         Py_TYPE(number)->tp_name);
+                         "type %T doesn't define __round__ method",
+                         number);
         return NULL;
     }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -1687,8 +1687,8 @@ main_loop:
                 PyErr_Format(
                     PyExc_TypeError,
                     "'async for' received an object from __aiter__ "
-                    "that does not implement __anext__: %.100s",
-                    Py_TYPE(iter)->tp_name);
+                    "that does not implement __anext__: %T",
+                    iter);
                 Py_DECREF(iter);
                 goto error;
             }
@@ -1734,8 +1734,8 @@ main_loop:
                     _PyErr_FormatFromCause(
                         PyExc_TypeError,
                         "'async for' received an invalid object "
-                        "from __anext__: %.100s",
-                        Py_TYPE(next_iter)->tp_name);
+                        "from __anext__: %T",
+                        next_iter);
 
                     Py_DECREF(next_iter);
                     goto error;
@@ -4911,16 +4911,16 @@ import_all_from(PyObject *locals, PyObject *v)
             }
             if (!PyUnicode_Check(modname)) {
                 PyErr_Format(PyExc_TypeError,
-                             "module __name__ must be a string, not %.100s",
-                             Py_TYPE(modname)->tp_name);
+                             "module __name__ must be a string, not %T",
+                             modname);
             }
             else {
                 PyErr_Format(PyExc_TypeError,
-                             "%s in %U.%s must be str, not %.100s",
+                             "%s in %U.%s must be str, not %T",
                              skip_leading_underscores ? "Key" : "Item",
                              modname,
                              skip_leading_underscores ? "__dict__" : "__all__",
-                             Py_TYPE(name)->tp_name);
+                             name);
             }
             Py_DECREF(modname);
             Py_DECREF(name);

--- a/Python/modsupport.c
+++ b/Python/modsupport.c
@@ -28,8 +28,8 @@ _Py_convert_optional_to_ssize_t(PyObject *obj, void *result)
     }
     else {
         PyErr_Format(PyExc_TypeError,
-                     "argument should be integer or None, not '%.200s'",
-                     Py_TYPE(obj)->tp_name);
+                     "argument should be integer or None, not '%T'",
+                     obj);
         return 0;
     }
     *((Py_ssize_t *)result) = limit;

--- a/Python/pytime.c
+++ b/Python/pytime.c
@@ -265,8 +265,7 @@ _PyTime_FromNanosecondsObject(_PyTime_t *tp, PyObject *obj)
     _PyTime_t t;
 
     if (!PyLong_Check(obj)) {
-        PyErr_Format(PyExc_TypeError, "expect int, got %s",
-                     Py_TYPE(obj)->tp_name);
+        PyErr_Format(PyExc_TypeError, "expect int, got %T", obj);
         return -1;
     }
 

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -781,9 +781,7 @@ sys_set_coroutine_wrapper(PyObject *self, PyObject *wrapper)
 
     if (wrapper != Py_None) {
         if (!PyCallable_Check(wrapper)) {
-            PyErr_Format(PyExc_TypeError,
-                         "callable expected, got %.50s",
-                         Py_TYPE(wrapper)->tp_name);
+            PyErr_Format(PyExc_TypeError, "callable expected, got %T", wrapper);
             return NULL;
         }
         _PyEval_SetCoroutineWrapper(wrapper);
@@ -860,8 +858,8 @@ sys_set_asyncgen_hooks(PyObject *self, PyObject *args, PyObject *kw)
     if (finalizer && finalizer != Py_None) {
         if (!PyCallable_Check(finalizer)) {
             PyErr_Format(PyExc_TypeError,
-                         "callable finalizer expected, got %.50s",
-                         Py_TYPE(finalizer)->tp_name);
+                         "callable finalizer expected, got %T",
+                         finalizer);
             return NULL;
         }
         _PyEval_SetAsyncGenFinalizer(finalizer);
@@ -873,8 +871,8 @@ sys_set_asyncgen_hooks(PyObject *self, PyObject *args, PyObject *kw)
     if (firstiter && firstiter != Py_None) {
         if (!PyCallable_Check(firstiter)) {
             PyErr_Format(PyExc_TypeError,
-                         "callable firstiter expected, got %.50s",
-                         Py_TYPE(firstiter)->tp_name);
+                         "callable firstiter expected, got %T",
+                         firstiter);
             return NULL;
         }
         _PyEval_SetAsyncGenFirstiter(firstiter);
@@ -1242,8 +1240,8 @@ _PySys_GetSizeOf(PyObject *o)
     if (method == NULL) {
         if (!PyErr_Occurred())
             PyErr_Format(PyExc_TypeError,
-                         "Type %.100s doesn't define __sizeof__",
-                         Py_TYPE(o)->tp_name);
+                         "Type %T doesn't define __sizeof__",
+                         o);
     }
     else {
         res = _PyObject_CallNoArg(method);

--- a/Python/traceback.c
+++ b/Python/traceback.c
@@ -78,8 +78,8 @@ tb_new_impl(PyTypeObject *type, PyObject *tb_next, PyFrameObject *tb_frame,
         tb_next = NULL;
     } else if (!PyTraceBack_Check(tb_next)) {
         return PyErr_Format(PyExc_TypeError,
-                            "expected traceback object or None, got '%s'",
-                            Py_TYPE(tb_next)->tp_name);
+                            "expected traceback object or None, got '%T'",
+                            tb_next);
     }
 
     return tb_create_raw((PyTracebackObject *)tb_next, tb_frame, tb_lasti,
@@ -118,8 +118,8 @@ tb_next_set(PyTracebackObject *self, PyObject *new_next, void *Py_UNUSED(_))
         new_next = NULL;
     } else if (!PyTraceBack_Check(new_next)) {
         PyErr_Format(PyExc_TypeError,
-                     "expected traceback object, got '%s'",
-                     Py_TYPE(new_next)->tp_name);
+                     "expected traceback object, got '%T'",
+                     new_next);
         return -1;
     }
 


### PR DESCRIPTION
* PyErr_Format(): replace Py_TYPE(obj)->tp_name using "%s" formatter
  with the new %T formatter in the Python/ subdirectory.
* For Python-ast.c, modify the Parser/asdl_c.py generator

<!-- issue-number: [bpo-34595](https://www.bugs.python.org/issue34595) -->
https://bugs.python.org/issue34595
<!-- /issue-number -->
