### PR TITLE
[3.7] bpo-34604: Fix possible mojibake in pwd.getpwnam() and grp.getgrnam() (GH-9098)

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-09-07-10-16-34.bpo-34604.xL7-kG.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-07-10-16-34.bpo-34604.xL7-kG.rst
@@ -1,0 +1,2 @@
+Fix possible mojibake in the error message of `pwd.getpwnam` and
+`grp.getgrnam`. Patch by William Grzybowski.

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -156,7 +156,7 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
         goto out;
 
     if ((p = getgrnam(name_chars)) == NULL) {
-        PyErr_Format(PyExc_KeyError, "getgrnam(): name not found: %s", name_chars);
+        PyErr_Format(PyExc_KeyError, "getgrnam(): name not found: %S", name);
         goto out;
     }
     retval = mkgrent(p);

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -163,7 +163,7 @@ pwd_getpwnam_impl(PyObject *module, PyObject *arg)
         goto out;
     if ((p = getpwnam(name)) == NULL) {
         PyErr_Format(PyExc_KeyError,
-                     "getpwnam(): name not found: %s", name);
+                     "getpwnam(): name not found: %S", arg);
         goto out;
     }
     retval = mkpwent(p);


### PR DESCRIPTION
Pass the user/group name as Unicode to the formatting function,
instead of always decoding a bytes string from UTF-8..
(cherry picked from commit 28658485a54ad5f9df52ecc12d9046269f1654ec)

Co-authored-by: William Grzybowski <wg@FreeBSD.org>


<!-- issue-number: [bpo-34604](https://www.bugs.python.org/issue34604) -->
https://bugs.python.org/issue34604
<!-- /issue-number -->
