### PR TITLE
bpo-34606: decode extra data only if zip64 end of central directory record is present

### DIFF
--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -2263,16 +2263,17 @@ class ZipInfoTests(unittest.TestCase):
 
 
 class ZipInfoWithExtraTest(unittest.TestCase):
-
+    path = pathlib.Path(TESTFN2)
     def setUp(self):
-        os.mkdir(TESTFN2)
+        os.mkdir(ZipInfoWithExtraTest.path)
 
     def tearDown(self):
-        rmtree(TESTFN2)
+        rmtree(ZipInfoWithExtraTest.path)
 
     @requires_zlib
     def test_extra_field(self):
-        f = os.path.join(TESTFN2, "f.zip")
+
+        f = ZipInfoWithExtraTest.path / "f.zip"
         with zipfile.ZipFile(f, 'w') as zf:
             zi = zipfile.ZipInfo("0")
             zi.extra = b"12345"

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -2272,12 +2272,13 @@ class ZipInfoWithExtraTest(unittest.TestCase):
 
     @requires_zlib
     def test_extra_field(self):
-        with zipfile.ZipFile(TESTFN, 'w') as zf:
+        f = os.path.join(TESTFN2, "f.zip")
+        with zipfile.ZipFile(f, 'w') as zf:
             zi = zipfile.ZipInfo("0")
             zi.extra = b"12345"
             zf.writestr(zi, b"some string")
         try:
-            with zipfile.ZipFile(TESTFN) as zf:
+            with zipfile.ZipFile(f) as zf:
                 infolist = zf.infolist()
                 self.assertTrue(len(infolist) == 1)
                 self.assertEqual(infolist[0].extra, b"12345")

--- a/Lib/test/test_zipfile.py
+++ b/Lib/test/test_zipfile.py
@@ -2262,6 +2262,28 @@ class ZipInfoTests(unittest.TestCase):
         self.assertEqual(zi.file_size, 0)
 
 
+class ZipInfoWithExtraTest(unittest.TestCase):
+
+    def setUp(self):
+        os.mkdir(TESTFN2)
+
+    def tearDown(self):
+        rmtree(TESTFN2)
+
+    @requires_zlib
+    def test_extra_field(self):
+        with zipfile.ZipFile(TESTFN, 'w') as zf:
+            zi = zipfile.ZipInfo("0")
+            zi.extra = b"12345"
+            zf.writestr(zi, b"some string")
+        try:
+            with zipfile.ZipFile(TESTFN) as zf:
+                infolist = zf.infolist()
+                self.assertTrue(len(infolist) == 1)
+                self.assertEqual(infolist[0].extra, b"12345")
+        except zipfile.BadZipfile as e:
+            self.fail(f"Unexpected exception: {e}")
+
 class CommandLineTest(unittest.TestCase):
 
     def zipfilecmd(self, *args, **kwargs):

--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -1277,7 +1277,8 @@ class ZipFile:
 
         # "concat" is zero, unless zip was concatenated to another file
         concat = endrec[_ECD_LOCATION] - size_cd - offset_cd
-        if endrec[_ECD_SIGNATURE] == stringEndArchive64:
+        hasZip64ECD = endrec[_ECD_SIGNATURE] == stringEndArchive64
+        if hasZip64ECD:
             # If Zip64 extension structures are present, account for them
             concat -= (sizeEndCentDir64 + sizeEndCentDir64Locator)
 
@@ -1324,7 +1325,8 @@ class ZipFile:
             x.date_time = ( (d>>9)+1980, (d>>5)&0xF, d&0x1F,
                             t>>11, (t>>5)&0x3F, (t&0x1F) * 2 )
 
-            x._decodeExtra()
+            if hasZip64ECD:
+                x._decodeExtra()
             x.header_offset = x.header_offset + concat
             self.filelist.append(x)
             self.NameToInfo[x.filename] = x

--- a/Misc/NEWS.d/next/Library/2018-09-07-14-25-22.bpo-34606.1-64yh.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-07-14-25-22.bpo-34606.1-64yh.rst
@@ -1,0 +1,1 @@
+Decode extra data only if Zip64 End of central directory record is present


### PR DESCRIPTION
During compression extra data is encoded conditionally when Zip64 extension is enabled but decoding used to to unconditional which lead to attempts to decode data that was not encoded in the first place.

<!-- issue-number: [bpo-34606](https://www.bugs.python.org/issue34606) -->
https://bugs.python.org/issue34606
<!-- /issue-number -->
