### PR TITLE
[Skip Issue] tokenizer.c: Replace unneeded PyUnicode_READY() with an assertion

### DIFF
--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1333,7 +1333,6 @@ verify_identifier(struct tok_state *tok)
         }
         return 0;
     }
-    assert(PyUnicode_IS_READY(s));
     result = PyUnicode_IsIdentifier(s);
     Py_DECREF(s);
     if (result == 0)

--- a/Parser/tokenizer.c
+++ b/Parser/tokenizer.c
@@ -1324,7 +1324,7 @@ verify_identifier(struct tok_state *tok)
     if (tok->decoding_erred)
         return 0;
     s = PyUnicode_DecodeUTF8(tok->start, tok->cur - tok->start, NULL);
-    if (s == NULL || PyUnicode_READY(s) == -1) {
+    if (s == NULL) {
         if (PyErr_ExceptionMatches(PyExc_UnicodeDecodeError)) {
             PyErr_Clear();
             tok->done = E_IDENTIFIER;
@@ -1333,6 +1333,7 @@ verify_identifier(struct tok_state *tok)
         }
         return 0;
     }
+    assert(PyUnicode_IS_READY(s));
     result = PyUnicode_IsIdentifier(s);
     Py_DECREF(s);
     if (result == 0)


### PR DESCRIPTION
In verify_identifier(), PyUnicode_READY(s) == -1 would never occur
(PyUnicode_DecodeUTF8() always returns a ready string on success).
Also, if PyUnicode_READY(s) == -1 did actually occur here, there would
be a reference leak.