### PR TITLE
bpo-34613: document the correct value of limit argument of asyncio.StreamReader

### DIFF
--- a/Doc/library/asyncio-stream.rst
+++ b/Doc/library/asyncio-stream.rst
@@ -126,9 +126,11 @@ Stream functions
 StreamReader
 ============
 
-.. class:: StreamReader(limit=None, loop=None)
+.. class:: StreamReader(limit=_DEFAULT_LIMIT, loop=None)
 
    This class is :ref:`not thread safe <asyncio-multithreading>`.
+
+   The *limit* argument's default value is set to _DEFAULT_LIMIT which is 2**16 (64 KiB)
 
    .. method:: exception()
 


### PR DESCRIPTION
The default value of asyncio.StreamReader *limit* is `_DEFAULT_LIMIT` instead of `None`.

<!-- issue-number: [bpo-34613](https://www.bugs.python.org/issue34613) -->
https://bugs.python.org/issue34613
<!-- /issue-number -->
