### PR TITLE
DO-NOT-MERGE: bpo-34595: Add %t format to PyUnicode_FromFormatV()

### DIFF
--- a/Doc/c-api/unicode.rst
+++ b/Doc/c-api/unicode.rst
@@ -519,8 +519,12 @@ APIs:
    | :attr:`%R`        | PyObject\*          | The result of calling          |
    |                   |                     | :c:func:`PyObject_Repr`.       |
    +-------------------+---------------------+--------------------------------+
-   | :attr:`%T`        | PyObject\*          | Object type name, equivalent   |
-   |                   |                     | to ``Py_TYPE(op)->tp_name``.   |
+   | :attr:`%T`        | PyObject\*          | The object type name,          |
+   |                   |                     | equivalent to:                 |
+   |                   |                     | ``type(op).__name__``.         |
+   +-------------------+---------------------+--------------------------------+
+   | :attr:`%T`        | PyObject\*          | The object type fully          |
+   |                   |                     | qualified name [2]_.           |
    +-------------------+---------------------+--------------------------------+
 
    An unrecognized format character causes all the rest of the format string to be
@@ -536,6 +540,9 @@ APIs:
    .. [1] For integer specifiers (d, u, ld, li, lu, lld, lli, llu, zd, zi,
       zu, i, x): the 0-conversion flag has effect even when a precision is given.
 
+   .. [2] The object type fully qualified name is equivalent to:
+      ``f"{type(obj).__module__}.{type(obj).__qualname__}"``.
+
    .. versionchanged:: 3.2
       Support for ``"%lld"`` and ``"%llu"`` added.
 
@@ -547,7 +554,8 @@ APIs:
       ``"%V"``, ``"%S"``, ``"%R"`` added.
 
    .. versionchanged:: 3.7
-      Support for ``"%T"`` (object type name) added.
+      Support for ``"%t"`` (object type name) and ``"%T"`` (object type fully
+      qualified name) added.
 
 
 .. c:function:: PyObject* PyUnicode_FromFormatV(const char *format, va_list vargs)

--- a/Include/object.h
+++ b/Include/object.h
@@ -502,6 +502,7 @@ PyAPI_FUNC(PyObject *) PyType_GenericNew(PyTypeObject *,
                                                PyObject *, PyObject *);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(const char *) _PyType_Name(PyTypeObject *);
+PyAPI_FUNC(PyObject*) _PyType_FullName(PyTypeObject *);
 PyAPI_FUNC(PyObject *) _PyType_Lookup(PyTypeObject *, PyObject *);
 PyAPI_FUNC(PyObject *) _PyType_LookupId(PyTypeObject *, _Py_Identifier *);
 PyAPI_FUNC(PyObject *) _PyObject_LookupSpecial(PyObject *, _Py_Identifier *);

--- a/Misc/NEWS.d/next/C API/2018-09-06-11-17-49.bpo-34595.Hkz62y.rst
+++ b/Misc/NEWS.d/next/C API/2018-09-06-11-17-49.bpo-34595.Hkz62y.rst
@@ -1,4 +1,5 @@
-:c:func:`PyUnicode_FromFormatV`: add ``%T`` format to
+:c:func:`PyUnicode_FromFormatV`: add ``%t`` and ``%T`` formats to
 :c:func:`PyUnicode_FromFormatV`, and so to :c:func:`PyUnicode_FromFormat`
-and :c:func:`PyErr_Format`, to format an object type name: equivalent to
-"%s" with ``Py_TYPE(obj)->tp_name``.
+and :c:func:`PyErr_Format`, to format an object type name. ``%t`` is equivalent to
+``type(obj).__name__`` and ``%T`` is equivalent to
+``f"{type(obj).__module__}.{type(obj).__qualname__}"``.


### PR DESCRIPTION
* The %T format of PyUnicode_FromFormatV() now returns the fully
  qualified name of an object type (ex: "module.namespace.typename").
* Add %t format to PyUnicode_FromFormatV(), and so to
  PyUnicode_FromFormat() and PyErr_Format(), to format the "short
  name" of an object type: equivalent to "%s" with
  _PyType_Name(Py_TYPE(obj)).
* Replace %T format with %t format in unicodeobject.c.

<!-- issue-number: [bpo-34595](https://www.bugs.python.org/issue34595) -->
https://bugs.python.org/issue34595
<!-- /issue-number -->
