### PR TITLE
bpo-34614: Builtin `abs(Path)` returns `Path.absolute()`.

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -1123,6 +1123,9 @@ class Path(PurePath):
         obj._init(template=self)
         return obj
 
+    def __abs__(self):
+        return self.absolute()
+
     def resolve(self, strict=False):
         """
         Make the path absolute, resolving all symlinks on the way and also

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2054,6 +2054,10 @@ class PathTest(_BasePathTest, unittest.TestCase):
         with self.assertRaisesRegex(ValueError, 'Unacceptable pattern'):
             list(p.glob(''))
 
+    def test_absolute(self):
+        p = self.cls(BASE)
+        self.assertEqual(abs(p), p.absolute())
+
 
 @only_posix
 class PosixPathTest(_BasePathTest, unittest.TestCase):


### PR DESCRIPTION
This complements the current Path behavior that overrides division operators for path joining, in that it makes manually-constructed paths easier to form and arguably more readable.

Before:

```py
p = Path("some", "relative", "path")
q = p.absolute() / "some" / "further" / "path"
```

After:

```py
p = Path("some", "relative", "path")
q = abs(p) / "some" / "further" / "path"
```

<!-- issue-number: [bpo-34614](https://www.bugs.python.org/issue34614) -->
https://bugs.python.org/issue34614
<!-- /issue-number -->
