### PR TITLE
bpo-34536: raise error for invalid _missing_ results

### DIFF
--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -585,7 +585,11 @@ class Enum(metaclass=EnumMeta):
                 if member._value_ == value:
                     return member
         # still not found -- try _missing_ hook
-        return cls._missing_(value)
+        result = cls._missing_(value)
+        if isinstance(result, cls):
+            return result
+        else:
+            raise ValueError("%r is not a valid %s" % (value, cls.__name__))
 
     def _generate_next_value_(name, start, count, last_values):
         for last_value in reversed(last_values):

--- a/Lib/enum.py
+++ b/Lib/enum.py
@@ -585,11 +585,25 @@ class Enum(metaclass=EnumMeta):
                 if member._value_ == value:
                     return member
         # still not found -- try _missing_ hook
-        result = cls._missing_(value)
+        try:
+            exc = None
+            result = cls._missing_(value)
+        except Exception as e:
+            exc = e
+            result = None
         if isinstance(result, cls):
             return result
         else:
-            raise ValueError("%r is not a valid %s" % (value, cls.__name__))
+            ve_exc = ValueError("%r is not a valid %s" % (value, cls.__name__))
+            if result is None and exc is None:
+                raise ve_exc
+            elif exc is None:
+                exc = TypeError(
+                        'error in %s._missing_: returned %r instead of None or a valid member'
+                        % (cls.__name__, result)
+                        )
+            exc.__context__ = ve_exc
+            raise exc
 
     def _generate_next_value_(name, start, count, last_values):
         for last_value in reversed(last_values):

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -1697,6 +1697,16 @@ class TestEnum(unittest.TestCase):
             third = auto()
         self.assertEqual([Dupes.first, Dupes.second, Dupes.third], list(Dupes))
 
+    def test_missing(self):
+        class Color(Enum):
+            red = 1
+            green = 2
+            blue = 3
+            @classmethod
+            def _missing_(cls, item):
+                return 5
+        self.assertRaises(ValueError, Color, 7)
+
 
 class TestOrder(unittest.TestCase):
 

--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3,6 +3,7 @@ import inspect
 import pydoc
 import sys
 import unittest
+import sys
 import threading
 from collections import OrderedDict
 from enum import Enum, IntEnum, EnumMeta, Flag, IntFlag, unique, auto
@@ -1704,8 +1705,30 @@ class TestEnum(unittest.TestCase):
             blue = 3
             @classmethod
             def _missing_(cls, item):
-                return 5
+                if item == 'three':
+                    return cls.blue
+                elif item == 'bad return':
+                    # trigger internal error
+                    return 5
+                elif item == 'error out':
+                    raise ZeroDivisionError
+                else:
+                    # trigger not found
+                    return None
+        self.assertIs(Color('three'), Color.blue)
         self.assertRaises(ValueError, Color, 7)
+        try:
+            Color('bad return')
+        except TypeError as exc:
+            self.assertTrue(isinstance(exc.__context__, ValueError))
+        else:
+            raise Exception('Exception not raised.')
+        try:
+            Color('error out')
+        except ZeroDivisionError as exc:
+            self.assertTrue(isinstance(exc.__context__, ValueError))
+        else:
+            raise Exception('Exception not raised.')
 
 
 class TestOrder(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-09-10-16-32-03.bpo-34536.l-Hb2r.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-10-16-32-03.bpo-34536.l-Hb2r.rst
@@ -1,1 +1,0 @@
-Raise `ValueError` if `_missing_` returns a non-Enum type.

--- a/Misc/NEWS.d/next/Library/2018-09-10-16-32-03.bpo-34536.l-Hb2r.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-10-16-32-03.bpo-34536.l-Hb2r.rst
@@ -1,0 +1,1 @@
+Raise `ValueError` if `_missing_` returns a non-Enum type.

--- a/Misc/NEWS.d/next/Library/2018-09-11-15-49-09.bpo-34536.3IPIH5.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-11-15-49-09.bpo-34536.3IPIH5.rst
@@ -1,0 +1,2 @@
+`Enum._missing_`:  raise `ValueError` if None returned and `TypeError` if
+non-member is returned.


### PR DESCRIPTION
raise ValueError if _missing_ returns invalid type

<!-- issue-number: [bpo-34536](https://www.bugs.python.org/issue34536) -->
https://bugs.python.org/issue34536
<!-- /issue-number -->
