### PR TITLE
Initialize a variable to make the compiler happy.

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -886,7 +886,7 @@ _Py_InitializeMainInterpreter(PyInterpreterState *interp,
 _PyInitError
 _Py_InitializeFromConfig(const _PyCoreConfig *config)
 {
-    PyInterpreterState *interp;
+    PyInterpreterState *interp = NULL;
     _PyInitError err;
     err = _Py_InitializeCore(&interp, config);
     if (_Py_INIT_FAILED(err)) {


### PR DESCRIPTION
GCC complains:
```
Python/pylifecycle.c: In function ‘_Py_InitializeFromConfig’:
Python/pylifecycle.c:900:13: warning: ‘interp’ may be used uninitialized in this function [-Wmaybe-uninitialized]
         err = _Py_InitializeMainInterpreter(interp, &main_config);
         ~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
This seems spurious since &interp is passed to _Py_InitializeCore. Anyway, we
can easily initialize to quiet the warning.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
