### PR TITLE
bpo-32490: Fix filename duplication in subprocess exception messages

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -1512,8 +1512,6 @@ class Popen(object):
                         err_filename = orig_executable
                     if errno_num != 0:
                         err_msg = os.strerror(errno_num)
-                        if errno_num == errno.ENOENT:
-                            err_msg += ': ' + repr(err_filename)
                     raise child_exception_type(errno_num, err_msg, err_filename)
                 raise child_exception_type(err_msg)
 

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -1520,7 +1520,6 @@ class POSIXProcessTestCase(BaseTestCase):
             # string and instead capture the exception that we want to see
             # below for comparison.
             desired_exception = e
-            desired_exception.strerror += ': ' + repr(self._nonexistent_dir)
         else:
             self.fail("chdir to nonexistent directory %s succeeded." %
                       self._nonexistent_dir)
@@ -1537,6 +1536,7 @@ class POSIXProcessTestCase(BaseTestCase):
             # it up to the parent process as the correct exception.
             self.assertEqual(desired_exception.errno, e.errno)
             self.assertEqual(desired_exception.strerror, e.strerror)
+            self.assertEqual(desired_exception.filename, e.filename)
         else:
             self.fail("Expected OSError: %s" % desired_exception)
 
@@ -1551,6 +1551,7 @@ class POSIXProcessTestCase(BaseTestCase):
             # it up to the parent process as the correct exception.
             self.assertEqual(desired_exception.errno, e.errno)
             self.assertEqual(desired_exception.strerror, e.strerror)
+            self.assertEqual(desired_exception.filename, e.filename)
         else:
             self.fail("Expected OSError: %s" % desired_exception)
 
@@ -1564,6 +1565,7 @@ class POSIXProcessTestCase(BaseTestCase):
             # it up to the parent process as the correct exception.
             self.assertEqual(desired_exception.errno, e.errno)
             self.assertEqual(desired_exception.strerror, e.strerror)
+            self.assertEqual(desired_exception.filename, e.filename)
         else:
             self.fail("Expected OSError: %s" % desired_exception)
 

--- a/Misc/NEWS.d/next/Library/2018-09-11-01-25-35.bpo-32490.ROIDO1.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-11-01-25-35.bpo-32490.ROIDO1.rst
@@ -1,0 +1,2 @@
+Prevent filename duplication in :mod:`subprocess` exception messages.  Patch
+by Zackery Spytz.


### PR DESCRIPTION


<!-- issue-number: [bpo-32490](https://www.bugs.python.org/issue32490) -->
https://bugs.python.org/issue32490
<!-- /issue-number -->
