### PR TITLE
bpo-20180: convert most of itertoolsmodule.c to use Argument Clinic

### DIFF
--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -349,4 +349,64 @@ itertools_combinations_with_replacement(PyTypeObject *type, PyObject *args, PyOb
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=51d46b2146b18d23 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_permutations__doc__,
+"permutations(iterable, r=None)\n"
+"--\n"
+"\n"
+"Return successive r-length permutations of elements in the iterable.\n"
+"\n"
+"permutations(range(3), 2) --> (0,1), (0,2), (1,0), (1,2), (2,0), (2,1)");
+
+static PyObject *
+itertools_permutations_impl(PyTypeObject *type, PyObject *iterable,
+                            PyObject *robj);
+
+static PyObject *
+itertools_permutations(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "r", NULL};
+    static _PyArg_Parser _parser = {"O|O:permutations", _keywords, 0};
+    PyObject *iterable;
+    PyObject *robj = Py_None;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &iterable, &robj)) {
+        goto exit;
+    }
+    return_value = itertools_permutations_impl(type, iterable, robj);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(itertools_accumulate__doc__,
+"accumulate(iterable, func=None)\n"
+"--\n"
+"\n"
+"Return series of accumulated sums (or other binary function results).");
+
+static PyObject *
+itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
+                          PyObject *binop);
+
+static PyObject *
+itertools_accumulate(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "func", NULL};
+    static _PyArg_Parser _parser = {"O|O:accumulate", _keywords, 0};
+    PyObject *iterable;
+    PyObject *binop = Py_None;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &iterable, &binop)) {
+        goto exit;
+    }
+    return_value = itertools_accumulate_impl(type, iterable, binop);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=7c3e21a9af91e30e input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -286,4 +286,67 @@ PyDoc_STRVAR(itertools_chain_from_iterable__doc__,
 
 #define ITERTOOLS_CHAIN_FROM_ITERABLE_METHODDEF    \
     {"from_iterable", (PyCFunction)itertools_chain_from_iterable, METH_O|METH_CLASS, itertools_chain_from_iterable__doc__},
-/*[clinic end generated code: output=932280435f5c08e9 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_combinations__doc__,
+"combinations(iterable, r)\n"
+"--\n"
+"\n"
+"Return successive r-length combinations of elements in the iterable.\n"
+"\n"
+"combinations(range(4), 3) --> (0,1,2), (0,1,3), (0,2,3), (1,2,3)");
+
+static PyObject *
+itertools_combinations_impl(PyTypeObject *type, PyObject *iterable,
+                            Py_ssize_t r);
+
+static PyObject *
+itertools_combinations(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "r", NULL};
+    static _PyArg_Parser _parser = {"On:combinations", _keywords, 0};
+    PyObject *iterable;
+    Py_ssize_t r;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &iterable, &r)) {
+        goto exit;
+    }
+    return_value = itertools_combinations_impl(type, iterable, r);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(itertools_combinations_with_replacement__doc__,
+"combinations_with_replacement(iterable, r)\n"
+"--\n"
+"\n"
+"Return successive r-length combinations of elements in the iterable allowing individual elements to have successive repeats.\n"
+"\n"
+"combinations_with_replacement(\'ABC\', 2) --> AA AB AC BB BC CC\"");
+
+static PyObject *
+itertools_combinations_with_replacement_impl(PyTypeObject *type,
+                                             PyObject *iterable,
+                                             Py_ssize_t r);
+
+static PyObject *
+itertools_combinations_with_replacement(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"iterable", "r", NULL};
+    static _PyArg_Parser _parser = {"On:combinations_with_replacement", _keywords, 0};
+    PyObject *iterable;
+    Py_ssize_t r;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &iterable, &r)) {
+        goto exit;
+    }
+    return_value = itertools_combinations_with_replacement_impl(type, iterable, r);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=51d46b2146b18d23 input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -409,4 +409,68 @@ itertools_accumulate(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=7c3e21a9af91e30e input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_compress__doc__,
+"compress(data, selectors)\n"
+"--\n"
+"\n"
+"Return data elements corresponding to true selector elements.\n"
+"\n"
+"Forms a shorter iterator from selected data elements using the selectors to\n"
+"choose the data elements.");
+
+static PyObject *
+itertools_compress_impl(PyTypeObject *type, PyObject *seq1, PyObject *seq2);
+
+static PyObject *
+itertools_compress(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"data", "selectors", NULL};
+    static _PyArg_Parser _parser = {"OO:compress", _keywords, 0};
+    PyObject *seq1;
+    PyObject *seq2;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &seq1, &seq2)) {
+        goto exit;
+    }
+    return_value = itertools_compress_impl(type, seq1, seq2);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(itertools_filterfalse__doc__,
+"filterfalse(function, iterable, /)\n"
+"--\n"
+"\n"
+"Return those items of iterable for which function(item) is false.\n"
+"\n"
+"If function is None, return the items that are false.");
+
+static PyObject *
+itertools_filterfalse_impl(PyTypeObject *type, PyObject *func, PyObject *seq);
+
+static PyObject *
+itertools_filterfalse(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *func;
+    PyObject *seq;
+
+    if ((type == &filterfalse_type) &&
+        !_PyArg_NoKeywords("filterfalse", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "filterfalse",
+        2, 2,
+        &func, &seq)) {
+        goto exit;
+    }
+    return_value = itertools_filterfalse_impl(type, func, seq);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=60cd7dad7f3b5f30 input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -182,4 +182,68 @@ itertools_cycle(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=88f5be1af59c931f input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_dropwhile__doc__,
+"dropwhile(predicate, iterable, /)\n"
+"--\n"
+"\n"
+"Drop items from the iterable while predicate(item) is true.\n"
+"\n"
+"Afterwards, return every element until the iterable is exhausted.");
+
+static PyObject *
+itertools_dropwhile_impl(PyTypeObject *type, PyObject *func, PyObject *seq);
+
+static PyObject *
+itertools_dropwhile(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *func;
+    PyObject *seq;
+
+    if ((type == &dropwhile_type) &&
+        !_PyArg_NoKeywords("dropwhile", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "dropwhile",
+        2, 2,
+        &func, &seq)) {
+        goto exit;
+    }
+    return_value = itertools_dropwhile_impl(type, func, seq);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(itertools_takewhile__doc__,
+"takewhile(predicate, iterable, /)\n"
+"--\n"
+"\n"
+"Return successive entries from an iterable as long as the predicate evaluates to true for each entry.");
+
+static PyObject *
+itertools_takewhile_impl(PyTypeObject *type, PyObject *func, PyObject *seq);
+
+static PyObject *
+itertools_takewhile(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *func;
+    PyObject *seq;
+
+    if ((type == &takewhile_type) &&
+        !_PyArg_NoKeywords("takewhile", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "takewhile",
+        2, 2,
+        &func, &seq)) {
+        goto exit;
+    }
+    return_value = itertools_takewhile_impl(type, func, seq);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=b2e5a03dc0504c37 input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -152,4 +152,34 @@ itertools_tee(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=93e1ec70438f4ebb input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_cycle__doc__,
+"cycle(iterable, /)\n"
+"--\n"
+"\n"
+"Return elements from the iterable until it is exhausted, then repeat the sequence indefinitely.");
+
+static PyObject *
+itertools_cycle_impl(PyTypeObject *type, PyObject *iterable);
+
+static PyObject *
+itertools_cycle(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *iterable;
+
+    if ((type == &cycle_type) &&
+        !_PyArg_NoKeywords("cycle", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "cycle",
+        1, 1,
+        &iterable)) {
+        goto exit;
+    }
+    return_value = itertools_cycle_impl(type, iterable);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=88f5be1af59c931f input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -157,7 +157,7 @@ PyDoc_STRVAR(itertools_cycle__doc__,
 "cycle(iterable, /)\n"
 "--\n"
 "\n"
-"Return elements from the iterable until it is exhausted, then repeat the sequence indefinitely.");
+"Return elements from the iterable until it is exhausted. Then repeat the sequence indefinitely.");
 
 static PyObject *
 itertools_cycle_impl(PyTypeObject *type, PyObject *iterable);
@@ -509,4 +509,4 @@ itertools_count(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6dfa46fef66453e7 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=d9eb9601bd3296ef input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -277,4 +277,13 @@ itertools_starmap(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=5fc47aea5f31a304 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_chain_from_iterable__doc__,
+"from_iterable($type, iterable, /)\n"
+"--\n"
+"\n"
+"Alternative chain() constructor taking a single iterable argument that evaluates lazily.");
+
+#define ITERTOOLS_CHAIN_FROM_ITERABLE_METHODDEF    \
+    {"from_iterable", (PyCFunction)itertools_chain_from_iterable, METH_O|METH_CLASS, itertools_chain_from_iterable__doc__},
+/*[clinic end generated code: output=932280435f5c08e9 input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -473,4 +473,40 @@ itertools_filterfalse(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=60cd7dad7f3b5f30 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_count__doc__,
+"count(start=0, step=1)\n"
+"--\n"
+"\n"
+"Return a count object whose .__next__() method returns consecutive values.\n"
+"\n"
+"Equivalent to:\n"
+"    def count(firstval=0, step=1):\n"
+"        x = firstval\n"
+"        while 1:\n"
+"            yield x\n"
+"            x += step");
+
+static PyObject *
+itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
+                     PyObject *long_step);
+
+static PyObject *
+itertools_count(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"start", "step", NULL};
+    static _PyArg_Parser _parser = {"|OO:count", _keywords, 0};
+    PyObject *long_cnt = NULL;
+    PyObject *long_step = NULL;
+
+    if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
+        &long_cnt, &long_step)) {
+        goto exit;
+    }
+    return_value = itertools_count_impl(type, long_cnt, long_step);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=6dfa46fef66453e7 input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -246,4 +246,35 @@ itertools_takewhile(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=b2e5a03dc0504c37 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_starmap__doc__,
+"starmap(function, iterable, /)\n"
+"--\n"
+"\n"
+"Return an iterator whose values are returned from the function evaluated with an argument tuple taken from the given sequence.");
+
+static PyObject *
+itertools_starmap_impl(PyTypeObject *type, PyObject *func, PyObject *seq);
+
+static PyObject *
+itertools_starmap(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *func;
+    PyObject *seq;
+
+    if ((type == &starmap_type) &&
+        !_PyArg_NoKeywords("starmap", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "starmap",
+        2, 2,
+        &func, &seq)) {
+        goto exit;
+    }
+    return_value = itertools_starmap_impl(type, func, seq);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=5fc47aea5f31a304 input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -61,4 +61,95 @@ itertools__grouper(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=82e10c91569d2b95 input=a9049054013a1b77]*/
+
+PyDoc_STRVAR(itertools_teedataobject__doc__,
+"teedataobject(iterable, values, next, /)\n"
+"--\n"
+"\n"
+"Data container common to multiple tee objects.");
+
+static PyObject *
+itertools_teedataobject_impl(PyTypeObject *type, PyObject *it,
+                             PyObject *values, PyObject *next);
+
+static PyObject *
+itertools_teedataobject(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *it;
+    PyObject *values;
+    PyObject *next;
+
+    if ((type == &teedataobject_type) &&
+        !_PyArg_NoKeywords("teedataobject", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_ParseTuple(args, "OO!O:teedataobject",
+        &it, &PyList_Type, &values, &next)) {
+        goto exit;
+    }
+    return_value = itertools_teedataobject_impl(type, it, values, next);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(itertools__tee__doc__,
+"_tee(iterable, /)\n"
+"--\n"
+"\n"
+"Iterator wrapped to make it copyable.");
+
+static PyObject *
+itertools__tee_impl(PyTypeObject *type, PyObject *iterable);
+
+static PyObject *
+itertools__tee(PyTypeObject *type, PyObject *args, PyObject *kwargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *iterable;
+
+    if ((type == &tee_type) &&
+        !_PyArg_NoKeywords("_tee", kwargs)) {
+        goto exit;
+    }
+    if (!PyArg_UnpackTuple(args, "_tee",
+        1, 1,
+        &iterable)) {
+        goto exit;
+    }
+    return_value = itertools__tee_impl(type, iterable);
+
+exit:
+    return return_value;
+}
+
+PyDoc_STRVAR(itertools_tee__doc__,
+"tee($module, iterable, n=2, /)\n"
+"--\n"
+"\n"
+"Returns a tuple of n independent iterators.");
+
+#define ITERTOOLS_TEE_METHODDEF    \
+    {"tee", (PyCFunction)itertools_tee, METH_FASTCALL, itertools_tee__doc__},
+
+static PyObject *
+itertools_tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n);
+
+static PyObject *
+itertools_tee(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+{
+    PyObject *return_value = NULL;
+    PyObject *iterable;
+    Py_ssize_t n = 2;
+
+    if (!_PyArg_ParseStack(args, nargs, "O|n:tee",
+        &iterable, &n)) {
+        goto exit;
+    }
+    return_value = itertools_tee_impl(module, iterable, n);
+
+exit:
+    return return_value;
+}
+/*[clinic end generated code: output=93e1ec70438f4ebb input=a9049054013a1b77]*/

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -16,8 +16,9 @@ class itertools._tee "teeobject *" "&tee_type"
 class itertools.cycle "cycleobject *" "&cycle_type"
 class itertools.dropwhile "dropwhileobject *" "&dropwhile_type"
 class itertools.takewhile "takewhileobject *" "&takewhile_type"
+class itertools.starmap "starmapobject *" "&starmap_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=4bf812ee14fd8b73]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=3c068cf5e3cbffb8]*/
 
 static PyTypeObject groupby_type;
 static PyTypeObject _grouper_type;
@@ -26,6 +27,7 @@ static PyTypeObject tee_type;
 static PyTypeObject cycle_type;
 static PyTypeObject dropwhile_type;
 static PyTypeObject takewhile_type;
+static PyTypeObject starmap_type;
 
 #include "clinic/itertoolsmodule.c.h"
 
@@ -1705,18 +1707,21 @@ typedef struct {
 
 static PyTypeObject starmap_type;
 
+/*[clinic input]
+@classmethod
+itertools.starmap.__new__
+    function as func: object
+    iterable as seq: object
+    /
+Return an iterator whose values are returned from the function evaluated with an argument tuple taken from the given sequence.
+[clinic start generated code]*/
+
 static PyObject *
-starmap_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_starmap_impl(PyTypeObject *type, PyObject *func, PyObject *seq)
+/*[clinic end generated code: output=79eeb81d452c6e8d input=844766df6a0d4dad]*/
 {
-    PyObject *func, *seq;
     PyObject *it;
     starmapobject *lz;
-
-    if (type == &starmap_type && !_PyArg_NoKeywords("starmap", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "starmap", 2, 2, &func, &seq))
-        return NULL;
 
     /* Get iterator. */
     it = PyObject_GetIter(seq);
@@ -1817,7 +1822,7 @@ static PyTypeObject starmap_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    starmap_doc,                        /* tp_doc */
+    itertools_starmap__doc__,           /* tp_doc */
     (traverseproc)starmap_traverse,     /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -1834,7 +1839,7 @@ static PyTypeObject starmap_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    starmap_new,                        /* tp_new */
+    itertools_starmap,                  /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -927,6 +927,7 @@ itertools_tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n)
     return result;
 }
 
+
 /* cycle object **************************************************************/
 
 typedef struct {
@@ -944,12 +945,12 @@ static PyTypeObject cycle_type;
 itertools.cycle.__new__
     iterable: object
     /
-Return elements from the iterable until it is exhausted, then repeat the sequence indefinitely.
+Return elements from the iterable until it is exhausted. Then repeat the sequence indefinitely.
 [clinic start generated code]*/
 
 static PyObject *
 itertools_cycle_impl(PyTypeObject *type, PyObject *iterable)
-/*[clinic end generated code: output=f60e5ec17a45b35c input=6a304d39a870c5db]*/
+/*[clinic end generated code: output=f60e5ec17a45b35c input=9d1d84bcf66e908b]*/
 {
     PyObject *it;
     PyObject *saved;
@@ -3466,6 +3467,7 @@ static PyTypeObject permutations_type = {
     PyObject_GC_Del,                    /* tp_free */
 };
 
+
 /* accumulate object ********************************************************/
 
 typedef struct {
@@ -4372,6 +4374,7 @@ static PyTypeObject repeat_type = {
     PyObject_GC_Del,                    /* tp_free */
 };
 
+
 /* ziplongest object *********************************************************/
 
 typedef struct {
@@ -4641,6 +4644,7 @@ static PyTypeObject ziplongest_type = {
     zip_longest_new,                    /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
+
 
 /* module level code ********************************************************/
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -11,11 +11,16 @@
 module itertools
 class itertools.groupby "groupbyobject *" "&groupby_type"
 class itertools._grouper "_grouperobject *" "&_grouper_type"
+class itertools.teedataobject "teedataobject *" "&teedataobject_type"
+class itertools._tee "teeobject *" "&tee_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=9d506f5bb9177570]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=2d7d7636c45c73d8]*/
 
 static PyTypeObject groupby_type;
 static PyTypeObject _grouper_type;
+static PyTypeObject teedataobject_type;
+static PyTypeObject tee_type;
+
 #include "clinic/itertoolsmodule.c.h"
 
 
@@ -539,18 +544,25 @@ teedataobject_reduce(teedataobject *tdo, PyObject *Py_UNUSED(ignored))
                          tdo->nextlink ? tdo->nextlink : Py_None);
 }
 
-static PyTypeObject teedataobject_type;
+/*[clinic input]
+@classmethod
+itertools.teedataobject.__new__
+    iterable as it: object
+    values: object(subclass_of='&PyList_Type')
+    next: object
+    /
+Data container common to multiple tee objects.
+[clinic start generated code]*/
 
 static PyObject *
-teedataobject_new(PyTypeObject *type, PyObject *args, PyObject *kw)
+itertools_teedataobject_impl(PyTypeObject *type, PyObject *it,
+                             PyObject *values, PyObject *next)
+/*[clinic end generated code: output=3343ceb07e08df5e input=be60f2fabd2b72ba]*/
 {
     teedataobject *tdo;
-    PyObject *it, *values, *next;
     Py_ssize_t i, len;
 
     assert(type == &teedataobject_type);
-    if (!PyArg_ParseTuple(args, "OO!O", &it, &PyList_Type, &values, &next))
-        return NULL;
 
     tdo = (teedataobject *)teedataobject_newinternal(it);
     if (!tdo)
@@ -592,8 +604,6 @@ static PyMethodDef teedataobject_methods[] = {
     {NULL,              NULL}           /* sentinel */
 };
 
-PyDoc_STRVAR(teedataobject_doc, "Data container common to multiple tee objects.");
-
 static PyTypeObject teedataobject_type = {
     PyVarObject_HEAD_INIT(0, 0)                 /* Must fill in type value later */
     "itertools._tee_dataobject",                /* tp_name */
@@ -616,7 +626,7 @@ static PyTypeObject teedataobject_type = {
     0,                                          /* tp_setattro */
     0,                                          /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,    /* tp_flags */
-    teedataobject_doc,                          /* tp_doc */
+    itertools_teedataobject__doc__,             /* tp_doc */
     (traverseproc)teedataobject_traverse,       /* tp_traverse */
     (inquiry)teedataobject_clear,               /* tp_clear */
     0,                                          /* tp_richcompare */
@@ -633,12 +643,10 @@ static PyTypeObject teedataobject_type = {
     0,                                          /* tp_dictoffset */
     0,                                          /* tp_init */
     0,                                          /* tp_alloc */
-    teedataobject_new,                          /* tp_new */
+    itertools_teedataobject,                    /* tp_new */
     PyObject_GC_Del,                            /* tp_free */
 };
 
-
-static PyTypeObject tee_type;
 
 static PyObject *
 tee_next(teeobject *to)
@@ -716,13 +724,18 @@ done:
     return (PyObject *)to;
 }
 
-static PyObject *
-tee_new(PyTypeObject *type, PyObject *args, PyObject *kw)
-{
-    PyObject *iterable;
+/*[clinic input]
+@classmethod
+itertools._tee.__new__
+    iterable: object
+    /
+Iterator wrapped to make it copyable.
+[clinic start generated code]*/
 
-    if (!PyArg_UnpackTuple(args, "_tee", 1, 1, &iterable))
-        return NULL;
+static PyObject *
+itertools__tee_impl(PyTypeObject *type, PyObject *iterable)
+/*[clinic end generated code: output=b02d3fd26c810c3f input=adc0779d2afe37a2]*/
+{
     return tee_fromiterable(iterable);
 }
 
@@ -771,9 +784,6 @@ tee_setstate(teeobject *to, PyObject *state)
     Py_RETURN_NONE;
 }
 
-PyDoc_STRVAR(teeobject_doc,
-"Iterator wrapped to make it copyable");
-
 static PyMethodDef tee_methods[] = {
     {"__copy__",        (PyCFunction)tee_copy,     METH_NOARGS, teecopy_doc},
     {"__reduce__",      (PyCFunction)tee_reduce,   METH_NOARGS, reduce_doc},
@@ -803,7 +813,7 @@ static PyTypeObject tee_type = {
     0,                                  /* tp_setattro */
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC,            /* tp_flags */
-    teeobject_doc,                      /* tp_doc */
+    itertools__tee__doc__,              /* tp_doc */
     (traverseproc)tee_traverse,         /* tp_traverse */
     (inquiry)tee_clear,                 /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -820,19 +830,26 @@ static PyTypeObject tee_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    tee_new,                            /* tp_new */
+    itertools__tee,                     /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
+/*[clinic input]
+itertools.tee
+    iterable: object
+    n: Py_ssize_t = 2
+    /
+Returns a tuple of n independent iterators.
+[clinic start generated code]*/
+
 static PyObject *
-tee(PyObject *self, PyObject *args)
+itertools_tee_impl(PyObject *module, PyObject *iterable, Py_ssize_t n)
+/*[clinic end generated code: output=1c64519cd859c2f0 input=c99a1472c425d66d]*/
 {
-    Py_ssize_t i, n=2;
-    PyObject *it, *iterable, *copyable, *copyfunc, *result;
+    Py_ssize_t i;
+    PyObject *it, *copyable, *copyfunc, *result;
     _Py_IDENTIFIER(__copy__);
 
-    if (!PyArg_ParseTuple(args, "O|n", &iterable, &n))
-        return NULL;
     if (n < 0) {
         PyErr_SetString(PyExc_ValueError, "n must be >= 0");
         return NULL;
@@ -884,10 +901,6 @@ tee(PyObject *self, PyObject *args)
     Py_DECREF(copyfunc);
     return result;
 }
-
-PyDoc_STRVAR(tee_doc,
-"tee(iterable, n=2) --> tuple of n independent iterators.");
-
 
 /* cycle object **************************************************************/
 
@@ -4653,7 +4666,7 @@ combinations_with_replacement(p, r)\n\
 
 
 static PyMethodDef module_methods[] = {
-    {"tee",     (PyCFunction)tee,       METH_VARARGS, tee_doc},
+    ITERTOOLS_TEE_METHODDEF
     {NULL,              NULL}           /* sentinel */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -13,13 +13,15 @@ class itertools.groupby "groupbyobject *" "&groupby_type"
 class itertools._grouper "_grouperobject *" "&_grouper_type"
 class itertools.teedataobject "teedataobject *" "&teedataobject_type"
 class itertools._tee "teeobject *" "&tee_type"
+class itertools.cycle "cycleobject *" "&cycle_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=2d7d7636c45c73d8]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=066b5d99490f49d4]*/
 
 static PyTypeObject groupby_type;
 static PyTypeObject _grouper_type;
 static PyTypeObject teedataobject_type;
 static PyTypeObject tee_type;
+static PyTypeObject cycle_type;
 
 #include "clinic/itertoolsmodule.c.h"
 
@@ -914,19 +916,21 @@ typedef struct {
 
 static PyTypeObject cycle_type;
 
+/*[clinic input]
+@classmethod
+itertools.cycle.__new__
+    iterable: object
+    /
+Return elements from the iterable until it is exhausted, then repeat the sequence indefinitely.
+[clinic start generated code]*/
+
 static PyObject *
-cycle_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_cycle_impl(PyTypeObject *type, PyObject *iterable)
+/*[clinic end generated code: output=f60e5ec17a45b35c input=6a304d39a870c5db]*/
 {
     PyObject *it;
-    PyObject *iterable;
     PyObject *saved;
     cycleobject *lz;
-
-    if (type == &cycle_type && !_PyArg_NoKeywords("cycle", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "cycle", 1, 1, &iterable))
-        return NULL;
 
     /* Get iterator. */
     it = PyObject_GetIter(iterable);
@@ -1054,12 +1058,6 @@ static PyMethodDef cycle_methods[] = {
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(cycle_doc,
-"cycle(iterable) --> cycle object\n\
-\n\
-Return elements from the iterable until it is exhausted.\n\
-Then repeat the sequence indefinitely.");
-
 static PyTypeObject cycle_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "itertools.cycle",                  /* tp_name */
@@ -1083,7 +1081,7 @@ static PyTypeObject cycle_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    cycle_doc,                          /* tp_doc */
+    itertools_cycle__doc__,             /* tp_doc */
     (traverseproc)cycle_traverse,       /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -1100,7 +1098,7 @@ static PyTypeObject cycle_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    cycle_new,                          /* tp_new */
+    itertools_cycle,                    /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -22,8 +22,10 @@ class itertools.combinations "combinationsobject *" "&combinations_type"
 class itertools.combinations_with_replacement "cwr_object *" "&cwr_type"
 class itertools.permutations "permutationsobject *" "&permutations_type"
 class itertools.accumulate "accumulateobject *" "&accumulate_type"
+class itertools.compress "compressobject *" "&compress_type"
+class itertools.filterfalse "filterfalseobject *" "&filterfalse_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=8b8a7363c65f60f6]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=1ebe103832d620a0]*/
 
 static PyTypeObject groupby_type;
 static PyTypeObject _grouper_type;
@@ -37,7 +39,8 @@ static PyTypeObject combinations_type;
 static PyTypeObject cwr_type;
 static PyTypeObject permutations_type;
 static PyTypeObject accumulate_type;
-
+static PyTypeObject compress_type;
+static PyTypeObject filterfalse_type;
 #include "clinic/itertoolsmodule.c.h"
 
 
@@ -3663,16 +3666,23 @@ typedef struct {
 
 static PyTypeObject compress_type;
 
+/*[clinic input]
+@classmethod
+itertools.compress.__new__
+    data as seq1: object
+    selectors as seq2: object
+Return data elements corresponding to true selector elements.
+
+Forms a shorter iterator from selected data elements using the selectors to
+choose the data elements.
+[clinic start generated code]*/
+
 static PyObject *
-compress_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_compress_impl(PyTypeObject *type, PyObject *seq1, PyObject *seq2)
+/*[clinic end generated code: output=7e67157212ed09e0 input=79596d7cd20c77e5]*/
 {
-    PyObject *seq1, *seq2;
     PyObject *data=NULL, *selectors=NULL;
     compressobject *lz;
-    static char *kwargs[] = {"data", "selectors", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO:compress", kwargs, &seq1, &seq2))
-        return NULL;
 
     data = PyObject_GetIter(seq1);
     if (data == NULL)
@@ -3761,13 +3771,6 @@ static PyMethodDef compress_methods[] = {
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(compress_doc,
-"compress(data, selectors) --> iterator over selected data\n\
-\n\
-Return data elements corresponding to true selector elements.\n\
-Forms a shorter iterator from selected data elements using the\n\
-selectors to choose the data elements.");
-
 static PyTypeObject compress_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "itertools.compress",               /* tp_name */
@@ -3791,7 +3794,7 @@ static PyTypeObject compress_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    compress_doc,                       /* tp_doc */
+    itertools_compress__doc__,          /* tp_doc */
     (traverseproc)compress_traverse,    /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -3808,7 +3811,7 @@ static PyTypeObject compress_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    compress_new,                       /* tp_new */
+    itertools_compress,                 /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
@@ -3823,19 +3826,23 @@ typedef struct {
 
 static PyTypeObject filterfalse_type;
 
+/*[clinic input]
+@classmethod
+itertools.filterfalse.__new__
+    function as func: object
+    iterable as seq: object
+    /
+Return those items of iterable for which function(item) is false.
+
+If function is None, return the items that are false.
+[clinic start generated code]*/
+
 static PyObject *
-filterfalse_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_filterfalse_impl(PyTypeObject *type, PyObject *func, PyObject *seq)
+/*[clinic end generated code: output=55f87eab9fc0484e input=2d684a2c66f99cde]*/
 {
-    PyObject *func, *seq;
     PyObject *it;
     filterfalseobject *lz;
-
-    if (type == &filterfalse_type &&
-        !_PyArg_NoKeywords("filterfalse", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "filterfalse", 2, 2, &func, &seq))
-        return NULL;
 
     /* Get iterator. */
     it = PyObject_GetIter(seq);
@@ -3918,12 +3925,6 @@ static PyMethodDef filterfalse_methods[] = {
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(filterfalse_doc,
-"filterfalse(function or None, sequence) --> filterfalse object\n\
-\n\
-Return those items of sequence for which function(item) is false.\n\
-If function is None, return the items that are false.");
-
 static PyTypeObject filterfalse_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "itertools.filterfalse",            /* tp_name */
@@ -3947,7 +3948,7 @@ static PyTypeObject filterfalse_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    filterfalse_doc,                    /* tp_doc */
+    itertools_filterfalse__doc__,       /* tp_doc */
     (traverseproc)filterfalse_traverse, /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -3964,7 +3965,7 @@ static PyTypeObject filterfalse_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    filterfalse_new,                    /* tp_new */
+    itertools_filterfalse,              /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -671,6 +671,8 @@ static PyTypeObject teedataobject_type = {
 };
 
 
+static PyTypeObject tee_type;
+
 static PyObject *
 tee_next(teeobject *to)
 {
@@ -1807,12 +1809,6 @@ static PyMethodDef starmap_methods[] = {
      reduce_doc},
     {NULL,              NULL}   /* sentinel */
 };
-
-PyDoc_STRVAR(starmap_doc,
-"starmap(function, sequence) --> starmap object\n\
-\n\
-Return an iterator whose values are returned from the function evaluated\n\
-with an argument tuple taken from the given sequence.");
 
 static PyTypeObject starmap_type = {
     PyVarObject_HEAD_INIT(NULL, 0)

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -14,14 +14,18 @@ class itertools._grouper "_grouperobject *" "&_grouper_type"
 class itertools.teedataobject "teedataobject *" "&teedataobject_type"
 class itertools._tee "teeobject *" "&tee_type"
 class itertools.cycle "cycleobject *" "&cycle_type"
+class itertools.dropwhile "dropwhileobject *" "&dropwhile_type"
+class itertools.takewhile "takewhileobject *" "&takewhile_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=066b5d99490f49d4]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=4bf812ee14fd8b73]*/
 
 static PyTypeObject groupby_type;
 static PyTypeObject _grouper_type;
 static PyTypeObject teedataobject_type;
 static PyTypeObject tee_type;
 static PyTypeObject cycle_type;
+static PyTypeObject dropwhile_type;
+static PyTypeObject takewhile_type;
 
 #include "clinic/itertoolsmodule.c.h"
 
@@ -1114,18 +1118,23 @@ typedef struct {
 
 static PyTypeObject dropwhile_type;
 
+/*[clinic input]
+@classmethod
+itertools.dropwhile.__new__
+    predicate as func: object
+    iterable as seq: object
+    /
+Drop items from the iterable while predicate(item) is true.
+
+Afterwards, return every element until the iterable is exhausted.
+[clinic start generated code]*/
+
 static PyObject *
-dropwhile_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_dropwhile_impl(PyTypeObject *type, PyObject *func, PyObject *seq)
+/*[clinic end generated code: output=92f9d0d89af149e4 input=d39737147c9f0a26]*/
 {
-    PyObject *func, *seq;
     PyObject *it;
     dropwhileobject *lz;
-
-    if (type == &dropwhile_type && !_PyArg_NoKeywords("dropwhile", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "dropwhile", 2, 2, &func, &seq))
-        return NULL;
 
     /* Get iterator. */
     it = PyObject_GetIter(seq);
@@ -1220,12 +1229,6 @@ static PyMethodDef dropwhile_methods[] = {
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(dropwhile_doc,
-"dropwhile(predicate, iterable) --> dropwhile object\n\
-\n\
-Drop items from the iterable while predicate(item) is true.\n\
-Afterwards, return every element until the iterable is exhausted.");
-
 static PyTypeObject dropwhile_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "itertools.dropwhile",              /* tp_name */
@@ -1249,7 +1252,7 @@ static PyTypeObject dropwhile_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    dropwhile_doc,                      /* tp_doc */
+    itertools_dropwhile__doc__,         /* tp_doc */
     (traverseproc)dropwhile_traverse,   /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -1266,7 +1269,7 @@ static PyTypeObject dropwhile_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    dropwhile_new,                      /* tp_new */
+    itertools_dropwhile,                /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
@@ -1282,18 +1285,21 @@ typedef struct {
 
 static PyTypeObject takewhile_type;
 
+/*[clinic input]
+@classmethod
+itertools.takewhile.__new__
+    predicate as func: object
+    iterable as seq: object
+    /
+Return successive entries from an iterable as long as the predicate evaluates to true for each entry.
+[clinic start generated code]*/
+
 static PyObject *
-takewhile_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_takewhile_impl(PyTypeObject *type, PyObject *func, PyObject *seq)
+/*[clinic end generated code: output=bb179ea7864e2ef6 input=ba5255f7519aa119]*/
 {
-    PyObject *func, *seq;
     PyObject *it;
     takewhileobject *lz;
-
-    if (type == &takewhile_type && !_PyArg_NoKeywords("takewhile", kwds))
-        return NULL;
-
-    if (!PyArg_UnpackTuple(args, "takewhile", 2, 2, &func, &seq))
-        return NULL;
 
     /* Get iterator. */
     it = PyObject_GetIter(seq);
@@ -1384,11 +1390,6 @@ static PyMethodDef takewhile_reduce_methods[] = {
      setstate_doc},
     {NULL,              NULL}   /* sentinel */
 };
-PyDoc_STRVAR(takewhile_doc,
-"takewhile(predicate, iterable) --> takewhile object\n\
-\n\
-Return successive entries from an iterable as long as the\n\
-predicate evaluates to true for each entry.");
 
 static PyTypeObject takewhile_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
@@ -1413,7 +1414,7 @@ static PyTypeObject takewhile_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    takewhile_doc,                      /* tp_doc */
+    itertools_takewhile__doc__,         /* tp_doc */
     (traverseproc)takewhile_traverse,   /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -1430,7 +1431,7 @@ static PyTypeObject takewhile_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    takewhile_new,                      /* tp_new */
+    itertools_takewhile,                /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -24,8 +24,9 @@ class itertools.permutations "permutationsobject *" "&permutations_type"
 class itertools.accumulate "accumulateobject *" "&accumulate_type"
 class itertools.compress "compressobject *" "&compress_type"
 class itertools.filterfalse "filterfalseobject *" "&filterfalse_type"
+class itertools.count "countobject *" "&count_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=1ebe103832d620a0]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=ea05c93c6d94726a]*/
 
 static PyTypeObject groupby_type;
 static PyTypeObject _grouper_type;
@@ -41,6 +42,8 @@ static PyTypeObject permutations_type;
 static PyTypeObject accumulate_type;
 static PyTypeObject compress_type;
 static PyTypeObject filterfalse_type;
+static PyTypeObject count_type;
+
 #include "clinic/itertoolsmodule.c.h"
 
 
@@ -3998,20 +4001,30 @@ slow_mode:  when cnt == PY_SSIZE_T_MAX, step is not int(1), or cnt is a float.
 
 static PyTypeObject count_type;
 
+/*[clinic input]
+@classmethod
+itertools.count.__new__
+    start as long_cnt: object(c_default="NULL") = 0
+    step as long_step: object(c_default="NULL") = 1
+Return a count object whose .__next__() method returns consecutive values.
+
+Equivalent to:
+    def count(firstval=0, step=1):
+        x = firstval
+        while 1:
+            yield x
+            x += step
+[clinic start generated code]*/
+
 static PyObject *
-count_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_count_impl(PyTypeObject *type, PyObject *long_cnt,
+                     PyObject *long_step)
+/*[clinic end generated code: output=09a9250aebd00b1c input=d7a85eec18bfcd94]*/
 {
     countobject *lz;
     int fast_mode;
     Py_ssize_t cnt = 0;
-    PyObject *long_cnt = NULL;
-    PyObject *long_step = NULL;
     long step;
-    static char *kwlist[] = {"start", "step", 0};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "|OO:count",
-                    kwlist, &long_cnt, &long_step))
-        return NULL;
 
     if ((long_cnt != NULL && !PyNumber_Check(long_cnt)) ||
         (long_step != NULL && !PyNumber_Check(long_step))) {
@@ -4164,17 +4177,6 @@ static PyMethodDef count_methods[] = {
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(count_doc,
-                         "count(start=0, step=1) --> count object\n\
-\n\
-Return a count object whose .__next__() method returns consecutive values.\n\
-Equivalent to:\n\n\
-    def count(firstval=0, step=1):\n\
-        x = firstval\n\
-        while 1:\n\
-            yield x\n\
-            x += step\n");
-
 static PyTypeObject count_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "itertools.count",                  /* tp_name */
@@ -4198,7 +4200,7 @@ static PyTypeObject count_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    count_doc,                          /* tp_doc */
+    itertools_count__doc__,             /* tp_doc */
     (traverseproc)count_traverse,       /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -4215,7 +4217,7 @@ static PyTypeObject count_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    count_new,                          /* tp_new */
+    itertools_count,                    /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -20,8 +20,10 @@ class itertools.starmap "starmapobject *" "&starmap_type"
 class itertools.chain "chainobject *" "&chain_type"
 class itertools.combinations "combinationsobject *" "&combinations_type"
 class itertools.combinations_with_replacement "cwr_object *" "&cwr_type"
+class itertools.permutations "permutationsobject *" "&permutations_type"
+class itertools.accumulate "accumulateobject *" "&accumulate_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=2c68aa7b4d0702a3]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=8b8a7363c65f60f6]*/
 
 static PyTypeObject groupby_type;
 static PyTypeObject _grouper_type;
@@ -33,6 +35,8 @@ static PyTypeObject takewhile_type;
 static PyTypeObject starmap_type;
 static PyTypeObject combinations_type;
 static PyTypeObject cwr_type;
+static PyTypeObject permutations_type;
+static PyTypeObject accumulate_type;
 
 #include "clinic/itertoolsmodule.c.h"
 
@@ -3107,23 +3111,28 @@ typedef struct {
 
 static PyTypeObject permutations_type;
 
+/*[clinic input]
+@classmethod
+itertools.permutations.__new__
+    iterable: object
+    r as robj: object = None
+Return successive r-length permutations of elements in the iterable.
+
+permutations(range(3), 2) --> (0,1), (0,2), (1,0), (1,2), (2,0), (2,1)
+[clinic start generated code]*/
+
 static PyObject *
-permutations_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_permutations_impl(PyTypeObject *type, PyObject *iterable,
+                            PyObject *robj)
+/*[clinic end generated code: output=296a72fa76d620ea input=57d0170a4ac0ec7a]*/
 {
     permutationsobject *po;
     Py_ssize_t n;
     Py_ssize_t r;
-    PyObject *robj = Py_None;
     PyObject *pool = NULL;
-    PyObject *iterable = NULL;
     Py_ssize_t *indices = NULL;
     Py_ssize_t *cycles = NULL;
     Py_ssize_t i;
-    static char *kwargs[] = {"iterable", "r", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:permutations", kwargs,
-                                     &iterable, &robj))
-        return NULL;
 
     pool = PySequence_Tuple(iterable);
     if (pool == NULL)
@@ -3411,12 +3420,6 @@ static PyMethodDef permuations_methods[] = {
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(permutations_doc,
-"permutations(iterable[, r]) --> permutations object\n\
-\n\
-Return successive r-length permutations of elements in the iterable.\n\n\
-permutations(range(3), 2) --> (0,1), (0,2), (1,0), (1,2), (2,0), (2,1)");
-
 static PyTypeObject permutations_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "itertools.permutations",           /* tp_name */
@@ -3440,7 +3443,7 @@ static PyTypeObject permutations_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    permutations_doc,                   /* tp_doc */
+    itertools_permutations__doc__,      /* tp_doc */
     (traverseproc)permutations_traverse,/* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -3457,7 +3460,7 @@ static PyTypeObject permutations_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    permutations_new,                   /* tp_new */
+    itertools_permutations,             /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
@@ -3472,18 +3475,22 @@ typedef struct {
 
 static PyTypeObject accumulate_type;
 
+/*[clinic input]
+@classmethod
+itertools.accumulate.__new__
+    iterable: object
+    func as binop: object = None
+Return series of accumulated sums (or other binary function results).
+[clinic start generated code]*/
+
 static PyObject *
-accumulate_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
+                          PyObject *binop)
+/*[clinic end generated code: output=514d0fb30ba14d55 input=6d9d16aaa1d3cbfc]*/
 {
-    static char *kwargs[] = {"iterable", "func", NULL};
-    PyObject *iterable;
     PyObject *it;
-    PyObject *binop = Py_None;
     accumulateobject *lz;
 
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "O|O:accumulate",
-                                     kwargs, &iterable, &binop))
-        return NULL;
 
     /* Get iterator. */
     it = PyObject_GetIter(iterable);
@@ -3594,11 +3601,6 @@ static PyMethodDef accumulate_methods[] = {
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(accumulate_doc,
-"accumulate(iterable[, func]) --> accumulate object\n\
-\n\
-Return series of accumulated sums (or other binary function results).");
-
 static PyTypeObject accumulate_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "itertools.accumulate",             /* tp_name */
@@ -3622,7 +3624,7 @@ static PyTypeObject accumulate_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    accumulate_doc,                     /* tp_doc */
+    itertools_accumulate__doc__,        /* tp_doc */
     (traverseproc)accumulate_traverse,  /* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -3639,7 +3641,7 @@ static PyTypeObject accumulate_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    accumulate_new,                     /* tp_new */
+    itertools_accumulate,               /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -18,8 +18,10 @@ class itertools.dropwhile "dropwhileobject *" "&dropwhile_type"
 class itertools.takewhile "takewhileobject *" "&takewhile_type"
 class itertools.starmap "starmapobject *" "&starmap_type"
 class itertools.chain "chainobject *" "&chain_type"
+class itertools.combinations "combinationsobject *" "&combinations_type"
+class itertools.combinations_with_replacement "cwr_object *" "&cwr_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=a7475b2da9c13892]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=2c68aa7b4d0702a3]*/
 
 static PyTypeObject groupby_type;
 static PyTypeObject _grouper_type;
@@ -29,6 +31,8 @@ static PyTypeObject cycle_type;
 static PyTypeObject dropwhile_type;
 static PyTypeObject takewhile_type;
 static PyTypeObject starmap_type;
+static PyTypeObject combinations_type;
+static PyTypeObject cwr_type;
 
 #include "clinic/itertoolsmodule.c.h"
 
@@ -2437,21 +2441,27 @@ typedef struct {
 
 static PyTypeObject combinations_type;
 
+
+/*[clinic input]
+@classmethod
+itertools.combinations.__new__
+    iterable: object
+    r: Py_ssize_t
+Return successive r-length combinations of elements in the iterable.
+
+combinations(range(4), 3) --> (0,1,2), (0,1,3), (0,2,3), (1,2,3)
+[clinic start generated code]*/
+
 static PyObject *
-combinations_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_combinations_impl(PyTypeObject *type, PyObject *iterable,
+                            Py_ssize_t r)
+/*[clinic end generated code: output=87a689b39c40039c input=06bede09e3da20f8]*/
 {
     combinationsobject *co;
     Py_ssize_t n;
-    Py_ssize_t r;
     PyObject *pool = NULL;
-    PyObject *iterable = NULL;
     Py_ssize_t *indices = NULL;
     Py_ssize_t i;
-    static char *kwargs[] = {"iterable", "r", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds, "On:combinations", kwargs,
-                                     &iterable, &r))
-        return NULL;
 
     pool = PySequence_Tuple(iterable);
     if (pool == NULL)
@@ -2686,12 +2696,6 @@ static PyMethodDef combinations_methods[] = {
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(combinations_doc,
-"combinations(iterable, r) --> combinations object\n\
-\n\
-Return successive r-length combinations of elements in the iterable.\n\n\
-combinations(range(4), 3) --> (0,1,2), (0,1,3), (0,2,3), (1,2,3)");
-
 static PyTypeObject combinations_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "itertools.combinations",           /* tp_name */
@@ -2715,7 +2719,7 @@ static PyTypeObject combinations_type = {
     0,                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,            /* tp_flags */
-    combinations_doc,                   /* tp_doc */
+    itertools_combinations__doc__,      /* tp_doc */
     (traverseproc)combinations_traverse,/* tp_traverse */
     0,                                  /* tp_clear */
     0,                                  /* tp_richcompare */
@@ -2732,7 +2736,7 @@ static PyTypeObject combinations_type = {
     0,                                  /* tp_dictoffset */
     0,                                  /* tp_init */
     0,                                  /* tp_alloc */
-    combinations_new,                   /* tp_new */
+    itertools_combinations,             /* tp_new */
     PyObject_GC_Del,                    /* tp_free */
 };
 
@@ -2776,22 +2780,27 @@ typedef struct {
 
 static PyTypeObject cwr_type;
 
+/*[clinic input]
+@classmethod
+itertools.combinations_with_replacement.__new__
+    iterable: object
+    r: Py_ssize_t
+Return successive r-length combinations of elements in the iterable allowing individual elements to have successive repeats.
+
+combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC"
+[clinic start generated code]*/
+
 static PyObject *
-cwr_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+itertools_combinations_with_replacement_impl(PyTypeObject *type,
+                                             PyObject *iterable,
+                                             Py_ssize_t r)
+/*[clinic end generated code: output=48b26856d4e659ca input=dc2a8c7ba785fad7]*/
 {
     cwrobject *co;
     Py_ssize_t n;
-    Py_ssize_t r;
     PyObject *pool = NULL;
-    PyObject *iterable = NULL;
     Py_ssize_t *indices = NULL;
     Py_ssize_t i;
-    static char *kwargs[] = {"iterable", "r", NULL};
-
-    if (!PyArg_ParseTupleAndKeywords(args, kwds,
-                                     "On:combinations_with_replacement",
-                                     kwargs, &iterable, &r))
-        return NULL;
 
     pool = PySequence_Tuple(iterable);
     if (pool == NULL)
@@ -3016,13 +3025,6 @@ static PyMethodDef cwr_methods[] = {
     {NULL,              NULL}   /* sentinel */
 };
 
-PyDoc_STRVAR(cwr_doc,
-"combinations_with_replacement(iterable, r) --> combinations_with_replacement object\n\
-\n\
-Return successive r-length combinations of elements in the iterable\n\
-allowing individual elements to have successive repeats.\n\
-combinations_with_replacement('ABC', 2) --> AA AB AC BB BC CC");
-
 static PyTypeObject cwr_type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "itertools.combinations_with_replacement",          /* tp_name */
@@ -3046,7 +3048,7 @@ static PyTypeObject cwr_type = {
     0,                                                  /* tp_as_buffer */
     Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_GC |
         Py_TPFLAGS_BASETYPE,                            /* tp_flags */
-    cwr_doc,                                            /* tp_doc */
+    itertools_combinations_with_replacement__doc__,     /* tp_doc */
     (traverseproc)cwr_traverse,                         /* tp_traverse */
     0,                                                  /* tp_clear */
     0,                                                  /* tp_richcompare */
@@ -3063,7 +3065,7 @@ static PyTypeObject cwr_type = {
     0,                                                  /* tp_dictoffset */
     0,                                                  /* tp_init */
     0,                                                  /* tp_alloc */
-    cwr_new,                                            /* tp_new */
+    itertools_combinations_with_replacement,            /* tp_new */
     PyObject_GC_Del,                                    /* tp_free */
 };
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -17,8 +17,9 @@ class itertools.cycle "cycleobject *" "&cycle_type"
 class itertools.dropwhile "dropwhileobject *" "&dropwhile_type"
 class itertools.takewhile "takewhileobject *" "&takewhile_type"
 class itertools.starmap "starmapobject *" "&starmap_type"
+class itertools.chain "chainobject *" "&chain_type"
 [clinic start generated code]*/
-/*[clinic end generated code: output=da39a3ee5e6b4b0d input=3c068cf5e3cbffb8]*/
+/*[clinic end generated code: output=da39a3ee5e6b4b0d input=a7475b2da9c13892]*/
 
 static PyTypeObject groupby_type;
 static PyTypeObject _grouper_type;
@@ -1885,8 +1886,17 @@ chain_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     return chain_new_internal(type, source);
 }
 
+/*[clinic input]
+@classmethod
+itertools.chain.from_iterable
+    iterable as arg: object
+    /
+Alternative chain() constructor taking a single iterable argument that evaluates lazily.
+[clinic start generated code]*/
+
 static PyObject *
-chain_new_from_iterable(PyTypeObject *type, PyObject *arg)
+itertools_chain_from_iterable(PyTypeObject *type, PyObject *arg)
+/*[clinic end generated code: output=667ae7a7f7b68654 input=72c39e3a2ca3be85]*/
 {
     PyObject *source;
 
@@ -2002,15 +2012,8 @@ Return a chain object whose .__next__() method returns elements from the\n\
 first iterable until it is exhausted, then elements from the next\n\
 iterable, until all of the iterables are exhausted.");
 
-PyDoc_STRVAR(chain_from_iterable_doc,
-"chain.from_iterable(iterable) --> chain object\n\
-\n\
-Alternate chain() constructor taking a single iterable argument\n\
-that evaluates lazily.");
-
 static PyMethodDef chain_methods[] = {
-    {"from_iterable", (PyCFunction) chain_new_from_iterable, METH_O | METH_CLASS,
-     chain_from_iterable_doc},
+    ITERTOOLS_CHAIN_FROM_ITERABLE_METHODDEF
     {"__reduce__",      (PyCFunction)chain_reduce,      METH_NOARGS,
      reduce_doc},
     {"__setstate__",    (PyCFunction)chain_setstate,    METH_O,


### PR DESCRIPTION
This is a followup to PRs #4117 and #4170.

As requested by @rhettinger, this PR:
* keeps doc-strings unchanged
* doesn't convert special dunder methods such as `__reduce__` and `__setstate__`
* keeps variable names unchanged e.g. `predicate as func: object`
* doesn't move anything around, only adding a required list of `static PyTypeObject` declarations at the top

Since AC *requires* the doc-string to begin with a single summary line, I've kept most of those unchanged, despite in some cases exceeding 79 characters in length. @rhettinger, what should be done with those?

<!-- issue-number: [bpo-20180](https://www.bugs.python.org/issue20180) -->
https://bugs.python.org/issue20180
<!-- /issue-number -->
