### PR TITLE
bpo-34604: Use %R because of invisible characters or trailing whitespaces

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-09-07-10-16-34.bpo-34604.xL7-kG.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-07-10-16-34.bpo-34604.xL7-kG.rst
@@ -1,2 +1,3 @@
 Fix possible mojibake in the error message of `pwd.getpwnam` and
-`grp.getgrnam`. Patch by William Grzybowski.
+`grp.getgrnam` using string representation because of invisible characters
+or trailing whitespaces. Patch by William Grzybowski.

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -245,7 +245,7 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
             PyErr_NoMemory();
         }
         else {
-            PyErr_Format(PyExc_KeyError, "getgrnam(): name not found: %S", name);
+            PyErr_Format(PyExc_KeyError, "getgrnam(): name not found: %R", name);
         }
         goto out;
     }

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -253,7 +253,7 @@ pwd_getpwnam_impl(PyObject *module, PyObject *name)
         }
         else {
             PyErr_Format(PyExc_KeyError,
-                         "getpwnam(): name not found: %S", name);
+                         "getpwnam(): name not found: %R", name);
         }
         goto out;
     }


### PR DESCRIPTION



<!-- issue-number: [bpo-34604](https://www.bugs.python.org/issue34604) -->
https://bugs.python.org/issue34604
<!-- /issue-number -->
