### PR TITLE
bpo-34405: Update to OpenSSL 1.1.0i for macOS installer builds

### DIFF
--- a/Mac/BuildScript/build-installer.py
+++ b/Mac/BuildScript/build-installer.py
@@ -215,9 +215,9 @@ def library_recipes():
 
     result.extend([
           dict(
-              name="OpenSSL 1.1.0h",
-              url="https://www.openssl.org/source/openssl-1.1.0h.tar.gz",
-              checksum='5271477e4d93f4ea032b665ef095ff24',
+              name="OpenSSL 1.1.0i",
+              url="https://www.openssl.org/source/openssl-1.1.0i.tar.gz",
+              checksum='9495126aafd2659d357ea66a969c3fe1',
               buildrecipe=build_universal_openssl,
               configure=None,
               install=None,

--- a/Misc/NEWS.d/next/macOS/2018-09-11-08-30-55.bpo-34405.UzIi0n.rst
+++ b/Misc/NEWS.d/next/macOS/2018-09-11-08-30-55.bpo-34405.UzIi0n.rst
@@ -1,0 +1,1 @@
+Update to OpenSSL 1.1.0i for macOS installer builds.


### PR DESCRIPTION


<!-- issue-number: [bpo-34405](https://www.bugs.python.org/issue34405) -->
https://bugs.python.org/issue34405
<!-- /issue-number -->
