### PR TITLE
bpo-34630: Skip logging SSL certificate errors by asyncio code

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -61,6 +61,9 @@ _MIN_CANCELLED_TIMER_HANDLES_FRACTION = 0.5
 _FATAL_ERROR_IGNORE = (BrokenPipeError,
                        ConnectionResetError, ConnectionAbortedError)
 
+if ssl is not None:
+    _FATAL_ERROR_IGNORE = _FATAL_ERROR_IGNORE + (ssl.SSLCertVerificationError)
+
 _HAS_IPv6 = hasattr(socket, 'AF_INET6')
 
 # Maximum timeout passed to select to avoid OS limitations

--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -62,7 +62,7 @@ _FATAL_ERROR_IGNORE = (BrokenPipeError,
                        ConnectionResetError, ConnectionAbortedError)
 
 if ssl is not None:
-    _FATAL_ERROR_IGNORE = _FATAL_ERROR_IGNORE + (ssl.SSLCertVerificationError)
+    _FATAL_ERROR_IGNORE = _FATAL_ERROR_IGNORE + (ssl.SSLCertVerificationError,)
 
 _HAS_IPv6 = hasattr(socket, 'AF_INET6')
 

--- a/Misc/NEWS.d/next/Library/2018-09-11-10-00-53.bpo-34630.YbqUS6.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-11-10-00-53.bpo-34630.YbqUS6.rst
@@ -1,0 +1,2 @@
+Don't log SSL certificate errors in asyncio code (connection error logging
+is skipped already).


### PR DESCRIPTION
We don't log connection errors, ssl cert error is not exceptional.

Now asyncio logs a bloated by cert error reports if asyncio is used, for example, for web crawling.
There is no way to suppress such logs, and there is no reason to log them at all.

<!-- issue-number: [bpo-34630](https://www.bugs.python.org/issue34630) -->
https://bugs.python.org/issue34630
<!-- /issue-number -->
