### PR TITLE
Use Py_TYPE(obj) rather than obj->ob_type.

### DIFF
--- a/Include/abstract.h
+++ b/Include/abstract.h
@@ -509,8 +509,8 @@ PyAPI_FUNC(int) PyObject_AsWriteBuffer(PyObject *obj,
 
 /* Return 1 if the getbuffer function is available, otherwise return 0. */
 #define PyObject_CheckBuffer(obj) \
-    (((obj)->ob_type->tp_as_buffer != NULL) &&  \
-     ((obj)->ob_type->tp_as_buffer->bf_getbuffer != NULL))
+    ((Py_TYPE(obj)->tp_as_buffer != NULL) &&  \
+     (Py_TYPE(obj)->tp_as_buffer->bf_getbuffer != NULL))
 
 /* This is a C-API version of the getbuffer function call.  It checks
    to make sure object has the required function pointer and issues the
@@ -596,8 +596,8 @@ PyAPI_FUNC(PyObject *) PyObject_GetIter(PyObject *);
 PyAPI_FUNC(int) PyIter_Check(PyObject *);
 #ifndef Py_LIMITED_API
 #define PyIter_Check(obj) \
-    ((obj)->ob_type->tp_iternext != NULL && \
-     (obj)->ob_type->tp_iternext != &_PyObject_NextNotImplemented)
+    (Py_TYPE(obj)->tp_iternext != NULL && \
+     Py_TYPE(obj)->tp_iternext != &_PyObject_NextNotImplemented)
 #endif
 
 /* Takes an iterator object and calls its tp_iternext slot,
@@ -721,8 +721,8 @@ PyAPI_FUNC(PyObject *) PyNumber_Or(PyObject *o1, PyObject *o2);
 PyAPI_FUNC(int) PyIndex_Check(PyObject *);
 #ifndef Py_LIMITED_API
 #define PyIndex_Check(obj)                              \
-    ((obj)->ob_type->tp_as_number != NULL &&            \
-     (obj)->ob_type->tp_as_number->nb_index != NULL)
+    (Py_TYPE(obj)->tp_as_number != NULL &&            \
+     Py_TYPE(obj)->tp_as_number->nb_index != NULL)
 #endif
 
 /* Returns the object 'o' converted to a Python int, or NULL with an exception

--- a/Include/classobject.h
+++ b/Include/classobject.h
@@ -18,7 +18,7 @@ typedef struct {
 
 PyAPI_DATA(PyTypeObject) PyMethod_Type;
 
-#define PyMethod_Check(op) ((op)->ob_type == &PyMethod_Type)
+#define PyMethod_Check(op) (Py_TYPE(op) == &PyMethod_Type)
 
 PyAPI_FUNC(PyObject *) PyMethod_New(PyObject *, PyObject *);
 
@@ -41,7 +41,7 @@ typedef struct {
 
 PyAPI_DATA(PyTypeObject) PyInstanceMethod_Type;
 
-#define PyInstanceMethod_Check(op) ((op)->ob_type == &PyInstanceMethod_Type)
+#define PyInstanceMethod_Check(op) (Py_TYPE(op) == &PyInstanceMethod_Type)
 
 PyAPI_FUNC(PyObject *) PyInstanceMethod_New(PyObject *);
 PyAPI_FUNC(PyObject *) PyInstanceMethod_Function(PyObject *);

--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -140,14 +140,14 @@ PyAPI_FUNC(void) _PyErr_ChainExceptions(PyObject *, PyObject *, PyObject *);
      PyType_FastSubclass((PyTypeObject*)(x), Py_TPFLAGS_BASE_EXC_SUBCLASS))
 
 #define PyExceptionInstance_Check(x)                    \
-    PyType_FastSubclass((x)->ob_type, Py_TPFLAGS_BASE_EXC_SUBCLASS)
+    PyType_FastSubclass(Py_TYPE(x), Py_TPFLAGS_BASE_EXC_SUBCLASS)
 
 PyAPI_FUNC(const char *) PyExceptionClass_Name(PyObject *);
 #ifndef Py_LIMITED_API
 #define PyExceptionClass_Name(x)  (((PyTypeObject*)(x))->tp_name)
 #endif
 
-#define PyExceptionInstance_Class(x) ((PyObject*)((x)->ob_type))
+#define PyExceptionInstance_Class(x) ((PyObject*)Py_TYPE((x)))
 
 
 /* Predefined exceptions */

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -531,7 +531,7 @@ deque_concat(dequeobject *deque, PyObject *other)
         if (rv == 0) {
             PyErr_Format(PyExc_TypeError,
                          "can only concatenate deque (not \"%.200s\") to deque",
-                         other->ob_type->tp_name);
+                         Py_TYPE(other)->tp_name);
         }
         return NULL;
     }

--- a/Modules/_csv.c
+++ b/Modules/_csv.c
@@ -236,7 +236,7 @@ _set_char(const char *name, Py_UCS4 *target, PyObject *src, Py_UCS4 dflt)
             if (!PyUnicode_Check(src)) {
                 PyErr_Format(PyExc_TypeError,
                     "\"%s\" must be string, not %.200s", name,
-                    src->ob_type->tp_name);
+                    Py_TYPE(src)->tp_name);
                 return -1;
             }
             len = PyUnicode_GetLength(src);
@@ -807,7 +807,7 @@ Reader_iternext(ReaderObj *self)
                          "iterator should return strings, "
                          "not %.200s "
                          "(did you open the file in text mode?)",
-                         lineobj->ob_type->tp_name
+                         Py_TYPE(lineobj)->tp_name
                 );
             Py_DECREF(lineobj);
             return NULL;
@@ -1168,7 +1168,7 @@ csv_writerow(WriterObj *self, PyObject *seq)
     if (iter == NULL)
         return PyErr_Format(_csvstate_global->error_obj,
                             "iterable expected, not %.200s",
-                            seq->ob_type->tp_name);
+                            Py_TYPE(seq)->tp_name);
 
     /* Join all fields in internal buffer.
      */

--- a/Modules/_ctypes/cfield.c
+++ b/Modules/_ctypes/cfield.c
@@ -275,7 +275,7 @@ static void
 PyCField_dealloc(PyObject *self)
 {
     PyCField_clear((CFieldObject *)self);
-    self->ob_type->tp_free((PyObject *)self);
+    Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
 static PyObject *
@@ -1176,7 +1176,7 @@ u_set(void *ptr, PyObject *value, Py_ssize_t size)
     if (!PyUnicode_Check(value)) {
         PyErr_Format(PyExc_TypeError,
                         "unicode string expected instead of %s instance",
-                        value->ob_type->tp_name);
+                        Py_TYPE(value)->tp_name);
         return NULL;
     } else
         Py_INCREF(value);
@@ -1238,7 +1238,7 @@ U_set(void *ptr, PyObject *value, Py_ssize_t length)
     if (!PyUnicode_Check(value)) {
         PyErr_Format(PyExc_TypeError,
                         "unicode string expected instead of %s instance",
-                        value->ob_type->tp_name);
+                        Py_TYPE(value)->tp_name);
         return NULL;
     }
 
@@ -1288,7 +1288,7 @@ s_set(void *ptr, PyObject *value, Py_ssize_t length)
     if(!PyBytes_Check(value)) {
         PyErr_Format(PyExc_TypeError,
                      "expected bytes, %s found",
-                     value->ob_type->tp_name);
+                     Py_TYPE(value)->tp_name);
         return NULL;
     }
 
@@ -1333,7 +1333,7 @@ z_set(void *ptr, PyObject *value, Py_ssize_t size)
     }
     PyErr_Format(PyExc_TypeError,
                  "bytes or integer address expected instead of %s instance",
-                 value->ob_type->tp_name);
+                 Py_TYPE(value)->tp_name);
     return NULL;
 }
 
@@ -1372,7 +1372,7 @@ Z_set(void *ptr, PyObject *value, Py_ssize_t size)
     if (!PyUnicode_Check(value)) {
         PyErr_Format(PyExc_TypeError,
                      "unicode string or integer address expected instead of %s instance",
-                     value->ob_type->tp_name);
+                     Py_TYPE(value)->tp_name);
         return NULL;
     }
 
@@ -1415,7 +1415,7 @@ BSTR_set(void *ptr, PyObject *value, Py_ssize_t size)
     } else if (!PyUnicode_Check(value)) {
         PyErr_Format(PyExc_TypeError,
                         "unicode string expected instead of %s instance",
-                        value->ob_type->tp_name);
+                        Py_TYPE(value)->tp_name);
         return NULL;
     }
 

--- a/Modules/_ctypes/ctypes.h
+++ b/Modules/_ctypes/ctypes.h
@@ -68,7 +68,7 @@ typedef struct {
     ffi_type *atypes[1];
 } CThunkObject;
 extern PyTypeObject PyCThunk_Type;
-#define CThunk_CheckExact(v)        ((v)->ob_type == &PyCThunk_Type)
+#define CThunk_CheckExact(v)        (Py_TYPE(v) == &PyCThunk_Type)
 
 typedef struct {
     /* First part identical to tagCDataObject */
@@ -102,7 +102,7 @@ typedef struct {
 } PyCFuncPtrObject;
 
 extern PyTypeObject PyCStgDict_Type;
-#define PyCStgDict_CheckExact(v)            ((v)->ob_type == &PyCStgDict_Type)
+#define PyCStgDict_CheckExact(v)            (Py_TYPE(v) == &PyCStgDict_Type)
 #define PyCStgDict_Check(v)         PyObject_TypeCheck(v, &PyCStgDict_Type)
 
 extern int PyCStructUnionType_update_stgdict(PyObject *fields, PyObject *type, int isStruct);
@@ -112,12 +112,12 @@ extern int PyObject_stginfo(PyObject *self, Py_ssize_t *psize, Py_ssize_t *palig
 
 
 extern PyTypeObject PyCData_Type;
-#define CDataObject_CheckExact(v)       ((v)->ob_type == &PyCData_Type)
+#define CDataObject_CheckExact(v)       (Py_TYPE(v) == &PyCData_Type)
 #define CDataObject_Check(v)            PyObject_TypeCheck(v, &PyCData_Type)
 #define _CDataObject_HasExternalBuffer(v)  ((v)->b_ptr != (char *)&(v)->b_value)
 
 extern PyTypeObject PyCSimpleType_Type;
-#define PyCSimpleTypeObject_CheckExact(v)       ((v)->ob_type == &PyCSimpleType_Type)
+#define PyCSimpleTypeObject_CheckExact(v)       (Py_TYPE(v) == &PyCSimpleType_Type)
 #define PyCSimpleTypeObject_Check(v)    PyObject_TypeCheck(v, &PyCSimpleType_Type)
 
 extern PyTypeObject PyCField_Type;
@@ -312,7 +312,7 @@ struct tagPyCArgObject {
 };
 
 extern PyTypeObject PyCArg_Type;
-#define PyCArg_CheckExact(v)        ((v)->ob_type == &PyCArg_Type)
+#define PyCArg_CheckExact(v)        (Py_TYPE(v) == &PyCArg_Type)
 extern PyCArgObject *PyCArgObject_new(void);
 
 extern PyObject *

--- a/Modules/_ctypes/stgdict.c
+++ b/Modules/_ctypes/stgdict.c
@@ -190,7 +190,7 @@ PyType_stgdict(PyObject *obj)
 StgDictObject *
 PyObject_stgdict(PyObject *self)
 {
-    PyTypeObject *type = self->ob_type;
+    PyTypeObject *type = Py_TYPE(self);
     if (!type->tp_dict || !PyCStgDict_CheckExact(type->tp_dict))
         return NULL;
     return (StgDictObject *)type->tp_dict;

--- a/Modules/_cursesmodule.c
+++ b/Modules/_cursesmodule.c
@@ -2912,7 +2912,7 @@ _curses_getwin(PyObject *module, PyObject *file)
     if (!PyBytes_Check(data)) {
         PyErr_Format(PyExc_TypeError,
                      "f.read() returned %.100s instead of bytes",
-                     data->ob_type->tp_name);
+                     Py_TYPE(data)->tp_name);
         Py_DECREF(data);
         goto error;
     }

--- a/Modules/_dbmmodule.c
+++ b/Modules/_dbmmodule.c
@@ -246,7 +246,7 @@ dbm_contains(PyObject *self, PyObject *arg)
     else if (!PyBytes_Check(arg)) {
         PyErr_Format(PyExc_TypeError,
                      "dbm key must be bytes or string, not %.100s",
-                     arg->ob_type->tp_name);
+                     Py_TYPE(arg)->tp_name);
         return -1;
     }
     else {

--- a/Modules/_decimal/_decimal.c
+++ b/Modules/_decimal/_decimal.c
@@ -2584,7 +2584,7 @@ PyDecType_FromObjectExact(PyTypeObject *type, PyObject *v, PyObject *context)
     else {
         PyErr_Format(PyExc_TypeError,
             "conversion from %s to Decimal is not supported",
-            v->ob_type->tp_name);
+            Py_TYPE(v)->tp_name);
         return NULL;
     }
 }
@@ -2633,7 +2633,7 @@ PyDec_FromObject(PyObject *v, PyObject *context)
     else {
         PyErr_Format(PyExc_TypeError,
             "conversion from %s to Decimal is not supported",
-            v->ob_type->tp_name);
+            Py_TYPE(v)->tp_name);
         return NULL;
     }
 }
@@ -2696,7 +2696,7 @@ convert_op(int type_err, PyObject **conv, PyObject *v, PyObject *context)
     if (type_err) {
         PyErr_Format(PyExc_TypeError,
             "conversion from %s to Decimal is not supported",
-            v->ob_type->tp_name);
+            Py_TYPE(v)->tp_name);
     }
     else {
         Py_INCREF(Py_NotImplemented);

--- a/Modules/_gdbmmodule.c
+++ b/Modules/_gdbmmodule.c
@@ -326,7 +326,7 @@ dbm_contains(PyObject *self, PyObject *arg)
     else if (!PyBytes_Check(arg)) {
         PyErr_Format(PyExc_TypeError,
                      "gdbm key must be bytes or string, not %.100s",
-                     arg->ob_type->tp_name);
+                     Py_TYPE(arg)->tp_name);
         return -1;
     }
     else {

--- a/Modules/_io/_iomodule.c
+++ b/Modules/_io/_iomodule.c
@@ -533,7 +533,7 @@ PyNumber_AsOff_t(PyObject *item, PyObject *err)
         /* Otherwise replace the error with caller's error object. */
         PyErr_Format(err,
                      "cannot fit '%.200s' into an offset-sized integer",
-                     item->ob_type->tp_name);
+                     Py_TYPE(item)->tp_name);
     }
 
  finish:

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1045,7 +1045,7 @@ _io_TextIOWrapper___init___impl(textio *self, PyObject *buffer,
         PyErr_Format(
             PyExc_TypeError,
             "TextIOWrapper() argument 'errors' must be str or None, not %.50s",
-            errors->ob_type->tp_name);
+            Py_TYPE(errors)->tp_name);
         return -1;
     }
 

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -1652,7 +1652,7 @@ encoder_listencode_dict(PyEncoderObject *s, _PyAccu *acc,
         else {
             PyErr_Format(PyExc_TypeError,
                          "keys must be str, int, float, bool or None, "
-                         "not %.100s", key->ob_type->tp_name);
+                         "not %.100s", Py_TYPE(key)->tp_name);
             goto bail;
         }
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -1856,7 +1856,7 @@ fast_save_enter(PicklerObject *self, PyObject *obj)
             PyErr_Format(PyExc_ValueError,
                          "fast mode: can't pickle cyclic objects "
                          "including object type %.200s at %p",
-                         obj->ob_type->tp_name, obj);
+                         Py_TYPE(obj)->tp_name, obj);
             self->fast_nesting = -1;
             return 0;
         }

--- a/Modules/_sqlite/microprotocols.c
+++ b/Modules/_sqlite/microprotocols.c
@@ -82,7 +82,7 @@ pysqlite_microprotocols_adapt(PyObject *obj, PyObject *proto, PyObject *alt)
        way to get a quotable object to be its instance */
 
     /* look for an adapter in the registry */
-    key = Py_BuildValue("(OO)", (PyObject*)obj->ob_type, proto);
+    key = Py_BuildValue("(OO)", (PyObject*)Py_TYPE(obj), proto);
     if (!key) {
         return NULL;
     }

--- a/Modules/_testbuffer.c
+++ b/Modules/_testbuffer.c
@@ -1856,7 +1856,7 @@ ndarray_subscript(NDArrayObject *self, PyObject *key)
 type_error:
     PyErr_Format(PyExc_TypeError,
         "cannot index memory using \"%.200s\"",
-        key->ob_type->tp_name);
+        Py_TYPE(key)->tp_name);
 err_occurred:
     Py_DECREF(nd);
     return NULL;

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -263,7 +263,7 @@ dict_hassplittable(PyObject *self, PyObject *arg)
     if (!PyDict_Check(arg)) {
         PyErr_Format(PyExc_TypeError,
                      "dict_hassplittable() argument must be dict, not '%s'",
-                     arg->ob_type->tp_name);
+                     Py_TYPE(arg)->tp_name);
         return NULL;
     }
 
@@ -2375,7 +2375,7 @@ test_thread_state(PyObject *self, PyObject *args)
 
     if (!PyCallable_Check(fn)) {
         PyErr_Format(PyExc_TypeError, "'%s' object is not callable",
-            fn->ob_type->tp_name);
+            Py_TYPE(fn)->tp_name);
         return NULL;
     }
 

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -793,7 +793,7 @@ typedef struct {
 } PyTclObject;
 
 static PyObject *PyTclObject_Type;
-#define PyTclObject_Check(v) ((v)->ob_type == (PyTypeObject *) PyTclObject_Type)
+#define PyTclObject_Check(v) (Py_TYPE((v)) == (PyTypeObject *) PyTclObject_Type)
 
 static PyObject *
 newPyTclObject(Tcl_Obj *arg)
@@ -1701,7 +1701,7 @@ varname_converter(PyObject *in, void *_out)
     }
     PyErr_Format(PyExc_TypeError,
                  "must be str, bytes or Tcl_Obj, not %.50s",
-                 in->ob_type->tp_name);
+                 Py_TYPE(in)->tp_name);
     return 0;
 }
 

--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -1285,7 +1285,7 @@ mbstreamreader_iread(MultibyteStreamReaderObject *self,
             PyErr_Format(PyExc_TypeError,
                          "stream function returned a "
                          "non-bytes object (%.100s)",
-                         cres->ob_type->tp_name);
+                         Py_TYPE(cres)->tp_name);
             goto errorexit;
         }
 

--- a/Modules/cjkcodecs/multibytecodec.h
+++ b/Modules/cjkcodecs/multibytecodec.h
@@ -62,7 +62,7 @@ typedef struct {
     MultibyteCodec *codec;
 } MultibyteCodecObject;
 
-#define MultibyteCodec_Check(op) ((op)->ob_type == &MultibyteCodec_Type)
+#define MultibyteCodec_Check(op) (Py_TYPE(op) == &MultibyteCodec_Type)
 
 #define _MultibyteStatefulCodec_HEAD            \
     PyObject_HEAD                               \

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -571,7 +571,7 @@ untrack_dicts(PyGC_Head *head)
 static int
 has_legacy_finalizer(PyObject *op)
 {
-    return op->ob_type->tp_del != NULL;
+    return Py_TYPE(op)->tp_del != NULL;
 }
 
 /* Move the objects in unreachable with tp_del slots into `finalizers`.

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -111,7 +111,7 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
         PyErr_Clear();
         if (PyErr_WarnFormat(PyExc_DeprecationWarning, 1,
                              "group id must be int, not %.200",
-                             id->ob_type->tp_name) < 0) {
+                             Py_TYPE(id)->tp_name) < 0) {
             return NULL;
         }
         py_int_id = PyNumber_Long(id);

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -260,7 +260,7 @@ PyTypeObject PyST_Type = {
 
 
 /* PyST_Type isn't subclassable, so just check ob_type */
-#define PyST_Object_Check(v) ((v)->ob_type == &PyST_Type)
+#define PyST_Object_Check(v) (Py_TYPE((v)) == &PyST_Type)
 
 static int
 parser_compare_nodes(node *left, node *right)

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1369,7 +1369,7 @@ xmlparse_setattro(xmlparseobject *self, PyObject *name, PyObject *v)
     if (!PyUnicode_Check(name)) {
         PyErr_Format(PyExc_TypeError,
                      "attribute name must be string, not '%.200s'",
-                     name->ob_type->tp_name);
+                     Py_TYPE(name)->tp_name);
         return -1;
     }
     if (v == NULL) {

--- a/Modules/sha512module.c
+++ b/Modules/sha512module.c
@@ -478,7 +478,7 @@ SHA512Type_copy_impl(SHAobject *self)
 {
     SHAobject *newobj;
 
-    if (((PyObject*)self)->ob_type == &SHA512type) {
+    if (Py_TYPE(((PyObject *)self)) == &SHA512type) {
         if ( (newobj = newSHA512object())==NULL)
             return NULL;
     } else {

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -1565,7 +1565,7 @@ idna_converter(PyObject *obj, struct maybe_idna *data)
     }
     else {
         PyErr_Format(PyExc_TypeError, "str, bytes or bytearray expected, not %s",
-                     obj->ob_type->tp_name);
+                     Py_TYPE(obj)->tp_name);
         return 0;
     }
     if (strlen(data->buf) != len) {

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2782,7 +2782,7 @@ PyBytes_FromObject(PyObject *x)
 
     PyErr_Format(PyExc_TypeError,
                  "cannot convert '%.200s' object to bytes",
-                 x->ob_type->tp_name);
+                 Py_TYPE(x)->tp_name);
     return NULL;
 }
 

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -105,10 +105,10 @@ _PyObject_FastCallDict(PyObject *callable, PyObject *const *args, Py_ssize_t nar
         ternaryfunc call;
 
         /* Slow-path: build a temporary tuple */
-        call = callable->ob_type->tp_call;
+        call = Py_TYPE(callable)->tp_call;
         if (call == NULL) {
             PyErr_Format(PyExc_TypeError, "'%.200s' object is not callable",
-                         callable->ob_type->tp_name);
+                         Py_TYPE(callable)->tp_name);
             return NULL;
         }
 
@@ -167,10 +167,10 @@ _PyObject_FastCallKeywords(PyObject *callable, PyObject *const *stack, Py_ssize_
         nkwargs = (kwnames == NULL) ? 0 : PyTuple_GET_SIZE(kwnames);
         assert((nargs == 0 && nkwargs == 0) || stack != NULL);
 
-        call = callable->ob_type->tp_call;
+        call = Py_TYPE(callable)->tp_call;
         if (call == NULL) {
             PyErr_Format(PyExc_TypeError, "'%.200s' object is not callable",
-                         callable->ob_type->tp_name);
+                         Py_TYPE(callable)->tp_name);
             return NULL;
         }
 
@@ -232,10 +232,10 @@ PyObject_Call(PyObject *callable, PyObject *args, PyObject *kwargs)
         return PyCFunction_Call(callable, args, kwargs);
     }
     else {
-        call = callable->ob_type->tp_call;
+        call = Py_TYPE(callable)->tp_call;
         if (call == NULL) {
             PyErr_Format(PyExc_TypeError, "'%.200s' object is not callable",
-                         callable->ob_type->tp_name);
+                         Py_TYPE(callable)->tp_name);
             return NULL;
         }
 

--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -80,7 +80,7 @@ cell_repr(PyCellObject *op)
         return PyUnicode_FromFormat("<cell at %p: empty>", op);
 
     return PyUnicode_FromFormat("<cell at %p: %.80s object at %p>",
-                               op, op->ob_ref->ob_type->tp_name,
+                               op, Py_TYPE(op->ob_ref)->tp_name,
                                op->ob_ref);
 }
 

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -136,7 +136,7 @@ static PyObject *
 method_getattro(PyObject *obj, PyObject *name)
 {
     PyMethodObject *im = (PyMethodObject *)obj;
-    PyTypeObject *tp = obj->ob_type;
+    PyTypeObject *tp = Py_TYPE(obj);
     PyObject *descr = NULL;
 
     {
@@ -148,9 +148,9 @@ method_getattro(PyObject *obj, PyObject *name)
     }
 
     if (descr != NULL) {
-        descrgetfunc f = TP_DESCR_GET(descr->ob_type);
+        descrgetfunc f = TP_DESCR_GET(Py_TYPE(descr));
         if (f != NULL)
-            return f(descr, obj, (PyObject *)obj->ob_type);
+            return f(descr, obj, (PyObject *)Py_TYPE(obj));
         else {
             Py_INCREF(descr);
             return descr;
@@ -447,7 +447,7 @@ static PyGetSetDef instancemethod_getset[] = {
 static PyObject *
 instancemethod_getattro(PyObject *self, PyObject *name)
 {
-    PyTypeObject *tp = self->ob_type;
+    PyTypeObject *tp = Py_TYPE(self);
     PyObject *descr = NULL;
 
     if (tp->tp_dict == NULL) {
@@ -457,9 +457,9 @@ instancemethod_getattro(PyObject *self, PyObject *name)
     descr = _PyType_Lookup(tp, name);
 
     if (descr != NULL) {
-        descrgetfunc f = TP_DESCR_GET(descr->ob_type);
+        descrgetfunc f = TP_DESCR_GET(Py_TYPE(descr));
         if (f != NULL)
-            return f(descr, self, (PyObject *)self->ob_type);
+            return f(descr, self, (PyObject *)Py_TYPE(self));
         else {
             Py_INCREF(descr);
             return descr;

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -316,7 +316,7 @@ validate_and_copy_tuple(PyObject *tup)
                 PyExc_TypeError,
                 "name tuples must contain only "
                 "strings, not '%.500s'",
-                item->ob_type->tp_name);
+                Py_TYPE(item)->tp_name);
             Py_DECREF(newtuple);
             return NULL;
         }

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -289,7 +289,7 @@ try_complex_special_method(PyObject *op)
         if (!PyComplex_Check(res)) {
             PyErr_Format(PyExc_TypeError,
                 "__complex__ returned non-complex (type %.200s)",
-                res->ob_type->tp_name);
+                Py_TYPE(res)->tp_name);
             Py_DECREF(res);
             return NULL;
         }
@@ -298,7 +298,7 @@ try_complex_special_method(PyObject *op)
                 "__complex__ returned non-complex (type %.200s).  "
                 "The ability to return an instance of a strict subclass of complex "
                 "is deprecated, and may be removed in a future version of Python.",
-                res->ob_type->tp_name)) {
+                Py_TYPE(res)->tp_name)) {
             Py_DECREF(res);
             return NULL;
         }
@@ -346,7 +346,7 @@ PyComplex_AsCComplex(PyObject *op)
 static void
 complex_dealloc(PyObject *op)
 {
-    op->ob_type->tp_free(op);
+    Py_TYPE(op)->tp_free(op);
 }
 
 static PyObject *
@@ -989,7 +989,7 @@ complex_new_impl(PyTypeObject *type, PyObject *r, PyObject *i)
         return NULL;
     }
 
-    nbr = r->ob_type->tp_as_number;
+    nbr = Py_TYPE(r)->tp_as_number;
     if (nbr == NULL || nbr->nb_float == NULL) {
         PyErr_Format(PyExc_TypeError,
                      "complex() first argument must be a string or a number, "
@@ -1001,7 +1001,7 @@ complex_new_impl(PyTypeObject *type, PyObject *r, PyObject *i)
         return NULL;
     }
     if (i != NULL) {
-        nbi = i->ob_type->tp_as_number;
+        nbi = Py_TYPE(i)->tp_as_number;
         if (nbi == NULL || nbi->nb_float == NULL) {
             PyErr_Format(PyExc_TypeError,
                          "complex() second argument must be a number, "

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -80,7 +80,7 @@ descr_check(PyDescrObject *descr, PyObject *obj, PyObject **pres)
                      "doesn't apply to '%s' object",
                      descr_name((PyDescrObject *)descr), "?",
                      descr->d_type->tp_name,
-                     obj->ob_type->tp_name);
+                     Py_TYPE(obj)->tp_name);
         *pres = NULL;
         return 1;
     }
@@ -93,7 +93,7 @@ classmethod_get(PyMethodDescrObject *descr, PyObject *obj, PyObject *type)
     /* Ensure a valid type.  Class methods ignore obj. */
     if (type == NULL) {
         if (obj != NULL)
-            type = (PyObject *)obj->ob_type;
+            type = (PyObject *)Py_TYPE(obj);
         else {
             /* Wot - no type?! */
             PyErr_Format(PyExc_TypeError,
@@ -110,7 +110,7 @@ classmethod_get(PyMethodDescrObject *descr, PyObject *obj, PyObject *type)
                      "needs a type, not a '%s' as arg 2",
                      descr_name((PyDescrObject *)descr), "?",
                      PyDescr_TYPE(descr)->tp_name,
-                     type->ob_type->tp_name);
+                     Py_TYPE(type)->tp_name);
         return NULL;
     }
     if (!PyType_IsSubtype((PyTypeObject *)type, PyDescr_TYPE(descr))) {
@@ -182,7 +182,7 @@ descr_setcheck(PyDescrObject *descr, PyObject *obj, PyObject *value,
                      "doesn't apply to '%.100s' object",
                      descr_name(descr), "?",
                      descr->d_type->tp_name,
-                     obj->ob_type->tp_name);
+                     Py_TYPE(obj)->tp_name);
         *pres = -1;
         return 1;
     }
@@ -242,7 +242,7 @@ methoddescr_call(PyMethodDescrObject *descr, PyObject *args, PyObject *kwargs)
                      "but received a '%.100s'",
                      descr_name((PyDescrObject *)descr), "?",
                      PyDescr_TYPE(descr)->tp_name,
-                     self->ob_type->tp_name);
+                     Py_TYPE(self)->tp_name);
         return NULL;
     }
 
@@ -281,7 +281,7 @@ _PyMethodDescr_FastCallKeywords(PyObject *descrobj,
                      "but received a '%.100s'",
                      descr_name((PyDescrObject *)descr), "?",
                      PyDescr_TYPE(descr)->tp_name,
-                     self->ob_type->tp_name);
+                     Py_TYPE(self)->tp_name);
         return NULL;
     }
 
@@ -316,7 +316,7 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
                      "but received a '%.100s'",
                      descr_name((PyDescrObject *)descr), "?",
                      PyDescr_TYPE(descr)->tp_name,
-                     self->ob_type->tp_name);
+                     Py_TYPE(self)->tp_name);
         return NULL;
     }
     if (!PyType_IsSubtype((PyTypeObject *)self, PyDescr_TYPE(descr))) {
@@ -326,7 +326,7 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
                      "but received '%.100s",
                      descr_name((PyDescrObject *)descr), "?",
                      PyDescr_TYPE(descr)->tp_name,
-                     self->ob_type->tp_name);
+                     Py_TYPE(self)->tp_name);
         return NULL;
     }
 
@@ -383,7 +383,7 @@ wrapperdescr_call(PyWrapperDescrObject *descr, PyObject *args, PyObject *kwds)
                      "but received a '%.100s'",
                      descr_name((PyDescrObject *)descr), "?",
                      PyDescr_TYPE(descr)->tp_name,
-                     self->ob_type->tp_name);
+                     Py_TYPE(self)->tp_name);
         return NULL;
     }
 
@@ -1078,7 +1078,7 @@ wrapper_repr(wrapperobject *wp)
 {
     return PyUnicode_FromFormat("<method-wrapper '%s' of %s object at %p>",
                                wp->descr->d_base->name,
-                               wp->self->ob_type->tp_name,
+                               Py_TYPE(wp->self)->tp_name,
                                wp->self);
 }
 
@@ -1325,7 +1325,7 @@ property_dealloc(PyObject *self)
     Py_XDECREF(gs->prop_set);
     Py_XDECREF(gs->prop_del);
     Py_XDECREF(gs->prop_doc);
-    self->ob_type->tp_free(self);
+    Py_TYPE(self)->tp_free(self);
 }
 
 static PyObject *

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -3747,7 +3747,7 @@ _PyDictView_New(PyObject *dict, PyTypeObject *type)
         /* XXX Get rid of this restriction later */
         PyErr_Format(PyExc_TypeError,
                      "%s() requires a dict argument, not '%s'",
-                     type->tp_name, dict->ob_type->tp_name);
+                     type->tp_name, Py_TYPE(dict)->tp_name);
         return NULL;
     }
     dv = PyObject_GC_New(_PyDictViewObject, type);

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -247,7 +247,7 @@ PyFloat_AsDouble(PyObject *op)
     nb = Py_TYPE(op)->tp_as_number;
     if (nb == NULL || nb->nb_float == NULL) {
         PyErr_Format(PyExc_TypeError, "must be real number, not %.50s",
-                     op->ob_type->tp_name);
+                     Py_TYPE(op)->tp_name);
         return -1;
     }
 
@@ -259,7 +259,7 @@ PyFloat_AsDouble(PyObject *op)
         if (!PyFloat_Check(res)) {
             PyErr_Format(PyExc_TypeError,
                          "%.50s.__float__ returned non-float (type %.50s)",
-                         op->ob_type->tp_name, res->ob_type->tp_name);
+                         Py_TYPE(op)->tp_name, Py_TYPE(res)->tp_name);
             Py_DECREF(res);
             return -1;
         }
@@ -267,7 +267,7 @@ PyFloat_AsDouble(PyObject *op)
                 "%.50s.__float__ returned non-float (type %.50s).  "
                 "The ability to return an instance of a strict subclass of float "
                 "is deprecated, and may be removed in a future version of Python.",
-                op->ob_type->tp_name, res->ob_type->tp_name)) {
+                Py_TYPE(op)->tp_name, Py_TYPE(res)->tp_name)) {
             Py_DECREF(res);
             return -1;
         }

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -189,7 +189,7 @@ PyFunction_SetClosure(PyObject *op, PyObject *closure)
     else {
         PyErr_Format(PyExc_SystemError,
                      "expected tuple for closure, got '%.100s'",
-                     closure->ob_type->tp_name);
+                     Py_TYPE(closure)->tp_name);
         return -1;
     }
     Py_XSETREF(((PyFunctionObject *)op)->func_closure, closure);
@@ -497,7 +497,7 @@ func_new_impl(PyTypeObject *type, PyCodeObject *code, PyObject *globals,
             if (!PyCell_Check(o)) {
                 return PyErr_Format(PyExc_TypeError,
                     "arg 5 (closure) expected cell, found %s",
-                                    o->ob_type->tp_name);
+                                    Py_TYPE(o)->tp_name);
             }
         }
     }

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -490,7 +490,7 @@ list_concat(PyListObject *a, PyObject *bb)
     if (!PyList_Check(bb)) {
         PyErr_Format(PyExc_TypeError,
                   "can only concatenate list (not \"%.200s\") to list",
-                  bb->ob_type->tp_name);
+                  Py_TYPE(bb)->tp_name);
         return NULL;
     }
 #define b ((PyListObject *)bb)
@@ -889,7 +889,7 @@ list_extend(PyListObject *self, PyObject *iterable)
     it = PyObject_GetIter(iterable);
     if (it == NULL)
         return NULL;
-    iternext = *it->ob_type->tp_iternext;
+    iternext = *Py_TYPE(it)->tp_iternext;
 
     /* Guess a result list size. */
     n = PyObject_LengthHint(iterable, 8);
@@ -2016,7 +2016,7 @@ unsafe_object_compare(PyObject *v, PyObject *w, MergeState *ms)
     PyObject *res_obj; int res;
 
     /* No assumptions, because we check first: */
-    if (v->ob_type->tp_richcompare != ms->key_richcompare)
+    if (Py_TYPE(v)->tp_richcompare != ms->key_richcompare)
         return PyObject_RichCompareBool(v, w, Py_LT);
 
     assert(ms->key_richcompare != NULL);
@@ -2053,8 +2053,8 @@ unsafe_latin_compare(PyObject *v, PyObject *w, MergeState *ms)
     int res;
 
     /* Modified from Objects/unicodeobject.c:unicode_compare, assuming: */
-    assert(v->ob_type == w->ob_type);
-    assert(v->ob_type == &PyUnicode_Type);
+    assert(Py_TYPE(v) == Py_TYPE(w));
+    assert(Py_TYPE(v) == &PyUnicode_Type);
     assert(PyUnicode_KIND(v) == PyUnicode_KIND(w));
     assert(PyUnicode_KIND(v) == PyUnicode_1BYTE_KIND);
 
@@ -2076,8 +2076,8 @@ unsafe_long_compare(PyObject *v, PyObject *w, MergeState *ms)
     PyLongObject *vl, *wl; sdigit v0, w0; int res;
 
     /* Modified from Objects/longobject.c:long_compare, assuming: */
-    assert(v->ob_type == w->ob_type);
-    assert(v->ob_type == &PyLong_Type);
+    assert(Py_TYPE(v) == Py_TYPE(w));
+    assert(Py_TYPE(v) == &PyLong_Type);
     assert(Py_ABS(Py_SIZE(v)) <= 1);
     assert(Py_ABS(Py_SIZE(w)) <= 1);
 
@@ -2104,8 +2104,8 @@ unsafe_float_compare(PyObject *v, PyObject *w, MergeState *ms)
     int res;
 
     /* Modified from Objects/floatobject.c:float_richcompare, assuming: */
-    assert(v->ob_type == w->ob_type);
-    assert(v->ob_type == &PyFloat_Type);
+    assert(Py_TYPE(v) == Py_TYPE(w));
+    assert(Py_TYPE(v) == &PyFloat_Type);
 
     res = PyFloat_AS_DOUBLE(v) < PyFloat_AS_DOUBLE(w);
     assert(res == PyObject_RichCompareBool(v, w, Py_LT));
@@ -2126,8 +2126,8 @@ unsafe_tuple_compare(PyObject *v, PyObject *w, MergeState *ms)
     int k;
 
     /* Modified from Objects/tupleobject.c:tuplerichcompare, assuming: */
-    assert(v->ob_type == w->ob_type);
-    assert(v->ob_type == &PyTuple_Type);
+    assert(Py_TYPE(v) == Py_TYPE(w));
+    assert(Py_TYPE(v) == &PyTuple_Type);
     assert(Py_SIZE(v) > 0);
     assert(Py_SIZE(w) > 0);
 
@@ -2241,12 +2241,12 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
      * set ms appropriately. */
     if (saved_ob_size > 1) {
         /* Assume the first element is representative of the whole list. */
-        int keys_are_in_tuples = (lo.keys[0]->ob_type == &PyTuple_Type &&
+        int keys_are_in_tuples = (Py_TYPE(lo.keys[0]) == &PyTuple_Type &&
                                   Py_SIZE(lo.keys[0]) > 0);
 
         PyTypeObject* key_type = (keys_are_in_tuples ?
-                                  PyTuple_GET_ITEM(lo.keys[0], 0)->ob_type :
-                                  lo.keys[0]->ob_type);
+                                  Py_TYPE(PyTuple_GET_ITEM(lo.keys[0], 0)) :
+                                  Py_TYPE(lo.keys[0]));
 
         int keys_are_all_same_type = 1;
         int strings_are_latin = 1;
@@ -2257,7 +2257,7 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
         for (i=0; i < saved_ob_size; i++) {
 
             if (keys_are_in_tuples &&
-                !(lo.keys[i]->ob_type == &PyTuple_Type && Py_SIZE(lo.keys[i]) != 0)) {
+                !(Py_TYPE(lo.keys[i]) == &PyTuple_Type && Py_SIZE(lo.keys[i]) != 0)) {
                 keys_are_in_tuples = 0;
                 keys_are_all_same_type = 0;
                 break;
@@ -2270,7 +2270,7 @@ list_sort_impl(PyListObject *self, PyObject *keyfunc, int reverse)
                              PyTuple_GET_ITEM(lo.keys[i], 0) :
                              lo.keys[i]);
 
-            if (key->ob_type != key_type) {
+            if (Py_TYPE(key) != key_type) {
                 keys_are_all_same_type = 0;
                 break;
             }
@@ -2777,7 +2777,7 @@ list_subscript(PyListObject* self, PyObject* item)
     else {
         PyErr_Format(PyExc_TypeError,
                      "list indices must be integers or slices, not %.200s",
-                     item->ob_type->tp_name);
+                     Py_TYPE(item)->tp_name);
         return NULL;
     }
 }
@@ -2939,7 +2939,7 @@ list_ass_subscript(PyListObject* self, PyObject* item, PyObject* value)
     else {
         PyErr_Format(PyExc_TypeError,
                      "list indices must be integers or slices, not %.200s",
-                     item->ob_type->tp_name);
+                     Py_TYPE(item)->tp_name);
         return -1;
     }
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -168,7 +168,7 @@ _PyLong_FromNbInt(PyObject *integral)
     if (!PyLong_Check(result)) {
         PyErr_Format(PyExc_TypeError,
                      "__int__ returned non-int (type %.200s)",
-                     result->ob_type->tp_name);
+                     Py_TYPE(result)->tp_name);
         Py_DECREF(result);
         return NULL;
     }
@@ -177,7 +177,7 @@ _PyLong_FromNbInt(PyObject *integral)
             "__int__ returned non-int (type %.200s).  "
             "The ability to return an instance of a strict subclass of int "
             "is deprecated, and may be removed in a future version of Python.",
-            result->ob_type->tp_name)) {
+            Py_TYPE(result)->tp_name)) {
         Py_DECREF(result);
         return NULL;
     }

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -217,7 +217,7 @@ meth_repr(PyCFunctionObject *m)
                                    m->m_ml->ml_name);
     return PyUnicode_FromFormat("<built-in method %s of %s object at %p>",
                                m->m_ml->ml_name,
-                               m->m_self->ob_type->tp_name,
+                               Py_TYPE(m->m_self)->tp_name,
                                m->m_self);
 }
 

--- a/Objects/namespaceobject.c
+++ b/Objects/namespaceobject.c
@@ -73,7 +73,7 @@ namespace_repr(PyObject *ns)
     const char * name;
 
     name = (Py_TYPE(ns) == &_PyNamespace_Type) ? "namespace"
-                                               : ns->ob_type->tp_name;
+                                               : Py_TYPE(ns)->tp_name;
 
     i = Py_ReprEnter(ns);
     if (i != 0) {

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -386,7 +386,7 @@ PyObject_Print(PyObject *op, FILE *fp, int flags)
             else {
                 PyErr_Format(PyExc_TypeError,
                              "str() or repr() returned '%.100s'",
-                             s->ob_type->tp_name);
+                             Py_TYPE(s)->tp_name);
                 ret = -1;
             }
             Py_XDECREF(s);
@@ -455,7 +455,7 @@ PyObject_Repr(PyObject *v)
         return PyUnicode_FromString("<NULL>");
     if (Py_TYPE(v)->tp_repr == NULL)
         return PyUnicode_FromFormat("<%s object at %p>",
-                                    v->ob_type->tp_name, v);
+                                    Py_TYPE(v)->tp_name, v);
 
 #ifdef Py_DEBUG
     /* PyObject_Repr() must not be called with an exception set,
@@ -468,14 +468,14 @@ PyObject_Repr(PyObject *v)
        infinitely. */
     if (Py_EnterRecursiveCall(" while getting the repr of an object"))
         return NULL;
-    res = (*v->ob_type->tp_repr)(v);
+    res = (*Py_TYPE(v)->tp_repr)(v);
     Py_LeaveRecursiveCall();
     if (res == NULL)
         return NULL;
     if (!PyUnicode_Check(res)) {
         PyErr_Format(PyExc_TypeError,
                      "__repr__ returned non-string (type %.200s)",
-                     res->ob_type->tp_name);
+                     Py_TYPE(res)->tp_name);
         Py_DECREF(res);
         return NULL;
     }
@@ -645,22 +645,22 @@ do_richcompare(PyObject *v, PyObject *w, int op)
     PyObject *res;
     int checked_reverse_op = 0;
 
-    if (v->ob_type != w->ob_type &&
-        PyType_IsSubtype(w->ob_type, v->ob_type) &&
-        (f = w->ob_type->tp_richcompare) != NULL) {
+    if (Py_TYPE(v) != Py_TYPE(w) &&
+        PyType_IsSubtype(Py_TYPE(w), Py_TYPE(v)) &&
+        (f = Py_TYPE(w)->tp_richcompare) != NULL) {
         checked_reverse_op = 1;
         res = (*f)(w, v, _Py_SwappedOp[op]);
         if (res != Py_NotImplemented)
             return res;
         Py_DECREF(res);
     }
-    if ((f = v->ob_type->tp_richcompare) != NULL) {
+    if ((f = Py_TYPE(v)->tp_richcompare) != NULL) {
         res = (*f)(v, w, op);
         if (res != Py_NotImplemented)
             return res;
         Py_DECREF(res);
     }
-    if (!checked_reverse_op && (f = w->ob_type->tp_richcompare) != NULL) {
+    if (!checked_reverse_op && (f = Py_TYPE(w)->tp_richcompare) != NULL) {
         res = (*f)(w, v, _Py_SwappedOp[op]);
         if (res != Py_NotImplemented)
             return res;
@@ -679,8 +679,8 @@ do_richcompare(PyObject *v, PyObject *w, int op)
         PyErr_Format(PyExc_TypeError,
                      "'%s' not supported between instances of '%.100s' and '%.100s'",
                      opstrings[op],
-                     v->ob_type->tp_name,
-                     w->ob_type->tp_name);
+                     Py_TYPE(v)->tp_name,
+                     Py_TYPE(w)->tp_name);
         return NULL;
     }
     Py_INCREF(res);
@@ -866,7 +866,7 @@ PyObject_GetAttr(PyObject *v, PyObject *name)
     if (!PyUnicode_Check(name)) {
         PyErr_Format(PyExc_TypeError,
                      "attribute name must be string, not '%.200s'",
-                     name->ob_type->tp_name);
+                     Py_TYPE(name)->tp_name);
         return NULL;
     }
     if (tp->tp_getattro != NULL)
@@ -891,7 +891,7 @@ _PyObject_LookupAttr(PyObject *v, PyObject *name, PyObject **result)
     if (!PyUnicode_Check(name)) {
         PyErr_Format(PyExc_TypeError,
                      "attribute name must be string, not '%.200s'",
-                     name->ob_type->tp_name);
+                     Py_TYPE(name)->tp_name);
         *result = NULL;
         return -1;
     }
@@ -967,7 +967,7 @@ PyObject_SetAttr(PyObject *v, PyObject *name, PyObject *value)
     if (!PyUnicode_Check(name)) {
         PyErr_Format(PyExc_TypeError,
                      "attribute name must be string, not '%.200s'",
-                     name->ob_type->tp_name);
+                     Py_TYPE(name)->tp_name);
         return -1;
     }
     Py_INCREF(name);
@@ -1109,9 +1109,9 @@ _PyObject_GetMethod(PyObject *obj, PyObject *name, PyObject **method)
                 (Py_TYPE(descr) == &PyMethodDescr_Type)) {
             meth_found = 1;
         } else {
-            f = descr->ob_type->tp_descr_get;
+            f = Py_TYPE(descr)->tp_descr_get;
             if (f != NULL && PyDescr_IsData(descr)) {
-                *method = f(descr, obj, (PyObject *)obj->ob_type);
+                *method = f(descr, obj, (PyObject *)Py_TYPE(obj));
                 Py_DECREF(descr);
                 return 0;
             }
@@ -1176,7 +1176,7 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
     if (!PyUnicode_Check(name)){
         PyErr_Format(PyExc_TypeError,
                      "attribute name must be string, not '%.200s'",
-                     name->ob_type->tp_name);
+                     Py_TYPE(name)->tp_name);
         return NULL;
     }
     Py_INCREF(name);
@@ -1191,9 +1191,9 @@ _PyObject_GenericGetAttrWithDict(PyObject *obj, PyObject *name,
     f = NULL;
     if (descr != NULL) {
         Py_INCREF(descr);
-        f = descr->ob_type->tp_descr_get;
+        f = Py_TYPE(descr)->tp_descr_get;
         if (f != NULL && PyDescr_IsData(descr)) {
-            res = f(descr, obj, (PyObject *)obj->ob_type);
+            res = f(descr, obj, (PyObject *)Py_TYPE(obj));
             if (res == NULL && suppress &&
                     PyErr_ExceptionMatches(PyExc_AttributeError)) {
                 PyErr_Clear();
@@ -1280,7 +1280,7 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
     if (!PyUnicode_Check(name)){
         PyErr_Format(PyExc_TypeError,
                      "attribute name must be string, not '%.200s'",
-                     name->ob_type->tp_name);
+                     Py_TYPE(name)->tp_name);
         return -1;
     }
 
@@ -1293,7 +1293,7 @@ _PyObject_GenericSetAttrWithDict(PyObject *obj, PyObject *name,
 
     if (descr != NULL) {
         Py_INCREF(descr);
-        f = descr->ob_type->tp_descr_set;
+        f = Py_TYPE(descr)->tp_descr_set;
         if (f != NULL) {
             res = f(descr, obj, value);
             goto done;
@@ -1378,15 +1378,15 @@ PyObject_IsTrue(PyObject *v)
         return 0;
     if (v == Py_None)
         return 0;
-    else if (v->ob_type->tp_as_number != NULL &&
-             v->ob_type->tp_as_number->nb_bool != NULL)
-        res = (*v->ob_type->tp_as_number->nb_bool)(v);
-    else if (v->ob_type->tp_as_mapping != NULL &&
-             v->ob_type->tp_as_mapping->mp_length != NULL)
-        res = (*v->ob_type->tp_as_mapping->mp_length)(v);
-    else if (v->ob_type->tp_as_sequence != NULL &&
-             v->ob_type->tp_as_sequence->sq_length != NULL)
-        res = (*v->ob_type->tp_as_sequence->sq_length)(v);
+    else if (Py_TYPE(v)->tp_as_number != NULL &&
+             Py_TYPE(v)->tp_as_number->nb_bool != NULL)
+        res = (*Py_TYPE(v)->tp_as_number->nb_bool)(v);
+    else if (Py_TYPE(v)->tp_as_mapping != NULL &&
+             Py_TYPE(v)->tp_as_mapping->mp_length != NULL)
+        res = (*Py_TYPE(v)->tp_as_mapping->mp_length)(v);
+    else if (Py_TYPE(v)->tp_as_sequence != NULL &&
+             Py_TYPE(v)->tp_as_sequence->sq_length != NULL)
+        res = (*Py_TYPE(v)->tp_as_sequence->sq_length)(v);
     else
         return 1;
     /* if it is negative, it should be either -1 or -2 */
@@ -1413,7 +1413,7 @@ PyCallable_Check(PyObject *x)
 {
     if (x == NULL)
         return 0;
-    return x->ob_type->tp_call != NULL;
+    return Py_TYPE(x)->tp_call != NULL;
 }
 
 

--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -614,7 +614,7 @@ range_subscript(rangeobject* self, PyObject* item)
     }
     PyErr_Format(PyExc_TypeError,
                  "range indices must be integers or slices, not %.200s",
-                 item->ob_type->tp_name);
+                 Py_TYPE(item)->tp_name);
     return NULL;
 }
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -3150,7 +3150,7 @@ type_getattro(PyTypeObject *type, PyObject *name)
     if (!PyUnicode_Check(name)) {
         PyErr_Format(PyExc_TypeError,
                      "attribute name must be string, not '%.200s'",
-                     name->ob_type->tp_name);
+                     Py_TYPE(name)->tp_name);
         return NULL;
     }
 
@@ -3792,12 +3792,12 @@ object_richcompare(PyObject *self, PyObject *other, int op)
     case Py_NE:
         /* By default, __ne__() delegates to __eq__() and inverts the result,
            unless the latter returns NotImplemented. */
-        if (self->ob_type->tp_richcompare == NULL) {
+        if (Py_TYPE(self)->tp_richcompare == NULL) {
             res = Py_NotImplemented;
             Py_INCREF(res);
             break;
         }
-        res = (*self->ob_type->tp_richcompare)(self, other, Py_EQ);
+        res = (*Py_TYPE(self)->tp_richcompare)(self, other, Py_EQ);
         if (res != NULL && res != Py_NotImplemented) {
             int ok = PyObject_IsTrue(res);
             Py_DECREF(res);
@@ -4114,7 +4114,7 @@ _PyObject_GetState(PyObject *obj, int required)
     if (getstate == NULL) {
         PyObject *slotnames;
 
-        if (required && obj->ob_type->tp_itemsize) {
+        if (required && Py_TYPE(obj)->tp_itemsize) {
             PyErr_Format(PyExc_TypeError,
                          "can't pickle %.200s objects",
                          Py_TYPE(obj)->tp_name);
@@ -4147,13 +4147,13 @@ _PyObject_GetState(PyObject *obj, int required)
         assert(slotnames == Py_None || PyList_Check(slotnames));
         if (required) {
             Py_ssize_t basicsize = PyBaseObject_Type.tp_basicsize;
-            if (obj->ob_type->tp_dictoffset)
+            if (Py_TYPE(obj)->tp_dictoffset)
                 basicsize += sizeof(PyObject *);
-            if (obj->ob_type->tp_weaklistoffset)
+            if (Py_TYPE(obj)->tp_weaklistoffset)
                 basicsize += sizeof(PyObject *);
             if (slotnames != Py_None)
                 basicsize += sizeof(PyObject *) * PyList_GET_SIZE(slotnames);
-            if (obj->ob_type->tp_basicsize > basicsize) {
+            if (Py_TYPE(obj)->tp_basicsize > basicsize) {
                 Py_DECREF(slotnames);
                 Py_DECREF(state);
                 PyErr_Format(PyExc_TypeError,
@@ -4626,7 +4626,7 @@ object___format___impl(PyObject *self, PyObject *format_spec)
     if (PyUnicode_GET_LENGTH(format_spec) > 0) {
         PyErr_Format(PyExc_TypeError,
                      "unsupported format string passed to %.200s.__format__",
-                     self->ob_type->tp_name);
+                     Py_TYPE(self)->tp_name);
         return NULL;
     }
     return PyObject_Str(self);
@@ -4645,10 +4645,10 @@ object___sizeof___impl(PyObject *self)
     Py_ssize_t res, isize;
 
     res = 0;
-    isize = self->ob_type->tp_itemsize;
+    isize = Py_TYPE(self)->tp_itemsize;
     if (isize > 0)
         res = Py_SIZE(self) * isize;
-    res += self->ob_type->tp_basicsize;
+    res += Py_TYPE(self)->tp_basicsize;
 
     return PyLong_FromSsize_t(res);
 }
@@ -7277,7 +7277,7 @@ set_names(PyTypeObject *type)
                 _PyErr_FormatFromCause(PyExc_RuntimeError,
                     "Error calling __set_name__ on '%.100s' instance %R "
                     "in '%.100s'",
-                    value->ob_type->tp_name, key, type->tp_name);
+                    Py_TYPE(value)->tp_name, key, type->tp_name);
                 Py_DECREF(names_to_set);
                 return -1;
             }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -8303,7 +8303,7 @@ charmapencode_lookup(Py_UCS4 c, PyObject *mapping)
         /* wrong return value */
         PyErr_Format(PyExc_TypeError,
                      "character mapping must return integer, bytes or None, not %.400s",
-                     x->ob_type->tp_name);
+                     Py_TYPE(x)->tp_name);
         Py_DECREF(x);
         return NULL;
     }
@@ -10941,8 +10941,8 @@ PyUnicode_Compare(PyObject *left, PyObject *right)
     }
     PyErr_Format(PyExc_TypeError,
                  "Can't compare %.100s and %.100s",
-                 left->ob_type->tp_name,
-                 right->ob_type->tp_name);
+                 Py_TYPE(left)->tp_name,
+                 Py_TYPE(right)->tp_name);
     return -1;
 }
 
@@ -11212,7 +11212,7 @@ PyUnicode_Concat(PyObject *left, PyObject *right)
     if (!PyUnicode_Check(right)) {
         PyErr_Format(PyExc_TypeError,
                      "can only concatenate str (not \"%.200s\") to str",
-                     right->ob_type->tp_name);
+                     Py_TYPE(right)->tp_name);
         return NULL;
     }
     if (PyUnicode_READY(right) < 0)

--- a/PC/_msi.c
+++ b/PC/_msi.c
@@ -143,7 +143,7 @@ static FNFCIGETNEXTCABINET(cb_getnextcabinet)
         if (!PyBytes_Check(result)) {
             PyErr_Format(PyExc_TypeError,
                 "Incorrect return type %s from getnextcabinet",
-                result->ob_type->tp_name);
+                Py_TYPE(result)->tp_name);
             Py_DECREF(result);
             return FALSE;
         }
@@ -718,7 +718,7 @@ view_execute(msiobj *view, PyObject*args)
         return NULL;
 
     if (oparams != Py_None) {
-        if (oparams->ob_type != &record_Type) {
+        if (Py_TYPE(oparams) != &record_Type) {
             PyErr_SetString(PyExc_TypeError, "Execute argument must be a record");
             return NULL;
         }
@@ -774,7 +774,7 @@ view_modify(msiobj *view, PyObject *args)
     if (!PyArg_ParseTuple(args, "iO:Modify", &kind, &data))
         return NULL;
 
-    if (data->ob_type != &record_Type) {
+    if (Py_TYPE(data) != &record_Type) {
         PyErr_SetString(PyExc_TypeError, "Modify expects a record object");
         return NULL;
     }

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -110,7 +110,7 @@ typedef struct {
     HKEY hkey;
 } PyHKEYObject;
 
-#define PyHKEY_Check(op) ((op)->ob_type == &PyHKEY_Type)
+#define PyHKEY_Check(op) (Py_TYPE((op)) == &PyHKEY_Type)
 
 static char *failMsg = "bad operand type";
 
@@ -675,7 +675,7 @@ Py2Reg(PyObject *value, DWORD typ, BYTE **retDataBuf, DWORD *retDataSize)
                     PyErr_Format(PyExc_TypeError,
                         "Objects of type '%s' can not "
                         "be used as binary registry values",
-                        value->ob_type->tp_name);
+                        Py_TYPE(value)->tp_name);
                     return FALSE;
                 }
 

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -524,7 +524,7 @@ class Obj2ModVisitor(PickleVisitor):
             self.emit("Py_ssize_t i;", depth+1)
             self.emit("if (!PyList_Check(tmp)) {", depth+1)
             self.emit("PyErr_Format(PyExc_TypeError, \"%s field \\\"%s\\\" must "
-                      "be a list, not a %%.200s\", tmp->ob_type->tp_name);" %
+                      "be a list, not a %%.200s\", Py_TYPE(tmp)->tp_name);" %
                       (name, field.name),
                       depth+2, reflow=False)
             self.emit("goto failed;", depth+2)

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -3969,8 +3969,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Module field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Module field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4011,8 +4010,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Interactive field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Interactive field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4077,8 +4075,7 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Suite field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Suite field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4195,8 +4192,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "FunctionDef field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "FunctionDef field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4226,8 +4222,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "FunctionDef field \"decorator_list\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "FunctionDef field \"decorator_list\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4312,8 +4307,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4343,8 +4337,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"decorator_list\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"decorator_list\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4416,8 +4409,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"bases\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"bases\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4447,8 +4439,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"keywords\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"keywords\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4478,8 +4469,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4509,8 +4499,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"decorator_list\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"decorator_list\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4576,8 +4565,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Delete field \"targets\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Delete field \"targets\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4619,8 +4607,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Assign field \"targets\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Assign field \"targets\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4822,8 +4809,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "For field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "For field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4853,8 +4839,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "For field \"orelse\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "For field \"orelse\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4924,8 +4909,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFor field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFor field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4955,8 +4939,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFor field \"orelse\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFor field \"orelse\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5012,8 +4995,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "While field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "While field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5043,8 +5025,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "While field \"orelse\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "While field \"orelse\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5100,8 +5081,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "If field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "If field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5131,8 +5111,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "If field \"orelse\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "If field \"orelse\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5174,8 +5153,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "With field \"items\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "With field \"items\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5205,8 +5183,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "With field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "With field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5248,8 +5225,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncWith field \"items\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncWith field \"items\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5279,8 +5255,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncWith field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncWith field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5362,8 +5337,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5393,8 +5367,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"handlers\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"handlers\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5424,8 +5397,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"orelse\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"orelse\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5455,8 +5427,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"finalbody\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"finalbody\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5536,8 +5507,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Import field \"names\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Import field \"names\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5593,8 +5563,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ImportFrom field \"names\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "ImportFrom field \"names\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5648,8 +5617,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Global field \"names\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Global field \"names\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5690,8 +5658,7 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Nonlocal field \"names\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Nonlocal field \"names\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5846,8 +5813,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "BoolOp field \"values\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "BoolOp field \"values\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6069,8 +6035,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Dict field \"keys\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Dict field \"keys\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6100,8 +6065,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Dict field \"values\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Dict field \"values\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6142,8 +6106,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Set field \"elts\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Set field \"elts\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6198,8 +6161,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ListComp field \"generators\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "ListComp field \"generators\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6254,8 +6216,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "SetComp field \"generators\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "SetComp field \"generators\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6324,8 +6285,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "DictComp field \"generators\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "DictComp field \"generators\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6380,8 +6340,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "GeneratorExp field \"generators\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "GeneratorExp field \"generators\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6509,8 +6468,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Compare field \"ops\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Compare field \"ops\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6540,8 +6498,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Compare field \"comparators\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Compare field \"comparators\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6597,8 +6554,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Call field \"args\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Call field \"args\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6628,8 +6584,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Call field \"keywords\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Call field \"keywords\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6771,8 +6726,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "JoinedStr field \"values\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "JoinedStr field \"values\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7076,8 +7030,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "List field \"elts\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "List field \"elts\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7132,8 +7085,7 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Tuple field \"elts\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "Tuple field \"elts\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7315,8 +7267,7 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ExtSlice field \"dims\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "ExtSlice field \"dims\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7688,8 +7639,7 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "comprehension field \"ifs\" must be a list, not a %.200s",
-                         Py_TYPE(tmp)->tp_name);
+            PyErr_Format(PyExc_TypeError, "comprehension field \"ifs\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -7813,8 +7763,7 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ExceptHandler field \"body\" must be a list, not a %.200s",
-                             Py_TYPE(tmp)->tp_name);
+                PyErr_Format(PyExc_TypeError, "ExceptHandler field \"body\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7866,8 +7815,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"args\" must be a list, not a %.200s",
-                         Py_TYPE(tmp)->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"args\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -7910,8 +7858,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"kwonlyargs\" must be a list, not a %.200s",
-                         Py_TYPE(tmp)->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"kwonlyargs\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -7941,8 +7888,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"kw_defaults\" must be a list, not a %.200s",
-                         Py_TYPE(tmp)->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"kw_defaults\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -7985,8 +7931,7 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"defaults\" must be a list, not a %.200s",
-                         Py_TYPE(tmp)->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"defaults\" must be a list, not a %.200s", Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);

--- a/Python/Python-ast.c
+++ b/Python/Python-ast.c
@@ -3969,7 +3969,8 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Module field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Module field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4010,7 +4011,8 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Interactive field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Interactive field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4075,7 +4077,8 @@ obj2ast_mod(PyObject* obj, mod_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Suite field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Suite field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4192,7 +4195,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "FunctionDef field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "FunctionDef field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4222,7 +4226,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "FunctionDef field \"decorator_list\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "FunctionDef field \"decorator_list\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4307,7 +4312,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4337,7 +4343,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"decorator_list\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFunctionDef field \"decorator_list\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4409,7 +4416,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"bases\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"bases\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4439,7 +4447,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"keywords\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"keywords\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4469,7 +4478,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4499,7 +4509,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ClassDef field \"decorator_list\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ClassDef field \"decorator_list\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4565,7 +4576,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Delete field \"targets\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Delete field \"targets\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4607,7 +4619,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Assign field \"targets\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Assign field \"targets\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4809,7 +4822,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "For field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "For field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4839,7 +4853,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "For field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "For field \"orelse\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4909,7 +4924,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFor field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFor field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4939,7 +4955,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncFor field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncFor field \"orelse\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -4995,7 +5012,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "While field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "While field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5025,7 +5043,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "While field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "While field \"orelse\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5081,7 +5100,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "If field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "If field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5111,7 +5131,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "If field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "If field \"orelse\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5153,7 +5174,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "With field \"items\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "With field \"items\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5183,7 +5205,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "With field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "With field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5225,7 +5248,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncWith field \"items\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncWith field \"items\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5255,7 +5279,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "AsyncWith field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "AsyncWith field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5337,7 +5362,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5367,7 +5393,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"handlers\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"handlers\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5397,7 +5424,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"orelse\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"orelse\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5427,7 +5455,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Try field \"finalbody\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Try field \"finalbody\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5507,7 +5536,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Import field \"names\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Import field \"names\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5563,7 +5593,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ImportFrom field \"names\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ImportFrom field \"names\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5617,7 +5648,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Global field \"names\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Global field \"names\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5658,7 +5690,8 @@ obj2ast_stmt(PyObject* obj, stmt_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Nonlocal field \"names\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Nonlocal field \"names\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -5813,7 +5846,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "BoolOp field \"values\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "BoolOp field \"values\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6035,7 +6069,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Dict field \"keys\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Dict field \"keys\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6065,7 +6100,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Dict field \"values\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Dict field \"values\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6106,7 +6142,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Set field \"elts\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Set field \"elts\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6161,7 +6198,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ListComp field \"generators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ListComp field \"generators\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6216,7 +6254,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "SetComp field \"generators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "SetComp field \"generators\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6285,7 +6324,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "DictComp field \"generators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "DictComp field \"generators\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6340,7 +6380,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "GeneratorExp field \"generators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "GeneratorExp field \"generators\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6468,7 +6509,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Compare field \"ops\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Compare field \"ops\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6498,7 +6540,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Compare field \"comparators\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Compare field \"comparators\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6554,7 +6597,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Call field \"args\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Call field \"args\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6584,7 +6628,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Call field \"keywords\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Call field \"keywords\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -6726,7 +6771,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "JoinedStr field \"values\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "JoinedStr field \"values\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7030,7 +7076,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "List field \"elts\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "List field \"elts\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7085,7 +7132,8 @@ obj2ast_expr(PyObject* obj, expr_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "Tuple field \"elts\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "Tuple field \"elts\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7267,7 +7315,8 @@ obj2ast_slice(PyObject* obj, slice_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ExtSlice field \"dims\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ExtSlice field \"dims\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7639,7 +7688,8 @@ obj2ast_comprehension(PyObject* obj, comprehension_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "comprehension field \"ifs\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "comprehension field \"ifs\" must be a list, not a %.200s",
+                         Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -7763,7 +7813,8 @@ obj2ast_excepthandler(PyObject* obj, excepthandler_ty* out, PyArena* arena)
             Py_ssize_t len;
             Py_ssize_t i;
             if (!PyList_Check(tmp)) {
-                PyErr_Format(PyExc_TypeError, "ExceptHandler field \"body\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+                PyErr_Format(PyExc_TypeError, "ExceptHandler field \"body\" must be a list, not a %.200s",
+                             Py_TYPE(tmp)->tp_name);
                 goto failed;
             }
             len = PyList_GET_SIZE(tmp);
@@ -7815,7 +7866,8 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"args\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"args\" must be a list, not a %.200s",
+                         Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -7858,7 +7910,8 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"kwonlyargs\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"kwonlyargs\" must be a list, not a %.200s",
+                         Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -7888,7 +7941,8 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"kw_defaults\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"kw_defaults\" must be a list, not a %.200s",
+                         Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);
@@ -7931,7 +7985,8 @@ obj2ast_arguments(PyObject* obj, arguments_ty* out, PyArena* arena)
         Py_ssize_t len;
         Py_ssize_t i;
         if (!PyList_Check(tmp)) {
-            PyErr_Format(PyExc_TypeError, "arguments field \"defaults\" must be a list, not a %.200s", tmp->ob_type->tp_name);
+            PyErr_Format(PyExc_TypeError, "arguments field \"defaults\" must be a list, not a %.200s",
+                         Py_TYPE(tmp)->tp_name);
             goto failed;
         }
         len = PyList_GET_SIZE(tmp);

--- a/Python/_warnings.c
+++ b/Python/_warnings.c
@@ -504,7 +504,7 @@ warn_explicit(PyObject *category, PyObject *message,
         text = PyObject_Str(message);
         if (text == NULL)
             goto cleanup;
-        category = (PyObject*)message->ob_type;
+        category = (PyObject*)Py_TYPE(message);
     }
     else {
         text = message;
@@ -749,7 +749,7 @@ get_category(PyObject *message, PyObject *category)
         return NULL;
 
     if (rc == 1)
-        category = (PyObject*)message->ob_type;
+        category = (PyObject*)Py_TYPE(message);
     else if (category == NULL || category == Py_None)
         category = PyExc_UserWarning;
 

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -169,7 +169,7 @@ builtin___build_class__(PyObject *self, PyObject *const *args, Py_ssize_t nargs,
         /* else get the type of the first base */
         else {
             PyObject *base0 = PyTuple_GET_ITEM(bases, 0);
-            meta = (PyObject *) (base0->ob_type);
+            meta = (PyObject *) (Py_TYPE(base0));
         }
         Py_INCREF(meta);
         isclass = 1;  /* meta is really a class */
@@ -1021,13 +1021,13 @@ builtin_exec_impl(PyObject *module, PyObject *source, PyObject *globals,
 
     if (!PyDict_Check(globals)) {
         PyErr_Format(PyExc_TypeError, "exec() globals must be a dict, not %.100s",
-                     globals->ob_type->tp_name);
+                     Py_TYPE(globals)->tp_name);
         return NULL;
     }
     if (!PyMapping_Check(locals)) {
         PyErr_Format(PyExc_TypeError,
             "locals must be a mapping or None, not %.100s",
-            locals->ob_type->tp_name);
+            Py_TYPE(locals)->tp_name);
         return NULL;
     }
     if (_PyDict_GetItemId(globals, &PyId___builtins__) == NULL) {
@@ -1386,11 +1386,11 @@ builtin_next(PyObject *self, PyObject *const *args, Py_ssize_t nargs)
     if (!PyIter_Check(it)) {
         PyErr_Format(PyExc_TypeError,
             "'%.200s' object is not an iterator",
-            it->ob_type->tp_name);
+            Py_TYPE(it)->tp_name);
         return NULL;
     }
 
-    res = (*it->ob_type->tp_iternext)(it);
+    res = (*Py_TYPE(it)->tp_iternext)(it);
     if (res != NULL) {
         return res;
     } else if (def != NULL) {
@@ -1783,7 +1783,7 @@ builtin_ord(PyObject *module, PyObject *c)
     else {
         PyErr_Format(PyExc_TypeError,
                      "ord() expected string of length 1, but " \
-                     "%.200s found", c->ob_type->tp_name);
+                     "%.200s found", Py_TYPE(c)->tp_name);
         return NULL;
     }
 
@@ -1850,7 +1850,7 @@ builtin_print(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject 
     else if (sep && !PyUnicode_Check(sep)) {
         PyErr_Format(PyExc_TypeError,
                      "sep must be None or a string, not %.200s",
-                     sep->ob_type->tp_name);
+                     Py_TYPE(sep)->tp_name);
         return NULL;
     }
     if (end == Py_None) {
@@ -1859,7 +1859,7 @@ builtin_print(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject 
     else if (end && !PyUnicode_Check(end)) {
         PyErr_Format(PyExc_TypeError,
                      "end must be None or a string, not %.200s",
-                     end->ob_type->tp_name);
+                     Py_TYPE(end)->tp_name);
         return NULL;
     }
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -2583,7 +2583,7 @@ main_loop:
                     if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
                         PyErr_Format(PyExc_TypeError,
                                 "'%.200s' object is not a mapping",
-                                arg->ob_type->tp_name);
+                                Py_TYPE(arg)->tp_name);
                     }
                     Py_DECREF(sum);
                     goto error;
@@ -2902,7 +2902,7 @@ main_loop:
         TARGET(FOR_ITER) {
             /* before: [iter]; after: [iter, iter()] *or* [] */
             PyObject *iter = TOP();
-            PyObject *next = (*iter->ob_type->tp_iternext)(iter);
+            PyObject *next = (*Py_TYPE(iter)->tp_iternext)(iter);
             if (next != NULL) {
                 PUSH(next);
                 PREDICT(STORE_FAST);
@@ -4119,11 +4119,11 @@ unpack_iterable(PyObject *v, int argcnt, int argcntafter, PyObject **sp)
     it = PyObject_GetIter(v);
     if (it == NULL) {
         if (PyErr_ExceptionMatches(PyExc_TypeError) &&
-            v->ob_type->tp_iter == NULL && !PySequence_Check(v))
+            Py_TYPE(v)->tp_iter == NULL && !PySequence_Check(v))
         {
             PyErr_Format(PyExc_TypeError,
                          "cannot unpack non-iterable %.200s object",
-                         v->ob_type->tp_name);
+                         Py_TYPE(v)->tp_name);
         }
         return 0;
     }
@@ -4508,7 +4508,7 @@ PyEval_GetFuncName(PyObject *func)
     else if (PyCFunction_Check(func))
         return ((PyCFunctionObject*)func)->m_ml->ml_name;
     else
-        return func->ob_type->tp_name;
+        return Py_TYPE(func)->tp_name;
 }
 
 const char *
@@ -4957,13 +4957,13 @@ import_all_from(PyObject *locals, PyObject *v)
 static int
 check_args_iterable(PyObject *func, PyObject *args)
 {
-    if (args->ob_type->tp_iter == NULL && !PySequence_Check(args)) {
+    if (Py_TYPE(args)->tp_iter == NULL && !PySequence_Check(args)) {
         PyErr_Format(PyExc_TypeError,
                      "%.200s%.200s argument after * "
                      "must be an iterable, not %.200s",
                      PyEval_GetFuncName(func),
                      PyEval_GetFuncDesc(func),
-                     args->ob_type->tp_name);
+                     Py_TYPE(args)->tp_name);
         return -1;
     }
     return 0;
@@ -4977,7 +4977,7 @@ format_kwargs_mapping_error(PyObject *func, PyObject *kwargs)
                  "must be a mapping, not %.200s",
                  PyEval_GetFuncName(func),
                  PyEval_GetFuncDesc(func),
-                 kwargs->ob_type->tp_name);
+                 Py_TYPE(kwargs)->tp_name);
 }
 
 static void

--- a/Python/codecs.c
+++ b/Python/codecs.c
@@ -658,7 +658,7 @@ static void wrong_exception_type(PyObject *exc)
 {
     PyErr_Format(PyExc_TypeError,
                  "don't know how to handle %.200s in error callback",
-                 exc->ob_type->tp_name);
+                 Py_TYPE(exc)->tp_name);
 }
 
 PyObject *PyCodec_StrictErrors(PyObject *exc)

--- a/Python/formatter_unicode.c
+++ b/Python/formatter_unicode.c
@@ -1428,7 +1428,7 @@ _PyUnicode_FormatAdvancedWriter(_PyUnicodeWriter *writer,
         return format_string_internal(obj, &format, writer);
     default:
         /* unknown */
-        unknown_presentation_type(format.type, obj->ob_type->tp_name);
+        unknown_presentation_type(format.type, Py_TYPE(obj)->tp_name);
         return -1;
     }
 }
@@ -1486,7 +1486,7 @@ _PyLong_FormatAdvancedWriter(_PyUnicodeWriter *writer,
 
     default:
         /* unknown */
-        unknown_presentation_type(format.type, obj->ob_type->tp_name);
+        unknown_presentation_type(format.type, Py_TYPE(obj)->tp_name);
         goto done;
     }
 
@@ -1530,7 +1530,7 @@ _PyFloat_FormatAdvancedWriter(_PyUnicodeWriter *writer,
 
     default:
         /* unknown */
-        unknown_presentation_type(format.type, obj->ob_type->tp_name);
+        unknown_presentation_type(format.type, Py_TYPE(obj)->tp_name);
         return -1;
     }
 }
@@ -1568,7 +1568,7 @@ _PyComplex_FormatAdvancedWriter(_PyUnicodeWriter *writer,
 
     default:
         /* unknown */
-        unknown_presentation_type(format.type, obj->ob_type->tp_name);
+        unknown_presentation_type(format.type, Py_TYPE(obj)->tp_name);
         return -1;
     }
 }

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -530,7 +530,7 @@ converttuple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
                       toplevel ? "expected %d arguments, not %.50s" :
                       "must be %d-item sequence, not %.50s",
                   n,
-                  arg == Py_None ? "None" : arg->ob_type->tp_name);
+                  arg == Py_None ? "None" : Py_TYPE(arg)->tp_name);
         return msgbuf;
     }
 
@@ -621,7 +621,7 @@ converterr(const char *expected, PyObject *arg, char *msgbuf, size_t bufsize)
     else {
         PyOS_snprintf(msgbuf, bufsize,
                       "must be %.50s, not %.50s", expected,
-                      arg == Py_None ? "None" : arg->ob_type->tp_name);
+                      arg == Py_None ? "None" : Py_TYPE(arg)->tp_name);
     }
     return msgbuf;
 }
@@ -1284,7 +1284,7 @@ convertsimple(PyObject *arg, const char **p_format, va_list *p_va, int flags,
             type = va_arg(*p_va, PyTypeObject*);
             p = va_arg(*p_va, PyObject **);
             format++;
-            if (PyType_IsSubtype(arg->ob_type, type))
+            if (PyType_IsSubtype(Py_TYPE(arg), type))
                 *p = arg;
             else
                 return converterr(type->tp_name, arg, msgbuf, bufsize);

--- a/Python/marshal.c
+++ b/Python/marshal.c
@@ -1689,7 +1689,7 @@ marshal_load(PyObject *module, PyObject *file)
     if (!PyBytes_Check(data)) {
         PyErr_Format(PyExc_TypeError,
                      "file.read() returned not bytes but %.100s",
-                     data->ob_type->tp_name);
+                     Py_TYPE(data)->tp_name);
         result = NULL;
     }
     else {

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -429,7 +429,7 @@ sys_intern(PyObject *self, PyObject *args)
     }
     else {
         PyErr_Format(PyExc_TypeError,
-                        "can't intern %.400s", s->ob_type->tp_name);
+                        "can't intern %.400s", Py_TYPE(s)->tp_name);
         return NULL;
     }
 }


### PR DESCRIPTION
We would prefer to not access the ob_type structure slot directly.  Using the Py_TYPE macro is cleaner.

This change affects a fair amount of code so perhaps we want to wait until the coding sprint is over before merging (in order to avoid merge conflicts with in-progress PRs and patches).