### PR TITLE
bpo-34635: inspect: add tools for subclasses

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -1043,11 +1043,11 @@ Classes and functions
       >>> class F(B): pass
       >>> tree = inspect.getallsubclasses(A)
       >>> tree
-		<SubclassNode <class '__main__.A'> [<SubclassNode <class '__main__.B'> [<class '__main__.D'>, <class '__main__.F'>]>, <SubclassNode <class '__main__.C'> [<class '__main__.D'>]>, <class '__main__.E'>]>
+      <SubclassNode <class '__main__.A'> [<SubclassNode <class '__main__.B'> [<class '__main__.D'>, <class '__main__.F'>]>, <SubclassNode <class '__main__.C'> [<class '__main__.D'>]>, <class '__main__.E'>]>
       >>> tree.cls
       <class '__main__.A'>
       >>> tree.children[0]
-		<SubclassNode <class '__main__.B'> [<class '__main__.D'>, <class '__main__.F'>]>
+      <SubclassNode <class '__main__.B'> [<class '__main__.D'>, <class '__main__.F'>]>
       >>> tree.children[0].children[0]
       <class '__main__.D'>
 

--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -1009,6 +1009,47 @@ Classes and functions
    resolution order depends on cls's type.  Unless a very peculiar user-defined
    metatype is in use, cls will be the first element of the tuple.
 
+.. function:: getsubclasses(cls)
+
+   Return a list of class cls's subclasses, including cls.
+   Only direct subclasses will be returned, i.e. sub-subclasses will not be.
+
+.. function:: getallsubclasses(cls)
+
+   Return a list of all the subclasses of class cls.
+   Duplicates will not be included.
+
+   If the subclass tree exceeds the maximum recursion depth, a :exc:`RecursionError`
+   will be raised in this case. This should not occur in normal usage.
+
+.. function:: getsubclasstree(cls)
+
+   Return an object representing the tree of subclasses of class cls.
+   The returned object ("the root") has two attributes, cls, and children.
+   cls is the passed in cls. children is a list of subclasses.
+   Each child in turn has these two attributes.
+
+   A :exc:`RecursionError` is raised if the subclass tree exceeds
+   the maximum recursion depth, however, this should not occur in practice.
+
+   For example: ::
+
+      >>> import inspect
+      >>> class A: pass
+      >>> class B(A): pass
+      >>> class C(A): pass
+      >>> class D(B, C): pass
+      >>> class E(A): pass
+      >>> class F(B): pass
+      >>> tree = inspect.getallsubclasses(A)
+      >>> tree
+		<SubclassNode <class '__main__.A'> [<SubclassNode <class '__main__.B'> [<class '__main__.D'>, <class '__main__.F'>]>, <SubclassNode <class '__main__.C'> [<class '__main__.D'>]>, <class '__main__.E'>]>
+      >>> tree.cls
+      <class '__main__.A'>
+      >>> tree.children[0]
+		<SubclassNode <class '__main__.B'> [<class '__main__.D'>, <class '__main__.F'>]>
+      >>> tree.children[0].children[0]
+      <class '__main__.D'>
 
 .. function:: getcallargs(func, *args, **kwds)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -104,6 +104,10 @@ New Modules
 Improved Modules
 ================
 
+* XXX Added :func:`inspect.getsubclasses`, :func:`inspect.getallsubclasses`, and
+  :func:`inspect.getsubclasstree`.
+  (Contributed by Benjamin Mintz in :issue:`34635`.)
+
 Optimizations
 =============
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -545,7 +545,7 @@ def getsubclasstree(cls, root=None):
     the object returned ("the root") has two attributes, cls and children.
     root.cls is the passed in cls. root.children is the subclasses of
     cls. root.children[0].cls is cls's first subclass, and
-    root.children[1].cls.children[0].cls is the cls's second subclass's
+    root.children[1].children[0].cls is the cls's second subclass's
     first subclass.
 
     A RecursionError is raised if the subclass tree exceeds a depth of

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -494,7 +494,7 @@ def getsubclasses(cls):
     """return the subclasses of cls, including cls"""
     return [cls] + _subclasses(cls)
 
-def getallsubclasses(cls, seen=None):
+def getallsubclasses(cls, _seen=None):
     """return an iterator over all subclasses of cls, including cls
 
     the subclass tree is traversed in depth-first order,
@@ -504,8 +504,7 @@ def getallsubclasses(cls, seen=None):
     sys.getrecursionlimit(), however,
     this should not occur in practice.
     """
-    seen = seen or set()
-    result = []
+    seen = _seen or set()
 
     yield cls
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -524,6 +524,16 @@ class SubclassNode:
         self.cls = cls
         self.children = children or []
 
+    def __eq__(self, other):
+        return (
+            isinstance(other, type(self))
+            and self.cls is other.cls
+            and self.children == other.children
+        )
+
+    def __hash__(self):
+        return hash((type(self), self.cls, tuple(map(hash, self.children))))
+
     def __repr__(self):
         if not self.children:
             return repr(self.cls)

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -1,3 +1,4 @@
+import abc
 import builtins
 import collections
 import datetime
@@ -702,6 +703,30 @@ class TestClassesAndFunctions(unittest.TestCase):
         expected = (D, B, C, A, object)
         got = inspect.getmro(D)
         self.assertEqual(expected, got)
+
+    def test_getsubclasses(self):
+        class A: pass
+        class B(A): pass
+        class C(A): pass
+        class D(B, C): pass
+        class E(A): pass
+
+        self.assertEqual([A, B, C, E], inspect.getsubclasses(A))
+        self.assertEqual([A, B, D, C, E], list(inspect.getallsubclasses(A)))
+
+        # test that getting subclasses of a metaclass doesn't fail
+        try:
+            inspect.getsubclasses(type)
+        except:
+            self.fail('exception raised')
+
+        self.assertIn(abc.ABCMeta, inspect.getallsubclasses(type))
+
+        expected = inspect.SubclassNode(A, list(map(inspect.SubclassNode, [B, C, E])))
+        expected.children[0].children = [inspect.SubclassNode(D)]  # B -> D
+        expected.children[1].children = [inspect.SubclassNode(D)]  # C -> D
+
+        self.assertEqual(expected, inspect.getsubclasstree(A))
 
     def assertArgSpecEquals(self, routine, args_e, varargs_e=None,
                             varkw_e=None, defaults_e=None, formatted=None):

--- a/Misc/NEWS.d/next/Library/2018-09-11-21-44-12.bpo-34635.pPrlMN.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-11-21-44-12.bpo-34635.pPrlMN.rst
@@ -1,0 +1,3 @@
+Added :func:`inspect.getsubclasses`, :func:`inspect.getallsubclasses`, and
+:func:`inspect.getsubclasstree`. These can be used to probe the subclasses
+of a class. Patch by Benjamin Mintz.


### PR DESCRIPTION
Adds inspect.getsubclasses, inspect.getallsubclasses (recursive), and inspect.getsubclasstree (recursive, maintains structure).

See documentation for more details.

<!-- issue-number: [bpo-34635](https://www.bugs.python.org/issue34635) -->
https://bugs.python.org/issue34635
<!-- /issue-number -->
