### PR TITLE
[3.6] bpo-34405: Update to OpenSSL 1.0.2p for macOS installer builds

### DIFF
--- a/Misc/NEWS.d/next/macOS/2018-09-11-08-47-50.bpo-34405.f1-fT5.rst
+++ b/Misc/NEWS.d/next/macOS/2018-09-11-08-47-50.bpo-34405.f1-fT5.rst
@@ -1,0 +1,1 @@
+Update to OpenSSL 1.0.2p for macOS installer builds.


### PR DESCRIPTION
Also resync 3.6.x and 2.7.x Mac/BuildInstaller/build-installer.py

<!-- issue-number: [bpo-34405](https://www.bugs.python.org/issue34405) -->
https://bugs.python.org/issue34405
<!-- /issue-number -->
