### PR TITLE
bpo-34605: Replace "pliant children" with "helpers"

### DIFF
--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -223,7 +223,7 @@ class install(Command):
 
     def finalize_options(self):
         """Finalizes options."""
-        # This method (and its pliant children, like 'finalize_unix()',
+        # This method (and its helpers, like 'finalize_unix()',
         # 'finalize_other()', and 'select_scheme()') is where the default
         # installation directories for modules, extension modules, and
         # anything else we care to install from a Python module


### PR DESCRIPTION
In distutils.command.install, replace "pliant children" (previously,
it was "pliant slaves") with "helpers".

<!-- issue-number: [bpo-34605](https://www.bugs.python.org/issue34605) -->
https://bugs.python.org/issue34605
<!-- /issue-number -->
