### PR TITLE
bpo-34638: Store a weak reference to stream reader to break strong references loop

### DIFF
--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -212,9 +212,6 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
         self._closed = self._loop.create_future()
 
     def _on_reader_gc(self, wr):
-        # connection_lost() is not called yet
-        assert self._stream_reader_wr is not None
-
         transport = self._transport
         if transport is not None:
             # connection_made was called

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -204,7 +204,7 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
             # we need to keep a strong reference to the reader
             # until connection is made
             self._strong_reader = stream_reader
-        self._reject_transport = False
+        self._reject_connection = False
         self._stream_writer = None
         self._transport = None
         self._client_connected_cb = client_connected_cb
@@ -225,7 +225,7 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
             self._loop.call_exception_handler(context)
             transport.abort()
         else:
-            self._reject_transport = True
+            self._reject_connection = True
         self._stream_reader_wr = None
 
     def _untrack_reader(self):
@@ -238,7 +238,7 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
         return self._stream_reader_wr()
 
     def connection_made(self, transport):
-        if self._reject_transport:
+        if self._reject_connection:
             context = {
                 'message': ("Close transport. "
                             "a stream was destroyed "

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -200,9 +200,9 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
         else:
             self._stream_reader_wr = None
         if client_connected_cb is not None:
-            # server socket
-            # we need to keep a strong reference to the reader
-            # until connection is made
+            # This is a stream created by the `create_server()` function.
+            # Keep a strong reference to the reader until a connection
+            # is established.
             self._strong_reader = stream_reader
         self._reject_connection = False
         self._stream_writer = None
@@ -216,9 +216,8 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
         if transport is not None:
             # connection_made was called
             context = {
-                'message': ("Close transport. "
-                            "A stream was destroyed without "
-                            "stream.close() call")
+                'message': ('An open stream object is being garbage '
+                            'collected; call "stream.close()" explicitly.')
             }
             if self._source_traceback:
                 context['source_traceback'] = self._source_traceback
@@ -240,9 +239,9 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
     def connection_made(self, transport):
         if self._reject_connection:
             context = {
-                'message': ("Close transport. "
-                            "a stream was destroyed "
-                            "before connection establishment")
+                'message': ('An open stream was garbage collected prior to '
+                            'establishing network connection; '
+                            'call "stream.close()" explicitly.')
             }
             if self._source_traceback:
                 context['source_traceback'] = self._source_traceback
@@ -346,7 +345,7 @@ class StreamWriter:
         return self._transport.can_write_eof()
 
     def close(self):
-        # a reader could be garbage collected / destroyed
+        # a reader can be garbage collected
         # after connection closing
         self._protocol._untrack_reader()
         return self._transport.close()

--- a/Lib/asyncio/streams.py
+++ b/Lib/asyncio/streams.py
@@ -212,14 +212,12 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
         self._closed = self._loop.create_future()
 
     def _on_reader_gc(self, wr):
-        print("on_reader_gc")
         # connection_lost() is not called yet
         assert self._stream_reader_wr is not None
 
         transport = self._transport
         if transport is not None:
             # connection_made was called
-            print("schedule abort")
             context = {
                 'message': ("Close transport. "
                             "A stream was destroyed without "
@@ -243,7 +241,6 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
         return self._stream_reader_wr()
 
     def connection_made(self, transport):
-        print("connection made")
         if self._reject_transport:
             context = {
                 'message': ("Close transport. "
@@ -271,7 +268,6 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
             self._strong_reader = None
 
     def connection_lost(self, exc):
-        print("connection lost")
         reader = self._stream_reader
         if reader is not None:
             if exc is None:
@@ -287,7 +283,6 @@ class StreamReaderProtocol(FlowControlMixin, protocols.Protocol):
         self._stream_reader_wr = None
         self._stream_writer = None
         self._transport = None
-        print("connection lost end")
 
     def data_received(self, data):
         reader = self._stream_reader

--- a/Lib/asyncio/subprocess.py
+++ b/Lib/asyncio/subprocess.py
@@ -37,8 +37,8 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
         return '<{}>'.format(' '.join(info))
 
     def _untrack_reader(self):
-        # a dummy placeholder subprocess protocol doesn't need it but
-        # the method is required for regular stream implementation.
+        # StreamWriter.close() expects the protocol
+        # to have this method defined.
         pass
 
     def connection_made(self, transport):

--- a/Lib/asyncio/subprocess.py
+++ b/Lib/asyncio/subprocess.py
@@ -36,6 +36,11 @@ class SubprocessStreamProtocol(streams.FlowControlMixin,
             info.append(f'stderr={self.stderr!r}')
         return '<{}>'.format(' '.join(info))
 
+    def _untrack_reader(self):
+        # a dummy placeholder subprocess protocol doesn't need it but
+        # the method is required for regular stream implementation.
+        pass
+
     def connection_made(self, transport):
         self._transport = transport
 

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -585,12 +585,10 @@ class StreamTests(test_utils.TestCase):
                 self.loop = loop
 
             async def handle_client(self, client_reader, client_writer):
-                print("start handle_client")
                 data = await client_reader.readline()
                 client_writer.write(data)
                 await client_writer.drain()
                 client_writer.close()
-                print("start handle_client")
 
             def start(self):
                 sock = socket.socket()
@@ -635,7 +633,6 @@ class StreamTests(test_utils.TestCase):
         messages = []
         self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
 
-        print("run 1")
         # test the server variant with a coroutine as client handler
         server = MyServer(self.loop)
         addr = server.start()
@@ -644,9 +641,6 @@ class StreamTests(test_utils.TestCase):
         server.stop()
         self.assertEqual(msg, b"hello world!\n")
 
-        print("run 1 end")
-
-        print("run 2")
         # test the server variant with a callback as client handler
         server = MyServer(self.loop)
         addr = server.start_callback()
@@ -654,7 +648,6 @@ class StreamTests(test_utils.TestCase):
                                                         loop=self.loop))
         server.stop()
         self.assertEqual(msg, b"hello world!\n")
-        print("run 2 end")
 
         self.assertEqual(messages, [])
 

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -585,10 +585,12 @@ class StreamTests(test_utils.TestCase):
                 self.loop = loop
 
             async def handle_client(self, client_reader, client_writer):
+                print("start handle_client")
                 data = await client_reader.readline()
                 client_writer.write(data)
                 await client_writer.drain()
                 client_writer.close()
+                print("start handle_client")
 
             def start(self):
                 sock = socket.socket()
@@ -633,6 +635,7 @@ class StreamTests(test_utils.TestCase):
         messages = []
         self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
 
+        print("run 1")
         # test the server variant with a coroutine as client handler
         server = MyServer(self.loop)
         addr = server.start()
@@ -641,6 +644,9 @@ class StreamTests(test_utils.TestCase):
         server.stop()
         self.assertEqual(msg, b"hello world!\n")
 
+        print("run 1 end")
+
+        print("run 2")
         # test the server variant with a callback as client handler
         server = MyServer(self.loop)
         addr = server.start_callback()
@@ -648,6 +654,7 @@ class StreamTests(test_utils.TestCase):
                                                         loop=self.loop))
         server.stop()
         self.assertEqual(msg, b"hello world!\n")
+        print("run 2 end")
 
         self.assertEqual(messages, [])
 
@@ -938,7 +945,8 @@ os.close(fd)
             self.assertEqual(sock.fileno(), -1)
 
         self.assertEqual(1, len(messages))
-        self.assertEqual('Stream was garbage collected',
+        self.assertEqual('Close transport. A stream was destroyed '
+                         'without stream.close() call',
                          messages[0]['message'])
 
 

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -46,6 +46,8 @@ class StreamTests(test_utils.TestCase):
         self.assertIs(stream._loop, m_events.get_event_loop.return_value)
 
     def _basetest_open_connection(self, open_connection_fut):
+        messages = []
+        self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
         reader, writer = self.loop.run_until_complete(open_connection_fut)
         writer.write(b'GET / HTTP/1.0\r\n\r\n')
         f = reader.readline()
@@ -55,6 +57,7 @@ class StreamTests(test_utils.TestCase):
         data = self.loop.run_until_complete(f)
         self.assertTrue(data.endswith(b'\r\n\r\nTest message'))
         writer.close()
+        self.assertEqual(messages, [])
 
     def test_open_connection(self):
         with test_utils.run_test_server() as httpd:
@@ -70,6 +73,8 @@ class StreamTests(test_utils.TestCase):
             self._basetest_open_connection(conn_fut)
 
     def _basetest_open_connection_no_loop_ssl(self, open_connection_fut):
+        messages = []
+        self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
         try:
             reader, writer = self.loop.run_until_complete(open_connection_fut)
         finally:
@@ -80,6 +85,7 @@ class StreamTests(test_utils.TestCase):
         self.assertTrue(data.endswith(b'\r\n\r\nTest message'))
 
         writer.close()
+        self.assertEqual(messages, [])
 
     @unittest.skipIf(ssl is None, 'No ssl module')
     def test_open_connection_no_loop_ssl(self):
@@ -104,6 +110,8 @@ class StreamTests(test_utils.TestCase):
             self._basetest_open_connection_no_loop_ssl(conn_fut)
 
     def _basetest_open_connection_error(self, open_connection_fut):
+        messages = []
+        self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
         reader, writer = self.loop.run_until_complete(open_connection_fut)
         writer._protocol.connection_lost(ZeroDivisionError())
         f = reader.read()
@@ -111,6 +119,7 @@ class StreamTests(test_utils.TestCase):
             self.loop.run_until_complete(f)
         writer.close()
         test_utils.run_briefly(self.loop)
+        self.assertEqual(messages, [])
 
     def test_open_connection_error(self):
         with test_utils.run_test_server() as httpd:
@@ -621,6 +630,9 @@ class StreamTests(test_utils.TestCase):
             writer.close()
             return msgback
 
+        messages = []
+        self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
+
         # test the server variant with a coroutine as client handler
         server = MyServer(self.loop)
         addr = server.start()
@@ -636,6 +648,8 @@ class StreamTests(test_utils.TestCase):
                                                         loop=self.loop))
         server.stop()
         self.assertEqual(msg, b"hello world!\n")
+
+        self.assertEqual(messages, [])
 
     @support.skip_unless_bind_unix_socket
     def test_start_unix_server(self):
@@ -685,6 +699,9 @@ class StreamTests(test_utils.TestCase):
             writer.close()
             return msgback
 
+        messages = []
+        self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
+
         # test the server variant with a coroutine as client handler
         with test_utils.unix_socket_path() as path:
             server = MyServer(self.loop, path)
@@ -702,6 +719,8 @@ class StreamTests(test_utils.TestCase):
                                                             loop=self.loop))
             server.stop()
             self.assertEqual(msg, b"hello world!\n")
+
+        self.assertEqual(messages, [])
 
     @unittest.skipIf(sys.platform == 'win32', "Don't have pipes")
     def test_read_all_from_pipe_reader(self):
@@ -892,6 +911,35 @@ os.close(fd)
             self.assertEqual(data, b'HTTP/1.0 200 OK\r\n')
             wr.close()
             self.loop.run_until_complete(wr.wait_closed())
+
+    def test_del_stream_before_sock_closing(self):
+        messages = []
+        self.loop.set_exception_handler(lambda loop, ctx: messages.append(ctx))
+
+        with test_utils.run_test_server() as httpd:
+            rd, wr = self.loop.run_until_complete(
+                asyncio.open_connection(*httpd.address, loop=self.loop))
+            sock = wr.get_extra_info('socket')
+            self.assertNotEqual(sock.fileno(), -1)
+
+            wr.write(b'GET / HTTP/1.0\r\n\r\n')
+            f = rd.readline()
+            data = self.loop.run_until_complete(f)
+            self.assertEqual(data, b'HTTP/1.0 200 OK\r\n')
+
+            # drop refs to reader/writer
+            del rd
+            del wr
+            gc.collect()
+            # make a chance to close the socket
+            test_utils.run_briefly(self.loop)
+
+            self.assertEqual(1, len(messages))
+            self.assertEqual(sock.fileno(), -1)
+
+        self.assertEqual(1, len(messages))
+        self.assertEqual('Stream was garbage collected',
+                         messages[0]['message'])
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -938,8 +938,8 @@ os.close(fd)
             self.assertEqual(sock.fileno(), -1)
 
         self.assertEqual(1, len(messages))
-        self.assertEqual('Close transport. A stream was destroyed '
-                         'without stream.close() call',
+        self.assertEqual('An open stream object is being garbage '
+                         'collected; call "stream.close()" explicitly.',
                          messages[0]['message'])
 
     def test_del_stream_before_connection_made(self):
@@ -959,8 +959,9 @@ os.close(fd)
             self.assertEqual(sock.fileno(), -1)
 
         self.assertEqual(1, len(messages))
-        self.assertEqual('Close transport. a stream was destroyed '
-                         'before connection establishment',
+        self.assertEqual('An open stream was garbage collected prior to '
+                         'establishing network connection; '
+                         'call "stream.close()" explicitly.',
                          messages[0]['message'])
 
 

--- a/Misc/NEWS.d/next/Library/2018-09-12-10-33-44.bpo-34638.xaeZX5.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-12-10-33-44.bpo-34638.xaeZX5.rst
@@ -1,0 +1,3 @@
+Store a weak reference to stream reader to break strong references loop
+between reader and protocol.  It allows to detect and close the socket if
+the stream is deleted (garbage collected) without ``close()`` call.


### PR DESCRIPTION
Breaking the strong reference loop between reader and protocol 
allows to detect and close the socket if the stream is deleted (garbage collected) without `close()` call.


<!-- issue-number: [bpo-34638](https://www.bugs.python.org/issue34638) -->
https://bugs.python.org/issue34638
<!-- /issue-number -->
