### PR TITLE
[2.7] bpo-34405: Updated to OpenSSL 1.0.2p for Windows builds. (GH-8776)

### DIFF
--- a/Misc/NEWS.d/next/Security/2018-08-15-12-14-03.bpo-34405.R4IZGw.rst
+++ b/Misc/NEWS.d/next/Security/2018-08-15-12-14-03.bpo-34405.R4IZGw.rst
@@ -1,0 +1,1 @@
+Updated to OpenSSL 1.0.2p for Windows builds.

--- a/PCbuild/get_externals.bat
+++ b/PCbuild/get_externals.bat
@@ -47,7 +47,7 @@ rem files in both this dir and PC\VS9.0
 set libraries=
 set libraries=%libraries%                                    bzip2-1.0.6
 if NOT "%IncludeBsddb%"=="false" set libraries=%libraries%   bsddb-4.7.25.0
-if NOT "%IncludeSSL%"=="false" set libraries=%libraries%     openssl-1.0.2o
+if NOT "%IncludeSSL%"=="false" set libraries=%libraries%     openssl-1.0.2p
 set libraries=%libraries%                                    sqlite-3.14.2.0
 if NOT "%IncludeTkinter%"=="false" set libraries=%libraries% tcl-8.5.19.0
 if NOT "%IncludeTkinter%"=="false" set libraries=%libraries% tk-8.5.19.0

--- a/PCbuild/python.props
+++ b/PCbuild/python.props
@@ -35,7 +35,7 @@
     <sqlite3Dir>$(ExternalsDir)sqlite-3.14.2.0\</sqlite3Dir>
     <bz2Dir>$(ExternalsDir)bzip2-1.0.6\</bz2Dir>
     <bsddbDir>$(ExternalsDir)bsddb-4.7.25.0</bsddbDir>
-    <opensslDir>$(ExternalsDir)openssl-1.0.2o\</opensslDir>
+    <opensslDir>$(ExternalsDir)openssl-1.0.2p\</opensslDir>
     <opensslIncludeDir>$(opensslDir)include32</opensslIncludeDir>
     <opensslIncludeDir Condition="'$(ArchName)' == 'amd64'">$(opensslDir)include64</opensslIncludeDir>
     <nasmDir>$(ExternalsDir)\nasm-2.11.06\</nasmDir>


### PR DESCRIPTION


<!-- issue-number: [bpo-34405](https://www.bugs.python.org/issue34405) -->
https://bugs.python.org/issue34405
<!-- /issue-number -->
