### PR TITLE
bpo-34637: Make the *start* argument for *sum()* visible as a keyword argument.

### DIFF
--- a/Doc/library/functions.rst
+++ b/Doc/library/functions.rst
@@ -1488,6 +1488,9 @@ are always available.  They are listed here in alphabetical order.
    see :func:`math.fsum`\.  To concatenate a series of iterables, consider using
    :func:`itertools.chain`.
 
+   .. versionchanged:: 3.8
+      The *start* parameter can be specified as a keyword argument.
+
 .. function:: super([type[, object-or-type]])
 
    Return a proxy object that delegates method calls to a parent or sibling

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1297,6 +1297,9 @@ class BuiltinTest(unittest.TestCase):
         self.assertEqual(sum(iter(Squares(10))), 285)
         self.assertEqual(sum([[1], [2], [3]], []), [1, 2, 3])
 
+        self.assertEqual(sum(range(10), 1000), 1045)
+        self.assertEqual(sum(range(10), start=1000), 1045)
+
         self.assertRaises(TypeError, sum)
         self.assertRaises(TypeError, sum, 42)
         self.assertRaises(TypeError, sum, ['a', 'b', 'c'])

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-11-17-25-44.bpo-34637.HSLqY4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-11-17-25-44.bpo-34637.HSLqY4.rst
@@ -1,0 +1,1 @@
+Make the *start* argument to *sum()* visible as a keyword argument.

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2272,8 +2272,8 @@ With an argument, equivalent to object.__dict__.");
 sum as builtin_sum
 
     iterable: object
-    start: object(c_default="NULL") = 0
     /
+    start: object(c_default="NULL") = 0
 
 Return the sum of a 'start' value (default: 0) plus an iterable of numbers
 
@@ -2284,7 +2284,7 @@ reject non-numeric types.
 
 static PyObject *
 builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start)
-/*[clinic end generated code: output=df758cec7d1d302f input=3b5b7a9d7611c73a]*/
+/*[clinic end generated code: output=df758cec7d1d302f input=162b50765250d222]*/
 {
     PyObject *result = start;
     PyObject *temp, *item, *iter;

--- a/Python/clinic/bltinmodule.c.h
+++ b/Python/clinic/bltinmodule.c.h
@@ -608,7 +608,7 @@ exit:
 }
 
 PyDoc_STRVAR(builtin_sum__doc__,
-"sum($module, iterable, start=0, /)\n"
+"sum($module, iterable, /, start=0)\n"
 "--\n"
 "\n"
 "Return the sum of a \'start\' value (default: 0) plus an iterable of numbers\n"
@@ -618,20 +618,21 @@ PyDoc_STRVAR(builtin_sum__doc__,
 "reject non-numeric types.");
 
 #define BUILTIN_SUM_METHODDEF    \
-    {"sum", (PyCFunction)builtin_sum, METH_FASTCALL, builtin_sum__doc__},
+    {"sum", (PyCFunction)builtin_sum, METH_FASTCALL|METH_KEYWORDS, builtin_sum__doc__},
 
 static PyObject *
 builtin_sum_impl(PyObject *module, PyObject *iterable, PyObject *start);
 
 static PyObject *
-builtin_sum(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+builtin_sum(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject *kwnames)
 {
     PyObject *return_value = NULL;
+    static const char * const _keywords[] = {"", "start", NULL};
+    static _PyArg_Parser _parser = {"O|O:sum", _keywords, 0};
     PyObject *iterable;
     PyObject *start = NULL;
 
-    if (!_PyArg_UnpackStack(args, nargs, "sum",
-        1, 2,
+    if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
         &iterable, &start)) {
         goto exit;
     }
@@ -710,4 +711,4 @@ builtin_issubclass(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=9f17c7a87d740374 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=eb6d08a32e7c83b6 input=a9049054013a1b77]*/


### PR DESCRIPTION


<!-- issue-number: [bpo-34637](https://www.bugs.python.org/issue34637) -->
https://bugs.python.org/issue34637
<!-- /issue-number -->
