### PR TITLE
bpo-34641: Further restrict the LHS of keyword argument function call syntax.

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -94,6 +94,10 @@ Other Language Changes
 * Added support of ``\N{name}`` escapes in :mod:`regular expressions <re>`.
   (Contributed by Jonathan Eunice and Serhiy Storchaka in :issue:`30688`.)
 
+* The syntax allowed for keyword names in function calls was further
+  restricted. In particular, ``f((keyword)=arg)`` is no longer allowed. It was
+  never intended to permit more than a bare name on the left-hand side of a
+  keyword argument assignment term. See :issue:`34641`.
 
 New Modules
 ===========
@@ -102,7 +106,7 @@ New Modules
 
 
 Improved Modules
-================
+===============r=
 
 Optimizations
 =============

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -106,7 +106,7 @@ New Modules
 
 
 Improved Modules
-===============r=
+================
 
 Optimizations
 =============

--- a/Lib/test/test_syntax.py
+++ b/Lib/test/test_syntax.py
@@ -269,6 +269,9 @@ SyntaxError: keyword can't be an expression
 >>> f(x.y=1)
 Traceback (most recent call last):
 SyntaxError: keyword can't be an expression
+>>> f((x)=2)
+Traceback (most recent call last):
+SyntaxError: keyword can't be an expression
 
 
 More set_context():

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-11-23-12-33.bpo-34641.gFBCc9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-11-23-12-33.bpo-34641.gFBCc9.rst
@@ -1,0 +1,2 @@
+Further restrict the syntax of the left-hand side of keyword arguments in
+function calls. In particular, ``f((arg)=default)`` is now disallowed.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-11-23-12-33.bpo-34641.gFBCc9.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-11-23-12-33.bpo-34641.gFBCc9.rst
@@ -1,2 +1,2 @@
 Further restrict the syntax of the left-hand side of keyword arguments in
-function calls. In particular, ``f((arg)=default)`` is now disallowed.
+function calls. In particular, ``f((keyword)=arg)`` is now disallowed.

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -2852,7 +2852,8 @@ ast_for_call(struct compiling *c, const node *n, expr_ty func, bool allowgen)
                     ast_error(c, chch,
                             "lambda cannot contain assignment");
                     return NULL;
-                } else if (TYPE(expr_node) != NAME) {
+                }
+                else if (TYPE(expr_node) != NAME) {
                     ast_error(c, chch,
                               "keyword can't be an expression");
                     return NULL;


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34641](https://www.bugs.python.org/issue34641) -->
https://bugs.python.org/issue34641
<!-- /issue-number -->
