### PR TITLE
closes bpo-34004: Skip lock interruption tests on musl.

### DIFF
--- a/Doc/library/threading.rst
+++ b/Doc/library/threading.rst
@@ -400,7 +400,8 @@ All methods are executed atomically.
          The *timeout* parameter is new.
 
       .. versionchanged:: 3.2
-         Lock acquires can now be interrupted by signals on POSIX.
+         Lock acquisition can now be interrupted by signals on POSIX if the
+         underlying threading implementation supports it.
 
 
    .. method:: release()

--- a/Lib/test/test_threadsignals.py
+++ b/Lib/test/test_threadsignals.py
@@ -78,6 +78,10 @@ class ThreadSignals(unittest.TestCase):
 
     @unittest.skipIf(USING_PTHREAD_COND,
                      'POSIX condition variables cannot be interrupted')
+    @unittest.skipIf(sys.platform.startswith('linux') and
+                     not sys.thread_info.version,
+                     'Issue 34004: musl does not allow interruption of locks '
+                     'by signals.')
     # Issue #20564: sem_timedwait() cannot be interrupted on OpenBSD
     @unittest.skipIf(sys.platform.startswith('openbsd'),
                      'lock cannot be interrupted on OpenBSD')
@@ -105,6 +109,10 @@ class ThreadSignals(unittest.TestCase):
 
     @unittest.skipIf(USING_PTHREAD_COND,
                      'POSIX condition variables cannot be interrupted')
+    @unittest.skipIf(sys.platform.startswith('linux') and
+                     not sys.thread_info.version,
+                     'Issue 34004: musl does not allow interruption of locks '
+                     'by signals.')
     # Issue #20564: sem_timedwait() cannot be interrupted on OpenBSD
     @unittest.skipIf(sys.platform.startswith('openbsd'),
                      'lock cannot be interrupted on OpenBSD')


### PR DESCRIPTION
Returning EINTR from pthread semaphore or lock acquisition is an optional POSIX
feature. musl does not provide this feature, so some threadsignal tests fail
when Python is built against it.

There's no good way to test for musl, so we skip if we're on Linux and not using
glibc pthreads.

Also, hedge in the threading documentation about when we can provide interrupts
from lock acquisition.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34004](https://www.bugs.python.org/issue34004) -->
https://bugs.python.org/issue34004
<!-- /issue-number -->
