### PR TITLE
closes bpo-34652: Always disable lchmod on Linux.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-09-12-14-46-51.bpo-34652.Rt1m1b.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-12-14-46-51.bpo-34652.Rt1m1b.rst
@@ -1,0 +1,1 @@
+Ensure :func:`os.lchmod` is never defined on Linux.

--- a/configure
+++ b/configure
@@ -11287,9 +11287,13 @@ done
 
 # Force lchmod off for Linux. Linux disallows changing the mode of symbolic
 # links. Some libc implementations have a stub lchmod implementation that always
-# returns ENOSYS.
-if test "$MACHDEP" = linux; then
-  undef HAVE_LCHMOD
+# returns an error.
+if test "$MACHDEP" != linux; then
+  ac_fn_c_check_func "$LINENO" "lchmod" "ac_cv_func_lchmod"
+if test "x$ac_cv_func_lchmod" = xyes; then :
+
+fi
+
 fi
 
 ac_fn_c_check_decl "$LINENO" "dirfd" "ac_cv_have_decl_dirfd" "#include <sys/types.h>

--- a/configure
+++ b/configure
@@ -11285,6 +11285,13 @@ fi
 done
 
 
+# Force lchmod off for Linux. Linux disallows changing the mode of symbolic
+# links. Some libc implementations have a stub lchmod implementation that always
+# returns ENOSYS.
+if test "$MACHDEP" = linux; then
+  undef HAVE_LCHMOD
+fi
+
 ac_fn_c_check_decl "$LINENO" "dirfd" "ac_cv_have_decl_dirfd" "#include <sys/types.h>
        #include <dirent.h>
 "

--- a/configure.ac
+++ b/configure.ac
@@ -3454,6 +3454,13 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \
  wcscoll wcsftime wcsxfrm wmemcmp writev _getpty)
 
+# Force lchmod off for Linux. Linux disallows changing the mode of symbolic
+# links. Some libc implementations have a stub lchmod implementation that always
+# returns an error.
+if test "$MACHDEP" = linux; then
+  undef HAVE_LCHMOD
+fi
+
 AC_CHECK_DECL(dirfd,
     AC_DEFINE(HAVE_DIRFD, 1,
               Define if you have the 'dirfd' function or macro.), ,

--- a/configure.ac
+++ b/configure.ac
@@ -3457,8 +3457,8 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
 # Force lchmod off for Linux. Linux disallows changing the mode of symbolic
 # links. Some libc implementations have a stub lchmod implementation that always
 # returns an error.
-if test "$MACHDEP" = linux; then
-  undef HAVE_LCHMOD
+if test "$MACHDEP" != linux; then
+  AC_CHECK_FUNC(lchmod)
 fi
 
 AC_CHECK_DECL(dirfd,


### PR DESCRIPTION
Symbolic link modes cannot be changed on Linux, so there's no point ever trying to use this function.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34652](https://www.bugs.python.org/issue34652) -->
https://bugs.python.org/issue34652
<!-- /issue-number -->
