### PR TITLE
Revert "closes bpo-34652: Always disable lchmod on Linux."

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-09-12-14-46-51.bpo-34652.Rt1m1b.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-12-14-46-51.bpo-34652.Rt1m1b.rst
@@ -1,1 +1,0 @@
-Ensure :func:`os.lchmod` is never defined on Linux.

--- a/configure
+++ b/configure
@@ -11285,17 +11285,6 @@ fi
 done
 
 
-# Force lchmod off for Linux. Linux disallows changing the mode of symbolic
-# links. Some libc implementations have a stub lchmod implementation that always
-# returns an error.
-if test "$MACHDEP" != linux; then
-  ac_fn_c_check_func "$LINENO" "lchmod" "ac_cv_func_lchmod"
-if test "x$ac_cv_func_lchmod" = xyes; then :
-
-fi
-
-fi
-
 ac_fn_c_check_decl "$LINENO" "dirfd" "ac_cv_have_decl_dirfd" "#include <sys/types.h>
        #include <dirent.h>
 "

--- a/configure.ac
+++ b/configure.ac
@@ -3454,13 +3454,6 @@ AC_CHECK_FUNCS(alarm accept4 setitimer getitimer bind_textdomain_codeset chown \
  truncate uname unlinkat unsetenv utimensat utimes waitid waitpid wait3 wait4 \
  wcscoll wcsftime wcsxfrm wmemcmp writev _getpty)
 
-# Force lchmod off for Linux. Linux disallows changing the mode of symbolic
-# links. Some libc implementations have a stub lchmod implementation that always
-# returns an error.
-if test "$MACHDEP" != linux; then
-  AC_CHECK_FUNC(lchmod)
-fi
-
 AC_CHECK_DECL(dirfd,
     AC_DEFINE(HAVE_DIRFD, 1,
               Define if you have the 'dirfd' function or macro.), ,


### PR DESCRIPTION
Reverts python/cpython#9234.

It was not complete.

<!-- issue-number: [bpo-34652](https://www.bugs.python.org/issue34652) -->
https://bugs.python.org/issue34652
<!-- /issue-number -->
