### PR TITLE
bpo-34200: Fix non-determinism of test_pkg

### DIFF
--- a/Lib/test/test_pkg.py
+++ b/Lib/test/test_pkg.py
@@ -5,7 +5,6 @@ import os
 import tempfile
 import textwrap
 import unittest
-from test import support
 
 
 # Helpers to create and destroy hierarchies.

--- a/Lib/test/test_pkg.py
+++ b/Lib/test/test_pkg.py
@@ -50,11 +50,13 @@ class TestPkg(unittest.TestCase):
         self.root = None
         self.pkgname = None
         self.syspath = list(sys.path)
-        self.modules_before = support.modules_setup()
+        self.modules_to_cleanup = set()  # Populated by mkhier().
 
     def tearDown(self):
         sys.path[:] = self.syspath
-        support.modules_cleanup(*self.modules_before)
+        for modulename in self.modules_to_cleanup:
+            if modulename in sys.modules:
+                del sys.modules[modulename]
         if self.root: # Only clean if the test was actually run
             cleanout(self.root)
 
@@ -75,17 +77,17 @@ class TestPkg(unittest.TestCase):
             os.mkdir(root)
         for name, contents in descr:
             comps = name.split()
+            self.modules_to_cleanup.add('.'.join(comps))
             fullname = root
             for c in comps:
                 fullname = os.path.join(fullname, c)
             if contents is None:
                 os.mkdir(fullname)
             else:
-                f = open(fullname, "w")
-                f.write(contents)
-                if contents and contents[-1] != '\n':
-                    f.write('\n')
-                f.close()
+                with open(fullname, "w") as f:
+                    f.write(contents)
+                    if not contents.endswith('\n'):
+                        f.write('\n')
         self.root = root
         # package name is the name of the first item
         self.pkgname = descr[0][0]

--- a/Misc/NEWS.d/next/Tests/2018-09-12-17-00-34.bpo-34200.dfxYQK.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-12-17-00-34.bpo-34200.dfxYQK.rst
@@ -1,0 +1,3 @@
+Fixed non-deterministic flakiness of test_pkg by not using the scary
+test.support.module_cleanup() logic to save and restore sys.modules contents
+between test cases.


### PR DESCRIPTION
This causes the tearDown code to only unimport the test modules specifically created as part of each test via the self.mkhier method rather than abusing test.support.modules_setup() and the scary test.support.modules_cleanup() code.

<!-- issue-number: [bpo-34200](https://www.bugs.python.org/issue34200) -->
https://bugs.python.org/issue34200
<!-- /issue-number -->
