### PR TITLE
bpo-34595: WIP: Type fully qualified name

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -223,13 +223,14 @@ PyAPI_FUNC(void) _PyEval_SignalAsyncExc(void);
 #endif
 
 /* Masks and values used by FORMAT_VALUE opcode. */
-#define FVC_MASK      0x3
+#define FVC_MASK      0x7
 #define FVC_NONE      0x0
 #define FVC_STR       0x1
 #define FVC_REPR      0x2
 #define FVC_ASCII     0x3
-#define FVS_MASK      0x4
-#define FVS_HAVE_SPEC 0x4
+#define FVC_TYPE_FQN  0x4
+#define FVS_MASK      0x8
+#define FVS_HAVE_SPEC 0x8
 
 #ifdef __cplusplus
 }

--- a/Include/object.h
+++ b/Include/object.h
@@ -502,6 +502,7 @@ PyAPI_FUNC(PyObject *) PyType_GenericNew(PyTypeObject *,
                                                PyObject *, PyObject *);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(const char *) _PyType_Name(PyTypeObject *);
+PyAPI_FUNC(PyObject*) _PyType_FQN(PyTypeObject *);
 PyAPI_FUNC(PyObject *) _PyType_Lookup(PyTypeObject *, PyObject *);
 PyAPI_FUNC(PyObject *) _PyType_LookupId(PyTypeObject *, _Py_Identifier *);
 PyAPI_FUNC(PyObject *) _PyObject_LookupSpecial(PyObject *, _Py_Identifier *);
@@ -525,6 +526,7 @@ PyAPI_FUNC(void) _PyObject_Dump(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_Repr(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_Str(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_ASCII(PyObject *);
+PyAPI_FUNC(PyObject*) _PyObject_TypeFQN(PyObject *v);
 PyAPI_FUNC(PyObject *) PyObject_Bytes(PyObject *);
 PyAPI_FUNC(PyObject *) PyObject_RichCompare(PyObject *, PyObject *, int);
 PyAPI_FUNC(int) PyObject_RichCompareBool(PyObject *, PyObject *, int);

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1827,6 +1827,7 @@ class TestType(unittest.TestCase):
         self.assertEqual(A.__name__, 'A')
         self.assertEqual(A.__qualname__, 'A')
         self.assertEqual(A.__module__, __name__)
+        self.assertEqual(A.__fqn__, f'{__name__}.A')
         self.assertEqual(A.__bases__, (object,))
         self.assertIs(A.__base__, object)
         x = A()
@@ -1906,6 +1907,12 @@ class TestType(unittest.TestCase):
         with self.assertRaises(TypeError):
             A.__qualname__ = b'B'
         self.assertEqual(A.__qualname__, 'D.E')
+
+    def test_type_fqn(self):
+        A = type('A', (), {})
+        self.assertEqual(A.__fqn__, f'{__name__}.A')
+        with self.assertRaises(AttributeError):
+            A.__fqn__ = "B"
 
     def test_type_doc(self):
         for doc in 'x', '\xc4', '\U0001f40d', 'x\x00y', b'x', 42, None:

--- a/Objects/clinic/typeobject.c.h
+++ b/Objects/clinic/typeobject.c.h
@@ -130,6 +130,33 @@ type___sizeof__(PyTypeObject *self, PyObject *Py_UNUSED(ignored))
     return type___sizeof___impl(self);
 }
 
+PyDoc_STRVAR(type___format____doc__,
+"__format__($self, format_spec, /)\n"
+"--\n"
+"\n"
+"Default type formatter.");
+
+#define TYPE___FORMAT___METHODDEF    \
+    {"__format__", (PyCFunction)type___format__, METH_O, type___format____doc__},
+
+static PyObject *
+type___format___impl(PyTypeObject *self, PyObject *format_spec);
+
+static PyObject *
+type___format__(PyTypeObject *self, PyObject *arg)
+{
+    PyObject *return_value = NULL;
+    PyObject *format_spec;
+
+    if (!PyArg_Parse(arg, "U:__format__", &format_spec)) {
+        goto exit;
+    }
+    return_value = type___format___impl(self, format_spec);
+
+exit:
+    return return_value;
+}
+
 PyDoc_STRVAR(object___reduce____doc__,
 "__reduce__($self, /)\n"
 "--\n"
@@ -237,4 +264,4 @@ object___dir__(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return object___dir___impl(self);
 }
-/*[clinic end generated code: output=8c4c856859564eaa input=a9049054013a1b77]*/
+/*[clinic end generated code: output=74c57a0184032856 input=a9049054013a1b77]*/

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -568,6 +568,13 @@ PyObject_ASCII(PyObject *v)
     return res;
 }
 
+PyObject*
+_PyObject_TypeFQN(PyObject *v)
+{
+    PyTypeObject *type = Py_TYPE(v);
+    return _PyType_FQN(type);
+}
+
 PyObject *
 PyObject_Bytes(PyObject *v)
 {

--- a/Objects/stringlib/unicode_format.h
+++ b/Objects/stringlib/unicode_format.h
@@ -766,6 +766,8 @@ do_conversion(PyObject *obj, Py_UCS4 conversion)
         return PyObject_Str(obj);
     case 'a':
         return PyObject_ASCII(obj);
+    case 't':
+        return _PyObject_TypeFQN(obj);
     default:
         if (conversion > 32 && conversion < 127) {
                 /* It's the ASCII subrange; casting to char is safe

--- a/Python/ast.c
+++ b/Python/ast.c
@@ -4608,7 +4608,7 @@ fstring_find_expr(const char **str, const char *end, int raw, int recurse_lvl,
 
         /* Validate the conversion. */
         if (!(conversion == 's' || conversion == 'r'
-              || conversion == 'a')) {
+              || conversion == 'a' || conversion == 't')) {
             ast_error(c, n, "f-string: invalid conversion character: "
                             "expected 's', 'r', or 'a'");
             return -1;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -3344,6 +3344,7 @@ main_loop:
             case FVC_STR:   conv_fn = PyObject_Str;   break;
             case FVC_REPR:  conv_fn = PyObject_Repr;  break;
             case FVC_ASCII: conv_fn = PyObject_ASCII; break;
+            case FVC_TYPE_FQN: conv_fn = _PyObject_TypeFQN; break;
 
             /* Must be 0 (meaning no conversion), since only four
                values are allowed by (oparg & FVC_MASK). */

--- a/Python/compile.c
+++ b/Python/compile.c
@@ -3677,6 +3677,7 @@ compiler_formatted_value(struct compiler *c, expr_ty e)
        !s  : 001  0x1  FVC_STR
        !r  : 010  0x2  FVC_REPR
        !a  : 011  0x3  FVC_ASCII
+       !t  : 100  0x4  FVC_TYPE_FQN
 
        next bit is whether or not we have a format spec:
        yes : 100  0x4
@@ -3692,6 +3693,7 @@ compiler_formatted_value(struct compiler *c, expr_ty e)
     case 's': oparg = FVC_STR;   break;
     case 'r': oparg = FVC_REPR;  break;
     case 'a': oparg = FVC_ASCII; break;
+    case 't': oparg = FVC_TYPE_FQN; break;
     case -1:  oparg = FVC_NONE;  break;
     default:
         PyErr_SetString(PyExc_SystemError,


### PR DESCRIPTION
* Add `type.__fqn__` read-only attribute
* Add "!t" conversion to format string
* Add ":T" format to `type.__format__()`
* Add "%t" and "%T" formatters to PyUnicode_FromUnicodeV(), and so to
  PyUnicode_FromUnicode() and PyErr_Format().

<!-- issue-number: [bpo-34595](https://www.bugs.python.org/issue34595) -->
https://bugs.python.org/issue34595
<!-- /issue-number -->
