### PR TITLE
bpo-34410: itertools.tee not thread-safe; can segfault

### DIFF
--- a/Misc/NEWS.d/next/Library/2019-08-22-16-08-46.bpo-34410.4DcUaI.rst
+++ b/Misc/NEWS.d/next/Library/2019-08-22-16-08-46.bpo-34410.4DcUaI.rst
@@ -1,0 +1,1 @@
+Fix itertools.tee() crash in multithreading. Patch by hongweipeng.

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -492,10 +492,18 @@ teedataobject_getitem(teedataobject *tdo, int i)
         /* this is the lead iterator, so fetch more data */
         assert(i == tdo->numread);
         value = PyIter_Next(tdo->it);
-        if (value == NULL)
+
+        if (value != NULL) {
+            teedataobject *temp = tdo;
+            while (temp->numread + 1 > LINKCELLS) {
+                temp = (teedataobject *) teedataobject_jumplink(temp);
+            }
+            temp->values[temp->numread] = value;
+            temp->numread++;
+        }else if (i == tdo->numread) {
             return NULL;
-        tdo->numread++;
-        tdo->values[i] = value;
+        }
+        value = tdo->values[i];
     }
     Py_INCREF(value);
     return value;

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -495,12 +495,12 @@ teedataobject_getitem(teedataobject *tdo, int i)
 
         if (value != NULL) {
             teedataobject *temp = tdo;
-            while (temp->numread + 1 > LINKCELLS) {
+            while (temp->numread >= LINKCELLS) {
                 temp = (teedataobject *) teedataobject_jumplink(temp);
             }
             temp->values[temp->numread] = value;
             temp->numread++;
-        }else if (i == tdo->numread) {
+        }else if (i == tdo->numread || PyErr_Occurred()) {
             return NULL;
         }
         value = tdo->values[i];


### PR DESCRIPTION
This is a resolution without lock. I think it's not right in the demo `3.py` , because it will use the original iterable in `imap_unordered -> _guarded_task_generation`.

**imap_unordered_demo.py**
```
import itertools
import multiprocessing

def f(x):
    return x

def g(x):
    return x

def main():
    pool = multiprocessing.Pool()

    #i = pool.imap_unordered(f, list(range(10)))
    i = list(range(10))

    i, i2 = itertools.tee(i)

    results = pool.imap_unordered(g, i)
    i2 = pool.imap_unordered(g, i2)

    print(list(i2))

    for x in results:
        print(x)

if __name__ == '__main__':
    main()
```

<!-- issue-number: [bpo-34410](https://www.bugs.python.org/issue34410) -->
https://bugs.python.org/issue34410
<!-- /issue-number -->
