### PR TITLE
bpo-34653: Removed unused function PyParser_SimpleParseStringFilename.

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-13-12-06-09.bpo-34653.z8NE-i.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-13-12-06-09.bpo-34653.z8NE-i.rst
@@ -1,0 +1,1 @@
+Remove unused function PyParser_SimpleParseStringFilename.

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -1295,12 +1295,6 @@ PyParser_SimpleParseStringFlagsFilename(const char *str, const char *filename,
     return n;
 }
 
-node *
-PyParser_SimpleParseStringFilename(const char *str, const char *filename, int start)
-{
-    return PyParser_SimpleParseStringFlagsFilename(str, filename, start, 0);
-}
-
 /* May want to move a more generalized form of this to parsetok.c or
    even parser modules. */
 


### PR DESCRIPTION
This function was not in any .h file and was not used by Python, so removing it is safe.

<!-- issue-number: [bpo-34653](https://www.bugs.python.org/issue34653) -->
https://bugs.python.org/issue34653
<!-- /issue-number -->
