### PR TITLE
[2.7] closes bpo-34661: Fix test_shutil if unzip doesn't support -t.

### DIFF
--- a/Lib/test/test_shutil.py
+++ b/Lib/test/test_shutil.py
@@ -543,6 +543,8 @@ class TestShutil(unittest.TestCase):
                 subprocess.check_output(zip_cmd, stderr=subprocess.STDOUT)
             except subprocess.CalledProcessError as exc:
                 details = exc.output
+                if 'unrecognized option: t' in details:
+                    self.skipTest("unzip doesn't support -t")
                 msg = "{}\n\n**Unzip Output**\n{}"
                 self.fail(msg.format(exc, details))
 

--- a/Misc/NEWS.d/next/Tests/2018-09-13-09-53-15.bpo-34661.bdTamP.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-13-09-53-15.bpo-34661.bdTamP.rst
@@ -1,0 +1,1 @@
+Fix test_shutil if unzip doesn't support -t.


### PR DESCRIPTION
(cherry picked from commit a710ebd21b09efe902dde84d4862ce5c6427f7af)
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34661](https://www.bugs.python.org/issue34661) -->
https://bugs.python.org/issue34661
<!-- /issue-number -->
