### PR TITLE
bpo-34587, test_socket: remove RDSTest.testCongestion()

### DIFF
--- a/Misc/NEWS.d/next/Tests/2018-09-13-20-58-07.bpo-34587.rCcxp3.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-13-20-58-07.bpo-34587.rCcxp3.rst
@@ -1,0 +1,5 @@
+test_socket: Remove RDSTest.testCongestion(). The test tries to fill the
+receiver's socket buffer and expects an error. But the RDS protocol doesn't
+require that. Moreover, the Linux implementation of RDS expects that the
+producer of the messages reduces its rate, it's not the role of the receiver to
+trigger an error. The test fails on Fedora 28 by design, so just remove it.


### PR DESCRIPTION
The test tries to fill the receiver's socket buffer and expects an
error. But the RDS protocol doesn't require that. Moreover, the Linux
implementation of RDS expects that the producer of the messages
reduces its rate, it's not the role of the receiver to trigger an
error.

The test fails on Fedora 28 by design, so remove it.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34587](https://www.bugs.python.org/issue34587) -->
https://bugs.python.org/issue34587
<!-- /issue-number -->
