### PR TITLE
[3.7] bpo-34490: Fix test_asyncio for AIX - do not call transport.get_extra_info('sockname') (GH-8907)

### DIFF
--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -37,10 +37,6 @@ from test.test_asyncio import utils as test_utils
 from test import support
 
 
-def tearDownModule():
-    asyncio.set_event_loop_policy(None)
-
-
 def broken_unix_getsockname():
     """Return True if the platform is Mac OS 10.4 or older."""
     if sys.platform.startswith("aix"):

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -37,9 +37,15 @@ from test.test_asyncio import utils as test_utils
 from test import support
 
 
-def osx_tiger():
+def tearDownModule():
+    asyncio.set_event_loop_policy(None)
+
+
+def broken_unix_getsockname():
     """Return True if the platform is Mac OS 10.4 or older."""
-    if sys.platform != 'darwin':
+    if sys.platform.startswith("aix"):
+        return True
+    elif sys.platform != 'darwin':
         return False
     version = platform.mac_ver()[0]
     version = tuple(map(int, version.split('.')))
@@ -613,7 +619,7 @@ class EventLoopTestsMixin:
     def test_create_unix_connection(self):
         # Issue #20682: On Mac OS X Tiger, getsockname() returns a
         # zero-length address for UNIX socket.
-        check_sockname = not osx_tiger()
+        check_sockname = not broken_unix_getsockname()
 
         with test_utils.run_test_unix_server() as httpd:
             conn_fut = self.loop.create_unix_connection(
@@ -744,7 +750,7 @@ class EventLoopTestsMixin:
     def test_create_ssl_unix_connection(self):
         # Issue #20682: On Mac OS X Tiger, getsockname() returns a
         # zero-length address for UNIX socket.
-        check_sockname = not osx_tiger()
+        check_sockname = not broken_unix_getsockname()
 
         with test_utils.run_test_unix_server(use_ssl=True) as httpd:
             create_connection = functools.partial(

--- a/Misc/NEWS.d/next/Tests/2018-08-24-20-23-15.bpo-34490.vb2cx4.rst
+++ b/Misc/NEWS.d/next/Tests/2018-08-24-20-23-15.bpo-34490.vb2cx4.rst
@@ -1,0 +1,2 @@
+On AIX with AF_UNIX family sockets getsockname() does not provide 'sockname',
+so skip calls to transport.get_extra_info('sockname')


### PR DESCRIPTION
(cherry picked from commit 413118ebf3162418639a5c4af14b02d26571a02c)

Co-authored-by: Michael Felt <aixtools@users.noreply.github.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34490](https://www.bugs.python.org/issue34490) -->
https://bugs.python.org/issue34490
<!-- /issue-number -->
