### PR TITLE
[3.6] bpo-34658: Fix rare subprocess prexec_fn fork error. (GH-9255)

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-09-13-03-59-43.bpo-34658.ykZ-ia.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-13-03-59-43.bpo-34658.ykZ-ia.rst
@@ -1,0 +1,3 @@
+Fix a rare interpreter unhandled exception state SystemError only seen when
+using subprocess with a preexec_fn while an after_parent handler has been
+registered with os.register_at_fork and the fork system call fails.


### PR DESCRIPTION
[bpo-34658](https://www.bugs.python.org/issue34658): Fix a rare interpreter unhandled exception state SystemError only
seen when using subprocess with a preexec_fn while an after_parent handler has
been registered with os.register_at_fork and the fork system call fails.

https://bugs.python.org/issue34658

Cherry picked from commit a20b6ad with manual fixups for it to make sense on 3.6.

<!-- issue-number: [bpo-34658](https://www.bugs.python.org/issue34658) -->
https://bugs.python.org/issue34658
<!-- /issue-number -->
