### PR TITLE
bpo-33073: Fix compiler warning with a type cast

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5286,7 +5286,7 @@ int_as_integer_ratio_impl(PyObject *self)
     if (PyLong_CheckExact(self)) {
         return PyTuple_Pack(2, self, _PyLong_One);
     }
-    numerator = _PyLong_Copy(self);
+    numerator = _PyLong_Copy((PyLongObject *) self);
     if (numerator == NULL) {
         return NULL;
     }


### PR DESCRIPTION


<!-- issue-number: [bpo-33073](https://www.bugs.python.org/issue33073) -->
https://bugs.python.org/issue33073
<!-- /issue-number -->
