### PR TITLE
bpo-31177: Skip deleted attributes while calling reset_mock

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -541,7 +541,7 @@ class NonCallableMock(Base):
             self._mock_side_effect = None
 
         for child in self._mock_children.values():
-            if isinstance(child, _SpecState):
+            if isinstance(child, _SpecState) or child is _deleted:
                 continue
             child.reset_mock(visited)
 

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1567,6 +1567,8 @@ class MockTest(unittest.TestCase):
 
 
     def test_reset_mock_does_not_raise_on_attr_deletion(self):
+        # bpo-31177: reset_mock should not AttributeError when attributes
+        # were deleted in a mock instance
         mock = Mock()
         mock.child = True
         del mock.child

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1566,20 +1566,11 @@ class MockTest(unittest.TestCase):
             self.assertRaises(AttributeError, getattr, mock, 'f')
 
 
-    def test_attribute_deletion_reset_mock(self):
+    def test_reset_mock_does_not_raise_on_attr_deletion(self):
         mock = Mock()
-        mock.something.return_value = 3
-
-        self.assertEqual(mock.something(), 3)
-        self.assertTrue(mock.something.called)
-        self.assertTrue(hasattr(mock, 'm'))
-
-        del mock.m
-        self.assertFalse(hasattr(mock, 'm'))
-
+        mock.child = True
+        del mock.child
         mock.reset_mock()
-        self.assertFalse(hasattr(mock, 'm'))
-        self.assertFalse(mock.something.called)
 
 
     def test_class_assignable(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1573,6 +1573,7 @@ class MockTest(unittest.TestCase):
         mock.child = True
         del mock.child
         mock.reset_mock()
+        self.assertFalse(hasattr(mock, 'child'))
 
 
     def test_class_assignable(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1567,7 +1567,7 @@ class MockTest(unittest.TestCase):
 
 
     def test_reset_mock_does_not_raise_on_attr_deletion(self):
-        # bpo-31177: reset_mock should not AttributeError when attributes
+        # bpo-31177: reset_mock should not raise AttributeError when attributes
         # were deleted in a mock instance
         mock = Mock()
         mock.child = True

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1566,6 +1566,22 @@ class MockTest(unittest.TestCase):
             self.assertRaises(AttributeError, getattr, mock, 'f')
 
 
+    def test_attribute_deletion_reset_mock(self):
+        mock = Mock()
+        mock.something.return_value = 3
+
+        self.assertEqual(mock.something(), 3)
+        self.assertTrue(mock.something.called)
+        self.assertTrue(hasattr(mock, 'm'))
+
+        del mock.m
+        self.assertFalse(hasattr(mock, 'm'))
+
+        mock.reset_mock()
+        self.assertFalse(hasattr(mock, 'm'))
+        self.assertFalse(mock.something.called)
+
+
     def test_class_assignable(self):
         for mock in Mock(), MagicMock():
             self.assertNotIsInstance(mock, int)

--- a/Misc/NEWS.d/next/Library/2018-09-14-10-38-18.bpo-31177.Sv91TN.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-14-10-38-18.bpo-31177.Sv91TN.rst
@@ -1,1 +1,1 @@
-Skip deleted attributes while calling :meth:`mock.reset_mock`.
+Fix bug that prevented using :meth:`mock.reset_mock` on mock instances with deleted attributes

--- a/Misc/NEWS.d/next/Library/2018-09-14-10-38-18.bpo-31177.Sv91TN.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-14-10-38-18.bpo-31177.Sv91TN.rst
@@ -1,0 +1,1 @@
+Skip deleted attributes while calling :meth:`mock.reset_mock`.

--- a/Misc/NEWS.d/next/Library/2018-09-14-10-38-18.bpo-31177.Sv91TN.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-14-10-38-18.bpo-31177.Sv91TN.rst
@@ -1,1 +1,2 @@
-Fix bug that prevented using :meth:`mock.reset_mock` on mock instances with deleted attributes
+Fix bug that prevented using :meth:`reset_mock <unittest.mock.Mock.reset_mock>`
+on mock instances with deleted attributes


### PR DESCRIPTION
Skip the deleted attributes while calling `reset_mock` so that it doesn't cause an `AttributeError` .

Thanks

<!-- issue-number: [bpo-31177](https://www.bugs.python.org/issue31177) -->
https://bugs.python.org/issue31177
<!-- /issue-number -->
