### PR TITLE
Fix typo in asyncio-dev.rst

### DIFF
--- a/Doc/library/asyncio-dev.rst
+++ b/Doc/library/asyncio-dev.rst
@@ -407,7 +407,7 @@ traceback where the task was created. Example of log in debug mode:
 Close transports and event loops
 --------------------------------
 
-When a transport is no more needed, call its ``close()`` method to release
+When a transport is no longer needed, call its ``close()`` method to release
 resources. Event loops must also be closed explicitly.
 
 If a transport or an event loop is not closed explicitly, a


### PR DESCRIPTION
While intuitively comprehensible by an English language reader, the phrase "When a transport is no more needed..." sounds unnatural in the English language. Natural sounding alternatives include "When a transport is no longer needed..." and "When a transport is not needed any more." I propose here the shorter of the two.