### PR TITLE
bpo-34695: sqlite3: Fix crash if Cache.get() is called before __init__()

### DIFF
--- a/Lib/sqlite3/test/regression.py
+++ b/Lib/sqlite3/test/regression.py
@@ -397,6 +397,17 @@ class RegressionTests(unittest.TestCase):
         del ref
         support.gc_collect()
 
+    def CheckBpo34695(self):
+        """
+        The interpreter shouldn't crash in case Cache.__init__() is not
+        called.
+        """
+        cache = sqlite.Cache.__new__(sqlite.Cache, lambda x: x)
+        self.assertRaisesRegex(sqlite.ProgrammingError, r'Cache\.__init__',
+                               cache.get, 42)
+        self.assertRaisesRegex(sqlite.ProgrammingError, r'Cache\.__init__',
+                               cache.display)
+
 
 def suite():
     regression_suite = unittest.makeSuite(RegressionTests, "Check")

--- a/Misc/NEWS.d/next/Library/2018-09-15-18-58-31.bpo-34695.Ts0-Kt.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-15-18-58-31.bpo-34695.Ts0-Kt.rst
@@ -1,0 +1,1 @@
+Fix crash if :meth:`sqlite3.Cache.get` is called before ``__init__``.

--- a/Modules/_sqlite/cache.c
+++ b/Modules/_sqlite/cache.c
@@ -22,6 +22,7 @@
  */
 
 #include "cache.h"
+#include "module.h"
 #include <limits.h>
 
 /* only used internally */
@@ -112,12 +113,25 @@ void pysqlite_cache_dealloc(pysqlite_Cache* self)
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 
+static int pysqlite_check_cache(pysqlite_Cache *self) {
+    if (self->factory == NULL) {
+        PyErr_SetString(pysqlite_ProgrammingError,
+                        "Cache.__init__ was not called or failed.");
+        return 0;
+    }
+    return 1;
+}
+
 PyObject* pysqlite_cache_get(pysqlite_Cache* self, PyObject* args)
 {
     PyObject* key = args;
     pysqlite_Node* node;
     pysqlite_Node* ptr;
     PyObject* data;
+
+    if (!pysqlite_check_cache(self)) {
+        return NULL;
+    }
 
     node = (pysqlite_Node*)PyDict_GetItem(self->mapping, key);
     if (node) {
@@ -217,6 +231,10 @@ PyObject* pysqlite_cache_display(pysqlite_Cache* self, PyObject* args)
     PyObject* prevkey;
     PyObject* nextkey;
     PyObject* display_str;
+
+    if (!pysqlite_check_cache(self)) {
+        return NULL;
+    }
 
     ptr = self->first;
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34695](https://www.bugs.python.org/issue34695) -->
https://bugs.python.org/issue34695
<!-- /issue-number -->
