### PR TITLE
[WIP] bpo-33608: Factor out a private, per-interpreter _Py_AddPendingCall().

### DIFF
--- a/Include/ceval.h
+++ b/Include/ceval.h
@@ -219,7 +219,7 @@ PyAPI_FUNC(Py_ssize_t) _PyEval_RequestCodeExtraIndex(freefunc);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(int) _PyEval_SliceIndex(PyObject *, Py_ssize_t *);
 PyAPI_FUNC(int) _PyEval_SliceIndexNotNone(PyObject *, Py_ssize_t *);
-PyAPI_FUNC(void) _PyEval_SignalAsyncExc(void);
+PyAPI_FUNC(void) _PyEval_SignalAsyncExc(PyInterpreterState *);
 #endif
 
 /* Masks and values used by FORMAT_VALUE opcode. */

--- a/Include/internal/ceval.h
+++ b/Include/internal/ceval.h
@@ -13,7 +13,7 @@ PyAPI_FUNC(int) _Py_AddPendingCall(struct _is*, int (*)(void *), void *);
 PyAPI_FUNC(int) _Py_MakePendingCalls(struct _is*);
 
 struct _pending_calls {
-    unsigned long main_thread;
+    unsigned long active_thread;
     PyThread_type_lock lock;
     /* Request for running pending calls. */
     _Py_atomic_int calls_to_do;

--- a/Include/internal/ceval.h
+++ b/Include/internal/ceval.h
@@ -13,7 +13,6 @@ PyAPI_FUNC(int) _Py_AddPendingCall(struct _is*, int (*)(void *), void *);
 PyAPI_FUNC(int) _Py_MakePendingCalls(struct _is*);
 
 struct _pending_calls {
-    unsigned long active_thread;
     PyThread_type_lock lock;
     /* Request for running pending calls. */
     _Py_atomic_int calls_to_do;

--- a/Include/internal/ceval.h
+++ b/Include/internal/ceval.h
@@ -9,7 +9,7 @@ extern "C" {
 
 struct _is;  // See PyInterpreterState in pystate.h.
 
-PyAPI_FUNC(int) _Py_AddPendingCall(struct _is*, int (*)(void *), void *);
+PyAPI_FUNC(int) _Py_AddPendingCall(struct _is*, unsigned long, int (*)(void *), void *);
 PyAPI_FUNC(int) _Py_MakePendingCalls(struct _is*);
 
 struct _pending_calls {
@@ -22,6 +22,7 @@ struct _pending_calls {
     int async_exc;
 #define NPENDINGCALLS 32
     struct {
+        unsigned long thread_id;
         int (*func)(void *);
         void *arg;
     } calls[NPENDINGCALLS];

--- a/Include/internal/ceval.h
+++ b/Include/internal/ceval.h
@@ -7,6 +7,11 @@ extern "C" {
 #include "pyatomic.h"
 #include "pythread.h"
 
+struct _is;  // See PyInterpreterState in pystate.h.
+
+PyAPI_FUNC(int) _Py_AddPendingCall(struct _is*, int (*)(void *), void *);
+PyAPI_FUNC(int) _Py_MakePendingCalls(struct _is*);
+
 struct _pending_calls {
     unsigned long main_thread;
     PyThread_type_lock lock;
@@ -35,12 +40,8 @@ struct _ceval_runtime_state {
        c_tracefunc.  This speeds up the if statement in
        PyEval_EvalFrameEx() after fast_next_opcode. */
     int tracing_possible;
-    /* This single variable consolidates all requests to break out of
-       the fast path in the eval loop. */
-    _Py_atomic_int eval_breaker;
     /* Request for dropping the GIL */
     _Py_atomic_int gil_drop_request;
-    struct _pending_calls pending;
     struct _gil_runtime_state gil;
 };
 

--- a/Include/internal/pystate.h
+++ b/Include/internal/pystate.h
@@ -188,6 +188,8 @@ typedef struct pyruntimestate {
         struct _xidregitem *head;
     } xidregistry;
 
+    unsigned long main_thread;
+
 #define NEXITFUNCS 32
     void (*exitfuncs[NEXITFUNCS])(void);
     int nexitfuncs;
@@ -210,6 +212,8 @@ PyAPI_FUNC(void) _PyRuntimeState_Fini(_PyRuntimeState *);
 /* Initialize _PyRuntimeState.
    Return NULL on success, or return an error message on failure. */
 PyAPI_FUNC(_PyInitError) _PyRuntime_Initialize(void);
+
+PyAPI_FUNC(unsigned long) _PyRuntimeState_GetMainThreadID(_PyRuntimeState*);
 
 #define _Py_CURRENTLY_FINALIZING(tstate) \
     (_PyRuntime.finalizing == tstate)

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -9,6 +9,10 @@ extern "C" {
 
 #include "pythread.h"
 #include "coreconfig.h"
+#ifdef Py_BUILD_CORE
+#include "pyatomic.h"
+#include "internal/ceval.h"
+#endif
 
 /* This limitation is for performance and simplicity. If needed it can be
 removed (with effort). */
@@ -64,6 +68,15 @@ typedef struct _is {
 
     /* Used in Python/sysmodule.c. */
     int check_interval;
+
+#ifdef Py_BUILD_CORE
+    struct _ceval {
+        /* This single variable consolidates all requests to break out of
+           the fast path in the eval loop. */
+        _Py_atomic_int eval_breaker;
+        struct _pending_calls pending;
+    } ceval;
+#endif
 
     /* Used in Modules/_threadmodule.c. */
     long num_threads;

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -77,9 +77,6 @@ typedef struct _is {
            the fast path in the eval loop. */
         _Py_atomic_int eval_breaker;
         struct _pending_calls pending;
-
-        int active;
-        unsigned long active_thread;
     } ceval;
 #endif
 

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -75,7 +75,7 @@ typedef struct _is {
            the fast path in the eval loop. */
         _Py_atomic_int eval_breaker;
         struct _pending_calls pending;
-        // XXX Is "active" the right word?
+
         int active;
         unsigned long active_thread;
     } ceval;

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -76,6 +76,7 @@ typedef struct _is {
         _Py_atomic_int eval_breaker;
         struct _pending_calls pending;
         // XXX Is "active" the right word?
+        int active;
         unsigned long active_thread;
     } ceval;
 #endif

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -75,6 +75,8 @@ typedef struct _is {
            the fast path in the eval loop. */
         _Py_atomic_int eval_breaker;
         struct _pending_calls pending;
+        // XXX Is "active" the right word?
+        unsigned long active_thread;
     } ceval;
 #endif
 

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -60,6 +60,8 @@ typedef struct _is {
     int64_t id_refcount;
     PyThread_type_lock id_mutex;
 
+    int finalizing;
+
     PyObject *modules;
     PyObject *modules_by_index;
     PyObject *sysdict;

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-15-12-13-46.bpo-33608.avmvVP.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-15-12-13-46.bpo-33608.avmvVP.rst
@@ -1,0 +1,5 @@
+We added a new internal _Py_AddPendingCall() that operates relative to the
+provided interpreter.  This allows us to use the existing implementation to
+ask another interpreter to do work that cannot be done in the current
+interpreter, like decref an object the other interpreter owns.  The existing
+Py_AddPendingCall() only operates relative to the main interpreter.

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -2441,6 +2441,7 @@ pending_threadfunc(PyObject *self, PyObject *arg)
     Py_INCREF(callable);
 
     Py_BEGIN_ALLOW_THREADS
+    /* XXX Use the internal _Py_AddPendingCall(). */
     r = Py_AddPendingCall(&_pending_callback, callable);
     Py_END_ALLOW_THREADS
 

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -281,6 +281,7 @@ trip_signal(int sig_num)
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
                     _Py_AddPendingCall(_PyRuntime.interpreters.main,
+                                       main_thread,
                                        report_wakeup_send_error,
                                        (void *)(intptr_t) last_error);
                 }
@@ -300,6 +301,7 @@ trip_signal(int sig_num)
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
                     _Py_AddPendingCall(_PyRuntime.interpreters.main,
+                                       main_thread,
                                        report_wakeup_write_error,
                                        (void *)(intptr_t)errno);
                 }

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -96,7 +96,7 @@ class sigset_t_converter(CConverter):
 
 #include <sys/types.h> /* For pid_t */
 #include "pythread.h"
-static unsigned long main_thread;
+#define main_thread _PyRuntimeState_GetMainThreadID(&_PyRuntime)
 static pid_t main_pid;
 
 static volatile struct {
@@ -1281,7 +1281,6 @@ PyInit__signal(void)
     PyObject *m, *d, *x;
     int i;
 
-    main_thread = PyThread_get_thread_ident();
     main_pid = getpid();
 
     /* Create the module and add the functions */
@@ -1683,7 +1682,6 @@ _PySignal_AfterFork(void)
      * in both processes if they came in just before the fork() but before
      * the interpreter had an opportunity to call the handlers.  issue9535. */
     _clear_pending_signals();
-    main_thread = PyThread_get_thread_ident();
     main_pid = getpid();
 }
 

--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -17,6 +17,7 @@
 #include <process.h>
 #endif
 #endif
+#include "internal/pystate.h"
 
 #ifdef HAVE_SIGNAL_H
 #include <signal.h>
@@ -279,8 +280,9 @@ trip_signal(int sig_num)
                 {
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
-                    Py_AddPendingCall(report_wakeup_send_error,
-                                      (void *)(intptr_t) last_error);
+                    _Py_AddPendingCall(_PyRuntime.interpreters.main,
+                                       report_wakeup_send_error,
+                                       (void *)(intptr_t) last_error);
                 }
             }
         }
@@ -297,8 +299,9 @@ trip_signal(int sig_num)
                 {
                     /* Py_AddPendingCall() isn't signal-safe, but we
                        still use it for this exceptional case. */
-                    Py_AddPendingCall(report_wakeup_write_error,
-                                      (void *)(intptr_t)errno);
+                    _Py_AddPendingCall(_PyRuntime.interpreters.main,
+                                       report_wakeup_write_error,
+                                       (void *)(intptr_t)errno);
                 }
             }
         }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -225,11 +225,9 @@ PyEval_ReInitThreads(void)
     if (!gil_created())
         return;
     recreate_gil();
-    // XXX Set for every interpreter.
     current_tstate->interp->ceval.pending.lock = PyThread_allocate_lock();
     take_gil(current_tstate);
-    // XXX Set for every interpreter.
-    current_tstate->interp->ceval.pending.active_thread = PyThread_get_thread_ident();
+    current_tstate->interp->ceval.active_thread = PyThread_get_thread_ident();
 
     /* Destroy all threads except the current one */
     _PyThreadState_DeleteExcept(current_tstate);
@@ -391,8 +389,8 @@ _Py_MakePendingCalls(PyInterpreterState *interp)
     }
 
     /* only service pending calls on main thread */
-    if (interp->ceval.pending.active_thread &&
-        PyThread_get_thread_ident() != interp->ceval.pending.active_thread)
+    if (interp->ceval.active_thread &&
+        PyThread_get_thread_ident() != interp->ceval.active_thread)
     {
         return 0;
     }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -225,6 +225,7 @@ PyEval_ReInitThreads(void)
     if (!gil_created())
         return;
     recreate_gil();
+    _PyRuntime.main_thread = PyThread_get_thread_ident();
     current_tstate->interp->ceval.pending.lock = PyThread_allocate_lock();
     take_gil(current_tstate);
 

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -227,6 +227,7 @@ PyEval_ReInitThreads(void)
     recreate_gil();
     current_tstate->interp->ceval.pending.lock = PyThread_allocate_lock();
     take_gil(current_tstate);
+    current_tstate->interp->ceval.active = 1;
     current_tstate->interp->ceval.active_thread = PyThread_get_thread_ident();
 
     /* Destroy all threads except the current one */

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -227,8 +227,6 @@ PyEval_ReInitThreads(void)
     recreate_gil();
     current_tstate->interp->ceval.pending.lock = PyThread_allocate_lock();
     take_gil(current_tstate);
-    current_tstate->interp->ceval.active = 1;
-    current_tstate->interp->ceval.active_thread = PyThread_get_thread_ident();
 
     /* Destroy all threads except the current one */
     _PyThreadState_DeleteExcept(current_tstate);
@@ -390,7 +388,7 @@ _Py_MakePendingCalls(PyInterpreterState *interp)
     }
 
     /* only service pending calls on main thread */
-    if (interp->ceval.active_thread &&
+    if (!interp->ceval.active ||
         PyThread_get_thread_ident() != interp->ceval.active_thread)
     {
         return 0;

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -229,7 +229,7 @@ PyEval_ReInitThreads(void)
     current_tstate->interp->ceval.pending.lock = PyThread_allocate_lock();
     take_gil(current_tstate);
     // XXX Set for every interpreter.
-    current_tstate->interp->ceval.pending.main_thread = PyThread_get_thread_ident();
+    current_tstate->interp->ceval.pending.active_thread = PyThread_get_thread_ident();
 
     /* Destroy all threads except the current one */
     _PyThreadState_DeleteExcept(current_tstate);
@@ -391,8 +391,8 @@ _Py_MakePendingCalls(PyInterpreterState *interp)
     }
 
     /* only service pending calls on main thread */
-    if (interp->ceval.pending.main_thread &&
-        PyThread_get_thread_ident() != interp->ceval.pending.main_thread)
+    if (interp->ceval.pending.active_thread &&
+        PyThread_get_thread_ident() != interp->ceval.pending.active_thread)
     {
         return 0;
     }

--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -175,7 +175,7 @@ static void drop_gil(PyThreadState *tstate)
                     &_PyRuntime.ceval.gil.last_holder)
             ) == tstate)
         {
-        RESET_GIL_DROP_REQUEST();
+        RESET_GIL_DROP_REQUEST(tstate->interp);
             /* NOTE: if COND_WAIT does not atomically start waiting when
                releasing the mutex, another thread can run through, take
                the GIL and drop it again, and reset the condition
@@ -212,7 +212,7 @@ static void take_gil(PyThreadState *tstate)
         if (timed_out &&
             _Py_atomic_load_relaxed(&_PyRuntime.ceval.gil.locked) &&
             _PyRuntime.ceval.gil.switch_number == saved_switchnum) {
-            SET_GIL_DROP_REQUEST();
+            SET_GIL_DROP_REQUEST(tstate->interp);
         }
     }
 _ready:
@@ -238,10 +238,10 @@ _ready:
     MUTEX_UNLOCK(_PyRuntime.ceval.gil.switch_mutex);
 #endif
     if (_Py_atomic_load_relaxed(&_PyRuntime.ceval.gil_drop_request)) {
-        RESET_GIL_DROP_REQUEST();
+        RESET_GIL_DROP_REQUEST(tstate->interp);
     }
     if (tstate->async_exc != NULL) {
-        _PyEval_SignalAsyncExc();
+        _PyEval_SignalAsyncExc(tstate->interp);
     }
 
     MUTEX_UNLOCK(_PyRuntime.ceval.gil.mutex);

--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -160,9 +160,11 @@ static void drop_gil(PyThreadState *tstate)
     }
 
     MUTEX_LOCK(_PyRuntime.ceval.gil.mutex);
-    /* Mark the interpreter as inactive. */
-    tstate->interp->ceval.active = 0;
-    tstate->interp->ceval.active_thread = 0;
+    if (tstate != NULL) {
+        /* Mark the interpreter as inactive. */
+        tstate->interp->ceval.active = 0;
+        tstate->interp->ceval.active_thread = 0;
+    }
     _Py_ANNOTATE_RWLOCK_RELEASED(&_PyRuntime.ceval.gil.locked, /*is_write=*/1);
     _Py_atomic_store_relaxed(&_PyRuntime.ceval.gil.locked, 0);
     COND_SIGNAL(_PyRuntime.ceval.gil.cond);

--- a/Python/ceval_gil.h
+++ b/Python/ceval_gil.h
@@ -160,11 +160,6 @@ static void drop_gil(PyThreadState *tstate)
     }
 
     MUTEX_LOCK(_PyRuntime.ceval.gil.mutex);
-    if (tstate != NULL) {
-        /* Mark the interpreter as inactive. */
-        tstate->interp->ceval.active = 0;
-        tstate->interp->ceval.active_thread = 0;
-    }
     _Py_ANNOTATE_RWLOCK_RELEASED(&_PyRuntime.ceval.gil.locked, /*is_write=*/1);
     _Py_atomic_store_relaxed(&_PyRuntime.ceval.gil.locked, 0);
     COND_SIGNAL(_PyRuntime.ceval.gil.cond);
@@ -248,10 +243,6 @@ _ready:
     if (tstate->async_exc != NULL) {
         _PyEval_SignalAsyncExc(tstate->interp);
     }
-
-    /* Mark the interpreter as active. */
-    tstate->interp->ceval.active = 1;
-    tstate->interp->ceval.active_thread = PyThread_get_thread_ident();
 
     MUTEX_UNLOCK(_PyRuntime.ceval.gil.mutex);
     errno = err;

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1416,10 +1416,21 @@ Py_EndInterpreter(PyThreadState *tstate)
     if (tstate->frame != NULL)
         Py_FatalError("Py_EndInterpreter: thread still has a frame");
 
+    // Mark as finalizing.
+    if (interp->ceval.pending.lock != NULL) {
+        PyThread_acquire_lock(interp->ceval.pending.lock, 1);
+    }
+    interp->finalizing = 1;
+    if (interp->ceval.pending.lock != NULL) {
+        PyThread_release_lock(interp->ceval.pending.lock);
+    }
+
+    // Wrap up existing threads.
     wait_for_thread_shutdown();
     interp->ceval.active = 1;
     interp->ceval.active_thread = PyThread_get_thread_ident();
 
+    // Make any pending calls.
     if (_Py_atomic_load_relaxed(
                 &(interp->ceval.pending.calls_to_do)))
     {

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1417,9 +1417,8 @@ Py_EndInterpreter(PyThreadState *tstate)
         Py_FatalError("Py_EndInterpreter: thread still has a frame");
 
     wait_for_thread_shutdown();
-    // XXX Forcibly mark current thread as active?
-    assert(interp->ceval.active);
-    assert(interp->ceval.active_thread == PyThread_get_thread_ident());
+    interp->ceval.active = 1;
+    interp->ceval.active_thread = PyThread_get_thread_ident();
 
     if (_Py_atomic_load_relaxed(
                 &(interp->ceval.pending.calls_to_do)))

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1427,8 +1427,6 @@ Py_EndInterpreter(PyThreadState *tstate)
 
     // Wrap up existing threads.
     wait_for_thread_shutdown();
-    interp->ceval.active = 1;
-    interp->ceval.active_thread = PyThread_get_thread_ident();
 
     // Make any pending calls.
     if (_Py_atomic_load_relaxed(

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -138,6 +138,7 @@ PyInterpreterState_New(void)
     interp->id_refcount = -1;
     interp->check_interval = 100;
 
+    interp->ceval.active = 1;
     interp->ceval.active_thread = PyThread_get_thread_ident();
     interp->ceval.pending.lock = PyThread_allocate_lock();
     if (interp->ceval.pending.lock == NULL) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -139,7 +139,7 @@ PyInterpreterState_New(void)
     interp->check_interval = 100;
 
     // XXX Is this the right thread?
-    interp->ceval.pending.main_thread = PyThread_get_thread_ident();
+    interp->ceval.pending.active_thread = PyThread_get_thread_ident();
     interp->ceval.pending.lock = PyThread_allocate_lock();
     if (interp->ceval.pending.lock == NULL) {
         PyErr_SetString(PyExc_RuntimeError,

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -1302,7 +1302,7 @@ _PyCrossInterpreterData_Release(_PyCrossInterpreterData *data)
     }
 
     // "Release" the data and/or the object.
-    _Py_AddPendingCall(interp, _release_xidata, data);
+    _Py_AddPendingCall(interp, 0, _release_xidata, data);
 }
 
 PyObject *

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -138,8 +138,7 @@ PyInterpreterState_New(void)
     interp->id_refcount = -1;
     interp->check_interval = 100;
 
-    // XXX Is this the right thread?
-    interp->ceval.pending.active_thread = PyThread_get_thread_ident();
+    interp->ceval.active_thread = PyThread_get_thread_ident();
     interp->ceval.pending.lock = PyThread_allocate_lock();
     if (interp->ceval.pending.lock == NULL) {
         PyErr_SetString(PyExc_RuntimeError,

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -847,7 +847,7 @@ PyThreadState_SetAsyncExc(unsigned long id, PyObject *exc)
             p->async_exc = exc;
             HEAD_UNLOCK();
             Py_XDECREF(old_exc);
-            _PyEval_SignalAsyncExc();
+            _PyEval_SignalAsyncExc(interp);
             return 1;
         }
     }

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -134,28 +134,12 @@ PyInterpreterState_New(void)
         return NULL;
     }
 
+    memset(interp, 0, sizeof(*interp));
     interp->id_refcount = -1;
-    interp->id_mutex = NULL;
-    interp->modules = NULL;
-    interp->modules_by_index = NULL;
-    interp->sysdict = NULL;
-    interp->builtins = NULL;
-    interp->builtins_copy = NULL;
-    interp->tstate_head = NULL;
     interp->check_interval = 100;
-    interp->num_threads = 0;
-    interp->pythread_stacksize = 0;
-    interp->codec_search_path = NULL;
-    interp->codec_search_cache = NULL;
-    interp->codec_error_registry = NULL;
-    interp->codecs_initialized = 0;
-    interp->fscodec_initialized = 0;
     interp->core_config = _PyCoreConfig_INIT;
     interp->config = _PyMainInterpreterConfig_INIT;
-    interp->importlib = NULL;
-    interp->import_func = NULL;
     interp->eval_frame = _PyEval_EvalFrameDefault;
-    interp->co_extra_user_count = 0;
 #ifdef HAVE_DLOPEN
 #if HAVE_DECL_RTLD_NOW
     interp->dlopenflags = RTLD_NOW;
@@ -163,13 +147,6 @@ PyInterpreterState_New(void)
     interp->dlopenflags = RTLD_LAZY;
 #endif
 #endif
-#ifdef HAVE_FORK
-    interp->before_forkers = NULL;
-    interp->after_forkers_parent = NULL;
-    interp->after_forkers_child = NULL;
-#endif
-    interp->pyexitfunc = NULL;
-    interp->pyexitmodule = NULL;
 
     HEAD_LOCK();
     if (_PyRuntime.interpreters.next_id < 0) {

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -138,8 +138,8 @@ PyInterpreterState_New(void)
     interp->id_refcount = -1;
     interp->check_interval = 100;
 
-    interp->ceval.active = 1;
-    interp->ceval.active_thread = PyThread_get_thread_ident();
+    //interp->ceval.active = 1;
+    //interp->ceval.active_thread = PyThread_get_thread_ident();
     interp->ceval.pending.lock = PyThread_allocate_lock();
     if (interp->ceval.pending.lock == NULL) {
         PyErr_SetString(PyExc_RuntimeError,

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -189,8 +189,6 @@ void
 PyInterpreterState_Clear(PyInterpreterState *interp)
 {
     PyThreadState *p;
-    // XXX Also ensure that all pending calls have been made.  Disallow
-    // registration of more pending calls.
     HEAD_LOCK();
     for (p = interp->tstate_head; p != NULL; p = p->next)
         PyThreadState_Clear(p);

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -189,6 +189,8 @@ void
 PyInterpreterState_Clear(PyInterpreterState *interp)
 {
     PyThreadState *p;
+    // XXX Also ensure that all pending calls have been made.  Disallow
+    // registration of more pending calls.
     HEAD_LOCK();
     for (p = interp->tstate_head; p != NULL; p = p->next)
         PyThreadState_Clear(p);
@@ -210,6 +212,9 @@ PyInterpreterState_Clear(PyInterpreterState *interp)
     Py_CLEAR(interp->after_forkers_parent);
     Py_CLEAR(interp->after_forkers_child);
 #endif
+    // XXX Once we have one allocator per interpreter (i.e.
+    // per-interpreter GC) we must ensure that all of the interpreter's
+    // objects have been cleaned up at the point.
 }
 
 


### PR DESCRIPTION
This is part of the work to improve isolation between subinterpreters.  We need a way for one interpreter to ask another interpreter to do small low-level tasks, like safely decref an object owned by the other interpreter.  The existing `Py_AddPendingCall()` (part of the public C-API) is specific to the main interpreter, so we factor out a private per-interpreter `_Py_AddPendingCall()`.  This involves moving the global "pending calls" state to `PyInterpreterState`.

As part of this change, we start tracking if each interpreter is "active" or finalizing.  "Active" means that the interpreter is currently running the eval loop.  We also start tracking the per-interpreter "active" thread ID rather than the global "main" thread ID.

<!-- issue-number: [bpo-33608](https://www.bugs.python.org/issue33608) -->
https://bugs.python.org/issue33608
<!-- /issue-number -->
