### PR TITLE
bpo-34660: Replace offensive words

### DIFF
--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -1042,7 +1042,7 @@ def gen_preprocess_options(macros, include_dirs):
     C++.
     """
     # XXX it would be nice (mainly aesthetic, and so we don't generate
-    # stupid-looking command lines) to go over 'macros' and eliminate
+    # bad-looking command lines) to go over 'macros' and eliminate
     # redundant definitions/undefinitions (ie. ensure that only the
     # latest mention of a particular macro winds up on the command
     # line).  I don't think it's essential, though, since most (all?)

--- a/Lib/distutils/dist.py
+++ b/Lib/distutils/dist.py
@@ -860,7 +860,7 @@ Common commands: (see '--help-commands' for more)
 
             # Set any options that were supplied in config files
             # or on the command line.  (NB. support for error
-            # reporting is lame here: any errors aren't reported
+            # reporting is limited here: any errors aren't reported
             # until 'finalize_options()' is called, which means
             # we won't report the source of the error.)
             options = self.command_options.get(command)

--- a/Lib/doctest.py
+++ b/Lib/doctest.py
@@ -24,7 +24,7 @@ python M.py
 
 This won't display anything unless an example fails, in which case the
 failing example(s) and the cause(s) of the failure(s) are printed to stdout
-(why not stderr? because stderr is a lame hack <0.2 wink>), and the final
+(why not stderr? because stderr is a hack <0.2 wink>), and the final
 line of output is "Test failed.".
 
 Run it with the -v switch instead:

--- a/Lib/idlelib/TODO.txt
+++ b/Lib/idlelib/TODO.txt
@@ -9,7 +9,7 @@ TO DO:
     - performance?  (updates of large sets of locals are slow)
     - better integration of "debug module"
     - debugger should be global resource (attached to flist, not to shell)
-    - fix the stupid bug where you need to step twice
+    - fix the annoying bug where you need to step twice
     - display class name in stack viewer entries for methods
     - suppress tracing through IDLE internals (e.g. print) DONE
     - add a button to suppress through a specific module or class or method

--- a/Lib/idlelib/TODO.txt
+++ b/Lib/idlelib/TODO.txt
@@ -9,7 +9,7 @@ TO DO:
     - performance?  (updates of large sets of locals are slow)
     - better integration of "debug module"
     - debugger should be global resource (attached to flist, not to shell)
-    - fix the annoying bug where you need to step twice
+    - fix the stupid bug where you need to step twice
     - display class name in stack viewer entries for methods
     - suppress tracing through IDLE internals (e.g. print) DONE
     - add a button to suppress through a specific module or class or method

--- a/Lib/sqlite3/test/dbapi.py
+++ b/Lib/sqlite3/test/dbapi.py
@@ -696,7 +696,7 @@ class ExtensionTests(unittest.TestCase):
         cur = con.cursor()
         cur.executescript("""
             -- bla bla
-            /* a stupid comment */
+            /* a comment */
             create table a(i);
             insert into a(i) values (5);
             """)

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1111,7 +1111,7 @@ class FormatTest(unittest.TestCase):
             'thousands_sep' : ' '
             }
 
-        crazy = {
+        weird = {
             'decimal_point' : '&',
             'grouping': make_grouping([1, 4, 2, CHAR_MAX]),
             'thousands_sep' : '-'
@@ -1126,17 +1126,17 @@ class FormatTest(unittest.TestCase):
         self.assertEqual(get_fmt(Decimal('12.7'), en_US), '12.7')
         self.assertEqual(get_fmt(Decimal('12.7'), fr_FR), '12,7')
         self.assertEqual(get_fmt(Decimal('12.7'), ru_RU), '12,7')
-        self.assertEqual(get_fmt(Decimal('12.7'), crazy), '1-2&7')
+        self.assertEqual(get_fmt(Decimal('12.7'), weird), '1-2&7')
 
         self.assertEqual(get_fmt(123456789, en_US), '123,456,789')
         self.assertEqual(get_fmt(123456789, fr_FR), '123456789')
         self.assertEqual(get_fmt(123456789, ru_RU), '123 456 789')
-        self.assertEqual(get_fmt(1234567890123, crazy), '123456-78-9012-3')
+        self.assertEqual(get_fmt(1234567890123, weird), '123456-78-9012-3')
 
         self.assertEqual(get_fmt(123456789, en_US, '.6n'), '1.23457e+8')
         self.assertEqual(get_fmt(123456789, fr_FR, '.6n'), '1,23457e+8')
         self.assertEqual(get_fmt(123456789, ru_RU, '.6n'), '1,23457e+8')
-        self.assertEqual(get_fmt(123456789, crazy, '.6n'), '1&23457e+8')
+        self.assertEqual(get_fmt(123456789, weird, '.6n'), '1&23457e+8')
 
         # zero padding
         self.assertEqual(get_fmt(1234, fr_FR, '03n'), '1234')
@@ -1151,14 +1151,14 @@ class FormatTest(unittest.TestCase):
         self.assertEqual(get_fmt(12345, en_US, '09n'), '0,012,345')
         self.assertEqual(get_fmt(12345, en_US, '010n'), '00,012,345')
 
-        self.assertEqual(get_fmt(123456, crazy, '06n'), '1-2345-6')
-        self.assertEqual(get_fmt(123456, crazy, '07n'), '1-2345-6')
-        self.assertEqual(get_fmt(123456, crazy, '08n'), '1-2345-6')
-        self.assertEqual(get_fmt(123456, crazy, '09n'), '01-2345-6')
-        self.assertEqual(get_fmt(123456, crazy, '010n'), '0-01-2345-6')
-        self.assertEqual(get_fmt(123456, crazy, '011n'), '0-01-2345-6')
-        self.assertEqual(get_fmt(123456, crazy, '012n'), '00-01-2345-6')
-        self.assertEqual(get_fmt(123456, crazy, '013n'), '000-01-2345-6')
+        self.assertEqual(get_fmt(123456, weird, '06n'), '1-2345-6')
+        self.assertEqual(get_fmt(123456, weird, '07n'), '1-2345-6')
+        self.assertEqual(get_fmt(123456, weird, '08n'), '1-2345-6')
+        self.assertEqual(get_fmt(123456, weird, '09n'), '01-2345-6')
+        self.assertEqual(get_fmt(123456, weird, '010n'), '0-01-2345-6')
+        self.assertEqual(get_fmt(123456, weird, '011n'), '0-01-2345-6')
+        self.assertEqual(get_fmt(123456, weird, '012n'), '00-01-2345-6')
+        self.assertEqual(get_fmt(123456, weird, '013n'), '000-01-2345-6')
 
         # wide char separator and decimal point
         self.assertEqual(get_fmt(Decimal('-1.5'), dotsep_wide, '020n'),

--- a/Lib/test/test_email/test_headerregistry.py
+++ b/Lib/test/test_email/test_headerregistry.py
@@ -290,7 +290,7 @@ class TestContentTypeHeader(TestHeaderBase):
             [errors.InvalidHeaderDefect]),
 
         'junk_text_in_content_type': (
-            '<crazy "stuff">',
+            '<random "stuff">',
             'text/plain',
             'text',
             'plain',

--- a/Lib/test/test_keyword.py
+++ b/Lib/test/test_keyword.py
@@ -79,7 +79,7 @@ class TestKeywordGeneration(unittest.TestCase):
                     {1, "turnip"},
                 \t{1, "This one is tab indented"
                     {278, 0},
-                    {1, "crazy but legal"
+                    {1, "weird but legal"
                 "also legal" {1, "
                     {1, "continue"},
                    {1, "lemon"},
@@ -94,7 +94,7 @@ class TestKeywordGeneration(unittest.TestCase):
             "        'This one is tab indented',",
             "        'also legal',",
             "        'continue',",
-            "        'crazy but legal',",
+            "        'weird but legal',",
             "        'jello',",
             "        'lemon',",
             "        'tomato',",

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -285,11 +285,11 @@ class QueryTestCase(unittest.TestCase):
         self.assertEqual(pprint.pformat([d, d]),
             "[{'a': 1, 'b': 1, 'c': 1}, {'a': 1, 'b': 1, 'c': 1}]")
 
-        # The next one is kind of goofy.  The sorted order depends on the
+        # The next one is kind of odd.  The sorted order depends on the
         # alphabetic order of type names:  "int" < "str" < "tuple".  Before
         # Python 2.5, this was in the test_same_as_repr() test.  It's worth
         # keeping around for now because it's one of few tests of pprint
-        # against a crazy mix of types.
+        # against a random mix of types.
         self.assertEqual(pprint.pformat({"xy\tab\n": (3,), 5: [[]], (): {}}),
             r"{5: [[]], 'xy\tab\n': (3,), (): {}}")
 

--- a/Lib/test/test_unicode_file_functions.py
+++ b/Lib/test/test_unicode_file_functions.py
@@ -104,7 +104,7 @@ class UnicodeFileTests(unittest.TestCase):
             self._apply_failure(os.listdir, name)
 
     if sys.platform == 'win32':
-        # Windows is lunatic. Issue #13366.
+        # Windows is weird. Issue #13366.
         _listdir_failure = NotADirectoryError, FileNotFoundError
     else:
         _listdir_failure = NotADirectoryError

--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -939,7 +939,7 @@ class HTTPPasswordMgrWithPriorAuth(HTTPPasswordMgrWithDefaultRealm):
 
 class AbstractBasicAuthHandler:
 
-    # XXX this allows for multiple auth-schemes, but will stupidly pick
+    # XXX this allows for multiple auth-schemes, but will simply pick
     # the last one with a realm specified.
 
     # allow for double- and single-quoted realm values


### PR DESCRIPTION
This is a work in progress. Contributor Form has not been reviewed yet, apparently. I'll push more commits in the meantime.

<!-- issue-number: [bpo-34660](https://www.bugs.python.org/issue34660) -->
https://bugs.python.org/issue34660
<!-- /issue-number -->
