### PR TITLE
bpo-34699: allow path-like objects in program arguments in Windows

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -515,7 +515,7 @@ def list2cmdline(seq):
     # "Parsing C++ Command-Line Arguments"
     result = []
     needquote = False
-    for arg in seq:
+    for arg in map(os.fspath, seq):
         bs_buf = []
 
         # Add a space to separate this argument from the others

--- a/Lib/test/test_subprocess.py
+++ b/Lib/test/test_subprocess.py
@@ -363,6 +363,18 @@ class ProcessTestCase(BaseTestCase):
         temp_dir = self._normalize_cwd(temp_dir)
         self._assert_cwd(temp_dir, sys.executable, cwd=FakePath(temp_dir))
 
+    def test_args_with_pathlike(self):
+        temp_dir = tempfile.gettempdir()
+        temp_dir = self._normalize_cwd(temp_dir)
+        p = subprocess.Popen([FakePath(sys.executable), "-c",
+                              "import sys; sys.exit(47)"])
+        self.assertEqual(p.wait(), 47)
+        p = subprocess.Popen([sys.executable, "-c",
+                              "import sys; print(sys.argv[1], end='')",
+                              FakePath(temp_dir)], stdout=subprocess.PIPE)
+        with p:
+            self.assertEqual(os.fsdecode(p.stdout.read()), temp_dir)
+
     @unittest.skipIf(mswindows, "pending resolution of issue #15533")
     def test_cwd_with_relative_arg(self):
         # Check that Popen looks for args[0] relative to cwd if args[0]
@@ -1047,6 +1059,8 @@ class ProcessTestCase(BaseTestCase):
 
     def test_list2cmdline(self):
         self.assertEqual(subprocess.list2cmdline(['a b c', 'd', 'e']),
+                         '"a b c" d e')
+        self.assertEqual(subprocess.list2cmdline(['a b c', 'd', FakePath('e')]),
                          '"a b c" d e')
         self.assertEqual(subprocess.list2cmdline(['ab"c', '\\', 'd']),
                          'ab\\"c \\ d')

--- a/Misc/NEWS.d/next/Library/2018-09-15-15-32-04.bpo-34699.Q7XUTY.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-15-15-32-04.bpo-34699.Q7XUTY.rst
@@ -1,0 +1,3 @@
+Currently, the `subprocess.Popen` function allows for path-like objects in
+the argument list for POSIX but not in Windows. This PR makes Windows'
+`subprocess.Popen` accept path-like objects in the argument list.


### PR DESCRIPTION
Currently, the `subprocess.Popen` function allows for path-like objects in the argument list for POSIX but not in Windows.
This PR makes Windows' `subprocess.Popen` accept path-like objects in the argument list.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34699](https://www.bugs.python.org/issue34699) -->
https://bugs.python.org/issue34699
<!-- /issue-number -->
