### PR TITLE
Doc: Disable smartquotes for zh-tw and fr translations.

### DIFF
--- a/Doc/docutils.conf
+++ b/Doc/docutils.conf
@@ -1,2 +1,3 @@
 [restructuredtext parser]
 smartquotes-locales: ja: ""''
+                     zh-tw: ""''

--- a/Doc/docutils.conf
+++ b/Doc/docutils.conf
@@ -1,3 +1,4 @@
 [restructuredtext parser]
-smartquotes-locales: ja: ""''
-                     zh-tw: ""''
+smartquotes-locales: ja: ""'',
+                     zh-tw: ""'',
+                     fr: ""''


### PR DESCRIPTION
See: https://mail.python.org/pipermail/doc-sig/2018-August/004079.html
and: https://github.com/python/cpython/pull/4006
