### PR TITLE
bpo-34701: Updated the asyncio documentation to clearly state what happens if an asyncio coroutine recursively calls itself.

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -67,6 +67,12 @@ using the :func:`ensure_future` function or the :meth:`AbstractEventLoop.create_
 method.
 
 
+If a coroutine calls ``await coroutine`` or ``yield from coroutine`` recursively on
+itself, rather than on another coroutine, this call will execute immediately. No other
+coroutines will be scheduled to run when a coroutine is recursively calling itself,
+unless it also makes calls to other coroutines. 
+
+
 Coroutines (and tasks) can only run when the event loop is running.
 
 .. decorator:: coroutine


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34701](https://www.bugs.python.org/issue34701) -->
https://bugs.python.org/issue34701
<!-- /issue-number -->
