### PR TITLE
Add additional generated files to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -54,3 +54,6 @@ Include/opcode.h            linguist-generated=true
 Python/opcode_targets.h     linguist-generated=true
 Objects/typeslots.inc       linguist-generated=true
 Modules/unicodedata_db.h    linguist-generated=true
+Lib/token.py                linguist-generated=true
+Lib/symbol.py               linguist-generated=true
+Lib/keyword.py              linguist-generated=true


### PR DESCRIPTION
I discovered a few generated files that are missing from the .gitattributes file -- this patch adds them.

(For anyone who is unfamiliar, this spec in the .gitattributes file is used by GitHub to suppress diffs for generated files automatically unless they are requested)