### PR TITLE
bpo-34659: Adds initial kwarg to itertools.accumulate()

### DIFF
--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -86,7 +86,7 @@ The following module functions all construct and return iterators. Some provide
 streams of infinite length, so they should only be accessed by functions or
 loops that truncate the stream.
 
-.. function:: accumulate(iterable[, func])
+.. function:: accumulate(iterable[, func, *, initial=None])
 
     Make an iterator that returns accumulated sums, or accumulated
     results of other binary functions (specified via the optional
@@ -96,19 +96,23 @@ loops that truncate the stream.
     the default operation of addition, elements may be any addable
     type including :class:`~decimal.Decimal` or
     :class:`~fractions.Fraction`.) If the input iterable is empty, the
-    output iterable will also be empty.
+    output iterable will also be empty. If the keyword argument *initial* is
+    provided, the accumulation starts with the *initial* value.
 
     Roughly equivalent to::
 
-        def accumulate(iterable, func=operator.add):
+        def accumulate(iterable, func=operator.add, *, initial=None):
             'Return running totals'
             # accumulate([1,2,3,4,5]) --> 1 3 6 10 15
             # accumulate([1,2,3,4,5], operator.mul) --> 1 2 6 24 120
+            # accumulate([1,2,3,4], initial=100) --> 100, 101, 103, 106, 110
             it = iter(iterable)
-            try:
-                total = next(it)
-            except StopIteration:
-                return
+            total = initial
+            if initial is None:
+                try:
+                    total = next(it)
+                except StopIteration:
+                    return
             yield total
             for element in it:
                 total = func(total, element)
@@ -151,6 +155,9 @@ loops that truncate the stream.
 
     .. versionchanged:: 3.3
        Added the optional *func* parameter.
+
+    .. versionchanged:: 3.8
+       Added the optional *initial* parameter.
 
 .. function:: chain(*iterables)
 

--- a/Doc/library/itertools.rst
+++ b/Doc/library/itertools.rst
@@ -90,22 +90,27 @@ loops that truncate the stream.
 
     Make an iterator that returns accumulated sums, or accumulated
     results of other binary functions (specified via the optional
-    *func* argument).  If *func* is supplied, it should be a function
+    *func* argument).
+
+    If *func* is supplied, it should be a function
     of two arguments. Elements of the input *iterable* may be any type
     that can be accepted as arguments to *func*. (For example, with
     the default operation of addition, elements may be any addable
     type including :class:`~decimal.Decimal` or
-    :class:`~fractions.Fraction`.) If the input iterable is empty, the
-    output iterable will also be empty. If the keyword argument *initial* is
-    provided, the accumulation starts with the *initial* value.
+    :class:`~fractions.Fraction`.)
+
+    Usually, the number of elements output matches the input iterable.
+    However, if the keyword argument *initial* is provided, the
+    accumulation leads off with the *initial* value so that the output
+    has one more element than the input iterable.
 
     Roughly equivalent to::
 
         def accumulate(iterable, func=operator.add, *, initial=None):
             'Return running totals'
             # accumulate([1,2,3,4,5]) --> 1 3 6 10 15
+            # accumulate([1,2,3,4,5], initial=100) --> 100 101 103 106 110 115
             # accumulate([1,2,3,4,5], operator.mul) --> 1 2 6 24 120
-            # accumulate([1,2,3,4], initial=100) --> 100, 101, 103, 106, 110
             it = iter(iterable)
             total = initial
             if initial is None:

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -147,6 +147,7 @@ class TestBasicOps(unittest.TestCase):
             list(accumulate(s, chr))                                # unary-operation
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             self.pickletest(proto, accumulate(range(10)))           # test pickling
+            self.pickletest(proto, accumulate(range(10), initial=7))
         self.assertEqual(list(accumulate([10, 5, 1], initial=None)), [10, 15, 16])
         self.assertEqual(list(accumulate([10, 5, 1], initial=100)), [100, 110, 115, 116])
         self.assertEqual(list(accumulate([], initial=100)), [100])

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -147,6 +147,7 @@ class TestBasicOps(unittest.TestCase):
             list(accumulate(s, chr))                                # unary-operation
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             self.pickletest(proto, accumulate(range(10)))           # test pickling
+        self.assertEqual(list(accumulate([10, 5, 1], initial=None)), [10, 15, 16])
         self.assertEqual(list(accumulate([10, 5, 1], initial=100)), [100, 110, 115, 116])
         self.assertEqual(list(accumulate([], initial=100)), [100])
         with self.assertRaises(TypeError):

--- a/Lib/test/test_itertools.py
+++ b/Lib/test/test_itertools.py
@@ -147,6 +147,10 @@ class TestBasicOps(unittest.TestCase):
             list(accumulate(s, chr))                                # unary-operation
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             self.pickletest(proto, accumulate(range(10)))           # test pickling
+        self.assertEqual(list(accumulate([10, 5, 1], initial=100)), [100, 110, 115, 116])
+        self.assertEqual(list(accumulate([], initial=100)), [100])
+        with self.assertRaises(TypeError):
+            list(accumulate([10, 20], 100))
 
     def test_chain(self):
 

--- a/Misc/NEWS.d/next/Library/2018-09-16-17-04-16.bpo-34659.CWemzH.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-16-17-04-16.bpo-34659.CWemzH.rst
@@ -1,0 +1,1 @@
+Add an optional *initial* argument to itertools.accumulate().

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -385,7 +385,7 @@ PyDoc_STRVAR(itertools_accumulate__doc__,
 "accumulate(iterable, func=None, *, initial=None)\n"
 "--\n"
 "\n"
-"Return series of accumulated sums (or other binary  function results).");
+"Return series of accumulated sums (or other binary function results).");
 
 static PyObject *
 itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
@@ -510,4 +510,4 @@ itertools_count(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=e523e549ab118753 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8747700a12551d60 input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -382,29 +382,30 @@ exit:
 }
 
 PyDoc_STRVAR(itertools_accumulate__doc__,
-"accumulate(iterable, func=None)\n"
+"accumulate(iterable, func=None, /, initial=0)\n"
 "--\n"
 "\n"
-"Return series of accumulated sums (or other binary function results).");
+"Return series of accumulated sums (or other binary  function results).");
 
 static PyObject *
 itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
-                          PyObject *binop);
+                          PyObject *binop, PyObject *initial);
 
 static PyObject *
 itertools_accumulate(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"iterable", "func", NULL};
-    static _PyArg_Parser _parser = {"O|O:accumulate", _keywords, 0};
+    static const char * const _keywords[] = {"", "", "initial", NULL};
+    static _PyArg_Parser _parser = {"O|OO:accumulate", _keywords, 0};
     PyObject *iterable;
     PyObject *binop = Py_None;
+    PyObject *initial = NULL;
 
     if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
-        &iterable, &binop)) {
+        &iterable, &binop, &initial)) {
         goto exit;
     }
-    return_value = itertools_accumulate_impl(type, iterable, binop);
+    return_value = itertools_accumulate_impl(type, iterable, binop, initial);
 
 exit:
     return return_value;
@@ -509,4 +510,4 @@ itertools_count(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=d9eb9601bd3296ef input=a9049054013a1b77]*/
+/*[clinic end generated code: output=3ea8c62e738b844a input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -382,7 +382,7 @@ exit:
 }
 
 PyDoc_STRVAR(itertools_accumulate__doc__,
-"accumulate(iterable, func=None, /, initial=0)\n"
+"accumulate(iterable, func=None, *, initial=None)\n"
 "--\n"
 "\n"
 "Return series of accumulated sums (or other binary  function results).");
@@ -395,8 +395,8 @@ static PyObject *
 itertools_accumulate(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 {
     PyObject *return_value = NULL;
-    static const char * const _keywords[] = {"", "", "initial", NULL};
-    static _PyArg_Parser _parser = {"O|OO:accumulate", _keywords, 0};
+    static const char * const _keywords[] = {"iterable", "func", "initial", NULL};
+    static _PyArg_Parser _parser = {"O|O$O:accumulate", _keywords, 0};
     PyObject *iterable;
     PyObject *binop = Py_None;
     PyObject *initial = NULL;
@@ -510,4 +510,4 @@ itertools_count(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=3ea8c62e738b844a input=a9049054013a1b77]*/
+/*[clinic end generated code: output=e523e549ab118753 input=a9049054013a1b77]*/

--- a/Modules/clinic/itertoolsmodule.c.h
+++ b/Modules/clinic/itertoolsmodule.c.h
@@ -399,7 +399,7 @@ itertools_accumulate(PyTypeObject *type, PyObject *args, PyObject *kwargs)
     static _PyArg_Parser _parser = {"O|O$O:accumulate", _keywords, 0};
     PyObject *iterable;
     PyObject *binop = Py_None;
-    PyObject *initial = NULL;
+    PyObject *initial = Py_None;
 
     if (!_PyArg_ParseTupleAndKeywordsFast(args, kwargs, &_parser,
         &iterable, &binop, &initial)) {
@@ -510,4 +510,4 @@ itertools_count(PyTypeObject *type, PyObject *args, PyObject *kwargs)
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=8747700a12551d60 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=c8c47b766deeffc3 input=a9049054013a1b77]*/

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3581,6 +3581,19 @@ accumulate_next(accumulateobject *lz)
 static PyObject *
 accumulate_reduce(accumulateobject *lz, PyObject *Py_UNUSED(ignored))
 {
+    if (lz->initial != Py_None) {
+        PyObject *it;
+
+        assert(lz->total == NULL);
+        if (PyType_Ready(&chain_type) < 0)
+            return NULL;
+        it = PyObject_CallFunction((PyObject *)&chain_type, "(O)O",
+                                   lz->initial, lz->it);
+        if (it == NULL)
+            return NULL;
+        return Py_BuildValue("O(OO)O", Py_TYPE(lz),
+                            it, lz->binop?lz->binop:Py_None, Py_None);
+    }
     if (lz->total == Py_None) {
         PyObject *it;
 

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3590,7 +3590,7 @@ accumulate_reduce(accumulateobject *lz, PyObject *Py_UNUSED(ignored))
                                    lz->initial, lz->it);
         if (it == NULL)
             return NULL;
-        return Py_BuildValue("O(OO)O", Py_TYPE(lz),
+        return Py_BuildValue("O(NO)O", Py_TYPE(lz),
                             it, lz->binop?lz->binop:Py_None, Py_None);
     }
     if (lz->total == Py_None) {

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3475,6 +3475,7 @@ typedef struct {
     PyObject *total;
     PyObject *it;
     PyObject *binop;
+    PyObject *initial;
 } accumulateobject;
 
 static PyTypeObject accumulate_type;
@@ -3484,13 +3485,16 @@ static PyTypeObject accumulate_type;
 itertools.accumulate.__new__
     iterable: object
     func as binop: object = None
-Return series of accumulated sums (or other binary function results).
+    /
+    initial: object(c_default="NULL") = 0
+Return series of accumulated sums (or other binary  function results).
 [clinic start generated code]*/
 
 static PyObject *
 itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
-                          PyObject *binop)
-/*[clinic end generated code: output=514d0fb30ba14d55 input=6d9d16aaa1d3cbfc]*/
+                          PyObject *binop, PyObject *initial)
+/*[clinic end generated code: output=66da2650627128f8 input=81217eb2acbda6df]*/
+
 {
     PyObject *it;
     accumulateobject *lz;
@@ -3514,6 +3518,8 @@ itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
     }
     lz->total = NULL;
     lz->it = it;
+    Py_XINCREF(initial);
+    lz->initial = initial;
     return (PyObject *)lz;
 }
 
@@ -3524,6 +3530,7 @@ accumulate_dealloc(accumulateobject *lz)
     Py_XDECREF(lz->binop);
     Py_XDECREF(lz->total);
     Py_XDECREF(lz->it);
+    Py_XDECREF(lz->initial);
     Py_TYPE(lz)->tp_free(lz);
 }
 
@@ -3533,6 +3540,7 @@ accumulate_traverse(accumulateobject *lz, visitproc visit, void *arg)
     Py_VISIT(lz->binop);
     Py_VISIT(lz->it);
     Py_VISIT(lz->total);
+    Py_VISIT(lz->initial);
     return 0;
 }
 
@@ -3541,6 +3549,13 @@ accumulate_next(accumulateobject *lz)
 {
     PyObject *val, *newtotal;
 
+    if (lz->initial != NULL) {
+        newtotal = lz->initial;
+        Py_INCREF(newtotal);
+        Py_SETREF(lz->total, newtotal);
+        lz->initial = NULL;
+        return newtotal;
+    }
     val = (*Py_TYPE(lz->it)->tp_iternext)(lz->it);
     if (val == NULL)
         return NULL;

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3494,7 +3494,6 @@ static PyObject *
 itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
                           PyObject *binop, PyObject *initial)
 /*[clinic end generated code: output=66da2650627128f8 input=759cc7dd710216bd]*/
-
 {
     PyObject *it;
     accumulateobject *lz;

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3485,15 +3485,15 @@ static PyTypeObject accumulate_type;
 itertools.accumulate.__new__
     iterable: object
     func as binop: object = None
-    /
-    initial: object(c_default="NULL") = 0
-Return series of accumulated sums (or other binary  function results).
+    *
+    initial: object(c_default="NULL") = None
+Return series of accumulated sums (or other binary function results).
 [clinic start generated code]*/
 
 static PyObject *
 itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
                           PyObject *binop, PyObject *initial)
-/*[clinic end generated code: output=66da2650627128f8 input=81217eb2acbda6df]*/
+/*[clinic end generated code: output=66da2650627128f8 input=5f85e0cd46fa7be4]*/
 
 {
     PyObject *it;
@@ -3550,11 +3550,10 @@ accumulate_next(accumulateobject *lz)
     PyObject *val, *newtotal;
 
     if (lz->initial != NULL) {
-        newtotal = lz->initial;
-        Py_INCREF(newtotal);
-        Py_SETREF(lz->total, newtotal);
+        lz->total = lz->initial;
         lz->initial = NULL;
-        return newtotal;
+        Py_INCREF(lz->total);
+        return lz->total;
     }
     val = (*Py_TYPE(lz->it)->tp_iternext)(lz->it);
     if (val == NULL)

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3498,7 +3498,6 @@ itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
     PyObject *it;
     accumulateobject *lz;
 
-
     /* Get iterator. */
     it = PyObject_GetIter(iterable);
     if (it == NULL)

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3493,7 +3493,7 @@ Return series of accumulated sums (or other binary function results).
 static PyObject *
 itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
                           PyObject *binop, PyObject *initial)
-/*[clinic end generated code: output=66da2650627128f8 input=5f85e0cd46fa7be4]*/
+/*[clinic end generated code: output=66da2650627128f8 input=759cc7dd710216bd]*/
 
 {
     PyObject *it;

--- a/Modules/itertoolsmodule.c
+++ b/Modules/itertoolsmodule.c
@@ -3486,14 +3486,14 @@ itertools.accumulate.__new__
     iterable: object
     func as binop: object = None
     *
-    initial: object(c_default="NULL") = None
+    initial: object = None
 Return series of accumulated sums (or other binary function results).
 [clinic start generated code]*/
 
 static PyObject *
 itertools_accumulate_impl(PyTypeObject *type, PyObject *iterable,
                           PyObject *binop, PyObject *initial)
-/*[clinic end generated code: output=66da2650627128f8 input=759cc7dd710216bd]*/
+/*[clinic end generated code: output=66da2650627128f8 input=c4ce20ac59bf7ffd]*/
 {
     PyObject *it;
     accumulateobject *lz;
@@ -3548,9 +3548,10 @@ accumulate_next(accumulateobject *lz)
 {
     PyObject *val, *newtotal;
 
-    if (lz->initial != NULL) {
+    if (lz->initial != Py_None) {
         lz->total = lz->initial;
-        lz->initial = NULL;
+        Py_INCREF(Py_None);
+        lz->initial = Py_None;
         Py_INCREF(lz->total);
         return lz->total;
     }


### PR DESCRIPTION
https://bugs.python.org/issue34659

<!-- issue-number: [bpo-34659](https://www.bugs.python.org/issue34659) -->
https://bugs.python.org/issue34659
<!-- /issue-number -->
