### PR TITLE
bpo-34710: fix SSL module build

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-09-17-13-56-12.bpo-34710.ARqIAK.rst
+++ b/Misc/NEWS.d/next/Build/2018-09-17-13-56-12.bpo-34710.ARqIAK.rst
@@ -1,0 +1,1 @@
+Fixed SSL module build with OpenSSL & pedantic CFLAGS.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -63,6 +63,7 @@ static PySocketModule_APIObject PySocketModule;
 #include "openssl/err.h"
 #include "openssl/rand.h"
 #include "openssl/bio.h"
+#include "openssl/dh.h"
 
 #ifndef HAVE_X509_VERIFY_PARAM_SET1_HOST
 #  ifdef LIBRESSL_VERSION_NUMBER


### PR DESCRIPTION
Not sure if this fails on all SSL versions. This was found while building
OpenWrt with Python 3.7.0 on x86 & OpenSSL 1.0.2p.

The `dh.h` header is included in several files, but it doesn't seem to be
included in the ones that are included in `_ssl.c` (as far as I could
tell).

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>

<!-- issue-number: [bpo-34710](https://www.bugs.python.org/issue34710) -->
https://bugs.python.org/issue34710
<!-- /issue-number -->
