### PR TITLE
[2.7] bpo-22851: Fix a segfault when accessing generator.gi_frame.f_restricted

### DIFF
--- a/Include/frameobject.h
+++ b/Include/frameobject.h
@@ -56,7 +56,7 @@ PyAPI_DATA(PyTypeObject) PyFrame_Type;
 
 #define PyFrame_Check(op) (Py_TYPE(op) == &PyFrame_Type)
 #define PyFrame_IsRestricted(f) \
-	((f)->f_builtins != (f)->f_tstate->interp->builtins)
+	((f)->f_tstate && (f)->f_builtins != (f)->f_tstate->interp->builtins)
 
 PyAPI_FUNC(PyFrameObject *) PyFrame_New(PyThreadState *, PyCodeObject *,
                                        PyObject *, PyObject *);

--- a/Lib/test/test_generators.py
+++ b/Lib/test/test_generators.py
@@ -1877,6 +1877,16 @@ test_generators just happened to be the test that drew these out.
 
 """
 
+crash_test = """
+>>> def foo(): yield
+>>> gen = foo()
+>>> gen.next()
+>>> print gen.gi_frame.f_restricted  # This would segfault.
+False
+
+"""
+
+
 __test__ = {"tut":      tutorial_tests,
             "pep":      pep_tests,
             "email":    email_tests,
@@ -1886,6 +1896,7 @@ __test__ = {"tut":      tutorial_tests,
             "weakref":  weakref_tests,
             "coroutine":  coroutine_tests,
             "refleaks": refleaks_tests,
+            "crash": crash_test,
             }
 
 # Magic test name that regrtest.py invokes *after* importing this module.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-17-04-41-42.bpo-22851.0hsJPh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-17-04-41-42.bpo-22851.0hsJPh.rst
@@ -1,0 +1,1 @@
+Fix a segfault when accessing ``generator.gi_frame.f_restricted``.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-17-04-41-42.bpo-22851.0hsJPh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-17-04-41-42.bpo-22851.0hsJPh.rst
@@ -1,2 +1,2 @@
 Fix a segfault when accessing ``generator.gi_frame.f_restricted`` when the
-generator is exhausted.
+generator is exhausted.  Patch by Zackery Spytz.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-17-04-41-42.bpo-22851.0hsJPh.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-17-04-41-42.bpo-22851.0hsJPh.rst
@@ -1,1 +1,2 @@
-Fix a segfault when accessing ``generator.gi_frame.f_restricted``.
+Fix a segfault when accessing ``generator.gi_frame.f_restricted`` when the
+generator is exhausted.


### PR DESCRIPTION



<!-- issue-number: [bpo-22851](https://www.bugs.python.org/issue22851) -->
https://bugs.python.org/issue22851
<!-- /issue-number -->
