### PR TITLE
[2.7] bpo-34710: fix SSL module build (GH-9347)

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-09-17-13-56-12.bpo-34710.ARqIAK.rst
+++ b/Misc/NEWS.d/next/Build/2018-09-17-13-56-12.bpo-34710.ARqIAK.rst
@@ -1,0 +1,1 @@
+Fixed SSL module build with OpenSSL & pedantic CFLAGS.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -74,6 +74,7 @@
 #include "openssl/ssl.h"
 #include "openssl/err.h"
 #include "openssl/rand.h"
+#include "openssl/dh.h"
 
 /* SSL error object */
 static PyObject *PySSLErrorObject;


### PR DESCRIPTION
Include ``openssl/dh.h`` header file to fix implicit function declaration of ``DH_free()``.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>.
(cherry picked from commit b3a271fc0ce3e13e427be8914decfc205a220ca8)

Co-authored-by: Alexandru Ardelean <ardeleanalex@gmail.com>


<!-- issue-number: [bpo-34710](https://www.bugs.python.org/issue34710) -->
https://bugs.python.org/issue34710
<!-- /issue-number -->
