### PR TITLE
bpo-34624: Allow regex for module passed via -W or PYTHONWARNINGS

### DIFF
--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -199,7 +199,9 @@ precedence over earlier ones).
 
 Commonly used warning filters apply to either all warnings, warnings in a
 particular category, or warnings raised by particular modules or packages.
-Some examples::
+Some examples:
+
+.. code-block:: none
 
    default                      # Show all warnings (even those ignored by default)
    ignore                       # Ignore all warnings

--- a/Doc/library/warnings.rst
+++ b/Doc/library/warnings.rst
@@ -207,8 +207,8 @@ Some examples::
    error::ResourceWarning       # Treat ResourceWarning messages as errors
    default::DeprecationWarning  # Show DeprecationWarning messages
    ignore,default:::mymodule    # Only report warnings triggered by "mymodule"
-   error:::mymodule[.*]         # Convert warnings to errors in "mymodule"
-                                # and any subpackages of "mymodule"
+   error:::mymodule(\..*)?      # Convert warnings to errors in "mymodule"
+                                # and any of its submodules and subpackages
 
 
 .. _default-warning-filter:

--- a/Lib/test/test_warnings/data/submodule_warning.py
+++ b/Lib/test/test_warnings/data/submodule_warning.py
@@ -1,0 +1,3 @@
+import warnings
+
+warnings.warn('submodule warning', DeprecationWarning)

--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -220,12 +220,8 @@ def _setoption(arg):
                                                  for s in parts]
     action = _getaction(action)
     category = _getcategory(category)
-    if message or module:
-        import re
-    if message:
-        message = re.escape(message)
     if module:
-        module = re.escape(module) + r'\Z'
+        module = r'\A(' + module + r')\Z'
     if lineno:
         try:
             lineno = int(lineno)

--- a/Misc/NEWS.d/next/Library/2018-09-30-19-49-37.bpo-34624.UrjcKN.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-30-19-49-37.bpo-34624.UrjcKN.rst
@@ -1,0 +1,2 @@
+When passing warning filters via ``-W`` or ``PYTHONWARNINGS``, treat the
+``module`` part as regex.


### PR DESCRIPTION
Enables passing in regexes for the *module* part via `-W` or `PYTHONWARNINGS` as implied it should be possible by the documentation.

https://bugs.python.org/issue34624

The same should should probably be done for the *message* part as this is implied to work as regex as well.

<!-- issue-number: [bpo-34624](https://www.bugs.python.org/issue34624) -->
https://bugs.python.org/issue34624
<!-- /issue-number -->
