### PR TITLE
bpo-34711: On systems that open() a regular file with a trailing slash respond with ENOTDIR

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-17-13-45-00.bpo-34711.Dp4bkz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-17-13-45-00.bpo-34711.Dp4bkz.rst
@@ -1,0 +1,2 @@
+On systems that open() a regular file with a trailing slash as ENOTDIR
+patch by Michael Felt

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -15,6 +15,7 @@
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
+#include <string.h>
 #include <stddef.h> /* For offsetof */
 #include "_iomodule.h"
 

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -15,7 +15,6 @@
 #ifdef HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
-#include <string.h>
 #include <stddef.h> /* For offsetof */
 #include "_iomodule.h"
 
@@ -455,7 +454,7 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
            be an error - ENOTDIR */
         if (S_ISREG(fdfstat.st_mode)) {
 #ifdef MS_WINDOWS
-                rcpt= strrch(widename, '\');
+                rcpt = strrchr(widename, '\');
 #else
 		rcpt = strrchr(name, '/');
 #endif

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -451,21 +451,15 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
         /* On AIX and Windows, open() may succeed for files with a trailing slash.
            The Open Group specifies filenames ending with a trailing slash should
            be an error - ENOTDIR */
-        if ( (fd < 0) && S_ISREG(fdfstat.st_mode)) {
-
-            int trailing_slash = 0;
+        if (fd < 0 && S_ISREG(fdfstat.st_mode)) {
 #ifdef MS_WINDOWS
             size_t len = wcslen(widename);
-            if (len && (widename[len - 1] == L'\\' || widename[len - 1] == L'/')) {
-                trailing_slash = 1;
-            }
+            if (len && (widename[len - 1] == L'\\' ||
+                widename[len - 1] == L'/')) {
 #else
             size_t len = strlen(name);
             if (len && name[len - 1] == '/') {
-                trailing_slash = 1;
-            }
 #endif
-            if (trailing_slash) {
                 errno = ENOTDIR;
                 PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, nameobj);
                 goto error;

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -228,7 +228,6 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
 #endif
     PyObject *stringobj = NULL;
     const char *s;
-    char *rcpt;
     int ret = 0;
     int rwa = 0, plus = 0;
     int flags = 0;

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -448,28 +448,35 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
     }
     else {
 #if defined(S_ISREG) && defined(ENOTDIR)
-        /* On AIX and Windows, open may succeed for files with a trailing slash.
+        /* On AIX and Windows, open() may succeed for files with a trailing slash.
            The Open Group specifies filenames ending with a trailing slash should
            be an error - ENOTDIR */
-	if (S_ISREG(fdfstat.st_mode)) {
-	    int trailing_slash = 0;
+        if (
 #ifdef MS_WINDOWS
-	    size_t len = wcslen(widename);
-	    if (len && (widename[len - 1] == L'\\' || widename[len - 1] == L'/')) {
-		trailing_slash = 1;
-	    }
+            (widename != NULL)
 #else
-	    size_t len = strlen(name);
-	    if (len && name[len - 1] == '/') {
-		trailing_slash = 1;
-	    }
+            (name != NULL)
 #endif
-	    if (trailing_slash) {
-		errno = ENOTDIR;
-		PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, nameobj);
-		goto error;
-	    }
-	}
+                && S_ISREG(fdfstat.st_mode)) {
+
+            int trailing_slash = 0;
+#ifdef MS_WINDOWS
+            size_t len = wcslen(widename);
+            if (len && (widename[len - 1] == L'\\' || widename[len - 1] == L'/')) {
+                trailing_slash = 1;
+            }
+#else
+            size_t len = strlen(name);
+            if (len && name[len - 1] == '/') {
+                trailing_slash = 1;
+            }
+#endif
+            if (trailing_slash) {
+                errno = ENOTDIR;
+                PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, nameobj);
+                goto error;
+            }
+        }
 #endif
 #if defined(S_ISDIR) && defined(EISDIR)
         /* On Unix, open will succeed for directories.

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -452,17 +452,24 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
         /* On AIX and Windows, open may succeed for files with a trailing slash.
            The Open Group specifies filenames ending with a trailing slash should
            be an error - ENOTDIR */
-        if (S_ISREG(fdfstat.st_mode)) {
+	if (S_ISREG(fdfstat.st_mode)) {
+	    int trailing_slash = 0;
 #ifdef MS_WINDOWS
-                rcpt = strrchr(widename, '\');
+	    size_t len = wcslen(widename);
+	    if (len && (widename[len - 1] == L'\\' || widename[len - 1] == L'/')) {
+		trailing_slash = 1;
+	    }
 #else
-		rcpt = strrchr(name, '/');
+	    size_t len = strlen(name);
+	    if (len && name[len - 1] == '/') {
+		trailing_slash = 1;
+	    }
 #endif
-                if ((rcpt != NULL) && (strlen(rcpt) == 1)) {
-		    errno = ENOTDIR;
-		    PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, nameobj);
-		    goto error;
-		}
+	    if (trailing_slash) {
+		errno = ENOTDIR;
+		PyErr_SetFromErrnoWithFilenameObject(PyExc_OSError, nameobj);
+		goto error;
+	    }
 	}
 #endif
 #if defined(S_ISDIR) && defined(EISDIR)

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -451,13 +451,7 @@ _io_FileIO___init___impl(fileio *self, PyObject *nameobj, const char *mode,
         /* On AIX and Windows, open() may succeed for files with a trailing slash.
            The Open Group specifies filenames ending with a trailing slash should
            be an error - ENOTDIR */
-        if (
-#ifdef MS_WINDOWS
-            (widename != NULL)
-#else
-            (name != NULL)
-#endif
-                && S_ISREG(fdfstat.st_mode)) {
+        if ( (fd < 0) && S_ISREG(fdfstat.st_mode)) {
 
             int trailing_slash = 0;
 #ifdef MS_WINDOWS


### PR DESCRIPTION
<!-- issue-number: [bpo-34711](https://www.bugs.python.org/issue34711) -->
https://bugs.python.org/issue34711
<!-- /issue-number -->
from http://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html

[ENOTDIR]
    A component of the path prefix names an existing file that is neither a directory nor a symbolic link to a directory; or O_CREAT and O_EXCL are not specified, the path argument contains at least one non- <slash> character and ends with one or more trailing <slash> characters, and the last pathname component names an existing file that is neither a directory nor a symbolic link to a directory; or O_DIRECTORY was specified and the path argument resolves to a non-directory file.