### PR TITLE
bpo-34712: Fix style in examples in "Input and Output"

### DIFF
--- a/Doc/tutorial/inputoutput.rst
+++ b/Doc/tutorial/inputoutput.rst
@@ -29,7 +29,8 @@ printing space-separated values. There are several ways to format output.
 
   ::
 
-     >>> year = 2016 ; event = 'Referendum'
+     >>> year = 2016
+     >>> event = 'Referendum'
      >>> f'Results of the {year} {event}'
      'Results of the 2016 Referendum'
 
@@ -40,8 +41,9 @@ printing space-separated values. There are several ways to format output.
 
   ::
 
-     >>> yes_votes = 42_572_654 ; no_votes = 43_132_495
-     >>> percentage = yes_votes/(yes_votes+no_votes)
+     >>> yes_votes = 42_572_654
+     >>> no_votes = 43_132_495
+     >>> percentage = yes_votes / (yes_votes + no_votes)
      >>> '{:-9} YES votes  {:2.2%}'.format(yes_votes, percentage)
      ' 42572654 YES votes  49.67%'
 
@@ -108,6 +110,7 @@ three places after the decimal::
 
    >>> import math
    >>> print(f'The value of pi is approximately {math.pi:.3f}.')
+   The value of pi is approximately 3.142.
 
 Passing an integer after the ``':'`` will cause that field to be a minimum
 number of characters wide.  This is useful for making columns line up. ::
@@ -127,7 +130,7 @@ applies :func:`repr`::
    >>> animals = 'eels'
    >>> print(f'My hovercraft is full of {animals}.')
    My hovercraft is full of eels.
-   >>> print(f'My hovercraft is full of {animals !r}.')
+   >>> print(f'My hovercraft is full of {animals!r}.')
    My hovercraft is full of 'eels'.
 
 For a reference on these format specifications, see


### PR DESCRIPTION
A couple of fixes here to make this more PEP-8:

* Avoid multiple statements on one line with `;` statement separator -- this is very rare in Python and is "generally discouraged" in PEP 8 (and if used, per PEP 8 there shouldn't be a space before the `;`)
* Add output for the first "Formatted String Literals" example. (Side note: are the doctests for this being run? If so, why didn't it fail?)
* Avoid space before `!r`. I have generally not seen spaces before the `!`, and this also matches the style used in the docs here: https://docs.python.org/3/library/string.html#format-string-syntax


<!-- issue-number: [bpo-34712](https://www.bugs.python.org/issue34712) -->
https://bugs.python.org/issue34712
<!-- /issue-number -->
