### PR TITLE
[3.6] bpo-32533: Fixed thread-safety of error handling in _ssl. (GH-7158)

### DIFF
--- a/Misc/NEWS.d/next/Security/2018-05-28-08-55-30.bpo-32533.IzwkBI.rst
+++ b/Misc/NEWS.d/next/Security/2018-05-28-08-55-30.bpo-32533.IzwkBI.rst
@@ -1,0 +1,1 @@
+Fixed thread-safety of error handling in _ssl.


### PR DESCRIPTION


<!-- issue-number: [bpo-32533](https://www.bugs.python.org/issue32533) -->
https://bugs.python.org/issue32533
<!-- /issue-number -->
