### PR TITLE
Trivial - Making pylifecycle.c:_Py_InitializeFromConfig pep7 compliant

### DIFF
--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -888,6 +888,7 @@ _Py_InitializeFromConfig(const _PyCoreConfig *config)
 {
     PyInterpreterState *interp = NULL;
     _PyInitError err;
+    
     err = _Py_InitializeCore(&interp, config);
     if (_Py_INIT_FAILED(err)) {
         return err;


### PR DESCRIPTION
Specific function was not conform with pep7. Simply added the blank line. 
