### PR TITLE
bpo-34717: Stop numbering stdlib titles/sections in the docs

### DIFF
--- a/Doc/library/index.rst
+++ b/Doc/library/index.rst
@@ -32,7 +32,9 @@ several thousand components (from individual programs and modules to
 packages and entire application development frameworks), available from
 the `Python Package Index <https://pypi.org>`_.
 
-
+.. We don't use :numbered: option for the TOC below as it enforces
+   numbered sections for the entire stdlib docs.  If desired,
+   :numbered: can be enabled on a per-module basis.
 .. toctree::
    :maxdepth: 2
 

--- a/Doc/library/index.rst
+++ b/Doc/library/index.rst
@@ -35,7 +35,6 @@ the `Python Package Index <https://pypi.org>`_.
 
 .. toctree::
    :maxdepth: 2
-   :numbered:
 
    intro.rst
    functions.rst


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34717](https://www.bugs.python.org/issue34717) -->
https://bugs.python.org/issue34717
<!-- /issue-number -->
