### PR TITLE
bpo-34589: Make _PyCoreConfig.coerce_c_locale private

### DIFF
--- a/Include/coreconfig.h
+++ b/Include/coreconfig.h
@@ -63,8 +63,6 @@ typedef struct {
     int show_alloc_count;   /* -X showalloccount */
     int dump_refs;          /* PYTHONDUMPREFS */
     int malloc_stats;       /* PYTHONMALLOCSTATS */
-    int coerce_c_locale;    /* PYTHONCOERCECLOCALE, -1 means unknown */
-    int coerce_c_locale_warn; /* PYTHONCOERCECLOCALE=warn */
 
     /* Python filesystem encoding and error handler:
        sys.getfilesystemencoding() and sys.getfilesystemencodeerrors().
@@ -297,6 +295,14 @@ typedef struct {
        If set to -1 (default), inherit Py_FrozenFlag value. */
     int _frozen;
 
+    /* C locale coercion (PEP 538).
+       Enabled by the PYTHONCOERCECLOCALE environment variable.
+       Unset (equal to -1) by default.
+
+       _coerce_c_locale_warn is set to 1 by PYTHONCOERCECLOCALE=warn. */
+    int _coerce_c_locale;
+    int _coerce_c_locale_warn;
+
 } _PyCoreConfig;
 
 #ifdef MS_WINDOWS
@@ -314,7 +320,7 @@ typedef struct {
         .use_hash_seed = -1, \
         .faulthandler = -1, \
         .tracemalloc = -1, \
-        .coerce_c_locale = -1, \
+        ._coerce_c_locale = -1, \
         .utf8_mode = -1, \
         .argc = -1, \
         .nmodule_search_path = -1, \

--- a/Include/coreconfig.h
+++ b/Include/coreconfig.h
@@ -296,11 +296,19 @@ typedef struct {
     int _frozen;
 
     /* C locale coercion (PEP 538).
-       Enabled by the PYTHONCOERCECLOCALE environment variable.
-       Unset (equal to -1) by default.
 
-       _coerce_c_locale_warn is set to 1 by PYTHONCOERCECLOCALE=warn. */
+       The option is enabled by the PYTHONCOERCECLOCALE environment
+       variable. The option is also enabled if the LC_CTYPE locale is "C"
+       and a target locale (ex: "C.UTF-8") is supported by the platform.
+
+       See also the _coerce_c_locale_warn option. */
     int _coerce_c_locale;
+
+    /* C locale coercion warning (PEP 538).
+
+       Enabled by the PYTHONCOERCECLOCALE=warn environment variable.
+
+       See also the _coerce_c_locale option. */
     int _coerce_c_locale_warn;
 
 } _PyCoreConfig;

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -277,8 +277,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'filesystem_errors': None,
 
         'utf8_mode': 0,
-        'coerce_c_locale': 0,
-        'coerce_c_locale_warn': 0,
 
         'pycache_prefix': NULL_STR,
         'program_name': './_testembed',
@@ -306,6 +304,8 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         '_install_importlib': 1,
         '_check_hash_pycs_mode': 'default',
         '_frozen': 0,
+        '_coerce_c_locale': 0,
+        '_coerce_c_locale_warn': 0,
     }
 
     def get_stdio_encoding(self, env):

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4701,10 +4701,6 @@ get_coreconfig(PyObject *self, PyObject *Py_UNUSED(args))
              PyLong_FromLong(config->dump_refs));
     SET_ITEM("malloc_stats",
              PyLong_FromLong(config->malloc_stats));
-    SET_ITEM("coerce_c_locale",
-             PyLong_FromLong(config->coerce_c_locale));
-    SET_ITEM("coerce_c_locale_warn",
-             PyLong_FromLong(config->coerce_c_locale_warn));
     SET_ITEM("filesystem_encoding",
              FROM_STRING(config->filesystem_encoding));
     SET_ITEM("filesystem_errors",
@@ -4783,6 +4779,10 @@ get_coreconfig(PyObject *self, PyObject *Py_UNUSED(args))
              FROM_STRING(config->_check_hash_pycs_mode));
     SET_ITEM("_frozen",
              PyLong_FromLong(config->_frozen));
+    SET_ITEM("_coerce_c_locale",
+             PyLong_FromLong(config->_coerce_c_locale));
+    SET_ITEM("_coerce_c_locale_warn",
+             PyLong_FromLong(config->_coerce_c_locale_warn));
 
     return dict;
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1342,9 +1342,9 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
          * See the documentation of the PYTHONCOERCECLOCALE setting for more
          * details.
          */
-        if (config->coerce_c_locale && !locale_coerced) {
+        if (config->_coerce_c_locale && !locale_coerced) {
             locale_coerced = 1;
-            _Py_CoerceLegacyLocale(config->coerce_c_locale_warn);
+            _Py_CoerceLegacyLocale(config->_coerce_c_locale_warn);
             encoding_changed = 1;
         }
 
@@ -1367,7 +1367,7 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
         /* Reset the configuration before reading again the configuration,
            just keep UTF-8 Mode value. */
         int new_utf8_mode = config->utf8_mode;
-        int new_coerce_c_locale = config->coerce_c_locale;
+        int new_coerce_c_locale = config->_coerce_c_locale;
         if (_PyCoreConfig_Copy(config, &save_config) < 0) {
             pymain->err = _Py_INIT_NO_MEMORY();
             goto done;
@@ -1375,7 +1375,7 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
         pymain_clear_cmdline(pymain, cmdline);
         memset(cmdline, 0, sizeof(*cmdline));
         config->utf8_mode = new_utf8_mode;
-        config->coerce_c_locale = new_coerce_c_locale;
+        config->_coerce_c_locale = new_coerce_c_locale;
 
         /* The encoding changed: read again the configuration
            with the new encoding */

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -330,8 +330,6 @@ dump_config(void)
 
     printf("filesystem_encoding = %s\n", config->filesystem_encoding);
     printf("filesystem_errors = %s\n", config->filesystem_errors);
-    printf("coerce_c_locale = %i\n", config->coerce_c_locale);
-    printf("coerce_c_locale_warn = %i\n", config->coerce_c_locale_warn);
     printf("utf8_mode = %i\n", config->utf8_mode);
 
     printf("pycache_prefix = %ls\n", config->pycache_prefix);
@@ -385,6 +383,8 @@ dump_config(void)
     printf("_install_importlib = %i\n", config->_install_importlib);
     printf("_check_hash_pycs_mode = %s\n", config->_check_hash_pycs_mode);
     printf("_frozen = %i\n", config->_frozen);
+    printf("_coerce_c_locale = %i\n", config->_coerce_c_locale);
+    printf("_coerce_c_locale_warn = %i\n", config->_coerce_c_locale_warn);
 
 #undef ASSERT_EQUAL
 #undef ASSERT_STR_EQUAL
@@ -482,7 +482,7 @@ static int test_init_from_config(void)
     putenv("PYTHONMALLOCSTATS=0");
     config.malloc_stats = 1;
 
-    /* FIXME: test coerce_c_locale and coerce_c_locale_warn */
+    /* FIXME: test _coerce_c_locale and _coerce_c_locale_warn */
 
     putenv("PYTHONUTF8=0");
     Py_UTF8Mode = 0;
@@ -606,8 +606,8 @@ static int test_init_isolated(void)
     /* Test _PyCoreConfig.isolated=1 */
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    /* Set coerce_c_locale and utf8_mode to not depend on the locale */
-    config.coerce_c_locale = 0;
+    /* Set _coerce_c_locale and utf8_mode to not depend on the locale */
+    config._coerce_c_locale = 0;
     config.utf8_mode = 0;
     /* Use path starting with "./" avoids a search along the PATH */
     config.program_name = L"./_testembed";

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -303,8 +303,8 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
     COPY_ATTR(dump_refs);
     COPY_ATTR(malloc_stats);
 
-    COPY_ATTR(coerce_c_locale);
-    COPY_ATTR(coerce_c_locale_warn);
+    COPY_ATTR(_coerce_c_locale);
+    COPY_ATTR(_coerce_c_locale_warn);
     COPY_ATTR(utf8_mode);
 
     COPY_WSTR_ATTR(pycache_prefix);
@@ -811,16 +811,16 @@ config_read_env_vars(_PyCoreConfig *config)
     const char *env = _PyCoreConfig_GetEnv(config, "PYTHONCOERCECLOCALE");
     if (env) {
         if (strcmp(env, "0") == 0) {
-            if (config->coerce_c_locale < 0) {
-                config->coerce_c_locale = 0;
+            if (config->_coerce_c_locale < 0) {
+                config->_coerce_c_locale = 0;
             }
         }
         else if (strcmp(env, "warn") == 0) {
-            config->coerce_c_locale_warn = 1;
+            config->_coerce_c_locale_warn = 1;
         }
         else {
-            if (config->coerce_c_locale < 0) {
-                config->coerce_c_locale = 1;
+            if (config->_coerce_c_locale < 0) {
+                config->_coerce_c_locale = 1;
             }
         }
     }
@@ -967,10 +967,10 @@ config_read_complex_options(_PyCoreConfig *config)
 static void
 config_init_locale(_PyCoreConfig *config)
 {
-    if (config->coerce_c_locale < 0) {
+    if (config->_coerce_c_locale < 0) {
         /* The C locale enables the C locale coercion (PEP 538) */
         if (_Py_LegacyLocaleDetected()) {
-            config->coerce_c_locale = 1;
+            config->_coerce_c_locale = 1;
         }
     }
 
@@ -1291,7 +1291,7 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         }
     }
 
-    if (config->utf8_mode < 0 || config->coerce_c_locale < 0) {
+    if (config->utf8_mode < 0 || config->_coerce_c_locale < 0) {
         config_init_locale(config);
     }
 
@@ -1321,8 +1321,8 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
     if (config->tracemalloc < 0) {
         config->tracemalloc = 0;
     }
-    if (config->coerce_c_locale < 0) {
-        config->coerce_c_locale = 0;
+    if (config->_coerce_c_locale < 0) {
+        config->_coerce_c_locale = 0;
     }
     if (config->utf8_mode < 0) {
         config->utf8_mode = 0;
@@ -1343,7 +1343,7 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         return err;
     }
 
-    assert(config->coerce_c_locale >= 0);
+    assert(config->_coerce_c_locale >= 0);
     assert(config->use_environment >= 0);
     assert(config->filesystem_encoding != NULL);
     assert(config->filesystem_errors != NULL);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -301,7 +301,7 @@ static const char *_C_LOCALE_WARNING =
 static void
 _emit_stderr_warning_for_legacy_locale(const _PyCoreConfig *core_config)
 {
-    if (core_config->coerce_c_locale_warn && _Py_LegacyLocaleDetected()) {
+    if (core_config->_coerce_c_locale_warn && _Py_LegacyLocaleDetected()) {
         PySys_FormatStderr("%s", _C_LOCALE_WARNING);
     }
 }


### PR DESCRIPTION
_PyCoreConfig:

* Rename coerce_c_locale to _coerce_c_locale
* Rename coerce_c_locale_warn to _coerce_c_locale_warn

These fields are now "private" (name prefixed by "_").


<!-- issue-number: [bpo-34589](https://www.bugs.python.org/issue34589) -->
https://bugs.python.org/issue34589
<!-- /issue-number -->
