### PR TITLE
bpo-33649: Fix syntax error on factorial example for asyncio

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -238,7 +238,7 @@ Running Tasks Concurrently
               factorial("A", 2),
               factorial("B", 3),
               factorial("C", 4),
-          ))
+          )
 
       asyncio.run(main())
 


### PR DESCRIPTION
Method `gather` require to close parenthesis, but it is being closed twice.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-33649](https://www.bugs.python.org/issue33649) -->
https://bugs.python.org/issue33649
<!-- /issue-number -->
