### PR TITLE
bpo-34720: Fix test_importlib.test_bad_traverse for AIX

### DIFF
--- a/Misc/NEWS.d/next/Tests/2018-09-18-12-03-41.bpo-34720.d5uOoP.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-18-12-03-41.bpo-34720.d5uOoP.rst
@@ -1,0 +1,1 @@
+Fix `test_importlib.test_bad_traverse` for AIX

--- a/Misc/NEWS.d/next/Tests/2018-09-18-12-03-41.bpo-34720.d5uOoP.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-18-12-03-41.bpo-34720.d5uOoP.rst
@@ -1,1 +1,0 @@
-Fix `test_importlib.test_bad_traverse` for AIX

--- a/Misc/NEWS.d/next/Tests/2018-12-26-12-31-16.bpo-34720.T268vz.rst
+++ b/Misc/NEWS.d/next/Tests/2018-12-26-12-31-16.bpo-34720.T268vz.rst
@@ -1,0 +1,2 @@
+Assert m_state != NULL to mimic transversal functions that do not correctly
+module creation when the module state has not been created.

--- a/Misc/NEWS.d/next/Tests/2018-12-26-12-31-16.bpo-34720.T268vz.rst
+++ b/Misc/NEWS.d/next/Tests/2018-12-26-12-31-16.bpo-34720.T268vz.rst
@@ -1,2 +1,2 @@
-Assert m_state != NULL to mimic transversal functions that do not correctly
-module creation when the module state has not been created.
+Assert m_state != NULL to mimic GC traversal functions that do not correctly
+handle module creation when the module state has not been created.

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -624,6 +624,18 @@ bad_traverse(PyObject *self, visitproc visit, void *arg) {
     testmultiphase_state *m_state;
 
     m_state = PyModule_GetState(self);
+
+#ifdef _AIX
+/*
+ * AIX does not have a segmentation fault is a NULL pointer is accessed
+ * In order to mimic other systems that would crash if &(m_state->integer) == NULL
+ * force a non-zero exit status
+ */
+    if (&(m_state->integer) == NULL) {
+	exit(255);
+    }
+#endif
+
     Py_VISIT(m_state->integer);
     return 0;
 }

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -632,7 +632,7 @@ bad_traverse(PyObject *self, visitproc visit, void *arg) {
  * force a non-zero exit status
  */
     if (&(m_state->integer) == NULL) {
-	exit(255);
+        exit(255);
     }
 #endif
 

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -625,17 +625,10 @@ bad_traverse(PyObject *self, visitproc visit, void *arg) {
 
     m_state = PyModule_GetState(self);
 
-#ifdef _AIX
-/*
- * AIX does not have a segmentation fault is a NULL pointer is accessed
- * In order to mimic other systems that would crash if &(m_state->integer) == NULL
- * force a non-zero exit status
- */
-    if (&(m_state->integer) == NULL) {
-        exit(255);
-    }
-#endif
-
+    /* The following assertion mimics any traversal function that doesn't correctly handle
+     * the case during module creation where the module state hasn't been created yet.
+     */
+    assert(m_state != NULL);
     Py_VISIT(m_state->integer);
     return 0;
 }

--- a/Modules/_testmultiphase.c
+++ b/Modules/_testmultiphase.c
@@ -627,6 +627,9 @@ bad_traverse(PyObject *self, visitproc visit, void *arg) {
 
     /* The following assertion mimics any traversal function that doesn't correctly handle
      * the case during module creation where the module state hasn't been created yet.
+     *
+     * The check that it is used to test only runs in debug mode, so it is OK that the
+     * assert() will get compiled out in fully optimised release builds.
      */
     assert(m_state != NULL);
     Py_VISIT(m_state->integer);


### PR DESCRIPTION
Fix  Modules/_testmultiphase.c so that it exits with non-zero status on AIX just as other systems do (non zero exit status, e.g. as result of a segmentation fault) when a NULL pointer is accessed for data.

<!-- issue-number: [[bpo-34720](https://bugs.python.org/issue34720)](https://www.bugs.python.org/issue34720) -->
https://bugs.python.org/issue34720
<!-- /issue-number -->
