### PR TITLE
[2.7] bpo-34623: Use XML_SetHashSalt in _elementtree (GH-9146)

### DIFF
--- a/Include/pyexpat.h
+++ b/Include/pyexpat.h
@@ -3,7 +3,7 @@
 
 /* note: you must import expat.h before importing this module! */
 
-#define PyExpat_CAPI_MAGIC  "pyexpat.expat_CAPI 1.0"
+#define PyExpat_CAPI_MAGIC  "pyexpat.expat_CAPI 1.1"
 #define PyExpat_CAPSULE_NAME "pyexpat.expat_CAPI"
 
 struct PyExpat_CAPI 
@@ -43,6 +43,8 @@ struct PyExpat_CAPI
         XML_Parser parser, XML_UnknownEncodingHandler handler,
         void *encodingHandlerData);
     void (*SetUserData)(XML_Parser parser, void *userData);
+    /* might be none for expat < 2.1.0 */
+    int (*SetHashSalt)(XML_Parser parser, unsigned long hash_salt);
     /* always add new stuff to the end! */
 };
 

--- a/Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst
+++ b/Misc/NEWS.d/next/Security/2018-09-10-16-05-39.bpo-34623.Ua9jMv.rst
@@ -1,0 +1,2 @@
+The C accelerated _elementtree module now initializes hash randomization
+salt from _Py_HashSecret instead of libexpat's default CSPRNG.

--- a/Modules/_elementtree.c
+++ b/Modules/_elementtree.c
@@ -2574,6 +2574,11 @@ xmlparser(PyObject* self_, PyObject* args, PyObject* kw)
         PyErr_NoMemory();
         return NULL;
     }
+    /* expat < 2.1.0 has no XML_SetHashSalt() */
+    if (EXPAT(SetHashSalt) != NULL) {
+        EXPAT(SetHashSalt)(self->parser,
+                           (unsigned long)_Py_HashSecret.prefix);
+    }
 
     ALLOC(sizeof(XMLParserObject), "create expatparser");
 

--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -2042,6 +2042,11 @@ MODULE_INITFUNC(void)
     capi.SetProcessingInstructionHandler = XML_SetProcessingInstructionHandler;
     capi.SetUnknownEncodingHandler = XML_SetUnknownEncodingHandler;
     capi.SetUserData = XML_SetUserData;
+#if XML_COMBINED_VERSION >= 20100
+    capi.SetHashSalt = XML_SetHashSalt;
+#else
+    capi.SetHashSalt = NULL;
+#endif
 
     /* export using capsule */
     capi_object = PyCapsule_New(&capi, PyExpat_CAPSULE_NAME, NULL);


### PR DESCRIPTION
The C accelerated _elementtree module now initializes hash randomization
salt from _Py_HashSecret instead of libexpat's default CPRNG.

Signed-off-by: Christian Heimes <christian@python.org>

https://bugs.python.org/issue34623.
(cherry picked from commit cb5778f00ce48631c7140f33ba242496aaf7102b)

Co-authored-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-34623](https://www.bugs.python.org/issue34623) -->
https://bugs.python.org/issue34623
<!-- /issue-number -->
