### PR TITLE
Clarify that AsyncExitStack works with coroutine functions

### DIFF
--- a/Doc/library/contextlib.rst
+++ b/Doc/library/contextlib.rst
@@ -471,11 +471,11 @@ Functions and classes provided:
    .. method:: push_async_exit(exit)
 
       Similar to :meth:`push` but expects either an asynchronous context manager
-      or a coroutine.
+      or a coroutine function.
 
    .. method:: push_async_callback(callback, *args, **kwds)
 
-      Similar to :meth:`callback` but expects a coroutine.
+      Similar to :meth:`callback` but expects a coroutine function.
 
    .. method:: aclose()
 


### PR DESCRIPTION
The docs were ambiguous about whether you pass in a coroutine function
or a coroutine object, e.g. is it:

  aestack.push_async_exit(some_async_func)

or

  aestack.push_async_exit(some_async_func())

(It's the first one.)

Here's an example of a user citing the docs as proof that it works the
way it *doesn't* work: https://github.com/python-trio/trio/issues/671#issuecomment-422333294