### PR TITLE
[2.7] bpo-34472: Add data descriptor signature to zipfile (GH-8871)

### DIFF
--- a/Lib/zipfile.py
+++ b/Lib/zipfile.py
@@ -131,6 +131,8 @@ _CD64_NUMBER_ENTRIES_TOTAL = 7
 _CD64_DIRECTORY_SIZE = 8
 _CD64_OFFSET_START_CENTDIR = 9
 
+_DD_SIGNATURE = 0x08074b50
+
 _EXTRA_FIELD_STRUCT = struct.Struct('<HH')
 
 def _strip_extra(extra, xids):
@@ -1270,9 +1272,9 @@ class ZipFile(object):
         self.fp.write(bytes)
         if zinfo.flag_bits & 0x08:
             # Write CRC and file sizes after the file data
-            fmt = '<LQQ' if zip64 else '<LLL'
-            self.fp.write(struct.pack(fmt, zinfo.CRC, zinfo.compress_size,
-                  zinfo.file_size))
+            fmt = '<LLQQ' if zip64 else '<LLLL'
+            self.fp.write(struct.pack(fmt, _DD_SIGNATURE, zinfo.CRC,
+                  zinfo.compress_size, zinfo.file_size))
         self.fp.flush()
         self.filelist.append(zinfo)
         self.NameToInfo[zinfo.filename] = zinfo

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1295,6 +1295,7 @@ Roger D. Serwy
 Jerry Seutter
 Pete Sevander
 Denis Severson
+Silas Sewell
 Ian Seyer
 Daniel Shahaf
 Mark Shannon

--- a/Misc/NEWS.d/next/Library/2018-08-23-09-25-08.bpo-34472.cGyYrO.rst
+++ b/Misc/NEWS.d/next/Library/2018-08-23-09-25-08.bpo-34472.cGyYrO.rst
@@ -1,0 +1,3 @@
+Improved compatibility for streamed files in :mod:`zipfile`. Previously an
+optional signature was not being written and certain ZIP applications were
+not supported. Patch by Silas Sewell.


### PR DESCRIPTION
This makes streamed zips compatible with MacOS Archive Utility and
other applications.
(cherry picked from commit 4ba3b50bfe6d50cd82d208023ea23e203ab50589)

Co-authored-by: Silas Sewell <silas@sewell.org>


<!-- issue-number: [bpo-34472](https://www.bugs.python.org/issue34472) -->
https://bugs.python.org/issue34472
<!-- /issue-number -->
