### PR TITLE
Revert the unwanted changes from offended SJW's.

### DIFF
--- a/Doc/library/gc.rst
+++ b/Doc/library/gc.rst
@@ -181,7 +181,7 @@ The :mod:`gc` module provides the following functions:
    fork() call to make the gc copy-on-write friendly or to speed up collection.
    Also collection before a POSIX fork() call may free pages for future
    allocation which can cause copy-on-write too so it's advised to disable gc
-   in parent process and freeze before fork and enable gc in child process.
+   in master process and freeze before fork and enable gc in child process.
 
    .. versionadded:: 3.7
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -435,7 +435,7 @@ process which created it.
 
    (If you try this it will actually output three full tracebacks
    interleaved in a semi-random fashion, and then you may have to
-   stop the parent process somehow.)
+   stop the master process somehow.)
 
 
 Reference

--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -223,7 +223,7 @@ class install(Command):
 
     def finalize_options(self):
         """Finalizes options."""
-        # This method (and its helpers, like 'finalize_unix()',
+        # This method (and its pliant slaves, like 'finalize_unix()',
         # 'finalize_other()', and 'select_scheme()') is where the default
         # installation directories for modules, extension modules, and
         # anything else we care to install from a Python module

--- a/Tools/README
+++ b/Tools/README
@@ -1,7 +1,7 @@
 This directory contains a number of Python programs that are useful
 while building or extending Python.
 
-buildbot        Batchfiles for running on Windows buildbot workers.
+buildbot        Batchfiles for running on Windows buildslaves.
 
 ccbench         A Python threads-based concurrency benchmark. (*)
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

This change is quite trivial, therefore I do not think that this needs an issue on the python.org issue tracker. That being said, I'd be happy to add one over there if so desired. In that case, I'll modify or recreate this issue here as needed.

The point of this PR is mostly to revert some of the changes made in #9100 (https://bugs.python.org/issue34605), whereas some of the files affected seem to have the "offensive" master/slave terminology removed altogether. The latter files have therefore not been modified.

To justify this revert, it does not seem like the master/slave terminology has anything to do with the social issues that these words may entail. The master/slave terminology is just as valid as client/server or host/guest. Technical terms should not be affected by social issues, particularly when it involves social justice warriors. The aforementioned issue met significant amounts of public outcry, which this revert may be able to rectify.