### PR TITLE
bpo-34728: Remove deprecate *loop* argument in asyncio.sleep

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -383,6 +383,10 @@ async def wait(fs, *, loop=None, timeout=None, return_when=ALL_COMPLETED):
 
     if loop is None:
         loop = events.get_event_loop()
+    else:
+        warnings.warn("The loop argument is deprecated and scheduled for"
+                      "removal in Python 4.0.",
+                      DeprecationWarning, stacklevel=2)
 
     fs = {ensure_future(f, loop=loop) for f in set(fs)}
 
@@ -409,6 +413,10 @@ async def wait_for(fut, timeout, *, loop=None):
     """
     if loop is None:
         loop = events.get_event_loop()
+    else:
+        warnings.warn("The loop argument is deprecated and scheduled for"
+                      "removal in Python 4.0.",
+                      DeprecationWarning, stacklevel=2)
 
     if timeout is None:
         return await fut

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -382,7 +382,7 @@ async def wait(fs, *, loop=None, timeout=None, return_when=ALL_COMPLETED):
         raise ValueError(f'Invalid return_when value: {return_when}')
 
     if loop is None:
-        loop = events.get_event_loop()
+        loop = events.get_running_loop()
     else:
         warnings.warn("The loop argument is deprecated and scheduled for"
                       "removal in Python 4.0.",
@@ -412,7 +412,7 @@ async def wait_for(fut, timeout, *, loop=None):
     This function is a coroutine.
     """
     if loop is None:
-        loop = events.get_event_loop()
+        loop = events.get_running_loop()
     else:
         warnings.warn("The loop argument is deprecated and scheduled for"
                       "removal in Python 4.0.",
@@ -593,7 +593,7 @@ async def sleep(delay, result=None, *, loop=None):
         return result
 
     if loop is None:
-        loop = events.get_event_loop()
+        loop = events.get_running_loop()
     else:
         warnings.warn("The loop argument is deprecated and scheduled for"
                       "removal in Python 4.0.",

--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -586,6 +586,11 @@ async def sleep(delay, result=None, *, loop=None):
 
     if loop is None:
         loop = events.get_event_loop()
+    else:
+        warnings.warn("The loop argument is deprecated and scheduled for"
+                      "removal in Python 4.0.",
+                      DeprecationWarning, stacklevel=2)
+
     future = loop.create_future()
     h = loop.call_later(delay,
                         futures._set_result_unless_cancelled,

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3229,6 +3229,37 @@ class SleepTests(test_utils.TestCase):
             self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
 
 
+class WaitTests(test_utils.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+    def tearDown(self):
+        self.loop.close()
+        self.loop = None
+        super().tearDown()
+
+    def test_loop_argument_is_deprecated_in_wait(self):
+        """
+        this test should be removed in Python 4.0 when the loop argument
+        will be removed
+        """
+        with self.assertWarns(DeprecationWarning):
+            self.loop.run_until_complete(asyncio.wait([coroutine_function()],
+                                                      loop=self.loop))
+
+    def test_loop_argument_is_deprecated_in_wait_for(self):
+        """
+        this test should be removed in Python 4.0 when the loop argument
+        will be removed
+        """
+        with self.assertWarns(DeprecationWarning):
+            self.loop.run_until_complete(asyncio.wait_for(coroutine_function(),
+                                                          0.01,
+                                                          loop=self.loop))
+
+
 class CompatibilityTests(test_utils.TestCase):
     # Tests for checking a bridge between old-styled coroutines
     # and async/await syntax

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3220,6 +3220,14 @@ class SleepTests(test_utils.TestCase):
         self.loop.run_until_complete(coro())
         self.assertEqual(result, 11)
 
+    def test_loop_argument_is_deprecated(self):
+        """
+        this test should be removed in Python 4.0 when the loop argument
+        will be removed
+        """
+        with self.assertWarns(DeprecationWarning):
+            self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+
 
 class CompatibilityTests(test_utils.TestCase):
     # Tests for checking a bridge between old-styled coroutines

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3221,8 +3221,7 @@ class SleepTests(test_utils.TestCase):
         self.assertEqual(result, 11)
 
     def test_loop_argument_is_deprecated(self):
-        # this test should be removed in Python 4.0 when the loop argument
-        # will be removed
+        # Remove test when loop argument is removed in Python 4.0
         with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
 
@@ -3239,15 +3238,13 @@ class WaitTests(test_utils.TestCase):
         super().tearDown()
 
     def test_loop_argument_is_deprecated_in_wait(self):
-        # this test should be removed in Python 4.0 when the loop argument
-        # will be removed
+        # Remove test when loop argument is removed in Python 4.0
         with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(
                 asyncio.wait([coroutine_function()], loop=self.loop))
 
     def test_loop_argument_is_deprecated_in_wait_for(self):
-        # this test should be removed in Python 4.0 when the loop argument
-        # will be removed
+        # Remove test when loop argument is removed in Python 4.0
         with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(
                 asyncio.wait_for(coroutine_function(), 0.01, loop=self.loop))

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -3221,10 +3221,8 @@ class SleepTests(test_utils.TestCase):
         self.assertEqual(result, 11)
 
     def test_loop_argument_is_deprecated(self):
-        """
-        this test should be removed in Python 4.0 when the loop argument
-        will be removed
-        """
+        # this test should be removed in Python 4.0 when the loop argument
+        # will be removed
         with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
 
@@ -3241,23 +3239,18 @@ class WaitTests(test_utils.TestCase):
         super().tearDown()
 
     def test_loop_argument_is_deprecated_in_wait(self):
-        """
-        this test should be removed in Python 4.0 when the loop argument
-        will be removed
-        """
+        # this test should be removed in Python 4.0 when the loop argument
+        # will be removed
         with self.assertWarns(DeprecationWarning):
-            self.loop.run_until_complete(asyncio.wait([coroutine_function()],
-                                                      loop=self.loop))
+            self.loop.run_until_complete(
+                asyncio.wait([coroutine_function()], loop=self.loop))
 
     def test_loop_argument_is_deprecated_in_wait_for(self):
-        """
-        this test should be removed in Python 4.0 when the loop argument
-        will be removed
-        """
+        # this test should be removed in Python 4.0 when the loop argument
+        # will be removed
         with self.assertWarns(DeprecationWarning):
-            self.loop.run_until_complete(asyncio.wait_for(coroutine_function(),
-                                                          0.01,
-                                                          loop=self.loop))
+            self.loop.run_until_complete(
+                asyncio.wait_for(coroutine_function(), 0.01, loop=self.loop))
 
 
 class CompatibilityTests(test_utils.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-09-20-16-55-43.bpo-34728.CUE8LU.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-20-16-55-43.bpo-34728.CUE8LU.rst
@@ -1,0 +1,2 @@
+Add warn when deprecate argument `loop` is used in methods: `asyncio.sleep`,
+`asyncio.wait` and `asyncio.wait_for`.

--- a/Misc/NEWS.d/next/Library/2018-09-20-16-55-43.bpo-34728.CUE8LU.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-20-16-55-43.bpo-34728.CUE8LU.rst
@@ -1,2 +1,2 @@
-Add warn when deprecate argument `loop` is used in methods: `asyncio.sleep`,
+Add deprecation warning when `loop` is used in methods: `asyncio.sleep`,
 `asyncio.wait` and `asyncio.wait_for`.


### PR DESCRIPTION
Warn deprecate argument *loop* in `asyncio.sleep`, `asyncio.wait` and  `asyncio.wait_for`. Also change calls for `get_event_loop()` to calls for `get_running_loop()` in these methods.

<!-- issue-number: [bpo-34728](https://www.bugs.python.org/issue34728) -->
https://bugs.python.org/issue34728
<!-- /issue-number -->
