### PR TITLE
[3.7] Revert "[3.7] bpo-34589: Add -X coerce_c_locale option; C locale coercion off by default (GH-9379)"

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -438,19 +438,10 @@ Miscellaneous options
      * Set the :attr:`~sys.flags.dev_mode` attribute of :attr:`sys.flags` to
        ``True``
 
-   * ``-X utf8`` enables UTF-8 mode (:pep:`540`) for operating system interfaces, overriding
+   * ``-X utf8`` enables UTF-8 mode for operating system interfaces, overriding
      the default locale-aware mode. ``-X utf8=0`` explicitly disables UTF-8
      mode (even when it would otherwise activate automatically).
      See :envvar:`PYTHONUTF8` for more details.
-   * ``-X coerce_c_locale`` or ``-X coerce_c_locale=1`` tries to coerce the C
-     locale (:pep:`538`).
-     ``-X coerce_c_locale=0`` skips coercing the legacy ASCII-based C and POSIX
-     locales to a more capable UTF-8 based alternative.
-     ``-X coerce_c_locale=warn`` will cause Python to emit warning messages on
-     ``stderr`` if either the locale coercion activates, or else if a locale
-     that *would* have triggered coercion is still active when the Python
-     runtime is initialized.
-     See :envvar:`PYTHONCOERCECLOCALE` for more details.
 
    It also allows passing arbitrary values and retrieving them through the
    :data:`sys._xoptions` dictionary.
@@ -469,9 +460,6 @@ Miscellaneous options
 
    .. versionadded:: 3.7
       The ``-X importtime``, ``-X dev`` and ``-X utf8`` options.
-
-   .. versionadded:: 3.7.1
-      The ``-X coerce_c_locale`` option.
 
 
 Options you shouldn't use
@@ -845,8 +833,6 @@ conflict.
    default in legacy ASCII-based locales. Both features must be disabled in
    order to force the interpreter to use ``ASCII`` instead of ``UTF-8`` for
    system interfaces.
-
-   Also available as the :option:`-X` ``coerce_c_locale`` option.
 
    Availability: \*nix
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2494,10 +2494,3 @@ versions, it respected an ill-defined subset of those environment variables,
 while in Python 3.7.0 it didn't read any of them due to :issue:`34247`). If
 this behavior is unwanted, set :c:data:`Py_IgnoreEnvironmentFlag` to 1 before
 calling :c:func:`Py_Initialize`.
-
-:c:func:`Py_Initialize` and :c:func:`Py_Main` cannot enable the C locale
-coercion (:pep:`538`) anymore: it is always disabled. It can now only be
-enabled by the Python program ("python3).
-
-New :option:`-X` ``coerce_c_locale`` command line option to control C locale
-coercion (:pep:`538`).

--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -119,11 +119,7 @@ PyAPI_FUNC(int) Py_FdIsInteractive(FILE *, const char *);
 /* Bootstrap __main__ (defined in Modules/main.c) */
 PyAPI_FUNC(int) Py_Main(int argc, wchar_t **argv);
 #ifdef Py_BUILD_CORE
-#  ifdef MS_WINDOWS
-PyAPI_FUNC(int) _Py_WindowsMain(int argc, wchar_t **argv);
-#  else
 PyAPI_FUNC(int) _Py_UnixMain(int argc, char **argv);
-#  endif
 #endif
 
 /* In getpath.c */

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -41,6 +41,8 @@ typedef struct {
     int show_alloc_count;   /* -X showalloccount */
     int dump_refs;          /* PYTHONDUMPREFS */
     int malloc_stats;       /* PYTHONMALLOCSTATS */
+    int coerce_c_locale;    /* PYTHONCOERCECLOCALE, -1 means unknown */
+    int coerce_c_locale_warn; /* PYTHONCOERCECLOCALE=warn */
     int utf8_mode;          /* PYTHONUTF8, -X utf8; -1 means unknown */
 
     wchar_t *program_name;  /* Program name, see also Py_GetProgramName() */
@@ -72,8 +74,6 @@ typedef struct {
 
     /* Private fields */
     int _disable_importlib; /* Needed by freeze_importlib */
-    int _coerce_c_locale;    /* PYTHONCOERCECLOCALE, -1 means unknown */
-    int _coerce_c_locale_warn; /* PYTHONCOERCECLOCALE=warn */
 } _PyCoreConfig;
 
 #define _PyCoreConfig_INIT \
@@ -81,8 +81,7 @@ typedef struct {
         .install_signal_handlers = -1, \
         .ignore_environment = -1, \
         .use_hash_seed = -1, \
-        ._coerce_c_locale = 0, \
-        ._coerce_c_locale_warn = 0, \
+        .coerce_c_locale = -1, \
         .faulthandler = -1, \
         .tracemalloc = -1, \
         .utf8_mode = -1, \

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -159,16 +159,13 @@ class CmdLineTest(unittest.TestCase):
         env = os.environ.copy()
         # Use C locale to get ascii for the locale encoding
         env['LC_ALL'] = 'C'
+        env['PYTHONCOERCECLOCALE'] = '0'
         code = (
             b'import locale; '
             b'print(ascii("' + undecodable + b'"), '
                 b'locale.getpreferredencoding())')
         p = subprocess.Popen(
-            [sys.executable,
-             # Disable C locale coercion and UTF-8 Mode to not use UTF-8
-             "-X", "coerce_c_locale=0",
-             "-X", "utf8=0",
-             "-c", code],
+            [sys.executable, "-c", code],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             env=env)
         stdout, stderr = p.communicate()

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -267,6 +267,9 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'malloc_stats': 0,
         'utf8_mode': 0,
 
+        'coerce_c_locale': 0,
+        'coerce_c_locale_warn': 0,
+
         'program_name': './_testembed',
         'argc': 0,
         'argv': '[]',
@@ -287,8 +290,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
 
         '_disable_importlib': 0,
         'Py_FrozenFlag': 0,
-        '_coerce_c_locale': 0,
-        '_coerce_c_locale_warn': 0,
     }
 
     def check_config(self, testname, expected):

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -656,8 +656,9 @@ class SysModuleTest(unittest.TestCase):
 
     def c_locale_get_error_handler(self, locale, isolated=False, encoding=None):
         # Force the POSIX locale
-        env = dict(os.environ)
+        env = os.environ.copy()
         env["LC_ALL"] = locale
+        env["PYTHONCOERCECLOCALE"] = "0"
         code = '\n'.join((
             'import sys',
             'def dump(name):',
@@ -667,10 +668,7 @@ class SysModuleTest(unittest.TestCase):
             'dump("stdout")',
             'dump("stderr")',
         ))
-        args = [sys.executable,
-                "-X", "utf8=0",
-                "-X", "coerce_c_locale=0",
-                "-c", code]
+        args = [sys.executable, "-c", code]
         if isolated:
             args.append("-I")
         if encoding is not None:

--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -27,8 +27,6 @@ class UTF8ModeTests(unittest.TestCase):
         return (loc in POSIX_LOCALES)
 
     def get_output(self, *args, failure=False, **kw):
-        # Always disable the C locale coercion (PEP 538)
-        args = ('-X', 'coerce_c_locale=0', *args)
         kw = dict(self.DEFAULT_ENV, **kw)
         if failure:
             out = assert_python_failure(*args, **kw)
@@ -118,6 +116,7 @@ class UTF8ModeTests(unittest.TestCase):
             # PYTHONLEGACYWINDOWSFSENCODING disables the UTF-8 mode
             # and has the priority over -X utf8 and PYTHONUTF8
             out = self.get_output('-X', 'utf8', '-c', code,
+                                  PYTHONUTF8='strict',
                                   PYTHONLEGACYWINDOWSFSENCODING='1')
             self.assertEqual(out, 'mbcs/replace')
 

--- a/Misc/NEWS.d/next/C API/2018-09-18-00-09-31.bpo-34589.C7bUpq.rst
+++ b/Misc/NEWS.d/next/C API/2018-09-18-00-09-31.bpo-34589.C7bUpq.rst
@@ -1,3 +1,0 @@
-Py_Initialize() and Py_Main() cannot enable the C locale coercion (PEP 538)
-anymore: it is always disabled. It can now only be enabled by the Python
-program ("python3).

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-18-01-41-33.bpo-34589.lLVTYc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-18-01-41-33.bpo-34589.lLVTYc.rst
@@ -1,2 +1,0 @@
-Add a new :option:`-X` ``coerce_c_locale`` command line option to control C
-locale coercion (:pep:`538`).

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1834,17 +1834,6 @@ config_init_utf8_mode(_PyCoreConfig *config)
         return _Py_INIT_OK();
     }
 
-#ifndef MS_WINDOWS
-    /* The C locale and the POSIX locale enable the UTF-8 Mode (PEP 540) */
-    const char *ctype_loc = setlocale(LC_CTYPE, NULL);
-    if (ctype_loc != NULL
-        && (strcmp(ctype_loc, "C") == 0 || strcmp(ctype_loc, "POSIX") == 0))
-    {
-        config->utf8_mode = 1;
-        return _Py_INIT_OK();
-    }
-#endif
-
     return _Py_INIT_OK();
 }
 
@@ -1868,18 +1857,16 @@ config_read_env_vars(_PyCoreConfig *config)
     const char *env = config_get_env_var("PYTHONCOERCECLOCALE");
     if (env) {
         if (strcmp(env, "0") == 0) {
-            if (config->_coerce_c_locale < 0) {
-                config->_coerce_c_locale = 0;
+            if (config->coerce_c_locale < 0) {
+                config->coerce_c_locale = 0;
             }
         }
         else if (strcmp(env, "warn") == 0) {
-            if (config->_coerce_c_locale_warn < 0) {
-                config->_coerce_c_locale_warn = 1;
-            }
+            config->coerce_c_locale_warn = 1;
         }
         else {
-            if (config->_coerce_c_locale < 0) {
-                config->_coerce_c_locale = 1;
+            if (config->coerce_c_locale < 0) {
+                config->coerce_c_locale = 1;
             }
         }
     }
@@ -2059,7 +2046,7 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
          * See the documentation of the PYTHONCOERCECLOCALE setting for more
          * details.
          */
-        if (config->_coerce_c_locale && !locale_coerced) {
+        if (config->coerce_c_locale && !locale_coerced) {
             locale_coerced = 1;
             _Py_CoerceLegacyLocale(config);
             encoding_changed = 1;
@@ -2086,7 +2073,7 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
            pymain_read_conf_impl(). Reset Py_IsolatedFlag and Py_NoSiteFlag
            modified by _PyCoreConfig_Read(). */
         int new_utf8_mode = config->utf8_mode;
-        int new_coerce_c_locale = config->_coerce_c_locale;
+        int new_coerce_c_locale = config->coerce_c_locale;
         Py_IgnoreEnvironmentFlag = init_ignore_env;
         if (_PyCoreConfig_Copy(config, &save_config) < 0) {
             pymain->err = _Py_INIT_NO_MEMORY();
@@ -2098,7 +2085,7 @@ pymain_read_conf(_PyMain *pymain, _Py_CommandLineDetails *cmdline)
         cmdline_get_global_config(cmdline);
         _PyCoreConfig_GetGlobalConfig(config);
         config->utf8_mode = new_utf8_mode;
-        config->_coerce_c_locale = new_coerce_c_locale;
+        config->coerce_c_locale = new_coerce_c_locale;
 
         /* The encoding changed: read again the configuration
            with the new encoding */
@@ -2116,76 +2103,28 @@ done:
 }
 
 
-static _PyInitError
-config_init_coerce_c_locale(_PyCoreConfig *config)
+static void
+config_init_locale(_PyCoreConfig *config)
 {
-    const wchar_t *xopt = config_get_xoption(config, L"coerce_c_locale");
-    if (xopt) {
-        wchar_t *sep = wcschr(xopt, L'=');
-        if (sep) {
-            xopt = sep + 1;
-            if (wcscmp(xopt, L"1") == 0) {
-                if (config->_coerce_c_locale < 0) {
-                    config->_coerce_c_locale = 1;
-                }
-            }
-            else if (wcscmp(xopt, L"0") == 0) {
-                if (config->_coerce_c_locale < 0) {
-                    config->_coerce_c_locale = 0;
-                }
-            }
-            else if (wcscmp(xopt, L"warn") == 0) {
-                if (config->_coerce_c_locale_warn < 0) {
-                    config->_coerce_c_locale_warn = 1;
-                }
-            }
-            else {
-                return _Py_INIT_USER_ERR("invalid -X coerce_c_locale option value");
-            }
-        }
-        else {
-            if (config->_coerce_c_locale < 0) {
-                config->_coerce_c_locale = 1;
-            }
-        }
-
-        if (config->_coerce_c_locale_warn < 0) {
-            config->_coerce_c_locale_warn = 0;
-        }
-    }
-
-    const char *env = config_get_env_var("PYTHONCOERCECLOCALE");
-    if (env) {
-        if (strcmp(env, "0") == 0) {
-            if (config->_coerce_c_locale < 0) {
-                config->_coerce_c_locale = 0;
-            }
-        }
-        else if (strcmp(env, "warn") == 0) {
-            if (config->_coerce_c_locale_warn < 0) {
-                config->_coerce_c_locale_warn = 1;
-            }
-        }
-        else {
-            if (config->_coerce_c_locale < 0) {
-                config->_coerce_c_locale = 1;
-            }
-        }
-
-        if (config->_coerce_c_locale_warn < 0) {
-            config->_coerce_c_locale_warn = 0;
-        }
-    }
-
-    if (config->_coerce_c_locale < 0) {
+    if (config->coerce_c_locale < 0) {
         /* The C locale enables the C locale coercion (PEP 538) */
         if (_Py_LegacyLocaleDetected()) {
-            config->_coerce_c_locale = 1;
-            return _Py_INIT_OK();
+            config->coerce_c_locale = 1;
         }
     }
 
-    return _Py_INIT_OK();
+#ifndef MS_WINDOWS
+    if (config->utf8_mode < 0) {
+        /* The C locale and the POSIX locale enable the UTF-8 Mode (PEP 540) */
+        const char *ctype_loc = setlocale(LC_CTYPE, NULL);
+        if (ctype_loc != NULL
+           && (strcmp(ctype_loc, "C") == 0
+               || strcmp(ctype_loc, "POSIX") == 0))
+        {
+            config->utf8_mode = 1;
+        }
+    }
+#endif
 }
 
 
@@ -2345,11 +2284,8 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         }
     }
 
-    if (config->_coerce_c_locale < 0 || config->_coerce_c_locale_warn < 0) {
-        err = config_init_coerce_c_locale(config);
-        if (_Py_INIT_FAILED(err)) {
-            return err;
-        }
+    if (config->utf8_mode < 0 || config->coerce_c_locale < 0) {
+        config_init_locale(config);
     }
 
     if (!config->_disable_importlib) {
@@ -2381,11 +2317,8 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
     if (config->tracemalloc < 0) {
         config->tracemalloc = 0;
     }
-    if (config->_coerce_c_locale < 0) {
-        config->_coerce_c_locale = 0;
-    }
-    if (config->_coerce_c_locale_warn < 0) {
-        config->_coerce_c_locale_warn = 0;
+    if (config->coerce_c_locale < 0) {
+        config->coerce_c_locale = 0;
     }
     if (config->utf8_mode < 0) {
         config->utf8_mode = 0;
@@ -2393,10 +2326,6 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
     if (config->argc < 0) {
         config->argc = 0;
     }
-
-    assert(config->_coerce_c_locale >= 0);
-    assert(config->_coerce_c_locale_warn >= 0);
-    assert(config->ignore_environment >= 0);
 
     return _Py_INIT_OK();
 }
@@ -2481,8 +2410,8 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
     COPY_ATTR(dump_refs);
     COPY_ATTR(malloc_stats);
 
-    COPY_ATTR(_coerce_c_locale);
-    COPY_ATTR(_coerce_c_locale_warn);
+    COPY_ATTR(coerce_c_locale);
+    COPY_ATTR(coerce_c_locale_warn);
     COPY_ATTR(utf8_mode);
 
     COPY_STR_ATTR(module_search_path_env);
@@ -2709,7 +2638,7 @@ pymain_run_python(_PyMain *pymain)
 
 
 static void
-pymain_init(_PyMain *pymain, int use_c_locale_coercion)
+pymain_init(_PyMain *pymain)
 {
     /* 754 requires that FP exceptions run in "no stop" mode by default,
      * and until C vendors implement C99's ways to control FP exceptions,
@@ -2722,11 +2651,6 @@ pymain_init(_PyMain *pymain, int use_c_locale_coercion)
 
     pymain->config._disable_importlib = 0;
     pymain->config.install_signal_handlers = 1;
-    if (use_c_locale_coercion) {
-        /* set to -1 to be able to enable the feature */
-        pymain->config._coerce_c_locale = -1;
-        pymain->config._coerce_c_locale_warn = -1;
-    }
 }
 
 
@@ -2827,9 +2751,9 @@ pymain_cmdline(_PyMain *pymain)
 
 
 static int
-pymain_main(_PyMain *pymain, int use_c_locale_coercion)
+pymain_main(_PyMain *pymain)
 {
-    pymain_init(pymain, use_c_locale_coercion);
+    pymain_init(pymain);
 
     int res = pymain_cmdline(pymain);
     if (res < 0) {
@@ -2878,22 +2802,10 @@ Py_Main(int argc, wchar_t **argv)
     pymain.argc = argc;
     pymain.wchar_argv = argv;
 
-    return pymain_main(&pymain, 0);
+    return pymain_main(&pymain);
 }
 
 
-#ifdef MS_WINDOWS
-int
-_Py_WindowsMain(int argc, wchar_t **argv)
-{
-    _PyMain pymain = _PyMain_INIT;
-    pymain.use_bytes_argv = 0;
-    pymain.argc = argc;
-    pymain.wchar_argv = argv;
-
-    return pymain_main(&pymain, 1);
-}
-#else
 int
 _Py_UnixMain(int argc, char **argv)
 {
@@ -2902,9 +2814,8 @@ _Py_UnixMain(int argc, char **argv)
     pymain.argc = argc;
     pymain.bytes_argv = argv;
 
-    return pymain_main(&pymain, 1);
+    return pymain_main(&pymain);
 }
-#endif
 
 
 /* this is gonna seem *real weird*, but if you put some other code between

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -328,8 +328,8 @@ dump_config(void)
     printf("dump_refs = %i\n", config->dump_refs);
     printf("malloc_stats = %i\n", config->malloc_stats);
 
-    printf("_coerce_c_locale = %i\n", config->_coerce_c_locale);
-    printf("_coerce_c_locale_warn = %i\n", config->_coerce_c_locale_warn);
+    printf("coerce_c_locale = %i\n", config->coerce_c_locale);
+    printf("coerce_c_locale_warn = %i\n", config->coerce_c_locale_warn);
     printf("utf8_mode = %i\n", config->utf8_mode);
 
     printf("program_name = %ls\n", config->program_name);
@@ -473,6 +473,8 @@ static int test_init_from_config(void)
     putenv("PYTHONMALLOCSTATS=0");
     config.malloc_stats = 1;
 
+    /* FIXME: test coerce_c_locale and coerce_c_locale_warn */
+
     putenv("PYTHONUTF8=0");
     Py_UTF8Mode = 0;
     config.utf8_mode = 1;
@@ -542,7 +544,8 @@ static int test_init_isolated(void)
     /* Test _PyCoreConfig.isolated=1 */
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    /* Set utf8_mode to not depend on the locale */
+    /* Set coerce_c_locale and utf8_mode to not depend on the locale */
+    config.coerce_c_locale = 0;
     config.utf8_mode = 0;
     /* Use path starting with "./" avoids a search along the PATH */
     config.program_name = L"./_testembed";

--- a/Programs/python.c
+++ b/Programs/python.c
@@ -6,7 +6,7 @@
 int
 wmain(int argc, wchar_t **argv)
 {
-    return _Py_WindowsMain(argc, argv);
+    return Py_Main(argc, argv);
 }
 #else
 int

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -400,7 +400,7 @@ static const char *_C_LOCALE_WARNING =
 static void
 _emit_stderr_warning_for_legacy_locale(const _PyCoreConfig *core_config)
 {
-    if (core_config->_coerce_c_locale_warn) {
+    if (core_config->coerce_c_locale_warn) {
         if (_Py_LegacyLocaleDetected()) {
             fprintf(stderr, "%s", _C_LOCALE_WARNING);
         }
@@ -462,7 +462,7 @@ _coerce_default_locale_settings(const _PyCoreConfig *config, const _LocaleCoerci
                 "Error setting LC_CTYPE, skipping C locale coercion\n");
         return;
     }
-    if (config->_coerce_c_locale_warn) {
+    if (config->coerce_c_locale_warn) {
         fprintf(stderr, C_LOCALE_COERCION_WARNING, newloc);
     }
 


### PR DESCRIPTION
This reverts commit 144f1e2c6f4a24bd288c045986842c65cc289684.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34589](https://www.bugs.python.org/issue34589) -->
https://bugs.python.org/issue34589
<!-- /issue-number -->
