### PR TITLE
bpo-34735: Fix a memory leak in Modules/timemodule.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-19-06-57-34.bpo-34735.-3mrSJ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-19-06-57-34.bpo-34735.-3mrSJ.rst
@@ -1,0 +1,1 @@
+Fix a memory leak in Modules/timemodule.c.  Patch by Zackery Spytz.

--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -801,6 +801,7 @@ time_strftime(PyObject *self, PyObject *args)
         if (outbuf[1] == L'y' && buf.tm_year < 0) {
             PyErr_SetString(PyExc_ValueError,
                             "format %y requires year >= 1900 on AIX");
+            PyMem_Free(format);
             return NULL;
         }
     }


### PR DESCRIPTION
The format string was not being freed when `ValueError` was raised for `%y` on certain platforms.