### PR TITLE
bpo-34744 Lib/argparse.py %(flag)s format specifier for argparse.add_argument help string

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -599,6 +599,8 @@ class HelpFormatter(object):
 
     def _expand_help(self, action):
         params = dict(vars(action), prog=self._prog)
+        if action.option_strings:
+            params['flag'] = action.option_strings[0]
         for name in list(params):
             if params[name] is SUPPRESS:
                 del params[name]


### PR DESCRIPTION
[bpo-34744](https://www.bugs.python.org/issue34744): Add %(flag)s format specifier for argparse.add_argument help string

<!-- issue-number: [bpo-34744](https://www.bugs.python.org/issue34744) -->
https://bugs.python.org/issue34744
<!-- /issue-number -->
