### PR TITLE
Revert "bpo-34589: Add -X coerce_c_locale command line option (GH-9378)"

### DIFF
--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -438,22 +438,13 @@ Miscellaneous options
      * Set the :attr:`~sys.flags.dev_mode` attribute of :attr:`sys.flags` to
        ``True``
 
-   * ``-X utf8`` enables UTF-8 mode (:pep:`540`) for operating system interfaces, overriding
+   * ``-X utf8`` enables UTF-8 mode for operating system interfaces, overriding
      the default locale-aware mode. ``-X utf8=0`` explicitly disables UTF-8
      mode (even when it would otherwise activate automatically).
      See :envvar:`PYTHONUTF8` for more details.
    * ``-X pycache_prefix=PATH`` enables writing ``.pyc`` files to a parallel
      tree rooted at the given directory instead of to the code tree. See also
      :envvar:`PYTHONPYCACHEPREFIX`.
-   * ``-X coerce_c_locale`` or ``-X coerce_c_locale=1`` tries to coerce the C
-     locale (:pep:`538`).
-     ``-X coerce_c_locale=0`` skips coercing the legacy ASCII-based C and POSIX
-     locales to a more capable UTF-8 based alternative.
-     ``-X coerce_c_locale=warn`` will cause Python to emit warning messages on
-     ``stderr`` if either the locale coercion activates, or else if a locale
-     that *would* have triggered coercion is still active when the Python
-     runtime is initialized.
-     See :envvar:`PYTHONCOERCECLOCALE` for more details.
 
    It also allows passing arbitrary values and retrieving them through the
    :data:`sys._xoptions` dictionary.
@@ -472,9 +463,6 @@ Miscellaneous options
 
    .. versionadded:: 3.7
       The ``-X importtime``, ``-X dev`` and ``-X utf8`` options.
-
-   .. versionadded:: 3.7.1
-      The ``-X coerce_c_locale`` option.
 
    .. versionadded:: 3.8
       The ``-X pycache_prefix`` option.
@@ -861,8 +849,6 @@ conflict.
    default in legacy ASCII-based locales. Both features must be disabled in
    order to force the interpreter to use ``ASCII`` instead of ``UTF-8`` for
    system interfaces.
-
-   Also available as the :option:`-X` ``coerce_c_locale`` option.
 
    Availability: \*nix
 

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2494,10 +2494,3 @@ versions, it respected an ill-defined subset of those environment variables,
 while in Python 3.7.0 it didn't read any of them due to :issue:`34247`). If
 this behavior is unwanted, set :c:data:`Py_IgnoreEnvironmentFlag` to 1 before
 calling :c:func:`Py_Initialize`.
-
-:c:func:`Py_Initialize` and :c:func:`Py_Main` cannot enable the C locale
-coercion (:pep:`538`) anymore: it is always disabled. It can now only be
-enabled by the Python program ("python3).
-
-New :option:`-X` ``coerce_c_locale`` command line option to control C locale
-coercion (:pep:`538`).

--- a/Include/coreconfig.h
+++ b/Include/coreconfig.h
@@ -63,6 +63,8 @@ typedef struct {
     int show_alloc_count;   /* -X showalloccount */
     int dump_refs;          /* PYTHONDUMPREFS */
     int malloc_stats;       /* PYTHONMALLOCSTATS */
+    int coerce_c_locale;    /* PYTHONCOERCECLOCALE, -1 means unknown */
+    int coerce_c_locale_warn; /* PYTHONCOERCECLOCALE=warn */
 
     /* Python filesystem encoding and error handler:
        sys.getfilesystemencoding() and sys.getfilesystemencodeerrors().
@@ -295,22 +297,6 @@ typedef struct {
        If set to -1 (default), inherit Py_FrozenFlag value. */
     int _frozen;
 
-    /* C locale coercion (PEP 538).
-
-       The option is enabled by the PYTHONCOERCECLOCALE environment
-       variable. The option is also enabled if the LC_CTYPE locale is "C"
-       and a target locale (ex: "C.UTF-8") is supported by the platform.
-
-       See also the _coerce_c_locale_warn option. */
-    int _coerce_c_locale;
-
-    /* C locale coercion warning (PEP 538).
-
-       Enabled by the PYTHONCOERCECLOCALE=warn environment variable.
-
-       See also the _coerce_c_locale option. */
-    int _coerce_c_locale_warn;
-
 } _PyCoreConfig;
 
 #ifdef MS_WINDOWS
@@ -328,7 +314,7 @@ typedef struct {
         .use_hash_seed = -1, \
         .faulthandler = -1, \
         .tracemalloc = -1, \
-        ._coerce_c_locale = -1, \
+        .coerce_c_locale = -1, \
         .utf8_mode = -1, \
         .argc = -1, \
         .nmodule_search_path = -1, \

--- a/Include/coreconfig.h
+++ b/Include/coreconfig.h
@@ -301,20 +301,12 @@ typedef struct {
        variable. The option is also enabled if the LC_CTYPE locale is "C"
        and a target locale (ex: "C.UTF-8") is supported by the platform.
 
-       Py_Initialize() and Py_Main() must not enable C locale coercion: it is
-       always disabled. The option can only be enabled by the Python program
-       ("python3).
-
        See also the _coerce_c_locale_warn option. */
     int _coerce_c_locale;
 
     /* C locale coercion warning (PEP 538).
 
        Enabled by the PYTHONCOERCECLOCALE=warn environment variable.
-
-       Py_Initialize() and Py_Main() must not enable C locale coercion warning:
-       it is always disabled. The warning can only be enabled by the Python
-       program ("python3).
 
        See also the _coerce_c_locale option. */
     int _coerce_c_locale_warn;
@@ -336,8 +328,7 @@ typedef struct {
         .use_hash_seed = -1, \
         .faulthandler = -1, \
         .tracemalloc = -1, \
-        ._coerce_c_locale = 0, \
-        ._coerce_c_locale_warn = 0, \
+        ._coerce_c_locale = -1, \
         .utf8_mode = -1, \
         .argc = -1, \
         .nmodule_search_path = -1, \

--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -83,11 +83,7 @@ PyAPI_FUNC(int) Py_FdIsInteractive(FILE *, const char *);
 /* Bootstrap __main__ (defined in Modules/main.c) */
 PyAPI_FUNC(int) Py_Main(int argc, wchar_t **argv);
 #ifdef Py_BUILD_CORE
-#  ifdef MS_WINDOWS
-PyAPI_FUNC(int) _Py_WindowsMain(int argc, wchar_t **argv);
-#  else
 PyAPI_FUNC(int) _Py_UnixMain(int argc, char **argv);
-#  endif
 #endif
 
 /* In getpath.c */

--- a/Lib/test/test_cmd_line.py
+++ b/Lib/test/test_cmd_line.py
@@ -159,16 +159,13 @@ class CmdLineTest(unittest.TestCase):
         env = os.environ.copy()
         # Use C locale to get ascii for the locale encoding
         env['LC_ALL'] = 'C'
+        env['PYTHONCOERCECLOCALE'] = '0'
         code = (
             b'import locale; '
             b'print(ascii("' + undecodable + b'"), '
                 b'locale.getpreferredencoding())')
         p = subprocess.Popen(
-            [sys.executable,
-             # Disable C locale coercion and UTF-8 Mode to not use UTF-8
-             "-X", "coerce_c_locale=0",
-             "-X", "utf8=0",
-             "-c", code],
+            [sys.executable, "-c", code],
             stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
             env=env)
         stdout, stderr = p.communicate()

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -277,6 +277,8 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'filesystem_errors': None,
 
         'utf8_mode': 0,
+        'coerce_c_locale': 0,
+        'coerce_c_locale_warn': 0,
 
         'pycache_prefix': NULL_STR,
         'program_name': './_testembed',
@@ -304,8 +306,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         '_install_importlib': 1,
         '_check_hash_pycs_mode': 'default',
         '_frozen': 0,
-        '_coerce_c_locale': 0,
-        '_coerce_c_locale_warn': 0,
     }
 
     def get_stdio_encoding(self, env):

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -324,6 +324,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 'print(sys.getfilesystemencoding(), '
                 'sys.getfilesystemencodeerrors())')
         args = (sys.executable, '-c', code)
+        env = dict(env)
+        if not isolated:
+            env['PYTHONCOERCECLOCALE'] = '0'
+            env['PYTHONUTF8'] = '0'
         proc = subprocess.run(args, text=True, env=env,
                               stdout=subprocess.PIPE,
                               stderr=subprocess.PIPE)

--- a/Lib/test/test_sys.py
+++ b/Lib/test/test_sys.py
@@ -656,8 +656,9 @@ class SysModuleTest(unittest.TestCase):
 
     def c_locale_get_error_handler(self, locale, isolated=False, encoding=None):
         # Force the POSIX locale
-        env = dict(os.environ)
+        env = os.environ.copy()
         env["LC_ALL"] = locale
+        env["PYTHONCOERCECLOCALE"] = "0"
         code = '\n'.join((
             'import sys',
             'def dump(name):',
@@ -667,10 +668,7 @@ class SysModuleTest(unittest.TestCase):
             'dump("stdout")',
             'dump("stderr")',
         ))
-        args = [sys.executable,
-                "-X", "utf8=0",
-                "-X", "coerce_c_locale=0",
-                "-c", code]
+        args = [sys.executable, "-X", "utf8=0", "-c", code]
         if isolated:
             args.append("-I")
         if encoding is not None:

--- a/Lib/test/test_utf8_mode.py
+++ b/Lib/test/test_utf8_mode.py
@@ -27,8 +27,6 @@ class UTF8ModeTests(unittest.TestCase):
         return (loc in POSIX_LOCALES)
 
     def get_output(self, *args, failure=False, **kw):
-        # Always disable the C locale coercion (PEP 538)
-        args = ('-X', 'coerce_c_locale=0', *args)
         kw = dict(self.DEFAULT_ENV, **kw)
         if failure:
             out = assert_python_failure(*args, **kw)
@@ -118,6 +116,7 @@ class UTF8ModeTests(unittest.TestCase):
             # PYTHONLEGACYWINDOWSFSENCODING disables the UTF-8 mode
             # and has the priority over -X utf8 and PYTHONUTF8
             out = self.get_output('-X', 'utf8', '-c', code,
+                                  PYTHONUTF8='strict',
                                   PYTHONLEGACYWINDOWSFSENCODING='1')
             self.assertEqual(out, 'mbcs/replace')
 

--- a/Misc/NEWS.d/next/C API/2018-09-18-00-09-31.bpo-34589.C7bUpq.rst
+++ b/Misc/NEWS.d/next/C API/2018-09-18-00-09-31.bpo-34589.C7bUpq.rst
@@ -1,3 +1,0 @@
-Py_Initialize() and Py_Main() cannot enable the C locale coercion (PEP 538)
-anymore: it is always disabled. It can now only be enabled by the Python
-program ("python3).

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-18-01-41-33.bpo-34589.lLVTYc.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-18-01-41-33.bpo-34589.lLVTYc.rst
@@ -1,2 +1,0 @@
-Add a new :option:`-X` ``coerce_c_locale`` command line option to control C
-locale coercion (:pep:`538`).

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4701,6 +4701,10 @@ get_coreconfig(PyObject *self, PyObject *Py_UNUSED(args))
              PyLong_FromLong(config->dump_refs));
     SET_ITEM("malloc_stats",
              PyLong_FromLong(config->malloc_stats));
+    SET_ITEM("coerce_c_locale",
+             PyLong_FromLong(config->coerce_c_locale));
+    SET_ITEM("coerce_c_locale_warn",
+             PyLong_FromLong(config->coerce_c_locale_warn));
     SET_ITEM("filesystem_encoding",
              FROM_STRING(config->filesystem_encoding));
     SET_ITEM("filesystem_errors",
@@ -4779,10 +4783,6 @@ get_coreconfig(PyObject *self, PyObject *Py_UNUSED(args))
              FROM_STRING(config->_check_hash_pycs_mode));
     SET_ITEM("_frozen",
              PyLong_FromLong(config->_frozen));
-    SET_ITEM("_coerce_c_locale",
-             PyLong_FromLong(config->_coerce_c_locale));
-    SET_ITEM("_coerce_c_locale_warn",
-             PyLong_FromLong(config->_coerce_c_locale_warn));
 
     return dict;
 

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1342,9 +1342,9 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
          * See the documentation of the PYTHONCOERCECLOCALE setting for more
          * details.
          */
-        if (config->_coerce_c_locale && !locale_coerced) {
+        if (config->coerce_c_locale && !locale_coerced) {
             locale_coerced = 1;
-            _Py_CoerceLegacyLocale(config->_coerce_c_locale_warn);
+            _Py_CoerceLegacyLocale(config->coerce_c_locale_warn);
             encoding_changed = 1;
         }
 
@@ -1367,7 +1367,7 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
         /* Reset the configuration before reading again the configuration,
            just keep UTF-8 Mode value. */
         int new_utf8_mode = config->utf8_mode;
-        int new_coerce_c_locale = config->_coerce_c_locale;
+        int new_coerce_c_locale = config->coerce_c_locale;
         if (_PyCoreConfig_Copy(config, &save_config) < 0) {
             pymain->err = _Py_INIT_NO_MEMORY();
             goto done;
@@ -1375,7 +1375,7 @@ pymain_read_conf(_PyMain *pymain, _PyCoreConfig *config,
         pymain_clear_cmdline(pymain, cmdline);
         memset(cmdline, 0, sizeof(*cmdline));
         config->utf8_mode = new_utf8_mode;
-        config->_coerce_c_locale = new_coerce_c_locale;
+        config->coerce_c_locale = new_coerce_c_locale;
 
         /* The encoding changed: read again the configuration
            with the new encoding */

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1700,8 +1700,7 @@ pymain_cmdline(_PyMain *pymain, _PyCoreConfig *config)
 
 
 static int
-pymain_init(_PyMain *pymain, PyInterpreterState **interp_p,
-            int use_c_locale_coercion)
+pymain_init(_PyMain *pymain, PyInterpreterState **interp_p)
 {
     /* 754 requires that FP exceptions run in "no stop" mode by default,
      * and until C vendors implement C99's ways to control FP exceptions,
@@ -1714,11 +1713,6 @@ pymain_init(_PyMain *pymain, PyInterpreterState **interp_p,
 
     _PyCoreConfig local_config = _PyCoreConfig_INIT;
     _PyCoreConfig *config = &local_config;
-    if (use_c_locale_coercion) {
-        /* set to -1 to be able to enable the feature */
-        config->_coerce_c_locale = -1;
-        config->_coerce_c_locale_warn = -1;
-    }
 
     _PyCoreConfig_GetGlobalConfig(config);
 
@@ -1753,10 +1747,10 @@ pymain_init(_PyMain *pymain, PyInterpreterState **interp_p,
 
 
 static int
-pymain_main(_PyMain *pymain, int use_c_locale_coercion)
+pymain_main(_PyMain *pymain)
 {
     PyInterpreterState *interp;
-    int res = pymain_init(pymain, &interp, use_c_locale_coercion);
+    int res = pymain_init(pymain, &interp);
     if (res != 1) {
         if (pymain_run_python(pymain, interp) < 0) {
             _Py_FatalInitError(pymain->err);
@@ -1783,22 +1777,10 @@ Py_Main(int argc, wchar_t **argv)
     pymain.argc = argc;
     pymain.wchar_argv = argv;
 
-    return pymain_main(&pymain, 0);
+    return pymain_main(&pymain);
 }
 
 
-#ifdef MS_WINDOWS
-int
-_Py_WindowsMain(int argc, wchar_t **argv)
-{
-    _PyMain pymain = _PyMain_INIT;
-    pymain.use_bytes_argv = 0;
-    pymain.argc = argc;
-    pymain.wchar_argv = argv;
-
-    return pymain_main(&pymain, 1);
-}
-#else
 int
 _Py_UnixMain(int argc, char **argv)
 {
@@ -1807,9 +1789,8 @@ _Py_UnixMain(int argc, char **argv)
     pymain.argc = argc;
     pymain.bytes_argv = argv;
 
-    return pymain_main(&pymain, 1);
+    return pymain_main(&pymain);
 }
-#endif
 
 
 /* this is gonna seem *real weird*, but if you put some other code between

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -482,6 +482,8 @@ static int test_init_from_config(void)
     putenv("PYTHONMALLOCSTATS=0");
     config.malloc_stats = 1;
 
+    /* FIXME: test _coerce_c_locale and _coerce_c_locale_warn */
+
     putenv("PYTHONUTF8=0");
     Py_UTF8Mode = 0;
     config.utf8_mode = 1;
@@ -604,7 +606,8 @@ static int test_init_isolated(void)
     /* Test _PyCoreConfig.isolated=1 */
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    /* Set utf8_mode to not depend on the locale */
+    /* Set _coerce_c_locale and utf8_mode to not depend on the locale */
+    config._coerce_c_locale = 0;
     config.utf8_mode = 0;
     /* Use path starting with "./" avoids a search along the PATH */
     config.program_name = L"./_testembed";

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -330,6 +330,8 @@ dump_config(void)
 
     printf("filesystem_encoding = %s\n", config->filesystem_encoding);
     printf("filesystem_errors = %s\n", config->filesystem_errors);
+    printf("coerce_c_locale = %i\n", config->coerce_c_locale);
+    printf("coerce_c_locale_warn = %i\n", config->coerce_c_locale_warn);
     printf("utf8_mode = %i\n", config->utf8_mode);
 
     printf("pycache_prefix = %ls\n", config->pycache_prefix);
@@ -383,8 +385,6 @@ dump_config(void)
     printf("_install_importlib = %i\n", config->_install_importlib);
     printf("_check_hash_pycs_mode = %s\n", config->_check_hash_pycs_mode);
     printf("_frozen = %i\n", config->_frozen);
-    printf("_coerce_c_locale = %i\n", config->_coerce_c_locale);
-    printf("_coerce_c_locale_warn = %i\n", config->_coerce_c_locale_warn);
 
 #undef ASSERT_EQUAL
 #undef ASSERT_STR_EQUAL
@@ -482,7 +482,7 @@ static int test_init_from_config(void)
     putenv("PYTHONMALLOCSTATS=0");
     config.malloc_stats = 1;
 
-    /* FIXME: test _coerce_c_locale and _coerce_c_locale_warn */
+    /* FIXME: test coerce_c_locale and coerce_c_locale_warn */
 
     putenv("PYTHONUTF8=0");
     Py_UTF8Mode = 0;
@@ -606,8 +606,8 @@ static int test_init_isolated(void)
     /* Test _PyCoreConfig.isolated=1 */
     _PyCoreConfig config = _PyCoreConfig_INIT;
 
-    /* Set _coerce_c_locale and utf8_mode to not depend on the locale */
-    config._coerce_c_locale = 0;
+    /* Set coerce_c_locale and utf8_mode to not depend on the locale */
+    config.coerce_c_locale = 0;
     config.utf8_mode = 0;
     /* Use path starting with "./" avoids a search along the PATH */
     config.program_name = L"./_testembed";

--- a/Programs/python.c
+++ b/Programs/python.c
@@ -6,7 +6,7 @@
 int
 wmain(int argc, wchar_t **argv)
 {
-    return _Py_WindowsMain(argc, argv);
+    return Py_Main(argc, argv);
 }
 #else
 int

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -816,9 +816,7 @@ config_read_env_vars(_PyCoreConfig *config)
             }
         }
         else if (strcmp(env, "warn") == 0) {
-            if (config->_coerce_c_locale_warn < 0) {
-                config->_coerce_c_locale_warn = 1;
-            }
+            config->_coerce_c_locale_warn = 1;
         }
         else {
             if (config->_coerce_c_locale < 0) {
@@ -1325,9 +1323,6 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
     }
     if (config->_coerce_c_locale < 0) {
         config->_coerce_c_locale = 0;
-    }
-    if (config->_coerce_c_locale_warn < 0) {
-        config->_coerce_c_locale_warn = 0;
     }
     if (config->utf8_mode < 0) {
         config->utf8_mode = 0;

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -303,8 +303,8 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
     COPY_ATTR(dump_refs);
     COPY_ATTR(malloc_stats);
 
-    COPY_ATTR(_coerce_c_locale);
-    COPY_ATTR(_coerce_c_locale_warn);
+    COPY_ATTR(coerce_c_locale);
+    COPY_ATTR(coerce_c_locale_warn);
     COPY_ATTR(utf8_mode);
 
     COPY_WSTR_ATTR(pycache_prefix);
@@ -811,16 +811,16 @@ config_read_env_vars(_PyCoreConfig *config)
     const char *env = _PyCoreConfig_GetEnv(config, "PYTHONCOERCECLOCALE");
     if (env) {
         if (strcmp(env, "0") == 0) {
-            if (config->_coerce_c_locale < 0) {
-                config->_coerce_c_locale = 0;
+            if (config->coerce_c_locale < 0) {
+                config->coerce_c_locale = 0;
             }
         }
         else if (strcmp(env, "warn") == 0) {
-            config->_coerce_c_locale_warn = 1;
+            config->coerce_c_locale_warn = 1;
         }
         else {
-            if (config->_coerce_c_locale < 0) {
-                config->_coerce_c_locale = 1;
+            if (config->coerce_c_locale < 0) {
+                config->coerce_c_locale = 1;
             }
         }
     }
@@ -967,10 +967,10 @@ config_read_complex_options(_PyCoreConfig *config)
 static void
 config_init_locale(_PyCoreConfig *config)
 {
-    if (config->_coerce_c_locale < 0) {
+    if (config->coerce_c_locale < 0) {
         /* The C locale enables the C locale coercion (PEP 538) */
         if (_Py_LegacyLocaleDetected()) {
-            config->_coerce_c_locale = 1;
+            config->coerce_c_locale = 1;
         }
     }
 
@@ -1291,7 +1291,7 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         }
     }
 
-    if (config->utf8_mode < 0 || config->_coerce_c_locale < 0) {
+    if (config->utf8_mode < 0 || config->coerce_c_locale < 0) {
         config_init_locale(config);
     }
 
@@ -1321,8 +1321,8 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
     if (config->tracemalloc < 0) {
         config->tracemalloc = 0;
     }
-    if (config->_coerce_c_locale < 0) {
-        config->_coerce_c_locale = 0;
+    if (config->coerce_c_locale < 0) {
+        config->coerce_c_locale = 0;
     }
     if (config->utf8_mode < 0) {
         config->utf8_mode = 0;
@@ -1343,7 +1343,7 @@ _PyCoreConfig_Read(_PyCoreConfig *config)
         return err;
     }
 
-    assert(config->_coerce_c_locale >= 0);
+    assert(config->coerce_c_locale >= 0);
     assert(config->use_environment >= 0);
     assert(config->filesystem_encoding != NULL);
     assert(config->filesystem_errors != NULL);

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -295,7 +295,7 @@ static const char *_C_LOCALE_WARNING =
 static void
 _emit_stderr_warning_for_legacy_locale(const _PyCoreConfig *core_config)
 {
-    if (core_config->_coerce_c_locale_warn && _Py_LegacyLocaleDetected()) {
+    if (core_config->coerce_c_locale_warn && _Py_LegacyLocaleDetected()) {
         PySys_FormatStderr("%s", _C_LOCALE_WARNING);
     }
 }


### PR DESCRIPTION
* Revert "[bpo-34589](https://www.bugs.python.org/issue34589): Add -X coerce_c_locale command line option (GH-9378)"
* Revert "[bpo-34589](https://www.bugs.python.org/issue34589): C locale coercion off by default (GH-9073)"
* Revert "[bpo-34589](https://www.bugs.python.org/issue34589): Make _PyCoreConfig.coerce_c_locale private (GH-9371)"


<!-- issue-number: [bpo-34589](https://www.bugs.python.org/issue34589) -->
https://bugs.python.org/issue34589
<!-- /issue-number -->
