### PR TITLE
Minor performance tweak for deque.index() with a start argument

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -290,8 +290,11 @@ class TestBasic(unittest.TestCase):
 
         # Test large start argument
         d = deque(range(0, 10000, 10))
-        i = d.index(9500, 900)
-        self.assertEqual(d[i], 9500)
+        for step in range(100):
+            i = d.index(8500, 700)
+            self.assertEqual(d[i], 8500)
+            # Repeat test with a different internal offset
+            d.rotate()
 
     def test_index_bug_24913(self):
         d = deque('A' * 3)

--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -288,6 +288,11 @@ class TestBasic(unittest.TestCase):
                     else:
                         self.assertEqual(d.index(element, start, stop), target)
 
+        # Test large start argument
+        d = deque(range(0, 10000, 10))
+        i = d.index(9500, 900)
+        self.assertEqual(d[i], 9500)
+
     def test_index_bug_24913(self):
         d = deque('A' * 3)
         with self.assertRaises(ValueError):

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1050,8 +1050,10 @@ deque_index(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
         start = stop;
     assert(0 <= start && start <= stop && stop <= Py_SIZE(deque));
 
-    /* XXX Replace this loop with faster code from deque_item() */
-    for (i=0 ; i<start ; i++) {
+    for (i=0 ; i<start-BLOCKLEN ; i+=BLOCKLEN) {
+            b = b->rightlink;
+    }
+    for ( ; i<start ; i++) {
         index++;
         if (index == BLOCKLEN) {
             b = b->rightlink;

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1050,10 +1050,10 @@ deque_index(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
         start = stop;
     assert(0 <= start && start <= stop && stop <= Py_SIZE(deque));
 
-    for (i=0 ; i<start-BLOCKLEN ; i+=BLOCKLEN) {
+    for (i=0 ; i < start - BLOCKLEN ; i += BLOCKLEN) {
         b = b->rightlink;
     }
-    for ( ; i<start ; i++) {
+    for ( ; i < start ; i++) {
         index++;
         if (index == BLOCKLEN) {
             b = b->rightlink;

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -1051,7 +1051,7 @@ deque_index(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
     assert(0 <= start && start <= stop && stop <= Py_SIZE(deque));
 
     for (i=0 ; i<start-BLOCKLEN ; i+=BLOCKLEN) {
-            b = b->rightlink;
+        b = b->rightlink;
     }
     for ( ; i<start ; i++) {
         index++;


### PR DESCRIPTION
Fix an old TODO to optimize the *start* argument for *deque.index()*.   In the search for the starting block/index pair, make bounding jumps one block at a time rather than a single index at a time.