### PR TITLE
bpo-34754: Fix test_flush_return_value on FreeBSD

### DIFF
--- a/Lib/test/test_mmap.py
+++ b/Lib/test/test_mmap.py
@@ -749,8 +749,9 @@ class MmapTests(unittest.TestCase):
         mm.write(b'python')
         result = mm.flush()
         self.assertIsNone(result)
-        if os.name != 'nt':
-            # 'offset' must be a multiple of mmap.PAGESIZE.
+        if sys.platform.startswith('linux'):
+            # 'offset' must be a multiple of mmap.PAGESIZE on Linux.
+            # See bpo-34754 for details.
             self.assertRaises(OSError, mm.flush, 1, len(b'python'))
 
 


### PR DESCRIPTION
Apparently, FreeBSD doesn't raise OSError when offset is
not a multiple of mmap.PAGESIZE.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34754](https://www.bugs.python.org/issue34754) -->
https://bugs.python.org/issue34754
<!-- /issue-number -->
