### PR TITLE
Include memo in the documented signature of copy.deepcopy()

### DIFF
--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -22,7 +22,7 @@ Interface summary:
    Return a shallow copy of *x*.
 
 
-.. function:: deepcopy(x)
+.. function:: deepcopy(x[, memo])
 
    Return a deep copy of *x*.
 

--- a/Doc/library/copy.rst
+++ b/Doc/library/copy.rst
@@ -52,7 +52,7 @@ copy operations:
 
 The :func:`deepcopy` function avoids these problems by:
 
-* keeping a "memo" dictionary of objects already copied during the current
+* keeping a ``memo`` dictionary of objects already copied during the current
   copying pass; and
 
 * letting user-defined classes override the copying operation or the set of
@@ -82,7 +82,7 @@ In order for a class to define its own copy implementation, it can define
 special methods :meth:`__copy__` and :meth:`__deepcopy__`.  The former is called
 to implement the shallow copy operation; no additional arguments are passed.
 The latter is called to implement the deep copy operation; it is passed one
-argument, the memo dictionary.  If the :meth:`__deepcopy__` implementation needs
+argument, the ``memo`` dictionary.  If the :meth:`__deepcopy__` implementation needs
 to make a deep copy of a component, it should call the :func:`deepcopy` function
 with the component as first argument and the memo dictionary as second argument.
 


### PR DESCRIPTION
The memo argument is mentioned lower on the doc page under writing a
`__deepcopy__` method, but is not included in the documented function signature.
This makes it easy to miss, and can lead to incorrect/buggy implementations of
`__deepcopy__` -- which is exatly what just happpend to me!

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
