### PR TITLE
bpo-34722: Consistent serialization of sets in bytecode

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-21-15-38-47.bpo-34722.F6VE5R.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-21-15-38-47.bpo-34722.F6VE5R.rst
@@ -1,0 +1,4 @@
+Ensures that sets / frozensets marshal in a consistent order by sorting the
+serialised items before writing them. This will result in somewhat slower
+serialisation but bytecode files using set literals in certain contexts will
+now serialise deterministically where it didn't before.


### PR DESCRIPTION
This ensures that sets / frozensets marshal in a consistent order by sorting the serialised items before writing them. That will obviously make serialisation of such types somewhat slower.

Added a test for the case in question; it needs to use `compileall` as a subprocess in order to test with different hash seeds.

<!-- issue-number: [bpo-34722](https://www.bugs.python.org/issue34722) -->
https://bugs.python.org/issue34722
<!-- /issue-number -->
