### PR TITLE
bpo-34762: Fix contextvars C API to use PyObject* pointer types.

### DIFF
--- a/Doc/c-api/contextvars.rst
+++ b/Doc/c-api/contextvars.rst
@@ -5,6 +5,25 @@
 Context Variables Objects
 -------------------------
 
+.. _contextvarsobjects_pointertype_change:
+.. versionchanged:: 3.7.1
+
+   .. note::
+
+      In Python 3.7.1 signatures of all context variables
+      C APIs were **changed** to use :c:type:`PyObject` pointers instead
+      of :c:type:`PyContext`, :c:type:`PyContextVar`, and
+      :c:type:`PyContextToken`, e.g.::
+
+         // in 3.7.0:
+         PyContext *PyContext_New(void);
+
+         // in 3.7.1+:
+         PyObject *PyContext_New(void);
+
+      See :issue:`34762` for more details.
+
+
 .. versionadded:: 3.7
 
 This section details the public C API for the :mod:`contextvars` module.
@@ -56,27 +75,27 @@ Type-check macros:
 
 Context object management functions:
 
-.. c:function:: PyContext *PyContext_New(void)
+.. c:function:: PyObject *PyContext_New(void)
 
    Create a new empty context object.  Returns ``NULL`` if an error
    has occurred.
 
-.. c:function:: PyContext *PyContext_Copy(PyContext *ctx)
+.. c:function:: PyObject *PyContext_Copy(PyObject *ctx)
 
    Create a shallow copy of the passed *ctx* context object.
    Returns ``NULL`` if an error has occurred.
 
-.. c:function:: PyContext *PyContext_CopyCurrent(void)
+.. c:function:: PyObject *PyContext_CopyCurrent(void)
 
    Create a shallow copy of the current thread context.
    Returns ``NULL`` if an error has occurred.
 
-.. c:function:: int PyContext_Enter(PyContext *ctx)
+.. c:function:: int PyContext_Enter(PyObject *ctx)
 
    Set *ctx* as the current context for the current thread.
    Returns ``0`` on success, and ``-1`` on error.
 
-.. c:function:: int PyContext_Exit(PyContext *ctx)
+.. c:function:: int PyContext_Exit(PyObject *ctx)
 
    Deactivate the *ctx* context and restore the previous context as the
    current context for the current thread.  Returns ``0`` on success,
@@ -90,14 +109,14 @@ Context object management functions:
 
 Context variable functions:
 
-.. c:function:: PyContextVar *PyContextVar_New(const char *name, PyObject *def)
+.. c:function:: PyObject *PyContextVar_New(const char *name, PyObject *def)
 
    Create a new ``ContextVar`` object.  The *name* parameter is used
    for introspection and debug purposes.  The *def* parameter may optionally
    specify the default value for the context variable.  If an error has
    occurred, this function returns ``NULL``.
 
-.. c:function:: int PyContextVar_Get(PyContextVar *var, PyObject *default_value, PyObject **value)
+.. c:function:: int PyContextVar_Get(PyObject *var, PyObject *default_value, PyObject **value)
 
    Get the value of a context variable.  Returns ``-1`` if an error has
    occurred during lookup, and ``0`` if no error occurred, whether or not
@@ -112,13 +131,13 @@ Context variable functions:
 
    If the value was found, the function will create a new reference to it.
 
-.. c:function:: PyContextToken *PyContextVar_Set(PyContextVar *var, PyObject *value)
+.. c:function:: PyObject *PyContextVar_Set(PyObject *var, PyObject *value)
 
    Set the value of *var* to *value* in the current context.  Returns a
-   pointer to a :c:type:`PyContextToken` object, or ``NULL`` if an error
+   pointer to a :c:type:`PyObject` object, or ``NULL`` if an error
    has occurred.
 
-.. c:function:: int PyContextVar_Reset(PyContextVar *var, PyContextToken *token)
+.. c:function:: int PyContextVar_Reset(PyObject *var, PyObject *token)
 
    Reset the state of the *var* context variable to that it was in before
    :c:func:`PyContextVar_Set` that returned the *token* was called.

--- a/Doc/c-api/contextvars.rst
+++ b/Doc/c-api/contextvars.rst
@@ -10,7 +10,7 @@ Context Variables Objects
 
    .. note::
 
-      In Python 3.7.1 signatures of all context variables
+      In Python 3.7.1 the signatures of all context variables
       C APIs were **changed** to use :c:type:`PyObject` pointers instead
       of :c:type:`PyContext`, :c:type:`PyContextVar`, and
       :c:type:`PyContextToken`, e.g.::

--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -2494,3 +2494,7 @@ versions, it respected an ill-defined subset of those environment variables,
 while in Python 3.7.0 it didn't read any of them due to :issue:`34247`). If
 this behavior is unwanted, set :c:data:`Py_IgnoreEnvironmentFlag` to 1 before
 calling :c:func:`Py_Initialize`.
+
+In 3.7.1 the C API for Context Variables
+:ref:`was updated <contextvarsobjects_pointertype_change>` to use
+:c:type:`PyObject` pointers.  See also :issue:`34762`.

--- a/Include/context.h
+++ b/Include/context.h
@@ -22,19 +22,19 @@ typedef struct _pycontexttokenobject PyContextToken;
 #define PyContextToken_CheckExact(o) (Py_TYPE(o) == &PyContextToken_Type)
 
 
-PyAPI_FUNC(PyContext *) PyContext_New(void);
-PyAPI_FUNC(PyContext *) PyContext_Copy(PyContext *);
-PyAPI_FUNC(PyContext *) PyContext_CopyCurrent(void);
+PyAPI_FUNC(PyObject *) PyContext_New(void);
+PyAPI_FUNC(PyObject *) PyContext_Copy(PyObject *);
+PyAPI_FUNC(PyObject *) PyContext_CopyCurrent(void);
 
-PyAPI_FUNC(int) PyContext_Enter(PyContext *);
-PyAPI_FUNC(int) PyContext_Exit(PyContext *);
+PyAPI_FUNC(int) PyContext_Enter(PyObject *);
+PyAPI_FUNC(int) PyContext_Exit(PyObject *);
 
 
 /* Create a new context variable.
 
    default_value can be NULL.
 */
-PyAPI_FUNC(PyContextVar *) PyContextVar_New(
+PyAPI_FUNC(PyObject *) PyContextVar_New(
     const char *name, PyObject *default_value);
 
 
@@ -54,21 +54,19 @@ PyAPI_FUNC(PyContextVar *) PyContextVar_New(
    '*value' will be a new ref, if not NULL.
 */
 PyAPI_FUNC(int) PyContextVar_Get(
-    PyContextVar *var, PyObject *default_value, PyObject **value);
+    PyObject *var, PyObject *default_value, PyObject **value);
 
 
 /* Set a new value for the variable.
    Returns NULL if an error occurs.
 */
-PyAPI_FUNC(PyContextToken *) PyContextVar_Set(
-    PyContextVar *var, PyObject *value);
+PyAPI_FUNC(PyObject *) PyContextVar_Set(PyObject *var, PyObject *value);
 
 
 /* Reset a variable to its previous value.
    Returns 0 on success, -1 on error.
 */
-PyAPI_FUNC(int) PyContextVar_Reset(
-    PyContextVar *var, PyContextToken *token);
+PyAPI_FUNC(int) PyContextVar_Reset(PyObject *var, PyObject *token);
 
 
 /* This method is exposed only for CPython tests. Don not use it. */

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-21-11-06-56.bpo-34762.1nN53m.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-21-11-06-56.bpo-34762.1nN53m.rst
@@ -1,0 +1,1 @@
+Fix contextvars C API to use PyObject* pointer types.

--- a/Modules/_contextvarsmodule.c
+++ b/Modules/_contextvarsmodule.c
@@ -16,7 +16,7 @@ static PyObject *
 _contextvars_copy_context_impl(PyObject *module)
 /*[clinic end generated code: output=1fcd5da7225c4fa9 input=89bb9ae485888440]*/
 {
-    return (PyObject *)PyContext_CopyCurrent();
+    return PyContext_CopyCurrent();
 }
 
 

--- a/Python/context.c
+++ b/Python/context.c
@@ -18,22 +18,25 @@ module _contextvars
 /*[clinic end generated code: output=da39a3ee5e6b4b0d input=a0955718c8b8cea6]*/
 
 
-#define ENSURE_Context(o, err_ret)          \
-    if (!PyContext_CheckExact(o)) {         \
-        PyErr_SetNone(PyExc_TypeError);     \
-        return err_ret;                     \
+#define ENSURE_Context(o, err_ret)                                  \
+    if (!PyContext_CheckExact(o)) {                                 \
+        PyErr_SetString(PyExc_TypeError,                            \
+                        "an instance of Context was expected");     \
+        return err_ret;                                             \
     }
 
-#define ENSURE_ContextVar(o, err_ret)       \
-    if (!PyContextVar_CheckExact(o)) {      \
-        PyErr_SetNone(PyExc_TypeError);     \
-        return err_ret;                     \
+#define ENSURE_ContextVar(o, err_ret)                               \
+    if (!PyContextVar_CheckExact(o)) {                              \
+        PyErr_SetString(PyExc_TypeError,                            \
+                       "an instance of ContextVar was expected");   \
+        return err_ret;                                             \
     }
 
-#define ENSURE_ContextToken(o, err_ret)     \
-    if (!PyContextToken_CheckExact(o)) {    \
-        PyErr_SetNone(PyExc_TypeError);     \
-        return err_ret;                     \
+#define ENSURE_ContextToken(o, err_ret)                             \
+    if (!PyContextToken_CheckExact(o)) {                            \
+        PyErr_SetString(PyExc_TypeError,                            \
+                        "an instance of Token was expected");       \
+        return err_ret;                                             \
     }
 
 


### PR DESCRIPTION
* [x] **Note:** if this PR is accepted I'll update the docs before merging it.

<!-- issue-number: [bpo-34762](https://www.bugs.python.org/issue34762) -->
https://bugs.python.org/issue34762
<!-- /issue-number -->
