### PR TITLE
bpo-34763:There is no  0x4E17 in PyUnicode_ToNumeric 

### DIFF
--- a/Objects/unicodetype_db.h
+++ b/Objects/unicodetype_db.h
@@ -5002,6 +5002,7 @@ double _PyUnicode_ToNumeric(Py_UCS4 ch)
         return (double) 3.0/80.0;
     case 0x1374:
     case 0x303A:
+    case 0x4E17:
     case 0x324A:
     case 0x325A:
     case 0x5345:


### PR DESCRIPTION
丗's meanning is 30.(丗 is 0x4E17)
"丗".isnumeric() must returns true.
but "丗".isnumeric()  returns  False.

0x4E17's meaning  equals to 0x303A's meaning  
(丗's meaning  equals to 卅's meaning )
Python lacks 0x4E17

I added 0x4E17 in  PyUnicode_ToNumeric 
I think  this issue is Trivial changes.

Thank you.
https://bugs.python.org/issue34763

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34763](https://www.bugs.python.org/issue34763) -->
https://bugs.python.org/issue34763
<!-- /issue-number -->
