### PR TITLE
bpo-34537: Fix test_gdb:test_strings with LC_ALL=C

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -321,7 +321,21 @@ class PrettyPrintTests(DebuggerTests):
 
     def test_strings(self):
         'Verify the pretty-printing of unicode strings'
-        encoding = locale.getpreferredencoding()
+        # We cannot simply call locale.getpreferredencoding() here,
+        # as GDB might have been linked against a different version
+        # of Python with a different encoding and coercion policy
+        # with respect to PEP 538 and PEP 540.
+        out, err = run_gdb(
+            '--eval-command',
+            'python import locale; print(locale.getpreferredencoding())')
+
+        if err:
+            raise RuntimeError(
+                'unable to determine the preferred encoding '
+                'of embedded Python in GDB.')
+
+        encoding = out.strip()
+
         def check_repr(text):
             try:
                 text.encode(encoding)

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -329,16 +329,11 @@ class PrettyPrintTests(DebuggerTests):
             '--eval-command',
             'python import locale; print(locale.getpreferredencoding())')
 
-        if err:
+        encoding = out.rstrip()
+        if err or not encoding:
             raise RuntimeError(
                 f'unable to determine the preferred encoding '
                 f'of embedded Python in GDB: {err}')
-
-        encoding = out.rstrip()
-        if not encoding:
-            raise RuntimeError(
-                f'unable to determine the preferred encoding '
-                f'of embedded Python in GDB: the command returned no output')
 
         def check_repr(text):
             try:

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -331,10 +331,14 @@ class PrettyPrintTests(DebuggerTests):
 
         if err:
             raise RuntimeError(
-                'unable to determine the preferred encoding '
-                'of embedded Python in GDB.')
+                f'unable to determine the preferred encoding '
+                f'of embedded Python in GDB: {err}')
 
-        encoding = out.strip()
+        encoding = out.rstrip()
+        if not encoding:
+            raise RuntimeError(
+                f'unable to determine the preferred encoding '
+                f'of embedded Python in GDB: the command returned no output')
 
         def check_repr(text):
             try:

--- a/Misc/NEWS.d/next/Tests/2018-09-21-17-33-41.bpo-34537.GImYtZ.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-21-17-33-41.bpo-34537.GImYtZ.rst
@@ -1,0 +1,2 @@
+Fix test_gdb:test_strings when LC_ALL=C and GDB was compiled with Python 3.6
+or earlier.

--- a/Misc/NEWS.d/next/Tests/2018-09-21-17-33-41.bpo-34537.GImYtZ.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-21-17-33-41.bpo-34537.GImYtZ.rst
@@ -1,2 +1,2 @@
-Fix test_gdb:test_strings when LC_ALL=C and GDB was compiled with Python 3.6
-or earlier.
+Fix ``test_gdb.test_strings()`` when ``LC_ALL=C`` and GDB was compiled with
+Python 3.6 or earlier.


### PR DESCRIPTION
We cannot simply call locale.getpreferredencoding() here,
as GDB might have been linked against a different version
of Python with a different encoding and coercion policy
with respect to PEP 538 and PEP 540.

Thanks to Victor Stinner for a hint on how to fix this.

<!-- issue-number: [bpo-34537](https://www.bugs.python.org/issue34537) -->
https://bugs.python.org/issue34537
<!-- /issue-number -->
