### PR TITLE
bpo-34022: Unbreak importlib tests when SOURCE_DATE_EPOCH is set

### DIFF
--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -10,7 +10,6 @@ import io
 import os
 import os.path
 from pathlib import Path, PurePath
-import py_compile
 from test import support
 import unittest
 import sys

--- a/Lib/test/test_importlib/util.py
+++ b/Lib/test/test_importlib/util.py
@@ -10,6 +10,7 @@ import io
 import os
 import os.path
 from pathlib import Path, PurePath
+import py_compile
 from test import support
 import unittest
 import sys
@@ -304,6 +305,26 @@ def writes_bytecode_files(fxn):
         finally:
             sys.dont_write_bytecode = original
         return to_return
+    return wrapper
+
+
+def without_source_date_epoch(fxn):
+    """Runs function with SOURCE_DATE_EPOCH unset."""
+    @functools.wraps(fxn)
+    def wrapper(*args, **kwargs):
+        with support.EnvironmentVarGuard() as env:
+            env.unset('SOURCE_DATE_EPOCH')
+            return fxn(*args, **kwargs)
+    return wrapper
+
+
+def with_source_date_epoch(fxn):
+    """Runs function with SOURCE_DATE_EPOCH set."""
+    @functools.wraps(fxn)
+    def wrapper(*args, **kwargs):
+        with support.EnvironmentVarGuard() as env:
+            env['SOURCE_DATE_EPOCH'] = '123456789'
+            return fxn(*args, **kwargs)
     return wrapper
 
 

--- a/Misc/NEWS.d/next/Tests/2018-09-21-18-36-29.bpo-34022.j6a0nt.rst
+++ b/Misc/NEWS.d/next/Tests/2018-09-21-18-36-29.bpo-34022.j6a0nt.rst
@@ -1,0 +1,1 @@
+Unbreak importlib tests when :envvar:`SOURCE_DATE_EPOCH` is set.


### PR DESCRIPTION
SOURCE_DATE_EPOCH forces py_compile to use the CHECKED_HASH .pyc
invalidation mode, and some tests fail when it is enabled.

The solution is to unset SOURCE_DATE_EPOCH for tests that expect a
different invalidation mode.  This also makes all relevant tests run
with SOURCE_DATE_EPOCH set explicitly.

<!-- issue-number: [bpo-34022](https://www.bugs.python.org/issue34022) -->
https://bugs.python.org/issue34022
<!-- /issue-number -->
