### PR TITLE
bpo-32117: Iterable unpacking in return and yield documentation

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -103,6 +103,10 @@ Other Language Changes
   never intended to permit more than a bare name on the left-hand side of a
   keyword argument assignment term. See :issue:`34641`.
 
+* Iterable unpacking is now allowed without parentheses in :keyword:`yield`
+  and :keyword:`return` statements.
+  (Contributed by David Cuthbert and Jordan Chapman in :issue:`32117`.)
+
 New Modules
 ===========
 

--- a/Misc/NEWS.d/next/Core and Builtins/2017-11-22-15-43-14.bpo-32117.-vloh8.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2017-11-22-15-43-14.bpo-32117.-vloh8.rst
@@ -1,3 +1,3 @@
-Iterable unpacking is now allowed without parenthesis in yield and return
+Iterable unpacking is now allowed without parentheses in yield and return
 statements, e.g. ``yield 1, 2, 3, *rest``. Thanks to David Cuthbert for the
-change and jChapman for added tests.
+change and Jordan Chapman for added tests.


### PR DESCRIPTION
News entry clean up, added to what's new

Requested by @gvanrossum in https://github.com/python/cpython/pull/4509 

<!-- issue-number: [bpo-32117](https://www.bugs.python.org/issue32117) -->
https://bugs.python.org/issue32117
<!-- /issue-number -->
