### PR TITLE
[3.6] bpo-34759: Fix error handling in ssl 'unwrap()' (GH-9468)

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -2407,9 +2407,9 @@ _ssl__SSLSocket_shutdown_impl(PySSLSocket *self)
             break;
     }
 
-    if (err.ssl < 0) {
+    if (ret < 0) {
         Py_XDECREF(sock);
-        return PySSL_SetError(self, err.ssl, __FILE__, __LINE__);
+        return PySSL_SetError(self, ret, __FILE__, __LINE__);
     }
     if (sock)
         /* It's already INCREF'ed */


### PR DESCRIPTION
OpenSSL follows the convention that whenever you call a function, it
returns an error indicator value; and if this value is negative, then
you need to go look at the actual error code to see what happened.

Commit c6fd1c1c3a introduced a small mistake in
_ssl__SSLSocket_shutdown_impl: instead of checking whether the error
indicator was negative, it started checking whether the actual error
code was negative, and it turns out that the error codes are never
negative. So the effect was that 'unwrap()' lost the ability to raise
SSL errors.

https://bugs.python.org/issue34759.
(cherry picked from commit c0da582b227f311126e278b5553a7fa89c79b054)

Co-authored-by: Nathaniel J. Smith <njs@pobox.com>


<!-- issue-number: [bpo-34759](https://www.bugs.python.org/issue34759) -->
https://bugs.python.org/issue34759
<!-- /issue-number -->
