### PR TITLE
bpo-34709: getpass.getuser(): check SUDO_USER too

### DIFF
--- a/Doc/library/getpass.rst
+++ b/Doc/library/getpass.rst
@@ -41,11 +41,11 @@ The :mod:`getpass` module provides two functions:
 
    Return the "login name" of the user.
 
-   This function checks the environment variables :envvar:`LOGNAME`,
-   :envvar:`USER`, :envvar:`LNAME` and :envvar:`USERNAME`, in order, and
-   returns the value of the first one which is set to a non-empty string.  If
-   none are set, the login name from the password database is returned on
-   systems which support the :mod:`pwd` module, otherwise, an exception is
-   raised.
+   This function checks the environment variables :envvar:`SUDO_USER`,
+   :envvar:`LOGNAME`, :envvar:`USER`, :envvar:`LNAME` and :envvar:`USERNAME`,
+   in order, and returns the value of the first one which is set to a
+   non-empty string.  If none are set, the login name from the password
+   database is returned on systems which support the :mod:`pwd` module,
+   otherwise, an exception is raised.
 
    In general, this function should be preferred over :func:`os.getlogin()`.

--- a/Lib/getpass.py
+++ b/Lib/getpass.py
@@ -159,7 +159,7 @@ def getuser():
 
     """
 
-    for name in ('LOGNAME', 'USER', 'LNAME', 'USERNAME'):
+    for name in ('SUDO_USER', 'LOGNAME', 'USER', 'LNAME', 'USERNAME'):
         user = os.environ.get(name)
         if user:
             return user

--- a/Lib/test/test_getpass.py
+++ b/Lib/test/test_getpass.py
@@ -30,7 +30,7 @@ class GetpassGetuserTest(unittest.TestCase):
             pass
         self.assertEqual(
             environ.get.call_args_list,
-            [mock.call(x) for x in ('LOGNAME', 'USER', 'LNAME', 'USERNAME')])
+            [mock.call(x) for x in ('SUDO_USER', 'LOGNAME', 'USER', 'LNAME', 'USERNAME')])
 
     def test_username_falls_back_to_pwd(self, environ):
         expected_name = 'some_name'

--- a/Misc/NEWS.d/next/Library/2018-09-22-22-35-15.bpo-34709.UmKIhBzy.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-22-22-35-15.bpo-34709.UmKIhBzy.rst
@@ -1,0 +1,1 @@
+getuser.getpass() looks at SUDO_USER environment variable too


### PR DESCRIPTION
This change makes `getpass.getuser()` look at `SUDO_USER` environment variable before anything else, so if a user executes `sudo python script.py...` then the original user's name is returned instead of the name that `sudo` changed to.

<!-- issue-number: [bpo-34709](https://www.bugs.python.org/issue34709) -->
https://bugs.python.org/issue34709
<!-- /issue-number -->
