### PR TITLE
bpo-34770: Fix a possible null pointer dereference in pyshellext.cpp

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-09-22-11-02-35.bpo-34770.4lEUOd.rst
+++ b/Misc/NEWS.d/next/Windows/2018-09-22-11-02-35.bpo-34770.4lEUOd.rst
@@ -1,0 +1,1 @@
+Fix a possible null pointer dereference in pyshellext.cpp.

--- a/PC/pyshellext.cpp
+++ b/PC/pyshellext.cpp
@@ -172,6 +172,11 @@ private:
             return E_FAIL;
         }
         auto dd = (DROPDESCRIPTION*)GlobalLock(medium.hGlobal);
+        if (!dd) {
+            OutputDebugString(L"PyShellExt::UpdateDropDescription - failed to lock DROPDESCRIPTION hGlobal");
+            ReleaseStgMedium(&medium);
+            return E_FAIL;
+        }
         StringCchCopy(dd->szMessage, sizeof(dd->szMessage) / sizeof(dd->szMessage[0]), DRAG_MESSAGE);
         StringCchCopy(dd->szInsert, sizeof(dd->szInsert) / sizeof(dd->szInsert[0]), PathFindFileNameW(target));
         dd->type = DROPIMAGE_MOVE;


### PR DESCRIPTION
The GlobalLock() call in UpdateDropDescription() was not checked for
failure.


<!-- issue-number: [bpo-34770](https://www.bugs.python.org/issue34770) -->
https://bugs.python.org/issue34770
<!-- /issue-number -->
