### PR TITLE
bpo-34369: make kqueue.control() docs better reflect that timeout is positional-only

### DIFF
--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -479,9 +479,10 @@ Kqueue Objects
 
    Low level interface to kevent
 
-   - changelist must be an iterable of kevent object or ``None``
+   - changelist must be an iterable of kevent objects or ``None``
    - max_events must be 0 or a positive integer
-   - timeout in seconds (floats possible)
+   - timeout in seconds (floats possible); the default is ``None``,
+     to wait forever
 
    .. versionchanged:: 3.5
       The function is now retried with a recomputed timeout when interrupted by

--- a/Doc/library/select.rst
+++ b/Doc/library/select.rst
@@ -475,7 +475,7 @@ Kqueue Objects
    Create a kqueue object from a given file descriptor.
 
 
-.. method:: kqueue.control(changelist, max_events[, timeout=None]) -> eventlist
+.. method:: kqueue.control(changelist, max_events[, timeout]) -> eventlist
 
    Low level interface to kevent
 


### PR DESCRIPTION
This improves consistency with the rest of the select module's doc page, e.g. `select.select()`.

<!-- issue-number: [bpo-34369](https://www.bugs.python.org/issue34369) -->
https://bugs.python.org/issue34369
<!-- /issue-number -->
