### PR TITLE
[2.7] bpo-34610: Fixed iterator of multiprocessing.managers.DictProxy (GH-9113).

### DIFF
--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -1059,10 +1059,13 @@ class ListProxy(BaseListProxy):
 
 
 DictProxy = MakeProxyType('DictProxy', (
-    '__contains__', '__delitem__', '__getitem__', '__len__',
+    '__contains__', '__delitem__', '__getitem__', '__iter__', '__len__',
     '__setitem__', 'clear', 'copy', 'get', 'has_key', 'items',
     'keys', 'pop', 'popitem', 'setdefault', 'update', 'values'
     ))
+DictProxy._method_to_typeid_ = {
+    '__iter__': 'Iterator',
+    }
 
 
 ArrayProxy = MakeProxyType('ArrayProxy', (

--- a/Lib/test/test_multiprocessing.py
+++ b/Lib/test/test_multiprocessing.py
@@ -1135,6 +1135,16 @@ class _TestContainers(BaseTestCase):
         a.append('hello')
         self.assertEqual(f[:], [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 'hello']])
 
+    def test_list_iter(self):
+        a = self.list(range(10))
+        it = iter(a)
+        self.assertEqual(list(it), range(10))
+        self.assertEqual(list(it), [])  # exhausted
+        # list modified during iteration
+        it = iter(a)
+        a[0] = 100
+        self.assertEqual(next(it), 100)
+
     def test_dict(self):
         d = self.dict()
         indices = range(65, 70)
@@ -1144,6 +1154,19 @@ class _TestContainers(BaseTestCase):
         self.assertEqual(sorted(d.keys()), indices)
         self.assertEqual(sorted(d.values()), [chr(i) for i in indices])
         self.assertEqual(sorted(d.items()), [(i, chr(i)) for i in indices])
+
+    def test_dict_iter(self):
+        d = self.dict()
+        indices = range(65, 70)
+        for i in indices:
+            d[i] = chr(i)
+        it = iter(d)
+        self.assertEqual(list(it), indices)
+        self.assertEqual(list(it), [])  # exhausted
+        # dictionary changed size during iteration
+        it = iter(d)
+        d.clear()
+        self.assertRaises(RuntimeError, next, it)
 
     def test_namespace(self):
         n = self.Namespace()

--- a/Misc/NEWS.d/next/Library/2018-09-08-12-57-07.bpo-34610.wmoP5j.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-08-12-57-07.bpo-34610.wmoP5j.rst
@@ -1,0 +1,1 @@
+Fixed iterator of :class:`multiprocessing.managers.DictProxy`.


### PR DESCRIPTION
(cherry picked from commit e0e5065daef36dafe10a46eaa8b7800274d73062)


<!-- issue-number: [bpo-34610](https://www.bugs.python.org/issue34610) -->
https://bugs.python.org/issue34610
<!-- /issue-number -->
