### PR TITLE
[3.7]Documentation minor update related to 3.6 - 3.7 migration

### DIFF
--- a/Doc/tutorial/interpreter.rst
+++ b/Doc/tutorial/interpreter.rst
@@ -24,11 +24,11 @@ Python guru or system administrator.  (E.g., :file:`/usr/local/python` is a
 popular alternative location.)
 
 On Windows machines, the Python installation is usually placed in
-:file:`C:\\Python36`, though you can change this when you're running the
+:file:`C:\\Python37`, though you can change this when you're running the
 installer.  To add this directory to your path,  you can type the following
 command into the command prompt in a DOS box::
 
-   set path=%path%;C:\python36
+   set path=%path%;C:\python37
 
 Typing an end-of-file character (:kbd:`Control-D` on Unix, :kbd:`Control-Z` on
 Windows) at the primary prompt causes the interpreter to exit with a zero exit

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -182,14 +182,14 @@ Generic options
 
    .. code-block:: none
 
-       Python 3.7.0
+       Python 3.7.0b2+
 
    When given twice, print more information about the build, like:
 
    .. code-block:: none
 
-       Python 3.7.0 (default, Jun 29 2018, 00:03:57)
-       [GCC 5.5.0]
+       Python 3.7.0b2+ (3.7:0c076caaa8, Sep 22 2018, 12:04:24)
+       [GCC 6.2.0 20161005]
 
    .. versionadded:: 3.6
       The ``-VV`` option.

--- a/Doc/using/cmdline.rst
+++ b/Doc/using/cmdline.rst
@@ -182,14 +182,14 @@ Generic options
 
    .. code-block:: none
 
-       Python 3.6.0b2+
+       Python 3.7.0
 
    When given twice, print more information about the build, like:
 
    .. code-block:: none
 
-       Python 3.6.0b2+ (3.6:84a3c5003510+, Oct 26 2016, 02:33:55)
-       [GCC 6.2.0 20161005]
+       Python 3.7.0 (default, Jun 29 2018, 00:03:57)
+       [GCC 5.5.0]
 
    .. versionadded:: 3.6
       The ``-VV`` option.

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -193,13 +193,13 @@ of available options is shown below.
 For example, to silently install a default, system-wide Python installation,
 you could use the following command (from an elevated command prompt)::
 
-    python-3.6.0.exe /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
+    python-3.7.0.exe /quiet InstallAllUsers=1 PrependPath=1 Include_test=0
 
 To allow users to easily install a personal copy of Python without the test
 suite, you could provide a shortcut with the following command. This will
 display a simplified initial page and disallow customization::
 
-    python-3.6.0.exe InstallAllUsers=0 Include_launcher=0 Include_test=0
+    python-3.7.0.exe InstallAllUsers=0 Include_launcher=0 Include_test=0
         SimpleInstall=1 SimpleInstallDescription="Just for me, no test suite."
 
 (Note that omitting the launcher also omits file associations, and is only
@@ -236,13 +236,13 @@ where a large number of installations are going to be performed it is very
 useful to have a locally cached copy.
 
 Execute the following command from Command Prompt to download all possible
-required files.  Remember to substitute ``python-3.6.0.exe`` for the actual
+required files.  Remember to substitute ``python-3.7.0.exe`` for the actual
 name of your installer, and to create layouts in their own directories to
 avoid collisions between files with the same name.
 
 ::
 
-    python-3.6.0.exe /layout [optional target directory]
+    python-3.7.0.exe /layout [optional target directory]
 
 You may also specify the ``/quiet`` option to hide the progress display.
 
@@ -349,7 +349,7 @@ To temporarily set environment variables, open Command Prompt and use the
 
 .. code-block:: doscon
 
-    C:\>set PATH=C:\Program Files\Python 3.6;%PATH%
+    C:\>set PATH=C:\Program Files\Python 3.7;%PATH%
     C:\>set PYTHONPATH=%PYTHONPATH%;C:\My_python_lib
     C:\>python
 
@@ -422,7 +422,7 @@ of your Python installation, delimited by a semicolon from other entries.  An
 example variable could look like this (assuming the first two entries already
 existed)::
 
-    C:\WINDOWS\system32;C:\WINDOWS;C:\Program Files\Python 3.6
+    C:\WINDOWS\system32;C:\WINDOWS;C:\Program Files\Python 3.7
 
 .. _launcher:
 


### PR DESCRIPTION
Change version from 3.6 to 3.7 in the documentation when it addresses newcomers.

original request from python/python-docs-fr#273