### PR TITLE
bpo-34775: Return NotImplemented in PurePath division.

### DIFF
--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -889,10 +889,16 @@ class PurePath(object):
         return self._make_child(args)
 
     def __truediv__(self, key):
-        return self._make_child((key,))
+        try:
+            return self._make_child((key,))
+        except TypeError:
+            return NotImplemented
 
     def __rtruediv__(self, key):
-        return self._from_parts([key] + self._parts)
+        try:
+            return self._from_parts([key] + self._parts)
+        except TypeError:
+            return NotImplemented
 
     @property
     def parent(self):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2306,8 +2306,10 @@ class CompatiblePathTest(unittest.TestCase):
 
     class CompatPath:
         """
-        Simple class to store a string and uses combine that
-        string with other object's string values via division.
+        Minimum viable class to test PurePath compatibility.
+        Simply uses the division operator to join a given 
+        string and the string value of another object with 
+        a forward slash.
         """
         def __init__(self, string):
             self.string = string

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2307,8 +2307,8 @@ class CompatiblePathTest(unittest.TestCase):
     class CompatPath:
         """
         Minimum viable class to test PurePath compatibility.
-        Simply uses the division operator to join a given 
-        string and the string value of another object with 
+        Simply uses the division operator to join a given
+        string and the string value of another object with
         a forward slash.
         """
         def __init__(self, string):

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -2298,5 +2298,44 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
             check()
 
 
+class CompatiblePathTest(unittest.TestCase):
+    """
+    Test that a type can be made compatible with PurePath
+    derivatives by implementing division operator overloads.
+    """
+
+    class CompatPath:
+        """
+        Simple class to store a string and uses combine that
+        string with other object's string values via division.
+        """
+        def __init__(self, string):
+            self.string = string
+
+        def __truediv__(self, other):
+            return type(self)(f"{self.string}/{other}")
+
+        def __rtruediv__(self, other):
+            return type(self)(f"{other}/{self.string}")
+
+    def test_truediv(self):
+        result = pathlib.PurePath("test") / self.CompatPath("right")
+        self.assertIsInstance(result, self.CompatPath)
+        self.assertEqual(result.string, "test/right")
+
+        with self.assertRaises(TypeError):
+            # Verify improper operations still raise a TypeError
+            pathlib.PurePath("test") / 10
+
+    def test_rtruediv(self):
+        result = self.CompatPath("left") / pathlib.PurePath("test")
+        self.assertIsInstance(result, self.CompatPath)
+        self.assertEqual(result.string, "left/test")
+
+        with self.assertRaises(TypeError):
+            # Verify improper operations still raise a TypeError
+            10 / pathlib.PurePath("test")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-09-23-03-18-52.bpo-34775.vHeuHk.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-23-03-18-52.bpo-34775.vHeuHk.rst
@@ -1,0 +1,2 @@
+Division handling of PurePath now returns NotImplemented instead of raising
+a TypeError when passed something other than an instance of str or PurePath.

--- a/Misc/NEWS.d/next/Library/2018-09-23-03-18-52.bpo-34775.vHeuHk.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-23-03-18-52.bpo-34775.vHeuHk.rst
@@ -1,2 +1,3 @@
 Division handling of PurePath now returns NotImplemented instead of raising
 a TypeError when passed something other than an instance of str or PurePath.
+Patch by Roger Aiudi.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

Return NotImplemented in `PurePath.__truediv__` and `PurePath.__rtruediv__` instead of raising a TypeError to allow custom compatible path types.

<!-- issue-number: [bpo-34775](https://www.bugs.python.org/issue34775) -->
https://bugs.python.org/issue34775
<!-- /issue-number -->
