### PR TITLE
bpo-34780: Fix potential hang during stdin initialization on Windows

### DIFF
--- a/Misc/NEWS.d/next/Windows/2018-09-23-23-02-46.bpo-34780.PIJ3OU.rst
+++ b/Misc/NEWS.d/next/Windows/2018-09-23-23-02-46.bpo-34780.PIJ3OU.rst
@@ -1,0 +1,2 @@
+Fix hang on startup if stdin refers to a pipe with an outstanding concurrent
+operation on Windows.

--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -6915,7 +6915,8 @@ posix_fdopen(PyObject *self, PyObject *args)
         PyMem_FREE(mode);
         return posix_error();
     }
-#if defined(HAVE_FSTAT) && defined(S_IFDIR) && defined(EISDIR)
+#if !defined(MS_WINDOWS) && defined(HAVE_FSTAT) && defined(S_IFDIR) && \
+    defined(EISDIR)
     {
         struct stat buf;
         const char *msg;

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -119,7 +119,8 @@ file_PyObject_Print(PyObject *op, PyFileObject *f, int flags)
 static PyFileObject*
 dircheck(PyFileObject* f)
 {
-#if defined(HAVE_FSTAT) && defined(S_IFDIR) && defined(EISDIR)
+#if !defined(MS_WINDOWS) && defined(HAVE_FSTAT) && defined(S_IFDIR) && \
+    defined(EISDIR)
     struct stat buf;
     int res;
     if (f->f_fp == NULL)


### PR DESCRIPTION
On Windows, if there is an outstanding operation on a synchronous
pipe handle (e.g., ReadFile()), many other operations will block until
the first one completes. This is true even for operations that
normally complete immediately (PeekNamedPipe(), SetFilePointer(),
etc.).

Python performs fstat(fd) during file object initialization to check for
attempts to open a directory, which is forbidden. If fd refers to a pipe,
msvcrt calls PeekNamedPipe() to fill in st_size member of struct stat,
potentially hanging the interpreter before execution of user code
when stdin object is initialized in the conditions described above.

fstat() on Windows can't distinguish between a file and a directory
because it relies on GetFileType(), which returns FILE_TYPE_DISK
in both cases. Therefore, skipping the no-op check avoids the hang.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34780](https://www.bugs.python.org/issue34780) -->
https://bugs.python.org/issue34780
<!-- /issue-number -->
