### PR TITLE
bpo-34783 move pymain_clear_config to directly before pymain_run_*

### DIFF
--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1538,6 +1538,7 @@ pymain_run_filename(_PyMain *pymain, PyCompilerFlags *cf)
     else {
         fp = stdin;
     }
+    pymain_clear_config(pymain);
 
     pymain->status = pymain_run_file(fp, pymain->filename, cf);
 }
@@ -2602,8 +2603,6 @@ pymain_init_sys_path(_PyMain *pymain)
         return -1;
     }
 
-    pymain_clear_config(pymain);
-
     if (path0 != NULL) {
         if (pymain_update_sys_path(pymain, path0) < 0) {
             Py_DECREF(path0);
@@ -2624,9 +2623,11 @@ pymain_run_python(_PyMain *pymain)
     pymain_import_readline(pymain);
 
     if (pymain->command) {
+        pymain_clear_config(pymain);
         pymain->status = pymain_run_command(pymain->command, &cf);
     }
     else if (pymain->module) {
+        pymain_clear_config(pymain);
         pymain->status = (pymain_run_module(pymain->module, 1) != 0);
     }
     else {


### PR DESCRIPTION
Posible fix for SIGSEGV on script specified on command line not found in 3.7 (for example on Alpine).
On other Linux there is a (null) output instead.

This would fix issue reported here: https://github.com/docker-library/python/issues/320 .

pymain_clear_config must not be run before pymain_run_filename -> pymain_open_filename.

Could be implemented other way, thought. @vstinner should now how to do it properly.

Alternative approaches I could mind, for example:
- preserver value of pymain->config.program and pass it through to pymain_open_filename in case it needs it for reporting errors
- get the program name for error message another way
- do not reference pymain->config.program in pymain_open_filename when the error message is generated
- ensure that all systems print "(null)" as program name instead to SEGV
- do not clear this at all

<!-- issue-number: [bpo-34783](https://www.bugs.python.org/issue34783) -->
https://bugs.python.org/issue34783
<!-- /issue-number -->
