### PR TITLE
[3.7] bpo-34783: Fix Py_Main()

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-24-11-31-23.bpo-34783.O79cwo.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-24-11-31-23.bpo-34783.O79cwo.rst
@@ -1,0 +1,2 @@
+Fix a crash with musl libc (on Alpine Linux) when the script filename
+specified on the command line doesn't exist.


### PR DESCRIPTION
Fix a crash with musl libc (on Alpine Linux) when the script filename
specified on the command line doesn't exist. pymain_open_filename()
now gets the current core configuration from the interpreter state.

Modify the code to make it closer to the master branch:

* Rename _Py_CommandLineDetails to _PyCmdline
* Remove _PyMain.config: replaced with a local variable
  'local_config' in pymain_init()
* Reorganize pymain_main(): move code using the "local config"
  into pymain_init()
* As soon as possible, switch from the local config to the core
  configuration attached to the interpreter.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34783](https://www.bugs.python.org/issue34783) -->
https://bugs.python.org/issue34783
<!-- /issue-number -->
