### PR TITLE
bpo-34334: Don't log traceback twice in QueueHandler

### DIFF
--- a/Doc/library/logging.handlers.rst
+++ b/Doc/library/logging.handlers.rst
@@ -973,9 +973,9 @@ possible, while any potentially slow operations (such as sending an email via
       Prepares a record for queuing. The object returned by this
       method is enqueued.
 
-      The base implementation formats the record to merge the message
-      and arguments, and removes unpickleable items from the record
-      in-place.
+      The base implementation formats the record to merge the message,
+      arguments, and exception information, if present.  It also
+      removes unpickleable items from the record in-place.
 
       You might want to override this method if you want to convert
       the record to a dict or JSON string, or send a modified copy

--- a/Lib/logging/handlers.py
+++ b/Lib/logging/handlers.py
@@ -1374,13 +1374,14 @@ class QueueHandler(logging.Handler):
         # (if there's exception data), and also returns the formatted
         # message. We can then use this to replace the original
         # msg + args, as these might be unpickleable. We also zap the
-        # exc_info attribute, as it's no longer needed and, if not None,
-        # will typically not be pickleable.
+        # exc_info and exc_text attributes, as they are no longer
+        # needed and, if not None, will typically not be pickleable.
         msg = self.format(record)
         record.message = msg
         record.msg = msg
         record.args = None
         record.exc_info = None
+        record.exc_text = None
         return record
 
     def emit(self, record):

--- a/Misc/NEWS.d/next/Library/2018-09-25-08-42-34.bpo-34334.rSPBW9.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-25-08-42-34.bpo-34334.rSPBW9.rst
@@ -1,0 +1,2 @@
+In :class:`QueueHandler`, clear `exc_text` from :class:`LogRecord` to
+prevent traceback from being written twice.


### PR DESCRIPTION
In QueueHandler in logging, the traceback (exc_info and exc_text) was being appended to the message twice after [bpo-31084](https://www.bugs.python.org/issue31084).  This clears `LogRecord.exc_text` in the QueueHandler to keep it in sync with `exc_info`.


<!-- issue-number: [bpo-34334](https://www.bugs.python.org/issue34334) -->
https://bugs.python.org/issue34334
<!-- /issue-number -->
