### PR TITLE
bpo-34687: asynico uses ProactorEventLoop by default

### DIFF
--- a/Doc/library/asyncio-platforms.rst
+++ b/Doc/library/asyncio-platforms.rst
@@ -23,6 +23,8 @@ All Platforms
 Windows
 =======
 
+The default event loop on Windows is :class:`ProactorEventLoop`.
+
 All event loops on Windows do not support the following methods:
 
 * :meth:`loop.create_unix_connection` and
@@ -61,22 +63,19 @@ hardware (availability of `HPET
 <https://en.wikipedia.org/wiki/High_Precision_Event_Timer>`_) and on the
 Windows configuration.
 
+.. versionchanged:: 3.8
+
+   On Windows, :class:`ProactorEventLoop` is now the default event loop.
+
 
 .. _asyncio-windows-subprocess:
 
 Subprocess Support on Windows
 -----------------------------
 
-:class:`SelectorEventLoop` on Windows does not support subproceses.
-On Windows, :class:`ProactorEventLoop` should be used instead::
+The default event loop :class:`ProactorEventLoop` supports subprocesses.
 
-  import asyncio
-
-  asyncio.set_event_loop_policy(
-      asyncio.WindowsProactorEventLoopPolicy())
-
-  asyncio.run(your_code())
-
+On Windows, :class:`SelectorEventLoop` does not support subprocesses.
 
 The :meth:`policy.set_child_watcher()
 <AbstractEventLoopPolicy.set_child_watcher>` function is also

--- a/Doc/library/asyncio-platforms.rst
+++ b/Doc/library/asyncio-platforms.rst
@@ -23,7 +23,9 @@ All Platforms
 Windows
 =======
 
-The default event loop on Windows is :class:`ProactorEventLoop`.
+.. versionchanged:: 3.8
+
+   On Windows, :class:`ProactorEventLoop` is now the default event loop.
 
 All event loops on Windows do not support the following methods:
 
@@ -63,19 +65,14 @@ hardware (availability of `HPET
 <https://en.wikipedia.org/wiki/High_Precision_Event_Timer>`_) and on the
 Windows configuration.
 
-.. versionchanged:: 3.8
-
-   On Windows, :class:`ProactorEventLoop` is now the default event loop.
-
 
 .. _asyncio-windows-subprocess:
 
 Subprocess Support on Windows
 -----------------------------
 
-The default event loop :class:`ProactorEventLoop` supports subprocesses.
-
-On Windows, :class:`SelectorEventLoop` does not support subprocesses.
+On Windows, the default event loop :class:`ProactorEventLoop` supports
+subprocesses, whereas :class:`SelectorEventLoop` does not.
 
 The :meth:`policy.set_child_watcher()
 <AbstractEventLoopPolicy.set_child_watcher>` function is also

--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -98,6 +98,14 @@ asyncio ships with the following built-in policies:
    is configured to use the default policy automatically.
 
 
+.. class:: WindowsSelectorEventLoopPolicy
+
+   An alternative event loop policy that uses the
+   :class:`SelectorEventLoop` event loop implementation.
+
+   Availability: Windows.
+
+
 .. class:: WindowsProactorEventLoopPolicy
 
    An alternative event loop policy that uses the

--- a/Doc/library/asyncio-policy.rst
+++ b/Doc/library/asyncio-policy.rst
@@ -92,10 +92,14 @@ asyncio ships with the following built-in policies:
 .. class:: DefaultEventLoopPolicy
 
    The default asyncio policy.  Uses :class:`SelectorEventLoop`
-   on both Unix and Windows platforms.
+   on Unix and :class:`ProactorEventLoop` on Windows.
 
    There is no need to install the default policy manually. asyncio
    is configured to use the default policy automatically.
+
+   .. versionchanged:: 3.8
+
+      On Windows, :class:`ProactorEventLoop` is now used by default.
 
 
 .. class:: WindowsSelectorEventLoopPolicy

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -116,6 +116,11 @@ New Modules
 Improved Modules
 ================
 
+asyncio
+-------
+
+On Windows, the default event loop is now :class:`~asyncio.ProactorEventLoop`.
+
 os.path
 -------
 

--- a/Lib/asyncio/windows_events.py
+++ b/Lib/asyncio/windows_events.py
@@ -811,4 +811,4 @@ class WindowsProactorEventLoopPolicy(events.BaseDefaultEventLoopPolicy):
     _loop_factory = ProactorEventLoop
 
 
-DefaultEventLoopPolicy = WindowsSelectorEventLoopPolicy
+DefaultEventLoopPolicy = WindowsProactorEventLoopPolicy

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -1014,7 +1014,7 @@ class BaseEventLoopWithSelectorTests(test_utils.TestCase):
 
     def setUp(self):
         super().setUp()
-        self.loop = asyncio.new_event_loop()
+        self.loop = asyncio.SelectorEventLoop()
         self.set_event_loop(self.loop)
 
     @mock.patch('socket.getnameinfo')

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -816,7 +816,8 @@ os.close(fd)
         addr = q.get()
 
         # Should not be stuck in an infinite loop.
-        with self.assertRaises((ConnectionResetError, BrokenPipeError)):
+        with self.assertRaises((ConnectionResetError, ConnectionAbortedError,
+                                BrokenPipeError)):
             self.loop.run_until_complete(client(*addr))
 
         # Clean up the thread.  (Only on success; on failure, it may

--- a/Misc/NEWS.d/next/Library/2018-09-24-17-14-57.bpo-34687.Fku_8S.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-24-17-14-57.bpo-34687.Fku_8S.rst
@@ -1,0 +1,2 @@
+On Windows, asyncio now uses ProactorEventLoop, instead of
+SelectorEventLoop, by default.


### PR DESCRIPTION
On Windows, asyncio now uses ProactorEventLoop, instead of
SelectorEventLoop, by default.

<!-- issue-number: [bpo-34687](https://www.bugs.python.org/issue34687) -->
https://bugs.python.org/issue34687
<!-- /issue-number -->
