### PR TITLE
bpo-30156: Remove property_descr_get() optimization

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-24-17-51-15.bpo-30156.pH0j5j.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-24-17-51-15.bpo-30156.pH0j5j.rst
@@ -1,0 +1,4 @@
+The C function ``property_descr_get()`` uses a "cached" tuple to optimize
+function calls. But this tuple can be discovered in debug mode with
+:func:`sys.getobjects()`. Remove the optimization, it's not really worth it
+and it causes 3 different crashes last years.


### PR DESCRIPTION
property_descr_get() uses a "cached" tuple to optimize function
calls. But this tuple can be discovered in debug mode with
sys.getobjects(). Remove the optimization, it's not really worth it
and it causes 3 different crashes.

Microbenchmark:

./python -m perf timeit -v \
    -s "from collections import namedtuple; P = namedtuple('P', 'x y'); p = P(1, 2)" \
    --duplicate 1024 "p.x"

Result:

Mean +- std dev: [ref] 32.8 ns +- 0.8 ns -> [patch] 40.4 ns +- 1.3 ns: 1.23x slower (+23%)

<!-- issue-number: [bpo-30156](https://www.bugs.python.org/issue30156) -->
https://bugs.python.org/issue30156
<!-- /issue-number -->
