### PR TITLE
bpo-34791: xml package obeys ignore env flags

### DIFF
--- a/Lib/xml/dom/domreg.py
+++ b/Lib/xml/dom/domreg.py
@@ -6,6 +6,8 @@ registerDOMImplementation should be imported from xml.dom."""
 # should be published by posting to xml-sig@python.org, and are
 # subsequently recorded in this file.
 
+import sys
+
 well_known_implementations = {
     'minidom':'xml.dom.minidom',
     '4DOM': 'xml.dom.DOMImplementation',
@@ -55,7 +57,7 @@ def getDOMImplementation(name=None, features=()):
         return mod.getDOMImplementation()
     elif name:
         return registered[name]()
-    elif "PYTHON_DOM" in os.environ:
+    elif not sys.flags.ignore_environment and "PYTHON_DOM" in os.environ:
         return getDOMImplementation(name = os.environ["PYTHON_DOM"])
 
     # User did not specify a name, try implementations in arbitrary

--- a/Lib/xml/sax/__init__.py
+++ b/Lib/xml/sax/__init__.py
@@ -58,7 +58,7 @@ if _false:
     import xml.sax.expatreader
 
 import os, sys
-if "PY_SAX_PARSER" in os.environ:
+if not sys.flags.ignore_environment and "PY_SAX_PARSER" in os.environ:
     default_parser_list = os.environ["PY_SAX_PARSER"].split(",")
 del os
 

--- a/Misc/NEWS.d/next/Security/2018-09-24-18-49-25.bpo-34791.78GmIG.rst
+++ b/Misc/NEWS.d/next/Security/2018-09-24-18-49-25.bpo-34791.78GmIG.rst
@@ -1,0 +1,3 @@
+The xml.sax and xml.dom.domreg no longer use environment variables to
+override parser implementations when sys.flags.ignore_environment is set by
+-E or -I arguments.


### PR DESCRIPTION
The xml.sax and xml.dom.domreg modules now obey
sys.flags.ignore_environment.

Signed-off-by: Christian Heimes <christian@python.org>


<!-- issue-number: [bpo-34791](https://www.bugs.python.org/issue34791) -->
https://bugs.python.org/issue34791
<!-- /issue-number -->
