### PR TITLE
[2.7] bpo-34794: Fix a memory leak in Tkinter.Image.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-09-25-11-04-12.bpo-34794.HGyLx-.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-25-11-04-12.bpo-34794.HGyLx-.rst
@@ -1,0 +1,2 @@
+Fixed a memory leak in :class:`Tkinter.Image` when set the *data* or
+*maskdata* options.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -3230,6 +3230,7 @@ Tkapp_CreateByteArray(PyObject *self, PyObject *args)
         return Tkinter_Error(self);
     }
     res = newPyTclObject(obj);
+    Tcl_DecrRefCount(obj);
     PyBuffer_Release(&view);
     return res;
 }


### PR DESCRIPTION
A Tcl object was leaked when set the data or maskdata options.


<!-- issue-number: [bpo-34794](https://www.bugs.python.org/issue34794) -->
https://bugs.python.org/issue34794
<!-- /issue-number -->
