### PR TITLE
bpo-34736: improve error message for invalid length b64decode inputs

### DIFF
--- a/Lib/test/test_binascii.py
+++ b/Lib/test/test_binascii.py
@@ -3,6 +3,7 @@
 import unittest
 import binascii
 import array
+import re
 
 # Note: "*_hex" functions are aliases for "(un)hexlify"
 b2a_functions = ['b2a_base64', 'b2a_hex', 'b2a_hqx', 'b2a_qp', 'b2a_uu',
@@ -127,7 +128,10 @@ class BinASCIITest(unittest.TestCase):
 
         # Test base64 with invalid number of valid characters (1 mod 4)
         def assertInvalidLength(data):
-            with self.assertRaisesRegex(binascii.Error, r'(?i)invalid.+length'):
+            n_data_chars = len(re.sub(br'[^A-Za-z0-9/+]', br'', data))
+            expected_errmsg_re = \
+                r'(?i)Invalid.+number of data characters.+' + str(n_data_chars)
+            with self.assertRaisesRegex(binascii.Error, expected_errmsg_re):
                 binascii.a2b_base64(self.type2test(data))
 
         assertInvalidLength(b'a')

--- a/Modules/binascii.c
+++ b/Modules/binascii.c
@@ -438,6 +438,7 @@ binascii_a2b_base64_impl(PyObject *module, Py_buffer *data)
 {
     const unsigned char *ascii_data;
     unsigned char *bin_data;
+    unsigned char *bin_data_start;
     int leftbits = 0;
     unsigned char this_ch;
     unsigned int leftchar = 0;
@@ -461,6 +462,7 @@ binascii_a2b_base64_impl(PyObject *module, Py_buffer *data)
     bin_data = _PyBytesWriter_Alloc(&writer, bin_len);
     if (bin_data == NULL)
         return NULL;
+    bin_data_start = bin_data;
 
     for( ; ascii_len > 0; ascii_len--, ascii_data++) {
         this_ch = *ascii_data;
@@ -516,9 +518,11 @@ binascii_a2b_base64_impl(PyObject *module, Py_buffer *data)
             ** This is an invalid length, as there is no possible input that
             ** could encoded into such a base64 string.
             */
-            PyErr_SetString(Error,
-                            "Invalid base64-encoded string: "
-                            "length cannot be 1 more than a multiple of 4");
+            PyErr_Format(Error,
+                         "Invalid base64-encoded string: "
+                         "number of data characters (%d) cannot be 1 more "
+                         "than a multiple of 4",
+                         (bin_data - bin_data_start) / 3 * 4 + 1);
         } else {
             PyErr_SetString(Error, "Incorrect padding");
         }


### PR DESCRIPTION
Improvements:
1. Include the number of valid data characters in the error message.
2. Mention "number of data characters" rather than "length".

<!-- issue-number: [bpo-34736](https://www.bugs.python.org/issue34736) -->
https://bugs.python.org/issue34736
<!-- /issue-number -->
