### PR TITLE
bpo-34800: Fix email.contentmanager raise error when policy.max_line_length is 0 or None

### DIFF
--- a/Lib/email/contentmanager.py
+++ b/Lib/email/contentmanager.py
@@ -131,6 +131,8 @@ def _finalize_set(msg, disposition, filename, cid, params):
 # drop both this and quoprimime.body_encode in favor of enhanced binascii
 # routines that accepted a max_line_length parameter.
 def _encode_base64(data, max_line_length):
+    if not max_line_length:
+        return binascii.b2a_base64(data).decode('ascii')
     encoded_lines = []
     unencoded_bytes_per_line = max_line_length // 4 * 3
     for i in range(0, len(data), unencoded_bytes_per_line):
@@ -150,8 +152,8 @@ def _encode_text(string, charset, cte, policy):
             return '7bit', normal_body(lines).decode('ascii')
         except UnicodeDecodeError:
             pass
-        if (policy.cte_type == '8bit' and
-                max(len(x) for x in lines) <= policy.max_line_length):
+        if (policy.cte_type == '8bit' and (not policy.max_line_length or
+                max(len(x) for x in lines) <= policy.max_line_length)):
             return '8bit', normal_body(lines).decode('ascii', 'surrogateescape')
         sniff = embedded_body(lines[:10])
         sniff_qp = quoprimime.body_encode(sniff.decode('latin-1'),

--- a/Lib/email/quoprimime.py
+++ b/Lib/email/quoprimime.py
@@ -168,6 +168,8 @@ def body_encode(body, maxlinelen=76, eol=NL):
 
     """
 
+    if not maxlinelen:
+        maxlinelen=float('+inf')
     if maxlinelen < 4:
         raise ValueError("maxlinelen must be at least 4")
     if not body:

--- a/Lib/test/test_email/test_contentmanager.py
+++ b/Lib/test/test_email/test_contentmanager.py
@@ -453,6 +453,45 @@ class TestRawDataManager(TestEmailBase):
         self.assertEqual(m.get_payload(decode=True).decode('utf-8'), content)
         self.assertEqual(m.get_content(), content)
 
+    def test_set_text_non_ascii_with_policy_max_line_length_none_or_0(self):
+        for max_line_length in (0, None):
+            with self.subTest(max_line_length=max_line_length):
+                policy = self.policy.clone(max_line_length=max_line_length)
+                m = self.message(policy=policy)
+                content = ("áàäéèęöőáàäéèęöőáàäéèęöőáàäéèęöő"
+                        "áàäéèęöőáàäéèęöőáàäéèęöőáàäéèęöő"
+                        "áàäéèęöőáàäéèęöőáàäéèęöőáàäéèęöő.\n")
+                raw_data_manager.set_content(m,content)
+                self.assertEqual(bytes(m), (textwrap.dedent("""\
+                    Content-Type: text/plain; charset="utf-8"
+                    Content-Transfer-Encoding: 8bit
+                    """) + "\n" + \
+                    "áàäéèęöőáàäéèęöőáàäéèęöőáàäéèęöő"
+                    "áàäéèęöőáàäéèęöőáàäéèęöőáàäéèęöő"
+                    "áàäéèęöőáàäéèęöőáàäéèęöőáàäéèęöő.\n"
+                    ).encode('utf8'))
+                self.assertEqual(
+                    m.get_payload(decode=True).decode('utf-8'), content)
+                self.assertEqual(m.get_content(), content)
+    
+    def test_set_bytes_with_policy_max_line_length_none_or_0(self):
+        for max_line_length in (0, None):
+            with self.subTest(max_line_length=max_line_length):
+                policy = self.policy.clone(max_line_length=max_line_length)
+                m = self.message(policy=policy)
+                content = b'b\xFFgus\tcon\nt\rent ' + b'z'*80
+                raw_data_manager.set_content(
+                    m,content, maintype='application', subtype='octet-stream')
+                self.assertEqual(bytes(m), textwrap.dedent("""\
+                    Content-Type: application/octet-stream
+                    Content-Transfer-Encoding: base64
+                    """).encode('ascii') + b"\n" + 
+                    b"Yv9ndXMJY29uCnQNZW50IHp6enp6enp6enp6enp6enp6enp6enp6enp6"
+                    b"enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6"
+                    b"enp6enp6enp6enp6\n")
+                self.assertEqual(m.get_payload(decode=True), content)
+                self.assertEqual(m.get_content(), content)
+
     def test_set_text_non_ascii_with_cte_7bit_raises(self):
         m = self._make_message()
         with self.assertRaises(UnicodeError):

--- a/Lib/test/test_email/test_contentmanager.py
+++ b/Lib/test/test_email/test_contentmanager.py
@@ -473,7 +473,7 @@ class TestRawDataManager(TestEmailBase):
                 self.assertEqual(
                     m.get_payload(decode=True).decode('utf-8'), content)
                 self.assertEqual(m.get_content(), content)
-    
+
     def test_set_bytes_with_policy_max_line_length_none_or_0(self):
         for max_line_length in (0, None):
             with self.subTest(max_line_length=max_line_length):
@@ -485,7 +485,7 @@ class TestRawDataManager(TestEmailBase):
                 self.assertEqual(bytes(m), textwrap.dedent("""\
                     Content-Type: application/octet-stream
                     Content-Transfer-Encoding: base64
-                    """).encode('ascii') + b"\n" + 
+                    """).encode('ascii') + b"\n" +
                     b"Yv9ndXMJY29uCnQNZW50IHp6enp6enp6enp6enp6enp6enp6enp6enp6"
                     b"enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6enp6"
                     b"enp6enp6enp6enp6\n")

--- a/Lib/test/test_email/test_contentmanager.py
+++ b/Lib/test/test_email/test_contentmanager.py
@@ -461,7 +461,7 @@ class TestRawDataManager(TestEmailBase):
                 content = ("áàäéèęöőáàäéèęöőáàäéèęöőáàäéèęöő"
                         "áàäéèęöőáàäéèęöőáàäéèęöőáàäéèęöő"
                         "áàäéèęöőáàäéèęöőáàäéèęöőáàäéèęöő.\n")
-                raw_data_manager.set_content(m,content)
+                raw_data_manager.set_content(m, content)
                 self.assertEqual(bytes(m), (textwrap.dedent("""\
                     Content-Type: text/plain; charset="utf-8"
                     Content-Transfer-Encoding: 8bit

--- a/Lib/test/test_email/test_contentmanager.py
+++ b/Lib/test/test_email/test_contentmanager.py
@@ -481,7 +481,7 @@ class TestRawDataManager(TestEmailBase):
                 m = self.message(policy=policy)
                 content = b'b\xFFgus\tcon\nt\rent ' + b'z'*80
                 raw_data_manager.set_content(
-                    m,content, maintype='application', subtype='octet-stream')
+                    m, content, maintype='application', subtype='octet-stream')
                 self.assertEqual(bytes(m), textwrap.dedent("""\
                     Content-Type: application/octet-stream
                     Content-Transfer-Encoding: base64

--- a/Misc/NEWS.d/next/Library/2018-09-26-15-18-18.bpo-34800.auD5YK.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-26-15-18-18.bpo-34800.auD5YK.rst
@@ -1,0 +1,2 @@
+Fix `email.contentmanager.set_content` raise error when
+`email.policy.Policy.max_line_length` is 0 or None. Patch by silane.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34800](https://www.bugs.python.org/issue34800) -->
https://bugs.python.org/issue34800
<!-- /issue-number -->
