### PR TITLE
[3.6] Drop confusing commented out code in pystrtod.c (GH-6072)

### DIFF
--- a/Python/pystrtod.c
+++ b/Python/pystrtod.c
@@ -1061,8 +1061,6 @@ format_float_short(double d, char format_code,
         else {
             /* shouldn't get here: Gay's code should always return
                something starting with a digit, an 'I',  or 'N' */
-            strncpy(p, "ERR", 3);
-            /* p += 3; */
             assert(0);
         }
         goto exit;


### PR DESCRIPTION
(cherry picked from commit 9fb84157595a385f15799e5d0729c1e1b0ba9d38)