### PR TITLE
[3.6] bpo-28655: Fix test_import.test_missing_source_legacy()

### DIFF
--- a/Lib/test/test_import/__init__.py
+++ b/Lib/test/test_import/__init__.py
@@ -779,8 +779,11 @@ class PycacheTests(unittest.TestCase):
         unload(TESTFN)
         importlib.invalidate_caches()
         m = __import__(TESTFN)
-        self.assertEqual(m.__file__,
-                         os.path.join(os.curdir, os.path.relpath(pyc_file)))
+        try:
+            self.assertEqual(m.__file__,
+                             os.path.join(os.curdir, os.path.relpath(pyc_file)))
+        finally:
+            os.remove(pyc_file)
 
     def test___cached__(self):
         # Modules now also have an __cached__ that points to the pyc file.


### PR DESCRIPTION
[bpo-28655](https://www.bugs.python.org/issue28655), [bpo-33053](https://www.bugs.python.org/issue33053): test_import.test_missing_source_legacy() now
removes the .pyc file that it creates to avoid leaking a file.

Fix extract from commit d5d9e02dd3c6df06a8dd9ce75ee9b52976420a8b.

Co-Authored-By: Nick Coghlan <ncoghlan@gmail.com>