### PR TITLE
bpo-34814: Fix Modules/makesetup for shared libraries

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-09-26-18-57-43.bpo-34814.tv7fIY.rst
+++ b/Misc/NEWS.d/next/Build/2018-09-26-18-57-43.bpo-34814.tv7fIY.rst
@@ -1,0 +1,3 @@
+Fix Modules/makesetup script for shared libraries. When Modules/Setup is
+modified to compile C extensions as shared libraries using Makefile, make
+sure that the generated shared library is linked to libpython3.X.

--- a/Modules/makesetup
+++ b/Modules/makesetup
@@ -247,8 +247,8 @@ sed -e 's/[ 	]*#.*//' -e '/^[ 	]*$/d' |
 			case $doconfig in
 			no)	SHAREDMODS="$SHAREDMODS $file";;
 			esac
-			rule="$file: $objs"
-			rule="$rule; \$(BLDSHARED) $objs $libs $ExtraLibs -o $file"
+			rule="$file: $objs \$(LDLIBRARY)"
+			rule="$rule; \$(BLDSHARED) $objs \$(BLDLIBRARY) $libs $ExtraLibs -o $file"
 			echo "$rule" >>$rulesf
 		done
 	done


### PR DESCRIPTION
Fix Modules/makesetup script for shared libraries. When Modules/Setup
is modified to compile C extensions as shared libraries using
Makefile, make sure that the generated shared library is linked to
libpython3.X.

Add also a dependency on the Makefile target to libpython, to make
sure that the parallel compilation works as expected.

<!-- issue-number: [bpo-34814](https://www.bugs.python.org/issue34814) -->
https://bugs.python.org/issue34814
<!-- /issue-number -->
