### PR TITLE
[3.7] Fix markup for xml.sax in 3.7 notes

### DIFF
--- a/Doc/whatsnew/3.7.rst
+++ b/Doc/whatsnew/3.7.rst
@@ -1586,7 +1586,7 @@ xml
 ---
 
 As mitigation against DTD and external entity retrieval, the
-:mod:`xml.dom.minidom` and mod:`xml.sax` modules no longer process
+:mod:`xml.dom.minidom` and :mod:`xml.sax` modules no longer process
 external entities by default.
 (Contributed by Christian Heimes in :issue:`17239`.)
 


### PR DESCRIPTION
This is a continuation of #9602. Sorry for the hassle.