### PR TITLE
bpo-34824: Fix a possible NULL pointer dereference in _ssl.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-27-11-10-02.bpo-34824.VLlCaU.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-27-11-10-02.bpo-34824.VLlCaU.rst
@@ -1,0 +1,2 @@
+Fix a possible null pointer dereference in Modules/_ssl.c. Patch by Zackery
+Spytz.

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4711,8 +4711,8 @@ _ssl_MemoryBIO_read_impl(PySSLMemoryBIO *self, int len)
 
     nbytes = BIO_read(self->bio, PyBytes_AS_STRING(result), len);
     /* There should never be any short reads but check anyway. */
-    if ((nbytes < len) && (_PyBytes_Resize(&result, len) < 0)) {
-        return NULL;
+    if (nbytes < len) {
+        _PyBytes_Resize(&result, len);
     }
 
     return result;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4712,7 +4712,6 @@ _ssl_MemoryBIO_read_impl(PySSLMemoryBIO *self, int len)
     nbytes = BIO_read(self->bio, PyBytes_AS_STRING(result), len);
     /* There should never be any short reads but check anyway. */
     if ((nbytes < len) && (_PyBytes_Resize(&result, len) < 0)) {
-        Py_DECREF(result);
         return NULL;
     }
 

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4710,9 +4710,14 @@ _ssl_MemoryBIO_read_impl(PySSLMemoryBIO *self, int len)
         return result;
 
     nbytes = BIO_read(self->bio, PyBytes_AS_STRING(result), len);
+    if (nbytes < 0) {
+        _setSSLError(NULL, 0, __FILE__, __LINE__);
+        return NULL;
+    }
+
     /* There should never be any short reads but check anyway. */
     if (nbytes < len) {
-        _PyBytes_Resize(&result, len);
+        _PyBytes_Resize(&result, nbytes);
     }
 
     return result;

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -4711,6 +4711,7 @@ _ssl_MemoryBIO_read_impl(PySSLMemoryBIO *self, int len)
 
     nbytes = BIO_read(self->bio, PyBytes_AS_STRING(result), len);
     if (nbytes < 0) {
+        Py_DECREF(result);
         _setSSLError(NULL, 0, __FILE__, __LINE__);
         return NULL;
     }


### PR DESCRIPTION
On failure, _PyBytes_Resize() will deallocate the bytes object and set
"result" to NULL.

<!-- issue-number: [bpo-34824](https://www.bugs.python.org/issue34824) -->
https://bugs.python.org/issue34824
<!-- /issue-number -->
