### PR TITLE
bpo-34825: Add more entries to os to pathlib reference table

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -1095,23 +1095,30 @@ Below is a table mapping various :mod:`os` functions to their corresponding
    overlapping use-cases, their semantics differ enough to warrant not
    considering them equivalent.
 
-============================   ==============================
-os and os.path                 pathlib
-============================   ==============================
-:func:`os.path.abspath`        :meth:`Path.resolve`
-:func:`os.getcwd`              :func:`Path.cwd`
-:func:`os.path.exists`         :meth:`Path.exists`
-:func:`os.path.expanduser`     :meth:`Path.expanduser` and
-                               :meth:`Path.home`
-:func:`os.path.isdir`          :meth:`Path.is_dir`
-:func:`os.path.isfile`         :meth:`Path.is_file`
-:func:`os.path.islink`         :meth:`Path.is_symlink`
-:func:`os.stat`                :meth:`Path.stat`,
-                               :meth:`Path.owner`,
-                               :meth:`Path.group`
-:func:`os.path.isabs`          :meth:`PurePath.is_absolute`
-:func:`os.path.join`           :func:`PurePath.joinpath`
-:func:`os.path.basename`       :data:`PurePath.name`
-:func:`os.path.dirname`        :data:`PurePath.parent`
-:func:`os.path.splitext`       :data:`PurePath.suffix`
-============================   ==============================
+====================================   ==============================
+os and os.path                         pathlib
+====================================   ==============================
+:func:`os.path.abspath`                :meth:`Path.resolve`
+:func:`os.chmod`                       :meth:`Path.chmod`
+:func:`os.mkdir`                       :meth:`Path.mkdir`
+:func:`os.rename`                      :meth:`Path.rename`
+:func:`os.replace`                     :meth:`Path.replace`
+:func:`os.rmdir`                       :meth:`Path.rmdir`
+:func:`os.remove`, :func:`os.unlink`   :meth:`Path.unlink`
+:func:`os.getcwd`                      :func:`Path.cwd`
+:func:`os.path.exists`                 :meth:`Path.exists`
+:func:`os.path.expanduser`             :meth:`Path.expanduser` and
+                                       :meth:`Path.home`
+:func:`os.path.isdir`                  :meth:`Path.is_dir`
+:func:`os.path.isfile`                 :meth:`Path.is_file`
+:func:`os.path.islink`                 :meth:`Path.is_symlink`
+:func:`os.stat`                        :meth:`Path.stat`,
+                                       :meth:`Path.owner`,
+                                       :meth:`Path.group`
+:func:`os.path.isabs`                  :meth:`PurePath.is_absolute`
+:func:`os.path.join`                   :func:`PurePath.joinpath`
+:func:`os.path.basename`               :data:`PurePath.name`
+:func:`os.path.dirname`                :data:`PurePath.parent`
+:func:`os.path.samefile`               :meth:`Path.samefile`
+:func:`os.path.splitext`               :data:`PurePath.suffix`
+====================================   ==============================


### PR DESCRIPTION
The added functions are as below :

| os module     | Pathlib       |
| ------------- | ------------- |
| os.chmod   | Path.chmod  |
| os.mkdir  | Path.mkdir  | 
| os.rename | Path.rename |
| os.replace | Path.replace |
| os.rmdir  | Path.rmdir |
| os.remove, os.unlink | Path.unlink |
| os.path.samefile | Path.samefile |

Thanks

<!-- issue-number: [bpo-34825](https://www.bugs.python.org/issue34825) -->
https://bugs.python.org/issue34825
<!-- /issue-number -->
