### PR TITLE
bpo-34521: Fix tests in test_multiprocessing_spawn to use correctly CMSG_SPACE

### DIFF
--- a/Lib/multiprocessing/reduction.py
+++ b/Lib/multiprocessing/reduction.py
@@ -154,7 +154,7 @@ else:
         '''Receive an array of fds over an AF_UNIX socket.'''
         a = array.array('i')
         bytes_size = a.itemsize * size
-        msg, ancdata, flags, addr = sock.recvmsg(1, socket.CMSG_LEN(bytes_size))
+        msg, ancdata, flags, addr = sock.recvmsg(1, socket.CMSG_SPACE(bytes_size))
         if not msg and not ancdata:
             raise EOFError
         try:


### PR DESCRIPTION
After some failures in AMD64 FreeBSD CURRENT Debug 3.x buildbots
regarding tests in test_multiprocessing_spawn and after examining
similar failures in test_socket, some errors in the calculation of
ancillary data buffers were found in multiprocessing.reduction.

CMSG_LEN() can often be used as the buffer size for recvmsg() to
receive a single item of ancillary data, but RFC 3542 requires portable
applications to use CMSG_SPACE() and thus include space for padding,
even when the item will be the last in the buffer.

The failures we experience are due to the usage of CMSG_LEN instead of
CMSG_SPACE.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34521](https://www.bugs.python.org/issue34521) -->
https://bugs.python.org/issue34521
<!-- /issue-number -->
