### PR TITLE
bpo-27195: Handle NULL format in memoryview objects.

### DIFF
--- a/Lib/test/test_memoryview.py
+++ b/Lib/test/test_memoryview.py
@@ -394,6 +394,20 @@ class AbstractMemoryTests:
         self.assertEqual(c.format, "H")
         self.assertEqual(d.format, "H")
 
+    def test_minimal_buffer(self):
+        # We rely here on the fact that io.BufferedReader uses PyBuffer_FillInfo
+        # to construct its Py_buffer.
+        class TrapReader(io.RawIOBase):
+            def readable(self):
+                return True
+
+            def readinto(self, b):
+                self.format = b.format
+                return 0
+        r = TrapReader()
+        io.BufferedReader(r).read(1)
+        self.assertEqual(r.format, 'B')
+
 
 # Variations on source objects for the buffer: bytes-like objects, then arrays
 # with itemsize > 1.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-09-28-00-52-28.bpo-27195.0dwSQz.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-09-28-00-52-28.bpo-27195.0dwSQz.rst
@@ -1,0 +1,6 @@
+Access to the ``format`` of a ``memoryview`` object could crash if the
+corresponding field in the buffer structure was not set. Per documentation
+of the new-style buffer protocol, an unset ``format`` field is to be
+interpreted as ``"B"``, so that is now returned in this case.
+
+Patch by JP Sugarbroad.

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -2942,6 +2942,9 @@ static PyObject *
 memory_format_get(PyMemoryViewObject *self)
 {
     CHECK_RELEASED(self);
+    if (self->view.format == NULL) {
+        return PyUnicode_FromString("B");
+    }
     return PyUnicode_FromString(self->view.format);
 }
 


### PR DESCRIPTION
See https://bugs.python.org/issue27195 for details of the crash. Backport PRs will come after this one is approved.

<!-- issue-number: [bpo-27195](https://www.bugs.python.org/issue27195) -->
https://bugs.python.org/issue27195
<!-- /issue-number -->
