### PR TITLE
bpo-34818: Add missing closing() wrapper in test_tls1_3.

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2812,7 +2812,7 @@ else:
                 ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1 | ssl.OP_NO_TLSv1_2
             )
             with ThreadedEchoServer(context=context) as server:
-                with context.wrap_socket(socket.socket()) as s:
+                with closing(context.wrap_socket(socket.socket())) as s:
                     s.connect((HOST, server.port))
                     self.assertIn(s.cipher()[0], [
                         'TLS13-AES-256-GCM-SHA384',


### PR DESCRIPTION
Python 2.7 socket classes do not implement context manager protocol, hence closing() is required around it. Resolves testcase error traceback.

<!-- issue-number: [bpo-34818](https://www.bugs.python.org/issue34818) -->
https://bugs.python.org/issue34818
<!-- /issue-number -->
