### PR TITLE
bpo-34687: Update asyncio doc for ProactorEventLoop

### DIFF
--- a/Doc/library/asyncio-eventloop.rst
+++ b/Doc/library/asyncio-eventloop.rst
@@ -1432,15 +1432,6 @@ on all platforms.
 
    Availability: Windows.
 
-   An example how to use :class:`ProactorEventLoop` on Windows::
-
-        import asyncio
-        import sys
-
-        if sys.platform == 'win32':
-            loop = asyncio.ProactorEventLoop()
-            asyncio.set_event_loop(loop)
-
    .. seealso::
 
       `MSDN documentation on I/O Completion Ports

--- a/Doc/library/asyncio-protocol.rst
+++ b/Doc/library/asyncio-protocol.rst
@@ -1030,10 +1030,6 @@ The subprocess is created by th :meth:`loop.subprocess_exec` method::
         data = bytes(protocol.output)
         return data.decode('ascii').rstrip()
 
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(
-            asyncio.WindowsProactorEventLoopPolicy())
-
     date = asyncio.run(get_date())
     print(f"Current date: {date}")
 

--- a/Doc/library/asyncio-subprocess.rst
+++ b/Doc/library/asyncio-subprocess.rst
@@ -344,10 +344,6 @@ function::
         await proc.wait()
         return line
 
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(
-            asyncio.WindowsProactorEventLoopPolicy())
-
     date = asyncio.run(get_date())
     print(f"Current date: {date}")
 


### PR DESCRIPTION
Since ProactorEventLoop is now the default in 3.8, remove examples
using it explicitly on Windows.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34687](https://www.bugs.python.org/issue34687) -->
https://bugs.python.org/issue34687
<!-- /issue-number -->
