### PR TITLE
[2.7] bpo-34836: fix test_default_ecdh_curve, needs no tlsv1.3.

### DIFF
--- a/Lib/test/test_ssl.py
+++ b/Lib/test/test_ssl.py
@@ -2828,6 +2828,9 @@ else:
             # should be enabled by default on SSL contexts.
             context = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             context.load_cert_chain(CERTFILE)
+            # TLSv1.3 defaults to PFS key agreement and no longer has KEA in
+            # cipher name.
+            context.options |= ssl.OP_NO_TLSv1_3
             # Prior to OpenSSL 1.0.0, ECDH ciphers have to be enabled
             # explicitly using the 'ECCdraft' cipher alias.  Otherwise,
             # our default cipher list should prefer ECDH-based ciphers

--- a/Misc/NEWS.d/next/Tests/2019-01-11-14-01-19.bpo-34836.7fat9-.rst
+++ b/Misc/NEWS.d/next/Tests/2019-01-11-14-01-19.bpo-34836.7fat9-.rst
@@ -1,0 +1,1 @@
+Fix ``test_default_ecdh_curve`` when TLSv1.3 is enabled by default.


### PR DESCRIPTION
https://bugs.python.org/issue34836

<!-- issue-number: [[bpo-34836](https://bugs.python.org/issue34836)](https://www.bugs.python.org/issue34836) -->
https://bugs.python.org/issue34836
<!-- /issue-number -->
