### PR TITLE
Speed-up math.dist() by 30%

### DIFF
--- a/Modules/clinic/mathmodule.c.h
+++ b/Modules/clinic/mathmodule.c.h
@@ -294,8 +294,9 @@ math_dist(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
     PyObject *p;
     PyObject *q;
 
-    if (!_PyArg_ParseStack(args, nargs, "O!O!:dist",
-        &PyTuple_Type, &p, &PyTuple_Type, &q)) {
+    if (!_PyArg_UnpackStack(args, nargs, "dist",
+        2, 2,
+        &p, &q)) {
         goto exit;
     }
     return_value = math_dist_impl(module, p, q);
@@ -522,4 +523,4 @@ math_isclose(PyObject *module, PyObject *const *args, Py_ssize_t nargs, PyObject
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=d936137c1189b89b input=a9049054013a1b77]*/
+/*[clinic end generated code: output=239c51a5acefbafb input=a9049054013a1b77]*/

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2101,8 +2101,8 @@ vector_norm(Py_ssize_t n, double *vec, double max, int found_nan)
 /*[clinic input]
 math.dist
 
-    p: object(subclass_of='&PyTuple_Type')
-    q: object(subclass_of='&PyTuple_Type')
+    p: object
+    q: object
     /
 
 Return the Euclidean distance between two points p and q.
@@ -2116,7 +2116,7 @@ Roughly equivalent to:
 
 static PyObject *
 math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
-/*[clinic end generated code: output=56bd9538d06bbcfe input=937122eaa5f19272]*/
+/*[clinic end generated code: output=56bd9538d06bbcfe input=8c83c07c7a524664]*/
 {
     PyObject *item;
     double max = 0.0;
@@ -2125,6 +2125,15 @@ math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
     int found_nan = 0;
     double diffs_on_stack[NUM_STACK_ELEMS];
     double *diffs = diffs_on_stack;
+
+    if (!PyTuple_Check(p)) {
+        PyErr_SetString(PyExc_TypeError, "dist argument must be a tuple");
+        return NULL;
+    }
+    if (!PyTuple_Check(q)) {
+        PyErr_SetString(PyExc_TypeError, "dist argument must be a tuple");
+        return NULL;
+    }
 
     m = PyTuple_GET_SIZE(p);
     n = PyTuple_GET_SIZE(q);

--- a/Modules/mathmodule.c
+++ b/Modules/mathmodule.c
@@ -2126,11 +2126,7 @@ math_dist_impl(PyObject *module, PyObject *p, PyObject *q)
     double diffs_on_stack[NUM_STACK_ELEMS];
     double *diffs = diffs_on_stack;
 
-    if (!PyTuple_Check(p)) {
-        PyErr_SetString(PyExc_TypeError, "dist argument must be a tuple");
-        return NULL;
-    }
-    if (!PyTuple_Check(q)) {
+    if (!PyTuple_Check(p) || !PyTuple_Check(q)) {
         PyErr_SetString(PyExc_TypeError, "dist argument must be a tuple");
         return NULL;
     }


### PR DESCRIPTION
Manual type checking is much faster than the argument clinic equivalent.

--------- baseline ------------
$ pytime -r11 -s 'from math import dist' -s 'p=(1.1, 2.2)' -s 'q=(1.5, 2.5)' 'dist(p, q)'
5000000 loops, best of 11: 95.5 nsec per loop
$ pytime -r11 -s 'from math import dist' -s 'p=(1.1, 2.2)' -s 'q=(1.5, 2.5)' 'dist(p, q)'
5000000 loops, best of 11: 95.3 nsec per loop
$ pytime -r11 -s 'from math import dist' -s 'p=(1.1, 2.2)' -s 'q=(1.5, 2.5)' 'dist(p, q)'
5000000 loops, best of 11: 95.5 nsec per loop

------ patched ------
$ pytime -r11 -s 'from math import dist' -s 'p=(1.1, 2.2)' -s 'q=(1.5, 2.5)' 'dist(p, q)'
5000000 loops, best of 11: 67 nsec per loop
$ pytime -r11 -s 'from math import dist' -s 'p=(1.1, 2.2)' -s 'q=(1.5, 2.5)' 'dist(p, q)'
5000000 loops, best of 11: 67.2 nsec per loop
$ pytime -r11 -s 'from math import dist' -s 'p=(1.1, 2.2)' -s 'q=(1.5, 2.5)' 'dist(p, q)'
5000000 loops, best of 11: 67.3 nsec per loop