### PR TITLE
[Skip Issue] Fix incorrect error handling in _pickle.Unpickler.__init__()

### DIFF
--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6792,7 +6792,7 @@ _pickle_Unpickler___init___impl(UnpicklerObject *self, PyObject *file,
 
     self->stack = (Pdata *)Pdata_New();
     if (self->stack == NULL)
-        return 1;
+        return -1;
 
     self->memo_size = 32;
     self->memo = _Unpickler_NewMemo(self->memo_size);


### PR DESCRIPTION
`_pickle.Unpickler.__init__()` should return -1 if `Pdata_New()` fails, not 1.

This bug was introduced in b7ccb204236dca49f3d8d119aa84631f519add09.
