### PR TITLE
Fix name of argument in docs for functools.reduce().

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -280,14 +280,14 @@ The :mod:`functools` module defines the following functions:
 
 .. function:: reduce(function, iterable[, initializer])
 
-   Apply *function* of two arguments cumulatively to the items of *sequence*, from
-   left to right, so as to reduce the sequence to a single value.  For example,
+   Apply *function* of two arguments cumulatively to the items of *iterable*, from
+   left to right, so as to reduce the iterable to a single value.  For example,
    ``reduce(lambda x, y: x+y, [1, 2, 3, 4, 5])`` calculates ``((((1+2)+3)+4)+5)``.
    The left argument, *x*, is the accumulated value and the right argument, *y*, is
-   the update value from the *sequence*.  If the optional *initializer* is present,
-   it is placed before the items of the sequence in the calculation, and serves as
-   a default when the sequence is empty.  If *initializer* is not given and
-   *sequence* contains only one item, the first item is returned.
+   the update value from the *iterable*.  If the optional *initializer* is present,
+   it is placed before the items of the iterable in the calculation, and serves as
+   a default when the iterable is empty.  If *initializer* is not given and
+   *iterable* contains only one item, the first item is returned.
 
    Roughly equivalent to::
 


### PR DESCRIPTION
The function signature gives the second argument as *iterable*, but the
descriptive text refers to it as "sequence".

This appears to have been broken since
commit:58f9e4f34793a14050648c9f620e96189908a3e9, 11 years ago.

I have not opened a bpo, as I believe this to be a trivial fix.  If you would prefer me to do a bpo for this, let me know and I'll be happy to.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
