### PR TITLE
bpo-34843: Remove recent from logging cookbook

### DIFF
--- a/Doc/howto/logging-cookbook.rst
+++ b/Doc/howto/logging-cookbook.rst
@@ -721,9 +721,8 @@ existing processes to perform this function.)
 includes a working socket receiver which can be used as a starting point for you
 to adapt in your own applications.
 
-If you are using a recent version of Python which includes the
-:mod:`multiprocessing` module, you could write your own handler which uses the
-:class:`~multiprocessing.Lock` class from this module to serialize access to the
+You could also write your own handler which uses the :class:`~multiprocessing.Lock`
+class from the :mod:`multiprocessing` module to serialize access to the
 file from your processes. The existing :class:`FileHandler` and subclasses do
 not make use of :mod:`multiprocessing` at present, though they may do so in the
 future. Note that at present, the :mod:`multiprocessing` module does not provide


### PR DESCRIPTION
Remove the word 'recent' when referring to multiprocessing in the logging cookbook.

<!-- issue-number: [bpo-34843](https://www.bugs.python.org/issue34843) -->
https://bugs.python.org/issue34843
<!-- /issue-number -->
