### PR TITLE
bpo-34476: Document that asyncio.sleep() always suspends.

### DIFF
--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -276,7 +276,7 @@ Sleeping
    If *result* is provided, it is returned to the caller
    when the coroutine completes.
 
-   ``sleep()` always suspends the current task, allowing other tasks
+   ``sleep()`` always suspends the current task, allowing other tasks
    to run.
 
    The *loop* argument is deprecated and scheduled for removal

--- a/Doc/library/asyncio-task.rst
+++ b/Doc/library/asyncio-task.rst
@@ -276,6 +276,9 @@ Sleeping
    If *result* is provided, it is returned to the caller
    when the coroutine completes.
 
+   ``sleep()` always suspends the current task, allowing other tasks
+   to run.
+
    The *loop* argument is deprecated and scheduled for removal
    in Python 3.10.
 


### PR DESCRIPTION
As discussed on https://bugs.python.org/issue34476


<!-- issue-number: [bpo-34476](https://www.bugs.python.org/issue34476) -->
https://bugs.python.org/issue34476
<!-- /issue-number -->
