### PR TITLE
bpo-34850: Replace is with == in idlelib.iomenu

### DIFF
--- a/Lib/idlelib/iomenu.py
+++ b/Lib/idlelib/iomenu.py
@@ -40,7 +40,7 @@ else:
             # resulting codeset may be unknown to Python. We ignore all
             # these problems, falling back to ASCII
             locale_encoding = locale.nl_langinfo(locale.CODESET)
-            if locale_encoding is None or locale_encoding is '':
+            if locale_encoding is None or locale_encoding == '':
                 # situation occurs on Mac OS X
                 locale_encoding = 'ascii'
             codecs.lookup(locale_encoding)
@@ -50,7 +50,7 @@ else:
             # bugs that can cause ValueError.
             try:
                 locale_encoding = locale.getdefaultlocale()[1]
-                if locale_encoding is None or locale_encoding is '':
+                if locale_encoding is None or locale_encoding == '':
                     # situation occurs on Mac OS X
                     locale_encoding = 'ascii'
                 codecs.lookup(locale_encoding)


### PR DESCRIPTION
Extracted from #9642 by Serhiy Storchaka.  I want to apply and backport this regardless of the fate of that PR.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34850](https://www.bugs.python.org/issue34850) -->
https://bugs.python.org/issue34850
<!-- /issue-number -->
