### PR TITLE
bpo-32962: Fix test_gdb failure in debug build with -mcet -fcf-protection -O0

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -55,7 +55,7 @@ checkout_hook_path = os.path.join(os.path.dirname(sys.executable),
 PYTHONHASHSEED = '123'
 
 
-def cet_cf_protection():
+def cet_protection():
     cflags = sysconfig.get_config_var('CFLAGS')
     if not cflags:
         return False
@@ -63,7 +63,8 @@ def cet_cf_protection():
     return (('-mcet' in flags)
             and any(flag.startswith('-fcf-protection') for flag in flags))
 
-CET_CF_PROTECTION = cet_cf_protection()
+# Control-flow enforcement technology
+CET_PROTECTION = cet_protection()
 
 
 def run_gdb(*args, **env_vars):
@@ -174,7 +175,7 @@ class DebuggerTests(unittest.TestCase):
             commands += ['set print entry-values no']
 
         if cmds_after_breakpoint:
-            if CET_CF_PROTECTION:
+            if CET_PROTECTION:
                 # bpo-32962: When Python is compiled with -mcet
                 # -fcf-protection, function arguments are unusable before
                 # running the first instruction of the function entry point.
@@ -888,7 +889,7 @@ id(42)
             l = MyList()
         ''')
         cmds_after_breakpoint = ['break wrapper_call', 'continue']
-        if CET_CF_PROTECTION:
+        if CET_PROTECTION:
             # bpo-32962: same case as in get_stack_trace():
             # we need an additional 'next' command in order to read
             # arguments of the innermost function of the call stack.

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -57,6 +57,8 @@ PYTHONHASHSEED = '123'
 
 def cet_cf_protection():
     cflags = sysconfig.get_config_var('CFLAGS')
+    if not cflags:
+        return False
     flags = cflags.split()
     return (('-mcet' in flags)
             and any(flag.startswith('-fcf-protection') for flag in flags))

--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -60,8 +60,12 @@ def cet_protection():
     if not cflags:
         return False
     flags = cflags.split()
+    # True if "-mcet -fcf-protection" options are found, but false
+    # if "-fcf-protection=none" or "-fcf-protection=return" is found.
     return (('-mcet' in flags)
-            and any(flag.startswith('-fcf-protection') for flag in flags))
+            and any((flag.startswith('-fcf-protection')
+                     and not flag.endswith(("=none", "=return")))
+                    for flag in flags))
 
 # Control-flow enforcement technology
 CET_PROTECTION = cet_protection()

--- a/Misc/NEWS.d/next/Tests/2018-05-10-16-59-15.bpo-32962.S-rcIN.rst
+++ b/Misc/NEWS.d/next/Tests/2018-05-10-16-59-15.bpo-32962.S-rcIN.rst
@@ -1,0 +1,1 @@
+Fixed test_gdb when Python is compiled with flags -mcet -fcf-protection -O0.


### PR DESCRIPTION
When Python is built with the intel control-flow protection flags,
-mcet -fcf-protection, gdb is not able to read the stack without
actually jumping inside the function. This means an extra
'next' command is required to make the $pc (program counter)
enter the function and make the stack of the function exposed to gdb.

<!-- issue-number: [bpo-32962](https://www.bugs.python.org/issue32962) -->
https://bugs.python.org/issue32962
<!-- /issue-number -->
