### PR TITLE
bpo-34728: Fix asyncio tests to run under "-Werror"

### DIFF
--- a/Lib/test/test_asyncgen.py
+++ b/Lib/test/test_asyncgen.py
@@ -395,9 +395,9 @@ class AsyncGenAsyncioTest(unittest.TestCase):
     def test_async_gen_asyncio_01(self):
         async def gen():
             yield 1
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             yield 2
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             return
             yield 3
 
@@ -407,7 +407,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
     def test_async_gen_asyncio_02(self):
         async def gen():
             yield 1
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             yield 2
             1 / 0
             yield 3
@@ -421,7 +421,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         class Gen:
             async def __aiter__(self):
                 yield 1
-                await asyncio.sleep(0.01, loop=loop)
+                await asyncio.sleep(0.01)
                 yield 2
 
         res = loop.run_until_complete(self.to_list(Gen()))
@@ -430,13 +430,13 @@ class AsyncGenAsyncioTest(unittest.TestCase):
     def test_async_gen_asyncio_anext_04(self):
         async def foo():
             yield 1
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             try:
                 yield 2
                 yield 3
             except ZeroDivisionError:
                 yield 1000
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             yield 4
 
         async def run1():
@@ -587,7 +587,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
                 yield 1
                 1 / 0
             finally:
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 yield 12
 
         async def run():
@@ -610,8 +610,8 @@ class AsyncGenAsyncioTest(unittest.TestCase):
                 yield 1
                 1 / 0
             finally:
-                await asyncio.sleep(0.01, loop=self.loop)
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.01)
                 DONE += 1
             DONE += 1000
 
@@ -637,8 +637,8 @@ class AsyncGenAsyncioTest(unittest.TestCase):
                 DONE += 1000
                 yield 2
             finally:
-                await asyncio.sleep(0.01, loop=self.loop)
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.01)
                 DONE += 1
             DONE += 1000
 
@@ -647,7 +647,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
             it = gen.__aiter__()
             self.assertEqual(await it.__anext__(), 1)
             t = self.loop.create_task(it.__anext__())
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             await gen.aclose()
             return t
 
@@ -657,7 +657,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         # Silence ResourceWarnings
         fut.cancel()
         t.cancel()
-        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.01))
 
     def test_async_gen_asyncio_gc_aclose_09(self):
         DONE = 0
@@ -668,8 +668,8 @@ class AsyncGenAsyncioTest(unittest.TestCase):
                 while True:
                     yield 1
             finally:
-                await asyncio.sleep(0.01, loop=self.loop)
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.01)
                 DONE = 1
 
         async def run():
@@ -678,7 +678,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
             await g.__anext__()
             del g
 
-            await asyncio.sleep(0.1, loop=self.loop)
+            await asyncio.sleep(0.1)
 
         self.loop.run_until_complete(run())
         self.assertEqual(DONE, 1)
@@ -769,15 +769,15 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         async def gen():
             nonlocal DONE
             try:
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 v = yield 1
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 yield v * 2
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 return
             finally:
-                await asyncio.sleep(0.01, loop=self.loop)
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.01)
                 DONE = 1
 
         async def run():
@@ -799,20 +799,20 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         DONE = 0
 
         async def sleep_n_crash(delay):
-            await asyncio.sleep(delay, loop=self.loop)
+            await asyncio.sleep(delay)
             1 / 0
 
         async def gen():
             nonlocal DONE
             try:
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 v = yield 1
                 await sleep_n_crash(0.01)
                 DONE += 1000
                 yield v * 2
             finally:
-                await asyncio.sleep(0.01, loop=self.loop)
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.01)
                 DONE = 1
 
         async def run():
@@ -831,7 +831,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         DONE = 0
 
         async def sleep_n_crash(delay):
-            fut = asyncio.ensure_future(asyncio.sleep(delay, loop=self.loop),
+            fut = asyncio.ensure_future(asyncio.sleep(delay),
                                         loop=self.loop)
             self.loop.call_later(delay / 2, lambda: fut.cancel())
             return await fut
@@ -839,14 +839,14 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         async def gen():
             nonlocal DONE
             try:
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 v = yield 1
                 await sleep_n_crash(0.01)
                 DONE += 1000
                 yield v * 2
             finally:
-                await asyncio.sleep(0.01, loop=self.loop)
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.01)
                 DONE = 1
 
         async def run():
@@ -885,18 +885,18 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         async def gen():
             nonlocal DONE
             try:
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 try:
                     v = yield 1
                 except FooEr:
                     v = 1000
-                    await asyncio.sleep(0.01, loop=self.loop)
+                    await asyncio.sleep(0.01)
                 yield v * 2
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 # return
             finally:
-                await asyncio.sleep(0.01, loop=self.loop)
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.01)
                 DONE = 1
 
         async def run():
@@ -921,7 +921,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
             pass
 
         async def sleep_n_crash(delay):
-            fut = asyncio.ensure_future(asyncio.sleep(delay, loop=self.loop),
+            fut = asyncio.ensure_future(asyncio.sleep(delay),
                                         loop=self.loop)
             self.loop.call_later(delay / 2, lambda: fut.cancel())
             return await fut
@@ -929,17 +929,17 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         async def gen():
             nonlocal DONE
             try:
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 try:
                     v = yield 1
                 except FooEr:
                     await sleep_n_crash(0.01)
                 yield v * 2
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 # return
             finally:
-                await asyncio.sleep(0.01, loop=self.loop)
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
+                await asyncio.sleep(0.01)
                 DONE = 1
 
         async def run():
@@ -1038,10 +1038,10 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         async def waiter(timeout):
             nonlocal finalized
             try:
-                await asyncio.sleep(timeout, loop=self.loop)
+                await asyncio.sleep(timeout)
                 yield 1
             finally:
-                await asyncio.sleep(0, loop=self.loop)
+                await asyncio.sleep(0)
                 finalized += 1
 
         async def wait():
@@ -1051,7 +1051,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         t1 = self.loop.create_task(wait())
         t2 = self.loop.create_task(wait())
 
-        self.loop.run_until_complete(asyncio.sleep(0.1, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.1))
 
         self.loop.run_until_complete(self.loop.shutdown_asyncgens())
         self.assertEqual(finalized, 2)
@@ -1059,7 +1059,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
         # Silence warnings
         t1.cancel()
         t2.cancel()
-        self.loop.run_until_complete(asyncio.sleep(0.1, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.1))
 
     def test_async_gen_asyncio_shutdown_02(self):
         logged = 0
@@ -1073,7 +1073,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
 
         async def waiter(timeout):
             try:
-                await asyncio.sleep(timeout, loop=self.loop)
+                await asyncio.sleep(timeout)
                 yield 1
             finally:
                 1 / 0
@@ -1083,7 +1083,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
                 pass
 
         t = self.loop.create_task(wait())
-        self.loop.run_until_complete(asyncio.sleep(0.1, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.1))
 
         self.loop.set_exception_handler(logger)
         self.loop.run_until_complete(self.loop.shutdown_asyncgens())
@@ -1092,12 +1092,12 @@ class AsyncGenAsyncioTest(unittest.TestCase):
 
         # Silence warnings
         t.cancel()
-        self.loop.run_until_complete(asyncio.sleep(0.1, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.1))
 
     def test_async_gen_expression_01(self):
         async def arange(n):
             for i in range(n):
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 yield i
 
         def make_arange(n):
@@ -1112,7 +1112,7 @@ class AsyncGenAsyncioTest(unittest.TestCase):
 
     def test_async_gen_expression_02(self):
         async def wrap(n):
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             return n
 
         def make_arange(n):

--- a/Lib/test/test_asyncio/functional.py
+++ b/Lib/test/test_asyncio/functional.py
@@ -15,7 +15,7 @@ class FunctionalTestCaseMixin:
         return asyncio.new_event_loop()
 
     def run_loop_briefly(self, *, delay=0.01):
-        self.loop.run_until_complete(asyncio.sleep(delay, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(delay))
 
     def loop_exception_handler(self, loop, context):
         self.__unhandled_exceptions.append(context)

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -482,7 +482,7 @@ class BaseEventLoopTests(test_utils.TestCase):
             pass
 
         async def foo(delay):
-            await asyncio.sleep(delay, loop=self.loop)
+            await asyncio.sleep(delay)
 
         def throw():
             raise ShowStopper
@@ -579,7 +579,7 @@ class BaseEventLoopTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def zero_error_coro():
-            yield from asyncio.sleep(0.01, loop=self.loop)
+            yield from asyncio.sleep(0.01)
             1/0
 
         # Test Future.__del__

--- a/Lib/test/test_asyncio/test_buffered_proto.py
+++ b/Lib/test/test_asyncio/test_buffered_proto.py
@@ -64,7 +64,7 @@ class BaseTestBufferedProtocol(func_tests.FunctionalTestCaseMixin):
 
         addr = srv.sockets[0].getsockname()
         self.loop.run_until_complete(
-            asyncio.wait_for(client(addr), 5, loop=self.loop))
+            asyncio.wait_for(client(addr), 5))
 
         srv.close()
         self.loop.run_until_complete(srv.wait_closed())

--- a/Lib/test/test_asyncio/test_events.py
+++ b/Lib/test/test_asyncio/test_events.py
@@ -271,7 +271,7 @@ class EventLoopTestsMixin:
 
     def test_run_until_complete(self):
         t0 = self.loop.time()
-        self.loop.run_until_complete(asyncio.sleep(0.1, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.1))
         t1 = self.loop.time()
         self.assertTrue(0.08 <= t1-t0 <= 0.8, t1-t0)
 
@@ -279,7 +279,7 @@ class EventLoopTestsMixin:
 
         async def cb():
             self.loop.stop()
-            await asyncio.sleep(0.1, loop=self.loop)
+            await asyncio.sleep(0.1)
         task = cb()
         self.assertRaises(RuntimeError,
                           self.loop.run_until_complete, task)
@@ -1757,11 +1757,11 @@ class EventLoopTestsMixin:
 
         async def wait():
             loop = self.loop
-            await asyncio.sleep(1e-2, loop=loop)
-            await asyncio.sleep(1e-4, loop=loop)
-            await asyncio.sleep(1e-6, loop=loop)
-            await asyncio.sleep(1e-8, loop=loop)
-            await asyncio.sleep(1e-10, loop=loop)
+            await asyncio.sleep(1e-2)
+            await asyncio.sleep(1e-4)
+            await asyncio.sleep(1e-6)
+            await asyncio.sleep(1e-8)
+            await asyncio.sleep(1e-10)
 
         self.loop.run_until_complete(wait())
         # The ideal number of call is 12, but on some platforms, the selector

--- a/Lib/test/test_asyncio/test_locks.py
+++ b/Lib/test/test_asyncio/test_locks.py
@@ -81,13 +81,13 @@ class LockTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def test(lock):
-            yield from asyncio.sleep(0.01, loop=loop)
+            yield from asyncio.sleep(0.01)
             self.assertFalse(lock.locked())
             with self.assertWarns(DeprecationWarning):
                 with (yield from lock) as _lock:
                     self.assertIs(_lock, None)
                     self.assertTrue(lock.locked())
-                    yield from asyncio.sleep(0.01, loop=loop)
+                    yield from asyncio.sleep(0.01)
                     self.assertTrue(lock.locked())
                 self.assertFalse(lock.locked())
 
@@ -819,8 +819,7 @@ class ConditionTests(test_utils.TestCase):
             condition = asyncio.Condition(loop=loop)
             async with condition:
                 with self.assertRaises(asyncio.TimeoutError):
-                    await asyncio.wait_for(condition.wait(), timeout=0.5,
-                                           loop=loop)
+                    await asyncio.wait_for(condition.wait(), timeout=0.5)
 
         loop.run_until_complete(task_timeout())
 

--- a/Lib/test/test_asyncio/test_pep492.py
+++ b/Lib/test/test_asyncio/test_pep492.py
@@ -52,12 +52,12 @@ class LockTests(BaseTest):
         ]
 
         async def test(lock):
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             self.assertFalse(lock.locked())
             async with lock as _lock:
                 self.assertIs(_lock, None)
                 self.assertTrue(lock.locked())
-                await asyncio.sleep(0.01, loop=self.loop)
+                await asyncio.sleep(0.01)
                 self.assertTrue(lock.locked())
             self.assertFalse(lock.locked())
 
@@ -74,13 +74,13 @@ class LockTests(BaseTest):
         ]
 
         async def test(lock):
-            await asyncio.sleep(0.01, loop=self.loop)
+            await asyncio.sleep(0.01)
             self.assertFalse(lock.locked())
             with self.assertWarns(DeprecationWarning):
                 with await lock as _lock:
                     self.assertIs(_lock, None)
                     self.assertTrue(lock.locked())
-                    await asyncio.sleep(0.01, loop=self.loop)
+                    await asyncio.sleep(0.01)
                     self.assertTrue(lock.locked())
                 self.assertFalse(lock.locked())
 
@@ -198,13 +198,13 @@ class CoroutineTests(BaseTest):
 
     def test_double_await(self):
         async def afunc():
-            await asyncio.sleep(0.1, loop=self.loop)
+            await asyncio.sleep(0.1)
 
         async def runner():
             coro = afunc()
             t = asyncio.Task(coro, loop=self.loop)
             try:
-                await asyncio.sleep(0, loop=self.loop)
+                await asyncio.sleep(0)
                 await coro
             finally:
                 t.cancel()

--- a/Lib/test/test_asyncio/test_queues.py
+++ b/Lib/test/test_asyncio/test_queues.py
@@ -45,7 +45,7 @@ class QueueBasicTests(_QueueTestBase):
             # Start a task that waits to get.
             asyncio.Task(q.get(), loop=loop)
             # Let it start waiting.
-            await asyncio.sleep(0.1, loop=loop)
+            await asyncio.sleep(0.1)
             self.assertTrue('_getters[1]' in fn(q))
             # resume q.get coroutine to finish generator
             q.put_nowait(0)
@@ -58,7 +58,7 @@ class QueueBasicTests(_QueueTestBase):
             # Start a task that waits to put.
             asyncio.Task(q.put(2), loop=loop)
             # Let it start waiting.
-            await asyncio.sleep(0.1, loop=loop)
+            await asyncio.sleep(0.1)
             self.assertTrue('_putters[1]' in fn(q))
             # resume q.put coroutine to finish generator
             q.get_nowait()
@@ -135,14 +135,14 @@ class QueueBasicTests(_QueueTestBase):
 
         async def test():
             t = asyncio.Task(putter(), loop=loop)
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
 
             # The putter is blocked after putting two items.
             self.assertEqual([0, 1], have_been_put)
             self.assertEqual(0, q.get_nowait())
 
             # Let the putter resume and put last item.
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
             self.assertEqual([0, 1, 2], have_been_put)
             self.assertEqual(1, q.get_nowait())
             self.assertEqual(2, q.get_nowait())
@@ -234,11 +234,11 @@ class QueueGetTests(_QueueTestBase):
         q = asyncio.Queue(loop=loop)
 
         async def queue_get():
-            return await asyncio.wait_for(q.get(), 0.051, loop=loop)
+            return await asyncio.wait_for(q.get(), 0.051)
 
         async def test():
             get_task = asyncio.Task(queue_get(), loop=loop)
-            await asyncio.sleep(0.01, loop=loop)  # let the task start
+            await asyncio.sleep(0.01)  # let the task start
             q.put_nowait(1)
             return await get_task
 
@@ -297,7 +297,7 @@ class QueueGetTests(_QueueTestBase):
 
         async def consumer(queue):
             try:
-                item = await asyncio.wait_for(queue.get(), 0.1, loop=self.loop)
+                item = await asyncio.wait_for(queue.get(), 0.1)
             except asyncio.TimeoutError:
                 pass
 
@@ -364,7 +364,7 @@ class QueuePutTests(_QueueTestBase):
 
         reader = loop.create_task(q.get())
 
-        loop.run_until_complete(asyncio.sleep(0.01, loop=loop))
+        loop.run_until_complete(asyncio.sleep(0.01))
 
         q.put_nowait(1)
         q.put_nowait(2)
@@ -395,7 +395,7 @@ class QueuePutTests(_QueueTestBase):
         reader2 = loop.create_task(q.get())
         reader3 = loop.create_task(q.get())
 
-        loop.run_until_complete(asyncio.sleep(0.01, loop=loop))
+        loop.run_until_complete(asyncio.sleep(0.01))
 
         q.put_nowait(1)
         q.put_nowait(2)
@@ -424,7 +424,7 @@ class QueuePutTests(_QueueTestBase):
 
         # putting a second item in the queue has to block (qsize=1)
         writer = loop.create_task(q.put(2))
-        loop.run_until_complete(asyncio.sleep(0.01, loop=loop))
+        loop.run_until_complete(asyncio.sleep(0.01))
 
         value1 = q.get_nowait()
         self.assertEqual(value1, 1)
@@ -512,7 +512,7 @@ class QueuePutTests(_QueueTestBase):
             await queue.put(item)
 
         async def getter():
-            await asyncio.sleep(0, loop=self.loop)
+            await asyncio.sleep(0)
             num = queue.qsize()
             for _ in range(num):
                 item = queue.get_nowait()
@@ -537,7 +537,7 @@ class QueuePutTests(_QueueTestBase):
 
         # Task waiting for space to put an item in the queue.
         put_task = loop.create_task(queue.put(1))
-        loop.run_until_complete(asyncio.sleep(0.01, loop=loop))
+        loop.run_until_complete(asyncio.sleep(0.01))
 
         # Check that the putter is correctly removed from queue._putters when
         # the task is canceled.
@@ -560,7 +560,7 @@ class QueuePutTests(_QueueTestBase):
 
         # Task waiting for space to put a item in the queue.
         put_task = loop.create_task(queue.put(1))
-        loop.run_until_complete(asyncio.sleep(0.01, loop=loop))
+        loop.run_until_complete(asyncio.sleep(0.01))
 
         # get_nowait() remove the future of put_task from queue._putters.
         queue.get_nowait()
@@ -638,7 +638,7 @@ class _QueueJoinTestMixin:
         running = False
         for i in range(len(tasks)):
             q.put_nowait(0)
-        self.loop.run_until_complete(asyncio.wait(tasks, loop=self.loop))
+        self.loop.run_until_complete(asyncio.wait(tasks))
 
     def test_join_empty_queue(self):
         q = self.q_class(loop=self.loop)

--- a/Lib/test/test_asyncio/test_selector_events.py
+++ b/Lib/test/test_asyncio/test_selector_events.py
@@ -195,7 +195,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         self.loop._sock_recv = mock.Mock()
 
         f = self.loop.create_task(self.loop.sock_recv(sock, 1024))
-        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.01))
 
         self.assertEqual(self.loop._sock_recv.call_args[0][1:],
                          (None, sock, 1024))
@@ -215,7 +215,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         fut = self.loop.create_task(
             self.loop.sock_recv(sock, 1024))
 
-        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.01))
 
         callback = self.loop.add_reader.call_args[0][1]
         params = self.loop.add_reader.call_args[0][2:]
@@ -226,7 +226,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock.recv.side_effect = OSError(9)
         callback(*params)
 
-        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.01))
 
         self.assertIsInstance(fut.exception(), OSError)
         self.assertEqual((10,), self.loop.remove_reader.call_args[0])
@@ -278,7 +278,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         f = self.loop.create_task(
             self.loop.sock_sendall(sock, b'data'))
 
-        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.01))
 
         self.assertEqual(
             (None, sock, b'data'),
@@ -293,7 +293,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         self.loop._sock_sendall = mock.Mock()
 
         f = self.loop.create_task(self.loop.sock_sendall(sock, b''))
-        self.loop.run_until_complete(asyncio.sleep(0, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0))
 
         self.assertTrue(f.done())
         self.assertIsNone(f.result())
@@ -309,7 +309,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         self.loop.remove_writer = mock.Mock()
         fut = self.loop.create_task(self.loop.sock_sendall(sock, b'data'))
 
-        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.01))
 
         callback = self.loop.add_writer.call_args[0][1]
         params = self.loop.add_writer.call_args[0][2:]
@@ -320,7 +320,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         sock.send.side_effect = OSError(9)
         callback(*params)
 
-        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.01))
 
         self.assertIsInstance(fut.exception(), OSError)
         self.assertEqual((10,), self.loop.remove_writer.call_args[0])
@@ -531,7 +531,7 @@ class BaseSelectorEventLoopTests(test_utils.TestCase):
         self.loop._sock_accept = mock.Mock()
 
         f = self.loop.create_task(self.loop.sock_accept(sock))
-        self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
+        self.loop.run_until_complete(asyncio.sleep(0.01))
 
         self.assertFalse(self.loop._sock_accept.call_args[0][1])
         self.assertIs(self.loop._sock_accept.call_args[0][2], sock)

--- a/Lib/test/test_asyncio/test_sslproto.py
+++ b/Lib/test/test_asyncio/test_sslproto.py
@@ -252,7 +252,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                 self.on_eof.set_result(True)
 
         async def client(addr):
-            await asyncio.sleep(0.5, loop=self.loop)
+            await asyncio.sleep(0.5)
 
             on_data = self.loop.create_future()
             on_eof = self.loop.create_future()
@@ -271,7 +271,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
 
         with self.tcp_server(serve, timeout=self.TIMEOUT) as srv:
             self.loop.run_until_complete(
-                asyncio.wait_for(client(srv.addr), loop=self.loop, timeout=10))
+                asyncio.wait_for(client(srv.addr), timeout=10))
 
     def test_start_tls_client_buf_proto_1(self):
         HELLO_MSG = b'1' * self.PAYLOAD_SIZE
@@ -332,7 +332,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                 self.on_eof.set_result(True)
 
         async def client(addr):
-            await asyncio.sleep(0.5, loop=self.loop)
+            await asyncio.sleep(0.5)
 
             on_data1 = self.loop.create_future()
             on_data2 = self.loop.create_future()
@@ -362,7 +362,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
         with self.tcp_server(serve, timeout=self.TIMEOUT) as srv:
             self.loop.run_until_complete(
                 asyncio.wait_for(client(srv.addr),
-                                 loop=self.loop, timeout=self.TIMEOUT))
+                                 timeout=self.TIMEOUT))
 
     def test_start_tls_slow_client_cancel(self):
         HELLO_MSG = b'1' * self.PAYLOAD_SIZE
@@ -403,7 +403,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                 self.on_eof.set_result(True)
 
         async def client(addr):
-            await asyncio.sleep(0.5, loop=self.loop)
+            await asyncio.sleep(0.5)
 
             on_data = self.loop.create_future()
             on_eof = self.loop.create_future()
@@ -418,12 +418,11 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
             with self.assertRaises(asyncio.TimeoutError):
                 await asyncio.wait_for(
                     self.loop.start_tls(tr, proto, client_context),
-                    0.5,
-                    loop=self.loop)
+                    0.5)
 
         with self.tcp_server(serve, timeout=self.TIMEOUT) as srv:
             self.loop.run_until_complete(
-                asyncio.wait_for(client(srv.addr), loop=self.loop, timeout=10))
+                asyncio.wait_for(client(srv.addr), timeout=10))
 
     def test_start_tls_server_1(self):
         HELLO_MSG = b'1' * self.PAYLOAD_SIZE
@@ -496,7 +495,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                                  timeout=self.TIMEOUT):
                 await asyncio.wait_for(
                     main(proto, on_con, on_eof, on_con_lost),
-                    loop=self.loop, timeout=self.TIMEOUT)
+                    timeout=self.TIMEOUT)
 
             server.close()
             await server.wait_closed()
@@ -541,8 +540,7 @@ class BaseStartTLS(func_tests.FunctionalTestCaseMixin):
                     ssl=client_sslctx,
                     server_hostname='',
                     ssl_handshake_timeout=10.0),
-                0.5,
-                loop=self.loop)
+                0.5)
 
         with self.tcp_server(server,
                              max_clients=1,

--- a/Lib/test/test_asyncio/test_streams.py
+++ b/Lib/test/test_asyncio/test_streams.py
@@ -560,7 +560,7 @@ class StreamTests(test_utils.TestCase):
         t1 = asyncio.Task(stream.readline(), loop=self.loop)
         t2 = asyncio.Task(set_err(), loop=self.loop)
 
-        self.loop.run_until_complete(asyncio.wait([t1, t2], loop=self.loop))
+        self.loop.run_until_complete(asyncio.wait([t1, t2]))
 
         self.assertRaises(ValueError, t1.result)
 

--- a/Lib/test/test_asyncio/test_subprocess.py
+++ b/Lib/test/test_asyncio/test_subprocess.py
@@ -126,7 +126,7 @@ class SubprocessMixin:
             return (exitcode, data)
 
         task = run(b'some data')
-        task = asyncio.wait_for(task, 60.0, loop=self.loop)
+        task = asyncio.wait_for(task, 60.0)
         exitcode, stdout = self.loop.run_until_complete(task)
         self.assertEqual(exitcode, 0)
         self.assertEqual(stdout, b'some data')
@@ -144,7 +144,7 @@ class SubprocessMixin:
             return proc.returncode, stdout
 
         task = run(b'some data')
-        task = asyncio.wait_for(task, 60.0, loop=self.loop)
+        task = asyncio.wait_for(task, 60.0)
         exitcode, stdout = self.loop.run_until_complete(task)
         self.assertEqual(exitcode, 0)
         self.assertEqual(stdout, b'some data')
@@ -233,7 +233,7 @@ class SubprocessMixin:
         proc, large_data = self.prepare_broken_pipe_test()
 
         async def write_stdin(proc, data):
-            await asyncio.sleep(0.5, loop=self.loop)
+            await asyncio.sleep(0.5)
             proc.stdin.write(data)
             await proc.stdin.drain()
 
@@ -504,7 +504,7 @@ class SubprocessMixin:
             while True:
                 data = await process.stdout.read(65536)
                 if data:
-                    await asyncio.sleep(0.3, loop=self.loop)
+                    await asyncio.sleep(0.3)
                 else:
                     break
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -45,7 +45,6 @@ def set_coroutine_debug(enabled):
         coroutines._DEBUG = old_debug
 
 
-
 def format_coroutine(qualname, state, src, source_traceback, generator=False):
     if generator:
         state = '%s' % state
@@ -472,7 +471,7 @@ class BaseTaskTests:
         loop = self.new_test_loop(gen)
 
         async def task():
-            await asyncio.sleep(10.0, loop=loop)
+            await asyncio.sleep(10.0)
             return 12
 
         t = self.new_task(loop, task())
@@ -595,7 +594,7 @@ class BaseTaskTests:
             t.cancel()
             self.assertTrue(t._must_cancel)  # White-box test.
             # The sleep should be cancelled immediately.
-            await asyncio.sleep(100, loop=loop)
+            await asyncio.sleep(100)
             return 12
 
         t = self.new_task(loop, task())
@@ -641,7 +640,7 @@ class BaseTaskTests:
         async def task():
             nonlocal x
             while x < 10:
-                await asyncio.sleep(0.1, loop=loop)
+                await asyncio.sleep(0.1)
                 x += 1
                 if x == 2:
                     loop.stop()
@@ -677,7 +676,7 @@ class BaseTaskTests:
         fut = self.new_future(loop)
         fut.set_result('done')
 
-        ret = loop.run_until_complete(asyncio.wait_for(fut, 0, loop=loop))
+        ret = loop.run_until_complete(asyncio.wait_for(fut, 0))
 
         self.assertEqual(ret, 'done')
         self.assertTrue(fut.done())
@@ -698,7 +697,7 @@ class BaseTaskTests:
             foo_started = True
 
         with self.assertRaises(asyncio.TimeoutError):
-            loop.run_until_complete(asyncio.wait_for(foo(), 0, loop=loop))
+            loop.run_until_complete(asyncio.wait_for(foo(), 0))
 
         self.assertAlmostEqual(0, loop.time())
         self.assertEqual(foo_started, False)
@@ -720,7 +719,7 @@ class BaseTaskTests:
                     nonlocal foo_running
                     foo_running = True
                     try:
-                        await asyncio.sleep(0.2, loop=loop)
+                        await asyncio.sleep(0.2)
                     finally:
                         foo_running = False
                     return 'done'
@@ -728,8 +727,7 @@ class BaseTaskTests:
                 fut = self.new_task(loop, foo())
 
                 with self.assertRaises(asyncio.TimeoutError):
-                    loop.run_until_complete(asyncio.wait_for(
-                        fut, timeout, loop=loop))
+                    loop.run_until_complete(asyncio.wait_for(fut, timeout))
                 self.assertTrue(fut.done())
                 # it should have been cancelled due to the timeout
                 self.assertTrue(fut.cancelled())
@@ -753,7 +751,7 @@ class BaseTaskTests:
             nonlocal foo_running
             foo_running = True
             try:
-                await asyncio.sleep(0.2, loop=loop)
+                await asyncio.sleep(0.2)
             finally:
                 foo_running = False
             return 'done'
@@ -761,7 +759,7 @@ class BaseTaskTests:
         fut = self.new_task(loop, foo())
 
         with self.assertRaises(asyncio.TimeoutError):
-            loop.run_until_complete(asyncio.wait_for(fut, 0.1, loop=loop))
+            loop.run_until_complete(asyncio.wait_for(fut, 0.1))
         self.assertTrue(fut.done())
         # it should have been cancelled due to the timeout
         self.assertTrue(fut.cancelled())
@@ -775,9 +773,7 @@ class BaseTaskTests:
         def coro():
             return 'done'
 
-        res = loop.run_until_complete(asyncio.wait_for(coro(),
-                                                       timeout=None,
-                                                       loop=loop))
+        res = loop.run_until_complete(asyncio.wait_for(coro(), timeout=None))
         self.assertEqual(res, 'done')
 
     def test_wait_for_with_global_loop(self):
@@ -792,7 +788,7 @@ class BaseTaskTests:
         loop = self.new_test_loop(gen)
 
         async def foo():
-            await asyncio.sleep(0.2, loop=loop)
+            await asyncio.sleep(0.2)
             return 'done'
 
         asyncio.set_event_loop(loop)
@@ -817,7 +813,7 @@ class BaseTaskTests:
         loop = self.new_test_loop(gen)
 
         fut = self.new_future(loop)
-        task = asyncio.wait_for(fut, timeout=0.2, loop=loop)
+        task = asyncio.wait_for(fut, timeout=0.2)
         loop.call_later(0.1, fut.set_result, "ok")
         res = loop.run_until_complete(task)
         self.assertEqual(res, "ok")
@@ -832,14 +828,14 @@ class BaseTaskTests:
             async def inner():
                 nonlocal task_done
                 try:
-                    await asyncio.sleep(0.2, loop=loop)
+                    await asyncio.sleep(0.2)
                 finally:
                     task_done = True
 
             inner_task = self.new_task(loop, inner())
 
             with self.assertRaises(asyncio.TimeoutError):
-                await asyncio.wait_for(inner_task, timeout=0.1, loop=loop)
+                await asyncio.wait_for(inner_task, timeout=0.1)
 
             self.assertTrue(task_done)
 
@@ -852,23 +848,23 @@ class BaseTaskTests:
         async def foo():
             async def inner():
                 try:
-                    await asyncio.sleep(0.3, loop=loop)
+                    await asyncio.sleep(0.3)
                 except asyncio.CancelledError:
                     try:
-                        await asyncio.sleep(0.3, loop=loop)
+                        await asyncio.sleep(0.3)
                     except asyncio.CancelledError:
-                        await asyncio.sleep(0.3, loop=loop)
+                        await asyncio.sleep(0.3)
 
                 return 42
 
             inner_task = self.new_task(loop, inner())
 
-            wait = asyncio.wait_for(inner_task, timeout=0.1, loop=loop)
+            wait = asyncio.wait_for(inner_task, timeout=0.1)
 
             # Test that wait_for itself is properly cancellable
             # even when the initial task holds up the initial cancellation.
             task = self.new_task(loop, wait)
-            await asyncio.sleep(0.2, loop=loop)
+            await asyncio.sleep(0.2)
             task.cancel()
 
             with self.assertRaises(asyncio.CancelledError):
@@ -889,11 +885,11 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = self.new_task(loop, asyncio.sleep(0.1, loop=loop))
-        b = self.new_task(loop, asyncio.sleep(0.15, loop=loop))
+        a = self.new_task(loop, asyncio.sleep(0.1))
+        b = self.new_task(loop, asyncio.sleep(0.15))
 
         async def foo():
-            done, pending = await asyncio.wait([b, a], loop=loop)
+            done, pending = await asyncio.wait([b, a])
             self.assertEqual(done, set([a, b]))
             self.assertEqual(pending, set())
             return 42
@@ -918,8 +914,8 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = self.new_task(loop, asyncio.sleep(0.01, loop=loop))
-        b = self.new_task(loop, asyncio.sleep(0.015, loop=loop))
+        a = self.new_task(loop, asyncio.sleep(0.01))
+        b = self.new_task(loop, asyncio.sleep(0.015))
 
         async def foo():
             done, pending = await asyncio.wait([b, a])
@@ -942,7 +938,7 @@ class BaseTaskTests:
 
         task =self.new_task(
             self.loop,
-            asyncio.wait([c, c, coro('spam')], loop=self.loop))
+            asyncio.wait([c, c, coro('spam')]))
 
         done, pending = self.loop.run_until_complete(task)
 
@@ -952,11 +948,11 @@ class BaseTaskTests:
     def test_wait_errors(self):
         self.assertRaises(
             ValueError, self.loop.run_until_complete,
-            asyncio.wait(set(), loop=self.loop))
+            asyncio.wait(set()))
 
         # -1 is an invalid return_when value
-        sleep_coro = asyncio.sleep(10.0, loop=self.loop)
-        wait_coro = asyncio.wait([sleep_coro], return_when=-1, loop=self.loop)
+        sleep_coro = asyncio.sleep(10.0)
+        wait_coro = asyncio.wait([sleep_coro], return_when=-1)
         self.assertRaises(ValueError,
                           self.loop.run_until_complete, wait_coro)
 
@@ -973,12 +969,11 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = self.new_task(loop, asyncio.sleep(10.0, loop=loop))
-        b = self.new_task(loop, asyncio.sleep(0.1, loop=loop))
+        a = self.new_task(loop, asyncio.sleep(10.0))
+        b = self.new_task(loop, asyncio.sleep(0.1))
         task = self.new_task(
             loop,
-            asyncio.wait([b, a], return_when=asyncio.FIRST_COMPLETED,
-                         loop=loop))
+            asyncio.wait([b, a], return_when=asyncio.FIRST_COMPLETED))
 
         done, pending = loop.run_until_complete(task)
         self.assertEqual({b}, done)
@@ -990,7 +985,7 @@ class BaseTaskTests:
 
         # move forward to close generator
         loop.advance_time(10)
-        loop.run_until_complete(asyncio.wait([a, b], loop=loop))
+        loop.run_until_complete(asyncio.wait([a, b]))
 
     def test_wait_really_done(self):
         # there is possibility that some tasks in the pending list
@@ -1009,8 +1004,7 @@ class BaseTaskTests:
         b = self.new_task(self.loop, coro2())
         task = self.new_task(
             self.loop,
-            asyncio.wait([b, a], return_when=asyncio.FIRST_COMPLETED,
-                         loop=self.loop))
+            asyncio.wait([b, a], return_when=asyncio.FIRST_COMPLETED))
 
         done, pending = self.loop.run_until_complete(task)
         self.assertEqual({a, b}, done)
@@ -1029,7 +1023,7 @@ class BaseTaskTests:
         loop = self.new_test_loop(gen)
 
         # first_exception, task already has exception
-        a = self.new_task(loop, asyncio.sleep(10.0, loop=loop))
+        a = self.new_task(loop, asyncio.sleep(10.0))
 
         @asyncio.coroutine
         def exc():
@@ -1038,8 +1032,7 @@ class BaseTaskTests:
         b = self.new_task(loop, exc())
         task = self.new_task(
             loop,
-            asyncio.wait([b, a], return_when=asyncio.FIRST_EXCEPTION,
-                         loop=loop))
+            asyncio.wait([b, a], return_when=asyncio.FIRST_EXCEPTION))
 
         done, pending = loop.run_until_complete(task)
         self.assertEqual({b}, done)
@@ -1048,7 +1041,7 @@ class BaseTaskTests:
 
         # move forward to close generator
         loop.advance_time(10)
-        loop.run_until_complete(asyncio.wait([a, b], loop=loop))
+        loop.run_until_complete(asyncio.wait([a, b]))
 
     def test_wait_first_exception_in_wait(self):
 
@@ -1062,15 +1055,14 @@ class BaseTaskTests:
         loop = self.new_test_loop(gen)
 
         # first_exception, exception during waiting
-        a = self.new_task(loop, asyncio.sleep(10.0, loop=loop))
+        a = self.new_task(loop, asyncio.sleep(10.0))
 
         async def exc():
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
             raise ZeroDivisionError('err')
 
         b = self.new_task(loop, exc())
-        task = asyncio.wait([b, a], return_when=asyncio.FIRST_EXCEPTION,
-                            loop=loop)
+        task = asyncio.wait([b, a], return_when=asyncio.FIRST_EXCEPTION)
 
         done, pending = loop.run_until_complete(task)
         self.assertEqual({b}, done)
@@ -1079,7 +1071,7 @@ class BaseTaskTests:
 
         # move forward to close generator
         loop.advance_time(10)
-        loop.run_until_complete(asyncio.wait([a, b], loop=loop))
+        loop.run_until_complete(asyncio.wait([a, b]))
 
     def test_wait_with_exception(self):
 
@@ -1092,17 +1084,17 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = self.new_task(loop, asyncio.sleep(0.1, loop=loop))
+        a = self.new_task(loop, asyncio.sleep(0.1))
 
         @asyncio.coroutine
         def sleeper():
-            yield from asyncio.sleep(0.15, loop=loop)
+            yield from asyncio.sleep(0.15)
             raise ZeroDivisionError('really')
 
         b = self.new_task(loop, sleeper())
 
         async def foo():
-            done, pending = await asyncio.wait([b, a], loop=loop)
+            done, pending = await asyncio.wait([b, a])
             self.assertEqual(len(done), 2)
             self.assertEqual(pending, set())
             errors = set(f for f in done if f.exception() is not None)
@@ -1127,12 +1119,11 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = self.new_task(loop, asyncio.sleep(0.1, loop=loop))
-        b = self.new_task(loop, asyncio.sleep(0.15, loop=loop))
+        a = self.new_task(loop, asyncio.sleep(0.1))
+        b = self.new_task(loop, asyncio.sleep(0.15))
 
         async def foo():
-            done, pending = await asyncio.wait([b, a], timeout=0.11,
-                                                    loop=loop)
+            done, pending = await asyncio.wait([b, a], timeout=0.11)
             self.assertEqual(done, set([a]))
             self.assertEqual(pending, set([b]))
 
@@ -1141,7 +1132,7 @@ class BaseTaskTests:
 
         # move forward to close generator
         loop.advance_time(10)
-        loop.run_until_complete(asyncio.wait([a, b], loop=loop))
+        loop.run_until_complete(asyncio.wait([a, b]))
 
     def test_wait_concurrent_complete(self):
 
@@ -1156,11 +1147,11 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = self.new_task(loop, asyncio.sleep(0.1, loop=loop))
-        b = self.new_task(loop, asyncio.sleep(0.15, loop=loop))
+        a = self.new_task(loop, asyncio.sleep(0.1))
+        b = self.new_task(loop, asyncio.sleep(0.15))
 
         done, pending = loop.run_until_complete(
-            asyncio.wait([b, a], timeout=0.1, loop=loop))
+            asyncio.wait([b, a], timeout=0.1))
 
         self.assertEqual(done, set([a]))
         self.assertEqual(pending, set([b]))
@@ -1168,7 +1159,7 @@ class BaseTaskTests:
 
         # move forward to close generator
         loop.advance_time(10)
-        loop.run_until_complete(asyncio.wait([a, b], loop=loop))
+        loop.run_until_complete(asyncio.wait([a, b]))
 
     def test_as_completed(self):
 
@@ -1187,7 +1178,7 @@ class BaseTaskTests:
         @asyncio.coroutine
         def sleeper(dt, x):
             nonlocal time_shifted
-            yield from asyncio.sleep(dt, loop=loop)
+            yield from asyncio.sleep(dt)
             completed.add(x)
             if not time_shifted and 'a' in completed and 'b' in completed:
                 time_shifted = True
@@ -1225,8 +1216,8 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = loop.create_task(asyncio.sleep(0.1, 'a', loop=loop))
-        b = loop.create_task(asyncio.sleep(0.15, 'b', loop=loop))
+        a = loop.create_task(asyncio.sleep(0.1, 'a'))
+        b = loop.create_task(asyncio.sleep(0.15, 'b'))
 
         async def foo():
             values = []
@@ -1249,7 +1240,7 @@ class BaseTaskTests:
 
         # move forward to close generator
         loop.advance_time(10)
-        loop.run_until_complete(asyncio.wait([a, b], loop=loop))
+        loop.run_until_complete(asyncio.wait([a, b]))
 
     def test_as_completed_with_unused_timeout(self):
 
@@ -1260,7 +1251,7 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = asyncio.sleep(0.01, 'a', loop=loop)
+        a = asyncio.sleep(0.01, 'a')
 
         async def foo():
             for f in asyncio.as_completed([a], timeout=1, loop=loop):
@@ -1278,8 +1269,8 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = asyncio.sleep(0.05, 'a', loop=loop)
-        b = asyncio.sleep(0.10, 'b', loop=loop)
+        a = asyncio.sleep(0.05, 'a')
+        b = asyncio.sleep(0.10, 'b')
         fs = {a, b}
         futs = list(asyncio.as_completed(fs, loop=loop))
         self.assertEqual(len(futs), 2)
@@ -1303,12 +1294,12 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        a = asyncio.sleep(0.05, 'a', loop=loop)
-        b = asyncio.sleep(0.05, 'b', loop=loop)
+        a = asyncio.sleep(0.05, 'a')
+        b = asyncio.sleep(0.05, 'b')
         fs = {a, b}
         futs = list(asyncio.as_completed(fs, loop=loop))
         self.assertEqual(len(futs), 2)
-        waiter = asyncio.wait(futs, loop=loop)
+        waiter = asyncio.wait(futs)
         done, pending = loop.run_until_complete(waiter)
         self.assertEqual(set(f.result() for f in done), {'a', 'b'})
 
@@ -1346,8 +1337,8 @@ class BaseTaskTests:
 
         @asyncio.coroutine
         def sleeper(dt, arg):
-            yield from asyncio.sleep(dt/2, loop=loop)
-            res = yield from asyncio.sleep(dt/2, arg, loop=loop)
+            yield from asyncio.sleep(dt/2)
+            res = yield from asyncio.sleep(dt/2, arg)
             return res
 
         t = self.new_task(loop, sleeper(0.1, 'yeah'))
@@ -1365,7 +1356,7 @@ class BaseTaskTests:
 
         loop = self.new_test_loop(gen)
 
-        t = self.new_task(loop, asyncio.sleep(10.0, 'yeah', loop=loop))
+        t = self.new_task(loop, asyncio.sleep(10.0, 'yeah'))
 
         handle = None
         orig_call_later = loop.call_later
@@ -1397,7 +1388,7 @@ class BaseTaskTests:
 
         @asyncio.coroutine
         def sleep(dt):
-            yield from asyncio.sleep(dt, loop=loop)
+            yield from asyncio.sleep(dt)
 
         @asyncio.coroutine
         def doit():
@@ -1502,7 +1493,7 @@ class BaseTaskTests:
 
         @asyncio.coroutine
         def sleeper():
-            yield from asyncio.sleep(10, loop=loop)
+            yield from asyncio.sleep(10)
 
         base_exc = BaseException()
 
@@ -1663,8 +1654,7 @@ class BaseTaskTests:
         task1 = self.new_task(self.loop, coro1(self.loop))
         task2 = self.new_task(self.loop, coro2(self.loop))
 
-        self.loop.run_until_complete(asyncio.wait((task1, task2),
-                                                  loop=self.loop))
+        self.loop.run_until_complete(asyncio.wait((task1, task2)))
         self.assertIsNone(asyncio.current_task(loop=self.loop))
 
     # Some thorough tests for cancellation propagation through
@@ -1714,7 +1704,7 @@ class BaseTaskTests:
 
         async def outer():
             nonlocal proof
-            d, p = await asyncio.wait([inner()], loop=self.loop)
+            d, p = await asyncio.wait([inner()])
             proof += 100
 
         f = asyncio.ensure_future(outer(), loop=self.loop)
@@ -1827,15 +1817,15 @@ class BaseTaskTests:
 
         # wait() expects a list of futures, not a future instance
         self.assertRaises(TypeError, self.loop.run_until_complete,
-            asyncio.wait(fut, loop=self.loop))
+            asyncio.wait(fut))
         coro = coroutine_function()
         self.assertRaises(TypeError, self.loop.run_until_complete,
-            asyncio.wait(coro, loop=self.loop))
+            asyncio.wait(coro))
         coro.close()
 
         # wait() expects at least a future
         self.assertRaises(ValueError, self.loop.run_until_complete,
-            asyncio.wait([], loop=self.loop))
+            asyncio.wait([]))
 
     def test_corowrapper_mocks_generator(self):
 
@@ -2027,7 +2017,7 @@ class BaseTaskTests:
         @asyncio.coroutine
         def runner():
             task = self.new_task(loop, coro())
-            yield from asyncio.sleep(0.05, loop=loop)
+            yield from asyncio.sleep(0.05)
             task.cancel()
             task = None
 
@@ -2111,7 +2101,7 @@ class BaseTaskTests:
 
         task = loop.create_task(blocking_coroutine())
 
-        wait = loop.create_task(asyncio.wait_for(task, timeout, loop=loop))
+        wait = loop.create_task(asyncio.wait_for(task, timeout))
         loop.call_soon(wait.cancel)
 
         self.assertRaises(asyncio.CancelledError,
@@ -2164,7 +2154,7 @@ class BaseTaskTests:
             time = 0
             while True:
                 time += 0.05
-                await asyncio.gather(asyncio.sleep(0.05, loop=loop),
+                await asyncio.gather(asyncio.sleep(0.05),
                                      return_exceptions=True,
                                      loop=loop)
                 if time > 1:
@@ -2172,7 +2162,7 @@ class BaseTaskTests:
 
         async def main():
             qwe = self.new_task(loop, test())
-            await asyncio.sleep(0.2, loop=loop)
+            await asyncio.sleep(0.2)
             qwe.cancel()
             try:
                 await qwe
@@ -2305,7 +2295,7 @@ class BaseTaskTests:
         cvar = contextvars.ContextVar('cvar', default='nope')
 
         async def sub():
-            await asyncio.sleep(0.01, loop=loop)
+            await asyncio.sleep(0.01)
             self.assertEqual(cvar.get(), 'nope')
             cvar.set('something else')
 
@@ -2346,7 +2336,7 @@ class BaseTaskTests:
                 for i in range(3):
                     # Test that task passed its context to add_done_callback:
                     cvar.set(f'yes{i}-{j}')
-                    await asyncio.sleep(0.001, loop=loop)
+                    await asyncio.sleep(0.001)
                     self.assertEqual(cvar.get(), f'yes{i}-{j}')
 
         loop = asyncio.new_event_loop()
@@ -2366,8 +2356,7 @@ class BaseTaskTests:
         async def sub(num):
             for i in range(10):
                 cvar.set(num + i)
-                await asyncio.sleep(
-                    random.uniform(0.001, 0.05), loop=loop)
+                await asyncio.sleep(random.uniform(0.001, 0.05))
                 self.assertEqual(cvar.get(), num + i)
 
         async def main():
@@ -2452,7 +2441,7 @@ class SetMethodsTest:
         self.loop.call_exception_handler = exc_handler = mock.Mock()
 
         async def foo():
-            await asyncio.sleep(0.1, loop=self.loop)
+            await asyncio.sleep(0.1)
             return 10
 
         coro = foo()
@@ -2479,7 +2468,7 @@ class SetMethodsTest:
         self.loop.call_exception_handler = exc_handler = mock.Mock()
 
         async def foo():
-            await asyncio.sleep(0.1, loop=self.loop)
+            await asyncio.sleep(0.1)
             return 10
 
         coro = foo()
@@ -3103,7 +3092,7 @@ class RunCoroutineThreadsafeTests(test_utils.TestCase):
     @asyncio.coroutine
     def add(self, a, b, fail=False, cancel=False):
         """Wait 0.05 second and return a + b."""
-        yield from asyncio.sleep(0.05, loop=self.loop)
+        yield from asyncio.sleep(0.05)
         if fail:
             raise RuntimeError("Fail!")
         if cancel:
@@ -3213,7 +3202,7 @@ class SleepTests(test_utils.TestCase):
         def coro():
             self.loop.call_soon(inc_result, 1)
             self.assertEqual(result, 0)
-            num = yield from asyncio.sleep(0, loop=self.loop, result=10)
+            num = yield from asyncio.sleep(0, result=10)
             self.assertEqual(result, 1) # inc'ed by call_soon
             inc_result(num) # num should be 11
 
@@ -3221,7 +3210,7 @@ class SleepTests(test_utils.TestCase):
         self.assertEqual(result, 11)
 
     def test_loop_argument_is_deprecated(self):
-        # Remove test when loop argument is removed in Python 4.0
+        # Remove test when loop argument is removed in Python 3.10
         with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(asyncio.sleep(0.01, loop=self.loop))
 
@@ -3238,13 +3227,13 @@ class WaitTests(test_utils.TestCase):
         super().tearDown()
 
     def test_loop_argument_is_deprecated_in_wait(self):
-        # Remove test when loop argument is removed in Python 4.0
+        # Remove test when loop argument is removed in Python 3.10
         with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(
                 asyncio.wait([coroutine_function()], loop=self.loop))
 
     def test_loop_argument_is_deprecated_in_wait_for(self):
-        # Remove test when loop argument is removed in Python 4.0
+        # Remove test when loop argument is removed in Python 3.10
         with self.assertWarns(DeprecationWarning):
             self.loop.run_until_complete(
                 asyncio.wait_for(coroutine_function(), 0.01, loop=self.loop))
@@ -3268,7 +3257,7 @@ class CompatibilityTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def coro():
-            yield from asyncio.sleep(0, loop=self.loop)
+            yield from asyncio.sleep(0)
             return 'ok'
 
         result = self.loop.run_until_complete(coro())
@@ -3282,7 +3271,7 @@ class CompatibilityTests(test_utils.TestCase):
 
         @asyncio.coroutine
         def coro2():
-            yield from asyncio.sleep(0, loop=self.loop)
+            yield from asyncio.sleep(0)
             return 'ok2'
 
         async def inner():

--- a/Lib/test/test_asyncio/utils.py
+++ b/Lib/test/test_asyncio/utils.py
@@ -113,7 +113,7 @@ def run_until(loop, pred, timeout=30):
             timeout = deadline - time.time()
             if timeout <= 0:
                 raise futures.TimeoutError()
-        loop.run_until_complete(tasks.sleep(0.001, loop=loop))
+        loop.run_until_complete(tasks.sleep(0.001))
 
 
 def run_once(loop):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34728](https://www.bugs.python.org/issue34728) -->
https://bugs.python.org/issue34728
<!-- /issue-number -->
