### PR TITLE
bpo-34875: change .js mimetype to text/javascript

### DIFF
--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -436,7 +436,7 @@ def _default_mime_types():
         '.jpe'    : 'image/jpeg',
         '.jpeg'   : 'image/jpeg',
         '.jpg'    : 'image/jpeg',
-        '.js'     : 'application/javascript',
+        '.js'     : 'text/javascript',
         '.json'   : 'application/json',
         '.ksh'    : 'text/plain',
         '.latex'  : 'application/x-latex',

--- a/Misc/NEWS.d/next/Library/2018-10-02-18-33-30.bpo-34875.8Js9dJ.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-02-18-33-30.bpo-34875.8Js9dJ.rst
@@ -1,0 +1,3 @@
+Change mimetype for file extension ``.js`` to ``test/javascript``. This is currently the recommended mimetype in the whatwg HTML spec
+
+https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages:javascript-mime-type

--- a/Misc/NEWS.d/next/Library/2018-10-02-18-33-30.bpo-34875.8Js9dJ.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-02-18-33-30.bpo-34875.8Js9dJ.rst
@@ -1,3 +1,3 @@
-Change mimetype for file extension ``.js`` to ``test/javascript``. This is currently the recommended mimetype in the whatwg HTML spec
+Change mimetype for file extension ``.js`` to ``text/javascript``. This is currently the recommended mimetype in the whatwg HTML spec
 
 https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages

--- a/Misc/NEWS.d/next/Library/2018-10-02-18-33-30.bpo-34875.8Js9dJ.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-02-18-33-30.bpo-34875.8Js9dJ.rst
@@ -1,3 +1,3 @@
 Change mimetype for file extension ``.js`` to ``test/javascript``. This is currently the recommended mimetype in the whatwg HTML spec
 
-https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages:javascript-mime-type
+https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages


### PR DESCRIPTION
Follow up to https://github.com/python/cpython/pull/3908

The official recommended mime type of `.js` in the [whatwg HTML spec](https://html.spec.whatwg.org/multipage/scripting.html#scriptingLanguages:javascript-mime-type) is "text/javascript" as opposed to "application/javascript" which is what is currently shipping

<!-- issue-number: [bpo-34875](https://www.bugs.python.org/issue34875) -->
https://bugs.python.org/issue34875
<!-- /issue-number -->
