### PR TITLE
bpo-34879: Fix a possible null pointer dereference in bytesobject.c

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-10-02-22-55-11.bpo-34879.7VNH2a.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-10-02-22-55-11.bpo-34879.7VNH2a.rst
@@ -1,0 +1,2 @@
+Fix a possible null pointer dereference in bytesobject.c.  Patch by Zackery
+Spytz.

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -448,7 +448,7 @@ formatfloat(PyObject *v, int flags, int prec, int type,
     result = PyBytes_FromStringAndSize(p, len);
     PyMem_Free(p);
     *p_result = result;
-    return str;
+    return result != NULL ? str : NULL;
 }
 
 static PyObject *


### PR DESCRIPTION
formatfloat() was not checking if PyBytes_FromStringAndSize()
failed, which could lead to a null pointer dereference in
_PyBytes_FormatEx().


<!-- issue-number: [bpo-34879](https://www.bugs.python.org/issue34879) -->
https://bugs.python.org/issue34879
<!-- /issue-number -->
