### PR TITLE
[2.7] bpo-34172: multiprocessing.Pool leaks resources after being deleted (GH-8450)

### DIFF
--- a/Lib/test/test_multiprocessing.py
+++ b/Lib/test/test_multiprocessing.py
@@ -1359,6 +1359,13 @@ class _TestPool(BaseTestCase):
         # they were released too.
         self.assertEqual(CountedObject.n_instances, 0)
 
+    def test_del_pool(self):
+        p = self.Pool(1)
+        wr = weakref.ref(p)
+        del p
+        gc.collect()
+        self.assertIsNone(wr())
+
 
 def unpickleable_result():
     return lambda: 42

--- a/Misc/NEWS.d/next/Library/2018-07-26-10-31-52.bpo-34172.8ovLNi.rst
+++ b/Misc/NEWS.d/next/Library/2018-07-26-10-31-52.bpo-34172.8ovLNi.rst
@@ -1,0 +1,1 @@
+Fix a reference issue inside multiprocessing.Pool that caused the pool to remain alive if it was deleted without being closed or terminated explicitly.


### PR DESCRIPTION
Manual backport of the fix for 2.7

<!-- issue-number: [bpo-34172](https://www.bugs.python.org/issue34172) -->
https://bugs.python.org/issue34172
<!-- /issue-number -->
