### PR TITLE
bpo-34711: Return HTTPStatus.NOT_FOUND if path.endswith(/) and not a directory

### DIFF
--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -692,6 +692,14 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             else:
                 return self.list_directory(path)
         ctype = self.guess_type(path)
+        # check for trailing "/" which should return 404. See Issue17324
+        # The test for this was added in test_httpserver.py
+        # However, some OS platforms accept a trailingSlash as a filename
+        # See discussion on python-dev and Issue34711 regarding
+        # parseing and rejection of filenames with a trailing slash
+        if path.endswith("/"):
+            self.send_error(HTTPStatus.NOT_FOUND, "File not found")
+            return None
         try:
             f = open(path, 'rb')
         except OSError:

--- a/Misc/NEWS.d/next/Library/2018-10-03-09-25-02.bpo-34711.HeOmKR.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-03-09-25-02.bpo-34711.HeOmKR.rst
@@ -1,0 +1,3 @@
+Reject as HTTPStatus.NOT_FOUND if path.endswith("/") and not a directory
+See also issue17324
+Patch by aixtools

--- a/Misc/NEWS.d/next/Library/2018-10-03-09-25-02.bpo-34711.HeOmKR.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-03-09-25-02.bpo-34711.HeOmKR.rst
@@ -1,3 +1,3 @@
-Reject as HTTPStatus.NOT_FOUND if path.endswith("/") and not a directory
-See also issue17324
-Patch by aixtools
+http.server ensures it reports HTTPStatus.NOT_FOUND when the local path ends with "/"
+and is not a directory, even if the underlying OS (e.g. AIX) accepts such paths as a
+valid file reference. Patch by Michael Felt.


### PR DESCRIPTION
Please provide guidelines on how much, if any comments, to have in Lib/http/server.py.

I assume there is too much now, while my gut says no comments may only make people wonder why this is being done.

<!-- issue-number: [bpo-34711](https://www.bugs.python.org/issue34711) -->
https://bugs.python.org/issue34711
<!-- /issue-number -->
