### PR TITLE
bpo-2506: Experiment with adding a "-X noopt" flag

### DIFF
--- a/Include/coreconfig.h
+++ b/Include/coreconfig.h
@@ -49,6 +49,7 @@ typedef struct {
 
     const char *allocator;  /* Memory allocator: PYTHONMALLOC */
     int dev_mode;           /* PYTHONDEVMODE, -X dev */
+    int noopt_mode;         /* -X noopt */
 
     /* Enable faulthandler?
        Set to 1 by -X faulthandler and PYTHONFAULTHANDLER. -1 means unset. */

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4687,6 +4687,8 @@ get_coreconfig(PyObject *self, PyObject *Py_UNUSED(args))
              FROM_STRING(config->allocator));
     SET_ITEM("dev_mode",
              PyLong_FromLong(config->dev_mode));
+    SET_ITEM("noopt_mode",
+             PyLong_FromLong(config->noopt_mode));
     SET_ITEM("faulthandler",
              PyLong_FromLong(config->faulthandler));
     SET_ITEM("tracemalloc",

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -320,6 +320,7 @@ dump_config(void)
     printf("allocator = %s\n", config->allocator);
 
     printf("dev_mode = %i\n", config->dev_mode);
+    printf("noopt_mode = %i\n", config->noopt_mode);
     printf("faulthandler = %i\n", config->faulthandler);
     printf("tracemalloc = %i\n", config->tracemalloc);
     printf("import_time = %i\n", config->import_time);

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -295,6 +295,7 @@ _PyCoreConfig_Copy(_PyCoreConfig *config, const _PyCoreConfig *config2)
     COPY_ATTR(_install_importlib);
     COPY_ATTR(allocator);
     COPY_ATTR(dev_mode);
+    COPY_ATTR(noopt_mode);
     COPY_ATTR(faulthandler);
     COPY_ATTR(tracemalloc);
     COPY_ATTR(import_time);
@@ -944,6 +945,10 @@ config_read_complex_options(_PyCoreConfig *config)
         _PyCoreConfig_GetEnv(config, "PYTHONDEVMODE"))
     {
         config->dev_mode = 1;
+    }
+    if (config_get_xoption(config, L"noopt"))
+    {
+        config->noopt_mode = 1;
     }
 
     _PyInitError err;

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2060,6 +2060,7 @@ static PyStructSequence_Field flags_fields[] = {
     {"hash_randomization",      "-R"},
     {"isolated",                "-I"},
     {"dev_mode",                "-X dev"},
+    {"noopt_mode",              "-X noopt"},
     {"utf8_mode",               "-X utf8"},
     {0}
 };
@@ -2101,6 +2102,7 @@ make_flags(void)
     SetFlag(config->use_hash_seed == 0 || config->hash_seed != 0);
     SetFlag(config->isolated);
     PyStructSequence_SET_ITEM(seq, pos++, PyBool_FromLong(config->dev_mode));
+    PyStructSequence_SET_ITEM(seq, pos++, PyBool_FromLong(config->noopt_mode));
     SetFlag(config->utf8_mode);
 #undef SetFlag
 


### PR DESCRIPTION
I've created this PR to **evaluate** if we can add the `-X noopt` (or similar) option.  So far I've done the following basic things:

- [x] Added the actual command line option
- [x] Modified the compiler to respect it and to disable AST and peephole optimizers
- [x] Modified the compiler to respect the flag and avoid optimizing the `while <const>` and `if <const>` constructs

**Partial list of ToDo's**

- [ ] Decide whether it's `-X noopt` or `-O0something`
- [ ] Fix importlib to generate "noopt" tags (`file.noopt.cpython-38.pyc`)
- [ ] Go through `compile.c` and disable micro-optimizations (like avoiding evaluating test cases of loops in `while [constant]` etc)
- [ ] Write new tests; fix existing tests.
- [ ] Documentation / What's New / NEWS

I don't have time to implement everything myself *right now*, but it might be a good idea to ask @elprans to work on this one in the next couple of months (@vstinner currently mentors Elvis.)

<!-- issue-number: [bpo-2506](https://www.bugs.python.org/issue2506) -->
https://bugs.python.org/issue2506
<!-- /issue-number -->

(See also https://bugs.python.org/issue34888)