### PR TITLE
bpo-34889: Use the system byteorder if not given in int.(to|from)_bytes

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -475,7 +475,7 @@ class`. In addition, it provides a few more methods:
 
     .. versionadded:: 3.1
 
-.. method:: int.to_bytes(length, byteorder, \*, signed=False)
+.. method:: int.to_bytes(length, byteorder=None, \*, signed=False)
 
     Return an array of bytes representing an integer.
 
@@ -496,9 +496,8 @@ class`. In addition, it provides a few more methods:
     The *byteorder* argument determines the byte order used to represent the
     integer.  If *byteorder* is ``"big"``, the most significant byte is at the
     beginning of the byte array.  If *byteorder* is ``"little"``, the most
-    significant byte is at the end of the byte array.  To request the native
-    byte order of the host system, use :data:`sys.byteorder` as the byte order
-    value.
+    significant byte is at the end of the byte array.  If *byteorder* is
+    ``None``, the native byte order of the host system is used.
 
     The *signed* argument determines whether two's complement is used to
     represent the integer.  If *signed* is ``False`` and a negative integer is
@@ -507,7 +506,7 @@ class`. In addition, it provides a few more methods:
 
     .. versionadded:: 3.2
 
-.. classmethod:: int.from_bytes(bytes, byteorder, \*, signed=False)
+.. classmethod:: int.from_bytes(bytes, byteorder=None, \*, signed=False)
 
     Return the integer represented by the given array of bytes.
 
@@ -528,9 +527,8 @@ class`. In addition, it provides a few more methods:
     The *byteorder* argument determines the byte order used to represent the
     integer.  If *byteorder* is ``"big"``, the most significant byte is at the
     beginning of the byte array.  If *byteorder* is ``"little"``, the most
-    significant byte is at the end of the byte array.  To request the native
-    byte order of the host system, use :data:`sys.byteorder` as the byte order
-    value.
+    significant byte is at the end of the byte array.  If *byteorder* is
+    ``None``, the native byte order of the host system is used.
 
     The *signed* argument indicates whether two's complement is used to
     represent the integer.

--- a/Objects/clinic/longobject.c.h
+++ b/Objects/clinic/longobject.c.h
@@ -147,7 +147,7 @@ int_as_integer_ratio(PyObject *self, PyObject *Py_UNUSED(ignored))
 }
 
 PyDoc_STRVAR(int_to_bytes__doc__,
-"to_bytes($self, /, length, byteorder, *, signed=False)\n"
+"to_bytes($self, /, length, byteorder=None, *, signed=False)\n"
 "--\n"
 "\n"
 "Return an array of bytes representing an integer.\n"
@@ -159,8 +159,8 @@ PyDoc_STRVAR(int_to_bytes__doc__,
 "    The byte order used to represent the integer.  If byteorder is \'big\',\n"
 "    the most significant byte is at the beginning of the byte array.  If\n"
 "    byteorder is \'little\', the most significant byte is at the end of the\n"
-"    byte array.  To request the native byte order of the host system, use\n"
-"    `sys.byteorder\' as the byte order value.\n"
+"    byte array.  If byteorder is None, the native byte order of the host\n"
+"    system is used.\n"
 "  signed\n"
 "    Determines whether two\'s complement is used to represent the integer.\n"
 "    If signed is False and a negative integer is given, an OverflowError\n"
@@ -178,9 +178,9 @@ int_to_bytes(PyObject *self, PyObject *const *args, Py_ssize_t nargs, PyObject *
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"length", "byteorder", "signed", NULL};
-    static _PyArg_Parser _parser = {"nU|$p:to_bytes", _keywords, 0};
+    static _PyArg_Parser _parser = {"n|U$p:to_bytes", _keywords, 0};
     Py_ssize_t length;
-    PyObject *byteorder;
+    PyObject *byteorder = Py_None;
     int is_signed = 0;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
@@ -194,7 +194,7 @@ exit:
 }
 
 PyDoc_STRVAR(int_from_bytes__doc__,
-"from_bytes($type, /, bytes, byteorder, *, signed=False)\n"
+"from_bytes($type, /, bytes, byteorder=None, *, signed=False)\n"
 "--\n"
 "\n"
 "Return the integer represented by the given array of bytes.\n"
@@ -208,8 +208,8 @@ PyDoc_STRVAR(int_from_bytes__doc__,
 "    The byte order used to represent the integer.  If byteorder is \'big\',\n"
 "    the most significant byte is at the beginning of the byte array.  If\n"
 "    byteorder is \'little\', the most significant byte is at the end of the\n"
-"    byte array.  To request the native byte order of the host system, use\n"
-"    `sys.byteorder\' as the byte order value.\n"
+"    byte array.  If byteorder is None, the native byte order of the host\n"
+"    system is used.\n"
 "  signed\n"
 "    Indicates whether two\'s complement is used to represent the integer.");
 
@@ -225,9 +225,9 @@ int_from_bytes(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, PyOb
 {
     PyObject *return_value = NULL;
     static const char * const _keywords[] = {"bytes", "byteorder", "signed", NULL};
-    static _PyArg_Parser _parser = {"OU|$p:from_bytes", _keywords, 0};
+    static _PyArg_Parser _parser = {"O|U$p:from_bytes", _keywords, 0};
     PyObject *bytes_obj;
-    PyObject *byteorder;
+    PyObject *byteorder = Py_None;
     int is_signed = 0;
 
     if (!_PyArg_ParseStackAndKeywords(args, nargs, kwnames, &_parser,
@@ -239,4 +239,4 @@ int_from_bytes(PyTypeObject *type, PyObject *const *args, Py_ssize_t nargs, PyOb
 exit:
     return return_value;
 }
-/*[clinic end generated code: output=6d5e92d7dc803751 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=4f2a70a91633519b input=a9049054013a1b77]*/

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -24,6 +24,7 @@ class int "PyObject *" "&PyLong_Type"
 
 _Py_IDENTIFIER(little);
 _Py_IDENTIFIER(big);
+_Py_IDENTIFIER(byteorder);
 
 /* convert a PyLong of size 1, 0 or -1 to an sdigit */
 #define MEDIUM_VALUE(x) (assert(-1 <= Py_SIZE(x) && Py_SIZE(x) <= 1),   \
@@ -5301,12 +5302,12 @@ int.to_bytes
     length: Py_ssize_t
         Length of bytes object to use.  An OverflowError is raised if the
         integer is not representable with the given number of bytes.
-    byteorder: unicode
+    byteorder: unicode = None
         The byte order used to represent the integer.  If byteorder is 'big',
         the most significant byte is at the beginning of the byte array.  If
         byteorder is 'little', the most significant byte is at the end of the
-        byte array.  To request the native byte order of the host system, use
-        `sys.byteorder' as the byte order value.
+        byte array.  If byteorder is None, the native byte order of the host
+        system is used.
     *
     signed as is_signed: bool = False
         Determines whether two's complement is used to represent the integer.
@@ -5319,10 +5320,13 @@ Return an array of bytes representing an integer.
 static PyObject *
 int_to_bytes_impl(PyObject *self, Py_ssize_t length, PyObject *byteorder,
                   int is_signed)
-/*[clinic end generated code: output=89c801df114050a3 input=ddac63f4c7bf414c]*/
+/*[clinic end generated code: output=89c801df114050a3 input=e53bf99c9e707752]*/
 {
     int little_endian;
     PyObject *bytes;
+
+    if (byteorder == Py_None)
+        byteorder = _PySys_GetObjectId(&PyId_byteorder);
 
     if (_PyUnicode_EqualToASCIIId(byteorder, &PyId_little))
         little_endian = 1;
@@ -5363,12 +5367,12 @@ int.from_bytes
         support the buffer protocol or be an iterable object producing bytes.
         Bytes and bytearray are examples of built-in objects that support the
         buffer protocol.
-    byteorder: unicode
+    byteorder: unicode = None
         The byte order used to represent the integer.  If byteorder is 'big',
         the most significant byte is at the beginning of the byte array.  If
         byteorder is 'little', the most significant byte is at the end of the
-        byte array.  To request the native byte order of the host system, use
-        `sys.byteorder' as the byte order value.
+        byte array.  If byteorder is None, the native byte order of the host
+        system is used.
     *
     signed as is_signed: bool = False
         Indicates whether two's complement is used to represent the integer.
@@ -5379,7 +5383,7 @@ Return the integer represented by the given array of bytes.
 static PyObject *
 int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
                     PyObject *byteorder, int is_signed)
-/*[clinic end generated code: output=efc5d68e31f9314f input=cdf98332b6a821b0]*/
+/*[clinic end generated code: output=efc5d68e31f9314f input=c485d8e041ef5d9e]*/
 {
     int little_endian;
     PyObject *long_obj, *bytes;


### PR DESCRIPTION
When serializing a single integer, int.to_bytes and int.from_bytes are more efficient alternatives to struct.pack and struct.unpack. However, struct.pack and struct.unpack currently have the advantage that the byteorder does not have to be specified (because it defaults to sys.byteorder). It would avoid a lot of redundant code to make the byteorder argument default to sys.byteorder in int.to_bytes and int.from_bytes too.

<!-- issue-number: [bpo-34889](https://www.bugs.python.org/issue34889) -->
https://bugs.python.org/issue34889
<!-- /issue-number -->
