### PR TITLE
bpo-27165: Skip callables when printing an exception details

### DIFF
--- a/Lib/cgitb.py
+++ b/Lib/cgitb.py
@@ -174,7 +174,9 @@ function calls leading up to the error, in the order they occurred.</p>'''
                                 pydoc.html.escape(str(evalue)))]
     for name in dir(evalue):
         if name[:1] == '_': continue
-        value = pydoc.html.repr(getattr(evalue, name))
+        attr_val = getattr(evalue, name)
+        if callable(attr_val): continue
+        value = pydoc.html.repr(attr_val)
         exception.append('\n<br>%s%s&nbsp;=\n%s' % (indent, name, value))
 
     return head + ''.join(frames) + ''.join(exception) + '''
@@ -244,7 +246,9 @@ function calls leading up to the error, in the order they occurred.
 
     exception = ['%s: %s' % (str(etype), str(evalue))]
     for name in dir(evalue):
-        value = pydoc.text.repr(getattr(evalue, name))
+        attr_val = getattr(evalue, name)
+        if callable(attr_val): continue
+        value = pydoc.text.repr(attr_val)
         exception.append('\n%s%s = %s' % (" "*4, name, value))
 
     return head + ''.join(frames) + ''.join(exception) + '''

--- a/Lib/test/test_cgitb.py
+++ b/Lib/test/test_cgitb.py
@@ -63,6 +63,25 @@ class TestCgitb(unittest.TestCase):
         self.assertNotIn('<p>', out)
         self.assertNotIn('</p>', out)
 
+    def test_exception_text(self):
+        # Issue 27165: Exclude callables from exception details
+        try:
+            raise Exception("text foo")
+        except Exception as e:
+            exc_text = cgitb.text(sys.exc_info())
+            print(exc_text)
+            self.assertNotIn('__init__', exc_text)
+            self.assertNotIn('__reduce__', exc_text)
+
+    def test_exception_html(self):
+        # Issue 27165: Exclude callables from exception details
+        try:
+            raise Exception("html foo")
+        except Exception as e:
+            exc_html = cgitb.html(sys.exc_info())
+            print(exc_html)
+            self.assertNotIn('__init__', exc_html)
+            self.assertNotIn('__reduce__', exc_html)
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-10-04-12-44-12.bpo-27165.AbG82B.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-04-12-44-12.bpo-27165.AbG82B.rst
@@ -1,0 +1,1 @@
+cgitb skips callable exception fields when creating exception description, both in HTML and text format


### PR DESCRIPTION
Included 2 tests and a news entry for the change. 

Since I deleted my previous forked cpython repo, I can't add commits to PR #9695 - so I'm creating new PR with the same change to code, but tests and news entry added.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-27165](https://www.bugs.python.org/issue27165) -->
https://bugs.python.org/issue27165
<!-- /issue-number -->
