### PR TITLE
bpo-34898: Add `mtime` argument to `gzip.compress`

### DIFF
--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -164,6 +164,8 @@ The module defines the following items:
    the :class:`GzipFile` constructor above.
 
    .. versionadded:: 3.2
+   .. versionchanged:: 3.8
+      Added *mtime* argument
 
 .. function:: decompress(data)
 

--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -157,10 +157,10 @@ The module defines the following items:
       Accepts a :term:`path-like object`.
 
 
-.. function:: compress(data, compresslevel=9)
+.. function:: compress(data, compresslevel=9, mtime=None)
 
    Compress the *data*, returning a :class:`bytes` object containing
-   the compressed data.  *compresslevel* has the same meaning as in
+   the compressed data.  *compresslevel* and *mtime* has the same meaning as in
    the :class:`GzipFile` constructor above.
 
    .. versionadded:: 3.2

--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -160,7 +160,7 @@ The module defines the following items:
 .. function:: compress(data, compresslevel=9, mtime=None)
 
    Compress the *data*, returning a :class:`bytes` object containing
-   the compressed data.  *compresslevel* and *mtime* has the same meaning as in
+   the compressed data.  *compresslevel* and *mtime* have the same meaning as in
    the :class:`GzipFile` constructor above.
 
    .. versionadded:: 3.2

--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -157,7 +157,7 @@ The module defines the following items:
       Accepts a :term:`path-like object`.
 
 
-.. function:: compress(data, compresslevel=9, mtime=None)
+.. function:: compress(data, compresslevel=9, *, mtime=None)
 
    Compress the *data*, returning a :class:`bytes` object containing
    the compressed data.  *compresslevel* and *mtime* have the same meaning as in
@@ -165,7 +165,7 @@ The module defines the following items:
 
    .. versionadded:: 3.2
    .. versionchanged:: 3.8
-      Added *mtime* argument
+      Added the *mtime* parameter for reproducible output.
 
 .. function:: decompress(data)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -128,6 +128,13 @@ asyncio
 On Windows, the default event loop is now :class:`~asyncio.ProactorEventLoop`.
 
 
+gzip
+----
+
+Added the *mtime* parameter to :func:`gzip.compress` for reproducible output.
+(Contributed by Guo Ci Teo in :issue:`34898`.)
+
+
 idlelib and IDLE
 ----------------
 

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -520,7 +520,7 @@ class _GzipReader(_compression.DecompressReader):
         super()._rewind()
         self._new_member = True
 
-def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, mtime=None):
+def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, *, mtime=None):
     """Compress data in one shot and return the compressed string.
     Optional argument is the compression level, in range of 0-9.
     """

--- a/Lib/gzip.py
+++ b/Lib/gzip.py
@@ -520,12 +520,12 @@ class _GzipReader(_compression.DecompressReader):
         super()._rewind()
         self._new_member = True
 
-def compress(data, compresslevel=_COMPRESS_LEVEL_BEST):
+def compress(data, compresslevel=_COMPRESS_LEVEL_BEST, mtime=None):
     """Compress data in one shot and return the compressed string.
     Optional argument is the compression level, in range of 0-9.
     """
     buf = io.BytesIO()
-    with GzipFile(fileobj=buf, mode='wb', compresslevel=compresslevel) as f:
+    with GzipFile(fileobj=buf, mode='wb', compresslevel=compresslevel, mtime=mtime) as f:
         f.write(data)
     return buf.getvalue()
 

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -499,6 +499,16 @@ class TestGzip(BaseTest):
                 with gzip.GzipFile(fileobj=io.BytesIO(datac), mode="rb") as f:
                     self.assertEqual(f.read(), data)
 
+    def test_compress_mtime(self):
+        mtime = 123456789
+        for data in [data1, data2]:
+            for args in [(1, mtime), (6, mtime), (9, mtime)]:
+                datac = gzip.compress(data, *args)
+                self.assertEqual(type(datac), bytes)
+                with gzip.GzipFile(fileobj=io.BytesIO(datac), mode="rb") as f:
+                    f.read(1) # to set mtime attribute
+                    self.assertEqual(f.mtime, mtime)
+
     def test_decompress(self):
         for data in (data1, data2):
             buf = io.BytesIO()

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -503,7 +503,7 @@ class TestGzip(BaseTest):
         mtime = 123456789
         for data in [data1, data2]:
             for args in [(1, mtime), (6, mtime), (9, mtime)]:
-                with self.subTest(data=data,args=args):
+                with self.subTest(data=data, args=args):
                     datac = gzip.compress(data, *args)
                     self.assertEqual(type(datac), bytes)
                     with gzip.GzipFile(fileobj=io.BytesIO(datac), mode="rb") as f:

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -503,11 +503,12 @@ class TestGzip(BaseTest):
         mtime = 123456789
         for data in [data1, data2]:
             for args in [(1, mtime), (6, mtime), (9, mtime)]:
-                datac = gzip.compress(data, *args)
-                self.assertEqual(type(datac), bytes)
-                with gzip.GzipFile(fileobj=io.BytesIO(datac), mode="rb") as f:
-                    f.read(1) # to set mtime attribute
-                    self.assertEqual(f.mtime, mtime)
+                with self.subTest(data=data,args=args):
+                    datac = gzip.compress(data, *args)
+                    self.assertEqual(type(datac), bytes)
+                    with gzip.GzipFile(fileobj=io.BytesIO(datac), mode="rb") as f:
+                        f.read(1) # to set mtime attribute
+                        self.assertEqual(f.mtime, mtime)
 
     def test_decompress(self):
         for data in (data1, data2):

--- a/Lib/test/test_gzip.py
+++ b/Lib/test/test_gzip.py
@@ -502,9 +502,9 @@ class TestGzip(BaseTest):
     def test_compress_mtime(self):
         mtime = 123456789
         for data in [data1, data2]:
-            for args in [(1, mtime), (6, mtime), (9, mtime)]:
+            for args in [(), (1,), (6,), (9,)]:
                 with self.subTest(data=data, args=args):
-                    datac = gzip.compress(data, *args)
+                    datac = gzip.compress(data, *args, mtime=mtime)
                     self.assertEqual(type(datac), bytes)
                     with gzip.GzipFile(fileobj=io.BytesIO(datac), mode="rb") as f:
                         f.read(1) # to set mtime attribute

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1615,6 +1615,7 @@ Monty Taylor
 Anatoly Techtonik
 Martin Teichmann
 Gustavo Temple
+Guo Ci Teo
 Mikhail Terekhov
 Victor Terrón
 Pablo Galindo

--- a/Misc/NEWS.d/next/Library/2018-10-04-17-23-43.bpo-34898.Wo2PoJ.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-04-17-23-43.bpo-34898.Wo2PoJ.rst
@@ -1,0 +1,1 @@
+Add `mtime` argument to `gzip.compress` for reproducible output.

--- a/Misc/NEWS.d/next/Library/2018-10-04-17-23-43.bpo-34898.Wo2PoJ.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-04-17-23-43.bpo-34898.Wo2PoJ.rst
@@ -1,1 +1,2 @@
 Add `mtime` argument to `gzip.compress` for reproducible output.
+Patch by Guo Ci Teo.


### PR DESCRIPTION
Add `mtime` argument to `gzip.compress` for reproducible output.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34898](https://www.bugs.python.org/issue34898) -->
https://bugs.python.org/issue34898
<!-- /issue-number -->
