### PR TITLE
bpo-34899: Fix a possible assertion failure due to int_from_bytes_impl()

### DIFF
--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5402,11 +5402,8 @@ int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
         (unsigned char *)PyBytes_AS_STRING(bytes), Py_SIZE(bytes),
         little_endian, is_signed);
     Py_DECREF(bytes);
-    if (long_obj == NULL) {
-        return NULL;
-    }
 
-    if (type != &PyLong_Type) {
+    if (long_obj != NULL && type != &PyLong_Type) {
         Py_SETREF(long_obj, PyObject_CallFunctionObjArgs((PyObject *)type,
                                                          long_obj, NULL));
     }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -5402,6 +5402,9 @@ int_from_bytes_impl(PyTypeObject *type, PyObject *bytes_obj,
         (unsigned char *)PyBytes_AS_STRING(bytes), Py_SIZE(bytes),
         little_endian, is_signed);
     Py_DECREF(bytes);
+    if (long_obj == NULL) {
+        return NULL;
+    }
 
     if (type != &PyLong_Type) {
         Py_SETREF(long_obj, PyObject_CallFunctionObjArgs((PyObject *)type,


### PR DESCRIPTION
The _PyLong_FromByteArray() call in int_from_bytes_impl() was
unchecked.

This is a "skip news" PR.


<!-- issue-number: [bpo-34899](https://www.bugs.python.org/issue34899) -->
https://bugs.python.org/issue34899
<!-- /issue-number -->
