### PR TITLE
bpo-34897: distutils test errors when CXX is not set

### DIFF
--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -148,7 +148,11 @@ class CCompiler:
             if key not in self.executables:
                 raise ValueError("unknown executable '%s' for class %s" %
                       (key, self.__class__.__name__))
-            self.set_executable(key, kwargs[key])
+            if kwargs[key]:
+                v = kwargs[key] if len(kwargs[key].strip()) else None
+            else:
+                v = None
+            self.set_executable(key, v)
 
     def set_executable(self, key, value):
         if isinstance(value, str):

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -148,11 +148,7 @@ class CCompiler:
             if key not in self.executables:
                 raise ValueError("unknown executable '%s' for class %s" %
                       (key, self.__class__.__name__))
-            if kwargs[key]:
-                v = kwargs[key] if len(kwargs[key].strip()) else None
-            else:
-                v = None
-            self.set_executable(key, v)
+            self.set_executable(key, kwargs[key] or None)
 
     def set_executable(self, key, value):
         if isinstance(value, str):

--- a/Lib/distutils/ccompiler.py
+++ b/Lib/distutils/ccompiler.py
@@ -148,7 +148,7 @@ class CCompiler:
             if key not in self.executables:
                 raise ValueError("unknown executable '%s' for class %s" %
                       (key, self.__class__.__name__))
-            self.set_executable(key, kwargs[key] or None)
+            self.set_executable(key, kwargs[key])
 
     def set_executable(self, key, value):
         if isinstance(value, str):

--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -2753,7 +2753,7 @@ def missing_compiler_executable(cmd_names=[]):
         if cmd_names:
             assert cmd is not None, \
                     "the '%s' executable is not configured" % name
-        elif cmd is None:
+        elif not cmd:
             continue
         if spawn.find_executable(cmd[0]) is None:
             return cmd[0]

--- a/Misc/NEWS.d/next/Library/2018-10-04-20-25-35.bpo-34897.rNE2Cy.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-04-20-25-35.bpo-34897.rNE2Cy.rst
@@ -1,0 +1,3 @@
+Fix Lib/distutils/ccompiler.py def set_executables() so that {key:value} when
+the value to be assigned is equivalent to NULL is set to {key:None}
+patch by aixtools

--- a/Misc/NEWS.d/next/Library/2018-10-04-20-25-35.bpo-34897.rNE2Cy.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-04-20-25-35.bpo-34897.rNE2Cy.rst
@@ -1,3 +1,4 @@
-Fix Lib/distutils/ccompiler.py def set_executables() so that {key:value} when
-the value to be assigned is equivalent to NULL is set to {key:None}
+Fix Lib/distutils/ccompiler.py def set_executables() so that when
+the value to be assigned is equivalent to NULL or len(value) = 0
+set to None
 patch by aixtools

--- a/Misc/NEWS.d/next/Library/2018-10-04-20-25-35.bpo-34897.rNE2Cy.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-04-20-25-35.bpo-34897.rNE2Cy.rst
@@ -1,4 +1,2 @@
-Fix Lib/distutils/ccompiler.py def set_executables() so that when
-the value to be assigned is equivalent to NULL or len(value) = 0
-set to None
+Fix Lib/test/support/__init__.py so that an assignment of "" is ignored
 patch by aixtools

--- a/Misc/NEWS.d/next/Library/2018-10-04-20-25-35.bpo-34897.rNE2Cy.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-04-20-25-35.bpo-34897.rNE2Cy.rst
@@ -1,2 +1,2 @@
-Fix Lib/test/support/__init__.py so that an assignment of "" is ignored
-patch by aixtools
+Adjust test.support.missing_compiler_executable check so that a nominal
+command name of "" is ignored. Patch by Michael Felt.


### PR DESCRIPTION
Ensure values set for compiler.executables are set to None when the value being set is the equivalent of a zero-length string.

<!-- issue-number: [[bpo-34897](https://bugs.python.org/issue34897)](https://www.bugs.python.org/issue34897) -->
https://bugs.python.org/issue34897
<!-- /issue-number -->
