### PR TITLE
bpo-34900: Fix subTests to not crash when called from TestCase.debug()

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -514,7 +514,7 @@ class TestCase(object):
         case as failed but resumes execution at the end of the enclosed
         block, allowing further test code to be executed.
         """
-        if not self._outcome.result_supports_subtests:
+        if self._outcome is None or not self._outcome.result_supports_subtests:
             yield
             return
         parent = self._subtest

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -425,6 +425,20 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         expected = ['a1', 'a2', 'b1']
         self.assertEqual(events, expected)
 
+    def test_subtests_debug(self):
+        # Test debug() with a test that uses subTest() (bpo-34900)
+        events = []
+
+        class Foo(unittest.TestCase):
+            def test_a(self):
+                events.append('test case')
+                with self.subTest():
+                    events.append('subtest 1')
+
+        Foo('test_a').debug()
+
+        self.assertEqual(events, ['test case', 'subtest 1'])
+
     # "This class attribute gives the exception raised by the test() method.
     # If a test framework needs to use a specialized exception, possibly to
     # carry additional information, it must subclass this exception in

--- a/Misc/NEWS.d/next/Library/2018-10-05-05-55-53.bpo-34900.8RNiFu.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-05-05-55-53.bpo-34900.8RNiFu.rst
@@ -1,2 +1,2 @@
-Fixed ``TestCase.debug()`` when used to call test methods with subtests.
-Patch by Bruno Oliveira.
+Fixed :meth:`unittest.TestCase.debug` when used to call test methods with
+subtests.  Patch by Bruno Oliveira.

--- a/Misc/NEWS.d/next/Library/2018-10-05-05-55-53.bpo-34900.8RNiFu.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-05-05-55-53.bpo-34900.8RNiFu.rst
@@ -1,0 +1,2 @@
+Fixed ``TestCase.debug()`` when used to call test methods with subtests.
+Patch by Bruno Oliveira.


### PR DESCRIPTION
Fixes issue [[bpo-34900](https://www.bugs.python.org/issue34900)](https://bugs.python.org/issue34900).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34900](https://www.bugs.python.org/issue34900) -->
https://bugs.python.org/issue34900
<!-- /issue-number -->
