### PR TITLE
bpo-27682: Handle client connection terminations in wsgiref.

### DIFF
--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -14,7 +14,6 @@ from io import StringIO, BytesIO, BufferedReader
 from socketserver import BaseServer
 from platform import python_implementation
 
-import io
 import os
 import re
 import signal
@@ -795,7 +794,7 @@ class HandlerTests(TestCase):
                 raise ExceptionClass()
 
         environ = {"SERVER_PROTOCOL": "HTTP/1.0"}
-        stderr = io.StringIO()
+        stderr = StringIO()
         h = SimpleHandler(BytesIO(), AbortingWriter(), stderr, environ)
         h.run(hello_app)
 

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -788,6 +788,18 @@ class HandlerTests(TestCase):
             b"Hello, world!",
             written)
 
+    def testConnectionAbortedError(self):
+        class AbortingWriter:
+            def write(self, b):
+                raise ConnectionAbortedError()
+
+            def flush(self):
+                pass
+
+        environ = {"SERVER_PROTOCOL": "HTTP/1.0"}
+        h = SimpleHandler(BytesIO(), AbortingWriter(), sys.stderr, environ)
+        h.run(hello_app)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/wsgiref/handlers.py
+++ b/Lib/wsgiref/handlers.py
@@ -136,7 +136,7 @@ class BaseHandler:
             self.setup_environ()
             self.result = application(self.environ, self.start_response)
             self.finish_response()
-        except ConnectionAbortedError:
+        except (ConnectionAbortedError, BrokenPipeError, ConnectionResetError):
             # We expect the client to close the connection abruptly from time
             # to time.
             return

--- a/Lib/wsgiref/handlers.py
+++ b/Lib/wsgiref/handlers.py
@@ -136,6 +136,10 @@ class BaseHandler:
             self.setup_environ()
             self.result = application(self.environ, self.start_response)
             self.finish_response()
+        except ConnectionAbortedError:
+            # We expect the client to close the connection abruptly from time
+            # to time.
+            return
         except:
             try:
                 self.handle_error()

--- a/Misc/NEWS.d/next/Library/2018-10-05-16-01-00.bpo-34547.abbaa.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-05-16-01-00.bpo-34547.abbaa.rst
@@ -1,3 +1,2 @@
-``wsgiref`` now handles abrupt client connection terminations gracefully.
-Previously, long stack traces with Python TypeErrors and AttributeErrors
-were printed. Patch by Petter Strandmark.
+:class:`wsgiref.handlers.BaseHandler` now handles abrupt client connection
+terminations gracefully. Patch by Petter Strandmark.

--- a/Misc/NEWS.d/next/Library/2018-10-05-16-01-00.bpo-34547.abbaa.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-05-16-01-00.bpo-34547.abbaa.rst
@@ -1,0 +1,3 @@
+``wsgiref`` now handles abrupt client connection terminations gracefully.
+Previously, long stack traces with Python TypeErrors and AttributeErrors
+were printed. Patch by Petter Strandmark.


### PR DESCRIPTION
Previously, long stack traces with Python TypeErrors and AttributeErrors
were printed (see bug).

The wsgiref server is used quite a lot in the community, notably by the
Django development server. I see these huge stack traces daily.


<!-- issue-number: [[bpo-27682](https://bugs.python.org/issue27682)](https://www.bugs.python.org/issue27682) -->
https://bugs.python.org/issue27682
<!-- /issue-number -->
