### PR TITLE
bpo-34769: Thread safety for _asyncgen_finalizer_hook().

### DIFF
--- a/Lib/asyncio/base_events.py
+++ b/Lib/asyncio/base_events.py
@@ -477,10 +477,7 @@ class BaseEventLoop(events.AbstractEventLoop):
     def _asyncgen_finalizer_hook(self, agen):
         self._asyncgens.discard(agen)
         if not self.is_closed():
-            self.create_task(agen.aclose())
-            # Wake up the loop if the finalizer was called from
-            # a different thread.
-            self._write_to_self()
+            self.call_soon_threadsafe(self.create_task, agen.aclose())
 
     def _asyncgen_firstiter_hook(self, agen):
         if self._asyncgens_shutdown_called:

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -991,7 +991,8 @@ class BaseEventLoopTests(test_utils.TestCase):
             self.assertTrue(status['started'])
             self.assertTrue(status['stopped'])
             self.assertFalse(status['finalized'])
-            self.loop.run_in_executor(None, support.gc_collect)
+            self.loop.run_until_complete(
+                self.loop.run_in_executor(None, support.gc_collect))
             test_utils.run_briefly(self.loop)
             self.assertTrue(status['finalized'])
 

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -928,12 +928,12 @@ class BaseEventLoopTests(test_utils.TestCase):
 
     async def leave_unfinalized_asyncgen(self):
         # The following should create an async generator, iterate
-        # it partially, and leave it to be garbage collected 
+        # it partially, and leave it to be garbage collected
         # in the future.
-        status = {'started': False, 
+        status = {'started': False,
                   'stopped': False,
                   'finalized': False}
-        
+
         async def agen():
             status['started'] = True
             try:

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -928,8 +928,12 @@ class BaseEventLoopTests(test_utils.TestCase):
 
     async def leave_unfinalized_asyncgen(self):
         # The following should create an async generator, iterate
-        # it partially, and leave it to be garbage collected
-        # in the future.
+        # it partially, and leave it to be garbage collected.
+        # This depends on implementation details of the garbage
+        # collector, and may stop working in future versions of
+        # cpython or in other implementations. In that case,
+        # the tests below on async generator finalization may
+        # break as well.
         status = {'started': False,
                   'stopped': False,
                   'finalized': False}
@@ -958,9 +962,8 @@ class BaseEventLoopTests(test_utils.TestCase):
         asyncio.create_task(iter_one())
         return status
 
-    def test__asyncgen_finalizer_hook_by_gc(self):
-        # Test for activation of _asyncgen_finalizer_hook when an
-        # async generator is garbage collected.
+    def test_asyncgen_finalization_by_gc(self):
+        # Async generators should be finalized when garbage collected.
         self.loop._process_events = mock.Mock()
         self.loop._write_to_self = mock.Mock()
         with support.disable_gc():

--- a/Lib/test/test_asyncio/test_base_events.py
+++ b/Lib/test/test_asyncio/test_base_events.py
@@ -927,13 +927,11 @@ class BaseEventLoopTests(test_utils.TestCase):
         self.loop._selector.select.assert_called_once_with(0)
 
     async def leave_unfinalized_asyncgen(self):
-        # The following should create an async generator, iterate
-        # it partially, and leave it to be garbage collected.
-        # This depends on implementation details of the garbage
-        # collector, and may stop working in future versions of
-        # cpython or in other implementations. In that case,
-        # the tests below on async generator finalization may
-        # break as well.
+        # Create an async generator, iterate it partially, and leave it
+        # to be garbage collected.
+        # Used in async generator finalization tests.
+        # Depends on implementation details of garbage collector. Changes
+        # in gc may break this function.
         status = {'started': False,
                   'stopped': False,
                   'finalized': False}

--- a/Misc/NEWS.d/next/Library/2018-10-09-11-01-16.bpo-34769.cSkkZt.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-09-11-01-16.bpo-34769.cSkkZt.rst
@@ -1,2 +1,2 @@
-Fix for async generators not finalizing when event loop in debug mode and
+Fix for async generators not finalizing when event loop is in debug mode and
 garbage collector runs in another thread.

--- a/Misc/NEWS.d/next/Library/2018-10-09-11-01-16.bpo-34769.cSkkZt.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-09-11-01-16.bpo-34769.cSkkZt.rst
@@ -1,0 +1,2 @@
+Fix for async generators not finalizing when event loop in debug mode and
+garbage collector runs in another thread.


### PR DESCRIPTION
Should fix [bpo-34769](https://www.bugs.python.org/issue34769) in debug mode.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34769](https://www.bugs.python.org/issue34769) -->
https://bugs.python.org/issue34769
<!-- /issue-number -->
