### PR TITLE
bpo-34576 warn users on security for http.server

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -16,6 +16,14 @@
 
 This module defines classes for implementing HTTP servers (Web servers).
 
+Security Considerations
+-----------------------
+
+http.server is meant for demo purposes and does not implement the stringent
+security checks needed of real HTTP server. We do not recommend
+using this module directly in production.
+
+
 One class, :class:`HTTPServer`, is a :class:`socketserver.TCPServer` subclass.
 It creates and listens at the HTTP socket, dispatching the requests to a
 handler.  Code to create and run the server looks like this::


### PR DESCRIPTION
It was proposed to add an warning for http.server regarding security
issues. The wording was provided at [bpo-26005](https://www.bugs.python.org/issue26005) by @orsenthil 

I created a section called "Security Considerations" as recommended in [Documenting Python](https://devguide.python.org/documenting/#security-considerations-and-other-concerns)
This needs to be backported to the Python 2 docs for SimpleHTTPServer but I'm not really sure how should I proceed to do that.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34576](https://www.bugs.python.org/issue34576) -->
https://bugs.python.org/issue34576
<!-- /issue-number -->
