### PR TITLE
Use assertEqual() instead of assertEquals().

### DIFF
--- a/Lib/ctypes/test/test_win32.py
+++ b/Lib/ctypes/test/test_win32.py
@@ -68,7 +68,7 @@ class ReturnStructSizesTestCase(unittest.TestCase):
             for i, f in enumerate(fields):
                 value = getattr(res, f[0])
                 expected = bytes([ord('a') + i])
-                self.assertEquals(value, expected)
+                self.assertEqual(value, expected)
 
 
 

--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -989,7 +989,7 @@ class GrammarTests(unittest.TestCase):
         def g(): f((yield from ()), 1)
         # Do not require parenthesis for tuple unpacking
         def g(): rest = 4, 5, 6; yield 1, 2, 3, *rest
-        self.assertEquals(list(g()), [(1, 2, 3, 4, 5, 6)])
+        self.assertEqual(list(g()), [(1, 2, 3, 4, 5, 6)])
         check_syntax_error(self, "def g(): f(yield 1)")
         check_syntax_error(self, "def g(): f(yield 1, 1)")
         check_syntax_error(self, "def g(): f(yield from ())")


### PR DESCRIPTION
Fixes warnings in tests added in [bpo-32117](https://www.bugs.python.org/issue32117) and [bpo-34603](https://www.bugs.python.org/issue34603).
