### PR TITLE
[3.7] Use assertEqual() instead of assertEquals(). (GH-9721)

### DIFF
--- a/Lib/ctypes/test/test_win32.py
+++ b/Lib/ctypes/test/test_win32.py
@@ -68,7 +68,7 @@ class ReturnStructSizesTestCase(unittest.TestCase):
             for i, f in enumerate(fields):
                 value = getattr(res, f[0])
                 expected = bytes([ord('a') + i])
-                self.assertEquals(value, expected)
+                self.assertEqual(value, expected)
 
 
 


### PR DESCRIPTION
Fixes warnings in test added in [bpo-34603](https://www.bugs.python.org/issue34603).
(cherry picked from commit 4642d5f59828e774585e9895b538b24d71b9df8e)
