### PR TITLE
[3.7] Fix a compiler warning added in bpo-34872. (GH-9722).

### DIFF
--- a/Modules/_asynciomodule.c
+++ b/Modules/_asynciomodule.c
@@ -2663,7 +2663,7 @@ set_exception:
             if (task->task_must_cancel) {
                 PyObject *r;
                 int is_true;
-                r = _PyObject_CallMethodId(fut, &PyId_cancel, NULL);
+                r = _PyObject_CallMethodId(result, &PyId_cancel, NULL);
                 if (r == NULL) {
                     return NULL;
                 }


### PR DESCRIPTION
(cherry picked from commit addf8afb43af58b9bf56a0ecfd0f316dd60ac0c3)


<!-- issue-number: [bpo-34872](https://www.bugs.python.org/issue34872) -->
https://bugs.python.org/issue34872
<!-- /issue-number -->
