### PR TITLE
bpo-34910: Ensure PyObject_Print() always returns -1 on error

### DIFF
--- a/Misc/NEWS.d/next/C API/2018-10-05-17-06-49.bpo-34910.tSFrls.rst
+++ b/Misc/NEWS.d/next/C API/2018-10-05-17-06-49.bpo-34910.tSFrls.rst
@@ -1,0 +1,2 @@
+Ensure that :c:func:`PyObject_Print` always returns ``-1`` on error.  Patch
+by Zackery Spytz.

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -375,8 +375,9 @@ PyObject_Print(PyObject *op, FILE *fp, int flags)
             else if (PyUnicode_Check(s)) {
                 PyObject *t;
                 t = PyUnicode_AsEncodedString(s, "utf-8", "backslashreplace");
-                if (t == NULL)
-                    ret = 0;
+                if (t == NULL) {
+                    ret = -1;
+                }
                 else {
                     fwrite(PyBytes_AS_STRING(t), 1,
                            PyBytes_GET_SIZE(t), fp);


### PR DESCRIPTION


<!-- issue-number: [bpo-34910](https://www.bugs.python.org/issue34910) -->
https://bugs.python.org/issue34910
<!-- /issue-number -->
