### PR TITLE
bpo-34911: Added support for secure websocket cookies

### DIFF
--- a/Doc/library/http.cookiejar.rst
+++ b/Doc/library/http.cookiejar.rst
@@ -78,14 +78,16 @@ The following classes are provided:
    from / returned to the server.
 
 
-.. class:: DefaultCookiePolicy( blocked_domains=None, allowed_domains=None, netscape=True, rfc2965=False, rfc2109_as_netscape=None, hide_cookie2=False, strict_domain=False, strict_rfc2965_unverifiable=True, strict_ns_unverifiable=False, strict_ns_domain=DefaultCookiePolicy.DomainLiberal, strict_ns_set_initial_dollar=False, strict_ns_set_path=False )
+.. class:: DefaultCookiePolicy( blocked_domains=None, allowed_domains=None, netscape=True, rfc2965=False, rfc2109_as_netscape=None, hide_cookie2=False, strict_domain=False, strict_rfc2965_unverifiable=True, strict_ns_unverifiable=False, strict_ns_domain=DefaultCookiePolicy.DomainLiberal, strict_ns_set_initial_dollar=False, strict_ns_set_path=False, secure_protocols=("https", "wss") )
 
    Constructor arguments should be passed as keyword arguments only.
    *blocked_domains* is a sequence of domain names that we never accept cookies
    from, nor return cookies to. *allowed_domains* if not :const:`None`, this is a
-   sequence of the only domains for which we accept and return cookies.  For all
-   other arguments, see the documentation for :class:`CookiePolicy` and
-   :class:`DefaultCookiePolicy` objects.
+   sequence of the only domains for which we accept and return cookies.
+   *secure_protocols* is a sequence of protocols for which secure cookies can be
+   added to. By default *https* and *wss* (secure websocket) are considered
+   secure protocols. For all other arguments, see the documentation for
+   :class:`CookiePolicy` and :class:`DefaultCookiePolicy` objects.
 
    :class:`DefaultCookiePolicy` implements the standard accept / reject rules for
    Netscape and :rfc:`2965` cookies.  By default, :rfc:`2109` cookies (ie. cookies

--- a/Lib/http/cookiejar.py
+++ b/Lib/http/cookiejar.py
@@ -878,6 +878,7 @@ class DefaultCookiePolicy(CookiePolicy):
                  strict_ns_domain=DomainLiberal,
                  strict_ns_set_initial_dollar=False,
                  strict_ns_set_path=False,
+                 secure_protocols=("https", "wss")
                  ):
         """Constructor arguments should be passed as keyword arguments only."""
         self.netscape = netscape
@@ -890,6 +891,7 @@ class DefaultCookiePolicy(CookiePolicy):
         self.strict_ns_domain = strict_ns_domain
         self.strict_ns_set_initial_dollar = strict_ns_set_initial_dollar
         self.strict_ns_set_path = strict_ns_set_path
+        self.secure_protocols = secure_protocols
 
         if blocked_domains is not None:
             self._blocked_domains = tuple(blocked_domains)
@@ -1116,7 +1118,7 @@ class DefaultCookiePolicy(CookiePolicy):
         return True
 
     def return_ok_secure(self, cookie, request):
-        if cookie.secure and request.type != "https":
+        if cookie.secure and request.type not in self.secure_protocols:
             _debug("   secure cookie with non-secure request")
             return False
         return True

--- a/Misc/NEWS.d/next/Library/2018-10-08-15-22-02.bpo-34911.hCy0Fv.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-08-15-22-02.bpo-34911.hCy0Fv.rst
@@ -1,0 +1,3 @@
+Added *secure_protocols* argument to *http.cookiejar.DefaultCookiePolicy* to
+allow for tweaking of protocols and also to add support by default for
+*wss*, the secure websocket protocol.


### PR DESCRIPTION
# Added support for secure websocket cookies

[bpo-34911](https://www.bugs.python.org/issue34911): Added support for secure websocket cookies


<!-- issue-number: [bpo-34911](https://www.bugs.python.org/issue34911) -->
https://bugs.python.org/issue34911
<!-- /issue-number -->
