### PR TITLE
bpo-34839: Add a 'before 3.6' in the section 'warnings' of doctest

### DIFF
--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -760,7 +760,7 @@ Warnings
 even a single character doesn't match, the test fails.  This will probably
 surprise you a few times, as you learn exactly what Python does and doesn't
 guarantee about output.  For example, before Python 3.6, when printing a dict,
-Python did not guarantee that the key-value pairs was printed in any
+Python did not guarantee that the key-value pairs were printed in any
 particular order, so a test like ::
 
    >>> foo()

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -759,19 +759,19 @@ Warnings
 :mod:`doctest` is serious about requiring exact matches in expected output.  If
 even a single character doesn't match, the test fails.  This will probably
 surprise you a few times, as you learn exactly what Python does and doesn't
-guarantee about output.  For example, when printing a dict, Python doesn't
-guarantee that the key-value pairs will be printed in any particular order, so a
-test like ::
+guarantee about output.  For example, before Python 3.6, when printing a dict,
+Python did not guarantee that the key-value pairs was printed in any
+particular order, so a test like ::
 
    >>> foo()
    {"Hermione": "hippogryph", "Harry": "broomstick"}
 
-is vulnerable!  One workaround is to do ::
+was vulnerable!  One workaround was to do ::
 
    >>> foo() == {"Hermione": "hippogryph", "Harry": "broomstick"}
    True
 
-instead.  Another is to do ::
+instead.  Another was to do ::
 
    >>> d = sorted(foo().items())
    >>> d

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -759,23 +759,27 @@ Warnings
 :mod:`doctest` is serious about requiring exact matches in expected output.  If
 even a single character doesn't match, the test fails.  This will probably
 surprise you a few times, as you learn exactly what Python does and doesn't
-guarantee about output.  For example, before Python 3.6, when printing a dict,
-Python did not guarantee that the key-value pairs were printed in any
-particular order, so a test like ::
+guarantee about output.  For example, when printing a set, Python doesn't
+guarantee that the key is printed in any particular order, so a test like ::
 
    >>> foo()
-   {"Hermione": "hippogryph", "Harry": "broomstick"}
+   {"Hermione", "Harry"}
 
-was vulnerable!  One workaround was to do ::
+was vulnerable!  One workaround is to do ::
 
-   >>> foo() == {"Hermione": "hippogryph", "Harry": "broomstick"}
+   >>> foo() == {"Hermione", "Harry"}
    True
 
-instead.  Another was to do ::
+instead.  Another is to do ::
 
-   >>> d = sorted(foo().items())
+   >>> d = sorted(foo())
    >>> d
-   [('Harry', 'broomstick'), ('Hermione', 'hippogryph')]
+   ['Harry', 'Hermione']
+
+.. note::
+
+    Before Python 3.6, when printing a dict, Python did not guarantee that
+    the key-value pairs was printed in any particular order.
 
 There are others, but you get the idea.
 

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -760,7 +760,7 @@ Warnings
 even a single character doesn't match, the test fails.  This will probably
 surprise you a few times, as you learn exactly what Python does and doesn't
 guarantee about output.  For example, when printing a set, Python doesn't
-guarantee that the key is printed in any particular order, so a test like ::
+guarantee that the element is printed in any particular order, so a test like ::
 
    >>> foo()
    {"Hermione", "Harry"}

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -765,7 +765,7 @@ guarantee that the element is printed in any particular order, so a test like ::
    >>> foo()
    {"Hermione", "Harry"}
 
-was vulnerable!  One workaround is to do ::
+is vulnerable!  One workaround is to do ::
 
    >>> foo() == {"Hermione", "Harry"}
    True


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34839](https://www.bugs.python.org/issue34839) -->
https://bugs.python.org/issue34839
<!-- /issue-number -->
