### PR TITLE
bpo-32995 - Added context variable in glossary

### DIFF
--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -221,6 +221,14 @@ Glossary
       statement by defining :meth:`__enter__` and :meth:`__exit__` methods.
       See :pep:`343`.
 
+    context variable
+      A variable which can have different values depending on it's context.
+      This is similar to TLS(Thread Local Storage) in which each execution
+      thread may have a different value for a variable. In case of context
+      variable, there may be sevaral contexts in one execution thread and it is
+      used to keep track of variables in concurrent asynchronous tasks.
+      See :pep:`567`.
+
    contiguous
       .. index:: C-contiguous, Fortran contiguous
 

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -227,7 +227,7 @@ Glossary
       thread may have a different value for a variable. In case of context
       variable, there may be sevaral contexts in one execution thread and it is
       used to keep track of variables in concurrent asynchronous tasks.
-      See :pep:`567`.
+      See `https://docs.python.org/3/library/contextvars.html`.
 
    contiguous
       .. index:: C-contiguous, Fortran contiguous

--- a/Doc/glossary.rst
+++ b/Doc/glossary.rst
@@ -222,12 +222,13 @@ Glossary
       See :pep:`343`.
 
     context variable
-      A variable which can have different values depending on it's context.
-      This is similar to TLS(Thread Local Storage) in which each execution
-      thread may have a different value for a variable. In case of context
-      variable, there may be sevaral contexts in one execution thread and it is
-      used to keep track of variables in concurrent asynchronous tasks.
-      See `https://docs.python.org/3/library/contextvars.html`.
+      A variable which can have different values depending on its context.
+      This is similar to Thread-Local Storage in which each execution
+      thread may have a different value for a variable. However, with context
+      variables, there may be several contexts in one execution thread and the
+      main usage for context variables is to keep track of variables in
+      concurrent asynchronous tasks.
+      See :mod:`contextvars`.
 
    contiguous
       .. index:: C-contiguous, Fortran contiguous

--- a/Misc/NEWS.d/next/Documentation/2018-10-07-03-04-57.bpo-32995.TXN9ur.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-10-07-03-04-57.bpo-32995.TXN9ur.rst
@@ -1,0 +1,1 @@
+Added the context variable in glossary.


### PR DESCRIPTION
[bpo-32995](https://www.bugs.python.org/issue32995) Added context variable in glossary.rst

<!-- issue-number: [bpo-32995](https://www.bugs.python.org/issue32995) -->
https://bugs.python.org/issue32995
<!-- /issue-number -->
