### PR TITLE
bpo-34921: No return not allowed by get_type_hints; line 133 …

### DIFF
--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -130,7 +130,7 @@ def _type_check(arg, msg, is_argument=True):
     if (isinstance(arg, _GenericAlias) and
             arg.__origin__ in invalid_generic_forms):
         raise TypeError(f"{arg} is not valid as type argument")
-    if (isinstance(arg, _SpecialForm) and arg not in [Any, NoReturn] or
+    if (isinstance(arg, _SpecialForm) and arg not in (Any, NoReturn) or
             arg in (Generic, _Protocol)):
         raise TypeError(f"Plain {arg} is not valid as type argument")
     if isinstance(arg, (type, TypeVar, ForwardRef)):

--- a/Lib/typing.py
+++ b/Lib/typing.py
@@ -130,7 +130,7 @@ def _type_check(arg, msg, is_argument=True):
     if (isinstance(arg, _GenericAlias) and
             arg.__origin__ in invalid_generic_forms):
         raise TypeError(f"{arg} is not valid as type argument")
-    if (isinstance(arg, _SpecialForm) and arg is not Any or
+    if (isinstance(arg, _SpecialForm) and arg not in [Any, NoReturn] or
             arg in (Generic, _Protocol)):
         raise TypeError(f"Plain {arg} is not valid as type argument")
     if isinstance(arg, (type, TypeVar, ForwardRef)):


### PR DESCRIPTION
[bpo-34921](https://www.bugs.python.org/issue34921): Modified line 133 in Lib/typing.py to fix get_type_hints(NoReturn)

<!-- issue-number: [bpo-34921](https://www.bugs.python.org/issue34921) -->
https://bugs.python.org/issue34921
<!-- /issue-number -->
