### PR TITLE
bpo-34817: Use double quote instead of backtick to clarify Ellipsis constant

### DIFF
--- a/Doc/library/constants.rst
+++ b/Doc/library/constants.rst
@@ -53,8 +53,8 @@ A small number of constants live in the built-in namespace.  They are:
 
 .. data:: Ellipsis
 
-   The same as ``...``.  Special value used mostly in conjunction with extended
-   slicing syntax for user-defined container data types.
+   The same as the ellipsis literal "...".  Special value used mostly in conjunction
+   with extended slicing syntax for user-defined container data types.
 
 
 .. data:: __debug__
@@ -96,4 +96,3 @@ should not be used in programs.
    Object that when printed, prints the message "Type license() to see the
    full license text", and when called, displays the full license text in a
    pager-like fashion (one screen at a time).
-


### PR DESCRIPTION
Using backtick `...`. in the docs is little confusing so use double quotes for a better visual distinction.

Current doc : 

The same as `...`.  Special value used mostly in conjunction with extended
slicing syntax for user-defined container data types.

Patch doc : 

The same as the ellipsis literal "...".  Special value used mostly in conjunction
with extended slicing syntax for user-defined container data types.



<!-- issue-number: [bpo-34817](https://www.bugs.python.org/issue34817) -->
https://bugs.python.org/issue34817
<!-- /issue-number -->
