### PR TITLE
[3.6] bpo-34901 - add isolated (-I) flag to sys.flags (GH-9708)

### DIFF
--- a/Doc/library/sys.rst
+++ b/Doc/library/sys.rst
@@ -286,6 +286,7 @@ always available.
    :const:`debug`                :option:`-d`
    :const:`inspect`              :option:`-i`
    :const:`interactive`          :option:`-i`
+   :const:`isolated`             :option:`-I`
    :const:`optimize`             :option:`-O` or :option:`-OO`
    :const:`dont_write_bytecode`  :option:`-B`
    :const:`no_user_site`         :option:`-s`
@@ -306,6 +307,8 @@ always available.
    .. versionchanged:: 3.3
       Removed obsolete ``division_warning`` attribute.
 
+   .. versionchanged:: 3.4
+      Added ``isolated`` attribute for :option:`-I` ``isolated`` flag.
 
 .. data:: float_info
 


### PR DESCRIPTION
(cherry picked from commit 656d52d)

<!-- issue-number: [bpo-34901](https://bugs.python.org/issue34901) -->
https://bugs.python.org/issue34901
<!-- /issue-number -->
