### PR TITLE
bpo-33014: minor docstring fixup

### DIFF
--- a/Objects/clinic/unicodeobject.c.h
+++ b/Objects/clinic/unicodeobject.c.h
@@ -382,7 +382,7 @@ PyDoc_STRVAR(unicode_isidentifier__doc__,
 "Return True if the string is a valid Python identifier, False otherwise.\n"
 "\n"
 "Call keyword.iskeyword(s) to test whether string s is a reserved identifier,\n"
-"such as \"def\" or \"class");
+"such as \"def\" or \"class\".");
 
 #define UNICODE_ISIDENTIFIER_METHODDEF    \
     {"isidentifier", (PyCFunction)unicode_isidentifier, METH_NOARGS, unicode_isidentifier__doc__},
@@ -951,4 +951,4 @@ unicode_sizeof(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     return unicode_sizeof_impl(self);
 }
-/*[clinic end generated code: output=c9476bf19f13c286 input=a9049054013a1b77]*/
+/*[clinic end generated code: output=8bcd992b25733bcc input=a9049054013a1b77]*/

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -12101,12 +12101,12 @@ str.isidentifier as unicode_isidentifier
 Return True if the string is a valid Python identifier, False otherwise.
 
 Call keyword.iskeyword(s) to test whether string s is a reserved identifier,
-such as "def" or "class
+such as "def" or "class".
 [clinic start generated code]*/
 
 static PyObject *
 unicode_isidentifier_impl(PyObject *self)
-/*[clinic end generated code: output=fe585a9666572905 input=2fb643aafbcf0e1c]*/
+/*[clinic end generated code: output=fe585a9666572905 input=2d807a104f21c0c5]*/
 {
     return PyBool_FromLong(PyUnicode_IsIdentifier(self));
 }


### PR DESCRIPTION
Add missing closing quote and trailing period in str.isidentifier() docstring

This rectifies commit ffc5a14d00db984c8e72c7b67da8a493e17e2c14.


<!-- issue-number: [bpo-33014](https://www.bugs.python.org/issue33014) -->
https://bugs.python.org/issue33014
<!-- /issue-number -->
