### PR TITLE
bpo-34932: Add TCP_KEEPALIVE to available flags when available

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -7800,6 +7800,9 @@ PyInit__socket(void)
 #ifdef  TCP_INFO
     PyModule_AddIntMacro(m, TCP_INFO);
 #endif
+#ifdef  TCP_KEEPALIVE
+    PyModule_AddIntMacro(m, TCP_KEEPALIVE);
+#endif
 #ifdef  TCP_QUICKACK
     PyModule_AddIntMacro(m, TCP_QUICKACK);
 #endif


### PR DESCRIPTION
Darwin uses TCP_KEEPALIVE flag for socket option. It is functionally
equivalent to TCP_KEEPIDLE on Linux.

https://bugs.python.org/issue34932

<!-- issue-number: [bpo-34932](https://www.bugs.python.org/issue34932) -->
https://bugs.python.org/issue34932
<!-- /issue-number -->
