### PR TITLE
bpo-34936: Fix TclError in tkinter.Spinbox.selection_element()

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3768,7 +3768,7 @@ class Spinbox(Widget, XView):
         If a spinbutton element is specified, it will be
         displayed depressed.
         """
-        return self.selection("element", element)
+        return self.tk.call(self._w, 'selection', 'element', element)
 
     def selection_from(self, index):
         """Set the fixed end of a selection to INDEX."""

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3737,8 +3737,11 @@ class Spinbox(Widget, XView):
 
     def selection(self, *args):
         """Internal function."""
-        return self._getints(
-            self.tk.call((self._w, 'selection') + args)) or ()
+        result = self.tk.call((self._w, 'selection') + args)
+        if result == "":
+            return ()
+        else:
+            return result
 
     def selection_adjust(self, index):
         """Locate the end of the selection nearest to the character

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3750,7 +3750,7 @@ class Spinbox(Widget, XView):
         select to commands. If the selection isn't currently in
         the spinbox, then a new selection is created to include
         the characters between index and the most recent selection
-        anchor point, inclusive. Returns an empty tuple.
+        anchor point, inclusive.
         """
         return self.selection("adjust", index)
 
@@ -3758,7 +3758,7 @@ class Spinbox(Widget, XView):
         """Clear the selection
 
         If the selection isn't in this widget then the
-        command has no effect. Returns an empty tuple.
+        command has no effect.
         """
         return self.selection("clear")
 

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3737,11 +3737,8 @@ class Spinbox(Widget, XView):
 
     def selection(self, *args):
         """Internal function."""
-        result = self.tk.call((self._w, 'selection') + args)
-        if result == "":
-            return ()
-        else:
-            return result
+        return self._getints(
+            self.tk.call((self._w, 'selection') + args)) or ()
 
     def selection_adjust(self, index):
         """Locate the end of the selection nearest to the character

--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3750,7 +3750,7 @@ class Spinbox(Widget, XView):
         select to commands. If the selection isn't currently in
         the spinbox, then a new selection is created to include
         the characters between index and the most recent selection
-        anchor point, inclusive. Returns an empty string.
+        anchor point, inclusive. Returns an empty tuple.
         """
         return self.selection("adjust", index)
 
@@ -3758,7 +3758,7 @@ class Spinbox(Widget, XView):
         """Clear the selection
 
         If the selection isn't in this widget then the
-        command has no effect. Returns an empty string.
+        command has no effect. Returns an empty tuple.
         """
         return self.selection("clear")
 
@@ -3766,7 +3766,7 @@ class Spinbox(Widget, XView):
         """Sets or gets the currently selected element.
 
         If a spinbutton element is specified, it will be
-        displayed depressed
+        displayed depressed.
         """
         return self.selection("element", element)
 

--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -522,6 +522,9 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self.assertEqual(widget.selection_get(), '2345')
         widget.selection_adjust(0)
         self.assertEqual(widget.selection_get(), '12345')
+
+    def test_selection_element_methods(self):
+        widget = self.create()
         self.assertEqual(widget.selection_element(), "none")
         widget.selection_element("buttonup")
         self.assertEqual(widget.selection_element(), "buttonup")

--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -522,7 +522,11 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self.assertEqual(widget.selection_get(), '2345')
         widget.selection_adjust(0)
         self.assertEqual(widget.selection_get(), '12345')
-        widget.selection_adjust(0)
+        self.assertEqual(widget.selection_element(), "none")
+        widget.selection_element("buttonup")
+        self.assertEqual(widget.selection_element(), "buttonup")
+        widget.selection_element("buttondown")
+        self.assertEqual(widget.selection_element(), "buttondown")
 
 
 @add_standard_options(StandardOptionsTests)

--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -523,7 +523,7 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         widget.selection_adjust(0)
         self.assertEqual(widget.selection_get(), '12345')
 
-    def test_selection_element_methods(self):
+    def test_selection_element(self):
         widget = self.create()
         self.assertEqual(widget.selection_element(), "none")
         widget.selection_element("buttonup")

--- a/Misc/NEWS.d/next/Library/2018-10-08-21-05-11.bpo-34936.3tRqdq.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-08-21-05-11.bpo-34936.3tRqdq.rst
@@ -1,0 +1,2 @@
+Fix ``TclError`` in ``tkinter.Spinbox.selection_element()``. Patch by
+Juliette Monsel.


### PR DESCRIPTION
``Spinbox.selection_element()`` raises ``TclError: expected integer but got "none"`` while it should return the currently selected element according to the docstring.

* I removed the call to ``self._getints`` in ``Spinbox.selection`` since the result is never a string of integers. For consistency with the previous behavior, ``Spinbox.selection`` still returns ``()`` when the result of ``self.tk.call((self._w, 'selection') + args)`` is an empty string.
* I added tests for the ``Spinbox.selection_element`` method.

<!-- issue-number: [bpo-34936](https://www.bugs.python.org/issue34936) -->
https://bugs.python.org/issue34936
<!-- /issue-number -->
