### PR TITLE
bpo-34940: Fix the error handling in _check_for_legacy_statements()

### DIFF
--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2906,7 +2906,7 @@ _check_for_legacy_statements(PySyntaxErrorObject *self, Py_ssize_t start)
      */
     static PyObject *print_prefix = NULL;
     static PyObject *exec_prefix = NULL;
-    Py_ssize_t text_len = PyUnicode_GET_LENGTH(self->text);
+    Py_ssize_t text_len = PyUnicode_GET_LENGTH(self->text), match;
     int kind = PyUnicode_KIND(self->text);
     void *data = PyUnicode_DATA(self->text);
 
@@ -2929,12 +2929,12 @@ _check_for_legacy_statements(PySyntaxErrorObject *self, Py_ssize_t start)
             return -1;
         }
     }
-    Py_ssize_t match = PyUnicode_Tailmatch(self->text, print_prefix,
-                                           start, text_len, -1);
+    match = PyUnicode_Tailmatch(self->text, print_prefix,
+                                start, text_len, -1);
     if (match == -1) {
         return -1;
     }
-    if (match == 1) {
+    if (match) {
         return _set_legacy_print_statement_msg(self, start);
     }
 
@@ -2949,12 +2949,13 @@ _check_for_legacy_statements(PySyntaxErrorObject *self, Py_ssize_t start)
     if (match == -1) {
         return -1;
     }
-    if (match == 1) {
-        Py_XSETREF(self->msg,
-                  PyUnicode_FromString("Missing parentheses in call to 'exec'"));
-        if (self->msg == NULL) {
+    if (match) {
+        PyObject *msg = PyUnicode_FromString("Missing parentheses in call "
+                                             "to 'exec'");
+        if (msg == NULL) {
             return -1;
         }
+        Py_XSETREF(self->msg, msg);
         return 1;
     }
     /* Fall back to the default error message */

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -2929,9 +2929,12 @@ _check_for_legacy_statements(PySyntaxErrorObject *self, Py_ssize_t start)
             return -1;
         }
     }
-    if (PyUnicode_Tailmatch(self->text, print_prefix,
-                            start, text_len, -1)) {
-
+    Py_ssize_t match = PyUnicode_Tailmatch(self->text, print_prefix,
+                                           start, text_len, -1);
+    if (match == -1) {
+        return -1;
+    }
+    if (match == 1) {
         return _set_legacy_print_statement_msg(self, start);
     }
 
@@ -2942,10 +2945,16 @@ _check_for_legacy_statements(PySyntaxErrorObject *self, Py_ssize_t start)
             return -1;
         }
     }
-    if (PyUnicode_Tailmatch(self->text, exec_prefix,
-                            start, text_len, -1)) {
+    match = PyUnicode_Tailmatch(self->text, exec_prefix, start, text_len, -1);
+    if (match == -1) {
+        return -1;
+    }
+    if (match == 1) {
         Py_XSETREF(self->msg,
                   PyUnicode_FromString("Missing parentheses in call to 'exec'"));
+        if (self->msg == NULL) {
+            return -1;
+        }
         return 1;
     }
     /* Fall back to the default error message */


### PR DESCRIPTION


<!-- issue-number: [bpo-34940](https://www.bugs.python.org/issue34940) -->
https://bugs.python.org/issue34940
<!-- /issue-number -->
