### PR TITLE
bpo-34941: Fix searching Element subclasses.

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -2160,6 +2160,21 @@ class ElementTreeTypeTest(unittest.TestCase):
         mye = MyElement('joe')
         self.assertEqual(mye.newmethod(), 'joe')
 
+    def test_Element_subclass_find(self):
+        class MyElement(ET.Element):
+            pass
+
+        e = ET.Element('foo')
+        e.text = 'text'
+        sub = MyElement('bar')
+        sub.text = 'subtext'
+        e.append(sub)
+        self.assertEqual(e.findtext('bar'), 'subtext')
+        self.assertEqual(e.find('bar').tag, 'bar')
+        found = list(e.findall('bar'))
+        self.assertEqual(len(found), 1, found)
+        self.assertEqual(found[0].tag, 'bar')
+
 
 class ElementFindTest(unittest.TestCase):
     def test_find_simple(self):

--- a/Misc/NEWS.d/next/Library/2018-10-09-14-42-16.bpo-34941.1Q5QKv.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-09-14-42-16.bpo-34941.1Q5QKv.rst
@@ -1,0 +1,3 @@
+Methods ``find()``, ``findtext()`` and ``findall()`` of the ``Element``
+class in the :mod:`xml.etree.ElementTree` module are now able to find
+children which are instances of ``Element`` subclasses.


### PR DESCRIPTION
Methods find(), findtext() and findall() of xml.etree.ElementTree.Element
were not able to find chldren which are instances of Element subclasses.


<!-- issue-number: [bpo-34941](https://www.bugs.python.org/issue34941) -->
https://bugs.python.org/issue34941
<!-- /issue-number -->
