### PR TITLE
bpo-34926: Make mimetypes.guess_type accept os.PathLike objects

### DIFF
--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -26,12 +26,12 @@ the module has not been initialized, they will call :func:`init` if they rely on
 the information :func:`init` sets up.
 
 
-.. function:: guess_type(url, strict=True)
+.. function:: guess_type(url_or_path, strict=True)
 
    .. index:: pair: MIME; headers
 
-   Guess the type of a file based on its filename or URL, given by *url*.  The
-   return value is a tuple ``(type, encoding)`` where *type* is ``None`` if the
+   Guess the type of a file based on its filename/URL or by its path (any :class:`os.PathLike`).
+   The return value is a tuple ``(type, encoding)`` where *type* is ``None`` if the
    type can't be guessed (missing or unknown suffix) or a string of the form
    ``'type/subtype'``, usable for a MIME :mailheader:`content-type` header.
 
@@ -48,6 +48,9 @@ the information :func:`init` sets up.
    When *strict* is ``True`` (the default), only the IANA types are supported; when
    *strict* is ``False``, some additional non-standard but commonly used MIME types
    are also recognized.
+
+   .. versionchanged:: 3.8
+      Added support for url being a :term:`path-like object`.
 
 
 .. function:: guess_all_extensions(type, strict=True)

--- a/Doc/library/mimetypes.rst
+++ b/Doc/library/mimetypes.rst
@@ -26,11 +26,13 @@ the module has not been initialized, they will call :func:`init` if they rely on
 the information :func:`init` sets up.
 
 
-.. function:: guess_type(url_or_path, strict=True)
+.. function:: guess_type(url, strict=True)
 
    .. index:: pair: MIME; headers
 
-   Guess the type of a file based on its filename/URL or by its path (any :class:`os.PathLike`).
+   Guess the type of a file based on its filename, path or URL, given by *url*.
+   URL can be a string or a :term:`path-like object`.
+
    The return value is a tuple ``(type, encoding)`` where *type* is ``None`` if the
    type can't be guessed (missing or unknown suffix) or a string of the form
    ``'type/subtype'``, usable for a MIME :mailheader:`content-type` header.

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -113,10 +113,7 @@ class MimeTypes:
         Optional `strict' argument when False adds a bunch of commonly found,
         but non-standard types.
         """
-        url = url_or_path
-        if isinstance(url_or_path, os.PathLike):
-            url = os.fspath(url)
-
+        url = os.fspath(url_or_path)
         scheme, url = urllib.parse._splittype(url)
         if scheme == 'data':
             # syntax of data URLs:

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -94,8 +94,8 @@ class MimeTypes:
         if ext not in exts:
             exts.append(ext)
 
-    def guess_type(self, url, strict=True):
-        """Guess the type of a file based on its URL.
+    def guess_type(self, url_or_path, strict=True):
+        """Guess the type of a file which can either be a url or an os.PathLike object.
 
         Return value is a tuple (type, encoding) where type is None if
         the type can't be guessed (no or unknown suffix) or a string
@@ -113,6 +113,10 @@ class MimeTypes:
         Optional `strict' argument when False adds a bunch of commonly found,
         but non-standard types.
         """
+        url = url_or_path
+        if isinstance(url_or_path, os.PathLike):
+            url = os.fspath(url)
+
         scheme, url = urllib.parse._splittype(url)
         if scheme == 'data':
             # syntax of data URLs:

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -95,7 +95,7 @@ class MimeTypes:
             exts.append(ext)
 
     def guess_type(self, url, strict=True):
-        """Guess the type of a file which is either a URL or an os.PathLike object.
+        """Guess the type of a file which is either a URL or a path-like object.
 
         Return value is a tuple (type, encoding) where type is None if
         the type can't be guessed (no or unknown suffix) or a string

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -94,7 +94,7 @@ class MimeTypes:
         if ext not in exts:
             exts.append(ext)
 
-    def guess_type(self, url_or_path, strict=True):
+    def guess_type(self, url, strict=True):
         """Guess the type of a file which is either a URL or an os.PathLike object.
 
         Return value is a tuple (type, encoding) where type is None if
@@ -113,7 +113,7 @@ class MimeTypes:
         Optional `strict' argument when False adds a bunch of commonly found,
         but non-standard types.
         """
-        url = os.fspath(url_or_path)
+        url = os.fspath(url)
         scheme, url = urllib.parse._splittype(url)
         if scheme == 'data':
             # syntax of data URLs:

--- a/Lib/mimetypes.py
+++ b/Lib/mimetypes.py
@@ -95,7 +95,7 @@ class MimeTypes:
             exts.append(ext)
 
     def guess_type(self, url_or_path, strict=True):
-        """Guess the type of a file which can either be a url or an os.PathLike object.
+        """Guess the type of a file which is either a URL or an os.PathLike object.
 
         Return value is a tuple (type, encoding) where type is None if
         the type can't be guessed (no or unknown suffix) or a string

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -3,6 +3,7 @@ import locale
 import mimetypes
 import sys
 import unittest
+import pathlib
 
 from test import support
 
@@ -76,6 +77,23 @@ class MimeTypesTestCase(unittest.TestCase):
         exts = mimes.guess_all_extensions('application/vnd.geocube+xml',
                                           strict=True)
         self.assertEqual(exts, ['.g3', '.g\xb3'])
+
+    def test_path_like_ob(self):
+        eq = self.assertEqual
+
+        filename = "LICENSE.txt"
+        filepath = pathlib.Path(filename)
+        filepath_with_abs_dir = pathlib.Path('/dir/'+filename)
+        filepath_relative = pathlib.Path('../dir/'+filename)
+        path_dir = pathlib.Path('./')
+
+        expected = self.db.guess_type(filename)
+
+        eq(self.db.guess_type(filepath), expected)
+        eq(self.db.guess_type(
+            filepath_with_abs_dir), expected)
+        eq(self.db.guess_type(filepath_relative), expected)
+        eq(self.db.guess_type(path_dir), (None, None))
 
 
 @unittest.skipUnless(sys.platform.startswith("win"), "Windows only")

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -1,9 +1,9 @@
 import io
 import locale
 import mimetypes
+import pathlib
 import sys
 import unittest
-import pathlib
 
 from test import support
 

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -79,8 +79,6 @@ class MimeTypesTestCase(unittest.TestCase):
         self.assertEqual(exts, ['.g3', '.g\xb3'])
 
     def test_path_like_ob(self):
-        eq = self.assertEqual
-
         filename = "LICENSE.txt"
         filepath = pathlib.Path(filename)
         filepath_with_abs_dir = pathlib.Path('/dir/'+filename)
@@ -89,11 +87,11 @@ class MimeTypesTestCase(unittest.TestCase):
 
         expected = self.db.guess_type(filename)
 
-        eq(self.db.guess_type(filepath), expected)
-        eq(self.db.guess_type(
+        self.assertEqual(self.db.guess_type(filepath), expected)
+        self.assertEqual(self.db.guess_type(
             filepath_with_abs_dir), expected)
-        eq(self.db.guess_type(filepath_relative), expected)
-        eq(self.db.guess_type(path_dir), (None, None))
+        self.assertEqual(self.db.guess_type(filepath_relative), expected)
+        self.assertEqual(self.db.guess_type(path_dir), (None, None))
 
 
 @unittest.skipUnless(sys.platform.startswith("win"), "Windows only")

--- a/Lib/test/test_mimetypes.py
+++ b/Lib/test/test_mimetypes.py
@@ -93,6 +93,14 @@ class MimeTypesTestCase(unittest.TestCase):
         self.assertEqual(self.db.guess_type(filepath_relative), expected)
         self.assertEqual(self.db.guess_type(path_dir), (None, None))
 
+    def test_keywords_args_api(self):
+        self.assertEqual(self.db.guess_type(
+            url="foo.html", strict=True), ("text/html", None))
+        self.assertEqual(self.db.guess_all_extensions(
+            type='image/jpg', strict=True), [])
+        self.assertEqual(self.db.guess_extension(
+            type='image/jpg', strict=False), '.jpg')
+
 
 @unittest.skipUnless(sys.platform.startswith("win"), "Windows only")
 class Win32MimeTypesTestCase(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-10-10-00-22-57.bpo-34926.CA0rqd.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-10-00-22-57.bpo-34926.CA0rqd.rst
@@ -1,0 +1,2 @@
+:meth:`mimetypes.MimeTypes.guess_type` now accepts :class:`os.PathLike`
+objects in addition to url strings. Patch by Mayank Asthana.

--- a/Misc/NEWS.d/next/Library/2018-10-10-00-22-57.bpo-34926.CA0rqd.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-10-00-22-57.bpo-34926.CA0rqd.rst
@@ -1,2 +1,2 @@
-:meth:`mimetypes.MimeTypes.guess_type` now accepts :term:`path-like` objects in addition to url strings.
+:meth:`mimetypes.MimeTypes.guess_type` now accepts :term:`path-like object`s in addition to url strings.
 Patch by Mayank Asthana.

--- a/Misc/NEWS.d/next/Library/2018-10-10-00-22-57.bpo-34926.CA0rqd.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-10-00-22-57.bpo-34926.CA0rqd.rst
@@ -1,2 +1,2 @@
-:meth:`mimetypes.MimeTypes.guess_type` now accepts :term:`path-like object`s in addition to url strings.
+:meth:`mimetypes.MimeTypes.guess_type` now accepts :term:`path-like object` in addition to url strings.
 Patch by Mayank Asthana.

--- a/Misc/NEWS.d/next/Library/2018-10-10-00-22-57.bpo-34926.CA0rqd.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-10-00-22-57.bpo-34926.CA0rqd.rst
@@ -1,2 +1,2 @@
-:meth:`mimetypes.MimeTypes.guess_type` now accepts :class:`os.PathLike`
-objects in addition to url strings. Patch by Mayank Asthana.
+:meth:`mimetypes.MimeTypes.guess_type` now accepts :term:`path-like` objects in addition to url strings.
+Patch by Mayank Asthana.


### PR DESCRIPTION
<!-- issue-number: [bpo-34926](https://www.bugs.python.org/issue34926) -->
https://bugs.python.org/issue34926
<!-- /issue-number -->
