### PR TITLE
[Skip Issue] Fix a possible decref of a borrowed reference in symtable.c

### DIFF
--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -625,8 +625,10 @@ update_symbols(PyObject *symbols, PyObject *scopes,
         return 0;
 
     itr = PyObject_GetIter(free);
-    if (!itr)
-        goto error;
+    if (itr == NULL) {
+        Py_DECREF(v_free);
+        return 0;
+    }
 
     while ((name = PyIter_Next(itr))) {
         v = PyDict_GetItem(symbols, name);


### PR DESCRIPTION
If `PyObject_GetIter()` fails in `update_symbols()`, `name` will be decrefed, but `name` is a borrowed reference at this point.