### PR TITLE
bpo-35138: Added an example for timeit.timeit with callable arguments

### DIFF
--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -45,10 +45,10 @@ This can be achieved from the :ref:`python-interface` with::
    0.23702679807320237
 
 
-Note however that :mod:`timeit` will automatically determine the number of
+Note however that :func:`.timeit` will automatically determine the number of
 repetitions only when the command-line interface is used.
 
-:mod:`timeit` also takes a callable for the statement and setup parameters::
+:func:`.timeit` also takes a callable for the *stmt* and *setup* parameters::
 
    >>> timeit.timeit(lambda: "-".join(map(str, range(100))), number=10000)
    0.19665591977536678

--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -46,8 +46,17 @@ This can be achieved from the :ref:`python-interface` with::
 
 
 Note however that :mod:`timeit` will automatically determine the number of
-repetitions only when the command-line interface is used.  In the
-:ref:`timeit-examples` section you can find more advanced examples.
+repetitions only when the command-line interface is used.
+
+:mod:`timeit` also takes a callable for the statement and setup parameters::
+
+   >>> timeit.timeit(lambda: "-".join(map(str, range(100))), number=10000)
+   0.19665591977536678
+   >>> import time
+   >>> timeit.timeit(lambda: "-".join(map(str, range(100))), setup=lambda: time.sleep(1), number=10000)
+   0.19662280194461346
+
+In the :ref:`timeit-examples` section you can find more advanced examples.
 
 
 .. _python-interface:

--- a/Doc/library/timeit.rst
+++ b/Doc/library/timeit.rst
@@ -44,19 +44,14 @@ This can be achieved from the :ref:`python-interface` with::
    >>> timeit.timeit('"-".join(map(str, range(100)))', number=10000)
    0.23702679807320237
 
-
-Note however that :func:`.timeit` will automatically determine the number of
-repetitions only when the command-line interface is used.
-
-:func:`.timeit` also takes a callable for the *stmt* and *setup* parameters::
+A callable can also be passed from the :ref:`python-interface`::
 
    >>> timeit.timeit(lambda: "-".join(map(str, range(100))), number=10000)
    0.19665591977536678
-   >>> import time
-   >>> timeit.timeit(lambda: "-".join(map(str, range(100))), setup=lambda: time.sleep(1), number=10000)
-   0.19662280194461346
 
-In the :ref:`timeit-examples` section you can find more advanced examples.
+Note however that :func:`.timeit` will automatically determine the number of
+repetitions only when the command-line interface is used.  In the
+:ref:`timeit-examples` section you can find more advanced examples.
 
 
 .. _python-interface:


### PR DESCRIPTION
The timeit module has a feature that is documented, but seems so hard to spot in the docs that it is easily missed. This PR adds a small example to make this feature easier to spot.

See python-ideas discussion: https://groups.google.com/forum/#!topic/python-ideas/0HzCEj0H9NM

<!-- issue-number: [bpo-35138](https://bugs.python.org/issue35138) -->
https://bugs.python.org/issue35138
<!-- /issue-number -->
