### PR TITLE
[2.7] bpo-32962: Fix test_gdb failure in debug build with -mcet -fcf-protection -O0 (GH-9656)

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -58,6 +58,23 @@ if sys.platform.startswith("sunos"):
 checkout_hook_path = os.path.join(os.path.dirname(sys.executable),
                                   'python-gdb.py')
 
+
+def cet_protection():
+    cflags = sysconfig.get_config_var('CFLAGS')
+    if not cflags:
+        return False
+    flags = cflags.split()
+    # True if "-mcet -fcf-protection" options are found, but false
+    # if "-fcf-protection=none" or "-fcf-protection=return" is found.
+    return (('-mcet' in flags)
+            and any((flag.startswith('-fcf-protection')
+                     and not flag.endswith(("=none", "=return")))
+                    for flag in flags))
+
+# Control-flow enforcement technology
+CET_PROTECTION = cet_protection()
+
+
 def run_gdb(*args, **env_vars):
     """Runs gdb in batch mode with the additional arguments given by *args.
 
@@ -171,6 +188,12 @@ class DebuggerTests(unittest.TestCase):
             commands += ['set print entry-values no']
 
         if cmds_after_breakpoint:
+            if CET_PROTECTION:
+                # bpo-32962: When Python is compiled with -mcet
+                # -fcf-protection, function arguments are unusable before
+                # running the first instruction of the function entry point.
+                # The 'next' command makes the required first step.
+                commands += ['next']
             commands += cmds_after_breakpoint
         else:
             commands += ['backtrace']
@@ -241,6 +264,11 @@ class DebuggerTests(unittest.TestCase):
         #
         # For a nested structure, the first time we hit the breakpoint will
         # give us the top-level structure
+
+        # NOTE: avoid decoding too much of the traceback as some
+        # undecodable characters may lurk there in optimized mode
+        # (issue #19743).
+        cmds_after_breakpoint = cmds_after_breakpoint or ["backtrace 1"]
         gdb_output = self.get_stack_trace(source, breakpoint='PyObject_Print',
                                           cmds_after_breakpoint=cmds_after_breakpoint,
                                           import_site=import_site)
@@ -886,9 +914,17 @@ print 42
             print("first break point")
             l = MyList()
         ''')
+        cmds_after_breakpoint = ['break wrapper_call', 'continue']
+        if CET_PROTECTION:
+            # bpo-32962: same case as in get_stack_trace():
+            # we need an additional 'next' command in order to read
+            # arguments of the innermost function of the call stack.
+            cmds_after_breakpoint.append('next')
+        cmds_after_breakpoint.append('py-bt')
+
         # Verify with "py-bt":
         gdb_output = self.get_stack_trace(cmd,
-                                          cmds_after_breakpoint=['break wrapper_call', 'continue', 'py-bt'])
+                                          cmds_after_breakpoint=cmds_after_breakpoint)
         self.assertRegexpMatches(gdb_output,
                                  r"<method-wrapper u?'__init__' of MyList object at ")
 

--- a/Misc/NEWS.d/next/Tests/2018-05-10-16-59-15.bpo-32962.S-rcIN.rst
+++ b/Misc/NEWS.d/next/Tests/2018-05-10-16-59-15.bpo-32962.S-rcIN.rst
@@ -1,0 +1,1 @@
+Fixed test_gdb when Python is compiled with flags -mcet -fcf-protection -O0.


### PR DESCRIPTION
When Python is built with the intel control-flow protection flags,
-mcet -fcf-protection, gdb is not able to read the stack without
actually jumping inside the function. This means an extra
'next' command is required to make the $pc (program counter)
enter the function and make the stack of the function exposed to gdb.

test_gdb: get_gdb_repr() now uses the "backtrace 1" command after
breakpoint, as in the master branch.

Co-Authored-By: Marcel Plch <gmarcel.plch@gmail.com>

(cherry picked from commit 9b7c74ca32d1bec7128d550a9ab1b2ddc7046287)
(cherry picked from commit 79d21331e605fdc941f947621846b8563485aab6)

<!-- issue-number: [bpo-32962](https://www.bugs.python.org/issue32962) -->
https://bugs.python.org/issue32962
<!-- /issue-number -->
