### PR TITLE
Fix outdated info in datamodel about dicts

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1450,8 +1450,8 @@ Basic customization
       dict insertion, O(n^2) complexity.  See
       http://www.ocert.org/advisories/ocert-2011-003.html for details.
 
-      Changing hash values affects the iteration order of dicts, sets and
-      other mappings.  Python has never made guarantees about this ordering
+      Changing hash values affects the iteration order of sets.
+      Python has never made guarantees about this ordering
       (and it typically varies between 32-bit and 64-bit builds).
 
       See also :envvar:`PYTHONHASHSEED`.


### PR DESCRIPTION
Pretty self explanatory, the docs say that Python has never made guarantees about iteration order but that's not true anymore.  It's still relevant for info sets, though.

Could a maintainer please add a "trivial" or "skip issue" label?