### PR TITLE
bpo-34748: link to :ref:partial-objects in functools doc.

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -205,10 +205,11 @@ The :mod:`functools` module defines the following functions:
 
 .. function:: partial(func, *args, **keywords)
 
-   Return a new :class:`partial` object which when called will behave like *func*
-   called with the positional arguments *args* and keyword arguments *keywords*. If
-   more arguments are supplied to the call, they are appended to *args*. If
-   additional keyword arguments are supplied, they extend and override *keywords*.
+   Return a new :ref:`partial object<partial-objects>` which when called
+   will behave like *func* called with the positional arguments *args*
+   and keyword arguments *keywords*. If more arguments are supplied to the
+   call, they are appended to *args*. If additional keyword arguments are
+   supplied, they extend and override *keywords*.
    Roughly equivalent to::
 
       def partial(func, *args, **keywords):
@@ -247,7 +248,7 @@ The :mod:`functools` module defines the following functions:
    :func:`classmethod`, :func:`staticmethod`, :func:`abstractmethod` or
    another instance of :class:`partialmethod`), calls to ``__get__`` are
    delegated to the underlying descriptor, and an appropriate
-   :class:`partial` object returned as the result.
+   :ref:`partial object<partial-objects>` returned as the result.
 
    When *func* is a non-descriptor callable, an appropriate bound method is
    created dynamically. This behaves like a normal Python function when


### PR DESCRIPTION
https://bugs.python.org/issue34748

* Needs backport to 2.7, 3.6, 3.7

The PR just changes
```
:class:`partial` object
```
into
```
:ref:`partial object<partial-objects>`
```


There are some more mentions of `partial objects` at the bottom in the partial objects section, but I don't think it's needed to change those links as well -- it's obvious that you're talking about the partial objects you're currently at, that section is pretty short.

<!-- issue-number: [bpo-34748](https://www.bugs.python.org/issue34748) -->
https://bugs.python.org/issue34748
<!-- /issue-number -->
