### PR TITLE
bpo-34203: FAQ: minor additional rewording and fix a few typos

### DIFF
--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -312,13 +312,13 @@ guaranteed that interfaces will remain the same throughout a series of bugfix
 releases.
 
 The latest stable releases can always be found on the `Python download page
-<https://www.python.org/downloads/>`_.  There are two production-ready version
-of Python: 2.x and 3.x, but the recommended one at this times is Python 3.x.
-Although Python 2.x is still widely used, `it will not be
-maintained after January 1, 2020 <https://www.python.org/dev/peps/pep-0373/>`_.
-Python 2.x was known for having more third-party libraries available, however,
-by the time of this writing, most of the widely used libraries support Python 3.x,
-and some are even dropping the Python 2.x support.
+<https://www.python.org/downloads/>`_.  There are two production-ready versions
+of Python: 2.x and 3.x, with the recommended one at this time being 3.x.
+Although 2.x is still widely used, `it will not be maintained after
+January 1, 2020 <https://www.python.org/dev/peps/pep-0373/>`_.  2.x was known
+for having more third-party libraries available; however, by the time of this
+writing, most of the widely used libraries support 3.x, and some are even
+dropping their support for 2.x.
 
 
 How many people are using Python?

--- a/Doc/faq/general.rst
+++ b/Doc/faq/general.rst
@@ -313,13 +313,9 @@ releases.
 
 The latest stable releases can always be found on the `Python download page
 <https://www.python.org/downloads/>`_.  There are two production-ready versions
-of Python: 2.x and 3.x, with the recommended one at this time being 3.x.
-Although 2.x is still widely used, `it will not be maintained after
-January 1, 2020 <https://www.python.org/dev/peps/pep-0373/>`_.  2.x was known
-for having more third-party libraries available; however, by the time of this
-writing, most of the widely used libraries support 3.x, and some are even
-dropping their support for 2.x.
-
+of Python: 2.x and 3.x. The recommended version is 3.x, which is supported by
+most widely used libraries.  Although 2.x is still widely used, `it will not
+be maintained after January 1, 2020 <https://www.python.org/dev/peps/pep-0373/>`_.
 
 How many people are using Python?
 ---------------------------------


### PR DESCRIPTION
This is following up @augustogoulart's recent change to the "How stable is Python?" FAQ section, recommending 3.x over 2.x.

Upon reading the final build version, I noticed a few typos and an over-abundant use of the name "Python". This is a minor revision fixing those issues.

<!-- issue-number: [bpo-34203](https://www.bugs.python.org/issue34203) -->
https://bugs.python.org/issue34203
<!-- /issue-number -->
