### PR TITLE
Clarify that plistlib's load and dump functions take a binary file object

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -928,7 +928,7 @@ _FORMATS={
 
 
 def load(fp, *, fmt=None, use_builtin_types=True, dict_type=dict):
-    """Read a .plist file. 'fp' should be (readable) file object.
+    """Read a .plist file. 'fp' should be a readable and binary file object.
     Return the unpacked root object (which usually is a dictionary).
     """
     if fmt is None:
@@ -959,8 +959,8 @@ def loads(value, *, fmt=None, use_builtin_types=True, dict_type=dict):
 
 
 def dump(value, fp, *, fmt=FMT_XML, sort_keys=True, skipkeys=False):
-    """Write 'value' to a .plist file. 'fp' should be a (writable)
-    file object.
+    """Write 'value' to a .plist file. 'fp' should be a writable,
+    binary file object.
     """
     if fmt not in _FORMATS:
         raise ValueError("Unsupported format: %r"%(fmt,))


### PR DESCRIPTION
The documentation says that the fp parameter to plistlib.load "should be a
readable and binary file object" but the docstring only mentions that it
should be readable. Similarly, plistlib.dump's docstring only mentions
"writable". This commit clarifies that fp should also be binary.

https://docs.python.org/3/library/plistlib.html#plistlib.load
https://docs.python.org/3/library/plistlib.html#plistlib.dump

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
