### PR TITLE
Update Windows download to direct link

### DIFF
--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -17,9 +17,9 @@ Installing Python
 
 Unlike most Unix systems and services, Windows does not include a system
 supported installation of Python. To make Python available, the CPython team
-has compiled Windows installers (MSI packages) for the current `release
-<https://www.python.org/downloads/>`_ and for previous `releases
-<https://www.python.org/downloads/windows/>`_. These installers
+has compiled Windows installers (MSI packages) for the `current
+<https://www.python.org/downloads/>`_ and `previous
+<https://www.python.org/downloads/windows/>`_ releases. These installers
 are primarily intended to add a per-user installation of Python, with the
 core interpreter and library being used by a single user. The installer is also
 able to install for all users of a single machine, and a separate ZIP file is

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -17,8 +17,9 @@ Installing Python
 
 Unlike most Unix systems and services, Windows does not include a system
 supported installation of Python. To make Python available, the CPython team
-has compiled Windows installers (MSI packages) with every `release
-<https://www.python.org/downloads/>`_ for many years. These installers
+has compiled Windows installers (MSI packages) for the current `release
+<https://www.python.org/downloads/>`_ and for previous `releases
+<https://www.python.org/downloads/windows/>`_. These installers
 are primarily intended to add a per-user installation of Python, with the
 core interpreter and library being used by a single user. The installer is also
 able to install for all users of a single machine, and a separate ZIP file is

--- a/Doc/using/windows.rst
+++ b/Doc/using/windows.rst
@@ -18,7 +18,7 @@ Installing Python
 Unlike most Unix systems and services, Windows does not include a system
 supported installation of Python. To make Python available, the CPython team
 has compiled Windows installers (MSI packages) with every `release
-<https://www.python.org/download/releases/>`_ for many years. These installers
+<https://www.python.org/downloads/>`_ for many years. These installers
 are primarily intended to add a per-user installation of Python, with the
 core interpreter and library being used by a single user. The installer is also
 able to install for all users of a single machine, and a separate ZIP file is


### PR DESCRIPTION
The `releases` link for Windows currently goes to a page that requires clicking on a link to go to the correct Downloads page.  This change will link directly to the downloads page.
