### PR TITLE
bpo-34783:  Disable test_nonexisting_script for macOS framework builds

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -630,9 +630,13 @@ class CmdLineTest(unittest.TestCase):
             traceback_lines = stderr.decode().splitlines()
             self.assertIn("No module named script_pkg", traceback_lines[-1])
 
+    @unittest.skipIf(sys.platform == 'darwin' and sys._framework,
+                        "test not valid for macOS framework builds")
     def test_nonexisting_script(self):
         # bpo-34783: "./python script.py" must not crash
         # if the script file doesn't exist.
+        # (Skip test for macOS framework builds because sys.excutable name
+        #  is not the actual Python executable file name.
         script = 'nonexistingscript.py'
         self.assertFalse(os.path.exists(script))
         # Only test the base name, since the error message can use


### PR DESCRIPTION
With macOS framework builds, test case test_nonexisting_script in
test_nonexisting_script fails because the test case assumes that
the file name in sys.executable will appear in the error message.
For macOS framework builds, sys.executable is the file name of the
stub launcher and its file name bears no relationship to the file
name of the actual python executable.  For now, skip the test in
this case.

<!-- issue-number: [bpo-34783](https://www.bugs.python.org/issue34783) -->
https://bugs.python.org/issue34783
<!-- /issue-number -->
