### PR TITLE
bpo-33234 Improve list() pre-sizing for inputs with known lengths (no __length_hint__) 

### DIFF
--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -2028,7 +2028,7 @@ order (MRO) for bases """
                 setattr(X, attr, obj)
             setattr(X, name, SpecialDescr(meth_impl))
             runner(X())
-            self.assertGreaterEqual(record.count(1), 1, name)
+            self.assertEqual(record, [1], name)
 
             class X(Checker):
                 pass

--- a/Lib/test/test_descr.py
+++ b/Lib/test/test_descr.py
@@ -2028,7 +2028,7 @@ order (MRO) for bases """
                 setattr(X, attr, obj)
             setattr(X, name, SpecialDescr(meth_impl))
             runner(X())
-            self.assertEqual(record, [1], name)
+            self.assertGreaterEqual(record.count(1), 1, name)
 
             class X(Checker):
                 pass

--- a/Lib/test/test_list.py
+++ b/Lib/test/test_list.py
@@ -1,5 +1,6 @@
 import sys
 from test import list_tests
+from test.support import cpython_only
 import pickle
 import unittest
 
@@ -156,6 +157,14 @@ class ListTest(list_tests.CommonTest):
         class L(list): pass
         with self.assertRaises(TypeError):
             (3,) + L([1,2])
+
+    @cpython_only
+    def test_preallocation(self):
+        iterable = [0] * 10
+        iter_size = sys.getsizeof(iterable)
+
+        self.assertEqual(iter_size, sys.getsizeof(list([0] * 10)))
+        self.assertEqual(iter_size, sys.getsizeof(list(range(10))))
 
 if __name__ == "__main__":
     unittest.main()

--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-17-01-24-51.bpo-33234.l9IDtp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-17-01-24-51.bpo-33234.l9IDtp.rst
@@ -1,2 +1,2 @@
-The list constructor will pre-size and not over-allocate when the input size
-is known or can be reasonably estimated.
+The list constructor will pre-size and not over-allocate when
+the input lenght is known.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-04-17-01-24-51.bpo-33234.l9IDtp.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-04-17-01-24-51.bpo-33234.l9IDtp.rst
@@ -1,0 +1,2 @@
+The list constructor will pre-size and not over-allocate when the input size
+is known or can be reasonably estimated.

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2675,7 +2675,7 @@ list___init___impl(PyListObject *self, PyObject *iterable)
         (void)_list_clear(self);
     }
     if (iterable != NULL) {
-        Py_ssize_t iter_len = PyObject_LengthHint(iterable, 0);
+        Py_ssize_t iter_len = PyObject_Length(iterable);
         if (iter_len == -1){
             PyErr_Clear();
         }

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2679,7 +2679,7 @@ list___init___impl(PyListObject *self, PyObject *iterable)
         if (_PyObject_HasLen(iterable)) {
             Py_ssize_t iter_len = PyObject_Size(iterable);
             if (iter_len == -1) {
-                if (!PyErr_ExceptionMatches(PyExc_Exception)) {
+                if (!PyErr_ExceptionMatches(PyExc_TypeError)) {
                     return -1;
                 }
                 PyErr_Clear();

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2675,12 +2675,14 @@ list___init___impl(PyListObject *self, PyObject *iterable)
         (void)_list_clear(self);
     }
     if (iterable != NULL) {
-        Py_ssize_t iter_len = PyObject_Length(iterable);
-        if (iter_len == -1) {
-            PyErr_Clear();
-        }
-        if (iter_len > 0 && list_preallocate_exact(self, iter_len)) {
-            return -1;
+        if(_PyObject_HasLen(iterable)){
+            Py_ssize_t iter_len = PyObject_Length(iterable);
+            if (iter_len == -1) {
+                PyErr_Clear();
+            }
+            if (iter_len > 0 && list_preallocate_exact(self, iter_len)) {
+                return -1;
+            }
         }
         PyObject *rv = list_extend(self, iterable);
         if (rv == NULL)

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -79,6 +79,8 @@ list_resize(PyListObject *self, Py_ssize_t newsize)
 static int
 list_preallocate_exact(PyListObject *self, Py_ssize_t size)
 {
+    assert(self->ob_item == NULL);
+
     PyObject **items;
     size_t allocated;
 
@@ -2679,7 +2681,8 @@ list___init___impl(PyListObject *self, PyObject *iterable)
             if (iter_len == -1) {
                 if (PyErr_ExceptionMatches(PyExc_Exception)) {
                     PyErr_Clear();
-                } else {
+                }
+                else {
                     return -1;
                 }
             }

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2676,7 +2676,7 @@ list___init___impl(PyListObject *self, PyObject *iterable)
         (void)_list_clear(self);
     }
     if (iterable != NULL) {
-        if (_PyObject_HasLen(iterable) && self->ob_item == NULL) {
+        if (_PyObject_HasLen(iterable)) {
             Py_ssize_t iter_len = PyObject_Size(iterable);
             if (iter_len == -1) {
                 if (PyErr_ExceptionMatches(PyExc_Exception)) {
@@ -2686,7 +2686,8 @@ list___init___impl(PyListObject *self, PyObject *iterable)
                     return -1;
                 }
             }
-            if (iter_len > 0 && list_preallocate_exact(self, iter_len)) {
+            if (iter_len > 0 && self->ob_item == NULL
+                && list_preallocate_exact(self, iter_len)) {
                 return -1;
             }
         }

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2676,7 +2676,7 @@ list___init___impl(PyListObject *self, PyObject *iterable)
     }
     if (iterable != NULL) {
         Py_ssize_t iter_len = PyObject_Length(iterable);
-        if (iter_len == -1){
+        if (iter_len == -1) {
             PyErr_Clear();
         }
         if (iter_len > 0 && list_preallocate_exact(self, iter_len)) {

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2679,12 +2679,10 @@ list___init___impl(PyListObject *self, PyObject *iterable)
         if (_PyObject_HasLen(iterable)) {
             Py_ssize_t iter_len = PyObject_Size(iterable);
             if (iter_len == -1) {
-                if (PyErr_ExceptionMatches(PyExc_Exception)) {
-                    PyErr_Clear();
-                }
-                else {
+                if (!PyErr_ExceptionMatches(PyExc_Exception)) {
                     return -1;
                 }
+                PyErr_Clear();
             }
             if (iter_len > 0 && self->ob_item == NULL
                 && list_preallocate_exact(self, iter_len)) {


### PR DESCRIPTION
This is a version of https://github.com/python/cpython/pull/6493 that only preallocates the list when `__len__` is available to reduce memory overallocation and possible performance hit on big iterables.

This are the L1 and L2 cache misses and related information:

THIS PR
```
❯ perf stat -r 200 -B -e cache-references,cache-misses,cycles,instructions,branches,faults,migrations ./python -c "
for _ in range(1000):
    list([0]*10000)
"
 Performance counter stats for './python -c
for _ in range(1000):
    list([0]*10000)
' (200 runs):

         1,151,365      cache-references:u                                            ( +-  0.47% )
             5,686      cache-misses:u            #    0.494 % of all cache refs      ( +-  8.06% )
       370,237,437      cycles:u                                                      ( +-  0.05% )
       542,049,270      instructions:u            #    1.46  insn per cycle           ( +-  0.00% )
       134,146,925      branches:u                                                    ( +-  0.00% )
             8,031      faults:u                                                      ( +-  0.00% )
                 0      migrations:u

          0.122170 +- 0.000307 seconds time elapsed  ( +-  0.25% )
```

MASTER
```
❯ perf stat -r 200 -B -e cache-references,cache-misses,cycles,instructions,branches,faults,migrations ./python -c "for _ in range(1000):
    list([0]*10000)
"
 Performance counter stats for './python -c
for _ in range(1000):
    list([0]*10000)
' (200 runs):

         1,275,440      cache-references:u                                            ( +-  0.61% )
            21,895      cache-misses:u            #    1.717 % of all cache refs      ( +-  4.69% )
       392,293,096      cycles:u                                                      ( +-  0.22% )
       543,254,939      instructions:u            #    1.38  insn per cycle           ( +-  0.00% )
       134,549,173      branches:u                                                    ( +-  0.00% )
            10,039      faults:u                                                      ( +-  0.00% )
                 0      migrations:u

          0.133171 +- 0.000463 seconds time elapsed  ( +-  0.35% )
```

<!-- issue-number: [bpo-33234](https://bugs.python.org/issue33234) -->
https://bugs.python.org/issue33234
<!-- /issue-number -->
