### PR TITLE
bpo-25246: Improve the performance of deque_remove()

### DIFF
--- a/Lib/test/test_deque.py
+++ b/Lib/test/test_deque.py
@@ -518,7 +518,7 @@ class TestBasic(unittest.TestCase):
         for match in (True, False):
             d = deque(['ab'])
             d.extend([MutateCmp(d, match), 'c'])
-            self.assertRaises(IndexError, d.remove, 'c')
+            self.assertRaises(RuntimeError, d.remove, 'c')
             self.assertEqual(d, deque())
 
     def test_repr(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-13-00-23-19.bpo-25246.HKOrh3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-13-00-23-19.bpo-25246.HKOrh3.rst
@@ -1,0 +1,2 @@
+Improve the performance of :meth:`collections.deque.remove` and raise
+`exc`:`RuntimeError` if the deque is mutated during removal.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-06-13-00-23-19.bpo-25246.HKOrh3.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-06-13-00-23-19.bpo-25246.HKOrh3.rst
@@ -1,2 +1,2 @@
 Improve the performance of :meth:`collections.deque.remove` and raise
-`exc`:`RuntimeError` if the deque is mutated during removal.
+:exc:`RuntimeError` if the deque is mutated during removal.

--- a/Modules/_collectionsmodule.c
+++ b/Modules/_collectionsmodule.c
@@ -134,6 +134,32 @@ freeblock(block *b)
     PyMem_Free(b);
 }
 
+static block *
+deque_get_block(dequeobject *deque, Py_ssize_t *index)
+{
+    Py_ssize_t i = *index, m = i, n;
+    block *b;
+
+    i += deque->leftindex;
+    n = (Py_ssize_t)((size_t) i / BLOCKLEN);
+    *index = (Py_ssize_t)((size_t) i % BLOCKLEN);
+    if (m < (Py_SIZE(deque) >> 1)) {
+        b = deque->leftblock;
+        while (n--) {
+            b = b->rightlink;
+        }
+    } else {
+        n = (Py_ssize_t)(
+                ((size_t)(deque->leftindex + Py_SIZE(deque) - 1))
+                / BLOCKLEN - n);
+        b = deque->rightblock;
+        while (n--) {
+            b = b->leftlink;
+        }
+    }
+    return b;
+}
+
 static PyObject *
 deque_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
@@ -1012,21 +1038,16 @@ deque_len(dequeobject *deque)
     return Py_SIZE(deque);
 }
 
-static PyObject *
-deque_index(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
+static Py_ssize_t
+_deque_index(dequeobject *deque, PyObject *value,
+             Py_ssize_t start, Py_ssize_t stop)
 {
-    Py_ssize_t i, n, start=0, stop=Py_SIZE(deque);
-    PyObject *v, *item;
+    Py_ssize_t n;
+    PyObject *item;
     block *b = deque->leftblock;
     Py_ssize_t index = deque->leftindex;
     size_t start_state = deque->state;
     int cmp;
-
-    if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index", &v,
-                           _PyEval_SliceIndexNotNone, &start,
-                           _PyEval_SliceIndexNotNone, &stop)) {
-        return NULL;
-    }
 
     if (start < 0) {
         start += Py_SIZE(deque);
@@ -1044,39 +1065,52 @@ deque_index(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
         start = stop;
     assert(0 <= start && start <= stop && stop <= Py_SIZE(deque));
 
-    for (i=0 ; i < start - BLOCKLEN ; i += BLOCKLEN) {
-        b = b->rightlink;
-    }
-    for ( ; i < start ; i++) {
-        index++;
-        if (index == BLOCKLEN) {
-            b = b->rightlink;
-            index = 0;
-        }
-    }
+    index = start;
+    b = deque_get_block(deque, &index);
 
-    n = stop - i;
+    n = stop - start ;
     while (--n >= 0) {
         CHECK_NOT_END(b);
         item = b->data[index];
-        cmp = PyObject_RichCompareBool(item, v, Py_EQ);
+        cmp = PyObject_RichCompareBool(item, value, Py_EQ);
         if (cmp > 0)
-            return PyLong_FromSsize_t(stop - n - 1);
+            return stop - n - 1;
         if (cmp < 0)
-            return NULL;
+            return -1;
         if (start_state != deque->state) {
             PyErr_SetString(PyExc_RuntimeError,
                             "deque mutated during iteration");
-            return NULL;
+            return -1;
         }
-        index++;
-        if (index == BLOCKLEN) {
+
+        if (++index == BLOCKLEN) {
             b = b->rightlink;
             index = 0;
         }
     }
-    PyErr_Format(PyExc_ValueError, "%R is not in deque", v);
-    return NULL;
+    PyErr_Format(PyExc_ValueError, "%R is not in deque", value);
+    return -1;
+}
+
+
+static PyObject *
+deque_index(dequeobject *deque, PyObject *args, Py_ssize_t nargs)
+{
+    Py_ssize_t i, start=0, stop=Py_SIZE(deque);
+    PyObject *value;
+
+    if (!_PyArg_ParseStack(args, nargs, "O|O&O&:index", &value,
+                           _PyEval_SliceIndexNotNone, &start,
+                           _PyEval_SliceIndexNotNone, &stop)) {
+        return NULL;
+    }
+
+    i = _deque_index(deque, value, start, stop);
+
+    if (i == -1 && PyErr_Occurred()) {
+        return NULL;
+    }
+   return PyLong_FromSsize_t(i);
 }
 
 PyDoc_STRVAR(index_doc,
@@ -1128,36 +1162,30 @@ deque_insert(dequeobject *deque, PyObject *const *args, Py_ssize_t nargs)
 PyDoc_STRVAR(insert_doc,
 "D.insert(index, object) -- insert object before index");
 
+static int deque_del_item(dequeobject *, Py_ssize_t);
+
 static PyObject *
 deque_remove(dequeobject *deque, PyObject *value)
 {
-    Py_ssize_t i, n=Py_SIZE(deque);
+    Py_ssize_t i;
+    size_t start_state = deque->state;
+    int rv;
 
-    for (i=0 ; i<n ; i++) {
-        PyObject *item = deque->leftblock->data[deque->leftindex];
-        int cmp = PyObject_RichCompareBool(item, value, Py_EQ);
-
-        if (Py_SIZE(deque) != n) {
-            PyErr_SetString(PyExc_IndexError,
-                "deque mutated during remove().");
-            return NULL;
-        }
-        if (cmp > 0) {
-            PyObject *tgt = deque_popleft(deque, NULL);
-            assert (tgt != NULL);
-            if (_deque_rotate(deque, i))
-                return NULL;
-            Py_DECREF(tgt);
-            Py_RETURN_NONE;
-        }
-        else if (cmp < 0) {
-            _deque_rotate(deque, i);
-            return NULL;
-        }
-        _deque_rotate(deque, -1);
+    i = _deque_index(deque, value, 0, Py_SIZE(deque));
+    if (i == -1 && PyErr_Occurred()) {
+        return NULL;
     }
-    PyErr_SetString(PyExc_ValueError, "deque.remove(x): x not in deque");
-    return NULL;
+    if (start_state != deque->state) {
+        PyErr_SetString(PyExc_RuntimeError, "deque mutated during remove");
+        return NULL;
+    }
+
+    rv = deque_del_item(deque, i);
+    if (rv < 0) {
+      return NULL;
+    }
+
+    Py_RETURN_NONE;
 }
 
 PyDoc_STRVAR(remove_doc,


### PR DESCRIPTION
❯ ./python -m perf compare_to old.json .new.json
Mean +- std dev: [old] 214 us +- 5 us -> [new] 147 us +- 2 us: 1.46x faster (-31%)


<!-- issue-number: [bpo-25246](https://bugs.python.org/issue25246) -->
https://bugs.python.org/issue25246
<!-- /issue-number -->
