### PR TITLE
bpo-34974: Do not replace unexpected errors in bytes() and bytearray().

### DIFF
--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -126,8 +126,8 @@ class BaseBytesTest:
         a = self.type2test(b"\x01\x02\x03")
         self.assertEqual(a, b"\x01\x02\x03")
 
-        # http://bugs.python.org/issue29159
-        # Fallback when __index__ raises exception other than OverflowError
+        # Issues #29159 and 34974.
+        # Fallback when __index__ raises a TypeError
         class B(bytes):
             def __index__(self):
                 raise TypeError
@@ -183,6 +183,19 @@ class BaseBytesTest:
             bytearray(size - 4)
         except (OverflowError, MemoryError):
             pass
+
+    def test_constructor_exceptions(self):
+        # Issue #34974: bytes and bytearray constructors replace unexpected
+        # exceptions.
+        class BadInt:
+            def __index__(self):
+                1/0
+        self.assertRaises(ZeroDivisionError, self.type2test, BadInt())
+
+        class BadIterable:
+            def __iter__(self):
+                1/0
+        self.assertRaises(ZeroDivisionError, self.type2test, BadIterable())
 
     def test_compare(self):
         b1 = self.type2test([1, 2, 3])

--- a/Lib/test/test_bytes.py
+++ b/Lib/test/test_bytes.py
@@ -126,7 +126,7 @@ class BaseBytesTest:
         a = self.type2test(b"\x01\x02\x03")
         self.assertEqual(a, b"\x01\x02\x03")
 
-        # Issues #29159 and 34974.
+        # Issues #29159 and #34974.
         # Fallback when __index__ raises a TypeError
         class B(bytes):
             def __index__(self):
@@ -191,6 +191,7 @@ class BaseBytesTest:
             def __index__(self):
                 1/0
         self.assertRaises(ZeroDivisionError, self.type2test, BadInt())
+        self.assertRaises(ZeroDivisionError, self.type2test, [BadInt()])
 
         class BadIterable:
             def __iter__(self):

--- a/Misc/NEWS.d/next/Core and Builtins/2018-10-13-22-24-19.bpo-34974.7LgTc2.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-10-13-22-24-19.bpo-34974.7LgTc2.rst
@@ -1,0 +1,3 @@
+:class:`bytes` and :class:`bytearray` constructors no longer convert
+unexpected exceptions (e.g. :exc:`MemoryError` and :exc:`KeyboardInterrupt`)
+to :exc:`TypeError`.

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -41,7 +41,6 @@ _getbytevalue(PyObject* arg, int *value)
     } else {
         PyObject *index = PyNumber_Index(arg);
         if (index == NULL) {
-            PyErr_Format(PyExc_TypeError, "an integer is required");
             *value = -1;
             return 0;
         }

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -821,7 +821,7 @@ bytearray_init(PyByteArrayObject *self, PyObject *args, PyObject *kwds)
     if (PyIndex_Check(arg)) {
         count = PyNumber_AsSsize_t(arg, PyExc_OverflowError);
         if (count == -1 && PyErr_Occurred()) {
-            if (PyErr_ExceptionMatches(PyExc_OverflowError))
+            if (!PyErr_ExceptionMatches(PyExc_TypeError))
                 return -1;
             PyErr_Clear();  /* fall through */
         }

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -2596,7 +2596,7 @@ bytes_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     if (PyIndex_Check(x)) {
         size = PyNumber_AsSsize_t(x, PyExc_OverflowError);
         if (size == -1 && PyErr_Occurred()) {
-            if (PyErr_ExceptionMatches(PyExc_OverflowError))
+            if (!PyErr_ExceptionMatches(PyExc_TypeError))
                 return NULL;
             PyErr_Clear();  /* fall through */
         }
@@ -2777,6 +2777,9 @@ PyBytes_FromObject(PyObject *x)
             result = _PyBytes_FromIterator(it, x);
             Py_DECREF(it);
             return result;
+        }
+        if (!PyErr_ExceptionMatches(PyExc_TypeError)) {
+            return NULL;
         }
     }
 


### PR DESCRIPTION
bytes and bytearray constructors converted unexpected exceptions
(e.g. MemoryError and KeyboardInterrupt) to TypeError.


<!-- issue-number: [bpo-34974](https://bugs.python.org/issue34974) -->
https://bugs.python.org/issue34974
<!-- /issue-number -->
