### PR TITLE
In email.parser in message_from_bytes, update `strict` to `policy`

### DIFF
--- a/Doc/library/email.parser.rst
+++ b/Doc/library/email.parser.rst
@@ -238,7 +238,7 @@ in the top-level :mod:`email` package namespace.
 
    Return a message object structure from a :term:`bytes-like object`.  This is
    equivalent to ``BytesParser().parsebytes(s)``.  Optional *_class* and
-   *strict* are interpreted as with the :class:`~email.parser.BytesParser` class
+   *policy* are interpreted as with the :class:`~email.parser.BytesParser` class
    constructor.
 
    .. versionadded:: 3.2


### PR DESCRIPTION
According to the versionchanged note, the `strict` argument was removed in 3.3 and `policy` was added, but the name of the argument in the paragraph wasn't updated.
