### PR TITLE
bpo-31522: mailbox: pass `from_` parameter to `get_bytes`

### DIFF
--- a/Lib/mailbox.py
+++ b/Lib/mailbox.py
@@ -784,7 +784,7 @@ class _mboxMMDF(_singlefileMailbox):
     def get_string(self, key, from_=False):
         """Return a string representation or raise a KeyError."""
         return email.message_from_bytes(
-            self.get_bytes(key)).as_string(unixfrom=from_)
+            self.get_bytes(key, from_)).as_string(unixfrom=from_)
 
     def get_bytes(self, key, from_=False):
         """Return a string representation or raise a KeyError."""

--- a/Lib/test/test_mailbox.py
+++ b/Lib/test/test_mailbox.py
@@ -988,6 +988,34 @@ class _TestMboxMMDF(_TestSingleFile):
         with open(self._path) as f:
             self.assertEqual(f.readlines(), [])
 
+    def test_get_bytes_from(self):
+        # Get bytes representations of messages with _unixfrom.
+        unixfrom = 'From foo@bar blah\n'
+        key0 = self._box.add(unixfrom + self._template % 0)
+        key1 = self._box.add(unixfrom + _sample_message)
+        self.assertEqual(self._box.get_bytes(key0, from_=False),
+            (self._template % 0).encode('ascii'))
+        self.assertEqual(self._box.get_bytes(key1, from_=False),
+            _bytes_sample_message)
+        self.assertEqual(self._box.get_bytes(key0, from_=True),
+            (unixfrom + self._template % 0).encode('ascii'))
+        self.assertEqual(self._box.get_bytes(key1, from_=True),
+            unixfrom.encode('ascii') + _bytes_sample_message)
+
+    def test_get_string_from(self):
+        # Get string representations of messages with _unixfrom.
+        unixfrom = 'From foo@bar blah\n'
+        key0 = self._box.add(unixfrom + self._template % 0)
+        key1 = self._box.add(unixfrom + _sample_message)
+        self.assertEqual(self._box.get_string(key0, from_=False),
+                         self._template % 0)
+        self.assertEqual(self._box.get_string(key1, from_=False).split('\n'),
+                         _sample_message.split('\n'))
+        self.assertEqual(self._box.get_string(key0, from_=True),
+                         unixfrom + self._template % 0)
+        self.assertEqual(self._box.get_string(key1, from_=True).split('\n'),
+                         (unixfrom + _sample_message).split('\n'))
+
     def test_add_from_string(self):
         # Add a string starting with 'From ' to the mailbox
         key = self._box.add('From foo@bar blah\nFrom: foo\n\n0\n')

--- a/Misc/NEWS.d/next/Library/2018-10-13-18-16-20.bpo-31522.rWBb43.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-13-18-16-20.bpo-31522.rWBb43.rst
@@ -1,0 +1,1 @@
+In `mailbox._mboxMMDF.get_string`, pass *from_* parameter to ``get_bytes``.

--- a/Misc/NEWS.d/next/Library/2018-10-13-18-16-20.bpo-31522.rWBb43.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-13-18-16-20.bpo-31522.rWBb43.rst
@@ -1,1 +1,1 @@
-In `mailbox._mboxMMDF.get_string`, pass *from_* parameter to ``get_bytes``.
+The `mailbox.mbox.get_string` function *from_* parameter can now successfully be set to a non-default value.


### PR DESCRIPTION
Added tests that failed before the change and pass after the change.



<!-- issue-number: [bpo-31522](https://bugs.python.org/issue31522) -->
https://bugs.python.org/issue31522
<!-- /issue-number -->
