### PR TITLE
bpo-33656: Move pyshell ctypes import inside try block.

### DIFF
--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -12,11 +12,11 @@ except ImportError:
 # Valid arguments for the ...Awareness call below are defined in the following.
 # https://msdn.microsoft.com/en-us/library/windows/desktop/dn280512(v=vs.85).aspx
 if sys.platform == 'win32':
-    import ctypes
-    PROCESS_SYSTEM_DPI_AWARE = 1
     try:
+        import ctypes
+        PROCESS_SYSTEM_DPI_AWARE = 1
         ctypes.OleDLL('shcore').SetProcessDpiAwareness(PROCESS_SYSTEM_DPI_AWARE)
-    except (AttributeError, OSError):
+    except (ImportError, AttributeError, OSError):
         pass
 
 import tkinter.messagebox as tkMessageBox


### PR DESCRIPTION
A Windows build with _tkinter, tkinter, and idlelib
but without ctypes is unlikely but apparently possible.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-33656](https://bugs.python.org/issue33656) -->
https://bugs.python.org/issue33656
<!-- /issue-number -->
