### PR TITLE
bpo-26441: Remove docs for deleted to_splittable and from_splittable methods

### DIFF
--- a/Doc/library/email.charset.rst
+++ b/Doc/library/email.charset.rst
@@ -110,39 +110,6 @@ Import this class from the :mod:`email.charset` module.
       returns the string ``7bit`` otherwise.
 
 
-   .. XXX to_splittable and from_splittable are not there anymore!
-
-   .. to_splittable(s)
-
-      Convert a possibly multibyte string to a safely splittable format. *s* is
-      the string to split.
-
-      Uses the *input_codec* to try and convert the string to Unicode, so it can
-      be safely split on character boundaries (even for multibyte characters).
-
-      Returns the string as-is if it isn't known how to convert *s* to Unicode
-      with the *input_charset*.
-
-      Characters that could not be converted to Unicode will be replaced with
-      the Unicode replacement character ``'U+FFFD'``.
-
-
-   .. from_splittable(ustr[, to_output])
-
-      Convert a splittable string back into an encoded string.  *ustr* is a
-      Unicode string to "unsplit".
-
-      This method uses the proper codec to try and convert the string from
-      Unicode back into an encoded format.  Return the string as-is if it is not
-      Unicode, or if it could not be converted from Unicode.
-
-      Characters that could not be converted from Unicode will be replaced with
-      an appropriate character (usually ``'?'``).
-
-      If *to_output* is ``True`` (the default), uses *output_codec* to convert
-      to an encoded format.  If *to_output* is ``False``, it uses *input_codec*.
-
-
    .. method:: get_output_charset()
 
       Return the output character set.


### PR DESCRIPTION


<!-- issue-number: [bpo-26441](https://bugs.python.org/issue26441) -->
https://bugs.python.org/issue26441
<!-- /issue-number -->
