### PR TITLE
"async def coroutines" to "coroutines"

### DIFF
--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -715,8 +715,7 @@ coroutine bodies.
 Functions defined with ``async def`` syntax are always coroutine functions,
 even if they do not contain ``await`` or ``async`` keywords.
 
-It is a :exc:`SyntaxError` to use ``yield from`` expressions in
-``async def`` coroutines.
+It is a :exc:`SyntaxError` to use ``yield from`` expressions in coroutines.
 
 An example of a coroutine function::
 


### PR DESCRIPTION
async def statements == coroutines. Been repetitive suggests the existence of a non-"async def" coroutine, which is confusing.