### PR TITLE
Stop using deprecated logging API in Sphinx

### DIFF
--- a/Doc/tools/extensions/suspicious.py
+++ b/Doc/tools/extensions/suspicious.py
@@ -48,6 +48,7 @@ import sys
 
 from docutils import nodes
 from sphinx.builders import Builder
+import sphinx.util
 
 detect_all = re.compile(r'''
     ::(?=[^=])|            # two :: (but NOT ::=)
@@ -85,6 +86,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
     Checks for possibly invalid markup that may leak into the output.
     """
     name = 'suspicious'
+    logger = sphinx.util.logging.getLogger("CheckSuspiciousMarkupBuilder")
 
     def init(self):
         # create output file
@@ -116,7 +118,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
             self.warn('Found %s/%s unused rules:' %
                       (len(unused_rules), len(self.rules)))
             for rule in unused_rules:
-                self.info(repr(rule))
+                self.logger.info(repr(rule))
         return
 
     def check_issue(self, line, lineno, issue):
@@ -146,7 +148,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
         return False
 
     def report_issue(self, text, lineno, issue):
-        if not self.any_issue: self.info()
+        if not self.any_issue: self.logger.info()
         self.any_issue = True
         self.write_log_entry(lineno, issue, text)
         if py3:
@@ -181,7 +183,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
         A csv file, with exactly the same format as suspicious.csv
         Fields: document name (normalized), line number, issue, surrounding text
         """
-        self.info("loading ignore rules... ", nonl=1)
+        self.logger.info("loading ignore rules... ", nonl=1)
         self.rules = rules = []
         try:
             if py3:
@@ -206,7 +208,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
             rule = Rule(docname, lineno, issue, text)
             rules.append(rule)
         f.close()
-        self.info('done, %d rules loaded' % len(self.rules))
+        self.logger.info('done, %d rules loaded' % len(self.rules))
 
 
 def get_lineno(node):


### PR DESCRIPTION
The doc target can fail due to the use of a deprecated logging API in 
` Doc/tools/extensions/suspicious.py` and treating warnings as errors. Example error:
```
$ make check suspicious html SPHINXOPTS="-q -W -j4"
python3 tools/rstlint.py -i tools -i ./venv -i README.rst
No problems found.
make[1]: Entering directory `/home/travis/build/python/cpython/Doc'
mkdir -p build
Building NEWS from Misc/NEWS.d with blurb
PATH=./venv/bin:$PATH sphinx-build -b suspicious -d build/doctrees -D latex_elements.papersize= -q -W -j4 . build/suspicious 
/home/travis/virtualenv/python3.6.3/lib/python3.6/site-packages/sphinx/application.py:402: RemovedInSphinx20Warning: app.info() is now deprecated. Use sphinx.util.logging instead.
  RemovedInSphinx20Warning)
```