### PR TITLE
removing documentation bug as per Issue34848

### DIFF
--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -645,7 +645,7 @@ PyDoc_STRVAR(count_doc,
 "rangeobject.count(value) -> integer -- return number of occurrences of value");
 
 PyDoc_STRVAR(index_doc,
-"rangeobject.index(value, [start, [stop]]) -> integer -- return index of value.\n"
+"rangeobject.index(value) -> integer -- return index of value.\n"
 "Raise ValueError if the value is not present.");
 
 static PyMethodDef range_methods[] = {


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
[bpo-34848](https://bugs.python.org/issue34848): Changed rangeobject docstring for index. Current docstring says user can pass in multiple args when only 2 args are supported.
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

-->
