### PR TITLE
bpo-34848: Changed rangeobject docstring for index. Current docstring says user can pass in multiple args when only 2 args are supported.

### DIFF
--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -645,7 +645,7 @@ PyDoc_STRVAR(count_doc,
 "rangeobject.count(value) -> integer -- return number of occurrences of value");
 
 PyDoc_STRVAR(index_doc,
-"rangeobject.index(value, [start, [stop]]) -> integer -- return index of value.\n"
+"rangeobject.index(value) -> integer -- return index of value.\n"
 "Raise ValueError if the value is not present.");
 
 static PyMethodDef range_methods[] = {


### PR DESCRIPTION
Current docstring for built in rangeobject index function suggests the use of multiple args to get values between two indices. This is not supported in current python. Changing docstring to be inline with functinoality.

<!-- issue-number: [bpo-34848](https://bugs.python.org/issue34848) -->
https://bugs.python.org/issue34848
<!-- /issue-number -->
