### PR TITLE
bpo-24653: Fix the documentation that passing an empty list to assert_has_calls([]) does not raise an exception

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -375,6 +375,10 @@ the *new_callable* argument to :func:`patch`.
             >>> calls = [call(4), call(2), call(3)]
             >>> mock.assert_has_calls(calls, any_order=True)
 
+        If you pass empty list of calls, then it does not raise an exception.
+
+            >>> mock.assert_has_calls([])
+
     .. method:: assert_not_called()
 
         Assert the mock was never called.


### PR DESCRIPTION


<!-- issue-number: [bpo-24653](https://bugs.python.org/issue24653) -->
https://bugs.python.org/issue24653
<!-- /issue-number -->
