### PR TITLE
bpo-34987: Fix a possible null pointer dereference in _pickle.c's save_reduce()

### DIFF
--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3840,6 +3840,9 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
 
         if (obj != NULL) {
             obj_class = get_class(obj);
+            if (obj_class == NULL) {
+                return -1;
+            }
             p = obj_class != cls;    /* true iff a problem */
             Py_DECREF(obj_class);
             if (p) {

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3843,7 +3843,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
             if (obj_class == NULL) {
                 return -1;
             }
-            p = obj_class != cls;    /* true iff a problem */
+            p = obj_class != cls;
             Py_DECREF(obj_class);
             if (p) {
                 PyErr_SetString(st->PicklingError, "args[0] from "


### PR DESCRIPTION


<!-- issue-number: [bpo-34987](https://bugs.python.org/issue34987) -->
https://bugs.python.org/issue34987
<!-- /issue-number -->
