### PR TITLE
[2.7] bpo-16965: 2to3 now rewrites execfile() to open with rb. (GH-8569)

### DIFF
--- a/Lib/lib2to3/fixes/fix_execfile.py
+++ b/Lib/lib2to3/fixes/fix_execfile.py
@@ -31,7 +31,8 @@ class FixExecfile(fixer_base.BaseFix):
         # call.
         execfile_paren = node.children[-1].children[-1].clone()
         # Construct open().read().
-        open_args = ArgList([filename.clone()], rparen=execfile_paren)
+        open_args = ArgList([filename.clone(), Comma(), String('"rb"', ' ')],
+                            rparen=execfile_paren)
         open_call = Node(syms.power, [Name(u"open"), open_args])
         read = [Node(syms.trailer, [Dot(), Name(u'read')]),
                 Node(syms.trailer, [LParen(), RParen()])]

--- a/Lib/lib2to3/tests/test_fixers.py
+++ b/Lib/lib2to3/tests/test_fixers.py
@@ -1143,36 +1143,36 @@ class Test_execfile(FixerTestCase):
 
     def test_conversion(self):
         b = """execfile("fn")"""
-        a = """exec(compile(open("fn").read(), "fn", 'exec'))"""
+        a = """exec(compile(open("fn", "rb").read(), "fn", 'exec'))"""
         self.check(b, a)
 
         b = """execfile("fn", glob)"""
-        a = """exec(compile(open("fn").read(), "fn", 'exec'), glob)"""
+        a = """exec(compile(open("fn", "rb").read(), "fn", 'exec'), glob)"""
         self.check(b, a)
 
         b = """execfile("fn", glob, loc)"""
-        a = """exec(compile(open("fn").read(), "fn", 'exec'), glob, loc)"""
+        a = """exec(compile(open("fn", "rb").read(), "fn", 'exec'), glob, loc)"""
         self.check(b, a)
 
         b = """execfile("fn", globals=glob)"""
-        a = """exec(compile(open("fn").read(), "fn", 'exec'), globals=glob)"""
+        a = """exec(compile(open("fn", "rb").read(), "fn", 'exec'), globals=glob)"""
         self.check(b, a)
 
         b = """execfile("fn", locals=loc)"""
-        a = """exec(compile(open("fn").read(), "fn", 'exec'), locals=loc)"""
+        a = """exec(compile(open("fn", "rb").read(), "fn", 'exec'), locals=loc)"""
         self.check(b, a)
 
         b = """execfile("fn", globals=glob, locals=loc)"""
-        a = """exec(compile(open("fn").read(), "fn", 'exec'), globals=glob, locals=loc)"""
+        a = """exec(compile(open("fn", "rb").read(), "fn", 'exec'), globals=glob, locals=loc)"""
         self.check(b, a)
 
     def test_spacing(self):
         b = """execfile( "fn" )"""
-        a = """exec(compile(open( "fn" ).read(), "fn", 'exec'))"""
+        a = """exec(compile(open( "fn", "rb" ).read(), "fn", 'exec'))"""
         self.check(b, a)
 
         b = """execfile("fn",  globals = glob)"""
-        a = """exec(compile(open("fn").read(), "fn", 'exec'),  globals = glob)"""
+        a = """exec(compile(open("fn", "rb").read(), "fn", 'exec'),  globals = glob)"""
         self.check(b, a)
 
 

--- a/Misc/NEWS.d/next/Library/2018-10-12-20-30-42.bpo-16965.xo5LAr.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-12-20-30-42.bpo-16965.xo5LAr.rst
@@ -1,0 +1,2 @@
+The :term:`2to3` :2to3fixer:`execfile` fixer now opens the file with mode
+``'rb'``.  Patch by Zackery Spytz.


### PR DESCRIPTION
(cherry picked from commit d4d60134b29290049e28df54f23493de4f1824b6)

<!-- issue-number: [bpo-16965](https://bugs.python.org/issue16965) -->
https://bugs.python.org/issue16965
<!-- /issue-number -->
