### PR TITLE
bpo-34783: Fix test_nonexisting_script()

### DIFF
--- a/Lib/test/test_cmd_line_script.py
+++ b/Lib/test/test_cmd_line_script.py
@@ -630,8 +630,6 @@ class CmdLineTest(unittest.TestCase):
             traceback_lines = stderr.decode().splitlines()
             self.assertIn("No module named script_pkg", traceback_lines[-1])
 
-    @unittest.skipIf(sys.platform == 'darwin' and sys._framework,
-                        "test not valid for macOS framework builds")
     def test_nonexisting_script(self):
         # bpo-34783: "./python script.py" must not crash
         # if the script file doesn't exist.
@@ -639,17 +637,12 @@ class CmdLineTest(unittest.TestCase):
         #  is not the actual Python executable file name.
         script = 'nonexistingscript.py'
         self.assertFalse(os.path.exists(script))
-        # Only test the base name, since the error message can use
-        # a relative path, whereas sys.executable can be an asolution path.
-        program = os.path.basename(sys.executable)
 
         proc = spawn_python(script, text=True,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE)
         out, err = proc.communicate()
-        # "./python" must be in the error message:
-        # "./python: can't open file (...)"
-        self.assertIn(program, err)
+        self.assertIn(": can't open file ", err)
         self.assertNotEqual(proc.returncode, 0)
 
 


### PR DESCRIPTION
Fix test_cmd_line_script.test_nonexisting_script(): the test must not
rely on sys.executable, since main.c uses config->program which can
be different than sys.executable in many cases (for example, on macOS
when using the framework).

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34783](https://bugs.python.org/issue34783) -->
https://bugs.python.org/issue34783
<!-- /issue-number -->
