### PR TITLE
bpo-34890: Make iscoroutinefunction, isgeneratorfunction and isasyncgenfunction work with functools.partial

### DIFF
--- a/Doc/library/inspect.rst
+++ b/Doc/library/inspect.rst
@@ -301,6 +301,10 @@ attributes:
 
    Return true if the object is a Python generator function.
 
+   .. versionchanged:: 3.8
+      Functions wrapped in :func:`functools.partial` now return true if the
+      wrapped function is a Python generator function.
+
 
 .. function:: isgenerator(object)
 
@@ -313,6 +317,10 @@ attributes:
    (a function defined with an :keyword:`async def` syntax).
 
    .. versionadded:: 3.5
+
+   .. versionchanged:: 3.8
+      Functions wrapped in :func:`functools.partial` now return true if the
+      wrapped function is a :term:`coroutine function`.
 
 
 .. function:: iscoroutine(object)
@@ -354,6 +362,10 @@ attributes:
     True
 
    .. versionadded:: 3.6
+
+   .. versionchanged:: 3.8
+      Functions wrapped in :func:`functools.partial` now return true if the
+      wrapped function is a :term:`asynchronous generator` function.
 
 
 .. function:: isasyncgen(object)

--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -107,12 +107,14 @@ def coroutine(func):
     If the coroutine is not yielded from before it is destroyed,
     an error message is logged.
     """
-    if inspect.iscoroutinefunction(func):
+    if (inspect.iscoroutinefunction(func)
+            and not isinstance(func, functools.partial)):
         # In Python 3.5 that's all we need to do for coroutines
         # defined with "async def".
         return func
 
-    if inspect.isgeneratorfunction(func):
+    if (inspect.isgeneratorfunction(func)
+            and not isinstance (func, functools.partial)):
         coro = func
     else:
         @functools.wraps(func)

--- a/Lib/asyncio/coroutines.py
+++ b/Lib/asyncio/coroutines.py
@@ -107,14 +107,12 @@ def coroutine(func):
     If the coroutine is not yielded from before it is destroyed,
     an error message is logged.
     """
-    if (inspect.iscoroutinefunction(func)
-            and not isinstance(func, functools.partial)):
+    if inspect.iscoroutinefunction(func):
         # In Python 3.5 that's all we need to do for coroutines
         # defined with "async def".
         return func
 
-    if (inspect.isgeneratorfunction(func)
-            and not isinstance (func, functools.partial)):
+    if inspect.isgeneratorfunction(func):
         coro = func
     else:
         @functools.wraps(func)

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -388,6 +388,12 @@ class partialmethod(object):
     def __isabstractmethod__(self):
         return getattr(self.func, "__isabstractmethod__", False)
 
+# Helper functions
+
+def _unwrap_partial(func):
+    while isinstance(func, partial):
+        func = func.func
+    return func
 
 ################################################################################
 ### LRU Cache function decorator

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -168,40 +168,36 @@ def isfunction(object):
         __kwdefaults__  dict of keyword only parameters with defaults"""
     return isinstance(object, types.FunctionType)
 
-def isgeneratorfunction(object):
+def isgeneratorfunction(obj):
     """Return true if the object is a user-defined generator function.
 
     Generator function objects provide the same attributes as functions.
     See help(isfunction) for a list of attributes."""
-    is_generator_function = bool((isfunction(object) or ismethod(object)) and
-                object.__code__.co_flags & CO_GENERATOR)
-    is_partial_generator = bool((isinstance(object, functools.partial) and
-                object.func.__code__.co_flags & CO_GENERATOR))
-    return is_generator_function or is_partial_generator
+    while isinstance(obj, functools.partial):
+            obj = obj.func
+    return bool((isfunction(obj) or ismethod(obj)) and
+                obj.__code__.co_flags & CO_GENERATOR)
 
-def iscoroutinefunction(object):
+def iscoroutinefunction(obj):
     """Return true if the object is a coroutine function.
 
     Coroutine functions are defined with "async def" syntax.
     """
-    is_coroutine_function = bool(((isfunction(object) or ismethod(object)) and
-                object.__code__.co_flags & CO_COROUTINE))
-    is_partial_coroutine = bool((isinstance(object, functools.partial) and
-                object.func.__code__.co_flags & CO_COROUTINE))
-    return is_coroutine_function or is_partial_coroutine
+    while isinstance(obj, functools.partial):
+        obj = obj.func
+    return bool(((isfunction(obj) or ismethod(obj)) and
+                obj.__code__.co_flags & CO_COROUTINE))
 
-def isasyncgenfunction(object):
+def isasyncgenfunction(obj):
     """Return true if the object is an asynchronous generator function.
 
     Asynchronous generator functions are defined with "async def"
     syntax and have "yield" expressions in their body.
     """
-    is_async_gen_function = bool((isfunction(object) or ismethod(object)) and
-                object.__code__.co_flags & CO_ASYNC_GENERATOR)
-    is_partial_async_gen = bool((isinstance(object, functools.partial) and
-                object.func.__code__.co_flags & CO_ASYNC_GENERATOR))
-    return is_async_gen_function or is_partial_async_gen
-
+    while isinstance(obj, functools.partial):
+            obj = obj.func
+    return bool((isfunction(obj) or ismethod(obj)) and
+                obj.__code__.co_flags & CO_ASYNC_GENERATOR)
 
 def isasyncgen(object):
     """Return true if the object is an asynchronous generator."""

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -173,16 +173,22 @@ def isgeneratorfunction(object):
 
     Generator function objects provide the same attributes as functions.
     See help(isfunction) for a list of attributes."""
-    return bool((isfunction(object) or ismethod(object)) and
+    is_generator_function = bool((isfunction(object) or ismethod(object)) and
                 object.__code__.co_flags & CO_GENERATOR)
+    is_partial_generator = bool((isinstance(object, functools.partial) and
+                object.func.__code__.co_flags & CO_GENERATOR))
+    return is_generator_function or is_partial_generator
 
 def iscoroutinefunction(object):
     """Return true if the object is a coroutine function.
 
     Coroutine functions are defined with "async def" syntax.
     """
-    return bool((isfunction(object) or ismethod(object)) and
-                object.__code__.co_flags & CO_COROUTINE)
+    is_coroutine_function = bool(((isfunction(object) or ismethod(object)) and
+                object.__code__.co_flags & CO_COROUTINE))
+    is_partial_coroutine = bool((isinstance(object, functools.partial) and
+                object.func.__code__.co_flags & CO_COROUTINE))
+    return is_coroutine_function or is_partial_coroutine
 
 def isasyncgenfunction(object):
     """Return true if the object is an asynchronous generator function.
@@ -190,8 +196,12 @@ def isasyncgenfunction(object):
     Asynchronous generator functions are defined with "async def"
     syntax and have "yield" expressions in their body.
     """
-    return bool((isfunction(object) or ismethod(object)) and
+    is_async_gen_function = bool((isfunction(object) or ismethod(object)) and
                 object.__code__.co_flags & CO_ASYNC_GENERATOR)
+    is_partial_async_gen = bool((isinstance(object, functools.partial) and
+                object.func.__code__.co_flags & CO_ASYNC_GENERATOR))
+    return is_async_gen_function or is_partial_async_gen
+
 
 def isasyncgen(object):
     """Return true if the object is an asynchronous generator."""

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -174,7 +174,7 @@ def isgeneratorfunction(obj):
     Generator function objects provide the same attributes as functions.
     See help(isfunction) for a list of attributes."""
     while isinstance(obj, functools.partial):
-            obj = obj.func
+        obj = obj.func
     return bool((isfunction(obj) or ismethod(obj)) and
                 obj.__code__.co_flags & CO_GENERATOR)
 
@@ -195,7 +195,7 @@ def isasyncgenfunction(obj):
     syntax and have "yield" expressions in their body.
     """
     while isinstance(obj, functools.partial):
-            obj = obj.func
+        obj = obj.func
     return bool((isfunction(obj) or ismethod(obj)) and
                 obj.__code__.co_flags & CO_ASYNC_GENERATOR)
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -59,11 +59,6 @@ for k, v in dis.COMPILER_FLAG_NAMES.items():
 # See Include/object.h
 TPFLAGS_IS_ABSTRACT = 1 << 20
 
-def _unwrap_partial(func):
-    while isinstance(func, functools.partial):
-        func = func.func
-    return func
-
 # ----------------------------------------------------------- type-checking
 def ismodule(object):
     """Return true if the object is a module.
@@ -178,7 +173,7 @@ def isgeneratorfunction(obj):
 
     Generator function objects provide the same attributes as functions.
     See help(isfunction) for a list of attributes."""
-    obj = _unwrap_partial(obj)
+    obj = functools._unwrap_partial(obj)
     return bool((isfunction(obj) or ismethod(obj)) and
                 obj.__code__.co_flags & CO_GENERATOR)
 
@@ -187,7 +182,7 @@ def iscoroutinefunction(obj):
 
     Coroutine functions are defined with "async def" syntax.
     """
-    obj = _unwrap_partial(obj)
+    obj = functools._unwrap_partial(obj)
     return bool(((isfunction(obj) or ismethod(obj)) and
                 obj.__code__.co_flags & CO_COROUTINE))
 
@@ -197,7 +192,7 @@ def isasyncgenfunction(obj):
     Asynchronous generator functions are defined with "async def"
     syntax and have "yield" expressions in their body.
     """
-    obj = _unwrap_partial(obj)
+    obj = functools._unwrap_partial(obj)
     return bool((isfunction(obj) or ismethod(obj)) and
                 obj.__code__.co_flags & CO_ASYNC_GENERATOR)
 

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -59,6 +59,11 @@ for k, v in dis.COMPILER_FLAG_NAMES.items():
 # See Include/object.h
 TPFLAGS_IS_ABSTRACT = 1 << 20
 
+def _unwrap_partial(func):
+    while isinstance(func, functools.partial):
+        func = func.func
+    return func
+
 # ----------------------------------------------------------- type-checking
 def ismodule(object):
     """Return true if the object is a module.
@@ -173,8 +178,7 @@ def isgeneratorfunction(obj):
 
     Generator function objects provide the same attributes as functions.
     See help(isfunction) for a list of attributes."""
-    while isinstance(obj, functools.partial):
-        obj = obj.func
+    obj = _unwrap_partial(obj)
     return bool((isfunction(obj) or ismethod(obj)) and
                 obj.__code__.co_flags & CO_GENERATOR)
 
@@ -183,8 +187,7 @@ def iscoroutinefunction(obj):
 
     Coroutine functions are defined with "async def" syntax.
     """
-    while isinstance(obj, functools.partial):
-        obj = obj.func
+    obj = _unwrap_partial(obj)
     return bool(((isfunction(obj) or ismethod(obj)) and
                 obj.__code__.co_flags & CO_COROUTINE))
 
@@ -194,8 +197,7 @@ def isasyncgenfunction(obj):
     Asynchronous generator functions are defined with "async def"
     syntax and have "yield" expressions in their body.
     """
-    while isinstance(obj, functools.partial):
-        obj = obj.func
+    obj = _unwrap_partial(obj)
     return bool((isfunction(obj) or ismethod(obj)) and
                 obj.__code__.co_flags & CO_ASYNC_GENERATOR)
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -440,8 +440,8 @@ class BaseTaskTests:
 
         coro_repr = repr(task._coro)
         expected = (
-            r'<CoroWrapper \w+.test_task_repr_partial_corowrapper'
-            r'\.<locals>\.func\(1\)\(\) running, '
+            r'<coroutine object \w+\.test_task_repr_partial_corowrapper'
+            r'\.<locals>\.func at'
         )
         self.assertRegex(coro_repr, expected)
 

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -2,6 +2,7 @@ import builtins
 import collections
 import datetime
 import functools
+from functools import partial
 import importlib
 import inspect
 import io
@@ -174,35 +175,35 @@ class TestPredicates(IsTestBase):
             inspect.iscoroutinefunction(gen_coroutine_function_example))
         self.assertFalse(
             inspect.iscoroutinefunction(
-                functools.partial(gen_coroutine_function_example)))
+                partial(partial(gen_coroutine_function_example))))
         self.assertFalse(inspect.iscoroutine(gen_coro))
 
         self.assertTrue(
             inspect.isgeneratorfunction(gen_coroutine_function_example))
         self.assertTrue(
             inspect.isgeneratorfunction(
-                functools.partial(gen_coroutine_function_example)))
+                partial(partial(gen_coroutine_function_example))))
         self.assertTrue(inspect.isgenerator(gen_coro))
 
         self.assertTrue(
             inspect.iscoroutinefunction(coroutine_function_example))
         self.assertTrue(
             inspect.iscoroutinefunction(
-                functools.partial(coroutine_function_example)))
+                partial(partial(coroutine_function_example))))
         self.assertTrue(inspect.iscoroutine(coro))
 
         self.assertFalse(
             inspect.isgeneratorfunction(coroutine_function_example))
         self.assertFalse(
             inspect.isgeneratorfunction(
-                functools.partial(coroutine_function_example)))
+                partial(partial(coroutine_function_example))))
         self.assertFalse(inspect.isgenerator(coro))
 
         self.assertTrue(
             inspect.isasyncgenfunction(async_generator_function_example))
         self.assertTrue(
             inspect.isasyncgenfunction(
-                functools.partial(async_generator_function_example)))
+                partial(partial(async_generator_function_example))))
         self.assertTrue(inspect.isasyncgen(async_gen_coro))
 
         coro.close(); gen_coro.close(); # silence warnings

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -2,7 +2,6 @@ import builtins
 import collections
 import datetime
 import functools
-from functools import partial
 import importlib
 import inspect
 import io
@@ -175,35 +174,40 @@ class TestPredicates(IsTestBase):
             inspect.iscoroutinefunction(gen_coroutine_function_example))
         self.assertFalse(
             inspect.iscoroutinefunction(
-                partial(partial(gen_coroutine_function_example))))
+                functools.partial(functools.partial(
+                    gen_coroutine_function_example))))
         self.assertFalse(inspect.iscoroutine(gen_coro))
 
         self.assertTrue(
             inspect.isgeneratorfunction(gen_coroutine_function_example))
         self.assertTrue(
             inspect.isgeneratorfunction(
-                partial(partial(gen_coroutine_function_example))))
+                functools.partial(functools.partial(
+                    gen_coroutine_function_example))))
         self.assertTrue(inspect.isgenerator(gen_coro))
 
         self.assertTrue(
             inspect.iscoroutinefunction(coroutine_function_example))
         self.assertTrue(
             inspect.iscoroutinefunction(
-                partial(partial(coroutine_function_example))))
+                functools.partial(functools.partial(
+                    coroutine_function_example))))
         self.assertTrue(inspect.iscoroutine(coro))
 
         self.assertFalse(
             inspect.isgeneratorfunction(coroutine_function_example))
         self.assertFalse(
             inspect.isgeneratorfunction(
-                partial(partial(coroutine_function_example))))
+                functools.partial(functools.partial(
+                    coroutine_function_example))))
         self.assertFalse(inspect.isgenerator(coro))
 
         self.assertTrue(
             inspect.isasyncgenfunction(async_generator_function_example))
         self.assertTrue(
             inspect.isasyncgenfunction(
-                partial(partial(async_generator_function_example))))
+                functools.partial(functools.partial(
+                    async_generator_function_example))))
         self.assertTrue(inspect.isasyncgen(async_gen_coro))
 
         coro.close(); gen_coro.close(); # silence warnings

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -166,26 +166,46 @@ class TestPredicates(IsTestBase):
             self.assertFalse(inspect.ismemberdescriptor(datetime.timedelta.days))
 
     def test_iscoroutine(self):
+        async_gen_coro = async_generator_function_example(1)
         gen_coro = gen_coroutine_function_example(1)
         coro = coroutine_function_example(1)
 
         self.assertFalse(
             inspect.iscoroutinefunction(gen_coroutine_function_example))
+        self.assertFalse(
+            inspect.iscoroutinefunction(
+                functools.partial(gen_coroutine_function_example)))
         self.assertFalse(inspect.iscoroutine(gen_coro))
 
         self.assertTrue(
             inspect.isgeneratorfunction(gen_coroutine_function_example))
+        self.assertTrue(
+            inspect.isgeneratorfunction(
+                functools.partial(gen_coroutine_function_example)))
         self.assertTrue(inspect.isgenerator(gen_coro))
 
         self.assertTrue(
             inspect.iscoroutinefunction(coroutine_function_example))
+        self.assertTrue(
+            inspect.iscoroutinefunction(
+                functools.partial(coroutine_function_example)))
         self.assertTrue(inspect.iscoroutine(coro))
 
         self.assertFalse(
             inspect.isgeneratorfunction(coroutine_function_example))
+        self.assertFalse(
+            inspect.isgeneratorfunction(
+                functools.partial(coroutine_function_example)))
         self.assertFalse(inspect.isgenerator(coro))
 
-        coro.close(); gen_coro.close() # silence warnings
+        self.assertTrue(
+            inspect.isasyncgenfunction(async_generator_function_example))
+        self.assertTrue(
+            inspect.isasyncgenfunction(
+                functools.partial(async_generator_function_example)))
+        self.assertTrue(inspect.isasyncgen(async_gen_coro))
+
+        coro.close(); gen_coro.close(); # silence warnings
 
     def test_isawaitable(self):
         def gen(): yield

--- a/Misc/NEWS.d/next/Library/2018-10-15-23-10-41.bpo-34890.77E770.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-15-23-10-41.bpo-34890.77E770.rst
@@ -1,0 +1,3 @@
+Make :func:`inspect.iscoroutinefunction`,
+:func:`inspect.isgeneratorfunction` and :func:`inspect.isasyncgenfunction`
+work with :func:`functools.partial`. Patch by Pablo Galindo.


### PR DESCRIPTION
I have added some extra test cases for `isasyncgenfunction` and `isasyncgen` in `test_iscoroutine` for symmetry, but I am not sure if that is the place for it. Tell me if I should reallocate these tests in other place.

<!-- issue-number: [bpo-34890](https://bugs.python.org/issue34890) -->
https://bugs.python.org/issue34890
<!-- /issue-number -->
