### PR TITLE
bpo-34995: Maintain func.__isabstractmethod__ in functools.cached_property

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -882,7 +882,9 @@ class cached_property:
         self.func = func
         self.attrname = None
         self.__doc__ = func.__doc__
-        self.__isabstractmethod__ = getattr(func, '__isabstractmethod__', False)
+        func_isabstractmethod = getattr(func, '__isabstractmethod__')
+        if func_isabstractmethod is not None:
+            self.__isabstractmethod__ = func_isabstractmethod
         self.lock = RLock()
 
     def __set_name__(self, owner, name):

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -882,6 +882,7 @@ class cached_property:
         self.func = func
         self.attrname = None
         self.__doc__ = func.__doc__
+        self.__isabstractmethod__ = getattr(func, '__isabstractmethod__', False)
         self.lock = RLock()
 
     def __set_name__(self, owner, name):

--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -882,9 +882,10 @@ class cached_property:
         self.func = func
         self.attrname = None
         self.__doc__ = func.__doc__
-        func_isabstractmethod = getattr(func, '__isabstractmethod__')
-        if func_isabstractmethod is not None:
-            self.__isabstractmethod__ = func_isabstractmethod
+        try:
+            self.__isabstractmethod__ = func.__isabstractmethod__
+        except AttributeError:
+            pass
         self.lock = RLock()
 
     def __set_name__(self, owner, name):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2478,16 +2478,25 @@ class TestCachedProperty(unittest.TestCase):
     def test_doc(self):
         self.assertEqual(CachedCostItem.cost.__doc__, "The cost of the item.")
 
-    def test_isabstractmethod(self):
+    def test_isabstractmethod_copied(self):
         class AbstractExpensiveCalculator(abc.ABC):
             @functools.cached_property
             @abc.abstractmethod
             def calculate(self):
                 pass
 
-        self.assertTrue(getattr(AbstractExpensiveCalculator.calculate, '__isabstractmethod__', False))
+        self.assertTrue(AbstractExpensiveCalculator.calculate.__isabstractmethod__)
         with self.assertRaises(TypeError):
             AbstractExpensiveCalculator()
+
+    def test_missing_isabstractmethod_not_copied(self):
+        class ConcreteExpensiveCalculator(abc.ABC):
+            @functools.cached_property
+            def calculate(self):
+                return 42
+
+        self.assertFalse(getattr(ConcreteExpensiveCalculator.calculate, '__isabstractmethod__', False))
+        ConcreteExpensiveCalculator()
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2485,6 +2485,7 @@ class TestCachedProperty(unittest.TestCase):
             def calculate(self):
                 pass
 
+        self.assertTrue(getattr(AbstractExpensiveCalculator.calculate, '__isabstractmethod__', False))
         with self.assertRaises(TypeError):
             AbstractExpensiveCalculator()
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2485,7 +2485,8 @@ class TestCachedProperty(unittest.TestCase):
             def calculate(self):
                 pass
 
-        self.assertTrue(AbstractExpensiveCalculator.calculate.__isabstractmethod__)
+        method = AbstractExpensiveCalculator.calculate
+        self.assertTrue(method.__isabstractmethod__)
         with self.assertRaises(TypeError):
             AbstractExpensiveCalculator()
 
@@ -2495,7 +2496,8 @@ class TestCachedProperty(unittest.TestCase):
             def calculate(self):
                 return 42
 
-        self.assertFalse(getattr(ConcreteExpensiveCalculator.calculate, '__isabstractmethod__', False))
+        method = ConcreteExpensiveCalculator.calculate
+        self.assertFalse(getattr(method, '__isabstractmethod__', False))
         ConcreteExpensiveCalculator()
 
 

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2478,6 +2478,16 @@ class TestCachedProperty(unittest.TestCase):
     def test_doc(self):
         self.assertEqual(CachedCostItem.cost.__doc__, "The cost of the item.")
 
+    def test_isabstractmethod(self):
+        class AbstractExpensiveCalculator(abc.ABC):
+            @functools.cached_property
+            @abc.abstractmethod
+            def calculate(self):
+                pass
+
+        with self.assertRaises(TypeError):
+            AbstractExpensiveCalculator()
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/Misc/NEWS.d/next/Library/2018-10-15-23-56-39.bpo-34995.kNA9ge.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-15-23-56-39.bpo-34995.kNA9ge.rst
@@ -1,0 +1,1 @@
+Maintain wrapped method's __isabstractmethod__ in functools.cached_property

--- a/Misc/NEWS.d/next/Library/2018-10-15-23-56-39.bpo-34995.kNA9ge.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-15-23-56-39.bpo-34995.kNA9ge.rst
@@ -1,1 +1,1 @@
-Maintain wrapped method's __isabstractmethod__ in functools.cached_property
+:func:`functools.cached_property` now also copies the wrapped method's ``__isabstractmethod__`` attribute.


### PR DESCRIPTION
# [bpo-34995](https://bugs.python.org/issue34995): Maintain func.__isabstractmethod__ in functools.cached_property

<!-- issue-number: [bpo-34995](https://bugs.python.org/issue34995) -->
https://bugs.python.org/issue34995
<!-- /issue-number -->
