### PR TITLE
[2.7] bpo-24307: Fix unicode error in optparse with unicode value for %default

### DIFF
--- a/Lib/optparse.py
+++ b/Lib/optparse.py
@@ -285,13 +285,7 @@ class HelpFormatter:
         if default_value is NO_DEFAULT or default_value is None:
             default_value = self.NO_DEFAULT_VALUE
 
-        encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
-        if isinstance(default_value, unicode):
-            default_value = default_value.encode(encoding)
-        else:
-            default_value = str(default_value)
-
-        return option.help.replace(self.default_tag, default_value)
+        return option.help.replace(self.default_tag, unicode(default_value))
 
     def format_option(self, option):
         # The help for each option consists of two parts:

--- a/Lib/optparse.py
+++ b/Lib/optparse.py
@@ -285,7 +285,13 @@ class HelpFormatter:
         if default_value is NO_DEFAULT or default_value is None:
             default_value = self.NO_DEFAULT_VALUE
 
-        return option.help.replace(self.default_tag, str(default_value))
+        encoding = sys.getfilesystemencoding() or sys.getdefaultencoding()
+        if isinstance(default_value, unicode):
+            default_value = default_value.encode(encoding)
+        else:
+            default_value = str(default_value)
+
+        return option.help.replace(self.default_tag, default_value)
 
     def format_option(self, option):
         # The help for each option consists of two parts:

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -619,7 +619,7 @@ Options:
             help="blow up with probability PROB [default: %default]")
         self.parser.set_defaults(prob=u"ol\u00E9!")
         expected_help = self.help_prefix + \
-            "  -p PROB, --prob=PROB  blow up with probability PROB [default: ol\xc3\xa9!]\n"
+            u"  -p PROB, --prob=PROB  blow up with probability PROB [default: ol\u00E9!]\n"
         self.assertHelp(self.parser, expected_help)
 
     def test_alt_expand(self):

--- a/Lib/test/test_optparse.py
+++ b/Lib/test/test_optparse.py
@@ -613,6 +613,15 @@ Options:
             "  -p PROB, --prob=PROB  blow up with probability PROB [default: 0.43]\n"
         self.assertHelp(self.parser, expected_help)
 
+    def test_unicode_default(self):
+        self.parser.add_option(
+            "-p", "--prob",
+            help="blow up with probability PROB [default: %default]")
+        self.parser.set_defaults(prob=u"ol\u00E9!")
+        expected_help = self.help_prefix + \
+            "  -p PROB, --prob=PROB  blow up with probability PROB [default: ol\xc3\xa9!]\n"
+        self.assertHelp(self.parser, expected_help)
+
     def test_alt_expand(self):
         self.parser.add_option("-f", "--file",
                                default="foo.txt",

--- a/Misc/NEWS.d/next/Library/2018-09-23-19-44-54.bpo-24307.EAcncD.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-23-19-44-54.bpo-24307.EAcncD.rst
@@ -1,0 +1,2 @@
+Encode default value before replacing it in the option. Based on patch by
+tanbro-liu.


### PR DESCRIPTION
`optparse` allows `%default` in the help string where a default value can be supplied. '%default' is replaced with the given value. If the given value is a unicode value than it fails with `UnicodeEncodeError` in Python 2.7. This is not a problem in Python 3 since all strings are unicode by default. This patch encodes the value before replacement and adds tests. 

It's based on the patch by tanbro-liu in the bug tracker. Since there was no response from tanbro-liu I have converted the patch as a PR with test and attribution to tanbro-liu. 

<!-- issue-number: [bpo-24307](https://bugs.python.org/issue24307) -->
https://bugs.python.org/issue24307
<!-- /issue-number -->
