### PR TITLE
bpo-34814: don't link C extensions to libpython on Unix

### DIFF
--- a/Doc/distutils/apiref.rst
+++ b/Doc/distutils/apiref.rst
@@ -276,6 +276,10 @@ the full reference.
    |                        | simply skip the extension.     |                           |
    +------------------------+--------------------------------+---------------------------+
 
+   .. versionchanged:: 3.8
+
+      On Unix, C extensions are no longer linked to libpython.
+
 
 .. class:: Distribution
 

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -713,20 +713,5 @@ class build_ext(Command):
                 # don't extend ext.libraries, it may be shared with other
                 # extensions, it is a reference to the original list
                 return ext.libraries + [pythonlib]
-            else:
-                return ext.libraries
-        elif sys.platform == 'darwin':
-            # Don't use the default code below
-            return ext.libraries
-        elif sys.platform[:3] == 'aix':
-            # Don't use the default code below
-            return ext.libraries
-        else:
-            from distutils import sysconfig
-            if sysconfig.get_config_var('Py_ENABLE_SHARED'):
-                pythonlib = 'python{}.{}{}'.format(
-                    sys.hexversion >> 24, (sys.hexversion >> 16) & 0xff,
-                    sysconfig.get_config_var('ABIFLAGS'))
-                return ext.libraries + [pythonlib]
-            else:
-                return ext.libraries
+
+        return ext.libraries

--- a/Misc/NEWS.d/next/Build/2018-10-16-14-32-00.bpo-34814.qtWVS8.rst
+++ b/Misc/NEWS.d/next/Build/2018-10-16-14-32-00.bpo-34814.qtWVS8.rst
@@ -1,0 +1,1 @@
+On Unix, C extensions are no longer linked to libpython.


### PR DESCRIPTION
On Unix, C extensions are no longer linked to libpython in distutils.

<!-- issue-number: [bpo-34814](https://bugs.python.org/issue34814) -->
https://bugs.python.org/issue34814
<!-- /issue-number -->
