### PR TITLE
bpo-34997: Fix test_logging.ConfigDictTest.test_out_of_order

### DIFF
--- a/Lib/test/test_logging.py
+++ b/Lib/test/test_logging.py
@@ -25,6 +25,7 @@ import logging.config
 
 import codecs
 import configparser
+import copy
 import datetime
 import pathlib
 import pickle
@@ -3278,7 +3279,7 @@ class ConfigDictTest(BaseTest):
         self.assertRaises(ValueError, self.apply_config, self.out_of_order)
 
     def test_out_of_order_with_dollar_style(self):
-        config = self.out_of_order.copy()
+        config = copy.deepcopy(self.out_of_order)
         config['formatters']['mySimpleFormatter']['format'] = "${asctime} (${name}) ${levelname}: ${message}"
 
         self.apply_config(config)


### PR DESCRIPTION
When runnint test_logging with --huntrleaks, test_out_of_order fails
to raise ValueError due to the fact that the new test
test_out_of_order_with_dollar_style mutates the out_of_order
dictionary. Even if the test copies the dictionary first, the mutation
is done in a very deep level so the original one is also affected.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34997](https://bugs.python.org/issue34997) -->
https://bugs.python.org/issue34997
<!-- /issue-number -->
