### PR TITLE
bpo-35008: Fix possible leaks in Element.__setstate__().

### DIFF
--- a/Lib/test/test_xml_etree_c.py
+++ b/Lib/test/test_xml_etree_c.py
@@ -117,6 +117,22 @@ class MiscTests(unittest.TestCase):
         elem.tail = X()
         elem.__setstate__({'tag': 42})  # shouldn't cause an assertion failure
 
+    def test_setstate_leaks(self):
+        # Test reference leaks
+        elem = cET.Element.__new__(cET.Element)
+        for i in range(100):
+            elem.__setstate__({'tag': 'foo', 'attrib': {'bar': 42},
+                               '_children': [cET.Element('child')],
+                               'text': 'text goes here',
+                               'tail': 'opposite of head'})
+
+        self.assertEqual(elem.tag, 'foo')
+        self.assertEqual(elem.text, 'text goes here')
+        self.assertEqual(elem.tail, 'opposite of head')
+        self.assertEqual(list(elem.attrib.items()), [('bar', 42)])
+        self.assertEqual(len(elem), 1)
+        self.assertEqual(elem[0].tag, 'child')
+
 
 @unittest.skipUnless(cET, 'requires _elementtree')
 class TestAliasWorking(unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-10-17-11-54-04.bpo-35008.dotef_.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-17-11-54-04.bpo-35008.dotef_.rst
@@ -1,0 +1,3 @@
+Fixed references leaks when call the ``__setstate__()`` method of
+:class:`xml.etree.ElementTree.Element` in the C implementation for already
+initialized element.


### PR DESCRIPTION
C implementation of `xml.etree.ElementTree.Element.__setstate__()`
leaked references to children when called for already initialized
element.


<!-- issue-number: [bpo-35008](https://bugs.python.org/issue35008) -->
https://bugs.python.org/issue35008
<!-- /issue-number -->
