### PR TITLE
[3.7] bpo-23420: Verify the value of '-s' when execute the CLI of cProfile (GH-9925)

### DIFF
--- a/Lib/cProfile.py
+++ b/Lib/cProfile.py
@@ -124,6 +124,7 @@ def main():
     import os
     import sys
     import runpy
+    import pstats
     from optparse import OptionParser
     usage = "cProfile.py [-o output_file_path] [-s sort] [-m module | scriptfile] [arg] ..."
     parser = OptionParser(usage=usage)
@@ -132,7 +133,8 @@ def main():
         help="Save stats to <outfile>", default=None)
     parser.add_option('-s', '--sort', dest="sort",
         help="Sort order when printing to stdout, based on pstats.Stats class",
-        default=-1)
+        default=-1,
+        choices=sorted(pstats.Stats.sort_arg_dict_default))
     parser.add_option('-m', dest="module", action="store_true",
         help="Profile a library module", default=False)
 

--- a/Lib/test/test_cprofile.py
+++ b/Lib/test/test_cprofile.py
@@ -2,6 +2,7 @@
 
 import sys
 from test.support import run_unittest, TESTFN, unlink
+import unittest
 
 # rip off all interesting stuff from test_profile
 import cProfile
@@ -50,8 +51,14 @@ class CProfileTest(ProfileTest):
         assert_python_ok('-m', 'cProfile', '-m', 'timeit', '-n', '1')
 
 
+class TestCommandLine(unittest.TestCase):
+    def test_sort(self):
+        rc, out, err = assert_python_failure('-m', 'cProfile', '-s', 'demo')
+        self.assertGreater(rc, 0)
+        self.assertIn(b"option -s: invalid choice: 'demo'", err)
+
 def test_main():
-    run_unittest(CProfileTest)
+    run_unittest(CProfileTest, TestCommandLine)
 
 def main():
     if '-r' not in sys.argv:

--- a/Misc/NEWS.d/next/Library/2018-10-17-11-00-00.bpo-23420.Lq74Uu.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-17-11-00-00.bpo-23420.Lq74Uu.rst
@@ -1,0 +1,2 @@
+Verify the value for the parameter '-s' of the cProfile CLI. Patch by Robert
+Kuska


### PR DESCRIPTION
[3.7] [bpo-23420](https://bugs.python.org/issue23420): Verify the value of '-s' when execute the CLI of cProfile (GH-9925)

Verify the value for the parameter '-s' of the cProfile CLI. Patch by Robert
Kuska.

Co-authored-by: Robert Kuska <rkuska@gmail.com>
(cherry picked from commit fcd5e84a515e19409840c570730f0728e9fcfc83)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-23420](https://bugs.python.org/issue23420) -->
https://bugs.python.org/issue23420
<!-- /issue-number -->
