### PR TITLE
bpo-35011: Restore use of pyexpatns.h in libexpat

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-10-17-17-38-57.bpo-35011.GgoPIC.rst
+++ b/Misc/NEWS.d/next/Build/2018-10-17-17-38-57.bpo-35011.GgoPIC.rst
@@ -1,0 +1,4 @@
+Restores the use of pyexpatns.h to isolate our embedded copy of the expat C
+library so that its symbols do not conflict at link or dynamic loading time
+with an embedding application or other extension modules with their own
+version of libexpat.

--- a/Modules/expat/expat_external.h
+++ b/Modules/expat/expat_external.h
@@ -35,6 +35,10 @@
 
 /* External API definitions */
 
+/* Namespace external symbols to allow multiple libexpat version to
+   co-exist. */
+#include "pyexpatns.h"
+
 #if defined(_MSC_EXTENSIONS) && !defined(__BEOS__) && !defined(__CYGWIN__)
 # define XML_USE_MSC_EXTENSIONS 1
 #endif


### PR DESCRIPTION
Restores the use of pyexpatns.h to isolate our embedded copy of the expat C
library so that its symbols do not conflict at link or dynamic loading time
with an embedding application or other extension modules with their own
version of libexpat.

https://github.com/python/cpython/commit/5dc3f23b5fb0b510926012cb3732dae63cddea60#diff-3afaf7274c90ce1b7405f75ad825f545 inadvertently removed it when upgrading expat.

<!-- issue-number: [bpo-35011](https://bugs.python.org/issue35011) -->
https://bugs.python.org/issue35011
<!-- /issue-number -->
