### PR TITLE
[Docs] Fix approximated importlib.import_module()

### DIFF
--- a/Doc/library/importlib.rst
+++ b/Doc/library/importlib.rst
@@ -1731,7 +1731,7 @@ Python 3.6 and newer for other parts of the code).
       if '.' in absolute_name:
           parent_name, _, child_name = absolute_name.rpartition('.')
           parent_module = import_module(parent_name)
-          path = parent_module.spec.submodule_search_locations
+          path = parent_module.__spec__.submodule_search_locations
       for finder in sys.meta_path:
           spec = finder.find_spec(absolute_name, path)
           if spec is not None:


### PR DESCRIPTION
The spec gets stored on modules with the `__spec__` attribute, not `spec`. An easy way to test the validity of this fix is running `import_module('collections.abc')`, which failed previously.