### PR TITLE
[3.7] bpo-34936: Fix TclError in tkinter.Spinbox.selection_element() (GH-9760)

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -3750,7 +3750,7 @@ class Spinbox(Widget, XView):
         select to commands. If the selection isn't currently in
         the spinbox, then a new selection is created to include
         the characters between index and the most recent selection
-        anchor point, inclusive. Returns an empty string.
+        anchor point, inclusive.
         """
         return self.selection("adjust", index)
 
@@ -3758,7 +3758,7 @@ class Spinbox(Widget, XView):
         """Clear the selection
 
         If the selection isn't in this widget then the
-        command has no effect. Returns an empty string.
+        command has no effect.
         """
         return self.selection("clear")
 
@@ -3766,9 +3766,9 @@ class Spinbox(Widget, XView):
         """Sets or gets the currently selected element.
 
         If a spinbutton element is specified, it will be
-        displayed depressed
+        displayed depressed.
         """
-        return self.selection("element", element)
+        return self.tk.call(self._w, 'selection', 'element', element)
 
 ###########################################################################
 

--- a/Lib/tkinter/test/test_tkinter/test_widgets.py
+++ b/Lib/tkinter/test/test_tkinter/test_widgets.py
@@ -474,6 +474,14 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self.assertRaises(TypeError, widget.bbox)
         self.assertRaises(TypeError, widget.bbox, 0, 1)
 
+    def test_selection_element(self):
+        widget = self.create()
+        self.assertEqual(widget.selection_element(), "none")
+        widget.selection_element("buttonup")
+        self.assertEqual(widget.selection_element(), "buttonup")
+        widget.selection_element("buttondown")
+        self.assertEqual(widget.selection_element(), "buttondown")
+
 
 @add_standard_options(StandardOptionsTests)
 class TextTest(AbstractWidgetTest, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-10-08-21-05-11.bpo-34936.3tRqdq.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-08-21-05-11.bpo-34936.3tRqdq.rst
@@ -1,0 +1,2 @@
+Fix ``TclError`` in ``tkinter.Spinbox.selection_element()``. Patch by
+Juliette Monsel.


### PR DESCRIPTION
I removed the tests for the unimplemented methods in 3.7.

(cherry picked from commit 1deea5e53991b46351f6bb395b22365c9455ed88)
<!-- issue-number: [bpo-34936](https://bugs.python.org/issue34936) -->
https://bugs.python.org/issue34936
<!-- /issue-number -->
