### PR TITLE
bpo-35021: Fix assertion failures in _datetimemodule.c.

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -893,8 +893,16 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         class BadInt(int):
             def __mul__(self, other):
                 return Prod()
+            def __rmul__(self, other):
+                return Prod()
+            def __floordiv__(self, other):
+                return Prod()
+            def __rfloordiv__(self, other):
+                return Prod()
 
         class Prod:
+            def __add__(self, other):
+                return Sum()
             def __radd__(self, other):
                 return Sum()
 
@@ -906,6 +914,9 @@ class TestTimeDelta(HarmlessMixedComparison, unittest.TestCase):
         timedelta(microseconds=BadInt(1))
         timedelta(hours=BadInt(1))
         timedelta(weeks=BadInt(1))
+        timedelta(1) * BadInt(1)
+        BadInt(1) * timedelta(1)
+        timedelta(1) // BadInt(1)
 
 
 #############################################################################


### PR DESCRIPTION
The result of multiplication and division of an integer and
an instance of integer subclass can be not exact integer.
The type of the right operand takes precedence when it is
a subclass of the type of the left operand.
Use PyLong slots explicitly to get an exact integer.


<!-- issue-number: [bpo-35021](https://bugs.python.org/issue35021) -->
https://bugs.python.org/issue35021
<!-- /issue-number -->
