### PR TITLE
bpo-28053: Complete and fix custom reducers in multiprocessing.

### DIFF
--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1210,18 +1210,18 @@ the reduction mechanism:
    Abstract base class that can be implemented in order to replace the standard
    reduction mechanism used in multiprocessing
 
-   .. function:: get_pickler_class():
+   .. method:: get_pickler_class():
 
-      This method must return an instance of a subclass of :class:`pickler.Pickler`
-      to be used by the multiprocessing reducer mechanism.
+      This method must return an subclass of :class:`pickler.Pickler` to be used by
+      the multiprocessing reducer mechanism.
 
 .. currentmodule:: multiprocessing
 
 .. method:: set_reducer(reduction)
 
-   Sets a reduction class to be used for serialization and deserialization by the module
-   primitive internals. **reduction** must be an instance of a subclass of
-   :class:`multiprocessing.reduction.AbstractReducer`.
+   Sets a reduction instance to be used for serialization and deserialization
+   by the module primitive internals. **reduction** must be an instance of a
+   subclass of :class:`multiprocessing.reduction.AbstractReducer`.
 
 .. method:: get_reducer()
 
@@ -1235,14 +1235,14 @@ version 2 to be able to communicate with a Python 2.x programs.::
 
    class ForkingPicklerProtocol2(ForkingPickler):
        @classmethod
-       def dumps(cls, obj, pickle_protocol=2):
-           return super().dumps(obj, protocol=pickle_protocol)
+       def dumps(cls, obj, protocol=2):
+           return super().dumps(obj, protocol=protocol)
 
    class PickleProtocol2Reducer(AbstractReducer):
        def get_pickler_class(self):
            return ForkingPicklerProtocol2
 
-   multiprocessing.set_reducer(PickleProtocol2Reducer)
+   multiprocessing.set_reducer(PickleProtocol2Reducer())
 
 Notice that using :meth:`multiprocessing.set_reducer` changes the reducer globally. If
 changing this setting globally is undesirable you could call :meth:`context.set_reducer`,

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1195,34 +1195,35 @@ Custom Reduction
 Several primitives of the :mod:`multiprocessing` module such as
 :class:`multiprocessing.Queue`, :class:`multiprocessing.connection.Listener` or
 :class:`multiprocessing.connection.Server` need to serialize and deserialize Python
-objects to communicate between processes. Sometimes is useful to control what
-serialization is to be used for the transport of data for supporting communication with
-different versions of Python, use more performant 3rd party tools or custom strategies.
+objects to communicate between processes. Sometimes it is useful to control what
+serialization is to be used for the transport of data in order to support communication
+with different versions of Python, use more performant third party tools or custom
+strategies.
 
-For this pourpose a set of hooks is available to provide alternate implementations of
+For this purpose a set of hooks is available to provide alternate implementations of
 the reduction mechanism:
 
 .. currentmodule:: multiprocessing.reduction
 
 .. class:: AbstractReducer()
 
-   Abstract base class for use in implementing a Reduction class suitable for use
-   in replacing the standard reduction mechanism used in multiprocessing.
+   Abstract base class that can be implemented in order to replace the standard
+   reduction mechanism used in multiprocessing
 
-   .. function:: get_pickler_class():
+   .. function:: get_pickler():
 
-      This method must return a subclass of :class:`pickle.Pickler` to be used by
-      the multiprocessing reducer mechanism.
+      This method must return a instance of a subclass of :class:`pickle.Pickler`
+      to be used by the multiprocessing reducer mechanism.
 
 .. currentmodule:: multiprocessing
 
-.. function:: set_reducer(reduction)
+.. method:: set_reducer(reduction)
 
    Sets a reduction class to be used for serialization and deserialization by the module
-   primitive internals. **reduction** must be a subclass of
+   primitive internals. **reduction** must be an instance of a subclass of
    :class:`multiprocessing.reduction.AbstractReducer`.
 
-.. function:: get_reducer()
+.. method:: get_reducer()
 
    Gets the current reduction class in use by the module's primitive internals.
 
@@ -1238,7 +1239,7 @@ version 2 to be able to communicate with a Python 2.x programs.::
            return super().dumps(obj, protocol=pickle_protocol)
 
    class PickleProtocol2Reducer(AbstractReducer):
-       def get_pickler_class(self):
+       def get_pickler(self):
            return ForkingPicklerProtocol2
 
    multiprocessing.set_reducer(PickleProtocol2Reducer)

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1205,6 +1205,21 @@ the reduction mechanism:
 
 .. currentmodule:: multiprocessing.reduction
 
+.. class:: AbstractPickler()
+   Abstract base class that can be implemented in order to override specidifc
+   methods of the reduction machinery used by multiprocessing.
+
+   .. method:: dump(obj)
+      Write a pickled representation of obj to the open file.
+
+      Defaults to :meth:`pickle.Pickle.dump`
+
+   .. classmethod:: loads(bytes_object, *, fix_imports=True, encoding="ASCII", errors="strict")
+      Read a pickled object hierarchy from a bytes object and return the reconstituted
+      object hierarchy specified therein.
+
+      Defaults to :func:`pickle.loads`
+
 .. class:: AbstractReducer()
 
    Abstract base class that can be implemented in order to replace the standard
@@ -1231,16 +1246,16 @@ For example, substituting the reducer class to use the :mod:`pickle` protocol
 version 2 to be able to communicate with a Python 2.x programs.::
 
    import multiprocessing
-   from multiprocessing.reduction import AbstractReducer, ForkingPickler
+   from multiprocessing.reduction import AbstractReducer, AbstractPickler
 
-   class ForkingPicklerProtocol2(ForkingPickler):
+   class PicklerProtocol2(AbstractPickler):
        @classmethod
        def dumps(cls, obj, protocol=2):
            return super().dumps(obj, protocol=protocol)
 
    class PickleProtocol2Reducer(AbstractReducer):
        def get_pickler_class(self):
-           return ForkingPicklerProtocol2
+           return PicklerProtocol2
 
    multiprocessing.set_reducer(PickleProtocol2Reducer())
 

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1210,7 +1210,7 @@ the reduction mechanism:
    Abstract base class that can be implemented in order to replace the standard
    reduction mechanism used in multiprocessing
 
-   .. function:: get_pickler():
+   .. function:: get_pickler_class():
 
       This method must return an instance of a subclass of :class:`pickler.Pickler`
       to be used by the multiprocessing reducer mechanism.
@@ -1239,7 +1239,7 @@ version 2 to be able to communicate with a Python 2.x programs.::
            return super().dumps(obj, protocol=pickle_protocol)
 
    class PickleProtocol2Reducer(AbstractReducer):
-       def get_pickler(self):
+       def get_pickler_class(self):
            return ForkingPicklerProtocol2
 
    multiprocessing.set_reducer(PickleProtocol2Reducer)

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1212,7 +1212,7 @@ the reduction mechanism:
 
    .. function:: get_pickler():
 
-      This method must return a instance of a subclass of :class:`pickle.Pickler`
+      This method must return an instance of a subclass of :class:`pickler.Pickler`
       to be used by the multiprocessing reducer mechanism.
 
 .. currentmodule:: multiprocessing
@@ -1239,10 +1239,14 @@ version 2 to be able to communicate with a Python 2.x programs.::
            return super().dumps(obj, protocol=pickle_protocol)
 
    class PickleProtocol2Reducer(AbstractReducer):
-       def get_pickler(self):
+       def get_pickler_class(self):
            return ForkingPicklerProtocol2
 
    multiprocessing.set_reducer(PickleProtocol2Reducer)
+
+Notice that using :meth:`multiprocessing.set_reducer` changes the reducer globally. If
+changing this setting globally is undesirable you could call :meth:`context.set_reducer`,
+where *context* is a context object obtained by calling :func:`get_context`.
 
 Synchronization primitives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1239,7 +1239,7 @@ version 2 to be able to communicate with a Python 2.x programs.::
            return super().dumps(obj, protocol=pickle_protocol)
 
    class PickleProtocol2Reducer(AbstractReducer):
-       def get_pickler_class(self):
+       def get_pickler(self):
            return ForkingPicklerProtocol2
 
    multiprocessing.set_reducer(PickleProtocol2Reducer)

--- a/Doc/library/multiprocessing.rst
+++ b/Doc/library/multiprocessing.rst
@@ -1209,17 +1209,10 @@ the reduction mechanism:
    Abstract base class for use in implementing a Reduction class suitable for use
    in replacing the standard reduction mechanism used in multiprocessing.
 
-   .. class:: ForkingPickler
+   .. function:: get_pickler_class():
 
-      A subclass of :class:`pickle.Pickler` to be used by multiprocessing.
-
-   .. function:: dump(obj, file, protocol=None)
-
-      Replacement for pickle.dump() to be used by multiprocessing.
-
-   .. function:: register(cls, type, reduce)
-
-      Register a reduce function for a type to be used by multiprocessing.
+      This method must return a subclass of :class:`pickle.Pickler` to be used by
+      the multiprocessing reducer mechanism.
 
 .. currentmodule:: multiprocessing
 
@@ -1238,26 +1231,17 @@ version 2 to be able to communicate with a Python 2.x programs.::
 
    import multiprocessing
    from multiprocessing.reduction import AbstractReducer, ForkingPickler
-   import pickle
 
-   class ForkingPickler2(ForkingPickler):
+   class ForkingPicklerProtocol2(ForkingPickler):
        @classmethod
        def dumps(cls, obj, pickle_protocol=2):
            return super().dumps(obj, protocol=pickle_protocol)
 
-      loads = pickle.loads
+   class PickleProtocol2Reducer(AbstractReducer):
+       def get_pickler_class(self):
+           return ForkingPicklerProtocol2
 
-
-   def dump(obj, file, protocol=2):
-       return ForkingPickler2(file, protocol).dump(obj)
-
-
-   class Pickle2Reducer(AbstractReducer):
-       ForkingPickler = ForkingPickler2
-       register = ForkingPickler2.register
-       dump = dump
-
-   multiprocessing.set_reducer(Pickle2Reducer)
+   multiprocessing.set_reducer(PickleProtocol2Reducer)
 
 Synchronization primitives
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Lib/multiprocessing/connection.py
+++ b/Lib/multiprocessing/connection.py
@@ -202,7 +202,7 @@ class _ConnectionBase:
         """Send a (picklable) object"""
         self._check_closed()
         self._check_writable()
-        self._send_bytes(context.reduction.ForkingPickler.dumps(obj))
+        self._send_bytes(context.reduction.dumps(obj))
 
     def recv_bytes(self, maxlength=None):
         """
@@ -247,7 +247,7 @@ class _ConnectionBase:
         self._check_closed()
         self._check_readable()
         buf = self._recv_bytes()
-        return context.reduction.ForkingPickler.loads(buf.getbuffer())
+        return context.reduction.loads(buf.getbuffer())
 
     def poll(self, timeout=0.0):
         """Whether there is any input available to be read"""

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -214,11 +214,11 @@ class BaseContext(object):
             return
 
         if not isinstance(reduction, original_reducer.AbstractReducer):
-            raise TypeError("Custom reducers must subclass "
-                            "multiprocessing.reduction.AbstractReducer")
-        if not isinstance(reduction.get_pickler_class(), pickle.Pickler):
+            raise TypeError("Custom reducers must be instances of a "
+                            "subclass of multiprocessing.reduction.AbstractReducer")
+        if not isinstance(reduction.get_pickler(), pickle.Pickler):
             raise TypeError("Custom reducers must return a subclass of "
-                            "pickler.Pickler in the get_pickler_class() method")
+                            "pickler.Pickler in the get_pickler() method")
 
         globals()['reduction'] = reduction
 

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -66,6 +66,16 @@ class BaseContext(object):
         from .connection import Pipe
         return Pipe(duplex)
 
+    def Listener(self, *args, **kwargs):
+        '''Returns a connection Listener object'''
+        from .connection import Listener
+        return Listener(*args, ctx=self.get_context(), **kwargs)
+
+    def Client(self, *args, **kwargs):
+        '''Returns a connection Client object'''
+        from .connection import Client
+        return Client(*args, ctx=self.get_context(), **kwargs)
+
     def Lock(self):
         '''Returns a non-recursive lock object'''
         from .synchronize import Lock
@@ -207,14 +217,16 @@ class BaseContext(object):
     def get_reducer(self):
         '''Controls how objects will be reduced to a form that can be
         shared with other processes.'''
-        reducer = self._reducer
+        ctx = self.get_context()
+        reducer = ctx._reducer
         if reducer is None:
             return reduction
         return reducer
 
     def set_reducer(self, reduction):
+        ctx = self.get_context()
         if reduction is original_reducer:
-            self._reducer = None
+            ctx._reducer = None
             return
 
         if not isinstance(reduction, original_reducer.AbstractReducer):
@@ -224,7 +236,7 @@ class BaseContext(object):
             raise TypeError("Custom reducers must return an subclass of "
                             "pickler.Pickler in the get_pickler_class() method")
 
-        self._reducer = reduction
+        ctx._reducer = reduction
 
     def _check_available(self):
         pass

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -206,21 +206,25 @@ class BaseContext(object):
     def get_reducer(self):
         '''Controls how objects will be reduced to a form that can be
         shared with other processes.'''
-        return globals().get('reduction')
+        reducer = getattr(self, "_reducer", None)
+        if reducer is None:
+            return reduction
+        return reducer
 
     def set_reducer(self, reduction):
         if reduction is original_reducer:
-            globals()['reduction'] = reduction
+            self._reducer = None
             return
 
         if not isinstance(reduction, original_reducer.AbstractReducer):
             raise TypeError("Custom reducers must be instances of a "
                             "subclass of multiprocessing.reduction.AbstractReducer")
         if not isinstance(reduction.get_pickler(), pickle.Pickler):
+            breakpoint()
             raise TypeError("Custom reducers must return a subclass of "
                             "pickler.Pickler in the get_pickler() method")
 
-        globals()['reduction'] = reduction
+        self._reducer = reduction
 
     def _check_available(self):
         pass

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -1,9 +1,12 @@
 import os
+import pickle
 import sys
 import threading
 
 from . import process
 from . import reduction
+
+original_reducer = reduction
 
 __all__ = ()
 
@@ -206,6 +209,17 @@ class BaseContext(object):
         return globals().get('reduction')
 
     def set_reducer(self, reduction):
+        if reduction is original_reducer:
+            globals()['reduction'] = reduction
+            return
+
+        if not isinstance(reduction, original_reducer.AbstractReducer):
+            raise TypeError("Custom reducers must subclass "
+                            "multiprocessing.reduction.AbstractReducer")
+        if not isinstance(reduction.get_pickler_class(), pickle.Pickler):
+            raise TypeError("Custom reducers must return a subclass of "
+                            "pickler.Pickler in the get_pickler_class() method")
+
         globals()['reduction'] = reduction
 
     def _check_available(self):

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -40,6 +40,7 @@ class BaseContext(object):
     current_process = staticmethod(process.current_process)
     parent_process = staticmethod(process.parent_process)
     active_children = staticmethod(process.active_children)
+    _reducer = None
 
     def cpu_count(self):
         '''Returns the number of CPUs in the system'''
@@ -206,7 +207,7 @@ class BaseContext(object):
     def get_reducer(self):
         '''Controls how objects will be reduced to a form that can be
         shared with other processes.'''
-        reducer = getattr(self, "_reducer", None)
+        reducer = self._reducer
         if reducer is None:
             return reduction
         return reducer
@@ -220,8 +221,7 @@ class BaseContext(object):
             raise TypeError("Custom reducers must be instances of a "
                             "subclass of multiprocessing.reduction.AbstractReducer")
         if not isinstance(reduction.get_pickler(), pickle.Pickler):
-            breakpoint()
-            raise TypeError("Custom reducers must return a subclass of "
+            raise TypeError("Custom reducers must return an instance of "
                             "pickler.Pickler in the get_pickler() method")
 
         self._reducer = reduction

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -232,9 +232,10 @@ class BaseContext(object):
         if not isinstance(reduction, original_reducer.AbstractReducer):
             raise TypeError("Custom reducers must be instances of a "
                             "subclass of multiprocessing.reduction.AbstractReducer")
-        if not issubclass(reduction.get_pickler_class(), pickle.Pickler):
+        if not issubclass(reduction.get_pickler_class(), original_reducer.AbstractPickler):
             raise TypeError("Custom reducers must return an subclass of "
-                            "pickler.Pickler in the get_pickler_class() method")
+                            "multiprocessing.reduction.AbstractPickler "
+                            "in the get_pickler_class() method")
 
         ctx._reducer = reduction
 

--- a/Lib/multiprocessing/context.py
+++ b/Lib/multiprocessing/context.py
@@ -200,14 +200,12 @@ class BaseContext(object):
     def set_start_method(self, method, force=False):
         raise ValueError('cannot set start method of concrete context')
 
-    @property
-    def reducer(self):
+    def get_reducer(self):
         '''Controls how objects will be reduced to a form that can be
         shared with other processes.'''
         return globals().get('reduction')
 
-    @reducer.setter
-    def reducer(self, reduction):
+    def set_reducer(self, reduction):
         globals()['reduction'] = reduction
 
     def _check_available(self):

--- a/Lib/multiprocessing/forkserver.py
+++ b/Lib/multiprocessing/forkserver.py
@@ -10,8 +10,9 @@ import warnings
 
 from . import connection
 from . import process
-from .context import reduction
 from . import resource_tracker
+from . import context
+from .context import reduction
 from . import spawn
 from . import util
 
@@ -72,7 +73,7 @@ class ForkServer(object):
                       resource_tracker.getfd()]
             allfds += fds
             try:
-                reduction.sendfds(client, allfds)
+                context.reduction.sendfds(client, allfds)
                 return parent_r, parent_w
             except:
                 os.close(parent_r)
@@ -240,7 +241,7 @@ def main(listener_fd, alive_r, preload, main_path=None, sys_path=None):
                     # Incoming fork request
                     with listener.accept()[0] as s:
                         # Receive fds from client
-                        fds = reduction.recvfds(s, MAXFDS_TO_SEND + 1)
+                        fds = context.reduction.recvfds(s, MAXFDS_TO_SEND + 1)
                         if len(fds) > MAXFDS_TO_SEND:
                             raise RuntimeError(
                                 "Too many ({0:n}) fds to send".format(

--- a/Lib/multiprocessing/heap.py
+++ b/Lib/multiprocessing/heap.py
@@ -15,7 +15,8 @@ import sys
 import tempfile
 import threading
 
-from .context import reduction, assert_spawning
+from . import context
+from .context import assert_spawning
 from . import util
 
 __all__ = ['BufferWrapper']
@@ -101,12 +102,12 @@ else:
         if a.fd == -1:
             raise ValueError('Arena is unpicklable because '
                              'forking was enabled when it was created')
-        return rebuild_arena, (a.size, reduction.DupFd(a.fd))
+        return rebuild_arena, (a.size, context.reduction.DupFd(a.fd))
 
     def rebuild_arena(size, dupfd):
         return Arena(size, dupfd.detach())
 
-    reduction.register(Arena, reduce_arena)
+    context.reduction.register(Arena, reduce_arena)
 
 #
 # Class allowing allocation of chunks of memory from arenas

--- a/Lib/multiprocessing/managers.py
+++ b/Lib/multiprocessing/managers.py
@@ -27,7 +27,8 @@ from os import getpid
 from traceback import format_exc
 
 from . import connection
-from .context import reduction, get_spawning_popen, ProcessError
+from . import context
+from .context import get_spawning_popen, ProcessError
 from . import pool
 from . import process
 from . import util
@@ -44,14 +45,14 @@ except ImportError:
 
 def reduce_array(a):
     return array.array, (a.typecode, a.tobytes())
-reduction.register(array.array, reduce_array)
+context.reduction.register(array.array, reduce_array)
 
 view_types = [type(getattr({}, name)()) for name in ('items','keys','values')]
 if view_types[0] is not list:       # only needed in Py3.0
     def rebuild_as_list(obj):
         return list, (list(obj),)
     for view_type in view_types:
-        reduction.register(view_type, rebuild_as_list)
+        context.reduction.register(view_type, rebuild_as_list)
 
 #
 # Type for identifying shared objects

--- a/Lib/multiprocessing/popen_fork.py
+++ b/Lib/multiprocessing/popen_fork.py
@@ -1,6 +1,7 @@
 import os
 import signal
 
+import multiprocessing
 from . import util
 
 __all__ = ['Popen']
@@ -12,10 +13,11 @@ __all__ = ['Popen']
 class Popen(object):
     method = 'fork'
 
-    def __init__(self, process_obj):
+    def __init__(self, process_obj, ctx=None):
         util._flush_std_streams()
         self.returncode = None
         self.finalizer = None
+        self.ctx = ctx or multiprocessing.get_context()
         self._launch(process_obj)
 
     def duplicate_for_child(self, fd):

--- a/Lib/multiprocessing/popen_forkserver.py
+++ b/Lib/multiprocessing/popen_forkserver.py
@@ -31,9 +31,9 @@ class Popen(popen_fork.Popen):
     method = 'forkserver'
     DupFd = _DupFd
 
-    def __init__(self, process_obj):
+    def __init__(self, process_obj, ctx=None):
         self._fds = []
-        super().__init__(process_obj)
+        super().__init__(process_obj, ctx)
 
     def duplicate_for_child(self, fd):
         self._fds.append(fd)
@@ -44,8 +44,8 @@ class Popen(popen_fork.Popen):
         buf = io.BytesIO()
         set_spawning_popen(self)
         try:
-            context.reduction.dump(prep_data, buf)
-            context.reduction.dump(process_obj, buf)
+            self.ctx.get_reducer().dump(prep_data, buf)
+            self.ctx.get_reducer().dump(process_obj, buf)
         finally:
             set_spawning_popen(None)
 

--- a/Lib/multiprocessing/popen_forkserver.py
+++ b/Lib/multiprocessing/popen_forkserver.py
@@ -1,8 +1,9 @@
 import io
 import os
 
-from .context import reduction, set_spawning_popen
-if not reduction.HAVE_SEND_HANDLE:
+from . import context
+from .context import set_spawning_popen
+if not context.reduction.HAVE_SEND_HANDLE:
     raise ImportError('No support for sending fds between processes')
 from . import forkserver
 from . import popen_fork
@@ -43,8 +44,8 @@ class Popen(popen_fork.Popen):
         buf = io.BytesIO()
         set_spawning_popen(self)
         try:
-            reduction.dump(prep_data, buf)
-            reduction.dump(process_obj, buf)
+            context.reduction.dump(prep_data, buf)
+            context.reduction.dump(process_obj, buf)
         finally:
             set_spawning_popen(None)
 

--- a/Lib/multiprocessing/popen_spawn_posix.py
+++ b/Lib/multiprocessing/popen_spawn_posix.py
@@ -1,7 +1,7 @@
 import io
 import os
 
-from . import context
+import multiprocessing
 from .context import set_spawning_popen
 from . import popen_fork
 from . import spawn
@@ -28,9 +28,10 @@ class Popen(popen_fork.Popen):
     method = 'spawn'
     DupFd = _DupFd
 
-    def __init__(self, process_obj):
+    def __init__(self, process_obj, ctx=None):
         self._fds = []
-        super().__init__(process_obj)
+        ctx = ctx or multiprocessing.get_context()
+        super().__init__(process_obj, ctx)
 
     def duplicate_for_child(self, fd):
         self._fds.append(fd)
@@ -44,8 +45,8 @@ class Popen(popen_fork.Popen):
         fp = io.BytesIO()
         set_spawning_popen(self)
         try:
-            context.reduction.dump(prep_data, fp)
-            context.reduction.dump(process_obj, fp)
+            self.ctx.get_reducer().dump(prep_data, fp)
+            self.ctx.get_reducer().dump(process_obj, fp)
         finally:
             set_spawning_popen(None)
 

--- a/Lib/multiprocessing/popen_spawn_posix.py
+++ b/Lib/multiprocessing/popen_spawn_posix.py
@@ -1,7 +1,8 @@
 import io
 import os
 
-from .context import reduction, set_spawning_popen
+from . import context
+from .context import set_spawning_popen
 from . import popen_fork
 from . import spawn
 from . import util
@@ -43,8 +44,8 @@ class Popen(popen_fork.Popen):
         fp = io.BytesIO()
         set_spawning_popen(self)
         try:
-            reduction.dump(prep_data, fp)
-            reduction.dump(process_obj, fp)
+            context.reduction.dump(prep_data, fp)
+            context.reduction.dump(process_obj, fp)
         finally:
             set_spawning_popen(None)
 

--- a/Lib/multiprocessing/popen_spawn_win32.py
+++ b/Lib/multiprocessing/popen_spawn_win32.py
@@ -4,7 +4,8 @@ import signal
 import sys
 import _winapi
 
-from .context import reduction, get_spawning_popen, set_spawning_popen
+from . import context
+from .context import get_spawning_popen, set_spawning_popen
 from . import spawn
 from . import util
 
@@ -90,14 +91,14 @@ class Popen(object):
             # send information to child
             set_spawning_popen(self)
             try:
-                reduction.dump(prep_data, to_child)
-                reduction.dump(process_obj, to_child)
+                context.reduction.dump(prep_data, to_child)
+                context.reduction.dump(process_obj, to_child)
             finally:
                 set_spawning_popen(None)
 
     def duplicate_for_child(self, handle):
         assert self is get_spawning_popen()
-        return reduction.duplicate(handle, self.sentinel)
+        return context.reduction.duplicate(handle, self.sentinel)
 
     def wait(self, timeout=None):
         if self.returncode is None:

--- a/Lib/multiprocessing/process.py
+++ b/Lib/multiprocessing/process.py
@@ -78,7 +78,7 @@ class BaseProcess(object):
         raise NotImplementedError
 
     def __init__(self, group=None, target=None, name=None, args=(), kwargs={},
-                 *, daemon=None):
+                 *, daemon=None, ctx=None):
         assert group is None, 'group argument must be None for now'
         count = next(_process_counter)
         self._identity = _current_process._identity + (count,)
@@ -95,6 +95,7 @@ class BaseProcess(object):
         if daemon is not None:
             self.daemon = daemon
         _dangling.add(self)
+        self._ctx = ctx
 
     def _check_closed(self):
         if self._closed:
@@ -118,7 +119,7 @@ class BaseProcess(object):
         assert not _current_process._config.get('daemon'), \
                'daemonic processes are not allowed to have children'
         _cleanup()
-        self._popen = self._Popen(self)
+        self._popen = self._Popen(self, ctx=self._ctx)
         self._sentinel = self._popen.sentinel
         # Avoid a refcycle if the target function holds an indirect
         # reference to the process object (see bpo-30775)

--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -112,7 +112,7 @@ class Queue(object):
             finally:
                 self._rlock.release()
         # unserialize the data after having released the lock
-        return context.reduction.ForkingPickler.loads(res)
+        return context.reduction.loads(res)
 
     def qsize(self):
         # Raises NotImplementedError on Mac OSX because of broken sem_getvalue()
@@ -235,7 +235,7 @@ class Queue(object):
                             return
 
                         # serialize the data before acquiring the lock
-                        obj = context.reduction.ForkingPickler.dumps(obj)
+                        obj = context.reduction.dumps(obj)
                         if wacquire is None:
                             send_bytes(obj)
                         else:
@@ -354,11 +354,11 @@ class SimpleQueue(object):
         with self._rlock:
             res = self._reader.recv_bytes()
         # unserialize the data after having released the lock
-        return context.reduction.ForkingPickler.loads(res)
+        return context.reduction.loads(res)
 
     def put(self, obj):
         # serialize the data before acquiring the lock
-        obj = context.reduction.ForkingPickler.dumps(obj)
+        obj = context.reduction.dumps(obj)
         if self._wlock is None:
             # writes to a message oriented win32 pipe are atomic
             self._writer.send_bytes(obj)

--- a/Lib/multiprocessing/queues.py
+++ b/Lib/multiprocessing/queues.py
@@ -23,7 +23,6 @@ import _multiprocessing
 
 from . import connection
 from . import context
-_ForkingPickler = context.reduction.ForkingPickler
 
 from .util import debug, info, Finalize, register_after_fork, is_exiting
 
@@ -113,7 +112,7 @@ class Queue(object):
             finally:
                 self._rlock.release()
         # unserialize the data after having released the lock
-        return _ForkingPickler.loads(res)
+        return context.reduction.ForkingPickler.loads(res)
 
     def qsize(self):
         # Raises NotImplementedError on Mac OSX because of broken sem_getvalue()
@@ -236,7 +235,7 @@ class Queue(object):
                             return
 
                         # serialize the data before acquiring the lock
-                        obj = _ForkingPickler.dumps(obj)
+                        obj = context.reduction.ForkingPickler.dumps(obj)
                         if wacquire is None:
                             send_bytes(obj)
                         else:
@@ -355,11 +354,11 @@ class SimpleQueue(object):
         with self._rlock:
             res = self._reader.recv_bytes()
         # unserialize the data after having released the lock
-        return _ForkingPickler.loads(res)
+        return context.reduction.ForkingPickler.loads(res)
 
     def put(self, obj):
         # serialize the data before acquiring the lock
-        obj = _ForkingPickler.dumps(obj)
+        obj = context.reduction.ForkingPickler.dumps(obj)
         if self._wlock is None:
             # writes to a message oriented win32 pipe are atomic
             self._writer.send_bytes(obj)

--- a/Lib/multiprocessing/reduction.py
+++ b/Lib/multiprocessing/reduction.py
@@ -7,7 +7,7 @@
 # Licensed to PSF under a Contributor Agreement.
 #
 
-from abc import ABCMeta
+import abc
 import copyreg
 import functools
 import io
@@ -53,11 +53,25 @@ class ForkingPickler(pickle.Pickler):
 
     loads = pickle.loads
 
-register = ForkingPickler.register
+
+
+def register(type_, reduce_):
+    return ForkingPickler.register(type_, reduce_)
+
 
 def dump(obj, file, protocol=None):
     '''Replacement for pickle.dump() using ForkingPickler.'''
     ForkingPickler(file, protocol).dump(obj)
+
+
+def dumps(obj, protocol=None):
+    return ForkingPickler.dumps(obj, protocol=protocol)
+
+
+def loads(s, *, fix_imports=True, encoding="ASCII", errors="strict"):
+    return ForkingPickler.loads(s, fix_imports=fix_imports,
+                                   encoding=encoding, errors=errors)
+
 
 #
 # Platform specific definitions
@@ -248,30 +262,27 @@ else:
     register(socket.socket, _reduce_socket)
 
 
-class AbstractReducer(metaclass=ABCMeta):
+class AbstractReducer(metaclass=abc.ABCMeta):
     '''Abstract base class for use in implementing a Reduction class
     suitable for use in replacing the standard reduction mechanism
     used in multiprocessing.'''
-    ForkingPickler = ForkingPickler
-    register = register
-    dump = dump
     send_handle = send_handle
     recv_handle = recv_handle
 
     if sys.platform == 'win32':
-        steal_handle = steal_handle
-        duplicate = duplicate
+        steal_handle = staticmethod(steal_handle)
+        duplicate = staticmethod(duplicate)
         DupHandle = DupHandle
     else:
-        sendfds = sendfds
-        recvfds = recvfds
-        DupFd = DupFd
+        sendfds = staticmethod(sendfds)
+        recvfds = staticmethod(recvfds)
+        DupFd = staticmethod(DupFd)
 
-    _reduce_method = _reduce_method
-    _reduce_method_descriptor = _reduce_method_descriptor
-    _rebuild_partial = _rebuild_partial
-    _reduce_socket = _reduce_socket
-    _rebuild_socket = _rebuild_socket
+    _reduce_method = staticmethod(_reduce_method)
+    _reduce_method_descriptor = staticmethod(_reduce_method_descriptor)
+    _rebuild_partial = staticmethod(_rebuild_partial)
+    _reduce_socket = staticmethod(_reduce_socket)
+    _rebuild_socket = staticmethod(_rebuild_socket)
 
     def __init__(self, *args):
         register(type(_C().f), _reduce_method)
@@ -279,3 +290,28 @@ class AbstractReducer(metaclass=ABCMeta):
         register(type(int.__add__), _reduce_method_descriptor)
         register(functools.partial, _reduce_partial)
         register(socket.socket, _reduce_socket)
+
+    @property
+    def HAVE_SEND_HANDLE(self):
+        import sys
+        return (sys.platform == 'win32' or
+                (hasattr(socket, 'CMSG_LEN') and
+                 hasattr(socket, 'SCM_RIGHTS') and
+                 hasattr(socket.socket, 'sendmsg')))
+
+    @abc.abstractmethod
+    def get_pickler_class(self):
+        pass
+
+    def register(self, type_, reduce_):
+        return self.get_pickler_class().register(type_, reduce_)
+
+    def dump(self, obj, file, protocol=None):
+        self.get_pickler_class()(file, protocol).dump(obj)
+
+    def dumps(self, obj, protocol=None):
+        return self.get_pickler_class().dumps(obj, protocol=protocol)
+
+    def loads(self, s, *, fix_imports=True, encoding="ASCII", errors="strict"):
+        return self.get_pickler_class().loads(s, fix_imports=fix_imports,
+                                              encoding=encoding, errors=errors)

--- a/Lib/multiprocessing/reduction.py
+++ b/Lib/multiprocessing/reduction.py
@@ -54,7 +54,6 @@ class ForkingPickler(pickle.Pickler):
     loads = pickle.loads
 
 
-
 def register(type_, reduce_):
     return ForkingPickler.register(type_, reduce_)
 

--- a/Lib/multiprocessing/reduction.py
+++ b/Lib/multiprocessing/reduction.py
@@ -300,18 +300,18 @@ class AbstractReducer(metaclass=abc.ABCMeta):
                  hasattr(socket.socket, 'sendmsg')))
 
     @abc.abstractmethod
-    def get_pickler_class(self):
+    def get_pickler(self):
         pass
 
     def register(self, type_, reduce_):
-        return self.get_pickler_class().register(type_, reduce_)
+        return self.get_pickler().register(type_, reduce_)
 
     def dump(self, obj, file, protocol=None):
-        self.get_pickler_class()(file, protocol).dump(obj)
+        self.get_pickler()(file, protocol).dump(obj)
 
     def dumps(self, obj, protocol=None):
-        return self.get_pickler_class().dumps(obj, protocol=protocol)
+        return self.get_pickler().dumps(obj, protocol=protocol)
 
     def loads(self, s, *, fix_imports=True, encoding="ASCII", errors="strict"):
-        return self.get_pickler_class().loads(s, fix_imports=fix_imports,
+        return self.get_pickler().loads(s, fix_imports=fix_imports,
                                               encoding=encoding, errors=errors)

--- a/Lib/multiprocessing/reduction.py
+++ b/Lib/multiprocessing/reduction.py
@@ -299,18 +299,18 @@ class AbstractReducer(metaclass=abc.ABCMeta):
                  hasattr(socket.socket, 'sendmsg')))
 
     @abc.abstractmethod
-    def get_pickler(self):
+    def get_pickler_class(self):
         pass
 
     def register(self, type_, reduce_):
-        return self.get_pickler().register(type_, reduce_)
+        return self.get_pickler_class().register(type_, reduce_)
 
     def dump(self, obj, file, protocol=None):
-        self.get_pickler()(file, protocol).dump(obj)
+        self.get_pickler_class()(file, protocol).dump(obj)
 
     def dumps(self, obj, protocol=None):
-        return self.get_pickler().dumps(obj, protocol=protocol)
+        return self.get_pickler_class().dumps(obj, protocol=protocol)
 
     def loads(self, s, *, fix_imports=True, encoding="ASCII", errors="strict"):
-        return self.get_pickler().loads(s, fix_imports=fix_imports,
+        return self.get_pickler_class().loads(s, fix_imports=fix_imports,
                                               encoding=encoding, errors=errors)

--- a/Lib/multiprocessing/reduction.py
+++ b/Lib/multiprocessing/reduction.py
@@ -51,7 +51,15 @@ class ForkingPickler(pickle.Pickler):
         cls(buf, protocol).dump(obj)
         return buf.getbuffer()
 
-    loads = pickle.loads
+    @classmethod
+    def loads(cls, bytes_object, *, fix_imports=True,
+                   encoding="ASCII", errors="strict"):
+        return pickle.loads(bytes_object, fix_imports=fix_imports,
+                            encoding=encoding, errors=errors)
+
+
+class AbstractPickler(ForkingPickler):
+    pass
 
 
 def register(type_, reduce_):

--- a/Lib/multiprocessing/resource_sharer.py
+++ b/Lib/multiprocessing/resource_sharer.py
@@ -15,7 +15,7 @@ import sys
 import threading
 
 from . import process
-from .context import reduction
+from . import context
 from . import util
 
 __all__ = ['stop']
@@ -47,7 +47,7 @@ else:
         def __init__(self, fd):
             new_fd = os.dup(fd)
             def send(conn, pid):
-                reduction.send_handle(conn, new_fd, pid)
+                context.reduction.send_handle(conn, new_fd, pid)
             def close():
                 os.close(new_fd)
             self._id = _resource_sharer.register(send, close)
@@ -55,7 +55,7 @@ else:
         def detach(self):
             '''Get the fd.  This should only be called once.'''
             with _resource_sharer.get_connection(self._id) as conn:
-                return reduction.recv_handle(conn)
+                return context.reduction.recv_handle(conn)
 
 
 class _ResourceSharer(object):

--- a/Lib/multiprocessing/spawn.py
+++ b/Lib/multiprocessing/spawn.py
@@ -104,12 +104,8 @@ def spawn_main(pipe_handle, parent_pid=None, tracker_fd=None):
                 False, parent_pid)
         else:
             source_process = None
-        try:
-            new_handle = context.reduction.duplicate(pipe_handle,
-                                             source_process=source_process)
-        finally:
-            if source_process is not None:
-                _winapi.CloseHandle(source_process)
+        new_handle = context.reduction.duplicate(pipe_handle,
+                                                 source_process=source_process)
         fd = msvcrt.open_osfhandle(new_handle, os.O_RDONLY)
         parent_sentinel = source_process
     else:

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5429,11 +5429,9 @@ class SpyReducer(reduction.AbstractReducer):
     play good with pickling"""
     def __init__(self, spy):
         self.spy = spy
-    def get_pickler(self):
+    def get_pickler_class(self):
         spy = self.spy
-        class Pickler(pickle.Pickler):
-            def __init__(self):
-                pass
+        class Pickler(multiprocessing.reduction.ForkingPickler):
             @classmethod
             def dumps(self, obj, protocol=None):
                 spy["dumps"] += 1
@@ -5442,7 +5440,7 @@ class SpyReducer(reduction.AbstractReducer):
             def loads(self, *args, **kwargs):
                 spy["loads"] += 1
                 return pickle.loads(*args, **kwargs)
-        return Pickler()
+        return Pickler
 
 class _TestCustomReducer(BaseTestCase):
     """Test case for the global reducer"""

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5431,13 +5431,12 @@ class SpyReducer(reduction.AbstractReducer):
         self.spy = spy
     def get_pickler_class(self):
         spy = self.spy
-        class Pickler(multiprocessing.reduction.ForkingPickler):
+        class Pickler(multiprocessing.reduction.AbstractPickler):
+            def dump(self, obj, protocol=None):
+                spy["dump"] += 1
+                super().dump(obj)
             @classmethod
-            def dumps(self, obj, protocol=None):
-                spy["dumps"] += 1
-                return pickle.dumps(obj)
-            @classmethod
-            def loads(self, *args, **kwargs):
+            def loads(cls, *args, **kwargs):
                 spy["loads"] += 1
                 return pickle.loads(*args, **kwargs)
         return Pickler
@@ -5450,7 +5449,7 @@ class _TestCustomReducer(BaseTestCase):
     def setUp(self):
         self.context = multiprocessing.get_context()
         self.original_reducer = multiprocessing.get_reducer()
-        self.spy = {'loads': 0, 'dumps': 0}
+        self.spy = {'loads': 0, 'dump': 0}
         self.context.set_reducer(SpyReducer(self.spy))
 
     def tearDown(self):
@@ -5469,7 +5468,7 @@ class _TestCustomReducer(BaseTestCase):
             self.assertRaises(OSError, l.accept)
 
         self.assertEqual(self.spy['loads'], 1)
-        self.assertEqual(self.spy['dumps'], 1)
+        self.assertEqual(self.spy['dump'], 1)
 
     @classmethod
     def _put_and_get_in_queue(cls, queue, parent_can_continue):
@@ -5496,7 +5495,7 @@ class _TestCustomReducer(BaseTestCase):
         p.terminate()
         self.assertEqual(element, "Something")
         self.assertEqual(self.spy['loads'], 1)
-        self.assertEqual(self.spy['dumps'], 1)
+        self.assertEqual(self.spy['dump'], 3)
         self.assertEqual(p.exitcode, 0)
 
     @unittest.skipUnless(HAS_REDUCTION, "test needs multiprocessing.reduction")
@@ -5511,7 +5510,7 @@ class _TestCustomReducer(BaseTestCase):
             self.assertRaises(OSError, l.accept)
 
         self.assertEqual(self.spy['loads'], 1)
-        self.assertEqual(self.spy['dumps'], 1)
+        self.assertEqual(self.spy['dump'], 1)
 
 class CustomContext(multiprocessing.context.BaseContext):
     _name = "custom"
@@ -5528,8 +5527,8 @@ class _TestCustomReducerWithContext(BaseTestCase):
         self.default_ctx = multiprocessing.get_context()
         self.original_custom_reducer = self.custom_ctx.get_reducer()
         self.original_default_reducer = self.default_ctx.get_reducer()
-        self.default_spy = {'loads': 0, 'dumps': 0}
-        self.custom_spy = {'loads': 0, 'dumps': 0}
+        self.default_spy = {'loads': 0, 'dump': 0}
+        self.custom_spy = {'loads': 0, 'dump': 0}
 
     def tearDown(self):
         self.custom_ctx.set_reducer(self.original_custom_reducer)
@@ -5563,9 +5562,9 @@ class _TestCustomReducerWithContext(BaseTestCase):
         p.terminate()
         self.assertEqual(element, "Something")
         self.assertEqual(self.custom_spy['loads'], 1)
-        self.assertEqual(self.custom_spy['dumps'], 1)
+        self.assertEqual(self.custom_spy['dump'], 1)
         self.assertEqual(self.default_spy['loads'], 0)
-        self.assertEqual(self.default_spy['dumps'], 0)
+        self.assertEqual(self.default_spy['dump'], 0)
         self.assertEqual(p.exitcode, 0)
 
     @unittest.skipUnless(HAS_REDUCTION, "test needs multiprocessing.reduction")
@@ -5583,9 +5582,9 @@ class _TestCustomReducerWithContext(BaseTestCase):
             self.assertRaises(OSError, l.accept)
 
         self.assertEqual(self.custom_spy['loads'], 1)
-        self.assertEqual(self.custom_spy['dumps'], 1)
+        self.assertEqual(self.custom_spy['dump'], 1)
         self.assertEqual(self.default_spy['loads'], 0)
-        self.assertEqual(self.default_spy['dumps'], 0)
+        self.assertEqual(self.default_spy['dump'], 0)
 
 
     @unittest.skipUnless(HAS_REDUCTION, "test needs multiprocessing.reduction")
@@ -5607,9 +5606,9 @@ class _TestCustomReducerWithContext(BaseTestCase):
         self.assertEqual(p.exitcode, 0)
         self.assertEqual(element, "Something")
         self.assertEqual(self.custom_spy['loads'], 0)
-        self.assertEqual(self.custom_spy['dumps'], 0)
+        self.assertEqual(self.custom_spy['dump'], 0)
         self.assertEqual(self.default_spy['loads'], 1)
-        self.assertEqual(self.default_spy['dumps'], 1)
+        self.assertEqual(self.default_spy['dump'], 3)
         close_queue(queue)
 
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5445,6 +5445,7 @@ class SpyReducer(reduction.AbstractReducer):
         return Pickler()
 
 class _TestCustomReducer(BaseTestCase):
+    """Test case for the global reducer"""
 
     ALLOWED_TYPES = ('processes',)
 
@@ -5504,6 +5505,7 @@ class CustomContext(multiprocessing.context.BaseContext):
 
 
 class _TestCustomReducerWithContext(BaseTestCase):
+    """Test case for per-context reducers"""
 
     ALLOWED_TYPES = ('processes',)
 

--- a/Lib/test/_test_multiprocessing.py
+++ b/Lib/test/_test_multiprocessing.py
@@ -5541,7 +5541,7 @@ class _TestCustomReducerWithContext(BaseTestCase):
 
         queue = self.custom_ctx.Queue()
         p = self.custom_ctx.Process(target=self._put_and_get_in_queue,
-            args=(queue,))
+            args=(queue,), ctx=self.custom_ctx)
         p.start()
         element = queue.get(timeout=TIMEOUT)
         self.assertEqual(element, "Something")

--- a/Misc/NEWS.d/next/Library/2018-12-09-19-20-12.bpo-28053.JiOeSY.rst
+++ b/Misc/NEWS.d/next/Library/2018-12-09-19-20-12.bpo-28053.JiOeSY.rst
@@ -1,0 +1,1 @@
+Fix the implementation of custom reducers for in `multiprocessing`.


### PR DESCRIPTION
This PR tries to complete and fix the implementation of the custom reducer classes in `multiprocessing`. 

**Important**

I have marked the PR as `DO-NOT-MERGE` because I have still several doubts about the previous implemented API, regarding the `AbstractReducer` base class and the methods that the user needs to implement and how the rest of the library interacts with `multiprocessing.reducer`. For example:

1. I am not sure `multiprocessing.reducer.dumps` and `multiprocessing.reducer.register` are needed outside the `ForklingPickler` class and how that interacts with the ABC.

2. I am not sure the `AbstractReducer` is implemented completely (there is no abstract methods marked).

This PR is a **draft** implementation of the complete API, tests and documentation so we can discuss how to implement these correctly in a better way. 

<!-- issue-number: [bpo-28053](https://bugs.python.org/issue28053) -->
https://bugs.python.org/issue28053
<!-- /issue-number -->
