### PR TITLE
bpo-35022: Add `__fspath__` support to `unittest.mock.MagicMock`

### DIFF
--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1701,6 +1701,9 @@ The full list of supported magic methods is:
   ``__getnewargs__``, ``__getstate__`` and ``__setstate__``
 * File system path representation: ``__fspath__``
 
+.. versionchanged:: 3.8
+   Added support for :func:`os.PathLike.__fspath__`.
+
 
 The following methods exist but are *not* supported as they are either in use
 by mock, can't be set dynamically, or can cause problems:

--- a/Doc/library/unittest.mock.rst
+++ b/Doc/library/unittest.mock.rst
@@ -1699,6 +1699,7 @@ The full list of supported magic methods is:
 * Descriptor methods: ``__get__``, ``__set__`` and ``__delete__``
 * Pickling: ``__reduce__``, ``__reduce_ex__``, ``__getinitargs__``,
   ``__getnewargs__``, ``__getstate__`` and ``__setstate__``
+* File system path representation: ``__fspath__``
 
 
 The following methods exist but are *not* supported as they are either in use

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1761,7 +1761,7 @@ _calculate_return_value = {
     '__hash__': lambda self: object.__hash__(self),
     '__str__': lambda self: object.__str__(self),
     '__sizeof__': lambda self: object.__sizeof__(self),
-    '__fspath__': lambda self: "%s/%s" % (type(self).__name__, id(self))
+    '__fspath__': lambda self: f"{type(self).__name__}/{self._extract_mock_name()}/{id(self)}",
 }
 
 _return_values = {

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1713,6 +1713,7 @@ magic_methods = (
     "complex int float index "
     "round trunc floor ceil "
     "bool next "
+    "fspath "
 )
 
 numerics = (
@@ -1760,6 +1761,7 @@ _calculate_return_value = {
     '__hash__': lambda self: object.__hash__(self),
     '__str__': lambda self: object.__str__(self),
     '__sizeof__': lambda self: object.__sizeof__(self),
+    '__fspath__': lambda self: "%s/%s" % (type(self).__name__, id(self))
 }
 
 _return_values = {

--- a/Lib/unittest/test/testmock/testmagicmethods.py
+++ b/Lib/unittest/test/testmock/testmagicmethods.py
@@ -1,5 +1,6 @@
 import math
 import unittest
+import os
 import sys
 from unittest.mock import Mock, MagicMock, _magics
 
@@ -291,6 +292,11 @@ class TestMockingMagicMethods(unittest.TestCase):
         self.assertEqual(oct(mock), '0o1')
         self.assertEqual(hex(mock), '0x1')
         # how to test __sizeof__ ?
+
+
+    def test_magic_methods_fspath(self):
+        mock = MagicMock()
+        self.assertEqual(os.fspath(mock), mock.__fspath__())
 
 
     def test_magic_methods_and_spec(self):

--- a/Lib/unittest/test/testmock/testmagicmethods.py
+++ b/Lib/unittest/test/testmock/testmagicmethods.py
@@ -296,7 +296,11 @@ class TestMockingMagicMethods(unittest.TestCase):
 
     def test_magic_methods_fspath(self):
         mock = MagicMock()
-        self.assertEqual(os.fspath(mock), mock.__fspath__())
+        expected_path = mock.__fspath__()
+        mock.reset_mock()
+
+        self.assertEqual(os.fspath(mock), expected_path)
+        mock.__fspath__.assert_called_once()
 
 
     def test_magic_methods_and_spec(self):

--- a/Misc/NEWS.d/next/Library/2018-10-18-17-57-28.bpo-35022.KeEF4T.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-18-17-57-28.bpo-35022.KeEF4T.rst
@@ -1,0 +1,2 @@
+:class:`unittest.mock.MagicMock` now supports the ``__fspath__`` method
+(from :class:`os.PathLike`).


### PR DESCRIPTION
This is a naive implementation of what has been working for us internally. 

<!-- issue-number: [bpo-35022](https://bugs.python.org/issue35022) -->
https://bugs.python.org/issue35022
<!-- /issue-number -->
