### PR TITLE
[2.7] bpo-34936: Fix TclError in tkinter.Spinbox.selection_element(). (GH-9760) (GH-9957)

### DIFF
--- a/Lib/lib-tk/Tkinter.py
+++ b/Lib/lib-tk/Tkinter.py
@@ -3582,7 +3582,7 @@ class Spinbox(Widget, XView):
         select to commands. If the selection isn't currently in
         the spinbox, then a new selection is created to include
         the characters between index and the most recent selection
-        anchor point, inclusive. Returns an empty string.
+        anchor point, inclusive.
         """
         return self.selection("adjust", index)
 
@@ -3590,7 +3590,7 @@ class Spinbox(Widget, XView):
         """Clear the selection
 
         If the selection isn't in this widget then the
-        command has no effect. Returns an empty string.
+        command has no effect.
         """
         return self.selection("clear")
 
@@ -3598,9 +3598,9 @@ class Spinbox(Widget, XView):
         """Sets or gets the currently selected element.
 
         If a spinbutton element is specified, it will be
-        displayed depressed
+        displayed depressed.
         """
-        return self.selection("element", element)
+        return self.tk.call(self._w, 'selection', 'element', element)
 
 ###########################################################################
 

--- a/Lib/lib-tk/test/test_tkinter/test_widgets.py
+++ b/Lib/lib-tk/test/test_tkinter/test_widgets.py
@@ -471,6 +471,14 @@ class SpinboxTest(EntryTest, unittest.TestCase):
         self.assertRaises(TypeError, widget.bbox)
         self.assertRaises(TypeError, widget.bbox, 0, 1)
 
+    def test_selection_element(self):
+        widget = self.create()
+        self.assertEqual(widget.selection_element(), "none")
+        widget.selection_element("buttonup")
+        self.assertEqual(widget.selection_element(), "buttonup")
+        widget.selection_element("buttondown")
+        self.assertEqual(widget.selection_element(), "buttondown")
+
 
 @add_standard_options(StandardOptionsTests)
 class TextTest(AbstractWidgetTest, unittest.TestCase):

--- a/Misc/NEWS.d/next/Library/2018-10-08-21-05-11.bpo-34936.3tRqdq.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-08-21-05-11.bpo-34936.3tRqdq.rst
@@ -1,0 +1,2 @@
+Fix ``TclError`` in ``tkinter.Spinbox.selection_element()``. Patch by
+Juliette Monsel.


### PR DESCRIPTION
(cherry picked from commit 1deea5e53991b46351f6bb395b22365c9455ed88).
(cherry picked from commit bd9c2ce7acaef45f23c2659b854fc9925096d040)

Co-authored-by: Juliette Monsel <j4321@users.noreply.github.com>


<!-- issue-number: [bpo-34936](https://bugs.python.org/issue34936) -->
https://bugs.python.org/issue34936
<!-- /issue-number -->
