### PR TITLE
[3.7] bpo-34536: raise error for invalid _missing_ results (GH-9147)

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-09-11-15-49-09.bpo-34536.3IPIH5.rst
+++ b/Misc/NEWS.d/next/Library/2018-09-11-15-49-09.bpo-34536.3IPIH5.rst
@@ -1,0 +1,2 @@
+`Enum._missing_`:  raise `ValueError` if None returned and `TypeError` if
+non-member is returned.


### PR DESCRIPTION
* raise exception if _missing_ returns None or invalid type

(cherry picked from commit 019f0a0cb85ebc234356415f3638b9bd77528e55)

<!-- issue-number: [bpo-34536](https://bugs.python.org/issue34536) -->
https://bugs.python.org/issue34536
<!-- /issue-number -->
