### PR TITLE
bpo-34536: Cleanup test_enum imports

### DIFF
--- a/Lib/test/test_enum.py
+++ b/Lib/test/test_enum.py
@@ -3,7 +3,6 @@ import inspect
 import pydoc
 import sys
 import unittest
-import sys
 import threading
 from collections import OrderedDict
 from enum import Enum, IntEnum, EnumMeta, Flag, IntFlag, unique, auto
@@ -12,10 +11,6 @@ from pickle import dumps, loads, PicklingError, HIGHEST_PROTOCOL
 from test import support
 from datetime import timedelta
 
-try:
-    import threading
-except ImportError:
-    threading = None
 
 # for pickle tests
 try:


### PR DESCRIPTION
sys and threading were imported twice.

<!-- issue-number: [bpo-34536](https://bugs.python.org/issue34536) -->
https://bugs.python.org/issue34536
<!-- /issue-number -->
