### PR TITLE
bpo-27741: Better wording for datetime.strptime()

### DIFF
--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2013,8 +2013,9 @@ although not all objects support a :meth:`timetuple` method.
 Conversely, the :meth:`datetime.strptime` class method creates a
 :class:`.datetime` object from a string representing a date and time and a
 corresponding format string. ``datetime.strptime(date_string, format)`` is
-similar to ``datetime(*(time.strptime(date_string, format)[0:6]))``, however,
-``datetime.strptime()`` also retains both microseconds and timezone data.
+equivalent to ``datetime(*(time.strptime(date_string, format)[0:6]))``, except
+when the format includes sub-second components or timezone offset information,
+which are supported in ``datetime.strptime`` but not ``time.strptime``.
 
 For :class:`.time` objects, the format codes for year, month, and day should not
 be used, as time objects have no such values.  If they're used anyway, ``1900``

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2013,7 +2013,8 @@ although not all objects support a :meth:`timetuple` method.
 Conversely, the :meth:`datetime.strptime` class method creates a
 :class:`.datetime` object from a string representing a date and time and a
 corresponding format string. ``datetime.strptime(date_string, format)`` is
-equivalent to ``datetime(*(time.strptime(date_string, format)[0:6]))``.
+similar to ``datetime(*(time.strptime(date_string, format)[0:6]))``, however,
+``datetime.strptime()`` also retains both microseconds and timezone data.
 
 For :class:`.time` objects, the format codes for year, month, and day should not
 be used, as time objects have no such values.  If they're used anyway, ``1900``

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2015,8 +2015,7 @@ Conversely, the :meth:`datetime.strptime` class method creates a
 corresponding format string. ``datetime.strptime(date_string, format)`` is
 equivalent to ``datetime(*(time.strptime(date_string, format)[0:6]))``, except
 when the format includes sub-second components or timezone offset information,
-which are supported in ``datetime.strptime`` but are discarded by ``time.strptime``,
-since ``time.strptime`` won't fail; however, it will silently ignore such input.
+which are supported in ``datetime.strptime`` but are discarded by ``time.strptime``.
 
 For :class:`.time` objects, the format codes for year, month, and day should not
 be used, as time objects have no such values.  If they're used anyway, ``1900``

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -2015,7 +2015,8 @@ Conversely, the :meth:`datetime.strptime` class method creates a
 corresponding format string. ``datetime.strptime(date_string, format)`` is
 equivalent to ``datetime(*(time.strptime(date_string, format)[0:6]))``, except
 when the format includes sub-second components or timezone offset information,
-which are supported in ``datetime.strptime`` but not ``time.strptime``.
+which are supported in ``datetime.strptime`` but are discarded by ``time.strptime``,
+since ``time.strptime`` won't fail; however, it will silently ignore such input.
 
 For :class:`.time` objects, the format codes for year, month, and day should not
 be used, as time objects have no such values.  If they're used anyway, ``1900``


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-27741](https://bugs.python.org/issue27741) -->
https://bugs.python.org/issue27741
<!-- /issue-number -->
