### PR TITLE
bpo-35029: Replace the SyntaxWarning exception with a SyntaxError.

### DIFF
--- a/Lib/test/test_grammar.py
+++ b/Lib/test/test_grammar.py
@@ -5,6 +5,7 @@ from test.support import check_syntax_error
 import inspect
 import unittest
 import sys
+import warnings
 # testing import *
 from sys import *
 
@@ -1098,6 +1099,14 @@ class GrammarTests(unittest.TestCase):
             self.assertEqual(len(e.args), 0)
         else:
             self.fail("AssertionError not raised by 'assert False'")
+
+        with self.assertWarnsRegex(SyntaxWarning, 'assertion is always true'):
+            compile('assert(x, "msg")', '<testcase>', 'exec')
+        with warnings.catch_warnings():
+            warnings.filterwarnings('error', category=SyntaxWarning)
+            with self.assertRaisesRegex(SyntaxError, 'assertion is always true'):
+                compile('assert(x, "msg")', '<testcase>', 'exec')
+            compile('assert x, "msg"', '<testcase>', 'exec')
 
 
     ### compound_stmt: if_stmt | while_stmt | for_stmt | try_stmt | funcdef | classdef

--- a/Misc/NEWS.d/next/Core and Builtins/2018-10-20-10-26-15.bpo-35029.t4tZcQ.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-10-20-10-26-15.bpo-35029.t4tZcQ.rst
@@ -1,0 +1,2 @@
+:exc:`SyntaxWarning` raised as an exception at code generation time will be
+now replaced with a :exc:`SyntaxError` for better error reporting.


### PR DESCRIPTION
If SyntaxWarning was raised as an exception, it will be replaced
with a SyntaxError for better error reporting.


<!-- issue-number: [bpo-35029](https://bugs.python.org/issue35029) -->
https://bugs.python.org/issue35029
<!-- /issue-number -->
