### PR TITLE
[2.7] bpo-35030 backport python 3 weakref implementation for OrderedDict

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-10-20-13-10-17.bpo-35030.1P5HWp.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-20-13-10-17.bpo-35030.1P5HWp.rst
@@ -1,0 +1,2 @@
+collections.OrderedDict had a circular reference issue which was fixed by
+backporting from python 3 to use weakref


### PR DESCRIPTION
While this seems to fix the issue, it would be nice to have another set of eyes on it.

Especially, pop and popitem were not backported (since the implementation seems to be different, but I might be wrong).

Also would be nice if there was some sort of testing framework like numpy has for detecting leaks like this:
https://github.com/requests/requests/issues/4553#issuecomment-431514753




<!-- issue-number: [bpo-35030](https://bugs.python.org/issue35030) -->
https://bugs.python.org/issue35030
<!-- /issue-number -->
