### PR TITLE
bpo-35034: Add closing and iteration to threading.Queue

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -170,7 +170,7 @@ post-handshake authentication.
 threading
 ---------
 
-Queue now supports closing and iteration.
+queue.Queue now supports closing and iteration.
 
 tkinter
 -------

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -167,6 +167,11 @@ Added :attr:`SSLContext.post_handshake_auth` to enable and
 post-handshake authentication.
 (Contributed by Christian Heimes in :issue:`34670`.)
 
+threading
+---------
+
+Queue now supports closing and iteration.
+
 tkinter
 -------
 

--- a/Lib/multiprocessing/dummy/connection.py
+++ b/Lib/multiprocessing/dummy/connection.py
@@ -61,8 +61,8 @@ class Connection(object):
             return True
         if timeout <= 0.0:
             return False
-        with self._in.not_empty:
-            self._in.not_empty.wait(timeout)
+        with self._in.exhausted_or_non_empty:
+            self._in.exhausted_or_non_empty.wait(timeout)
         return self._in.qsize() > 0
 
     def close(self):

--- a/Lib/queue.py
+++ b/Lib/queue.py
@@ -9,7 +9,8 @@ try:
 except ImportError:
     SimpleQueue = None
 
-__all__ = ['Empty', 'Full', 'Queue', 'PriorityQueue', 'LifoQueue', 'SimpleQueue']
+__all__ = ['Empty', 'Full', 'Closed', 'Exhausted',
+           'Queue', 'PriorityQueue', 'LifoQueue', 'SimpleQueue']
 
 
 try:
@@ -19,10 +20,17 @@ except AttributeError:
         'Exception raised by Queue.get(block=0)/get_nowait().'
         pass
 
+class Exhausted(Empty):
+    'Exception raised by Queue.get/get_nowait().'
+    pass
+
 class Full(Exception):
     'Exception raised by Queue.put(block=0)/put_nowait().'
     pass
 
+class Closed(Full):
+    'Exception raised by Queue.put/put_nowait().'
+    pass
 
 class Queue:
     '''Create a queue object with a given maximum size.
@@ -38,15 +46,20 @@ class Queue:
         # that acquire mutex must release it before returning.  mutex
         # is shared between the three conditions, so acquiring and
         # releasing the conditions also acquires and releases mutex.
-        self.mutex = threading.Lock()
+        self.mutex = threading.RLock()
 
-        # Notify not_empty whenever an item is added to the queue; a
-        # thread waiting to get is notified then.
-        self.not_empty = threading.Condition(self.mutex)
+        # Event waited upon by threads trying to get. Notify one thread
+        # when an item is added to the queue; notify all when the queue is
+        # exhausted (and thus no get operations can ever succeed anymore).
+        self.exhausted_or_non_empty = threading.Condition(self.mutex)
 
-        # Notify not_full whenever an item is removed from the queue;
-        # a thread waiting to put is notified then.
-        self.not_full = threading.Condition(self.mutex)
+        # Event waited upon by threads trying to put. Notify one thread
+        # when an item is removed from the queue; notify all when the
+        # queue is closed (and thus no put operations can ever succeed
+        # anymore).
+        self.closed_or_non_full = threading.Condition(self.mutex)
+
+        self._closed = False
 
         # Notify all_tasks_done whenever the number of unfinished tasks
         # drops to zero; thread waiting to join() is notified to resume
@@ -98,8 +111,8 @@ class Queue:
 
         This method is likely to be removed at some point.  Use qsize() == 0
         as a direct substitute, but be aware that either approach risks a race
-        condition where a queue can grow before the result of empty() or
-        qsize() can be used.
+        condition where a queue can change from empty to non-empty or vice
+        versa before the result of empty() or qsize() can be used.
 
         To create code that needs to wait for all queued tasks to be
         completed, the preferred technique is to use the join() method.
@@ -107,36 +120,58 @@ class Queue:
         with self.mutex:
             return not self._qsize()
 
+    def closed(self):
+        with self.mutex:
+            return self._closed
+
+    def exhausted(self):
+        with self.mutex:
+            return self._closed and not self._qsize()
+
     def full(self):
         '''Return True if the queue is full, False otherwise (not reliable!).
 
-        This method is likely to be removed at some point.  Use qsize() >= n
-        as a direct substitute, but be aware that either approach risks a race
-        condition where a queue can shrink before the result of full() or
-        qsize() can be used.
+        A queue is considered full if, at the moment of the call, it has no
+        free slots that could accept a new item. Therefore, closed queues are
+        always full, and it is possible for a closed queue to be
+        simultaneously empty and full.
+
+        As with empty() and qsize(), a race condition is possible where a
+        queue's state can change from full to non-full or vice versa before
+        the result of full() can be used.
         '''
         with self.mutex:
-            return 0 < self.maxsize <= self._qsize()
+            return self._closed or 0 < self.maxsize <= self._qsize()
 
     def put(self, item, block=True, timeout=None):
         '''Put an item into the queue.
 
         If optional args 'block' is true and 'timeout' is None (the default),
-        block if necessary until a free slot is available. If 'timeout' is
-        a non-negative number, it blocks at most 'timeout' seconds and raises
-        the Full exception if no free slot was available within that time.
-        Otherwise ('block' is false), put an item on the queue if a free slot
-        is immediately available, else raise the Full exception ('timeout'
-        is ignored in that case).
+        block if necessary until a free slot is available or the queue is
+        closed; in the latter case, raise a :exc:`Closed` exception.
+
+        If 'block' is true and 'timeout' is a positive number, block at most
+        'timeout' seconds and raise the Full exception if no free slot
+        becomes available within that time, or the Closed exception if the
+        queue gets closed before any slots are available.
+
+        If 'block' is false, ignore 'timeout' and put an item on the
+        queue if a free slot is immediately available, else raise the Full or
+        Closed exception, depending on whether the queue is closed.
+        (Note that Closed is a subclass of Full.)
         '''
-        with self.not_full:
+        with self.closed_or_non_full:
+            if self._closed:
+                raise Closed
             if self.maxsize > 0:
                 if not block:
                     if self._qsize() >= self.maxsize:
                         raise Full
                 elif timeout is None:
                     while self._qsize() >= self.maxsize:
-                        self.not_full.wait()
+                        self.closed_or_non_full.wait()
+                        if self._closed:
+                            raise Closed
                 elif timeout < 0:
                     raise ValueError("'timeout' must be a non-negative number")
                 else:
@@ -145,29 +180,42 @@ class Queue:
                         remaining = endtime - time()
                         if remaining <= 0.0:
                             raise Full
-                        self.not_full.wait(remaining)
+                        self.closed_or_non_full.wait(remaining)
+                        if self._closed:
+                            raise Closed
             self._put(item)
             self.unfinished_tasks += 1
-            self.not_empty.notify()
+            self.exhausted_or_non_empty.notify()
 
     def get(self, block=True, timeout=None):
         '''Remove and return an item from the queue.
 
         If optional args 'block' is true and 'timeout' is None (the default),
-        block if necessary until an item is available. If 'timeout' is
-        a non-negative number, it blocks at most 'timeout' seconds and raises
-        the Empty exception if no item was available within that time.
-        Otherwise ('block' is false), return an item if one is immediately
-        available, else raise the Empty exception ('timeout' is ignored
-        in that case).
+        block if necessary until an item is available or the queue is closed.
+        If the queue is closed and no items are available, raise the
+        Exhausted exception.
+
+        If 'block' is true and 'timeout' is a positive number, block at most
+        'timeout' seconds and raise the Empty exception if no item becomes
+        available within that time, or the Exhausted exception if the queue
+        gets closed before any items are available.
+
+        If 'block' is false, ignore 'timeout' and return an item if one is
+        immediately available, else raise the Empty or Exhausted
+        exception, depending on whether the queue is closed.
+        (Note that Exhausted is a subclass of Empty.)
         '''
-        with self.not_empty:
+        with self.exhausted_or_non_empty:
+            if self.exhausted():
+                raise Exhausted
             if not block:
                 if not self._qsize():
                     raise Empty
             elif timeout is None:
                 while not self._qsize():
-                    self.not_empty.wait()
+                    self.exhausted_or_non_empty.wait()
+                    if self.exhausted():
+                        raise Exhausted
             elif timeout < 0:
                 raise ValueError("'timeout' must be a non-negative number")
             else:
@@ -176,16 +224,21 @@ class Queue:
                     remaining = endtime - time()
                     if remaining <= 0.0:
                         raise Empty
-                    self.not_empty.wait(remaining)
+                    self.exhausted_or_non_empty.wait(remaining)
+                    if self.exhausted():
+                        raise Exhausted
             item = self._get()
-            self.not_full.notify()
+            self.closed_or_non_full.notify()
+            if self.exhausted():  # Was this the last item ever?
+                self.exhausted_or_non_empty.notify_all()
             return item
 
     def put_nowait(self, item):
         '''Put an item into the queue without blocking.
 
         Only enqueue the item if a free slot is immediately available.
-        Otherwise raise the Full exception.
+        Otherwise raise the Full exception, or Closed if the queue is
+        closed.
         '''
         return self.put(item, block=False)
 
@@ -193,9 +246,38 @@ class Queue:
         '''Remove and return an item from the queue without blocking.
 
         Only get an item if one is immediately available. Otherwise
-        raise the Empty exception.
+        raise the Empty exception, or Exhausted if the queue is
+        exhausted.
         '''
         return self.get(block=False)
+
+    def close(self):
+        '''Close the queue.
+
+        Once closed, the queue does not accept new items and can not be
+        reopened. Closing immediately aborts any currently-blocking put()
+        calls; if the queue is empty at the moment of closing, it also
+        aborts any currently-blocking get() calls.
+        Repeated calls to close() after the first one do nothing.
+        '''
+        with self.mutex:
+            if self._closed:
+                return
+            self._closed = True
+            self.closed_or_non_full.notify_all()
+            if self.empty():
+                self.exhausted_or_non_empty.notify_all()
+
+    def __iter__(self):
+        '''Iterate through (blocking) retrieval of items from the queue.
+
+        The iteration stops when the queue is exhausted.
+        '''
+        while True:
+            try:
+                yield self.get()
+            except Exhausted:
+                break
 
     # Override these methods to implement other queue organizations
     # (e.g. stack or priority queue).

--- a/Lib/test/test_queue.py
+++ b/Lib/test/test_queue.py
@@ -97,14 +97,14 @@ class BlockingTestMixin:
     # Call this if multiple instances of block_func are expected to all be
     # released by a single trigger call, and to then raise an exception:
     def do_exceptional_simultaneously_blocking_test(
-            self,block_func, block_args, trigger_func, trigger_args,
+            self, block_func, block_args, trigger_func, trigger_args,
             expected_exception_class, instances_count = 5):
         raising_events = [threading.Event() for _ in range(instances_count)]
         blocking_threads = [threading.Thread(
             target=_set_event_on_exception,
             args=(block_func, block_args,
-                  expected_exception_class, raising_events[i]))
-            for i in range(instances_count)]
+                  expected_exception_class, event))
+            for event in raising_events]
         for t in blocking_threads:
             t.start()
 

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -484,6 +484,7 @@ Carl Feynman
 Vincent Fiack
 Anastasia Filatova
 Tomer Filiba
+Vladimir Filipović
 Segev Finer
 Jeffrey Finkelstein
 Russell Finn

--- a/Misc/NEWS.d/next/Library/2018-10-21-01-33-58.bpo-35034.F2pz-i.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-21-01-33-58.bpo-35034.F2pz-i.rst
@@ -1,2 +1,2 @@
-Add close() and __iter__() to threading.Queue to simplify coordination
+Add close() and __iter__() to queue.Queue to simplify coordination
 between producers and consumers. Patch by Vladimir Filipović.

--- a/Misc/NEWS.d/next/Library/2018-10-21-01-33-58.bpo-35034.F2pz-i.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-21-01-33-58.bpo-35034.F2pz-i.rst
@@ -1,0 +1,2 @@
+Add close() and __iter__() to threading.Queue to simplify coordination
+between producers and consumers. Patch by Vladimir Filipović.


### PR DESCRIPTION
(Copied from [bpo-35034](https://bugs.python.org/issue35034))

Code using threading.Queue often needs to coordinate a "work is finished as far as I care" state between the producing and consuming side.

When going from the producer to the consumer ("No more items after this, so don't bother waiting"), this is usually implemented with sentinel objects, which is at best needlessly verbose and at worst tricky to get right (as with multiple consumers, or communicating a non-trivial sentinel object).
When going the other direction ("I'm not interested in consuming any more, so you can stop putting them on the queue"), or when a third component needs to notify both sides ("You two start wrapping up, but don't drop any in-flight items") there isn't even a clear usual solution.

Adding a close() method to the Queue (with accompanying exception treatment etc.) would solve all of this in a very clean way. It would not change anything for code that doesn't want to use it. It would simplify a lot of everyday uses of Queue. Many simple producers could reduce their coordination code to a `with closing(queue)` idiom. A further \_\_iter\_\_() method would enable many simple consumers to safely cut all their coordination boilerplate down to just `for item in queue`.

<!-- issue-number: [bpo-35034](https://bugs.python.org/issue35034) -->
https://bugs.python.org/issue35034
<!-- /issue-number -->
