### PR TITLE
bpo-35036: Use empty message as default for logger

### DIFF
--- a/Doc/tools/extensions/suspicious.py
+++ b/Doc/tools/extensions/suspicious.py
@@ -148,7 +148,6 @@ class CheckSuspiciousMarkupBuilder(Builder):
         return False
 
     def report_issue(self, text, lineno, issue):
-        if not self.any_issue: self.logger.info('')
         self.any_issue = True
         self.write_log_entry(lineno, issue, text)
         if py3:

--- a/Doc/tools/extensions/suspicious.py
+++ b/Doc/tools/extensions/suspicious.py
@@ -148,7 +148,7 @@ class CheckSuspiciousMarkupBuilder(Builder):
         return False
 
     def report_issue(self, text, lineno, issue):
-        if not self.any_issue: self.logger.info()
+        if not self.any_issue: self.logger.info('')
         self.any_issue = True
         self.write_log_entry(lineno, issue, text)
         if py3:


### PR DESCRIPTION
This fixes the change introduced in ee171a26c11 where `self.info()` was replaced with `self.logger.info()` . `self.info` was deprecated but it had a default of `message=''` and the new change also follows the same. I think this is a no-op and can be removed but that is subjected to approval from the reviewer. 

Original `self.info` definition : 

```python
def info(self, message='', nonl=False):
    # type: (unicode, bool) > None
    """Emit an informational message.

    If *nonl* is true, don't emit a newline at the end (which implies that
    more info output will follow soon.)

    .. deprecated:: 1.6
       Use :mod:`sphinx.util.logging` instead.
    """
    warnings.warn('app.info() is now deprecated. Use sphinx.util.logging instead.',
                  RemovedInSphinx20Warning)
    logger.info(message, nonl=nonl)

```

<!-- issue-number: [bpo-35036](https://bugs.python.org/issue35036) -->
https://bugs.python.org/issue35036
<!-- /issue-number -->
