### PR TITLE
bpo-29843: raise AttributeError if given negative _length_

### DIFF
--- a/Lib/ctypes/test/test_arrays.py
+++ b/Lib/ctypes/test/test_arrays.py
@@ -163,8 +163,6 @@ class ArrayTestCase(unittest.TestCase):
         self.assertEqual(Y()._length_, 187)
 
     def test_bad_subclass(self):
-        import sys
-
         with self.assertRaises(AttributeError):
             class T(Array):
                 pass
@@ -174,29 +172,29 @@ class ArrayTestCase(unittest.TestCase):
         with self.assertRaises(AttributeError):
             class T(Array):
                 _length_ = 13
+
+    def test_bad_length(self):
+        import sys
+
+        with self.assertRaises(ValueError):
+            class T(Array):
+                _type_ = c_int
+                _length_ = - sys.maxsize * 2
+        with self.assertRaises(ValueError):
+            class T(Array):
+                _type_ = c_int
+                _length_ = -1
+        with self.assertRaises(TypeError):
+            class T(Array):
+                _type_ = c_int
+                _length_ = 1.87
         with self.assertRaises(OverflowError):
             class T(Array):
                 _type_ = c_int
                 _length_ = sys.maxsize * 2
-        with self.assertRaises(AttributeError):
-            class T(Array):
-                _type_ = c_int
-                _length_ = 1.87
 
-    def test_bad_length(self):
-        with self.assertRaises(AttributeError):
-            class T(Array):
-                _type_ = c_int
-                _length_ = -1 << 1000
-        with self.assertRaises(AttributeError):
-            class T(Array):
-                _type_ = c_int
-                _length_ = -1
-        with self.assertRaises(OverflowError):
-            class T(Array):
-                _type_ = c_int
-                _length_ = 1 << 1000
-        # _length_ might be zero.
+    def test_zero_length(self):
+        # _length_ can be zero.
         class T(Array):
             _type_ = c_int
             _length_ = 0

--- a/Lib/ctypes/test/test_arrays.py
+++ b/Lib/ctypes/test/test_arrays.py
@@ -183,6 +183,24 @@ class ArrayTestCase(unittest.TestCase):
                 _type_ = c_int
                 _length_ = 1.87
 
+    def test_bad_length(self):
+        with self.assertRaises(AttributeError):
+            class T(Array):
+                _type_ = c_int
+                _length_ = -1 << 1000
+        with self.assertRaises(AttributeError):
+            class T(Array):
+                _type_ = c_int
+                _length_ = -1
+        with self.assertRaises(OverflowError):
+            class T(Array):
+                _type_ = c_int
+                _length_ = 1 << 1000
+        # _length_ might be zero.
+        class T(Array):
+            _type_ = c_int
+            _length_ = 0
+
     @unittest.skipUnless(sys.maxsize > 2**32, 'requires 64bit platform')
     @bigmemtest(size=_2G, memuse=1, dry_run=False)
     def test_large_array(self, size):

--- a/Lib/ctypes/test/test_arrays.py
+++ b/Lib/ctypes/test/test_arrays.py
@@ -174,8 +174,6 @@ class ArrayTestCase(unittest.TestCase):
                 _length_ = 13
 
     def test_bad_length(self):
-        import sys
-
         with self.assertRaises(ValueError):
             class T(Array):
                 _type_ = c_int

--- a/Misc/NEWS.d/next/Core and Builtins/2018-10-21-17-43-48.bpo-29743.aeCcKR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-10-21-17-43-48.bpo-29743.aeCcKR.rst
@@ -1,2 +1,4 @@
-Raise `AttributeError` instead of `OverflowError` in case of a negative
-``_length_`` in a `ctypes.Array` subclass.  Original patch by Oren Milman.
+Raise `ValueError` instead of `OverflowError` in case of a negative
+``_length_`` in a `ctypes.Array` subclass.  Also raise `TypeError`
+instead of `OverflowError` for non-integer ``_length_``.
+Original patch by Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-10-21-17-43-48.bpo-29743.aeCcKR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-10-21-17-43-48.bpo-29743.aeCcKR.rst
@@ -1,4 +1,4 @@
-Raise `ValueError` instead of `OverflowError` in case of a negative
-``_length_`` in a `ctypes.Array` subclass.  Also raise `TypeError`
-instead of `OverflowError` for non-integer ``_length_``.
+Raise :exc:`ValueError` instead of :exc:`OverflowError` in case of a negative
+``_length_`` in a :class:`ctypes.Array` subclass.  Also raise :exc:`TypeError`
+instead of :exc:`AttributeError` for non-integer ``_length_``.
 Original patch by Oren Milman.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-10-21-17-43-48.bpo-29743.aeCcKR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-10-21-17-43-48.bpo-29743.aeCcKR.rst
@@ -1,0 +1,2 @@
+Raise `AttributeError` instead of `OverflowError` in case of a negative
+``_length_`` in a `ctypes.Array` subclass.  Original patch by Oren Milman.

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1405,13 +1405,17 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     type_attr = NULL;
 
     length_attr = PyObject_GetAttrString((PyObject *)result, "_length_");
-    if (!length_attr || !PyLong_Check(length_attr)) {
+    if (!length_attr ||
+        !PyLong_Check(length_attr) ||
+        _PyLong_Sign(length_attr) == -1)
+    {
         PyErr_SetString(PyExc_AttributeError,
                         "class must define a '_length_' attribute, "
                         "which must be a positive integer");
         Py_XDECREF(length_attr);
         goto error;
     }
+
     length = PyLong_AsSsize_t(length_attr);
     Py_DECREF(length_attr);
     if (length == -1 && PyErr_Occurred()) {

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1406,8 +1406,7 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     length_attr = PyObject_GetAttrString((PyObject *)result, "_length_");
     if (!length_attr) {
-        if (!PyErr_Occurred() ||
-            PyErr_ExceptionMatches(PyExc_AttributeError))
+        if (PyErr_ExceptionMatches(PyExc_AttributeError))
         {
             PyErr_SetString(PyExc_AttributeError,
                             "class must define a '_length_' attribute");

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1406,8 +1406,7 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 
     length_attr = PyObject_GetAttrString((PyObject *)result, "_length_");
     if (!length_attr) {
-        if (PyErr_ExceptionMatches(PyExc_AttributeError))
-        {
+        if (PyErr_ExceptionMatches(PyExc_AttributeError)) {
             PyErr_SetString(PyExc_AttributeError,
                             "class must define a '_length_' attribute");
         }

--- a/Modules/_ctypes/_ctypes.c
+++ b/Modules/_ctypes/_ctypes.c
@@ -1405,14 +1405,27 @@ PyCArrayType_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
     type_attr = NULL;
 
     length_attr = PyObject_GetAttrString((PyObject *)result, "_length_");
-    if (!length_attr ||
-        !PyLong_Check(length_attr) ||
-        _PyLong_Sign(length_attr) == -1)
-    {
-        PyErr_SetString(PyExc_AttributeError,
-                        "class must define a '_length_' attribute, "
-                        "which must be a positive integer");
-        Py_XDECREF(length_attr);
+    if (!length_attr) {
+        if (!PyErr_Occurred() ||
+            PyErr_ExceptionMatches(PyExc_AttributeError))
+        {
+            PyErr_SetString(PyExc_AttributeError,
+                            "class must define a '_length_' attribute");
+        }
+        goto error;
+    }
+
+    if (!PyLong_Check(length_attr)) {
+        Py_DECREF(length_attr);
+        PyErr_SetString(PyExc_TypeError,
+                        "The '_length_' attribute must be an integer");
+        goto error;
+    }
+
+    if (_PyLong_Sign(length_attr) == -1) {
+        Py_DECREF(length_attr);
+        PyErr_SetString(PyExc_ValueError,
+                        "The '_length_' attribute must not be negative");
         goto error;
     }
 


### PR DESCRIPTION
This is based on @orenmn's PR #3822.

The tests are the same, but this uses `_PyLong_Sign()` to check for negative values rather than `PyLong_AsLongAndOverflow()`.

This raises `AttributeError` since the existing code already raises that for other invalid values (non-integers).

<!-- issue-number: [bpo-29843](https://bugs.python.org/issue29843) -->
https://bugs.python.org/issue29843
<!-- /issue-number -->
