### PR TITLE
bpo-35027: Correct 3.7 meta-data changes in setup.py documentation.

### DIFF
--- a/Doc/distutils/setupscript.rst
+++ b/Doc/distutils/setupscript.rst
@@ -682,9 +682,8 @@ information is sometimes used to indicate sub-releases.  These are
           )
 
 .. versionchanged:: 3.7
-   :class:`~distutils.core.setup` now raises a :exc:`TypeError` if
-   ``classifiers``, ``keywords`` and ``platforms`` fields are not specified
-   as a list.
+   :class:`~distutils.core.setup` now warns when ``classifiers``, ``keywords``
+   or ``platforms`` fields are not specified as a list or a string.
 
 .. _debug-setup-script:
 


### PR DESCRIPTION
This fixes the setup.py user documentation to reflect the changes made in https://github.com/python/cpython/commit/8837dd092fe5ad5184889104e8036811ed839f98#diff-d9afd486aff62306cb23cb8be2d4458eR30.

Distutils will only warn when something else than a list or str is used, but not raise a TypeError explicitly. It will even convert the given value to a list if possible (i.e. for a tuple).. Therefore, I removed the passage about the TypeError replacing it with the hint about the new warning.

<!-- issue-number: [bpo-35027](https://bugs.python.org/issue35027) -->
https://bugs.python.org/issue35027
<!-- /issue-number -->
