### PR TITLE
bpo-35039: remove unused clock() objects

### DIFF
--- a/Lib/turtledemo/penrose.py
+++ b/Lib/turtledemo/penrose.py
@@ -137,13 +137,10 @@ def test(l=200, n=4, fun=sun, startpos=(0,0), th=2):
     goto(startpos)
     setheading(0)
     tiledict = {}
-    a = clock()
     tracer(0)
     fun(l, n)
-    b = clock()
     draw(l, n, th)
     tracer(1)
-    c = clock()
     nk = len([x for x in tiledict if tiledict[x]])
     nd = len([x for x in tiledict if not tiledict[x]])
     print("%d kites and %d darts = %d pieces." % (nk, nd, nk+nd))


### PR DESCRIPTION
<!-- issue-number: [bpo-35039](https://bugs.python.org/issue35039) -->
https://bugs.python.org/issue35039
<!-- /issue-number -->

Closes [bpo-35039](https://bugs.python.org/issue35039): remove unused clock() objects; actually time calculations were removed in 891a1f8 