### PR TITLE
Fix bpo-19217: Calling assertEquals for moderately long list takes too long

### DIFF
--- a/Lib/unittest/case.py
+++ b/Lib/unittest/case.py
@@ -1013,9 +1013,10 @@ class TestCase(object):
                     differing += ('Unable to index element %d '
                                   'of second %s\n' % (len1, seq_type_name))
         standardMsg = differing
-        diffMsg = '\n' + '\n'.join(
-            difflib.ndiff(pprint.pformat(seq1).splitlines(),
-                          pprint.pformat(seq2).splitlines()))
+        diffMsg = difflib.unified_diff(pprint.pformat(seq1).splitlines(),
+                                       pprint.pformat(seq2).splitlines(),
+                                       lineterm='')
+        diffMsg = '\n' + '\n'.join(diffMsg)
 
         standardMsg = self._truncateMessage(standardMsg, diffMsg)
         msg = self._formatMessage(msg, standardMsg)

--- a/Lib/unittest/test/test_assertions.py
+++ b/Lib/unittest/test/test_assertions.py
@@ -242,8 +242,8 @@ class TestLongMessage(unittest.TestCase):
         # Error messages are multiline so not testing on full message
         # assertTupleEqual and assertListEqual delegate to this method
         self.assertMessages('assertSequenceEqual', ([], [None]),
-                            [r"\+ \[None\]$", "^oops$", r"\+ \[None\]$",
-                             r"\+ \[None\] : oops$"])
+                            [r"\+\[None\]$", "^oops$", r"\+\[None\]$",
+                             r"\+\[None\] : oops$"])
 
     def testAssertSetEqual(self):
         self.assertMessages('assertSetEqual', (set(), set([None])),

--- a/Lib/unittest/test/test_case.py
+++ b/Lib/unittest/test/test_case.py
@@ -789,8 +789,10 @@ class Test_TestCase(unittest.TestCase, TestEquality, TestHashing):
         self.assertEqual(self.maxDiff, 80*8)
         seq1 = 'a' + 'x' * 80**2
         seq2 = 'b' + 'x' * 80**2
-        diff = '\n'.join(difflib.ndiff(pprint.pformat(seq1).splitlines(),
-                                       pprint.pformat(seq2).splitlines()))
+        diff = difflib.unified_diff(pprint.pformat(seq1).splitlines(),
+                                    pprint.pformat(seq2).splitlines(),
+                                    lineterm='')
+        diff = '\n'.join(diff)
         # the +1 is the leading \n added by assertSequenceEqual
         omitted = unittest.case.DIFF_OMITTED % (len(diff) + 1,)
 


### PR DESCRIPTION


<!-- issue-number: [bpo-19217](https://bugs.python.org/issue19217) -->
https://bugs.python.org/issue19217
<!-- /issue-number -->
