### PR TITLE
bpo-35046: do only one system call per line (logging.StreamHandler)

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -982,6 +982,7 @@ class StreamHandler(Handler):
         try:
             msg = self.format(record)
             stream = self.stream
+            # issue 35046: merged two stream.writes into one.
             stream.write(msg + self.terminator)
             self.flush()
         except Exception:

--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -982,8 +982,7 @@ class StreamHandler(Handler):
         try:
             msg = self.format(record)
             stream = self.stream
-            stream.write(msg)
-            stream.write(self.terminator)
+            stream.write(msg + self.terminator)
             self.flush()
         except Exception:
             self.handleError(record)


### PR DESCRIPTION
When sys.stderr (or whatever other stream) is unbuffered, this results in two system calls and allows log records from different processes to concatenate on the same line in the output stream (followed by multiple newlines). This issue is new in Python 3.7, as stdout and stderr became "truly unbuffered" (cf. #30404).

<!-- issue-number: [bpo-35046](https://bugs.python.org/issue35046) -->
https://bugs.python.org/issue35046
<!-- /issue-number -->
