### PR TITLE
bpo-35046: coalesced two syscalls into one in logging.

### DIFF
--- a/Lib/logging/__init__.py
+++ b/Lib/logging/__init__.py
@@ -1091,8 +1091,8 @@ class StreamHandler(Handler):
         try:
             msg = self.format(record)
             stream = self.stream
-            stream.write(msg)
-            stream.write(self.terminator)
+            # issue 35046: merged two stream.writes into one.
+            stream.write(msg + self.terminator)
             self.flush()
         except Exception:
             self.handleError(record)


### PR DESCRIPTION


<!-- issue-number: [bpo-35046](https://bugs.python.org/issue35046) -->
https://bugs.python.org/issue35046
<!-- /issue-number -->
