### PR TITLE
[2.7] bpo-34748: link to :ref:`partial-objects` in functools.partial doc. (GH-9809)

### DIFF
--- a/Doc/library/functools.rst
+++ b/Doc/library/functools.rst
@@ -76,9 +76,9 @@ The :mod:`functools` module defines the following functions:
 
 .. function:: partial(func[,*args][, **keywords])
 
-   Return a new :class:`partial` object which when called will behave like *func*
-   called with the positional arguments *args* and keyword arguments *keywords*. If
-   more arguments are supplied to the call, they are appended to *args*. If
+   Return a new :ref:`partial object<partial-objects>` which when called will behave
+   like *func* called with the positional arguments *args* and keyword arguments *keywords*.
+   If more arguments are supplied to the call, they are appended to *args*. If
    additional keyword arguments are supplied, they extend and override *keywords*.
    Roughly equivalent to::
 


### PR DESCRIPTION
(cherry picked from commit 83a0765)

Co-authored-by: Andrei Petre p31andrei@gmail.com

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34748](https://bugs.python.org/issue34748) -->
https://bugs.python.org/issue34748
<!-- /issue-number -->
