### PR TITLE
bpo-35051:Fix pep8 on Lib/turtledemo module

### DIFF
--- a/Lib/turtledemo/penrose.py
+++ b/Lib/turtledemo/penrose.py
@@ -22,6 +22,7 @@ from time import perf_counter as clock, sleep
 f = (5**0.5-1)/2.0   # (sqrt(5)-1)/2 -- golden ratio
 d = 2 * cos(3*pi/10)
 
+
 def kite(l):
     fl = f * l
     lt(36)
@@ -33,6 +34,7 @@ def kite(l):
     rt(108)
     fd(l)
     rt(144)
+
 
 def dart(l):
     fl = f * l
@@ -46,11 +48,12 @@ def dart(l):
     fd(l)
     rt(144)
 
+
 def inflatekite(l, n):
     if n == 0:
         px, py = pos()
-        h, x, y = int(heading()), round(px,3), round(py,3)
-        tiledict[(h,x,y)] = True
+        h, x, y = int(heading()), round(px, 3), round(py, 3)
+        tiledict[(h, x, y)] = True
         return
     fl = f * l
     lt(36)
@@ -68,11 +71,12 @@ def inflatekite(l, n):
     inflatedart(fl, n-1)
     lt(36)
 
+
 def inflatedart(l, n):
     if n == 0:
         px, py = pos()
-        h, x, y = int(heading()), round(px,3), round(py,3)
-        tiledict[(h,x,y)] = False
+        h, x, y = int(heading()), round(px, 3), round(py, 3)
+        tiledict[(h, x, y)] = False
         return
     fl = f * l
     inflatekite(fl, n-1)
@@ -86,6 +90,7 @@ def inflatedart(l, n):
     inflatedart(fl, n-1)
     fd(l)
     rt(144)
+
 
 def draw(l, n, th=2):
     clear()
@@ -103,15 +108,18 @@ def draw(l, n, th=2):
             color("black", (0.75, 0, 0))
         stamp()
 
+
 def sun(l, n):
     for i in range(5):
         inflatekite(l, n)
         lt(72)
 
-def star(l,n):
+
+def star(l, n):
     for i in range(5):
         inflatedart(l, n)
         lt(72)
+
 
 def makeshapes():
     tracer(0)
@@ -125,6 +133,7 @@ def makeshapes():
     register_shape("dart", get_poly())
     tracer(1)
 
+
 def start():
     reset()
     ht()
@@ -132,7 +141,8 @@ def start():
     makeshapes()
     resizemode("user")
 
-def test(l=200, n=4, fun=sun, startpos=(0,0), th=2):
+
+def test(l=200, n=4, fun=sun, startpos=(0, 0), th=2):
     global tiledict
     goto(startpos)
     setheading(0)
@@ -148,6 +158,7 @@ def test(l=200, n=4, fun=sun, startpos=(0,0), th=2):
     nd = len([x for x in tiledict if not tiledict[x]])
     print("%d kites and %d darts = %d pieces." % (nk, nd, nk+nd))
 
+
 def demo(fun=sun):
     start()
     for i in range(8):
@@ -158,20 +169,22 @@ def demo(fun=sun):
         if t < 2:
             sleep(2 - t)
 
+
 def main():
-    #title("Penrose-tiling with kites and darts.")
+    # title("Penrose-tiling with kites and darts.")
     mode("logo")
     bgcolor(0.3, 0.3, 0)
     demo(sun)
     sleep(2)
     demo(star)
     pencolor("black")
-    goto(0,-200)
-    pencolor(0.7,0.7,1)
+    goto(0, -200)
+    pencolor(0.7, 0.7, 1)
     write("Please wait...",
           align="center", font=('Arial Black', 36, 'bold'))
     test(600, 8, startpos=(70, 117))
     return "Done"
+
 
 if __name__ == "__main__":
     msg = main()


### PR DESCRIPTION
# Fix pep8 on Lib/turtledemo module

[bpo-35051](https://bugs.python.org/issue35051): Fix pep8 problems on penrose.py

This PR is related to #10033 

Please, see  https://github.com/python/cpython/pull/10044 for more information about this PR

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35051](https://bugs.python.org/issue35051) -->
https://bugs.python.org/issue35051
<!-- /issue-number -->
