### PR TITLE
bpo-35059: Convert _Py_NewReference() to function

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -775,12 +775,17 @@ PyAPI_FUNC(void) _Py_AddToAllObjects(PyObject *, int force);
 /* Without Py_TRACE_REFS, there's little enough to do that we expand code
  * inline.
  */
-#define _Py_NewReference(op) (                          \
-    _Py_INC_TPALLOCS(op) _Py_COUNT_ALLOCS_COMMA         \
-    _Py_INC_REFTOTAL  _Py_REF_DEBUG_COMMA               \
-    Py_REFCNT(op) = 1)
+static inline void _Py_NewReference(PyObject *op)
+{
+    _Py_INC_TPALLOCS(op);
+    _Py_INC_REFTOTAL;
+    Py_REFCNT(op) = 1;
+}
 
-#define _Py_ForgetReference(op) _Py_INC_TPFREES(op)
+static inline void _Py_ForgetReference(PyObject *op)
+{
+    _Py_INC_TPFREES(op);
+}
 
 #ifdef Py_LIMITED_API
 PyAPI_FUNC(void) _Py_Dealloc(PyObject *);

--- a/Misc/NEWS.d/next/C API/2018-10-24-16-45-26.bpo-35059.jhoVMQ.rst
+++ b/Misc/NEWS.d/next/C API/2018-10-24-16-45-26.bpo-35059.jhoVMQ.rst
@@ -1,0 +1,2 @@
+Convert :c:func:`_Py_NewReference` and :c:func:`_Py_ForgetReference` macros
+to static inline functions.


### PR DESCRIPTION
Convert _Py_NewReference() and _Py_ForgetReference() macros to static
inlined functions.

<!-- issue-number: [bpo-35059](https://bugs.python.org/issue35059) -->
https://bugs.python.org/issue35059
<!-- /issue-number -->
