### PR TITLE
Remove mention of reduce() in decimal.Context.normalize().

### DIFF
--- a/Modules/_decimal/docstrings.h
+++ b/Modules/_decimal/docstrings.h
@@ -768,7 +768,7 @@ Return the number closest to x, in the direction towards y.\n\
 
 PyDoc_STRVAR(doc_ctx_normalize,
 "normalize($self, x, /)\n--\n\n\
-Reduce x to its simplest form. Alias for reduce(x).\n\
+Reduce x to its simplest form.\n\
 \n");
 
 PyDoc_STRVAR(doc_ctx_number_class,


### PR DESCRIPTION
Context.reduce() exists in cdecimal, but was not merged in cPython.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
