### PR TITLE
bpo-31047: Fix ntpath.abspath to trim ending separator

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -523,7 +523,7 @@ else:  # use native Windows method on Windows
     def abspath(path):
         """Return the absolute version of a path."""
         try:
-            return _getfullpathname(path)
+            return normpath(_getfullpathname(path))
         except (OSError, ValueError):
             return _abspath_fallback(path)
 

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -284,6 +284,8 @@ class TestNtpath(unittest.TestCase):
             tester('ntpath.abspath("")', cwd_dir)
             tester('ntpath.abspath(" ")', cwd_dir + "\\ ")
             tester('ntpath.abspath("?")', cwd_dir + "\\?")
+            drive, _ = ntpath.splitdrive(cwd_dir)
+            tester('ntpath.abspath("/abc/")', drive + "\\abc")
 
     def test_relpath(self):
         tester('ntpath.relpath("a")', 'a')

--- a/Misc/NEWS.d/next/Library/2018-10-25-09-37-03.bpo-31047.kBbX8r.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-25-09-37-03.bpo-31047.kBbX8r.rst
@@ -1,0 +1,2 @@
+Fix ``ntpath.abspath`` regression where it didn't remove a trailing
+separator on Windows. Patch by Tim Graham.


### PR DESCRIPTION
Regression in b0bf51b32240369ccb736dc32ff82bb96f375402.
https://bugs.python.org/issue31047#msg328322
