### PR TITLE
bpo-35047: Better error messages in unittest.mock

### DIFF
--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -30,6 +30,7 @@ import pprint
 import sys
 import builtins
 from types import ModuleType
+from unittest.util import safe_repr
 from functools import wraps, partial
 
 
@@ -778,10 +779,10 @@ class NonCallableMock(Base):
         """
         self = _mock_self
         if self.call_count != 0:
-            msg = ("Expected '%s' to not have been called. Called %s times.\n"
-                   "Calls: %r." % (self._mock_name or 'mock',
-                                   self.call_count,
-                                   self.mock_calls))
+            msg = ("Expected '%s' to not have been called. Called %s times.%s"
+                   % (self._mock_name or 'mock',
+                      self.call_count,
+                      self._call_list_as_string()))
             raise AssertionError(msg)
 
     def assert_called(_mock_self):
@@ -798,10 +799,10 @@ class NonCallableMock(Base):
         """
         self = _mock_self
         if not self.call_count == 1:
-            msg = ("Expected '%s' to have been called once. Called %s times.\n"
-                   "Calls %r. " % (self._mock_name or 'mock',
-                                   self.call_count,
-                                   self.mock_calls))
+            msg = ("Expected '%s' to have been called once. Called %s times.%s"
+                   % (self._mock_name or 'mock',
+                      self.call_count,
+                      self._call_list_as_string()))
             raise AssertionError(msg)
 
     def assert_called_with(_mock_self, *args, **kwargs):
@@ -829,8 +830,10 @@ class NonCallableMock(Base):
         with the specified arguments."""
         self = _mock_self
         if not self.call_count == 1:
-            msg = ("Expected '%s' to be called once. Called %s times." %
-                   (self._mock_name or 'mock', self.call_count))
+            msg = ("Expected '%s' to be called once. Called %s times.%s"
+                   % (self._mock_name or 'mock',
+                      self.call_count,
+                      self._call_list_as_string()))
             raise AssertionError(msg)
         return self.assert_called_with(*args, **kwargs)
 
@@ -851,8 +854,8 @@ class NonCallableMock(Base):
         if not any_order:
             if expected not in all_calls:
                 raise AssertionError(
-                    'Calls not found.\nExpected: %r\n'
-                    'Actual: %r' % (_CallList(calls), self.mock_calls)
+                    'Calls not found.\nExpected: %r%s'
+                    % (_CallList(calls), self._call_list_as_string())
                 ) from cause
             return
 
@@ -911,6 +914,19 @@ class NonCallableMock(Base):
             raise AttributeError(mock_name)
 
         return klass(**kw)
+
+
+    def _call_list_as_string(self):
+        """Renders self.mock_calls as a string.
+
+        Example: "\nCalls: [call(1), call(2)]."
+
+        If self.mock_calls is empty, an empty string is returned. The
+        output will be truncated if very long. 
+        """
+        if not self.mock_calls:
+            return ""
+        return f"\nCalls: {safe_repr(self.mock_calls)}."
 
 
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -922,7 +922,7 @@ class NonCallableMock(Base):
         Example: "\nCalls: [call(1), call(2)]."
 
         If self.mock_calls is empty, an empty string is returned. The
-        output will be truncated if very long. 
+        output will be truncated if very long.
         """
         if not self.mock_calls:
             return ""

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -782,7 +782,7 @@ class NonCallableMock(Base):
             msg = ("Expected '%s' to not have been called. Called %s times.%s"
                    % (self._mock_name or 'mock',
                       self.call_count,
-                      self._call_list_as_string()))
+                      self._calls_repr()))
             raise AssertionError(msg)
 
     def assert_called(_mock_self):
@@ -802,7 +802,7 @@ class NonCallableMock(Base):
             msg = ("Expected '%s' to have been called once. Called %s times.%s"
                    % (self._mock_name or 'mock',
                       self.call_count,
-                      self._call_list_as_string()))
+                      self._calls_repr()))
             raise AssertionError(msg)
 
     def assert_called_with(_mock_self, *args, **kwargs):
@@ -833,7 +833,7 @@ class NonCallableMock(Base):
             msg = ("Expected '%s' to be called once. Called %s times.%s"
                    % (self._mock_name or 'mock',
                       self.call_count,
-                      self._call_list_as_string()))
+                      self._calls_repr()))
             raise AssertionError(msg)
         return self.assert_called_with(*args, **kwargs)
 
@@ -855,7 +855,7 @@ class NonCallableMock(Base):
             if expected not in all_calls:
                 raise AssertionError(
                     'Calls not found.\nExpected: %r%s'
-                    % (_CallList(calls), self._call_list_as_string())
+                    % (_CallList(calls), self._calls_repr(prefix="Actual"))
                 ) from cause
             return
 
@@ -916,7 +916,7 @@ class NonCallableMock(Base):
         return klass(**kw)
 
 
-    def _call_list_as_string(self):
+    def _calls_repr(self, prefix="Calls"):
         """Renders self.mock_calls as a string.
 
         Example: "\nCalls: [call(1), call(2)]."
@@ -926,7 +926,7 @@ class NonCallableMock(Base):
         """
         if not self.mock_calls:
             return ""
-        return f"\nCalls: {safe_repr(self.mock_calls)}."
+        return f"\n{prefix}: {safe_repr(self.mock_calls)}."
 
 
 

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -778,8 +778,10 @@ class NonCallableMock(Base):
         """
         self = _mock_self
         if self.call_count != 0:
-            msg = ("Expected '%s' to not have been called. Called %s times." %
-                   (self._mock_name or 'mock', self.call_count))
+            msg = ("Expected '%s' to not have been called. Called %s times.\n"
+                   "Calls: %r." % (self._mock_name or 'mock',
+                                   self.call_count,
+                                   self.mock_calls))
             raise AssertionError(msg)
 
     def assert_called(_mock_self):
@@ -796,8 +798,10 @@ class NonCallableMock(Base):
         """
         self = _mock_self
         if not self.call_count == 1:
-            msg = ("Expected '%s' to have been called once. Called %s times." %
-                   (self._mock_name or 'mock', self.call_count))
+            msg = ("Expected '%s' to have been called once. Called %s times.\n"
+                   "Calls %r. " % (self._mock_name or 'mock',
+                                   self.call_count,
+                                   self.mock_calls))
             raise AssertionError(msg)
 
     def assert_called_with(_mock_self, *args, **kwargs):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1298,7 +1298,7 @@ class MockTest(unittest.TestCase):
         m = Mock()
         with self.assertRaises(AssertionError) as e:
             m.assert_called_once()
-        self.assertFalse("Calls:" in str(e.exception))
+        self.assertNotIn("Calls:", str(e.exception))
 
     #Issue21256 printout of keyword args should be in deterministic order
     def test_sorted_call_signature(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -1,4 +1,5 @@
 import copy
+import re
 import sys
 import tempfile
 
@@ -412,7 +413,7 @@ class MockTest(unittest.TestCase):
         m(1)
         m(2)
         self.assertRaisesRegex(AssertionError,
-            r"Calls: \[call\(1\), call\(2\)\]",
+            re.escape("Calls: [call(1), call(2)]"),
             lambda: m.assert_called_once_with(2))
 
 
@@ -1262,7 +1263,7 @@ class MockTest(unittest.TestCase):
         m = Mock()
         m(1, 2)
         self.assertRaisesRegex(AssertionError,
-            r"Calls: \[call\(1, 2\)\]",
+            re.escape("Calls: [call(1, 2)]"),
             m.assert_not_called)
 
     def test_assert_called(self):
@@ -1291,7 +1292,7 @@ class MockTest(unittest.TestCase):
         m(1, 2)
         m(3)
         self.assertRaisesRegex(AssertionError,
-            r"Calls: \[call\(1, 2\), call\(3\)\]",
+            re.escape("Calls: [call(1, 2), call(3)]"),
             m.assert_called_once)
 
     def test_assert_called_once_message_not_called(self):

--- a/Lib/unittest/test/testmock/testmock.py
+++ b/Lib/unittest/test/testmock/testmock.py
@@ -407,6 +407,14 @@ class MockTest(unittest.TestCase):
             lambda: mock.assert_called_once_with('bob', 'bar', baz=2)
         )
 
+    def test_assert_called_once_with_call_list(self):
+        m = Mock()
+        m(1)
+        m(2)
+        self.assertRaisesRegex(AssertionError,
+            r"Calls: \[call\(1\), call\(2\)\]",
+            lambda: m.assert_called_once_with(2))
+
 
     def test_assert_called_once_with_function_spec(self):
         def f(a, b, c, d=None):
@@ -1250,6 +1258,13 @@ class MockTest(unittest.TestCase):
         with self.assertRaises(AssertionError):
             m.hello.assert_not_called()
 
+    def test_assert_not_called_message(self):
+        m = Mock()
+        m(1, 2)
+        self.assertRaisesRegex(AssertionError,
+            r"Calls: \[call\(1, 2\)\]",
+            m.assert_not_called)
+
     def test_assert_called(self):
         m = Mock()
         with self.assertRaises(AssertionError):
@@ -1270,6 +1285,20 @@ class MockTest(unittest.TestCase):
         m.hello()
         with self.assertRaises(AssertionError):
             m.hello.assert_called_once()
+
+    def test_assert_called_once_message(self):
+        m = Mock()
+        m(1, 2)
+        m(3)
+        self.assertRaisesRegex(AssertionError,
+            r"Calls: \[call\(1, 2\), call\(3\)\]",
+            m.assert_called_once)
+
+    def test_assert_called_once_message_not_called(self):
+        m = Mock()
+        with self.assertRaises(AssertionError) as e:
+            m.assert_called_once()
+        self.assertFalse("Calls:" in str(e.exception))
 
     #Issue21256 printout of keyword args should be in deterministic order
     def test_sorted_call_signature(self):

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1570,6 +1570,7 @@ Daniel Stokes
 Michael Stone
 Serhiy Storchaka
 Ken Stox
+Petter Strandmark
 Charalampos Stratakis
 Dan Stromberg
 Donald Stufft

--- a/Misc/NEWS.d/next/Library/2018-10-25-09-59-00.bpo-35047.abbaa.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-25-09-59-00.bpo-35047.abbaa.rst
@@ -1,0 +1,2 @@
+``unittest.mock`` now prints the list of calls if ``assert_not_called``
+or ``assert_called_once`` fails. Patch by Petter Strandmark.

--- a/Misc/NEWS.d/next/Library/2018-10-25-09-59-00.bpo-35047.abbaa.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-25-09-59-00.bpo-35047.abbaa.rst
@@ -1,3 +1,3 @@
 ``unittest.mock`` now includes mock calls in exception messages if
-``assert_not_called`` or ``assert_called_once`` fails. Patch by Petter
-Strandmark.
+``assert_not_called``, ``assert_called_once``, or ``assert_called_once_with``
+fails. Patch by Petter Strandmark.

--- a/Misc/NEWS.d/next/Library/2018-10-25-09-59-00.bpo-35047.abbaa.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-25-09-59-00.bpo-35047.abbaa.rst
@@ -1,2 +1,3 @@
-``unittest.mock`` now prints the list of calls if ``assert_not_called``
-or ``assert_called_once`` fails. Patch by Petter Strandmark.
+``unittest.mock`` now includes mock calls in exception messages if
+``assert_not_called`` or ``assert_called_once`` fails. Patch by Petter
+Strandmark.


### PR DESCRIPTION
When developing unit tests with `unittest.mock`, it is common to see error messages like this:

    AssertionError: Expected 'info' to not have been called. Called 3 times.

This commit adds the actual list of calls to the error message.

<!-- issue-number: [bpo-34547](https://bugs.python.org/issue34547) -->
https://bugs.python.org/issue35047
<!-- /issue-number -->
