### PR TITLE
bpo-35053: Add Include/tracemalloc.h

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -137,5 +137,6 @@
 #include "dtoa.h"
 #include "fileutils.h"
 #include "pyfpe.h"
+#include "tracemalloc.h"
 
 #endif /* !Py_PYTHON_H */

--- a/Include/object.h
+++ b/Include/object.h
@@ -1,5 +1,8 @@
 #ifndef Py_OBJECT_H
 #define Py_OBJECT_H
+
+#include "pymem.h"   /* _Py_tracemalloc_config */
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -24,42 +24,6 @@ PyAPI_FUNC(int) _PyMem_SetupAllocators(const char *opt);
 /* Try to get the allocators name set by _PyMem_SetupAllocators(). */
 PyAPI_FUNC(const char*) _PyMem_GetAllocatorsName(void);
 
-/* Track an allocated memory block in the tracemalloc module.
-   Return 0 on success, return -1 on error (failed to allocate memory to store
-   the trace).
-
-   Return -2 if tracemalloc is disabled.
-
-   If memory block is already tracked, update the existing trace. */
-PyAPI_FUNC(int) PyTraceMalloc_Track(
-    unsigned int domain,
-    uintptr_t ptr,
-    size_t size);
-
-/* Update the Python traceback of an object.
-   This function can be used when a memory block is reused from a free list. */
-PyAPI_FUNC(int) _PyTraceMalloc_NewReference(PyObject *op);
-
-/* Untrack an allocated memory block in the tracemalloc module.
-   Do nothing if the block was not tracked.
-
-   Return -2 if tracemalloc is disabled, otherwise return 0. */
-PyAPI_FUNC(int) PyTraceMalloc_Untrack(
-    unsigned int domain,
-    uintptr_t ptr);
-
-/* Get the traceback where a memory block was allocated.
-
-   Return a tuple of (filename: str, lineno: int) tuples.
-
-   Return None if the tracemalloc module is disabled or if the memory block
-   is not tracked by tracemalloc.
-
-   Raise an exception and return NULL on error. */
-PyAPI_FUNC(PyObject*) _PyTraceMalloc_GetTraceback(
-    unsigned int domain,
-    uintptr_t ptr);
-
 PyAPI_FUNC(int) _PyMem_IsFreed(void *ptr, size_t size);
 #endif   /* !defined(Py_LIMITED_API) */
 
@@ -246,7 +210,9 @@ PyAPI_FUNC(int) _PyMem_SetDefaultAllocator(
 
 /* bpo-35053: expose _Py_tracemalloc_config for performance:
    _Py_NewReference() needs an efficient check to test if tracemalloc is
-   tracing. */
+   tracing.
+
+   It has to be defined in pymem.h, before object.h is included. */
 struct _PyTraceMalloc_Config {
     /* Module initialized?
        Variable protected by the GIL */

--- a/Include/tracemalloc.h
+++ b/Include/tracemalloc.h
@@ -1,0 +1,42 @@
+#ifndef Py_TRACEMALLOC_H
+#define Py_TRACEMALLOC_H
+
+#ifndef Py_LIMITED_API
+/* Track an allocated memory block in the tracemalloc module.
+   Return 0 on success, return -1 on error (failed to allocate memory to store
+   the trace).
+
+   Return -2 if tracemalloc is disabled.
+
+   If memory block is already tracked, update the existing trace. */
+PyAPI_FUNC(int) PyTraceMalloc_Track(
+    unsigned int domain,
+    uintptr_t ptr,
+    size_t size);
+
+/* Update the Python traceback of an object.
+   This function can be used when a memory block is reused from a free list. */
+PyAPI_FUNC(int) _PyTraceMalloc_NewReference(PyObject *op);
+
+/* Untrack an allocated memory block in the tracemalloc module.
+   Do nothing if the block was not tracked.
+
+   Return -2 if tracemalloc is disabled, otherwise return 0. */
+PyAPI_FUNC(int) PyTraceMalloc_Untrack(
+    unsigned int domain,
+    uintptr_t ptr);
+
+/* Get the traceback where a memory block was allocated.
+
+   Return a tuple of (filename: str, lineno: int) tuples.
+
+   Return None if the tracemalloc module is disabled or if the memory block
+   is not tracked by tracemalloc.
+
+   Raise an exception and return NULL on error. */
+PyAPI_FUNC(PyObject*) _PyTraceMalloc_GetTraceback(
+    unsigned int domain,
+    uintptr_t ptr);
+#endif
+
+#endif /* !Py_TRACEMALLOC_H */

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1017,6 +1017,7 @@ PYTHON_HEADERS= \
 		$(srcdir)/Include/symtable.h \
 		$(srcdir)/Include/sysmodule.h \
 		$(srcdir)/Include/traceback.h \
+		$(srcdir)/Include/tracemalloc.h \
 		$(srcdir)/Include/tupleobject.h \
 		$(srcdir)/Include/ucnhash.h \
 		$(srcdir)/Include/unicodeobject.h \

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -177,6 +177,7 @@
     <ClInclude Include="..\Include\sysmodule.h" />
     <ClInclude Include="..\Include\token.h" />
     <ClInclude Include="..\Include\traceback.h" />
+    <ClInclude Include="..\Include\tracemalloc.h" />
     <ClInclude Include="..\Include\tupleobject.h" />
     <ClInclude Include="..\Include\ucnhash.h" />
     <ClInclude Include="..\Include\unicodeobject.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -321,6 +321,9 @@
     <ClInclude Include="..\Include\traceback.h">
       <Filter>Include</Filter>
     </ClInclude>
+    <ClInclude Include="..\Include\tracemalloc.h">
+      <Filter>Include</Filter>
+    </ClInclude>
     <ClInclude Include="..\Include\tupleobject.h">
       <Filter>Include</Filter>
     </ClInclude>


### PR DESCRIPTION
* Modify object.h to ensure that pymem.h is included,
  to get _Py_tracemalloc_config variable.
* Move _PyTraceMalloc_XXX() functions to tracemalloc.h,
  they need PyObject type. Break circular dependency between pymem.h
  and object.h.

<!-- issue-number: [bpo-35053](https://bugs.python.org/issue35053) -->
https://bugs.python.org/issue35053
<!-- /issue-number -->
