### PR TITLE
[3.6] bpo-31047: Fix ntpath.abspath to trim ending separator (GH-10082)

### DIFF
--- a/Lib/ntpath.py
+++ b/Lib/ntpath.py
@@ -545,8 +545,8 @@ else:  # use native Windows method on Windows
     def abspath(path):
         """Return the absolute version of a path."""
         try:
-            return _getfullpathname(path)
-        except OSError:
+            return normpath(_getfullpathname(path))
+        except (OSError, ValueError):
             return _abspath_fallback(path)
 
 # realpath is a no-op on systems without islink support

--- a/Lib/test/test_ntpath.py
+++ b/Lib/test/test_ntpath.py
@@ -307,6 +307,8 @@ class TestNtpath(unittest.TestCase):
                 tester('ntpath.abspath("")', cwd_dir)
                 tester('ntpath.abspath(" ")', cwd_dir + "\\ ")
                 tester('ntpath.abspath("?")', cwd_dir + "\\?")
+                drive, _ = ntpath.splitdrive(cwd_dir)
+                tester('ntpath.abspath("/abc/")', drive + "\\abc")
         except ImportError:
             self.skipTest('nt module not available')
 

--- a/Misc/NEWS.d/next/Library/2018-10-25-09-37-03.bpo-31047.kBbX8r.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-25-09-37-03.bpo-31047.kBbX8r.rst
@@ -1,0 +1,2 @@
+Fix ``ntpath.abspath`` regression where it didn't remove a trailing
+separator on Windows. Patch by Tim Graham.


### PR DESCRIPTION


<!-- issue-number: [bpo-31047](https://bugs.python.org/issue31047) -->
https://bugs.python.org/issue31047
<!-- /issue-number -->
