### PR TITLE
glob uses fnmatch.filter instead of fnmatch since 2001

### DIFF
--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -35,9 +35,9 @@ For example, ``'[?]'`` matches the character ``'?'``.
 
 Note that the filename separator (``'/'`` on Unix) is *not* special to this
 module.  See module :mod:`glob` for pathname expansion (:mod:`glob` uses
-:func:`fnmatch` to match pathname segments).  Similarly, filenames starting with
-a period are not special for this module, and are matched by the ``*`` and ``?``
-patterns.
+:func:`~fnmatch.filter` to match pathname segments).  Similarly, filenames
+starting with a period are not special for this module, and are matched by the
+``*`` and ``?`` patterns.
 
 
 .. function:: fnmatch(filename, pattern)

--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -35,9 +35,9 @@ For example, ``'[?]'`` matches the character ``'?'``.
 
 Note that the filename separator (``'/'`` on Unix) is *not* special to this
 module.  See module :mod:`glob` for pathname expansion (:mod:`glob` uses
-:func:`~fnmatch.filter` to match pathname segments).  Similarly, filenames
-starting with a period are not special for this module, and are matched by the
-``*`` and ``?`` patterns.
+:func:`.filter` to match pathname segments).  Similarly, filenames starting with
+a period are not special for this module, and are matched by the ``*`` and ``?``
+patterns.
 
 
 .. function:: fnmatch(filename, pattern)


### PR DESCRIPTION
glob uses fnmatch.filter since https://github.com/python/cpython/commit/b5d4d2a7d53f8c2926fd3004aeba0b8b38a3d111