### PR TITLE
bpo-35053: Define _PyTraceMalloc_NewReference in object.h

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -765,6 +765,10 @@ PyAPI_FUNC(void) dec_count(PyTypeObject *);
 #define _Py_COUNT_ALLOCS_COMMA
 #endif /* COUNT_ALLOCS */
 
+/* Update the Python traceback of an object. This function must be called
+   when a memory block is reused from a free list. */
+PyAPI_FUNC(int) _PyTraceMalloc_NewReference(PyObject *op);
+
 #ifdef Py_TRACE_REFS
 /* Py_TRACE_REFS is such major surgery that we call external routines. */
 PyAPI_FUNC(void) _Py_NewReference(PyObject *);

--- a/Include/tracemalloc.h
+++ b/Include/tracemalloc.h
@@ -14,10 +14,6 @@ PyAPI_FUNC(int) PyTraceMalloc_Track(
     uintptr_t ptr,
     size_t size);
 
-/* Update the Python traceback of an object.
-   This function can be used when a memory block is reused from a free list. */
-PyAPI_FUNC(int) _PyTraceMalloc_NewReference(PyObject *op);
-
 /* Untrack an allocated memory block in the tracemalloc module.
    Do nothing if the block was not tracked.
 

--- a/Modules/Setup
+++ b/Modules/Setup
@@ -129,6 +129,9 @@ _io -DPy_BUILD_CORE -I$(srcdir)/Modules/_io _io/_iomodule.c _io/iobase.c _io/fil
 faulthandler faulthandler.c
 
 # debug tool to trace memory blocks allocated by Python
+#
+# bpo-35053: The module must be builtin since _Py_NewReference()
+# can call _PyTraceMalloc_NewReference().
 _tracemalloc _tracemalloc.c hashtable.c
 
 # The rest of the modules listed in this file are all commented out by


### PR DESCRIPTION
_PyTraceMalloc_NewReference() is now called by _Py_NewReference(), so
move its definition to object.h. Moreover, define it even if
Py_LIMITED_API is defined, since _Py_NewReference() is also exposed
even if Py_LIMITED_API is defined.

<!-- issue-number: [bpo-35053](https://bugs.python.org/issue35053) -->
https://bugs.python.org/issue35053
<!-- /issue-number -->
