### PR TITLE
bpo-9263: _Py_NegativeRefcount() use _PyObject_AssertFailed()

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -329,8 +329,9 @@ class CAPITest(unittest.TestCase):
         """)
         rc, out, err = assert_python_failure('-c', code)
         self.assertRegex(err,
-                         br'_testcapimodule\.c:[0-9]+ object at .* '
-                         br'has negative ref count', err)
+                         br'_testcapimodule\.c:[0-9]+: '
+                         br'_Py_NegativeRefcount: Assertion ".*" failed; '
+                         br'object has negative ref count')
 
 
 class TestPendingCalls(unittest.TestCase):

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -205,13 +205,9 @@ void dec_count(PyTypeObject *tp)
 void
 _Py_NegativeRefcount(const char *filename, int lineno, PyObject *op)
 {
-    char buf[300];
-
-    PyOS_snprintf(buf, sizeof(buf),
-                  "%s:%i object at %p has negative ref count "
-                  "%" PY_FORMAT_SIZE_T "d",
-                  filename, lineno, op, op->ob_refcnt);
-    Py_FatalError(buf);
+    _PyObject_AssertFailed(op, "object has negative ref count",
+                           "op->ob_refcnt >= 0",
+                           filename, lineno, __PRETTY_FUNCTION__);
 }
 
 #endif /* Py_REF_DEBUG */
@@ -356,13 +352,14 @@ PyObject_Print(PyObject *op, FILE *fp, int flags)
         Py_END_ALLOW_THREADS
     }
     else {
-        if (op->ob_refcnt <= 0)
+        if (op->ob_refcnt <= 0) {
             /* XXX(twouters) cast refcount to long until %zd is
                universally available */
             Py_BEGIN_ALLOW_THREADS
             fprintf(fp, "<refcnt %ld at %p>",
                 (long)op->ob_refcnt, op);
             Py_END_ALLOW_THREADS
+        }
         else {
             PyObject *s;
             if (flags & Py_PRINT_RAW)

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -207,7 +207,7 @@ _Py_NegativeRefcount(const char *filename, int lineno, PyObject *op)
 {
     _PyObject_AssertFailed(op, "object has negative ref count",
                            "op->ob_refcnt >= 0",
-                           filename, lineno, __PRETTY_FUNCTION__);
+                           filename, lineno, __func__);
 }
 
 #endif /* Py_REF_DEBUG */


### PR DESCRIPTION
_Py_NegativeRefcount() now uses _PyObject_AssertFailed() to dump the
object to help debugging.

<!-- issue-number: [bpo-9263](https://bugs.python.org/issue9263) -->
https://bugs.python.org/issue9263
<!-- /issue-number -->
