### PR TITLE
bpo-9263: Use _PyObject_ASSERT() in typeobject.c

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1116,7 +1116,7 @@ subtype_dealloc(PyObject *self)
 
     /* Extract the type; we expect it to be a heap type */
     type = Py_TYPE(self);
-    assert(type->tp_flags & Py_TPFLAGS_HEAPTYPE);
+    _PyObject_ASSERT(self, type->tp_flags & Py_TPFLAGS_HEAPTYPE);
 
     /* Test whether the type has GC exactly once */
 
@@ -2214,9 +2214,10 @@ subtype_getweakref(PyObject *obj, void *context)
                         "This object has no __weakref__");
         return NULL;
     }
-    assert(Py_TYPE(obj)->tp_weaklistoffset > 0);
-    assert(Py_TYPE(obj)->tp_weaklistoffset + sizeof(PyObject *) <=
-           (size_t)(Py_TYPE(obj)->tp_basicsize));
+    _PyObject_ASSERT(obj, Py_TYPE(obj)->tp_weaklistoffset > 0);
+    _PyObject_ASSERT(obj,
+                     (Py_TYPE(obj)->tp_weaklistoffset + sizeof(PyObject *)) \
+                     <= (size_t)(Py_TYPE(obj)->tp_basicsize));
     weaklistptr = (PyObject **)
         ((char *)obj + Py_TYPE(obj)->tp_weaklistoffset);
     if (*weaklistptr == NULL)
@@ -3279,7 +3280,7 @@ type_dealloc(PyTypeObject *type)
     PyObject *tp, *val, *tb;
 
     /* Assert this is a heap-allocated type object */
-    assert(type->tp_flags & Py_TPFLAGS_HEAPTYPE);
+    _PyObject_ASSERT((PyObject *)type, type->tp_flags & Py_TPFLAGS_HEAPTYPE);
     _PyObject_GC_UNTRACK(type);
     PyErr_Fetch(&tp, &val, &tb);
     remove_all_subclasses(type, type->tp_bases);
@@ -3503,7 +3504,7 @@ type_clear(PyTypeObject *type)
     PyDictKeysObject *cached_keys;
     /* Because of type_is_gc(), the collector only calls this
        for heaptypes. */
-    assert(type->tp_flags & Py_TPFLAGS_HEAPTYPE);
+    _PyObject_ASSERT((PyObject *)type, type->tp_flags & Py_TPFLAGS_HEAPTYPE);
 
     /* We need to invalidate the method cache carefully before clearing
        the dict, so that other objects caught in a reference cycle
@@ -5117,7 +5118,8 @@ PyType_Ready(PyTypeObject *type)
         assert(_PyType_CheckConsistency(type));
         return 0;
     }
-    assert((type->tp_flags & Py_TPFLAGS_READYING) == 0);
+    _PyObject_ASSERT((PyObject *)type,
+                     (type->tp_flags & Py_TPFLAGS_READYING) == 0);
 
     type->tp_flags |= Py_TPFLAGS_READYING;
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2215,9 +2215,11 @@ subtype_getweakref(PyObject *obj, void *context)
                         "This object has no __weakref__");
         return NULL;
     }
-    _PyObject_ASSERT(type, type->tp_weaklistoffset > 0);
-    _PyObject_ASSERT(type, ((type->tp_weaklistoffset + sizeof(PyObject *))
-                            <= (size_t)(type->tp_basicsize)));
+    _PyObject_ASSERT((PyObject *)type,
+                     type->tp_weaklistoffset > 0);
+    _PyObject_ASSERT((PyObject *)type,
+                     ((type->tp_weaklistoffset + sizeof(PyObject *))
+                      <= (size_t)(type->tp_basicsize)));
     weaklistptr = (PyObject **)((char *)obj + type->tp_weaklistoffset);
     if (*weaklistptr == NULL)
         result = Py_None;

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2208,18 +2208,17 @@ subtype_getweakref(PyObject *obj, void *context)
 {
     PyObject **weaklistptr;
     PyObject *result;
+    PyTypeObject *type = Py_TYPE(obj);
 
-    if (Py_TYPE(obj)->tp_weaklistoffset == 0) {
+    if (type->tp_weaklistoffset == 0) {
         PyErr_SetString(PyExc_AttributeError,
                         "This object has no __weakref__");
         return NULL;
     }
-    _PyObject_ASSERT(obj, Py_TYPE(obj)->tp_weaklistoffset > 0);
-    _PyObject_ASSERT(obj,
-                     (Py_TYPE(obj)->tp_weaklistoffset + sizeof(PyObject *)) \
-                      <= (size_t)(Py_TYPE(obj)->tp_basicsize));
-    weaklistptr = (PyObject **)
-        ((char *)obj + Py_TYPE(obj)->tp_weaklistoffset);
+    _PyObject_ASSERT(type, type->tp_weaklistoffset > 0);
+    _PyObject_ASSERT(type, ((type->tp_weaklistoffset + sizeof(PyObject *))
+                            <= (size_t)(type->tp_basicsize)));
+    weaklistptr = (PyObject **)((char *)obj + type->tp_weaklistoffset);
     if (*weaklistptr == NULL)
         result = Py_None;
     else

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1116,7 +1116,7 @@ subtype_dealloc(PyObject *self)
 
     /* Extract the type; we expect it to be a heap type */
     type = Py_TYPE(self);
-    _PyObject_ASSERT(self, type->tp_flags & Py_TPFLAGS_HEAPTYPE);
+    _PyObject_ASSERT((PyObject *)type, type->tp_flags & Py_TPFLAGS_HEAPTYPE);
 
     /* Test whether the type has GC exactly once */
 
@@ -2217,7 +2217,7 @@ subtype_getweakref(PyObject *obj, void *context)
     _PyObject_ASSERT(obj, Py_TYPE(obj)->tp_weaklistoffset > 0);
     _PyObject_ASSERT(obj,
                      (Py_TYPE(obj)->tp_weaklistoffset + sizeof(PyObject *)) \
-                     <= (size_t)(Py_TYPE(obj)->tp_basicsize));
+                      <= (size_t)(Py_TYPE(obj)->tp_basicsize));
     weaklistptr = (PyObject **)
         ((char *)obj + Py_TYPE(obj)->tp_weaklistoffset);
     if (*weaklistptr == NULL)


### PR DESCRIPTION
Replace assert() with _PyObject_ASSERT() in Objects/typeobject.c
to dump the faulty object on assertion failure to ease debugging.

<!-- issue-number: [bpo-9263](https://bugs.python.org/issue9263) -->
https://bugs.python.org/issue9263
<!-- /issue-number -->
