### PR TITLE
bpo-1154351: Add get_current_dir_name() to os module

### DIFF
--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -155,6 +155,7 @@ process and user.
 .. function:: chdir(path)
               fchdir(fd)
               getcwd()
+              get_current_dir_name()
    :noindex:
 
    These functions are described in :ref:`os-file-dir`.
@@ -1696,6 +1697,19 @@ features:
 .. function:: getcwdb()
 
    Return a bytestring representing the current working directory.
+
+
+.. function:: get_current_dir_name()
+
+    Return a string representing the current working directory taking into
+    consideration the users ``PWD`` environment variable if it exists. This is
+    opposed to :func:`getcwd()` which dereferences symlinks in the path. This
+    function is identical to :func:`getcwd()` on systems that do **not**
+    support the ``PWD`` environment variable.
+
+    .. availability:: Unix.
+
+    .. versionadded:: 3.8
 
 
 .. function:: lchflags(path, flags)

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1707,8 +1707,6 @@ features:
     function is identical to :func:`getcwd()` on systems that do **not**
     support the ``PWD`` environment variable.
 
-    .. availability:: Unix.
-
     .. versionadded:: 3.8
 
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -1702,10 +1702,10 @@ features:
 .. function:: get_current_dir_name()
 
     Return a string representing the current working directory taking into
-    consideration the users ``PWD`` environment variable if it exists. This is
-    opposed to :func:`getcwd()` which dereferences symlinks in the path. This
-    function is identical to :func:`getcwd()` on systems that do **not**
-    support the ``PWD`` environment variable.
+    consideration the users :envvar:`PWD` environment variable if it exists. This is
+    opposed to :func:`getcwd` which dereferences symlinks in the path. This
+    function is identical to :func:`getcwd` on systems that do **not**
+    support the :envvar:`PWD` environment variable.
 
     .. versionadded:: 3.8
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -141,6 +141,12 @@ by right-clicking the button.  (Contributed by Tal Einat in :issue:`1529353`.)
 The changes above have been backported to 3.7 maintenance releases.
 
 
+os
+--
+
+Added :func:`~os.get_current_dir_name` function.
+(Contributed by Braden Groom in :issue:`1154351`.)
+
 os.path
 -------
 

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -661,6 +661,9 @@ def get_current_dir_name():
     """
     cwd = getcwd()
 
+    if name == 'nt':
+        return cwd
+
     try:
         pwd = environ["PWD"]
     except KeyError:

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -666,10 +666,7 @@ def get_current_dir_name():
     except KeyError:
         return cwd
 
-    cwd_stat, pwd_stat = map(stat, [cwd, pwd])
-
-    if (cwd_stat.st_dev == pwd_stat.st_dev and
-            cwd_stat.st_ino == pwd_stat.st_ino):
+    if path.samefile(cwd, pwd):
         return pwd
     return cwd
 

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -660,15 +660,12 @@ def get_current_dir_name():
     the *PWD* environment variable.
     """
     cwd = getcwd()
-
     if name == 'nt':
         return cwd
-
     try:
         pwd = environ["PWD"]
     except KeyError:
         return cwd
-
     if path.samefile(cwd, pwd):
         return pwd
     return cwd

--- a/Lib/os.py
+++ b/Lib/os.py
@@ -32,7 +32,7 @@ _names = sys.builtin_module_names
 __all__ = ["altsep", "curdir", "pardir", "sep", "pathsep", "linesep",
            "defpath", "name", "path", "devnull", "SEEK_SET", "SEEK_CUR",
            "SEEK_END", "fsencode", "fsdecode", "get_exec_path", "fdopen",
-           "popen", "extsep"]
+           "popen", "extsep", "get_current_dir_name"]
 
 def _exists(name):
     return name in globals()
@@ -649,6 +649,29 @@ def get_exec_path(env=None):
     if path_list is None:
         path_list = defpath
     return path_list.split(pathsep)
+
+
+def get_current_dir_name():
+    """
+    Return a string representing the current working directory taking into
+    consideration the users *PWD* environment variable if it exists. This
+    is opposed to getcwd() which dereferences symlinks in the path. This
+    function is identical to getcwd() on systems that do *not* support
+    the *PWD* environment variable.
+    """
+    cwd = getcwd()
+
+    try:
+        pwd = environ["PWD"]
+    except KeyError:
+        return cwd
+
+    cwd_stat, pwd_stat = map(stat, [cwd, pwd])
+
+    if (cwd_stat.st_dev == pwd_stat.st_dev and
+            cwd_stat.st_ino == pwd_stat.st_ino):
+        return pwd
+    return cwd
 
 
 # Change environ to automatically call putenv(), unsetenv if they exist.

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1268,7 +1268,10 @@ class CurrentDirTests(unittest.TestCase):
             self.addCleanup(support.unlink, self.tmp_lnk)
             os.symlink(self.tmp_dir, self.tmp_lnk, True)
             os.chdir(self.tmp_lnk)
-            self.assertEqual(os.getcwd(), self.tmp_dir)
+            if os.name == 'nt':
+                self.assertEqual(os.getcwd(), self.tmp_lnk)
+            else:
+                self.assertEqual(os.getcwd(), self.tmp_dir)
             with mock.patch.dict('os.environ', {'PWD': self.tmp_dir}):
                 self.assertEqual(os.getcwd(), self.tmp_dir)
             with mock.patch.dict('os.environ', {'PWD': self.tmp_lnk}):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1264,14 +1264,14 @@ class CurrentDirTests(unittest.TestCase):
         # os.getcwd() always returns the dereferenced path
         with support.temp_cwd(self.tmp_dir):
             os.chdir(self.tmp_dir)
-            self.assertEqual(self.tmp_dir, os.getcwd())
+            self.assertEqual(os.getcwd(), self.tmp_dir)
             os.symlink(self.tmp_dir, self.tmp_lnk, True)
             os.chdir(self.tmp_lnk)
-            self.assertEqual(self.tmp_dir, os.getcwd())
+            self.assertEqual(os.getcwd(), self.tmp_dir)
             with mock.patch.dict('os.environ', {'PWD': self.tmp_dir}):
-                self.assertEqual(self.tmp_dir, os.getcwd())
+                self.assertEqual(os.getcwd(), self.tmp_dir)
             with mock.patch.dict('os.environ', {'PWD': self.tmp_lnk}):
-                self.assertEqual(self.tmp_dir, os.getcwd())
+                self.assertEqual(os.getcwd(), self.tmp_dir)
             os.unlink(self.tmp_lnk)
 
     def test_get_current_dir_name(self):
@@ -1280,14 +1280,14 @@ class CurrentDirTests(unittest.TestCase):
         # whether the path contains symlinks.
         with support.temp_cwd(self.tmp_dir):
             with mock.patch.dict('os.environ', {'PWD': self.tmp_dir}):
-                self.assertEqual(self.tmp_dir, os.get_current_dir_name())
+                self.assertEqual(os.get_current_dir_name(), self.tmp_dir)
+            self.addCleanup(support.unlink, self.tmp_lnk)
             os.symlink(self.tmp_dir, self.tmp_lnk, True)
             with mock.patch.dict('os.environ', {'PWD': self.tmp_lnk}):
                 if os.name == 'posix':
-                    self.assertEqual(self.tmp_lnk, os.get_current_dir_name())
+                    self.assertEqual(os.get_current_dir_name(), self.tmp_lnk)
                 else:
-                    self.assertEqual(self.tmp_dir, os.get_current_dir_name())
-            os.unlink(self.tmp_lnk)
+                    self.assertEqual(os.get_current_dir_name(), self.tmp_dir)
 
 
 class RemoveDirsTests(unittest.TestCase):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1255,7 +1255,7 @@ class ChownFileTests(unittest.TestCase):
 class CurrentDirTests(unittest.TestCase):
 
     def setUp(self):
-        self.pwd = os.environ['PWD']
+        self.pwd = os.environ.get('PWD')
         base = os.path.abspath(support.TESTFN)
         self.tmp_dir = base + '_dir'
         self.tmp_lnk = base + '_lnk'
@@ -1291,7 +1291,8 @@ class CurrentDirTests(unittest.TestCase):
             os.unlink(self.tmp_lnk)
 
     def tearDown(self):
-        os.environ['PWD'] = self.pwd
+        if self.pwd is not None:
+            os.environ['PWD'] = self.pwd
 
 
 class RemoveDirsTests(unittest.TestCase):

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1269,13 +1269,15 @@ class CurrentDirTests(unittest.TestCase):
             os.symlink(self.tmp_dir, self.tmp_lnk, True)
             os.chdir(self.tmp_lnk)
             if os.name == 'nt':
-                self.assertEqual(os.getcwd(), self.tmp_lnk)
+                # windows doesn't dereference the path
+                expected_cwd = self.tmp_lnk
             else:
-                self.assertEqual(os.getcwd(), self.tmp_dir)
+                expected_cwd = self.tmp_dir
+            self.assertEqual(os.getcwd(), expected_cwd)
             with mock.patch.dict('os.environ', {'PWD': self.tmp_dir}):
-                self.assertEqual(os.getcwd(), self.tmp_dir)
+                self.assertEqual(os.getcwd(), expected_cwd)
             with mock.patch.dict('os.environ', {'PWD': self.tmp_lnk}):
-                self.assertEqual(os.getcwd(), self.tmp_dir)
+                self.assertEqual(os.getcwd(), expected_cwd)
 
     def test_get_current_dir_name(self):
         # os.get_current_dir_name() returns the direct path--mirroring

--- a/Lib/test/test_os.py
+++ b/Lib/test/test_os.py
@@ -1265,6 +1265,7 @@ class CurrentDirTests(unittest.TestCase):
         with support.temp_cwd(self.tmp_dir):
             os.chdir(self.tmp_dir)
             self.assertEqual(os.getcwd(), self.tmp_dir)
+            self.addCleanup(support.unlink, self.tmp_lnk)
             os.symlink(self.tmp_dir, self.tmp_lnk, True)
             os.chdir(self.tmp_lnk)
             self.assertEqual(os.getcwd(), self.tmp_dir)
@@ -1272,7 +1273,6 @@ class CurrentDirTests(unittest.TestCase):
                 self.assertEqual(os.getcwd(), self.tmp_dir)
             with mock.patch.dict('os.environ', {'PWD': self.tmp_lnk}):
                 self.assertEqual(os.getcwd(), self.tmp_dir)
-            os.unlink(self.tmp_lnk)
 
     def test_get_current_dir_name(self):
         # os.get_current_dir_name() returns the direct path--mirroring

--- a/Misc/NEWS.d/next/Library/2018-10-25-19-44-42.bpo-1154351.KhXLos.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-25-19-44-42.bpo-1154351.KhXLos.rst
@@ -1,0 +1,1 @@
+Add get_current_dir_name() to the os module.

--- a/Misc/NEWS.d/next/Library/2018-10-25-19-44-42.bpo-1154351.KhXLos.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-25-19-44-42.bpo-1154351.KhXLos.rst
@@ -1,1 +1,2 @@
 Add get_current_dir_name() to the os module.
+Patch by Braden Groom


### PR DESCRIPTION
Co-authored-by: Marc Adam Anderson <marc@marcadam.com> .


<!-- issue-number: [bpo-1154351](https://bugs.python.org/issue1154351) -->
https://bugs.python.org/issue1154351
<!-- /issue-number -->
