### PR TITLE
Revert "bpo-35059 : Add /Ob1 flag when building pythoncore in debug mode"

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-10-26-14-49-19.bpo-35059.PKsBxP.rst
+++ b/Misc/NEWS.d/next/Build/2018-10-26-14-49-19.bpo-35059.PKsBxP.rst
@@ -1,4 +1,0 @@
-PCbuild: Set InlineFunctionExpansion to OnlyExplicitInline ("/Ob1" option)
-in pyproject.props in Debug mode to expand functions marked as inline. This
-change should make Python compiled in Debug mode a little bit faster on
-Windows.

--- a/PCbuild/pyproject.props
+++ b/PCbuild/pyproject.props
@@ -42,8 +42,6 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <EnableEnhancedInstructionSet Condition="'$(Platform)'=='Win32'">NoExtensions</EnableEnhancedInstructionSet>
-      <InlineFunctionExpansion Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">OnlyExplicitInline</InlineFunctionExpansion>
-      <InlineFunctionExpansion Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">OnlyExplicitInline</InlineFunctionExpansion>
     </ClCompile>
     <ClCompile Condition="$(Configuration) == 'Debug'">
       <Optimization>Disabled</Optimization>


### PR DESCRIPTION
Reverts python/cpython#10094

<!-- issue-number: [bpo-35059](https://bugs.python.org/issue35059) -->
https://bugs.python.org/issue35059
<!-- /issue-number -->
