### PR TITLE
[2.7] bpo-35017, socketserver: don't accept any request after shutdown (GH-9952)

### DIFF
--- a/Lib/SocketServer.py
+++ b/Lib/SocketServer.py
@@ -229,6 +229,9 @@ class BaseServer:
                 # shutdown request and wastes cpu at all other times.
                 r, w, e = _eintr_retry(select.select, [self], [], [],
                                        poll_interval)
+                # bpo-35017: shutdown() called during select(), exit immediately.
+                if self.__shutdown_request:
+                    break
                 if self in r:
                     self._handle_request_noblock()
         finally:

--- a/Misc/NEWS.d/next/Library/2018-10-26-00-11-21.bpo-35017.6Ez4Cv.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-26-00-11-21.bpo-35017.6Ez4Cv.rst
@@ -1,0 +1,3 @@
+:meth:`socketserver.BaseServer.serve_forever` now exits immediately if it's
+:meth:`~socketserver.BaseServer.shutdown` method is called while it is
+polling for new events.


### PR DESCRIPTION
Prior to this revision, after the shutdown of a `BaseServer`,
the server accepted a last single request
if it was sent between the server socket polling
and the polling timeout.

This can be problematic for instance for a server restart
for which you do not want to interrupt the service,
by not closing the listening socket during the restart.
One request failed because of this behavior.

Note that only one request failed,
following requests were not accepted, as expected.

(cherry picked from commit 10cb3760e8631a27f5db1e51b05494e29306c671)

<!-- issue-number: [bpo-35017](https://bugs.python.org/issue35017) -->
https://bugs.python.org/issue35017
<!-- /issue-number -->
