### PR TITLE
bpo-35077: Make error message on string object less ambiguous

### DIFF
--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13977,7 +13977,7 @@ unicode_subscript(PyObject* self, PyObject* item)
         assert(_PyUnicode_CheckConsistency(result, 1));
         return result;
     } else {
-        PyErr_SetString(PyExc_TypeError, "string indices must be integers");
+        PyErr_SetString(PyExc_TypeError, "indices of string must be integers");
         return NULL;
     }
 }

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -13977,7 +13977,7 @@ unicode_subscript(PyObject* self, PyObject* item)
         assert(_PyUnicode_CheckConsistency(result, 1));
         return result;
     } else {
-        PyErr_SetString(PyExc_TypeError, "indices of string must be integers");
+        PyErr_SetString(PyExc_TypeError, "indices of strings must be integers");
         return NULL;
     }
 }


### PR DESCRIPTION


<!-- issue-number: [bpo-35077](https://bugs.python.org/issue35077) -->
https://bugs.python.org/issue35077
<!-- /issue-number -->
