### PR TITLE
bpo-35078:Allow customization of CSS class name of a month in calendar module

### DIFF
--- a/Lib/calendar.py
+++ b/Lib/calendar.py
@@ -571,19 +571,11 @@ class LocaleTextCalendar(TextCalendar):
 
     def formatweekday(self, day, width):
         with different_locale(self.locale):
-            if width >= 9:
-                names = day_name
-            else:
-                names = day_abbr
-            name = names[day]
-            return name[:width].center(width)
+            return super().formatweekday(day, width)
 
     def formatmonthname(self, theyear, themonth, width, withyear=True):
         with different_locale(self.locale):
-            s = month_name[themonth]
-            if withyear:
-                s = "%s %r" % (s, theyear)
-            return s.center(width)
+            return super().formatmonthname(theyear, themonth, width, withyear)
 
 
 class LocaleHTMLCalendar(HTMLCalendar):
@@ -601,16 +593,11 @@ class LocaleHTMLCalendar(HTMLCalendar):
 
     def formatweekday(self, day):
         with different_locale(self.locale):
-            s = day_abbr[day]
-            return '<th class="%s">%s</th>' % (self.cssclasses[day], s)
+            return super().formatweekday(day)
 
     def formatmonthname(self, theyear, themonth, withyear=True):
         with different_locale(self.locale):
-            s = month_name[themonth]
-            if withyear:
-                s = '%s %s' % (s, theyear)
-            return '<tr><th colspan="7" class="month">%s</th></tr>' % s
-
+            return super().formatmonthname(theyear, themonth, withyear)
 
 # Support for old module level interface
 c = TextCalendar()

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -564,6 +564,18 @@ class CalendarTestCase(unittest.TestCase):
         new_october = calendar.TextCalendar().formatmonthname(2010, 10, 10)
         self.assertEqual(old_october, new_october)
 
+    def test_locale_html_calendar_custom_css_class(self):
+        try:
+            cal = calendar.LocaleHTMLCalendar(locale='')
+            local_month = cal.formatmonthname(2010, 10, 10)
+        except locale.Error:
+            # cannot set the system default locale -- skip rest of test
+            raise unittest.SkipTest('cannot set the system default locale')
+        self.assertIn('class="month"', local_month)
+        cal.cssclass_month_head = "text-center month"
+        local_month = cal.formatmonthname(2010, 10, 10)
+        self.assertIn('class="text-center month"', local_month)
+
     def test_itermonthdays3(self):
         # ensure itermonthdays3 doesn't overflow after datetime.MAXYEAR
         list(calendar.Calendar().itermonthdays3(datetime.MAXYEAR, 12))

--- a/Lib/test/test_calendar.py
+++ b/Lib/test/test_calendar.py
@@ -564,7 +564,7 @@ class CalendarTestCase(unittest.TestCase):
         new_october = calendar.TextCalendar().formatmonthname(2010, 10, 10)
         self.assertEqual(old_october, new_october)
 
-    def test_locale_html_calendar_custom_css_class(self):
+    def test_locale_html_calendar_custom_css_class_month_name(self):
         try:
             cal = calendar.LocaleHTMLCalendar(locale='')
             local_month = cal.formatmonthname(2010, 10, 10)
@@ -575,6 +575,18 @@ class CalendarTestCase(unittest.TestCase):
         cal.cssclass_month_head = "text-center month"
         local_month = cal.formatmonthname(2010, 10, 10)
         self.assertIn('class="text-center month"', local_month)
+
+    def test_locale_html_calendar_custom_css_class_weekday(self):
+        try:
+            cal = calendar.LocaleHTMLCalendar(locale='')
+            local_weekday = cal.formatweekday(6)
+        except locale.Error:
+            # cannot set the system default locale -- skip rest of test
+            raise unittest.SkipTest('cannot set the system default locale')
+        self.assertIn('class="sun"', local_weekday)
+        cal.cssclasses_weekday_head = ["mon2", "tue2", "wed2", "thu2", "fri2", "sat2", "sun2"]
+        local_weekday = cal.formatweekday(6)
+        self.assertIn('class="sun2"', local_weekday)
 
     def test_itermonthdays3(self):
         # ensure itermonthdays3 doesn't overflow after datetime.MAXYEAR

--- a/Misc/NEWS.d/next/Library/2018-10-27-09-37-03.bpo-35078.kweA3R.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-27-09-37-03.bpo-35078.kweA3R.rst
@@ -1,0 +1,3 @@
+Refactor `formatweekday`, `formatmonthname` methods in `LocaleHTMLCalendar` class in `calendar` module.
+Patch by Srinivas Reddy Thatiparthy.
+

--- a/Misc/NEWS.d/next/Library/2018-10-27-09-37-03.bpo-35078.kweA3R.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-27-09-37-03.bpo-35078.kweA3R.rst
@@ -1,3 +1,3 @@
-Refactor `formatweekday`, `formatmonthname` methods in `LocaleHTMLCalendar` class in `calendar` module.
-Patch by Srinivas Reddy Thatiparthy.
+Refactor formatweekday, formatmonthname methods in LocaleHTMLCalendar and LocaleTextCalendar classes in calendar module to call the base class methods.This enables customizable CSS classes for LocaleHTMLCalendar.
+Patch by Srinivas Reddy Thatiparthy
 


### PR DESCRIPTION


<!-- issue-number: [bpo-35078](https://bugs.python.org/issue35078) -->
https://bugs.python.org/issue35078
<!-- /issue-number -->
