### PR TITLE
bpo-33710: Deprecate l*gettext() and related functions in the gettext module.

### DIFF
--- a/Doc/library/gettext.rst
+++ b/Doc/library/gettext.rst
@@ -53,6 +53,8 @@ class-based API instead.
    and :func:`ldngettext` functions.
    If *codeset* is omitted, then the current binding is returned.
 
+   .. deprecated-removed:: 3.8 3.10
+
 
 .. function:: textdomain(domain=None)
 
@@ -112,9 +114,9 @@ class-based API instead.
       Unicode strings instead, since most Python applications will want to
       manipulate human readable text as strings instead of bytes.  Further,
       it's possible that you may get unexpected Unicode-related exceptions
-      if there are encoding problems with the translated strings.  It is
-      possible that the ``l*()`` functions will be deprecated in future Python
-      versions due to their inherent problems and limitations.
+      if there are encoding problems with the translated strings.
+
+   .. deprecated-removed:: 3.8 3.10
 
 
 Note that GNU :program:`gettext` also defines a :func:`dcgettext` method, but
@@ -192,6 +194,9 @@ class can also install themselves in the built-in namespace as the function
    .. versionchanged:: 3.3
       :exc:`IOError` used to be raised instead of :exc:`OSError`.
 
+   .. deprecated-removed:: 3.8 3.10
+      The *codeset* parameter.
+
 
 .. function:: install(domain, localedir=None, codeset=None, names=None)
 
@@ -211,6 +216,9 @@ class can also install themselves in the built-in namespace as the function
    For convenience, you want the :func:`_` function to be installed in Python's
    builtins namespace, so it is easily accessible in all modules of your
    application.
+
+   .. deprecated-removed:: 3.8 3.10
+      The *codeset* parameter.
 
 
 The :class:`NullTranslations` class
@@ -272,6 +280,8 @@ are the methods of :class:`!NullTranslations`:
          These methods should be avoided in Python 3.  See the warning for the
          :func:`lgettext` function.
 
+      .. deprecated-removed:: 3.8 3.10
+
 
    .. method:: info()
 
@@ -288,10 +298,14 @@ are the methods of :class:`!NullTranslations`:
       Return the encoding used to return translated messages in :meth:`.lgettext`
       and :meth:`.lngettext`.
 
+      .. deprecated-removed:: 3.8 3.10
+
 
    .. method:: set_output_charset(charset)
 
       Change the encoding used to return translated messages.
+
+      .. deprecated-removed:: 3.8 3.10
 
 
    .. method:: install(names=None)
@@ -392,6 +406,8 @@ unexpected, or if other problems occur while reading the file, instantiating a
 
          These methods should be avoided in Python 3.  See the warning for the
          :func:`lgettext` function.
+
+      .. deprecated-removed:: 3.8 3.10
 
 
 Solaris message catalog support

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -308,7 +308,7 @@ Deprecated
   :meth:`~gettext.NullTranslations.output_charset` and
   :meth:`~gettext.NullTranslations.set_output_charset`, and the *codeset*
   parameter of functions :func:`~gettext.translation` and
-  :func:`~gettext.install` are also depreted, since they are only used for
+  :func:`~gettext.install` are also deprecated, since they are only used for
   for ``l*gettext()`` functions.
 
   (Contributed by Serhiy Storchaka in :issue:`33710`.)

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -295,10 +295,9 @@ Deprecated
   versions. :class:`~ast.Constant` should be used instead.
   (Contributed by Serhiy Storchaka in :issue:`32892`.)
 
-* The following functions are deprecated: :func:`~gettext.lgettext`, :func:`~gettext.ldgettext`,
-  :func:`~gettext.lngettext` and :func:`~gettext.ldngettext` in the
-  :mod:`gettext` module and corresponding methods of the
-  :class:`~gettext.NullTranslations` and :class:`~GNUTranslations` classes.
+* The following functions and methods are deprecated in the :mod:`gettext`
+  module: :func:`~gettext.lgettext`, :func:`~gettext.ldgettext`,
+  :func:`~gettext.lngettext` and :func:`~gettext.ldngettext`.
   They return encoded bytes, and it's possible that you will get unexpected
   Unicode-related exceptions if there are encoding problems with the
   translated strings. It's much better to use alternatives which return
@@ -309,7 +308,7 @@ Deprecated
   :meth:`~gettext.NullTranslations.set_output_charset`, and the *codeset*
   parameter of functions :func:`~gettext.translation` and
   :func:`~gettext.install` are also deprecated, since they are only used for
-  for ``l*gettext()`` functions.
+  for the ``l*gettext()`` functions.
 
   (Contributed by Serhiy Storchaka in :issue:`33710`.)
 

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -295,6 +295,24 @@ Deprecated
   versions. :class:`~ast.Constant` should be used instead.
   (Contributed by Serhiy Storchaka in :issue:`32892`.)
 
+* Functions :func:`~gettext.lgettext`, :func:`~gettext.ldgettext`,
+  :func:`~gettext.lngettext` and :func:`~gettext.ldngettext` in the
+  :mod:`gettext` module and corresponding methods of the
+  :class:`~gettext.NullTranslations` and :class:`~GNUTranslations` classes.
+  They return encoded bytes, and it's possible that you may get unexpected
+  Unicode-related exceptions if there are encoding problems with the
+  translated strings. It's much better to use alternatives which return
+  Unicode strings in Python 3.  Further, they were broken for long time.
+
+  Function :func:`~gettext.bind_textdomain_codeset`, methods
+  :meth:`~gettext.NullTranslations.output_charset` and
+  :meth:`~gettext.NullTranslations.set_output_charset`, and the *codeset*
+  parameter of functions :func:`~gettext.translation` and
+  :func:`~gettext.install` are also depreted, since they are only used for
+  for ``l*gettext()`` functions.
+
+  (Contributed by Serhiy Storchaka in :issue:`33710`.)
+
 
 Removed
 =======

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -299,7 +299,7 @@ Deprecated
   :func:`~gettext.lngettext` and :func:`~gettext.ldngettext` in the
   :mod:`gettext` module and corresponding methods of the
   :class:`~gettext.NullTranslations` and :class:`~GNUTranslations` classes.
-  They return encoded bytes, and it's possible that you may get unexpected
+  They return encoded bytes, and it's possible that you will get unexpected
   Unicode-related exceptions if there are encoding problems with the
   translated strings. It's much better to use alternatives which return
   Unicode strings in Python 3.  Further, they were broken for long time.

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -302,7 +302,7 @@ Deprecated
   They return encoded bytes, and it's possible that you will get unexpected
   Unicode-related exceptions if there are encoding problems with the
   translated strings. It's much better to use alternatives which return
-  Unicode strings in Python 3.  Further, they were broken for long time.
+  Unicode strings in Python 3. These functions have been broken for a long time.
 
   Function :func:`~gettext.bind_textdomain_codeset`, methods
   :meth:`~gettext.NullTranslations.output_charset` and

--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -295,7 +295,7 @@ Deprecated
   versions. :class:`~ast.Constant` should be used instead.
   (Contributed by Serhiy Storchaka in :issue:`32892`.)
 
-* Functions :func:`~gettext.lgettext`, :func:`~gettext.ldgettext`,
+* The following functions are deprecated: :func:`~gettext.lgettext`, :func:`~gettext.ldgettext`,
   :func:`~gettext.lngettext` and :func:`~gettext.ldngettext` in the
   :mod:`gettext` module and corresponding methods of the
   :class:`~gettext.NullTranslations` and :class:`~GNUTranslations` classes.

--- a/Lib/test/test_gettext.py
+++ b/Lib/test/test_gettext.py
@@ -1,5 +1,6 @@
 import os
 import base64
+import contextlib
 import gettext
 import locale
 import unittest
@@ -461,115 +462,173 @@ class LGettextTestCase(GettextBaseTest):
         GettextBaseTest.setUp(self)
         self.mofile = MOFILE
 
+    @contextlib.contextmanager
+    def assertDeprecated(self, name):
+        with self.assertWarnsRegex(DeprecationWarning,
+                                   fr'^{name}\(\) is deprecated'):
+            yield
+
     def test_lgettext(self):
         lgettext = gettext.lgettext
         ldgettext = gettext.ldgettext
-        self.assertEqual(lgettext('mullusk'), b'bacon')
-        self.assertEqual(lgettext('spam'), b'spam')
-        self.assertEqual(ldgettext('gettext', 'mullusk'), b'bacon')
-        self.assertEqual(ldgettext('gettext', 'spam'), b'spam')
+        with self.assertDeprecated('lgettext'):
+            self.assertEqual(lgettext('mullusk'), b'bacon')
+        with self.assertDeprecated('lgettext'):
+            self.assertEqual(lgettext('spam'), b'spam')
+        with self.assertDeprecated('ldgettext'):
+            self.assertEqual(ldgettext('gettext', 'mullusk'), b'bacon')
+        with self.assertDeprecated('ldgettext'):
+            self.assertEqual(ldgettext('gettext', 'spam'), b'spam')
 
     def test_lgettext_2(self):
         with open(self.mofile, 'rb') as fp:
             t = gettext.GNUTranslations(fp)
         lgettext = t.lgettext
-        self.assertEqual(lgettext('mullusk'), b'bacon')
-        self.assertEqual(lgettext('spam'), b'spam')
+        with self.assertDeprecated('lgettext'):
+            self.assertEqual(lgettext('mullusk'), b'bacon')
+        with self.assertDeprecated('lgettext'):
+            self.assertEqual(lgettext('spam'), b'spam')
 
     def test_lgettext_bind_textdomain_codeset(self):
         lgettext = gettext.lgettext
         ldgettext = gettext.ldgettext
-        saved_codeset = gettext.bind_textdomain_codeset('gettext')
+        with self.assertDeprecated('bind_textdomain_codeset'):
+            saved_codeset = gettext.bind_textdomain_codeset('gettext')
         try:
-            gettext.bind_textdomain_codeset('gettext', 'utf-16')
-            self.assertEqual(lgettext('mullusk'), 'bacon'.encode('utf-16'))
-            self.assertEqual(lgettext('spam'), 'spam'.encode('utf-16'))
-            self.assertEqual(ldgettext('gettext', 'mullusk'), 'bacon'.encode('utf-16'))
-            self.assertEqual(ldgettext('gettext', 'spam'), 'spam'.encode('utf-16'))
+            with self.assertDeprecated('bind_textdomain_codeset'):
+                gettext.bind_textdomain_codeset('gettext', 'utf-16')
+            with self.assertDeprecated('lgettext'):
+                self.assertEqual(lgettext('mullusk'), 'bacon'.encode('utf-16'))
+            with self.assertDeprecated('lgettext'):
+                self.assertEqual(lgettext('spam'), 'spam'.encode('utf-16'))
+            with self.assertDeprecated('ldgettext'):
+                self.assertEqual(ldgettext('gettext', 'mullusk'), 'bacon'.encode('utf-16'))
+            with self.assertDeprecated('ldgettext'):
+                self.assertEqual(ldgettext('gettext', 'spam'), 'spam'.encode('utf-16'))
         finally:
             del gettext._localecodesets['gettext']
-            gettext.bind_textdomain_codeset('gettext', saved_codeset)
+            with self.assertDeprecated('bind_textdomain_codeset'):
+                gettext.bind_textdomain_codeset('gettext', saved_codeset)
 
     def test_lgettext_output_encoding(self):
         with open(self.mofile, 'rb') as fp:
             t = gettext.GNUTranslations(fp)
         lgettext = t.lgettext
-        t.set_output_charset('utf-16')
-        self.assertEqual(lgettext('mullusk'), 'bacon'.encode('utf-16'))
-        self.assertEqual(lgettext('spam'), 'spam'.encode('utf-16'))
+        with self.assertDeprecated('set_output_charset'):
+            t.set_output_charset('utf-16')
+        with self.assertDeprecated('lgettext'):
+            self.assertEqual(lgettext('mullusk'), 'bacon'.encode('utf-16'))
+        with self.assertDeprecated('lgettext'):
+            self.assertEqual(lgettext('spam'), 'spam'.encode('utf-16'))
 
     def test_lngettext(self):
         lngettext = gettext.lngettext
         ldngettext = gettext.ldngettext
-        x = lngettext('There is %s file', 'There are %s files', 1)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s file', 'There are %s files', 1)
         self.assertEqual(x, b'Hay %s fichero')
-        x = lngettext('There is %s file', 'There are %s files', 2)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s file', 'There are %s files', 2)
         self.assertEqual(x, b'Hay %s ficheros')
-        x = lngettext('There is %s directory', 'There are %s directories', 1)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s directory', 'There are %s directories', 1)
         self.assertEqual(x, b'There is %s directory')
-        x = lngettext('There is %s directory', 'There are %s directories', 2)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s directory', 'There are %s directories', 2)
         self.assertEqual(x, b'There are %s directories')
-        x = ldngettext('gettext', 'There is %s file', 'There are %s files', 1)
+        with self.assertDeprecated('ldngettext'):
+            x = ldngettext('gettext', 'There is %s file', 'There are %s files', 1)
         self.assertEqual(x, b'Hay %s fichero')
-        x = ldngettext('gettext', 'There is %s file', 'There are %s files', 2)
+        with self.assertDeprecated('ldngettext'):
+            x = ldngettext('gettext', 'There is %s file', 'There are %s files', 2)
         self.assertEqual(x, b'Hay %s ficheros')
-        x = ldngettext('gettext', 'There is %s directory', 'There are %s directories', 1)
+        with self.assertDeprecated('ldngettext'):
+            x = ldngettext('gettext', 'There is %s directory', 'There are %s directories', 1)
         self.assertEqual(x, b'There is %s directory')
-        x = ldngettext('gettext', 'There is %s directory', 'There are %s directories', 2)
+        with self.assertDeprecated('ldngettext'):
+            x = ldngettext('gettext', 'There is %s directory', 'There are %s directories', 2)
         self.assertEqual(x, b'There are %s directories')
 
     def test_lngettext_2(self):
         with open(self.mofile, 'rb') as fp:
             t = gettext.GNUTranslations(fp)
         lngettext = t.lngettext
-        x = lngettext('There is %s file', 'There are %s files', 1)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s file', 'There are %s files', 1)
         self.assertEqual(x, b'Hay %s fichero')
-        x = lngettext('There is %s file', 'There are %s files', 2)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s file', 'There are %s files', 2)
         self.assertEqual(x, b'Hay %s ficheros')
-        x = lngettext('There is %s directory', 'There are %s directories', 1)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s directory', 'There are %s directories', 1)
         self.assertEqual(x, b'There is %s directory')
-        x = lngettext('There is %s directory', 'There are %s directories', 2)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s directory', 'There are %s directories', 2)
         self.assertEqual(x, b'There are %s directories')
 
     def test_lngettext_bind_textdomain_codeset(self):
         lngettext = gettext.lngettext
         ldngettext = gettext.ldngettext
-        saved_codeset = gettext.bind_textdomain_codeset('gettext')
+        with self.assertDeprecated('bind_textdomain_codeset'):
+            saved_codeset = gettext.bind_textdomain_codeset('gettext')
         try:
-            gettext.bind_textdomain_codeset('gettext', 'utf-16')
-            x = lngettext('There is %s file', 'There are %s files', 1)
+            with self.assertDeprecated('bind_textdomain_codeset'):
+                gettext.bind_textdomain_codeset('gettext', 'utf-16')
+            with self.assertDeprecated('lngettext'):
+                x = lngettext('There is %s file', 'There are %s files', 1)
             self.assertEqual(x, 'Hay %s fichero'.encode('utf-16'))
-            x = lngettext('There is %s file', 'There are %s files', 2)
+            with self.assertDeprecated('lngettext'):
+                x = lngettext('There is %s file', 'There are %s files', 2)
             self.assertEqual(x, 'Hay %s ficheros'.encode('utf-16'))
-            x = lngettext('There is %s directory', 'There are %s directories', 1)
+            with self.assertDeprecated('lngettext'):
+                x = lngettext('There is %s directory', 'There are %s directories', 1)
             self.assertEqual(x, 'There is %s directory'.encode('utf-16'))
-            x = lngettext('There is %s directory', 'There are %s directories', 2)
+            with self.assertDeprecated('lngettext'):
+                x = lngettext('There is %s directory', 'There are %s directories', 2)
             self.assertEqual(x, 'There are %s directories'.encode('utf-16'))
-            x = ldngettext('gettext', 'There is %s file', 'There are %s files', 1)
+            with self.assertDeprecated('ldngettext'):
+                x = ldngettext('gettext', 'There is %s file', 'There are %s files', 1)
             self.assertEqual(x, 'Hay %s fichero'.encode('utf-16'))
-            x = ldngettext('gettext', 'There is %s file', 'There are %s files', 2)
+            with self.assertDeprecated('ldngettext'):
+                x = ldngettext('gettext', 'There is %s file', 'There are %s files', 2)
             self.assertEqual(x, 'Hay %s ficheros'.encode('utf-16'))
-            x = ldngettext('gettext', 'There is %s directory', 'There are %s directories', 1)
+            with self.assertDeprecated('ldngettext'):
+                x = ldngettext('gettext', 'There is %s directory', 'There are %s directories', 1)
             self.assertEqual(x, 'There is %s directory'.encode('utf-16'))
-            x = ldngettext('gettext', 'There is %s directory', 'There are %s directories', 2)
+            with self.assertDeprecated('ldngettext'):
+                x = ldngettext('gettext', 'There is %s directory', 'There are %s directories', 2)
             self.assertEqual(x, 'There are %s directories'.encode('utf-16'))
         finally:
             del gettext._localecodesets['gettext']
-            gettext.bind_textdomain_codeset('gettext', saved_codeset)
+            with self.assertDeprecated('bind_textdomain_codeset'):
+                gettext.bind_textdomain_codeset('gettext', saved_codeset)
 
     def test_lngettext_output_encoding(self):
         with open(self.mofile, 'rb') as fp:
             t = gettext.GNUTranslations(fp)
         lngettext = t.lngettext
-        t.set_output_charset('utf-16')
-        x = lngettext('There is %s file', 'There are %s files', 1)
+        with self.assertDeprecated('set_output_charset'):
+            t.set_output_charset('utf-16')
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s file', 'There are %s files', 1)
         self.assertEqual(x, 'Hay %s fichero'.encode('utf-16'))
-        x = lngettext('There is %s file', 'There are %s files', 2)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s file', 'There are %s files', 2)
         self.assertEqual(x, 'Hay %s ficheros'.encode('utf-16'))
-        x = lngettext('There is %s directory', 'There are %s directories', 1)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s directory', 'There are %s directories', 1)
         self.assertEqual(x, 'There is %s directory'.encode('utf-16'))
-        x = lngettext('There is %s directory', 'There are %s directories', 2)
+        with self.assertDeprecated('lngettext'):
+            x = lngettext('There is %s directory', 'There are %s directories', 2)
         self.assertEqual(x, 'There are %s directories'.encode('utf-16'))
+
+    def test_output_encoding(self):
+        with open(self.mofile, 'rb') as fp:
+            t = gettext.GNUTranslations(fp)
+        with self.assertDeprecated('set_output_charset'):
+            t.set_output_charset('utf-16')
+        with self.assertDeprecated('output_charset'):
+            self.assertEqual(t.output_charset(), 'utf-16')
 
 
 class GNUTranslationParsingTest(GettextBaseTest):
@@ -642,6 +701,16 @@ class GettextCacheTestCase(GettextBaseTest):
         self.assertEqual(len(gettext._translations), 2)
         self.assertEqual(t.__class__, DummyGNUTranslations)
 
+        # Test deprecated parameter codeset
+        with self.assertWarnsRegex(DeprecationWarning, 'parameter codeset'):
+            t = gettext.translation('gettext', self.localedir,
+                                    class_=DummyGNUTranslations,
+                                    codeset='utf-16')
+        self.assertEqual(len(gettext._translations), 2)
+        self.assertEqual(t.__class__, DummyGNUTranslations)
+        with self.assertWarns(DeprecationWarning):
+            self.assertEqual(t.output_charset(), 'utf-16')
+
 
 class MiscTestCase(unittest.TestCase):
     def test__all__(self):
@@ -649,11 +718,8 @@ class MiscTestCase(unittest.TestCase):
         support.check__all__(self, gettext, blacklist=blacklist)
 
 
-def test_main():
-    support.run_unittest(__name__)
-
 if __name__ == '__main__':
-    test_main()
+    unittest.main()
 
 
 # For reference, here's the .po file used to created the GNU_MO_DATA above.

--- a/Misc/NEWS.d/next/Library/2018-10-26-21-12-55.bpo-33710.Q5oXc6.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-26-21-12-55.bpo-33710.Q5oXc6.rst
@@ -1,4 +1,4 @@
 Deprecated ``l*gettext()`` functions and methods in the :mod:`gettext`
 module. They return encoded bytes instead of Unicode strings and are
-artifacts from Python 2 times. Deprecated also functions and methods related
+artifacts from Python 2 times. Also deprecated functions and methods related
 to setting the charset for ``l*gettext()`` functions and methods.

--- a/Misc/NEWS.d/next/Library/2018-10-26-21-12-55.bpo-33710.Q5oXc6.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-26-21-12-55.bpo-33710.Q5oXc6.rst
@@ -1,0 +1,4 @@
+Deprecated ``l*gettext()`` functions and methods in the :mod:`gettext`
+module. They return encoded bytes instead of Unicode strings and are
+artifacts from Python 2 times. Deprecated also functions and methods related
+to setting the charset for ``l*gettext()`` functions and methods.


### PR DESCRIPTION
They return encoded bytes and are Python 2 artifacts.


<!-- issue-number: [bpo-33710](https://bugs.python.org/issue33710) -->
https://bugs.python.org/issue33710
<!-- /issue-number -->
