### PR TITLE
[2.7] unittest documentation: Spell pytest without the dot (GH-9820)

### DIFF
--- a/Doc/library/unittest.rst
+++ b/Doc/library/unittest.rst
@@ -87,7 +87,7 @@ need to derive from a specific class.
       Kent Beck's original paper on testing frameworks using the pattern shared
       by :mod:`unittest`.
 
-   `Nose <https://nose.readthedocs.org/en/latest/>`_ and `py.test <http://pytest.org>`_
+   `Nose <https://nose.readthedocs.io/>`_ and `pytest <https://docs.pytest.org/>`_
       Third-party unittest frameworks with a lighter-weight syntax for writing
       tests.  For example, ``assert func(10) == 42``.
 


### PR DESCRIPTION
Referring to ``pytest`` as ``py.test`` is deprecated..
(cherry picked from commit d855f2fdbd73016ece9b58e6f6ac26cf986fabf6)

Co-authored-by: Andreas Pelme <andreas@pelme.se>