### PR TITLE
bpo-14856: Deprecate using add_parser() to overwrite an existing subparser

### DIFF
--- a/Doc/whatsnew/3.8.rst
+++ b/Doc/whatsnew/3.8.rst
@@ -312,6 +312,10 @@ Deprecated
 
   (Contributed by Serhiy Storchaka in :issue:`33710`.)
 
+* Using :meth:`~argparser._SubParsersAction.add_parser` to overwrite an existing
+  subparser is deprecated and will be prohibited in Python 3.9.
+  (Contributed by Braden Groom in :issue:`14856`.)
+
 
 Removed
 =======

--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1097,6 +1097,20 @@ class _SubParsersAction(Action):
             metavar=metavar)
 
     def add_parser(self, name, **kwargs):
+        import warnings
+        if name in self._name_parser_map:
+            warnings.warn('using add_parser() to overwrite an existing '
+                          'subparser is deprecated, use set_parser() instead',
+                          DeprecationWarning, 2)
+        aliases = kwargs.get('aliases', [])
+        for alias in aliases:
+            if alias in self._name_parser_map:
+                warnings.warn('using add_parser() to overwrite an existing '
+                              'subparser is deprecated, use set_parser() instead',
+                              DeprecationWarning, 2)
+        return self.set_parser(name, **kwargs)
+
+    def set_parser(self, name, **kwargs):
         # set prog from the existing prefix
         if kwargs.get('prog') is None:
             kwargs['prog'] = '%s %s' % (self._prog_prefix, name)

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -2149,6 +2149,18 @@ class TestAddSubparsers(TestCase):
                 3                   3 help
             """))
 
+    def test_warn_already_defined_subparser(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers()
+        subparsers.add_parser('foo')
+        self.assertWarns(DeprecationWarning, subparsers.add_parser, 'foo')
+
+    def test_warn_already_defined_alias(self):
+        parser = ErrorRaisingArgumentParser()
+        subparsers = parser.add_subparsers()
+        subparsers.add_parser('foo')
+        self.assertWarns(DeprecationWarning, subparsers.add_parser, 'bar', aliases=['foo'])
+
 # ============
 # Groups tests
 # ============

--- a/Misc/NEWS.d/next/Library/2018-10-27-17-13-25.bpo-14856.F4DJr3.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-27-17-13-25.bpo-14856.F4DJr3.rst
@@ -1,0 +1,2 @@
+Deprecate using add_parser() to overwrite an existing subparser.
+Patch by Braden Groom


### PR DESCRIPTION


<!-- issue-number: [bpo-14856](https://bugs.python.org/issue14856) -->
https://bugs.python.org/issue14856
<!-- /issue-number -->
