### PR TITLE
bpo-35086: Fix tkinter docs A Simple Hello World Program

### DIFF
--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -205,6 +205,7 @@ A Simple Hello World Program
     class Application(tk.Frame):
         def __init__(self, master=None):
             super().__init__(master)
+            self.master = master
             self.pack()
             self.create_widgets()
 
@@ -215,7 +216,7 @@ A Simple Hello World Program
             self.hi_there.pack(side="top")
 
             self.quit = tk.Button(self, text="QUIT", fg="red",
-                                  command=root.destroy)
+                                  command=self.master.destroy)
             self.quit.pack(side="bottom")
 
         def say_hi(self):


### PR DESCRIPTION
Application class does not hold onto the master Tk() instance as a class attribute. This is a good practice, and newcomers to tkinter would likely have trouble closing the window without this since root will almost never be in the global namespace.

<!-- issue-number: [bpo-35086](https://bugs.python.org/issue35086) -->
https://bugs.python.org/issue35086
<!-- /issue-number -->
