### PR TITLE
bpo-34160: Preserve user specified order of Element attributes

### DIFF
--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -489,6 +489,10 @@ Functions
 
    *elem* is an element tree or an individual element.
 
+   .. versionchanged:: 3.8
+      The :func:`dump` function now preserves the attribute order specified
+      by the user.
+
 
 .. function:: fromstring(text)
 
@@ -946,6 +950,10 @@ ElementTree Objects
 
       .. versionadded:: 3.4
          The *short_empty_elements* parameter.
+
+      .. versionchanged:: 3.8
+         The :meth:`write` method now preserves the attribute order specified
+         by the user.
 
 
 This is the XML file that is going to be manipulated::

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -5,6 +5,7 @@
 # For this purpose, the module-level "ET" symbol is temporarily
 # monkey-patched when running the "test_xml_etree_c" test suite.
 
+import contextlib
 import copy
 import functools
 import html
@@ -1056,18 +1057,12 @@ class ElementTreeTest(unittest.TestCase):
         # See BPO 34160
         root = ET.Element('cirriculum', status='public', company='example')
         tree = ET.ElementTree(root)
-        try:
-            fo = open(support.TESTFN, "wb")
-            tree.write(fo, encoding='utf-8', xml_declaration=True)
-            fo.close()
-            fo = open(support.TESTFN, "r")
-            text = fo.read()
-        finally:
-            fo.close()
-            support.unlink(support.TESTFN)
-        self.assertEqual(text,
-                         "<?xml version='1.0' encoding='utf-8'?>\n"
-                         '<cirriculum status="public" company="example" />')
+        f = io.BytesIO()
+        with contextlib.redirect_stdout(f):
+            tree.write(f, encoding='utf-8', xml_declaration=True)
+        self.assertEqual(f.getvalue(),
+                         b"<?xml version='1.0' encoding='utf-8'?>\n"
+                         b'<cirriculum status="public" company="example" />')
 
 
 class XMLPullParserTest(unittest.TestCase):

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1044,6 +1044,31 @@ class ElementTreeTest(unittest.TestCase):
                                        method='html')
                 self.assertEqual(serialized, expected)
 
+    def test_dump_attribute_order(self):
+        # See BPO 34160
+        e = ET.Element('cirriculum', status='public', company='example')
+        with support.captured_stdout() as stdout:
+            ET.dump(e)
+        self.assertEqual(stdout.getvalue(),
+                         '<cirriculum status="public" company="example" />\n')
+
+    def test_tree_write_attribute_order(self):
+        # See BPO 34160
+        root = ET.Element('cirriculum', status='public', company='example')
+        tree = ET.ElementTree(root)
+        try:
+            fo = open(support.TESTFN, "wb")
+            tree.write(fo, encoding='utf-8', xml_declaration=True)
+            fo.close()
+            fo = open(support.TESTFN, "r")
+            text = fo.read()
+        finally:
+            fo.close()
+            support.unlink(support.TESTFN)
+        self.assertEqual(text,
+                         "<?xml version='1.0' encoding='utf-8'?>\n"
+                         '<cirriculum status="public" company="example" />')
+
 
 class XMLPullParserTest(unittest.TestCase):
 

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -923,7 +923,7 @@ def _serialize_xml(write, elem, qnames, namespaces,
                             k,
                             _escape_attrib(v)
                             ))
-                for k, v in items:  # lexical order
+                for k, v in items:
                     if isinstance(k, QName):
                         k = k.text
                     if isinstance(v, QName):

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -923,7 +923,7 @@ def _serialize_xml(write, elem, qnames, namespaces,
                             k,
                             _escape_attrib(v)
                             ))
-                for k, v in sorted(items):  # lexical order
+                for k, v in items:  # lexical order
                     if isinstance(k, QName):
                         k = k.text
                     if isinstance(v, QName):

--- a/Misc/NEWS.d/next/Library/2018-10-27-21-11-42.bpo-34160.UzyPZf.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-27-21-11-42.bpo-34160.UzyPZf.rst
@@ -1,0 +1,1 @@
+ElementTree now preserves the attribute order specified by the user.


### PR DESCRIPTION
Minidom should also be fixed but that can be done in a separate PR.

<!-- issue-number: [bpo-34160](https://bugs.python.org/issue34160) -->
https://bugs.python.org/issue34160
<!-- /issue-number -->
