### PR TITLE
bpo-35090: Fix potential division by zero and integer overflow in allocator wrappers

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-10-28-17-25-24.bpo-35090.oMjlmF.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-28-17-25-24.bpo-35090.oMjlmF.rst
@@ -1,0 +1,2 @@
+:mod:`bz2`: Avoid division by zero in ``BZ2_Malloc()`` in case if
+``size == 0``.

--- a/Misc/NEWS.d/next/Library/2018-10-28-17-25-24.bpo-35090.oMjlmF.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-28-17-25-24.bpo-35090.oMjlmF.rst
@@ -1,2 +1,0 @@
-:mod:`bz2`: Avoid division by zero in ``BZ2_Malloc()`` in case if
-``size == 0``.

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -277,7 +277,7 @@ BZ2_Malloc(void* ctx, int items, int size)
 {
     if (items < 0 || size < 0)
         return NULL;
-    if ((size_t)items > (size_t)PY_SSIZE_T_MAX / (size_t)size)
+    if (size != 0 && (size_t)items > (size_t)PY_SSIZE_T_MAX / (size_t)size)
         return NULL;
     /* PyMem_Malloc() cannot be used: compress() and decompress()
        release the GIL */

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -281,7 +281,7 @@ BZ2_Malloc(void* ctx, int items, int size)
         return NULL;
     /* PyMem_Malloc() cannot be used: compress() and decompress()
        release the GIL */
-    return PyMem_RawMalloc((Py_ssize_t)items * (Py_ssize_t)size);
+    return PyMem_RawMalloc((size_t)items * (size_t)size);
 }
 
 static void

--- a/Modules/_bz2module.c
+++ b/Modules/_bz2module.c
@@ -281,7 +281,7 @@ BZ2_Malloc(void* ctx, int items, int size)
         return NULL;
     /* PyMem_Malloc() cannot be used: compress() and decompress()
        release the GIL */
-    return PyMem_RawMalloc(items * size);
+    return PyMem_RawMalloc((Py_ssize_t)items * (Py_ssize_t)size);
 }
 
 static void

--- a/Modules/_lzmamodule.c
+++ b/Modules/_lzmamodule.c
@@ -108,7 +108,7 @@ catch_lzma_error(lzma_ret lzret)
 static void*
 PyLzma_Malloc(void *opaque, size_t items, size_t size)
 {
-    if (items > (size_t)PY_SSIZE_T_MAX / size)
+    if (size != 0 && items > (size_t)PY_SSIZE_T_MAX / size)
         return NULL;
     /* PyMem_Malloc() cannot be used:
        the GIL is not held when lzma_code() is called */

--- a/Modules/zlibmodule.c
+++ b/Modules/zlibmodule.c
@@ -117,11 +117,11 @@ newcompobject(PyTypeObject *type)
 static void*
 PyZlib_Malloc(voidpf ctx, uInt items, uInt size)
 {
-    if (items > (size_t)PY_SSIZE_T_MAX / size)
+    if (size != 0 && items > (size_t)PY_SSIZE_T_MAX / size)
         return NULL;
     /* PyMem_Malloc() cannot be used: the GIL is not held when
        inflate() and deflate() are called */
-    return PyMem_RawMalloc(items * size);
+    return PyMem_RawMalloc((size_t)items * (size_t)size);
 }
 
 static void


### PR DESCRIPTION
Reported by Svace static analyzer.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35090](https://bugs.python.org/issue35090) -->
https://bugs.python.org/issue35090
<!-- /issue-number -->
