### PR TITLE
bpo-35091: Objects/listobject.c: Don't rely on signed int overflow in…

### DIFF
--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1358,9 +1358,11 @@ gallop_left(MergeState *ms, PyObject *key, PyObject **a, Py_ssize_t n, Py_ssize_
         while (ofs < maxofs) {
             IFLT(a[ofs], key) {
                 lastofs = ofs;
-                ofs = (ofs << 1) + 1;
-                if (ofs <= 0)                   /* int overflow */
+                if (ofs <= (PY_SSIZE_T_MAX - 1) >> 1) {
+                    ofs = (ofs << 1) + 1;
+                } else {
                     ofs = maxofs;
+                }
             }
             else                /* key <= a[hint + ofs] */
                 break;
@@ -1381,9 +1383,11 @@ gallop_left(MergeState *ms, PyObject *key, PyObject **a, Py_ssize_t n, Py_ssize_
                 break;
             /* key <= a[hint - ofs] */
             lastofs = ofs;
-            ofs = (ofs << 1) + 1;
-            if (ofs <= 0)               /* int overflow */
+            if (ofs <= (PY_SSIZE_T_MAX - 1) >> 1) {
+                ofs = (ofs << 1) + 1;
+            } else {
                 ofs = maxofs;
+            }
         }
         if (ofs > maxofs)
             ofs = maxofs;
@@ -1449,9 +1453,11 @@ gallop_right(MergeState *ms, PyObject *key, PyObject **a, Py_ssize_t n, Py_ssize
         while (ofs < maxofs) {
             IFLT(key, *(a-ofs)) {
                 lastofs = ofs;
-                ofs = (ofs << 1) + 1;
-                if (ofs <= 0)                   /* int overflow */
+                if (ofs <= (PY_SSIZE_T_MAX - 1) >> 1) {
+                    ofs = (ofs << 1) + 1;
+                } else {
                     ofs = maxofs;
+                }
             }
             else                /* a[hint - ofs] <= key */
                 break;
@@ -1473,9 +1479,11 @@ gallop_right(MergeState *ms, PyObject *key, PyObject **a, Py_ssize_t n, Py_ssize
                 break;
             /* a[hint + ofs] <= key */
             lastofs = ofs;
-            ofs = (ofs << 1) + 1;
-            if (ofs <= 0)               /* int overflow */
+            if (ofs <= (PY_SSIZE_T_MAX - 1) >> 1) {
+                ofs = (ofs << 1) + 1;
+            } else {
                 ofs = maxofs;
+            }
         }
         if (ofs > maxofs)
             ofs = maxofs;


### PR DESCRIPTION
… gallop functions

Signed integer overflow is undefined behavior.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35091](https://bugs.python.org/issue35091) -->
https://bugs.python.org/issue35091
<!-- /issue-number -->
