### PR TITLE
bpo-34672: fix a compiler warning in timemodule.c

### DIFF
--- a/Modules/timemodule.c
+++ b/Modules/timemodule.c
@@ -570,7 +570,7 @@ gettmarg(PyObject *args, struct tm *p, const char *format)
         PyObject *item;
         item = PyTuple_GET_ITEM(args, 9);
         if (item != Py_None) {
-            p->tm_zone = PyUnicode_AsUTF8(item);
+            p->tm_zone = (char *)PyUnicode_AsUTF8(item);
             if (p->tm_zone == NULL) {
                 return 0;
             }


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

> ./Modules/timemodule.c:573:24: warning: assigning to 'char *' from 'const char *' discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
>             p->tm_zone = PyUnicode_AsUTF8(item);
>                        ^ ~~~~~~~~~~~~~~~~~~~~~~
> 1 warning generated.

<!-- issue-number: [bpo-34672](https://bugs.python.org/issue34672) -->
https://bugs.python.org/issue34672
<!-- /issue-number -->
