### PR TITLE
[2.7] bpo-34794: Fix a leak in Tkinter. (GH-10025)

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-10-21-14-53-19.bpo-34794.yt3R4-.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-21-14-53-19.bpo-34794.yt3R4-.rst
@@ -1,0 +1,2 @@
+Fixed a leak in Tkinter when pass the Python wrapper around Tcl_Obj back to
+Tcl/Tk.

--- a/Modules/_tkinter.c
+++ b/Modules/_tkinter.c
@@ -1205,10 +1205,8 @@ AsObj(PyObject *value)
     }
 #endif
 
-    if(PyTclObject_Check(value)) {
-        Tcl_Obj *v = ((PyTclObject*)value)->value;
-        Tcl_IncrRefCount(v);
-        return v;
+    if (PyTclObject_Check(value)) {
+        return ((PyTclObject*)value)->value;
     }
 
     {


### PR DESCRIPTION
Based on the investigation by Xiang Zhang.
(cherry picked from commit df13df41a25765d8a39a77220691698498e758d4)


<!-- issue-number: [bpo-34794](https://bugs.python.org/issue34794) -->
https://bugs.python.org/issue34794
<!-- /issue-number -->
