### PR TITLE
[3.6] bpo-35054: Add yet more index entries for symbols. (GH-10121).

### DIFF
--- a/Doc/library/argparse.rst
+++ b/Doc/library/argparse.rst
@@ -844,6 +844,8 @@ values are:
   Note that ``nargs=1`` produces a list of one item.  This is different from
   the default, in which the item is produced by itself.
 
+.. index:: single: ? (question mark); in argparse module
+
 * ``'?'``. One argument will be consumed from the command line if possible, and
   produced as a single item.  If no command-line argument is present, the value from
   default_ will be produced.  Note that for optional arguments, there is an
@@ -876,6 +878,8 @@ values are:
      Namespace(infile=<_io.TextIOWrapper name='<stdin>' encoding='UTF-8'>,
                outfile=<_io.TextIOWrapper name='<stdout>' encoding='UTF-8'>)
 
+.. index:: single: * (asterisk); in argparse module
+
 * ``'*'``.  All command-line arguments present are gathered into a list.  Note that
   it generally doesn't make much sense to have more than one positional argument
   with ``nargs='*'``, but multiple optional arguments with ``nargs='*'`` is
@@ -887,6 +891,8 @@ values are:
      >>> parser.add_argument('baz', nargs='*')
      >>> parser.parse_args('a b --foo x y --bar 1 2'.split())
      Namespace(bar=['1', '2'], baz=['a', 'b'], foo=['x', 'y'])
+
+.. index:: single: + (plus); in argparse module
 
 * ``'+'``. Just like ``'*'``, all command-line args present are gathered into a
   list.  Additionally, an error message will be generated if there wasn't at

--- a/Doc/library/ast.rst
+++ b/Doc/library/ast.rst
@@ -41,6 +41,9 @@ Node classes
    with alternatives (aka "sums"), the left-hand side class is abstract: only
    instances of specific constructor nodes are ever created.
 
+   .. index:: single: ? (question mark); in AST grammar
+   .. index:: single: * (asterisk); in AST grammar
+
    .. attribute:: _fields
 
       Each concrete class has an attribute :attr:`_fields` which gives the names

--- a/Doc/library/cmd.rst
+++ b/Doc/library/cmd.rst
@@ -61,6 +61,10 @@ A :class:`Cmd` instance has the following methods:
 
    An end-of-file on input is passed back as the string ``'EOF'``.
 
+   .. index::
+      single: ? (question mark); in a command interpreter
+      single: ! (exclamation); in a command interpreter
+
    An interpreter instance will recognize a command name ``foo`` if and only if it
    has a method :meth:`do_foo`.  As a special case, a line beginning with the
    character ``'?'`` is dispatched to the method :meth:`do_help`.  As another

--- a/Doc/library/codecs.rst
+++ b/Doc/library/codecs.rst
@@ -312,6 +312,14 @@ defined and implemented by all standard Python codecs:
 The following error handlers are only applicable to
 :term:`text encodings <text encoding>`:
 
+.. index::
+   single: ? (question mark); replacement character
+   single: \ (backslash); escape sequence
+   single: \x; escape sequence
+   single: \u; escape sequence
+   single: \U; escape sequence
+   single: \N; escape sequence
+
 +-------------------------+-----------------------------------------------+
 | Value                   | Meaning                                       |
 +=========================+===============================================+

--- a/Doc/library/configparser.rst
+++ b/Doc/library/configparser.rst
@@ -291,7 +291,7 @@ On top of the core functionality, :class:`ConfigParser` supports
 interpolation.  This means values can be preprocessed before returning them
 from ``get()`` calls.
 
-.. index:: single: %; interpolation in configuration files
+.. index:: single: % (percent); interpolation in configuration files
 
 .. class:: BasicInterpolation()
 
@@ -321,7 +321,7 @@ from ``get()`` calls.
    ``%(my_dir)s/Pictures`` as the value of ``my_pictures`` and
    ``%(home_dir)s/lumberjack`` as the value of ``my_dir``.
 
-.. index:: single: $; interpolation in configuration files
+.. index:: single: $ (dollar); interpolation in configuration files
 
 .. class:: ExtendedInterpolation()
 

--- a/Doc/library/curses.ascii.rst
+++ b/Doc/library/curses.ascii.rst
@@ -207,6 +207,10 @@ The following function takes either a single-character string or integer value;
 it returns a string.
 
 
+.. index::
+   single: ^ (caret); in curses module
+   single: ! (exclamation); in curses module
+
 .. function:: unctrl(c)
 
    Return a string representation of the ASCII character *c*.  If *c* is printable,

--- a/Doc/library/datetime.rst
+++ b/Doc/library/datetime.rst
@@ -1928,7 +1928,7 @@ Class attributes:
 
 
 .. index::
-   single: %; datetime format
+   single: % (percent); datetime format
 
 .. _strftime-strptime-behavior:
 

--- a/Doc/library/doctest.rst
+++ b/Doc/library/doctest.rst
@@ -485,7 +485,7 @@ Some details you should read once, but won't need to remember:
   to test a :exc:`SyntaxError` that omits the traceback header, you will need to
   manually add the traceback header line to your test example.
 
-.. index:: single: ^; caret
+.. index:: single: ^ (caret); marker
 
 * For some :exc:`SyntaxError`\ s, Python displays the character position of the
   syntax error, using a ``^`` marker::
@@ -695,9 +695,9 @@ useful unless you intend to extend :mod:`doctest` internals via subclassing:
 
 
 .. index::
-   single: #; in doctests
-   single: +; in doctests
-   single: -; in doctests
+   single: # (hash); in doctests
+   single: + (plus); in doctests
+   single: - (minus); in doctests
 .. _doctest-directives:
 
 Directives

--- a/Doc/library/fnmatch.rst
+++ b/Doc/library/fnmatch.rst
@@ -16,6 +16,13 @@ This module provides support for Unix shell-style wildcards, which are *not* the
 same as regular expressions (which are documented in the :mod:`re` module).  The
 special characters used in shell-style wildcards are:
 
+.. index::
+   single: * (asterisk); in glob-style wildcards
+   single: ? (question mark); in glob-style wildcards
+   single: [] (square brackets); in glob-style wildcards
+   single: ! (exclamation); in glob-style wildcards
+   single: - (minus); in glob-style wildcards
+
 +------------+------------------------------------+
 | Pattern    | Meaning                            |
 +============+====================================+

--- a/Doc/library/gettext.rst
+++ b/Doc/library/gettext.rst
@@ -61,7 +61,7 @@ class-based API instead.
    *domain*, which is returned.
 
 
-.. index:: single: _; gettext
+.. index:: single: _ (underscore); gettext
 .. function:: gettext(message)
 
    Return the localized translation of *message*, based on the current global

--- a/Doc/library/glob.rst
+++ b/Doc/library/glob.rst
@@ -10,6 +10,14 @@
 
 --------------
 
+.. index::
+   single: * (asterisk); in glob-style wildcards
+   single: ? (question mark); in glob-style wildcards
+   single: [] (square brackets); in glob-style wildcards
+   single: ! (exclamation); in glob-style wildcards
+   single: - (minus); in glob-style wildcards
+   single: . (dot); in glob-style wildcards
+
 The :mod:`glob` module finds all the pathnames matching a specified pattern
 according to the rules used by the Unix shell, although results are returned in
 arbitrary order.  No tilde expansion is done, but ``*``, ``?``, and character
@@ -35,6 +43,9 @@ For example, ``'[?]'`` matches the character ``'?'``.
    (like :file:`/usr/src/Python-1.5/Makefile`) or relative (like
    :file:`../../Tools/\*/\*.gif`), and can contain shell-style wildcards. Broken
    symlinks are included in the results (as in the shell).
+
+   .. index::
+      single: **; in glob-style wildcards
 
    If *recursive* is true, the pattern "``**``" will match any files and zero or
    more directories and subdirectories.  If the pattern is followed by an

--- a/Doc/library/os.path.rst
+++ b/Doc/library/os.path.rst
@@ -152,7 +152,7 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 
-.. index:: single: ~; home directory expansion
+.. index:: single: ~ (tilde); home directory expansion
 
 .. function:: expanduser(path)
 
@@ -178,8 +178,8 @@ the :mod:`glob` module.)
       Accepts a :term:`path-like object`.
 
 .. index::
-   single: $; environment variables expansion
-   single: %; environment variables expansion (Windows)
+   single: $ (dollar); environment variables expansion
+   single: % (percent); environment variables expansion (Windows)
 
 .. function:: expandvars(path)
 

--- a/Doc/library/os.rst
+++ b/Doc/library/os.rst
@@ -3867,7 +3867,7 @@ are defined for all platforms.
 Higher-level operations on pathnames are defined in the :mod:`os.path` module.
 
 
-.. index:: single: .; in pathnames
+.. index:: single: . (dot); in pathnames
 .. data:: curdir
 
    The constant string used by the operating system to refer to the current
@@ -3883,8 +3883,8 @@ Higher-level operations on pathnames are defined in the :mod:`os.path` module.
    :mod:`os.path`.
 
 
-.. index:: single: /; in pathnames
-.. index:: single: \; in pathnames (Windows)
+.. index:: single: / (slash); in pathnames
+.. index:: single: \ (backslash); in pathnames (Windows)
 .. data:: sep
 
    The character used by the operating system to separate pathname components.
@@ -3894,7 +3894,7 @@ Higher-level operations on pathnames are defined in the :mod:`os.path` module.
    useful. Also available via :mod:`os.path`.
 
 
-.. index:: single: /; in pathnames
+.. index:: single: / (slash); in pathnames
 .. data:: altsep
 
    An alternative character used by the operating system to separate pathname
@@ -3903,14 +3903,15 @@ Higher-level operations on pathnames are defined in the :mod:`os.path` module.
    :mod:`os.path`.
 
 
-.. index:: single: .; in pathnames
+.. index:: single: . (dot); in pathnames
 .. data:: extsep
 
    The character which separates the base filename from the extension; for example,
    the ``'.'`` in :file:`os.py`. Also available via :mod:`os.path`.
 
 
-.. index:: single: :; path separator (POSIX)
+.. index:: single: : (colon); path separator (POSIX)
+   single: ; (semicolon)
 .. data:: pathsep
 
    The character conventionally used by the operating system to separate search

--- a/Doc/library/re.rst
+++ b/Doc/library/re.rst
@@ -93,20 +93,20 @@ the expression ``(?:a{6})*`` matches any multiple of six ``'a'`` characters.
 
 The special characters are:
 
-.. index:: single: .; in regular expressions
+.. index:: single: . (dot); in regular expressions
 
 ``.``
    (Dot.)  In the default mode, this matches any character except a newline.  If
    the :const:`DOTALL` flag has been specified, this matches any character
    including a newline.
 
-.. index:: single: ^; in regular expressions
+.. index:: single: ^ (caret); in regular expressions
 
 ``^``
    (Caret.)  Matches the start of the string, and in :const:`MULTILINE` mode also
    matches immediately after each newline.
 
-.. index:: single: $; in regular expressions
+.. index:: single: $ (dollar); in regular expressions
 
 ``$``
    Matches the end of the string or just before the newline at the end of the
@@ -117,21 +117,21 @@ The special characters are:
    a single ``$`` in ``'foo\n'`` will find two (empty) matches: one just before
    the newline, and one at the end of the string.
 
-.. index:: single: *; in regular expressions
+.. index:: single: * (asterisk); in regular expressions
 
 ``*``
    Causes the resulting RE to match 0 or more repetitions of the preceding RE, as
    many repetitions as are possible.  ``ab*`` will match 'a', 'ab', or 'a' followed
    by any number of 'b's.
 
-.. index:: single: +; in regular expressions
+.. index:: single: + (plus); in regular expressions
 
 ``+``
    Causes the resulting RE to match 1 or more repetitions of the preceding RE.
    ``ab+`` will match 'a' followed by any non-zero number of 'b's; it will not
    match just 'a'.
 
-.. index:: single: ?; in regular expressions
+.. index:: single: ? (question mark); in regular expressions
 
 ``?``
    Causes the resulting RE to match 0 or 1 repetitions of the preceding RE.
@@ -152,8 +152,7 @@ The special characters are:
    only ``'<a>'``.
 
 .. index::
-   single: {; in regular expressions
-   single: }; in regular expressions
+   single: {} (curly brackets); in regular expressions
 
 ``{m}``
    Specifies that exactly *m* copies of the previous RE should be matched; fewer
@@ -176,7 +175,7 @@ The special characters are:
    6-character string ``'aaaaaa'``, ``a{3,5}`` will match 5 ``'a'`` characters,
    while ``a{3,5}?`` will only match 3 characters.
 
-.. index:: single: \; in regular expressions
+.. index:: single: \ (backslash); in regular expressions
 
 ``\``
    Either escapes special characters (permitting you to match characters like
@@ -192,8 +191,7 @@ The special characters are:
    raw strings for all but the simplest expressions.
 
 .. index::
-   single: [; in regular expressions
-   single: ]; in regular expressions
+   single: [] (square brackets); in regular expressions
 
 ``[]``
    Used to indicate a set of characters.  In a set:
@@ -201,7 +199,7 @@ The special characters are:
    * Characters can be listed individually, e.g. ``[amk]`` will match ``'a'``,
      ``'m'``, or ``'k'``.
 
-   .. index:: single: -; in regular expressions
+   .. index:: single: - (minus); in regular expressions
 
    * Ranges of characters can be indicated by giving two characters and separating
      them by a ``'-'``, for example ``[a-z]`` will match any lowercase ASCII letter,
@@ -214,13 +212,13 @@ The special characters are:
      ``[(+*)]`` will match any of the literal characters ``'('``, ``'+'``,
      ``'*'``, or ``')'``.
 
-   .. index:: single: \; in regular expressions
+   .. index:: single: \ (backslash); in regular expressions
 
    * Character classes such as ``\w`` or ``\S`` (defined below) are also accepted
      inside a set, although the characters they match depends on whether
      :const:`ASCII` or :const:`LOCALE` mode is in force.
 
-   .. index:: single: ^; in regular expressions
+   .. index:: single: ^ (caret); in regular expressions
 
    * Characters that are not within a range can be matched by :dfn:`complementing`
      the set.  If the first character of the set is ``'^'``, all the characters
@@ -233,7 +231,7 @@ The special characters are:
      place it at the beginning of the set.  For example, both ``[()[\]{}]`` and
      ``[]()[{}]`` will both match a parenthesis.
 
-.. index:: single: |; in regular expressions
+.. index:: single: | (vertical bar); in regular expressions
 
 ``|``
    ``A|B``, where *A* and *B* can be arbitrary REs, creates a regular expression that
@@ -247,8 +245,7 @@ The special characters are:
    character class, as in ``[|]``.
 
 .. index::
-   single: (; in regular expressions
-   single: ); in regular expressions
+   single: () (parentheses); in regular expressions
 
 ``(...)``
    Matches whatever regular expression is inside the parentheses, and indicates the
@@ -398,7 +395,7 @@ If the ordinary character is not an ASCII digit or an ASCII letter, then the
 resulting RE will match the second character.  For example, ``\$`` matches the
 character ``'$'``.
 
-.. index:: single: \; in regular expressions
+.. index:: single: \ (backslash); in regular expressions
 
 ``\number``
    Matches the contents of the group of the same number.  Groups are numbered
@@ -690,7 +687,7 @@ form.
 .. data:: X
           VERBOSE
 
-   .. index:: single: #; in regular expressions
+   .. index:: single: # (hash); in regular expressions
 
    This flag allows you to write regular expressions that look nicer and are
    more readable by allowing you to visually separate logical sections of the

--- a/Doc/library/site.rst
+++ b/Doc/library/site.rst
@@ -50,7 +50,7 @@ the key "include-system-site-packages" set to anything other than "false"
 searched for site-packages; otherwise they won't.
 
 .. index::
-   single: #; comment
+   single: # (hash); comment
    statement: import
 
 A path configuration file is a file whose name has the form :file:`{name}.pth`

--- a/Doc/library/sqlite3.rst
+++ b/Doc/library/sqlite3.rst
@@ -534,6 +534,9 @@ Cursor Objects
 
    A :class:`Cursor` instance has the following attributes and methods.
 
+   .. index:: single: ? (question mark); in SQL statements
+   .. index:: single: : (colon); in SQL statements
+
    .. method:: execute(sql[, parameters])
 
       Executes an SQL statement. The SQL statement may be parameterized (i. e.

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -123,9 +123,9 @@ Comparisons
    pair: chaining; comparisons
    pair: operator; comparison
    operator: ==
-   operator: <
+   operator: < (less)
    operator: <=
-   operator: >
+   operator: > (greater)
    operator: >=
    operator: !=
    operator: is
@@ -248,16 +248,16 @@ and imaginary parts.
    builtin: int
    builtin: float
    builtin: complex
-   single: operator; +
-   single: +; unary operator
-   single: +; binary operator
-   single: operator; -
-   single: -; unary operator
-   single: -; binary operator
-   operator: *
-   operator: /
+   single: operator; + (plus)
+   single: + (plus); unary operator
+   single: + (plus); binary operator
+   single: operator; - (minus)
+   single: - (minus); unary operator
+   single: - (minus); binary operator
+   operator: * (asterisk)
+   operator: / (slash)
    operator: //
-   operator: %
+   operator: % (percent)
    operator: **
 
 Python fully supports mixed arithmetic: when a binary arithmetic operator has
@@ -393,12 +393,12 @@ Bitwise Operations on Integer Types
    pair: bitwise; operations
    pair: shifting; operations
    pair: masking; operations
-   operator: |
-   operator: ^
-   operator: &
+   operator: | (vertical bar)
+   operator: ^ (caret)
+   operator: & (ampersand)
    operator: <<
    operator: >>
-   operator: ~
+   operator: ~ (tilde)
 
 Bitwise operations only make sense for integers. The result of bitwise
 operations is calculated as though carried out in two's complement with an
@@ -2091,7 +2091,7 @@ expression support in the :mod:`re` module).
    single: string; interpolation, printf
    single: printf-style formatting
    single: sprintf-style formatting
-   single: %; printf-style formatting
+   single: % (percent); printf-style formatting
 
 .. note::
 
@@ -2119,8 +2119,7 @@ components, which must occur in this order:
 #. The ``'%'`` character, which marks the start of the specifier.
 
 .. index::
-   single: (; in printf-style formatting
-   single: ); in printf-style formatting
+   single: () (parentheses); in printf-style formatting
 
 #. Mapping key (optional), consisting of a parenthesised sequence of characters
    (for example, ``(somename)``).
@@ -2128,13 +2127,13 @@ components, which must occur in this order:
 #. Conversion flags (optional), which affect the result of some conversion
    types.
 
-.. index:: single: *; in printf-style formatting
+.. index:: single: * (asterisk); in printf-style formatting
 
 #. Minimum field width (optional).  If specified as an ``'*'`` (asterisk), the
    actual width is read from the next element of the tuple in *values*, and the
    object to convert comes after the minimum field width and optional precision.
 
-.. index:: single: .; in printf-style formatting
+.. index:: single: . (dot); in printf-style formatting
 
 #. Precision (optional), given as a ``'.'`` (dot) followed by the precision.  If
    specified as ``'*'`` (an asterisk), the actual precision is read from the next
@@ -2160,9 +2159,9 @@ sequential parameter list).
 The conversion flag characters are:
 
 .. index::
-   single: #; in printf-style formatting
-   single: -; in printf-style formatting
-   single: +; in printf-style formatting
+   single: # (hash); in printf-style formatting
+   single: - (minus); in printf-style formatting
+   single: + (plus); in printf-style formatting
    single: space; in printf-style formatting
 
 +---------+---------------------------------------------------------------------+
@@ -3209,7 +3208,7 @@ place, and instead produce new objects.
    single: bytearray; interpolation
    single: printf-style formatting
    single: sprintf-style formatting
-   single: %; printf-style formatting
+   single: % (percent); printf-style formatting
 
 .. note::
 
@@ -3236,8 +3235,7 @@ components, which must occur in this order:
 #. The ``'%'`` character, which marks the start of the specifier.
 
 .. index::
-   single: (; in printf-style formatting
-   single: ); in printf-style formatting
+   single: () (parentheses); in printf-style formatting
 
 #. Mapping key (optional), consisting of a parenthesised sequence of characters
    (for example, ``(somename)``).
@@ -3245,13 +3243,13 @@ components, which must occur in this order:
 #. Conversion flags (optional), which affect the result of some conversion
    types.
 
-.. index:: single: *; in printf-style formatting
+.. index:: single: * (asterisk); in printf-style formatting
 
 #. Minimum field width (optional).  If specified as an ``'*'`` (asterisk), the
    actual width is read from the next element of the tuple in *values*, and the
    object to convert comes after the minimum field width and optional precision.
 
-.. index:: single: .; in printf-style formatting
+.. index:: single: . (dot); in printf-style formatting
 
 #. Precision (optional), given as a ``'.'`` (dot) followed by the precision.  If
    specified as ``'*'`` (an asterisk), the actual precision is read from the next
@@ -3277,9 +3275,9 @@ sequential parameter list).
 The conversion flag characters are:
 
 .. index::
-   single: #; in printf-style formatting
-   single: -; in printf-style formatting
-   single: +; in printf-style formatting
+   single: # (hash); in printf-style formatting
+   single: - (minus); in printf-style formatting
+   single: + (plus); in printf-style formatting
    single: space; in printf-style formatting
 
 +---------+---------------------------------------------------------------------+

--- a/Doc/library/string.rst
+++ b/Doc/library/string.rst
@@ -193,13 +193,11 @@ related to that of :ref:`formatted string literals <f-strings>`, but
 there are differences.
 
 .. index::
-   single: {; in string formatting
-   single: }; in string formatting
-   single: .; in string formatting
-   single: [; in string formatting
-   single: ]; in string formatting
-   single: !; in string formatting
-   single: :; in string formatting
+   single: {} (curly brackets); in string formatting
+   single: . (dot); in string formatting
+   single: [] (square brackets); in string formatting
+   single: ! (exclamation); in string formatting
+   single: : (colon); in string formatting
 
 Format strings contain "replacement fields" surrounded by curly braces ``{}``.
 Anything that is not contained in braces is considered literal text, which is
@@ -333,10 +331,10 @@ affect the :func:`format` function.
 The meaning of the various alignment options is as follows:
 
    .. index::
-      single: <; in string formatting
-      single: >; in string formatting
-      single: =; in string formatting
-      single: ^; in string formatting
+      single: < (less); in string formatting
+      single: > (greater); in string formatting
+      single: = (equals); in string formatting
+      single: ^ (caret); in string formatting
 
    +---------+----------------------------------------------------------+
    | Option  | Meaning                                                  |
@@ -365,8 +363,8 @@ The *sign* option is only valid for number types, and can be one of the
 following:
 
    .. index::
-      single: +; in string formatting
-      single: -; in string formatting
+      single: + (plus); in string formatting
+      single: - (minus); in string formatting
       single: space; in string formatting
 
    +---------+----------------------------------------------------------+
@@ -383,7 +381,7 @@ following:
    +---------+----------------------------------------------------------+
 
 
-.. index:: single: #; in string formatting
+.. index:: single: # (hash); in string formatting
 
 The ``'#'`` option causes the "alternate form" to be used for the
 conversion.  The alternate form is defined differently for different
@@ -397,7 +395,7 @@ decimal-point character appears in the result of these conversions
 only if a digit follows it. In addition, for ``'g'`` and ``'G'``
 conversions, trailing zeros are not removed from the result.
 
-.. index:: single: ,; in string formatting
+.. index:: single: , (comma); in string formatting
 
 The ``','`` option signals the use of a comma for a thousands separator.
 For a locale aware separator, use the ``'n'`` integer presentation type
@@ -406,7 +404,7 @@ instead.
 .. versionchanged:: 3.1
    Added the ``','`` option (see also :pep:`378`).
 
-.. index:: single: _; in string formatting
+.. index:: single: _ (underscore); in string formatting
 
 The ``'_'`` option signals the use of an underscore for a thousands
 separator for floating point presentation types and for integer
@@ -694,7 +692,7 @@ formatting facilities in Python.  As an example of a library built on template
 strings for i18n, see the
 `flufl.i18n <http://flufli18n.readthedocs.io/en/latest/>`_ package.
 
-.. index:: single: $; in template strings
+.. index:: single: $ (dollar); in template strings
 
 Template strings support ``$``-based substitutions, using the following rules:
 

--- a/Doc/library/struct.rst
+++ b/Doc/library/struct.rst
@@ -117,11 +117,11 @@ order, and properly aligned by skipping pad bytes if necessary (according to the
 rules used by the C compiler).
 
 .. index::
-   single: @; in struct format strings
-   single: =; in struct format strings
-   single: <; in struct format strings
-   single: >; in struct format strings
-   single: !; in struct format strings
+   single: @ (at); in struct format strings
+   single: = (equals); in struct format strings
+   single: < (less); in struct format strings
+   single: > (greater); in struct format strings
+   single: ! (exclamation); in struct format strings
 
 Alternatively, the first character of the format string can be used to indicate
 the byte order, size and alignment of the packed data, according to the
@@ -246,6 +246,8 @@ platform-dependent.
 Notes:
 
 (1)
+   .. index:: single: ? (question mark); in struct format strings
+
    The ``'?'`` conversion code corresponds to the :c:type:`_Bool` type defined by
    C99. If this type is not available, it is simulated using a :c:type:`char`. In
    standard mode, it is always represented by one byte.
@@ -327,6 +329,8 @@ smaller.  The bytes of the string follow.  If the string passed in to
 are used.  Note that for :func:`unpack`, the ``'p'`` format character consumes
 ``count`` bytes, but that the string returned can never contain more than 255
 bytes.
+
+.. index:: single: ? (question mark); in struct format strings
 
 For the ``'?'`` format character, the return value is either :const:`True` or
 :const:`False`. When packing, the truth value of the argument object is used.

--- a/Doc/library/time.rst
+++ b/Doc/library/time.rst
@@ -309,7 +309,7 @@ Functions
 
 
 .. index::
-   single: %; datetime format
+   single: % (percent); datetime format
 
 .. function:: strftime(format[, t])
 
@@ -443,7 +443,7 @@ Functions
 
 
 .. index::
-   single: %; datetime format
+   single: % (percent); datetime format
 
 .. function:: strptime(string[, format])
 

--- a/Doc/library/tkinter.rst
+++ b/Doc/library/tkinter.rst
@@ -262,6 +262,8 @@ To make a widget in Tk, the command is always of the form::
 *classCommand*
    denotes which kind of widget to make (a button, a label, a menu...)
 
+.. index:: single: . (dot); in Tkinter
+
 *newPathname*
    is the new name for this widget.  All names in Tk must be unique.  To help
    enforce this, widgets in Tk are named with *pathnames*, just like files in a

--- a/Doc/library/traceback.rst
+++ b/Doc/library/traceback.rst
@@ -47,7 +47,7 @@ The module defines the following functions:
 
    * it prints the exception *etype* and *value* after the stack trace
 
-   .. index:: single: ^; caret
+   .. index:: single: ^ (caret); marker
 
    * if *type(value)* is :exc:`SyntaxError` and *value* has the appropriate
      format, it prints the line where the syntax error occurred with a caret

--- a/Doc/library/winreg.rst
+++ b/Doc/library/winreg.rst
@@ -225,7 +225,7 @@ This module offers the following functions:
 
 
 .. index::
-   single: %; environment variables expansion (Windows)
+   single: % (percent); environment variables expansion (Windows)
 
 .. function:: ExpandEnvironmentStrings(str)
 

--- a/Doc/reference/compound_stmts.rst
+++ b/Doc/reference/compound_stmts.rst
@@ -21,7 +21,7 @@ also syntactically compound statements.
 .. index::
    single: clause
    single: suite
-   single: ;
+   single: ; (semicolon)
 
 A compound statement consists of one or more 'clauses.'  A clause consists of a
 header and a 'suite.'  The clause headers of a particular compound statement are
@@ -85,7 +85,7 @@ The :keyword:`if` statement
    statement: if
    keyword: elif
    keyword: else
-   single: :; compound statement
+   single: : (colon); compound statement
 
 The :keyword:`if` statement is used for conditional execution:
 
@@ -111,7 +111,7 @@ The :keyword:`while` statement
    keyword: else
    pair: loop; statement
    keyword: else
-   single: :; compound statement
+   single: : (colon); compound statement
 
 The :keyword:`while` statement is used for repeated execution as long as an
 expression is true:
@@ -150,7 +150,7 @@ The :keyword:`for` statement
    keyword: else
    pair: target; list
    object: sequence
-   single: :; compound statement
+   single: : (colon); compound statement
 
 The :keyword:`for` statement is used to iterate over the elements of a sequence
 (such as a string, tuple or list) or other iterable object:
@@ -233,7 +233,7 @@ The :keyword:`try` statement
    keyword: finally
    keyword: else
    keyword: as
-   single: :; compound statement
+   single: : (colon); compound statement
 
 The :keyword:`try` statement specifies exception handlers and/or cleanup code
 for a group of statements:
@@ -383,8 +383,8 @@ The :keyword:`with` statement
    statement: with
    keyword: as
    single: as; with statement
-   single: ,; with statement
-   single: :; compound statement
+   single: , (comma); with statement
+   single: : (colon); compound statement
 
 The :keyword:`with` statement is used to wrap the execution of a block with
 methods defined by a context manager (see section :ref:`context-managers`).
@@ -471,10 +471,9 @@ Function definitions
    object: function
    pair: function; name
    pair: name; binding
-   single: (; function definition
-   single: ); function definition
-   single: ,; parameter list
-   single: :; compound statement
+   single: () (parentheses); function definition
+   single: , (comma); parameter list
+   single: : (colon); compound statement
 
 A function definition defines a user-defined function object (see section
 :ref:`types`):
@@ -504,7 +503,7 @@ The function definition does not execute the function body; this gets executed
 only when the function is called. [#]_
 
 .. index::
-   single: @; function definition
+   single: @ (at); function definition
 
 A function definition may be wrapped by one or more :term:`decorator` expressions.
 Decorator expressions are evaluated when the function is defined, in the scope
@@ -527,7 +526,7 @@ except that the original function is not temporarily bound to the name ``func``.
 .. index::
    triple: default; parameter; value
    single: argument; function definition
-   single: =; function definition
+   single: = (equals); function definition
 
 When one or more :term:`parameters <parameter>` have the form *parameter* ``=``
 *expression*, the function is said to have "default parameter values."  For a
@@ -554,7 +553,7 @@ e.g.::
        return penguin
 
 .. index::
-   single: *; function definition
+   single: * (asterisk); function definition
    single: **; function definition
 
 Function call semantics are described in more detail in section :ref:`calls`. A
@@ -571,7 +570,7 @@ used keyword arguments.
 .. index::
    pair: function; annotations
    single: ->; function annotations
-   single: :; function annotations
+   single: : (colon); function annotations
 
 Parameters may have annotations of the form "``: expression``" following the
 parameter name.  Any parameter may have an annotation even those of the form
@@ -620,10 +619,9 @@ Class definitions
    pair: execution; frame
    single: inheritance
    single: docstring
-   single: (; class definition
-   single: ); class definition
-   single: ,; expression list
-   single: :; compound statement
+   single: () (parentheses); class definition
+   single: , (comma); expression list
+   single: : (colon); compound statement
 
 A class definition defines a class object (see section :ref:`types`):
 
@@ -663,7 +661,7 @@ the definition syntax.
 Class creation can be customized heavily using :ref:`metaclasses <metaclasses>`.
 
 .. index::
-   single: @; class definition
+   single: @ (at); class definition
 
 Classes can also be decorated: just like when decorating functions, ::
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1770,7 +1770,7 @@ Metaclasses
 .. index::
    single: metaclass
    builtin: type
-   single: =; class definition
+   single: = (equals); class definition
 
 By default, classes are constructed using :func:`type`. The class body is
 executed in a new namespace and the class name is bound locally to the

--- a/Doc/reference/expressions.rst
+++ b/Doc/reference/expressions.rst
@@ -130,8 +130,7 @@ Parenthesized forms
 
 .. index::
    single: parenthesized form
-   single: (; tuple display
-   single: ); tuple display
+   single: () (parentheses); tuple display
 
 A parenthesized form is an optional expression list enclosed in parentheses:
 
@@ -151,7 +150,7 @@ tuple may or may not yield the same object).
 .. index::
    single: comma; tuple display
    pair: tuple; display
-   single: ,; tuple display
+   single: , (comma); tuple display
 
 Note that tuples are not formed by the parentheses, but rather by use of the
 comma operator.  The exception is the empty tuple, for which parentheses *are*
@@ -220,9 +219,8 @@ List displays
    pair: list; comprehensions
    pair: empty; list
    object: list
-   single: [; list expression
-   single: ]; list expression
-   single: ,; expression list
+   single: [] (square brackets); list expression
+   single: , (comma); expression list
 
 A list display is a possibly empty series of expressions enclosed in square
 brackets:
@@ -245,9 +243,8 @@ Set displays
 .. index::
    pair: set; display
    object: set
-   single: {; set expression
-   single: }; set expression
-   single: ,; expression list
+   single: {} (curly brackets); set expression
+   single: , (comma); expression list
 
 A set display is denoted by curly braces and distinguishable from dictionary
 displays by the lack of colons separating keys and values:
@@ -274,10 +271,9 @@ Dictionary displays
    pair: dictionary; display
    key, datum, key/datum pair
    object: dictionary
-   single: {; dictionary expression
-   single: }; dictionary expression
-   single: :; in dictionary expressions
-   single: ,; in dictionary displays
+   single: {} (curly brackets); dictionary expression
+   single: : (colon); in dictionary expressions
+   single: , (comma); in dictionary displays
 
 A dictionary display is a possibly empty series of key/datum pairs enclosed in
 curly braces:
@@ -331,8 +327,7 @@ Generator expressions
 .. index::
    pair: generator; expression
    object: generator
-   single: (; generator expression
-   single: ); generator expression
+   single: () (parentheses); generator expression
 
 A generator expression is a compact generator notation in parentheses:
 
@@ -711,7 +706,7 @@ Attribute references
 
 .. index::
    pair: attribute; reference
-   single: .; attribute reference
+   single: . (dot); attribute reference
 
 An attribute reference is a primary followed by a period and a name:
 
@@ -739,8 +734,7 @@ Subscriptions
 
 .. index::
    single: subscription
-   single: [; subscription
-   single: ]; subscription
+   single: [] (square brackets); subscription
 
 .. index::
    object: sequence
@@ -797,8 +791,8 @@ Slicings
 .. index::
    single: slicing
    single: slice
-   single: :; slicing
-   single: ,; slicing
+   single: : (colon); slicing
+   single: , (comma); slicing
 
 .. index::
    object: sequence
@@ -848,10 +842,9 @@ substituting ``None`` for missing expressions.
    object: callable
    single: call
    single: argument; call semantics
-   single: (; call
-   single: ); call
-   single: ,; argument list
-   single: =; in function calls
+   single: () (parentheses); call
+   single: , (comma); argument list
+   single: = (equals); in function calls
 
 .. _calls:
 
@@ -928,7 +921,7 @@ and the argument values as corresponding values), or a (new) empty dictionary if
 there were no excess keyword arguments.
 
 .. index::
-   single: *; in function calls
+   single: * (asterisk); in function calls
    single: unpacking; in function calls
 
 If the syntax ``*expression`` appears in the function call, ``expression`` must
@@ -1100,21 +1093,21 @@ All unary arithmetic and bitwise operations have the same priority:
 .. index::
    single: negation
    single: minus
-   single: operator; -
-   single: -; unary operator
+   single: operator; - (minus)
+   single: - (minus); unary operator
 
 The unary ``-`` (minus) operator yields the negation of its numeric argument.
 
 .. index::
    single: plus
-   single: operator; +
-   single: +; unary operator
+   single: operator; + (plus)
+   single: + (plus); unary operator
 
 The unary ``+`` (plus) operator yields its numeric argument unchanged.
 
 .. index::
    single: inversion
-   operator: ~
+   operator: ~ (tilde)
 
 The unary ``~`` (invert) operator yields the bitwise inversion of its integer
 argument.  The bitwise inversion of ``x`` is defined as ``-(x+1)``.  It only
@@ -1146,7 +1139,7 @@ operators and one for additive operators:
 
 .. index::
    single: multiplication
-   operator: *
+   operator: * (asterisk)
 
 The ``*`` (multiplication) operator yields the product of its arguments.  The
 arguments must either both be numbers, or one argument must be an integer and
@@ -1156,7 +1149,7 @@ repetition is performed; a negative repetition factor yields an empty sequence.
 
 .. index::
    single: matrix multiplication
-   operator: @
+   operator: @ (at)
 
 The ``@`` (at) operator is intended to be used for matrix multiplication.  No
 builtin Python types implement this operator.
@@ -1166,7 +1159,7 @@ builtin Python types implement this operator.
 .. index::
    exception: ZeroDivisionError
    single: division
-   operator: /
+   operator: / (slash)
    operator: //
 
 The ``/`` (division) and ``//`` (floor division) operators yield the quotient of
@@ -1178,7 +1171,7 @@ exception.
 
 .. index::
    single: modulo
-   operator: %
+   operator: % (percent)
 
 The ``%`` (modulo) operator yields the remainder from the division of the first
 argument by the second.  The numeric arguments are first converted to a common
@@ -1205,8 +1198,8 @@ point number using the :func:`abs` function if appropriate.
 
 .. index::
    single: addition
-   single: operator; +
-   single: +; binary operator
+   single: operator; + (plus)
+   single: + (plus); binary operator
 
 The ``+`` (addition) operator yields the sum of its arguments.  The arguments
 must either both be numbers or both be sequences of the same type.  In the
@@ -1215,8 +1208,8 @@ In the latter case, the sequences are concatenated.
 
 .. index::
    single: subtraction
-   single: operator; -
-   single: -; binary operator
+   single: operator; - (minus)
+   single: - (minus); binary operator
 
 The ``-`` (subtraction) operator yields the difference of its arguments.  The
 numeric arguments are first converted to a common type.
@@ -1267,7 +1260,7 @@ Each of the three bitwise operations has a different priority level:
 
 .. index::
    pair: bitwise; and
-   operator: &
+   operator: & (ampersand)
 
 The ``&`` operator yields the bitwise AND of its arguments, which must be
 integers.
@@ -1275,7 +1268,7 @@ integers.
 .. index::
    pair: bitwise; xor
    pair: exclusive; or
-   operator: ^
+   operator: ^ (caret)
 
 The ``^`` operator yields the bitwise XOR (exclusive OR) of its arguments, which
 must be integers.
@@ -1283,7 +1276,7 @@ must be integers.
 .. index::
    pair: bitwise; or
    pair: inclusive; or
-   operator: |
+   operator: | (vertical bar)
 
 The ``|`` operator yields the bitwise (inclusive) OR of its arguments, which
 must be integers.
@@ -1297,8 +1290,8 @@ Comparisons
 .. index::
    single: comparison
    pair: C; language
-   operator: <
-   operator: >
+   operator: < (less)
+   operator: > (greater)
    operator: <=
    operator: >=
    operator: ==
@@ -1649,7 +1642,7 @@ Lambdas
    pair: lambda; expression
    pair: lambda; form
    pair: anonymous; function
-   single: :; lambda expression
+   single: : (colon); lambda expression
 
 .. productionlist::
    lambda_expr: "lambda" [`parameter_list`] ":" `expression`
@@ -1676,8 +1669,7 @@ Expression lists
 
 .. index::
    pair: expression; list
-   single: comma; expression list
-   single: ,; expression list
+   single: , (comma); expression list
 
 .. productionlist::
    expression_list: `expression` ("," `expression`)* [","]
@@ -1694,7 +1686,7 @@ evaluated from left to right.
 
 .. index::
    pair: iterable; unpacking
-   single: *; in expression lists
+   single: * (asterisk); in expression lists
 
 An asterisk ``*`` denotes :dfn:`iterable unpacking`.  Its operand must be
 an :term:`iterable`.  The iterable is expanded into a sequence of items,

--- a/Doc/reference/lexical_analysis.rst
+++ b/Doc/reference/lexical_analysis.rst
@@ -65,7 +65,7 @@ Comments
 --------
 
 .. index:: comment, hash character
-   single: #; comment
+   single: # (hash); comment
 
 A comment starts with a hash character (``#``) that is not part of a string
 literal, and ends at the end of the physical line.  A comment signifies the end
@@ -79,7 +79,7 @@ Encoding declarations
 ---------------------
 
 .. index:: source character set, encoding declarations (source file)
-   single: #; source encoding declaration
+   single: # (hash); source encoding declaration
 
 If a comment in the first or second line of the Python script matches the
 regular expression ``coding[=:]\s*([-\w.]+)``, this comment is processed as an
@@ -401,8 +401,8 @@ Literals are notations for constant values of some built-in types.
 
 
 .. index:: string literal, bytes literal, ASCII
-   single: '; string literal
-   single: "; string literal
+   single: ' (single quote); string literal
+   single: " (double quote); string literal
    single: u'; string literal
    single: u"; string literal
 .. _strings:
@@ -495,7 +495,7 @@ retained), except that three unescaped quotes in a row terminate the literal.  (
 "quote" is the character used to open the literal, i.e. either ``'`` or ``"``.)
 
 .. index:: physical line, escape sequence, Standard C, C
-   single: \; escape sequence
+   single: \ (backslash); escape sequence
    single: \\; escape sequence
    single: \a; escape sequence
    single: \b; escape sequence
@@ -636,10 +636,9 @@ and formatted string literals may be concatenated with plain string literals.
    single: string; formatted literal
    single: string; interpolated literal
    single: f-string
-   single: {; in formatted string literal
-   single: }; in formatted string literal
-   single: !; in formatted string literal
-   single: :; in formatted string literal
+   single: {} (curly brackets); in formatted string literal
+   single: ! (exclamation); in formatted string literal
+   single: : (colon); in formatted string literal
 .. _f-strings:
 
 Formatted string literals
@@ -778,7 +777,7 @@ actually an expression composed of the unary operator '``-``' and the literal
    single: 0b; integer literal
    single: 0o; integer literal
    single: 0x; integer literal
-   single: _; in numeric literal
+   single: _ (underscore); in numeric literal
 
 .. _integers:
 
@@ -821,9 +820,9 @@ Some examples of integer literals::
 
 
 .. index::
-   single: .; in numeric literal
+   single: . (dot); in numeric literal
    single: e; in numeric literal
-   single: _; in numeric literal
+   single: _ (underscore); in numeric literal
 .. _floating:
 
 Floating point literals

--- a/Doc/reference/simple_stmts.rst
+++ b/Doc/reference/simple_stmts.rst
@@ -71,7 +71,7 @@ Assignment statements
 =====================
 
 .. index::
-   single: =; assignment statement
+   single: = (equals); assignment statement
    pair: assignment; statement
    pair: binding; name
    pair: rebinding; name
@@ -112,12 +112,10 @@ unacceptable.  The rules observed by various types and the exceptions raised are
 given with the definition of the object types (see section :ref:`types`).
 
 .. index:: triple: target; list; assignment
-   single: ,; in target list
-   single: *; in assignment target list
-   single: [; in assignment target list
-   single: ]; in assignment target list
-   single: (; in assignment target list
-   single: ); in assignment target list
+   single: , (comma); in target list
+   single: * (asterisk); in assignment target list
+   single: [] (square brackets); in assignment target list
+   single: () (parentheses); in assignment target list
 
 Assignment of an object to a target list, optionally enclosed in parentheses or
 square brackets, is recursively defined as follows.
@@ -327,7 +325,7 @@ Annotated assignment statements
 .. index::
    pair: annotated; assignment
    single: statement; assignment, annotated
-   single: :; annotated variable
+   single: : (colon); annotated variable
 
 Annotation assignment is the combination, in a single statement,
 of a variable or attribute annotation and an optional assignment statement:
@@ -379,7 +377,7 @@ The :keyword:`assert` statement
 .. index::
    statement: assert
    pair: debugging; assertions
-   single: ,; expression list
+   single: , (comma); expression list
 
 Assert statements are a convenient way to insert debugging assertions into a
 program:
@@ -723,7 +721,7 @@ The :keyword:`import` statement
    keyword: from
    keyword: as
    exception: ImportError
-   single: ,; import statement
+   single: , (comma); import statement
 
 .. productionlist::
    import_stmt: "import" `module` ["as" `identifier`] ("," `module` ["as" `identifier`])*
@@ -797,7 +795,7 @@ Examples::
    from foo.bar import baz    # foo.bar.baz imported and bound as baz
    from foo import attr       # foo imported and foo.attr bound as attr
 
-.. index:: single: *; import statement
+.. index:: single: * (asterisk); import statement
 
 If the list of identifiers is replaced by a star (``'*'``), all public
 names defined in the module are bound in the local namespace for the scope
@@ -930,7 +928,7 @@ The :keyword:`global` statement
 .. index::
    statement: global
    triple: global; name; binding
-   single: ,; identifier list
+   single: , (comma); identifier list
 
 .. productionlist::
    global_stmt: "global" `identifier` ("," `identifier`)*
@@ -975,7 +973,7 @@ The :keyword:`nonlocal` statement
 =================================
 
 .. index:: statement: nonlocal
-   single: ,; identifier list
+   single: , (comma); identifier list
 
 .. productionlist::
    nonlocal_stmt: "nonlocal" `identifier` ("," `identifier`)*

--- a/Doc/tutorial/controlflow.rst
+++ b/Doc/tutorial/controlflow.rst
@@ -526,7 +526,7 @@ Arbitrary Argument Lists
 ------------------------
 
 .. index::
-   single: *; in function calls
+   single: * (asterisk); in function calls
 
 Finally, the least frequently used option is to specify that a function can be
 called with an arbitrary number of arguments.  These arguments will be wrapped
@@ -676,7 +676,7 @@ Function Annotations
 .. index::
    pair: function; annotations
    single: ->; function annotations
-   single: :; function annotations
+   single: : (colon); function annotations
 
 :ref:`Function annotations <function>` are completely optional metadata
 information about the types used by user-defined functions (see :pep:`3107` and

--- a/Doc/tutorial/introduction.rst
+++ b/Doc/tutorial/introduction.rst
@@ -11,7 +11,7 @@ with a prompt are output from the interpreter. Note that a secondary prompt on a
 line by itself in an example means you must type a blank line; this is used to
 end a multi-line command.
 
-.. index:: single: #; comment
+.. index:: single: # (hash); comment
 
 Many of the examples in this manual, even those entered at the interactive
 prompt, include comments.  Comments in Python start with the hash character,


### PR DESCRIPTION
(cherry picked from commit 913876d824d969f8c7431e8a9d4610a9a11a786e)


<!-- issue-number: [bpo-35054](https://bugs.python.org/issue35054) -->
https://bugs.python.org/issue35054
<!-- /issue-number -->
