### PR TITLE
bpo-34160: Preserve user specified order of Element attributes in html.

### DIFF
--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -5,7 +5,6 @@
 # For this purpose, the module-level "ET" symbol is temporarily
 # monkey-patched when running the "test_xml_etree_c" test suite.
 
-import contextlib
 import copy
 import functools
 import html
@@ -1056,13 +1055,10 @@ class ElementTreeTest(unittest.TestCase):
     def test_tree_write_attribute_order(self):
         # See BPO 34160
         root = ET.Element('cirriculum', status='public', company='example')
-        tree = ET.ElementTree(root)
-        f = io.BytesIO()
-        with contextlib.redirect_stdout(f):
-            tree.write(f, encoding='utf-8', xml_declaration=True)
-        self.assertEqual(f.getvalue(),
-                         b"<?xml version='1.0' encoding='utf-8'?>\n"
-                         b'<cirriculum status="public" company="example" />')
+        self.assertEqual(serialize(root),
+                         '<cirriculum status="public" company="example" />')
+        self.assertEqual(serialize(root, method='html'),
+                '<cirriculum status="public" company="example"></cirriculum>')
 
 
 class XMLPullParserTest(unittest.TestCase):

--- a/Lib/xml/etree/ElementTree.py
+++ b/Lib/xml/etree/ElementTree.py
@@ -979,7 +979,7 @@ def _serialize_html(write, elem, qnames, namespaces, **kwargs):
                             k,
                             _escape_attrib(v)
                             ))
-                for k, v in sorted(items):  # lexical order
+                for k, v in items:
                     if isinstance(k, QName):
                         k = k.text
                     if isinstance(v, QName):


### PR DESCRIPTION


<!-- issue-number: [bpo-34160](https://bugs.python.org/issue34160) -->
https://bugs.python.org/issue34160
<!-- /issue-number -->
