### PR TITLE
bpo-35075: Fix broken url in the pprint documentation

### DIFF
--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -218,228 +218,155 @@ let's fetch information about a project from `PyPI <https://pypi.org>`_::
    >>> import pprint
    >>> from urllib.request import urlopen
    >>> with urlopen('https://pypi.org/pypi/sampleproject/json') as resp:
-   ...    project_info = json.load(resp)
+   ...    project_info = json.load(resp)['info']
 
 In its basic form, :func:`pprint` shows the whole object::
 
    >>> pprint.pprint(project_info)
-   {'info': {'author': 'The Python Packaging Authority',
-             'author_email': 'pypa-dev@googlegroups.com',
-             'bugtrack_url': None,
-             'classifiers': ['Development Status :: 3 - Alpha',
-                             'Intended Audience :: Developers',
-                             'License :: OSI Approved :: MIT License',
-                             'Programming Language :: Python :: 2',
-                             'Programming Language :: Python :: 2.6',
-                             'Programming Language :: Python :: 2.7',
-                             'Programming Language :: Python :: 3',
-                             'Programming Language :: Python :: 3.2',
-                             'Programming Language :: Python :: 3.3',
-                             'Programming Language :: Python :: 3.4',
-                             'Topic :: Software Development :: Build Tools'],
-             'description': 'A sample Python project\n'
-                            '=======================\n'
-                            '\n'
-                            'This is the description file for the project.\n'
-                            '\n'
-                            'The file should use UTF-8 encoding and be written '
-                            'using ReStructured Text. It\n'
-                            'will be used to generate the project webpage on '
-                            'PyPI, and should be written for\n'
-                            'that purpose.\n'
-                            '\n'
-                            'Typical contents for this file would include an '
-                            'overview of the project, basic\n'
-                            'usage examples, etc. Generally, including the '
-                            'project changelog in here is not\n'
-                            'a good idea, although a simple "What\'s New" section '
-                            'for the most recent version\n'
-                            'may be appropriate.',
-             'description_content_type': None,
-             'docs_url': None,
-             'download_url': 'UNKNOWN',
-             'downloads': {'last_day': -1, 'last_month': -1, 'last_week': -1},
-             'home_page': 'https://github.com/pypa/sampleproject',
-             'keywords': 'sample setuptools development',
-             'license': 'MIT',
-             'maintainer': None,
-             'maintainer_email': None,
-             'name': 'sampleproject',
-             'package_url': 'https://pypi.org/project/sampleproject/',
-             'platform': 'UNKNOWN',
-             'project_url': 'https://pypi.org/project/sampleproject/',
-             'project_urls': {'Download': 'UNKNOWN',
-                              'Homepage': 'https://github.com/pypa/sampleproject'},
-             'release_url': 'https://pypi.org/project/sampleproject/1.2.0/',
-             'requires_dist': None,
-             'requires_python': None,
-             'summary': 'A sample Python project',
-             'version': '1.2.0'},
-    'last_serial': 1591652,
-    'releases': {'1.0': [],
-                 '1.2.0': [{'comment_text': '',
-                            'digests': {'md5': 'bab8eb22e6710eddae3c6c7ac3453bd9',
-                                        'sha256': '7a7a8b91086deccc54cac8d631e33f6a0e232ce5775c6be3dc44f86c2154019d'},
-                            'downloads': -1,
-                            'filename': 'sampleproject-1.2.0-py2.py3-none-any.whl',
-                            'has_sig': False,
-                            'md5_digest': 'bab8eb22e6710eddae3c6c7ac3453bd9',
-                            'packagetype': 'bdist_wheel',
-                            'python_version': '2.7',
-                            'requires_python': None,
-                            'size': 3795,
-                            'upload_time': '2015-06-14T14:38:05',
-                            'url': 'https://files.pythonhosted.org/packages/30/52/547eb3719d0e872bdd6fe3ab60cef92596f95262e925e1943f68f840df88/sampleproject-1.2.0-py2.py3-none-any.whl'},
-                           {'comment_text': '',
-                            'digests': {'md5': 'd3bd605f932b3fb6e91f49be2d6f9479',
-                                        'sha256': '3427a8a5dd0c1e176da48a44efb410875b3973bd9843403a0997e4187c408dc1'},
-                            'downloads': -1,
-                            'filename': 'sampleproject-1.2.0.tar.gz',
-                            'has_sig': False,
-                            'md5_digest': 'd3bd605f932b3fb6e91f49be2d6f9479',
-                            'packagetype': 'sdist',
-                            'python_version': 'source',
-                            'requires_python': None,
-                            'size': 3148,
-                            'upload_time': '2015-06-14T14:37:56',
-                            'url': 'https://files.pythonhosted.org/packages/eb/45/79be82bdeafcecb9dca474cad4003e32ef8e4a0dec6abbd4145ccb02abe1/sampleproject-1.2.0.tar.gz'}]},
-    'urls': [{'comment_text': '',
-              'digests': {'md5': 'bab8eb22e6710eddae3c6c7ac3453bd9',
-                          'sha256': '7a7a8b91086deccc54cac8d631e33f6a0e232ce5775c6be3dc44f86c2154019d'},
-              'downloads': -1,
-              'filename': 'sampleproject-1.2.0-py2.py3-none-any.whl',
-              'has_sig': False,
-              'md5_digest': 'bab8eb22e6710eddae3c6c7ac3453bd9',
-              'packagetype': 'bdist_wheel',
-              'python_version': '2.7',
-              'requires_python': None,
-              'size': 3795,
-              'upload_time': '2015-06-14T14:38:05',
-              'url': 'https://files.pythonhosted.org/packages/30/52/547eb3719d0e872bdd6fe3ab60cef92596f95262e925e1943f68f840df88/sampleproject-1.2.0-py2.py3-none-any.whl'},
-             {'comment_text': '',
-              'digests': {'md5': 'd3bd605f932b3fb6e91f49be2d6f9479',
-                          'sha256': '3427a8a5dd0c1e176da48a44efb410875b3973bd9843403a0997e4187c408dc1'},
-              'downloads': -1,
-              'filename': 'sampleproject-1.2.0.tar.gz',
-              'has_sig': False,
-              'md5_digest': 'd3bd605f932b3fb6e91f49be2d6f9479',
-              'packagetype': 'sdist',
-              'python_version': 'source',
-              'requires_python': None,
-              'size': 3148,
-              'upload_time': '2015-06-14T14:37:56',
-              'url': 'https://files.pythonhosted.org/packages/eb/45/79be82bdeafcecb9dca474cad4003e32ef8e4a0dec6abbd4145ccb02abe1/sampleproject-1.2.0.tar.gz'}]}
-
+   {'author': 'The Python Packaging Authority',
+    'author_email': 'pypa-dev@googlegroups.com',
+    'bugtrack_url': None,
+    'classifiers': ['Development Status :: 3 - Alpha',
+                    'Intended Audience :: Developers',
+                    'License :: OSI Approved :: MIT License',
+                    'Programming Language :: Python :: 2',
+                    'Programming Language :: Python :: 2.6',
+                    'Programming Language :: Python :: 2.7',
+                    'Programming Language :: Python :: 3',
+                    'Programming Language :: Python :: 3.2',
+                    'Programming Language :: Python :: 3.3',
+                    'Programming Language :: Python :: 3.4',
+                    'Topic :: Software Development :: Build Tools'],
+    'description': 'A sample Python project\n'
+                   '=======================\n'
+                   '\n'
+                   'This is the description file for the project.\n'
+                   '\n'
+                   'The file should use UTF-8 encoding and be written using '
+                   'ReStructured Text. It\n'
+                   'will be used to generate the project webpage on PyPI, and '
+                   'should be written for\n'
+                   'that purpose.\n'
+                   '\n'
+                   'Typical contents for this file would include an overview of '
+                   'the project, basic\n'
+                   'usage examples, etc. Generally, including the project '
+                   'changelog in here is not\n'
+                   'a good idea, although a simple "What\'s New" section for the '
+                   'most recent version\n'
+                   'may be appropriate.',
+    'description_content_type': None,
+    'docs_url': None,
+    'download_url': 'UNKNOWN',
+    'downloads': {'last_day': -1, 'last_month': -1, 'last_week': -1},
+    'home_page': 'https://github.com/pypa/sampleproject',
+    'keywords': 'sample setuptools development',
+    'license': 'MIT',
+    'maintainer': None,
+    'maintainer_email': None,
+    'name': 'sampleproject',
+    'package_url': 'https://pypi.org/project/sampleproject/',
+    'platform': 'UNKNOWN',
+    'project_url': 'https://pypi.org/project/sampleproject/',
+    'project_urls': {'Download': 'UNKNOWN',
+                     'Homepage': 'https://github.com/pypa/sampleproject'},
+    'release_url': 'https://pypi.org/project/sampleproject/1.2.0/',
+    'requires_dist': None,
+    'requires_python': None,
+    'summary': 'A sample Python project',
+    'version': '1.2.0'}
 
 The result can be limited to a certain *depth* (ellipsis is used for deeper
 contents)::
 
-   >>> pprint.pprint(project_info, depth=2)
-   {'info': {'author': 'The Python Packaging Authority',
-             'author_email': 'pypa-dev@googlegroups.com',
-             'bugtrack_url': None,
-             'classifiers': [...],
-             'description': 'A sample Python project\n'
-                            '=======================\n'
-                            '\n'
-                            'This is the description file for the project.\n'
-                            '\n'
-                            'The file should use UTF-8 encoding and be written '
-                            'using ReStructured Text. It\n'
-                            'will be used to generate the project webpage on '
-                            'PyPI, and should be written for\n'
-                            'that purpose.\n'
-                            '\n'
-                            'Typical contents for this file would include an '
-                            'overview of the project, basic\n'
-                            'usage examples, etc. Generally, including the '
-                            'project changelog in here is not\n'
-                            'a good idea, although a simple "What\'s New" section '
-                            'for the most recent version\n'
-                            'may be appropriate.',
-             'description_content_type': None,
-             'docs_url': None,
-             'download_url': 'UNKNOWN',
-             'downloads': {...},
-             'home_page': 'https://github.com/pypa/sampleproject',
-             'keywords': 'sample setuptools development',
-             'license': 'MIT',
-             'maintainer': None,
-             'maintainer_email': None,
-             'name': 'sampleproject',
-             'package_url': 'https://pypi.org/project/sampleproject/',
-             'platform': 'UNKNOWN',
-             'project_url': 'https://pypi.org/project/sampleproject/',
-             'project_urls': {...},
-             'release_url': 'https://pypi.org/project/sampleproject/1.2.0/',
-             'requires_dist': None,
-             'requires_python': None,
-             'summary': 'A sample Python project',
-             'version': '1.2.0'},
-    'last_serial': 1591652,
-    'releases': {'1.0': [], '1.2.0': [...]},
-    'urls': [{...}, {...}]}
+   >>> pprint.pprint(project_info, depth=1)
+   {'author': 'The Python Packaging Authority',
+    'author_email': 'pypa-dev@googlegroups.com',
+    'bugtrack_url': None,
+    'classifiers': [...],
+    'description': 'A sample Python project\n'
+                   '=======================\n'
+                   '\n'
+                   'This is the description file for the project.\n'
+                   '\n'
+                   'The file should use UTF-8 encoding and be written using '
+                   'ReStructured Text. It\n'
+                   'will be used to generate the project webpage on PyPI, and '
+                   'should be written for\n'
+                   'that purpose.\n'
+                   '\n'
+                   'Typical contents for this file would include an overview of '
+                   'the project, basic\n'
+                   'usage examples, etc. Generally, including the project '
+                   'changelog in here is not\n'
+                   'a good idea, although a simple "What\'s New" section for the '
+                   'most recent version\n'
+                   'may be appropriate.',
+    'description_content_type': None,
+    'docs_url': None,
+    'download_url': 'UNKNOWN',
+    'downloads': {...},
+    'home_page': 'https://github.com/pypa/sampleproject',
+    'keywords': 'sample setuptools development',
+    'license': 'MIT',
+    'maintainer': None,
+    'maintainer_email': None,
+    'name': 'sampleproject',
+    'package_url': 'https://pypi.org/project/sampleproject/',
+    'platform': 'UNKNOWN',
+    'project_url': 'https://pypi.org/project/sampleproject/',
+    'project_urls': {...},
+    'release_url': 'https://pypi.org/project/sampleproject/1.2.0/',
+    'requires_dist': None,
+    'requires_python': None,
+    'summary': 'A sample Python project',
+    'version': '1.2.0'}
 
 Additionally, maximum character *width* can be suggested. If a long object
 cannot be split, the specified width will be exceeded::
 
-   >>> pprint.pprint(project_info, depth=2, width=50)
-   {'info': {'author': 'The Python Packaging '
-                       'Authority',
-             'author_email': 'pypa-dev@googlegroups.com',
-             'bugtrack_url': None,
-             'classifiers': [...],
-             'description': 'A sample Python '
-                            'project\n'
-                            '=======================\n'
-                            '\n'
-                            'This is the '
-                            'description file for '
-                            'the project.\n'
-                            '\n'
-                            'The file should use '
-                            'UTF-8 encoding and be '
-                            'written using '
-                            'ReStructured Text. It\n'
-                            'will be used to '
-                            'generate the project '
-                            'webpage on PyPI, and '
-                            'should be written for\n'
-                            'that purpose.\n'
-                            '\n'
-                            'Typical contents for '
-                            'this file would '
-                            'include an overview of '
-                            'the project, basic\n'
-                            'usage examples, etc. '
-                            'Generally, including '
-                            'the project changelog '
-                            'in here is not\n'
-                            'a good idea, although '
-                            'a simple "What\'s New" '
-                            'section for the most '
-                            'recent version\n'
-                            'may be appropriate.',
-             'description_content_type': None,
-             'docs_url': None,
-             'download_url': 'UNKNOWN',
-             'downloads': {...},
-             'home_page': 'https://github.com/pypa/sampleproject',
-             'keywords': 'sample setuptools '
-                         'development',
-             'license': 'MIT',
-             'maintainer': None,
-             'maintainer_email': None,
-             'name': 'sampleproject',
-             'package_url': 'https://pypi.org/project/sampleproject/',
-             'platform': 'UNKNOWN',
-             'project_url': 'https://pypi.org/project/sampleproject/',
-             'project_urls': {...},
-             'release_url': 'https://pypi.org/project/sampleproject/1.2.0/',
-             'requires_dist': None,
-             'requires_python': None,
-             'summary': 'A sample Python project',
-             'version': '1.2.0'},
-    'last_serial': 1591652,
-    'releases': {'1.0': [], '1.2.0': [...]},
-    'urls': [{...}, {...}]}
+   >>> pprint.pprint(project_info, depth=1, width=60)
+   {'author': 'The Python Packaging Authority',
+    'author_email': 'pypa-dev@googlegroups.com',
+    'bugtrack_url': None,
+    'classifiers': [...],
+    'description': 'A sample Python project\n'
+                   '=======================\n'
+                   '\n'
+                   'This is the description file for the '
+                   'project.\n'
+                   '\n'
+                   'The file should use UTF-8 encoding and be '
+                   'written using ReStructured Text. It\n'
+                   'will be used to generate the project '
+                   'webpage on PyPI, and should be written '
+                   'for\n'
+                   'that purpose.\n'
+                   '\n'
+                   'Typical contents for this file would '
+                   'include an overview of the project, '
+                   'basic\n'
+                   'usage examples, etc. Generally, including '
+                   'the project changelog in here is not\n'
+                   'a good idea, although a simple "What\'s '
+                   'New" section for the most recent version\n'
+                   'may be appropriate.',
+    'description_content_type': None,
+    'docs_url': None,
+    'download_url': 'UNKNOWN',
+    'downloads': {...},
+    'home_page': 'https://github.com/pypa/sampleproject',
+    'keywords': 'sample setuptools development',
+    'license': 'MIT',
+    'maintainer': None,
+    'maintainer_email': None,
+    'name': 'sampleproject',
+    'package_url': 'https://pypi.org/project/sampleproject/',
+    'platform': 'UNKNOWN',
+    'project_url': 'https://pypi.org/project/sampleproject/',
+    'project_urls': {...},
+    'release_url': 'https://pypi.org/project/sampleproject/1.2.0/',
+    'requires_dist': None,
+    'requires_python': None,
+    'summary': 'A sample Python project',
+    'version': '1.2.0'}

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -217,136 +217,229 @@ let's fetch information about a project from `PyPI <https://pypi.org>`_::
    >>> import json
    >>> import pprint
    >>> from urllib.request import urlopen
-   >>> with urlopen('https://pypi.org/pypi/Twisted/json') as url:
-   ...     http_info = url.info()
-   ...     charset = http_info.get_content_charset(failobj="utf-8")
-   ...     raw_data = url.read().decode(charset)
-   >>> project_info = json.loads(raw_data)
+   >>> with urlopen('https://pypi.org/pypi/sampleproject/json') as resp:
+           project_info = json.loads(resp.read())
 
 In its basic form, :func:`pprint` shows the whole object::
 
    >>> pprint.pprint(project_info)
-   {'info': {'_pypi_hidden': False,
-             '_pypi_ordering': 125,
-             'author': 'Glyph Lefkowitz',
-             'author_email': 'glyph@twistedmatrix.com',
-             'bugtrack_url': '',
-             'cheesecake_code_kwalitee_id': None,
-             'cheesecake_documentation_id': None,
-             'cheesecake_installability_id': None,
-             'classifiers': ['Programming Language :: Python :: 2.6',
+   {'info': {'author': 'The Python Packaging Authority',
+             'author_email': 'pypa-dev@googlegroups.com',
+             'bugtrack_url': None,
+             'classifiers': ['Development Status :: 3 - Alpha',
+                             'Intended Audience :: Developers',
+                             'License :: OSI Approved :: MIT License',
+                             'Programming Language :: Python :: 2',
+                             'Programming Language :: Python :: 2.6',
                              'Programming Language :: Python :: 2.7',
-                             'Programming Language :: Python :: 2 :: Only'],
-             'description': 'An extensible framework for Python programming, with '
-                            'special focus\r\n'
-                            'on event-based network programming and multiprotocol '
-                            'integration.',
-             'docs_url': '',
+                             'Programming Language :: Python :: 3',
+                             'Programming Language :: Python :: 3.2',
+                             'Programming Language :: Python :: 3.3',
+                             'Programming Language :: Python :: 3.4',
+                             'Topic :: Software Development :: Build Tools'],
+             'description': 'A sample Python project\n'
+                            '=======================\n'
+                            '\n'
+                            'This is the description file for the project.\n'
+                            '\n'
+                            'The file should use UTF-8 encoding and be written '
+                            'using ReStructured Text. It\n'
+                            'will be used to generate the project webpage on '
+                            'PyPI, and should be written for\n'
+                            'that purpose.\n'
+                            '\n'
+                            'Typical contents for this file would include an '
+                            'overview of the project, basic\n'
+                            'usage examples, etc. Generally, including the '
+                            'project changelog in here is not\n'
+                            'a good idea, although a simple "What\'s New" section '
+                            'for the most recent version\n'
+                            'may be appropriate.',
+             'description_content_type': None,
+             'docs_url': None,
              'download_url': 'UNKNOWN',
-             'home_page': 'http://twistedmatrix.com/',
-             'keywords': '',
+             'downloads': {'last_day': -1, 'last_month': -1, 'last_week': -1},
+             'home_page': 'https://github.com/pypa/sampleproject',
+             'keywords': 'sample setuptools development',
              'license': 'MIT',
-             'maintainer': '',
-             'maintainer_email': '',
-             'name': 'Twisted',
-             'package_url': 'http://pypi.org/project/Twisted',
+             'maintainer': None,
+             'maintainer_email': None,
+             'name': 'sampleproject',
+             'package_url': 'https://pypi.org/project/sampleproject/',
              'platform': 'UNKNOWN',
-             'release_url': 'http://pypi.org/project/Twisted/12.3.0',
+             'project_url': 'https://pypi.org/project/sampleproject/',
+             'project_urls': {'Download': 'UNKNOWN',
+                              'Homepage': 'https://github.com/pypa/sampleproject'},
+             'release_url': 'https://pypi.org/project/sampleproject/1.2.0/',
+             'requires_dist': None,
              'requires_python': None,
-             'stable_version': None,
-             'summary': 'An asynchronous networking framework written in Python',
-             'version': '12.3.0'},
+             'summary': 'A sample Python project',
+             'version': '1.2.0'},
+    'last_serial': 1591652,
+    'releases': {'1.0': [],
+                 '1.2.0': [{'comment_text': '',
+                            'digests': {'md5': 'bab8eb22e6710eddae3c6c7ac3453bd9',
+                                        'sha256': '7a7a8b91086deccc54cac8d631e33f6a0e232ce5775c6be3dc44f86c2154019d'},
+                            'downloads': -1,
+                            'filename': 'sampleproject-1.2.0-py2.py3-none-any.whl',
+                            'has_sig': False,
+                            'md5_digest': 'bab8eb22e6710eddae3c6c7ac3453bd9',
+                            'packagetype': 'bdist_wheel',
+                            'python_version': '2.7',
+                            'requires_python': None,
+                            'size': 3795,
+                            'upload_time': '2015-06-14T14:38:05',
+                            'url': 'https://files.pythonhosted.org/packages/30/52/547eb3719d0e872bdd6fe3ab60cef92596f95262e925e1943f68f840df88/sampleproject-1.2.0-py2.py3-none-any.whl'},
+                           {'comment_text': '',
+                            'digests': {'md5': 'd3bd605f932b3fb6e91f49be2d6f9479',
+                                        'sha256': '3427a8a5dd0c1e176da48a44efb410875b3973bd9843403a0997e4187c408dc1'},
+                            'downloads': -1,
+                            'filename': 'sampleproject-1.2.0.tar.gz',
+                            'has_sig': False,
+                            'md5_digest': 'd3bd605f932b3fb6e91f49be2d6f9479',
+                            'packagetype': 'sdist',
+                            'python_version': 'source',
+                            'requires_python': None,
+                            'size': 3148,
+                            'upload_time': '2015-06-14T14:37:56',
+                            'url': 'https://files.pythonhosted.org/packages/eb/45/79be82bdeafcecb9dca474cad4003e32ef8e4a0dec6abbd4145ccb02abe1/sampleproject-1.2.0.tar.gz'}]},
     'urls': [{'comment_text': '',
-              'downloads': 71844,
-              'filename': 'Twisted-12.3.0.tar.bz2',
+              'digests': {'md5': 'bab8eb22e6710eddae3c6c7ac3453bd9',
+                          'sha256': '7a7a8b91086deccc54cac8d631e33f6a0e232ce5775c6be3dc44f86c2154019d'},
+              'downloads': -1,
+              'filename': 'sampleproject-1.2.0-py2.py3-none-any.whl',
               'has_sig': False,
-              'md5_digest': '6e289825f3bf5591cfd670874cc0862d',
+              'md5_digest': 'bab8eb22e6710eddae3c6c7ac3453bd9',
+              'packagetype': 'bdist_wheel',
+              'python_version': '2.7',
+              'requires_python': None,
+              'size': 3795,
+              'upload_time': '2015-06-14T14:38:05',
+              'url': 'https://files.pythonhosted.org/packages/30/52/547eb3719d0e872bdd6fe3ab60cef92596f95262e925e1943f68f840df88/sampleproject-1.2.0-py2.py3-none-any.whl'},
+             {'comment_text': '',
+              'digests': {'md5': 'd3bd605f932b3fb6e91f49be2d6f9479',
+                          'sha256': '3427a8a5dd0c1e176da48a44efb410875b3973bd9843403a0997e4187c408dc1'},
+              'downloads': -1,
+              'filename': 'sampleproject-1.2.0.tar.gz',
+              'has_sig': False,
+              'md5_digest': 'd3bd605f932b3fb6e91f49be2d6f9479',
               'packagetype': 'sdist',
               'python_version': 'source',
-              'size': 2615733,
-              'upload_time': '2012-12-26T12:47:03',
-              'url': 'https://pypi.org/packages/source/T/Twisted/Twisted-12.3.0.tar.bz2'},
-             {'comment_text': '',
-              'downloads': 5224,
-              'filename': 'Twisted-12.3.0.win32-py2.7.msi',
-              'has_sig': False,
-              'md5_digest': '6b778f5201b622a5519a2aca1a2fe512',
-              'packagetype': 'bdist_msi',
-              'python_version': '2.7',
-              'size': 2916352,
-              'upload_time': '2012-12-26T12:48:15',
-              'url': 'https://pypi.org/packages/2.7/T/Twisted/Twisted-12.3.0.win32-py2.7.msi'}]}
+              'requires_python': None,
+              'size': 3148,
+              'upload_time': '2015-06-14T14:37:56',
+              'url': 'https://files.pythonhosted.org/packages/eb/45/79be82bdeafcecb9dca474cad4003e32ef8e4a0dec6abbd4145ccb02abe1/sampleproject-1.2.0.tar.gz'}]}
+
 
 The result can be limited to a certain *depth* (ellipsis is used for deeper
 contents)::
 
    >>> pprint.pprint(project_info, depth=2)
-   {'info': {'_pypi_hidden': False,
-             '_pypi_ordering': 125,
-             'author': 'Glyph Lefkowitz',
-             'author_email': 'glyph@twistedmatrix.com',
-             'bugtrack_url': '',
-             'cheesecake_code_kwalitee_id': None,
-             'cheesecake_documentation_id': None,
-             'cheesecake_installability_id': None,
+   {'info': {'author': 'The Python Packaging Authority',
+             'author_email': 'pypa-dev@googlegroups.com',
+             'bugtrack_url': None,
              'classifiers': [...],
-             'description': 'An extensible framework for Python programming, with '
-                            'special focus\r\n'
-                            'on event-based network programming and multiprotocol '
-                            'integration.',
-             'docs_url': '',
+             'description': 'A sample Python project\n'
+                            '=======================\n'
+                            '\n'
+                            'This is the description file for the project.\n'
+                            '\n'
+                            'The file should use UTF-8 encoding and be written '
+                            'using ReStructured Text. It\n'
+                            'will be used to generate the project webpage on '
+                            'PyPI, and should be written for\n'
+                            'that purpose.\n'
+                            '\n'
+                            'Typical contents for this file would include an '
+                            'overview of the project, basic\n'
+                            'usage examples, etc. Generally, including the '
+                            'project changelog in here is not\n'
+                            'a good idea, although a simple "What\'s New" section '
+                            'for the most recent version\n'
+                            'may be appropriate.',
+             'description_content_type': None,
+             'docs_url': None,
              'download_url': 'UNKNOWN',
-             'home_page': 'http://twistedmatrix.com/',
-             'keywords': '',
+             'downloads': {...},
+             'home_page': 'https://github.com/pypa/sampleproject',
+             'keywords': 'sample setuptools development',
              'license': 'MIT',
-             'maintainer': '',
-             'maintainer_email': '',
-             'name': 'Twisted',
-             'package_url': 'http://pypi.org/project/Twisted',
+             'maintainer': None,
+             'maintainer_email': None,
+             'name': 'sampleproject',
+             'package_url': 'https://pypi.org/project/sampleproject/',
              'platform': 'UNKNOWN',
-             'release_url': 'http://pypi.org/project/Twisted/12.3.0',
+             'project_url': 'https://pypi.org/project/sampleproject/',
+             'project_urls': {...},
+             'release_url': 'https://pypi.org/project/sampleproject/1.2.0/',
+             'requires_dist': None,
              'requires_python': None,
-             'stable_version': None,
-             'summary': 'An asynchronous networking framework written in Python',
-             'version': '12.3.0'},
+             'summary': 'A sample Python project',
+             'version': '1.2.0'},
+    'last_serial': 1591652,
+    'releases': {'1.0': [], '1.2.0': [...]},
     'urls': [{...}, {...}]}
 
 Additionally, maximum character *width* can be suggested. If a long object
 cannot be split, the specified width will be exceeded::
 
    >>> pprint.pprint(project_info, depth=2, width=50)
-   {'info': {'_pypi_hidden': False,
-             '_pypi_ordering': 125,
-             'author': 'Glyph Lefkowitz',
-             'author_email': 'glyph@twistedmatrix.com',
-             'bugtrack_url': '',
-             'cheesecake_code_kwalitee_id': None,
-             'cheesecake_documentation_id': None,
-             'cheesecake_installability_id': None,
+   {'info': {'author': 'The Python Packaging '
+                       'Authority',
+             'author_email': 'pypa-dev@googlegroups.com',
+             'bugtrack_url': None,
              'classifiers': [...],
-             'description': 'An extensible '
-                            'framework for Python '
-                            'programming, with '
-                            'special focus\r\n'
-                            'on event-based network '
-                            'programming and '
-                            'multiprotocol '
-                            'integration.',
-             'docs_url': '',
+             'description': 'A sample Python '
+                            'project\n'
+                            '=======================\n'
+                            '\n'
+                            'This is the '
+                            'description file for '
+                            'the project.\n'
+                            '\n'
+                            'The file should use '
+                            'UTF-8 encoding and be '
+                            'written using '
+                            'ReStructured Text. It\n'
+                            'will be used to '
+                            'generate the project '
+                            'webpage on PyPI, and '
+                            'should be written for\n'
+                            'that purpose.\n'
+                            '\n'
+                            'Typical contents for '
+                            'this file would '
+                            'include an overview of '
+                            'the project, basic\n'
+                            'usage examples, etc. '
+                            'Generally, including '
+                            'the project changelog '
+                            'in here is not\n'
+                            'a good idea, although '
+                            'a simple "What\'s New" '
+                            'section for the most '
+                            'recent version\n'
+                            'may be appropriate.',
+             'description_content_type': None,
+             'docs_url': None,
              'download_url': 'UNKNOWN',
-             'home_page': 'http://twistedmatrix.com/',
-             'keywords': '',
+             'downloads': {...},
+             'home_page': 'https://github.com/pypa/sampleproject',
+             'keywords': 'sample setuptools '
+                         'development',
              'license': 'MIT',
-             'maintainer': '',
-             'maintainer_email': '',
-             'name': 'Twisted',
-             'package_url': 'http://pypi.org/project/Twisted',
+             'maintainer': None,
+             'maintainer_email': None,
+             'name': 'sampleproject',
+             'package_url': 'https://pypi.org/project/sampleproject/',
              'platform': 'UNKNOWN',
-             'release_url': 'http://pypi.org/project/Twisted/12.3.0',
+             'project_url': 'https://pypi.org/project/sampleproject/',
+             'project_urls': {...},
+             'release_url': 'https://pypi.org/project/sampleproject/1.2.0/',
+             'requires_dist': None,
              'requires_python': None,
-             'stable_version': None,
-             'summary': 'An asynchronous networking '
-                        'framework written in '
-                        'Python',
-             'version': '12.3.0'},
+             'summary': 'A sample Python project',
+             'version': '1.2.0'},
+    'last_serial': 1591652,
+    'releases': {'1.0': [], '1.2.0': [...]},
     'urls': [{...}, {...}]}

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -218,7 +218,7 @@ let's fetch information about a project from `PyPI <https://pypi.org>`_::
    >>> import pprint
    >>> from urllib.request import urlopen
    >>> with urlopen('https://pypi.org/pypi/sampleproject/json') as resp:
-           project_info = json.load(resp)
+   ...    project_info = json.load(resp)
 
 In its basic form, :func:`pprint` shows the whole object::
 

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -218,7 +218,7 @@ let's fetch information about a project from `PyPI <https://pypi.org>`_::
    >>> import pprint
    >>> from urllib.request import urlopen
    >>> with urlopen('https://pypi.org/pypi/sampleproject/json') as resp:
-           project_info = json.loads(resp.read())
+           project_info = json.load(resp)
 
 In its basic form, :func:`pprint` shows the whole object::
 

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -218,7 +218,7 @@ let's fetch information about a project from `PyPI <https://pypi.org>`_::
    >>> import pprint
    >>> from urllib.request import urlopen
    >>> with urlopen('https://pypi.org/pypi/sampleproject/json') as resp:
-   ...    project_info = json.load(resp)['info']
+   ...     project_info = json.load(resp)['info']
 
 In its basic form, :func:`pprint` shows the whole object::
 

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -217,7 +217,7 @@ let's fetch information about a project from `PyPI <https://pypi.org>`_::
    >>> import json
    >>> import pprint
    >>> from urllib.request import urlopen
-   >>> with urlopen('http://pypi.org/project/Twisted/json') as url:
+   >>> with urlopen('https://pypi.org/pypi/Twisted/json') as url:
    ...     http_info = url.info()
    ...     raw_data = url.read().decode(http_info.get_content_charset())
    >>> project_info = json.loads(raw_data)

--- a/Doc/library/pprint.rst
+++ b/Doc/library/pprint.rst
@@ -219,7 +219,8 @@ let's fetch information about a project from `PyPI <https://pypi.org>`_::
    >>> from urllib.request import urlopen
    >>> with urlopen('https://pypi.org/pypi/Twisted/json') as url:
    ...     http_info = url.info()
-   ...     raw_data = url.read().decode(http_info.get_content_charset())
+   ...     charset = http_info.get_content_charset(failobj="utf-8")
+   ...     raw_data = url.read().decode(charset)
    >>> project_info = json.loads(raw_data)
 
 In its basic form, :func:`pprint` shows the whole object::

--- a/Doc/tools/susp-ignored.csv
+++ b/Doc/tools/susp-ignored.csv
@@ -178,9 +178,17 @@ library/pathlib,,:Program,>>> PureWindowsPath('c:Program Files/').anchor
 library/pdb,,:lineno,filename:lineno
 library/pickle,,:memory,"conn = sqlite3.connect("":memory:"")"
 library/posix,,`,"CFLAGS=""`getconf LFS_CFLAGS`"" OPT=""-g -O2 $CFLAGS"""
-library/pprint,,::,"'Programming Language :: Python :: 2 :: Only'],"
 library/pprint,,::,"'Programming Language :: Python :: 2.6',"
 library/pprint,,::,"'Programming Language :: Python :: 2.7',"
+library/pprint,225,::,"'classifiers': ['Development Status :: 3 - Alpha',"
+library/pprint,225,::,"'Intended Audience :: Developers',"
+library/pprint,225,::,"'License :: OSI Approved :: MIT License',"
+library/pprint,225,::,"'Programming Language :: Python :: 2',"
+library/pprint,225,::,"'Programming Language :: Python :: 3',"
+library/pprint,225,::,"'Programming Language :: Python :: 3.2',"
+library/pprint,225,::,"'Programming Language :: Python :: 3.3',"
+library/pprint,225,::,"'Programming Language :: Python :: 3.4',"
+library/pprint,225,::,"'Topic :: Software Development :: Build Tools'],"
 library/profile,,:lineno,filename:lineno(function)
 library/pyexpat,,:elem1,<py:elem1 />
 library/pyexpat,,:py,"xmlns:py = ""http://www.python.org/ns/"">"


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35075](https://bugs.python.org/issue35075) -->
https://bugs.python.org/issue35075
<!-- /issue-number -->
