### PR TITLE
[2.7] bpo-32804: Include the context parameter in urlretrieve documentation

### DIFF
--- a/Doc/library/urllib.rst
+++ b/Doc/library/urllib.rst
@@ -154,7 +154,7 @@ High-level interface
       of :func:`urllib2.urlopen`.
 
 
-.. function:: urlretrieve(url[, filename[, reporthook[, data]]])
+.. function:: urlretrieve(url[, filename[, reporthook[, data[, context]]]])
 
    Copy a network object denoted by a URL to a local file, if necessary. If the URL
    points to a local file, or a valid cached copy of the object exists, the object
@@ -179,6 +179,10 @@ High-level interface
    :mimetype:`application/x-www-form-urlencoded` format; see the :func:`urlencode`
    function below.
 
+   The *context* parameter may be set to a :class:`ssl.SSLContext` instance to
+   configure the SSL settings that are used if :func:`urlretrieve` makes a HTTPS
+   connection.
+
    .. versionchanged:: 2.5
       :func:`urlretrieve` will raise :exc:`ContentTooShortError` when it detects that
       the amount of data available  was less than the expected amount (which is the
@@ -195,6 +199,9 @@ High-level interface
       If no *Content-Length* header was supplied, :func:`urlretrieve` can not check
       the size of the data it has downloaded, and just returns it.  In this case you
       just have to assume that the download was successful.
+
+   .. versionchanged:: 2.7.9
+      The *context* parameter was added. All the neccessary certificate and hostname checks are done by default.
 
 
 .. data:: _urlopener

--- a/Doc/library/urllib.rst
+++ b/Doc/library/urllib.rst
@@ -201,7 +201,8 @@ High-level interface
       just have to assume that the download was successful.
 
    .. versionchanged:: 2.7.9
-      The *context* parameter was added. All the neccessary certificate and hostname checks are done by default.
+      The *context* parameter was added. All the neccessary certificate and hostname
+      checks are done by default.
 
 
 .. data:: _urlopener

--- a/Doc/library/urllib.rst
+++ b/Doc/library/urllib.rst
@@ -147,7 +147,8 @@ High-level interface
       :envvar:`no_proxy` environment variable.
 
    .. versionchanged:: 2.7.9
-      The *context* parameter was added. All the neccessary certificate and hostname checks are done by default.
+      The *context* parameter was added.  All the neccessary certificate and hostname
+      checks are done by default.
 
    .. deprecated:: 2.6
       The :func:`urlopen` function has been removed in Python 3 in favor
@@ -201,7 +202,7 @@ High-level interface
       just have to assume that the download was successful.
 
    .. versionchanged:: 2.7.9
-      The *context* parameter was added. All the neccessary certificate and hostname
+      The *context* parameter was added.  All the neccessary certificate and hostname
       checks are done by default.
 
 
@@ -356,6 +357,10 @@ URL Opener objects
 
    :class:`URLopener` objects will raise an :exc:`IOError` exception if the server
    returns an error code.
+
+   .. versionchanged:: 2.7.9
+      The *context* parameter was added.  All the neccessary certificate and hostname
+      checks are done by default.
 
    .. method:: open(fullurl[, data])
 


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32804](https://bugs.python.org/issue32804) -->
https://bugs.python.org/issue32804
<!-- /issue-number -->
