### PR TITLE
bpo-34945: Buffer output in test suite only when creating junit file

### DIFF
--- a/Lib/test/support/__init__.py
+++ b/Lib/test/support/__init__.py
@@ -1921,10 +1921,9 @@ def _filter_suite(suite, pred):
 
 def _run_suite(suite):
     """Run tests from a unittest.TestSuite-derived class."""
-    runner = get_test_runner(sys.stdout, verbosity=verbose)
-
-    # TODO: Remove this before merging (here for easy comparison with old impl)
-    #runner = unittest.TextTestRunner(sys.stdout, verbosity=2, failfast=failfast)
+    runner = get_test_runner(sys.stdout,
+                             verbosity=verbose,
+                             capture_output=(junit_xml_list is not None))
 
     result = runner.run(suite)
 

--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -60,10 +60,12 @@ class RegressionTestResult(unittest.TextTestResult):
             e.set('time', f'{time.perf_counter() - self.__start_time:0.6f}')
 
         if capture:
-            stdout = self._stdout_buffer.getvalue().rstrip()
-            ET.SubElement(e, 'system-out').text = stdout
-            stderr = self._stderr_buffer.getvalue().rstrip()
-            ET.SubElement(e, 'system-err').text = stderr
+            if self._stdout_buffer:
+                stdout = self._stdout_buffer.getvalue().rstrip()
+                ET.SubElement(e, 'system-out').text = stdout
+            if self._stderr_buffer:
+                stderr = self._stderr_buffer.getvalue().rstrip()
+                ET.SubElement(e, 'system-err').text = stderr
 
         for k, v in args.items():
             if not k or not v:
@@ -159,16 +161,16 @@ class QuietRegressionTestRunner:
         test(self.result)
         return self.result
 
-def get_test_runner_class(verbosity):
+def get_test_runner_class(verbosity, buffer=False):
     if verbosity:
         return functools.partial(unittest.TextTestRunner,
                                  resultclass=RegressionTestResult,
-                                 buffer=True,
+                                 buffer=buffer,
                                  verbosity=verbosity)
     return QuietRegressionTestRunner
 
-def get_test_runner(stream, verbosity):
-    return get_test_runner_class(verbosity)(stream)
+def get_test_runner(stream, verbosity, capture_output=False):
+    return get_test_runner_class(verbosity, capture_output)(stream)
 
 if __name__ == '__main__':
     class TestTests(unittest.TestCase):

--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -154,8 +154,9 @@ class RegressionTestResult(unittest.TextTestResult):
         return e
 
 class QuietRegressionTestRunner:
-    def __init__(self, stream):
+    def __init__(self, stream, buffer=False):
         self.result = RegressionTestResult(stream, None, 0)
+        self.result.buffer = buffer
 
     def run(self, test):
         test(self.result)
@@ -167,7 +168,7 @@ def get_test_runner_class(verbosity, buffer=False):
                                  resultclass=RegressionTestResult,
                                  buffer=buffer,
                                  verbosity=verbosity)
-    return QuietRegressionTestRunner
+    return functools.partial(QuietRegressionTestRunner, buffer=buffer)
 
 def get_test_runner(stream, verbosity, capture_output=False):
     return get_test_runner_class(verbosity, capture_output)(stream)

--- a/Lib/test/support/testresult.py
+++ b/Lib/test/support/testresult.py
@@ -60,10 +60,10 @@ class RegressionTestResult(unittest.TextTestResult):
             e.set('time', f'{time.perf_counter() - self.__start_time:0.6f}')
 
         if capture:
-            if self._stdout_buffer:
+            if self._stdout_buffer is not None:
                 stdout = self._stdout_buffer.getvalue().rstrip()
                 ET.SubElement(e, 'system-out').text = stdout
-            if self._stderr_buffer:
+            if self._stderr_buffer is not None:
                 stderr = self._stderr_buffer.getvalue().rstrip()
                 ET.SubElement(e, 'system-err').text = stderr
 


### PR DESCRIPTION
After commit d0f49d2f5085ca68e3dc8725f1fb1c9674bfb5ed, the output of the
test suite is always buffered as the test output needs to be included in
the JUnit file in same cases (as when a test fails). This has the
consequence that printing or using debuggers (like pdb) in the test
suite does not result in a good user experience anymore.

This commit modifies the test suite runner so it only captures the test
output when the JUnit file is requested to fix the regression so prints
and debuggers are usable again.

CC: @matrixise 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34945](https://bugs.python.org/issue34945) -->
https://bugs.python.org/issue34945
<!-- /issue-number -->
