### PR TITLE
bpo-16516: Allow argparse types to be unhashable

### DIFF
--- a/Lib/argparse.py
+++ b/Lib/argparse.py
@@ -1292,7 +1292,11 @@ class _ActionsContainer(object):
         registry[value] = object
 
     def _registry_get(self, registry_name, value, default=None):
-        return self._registries[registry_name].get(value, default)
+        try:
+            return self._registries[registry_name].get(value, default)
+        except TypeError:
+            # probably TypeError: unhashable type: 'dict', e.g. {}.get
+            return default
 
     # ==================================
     # Namespace default accessor methods

--- a/Lib/test/test_argparse.py
+++ b/Lib/test/test_argparse.py
@@ -4809,6 +4809,20 @@ class TestTypeFunctionCalledOnDefault(TestCase):
         args = parser.parse_args([])
         self.assertEqual(args.test, [])
 
+# =======================
+# unhashable type tests
+# =======================
+
+class TestUnhasableTypeError(TestCase):
+
+    def test_unhashable_type_noerror(self):
+        "_registry_get handles unhashable TypeError"
+        dd = dict(one=1, two=20, three=300)
+        parser = ErrorRaisingArgumentParser(prog='PROG', add_help=False)
+        parser.add_argument('x', type=dd.get)
+        args = parser.parse_args('two'.split())
+        self.assertEqual(NS(x=20), args)
+
 # ======================
 # parse_known_args tests
 # ======================

--- a/Misc/NEWS.d/next/Library/2018-10-28-16-10-45.bpo-16516.GjHIOG.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-28-16-10-45.bpo-16516.GjHIOG.rst
@@ -1,0 +1,2 @@
+Allow argparse type to be unhashable
+Patch by Braden Groom


### PR DESCRIPTION


<!-- issue-number: [bpo-16516](https://bugs.python.org/issue16516) -->
https://bugs.python.org/issue16516
<!-- /issue-number -->
