### PR TITLE
gh-79282: Fix inspect.findsource breaking on class frame objects

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -826,7 +826,7 @@ def findsource(object):
         if not hasattr(object, 'co_firstlineno'):
             raise OSError('could not find function definition')
         lnum = object.co_firstlineno - 1
-        pat = re.compile(r'^(\s*def\s)|(\s*async\s+def\s)|(.*(?<!\w)lambda(:|\s))|^(\s*@)')
+        pat = re.compile(r'^(\s*def\s)|(\s*async\s+def\s)|(.*(?<!\w)lambda(:|\s))|^(\s*class\s)|^(\s*@)')
         while lnum > 0:
             if pat.match(lines[lnum]): break
             lnum = lnum - 1

--- a/Lib/test/inspect_fodder.py
+++ b/Lib/test/inspect_fodder.py
@@ -80,3 +80,26 @@ try:
     raise Exception()
 except:
     tb = sys.exc_info()[2]
+
+# line 84
+def extra_a():
+    pass
+class A:
+    def func(self):
+        pass
+    fr = inspect.currentframe()
+
+# line 92
+extra_b = 1
+class B:
+    def func(self):
+        pass
+    fr = inspect.currentframe()
+
+# line 99
+def extra_c():
+    pass
+class C:
+    def func(self):
+        pass
+    fr = inspect.currentframe()

--- a/Lib/test/inspect_fodder.py
+++ b/Lib/test/inspect_fodder.py
@@ -82,9 +82,9 @@ except:
     tb = sys.exc_info()[2]
 
 # line 84
-def extra_a():
+def extra_c():
     pass
-class A:
+class C:
     def func(self):
         pass
     fr = inspect.currentframe()
@@ -97,9 +97,7 @@ class B:
     fr = inspect.currentframe()
 
 # line 99
-def extra_c():
-    pass
-class C:
+class A:
     def func(self):
         pass
     fr = inspect.currentframe()

--- a/Lib/test/inspect_fodder2.py
+++ b/Lib/test/inspect_fodder2.py
@@ -137,8 +137,3 @@ class cls135:
         def func137():
             never_reached1
             never_reached2
-
-#line 141
-class cls142:
-    import inspect
-    frame144 = inspect.currentframe()

--- a/Lib/test/inspect_fodder2.py
+++ b/Lib/test/inspect_fodder2.py
@@ -137,3 +137,8 @@ class cls135:
         def func137():
             never_reached1
             never_reached2
+
+#line 141
+class cls142:
+    import inspect
+    frame144 = inspect.currentframe()

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -375,6 +375,10 @@ class GetSourceBase(unittest.TestCase):
         self.assertEqual(inspect.getsource(obj),
                          self.sourcerange(top, bottom))
 
+    def assertNotSourceEqual(self, obj, top, bottom):
+        self.assertNotEqual(inspect.getsource(obj),
+                            self.sourcerange(top, bottom))
+
 class TestRetrievingSourceCode(GetSourceBase):
     fodderModule = mod
 
@@ -552,7 +556,7 @@ class TestRetrievingSourceCode(GetSourceBase):
     def test_getsource_on_code_object(self):
         self.assertSourceEqual(mod.eggs.__code__, 12, 18)
 
-class TestGettingSourceOfToplevelFrames(GetSourceBase):
+class TestGettingSourceOfFrames(GetSourceBase):
     fodderModule = mod
 
     def test_range_toplevel_frame(self):
@@ -561,6 +565,14 @@ class TestGettingSourceOfToplevelFrames(GetSourceBase):
 
     def test_range_traceback_toplevel_frame(self):
         self.assertSourceEqual(mod.tb, 1, None)
+
+    def test_class_frame(self):
+        self.assertSourceEqual(mod.A.fr, 87, 90)
+        self.assertNotSourceEqual(mod.A.fr, 85, 86)
+        self.assertSourceEqual(mod.B.fr, 94, 97)
+        self.assertNotSourceEqual(mod.B.fr, 87, 90)
+        self.assertSourceEqual(mod.C.fr, 102, 105)
+        self.assertNotSourceEqual(mod.C.fr, 100, 101)
 
 class TestDecorators(GetSourceBase):
     fodderModule = mod2
@@ -3904,7 +3916,7 @@ def test_main():
         TestBoundArguments, TestSignaturePrivateHelpers,
         TestSignatureDefinitions, TestIsDataDescriptor,
         TestGetClosureVars, TestUnwrap, TestMain, TestReload,
-        TestGetCoroutineState, TestGettingSourceOfToplevelFrames
+        TestGetCoroutineState, TestGettingSourceOfFrames
     )
 
 if __name__ == "__main__":

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -431,7 +431,6 @@ class TestRetrievingSourceCode(GetSourceBase):
     def test_getfunctions(self):
         functions = inspect.getmembers(mod, inspect.isfunction)
         self.assertEqual(functions, [('eggs', mod.eggs),
-                                     ('extra_a', mod.extra_a),
                                      ('extra_c', mod.extra_c),
                                      ('lobbest', mod.lobbest),
                                      ('spam', mod.spam)])
@@ -578,12 +577,12 @@ class TestGettingSourceOfFrames(GetSourceBase):
         self.assertSourceEqual(mod.tb, 1, None)
 
     def test_class_frame(self):
-        self.assertSourceEqual(mod.A.fr, 87, 90)
+        self.assertSourceEqual(mod.A.fr, 100, 103)
         self.assertNotSourceEqual(mod.A.fr, 85, 86)
         self.assertSourceEqual(mod.B.fr, 94, 97)
-        self.assertNotSourceEqual(mod.B.fr, 87, 90)
-        self.assertSourceEqual(mod.C.fr, 102, 105)
-        self.assertNotSourceEqual(mod.C.fr, 100, 101)
+        self.assertNotSourceEqual(mod.B.fr, 85, 86)
+        self.assertSourceEqual(mod.C.fr, 87, 90)
+        self.assertNotSourceEqual(mod.C.fr, 85, 86)
 
 class TestDecorators(GetSourceBase):
     fodderModule = mod2

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -676,6 +676,8 @@ class TestBuggyCases(GetSourceBase):
     def test_nested_func(self):
         self.assertSourceEqual(mod2.cls135.func136, 136, 139)
 
+    def test_getsource_on_class_frame(self):
+        self.assertSourceEqual(mod2.cls142.frame144, 142, 144)
 
 class TestNoEOL(GetSourceBase):
     def setUp(self):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -385,7 +385,10 @@ class TestRetrievingSourceCode(GetSourceBase):
     def test_getclasses(self):
         classes = inspect.getmembers(mod, inspect.isclass)
         self.assertEqual(classes,
-                         [('FesteringGob', mod.FesteringGob),
+                         [('A', mod.A),
+                          ('B', mod.B),
+                          ('C', mod.C),
+                          ('FesteringGob', mod.FesteringGob),
                           ('MalodorousPervert', mod.MalodorousPervert),
                           ('ParrotDroppings', mod.ParrotDroppings),
                           ('StupidGit', mod.StupidGit),
@@ -394,7 +397,10 @@ class TestRetrievingSourceCode(GetSourceBase):
         tree = inspect.getclasstree([cls[1] for cls in classes])
         self.assertEqual(tree,
                          [(object, ()),
-                          [(mod.ParrotDroppings, (object,)),
+                          [(mod.A, (object,)),
+                           (mod.B, (object,)),
+                           (mod.C, (object,)),
+                           (mod.ParrotDroppings, (object,)),
                            [(mod.FesteringGob, (mod.MalodorousPervert,
                                                    mod.ParrotDroppings))
                             ],
@@ -409,7 +415,10 @@ class TestRetrievingSourceCode(GetSourceBase):
         tree = inspect.getclasstree([cls[1] for cls in classes], True)
         self.assertEqual(tree,
                          [(object, ()),
-                          [(mod.ParrotDroppings, (object,)),
+                          [(mod.A, (object,)),
+                           (mod.B, (object,)),
+                           (mod.C, (object,)),
+                           (mod.ParrotDroppings, (object,)),
                            (mod.StupidGit, (object,)),
                            [(mod.MalodorousPervert, (mod.StupidGit,)),
                             [(mod.FesteringGob, (mod.MalodorousPervert,
@@ -422,6 +431,8 @@ class TestRetrievingSourceCode(GetSourceBase):
     def test_getfunctions(self):
         functions = inspect.getmembers(mod, inspect.isfunction)
         self.assertEqual(functions, [('eggs', mod.eggs),
+                                     ('extra_a', mod.extra_a),
+                                     ('extra_c', mod.extra_c),
                                      ('lobbest', mod.lobbest),
                                      ('spam', mod.spam)])
 

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -676,9 +676,6 @@ class TestBuggyCases(GetSourceBase):
     def test_nested_func(self):
         self.assertSourceEqual(mod2.cls135.func136, 136, 139)
 
-    def test_getsource_on_class_frame(self):
-        self.assertSourceEqual(mod2.cls142.frame144, 142, 144)
-
 class TestNoEOL(GetSourceBase):
     def setUp(self):
         self.tempdir = TESTFN + '_dir'

--- a/Misc/NEWS.d/next/Library/2018-10-29-04-14-58.bpo-35101.xImh8d.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-29-04-14-58.bpo-35101.xImh8d.rst
@@ -1,0 +1,2 @@
+Fix inspect.findsource incorrectly returning the line number of the first
+function above any given class frame objects.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35101](https://bugs.python.org/issue35101) -->
https://bugs.python.org/issue35101
<!-- /issue-number -->


<!-- gh-issue-number: gh-79282 -->
* Issue: gh-79282
<!-- /gh-issue-number -->
