### PR TITLE
bpo-35059: Remove Py_STATIC_INLINE() macro

### DIFF
--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -144,7 +144,7 @@ PyAPI_FUNC(PyVarObject *) _PyObject_NewVar(PyTypeObject *, Py_ssize_t);
    See also pymem.h.
 
    These inline functions expect non-NULL object pointers. */
-Py_STATIC_INLINE(PyObject*)
+static inline PyObject*
 PyObject_INIT(PyObject *op, PyTypeObject *typeobj)
 {
     assert(op != NULL);
@@ -153,7 +153,7 @@ PyObject_INIT(PyObject *op, PyTypeObject *typeobj)
     return op;
 }
 
-Py_STATIC_INLINE(PyVarObject*)
+static inline PyVarObject*
 PyObject_INIT_VAR(PyVarObject *op, PyTypeObject *typeobj, Py_ssize_t size)
 {
     assert(op != NULL);

--- a/Include/pydtrace.h
+++ b/Include/pydtrace.h
@@ -25,29 +25,29 @@ extern "C" {
 
 /* Without DTrace, compile to nothing. */
 
-Py_STATIC_INLINE(void) PyDTrace_LINE(const char *arg0, const char *arg1, int arg2) {}
-Py_STATIC_INLINE(void) PyDTrace_FUNCTION_ENTRY(const char *arg0, const char *arg1, int arg2)  {}
-Py_STATIC_INLINE(void) PyDTrace_FUNCTION_RETURN(const char *arg0, const char *arg1, int arg2) {}
-Py_STATIC_INLINE(void) PyDTrace_GC_START(int arg0) {}
-Py_STATIC_INLINE(void) PyDTrace_GC_DONE(int arg0) {}
-Py_STATIC_INLINE(void) PyDTrace_INSTANCE_NEW_START(int arg0) {}
-Py_STATIC_INLINE(void) PyDTrace_INSTANCE_NEW_DONE(int arg0) {}
-Py_STATIC_INLINE(void) PyDTrace_INSTANCE_DELETE_START(int arg0) {}
-Py_STATIC_INLINE(void) PyDTrace_INSTANCE_DELETE_DONE(int arg0) {}
-Py_STATIC_INLINE(void) PyDTrace_IMPORT_FIND_LOAD_START(const char *arg0) {}
-Py_STATIC_INLINE(void) PyDTrace_IMPORT_FIND_LOAD_DONE(const char *arg0, int arg1) {}
+static inline void PyDTrace_LINE(const char *arg0, const char *arg1, int arg2) {}
+static inline void PyDTrace_FUNCTION_ENTRY(const char *arg0, const char *arg1, int arg2)  {}
+static inline void PyDTrace_FUNCTION_RETURN(const char *arg0, const char *arg1, int arg2) {}
+static inline void PyDTrace_GC_START(int arg0) {}
+static inline void PyDTrace_GC_DONE(int arg0) {}
+static inline void PyDTrace_INSTANCE_NEW_START(int arg0) {}
+static inline void PyDTrace_INSTANCE_NEW_DONE(int arg0) {}
+static inline void PyDTrace_INSTANCE_DELETE_START(int arg0) {}
+static inline void PyDTrace_INSTANCE_DELETE_DONE(int arg0) {}
+static inline void PyDTrace_IMPORT_FIND_LOAD_START(const char *arg0) {}
+static inline void PyDTrace_IMPORT_FIND_LOAD_DONE(const char *arg0, int arg1) {}
 
-Py_STATIC_INLINE(int) PyDTrace_LINE_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_FUNCTION_ENTRY_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_FUNCTION_RETURN_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_GC_START_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_GC_DONE_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_INSTANCE_NEW_START_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_INSTANCE_NEW_DONE_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_INSTANCE_DELETE_START_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_INSTANCE_DELETE_DONE_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_IMPORT_FIND_LOAD_START_ENABLED(void) { return 0; }
-Py_STATIC_INLINE(int) PyDTrace_IMPORT_FIND_LOAD_DONE_ENABLED(void) { return 0; }
+static inline int PyDTrace_LINE_ENABLED(void) { return 0; }
+static inline int PyDTrace_FUNCTION_ENTRY_ENABLED(void) { return 0; }
+static inline int PyDTrace_FUNCTION_RETURN_ENABLED(void) { return 0; }
+static inline int PyDTrace_GC_START_ENABLED(void) { return 0; }
+static inline int PyDTrace_GC_DONE_ENABLED(void) { return 0; }
+static inline int PyDTrace_INSTANCE_NEW_START_ENABLED(void) { return 0; }
+static inline int PyDTrace_INSTANCE_NEW_DONE_ENABLED(void) { return 0; }
+static inline int PyDTrace_INSTANCE_DELETE_START_ENABLED(void) { return 0; }
+static inline int PyDTrace_INSTANCE_DELETE_DONE_ENABLED(void) { return 0; }
+static inline int PyDTrace_IMPORT_FIND_LOAD_START_ENABLED(void) { return 0; }
+static inline int PyDTrace_IMPORT_FIND_LOAD_DONE_ENABLED(void) { return 0; }
 
 #endif /* !WITH_DTRACE */
 

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -178,23 +178,6 @@ typedef int Py_ssize_clean_t;
 #  define Py_LOCAL_INLINE(type) static inline type
 #endif
 
-/* Declare a "static inline" function. Typical usage:
-
-     Py_STATIC_INLINE(int) add(int a, int b) { return a + b; }
-
-   If the compiler supports it, try to always inline the function even if no
-   optimization level was specified. */
-#if defined(__GNUC__) || defined(__clang__)
-#  define Py_STATIC_INLINE(TYPE) \
-       __attribute__((always_inline)) static inline TYPE
-#elif defined(_MSC_VER)
-#  define Py_STATIC_INLINE(TYPE) \
-       static __forceinline TYPE
-#else
-#  define Py_STATIC_INLINE(TYPE) static inline TYPE
-#endif
-
-
 /* Py_MEMCPY is kept for backwards compatibility,
  * see https://bugs.python.org/issue28126 */
 #define Py_MEMCPY memcpy


### PR DESCRIPTION
"static inline" should be used directly. Forcing the compiler to
inline is not recommended.

<!-- issue-number: [bpo-35059](https://bugs.python.org/issue35059) -->
https://bugs.python.org/issue35059
<!-- /issue-number -->
