### PR TITLE
bpo-35062: Fix parsing _io.IncrementalNewlineDecoder's *translate* argument.

### DIFF
--- a/Lib/test/test_io.py
+++ b/Lib/test/test_io.py
@@ -3748,6 +3748,16 @@ class IncrementalNewlineDecoderTest(unittest.TestCase):
         dec = self.IncrementalNewlineDecoder(None, translate=True)
         _check(dec)
 
+    def test_translate(self):
+        # issue 35062
+        for translate in (-2, -1, 1, 2):
+            decoder = codecs.getincrementaldecoder("utf-8")()
+            decoder = self.IncrementalNewlineDecoder(decoder, translate)
+            self.check_newline_decoding_utf8(decoder)
+        decoder = codecs.getincrementaldecoder("utf-8")()
+        decoder = self.IncrementalNewlineDecoder(decoder, translate=0)
+        self.assertEqual(decoder.decode(b"\r\r\n"), "\r\r\n")
+
 class CIncrementalNewlineDecoderTest(IncrementalNewlineDecoderTest):
     pass
 

--- a/Misc/NEWS.d/next/Library/2018-10-29-23-09-24.bpo-35062.dQS1ng.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-29-23-09-24.bpo-35062.dQS1ng.rst
@@ -1,0 +1,2 @@
+Fix incorrect parsing of :class:`_io.IncrementalNewlineDecoder`'s
+*translate* argument.

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -261,7 +261,7 @@ _io_IncrementalNewlineDecoder___init___impl(nldecoder_object *self,
     }
     Py_INCREF(self->errors);
 
-    self->translate = translate;
+    self->translate = translate ? 1 : 0;
     self->seennl = 0;
     self->pendingcr = 0;
 


### PR DESCRIPTION
_io.IncrementalNewlineDecoder's initializer possibly assigns out-of-range
value to the bitwise struct field.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35062](https://bugs.python.org/issue35062) -->
https://bugs.python.org/issue35062
<!-- /issue-number -->
