### PR TITLE
[2.7] Fix a possible "double decref" in termios.tcgetattr(). (GH-10194)

### DIFF
--- a/Modules/termios.c
+++ b/Modules/termios.c
@@ -120,11 +120,11 @@ termios_tcgetattr(PyObject *self, PyObject *args)
     PyList_SetItem(v, 3, PyInt_FromLong((long)mode.c_lflag));
     PyList_SetItem(v, 4, PyInt_FromLong((long)ispeed));
     PyList_SetItem(v, 5, PyInt_FromLong((long)ospeed));
-    PyList_SetItem(v, 6, cc);
-    if (PyErr_Occurred()){
+    if (PyErr_Occurred()) {
         Py_DECREF(v);
         goto err;
     }
+    PyList_SetItem(v, 6, cc);
     return v;
   err:
     Py_DECREF(cc);


### PR DESCRIPTION
(cherry picked from commit 53835e92d315340444e3dd083b3f69a590b00e07)