### PR TITLE
bpo-34160: Preserves order of minidom of Element attributes

### DIFF
--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -143,6 +143,9 @@ module documentation.  This section lists the differences between the API and
    For the :class:`Document` node, an additional keyword argument *encoding* can
    be used to specify the encoding field of the XML header.
 
+   .. versionchanged:: 3.8
+      The :meth:`writexml` method now preserves the attribute order specified
+      by the user.
 
 .. method:: Node.toxml(encoding=None)
 
@@ -156,6 +159,10 @@ module documentation.  This section lists the differences between the API and
    encoding. Encoding this string in an encoding other than UTF-8 is
    likely incorrect, since UTF-8 is the default encoding of XML.
 
+   .. versionchanged:: 3.8
+      The :meth:`toxml` method now preserves the attribute order specified
+      by the user.
+
 .. method:: Node.toprettyxml(indent="", newl="", encoding="")
 
    Return a pretty-printed version of the document. *indent* specifies the
@@ -164,6 +171,10 @@ module documentation.  This section lists the differences between the API and
 
    The *encoding* argument behaves like the corresponding argument of
    :meth:`toxml`.
+
+   .. versionchanged:: 3.8
+      The :meth:`toprettyxml` method now preserves the attribute order specified
+      by the user.
 
 
 .. _dom-example:

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -2,6 +2,8 @@
 
 import copy
 import pickle
+import io
+import contextlib
 from test.support import findfile
 import unittest
 
@@ -1559,6 +1561,29 @@ class MinidomTest(unittest.TestCase):
         doc = parse(tstfile)
         pi = doc.createProcessingInstruction("y", "z")
         pi.nodeValue = "crash"
+
+    def test_minidom_attribute_order(self):
+        xml_str = '<?xml version="1.0" ?><curriculum status="public" company="example"/>'
+        doc = parseString(xml_str)
+        output = io.StringIO()
+
+        with contextlib.redirect_stdout(output) as xml_file:
+            doc.writexml(xml_file)
+        self.assertEqual(output.getvalue(),
+                         '<?xml version="1.0" ?><curriculum status="public" company="example"/>')
+
+    def test_toxml_with_attributes_ordered(self):
+        xml_str = '<?xml version="1.0" ?><curriculum status="public" company="example"/>'
+        doc = parseString(xml_str)
+        self.assertEqual(doc.toxml(),
+                         '<?xml version="1.0" ?><curriculum status="public" company="example"/>')
+
+    def test_toprettyxml_with_attributes_ordered(self):
+        xml_str = '<?xml version="1.0" ?><curriculum status="public" company="example"/>'
+        doc = parseString(xml_str)
+        self.assertEqual(doc.toprettyxml(),
+                         '<?xml version="1.0" ?>\n'
+                         '<curriculum status="public" company="example"/>\n')
 
 if __name__ == "__main__":
     unittest.main()

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -1566,17 +1566,13 @@ class MinidomTest(unittest.TestCase):
         xml_str = '<?xml version="1.0" ?><curriculum status="public" company="example"/>'
         doc = parseString(xml_str)
         output = io.StringIO()
-
-        with contextlib.redirect_stdout(output) as xml_file:
-            doc.writexml(xml_file)
-        self.assertEqual(output.getvalue(),
-                         '<?xml version="1.0" ?><curriculum status="public" company="example"/>')
+        doc.writexml(output)
+        self.assertEqual(output.getvalue(), xml_str)
 
     def test_toxml_with_attributes_ordered(self):
         xml_str = '<?xml version="1.0" ?><curriculum status="public" company="example"/>'
         doc = parseString(xml_str)
-        self.assertEqual(doc.toxml(),
-                         '<?xml version="1.0" ?><curriculum status="public" company="example"/>')
+        self.assertEqual(doc.toxml(), xml_str)
 
     def test_toprettyxml_with_attributes_ordered(self):
         xml_str = '<?xml version="1.0" ?><curriculum status="public" company="example"/>'

--- a/Lib/xml/dom/minidom.py
+++ b/Lib/xml/dom/minidom.py
@@ -854,9 +854,8 @@ class Element(Node):
         writer.write(indent+"<" + self.tagName)
 
         attrs = self._get_attributes()
-        a_names = sorted(attrs.keys())
 
-        for a_name in a_names:
+        for a_name in attrs.keys():
             writer.write(" %s=\"" % a_name)
             _write_data(writer, attrs[a_name].value)
             writer.write("\"")

--- a/Misc/NEWS.d/next/Library/2018-10-27-21-11-42.bpo-34160.UzyPZf.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-27-21-11-42.bpo-34160.UzyPZf.rst
@@ -1,1 +1,1 @@
-ElementTree now preserves the attribute order specified by the user.
+ElementTree and minidom now preserve the attribute order specified by the user.


### PR DESCRIPTION
This PR is a continuation of the work in https://github.com/python/cpython/pull/10163

<!-- issue-number: [bpo-34160](https://bugs.python.org/issue34160) -->
https://bugs.python.org/issue34160
<!-- /issue-number -->
