### PR TITLE
[3.6] bpo-28655: Fix test bdb for isolate mode

### DIFF
--- a/Lib/test/test_bdb.py
+++ b/Lib/test/test_bdb.py
@@ -526,13 +526,13 @@ def run_test(modules, set_list, skip=None):
     test.id = lambda : None
     test.expect_set = list(gen(repeat(()), iter(sl)))
     with create_modules(modules):
-        sys.path.append(os.getcwd())
         with TracerRun(test, skip=skip) as tracer:
             tracer.runcall(tfunc_import)
 
 @contextmanager
 def create_modules(modules):
     with test.support.temp_cwd():
+        sys.path.append(os.getcwd())
         try:
             for m in modules:
                 fname = m + '.py'
@@ -544,6 +544,7 @@ def create_modules(modules):
         finally:
             for m in modules:
                 test.support.forget(m)
+            sys.path.pop()
 
 def break_in_func(funcname, fname=__file__, temporary=False, cond=None):
     return 'break', (fname, None, temporary, cond, funcname)


### PR DESCRIPTION
Fix test_bdb when running Python is isolated mode (python3 -I).


<!-- issue-number: [bpo-28655](https://bugs.python.org/issue28655) -->
https://bugs.python.org/issue28655
<!-- /issue-number -->
