### PR TITLE
[2.7] bpo-3243: Support iterable bodies in httplib

### DIFF
--- a/Lib/httplib.py
+++ b/Lib/httplib.py
@@ -71,6 +71,7 @@ import os
 import re
 import socket
 from sys import py3kwarning
+import collections
 from urlparse import urlsplit
 import warnings
 with warnings.catch_warnings():
@@ -855,7 +856,15 @@ class HTTPConnection:
                 self.sock.sendall(datablock)
                 datablock = data.read(blocksize)
         else:
-            self.sock.sendall(data)
+            try:
+                self.sock.sendall(data)
+            except TypeError:
+                if isinstance(data, collections.Iterable):
+                    for d in data:
+                        self.sock.sendall(d)
+                else:
+                    raise TypeError("data should be a bytes-like object "
+                                    "or an iterable, got %r" % type(data))
 
     def _output(self, s):
         """Add a line of output to the current request buffer.

--- a/Lib/test/test_httplib.py
+++ b/Lib/test/test_httplib.py
@@ -545,6 +545,22 @@ class BasicTest(TestCase):
         conn.send(StringIO.StringIO(expected))
         self.assertEqual(expected, sock.data)
 
+    def test_send_iter(self):
+        expected = b'GET /foo HTTP/1.1\r\nHost: example.com\r\n' \
+                   b'Accept-Encoding: identity\r\nContent-Length: 11\r\n' \
+                   b'\r\nonetwothree'
+
+        def body():
+            yield b"one"
+            yield b"two"
+            yield b"three"
+
+        conn = httplib.HTTPConnection('example.com')
+        sock = FakeSocket("")
+        conn.sock = sock
+        conn.request('GET', '/foo', body(), {'Content-Length': '11'})
+        self.assertEquals(sock.data, expected)
+
     def test_chunked(self):
         chunked_start = (
             'HTTP/1.1 200 OK\r\n'

--- a/Misc/NEWS.d/next/Library/2018-10-29-22-12-31.bpo-3243.-ytiRj.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-29-22-12-31.bpo-3243.-ytiRj.rst
@@ -1,0 +1,1 @@
+Support iterable bodies in httplib.


### PR DESCRIPTION
I know this is kinda late to the party, but this is not a new functionality API-wise, but a feature parity is required to make HTTP libraries such as requests (and others), be able to send data efficiently.

requests for example uses this piece of code to send the POST data over the HTTP socket if the connection is not chunked. But if the POST data is an iterable object (for example, you want to send the data natively how you stored it, and not split it of read it in 8192 or block chunks), Python 3 works just fine, but Python 2 borks on the sendall(iterable), this fixes this issue...

<!-- issue-number: [bpo-3243](https://bugs.python.org/issue3243) -->
https://bugs.python.org/issue3243
<!-- /issue-number -->
