### PR TITLE
bpo-34523: Fix config_init_fs_encoding() for ASCII

### DIFF
--- a/Include/coreconfig.h
+++ b/Include/coreconfig.h
@@ -75,6 +75,8 @@ typedef struct {
          highest priority;
        * PYTHONIOENCODING environment variable;
        * The UTF-8 Mode uses UTF-8/surrogateescape;
+       * If Python forces the usage of the ASCII encoding (ex: C locale
+         or POSIX locale on FreeBSD or HP-UX), use ASCII/surrogateescape;
        * locale encoding: ANSI code page on Windows, UTF-8 on Android,
          LC_CTYPE locale encoding on other platforms;
        * On Windows, "surrogateescape" error handler;


### PR DESCRIPTION
* [bpo-34523](https://bugs.python.org/issue34523), [bpo-34403](https://bugs.python.org/issue34403): Fix config_init_fs_encoding(): it now uses
  ASCII if _Py_GetForceASCII() is true.
* Fix a regression of commit b2457efc78b74a1d6d1b77d11a939e886b8a4e2c.
* Fix also a memory leak: get_locale_encoding() already allocates
  memory, no need to duplicate the string.

<!-- issue-number: [bpo-34523](https://bugs.python.org/issue34523) -->
https://bugs.python.org/issue34523
<!-- /issue-number -->
