### PR TITLE
[3.7] bpo-34403: Fix initfsencoding() for ASCII

### DIFF
--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -183,6 +183,10 @@ PyAPI_FUNC(int) _Py_GetLocaleconvNumeric(
 
 #endif   /* Py_LIMITED_API */
 
+#ifdef Py_BUILD_CORE
+PyAPI_FUNC(int) _Py_GetForceASCII(void);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -180,6 +180,18 @@ error:
     return 1;
 }
 
+
+int
+_Py_GetForceASCII(void)
+{
+    if (force_ascii == -1) {
+        force_ascii = check_force_ascii();
+    }
+    return force_ascii;
+}
+
+
+
 static int
 encode_ascii(const wchar_t *text, char **str,
              size_t *error_pos, const char **reason,

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1615,6 +1615,10 @@ initfsencoding(PyInterpreterState *interp)
         Py_FileSystemDefaultEncoding = "utf-8";
         Py_HasFileSystemDefaultEncoding = 1;
     }
+    else if (_Py_GetForceASCII()) {
+        Py_FileSystemDefaultEncoding = "ascii";
+        Py_HasFileSystemDefaultEncoding = 1;
+    }
     else if (Py_FileSystemDefaultEncoding == NULL) {
         Py_FileSystemDefaultEncoding = get_locale_encoding();
         if (Py_FileSystemDefaultEncoding == NULL) {


### PR DESCRIPTION
* Add _Py_GetForceASCII(): check if Python forces the usage of ASCII
  in Py_DecodeLocale() and Py_EncodeLocale().
* initfsencoding() now uses ASCII if _Py_GetForceASCII() is true.

<!-- issue-number: [bpo-34403](https://bugs.python.org/issue34403) -->
https://bugs.python.org/issue34403
<!-- /issue-number -->
