### PR TITLE
bpo-25750: Fix a compiler warning introduced in #9084.

### DIFF
--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4584,10 +4584,10 @@ new_hamt(PyObject *self, PyObject *args)
        return repr(self)
 */
 static PyObject*
-bad_get(PyObject *module, PyObject *args)
+bad_get(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
 {
     PyObject *self, *obj, *cls;
-    if (!PyArg_UnpackTuple(args, "bad_get", 3, 3, &self, &obj, &cls)) {
+    if (!_PyArg_UnpackStack(args, nargs, "bad_get", 3, 3, &self, &obj, &cls)) {
         return NULL;
     }
 
@@ -4960,7 +4960,7 @@ static PyMethodDef TestMethods[] = {
     {"get_mapping_items", get_mapping_items, METH_O},
     {"test_pythread_tss_key_state", test_pythread_tss_key_state, METH_VARARGS},
     {"hamt", new_hamt, METH_NOARGS},
-    {"bad_get", bad_get, METH_VARARGS},
+    {"bad_get", (PyCFunction)bad_get, METH_FASTCALL},
     {"EncodeLocaleEx", encode_locale_ex, METH_VARARGS},
     {"DecodeLocaleEx", decode_locale_ex, METH_VARARGS},
     {"get_global_config", get_global_config, METH_NOARGS},

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4584,20 +4584,20 @@ new_hamt(PyObject *self, PyObject *args)
        return repr(self)
 */
 static PyObject*
-bad_get(PyObject *module, PyObject *const *args, Py_ssize_t nargs)
+bad_get(PyObject *module, PyObject *args)
 {
-    if (nargs != 3) {
-        PyErr_SetString(PyExc_TypeError, "bad_get requires exactly 3 arguments");
+    PyObject *self, *obj, *cls;
+    if (!PyArg_UnpackTuple(args, "bad_get", 3, 3, &self, &obj, &cls)) {
         return NULL;
     }
 
-    PyObject *res = PyObject_CallObject(args[2], NULL);
+    PyObject *res = PyObject_CallObject(cls, NULL);
     if (res == NULL) {
         return NULL;
     }
     Py_DECREF(res);
 
-    return PyObject_Repr(args[0]);
+    return PyObject_Repr(self);
 }
 
 
@@ -4960,7 +4960,7 @@ static PyMethodDef TestMethods[] = {
     {"get_mapping_items", get_mapping_items, METH_O},
     {"test_pythread_tss_key_state", test_pythread_tss_key_state, METH_VARARGS},
     {"hamt", new_hamt, METH_NOARGS},
-    {"bad_get", bad_get, METH_FASTCALL},
+    {"bad_get", bad_get, METH_VARARGS},
     {"EncodeLocaleEx", encode_locale_ex, METH_VARARGS},
     {"DecodeLocaleEx", decode_locale_ex, METH_VARARGS},
     {"get_global_config", get_global_config, METH_NOARGS},


### PR DESCRIPTION
See #9084.

<!-- issue-number: [bpo-25750](https://bugs.python.org/issue25750) -->
https://bugs.python.org/issue25750
<!-- /issue-number -->
