### PR TITLE
[3.7] bpo-34403: Always implement _Py_GetForceASCII()

### DIFF
--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -246,6 +246,12 @@ encode_ascii(const wchar_t *text, char **str,
     *str = result;
     return 0;
 }
+#else
+int
+_Py_GetForceASCII(void)
+{
+    return 0;
+}
 #endif   /* !defined(__APPLE__) && !defined(__ANDROID__) && !defined(MS_WINDOWS) */
 
 


### PR DESCRIPTION
Compilation fails on macOS because _Py_GetForceASCII() wasn't define:
always implement implement (default implementation: just return 0).

<!-- issue-number: [bpo-34403](https://bugs.python.org/issue34403) -->
https://bugs.python.org/issue34403
<!-- /issue-number -->
