### PR TITLE
bpo-32030: Make _PySys_AddXOptionWithError() private

### DIFF
--- a/Include/sysmodule.h
+++ b/Include/sysmodule.h
@@ -37,11 +37,6 @@ PyAPI_FUNC(PyObject *) PySys_GetXOptions(void);
 PyAPI_FUNC(size_t) _PySys_GetSizeOf(PyObject *);
 #endif
 
-#ifdef Py_BUILD_CORE
-PyAPI_FUNC(int) _PySys_AddXOptionWithError(const wchar_t *s);
-PyAPI_FUNC(int) _PySys_AddWarnOptionWithError(PyObject *option);
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -1807,7 +1807,7 @@ PySys_ResetWarnOptions(void)
     PyList_SetSlice(warnoptions, 0, PyList_GET_SIZE(warnoptions), NULL);
 }
 
-int
+static int
 _PySys_AddWarnOptionWithError(PyObject *option)
 {
     PyObject *warnoptions = get_warnoptions();
@@ -1823,7 +1823,12 @@ _PySys_AddWarnOptionWithError(PyObject *option)
 void
 PySys_AddWarnOptionUnicode(PyObject *option)
 {
-    (void)_PySys_AddWarnOptionWithError(option);
+    if (_PySys_AddWarnOptionWithError(option) < 0) {
+        /* No return value, therefore clear error state if possible */
+        if (_PyThreadState_UncheckedGet()) {
+            PyErr_Clear();
+        }
+    }
 }
 
 void
@@ -1877,7 +1882,7 @@ get_xoptions(void)
     return xoptions;
 }
 
-int
+static int
 _PySys_AddXOptionWithError(const wchar_t *s)
 {
     PyObject *name = NULL, *value = NULL;


### PR DESCRIPTION
Make _PySys_AddXOptionWithError() and _PySys_AddWarnOptionWithError()
functions private again. They are no longer need to initalize Python:
_PySys_EndInit() is now responsible to add these options instead.

Moreover, PySys_AddWarnOptionUnicode() now clears the exception on
failure if possible.

<!-- issue-number: [bpo-32030](https://bugs.python.org/issue32030) -->
https://bugs.python.org/issue32030
<!-- /issue-number -->
