### PR TITLE
bpo-25416: add aliases for cp874 and mac_cyrillic encodings

### DIFF
--- a/Lib/encodings/aliases.py
+++ b/Lib/encodings/aliases.py
@@ -204,6 +204,10 @@ aliases = {
     'csibm869'           : 'cp869',
     'ibm869'             : 'cp869',
 
+    # cp874 codec
+    'windows_874'        : 'cp874',
+
+
     # cp932 codec
     '932'                : 'cp932',
     'ms932'              : 'cp932',
@@ -439,6 +443,7 @@ aliases = {
 
     # mac_cyrillic codec
     'maccyrillic'        : 'mac_cyrillic',
+    'x_mac_cyrillic'     : 'mac_cyrillic',
 
     # mac_greek codec
     'macgreek'           : 'mac_greek',


### PR DESCRIPTION
Hi all!

This PR is about issue 25416 that is also closely related with with [bpo-18624](https://bugs.python.org/issue18624), both deal with missing aliases in the encondings module.

In this changeset I only tackled the lack of aliases reported on 25416 but I'm still missing tests on it. Reading through 18624, I noted that the file suggested by @bitdancer - `test_encodings.py` - is missing. The author of 18624's patch added a test on `test_codecs.py` but that test seems incomplete.

I'm considering add a test that checks if all the aliases are implemented and another one that checks if they are mapped to correct encodings. I'd be glad if a core dev could give me a guidance in how to proceed with that. 

Thank you!

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-25416](https://bugs.python.org/issue25416) -->
https://bugs.python.org/issue25416
<!-- /issue-number -->
