### PR TITLE
bpo-35081: Remove Py_BUILD_CORE from datetime.h

### DIFF
--- a/Include/datetime.h
+++ b/Include/datetime.h
@@ -181,11 +181,10 @@ typedef struct {
 
 
 /* When datetime.h is included from _datetimemodule.c,
-   the PyDateTimeAPI variable must not be defined. */
+   the macros are defines in _datetimemodule.c. */
 #ifndef _PY_DATETIME_IMPL
 /* Define global variable for the C API and a macro for setting it. */
 static PyDateTime_CAPI *PyDateTimeAPI = NULL;
-#endif
 
 #define PyDateTime_IMPORT \
     PyDateTimeAPI = (PyDateTime_CAPI *)PyCapsule_Import(PyDateTime_CAPSULE_NAME, 0)
@@ -208,6 +207,8 @@ static PyDateTime_CAPI *PyDateTimeAPI = NULL;
 
 #define PyTZInfo_Check(op) PyObject_TypeCheck(op, PyDateTimeAPI->TZInfoType)
 #define PyTZInfo_CheckExact(op) (Py_TYPE(op) == PyDateTimeAPI->TZInfoType)
+#endif   /* !defined(_PY_DATETIME_IMPL) */
+
 
 /* Macros for accessing constructors in a simplified fashion. */
 #define PyDate_FromDate(year, month, day) \

--- a/Include/datetime.h
+++ b/Include/datetime.h
@@ -181,7 +181,7 @@ typedef struct {
 
 
 /* When datetime.h is included from _datetimemodule.c,
-   the macros are defines in _datetimemodule.c. */
+   the macros are defined in _datetimemodule.c. */
 #ifndef _PY_DATETIME_IMPL
 /* Define global variable for the C API and a macro for setting it. */
 static PyDateTime_CAPI *PyDateTimeAPI = NULL;

--- a/Include/datetime.h
+++ b/Include/datetime.h
@@ -180,8 +180,12 @@ typedef struct {
 #define PyDateTime_CAPSULE_NAME "datetime.datetime_CAPI"
 
 
+/* When datetime.h is included from _datetimemodule.c,
+   the PyDateTimeAPI variable must not be defined. */
+#ifndef _PY_DATETIME_IMPL
 /* Define global variable for the C API and a macro for setting it. */
 static PyDateTime_CAPI *PyDateTimeAPI = NULL;
+#endif
 
 #define PyDateTime_IMPORT \
     PyDateTimeAPI = (PyDateTime_CAPI *)PyCapsule_Import(PyDateTime_CAPSULE_NAME, 0)

--- a/Include/datetime.h
+++ b/Include/datetime.h
@@ -180,26 +180,6 @@ typedef struct {
 #define PyDateTime_CAPSULE_NAME "datetime.datetime_CAPI"
 
 
-#ifdef Py_BUILD_CORE
-
-/* Macros for type checking when building the Python core. */
-#define PyDate_Check(op) PyObject_TypeCheck(op, &PyDateTime_DateType)
-#define PyDate_CheckExact(op) (Py_TYPE(op) == &PyDateTime_DateType)
-
-#define PyDateTime_Check(op) PyObject_TypeCheck(op, &PyDateTime_DateTimeType)
-#define PyDateTime_CheckExact(op) (Py_TYPE(op) == &PyDateTime_DateTimeType)
-
-#define PyTime_Check(op) PyObject_TypeCheck(op, &PyDateTime_TimeType)
-#define PyTime_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TimeType)
-
-#define PyDelta_Check(op) PyObject_TypeCheck(op, &PyDateTime_DeltaType)
-#define PyDelta_CheckExact(op) (Py_TYPE(op) == &PyDateTime_DeltaType)
-
-#define PyTZInfo_Check(op) PyObject_TypeCheck(op, &PyDateTime_TZInfoType)
-#define PyTZInfo_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TZInfoType)
-
-#else
-
 /* Define global variable for the C API and a macro for setting it. */
 static PyDateTime_CAPI *PyDateTimeAPI = NULL;
 
@@ -263,8 +243,6 @@ static PyDateTime_CAPI *PyDateTimeAPI = NULL;
 #define PyDate_FromTimestamp(args) \
     PyDateTimeAPI->Date_FromTimestamp( \
         (PyObject*) (PyDateTimeAPI->DateType), args)
-
-#endif  /* Py_BUILD_CORE */
 
 #ifdef __cplusplus
 }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3,6 +3,7 @@
  */
 
 #include "Python.h"
+#include "datetime.h"
 #include "structmember.h"
 
 #include <time.h>
@@ -11,14 +12,32 @@
 #  include <winsock2.h>         /* struct timeval */
 #endif
 
-/* Differentiate between building the core module and building extension
- * modules.
- */
-#ifndef Py_BUILD_CORE
-#define Py_BUILD_CORE
-#endif
-#include "datetime.h"
-#undef Py_BUILD_CORE
+
+#undef PyDate_Check
+#undef PyDate_CheckExact
+#define PyDate_Check(op) PyObject_TypeCheck(op, &PyDateTime_DateType)
+#define PyDate_CheckExact(op) (Py_TYPE(op) == &PyDateTime_DateType)
+
+#undef PyDateTime_Check
+#undef PyDateTime_CheckExact
+#define PyDateTime_Check(op) PyObject_TypeCheck(op, &PyDateTime_DateTimeType)
+#define PyDateTime_CheckExact(op) (Py_TYPE(op) == &PyDateTime_DateTimeType)
+
+#undef PyTime_Check
+#undef PyTime_CheckExact
+#define PyTime_Check(op) PyObject_TypeCheck(op, &PyDateTime_TimeType)
+#define PyTime_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TimeType)
+
+#undef PyDelta_Check
+#undef PyDelta_CheckExact
+#define PyDelta_Check(op) PyObject_TypeCheck(op, &PyDateTime_DeltaType)
+#define PyDelta_CheckExact(op) (Py_TYPE(op) == &PyDateTime_DeltaType)
+
+#undef PyTZInfo_Check
+#undef PyTZInfo_CheckExact
+#define PyTZInfo_Check(op) PyObject_TypeCheck(op, &PyDateTime_TZInfoType)
+#define PyTZInfo_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TZInfoType)
+
 
 /*[clinic input]
 module datetime

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -2,6 +2,10 @@
  *  http://www.zope.org/Members/fdrake/DateTimeWiki/FrontPage
  */
 
+/* When datetime.h is included from _datetimemodule.c,
+   the PyDateTimeAPI variable must not be defined. */
+#define _PY_DATETIME_IMPL
+
 #include "Python.h"
 #include "datetime.h"
 #include "structmember.h"

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -38,6 +38,8 @@
 #define PyTZInfo_Check(op) PyObject_TypeCheck(op, &PyDateTime_TZInfoType)
 #define PyTZInfo_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TZInfoType)
 
+#undef PyDateTime_TimeZone_UTC
+
 
 /*[clinic input]
 module datetime

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -12,6 +12,8 @@
 #  include <winsock2.h>         /* struct timeval */
 #endif
 
+/* Redefine macros defined in datetime.h to use directly types,
+   rather than getting types from PyDateTimeAPI. */
 
 #undef PyDate_Check
 #undef PyDate_CheckExact

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3,7 +3,7 @@
  */
 
 /* When datetime.h is included from _datetimemodule.c,
-   the PyDateTimeAPI variable must not be defined. */
+   the macros are defines in _datetimemodule.c. */
 #define _PY_DATETIME_IMPL
 
 #include "Python.h"
@@ -16,35 +16,20 @@
 #  include <winsock2.h>         /* struct timeval */
 #endif
 
-/* Redefine macros defined in datetime.h to use directly types,
-   rather than getting types from PyDateTimeAPI. */
-
-#undef PyDate_Check
-#undef PyDate_CheckExact
 #define PyDate_Check(op) PyObject_TypeCheck(op, &PyDateTime_DateType)
 #define PyDate_CheckExact(op) (Py_TYPE(op) == &PyDateTime_DateType)
 
-#undef PyDateTime_Check
-#undef PyDateTime_CheckExact
 #define PyDateTime_Check(op) PyObject_TypeCheck(op, &PyDateTime_DateTimeType)
 #define PyDateTime_CheckExact(op) (Py_TYPE(op) == &PyDateTime_DateTimeType)
 
-#undef PyTime_Check
-#undef PyTime_CheckExact
 #define PyTime_Check(op) PyObject_TypeCheck(op, &PyDateTime_TimeType)
 #define PyTime_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TimeType)
 
-#undef PyDelta_Check
-#undef PyDelta_CheckExact
 #define PyDelta_Check(op) PyObject_TypeCheck(op, &PyDateTime_DeltaType)
 #define PyDelta_CheckExact(op) (Py_TYPE(op) == &PyDateTime_DeltaType)
 
-#undef PyTZInfo_Check
-#undef PyTZInfo_CheckExact
 #define PyTZInfo_Check(op) PyObject_TypeCheck(op, &PyDateTime_TZInfoType)
 #define PyTZInfo_CheckExact(op) (Py_TYPE(op) == &PyDateTime_TZInfoType)
-
-#undef PyDateTime_TimeZone_UTC
 
 
 /*[clinic input]


### PR DESCRIPTION
Datetime macros like PyDate_Check() are now reimplemented in
_datetimemodule.c, rather than having two implementations depending
on Py_BUILD_CORE in datetime.h.

These macros are not used outside _datetimemodule.c.

<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
