### PR TITLE
bpo-35115 Add __index__ to UUID class

### DIFF
--- a/Lib/test/test_uuid.py
+++ b/Lib/test/test_uuid.py
@@ -29,7 +29,7 @@ class BaseTestUUID:
     def test_UUID(self):
         equal = self.assertEqual
         ascending = []
-        for (string, curly, hex, bytes, bytes_le, fields, integer, urn,
+        for (string, curly, hex_, bytes, bytes_le, fields, integer, urn,
              time, clock_seq, variant, version) in [
             ('00000000-0000-0000-0000-000000000000',
              '{00000000-0000-0000-0000-000000000000}',
@@ -167,6 +167,7 @@ class BaseTestUUID:
                 # Test all conversions and properties of the UUID object.
                 equal(str(u), string)
                 equal(int(u), integer)
+                equal(hex(u), hex_)
                 equal(u.bytes, bytes)
                 equal(u.bytes_le, bytes_le)
                 equal(u.fields, fields)
@@ -176,7 +177,7 @@ class BaseTestUUID:
                 equal(u.clock_seq_hi_variant, fields[3])
                 equal(u.clock_seq_low, fields[4])
                 equal(u.node, fields[5])
-                equal(u.hex, hex)
+                equal(u.hex, hex_)
                 equal(u.int, integer)
                 equal(u.urn, urn)
                 equal(u.time, time)

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -254,6 +254,9 @@ class UUID:
 
     def __int__(self):
         return self.int
+    
+    def __index__(self):
+        return self.int
 
     def __repr__(self):
         return '%s(%r)' % (self.__class__.__name__, str(self))

--- a/Lib/uuid.py
+++ b/Lib/uuid.py
@@ -252,10 +252,10 @@ class UUID:
     def __hash__(self):
         return hash(self.int)
 
-    def __int__(self):
-        return self.int
-    
     def __index__(self):
+        return self.int
+
+    def __int__(self):
         return self.int
 
     def __repr__(self):

--- a/Misc/NEWS.d/next/Library/2018-10-30-10-28-00.bpo-35115.ge6jv9.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-30-10-28-00.bpo-35115.ge6jv9.rst
@@ -1,0 +1,1 @@
+``UUID`` objects can now be casted by using the built-in function ``hex()``. Patch by Flavio Curella.


### PR DESCRIPTION
Casting a UUID to an `int` or to a string works as expected:

```python
import uuid

value = uuid.UUID()
str(value)
int(value)
```

but casting to an `hex()` raises an exception:

```python
import uuid

value = uuid.UUID()

# uuid instances already have the correct value stored in the `.hex` attribute
value.hex

# this raises `TypeError: 'UUID' object cannot be interpreted as an integer`
hex(value)

# this behaves correctly
hex(value.int)

```

Adding support for `hex()` should be simple enough as adding the following to the UUID class in: https://github.com/python/cpython/blob/54752533b2ed1c898ffe5ec2e795c6910ee46a39/Lib/uuid.py#L69

```python
def __index__(self):
    return self.int
```

<!-- issue-number: [bpo-35115](https://bugs.python.org/issue35115) -->
https://bugs.python.org/issue35115
<!-- /issue-number -->
