### PR TITLE
[3.6] bpo-35116: Adding Doc/library entries for max_num_fields

### DIFF
--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -155,9 +155,9 @@ or on combining URL components into a URL string.
    percent-encoded sequences into Unicode characters, as accepted by the
    :meth:`bytes.decode` method.
 
-   The optional argument *max_num_fields* is a flag for the maximum number of
-   fields to read. If set, then throws a :exc:`ValueError` if there are more
-   than *max_num_fields* fields read. Default is *None*.
+   The optional argument *max_num_fields* is the maximum number of fields to
+   read. If set, then throws a :exc:`ValueError` if there are more than
+   *max_num_fields* fields read.
 
    Use the :func:`urllib.parse.urlencode` function (with the ``doseq``
    parameter set to ``True``) to convert such dictionaries into query
@@ -191,9 +191,9 @@ or on combining URL components into a URL string.
    percent-encoded sequences into Unicode characters, as accepted by the
    :meth:`bytes.decode` method.
 
-   The optional argument *max_num_fields* is a flag for the maximum number of
-   fields to read. If set, then throws a :exc:`ValueError` if there are more
-   than *max_num_fields* fields read. Default is *None*.
+   The optional argument *max_num_fields* is the maximum number of fields to
+   read. If set, then throws a :exc:`ValueError` if there are more than
+   *max_num_fields* fields read.
 
    Use the :func:`urllib.parse.urlencode` function to convert such lists of pairs into
    query strings.

--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -168,7 +168,7 @@ or on combining URL components into a URL string.
       Add *encoding* and *errors* parameters.
 
    .. versionchanged:: 3.6.8
-      Added *max_num_fields* param.
+      Added *max_num_fields* parameter.
 
 
 .. function:: parse_qsl(qs, keep_blank_values=False, strict_parsing=False, encoding='utf-8', errors='replace', max_num_fields=None)
@@ -202,7 +202,7 @@ or on combining URL components into a URL string.
       Add *encoding* and *errors* parameters.
 
    .. versionchanged:: 3.6.8
-      Added *max_num_fields* param.
+      Added *max_num_fields* parameter.
 
 
 .. function:: urlunparse(parts)

--- a/Doc/library/urllib.parse.rst
+++ b/Doc/library/urllib.parse.rst
@@ -134,7 +134,7 @@ or on combining URL components into a URL string.
       returning :const:`None`.
 
 
-.. function:: parse_qs(qs, keep_blank_values=False, strict_parsing=False, encoding='utf-8', errors='replace')
+.. function:: parse_qs(qs, keep_blank_values=False, strict_parsing=False, encoding='utf-8', errors='replace', max_num_fields=None)
 
    Parse a query string given as a string argument (data of type
    :mimetype:`application/x-www-form-urlencoded`).  Data are returned as a
@@ -155,6 +155,10 @@ or on combining URL components into a URL string.
    percent-encoded sequences into Unicode characters, as accepted by the
    :meth:`bytes.decode` method.
 
+   The optional argument *max_num_fields* is a flag for the maximum number of
+   fields to read. If set, then throws a :exc:`ValueError` if there are more
+   than *max_num_fields* fields read. Default is *None*.
+
    Use the :func:`urllib.parse.urlencode` function (with the ``doseq``
    parameter set to ``True``) to convert such dictionaries into query
    strings.
@@ -163,8 +167,11 @@ or on combining URL components into a URL string.
    .. versionchanged:: 3.2
       Add *encoding* and *errors* parameters.
 
+   .. versionchanged:: 3.6.8
+      Added *max_num_fields* param.
 
-.. function:: parse_qsl(qs, keep_blank_values=False, strict_parsing=False, encoding='utf-8', errors='replace')
+
+.. function:: parse_qsl(qs, keep_blank_values=False, strict_parsing=False, encoding='utf-8', errors='replace', max_num_fields=None)
 
    Parse a query string given as a string argument (data of type
    :mimetype:`application/x-www-form-urlencoded`).  Data are returned as a list of
@@ -184,11 +191,18 @@ or on combining URL components into a URL string.
    percent-encoded sequences into Unicode characters, as accepted by the
    :meth:`bytes.decode` method.
 
+   The optional argument *max_num_fields* is a flag for the maximum number of
+   fields to read. If set, then throws a :exc:`ValueError` if there are more
+   than *max_num_fields* fields read. Default is *None*.
+
    Use the :func:`urllib.parse.urlencode` function to convert such lists of pairs into
    query strings.
 
    .. versionchanged:: 3.2
       Add *encoding* and *errors* parameters.
+
+   .. versionchanged:: 3.6.8
+      Added *max_num_fields* param.
 
 
 .. function:: urlunparse(parts)


### PR DESCRIPTION
(cherry picked from commit 98ace4b856)

Co-authored-by: Matt Belisle <matthew.belisle@workiva.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35116](https://bugs.python.org/issue35116) -->
https://bugs.python.org/issue35116
<!-- /issue-number -->
