### PR TITLE
bpo-35081: Move Py_BUILD_CORE code to internal/mem.h

### DIFF
--- a/Include/internal/mem.h
+++ b/Include/internal/mem.h
@@ -4,6 +4,10 @@
 extern "C" {
 #endif
 
+#ifndef Py_BUILD_CORE
+#  error "Py_BUILD_CORE must be defined to include this header"
+#endif
+
 #include "objimpl.h"
 #include "pymem.h"
 
@@ -144,6 +148,14 @@ struct _gc_runtime_state {
 PyAPI_FUNC(void) _PyGC_Initialize(struct _gc_runtime_state *);
 
 #define _PyGC_generation0 _PyRuntime.gc.generation0
+
+
+/* Set the memory allocator of the specified domain to the default.
+   Save the old allocator into *old_alloc if it's non-NULL.
+   Return on success, or return -1 if the domain is unknown. */
+PyAPI_FUNC(int) _PyMem_SetDefaultAllocator(
+    PyMemAllocatorDomain domain,
+    PyMemAllocatorEx *old_alloc);
 
 #ifdef __cplusplus
 }

--- a/Include/pymem.h
+++ b/Include/pymem.h
@@ -198,16 +198,6 @@ PyAPI_FUNC(void) PyMem_SetAllocator(PyMemAllocatorDomain domain,
 PyAPI_FUNC(void) PyMem_SetupDebugHooks(void);
 #endif   /* Py_LIMITED_API */
 
-#ifdef Py_BUILD_CORE
-/* Set the memory allocator of the specified domain to the default.
-   Save the old allocator into *old_alloc if it's non-NULL.
-   Return on success, or return -1 if the domain is unknown. */
-PyAPI_FUNC(int) _PyMem_SetDefaultAllocator(
-    PyMemAllocatorDomain domain,
-    PyMemAllocatorEx *old_alloc);
-#endif
-
-
 /* bpo-35053: expose _Py_tracemalloc_config for performance:
    _Py_NewReference() needs an efficient check to test if tracemalloc is
    tracing.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "osdefs.h"
+#include "internal/mem.h"
 #include "internal/pygetopt.h"
 #include "internal/pystate.h"
 

--- a/Objects/obmalloc.c
+++ b/Objects/obmalloc.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "internal/mem.h"
 
 #include <stdbool.h>
 

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "internal/mem.h"
 #include "internal/pystate.h"
 #include <locale.h>
 #ifdef HAVE_LANGINFO_H

--- a/Python/import.c
+++ b/Python/import.c
@@ -5,6 +5,7 @@
 #include "Python-ast.h"
 #undef Yield /* undefine macro conflicting with winbase.h */
 #include "internal/hash.h"
+#include "internal/mem.h"
 #include "internal/pystate.h"
 #include "errcode.h"
 #include "marshal.h"

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "osdefs.h"
+#include "internal/mem.h"
 #include "internal/pystate.h"
 #include <wchar.h>
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -6,6 +6,7 @@
 #undef Yield /* undefine macro conflicting with winbase.h */
 #include "internal/context.h"
 #include "internal/hamt.h"
+#include "internal/mem.h"
 #include "internal/pystate.h"
 #include "grammar.h"
 #include "node.h"

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2,6 +2,7 @@
 /* Thread and interpreter state structures and their interfaces */
 
 #include "Python.h"
+#include "internal/mem.h"
 #include "internal/pystate.h"
 
 #define _PyThreadState_SET(value) \

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -15,6 +15,7 @@ Data members:
 */
 
 #include "Python.h"
+#include "internal/mem.h"
 #include "internal/pystate.h"
 #include "code.h"
 #include "frameobject.h"


### PR DESCRIPTION
* Add #include "internal/mem.h" to C files using
  _PyMem_SetDefaultAllocator().
* Include/internal/mem.h now requires Py_BUILD_CORE to be defined.

<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
