### PR TITLE
bpo-33376: clear cursor->statement when setting cursor->reset

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-10-30-14-34-26.bpo-33376.D4Xydk.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-30-14-34-26.bpo-33376.D4Xydk.rst
@@ -1,0 +1,2 @@
+Fixes spurious statement resets after a connection rollback in some
+situations.

--- a/Modules/_sqlite/connection.c
+++ b/Modules/_sqlite/connection.c
@@ -238,6 +238,7 @@ void pysqlite_do_all_statements(pysqlite_Connection* self, int action, int reset
             cursor = (pysqlite_Cursor*)PyWeakref_GetObject(weakref);
             if ((PyObject*)cursor != Py_None) {
                 cursor->reset = 1;
+                Py_CLEAR(cursor->statement);
             }
         }
     }


### PR DESCRIPTION
When statements and cursors are reset as a result of a connection
rollback, their associated statements are not cleared. This can lead to
spurious statement resets when referencing cursors created before the
rollback.

<!-- issue-number: [bpo-33376](https://bugs.python.org/issue33376) -->
https://bugs.python.org/issue33376
<!-- /issue-number -->
