### PR TITLE
[Skip Issue] Fix a possible crash due to range_reverse()

### DIFF
--- a/Objects/rangeobject.c
+++ b/Objects/rangeobject.c
@@ -1154,6 +1154,7 @@ long_range:
     it = PyObject_New(longrangeiterobject, &PyLongRangeIter_Type);
     if (it == NULL)
         return NULL;
+    it->index = it->start = it->step = NULL;
 
     /* start + (len - 1) * step */
     it->len = range->length;


### PR DESCRIPTION
If any of the `PyNumber_*` calls fail while the new iterator object is being prepared, a crash will occur during deallocation.