### PR TITLE
bpo-35118: add indexing details to queue and deque

### DIFF
--- a/Doc/library/collections.rst
+++ b/Doc/library/collections.rst
@@ -531,9 +531,9 @@ or subtracting from an empty counter.
 
 In addition to the above, deques support iteration, pickling, ``len(d)``,
 ``reversed(d)``, ``copy.copy(d)``, ``copy.deepcopy(d)``, membership testing with
-the :keyword:`in` operator, and subscript references such as ``d[-1]``.  Indexed
-access is O(1) at both ends but slows to O(n) in the middle.  For fast random
-access, use lists instead.
+the :keyword:`in` operator, and subscript references such as ``d[0]`` to access
+the first element.  Indexed access is O(1) at both ends but slows to O(n) in
+the middle.  For fast random access, use lists instead.
 
 Starting in version 3.5, deques support ``__add__()``, ``__mul__()``,
 and ``__imul__()``.

--- a/Doc/library/queue.rst
+++ b/Doc/library/queue.rst
@@ -275,4 +275,5 @@ SimpleQueue Objects
 
    :class:`collections.deque` is an alternative implementation of unbounded
    queues with fast atomic :meth:`~collections.deque.append` and
-   :meth:`~collections.deque.popleft` operations that do not require locking.
+   :meth:`~collections.deque.popleft` operations that do not require locking
+   and also support indexing.


### PR DESCRIPTION
Maybe only me think that Queue like object should have a peek() like method or just indexing, feel free to discuss at https://bugs.python.org/issue35118


<!-- issue-number: [bpo-35118](https://bugs.python.org/issue35118) -->
https://bugs.python.org/issue35118
<!-- /issue-number -->
