### PR TITLE
bpo-35081: Move accu.h to Include/internal/pycore_accu.h

### DIFF
--- a/Include/internal/pycore_accu.h
+++ b/Include/internal/pycore_accu.h
@@ -1,6 +1,9 @@
 #ifndef Py_LIMITED_API
-#ifndef Py_ACCU_H
-#define Py_ACCU_H
+#ifndef Py_INTERNAL_ACCU_H
+#define Py_INTERNAL_ACCU_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /*** This is a private API for use by the interpreter and the stdlib.
  *** Its definition may be changed or removed at any moment.
@@ -11,10 +14,6 @@
  * of keeping a huge number of small separate objects, and the quadratic
  * behaviour of using a naive repeated concatenation scheme.
  */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #undef small /* defined by some Windows headers */
 
@@ -32,6 +31,5 @@ PyAPI_FUNC(void) _PyAccu_Destroy(_PyAccu *acc);
 #ifdef __cplusplus
 }
 #endif
-
-#endif /* Py_ACCU_H */
-#endif /* Py_LIMITED_API */
+#endif /* !Py_INTERNAL_ACCU_H */
+#endif /* !Py_LIMITED_API */

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -935,7 +935,6 @@ regen-typeslots:
 PYTHON_HEADERS= \
 		$(srcdir)/Include/Python.h \
 		$(srcdir)/Include/abstract.h \
-		$(srcdir)/Include/accu.h \
 		$(srcdir)/Include/asdl.h \
 		$(srcdir)/Include/ast.h \
 		$(srcdir)/Include/bltinmodule.h \
@@ -1025,6 +1024,7 @@ PYTHON_HEADERS= \
 		pyconfig.h \
 		$(PARSER_HEADERS) \
 		$(srcdir)/Include/Python-ast.h \
+		$(srcdir)/Include/internal/pycore_accu.h \
 		$(srcdir)/Include/internal/pycore_atomic.h \
 		$(srcdir)/Include/internal/pycore_ceval.h \
 		$(srcdir)/Include/internal/pycore_context.h \

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -1,7 +1,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "structmember.h"
-#include "accu.h"
+#include "pycore_accu.h"
 #include "_iomodule.h"
 
 /* Implementation note: the buffer is always at least one character longer

--- a/Modules/_json.c
+++ b/Modules/_json.c
@@ -7,7 +7,7 @@
 
 #include "Python.h"
 #include "structmember.h"
-#include "accu.h"
+#include "pycore_accu.h"
 
 #ifdef __GNUC__
 #define UNUSED __attribute__((__unused__))

--- a/Objects/accu.c
+++ b/Objects/accu.c
@@ -1,7 +1,7 @@
 /* Accumulator struct implementation */
 
 #include "Python.h"
-#include "accu.h"
+#include "pycore_accu.h"
 
 static PyObject *
 join_list_unicode(PyObject *lst)

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -2,7 +2,7 @@
 
 #include "Python.h"
 #include "pycore_state.h"
-#include "accu.h"
+#include "pycore_accu.h"
 
 #ifdef STDC_HEADERS
 #include <stddef.h>

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -3,7 +3,7 @@
 
 #include "Python.h"
 #include "pycore_state.h"
-#include "accu.h"
+#include "pycore_accu.h"
 
 /*[clinic input]
 class tuple "PyTupleObject *" "&PyTuple_Type"

--- a/PCbuild/pythoncore.vcxproj
+++ b/PCbuild/pythoncore.vcxproj
@@ -79,7 +79,6 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\Include\abstract.h" />
-    <ClInclude Include="..\Include\accu.h" />
     <ClInclude Include="..\Include\asdl.h" />
     <ClInclude Include="..\Include\ast.h" />
     <ClInclude Include="..\Include\bitset.h" />
@@ -112,6 +111,7 @@
     <ClInclude Include="..\Include\graminit.h" />
     <ClInclude Include="..\Include\grammar.h" />
     <ClInclude Include="..\Include\import.h" />
+    <ClInclude Include="..\Include\internal\pycore_accu.h" />
     <ClInclude Include="..\Include\internal\pycore_atomic.h" />
     <ClInclude Include="..\Include\internal\pycore_ceval.h" />
     <ClInclude Include="..\Include\internal\pycore_condvar.h" />
@@ -154,7 +154,6 @@
     <ClInclude Include="..\Include\pyerrors.h" />
     <ClInclude Include="..\Include\pyexpat.h" />
     <ClInclude Include="..\Include\pyfpe.h" />
-    <ClInclude Include="..\Include\internal\pygetopt.h" />
     <ClInclude Include="..\Include\pylifecycle.h" />
     <ClInclude Include="..\Include\pymath.h" />
     <ClInclude Include="..\Include\pytime.h" />

--- a/PCbuild/pythoncore.vcxproj.filters
+++ b/PCbuild/pythoncore.vcxproj.filters
@@ -36,9 +36,6 @@
     <ClInclude Include="..\Include\abstract.h">
       <Filter>Include</Filter>
     </ClInclude>
-    <ClInclude Include="..\Include\accu.h">
-      <Filter>Include</Filter>
-    </ClInclude>
     <ClInclude Include="..\Include\asdl.h">
       <Filter>Include</Filter>
     </ClInclude>
@@ -133,6 +130,9 @@
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\import.h">
+      <Filter>Include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\Include\internal\pycore_accu.h">
       <Filter>Include</Filter>
     </ClInclude>
     <ClInclude Include="..\Include\internal\pycore_atomic.h">


### PR DESCRIPTION
The accu.h header is no longer part of the Python C API: it has been
moved to the "internal" headers which are restricted to Python
itself.

Replace #include "accu.h" with #include "pycore_accu.h".

<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
