### PR TITLE
bpo-35081: Move _PyObject_GC_TRACK() to pycore_object.h

### DIFF
--- a/Include/internal/pycore_mem.h
+++ b/Include/internal/pycore_mem.h
@@ -147,9 +147,6 @@ struct _gc_runtime_state {
 
 PyAPI_FUNC(void) _PyGC_Initialize(struct _gc_runtime_state *);
 
-#define _PyGC_generation0 _PyRuntime.gc.generation0
-
-
 /* Set the memory allocator of the specified domain to the default.
    Save the old allocator into *old_alloc if it's non-NULL.
    Return on success, or return -1 if the domain is unknown. */

--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -1,0 +1,54 @@
+#ifndef Py_INTERNAL_OBECT_H
+#define Py_INTERNAL_OBECT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "Py_BUILD_CORE must be defined to include this header"
+#endif
+
+#include "pycore_state.h"
+
+/* Tell the GC to track this object.
+ *
+ * NB: While the object is tracked by the collector, it must be safe to call the
+ * ob_traverse method.
+ *
+ * Internal note: _PyRuntime.gc.generation0->_gc_prev doesn't have any bit flags
+ * because it's not object header.  So we don't use _PyGCHead_PREV() and
+ * _PyGCHead_SET_PREV() for it to avoid unnecessary bitwise operations.
+ */
+#define _PyObject_GC_TRACK(o) do { \
+    PyGC_Head *g = _Py_AS_GC(o); \
+    if (g->_gc_next != 0) { \
+        Py_FatalError("GC object already tracked"); \
+    } \
+    assert((g->_gc_prev & _PyGC_PREV_MASK_COLLECTING) == 0); \
+    PyGC_Head *last = (PyGC_Head*)(_PyRuntime.gc.generation0->_gc_prev); \
+    _PyGCHead_SET_NEXT(last, g); \
+    _PyGCHead_SET_PREV(g, last); \
+    _PyGCHead_SET_NEXT(g, _PyRuntime.gc.generation0); \
+    _PyRuntime.gc.generation0->_gc_prev = (uintptr_t)g; \
+    } while (0);
+
+/* Tell the GC to stop tracking this object.
+ *
+ * Internal note: This may be called while GC.  So _PyGC_PREV_MASK_COLLECTING must
+ * be cleared.  But _PyGC_PREV_MASK_FINALIZED bit is kept.
+ */
+#define _PyObject_GC_UNTRACK(o) do { \
+    PyGC_Head *g = _Py_AS_GC(o); \
+    PyGC_Head *prev = _PyGCHead_PREV(g); \
+    PyGC_Head *next = _PyGCHead_NEXT(g); \
+    assert(next != NULL); \
+    _PyGCHead_SET_NEXT(prev, next); \
+    _PyGCHead_SET_PREV(next, prev); \
+    g->_gc_next = 0; \
+    g->_gc_prev &= _PyGC_PREV_MASK_FINALIZED; \
+    } while (0);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_OBECT_H */

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -9,6 +9,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "structmember.h"
 #include "pythread.h"

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 #include "structmember.h"       /* for offsetof() */
 #include "_iomodule.h"
+#include "pycore_object.h"
 
 /*[clinic input]
 module _io

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -2,6 +2,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 #include "structmember.h"
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -11,6 +11,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "structmember.h"
+#include "pycore_object.h"
 #include "_iomodule.h"
 
 /*[clinic input]

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -2,6 +2,7 @@
 #include "Python.h"
 #include "structmember.h"
 #include "accu.h"
+#include "pycore_object.h"
 #include "_iomodule.h"
 
 /* Implementation note: the buffer is always at least one character longer

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -8,6 +8,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 #include "structmember.h"
 #include "_iomodule.h"
 

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -8,6 +8,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 
 #ifdef MS_WINDOWS
 
@@ -556,7 +557,7 @@ read_console_w(HANDLE handle, DWORD maxlen, DWORD *readlen) {
     Py_BEGIN_ALLOW_THREADS
     DWORD off = 0;
     while (off < maxlen) {
-        DWORD n = (DWORD)-1; 
+        DWORD n = (DWORD)-1;
         DWORD len = min(maxlen - off, BUFSIZ);
         SetLastError(0);
         BOOL res = ReadConsoleW(handle, &buf[off], len, &n, NULL);

--- a/Modules/_queuemodule.c
+++ b/Modules/_queuemodule.c
@@ -1,6 +1,6 @@
 #include "Python.h"
-#include "structmember.h" /* offsetof */
 #include "pythread.h"
+#include "structmember.h" /* offsetof */
 
 /*[clinic input]
 module _queue
@@ -26,7 +26,7 @@ typedef struct {
 static void
 simplequeue_dealloc(simplequeueobject *self)
 {
-    _PyObject_GC_UNTRACK(self);
+    PyObject_GC_UnTrack(self);
     if (self->lock != NULL) {
         /* Unlock the lock so it's safe to free it */
         if (self->locked > 0)

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -26,6 +26,7 @@
 #include "Python.h"
 #include "pycore_context.h"
 #include "pycore_mem.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "frameobject.h"        /* for PyFrame_ClearFreeList */
 #include "pydtrace.h"

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2,12 +2,13 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "pycore_mem.h"
-#include "pycore_state.h"
-#include "structmember.h"
 #include "bytes_methods.h"
 #include "bytesobject.h"
+#include "pycore_mem.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 #include "pystrhex.h"
+#include "structmember.h"
 
 /*[clinic input]
 class bytearray "PyByteArrayObject *" "&PyByteArray_Type"

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3,10 +3,10 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
-#include "pycore_mem.h"
-#include "pycore_state.h"
-
 #include "bytes_methods.h"
+#include "pycore_mem.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 #include "pystrhex.h"
 #include <stddef.h>
 

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1,6 +1,7 @@
 #include "Python.h"
-#include "pycore_state.h"
 #include "frameobject.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 
 
 int

--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "pycore_mem.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 
 PyObject *

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "pycore_mem.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "structmember.h"
 

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1,6 +1,7 @@
 /* Descriptors -- a new, flexible way to describe attributes */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "structmember.h" /* Why is this not included in Python.h? */
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -111,8 +111,9 @@ converting the dict to the combined table.
 #define PyDict_MINSIZE 8
 
 #include "Python.h"
-#include "pycore_state.h"
 #include "dict-common.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 #include "stringlib/eq.h"    /* to get unicode_eq() */
 
 /*[clinic input]

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -7,6 +7,7 @@
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "pycore_mem.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "structmember.h"
 #include "osdefs.h"

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1,11 +1,11 @@
 /* Frame object implementation */
 
 #include "Python.h"
-#include "pycore_state.h"
-
 #include "code.h"
 #include "frameobject.h"
 #include "opcode.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 #include "structmember.h"
 
 #define OFF(x) offsetof(PyFrameObject, x)

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -2,9 +2,10 @@
 /* Function object implementation */
 
 #include "Python.h"
-#include "pycore_mem.h"
-#include "pycore_state.h"
 #include "code.h"
+#include "pycore_mem.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 #include "structmember.h"
 
 PyObject *

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1,10 +1,11 @@
 /* Generator object implementation */
 
 #include "Python.h"
-#include "pycore_state.h"
 #include "frameobject.h"
-#include "structmember.h"
 #include "opcode.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
+#include "structmember.h"
 
 static PyObject *gen_close(PyGenObject *, PyObject *);
 static PyObject *async_gen_asend_new(PyAsyncGenObject *, PyObject *);

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "pycore_mem.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 
 typedef struct {

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1,8 +1,9 @@
 /* List object implementation */
 
 #include "Python.h"
-#include "pycore_state.h"
 #include "accu.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 
 #ifdef STDC_HEADERS
 #include <stddef.h>

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "pycore_mem.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "pystrhex.h"
 #include <stddef.h>

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -3,6 +3,7 @@
 
 #include "Python.h"
 #include "pycore_mem.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "structmember.h"
 

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -465,9 +465,10 @@ later:
 */
 
 #include "Python.h"
+#include "dict-common.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "structmember.h"
-#include "dict-common.h"
 #include <stddef.h>
 
 #include "clinic/odictobject.c.h"

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -32,6 +32,7 @@
 */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "structmember.h"
 

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -15,6 +15,7 @@ this type and there is exactly one in existence.
 
 #include "Python.h"
 #include "pycore_mem.h"
+#include "pycore_object.h"
 #include "pycore_state.h"
 #include "structmember.h"
 

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -2,8 +2,9 @@
 /* Tuple object implementation */
 
 #include "Python.h"
-#include "pycore_state.h"
 #include "accu.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 
 /*[clinic input]
 class tuple "PyTupleObject *" "&PyTuple_Type"

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1,8 +1,9 @@
 /* Type object implementation */
 
 #include "Python.h"
-#include "pycore_state.h"
 #include "frameobject.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 #include "structmember.h"
 
 #include <ctype.h>

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -40,10 +40,11 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
-#include "pycore_state.h"
-#include "ucnhash.h"
 #include "bytes_methods.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 #include "stringlib/eq.h"
+#include "ucnhash.h"
 
 #ifdef MS_WINDOWS
 #include <windows.h>

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -10,16 +10,15 @@
 #define PY_LOCAL_AGGRESSIVE
 
 #include "Python.h"
-#include "pycore_state.h"
-
 #include "code.h"
 #include "dictobject.h"
 #include "frameobject.h"
 #include "opcode.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 #include "pydtrace.h"
 #include "setobject.h"
 #include "structmember.h"
-
 #include <ctype.h>
 
 #ifdef Py_DEBUG

--- a/Python/context.c
+++ b/Python/context.c
@@ -1,9 +1,10 @@
 #include "Python.h"
 
-#include "structmember.h"
-#include "pycore_state.h"
 #include "pycore_context.h"
 #include "pycore_hamt.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
+#include "structmember.h"
 
 
 #define CONTEXT_FREELIST_MAXLEN 255

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -1,8 +1,9 @@
 #include "Python.h"
 
 #include "structmember.h"
-#include "pycore_state.h"
 #include "pycore_hamt.h"
+#include "pycore_object.h"
+#include "pycore_state.h"
 
 /*
 This file provides an implemention of an immutable mapping using the


### PR DESCRIPTION
* Create Include/internal/pycore_object.h
* Move _PyObject_GC_TRACK() and _PyObject_GC_UNTRACK() macros to
  pycore_object.h
* Remove _PyGC_generation0: replaced with _PyRuntime.gc.generation0
* Replace _PyObject_GC_UNTRACK() with PyObject_GC_UnTrack()
  in _queuemodule.c. The file is compiled without Py_BUILD_CORE.
* Add #include "pycore_object.h" in all C files using
  _PyObject_GC_TRACK() and/or _PyObject_GC_UNTRACK()

<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
