### PR TITLE
[WIP] bpo-35081: _testcapi is now compiled with Py_BUILD_CORE

### DIFF
--- a/Include/internal/pycore_pathconfig.h
+++ b/Include/internal/pycore_pathconfig.h
@@ -4,6 +4,10 @@
 extern "C" {
 #endif
 
+#ifndef Py_BUILD_CORE
+#  error "Py_BUILD_CORE must be defined to include this header"
+#endif
+
 PyAPI_FUNC(void) _Py_wstrlist_clear(
     int len,
     wchar_t **list);

--- a/setup.py
+++ b/setup.py
@@ -681,7 +681,8 @@ class PyBuildExt(build_ext):
         exts.append( Extension("_json", ["_json.c"]) )
         # Python C API test module
         exts.append( Extension('_testcapi', ['_testcapimodule.c'],
-                               depends=['testcapi_long.h']) )
+                               depends=['testcapi_long.h'],
+                               define_macros=[('Py_BUILD_CORE', '')]) )
         # Python PEP-3118 (buffer protocol) test module
         exts.append( Extension('_testbuffer', ['_testbuffer.c']) )
         # Test loading multiple modules from one compiled file (http://bugs.python.org/issue16421)


### PR DESCRIPTION
* setup.py now defines Py_BUILD_CORE to build the _testcapi module
  (_testcapimodule.c).
* pycore_pathconfig.h now requires Py_BUILD_CORE to be defined.

<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
