### PR TITLE
WIP: bpo-35059: _PyThreadState_GET() checks that the GIL is hold

### DIFF
--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -59,9 +59,12 @@ class CAPITest(unittest.TestCase):
         (out, err) = p.communicate()
         self.assertEqual(out, b'')
         # This used to cause an infinite loop.
-        self.assertTrue(err.rstrip().startswith(
+        err = err.rstrip()
+        cond = err.startswith(
                          b'Fatal Python error:'
-                         b' PyThreadState_Get: no current thread'))
+                         b' PyThreadState_Get: no current thread')
+        cond |= bool(re.search(b"Assertion.*PyGILState_Check.*failed", err))
+        self.assertTrue(cond, err.decode(errors="replace"))
 
     def test_memoryview_from_NULL_pointer(self):
         self.assertRaises(ValueError, _testcapi.make_memoryview_from_NULL_pointer)

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -188,7 +188,8 @@ PyEval_ReleaseLock(void)
        We therefore avoid PyThreadState_Get() which dumps a fatal error
        in debug mode.
     */
-    drop_gil(_PyThreadState_GET());
+    PyThreadState *tstate = _PyThreadState_GET_UNSAFE();
+    drop_gil(tstate);
 }
 
 void

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -1916,7 +1916,7 @@ fatal_error(const char *prefix, const char *msg, int status)
        and holds the GIL */
     PyThreadState *tss_tstate = PyGILState_GetThisThreadState();
     if (tss_tstate != NULL) {
-        PyThreadState *tstate = _PyThreadState_GET();
+        PyThreadState *tstate = _PyThreadState_GET_UNSAFE();
         if (tss_tstate != tstate) {
             /* The Python thread does not hold the GIL */
             tss_tstate = NULL;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -703,7 +703,7 @@ PyThreadState_Delete(PyThreadState *tstate)
 void
 PyThreadState_DeleteCurrent()
 {
-    PyThreadState *tstate = _PyThreadState_GET();
+    PyThreadState *tstate = _PyThreadState_GET_UNSAFE();
     if (tstate == NULL)
         Py_FatalError(
             "PyThreadState_DeleteCurrent: no current tstate");
@@ -776,7 +776,7 @@ PyThreadState_Get(void)
 PyThreadState *
 PyThreadState_Swap(PyThreadState *newts)
 {
-    PyThreadState *oldts = _PyThreadState_GET();
+    PyThreadState *oldts = _PyThreadState_GET_UNSAFE();
 
     _PyThreadState_SET(newts);
     /* It should not be possible for more than one thread state
@@ -957,8 +957,10 @@ static int
 PyThreadState_IsCurrent(PyThreadState *tstate)
 {
     /* Must be the tstate for this thread */
-    assert(PyGILState_GetThisThreadState()==tstate);
-    return tstate == _PyThreadState_GET();
+    assert(PyGILState_GetThisThreadState() == tstate);
+
+    PyThreadState *current = _PyThreadState_GET_UNSAFE();
+    return (tstate == current);
 }
 
 /* Internal initialization/finalization functions called by
@@ -1085,7 +1087,7 @@ PyGILState_Check(void)
         return 1;
     }
 
-    tstate = _PyThreadState_GET();
+    tstate = _PyThreadState_GET_UNSAFE();
     if (tstate == NULL)
         return 0;
 


### PR DESCRIPTION
Convert _PyThreadState_GET() and _PyInterpreterState_GET_UNSAFE()
macros to static inline functions, and the functions now check that
the GIL is hold.

Add _PyThreadState_GET_UNSAFE(): similar to _PyThreadState_GET(), but
don't check that the GIL is hold.

<!-- issue-number: [bpo-35059](https://bugs.python.org/issue35059) -->
https://bugs.python.org/issue35059
<!-- /issue-number -->
