### PR TITLE
bpo-24303: Fix random EEXIST upon multiprocessing semaphore creation when using Linux PID namespaces.

### DIFF
--- a/Misc/NEWS.d/next/Library/2018-10-31-21-45-45.bpo-24303.iiGG_o.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-31-21-45-45.bpo-24303.iiGG_o.rst
@@ -1,0 +1,2 @@
+Fix random EEXIST upon multiprocessing semaphore creation when using Linux
+PID namespaces.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-24303](https://bugs.python.org/issue24303) -->
https://bugs.python.org/issue24303
<!-- /issue-number -->
