### PR TITLE
[3.6] bpo-35128: Fix spacing issues in warning.warn() messages. (GH-10268).

### DIFF
--- a/Lib/ftplib.py
+++ b/Lib/ftplib.py
@@ -732,7 +732,7 @@ else:
                                  "exclusive")
             if keyfile is not None or certfile is not None:
                 import warnings
-                warnings.warn("keyfile and certfile are deprecated, use a"
+                warnings.warn("keyfile and certfile are deprecated, use a "
                               "custom context instead", DeprecationWarning, 2)
             self.keyfile = keyfile
             self.certfile = certfile

--- a/Lib/imaplib.py
+++ b/Lib/imaplib.py
@@ -1277,7 +1277,7 @@ if HAVE_SSL:
                                  "exclusive")
             if keyfile is not None or certfile is not None:
                 import warnings
-                warnings.warn("keyfile and certfile are deprecated, use a"
+                warnings.warn("keyfile and certfile are deprecated, use a "
                               "custom ssl_context instead", DeprecationWarning, 2)
             self.keyfile = keyfile
             self.certfile = certfile

--- a/Lib/poplib.py
+++ b/Lib/poplib.py
@@ -436,7 +436,7 @@ if HAVE_SSL:
                                  "exclusive")
             if keyfile is not None or certfile is not None:
                 import warnings
-                warnings.warn("keyfile and certfile are deprecated, use a"
+                warnings.warn("keyfile and certfile are deprecated, use a "
                               "custom context instead", DeprecationWarning, 2)
             self.keyfile = keyfile
             self.certfile = certfile

--- a/Lib/smtplib.py
+++ b/Lib/smtplib.py
@@ -762,7 +762,7 @@ class SMTP:
                                  "exclusive")
             if keyfile is not None or certfile is not None:
                 import warnings
-                warnings.warn("keyfile and certfile are deprecated, use a"
+                warnings.warn("keyfile and certfile are deprecated, use a "
                               "custom context instead", DeprecationWarning, 2)
             if context is None:
                 context = ssl._create_stdlib_context(certfile=certfile,
@@ -1019,7 +1019,7 @@ if _have_ssl:
                                  "exclusive")
             if keyfile is not None or certfile is not None:
                 import warnings
-                warnings.warn("keyfile and certfile are deprecated, use a"
+                warnings.warn("keyfile and certfile are deprecated, use a "
                               "custom context instead", DeprecationWarning, 2)
             self.keyfile = keyfile
             self.certfile = certfile


### PR DESCRIPTION
(cherry picked from commit 4b5e62dbb22a3593e0db266c12f805b727a42b00)

Co-authored-by: Pablo Aguiar <scorphus@gmail.com>


<!-- issue-number: [bpo-35128](https://bugs.python.org/issue35128) -->
https://bugs.python.org/issue35128
<!-- /issue-number -->
