### PR TITLE
bpo-35133: Fix mistakes when concatenate string literals on different lines.

### DIFF
--- a/Lib/_pydecimal.py
+++ b/Lib/_pydecimal.py
@@ -2021,7 +2021,7 @@ class Decimal(object):
         if not other and not self:
             return context._raise_error(InvalidOperation,
                                         'at least one of pow() 1st argument '
-                                        'and 2nd argument must be nonzero ;'
+                                        'and 2nd argument must be nonzero; '
                                         '0**0 is not defined')
 
         # compute sign of result

--- a/Lib/concurrent/futures/thread.py
+++ b/Lib/concurrent/futures/thread.py
@@ -150,7 +150,7 @@ class ThreadPoolExecutor(_base.Executor):
             if self._shutdown:
                 raise RuntimeError('cannot schedule new futures after shutdown')
             if _shutdown:
-                raise RuntimeError('cannot schedule new futures after'
+                raise RuntimeError('cannot schedule new futures after '
                                    'interpreter shutdown')
 
             f = _base.Future()

--- a/Lib/distutils/command/bdist_dumb.py
+++ b/Lib/distutils/command/bdist_dumb.py
@@ -32,7 +32,7 @@ class bdist_dumb(Command):
                     ('skip-build', None,
                      "skip rebuilding everything (for testing/debugging)"),
                     ('relative', None,
-                     "build the archive using relative paths"
+                     "build the archive using relative paths "
                      "(default: false)"),
                     ('owner=', 'u',
                      "Owner name used when creating a tar file"

--- a/Lib/distutils/command/bdist_msi.py
+++ b/Lib/distutils/command/bdist_msi.py
@@ -98,14 +98,14 @@ class bdist_msi(Command):
                     ('no-target-compile', 'c',
                      "do not compile .py to .pyc on the target system"),
                     ('no-target-optimize', 'o',
-                     "do not compile .py to .pyo (optimized)"
+                     "do not compile .py to .pyo (optimized) "
                      "on the target system"),
                     ('dist-dir=', 'd',
                      "directory to put final built distributions in"),
                     ('skip-build', None,
                      "skip rebuilding everything (for testing/debugging)"),
                     ('install-script=', None,
-                     "basename of installation script to be run after"
+                     "basename of installation script to be run after "
                      "installation or before deinstallation"),
                     ('pre-install-script=', None,
                      "Fully qualified filename of a script to be run before "

--- a/Lib/distutils/command/bdist_rpm.py
+++ b/Lib/distutils/command/bdist_rpm.py
@@ -58,7 +58,7 @@ class bdist_rpm(Command):
          "RPM \"vendor\" (eg. \"Joe Blow <joe@example.com>\") "
          "[default: maintainer or author from setup script]"),
         ('packager=', None,
-         "RPM packager (eg. \"Jane Doe <jane@example.net>\")"
+         "RPM packager (eg. \"Jane Doe <jane@example.net>\") "
          "[default: vendor]"),
         ('doc-files=', None,
          "list of documentation files (space or comma-separated)"),

--- a/Lib/distutils/command/bdist_wininst.py
+++ b/Lib/distutils/command/bdist_wininst.py
@@ -29,7 +29,7 @@ class bdist_wininst(Command):
                     ('no-target-compile', 'c',
                      "do not compile .py to .pyc on the target system"),
                     ('no-target-optimize', 'o',
-                     "do not compile .py to .pyo (optimized)"
+                     "do not compile .py to .pyo (optimized) "
                      "on the target system"),
                     ('dist-dir=', 'd',
                      "directory to put final built distributions in"),
@@ -40,7 +40,7 @@ class bdist_wininst(Command):
                     ('skip-build', None,
                      "skip rebuilding everything (for testing/debugging)"),
                     ('install-script=', None,
-                     "basename of installation script to be run after"
+                     "basename of installation script to be run after "
                      "installation or before deinstallation"),
                     ('pre-install-script=', None,
                      "Fully qualified filename of a script to be run before "

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -365,7 +365,7 @@ class build_ext(Command):
             ext_name, build_info = ext
 
             log.warn("old-style (ext_name, build_info) tuple found in "
-                     "ext_modules for extension '%s'"
+                     "ext_modules for extension '%s' "
                      "-- please convert to Extension instance", ext_name)
 
             if not (isinstance(ext_name, str) and

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2209,8 +2209,8 @@ def get_section(value):
         digits += value[0]
         value = value[1:]
     if digits[0] == '0' and digits != '0':
-        section.defects.append(errors.InvalidHeaderError("section number "
-            "has an invalid leading 0"))
+        section.defects.append(errors.InvalidHeaderError(
+                "section number has an invalid leading 0"))
     section.number = int(digits)
     section.append(ValueTerminal(digits, 'digits'))
     return section, value

--- a/Lib/email/_header_value_parser.py
+++ b/Lib/email/_header_value_parser.py
@@ -2209,7 +2209,7 @@ def get_section(value):
         digits += value[0]
         value = value[1:]
     if digits[0] == '0' and digits != '0':
-        section.defects.append(errors.InvalidHeaderError("section number"
+        section.defects.append(errors.InvalidHeaderError("section number "
             "has an invalid leading 0"))
     section.number = int(digits)
     section.append(ValueTerminal(digits, 'digits'))

--- a/Lib/idlelib/hyperparser.py
+++ b/Lib/idlelib/hyperparser.py
@@ -224,7 +224,7 @@ class HyperParser:
         given index, which is empty if there is no real one.
         """
         if not self.is_in_code():
-            raise ValueError("get_expression should only be called"
+            raise ValueError("get_expression should only be called "
                              "if index is inside a code.")
 
         rawtext = self.rawtext

--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -335,7 +335,7 @@ ViewWindow_spec = {
 _widget_redirector_spec = {
     'file': 'redirector',
     'kwds': {},
-    'msg': "Every text insert should be printed to the console. "
+    'msg': "Every text insert should be printed to the console "
            "or the IDLE shell."
     }
 

--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -117,7 +117,7 @@ ConfigDialog_spec = {
            "font face of the text in the area below it.\nIn the "
            "'Highlighting' tab, try different color schemes. Clicking "
            "items in the sample program should update the choices above it."
-           "\nIn the 'Keys', 'General' and 'Extensions' tabs, test settings"
+           "\nIn the 'Keys', 'General' and 'Extensions' tabs, test settings "
            "of interest."
            "\n[Ok] to close the dialog.[Apply] to apply the settings and "
            "and [Cancel] to revert all changes.\nRe-run the test to ensure "
@@ -152,7 +152,7 @@ GetKeysDialog_spec = {
     'msg': "Test for different key modifier sequences.\n"
            "<nothing> is invalid.\n"
            "No modifier key is invalid.\n"
-           "Shift key with [a-z],[0-9], function key, move key, tab, space"
+           "Shift key with [a-z],[0-9], function key, move key, tab, space "
            "is invalid.\nNo validity checking if advanced key binding "
            "entry is used."
     }
@@ -234,7 +234,7 @@ _percolator_spec = {
     'file': 'percolator',
     'kwds': {},
     'msg': "There are two tracers which can be toggled using a checkbox.\n"
-           "Toggling a tracer 'on' by checking it should print tracer"
+           "Toggling a tracer 'on' by checking it should print tracer "
            "output to the console or to the IDLE shell.\n"
            "If both the tracers are 'on', the output from the tracer which "
            "was switched 'on' later, should be printed first\n"
@@ -335,7 +335,7 @@ ViewWindow_spec = {
 _widget_redirector_spec = {
     'file': 'redirector',
     'kwds': {},
-    'msg': "Every text insert should be printed to the console."
+    'msg': "Every text insert should be printed to the console. "
            "or the IDLE shell."
     }
 

--- a/Lib/idlelib/idle_test/mock_tk.py
+++ b/Lib/idlelib/idle_test/mock_tk.py
@@ -260,7 +260,7 @@ class Text:
         elif op == '!=':
             return line1 != line2 or  char1 != char2
         else:
-            raise TclError('''bad comparison operator "%s":'''
+            raise TclError('''bad comparison operator "%s": '''
                                   '''must be <, <=, ==, >=, >, or !=''' % op)
 
     # The following Text methods normally do something and return None.

--- a/Lib/importlib/abc.py
+++ b/Lib/importlib/abc.py
@@ -66,7 +66,7 @@ class MetaPathFinder(Finder):
 
         """
         warnings.warn("MetaPathFinder.find_module() is deprecated since Python "
-                      "3.4 in favor of MetaPathFinder.find_spec()"
+                      "3.4 in favor of MetaPathFinder.find_spec() "
                       "(available since 3.4)",
                       DeprecationWarning,
                       stacklevel=2)

--- a/Lib/test/test_builtin.py
+++ b/Lib/test/test_builtin.py
@@ -1607,7 +1607,7 @@ class TestBreakpoint(unittest.TestCase):
     @unittest.skipIf(sys.flags.ignore_environment, '-E was given')
     def test_envar_unimportable(self):
         for envar in (
-                '.', '..', '.foo', 'foo.', '.int', 'int.'
+                '.', '..', '.foo', 'foo.', '.int', 'int.',
                 'nosuchbuiltin',
                 'nosuchmodule.nosuchcallable',
                 ):

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -285,7 +285,7 @@ if 1:
             'from sys import stdin)',
             'from sys import stdin, stdout,\nstderr',
             'from sys import stdin si',
-            'from sys import stdin,'
+            'from sys import stdin,',
             'from sys import (*)',
             'from sys import (stdin,, stdout, stderr)',
             'from sys import (stdin, stdout),',

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -1172,10 +1172,10 @@ class FormatTest(unittest.TestCase):
         decimal_point = locale.localeconv()['decimal_point']
         thousands_sep = locale.localeconv()['thousands_sep']
         if decimal_point != '\u066b':
-            self.skipTest('inappropriate decimal point separator'
+            self.skipTest('inappropriate decimal point separator '
                           '({!a} not {!a})'.format(decimal_point, '\u066b'))
         if thousands_sep != '\u066c':
-            self.skipTest('inappropriate thousands separator'
+            self.skipTest('inappropriate thousands separator '
                           '({!a} not {!a})'.format(thousands_sep, '\u066c'))
 
         self.assertEqual(format(Decimal('100000000.123'), 'n'),

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2113,9 +2113,9 @@ class TestParser(TestParserMixin, TestEmailBase):
 
     def test_get_group_mixed_list(self):
         group = self._test_get_x(parser.get_group,
-            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>, '
+            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
                 '(foo) Roger <ping@exampele.com>, x@test.example.com;'),
-            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>, '
+            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
                 '(foo) Roger <ping@exampele.com>, x@test.example.com;'),
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
                 ' Roger <ping@exampele.com>, x@test.example.com;'),
@@ -2134,9 +2134,9 @@ class TestParser(TestParserMixin, TestEmailBase):
 
     def test_get_group_one_invalid(self):
         group = self._test_get_x(parser.get_group,
-            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>, '
+            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
                 '(foo) Roger ping@exampele.com, x@test.example.com;'),
-            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>, '
+            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
                 '(foo) Roger ping@exampele.com, x@test.example.com;'),
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
                 ' Roger ping@exampele.com, x@test.example.com;'),
@@ -2154,11 +2154,11 @@ class TestParser(TestParserMixin, TestEmailBase):
 
     def test_get_group_missing_final_semicol(self):
         group = self._test_get_x(parser.get_group,
-            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>, '
+            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>,'
              'eric@where.test,John <jdoe@test>'),
-            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>, '
+            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>,'
              'eric@where.test,John <jdoe@test>;'),
-            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>, '
+            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>,'
              'eric@where.test,John <jdoe@test>;'),
             [errors.InvalidHeaderDefect],
             '')
@@ -2359,13 +2359,13 @@ class TestParser(TestParserMixin, TestEmailBase):
     def test_get_address_list_mailboxes_complex(self):
         address_list = self._test_get_x(parser.get_address_list,
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                '(ping) Foo <x@example.com>, '
+                '(ping) Foo <x@example.com>,'
                 'Nobody Is. Special <y@(bird)example.(bad)com>'),
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                '(ping) Foo <x@example.com>, '
+                '(ping) Foo <x@example.com>,'
                 'Nobody Is. Special <y@(bird)example.(bad)com>'),
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                'Foo <x@example.com>, '
+                'Foo <x@example.com>,'
                 '"Nobody Is. Special" <y@example. com>'),
             [errors.ObsoleteHeaderDefect, # period in Is.
             errors.ObsoleteHeaderDefect], # cfws in domain
@@ -2386,13 +2386,13 @@ class TestParser(TestParserMixin, TestEmailBase):
     def test_get_address_list_mailboxes_invalid_addresses(self):
         address_list = self._test_get_x(parser.get_address_list,
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                '(ping) Foo x@example.com[], '
+                '(ping) Foo x@example.com[],'
                 'Nobody Is. Special <(bird)example.(bad)com>'),
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                '(ping) Foo x@example.com[], '
+                '(ping) Foo x@example.com[],'
                 'Nobody Is. Special <(bird)example.(bad)com>'),
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                'Foo x@example.com[], '
+                'Foo x@example.com[],'
                 '"Nobody Is. Special" < example. com>'),
              [errors.InvalidHeaderDefect,   # invalid address in list
               errors.InvalidHeaderDefect,   # 'Foo x' local part invalid.

--- a/Lib/test/test_email/test__header_value_parser.py
+++ b/Lib/test/test_email/test__header_value_parser.py
@@ -2113,9 +2113,9 @@ class TestParser(TestParserMixin, TestEmailBase):
 
     def test_get_group_mixed_list(self):
         group = self._test_get_x(parser.get_group,
-            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
+            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>, '
                 '(foo) Roger <ping@exampele.com>, x@test.example.com;'),
-            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
+            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>, '
                 '(foo) Roger <ping@exampele.com>, x@test.example.com;'),
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
                 ' Roger <ping@exampele.com>, x@test.example.com;'),
@@ -2134,9 +2134,9 @@ class TestParser(TestParserMixin, TestEmailBase):
 
     def test_get_group_one_invalid(self):
         group = self._test_get_x(parser.get_group,
-            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
+            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>, '
                 '(foo) Roger ping@exampele.com, x@test.example.com;'),
-            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
+            ('Monty Python: "Fred A. Bear" <dinsdale@example.com>, '
                 '(foo) Roger ping@exampele.com, x@test.example.com;'),
             ('Monty Python: "Fred A. Bear" <dinsdale@example.com>,'
                 ' Roger ping@exampele.com, x@test.example.com;'),
@@ -2154,11 +2154,11 @@ class TestParser(TestParserMixin, TestEmailBase):
 
     def test_get_group_missing_final_semicol(self):
         group = self._test_get_x(parser.get_group,
-            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>,'
+            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>, '
              'eric@where.test,John <jdoe@test>'),
-            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>,'
+            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>, '
              'eric@where.test,John <jdoe@test>;'),
-            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>,'
+            ('Monty Python:"Fred A. Bear" <dinsdale@example.com>, '
              'eric@where.test,John <jdoe@test>;'),
             [errors.InvalidHeaderDefect],
             '')
@@ -2359,13 +2359,13 @@ class TestParser(TestParserMixin, TestEmailBase):
     def test_get_address_list_mailboxes_complex(self):
         address_list = self._test_get_x(parser.get_address_list,
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                '(ping) Foo <x@example.com>,'
+                '(ping) Foo <x@example.com>, '
                 'Nobody Is. Special <y@(bird)example.(bad)com>'),
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                '(ping) Foo <x@example.com>,'
+                '(ping) Foo <x@example.com>, '
                 'Nobody Is. Special <y@(bird)example.(bad)com>'),
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                'Foo <x@example.com>,'
+                'Foo <x@example.com>, '
                 '"Nobody Is. Special" <y@example. com>'),
             [errors.ObsoleteHeaderDefect, # period in Is.
             errors.ObsoleteHeaderDefect], # cfws in domain
@@ -2386,13 +2386,13 @@ class TestParser(TestParserMixin, TestEmailBase):
     def test_get_address_list_mailboxes_invalid_addresses(self):
         address_list = self._test_get_x(parser.get_address_list,
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                '(ping) Foo x@example.com[],'
+                '(ping) Foo x@example.com[], '
                 'Nobody Is. Special <(bird)example.(bad)com>'),
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                '(ping) Foo x@example.com[],'
+                '(ping) Foo x@example.com[], '
                 'Nobody Is. Special <(bird)example.(bad)com>'),
             ('"Roy A. Bear" <dinsdale@example.com>, '
-                'Foo x@example.com[],'
+                'Foo x@example.com[], '
                 '"Nobody Is. Special" < example. com>'),
              [errors.InvalidHeaderDefect,   # invalid address in list
               errors.InvalidHeaderDefect,   # 'Foo x' local part invalid.

--- a/Lib/test/test_http_cookiejar.py
+++ b/Lib/test/test_http_cookiejar.py
@@ -174,12 +174,10 @@ class DateTimeTests(unittest.TestCase):
             '1980-01-01 00:61:00',
             '01-01-1980 00:00:62',
             '01-01-1980T00:00:62',
-            '19800101T250000Z'
-            '1980-01-01 00:00:00 -2500',
+            '19800101T250000Z',
             ]:
             self.assertIsNone(iso2time(test),
-                              "iso2time(%s) is not None\n"
-                              "iso2time(test) %s" % (test, iso2time(test)))
+                              "iso2time(%r)" % test)
 
 
 class HeaderTests(unittest.TestCase):

--- a/Lib/test/test_range.py
+++ b/Lib/test/test_range.py
@@ -39,7 +39,7 @@ class RangeTest(unittest.TestCase):
                 self.fail('{}: unexpected excess element {} at '
                           'position {}'.format(test_id, x, i))
             else:
-                self.fail('{}: wrong element at position {};'
+                self.fail('{}: wrong element at position {}; '
                           'expected {}, got {}'.format(test_id, i, y, x))
 
     def test_range(self):

--- a/Lib/test/test_smtplib.py
+++ b/Lib/test/test_smtplib.py
@@ -805,7 +805,7 @@ class SimSMTPChannel(smtpd.SMTPChannel):
             try:
                 user, hashed_pass = logpass.split()
             except ValueError as e:
-                self.push('535 Splitting response {!r} into user and password'
+                self.push('535 Splitting response {!r} into user and password '
                           'failed: {}'.format(logpass, e))
                 return False
             valid_hashed_pass = hmac.HMAC(

--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -506,7 +506,7 @@ class CalculationTests(unittest.TestCase):
         self.assertTrue(result.tm_year == self.time_tuple.tm_year and
                          result.tm_mon == self.time_tuple.tm_mon and
                          result.tm_mday == self.time_tuple.tm_mday,
-                        "Calculation of Gregorian date failed;"
+                        "Calculation of Gregorian date failed; "
                          "%s-%s-%s != %s-%s-%s" %
                          (result.tm_year, result.tm_mon, result.tm_mday,
                           self.time_tuple.tm_year, self.time_tuple.tm_mon,
@@ -518,7 +518,7 @@ class CalculationTests(unittest.TestCase):
         result = _strptime._strptime_time(time.strftime(format_string, self.time_tuple),
                                     format_string)
         self.assertTrue(result.tm_wday == self.time_tuple.tm_wday,
-                        "Calculation of day of the week failed;"
+                        "Calculation of day of the week failed; "
                          "%s != %s" % (result.tm_wday, self.time_tuple.tm_wday))
 
     if support.is_android:

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -299,7 +299,7 @@ class CoverageResults:
         try:
             outfile = open(path, "w", encoding=encoding)
         except OSError as err:
-            print(("trace: Could not open %r for writing: %s"
+            print(("trace: Could not open %r for writing: %s "
                                   "- skipping" % (path, err)), file=sys.stderr)
             return 0, 0
 
@@ -644,7 +644,7 @@ def main():
     grp = parser.add_argument_group('Filters',
             'Can be specified multiple times')
     grp.add_argument('--ignore-module', action='append', default=[],
-            help='Ignore the given module(s) and its submodules'
+            help='Ignore the given module(s) and its submodules '
                  '(if it is a package). Accepts comma separated list of '
                  'module names.')
     grp.add_argument('--ignore-dir', action='append', default=[],

--- a/Lib/unittest/mock.py
+++ b/Lib/unittest/mock.py
@@ -1772,7 +1772,7 @@ _all_magics = _magics | _non_defaults
 
 _unsupported_magics = {
     '__getattr__', '__setattr__',
-    '__init__', '__new__', '__prepare__'
+    '__init__', '__new__', '__prepare__',
     '__instancecheck__', '__subclasscheck__',
     '__del__'
 }

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -3446,7 +3446,7 @@ tzinfo_fromutc(PyDateTime_TZInfo *self, PyObject *dt)
     return result;
 
 Inconsistent:
-    PyErr_SetString(PyExc_ValueError, "fromutc: tz.dst() gave"
+    PyErr_SetString(PyExc_ValueError, "fromutc: tz.dst() gave "
                     "inconsistent results; cannot convert");
 
     /* fall through to failure */

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -1313,7 +1313,7 @@ _io_TextIOWrapper_reconfigure_impl(textio *self, PyObject *encoding,
     /* Check if something is in the read buffer */
     if (self->decoded_chars != NULL) {
         if (encoding != Py_None || errors != Py_None || newline_obj != NULL) {
-            _unsupported("It is not possible to set the encoding or newline"
+            _unsupported("It is not possible to set the encoding or newline "
                          "of stream after the first read");
             return NULL;
         }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -4612,7 +4612,7 @@ Pickler_set_memo(PicklerObject *self, PyObject *obj)
     }
     else {
         PyErr_Format(PyExc_TypeError,
-                     "'memo' attribute must be a PicklerMemoProxy object"
+                     "'memo' attribute must be a PicklerMemoProxy object "
                      "or dict, not %.200s", Py_TYPE(obj)->tp_name);
         return -1;
     }
@@ -7048,7 +7048,7 @@ Unpickler_set_memo(UnpicklerObject *self, PyObject *obj)
     }
     else {
         PyErr_Format(PyExc_TypeError,
-                     "'memo' attribute must be an UnpicklerMemoProxy object"
+                     "'memo' attribute must be an UnpicklerMemoProxy object "
                      "or dict, not %.200s", Py_TYPE(obj)->tp_name);
         return -1;
     }

--- a/Python/import.c
+++ b/Python/import.c
@@ -839,7 +839,7 @@ remove_module(PyObject *name)
         if (!PyMapping_HasKey(modules, name)) {
             return;
         }
-        Py_FatalError("import:  deleting existing key in"
+        Py_FatalError("import:  deleting existing key in "
                       "sys.modules failed");
     }
 }

--- a/Tools/scripts/texi2html.py
+++ b/Tools/scripts/texi2html.py
@@ -1806,7 +1806,7 @@ class HTMLHelp:
             print('<!-- This file defines the table of contents -->', file=fp)
             print('<HTML>', file=fp)
             print('<HEAD>', file=fp)
-            print('<meta name="GENERATOR"'
+            print('<meta name="GENERATOR" '
                         'content="Microsoft&reg; HTML Help Workshop 4.1">', file=fp)
             print('<!-- Sitemap 1.0 -->', file=fp)
             print('</HEAD>', file=fp)
@@ -1831,7 +1831,7 @@ class HTMLHelp:
             print('<!-- This file defines the index -->', file=fp)
             print('<HTML>', file=fp)
             print('<HEAD>', file=fp)
-            print('<meta name="GENERATOR"'
+            print('<meta name="GENERATOR" '
                         'content="Microsoft&reg; HTML Help Workshop 4.1">', file=fp)
             print('<!-- Sitemap 1.0 -->', file=fp)
             print('</HEAD>', file=fp)


### PR DESCRIPTION
Two kind of mistakes:

1. Missed space. After concatenating there is no space between words.

2. Missed comma. Causes unintentional concatenating in a list of strings.


<!-- issue-number: [bpo-35133](https://bugs.python.org/issue35133) -->
https://bugs.python.org/issue35133
<!-- /issue-number -->
