### PR TITLE
bpo-20596: define a platform dependent Py_WCSTOK in Include/pyport.h,…

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -809,4 +809,19 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 #define WITH_THREAD
 #endif
 
+/* The Py_WCSTOK macro provides a uniform interface to the wide
+ * character tokenizer function.  Based on the environment,
+ * an appropriate implementation will be chosen.
+ *
+ * Microsoft does not have a three-argument wcstok, but instead provides
+ * an equivalent via the wcstok_s().  Borland/Embarcadero and MinGW provide this
+ * same wcstok_s() function.  If MS_WINDOWS is not defined,
+ * we'll assume that a POSIX-like three-argument version is available.
+ */
+#if defined(MS_WINDOWS)
+#       define Py_WCSTOK(str, tok, state)  wcstok_s(str, tok, state)
+#else
+#       define Py_WCSTOK(str, tok, state)  wcstok(str, tok, state)
+#endif
+
 #endif /* Py_PYPORT_H */

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -819,9 +819,9 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
  * we'll assume that a POSIX-like three-argument version is available.
  */
 #if defined(MS_WINDOWS)
-#       define Py_WCSTOK(str, tok, state)  wcstok_s(str, tok, state)
+#       define _Py_WCSTOK(str, tok, state)  wcstok_s(str, tok, state)
 #else
-#       define Py_WCSTOK(str, tok, state)  wcstok(str, tok, state)
+#       define _Py_WCSTOK(str, tok, state)  wcstok(str, tok, state)
 #endif
 
 #endif /* Py_PYPORT_H */

--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -809,7 +809,7 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 #define WITH_THREAD
 #endif
 
-/* The Py_WCSTOK macro provides a uniform interface to the wide
+/* The _Py_WCSTOK macro provides a uniform interface to the wide
  * character tokenizer function.  Based on the environment,
  * an appropriate implementation will be chosen.
  *

--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-04-11-47-53.bpo-20596.N6nB_g.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-04-11-47-53.bpo-20596.N6nB_g.rst
@@ -1,0 +1,1 @@
+define a platform dependent _Py_WCSTOK in Include/pyport.h

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -886,9 +886,9 @@ cmdline_init_env_warnoptions(_PyMain *pymain, const _PyCoreConfig *config,
 
 
     wchar_t *warning, *context = NULL;
-    for (warning = Py_WCSTOK(env, L",", &context);
+    for (warning = _Py_WCSTOK(env, L",", &context);
          warning != NULL;
-         warning = Py_WCSTOK(NULL, L",", &context))
+         warning = _Py_WCSTOK(NULL, L",", &context))
     {
         _PyInitError err = _Py_wstrlist_append(&cmdline->nenv_warnoption,
                                                &cmdline->env_warnoptions,

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -44,13 +44,6 @@ extern "C" {
      ? _Py_INIT_USER_ERR("cannot decode " NAME) \
      : _Py_INIT_NO_MEMORY())
 
-
-#ifdef MS_WINDOWS
-#define WCSTOK wcstok_s
-#else
-#define WCSTOK wcstok
-#endif
-
 /* For Py_GetArgcArgv(); set by main() */
 static wchar_t **orig_argv = NULL;
 static int orig_argc = 0;
@@ -893,9 +886,9 @@ cmdline_init_env_warnoptions(_PyMain *pymain, const _PyCoreConfig *config,
 
 
     wchar_t *warning, *context = NULL;
-    for (warning = WCSTOK(env, L",", &context);
+    for (warning = Py_WCSTOK(env, L",", &context);
          warning != NULL;
-         warning = WCSTOK(NULL, L",", &context))
+         warning = Py_WCSTOK(NULL, L",", &context))
     {
         _PyInitError err = _Py_wstrlist_append(&cmdline->nenv_warnoption,
                                                &cmdline->env_warnoptions,

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -693,11 +693,11 @@ _Py_FindEnvConfigValue(FILE *env_file, const wchar_t *key,
         wchar_t *tmpbuffer = _Py_DecodeUTF8_surrogateescape(buffer, n);
         if (tmpbuffer) {
             wchar_t * state;
-            wchar_t * tok = wcstok(tmpbuffer, L" \t\r\n", &state);
+            wchar_t * tok = Py_WCSTOK(tmpbuffer, L" \t\r\n", &state);
             if ((tok != NULL) && !wcscmp(tok, key)) {
-                tok = wcstok(NULL, L" \t", &state);
+                tok = Py_WCSTOK(NULL, L" \t", &state);
                 if ((tok != NULL) && !wcscmp(tok, L"=")) {
-                    tok = wcstok(NULL, L"\r\n", &state);
+                    tok = Py_WCSTOK(NULL, L"\r\n", &state);
                     if (tok != NULL) {
                         wcsncpy(value, tok, MAXPATHLEN);
                         result = 1;

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -693,11 +693,11 @@ _Py_FindEnvConfigValue(FILE *env_file, const wchar_t *key,
         wchar_t *tmpbuffer = _Py_DecodeUTF8_surrogateescape(buffer, n);
         if (tmpbuffer) {
             wchar_t * state;
-            wchar_t * tok = Py_WCSTOK(tmpbuffer, L" \t\r\n", &state);
+            wchar_t * tok = _Py_WCSTOK(tmpbuffer, L" \t\r\n", &state);
             if ((tok != NULL) && !wcscmp(tok, key)) {
-                tok = Py_WCSTOK(NULL, L" \t", &state);
+                tok = _Py_WCSTOK(NULL, L" \t", &state);
                 if ((tok != NULL) && !wcscmp(tok, L"=")) {
-                    tok = Py_WCSTOK(NULL, L"\r\n", &state);
+                    tok = _Py_WCSTOK(NULL, L"\r\n", &state);
                     if (tok != NULL) {
                         wcsncpy(value, tok, MAXPATHLEN);
                         result = 1;


### PR DESCRIPTION
pull request based on the patch of Jeffry Armstrong on 2014-02-13,
but discriminating on MS_WINDOWS instead of specific compilers.

<!-- issue-number: [bpo-20596](https://bugs.python.org/issue20596) -->
https://bugs.python.org/issue20596
<!-- /issue-number -->
