### PR TITLE
Doc: Simplify Copyright line in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,9 +22,7 @@ This is Python version 3.8.0 alpha 0
    :target: https://python.zulipchat.com
 
 
-Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
-2012, 2013, 2014, 2015, 2016, 2017, 2018 Python Software Foundation.  All rights
-reserved.
+Copyright (c) 2001-2018 Python Software Foundation.  All rights reserved.
 
 See the end of this file for further copyright and license information.
 
@@ -251,9 +249,7 @@ See :pep:`569` for Python 3.8 release details.
 Copyright and License Information
 ---------------------------------
 
-Copyright (c) 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011,
-2012, 2013, 2014, 2015, 2016, 2017, 2018 Python Software Foundation.  All rights
-reserved.
+Copyright (c) 2001-2018 Python Software Foundation.  All rights reserved.
 
 Copyright (c) 2000 BeOpen.com.  All rights reserved.
 


### PR DESCRIPTION
This also makes it consistent with other places like:

- https://docs.python.org/dev/copyright.html
- https://www.python.org/ footer
- https://github.com/python/cpython/blob/e42b705188271da108de42b55d9344642170aa2b/Python/getcopyright.c#L7

