### PR TITLE
bpo-35139: The `pyexpat` module's macros in `Modules/Setup` now matches `setup.py`

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-11-01-15-01-23.bpo-35139.XZTttb.rst
+++ b/Misc/NEWS.d/next/Build/2018-11-01-15-01-23.bpo-35139.XZTttb.rst
@@ -1,0 +1,1 @@
+Fix a compiler error when statically linking `pyexpat` in `Modules/Setup`.

--- a/Modules/Setup
+++ b/Modules/Setup
@@ -333,7 +333,7 @@ _symtable symtablemodule.c
 # Interface to the Expat XML parser
 # More information on Expat can be found at www.libexpat.org.
 #
-#pyexpat expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DUSE_PYEXPAT_CAPI
+#pyexpat expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DXML_POOR_ENTROPY=1 -DUSE_PYEXPAT_CAPI
 
 # Hye-Shik Chang's CJKCodecs
 


### PR DESCRIPTION
This could cause compile errors on macOS or other platforms.


<!-- issue-number: [bpo-35139](https://bugs.python.org/issue35139) -->
https://bugs.python.org/issue35139
<!-- /issue-number -->
