### PR TITLE
[2.7] closes bpo-35139: The `pyexpat` module's macros in `Modules/Setup` now match `setup.py` (GH-10289)

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-11-01-15-01-23.bpo-35139.XZTttb.rst
+++ b/Misc/NEWS.d/next/Build/2018-11-01-15-01-23.bpo-35139.XZTttb.rst
@@ -1,0 +1,1 @@
+Fix a compiler error when statically linking `pyexpat` in `Modules/Setup`.

--- a/Modules/Setup.dist
+++ b/Modules/Setup.dist
@@ -469,7 +469,7 @@ GLHACK=-Dclear=__GLclear
 # Interface to the Expat XML parser
 # More information on Expat can be found at www.libexpat.org.
 #
-#pyexpat expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DUSE_PYEXPAT_CAPI
+#pyexpat expat/xmlparse.c expat/xmlrole.c expat/xmltok.c pyexpat.c -I$(srcdir)/Modules/expat -DHAVE_EXPAT_CONFIG_H -DXML_POOR_ENTROPY=1 -DUSE_PYEXPAT_CAPI
 
 
 # Hye-Shik Chang's CJKCodecs


### PR DESCRIPTION
This could cause compile errors on macOS or other platforms..
(cherry picked from commit 318ab63c01f5b8e7562b122ab5ba01258a51277b)

Co-authored-by: Max Bélanger <aeromax@gmail.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35139](https://bugs.python.org/issue35139) -->
https://bugs.python.org/issue35139
<!-- /issue-number -->
