### PR TITLE
bpo-32409 Ensures activate.bat can handle Unicode contents

### DIFF
--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -1,11 +1,10 @@
 @echo off
 
-rem This file is UTF-8 encoded, so we need to update the current code page while executing it
-for /f "tokens=2 delims=:" %%a in ('"%SystemRoot%\System32\chcp.com"') do (
-    set "_OLD_CODEPAGE=%%a"
-)
+rem This file is UTF-8 encoded, so we need to update the current code page while executing it.
+for /f %%a in ('%~dp0python.exe -Ic "import ctypes; print(ctypes.windll.kernel32.GetConsoleOutputCP())"') do (set "_OLD_CODEPAGE=%%a")
+
 if defined _OLD_CODEPAGE (
-    "%SystemRoot%\System32\chcp.com" 65001 > nul
+    %~dp0python.exe -Ic "import ctypes; ctypes.windll.kernel32.SetConsoleOutputCP(65001)"
 )
 
 set "VIRTUAL_ENV=__VENV_DIR__"
@@ -40,6 +39,6 @@ set "PATH=%VIRTUAL_ENV%\__VENV_BIN_NAME__;%PATH%"
 
 :END
 if defined _OLD_CODEPAGE (
-    "%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE% > nul
+    %~dp0python.exe -Ic "import ctypes; ctypes.windll.kernel32.SetConsoleOutputCP(%_OLD_CODEPAGE%)"
     set "_OLD_CODEPAGE="
 )

--- a/Misc/NEWS.d/next/Library/2018-11-02-12-01-00.bpo-32409.MFRX2Q.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-02-12-01-00.bpo-32409.MFRX2Q.rst
@@ -1,0 +1,2 @@
+Fixed implementation of :file:`activate.bat` to handle Unicode contents on
+localized Windows systems (eg. German). Patch by Martin Bijl.


### PR DESCRIPTION
activate.bat breaks on German Windows systems as chcp does not return a plain number as on English systems, but appends a dot at the end (for example "Aktive Codepage: 850." instead of "Active Codepage: 850). We convert the string to a number deleting the trailing dot.

Note: this must be backported to Python 3.6 and Python 3.7

The solution of msg308934 on https://bugs.python.org/issue32409 does not take internationalization of Windows in account. I could create a new bugticket.

<!-- issue-number: [bpo-32409](https://bugs.python.org/issue32409) -->
https://bugs.python.org/issue32409
<!-- /issue-number -->
