### PR TITLE
bpo-35147: Fix _Py_NO_RETURN for GCC

### DIFF
--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -94,9 +94,9 @@ PyAPI_FUNC(void) PyErr_SetExcInfo(PyObject *, PyObject *, PyObject *);
 #endif
 
 #if defined(__clang__) || \
-    (defined(__GNUC_MAJOR__) && \
-     ((__GNUC_MAJOR__ >= 3) || \
-      (__GNUC_MAJOR__ == 2) && (__GNUC_MINOR__ >= 5)))
+    (defined(__GNUC__) && \
+     ((__GNUC__ >= 3) || \
+      (__GNUC__ == 2) && (__GNUC_MINOR__ >= 5)))
 #  define _Py_NO_RETURN __attribute__((__noreturn__))
 #elif defined(_MSC_VER)
 #  define _Py_NO_RETURN __declspec(noreturn)


### PR DESCRIPTION
Use `__GNUC__` instead of non-existing `__GNUC_MAJOR__`.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35147](https://bugs.python.org/issue35147) -->
https://bugs.python.org/issue35147
<!-- /issue-number -->
