### PR TITLE
[3.7] bpo-35147: Fix _Py_NO_RETURN for GCC (GH-10300)

### DIFF
--- a/Include/pyerrors.h
+++ b/Include/pyerrors.h
@@ -94,9 +94,9 @@ PyAPI_FUNC(void) PyErr_SetExcInfo(PyObject *, PyObject *, PyObject *);
 #endif
 
 #if defined(__clang__) || \
-    (defined(__GNUC_MAJOR__) && \
-     ((__GNUC_MAJOR__ >= 3) || \
-      (__GNUC_MAJOR__ == 2) && (__GNUC_MINOR__ >= 5)))
+    (defined(__GNUC__) && \
+     ((__GNUC__ >= 3) || \
+      (__GNUC__ == 2) && (__GNUC_MINOR__ >= 5)))
 #define _Py_NO_RETURN __attribute__((__noreturn__))
 #else
 #define _Py_NO_RETURN


### PR DESCRIPTION
Use `__GNUC__` instead of non-existing `__GNUC_MAJOR__`.

(cherry picked from commit e2ed5adcb5db2d70cfa72da1ba8446f7aa9e05cd)

<!-- issue-number: [bpo-35147](https://bugs.python.org/issue35147) -->
https://bugs.python.org/issue35147
<!-- /issue-number -->