### PR TITLE
bpo-37012: Fix a possible crash due to PyType_FromSpecWithBases()

### DIFF
--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -2944,6 +2944,7 @@ PyType_FromSpecWithBases(PyType_Spec *spec, PyObject *bases)
             size_t len = strlen(old_doc)+1;
             char *tp_doc = PyObject_MALLOC(len);
             if (tp_doc == NULL) {
+                type->tp_doc = NULL;
                 PyErr_NoMemory();
                 goto fail;
             }


### PR DESCRIPTION
If the PyObject_MALLOC() call failed in PyType_FromSpecWithBases(),
PyObject_Free() would be called on a static string in type_dealloc().

<!-- issue-number: [bpo-37012](https://bugs.python.org/issue37012) -->
https://bugs.python.org/issue37012
<!-- /issue-number -->
