### PR TITLE
bpo-35113: Fix inspect.getsource to return correct source for inner classes

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -821,12 +821,9 @@ def findsource(object):
                 nonlocal line_number
                 stack.append(node.name)
                 if qualname == '.'.join(stack):
-                    if node.decorator_list:
-                        line_number = node.decorator_list[0].lineno
-                    else:
-                        line_number = node.lineno
                     # decrement by one since lines starts with indexing by zero
-                    line_number = line_number - 1
+                    line_number = node.lineno - 1
+                    raise StopIteration(line_number)
                 self.generic_visit(node)
                 stack.pop()
 
@@ -836,9 +833,10 @@ def findsource(object):
         source = ''.join(lines)
         tree = ast.parse(source)
         class_finder = ClassFinder()
-        class_finder.visit(tree)
-
-        if line_number is not None:
+        try:
+            class_finder.visit(tree)
+        except StopIteration as e:
+            line_number = e.value
             return lines, line_number
         else:
             raise OSError('could not find class definition')

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -806,7 +806,7 @@ def findsource(object):
         # it's not used for other than this part.
         import ast
 
-        class ClassVisitor(ast.NodeVisitor):
+        class ClassFinder(ast.NodeVisitor):
 
             def visit_FunctionDef(self, node):
                 stack.append(node.name)
@@ -835,11 +835,10 @@ def findsource(object):
         qualname = object.__qualname__
         source = ''.join(lines)
         tree = ast.parse(source)
-        class_visitor = ClassVisitor()
-        class_visitor.visit(tree)
+        class_finder = ClassFinder()
+        class_finder.visit(tree)
 
         if line_number is not None:
-            line_number = line_number
             return lines, line_number
         else:
             raise OSError('could not find class definition')

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -820,12 +820,7 @@ def findsource(object):
                 self.stack.pop()
                 self.stack.pop()
 
-            def visit_AsyncFunctionDef(self, node):
-                self.stack.append(node.name)
-                self.stack.append('<locals>')
-                self.generic_visit(node)
-                self.stack.pop()
-                self.stack.pop()
+            visit_AsyncFunctionDef = visit_FunctionDef
 
             def visit_ClassDef(self, node):
                 self.stack.append(node.name)

--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -821,8 +821,14 @@ def findsource(object):
                 nonlocal line_number
                 stack.append(node.name)
                 if qualname == '.'.join(stack):
+                    # Return the decorator for the class if present
+                    if node.decorator_list:
+                        line_number = node.decorator_list[0].lineno
+                    else:
+                        line_number = node.lineno
+
                     # decrement by one since lines starts with indexing by zero
-                    line_number = node.lineno - 1
+                    line_number -= 1
                     raise StopIteration(line_number)
                 self.generic_visit(node)
                 stack.pop()

--- a/Lib/test/inspect_fodder2.py
+++ b/Lib/test/inspect_fodder2.py
@@ -187,40 +187,67 @@ class cls183:
         def func186(self):
             pass
 
-
 def class_decorator(cls):
     return cls
 
-# line 195
+# line 193
 @class_decorator
 @class_decorator
-class cls197:
+class cls196:
 
     @class_decorator
     @class_decorator
-    class cls201:
+    class cls200:
         pass
 
-class cls204:
-    class cls205:
-        class cls206:
+class cls203:
+    class cls204:
+        class cls205:
             pass
-    class cls208:
-        class cls209:
+    class cls207:
+        class cls208:
             pass
 
-#line 212
+# line 211
+def func212():
+    class cls213:
+        def func(self):
+            pass
+    return cls213
+
+# line 218
+class cls213:
+    def func220(self):
+        class cls221:
+            pass
+        return cls221
+
+# line 225
+async def func226():
+    class cls227:
+        def func(self):
+            pass
+    return cls227
+
+# line 232
+class cls227:
+    async def func234(self):
+        class cls235:
+            pass
+        return cls235
+
+#line 239
 def positional_only_arg(a, /):
     pass
 
-#line 216
+#line 243
 def all_markers(a, b, /, c, d, *, e, f):
     pass
 
-# line 220
+# line 247
 def all_markers_with_args_and_kwargs(a, b, /, c, d, *args, e, f, **kwargs):
     pass
 
-#line 224
+#line 251
 def all_markers_with_defaults(a, b=1, /, c=2, d=3, *, e=4, f=5):
     pass

--- a/Lib/test/inspect_fodder2.py
+++ b/Lib/test/inspect_fodder2.py
@@ -237,24 +237,25 @@ class cls226:
 if True:
     class cls238:
         class cls239:
-            pass
+            '''if clause cls239'''
 else:
     class cls238:
         class cls239:
+            '''else clause 239'''
             pass
 
-#line 246
+#line 247
 def positional_only_arg(a, /):
     pass
 
-#line 250
+#line 251
 def all_markers(a, b, /, c, d, *, e, f):
     pass
 
-# line 254
+# line 255
 def all_markers_with_args_and_kwargs(a, b, /, c, d, *args, e, f, **kwargs):
     pass
 
-#line 258
+#line 259
 def all_markers_with_defaults(a, b=1, /, c=2, d=3, *, e=4, f=5):
     pass

--- a/Lib/test/inspect_fodder2.py
+++ b/Lib/test/inspect_fodder2.py
@@ -232,20 +232,29 @@ class cls226:
     async def func232(self):
         class cls233:
             pass
-        return cls235
+        return cls233
 
-#line 237
+if True:
+    class cls238:
+        class cls239:
+            pass
+else:
+    class cls238:
+        class cls239:
+            pass
+
+#line 246
 def positional_only_arg(a, /):
     pass
 
-#line 241
+#line 250
 def all_markers(a, b, /, c, d, *, e, f):
     pass
 
-# line 245
+# line 254
 def all_markers_with_args_and_kwargs(a, b, /, c, d, *args, e, f, **kwargs):
     pass
 
-#line 249
+#line 258
 def all_markers_with_defaults(a, b=1, /, c=2, d=3, *, e=4, f=5):
     pass

--- a/Lib/test/inspect_fodder2.py
+++ b/Lib/test/inspect_fodder2.py
@@ -201,18 +201,26 @@ class cls197:
     class cls201:
         pass
 
-#line 204
+class cls204:
+    class cls205:
+        class cls206:
+            pass
+    class cls208:
+        class cls209:
+            pass
+
+#line 212
 def positional_only_arg(a, /):
     pass
 
-#line 208
+#line 216
 def all_markers(a, b, /, c, d, *, e, f):
     pass
 
-# line 212
+# line 220
 def all_markers_with_args_and_kwargs(a, b, /, c, d, *args, e, f, **kwargs):
     pass
 
-#line 216
+#line 224
 def all_markers_with_defaults(a, b=1, /, c=2, d=3, *, e=4, f=5):
     pass

--- a/Lib/test/inspect_fodder2.py
+++ b/Lib/test/inspect_fodder2.py
@@ -205,49 +205,47 @@ class cls203:
         class cls205:
             pass
     class cls207:
-        class cls208:
+        class cls205:
             pass
 
 # line 211
 def func212():
     class cls213:
-        def func(self):
-            pass
+        pass
     return cls213
 
-# line 218
+# line 217
 class cls213:
-    def func220(self):
-        class cls221:
+    def func219(self):
+        class cls220:
             pass
-        return cls221
+        return cls220
 
-# line 225
-async def func226():
-    class cls227:
-        def func(self):
-            pass
-    return cls227
+# line 224
+async def func225():
+    class cls226:
+        pass
+    return cls226
 
-# line 232
-class cls227:
-    async def func234(self):
-        class cls235:
+# line 230
+class cls226:
+    async def func232(self):
+        class cls233:
             pass
         return cls235
 
-#line 239
+#line 237
 def positional_only_arg(a, /):
     pass
 
-#line 243
+#line 241
 def all_markers(a, b, /, c, d, *, e, f):
     pass
 
-# line 247
+# line 245
 def all_markers_with_args_and_kwargs(a, b, /, c, d, *args, e, f, **kwargs):
     pass
 
-#line 251
+#line 249
 def all_markers_with_defaults(a, b=1, /, c=2, d=3, *, e=4, f=5):
     pass

--- a/Lib/test/inspect_fodder2.py
+++ b/Lib/test/inspect_fodder2.py
@@ -138,18 +138,81 @@ class cls135:
             never_reached1
             never_reached2
 
-#line 141
+# line 141
+class cls142:
+    a = """
+class cls149:
+    ...
+"""
+
+# line 148
+class cls149:
+
+    def func151(self):
+        pass
+
+'''
+class cls160:
+    pass
+'''
+
+# line 159
+class cls160:
+
+    def func162(self):
+        pass
+
+# line 165
+class cls166:
+    a = '''
+    class cls175:
+        ...
+    '''
+
+# line 172
+class cls173:
+
+    class cls175:
+        pass
+
+# line 178
+class cls179:
+    pass
+
+# line 182
+class cls183:
+
+    class cls185:
+
+        def func186(self):
+            pass
+
+
+def class_decorator(cls):
+    return cls
+
+# line 195
+@class_decorator
+@class_decorator
+class cls197:
+
+    @class_decorator
+    @class_decorator
+    class cls201:
+        pass
+
+#line 204
 def positional_only_arg(a, /):
     pass
 
-#line 145
+#line 208
 def all_markers(a, b, /, c, d, *, e, f):
     pass
 
-# line 149
+# line 212
 def all_markers_with_args_and_kwargs(a, b, /, c, d, *args, e, f, **kwargs):
     pass
 
-#line 153
+#line 216
 def all_markers_with_defaults(a, b=1, /, c=2, d=3, *, e=4, f=5):
     pass

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -709,6 +709,22 @@ class TestBuggyCases(GetSourceBase):
     def test_nested_func(self):
         self.assertSourceEqual(mod2.cls135.func136, 136, 139)
 
+    def test_class_definition_in_multiline_string_definition(self):
+        self.assertSourceEqual(mod2.cls149, 149, 152)
+
+    def test_class_definition_in_multiline_comment(self):
+        self.assertSourceEqual(mod2.cls160, 160, 163)
+
+    def test_nested_class_definition_indented_string(self):
+        self.assertSourceEqual(mod2.cls173.cls175, 175, 176)
+
+    def test_nested_class_definition(self):
+        self.assertSourceEqual(mod2.cls183, 183, 188)
+        self.assertSourceEqual(mod2.cls183.cls185, 185, 188)
+
+    def test_class_decorator(self):
+        self.assertSourceEqual(mod2.cls197, 195, 202)
+        self.assertSourceEqual(mod2.cls197.cls201, 199, 202)
 
 class TestNoEOL(GetSourceBase):
     def setUp(self):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -741,10 +741,10 @@ class TestBuggyCases(GetSourceBase):
 
     def test_nested_class_definition_inside_async_function(self):
         import asyncio
+        self.addCleanup(asyncio.set_event_loop_policy, None)
         self.assertSourceEqual(asyncio.run(mod2.func225()), 226, 227)
         self.assertSourceEqual(mod2.cls226, 231, 235)
         self.assertSourceEqual(asyncio.run(mod2.cls226().func232()), 233, 234)
-        self.addCleanup(asyncio.set_event_loop_policy, None)
 
 class TestNoEOL(GetSourceBase):
     def setUp(self):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -724,8 +724,8 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(mod2.cls183.cls185, 185, 188)
 
     def test_class_decorator(self):
-        self.assertSourceEqual(mod2.cls196, 196, 201)
-        self.assertSourceEqual(mod2.cls196.cls200, 200, 201)
+        self.assertSourceEqual(mod2.cls196, 194, 201)
+        self.assertSourceEqual(mod2.cls196.cls200, 198, 201)
 
     def test_class_inside_conditional(self):
         self.assertSourceEqual(mod2.cls238, 238, 240)

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -744,6 +744,7 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(asyncio.run(mod2.func226()), 227, 229)
         self.assertSourceEqual(mod2.cls227, 233, 237)
         self.assertSourceEqual(asyncio.run(mod2.cls227().func234()), 235, 236)
+        asyncio.set_event_loop_policy(None)
 
 class TestNoEOL(GetSourceBase):
     def setUp(self):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -726,6 +726,13 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(mod2.cls197, 195, 202)
         self.assertSourceEqual(mod2.cls197.cls201, 199, 202)
 
+    def test_multiple_children_classes(self):
+        self.assertSourceEqual(mod2.cls204, 204, 210)
+        self.assertSourceEqual(mod2.cls204.cls205, 205, 207)
+        self.assertSourceEqual(mod2.cls204.cls205.cls206, 206, 207)
+        self.assertSourceEqual(mod2.cls204.cls208, 208, 210)
+        self.assertSourceEqual(mod2.cls204.cls208.cls209, 209, 210)
+
 class TestNoEOL(GetSourceBase):
     def setUp(self):
         self.tempdir = TESTFN + '_dir'

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -744,7 +744,7 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(asyncio.run(mod2.func225()), 226, 227)
         self.assertSourceEqual(mod2.cls226, 231, 235)
         self.assertSourceEqual(asyncio.run(mod2.cls226().func232()), 233, 234)
-        asyncio.set_event_loop_policy(None)
+        self.addCleanup(asyncio.set_event_loop_policy, None)
 
 class TestNoEOL(GetSourceBase):
     def setUp(self):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -735,16 +735,16 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(mod2.cls203.cls207.cls205, 208, 209)
 
     def test_nested_class_definition_inside_function(self):
-        self.assertSourceEqual(mod2.func212(), 213, 215)
+        self.assertSourceEqual(mod2.func212(), 213, 214)
         self.assertSourceEqual(mod2.cls213, 218, 222)
         self.assertSourceEqual(mod2.cls213().func219(), 220, 221)
 
     def test_nested_class_definition_inside_async_function(self):
         import asyncio
-        self.assertSourceEqual(asyncio.run(mod2.func225()), 226, 228)
+        self.assertSourceEqual(asyncio.run(mod2.func225()), 226, 227)
         self.assertSourceEqual(mod2.cls226, 231, 235)
         self.assertSourceEqual(asyncio.run(mod2.cls226().func232()), 233, 234)
-        self.addCleanup(asyncio.set_event_loop_policy, None)
+        asyncio.set_event_loop_policy(None)
 
 class TestNoEOL(GetSourceBase):
     def setUp(self):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -724,8 +724,12 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(mod2.cls183.cls185, 185, 188)
 
     def test_class_decorator(self):
-        self.assertSourceEqual(mod2.cls196, 194, 201)
-        self.assertSourceEqual(mod2.cls196.cls200, 198, 201)
+        self.assertSourceEqual(mod2.cls196, 196, 201)
+        self.assertSourceEqual(mod2.cls196.cls200, 200, 201)
+
+    def test_class_inside_conditional(self):
+        self.assertSourceEqual(mod2.cls238, 238, 240)
+        self.assertSourceEqual(mod2.cls238.cls239, 239, 240)
 
     def test_multiple_children_classes(self):
         self.assertSourceEqual(mod2.cls203, 203, 209)

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -732,19 +732,19 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(mod2.cls203.cls204, 204, 206)
         self.assertSourceEqual(mod2.cls203.cls204.cls205, 205, 206)
         self.assertSourceEqual(mod2.cls203.cls207, 207, 209)
-        self.assertSourceEqual(mod2.cls203.cls207.cls208, 208, 209)
+        self.assertSourceEqual(mod2.cls203.cls207.cls205, 208, 209)
 
     def test_nested_class_definition_inside_function(self):
         self.assertSourceEqual(mod2.func212(), 213, 215)
-        self.assertSourceEqual(mod2.cls213, 219, 223)
-        self.assertSourceEqual(mod2.cls213().func220(), 221, 222)
+        self.assertSourceEqual(mod2.cls213, 218, 222)
+        self.assertSourceEqual(mod2.cls213().func219(), 220, 221)
 
     def test_nested_class_definition_inside_async_function(self):
         import asyncio
-        self.assertSourceEqual(asyncio.run(mod2.func226()), 227, 229)
-        self.assertSourceEqual(mod2.cls227, 233, 237)
-        self.assertSourceEqual(asyncio.run(mod2.cls227().func234()), 235, 236)
-        asyncio.set_event_loop_policy(None)
+        self.assertSourceEqual(asyncio.run(mod2.func225()), 226, 228)
+        self.assertSourceEqual(mod2.cls226, 231, 235)
+        self.assertSourceEqual(asyncio.run(mod2.cls226().func232()), 233, 234)
+        self.addCleanup(asyncio.set_event_loop_policy, None)
 
 class TestNoEOL(GetSourceBase):
     def setUp(self):

--- a/Lib/test/test_inspect.py
+++ b/Lib/test/test_inspect.py
@@ -473,6 +473,7 @@ class TestRetrievingSourceCode(GetSourceBase):
     def test_getcomments(self):
         self.assertEqual(inspect.getcomments(mod), '# line 1\n')
         self.assertEqual(inspect.getcomments(mod.StupidGit), '# line 20\n')
+        self.assertEqual(inspect.getcomments(mod2.cls160), '# line 159\n')
         # If the object source file is not available, return None.
         co = compile('x=1', '_non_existing_filename.py', 'exec')
         self.assertIsNone(inspect.getcomments(co))
@@ -723,15 +724,26 @@ class TestBuggyCases(GetSourceBase):
         self.assertSourceEqual(mod2.cls183.cls185, 185, 188)
 
     def test_class_decorator(self):
-        self.assertSourceEqual(mod2.cls197, 195, 202)
-        self.assertSourceEqual(mod2.cls197.cls201, 199, 202)
+        self.assertSourceEqual(mod2.cls196, 194, 201)
+        self.assertSourceEqual(mod2.cls196.cls200, 198, 201)
 
     def test_multiple_children_classes(self):
-        self.assertSourceEqual(mod2.cls204, 204, 210)
-        self.assertSourceEqual(mod2.cls204.cls205, 205, 207)
-        self.assertSourceEqual(mod2.cls204.cls205.cls206, 206, 207)
-        self.assertSourceEqual(mod2.cls204.cls208, 208, 210)
-        self.assertSourceEqual(mod2.cls204.cls208.cls209, 209, 210)
+        self.assertSourceEqual(mod2.cls203, 203, 209)
+        self.assertSourceEqual(mod2.cls203.cls204, 204, 206)
+        self.assertSourceEqual(mod2.cls203.cls204.cls205, 205, 206)
+        self.assertSourceEqual(mod2.cls203.cls207, 207, 209)
+        self.assertSourceEqual(mod2.cls203.cls207.cls208, 208, 209)
+
+    def test_nested_class_definition_inside_function(self):
+        self.assertSourceEqual(mod2.func212(), 213, 215)
+        self.assertSourceEqual(mod2.cls213, 219, 223)
+        self.assertSourceEqual(mod2.cls213().func220(), 221, 222)
+
+    def test_nested_class_definition_inside_async_function(self):
+        import asyncio
+        self.assertSourceEqual(asyncio.run(mod2.func226()), 227, 229)
+        self.assertSourceEqual(mod2.cls227, 233, 237)
+        self.assertSourceEqual(asyncio.run(mod2.cls227().func234()), 235, 236)
 
 class TestNoEOL(GetSourceBase):
     def setUp(self):

--- a/Lib/test/test_pydoc.py
+++ b/Lib/test/test_pydoc.py
@@ -476,6 +476,7 @@ class PydocDocTest(unittest.TestCase):
     def test_non_str_name(self):
         # issue14638
         # Treat illegal (non-str) name like no name
+
         class A:
             __name__ = 42
         class B:

--- a/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
@@ -1,3 +1,2 @@
 :meth:`inspect.getsource` now returns correct source code for inner class
-with same name as module level class. Class decorators are also returned as
-part of the source. Patch by Karthikeyan Singaravelan.
+with same name as module level class. Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
@@ -1,0 +1,3 @@
+:meth:`inspect.getsource` now returns correct source code for inner class
+with same name as module level class. class decorators are also returned as
+part of the source.

--- a/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
@@ -1,2 +1,3 @@
 :meth:`inspect.getsource` now returns correct source code for inner class
-with same name as module level class. Patch by Karthikeyan Singaravelan.
+with same name as module level class. Decorators are also returned as part
+of source of the class. Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
@@ -1,3 +1,3 @@
 :meth:`inspect.getsource` now returns correct source code for inner class
-with same name as module level class. class decorators are also returned as
+with same name as module level class. Class decorators are also returned as
 part of the source. Patch by Karthikeyan Singaravelan.

--- a/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-03-16-18-20.bpo-35113.vwvWKG.rst
@@ -1,3 +1,3 @@
 :meth:`inspect.getsource` now returns correct source code for inner class
 with same name as module level class. class decorators are also returned as
-part of the source.
+part of the source. Patch by Karthikeyan Singaravelan.


### PR DESCRIPTION
Previous approach used regex along with indentation of the match to return the source code. This caused below issues. This PR proposes usage of ast module to do correct parsing.  

**Issues**

1. When a class with same name is defined under different classes.
2. When a class definition is part of a string declaration.
3. When a class definition is part of multiline comment.

Examples of incorrect output can be found with https://bugs.python.org/issue35113. 

This PR also adds returning class decorators as part of the source code instead of just returning the class definition. 

**Inner class example :** 

```python
import inspect

class Foo:
    class Bar:
        def foo(self):
            pass

class Spam:
    class Bar:
        def bar(self):
            pass

print(inspect.getsource(Spam.Bar))
```

**On master**

```
$ ./python.exe foo.py
    class Bar:
        def foo(self):
            pass

```

**IPython**

`inspect.getsource` is also used in lot of tools like IPython and pdb which also return incorrect output due to this

```python
ipython
Python 3.6.4 (default, Mar 12 2018, 13:42:53)
Type 'copyright', 'credits' or 'license' for more information
IPython 6.3.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import foo

In [2]: foo.Spam.Bar??
Init signature: foo.Spam.Bar()
Docstring:      <no docstring>
Source:
    class Bar:
        def foo(self):
            pass
File:           ~/stuff/python/backups/foo.py
Type:           type

$ python3 foo.py
> /Users/karthikeyansingaravelan/stuff/python/backups/foo.py(13)<module>()
-> if __name__ == "__main__":
(Pdb) pdb.getsourcelines(Spam.Bar)
(['    class Bar:\n', '        def foo(self):\n', '            pass\n'], 2)
```

**With PR**

```
$ ./python.exe foo.py
    class Bar:
        def bar(self):
            pass

```

**Class decorator example**

```python
import inspect

def foo(cls):
    return cls

@foo
@foo
class Foo:
    pass

print(inspect.getsource(Foo))
```

**On master**

```
$ ./python.exe foo.py
class Foo:
    pass

```

**With PR**

```
$ ./python.exe foo.py
@foo
@foo
class Foo:
    pass
```

<!-- issue-number: [bpo-35113](https://bugs.python.org/issue35113) -->
https://bugs.python.org/issue35113
<!-- /issue-number -->
