### PR TITLE
bpo-21263: Skip test_gdb when python has been compiled with LLVM clang

### DIFF
--- a/Lib/test/test_gdb.py
+++ b/Lib/test/test_gdb.py
@@ -5,6 +5,7 @@
 
 import locale
 import os
+import platform
 import re
 import subprocess
 import sys
@@ -47,6 +48,10 @@ if gdb_major_version < 7:
 
 if not sysconfig.is_python_build():
     raise unittest.SkipTest("test_gdb only works on source builds at the moment.")
+
+if 'Clang' in platform.python_compiler() and sys.platform == 'darwin':
+    raise unittest.SkipTest("test_gdb doesn't work correctly when python is"
+                            " built with LLVM clang")
 
 # Location of custom hooks file in a repository checkout.
 checkout_hook_path = os.path.join(os.path.dirname(sys.executable),

--- a/Misc/ACKS
+++ b/Misc/ACKS
@@ -1147,6 +1147,7 @@ Samuel Nicolary
 Jonathan Niehof
 Gustavo Niemeyer
 Oscar Nierstrasz
+Lysandros Nikolaou
 Hrvoje Nikšić
 Gregory Nofi
 Jesse Noller

--- a/Misc/NEWS.d/next/Tests/2018-11-04-20-17-09.bpo-21263.T3qo9r.rst
+++ b/Misc/NEWS.d/next/Tests/2018-11-04-20-17-09.bpo-21263.T3qo9r.rst
@@ -1,0 +1,4 @@
+After several reports that test_gdb does not work properly on macOS and
+since gdb is not shipped by default anymore, test_gdb is now skipped on
+macOS when LLVM Clang has been used to compile Python. Patch by
+Lysandros Nikolaou


### PR DESCRIPTION
I have also added a new field in the test support module,  which enables one to find out which compiler was used to build Python.
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-21263](https://bugs.python.org/issue21263) -->
https://bugs.python.org/issue21263
<!-- /issue-number -->
