### PR TITLE
bpo-35161: Fix stack-use-after-scope in grp.getgr{nam,gid} and pwd.getpw{nam,uid}

### DIFF
--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -124,11 +124,11 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
         Py_DECREF(py_int_id);
     }
 #ifdef HAVE_GETGRGID_R
-    Py_BEGIN_ALLOW_THREADS
     int status;
     Py_ssize_t bufsize;
     struct group grp;
 
+    Py_BEGIN_ALLOW_THREADS
     bufsize = sysconf(_SC_GETGR_R_SIZE_MAX);
     if (bufsize == -1) {
         bufsize = DEFAULT_BUFFER_SIZE;
@@ -204,11 +204,11 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
     if (PyBytes_AsStringAndSize(bytes, &name_chars, NULL) == -1)
         goto out;
 #ifdef HAVE_GETGRNAM_R
-    Py_BEGIN_ALLOW_THREADS
     int status;
     Py_ssize_t bufsize;
     struct group grp;
 
+    Py_BEGIN_ALLOW_THREADS
     bufsize = sysconf(_SC_GETGR_R_SIZE_MAX);
     if (bufsize == -1) {
         bufsize = DEFAULT_BUFFER_SIZE;

--- a/Modules/grpmodule.c
+++ b/Modules/grpmodule.c
@@ -126,6 +126,7 @@ grp_getgrgid_impl(PyObject *module, PyObject *id)
 #ifdef HAVE_GETGRGID_R
     int status;
     Py_ssize_t bufsize;
+    /* Note: 'grp' will be used via pointer 'p' on getgrgid_r success. */
     struct group grp;
 
     Py_BEGIN_ALLOW_THREADS
@@ -206,6 +207,7 @@ grp_getgrnam_impl(PyObject *module, PyObject *name)
 #ifdef HAVE_GETGRNAM_R
     int status;
     Py_ssize_t bufsize;
+    /* Note: 'grp' will be used via pointer 'p' on getgrnam_r success. */
     struct group grp;
 
     Py_BEGIN_ALLOW_THREADS

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -131,11 +131,11 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
         return NULL;
     }
 #ifdef HAVE_GETPWUID_R
-    Py_BEGIN_ALLOW_THREADS
     int status;
     Py_ssize_t bufsize;
     struct passwd pwd;
 
+    Py_BEGIN_ALLOW_THREADS
     bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
     if (bufsize == -1) {
         bufsize = DEFAULT_BUFFER_SIZE;
@@ -212,11 +212,11 @@ pwd_getpwnam_impl(PyObject *module, PyObject *name)
     if (PyBytes_AsStringAndSize(bytes, &name_chars, NULL) == -1)
         goto out;
 #ifdef HAVE_GETPWNAM_R
-    Py_BEGIN_ALLOW_THREADS
     int status;
     Py_ssize_t bufsize;
     struct passwd pwd;
 
+    Py_BEGIN_ALLOW_THREADS
     bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
     if (bufsize == -1) {
         bufsize = DEFAULT_BUFFER_SIZE;

--- a/Modules/pwdmodule.c
+++ b/Modules/pwdmodule.c
@@ -133,6 +133,7 @@ pwd_getpwuid(PyObject *module, PyObject *uidobj)
 #ifdef HAVE_GETPWUID_R
     int status;
     Py_ssize_t bufsize;
+    /* Note: 'pwd' will be used via pointer 'p' on getpwuid_r success. */
     struct passwd pwd;
 
     Py_BEGIN_ALLOW_THREADS
@@ -214,6 +215,7 @@ pwd_getpwnam_impl(PyObject *module, PyObject *name)
 #ifdef HAVE_GETPWNAM_R
     int status;
     Py_ssize_t bufsize;
+    /* Note: 'pwd' will be used via pointer 'p' on getpwnam_r success. */
     struct passwd pwd;
 
     Py_BEGIN_ALLOW_THREADS


### PR DESCRIPTION
Reported by ASAN.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35161](https://bugs.python.org/issue35161) -->
https://bugs.python.org/issue35161
<!-- /issue-number -->
