### PR TITLE
bpo-24916: Change _PY_VERSION in sysconfig.py and py_version in install.py

### DIFF
--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -280,7 +280,14 @@ class install(Command):
         # $platbase in the other installation directories and not worry
         # about needing recursive variable expansion (shudder).
 
-        py_version = sys.version.split()[0]
+        releaselevel_serial = ''
+        if sys.version_info[3] == 'alpha' or sys.version_info[3] == 'beta':
+            releaselevel_serial = (sys.version_info[3][0]
+                                   + str(sys.version_info[4]))
+        elif sys.version_info[3] == 'release':
+            releaselevel_serial = 'rc' + str(sys.version_info[4])
+        py_version = '%d.%d.%d%s' % (*sys.version_info[:3],
+                                     releaselevel_serial)
         (prefix, exec_prefix) = get_config_vars('prefix', 'exec_prefix')
         try:
             abiflags = sys.abiflags

--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -3,6 +3,7 @@
 Implements the Distutils 'install' command."""
 
 import sys
+import sysconfig
 import os
 
 from distutils import log
@@ -280,14 +281,7 @@ class install(Command):
         # $platbase in the other installation directories and not worry
         # about needing recursive variable expansion (shudder).
 
-        releaselevel_serial = ''
-        if sys.version_info[3] == 'alpha' or sys.version_info[3] == 'beta':
-            releaselevel_serial = (sys.version_info[3][0]
-                                   + str(sys.version_info[4]))
-        elif sys.version_info[3] == 'release':
-            releaselevel_serial = 'rc' + str(sys.version_info[4])
-        py_version = '%d.%d.%d%s' % (*sys.version_info[:3],
-                                     releaselevel_serial)
+        py_version = sysconfig.get_full_python_version()
         (prefix, exec_prefix) = get_config_vars('prefix', 'exec_prefix')
         try:
             abiflags = sys.abiflags

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -84,9 +84,12 @@ _INSTALL_SCHEMES = {
 _SCHEME_KEYS = ('stdlib', 'platstdlib', 'purelib', 'platlib', 'include',
                 'scripts', 'data')
 
- # FIXME don't rely on sys.version here, its format is an implementation detail
- # of CPython, use sys.version_info or sys.hexversion
-_PY_VERSION = sys.version.split()[0]
+releaselevel_serial = ''
+if sys.version_info[3] == 'alpha' or sys.version_info[3] == 'beta':
+    releaselevel_serial = sys.version_info[3][0] + str(sys.version_info[4])
+elif sys.version_info[3] == 'release':
+    releaselevel_serial = 'rc' + str(sys.version_info[4])
+_PY_VERSION = '%d.%d.%d%s' % (*sys.version_info[:3], releaselevel_serial)
 _PY_VERSION_SHORT = '%d.%d' % sys.version_info[:2]
 _PY_VERSION_SHORT_NO_DOT = '%d%d' % sys.version_info[:2]
 _PREFIX = os.path.normpath(sys.prefix)

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -14,6 +14,7 @@ __all__ = [
     'get_paths',
     'get_platform',
     'get_python_version',
+    'get_full_python_version',
     'get_scheme_names',
     'parse_config_h',
 ]
@@ -85,7 +86,7 @@ _SCHEME_KEYS = ('stdlib', 'platstdlib', 'purelib', 'platlib', 'include',
                 'scripts', 'data')
 
 releaselevel_serial = ''
-if sys.version_info[3] == 'alpha' or sys.version_info[3] == 'beta':
+if sys.version_info[3] in ('alpha', 'beta'):
     releaselevel_serial = sys.version_info[3][0] + str(sys.version_info[4])
 elif sys.version_info[3] == 'release':
     releaselevel_serial = 'rc' + str(sys.version_info[4])
@@ -676,6 +677,10 @@ def get_platform():
 
 def get_python_version():
     return _PY_VERSION_SHORT
+
+
+def get_full_python_version():
+    return _PY_VERSION
 
 
 def _print_dict(title, data):


### PR DESCRIPTION
Both fields now get their values from sys.version_info and not sys.version, which is considered an implementation detail. 

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-24916](https://bugs.python.org/issue24916) -->
https://bugs.python.org/issue24916
<!-- /issue-number -->
