### PR TITLE
Add --tempdir option for test run

### DIFF
--- a/.azure-pipelines/windows-steps.yml
+++ b/.azure-pipelines/windows-steps.yml
@@ -17,7 +17,7 @@ steps:
 - script: python.bat -m test.pythoninfo
   displayName: 'Display build info'
 
-- script: PCbuild\rt.bat -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0 --junit-xml="$(Build.BinariesDirectory)\test-results.xml"
+- script: PCbuild\rt.bat -q -uall -u-cpu -rwW --slowest --timeout=1200 -j0 --junit-xml="$(Build.BinariesDirectory)\test-results.xml" --tempdir="$(Build.BinariesDirectory)\test"
   displayName: 'Tests'
   env:
     PREFIX: $(Py_OutDir)\$(arch)

--- a/Lib/test/libregrtest/cmdline.py
+++ b/Lib/test/libregrtest/cmdline.py
@@ -271,7 +271,8 @@ def _create_parser():
     group.add_argument('--junit-xml', dest='xmlpath', metavar='FILENAME',
                        help='writes JUnit-style XML results to the specified '
                             'file')
-
+    group.add_argument('--tempdir', dest='tempdir', metavar='PATH',
+                       help='override the working directory for the test run')
     return parser
 
 
@@ -383,8 +384,7 @@ def _parse_args(args, **kwargs):
     if ns.match_filename:
         if ns.match_tests is None:
             ns.match_tests = []
-        filename = os.path.join(support.SAVEDCWD, ns.match_filename)
-        with open(filename) as fp:
+        with open(ns.match_filename) as fp:
             for line in fp:
                 ns.match_tests.append(line.strip())
 

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -555,11 +555,7 @@ class Regrtest:
         if self.ns.tempdir:
             TEMPDIR = self.ns.tempdir
 
-        if not os.path.isdir(TEMPDIR):
-            try:
-                os.makedirs(TEMPDIR)
-            except FileExistsError:
-                pass
+        os.makedirs(TEMPDIR, exist_ok=True)
 
         # Define a writable temp dir that will be used as cwd while running
         # the tests. The name of the dir includes the pid to allow parallel

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -37,7 +37,7 @@ if sysconfig.is_python_build():
         TEMPDIR = sysconfig.get_config_var('srcdir')
     TEMPDIR = os.path.join(TEMPDIR, 'build')
 else:
-    TEMPDIR = os.getenv('PY_TEMPDIR', None) or tempfile.gettempdir()
+    TEMPDIR = tempfile.gettempdir()
 TEMPDIR = os.path.abspath(TEMPDIR)
 
 

--- a/Lib/test/libregrtest/main.py
+++ b/Lib/test/libregrtest/main.py
@@ -37,7 +37,7 @@ if sysconfig.is_python_build():
         TEMPDIR = sysconfig.get_config_var('srcdir')
     TEMPDIR = os.path.join(TEMPDIR, 'build')
 else:
-    TEMPDIR = tempfile.gettempdir()
+    TEMPDIR = os.getenv('PY_TEMPDIR', None) or tempfile.gettempdir()
 TEMPDIR = os.path.abspath(TEMPDIR)
 
 
@@ -550,10 +550,14 @@ class Regrtest:
 
     def main(self, tests=None, **kwargs):
         global TEMPDIR
+        self.ns = self.parse_args(kwargs)
 
-        if sysconfig.is_python_build():
+        if self.ns.tempdir:
+            TEMPDIR = self.ns.tempdir
+
+        if not os.path.isdir(TEMPDIR):
             try:
-                os.mkdir(TEMPDIR)
+                os.makedirs(TEMPDIR)
             except FileExistsError:
                 pass
 
@@ -571,8 +575,6 @@ class Regrtest:
             self._main(tests, kwargs)
 
     def _main(self, tests, kwargs):
-        self.ns = self.parse_args(kwargs)
-
         if self.ns.huntrleaks:
             warmup, repetitions, _ = self.ns.huntrleaks
             if warmup < 1 or repetitions < 1:


### PR DESCRIPTION
This allows changing particularly the drive where tests are run, which can help ensure that the best performance and sometimes features like symlinks are available.

I've only updated it from the default for the Window build on Azure Pipelines, as that is known to have slower performance on the C: drive compared to the work drive.