### PR TITLE
bpo-35119: Fix RecursionError in example of customizing module attribute access.

### DIFF
--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1580,7 +1580,7 @@ a module object to a subclass of :class:`types.ModuleType`. For example::
 
        def __setattr__(self, attr, value):
            print(f'Setting {attr}...')
-           super().__setattr__(self, attr, value)
+           super().__setattr__(attr, value)
 
    sys.modules[__name__].__class__ = VerboseModule
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1580,7 +1580,7 @@ a module object to a subclass of :class:`types.ModuleType`. For example::
 
        def __setattr__(self, attr, value):
            print(f'Setting {attr}...')
-           super().setattr(self, attr, value)
+           super().__setattr__(self, attr, value)
 
    sys.modules[__name__].__class__ = VerboseModule
 

--- a/Doc/reference/datamodel.rst
+++ b/Doc/reference/datamodel.rst
@@ -1580,7 +1580,7 @@ a module object to a subclass of :class:`types.ModuleType`. For example::
 
        def __setattr__(self, attr, value):
            print(f'Setting {attr}...')
-           setattr(self, attr, value)
+           super().setattr(self, attr, value)
 
    sys.modules[__name__].__class__ = VerboseModule
 


### PR DESCRIPTION


<!-- issue-number: [bpo-35119](https://bugs.python.org/issue35119) -->
https://bugs.python.org/issue35119
<!-- /issue-number -->
