### PR TITLE
bpo-35167: Specify program for gzip and json.tool command line options.

### DIFF
--- a/Doc/library/gzip.rst
+++ b/Doc/library/gzip.rst
@@ -211,6 +211,9 @@ Example of how to GZIP compress a binary string::
       The basic data compression module needed to support the :program:`gzip` file
       format.
 
+
+.. program:: gzip
+
 Command Line Interface
 ----------------------
 

--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -648,7 +648,9 @@ when serializing Python :class:`int` values of extremely large magnitude, or
 when serializing instances of "exotic" numerical types such as
 :class:`decimal.Decimal`.
 
+
 .. _json-commandline:
+.. program:: json.tool
 
 Command Line Interface
 ----------------------
@@ -679,6 +681,7 @@ specified, :attr:`sys.stdin` and :attr:`sys.stdout` will be used respectively:
    The output is now in the same order as the input. Use the
    :option:`--sort-keys` option to sort the output of dictionaries
    alphabetically by key.
+
 
 Command line options
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION


<!-- issue-number: [bpo-35167](https://bugs.python.org/issue35167) -->
https://bugs.python.org/issue35167
<!-- /issue-number -->
