### PR TITLE
[2.7] bpo-35133: Fix mistakes when concatenate string literals on different lines. (GH-10284) (GH-10335)

### DIFF
--- a/Lib/decimal.py
+++ b/Lib/decimal.py
@@ -1909,7 +1909,7 @@ class Decimal(object):
         if not other and not self:
             return context._raise_error(InvalidOperation,
                                         'at least one of pow() 1st argument '
-                                        'and 2nd argument must be nonzero ;'
+                                        'and 2nd argument must be nonzero; '
                                         '0**0 is not defined')
 
         # compute sign of result

--- a/Lib/distutils/command/bdist_dumb.py
+++ b/Lib/distutils/command/bdist_dumb.py
@@ -35,7 +35,7 @@ class bdist_dumb (Command):
                     ('skip-build', None,
                      "skip rebuilding everything (for testing/debugging)"),
                     ('relative', None,
-                     "build the archive using relative paths"
+                     "build the archive using relative paths "
                      "(default: false)"),
                     ('owner=', 'u',
                      "Owner name used when creating a tar file"

--- a/Lib/distutils/command/bdist_msi.py
+++ b/Lib/distutils/command/bdist_msi.py
@@ -99,14 +99,14 @@ class bdist_msi (Command):
                     ('no-target-compile', 'c',
                      "do not compile .py to .pyc on the target system"),
                     ('no-target-optimize', 'o',
-                     "do not compile .py to .pyo (optimized)"
+                     "do not compile .py to .pyo (optimized) "
                      "on the target system"),
                     ('dist-dir=', 'd',
                      "directory to put final built distributions in"),
                     ('skip-build', None,
                      "skip rebuilding everything (for testing/debugging)"),
                     ('install-script=', None,
-                     "basename of installation script to be run after"
+                     "basename of installation script to be run after "
                      "installation or before deinstallation"),
                     ('pre-install-script=', None,
                      "Fully qualified filename of a script to be run before "

--- a/Lib/distutils/command/bdist_rpm.py
+++ b/Lib/distutils/command/bdist_rpm.py
@@ -63,7 +63,7 @@ class bdist_rpm (Command):
          "RPM \"vendor\" (eg. \"Joe Blow <joe@example.com>\") "
          "[default: maintainer or author from setup script]"),
         ('packager=', None,
-         "RPM packager (eg. \"Jane Doe <jane@example.net>\")"
+         "RPM packager (eg. \"Jane Doe <jane@example.net>\") "
          "[default: vendor]"),
         ('doc-files=', None,
          "list of documentation files (space or comma-separated)"),

--- a/Lib/distutils/command/bdist_wininst.py
+++ b/Lib/distutils/command/bdist_wininst.py
@@ -35,7 +35,7 @@ class bdist_wininst (Command):
                     ('no-target-compile', 'c',
                      "do not compile .py to .pyc on the target system"),
                     ('no-target-optimize', 'o',
-                     "do not compile .py to .pyo (optimized)"
+                     "do not compile .py to .pyo (optimized) "
                      "on the target system"),
                     ('dist-dir=', 'd',
                      "directory to put final built distributions in"),
@@ -46,7 +46,7 @@ class bdist_wininst (Command):
                     ('skip-build', None,
                      "skip rebuilding everything (for testing/debugging)"),
                     ('install-script=', None,
-                     "basename of installation script to be run after"
+                     "basename of installation script to be run after "
                      "installation or before deinstallation"),
                     ('pre-install-script=', None,
                      "Fully qualified filename of a script to be run before "

--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -366,7 +366,7 @@ class build_ext (Command):
             ext_name, build_info = ext
 
             log.warn(("old-style (ext_name, build_info) tuple found in "
-                      "ext_modules for extension '%s'"
+                      "ext_modules for extension '%s' "
                       "-- please convert to Extension instance" % ext_name))
 
             if not (isinstance(ext_name, str) and

--- a/Lib/idlelib/HyperParser.py
+++ b/Lib/idlelib/HyperParser.py
@@ -167,7 +167,7 @@ class HyperParser:
         given index, which is empty if there is no real one.
         """
         if not self.is_in_code():
-            raise ValueError("get_expression should only be called"
+            raise ValueError("get_expression should only be called "
                              "if index is inside a code.")
 
         rawtext = self.rawtext

--- a/Lib/idlelib/idle_test/htest.py
+++ b/Lib/idlelib/idle_test/htest.py
@@ -112,7 +112,7 @@ ConfigDialog_spec = {
            "font face of the text in the area below it.\nIn the "
            "'Highlighting' tab, try different color schemes. Clicking "
            "items in the sample program should update the choices above it."
-           "\nIn the 'Keys', 'General' and 'Extensions' tabs, test settings"
+           "\nIn the 'Keys', 'General' and 'Extensions' tabs, test settings "
            "of interest."
            "\n[Ok] to close the dialog.[Apply] to apply the settings and "
            "and [Cancel] to revert all changes.\nRe-run the test to ensure "
@@ -171,7 +171,7 @@ GetKeysDialog_spec = {
     'msg': "Test for different key modifier sequences.\n"
            "<nothing> is invalid.\n"
            "No modifier key is invalid.\n"
-           "Shift key with [a-z],[0-9], function key, move key, tab, space"
+           "Shift key with [a-z],[0-9], function key, move key, tab, space "
            "is invalid.\nNo validitity checking if advanced key binding "
            "entry is used."
     }
@@ -237,7 +237,7 @@ _percolator_spec = {
     'file': 'Percolator',
     'kwds': {},
     'msg': "There are two tracers which can be toggled using a checkbox.\n"
-           "Toggling a tracer 'on' by checking it should print tracer"
+           "Toggling a tracer 'on' by checking it should print tracer "
            "output to the console or to the IDLE shell.\n"
            "If both the tracers are 'on', the output from the tracer which "
            "was switched 'on' later, should be printed first\n"
@@ -329,7 +329,7 @@ _undo_delegator_spec = {
 _widget_redirector_spec = {
     'file': 'WidgetRedirector',
     'kwds': {},
-    'msg': "Every text insert should be printed to the console."
+    'msg': "Every text insert should be printed to the console "
            "or the IDLE shell."
     }
 

--- a/Lib/idlelib/idle_test/mock_tk.py
+++ b/Lib/idlelib/idle_test/mock_tk.py
@@ -260,7 +260,7 @@ class Text(object):
         elif op == '!=':
             return line1 != line2 or  char1 != char2
         else:
-            raise TclError('''bad comparison operator "%s":'''
+            raise TclError('''bad comparison operator "%s": '''
                                   '''must be <, <=, ==, >=, >, or !=''' % op)
 
     # The following Text methods normally do something and return None.

--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -392,7 +392,7 @@ if 1:
             'from sys import stdin)',
             'from sys import stdin, stdout,\nstderr',
             'from sys import stdin si',
-            'from sys import stdin,'
+            'from sys import stdin,',
             'from sys import (*)',
             'from sys import (stdin,, stdout, stderr)',
             'from sys import (stdin, stdout),',

--- a/Lib/test/test_decimal.py
+++ b/Lib/test/test_decimal.py
@@ -914,10 +914,10 @@ class DecimalFormatTest(unittest.TestCase):
         decimal_point = locale.localeconv()['decimal_point']
         thousands_sep = locale.localeconv()['thousands_sep']
         if decimal_point != '\xd9\xab':
-            self.skipTest('inappropriate decimal point separator'
+            self.skipTest('inappropriate decimal point separator '
                           '({!r} not {!r})'.format(decimal_point, '\xd9\xab'))
         if thousands_sep != '\xd9\xac':
-            self.skipTest('inappropriate thousands separator'
+            self.skipTest('inappropriate thousands separator '
                           '({!r} not {!r})'.format(thousands_sep, '\xd9\xac'))
 
         self.assertEqual(format(Decimal('100000000.123'), 'n'),

--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -428,7 +428,7 @@ class CalculationTests(unittest.TestCase):
         self.assertTrue(result.tm_year == self.time_tuple.tm_year and
                          result.tm_mon == self.time_tuple.tm_mon and
                          result.tm_mday == self.time_tuple.tm_mday,
-                        "Calculation of Gregorian date failed;"
+                        "Calculation of Gregorian date failed; "
                          "%s-%s-%s != %s-%s-%s" %
                          (result.tm_year, result.tm_mon, result.tm_mday,
                           self.time_tuple.tm_year, self.time_tuple.tm_mon,
@@ -440,7 +440,7 @@ class CalculationTests(unittest.TestCase):
         result = _strptime._strptime_time(time.strftime(format_string, self.time_tuple),
                                     format_string)
         self.assertTrue(result.tm_wday == self.time_tuple.tm_wday,
-                        "Calculation of day of the week failed;"
+                        "Calculation of day of the week failed; "
                          "%s != %s" % (result.tm_wday, self.time_tuple.tm_wday))
 
     def test_week_of_year_and_day_of_week_calculation(self):

--- a/Lib/trace.py
+++ b/Lib/trace.py
@@ -360,7 +360,7 @@ class CoverageResults:
         try:
             outfile = open(path, "w")
         except IOError, err:
-            print >> sys.stderr, ("trace: Could not open %r for writing: %s"
+            print >> sys.stderr, ("trace: Could not open %r for writing: %s "
                                   "- skipping" % (path, err))
             return 0, 0
 

--- a/Python/import.c
+++ b/Python/import.c
@@ -701,7 +701,7 @@ remove_module(const char *name)
     if (PyDict_GetItemString(modules, name) == NULL)
         return;
     if (PyDict_DelItemString(modules, name) < 0)
-        Py_FatalError("import:  deleting existing key in"
+        Py_FatalError("import:  deleting existing key in "
                       "sys.modules failed");
 }
 

--- a/Tools/scripts/texi2html.py
+++ b/Tools/scripts/texi2html.py
@@ -1808,7 +1808,7 @@ class HTMLHelp:
             print>>fp, '<!-- This file defines the table of contents -->'
             print>>fp, '<HTML>'
             print>>fp, '<HEAD>'
-            print>>fp, ('<meta name="GENERATOR"'
+            print>>fp, ('<meta name="GENERATOR" '
                         'content="Microsoft&reg; HTML Help Workshop 4.1">')
             print>>fp, '<!-- Sitemap 1.0 -->'
             print>>fp, '</HEAD>'
@@ -1833,7 +1833,7 @@ class HTMLHelp:
             print>>fp, '<!-- This file defines the index -->'
             print>>fp, '<HTML>'
             print>>fp, '<HEAD>'
-            print>>fp, ('<meta name="GENERATOR"'
+            print>>fp, ('<meta name="GENERATOR" '
                         'content="Microsoft&reg; HTML Help Workshop 4.1">')
             print>>fp, '<!-- Sitemap 1.0 -->'
             print>>fp, '</HEAD>'


### PR DESCRIPTION
Two kind of mistakes:

1. Missed space. After concatenating there is no space between words.

2. Missed comma. Causes unintentional concatenating in a list of strings.

(cherry picked from commit 34fd4c20198dea6ab2fe8dc6d32d744d9bde868d).
(cherry picked from commit 7054e5c80b6e98cd44e22d1bc2d7f0a94343089d)


<!-- issue-number: [bpo-35133](https://bugs.python.org/issue35133) -->
https://bugs.python.org/issue35133
<!-- /issue-number -->
