### PR TITLE
[3.7] bpo-35167: Specify program for json.tool command line options. (GH-10332)

### DIFF
--- a/Doc/library/json.rst
+++ b/Doc/library/json.rst
@@ -648,7 +648,9 @@ when serializing Python :class:`int` values of extremely large magnitude, or
 when serializing instances of "exotic" numerical types such as
 :class:`decimal.Decimal`.
 
+
 .. _json-commandline:
+.. program:: json.tool
 
 Command Line Interface
 ----------------------
@@ -679,6 +681,7 @@ specified, :attr:`sys.stdin` and :attr:`sys.stdout` will be used respectively:
    The output is now in the same order as the input. Use the
    :option:`--sort-keys` option to sort the output of dictionaries
    alphabetically by key.
+
 
 Command line options
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
(cherry picked from commit 083a7a172b8c8888252d72031f21dcfea3c0d73f)


<!-- issue-number: [bpo-35167](https://bugs.python.org/issue35167) -->
https://bugs.python.org/issue35167
<!-- /issue-number -->
