### PR TITLE
bpo-35125: remove inner callback on outer cancellation in asyncio shield

### DIFF
--- a/Lib/asyncio/tasks.py
+++ b/Lib/asyncio/tasks.py
@@ -816,7 +816,7 @@ def shield(arg, *, loop=None):
     loop = futures._get_loop(inner)
     outer = loop.create_future()
 
-    def _done_callback(inner):
+    def _inner_done_callback(inner):
         if outer.cancelled():
             if not inner.cancelled():
                 # Mark inner's result as retrieved.
@@ -832,7 +832,13 @@ def shield(arg, *, loop=None):
             else:
                 outer.set_result(inner.result())
 
-    inner.add_done_callback(_done_callback)
+
+    def _outer_done_callback(outer):
+        if not inner.done():
+            inner.remove_done_callback(_inner_done_callback)
+
+    inner.add_done_callback(_inner_done_callback)
+    outer.add_done_callback(_outer_done_callback)
     return outer
 
 

--- a/Lib/test/test_asyncio/test_tasks.py
+++ b/Lib/test/test_asyncio/test_tasks.py
@@ -1768,13 +1768,22 @@ class BaseTaskTests:
         test_utils.run_briefly(self.loop)
         self.assertIs(outer.exception(), exc)
 
-    def test_shield_cancel(self):
+    def test_shield_cancel_inner(self):
         inner = self.new_future(self.loop)
         outer = asyncio.shield(inner)
         test_utils.run_briefly(self.loop)
         inner.cancel()
         test_utils.run_briefly(self.loop)
         self.assertTrue(outer.cancelled())
+
+    def test_shield_cancel_outer(self):
+        inner = self.new_future(self.loop)
+        outer = asyncio.shield(inner)
+        test_utils.run_briefly(self.loop)
+        outer.cancel()
+        test_utils.run_briefly(self.loop)
+        self.assertTrue(outer.cancelled())
+        self.assertEqual(0, 0 if outer._callbacks is None else len(outer._callbacks))
 
     def test_shield_shortcut(self):
         fut = self.new_future(self.loop)

--- a/Misc/NEWS.d/next/Library/2019-02-15-17-18-50.bpo-35125.h0xk0f.rst
+++ b/Misc/NEWS.d/next/Library/2019-02-15-17-18-50.bpo-35125.h0xk0f.rst
@@ -1,0 +1,1 @@
+Asyncio: Remove inner callback on outer cancellation in shield


### PR DESCRIPTION
When the future returned by shield is cancelled, its completion callback of the
inner future is not removed. This makes the callback list of inner inner future
grow each time a shield is created and cancelled.

This change unregisters the callback from the inner future when the outer
future is cancelled.


<!-- issue-number: [bpo-35125](https://bugs.python.org/issue35125) -->
https://bugs.python.org/issue35125
<!-- /issue-number -->
