### PR TITLE
bpo-35178: Pass positional arguments to formatwarning().

### DIFF
--- a/Lib/warnings.py
+++ b/Lib/warnings.py
@@ -113,7 +113,7 @@ def _formatwarnmsg(msg):
         if fw is not _formatwarning_orig:
             # warnings.formatwarning() was replaced
             return fw(msg.message, msg.category,
-                      msg.filename, msg.lineno, line=msg.line)
+                      msg.filename, msg.lineno, msg.line)
     return _formatwarnmsg_impl(msg)
 
 def filterwarnings(action, message="", category=Warning, module="", lineno=0,


### PR DESCRIPTION
The last argument should be `msg.line`. Having `line=msg.line` generates an error message:
`got an unexpected keyword arugument line=msg.line`

Compare with Ln 99, the discrepancy should be apparent.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35178](https://bugs.python.org/issue35178) -->
https://bugs.python.org/issue35178
<!-- /issue-number -->
