### PR TITLE
[3.7] Doc: Disable smartquotes for zh-tw, zh-cn, fr and ja translations (GH-9423)

### DIFF
--- a/Doc/conf.py
+++ b/Doc/conf.py
@@ -34,12 +34,17 @@ today_fmt = '%B %d, %Y'
 # By default, highlight as Python 3.
 highlight_language = 'python3'
 
-# Require Sphinx 1.2 for build.
-needs_sphinx = '1.2'
+# Require Sphinx 1.7 for build.
+needs_sphinx = '1.7'
 
 # Ignore any .rst files in the venv/ directory.
 venvdir = os.getenv('VENVDIR', 'venv')
 exclude_patterns = [venvdir+'/*', 'README.rst']
+
+# Disable Docutils smartquotes for several translations
+smartquotes_excludes = {
+    'languages': ['ja', 'fr', 'zh_TW', 'zh_CN'], 'builders': ['man', 'text'],
+}
 
 
 # Options for HTML output

--- a/Doc/docutils.conf
+++ b/Doc/docutils.conf
@@ -1,2 +1,0 @@
-[restructuredtext parser]
-smartquotes-locales: ja: ""''


### PR DESCRIPTION
(cherry picked from commit c03bf0ae794c3bec9b56f38164535fd1f5bfc04a)
