### PR TITLE
bpo-35171: Fix test_TimeRE_recreation_timezone failure on some systems

### DIFF
--- a/Lib/test/test_strptime.py
+++ b/Lib/test/test_strptime.py
@@ -692,7 +692,7 @@ class CacheTests(unittest.TestCase):
         finally:
             locale.setlocale(locale.LC_TIME, locale_info)
 
-    @support.run_with_tz('STD-1DST')
+    @support.run_with_tz('STD-1DST,M4.1.0,M10.1.0')
     def test_TimeRE_recreation_timezone(self):
         # The TimeRE instance should be recreated upon changing the timezone.
         oldtzname = time.tzname


### PR DESCRIPTION
The test depended on '/usr/share/zoneinfo/posixrules' or equivalent
because it set TZ without explicit DST transition rules. At least
on OpenSUSE Tumbleweed that file is linked to '/etc/localtime',
making the test fail with certain local timezones,
such as 'Europe/Moscow' which doesn't have DST transitions since 2011.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35171](https://bugs.python.org/issue35171) -->
https://bugs.python.org/issue35171
<!-- /issue-number -->
