### PR TITLE
bpo-22276: Fix pathlib.Path.glob not to ignore trailing path separator

### DIFF
--- a/Doc/library/pathlib.rst
+++ b/Doc/library/pathlib.rst
@@ -815,6 +815,9 @@ call fails (for example because the path doesn't exist).
 
    .. audit-event:: pathlib.Path.glob self,pattern pathlib.Path.glob
 
+   .. versionchanged:: 3.11
+      Return only directories if *pattern* ends with a pathname components
+      separator (:data:`~os.sep` or :data:`~os.altsep`).
 
 .. method:: Path.group()
 
@@ -1104,6 +1107,9 @@ call fails (for example because the path doesn't exist).
 
    .. audit-event:: pathlib.Path.rglob self,pattern pathlib.Path.rglob
 
+   .. versionchanged:: 3.11
+      Return only directories if *pattern* ends with a pathname components
+      separator (:data:`~os.sep` or :data:`~os.altsep`).
 
 .. method:: Path.rmdir()
 

--- a/Doc/whatsnew/3.11.rst
+++ b/Doc/whatsnew/3.11.rst
@@ -506,6 +506,15 @@ os
   instead of ``CryptGenRandom()`` which is deprecated.
   (Contributed by Dong-hee Na in :issue:`44611`.)
 
+
+pathlib
+-------
+
+* :meth:`~pathlib.Path.glob` and :meth:`~pathlib.Path.rglob` return only
+  directories if *pattern* ends with a pathname components separator:
+  :data:`~os.sep` or :data:`~os.altsep`.
+  (Contributed by Eisuke Kawasima in :issue:`22276` and :issue:`33392`.)
+
 re
 --
 

--- a/Lib/pathlib.py
+++ b/Lib/pathlib.py
@@ -281,6 +281,8 @@ _posix_flavour = _PosixFlavour()
 def _make_selector(pattern_parts, flavour):
     pat = pattern_parts[0]
     child_parts = pattern_parts[1:]
+    if not pat:
+        return _TerminatingSelector()
     if pat == '**':
         cls = _RecursiveWildcardSelector
     elif '**' in pat:
@@ -943,6 +945,8 @@ class Path(PurePath):
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
         if drv or root:
             raise NotImplementedError("Non-relative patterns are unsupported")
+        if pattern[-1] in (self._flavour.sep, self._flavour.altsep):
+            pattern_parts.append('')
         selector = _make_selector(tuple(pattern_parts), self._flavour)
         for p in selector.select_from(self):
             yield p
@@ -956,6 +960,8 @@ class Path(PurePath):
         drv, root, pattern_parts = self._flavour.parse_parts((pattern,))
         if drv or root:
             raise NotImplementedError("Non-relative patterns are unsupported")
+        if pattern[-1] in (self._flavour.sep, self._flavour.altsep):
+            pattern_parts.append('')
         selector = _make_selector(("**",) + tuple(pattern_parts), self._flavour)
         for p in selector.select_from(self):
             yield p

--- a/Lib/test/test_pathlib.py
+++ b/Lib/test/test_pathlib.py
@@ -1662,6 +1662,11 @@ class _BasePathTest(object):
         else:
             _check(p.glob("*/fileB"), ['dirB/fileB', 'linkB/fileB'])
 
+        if not os_helper.can_symlink():
+            _check(p.glob("*/"), ["dirA", "dirB", "dirC", "dirE"])
+        else:
+            _check(p.glob("*/"), ["dirA", "dirB", "dirC", "dirE", "linkB"])
+
     def test_rglob_common(self):
         def _check(glob, expected):
             self.assertEqual(set(glob), { P(BASE, q) for q in expected })
@@ -1679,6 +1684,16 @@ class _BasePathTest(object):
                                         "linkB/fileB", "dirA/linkC/fileB"])
         _check(p.rglob("file*"), ["fileA", "dirB/fileB",
                                   "dirC/fileC", "dirC/dirD/fileD"])
+        if not os_helper.can_symlink():
+            _check(p.rglob("*/"), [
+                "dirA", "dirB", "dirC", "dirC/dirD", "dirE",
+            ])
+        else:
+            _check(p.rglob("*/"), [
+                "dirA", "dirA/linkC", "dirB", "dirB/linkD", "dirC",
+                "dirC/dirD", "dirE", "linkB",
+            ])
+
         p = P(BASE, "dirC")
         _check(p.rglob("file*"), ["dirC/fileC", "dirC/dirD/fileD"])
         _check(p.rglob("*/*"), ["dirC/dirD/fileD"])
@@ -2704,6 +2719,7 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
         P = self.cls
         p = P(BASE)
         self.assertEqual(set(p.glob("FILEa")), { P(BASE, "fileA") })
+        self.assertEqual(set(p.glob("*a\\")), { P(BASE, "dirA") })
         self.assertEqual(set(p.glob("F*a")), { P(BASE, "fileA") })
         self.assertEqual(set(map(str, p.glob("FILEa"))), {f"{p}\\FILEa"})
         self.assertEqual(set(map(str, p.glob("F*a"))), {f"{p}\\fileA"})
@@ -2712,6 +2728,7 @@ class WindowsPathTest(_BasePathTest, unittest.TestCase):
         P = self.cls
         p = P(BASE, "dirC")
         self.assertEqual(set(p.rglob("FILEd")), { P(BASE, "dirC/dirD/fileD") })
+        self.assertEqual(set(p.rglob("*\\")), { P(BASE, "dirC/dirD") })
         self.assertEqual(set(map(str, p.rglob("FILEd"))), {f"{p}\\dirD\\FILEd"})
 
     def test_expanduser(self):

--- a/Misc/NEWS.d/next/Library/2018-11-11-04-41-11.bpo-22276.Tt19TW.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-11-04-41-11.bpo-22276.Tt19TW.rst
@@ -1,0 +1,4 @@
+:meth:`~pathlib.Path.glob` and :meth:`~pathlib.Path.rglob` return only
+directories if *pattern* ends with a pathname components separator
+(``/`` or :data:`~os.sep`).
+Patch by Eisuke Kawashima.

--- a/Misc/NEWS.d/next/Library/2018-11-11-04-41-11.bpo-22276.Tt19TW.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-11-04-41-11.bpo-22276.Tt19TW.rst
@@ -1,4 +1,4 @@
-:meth:`~pathlib.Path.glob` and :meth:`~pathlib.Path.rglob` return only
+:class:`~pathlib.Path` methods :meth:`~pathlib.Path.glob` and :meth:`~pathlib.Path.rglob` return only
 directories if *pattern* ends with a pathname components separator
 (``/`` or :data:`~os.sep`).
 Patch by Eisuke Kawashima.


### PR DESCRIPTION
See also [Issue 33392: pathlib .glob('*/') returns files as well as directories](https://bugs.python.org/issue33392), closed as duplicate of 22276.

At present `pathlib.Path.glob` returns directories and **FILES** even if glob pattern ends with the path separator (`/` in Linux), while `glob.glob` works as expected.
This PR fixes the behaviour.

```shellsession
$ uname -s
Linux
$ mkdir /tmp/test-glob
$ cd /tmp/test-glob
$ mkdir dir
$ touch file
$ echo *  # shell glob
dir file
$ echo */
dir/
```

```python
>>> from glob import glob
>>> glob("*")
['file', 'dir']
>>> glob("*/")
['dir/']
>>> 
>>> from pathlib import Path
>>> list(Path(".").glob("*"))
[PosixPath('file'), PosixPath('dir')]
>>> list(Path(".").glob("*/"))
[PosixPath('file'), PosixPath('dir')]
```

<!-- issue-number: [bpo-22276](https://bugs.python.org/issue22276) -->
https://bugs.python.org/issue22276
<!-- /issue-number -->
