### PR TITLE
bpo-35015: Doc: Fix internationalisation of the availability directive.

### DIFF
--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -150,6 +150,7 @@ class Availability(Directive):
         pnode.extend(n + m)
         return [pnode]
 
+
 # Support for documenting decorators
 
 class PyDecoratorMixin(object):

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -141,7 +141,10 @@ class Availability(Directive):
     final_argument_whitespace = True
 
     def run(self):
-        pnode = nodes.paragraph(classes=['availability'])
+        pnode = nodes.paragraph(
+            ':ref:`Availability <availability>`: ' + self.arguments[0],
+            classes=["availability"],
+        )
         n, m = self.state.inline_text(':ref:`Availability <availability>`: ',
                                       self.lineno)
         pnode.extend(n + m)

--- a/Doc/tools/extensions/pyspecific.py
+++ b/Doc/tools/extensions/pyspecific.py
@@ -141,17 +141,14 @@ class Availability(Directive):
     final_argument_whitespace = True
 
     def run(self):
-        pnode = nodes.paragraph(
-            ':ref:`Availability <availability>`: ' + self.arguments[0],
-            classes=["availability"],
-        )
-        n, m = self.state.inline_text(':ref:`Availability <availability>`: ',
-                                      self.lineno)
+        availability_ref = ':ref:`Availability <availability>`: '
+        pnode = nodes.paragraph(availability_ref + self.arguments[0],
+                                classes=["availability"],)
+        n, m = self.state.inline_text(availability_ref, self.lineno)
         pnode.extend(n + m)
         n, m = self.state.inline_text(self.arguments[0], self.lineno)
         pnode.extend(n + m)
         return [pnode]
-
 
 # Support for documenting decorators
 


### PR DESCRIPTION
I don't really understand why we have to give the content twice (once as a parameter of the node, and once as child of the node) but that's what's the `BaseAdmonition` directive does: 

Add it first as a text parameter of the node:

    admonition_node = self.node_class(text, **self.options)

then add the content as child of the node:
    self.state.nested_parse(self.content, self.content_offset,
                            admonition_node)

so I did the same and it works.

https://bugs.python.org/issue35015

<!-- issue-number: [bpo-35015](https://bugs.python.org/issue35015) -->
https://bugs.python.org/issue35015
<!-- /issue-number -->
