### PR TITLE
bpo-35081: Internal headers require Py_BUILD_CORE

### DIFF
--- a/Include/internal/pycore_accu.h
+++ b/Include/internal/pycore_accu.h
@@ -9,6 +9,10 @@ extern "C" {
  *** Its definition may be changed or removed at any moment.
  ***/
 
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
+
 /*
  * A two-level accumulator of unicode objects that avoids both the overhead
  * of keeping a huge number of small separate objects, and the quadratic

--- a/Include/internal/pycore_atomic.h
+++ b/Include/internal/pycore_atomic.h
@@ -4,8 +4,8 @@
 extern "C" {
 #endif
 
-#ifndef Py_BUILD_CORE
-#  error "Py_BUILD_CORE must be defined to include this header"
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
 #endif
 
 #include "dynamic_annotations.h"

--- a/Include/internal/pycore_ceval.h
+++ b/Include/internal/pycore_ceval.h
@@ -4,6 +4,10 @@
 extern "C" {
 #endif
 
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
+
 #include "pycore_atomic.h"
 #include "pythread.h"
 

--- a/Include/internal/pycore_condvar.h
+++ b/Include/internal/pycore_condvar.h
@@ -1,6 +1,10 @@
 #ifndef Py_INTERNAL_CONDVAR_H
 #define Py_INTERNAL_CONDVAR_H
 
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
+
 #ifndef _POSIX_THREADS
 /* This means pthreads are not implemented in libc headers, hence the macro
    not present in unistd.h. But they still can be implemented as an external

--- a/Include/internal/pycore_context.h
+++ b/Include/internal/pycore_context.h
@@ -1,9 +1,11 @@
 #ifndef Py_INTERNAL_CONTEXT_H
 #define Py_INTERNAL_CONTEXT_H
 
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
 
 #include "pycore_hamt.h"
-
 
 struct _pycontextobject {
     PyObject_HEAD
@@ -36,6 +38,5 @@ struct _pycontexttokenobject {
 
 int _PyContext_Init(void);
 void _PyContext_Fini(void);
-
 
 #endif /* !Py_INTERNAL_CONTEXT_H */

--- a/Include/internal/pycore_getopt.h
+++ b/Include/internal/pycore_getopt.h
@@ -1,6 +1,10 @@
 #ifndef Py_INTERNAL_PYGETOPT_H
 #define Py_INTERNAL_PYGETOPT_H
 
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
+
 extern int _PyOS_opterr;
 extern int _PyOS_optind;
 extern wchar_t *_PyOS_optarg;

--- a/Include/internal/pycore_gil.h
+++ b/Include/internal/pycore_gil.h
@@ -4,6 +4,10 @@
 extern "C" {
 #endif
 
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
+
 #include "pycore_condvar.h"
 #include "pycore_atomic.h"
 

--- a/Include/internal/pycore_hamt.h
+++ b/Include/internal/pycore_hamt.h
@@ -1,6 +1,9 @@
 #ifndef Py_INTERNAL_HAMT_H
 #define Py_INTERNAL_HAMT_H
 
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
 
 #define _Py_HAMT_MAX_TREE_DEPTH 7
 

--- a/Include/internal/pycore_hash.h
+++ b/Include/internal/pycore_hash.h
@@ -1,6 +1,10 @@
 #ifndef Py_INTERNAL_HASH_H
 #define Py_INTERNAL_HASH_H
 
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
+
 uint64_t _Py_KeyedHash(uint64_t, const char *, Py_ssize_t);
 
 #endif

--- a/Include/internal/pycore_lifecycle.h
+++ b/Include/internal/pycore_lifecycle.h
@@ -4,8 +4,8 @@
 extern "C" {
 #endif
 
-#ifndef Py_BUILD_CORE
-#  error "Py_BUILD_CORE must be defined to include this header"
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
 #endif
 
 PyAPI_FUNC(int) _Py_UnixMain(int argc, char **argv);

--- a/Include/internal/pycore_mem.h
+++ b/Include/internal/pycore_mem.h
@@ -4,8 +4,8 @@
 extern "C" {
 #endif
 
-#ifndef Py_BUILD_CORE
-#  error "Py_BUILD_CORE must be defined to include this header"
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN defined"
 #endif
 
 #include "objimpl.h"

--- a/Include/internal/pycore_pathconfig.h
+++ b/Include/internal/pycore_pathconfig.h
@@ -4,8 +4,8 @@
 extern "C" {
 #endif
 
-#ifndef Py_BUILD_CORE
-#  error "Py_BUILD_CORE must be defined to include this header"
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
 #endif
 
 PyAPI_FUNC(void) _Py_wstrlist_clear(

--- a/Include/internal/pycore_state.h
+++ b/Include/internal/pycore_state.h
@@ -4,8 +4,8 @@
 extern "C" {
 #endif
 
-#ifndef Py_BUILD_CORE
-#  error "Py_BUILD_CORE must be defined to include this header"
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
 #endif
 
 #include "pystate.h"

--- a/Include/internal/pycore_warnings.h
+++ b/Include/internal/pycore_warnings.h
@@ -4,6 +4,10 @@
 extern "C" {
 #endif
 
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN define"
+#endif
+
 #include "object.h"
 
 struct _warnings_runtime_state {

--- a/Modules/Setup
+++ b/Modules/Setup
@@ -180,6 +180,7 @@ _symtable symtablemodule.c
 #_bisect _bisectmodule.c	# Bisection algorithms
 #_heapq _heapqmodule.c	# Heap queue algorithm
 #_asyncio _asynciomodule.c  # Fast asyncio Future
+#_json -I$(srcdir)/Include/internal -DPy_BUILD_CORE_BUILTIN _json.c	# _json speedups
 
 #unicodedata unicodedata.c    # static Unicode character database
 

--- a/setup.py
+++ b/setup.py
@@ -678,7 +678,9 @@ class PyBuildExt(build_ext):
         # atexit
         exts.append( Extension("atexit", ["atexitmodule.c"]) )
         # _json speedups
-        exts.append( Extension("_json", ["_json.c"]) )
+        exts.append( Extension("_json", ["_json.c"],
+                               # pycore_accu.h requires Py_BUILD_CORE_BUILTIN
+                               extra_compile_args=['-DPy_BUILD_CORE_BUILTIN']) )
         # Python C API test module
         exts.append( Extension('_testcapi', ['_testcapimodule.c'],
                                depends=['testcapi_long.h']) )


### PR DESCRIPTION
Modify internal header files to fail if Py_BUILD_CORE is not defined.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
