### PR TITLE
target `altbininstall` not works when shell is zsh

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1001,14 +1001,14 @@ altbininstall:	$(BUILDPYTHON)
 		fi; \
 	done
 	$(INSTALL_PROGRAM) $(BUILDPYTHON) $(DESTDIR)$(BINDIR)/python$(VERSION)$(EXE)
-	if test -f $(LDLIBRARY); then \
+	@if test -f $(LDLIBRARY); then \
 		if test -n "$(DLLLIBRARY)" ; then \
 			$(INSTALL_SHARED) $(DLLLIBRARY) $(DESTDIR)$(BINDIR); \
 		else \
 			$(INSTALL_SHARED) $(LDLIBRARY) $(DESTDIR)$(LIBDIR)/$(INSTSONAME); \
 			if test $(LDLIBRARY) != $(INSTSONAME); then \
 				(cd $(DESTDIR)$(LIBDIR); $(LN) -sf $(INSTSONAME) $(LDLIBRARY)) \
-			fi \
+			fi; \
 		fi; \
 	else	true; \
 	fi


### PR DESCRIPTION
Error happens in buildroot.
python version 2.7.15
zsh veriosn: zsh 5.3.1 (x86_64-redhat-linux-gnu)
the error output looks like:

if test -f libpython2.7.so; then \
	if test -n "" ; then \
		/usr/bin/install -c -m 555  /home/user/projects/buildroot/output/host/bin; \
	else \
		/usr/bin/install -c -m 555 libpython2.7.so /home/user/projects/buildroot/output/host/lib/libpython2.7.so.1.0; \
		if test libpython2.7.so != libpython2.7.so.1.0; then \
			(cd /home/user/projects/buildroot/output/host/lib; ln -sf libpython2.7.so.1.0 libpython2.7.so) \
		fi \
	fi; \
else	true; \
fi
zsh:9: parse error near `fi'

seems like python3 makefile also have same problem.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
