### PR TITLE
bpo-35081: Add pycore_fileutils.h

### DIFF
--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -1,8 +1,21 @@
 #ifndef Py_FILEUTILS_H
 #define Py_FILEUTILS_H
-
 #ifdef __cplusplus
 extern "C" {
+#endif
+
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03050000
+PyAPI_FUNC(wchar_t *) Py_DecodeLocale(
+    const char *arg,
+    size_t *size);
+
+PyAPI_FUNC(char*) Py_EncodeLocale(
+    const wchar_t *text,
+    size_t *error_pos);
+
+PyAPI_FUNC(char*) _Py_EncodeLocaleRaw(
+    const wchar_t *text,
+    size_t *error_pos);
 #endif
 
 
@@ -20,47 +33,7 @@ typedef enum {
 } _Py_error_handler;
 
 PyAPI_FUNC(_Py_error_handler) _Py_GetErrorHandler(const char *errors);
-#endif
 
-
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03050000
-PyAPI_FUNC(wchar_t *) Py_DecodeLocale(
-    const char *arg,
-    size_t *size);
-
-PyAPI_FUNC(char*) Py_EncodeLocale(
-    const wchar_t *text,
-    size_t *error_pos);
-
-PyAPI_FUNC(char*) _Py_EncodeLocaleRaw(
-    const wchar_t *text,
-    size_t *error_pos);
-#endif
-
-#ifdef Py_BUILD_CORE
-PyAPI_FUNC(int) _Py_DecodeUTF8Ex(
-    const char *arg,
-    Py_ssize_t arglen,
-    wchar_t **wstr,
-    size_t *wlen,
-    const char **reason,
-    _Py_error_handler errors);
-
-PyAPI_FUNC(int) _Py_EncodeUTF8Ex(
-    const wchar_t *text,
-    char **str,
-    size_t *error_pos,
-    const char **reason,
-    int raw_malloc,
-    _Py_error_handler errors);
-
-PyAPI_FUNC(wchar_t*) _Py_DecodeUTF8_surrogateescape(
-    const char *arg,
-    Py_ssize_t arglen);
-#endif
-
-
-#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03080000
 PyAPI_FUNC(int) _Py_DecodeLocaleEx(
     const char *arg,
     wchar_t **wstr,
@@ -204,13 +177,7 @@ PyAPI_FUNC(int) _Py_GetLocaleconvNumeric(
 
 #endif   /* Py_LIMITED_API */
 
-
-#ifdef Py_BUILD_CORE
-PyAPI_FUNC(int) _Py_GetForceASCII(void);
-#endif
-
 #ifdef __cplusplus
 }
 #endif
-
 #endif /* !Py_FILEUTILS_H */

--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -1,0 +1,36 @@
+#ifndef Py_INTERNAL_FILEUTILS_H
+#define Py_INTERNAL_FILEUTILS_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef Py_BUILD_CORE
+#  error "Py_BUILD_CORE must be defined to include this header"
+#endif
+
+PyAPI_FUNC(int) _Py_DecodeUTF8Ex(
+    const char *arg,
+    Py_ssize_t arglen,
+    wchar_t **wstr,
+    size_t *wlen,
+    const char **reason,
+    _Py_error_handler errors);
+
+PyAPI_FUNC(int) _Py_EncodeUTF8Ex(
+    const wchar_t *text,
+    char **str,
+    size_t *error_pos,
+    const char **reason,
+    int raw_malloc,
+    _Py_error_handler errors);
+
+PyAPI_FUNC(wchar_t*) _Py_DecodeUTF8_surrogateescape(
+    const char *arg,
+    Py_ssize_t arglen);
+
+PyAPI_FUNC(int) _Py_GetForceASCII(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_FILEUTILS_H */

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -2,6 +2,7 @@
 
 #include "Python.h"
 #include "osdefs.h"
+#include "pycore_fileutils.h"
 #include "pycore_pathconfig.h"
 #include "pycore_state.h"
 

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -40,6 +40,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_fileutils.h"
 #include "pycore_state.h"
 #include "ucnhash.h"
 #include "bytes_methods.h"

--- a/Python/coreconfig.c
+++ b/Python/coreconfig.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_fileutils.h"
 #include "pycore_lifecycle.h"
 #include "pycore_mem.h"
 #include "pycore_pathconfig.h"

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_fileutils.h"
 #include "osdefs.h"
 #include <locale.h>
 

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -3,6 +3,7 @@
 #include "Python.h"
 #include "osdefs.h"
 #include "pycore_mem.h"
+#include "pycore_fileutils.h"
 #include "pycore_pathconfig.h"
 #include "pycore_state.h"
 #include <wchar.h>


### PR DESCRIPTION
Move Py_BUILD_CORE code from Include/fileutils.h to a new
Include/internal/pycore_fileutils.h file.

<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
