### PR TITLE
bpo-35181: Correct an assumption about the namespace package loader attribute

### DIFF
--- a/Doc/reference/import.rst
+++ b/Doc/reference/import.rst
@@ -345,12 +345,11 @@ of what happens during the loading portion of import::
     _init_module_attrs(spec, module)
 
     if spec.loader is None:
-        if spec.submodule_search_locations is not None:
-            # namespace package
-            sys.modules[spec.name] = module
-        else:
-            # unsupported
-            raise ImportError
+        # unsupported
+        raise ImportError
+    if spec.origin is None and spec.submodule_search_locations is not None:
+        # namespace package
+        sys.modules[spec.name] = module
     elif not hasattr(spec.loader, 'exec_module'):
         module = spec.loader.load_module(spec.name)
         # Set __loader__ and __package__ if missing.


### PR DESCRIPTION
The namespace package `importlib._bootstrap.ModuleSpec.loader` attribute is no longer `None` _after_ calling the `importlib._bootstrap._init_module_attrs` function. But a namespace package can be detected with its `importlib._bootstrap.ModuleSpec.origin` attribute which is always `None`.

See https://stackoverflow.com/questions/52869541/namespace-package-spec-loader-and-loader-attributes-not-set-to-none

<!-- issue-number: [bpo-35181](https://bugs.python.org/issue35181) -->
https://bugs.python.org/issue35181
<!-- /issue-number -->
