### PR TITLE
bpo-32153: Add unit test for create_autospec with partial function returned in getattr

### DIFF
--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -8,6 +8,7 @@ from unittest.mock import (
 )
 
 from datetime import datetime
+from functools import partial
 
 class SomeClass(object):
     def one(self, a, b):
@@ -869,6 +870,19 @@ class SpecSignatureTest(unittest.TestCase):
         mocked.reset_mock()
         mocked(4, 5, 6)
         mocked.assert_called_once_with(4, 5, 6)
+
+
+    def test_autospec_getattr_partial_function(self):
+        # bpo-32153 : getattr returning partial functions without
+        # __name__ should not create AttributeError in create_autospec
+        class Foo(object):
+
+            def __getattr__(self, name):
+                return partial(lambda name: name, name)
+
+        proxy = Foo()
+        autospec = create_autospec(proxy)
+        assert not hasattr(autospec, '__name__')
 
 
 class TestCallList(unittest.TestCase):

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -882,7 +882,7 @@ class SpecSignatureTest(unittest.TestCase):
 
         proxy = Foo()
         autospec = create_autospec(proxy)
-        assert not hasattr(autospec, '__name__')
+        self.assertFalse(hasattr(autospec, '__name__'))
 
 
 class TestCallList(unittest.TestCase):

--- a/Lib/unittest/test/testmock/testhelpers.py
+++ b/Lib/unittest/test/testmock/testhelpers.py
@@ -875,10 +875,10 @@ class SpecSignatureTest(unittest.TestCase):
     def test_autospec_getattr_partial_function(self):
         # bpo-32153 : getattr returning partial functions without
         # __name__ should not create AttributeError in create_autospec
-        class Foo(object):
+        class Foo:
 
-            def __getattr__(self, name):
-                return partial(lambda name: name, name)
+            def __getattr__(self, attribute):
+                return partial(lambda name: name, attribute)
 
         proxy = Foo()
         autospec = create_autospec(proxy)


### PR DESCRIPTION
This adds an unit test for https://bugs.python.org/issue32153 which was out dated and fixed by https://bugs.python.org/issue28919 . During create_autospec the function attributes are copied and when getattr returns a partial function then it doesn't contain `__name__` causing `AttributeError` . This was fixed in 3.7 suppressing `AttributeError` but was not backported thus this test can be applied only on 3.7 and master.

**Fails on 3.6 branch**

```
   cpython git:(25bd107399)   ./python.exe
Python 3.6.7+ (remotes/upstream/3.6:25bd107399, Nov  8 2018, 00:50:43)
[GCC 4.2.1 Compatible Apple LLVM 7.0.2 (clang-700.1.81)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> ^D
   cpython git:(25bd107399)   ./python.exe -m unittest -v unittest.test.testmock.testhelpers.SpecSignatureTest.test_autospec_getattr_partial_function
test_autospec_getattr_partial_function (unittest.test.testmock.testhelpers.SpecSignatureTest) ... ERROR

======================================================================
ERROR: test_autospec_getattr_partial_function (unittest.test.testmock.testhelpers.SpecSignatureTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/karthikeyansingaravelan/stuff/python/cpython/Lib/unittest/test/testmock/testhelpers.py", line 884, in test_autospec_getattr_partial_function
    autospec = create_autospec(proxy)
  File "/Users/karthikeyansingaravelan/stuff/python/cpython/Lib/unittest/mock.py", line 2182, in create_autospec
    _check_signature(spec, mock, is_type, instance)
  File "/Users/karthikeyansingaravelan/stuff/python/cpython/Lib/unittest/mock.py", line 102, in _check_signature
    _copy_func_details(func, checksig)
  File "/Users/karthikeyansingaravelan/stuff/python/cpython/Lib/unittest/mock.py", line 107, in _copy_func_details
    funcopy.__name__ = func.__name__
AttributeError: 'functools.partial' object has no attribute '__name__'

----------------------------------------------------------------------
Ran 1 test in 0.007s

FAILED (errors=1)
```

**Passes on master**

```
   cpython git:(bpo32153) ./python.exe
Python 3.8.0a0 (heads/bpo32153:3e9cd8d982, Nov  8 2018, 00:53:46)
[Clang 7.0.2 (clang-700.1.81)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> ^D
   cpython git:(bpo32153) ./python.exe -m unittest -v unittest.test.testmock.testhelpers.SpecSignatureTest.test_autospec_getattr_partial_function
test_autospec_getattr_partial_function (unittest.test.testmock.testhelpers.SpecSignatureTest) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.005s

OK

```

<!-- issue-number: [bpo-32513](https://bugs.python.org/issue32513) -->
https://bugs.python.org/issue32513
<!-- /issue-number -->
