### PR TITLE
bpo-34011: Fix the construction of subprocess.CalledProcessError in test_venv

### DIFF
--- a/Lib/test/test_venv.py
+++ b/Lib/test/test_venv.py
@@ -35,7 +35,7 @@ def check_output(cmd, encoding=None):
     out, err = p.communicate()
     if p.returncode:
         raise subprocess.CalledProcessError(
-            p.returncode, cmd, None, out, err)
+            p.returncode, cmd, out, err)
     return out, err
 
 class BaseTest(unittest.TestCase):


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-34011](https://bugs.python.org/issue34011) -->
https://bugs.python.org/issue34011
<!-- /issue-number -->
