### PR TITLE
bpo-32409: Revert "bpo-32409: Fix regression in activate.bat on international Windows (GH-10295)"

### DIFF
--- a/Lib/venv/scripts/nt/activate.bat
+++ b/Lib/venv/scripts/nt/activate.bat
@@ -1,10 +1,11 @@
 @echo off
 
-rem This file is UTF-8 encoded, so we need to update the current code page while executing it.
-for /f %%a in ('%~dp0python.exe -Ic "import ctypes; print(ctypes.windll.kernel32.GetConsoleOutputCP())"') do (set "_OLD_CODEPAGE=%%a")
-
+rem This file is UTF-8 encoded, so we need to update the current code page while executing it
+for /f "tokens=2 delims=:" %%a in ('"%SystemRoot%\System32\chcp.com"') do (
+    set "_OLD_CODEPAGE=%%a"
+)
 if defined _OLD_CODEPAGE (
-    %~dp0python.exe -Ic "import ctypes; ctypes.windll.kernel32.SetConsoleOutputCP(65001)"
+    "%SystemRoot%\System32\chcp.com" 65001 > nul
 )
 
 set "VIRTUAL_ENV=__VENV_DIR__"
@@ -39,6 +40,6 @@ set "PATH=%VIRTUAL_ENV%\__VENV_BIN_NAME__;%PATH%"
 
 :END
 if defined _OLD_CODEPAGE (
-    %~dp0python.exe -Ic "import ctypes; ctypes.windll.kernel32.SetConsoleOutputCP(%_OLD_CODEPAGE%)"
+    "%SystemRoot%\System32\chcp.com" %_OLD_CODEPAGE% > nul
     set "_OLD_CODEPAGE="
 )

--- a/Misc/NEWS.d/next/Library/2018-11-02-12-01-00.bpo-32409.MFRX2Q.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-02-12-01-00.bpo-32409.MFRX2Q.rst
@@ -1,2 +1,0 @@
-Fixed implementation of :file:`activate.bat` to handle Unicode contents on
-localized Windows systems (eg. German). Patch by Martin Bijl.


### PR DESCRIPTION
This reverts commit c64583b6d3e8516a8cd2b5f84fc1e300bfac2206 as it broke several Windows buildbots:

Original PR:

https://github.com/python/cpython/pull/10295

Broken buildbot links:

https://buildbot.python.org/all/#/builders/32/builds/1707
https://buildbot.python.org/all/#/builders/113/builds/733
https://buildbot.python.org/all/#/builders/40/builds/1137
https://buildbot.python.org/all/#/builders/130/builds/420
https://buildbot.python.org/all/#/builders/3/builds/1634

Revert policy:

https://discuss.python.org/t/policy-to-revert-commits-on-buildbot-failure/404/4

Custom run in the buildbot of this revert:

https://buildbot.python.org/all/#/builders/22/builds/4

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-32409](https://bugs.python.org/issue32409) -->
https://bugs.python.org/issue32409
<!-- /issue-number -->
