### PR TITLE
bpo-35186: Remove "built with" comment in setup.py upload

### DIFF
--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -121,14 +121,8 @@ class upload(PyPIRCCommand):
             'requires': meta.get_requires(),
             'obsoletes': meta.get_obsoletes(),
             }
-        comment = ''
-        if command == 'bdist_rpm':
-            dist, version, id = platform.dist()
-            if dist:
-                comment = 'built for %s %s' % (dist, version)
-        elif command == 'bdist_dumb':
-            comment = 'built for %s' % platform.platform(terse=1)
-        data['comment'] = comment
+
+        data['comment'] = ''
 
         if self.sign:
             data['gpg_signature'] = (os.path.basename(filename) + ".asc",

--- a/Misc/NEWS.d/next/Library/2018-11-08-14-22-29.bpo-35186.5m22Mj.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-08-14-22-29.bpo-35186.5m22Mj.rst
@@ -1,0 +1,2 @@
+Removed the "built with" comment added when ``setup.py upload`` is used with
+either ``bdist_rpm`` or ``bdist_dumb``.


### PR DESCRIPTION
platform.dist() is deprecated and slated for removal in Python 3.8. The upload command itself should also not be used to upload to PyPI, but while it continues to exist it should not use deprecated functions.

This is the first option I proposed in [bpo-35186](https://bugs.python.org/issue35186). A slightly more conservative option (option 2) is easy enough to implement:

```diff
diff --git a/Lib/distutils/command/upload.py b/Lib/distutils/command/upload.py
index 32dda359ba..56ba12b1c5 100644
--- a/Lib/distutils/command/upload.py
+++ b/Lib/distutils/command/upload.py
@@ -121,12 +121,9 @@ class upload(PyPIRCCommand):
             'requires': meta.get_requires(),
             'obsoletes': meta.get_obsoletes(),
             }
+
         comment = ''
-        if command == 'bdist_rpm':
-            dist, version, id = platform.dist()
-            if dist:
-                comment = 'built for %s %s' % (dist, version)
-        elif command == 'bdist_dumb':
+        if command in ('bdist_rpm', 'bdist_dumb'):
             comment = 'built for %s' % platform.platform(terse=1)
         data['comment'] = comment
```

Distutils maintainers let me know how you want to go. I'll hold off on the news entry until after we decide which way to go.

<!-- issue-number: [bpo-35186](https://bugs.python.org/issue35186) -->
https://bugs.python.org/issue35186
<!-- /issue-number -->
