### PR TITLE
[3.11] bpo-35191: Fix unexpected integer truncation in socket.setblocking()

### DIFF
--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4705,10 +4705,14 @@ class NonBlockingTCPTests(ThreadedTCPSocketTest):
             self.skipTest('needs UINT_MAX < ULONG_MAX')
 
         self.serv.setblocking(False)
+        if fcntl:
+            self.assertFalse(_is_fd_in_blocking_mode(self.serv))
         self.assertEqual(self.serv.gettimeout(), 0.0)
 
         self.serv.setblocking(_testcapi.UINT_MAX + 1)
         self.assertIsNone(self.serv.gettimeout())
+        if fcntl:
+            self.assertTrue(_is_fd_in_blocking_mode(self.serv))
 
     _testSetBlocking_overflow = support.cpython_only(_testSetBlocking)
 

--- a/Lib/test/test_socket.py
+++ b/Lib/test/test_socket.py
@@ -4705,14 +4705,10 @@ class NonBlockingTCPTests(ThreadedTCPSocketTest):
             self.skipTest('needs UINT_MAX < ULONG_MAX')
 
         self.serv.setblocking(False)
-        if fcntl:
-            self.assertFalse(_is_fd_in_blocking_mode(self.serv))
-        self.assertEqual(self.serv.gettimeout(), 0.0)
+        self.assert_sock_timeout(self.serv, 0.0)
 
         self.serv.setblocking(_testcapi.UINT_MAX + 1)
-        self.assertIsNone(self.serv.gettimeout())
-        if fcntl:
-            self.assertTrue(_is_fd_in_blocking_mode(self.serv))
+        self.assert_sock_timeout(self.serv, None)
 
     _testSetBlocking_overflow = support.cpython_only(_testSetBlocking)
 

--- a/Misc/NEWS.d/next/Library/2018-11-08-18-44-04.bpo-35191.s29bWu.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-08-18-44-04.bpo-35191.s29bWu.rst
@@ -1,2 +1,2 @@
 Fix unexpected integer truncation in :meth:`socket.setblocking` which caused
-it to interpret multiples of `2**32` as :keyword:`False`.
+it to interpret multiples of `2**32` as `False`.

--- a/Misc/NEWS.d/next/Library/2018-11-08-18-44-04.bpo-35191.s29bWu.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-08-18-44-04.bpo-35191.s29bWu.rst
@@ -1,0 +1,2 @@
+Fix unexpected integer truncation in :meth:`socket.setblocking` which caused
+it to interpret multiples of `2**32` as :keyword:`False`.

--- a/Misc/NEWS.d/next/Library/2018-11-08-18-44-04.bpo-35191.s29bWu.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-08-18-44-04.bpo-35191.s29bWu.rst
@@ -1,2 +1,2 @@
 Fix unexpected integer truncation in :meth:`socket.setblocking` which caused
-it to interpret multiples of `2**32` as `False`.
+it to interpret multiples of ``2**32`` as ``False``.

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2821,6 +2821,7 @@ sock_setblocking(PySocketSockObject *s, PyObject *arg)
     if (block == -1 && PyErr_Occurred())
         return NULL;
 
+    block = !!block;
     s->sock_timeout = _PyTime_FromSeconds(block ? -1 : 0);
     if (internal_setblocking(s, block) == -1) {
         return NULL;

--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -2815,13 +2815,14 @@ For IP sockets, the address info is a pair (hostaddr, port).");
 static PyObject *
 sock_setblocking(PySocketSockObject *s, PyObject *arg)
 {
-    long block;
+    long value;
+    int block;
 
-    block = PyLong_AsLong(arg);
-    if (block == -1 && PyErr_Occurred())
+    value = PyLong_AsLong(arg);
+    if (value == -1 && PyErr_Occurred())
         return NULL;
 
-    block = !!block;
+    block = (value != 0);
     s->sock_timeout = _PyTime_FromSeconds(block ? -1 : 0);
     if (internal_setblocking(s, block) == -1) {
         return NULL;


### PR DESCRIPTION
On platforms with 64-bit long, socket.setblocking(x) treated all x
which lower 32 bits are zero as False due to integer truncation.

Reported by ubsan.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35191](https://bugs.python.org/issue35191) -->
https://bugs.python.org/issue35191
<!-- /issue-number -->
