### PR TITLE
Hoist the float conversion out of the inner loop.

### DIFF
--- a/Lib/random.py
+++ b/Lib/random.py
@@ -383,7 +383,7 @@ class Random(_random.Random):
         if len(cum_weights) != n:
             raise ValueError('The number of weights does not match the population')
         bisect = _bisect.bisect
-        total = cum_weights[-1] + 0.0
+        total = cum_weights[-1] + 0.0   # convert to float
         hi = n - 1
         return [population[bisect(cum_weights, random() * total, 0, hi)]
                 for i in range(k)]

--- a/Lib/random.py
+++ b/Lib/random.py
@@ -375,6 +375,7 @@ class Random(_random.Random):
         if cum_weights is None:
             if weights is None:
                 _int = int
+                n += 0.0    # convert to float for a small speed improvement
                 return [population[_int(random() * n)] for i in range(k)]
             cum_weights = list(_itertools.accumulate(weights))
         elif weights is not None:
@@ -382,7 +383,7 @@ class Random(_random.Random):
         if len(cum_weights) != n:
             raise ValueError('The number of weights does not match the population')
         bisect = _bisect.bisect
-        total = cum_weights[-1]
+        total = cum_weights[-1] + 0.0
         hi = n - 1
         return [population[bisect(cum_weights, random() * total, 0, hi)]
                 for i in range(k)]


### PR DESCRIPTION
Currently, the *n* and *total* variables get converted to floats each time they are multiplied by random().  This minor tweak does the conversion just once and gets a small speedup (approx 3%).