### PR TITLE
[2.7] bpo-35194: Fix a wrong constant in cp932 codec (GH-10420)

### DIFF
--- a/Modules/cjkcodecs/_codecs_jp.c
+++ b/Modules/cjkcodecs/_codecs_jp.c
@@ -40,7 +40,7 @@ ENCODER(cp932)
             if (c == 0xf8f0)
                 OUT1(0xa0)
             else
-                OUT1(c - 0xfef1 + 0xfd)
+                OUT1(c - 0xf8f1 + 0xfd)
             NEXT(1, 1)
             continue;
         }


### PR DESCRIPTION
This typo doesn't affect the result because wrong bits are discarded
on implicit conversion to unsigned char, but it trips UBSan
with -fsanitize=implicit-integer-truncation.

https://bugs.python.org/issue35194.
(cherry picked from commit 7a69cf47a9bbc95f95fd67c982bff121b2a903cb)

Co-authored-by: Alexey Izbyshev <izbyshev@ispras.ru>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35194](https://bugs.python.org/issue35194) -->
https://bugs.python.org/issue35194
<!-- /issue-number -->
