### PR TITLE
bpo-35199: Add an internal _PyTuple_ITEMS() macro

### DIFF
--- a/Include/tupleobject.h
+++ b/Include/tupleobject.h
@@ -58,6 +58,10 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 #define PyTuple_GET_ITEM(op, i) (((PyTupleObject *)(op))->ob_item[i])
 #define PyTuple_GET_SIZE(op)    (assert(PyTuple_Check(op)),Py_SIZE(op))
 
+#ifdef Py_BUILD_CORE
+#  define _PyTuple_ITEMS(op) ((((PyTupleObject *)(op))->ob_item))
+#endif
+
 /* Macro, *only* to be used to fill in brand new tuples */
 #define PyTuple_SET_ITEM(op, i, v) (((PyTupleObject *)(op))->ob_item[i] = v)
 #endif

--- a/Modules/_functoolsmodule.c
+++ b/Modules/_functoolsmodule.c
@@ -142,7 +142,7 @@ partial_fastcall(partialobject *pto, PyObject **args, Py_ssize_t nargs,
         stack = args;
     }
     else if (nargs == 0) {
-        stack = &PyTuple_GET_ITEM(pto->args, 0);
+        stack = _PyTuple_ITEMS(pto->args);
     }
     else {
         if (nargs2 <= (Py_ssize_t)Py_ARRAY_LENGTH(small_stack)) {
@@ -159,7 +159,7 @@ partial_fastcall(partialobject *pto, PyObject **args, Py_ssize_t nargs,
 
         /* use borrowed references */
         memcpy(stack,
-               &PyTuple_GET_ITEM(pto->args, 0),
+               _PyTuple_ITEMS(pto->args),
                pto_nargs * sizeof(PyObject*));
         memcpy(&stack[pto_nargs],
                args,
@@ -222,7 +222,7 @@ partial_call(partialobject *pto, PyObject *args, PyObject *kwargs)
 
     if (pto->use_fastcall) {
         res = partial_fastcall(pto,
-                               &PyTuple_GET_ITEM(args, 0),
+                               _PyTuple_ITEMS(args),
                                PyTuple_GET_SIZE(args),
                                kwargs2);
     }

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4361,7 +4361,7 @@ fastcall_args(PyObject *args, PyObject ***stack, Py_ssize_t *nargs)
         *nargs = 0;
     }
     else if (PyTuple_Check(args)) {
-        *stack = &PyTuple_GET_ITEM(args, 0);
+        *stack = ((PyTupleObject *)args)->ob_item;
         *nargs = PyTuple_GET_SIZE(args);
     }
     else {

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -224,7 +224,7 @@ PyObject_Call(PyObject *callable, PyObject *args, PyObject *kwargs)
 
     if (PyFunction_Check(callable)) {
         return _PyFunction_FastCallDict(callable,
-                                        &PyTuple_GET_ITEM(args, 0),
+                                        _PyTuple_ITEMS(args),
                                         PyTuple_GET_SIZE(args),
                                         kwargs);
     }
@@ -325,7 +325,7 @@ _PyFunction_FastCallDict(PyObject *func, PyObject *const *args, Py_ssize_t nargs
                  && co->co_argcount == PyTuple_GET_SIZE(argdefs)) {
             /* function called with no arguments, but all parameters have
                a default value: use default values as arguments .*/
-            args = &PyTuple_GET_ITEM(argdefs, 0);
+            args = _PyTuple_ITEMS(argdefs);
             return function_code_fastcall(co, args, PyTuple_GET_SIZE(argdefs),
                                           globals);
         }
@@ -342,7 +342,7 @@ _PyFunction_FastCallDict(PyObject *func, PyObject *const *args, Py_ssize_t nargs
             return NULL;
         }
 
-        k = &PyTuple_GET_ITEM(kwtuple, 0);
+        k = _PyTuple_ITEMS(kwtuple);
         pos = i = 0;
         while (PyDict_Next(kwargs, &pos, &k[i], &k[i+1])) {
             /* We must hold strong references because keyword arguments can be
@@ -365,7 +365,7 @@ _PyFunction_FastCallDict(PyObject *func, PyObject *const *args, Py_ssize_t nargs
     qualname = ((PyFunctionObject *)func) -> func_qualname;
 
     if (argdefs != NULL) {
-        d = &PyTuple_GET_ITEM(argdefs, 0);
+        d = _PyTuple_ITEMS(argdefs);
         nd = PyTuple_GET_SIZE(argdefs);
     }
     else {
@@ -411,7 +411,7 @@ _PyFunction_FastCallKeywords(PyObject *func, PyObject *const *stack,
                  && co->co_argcount == PyTuple_GET_SIZE(argdefs)) {
             /* function called with no arguments, but all parameters have
                a default value: use default values as arguments .*/
-            stack = &PyTuple_GET_ITEM(argdefs, 0);
+            stack = _PyTuple_ITEMS(argdefs);
             return function_code_fastcall(co, stack, PyTuple_GET_SIZE(argdefs),
                                           globals);
         }
@@ -423,7 +423,7 @@ _PyFunction_FastCallKeywords(PyObject *func, PyObject *const *stack,
     qualname = ((PyFunctionObject *)func) -> func_qualname;
 
     if (argdefs != NULL) {
-        d = &PyTuple_GET_ITEM(argdefs, 0);
+        d = _PyTuple_ITEMS(argdefs);
         nd = PyTuple_GET_SIZE(argdefs);
     }
     else {
@@ -432,7 +432,7 @@ _PyFunction_FastCallKeywords(PyObject *func, PyObject *const *stack,
     }
     return _PyEval_EvalCodeWithName((PyObject*)co, globals, (PyObject *)NULL,
                                     stack, nargs,
-                                    nkwargs ? &PyTuple_GET_ITEM(kwnames, 0) : NULL,
+                                    nkwargs ? _PyTuple_ITEMS(kwnames) : NULL,
                                     stack + nargs,
                                     nkwargs, 1,
                                     d, (int)nd, kwdefs,
@@ -785,7 +785,7 @@ PyCFunction_Call(PyObject *func, PyObject *args, PyObject *kwargs)
     }
     else {
         return _PyCFunction_FastCallDict(func,
-                                         &PyTuple_GET_ITEM(args, 0),
+                                         _PyTuple_ITEMS(args),
                                          PyTuple_GET_SIZE(args),
                                          kwargs);
     }
@@ -898,8 +898,8 @@ _PyObject_Call_Prepend(PyObject *callable,
     /* use borrowed references */
     stack[0] = obj;
     memcpy(&stack[1],
-              &PyTuple_GET_ITEM(args, 0),
-              argcount * sizeof(PyObject *));
+           _PyTuple_ITEMS(args),
+           argcount * sizeof(PyObject *));
 
     result = _PyObject_FastCallDict(callable,
                                     stack, argcount + 1,
@@ -950,7 +950,7 @@ _PyObject_CallFunctionVa(PyObject *callable, const char *format,
              func(*(arg1, arg2, arg3)): func(arg1, arg2, arg3) */
         PyObject *args = stack[0];
         result = _PyObject_FastCall(callable,
-                                    &PyTuple_GET_ITEM(args, 0),
+                                    _PyTuple_ITEMS(args),
                                     PyTuple_GET_SIZE(args));
     }
     else {

--- a/Objects/codeobject.c
+++ b/Objects/codeobject.c
@@ -39,7 +39,7 @@ intern_strings(PyObject *tuple)
         if (v == NULL || !PyUnicode_CheckExact(v)) {
             Py_FatalError("non-string found in code slot");
         }
-        PyUnicode_InternInPlace(&PyTuple_GET_ITEM(tuple, i));
+        PyUnicode_InternInPlace(&_PyTuple_ITEMS(tuple)[i]);
     }
 }
 

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -247,7 +247,7 @@ methoddescr_call(PyMethodDescrObject *descr, PyObject *args, PyObject *kwargs)
     }
 
     result = _PyMethodDef_RawFastCallDict(descr->d_method, self,
-                                          &PyTuple_GET_ITEM(args, 1), nargs - 1,
+                                          &_PyTuple_ITEMS(args)[1], nargs - 1,
                                           kwargs);
     result = _Py_CheckFunctionResult((PyObject *)descr, result, NULL);
     return result;
@@ -331,7 +331,7 @@ classmethoddescr_call(PyMethodDescrObject *descr, PyObject *args,
     }
 
     result = _PyMethodDef_RawFastCallDict(descr->d_method, self,
-                                          &PyTuple_GET_ITEM(args, 1), argc - 1,
+                                          &_PyTuple_ITEMS(args)[1], argc - 1,
                                           kwds);
     result = _Py_CheckFunctionResult((PyObject *)descr, result, NULL);
     return result;

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -581,7 +581,7 @@ function_call(PyObject *func, PyObject *args, PyObject *kwargs)
     PyObject **stack;
     Py_ssize_t nargs;
 
-    stack = &PyTuple_GET_ITEM(args, 0);
+    stack = _PyTuple_ITEMS(args);
     nargs = PyTuple_GET_SIZE(args);
     return _PyFunction_FastCallDict(func, stack, nargs, kwargs);
 }

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -4662,7 +4662,7 @@ do_call_core(PyObject *func, PyObject *callargs, PyObject *kwdict)
             }
 
             C_TRACE(result, _PyCFunction_FastCallDict(func,
-                                                      &PyTuple_GET_ITEM(callargs, 1),
+                                                      &_PyTuple_ITEMS(callargs)[1],
                                                       nargs - 1,
                                                       kwdict));
             Py_DECREF(func);

--- a/Python/getargs.c
+++ b/Python/getargs.c
@@ -422,7 +422,7 @@ vgetargs1(PyObject *args, const char *format, va_list *p_va, int flags)
             return 0;
         }
 
-        stack = &PyTuple_GET_ITEM(args, 0);
+        stack = _PyTuple_ITEMS(args);
         nargs = PyTuple_GET_SIZE(args);
     }
     else {
@@ -2254,7 +2254,7 @@ vgetargskeywordsfast(PyObject *args, PyObject *keywords,
         return 0;
     }
 
-    stack = &PyTuple_GET_ITEM(args, 0);
+    stack = _PyTuple_ITEMS(args);
     nargs = PyTuple_GET_SIZE(args);
     return vgetargskeywordsfast_impl(stack, nargs, keywords, NULL,
                                      parser, p_va, flags);
@@ -2461,7 +2461,7 @@ PyArg_UnpackTuple(PyObject *args, const char *name, Py_ssize_t min, Py_ssize_t m
             "PyArg_UnpackTuple() argument list is not a tuple");
         return 0;
     }
-    stack = &PyTuple_GET_ITEM(args, 0);
+    stack = _PyTuple_ITEMS(args);
     nargs = PyTuple_GET_SIZE(args);
 
 #ifdef HAVE_STDARG_PROTOTYPES


### PR DESCRIPTION
* _PyTuple_ITEMS() gives access to the tuple->ob_item field; cast the
  first argument to PyTupleObject*. The macro is only usable if
  Py_BUILD_CORE is defined.
* Replace &PyTuple_GET_ITEM(ob, 0) with _PyTuple_ITEMS(ob)
* Replace PyTuple_GET_ITEM(op, 1) with &_PyTuple_ITEMS(ob)[1]

<!-- issue-number: [bpo-35199](https://bugs.python.org/issue35199) -->
https://bugs.python.org/issue35199
<!-- /issue-number -->
