### PR TITLE
[WIP] bpo-35199: PyTuple_GET_ITEM() becomes a function in debug mode

### DIFF
--- a/Include/tupleobject.h
+++ b/Include/tupleobject.h
@@ -55,8 +55,17 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 
 /* Macro, trading safety for speed */
 #ifndef Py_LIMITED_API
-#define PyTuple_GET_ITEM(op, i) (((PyTupleObject *)(op))->ob_item[i])
-#define PyTuple_GET_SIZE(op)    (assert(PyTuple_Check(op)),Py_SIZE(op))
+
+#ifdef Py_DEBUG
+PyAPI_FUNC(PyObject*) _PyTuple_GET_ITEM_impl(const PyObject *op, Py_ssize_t i);
+PyAPI_FUNC(Py_ssize_t) _PyTuple_GET_SIZE_impl(const PyObject *op);
+
+#  define PyTuple_GET_ITEM(op, i) _PyTuple_GET_ITEM_impl((PyObject *)(op), i)
+#  define PyTuple_GET_SIZE(op) _PyTuple_GET_SIZE_impl((PyObject *)(op))
+#else
+#  define PyTuple_GET_ITEM(op, i) (((PyTupleObject *)(op))->ob_item[i])
+#  define PyTuple_GET_SIZE(op)    (assert(PyTuple_Check(op)),Py_SIZE(op))
+#endif
 
 #ifdef Py_BUILD_CORE
 #  define _PyTuple_ITEMS(op) ((((PyTupleObject *)(op))->ob_item))

--- a/Misc/NEWS.d/next/C API/2018-11-09-17-00-12.bpo-35199.9LxO8j.rst
+++ b/Misc/NEWS.d/next/C API/2018-11-09-17-00-12.bpo-35199.9LxO8j.rst
@@ -1,0 +1,4 @@
+When Python is compiled in debug mode (Py_DEBUG), PyTuple_GET_ITEM() macro
+becomes a function which implements sanity checks using assertions. It
+should help to detect misusage of the C API. "&PyTuple_GET_ITEM(op, i)" is
+now invalid in debug mode.

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -134,6 +134,16 @@ PyTuple_New(Py_ssize_t size)
     return (PyObject *) op;
 }
 
+#ifdef Py_DEBUG
+Py_ssize_t
+_PyTuple_GET_SIZE_impl(const PyObject *op)
+{
+    _PyObject_ASSERT((PyObject *)op, PyTuple_Check(op));
+    return Py_SIZE(op);
+
+}
+#endif
+
 Py_ssize_t
 PyTuple_Size(PyObject *op)
 {
@@ -144,6 +154,16 @@ PyTuple_Size(PyObject *op)
     else
         return Py_SIZE(op);
 }
+
+#ifdef Py_DEBUG
+PyObject*
+_PyTuple_GET_ITEM_impl(const PyObject *op, Py_ssize_t i)
+{
+    _PyObject_ASSERT((PyObject *)op, PyTuple_Check(op));
+    assert(0 <= i && i < Py_SIZE(op));
+    return ((PyTupleObject *)op) -> ob_item[i];
+}
+#endif
 
 PyObject *
 PyTuple_GetItem(PyObject *op, Py_ssize_t i)


### PR DESCRIPTION
When Python is compiled in debug mode (Py_DEBUG), PyTuple_GET_ITEM()
macro becomes a function which implements sanity checks using
_PyObject_ASSERT() and assert(). It should help to detect misusage of
the C API.

<!-- issue-number: [bpo-35199](https://bugs.python.org/issue35199) -->
https://bugs.python.org/issue35199
<!-- /issue-number -->
