### PR TITLE
bpo-35198 Fix C++ extension compilation on AIX

### DIFF
--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -188,7 +188,10 @@ class UnixCCompiler(CCompiler):
                         i = 1
                         while '=' in linker[i]:
                             i += 1
-                    linker[i] = self.compiler_cxx[i]
+                    if linker[i].endswith('ld_so_aix'):
+                        # Linker is ld_so_aix, so compiler is next arg
+                        i += 1
+                    linker = linker[:i] + self.compiler_cxx + linker[i+1:]
 
                 if sys.platform == 'darwin':
                     linker = _osx_support.compiler_fixup(linker, ld_args)

--- a/Lib/distutils/unixccompiler.py
+++ b/Lib/distutils/unixccompiler.py
@@ -188,10 +188,15 @@ class UnixCCompiler(CCompiler):
                         i = 1
                         while '=' in linker[i]:
                             i += 1
-                    if linker[i].endswith('ld_so_aix'):
-                        # Linker is ld_so_aix, so compiler is next arg
-                        i += 1
-                    linker = linker[:i] + self.compiler_cxx + linker[i+1:]
+
+                    if os.path.basename(linker[i]) == 'ld_so_aix':
+                        # AIX platforms prefix the compiler with the ld_so_aix
+                        # script, so we need to adjust our linker index
+                        offset = 1
+                    else:
+                        offset = 0
+
+                    linker[i+offset] = self.compiler_cxx[i]
 
                 if sys.platform == 'darwin':
                     linker = _osx_support.compiler_fixup(linker, ld_args)

--- a/Misc/NEWS.d/next/Library/2018-11-09-12-45-28.bpo-35198.EJ8keW.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-09-12-45-28.bpo-35198.EJ8keW.rst
@@ -1,0 +1,1 @@
+Fix C++ extension compilation on AIX


### PR DESCRIPTION
For C++ extensions, distutils tries to replace the C compiler with the
C++ compiler, but it assumes that C compiler is the first element after
any environment variables set. On AIX, linking goes through ld_so_aix,
so it is the first element and the compiler is the next element. Thus
the replacement is faulty:

ld_so_aix gcc ... -> g++ gcc ...

Also, it assumed that self.compiler_cxx had only 1 element or that
there were the same number of elements as the linker has and in the
same order. This might not be the case, so instead concatenate
everything together.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35198](https://bugs.python.org/issue35198) -->
https://bugs.python.org/issue35198
<!-- /issue-number -->
