### PR TITLE
bpo-35202: Remove unused imports in idle lib package

### DIFF
--- a/Lib/idlelib/codecontext.py
+++ b/Lib/idlelib/codecontext.py
@@ -13,7 +13,7 @@ import re
 from sys import maxsize as INFINITY
 
 import tkinter
-from tkinter.constants import TOP, LEFT, X, W, SUNKEN
+from tkinter.constants import TOP, X, SUNKEN
 
 from idlelib.config import idleConf
 

--- a/Lib/idlelib/filelist.py
+++ b/Lib/idlelib/filelist.py
@@ -115,7 +115,6 @@ def _test():  # TODO check and convert to htest
     from tkinter import Tk
     from idlelib.editor import fixwordbreaks
     from idlelib.run import fix_scaling
-    import sys
     root = Tk()
     fix_scaling(root)
     fixwordbreaks(root)

--- a/Lib/idlelib/idle_test/test_config.py
+++ b/Lib/idlelib/idle_test/test_config.py
@@ -4,7 +4,6 @@
 Much of IdleConf is also exercised by ConfigDialog and test_configdialog.
 """
 from idlelib import config
-import copy
 import sys
 import os
 import tempfile

--- a/Lib/idlelib/idle_test/test_config_key.py
+++ b/Lib/idlelib/idle_test/test_config_key.py
@@ -2,7 +2,6 @@
 
 from idlelib import config_key
 from test.support import requires
-import sys
 import unittest
 from tkinter import Tk
 from idlelib.idle_test.mock_idle import Func

--- a/Lib/idlelib/idle_test/test_rpc.py
+++ b/Lib/idlelib/idle_test/test_rpc.py
@@ -3,7 +3,6 @@
 from idlelib import rpc
 import unittest
 
-import marshal
 
 
 class CodePicklerTest(unittest.TestCase):

--- a/Lib/idlelib/pyparse.py
+++ b/Lib/idlelib/pyparse.py
@@ -11,7 +11,6 @@ _closere - line that must be followed by dedent.
 _chew_ordinaryre - non-special characters.
 """
 import re
-import sys
 
 # Reason last statement is continued (or C_NONE if it's not).
 (C_NONE, C_BACKSLASH, C_STRING_FIRST_LINE,

--- a/Misc/NEWS.d/next/IDLE/2018-11-10-09-10-54.bpo-35202.TeJJrt.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-11-10-09-10-54.bpo-35202.TeJJrt.rst
@@ -1,1 +1,1 @@
-Removed unused imports from IDLE lib package
+Remove unused imports from lib/idlelib

--- a/Misc/NEWS.d/next/IDLE/2018-11-10-09-10-54.bpo-35202.TeJJrt.rst
+++ b/Misc/NEWS.d/next/IDLE/2018-11-10-09-10-54.bpo-35202.TeJJrt.rst
@@ -1,0 +1,1 @@
+Removed unused imports from IDLE lib package


### PR DESCRIPTION


<!-- issue-number: [bpo-35202](https://bugs.python.org/issue35202) -->
https://bugs.python.org/issue35202
<!-- /issue-number -->
