### PR TITLE
[WIP] bpo-35206: Add new experimental _Py_CAPI2 API

### DIFF
--- a/Include/tupleobject.h
+++ b/Include/tupleobject.h
@@ -55,8 +55,17 @@ PyAPI_FUNC(void) _PyTuple_MaybeUntrack(PyObject *);
 
 /* Macro, trading safety for speed */
 #ifndef Py_LIMITED_API
-#define PyTuple_GET_ITEM(op, i) (((PyTupleObject *)(op))->ob_item[i])
-#define PyTuple_GET_SIZE(op)    (assert(PyTuple_Check(op)),Py_SIZE(op))
+
+#ifdef _Py_CAPI2
+PyAPI_FUNC(PyObject*) _PyTuple_GET_ITEM_impl(const PyObject *op, Py_ssize_t i);
+PyAPI_FUNC(Py_ssize_t) _PyTuple_GET_SIZE_impl(const PyObject *op);
+
+#  define PyTuple_GET_ITEM(op, i) _PyTuple_GET_ITEM_impl((PyObject *)(op), i)
+#  define PyTuple_GET_SIZE(op) _PyTuple_GET_SIZE_impl((PyObject *)(op))
+#else
+#  define PyTuple_GET_ITEM(op, i) (((PyTupleObject *)(op))->ob_item[i])
+#  define PyTuple_GET_SIZE(op)    (assert(PyTuple_Check(op)),Py_SIZE(op))
+#endif   /* !_Py_CAPI2 */
 
 #ifdef Py_BUILD_CORE
 #  define _PyTuple_ITEMS(op) ((((PyTupleObject *)(op))->ob_item))

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -135,6 +135,14 @@ PyTuple_New(Py_ssize_t size)
 }
 
 Py_ssize_t
+_PyTuple_GET_SIZE_impl(const PyObject *op)
+{
+    _PyObject_ASSERT((PyObject *)op, PyTuple_Check(op));
+    return Py_SIZE(op);
+
+}
+
+Py_ssize_t
 PyTuple_Size(PyObject *op)
 {
     if (!PyTuple_Check(op)) {
@@ -143,6 +151,14 @@ PyTuple_Size(PyObject *op)
     }
     else
         return Py_SIZE(op);
+}
+
+PyObject*
+_PyTuple_GET_ITEM_impl(const PyObject *op, Py_ssize_t i)
+{
+    _PyObject_ASSERT((PyObject *)op, PyTuple_Check(op));
+    assert(0 <= i && i < Py_SIZE(op));
+    return ((PyTupleObject *)op) -> ob_item[i];
 }
 
 PyObject *


### PR DESCRIPTION
Add a new experimental "_Py_CAPI2" API: opt-in which doesn't leak
implementation details and replace macros with function calls. The
defined is called "_Py_CAPI2" and not "Py_CAPI2" because it must not
be used at this stage. The new API is experiment and can be removed
anytime.

With this API, PyTuple_GET_ITEM() macro becomes a function call and
the implementation uses assertions to check if the first argument is
a tuple and that the index is valid. It should help to investigate
bugs when Python is compiled in debug mode.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35206](https://bugs.python.org/issue35206) -->
https://bugs.python.org/issue35206
<!-- /issue-number -->
