### PR TITLE
bpo-35207: Disallow expressions like (a) = 42

### DIFF
--- a/Lib/test/test_compile.py
+++ b/Lib/test/test_compile.py
@@ -30,6 +30,10 @@ class TestSpecifics(unittest.TestCase):
         compile("hi\r\nstuff\r\ndef f():\n    pass\r", "<test>", "exec")
         compile("this_is\rreally_old_mac\rdef f():\n    pass", "<test>", "exec")
 
+    def test_assignment_to_name_surrounded_by_parentheses(self):
+        self.assertRaises(SyntaxError, compile, '(x) = 1', '?', 'single')
+        self.assertRaises(SyntaxError, compile, 'x=1; (x) += 1', '?', 'single')
+
     def test_debug_assignment(self):
         # catch assignments to __debug__
         self.assertRaises(SyntaxError, compile, '__debug__ = 1', '?', 'single')

--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-10-04-18-37.bpo-35207.VS2LZH.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-10-04-18-37.bpo-35207.VS2LZH.rst
@@ -1,0 +1,2 @@
+Assignments to single names surrounded by parenthesis (i.e. :code:`(x) =
+42`) now raises :exc:`SyntaxError`.


### PR DESCRIPTION
As commented initially in [bpo-33878](https://bugs.python.org/issue33878), the fact that expressions like
(x) = 42 are accepted is, in reality, an implementation detail and
they should be disallowed.


I am not sure if this is the cleanest/simplest implementation...if you think there is a better way to do this I am happy to change the Pull Request :)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35207](https://bugs.python.org/issue35207) -->
https://bugs.python.org/issue35207
<!-- /issue-number -->
