### PR TITLE
bpo-35210: Use bytes + memoryview + resize instead of bytesarray + array in io.RawIOBase.read

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-10-19-26-00.bpo-35210.nhRfM4.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-10-19-26-00.bpo-35210.nhRfM4.rst
@@ -1,0 +1,2 @@
+Use bytes + memoryview + resize instead of bytesarray + bytes in
+io.RawIOBase.read


### PR DESCRIPTION


<!-- issue-number: [bpo-35210](https://bugs.python.org/issue35210) -->
https://bugs.python.org/issue35210
<!-- /issue-number -->
