### PR TITLE
bpo-34160: Make sorting attributes in XML serialization optional.

### DIFF
--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -161,7 +161,7 @@ module documentation.  This section lists the differences between the API and
    encoding. Encoding this string in an encoding other than UTF-8 is
    likely incorrect, since UTF-8 is the default encoding of XML.
 
-   The *sort_attrs* argument behaves like the corresponding arguments of
+   The *sort_attrs* argument behaves like the corresponding argument of
    :meth:`writexml`.
 
    .. versionchanged:: 3.8

--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -173,7 +173,7 @@ module documentation.  This section lists the differences between the API and
    indentation string and defaults to a tabulator; *newl* specifies the string
    emitted at the end of each line and defaults to ``\n``.
 
-   The *encoding* and *sort_attrs* argument behave like the corresponding
+   The *encoding* and *sort_attrs* arguments behave like the corresponding
    arguments of :meth:`toxml`.
 
    .. versionchanged:: 3.8

--- a/Doc/library/xml.dom.minidom.rst
+++ b/Doc/library/xml.dom.minidom.rst
@@ -132,7 +132,7 @@ module documentation.  This section lists the differences between the API and
           ... # Work with dom.
 
 
-.. method:: Node.writexml(writer, indent="", addindent="", newl="")
+.. method:: Node.writexml(writer, indent="", addindent="", newl="", *, sort_attrs=True)
 
    Write XML to the writer object.  The writer should have a :meth:`write` method
    which matches that of the file object interface.  The *indent* parameter is the
@@ -143,11 +143,13 @@ module documentation.  This section lists the differences between the API and
    For the :class:`Document` node, an additional keyword argument *encoding* can
    be used to specify the encoding field of the XML header.
 
-   .. versionchanged:: 3.8
-      The :meth:`writexml` method now preserves the attribute order specified
-      by the user.
+   If *sort_attrs* is true (by default), then element attributes will be
+   written in lexical order.
 
-.. method:: Node.toxml(encoding=None)
+   .. versionchanged:: 3.8
+      Added support for the *sort_attrs* argument.
+
+.. method:: Node.toxml(encoding=None, *, sort_attrs=True)
 
    Return a string or byte string containing the XML represented by
    the DOM node.
@@ -159,22 +161,23 @@ module documentation.  This section lists the differences between the API and
    encoding. Encoding this string in an encoding other than UTF-8 is
    likely incorrect, since UTF-8 is the default encoding of XML.
 
-   .. versionchanged:: 3.8
-      The :meth:`toxml` method now preserves the attribute order specified
-      by the user.
+   The *sort_attrs* argument behaves like the corresponding arguments of
+   :meth:`writexml`.
 
-.. method:: Node.toprettyxml(indent="", newl="", encoding="")
+   .. versionchanged:: 3.8
+      Added support for the *sort_attrs* argument.
+
+.. method:: Node.toprettyxml(indent="", newl="", encoding="", *, sort_attrs=True)
 
    Return a pretty-printed version of the document. *indent* specifies the
    indentation string and defaults to a tabulator; *newl* specifies the string
    emitted at the end of each line and defaults to ``\n``.
 
-   The *encoding* argument behaves like the corresponding argument of
-   :meth:`toxml`.
+   The *encoding* and *sort_attrs* argument behave like the corresponding
+   arguments of :meth:`toxml`.
 
    .. versionchanged:: 3.8
-      The :meth:`toprettyxml` method now preserves the attribute order specified
-      by the user.
+      Added support for the *sort_attrs* argument.
 
 
 .. _dom-example:

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -599,7 +599,7 @@ Functions
    the output encoding (default is US-ASCII).  Use ``encoding="unicode"`` to
    generate a Unicode string (otherwise, a bytestring is generated).  *method*
    is either ``"xml"``, ``"html"`` or ``"text"`` (default is ``"xml"``).
-   *short_empty_elements* and *sort_attrs* has the same meaning as in
+   *short_empty_elements* and *sort_attrs* have the same meaning as in
    :meth:`ElementTree.write`.
    Returns an (optionally) encoded string containing the XML data.
 

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -618,7 +618,7 @@ Functions
    the output encoding (default is US-ASCII).  Use ``encoding="unicode"`` to
    generate a Unicode string (otherwise, a bytestring is generated).  *method*
    is either ``"xml"``, ``"html"`` or ``"text"`` (default is ``"xml"``).
-   *short_empty_elements* and *sort_attrs* has the same meaning as in
+   *short_empty_elements* and *sort_attrs* have the same meaning as in
    :meth:`ElementTree.write`.
    Returns a list of (optionally) encoded strings containing the XML data.
    It does not guarantee any specific sequence, except that

--- a/Doc/library/xml.etree.elementtree.rst
+++ b/Doc/library/xml.etree.elementtree.rst
@@ -592,29 +592,34 @@ Functions
 
 
 .. function:: tostring(element, encoding="us-ascii", method="xml", *, \
-                       short_empty_elements=True)
+                       short_empty_elements=True, sort_attrs=True)
 
    Generates a string representation of an XML element, including all
    subelements.  *element* is an :class:`Element` instance.  *encoding* [1]_ is
    the output encoding (default is US-ASCII).  Use ``encoding="unicode"`` to
    generate a Unicode string (otherwise, a bytestring is generated).  *method*
    is either ``"xml"``, ``"html"`` or ``"text"`` (default is ``"xml"``).
-   *short_empty_elements* has the same meaning as in :meth:`ElementTree.write`.
+   *short_empty_elements* and *sort_attrs* has the same meaning as in
+   :meth:`ElementTree.write`.
    Returns an (optionally) encoded string containing the XML data.
 
    .. versionadded:: 3.4
       The *short_empty_elements* parameter.
 
+   .. versionadded:: 3.8
+      The *sort_attrs* parameter.
+
 
 .. function:: tostringlist(element, encoding="us-ascii", method="xml", *, \
-                           short_empty_elements=True)
+                           short_empty_elements=True, sort_attrs=True)
 
    Generates a string representation of an XML element, including all
    subelements.  *element* is an :class:`Element` instance.  *encoding* [1]_ is
    the output encoding (default is US-ASCII).  Use ``encoding="unicode"`` to
    generate a Unicode string (otherwise, a bytestring is generated).  *method*
    is either ``"xml"``, ``"html"`` or ``"text"`` (default is ``"xml"``).
-   *short_empty_elements* has the same meaning as in :meth:`ElementTree.write`.
+   *short_empty_elements* and *sort_attrs* has the same meaning as in
+   :meth:`ElementTree.write`.
    Returns a list of (optionally) encoded strings containing the XML data.
    It does not guarantee any specific sequence, except that
    ``b"".join(tostringlist(element)) == tostring(element)``.
@@ -623,6 +628,9 @@ Functions
 
    .. versionadded:: 3.4
       The *short_empty_elements* parameter.
+
+   .. versionadded:: 3.8
+      The *sort_attrs* parameter.
 
 
 .. function:: XML(text, parser=None)
@@ -925,7 +933,7 @@ ElementTree Objects
 
    .. method:: write(file, encoding="us-ascii", xml_declaration=None, \
                      default_namespace=None, method="xml", *, \
-                     short_empty_elements=True)
+                     short_empty_elements=True, sort_attrs=True)
 
       Writes the element tree to a file, as XML.  *file* is a file name, or a
       :term:`file object` opened for writing.  *encoding* [1]_ is the output
@@ -940,6 +948,8 @@ ElementTree Objects
       of elements that contain no content.  If ``True`` (the default), they are
       emitted as a single self-closed tag, otherwise they are emitted as a pair
       of start/end tags.
+      If *sort_attrs* is true (by default), then element attributes will be
+      written in lexical order.
 
       The output is either a string (:class:`str`) or binary (:class:`bytes`).
       This is controlled by the *encoding* argument.  If *encoding* is
@@ -951,9 +961,8 @@ ElementTree Objects
       .. versionadded:: 3.4
          The *short_empty_elements* parameter.
 
-      .. versionchanged:: 3.8
-         The :meth:`write` method now preserves the attribute order specified
-         by the user.
+      .. versionadded:: 3.8
+         The *sort_attrs* parameter.
 
 
 This is the XML file that is going to be manipulated::

--- a/Lib/test/test_minidom.py
+++ b/Lib/test/test_minidom.py
@@ -1567,17 +1567,26 @@ class MinidomTest(unittest.TestCase):
         doc = parseString(xml_str)
         output = io.StringIO()
         doc.writexml(output)
+        self.assertEqual(output.getvalue(),
+            '<?xml version="1.0" ?><curriculum company="example" status="public"/>')
+        output = io.StringIO()
+        doc.writexml(output, sort_attrs=False)
         self.assertEqual(output.getvalue(), xml_str)
 
     def test_toxml_with_attributes_ordered(self):
         xml_str = '<?xml version="1.0" ?><curriculum status="public" company="example"/>'
         doc = parseString(xml_str)
-        self.assertEqual(doc.toxml(), xml_str)
+        self.assertEqual(doc.toxml(),
+            '<?xml version="1.0" ?><curriculum company="example" status="public"/>')
+        self.assertEqual(doc.toxml(sort_attrs=False), xml_str)
 
     def test_toprettyxml_with_attributes_ordered(self):
         xml_str = '<?xml version="1.0" ?><curriculum status="public" company="example"/>'
         doc = parseString(xml_str)
         self.assertEqual(doc.toprettyxml(),
+                         '<?xml version="1.0" ?>\n'
+                         '<curriculum company="example" status="public"/>\n')
+        self.assertEqual(doc.toprettyxml(sort_attrs=False),
                          '<?xml version="1.0" ?>\n'
                          '<curriculum status="public" company="example"/>\n')
 

--- a/Lib/test/test_xml_etree.py
+++ b/Lib/test/test_xml_etree.py
@@ -1054,10 +1054,15 @@ class ElementTreeTest(unittest.TestCase):
 
     def test_tree_write_attribute_order(self):
         # See BPO 34160
-        root = ET.Element('cirriculum', status='public', company='example')
+        root = ET.XML('<cirriculum status="public" company="example"></cirriculum>')
+        #root = ET.Element('cirriculum', status='public', company='example')
         self.assertEqual(serialize(root),
+                         '<cirriculum company="example" status="public" />')
+        self.assertEqual(serialize(root, sort_attrs=False),
                          '<cirriculum status="public" company="example" />')
         self.assertEqual(serialize(root, method='html'),
+                '<cirriculum company="example" status="public"></cirriculum>')
+        self.assertEqual(serialize(root, method='html', sort_attrs=False),
                 '<cirriculum status="public" company="example"></cirriculum>')
 
 

--- a/Misc/NEWS.d/next/Library/2018-10-27-21-11-42.bpo-34160.UzyPZf.rst
+++ b/Misc/NEWS.d/next/Library/2018-10-27-21-11-42.bpo-34160.UzyPZf.rst
@@ -1,1 +1,2 @@
-ElementTree and minidom now preserve the attribute order specified by the user.
+Added support for the *sort_attrs* argument in methods for serializing XML in
+modules :mod:`xml.etree.ElementTree` and :mod:`xml.dom.minidom`.


### PR DESCRIPTION


<!-- issue-number: [bpo-34160](https://bugs.python.org/issue34160) -->
https://bugs.python.org/issue34160
<!-- /issue-number -->
