### PR TITLE
[2.7] bpo-21622 ctypes.util find_library walk LD_LIBRARY_PATH (GH-10453)

### DIFF
--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -271,12 +271,14 @@ elif os.name == "posix":
             return res.group(1)
 
         def _findWalk_ldpath(name):
+
             def _is_elf(filepath):
                 try:
                     with open(filepath, 'rb') as fh:
                         return fh.read(4) == b'\x7fELF'
                 except:
                     return False
+
             from glob import glob
 
             if os.path.isabs(name):


### PR DESCRIPTION
Originally, issue was open for case where SONAME wasn't part of binary.

Later updates to the posix search case did include LD_LIBRARY_PATH but were not backported. Additionally, these had reliance on gcc and ldconfig behavior that breaks in some cases. e.g. musl on alpine builds

This provides a find method that walks the LD_LIBRARY_PATH, checks for ELF bytes, and returns the name when found or None, matching the other behavior.

This runs after all prior cases fail, does not rely on SONAME entry, gcc or ldconfig -p behavior.

<!-- issue-number: [bpo-21622](https://bugs.python.org/issue21622) -->
https://bugs.python.org/issue21622
<!-- /issue-number -->
