### PR TITLE
[3.7] bpo-21622 ctypes.util find_library walk LD_LIBRARY_PATH (GH-10460)

### DIFF
--- a/Lib/ctypes/util.py
+++ b/Lib/ctypes/util.py
@@ -306,10 +306,36 @@ elif os.name == "posix":
                 pass  # result will be None
             return result
 
+        def _findWalk_ldpath(name):
+
+            def _is_elf(filepath):
+                try:
+                    with open(filepath, 'rb') as fh:
+                        return fh.read(4) == b'\x7fELF'
+                except:
+                    return False
+
+            from glob import glob
+            if os.path.isabs(name):
+                return name
+            # search LD_LIBRARY_PATH list
+            paths = os.environ.get('LD_LIBRARY_PATH', '').split(':')
+            if paths:
+                for d in paths:
+                    f = os.path.join(d, name)
+                    if _is_elf(f):
+                        return os.path.basename(f)
+                    prefix = os.path.join(d, 'lib'+name)
+                    for suffix in ['.so', '.so.*']:
+                        for f in glob('{0}{1}'.format(prefix, suffix)):
+                            if _is_elf(f):
+                                return os.path.basename(f)
+
         def find_library(name):
             # See issue #9998
             return _findSoname_ldconfig(name) or \
-                   _get_soname(_findLib_gcc(name) or _findLib_ld(name))
+                   _get_soname(_findLib_gcc(name) or _findLib_ld(name)) or \
+                   _findWalk_ldpath(name)
 
 ################################################################
 # test code


### PR DESCRIPTION
Originally, issue was open for case where SONAME wasn't part of binary.

Updates to the posix case did include LD_LIBRARY_PATH, but reliance on gcc and ldconfig behavior breaks in some cases. e.g. musl on alpine builds

This provides a find method that walks the LD_LIBRARY_PATH, checks for ELF bytes, and returns the name when found or None, matching the other behavior.

This runs after all prior cases fail, does not rely on SONAME entry, gcc or ldconfig -p behavior.

<!-- issue-number: [bpo-21622](https://bugs.python.org/issue21622) -->
https://bugs.python.org/issue21622
<!-- /issue-number -->
