### PR TITLE
Neaten the code without any algorithmic change.

### DIFF
--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -701,17 +701,14 @@ static PyObject *
 set_pop(PySetObject *so, PyObject *Py_UNUSED(ignored))
 {
     /* Make sure the search finger is in bounds */
-    setentry *entry, *limit;
+    setentry *entry = so->table + (so->finger & so->mask);
+    setentry *limit = so->table + so->mask;
     PyObject *key;
 
-    assert (PyAnySet_Check(so));
     if (so->used == 0) {
         PyErr_SetString(PyExc_KeyError, "pop from an empty set");
         return NULL;
     }
-
-    entry = so->table + (so->finger & so->mask);
-    limit = so->table + so->mask;
     while (entry->key == NULL || entry->key==dummy) {
         entry++;
         if (entry > limit)


### PR DESCRIPTION
Remove unneeded assertion -- we already know *so* is a PySetObject pointer.
