### PR TITLE
bpo-35220: delete "how do I emulate os.kill" section in Windows FAQ

### DIFF
--- a/Doc/faq/windows.rst
+++ b/Doc/faq/windows.rst
@@ -302,26 +302,6 @@ It defines a function ``kbhit()`` which checks whether a keyboard hit is
 present, and ``getch()`` which gets one character without echoing it.
 
 
-How do I emulate os.kill() in Windows?
---------------------------------------
-
-Prior to Python 2.7 and 3.2, to terminate a process, you can use :mod:`ctypes`:
-
-.. code-block:: python
-
-   import ctypes
-
-   def kill(pid):
-       """kill function for Win32"""
-       kernel32 = ctypes.windll.kernel32
-       handle = kernel32.OpenProcess(1, 0, pid)
-       return (0 != kernel32.TerminateProcess(handle, 0))
-
-In 2.7 and 3.2, :func:`os.kill` is implemented similar to the above function,
-with the additional feature of being able to send :kbd:`Ctrl+C` and :kbd:`Ctrl+Break`
-to console subprocesses which are designed to handle those signals. See
-:func:`os.kill` for further details.
-
 How do I extract the downloaded documentation on Windows?
 ---------------------------------------------------------
 


### PR DESCRIPTION
That section is a tip on how to kill process on Windows for Python prior to 2.7 and 3.2.
3.1 end of support was April 2012 and 2.6 was October 2013, so that hasn't been needed for supported versions of Python for more than 5 years. Beside not being needed anymore for a long time, when I read it with the eyes of a Python profane, it makes Python looks bad, like a language from the past with warts you need to circumvent.
Let's delete that :)

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
