### PR TITLE
Remove outdated reference to PEP 333

### DIFF
--- a/Doc/library/wsgiref.rst
+++ b/Doc/library/wsgiref.rst
@@ -767,7 +767,7 @@ This is a working "Hello World" WSGI application::
    # use a function (note that you're not limited to a function, you can
    # use a class for example). The first argument passed to the function
    # is a dictionary containing CGI-style environment variables and the
-   # second variable is the callable object (see PEP 333).
+   # second variable is the callable object.
    def hello_world_app(environ, start_response):
        status = '200 OK'  # HTTP Status
        headers = [('Content-type', 'text/plain; charset=utf-8')]  # HTTP Headers


### PR DESCRIPTION
PEP 3333 replaced PEP 333 in 3.2, and the application object is already described in the wsgiref.simple_server.make_server reference. PEP 3333 is linked to several times before too.