### PR TITLE
bpo-23930: Add support to parse comma-separated cookies

### DIFF
--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -429,7 +429,7 @@ class Morsel(dict):
 # result, the parsing rules here are less strict.
 #
 
-_LegalKeyChars  = r"\w\d!#%&'~_`><@,:/\$\*\+\-\.\^\|\)\(\?\}\{\="
+_LegalKeyChars  = r"\w\d!#%&'~_`><@:/\$\*\+\-\.\^\|\)\(\?\}\{\="
 _LegalValueChars = _LegalKeyChars + r'\[\]'
 _CookiePattern = re.compile(r"""
     \s*                            # Optional whitespace at start of cookie
@@ -447,7 +447,7 @@ _CookiePattern = re.compile(r"""
     )                                # End of group 'val'
     )?                             # End of optional value group
     \s*                            # Any number of spaces.
-    (\s+|;|$)                      # Ending either at space, semicolon, or EOS.
+    (\s+|;|,|$)                    # Ending either at space, comma, semicolon, or EOS.
     """, re.ASCII | re.VERBOSE)    # re.ASCII may be removed if safe.
 
 

--- a/Lib/http/cookies.py
+++ b/Lib/http/cookies.py
@@ -447,6 +447,8 @@ _CookiePattern = re.compile(r"""
     )                                # End of group 'val'
     )?                             # End of optional value group
     \s*                            # Any number of spaces.
+                                   # We allow comma as separator as some user-agents
+                                   # send badly formed cookies (see bpo-23930)
     (\s+|;|,|$)                    # Ending either at space, comma, semicolon, or EOS.
     """, re.ASCII | re.VERBOSE)    # re.ASCII may be removed if safe.
 

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -220,6 +220,12 @@ class CookieTests(unittest.TestCase):
         with self.assertRaises(cookies.CookieError):
             C.load(rawdata)
 
+    def test_badly_formed_cookies(self):
+        for rawdata in ('a=b; c;d=e', 'a=b; c,d=e'):
+            C = cookies.SimpleCookie()
+            C.load(rawdata)
+            self.assertEquals(dict(C), {})
+
     def test_comma_separator(self):
         rawdata = "a=b,z=zz"  # , is accepted as a cookie separator
         C = cookies.SimpleCookie()

--- a/Lib/test/test_http_cookies.py
+++ b/Lib/test/test_http_cookies.py
@@ -215,10 +215,17 @@ class CookieTests(unittest.TestCase):
                 self.assertEqual(C1.output(), expected_output)
 
     def test_illegal_chars(self):
-        rawdata = "a=b; c,d=e"
+        rawdata = "a=b; c@d=e"
         C = cookies.SimpleCookie()
         with self.assertRaises(cookies.CookieError):
             C.load(rawdata)
+
+    def test_comma_separator(self):
+        rawdata = "a=b,z=zz"  # , is accepted as a cookie separator
+        C = cookies.SimpleCookie()
+        C.load(rawdata)
+        self.assertEqual(C["a"].value, 'b')
+        self.assertEqual(C["z"].value, 'zz')
 
     def test_comment_quoting(self):
         c = cookies.SimpleCookie()

--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-12-23-01-18.bpo-23930.jKAWJO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-12-23-01-18.bpo-23930.jKAWJO.rst
@@ -1,0 +1,1 @@
+Add support for comma-separated cookies (contributed by Rémi Lapeyre).


### PR DESCRIPTION
Some user-agents do not respect RFC 6265 and sends comma-separated
cookies like "a=b,z=zz" when it should be "a=b; z=zz". Until now,
cookies.SimpleCookie would parse this as a unique cookie "a" with value
"b,z=zz".

A comma in the cookie value is explicitly prohibited by RFC 6265 (https://tools.ietf.org/html/rfc6265#section-4.1.1).
If a comma happens to be in the value, it should have been base 64
encoded:

    cookie-pair       = cookie-name "=" cookie-value
    cookie-name       = token
    cookie-value      = *cookie-octet / ( DQUOTE *cookie-octet DQUOTE )
    cookie-octet      = %x21 / %x23-2B / %x2D-3A / %x3C-5B / %x5D-7E
                       ; US-ASCII characters excluding CTLs,
                       ; whitespace DQUOTE, comma, semicolon,
                       ; and backslash

When this happens since the cookie string is invalid and no comma should
be present, a better default is to consider it a separator and to parse
the string as two cookies "a=b" and "z=zz".

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-23930](https://bugs.python.org/issue23930) -->
https://bugs.python.org/issue23930
<!-- /issue-number -->
