### PR TITLE
bpo-35214: Add _Py_ prefix to MEMORY_SANITIZER define

### DIFF
--- a/Include/Python.h
+++ b/Include/Python.h
@@ -56,8 +56,8 @@
 /* A convenient way for code to know if clang's memory sanitizer is enabled. */
 #if defined(__has_feature)
 #  if __has_feature(memory_sanitizer)
-#    if !defined(MEMORY_SANITIZER)
-#      define MEMORY_SANITIZER
+#    if !defined(_Py_MEMORY_SANITIZER)
+#      define _Py_MEMORY_SANITIZER
 #    endif
 #  endif
 #endif

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -75,7 +75,7 @@
 #include <alloca.h>
 #endif
 
-#ifdef MEMORY_SANITIZER
+#ifdef _Py_MEMORY_SANITIZER
 #include <sanitizer/msan_interface.h>
 #endif
 
@@ -1129,7 +1129,7 @@ PyObject *_ctypes_callproc(PPROC pProc,
     rtype = _ctypes_get_ffi_type(restype);
     resbuf = alloca(max(rtype->size, sizeof(ffi_arg)));
 
-#ifdef MEMORY_SANITIZER
+#ifdef _Py_MEMORY_SANITIZER
     /* ffi_call actually initializes resbuf, but from asm, which
      * MemorySanitizer can't detect. Avoid false positives from MSan. */
     if (resbuf != NULL) {

--- a/Modules/_posixsubprocess.c
+++ b/Modules/_posixsubprocess.c
@@ -21,7 +21,7 @@
 #include <dirent.h>
 #endif
 
-#ifdef MEMORY_SANITIZER
+#ifdef _Py_MEMORY_SANITIZER
 # include <sanitizer/msan_interface.h>
 #endif
 
@@ -291,7 +291,7 @@ _close_open_fds_safe(int start_fd, PyObject* py_fds_to_keep)
                                 sizeof(buffer))) > 0) {
             struct linux_dirent64 *entry;
             int offset;
-#ifdef MEMORY_SANITIZER
+#ifdef _Py_MEMORY_SANITIZER
             __msan_unpoison(buffer, bytes);
 #endif
             for (offset = 0; offset < bytes; offset += entry->d_reclen) {

--- a/Objects/fileobject.c
+++ b/Objects/fileobject.c
@@ -3,7 +3,7 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
-#if defined(HAVE_GETC_UNLOCKED) && !defined(MEMORY_SANITIZER)
+#if defined(HAVE_GETC_UNLOCKED) && !defined(_Py_MEMORY_SANITIZER)
 /* clang MemorySanitizer doesn't yet understand getc_unlocked. */
 #define GETC(f) getc_unlocked(f)
 #define FLOCKFILE(f) flockfile(f)

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -20,7 +20,7 @@
 #  endif
 #endif
 
-#ifdef MEMORY_SANITIZER
+#ifdef _Py_MEMORY_SANITIZER
 #  include <sanitizer/msan_interface.h>
 #endif
 
@@ -147,7 +147,7 @@ py_getrandom(void *buffer, Py_ssize_t size, int blocking, int raise)
         else {
             n = syscall(SYS_getrandom, dest, n, flags);
         }
-#  ifdef MEMORY_SANITIZER
+#  ifdef _Py_MEMORY_SANITIZER
         if (n > 0) {
              __msan_unpoison(dest, n);
         }

--- a/Python/pymath.c
+++ b/Python/pymath.c
@@ -17,7 +17,7 @@ double _Py_force_double(double x)
 
 /* inline assembly for getting and setting the 387 FPU control word on
    gcc/x86 */
-#ifdef MEMORY_SANITIZER
+#ifdef _Py_MEMORY_SANITIZER
 __attribute__((no_sanitize_memory))
 #endif
 unsigned short _Py_get_387controlword(void) {


### PR DESCRIPTION
Rename our new `MEMORY_SANITIZER` define to `_Py_MEMORY_SANITIZER`.
Project based C Preprocessor namespacing at its finest. :P

<!-- issue-number: [bpo-35214](https://bugs.python.org/issue35214) -->
https://bugs.python.org/issue35214
<!-- /issue-number -->
