### PR TITLE
bpo-35214: Fix OOB memory access in unicode escape parser

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-13-00-40-35.bpo-35214.OQBjph.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-13-00-40-35.bpo-35214.OQBjph.rst
@@ -1,2 +1,3 @@
-Fixed an out of bounds memory access when parsing a malformed f-string
-ending with ``\N``.
+Fixed an out of bounds memory access when parsing a truncated unicode
+escape sequence at the end of a string such as ``'\N'``.  It would read
+one byte beyond the end of the memory allocation.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-13-00-40-35.bpo-35214.OQBjph.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-13-00-40-35.bpo-35214.OQBjph.rst
@@ -1,0 +1,2 @@
+Fixed an out of bounds memory access when parsing a malformed f-string
+ending with ``\N``.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -6069,7 +6069,7 @@ _PyUnicode_DecodeUnicodeEscape(const char *s,
             }
 
             message = "malformed \\N character escape";
-            if (*s == '{') {
+            if (s < end && *s == '{') {
                 const char *start = ++s;
                 size_t namelen;
                 /* look for the closing brace */


### PR DESCRIPTION
Discovered using clang's MemorySanitizer when it ran
`test_fstring`'s `test_misformed_unicode_character_name`.

An f-string ending in `\N` would access one byte beyond the end of
the string while looking for a potential `}`.

<!-- issue-number: [bpo-35214](https://bugs.python.org/issue35214) -->
https://bugs.python.org/issue35214
<!-- /issue-number -->
