### PR TITLE
[3.7] bpo-35229: Deprecate _PyObject_GC_TRACK()

### DIFF
--- a/Doc/c-api/gcsupport.rst
+++ b/Doc/c-api/gcsupport.rst
@@ -66,6 +66,9 @@ Constructors for container types must conform to two rules:
    A macro version of :c:func:`PyObject_GC_Track`.  It should not be used for
    extension modules.
 
+   .. deprecated:: 3.6
+      This macro is removed from Python 3.8.
+
 Similarly, the deallocator for the object must conform to a similar pair of
 rules:
 
@@ -94,6 +97,9 @@ rules:
 
    A macro version of :c:func:`PyObject_GC_UnTrack`.  It should not be used for
    extension modules.
+
+   .. deprecated:: 3.6
+      This macro is removed from Python 3.8.
 
 The :c:member:`~PyTypeObject.tp_traverse` handler accepts a function parameter of this type:
 


### PR DESCRIPTION
Deprecate _PyObject_GC_TRACK() and _PyObject_GC_UNTRACK() in the
documentation. These macros are removed from Python 3.8 by the commit
1a6be91e6fd65ce9cb88cbbbb193db7e92ec6076.

<!-- issue-number: [bpo-35229](https://bugs.python.org/issue35229) -->
https://bugs.python.org/issue35229
<!-- /issue-number -->
