### PR TITLE
bpo-35236: Add trailing slash to FTP directory path

### DIFF
--- a/Lib/urllib/request.py
+++ b/Lib/urllib/request.py
@@ -2383,7 +2383,7 @@ class ftpwrapper:
         self.ftp = ftplib.FTP()
         self.ftp.connect(self.host, self.port, self.timeout)
         self.ftp.login(self.user, self.passwd)
-        _target = '/'.join(self.dirs)
+        _target = '/'.join(self.dirs) + '/'
         self.ftp.cwd(_target)
 
     def retrfile(self, file, type):

--- a/Misc/NEWS.d/next/Library/2018-11-13-17-43-44.bpo-35236.J5Tbzb.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-13-17-43-44.bpo-35236.J5Tbzb.rst
@@ -1,0 +1,3 @@
+Adds a trailing slash to the FTP directory path when issuing a
+urllib.request.urlopen on a FTP url. This prevents the 'No such file or
+directory' error on some FTP server when the directory is a symlink.


### PR DESCRIPTION
Some FTP servers will not allow changing to a directory if the path does
not end with a slash. For example, try out this in a public FTP:

```python
from ftplib import FTP
ftp = FTP('ftp.unicamp.br')
ftp.login()
ftp.cwd('pub/libreoffice') # throws error
ftp.cwd('pub/libreoffice/') # OK
```

The problem is `urllib.request` doesn't include the trailing slash, thus
throwing an error. This behavior also happens with the command line ftp
client.

I think this happens because the libreoffice directory is a symlink, and
this can be a FTP server specific behavior.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35236](https://bugs.python.org/issue35236) -->
https://bugs.python.org/issue35236
<!-- /issue-number -->
