### PR TITLE
bpo-16438: confusing text regarding numeric precedence corrected

### DIFF
--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -265,7 +265,7 @@ which is narrower than complex.  Comparisons between numbers of mixed type use
 the same rule. [2]_ The constructors :func:`int`, :func:`float`, and
 :func:`complex` can be used to produce numbers of a specific type.
 
-All numeric types (except complex) support the following operations (for priorities of 
+All numeric types (except complex) support the following operations (for priorities of
 the operations, see :ref:`operator-summary`):
 
 +---------------------+---------------------------------+---------+--------------------+

--- a/Doc/library/stdtypes.rst
+++ b/Doc/library/stdtypes.rst
@@ -265,9 +265,8 @@ which is narrower than complex.  Comparisons between numbers of mixed type use
 the same rule. [2]_ The constructors :func:`int`, :func:`float`, and
 :func:`complex` can be used to produce numbers of a specific type.
 
-All numeric types (except complex) support the following operations, sorted by
-ascending priority (all numeric operations have a higher priority than
-comparison operations):
+All numeric types (except complex) support the following operations (for priorities of 
+the operations, see :ref:`operator-summary`):
 
 +---------------------+---------------------------------+---------+--------------------+
 | Operation           | Result                          | Notes   | Full documentation |


### PR DESCRIPTION
No changes to the table, instead reference to the operator precedence
table in expressions page is provided.

A patch was previously submitted by Kiet Tran in 2012 on bpo but it had a small typo.

<!-- issue-number: [bpo-16438](https://bugs.python.org/issue16438) -->
https://bugs.python.org/issue16438
<!-- /issue-number -->
