### PR TITLE
bpo-35233: Rewrite test_embed.InitConfigTests

### DIFF
--- a/Include/coreconfig.h
+++ b/Include/coreconfig.h
@@ -361,6 +361,7 @@ PyAPI_FUNC(int) _PyCoreConfig_GetEnvDup(
 
 /* Used by _testcapi.get_coreconfig() */
 PyAPI_FUNC(PyObject *) _PyCoreConfig_AsDict(const _PyCoreConfig *config);
+PyAPI_FUNC(PyObject *) _Py_GetGlobalVariablesAsDict(void);
 #endif
 
 #ifdef __cplusplus

--- a/Lib/test/pythoninfo.py
+++ b/Lib/test/pythoninfo.py
@@ -535,24 +535,21 @@ def collect_gdbm(info_add):
 
 
 def collect_get_config(info_add):
-    # Dump _PyCoreConfig and _PyMainInterpreterConfig
+    # Dump global configuration variables, _PyCoreConfig
+    # and _PyMainInterpreterConfig
     try:
-        from _testcapi import get_coreconfig
+        from _testcapi import get_global_config, get_core_config, get_main_config
     except ImportError:
-        pass
-    else:
-        config = get_coreconfig()
-        for key in sorted(config):
-            info_add('core_config[%s]' % key, repr(config[key]))
+        return
 
-    try:
-        from _testcapi import get_mainconfig
-    except ImportError:
-        pass
-    else:
-        config = get_mainconfig()
+    for prefix, get_config_func in (
+        ('global_config', get_global_config),
+        ('core_config', get_core_config),
+        ('main_config', get_main_config),
+    ):
+        config = get_config_func()
         for key in sorted(config):
-            info_add('main_config[%s]' % key, repr(config[key]))
+            info_add('%s[%s]' % (prefix, key), repr(config[key]))
 
 
 def collect_info(info):

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -259,6 +259,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     UNTESTED_CORE_CONFIG = (
         'base_exec_prefix',
         'base_prefix',
+        'dll_path',
         'exec_prefix',
         'executable',
         'home',

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -3,15 +3,13 @@ from test import support
 import unittest
 
 from collections import namedtuple
+import json
 import os
 import platform
 import re
 import subprocess
 import sys
 
-
-# AIX libc prints an empty string as '' rather than the string '(null)'
-NULL_STR = '' if platform.system() == 'AIX' else '(null)'
 
 class EmbeddingTestsMixin:
     def setUp(self):
@@ -255,16 +253,31 @@ class EmbeddingTests(EmbeddingTestsMixin, unittest.TestCase):
 
 class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     maxDiff = 4096
-    CORE_CONFIG_REGEX = re.compile(r"^core_config\[([^]]*)\] = (.*)$")
-    MAIN_CONFIG_REGEX = re.compile(r"^main_config\[([^]]*)\] = (.*)$")
     UTF8_MODE_ERRORS = ('surrogatepass' if sys.platform == 'win32'
                         else 'surrogateescape')
+    # FIXME: untested core configuration variables
+    UNTESTED_CORE_CONFIG = (
+        'base_exec_prefix',
+        'base_prefix',
+        'exec_prefix',
+        'executable',
+        'home',
+        'legacy_windows_fs_encoding',
+        'legacy_windows_stdio',
+        'module_search_path_env',
+        'module_search_paths',
+        'prefix',
+    )
+    # FIXME: untested main configuration variables
+    UNTESTED_MAIN_CONFIG = (
+        'module_search_path',
+    )
     DEFAULT_CORE_CONFIG = {
         'install_signal_handlers': 1,
         'use_environment': 1,
         'use_hash_seed': 0,
         'hash_seed': 0,
-        'allocator': NULL_STR,
+        'allocator': None,
         'dev_mode': 0,
         'faulthandler': 0,
         'tracemalloc': 0,
@@ -282,11 +295,13 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'coerce_c_locale': 0,
         'coerce_c_locale_warn': 0,
 
-        'pycache_prefix': NULL_STR,
+        'pycache_prefix': None,
         'program_name': './_testembed',
-        'argc': 0,
-        'argv': '[]',
-        'program': NULL_STR,
+        'argv': [],
+        'program': None,
+
+        'xoptions': [],
+        'warnoptions': [],
 
         'isolated': 0,
         'site_import': 1,
@@ -363,45 +378,66 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
                 expected['filesystem_encoding'] = res[0]
             if expected['filesystem_errors'] is None:
                 expected['filesystem_errors'] = res[1]
-        for key, value in expected.items():
-            expected[key] = str(value)
 
         out, err = self.run_embedded_interpreter(testname, env=env)
         # Ignore err
 
-        core_config = {}
-        main_config = {}
-        for line in out.splitlines():
-            match = self.CORE_CONFIG_REGEX.match(line)
-            if match is not None:
-                key = match.group(1)
-                value = match.group(2)
-                core_config[key] = value
-            else:
-                match = self.MAIN_CONFIG_REGEX.match(line)
-                if match is None:
-                    raise ValueError(f"failed to parse line {line!r}")
-                key = match.group(1)
-                value = match.group(2)
-                main_config[key] = value
-        self.assertEqual(core_config, expected)
+        config = json.loads(out)
+        core_config = config['core_config']
+        executable = core_config['executable']
+        main_config = config['main_config']
 
-        pycache_prefix = core_config['pycache_prefix']
-        if pycache_prefix != NULL_STR:
-            pycache_prefix = repr(pycache_prefix)
-        else:
-            pycache_prefix = "NULL"
+        for key in self.UNTESTED_MAIN_CONFIG:
+            del main_config[key]
+
         expected_main = {
             'install_signal_handlers': core_config['install_signal_handlers'],
-            'argv': '[]',
-            'prefix': repr(sys.prefix),
-            'base_prefix': repr(sys.base_prefix),
-            'base_exec_prefix': repr(sys.base_exec_prefix),
-            'warnoptions': '[]',
-            'xoptions': '{}',
-            'pycache_prefix': pycache_prefix,
+            'argv': [],
+            'prefix': sys.prefix,
+            'executable': core_config['executable'],
+            'base_prefix': sys.base_prefix,
+            'base_exec_prefix': sys.base_exec_prefix,
+            'warnoptions': core_config['warnoptions'],
+            'xoptions': {},
+            'pycache_prefix': core_config['pycache_prefix'],
+            'exec_prefix': core_config['exec_prefix'],
         }
         self.assertEqual(main_config, expected_main)
+
+        expected_global = {}
+        for item in (
+            ('Py_BytesWarningFlag', 'bytes_warning'),
+            ('Py_DebugFlag', 'parser_debug'),
+            ('Py_DontWriteBytecodeFlag', 'write_bytecode', True),
+            ('Py_FileSystemDefaultEncodeErrors', 'filesystem_errors'),
+            ('Py_FileSystemDefaultEncoding', 'filesystem_encoding'),
+            ('Py_FrozenFlag', '_frozen'),
+            ('Py_IgnoreEnvironmentFlag', 'use_environment', True),
+            ('Py_InspectFlag', 'inspect'),
+            ('Py_InteractiveFlag', 'interactive'),
+            ('Py_IsolatedFlag', 'isolated'),
+            ('Py_NoSiteFlag', 'site_import', True),
+            ('Py_NoUserSiteDirectory', 'user_site_directory', True),
+            ('Py_OptimizeFlag', 'optimization_level'),
+            ('Py_QuietFlag', 'quiet'),
+            ('Py_UTF8Mode', 'utf8_mode'),
+            ('Py_UnbufferedStdioFlag', 'buffered_stdio', True),
+            ('Py_VerboseFlag', 'verbose'),
+        ):
+            if len(item) == 3:
+                global_key, core_key, opposite = item
+                expected_global[global_key] = 0 if core_config[core_key] else 1
+            else:
+                global_key, core_key = item
+                expected_global[global_key] = core_config[core_key]
+        expected_global['Py_HasFileSystemDefaultEncoding'] = 0
+        expected_global['_Py_HasFileSystemDefaultEncodeErrors'] = 0
+        expected_global['Py_HashRandomizationFlag'] = 1
+        self.assertEqual(config['global_config'], expected_global)
+
+        for key in self.UNTESTED_CORE_CONFIG:
+            core_config.pop(key, None)
+        self.assertEqual(core_config, expected)
 
     def test_init_default_config(self):
         self.check_config("init_default_config", {})

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -404,8 +404,8 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         }
         self.assertEqual(main_config, expected_main)
 
-        expected_global = {}
-        for item in (
+
+        copy_global_config = [
             ('Py_BytesWarningFlag', 'bytes_warning'),
             ('Py_DebugFlag', 'parser_debug'),
             ('Py_DontWriteBytecodeFlag', 'write_bytecode', True),
@@ -423,13 +423,22 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             ('Py_UTF8Mode', 'utf8_mode'),
             ('Py_UnbufferedStdioFlag', 'buffered_stdio', True),
             ('Py_VerboseFlag', 'verbose'),
-        ):
+        ]
+        if os.name == 'nt':
+            copy_global_config.extend((
+                ('Py_LegacyWindowsFSEncodingFlag', 'legacy_windows_fs_encoding'),
+                ('Py_LegacyWindowsStdioFlag', 'legacy_windows_stdio'),
+            ))
+
+        expected_global = {}
+        for item in copy_global_config:
             if len(item) == 3:
                 global_key, core_key, opposite = item
                 expected_global[global_key] = 0 if core_config[core_key] else 1
             else:
                 global_key, core_key = item
                 expected_global[global_key] = core_config[core_key]
+
         expected_global['Py_HasFileSystemDefaultEncoding'] = 0
         expected_global['_Py_HasFileSystemDefaultEncodeErrors'] = 0
         expected_global['Py_HashRandomizationFlag'] = 1

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4694,7 +4694,14 @@ decode_locale_ex(PyObject *self, PyObject *args)
 
 
 static PyObject *
-get_coreconfig(PyObject *self, PyObject *Py_UNUSED(args))
+get_global_config(PyObject *self, PyObject *Py_UNUSED(args))
+{
+    return _Py_GetGlobalVariablesAsDict();
+}
+
+
+static PyObject *
+get_core_config(PyObject *self, PyObject *Py_UNUSED(args))
 {
     PyInterpreterState *interp = _PyInterpreterState_Get();
     const _PyCoreConfig *config = &interp->core_config;
@@ -4703,7 +4710,7 @@ get_coreconfig(PyObject *self, PyObject *Py_UNUSED(args))
 
 
 static PyObject *
-get_mainconfig(PyObject *self, PyObject *Py_UNUSED(args))
+get_main_config(PyObject *self, PyObject *Py_UNUSED(args))
 {
     PyInterpreterState *interp = _PyInterpreterState_Get();
     const _PyMainInterpreterConfig *config = &interp->config;
@@ -4956,8 +4963,9 @@ static PyMethodDef TestMethods[] = {
     {"bad_get", bad_get, METH_FASTCALL},
     {"EncodeLocaleEx", encode_locale_ex, METH_VARARGS},
     {"DecodeLocaleEx", decode_locale_ex, METH_VARARGS},
-    {"get_coreconfig", get_coreconfig, METH_NOARGS},
-    {"get_mainconfig", get_mainconfig, METH_NOARGS},
+    {"get_global_config", get_global_config, METH_NOARGS},
+    {"get_core_config", get_core_config, METH_NOARGS},
+    {"get_main_config", get_main_config, METH_NOARGS},
 #ifdef Py_REF_DEBUG
     {"negative_refcount", negative_refcount, METH_NOARGS},
 #endif


### PR DESCRIPTION
* Fix _PyCoreConfig_SetGlobalConfig(): set also Py_FrozenFlag
* Fix _PyCoreConfig_AsDict(): export also xoptions
* Add _Py_GetGlobalVariablesAsDict() and _testcapi.get_global_config()
* test.pythoninfo: dump also global configuration variables
* _testembed now serializes global, core and main configurations
  using JSON to reuse _Py_GetGlobalVariablesAsDict(),
  _PyCoreConfig_AsDict() and _PyMainInterpreterConfig_AsDict(),
  rather than duplicating code.
* test_embed.InitConfigTests now test much more configuration
  variables

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35233](https://bugs.python.org/issue35233) -->
https://bugs.python.org/issue35233
<!-- /issue-number -->
