### PR TITLE
bpo-35239: _PySys_EndInit() copies module_search_path

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -331,10 +331,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         })
 
     # main config
-    UNTESTED_MAIN_CONFIG = (
-        # FIXME: untested main configuration variables
-        'module_search_path',
-    )
     COPY_MAIN_CONFIG = (
         # Copy core config to main config for expected values
         'argv',
@@ -346,7 +342,8 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'prefix',
         'pycache_prefix',
         'warnoptions',
-        # xoptions is created from core_config in check_main_config()
+        # xoptions is created from core_config in check_main_config().
+        # 'module_search_paths' is copied to 'module_search_path'.
     )
 
     # global config
@@ -426,12 +423,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         main_config = config['main_config']
 
         # main config
-        for key in self.UNTESTED_MAIN_CONFIG:
-            del main_config[key]
-
         expected_main = {}
         for key in self.COPY_MAIN_CONFIG:
             expected_main[key] = core_config[key]
+        expected_main['module_search_path'] = core_config['module_search_paths']
         expected_main['xoptions'] = self.main_xoptions(core_config['xoptions'])
         self.assertEqual(main_config, expected_main)
 

--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -269,10 +269,6 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'module_search_paths',
         'prefix',
     )
-    # FIXME: untested main configuration variables
-    UNTESTED_MAIN_CONFIG = (
-        'module_search_path',
-    )
     DEFAULT_CORE_CONFIG = {
         'install_signal_handlers': 1,
         'use_environment': 1,
@@ -388,15 +384,13 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         executable = core_config['executable']
         main_config = config['main_config']
 
-        for key in self.UNTESTED_MAIN_CONFIG:
-            del main_config[key]
-
         expected_main = {
             'install_signal_handlers': core_config['install_signal_handlers'],
             'argv': [],
             'prefix': sys.prefix,
             'executable': core_config['executable'],
             'base_prefix': sys.base_prefix,
+            'module_search_path': core_config['module_search_paths'],
             'base_exec_prefix': sys.base_exec_prefix,
             'warnoptions': core_config['warnoptions'],
             'xoptions': {},

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -202,10 +202,9 @@ static int test_pre_initialization_sys_options(void)
     _Py_EMBED_PREINIT_CHECK("Initializing interpreter\n");
     _testembed_Py_Initialize();
     _Py_EMBED_PREINIT_CHECK("Check sys module contents\n");
-    PyRun_SimpleString("import sys; "
+    PyRun_SimpleString("import sys, warnings; "
                        "print('sys.warnoptions:', sys.warnoptions); "
                        "print('sys._xoptions:', sys._xoptions); "
-                       "warnings = sys.modules['warnings']; "
                        "latest_filters = [f[0] for f in warnings.filters[:3]]; "
                        "print('warnings.filters[:3]:', latest_filters)");
     _Py_EMBED_PREINIT_CHECK("Finalizing interpreter\n");

--- a/Programs/_testembed.c
+++ b/Programs/_testembed.c
@@ -202,9 +202,10 @@ static int test_pre_initialization_sys_options(void)
     _Py_EMBED_PREINIT_CHECK("Initializing interpreter\n");
     _testembed_Py_Initialize();
     _Py_EMBED_PREINIT_CHECK("Check sys module contents\n");
-    PyRun_SimpleString("import sys, warnings; "
+    PyRun_SimpleString("import sys; "
                        "print('sys.warnoptions:', sys.warnoptions); "
                        "print('sys._xoptions:', sys._xoptions); "
+                       "warnings = sys.modules['warnings']; "
                        "latest_filters = [f[0] for f in warnings.filters[:3]]; "
                        "print('warnings.filters[:3]:', latest_filters)");
     _Py_EMBED_PREINIT_CHECK("Finalizing interpreter\n");

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -836,8 +836,8 @@ _Py_InitializeMainInterpreter(PyInterpreterState *interp,
     }
 
     /* Initialize warnings. */
-    if (interp->config.warnoptions != NULL &&
-        PyList_Size(interp->config.warnoptions) > 0)
+    PyObject *warnoptions = PySys_GetObject("warnoptions");
+    if (warnoptions != NULL && PyList_Size(warnoptions) > 0)
     {
         PyObject *warnings_module = PyImport_ImportModule("warnings");
         if (warnings_module == NULL) {

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2488,7 +2488,20 @@ _PySys_EndInit(PyObject *sysdict, PyInterpreterState *interp)
     assert(config->exec_prefix != NULL);
     assert(config->base_exec_prefix != NULL);
 
-    SET_SYS_FROM_STRING_BORROW("path", config->module_search_path);
+#define COPY_LIST(KEY, ATTR) \
+    do { \
+        assert(PyList_Check(config->ATTR)); \
+        PyObject *list = PyList_GetSlice(config->ATTR, \
+                                         0, PyList_GET_SIZE(config->ATTR)); \
+        if (list == NULL) { \
+            return -1; \
+        } \
+        SET_SYS_FROM_STRING_BORROW(KEY, list); \
+        Py_DECREF(list); \
+    } while (0)
+
+    COPY_LIST("path", module_search_path);
+
     SET_SYS_FROM_STRING_BORROW("executable", config->executable);
     SET_SYS_FROM_STRING_BORROW("prefix", config->prefix);
     SET_SYS_FROM_STRING_BORROW("base_prefix", config->base_prefix);
@@ -2505,10 +2518,15 @@ _PySys_EndInit(PyObject *sysdict, PyInterpreterState *interp)
         SET_SYS_FROM_STRING_BORROW("argv", config->argv);
     }
     if (config->warnoptions != NULL) {
-        SET_SYS_FROM_STRING_BORROW("warnoptions", config->warnoptions);
+        COPY_LIST("warnoptions", warnoptions);
     }
     if (config->xoptions != NULL) {
-        SET_SYS_FROM_STRING_BORROW("_xoptions", config->xoptions);
+        PyObject *dict = PyDict_Copy(config->xoptions);
+        if (dict == NULL) {
+            return -1;
+        }
+        SET_SYS_FROM_STRING_BORROW("_xoptions", dict);
+        Py_DECREF(dict);
     }
 
     /* Set flags to their final values */

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2529,6 +2529,8 @@ _PySys_EndInit(PyObject *sysdict, PyInterpreterState *interp)
         Py_DECREF(dict);
     }
 
+#undef COPY_LIST
+
     /* Set flags to their final values */
     SET_SYS_FROM_STRING_INT_RESULT("flags", make_flags());
     /* prevent user from creating new instances */


### PR DESCRIPTION
* The _PySys_EndInit() function now copies the
  config->module_search_path list, so config is longer modified when
  sys.path is updated.
* test_embed: InitConfigTests now also tests
  main_config['module_search_path']

<!-- issue-number: [bpo-35239](https://bugs.python.org/issue35239) -->
https://bugs.python.org/issue35239
<!-- /issue-number -->
