### PR TITLE
bpo-34784: Prevent creating types without bases on PyTuple_Pack failure

### DIFF
--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -448,6 +448,7 @@ PyStructSequence_NewType(PyStructSequence_Desc *desc)
 
     bases = PyTuple_Pack(1, &PyTuple_Type);
     if (bases == NULL) {
+        PyMem_FREE(members);
         return NULL;
     }
     type = (PyTypeObject *)PyType_FromSpecWithBases(&spec, bases);
@@ -459,6 +460,7 @@ PyStructSequence_NewType(PyStructSequence_Desc *desc)
 
     if (initialize_structseq_dict(
             desc, type->tp_dict, n_members, n_unnamed_members) < 0) {
+        Py_DECREF(type);
         return NULL;
     }
 

--- a/Objects/structseq.c
+++ b/Objects/structseq.c
@@ -447,6 +447,9 @@ PyStructSequence_NewType(PyStructSequence_Desc *desc)
     spec.slots = slots;
 
     bases = PyTuple_Pack(1, &PyTuple_Type);
+    if (bases == NULL) {
+        return NULL;
+    }
     type = (PyTypeObject *)PyType_FromSpecWithBases(&spec, bases);
     Py_DECREF(bases);
     PyMem_FREE(members);


### PR DESCRIPTION
`PyTuple_Pack` can fail and return `NULL`. If this happens, then `PyType_FromSpecWithBases` will incorrectly create a new type without bases. Also, it will crash on the `Py_DECREF` that follows.

<!-- issue-number: [bpo-34784](https://bugs.python.org/issue34784) -->
https://bugs.python.org/issue34784
<!-- /issue-number -->
