### PR TITLE
[2.7] bpo-35214: Fix OOB memory access in unicode escape parser (GH-10506)

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-13-17-20-18.bpo-35214.AH2F87.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-13-17-20-18.bpo-35214.AH2F87.rst
@@ -1,3 +1,3 @@
 Fixed an out of bounds memory access when parsing a truncated unicode escape
-sequence at the end of a string such as ``'\N'``.  It would read one byte
+sequence at the end of a string such as ``u'\N'``.  It would read one byte
 beyond the end of the memory allocation.

--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-13-17-20-18.bpo-35214.AH2F87.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-13-17-20-18.bpo-35214.AH2F87.rst
@@ -1,0 +1,3 @@
+Fixed an out of bounds memory access when parsing a truncated unicode escape
+sequence at the end of a string such as ``'\N'``.  It would read one byte
+beyond the end of the memory allocation.

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -2950,7 +2950,7 @@ PyObject *PyUnicode_DecodeUnicodeEscape(const char *s,
                 if (ucnhash_CAPI == NULL)
                     goto ucnhashError;
             }
-            if (*s == '{') {
+            if (s < end && *s == '{') {
                 const char *start = s+1;
                 /* look for the closing brace */
                 while (*s != '}' && s < end)


### PR DESCRIPTION
Discovered using clang's MemorySanitizer.

An msan build will fail by simply executing: ./python -c 'u"\N"'
(cherry picked from commit 746b2d35ea47005054ed774fecaed64fab803d7d)

Co-authored-by: Gregory P. Smith <greg@krypto.org> [Google LLC]

<!-- issue-number: [bpo-35214](https://bugs.python.org/issue35214) -->
https://bugs.python.org/issue35214
<!-- /issue-number -->
