### PR TITLE
[3.7] bpo-35233: Fix test_embed.InitConfigTests on macOS

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -287,9 +287,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'Py_VerboseFlag': 0,
     }
     if os.name == 'nt':
-        DEFAULT_GLOBAL_CONFIG['Py_HasFileSystemDefaultEncoding'] = 1
         DEFAULT_GLOBAL_CONFIG['Py_LegacyWindowsFSEncodingFlag'] = 0
         DEFAULT_GLOBAL_CONFIG['Py_LegacyWindowsStdioFlag'] = 0
+    if sys.platform in ('win32', 'darwin'):
+        DEFAULT_GLOBAL_CONFIG['Py_HasFileSystemDefaultEncoding'] = 1
 
     DEFAULT_CORE_CONFIG = {
         'install_signal_handlers': 1,


### PR DESCRIPTION
On macOS and Windows, Py_HasFileSystemDefaultEncoding is 1 by
default.

<!-- issue-number: [bpo-35233](https://bugs.python.org/issue35233) -->
https://bugs.python.org/issue35233
<!-- /issue-number -->
