### PR TITLE
[Skip Issue] Fix a possible reference leak in _socket.getaddrinfo()

### DIFF
--- a/Modules/socketmodule.c
+++ b/Modules/socketmodule.c
@@ -6370,9 +6370,11 @@ socket_getaddrinfo(PyObject *self, PyObject *args, PyObject* kwargs)
         if (single == NULL)
             goto err;
 
-        if (PyList_Append(all, single))
+        if (PyList_Append(all, single)) {
+            Py_DECREF(single);
             goto err;
-        Py_XDECREF(single);
+        }
+        Py_DECREF(single);
     }
     Py_XDECREF(idna);
     if (res0)


### PR DESCRIPTION
"single" needs to be decrefed if PyList_Append() fails.
