### PR TITLE
bpo-35249: Updated Makefile to add quick building option

### DIFF
--- a/Doc/Makefile
+++ b/Doc/Makefile
@@ -191,6 +191,10 @@ autobuild-dev:
 autobuild-dev-html:
 	make html SPHINXOPTS='$(SPHINXOPTS) -Ea -A daily=1 -A switchers=1'
 
+# for quick rebuilds (HTML only)
+quickbuild-dev-html:
+	make html SPHINXOPTS='$(SPHINXOPTS) -A daily=1 -A switchers=1'
+
 # for stable releases: only build if not in pre-release stage (alpha, beta)
 # release candidate downloads are okay, since the stable tree can be in that stage
 autobuild-stable:


### PR DESCRIPTION
When working on the Documentation or when translating it, I often have to rebuild the doc locally to see the changes I made and see how it looks.

However, with the current configuration, It takes (on my computer at least) more than 4 minutes to build.

After investigating, I've found out that the build options on the Makefile of python-docs-fr and of cpython/Docs both have the `E` and `a` options set, which forces a complete rebuild, even when running locally.

https://github.com/python/cpython/blob/9ee1d42f019ac827f73479ce241e95733d050e67/Doc/Makefile#L178-L208
https://github.com/python/python-docs-fr/commit/af8c7a95ab5bc50523ba919c74bb6e6b89d16962

My proposal is to add a `make dev` in the `python-docs-fr` Makefile and add in `cpython/Docs` a mode which will only recompile the needed files.

<!-- issue-number: [bpo-35249](https://bugs.python.org/issue35249) -->
https://bugs.python.org/issue35249
<!-- /issue-number -->
