### PR TITLE
bpo-35252: Remove FIXME from test_functools

### DIFF
--- a/Lib/functools.py
+++ b/Lib/functools.py
@@ -848,9 +848,11 @@ def singledispatch(func):
             # only import typing if annotation parsing is necessary
             from typing import get_type_hints
             argname, cls = next(iter(get_type_hints(func).items()))
-            assert isinstance(cls, type), (
-                f"Invalid annotation for {argname!r}. {cls!r} is not a class."
-            )
+            if not isinstance(cls, type):
+                raise TypeError(
+                    f"Invalid annotation for {argname!r}. "
+                    f"{cls!r} is not a class."
+                )
         registry[cls] = func
         if cache_token is None and hasattr(cls, '__abstractmethods__'):
             cache_token = get_cache_token()

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2296,9 +2296,6 @@ class TestSingleDispatch(unittest.TestCase):
         ))
         self.assertTrue(str(exc.exception).endswith(msg_suffix))
 
-        # FIXME: The following will only work after PEP 560 is implemented.
-        return
-
         with self.assertRaises(TypeError) as exc:
             @i.register
             def _(arg: typing.Iterable[str]):

--- a/Lib/test/test_functools.py
+++ b/Lib/test/test_functools.py
@@ -2304,10 +2304,12 @@ class TestSingleDispatch(unittest.TestCase):
                 # types from `typing`. Instead, annotate with regular types
                 # or ABCs.
                 return "I annotated with a generic collection"
-        self.assertTrue(str(exc.exception).startswith(msg_prefix +
-            "<function TestSingleDispatch.test_invalid_registrations.<locals>._"
+        self.assertTrue(str(exc.exception).startswith(
+            "Invalid annotation for 'arg'."
         ))
-        self.assertTrue(str(exc.exception).endswith(msg_suffix))
+        self.assertTrue(str(exc.exception).endswith(
+            'typing.Iterable[str] is not a class.'
+        ))
 
     def test_invalid_positional_argument(self):
         @functools.singledispatch

--- a/Misc/NEWS.d/next/Library/2019-04-02-19-23-12.bpo-35252.VooTVv.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-02-19-23-12.bpo-35252.VooTVv.rst
@@ -1,0 +1,1 @@
+Throw a TypeError instead of an AssertionError when using a type annotation with singledispatch.

--- a/Misc/NEWS.d/next/Library/2019-04-02-19-23-12.bpo-35252.VooTVv.rst
+++ b/Misc/NEWS.d/next/Library/2019-04-02-19-23-12.bpo-35252.VooTVv.rst
@@ -1,1 +1,1 @@
-Throw a TypeError instead of an AssertionError when using a type annotation with singledispatch.
+Throw a TypeError instead of an AssertionError when using an invalid type annotation with singledispatch.


### PR DESCRIPTION
The FIXME was stopping execution of a test that would only work fine after PEP560 implementation. Now that the PEP is implemented the FIXME should be deleted.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->

<!-- issue-number: [bpo-35252](https://bugs.python.org/issue35252) -->
https://bugs.python.org/issue35252
<!-- /issue-number -->
