### PR TITLE
po-31171: add `-lpthread' to build multiprocessing for linux platform

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1571,8 +1571,10 @@ class PyBuildExt(build_ext):
         elif host_platform.startswith('netbsd'):
             macros = dict()
             libraries = []
-
-        else:                                   # Linux and other unices
+        elif host_platform.startswith(('linux')):
+            macros = dict()
+            libraries = ['pthread']
+        else:                                   # Other unixes
             macros = dict()
             libraries = ['rt']
 
@@ -1590,6 +1592,7 @@ class PyBuildExt(build_ext):
 
         exts.append ( Extension('_multiprocessing', multiprocessing_srcs,
                                 define_macros=list(macros.items()),
+                                libraries=libraries,
                                 include_dirs=["Modules/_multiprocessing"]))
         # End multiprocessing
 


### PR DESCRIPTION
It fixed multiprocessing.BoundedSemaphore of 32-bit python could not work
while cross compiling on linux platform.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
