### PR TITLE
[2.7] bpo-35264: Modules/_ssl.c: fix build with OpenSSL 1.1.0

### DIFF
--- a/Misc/NEWS.d/next/Build/2018-11-16-15-19-09.bpo-35264.h5GxH3.rst
+++ b/Misc/NEWS.d/next/Build/2018-11-16-15-19-09.bpo-35264.h5GxH3.rst
@@ -1,0 +1,1 @@
+Fix SSL module build with OpenSSL 1.1.0

--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -1586,7 +1586,7 @@ static PyObject *PySSL_version(PySSLSocket *self)
     return PyUnicode_FromString(version);
 }
 
-#if defined(OPENSSL_NPN_NEGOTIATED) && !defined(OPENSSL_NO_NEXTPROTONEG)
+#if HAVE_NPN
 static PyObject *PySSL_selected_npn_protocol(PySSLSocket *self) {
     const unsigned char *out;
     unsigned int outlen;
@@ -2114,7 +2114,7 @@ static PyMethodDef PySSLMethods[] = {
      PySSL_peercert_doc},
     {"cipher", (PyCFunction)PySSL_cipher, METH_NOARGS},
     {"version", (PyCFunction)PySSL_version, METH_NOARGS},
-#ifdef OPENSSL_NPN_NEGOTIATED
+#if HAVE_NPN
     {"selected_npn_protocol", (PyCFunction)PySSL_selected_npn_protocol, METH_NOARGS},
 #endif
 #if HAVE_ALPN


### PR DESCRIPTION
Fixes a build error with OpenSSL 1.1.0. There is already code in the
`_ssl.c` that handles all the weird cases of the NPN config macros (with
various OpenSSL & LibreSSL versions).
That code will provide a HAVE_NPN variable, which should be used in the
rest of the code to check whether (or what) to compile regarding NPN.

This change adds HAVE_NPN in the remaining places where it should have been
placed.

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>

<!-- issue-number: [bpo-35264](https://bugs.python.org/issue35264) -->
https://bugs.python.org/issue35264
<!-- /issue-number -->


Automerge-Triggered-By: @tiran