### PR TITLE
[WIP] bpo-35266: Add _PyPreConfig

### DIFF
--- a/Include/coreconfig.h
+++ b/Include/coreconfig.h
@@ -107,13 +107,9 @@ typedef struct {
        If set to -1 (default), inherit Py_UTF8Mode value. */
     int utf8_mode;
 
-    wchar_t *pycache_prefix; /* PYTHONPYCACHEPREFIX, -X pycache_prefix=PATH */
-
-    wchar_t *program_name;  /* Program name, see also Py_GetProgramName() */
     int argc;               /* Number of command line arguments,
                                -1 means unset */
     wchar_t **argv;         /* Command line arguments */
-    wchar_t *program;       /* argv[0] or "" */
 
     int nxoption;           /* Number of -X options */
     wchar_t **xoptions;     /* -X options */
@@ -339,15 +335,54 @@ typedef struct {
 /* Note: _PyCoreConfig_INIT sets other fields to 0/NULL */
 
 
+typedef struct {
+    _PyCoreConfig core_config;
+    wchar_t *program_name;  /* Program name, see also Py_GetProgramName() */
+    wchar_t *program;       /* argv[0] or "" */
+    wchar_t *pycache_prefix; /* PYTHONPYCACHEPREFIX, -X pycache_prefix=PATH */
+} _PyPreConfig;
+
+#define _PyPreConfig_INIT \
+    (_PyPreConfig){.core_config = _PyCoreConfig_INIT}
+/* Note: _PyPreConfig_INIT sets other fields to 0/NULL */
+
+
+typedef struct {
+    _PyCoreConfig core_config;
+    PyObject *argv;                /* sys.argv list, can be NULL */
+    PyObject *program_name;        /* Program name, see also Py_GetProgramName() */
+    PyObject* program;             /* argv[0] or "" */
+    PyObject *executable;          /* sys.executable str */
+    PyObject *prefix;              /* sys.prefix str */
+    PyObject *base_prefix;         /* sys.base_prefix str, can be NULL */
+    PyObject *exec_prefix;         /* sys.exec_prefix str */
+    PyObject *base_exec_prefix;    /* sys.base_exec_prefix str, can be NULL */
+    PyObject *warnoptions;         /* sys.warnoptions list, can be NULL */
+    PyObject *xoptions;            /* sys._xoptions dict, can be NULL */
+    PyObject *module_search_path;  /* sys.path list */
+    PyObject *pycache_prefix;      /* sys.pycache_prefix str, can be NULL */
+} _PyMainInterpreterConfig;
+
+#define _PyMainInterpreterConfig_INIT \
+    (_PyMainInterpreterConfig){ \
+        .core_config = _PyCoreConfig_INIT}
+/* Note: _PyMainInterpreterConfig_INIT sets other fields to 0/NULL */
+
+
 #ifndef Py_LIMITED_API
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_Read(_PyCoreConfig *config);
+PyAPI_FUNC(void) _PyPreConfig_Clear(_PyPreConfig *config);
+PyAPI_FUNC(int) _PyPreConfig_Copy(_PyPreConfig *config,
+    const _PyPreConfig *config2);
+PyAPI_FUNC(_PyInitError) _PyPreConfig_Read(_PyPreConfig *config);
+PyAPI_FUNC(_PyInitError) _PyPreConfig_SetPathConfig(
+    const _PyPreConfig *config);
+
 PyAPI_FUNC(void) _PyCoreConfig_Clear(_PyCoreConfig *);
 PyAPI_FUNC(int) _PyCoreConfig_Copy(
     _PyCoreConfig *config,
     const _PyCoreConfig *config2);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPathConfig(_PyCoreConfig *config);
-PyAPI_FUNC(_PyInitError) _PyCoreConfig_SetPathConfig(
-    const _PyCoreConfig *config);
+PyAPI_FUNC(_PyInitError) _PyCoreConfig_InitPathConfig(
+    _PyPreConfig *preconfig);
 PyAPI_FUNC(void) _PyCoreConfig_GetGlobalConfig(_PyCoreConfig *config);
 PyAPI_FUNC(void) _PyCoreConfig_SetGlobalConfig(const _PyCoreConfig *config);
 PyAPI_FUNC(const char*) _PyCoreConfig_GetEnv(

--- a/Include/internal/pycore_pathconfig.h
+++ b/Include/internal/pycore_pathconfig.h
@@ -58,6 +58,7 @@ PyAPI_FUNC(_PyInitError) _PyPathConfig_SetGlobal(
 
 PyAPI_FUNC(_PyInitError) _PyPathConfig_Calculate_impl(
     _PyPathConfig *config,
+    const _PyPreConfig *pre_config,
     const _PyCoreConfig *core_config);
 PyAPI_FUNC(PyObject*) _PyPathConfig_ComputeArgv0(int argc, wchar_t **argv);
 PyAPI_FUNC(int) _Py_FindEnvConfigValue(

--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -23,16 +23,12 @@ PyAPI_FUNC(int) Py_SetStandardStreamEncoding(const char *encoding,
 
 
 #ifndef Py_LIMITED_API
-/* PEP 432 Multi-phase initialization API (Private while provisional!) */
-PyAPI_FUNC(_PyInitError) _Py_InitializeCore(
-    PyInterpreterState **interp,
-    const _PyCoreConfig *);
 PyAPI_FUNC(int) _Py_IsCoreInitialized(void);
 
 
 PyAPI_FUNC(_PyInitError) _PyMainInterpreterConfig_Read(
     _PyMainInterpreterConfig *config,
-    const _PyCoreConfig *core_config);
+    const _PyPreConfig *preconfig);
 PyAPI_FUNC(void) _PyMainInterpreterConfig_Clear(_PyMainInterpreterConfig *);
 PyAPI_FUNC(int) _PyMainInterpreterConfig_Copy(
     _PyMainInterpreterConfig *config,
@@ -51,7 +47,8 @@ PyAPI_FUNC(void) Py_Initialize(void);
 PyAPI_FUNC(void) Py_InitializeEx(int);
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(_PyInitError) _Py_InitializeFromConfig(
-    const _PyCoreConfig *config);
+    const _PyPreConfig *config,
+    PyInterpreterState **interp_p);
 PyAPI_FUNC(void) _Py_NO_RETURN _Py_FatalInitError(_PyInitError err);
 #endif
 PyAPI_FUNC(void) Py_Finalize(void);

--- a/Include/pystate.h
+++ b/Include/pystate.h
@@ -25,28 +25,6 @@ typedef struct _is PyInterpreterState;
 #else
 typedef PyObject* (*_PyFrameEvalFunction)(struct _frame *, int);
 
-/* Placeholders while working on the new configuration API
- *
- * See PEP 432 for final anticipated contents
- */
-typedef struct {
-    int install_signal_handlers;   /* Install signal handlers? -1 means unset */
-    PyObject *argv;                /* sys.argv list, can be NULL */
-    PyObject *executable;          /* sys.executable str */
-    PyObject *prefix;              /* sys.prefix str */
-    PyObject *base_prefix;         /* sys.base_prefix str, can be NULL */
-    PyObject *exec_prefix;         /* sys.exec_prefix str */
-    PyObject *base_exec_prefix;    /* sys.base_exec_prefix str, can be NULL */
-    PyObject *warnoptions;         /* sys.warnoptions list, can be NULL */
-    PyObject *xoptions;            /* sys._xoptions dict, can be NULL */
-    PyObject *module_search_path;  /* sys.path list */
-    PyObject *pycache_prefix;      /* sys.pycache_prefix str, can be NULL */
-} _PyMainInterpreterConfig;
-
-#define _PyMainInterpreterConfig_INIT \
-    (_PyMainInterpreterConfig){.install_signal_handlers = -1}
-/* Note: _PyMainInterpreterConfig_INIT sets other fields to 0/NULL */
-
 typedef struct _is {
 
     struct _is *next;
@@ -79,7 +57,6 @@ typedef struct _is {
     int codecs_initialized;
     int fscodec_initialized;
 
-    _PyCoreConfig core_config;
     _PyMainInterpreterConfig config;
 #ifdef HAVE_DLOPEN
     int dlopenflags;

--- a/Modules/_testcapimodule.c
+++ b/Modules/_testcapimodule.c
@@ -4704,7 +4704,7 @@ static PyObject *
 get_core_config(PyObject *self, PyObject *Py_UNUSED(args))
 {
     PyInterpreterState *interp = _PyInterpreterState_Get();
-    const _PyCoreConfig *config = &interp->core_config;
+    const _PyCoreConfig *config = &interp->config.core_config;
     return _PyCoreConfig_AsDict(config);
 }
 

--- a/Modules/getpath.c
+++ b/Modules/getpath.c
@@ -561,7 +561,8 @@ calculate_reduce_exec_prefix(PyCalculatePath *calculate, wchar_t *exec_prefix)
 
 
 static _PyInitError
-calculate_program_full_path(const _PyCoreConfig *core_config,
+calculate_program_full_path(const _PyPreConfig *pre_config,
+                            const _PyCoreConfig *core_config,
                             PyCalculatePath *calculate, _PyPathConfig *config)
 {
     wchar_t program_full_path[MAXPATHLEN+1];
@@ -581,8 +582,8 @@ calculate_program_full_path(const _PyCoreConfig *core_config,
      * other way to find a directory to start the search from.  If
      * $PATH isn't exported, you lose.
      */
-    if (wcschr(core_config->program_name, SEP)) {
-        wcsncpy(program_full_path, core_config->program_name, MAXPATHLEN);
+    if (wcschr(pre_config->program_name, SEP)) {
+        wcsncpy(program_full_path, pre_config->program_name, MAXPATHLEN);
     }
 #ifdef __APPLE__
      /* On Mac OS X, if a script uses an interpreter of the form
@@ -624,7 +625,7 @@ calculate_program_full_path(const _PyCoreConfig *core_config,
                 wcsncpy(program_full_path, path, MAXPATHLEN);
             }
 
-            joinpath(program_full_path, core_config->program_name);
+            joinpath(program_full_path, pre_config->program_name);
             if (isxfile(program_full_path)) {
                 break;
             }
@@ -934,12 +935,13 @@ calculate_free(PyCalculatePath *calculate)
 
 
 static _PyInitError
-calculate_path_impl(const _PyCoreConfig *core_config,
+calculate_path_impl(const _PyPreConfig *pre_config,
+                    const _PyCoreConfig *core_config,
                     PyCalculatePath *calculate, _PyPathConfig *config)
 {
     _PyInitError err;
 
-    err = calculate_program_full_path(core_config, calculate, config);
+    err = calculate_program_full_path(pre_config, core_config, calculate, config);
     if (_Py_INIT_FAILED(err)) {
         return err;
     }
@@ -993,7 +995,9 @@ calculate_path_impl(const _PyCoreConfig *core_config,
 
 
 _PyInitError
-_PyPathConfig_Calculate_impl(_PyPathConfig *config, const _PyCoreConfig *core_config)
+_PyPathConfig_Calculate_impl(_PyPathConfig *path_config,
+                             const _PyPreConfig *pre_config,
+                             const _PyCoreConfig *core_config)
 {
     PyCalculatePath calculate;
     memset(&calculate, 0, sizeof(calculate));
@@ -1003,7 +1007,8 @@ _PyPathConfig_Calculate_impl(_PyPathConfig *config, const _PyCoreConfig *core_co
         goto done;
     }
 
-    err = calculate_path_impl(core_config, &calculate, config);
+    err = calculate_path_impl(pre_config, core_config,
+                              &calculate, path_config);
     if (_Py_INIT_FAILED(err)) {
         goto done;
     }

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -1097,6 +1097,7 @@ pymain_run_file(_PyMain *pymain, _PyMainInterpreterConfig *config, PyCompilerFla
         else {
             PySys_WriteStderr("<undecodable filename>");
         }
+        PySys_WriteStderr(": can't open file [Errno %d]", err);
 
         PyObject* errmsg_obj;
         char *errmsg = strerror(err);
@@ -1107,11 +1108,11 @@ pymain_run_file(_PyMain *pymain, _PyMainInterpreterConfig *config, PyCompilerFla
             errmsg_obj = NULL;
         }
         if (errmsg_obj != NULL) {
-            PySys_FormatStderr(": [Errno %d] %U\n", err, errmsg_obj);
+            PySys_FormatStderr(" %U\n", errmsg_obj);
             Py_DECREF(errmsg_obj);
         }
         else {
-            PySys_WriteStderr(": [Errno %d]\n", err);
+            PySys_WriteStderr("\n");
         }
 
         pymain->status = 2;

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -3466,7 +3466,7 @@ PyObject *
 PyUnicode_EncodeFSDefault(PyObject *unicode)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
-    const _PyCoreConfig *config = &interp->core_config;
+    const _PyCoreConfig *config = &interp->config.core_config;
 #if defined(__APPLE__)
     return _PyUnicode_AsUTF8String(unicode, config->filesystem_errors);
 #else
@@ -3690,7 +3690,7 @@ PyObject*
 PyUnicode_DecodeFSDefaultAndSize(const char *s, Py_ssize_t size)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
-    const _PyCoreConfig *config = &interp->core_config;
+    const _PyCoreConfig *config = &interp->config.core_config;
 #if defined(__APPLE__)
     return PyUnicode_DecodeUTF8Stateful(s, size, config->filesystem_errors, NULL);
 #else

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -76,6 +76,7 @@ main(int argc, char *argv[])
     }
     text[text_size] = '\0';
 
+    _PyPreConfig preconfig = _PyPreConfig_INIT;
     _PyCoreConfig config = _PyCoreConfig_INIT;
     config.user_site_directory = 0;
     config.site_import = 0;
@@ -85,7 +86,7 @@ main(int argc, char *argv[])
     config._install_importlib = 0;
     config._frozen = 1;
 
-    _PyInitError err = _Py_InitializeFromConfig(&config);
+    _PyInitError err = _Py_InitializeFromConfig(&preconfig, &config, NULL);
     /* No need to call _PyCoreConfig_Clear() since we didn't allocate any
        memory: program_name is a constant string. */
     if (_Py_INIT_FAILED(err)) {

--- a/Programs/_freeze_importlib.c
+++ b/Programs/_freeze_importlib.c
@@ -77,16 +77,16 @@ main(int argc, char *argv[])
     text[text_size] = '\0';
 
     _PyPreConfig preconfig = _PyPreConfig_INIT;
-    _PyCoreConfig config = _PyCoreConfig_INIT;
-    config.user_site_directory = 0;
-    config.site_import = 0;
-    config.use_environment = 0;
-    config.program_name = L"./_freeze_importlib";
+    _PyCoreConfig *config = &preconfig.core_config;
+    config->user_site_directory = 0;
+    config->site_import = 0;
+    config->use_environment = 0;
+    preconfig.program_name = L"./_freeze_importlib";
     /* Don't install importlib, since it could execute outdated bytecode. */
-    config._install_importlib = 0;
-    config._frozen = 1;
+    config->_install_importlib = 0;
+    config->_frozen = 1;
 
-    _PyInitError err = _Py_InitializeFromConfig(&preconfig, &config, NULL);
+    _PyInitError err = _Py_InitializeFromConfig(&preconfig, NULL);
     /* No need to call _PyCoreConfig_Clear() since we didn't allocate any
        memory: program_name is a constant string. */
     if (_Py_INIT_FAILED(err)) {

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -2759,7 +2759,7 @@ _PyBuiltin_Init(void)
 {
     PyObject *mod, *dict, *debug;
 
-    const _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->core_config;
+    const _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->config.core_config;
 
     if (PyType_Ready(&PyFilter_Type) < 0 ||
         PyType_Ready(&PyMap_Type) < 0 ||

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -41,8 +41,8 @@ Py_FrozenMain(int argc, char **argv)
         }
     }
 
-    _PyCoreConfig config = _PyCoreConfig_INIT;
-    config._frozen = 1;   /* Suppress errors from getpath.c */
+    _PyPreConfig preconfig = _PyPreConfig_INIT;
+    preconfig.core_config._frozen = 1;   /* Suppress errors from getpath.c */
 
     if ((p = Py_GETENV("PYTHONINSPECT")) && *p != '\0')
         inspect = 1;
@@ -82,7 +82,7 @@ Py_FrozenMain(int argc, char **argv)
     if (argc >= 1)
         Py_SetProgramName(argv_copy[0]);
 
-    err = _Py_InitializeFromConfig(&config);
+    err = _Py_InitializeFromConfig(&preconfig, NULL);
     /* No need to call _PyCoreConfig_Clear() since we didn't allocate any
        memory: program_name is a constant string. */
     if (_Py_INIT_FAILED(err)) {

--- a/Python/import.c
+++ b/Python/import.c
@@ -1622,7 +1622,7 @@ import_find_and_load(PyObject *abs_name)
     _Py_IDENTIFIER(_find_and_load);
     PyObject *mod = NULL;
     PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
-    int import_time = interp->core_config.import_time;
+    int import_time = interp->config.core_config.import_time;
     static int import_level;
     static _PyTime_t accumulated;
 
@@ -2279,7 +2279,7 @@ PyInit__imp(void)
     d = PyModule_GetDict(m);
     if (d == NULL)
         goto failure;
-    _PyCoreConfig *config = &_PyInterpreterState_Get()->core_config;
+    _PyCoreConfig *config = &_PyInterpreterState_Get()->config.core_config;
     PyObject *pyc_mode = PyUnicode_FromString(config->_check_hash_pycs_mode);
     if (pyc_mode == NULL) {
         goto failure;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -148,7 +148,6 @@ PyInterpreterState_New(void)
     interp->codec_error_registry = NULL;
     interp->codecs_initialized = 0;
     interp->fscodec_initialized = 0;
-    interp->core_config = _PyCoreConfig_INIT;
     interp->config = _PyMainInterpreterConfig_INIT;
     interp->importlib = NULL;
     interp->import_func = NULL;
@@ -205,7 +204,6 @@ PyInterpreterState_Clear(PyInterpreterState *interp)
     for (p = interp->tstate_head; p != NULL; p = p->next)
         PyThreadState_Clear(p);
     HEAD_UNLOCK();
-    _PyCoreConfig_Clear(&interp->core_config);
     _PyMainInterpreterConfig_Clear(&interp->config);
     Py_CLEAR(interp->codec_search_path);
     Py_CLEAR(interp->codec_search_cache);
@@ -623,7 +621,7 @@ _PyState_ClearModules(void)
 void
 PyThreadState_Clear(PyThreadState *tstate)
 {
-    int verbose = tstate->interp->core_config.verbose;
+    int verbose = tstate->interp->config.core_config.verbose;
 
     if (verbose && tstate->frame != NULL)
         fprintf(stderr,

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -91,7 +91,7 @@ PyRun_InteractiveLoopFlags(FILE *fp, const char *filename_str, PyCompilerFlags *
     PyCompilerFlags local_flags;
     int nomem_count = 0;
 #ifdef Py_REF_DEBUG
-    int show_ref_count = _PyInterpreterState_Get()->core_config.show_ref_count;
+    int show_ref_count = _PyInterpreterState_Get()->config.core_config.show_ref_count;
 #endif
 
     filename = PyUnicode_DecodeFSDefault(filename_str);

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -385,7 +385,7 @@ static PyObject *
 sys_getfilesystemencoding(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
-    const _PyCoreConfig *config = &interp->core_config;
+    const _PyCoreConfig *config = &interp->config.core_config;
     return PyUnicode_FromString(config->filesystem_encoding);
 }
 
@@ -400,7 +400,7 @@ static PyObject *
 sys_getfilesystemencodeerrors(PyObject *self, PyObject *Py_UNUSED(ignored))
 {
     PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
-    const _PyCoreConfig *config = &interp->core_config;
+    const _PyCoreConfig *config = &interp->config.core_config;
     return PyUnicode_FromString(config->filesystem_errors);
 }
 
@@ -1142,7 +1142,7 @@ static PyObject *
 sys_enablelegacywindowsfsencoding(PyObject *self)
 {
     PyInterpreterState *interp = _PyInterpreterState_GET_UNSAFE();
-    _PyCoreConfig *config = &interp->core_config;
+    _PyCoreConfig *config = &interp->config.core_config;
 
     /* Set the filesystem encoding to mbcs/replace (PEP 529) */
     char *encoding = _PyMem_RawStrdup("mbcs");
@@ -2076,7 +2076,7 @@ make_flags(void)
 {
     int pos = 0;
     PyObject *seq;
-    const _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->core_config;
+    const _PyCoreConfig *config = &_PyInterpreterState_GET_UNSAFE()->config.core_config;
 
     seq = PyStructSequence_New(&FlagsType);
     if (seq == NULL)
@@ -2476,7 +2476,7 @@ err_occurred:
 int
 _PySys_EndInit(PyObject *sysdict, PyInterpreterState *interp)
 {
-    const _PyCoreConfig *core_config = &interp->core_config;
+    const _PyCoreConfig *core_config = &interp->config.core_config;
     const _PyMainInterpreterConfig *config = &interp->config;
     int res;
 


### PR DESCRIPTION
* Remove PyInterpreterState.core_config: _PyMainInterpreterConfig now
  has a "_PyCoreConfig core_config" attribute.
* Add _PyPreConfig structure which contains a _PyCoreConfig attriute
* Move program_name, program and pycache_prefix from _PyCoreConfig
  into _PyPreConfig
* Add program_name and program to _PyMainInterpreterConfig
* Py_Main() now uses a _PyPreConfig for early Python intiailization
* _PyPreConfig is destroyed when Python initialization is done

<!-- issue-number: [bpo-35266](https://bugs.python.org/issue35266) -->
https://bugs.python.org/issue35266
<!-- /issue-number -->
