### PR TITLE
[Skip Issue] Add a missed PyErr_NoMemory() in symtable_new()

### DIFF
--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -210,8 +210,10 @@ symtable_new(void)
     struct symtable *st;
 
     st = (struct symtable *)PyMem_Malloc(sizeof(struct symtable));
-    if (st == NULL)
+    if (st == NULL) {
+        PyErr_NoMemory();
         return NULL;
+    }
 
     st->st_filename = NULL;
     st->st_blocks = NULL;


### PR DESCRIPTION
This missed PyErr_NoMemory() could cause a SystemError when calling
_symtable.symtable().
