### PR TITLE
bpo-25438: document what codec PyMemberDef T_STRING decodes the char * as

### DIFF
--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -292,7 +292,8 @@ definition with the same method name.
 
    :attr:`flags` can be ``0`` for write and read access or :c:macro:`READONLY` for
    read-only access.  Using :c:macro:`T_STRING` for :attr:`type` implies
-   :c:macro:`READONLY` and T_STRING will always interpreted as UTF-8 encoded string.  Only :c:macro:`T_OBJECT` and :c:macro:`T_OBJECT_EX`
+   :c:macro:`READONLY`.  :c:macro:`T_STRING` data is interpreted as UTF-8.
+   Only :c:macro:`T_OBJECT` and :c:macro:`T_OBJECT_EX`
    members can be deleted.  (They are set to *NULL*).
 
 

--- a/Doc/c-api/structures.rst
+++ b/Doc/c-api/structures.rst
@@ -292,7 +292,7 @@ definition with the same method name.
 
    :attr:`flags` can be ``0`` for write and read access or :c:macro:`READONLY` for
    read-only access.  Using :c:macro:`T_STRING` for :attr:`type` implies
-   :c:macro:`READONLY`.  Only :c:macro:`T_OBJECT` and :c:macro:`T_OBJECT_EX`
+   :c:macro:`READONLY` and T_STRING will always interpreted as UTF-8 encoded string.  Only :c:macro:`T_OBJECT` and :c:macro:`T_OBJECT_EX`
    members can be deleted.  (They are set to *NULL*).
 
 

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -430,7 +430,7 @@ The reverse operation is also possible::
 This is called, appropriately enough, *sequence unpacking* and works for any
 sequence on the right-hand side.  Sequence unpacking requires that there are as
 many variables on the left side of the equals sign as there are elements in the
-sequence.  Note that multiple assignment is really just a combination of tuple
+sequence.  Note that multiple assignments is really just a combination of tuple
 packing and sequence unpacking.
 
 

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -430,7 +430,7 @@ The reverse operation is also possible::
 This is called, appropriately enough, *sequence unpacking* and works for any
 sequence on the right-hand side.  Sequence unpacking requires that there are as
 many variables on the left side of the equals sign as there are elements in the
-sequence.  Note that multiple assignments is really just a combination of tuple
+sequence.  Note that multiple assignments are really just a combination of tuple
 packing and sequence unpacking.
 
 

--- a/Doc/tutorial/datastructures.rst
+++ b/Doc/tutorial/datastructures.rst
@@ -430,7 +430,7 @@ The reverse operation is also possible::
 This is called, appropriately enough, *sequence unpacking* and works for any
 sequence on the right-hand side.  Sequence unpacking requires that there are as
 many variables on the left side of the equals sign as there are elements in the
-sequence.  Note that multiple assignments are really just a combination of tuple
+sequence.  Note that multiple assignment is really just a combination of tuple
 packing and sequence unpacking.
 
 


### PR DESCRIPTION
Source of T_STRING: https://github.com/python/cpython/blob/e42b705188271da108de42b55d9344642170aa2b/Python/structmember.c#L51

Source of PyUnicode_FromString
https://github.com/python/cpython/blob/master/Include/unicodeobject.h#L702

<!-- issue-number: [bpo-25438](https://bugs.python.org/issue25438) -->
https://bugs.python.org/issue25438
<!-- /issue-number -->
