### PR TITLE
bpo-35269: Fix a possible segfault involving a newly-created coroutine

### DIFF
--- a/Misc/NEWS.d/next/Core and Builtins/2018-11-17-10-18-29.bpo-35269.gjm1LO.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2018-11-17-10-18-29.bpo-35269.gjm1LO.rst
@@ -1,0 +1,2 @@
+Fix a possible segfault involving a newly-created coroutine.  Patch by
+Zackery Spytz.

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1152,8 +1152,7 @@ compute_cr_origin(int origin_depth)
 PyObject *
 PyCoro_New(PyFrameObject *f, PyObject *name, PyObject *qualname)
 {
-    PyCoroObject *coro = (PyCoroObject *)gen_new_with_qualname(
-                         &PyCoro_Type, f, name, qualname);
+    PyObject *coro = gen_new_with_qualname(&PyCoro_Type, f, name, qualname);
     if (!coro) {
         return NULL;
     }
@@ -1162,14 +1161,17 @@ PyCoro_New(PyFrameObject *f, PyObject *name, PyObject *qualname)
     int origin_depth = tstate->coroutine_origin_tracking_depth;
 
     if (origin_depth == 0) {
-        coro->cr_origin = NULL;
-    }
-    else if ((coro->cr_origin = compute_cr_origin(origin_depth)) == NULL) {
-        Py_DECREF(coro);
-        return NULL;
+        ((PyCoroObject *)coro)->cr_origin = NULL;
+    } else {
+        PyObject *cr_origin = compute_cr_origin(origin_depth);
+        ((PyCoroObject *)coro)->cr_origin = cr_origin;
+        if (!cr_origin) {
+            Py_DECREF(coro);
+            return NULL;
+        }
     }
 
-    return (PyObject *)coro;
+    return coro;
 }
 
 

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1152,7 +1152,8 @@ compute_cr_origin(int origin_depth)
 PyObject *
 PyCoro_New(PyFrameObject *f, PyObject *name, PyObject *qualname)
 {
-    PyObject *coro = gen_new_with_qualname(&PyCoro_Type, f, name, qualname);
+    PyCoroObject *coro = (PyCoroObject *)gen_new_with_qualname(
+                         &PyCoro_Type, f, name, qualname);
     if (!coro) {
         return NULL;
     }
@@ -1161,17 +1162,14 @@ PyCoro_New(PyFrameObject *f, PyObject *name, PyObject *qualname)
     int origin_depth = tstate->coroutine_origin_tracking_depth;
 
     if (origin_depth == 0) {
-        ((PyCoroObject *)coro)->cr_origin = NULL;
-    } else {
-        PyObject *cr_origin = compute_cr_origin(origin_depth);
-        if (!cr_origin) {
-            Py_DECREF(coro);
-            return NULL;
-        }
-        ((PyCoroObject *)coro)->cr_origin = cr_origin;
+        coro->cr_origin = NULL;
+    }
+    else if ((coro->cr_origin = compute_cr_origin(origin_depth)) == NULL) {
+        Py_DECREF(coro);
+        return NULL;
     }
 
-    return coro;
+    return (PyObject *)coro;
 }
 
 


### PR DESCRIPTION
coro->cr_origin wasn't initialized if compute_cr_origin() failed in
PyCoro_New(), which would cause a crash during the coroutine's
deallocation.


<!-- issue-number: [bpo-35269](https://bugs.python.org/issue35269) -->
https://bugs.python.org/issue35269
<!-- /issue-number -->
