### PR TITLE
bpo-32281: Fix hardcoded bdist_rpm in Lib/distutils/command/bdist_rpm.py

### DIFF
--- a/Lib/distutils/command/bdist_rpm.py
+++ b/Lib/distutils/command/bdist_rpm.py
@@ -9,6 +9,7 @@ from distutils.debug import DEBUG
 from distutils.util import get_platform
 from distutils.file_util import write_file
 from distutils.errors import *
+from distutils.spawn import find_executable
 from distutils.sysconfig import get_python_version
 from distutils import log
 
@@ -310,8 +311,7 @@ class bdist_rpm(Command):
         # build package
         log.info("building RPMs")
         rpm_cmd = ['rpm']
-        if os.path.exists('/usr/bin/rpmbuild') or \
-           os.path.exists('/bin/rpmbuild'):
+        if find_executable('rpmbuild'):
             rpm_cmd = ['rpmbuild']
 
         if self.source_only: # what kind of RPMs?

--- a/Misc/NEWS.d/next/Library/2018-11-18-22-32-11.bpo-32281.DFs8d3.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-18-22-32-11.bpo-32281.DFs8d3.rst
@@ -1,0 +1,1 @@
+Fix hardcoded rpmbuild paths in Lib/distutils/command/bdist_rpm.py


### PR DESCRIPTION


<!-- issue-number: [bpo-32281](https://bugs.python.org/issue32281) -->
https://bugs.python.org/issue32281
<!-- /issue-number -->
