### PR TITLE
bpo-11122: always use rpmbuild in bdist_rpm

### DIFF
--- a/Lib/distutils/command/bdist_rpm.py
+++ b/Lib/distutils/command/bdist_rpm.py
@@ -309,10 +309,7 @@ class bdist_rpm(Command):
 
         # build package
         log.info("building RPMs")
-        rpm_cmd = ['rpm']
-        if os.path.exists('/usr/bin/rpmbuild') or \
-           os.path.exists('/bin/rpmbuild'):
-            rpm_cmd = ['rpmbuild']
+        rpm_cmd = ['rpmbuild']
 
         if self.source_only: # what kind of RPMs?
             rpm_cmd.append('-bs')

--- a/Misc/NEWS.d/next/Library/2018-11-12-19-08-50.bpo-11122.Gj7BQn.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-12-19-08-50.bpo-11122.Gj7BQn.rst
@@ -1,0 +1,1 @@
+Distutils won't check for rpmbuild in specified paths only.


### PR DESCRIPTION


<!-- issue-number: [bpo-11122](https://bugs.python.org/issue11122) -->
https://bugs.python.org/issue11122
<!-- /issue-number -->
