### PR TITLE
bpo-24209: Adds IPv6 support when invoking http.server directly.

### DIFF
--- a/Doc/library/http.server.rst
+++ b/Doc/library/http.server.rst
@@ -410,13 +410,17 @@ the previous example, this serves files relative to the current directory::
         python -m http.server 8000
 
 By default, server binds itself to all interfaces.  The option ``-b/--bind``
-specifies a specific address to which it should bind.  For example, the
-following command causes the server to bind to localhost only::
+specifies a specific address to which it should bind. Both IPv4 and IPv6
+addresses are supported. For example, the following command causes the server
+to bind to localhost only::
 
         python -m http.server 8000 --bind 127.0.0.1
 
 .. versionadded:: 3.4
     ``--bind`` argument was introduced.
+
+.. versionadded:: 3.8
+    ``--bind`` argument enhanced to support IPv6
 
 By default, server uses the current directory. The option ``-d/--directory``
 specifies a directory to which it should serve the files. For example,

--- a/Lib/http/server.py
+++ b/Lib/http/server.py
@@ -1226,6 +1226,9 @@ def test(HandlerClass=BaseHTTPRequestHandler,
     """
     server_address = (bind, port)
 
+    if ':' in bind:
+        ServerClass.address_family = socket.AF_INET6
+
     HandlerClass.protocol_version = protocol
     with ServerClass(server_address, HandlerClass) as httpd:
         sa = httpd.socket.getsockname()

--- a/Lib/test/test_httpservers.py
+++ b/Lib/test/test_httpservers.py
@@ -9,6 +9,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer, \
 from http import server, HTTPStatus
 
 import os
+import socket
 import sys
 import re
 import base64
@@ -1116,6 +1117,24 @@ class MiscTestCase(unittest.TestCase):
         self.assertCountEqual(server.__all__, expected)
 
 
+class ScriptTestCase(unittest.TestCase):
+    @mock.patch('builtins.print')
+    def test_server_test_ipv6(self, _):
+        mock_server = mock.MagicMock()
+        server.test(ServerClass=mock_server, bind="::")
+        self.assertEqual(mock_server.address_family, socket.AF_INET6)
+
+        mock_server.reset_mock()
+        server.test(ServerClass=mock_server,
+                    bind="2001:0db8:85a3:0000:0000:8a2e:0370:7334")
+        self.assertEqual(mock_server.address_family, socket.AF_INET6)
+
+        mock_server.reset_mock()
+        server.test(ServerClass=mock_server,
+                    bind="::1")
+        self.assertEqual(mock_server.address_family, socket.AF_INET6)
+
+
 def test_main(verbose=None):
     cwd = os.getcwd()
     try:
@@ -1127,6 +1146,7 @@ def test_main(verbose=None):
             CGIHTTPServerTestCase,
             SimpleHTTPRequestHandlerTestCase,
             MiscTestCase,
+            ScriptTestCase
         )
     finally:
         os.chdir(cwd)

--- a/Misc/NEWS.d/next/Library/2018-11-18-18-44-40.bpo-24209.p3YWOf.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-18-18-44-40.bpo-24209.p3YWOf.rst
@@ -1,0 +1,1 @@
+Adds IPv6 support when invoking http.server directly.


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-24209](https://bugs.python.org/issue24209) -->
https://bugs.python.org/issue24209
<!-- /issue-number -->
