### PR TITLE
[3.7] bpo-35233: test_embed: fix filesystem encoding

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -492,6 +492,8 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
             'faulthandler': 1,
         }
         global_config = {
+            'Py_FileSystemDefaultEncodeErrors': self.UTF8_MODE_ERRORS,
+            'Py_FileSystemDefaultEncoding': 'utf-8',
             'Py_NoUserSiteDirectory': 0,
         }
         self.check_config("init_from_config", core_config, global_config)
@@ -510,13 +512,13 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         }
         global_config = {
             'Py_DontWriteBytecodeFlag': 1,
+            'Py_FileSystemDefaultEncodeErrors': self.UTF8_MODE_ERRORS,
+            'Py_FileSystemDefaultEncoding': 'utf-8',
             'Py_InspectFlag': 1,
             'Py_NoUserSiteDirectory': 1,
             'Py_OptimizeFlag': 2,
             'Py_UnbufferedStdioFlag': 1,
             'Py_VerboseFlag': 1,
-            'Py_FileSystemDefaultEncoding': 'utf-8',
-            'Py_FileSystemDefaultEncodeErrors': self.UTF8_MODE_ERRORS,
         }
         self.check_config("init_env", core_config, global_config)
 


### PR DESCRIPTION
Fix InitConfigTests: if utf8_mode is enabled, the expected filesystem
encoding is UTF-8.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35233](https://bugs.python.org/issue35233) -->
https://bugs.python.org/issue35233
<!-- /issue-number -->
