### PR TITLE
bpo-35282: Add a return value to lib2to3.refactor_file and refactor_dir

### DIFF
--- a/Lib/lib2to3/refactor.py
+++ b/Lib/lib2to3/refactor.py
@@ -301,7 +301,7 @@ class RefactoringTool(object):
                     os.path.splitext(name)[1] == py_ext):
                     fullname = os.path.join(dirpath, name)
                     if self.refactor_file(fullname, write, doctests_only):
-                      changed.append(fullname)
+                        changed.append(fullname)
             # Modify dirnames in-place to remove subdirs with leading dots
             dirnames[:] = [dn for dn in dirnames if not dn.startswith(".")]
         return changed

--- a/Lib/lib2to3/refactor.py
+++ b/Lib/lib2to3/refactor.py
@@ -323,7 +323,13 @@ class RefactoringTool(object):
             return f.read(), encoding
 
     def refactor_file(self, filename, write=False, doctests_only=False):
-        """Refactors a file."""
+        """Refactors a file.
+
+        Returns:
+          True: if the file was modified.
+          False: if the file was not modified.
+          None: if the file could not be read.
+        """
         input, encoding = self._read_python_source(filename)
         if input is None:
             # Reading the file failed.

--- a/Lib/lib2to3/tests/test_refactor.py
+++ b/Lib/lib2to3/tests/test_refactor.py
@@ -196,7 +196,7 @@ from __future__ import print_function"""
         write_unchanged = options and options.get(
             "write_unchanged_files", False)
         if expected_return and not write_unchanged:
-          self.assertNotEqual(old_contents, new_contents)
+            self.assertNotEqual(old_contents, new_contents)
         self.assertEqual(ret, expected_return)
         return new_contents
 

--- a/Misc/NEWS.d/next/Library/2018-11-20-14-31-36.bpo-35282.uimIBv.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-20-14-31-36.bpo-35282.uimIBv.rst
@@ -1,0 +1,6 @@
+:func: `lib2to3.refactor.refactor_file` now returns a status: * True: The
+file was written to. * False: The file was not written to. * None: The file
+could not be read.
+
+:func: `lib2to3.refactor.refactor_dir` now returns a list of all written
+files.

--- a/Misc/NEWS.d/next/Library/2018-11-20-14-31-36.bpo-35282.uimIBv.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-20-14-31-36.bpo-35282.uimIBv.rst
@@ -1,6 +1,8 @@
-:func: `lib2to3.refactor.refactor_file` now returns a status: * True: The
-file was written to. * False: The file was not written to. * None: The file
-could not be read.
+:func: `lib2to3.refactor.refactor_file` now returns a status:
+
+* True: The file was written to.
+* False: The file was not written to.
+* None: The file could not be read.
 
 :func: `lib2to3.refactor.refactor_dir` now returns a list of all written
 files.

--- a/Misc/NEWS.d/next/Library/2018-11-20-14-31-36.bpo-35282.uimIBv.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-20-14-31-36.bpo-35282.uimIBv.rst
@@ -1,8 +1,10 @@
-:func: `lib2to3.refactor.refactor_file` now returns a status:
+Added return values to lib2to3.refactor functions.
+
+:func:`lib2to3.refactor.refactor_file` now returns a status:
 
 * True: The file was written to.
 * False: The file was not written to.
 * None: The file could not be read.
 
-:func: `lib2to3.refactor.refactor_dir` now returns a list of all written
+:func:`lib2to3.refactor.refactor_dir` now returns a list of all written
 files.


### PR DESCRIPTION
lib2to3.refactor.refactor_file returns None (file read failed), True (file was written to) or False (file was not written to)
lib2to3.refactor.refactor_dir returns a list of changed files 

<!-- issue-number: [bpo-35282](https://bugs.python.org/issue35282) -->
https://bugs.python.org/issue35282
<!-- /issue-number -->
