### PR TITLE
bpo-35259: Limit `Py_FinalizeEx()` to `Py_LIMITED_API >= 0x03060000`

### DIFF
--- a/Include/pylifecycle.h
+++ b/Include/pylifecycle.h
@@ -49,7 +49,9 @@ PyAPI_FUNC(_PyInitError) _Py_InitializeFromConfig(
 PyAPI_FUNC(void) _Py_NO_RETURN _Py_FatalInitError(_PyInitError err);
 #endif
 PyAPI_FUNC(void) Py_Finalize(void);
+#if !defined(Py_LIMITED_API) || Py_LIMITED_API+0 >= 0x03060000
 PyAPI_FUNC(int) Py_FinalizeEx(void);
+#endif
 PyAPI_FUNC(int) Py_IsInitialized(void);
 
 /* Subinterpreter support */

--- a/Misc/NEWS.d/next/C API/2018-11-22-13-52-36.bpo-35259.p07c61.rst
+++ b/Misc/NEWS.d/next/C API/2018-11-22-13-52-36.bpo-35259.p07c61.rst
@@ -1,0 +1,2 @@
+Conditionally declare Py_FinalizeEx(void) (New in 3.6) based on
+Py_LIMITED_API

--- a/Misc/NEWS.d/next/C API/2018-11-22-13-52-36.bpo-35259.p07c61.rst
+++ b/Misc/NEWS.d/next/C API/2018-11-22-13-52-36.bpo-35259.p07c61.rst
@@ -1,2 +1,2 @@
 Conditionally declare :c:func:`Py_FinalizeEx()` (new in 3.6) based on
-Py_LIMITED_API.
+Py_LIMITED_API. Patch by Arthur Neufeld.

--- a/Misc/NEWS.d/next/C API/2018-11-22-13-52-36.bpo-35259.p07c61.rst
+++ b/Misc/NEWS.d/next/C API/2018-11-22-13-52-36.bpo-35259.p07c61.rst
@@ -1,2 +1,2 @@
-Conditionally declare Py_FinalizeEx(void) (New in 3.6) based on
-Py_LIMITED_API
+Conditionally declare :c:func:`Py_FinalizeEx()` (new in 3.6) based on
+Py_LIMITED_API.


### PR DESCRIPTION
Since `Py_FinalizeEx()` is "New in version 3.6", so should not be declared when
`Py_LIMITED_API` is less than `0x03060000`


<!-- issue-number: [bpo-35259](https://bugs.python.org/issue35259) -->
https://bugs.python.org/issue35259
<!-- /issue-number -->
