### PR TITLE
bpo-35081: Move _PyGC_FINALIZED() back to C API

### DIFF
--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -288,10 +288,7 @@ typedef struct {
 #define _PyObject_GC_MAY_BE_TRACKED(obj) \
     (PyObject_IS_GC(obj) && \
         (!PyTuple_CheckExact(obj) || _PyObject_GC_IS_TRACKED(obj)))
-#endif
 
-
-#if defined(Py_BUILD_CORE) || defined(Py_BUILD_CORE_BUILTIN)
 
 /* Bit flags for _gc_prev */
 /* Bit 0 is set when tp_finalize is called */
@@ -324,7 +321,10 @@ typedef struct {
     _PyGCHead_FINALIZED(_Py_AS_GC(o))
 #define _PyGC_SET_FINALIZED(o) \
     _PyGCHead_SET_FINALIZED(_Py_AS_GC(o))
+#endif   /* !defined(Py_LIMITED_API) */
 
+
+#if defined(Py_BUILD_CORE) || defined(Py_BUILD_CORE_BUILTIN)
 /* Tell the GC to track this object.
  *
  * NB: While the object is tracked by the collector, it must be safe to call the


### PR DESCRIPTION
Partially revert commit 1a6be91e6fd65ce9cb88cbbbb193db7e92ec6076,
move back PyGC API from the internal API to the C API:

* _PyGCHead_NEXT(g), _PyGCHead_SET_NEXT(g, p)
* _PyGCHead_PREV(g), _PyGCHead_SET_PREV(g, p)
* _PyGCHead_FINALIZED(g), _PyGCHead_SET_FINALIZED(g)
* _PyGC_FINALIZED(o), _PyGC_SET_FINALIZED(o)
* _PyGC_PREV_MASK_FINALIZED
* _PyGC_PREV_MASK_COLLECTING
* _PyGC_PREV_SHIFT
* _PyGC_PREV_MASK

_PyObject_GC_TRACK(o) and _PyObject_GC_UNTRACK(o) remain in the
internal API.

<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
