### PR TITLE
bpo-35081: Add Include/internal/pycore_object.h

### DIFF
--- a/Include/internal/pycore_object.h
+++ b/Include/internal/pycore_object.h
@@ -1,0 +1,56 @@
+#ifndef Py_INTERNAL_OBJECT_H
+#define Py_INTERNAL_OBJECT_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if !defined(Py_BUILD_CORE) && !defined(Py_BUILD_CORE_BUILTIN)
+#  error "this header requires Py_BUILD_CORE or Py_BUILD_CORE_BUILTIN defined"
+#endif
+
+/* Tell the GC to track this object.
+ *
+ * NB: While the object is tracked by the collector, it must be safe to call the
+ * ob_traverse method.
+ *
+ * Internal note: _PyRuntime.gc.generation0->_gc_prev doesn't have any bit flags
+ * because it's not object header.  So we don't use _PyGCHead_PREV() and
+ * _PyGCHead_SET_PREV() for it to avoid unnecessary bitwise operations.
+ *
+ * The PyObject_GC_Track() function is the public version of this macro.
+ */
+#define _PyObject_GC_TRACK(o) do { \
+        PyGC_Head *g = _Py_AS_GC(o); \
+        if (g->_gc_next != 0) { \
+            Py_FatalError("GC object already tracked"); \
+        } \
+        assert((g->_gc_prev & _PyGC_PREV_MASK_COLLECTING) == 0); \
+        PyGC_Head *last = (PyGC_Head*)(_PyRuntime.gc.generation0->_gc_prev); \
+        _PyGCHead_SET_NEXT(last, g); \
+        _PyGCHead_SET_PREV(g, last); \
+        _PyGCHead_SET_NEXT(g, _PyRuntime.gc.generation0); \
+        _PyRuntime.gc.generation0->_gc_prev = (uintptr_t)g; \
+    } while (0);
+
+/* Tell the GC to stop tracking this object.
+ *
+ * Internal note: This may be called while GC.  So _PyGC_PREV_MASK_COLLECTING must
+ * be cleared.  But _PyGC_PREV_MASK_FINALIZED bit is kept.
+ *
+ * The PyObject_GC_UnTrack() function is the public version of this macro.
+ */
+#define _PyObject_GC_UNTRACK(o) do { \
+        PyGC_Head *g = _Py_AS_GC(o); \
+        PyGC_Head *prev = _PyGCHead_PREV(g); \
+        PyGC_Head *next = _PyGCHead_NEXT(g); \
+        assert(next != NULL); \
+        _PyGCHead_SET_NEXT(prev, next); \
+        _PyGCHead_SET_PREV(next, prev); \
+        g->_gc_next = 0; \
+        g->_gc_prev &= _PyGC_PREV_MASK_FINALIZED; \
+    } while (0);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* !Py_INTERNAL_OBJECT_H */

--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -323,51 +323,6 @@ typedef struct {
     _PyGCHead_SET_FINALIZED(_Py_AS_GC(o))
 #endif   /* !defined(Py_LIMITED_API) */
 
-
-#if defined(Py_BUILD_CORE) || defined(Py_BUILD_CORE_BUILTIN)
-/* Tell the GC to track this object.
- *
- * NB: While the object is tracked by the collector, it must be safe to call the
- * ob_traverse method.
- *
- * Internal note: _PyRuntime.gc.generation0->_gc_prev doesn't have any bit flags
- * because it's not object header.  So we don't use _PyGCHead_PREV() and
- * _PyGCHead_SET_PREV() for it to avoid unnecessary bitwise operations.
- *
- * The PyObject_GC_Track() function is the public version of this macro.
- */
-#define _PyObject_GC_TRACK(o) do { \
-    PyGC_Head *g = _Py_AS_GC(o); \
-    if (g->_gc_next != 0) { \
-        Py_FatalError("GC object already tracked"); \
-    } \
-    assert((g->_gc_prev & _PyGC_PREV_MASK_COLLECTING) == 0); \
-    PyGC_Head *last = (PyGC_Head*)(_PyRuntime.gc.generation0->_gc_prev); \
-    _PyGCHead_SET_NEXT(last, g); \
-    _PyGCHead_SET_PREV(g, last); \
-    _PyGCHead_SET_NEXT(g, _PyRuntime.gc.generation0); \
-    _PyRuntime.gc.generation0->_gc_prev = (uintptr_t)g; \
-    } while (0);
-
-/* Tell the GC to stop tracking this object.
- *
- * Internal note: This may be called while GC.  So _PyGC_PREV_MASK_COLLECTING must
- * be cleared.  But _PyGC_PREV_MASK_FINALIZED bit is kept.
- *
- * The PyObject_GC_UnTrack() function is the public version of this macro.
- */
-#define _PyObject_GC_UNTRACK(o) do { \
-    PyGC_Head *g = _Py_AS_GC(o); \
-    PyGC_Head *prev = _PyGCHead_PREV(g); \
-    PyGC_Head *next = _PyGCHead_NEXT(g); \
-    assert(next != NULL); \
-    _PyGCHead_SET_NEXT(prev, next); \
-    _PyGCHead_SET_PREV(next, prev); \
-    g->_gc_next = 0; \
-    g->_gc_prev &= _PyGC_PREV_MASK_FINALIZED; \
-    } while (0);
-#endif   /* defined(Py_BUILD_CORE) || defined(Py_BUILD_CORE_BUILTIN) */
-
 #ifndef Py_LIMITED_API
 PyAPI_FUNC(PyObject *) _PyObject_GC_Malloc(size_t size);
 PyAPI_FUNC(PyObject *) _PyObject_GC_Calloc(size_t size);

--- a/Modules/_io/bufferedio.c
+++ b/Modules/_io/bufferedio.c
@@ -9,6 +9,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "structmember.h"
 #include "pythread.h"

--- a/Modules/_io/bytesio.c
+++ b/Modules/_io/bytesio.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_object.h"
 #include "structmember.h"       /* for offsetof() */
 #include "_iomodule.h"
 

--- a/Modules/_io/fileio.c
+++ b/Modules/_io/fileio.c
@@ -2,6 +2,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 #include "structmember.h"
 #ifdef HAVE_SYS_TYPES_H
 #include <sys/types.h>

--- a/Modules/_io/iobase.c
+++ b/Modules/_io/iobase.c
@@ -10,6 +10,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 #include "structmember.h"
 #include "_iomodule.h"
 

--- a/Modules/_io/stringio.c
+++ b/Modules/_io/stringio.c
@@ -2,6 +2,7 @@
 #include "Python.h"
 #include "structmember.h"
 #include "pycore_accu.h"
+#include "pycore_object.h"
 #include "_iomodule.h"
 
 /* Implementation note: the buffer is always at least one character longer

--- a/Modules/_io/textio.c
+++ b/Modules/_io/textio.c
@@ -8,6 +8,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 #include "structmember.h"
 #include "_iomodule.h"
 

--- a/Modules/_io/winconsoleio.c
+++ b/Modules/_io/winconsoleio.c
@@ -8,6 +8,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 
 #ifdef MS_WINDOWS
 
@@ -556,7 +557,7 @@ read_console_w(HANDLE handle, DWORD maxlen, DWORD *readlen) {
     Py_BEGIN_ALLOW_THREADS
     DWORD off = 0;
     while (off < maxlen) {
-        DWORD n = (DWORD)-1; 
+        DWORD n = (DWORD)-1;
         DWORD len = min(maxlen - off, BUFSIZ);
         SetLastError(0);
         BOOL res = ReadConsoleW(handle, &buf[off], len, &n, NULL);

--- a/Modules/gcmodule.c
+++ b/Modules/gcmodule.c
@@ -25,6 +25,7 @@
 
 #include "Python.h"
 #include "pycore_context.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 #include "frameobject.h"        /* for PyFrame_ClearFreeList */

--- a/Objects/bytearrayobject.c
+++ b/Objects/bytearrayobject.c
@@ -2,6 +2,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 #include "structmember.h"

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -3,6 +3,7 @@
 #define PY_SSIZE_T_CLEAN
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 

--- a/Objects/call.c
+++ b/Objects/call.c
@@ -1,4 +1,5 @@
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "frameobject.h"
 

--- a/Objects/cellobject.c
+++ b/Objects/cellobject.c
@@ -1,6 +1,7 @@
 /* Cell object implementation */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -1,6 +1,7 @@
 /* Class object implementation (dead now except for methods) */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 #include "structmember.h"

--- a/Objects/descrobject.c
+++ b/Objects/descrobject.c
@@ -1,6 +1,7 @@
 /* Descriptors -- a new, flexible way to describe attributes */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "structmember.h" /* Why is this not included in Python.h? */
 

--- a/Objects/dictobject.c
+++ b/Objects/dictobject.c
@@ -111,6 +111,7 @@ converting the dict to the combined table.
 #define PyDict_MINSIZE 8
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "dict-common.h"
 #include "stringlib/eq.h"    /* to get unicode_eq() */

--- a/Objects/exceptions.c
+++ b/Objects/exceptions.c
@@ -6,6 +6,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 #include "structmember.h"

--- a/Objects/frameobject.c
+++ b/Objects/frameobject.c
@@ -1,6 +1,7 @@
 /* Frame object implementation */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 
 #include "code.h"

--- a/Objects/funcobject.c
+++ b/Objects/funcobject.c
@@ -2,6 +2,7 @@
 /* Function object implementation */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 #include "code.h"

--- a/Objects/genobject.c
+++ b/Objects/genobject.c
@@ -1,6 +1,7 @@
 /* Generator object implementation */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "frameobject.h"
 #include "structmember.h"

--- a/Objects/iterobject.c
+++ b/Objects/iterobject.c
@@ -1,6 +1,7 @@
 /* Iterator objects */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 

--- a/Objects/listobject.c
+++ b/Objects/listobject.c
@@ -1,6 +1,7 @@
 /* List object implementation */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "pycore_accu.h"
 

--- a/Objects/memoryobject.c
+++ b/Objects/memoryobject.c
@@ -1,6 +1,7 @@
 /* Memoryview object implementation */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 #include "pystrhex.h"

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -2,6 +2,7 @@
 /* Method object implementation */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 #include "structmember.h"

--- a/Objects/odictobject.c
+++ b/Objects/odictobject.c
@@ -465,6 +465,7 @@ later:
 */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "structmember.h"
 #include "dict-common.h"

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -32,6 +32,7 @@
 */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "structmember.h"
 

--- a/Objects/sliceobject.c
+++ b/Objects/sliceobject.c
@@ -14,6 +14,7 @@ this type and there is exactly one in existence.
 */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 #include "structmember.h"

--- a/Objects/tupleobject.c
+++ b/Objects/tupleobject.c
@@ -2,6 +2,7 @@
 /* Tuple object implementation */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "pycore_accu.h"
 

--- a/Objects/typeobject.c
+++ b/Objects/typeobject.c
@@ -1,6 +1,7 @@
 /* Type object implementation */
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "frameobject.h"
 #include "structmember.h"

--- a/Objects/unicodeobject.c
+++ b/Objects/unicodeobject.c
@@ -41,6 +41,7 @@ OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 #include "pycore_fileutils.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 #include "ucnhash.h"
 #include "bytes_methods.h"

--- a/Python/ceval.c
+++ b/Python/ceval.c
@@ -10,6 +10,7 @@
 #define PY_LOCAL_AGGRESSIVE
 
 #include "Python.h"
+#include "pycore_object.h"
 #include "pycore_pystate.h"
 
 #include "code.h"

--- a/Python/context.c
+++ b/Python/context.c
@@ -1,9 +1,10 @@
 #include "Python.h"
 
-#include "structmember.h"
-#include "pycore_pystate.h"
 #include "pycore_context.h"
 #include "pycore_hamt.h"
+#include "pycore_object.h"
+#include "pycore_pystate.h"
+#include "structmember.h"
 
 
 #define CONTEXT_FREELIST_MAXLEN 255

--- a/Python/hamt.c
+++ b/Python/hamt.c
@@ -1,8 +1,9 @@
 #include "Python.h"
 
-#include "structmember.h"
-#include "pycore_pystate.h"
 #include "pycore_hamt.h"
+#include "pycore_object.h"
+#include "pycore_pystate.h"
+#include "structmember.h"
 
 /*
 This file provides an implemention of an immutable mapping using the


### PR DESCRIPTION
Move _PyObject_GC_TRACK() and _PyObject_GC_UNTRACK() from
Include/objimpl.h to Include/internal/pycore_object.h.

<!-- issue-number: [bpo-35081](https://bugs.python.org/issue35081) -->
https://bugs.python.org/issue35081
<!-- /issue-number -->
