### PR TITLE
bpo-35059: Enhance _PyObject_AssertFailed()

### DIFF
--- a/Include/object.h
+++ b/Include/object.h
@@ -1158,8 +1158,8 @@ _PyObject_DebugTypeStats(FILE *out);
      ((expr)                                           \
       ? (void)(0)                                      \
       : _PyObject_AssertFailed((obj),                  \
-                               (msg),                  \
                                Py_STRINGIFY(expr),     \
+                               (msg),                  \
                                __FILE__,               \
                                __LINE__,               \
                                __func__))
@@ -1169,11 +1169,13 @@ _PyObject_DebugTypeStats(FILE *out);
 
 /* Declare and define _PyObject_AssertFailed() even when NDEBUG is defined,
    to avoid causing compiler/linker errors when building extensions without
-   NDEBUG against a Python built with NDEBUG defined. */
+   NDEBUG against a Python built with NDEBUG defined.
+
+   msg, expr and function can be NULL. */
 PyAPI_FUNC(void) _PyObject_AssertFailed(
     PyObject *obj,
-    const char *msg,
     const char *expr,
+    const char *msg,
     const char *file,
     int line,
     const char *function);

--- a/Lib/test/test_capi.py
+++ b/Lib/test/test_capi.py
@@ -330,7 +330,7 @@ class CAPITest(unittest.TestCase):
         rc, out, err = assert_python_failure('-c', code)
         self.assertRegex(err,
                          br'_testcapimodule\.c:[0-9]+: '
-                         br'_Py_NegativeRefcount: Assertion ".*" failed; '
+                         br'_Py_NegativeRefcount: Assertion failed: '
                          br'object has negative ref count')
 
 

--- a/Objects/object.c
+++ b/Objects/object.c
@@ -205,8 +205,7 @@ void _Py_dec_count(PyTypeObject *tp)
 void
 _Py_NegativeRefcount(const char *filename, int lineno, PyObject *op)
 {
-    _PyObject_AssertFailed(op, "object has negative ref count",
-                           "op->ob_refcnt >= 0",
+    _PyObject_AssertFailed(op, NULL, "object has negative ref count",
                            filename, lineno, __func__);
 }
 
@@ -2219,20 +2218,25 @@ _PyTrash_thread_destroy_chain(void)
 
 
 void
-_PyObject_AssertFailed(PyObject *obj, const char *msg, const char *expr,
+_PyObject_AssertFailed(PyObject *obj, const char *expr, const char *msg,
                        const char *file, int line, const char *function)
 {
-    fprintf(stderr,
-            "%s:%d: %s: Assertion \"%s\" failed",
-            file, line, function, expr);
+    fprintf(stderr, "%s:%d: ", file, line);
+    if (function) {
+        fprintf(stderr, "%s: ", function);
+    }
     fflush(stderr);
-
-    if (msg) {
-        fprintf(stderr, "; %s.\n", msg);
+    if (expr) {
+        fprintf(stderr, "Assertion \"%s\" failed", expr);
     }
     else {
-        fprintf(stderr, ".\n");
+        fprintf(stderr, "Assertion failed");
     }
+    fflush(stderr);
+    if (msg) {
+        fprintf(stderr, ": %s", msg);
+    }
+    fprintf(stderr, "\n");
     fflush(stderr);
 
     if (obj == NULL) {


### PR DESCRIPTION
_PyObject_AssertFailed():

* exchange expr and msg arguments
* expr and func arguments can now be NULL

<!-- issue-number: [bpo-35059](https://bugs.python.org/issue35059) -->
https://bugs.python.org/issue35059
<!-- /issue-number -->
