### PR TITLE
Add doc note to C api to prevent bugs when parsing 'p' (bool) arguments

### DIFF
--- a/Doc/c-api/arg.rst
+++ b/Doc/c-api/arg.rst
@@ -358,6 +358,10 @@ Other objects
    This accepts any valid Python value.  See :ref:`truth` for more
    information about how Python tests values for truth.
 
+   .. note::
+      Passing the address of a :c:type`bool` variable results in undefined
+      behavior. The address must point to an :c:type:`int` value.
+
    .. versionadded:: 3.3
 
 ``(items)`` (:class:`tuple`) [*matching-items*]


### PR DESCRIPTION
I did not open an issue on https://bugs.python.org, because I think the change is very minimal.

The background is numpy/numpy#12400. The short story is, that
```c
bool dummy;
PyArg_ParseTuple(args, "p", &dummy);
```
is wrong, because `dummy` must be of type `int`, although 'p' designates a boolean argument. 

Actually, this new note is just repeating what is already in the [documentation](https://docs.python.org/3/c-api/arg.html#other-objects) (the `int` type is given in square brackets right after `p`), but using `int` for boolean values can be unexpected, so this note might help to prevent some bugs.