### PR TITLE
bpo-35059: Cleanup usage of Python macros

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5983,9 +5983,12 @@ PyInit__ssl(void)
     PyModule_AddIntConstant(m, "PROTO_TLSv1_2", PY_PROTO_TLSv1_2);
     PyModule_AddIntConstant(m, "PROTO_TLSv1_3", PY_PROTO_TLSv1_3);
 
-#define addbool(m, v, b) \
-    Py_INCREF((b) ? Py_True : Py_False); \
-    PyModule_AddObject((m), (v), (b) ? Py_True : Py_False);
+#define addbool(m, key, value) \
+    do { \
+        PyObject *bool_obj = (value) ? Py_True : Py_False; \
+        Py_INCREF(bool_obj); \
+        PyModule_AddObject((m), (key), bool_obj); \
+    } while (0)
 
 #if HAVE_SNI
     addbool(m, "HAS_SNI", 1);

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -833,7 +833,8 @@ PyWeakref_NewProxy(PyObject *ob, PyObject *callback)
                        to avoid violating the invariants of the list
                        of weakrefs for ob. */
                     Py_DECREF(result);
-                    Py_INCREF(result = proxy);
+                    result = proxy;
+                    Py_INCREF(result);
                     goto skip_insert;
                 }
                 prev = ref;


### PR DESCRIPTION
Don't pass complex expressions but regular variables to Python
macros.

* _datetimemodule.c: split single large "if" into two "if"
  in date_new(), time_new() and datetime_new().
* _pickle.c, load_extension(): flatten complex "if" expression into
  more regular C code.
* _ssl.c: addbool() now uses a temporary bool_obj to only evaluate
  the value once.
* weakrefobject.c: replace "Py_INCREF(result = proxy);"
  with "result = proxy; Py_INCREF(result);"

<!-- issue-number: [bpo-35059](https://bugs.python.org/issue35059) -->
https://bugs.python.org/issue35059
<!-- /issue-number -->
