### PR TITLE
[WIP] bpo-35059: Add assertion to _PyObject_CAST()

### DIFF
--- a/Modules/_ssl.c
+++ b/Modules/_ssl.c
@@ -5983,12 +5983,9 @@ PyInit__ssl(void)
     PyModule_AddIntConstant(m, "PROTO_TLSv1_2", PY_PROTO_TLSv1_2);
     PyModule_AddIntConstant(m, "PROTO_TLSv1_3", PY_PROTO_TLSv1_3);
 
-#define addbool(m, key, value) \
-    do { \
-        PyObject *bool_obj = (value) ? Py_True : Py_False; \
-        Py_INCREF(bool_obj); \
-        PyModule_AddObject((m), (key), bool_obj); \
-    } while (0)
+#define addbool(m, v, b) \
+    Py_INCREF((b) ? Py_True : Py_False); \
+    PyModule_AddObject((m), (v), (b) ? Py_True : Py_False);
 
 #if HAVE_SNI
     addbool(m, "HAS_SNI", 1);

--- a/Objects/weakrefobject.c
+++ b/Objects/weakrefobject.c
@@ -833,8 +833,7 @@ PyWeakref_NewProxy(PyObject *ob, PyObject *callback)
                        to avoid violating the invariants of the list
                        of weakrefs for ob. */
                     Py_DECREF(result);
-                    result = proxy;
-                    Py_INCREF(result);
+                    Py_INCREF(result = proxy);
                     goto skip_insert;
                 }
                 prev = ref;

--- a/Python/pystate.c
+++ b/Python/pystate.c
@@ -2,6 +2,7 @@
 /* Thread and interpreter state structures and their interfaces */
 
 #include "Python.h"
+#include "frameobject.h"
 #include "pycore_pymem.h"
 #include "pycore_pystate.h"
 


### PR DESCRIPTION
_PyObject_CAST() and _PyVarObject_CAST() macros now require that the
type of the argument has a size. For example, _PyObject_CAST(frame)
now raises a compilation error if frame type is "struct _frame*" but
"struct _frame" is not defined.

_PyObject_CAST() and _PyVarObject_CAST() macros now raise a
compilation error if the argument is a "PyObject" or a "PyObject**".

Partially revert b37672daf61740fe1ff9d805f6d74bc5ef04012b to show
that _PyObject_CAST() accepts non-trivial expressions.

<!-- issue-number: [bpo-35059](https://bugs.python.org/issue35059) -->
https://bugs.python.org/issue35059
<!-- /issue-number -->
