### PR TITLE
cjkcodecs: Fix compiler warning

### DIFF
--- a/Modules/cjkcodecs/multibytecodec.c
+++ b/Modules/cjkcodecs/multibytecodec.c
@@ -923,8 +923,8 @@ _multibytecodec_MultibyteIncrementalEncoder_getstate_impl(MultibyteIncrementalEn
             PyErr_SetString(PyExc_UnicodeError, "pending buffer too large");
             return NULL;
         }
-        statebytes[0] = pendingsize;
-        memcpy(statebytes+1, pendingbuffer, pendingsize);
+        statebytes[0] = (unsigned char)pendingsize;
+        memcpy(statebytes + 1, pendingbuffer, pendingsize);
         statesize = 1 + pendingsize;
     } else {
         statebytes[0] = 0;


### PR DESCRIPTION
Fixed the following compiler warning in multibytecodec.c:

    warning C4244: '=': conversion from 'Py_ssize_t'
    to 'unsigned char', possible loss of data

Cast Py_ssize_t to unsigned char: the maximum value is checked
on the previous line.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
