### PR TITLE
bpo-35283: Add the "isAlive" alias for _DummyThread

### DIFF
--- a/Lib/test/test_threading.py
+++ b/Lib/test/test_threading.py
@@ -173,6 +173,8 @@ class ThreadTests(BaseTestCase):
         self.assertIsInstance(threading._active[tid], threading._DummyThread)
         #Issue 29376
         self.assertTrue(threading._active[tid].is_alive())
+        #Issue 35283
+        self.assertTrue(threading._active[tid].isAlive())
         self.assertRegex(repr(threading._active[tid]), '_DummyThread')
         del threading._active[tid]
 

--- a/Lib/threading.py
+++ b/Lib/threading.py
@@ -1197,6 +1197,8 @@ class _DummyThread(Thread):
         assert not self._is_stopped and self._started.is_set()
         return True
 
+    isAlive = is_alive
+
     def join(self, timeout=None):
         assert False, "cannot join a dummy thread"
 

--- a/Misc/NEWS.d/next/Library/2018-11-22-20-14-14.bpo-35283.OBqxuw.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-22-20-14-14.bpo-35283.OBqxuw.rst
@@ -1,0 +1,1 @@
+Add the "isAlive" alias for _DummyThread


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-35283](https://bugs.python.org/issue35283) -->
https://bugs.python.org/issue35283
<!-- /issue-number -->
