### PR TITLE
bpo-9566: Fix compiler warnings in pyexpat.c

### DIFF
--- a/Modules/pyexpat.c
+++ b/Modules/pyexpat.c
@@ -1178,7 +1178,8 @@ xmlparse_dealloc(xmlparseobject *self)
 static PyObject *
 xmlparse_handler_getter(xmlparseobject *self, struct HandlerInfo *hi)
 {
-    int handlernum = hi - handler_info;
+    assert((hi - handler_info) < (Py_ssize_t)Py_ARRAY_LENGTH(handler_info));
+    int handlernum = (int)(hi - handler_info);
     PyObject *result = self->handlers[handlernum];
     if (result == NULL)
         result = Py_None;
@@ -1189,7 +1190,8 @@ xmlparse_handler_getter(xmlparseobject *self, struct HandlerInfo *hi)
 static int
 xmlparse_handler_setter(xmlparseobject *self, PyObject *v, struct HandlerInfo *hi)
 {
-    int handlernum = hi - handler_info;
+    assert((hi - handler_info) < (Py_ssize_t)Py_ARRAY_LENGTH(handler_info));
+    int handlernum = (int)(hi - handler_info);
     if (v == NULL) {
         PyErr_SetString(PyExc_RuntimeError, "Cannot delete attribute");
         return -1;


### PR DESCRIPTION
Explicit cast a intptr_t to int to fix two warnings
on 64-bit Windows:

    Modules\pyexpat.c(1181): warning C4244: 'initializing':
    conversion from '__int64' to 'int', possible  loss of data

    Modules\pyexpat.c(1192): warning C4244: 'initializing':
    conversion from '__int64' to 'int', possible  loss of data

<!-- issue-number: [bpo-9566](https://bugs.python.org/issue9566) -->
https://bugs.python.org/issue9566
<!-- /issue-number -->
