### PR TITLE
bpo-18407: win32_urandom() uses PY_DWORD_MAX

### DIFF
--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -55,8 +55,6 @@ error:
 static int
 win32_urandom(unsigned char *buffer, Py_ssize_t size, int raise)
 {
-    Py_ssize_t chunk;
-
     if (hCryptProv == 0)
     {
         if (win32_urandom_init(raise) == -1) {
@@ -66,8 +64,8 @@ win32_urandom(unsigned char *buffer, Py_ssize_t size, int raise)
 
     while (size > 0)
     {
-        chunk = Py_MIN(size, PY_DWORD_MAX);
-        if (!CryptGenRandom(hCryptProv, (DWORD)chunk, buffer))
+        DWORD chunk = (DWORD)Py_MIN(size, PY_DWORD_MAX);
+        if (!CryptGenRandom(hCryptProv, chunk, buffer))
         {
             /* CryptGenRandom() failed */
             if (raise) {

--- a/Python/bootstrap_hash.c
+++ b/Python/bootstrap_hash.c
@@ -66,7 +66,7 @@ win32_urandom(unsigned char *buffer, Py_ssize_t size, int raise)
 
     while (size > 0)
     {
-        chunk = size > INT_MAX ? INT_MAX : size;
+        chunk = Py_MIN(size, PY_DWORD_MAX);
         if (!CryptGenRandom(hCryptProv, (DWORD)chunk, buffer))
         {
             /* CryptGenRandom() failed */


### PR DESCRIPTION
CryptGenRandom() maximum size is PY_DWORD_MAX, not INT_MAX.

Co-Authored-By: Jeremy Kloth <jeremy.kloth@gmail.com>

<!-- issue-number: [bpo-18407](https://bugs.python.org/issue18407) -->
https://bugs.python.org/issue18407
<!-- /issue-number -->
