### PR TITLE
bpo-24658: os.read() reuses _PY_READ_MAX

### DIFF
--- a/Modules/posixmodule.c
+++ b/Modules/posixmodule.c
@@ -8410,11 +8410,7 @@ os_read_impl(PyObject *module, int fd, Py_ssize_t length)
         return posix_error();
     }
 
-#ifdef MS_WINDOWS
-    /* On Windows, the count parameter of read() is an int */
-    if (length > INT_MAX)
-        length = INT_MAX;
-#endif
+    length = Py_MIN(length, _PY_READ_MAX);
 
     buffer = PyBytes_FromStringAndSize((char *)NULL, length);
     if (buffer == NULL)


### PR DESCRIPTION
os_read_impl() now also truncates the size of _PY_READ_MAX (INT_MAX)
on macOS, to avoid to allocate a larger buffer even if _Py_read() is
limited to _PY_READ_MAX bytes.

<!-- issue-number: [bpo-24658](https://bugs.python.org/issue24658) -->
https://bugs.python.org/issue24658
<!-- /issue-number -->
