### PR TITLE
[3.7] Revert "bpo-35239: _PySys_EndInit() copies module_search_path (GH-10532)"

### DIFF
--- a/Lib/test/test_embed.py
+++ b/Lib/test/test_embed.py
@@ -301,6 +301,10 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
     }
 
     # main config
+    UNTESTED_MAIN_CONFIG = (
+        # FIXME: untested main configuration variables
+        'module_search_path',
+    )
     COPY_MAIN_CONFIG = (
         # Copy core config to main config for expected values
         'argv',
@@ -311,8 +315,7 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         'install_signal_handlers',
         'prefix',
         'warnoptions',
-        # xoptions is created from core_config in check_main_config().
-        # 'module_search_paths' is copied to 'module_search_path'.
+        # xoptions is created from core_config in check_main_config()
     )
 
     # global config
@@ -386,10 +389,12 @@ class InitConfigTests(EmbeddingTestsMixin, unittest.TestCase):
         main_config = config['main_config']
 
         # main config
+        for key in self.UNTESTED_MAIN_CONFIG:
+            del main_config[key]
+
         expected_main = {}
         for key in self.COPY_MAIN_CONFIG:
             expected_main[key] = core_config[key]
-        expected_main['module_search_path'] = core_config['module_search_paths']
         expected_main['xoptions'] = self.main_xoptions(core_config['xoptions'])
         self.assertEqual(main_config, expected_main)
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -967,8 +967,8 @@ _Py_InitializeMainInterpreter(PyInterpreterState *interp,
     }
 
     /* Initialize warnings. */
-    PyObject *warnoptions = PySys_GetObject("warnoptions");
-    if (warnoptions != NULL && PyList_Size(warnoptions) > 0)
+    if (interp->config.warnoptions != NULL &&
+        PyList_Size(interp->config.warnoptions) > 0)
     {
         PyObject *warnings_module = PyImport_ImportModule("warnings");
         if (warnings_module == NULL) {

--- a/Python/sysmodule.c
+++ b/Python/sysmodule.c
@@ -2464,20 +2464,7 @@ _PySys_EndInit(PyObject *sysdict, _PyMainInterpreterConfig *config)
     assert(config->exec_prefix != NULL);
     assert(config->base_exec_prefix != NULL);
 
-#define COPY_LIST(KEY, ATTR) \
-    do { \
-        assert(PyList_Check(config->ATTR)); \
-        PyObject *list = PyList_GetSlice(config->ATTR, \
-                                         0, PyList_GET_SIZE(config->ATTR)); \
-        if (list == NULL) { \
-            return -1; \
-        } \
-        SET_SYS_FROM_STRING_BORROW(KEY, list); \
-        Py_DECREF(list); \
-    } while (0)
-
-    COPY_LIST("path", module_search_path);
-
+    SET_SYS_FROM_STRING_BORROW("path", config->module_search_path);
     SET_SYS_FROM_STRING_BORROW("executable", config->executable);
     SET_SYS_FROM_STRING_BORROW("prefix", config->prefix);
     SET_SYS_FROM_STRING_BORROW("base_prefix", config->base_prefix);
@@ -2488,18 +2475,11 @@ _PySys_EndInit(PyObject *sysdict, _PyMainInterpreterConfig *config)
         SET_SYS_FROM_STRING_BORROW("argv", config->argv);
     }
     if (config->warnoptions != NULL) {
-        COPY_LIST("warnoptions", warnoptions);
+        SET_SYS_FROM_STRING_BORROW("warnoptions", config->warnoptions);
     }
     if (config->xoptions != NULL) {
-        PyObject *dict = PyDict_Copy(config->xoptions);
-        if (dict == NULL) {
-            return -1;
-        }
-        SET_SYS_FROM_STRING_BORROW("_xoptions", dict);
-        Py_DECREF(dict);
+        SET_SYS_FROM_STRING_BORROW("_xoptions", config->xoptions);
     }
-
-#undef COPY_LIST
 
     /* Set flags to their final values */
     SET_SYS_FROM_STRING_INT_RESULT("flags", make_flags());


### PR DESCRIPTION
This reverts commit d2be9a5c13221fb84c2221bbfd93efac6111e697.

<!-- issue-number: [bpo-35239](https://bugs.python.org/issue35239) -->
https://bugs.python.org/issue35239
<!-- /issue-number -->
