### PR TITLE
bpo-35177, Python-ast.h: Fix compiler warning on Yield

### DIFF
--- a/Include/Python-ast.h
+++ b/Include/Python-ast.h
@@ -8,7 +8,7 @@ extern "C" {
 
 #include "asdl.h"
 
-#undef Yield /* undefine macro conflicting with winbase.h */
+#undef Yield   /* undefine macro conflicting with <winbase.h> */
 
 typedef struct _mod *mod_ty;
 

--- a/Modules/parsermodule.c
+++ b/Modules/parsermodule.c
@@ -32,6 +32,7 @@
 
 #include "Python.h"                     /* general Python API             */
 #include "Python-ast.h"                 /* mod_ty */
+#undef Yield   /* undefine macro conflicting with <winbase.h> */
 #include "ast.h"
 #include "graminit.h"                   /* symbols defined in the grammar */
 #include "node.h"                       /* internal parser structure      */

--- a/Parser/asdl_c.py
+++ b/Parser/asdl_c.py
@@ -1247,7 +1247,7 @@ def main(srcfile, dump_module=False):
             f.write('\n')
             f.write('#include "asdl.h"\n')
             f.write('\n')
-            f.write('#undef Yield /* undefine macro conflicting with winbase.h */\n')
+            f.write('#undef Yield   /* undefine macro conflicting with <winbase.h> */\n')
             f.write('\n')
             c = ChainOfVisitors(TypeDefVisitor(f),
                                 StructVisitor(f),

--- a/Python/bltinmodule.c
+++ b/Python/bltinmodule.c
@@ -3,6 +3,7 @@
 #include "Python.h"
 #include <ctype.h>
 #include "ast.h"
+#undef Yield   /* undefine macro conflicting with <winbase.h> */
 #include "pycore_pystate.h"
 
 _Py_IDENTIFIER(__builtins__);

--- a/Python/import.c
+++ b/Python/import.c
@@ -3,6 +3,7 @@
 #include "Python.h"
 
 #include "Python-ast.h"
+#undef Yield   /* undefine macro conflicting with <winbase.h> */
 #include "pycore_pyhash.h"
 #include "pycore_pylifecycle.h"
 #include "pycore_pymem.h"

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -3,6 +3,7 @@
 #include "Python.h"
 
 #include "Python-ast.h"
+#undef Yield   /* undefine macro conflicting with <winbase.h> */
 #include "pycore_context.h"
 #include "pycore_hamt.h"
 #include "pycore_pathconfig.h"

--- a/Python/pythonrun.c
+++ b/Python/pythonrun.c
@@ -11,6 +11,7 @@
 #include "Python.h"
 
 #include "Python-ast.h"
+#undef Yield   /* undefine macro conflicting with <winbase.h> */
 #include "pycore_pystate.h"
 #include "grammar.h"
 #include "node.h"

--- a/Python/symtable.c
+++ b/Python/symtable.c
@@ -1,6 +1,7 @@
 #include "Python.h"
 #include "pycore_pystate.h"
 #include "symtable.h"
+#undef Yield   /* undefine macro conflicting with <winbase.h> */
 #include "structmember.h"
 
 /* error strings used for warnings */


### PR DESCRIPTION
Partially revert commit 5f2df88b63e50d23914e97ec778861a52abdeaad:
remove "#undef Yield" from Python-ast.h and move it back to .c files.

<!-- issue-number: [bpo-35177](https://bugs.python.org/issue35177) -->
https://bugs.python.org/issue35177
<!-- /issue-number -->
