### PR TITLE
bpo-35296: make install now installs the internal API

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -1444,10 +1444,20 @@ inclinstall:
 		else	true; \
 		fi; \
 	done
+	@if test ! -d $(DESTDIR)$(INCLUDEPY)/internal; then \
+		echo "Creating directory $(DESTDIR)$(INCLUDEPY)/internal"; \
+		$(INSTALL) -d -m $(DIRMODE) $(DESTDIR)$(INCLUDEPY)/internal; \
+	else	true; \
+	fi
 	@for i in $(srcdir)/Include/*.h; \
 	do \
 		echo $(INSTALL_DATA) $$i $(INCLUDEPY); \
 		$(INSTALL_DATA) $$i $(DESTDIR)$(INCLUDEPY); \
+	done
+	@for i in $(srcdir)/Include/internal/*.h; \
+	do \
+		echo $(INSTALL_DATA) $$i $(INCLUDEPY)/internal; \
+		$(INSTALL_DATA) $$i $(DESTDIR)$(INCLUDEPY)/internal; \
 	done
 	$(INSTALL_DATA) pyconfig.h $(DESTDIR)$(CONFINCLUDEPY)/pyconfig.h
 

--- a/Misc/NEWS.d/next/C API/2018-11-22-18-34-23.bpo-35296.nxrIQt.rst
+++ b/Misc/NEWS.d/next/C API/2018-11-22-18-34-23.bpo-35296.nxrIQt.rst
@@ -1,0 +1,2 @@
+``make install`` now also installs the internal API:
+``Include/internal/*.h`` header files.


### PR DESCRIPTION
make install now also installs the internal API: Include/internal/*.h
header files.

<!-- issue-number: [bpo-35296](https://bugs.python.org/issue35296) -->
https://bugs.python.org/issue35296
<!-- /issue-number -->
