### PR TITLE
bpo-30951: Rename local variables to global variables in Lib/inspect.py

### DIFF
--- a/Lib/inspect.py
+++ b/Lib/inspect.py
@@ -270,7 +270,7 @@ def iscode(object):
         co_kwonlyargcount   number of keyword only arguments (not including ** arg)
         co_lnotab           encoded mapping of line numbers to bytecode indices
         co_name             name with which this code object was defined
-        co_names            tuple of names of local variables
+        co_names            tuple of names of global variables used in the bytecode
         co_nlocals          number of local variables
         co_stacksize        virtual machine stack space required
         co_varnames         tuple of names of arguments and local variables"""

--- a/Misc/NEWS.d/next/Documentation/2018-11-23-03-32-40.bpo-30951.aMqlc4.rst
+++ b/Misc/NEWS.d/next/Documentation/2018-11-23-03-32-40.bpo-30951.aMqlc4.rst
@@ -1,0 +1,1 @@
+Rename ``local`` variables to ``global`` variables in Lib/inspect.py.


### PR DESCRIPTION
This PR renames the "local" variables to the "global" variables in Lib/inspect.py, in reference to [this post](https://stackoverflow.com/questions/45147260/what-is-co-names).

Closes https://bugs.python.org/issue30951

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->


<!-- issue-number: [bpo-30951](https://bugs.python.org/issue30951) -->
https://bugs.python.org/issue30951
<!-- /issue-number -->
