### PR TITLE
bpo-34523: Fix C locale coercion on FreeBSD CURRENT

### DIFF
--- a/Include/internal/pycore_fileutils.h
+++ b/Include/internal/pycore_fileutils.h
@@ -32,6 +32,14 @@ PyAPI_FUNC(wchar_t*) _Py_DecodeUTF8_surrogateescape(
 
 PyAPI_FUNC(int) _Py_GetForceASCII(void);
 
+/* Reset "force ASCII" mode (if it was initialized).
+
+   This function should be called when Python changes the LC_CTYPE locale,
+   so the "force ASCII" mode can be detected again on the new locale
+   encoding. */
+PyAPI_FUNC(void) _Py_ResetForceASCII(void);
+
+
 PyAPI_FUNC(int) _Py_GetLocaleconvNumeric(
     struct lconv *lc,
     PyObject **decimal_point,

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -303,6 +303,12 @@ _Py_GetForceASCII(void)
 {
     return 0;
 }
+
+void
+_Py_ResetForceASCII(void)
+{
+    /* nothing to do */
+}
 #endif   /* !defined(__APPLE__) && !defined(__ANDROID__) && !defined(MS_WINDOWS) */
 
 

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -231,6 +231,13 @@ _Py_GetForceASCII(void)
 }
 
 
+void
+_Py_ResetForceASCII(void)
+{
+    force_ascii = -1;
+}
+
+
 static int
 encode_ascii(const wchar_t *text, char **str,
              size_t *error_pos, const char **reason,

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -5,6 +5,7 @@
 #include "Python-ast.h"
 #undef Yield   /* undefine macro conflicting with <winbase.h> */
 #include "pycore_context.h"
+#include "pycore_fileutils.h"
 #include "pycore_hamt.h"
 #include "pycore_pathconfig.h"
 #include "pycore_pylifecycle.h"
@@ -394,6 +395,7 @@ done:
 char *
 _Py_SetLocaleFromEnv(int category)
 {
+    char *res;
 #ifdef __ANDROID__
     const char *locale;
     const char **pvar;
@@ -440,10 +442,12 @@ _Py_SetLocaleFromEnv(int category)
         }
     }
 #endif
-    return setlocale(category, utf8_locale);
-#else /* __ANDROID__ */
-    return setlocale(category, "");
-#endif /* __ANDROID__ */
+    res = setlocale(category, utf8_locale);
+#else /* !defined(__ANDROID__) */
+    res = setlocale(category, "");
+#endif
+    _Py_ResetForceASCII();
+    return res;
 }
 
 


### PR DESCRIPTION
[bpo-34523](https://bugs.python.org/issue34523), [bpo-35290](https://bugs.python.org/issue35290): C locale coercion now resets the Python
internal "force ASCII" mode. This change fix the filesystem encoding
on FreeBSD CURRENT which has a new "C.UTF-8" locale.

* Add _Py_ResetForceASCII()
* _coerce_default_locale_settings() now calls _Py_ResetForceASCII()

<!-- issue-number: [bpo-34523](https://bugs.python.org/issue34523) -->
https://bugs.python.org/issue34523
<!-- /issue-number -->
