### PR TITLE
[3.7] bpo-34523: Fix C locale coercion on FreeBSD CURRENT (GH-10672)

### DIFF
--- a/Include/fileutils.h
+++ b/Include/fileutils.h
@@ -185,6 +185,13 @@ PyAPI_FUNC(int) _Py_GetLocaleconvNumeric(
 
 #ifdef Py_BUILD_CORE
 PyAPI_FUNC(int) _Py_GetForceASCII(void);
+
+/* Reset "force ASCII" mode (if it was initialized).
+
+   This function should be called when Python changes the LC_CTYPE locale,
+   so the "force ASCII" mode can be detected again on the new locale
+   encoding. */
+PyAPI_FUNC(void) _Py_ResetForceASCII(void);
 #endif
 
 #ifdef __cplusplus

--- a/Python/fileutils.c
+++ b/Python/fileutils.c
@@ -191,6 +191,12 @@ _Py_GetForceASCII(void)
 }
 
 
+void
+_Py_ResetForceASCII(void)
+{
+    force_ascii = -1;
+}
+
 
 static int
 encode_ascii(const wchar_t *text, char **str,
@@ -251,6 +257,12 @@ int
 _Py_GetForceASCII(void)
 {
     return 0;
+}
+
+void
+_Py_ResetForceASCII(void)
+{
+    /* nothing to do */
 }
 #endif   /* !defined(__APPLE__) && !defined(__ANDROID__) && !defined(MS_WINDOWS) */
 

--- a/Python/pylifecycle.c
+++ b/Python/pylifecycle.c
@@ -523,6 +523,7 @@ done:
 char *
 _Py_SetLocaleFromEnv(int category)
 {
+    char *res;
 #ifdef __ANDROID__
     const char *locale;
     const char **pvar;
@@ -569,10 +570,12 @@ _Py_SetLocaleFromEnv(int category)
         }
     }
 #endif
-    return setlocale(category, utf8_locale);
-#else /* __ANDROID__ */
-    return setlocale(category, "");
-#endif /* __ANDROID__ */
+    res = setlocale(category, utf8_locale);
+#else /* !defined(__ANDROID__) */
+    res = setlocale(category, "");
+#endif
+    _Py_ResetForceASCII();
+    return res;
 }
 
 


### PR DESCRIPTION
[bpo-34523](https://bugs.python.org/issue34523), [bpo-35290](https://bugs.python.org/issue35290): C locale coercion now resets the Python
internal "force ASCII" mode. This change fix the filesystem encoding
on FreeBSD CURRENT, which has a new "C.UTF-8" locale, when
the UTF-8 mode is disabled.

Add _Py_ResetForceASCII(): _Py_SetLocaleFromEnv() now calls it.

(cherry picked from commit 353933e712b6c7f7ba9a9a50bd5bd472db7c35d0)

<!-- issue-number: [bpo-34523](https://bugs.python.org/issue34523) -->
https://bugs.python.org/issue34523
<!-- /issue-number -->
