### PR TITLE
bpo-35059: PyObject_INIT() casts to PyObject*

### DIFF
--- a/Include/objimpl.h
+++ b/Include/objimpl.h
@@ -145,7 +145,7 @@ PyAPI_FUNC(PyVarObject *) _PyObject_NewVar(PyTypeObject *, Py_ssize_t);
 
    These inline functions expect non-NULL object pointers. */
 static inline PyObject*
-PyObject_INIT(PyObject *op, PyTypeObject *typeobj)
+_PyObject_INIT(PyObject *op, PyTypeObject *typeobj)
 {
     assert(op != NULL);
     Py_TYPE(op) = typeobj;
@@ -153,14 +153,20 @@ PyObject_INIT(PyObject *op, PyTypeObject *typeobj)
     return op;
 }
 
+#define PyObject_INIT(op, typeobj) \
+    _PyObject_INIT(_PyObject_CAST(op), (typeobj))
+
 static inline PyVarObject*
-PyObject_INIT_VAR(PyVarObject *op, PyTypeObject *typeobj, Py_ssize_t size)
+_PyObject_INIT_VAR(PyVarObject *op, PyTypeObject *typeobj, Py_ssize_t size)
 {
     assert(op != NULL);
     Py_SIZE(op) = size;
     PyObject_INIT((PyObject *)op, typeobj);
     return op;
 }
+
+#define PyObject_INIT_VAR(op, typeobj, size) \
+    _PyObject_INIT_VAR(_PyVarObject_CAST(op), (typeobj), (size))
 
 #define _PyObject_SIZE(typeobj) ( (typeobj)->tp_basicsize )
 

--- a/Objects/bytesobject.c
+++ b/Objects/bytesobject.c
@@ -86,7 +86,7 @@ _PyBytes_FromSize(Py_ssize_t size, int use_calloc)
         op = (PyBytesObject *)PyObject_Malloc(PyBytesObject_SIZE + size);
     if (op == NULL)
         return PyErr_NoMemory();
-    (void)PyObject_INIT_VAR((PyVarObject *)op, &PyBytes_Type, size);
+    (void)PyObject_INIT_VAR(op, &PyBytes_Type, size);
     op->ob_shash = -1;
     if (!use_calloc)
         op->ob_sval[size] = '\0';
@@ -164,7 +164,7 @@ PyBytes_FromString(const char *str)
     op = (PyBytesObject *)PyObject_MALLOC(PyBytesObject_SIZE + size);
     if (op == NULL)
         return PyErr_NoMemory();
-    (void)PyObject_INIT_VAR((PyVarObject *)op, &PyBytes_Type, size);
+    (void)PyObject_INIT_VAR(op, &PyBytes_Type, size);
     op->ob_shash = -1;
     memcpy(op->ob_sval, str, size+1);
     /* share short strings */
@@ -1509,7 +1509,7 @@ bytes_repeat(PyBytesObject *a, Py_ssize_t n)
     op = (PyBytesObject *)PyObject_MALLOC(PyBytesObject_SIZE + nbytes);
     if (op == NULL)
         return PyErr_NoMemory();
-    (void)PyObject_INIT_VAR((PyVarObject *)op, &PyBytes_Type, size);
+    (void)PyObject_INIT_VAR(op, &PyBytes_Type, size);
     op->ob_shash = -1;
     op->ob_sval[size] = '\0';
     if (Py_SIZE(a) == 1 && n > 0) {

--- a/Objects/classobject.c
+++ b/Objects/classobject.c
@@ -56,7 +56,7 @@ PyMethod_New(PyObject *func, PyObject *self)
     im = free_list;
     if (im != NULL) {
         free_list = (PyMethodObject *)(im->im_self);
-        (void)PyObject_INIT((PyObject *)im, &PyMethod_Type);
+        (void)PyObject_INIT(im, &PyMethod_Type);
         numfree--;
     }
     else {

--- a/Objects/complexobject.c
+++ b/Objects/complexobject.c
@@ -228,7 +228,7 @@ PyComplex_FromCComplex(Py_complex cval)
     op = (PyComplexObject *) PyObject_MALLOC(sizeof(PyComplexObject));
     if (op == NULL)
         return PyErr_NoMemory();
-    (void)PyObject_INIT((PyObject *)op, &PyComplex_Type);
+    (void)PyObject_INIT(op, &PyComplex_Type);
     op->cval = cval;
     return (PyObject *) op;
 }

--- a/Objects/floatobject.c
+++ b/Objects/floatobject.c
@@ -124,7 +124,7 @@ PyFloat_FromDouble(double fval)
             return PyErr_NoMemory();
     }
     /* Inline PyObject_New */
-    (void)PyObject_INIT((PyObject *)op, &PyFloat_Type);
+    (void)PyObject_INIT(op, &PyFloat_Type);
     op->ob_fval = fval;
     return (PyObject *) op;
 }

--- a/Objects/longobject.c
+++ b/Objects/longobject.c
@@ -211,7 +211,7 @@ _PyLong_New(Py_ssize_t size)
         PyErr_NoMemory();
         return NULL;
     }
-    return (PyLongObject*)PyObject_INIT_VAR((PyVarObject *)result, &PyLong_Type, size);
+    return (PyLongObject*)PyObject_INIT_VAR(result, &PyLong_Type, size);
 }
 
 PyObject *
@@ -5620,7 +5620,7 @@ _PyLong_Init(void)
             assert(v->ob_digit[0] == (digit)abs(ival));
         }
         else {
-            (void)PyObject_INIT((PyObject *)v, &PyLong_Type);
+            (void)PyObject_INIT(v, &PyLong_Type);
         }
         Py_SIZE(v) = size;
         v->ob_digit[0] = (digit)abs(ival);

--- a/Objects/methodobject.c
+++ b/Objects/methodobject.c
@@ -32,7 +32,7 @@ PyCFunction_NewEx(PyMethodDef *ml, PyObject *self, PyObject *module)
     op = free_list;
     if (op != NULL) {
         free_list = (PyCFunctionObject *)(op->m_self);
-        (void)PyObject_INIT((PyObject *)op, &PyCFunction_Type);
+        (void)PyObject_INIT(op, &PyCFunction_Type);
         numfree--;
     }
     else {

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -459,7 +459,7 @@ PyHKEY_FromHKEY(HKEY h)
     op = (PyHKEYObject *) PyObject_MALLOC(sizeof(PyHKEYObject));
     if (op == NULL)
         return PyErr_NoMemory();
-    PyObject_INIT((PyObject *)op, &PyHKEY_Type);
+    PyObject_INIT(op, &PyHKEY_Type);
     op->hkey = h;
     return (PyObject *)op;
 }


### PR DESCRIPTION
PyObject_INIT() and PyObject_INIT_VAR() now cast their first argument
to PyObject*, as done in Python 3.7.

Revert partially commit b4435e20a92af474f117b78b98ddc6f515363af5.

<!-- issue-number: [bpo-35059](https://bugs.python.org/issue35059) -->
https://bugs.python.org/issue35059
<!-- /issue-number -->
