### PR TITLE
bpo-34812: subprocess._args_from_interpreter_flags(): add isolated

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -262,9 +262,7 @@ def _args_from_interpreter_flags():
         # 'inspect': 'i',
         # 'interactive': 'i',
         'dont_write_bytecode': 'B',
-        'no_user_site': 's',
         'no_site': 'S',
-        'ignore_environment': 'E',
         'verbose': 'v',
         'bytes_warning': 'b',
         'quiet': 'q',
@@ -275,6 +273,14 @@ def _args_from_interpreter_flags():
         v = getattr(sys.flags, flag)
         if v > 0:
             args.append('-' + opt * v)
+
+    if sys.flags.isolated:
+        args.append('-I')
+    else:
+        if sys.flags.ignore_environment:
+            args.append('-E')
+        if sys.flags.no_user_site:
+            args.append('-s')
 
     # -W options
     warnopts = sys.warnoptions[:]

--- a/Lib/test/test_support.py
+++ b/Lib/test/test_support.py
@@ -456,7 +456,7 @@ class TestSupport(unittest.TestCase):
         # pending child process
         support.reap_children()
 
-    def check_options(self, args, func):
+    def check_options(self, args, func, expected=None):
         code = f'from test.support import {func}; print(repr({func}()))'
         cmd = [sys.executable, *args, '-c', code]
         env = {key: value for key, value in os.environ.items()
@@ -466,7 +466,9 @@ class TestSupport(unittest.TestCase):
                               stderr=subprocess.DEVNULL,
                               universal_newlines=True,
                               env=env)
-        self.assertEqual(proc.stdout.rstrip(), repr(args))
+        if expected is None:
+            expected = args
+        self.assertEqual(proc.stdout.rstrip(), repr(expected))
         self.assertEqual(proc.returncode, 0)
 
     def test_args_from_interpreter_flags(self):
@@ -482,6 +484,7 @@ class TestSupport(unittest.TestCase):
             ['-v'],
             ['-b'],
             ['-q'],
+            ['-I'],
             # same option multiple times
             ['-bb'],
             ['-vvv'],
@@ -499,6 +502,9 @@ class TestSupport(unittest.TestCase):
         ):
             with self.subTest(opts=opts):
                 self.check_options(opts, 'args_from_interpreter_flags')
+
+        self.check_options(['-I', '-E', '-s'], 'args_from_interpreter_flags',
+                           ['-I'])
 
     def test_optim_args_from_interpreter_flags(self):
         # Test test.support.optim_args_from_interpreter_flags()

--- a/Misc/NEWS.d/next/Security/2018-11-23-15-00-23.bpo-34812.84VQnb.rst
+++ b/Misc/NEWS.d/next/Security/2018-11-23-15-00-23.bpo-34812.84VQnb.rst
@@ -1,0 +1,4 @@
+The :option:`-I` command line option (run Python in isolated mode) is now
+also copied by the :mod:`multiprocessing` and :mod:`distutils` modules when
+spawning child processes. Previously, only :option:`-E and :option:`-s` options
+(enabled by :option:`-I`) were copied.

--- a/Misc/NEWS.d/next/Security/2018-11-23-15-00-23.bpo-34812.84VQnb.rst
+++ b/Misc/NEWS.d/next/Security/2018-11-23-15-00-23.bpo-34812.84VQnb.rst
@@ -1,4 +1,4 @@
 The :option:`-I` command line option (run Python in isolated mode) is now
 also copied by the :mod:`multiprocessing` and :mod:`distutils` modules when
-spawning child processes. Previously, only :option:`-E and :option:`-s` options
+spawning child processes. Previously, only :option:`-E` and :option:`-s` options
 (enabled by :option:`-I`) were copied.


### PR DESCRIPTION
The "-I" command line option (enable isolated mode) is now also
copied by the multiprocessing and distutils modules when spawning
child processes. Previously, only -E and -s options (enabled by -I)
were copied.

subprocess._args_from_interpreter_flags() now copies the -I flag.

<!-- issue-number: [bpo-34812](https://bugs.python.org/issue34812) -->
https://bugs.python.org/issue34812
<!-- /issue-number -->
