### PR TITLE
[3.6] bpo-34812: subprocess._args_from_interpreter_flags(): add isolated (GH-10675)

### DIFF
--- a/Lib/subprocess.py
+++ b/Lib/subprocess.py
@@ -232,15 +232,13 @@ def _optim_args_from_interpreter_flags():
 
 def _args_from_interpreter_flags():
     """Return a list of command-line arguments reproducing the current
-    settings in sys.flags and sys.warnoptions."""
+    settings in sys.flags, sys.warnoptions and sys._xoptions."""
     flag_opt_map = {
         'debug': 'd',
         # 'inspect': 'i',
         # 'interactive': 'i',
         'dont_write_bytecode': 'B',
-        'no_user_site': 's',
         'no_site': 'S',
-        'ignore_environment': 'E',
         'verbose': 'v',
         'bytes_warning': 'b',
         'quiet': 'q',
@@ -251,8 +249,30 @@ def _args_from_interpreter_flags():
         v = getattr(sys.flags, flag)
         if v > 0:
             args.append('-' + opt * v)
+
+    if sys.flags.isolated:
+        args.append('-I')
+    else:
+        if sys.flags.ignore_environment:
+            args.append('-E')
+        if sys.flags.no_user_site:
+            args.append('-s')
+
     for opt in sys.warnoptions:
         args.append('-W' + opt)
+
+    # -X options
+    xoptions = getattr(sys, '_xoptions', {})
+    for opt in ('faulthandler', 'tracemalloc',
+                'showalloccount', 'showrefcount', 'utf8'):
+        if opt in xoptions:
+            value = xoptions[opt]
+            if value is True:
+                arg = opt
+            else:
+                arg = '%s=%s' % (opt, value)
+            args.extend(('-X', arg))
+
     return args
 
 

--- a/Misc/NEWS.d/next/Security/2018-11-23-15-00-23.bpo-34812.84VQnb.rst
+++ b/Misc/NEWS.d/next/Security/2018-11-23-15-00-23.bpo-34812.84VQnb.rst
@@ -1,0 +1,4 @@
+The :option:`-I` command line option (run Python in isolated mode) is now
+also copied by the :mod:`multiprocessing` and :mod:`distutils` modules when
+spawning child processes. Previously, only :option:`-E` and :option:`-s` options
+(enabled by :option:`-I`) were copied.


### PR DESCRIPTION
The "-I" command line option (run Python in isolated mode) and -X
options (like -X faulthandler) are now also copied by the
multiprocessing and distutils modules when spawning child processes.
Previously, only -E and -s options (enabled by -I) were copied.

subprocess._args_from_interpreter_flags() now copies the -I flag
and options from sys._xoptions like -X dev.

(cherry picked from commit 9de363271519e0616f4a7b59427057c4810d3acc)

<!-- issue-number: [bpo-34812](https://bugs.python.org/issue34812) -->
https://bugs.python.org/issue34812
<!-- /issue-number -->
