### PR TITLE
bpo-35303: Fix a reference leak in _operator.c's methodcaller_repr()

### DIFF
--- a/Modules/_operator.c
+++ b/Modules/_operator.c
@@ -1583,6 +1583,7 @@ methodcaller_repr(methodcallerobject *mc)
                 goto done;
             if (i >= numtotalargs) {
                 i = -1;
+                Py_DECREF(onerepr);
                 break;
             }
             PyTuple_SET_ITEM(argreprs, i, onerepr);


### PR DESCRIPTION


<!-- issue-number: [bpo-35303](https://bugs.python.org/issue35303) -->
https://bugs.python.org/issue35303
<!-- /issue-number -->
