### PR TITLE
bpo-35066: _dateime.datetime.strftime copies trailing '%'

### DIFF
--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1350,16 +1350,16 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         #check that this standard extension works
         t.strftime("%f")
 
-        # bpo-35066: make sure trailing '%' don't cause
-        # datetime's strftime to complain
-        failed = False
+    def test_strftime_trailing_percent(self):
+    # bpo-35066: make sure trailing '%' doesn't cause
+    # datetime's strftime to complain
+        t = self.theclass(2005, 3, 2)
         try:
-            t.strftime('%')
+            _time.strftime('%')
         except ValueError:
-            failed = True
-        if not failed:
-            self.assertEqual(t.strftime('%'), '%')
-            self.assertEqual(t.strftime("m:%m d:%d y:%y %"), "m:03 d:02 y:05 %")
+            self.skipTest('time module does not support trailing %')
+        self.assertEqual(t.strftime('%'), '%')
+        self.assertEqual(t.strftime("m:%m d:%d y:%y %"), "m:03 d:02 y:05 %")
 
     def test_format(self):
         dt = self.theclass(2007, 9, 10)

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1351,8 +1351,8 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         t.strftime("%f")
 
     def test_strftime_trailing_percent(self):
-    # bpo-35066: make sure trailing '%' doesn't cause
-    # datetime's strftime to complain
+        # bpo-35066: make sure trailing '%' doesn't cause
+        # datetime's strftime to complain
         t = self.theclass(2005, 3, 2)
         try:
             _time.strftime('%')

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1350,6 +1350,17 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
         #check that this standard extension works
         t.strftime("%f")
 
+        # bpo-35066: make sure trailing '%' don't cause
+        # datetime's strftime to complain
+        failed = False
+        try:
+            t.strftime('%')
+        except ValueError:
+            failed = True
+        if not failed:
+            self.assertEqual(t.strftime('%'), '%')
+            self.assertEqual(t.strftime("m:%m d:%d y:%y %"), "m:03 d:02 y:05 %")        
+
     def test_format(self):
         dt = self.theclass(2007, 9, 10)
         self.assertEqual(dt.__format__(''), str(dt))

--- a/Lib/test/datetimetester.py
+++ b/Lib/test/datetimetester.py
@@ -1359,7 +1359,7 @@ class TestDate(HarmlessMixedComparison, unittest.TestCase):
             failed = True
         if not failed:
             self.assertEqual(t.strftime('%'), '%')
-            self.assertEqual(t.strftime("m:%m d:%d y:%y %"), "m:03 d:02 y:05 %")        
+            self.assertEqual(t.strftime("m:%m d:%d y:%y %"), "m:03 d:02 y:05 %")
 
     def test_format(self):
         dt = self.theclass(2007, 9, 10)

--- a/Misc/NEWS.d/next/Library/2018-11-29-09-38-40.bpo-35066.Nwej2s.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-29-09-38-40.bpo-35066.Nwej2s.rst
@@ -1,0 +1,5 @@
+Previously, calling the strftime() method on a datetime object with a
+trailing '%' in the format string would result in an exception. However,
+this only occured when the datetime C module was being used; the python
+implementation did not match this behavior. Datetime is now PEP-399
+compliant, and will not throw an exception on a trailing '%'.

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1583,6 +1583,12 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             ptoappend = PyBytes_AS_STRING(freplacement);
             ntoappend = PyBytes_GET_SIZE(freplacement);
         }
+        else if (ch == '\0') {
+            /* percent followed by null char, copy only
+             * the '%' */
+            ptoappend = pin - 2;
+            ntoappend = 1;
+        }
         else {
             /* percent followed by neither z nor Z */
             ptoappend = pin - 2;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1528,14 +1528,6 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             ptoappend = pin - 1;
             ntoappend = 1;
         }
-//        else if ((ch = *pin++) == '\0') {
-            /* There's a lone trailing %; doesn't make sense. */
-//            PyErr_SetString(PyExc_ValueError, "strftime format "
-//                            "ends with raw %");
-//            goto Done;
-//            ptoappend = pin - 2;
-//            ntoappend = 2;
-//        }
 
         /* A % has been seen and ch is the character after it. */
         else if ((ch = *pin++) == 'z') {
@@ -1620,7 +1612,6 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         usednew += ntoappend;
         assert(usednew <= totalnew);
 
-        printf("%s\n", PyUnicode_AsUTF8(PyObject_Repr(newfmt)));
         if (ch == '\0')
             break;
     }  /* end while() */

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1521,10 +1521,11 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     if (newfmt == NULL) goto Done;
     pnew = PyBytes_AsString(newfmt);
     usednew = 0;
+    ch = *pin;
 
-    while ((ch = *pin++) != '\0')
+    do
     {
-        if (ch != '%') {
+        if ((ch = *pin++) != '%') {
             ptoappend = pin - 1;
             ntoappend = 1;
         }
@@ -1611,10 +1612,8 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         pnew += ntoappend;
         usednew += ntoappend;
         assert(usednew <= totalnew);
-
-        if (ch == '\0')
-            break;
-    }  /* end while() */
+    } while (ch != '\0');
+  /* end do while */
 
     if (_PyBytes_Resize(&newfmt, usednew) < 0)
         goto Done;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1516,7 +1516,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         goto Done;
     }
 
-totalnew = flen + 1;        /* realistic if no %z/%Z */
+    totalnew = flen + 1;        /* realistic if no %z/%Z */
     newfmt = PyBytes_FromStringAndSize(NULL, totalnew);
     if (newfmt == NULL) goto Done;
     pnew = PyBytes_AsString(newfmt);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1611,7 +1611,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         pnew += ntoappend;
         usednew += ntoappend;
         assert(usednew <= totalnew);
-    } while (ch != '\0'); /* end do while */
+    } while (ch != '\0');
 
     if (_PyBytes_Resize(&newfmt, usednew) < 0)
         goto Done;
@@ -1622,11 +1622,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         if (time == NULL)
             goto Done;
         format = PyUnicode_FromString(PyBytes_AS_STRING(newfmt));
-
-
-        if (format != NULL)
-        {
-
+        if (format != NULL) {
             result = _PyObject_CallMethodIdObjArgs(time, &PyId_strftime,
                                                    format, timetuple, NULL);
             Py_DECREF(format);

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1529,7 +1529,6 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
             ptoappend = pin - 1;
             ntoappend = 1;
         }
-
         /* A % has been seen and ch is the character after it. */
         else if ((ch = *pin++) == 'z') {
             if (zreplacement == NULL) {
@@ -1612,8 +1611,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         pnew += ntoappend;
         usednew += ntoappend;
         assert(usednew <= totalnew);
-    } while (ch != '\0');
-  /* end do while */
+    } while (ch != '\0'); /* end do while */
 
     if (_PyBytes_Resize(&newfmt, usednew) < 0)
         goto Done;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1523,8 +1523,7 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     usednew = 0;
     ch = *pin;
 
-    do
-    {
+    do {
         if ((ch = *pin++) != '%') {
             ptoappend = pin - 1;
             ntoappend = 1;

--- a/Modules/_datetimemodule.c
+++ b/Modules/_datetimemodule.c
@@ -1522,19 +1522,23 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
     pnew = PyBytes_AsString(newfmt);
     usednew = 0;
 
-    while ((ch = *pin++) != '\0') {
+    while ((ch = *pin++) != '\0')
+    {
         if (ch != '%') {
             ptoappend = pin - 1;
             ntoappend = 1;
         }
-        else if ((ch = *pin++) == '\0') {
+//        else if ((ch = *pin++) == '\0') {
             /* There's a lone trailing %; doesn't make sense. */
-            PyErr_SetString(PyExc_ValueError, "strftime format "
-                            "ends with raw %");
-            goto Done;
-        }
+//            PyErr_SetString(PyExc_ValueError, "strftime format "
+//                            "ends with raw %");
+//            goto Done;
+//            ptoappend = pin - 2;
+//            ntoappend = 2;
+//        }
+
         /* A % has been seen and ch is the character after it. */
-        else if (ch == 'z') {
+        else if ((ch = *pin++) == 'z') {
             if (zreplacement == NULL) {
                 /* format utcoffset */
                 char buf[100];
@@ -1615,6 +1619,10 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         pnew += ntoappend;
         usednew += ntoappend;
         assert(usednew <= totalnew);
+
+        printf("%s\n", PyUnicode_AsUTF8(PyObject_Repr(newfmt)));
+        if (ch == '\0')
+            break;
     }  /* end while() */
 
     if (_PyBytes_Resize(&newfmt, usednew) < 0)
@@ -1626,7 +1634,11 @@ wrap_strftime(PyObject *object, PyObject *format, PyObject *timetuple,
         if (time == NULL)
             goto Done;
         format = PyUnicode_FromString(PyBytes_AS_STRING(newfmt));
-        if (format != NULL) {
+
+
+        if (format != NULL)
+        {
+
             result = _PyObject_CallMethodIdObjArgs(time, &PyId_strftime,
                                                    format, timetuple, NULL);
             Py_DECREF(format);


### PR DESCRIPTION
<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
https://bugs.python.org/issue35066

<!-- issue-number: [bpo-35066](https://bugs.python.org/issue35066) -->
https://bugs.python.org/issue35066
<!-- /issue-number -->
