### PR TITLE
bpo-35308: Fix regression where BROWSER env var is not respected

### DIFF
--- a/Lib/test/test_webbrowser.py
+++ b/Lib/test/test_webbrowser.py
@@ -309,6 +309,24 @@ class ImportTest(unittest.TestCase):
             webbrowser = support.import_fresh_module('webbrowser')
             webbrowser.get()
 
+    def test_environment_preferred(self):
+        webbrowser = support.import_fresh_module('webbrowser')
+        try:
+            webbrowser.get()
+            least_preferred_browser = webbrowser.get(webbrowser._tryorder[-1]).name
+        except (webbrowser.Error, AttributeError, IndexError) as err:
+            self.skipTest(str(err))
+
+        with support.EnvironmentVarGuard() as env:
+            env["BROWSER"] = least_preferred_browser
+            webbrowser = support.import_fresh_module('webbrowser')
+            self.assertEqual(webbrowser.get().name, least_preferred_browser)
+
+        with support.EnvironmentVarGuard() as env:
+            env["BROWSER"] = sys.executable
+            webbrowser = support.import_fresh_module('webbrowser')
+            self.assertEqual(webbrowser.get().name, sys.executable)
+
 
 if __name__=='__main__':
     unittest.main()

--- a/Lib/webbrowser.py
+++ b/Lib/webbrowser.py
@@ -86,7 +86,7 @@ def open_new_tab(url):
     return open(url, 2)
 
 
-def _synthesize(browser, *, preferred=True):
+def _synthesize(browser, *, preferred=False):
     """Attempt to synthesize a controller base on existing controllers.
 
     This is useful to create a controller when a user specifies a path to
@@ -563,7 +563,7 @@ def register_standard_browsers():
         # and prepend to _tryorder
         for cmdline in userchoices:
             if cmdline != '':
-                cmd = _synthesize(cmdline, preferred=False)
+                cmd = _synthesize(cmdline, preferred=True)
                 if cmd[1] is None:
                     register(cmdline, None, GenericBrowser(cmdline), preferred=True)
 

--- a/Misc/NEWS.d/next/Library/2018-11-24-10-33-42.bpo-35308.9--2iy.rst
+++ b/Misc/NEWS.d/next/Library/2018-11-24-10-33-42.bpo-35308.9--2iy.rst
@@ -1,0 +1,2 @@
+Fix regression in ``webbrowser`` where default browsers may be preferred
+over browsers in the ``BROWSER`` environment variable.


### PR DESCRIPTION


<!-- issue-number: [bpo-35308](https://bugs.python.org/issue35308) -->
https://bugs.python.org/issue35308
<!-- /issue-number -->
